### PR TITLE
[AutoDiff] Support `@differentiable` class initializers.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3004,10 +3004,6 @@ ERROR(differentiable_attr_stored_property_variable_unsupported,none,
 ERROR(differentiable_attr_class_member_no_dynamic_self,none,
       "'@differentiable' attribute cannot be declared on class methods "
       "returning 'Self'", ())
-// TODO(TF-654): Remove when differentiation supports class initializers.
-ERROR(differentiable_attr_class_init_not_yet_supported,none,
-      "'@differentiable' attribute does not yet support class initializers",
-      ())
 ERROR(differentiable_attr_empty_where_clause,none,
       "empty 'where' clause in '@differentiable' attribute", ())
 // SWIFT_ENABLE_TENSORFLOW

--- a/include/swift/SILOptimizer/Utils/Differentiation/PullbackEmitter.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/PullbackEmitter.h
@@ -434,6 +434,16 @@ public:
   void visitUnconditionalCheckedCastAddrInst(
       UnconditionalCheckedCastAddrInst *uccai);
 
+  /// Handle `unchecked_ref_cast` instruction.
+  ///   Original: y = unchecked_ref_cast x
+  ///    Adjoint: adj[x] += adj[y] (assuming x' and y' have the same type)
+  void visitUncheckedRefCastInst(UncheckedRefCastInst *urci);
+
+  /// Handle `upcast` instruction.
+  ///   Original: y = upcast x
+  ///    Adjoint: adj[x] += adj[y] (assuming x' and y' have the same type)
+  void visitUpcastInst(UpcastInst *ui);
+
 #define NOT_DIFFERENTIABLE(INST, DIAG) void visit##INST##Inst(INST##Inst *inst);
 #undef NOT_DIFFERENTIABLE
 

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -2705,17 +2705,15 @@ TypeConverter::getConstantInfo(TypeExpansionContext expansion,
                                             loweredInterfaceType);
 
   // SWIFT_ENABLE_TENSORFLOW
-  // In the case of autodiff derivative functions, the above computations
-  // determine `silFnType` by first computing the derivative function type at
-  // the AST level and then lowering that. Unfortunately, the actual
-  // SILFunctionType for the function is determined by first lowering the
-  // function's AST type, and then computing the derivative function type at the
-  // SIL level. "Lowering" does not commute with "getting the autodiff
-  // associated type", so these two computations produce different results.
-  // Therefore `silFnType` is not the actual type of the function that
-  // `constant` refers to.
+  // For derivative functions, the above computations determine `silFnType`
+  // by first computing the derivative AST function type and then lowering it to
+  // SIL. Unfortunately, the expected derivative SIL function type is determined
+  // by first lowering the original function's AST type, and then computing its
+  // SIL derivative function type. "Lowering" does not commute with "getting the
+  // derivative type", so these two computations produce different results.
+  // Therefore, `silFnType` is not the expected SIL derivative function type.
   //
-  // We hackily fix this problem by redoing the computation in the right order.
+  // We fix this problem by performing the computation in the right order.
   if (auto *autoDiffFuncId = constant.autoDiffDerivativeFunctionIdentifier) {
     auto origFnConstantInfo = getConstantInfo(
         TypeExpansionContext::minimal(), constant.asAutoDiffOriginalFunction());
@@ -2725,6 +2723,7 @@ TypeConverter::getConstantInfo(TypeExpansionContext expansion,
         loweredIndices, /*resultIndex*/ 0, autoDiffFuncId->getKind(),
         *this, LookUpConformanceInModule(&M));
   }
+  // SWIFT_ENABLE_TENSORFLOW END
 
   LLVM_DEBUG(llvm::dbgs() << "lowering type for constant ";
              constant.print(llvm::dbgs());
@@ -2937,6 +2936,30 @@ TypeConverter::getConstantOverrideInfo(TypeExpansionContext context,
   CanSILFunctionType fnTy = getNativeSILFunctionType(
       *this, context, basePattern, bridgedTypes.Uncurried, base, derived,
       /*reqt subs*/ None, ProtocolConformanceRef());
+
+  // SWIFT_ENABLE_TENSORFLOW
+  // For derivative functions, the above computations determine `fnTy`
+  // by first computing the derivative AST function type and then lowering it to
+  // SIL. Unfortunately, the expected derivative SIL function type is determined
+  // by first lowering the original function's AST type, and then computing its
+  // SIL derivative function type. "Lowering" does not commute with "getting the
+  // derivative type", so these two computations produce different results.
+  // Therefore, `fnTy` is not the expected SIL derivative function type.
+  //
+  // We fix this problem by performing the computation in the right order.
+  if (auto *derivedDerivID = derived.autoDiffDerivativeFunctionIdentifier) {
+    auto *baseDerivID = base.autoDiffDerivativeFunctionIdentifier;
+    assert(baseDerivID);
+    auto &overrideInfo =
+        getConstantOverrideInfo(context, derived.asAutoDiffOriginalFunction(),
+                                base.asAutoDiffOriginalFunction());
+    auto loweredIndices = autodiff::getLoweredParameterIndices(
+        derivedDerivID->getParameterIndices(), overrideInterfaceTy);
+    fnTy = overrideInfo.SILFnType->getAutoDiffDerivativeFunctionType(
+        loweredIndices, /*resultIndex*/ 0, derivedDerivID->getKind(), *this,
+        LookUpConformanceInModule(&M));
+  }
+  // SWIFT_ENABLE_TENSORFLOW END
 
   // Build the SILConstantInfo and cache it.
   auto resultBuf = Context.Allocate(sizeof(SILConstantInfo),

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3749,8 +3749,9 @@ SILFunction *SILGenModule::getOrCreateCustomDerivativeThunk(
   auto *thunk = fb.getOrCreateFunction(
       loc, name, customDerivativeFn->getLinkage(), thunkFnTy, IsBare,
       IsNotTransparent, customDerivativeFn->isSerialized(),
-      customDerivativeFn->isDynamicallyReplaceable(), customDerivativeFn->getEntryCount(),
-      IsThunk, customDerivativeFn->getClassSubclassScope());
+      customDerivativeFn->isDynamicallyReplaceable(),
+      customDerivativeFn->getEntryCount(), IsThunk,
+      customDerivativeFn->getClassSubclassScope());
   thunk->setInlineStrategy(AlwaysInline);
   if (!thunk->empty())
     return thunk;
@@ -3762,15 +3763,39 @@ SILFunction *SILGenModule::getOrCreateCustomDerivativeThunk(
   thunkSGF.collectThunkParams(loc, params, &indirectResults);
 
   auto *fnRef = thunkSGF.B.createFunctionRef(loc, customDerivativeFn);
-  auto fnRefType =
-      fnRef->getType().castTo<SILFunctionType>();
+  auto fnRefType = fnRef->getType().castTo<SILFunctionType>();
 
   // Collect thunk arguments, converting ownership.
   SmallVector<SILValue, 8> arguments;
   for (auto *indRes : indirectResults)
     arguments.push_back(indRes);
-  forwardFunctionArguments(thunkSGF, loc, fnRefType, params,
-                           arguments);
+  forwardFunctionArguments(thunkSGF, loc, fnRefType, params, arguments);
+
+  // Special support for thunking class initializer derivatives.
+  //
+  // User-defined custom derivatives take a metatype as the last parameter:
+  // - `$(Param0, Param1, ..., @thick Class.Type) -> (...)`
+  // But class initializers take an allocated instance as the last parameter:
+  // - `$(Param0, Param1, ..., @owned Class) -> (...)`
+  //
+  // Adjust forwarded arguments:
+  // - Pop the last `@owned Class` argument.
+  // - Create a `@thick Class.Type` value and pass it as the last argument.
+  auto *origAFD =
+      cast<AbstractFunctionDecl>(originalFn->getDeclContext()->getAsDecl());
+  if (isa<ConstructorDecl>(origAFD) &&
+      SILDeclRef(origAFD, SILDeclRef::Kind::Initializer).mangle() ==
+          originalFn->getName()) {
+    auto classArgument = arguments.pop_back_val();
+    auto *classDecl = classArgument->getType().getClassOrBoundGenericClass();
+    assert(classDecl && "Expected last argument to have class type");
+    auto classMetatype = MetatypeType::get(
+        classDecl->getDeclaredInterfaceType(), MetatypeRepresentation::Thick);
+    auto canClassMetatype = classMetatype->getCanonicalType();
+    auto *metatype = thunkSGF.B.createMetatype(
+        loc, SILType::getPrimitiveObjectType(canClassMetatype));
+    arguments.push_back(metatype);
+  }
   // Apply function argument.
   auto apply = thunkSGF.emitApplyWithRethrow(
       loc, fnRef, /*substFnType*/ fnRef->getType(),

--- a/lib/SILOptimizer/Utils/Differentiation/PullbackEmitter.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/PullbackEmitter.cpp
@@ -1672,6 +1672,26 @@ void PullbackEmitter::visitUnconditionalCheckedCastAddrInst(
   emitZeroIndirect(destType.getASTType(), adjDest, uccai->getLoc());
 }
 
+void PullbackEmitter::visitUncheckedRefCastInst(UncheckedRefCastInst *urci) {
+  auto *bb = urci->getParent();
+  assert(urci->getOperand()->getType().isObject());
+  assert(getRemappedTangentType(urci->getOperand()->getType()) ==
+             getRemappedTangentType(urci->getType()) &&
+         "Operand/result must have the same `TangentVector` type");
+  auto adj = getAdjointValue(bb, urci);
+  addAdjointValue(bb, urci->getOperand(), adj, urci->getLoc());
+}
+
+void PullbackEmitter::visitUpcastInst(UpcastInst *ui) {
+  auto *bb = ui->getParent();
+  assert(ui->getOperand()->getType().isObject());
+  assert(getRemappedTangentType(ui->getOperand()->getType()) ==
+             getRemappedTangentType(ui->getType()) &&
+         "Operand/result must have the same `TangentVector` type");
+  auto adj = getAdjointValue(bb, ui);
+  addAdjointValue(bb, ui->getOperand(), adj, ui->getLoc());
+}
+
 #define NOT_DIFFERENTIABLE(INST, DIAG)                                         \
   void PullbackEmitter::visit##INST##Inst(INST##Inst *inst) {                  \
     getContext().emitNondifferentiabilityError(inst, getInvoker(),             \

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3975,25 +3975,15 @@ llvm::Expected<IndexSubset *> DifferentiableAttributeTypeCheckRequest::evaluate(
   // Diagnose if original function is an invalid class member.
   if (isOriginalClassMember) {
     // Class methods returning dynamic `Self` are not supported.
-    // (For class methods, dynamic `Self` is supported only as the single
-    // result - tuple-returning JVPs/VJPs would not type-check.)
-    if (auto *originalFn = dyn_cast<FuncDecl>(original)) {
-      if (originalFn->hasDynamicSelfResult()) {
+    // For class methods, dynamic `Self` is supported only as the single
+    // result - tuple-returning JVPs/VJPs would not type-check.
+    if (auto *originalFD = dyn_cast<FuncDecl>(original)) {
+      if (originalFD->hasDynamicSelfResult()) {
         diags.diagnose(attr->getLocation(),
                        diag::differentiable_attr_class_member_no_dynamic_self);
         attr->setInvalid();
         return nullptr;
       }
-    }
-
-    // TODO(TF-654): Class initializers are not yet supported.
-    // Extra JVP/VJP type calculation logic is necessary because classes have
-    // both allocators and initializers.
-    if (auto *initDecl = dyn_cast<ConstructorDecl>(original)) {
-      diags.diagnose(attr->getLocation(),
-                     diag::differentiable_attr_class_init_not_yet_supported);
-      attr->setInvalid();
-      return nullptr;
     }
   }
 

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -1080,8 +1080,6 @@ class Super: Differentiable {
 
   var base: Float
 
-  // NOTE(TF-654): Class initializers are not yet supported.
-  // expected-error @+1 {{'@differentiable' attribute does not yet support class initializers}}
   @differentiable
   init(base: Float) {
     self.base = base

--- a/test/AutoDiff/downstream/class_differentiation.swift
+++ b/test/AutoDiff/downstream/class_differentiation.swift
@@ -92,6 +92,7 @@ ClassTests.test("AddressOnlyTangentVector") {
     @differentiable
     var stored: T
 
+    @differentiable
     init(_ stored: T) {
       self.stored = stored
     }

--- a/test/AutoDiff/downstream/class_method.swift
+++ b/test/AutoDiff/downstream/class_method.swift
@@ -7,7 +7,7 @@ import DifferentiationUnittest
 var ClassMethodTests = TestSuite("ClassMethods")
 
 ClassMethodTests.test("Final") {
-  final class Final : Differentiable {
+  final class Final: Differentiable {
     func method(_ x: Tracked<Float>) -> Tracked<Float> {
       return x * x
     }
@@ -35,14 +35,14 @@ ClassMethodTests.test("Simple") {
     }
   }
 
-  class SubOverride : Super {
+  class SubOverride: Super {
     @differentiable(wrt: x)
     override func f(_ x: Tracked<Float>) -> Tracked<Float> {
       return 3 * x
     }
   }
 
-  class SubOverrideCustomDerivatives : Super {
+  class SubOverrideCustomDerivatives: Super {
     @differentiable(wrt: x, jvp: jvpf2, vjp: vjpf2)
     override func f(_ x: Tracked<Float>) -> Tracked<Float> {
       return 3 * x
@@ -64,18 +64,14 @@ ClassMethodTests.test("Simple") {
 }
 
 ClassMethodTests.test("SimpleWrtSelf") {
-  class Super : Differentiable {
+  class Super: Differentiable {
     var base: Tracked<Float>
     // FIXME(TF-648): Dummy to make `Super.AllDifferentiableVariables` be nontrivial.
     var _nontrivial: [Tracked<Float>] = []
 
-    // TODO(TF-654): Remove attribute when differentiation supports class initializers.
-    // @differentiable(vjp: vjpInit)
-    required init(base: Tracked<Float>) {
+    @differentiable
+    init(base: Tracked<Float>) {
       self.base = base
-    }
-    static func vjpInit(base: Tracked<Float>) -> (Super, (TangentVector) -> Tracked<Float>) {
-      return (Super(base: base), { x in x.base })
     }
 
     @differentiable(wrt: (self, x), jvp: jvpf, vjp: vjpf)
@@ -97,14 +93,36 @@ ClassMethodTests.test("SimpleWrtSelf") {
     }
   }
 
-  class SubOverride : Super {
+  class SubOverride: Super {
+    @differentiable
+    override init(base: Tracked<Float>) {
+      super.init(base: base)
+    }
+
+    // Note: `TangentVector` type is unused.
+    // There is no way to customize `SubOverride: Differentiable` conformance.
+    // The conformance is always inherited from `Super`.
+    struct TangentVector: Differentiable & AdditiveArithmetic {
+      var base: Float
+    }
+
     @differentiable(wrt: (self, x))
     override func f(_ x: Tracked<Float>) -> Tracked<Float> {
       return 3 * x
     }
   }
 
-  class SubOverrideCustomDerivatives : Super {
+  class SubOverrideCustomDerivatives: Super {
+    @differentiable(vjp: vjpInit)
+    override init(base: Tracked<Float>) {
+      super.init(base: base)
+    }
+    static func vjpInit(base: Tracked<Float>) -> (
+      SubOverrideCustomDerivatives, (Super.TangentVector) -> Tracked<Float>
+    ) {
+      return (SubOverrideCustomDerivatives(base: base), { x in x.base * 2 })
+    }
+
     @differentiable(wrt: (self, x))
     @differentiable(wrt: x, jvp: jvpf2, vjp: vjpf2)
     override func f(_ x: Tracked<Float>) -> Tracked<Float> {
@@ -118,13 +136,10 @@ ClassMethodTests.test("SimpleWrtSelf") {
     }
   }
 
-  // TODO(TF-654): Uncomment when differentiation supports class initializers.
-  /*
   let v = Super.TangentVector(base: 100, _nontrivial: [])
   expectEqual(100, pullback(at: 1337) { x in Super(base: x) }(v))
   expectEqual(100, pullback(at: 1337) { x in SubOverride(base: x) }(v))
-  expectEqual(100, pullback(at: 1337) { x in SubOverrideCustomDerivatives(base: x) }(v))
-  */
+  expectEqual(200, pullback(at: 1337) { x in SubOverrideCustomDerivatives(base: x) }(v))
 
   // `valueWithGradient` is not used because nested tuples cannot be compared
   // with `expectEqual`.
@@ -140,7 +155,7 @@ ClassMethodTests.test("SimpleWrtSelf") {
 }
 
 ClassMethodTests.test("Generics") {
-  class Super<T : Differentiable & FloatingPoint> where T == T.TangentVector {
+  class Super<T: Differentiable & FloatingPoint> where T == T.TangentVector {
     @differentiable(wrt: x, jvp: jvpf, vjp: vjpf)
     func f(_ x: Tracked<T>) -> Tracked<T> {
       return Tracked<T>(2) * x
@@ -157,21 +172,21 @@ ClassMethodTests.test("Generics") {
     }
   }
 
-  class SubOverride<T : Differentiable & FloatingPoint> : Super<T> where T == T.TangentVector {
+  class SubOverride<T: Differentiable & FloatingPoint>: Super<T> where T == T.TangentVector {
     @differentiable(wrt: x)
     override func f(_ x: Tracked<T>) -> Tracked<T> {
       return x
     }
   }
 
-  class SubSpecializeOverride : Super<Float> {
+  class SubSpecializeOverride: Super<Float> {
     @differentiable(wrt: x)
     override func f(_ x: Tracked<Float>) -> Tracked<Float> {
       return 3 * x
     }
   }
 
-  class SubOverrideCustomDerivatives<T : Differentiable & FloatingPoint> : Super<T>
+  class SubOverrideCustomDerivatives<T: Differentiable & FloatingPoint>: Super<T>
   where T == T.TangentVector {
     @differentiable(wrt: x, jvp: jvpf2, vjp: vjpf2)
     override func f(_ x: Tracked<T>) -> Tracked<T> {
@@ -189,7 +204,7 @@ ClassMethodTests.test("Generics") {
     }
   }
 
-  class SubSpecializeOverrideCustomDerivatives : Super<Float80> {
+  class SubSpecializeOverrideCustomDerivatives: Super<Float80> {
     @differentiable(wrt: x, jvp: jvpf2, vjp: vjpf2)
     override func f(_ x: Tracked<Float80>) -> Tracked<Float80> {
       return 3 * x
@@ -206,7 +221,7 @@ ClassMethodTests.test("Generics") {
     }
   }
 
-  func classValueWithGradient<T : Differentiable & FloatingPoint>(
+  func classValueWithGradient<T: Differentiable & FloatingPoint>(
     _ c: Super<T>
   ) -> (T, T) where T == T.TangentVector {
     let (x,y) =  valueWithGradient(at: Tracked<T>(1), in: {
@@ -221,18 +236,14 @@ ClassMethodTests.test("Generics") {
 }
 
 ClassMethodTests.test("Methods") {
-  class Super : Differentiable {
+  class Super: Differentiable {
     var base: Tracked<Float>
     // Dummy to make `Super.AllDifferentiableVariables` be nontrivial.
     var _nontrivial: [Tracked<Float>] = []
 
-    // TODO(TF-654): Remove attribute when differentiation supports class initializers.
-    // @differentiable(vjp: vjpInit)
+    @differentiable
     init(base: Tracked<Float>) {
       self.base = base
-    }
-    static func vjpInit(base: Tracked<Float>) -> (Super, (TangentVector) -> Tracked<Float>) {
-      return (Super(base: base), { x in x.base })
     }
 
     @differentiable(vjp: vjpSquared)
@@ -246,7 +257,7 @@ ClassMethodTests.test("Methods") {
     }
   }
 
-  class Sub1 : Super {
+  class Sub1: Super {
     @differentiable(vjp: vjpSquared2)
     override func squared() -> Tracked<Float> { base * base }
     final func vjpSquared2() -> (Tracked<Float>, (Tracked<Float>) -> TangentVector) {
@@ -261,15 +272,8 @@ ClassMethodTests.test("Methods") {
     return valueWithGradient(at: c) { c in c.squared() }
   }
 
-  // TODO(TF-654, TF-645): Uncomment when differentiation supports class initializers or `ref_element_addr`.
-  // expectEqual(4, gradient(at: 2) { x in Super(base: x).squared() })
-
-  // TODO(TF-647): Handle `unchecked_ref_cast` in `Sub1.init` during pullback generation.
-  // FIXME: `Super.init` VJP type mismatch for empty `Super.AllDifferentiableVariables`:
-  // SIL verification failed: VJP type does not match expected VJP type
-  //   $@convention(method) (Tracked<Float>, @thick Super.Type) -> (@owned Super, @owned @callee_guaranteed (@guaranteed Super.AllDifferentiableVariables) -> Tracked<Float>)
-  //   $@convention(method) (Tracked<Float>, @owned Super) -> (@owned Super, @owned @callee_guaranteed (@guaranteed Super.AllDifferentiableVariables) -> Tracked<Float>)
-  // expectEqual(4, gradient(at: 2) { x in Sub1(base: x).squared() })
+  expectEqual(4, gradient(at: 2) { x in Super(base: x).squared() })
+  expectEqual(4, gradient(at: 2) { x in Sub1(base: x).squared() })
 
   expectEqual(Super.TangentVector(base: 4, _nontrivial: []),
               gradient(at: Super(base: 2)) { foo in foo.squared() })
@@ -278,15 +282,11 @@ ClassMethodTests.test("Methods") {
 }
 
 ClassMethodTests.test("Properties") {
-  class Super : Differentiable {
+  class Super: Differentiable {
+    @differentiable
     var base: Tracked<Float>
 
-    // TODO(TF-654): Remove attribute when differentiation supports class initializers.
-    // @differentiable(vjp: vjpInit)
     init(base: Tracked<Float>) { self.base = base }
-    static func vjpInit(base: Tracked<Float>) -> (Super, (TangentVector) -> Tracked<Float>) {
-      return (Super(base: base), { x in x.base })
-    }
 
     @differentiable(vjp: vjpSquared)
     var squared: Tracked<Float> { base * base }
@@ -297,22 +297,16 @@ ClassMethodTests.test("Properties") {
     }
   }
 
-  class Sub1 : Super {
-    // FIXME(TF-625): Crash due to `Super.AllDifferentiableVariables` abstraction pattern mismatch.
-    // SIL verification failed: vtable entry for #<anonymous function>Super.squared!getter.1.jvp.1.S must be ABI-compatible
-    //   ABI incompatible return values
-    //   @convention(method) (@guaranteed Super) -> (Tracked<Float>, @owned @callee_guaranteed (@guaranteed Super.AllDifferentiableVariables) -> Tracked<Float>)
-    //   @convention(method) (@guaranteed Sub1) -> (Tracked<Float>, @owned @callee_guaranteed (Super.AllDifferentiableVariables) -> Tracked<Float>)
-    // @differentiable
-    // override var squared: Tracked<Float> { base * base }
+  class Sub1: Super {
+    @differentiable
+    override var squared: Tracked<Float> { base * base }
   }
 
   func classValueWithGradient(_ c: Super) -> (Tracked<Float>, Super.TangentVector) {
     return valueWithGradient(at: c) { c in c.squared }
   }
 
-  // TODO(TF-654, TF-645): Uncomment when differentiation supports class initializers or `ref_element_addr`.
-  // expectEqual(4, gradient(at: 2) { x in Super(base: x).squared })
+  expectEqual(4, gradient(at: 2) { x in Super(base: x).squared })
   expectEqual(Super.TangentVector(base: 4),
               gradient(at: Super(base: 2)) { foo in foo.squared })
 }

--- a/test/AutoDiff/downstream/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/downstream/differentiable_attr_type_checking.swift
@@ -1030,8 +1030,6 @@ extension ProtocolRequirementUnsupported {
 class Super : Differentiable {
   var base: Float
 
-  // NOTE(TF-654): Class initializers are not yet supported.
-  // expected-error @+1 {{'@differentiable' attribute does not yet support class initializers}}
   @differentiable
   init(base: Float) {
     self.base = base

--- a/test/AutoDiff/downstream/differentiation_transform_diagnostics.swift
+++ b/test/AutoDiff/downstream/differentiation_transform_diagnostics.swift
@@ -247,9 +247,6 @@ class MultipleDiffAttrsClass : Differentiable {
   func f(_ x: Float) -> Float { x }
 }
 func testMultipleDiffAttrsClass<C: MultipleDiffAttrsClass>(_ c: C, _ x: Float) {
-  // TODO(TF-647): Handle differentiation of `upcast` instruction.
-  // expected-error @+2 {{function is not differentiable}}
-  // expected-note @+1 {{expression is not differentiable}}
   _ = gradient(at: c, x) { c, x in c.f(x) }
   _ = gradient(at: x) { x in c.f(x) }
 }

--- a/test/AutoDiff/downstream/forward_mode_runtime.swift
+++ b/test/AutoDiff/downstream/forward_mode_runtime.swift
@@ -745,17 +745,10 @@ ForwardModeTests.test("SimpleWrtSelf") {
     // FIXME(TF-648): Dummy to make `Super.AllDifferentiableVariables` be nontrivial.
     var _nontrivial: [Float] = []
 
-    // TODO(TF-654): Remove attribute when differentiation supports class initializers.
-    // @differentiable(vjp: vjpInit)
+    // FIXME(SR-12175): Fix forward-mode differentiation crash.
+    // @differentiable
     required init(base: Float) {
       self.base = base
-    }
-    static func vjpInit(base: Float) -> (Super, (TangentVector) -> Float) {
-      return (Super(base: base), { x in x.base })
-    }
-
-    static func jvpInit(base: Float) -> (Super, (Float) -> TangentVector) {
-      return (Super(base: base), { x in TangentVector(base: x, _nontrivial: []) })
     }
 
     @differentiable(wrt: (self, x), jvp: jvpf, vjp: vjpf)
@@ -794,7 +787,7 @@ ForwardModeTests.test("SimpleWrtSelf") {
     }
   }
 
-  // TODO(TF-654): Uncomment when differentiation supports class initializers.
+  // FIXME(SR-12175): Fix forward-mode differentiation crash.
   // let v = Super.TangentVector(base: 100, _nontrivial: [])
   // expectEqual(100, pullback(at: 1337) { x in Super(base: x) }(v))
   // expectEqual(100, pullback(at: 1337) { x in SubOverride(base: x) }(v))

--- a/test/AutoDiff/downstream/vtable_sil.swift
+++ b/test/AutoDiff/downstream/vtable_sil.swift
@@ -10,13 +10,9 @@ class Super : Differentiable {
   // FIXME(TF-648): Dummy to make `Super.TangentVector` be nontrivial.
   var _nontrivial: [Float] = []
 
-  // TODO(TF-654): Remove attribute when differentiation supports class initializers.
-  // @differentiable(vjp: vjpInit)
+  @differentiable
   init(base: Float) {
     self.base = base
-  }
-  static func vjpInit(base: Float) -> (Super, (TangentVector) -> Float) {
-    return (Super(base: base), { x in x.base })
   }
 
   @differentiable
@@ -54,14 +50,10 @@ class Super : Differentiable {
 }
 
 class Sub : Super {
-  // TODO(TF-654): Remove attribute when differentiation supports class initializers.
-  // @differentiable(vjp: vjpInit2)
+  @differentiable
   override init(base: Float) {
     super.init(base: base)
     self.base = base
-  }
-  static func vjpInit2(base: Float) -> (Sub, (TangentVector) -> Float) {
-    return (Sub(base: base), { x in x.base })
   }
 
   @differentiable
@@ -105,6 +97,8 @@ class SubSub : Sub {}
 // CHECK-NEXT:   #Super._nontrivial!setter.1: (Super) -> ([Float]) -> () : @$s10vtable_sil5SuperC11_nontrivialSaySfGvs
 // CHECK-NEXT:   #Super._nontrivial!modify.1: (Super) -> () -> () : @$s10vtable_sil5SuperC11_nontrivialSaySfGvM
 // CHECK-NEXT:   #Super.init!allocator.1: (Super.Type) -> (Float) -> Super : @$s10vtable_sil5SuperC4baseACSf_tcfC
+// CHECK-NEXT:   #Super.init!allocator.1.jvp.SU: (Super.Type) -> (Float) -> Super : @AD__$s10vtable_sil5SuperC4baseACSf_tcfC__jvp_src_0_wrt_0_vtable_entry_thunk
+// CHECK-NEXT:   #Super.init!allocator.1.vjp.SU: (Super.Type) -> (Float) -> Super : @AD__$s10vtable_sil5SuperC4baseACSf_tcfC__vjp_src_0_wrt_0_vtable_entry_thunk
 // CHECK-NEXT:   #Super.property!getter.1: (Super) -> () -> Float : @$s10vtable_sil5SuperC8propertySfvg
 // CHECK-NEXT:   #Super.property!getter.1.jvp.S: (Super) -> () -> Float : @AD__$s10vtable_sil5SuperC8propertySfvg__jvp_src_0_wrt_0_vtable_entry_thunk
 // CHECK-NEXT:   #Super.property!getter.1.vjp.S: (Super) -> () -> Float : @AD__$s10vtable_sil5SuperC8propertySfvg__vjp_src_0_wrt_0_vtable_entry_thunk
@@ -129,6 +123,8 @@ class SubSub : Sub {}
 // CHECK-NEXT:   #Super._nontrivial!setter.1: (Super) -> ([Float]) -> () : @$s10vtable_sil5SuperC11_nontrivialSaySfGvs [inherited]
 // CHECK-NEXT:   #Super._nontrivial!modify.1: (Super) -> () -> () : @$s10vtable_sil5SuperC11_nontrivialSaySfGvM [inherited]
 // CHECK-NEXT:   #Super.init!allocator.1: (Super.Type) -> (Float) -> Super : @$s10vtable_sil3SubC4baseACSf_tcfC [override]
+// CHECK-NEXT:   #Super.init!allocator.1.jvp.SU: (Super.Type) -> (Float) -> Super : @AD__$s10vtable_sil3SubC4baseACSf_tcfC__jvp_src_0_wrt_0_vtable_entry_thunk [override]
+// CHECK-NEXT:   #Super.init!allocator.1.vjp.SU: (Super.Type) -> (Float) -> Super : @AD__$s10vtable_sil3SubC4baseACSf_tcfC__vjp_src_0_wrt_0_vtable_entry_thunk [override]
 // CHECK-NEXT:   #Super.property!getter.1: (Super) -> () -> Float : @$s10vtable_sil3SubC8propertySfvg [override]
 // CHECK-NEXT:   #Super.property!getter.1.jvp.S: (Super) -> () -> Float : @AD__$s10vtable_sil3SubC8propertySfvg__jvp_src_0_wrt_0_vtable_entry_thunk [override]
 // CHECK-NEXT:   #Super.property!getter.1.vjp.S: (Super) -> () -> Float : @AD__$s10vtable_sil3SubC8propertySfvg__vjp_src_0_wrt_0_vtable_entry_thunk [override]
@@ -155,6 +151,8 @@ class SubSub : Sub {}
 // CHECK-NEXT:   #Super._nontrivial!setter.1: (Super) -> ([Float]) -> () : @$s10vtable_sil5SuperC11_nontrivialSaySfGvs [inherited]
 // CHECK-NEXT:   #Super._nontrivial!modify.1: (Super) -> () -> () : @$s10vtable_sil5SuperC11_nontrivialSaySfGvM [inherited]
 // CHECK-NEXT:   #Super.init!allocator.1: (Super.Type) -> (Float) -> Super : @$s10vtable_sil03SubC0C4baseACSf_tcfC [override]
+// CHECK-NEXT:   #Super.init!allocator.1.jvp.SU: (Super.Type) -> (Float) -> Super : @AD__$s10vtable_sil3SubC4baseACSf_tcfC__jvp_src_0_wrt_0_vtable_entry_thunk [inherited]
+// CHECK-NEXT:   #Super.init!allocator.1.vjp.SU: (Super.Type) -> (Float) -> Super : @AD__$s10vtable_sil3SubC4baseACSf_tcfC__vjp_src_0_wrt_0_vtable_entry_thunk [inherited]
 // CHECK-NEXT:   #Super.property!getter.1: (Super) -> () -> Float : @$s10vtable_sil3SubC8propertySfvg [inherited]
 // CHECK-NEXT:   #Super.property!getter.1.jvp.S: (Super) -> () -> Float : @AD__$s10vtable_sil3SubC8propertySfvg__jvp_src_0_wrt_0_vtable_entry_thunk [inherited]
 // CHECK-NEXT:   #Super.property!getter.1.vjp.S: (Super) -> () -> Float : @AD__$s10vtable_sil3SubC8propertySfvg__vjp_src_0_wrt_0_vtable_entry_thunk [inherited]


### PR DESCRIPTION
Support `@differentiable` class initializers.
- Add special logic in `SILGenModule::getOrCreateCustomDerivativeThunk` to
  thunk user-defined class initializer derivative functions to the expected
  derivative type for class initializers.
- Make minor vtable SILGen changes for class initializer derivatives.

Also support differentiation for class-related casting instructions:
`unchecked_ref_cast` and `upcast`.

These instructions are generated when calling `super.init` or referencing
inherited superclass members.

Resolves SR-12151 and SR-12153.