### PR TITLE
[AutoDiff] Support `@differentiable` class initializers.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3001,18 +3001,18 @@ ERROR(differentiable_attr_protocol_req_assoc_func,none,
 ERROR(differentiable_attr_stored_property_variable_unsupported,none,
       "'@differentiable' attribute on stored property cannot specify "
       "'jvp:' or 'vjp:'", ())
-ERROR(differentiable_attr_class_member_no_dynamic_self,none,
-      "'@differentiable' attribute cannot be declared on class methods "
+ERROR(differentiable_attr_class_member_dynamic_self_result_unsupported,none,
+      "'@differentiable' attribute cannot be declared on class members "
       "returning 'Self'", ())
-// TODO(TF-654): Remove when differentiation supports class initializers.
-ERROR(differentiable_attr_class_init_not_yet_supported,none,
-      "'@differentiable' attribute does not yet support class initializers",
-      ())
+ERROR(differentiable_attr_nonfinal_class_init_unsupported,none,
+      "'@differentiable' attribute cannot be declared on 'init' in a non-final "
+      "class; consider making %0 final", (Type))
 ERROR(differentiable_attr_empty_where_clause,none,
       "empty 'where' clause in '@differentiable' attribute", ())
 // SWIFT_ENABLE_TENSORFLOW
 ERROR(differentiable_attr_nongeneric_trailing_where,none,
-      "trailing 'where' clause in '@differentiable' attribute of non-generic function %0", (DeclName))
+      "trailing 'where' clause in '@differentiable' attribute of non-generic "
+      "function %0", (DeclName))
 ERROR(differentiable_attr_where_clause_for_nongeneric_original,none,
       "'where' clause is valid only when original function is generic %0",
       (DeclName))
@@ -3049,6 +3049,12 @@ ERROR(derivative_attr_not_in_same_file_as_original,none,
       "derivative not in the same file as the original function", ())
 ERROR(derivative_attr_original_stored_property_unsupported,none,
       "cannot register derivative for stored property %0", (DeclNameRef))
+ERROR(derivative_attr_class_member_dynamic_self_result_unsupported,none,
+      "cannot register derivative for class member %0 returning 'Self'",
+      (DeclNameRef))
+ERROR(derivative_attr_nonfinal_class_init_unsupported,none,
+      "cannot register derivative for 'init' in a non-final class; consider "
+      "making %0 final", (Type))
 ERROR(derivative_attr_original_already_has_derivative,none,
       "a derivative already exists for %0", (DeclName))
 NOTE(derivative_attr_duplicate_note,none,

--- a/include/swift/SILOptimizer/Utils/Differentiation/PullbackEmitter.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/PullbackEmitter.h
@@ -434,6 +434,16 @@ public:
   void visitUnconditionalCheckedCastAddrInst(
       UnconditionalCheckedCastAddrInst *uccai);
 
+  /// Handle `unchecked_ref_cast` instruction.
+  ///   Original: y = unchecked_ref_cast x
+  ///    Adjoint: adj[x] += adj[y] (assuming x' and y' have the same type)
+  void visitUncheckedRefCastInst(UncheckedRefCastInst *urci);
+
+  /// Handle `upcast` instruction.
+  ///   Original: y = upcast x
+  ///    Adjoint: adj[x] += adj[y] (assuming x' and y' have the same type)
+  void visitUpcastInst(UpcastInst *ui);
+
 #define NOT_DIFFERENTIABLE(INST, DIAG) void visit##INST##Inst(INST##Inst *inst);
 #undef NOT_DIFFERENTIABLE
 

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3749,8 +3749,9 @@ SILFunction *SILGenModule::getOrCreateCustomDerivativeThunk(
   auto *thunk = fb.getOrCreateFunction(
       loc, name, customDerivativeFn->getLinkage(), thunkFnTy, IsBare,
       IsNotTransparent, customDerivativeFn->isSerialized(),
-      customDerivativeFn->isDynamicallyReplaceable(), customDerivativeFn->getEntryCount(),
-      IsThunk, customDerivativeFn->getClassSubclassScope());
+      customDerivativeFn->isDynamicallyReplaceable(),
+      customDerivativeFn->getEntryCount(), IsThunk,
+      customDerivativeFn->getClassSubclassScope());
   thunk->setInlineStrategy(AlwaysInline);
   if (!thunk->empty())
     return thunk;
@@ -3762,15 +3763,39 @@ SILFunction *SILGenModule::getOrCreateCustomDerivativeThunk(
   thunkSGF.collectThunkParams(loc, params, &indirectResults);
 
   auto *fnRef = thunkSGF.B.createFunctionRef(loc, customDerivativeFn);
-  auto fnRefType =
-      fnRef->getType().castTo<SILFunctionType>();
+  auto fnRefType = fnRef->getType().castTo<SILFunctionType>();
 
   // Collect thunk arguments, converting ownership.
   SmallVector<SILValue, 8> arguments;
   for (auto *indRes : indirectResults)
     arguments.push_back(indRes);
-  forwardFunctionArguments(thunkSGF, loc, fnRefType, params,
-                           arguments);
+  forwardFunctionArguments(thunkSGF, loc, fnRefType, params, arguments);
+
+  // Special support for thunking class initializer derivatives.
+  //
+  // User-defined custom derivatives take a metatype as the last parameter:
+  // - `$(Param0, Param1, ..., @thick Class.Type) -> (...)`
+  // But class initializers take an allocated instance as the last parameter:
+  // - `$(Param0, Param1, ..., @owned Class) -> (...)`
+  //
+  // Adjust forwarded arguments:
+  // - Pop the last `@owned Class` argument.
+  // - Create a `@thick Class.Type` value and pass it as the last argument.
+  auto *origAFD =
+      cast<AbstractFunctionDecl>(originalFn->getDeclContext()->getAsDecl());
+  if (isa<ConstructorDecl>(origAFD) &&
+      SILDeclRef(origAFD, SILDeclRef::Kind::Initializer).mangle() ==
+          originalFn->getName()) {
+    auto classArgument = arguments.pop_back_val();
+    auto *classDecl = classArgument->getType().getClassOrBoundGenericClass();
+    assert(classDecl && "Expected last argument to have class type");
+    auto classMetatype = MetatypeType::get(
+        classDecl->getDeclaredInterfaceType(), MetatypeRepresentation::Thick);
+    auto canClassMetatype = classMetatype->getCanonicalType();
+    auto *metatype = thunkSGF.B.createMetatype(
+        loc, SILType::getPrimitiveObjectType(canClassMetatype));
+    arguments.push_back(metatype);
+  }
   // Apply function argument.
   auto apply = thunkSGF.emitApplyWithRethrow(
       loc, fnRef, /*substFnType*/ fnRef->getType(),

--- a/lib/SILOptimizer/Utils/Differentiation/PullbackEmitter.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/PullbackEmitter.cpp
@@ -376,7 +376,8 @@ SILValue PullbackEmitter::getAdjointProjection(SILBasicBlock *origBB,
     auto *tanField = cast<VarDecl>(tanFieldLookup.front());
     // Create a local allocation for the element adjoint buffer.
     auto eltTanType = tanField->getValueInterfaceType()->getCanonicalType();
-    auto eltTanSILType = SILType::getPrimitiveAddressType(eltTanType);
+    auto eltTanSILType =
+        remapType(SILType::getPrimitiveAddressType(eltTanType));
     auto *eltAdjBuffer = createFunctionLocalAllocation(eltTanSILType, loc);
     builder.emitScopedBorrowOperation(
         loc, adjClass, [&](SILValue borrowedAdjClass) {
@@ -1090,7 +1091,7 @@ PullbackEmitter::getArrayAdjointElementBuffer(SILValue arrayAdjoint,
   auto arrayTanType = cast<StructType>(arrayAdjoint->getType().getASTType());
   auto arrayType = arrayTanType->getParent()->castTo<BoundGenericStructType>();
   auto eltTanType = arrayType->getGenericArgs().front()->getCanonicalType();
-  auto eltTanSILType = SILType::getPrimitiveAddressType(eltTanType);
+  auto eltTanSILType = remapType(SILType::getPrimitiveAddressType(eltTanType));
   // Get `function_ref` and generic signature of
   // `Array.TangentVector.subscript.getter`.
   auto *arrayTanStructDecl = arrayTanType->getStructOrBoundGenericStruct();
@@ -1602,12 +1603,11 @@ void PullbackEmitter::visitLoadOperation(SingleValueInstruction *inst) {
 void PullbackEmitter::visitStoreOperation(SILBasicBlock *bb, SILLocation loc,
                                           SILValue origSrc, SILValue origDest) {
   auto &adjBuf = getAdjointBuffer(bb, origDest);
-  auto bufType = remapType(adjBuf->getType());
   auto adjVal =
       builder.emitLoadValueOperation(loc, adjBuf, LoadOwnershipQualifier::Take);
   recordTemporary(adjVal);
   addAdjointValue(bb, origSrc, makeConcreteAdjointValue(adjVal), loc);
-  emitZeroIndirect(bufType.getASTType(), adjBuf, loc);
+  emitZeroIndirect(adjBuf->getType().getASTType(), adjBuf, loc);
 }
 
 void PullbackEmitter::visitStoreInst(StoreInst *si) {
@@ -1670,6 +1670,26 @@ void PullbackEmitter::visitUnconditionalCheckedCastAddrInst(
   builder.emitDestroyAddrAndFold(uccai->getLoc(), castBuf);
   builder.createDeallocStack(uccai->getLoc(), castBuf);
   emitZeroIndirect(destType.getASTType(), adjDest, uccai->getLoc());
+}
+
+void PullbackEmitter::visitUncheckedRefCastInst(UncheckedRefCastInst *urci) {
+  auto *bb = urci->getParent();
+  assert(urci->getOperand()->getType().isObject());
+  assert(getRemappedTangentType(urci->getOperand()->getType()) ==
+             getRemappedTangentType(urci->getType()) &&
+         "Operand/result must have the same `TangentVector` type");
+  auto adj = getAdjointValue(bb, urci);
+  addAdjointValue(bb, urci->getOperand(), adj, urci->getLoc());
+}
+
+void PullbackEmitter::visitUpcastInst(UpcastInst *ui) {
+  auto *bb = ui->getParent();
+  assert(ui->getOperand()->getType().isObject());
+  assert(getRemappedTangentType(ui->getOperand()->getType()) ==
+             getRemappedTangentType(ui->getType()) &&
+         "Operand/result must have the same `TangentVector` type");
+  auto adj = getAdjointValue(bb, ui);
+  addAdjointValue(bb, ui->getOperand(), adj, ui->getLoc());
 }
 
 #define NOT_DIFFERENTIABLE(INST, DIAG)                                         \

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3969,31 +3969,38 @@ llvm::Expected<IndexSubset *> DifferentiableAttributeTypeCheckRequest::evaluate(
     return nullptr;
   }
 
+  // Diagnose if original function is an invalid class member.
   bool isOriginalClassMember = original->getDeclContext() &&
                                original->getDeclContext()->getSelfClassDecl();
-
-  // Diagnose if original function is an invalid class member.
   if (isOriginalClassMember) {
-    // Class methods returning dynamic `Self` are not supported.
-    // (For class methods, dynamic `Self` is supported only as the single
-    // result - tuple-returning JVPs/VJPs would not type-check.)
-    if (auto *originalFn = dyn_cast<FuncDecl>(original)) {
-      if (originalFn->hasDynamicSelfResult()) {
-        diags.diagnose(attr->getLocation(),
-                       diag::differentiable_attr_class_member_no_dynamic_self);
+    auto *classDecl = original->getDeclContext()->getSelfClassDecl();
+    assert(classDecl);
+    // Class members returning dynamic `Self` are not supported.
+    // Dynamic `Self` is supported only as a single top-level result for class
+    // members. JVP/VJP functions returning `(Self, ...)` tuples would not
+    // type-check.
+    bool diagnoseDynamicSelfResult = original->hasDynamicSelfResult();
+    if (diagnoseDynamicSelfResult) {
+      // Diagnose class initializers in non-final classes.
+      if (isa<ConstructorDecl>(original)) {
+        if (!classDecl->isFinal()) {
+          diags.diagnose(
+              attr->getLocation(),
+              diag::differentiable_attr_nonfinal_class_init_unsupported,
+              classDecl->getDeclaredInterfaceType());
+          attr->setInvalid();
+          return nullptr;
+        }
+      }
+      // Diagnose all other declarations returning dynamic `Self`.
+      else {
+        diags.diagnose(
+            attr->getLocation(),
+            diag::
+                differentiable_attr_class_member_dynamic_self_result_unsupported);
         attr->setInvalid();
         return nullptr;
       }
-    }
-
-    // TODO(TF-654): Class initializers are not yet supported.
-    // Extra JVP/VJP type calculation logic is necessary because classes have
-    // both allocators and initializers.
-    if (auto *initDecl = dyn_cast<ConstructorDecl>(original)) {
-      diags.diagnose(attr->getLocation(),
-                     diag::differentiable_attr_class_init_not_yet_supported);
-      attr->setInvalid();
-      return nullptr;
     }
   }
 
@@ -4282,6 +4289,38 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
       diags.diagnose(originalAFD->getLoc(), diag::decl_declared_here,
                      asd->getFullName());
       return true;
+    }
+  }
+  // Diagnose if original function is an invalid class member.
+  bool isOriginalClassMember =
+      originalAFD->getDeclContext() &&
+      originalAFD->getDeclContext()->getSelfClassDecl();
+  if (isOriginalClassMember) {
+    auto *classDecl = originalAFD->getDeclContext()->getSelfClassDecl();
+    assert(classDecl);
+    // Class members returning dynamic `Self` are not supported.
+    // Dynamic `Self` is supported only as a single top-level result for class
+    // members. JVP/VJP functions returning `(Self, ...)` tuples would not
+    // type-check.
+    bool diagnoseDynamicSelfResult = originalAFD->hasDynamicSelfResult();
+    if (diagnoseDynamicSelfResult) {
+      // Diagnose class initializers in non-final classes.
+      if (isa<ConstructorDecl>(originalAFD)) {
+        if (!classDecl->isFinal()) {
+          diags.diagnose(attr->getLocation(),
+                         diag::derivative_attr_nonfinal_class_init_unsupported,
+                         classDecl->getDeclaredInterfaceType());
+          return true;
+        }
+      }
+      // Diagnose all other declarations returning dynamic `Self`.
+      else {
+        diags.diagnose(
+            attr->getLocation(),
+            diag::derivative_attr_class_member_dynamic_self_result_unsupported,
+            DeclNameRef(originalAFD->getFullName()));
+        return true;
+      }
     }
   }
   attr->setOriginalFunction(originalAFD);

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -1080,8 +1080,7 @@ class Super: Differentiable {
 
   var base: Float
 
-  // NOTE(TF-654): Class initializers are not yet supported.
-  // expected-error @+1 {{'@differentiable' attribute does not yet support class initializers}}
+  // expected-error @+1 {{'@differentiable' attribute cannot be declared on 'init' in a non-final class; consider making 'Super' final}}
   @differentiable
   init(base: Float) {
     self.base = base
@@ -1146,6 +1145,18 @@ class Sub: Super {
   // expected-error @+1 {{'vjp' is not defined in the current type context}}
   @differentiable(wrt: x, vjp: vjp)
   override func testSuperclassDerivatives(_ x: Float) -> Float { x }
+}
+
+final class FinalClass: Differentiable {
+  typealias TangentVector = DummyTangentVector
+  func move(along _: TangentVector) {}
+
+  var base: Float
+
+  @differentiable
+  init(base: Float) {
+    self.base = base
+  }
 }
 
 // Test unsupported accessors: `set`, `_read`, `_modify`.

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -1123,7 +1123,7 @@ class Super: Differentiable {
   func instanceMethod<T>(_ x: Float, y: T) -> Float { x }
 
   // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
-  // expected-error @+1 {{'@differentiable' attribute cannot be declared on class methods returning 'Self'}}
+  // expected-error @+1 {{'@differentiable' attribute cannot be declared on class members returning 'Self'}}
   @differentiable(vjp: vjpDynamicSelfResult)
   func dynamicSelfResult() -> Self { self }
 

--- a/test/AutoDiff/downstream/class_differentiation.swift
+++ b/test/AutoDiff/downstream/class_differentiation.swift
@@ -9,15 +9,21 @@ import DifferentiationUnittest
 var ClassTests = TestSuite("ClassDifferentiation")
 
 ClassTests.test("TrivialMember") {
-  class C: Differentiable {
+  final class C: Differentiable {
     @differentiable
     var float: Float
 
     @noDerivative
     final var noDerivative: Float = 1
 
+    @differentiable
     init(_ float: Float) {
       self.float = float
+    }
+
+    @differentiable
+    convenience init(convenience x: Float) {
+      self.init(x)
     }
 
     @differentiable
@@ -44,6 +50,7 @@ ClassTests.test("TrivialMember") {
   }
   // Test class initializer differentiation.
   expectEqual(10, pullback(at: 3, in: { C($0) })(.init(float: 10)))
+  expectEqual(10, pullback(at: 3, in: { C(convenience: $0) })(.init(float: 10)))
   // Test class method differentiation.
   expectEqual((.init(float: 3), 10), gradient(at: C(10), 3, in: { c, x in c.method(x) }))
   expectEqual(.init(float: 0), gradient(at: C(10), in: { c in c.testNoDerivative() }))
@@ -52,10 +59,11 @@ ClassTests.test("TrivialMember") {
 }
 
 ClassTests.test("NontrivialMember") {
-  class C: Differentiable {
+  final class C: Differentiable {
     @differentiable
     var float: Tracked<Float>
 
+    @differentiable
     init(_ float: Tracked<Float>) {
       self.float = float
     }
@@ -84,14 +92,35 @@ ClassTests.test("NontrivialMember") {
               gradient(at: C(10), C(20), in: { c1, c2 in C.controlFlow(c1, c2, true) }))
 }
 
+ClassTests.test("GenericNontrivialMember") {
+  final class C<T: Differentiable>: Differentiable where T == T.TangentVector {
+    @differentiable
+    var x: Tracked<T>
+
+    @differentiable
+    init(_ x: T) {
+      self.x = Tracked(x)
+    }
+
+    @differentiable
+    convenience init(convenience x: T) {
+      self.init(x)
+    }
+  }
+  // Test class initializer differentiation.
+  expectEqual(10, pullback(at: 3, in: { C<Float>($0) })(.init(x: 10)))
+  expectEqual(10, pullback(at: 3, in: { C<Float>(convenience: $0) })(.init(x: 10)))
+}
+
 // TF-1149: Test class with loadable type but address-only `TangentVector` type.
 // TODO(TF-1149): Uncomment when supported.
 /*
 ClassTests.test("AddressOnlyTangentVector") {
-  class C<T: Differentiable>: Differentiable {
+  final class C<T: Differentiable>: Differentiable {
     @differentiable
     var stored: T
 
+    @differentiable
     init(_ stored: T) {
       self.stored = stored
     }

--- a/test/AutoDiff/downstream/class_method.swift
+++ b/test/AutoDiff/downstream/class_method.swift
@@ -7,7 +7,7 @@ import DifferentiationUnittest
 var ClassMethodTests = TestSuite("ClassMethods")
 
 ClassMethodTests.test("Final") {
-  final class Final : Differentiable {
+  final class Final: Differentiable {
     func method(_ x: Tracked<Float>) -> Tracked<Float> {
       return x * x
     }
@@ -35,14 +35,14 @@ ClassMethodTests.test("Simple") {
     }
   }
 
-  class SubOverride : Super {
+  class SubOverride: Super {
     @differentiable(wrt: x)
     override func f(_ x: Tracked<Float>) -> Tracked<Float> {
       return 3 * x
     }
   }
 
-  class SubOverrideCustomDerivatives : Super {
+  class SubOverrideCustomDerivatives: Super {
     @differentiable(wrt: x, jvp: jvpf2, vjp: vjpf2)
     override func f(_ x: Tracked<Float>) -> Tracked<Float> {
       return 3 * x
@@ -64,18 +64,13 @@ ClassMethodTests.test("Simple") {
 }
 
 ClassMethodTests.test("SimpleWrtSelf") {
-  class Super : Differentiable {
+  class Super: Differentiable {
     var base: Tracked<Float>
     // FIXME(TF-648): Dummy to make `Super.AllDifferentiableVariables` be nontrivial.
     var _nontrivial: [Tracked<Float>] = []
 
-    // TODO(TF-654): Remove attribute when differentiation supports class initializers.
-    // @differentiable(vjp: vjpInit)
-    required init(base: Tracked<Float>) {
+    init(base: Tracked<Float>) {
       self.base = base
-    }
-    static func vjpInit(base: Tracked<Float>) -> (Super, (TangentVector) -> Tracked<Float>) {
-      return (Super(base: base), { x in x.base })
     }
 
     @differentiable(wrt: (self, x), jvp: jvpf, vjp: vjpf)
@@ -97,14 +92,36 @@ ClassMethodTests.test("SimpleWrtSelf") {
     }
   }
 
-  class SubOverride : Super {
+  final class SubOverride: Super {
+    @differentiable
+    override init(base: Tracked<Float>) {
+      super.init(base: base)
+    }
+
+    // Note: `TangentVector` type is unused.
+    // There is no way to customize `SubOverride: Differentiable` conformance.
+    // The conformance is always inherited from `Super`.
+    struct TangentVector: Differentiable & AdditiveArithmetic {
+      var base: Float
+    }
+
     @differentiable(wrt: (self, x))
     override func f(_ x: Tracked<Float>) -> Tracked<Float> {
       return 3 * x
     }
   }
 
-  class SubOverrideCustomDerivatives : Super {
+  final class SubOverrideCustomDerivatives: Super {
+    @differentiable(vjp: vjpInit)
+    override init(base: Tracked<Float>) {
+      super.init(base: base)
+    }
+    static func vjpInit(base: Tracked<Float>) -> (
+      SubOverrideCustomDerivatives, (Super.TangentVector) -> Tracked<Float>
+    ) {
+      return (SubOverrideCustomDerivatives(base: base), { x in x.base * 2 })
+    }
+
     @differentiable(wrt: (self, x))
     @differentiable(wrt: x, jvp: jvpf2, vjp: vjpf2)
     override func f(_ x: Tracked<Float>) -> Tracked<Float> {
@@ -118,13 +135,10 @@ ClassMethodTests.test("SimpleWrtSelf") {
     }
   }
 
-  // TODO(TF-654): Uncomment when differentiation supports class initializers.
-  /*
   let v = Super.TangentVector(base: 100, _nontrivial: [])
   expectEqual(100, pullback(at: 1337) { x in Super(base: x) }(v))
   expectEqual(100, pullback(at: 1337) { x in SubOverride(base: x) }(v))
-  expectEqual(100, pullback(at: 1337) { x in SubOverrideCustomDerivatives(base: x) }(v))
-  */
+  expectEqual(200, pullback(at: 1337) { x in SubOverrideCustomDerivatives(base: x) }(v))
 
   // `valueWithGradient` is not used because nested tuples cannot be compared
   // with `expectEqual`.
@@ -140,7 +154,7 @@ ClassMethodTests.test("SimpleWrtSelf") {
 }
 
 ClassMethodTests.test("Generics") {
-  class Super<T : Differentiable & FloatingPoint> where T == T.TangentVector {
+  class Super<T: Differentiable & FloatingPoint> where T == T.TangentVector {
     @differentiable(wrt: x, jvp: jvpf, vjp: vjpf)
     func f(_ x: Tracked<T>) -> Tracked<T> {
       return Tracked<T>(2) * x
@@ -157,21 +171,21 @@ ClassMethodTests.test("Generics") {
     }
   }
 
-  class SubOverride<T : Differentiable & FloatingPoint> : Super<T> where T == T.TangentVector {
+  class SubOverride<T: Differentiable & FloatingPoint>: Super<T> where T == T.TangentVector {
     @differentiable(wrt: x)
     override func f(_ x: Tracked<T>) -> Tracked<T> {
       return x
     }
   }
 
-  class SubSpecializeOverride : Super<Float> {
+  class SubSpecializeOverride: Super<Float> {
     @differentiable(wrt: x)
     override func f(_ x: Tracked<Float>) -> Tracked<Float> {
       return 3 * x
     }
   }
 
-  class SubOverrideCustomDerivatives<T : Differentiable & FloatingPoint> : Super<T>
+  class SubOverrideCustomDerivatives<T: Differentiable & FloatingPoint>: Super<T>
   where T == T.TangentVector {
     @differentiable(wrt: x, jvp: jvpf2, vjp: vjpf2)
     override func f(_ x: Tracked<T>) -> Tracked<T> {
@@ -189,7 +203,7 @@ ClassMethodTests.test("Generics") {
     }
   }
 
-  class SubSpecializeOverrideCustomDerivatives : Super<Float80> {
+  class SubSpecializeOverrideCustomDerivatives: Super<Float80> {
     @differentiable(wrt: x, jvp: jvpf2, vjp: vjpf2)
     override func f(_ x: Tracked<Float80>) -> Tracked<Float80> {
       return 3 * x
@@ -206,7 +220,7 @@ ClassMethodTests.test("Generics") {
     }
   }
 
-  func classValueWithGradient<T : Differentiable & FloatingPoint>(
+  func classValueWithGradient<T: Differentiable & FloatingPoint>(
     _ c: Super<T>
   ) -> (T, T) where T == T.TangentVector {
     let (x,y) =  valueWithGradient(at: Tracked<T>(1), in: {
@@ -221,18 +235,13 @@ ClassMethodTests.test("Generics") {
 }
 
 ClassMethodTests.test("Methods") {
-  class Super : Differentiable {
+  class Super: Differentiable {
     var base: Tracked<Float>
     // Dummy to make `Super.AllDifferentiableVariables` be nontrivial.
     var _nontrivial: [Tracked<Float>] = []
 
-    // TODO(TF-654): Remove attribute when differentiation supports class initializers.
-    // @differentiable(vjp: vjpInit)
     init(base: Tracked<Float>) {
       self.base = base
-    }
-    static func vjpInit(base: Tracked<Float>) -> (Super, (TangentVector) -> Tracked<Float>) {
-      return (Super(base: base), { x in x.base })
     }
 
     @differentiable(vjp: vjpSquared)
@@ -246,7 +255,7 @@ ClassMethodTests.test("Methods") {
     }
   }
 
-  class Sub1 : Super {
+  class Sub1: Super {
     @differentiable(vjp: vjpSquared2)
     override func squared() -> Tracked<Float> { base * base }
     final func vjpSquared2() -> (Tracked<Float>, (Tracked<Float>) -> TangentVector) {
@@ -261,15 +270,8 @@ ClassMethodTests.test("Methods") {
     return valueWithGradient(at: c) { c in c.squared() }
   }
 
-  // TODO(TF-654, TF-645): Uncomment when differentiation supports class initializers or `ref_element_addr`.
-  // expectEqual(4, gradient(at: 2) { x in Super(base: x).squared() })
-
-  // TODO(TF-647): Handle `unchecked_ref_cast` in `Sub1.init` during pullback generation.
-  // FIXME: `Super.init` VJP type mismatch for empty `Super.AllDifferentiableVariables`:
-  // SIL verification failed: VJP type does not match expected VJP type
-  //   $@convention(method) (Tracked<Float>, @thick Super.Type) -> (@owned Super, @owned @callee_guaranteed (@guaranteed Super.AllDifferentiableVariables) -> Tracked<Float>)
-  //   $@convention(method) (Tracked<Float>, @owned Super) -> (@owned Super, @owned @callee_guaranteed (@guaranteed Super.AllDifferentiableVariables) -> Tracked<Float>)
-  // expectEqual(4, gradient(at: 2) { x in Sub1(base: x).squared() })
+  expectEqual(4, gradient(at: 2) { x in Super(base: x).squared() })
+  expectEqual(4, gradient(at: 2) { x in Sub1(base: x).squared() })
 
   expectEqual(Super.TangentVector(base: 4, _nontrivial: []),
               gradient(at: Super(base: 2)) { foo in foo.squared() })
@@ -278,15 +280,11 @@ ClassMethodTests.test("Methods") {
 }
 
 ClassMethodTests.test("Properties") {
-  class Super : Differentiable {
+  class Super: Differentiable {
+    @differentiable
     var base: Tracked<Float>
 
-    // TODO(TF-654): Remove attribute when differentiation supports class initializers.
-    // @differentiable(vjp: vjpInit)
     init(base: Tracked<Float>) { self.base = base }
-    static func vjpInit(base: Tracked<Float>) -> (Super, (TangentVector) -> Tracked<Float>) {
-      return (Super(base: base), { x in x.base })
-    }
 
     @differentiable(vjp: vjpSquared)
     var squared: Tracked<Float> { base * base }
@@ -297,22 +295,16 @@ ClassMethodTests.test("Properties") {
     }
   }
 
-  class Sub1 : Super {
-    // FIXME(TF-625): Crash due to `Super.AllDifferentiableVariables` abstraction pattern mismatch.
-    // SIL verification failed: vtable entry for #<anonymous function>Super.squared!getter.1.jvp.1.S must be ABI-compatible
-    //   ABI incompatible return values
-    //   @convention(method) (@guaranteed Super) -> (Tracked<Float>, @owned @callee_guaranteed (@guaranteed Super.AllDifferentiableVariables) -> Tracked<Float>)
-    //   @convention(method) (@guaranteed Sub1) -> (Tracked<Float>, @owned @callee_guaranteed (Super.AllDifferentiableVariables) -> Tracked<Float>)
-    // @differentiable
-    // override var squared: Tracked<Float> { base * base }
+  class Sub1: Super {
+    @differentiable
+    override var squared: Tracked<Float> { base * base }
   }
 
   func classValueWithGradient(_ c: Super) -> (Tracked<Float>, Super.TangentVector) {
     return valueWithGradient(at: c) { c in c.squared }
   }
 
-  // TODO(TF-654, TF-645): Uncomment when differentiation supports class initializers or `ref_element_addr`.
-  // expectEqual(4, gradient(at: 2) { x in Super(base: x).squared })
+  expectEqual(4, gradient(at: 2) { x in Super(base: x).squared })
   expectEqual(Super.TangentVector(base: 4),
               gradient(at: Super(base: 2)) { foo in foo.squared })
 }

--- a/test/AutoDiff/downstream/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/downstream/differentiable_attr_type_checking.swift
@@ -1030,8 +1030,7 @@ extension ProtocolRequirementUnsupported {
 class Super : Differentiable {
   var base: Float
 
-  // NOTE(TF-654): Class initializers are not yet supported.
-  // expected-error @+1 {{'@differentiable' attribute does not yet support class initializers}}
+  // expected-error @+1 {{'@differentiable' attribute cannot be declared on 'init' in a non-final class; consider making 'Super' final}}
   @differentiable
   init(base: Float) {
     self.base = base
@@ -1074,9 +1073,13 @@ class Super : Differentiable {
   func instanceMethod<T>(_ x: Float, y: T) -> Float { x }
 
   // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
-  // expected-error @+1 {{'@differentiable' attribute cannot be declared on class methods returning 'Self'}}
+  // expected-error @+1 {{'@differentiable' attribute cannot be declared on class members returning 'Self'}}
   @differentiable(vjp: vjpDynamicSelfResult)
   func dynamicSelfResult() -> Self { self }
+
+  // expected-error @+1 {{'@differentiable' attribute cannot be declared on class members returning 'Self'}}
+  @differentiable
+  var testDynamicSelfProperty: Self { self }
 
   // TODO(TF-632): Fix "'TangentVector' is not a member type of 'Self'" diagnostic.
   // The underlying error should appear instead:
@@ -1096,6 +1099,15 @@ class Sub : Super {
   // expected-error @+1 {{'vjp' is not defined in the current type context}}
   @differentiable(wrt: x, vjp: vjp)
   override func testSuperclassDerivatives(_ x: Float) -> Float { x }
+}
+
+final class FinalClass: Differentiable {
+  var base: Float
+
+  @differentiable
+  init(base: Float) {
+    self.base = base
+  }
 }
 
 // Test unsupported accessors: `set`, `_read`, `_modify`.

--- a/test/AutoDiff/downstream/differentiation_transform_diagnostics.swift
+++ b/test/AutoDiff/downstream/differentiation_transform_diagnostics.swift
@@ -247,9 +247,6 @@ class MultipleDiffAttrsClass : Differentiable {
   func f(_ x: Float) -> Float { x }
 }
 func testMultipleDiffAttrsClass<C: MultipleDiffAttrsClass>(_ c: C, _ x: Float) {
-  // TODO(TF-647): Handle differentiation of `upcast` instruction.
-  // expected-error @+2 {{function is not differentiable}}
-  // expected-note @+1 {{expression is not differentiable}}
   _ = gradient(at: c, x) { c, x in c.f(x) }
   _ = gradient(at: x) { x in c.f(x) }
 }

--- a/test/AutoDiff/downstream/forward_mode_runtime.swift
+++ b/test/AutoDiff/downstream/forward_mode_runtime.swift
@@ -745,17 +745,10 @@ ForwardModeTests.test("SimpleWrtSelf") {
     // FIXME(TF-648): Dummy to make `Super.AllDifferentiableVariables` be nontrivial.
     var _nontrivial: [Float] = []
 
-    // TODO(TF-654): Remove attribute when differentiation supports class initializers.
-    // @differentiable(vjp: vjpInit)
+    // FIXME(SR-12175): Fix forward-mode differentiation crash.
+    // @differentiable
     required init(base: Float) {
       self.base = base
-    }
-    static func vjpInit(base: Float) -> (Super, (TangentVector) -> Float) {
-      return (Super(base: base), { x in x.base })
-    }
-
-    static func jvpInit(base: Float) -> (Super, (Float) -> TangentVector) {
-      return (Super(base: base), { x in TangentVector(base: x, _nontrivial: []) })
     }
 
     @differentiable(wrt: (self, x), jvp: jvpf, vjp: vjpf)
@@ -794,7 +787,7 @@ ForwardModeTests.test("SimpleWrtSelf") {
     }
   }
 
-  // TODO(TF-654): Uncomment when differentiation supports class initializers.
+  // FIXME(SR-12175): Fix forward-mode differentiation crash.
   // let v = Super.TangentVector(base: 100, _nontrivial: [])
   // expectEqual(100, pullback(at: 1337) { x in Super(base: x) }(v))
   // expectEqual(100, pullback(at: 1337) { x in SubOverride(base: x) }(v))

--- a/test/AutoDiff/downstream/vtable_sil.swift
+++ b/test/AutoDiff/downstream/vtable_sil.swift
@@ -10,13 +10,8 @@ class Super : Differentiable {
   // FIXME(TF-648): Dummy to make `Super.TangentVector` be nontrivial.
   var _nontrivial: [Float] = []
 
-  // TODO(TF-654): Remove attribute when differentiation supports class initializers.
-  // @differentiable(vjp: vjpInit)
   init(base: Float) {
     self.base = base
-  }
-  static func vjpInit(base: Float) -> (Super, (TangentVector) -> Float) {
-    return (Super(base: base), { x in x.base })
   }
 
   @differentiable
@@ -54,14 +49,8 @@ class Super : Differentiable {
 }
 
 class Sub : Super {
-  // TODO(TF-654): Remove attribute when differentiation supports class initializers.
-  // @differentiable(vjp: vjpInit2)
   override init(base: Float) {
     super.init(base: base)
-    self.base = base
-  }
-  static func vjpInit2(base: Float) -> (Sub, (TangentVector) -> Float) {
-    return (Sub(base: base), { x in x.base })
   }
 
   @differentiable


### PR DESCRIPTION
Support `@differentiable` class initializers in final classes.

- Allow `@differentiable` and `@derivative` attributes for original initializers
  in final classes. Reject original initializers in non-final classes.
- Add special logic in `SILGenModule::getOrCreateCustomDerivativeThunk` to
  thunk user-defined class initializer derivative functions to the expected
  derivative type for class initializers.

Also support differentiation for class-related casting instructions:
`unchecked_ref_cast` and `upcast`.

These instructions are generated when calling `super.init` or referencing
inherited superclass members.

Resolves SR-12151 and SR-12153.

---

Example:
```swift
class Super: Differentiable {
  var base: Float

  // Error: `Super` is non-final.
  @differentiable
  init(base: Float) {
    self.base = base
  }
}

final class Sub: Super {
  // No error: `Sub` is final.
  @differentiable
  override init(base: Float) {
    super.init(base: base)
  }
}
```
```console
class.swift:5:4: error: '@differentiable' attribute cannot be declared on 'init' in a non-final class; consider making 'Super' final
  @differentiable
   ^
```