### PR TITLE
[AutoDiff] Clean up `SILFunctionType::getAutoDiffTransposeFunctionType`.

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -243,14 +243,17 @@ void getSubsetParameterTypes(IndexSubset *indices, AnyFunctionType *type,
 /// "Constrained" derivative generic signatures require all differentiability
 /// parameters to conform to the `Differentiable` protocol.
 ///
-/// Returns the "constrained" derivative generic signature given:
+/// "Constrained" transpose generic signatures additionally require all
+/// linearity parameters to satisfy `Self == Self.TangentVector`.
+///
+/// Returns the "constrained" derivative/transpose generic signature given:
 /// - An original SIL function type.
-/// - Differentiability parameter indices.
-/// - A possibly "unconstrained" derivative generic signature.
-GenericSignature
-getConstrainedDerivativeGenericSignature(SILFunctionType *originalFnTy,
-                                         IndexSubset *diffParamIndices,
-                                         GenericSignature derivativeGenSig);
+/// - Differentiability/linearity parameter indices.
+/// - A possibly "unconstrained" derivative/transpose generic signature.
+GenericSignature getConstrainedDerivativeGenericSignature(
+    SILFunctionType *originalFnTy, IndexSubset *parameterIndices,
+    GenericSignature derivativeGenSig, LookupConformanceFn lookupConformance,
+    bool isTranspose = false);
 
 } // end namespace autodiff
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4532,11 +4532,41 @@ public:
       CanGenericSignature derivativeFunctionGenericSignature = nullptr,
       bool isReabstractionThunk = false);
 
-  /// Returns the type of the transpose function.
+  /// Returns the type of the transpose function for the given parameter
+  /// indices, transpose function generic signature (optional), and other
+  /// auxiliary parameters.
+  ///
+  /// Preconditions:
+  /// - Linearity parameters corresponding to parameter indices must conform to
+  ///   `Differentiable` and satisfy `Self == Self.TangentVector`.
+  ///
+  /// Typing rules, given:
+  /// - Original function type: $(T0, T1, ...) -> (R0, R1, ...)
+  ///
+  /// Transpose function type:
+  /// - Takes non-linearity parameters, followed by original results, as
+  ///   parameters.
+  /// - Returns linearity parameters.
+  ///
+  /// A "constrained transpose generic signature" is computed from
+  /// `transposeFunctionGenericSignature`, if specified. Otherwise, it is
+  /// computed from the original generic signature. A "constrained transpose
+  /// generic signature" requires all linearity parameters to conform to
+  /// `Differentiable` and to satisfy `Self == Self.TangentVector`; this is
+  /// important for correctness.
+  ///
+  /// This "constrained transpose generic signature" is used for
+  /// parameter/result type lowering. It is used as the actual generic signature
+  /// of the transpose function type iff the original function type has a
+  /// generic signature and not all generic parameters are bound to concrete
+  /// types. Otherwise, no transpose generic signature is used.
+  ///
+  /// Other properties of the original function type are copied exactly:
+  /// `ExtInfo`, callee convention, witness method conformance, etc.
   CanSILFunctionType getAutoDiffTransposeFunctionType(
       IndexSubset *parameterIndices, Lowering::TypeConverter &TC,
       LookupConformanceFn lookupConformance,
-      CanGenericSignature derivativeFunctionGenericSignature = nullptr);
+      CanGenericSignature transposeFunctionGenericSignature = nullptr);
 
   /// Returns a bit vector that specifices which parameters you can
   /// differentiate with respect to for this differentiable function type. (e.g.

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -567,7 +567,8 @@ emitDerivativeFunctionReference(
       auto derivativeConstrainedGenSig =
           autodiff::getConstrainedDerivativeGenericSignature(
               originalFn->getLoweredFunctionType(), desiredParameterIndices,
-              contextualDerivativeGenSig);
+              contextualDerivativeGenSig,
+              LookUpConformanceInModule(context.getModule().getSwiftModule()));
       minimalWitness = SILDifferentiabilityWitness::createDefinition(
           context.getModule(), SILLinkage::Private, originalFn,
           desiredParameterIndices, desiredResultIndices,


### PR DESCRIPTION
Add doc comments and minor edits to
`SILFunctionType::getAutoDiffTransposeFunctionType`.

Add `isTranspose` flag to `autodiff::getConstrainedDerivativeGenericSignature`.
Use it to constrain `Self == Self.TangentVector` for linearity parameters.

---

Mirror of upstream PR https://github.com/apple/swift/pull/29755. Basically NFC.