### PR TITLE
tests: remove -enforce-exclusivity=unchecked from tests which check the optimization result.

### DIFF
--- a/test/SILOptimizer/illegal_escaping_address.swift
+++ b/test/SILOptimizer/illegal_escaping_address.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -sil-verify-all -emit-sil -enforce-exclusivity=unchecked -parse-as-library %s
+// RUN: %target-swift-frontend -O -sil-verify-all -emit-sil -parse-as-library %s
 
 // Check that the compiler does not crash for illegal escaping of an address
 // of a local variable.

--- a/test/SILOptimizer/let_propagation.swift
+++ b/test/SILOptimizer/let_propagation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s  -emit-sil -enforce-exclusivity=unchecked -O | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s  -emit-sil -O | %FileCheck %s
 
 // Check that LoadStoreOpts can handle "let" variables properly.
 // Such variables should be loaded only once and their loaded values can be reused.
@@ -311,12 +311,13 @@ public func testLetTuple(s: S3) -> Int32 {
 
 // Check that s.x.0 is reloaded every time.
 // CHECK-LABEL: sil {{.*}}testVarTuple
-// CHECK: tuple_element_addr
-// CHECK: %[[X:[0-9]+]] = struct_element_addr
-// CHECK: load %[[X]]
-// CHECK: load %[[X]]
-// CHECK: load %[[X]]
-// CHECK: load %[[X]]
+// CHECK: [[X0:%[0-9]+]] = load
+// CHECK: [[X1:%[0-9]+]] = load
+// CHECK: builtin "sadd_with_overflow{{.*}}"([[X0]] {{.*}}, [[X1]]
+// CHECK: [[X2:%[0-9]+]] = load
+// CHECK: builtin "sadd_with_overflow{{.*}} [[X2]]
+// CHECK: [[X3:%[0-9]+]] = load
+// CHECK: builtin "sadd_with_overflow{{.*}} [[X3]]
 // CHECK: return
 public func testVarTuple(s: S3) -> Int32 {
   var counter: Int32 = 0

--- a/test/SILOptimizer/static_arrays.swift
+++ b/test/SILOptimizer/static_arrays.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend  -primary-file %s -O -sil-verify-all -Xllvm -sil-disable-pass=FunctionSignatureOpts -module-name=test -emit-sil -enforce-exclusivity=unchecked | %FileCheck %s
+// RUN: %target-swift-frontend  -primary-file %s -O -sil-verify-all -Xllvm -sil-disable-pass=FunctionSignatureOpts -module-name=test -emit-sil | %FileCheck %s
 
 // Also do an end-to-end test to check all components, including IRGen.
 // RUN: %empty-directory(%t) 


### PR DESCRIPTION
Tests which check if the optimizer is able to generate a certain code should never be "worked around" by adding command line options.
This defeats the purpose of such tests.
Unfortunately some optimizer deficiencies got unnoticed by adding this option.

to-do: there are more such cases which I didn't fix in this PR yet.
