### PR TITLE
Fix spelling of '@available' in error message "'@availability' attribute cannot be applied to this declaration"

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -66,7 +66,7 @@ public:
     /// "open", "public", "internal", "fileprivate", or "private".
     AccessControlKeyword,
 
-    /// such as @"availability".
+    /// such as @"available".
     DeclAttrKeyword,
 
     /// such as "unavailable" etc. for @available.

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1088,7 +1088,7 @@ StringRef DeclAttribute::getAttrName() const {
   case DAK_Semantics:
     return "_semantics";
   case DAK_Available:
-    return "availability";
+    return "available";
   case DAK_ObjC:
   case DAK_ObjCRuntimeName:
     return "objc";

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -134,7 +134,7 @@ let x: () = ()
 !x // expected-error {{cannot convert value of type '()' to expected argument type 'Bool'}}
 
 func sr8202_foo(@NSApplicationMain x: Int) {} // expected-error {{@NSApplicationMain may only be used on 'class' declarations}}
-func sr8202_bar(@available(iOS, deprecated: 0) x: Int) {} // expected-error {{'@availability' attribute cannot be applied to this declaration}}
+func sr8202_bar(@available(iOS, deprecated: 0) x: Int) {} // expected-error {{'@available' attribute cannot be applied to this declaration}}
 func sr8202_baz(@discardableResult x: Int) {} // expected-error {{'@discardableResult' attribute cannot be applied to this declaration}}
 func sr8202_qux(@objcMembers x: String) {} // expected-error {{@objcMembers may only be used on 'class' declarations}}
 func sr8202_quux(@weak x: String) {} // expected-error {{'weak' is a declaration modifier, not an attribute}} expected-error {{'weak' may only be used on 'var' declarations}}
@@ -143,5 +143,5 @@ class sr8202_cls<@NSApplicationMain T: AnyObject> {} // expected-error {{@NSAppl
 func sr8202_func<@discardableResult T>(x: T) {} // expected-error {{'@discardableResult' attribute cannot be applied to this declaration}}
 enum sr8202_enum<@indirect T> {} // expected-error {{'indirect' is a declaration modifier, not an attribute}} expected-error {{'indirect' modifier cannot be applied to this declaration}}
 protocol P {
-  @available(swift, introduced: 4.2) associatedtype Assoc // expected-error {{'@availability' attribute cannot be applied to this declaration}}
+  @available(swift, introduced: 4.2) associatedtype Assoc // expected-error {{'@available' attribute cannot be applied to this declaration}}
 }


### PR DESCRIPTION
In Xcode, if you apply the `@available` attribute to an unsupported declaration (such as an associated type), the compiler generates the following error:

> '@availability' attribute cannot be applied to this declaration

<img width="704" alt="'@availability' attribute cannot be applied to this declaration" src="https://user-images.githubusercontent.com/7659/74254005-b39d4f00-4ca4-11ea-9175-98478c0e855e.png">

At some point (I think in Swift 3; I had tracing back through commit history), the `@availability` attribute keyword was changed to `@available`, but the attribute name stayed the same. This results in a mismatch in the diagnostic message, because `invalid_decl_attribute` uses the result of `DeclAttribute::getAttrName()`.

This PR updates the return value of `DeclAttribute::getAttrName()` for `DAK_Available` to return the new spelling (`"available"`), as well as the affected parse tests.

https://github.com/apple/swift/blob/d246512b03f3716fe5277f2b3a68b1b4b170a098/test/Parse/invalid.swift#L137

https://github.com/apple/swift/blob/d246512b03f3716fe5277f2b3a68b1b4b170a098/test/Parse/invalid.swift#L145-L147