### PR TITLE
Minor cleanups after https://github.com/apple/swift/pull/29703

### DIFF
--- a/include/swift/SILOptimizer/Utils/SILInliner.h
+++ b/include/swift/SILOptimizer/Utils/SILInliner.h
@@ -72,7 +72,7 @@ public:
   ///
   /// In this case stack nesting must be corrected after inlining with the
   /// StackNesting utility.
-  static bool needsUpdateStackNesting(FullApplySite apply) {
+  static bool invalidatesStackNesting(FullApplySite apply) {
     // Inlining of coroutines can result in improperly nested stack
     // allocations.
     return isa<BeginApplyInst>(apply);
@@ -111,7 +111,7 @@ public:
   /// function.
   ///
   /// *NOTE*: Inlining can result in improperly nested stack allocations, which
-  /// must be corrected after inlining. See needsUpdateStackNesting().
+  /// must be corrected after inlining. See invalidatesStackNesting().
   ///
   /// Returns an iterator to the first inlined instruction (or the end of the
   /// caller block for empty functions) and the last block in function order
@@ -134,7 +134,7 @@ public:
   /// function.
   ///
   /// *NOTE*: Inlining can result in improperly nested stack allocations, which
-  /// must be corrected after inlining. See needsUpdateStackNesting().
+  /// must be corrected after inlining. See invalidatesStackNesting().
   ///
   /// Returns an iterator to the first inlined instruction (or the end of the
   /// caller block for empty functions) and the last block in function order

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -780,7 +780,7 @@ SILValue ClosureSpecCloner::cloneCalleeConversion(
 /// Populate the body of the cloned closure, modifying instructions as
 /// necessary. This is where we create the actual specialized BB Arguments
 void ClosureSpecCloner::populateCloned() {
-  bool needToUpdateStackNesting = false;
+  bool invalidatedStackNesting = false;
   SILFunction *Cloned = getCloned();
   SILFunction *ClosureUser = CallSiteDesc.getApplyCallee();
 
@@ -880,11 +880,11 @@ void ClosureSpecCloner::populateCloned() {
           Builder.createReleaseValue(Loc, SILValue(NewClosure),
                                      Builder.getDefaultAtomicity());
         else
-          needToUpdateStackNesting |=
+          invalidatedStackNesting |=
               CallSiteDesc.destroyIfPartialApplyStack(Builder, NewClosure);
         for (auto PAI : NeedsRelease) {
           if (PAI->isOnStack())
-            needToUpdateStackNesting |=
+            invalidatedStackNesting |=
                 CallSiteDesc.destroyIfPartialApplyStack(Builder, PAI);
           else
             Builder.createReleaseValue(Loc, SILValue(PAI),
@@ -909,11 +909,11 @@ void ClosureSpecCloner::populateCloned() {
         Builder.createReleaseValue(Loc, SILValue(NewClosure),
                                    Builder.getDefaultAtomicity());
       else
-        needToUpdateStackNesting |=
+        invalidatedStackNesting |=
             CallSiteDesc.destroyIfPartialApplyStack(Builder, NewClosure);
       for (auto PAI : NeedsRelease) {
         if (PAI->isOnStack())
-          needToUpdateStackNesting |=
+          invalidatedStackNesting |=
               CallSiteDesc.destroyIfPartialApplyStack(Builder, PAI);
         else
           Builder.createReleaseValue(Loc, SILValue(PAI),
@@ -921,7 +921,7 @@ void ClosureSpecCloner::populateCloned() {
       }
     }
   }
-  if (needToUpdateStackNesting) {
+  if (invalidatedStackNesting) {
     StackNesting().correctStackNesting(Cloned);
   }
 }
@@ -971,7 +971,7 @@ void SILClosureSpecializerTransform::run() {
     // specialized all of their uses.
     LLVM_DEBUG(llvm::dbgs() << "Trying to remove dead closures!\n");
     sortUnique(PropagatedClosures);
-    bool needUpdateStackNesting = false;
+    bool invalidatedStackNesting = false;
 
     for (auto *Closure : PropagatedClosures) {
       LLVM_DEBUG(llvm::dbgs() << "    Visiting: " << *Closure);
@@ -983,10 +983,10 @@ void SILClosureSpecializerTransform::run() {
 
       LLVM_DEBUG(llvm::dbgs() << "        Deleted closure!\n");
       ++NumPropagatedClosuresEliminated;
-      needUpdateStackNesting = true;
+      invalidatedStackNesting = true;
     }
 
-    if (needUpdateStackNesting) {
+    if (invalidatedStackNesting) {
       StackNesting().correctStackNesting(F);
     }
   }

--- a/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
@@ -72,7 +72,7 @@ class MandatoryCombiner final
 
   /// Set to true if some alloc/dealloc_stack instruction are inserted and at
   /// the end of the run stack nesting needs to be corrected.
-  bool needUpdateStackNesting;
+  bool invalidatedStackNesting;
 
   /// The number of times that the worklist has been processed.
   unsigned iteration;
@@ -119,7 +119,7 @@ public:
       ++iteration;
     }
 
-    if (needUpdateStackNesting) {
+    if (invalidatedStackNesting) {
       StackNesting().correctStackNesting(&function);
     }
 
@@ -279,7 +279,7 @@ SILInstruction *MandatoryCombiner::visitApplyInst(ApplyInst *instruction) {
 #endif
   );
   if (tryDeleteDeadClosure(partialApply, instModCallbacks)) {
-    needUpdateStackNesting = true;
+    invalidatedStackNesting = true;
   }
   return nullptr;
 }

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -230,7 +230,7 @@ bool SILCombiner::runOnFunction(SILFunction &F) {
     Iteration++;
   }
 
-  if (needUpdateStackNesting) {
+  if (invalidatedStackNesting) {
     StackNesting().correctStackNesting(&F);
   }
 

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -67,7 +67,7 @@ class SILCombiner :
 
   /// Set to true if some alloc/dealloc_stack instruction are inserted and at
   /// the end of the run stack nesting needs to be corrected.
-  bool needUpdateStackNesting = false;
+  bool invalidatedStackNesting = false;
 
   /// The current iteration of the SILCombine.
   unsigned Iteration;

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -107,14 +107,14 @@ SILInstruction *SILCombiner::visitPartialApplyInst(PartialApplyInst *PAI) {
   bool argsAreKeptAlive = tryOptimizeApplyOfPartialApply(
       PAI, Builder.getBuilderContext(), getInstModCallbacks());
   if (argsAreKeptAlive)
-    needUpdateStackNesting = true;
+    invalidatedStackNesting = true;
 
   // Try to delete the partial_apply.
   // In case it became dead because of tryOptimizeApplyOfPartialApply, we don't
   // need to copy all arguments again (to extend their lifetimes), because it
   // was already done in tryOptimizeApplyOfPartialApply.
   if (tryDeleteDeadClosure(PAI, getInstModCallbacks(), !argsAreKeptAlive))
-    needUpdateStackNesting = true;
+    invalidatedStackNesting = true;
 
   return nullptr;
 }

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -104,10 +104,8 @@ SILInstruction *SILCombiner::visitPartialApplyInst(PartialApplyInst *PAI) {
   if (foldInverseReabstractionThunks(PAI, this))
     return nullptr;
 
-  SILBuilderContext BuilderCtxt(Builder.getModule(), Builder.getTrackingList());
-  BuilderCtxt.setOpenedArchetypesTracker(Builder.getOpenedArchetypesTracker());
-  bool argsAreKeptAlive =
-      tryOptimizeApplyOfPartialApply(PAI, BuilderCtxt, getInstModCallbacks());
+  bool argsAreKeptAlive = tryOptimizeApplyOfPartialApply(
+      PAI, Builder.getBuilderContext(), getInstModCallbacks());
   if (argsAreKeptAlive)
     needUpdateStackNesting = true;
 

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -888,7 +888,7 @@ bool SILPerformanceInliner::inlineCallsIntoFunction(SILFunction *Caller) {
   // remains valid.
   SmallVector<FullApplySite, 8> AppliesToInline;
   collectAppliesToInline(Caller, AppliesToInline);
-  bool needUpdateStackNesting = false;
+  bool invalidatedStackNesting = false;
 
   if (AppliesToInline.empty())
     return false;
@@ -918,7 +918,7 @@ bool SILPerformanceInliner::inlineCallsIntoFunction(SILFunction *Caller) {
 
     // Note that this must happen before inlining as the apply instruction
     // will be deleted after inlining.
-    needUpdateStackNesting |= SILInliner::needsUpdateStackNesting(AI);
+    invalidatedStackNesting |= SILInliner::invalidatesStackNesting(AI);
 
     // We've already determined we should be able to inline this, so
     // unconditionally inline the function.
@@ -933,7 +933,7 @@ bool SILPerformanceInliner::inlineCallsIntoFunction(SILFunction *Caller) {
   // reestablish a canonical CFG.
   mergeBasicBlocks(Caller);
 
-  if (needUpdateStackNesting) {
+  if (invalidatedStackNesting) {
     StackNesting().correctStackNesting(Caller);
   }
 


### PR DESCRIPTION
* directly get the SILBuilderContext from SILBuilder for tryOptimizeApplyOfPartialApply

* rename needUpdateStackNesting (and similar) -> invalidatedStackNesting

(as suggested by @gottesmm)