### PR TITLE
[CodeCompletion] Workaround fast-completion issue in UnqualifiedLookup

### DIFF
--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -76,6 +76,10 @@ public:
     CodeCompletionOffset = Offset;
   }
 
+  bool hasCodeCompletionBuffer() const {
+    return CodeCompletionBufferID != 0U;
+  }
+
   unsigned getCodeCompletionBufferID() const {
     return CodeCompletionBufferID;
   }

--- a/test/SourceKit/CodeComplete/complete_sequence_nestedtype.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_nestedtype.swift
@@ -1,0 +1,50 @@
+struct Outer {
+  enum Inner {
+    case east, west
+    static func staticMethod() {}
+    func instanceMethod() {}
+
+    func test() {
+      Inner.
+    }
+  }
+
+  func test() {
+    Inner.
+  }
+}
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=track-compiles == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=8:13 %s -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=8:13 %s -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=13:11 %s -- %s \
+// RUN:   > %t.response
+// RUN: %FileCheck --check-prefix=RESULT  %s < %t.response
+// RUN: %FileCheck --check-prefix=TRACE  %s < %t.response
+
+// RESULT-LABEL: key.results: [
+// RESULT-DAG: key.description: "east"
+// RESULT-DAG: key.description: "west"
+// RESULT-DAG: key.description: "staticMethod()"
+// RESULT-DAG: key.description: "instanceMethod(self: Outer.Inner)"
+// RESULT: ]
+// RESULT-LABEL: key.results: [
+// RESULT-DAG: key.description: "east"
+// RESULT-DAG: key.description: "west"
+// RESULT-DAG: key.description: "staticMethod()"
+// RESULT-DAG: key.description: "instanceMethod(self: Outer.Inner)"
+// RESULT: ]
+// RESULT-LABEL: key.results: [
+// RESULT-DAG: key.description: "east"
+// RESULT-DAG: key.description: "west"
+// RESULT-DAG: key.description: "staticMethod()"
+// RESULT-DAG: key.description: "instanceMethod(self: Inner)"
+// RESULT: ]
+
+// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
+// TRACE-NOT: key.description: "completion reusing previous ASTContext (benign diagnostic)"
+// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
+// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
+// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
+// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"


### PR DESCRIPTION
In fast-completion, a function body can be replaced with another function body parsed from a new buffer. In such cases, during typechecking the expressions in the *new* function body, a source location range check in UnqualifiedLookup didn't work well because they are not from the same
buffer.

This patch workaround it by skipping the source range checks and returns 'success' in such cases.

rdar://problem/58881999
