### PR TITLE
[5.2][SourceKit] Still report modulename in CursorInfo when .swiftsourceinfo files are present

### DIFF
--- a/test/SourceKit/CursorInfo/use-swift-source-info.swift
+++ b/test/SourceKit/CursorInfo/use-swift-source-info.swift
@@ -23,7 +23,7 @@ func bar() {
 // WITH: source.lang.swift.ref.function.free ({{.*}}/Foo.swift:2:13-2:16)
 // WITHOUT: source.lang.swift.ref.function.free ()
 // BOTH: foo()
-// BOTH: s:3Foo3fooyyF
-// BOTH: () -> ()
-// BOTH: $syycD
-// BOTH: Foo
+// BOTH-NEXT: s:3Foo3fooyyF
+// BOTH-NEXT: () -> ()
+// BOTH-NEXT: $syycD
+// BOTH-NEXT: Foo

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -915,7 +915,7 @@ static bool passCursorInfoForDecl(SourceFile* SF,
     auto ClangMod = Importer->getClangOwningModule(ClangNode);
     if (ClangMod)
       ModuleName = ClangMod->getFullModuleName();
-  } else if (VD->getLoc().isInvalid() && VD->getModuleContext() != MainModule) {
+  } else if (VD->getModuleContext() != MainModule) {
     ModuleName = VD->getModuleContext()->getName().str();
   }
   StringRef ModuleInterfaceName;


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/29702 by @johnfairh 

* **Explanation**:
SourceKit's cursor-info request (used for jump to definition support among other things) would previously include the module of the symbol under the cursor in its response if the symbol came from a different module to the one the target source file belongs to. The check for it being in a different module was more specific than it should have been, however, and assumed that symbols from other modules would not have source locations. That assumption doesn't hold anymore because of the new .swiftsourceinfo files that provide source locations for symbols from other modules, so we ended up never reporting the module name if these files were present.

* **Scope of issue**:  
This impacts several open source tools that are using SourceKit and is a regression relative to the previous release.

* **Origination**: This regressed due to the introduction of .swiftsourceinfo files which provided source locations for symbols from other modules, breaking an assumption in the existing code.

* **Risk**: Low. This only affects SourceKit's cursor info request for symbols from other modules, and is restoring its previous behavior.

* **Testing**: John's changes include a fix for my existing regression test for this case which wasn't strict enough in its textual matching of the module name in the response. Apart from running the test suite with the updated test, I also verified this change in Xcode to make sure it doesn't affect Xcode's jump-to-definition functionality.

* **Reviewers**: Myself (@johnfairh found and contributed the fix for this issue)

Resolves rdar://problem/59359894