### PR TITLE
change "new" to "malloc" because it gets "free"d later

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7564,7 +7564,8 @@ void Solution::setExprTypes(Expr *expr) const {
 
 SolutionResult SolutionResult::forSolved(Solution &&solution) {
   SolutionResult result(Kind::Success);
-  result.solutions = new Solution(std::move(solution));
+  void *memory = malloc(sizeof(Solution));
+  result.solutions = new (memory) Solution(std::move(solution));
   result.numSolutions = 1;
   return result;
 }


### PR DESCRIPTION
This memory should be allocated with "malloc" instead of "new" because `SolutionResult::~SolutionResult()` "free"s it. (This is causing a failure in some internal google tests that check for this.)