### PR TITLE
[AutoDiff] Relax `@differentiable` requirement for protocol witnesses.

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1672,6 +1672,13 @@ class DifferentiableAttr final
   /// attribute's where clause requirements. This is set only if the attribute
   /// has a where clause.
   GenericSignature DerivativeGenericSignature;
+  /// The source location of the implicitly inherited protocol requirement
+  /// `@differentiable` attribute. Used for diagnostics, not serialized.
+  ///
+  /// This is set during conformance type-checking, only for implicit
+  /// `@differentiable` attributes created for non-public protocol witnesses of
+  /// protocol requirements with `@differentiable` attributes.
+  SourceLoc ImplicitlyInheritedDifferentiableAttrLocation;
 
   explicit DifferentiableAttr(bool implicit, SourceLoc atLoc,
                               SourceRange baseRange, bool linear,
@@ -1756,6 +1763,14 @@ public:
   void setJVPFunction(FuncDecl *decl);
   FuncDecl *getVJPFunction() const { return VJPFunction; }
   void setVJPFunction(FuncDecl *decl);
+
+  SourceLoc getImplicitlyInheritedDifferentiableAttrLocation() const {
+    return ImplicitlyInheritedDifferentiableAttrLocation;
+  }
+  void getImplicitlyInheritedDifferentiableAttrLocation(SourceLoc loc) {
+    assert(isImplicit());
+    ImplicitlyInheritedDifferentiableAttrLocation = loc;
+  }
 
   /// Get the derivative generic environment for the given `@differentiable`
   /// attribute and original function.

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -540,6 +540,9 @@ NOTE(autodiff_cannot_differentiate_through_multiple_results,none,
      "cannot differentiate through multiple results", ())
 NOTE(autodiff_class_member_not_supported,none,
      "differentiating class members is not yet supported", ())
+NOTE(autodiff_implicitly_inherited_differentiable_attr_here,none,
+     "differentiability required by the corresponding protocol requirement "
+     "here", ())
 // TODO(TF-642): Remove when `partial_apply` works with `@differentiable`
 // functions.
 NOTE(autodiff_cannot_param_subset_thunk_partially_applied_orig_fn,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3023,6 +3023,12 @@ ERROR(overriding_decl_missing_differentiable_attr,none,
       "overriding declaration is missing attribute '%0'", (StringRef))
 NOTE(protocol_witness_missing_differentiable_attr,none,
      "candidate is missing attribute '%0'", (StringRef))
+NOTE(protocol_witness_missing_differentiable_attr_nonpublic_other_file,none,
+     "non-public %1 %2 must have explicit '%0' attribute to satisfy "
+     "requirement %3 %4 (in protocol %6) because it is declared in a different "
+     "file than the conformance of %5 to %6",
+     (StringRef, DescriptiveDeclKind, DeclName, DescriptiveDeclKind, DeclName,
+      Type, Type))
 
 // @derivative
 ERROR(derivative_attr_expected_result_tuple,none,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -425,6 +425,13 @@ matchWitnessDifferentiableAttr(DeclContext *dc, ValueDecl *req,
             witnessAFD, /*implicit*/ true, witness->getLoc(), witness->getLoc(),
             reqDiffAttr->isLinear(), reqDiffAttr->getParameterIndices(),
             /*jvp*/ None, /*vjp*/ None, derivativeGenSig);
+        // If the implicit attribute is inherited from a protocol requirement's
+        // attribute, store the protocol requirement attribute's location for
+        // use in diagnostics.
+        if (witness->getFormalAccess() < AccessLevel::Public) {
+          newAttr->getImplicitlyInheritedDifferentiableAttrLocation(
+              reqDiffAttr->getLocation());
+        }
         auto insertion = ctx.DifferentiableAttrs.try_emplace(
             {witnessAFD, newAttr->getParameterIndices()}, newAttr);
         // Valid `@differentiable` attributes are uniqued by original function

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -419,11 +419,12 @@ matchWitnessDifferentiableAttr(DeclContext *dc, ValueDecl *req,
         auto derivativeGenSig = witnessAFD->getGenericSignature();
         if (supersetConfig)
           derivativeGenSig = supersetConfig->derivativeGenericSignature;
+        // Use source location of the witness declaration as the source location
+        // of the implicit `@differentiable` attribute.
         auto *newAttr = DifferentiableAttr::create(
-            witnessAFD, /*implicit*/ true, reqDiffAttr->AtLoc,
-            reqDiffAttr->getRange(), reqDiffAttr->isLinear(),
-            reqDiffAttr->getParameterIndices(), /*jvp*/ None,
-            /*vjp*/ None, derivativeGenSig);
+            witnessAFD, /*implicit*/ true, witness->getLoc(), witness->getLoc(),
+            reqDiffAttr->isLinear(), reqDiffAttr->getParameterIndices(),
+            /*jvp*/ None, /*vjp*/ None, derivativeGenSig);
         auto insertion = ctx.DifferentiableAttrs.try_emplace(
             {witnessAFD, newAttr->getParameterIndices()}, newAttr);
         // Valid `@differentiable` attributes are uniqued by original function

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -212,11 +212,6 @@ enum class MatchKind : uint8_t {
 
   /// The witness is missing a `@differentiable` attribute from the requirement.
   MissingDifferentiableAttr,
-
-  /// The witness is missing a `@differentiable` attribute from the requirement.
-  /// The witness has less-than-public visibility and is declared in a different
-  /// files than the conformance.
-  MissingDifferentiableAttrNonPublicOtherFile,
 };
 
 /// Describes the kind of optional adjustment performed when
@@ -443,7 +438,6 @@ struct RequirementMatch {
     case MatchKind::ThrowsConflict:
     case MatchKind::NonObjC:
     case MatchKind::MissingDifferentiableAttr:
-    case MatchKind::MissingDifferentiableAttrNonPublicOtherFile:
       return false;
     }
 
@@ -474,7 +468,6 @@ struct RequirementMatch {
     case MatchKind::ThrowsConflict:
     case MatchKind::NonObjC:
     case MatchKind::MissingDifferentiableAttr:
-    case MatchKind::MissingDifferentiableAttrNonPublicOtherFile:
       return false;
     }
 
@@ -486,13 +479,7 @@ struct RequirementMatch {
 
   /// Determine whether this requirement match has an unmet attribute.
   bool hasUnmetAttribute() {
-    switch (Kind) {
-    case MatchKind::MissingDifferentiableAttr:
-    case MatchKind::MissingDifferentiableAttrNonPublicOtherFile:
-      return true;
-    default:
-      return false;
-    }
+    return Kind == MatchKind::MissingDifferentiableAttr;
   }
 
   swift::Witness getWitness(ASTContext &ctx) const;

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -212,6 +212,11 @@ enum class MatchKind : uint8_t {
 
   /// The witness is missing a `@differentiable` attribute from the requirement.
   MissingDifferentiableAttr,
+
+  /// The witness is missing a `@differentiable` attribute from the requirement.
+  /// The witness has less-than-public visibility and is declared in a different
+  /// files than the conformance.
+  MissingDifferentiableAttrNonPublicOtherFile,
 };
 
 /// Describes the kind of optional adjustment performed when
@@ -438,6 +443,7 @@ struct RequirementMatch {
     case MatchKind::ThrowsConflict:
     case MatchKind::NonObjC:
     case MatchKind::MissingDifferentiableAttr:
+    case MatchKind::MissingDifferentiableAttrNonPublicOtherFile:
       return false;
     }
 
@@ -468,6 +474,7 @@ struct RequirementMatch {
     case MatchKind::ThrowsConflict:
     case MatchKind::NonObjC:
     case MatchKind::MissingDifferentiableAttr:
+    case MatchKind::MissingDifferentiableAttrNonPublicOtherFile:
       return false;
     }
 
@@ -479,7 +486,13 @@ struct RequirementMatch {
 
   /// Determine whether this requirement match has an unmet attribute.
   bool hasUnmetAttribute() {
-    return Kind == MatchKind::MissingDifferentiableAttr;
+    switch (Kind) {
+    case MatchKind::MissingDifferentiableAttr:
+    case MatchKind::MissingDifferentiableAttrNonPublicOtherFile:
+      return true;
+    default:
+      return false;
+    }
   }
 
   swift::Witness getWitness(ASTContext &ctx) const;

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -210,9 +210,8 @@ enum class MatchKind : uint8_t {
   /// The witness is explicitly @nonobjc but the requirement is @objc.
   NonObjC,
 
-  /// The witness does not have a `@differentiable` attribute satisfying one
-  /// from the requirement.
-  DifferentiableConflict,
+  /// The witness is missing a `@differentiable` attribute from the requirement.
+  MissingDifferentiableAttr,
 };
 
 /// Describes the kind of optional adjustment performed when
@@ -363,7 +362,7 @@ struct RequirementMatch {
       : Witness(witness), Kind(kind), WitnessType(), UnmetAttribute(attr),
         ReqEnv(None) {
     assert(!hasWitnessType() && "Should have witness type");
-    assert(UnmetAttribute);
+    assert(hasUnmetAttribute() && "Should have unmet attribute");
   }
 
   RequirementMatch(ValueDecl *witness, MatchKind kind,
@@ -438,7 +437,7 @@ struct RequirementMatch {
     case MatchKind::RethrowsConflict:
     case MatchKind::ThrowsConflict:
     case MatchKind::NonObjC:
-    case MatchKind::DifferentiableConflict:
+    case MatchKind::MissingDifferentiableAttr:
       return false;
     }
 
@@ -468,7 +467,7 @@ struct RequirementMatch {
     case MatchKind::RethrowsConflict:
     case MatchKind::ThrowsConflict:
     case MatchKind::NonObjC:
-    case MatchKind::DifferentiableConflict:
+    case MatchKind::MissingDifferentiableAttr:
       return false;
     }
 
@@ -479,7 +478,9 @@ struct RequirementMatch {
   bool hasRequirement() { return Kind == MatchKind::MissingRequirement; }
 
   /// Determine whether this requirement match has an unmet attribute.
-  bool hasUnmetAttribute() { return Kind == MatchKind::DifferentiableConflict; }
+  bool hasUnmetAttribute() {
+    return Kind == MatchKind::MissingDifferentiableAttr;
+  }
 
   swift::Witness getWitness(ASTContext &ctx) const;
 };

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -4,11 +4,11 @@
 import _Differentiation
 
 // Dummy `Differentiable`-conforming type.
-struct DummyTangentVector: Differentiable & AdditiveArithmetic {
-  static var zero: Self { Self() }
-  static func + (_: Self, _: Self) -> Self { Self() }
-  static func - (_: Self, _: Self) -> Self { Self() }
-  typealias TangentVector = Self
+public struct DummyTangentVector: Differentiable & AdditiveArithmetic {
+  public static var zero: Self { Self() }
+  public static func + (_: Self, _: Self) -> Self { Self() }
+  public static func - (_: Self, _: Self) -> Self { Self() }
+  public typealias TangentVector = Self
 }
 
 @differentiable // expected-error {{'@differentiable' attribute cannot be applied to this declaration}}
@@ -710,50 +710,90 @@ protocol ProtocolRequirementsRefined: ProtocolRequirements {
   func f1(_ x: Float) -> Float
 }
 
-// expected-error @+1 {{does not conform to protocol 'ProtocolRequirements'}}
-struct DiffAttrConformanceErrors: ProtocolRequirements {
+// Test missing `@differentiable` attribute for internal protocol witnesses.
+// No errors expected; internal `@differentiable` attributes are created.
+
+struct InternalDiffAttrConformance: ProtocolRequirements {
   typealias TangentVector = DummyTangentVector
   mutating func move(along _: TangentVector) {}
 
   var x: Float
   var y: Float
 
-  // FIXME(TF-284): Fix unexpected diagnostic.
-  // expected-note @+2 {{candidate is missing attribute '@differentiable'}} {{3-3=@differentiable }}
-  // expected-note @+1 {{candidate has non-matching type '(x: Float, y: Float)'}}
   init(x: Float, y: Float) {
     self.x = x
     self.y = y
   }
 
-  // FIXME(TF-284): Fix unexpected diagnostic.
-  // expected-note @+2 {{candidate is missing attribute '@differentiable'}} {{3-3=@differentiable }}
-  // expected-note @+1 {{candidate has non-matching type '(x: Float, y: Int)'}}
   init(x: Float, y: Int) {
     self.x = x
     self.y = Float(y)
   }
 
-  // expected-note @+2 {{candidate is missing attribute '@differentiable'}} {{3-3=@differentiable }}
-  // expected-note @+1 {{candidate has non-matching type '(Float, Float) -> Float'}}
   func amb(x: Float, y: Float) -> Float {
     return x
   }
 
-  // expected-note @+2 {{candidate is missing attribute '@differentiable(wrt: x)'}} {{3-3=@differentiable(wrt: x) }}
-  // expected-note @+1 {{candidate has non-matching type '(Float, Int) -> Float'}}
   func amb(x: Float, y: Int) -> Float {
     return x
   }
 
-  // expected-note @+1 {{candidate is missing attribute '@differentiable'}} {{3-3=@differentiable }}
   func f1(_ x: Float) -> Float {
     return x
   }
 
-  // expected-note @+2 {{candidate is missing attribute '@differentiable'}} {{3-3=@differentiable }}
   @differentiable(wrt: (self, x))
   func f2(_ x: Float, _ y: Float) -> Float {
+    return x + y
+  }
+}
+
+// Test missing `@differentiable` attribute for public protocol witnesses. Errors expected.
+
+// expected-error @+1 {{does not conform to protocol 'ProtocolRequirements'}}
+public struct PublicDiffAttrConformance: ProtocolRequirements {
+  public typealias TangentVector = DummyTangentVector
+  public mutating func move(along _: TangentVector) {}
+
+  var x: Float
+  var y: Float
+
+  // FIXME(TF-284): Fix unexpected diagnostic.
+  // expected-note @+2 {{candidate is missing attribute '@differentiable'}} {{10-10=@differentiable }}
+  // expected-note @+1 {{candidate has non-matching type '(x: Float, y: Float)'}}
+  public init(x: Float, y: Float) {
+    self.x = x
+    self.y = y
+  }
+
+  // FIXME(TF-284): Fix unexpected diagnostic.
+  // expected-note @+2 {{candidate is missing attribute '@differentiable'}} {{10-10=@differentiable }}
+  // expected-note @+1 {{candidate has non-matching type '(x: Float, y: Int)'}}
+  public init(x: Float, y: Int) {
+    self.x = x
+    self.y = Float(y)
+  }
+
+  // expected-note @+2 {{candidate is missing attribute '@differentiable'}} {{10-10=@differentiable }}
+  // expected-note @+1 {{candidate has non-matching type '(Float, Float) -> Float'}}
+  public func amb(x: Float, y: Float) -> Float {
+    return x
+  }
+
+  // expected-note @+2 {{candidate is missing attribute '@differentiable(wrt: x)'}} {{10-10=@differentiable(wrt: x) }}
+  // expected-note @+1 {{candidate has non-matching type '(Float, Int) -> Float'}}
+  public func amb(x: Float, y: Int) -> Float {
+    return x
+  }
+
+  // expected-note @+1 {{candidate is missing attribute '@differentiable'}}
+  public func f1(_ x: Float) -> Float {
+    return x
+  }
+
+  // expected-note @+2 {{candidate is missing attribute '@differentiable'}}
+  @differentiable(wrt: (self, x))
+  public func f2(_ x: Float, _ y: Float) -> Float {
     return x + y
   }
 }
@@ -769,51 +809,41 @@ extension ProtocolRequirementsWithDefault_NoConformingTypes {
 }
 
 protocol ProtocolRequirementsWithDefault {
-  // expected-note @+2 {{protocol requires function 'f1'}}
   @differentiable
   func f1(_ x: Float) -> Float
 }
 extension ProtocolRequirementsWithDefault {
-  // expected-note @+1 {{candidate is missing attribute '@differentiable'}} {{3-3=@differentiable }}
   func f1(_ x: Float) -> Float { x }
 }
-// expected-error @+1 {{type 'DiffAttrConformanceErrors2' does not conform to protocol 'ProtocolRequirementsWithDefault'}}
 struct DiffAttrConformanceErrors2: ProtocolRequirementsWithDefault {
   typealias TangentVector = DummyTangentVector
   mutating func move(along _: TangentVector) {}
 
-  // expected-note @+1 {{candidate is missing attribute '@differentiable'}} {{3-3=@differentiable }}
   func f1(_ x: Float) -> Float { x }
 }
 
 protocol NotRefiningDiffable {
   @differentiable(wrt: x)
-  // expected-note @+1 {{protocol requires function 'a' with type '(Float) -> Float'; do you want to add a stub?}}
   func a(_ x: Float) -> Float
 }
 
-// expected-error @+1 {{type 'CertainlyNotDiffableWrtSelf' does not conform to protocol 'NotRefiningDiffable'}}
 struct CertainlyNotDiffableWrtSelf: NotRefiningDiffable {
-  // expected-note @+1 {{candidate is missing attribute '@differentiable'}} {{3-3=@differentiable }}
   func a(_ x: Float) -> Float { return x * 5.0 }
 }
-
 
 protocol TF285: Differentiable {
   @differentiable(wrt: (x, y))
   @differentiable(wrt: x)
-  // expected-note @+1 {{protocol requires function 'foo(x:y:)' with type '(Float, Float) -> Float'; do you want to add a stub?}}
   func foo(x: Float, y: Float) -> Float
 }
 
-// expected-error @+1 {{type 'TF285MissingOneDiffAttr' does not conform to protocol 'TF285'}}
 struct TF285MissingOneDiffAttr: TF285 {
   typealias TangentVector = DummyTangentVector
   mutating func move(along _: TangentVector) {}
 
-  // Requirement is missing an attribute.
+  // Requirement is missing the required `@differentiable(wrt: (x, y))` attribute.
+  // Since `TF285MissingOneDiffAttr.foo` is internal, the attribute is implicitly created.
   @differentiable(wrt: x)
-  // expected-note @+1 {{candidate is missing attribute '@differentiable(wrt: (x, y))}} {{3-3=@differentiable(wrt: (x, y)) }}
   func foo(x: Float, y: Float) -> Float {
     return x
   }

--- a/test/AutoDiff/downstream/differentiable_requirement_cross_module.swift
+++ b/test/AutoDiff/downstream/differentiable_requirement_cross_module.swift
@@ -11,10 +11,22 @@ extension Empty : Differentiable {
   public typealias AllDifferentiableVariables = Empty
 }
 
-// expected-error @+1 {{type 'Conforming' does not conform to protocol 'DifferentiableRequirement'}}
-struct Conforming : DifferentiableRequirement {
-  // expected-note @+1 {{candidate is missing attribute '@differentiable(wrt: float)'}}
+private struct PrivateConforming : DifferentiableRequirement {
+  fileprivate func foo(float: Float, empty: Empty) -> Float {
+    return float
+  }
+}
+
+struct InternalConforming : DifferentiableRequirement {
   func foo(float: Float, empty: Empty) -> Float {
+    return float
+  }
+}
+
+// expected-error @+1 {{type 'PublicConforming' does not conform to protocol 'DifferentiableRequirement'}}
+public struct PublicConforming : DifferentiableRequirement {
+  // expected-note @+1 {{candidate is missing attribute '@differentiable(wrt: float)'}}
+  public func foo(float: Float, empty: Empty) -> Float {
     return float
   }
 }

--- a/test/AutoDiff/downstream/implicit_nonpublic_differentiable_attr_cross_file/Inputs/other_file.swift
+++ b/test/AutoDiff/downstream/implicit_nonpublic_differentiable_attr_cross_file/Inputs/other_file.swift
@@ -4,12 +4,12 @@ protocol Protocol: Differentiable {
   func internalMethod1(_ x: Float) -> Float
 
   // expected-note @+3 {{protocol requires function 'internalMethod2' with type '(Float) -> Float'}}
-  @differentiable(wrt: (self, x))
   @differentiable(wrt: x)
+  @differentiable(wrt: (self, x))
   func internalMethod2(_ x: Float) -> Float
 
-  @differentiable(wrt: (self, x))
   @differentiable(wrt: x)
+  @differentiable(wrt: (self, x))
   func internalMethod3(_ x: Float) -> Float
 }
 
@@ -28,20 +28,20 @@ protocol Protocol2: Differentiable {
 //   Context: https://github.com/apple/swift/pull/29771#issuecomment-585059721
 
 struct ConformingStruct: Differentiable {
-  // Expected: errors for missing `@differentiable` attribute.
-  // expected-note @+1 {{candidate is missing attribute '@differentiable'}}
+  // Expected: error for missing `@differentiable` attribute.
+  // expected-note @+1 {{non-public instance method 'internalMethod1' must have explicit '@differentiable' attribute to satisfy requirement instance method 'internalMethod1' (in protocol 'Protocol') because it is declared in a different file than the conformance of 'ConformingStruct' to 'Protocol'}} {{3-3=@differentiable }}
   func internalMethod1(_ x: Float) -> Float {
     x
   }
 
-  // Expected: errors for missing `@differentiable` superset attribute.
-  // expected-note @+2 {{candidate is missing attribute '@differentiable'}}
+  // Expected: error for missing `@differentiable` superset attribute.
+  // expected-note @+2 {{non-public instance method 'internalMethod2' must have explicit '@differentiable' attribute to satisfy requirement instance method 'internalMethod2' (in protocol 'Protocol') because it is declared in a different file than the conformance of 'ConformingStruct' to 'Protocol'}} {{3-3=@differentiable }}
   @differentiable(wrt: x)
   func internalMethod2(_ x: Float) -> Float {
     x
   }
 
-  // Expected: no errors for missing `@differentiable` subset attribute.
+  // Expected: no error for missing `@differentiable` subset attribute.
   @differentiable(wrt: (self, x))
   func internalMethod3(_ x: Float) -> Float {
     x

--- a/test/AutoDiff/downstream/implicit_nonpublic_differentiable_attr_cross_file/Inputs/other_file.swift
+++ b/test/AutoDiff/downstream/implicit_nonpublic_differentiable_attr_cross_file/Inputs/other_file.swift
@@ -1,0 +1,49 @@
+protocol Protocol: Differentiable {
+  // expected-note @+2 {{protocol requires function 'internalMethod1' with type '(Float) -> Float'}}
+  @differentiable(wrt: (self, x))
+  func internalMethod1(_ x: Float) -> Float
+
+  // expected-note @+3 {{protocol requires function 'internalMethod2' with type '(Float) -> Float'}}
+  @differentiable(wrt: (self, x))
+  @differentiable(wrt: x)
+  func internalMethod2(_ x: Float) -> Float
+
+  @differentiable(wrt: (self, x))
+  @differentiable(wrt: x)
+  func internalMethod3(_ x: Float) -> Float
+}
+
+protocol Protocol2: Differentiable {
+  @differentiable(wrt: (self, x))
+  func internalMethod4(_ x: Float) -> Float
+}
+
+// Note:
+// - No `ConformingStruct: Protocol` conformance exists in this file, so this
+//   file should compile just file.
+// - A `ConformingStruct: Protocol` conformance in a different file should be
+//   diagnosed to prevent linker errors. Without a diagnostic, compilation of
+//   the other file creates external references to symbols for implicit
+//   `@differentiable` attributes, even though no such symbols exist.
+//   Context: https://github.com/apple/swift/pull/29771#issuecomment-585059721
+
+struct ConformingStruct: Differentiable {
+  // Expected: errors for missing `@differentiable` attribute.
+  // expected-note @+1 {{candidate is missing attribute '@differentiable'}}
+  func internalMethod1(_ x: Float) -> Float {
+    x
+  }
+
+  // Expected: errors for missing `@differentiable` superset attribute.
+  // expected-note @+2 {{candidate is missing attribute '@differentiable'}}
+  @differentiable(wrt: x)
+  func internalMethod2(_ x: Float) -> Float {
+    x
+  }
+
+  // Expected: no errors for missing `@differentiable` subset attribute.
+  @differentiable(wrt: (self, x))
+  func internalMethod3(_ x: Float) -> Float {
+    x
+  }
+}

--- a/test/AutoDiff/downstream/implicit_nonpublic_differentiable_attr_cross_file/main.swift
+++ b/test/AutoDiff/downstream/implicit_nonpublic_differentiable_attr_cross_file/main.swift
@@ -1,0 +1,35 @@
+// Test missing protocol requirement `@differentiable` attribute errors for
+// non-public protocol witnesses, when the protocol conformance is declared in a
+// separate file from witnesses.
+//
+// Implicit `@differentiable` attributes cannot be generated for protocol
+// witnesses when the conformance is declared from a separate file from the
+// witness. Otherwise, compilation of the file containing the conformance
+// creates external references to symbols for implicit `@differentiable`
+// attributes, even though no such symbols exist.
+//
+// Context: https://github.com/apple/swift/pull/29771#issuecomment-585059721
+
+// Note: `swiftc main.swift other_file.swift` runs three commands:
+// - `swiftc -frontend -primary-file main.swift other_file.swift -o ...`
+// - `swiftc -frontend main.swift -primary-file other_file.swift -o ...`
+// - `/usr/bin/ld ...`
+//
+// `%target-build-swift` performs `swiftc main.swift other_file.swift`, so it is expected to fail (hence `not`).
+// `swiftc -frontend -primary-file main.swift other_file.swift` should succeed, so no need for `-verify`.
+// `swiftc -frontend main.swift -primary-file other_file.swift` should fail, so `-verify` is needed.
+
+// RUN: %target-swift-frontend -c -verify -primary-file %s %S/Inputs/other_file.swift
+// RUN: %target-swift-frontend -c %s -primary-file %S/Inputs/other_file.swift
+// RUN: not %target-build-swift %s %S/Inputs/other_file.swift
+
+// Error: conformance is in different file than witnesses.
+// expected-error @+1 {{type 'ConformingStruct' does not conform to protocol 'Protocol'}}
+extension ConformingStruct: Protocol {}
+
+// No error: conformance is in same file as witnesses.
+extension ConformingStruct: Protocol2 {
+  func internalMethod4(_ x: Float) -> Float {
+    x
+  }
+}

--- a/test/AutoDiff/downstream/implicit_nonpublic_differentiable_attr_cross_file/main.swift
+++ b/test/AutoDiff/downstream/implicit_nonpublic_differentiable_attr_cross_file/main.swift
@@ -16,8 +16,8 @@
 // - `/usr/bin/ld ...`
 //
 // `%target-build-swift` performs `swiftc main.swift other_file.swift`, so it is expected to fail (hence `not`).
-// `swiftc -frontend -primary-file main.swift other_file.swift` should succeed, so no need for `-verify`.
-// `swiftc -frontend main.swift -primary-file other_file.swift` should fail, so `-verify` is needed.
+// `swiftc -frontend -primary-file main.swift other_file.swift` should fail, so `-verify` is needed.
+// `swiftc -frontend main.swift -primary-file other_file.swift` should succeed, so no need for `-verify`.
 
 // RUN: %target-swift-frontend -c -verify -primary-file %s %S/Inputs/other_file.swift
 // RUN: %target-swift-frontend -c %s -primary-file %S/Inputs/other_file.swift

--- a/test/AutoDiff/downstream/implicit_nonpublic_differentiable_attr_sil.swift
+++ b/test/AutoDiff/downstream/implicit_nonpublic_differentiable_attr_sil.swift
@@ -6,11 +6,6 @@
 // Specifically, test the diagnostic source locations for implicit attributes.
 
 protocol Protocol: Differentiable {
-  // Note: error below comes from the implicit `@differentiable` attribute on
-  // `PublicConformingStruct.internalMethod`. The source location of the
-  // implicit attribute is copied from the protocol requirement's attribute.
-
-  // expected-error @+1 {{function is not differentiable}}
   @differentiable(wrt: (self, x))
   func internalMethod(_ x: Float) -> Float
 }
@@ -20,6 +15,7 @@ struct ConformingStruct: Protocol {
   // - No error for missing `@differentiable` attribute on internal protocol witness.
   //   An implicit `@differentiable` attribute should be created.
   // - A non-differentiability error, because the method body is non-differentiable.
+  // expected-error @+2 {{function is not differentiable}}
   // expected-note @+1 {{when differentiating this function definition}}
   func internalMethod(_ x: Float) -> Float {
     // expected-note @+1 {{cannot differentiate through a non-differentiable result; do you want to use 'withoutDerivative(at:)'?}}

--- a/test/AutoDiff/downstream/implicit_nonpublic_differentiable_attr_sil.swift
+++ b/test/AutoDiff/downstream/implicit_nonpublic_differentiable_attr_sil.swift
@@ -6,6 +6,7 @@
 // Specifically, test the diagnostic source locations for implicit attributes.
 
 protocol Protocol: Differentiable {
+  // expected-note @+1 {{differentiability required by the corresponding protocol requirement here}}
   @differentiable(wrt: (self, x))
   func internalMethod(_ x: Float) -> Float
 }
@@ -15,8 +16,7 @@ struct ConformingStruct: Protocol {
   // - No error for missing `@differentiable` attribute on internal protocol witness.
   //   An implicit `@differentiable` attribute should be created.
   // - A non-differentiability error, because the method body is non-differentiable.
-  // expected-error @+2 {{function is not differentiable}}
-  // expected-note @+1 {{when differentiating this function definition}}
+  // expected-error @+1 {{function is not differentiable}}
   func internalMethod(_ x: Float) -> Float {
     // expected-note @+1 {{cannot differentiate through a non-differentiable result; do you want to use 'withoutDerivative(at:)'?}}
     return Float(Int(x))

--- a/test/AutoDiff/downstream/implicit_nonpublic_differentiable_attr_sil.swift
+++ b/test/AutoDiff/downstream/implicit_nonpublic_differentiable_attr_sil.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+// Test end-to-end differentiation involving implicit `@differentiable`
+// attributes for non-public protocol witnesses.
+//
+// Specifically, test the diagnostic source locations for implicit attributes.
+
+protocol Protocol: Differentiable {
+  // Note: error below comes from the implicit `@differentiable` attribute on
+  // `PublicConformingStruct.internalMethod`. The source location of the
+  // implicit attribute is copied from the protocol requirement's attribute.
+
+  // expected-error @+1 {{function is not differentiable}}
+  @differentiable(wrt: (self, x))
+  func internalMethod(_ x: Float) -> Float
+}
+
+struct ConformingStruct: Protocol {
+  // Expected:
+  // - No error for missing `@differentiable` attribute on internal protocol witness.
+  //   An implicit `@differentiable` attribute should be created.
+  // - A non-differentiability error, because the method body is non-differentiable.
+  // expected-note @+1 {{when differentiating this function definition}}
+  func internalMethod(_ x: Float) -> Float {
+    // expected-note @+1 {{cannot differentiate through a non-differentiable result; do you want to use 'withoutDerivative(at:)'?}}
+    return Float(Int(x))
+  }
+}

--- a/test/AutoDiff/downstream/implicit_nonpublic_differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/downstream/implicit_nonpublic_differentiable_attr_type_checking.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-frontend -print-ast -verify %s | %FileCheck %s
+
+// Test implicit `@differentiable` attributes for non-public protocol witnesses.
+
+protocol InternalProtocol: Differentiable {
+  // expected-note @+3 {{protocol requires function 'publicMethod' with type '(Float) -> Float'}}
+  @differentiable(wrt: self)
+  @differentiable(wrt: (self, x))
+  func publicMethod(_ x: Float) -> Float
+
+  @differentiable(wrt: self)
+  @differentiable(wrt: (self, x))
+  func internalMethod(_ x: Float) -> Float
+}
+
+// expected-error @+1 {{type 'PublicConformingStruct' does not conform to protocol 'InternalProtocol'}}
+public struct PublicConformingStruct: InternalProtocol {
+  // Expected: error for missing `@differentiable` attribute on public protocol witness.
+  // expected-note @+1 {{candidate is missing attribute '@differentiable'}}
+  public func publicMethod(_ x: Float) -> Float {
+    x
+  }
+
+  // Expected: no error for missing `@differentiable` attribute on internal protocol witness.
+  // Implicit `@differentiable` attributes should be created.
+  func internalMethod(_ x: Float) -> Float {
+    x
+  }
+}
+
+// CHECK-LABEL: public struct PublicConformingStruct : InternalProtocol {
+// CHECK:   public func publicMethod(_ x: Float) -> Float
+// CHECK:   @differentiable(wrt: (self, x))
+// CHECK:   @differentiable(wrt: self)
+// CHECK:   internal func internalMethod(_ x: Float) -> Float
+// CHECK: }

--- a/test/AutoDiff/downstream/protocol_requirement_autodiff_diags.swift
+++ b/test/AutoDiff/downstream/protocol_requirement_autodiff_diags.swift
@@ -2,17 +2,17 @@
 
 protocol P {}
 
-protocol HasRequirement {
+public protocol HasRequirement {
   @differentiable
   // expected-note @+1 {{protocol requires function 'requirement' with type '<T> (T, T) -> T'; do you want to add a stub?}}
   func requirement<T: Differentiable>(_ x: T, _ y: T) -> T
 }
 
 // expected-error @+1 {{type 'AttemptsToSatisfyRequirement' does not conform to protocol 'HasRequirement'}}
-struct AttemptsToSatisfyRequirement: HasRequirement {
+public struct AttemptsToSatisfyRequirement: HasRequirement {
   // This does not satisfy the requirement because the differentiable attribute is more
   // constrained than the requirement's differentiable attribute.
   @differentiable(where T: P)
   // expected-note @+1 {{candidate is missing attribute '@differentiable(wrt: (x, y))'}}
-  func requirement<T: Differentiable>(_ x: T, _ y: T) -> T { x }
+  public func requirement<T: Differentiable>(_ x: T, _ y: T) -> T { x }
 }


### PR DESCRIPTION
Previously, all witnesses of a `@differentiable` protocol requirement were
required to have the same attribute (or one with superset parameter indices).

However, this leads to many annotations on witnesses and is not ideal for
usability. `@differentiable` attributes are really only significant on
public witnesses, so that they are clearly `@differentiable` at a glance (in
source code, interface files, and API documentation), without looking through
protocol conformance hierarchies.

Now, only *public* witnesses of `@differentiable` protocol requirements are
required to have the same attribute (or one with superset parameter indices).
For less-visible witnesses, an implicit `@differentiable` attribute is created
with the same configuration as the requirement's.

Resolves TF-1117.

---

This usability improvement was discussed during the
[2020-01-17 Swift for TensorFlow open design review](https://docs.google.com/document/d/1Fm56p5rV1t2Euh6WLtBFKGqI43ozC3EIjReyLk-LCLU/edit#bookmark=id.rrfb0uhvuzry).
We agreed that it's a good idea!

Todo: upstream changes to `master`.

---

Example:
```swift
public protocol Layer: Differentiable {
  associatedtype Input: Differentiable
  associatedtype Output: Differentiable
  @differentiable(wrt: (self, input))
  func callAsFunction(_ input: Input) -> Output
}

// Internal conforming type.
struct DummyInternalLayer: Layer {
  func callAsFunction(_ input: Float) -> Float {
    return input
  }
}
```

Before (misleading diagnostic due to TF-1014):
```console
layer.swift:9:8: error: type 'DummyInternalLayer' does not conform to protocol 'Layer'
struct DummyInternalLayer: Layer {
       ^
layer.swift:2:18: note: protocol requires nested type 'Input'; do you want to add it?
  associatedtype Input: Differentiable
                 ^
layer.swift:3:18: note: protocol requires nested type 'Output'; do you want to add it?
  associatedtype Output: Differentiable
                 ^
```

After: no error.

An implicit `@differentiable` attribute is created for `DummyInternalLayer.callAsFunction`:
```console
$ swiftc -print-ast layer.swift
...

internal struct DummyInternalLayer : Layer {
  @differentiable(wrt: (self, input))
  internal func callAsFunction(_ input: Float) -> Float
  ...
}
```