### PR TITLE
[Driver] Disable one dependency file emission by default

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -964,7 +964,7 @@ Driver::buildCompilation(const ToolChain &TC,
 
     const bool OnlyOneDependencyFile =
         ArgList->hasFlag(options::OPT_enable_only_one_dependency_file,
-                         options::OPT_disable_only_one_dependency_file, true);
+                         options::OPT_disable_only_one_dependency_file, false);
 
     // relies on the new dependency graph
     // Get the default from the initializer in LangOptions.

--- a/test/Driver/advanced_output_file_map.swift
+++ b/test/Driver/advanced_output_file_map.swift
@@ -82,13 +82,15 @@
 // BINDINGS-ENA: # "x86_64-apple-macosx10.9" - "ld{{(.exe)?}}", inputs: ["./obj/advanced_output_file_map.o", "./obj/main.o", "./obj/lib.o", "./OutputFileMap.swiftmodule"], output: {image: "./advanced_output_file_map.out"}
 // BINDINGS-ENA: # "x86_64-apple-macosx10.9" - "dsymutil{{(\.exe)?}}", inputs: ["./advanced_output_file_map.out"], output: {dSYM: "./advanced_output_file_map.out.dSYM"}
 
-// Defaulting to: -enable-only-one-dependency-file
+// Defaulting to: -disable-only-one-dependency-file
 
-// RUN: %swiftc_driver -driver-print-output-file-map -target x86_64-apple-macosx10.9 -emit-executable -emit-module -serialize-diagnostics %/s %/S/Inputs/main.swift %/S/Inputs/lib.swift -g -o ./advanced_output_file_map.out -emit-module-path ./OutputFileMap.swiftmodule -module-name OutputFileMap -output-file-map %t/ofm.json 2>&1 | %FileCheck %/s -check-prefix=DUMPOFM-ENA
+// RUN: %swiftc_driver -driver-print-output-file-map -target x86_64-apple-macosx10.9 -emit-executable -emit-module -serialize-diagnostics %/s %/S/Inputs/main.swift %/S/Inputs/lib.swift -g -o ./advanced_output_file_map.out -emit-module-path ./OutputFileMap.swiftmodule -module-name OutputFileMap -output-file-map %t/ofm.json 2>&1 | %FileCheck %/s -check-prefix=DUMPOFM-DIS
 
 
 // RUN: %empty-directory(%t/d)
-// RUN: %swiftc_driver -driver-print-bindings -target x86_64-apple-macosx10.9 -emit-executable -emit-module -serialize-diagnostics -emit-dependencies %/s %/S/Inputs/main.swift %/S/Inputs/lib.swift -g -o ./advanced_output_file_map.out -emit-module-path ./OutputFileMap.swiftmodule -module-name OutputFileMap -output-file-map %t/ofm.json 2>&1 | %FileCheck %/s -check-prefix=BINDINGS-ENA
+// RUN: %swiftc_driver -driver-print-bindings -target x86_64-apple-macosx10.9 -emit-executable -emit-module -serialize-diagnostics -emit-dependencies %/s %/S/Inputs/main.swift %/S/Inputs/lib.swift -g -o ./advanced_output_file_map.out -emit-module-path ./OutputFileMap.swiftmodule -module-name OutputFileMap -output-file-map %t/ofm.json 2>&1 | %FileCheck %/s -check-prefix=BINDINGS-DIS
+
+// Should be no dummy files:
 // RUN: test ! -e %t/d/advanced_output_file_map.d
-// RUN: test -e %t/d/main.d -a ! -s %t/d/main.d
-// RUN: test -e %t/d/lib.d  -a ! -s %t/d/lib.d
+// RUN: test ! -e %t/d/main.d -a ! -s %t/d/main.d
+// RUN: test ! -e %t/d/lib.d  -a ! -s %t/d/lib.d


### PR DESCRIPTION
This reverts commit b1f6a8941c22ca8aa3e0b713f056a72b0dd70e44. This
change is causing some instability with incremental builds, so we're
backing it out. Fixes rdar://problem/59016969.