### PR TITLE
[5.2][IDE/SyntaxModel] For syntactic structure, make sure to not visit the captured list variables twice

### DIFF
--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -666,6 +666,19 @@ std::pair<bool, Expr *> ModelASTWalker::walkToExprPre(Expr *E) {
                           Closure->getExplicitResultTypeLoc().getSourceRange());
 
     pushStructureNode(SN, Closure);
+
+  } else if (auto *CLE = dyn_cast<CaptureListExpr>(E)) {
+    // The ASTWalker visits captured variables twice, from a `CaptureListEntry` they are visited
+    // from the `VarDecl` and the `PatternBindingDecl` entries.
+    // We take over visitation here to avoid walking the `PatternBindingDecl` ones.
+    for (auto c : CLE->getCaptureList()) {
+      if (auto *VD = c.Var)
+        VD->walk(*this);
+    }
+    if (auto *CE = CLE->getClosureBody())
+      CE->walk(*this);
+    return { false, walkToExprPost(E) };
+
   } else if (auto SE = dyn_cast<SequenceExpr>(E)) {
     // In SequenceExpr, explicit cast expressions (e.g. 'as', 'is') appear
     // twice. Skip pointers we've already seen.

--- a/test/IDE/structure.swift
+++ b/test/IDE/structure.swift
@@ -330,3 +330,5 @@ thirdCall("""
 fourthCall(a: @escaping () -> Int)
 // CHECK: <call><name>fourthCall</name>(<arg><name>a</name>: @escaping () -> Int</arg>)</call>
 
+// CHECK: <call><name>foo</name> <closure>{ [unowned <lvar><name>self</name></lvar>, <lvar><name>x</name></lvar>] in _ }</closure></call>
+foo { [unowned self, x] in _ }


### PR DESCRIPTION
**Explanation**: For SourceKit's syntactic structure request, when reporting local variables in a closure capture list we were reporting the `self` variable twice, this is a regression from swift-5.1

**Scope of issue**: This impacts open source tools that are using SourceKit and is a regression relative to the previous release.

**Origination**: Likely due to AST construction changes

**Risk**: Low. This only affects SourceKit's syntactic structure request, while visiting capture lists.

**Testing**: Added regression test

**Reviewers**: Nathan Hawes

Resolves rdar://59302427
