### PR TITLE
NFC for SR-12085 Clean up TypeCheckType so it never returns Type().

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2688,7 +2688,7 @@ bool ContextualFailure::trySequenceSubsequenceFixIts(
   auto String = TypeChecker::getStringType(getASTContext());
   auto Substring = TypeChecker::getSubstringType(getASTContext());
 
-  if (!String || !Substring)
+  if (String->hasError() || Substring->hasError())
     return false;
 
   // Substring -> String conversion

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1768,7 +1768,7 @@ namespace {
                                            TVO_CanBindToNoEscape);
 
       Type optTy = getOptionalType(expr->getSubExpr()->getLoc(), valueTy);
-      if (!optTy)
+      if (optTy->hasError())
         return Type();
 
       // Prior to Swift 5, 'try?' always adds an additional layer of optionality,
@@ -2828,7 +2828,7 @@ namespace {
       // Try to build the appropriate type for a variadic argument list of
       // the fresh element type.  If that failed, just bail out.
       auto array = TypeChecker::getArraySliceType(expr->getLoc(), element);
-      if (!array) return element;
+      if (array->hasError()) return element;
 
       // Require the operand to be convertible to the array type.
       CS.addConstraint(ConstraintKind::Conversion,
@@ -3200,9 +3200,9 @@ namespace {
     /// worth QoI efforts.
     Type getOptionalType(SourceLoc optLoc, Type valueTy) {
       auto optTy = TypeChecker::getOptionalType(optLoc, valueTy);
-      if (!optTy ||
+      if (optTy->hasError() ||
           TypeChecker::requireOptionalIntrinsics(CS.getASTContext(), optLoc))
-        return Type();
+        return ErrorType::get(CS.getASTContext());
 
       return optTy;
     }
@@ -3233,7 +3233,7 @@ namespace {
                                            TVO_CanBindToNoEscape);
 
       Type optTy = getOptionalType(expr->getSubExpr()->getLoc(), valueTy);
-      if (!optTy)
+      if (optTy->hasError())
         return Type();
 
       CS.addConstraint(ConstraintKind::Conversion,

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2122,9 +2122,9 @@ static Type validateParameterType(ParamDecl *decl) {
 
   if (decl->isVariadic()) {
     Ty = TypeChecker::getArraySliceType(decl->getStartLoc(), Ty);
-    if (Ty.isNull()) {
+    if (Ty->hasError()) {
       decl->setInvalid();
-      return ErrorType::get(ctx);
+      return Ty;
     }
 
     // Disallow variadic parameters in enum elements.


### PR DESCRIPTION
Added ErrorType::get(Context) to TypeCheckType.cpp and clients.
Replaced assertions checking for null pointers with type->hasError() checks.
Note that getDynamicBridgedThroughObjCClass can still return null pointers so
the assert checks are still there for callers.

<!-- What's in this pull request? -->
No functional change. This cleans up some instances of return Type() in TypeCheckType.cpp. There are a lot of other instances of return Type() but this gets the 15 of them in TypeCheckType.cpp plus a few others in direct clients to the functions in TypeCheckType.cpp that returned Type(). @CodaFi helped me with this. 

This is my first one so I'm not sure I'm doing it right. Running all the validation tests gives me:

    Expected Passes    : 6490
    Expected Failures  : 5
    Unsupported Tests  : 100
    Unexpected Failures: 205

both before and after this change when I build with ninja. A lot of the validation test failures are in stdlib--I am not sure why.

The two validation test failures in Sema are:

    Swift(macosx-x86_64) :: Sema/type_checker_perf/fast/rdar42672946.swift
    Swift(macosx-x86_64) :: Sema/type_checker_perf/slow/rdar23327871.swift.gyb
   
I checked out swift-DEVELOPMENT-SNAPSHOT-2020-02-08-a and then put the commit directly on top of that. I hope that is OK--I tried a couple of things but that seemed to build clean. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-12085.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
