### PR TITLE
Re-enable running indexstoreDB tests part of Swift pull request preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -584,9 +584,6 @@ swift-primary-variant-arch=x86_64
 # Don't build the benchmarks
 skip-build-benchmarks
 
-# FIX: rdar://problem/59327164
-skip-test-indexstore-db
-
 [preset: buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx,flto]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx
 build-subdir=buildbot_incremental
@@ -1475,8 +1472,6 @@ sil-verify-all
 skip-test-ios-host
 skip-test-watchos-host
 
-# FIX: rdar://problem/59327164
-skip-test-indexstore-db
 
 #===------------------------------------------------------------------------===#
 # Test watchOS on OS X builder


### PR DESCRIPTION
This reverts commit df31c7265b80ec1abfd34171f2c007988f5300cf.

Underlying issue should be fixed by https://github.com/apple/llvm-project/pull/767, which has now merged into swift/master.

rdar://59327164