### PR TITLE
Allow initialized let/var declarations in function builders.

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -235,6 +235,143 @@ protected:
     return nullptr;                                        \
   }
 
+  /// Provide a type for each variable that occurs within the given pattern,
+  /// by matching the pattern structurally with its already-computed pattern
+  /// type. The variables will either get a concrete type (when present in
+  /// the pattern type) or a fresh type variable bound to that part of the
+  /// pattern via a one-way constraint.
+  void bindVariablesInPattern(Pattern *pattern, Type patternType,
+                              ConstraintLocator *locator) {
+    switch (pattern->getKind()) {
+    case PatternKind::Paren: {
+      // Parentheses don't affect the type, but unwrap a paren type if we have
+      // one.
+      Type subPatternType;
+      if (auto parenType = dyn_cast<ParenType>(patternType.getPointer()))
+        subPatternType = parenType->getUnderlyingType();
+      else
+        subPatternType = patternType;
+      return bindVariablesInPattern(
+          cast<ParenPattern>(pattern)->getSubPattern(),
+          subPatternType, locator);
+    }
+
+    case PatternKind::Var:
+      // Var doesn't affect the type.
+      return bindVariablesInPattern(cast<VarPattern>(pattern)->getSubPattern(),
+                                    patternType, locator);
+
+    case PatternKind::Any:
+      // Nothing to bind.
+      return;
+
+    case PatternKind::Named: {
+      auto var = cast<NamedPattern>(pattern)->getDecl();
+
+      /// Create a fresh type variable to describe the type of the
+      Type varType = cs->createTypeVariable(locator, TVO_CanBindToNoEscape);
+
+      auto ROK = ReferenceOwnership::Strong;
+      if (auto *OA = var->getAttrs().getAttribute<ReferenceOwnershipAttr>())
+        ROK = OA->get();
+      switch (optionalityOf(ROK)) {
+      case ReferenceOwnershipOptionality::Required:
+        // FIXME: Can we assert this rather than just checking it.
+        if (auto optPatternType =
+                dyn_cast<OptionalType>(patternType.getPointer())) {
+          // Add a one-way constraint from the type variable to the wrapped
+          // type of the optional.
+          cs->addConstraint(
+            ConstraintKind::OneWayEqual, varType, optPatternType->getBaseType(),
+                            locator);
+
+          // Make the variable type optional.
+          varType = TypeChecker::getOptionalType(var->getLoc(), varType);
+          break;
+        }
+
+        // Fall through to treat this normally.
+        LLVM_FALLTHROUGH;
+
+      case ReferenceOwnershipOptionality::Allowed:
+      case ReferenceOwnershipOptionality::Disallowed:
+        // Add the one-way constraint from the variable type to the pattern
+        // type.
+        cs->addConstraint(ConstraintKind::OneWayEqual, varType, patternType,
+                          locator);
+        break;
+      }
+
+      // Bind the type of the variable.
+      cs->setType(var, varType);
+      return;
+    }
+
+    case PatternKind::Typed: {
+      // Ignore the type itself; it's part of patternType now.
+      return bindVariablesInPattern(
+          cast<TypedPattern>(pattern)->getSubPattern(),
+          patternType, locator);
+    }
+
+    case PatternKind::Tuple: {
+      auto tuplePat = cast<TuplePattern>(pattern);
+      auto tupleType = patternType->castTo<TupleType>();
+      for (unsigned i = 0, e = tuplePat->getNumElements(); i != e; ++i) {
+        bindVariablesInPattern(tuplePat->getElement(i).getPattern(),
+                               tupleType->getElementType(i), locator);
+      }
+      return;
+    }
+
+    // FIXME: Refutable patterns will generate additional constraints.
+#define PATTERN(Id, Parent)
+#define REFUTABLE_PATTERN(Id, Parent) case PatternKind::Id:
+#include "swift/AST/PatternNodes.def"
+      llvm_unreachable("Refutable patterns are not supported here");
+    }
+
+    llvm_unreachable("Unhandled pattern kind");
+  }
+
+  void visitPatternBindingDecl(PatternBindingDecl *patternBinding) {
+    // If any of the entries lacks an initializer, don't handle this node.
+    if (!llvm::all_of(range(patternBinding->getNumPatternEntries()),
+                      [&](unsigned index) {
+            return patternBinding->isExplicitlyInitialized(index);
+        })) {
+      if (!unhandledNode)
+        unhandledNode = patternBinding;
+      return;
+    }
+
+    // If we aren't generating constraints, there's nothing to do.
+    if (!cs)
+      return;
+
+    /// Generate constraints for each pattern binding entry
+    for (unsigned index : range(patternBinding->getNumPatternEntries())) {
+      // Type check the pattern.
+      auto pattern = patternBinding->getPattern(index);
+      auto contextualPattern = ContextualPattern::forRawPattern(pattern, dc);
+      Type patternType = TypeChecker::typeCheckPattern(contextualPattern);
+
+      // Generate constraints for the initialization.
+      auto target = SolutionApplicationTarget::forInitialization(
+          patternBinding->getInit(index), dc, patternType, pattern);
+      if (cs->generateConstraints(target, FreeTypeVariableBinding::Disallow))
+        continue;
+
+      // Keep track of this binding entry.
+      applied.patternBindingEntries.insert({{patternBinding, index}, target});
+
+      // Bind the variables that occur in the pattern to the corresponding
+      // type entry for the pattern itself.
+      bindVariablesInPattern(pattern, cs->getType(pattern),
+                             cs->getConstraintLocator(target.getAsExpr()));
+    }
+  }
+
   VarDecl *visitBraceStmt(BraceStmt *braceStmt) {
     SmallVector<Expr *, 4> expressions;
     auto addChild = [&](VarDecl *childVar) {
@@ -269,6 +406,18 @@ protected:
         if (auto poundDiag = dyn_cast<PoundDiagnosticDecl>(decl)) {
           continue;
         }
+
+        // Pattern bindings are okay so long as all of the entries are
+        // initialized.
+        if (auto patternBinding = dyn_cast<PatternBindingDecl>(decl)) {
+          visitPatternBindingDecl(patternBinding);
+          continue;
+        }
+
+        // Ignore variable declarations, because they're always handled within
+        // their enclosing pattern bindings.
+        if (isa<VarDecl>(decl))
+          continue;
 
         if (!unhandledNode)
           unhandledNode = decl;
@@ -744,6 +893,26 @@ private:
     elements.push_back(pbd);
   }
 
+  /// Produce a final type-checked pattern binding.
+  void finishPatternBindingDecl(PatternBindingDecl *patternBinding) {
+    for (unsigned index : range(patternBinding->getNumPatternEntries())) {
+      // Find the solution application target for this.
+      auto knownTarget =
+          builderTransform.patternBindingEntries.find({patternBinding, index});
+      assert(knownTarget != builderTransform.patternBindingEntries.end());
+
+      // Rewrite the target.
+      auto resultTarget = rewriteTarget(knownTarget->second);
+      if (!resultTarget)
+        continue;
+
+      patternBinding->setPattern(
+          index, resultTarget->getInitializationPattern(),
+          resultTarget->getDeclContext());
+      patternBinding->setInit(index, resultTarget->getAsExpr());
+    }
+  }
+
 public:
   BuilderClosureRewriter(
       const Solution &solution,
@@ -811,12 +980,29 @@ public:
       auto decl = node.get<Decl *>();
 
       // Skip #if declarations.
-      if (isa<IfConfigDecl>(decl))
+      if (isa<IfConfigDecl>(decl)) {
+        newElements.push_back(decl);
         continue;
+      }
 
       // Diagnose #warning / #error during application.
       if (auto poundDiag = dyn_cast<PoundDiagnosticDecl>(decl)) {
         TypeChecker::typeCheckDecl(poundDiag);
+        newElements.push_back(decl);
+        continue;
+      }
+
+      // Skip variable declarations; they're always part of a pattern
+      // binding.
+      if (isa<VarDecl>(decl)) {
+        newElements.push_back(decl);
+        continue;
+      }
+
+      // Handle pattern bindings.
+      if (auto patternBinding = dyn_cast<PatternBindingDecl>(decl)) {
+        finishPatternBindingDecl(patternBinding);
+        newElements.push_back(decl);
         continue;
       }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -290,7 +290,7 @@ namespace {
   public:
     ConstraintSystem &cs;
     DeclContext *dc;
-    const Solution &solution;
+    Solution &solution;
     bool SuppressDiagnostics;
 
     /// Coerce the given tuple to another tuple type.
@@ -1792,7 +1792,7 @@ namespace {
     }
     
   public:
-    ExprRewriter(ConstraintSystem &cs, const Solution &solution,
+    ExprRewriter(ConstraintSystem &cs, Solution &solution,
                  bool suppressDiagnostics)
         : cs(cs), dc(cs.DC), solution(solution),
           SuppressDiagnostics(suppressDiagnostics) {}
@@ -7142,6 +7142,10 @@ namespace {
 
     /// Ignore declarations.
     bool walkToDeclPre(Decl *decl) override { return false; }
+
+    /// Rewrite the target, producing a new target.
+    Optional<SolutionApplicationTarget>
+    rewriteTarget(SolutionApplicationTarget target);
   };
 } // end anonymous namespace
 
@@ -7305,6 +7309,111 @@ static Optional<SolutionApplicationTarget> applySolutionToInitialization(
   return resultTarget;
 }
 
+Optional<SolutionApplicationTarget>
+ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
+  auto &solution = Rewriter.solution;
+
+  // Apply the solution to the target.
+  SolutionApplicationTarget result = target;
+  if (auto expr = target.getAsExpr()) {
+    Expr *rewrittenExpr = expr->walk(*this);
+    if (!rewrittenExpr)
+      return None;
+
+    /// Handle application for initializations.
+    if (target.getExprContextualTypePurpose() == CTP_Initialization) {
+      auto initResultTarget = applySolutionToInitialization(
+          solution, target, rewrittenExpr);
+      if (!initResultTarget)
+        return None;
+
+      result = *initResultTarget;
+    } else {
+      result.setExpr(rewrittenExpr);
+    }
+  } else {
+    auto fn = *target.getAsFunction();
+
+    // Dig out the function builder transformation we applied.
+    auto transform = Rewriter.getAppliedBuilderTransform(fn);
+    assert(transform);
+
+    auto newBody = applyFunctionBuilderTransform(
+        solution, *transform, fn.getBody(), fn.getAsDeclContext(),
+        [&](Expr *expr) {
+          Expr *result = expr->walk(*this);
+          if (result)
+            solution.setExprTypes(result);
+          return result;
+        },
+        [&](Expr *expr, Type toType, ConstraintLocator *locator) {
+          return Rewriter.coerceToType(expr, toType, locator);
+        });
+
+    if (!newBody)
+      return None;
+
+    result.setFunctionBody(newBody);
+  }
+
+  // Follow-up tasks.
+  auto &cs = solution.getConstraintSystem();
+  if (auto resultExpr = result.getAsExpr()) {
+    Expr *expr = target.getAsExpr();
+    assert(expr && "Can't have expression result without expression target");
+
+    // We are supposed to use contextual type only if it is present and
+    // this expression doesn't represent the implicit return of the single
+    // expression function which got deduced to be `Never`.
+    Type convertType = target.getExprConversionType();
+    auto shouldCoerceToContextualType = [&]() {
+      return convertType &&
+          !target.isOptionalSomePatternInit() &&
+          !(solution.getType(resultExpr)->isUninhabited() &&
+            cs.getContextualTypePurpose(target.getAsExpr())
+              == CTP_ReturnSingleExpr);
+    };
+
+    // If we're supposed to convert the expression to some particular type,
+    // do so now.
+    if (shouldCoerceToContextualType()) {
+      resultExpr = Rewriter.coerceToType(resultExpr,
+                                         solution.simplifyType(convertType),
+                                         cs.getConstraintLocator(expr));
+    } else if (cs.getType(resultExpr)->hasLValueType() &&
+               !target.isDiscardedExpr()) {
+      // We referenced an lvalue. Load it.
+      resultExpr = Rewriter.coerceToType(
+          resultExpr,
+          cs.getType(resultExpr)->getRValueType(),
+          cs.getConstraintLocator(expr));
+    }
+
+    if (!resultExpr)
+      return None;
+
+    // For an @autoclosure default parameter type, add the autoclosure
+    // conversion.
+    if (FunctionType *autoclosureParamType =
+            target.getAsAutoclosureParamType()) {
+      resultExpr = cs.buildAutoClosureExpr(resultExpr, autoclosureParamType);
+    }
+
+    solution.setExprTypes(resultExpr);
+    result.setExpr(resultExpr);
+
+    auto &ctx = cs.getASTContext();
+    if (ctx.TypeCheckerOpts.DebugConstraintSolver) {
+      auto &log = ctx.TypeCheckerDebug->getStream();
+      log << "---Type-checked expression---\n";
+      resultExpr->dump(log);
+      log << "\n";
+    }
+  }
+
+  return result;
+}
+
 /// Apply a given solution to the expression, producing a fully
 /// type-checked expression.
 Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
@@ -7335,49 +7444,9 @@ Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
 
   ExprRewriter rewriter(*this, solution, shouldSuppressDiagnostics());
   ExprWalker walker(rewriter);
-
-  // Apply the solution to the target.
-  SolutionApplicationTarget result = target;
-  if (auto expr = target.getAsExpr()) {
-    Expr *rewrittenExpr = expr->walk(walker);
-    if (!rewrittenExpr)
-      return None;
-
-    /// Handle application for initializations.
-    if (target.getExprContextualTypePurpose() == CTP_Initialization) {
-      auto initResultTarget = applySolutionToInitialization(
-          solution, target, rewrittenExpr);
-      if (!initResultTarget)
-        return None;
-
-      result = *initResultTarget;
-    } else {
-      result.setExpr(rewrittenExpr);
-    }
-  } else {
-    auto fn = *target.getAsFunction();
-
-    // Dig out the function builder transformation we applied.
-    auto transform = rewriter.getAppliedBuilderTransform(fn);
-    assert(transform);
-
-    auto newBody = applyFunctionBuilderTransform(
-        solution, *transform, fn.getBody(), fn.getAsDeclContext(),
-        [&](Expr *expr) {
-          Expr *result = expr->walk(walker);
-          if (result)
-            solution.setExprTypes(result);
-          return result;
-        },
-        [&](Expr *expr, Type toType, ConstraintLocator *locator) {
-          return rewriter.coerceToType(expr, toType, locator);
-        });
-
-    if (!newBody)
-      return None;
-
-    result.setFunctionBody(newBody);
-  }
+  auto resultTarget = walker.rewriteTarget(target);
+  if (!resultTarget)
+    return None;
 
   // If we're re-typechecking an expression for diagnostics, don't
   // visit closures that have non-single expression bodies.
@@ -7399,65 +7468,14 @@ Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
       return None;
   }
 
-  if (auto resultExpr = result.getAsExpr()) {
-    Expr *expr = target.getAsExpr();
-    assert(expr && "Can't have expression result without expression target");
-
-    // We are supposed to use contextual type only if it is present and
-    // this expression doesn't represent the implicit return of the single
-    // expression function which got deduced to be `Never`.
-    Type convertType = target.getExprConversionType();
-    auto shouldCoerceToContextualType = [&]() {
-      return convertType &&
-          !target.isOptionalSomePatternInit() &&
-          !(getType(resultExpr)->isUninhabited() &&
-            getContextualTypePurpose(target.getAsExpr())
-              == CTP_ReturnSingleExpr);
-    };
-
-    // If we're supposed to convert the expression to some particular type,
-    // do so now.
-    if (shouldCoerceToContextualType()) {
-      resultExpr = rewriter.coerceToType(resultExpr,
-                                         simplifyType(convertType),
-                                         getConstraintLocator(expr));
-    } else if (getType(resultExpr)->hasLValueType() &&
-               !target.isDiscardedExpr()) {
-      // We referenced an lvalue. Load it.
-      resultExpr = rewriter.coerceToType(resultExpr,
-                                         getType(resultExpr)->getRValueType(),
-                                         getConstraintLocator(expr));
-    }
-
-    if (!resultExpr)
-      return None;
-
-    // For an @autoclosure default parameter type, add the autoclosure
-    // conversion.
-    if (FunctionType *autoclosureParamType =
-            target.getAsAutoclosureParamType()) {
-      resultExpr = buildAutoClosureExpr(resultExpr, autoclosureParamType);
-    }
-
-    solution.setExprTypes(resultExpr);
-    result.setExpr(resultExpr);
-
-    if (Context.TypeCheckerOpts.DebugConstraintSolver) {
-      auto &log = Context.TypeCheckerDebug->getStream();
-      log << "---Type-checked expression---\n";
-      resultExpr->dump(log);
-      log << "\n";
-    }
-  }
-
   rewriter.finalize();
 
-  return result;
+  return resultTarget;
 }
 
 Expr *Solution::coerceToType(Expr *expr, Type toType,
                              ConstraintLocator *locator,
-                             Optional<Pattern*> typeFromPattern) const {
+                             Optional<Pattern*> typeFromPattern) {
   auto &cs = getConstraintSystem();
   ExprRewriter rewriter(cs, *this, /*suppressDiagnostics=*/false);
   Expr *result = rewriter.coerceToType(expr, toType, locator, typeFromPattern);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -5067,10 +5067,8 @@ bool isSIMDOperator(ValueDecl *value);
 /// \param applied The applied builder transform.
 /// \param body The body to transform
 /// \param dc The context in which the transform occurs.
-/// \param rewriteExpr Rewrites expressions that show up in the transform
-/// to their final, type-checked versions.
-/// \param coerceToType Coerce the given expression to the specified type,
-/// which may introduce implicit conversions.
+/// \param rewriteTarget Rewrites a solution application target to its final,
+/// type-checked version.
 ///
 /// \returns the transformed body
 BraceStmt *applyFunctionBuilderTransform(
@@ -5078,9 +5076,10 @@ BraceStmt *applyFunctionBuilderTransform(
     constraints::AppliedBuilderTransform applied,
     BraceStmt *body,
     DeclContext *dc,
-    std::function<Expr *(Expr *)> rewriteExpr,
-    std::function<Expr *(Expr *, Type, constraints::ConstraintLocator *)>
-      coerceToType);
+    std::function<
+        Optional<constraints::SolutionApplicationTarget> (
+          constraints::SolutionApplicationTarget)>
+            rewriteTarget);
 
 } // end namespace swift
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -886,7 +886,7 @@ public:
   /// \returns the coerced expression, which will have type \c ToType.
   Expr *coerceToType(Expr *expr, Type toType,
                      ConstraintLocator *locator,
-                     Optional<Pattern*> typeFromPattern = None) const;
+                     Optional<Pattern*> typeFromPattern = None);
 
   /// Compute the set of substitutions for a generic signature opened at the
   /// given locator.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -697,6 +697,13 @@ struct AppliedBuilderTransform {
 
   /// The return expression, capturing the last value to be emitted.
   Expr *returnExpr = nullptr;
+
+  using PatternEntry = std::pair<const PatternBindingDecl *, unsigned>;
+
+  /// Mapping from specific pattern binding entries to the solution application
+  /// targets capturing their initialization.
+  llvm::DenseMap<PatternEntry, SolutionApplicationTarget>
+      patternBindingEntries;
 };
 
 /// Describes the fixed score of a solution to the constraint system.

--- a/test/Constraints/function_builder.swift
+++ b/test/Constraints/function_builder.swift
@@ -476,3 +476,18 @@ func testIfConditions(cond: Bool, c1: Bool, i1: Int, i2: Int) {
 testIfConditions(cond: true, c1: true, i1: 1, i2: 1)
 // CHECK: testIfConditions
 // CHECK-SAME: hello
+
+// Use a "let" declaration within a function builder.
+tuplify(true) { c in
+  "testLetDeclarations"
+  let (a, b) = (c, c && true)
+  if a == b {
+    "hello"
+    b
+  }
+  a
+}
+// CHECK: testLetDeclarations"
+// CHECK-SAME: hello
+// CHECK-SAME: true
+

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -83,7 +83,8 @@ func testDiags() {
   // Declarations
   tuplify(true) { _ in
     17
-    let x = 17 // expected-error{{closure containing a declaration cannot be used with function builder 'TupleBuilder'}}
+    let x = 17
+    let y: Int // expected-error{{closure containing a declaration cannot be used with function builder 'TupleBuilder'}}
     x + 25
   }
 


### PR DESCRIPTION
Introduce support for initialized let/var declarations within function
builder closures, e.g.,

    let (a, b) = c()

We generate constraints for the declarations as elsewhere, but the types of
the declared variables (a and b in this case) are bound to the type of the
pattern by one-way constraints, to describe the flow of type information
through the closure.

We generate constraints for the declarations as elsewhere, but the types of
the declared variables (a and b in this case) are bound to the type of the
pattern by one-way constraints, to describe the flow of type information
through the closure.

Implements rdar://problem/57330696.