### PR TITLE
[android][aarch64] XFAIL IRGen/pic.swift test.

### DIFF
--- a/test/IRGen/pic.swift
+++ b/test/IRGen/pic.swift
@@ -1,6 +1,9 @@
 // <rdar://problem/15358345> Check that we always use PIC relocations on all
 // platforms.
 
+// SR-12194
+// XFAIL: OS=linux-android, CPU=aarch64
+
 // RUN: %target-swift-frontend %s -module-name main -S -o - | %FileCheck -check-prefix=%target-cpu -check-prefix=%target-cpu-%target-sdk-name %s
 
 var global: Int = 0


### PR DESCRIPTION
The codegen for Android AArch64 differs in order to the expected one
(and the one that seems to happen in Linux AArch64). The SIL and IR are
the same, but the final codegen is different.

More details in https://bugs.swift.org/browse/SR-12194.

This started happening with the master rebranch of February 10th 2020. I tried to look around, but I don't have a fix, so xfailing the test seems like the next best thing.
