### PR TITLE
[CodeCompletion] Enable fast-completion at the top of implicit getter

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6417,6 +6417,10 @@ public:
     llvm_unreachable("bad accessor kind");
   }
 
+  bool isImplicitGetter() const {
+    return isGetter() && getAccessorKeywordLoc().isInvalid();
+  }
+
   void setIsTransparent(bool transparent) {
     Bits.AccessorDecl.IsTransparent = transparent;
     Bits.AccessorDecl.IsTransparentComputed = 1;

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1122,6 +1122,8 @@ public:
                                        ParseDeclOptions Flags,
                                        DeclAttributes &Attributes,
                                        bool HasFuncKeyword = true);
+  ParserResult<BraceStmt>
+  parseAbstractFunctionBodyImpl(AbstractFunctionDecl *AFD);
   void parseAbstractFunctionBody(AbstractFunctionDecl *AFD);
   BraceStmt *parseAbstractFunctionBodyDelayed(AbstractFunctionDecl *AFD);
   ParserResult<ProtocolDecl> parseDeclProtocol(ParseDeclOptions Flags,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -520,7 +520,7 @@ SourceRange Decl::getSourceRangeIncludingAttrs() const {
   // e.g. 'override'.
   if (auto *AD = dyn_cast<AccessorDecl>(this)) {
     // If this is implicit getter, accessor range should not include attributes.
-    if (!AD->getAccessorKeywordLoc().isValid())
+    if (AD->isImplicitGetter())
       return Range;
 
     // Otherwise, include attributes directly attached to the accessor.
@@ -5937,7 +5937,7 @@ void VarDecl::emitLetToVarNoteIfSimple(DeclContext *UseDC) const {
                  ->hasReferenceSemantics()) {
       // Do not suggest the fix-it in implicit getters
       if (auto AD = dyn_cast<AccessorDecl>(FD)) {
-        if (AD->isGetter() && !AD->getAccessorKeywordLoc().isValid())
+        if (AD->isImplicitGetter())
           return;
       }
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -197,16 +197,7 @@ void Parser::performCodeCompletionSecondPassImpl(
 
   case CodeCompletionDelayedDeclKind::FunctionBody: {
     auto *AFD = cast<AbstractFunctionDecl>(DC);
-
-    if (auto *P = AFD->getImplicitSelfDecl())
-      addToScope(P);
-    addParametersToScope(AFD->getParameters());
-
-    ParseFunctionBody CC(*this, AFD);
-    setLocalDiscriminatorToParamList(AFD->getParameters());
-
-    auto result = parseBraceItemList(diag::func_decl_without_brace);
-    AFD->setBody(result.getPtrOrNull());
+    AFD->setBodyParsed(parseAbstractFunctionBodyImpl(AFD).getPtrOrNull());
     break;
   }
   }

--- a/test/IDE/complete_single_expression_return.swift
+++ b/test/IDE/complete_single_expression_return.swift
@@ -555,8 +555,8 @@ struct TestSingleExprSubscriptGlobal {
   }
 
 // TestSingleExprSubscriptGlobal: Begin completions
-// TestSingleExprSubscriptGlobal-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
-// TestSingleExprSubscriptGlobal-DAG: Decl[InstanceMethod]/CurrNominal: int()[#Int#];
+// TestSingleExprSubscriptGlobal-DAG: Decl[InstanceMethod]/CurrNominal: str()[#String#];
+// TestSingleExprSubscriptGlobal-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
 // TestSingleExprSubscriptGlobal-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
 // TestSingleExprSubscriptGlobal: End completions
 }

--- a/test/SourceKit/CodeComplete/complete_sequence_accessor.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_accessor.swift
@@ -47,7 +47,10 @@ enum S {
 // RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=27:15 %s -- %s == \
 // RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=30:9 %s -- %s == \
 // RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=33:15 %s -- %s == \
-// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=34:15 %s -- %s > %t.response
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=34:15 %s -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=12:1 %s -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=23:1 %s -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=16:1 %s -- %s > %t.response
 // RUN: %FileCheck --check-prefix=RESULT  %s < %t.response
 // RUN: %FileCheck --check-prefix=TRACE  %s < %t.response
 
@@ -114,6 +117,30 @@ enum S {
 // RESULT-DAG: key.name: "a"
 // RESULT-DAG: key.name: "b"
 // RESULT: ]
+// accessor top (global var)
+// RESULT-LABEL: key.results: [
+// RESULT-DAG: key.description: "get"
+// RESULT-DAG: key.description: "set"
+// RESULT-DAG: key.description: "willSet"
+// RESULT-DAG: key.description: "didSet"
+// RESULT-DAG: key.description: "Foo"
+// RESULT: ]
+// accessor top (property)
+// RESULT-LABEL: key.results: [
+// RESULT-DAG: key.description: "get"
+// RESULT-DAG: key.description: "set"
+// RESULT-DAG: key.description: "willSet"
+// RESULT-DAG: key.description: "didSet"
+// RESULT-DAG: key.description: "Foo"
+// RESULT: ]
+// accessor second (global var)
+// RESULT-LABEL: key.results: [
+// RESULT-NOT: key.description: "Foo"
+// RESULT-DAG: key.description: "get"
+// RESULT-DAG: key.description: "set"
+// RESULT-DAG: key.description: "willSet"
+// RESULT-DAG: key.description: "didSet"
+// RESULT: ]
 
 
 // TRACE-LABEL: key.notification: source.notification.compile-did-finish,
@@ -134,3 +161,9 @@ enum S {
 // TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
 // TRACE-LABEL: key.notification: source.notification.compile-did-finish,
 // TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
+// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
+// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
+// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
+// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
+// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
+// TRACE-NOT: key.description: "completion reusing previous ASTContext (benign diagnostic)"


### PR DESCRIPTION
If a CC token is right after the '{' we still don't know it's an implicit getter or a start of a accessor block. Previously, the parser used to parse it as an accessor block, but it prevents fast-completion kicks in.

Instead handle it as a part of function body parsing so the fast-completion works.

rdar://problem/58851121

Groundwork:
* Consolidate `AbstructFunctionDecl` body parsing functions
* Add a convenient `AccessorDecl::isImplictGetter()` function