### PR TITLE
[IRGen] Adapt remaining tests to arguments in IR.

### DIFF
--- a/test/IRGen/abi_v7k.swift
+++ b/test/IRGen/abi_v7k.swift
@@ -4,7 +4,7 @@
 // REQUIRES: CPU=armv7k
 // REQUIRES: OS=watchos
 
-// CHECK-LABEL: define hidden swiftcc float @"$s8test_v7k9addFloats{{.*}}"(float, float)
+// CHECK-LABEL: define hidden swiftcc float @"$s8test_v7k9addFloats{{.*}}"(float %0, float %1)
 // CHECK: fadd float %0, %1
 // CHECK: ret float
 // V7K-LABEL: _$s8test_v7k9addFloats{{.*}}
@@ -13,7 +13,7 @@ func addFloats(x: Float, y : Float) -> Float {
   return x+y
 }
 
-// CHECK-LABEL: define hidden swiftcc double @"$s8test_v7k10addDoubles{{.*}}"(double, double, double)
+// CHECK-LABEL: define hidden swiftcc double @"$s8test_v7k10addDoubles{{.*}}"(double %0, double %1, double %2)
 // CHECK: fadd double %0, %1
 // CHECK: fadd double
 // CHECK: ret double
@@ -24,7 +24,7 @@ func addDoubles(x: Double, y: Double, z: Double) -> Double {
   return x+y+z
 }
 
-// CHECK-LABEL: define hidden swiftcc float @"$s8test_v7k6addFDF{{.*}}"(float, double, float)
+// CHECK-LABEL: define hidden swiftcc float @"$s8test_v7k6addFDF{{.*}}"(float %0, double %1, float %2)
 // CHECK: fmul float
 // CHECK: ret float
 // V7K-LABEL: _$s8test_v7k6addFDF
@@ -34,7 +34,7 @@ func addFDF(x: Float, y: Double, z: Float) -> Float {
   return x*z
 }
 
-// CHECK-LABEL: define hidden swiftcc double @"$s8test_v7k8addStack{{.*}}"(double, double, double, double, double, double, double, float, double)
+// CHECK-LABEL: define hidden swiftcc double @"$s8test_v7k8addStack{{.*}}"(double %0, double %1, double %2, double %3, double %4, double %5, double %6, float %7, double %8)
 // CHECK: fadd double
 // CHECK: ret double
 // V7K-LABEL: _$s8test_v7k8addStack
@@ -47,7 +47,7 @@ func addStack(d0: Double, d1: Double, d2: Double, d3: Double, d4: Double,
   return a+c
 }
 
-// CHECK-LABEL: define hidden swiftcc float @"$s8test_v7k9addStack{{.*}}"(double, double, double, double, double, double, double, float, double, float)
+// CHECK-LABEL: define hidden swiftcc float @"$s8test_v7k9addStack{{.*}}"(double %0, double %1, double %2, double %3, double %4, double %5, double %6, float %7, double %8, float %9)
 // CHECK: fadd float
 // V7K-LABEL: _$s8test_v7k9addStack
 // V7K: sub     sp, #80
@@ -78,7 +78,7 @@ func testSingle(x: SingleCase) -> Int32{
   }
 }
 
-// CHECK-LABEL: define hidden swiftcc double @"$s8test_v7k0A4Data{{.*}}"(i32, double)
+// CHECK-LABEL: define hidden swiftcc double @"$s8test_v7k0A4Data{{.*}}"(i32 %0, double %1)
 // CHECK: ret double
 // V7K-LABEL: _$s8test_v7k0A4Data
 // V7K: vstr d0
@@ -91,7 +91,7 @@ func testData(x: DataCase) -> Double {
   }
 }
 
-// CHECK-LABEL: define hidden swiftcc i32 @"$s8test_v7k0A6Clike2{{.*}}"(i8)
+// CHECK-LABEL: define hidden swiftcc i32 @"$s8test_v7k0A6Clike2{{.*}}"(i8 %0)
 // CHECK: [[ID:%[0-9]+]] = phi i32 [ 2, {{.*}} ], [ 1, {{.*}} ]
 // CHECK: ret i32 [[ID]]
 // V7K-LABEL: _$s8test_v7k0A6Clike2
@@ -111,7 +111,7 @@ func testClike2(x: CLike2) -> Int {
   }
 }
 
-// CHECK-LABEL: define hidden swiftcc i32 @"$s8test_v7k0A6Clike8{{.*}}"(i32, i8)
+// CHECK-LABEL: define hidden swiftcc i32 @"$s8test_v7k0A6Clike8{{.*}}"(i32 %0, i8 %1)
 // CHECK: [[ID:%[0-9]+]] = phi i32 [ -1, {{.*}} ], [ 1, {{.*}} ]
 // CHECK: ret i32 [[ID]]
 // V7K-LABEL: _$s8test_v7k0A6Clike8
@@ -140,7 +140,7 @@ func testClike8(t: Int, x: CLike8) -> Int {
 
 // layout of the enum: the tag bit is set for the no-data cases, which are then
 // assigned values in the data area of the enum in declaration order
-// CHECK-LABEL: define hidden swiftcc double @"$s8test_v7k0A7SingleP{{.*}}"(i32, i32, i8)
+// CHECK-LABEL: define hidden swiftcc double @"$s8test_v7k0A7SingleP{{.*}}"(i32 %0, i32 %1, i8 %2)
 // CHECK: br i1
 // CHECK: switch i64 [[ID:%[0-9]+]]
 // CHECK: [[FIRST:%[0-9]+]] = zext i32 %0 to i64
@@ -168,7 +168,7 @@ func testSingleP(x: SinglePayload) -> Double {
   }
 }
 
-// CHECK-LABEL: define hidden swiftcc double @"$s8test_v7k0A6MultiP{{.*}}"(i32, i32, i8)
+// CHECK-LABEL: define hidden swiftcc double @"$s8test_v7k0A6MultiP{{.*}}"(i32 %0, i32 %1, i8 %2)
 // CHECK: [[FIRST:%[0-9]+]] = zext i32 %0 to i64
 // CHECK: [[F1:%[0-9]+]] = and i64 [[FIRST]], 4294967295
 // CHECK: [[SECOND:%[0-9]+]] = zext i32 %1 to i64
@@ -201,7 +201,7 @@ func testMultiP(x: MultiPayload) -> Double {
   }
 }
 
-// CHECK-LABEL: define hidden swiftcc float @"$s8test_v7k0A3Opt{{.*}}"(i32, i8)
+// CHECK-LABEL: define hidden swiftcc float @"$s8test_v7k0A3Opt{{.*}}"(i32 %0, i8 %1)
 // CHECK: entry:
 // CHECK: [[TR:%.*]] = trunc i8 %1
 // CHECK: br i1 [[TR]], {{.*}}, label %[[PAYLOADLABEL:.*]]
@@ -221,7 +221,7 @@ func testOpt(x: Float?) -> Float {
 }
 
 // Returning tuple: (Int, Int)
-// CHECK-LABEL: define hidden swiftcc { i32, i32 } @"$s8test_v7k6minMax{{.*}}"(i32, i32)
+// CHECK-LABEL: define hidden swiftcc { i32, i32 } @"$s8test_v7k6minMax{{.*}}"(i32 %0, i32 %1)
 // V7K-LABEL: _$s8test_v7k6minMax
 // V7K: ldr r0
 // V7K: ldr r1
@@ -269,7 +269,7 @@ struct MyRect4 {
    s = MySize(w: 1.0, h: 2.0)
   }
 }
-// CHECK-LABEL: define hidden swiftcc { double, double, double, double } @"$s8test_v7k0A4Ret2{{.*}}"(double, i32)
+// CHECK-LABEL: define hidden swiftcc { double, double, double, double } @"$s8test_v7k0A4Ret2{{.*}}"(double %0, i32 %1)
 // V7K-LABEL: _$s8test_v7k0A4Ret2
 // double in d0, i32 in r0, return in d0,...,d3
 // V7K: vmov [[ID:s[0-9]+]], r0
@@ -292,7 +292,7 @@ func testRet3() -> MyRect2 {
 }
 
 // Returning tuple?: (Int x 6)?
-// CHECK-LABEL: define hidden swiftcc void @"$s8test_v7k7minMax2{{.*}}"({{%TSi.*}} noalias nocapture sret, i32, i32)
+// CHECK-LABEL: define hidden swiftcc void @"$s8test_v7k7minMax2{{.*}}"({{%TSi.*}} noalias nocapture sret %0, i32 %1, i32 %2)
 // V7K-LABEL: _$s8test_v7k7minMax2
 // We will indirectly return an optional with the address in r0, input parameters will be in r1 and r2
 // V7K: cmp r1, r2
@@ -320,7 +320,7 @@ func minMax2(x : Int, y : Int) -> (min: Int, max: Int, min2: Int, max2: Int, min
 }
 
 // Returning struct?: {Int x 6}?
-// CHECK-LABEL: define hidden swiftcc void @"$s8test_v7k7minMax3{{.*}}"({{%T.*}} noalias nocapture sret, i32, i32)
+// CHECK-LABEL: define hidden swiftcc void @"$s8test_v7k7minMax3{{.*}}"({{%T.*}} noalias nocapture sret %0, i32 %1, i32 %2)
 // V7K-LABEL: _$s8test_v7k7minMax3
 struct Ret {
   var min:Int

--- a/test/IRGen/abitypes.swift
+++ b/test/IRGen/abitypes.swift
@@ -47,8 +47,8 @@ class Foo {
   // x86_64-macosx: define hidden double @"$s8abitypes3FooC14getXFromNSRect{{[_0-9a-zA-Z]*}}FTo"(i8* %0, i8* %1, %TSo6CGRectV* byval align 8 %2) {{[#0-9]*}} {
   // armv7-ios: define hidden swiftcc double @"$s8abitypes3FooC14getXFromNSRect{{[_0-9a-zA-Z]*}}F"(float %0, float %1, float %2, float %3, %T8abitypes3FooC* swiftself %4) {{.*}} {
   // armv7-ios: define hidden double @"$s8abitypes3FooC14getXFromNSRect{{[_0-9a-zA-Z]*}}FTo"(i8* %0, i8* %1, [4 x i32] %2) {{[#0-9]*}} {
-  // armv7s-ios: define hidden swiftcc double @"$s8abitypes3FooC14getXFromNSRect{{[_0-9a-zA-Z]*}}F"(float %0, float %1, float %2, float %3, %T8abitypes3FooC* swiftself %3) {{.*}} {
-  // armv7s-ios: define hidden double @"$s8abitypes3FooC14getXFromNSRect{{[_0-9a-zA-Z]*}}FTo"(i8* %0, i8* %1, [4 x i32] %3) {{[#0-9]*}} {
+  // armv7s-ios: define hidden swiftcc double @"$s8abitypes3FooC14getXFromNSRect{{[_0-9a-zA-Z]*}}F"(float %0, float %1, float %2, float %3, %T8abitypes3FooC* swiftself %4) {{.*}} {
+  // armv7s-ios: define hidden double @"$s8abitypes3FooC14getXFromNSRect{{[_0-9a-zA-Z]*}}FTo"(i8* %0, i8* %1, [4 x i32] %2) {{[#0-9]*}} {
   // armv7k-watchos: define hidden swiftcc double @"$s8abitypes3FooC14getXFromNSRect{{[_0-9a-zA-Z]*}}F"(float %0, float %1, float %2, float %3, %T8abitypes3FooC* swiftself %4) {{.*}} {
   // armv7k-watchos: define hidden double @"$s8abitypes3FooC14getXFromNSRect{{[_0-9a-zA-Z]*}}FTo"(i8* %0, i8* %1, [4 x float] %2) {{[#0-9]*}} {
   @objc dynamic func getXFromNSRect(_ r: NSRect) -> Double {
@@ -62,7 +62,7 @@ class Foo {
   // armv7s-ios: define hidden swiftcc float @"$s8abitypes3FooC12getXFromRect{{[_0-9a-zA-Z]*}}F"(float %0, float %1, float %2, float %3, %T8abitypes3FooC* swiftself %4) {{.*}} {
   // armv7s-ios: define hidden float @"$s8abitypes3FooC12getXFromRect{{[_0-9a-zA-Z]*}}FTo"(i8* %0, i8* %1, [4 x i32] %2) {{[#0-9]*}} {
   // armv7k-watchos: define hidden swiftcc float @"$s8abitypes3FooC12getXFromRect{{[_0-9a-zA-Z]*}}F"(float %0, float %1, float %2, float %3, %T8abitypes3FooC* swiftself %4) {{.*}} {
-  // armv7k-watchos: define hidden float @"$s8abitypes3FooC12getXFromRect{{[_0-9a-zA-Z]*}}FTo"(i8* %0, i8* %1, [4 x float] %3) {{[#0-9]*}} {
+  // armv7k-watchos: define hidden float @"$s8abitypes3FooC12getXFromRect{{[_0-9a-zA-Z]*}}FTo"(i8* %0, i8* %1, [4 x float] %2) {{[#0-9]*}} {
   @objc dynamic func getXFromRect(_ r: MyRect) -> Float {
     return r.x
   }
@@ -151,7 +151,7 @@ class Foo {
   // armv7-ios: ret float [[RETVAL]]
   //
   // armv7s returns an HA of four floats indirectly
-  // armv7s-ios: define hidden swiftcc float @"$s8abitypes3FooC4barc{{[_0-9a-zA-Z]*}}F"(%TSo13StructReturnsC* %0, %T8abitypes3FooC* swiftself % %1) {{.*}} {
+  // armv7s-ios: define hidden swiftcc float @"$s8abitypes3FooC4barc{{[_0-9a-zA-Z]*}}F"(%TSo13StructReturnsC* %0, %T8abitypes3FooC* swiftself %1) {{.*}} {
   // armv7s-ios: [[RESULT:%.*]] = alloca [[RECTTYPE:%.*MyRect.*]], align 4
   // armv7s-ios: load i8*, i8** @"\01L_selector(newRect)", align 4
   // armv7s-ios: call void bitcast (void ()* @objc_msgSend_stret to void ([[RECTTYPE]]*, [[RECEIVER:.*]]*, i8*)*)([[RECTTYPE]]* noalias nocapture sret %call.aggresult
@@ -514,10 +514,10 @@ class Foo {
   }
 
   // arm64-ios: define hidden swiftcc { i64, i64, i64, i64 } @"$s8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}F"(%TSo13StructReturnsC* %0, i64 %1, i64 %2, i64 %3, i64 %4, %T8abitypes3FooC* swiftself %5) {{.*}} {
-  // arm64-ios: define hidden void @"$s8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo"(%TSo9BigStructV* noalias nocapture sret, i8*, i8*, [[OPAQUE:.*]]*, %TSo9BigStructV*) {{[#0-9]*}} {
+  // arm64-ios: define hidden void @"$s8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo"(%TSo9BigStructV* noalias nocapture sret %0, i8* %1, i8* %2, [[OPAQUE:.*]]* %3, %TSo9BigStructV* %4) {{[#0-9]*}} {
   //
   // arm64-tvos: define hidden swiftcc { i64, i64, i64, i64 } @"$s8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}F"(%TSo13StructReturnsC* %0, i64 %1, i64 %2, i64 %3, i64 %4, %T8abitypes3FooC* swiftself %5) {{.*}} {
-  // arm64-tvos: define hidden void @"$s8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo"(%TSo9BigStructV* noalias nocapture sret, i8*, i8*, [[OPAQUE:.*]]*, %TSo9BigStructV*) {{[#0-9]*}} {
+  // arm64-tvos: define hidden void @"$s8abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo"(%TSo9BigStructV* noalias nocapture sret %0, i8* %1, i8* %2, [[OPAQUE:.*]]* %3, %TSo9BigStructV* %4) {{[#0-9]*}} {
   @objc dynamic func callJustReturn(_ r: StructReturns, with v: BigStruct) -> BigStruct {
     return r.justReturn(v)
   }

--- a/test/IRGen/class_isa_pointers_armv7k_watchos.sil
+++ b/test/IRGen/class_isa_pointers_armv7k_watchos.sil
@@ -17,7 +17,7 @@ class Purebred {
 }
 sil_vtable Purebred {}
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @purebred_method(%T33class_isa_pointers_armv7k_watchos8PurebredC*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @purebred_method(%T33class_isa_pointers_armv7k_watchos8PurebredC* %0) {{.*}} {
 // CHECK:         [[ISA_PTR:%.*]] = bitcast %T33class_isa_pointers_armv7k_watchos8PurebredC* %0 to %swift.type**
 // CHECK:         [[ISA:%.*]] = load %swift.type*, %swift.type** [[ISA_PTR]]
 // CHECK:         [[VTABLE:%.*]] = bitcast %swift.type* [[ISA]]
@@ -38,7 +38,7 @@ class Mongrel: Gizmo {
 }
 sil_vtable Mongrel {}
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @mongrel_method(%T33class_isa_pointers_armv7k_watchos7MongrelC*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @mongrel_method(%T33class_isa_pointers_armv7k_watchos7MongrelC* %0) {{.*}} {
 // CHECK:         [[T0:%.*]] = bitcast {{.*}} %0 to %objc_object*
 // CHECK:         [[T1:%.*]] = call %objc_class* @object_getClass(%objc_object* [[T0]])
 // CHECK:         [[ISA:%.*]] = bitcast %objc_class* [[T1]] to %swift.type*

--- a/test/IRGen/class_resilience_objc_armv7k.swift
+++ b/test/IRGen/class_resilience_objc_armv7k.swift
@@ -12,7 +12,7 @@ public class FixedLayoutObjCSubclass : NSObject {
   public final var field: Int32 = 0
 };
 
-// CHECK-LABEL: define hidden swiftcc void @"$s28class_resilience_objc_armv7k29testConstantDirectFieldAccessyyAA23FixedLayoutObjCSubclassCF"(%T28class_resilience_objc_armv7k23FixedLayoutObjCSubclassC*)
+// CHECK-LABEL: define hidden swiftcc void @"$s28class_resilience_objc_armv7k29testConstantDirectFieldAccessyyAA23FixedLayoutObjCSubclassCF"(%T28class_resilience_objc_armv7k23FixedLayoutObjCSubclassC* %0)
 // CHECK:      [[OFFSET:%.*]] = load [[INT]], [[INT]]* @"$s28class_resilience_objc_armv7k23FixedLayoutObjCSubclassC5fields5Int32VvpWvd"
 // CHECK-NEXT: [[OBJECT:%.*]] = bitcast %T28class_resilience_objc_armv7k23FixedLayoutObjCSubclassC* %0 to i8*
 // CHECK-NEXT: [[ADDR:%.*]] = getelementptr inbounds i8, i8* [[OBJECT]], [[INT]] [[OFFSET]]
@@ -31,7 +31,7 @@ public class NonFixedLayoutObjCSubclass : NSCoder {
   public final var field: Int32 = 0
 }
 
-// CHECK-LABEL: define hidden swiftcc void @"$s28class_resilience_objc_armv7k32testNonConstantDirectFieldAccessyyAA0F23FixedLayoutObjCSubclassCF"(%T28class_resilience_objc_armv7k26NonFixedLayoutObjCSubclassC*)
+// CHECK-LABEL: define hidden swiftcc void @"$s28class_resilience_objc_armv7k32testNonConstantDirectFieldAccessyyAA0F23FixedLayoutObjCSubclassCF"(%T28class_resilience_objc_armv7k26NonFixedLayoutObjCSubclassC* %0)
 // CHECK:      [[OFFSET:%.*]] = load [[INT]], [[INT]]* @"$s28class_resilience_objc_armv7k26NonFixedLayoutObjCSubclassC5fields5Int32VvpWvd"
 // CHECK-NEXT: [[OBJECT:%.*]] = bitcast %T28class_resilience_objc_armv7k26NonFixedLayoutObjCSubclassC* %0 to i8*
 // CHECK-NEXT: [[ADDR:%.*]] = getelementptr inbounds i8, i8* [[OBJECT]], [[INT]] [[OFFSET]]
@@ -53,7 +53,7 @@ public class GenericObjCSubclass<T> : NSCoder {
   }
 }
 
-// CHECK-LABEL: define hidden swiftcc void @"$s28class_resilience_objc_armv7k31testConstantIndirectFieldAccessyyAA19GenericObjCSubclassCyxGlF"(%T28class_resilience_objc_armv7k19GenericObjCSubclassC*)
+// CHECK-LABEL: define hidden swiftcc void @"$s28class_resilience_objc_armv7k31testConstantIndirectFieldAccessyyAA19GenericObjCSubclassCyxGlF"(%T28class_resilience_objc_armv7k19GenericObjCSubclassC* %0)
 
 // FIXME: we could eliminate the unnecessary isa load by lazily emitting
 // metadata sources in EmitPolymorphicParameters

--- a/test/IRGen/pic.swift
+++ b/test/IRGen/pic.swift
@@ -58,9 +58,9 @@ public func use_global() -> Int {
 // armv7k:        ldr [[R_ADR]], {{\[}}[[R_ADR]]{{\]}}
 
 // arm64-LABEL: {{_?}}$s4main10use_globalSiyF:
-// arm64:        bl _swift_beginAccess
 // arm64:        adrp [[REG1:x[0-9]+]], _$s4main6globalSivp@PAGE
 // arm64:        add [[REG1]], [[REG1]], _$s4main6globalSivp@PAGEOFF
+// arm64:        bl _swift_beginAccess
 // arm64:        ldr [[REG2:x[0-9]+]], {{\[}}[[REG1]]{{\]}}
 // arm64:        str [[REG2]], [sp]
 // arm64:        bl _swift_endAccess


### PR DESCRIPTION
A few tests that may not be exercised by CI need to be tweaked to adapt to the new LLVM.