### PR TITLE
Specialize a test for Windows

### DIFF
--- a/test/ModuleInterface/swift_build_sdk_interfaces/compiler-crash-windows.test-sh
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/compiler-crash-windows.test-sh
@@ -1,0 +1,13 @@
+# This test is intentionally specialized on windows becauase not --crash behaves
+# differently there. The exit code from the crashing frontend invocations is
+# mapped to `-21` there, which lit's `not` along does not remap correctly.
+# See rdar://59397376
+REQUIRES: OS=windows-msvc
+
+RUN: env SWIFT_EXEC=%swiftc_driver_plain not --crash %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/mock-sdk/ -o %t/output -debug-crash-compiler 2>&1 | %FileCheck %s
+
+CHECK: Program arguments:
+CHECK-SAME: -debug-crash-immediately
+CHECK-SAME: {{.+}}.swiftinterface
+
+REQUIRES: asserts

--- a/test/ModuleInterface/swift_build_sdk_interfaces/compiler-crash.test-sh
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/compiler-crash.test-sh
@@ -1,4 +1,5 @@
-REQUIRES: rdar59318361
+# For its Windows counterpart, see compiler-crash-windows.test-sh
+UNSUPPORTED: windows
 
 RUN: not %swift_build_sdk_interfaces -sdk %S/Inputs/mock-sdk/ -o %t/output -debug-crash-compiler 2>&1 | %FileCheck %s
 


### PR DESCRIPTION
An unfortunate workaround for rdar://59397376

Resolves rdar://59318361

Supersedes the not-env work in #29198