### PR TITLE
[CSSimplify] Increment impact for DefineMemberBasedOnUse when base type is any function type

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6325,8 +6325,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
 
       // Impact is higher if the the base type is any function type
       // because function types can't have any members other than self
-      if (baseObjTy->getDesugaredType()->is<AnyFunctionType>()) {
-          impact += 1;
+      if (baseObjTy->is<AnyFunctionType>()) {
+          impact += 10;
       }
 
       if (recordFix(fix, impact))

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6322,6 +6322,13 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
       // not a match in this case.
       auto impact =
           locator->findLast<LocatorPathElt::UnresolvedMember>() ? 2 : 1;
+
+      // Impact is higher if the the base type is any function type
+      // because function types can't have any members other than self
+      if (baseObjTy->getDesugaredType()->is<AnyFunctionType>()) {
+          impact += 1;
+      }
+
       if (recordFix(fix, impact))
         return SolutionKind::Error;
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1385,3 +1385,23 @@ class ClassWithPropContainingSetter {
     set { return 1 } // expected-error {{unexpected non-void return value in void function}}
   }
 }
+
+// https://bugs.swift.org/browse/SR-11964
+struct Rect {
+    let width: Int
+    let height: Int
+}
+
+struct Frame {
+    func rect(width: Int, height: Int) -> Rect {
+        Rect(width: width, height: height)
+    }
+
+    let rect: Rect
+}
+
+func foo(frame: Frame) {
+    frame.rect.width + 10.0 // expected-error {{binary operator '+' cannot be applied to operands of type 'Int' and 'Double'}}
+    // expected-note@-1 {{overloads for '+' exist with these partially matching parameter lists: (Double, Double), (Int, Int)}}
+
+}


### PR DESCRIPTION
This pull request increments the impact by 10 for DefineMemberBasedOnUse fixes when the base type is any function type.

This allows the constraint system to prefer a case when a member is found and then has an argument to parameter mismatch like in the example in SR-11964. 

https://bugs.swift.org/browse/SR-11964

Resolves: SR-11964
Resolves: rdar://problem/58028105