### PR TITLE
Add a regression test for the @usableFromInline pattern in rdar://59171169

### DIFF
--- a/test/ModuleInterface/inherits-superclass-initializers.swift
+++ b/test/ModuleInterface/inherits-superclass-initializers.swift
@@ -24,6 +24,27 @@ open class Base {
 // CHECK: }
 }
 
+// CHECK-NOT: @_hasMissingDesignatedInitializers
+// CHECK: open class InlineBase {
+open class InlineBase {
+  // CHECK-NEXT: public init(arg: Swift.Int)
+  public init(arg: Int) {
+    print("public init from Inline Base")
+  }
+
+  // CHECK-NOT: @usableFromInline init(secret: Swift.Int)
+  @usableFromInline
+  internal init(secret: Int) {
+    print("secret init from Inline Base")
+  }
+
+  // CHECK: convenience public init()
+  public convenience init() {
+    self.init(secret: 42)
+  }
+  // CHECK: }
+}
+
 // CHECK: @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers public class Sub : Module.Base {
 public class Sub : Base {
   // CHECK: override public init(arg: Swift.Int)


### PR DESCRIPTION
Make sure we don't print @_hasMissingDesignatedInitializers in the swift interface when we actually can see all the designated initializers.