### PR TITLE
unittests: add stub for `__SwiftValue`

### DIFF
--- a/unittests/runtime/Stdlib.cpp
+++ b/unittests/runtime/Stdlib.cpp
@@ -506,3 +506,8 @@ const long long $ss21_ObjectiveCBridgeableMp[1] = {0};
 
 SWIFT_RUNTIME_STDLIB_INTERNAL
 const long long $ss7KeyPathCMo[1] = {0};
+
+// Boxing
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $ss12__SwiftValueCMn[1] = {0};


### PR DESCRIPTION
This placeholds the `__SwiftValue` metadata necessary for the Swift
runtime tests.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
