### PR TITLE
Fixing build breaks for master-next against latest llvm.org.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -661,8 +661,7 @@ private:
 
     StringRef Sysroot = IGM.Context.SearchPathOpts.SDKPath;
     llvm::DIModule *M =
-        DBuilder.createModule(Parent, Name, ConfigMacros, RemappedIncludePath,
-                              Sysroot);
+        DBuilder.createModule(Parent, Name, ConfigMacros, RemappedIncludePath);
     DIModuleCache.insert({Key, llvm::TrackingMDNodeRef(M)});
     return M;
   }


### PR DESCRIPTION
There were changes due to the StringRef to std::string conversion, changes in the Debug Info DIBuilder::createModule API, and a drop in the using for PointerUnion4 since PointerUnion is now a variadic template and will do in its place.