### PR TITLE
[Constraint system] Factor out application to a SolutionApplicationTarget

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -290,7 +290,7 @@ namespace {
   public:
     ConstraintSystem &cs;
     DeclContext *dc;
-    const Solution &solution;
+    Solution &solution;
     bool SuppressDiagnostics;
 
     /// Coerce the given tuple to another tuple type.
@@ -1792,7 +1792,7 @@ namespace {
     }
     
   public:
-    ExprRewriter(ConstraintSystem &cs, const Solution &solution,
+    ExprRewriter(ConstraintSystem &cs, Solution &solution,
                  bool suppressDiagnostics)
         : cs(cs), dc(cs.DC), solution(solution),
           SuppressDiagnostics(suppressDiagnostics) {}
@@ -7142,6 +7142,10 @@ namespace {
 
     /// Ignore declarations.
     bool walkToDeclPre(Decl *decl) override { return false; }
+
+    /// Rewrite the target, producing a new target.
+    Optional<SolutionApplicationTarget>
+    rewriteTarget(SolutionApplicationTarget target);
   };
 } // end anonymous namespace
 
@@ -7305,6 +7309,111 @@ static Optional<SolutionApplicationTarget> applySolutionToInitialization(
   return resultTarget;
 }
 
+Optional<SolutionApplicationTarget>
+ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
+  auto &solution = Rewriter.solution;
+
+  // Apply the solution to the target.
+  SolutionApplicationTarget result = target;
+  if (auto expr = target.getAsExpr()) {
+    Expr *rewrittenExpr = expr->walk(*this);
+    if (!rewrittenExpr)
+      return None;
+
+    /// Handle application for initializations.
+    if (target.getExprContextualTypePurpose() == CTP_Initialization) {
+      auto initResultTarget = applySolutionToInitialization(
+          solution, target, rewrittenExpr);
+      if (!initResultTarget)
+        return None;
+
+      result = *initResultTarget;
+    } else {
+      result.setExpr(rewrittenExpr);
+    }
+  } else {
+    auto fn = *target.getAsFunction();
+
+    // Dig out the function builder transformation we applied.
+    auto transform = Rewriter.getAppliedBuilderTransform(fn);
+    assert(transform);
+
+    auto newBody = applyFunctionBuilderTransform(
+        solution, *transform, fn.getBody(), fn.getAsDeclContext(),
+        [&](Expr *expr) {
+          Expr *result = expr->walk(*this);
+          if (result)
+            solution.setExprTypes(result);
+          return result;
+        },
+        [&](Expr *expr, Type toType, ConstraintLocator *locator) {
+          return Rewriter.coerceToType(expr, toType, locator);
+        });
+
+    if (!newBody)
+      return None;
+
+    result.setFunctionBody(newBody);
+  }
+
+  // Follow-up tasks.
+  auto &cs = solution.getConstraintSystem();
+  if (auto resultExpr = result.getAsExpr()) {
+    Expr *expr = target.getAsExpr();
+    assert(expr && "Can't have expression result without expression target");
+
+    // We are supposed to use contextual type only if it is present and
+    // this expression doesn't represent the implicit return of the single
+    // expression function which got deduced to be `Never`.
+    Type convertType = target.getExprConversionType();
+    auto shouldCoerceToContextualType = [&]() {
+      return convertType &&
+          !target.isOptionalSomePatternInit() &&
+          !(solution.getType(resultExpr)->isUninhabited() &&
+            cs.getContextualTypePurpose(target.getAsExpr())
+              == CTP_ReturnSingleExpr);
+    };
+
+    // If we're supposed to convert the expression to some particular type,
+    // do so now.
+    if (shouldCoerceToContextualType()) {
+      resultExpr = Rewriter.coerceToType(resultExpr,
+                                         solution.simplifyType(convertType),
+                                         cs.getConstraintLocator(expr));
+    } else if (cs.getType(resultExpr)->hasLValueType() &&
+               !target.isDiscardedExpr()) {
+      // We referenced an lvalue. Load it.
+      resultExpr = Rewriter.coerceToType(
+          resultExpr,
+          cs.getType(resultExpr)->getRValueType(),
+          cs.getConstraintLocator(expr));
+    }
+
+    if (!resultExpr)
+      return None;
+
+    // For an @autoclosure default parameter type, add the autoclosure
+    // conversion.
+    if (FunctionType *autoclosureParamType =
+            target.getAsAutoclosureParamType()) {
+      resultExpr = cs.buildAutoClosureExpr(resultExpr, autoclosureParamType);
+    }
+
+    solution.setExprTypes(resultExpr);
+    result.setExpr(resultExpr);
+
+    auto &ctx = cs.getASTContext();
+    if (ctx.TypeCheckerOpts.DebugConstraintSolver) {
+      auto &log = ctx.TypeCheckerDebug->getStream();
+      log << "---Type-checked expression---\n";
+      resultExpr->dump(log);
+      log << "\n";
+    }
+  }
+
+  return result;
+}
+
 /// Apply a given solution to the expression, producing a fully
 /// type-checked expression.
 Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
@@ -7335,49 +7444,9 @@ Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
 
   ExprRewriter rewriter(*this, solution, shouldSuppressDiagnostics());
   ExprWalker walker(rewriter);
-
-  // Apply the solution to the target.
-  SolutionApplicationTarget result = target;
-  if (auto expr = target.getAsExpr()) {
-    Expr *rewrittenExpr = expr->walk(walker);
-    if (!rewrittenExpr)
-      return None;
-
-    /// Handle application for initializations.
-    if (target.getExprContextualTypePurpose() == CTP_Initialization) {
-      auto initResultTarget = applySolutionToInitialization(
-          solution, target, rewrittenExpr);
-      if (!initResultTarget)
-        return None;
-
-      result = *initResultTarget;
-    } else {
-      result.setExpr(rewrittenExpr);
-    }
-  } else {
-    auto fn = *target.getAsFunction();
-
-    // Dig out the function builder transformation we applied.
-    auto transform = rewriter.getAppliedBuilderTransform(fn);
-    assert(transform);
-
-    auto newBody = applyFunctionBuilderTransform(
-        solution, *transform, fn.getBody(), fn.getAsDeclContext(),
-        [&](Expr *expr) {
-          Expr *result = expr->walk(walker);
-          if (result)
-            solution.setExprTypes(result);
-          return result;
-        },
-        [&](Expr *expr, Type toType, ConstraintLocator *locator) {
-          return rewriter.coerceToType(expr, toType, locator);
-        });
-
-    if (!newBody)
-      return None;
-
-    result.setFunctionBody(newBody);
-  }
+  auto resultTarget = walker.rewriteTarget(target);
+  if (!resultTarget)
+    return None;
 
   // If we're re-typechecking an expression for diagnostics, don't
   // visit closures that have non-single expression bodies.
@@ -7399,65 +7468,14 @@ Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
       return None;
   }
 
-  if (auto resultExpr = result.getAsExpr()) {
-    Expr *expr = target.getAsExpr();
-    assert(expr && "Can't have expression result without expression target");
-
-    // We are supposed to use contextual type only if it is present and
-    // this expression doesn't represent the implicit return of the single
-    // expression function which got deduced to be `Never`.
-    Type convertType = target.getExprConversionType();
-    auto shouldCoerceToContextualType = [&]() {
-      return convertType &&
-          !target.isOptionalSomePatternInit() &&
-          !(getType(resultExpr)->isUninhabited() &&
-            getContextualTypePurpose(target.getAsExpr())
-              == CTP_ReturnSingleExpr);
-    };
-
-    // If we're supposed to convert the expression to some particular type,
-    // do so now.
-    if (shouldCoerceToContextualType()) {
-      resultExpr = rewriter.coerceToType(resultExpr,
-                                         simplifyType(convertType),
-                                         getConstraintLocator(expr));
-    } else if (getType(resultExpr)->hasLValueType() &&
-               !target.isDiscardedExpr()) {
-      // We referenced an lvalue. Load it.
-      resultExpr = rewriter.coerceToType(resultExpr,
-                                         getType(resultExpr)->getRValueType(),
-                                         getConstraintLocator(expr));
-    }
-
-    if (!resultExpr)
-      return None;
-
-    // For an @autoclosure default parameter type, add the autoclosure
-    // conversion.
-    if (FunctionType *autoclosureParamType =
-            target.getAsAutoclosureParamType()) {
-      resultExpr = buildAutoClosureExpr(resultExpr, autoclosureParamType);
-    }
-
-    solution.setExprTypes(resultExpr);
-    result.setExpr(resultExpr);
-
-    if (Context.TypeCheckerOpts.DebugConstraintSolver) {
-      auto &log = Context.TypeCheckerDebug->getStream();
-      log << "---Type-checked expression---\n";
-      resultExpr->dump(log);
-      log << "\n";
-    }
-  }
-
   rewriter.finalize();
 
-  return result;
+  return resultTarget;
 }
 
 Expr *Solution::coerceToType(Expr *expr, Type toType,
                              ConstraintLocator *locator,
-                             Optional<Pattern*> typeFromPattern) const {
+                             Optional<Pattern*> typeFromPattern) {
   auto &cs = getConstraintSystem();
   ExprRewriter rewriter(cs, *this, /*suppressDiagnostics=*/false);
   Expr *result = rewriter.coerceToType(expr, toType, locator, typeFromPattern);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -5067,10 +5067,8 @@ bool isSIMDOperator(ValueDecl *value);
 /// \param applied The applied builder transform.
 /// \param body The body to transform
 /// \param dc The context in which the transform occurs.
-/// \param rewriteExpr Rewrites expressions that show up in the transform
-/// to their final, type-checked versions.
-/// \param coerceToType Coerce the given expression to the specified type,
-/// which may introduce implicit conversions.
+/// \param rewriteTarget Rewrites a solution application target to its final,
+/// type-checked version.
 ///
 /// \returns the transformed body
 BraceStmt *applyFunctionBuilderTransform(
@@ -5078,9 +5076,10 @@ BraceStmt *applyFunctionBuilderTransform(
     constraints::AppliedBuilderTransform applied,
     BraceStmt *body,
     DeclContext *dc,
-    std::function<Expr *(Expr *)> rewriteExpr,
-    std::function<Expr *(Expr *, Type, constraints::ConstraintLocator *)>
-      coerceToType);
+    std::function<
+        Optional<constraints::SolutionApplicationTarget> (
+          constraints::SolutionApplicationTarget)>
+            rewriteTarget);
 
 } // end namespace swift
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -886,7 +886,7 @@ public:
   /// \returns the coerced expression, which will have type \c ToType.
   Expr *coerceToType(Expr *expr, Type toType,
                      ConstraintLocator *locator,
-                     Optional<Pattern*> typeFromPattern = None) const;
+                     Optional<Pattern*> typeFromPattern = None);
 
   /// Compute the set of substitutions for a generic signature opened at the
   /// given locator.


### PR DESCRIPTION
Pull out the core operation of rewriting a given `SolutionApplicationTarget`
into into a method on the `ExprWalker` that does the overall rewrite, so it
can be called multiple times within application. Use this to eliminate some
boilerplate in function builder application.