### PR TITLE
[stdlib/private][OSLog] Add missing features to the new os log APIs.

### DIFF
--- a/stdlib/private/OSLog/CMakeLists.txt
+++ b/stdlib/private/OSLog/CMakeLists.txt
@@ -9,6 +9,7 @@ add_swift_target_library(swiftOSLogPrototype
   OSLogIntegerTypes.swift
   OSLogStringTypes.swift
   OSLogNSObjectType.swift
+  OSLogFloatingPointTypes.swift
 
   SWIFT_MODULE_DEPENDS_IOS Darwin os ObjectiveC
   SWIFT_MODULE_DEPENDS_OSX Darwin os ObjectiveC

--- a/stdlib/private/OSLog/OSLog.swift
+++ b/stdlib/private/OSLog/OSLog.swift
@@ -2,13 +2,13 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
-//===-----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 // This file contains the new swift APIs for OS log that accept string
 // interpolations. This is a prototype meant for experimentation and testing.

--- a/stdlib/private/OSLog/OSLogFloatingPointTypes.swift
+++ b/stdlib/private/OSLog/OSLogFloatingPointTypes.swift
@@ -1,0 +1,145 @@
+//===----------------- OSLogFloatingPointTypes.swift ----------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This file defines extensions for interpolating floating-point expressions
+// into an OSLogMesage. It defines `appendInterpolation` functions for standard
+// floating-point types. It also defines extensions for serializing floating-
+// point types into the argument buffer passed to os_log ABIs.
+//
+// The `appendInterpolation` functions defined in this file accept privacy
+// options along with the interpolated expression as shown below:
+// TODO: support floating-point formatting options.
+//
+//    "\(x, privacy: .private\)"
+
+extension OSLogInterpolation {
+
+  /// Define interpolation for expressions of type Float.
+  /// - Parameters:
+  ///  - number: the interpolated expression of type Float, which is autoclosured.
+  ///  - privacy: a privacy qualifier which is either private or public.
+  ///    It is auto-inferred by default.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public mutating func appendInterpolation(
+    _ number: @autoclosure @escaping () -> Float,
+    privacy: OSLogPrivacy = .auto
+  ) {
+    appendInterpolation(Double(number()), privacy: privacy)
+  }
+
+  /// Define interpolation for expressions of type Double.
+  /// - Parameters:
+  ///  - number: the interpolated expression of type Double, which is autoclosured.
+  ///  - privacy: a privacy qualifier which is either private or public.
+  ///    It is auto-inferred by default.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public mutating func appendInterpolation(
+    _ number: @autoclosure @escaping () -> Double,
+    privacy: OSLogPrivacy = .auto
+  ) {
+    guard argumentCount < maxOSLogArgumentCount else { return }
+
+    formatString += getDoubleFormatSpecifier(privacy: privacy)
+    addDoubleHeaders(privacy)
+
+    arguments.append(number)
+    argumentCount += 1
+  }
+
+  /// Update preamble and append argument headers based on the parameters of
+  /// the interpolation.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  internal mutating func addDoubleHeaders(_ privacy: OSLogPrivacy) {
+    // Append argument header.
+    let argumentHeader = getArgumentHeader(privacy: privacy, type: .scalar)
+    arguments.append(argumentHeader)
+
+    // Append number of bytes needed to serialize the argument.
+    let byteCount = doubleSizeInBytes()
+    arguments.append(UInt8(byteCount))
+
+    // Increment total byte size by the number of bytes needed for this
+    // argument, which is the sum of the byte size of the argument and
+    // two bytes needed for the headers.
+    totalBytesForSerializingArguments += byteCount + 2
+
+    preamble = getUpdatedPreamble(privacy: privacy, isScalar: true)
+  }
+
+  /// Construct an os_log format specifier from the given parameters.
+  /// This function must be constant evaluable and all its arguments
+  /// must be known at compile time.
+  @inlinable
+  @_semantics("constant_evaluable")
+  @_effects(readonly)
+  @_optimize(none)
+  internal func getDoubleFormatSpecifier(privacy: OSLogPrivacy) -> String {
+    // TODO: this will become more sophisticated when floating-point formatting
+    // options are supported.
+    var specifier = "%"
+    switch privacy {
+    case .private:
+      specifier += "{private}"
+    case .public:
+      specifier += "{public}"
+    default:
+      break
+    }
+    specifier += "f"
+    return specifier
+  }
+}
+
+extension OSLogArguments {
+  /// Append an (autoclosured) interpolated expression of Double type, passed to
+  /// `OSLogMessage.appendInterpolation`, to the array of closures tracked
+  /// by this instance.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  internal mutating func append(_ value: @escaping () -> Double) {
+    argumentClosures.append({ (position, _) in
+      serialize(value(), at: &position)
+    })
+  }
+}
+
+/// Return the number of bytes needed for serializing a double argument as
+/// specified by os_log. Note that this is marked transparent instead of
+/// @inline(__always) as it is used in optimize(none) functions.
+@_transparent
+@usableFromInline
+internal func doubleSizeInBytes() -> Int {
+  return 8
+}
+
+/// Serialize a double at the buffer location that `position` points to and
+/// increment `position` by the byte size of the double.
+@inlinable
+@_alwaysEmitIntoClient
+@inline(__always)
+internal func serialize(
+  _ value: Double,
+  at bufferPosition: inout ByteBufferPointer
+) {
+  let byteCount = doubleSizeInBytes()
+  let dest =
+    UnsafeMutableRawBufferPointer(start: bufferPosition, count: byteCount)
+  withUnsafeBytes(of: value) { dest.copyMemory(from: $0) }
+  bufferPosition += byteCount
+}

--- a/stdlib/private/OSLog/OSLogIntegerFormatting.swift
+++ b/stdlib/private/OSLog/OSLogIntegerFormatting.swift
@@ -1,3 +1,18 @@
+//===----------------- OSLogIntegerFormatting.swift -----------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This file defines types and functions for specifying formatting of
+// integer-valued interpolations passed to the os log APIs.
+
 @frozen
 public struct OSLogIntegerFormatting: Equatable {
   /// The base to use for the string representation. `radix` must be at least 2
@@ -261,11 +276,8 @@ extension OSLogIntegerFormatting {
     // IEEE: `-` The result of the conversion shall be left-justified within
     // the field. The conversion is right-justified if this flag is not
     // specified.
-    switch align.anchor {
-    case OSLogCollectionBound.start:
-        specification += "-"
-    default:
-        break
+    if case .start = align.anchor {
+      specification += "-"
     }
 
     // 2. Minimumn field width

--- a/stdlib/private/OSLog/OSLogIntegerTypes.swift
+++ b/stdlib/private/OSLog/OSLogIntegerTypes.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,15 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-// This file defines extensions for interpolating integer expressions into a
+// This file defines extensions for interpolating integer expressions into an
 // OSLogMesage. It defines `appendInterpolation` functions for standard integer
 // types. It also defines extensions for serializing integer types into the
 // argument buffer passed to os_log ABIs.
 //
-// The `appendInterpolation` functions defined in this file accept formatting
-// and privacy options along with the interpolated expression as shown below:
+// The `appendInterpolation` functions defined in this file accept formatting,
+// privacy and alignment options along with the interpolated expression as
+// shown below:
 //
-//         "\(x, format: .hex, privacy: .private\)"
+//  1.  "\(x, format: .hex, privacy: .private, align: .right\)"
+//  2.  "\(x, format: .hex(minDigits: 10), align: .right(columns: 10)\)"
 
 extension OSLogInterpolation {
 
@@ -26,9 +28,11 @@ extension OSLogInterpolation {
   /// - Parameters:
   ///  - number: the interpolated expression of type Int, which is autoclosured.
   ///  - format: a formatting option available for integer types, defined by the
-  ///    enum `OSLogIntegerFormatting`.
+  ///    type`OSLogIntegerFormatting`. The default is .decimal.
+  ///  - align: left or right alignment with the minimum number of columns as
+  ///    defined by the type `OSLogStringAlignment`.
   ///  - privacy: a privacy qualifier which is either private or public.
-  ///    The default is public.
+  ///    It is auto-inferred by default.
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
@@ -36,7 +40,7 @@ extension OSLogInterpolation {
     _ number: @autoclosure @escaping () -> Int,
     format: OSLogIntegerFormatting = .decimal,
     align: OSLogStringAlignment = .none,
-    privacy: OSLogPrivacy = .public
+    privacy: OSLogPrivacy = .auto
   ) {
     appendInteger(number, format: format, align: align, privacy: privacy)
   }
@@ -45,9 +49,11 @@ extension OSLogInterpolation {
   /// - Parameters:
   ///  - number: the interpolated expression of type Int32, which is autoclosured.
   ///  - format: a formatting option available for integer types, defined by the
-  ///    enum `OSLogIntegerFormatting`.
+  ///    type `OSLogIntegerFormatting`.
+  ///  - align: left or right alignment with the minimum number of columns as
+  ///    defined by the type `OSLogStringAlignment`.
   ///  - privacy: a privacy qualifier which is either private or public.
-  ///    The default is public.
+  ///    It is auto-inferred by default.
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
@@ -55,7 +61,7 @@ extension OSLogInterpolation {
     _ number: @autoclosure @escaping () -> Int32,
     format: OSLogIntegerFormatting = .decimal,
     align: OSLogStringAlignment = .none,
-    privacy: OSLogPrivacy = .public
+    privacy: OSLogPrivacy = .auto
   ) {
     appendInteger(number, format: format, align: align, privacy: privacy)
   }
@@ -64,9 +70,11 @@ extension OSLogInterpolation {
   /// - Parameters:
   ///  - number: the interpolated expression of type UInt, which is autoclosured.
   ///  - format: a formatting option available for integer types, defined by the
-  ///    enum `OSLogIntegerFormatting`.
+  ///    type `OSLogIntegerFormatting`.
+  ///  - align: left or right alignment with the minimum number of columns as
+  ///    defined by the type `OSLogStringAlignment`.
   ///  - privacy: a privacy qualifier which is either private or public.
-  ///    The default is public.
+  ///    It is auto-inferred by default.
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
@@ -74,7 +82,7 @@ extension OSLogInterpolation {
     _ number: @autoclosure @escaping () -> UInt,
     format: OSLogIntegerFormatting = .decimal,
     align: OSLogStringAlignment = .none,
-    privacy: OSLogPrivacy = .public
+    privacy: OSLogPrivacy = .auto
   ) {
     appendInteger(number, format: format, align: align, privacy: privacy)
   }
@@ -94,9 +102,7 @@ extension OSLogInterpolation {
     guard argumentCount < maxOSLogArgumentCount else { return }
     formatString +=
       format.formatSpecifier(for: T.self, align: align, privacy: privacy)
-
-    let isPrivateArgument = isPrivate(privacy)
-    addIntHeaders(isPrivateArgument, sizeForEncoding(T.self))
+    addIntHeaders(privacy, sizeForEncoding(T.self))
 
     arguments.append(number)
     argumentCount += 1
@@ -107,9 +113,12 @@ extension OSLogInterpolation {
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
-  internal mutating func addIntHeaders(_ isPrivate: Bool, _ byteCount: Int) {
+  internal mutating func addIntHeaders(
+    _ privacy: OSLogPrivacy,
+    _ byteCount: Int
+  ) {
     // Append argument header.
-    let argumentHeader = getArgumentHeader(isPrivate: isPrivate, type: .scalar)
+    let argumentHeader = getArgumentHeader(privacy: privacy, type: .scalar)
     arguments.append(argumentHeader)
 
     // Append number of bytes needed to serialize the argument.
@@ -120,7 +129,7 @@ extension OSLogInterpolation {
     // two bytes needed for the headers.
     totalBytesForSerializingArguments += byteCount + 2
 
-    preamble = getUpdatedPreamble(isPrivate: isPrivate, isScalar: true)
+    preamble = getUpdatedPreamble(privacy: privacy, isScalar: true)
   }
 }
 

--- a/stdlib/private/OSLog/OSLogNSObjectType.swift
+++ b/stdlib/private/OSLog/OSLogNSObjectType.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,14 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-// This file defines extensions for interpolating NSObject into a OSLogMesage.
+// This file defines extensions for interpolating NSObject into an OSLogMesage.
 // It defines `appendInterpolation` function for NSObject type. It also defines
 // extensions for generating an os_log format string for NSObjects (using the
 // format specifier %@) and for serializing NSObject into the argument buffer
 // passed to os_log ABIs.
 //
-// The `appendInterpolation` function defined in this file accept formatting
-// and privacy options along with the interpolated expression as shown below:
+// The `appendInterpolation` function defined in this file accept privacy
+// options along with the interpolated expression as shown below:
 //
 //         "\(x, privacy: .public\)"
 import ObjectiveC
@@ -27,20 +27,19 @@ extension OSLogInterpolation {
   /// Define interpolation for expressions of type NSObject.
   /// - Parameters:
   ///  - argumentObject: the interpolated expression of type NSObject, which is autoclosured.
-  ///  - privacy: a privacy qualifier which is either private or public. Default is private.
-  ///  TODO: create a specifier to denote auto-inferred privacy level and make it default.
+  ///  - privacy: a privacy qualifier which is either private or public.
+  ///  It is auto-inferred by default.
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
   public mutating func appendInterpolation(
     _ argumentObject: @autoclosure @escaping () -> NSObject,
-    privacy: OSLogPrivacy = .private
+    privacy: OSLogPrivacy = .auto
   ) {
     guard argumentCount < maxOSLogArgumentCount else { return }
 
-    let isPrivateArgument = isPrivate(privacy)
-    formatString += getNSObjectFormatSpecifier(isPrivateArgument)
-    addNSObjectHeaders(isPrivateArgument)
+    formatString += getNSObjectFormatSpecifier(privacy)
+    addNSObjectHeaders(privacy)
 
     arguments.append(argumentObject)
     argumentCount += 1
@@ -51,9 +50,9 @@ extension OSLogInterpolation {
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
-  internal mutating func addNSObjectHeaders(_ isPrivate: Bool) {
+  internal mutating func addNSObjectHeaders(_ privacy: OSLogPrivacy) {
     // Append argument header.
-    let header = getArgumentHeader(isPrivate: isPrivate, type: .object)
+    let header = getArgumentHeader(privacy: privacy, type: .object)
     arguments.append(header)
 
     // Append number of bytes needed to serialize the argument.
@@ -65,7 +64,7 @@ extension OSLogInterpolation {
     // two bytes needed for the headers.
     totalBytesForSerializingArguments += byteCount + 2
 
-    preamble = getUpdatedPreamble(isPrivate: isPrivate, isScalar: false)
+    preamble = getUpdatedPreamble(privacy: privacy, isScalar: false)
   }
 
   /// Construct an os_log format specifier from the given parameters.
@@ -75,9 +74,15 @@ extension OSLogInterpolation {
   @_semantics("constant_evaluable")
   @_effects(readonly)
   @_optimize(none)
-  internal func getNSObjectFormatSpecifier(_ isPrivate: Bool) -> String {
-    // TODO: create a specifier to denote auto-inferred privacy.
-    return isPrivate ? "%{private}@" : "%{public}@"
+  internal func getNSObjectFormatSpecifier(_ privacy: OSLogPrivacy) -> String {
+    switch privacy {
+    case .private:
+      return "%{private}@"
+    case .public:
+      return "%{public}@"
+    default:
+      return "%@"
+    }
   }
 }
 

--- a/stdlib/private/OSLog/OSLogStringAlignment.swift
+++ b/stdlib/private/OSLog/OSLogStringAlignment.swift
@@ -1,3 +1,18 @@
+//===----------------- OSLogStringAlignment.swift -------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This file defines types and functions for specifying alignment of the
+// interpolations passed to the os log APIs.
+
 @frozen
 public enum OSLogCollectionBound {
   case start

--- a/stdlib/private/OSLog/OSLogStringTypes.swift
+++ b/stdlib/private/OSLog/OSLogStringTypes.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,40 +10,40 @@
 //
 //===----------------------------------------------------------------------===//
 
-// This file defines extensions for interpolating strings into a OSLogMesage.
+// This file defines extensions for interpolating strings into an OSLogMesage.
 // It defines `appendInterpolation` function for String type. It also defines
 // extensions for serializing strings into the argument buffer passed to
 // os_log ABIs. Note that os_log requires passing a stable pointer to an
 // interpolated string. The SPI: `_convertConstStringToUTF8PointerArgument`
 // is used to construct a stable pointer to a (dynamic) string.
 //
-// The `appendInterpolation` function defined in this file accept formatting
-// and privacy options along with the interpolated expression as shown below:
+// The `appendInterpolation` function defined in this file accept privacy and
+// alignment options along with the interpolated expression as shown below:
 //
-//         "\(x, privacy: .public\)"
-//
-// TODO: support formatting options such as left and right padding
-// (e.g. %10s, %-10s).
+//  1.  "\(x, privacy: .private, align: .right\)"
+//  2.  "\(x, align: .right(columns: 10)\)"
 
 extension OSLogInterpolation {
 
   /// Define interpolation for expressions of type String.
   /// - Parameters:
   ///  - argumentString: the interpolated expression of type String, which is autoclosured.
-  ///  - privacy: a privacy qualifier which is either private or public. Default is private.
-  ///  TODO: create a specifier to denote auto-inferred privacy level and make it default.
+  ///  - align: left or right alignment with the minimum number of columns as
+  ///    defined by the type `OSLogStringAlignment`.
+  ///  - privacy: a privacy qualifier which is either private or public.
+  ///  It is auto-inferred by default.
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
   public mutating func appendInterpolation(
     _ argumentString: @autoclosure @escaping () -> String,
-    privacy: OSLogPrivacy = .private
+    align: OSLogStringAlignment = .none,
+    privacy: OSLogPrivacy = .auto
   ) {
     guard argumentCount < maxOSLogArgumentCount else { return }
 
-    let isPrivateArgument = isPrivate(privacy)
-    formatString += getStringFormatSpecifier(isPrivateArgument)
-    addStringHeaders(isPrivateArgument)
+    formatString += getStringFormatSpecifier(align, privacy)
+    addStringHeaders(privacy)
 
     arguments.append(argumentString)
     argumentCount += 1
@@ -54,9 +54,9 @@ extension OSLogInterpolation {
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
-  internal mutating func addStringHeaders(_ isPrivate: Bool) {
+  internal mutating func addStringHeaders(_ privacy: OSLogPrivacy) {
     // Append argument header.
-    let header = getArgumentHeader(isPrivate: isPrivate, type: .string)
+    let header = getArgumentHeader(privacy: privacy, type: .string)
     arguments.append(header)
 
     // Append number of bytes needed to serialize the argument.
@@ -68,7 +68,7 @@ extension OSLogInterpolation {
     // two bytes needed for the headers.
     totalBytesForSerializingArguments += byteCount + 2
 
-    preamble = getUpdatedPreamble(isPrivate: isPrivate, isScalar: false)
+    preamble = getUpdatedPreamble(privacy: privacy, isScalar: false)
   }
 
   /// Construct an os_log format specifier from the given parameters.
@@ -78,9 +78,27 @@ extension OSLogInterpolation {
   @_semantics("constant_evaluable")
   @_effects(readonly)
   @_optimize(none)
-  internal func getStringFormatSpecifier(_ isPrivate: Bool) -> String {
-    // TODO: create a specifier to denote auto-inferred privacy.
-    return isPrivate ? "%{private}s" : "%{public}s"
+  internal func getStringFormatSpecifier(
+    _ align: OSLogStringAlignment,
+    _ privacy: OSLogPrivacy
+  ) -> String {
+    var specifier = "%"
+    switch privacy {
+    case .private:
+      specifier += "{private}"
+    case .public:
+      specifier += "{public}"
+    default:
+      break
+    }
+    if case .start = align.anchor {
+      specifier += "-"
+    }
+    if align.minimumColumnWidth > 0 {
+      specifier += align.minimumColumnWidth.description
+    }
+    specifier += "s"
+    return specifier
   }
 }
 

--- a/test/SILOptimizer/OSLogConstantEvaluableTest.swift
+++ b/test/SILOptimizer/OSLogConstantEvaluableTest.swift
@@ -41,7 +41,7 @@ func intValueInterpolationTest() -> OSLogMessage {
 
 // CHECK-LABEL: @init(literalCapacity: Int, interpolationCount: Int) -> OSLogInterpolation
 // CHECK-NOT: error:
-// CHECK-LABEL: @appendInterpolation(_: @autoclosure () -> String, privacy: OSLogPrivacy) -> ()
+// CHECK-LABEL: @appendInterpolation(_: @autoclosure () -> String, align: OSLogStringAlignment, privacy: OSLogPrivacy) -> ()
 // CHECK-NOT: error:
 @_semantics("test_driver")
 func stringValueInterpolationTest() -> OSLogMessage {

--- a/test/SILOptimizer/OSLogPrototypeCompileDiagnostics.swift
+++ b/test/SILOptimizer/OSLogPrototypeCompileDiagnostics.swift
@@ -11,6 +11,9 @@ import OSLogPrototype
 
 if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
 
+  // The following tests check the diagnostics for when the APIs are not invoked
+  // with constants needed for generating a static format string.
+
   func testDynamicLogMessage(h: Logger, message: OSLogMessage) {
     // FIXME: log APIs must always be passed a string interpolation literal.
     // Diagnose this.

--- a/test/SILOptimizer/OSLogPrototypeCompileTest.swift
+++ b/test/SILOptimizer/OSLogPrototypeCompileTest.swift
@@ -27,7 +27,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     // CHECK-DAG: [[STRING3]] = begin_borrow [[STRING4:%[0-9]+]]
     // CHECK-DAG: [[STRING4]] = apply [[STRING_INIT:%[0-9]+]]([[LIT:%[0-9]+]],
     // CHECK-DAG: [[STRING_INIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
-    // CHECK-DAG: [[LIT]] = string_literal utf8 "Minimum integer value: %{public}ld"
+    // CHECK-DAG: [[LIT]] = string_literal utf8 "Minimum integer value: %ld"
 
     // Check if the size of the argument buffer is a constant.
 
@@ -77,7 +77,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     // CHECK-DAG: [[STRING3]] = begin_borrow [[STRING4:%[0-9]+]]
     // CHECK-DAG: [[STRING4]] = apply [[STRING_INIT:%[0-9]+]]([[LIT:%[0-9]+]],
     // CHECK-DAG: [[STRING_INIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
-    // CHECK-DAG: [[LIT]] = string_literal utf8 "Maximum unsigned integer value: %{public}lx"
+    // CHECK-DAG: [[LIT]] = string_literal utf8 "Maximum unsigned integer value: %lx"
 
     // Check if the size of the argument buffer is a constant.
 
@@ -174,7 +174,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     h.log(
       level: .error,
       """
-      Access prevented: process \(pid) initiated by \
+      Access prevented: process \(pid, privacy: .public) initiated by \
       user: \(privateID, privacy: .private) attempted resetting \
       permissions to \(filePermissions, format: .octal)
       """)
@@ -187,7 +187,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     // CHECK-DAG: [[STRING3]] = begin_borrow [[STRING4:%[0-9]+]]
     // CHECK-DAG: [[STRING4]] = apply [[STRING_INIT:%[0-9]+]]([[LIT:%[0-9]+]],
     // CHECK-DAG: [[STRING_INIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
-    // CHECK-DAG: [[LIT]] = string_literal utf8 "Access prevented: process %{public}ld initiated by user: %{private}ld attempted resetting permissions to %{public}lo"
+    // CHECK-DAG: [[LIT]] = string_literal utf8 "Access prevented: process %{public}ld initiated by user: %{private}ld attempted resetting permissions to %lo"
 
     // Check if the size of the argument buffer is a constant.
 
@@ -335,7 +335,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     // CHECK-DAG: [[STRING3]] = begin_borrow [[STRING4:%[0-9]+]]
     // CHECK-DAG: [[STRING4]] = apply [[STRING_INIT:%[0-9]+]]([[LIT:%[0-9]+]],
     // CHECK-DAG: [[STRING_INIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
-    // CHECK-DAG: [[LIT]] = string_literal utf8 "%{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld "
+    // CHECK-DAG: [[LIT]] = string_literal utf8 "%ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld "
 
     // Check if the size of the argument buffer is a constant.
 
@@ -383,7 +383,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     // CHECK-DAG: [[STRING3]] = begin_borrow [[STRING4:%[0-9]+]]
     // CHECK-DAG: [[STRING4]] = apply [[STRING_INIT:%[0-9]+]]([[LIT:%[0-9]+]],
     // CHECK-DAG: [[STRING_INIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
-    // CHECK-DAG: [[LIT]] = string_literal utf8 "32-bit integer value: %{public}d"
+    // CHECK-DAG: [[LIT]] = string_literal utf8 "32-bit integer value: %d"
 
     // Check if the size of the argument buffer is a constant.
 
@@ -516,6 +516,57 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
       // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>([[ARRAYSIZE:%[0-9]+]])
       // CHECK-DAG: [[ARRAYINIT]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
       // CHECK-DAG: [[ARRAYSIZE]] = integer_literal $Builtin.Word, 6
+  }
+
+  // CHECK-LABEL: @${{.*}}testDoubleInterpolationL_
+  func testDoubleInterpolation(h: Logger) {
+    let twoPi = 2 * 3.14
+    h.log("Tau = \(twoPi)")
+      // Check if there is a call to _os_log_impl with a literal format string.
+      // CHECK-DAG is used here as it is easier to perform the checks backwards
+      // from uses to the definitions.
+
+      // CHECK-DAG: builtin "globalStringTablePointer"([[STRING:%[0-9]+]] : $String)
+      // CHECK-DAG: [[STRING]] = begin_borrow [[STRING2:%[0-9]+]]
+      // CHECK-DAG: [[STRING2]] = copy_value [[STRING3:%[0-9]+]]
+      // CHECK-DAG: [[STRING3]] = begin_borrow [[STRING4:%[0-9]+]]
+      // CHECK-DAG: [[STRING4]] = apply [[STRING_INIT:%[0-9]+]]([[LIT:%[0-9]+]],
+      // CHECK-DAG: [[STRING_INIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
+      // CHECK-DAG: [[LIT]] = string_literal utf8 "Tau = %f"
+
+      // Check if the size of the argument buffer is a constant.
+
+      // CHECK-DAG: [[ALLOCATE:%[0-9]+]] = function_ref @$sSp8allocate8capacitySpyxGSi_tFZ
+      // CHECK-DAG: apply [[ALLOCATE]]<UInt8>([[BUFFERSIZE:%[0-9]+]], {{%.*}})
+      // CHECK-DAG: [[BUFFERSIZE]] = struct $Int ([[BUFFERSIZELIT:%[0-9]+]]
+      // CHECK-64-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int64, 12
+      // CHECK-32-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int32, 12
+
+      // Check whether the header bytes: premable and argument count are constants.
+
+      // CHECK-DAG: [[SERIALIZE:%[0-9]+]] = function_ref @$s14OSLogPrototype9serialize_2atys5UInt8V_SpyAEGztF
+      // CHECK-DAG: apply [[SERIALIZE]]([[PREAMBLE:%[0-9]+]], {{%.*}})
+      // CHECK-DAG: [[PREAMBLE]] =  struct $UInt8 ([[PREAMBLELIT:%[0-9]+]] : $Builtin.Int8)
+      // CHECK-DAG: [[PREAMBLELIT]] = integer_literal $Builtin.Int8, 0
+
+      // CHECK-DAG: [[SERIALIZE:%[0-9]+]] = function_ref @$s14OSLogPrototype9serialize_2atys5UInt8V_SpyAEGztF
+      // CHECK-DAG: apply [[SERIALIZE]]([[ARGCOUNT:%[0-9]+]], {{%.*}})
+      // CHECK-DAG: [[ARGCOUNT]] =  struct $UInt8 ([[ARGCOUNTLIT:%[0-9]+]] : $Builtin.Int8)
+      // CHECK-DAG: [[ARGCOUNTLIT]] = integer_literal $Builtin.Int8, 1
+
+      // Check whether argument array is folded. The contents of the array is
+      // not checked here, but is checked by a different test suite.
+
+      // CHECK-DAG: [[FOREACH:%[0-9]+]] = function_ref @$sSTsE7forEachyyy7ElementQzKXEKF
+      // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>>({{%.*}}, [[ARGSARRAYADDR:%[0-9]+]])
+      // CHECK-DAG: store_borrow [[ARGSARRAY2:%[0-9]+]] to [[ARGSARRAYADDR]]
+      // CHECK-DAG: [[ARGSARRAY2]] = begin_borrow [[ARGSARRAY3:%[0-9]+]]
+      // CHECK-DAG: [[ARGSARRAY3]] = copy_value [[ARGSARRAY4:%[0-9]+]]
+      // CHECK-DAG: [[ARGSARRAY4]] = begin_borrow [[ARGSARRAY:%[0-9]+]]
+      // CHECK-DAG: ([[ARGSARRAY]], {{%.*}}) = destructure_tuple [[ARRAYINITRES:%[0-9]+]]
+      // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>([[ARRAYSIZE:%[0-9]+]])
+      // CHECK-DAG: [[ARRAYINIT]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
+      // CHECK-DAG: [[ARRAYSIZE]] = integer_literal $Builtin.Word, 3
   }
 
   // CHECK-LABEL: @${{.*}}testDeadCodeEliminationL_

--- a/test/SILOptimizer/OSLogPrototypeFullOptTest.swift
+++ b/test/SILOptimizer/OSLogPrototypeFullOptTest.swift
@@ -35,7 +35,7 @@ func testSimpleInterpolation(h: Logger) {
     // Argument bytes.
     //
     // CHECK-NEXT: [[OFFSET2:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 2
-    // CHECK-NEXT: store i8 2, i8* [[OFFSET2]], align 1
+    // CHECK-NEXT: store i8 0, i8* [[OFFSET2]], align 1
     // CHECK-NEXT: [[OFFSET3:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 3
     // CHECK-64-NEXT: store i8 8, i8* [[OFFSET3]], align 1
     // CHECK-32-NEXT: store i8 4, i8* [[OFFSET3]], align 1
@@ -43,8 +43,8 @@ func testSimpleInterpolation(h: Logger) {
     // CHECK-NEXT: [[BITCASTED:%.+]] = bitcast i8* [[OFFSET4]] to i{{.*}}*
     // CHECK-64-NEXT: store i64 -9223372036854775808, i64* [[BITCASTED]], align 1
     // CHECK-32-NEXT: store i32 -2147483648, i32* [[BITCASTED]], align 1
-    // CHECK-64-NEXT: tail call void @_os_log_impl({{.*}}, {{.*}} [[LOGOBJ]], i8 zeroext [[LOGLEVEL]], i8* getelementptr inbounds ([35 x i8], [35 x i8]* @{{.*}}, i64 0, i64 0), i8* {{(nonnull )?}}[[BUFFER]], i32 12)
-    // CHECK-32-NEXT: tail call void @_os_log_impl({{.*}}, {{.*}} [[LOGOBJ]], i8 zeroext [[LOGLEVEL]], i8* getelementptr inbounds ([35 x i8], [35 x i8]* @{{.*}}, i32 0, i32 0), i8* {{(nonnull )?}}[[BUFFER]], i32 8)
+    // CHECK-64-NEXT: tail call void @_os_log_impl({{.*}}, {{.*}} [[LOGOBJ]], i8 zeroext [[LOGLEVEL]], i8* getelementptr inbounds ([27 x i8], [27 x i8]* @{{.*}}, i64 0, i64 0), i8* {{(nonnull )?}}[[BUFFER]], i32 12)
+    // CHECK-32-NEXT: tail call void @_os_log_impl({{.*}}, {{.*}} [[LOGOBJ]], i8 zeroext [[LOGLEVEL]], i8* getelementptr inbounds ([27 x i8], [27 x i8]* @{{.*}}, i32 0, i32 0), i8* {{(nonnull )?}}[[BUFFER]], i32 8)
     // CHECK-NEXT: tail call void @swift_slowDealloc(i8* {{(nonnull )?}}[[BUFFER]]
     // CHECK-NEXT: br label %[[NOT_ENABLED]]
 
@@ -63,7 +63,7 @@ func testInterpolationWithMultipleArguments(h: Logger) {
   h.log(
     level: .error,
     """
-    Access prevented: process \(pid) initiated by \
+    Access prevented: process \(pid, privacy: .public) initiated by \
     user: \(privateID, privacy: .private) attempted resetting \
     permissions to \(filePermissions)
     """)
@@ -106,7 +106,7 @@ func testInterpolationWithMultipleArguments(h: Logger) {
     // Third argument
     //
     // CHECK-NEXT: [[OFFSET22:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 14
-    // CHECK-NEXT: store i8 2, i8* [[OFFSET22]], align 1
+    // CHECK-NEXT: store i8 0, i8* [[OFFSET22]], align 1
     // CHECK-NEXT: [[OFFSET23:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 15
     // CHECK-NEXT: store i8 4, i8* [[OFFSET23]], align 1
     // CHECK-NEXT: [[OFFSET24:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 16
@@ -114,7 +114,7 @@ func testInterpolationWithMultipleArguments(h: Logger) {
     // CHECK-NEXT: store i32 511, i32* [[BITCASTED3]], align 1
     //
     // os_log_impl call.
-    // CHECK-NEXT: tail call void @_os_log_impl({{.*}}, {{.*}} [[LOGOBJ]], i8 zeroext [[LOGLEVEL]], i8* getelementptr inbounds ([114 x i8], [114 x i8]* @{{.*}}, i{{.*}} 0, i{{.*}} 0), i8* {{(nonnull )?}}[[BUFFER]], i32 20)
+    // CHECK-NEXT: tail call void @_os_log_impl({{.*}}, {{.*}} [[LOGOBJ]], i8 zeroext [[LOGLEVEL]], i8* getelementptr inbounds ([106 x i8], [106 x i8]* @{{.*}}, i{{.*}} 0, i{{.*}} 0), i8* {{(nonnull )?}}[[BUFFER]], i32 20)
     // CHECK-NEXT: tail call void @swift_slowDealloc(i8* {{(nonnull )?}}[[BUFFER]]
     // CHECK-NEXT: br label %[[NOT_ENABLED]]
 
@@ -169,6 +169,45 @@ func testNSObjectInterpolation(h: Logger, nsArray: NSArray) {
 
     // CHECK: [[NOT_ENABLED]]:
     // CHECK-NEXT: tail call void @llvm.objc.release(i8* [[NSARRAY_ARG]])
+    // CHECK-NEXT: bitcast
+    // CHECK-NEXT: tail call void @llvm.objc.release
+    // CHECK-NEXT: ret void
+}
+
+// CHECK-LABEL: define hidden swiftcc void @"${{.*}}testFloatInterpolation
+@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+func testFloatInterpolation(h: Logger, doubleValue: Double) {
+  h.info("Double value: \(doubleValue)")
+    // CHECK: entry:
+    // CHECK-NEXT: tail call swiftcc %TSo9OS_os_logC* @"$s14OSLogPrototype6LoggerV9logObjectSo06OS_os_D0Cvg"
+    // CHECK-NEXT: [[LOGLEVEL:%.+]] = tail call swiftcc i8 @"$sSo13os_log_type_ta0A0E4infoABvgZ"()
+    // CHECK-NEXT: [[LOGOBJ:%.+]] = bitcast %TSo9OS_os_logC*
+    // CHECK-NEXT: tail call zeroext i1 @os_log_type_enabled
+    // CHECK-NEXT: br i1 {{%.*}}, label %[[ENABLED:[0-9]+]], label %[[NOT_ENABLED:[0-9]+]]
+
+    // CHECK: [[ENABLED]]:
+    //
+    // Header bytes.
+    //
+    // CHECK-NEXT: [[BUFFER:%.+]] = tail call noalias i8* @swift_slowAlloc(i{{.*}} 12
+    // CHECK-NEXT: store i8 0, i8* [[BUFFER]], align 1
+    // CHECK-NEXT: [[OFFSET1:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 1
+    // CHECK-NEXT: store i8 1, i8* [[OFFSET1]], align 1
+    //
+    // Argument bytes.
+    //
+    // CHECK-NEXT: [[OFFSET2:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 2
+    // CHECK-NEXT: store i8 0, i8* [[OFFSET2]], align 1
+    // CHECK-NEXT: [[OFFSET3:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 3
+    // CHECK-NEXT: store i8 8, i8* [[OFFSET3]], align 1
+    // CHECK-NEXT: [[OFFSET4:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 4
+    // CHECK-NEXT: [[BITCASTED:%.+]] = bitcast i8* [[OFFSET4]] to double*
+    // CHECK-NEXT: store double %1, double* [[BITCASTED]], align 1
+    // CHECK-NEXT: tail call void @_os_log_impl({{.*}}, {{.*}} [[LOGOBJ]], i8 zeroext [[LOGLEVEL]], i8* getelementptr inbounds ([17 x i8], [17 x i8]* @{{.*}}, i{{.*}} 0, i{{.*}} 0), i8* {{(nonnull )?}}[[BUFFER]], i32 12)
+    // CHECK-NEXT: tail call void @swift_slowDealloc(i8* {{(nonnull )?}}[[BUFFER]]
+    // CHECK-NEXT: br label %[[NOT_ENABLED]]
+
+    // CHECK: [[NOT_ENABLED]]:
     // CHECK-NEXT: bitcast
     // CHECK-NEXT: tail call void @llvm.objc.release
     // CHECK-NEXT: ret void

--- a/test/stdlib/OSLogPrototypeExecTest.swift
+++ b/test/stdlib/OSLogPrototypeExecTest.swift
@@ -144,6 +144,48 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     let nsDictionary: NSDictionary = [1 : ""]
     h.log("NS Dictionary: \(nsDictionary, privacy: .public)")
   }
+
+  OSLogTestSuite.test("integer formatting") {
+    let h = Logger()
+
+    let unsignedOctal: UInt = 0o171
+    // format specifier "0o%lo" output: "0o171"
+    h.log("\(unsignedOctal, format: .octal(includePrefix: true))")
+
+    // format specifier: "%lX" output: "DEADBEEF"
+    let unsignedValue: UInt = 0xdeadbeef
+    h.log("\(unsignedValue, format: .hex(uppercase: true))")
+
+    // format specifier: "%+ld" output: "+20"
+    h.log("\(20, format: .decimal(explicitPositiveSign: true))")
+
+    // format specifier: "+%lu" output: "+2"
+    h.log("\(UInt(2), format: .decimal(explicitPositiveSign: true))")
+
+    // format specifier: "%.10ld" output: "0000000010"
+    h.log("\(10, format: .decimal(minDigits: 10))")
+
+    // format specifier: "%10ld" output: "        10"
+    h.log("\(10, align: .right(columns: 10))")
+
+    // format specifier: "%-5ld" output: "10   "
+    h.log("\(10, align: .left(columns: 5))")
+  }
+
+  OSLogTestSuite.test("string formatting") {
+    let h = Logger()
+    let smallString = "a"
+    h.log("\(smallString, align: .right(columns: 10), privacy: .public)")
+  }
+
+  OSLogTestSuite.test("Floats and Doubles") {
+    let h = Logger()
+    let x = 1.2 + 0.5
+    let pi: Double = 3.141593
+    let floatPi: Float = 3.141593
+    h.log("A double value: \(x, privacy: .private)")
+    h.log("pi as double: \(pi), pi as float: \(floatPi)")
+  }
 }
 
 // The following tests check the correctness of the format string and the
@@ -198,6 +240,7 @@ internal struct OSLogBufferChecker {
   /// argument header. Two least significant bits are used to indicate privacy
   /// and the other two bits are reserved.
   internal enum ArgumentFlag: UInt8 {
+    case autoFlag = 0
     case privateFlag = 0x1
     case publicFlag = 0x2
   }
@@ -318,6 +361,29 @@ internal struct OSLogBufferChecker {
     }
   }
 
+  internal func checkDouble(
+    startIndex: Int,
+    flag: ArgumentFlag,
+    expectedValue: Double
+  ) {
+    let byteSize: UInt8 = 8
+    let argumentBytes =
+      checkArgumentHeadersAndGetBytes(
+        startIndex: startIndex,
+        size: byteSize,
+        flag: flag,
+        type: .scalar)
+    withUnsafeBytes(of: expectedValue) { expectedBytes in
+      for i in 0..<Int(byteSize) {
+        expectEqual(
+          expectedBytes[i],
+          argumentBytes[i],
+          "mismatch at byte number \(i) "
+            + "of the expected value \(expectedValue)")
+      }
+    }
+  }
+
   /// Check the given assertions on the arguments stored in the byte buffer.
   /// - Parameters:
   ///  - assertions: one assertion for each argument stored in the byte buffer.
@@ -345,7 +411,7 @@ InterpolationTestSuite.test("integer literal") {
     "An integer literal \(10)",
     with: { (formatString, buffer) in
     expectEqual(
-      "An integer literal %{public}ld",
+      "An integer literal %ld",
       formatString)
 
     let bufferChecker = OSLogBufferChecker(buffer)
@@ -355,7 +421,7 @@ InterpolationTestSuite.test("integer literal") {
       hasNonScalar: false)
 
     bufferChecker.checkArguments({
-      bufferChecker.checkInt(startIndex: $0, flag: .publicFlag, expectedInt: 10)
+      bufferChecker.checkInt(startIndex: $0, flag: .autoFlag, expectedInt: 10)
     })
   })
 }
@@ -365,7 +431,7 @@ InterpolationTestSuite.test("integer with formatting") {
     "Minimum integer value: \(UInt.max, format: .hex)",
     with: { (formatString, buffer) in
       expectEqual(
-        "Minimum integer value: %{public}lx",
+        "Minimum integer value: %lx",
         formatString)
 
       let bufferChecker = OSLogBufferChecker(buffer)
@@ -377,7 +443,7 @@ InterpolationTestSuite.test("integer with formatting") {
       bufferChecker.checkArguments({
         bufferChecker.checkInt(
           startIndex: $0,
-          flag: .publicFlag,
+          flag: .autoFlag,
           expectedInt: UInt.max)
       })
   })
@@ -414,7 +480,7 @@ InterpolationTestSuite.test("test multiple arguments") {
 
   _checkFormatStringAndBuffer(
     """
-    Access prevented: process \(pid) initiated by \
+    Access prevented: process \(pid, privacy: .public) initiated by \
     user: \(privateID, privacy: .private) attempted resetting \
     permissions to \(filePerms, format: .octal)
     """,
@@ -423,7 +489,7 @@ InterpolationTestSuite.test("test multiple arguments") {
         """
         Access prevented: process %{public}ld initiated by \
         user: %{private}ld attempted resetting permissions \
-        to %{public}lo
+        to %lo
         """,
         formatString)
 
@@ -449,7 +515,7 @@ InterpolationTestSuite.test("test multiple arguments") {
         {
           bufferChecker.checkInt(
           startIndex: $0,
-          flag: .publicFlag,
+          flag: .autoFlag,
           expectedInt: filePerms)
         })
   })
@@ -468,7 +534,7 @@ InterpolationTestSuite.test("interpolation of too many arguments") {
     with: { (formatString, buffer) in
       expectEqual(
         String(
-          repeating: "%{public}ld ",
+          repeating: "%ld ",
           count: Int(maxOSLogArgumentCount)),
         formatString)
 
@@ -483,7 +549,7 @@ InterpolationTestSuite.test("interpolation of too many arguments") {
           repeating: {
             bufferChecker.checkInt(
               startIndex: $0,
-              flag: .publicFlag,
+              flag: .autoFlag,
               expectedInt: 1) },
           count: Int(maxOSLogArgumentCount))
       )
@@ -508,7 +574,7 @@ InterpolationTestSuite.test("string interpolations with percents") {
 InterpolationTestSuite.test("integer types") {
   _checkFormatStringAndBuffer("Int32 max: \(Int32.max)") {
     (formatString, buffer) in
-    expectEqual("Int32 max: %{public}d", formatString)
+    expectEqual("Int32 max: %d", formatString)
 
     let bufferChecker = OSLogBufferChecker(buffer)
     bufferChecker.checkSummaryBytes(
@@ -519,7 +585,7 @@ InterpolationTestSuite.test("integer types") {
     bufferChecker.checkArguments({
       bufferChecker.checkInt(
         startIndex: $0,
-        flag: .publicFlag,
+        flag: .autoFlag,
         expectedInt: Int32.max)
     })
   }
@@ -529,17 +595,14 @@ InterpolationTestSuite.test("string arguments") {
   let small = "a"
   let large = "this is a large string"
   _checkFormatStringAndBuffer(
-    """
-    small: \(small, privacy: .public) \
-    large: \(large, privacy: .private)
-    """) {
+    "small: \(small, privacy: .public) large: \(large)") {
     (formatString, buffer) in
-      expectEqual("small: %{public}s large: %{private}s", formatString)
+      expectEqual("small: %{public}s large: %s", formatString)
 
     let bufferChecker = OSLogBufferChecker(buffer)
     bufferChecker.checkSummaryBytes(
       argumentCount: 2,
-      hasPrivate: true,
+      hasPrivate: false,
       hasNonScalar: true
     )
 
@@ -551,7 +614,7 @@ InterpolationTestSuite.test("string arguments") {
     },
     { bufferChecker.checkString(
       startIndex: $0,
-      flag: .privateFlag,
+      flag: .autoFlag,
       expectedString: large)
     })
   }
@@ -596,14 +659,14 @@ InterpolationTestSuite.test("NSObject") {
   _checkFormatStringAndBuffer(
     """
     NSArray: \(nsArray, privacy: .public) \
-    NSDictionary: \(nsDictionary, privacy: .private)
+    NSDictionary: \(nsDictionary)
     """) { (formatString, buffer) in
-      expectEqual("NSArray: %{public}@ NSDictionary: %{private}@", formatString)
+      expectEqual("NSArray: %{public}@ NSDictionary: %@", formatString)
 
       let bufferChecker = OSLogBufferChecker(buffer)
       bufferChecker.checkSummaryBytes(
         argumentCount: 2,
-        hasPrivate: true,
+        hasPrivate: false,
         hasNonScalar: true
       )
 
@@ -615,7 +678,7 @@ InterpolationTestSuite.test("NSObject") {
       },
       { bufferChecker.checkNSObject(
           startIndex: $0,
-          flag: .privateFlag,
+          flag: .autoFlag,
           expectedObject: nsDictionary)
       })
   }
@@ -639,6 +702,8 @@ InterpolationTestSuite.test("Interpolation of complex expressions") {
       }
     }
   }
+  class B : TestProto { }
+  TestClass<B>().testFunction()
 }
 
 InterpolationTestSuite.test("Include prefix formatting option") {
@@ -646,7 +711,7 @@ InterpolationTestSuite.test("Include prefix formatting option") {
   _checkFormatStringAndBuffer(
   "Octal with prefix: \(unsignedValue, format: .octal(includePrefix: true))") {
     (formatString, buffer) in
-    expectEqual("Octal with prefix: 0o%{public}lo", formatString)
+    expectEqual("Octal with prefix: 0o%lo", formatString)
   }
 }
 
@@ -655,7 +720,7 @@ InterpolationTestSuite.test("Hex with uppercase formatting option") {
   _checkFormatStringAndBuffer(
   "Hex with uppercase: \(unsignedValue, format: .hex(uppercase: true))") {
     (formatString, buffer) in
-    expectEqual("Hex with uppercase: %{public}lX", formatString)
+    expectEqual("Hex with uppercase: %lX", formatString)
   }
 }
 
@@ -664,7 +729,7 @@ InterpolationTestSuite.test("Integer with explicit positive sign") {
   _checkFormatStringAndBuffer(
   "\(posValue, format: .decimal(explicitPositiveSign: true))") {
     (formatString, buffer) in
-    expectEqual("%{public}+ld", formatString)
+    expectEqual("%+ld", formatString)
   }
 }
 
@@ -673,7 +738,7 @@ InterpolationTestSuite.test("Unsigned integer with explicit positive sign") {
   _checkFormatStringAndBuffer(
   "\(posValue, format: .decimal(explicitPositiveSign: true))") {
     (formatString, buffer) in
-    expectEqual("+%{public}lu", formatString)
+    expectEqual("+%lu", formatString)
   }
 }
 
@@ -682,15 +747,73 @@ InterpolationTestSuite.test("Integer formatting with precision") {
   _checkFormatStringAndBuffer(
   "\(intValue, format: .decimal(minDigits: 10))") {
     (formatString, buffer) in
-    expectEqual("%{public}.10ld", formatString)
+    expectEqual("%.10ld", formatString)
   }
 }
 
 InterpolationTestSuite.test("Integer formatting with alignment") {
   let intValue = 10
   _checkFormatStringAndBuffer(
-  "\(intValue, align: .right(columns: 10)) \(intValue, align: .left(columns: 5))") {
+    """
+    \(intValue, align: .right(columns: 10)) \
+    \(intValue, align: .left(columns: 5), privacy: .private)
+    """) {
     (formatString, buffer) in
-    expectEqual("%{public}10ld %{public}-5ld", formatString)
+      expectEqual("%10ld %{private}-5ld", formatString)
+  }
+}
+
+InterpolationTestSuite.test("String with alignment") {
+  let smallString = "a" + "b"
+  let concatString = "hello" + " - " + "world"
+  _checkFormatStringAndBuffer(
+    """
+    \(smallString, align: .right(columns: 10)) \
+    \(concatString, align: .left(columns: 7), privacy: .public)
+    """) {
+    (formatString, buffer) in
+      expectEqual("%10s %{public}-7s", formatString)
+  }
+}
+
+InterpolationTestSuite.test("Floats and Doubles") {
+  let x = 1.2 + 0.5
+  let pi: Double = 3.141593
+  let floatPi: Float = 3.141593
+  _checkFormatStringAndBuffer(
+    """
+    A double value: \(x, privacy: .private) \
+    pi as double: \(pi), pi as float: \(floatPi)
+    """) {
+    (formatString, buffer) in
+      expectEqual(
+        """
+        A double value: %{private}f pi as double: %f, \
+        pi as float: %f
+        """,
+        formatString)
+
+      let bufferChecker = OSLogBufferChecker(buffer)
+      bufferChecker.checkSummaryBytes(
+        argumentCount: 3,
+        hasPrivate: true,
+        hasNonScalar: false)
+
+      bufferChecker.checkArguments(
+        { bufferChecker.checkDouble(
+          startIndex: $0,
+          flag: .privateFlag,
+          expectedValue: x)
+        },
+        { bufferChecker.checkDouble(
+          startIndex: $0,
+          flag: .autoFlag,
+          expectedValue: pi)
+        },
+        { bufferChecker.checkDouble(
+          startIndex: $0,
+          flag: .autoFlag,
+          expectedValue: Double(floatPi))
+        })
   }
 }


### PR DESCRIPTION
This PR  adds the following features: 

* adds basic support for interpolating floating-point types without formatting options.
* adds an auto-inferred privacy mode and makes it the default privacy mode. 
* adds support for left/right justifying dynamic strings interpolated in the string interpolations passed to os log APIs. 

It updates the os log tests to match these changes. 