### PR TITLE
build: help pave the road for a mixed Python build

### DIFF
--- a/cmake/modules/SwiftHandleGybSources.cmake
+++ b/cmake/modules/SwiftHandleGybSources.cmake
@@ -1,6 +1,8 @@
 include(SwiftAddCustomCommandTarget)
 include(SwiftSetIfArchBitness)
 
+find_package(Python2 COMPONENTS Interpreter REQUIRED)
+
 # Create a target to process single gyb source with the 'gyb' tool.
 #
 # handle_gyb_source_single(
@@ -58,7 +60,7 @@ function(handle_gyb_source_single dependency_out_var_name)
       COMMAND
           "${CMAKE_COMMAND}" -E make_directory "${dir}"
       COMMAND
-          "${PYTHON_EXECUTABLE}" "${gyb_tool}" ${SWIFT_GYB_FLAGS} ${GYB_SINGLE_FLAGS} -o "${GYB_SINGLE_OUTPUT}.tmp" "${GYB_SINGLE_SOURCE}"
+          "$<TARGET_FILE:Python2::Interpreter>" "${gyb_tool}" ${SWIFT_GYB_FLAGS} ${GYB_SINGLE_FLAGS} -o "${GYB_SINGLE_OUTPUT}.tmp" "${GYB_SINGLE_SOURCE}"
       COMMAND
           "${CMAKE_COMMAND}" -E copy_if_different "${GYB_SINGLE_OUTPUT}.tmp" "${GYB_SINGLE_OUTPUT}"
       COMMAND


### PR DESCRIPTION
LLDB requires python3, however, gyb is a python2 tool.  Use the fact
that we have a newer CMake at our disposal and use the `Python2` package
in CMake to locate a viable python interpreter.  This allows us to have
references to both versions of python simultaneously.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
