### PR TITLE
Temporarily disable Result_future.swift test.

### DIFF
--- a/test/Prototypes/Result_future.swift
+++ b/test/Prototypes/Result_future.swift
@@ -12,6 +12,7 @@
 // RUN: %target-run-stdlib-swift-target-future
 // REQUIRES: executable_test
 
+// REQUIRES: rdar59425215
 // REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios


### PR DESCRIPTION
Reenabling the test is tracked by rdar://problem/59425215 .