### PR TITLE
[GSB] Map invalid subject type to error type after resolving it

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4358,10 +4358,16 @@ ConstraintResult GenericSignatureBuilder::addTypeRequirement(
                         ->getDependentType(getGenericParams());
 
       Impl->HadAnyError = true;
-      
+
       if (subjectType->is<DependentMemberType>()) {
         subjectType = resolveDependentMemberTypes(*this, subjectType);
-      } else {
+      }
+
+      if (!subjectType->is<DependentMemberType>()) {
+        // If we end up here, it means either the subject type was never a
+        // a dependent member type, or it was initially a dependent member
+        // type, but resolving it lead to some other type. Let's map this
+        // to an error type so we can emit correct diagnostics.
         subjectType = ErrorType::get(subjectType);
       }
 

--- a/test/Constraints/associated_types.swift
+++ b/test/Constraints/associated_types.swift
@@ -109,3 +109,14 @@ struct UsesSameTypedDefaultDerivedWithoutSatisfyingReqts: SameTypedDefaultDerive
     static var y: YType { return YType() }
 }
 
+// SR-12199
+
+protocol SR_12199_P1 {
+  associatedtype Assoc
+}
+
+enum SR_12199_E {}
+
+protocol SR_12199_P2: SR_12199_P1 where Assoc == SR_12199_E {
+  associatedtype Assoc: SR_12199_E // expected-error {{type 'Self.Assoc' constrained to non-protocol, non-class type 'SR_12199_E'}}
+}


### PR DESCRIPTION
In https://github.com/apple/swift/pull/29491, we mapped an invalid subject type to an error type, but only mapping it if the subject type isn't a dependent member type is not enough - it's possible we have a dependent member type initially, but resolving it leads to some other type. So, we should delay the mapping instead.  Otherwise, we could crash in scenarios like:

```swift
protocol P {
  associatedtype Assoc
}

enum SomeEnum {}

protocol Q: P where Assoc == SomeEnum {
  associatedtype Assoc: SomeEnum // crash
}
```
