### PR TITLE
[DNM] Try uncommenting `VectorProtocol` operator definitions.

### DIFF
--- a/stdlib/public/Differentiation/DifferentiationSupport.swift
+++ b/stdlib/public/Differentiation/DifferentiationSupport.swift
@@ -102,7 +102,6 @@ public extension VectorProtocol {
   }
 }
 
-/*
 // Note: These default-implemented operators will slow down type-checking
 // performance and break existing code.
 
@@ -149,7 +148,6 @@ public extension VectorProtocol where VectorSpaceScalar : SignedNumeric {
     .zero - x
   }
 }
-*/
 
 /// A type that is differentiable in the Euclidean space.
 /// The type may represent a vector space, or consist of a vector space and some


### PR DESCRIPTION
Try uncommenting `VectorProtocol` operators to see if they break the stdlib:
- `VectorProtocol.+` (two variants)
- `VectorProtocol.+=`
- `VectorProtocol.-` (two variants)
- `VectorProtocol.-=`
- `VectorProtocol.*` (two variants)
- `VectorProtocol.*=`

If they do break the stdlib, we should consider publicizing/removing [internal
operator definitions from tensorflow/swift-apis](https://github.com/tensorflow/swift-apis/blob/f2acd6c4d1f14e7d0c1f9579dcc3631990e32602/Sources/TensorFlow/Operators/Math.swift#L223-L253), since it's surprising that the
operators aren't available to library users.