### PR TITLE
[CodeCompletion] Fix a crash in context type analysis

### DIFF
--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -647,7 +647,8 @@ class ExprContextAnalyzer {
     }
     case ExprKind::If: {
       auto *IE = cast<IfExpr>(Parent);
-      if (SM.rangeContains(IE->getCondExpr()->getSourceRange(),
+      if (IE->isFolded() &&
+          SM.rangeContains(IE->getCondExpr()->getSourceRange(),
                            ParsedExpr->getSourceRange())) {
         recordPossibleType(Context.getBoolDecl()->getDeclaredInterfaceType());
         break;


### PR DESCRIPTION
`IfExpr` (ternary expression) does not have the condition part until sequence folding. Add a simple guard to avoid a crash.

I haven't been able to find a reproducer for this.

rdar://problem/59344203

