### PR TITLE
[Constraint System] Move bindVariablesInPattern into the constraint system

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -235,105 +235,6 @@ protected:
     return nullptr;                                        \
   }
 
-  /// Provide a type for each variable that occurs within the given pattern,
-  /// by matching the pattern structurally with its already-computed pattern
-  /// type. The variables will either get a concrete type (when present in
-  /// the pattern type) or a fresh type variable bound to that part of the
-  /// pattern via a one-way constraint.
-  void bindVariablesInPattern(Pattern *pattern, Type patternType,
-                              ConstraintLocator *locator) {
-    switch (pattern->getKind()) {
-    case PatternKind::Paren: {
-      // Parentheses don't affect the type, but unwrap a paren type if we have
-      // one.
-      Type subPatternType;
-      if (auto parenType = dyn_cast<ParenType>(patternType.getPointer()))
-        subPatternType = parenType->getUnderlyingType();
-      else
-        subPatternType = patternType;
-      return bindVariablesInPattern(
-          cast<ParenPattern>(pattern)->getSubPattern(),
-          subPatternType, locator);
-    }
-
-    case PatternKind::Var:
-      // Var doesn't affect the type.
-      return bindVariablesInPattern(cast<VarPattern>(pattern)->getSubPattern(),
-                                    patternType, locator);
-
-    case PatternKind::Any:
-      // Nothing to bind.
-      return;
-
-    case PatternKind::Named: {
-      auto var = cast<NamedPattern>(pattern)->getDecl();
-
-      /// Create a fresh type variable to describe the type of the
-      Type varType = cs->createTypeVariable(locator, TVO_CanBindToNoEscape);
-
-      auto ROK = ReferenceOwnership::Strong;
-      if (auto *OA = var->getAttrs().getAttribute<ReferenceOwnershipAttr>())
-        ROK = OA->get();
-      switch (optionalityOf(ROK)) {
-      case ReferenceOwnershipOptionality::Required:
-        // FIXME: Can we assert this rather than just checking it.
-        if (auto optPatternType =
-                dyn_cast<OptionalType>(patternType.getPointer())) {
-          // Add a one-way constraint from the type variable to the wrapped
-          // type of the optional.
-          cs->addConstraint(
-            ConstraintKind::OneWayEqual, varType, optPatternType->getBaseType(),
-                            locator);
-
-          // Make the variable type optional.
-          varType = TypeChecker::getOptionalType(var->getLoc(), varType);
-          break;
-        }
-
-        // Fall through to treat this normally.
-        LLVM_FALLTHROUGH;
-
-      case ReferenceOwnershipOptionality::Allowed:
-      case ReferenceOwnershipOptionality::Disallowed:
-        // Add the one-way constraint from the variable type to the pattern
-        // type.
-        cs->addConstraint(ConstraintKind::OneWayEqual, varType, patternType,
-                          locator);
-        break;
-      }
-
-      // Bind the type of the variable.
-      cs->setType(var, varType);
-      return;
-    }
-
-    case PatternKind::Typed: {
-      // Ignore the type itself; it's part of patternType now.
-      return bindVariablesInPattern(
-          cast<TypedPattern>(pattern)->getSubPattern(),
-          patternType, locator);
-    }
-
-    case PatternKind::Tuple: {
-      auto tuplePat = cast<TuplePattern>(pattern);
-      auto tupleType = patternType->castTo<TupleType>();
-      for (unsigned i = 0, e = tuplePat->getNumElements(); i != e; ++i) {
-        bindVariablesInPattern(tuplePat->getElement(i).getPattern(),
-                               tupleType->getElementType(i), locator);
-      }
-      return;
-    }
-
-    // FIXME: Refutable patterns will generate additional constraints.
-#define PATTERN(Id, Parent)
-#define REFUTABLE_PATTERN(Id, Parent) case PatternKind::Id:
-#include "swift/AST/PatternNodes.def"
-      llvm_unreachable("Refutable patterns are not supported here");
-    }
-
-    llvm_unreachable("Unhandled pattern kind");
-  }
-
   void visitPatternBindingDecl(PatternBindingDecl *patternBinding) {
     // If any of the entries lacks an initializer, don't handle this node.
     if (!llvm::all_of(range(patternBinding->getNumPatternEntries()),
@@ -367,8 +268,8 @@ protected:
 
       // Bind the variables that occur in the pattern to the corresponding
       // type entry for the pattern itself.
-      bindVariablesInPattern(pattern, cs->getType(pattern),
-                             cs->getConstraintLocator(target.getAsExpr()));
+      cs->bindVariablesInPattern(
+          pattern, cs->getConstraintLocator(target.getAsExpr()));
     }
   }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3256,6 +3256,23 @@ public:
   /// if generation succeeded.
   bool generateConstraints(StmtCondition condition, DeclContext *dc);
 
+  /// Provide a type for each variable that occurs within the given pattern,
+  /// by matching the pattern structurally with its already-computed pattern
+  /// type. The variables will either get a concrete type (when present in
+  /// the pattern type) or a fresh type variable bound to that part of the
+  /// pattern via a one-way constraint.
+  void bindVariablesInPattern(Pattern *pattern, Type patternType,
+                              ConstraintLocator *locator);
+
+  /// Provide a type for each variable that occurs within the given pattern,
+  /// by matching the pattern structurally with its already-computed pattern
+  /// type. The variables will either get a concrete type (when present in
+  /// the pattern type) or a fresh type variable bound to that part of the
+  /// pattern via a one-way constraint.
+  void bindVariablesInPattern(Pattern *pattern, ConstraintLocator *locator) {
+    bindVariablesInPattern(pattern, getType(pattern), locator);
+  }
+
   /// Generate constraints for a given set of overload choices.
   ///
   /// \param constraints The container of generated constraint choices.


### PR DESCRIPTION
This general notion of wiring up the types of variables that occur
within a pattern to the types in the produced pattern type is useful
outside of function builders, too.
