### PR TITLE
[windows] Compare SWIFT_HOST_VARIANT against lowercase value.

### DIFF
--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -85,7 +85,7 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
                              PRIVATE
                                swiftCore_EXPORTS)
 
-  if(SWIFT_HOST_VARIANT STREQUAL WINDOWS)
+  if(SWIFT_HOST_VARIANT STREQUAL "windows")
     target_compile_definitions(SwiftRuntimeTests PRIVATE
       _ENABLE_EXTENDED_ALIGNED_STORAGE)
   endif()


### PR DESCRIPTION
SWIFT_HOST_VARIANT is lowercase. SWIFT_HOST_VARIANT_SDK is uppercase.

Compare against the right one.

This tries to fix #29805, which didn't fix the CI for Windows VS2017.

/cc @compnerd 