### PR TITLE
Fixing build breaks against latest llvm.org (that can go into master).

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -2470,7 +2470,7 @@ bool RefactoringActionConvertToSwitchStmt::performChange() {
     std::string findDefaultStatements() {
       auto ElseBody = dyn_cast_or_null<BraceStmt>(PreviousIf->getElseStmt());
       if (!ElseBody)
-        return getTokenText(tok::kw_break);
+        return getTokenText(tok::kw_break).str();
       return findBodyWithoutBraces(ElseBody);
     }
 
@@ -2479,7 +2479,7 @@ bool RefactoringActionConvertToSwitchStmt::performChange() {
       if (!BS)
         return Lexer::getCharSourceRangeFromSourceRange(SM, body->getSourceRange()).str().str();
       if (BS->getElements().empty())
-        return getTokenText(tok::kw_break);
+        return getTokenText(tok::kw_break).str();
       SourceRange BodyRange = BS->getElements().front().getSourceRange();
       BodyRange.widen(BS->getElements().back().getSourceRange());
       return Lexer::getCharSourceRangeFromSourceRange(SM, BodyRange).str().str();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2759,7 +2759,7 @@ std::string swift::describeGenericType(ValueDecl *GP, bool includeName) {
       OS << " '" << decl->getFullName() << "'";
   }
 
-  return OS.str();
+  return OS.str().str();
 }
 
 /// Special handling of conflicts associated with generic arguments.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -781,8 +781,8 @@ struct Score {
 
 /// An AST node that can gain type information while solving.
 using TypedNode =
-    llvm::PointerUnion4<const Expr *, const TypeLoc *,
-                        const VarDecl *, const Pattern *>;
+    llvm::PointerUnion<const Expr *, const TypeLoc *,
+                       const VarDecl *, const Pattern *>;
 
 /// Display a score.
 llvm::raw_ostream &operator<<(llvm::raw_ostream &out, const Score &score);


### PR DESCRIPTION
There were changes due to the StringRef to std::string conversion, and a drop in the using for PointerUnion4 since PointerUnion is now a variadic template and will do in its place.


These changes can go straight into master, and were pulled out of https://github.com/apple/swift/pull/29799