### PR TITLE
build: obsolete options which have long been deprecated

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1542,15 +1542,10 @@ endfunction()
 #   Sources to add into this library.
 function(add_swift_host_library name)
   set(options
-        FORCE_BUILD_OPTIMIZED
         SHARED
         STATIC)
   set(single_parameter_options)
   set(multiple_parameter_options
-        C_COMPILE_FLAGS
-        DEPENDS
-        FILE_DEPENDS
-        LINK_LIBRARIES
         LLVM_LINK_COMPONENTS)
 
   cmake_parse_arguments(ASHL
@@ -1559,22 +1554,6 @@ function(add_swift_host_library name)
                         "${multiple_parameter_options}"
                         ${ARGN})
   set(ASHL_SOURCES ${ASHL_UNPARSED_ARGUMENTS})
-
-  if(ASHL_FORCE_BUILD_OPTIMIZED)
-    message(SEND_ERROR "library ${name} is using FORCE_BUILD_OPTIMIZED flag which is deprecated.  Please use target_compile_options instead")
-  endif()
-  if(ASHL_C_COMPILE_FLAGS)
-    message(SEND_ERROR "library ${name} is using C_COMPILE_FLAGS parameter which is deprecated.  Please use target_compile_definitions, target_compile_options, or target_include_directories instead")
-  endif()
-  if(ASHL_DEPENDS)
-    message(SEND_ERROR "library ${name} is using DEPENDS parameter which is deprecated.  Please use add_dependencies instead")
-  endif()
-  if(ASHL_FILE_DEPENDS)
-    message(SEND_ERROR "library ${name} is using FILE_DEPENDS parameter which is deprecated.")
-  endif()
-  if(ASHL_LINK_LIBRARIES)
-    message(SEND_ERROR "library ${name} is using LINK_LIBRARIES parameter which is deprecated.  Please use target_link_libraries instead")
-  endif()
 
   translate_flags(ASHL "${options}")
 
@@ -2524,21 +2503,21 @@ endfunction()
 #   [ARCHITECTURE architecture]
 #     Architecture to build for.
 function(_add_swift_executable_single name)
-  # Parse the arguments we were given.
+  set(options)
+  set(single_parameter_options
+    ARCHITECTURE
+    SDK)
+  set(multiple_parameter_options
+    COMPILE_FLAGS
+    DEPENDS
+    LLVM_LINK_COMPONENTS)
   cmake_parse_arguments(SWIFTEXE_SINGLE
-    "EXCLUDE_FROM_ALL"
-    "SDK;ARCHITECTURE"
-    "DEPENDS;LLVM_LINK_COMPONENTS;LINK_LIBRARIES;COMPILE_FLAGS"
+    "${options}"
+    "${single_parameter_options}"
+    "${multiple_parameter_options}"
     ${ARGN})
 
   set(SWIFTEXE_SINGLE_SOURCES ${SWIFTEXE_SINGLE_UNPARSED_ARGUMENTS})
-
-  if(SWIFTEXE_SINGLE_EXCLUDE_FROM_ALL)
-    message(SEND_ERROR "${name} is using EXCLUDE_FROM_ALL option which is deprecated.")
-  endif()
-  if(SWIFTEXE_SINGLE_LINK_LIBRARIES)
-    message(SEND_ERROR "${name} is using LINK_LIBRARIES parameter which is deprecated.  Please use target_link_libraries instead")
-  endif()
 
   # Check arguments.
   precondition(SWIFTEXE_SINGLE_SDK MESSAGE "Should specify an SDK")
@@ -2663,17 +2642,13 @@ endmacro()
 function(add_swift_host_tool executable)
   set(options)
   set(single_parameter_options SWIFT_COMPONENT)
-  set(multiple_parameter_options LINK_LIBRARIES)
+  set(multiple_parameter_options)
 
   cmake_parse_arguments(ASHT
     "${options}"
     "${single_parameter_options}"
     "${multiple_parameter_options}"
     ${ARGN})
-
-  if(ASHT_LINK_LIBRARIES)
-    message(SEND_ERROR "${executable} is using LINK_LIBRARIES parameter which is deprecated.  Please use target_link_libraries instead")
-  endif()
 
   precondition(ASHT_SWIFT_COMPONENT
                MESSAGE "Swift Component is required to add a host tool")


### PR DESCRIPTION
This is simply dropping the error that would be presented for any
existing usage.  These have been rooted out for some time now.  Remove
the obsoleted checks.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
