### PR TITLE
[Typechecker] Covariant subscript check must also take into consideration mismatched types

### DIFF
--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1157,7 +1157,8 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
     // Otherwise, if this is a subscript, validate that covariance is ok.
     // If the parent is non-mutable, it's okay to be covariant.
     auto parentSubscript = cast<SubscriptDecl>(baseDecl);
-    if (parentSubscript->supportsMutation()) {
+    if (parentSubscript->supportsMutation() &&
+        attempt != OverrideCheckingAttempt::MismatchedTypes) {
       diags.diagnose(subscript, diag::override_mutable_covariant_subscript,
                      declTy, baseTy);
       diags.diagnose(baseDecl, diag::subscript_override_here);

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -59,8 +59,7 @@ class A {
     }
   }
   
-  // FIXME(SR-10323): The second note is wrong; it should be "potential overridden class subscript 'subscript(_:)' here". This is a preexisting bug.
-  class subscript (i: String) -> String { // expected-note{{overridden declaration is here}} expected-note{{attempt to override subscript here}}
+  class subscript (i: String) -> String { // expected-note{{overridden declaration is here}} expected-note{{potential overridden class subscript 'subscript(_:)' here}}
     get {
       return "hello"
     }
@@ -144,8 +143,7 @@ class B : A {
     }
   }
   
-  // FIXME(SR-10323): This error is wrong; it should be "subscript does not override any subscript from its superclass". This is a preexisting bug.
-  override class subscript (i: Int) -> String { // expected-error{{cannot override mutable subscript of type '(Int) -> String' with covariant type '(String) -> String'}}
+  override class subscript (i: Int) -> String { // expected-error{{subscript does not override any subscript from its superclass}}
     get {
       return "hello"
     }
@@ -647,4 +645,3 @@ public extension SR_11740_Base where F: SR_11740_Q {
 extension SR_11740_Derived where F: SR_11740_P {
     public static func foo(_: A) {}
 }
-


### PR DESCRIPTION
When we override a settable subscript with a different argument type, the compiler emits an error complaining that the types are not covariant:

```swift
class A {
  subscript (foo: Int) -> Int {
    get { fatalError() }
    set {}
  }
}
class B: A {
  override subscript (foo: String) -> Int {
    get { fatalError() }
    set {}
  }
}
```

The compiler currently emits an error saying `cannot override mutable subscript of type '(Int) -> Int' with covariant type '(String) -> Int'`, but the argument types (`Int` and `String`) are unrelated.

We should make sure that we don't have mismatched types, so we can print the right diagnostics.

Resolves SR-10323