### PR TITLE
[5.2][CodeCompletion] Fix a crash in context type analysis

### DIFF
--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -645,7 +645,8 @@ class ExprContextAnalyzer {
     }
     case ExprKind::If: {
       auto *IE = cast<IfExpr>(Parent);
-      if (SM.rangeContains(IE->getCondExpr()->getSourceRange(),
+      if (IE->isFolded() &&
+          SM.rangeContains(IE->getCondExpr()->getSourceRange(),
                            ParsedExpr->getSourceRange())) {
         recordPossibleType(Context.getBoolDecl()->getDeclaredInterfaceType());
         break;


### PR DESCRIPTION
Cherry-pick of #29816 into `swift-5.2-branch`

**Explanation**: Fix a crash in context type analysis for `IfExpr` (ternary expression) in code completions. Before sequence folding, `IfExpr` doesn't have the condition part. When they somehow aren't type checked prior to the code completion analysis, it used to crash because of the lack of the `nullptr` check.
**Scope**: Code completion inside "then" part of ternary expressions.
**Risk**: Very low. Just add a check to guard.
**Issue**: rdar://problem/59344203
**Testing**: Passed the current regression test. (No additional test because I haven't been able to find a reproducer)
**Reviewer**: Nathan Hawes (@nathawes)