### PR TITLE
[ownership] Add helper method Operand::isConsumingUse() const.

### DIFF
--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -644,6 +644,14 @@ public:
   OperandOwnershipKindMap
   getOwnershipKindMap(bool isForwardingSubValue = false) const;
 
+  /// Returns true if this operand acts as a use that consumes its associated
+  /// value.
+  bool isConsumingUse() const {
+    auto map = getOwnershipKindMap();
+    auto constraint = map.getLifetimeConstraint(get().getOwnershipKind());
+    return constraint == UseLifetimeConstraint::MustBeInvalidated;
+  }
+
 private:
   void removeFromCurrent() {
     if (!Back) return;

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -362,13 +362,10 @@ static void destroyConsumedOperandOfDeadInst(Operand &operand) {
   assert(!isEndOfScopeMarker(deadInst) && !isa<DestroyValueInst>(deadInst) &&
          !isa<DestroyAddrInst>(deadInst) &&
          "lifetime ending instruction is deleted without its operand");
-  ValueOwnershipKind operandOwnershipKind = operandValue.getOwnershipKind();
-  UseLifetimeConstraint lifetimeConstraint =
-      operand.getOwnershipKindMap().getLifetimeConstraint(operandOwnershipKind);
-  if (lifetimeConstraint == UseLifetimeConstraint::MustBeInvalidated) {
+  if (operand.isConsumingUse()) {
     // Since deadInst cannot be an end-of-scope instruction (asserted above),
     // this must be a consuming use of an owned value.
-    assert(operandOwnershipKind == ValueOwnershipKind::Owned);
+    assert(operandValue.getOwnershipKind() == ValueOwnershipKind::Owned);
     SILBuilderWithScope builder(deadInst);
     builder.emitDestroyValueOperation(deadInst->getLoc(), operandValue);
   }


### PR DESCRIPTION
This just provides a higher level of abstraction around determining if an
operand consumes its associated value needing to touch the ownership kind
map/etc.

I also refactored parts of the code base where it made sense to use this instead
of messing with the ownership kind map itself.
