### PR TITLE
[ClangImporter] Commit a regression test for protocols via nested names

### DIFF
--- a/test/ClangImporter/Inputs/nested_protocol_name.h
+++ b/test/ClangImporter/Inputs/nested_protocol_name.h
@@ -1,0 +1,14 @@
+@protocol TrunkBranchProtocol;
+
+__attribute__((objc_root_class))
+@interface Trunk
+- (instancetype)init;
+- (void)addLimb:(id<TrunkBranchProtocol>)limb;
+@end
+
+// NS_SWIFT_NAME(Trunk.Branch)
+__attribute__((swift_name("Trunk.Branch")))
+@protocol TrunkBranchProtocol
+- (void) flower;
+@end
+

--- a/test/ClangImporter/nested_protocol_name.swift
+++ b/test/ClangImporter/nested_protocol_name.swift
@@ -1,0 +1,38 @@
+// REQUIRES: objc_interop
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -import-objc-header %S/Inputs/nested_protocol_name.h -typecheck -verify %s
+
+// RUN: echo '#include "nested_protocol_name.h"' > %t.m
+// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/nested_protocol_name.h -import-objc-header %S/Inputs/nested_protocol_name.h -print-regular-comments --cc-args %target-cc-options -fsyntax-only %t.m -I %S/Inputs > %t.txt
+// RUN: %FileCheck -check-prefix=HEADER %s < %t.txt
+
+// rdar://59431058
+// Let's make sure this works, but let's not encourage its spread...
+
+// HEADER: class Trunk {
+// HEADER:   init!()
+// HEADER:   class func addLimb(_ limb: Branch!)
+// HEADER:   func addLimb(_ limb: Branch!)
+// HEADER: }
+// HEADER: // NS_SWIFT_NAME(Trunk.Branch)
+// HEADER: protocol Branch {
+// HEADER:   func flower()
+// HEADER: }
+
+func grow(_ branch: Trunk.Branch, from trunk: Trunk) {
+  branch.flower()
+  trunk.addLimb(branch)
+}
+
+class SturdyBranch: Trunk.Branch {
+  func flower() {}
+}
+
+// FIXME: Odd that name lookup can't find this...
+class NormalBranch: Branch { // expected-error {{use of undeclared type 'Branch'}}
+  func flower() {}
+}
+
+class WeakBranch: TrunkBranchProtocol { // expected-error {{'TrunkBranchProtocol' has been renamed to 'Trunk.Branch'}}
+  func flower() {}
+}


### PR DESCRIPTION
It's a terrible idea to support this in the long run, but in the short
term we should at least know what the compiler does in these situations.

At least I get to practice my puns for arbor day.

Relates to rdar://59431058