### PR TITLE
[Sema] Warn About Tuple Shuffles

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4905,6 +4905,14 @@ NOTE(function_builder_remove_returns, none,
      "remove 'return' statements to apply the function builder", ())
 
 //------------------------------------------------------------------------------
+// MARK: Tuple Shuffle Diagnostics
+//------------------------------------------------------------------------------
+
+ WARNING(warn_reordering_tuple_shuffle_deprecated,none,
+        "expression shuffles the elements of this tuple; "
+        "this behavior is deprecated", ())
+
+//------------------------------------------------------------------------------
 // MARK: differentiable programming diagnostics
 //------------------------------------------------------------------------------
 ERROR(experimental_differentiable_programming_disabled, none,

--- a/test/Constraints/tuple_shuffle.swift
+++ b/test/Constraints/tuple_shuffle.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+
+ func consume<T>(_ x: T) {} // Suppress unused variable warnings
+
+ func shuffle_through_initialization() {
+   let a = (x: 1, y: 2)
+   let b: (y: Int, x: Int)
+   b = a // expected-warning {{expression shuffles the elements of this tuple}}
+   consume(b)
+ }
+
+  func shuffle_through_destructuring() {
+   let a = (x: 1, y: 2)
+   let (y: b, x: c) = a // expected-warning {{expression shuffles the elements of this tuple}}
+   consume((b, c))
+ }
+
+  func shuffle_through_call() {
+   func foo(_ : (x: Int, y: Int)) {}
+   foo((y: 5, x: 10)) // expected-warning {{expression shuffles the elements of this tuple}}
+ }
+
+  func shuffle_through_cast() {
+   let x = ((a: Int(), b: Int()) as (b: Int, a: Int)).0 // expected-warning {{expression shuffles the elements of this tuple}}
+
+   // Ah, the famous double-shuffle
+   let (c1, (c2, c3)): (c: Int, (b: Int, a: Int)) = ((a: Int(), b: Int()), c: Int())
+   // expected-warning@-1 {{expression shuffles the elements of this tuple}}
+   // expected-warning@-2 {{expression shuffles the elements of this tuple}}
+   consume((x, c1, c2, c3))
+ }

--- a/test/Parse/omit_return.swift
+++ b/test/Parse/omit_return.swift
@@ -474,7 +474,7 @@ func ff_implicitInjectIntoOptionalExpr(_ int: Int) -> Int? {
 }
 
 func ff_implicitTupleShuffle(_ input: (one: Int, two: Int)) -> (two: Int, one: Int) {
-    input
+    input // expected-warning {{expression shuffles the elements of this tuple; this behavior is deprecated}}
 }
 
 func ff_implicitCollectionUpcast(_ deriveds: [Derived]) -> [Base] {

--- a/test/Sema/diag_unowned_immediate_deallocation.swift
+++ b/test/Sema/diag_unowned_immediate_deallocation.swift
@@ -450,7 +450,10 @@ func testGenericWeakClassDiag() {
 // The diagnostic doesn't currently support tuple shuffles.
 func testDontDiagnoseThroughTupleShuffles() {
   unowned let (c1, (c2, c3)): (c: C, (b: C, a: C)) = ((a: D(), b: C()), c: D())
+  // expected-warning@-1 {{expression shuffles the elements of this tuple; this behavior is deprecated}}
+  // expected-warning@-2 {{expression shuffles the elements of this tuple; this behavior is deprecated}}
   unowned let c4 = ((a: C(), b: C()) as (b: C, a: C)).0
+  // expected-warning@-1 {{expression shuffles the elements of this tuple; this behavior is deprecated}}
 
   _ = c1; _ = c2; _ = c3; _ = c4
 }

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -132,7 +132,7 @@ var f2 : (Int) -> Int = (+-+)
 var f3 : (inout Int) -> Int = (-+-) // expected-error{{ambiguous use of operator '-+-'}}
 var f4 : (inout Int, Int) -> Int = (+-+=)
 var r5 : (a : (Int, Int) -> Int, b : (Int, Int) -> Int) = (+, -)
-var r6 : (a : (Int, Int) -> Int, b : (Int, Int) -> Int) = (b : +, a : -)
+var r6 : (a : (Int, Int) -> Int, b : (Int, Int) -> Int) = (b : +, a : -) // expected-warning {{expression shuffles the elements of this tuple; this behavior is deprecated}}
 
 struct f6_S {
   subscript(op : (Int, Int) -> Int) -> Int {

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -53,7 +53,7 @@ func funcdecl5(_ a: Int, _ y: Int) {
   var b = a.1+a.f
 
   // Tuple expressions with named elements.
-  var i : (y : Int, x : Int) = (x : 42, y : 11)
+  var i : (y : Int, x : Int) = (x : 42, y : 11) // expected-warning {{expression shuffles the elements of this tuple; this behavior is deprecated}}
   funcdecl1(123, 444)
   
   // Calls.

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -193,7 +193,7 @@ func test5() {
 
 
   let c: (a: Int, b: Int) = (1,2)
-  let _: (b: Int, a: Int) = c  // Ok, reshuffle tuple.
+  let _: (b: Int, a: Int) = c  // expected-warning {{expression shuffles the elements of this tuple; this behavior is deprecated}}
 }
 
 


### PR DESCRIPTION
Emit a warning that tuple shuffling is deprecated across the board. In
the future, we should try to unshuffle these expressions where we can,
but that's a diagnostic improvement for another day.

See also https://forums.swift.org/t/deprecating-tuple-shuffles-round-2/16884/30