### PR TITLE
[Availability] Make _stdlib_isOSVersionAtLeast() no longer inlinable

### DIFF
--- a/lib/IRGen/AllocStackHoisting.cpp
+++ b/lib/IRGen/AllocStackHoisting.cpp
@@ -355,8 +355,6 @@ bool indicatesDynamicAvailabilityCheckUse(SILInstruction *I) {
   auto *FunRef = Apply->getReferencedFunctionOrNull();
   if (!FunRef)
     return false;
-  if (FunRef->getName().equals("_swift_stdlib_operatingSystemVersion"))
-    return true;
   return false;
 }
 

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -18,7 +18,7 @@ import SwiftShims
 /// This is a magic entry point known to the compiler. It is called in
 /// generated code for API availability checking.
 @_semantics("availability.osversion")
-@inlinable
+@_effects(readnone)
 public func _stdlib_isOSVersionAtLeast(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,
@@ -28,9 +28,6 @@ public func _stdlib_isOSVersionAtLeast(
   if Int(major) == 9999 {
     return true._value
   }
-  // The call to _swift_stdlib_operatingSystemVersion is used as an indicator
-  // that this function was called by a compiler optimization pass. If it is
-  // replaced that pass needs to be updated.
   let runningVersion = _swift_stdlib_operatingSystemVersion()
   
   let result =

--- a/stdlib/public/stubs/Availability.mm
+++ b/stdlib/public/stubs/Availability.mm
@@ -43,6 +43,10 @@ using namespace swift;
 
 /// Return the version of the operating system currently running for use in
 /// API availability queries.
+///
+/// This is ABI and cannot be removed. Even though _stdlib_isOSVersionAtLeast()
+/// is no longer inlinable, is previously was and so calls to this method
+/// have been inlined into shipped apps.
 _SwiftNSOperatingSystemVersion swift::_swift_stdlib_operatingSystemVersion() {
   os_system_version_s version = SWIFT_LAZY_CONSTANT(getOSVersion());
 

--- a/test/IRGen/availability.swift
+++ b/test/IRGen/availability.swift
@@ -15,7 +15,7 @@ import Foundation
 
 // OPT-LABEL: define{{.*}} @{{.*}}dontHoist
 // OPT-NOT: S10Foundation11MeasurementVySo17NSUnitTemperature
-// OPT: call {{.*}} @_swift_stdlib_operatingSystemVersion(
+// OPT: call {{.*}} @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(
 // OPT: s10Foundation11MeasurementVySo17NSUnitTemperature
 
 public func dontHoist() {
@@ -28,8 +28,15 @@ public func dontHoist() {
 }
 
 
+// Now that _isOSVersionAtLeast is no longer inlinable, we do still
+// mark it as _effects(readnone).
+// This means that unlike in the past the optimizer can now only coalesce
+// availability checks with the same availability. It does not determine,
+// for example, that a check for iOS 10 is sufficient to guarantee that a check
+// for iOS 9 will also succeed.
+
 // With optimizations on, multiple #availability checks should generate only
-// a single call into _swift_stdlib_operatingSystemVersion.
+// a single call into _isOSVersionAtLeast.
 
 // CHECK-LABEL: define{{.*}} @{{.*}}multipleAvailabilityChecks
 // CHECK: call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(
@@ -38,17 +45,17 @@ public func dontHoist() {
 // CHECK: ret void
 
 // OPT-LABEL: define{{.*}} @{{.*}}multipleAvailabilityChecks
-// OPT: call {{.*}} @_swift_stdlib_operatingSystemVersion
-// OPT-NOT: call {{.*}} @_swift_stdlib_operatingSystemVersion
+// OPT: call {{.*}} @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"
+// OPT-NOT: call {{.*}} @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"
 // OPT: ret void
 public func multipleAvailabilityChecks() {
   if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     print("test one")
   }
-  if #available(OSX 10.11, iOS 9.0, watchOS 2.0, tvOS 9.0, *) {
+  if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     print("test two")
   }
-  if #available(OSX 10.10, iOS 8.0, watchOS 1.0, tvOS 8.0, *) {
+  if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     print("test three")
   }
 }


### PR DESCRIPTION
To make it possible to change the implementation of
_stdlib_isOSVersionAtLeast(), remove the @inlinable attribute from it.

Since it is currently inlinable and calls the helper function
_swift_stdlib_operatingSystemVersion(), we’ll have to keep the
helper around as ABI.

This change causes a minor pessimization where the LLVM optimizer can no
longer reason that, for example, a successful check for 10.12 availability
means that a later check for 10.11 will always succeed. I don't expect this
pessimization to be a problem, but if needed we could write a custom SIL
optimizer pass to claw back the performance.

<rdar://problem/59447474>