### PR TITLE
Add top-level request for TBDGen

### DIFF
--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -369,6 +369,7 @@ public:
   }
 };
 
+void simple_display(llvm::raw_ostream &out, const FileUnit *file);
 
 inline FileUnit &ModuleDecl::getMainFile(FileUnitKind expectedKind) const {
   assert(expectedKind != FileUnitKind::Source &&

--- a/include/swift/AST/TBDGenRequests.h
+++ b/include/swift/AST/TBDGenRequests.h
@@ -1,0 +1,124 @@
+//===--- TBDGenRequests.h - TBDGen Requests ---------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines TBDGen requests.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_TBDGEN_REQUESTS_H
+#define SWIFT_TBDGEN_REQUESTS_H
+
+#include "swift/AST/ASTTypeIDs.h"
+#include "swift/AST/SimpleRequest.h"
+
+namespace llvm {
+namespace MachO {
+class InterfaceFile;
+} // end namespace MachO
+
+template <class AllocatorTy>
+class StringSet;
+} // end namespace llvm
+
+namespace swift {
+
+class FileUnit;
+class ModuleDecl;
+struct TBDGenOptions;
+
+class TBDGenDescriptor final {
+  using FileOrModule = llvm::PointerUnion<FileUnit *, ModuleDecl *>;
+  FileOrModule Input;
+  const TBDGenOptions &Opts;
+
+  TBDGenDescriptor(FileOrModule input, const TBDGenOptions &opts)
+      : Input(input), Opts(opts) {
+    assert(input);
+  }
+
+public:
+  /// Returns the file or module we're emitting TBD for.
+  FileOrModule getFileOrModule() const { return Input; }
+
+  /// If the input is a single file, returns that file. Otherwise returns
+  /// \c nullptr.
+  FileUnit *getSingleFile() const;
+
+  /// Returns the parent module for TBD emission.
+  ModuleDecl *getParentModule() const;
+
+  /// Returns the TBDGen options.
+  const TBDGenOptions &getOptions() const { return Opts; }
+
+  bool operator==(const TBDGenDescriptor &other) const;
+  bool operator!=(const TBDGenDescriptor &other) const {
+    return !(*this == other);
+  }
+
+  static TBDGenDescriptor forFile(FileUnit *file, const TBDGenOptions &opts) {
+    return TBDGenDescriptor(file, opts);
+  }
+
+  static TBDGenDescriptor forModule(ModuleDecl *M, const TBDGenOptions &opts) {
+    return TBDGenDescriptor(M, opts);
+  }
+};
+
+llvm::hash_code hash_value(const TBDGenDescriptor &desc);
+void simple_display(llvm::raw_ostream &out, const TBDGenDescriptor &desc);
+SourceLoc extractNearestSourceLoc(const TBDGenDescriptor &desc);
+
+using TBDFileAndSymbols =
+    std::pair<llvm::MachO::InterfaceFile, llvm::StringSet<>>;
+
+/// Computes the TBD file and public symbols for a given module or file.
+class GenerateTBDRequest
+    : public SimpleRequest<GenerateTBDRequest,
+                           TBDFileAndSymbols(TBDGenDescriptor),
+                           CacheKind::Uncached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  llvm::Expected<TBDFileAndSymbols> evaluate(Evaluator &evaluator,
+                                             TBDGenDescriptor desc) const;
+};
+
+/// Report that a request of the given kind is being evaluated, so it
+/// can be recorded by the stats reporter.
+template <typename Request>
+void reportEvaluatedRequest(UnifiedStatsReporter &stats,
+                            const Request &request);
+
+/// The zone number for TBDGen.
+#define SWIFT_TYPEID_ZONE TBDGen
+#define SWIFT_TYPEID_HEADER "swift/AST/TBDGenTypeIDZone.def"
+#include "swift/Basic/DefineTypeIDZone.h"
+#undef SWIFT_TYPEID_ZONE
+#undef SWIFT_TYPEID_HEADER
+
+// Set up reporting of evaluated requests.
+#define SWIFT_REQUEST(Zone, RequestType, Sig, Caching, LocOptions)             \
+template<>                                                                     \
+inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,                \
+                                   const RequestType &request) {               \
+  ++stats.getFrontendCounters().RequestType;                                   \
+}
+#include "swift/AST/TBDGenTypeIDZone.def"
+#undef SWIFT_REQUEST
+
+} // end namespace swift
+
+#endif // SWIFT_TBDGEN_REQUESTS_H

--- a/include/swift/AST/TBDGenTypeIDZone.def
+++ b/include/swift/AST/TBDGenTypeIDZone.def
@@ -1,0 +1,18 @@
+//===--- TBDGenTypeIDZone.def -----------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This definition file describes the requests in TBDGen's zone.
+//
+//===----------------------------------------------------------------------===//
+
+SWIFT_REQUEST(TBDGen, GenerateTBDRequest, TBDFileAndSymbols(TBDGenDescriptor),
+              Uncached, NoLocationInfo)

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -300,4 +300,8 @@ FRONTEND_STATISTIC(IRModule, NumGOTEntries)
 /// the .o file you find on disk after the frontend exits.
 FRONTEND_STATISTIC(LLVM, NumLLVMBytesOutput)
 
+#define SWIFT_REQUEST(ZONE, NAME, Sig, Caching, LocOptions) FRONTEND_STATISTIC(TBDGen, NAME)
+#include "swift/AST/TBDGenTypeIDZone.def"
+#undef SWIFT_REQUEST
+
 #endif

--- a/include/swift/Basic/TypeID.h
+++ b/include/swift/Basic/TypeID.h
@@ -38,6 +38,7 @@ enum class Zone : uint8_t {
   Parse                   = 8,
   TypeChecker             = 10,
   SILGen                  = 12,
+  TBDGen                  = 14,
   // N.B. This is not a formal zone and exists solely to support the unit tests.
   ArithmeticEvaluator     = 255,
 };

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -53,12 +53,10 @@ public:
   /// be promoted to public external. Used by the LLDB expression evaluator.
   bool ForcePublicDecls;
 
-  bool IsWholeModule;
-
   explicit UniversalLinkageInfo(IRGenModule &IGM);
 
   UniversalLinkageInfo(const llvm::Triple &triple, bool hasMultipleIGMs,
-                       bool forcePublicDecls, bool isWholeModule);
+                       bool forcePublicDecls);
 
   /// In case of multiple llvm modules (in multi-threaded compilation) all
   /// private decls must be visible from other files.

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -375,6 +375,12 @@ namespace swift {
   /// should call this functions after forming the ASTContext.
   void registerSILGenRequestFunctions(Evaluator &evaluator);
 
+  /// Register TBDGen-level request functions with the evaluator.
+  ///
+  /// Clients that form an ASTContext and will perform any TBD generation
+  /// should call this functions after forming the ASTContext.
+  void registerTBDGenRequestFunctions(Evaluator &evaluator);
+
   /// Register IDE-level request functions with the evaluator.
   ///
   /// The ASTContext will automatically call these upon construction.

--- a/include/swift/TBDGen/TBDGen.h
+++ b/include/swift/TBDGen/TBDGen.h
@@ -59,6 +59,32 @@ struct TBDGenOptions {
   /// Typically, these modules are static linked libraries. Thus their symbols
   /// are embeded in the current dylib.
   std::vector<std::string> embedSymbolsFromModules;
+
+  friend bool operator==(const TBDGenOptions &lhs, const TBDGenOptions &rhs) {
+    return lhs.HasMultipleIGMs == rhs.HasMultipleIGMs &&
+           lhs.IsInstallAPI == rhs.IsInstallAPI &&
+           lhs.LinkerDirectivesOnly == rhs.LinkerDirectivesOnly &&
+           lhs.InstallName == rhs.InstallName &&
+           lhs.ModuleLinkName == rhs.ModuleLinkName &&
+           lhs.CurrentVersion == rhs.CurrentVersion &&
+           lhs.CompatibilityVersion == rhs.CompatibilityVersion &&
+           lhs.ModuleInstallNameMapPath == rhs.ModuleInstallNameMapPath &&
+           lhs.embedSymbolsFromModules == rhs.embedSymbolsFromModules;
+  }
+
+  friend bool operator!=(const TBDGenOptions &lhs, const TBDGenOptions &rhs) {
+    return !(lhs == rhs);
+  }
+
+  friend llvm::hash_code hash_value(const TBDGenOptions &opts) {
+    using namespace llvm;
+    return hash_combine(
+        opts.HasMultipleIGMs, opts.IsInstallAPI, opts.LinkerDirectivesOnly,
+        opts.InstallName, opts.ModuleLinkName, opts.CurrentVersion,
+        opts.CompatibilityVersion, opts.ModuleInstallNameMapPath,
+        hash_combine_range(opts.embedSymbolsFromModules.begin(),
+                           opts.embedSymbolsFromModules.end()));
+  }
 };
 
 void enumeratePublicSymbols(FileUnit *module, llvm::StringSet<> &symbols,

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1895,6 +1895,28 @@ void FileUnit::getTopLevelDeclsWhereAttributesMatch(
   Results.erase(newEnd, Results.end());
 }
 
+void swift::simple_display(llvm::raw_ostream &out, const FileUnit *file) {
+  if (!file) {
+    out << "(null)";
+    return;
+  }
+
+  switch (file->getKind()) {
+  case FileUnitKind::Source:
+    out << '\"' << cast<SourceFile>(file)->getFilename() << '\"';
+    return;
+  case FileUnitKind::Builtin:
+    out << "(Builtin)";
+    return;
+  case FileUnitKind::DWARFModule:
+  case FileUnitKind::ClangModule:
+  case FileUnitKind::SerializedAST:
+    out << '\"' << cast<LoadedFile>(file)->getFilename() << '\"';
+    return;
+  }
+  llvm_unreachable("Unhandled case in switch");
+}
+
 StringRef LoadedFile::getFilename() const {
   return "";
 }

--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -22,5 +22,6 @@ target_link_libraries(swiftFrontend PRIVATE
   swiftSILGen
   swiftSILOptimizer
   swiftSema
-  swiftSerialization)
+  swiftSerialization
+  swiftTBDGen)
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -211,6 +211,7 @@ bool CompilerInstance::setUpASTContextIfNeeded() {
   registerParseRequestFunctions(Context->evaluator);
   registerTypeCheckerRequestFunctions(Context->evaluator);
   registerSILGenRequestFunctions(Context->evaluator);
+  registerTBDGenRequestFunctions(Context->evaluator);
 
   // Migrator, indexing and typo correction need some IDE requests.
   // The integrated REPL needs IDE requests for completion.

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -74,16 +74,14 @@ bool swift::irgen::useDllStorage(const llvm::Triple &triple) {
 
 UniversalLinkageInfo::UniversalLinkageInfo(IRGenModule &IGM)
     : UniversalLinkageInfo(IGM.Triple, IGM.IRGen.hasMultipleIGMs(),
-                           IGM.IRGen.Opts.ForcePublicLinkage,
-                           IGM.getSILModule().isWholeModule()) {}
+                           IGM.IRGen.Opts.ForcePublicLinkage) {}
 
 UniversalLinkageInfo::UniversalLinkageInfo(const llvm::Triple &triple,
                                            bool hasMultipleIGMs,
-                                           bool forcePublicDecls,
-                                           bool isWholeModule)
+                                           bool forcePublicDecls)
     : IsELFObject(triple.isOSBinFormatELF()),
       UseDLLStorage(useDllStorage(triple)), HasMultipleIGMs(hasMultipleIGMs),
-      ForcePublicDecls(forcePublicDecls), IsWholeModule(isWholeModule) {}
+      ForcePublicDecls(forcePublicDecls) {}
 
 /// Mangle this entity into the given buffer.
 void LinkEntity::mangle(SmallVectorImpl<char> &buffer) const {

--- a/lib/SILGen/SILGenRequests.cpp
+++ b/lib/SILGen/SILGenRequests.cpp
@@ -38,19 +38,7 @@ void swift::simple_display(llvm::raw_ostream &out,
   } else {
     assert(unit);
     out << "SIL Generation for file ";
-    switch (unit->getKind()) {
-    case FileUnitKind::Source:
-      out << '\"' << cast<SourceFile>(unit)->getFilename() << '\"';
-      break;
-    case FileUnitKind::Builtin:
-      out << "(Builtin)";
-      break;
-    case FileUnitKind::DWARFModule:
-    case FileUnitKind::ClangModule:
-    case FileUnitKind::SerializedAST:
-      out << '\"' << cast<LoadedFile>(unit)->getFilename() << '\"';
-      break;
-    }
+    simple_display(out, unit);
   }
 }
 

--- a/lib/TBDGen/CMakeLists.txt
+++ b/lib/TBDGen/CMakeLists.txt
@@ -1,9 +1,11 @@
 add_swift_host_library(swiftTBDGen STATIC
   TBDGen.cpp
+  TBDGenRequests.cpp
   LLVM_LINK_COMPONENTS
     demangle
     TextAPI 
 )
 target_link_libraries(swiftTBDGen PRIVATE
   swiftAST
+  swiftIRGen
   swiftSIL)

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -23,6 +23,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/PropertyWrappers.h"
+#include "swift/AST/TBDGenRequests.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/IRGen/IRGenPublic.h"
@@ -945,10 +946,12 @@ static bool hasLinkerDirective(Decl *D) {
   return !getAllMovedPlatformVersions(D).empty();
 }
 
-static void enumeratePublicSymbolsAndWrite(ModuleDecl *M, FileUnit *singleFile,
-                                           StringSet *symbols,
-                                           llvm::raw_ostream *os,
-                                           const TBDGenOptions &opts) {
+llvm::Expected<TBDFileAndSymbols>
+GenerateTBDRequest::evaluate(Evaluator &evaluator,
+                             TBDGenDescriptor desc) const {
+  auto *M = desc.getParentModule();
+  auto &opts = desc.getOptions();
+
   auto &ctx = M->getASTContext();
   const auto &triple = ctx.LangOpts.Target;
   UniversalLinkageInfo linkInfo(triple, opts.HasMultipleIGMs,
@@ -976,8 +979,9 @@ static void enumeratePublicSymbolsAndWrite(ModuleDecl *M, FileUnit *singleFile,
   llvm::MachO::Target target(triple);
   file.addTarget(target);
 
+  StringSet symbols;
   auto *clang = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
-  TBDGenVisitor visitor(file, {target}, symbols,
+  TBDGenVisitor visitor(file, {target}, &symbols,
                         clang->getTargetInfo().getDataLayout(),
                         linkInfo, M, opts);
 
@@ -1000,7 +1004,7 @@ static void enumeratePublicSymbolsAndWrite(ModuleDecl *M, FileUnit *singleFile,
     }
   };
 
-  if (singleFile) {
+  if (auto *singleFile = desc.getSingleFile()) {
     assert(M == singleFile->getParentModule() && "mismatched file and module");
     visitFile(singleFile);
   } else {
@@ -1025,22 +1029,28 @@ static void enumeratePublicSymbolsAndWrite(ModuleDecl *M, FileUnit *singleFile,
     });
   }
 
-  if (os) {
-    llvm::cantFail(llvm::MachO::TextAPIWriter::writeToStream(*os, file),
-                   "YAML writing should be error-free");
-  }
+  return std::make_pair(std::move(file), std::move(symbols));
 }
 
 void swift::enumeratePublicSymbols(FileUnit *file, StringSet &symbols,
                                    const TBDGenOptions &opts) {
-  enumeratePublicSymbolsAndWrite(file->getParentModule(), file, &symbols,
-                                 nullptr, opts);
+  assert(symbols.empty() && "Additive symbol enumeration not supported");
+  auto &evaluator = file->getASTContext().evaluator;
+  auto desc = TBDGenDescriptor::forFile(file, opts);
+  symbols = llvm::cantFail(evaluator(GenerateTBDRequest{desc})).second;
 }
 void swift::enumeratePublicSymbols(ModuleDecl *M, StringSet &symbols,
                                    const TBDGenOptions &opts) {
-  enumeratePublicSymbolsAndWrite(M, nullptr, &symbols, nullptr, opts);
+  assert(symbols.empty() && "Additive symbol enumeration not supported");
+  auto &evaluator = M->getASTContext().evaluator;
+  auto desc = TBDGenDescriptor::forModule(M, opts);
+  symbols = llvm::cantFail(evaluator(GenerateTBDRequest{desc})).second;
 }
 void swift::writeTBDFile(ModuleDecl *M, llvm::raw_ostream &os,
                          const TBDGenOptions &opts) {
-  enumeratePublicSymbolsAndWrite(M, nullptr, nullptr, &os, opts);
+  auto &evaluator = M->getASTContext().evaluator;
+  auto desc = TBDGenDescriptor::forModule(M, opts);
+  auto file = llvm::cantFail(evaluator(GenerateTBDRequest{desc})).first;
+  llvm::cantFail(llvm::MachO::TextAPIWriter::writeToStream(os, file),
+                 "YAML writing should be error-free");
 }

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -950,10 +950,9 @@ static void enumeratePublicSymbolsAndWrite(ModuleDecl *M, FileUnit *singleFile,
                                            llvm::raw_ostream *os,
                                            const TBDGenOptions &opts) {
   auto &ctx = M->getASTContext();
-  auto isWholeModule = singleFile == nullptr;
   const auto &triple = ctx.LangOpts.Target;
-  UniversalLinkageInfo linkInfo(triple, opts.HasMultipleIGMs, false,
-                                isWholeModule);
+  UniversalLinkageInfo linkInfo(triple, opts.HasMultipleIGMs,
+                                /*forcePublicDecls*/ false);
 
   llvm::MachO::InterfaceFile file;
   file.setFileType(llvm::MachO::FileType::TBD_V3);

--- a/lib/TBDGen/TBDGenRequests.cpp
+++ b/lib/TBDGen/TBDGenRequests.cpp
@@ -1,0 +1,80 @@
+//===--- TBDGenRequests.cpp - Requests for TBD Generation  ----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/TBDGenRequests.h"
+#include "swift/AST/Evaluator.h"
+#include "swift/AST/FileUnit.h"
+#include "swift/AST/Module.h"
+#include "swift/Subsystems.h"
+#include "swift/TBDGen/TBDGen.h"
+#include "llvm/TextAPI/MachO/InterfaceFile.h"
+
+using namespace swift;
+
+namespace swift {
+// Implement the TBDGen type zone (zone 14).
+#define SWIFT_TYPEID_ZONE TBDGen
+#define SWIFT_TYPEID_HEADER "swift/AST/TBDGenTypeIDZone.def"
+#include "swift/Basic/ImplementTypeIDZone.h"
+#undef SWIFT_TYPEID_ZONE
+#undef SWIFT_TYPEID_HEADER
+} // end namespace swift
+
+//----------------------------------------------------------------------------//
+// GenerateTBDRequest computation.
+//----------------------------------------------------------------------------//
+
+FileUnit *TBDGenDescriptor::getSingleFile() const {
+  return Input.dyn_cast<FileUnit *>();
+}
+
+ModuleDecl *TBDGenDescriptor::getParentModule() const {
+  if (auto *module = Input.dyn_cast<ModuleDecl *>())
+    return module;
+  return Input.get<FileUnit *>()->getParentModule();
+}
+
+bool TBDGenDescriptor::operator==(const TBDGenDescriptor &other) const {
+  return Input == other.Input && Opts == other.Opts;
+}
+
+llvm::hash_code swift::hash_value(const TBDGenDescriptor &desc) {
+  return llvm::hash_combine(desc.getFileOrModule(), desc.getOptions());
+}
+
+void swift::simple_display(llvm::raw_ostream &out,
+                           const TBDGenDescriptor &desc) {
+  out << "Generate TBD for ";
+  if (auto *module = desc.getFileOrModule().dyn_cast<ModuleDecl *>()) {
+    out << "module ";
+    simple_display(out, module);
+  } else {
+    out << "file ";
+    simple_display(out, desc.getFileOrModule().get<FileUnit *>());
+  }
+}
+
+SourceLoc swift::extractNearestSourceLoc(const TBDGenDescriptor &desc) {
+  return extractNearestSourceLoc(desc.getFileOrModule());
+}
+
+// Define request evaluation functions for each of the TBDGen requests.
+static AbstractRequestFunction *tbdGenRequestFunctions[] = {
+#define SWIFT_REQUEST(Zone, Name, Sig, Caching, LocOptions)                    \
+  reinterpret_cast<AbstractRequestFunction *>(&Name::evaluateRequest),
+#include "swift/AST/TBDGenTypeIDZone.def"
+#undef SWIFT_REQUEST
+};
+
+void swift::registerTBDGenRequestFunctions(Evaluator &evaluator) {
+  evaluator.registerRequestFunctions(Zone::TBDGen, tbdGenRequestFunctions);
+}

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -113,7 +113,10 @@ public:
     // HACK: 'main' is a special symbol that's always emitted in SILGen if
     //       the file has an entry point. Since it doesn't show up in the
     //       module until SILGen, we need to explicitly add it here.
-    if (file->hasEntryPoint())
+    //
+    // Make sure to only add the main symbol for the module that we're emitting
+    // TBD for, and not for any statically linked libraries.
+    if (file->hasEntryPoint() && file->getParentModule() == SwiftModule)
       addSymbol("main");
   }
 


### PR DESCRIPTION
Introduce `GenerateTBDRequest` which returns the TBD interface file along with a set of public symbols.