### PR TITLE
[windows] Move ENABLE_EXTENDED_ALIGN_STORAGE into AddSwiftUnittest

### DIFF
--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -52,6 +52,9 @@ function(add_swift_unittest test_dirname)
       target_compile_options(${test_dirname} PRIVATE
         -march=core2)
     endif()
+  elseif("${SWIFT_HOST_VARIANT}" STREQUAL "windows")
+    target_compile_definitions("${test_dirname}" PRIVATE
+      _ENABLE_EXTENDED_ALIGNED_STORAGE)
   endif()
 
   find_program(LDLLD_PATH "ld.lld")

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -85,11 +85,6 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
                              PRIVATE
                                swiftCore_EXPORTS)
 
-  if(SWIFT_HOST_VARIANT STREQUAL "windows")
-    target_compile_definitions(SwiftRuntimeTests PRIVATE
-      _ENABLE_EXTENDED_ALIGNED_STORAGE)
-  endif()
-
   # FIXME: cross-compile for all variants.
   target_link_libraries(SwiftRuntimeTests
     PRIVATE


### PR DESCRIPTION
It will apply to everything that uses add_swift_unittest and hopefully it will avoid all the problems.

/cc @compnerd I am going to not have signal for the rest of the night, so I will not be able to babysit this one. Feel free to comandeer, abort or anything if feel so. I have no way to test that it will work, sadly.