### PR TITLE
[AutoDiff] NFC: make FileCheck test work on master and tensorflow.

### DIFF
--- a/test/AutoDiff/SIL/Serialization/differentiability_witness_function_inst.sil
+++ b/test/AutoDiff/SIL/Serialization/differentiability_witness_function_inst.sil
@@ -86,9 +86,9 @@ bb0:
 // IRGEN: @AD__foo_PSSURS = external global %swift.differentiability_witness, align [[PTR_ALIGNMENT]]
 // IRGEN: @AD__bar_PSUURSU = external global %swift.differentiability_witness, align [[PTR_ALIGNMENT]]
 // IRGEN: @AD__bar_PSSURSS = external global %swift.differentiability_witness, align [[PTR_ALIGNMENT]]
-// IRGEN: @AD__generic_PSURS16_Differentiation14DifferentiableRzl = external global %swift.differentiability_witness, align [[PTR_ALIGNMENT]]
-// IRGEN: @AD__generic_PSSRSs18AdditiveArithmeticRz16_Differentiation14DifferentiableRzl = external global %swift.differentiability_witness, align [[PTR_ALIGNMENT]]
-// IRGEN: @AD__generic_PSSRS16_Differentiation14DifferentiableRz13TangentVectorAaBPQzRszl = external global %swift.differentiability_witness, align [[PTR_ALIGNMENT]]
+// IRGEN: @AD__generic_PSURS{{16_Differentiation|s}}14DifferentiableRzl = external global %swift.differentiability_witness, align [[PTR_ALIGNMENT]]
+// IRGEN: @AD__generic_PSSRSs18AdditiveArithmeticRz{{16_Differentiation|s}}14DifferentiableRzl = external global %swift.differentiability_witness, align [[PTR_ALIGNMENT]]
+// IRGEN: @AD__generic_PSSRS{{16_Differentiation|s}}14DifferentiableRz13TangentVector{{.*}} = external global %swift.differentiability_witness, align [[PTR_ALIGNMENT]]
 
 // IRGEN-LABEL: define {{.*}} @test_derivative_witnesses()
 
@@ -106,11 +106,11 @@ bb0:
 // x86_64: [[FNPTR4:%.*]] = bitcast i8* [[PTR4]] to { float, float, i8*, %swift.refcounted* } (float, float, float)*
 // i386: [[FNPTR4:%.*]] = bitcast i8* [[PTR4]] to void (<{ %TSf, %TSf, %swift.function }>*, float, float, float)*
 
-// IRGEN: [[PTR5:%.*]] = load i8*, i8** getelementptr inbounds (%swift.differentiability_witness, %swift.differentiability_witness* @AD__generic_PSURS16_Differentiation14DifferentiableRzl, i32 0, i32 0), align [[PTR_ALIGNMENT]]
+// IRGEN: [[PTR5:%.*]] = load i8*, i8** getelementptr inbounds (%swift.differentiability_witness, %swift.differentiability_witness* @AD__generic_PSURS{{16_Differentiation|s}}14DifferentiableRzl, i32 0, i32 0), align [[PTR_ALIGNMENT]]
 // IRGEN: [[FNPTR5:%.*]] = bitcast i8* [[PTR5]] to { i8*, %swift.refcounted* } (%swift.opaque*, %swift.opaque*, float, %swift.type*, i8**)*
 
-// IRGEN: [[PTR6:%.*]] = load i8*, i8** getelementptr inbounds (%swift.differentiability_witness, %swift.differentiability_witness* @AD__generic_PSSRSs18AdditiveArithmeticRz16_Differentiation14DifferentiableRzl, i32 0, i32 1), align [[PTR_ALIGNMENT]]
+// IRGEN: [[PTR6:%.*]] = load i8*, i8** getelementptr inbounds (%swift.differentiability_witness, %swift.differentiability_witness* @AD__generic_PSSRSs18AdditiveArithmeticRz{{16_Differentiation|s}}14DifferentiableRzl, i32 0, i32 1), align [[PTR_ALIGNMENT]]
 // IRGEN: [[FNPTR6:%.*]] = bitcast i8* [[PTR6]] to { i8*, %swift.refcounted* } (%swift.opaque*, %swift.opaque*, float, %swift.type*, i8**, i8**)*
 
-// IRGEN: [[PTR7:%.*]] = load i8*, i8** getelementptr inbounds (%swift.differentiability_witness, %swift.differentiability_witness* @AD__generic_PSSRS16_Differentiation14DifferentiableRz13TangentVectorAaBPQzRszl, i32 0, i32 1), align [[PTR_ALIGNMENT]]
+// IRGEN: [[PTR7:%.*]] = load i8*, i8** getelementptr inbounds (%swift.differentiability_witness, %swift.differentiability_witness* @AD__generic_PSSRS{{16_Differentiation|s}}14DifferentiableRz13TangentVector{{.*}}, i32 0, i32 1), align [[PTR_ALIGNMENT]]
 // IRGEN: [[FNPTR7:%.*]] = bitcast i8* [[PTR7]] to { i8*, %swift.refcounted* } (%swift.opaque*, %swift.opaque*, float, %swift.type*, i8**)*


### PR DESCRIPTION
This is necessary because the `Differentiable` protocol exists in stdlib core
on `tensorflow` branch but in the `_Differentiation` module on `master` branch.

The robust solution is to add auto-import `_Differentiation` logic to `tensorflow`.

Related patch: https://github.com/apple/swift/pull/29711.