### PR TITLE
[ConstraintSystem] Accept trailing closure if multiple defaulted parameters after last function parameter

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -430,24 +430,24 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
 
   // If we have a trailing closure, it maps to the last parameter.
   if (hasTrailingClosure && numParams > 0) {
-    unsigned lastParamIdx = numParams - 1;
-    bool lastAcceptsTrailingClosure =
-        acceptsTrailingClosure(params[lastParamIdx]);
-
     // If the last parameter is defaulted, this might be
     // an attempt to use a trailing closure with previous
     // parameter that accepts a function type e.g.
     //
     // func foo(_: () -> Int, _ x: Int = 0) {}
     // foo { 42 }
-    if (!lastAcceptsTrailingClosure && numParams > 1 &&
-        paramInfo.hasDefaultArgument(lastParamIdx)) {
-      auto paramType = params[lastParamIdx - 1].getPlainType();
-      // If the parameter before defaulted last accepts.
-      if (paramType->is<AnyFunctionType>()) {
+    bool lastAcceptsTrailingClosure = false;
+    unsigned lastParamIdx = numParams - 1;
+    for (unsigned i : indices(params)) {
+      unsigned idx = numParams - 1 - i;
+      if (acceptsTrailingClosure(params[idx])) {
         lastAcceptsTrailingClosure = true;
-        lastParamIdx -= 1;
+        lastParamIdx = idx;
+        break;
       }
+      if (paramInfo.hasDefaultArgument(idx))
+        continue;
+      break;
     }
 
     bool isExtraClosure = false;

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -921,6 +921,14 @@ func test_trailing_closure_with_defaulted_last() {
   func foo<T>(fn: () -> T, value: Int = 0) {}
   foo { 42 } // Ok
   foo(fn: { 42 }) // Ok
+
+  func bar<T>(type: T.Type, fn: T, a: Int = 0) {}
+  bar(type: (() -> Int).self) { 42 }
+  bar(type: (() -> Int).self, fn: { 42 })
+
+  func baz(fn: () -> Int, a: Int = 0, b: Int = 0, c: Int = 0) {}
+  baz { 42 }
+  baz(fn: { 42 })
 }
 
 // Test that even in multi-statement closure case we still pick up `(Action) -> Void` over `Optional<(Action) -> Void>`.


### PR DESCRIPTION
This patch improve trailing closure matching with parameters.

Currently, trailing closure can match with function parameter followed by one defaulted parameter.
But it can not do if:
- function type from generic parameter.
- More than one defaulted parameters exist.

For example with below,

```swift
  func foo<T>(fn: () -> T, value: Int = 0) {}
  foo { 42 }

  func bar<T>(type: T.Type, fn: T, a: Int = 0) {}
  bar(type: (() -> Int).self) { 42 }

  func baz(fn: () -> Int, a: Int = 0, b: Int = 0, c: Int = 0) {}
  baz { 42 }
```

Only `foo` is ok but `bar` and `baz` are rejected.

This patch supports all of them.

@xedin Please review it.

