### PR TITLE
[Stdlib] Eagerly realize EmptyDictionarySingleton and EmptySetSingleton.

### DIFF
--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -117,6 +117,7 @@ internal class __RawDictionaryStorage: __SwiftNativeNSDictionary {
 // renamed. The old name must not be used in the new runtime.
 @_fixed_layout
 @usableFromInline
+@_objc_non_lazy_realization
 internal class __EmptyDictionarySingleton: __RawDictionaryStorage {
   @nonobjc
   internal override init(_doNotCallMe: ()) {

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -112,6 +112,7 @@ internal class __RawSetStorage: __SwiftNativeNSSet {
 // The old names must not be used in the new runtime.
 @_fixed_layout
 @usableFromInline
+@_objc_non_lazy_realization
 internal class __EmptySetSingleton: __RawSetStorage {
   @nonobjc
   override internal init(_doNotCallMe: ()) {

--- a/test/stdlib/EmptyCollectionSingletonRealization.swift
+++ b/test/stdlib/EmptyCollectionSingletonRealization.swift
@@ -1,0 +1,48 @@
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+
+// Test to make sure that empty collections don't cause a crash if we smuggle
+// them into the ObjC runtime without doing anything that would trigger
+// realization. The ObjC runtime expects all classes to have been realized
+// (i.e. runtime data structures initialized, triggered the first time a class
+// is accessed or used) before being queried in any way.
+//
+// Note: this test deliberately avoids StdlibUnittest to make sure
+// no other code runs that might inadvertently trigger realization behind our
+// back.
+
+@objc protocol P {}
+
+do {
+  let d: [NSObject: NSObject] = [:]
+  let c: AnyClass? = object_getClass(d)
+  let conforms = class_conformsToProtocol(c, P.self)
+  print("Dictionary: ", conforms) // CHECK: Dictionary: false
+}
+
+do {
+  let a: [NSObject] = []
+  let c: AnyClass? = object_getClass(a)
+  let p = objc_getProtocol("NSObject")
+  let conforms = class_conformsToProtocol(c, p)
+  print("Array:", conforms) // CHECK: Array: false
+}
+
+do {
+  let s: Set<NSObject> = []
+  let c: AnyClass? = object_getClass(s)
+  let p = objc_getProtocol("NSObject")
+  let conforms = class_conformsToProtocol(c, p)
+  print("Set:", conforms) // CHECK: Set: false
+}


### PR DESCRIPTION
These objects can escape into ObjC without their class being realized first, which can cause a crash if the unrealized class gets passed into the ObjC runtime.

rdar://problem/59295395