### PR TITLE
[Constraint solver] Always produce optional types for '?' patterns.

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2246,13 +2246,22 @@ namespace {
         }
         return TupleType::get(tupleTypeElts, CS.getASTContext());
       }
-      
+
+      case PatternKind::OptionalSome: {
+        // The subpattern must have optional type.
+        Type subPatternType = getTypeForPattern(
+            cast<OptionalSomePattern>(pattern)->getSubPattern(), locator);
+
+        return OptionalType::get(subPatternType);
+      }
+
       // Refutable patterns occur when checking the PatternBindingDecls in an
       // if/let or while/let condition.  They always require an initial value,
       // so they always allow unspecified types.
-#define PATTERN(Id, Parent)
-#define REFUTABLE_PATTERN(Id, Parent) case PatternKind::Id:
-#include "swift/AST/PatternNodes.def"
+      case PatternKind::Is:
+      case PatternKind::EnumElement:
+      case PatternKind::Bool:
+      case PatternKind::Expr:
         // TODO: we could try harder here, e.g. for enum elements to provide the
         // enum type.
         return CS.createTypeVariable(CS.getConstraintLocator(locator),

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -1982,8 +1982,8 @@ func testThrows006() {
 
 // rdar://21346928
 // Just sample some String API to sanity check.
-// AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal:      unicodeScalars[#String.UnicodeScalarView#]
-// AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal:      utf16[#String.UTF16View#]
+// AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal{{.*}}:      {{.*}}unicodeScalars[#String.UnicodeScalarView#]
+// AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal{{.*}}:      {{.*}}utf16[#String.UTF16View#]
 func testWithAutoClosure1(_ x: String?) {
   (x ?? "autoclosure").#^AUTOCLOSURE1^#
 }

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -8,8 +8,11 @@ import CoreGraphics
 var roomName : String?
 
 if let realRoomName = roomName as! NSString { // expected-warning{{forced cast from 'String?' to 'NSString' only unwraps and bridges; did you mean to use '!' with 'as'?}}
-// expected-error@-1{{initializer for conditional binding must have Optional type, not 'NSString'}}
-
+  // expected-error@-1{{initializer for conditional binding must have Optional type, not 'NSString'}}
+  // expected-warning@-2{{treating a forced downcast to 'NSString' as optional will never produce 'nil'}}
+  // expected-note@-3{{add parentheses around the cast to silence this warning}}
+  // expected-note@-4{{use 'as?' to perform a conditional downcast to 'NSString'}}
+  _ = realRoomName
 }
 
 var pi = 3.14159265358979

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -23,23 +23,25 @@ if var x = foo() {
 
 use(x) // expected-error{{unresolved identifier 'x'}}
 
-if let x = nonOptionalStruct() { } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalStruct'}}
-if let x = nonOptionalEnum() { } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalEnum'}}
+if let x = nonOptionalStruct() { _ = x} // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalStruct'}}
+if let x = nonOptionalEnum() { _ = x} // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalEnum'}}
 
 guard let _ = nonOptionalStruct() else { fatalError() } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalStruct'}}
 guard let _ = nonOptionalEnum() else { fatalError() } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalEnum'}}
 
-if case let x? = nonOptionalStruct() { } // expected-error{{'?' pattern cannot match values of type 'NonOptionalStruct'}}
-if case let x? = nonOptionalEnum() { } // expected-error{{'?' pattern cannot match values of type 'NonOptionalEnum'}}
+if case let x? = nonOptionalStruct() { _ = x } // expected-error{{'?' pattern cannot match values of type 'NonOptionalStruct'}}
+if case let x? = nonOptionalEnum() { _ = x } // expected-error{{'?' pattern cannot match values of type 'NonOptionalEnum'}}
 
 class B {} // expected-note * {{did you mean 'B'?}}
 class D : B {}// expected-note * {{did you mean 'D'?}}
 
 // TODO poor recovery in these cases
 if let {} // expected-error {{expected '{' after 'if' condition}} expected-error {{pattern matching in a condition requires the 'case' keyword}}
-if let x = {} // expected-error{{'{' after 'if'}} expected-error {{variable binding in a condition requires an initializer}} expected-error{{initializer for conditional binding must have Optional type, not '() -> ()'}}
+if let x = { } // expected-error{{'{' after 'if'}} expected-error {{variable binding in a condition requires an initializer}} expected-error{{initializer for conditional binding must have Optional type, not '() -> ()'}}
+// expected-warning@-1{{value 'x' was defined but never used}}
 
 if let x = foo() {
+  _ = x
 } else {
   // TODO: more contextual error? "x is only available on the true branch"?
   use(x) // expected-error{{unresolved identifier 'x'}}
@@ -62,8 +64,8 @@ if var x = opt {} // expected-warning {{value 'x' was defined but never used; co
 
 // <rdar://problem/20800015> Fix error message for invalid if-let
 let someInteger = 1
-if let y = someInteger {}  // expected-error {{initializer for conditional binding must have Optional type, not 'Int'}}
-if case let y? = someInteger {}  // expected-error {{'?' pattern cannot match values of type 'Int'}}
+if let y = someInteger { _ = y }  // expected-error {{initializer for conditional binding must have Optional type, not 'Int'}}
+if case let y? = someInteger { _ = y }  // expected-error {{'?' pattern cannot match values of type 'Int'}}
 
 // Test multiple clauses on "if let".
 if let x = opt, let y = opt, x != y,

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -554,7 +554,7 @@ func testThrowNil() throws {
 // Even if the condition fails to typecheck, save it in the AST anyway; the old
 // condition may have contained a SequenceExpr.
 func r23684220(_ b: Any) {
-  if let _ = b ?? b {} // expected-error {{initializer for conditional binding must have Optional type, not 'Any'}}
+  if let _ = b ?? b {} // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'Any', so the right side is never used}}
 }
 
 


### PR DESCRIPTION
When generating a type from an optional some pattern (`e.g., x?`), the type is always an optional type. Form that optional type rather than an otherwise-meaningless type variable.