### PR TITLE
[ownership] Split out the gathering of users of non-guaranteed values into its own helper function.

### DIFF
--- a/test/SIL/ownership-verifier/arguments.sil
+++ b/test/SIL/ownership-verifier/arguments.sil
@@ -322,7 +322,7 @@ bb7:
 // CHECK-LABEL: Function: 'owned_argument_overuse_br1'
 // CHECK-NEXT: Found over consume?!
 // CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject
-// CHECK-NEXT: User:   br bb1(%0 : $Builtin.NativeObject)
+// CHECK-NEXT: User:   destroy_value %0 : $Builtin.NativeObject
 // CHECK-NEXT: Block: bb0
 
 // CHECK-LABEL: Function: 'owned_argument_overuse_br1'
@@ -343,7 +343,7 @@ bb1(%1 : @owned $Builtin.NativeObject):
 // CHECK-LABEL: Function: 'owned_argument_overuse_br2'
 // CHECK-NEXT: Found over consume?!
 // CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject
-// CHECK-NEXT: User:   br bb1(%0 : $Builtin.NativeObject)
+// CHECK-NEXT: User:   destroy_value %0 : $Builtin.NativeObject
 // CHECK-NEXT: Block: bb0
 // CHECK-NOT: Block
 // CHECK-NOT: Function: 'owned_argument_overuse_br2'

--- a/test/SIL/ownership-verifier/cond_br_crash.sil
+++ b/test/SIL/ownership-verifier/cond_br_crash.sil
@@ -39,7 +39,7 @@ bb2:
 // CHECK-LABEL: Function: 'test2'
 // CHECK: Found over consume?!
 // CHECK: Value:   %0 = argument of bb0 : $Builtin.NativeObject
-// CHECK: User:   destroy_value %0 : $Builtin.NativeObject
+// CHECK: User:   cond_br undef, bb1(%0 : $Builtin.NativeObject), bb2
 // CHECK: Block: bb1
 sil [ossa] @test2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):

--- a/test/SIL/ownership-verifier/over_consume.sil
+++ b/test/SIL/ownership-verifier/over_consume.sil
@@ -182,7 +182,7 @@ bb0(%0 : @owned $RefWithInt):
 // CHECK-LABEL: Function: 'unchecked_enum_data_propagates_ownership'
 // CHECK: Found over consume?!
 // CHECK: Value: %0 = argument of bb0 : $Optional<Builtin.NativeObject>
-// CHECK: User: destroy_value %0 : $Optional<Builtin.NativeObject>
+// CHECK: User:   %1 = unchecked_enum_data %0 : $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1
 // CHECK: Block: bb0
 sil [ossa] @unchecked_enum_data_propagates_ownership : $@convention(thin) (@owned Optional<Builtin.NativeObject>) -> () {
 bb0(%0 : @owned $Optional<Builtin.NativeObject>):


### PR DESCRIPTION
This enables me to simplify the code by not using the worklist for
non-guaranteed values (where it is not necessary). I think the non-guaranteed
value handling snuck in over time. I don't think in the non-guaranteed case we
/ever/ used the actual worklist functionality.

This also enabled me to safely, algebraically eliminate unnecessary variables
making the code easier to read (since less indirection).
