### PR TITLE
[ownership] Change BorrowScopeIntroducingValue::{visit,gather}LocalScopeEndingUses to use isConsumingUse instead of checking for isa<EndBorrowInst>().

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -261,25 +261,7 @@ struct BorrowScopeOperand {
     return BorrowScopeOperand(*kind, op);
   }
 
-  void visitEndScopeInstructions(function_ref<void(Operand *)> func) const {
-    switch (kind) {
-    case BorrowScopeOperandKind::BeginBorrow:
-      for (auto *use : cast<BeginBorrowInst>(op->getUser())->getUses()) {
-        if (isa<EndBorrowInst>(use->getUser())) {
-          func(use);
-        }
-      }
-      return;
-    case BorrowScopeOperandKind::BeginApply: {
-      auto *user = cast<BeginApplyInst>(op->getUser());
-      for (auto *use : user->getTokenResult()->getUses()) {
-        func(use);
-      }
-      return;
-    }
-    }
-    llvm_unreachable("Covered switch isn't covered");
-  }
+  void visitEndScopeInstructions(function_ref<void(Operand *)> func) const;
 
   void print(llvm::raw_ostream &os) const;
   SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -236,8 +236,11 @@ struct BorrowScopeOperandKind {
   }
 
   void print(llvm::raw_ostream &os) const;
-  SWIFT_DEBUG_DUMP;
+  SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }
 };
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                              BorrowScopeOperandKind kind);
 
 /// An operand whose user instruction introduces a new borrow scope for the
 /// operand's value. The value of the operand must be considered as implicitly
@@ -278,6 +281,9 @@ struct BorrowScopeOperand {
     llvm_unreachable("Covered switch isn't covered");
   }
 
+  void print(llvm::raw_ostream &os) const;
+  SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }
+
 private:
   /// Internal constructor for failable static constructor. Please do not expand
   /// its usage since it assumes the code passed in is well formed.
@@ -286,7 +292,7 @@ private:
 };
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                              BorrowScopeOperandKind kind);
+                              const BorrowScopeOperand &operand);
 
 struct BorrowScopeIntroducingValueKind {
   using UnderlyingKindTy = std::underlying_type<ValueKind>::type;
@@ -336,7 +342,7 @@ struct BorrowScopeIntroducingValueKind {
   }
 
   void print(llvm::raw_ostream &os) const;
-  SWIFT_DEBUG_DUMP;
+  SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }
 };
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
@@ -419,6 +425,9 @@ struct BorrowScopeIntroducingValue {
                              SmallPtrSetImpl<SILBasicBlock *> &visitedBlocks,
                              DeadEndBlocks &deadEndBlocks) const;
 
+  void print(llvm::raw_ostream &os) const;
+  SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }
+
 private:
   /// Internal constructor for failable static constructor. Please do not expand
   /// its usage since it assumes the code passed in is well formed.
@@ -426,6 +435,9 @@ private:
                               SILValue value)
       : kind(kind), value(value) {}
 };
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                              const BorrowScopeIntroducingValue &value);
 
 /// Look up through the def-use chain of \p inputValue, recording any "borrow"
 /// introducing values that we find into \p out. If at any point, we find a

--- a/lib/SIL/OwnershipUtils.cpp
+++ b/lib/SIL/OwnershipUtils.cpp
@@ -88,6 +88,41 @@ bool swift::isOwnershipForwardingInst(SILInstruction *i) {
 }
 
 //===----------------------------------------------------------------------===//
+//                           Borrow Scope Operand
+//===----------------------------------------------------------------------===//
+
+void BorrowScopeOperandKind::print(llvm::raw_ostream &os) const {
+  switch (value) {
+  case Kind::BeginBorrow:
+    os << "BeginBorrow";
+    return;
+  case Kind::BeginApply:
+    os << "BeginApply";
+    return;
+  }
+  llvm_unreachable("Covered switch isn't covered?!");
+}
+
+llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
+                                     BorrowScopeOperandKind kind) {
+  kind.print(os);
+  return os;
+}
+
+void BorrowScopeOperand::print(llvm::raw_ostream &os) const {
+  os << "BorrowScopeOperand:\n"
+        "Kind: " << kind << "\n"
+        "Value: " << op->get()
+     << "User: " << op->getUser();
+}
+
+llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
+                                     const BorrowScopeOperand &operand) {
+  operand.print(os);
+  return os;
+}
+
+//===----------------------------------------------------------------------===//
 //                             Borrow Introducers
 //===----------------------------------------------------------------------===//
 
@@ -104,12 +139,6 @@ void BorrowScopeIntroducingValueKind::print(llvm::raw_ostream &os) const {
     return;
   }
   llvm_unreachable("Covered switch isn't covered?!");
-}
-
-void BorrowScopeIntroducingValueKind::dump() const {
-#ifndef NDEBUG
-  print(llvm::dbgs());
-#endif
 }
 
 void BorrowScopeIntroducingValue::getLocalScopeEndingInstructions(
@@ -203,6 +232,12 @@ bool swift::getUnderlyingBorrowIntroducingValues(
 llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
                                      BorrowScopeIntroducingValueKind kind) {
   kind.print(os);
+  return os;
+}
+
+llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
+                                     const BorrowScopeIntroducingValue &value) {
+  value.print(os);
   return os;
 }
 


### PR DESCRIPTION
I am going to be adding support for branch insts/SILPhiArgument to be able to
merge borrow scopes. Thus, the end lifetime for a borrow scope introducing
value, may not be an end_borrow. Luckily, in both cases of br and end_borrow we
model the end of lifetime as a consuming use, so checking for a consuming use
will work both before/after the change.

Should be NFC.