### PR TITLE
[CSApply] Always use `String` type for ObjC interop key path

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4312,7 +4312,7 @@ namespace {
                                  StringRef(stringCopy, compatStringBuf.size()),
                                  SourceRange(),
                                  /*implicit*/ true);
-          cs.setType(stringExpr, cs.getType(E));
+          cs.setType(stringExpr, TypeChecker::getStringType(cs.getASTContext()));
           E->setObjCStringLiteralExpr(stringExpr);
         }
       }

--- a/validation-test/compiler_crashers_2_fixed/0210-rdar57356196.swift
+++ b/validation-test/compiler_crashers_2_fixed/0210-rdar57356196.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -verify
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc class A : NSObject {
+  @objc var x: Int = 42
+}
+
+@propertyWrapper
+struct Attr<V> {
+  var wrappedValue: V {
+    get { fatalError() }
+  }
+
+  init(wrappedValue: V, key: KeyPath<A, V>) {}
+}
+
+class B {
+  @Attr(key: \.x) var y: Int = 0 // Ok
+}


### PR DESCRIPTION
If it's possible to build an Objective-C key path for key path
expression make sure that its implicitly generated string literal
expression has a `String` type.

Resolves: rdar://problem/57356196

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
