### PR TITLE
[ConstraintSystem] remove unused computation in claimNextNamed

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -313,6 +313,7 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
 
       // Skip claimed arguments.
       if (claimedArgs[i]) {
+        assert(!forVariadic && "Cannot be for a variadic claim");
         // Note that we have already claimed an argument with the same name.
         if (!claimedWithSameName)
           claimedWithSameName = i;
@@ -322,6 +323,7 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
       // We found a match.  If the match wasn't the next one, we have
       // potentially out of order arguments.
       if (i != nextArgIdx) {
+        assert(!forVariadic && "Cannot be for a variadic claim");
         // Avoid claiming un-labeled defaulted parameters
         // by out-of-order un-labeled arguments or parts
         // of variadic argument sequence, because that might
@@ -330,8 +332,7 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
         // func foo(_ a: Int, _ b: Int = 0, c: Int = 0, _ d: Int) {}
         // foo(1, c: 2, 3) // -> `3` will be claimed as '_ b:'.
         // ```
-        if (argLabel.empty() &&
-            (paramInfo.hasDefaultArgument(i) || !forVariadic))
+        if (argLabel.empty())
           continue;
 
         potentiallyOutOfOrder = true;

--- a/test/Constraints/keyword_arguments.swift
+++ b/test/Constraints/keyword_arguments.swift
@@ -241,6 +241,267 @@ func outOfOrder(_ a : Int, b: Int) {
 }
 
 // -------------------------------------------
+// Positions around defaults and variadics 
+// -------------------------------------------
+
+struct PositionsAroundDefaultsAndVariadics {
+  // unlabeled defaulted around labeled parameter
+  func f1(_ a: Bool = false, _ b: Int = 0, c: String = "", _ d: [Int] = []) {}
+
+  func test_f1() {
+    f1(true, 2, c: "3", [4])
+
+    f1(true, c: "3", 2, [4]) // expected-error {{unnamed argument #4 must precede argument 'c'}}
+
+    f1(true, c: "3", [4], 2) // expected-error {{unnamed argument #4 must precede argument 'c'}}
+
+    f1(true, c: "3", 2) // expected-error {{cannot convert value of type 'Int' to expected argument type '[Int]'}}
+
+    f1(true, c: "3", [4])
+
+    f1(c: "3", 2, [4]) // expected-error {{unnamed argument #3 must precede argument 'c'}}
+
+    f1(c: "3", [4], 2) // expected-error {{unnamed argument #3 must precede argument 'c'}}
+    
+    f1(c: "3", 2) // expected-error {{cannot convert value of type 'Int' to expected argument type '[Int]'}}
+
+    f1(c: "3", [4])
+
+    f1(b: "2", [3]) // expected-error {{unnamed argument #2 must precede argument 'b'}}
+    
+    f1(b: "2", 1) // expected-error {{unnamed argument #2 must precede argument 'b'}}
+
+    f1(b: "2", [3], 1) // expected-error {{unnamed argument #2 must precede argument 'b'}}
+
+    f1(b: "2", 1, [3]) // expected-error {{unnamed argument #2 must precede argument 'b'}}
+  }
+
+  // unlabeled variadics before labeled parameter
+  func f2(_ a: Bool = false, _ b: Int..., c: String = "", _ d: [Int] = []) {}
+
+  func test_f2() {
+    f2(true, 21, 22, 23, c: "3", [4])
+
+    f2(true, "21", 22, 23, c: "3", [4]) // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+
+    f2(true, 21, "22", 23, c: "3", [4]) // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+
+    f2(true, 21, 22, "23", c: "3", [4]) // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+
+    f2(true, 21, 22, c: "3", [4])
+    f2(true, 21, c: "3", [4])
+    f2(true, c: "3", [4])
+
+    f2(true, c: "3", 21) // expected-error {{cannot convert value of type 'Int' to expected argument type '[Int]'}}
+
+    f2(true, c: "3", 21, [4]) // expected-error {{unnamed argument #4 must precede argument 'c'}}
+    // expected-error@-1 {{cannot pass array of type '[Int]' as variadic arguments of type 'Int'}}
+    // expected-note@-2 {{remove brackets to pass array elements directly}}
+
+    f2(true, c: "3", [4], 21) // expected-error {{unnamed argument #4 must precede argument 'c'}}
+
+    f2(true, [4]) // expected-error {{cannot pass array of type '[Int]' as variadic arguments of type 'Int'}}
+    // expected-note@-1 {{remove brackets to pass array elements directly}}
+
+    f2(true, 21, [4]) // expected-error {{cannot pass array of type '[Int]' as variadic arguments of type 'Int'}}
+    // expected-note@-1 {{remove brackets to pass array elements directly}}
+    
+    f2(true, 21, 22, [4]) // expected-error {{cannot pass array of type '[Int]' as variadic arguments of type 'Int'}}
+    // expected-note@-1 {{remove brackets to pass array elements directly}}
+
+    f2(21, 22, 23, c: "3", [4]) // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+
+    f2(21, 22, c: "3", [4]) // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+
+    f2(21, c: "3", [4]) // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+
+    f2(c: "3", [4])
+    f2(c: "3")
+    f2()
+
+    f2(c: "3", 21) // expected-error {{cannot convert value of type 'Int' to expected argument type '[Int]'}}
+    
+    f2(c: "3", 21, [4]) // expected-error {{incorrect argument labels in call (have 'c:_:_:', expected '_:_:c:_:')}}
+    // expected-error@-1 {{cannot convert value of type 'Int' to expected argument type '[Int]'}}
+    // expected-error@-2 {{cannot convert value of type '[Int]' to expected argument type 'Bool'}}
+
+    f2(c: "3", [4], 21) // expected-error {{incorrect argument labels in call (have 'c:_:_:', expected '_:_:c:_:')}}
+    // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+
+    f2([4]) // expected-error {{cannot convert value of type '[Int]' to expected argument type 'Bool'}}
+
+    f2(21, [4]) // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+    // expected-error@-1 {{cannot pass array of type '[Int]' as variadic arguments of type 'Int'}}
+    // expected-note@-2 {{remove brackets to pass array elements directly}}
+
+    f2(21, 22, [4]) // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+    // expected-error@-1 {{cannot pass array of type '[Int]' as variadic arguments of type 'Int'}}
+    // expected-note@-2 {{remove brackets to pass array elements directly}}
+  }
+
+  // labeled variadics before labeled parameter
+  func f3(_ a: Bool = false, b: Int..., c: String = "", _ d: [Int] = []) {}
+
+  func test_f3() {
+    f3(true, b: 21, 22, 23, c: "3", [4])
+
+    f3(true, b: "21", 22, 23, c: "3", [4]) // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+    
+    f3(true, b: 21, "22", 23, c: "3", [4]) // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+    
+    f3(true, b: 21, 22, "23", c: "3", [4]) // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+
+    f3(true, b: 21, 22, c: "3", [4])
+    f3(true, b: 21, c: "3", [4])
+    f3(true, c: "3", [4])
+
+    f3(true, c: "3", b: 21) // expected-error {{argument 'b' must precede argument 'c'}}
+
+    f3(true, c: "3", b: 21, [4]) // expected-error {{argument 'b' must precede argument 'c'}}
+    // expected-error@-1 {{cannot pass array of type '[Int]' as variadic arguments of type 'Int'}}
+    // expected-note@-2 {{remove brackets to pass array elements directly}}
+
+    f3(true, c: "3", [4], b: 21) // expected-error {{argument 'b' must precede argument 'c'}}
+
+    f3(true, b: 21, [4]) // expected-error {{cannot pass array of type '[Int]' as variadic arguments of type 'Int'}}
+    // expected-note@-1 {{remove brackets to pass array elements directly}}
+
+    f3(b: 21, 22, 23, c: "3", [4])
+    f3(b: 21, 22, c: "3", [4])
+    f3(b: 21, c: "3", [4])
+    f3(c: "3", [4])
+
+    f3([4]) // expected-error {{cannot convert value of type '[Int]' to expected argument type 'Bool'}}
+    
+    f3()
+
+    f3(c: "3", b: 21) // expected-error {{incorrect argument labels in call (have 'c:b:', expected '_:b:c:_:')}}
+
+    f3(c: "3", b: 21, [4]) // expected-error {{incorrect argument labels in call (have 'c:b:_:', expected '_:b:c:_:')}}
+    // expected-error@-1 {{cannot pass array of type '[Int]' as variadic arguments of type 'Int'}}
+    // expected-note@-2 {{remove brackets to pass array elements directly}}
+
+    f3(c: "3", [4], b: 21) // expected-error {{incorrect argument labels in call (have 'c:_:b:', expected '_:b:c:_:')}}
+  }
+
+  // unlabeled variadics after labeled parameter
+  func f4(_ a: Bool = false, b: String = "", _ c: Int..., d: [Int] = []) {}
+
+  func test_f4() {
+    f4(true, b: "2", 31, 32, 33, d: [4])
+    
+    f4(true, b: "2", "31", 32, 33, d: [4]) // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+
+    f4(true, b: "2", 31, "32", 33, d: [4]) // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+    
+    f4(true, b: "2", 31, 32, "33", d: [4]) // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+    
+    f4(true, b: "2", 31, 32, d: [4])
+    f4(true, b: "2", 31, d: [4])
+    f4(true, b: "2", d: [4])
+
+    f4(true, 31, b: "2", d: [4]) // expected-error {{argument 'b' must precede unnamed argument #2}}
+
+    f4(true, b: "2", d: [4], 31) // expected-error {{unnamed argument #4 must precede argument 'd'}}
+
+    f4(true, b: "2", 31)
+    f4(true, b: "2")
+
+    f4(true)
+    f4(true, 31)
+    f4(true, 31, d: [4])
+    f4(true, 31, 32)
+    f4(true, 31, 32, d: [4])
+
+    f4(b: "2", 31, 32, 33, d: [4])
+
+    f4(b: "2", "31", 32, 33, d: [4]) // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+
+    f4(b: "2", 31, "32", 33, d: [4]) // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+
+    f4(b: "2", 31, 32, "33", d: [4]) // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+
+    f4(b: "2", 31, 32, d: [4])
+    f4(b: "2", 31, d: [4])
+    f4(b: "2", d: [4])
+
+    f4(31, b: "2", d: [4]) // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+
+    f4(b: "2", d: [4], 31) // expected-error {{unnamed argument #3 must precede argument 'b'}}
+
+    f4(b: "2", 31)
+    f4(b: "2", 31, 32)
+    f4(b: "2")
+
+    f4()
+    
+    f4(31) // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+
+    f4(31, d: [4]) // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+
+    f4(31, 32) // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+
+    f4(31, 32, d: [4]) // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+  }
+
+  // labeled variadics after labeled parameter
+  func f5(_ a: Bool = false, b: String = "", c: Int..., d: [Int] = []) {}
+
+  func test_f5() {
+    f5(true, b: "2", c: 31, 32, 33, d: [4])
+    
+    f5(true, b: "2", c: "31", 32, 33, d: [4]) // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+
+    f5(true, b: "2", c: 31, "32", 33, d: [4]) // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+
+    f5(true, b: "2", c: 31, 32, "33", d: [4]) // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+    
+    f5(true, b: "2", c: 31, 32, d: [4])
+    f5(true, b: "2", c: 31, d: [4])
+    f5(true, b: "2", d: [4])
+
+    f5(true, c: 31, b: "2", d: [4]) // expected-error {{argument 'b' must precede argument 'c'}}
+
+    f5(true, b: "2", d: [4], 31) // expected-error {{incorrect argument labels in call (have '_:b:d:_:', expected '_:b:c:d:')}}
+
+    f5(true, b: "2", c: 31)
+    f5(true, b: "2")
+
+    f5(true)
+    f5(true, c: 31)
+    f5(true, c: 31, d: [4])
+    f5(true, c: 31, 32)
+    f5(true, c: 31, 32, d: [4])
+
+    f5(b: "2", c: 31, 32, 33, d: [4])
+    
+    f5(b: "2", c: "31", 32, 33, d: [4]) // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+
+    f5(b: "2", c: 31, "32", 33, d: [4]) // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+
+    f5(b: "2", c: 31, 32, "33", d: [4]) // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+
+    f5(b: "2", c: 31, 32, d: [4])
+    f5(b: "2", c: 31, d: [4])
+    f5(b: "2", d: [4])
+
+    f5(c: 31, b: "2", d: [4]) // expected-error {{incorrect argument labels in call (have 'c:b:d:', expected '_:b:c:d:')}}
+
+    f5(b: "2", d: [4], c: 31) // expected-error {{incorrect argument labels in call (have 'b:d:c:', expected '_:b:c:d:')}}
+
+    f5(b: "2", c: 31)
+    f5(b: "2", c: 31, 32)
+    f5(b: "2")
+
+    f5()
+    f5(c: 31)
+    f5(c: 31, d: [4])
+    f5(c: 31, 32)
+    f5(c: 31, 32, d: [4])
+  }
+}
+
+// -------------------------------------------
 // Missing arguments
 // -------------------------------------------
 // FIXME: Diagnostics could be improved with all missing names, or


### PR DESCRIPTION
This patch removes unused computation in `claimNextNamed`.

See this line in original code.

```c++
        if (argLabel.empty() &&
            (paramInfo.hasDefaultArgument(i) || !forVariadic))
```

I found two issue here.

- A variable `i` passing to `paramInfo` is index not for **parameters** but for **arguments**. So `paramInfo.hasDefaultArgument(i)` may be bug.
- A variable `forVariadic` is always `false` here. So expression `!forVariadic` is always `true` here and previous expression about `paramInfo` is meaningless.

## The reason why `forVariadic` is always `false`

In this `for` loop with `i`, `return` is at bottom.
So to increment `i`, one of three `continue` statement is reached but all are never happens.

About first `continue`, there is `if (forVariadic) return` before `continue`.

About second `continue`, it is in `if (claimedArgs[i])` scope.
It is not entered in first time of loop.
Because `skipClaimedArgs()` before `for` loop seek `nextArgIdx` to index of first unclaimed argument.

About third `continue`, it is in `if (i != nextArgIdx)`.
It is not entered in first time of loop.

In conclusion, when `forVariadic` is true,
this `for` loop is not repeated more than once and always reaches one of two `return` in first time of loop.

## Patch content

With above conclusion, it turns out that `forVariadic` is always `false` also in `if (claimedArgs[i])` scope.

So I write this patch as:

- add assertion about `forVariadic` in `if (claimedArgs[i])` as hint for code reader in future
- add assertion about `forVariadic` in `if (i != nextArgIdx)` as hint for code reader in future
- remove unused expression (`(paramInfo.hasDefaultArgument(i) || !forVariadic)`)

