### PR TITLE
[Incremental] Reorganization of SourceFileDepGraph building and mocking.

### DIFF
--- a/include/swift/AST/FineGrainedDependencies.h
+++ b/include/swift/AST/FineGrainedDependencies.h
@@ -378,6 +378,7 @@ const std::string NodeKindNames[]{
     "topLevel",      "nominal",        "potentialMember",  "member",
     "dynamicLookup", "externalDepend", "sourceFileProvide"};
 
+
 /// Instead of the status quo scheme of two kinds of "Depends", cascading and
 /// non-cascading this code represents each entity ("Provides" in the status
 /// quo), by a pair of nodes. One node represents the "implementation." If the
@@ -396,6 +397,7 @@ template <typename FnT> void forEachAspect(FnT fn) {
   for (size_t i = 0; i < size_t(DeclAspect::aspectCount); ++i)
     fn(DeclAspect(i));
 }
+
 
 /// A pair of nodes that represent the two aspects of a given entity.
 /// Templated in order to serve for either SourceFileDepGraphNodes or
@@ -575,6 +577,14 @@ struct std::hash<typename swift::fine_grained_dependencies::DeclAspect> {
     return size_t(aspect);
   }
 };
+template <>
+struct std::hash<typename swift::fine_grained_dependencies::NodeKind> {
+  size_t
+  operator()(const swift::fine_grained_dependencies::NodeKind kind) const {
+    return size_t(kind);
+  }
+};
+
 
 namespace swift {
 namespace fine_grained_dependencies {

--- a/include/swift/AST/FineGrainedDependencies.h
+++ b/include/swift/AST/FineGrainedDependencies.h
@@ -93,14 +93,20 @@ template <typename KeyT, typename ValueT> class Memoizer {
 public:
   Memoizer() = default;
 
+  Optional<ValueT> findExisting(KeyT key) {
+    auto iter = memos.find(key);
+    if (iter != memos.end())
+      return iter->second;
+    return None;
+  }
+
   /// \p createFn must create a \ref ValueT that corresponds to the \ref KeyT
   /// passed into it.
   ValueT
   findExistingOrCreateIfNew(KeyT key,
                             function_ref<ValueT(const KeyT &)> createFn) {
-    auto iter = memos.find(key);
-    if (iter != memos.end())
-      return iter->second;
+    if (auto existing = findExisting(key))
+      return existing.getValue();
     ValueT v = createFn(key);
     (void)insert(key, v);
     return v;
@@ -499,9 +505,22 @@ public:
   }
   bool isInterface() const { return getAspect() == DeclAspect::interface; }
 
+  /// Create just the interface half of the keys for a provided Decl or Decl
+  /// pair
+  template <NodeKind kind, typename Entity>
+  static DependencyKey createForProvidedEntityInterface(Entity);
+
   /// Given some type of provided entity compute the context field of the key.
   template <NodeKind kind, typename Entity>
   static std::string computeContextForProvidedEntity(Entity);
+
+  DependencyKey correspondingImplementation() const {
+    return withAspect(DeclAspect::implementation);
+  }
+
+  DependencyKey withAspect(DeclAspect aspect) const {
+    return DependencyKey(kind, aspect, context, name);
+  }
 
   /// Given some type of provided entity compute the name field of the key.
   template <NodeKind kind, typename Entity>
@@ -514,7 +533,8 @@ public:
   template <NodeKind kind>
   static DependencyKey createDependedUponKey(StringRef);
 
-  static DependencyKey createKeyForWholeSourceFile(StringRef swiftDeps);
+  static DependencyKey createKeyForWholeSourceFile(DeclAspect,
+                                                   StringRef swiftDeps);
 
   std::string humanReadableName() const;
 
@@ -616,6 +636,10 @@ public:
   /// See SourceFileDepGraphNode::SourceFileDepGraphNode(...) and
   /// ModuleDepGraphNode::ModuleDepGraphNode(...) Don't set swiftDeps on
   /// creation because this field can change if a node is moved.
+  DepGraphNode(DependencyKey key, Optional<StringRef> fingerprint)
+      : DepGraphNode(key, fingerprint ? fingerprint->str()
+                                      : Optional<std::string>()) {}
+
   DepGraphNode(DependencyKey key, Optional<std::string> fingerprint)
       : key(key), fingerprint(fingerprint) {}
   DepGraphNode(const DepGraphNode &other) = default;
@@ -627,8 +651,12 @@ public:
 
   const DependencyKey &getKey() const { return key; }
 
-  const Optional<std::string> &getFingerprint() const { return fingerprint; }
-
+  const Optional<StringRef> getFingerprint() const {
+    if (fingerprint) {
+      return StringRef(fingerprint.getValue());
+    }
+    return None;
+  }
   /// When driver reads a SourceFileDepGraphNode, it may be a node that was
   /// created to represent a name-lookup (a.k.a a "depend") in the frontend. In
   /// that case, the node represents an entity that resides in some other file
@@ -637,7 +665,9 @@ public:
   /// (someday) have a fingerprint. In order to preserve the
   /// ModuleDepGraphNode's identity but bring its fingerprint up to date, it
   /// needs to set the fingerprint *after* the node has been created.
-  void setFingerprint(Optional<std::string> fp) { fingerprint = fp; }
+  void setFingerprint(Optional<StringRef> fp) {
+    fingerprint = fp ? fp->str() : Optional<std::string>();
+  }
 
   SWIFT_DEBUG_DUMP;
   void dump(llvm::raw_ostream &os) const;
@@ -684,7 +714,7 @@ public:
   SourceFileDepGraphNode() : DepGraphNode(), sequenceNumber(~0) {}
 
   /// Used by the frontend to build nodes.
-  SourceFileDepGraphNode(DependencyKey key, Optional<std::string> fingerprint,
+  SourceFileDepGraphNode(DependencyKey key, Optional<StringRef> fingerprint,
                          bool isProvides)
       : DepGraphNode(key, fingerprint), isProvides(isProvides) {
     assert(key.verify());
@@ -780,34 +810,6 @@ public:
   SourceFileDepGraph(const SourceFileDepGraph &g) = delete;
   SourceFileDepGraph(SourceFileDepGraph &&g) = default;
 
-  /// Simulate loading for unit testing:
-  /// \param swiftDepsFileName The name of the swiftdeps file of the phony job
-  /// \param includePrivateDeps Whether the graph includes intra-file arcs
-  /// \param hadCompilationError Simulate a compilation error
-  /// \param interfaceHash The interface hash of the simulated graph
-  /// \param simpleNamesByRDK A map of vectors of names keyed by reference
-  /// dependency key \param compoundNamesByRDK A map of (mangledHolder,
-  /// baseName) pairs keyed by reference dependency key. For single-name
-  /// dependencies, an initial underscore indicates that the name does not
-  /// cascade. For compound names, it is the first name, the holder which
-  /// indicates non-cascading. For member names, an initial underscore indicates
-  /// file-privacy.
-  static SourceFileDepGraph
-  simulateLoad(std::string swiftDepsFileName, const bool includePrivateDeps,
-               const bool hadCompilationError, std::string interfaceHash,
-               llvm::StringMap<std::vector<std::string>> simpleNamesByRDK,
-               llvm::StringMap<std::vector<std::pair<std::string, std::string>>>
-                   compoundNamesByRDK);
-
-  static constexpr char noncascadingOrPrivatePrefix = '#';
-  static constexpr char nameFingerprintSeparator = ',';
-
-  static std::string noncascading(std::string name);
-
-  LLVM_ATTRIBUTE_UNUSED
-  static std::string privatize(std::string name);
-
-
   /// Nodes are owned by the graph.
   ~SourceFileDepGraph() {
     forEachNode([&](SourceFileDepGraphNode *n) { delete n; });
@@ -851,12 +853,15 @@ public:
   /// The frontend creates a pair of nodes for every tracked Decl and the source
   /// file itself.
   InterfaceAndImplementationPair<SourceFileDepGraphNode>
-  findExistingNodePairOrCreateAndAddIfNew(
-      NodeKind k, const ContextNameFingerprint &contextNameFingerprint);
+  findExistingNodePairOrCreateAndAddIfNew(const DependencyKey &interfaceKey,
+                                          Optional<StringRef> fingerprint);
+
+  NullablePtr<SourceFileDepGraphNode>
+  findExistingNode(const DependencyKey &key);
 
   SourceFileDepGraphNode *
-  findExistingNodeOrCreateIfNew(DependencyKey key,
-                                const Optional<std::string> &fingerprint,
+  findExistingNodeOrCreateIfNew(const DependencyKey &key,
+                                const Optional<StringRef> fingerprint,
                                 bool isProvides);
 
   /// \p Use is the Node that must be rebuilt when \p def changes.

--- a/include/swift/AST/SourceFileDepGraphConstructor.h
+++ b/include/swift/AST/SourceFileDepGraphConstructor.h
@@ -1,0 +1,143 @@
+//===----- SourceFileDepGraphConstructor.h ----------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_SOURCE_FILE_DEP_GRAPH_CONSTRUCTOR_H
+#define SWIFT_AST_SOURCE_FILE_DEP_GRAPH_CONSTRUCTOR_H
+
+#include <swift/AST/DeclContext.h>
+
+namespace swift {
+namespace fine_grained_dependencies {
+/// Reads the information provided by the frontend and builds the
+/// SourceFileDepGraph
+class SourceFileDepGraphConstructor {
+  /// To match the existing system, set this to false.
+  /// To include even private entities and get intra-file info, set to true.
+  const bool includePrivateDeps;
+
+  /// If there was an error, cannot get accurate info.
+  const bool hadCompilationError;
+
+public:
+  /// A lambda which invokes its parameter for every unconstrained \c Decl used
+  /// in the source file, passing in the base name, and whether this use
+  /// cascades..
+  using ForEachUnconstrainedDeclUsed =
+      function_ref<void(function_ref<void(StringRef, bool)>)>;
+
+  /// A lambda which invokes its parameter for every constrained \c Decl used in
+  /// the source file, passing in the manged type name of the holder, the member
+  /// base name, whether the holder is private to its source file, and whether
+  /// the use cascades. If the baseName is empty, this entry will be a \c
+  /// potentialMember dependency.
+  using ForEachConstrainedDeclUsed =
+      function_ref<void(function_ref<void(StringRef, StringRef, bool, bool)>)>;
+
+  /// Adds nodes to the graph corresponding to a defined \c Decl.
+  /// Parameters are an interface key (implementation node will also be added)
+  /// and the fingerprint if any.
+  using AddDefinedDecl =
+      function_ref<void(const DependencyKey &, Optional<StringRef>)>;
+
+  /// A lambda which invokes its parameter for every mock \c Decl "defined" in
+  /// the source file, passing in to its argument the \c NodeKind, \c context,
+  /// and \c name fields of resulting \c DependencyKey pair, and also the
+  /// fingerprint (if present) of the resulting node pair.
+  using ForEachDefinedDecl = function_ref<void(AddDefinedDecl)>;
+
+  /// A lambda which invokes its parameter for every  use of a \c Decl in the
+  /// source file, passing in to its argument the \c DependencyKey used, and the
+  /// \c DependencyKey doing the using. (A.k.a. a "def" and an a "use".
+  using ForEachUsedDecl = function_ref<void(
+      function_ref<void(const DependencyKey &, const DependencyKey &)>)>;
+
+private:
+  /// Graph under construction
+  SourceFileDepGraph g;
+
+public:
+  /// Expose this layer to enable faking up a constructor for testing.
+  /// See the instance variable comments for explanation.
+  // clang-format off
+  SourceFileDepGraphConstructor(
+    bool includePrivateDeps,
+    bool hadCompilationError
+    ) :
+    includePrivateDeps(includePrivateDeps),
+    hadCompilationError(hadCompilationError)
+    {} // clang-format on
+
+  /// Create a SourceFileDepGraph.
+  ///
+  /// \param swiftDeps The "output path name" and \c sourceFileProvide node
+  /// names \param interfaceHash The fingerprint for the \c sourceFileProvide
+  /// nodes. \param forEachMockDefinedDecl Iterator for "provides", i.e.
+  /// definitions in this file \param forEachMockUsedDecl Iterator for
+  /// "depends", i.e. used definitions in this file
+  SourceFileDepGraph construct(StringRef swiftDeps, StringRef interfaceHash,
+                               ForEachDefinedDecl forEachDefinedDecl,
+                               ForEachUsedDecl forEachUsedDecl) {
+
+    return addSourceFileNodesAndThen(swiftDeps, interfaceHash, [&] {
+      addAllDefinedDecls(forEachDefinedDecl);
+      addAllUsedDecls(forEachUsedDecl);
+    });
+  }
+
+  /// Centralize the invariant that the fingerprint of the whole file is the
+  /// interface hash
+  static std::string getFingerprint(SourceFile *SF);
+
+  void enumerateDefinedDecls(SourceFile *SF, AddDefinedDecl addDefinedDeclFn);
+
+private:
+  /// Add the first two nodes in the graph and then, if there is no compilation
+  /// error, do rest of the work to build the graph.
+  SourceFileDepGraph addSourceFileNodesAndThen(StringRef name,
+                                               StringRef fingerprint,
+                                               function_ref<void()> doTheRest);
+
+  /// Add the "provides" nodes when mocking up a graph
+  void addAllDefinedDecls(ForEachDefinedDecl forEachDefinedDecl);
+
+  /// Add the "depends" nodes and arcs when mocking a graph
+  void addAllUsedDecls(ForEachUsedDecl forEachUsedDecl);
+
+  /// At present, only nominals, protocols, and extensions have (body)
+  /// fingerprints
+  static Optional<std::string>
+  getFingerprintIfAny(std::pair<const NominalTypeDecl *, const ValueDecl *>);
+
+  static Optional<std::string> getFingerprintIfAny(const Decl *d);
+
+  static std::string getInterfaceHash(SourceFile *SF);
+
+  void addSourceFileNodesToGraph(StringRef swiftDeps, StringRef fingerprint);
+
+  /// Given an array of Decls or pairs of them in \p declsOrPairs
+  /// create node pairs for context and name
+  template <NodeKind kind, typename ContentsT>
+  void
+  enumerateAllProviderNodesOfAGivenType(std::vector<ContentsT> &contentsVec,
+                                        AddDefinedDecl addDefinedDeclFn);
+
+  /// Add an pair of interface, implementation nodes to the graph, which
+  /// represent some \c Decl defined in this source file. \param key the
+  /// interface key of the pair
+  void addDefinedDecl(const DependencyKey &key,
+                      Optional<StringRef> fingerprint);
+};
+
+} // namespace fine_grained_dependencies
+} // namespace swift
+
+#endif // SWIFT_AST_SOURCE_FILE_DEP_GRAPH_CONSTRUCTOR_H

--- a/include/swift/Driver/FineGrainedDependencyDriverGraph.h
+++ b/include/swift/Driver/FineGrainedDependencyDriverGraph.h
@@ -57,8 +57,7 @@ class ModuleDepGraphNode : public DepGraphNode {
   bool hasBeenTracedAsADependent = false;
 
 public:
-  ModuleDepGraphNode(const DependencyKey &key,
-                     Optional<std::string> fingerprint,
+  ModuleDepGraphNode(const DependencyKey &key, Optional<StringRef> fingerprint,
                      Optional<std::string> swiftDeps)
       : DepGraphNode(key, fingerprint), swiftDeps(swiftDeps) {}
 
@@ -187,11 +186,13 @@ class ModuleDepGraph {
   /// files for the same name distinct, keep a sequence number for each name.
   std::unordered_map<std::string, unsigned> dotFileSequenceNumber;
 
+public:
   const bool verifyFineGrainedDependencyGraphAfterEveryImport;
   const bool emitFineGrainedDependencyDotFileAfterEveryImport;
 
   const bool EnableTypeFingerprints;
 
+private:
   /// If tracing dependencies, holds a vector used to hold the current path
   /// def - use/def - use/def - ...
   Optional<std::vector<const ModuleDepGraphNode *>> currentPathIfTracing;
@@ -335,15 +336,6 @@ public:
   Changes loadFromSourceFileDepGraph(const driver::Job *cmd,
                                      const SourceFileDepGraph &,
                                      DiagnosticEngine &);
-
-  /// Also for unit tests
-  Changes
-  simulateLoad(const driver::Job *cmd,
-               llvm::StringMap<std::vector<std::string>> simpleNames,
-               llvm::StringMap<std::vector<std::pair<std::string, std::string>>>
-                   compoundNames = {},
-               const bool includePrivateDeps = false,
-               const bool hadCompilationError = false);
 
 
 private:
@@ -514,6 +506,8 @@ private:
 public:
   /// Record a new (to this graph) Job.
   void registerJob(const driver::Job *);
+
+  std::vector<const driver::Job *> getAllJobs() const;
 
   /// Find jobs that were previously not known to need compilation but that
   /// depend on \c externalDependency.

--- a/lib/AST/FineGrainedDependencies.cpp
+++ b/lib/AST/FineGrainedDependencies.cpp
@@ -180,9 +180,9 @@ std::string DependencyKey::demangleTypeAsContext(StringRef s) {
 DependencyKey DependencyKey::createKeyForWholeSourceFile(DeclAspect aspect,
                                                          StringRef swiftDeps) {
   assert(!swiftDeps.empty());
-  const auto context = DependencyKey::computeContextForProvidedEntity<
+  const std::string context = DependencyKey::computeContextForProvidedEntity<
       NodeKind::sourceFileProvide>(swiftDeps);
-  const auto name =
+  const std::string name =
       DependencyKey::computeNameForProvidedEntity<NodeKind::sourceFileProvide>(
           swiftDeps);
   return DependencyKey(NodeKind::sourceFileProvide, aspect, context, name);

--- a/lib/AST/FineGrainedDependencies.cpp
+++ b/lib/AST/FineGrainedDependencies.cpp
@@ -103,17 +103,20 @@ void SourceFileDepGraph::forEachArc(
 
 InterfaceAndImplementationPair<SourceFileDepGraphNode>
 SourceFileDepGraph::findExistingNodePairOrCreateAndAddIfNew(
-    NodeKind k, const ContextNameFingerprint &contextNameFingerprint) {
-  const std::string &context = std::get<0>(contextNameFingerprint);
-  const std::string &name = std::get<1>(contextNameFingerprint);
-  const Optional<std::string> &fingerprint =
-      std::get<2>(contextNameFingerprint);
-  auto *interfaceNode = findExistingNodeOrCreateIfNew(
-      DependencyKey(k, DeclAspect::interface, context, name), fingerprint,
-      true /* = isProvides */);
+    const DependencyKey &interfaceKey, Optional<StringRef> fingerprint) {
+
+  // Optimization for whole-file users:
+  if (interfaceKey.getKind() == NodeKind::sourceFileProvide &&
+      !allNodes.empty())
+    return getSourceFileNodePair();
+
+  assert(interfaceKey.isInterface());
+  const DependencyKey implementationKey =
+      interfaceKey.correspondingImplementation();
+  auto *interfaceNode = findExistingNodeOrCreateIfNew(interfaceKey, fingerprint,
+                                                      true /* = isProvides */);
   auto *implementationNode = findExistingNodeOrCreateIfNew(
-      DependencyKey(k, DeclAspect::implementation, context, name), fingerprint,
-      true /* = isProvides */);
+      implementationKey, fingerprint, true /* = isProvides */);
 
   InterfaceAndImplementationPair<SourceFileDepGraphNode> nodePair{
       interfaceNode, implementationNode};
@@ -136,7 +139,7 @@ SourceFileDepGraph::findExistingNodePairOrCreateAndAddIfNew(
 }
 
 SourceFileDepGraphNode *SourceFileDepGraph::findExistingNodeOrCreateIfNew(
-    DependencyKey key, const Optional<std::string> &fingerprint,
+    const DependencyKey &key, const Optional<StringRef> fingerprint,
     const bool isProvides) {
   SourceFileDepGraphNode *result = memoizedNodes.findExistingOrCreateIfNew(
       key, [&](DependencyKey key) -> SourceFileDepGraphNode * {
@@ -164,20 +167,25 @@ SourceFileDepGraphNode *SourceFileDepGraph::findExistingNodeOrCreateIfNew(
   return result;
 }
 
+NullablePtr<SourceFileDepGraphNode>
+SourceFileDepGraph::findExistingNode(const DependencyKey &key) {
+  auto existing = memoizedNodes.findExisting(key);
+  return existing ? existing.getValue() : NullablePtr<SourceFileDepGraphNode>();
+}
+
 std::string DependencyKey::demangleTypeAsContext(StringRef s) {
   return swift::Demangle::demangleTypeAsString(s.str());
 }
 
-DependencyKey
-DependencyKey::createKeyForWholeSourceFile(const StringRef swiftDeps) {
+DependencyKey DependencyKey::createKeyForWholeSourceFile(DeclAspect aspect,
+                                                         StringRef swiftDeps) {
   assert(!swiftDeps.empty());
   const auto context = DependencyKey::computeContextForProvidedEntity<
       NodeKind::sourceFileProvide>(swiftDeps);
   const auto name =
       DependencyKey::computeNameForProvidedEntity<NodeKind::sourceFileProvide>(
           swiftDeps);
-  return DependencyKey(NodeKind::sourceFileProvide, DeclAspect::interface,
-                       context, name);
+  return DependencyKey(NodeKind::sourceFileProvide, aspect, context, name);
 }
 
 //==============================================================================

--- a/lib/AST/SourceFileDepGraphConstructor.cpp
+++ b/lib/AST/SourceFileDepGraphConstructor.cpp
@@ -695,15 +695,15 @@ private:
     enumerateMemberUses();
   }
 
-  llvm::StringSet<> computeHoldersOfCascadingMembers() {
-    llvm::StringSet<> holdersOfCascadingMembers;
+  std::unordered_set<std::string> computeHoldersOfCascadingMembers() {
+    std::unordered_set<std::string> holdersOfCascadingMembers;
     for (const auto &p : SF->getReferencedNameTracker()->getUsedMembers()) {
       {
         bool isPrivate = declIsPrivate(p.getFirst().first);
         if (isPrivate && !includeIntrafileDeps)
           continue;
       }
-      StringRef context =
+      std::string context =
           DependencyKey::computeContextForProvidedEntity<NodeKind::nominal>(
               p.getFirst().first);
       bool isCascading = p.getSecond();
@@ -713,8 +713,8 @@ private:
     return holdersOfCascadingMembers;
   }
 
-  void
-  enumerateNominalUses(const llvm::StringSet<> &&holdersOfCascadingMembers) {
+  void enumerateNominalUses(
+      const std::unordered_set<std::string> &&holdersOfCascadingMembers) {
     for (const auto &p : SF->getReferencedNameTracker()->getUsedMembers()) {
       {
         bool isPrivate = declIsPrivate(p.getFirst().first);
@@ -723,7 +723,7 @@ private:
       }
       const NominalTypeDecl *nominal = p.getFirst().first;
 
-      StringRef context =
+      std::string context =
           DependencyKey::computeContextForProvidedEntity<NodeKind::nominal>(
               nominal);
       const bool isCascadingUse = holdersOfCascadingMembers.count(context) != 0;
@@ -738,11 +738,11 @@ private:
       const bool isPotentialMember = rawName.empty();
       const bool isCascadingUse = p.getSecond();
       if (isPotentialMember) {
-        StringRef context = DependencyKey::computeContextForProvidedEntity<
+        std::string context = DependencyKey::computeContextForProvidedEntity<
             NodeKind::potentialMember>(nominal);
         enumerateUse(NodeKind::potentialMember, context, "", isCascadingUse);
       } else {
-        StringRef context =
+        std::string context =
             DependencyKey::computeContextForProvidedEntity<NodeKind::member>(
                 nominal);
         StringRef name = rawName.userFacingName();

--- a/unittests/Driver/CMakeLists.txt
+++ b/unittests/Driver/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_swift_unittest(SwiftDriverTests
   CoarseGrainedDependencyGraphTests.cpp
   FineGrainedDependencyGraphTests.cpp
+  MockingFineGrainedDependencyGraphs.cpp
   TypeBodyFingerprintsDependencyGraphTests.cpp
 )
 

--- a/unittests/Driver/FineGrainedDependencyGraphTests.cpp
+++ b/unittests/Driver/FineGrainedDependencyGraphTests.cpp
@@ -1,22 +1,20 @@
+#include "MockingFineGrainedDependencyGraphs.h"
 #include "swift/Basic/ReferenceDependencyKeys.h"
 #include "swift/Driver/CoarseGrainedDependencyGraph.h"
 #include "swift/Driver/FineGrainedDependencyDriverGraph.h"
 #include "swift/Driver/Job.h"
 #include "gtest/gtest.h"
 
-// This file adapts the unit tests from the older, coarse-grained, dependency
-// graph to the new fine-grained graph.
-
-// \c findJobsToRecompileWhenWholeJobChanges and \c
-// findExternallyDependentUntracedJobs may include jobs in their result that
-// would be excluded in the coarse-grained graph. But since these will be jobs
-// that have already been scheduled, downstream mechanisms will filter them out.
+// A version of \c ModuleDepGraphTests.cpp that tests things with
+// type-body fingerprints disabled.
+//
+// In order to get the test macros to work right, it seems that the tests
+// must be copied-and-pasted, sigh.
 
 using namespace swift;
-using namespace reference_dependency_keys;
 using namespace fine_grained_dependencies;
+using namespace mocking_fine_grained_dependency_graphs;
 using Job = driver::Job;
-
 
 static OutputFileMap OFM;
 
@@ -41,39 +39,31 @@ static bool contains(const Range &range, const T &value) {
          std::end(range);
 }
 
-TEST(ModuleDepGraph, BasicLoad) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, BasicLoad) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{dependsTopLevel, {"a", "b"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsNominal, {"c", "d"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{providesTopLevel, {"e", "f"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job3, {{providesNominal, {"g", "h"}}}));
-  EXPECT_TRUE(
-      graph.simulateLoad( &job4, {{providesDynamicLookup, {"i", "j"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job5, {{dependsDynamicLookup, {"k", "l"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job6, {},
-                           {{providesMember, {{"m", "mm"}, {"n", "nn"}}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job7, {},
-                           {{dependsMember, {{"o", "oo"}, {"p", "pp"}}}}));
-  EXPECT_TRUE(
-      graph.simulateLoad( &job8, {{dependsExternal, {"/foo", "/bar"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a->", "b->"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"c->", "d->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::topLevel, {"e", "f"}}});
+  simulateLoad(graph, &job3, {{NodeKind::nominal, {"g", "h"}}});
+  simulateLoad(graph, &job4, {{NodeKind::dynamicLookup, {"i", "j"}}});
+  simulateLoad(graph, &job5, {{NodeKind::dynamicLookup, {"k->", "l->"}}});
+  simulateLoad(graph, &job6, {{NodeKind::member, {"m,mm", "n,nn"}}});
+  simulateLoad(graph, &job7, {{NodeKind::member, {"o,oo->", "p,pp->"}}});
+  simulateLoad(graph, &job8,
+               {{NodeKind::externalDepend, {"/foo->", "/bar->"}}});
 
-  EXPECT_TRUE(graph.simulateLoad( &job9,
-                           {{providesNominal, {"a", "b"}},
-                            {providesTopLevel, {"b", "c"}},
-                            {dependsNominal, {"c", "d"}},
-                            {dependsTopLevel, {"d", "a"}}}));
+  simulateLoad(graph, &job9,
+               {{NodeKind::nominal, {"a", "b", "c->", "d->"}},
+                {NodeKind::topLevel, {"b", "c", "d->", "a->"}}});
 }
 
-TEST(ModuleDepGraph, IndependentNodes) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, IndependentNodes) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(graph.simulateLoad(
-      &job0, {{dependsTopLevel, {"a"}}, {providesTopLevel, {"a0"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsTopLevel, {"b"}}, {providesTopLevel, {"b0"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job2, {{dependsTopLevel, {"c"}}, {providesTopLevel, {"c0"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a0", "a->"}}});
+  simulateLoad(graph, &job1, {{NodeKind::topLevel, {"b0", "b->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::topLevel, {"c0", "c->"}}});
 
   EXPECT_EQ(1u, graph.findJobsToRecompileWhenWholeJobChanges(&job0).size());
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
@@ -97,41 +87,36 @@ TEST(ModuleDepGraph, IndependentNodes) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
 }
 
-TEST(ModuleDepGraph, IndependentDepKinds) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, IndependentDepKinds) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(graph.simulateLoad(
-      &job0, {{dependsNominal, {"a"}}, {providesNominal, {"b"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsTopLevel, {"b"}}, {providesTopLevel, {"a"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a", "a->"}}});
+  simulateLoad(graph, &job1, {{NodeKind::topLevel, {"a", "b->"}}});
 
   EXPECT_EQ(1u, graph.findJobsToRecompileWhenWholeJobChanges(&job0).size());
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraph, IndependentDepKinds2) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, IndependentDepKinds2) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(graph.simulateLoad(
-      &job0, {{dependsNominal, {"a"}}, {providesNominal, {"b"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsTopLevel, {"b"}}, {providesTopLevel, {"a"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a->", "b"}}});
+  simulateLoad(graph, &job1, {{NodeKind::topLevel, {"b->", "a"}}});
 
   EXPECT_EQ(1u, graph.findJobsToRecompileWhenWholeJobChanges(&job1).size());
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job0));
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraph, IndependentMembers) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, IndependentMembers) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(
-      graph.simulateLoad( &job0, {}, {{providesMember, {{"a", "aa"}}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {}, {{dependsMember, {{"a", "bb"}}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {}, {{dependsMember, {{"a", ""}}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job3, {}, {{dependsMember, {{"b", "aa"}}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job4, {}, {{dependsMember, {{"b", "bb"}}}}));
+  simulateLoad(graph, &job0, {{NodeKind::member, {"a,aa"}}});
+  simulateLoad(graph, &job1, {{NodeKind::member, {"a,bb->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::potentialMember, {"a"}}});
+  simulateLoad(graph, &job3, {{NodeKind::member, {"b,aa->"}}});
+  simulateLoad(graph, &job4, {{NodeKind::member, {"b,bb->"}}});
 
   EXPECT_EQ(1u, graph.findJobsToRecompileWhenWholeJobChanges(&job0).size());
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
@@ -141,12 +126,11 @@ TEST(ModuleDepGraph, IndependentMembers) {
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job4));
 }
 
-TEST(ModuleDepGraph, SimpleDependent) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, SimpleDependent) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(
-      graph.simulateLoad( &job0, {{providesTopLevel, {"a", "b", "c"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsTopLevel, {"x", "b", "z"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a", "b", "c"}}});
+  simulateLoad(graph, &job1, {{NodeKind::topLevel, {"x->", "b->", "z->"}}});
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
     EXPECT_EQ(2u, jobs.size());
@@ -160,17 +144,16 @@ TEST(ModuleDepGraph, SimpleDependent) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraph, SimpleDependentReverse) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, SimpleDependentReverse) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{dependsTopLevel, {"a", "b", "c"}}}));
-  EXPECT_TRUE(
-      graph.simulateLoad( &job1, {{providesTopLevel, {"x", "b", "z"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a->", "b->", "c->"}}});
+  simulateLoad(graph, &job1, {{NodeKind::topLevel, {"x", "b", "z"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job1);
     EXPECT_EQ(2u, jobs.size());
-    EXPECT_EQ(&job0, jobs.front());
+    EXPECT_TRUE(contains(jobs, &job0));
   }
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
@@ -184,31 +167,11 @@ TEST(ModuleDepGraph, SimpleDependentReverse) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraph, SimpleDependent2) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, SimpleDependent2) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a", "b", "c"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsNominal, {"x", "b", "z"}}}));
-
-  {
-    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
-    EXPECT_EQ(2u, jobs.size());
-    EXPECT_TRUE(contains(jobs, &job1));
-  }
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
-
-  EXPECT_EQ(0u, graph.findJobsToRecompileWhenWholeJobChanges(&job0).size());
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
-}
-
-TEST(ModuleDepGraph, SimpleDependent3) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
-
-  EXPECT_TRUE(graph.simulateLoad(
-      &job0, {{providesNominal, {"a"}}, {providesTopLevel, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsNominal, {"a"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a", "b", "c"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"x->", "b->", "z->"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
@@ -223,12 +186,12 @@ TEST(ModuleDepGraph, SimpleDependent3) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraph, SimpleDependent4) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, SimpleDependent3) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsNominal, {"a"}}, {dependsTopLevel, {"a"}}}));
+  simulateLoad(graph, &job0,
+               {{NodeKind::nominal, {"a"}}, {NodeKind::topLevel, {"a"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"a->"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
@@ -243,13 +206,33 @@ TEST(ModuleDepGraph, SimpleDependent4) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraph, SimpleDependent5) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, SimpleDependent4) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(graph.simulateLoad(
-      &job0, {{providesNominal, {"a"}}, {providesTopLevel, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsNominal, {"a"}}, {dependsTopLevel, {"a"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a"}}});
+  simulateLoad(graph, &job1,
+               {{NodeKind::nominal, {"a->"}}, {NodeKind::topLevel, {"a->"}}});
+
+  {
+    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
+    EXPECT_EQ(2u, jobs.size());
+    EXPECT_TRUE(contains(jobs, &job1));
+  }
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
+
+  EXPECT_EQ(0u, graph.findJobsToRecompileWhenWholeJobChanges(&job0).size());
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
+}
+
+TEST(ModuleDepGraphWithoutFingerprints, SimpleDependent5) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
+
+  simulateLoad(graph, &job0,
+               {{NodeKind::nominal, {"a"}}, {NodeKind::topLevel, {"a"}}});
+  simulateLoad(graph, &job1,
+               {{NodeKind::nominal, {"a->"}}, {NodeKind::topLevel, {"a->"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
@@ -265,13 +248,12 @@ TEST(ModuleDepGraph, SimpleDependent5) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraph, SimpleDependent6) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, SimpleDependent6) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(
-      graph.simulateLoad( &job0, {{providesDynamicLookup, {"a", "b", "c"}}}));
-  EXPECT_TRUE(
-      graph.simulateLoad( &job1, {{dependsDynamicLookup, {"x", "b", "z"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::dynamicLookup, {"a", "b", "c"}}});
+  simulateLoad(graph, &job1,
+               {{NodeKind::dynamicLookup, {"x->", "b->", "z->"}}});
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
     EXPECT_EQ(2u, jobs.size());
@@ -285,15 +267,12 @@ TEST(ModuleDepGraph, SimpleDependent6) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraph, SimpleDependentMember) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, SimpleDependentMember) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(graph.simulateLoad(
-      &job0, {},
-      {{providesMember, {{"a", "aa"}, {"b", "bb"}, {"c", "cc"}}}}));
-  EXPECT_TRUE(
-      graph.simulateLoad( &job1, {},
-                   {{dependsMember, {{"x", "xx"}, {"b", "bb"}, {"z", "zz"}}}}));
+  simulateLoad(graph, &job0, {{NodeKind::member, {"a,aa", "b,bb", "c,cc"}}});
+  simulateLoad(graph, &job1,
+               {{NodeKind::member, {"x,xx->", "b,bb->", "z,zz->"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
@@ -308,35 +287,12 @@ TEST(ModuleDepGraph, SimpleDependentMember) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraph, MultipleDependentsSame) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, MultipleDependentsSame) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a", "b", "c"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsNominal, {"x", "b", "z"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsNominal, {"q", "b", "s"}}}));
-
-  {
-    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
-    EXPECT_EQ(3u, jobs.size());
-    EXPECT_TRUE(contains(jobs, &job1));
-    EXPECT_TRUE(contains(jobs, &job2));
-  }
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
-
-  EXPECT_EQ(0u, graph.findJobsToRecompileWhenWholeJobChanges(&job0).size());
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
-}
-
-TEST(ModuleDepGraph, MultipleDependentsDifferent) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
-
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a", "b", "c"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsNominal, {"x", "b", "z"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsNominal, {"q", "r", "c"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a", "b", "c"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"x->", "b->", "z->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"q->", "b->", "s->"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
@@ -354,37 +310,12 @@ TEST(ModuleDepGraph, MultipleDependentsDifferent) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
 }
 
-TEST(ModuleDepGraph, ChainedDependents) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, MultipleDependentsDifferent) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a", "b", "c"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsNominal, {"x", "b"}}, {providesNominal, {"z"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsNominal, {"z"}}}));
-
-  {
-    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
-    EXPECT_EQ(3u, jobs.size());
-    EXPECT_TRUE(contains(jobs, &job1));
-    EXPECT_TRUE(contains(jobs, &job2));
-  }
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
-
-  EXPECT_EQ(0u, graph.findJobsToRecompileWhenWholeJobChanges(&job0).size());
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
-}
-
-TEST(ModuleDepGraph, ChainedNoncascadingDependents) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
-
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a", "b", "c"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsNominal, {"x", "b"}}, {providesNominal, {SourceFileDepGraph::noncascading("z")}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsNominal, {SourceFileDepGraph::noncascading("z")}}}));
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a", "b", "c"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"x->", "b->", "z->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"q->", "r->", "c->"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
@@ -402,15 +333,60 @@ TEST(ModuleDepGraph, ChainedNoncascadingDependents) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
 }
 
-TEST(ModuleDepGraph, ChainedNoncascadingDependents2) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, ChainedDependents) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(
-      graph.simulateLoad( &job0, {{providesTopLevel, {"a", SourceFileDepGraph::noncascading("b"), "c"}}}));
-  EXPECT_TRUE(
-      graph.simulateLoad( &job1,
-                   {{dependsTopLevel, {"x", SourceFileDepGraph::noncascading("b")}}, {providesNominal, {"z"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsNominal, {"z"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a", "b", "c"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"x->", "b->", "z"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"z->"}}});
+
+  {
+    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
+    EXPECT_EQ(3u, jobs.size());
+    EXPECT_TRUE(contains(jobs, &job1));
+    EXPECT_TRUE(contains(jobs, &job2));
+  }
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
+
+  EXPECT_EQ(0u, graph.findJobsToRecompileWhenWholeJobChanges(&job0).size());
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
+}
+
+TEST(ModuleDepGraphWithoutFingerprints, ChainedNoncascadingDependents) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
+
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a", "b", "c"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"x->", "b->", "#z"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"#z->"}}});
+
+  {
+    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
+    EXPECT_EQ(3u, jobs.size());
+    EXPECT_TRUE(contains(jobs, &job1));
+    EXPECT_TRUE(contains(jobs, &job2));
+  }
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
+
+  EXPECT_EQ(0u, graph.findJobsToRecompileWhenWholeJobChanges(&job0).size());
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
+}
+
+TEST(ModuleDepGraphWithoutFingerprints, ChainedNoncascadingDependents2) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
+
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a", "b", "c"}}});
+  simulateLoad(
+      graph, &job1,
+      {{NodeKind::topLevel, {"x->", "#b->"}}, {NodeKind::nominal, {"z"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"z->"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
@@ -422,19 +398,15 @@ TEST(ModuleDepGraph, ChainedNoncascadingDependents2) {
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job2));
 }
 
-TEST(ModuleDepGraph, MarkTwoNodes) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, MarkTwoNodes) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesTopLevel, {"a", "b"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsTopLevel, {"a"}}, {providesTopLevel, {"z"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsTopLevel, {"z"}}}));
-  EXPECT_TRUE(
-      graph.simulateLoad( &job10,
-                   {{providesTopLevel, {"y", "z"}}, {dependsTopLevel, {"q"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job11, {{dependsTopLevel, {"y"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job12, {{dependsTopLevel, {"q"}}, {providesTopLevel, {"q"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a", "b"}}});
+  simulateLoad(graph, &job1, {{NodeKind::topLevel, {"a->", "z"}}});
+  simulateLoad(graph, &job2, {{NodeKind::topLevel, {"z->"}}});
+  simulateLoad(graph, &job10, {{NodeKind::topLevel, {"y", "z", "q->"}}});
+  simulateLoad(graph, &job11, {{NodeKind::topLevel, {"y->"}}});
+  simulateLoad(graph, &job12, {{NodeKind::topLevel, {"q->", "q"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
@@ -464,41 +436,12 @@ TEST(ModuleDepGraph, MarkTwoNodes) {
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job12));
 }
 
-TEST(ModuleDepGraph, MarkOneNodeTwice) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, MarkOneNodeTwice) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsNominal, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsNominal, {"b"}}}));
-
-  {
-    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
-    EXPECT_EQ(2u, jobs.size());
-    EXPECT_TRUE(contains(jobs, &job1));
-  }
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
-  EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job2));
-
-  // Reload 0.
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"b"}}}));
-
-  {
-    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
-    EXPECT_EQ(2u, jobs.size());
-    EXPECT_TRUE(contains(jobs, &job2));
-  }
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
-}
-
-TEST(ModuleDepGraph, MarkOneNodeTwice2) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
-
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsNominal, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsNominal, {"b"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"a->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"b->"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
@@ -509,11 +452,8 @@ TEST(ModuleDepGraph, MarkOneNodeTwice2) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job2));
 
-  // Reload 0.
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a", "b"}}}));
-
   {
-    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
+    auto jobs = simulateReload(graph, &job0, {{NodeKind::nominal, {"b"}}});
     EXPECT_EQ(2u, jobs.size());
     EXPECT_TRUE(contains(jobs, &job2));
   }
@@ -522,12 +462,38 @@ TEST(ModuleDepGraph, MarkOneNodeTwice2) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
 }
 
-TEST(ModuleDepGraph, ReloadDetectsChange) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, MarkOneNodeTwice2) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsNominal, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsNominal, {"b"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"a->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"b->"}}});
+
+  {
+    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
+    EXPECT_EQ(2u, jobs.size());
+    EXPECT_TRUE(contains(jobs, &job1));
+  }
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
+  EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job2));
+
+  {
+    auto jobs = simulateReload(graph, &job0, {{NodeKind::nominal, {"a", "b"}}});
+    EXPECT_EQ(2u, jobs.size());
+    EXPECT_TRUE(contains(jobs, &job2));
+  }
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
+}
+
+TEST(ModuleDepGraphWithoutFingerprints, ReloadDetectsChange) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
+
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"a->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"b->"}}});
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job1);
     EXPECT_EQ(1u, jobs.size());
@@ -537,41 +503,27 @@ TEST(ModuleDepGraph, ReloadDetectsChange) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job2));
 
-  // Reload 1.
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsNominal, {"a"}}, {providesNominal, {"b"}}}));
-
   {
-    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
-    EXPECT_EQ(1u, jobs.size());
-    EXPECT_TRUE(contains(jobs, &job0));
-  }
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
-  EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job2));
-
-  // Re-mark 1.
-  {
-    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job1);
+    auto jobs =
+        simulateReload(graph, &job1, {{NodeKind::nominal, {"b", "a->"}}});
     EXPECT_EQ(2u, jobs.size());
     EXPECT_TRUE(contains(jobs, &job1));
     EXPECT_TRUE(contains(jobs, &job2));
   }
-
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
+  EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job0));
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
 }
 
-TEST(ModuleDepGraph, NotTransitiveOnceMarked) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, NotTransitiveOnceMarked) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsNominal, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsNominal, {"b"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"a->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"b->"}}});
 
   {
-  const auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job1);
+    const auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job1);
     EXPECT_EQ(1u, jobs.size());
     EXPECT_TRUE(contains(jobs, &job1));
   }
@@ -579,41 +531,25 @@ TEST(ModuleDepGraph, NotTransitiveOnceMarked) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job2));
 
-  // Reload 1.
-  EXPECT_TRUE(graph.simulateLoad( &job1,
-  {{dependsNominal, {"a"}}, {providesNominal, {"b"}}}));
-
   {
-  const auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
-    EXPECT_EQ(1u, jobs.size());
-    EXPECT_TRUE(contains(jobs, &job0));
+    const auto jobs =
+        simulateReload(graph, &job1, {{NodeKind::nominal, {"b", "a->"}}});
+    EXPECT_EQ(2u, jobs.size());
+    EXPECT_TRUE(contains(jobs, &job1));
+    EXPECT_TRUE(contains(jobs, &job2));
   }
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
-  EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job2));
-
-  // Re-mark 1.
-  {
-    auto found = graph.findJobsToRecompileWhenWholeJobChanges(&job1);
-    EXPECT_EQ(2u, found.size());
-    EXPECT_TRUE(contains(found, &job1));
-    EXPECT_TRUE(contains(found, &job2));
-  }
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
+  EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job0));
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
 }
 
-TEST(ModuleDepGraph, DependencyLoops) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, DependencyLoops) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(graph.simulateLoad(
-      &job0,
-      {{providesTopLevel, {"a", "b", "c"}}, {dependsTopLevel, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1,
-      {{providesTopLevel, {"x"}}, {dependsTopLevel, {"x", "b", "z"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsTopLevel, {"x"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a", "b", "c", "a->"}}});
+  simulateLoad(graph, &job1,
+               {{NodeKind::topLevel, {"x", "x->", "b->", "z->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::topLevel, {"x->"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
@@ -634,12 +570,11 @@ TEST(ModuleDepGraph, DependencyLoops) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
 }
 
-TEST(ModuleDepGraph, MarkIntransitive) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, MarkIntransitive) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(
-      graph.simulateLoad( &job0, {{providesTopLevel, {"a", "b", "c"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsTopLevel, {"x", "b", "z"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a", "b", "c"}}});
+  simulateLoad(graph, &job1, {{NodeKind::topLevel, {"x->", "b->", "z->"}}});
 
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job0));
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job1));
@@ -653,23 +588,21 @@ TEST(ModuleDepGraph, MarkIntransitive) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraph, MarkIntransitiveTwice) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, MarkIntransitiveTwice) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(
-      graph.simulateLoad( &job0, {{providesTopLevel, {"a", "b", "c"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsTopLevel, {"x", "b", "z"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a", "b", "c"}}});
+  simulateLoad(graph, &job1, {{NodeKind::topLevel, {"x->", "b->", "z->"}}});
 
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job0));
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraph, MarkIntransitiveThenIndirect) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, MarkIntransitiveThenIndirect) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(
-      graph.simulateLoad( &job0, {{providesTopLevel, {"a", "b", "c"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsTopLevel, {"x", "b", "z"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a", "b", "c"}}});
+  simulateLoad(graph, &job1, {{NodeKind::topLevel, {"x->", "b->", "z->"}}});
 
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job0));
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job1));
@@ -684,11 +617,11 @@ TEST(ModuleDepGraph, MarkIntransitiveThenIndirect) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraph, SimpleExternal) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, SimpleExternal) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(
-      graph.simulateLoad( &job0, {{dependsExternal, {"/foo", "/bar"}}}));
+  simulateLoad(graph, &job0,
+               {{NodeKind::externalDepend, {"/foo->", "/bar->"}}});
 
   EXPECT_TRUE(contains(graph.getExternalDependencies(), "/foo"));
   EXPECT_TRUE(contains(graph.getExternalDependencies(), "/bar"));
@@ -705,11 +638,11 @@ TEST(ModuleDepGraph, SimpleExternal) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
 }
 
-TEST(ModuleDepGraph, SimpleExternal2) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, SimpleExternal2) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(
-      graph.simulateLoad( &job0, {{dependsExternal, {"/foo", "/bar"}}}));
+  simulateLoad(graph, &job0,
+               {{NodeKind::externalDepend, {"/foo->", "/bar->"}}});
 
   EXPECT_EQ(1u, graph.findExternallyDependentUntracedJobs("/bar").size());
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
@@ -718,13 +651,15 @@ TEST(ModuleDepGraph, SimpleExternal2) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
 }
 
-TEST(ModuleDepGraph, ChainedExternal) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, ChainedExternal) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(graph.simulateLoad(
-      &job0, {{dependsExternal, {"/foo"}}, {providesTopLevel, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsExternal, {"/bar"}}, {dependsTopLevel, {"a"}}}));
+  simulateLoad(
+      graph, &job0,
+      {{NodeKind::externalDepend, {"/foo->"}}, {NodeKind::topLevel, {"a"}}});
+  simulateLoad(
+      graph, &job1,
+      {{NodeKind::externalDepend, {"/bar->"}}, {NodeKind::topLevel, {"a->"}}});
 
   EXPECT_TRUE(contains(graph.getExternalDependencies(), "/foo"));
   EXPECT_TRUE(contains(graph.getExternalDependencies(), "/bar"));
@@ -746,13 +681,15 @@ TEST(ModuleDepGraph, ChainedExternal) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraph, ChainedExternalReverse) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, ChainedExternalReverse) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(graph.simulateLoad(
-      &job0, {{dependsExternal, {"/foo"}}, {providesTopLevel, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsExternal, {"/bar"}}, {dependsTopLevel, {"a"}}}));
+  simulateLoad(
+      graph, &job0,
+      {{NodeKind::externalDepend, {"/foo->"}}, {NodeKind::topLevel, {"a"}}});
+  simulateLoad(
+      graph, &job1,
+      {{NodeKind::externalDepend, {"/bar->"}}, {NodeKind::topLevel, {"a->"}}});
 
   {
     auto jobs = graph.findExternallyDependentUntracedJobs("/bar");
@@ -769,19 +706,21 @@ TEST(ModuleDepGraph, ChainedExternalReverse) {
   {
     auto jobs = graph.findExternallyDependentUntracedJobs("/foo");
     EXPECT_EQ(1u, jobs.size());
-    EXPECT_EQ(&job0, jobs.front());
+    EXPECT_TRUE(contains(jobs, &job0));
   }
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraph, ChainedExternalPreMarked) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, ChainedExternalPreMarked) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  EXPECT_TRUE(graph.simulateLoad(
-      &job0, {{dependsExternal, {"/foo"}}, {providesTopLevel, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsExternal, {"/bar"}}, {dependsTopLevel, {"a"}}}));
+  simulateLoad(
+      graph, &job0,
+      {{NodeKind::externalDepend, {"/foo->"}}, {NodeKind::topLevel, {"a"}}});
+  simulateLoad(
+      graph, &job1,
+      {{NodeKind::externalDepend, {"/bar->"}}, {NodeKind::topLevel, {"a->"}}});
 
   {
     auto jobs = graph.findExternallyDependentUntracedJobs("/foo");
@@ -793,34 +732,105 @@ TEST(ModuleDepGraph, ChainedExternalPreMarked) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-
-TEST(ModuleDepGraph, MutualInterfaceHash) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
-  graph.simulateLoad( &job0, {
-    {providesTopLevel, {"a"}},
-    {dependsTopLevel, {"b"}}
-  });
-  graph.simulateLoad( &job1, {
-    {dependsTopLevel, {"a"}},
-    {providesTopLevel, {"b"}}
-  });
+TEST(ModuleDepGraphWithoutFingerprints, MutualInterfaceHash) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a", "b->"}}});
+  simulateLoad(graph, &job1, {{NodeKind::topLevel, {"a->", "b"}}});
 
   const auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
   EXPECT_TRUE(contains(jobs, &job1));
 }
 
-TEST(ModuleDepGraph, DisabledTypeBodyFingerprints) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ false);
+TEST(ModuleDepGraphWithoutFingerprints, DisabledTypeBodyFingerprints) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
 
-  graph.simulateLoad(&job0, {{dependsNominal, {"B2"}}});
-  graph.simulateLoad(&job1, {{providesNominal, {"B1", "B2"}}});
-  graph.simulateLoad(&job2, {{dependsNominal, {"B1"}}});
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"B2->"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"B1", "B2"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"B1->"}}});
 
   {
-  const auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job1);
-  EXPECT_EQ(3u, jobs.size());
+    const auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job1);
+    EXPECT_EQ(3u, jobs.size());
+    EXPECT_TRUE(contains(jobs, &job0));
+    EXPECT_TRUE(contains(jobs, &job1));
+    EXPECT_TRUE(contains(jobs, &job2));
+  }
+}
+
+TEST(ModuleDepGraphWithoutFingerprints, BaselineForPrintsAndCrossType) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
+
+  // Because when A1 changes, B1 and not B2 is affected, only jobs1 and job2
+  // should be recompiled, except type fingerprints is off!
+
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"A1", "A2"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"B1", "A1->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"C1", "A2->"}}});
+  simulateLoad(graph, &job3, {{NodeKind::nominal, {"D1"}}});
+
+  {
+    const auto jobs = simulateReload(
+        graph, &job0, {{NodeKind::nominal, {"A1", "A2"}}}, "changed");
+    EXPECT_EQ(3u, jobs.size());
+    EXPECT_TRUE(contains(jobs, &job0));
+    EXPECT_TRUE(contains(jobs, &job1));
+    EXPECT_TRUE(contains(jobs, &job2));
+    EXPECT_FALSE(contains(jobs, &job3));
+  }
+}
+
+TEST(ModuleDepGraphWithoutFingerprints, LoadFailsWithFingerprint) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
+  EXPECT_FALSE(
+      getChangesForSimulatedLoad(graph, &job0, {{NodeKind::nominal, {"A@1"}}}));
+}
+
+TEST(ModuleDepGraphWithoutFingerprints, IgnoreFingerprints) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
+
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"A1", "A2"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"B1", "A1->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"C1", "A2->"}}});
+  simulateLoad(graph, &job3, {{NodeKind::nominal, {"D1"}}});
+
+  {
+    const auto jobs =
+        simulateReload(graph, &job0, {{NodeKind::nominal, {"A1@11", "A2@2"}}});
+    EXPECT_EQ(4u, jobs.size());
+    EXPECT_TRUE(contains(jobs, &job0));
+    EXPECT_TRUE(contains(jobs, &job1));
+    EXPECT_TRUE(contains(jobs, &job2));
+    EXPECT_TRUE(contains(jobs, &job3));
+  }
+}
+
+TEST(ModuleDepGraphWithoutFingerprints, CrossTypeDependencyBaseline) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"A"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"B", "C", "A->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"B->"}}});
+  simulateLoad(graph, &job3, {{NodeKind::nominal, {"C->"}}});
+
+  const auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
   EXPECT_TRUE(contains(jobs, &job0));
   EXPECT_TRUE(contains(jobs, &job1));
   EXPECT_TRUE(contains(jobs, &job2));
-  }
+  EXPECT_TRUE(contains(jobs, &job3));
+}
+
+TEST(ModuleDepGraphWithoutFingerprints, CrossTypeDependency) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/false);
+  // Because of the cross-type dependency, A->B,
+  // when A changes, only B is dirtied in job1.
+
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"A"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"B", "C", "A->B"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"B->"}}});
+  simulateLoad(graph, &job3, {{NodeKind::nominal, {"C->"}}});
+
+  const auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
+  EXPECT_TRUE(contains(jobs, &job0));
+  EXPECT_TRUE(contains(jobs, &job1));
+  EXPECT_TRUE(contains(jobs, &job2));
+  EXPECT_FALSE(contains(jobs, &job3));
 }

--- a/unittests/Driver/MockingFineGrainedDependencyGraphs.cpp
+++ b/unittests/Driver/MockingFineGrainedDependencyGraphs.cpp
@@ -1,0 +1,247 @@
+//===--------------- MockingFineGraonedDependencyGraphs.cpp ---------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "MockingFineGrainedDependencyGraphs.h"
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/SourceFileDepGraphConstructor.h"
+#include "swift/Basic/ReferenceDependencyKeys.h"
+#include "swift/Basic/SourceManager.h"
+
+#include <array>
+#include <unordered_map>
+
+using namespace swift;
+using namespace fine_grained_dependencies;
+using namespace mocking_fine_grained_dependency_graphs;
+
+using AddDefinedDecl = SourceFileDepGraphConstructor::AddDefinedDecl;
+
+// For now, in unit tests, mock uses are always nominal
+static const NodeKind kindOfUse = NodeKind::nominal;
+
+static Optional<StringRef> noneIfEmpty(StringRef s) {
+  return s.empty() ? Optional<StringRef>() : s;
+}
+
+/// Return true if when the name appears in a unit test, it represents a
+/// context, not a baseName. Return false if a single name is a baseName,
+/// without context Return None if there shoud be two names
+static Optional<bool> singleNameIsContext(const NodeKind kind) {
+  switch (kind) {
+  case NodeKind::nominal:
+  case NodeKind::potentialMember:
+    return true;
+  case NodeKind::topLevel:
+  case NodeKind::dynamicLookup:
+  case NodeKind::externalDepend:
+  case NodeKind::sourceFileProvide:
+    return false;
+  case NodeKind::member:
+    return None;
+  case NodeKind::kindCount:
+    llvm_unreachable("impossible case");
+  }
+}
+
+static constexpr char nameContextSeparator = ',';
+
+static std::string parseContext(const StringRef s, const NodeKind kind) {
+  return !singleNameIsContext(kind)
+             ? s.split(nameContextSeparator).first.str()
+             : singleNameIsContext(kind).getValue() ? s.str() : "";
+}
+
+static std::string parseName(const StringRef s, const NodeKind kind) {
+  const std::string name =
+      !singleNameIsContext(kind)
+          ? s.split(nameContextSeparator).second.str()
+          : singleNameIsContext(kind).getValue() ? "" : s.str();
+  assert(kind != NodeKind::member ||
+         !name.empty() && "Should be a potentialMember");
+  return name;
+}
+// clang-format off
+
+static void parseProvides(StringRef s, const NodeKind kind, const bool includePrivateDeps,
+    AddDefinedDecl addDefinedDeclFn) {
+  static const char *privatePrefix = "#";
+  static constexpr char fingerprintSeparator = '@';
+
+  const bool isPrivate = s.consume_front(privatePrefix);
+  if (isPrivate && !includePrivateDeps)
+    return;
+  std::string context = parseContext(s.split(fingerprintSeparator).first, kind);
+  std::string name = parseName(s.split(fingerprintSeparator).first, kind);
+  Optional<StringRef> fingerprint = noneIfEmpty(s.split(fingerprintSeparator).second);
+
+  addDefinedDeclFn(DependencyKey(kind, DeclAspect::interface, context, name), fingerprint);
+}
+
+
+static const char* defUseSeparator = "->";
+
+void parseDefUse(const StringRef argString, const NodeKind kind, const bool includePrivateDeps,
+StringRef swiftDeps,
+    function_ref<void(const DependencyKey&, const DependencyKey&)> fn) {
+  static const char* noncascadingPrefix = "#";
+  static const char* privateHolderPrefix = "~";
+
+  StringRef s = argString;
+  const bool isCascadingUse = !s.consume_front(noncascadingPrefix);
+  // Someday, we might differentiate.
+  const DeclAspect aspectOfDefUsed = DeclAspect::interface;
+  const DeclAspect aspectOfUse = isCascadingUse ? DeclAspect::interface : DeclAspect::implementation;
+  const bool isHolderPrivate = s.consume_front(privateHolderPrefix);
+  if (!includePrivateDeps && isHolderPrivate)
+    return;
+  const auto defUseStrings = s.split(defUseSeparator);
+  const auto context = parseContext(defUseStrings.first, kind);
+  const auto name = parseName(defUseStrings.first, kind);
+
+ 
+  const DependencyKey defKey = DependencyKey(kind, aspectOfDefUsed, context, name);
+  
+  auto useKey = [&]() -> DependencyKey {
+  if (defUseStrings.second.empty()) {
+    return DependencyKey(NodeKind::sourceFileProvide,
+                           aspectOfUse,
+                           DependencyKey::computeContextForProvidedEntity<
+                           NodeKind::sourceFileProvide>(swiftDeps),
+                           DependencyKey::computeNameForProvidedEntity<
+                           NodeKind::sourceFileProvide>(
+                                                        swiftDeps));
+  }
+  else {
+    DependencyKey specificUse;
+    parseProvides(defUseStrings.second, kindOfUse, includePrivateDeps,
+                  [&](const DependencyKey &parsedUse, Optional<StringRef> fingerprint) {
+      assert(!fingerprint && "Users have no prints");
+      specificUse = parsedUse.withAspect(aspectOfUse);
+    });
+    return specificUse;
+  }
+  };
+  fn(defKey, useKey());
+}
+
+
+static void forEachEntry(const DependencyDescriptions &dependencyDescriptions,
+                         function_ref<void(NodeKind kind, StringRef entry)> fn) {
+  for (const auto &kindAndEntries: dependencyDescriptions) {
+    for (StringRef s: kindAndEntries.second)
+      fn(kindAndEntries.first, s);
+  }
+}
+
+
+static bool isAProvides(StringRef s) {
+  return s.find(defUseSeparator) == StringRef::npos;
+}
+
+
+static SourceFileDepGraph mockSourceFileDepGraph(
+    std::string swiftDepsFilename,
+    const bool includePrivateDeps,
+    const bool hadCompilationError,
+    std::string interfaceHash,
+    const DependencyDescriptions &dependencyDescriptions) {
+  
+
+  auto forEachMockDefinedDecl = [&](AddDefinedDecl addDefinedDeclFn) {
+      forEachEntry(dependencyDescriptions, [&](NodeKind kind, StringRef s) {
+        if (isAProvides(s))
+        parseProvides(s, kind, includePrivateDeps, addDefinedDeclFn);
+      });
+    };
+
+
+  auto forEachMockUsedDecl = [&] (function_ref<void(const DependencyKey&, const DependencyKey&)> fn) {
+      forEachEntry(dependencyDescriptions, [&](NodeKind kind, StringRef s) {
+        if (!isAProvides(s))
+          parseDefUse(s, kind, includePrivateDeps, swiftDepsFilename, fn);
+      });
+    };
+
+
+  return SourceFileDepGraphConstructor(includePrivateDeps, hadCompilationError)
+  .construct(
+        swiftDepsFilename,
+        interfaceHash,
+        forEachMockDefinedDecl,
+        forEachMockUsedDecl);
+}
+  
+
+
+void mocking_fine_grained_dependency_graphs::simulateLoad(
+    ModuleDepGraph &g, const driver::Job *cmd,
+    const DependencyDescriptions &dependencyDescriptions,
+    StringRef interfaceHashIfNonEmpty, const bool includePrivateDeps,
+    const bool hadCompilationError) {
+  const auto changes = getChangesForSimulatedLoad(
+      g, cmd, dependencyDescriptions, interfaceHashIfNonEmpty, includePrivateDeps,
+      hadCompilationError);
+  assert(changes && "simulated load should always succeed");
+}
+
+
+ModuleDepGraph::Changes
+mocking_fine_grained_dependency_graphs::getChangesForSimulatedLoad(
+    ModuleDepGraph &g, const driver::Job *cmd,
+    const DependencyDescriptions &dependencyDescriptions,
+    StringRef interfaceHashIfNonEmpty, const bool includePrivateDeps,
+    const bool hadCompilationError) {
+  StringRef swiftDeps =
+      cmd->getOutput().getAdditionalOutputForType(file_types::TY_SwiftDeps);
+  assert(!swiftDeps.empty());
+  StringRef interfaceHash =
+      interfaceHashIfNonEmpty.empty() ? swiftDeps : interfaceHashIfNonEmpty;
+  auto sfdg =
+      mockSourceFileDepGraph(swiftDeps, includePrivateDeps, hadCompilationError,
+                             interfaceHash, dependencyDescriptions);
+  SourceManager sm;
+  DiagnosticEngine diags(sm);
+  // help for debugging: emit imported file, too
+  if (g.emitFineGrainedDependencyDotFileAfterEveryImport) {
+    sfdg.emitDotFile(swiftDeps, diags);
+  }
+  return g.loadFromSourceFileDepGraph(cmd, sfdg, diags);
+}
+
+std::vector<const driver::Job *>
+mocking_fine_grained_dependency_graphs::simulateReload(
+    ModuleDepGraph &g, const driver::Job *cmd,
+    const DependencyDescriptions &dependencyDescriptions,
+    StringRef interfaceHashIfNonEmpty, const bool includePrivateDeps,
+    const bool hadCompilationError) {
+  const auto changedNodes = getChangesForSimulatedLoad(
+      g, cmd, dependencyDescriptions, interfaceHashIfNonEmpty, includePrivateDeps,
+      hadCompilationError);
+  if (!changedNodes)
+    return g.getAllJobs();
+  return g.findJobsToRecompileWhenNodesChange(changedNodes.getValue());
+}
+
+LLVM_ATTRIBUTE_UNUSED
+std::vector<const driver::Job *>
+mocking_fine_grained_dependency_graphs::printJobsForDebugging(
+    const std::vector<const driver::Job *> &jobs) {
+  llvm::errs() << "\nprintForDebugging: ";
+  for (auto *j : jobs) {
+    const auto swiftDeps =
+        j->getOutput().getAdditionalOutputForType(file_types::TY_SwiftDeps);
+    assert(!swiftDeps.empty());
+    llvm::errs() << "job" << swiftDeps << " ";
+  }
+  llvm::errs() << "\n";
+  return jobs;
+}

--- a/unittests/Driver/MockingFineGrainedDependencyGraphs.cpp
+++ b/unittests/Driver/MockingFineGrainedDependencyGraphs.cpp
@@ -23,176 +23,16 @@ using namespace swift;
 using namespace fine_grained_dependencies;
 using namespace mocking_fine_grained_dependency_graphs;
 
-using AddDefinedDecl = SourceFileDepGraphConstructor::AddDefinedDecl;
-
-// For now, in unit tests, mock uses are always nominal
-static const NodeKind kindOfUse = NodeKind::nominal;
-
-static Optional<StringRef> noneIfEmpty(StringRef s) {
-  return s.empty() ? Optional<StringRef>() : s;
-}
-
-/// Return true if when the name appears in a unit test, it represents a
-/// context, not a baseName. Return false if a single name is a baseName,
-/// without context Return None if there shoud be two names
-static Optional<bool> singleNameIsContext(const NodeKind kind) {
-  switch (kind) {
-  case NodeKind::nominal:
-  case NodeKind::potentialMember:
-    return true;
-  case NodeKind::topLevel:
-  case NodeKind::dynamicLookup:
-  case NodeKind::externalDepend:
-  case NodeKind::sourceFileProvide:
-    return false;
-  case NodeKind::member:
-    return None;
-  case NodeKind::kindCount:
-    llvm_unreachable("impossible case");
-  }
-}
-
-static constexpr char nameContextSeparator = ',';
-
-static std::string parseContext(const StringRef s, const NodeKind kind) {
-  return !singleNameIsContext(kind)
-             ? s.split(nameContextSeparator).first.str()
-             : singleNameIsContext(kind).getValue() ? s.str() : "";
-}
-
-static std::string parseName(const StringRef s, const NodeKind kind) {
-  const std::string name =
-      !singleNameIsContext(kind)
-          ? s.split(nameContextSeparator).second.str()
-          : singleNameIsContext(kind).getValue() ? "" : s.str();
-  assert(kind != NodeKind::member ||
-         !name.empty() && "Should be a potentialMember");
-  return name;
-}
-// clang-format off
-
-static void parseProvides(StringRef s, const NodeKind kind, const bool includePrivateDeps,
-    AddDefinedDecl addDefinedDeclFn) {
-  static const char *privatePrefix = "#";
-  static constexpr char fingerprintSeparator = '@';
-
-  const bool isPrivate = s.consume_front(privatePrefix);
-  if (isPrivate && !includePrivateDeps)
-    return;
-  std::string context = parseContext(s.split(fingerprintSeparator).first, kind);
-  std::string name = parseName(s.split(fingerprintSeparator).first, kind);
-  Optional<StringRef> fingerprint = noneIfEmpty(s.split(fingerprintSeparator).second);
-
-  addDefinedDeclFn(DependencyKey(kind, DeclAspect::interface, context, name), fingerprint);
-}
-
-
-static const char* defUseSeparator = "->";
-
-void parseDefUse(const StringRef argString, const NodeKind kind, const bool includePrivateDeps,
-StringRef swiftDeps,
-    function_ref<void(const DependencyKey&, const DependencyKey&)> fn) {
-  static const char* noncascadingPrefix = "#";
-  static const char* privateHolderPrefix = "~";
-
-  StringRef s = argString;
-  const bool isCascadingUse = !s.consume_front(noncascadingPrefix);
-  // Someday, we might differentiate.
-  const DeclAspect aspectOfDefUsed = DeclAspect::interface;
-  const DeclAspect aspectOfUse = isCascadingUse ? DeclAspect::interface : DeclAspect::implementation;
-  const bool isHolderPrivate = s.consume_front(privateHolderPrefix);
-  if (!includePrivateDeps && isHolderPrivate)
-    return;
-  const auto defUseStrings = s.split(defUseSeparator);
-  const auto context = parseContext(defUseStrings.first, kind);
-  const auto name = parseName(defUseStrings.first, kind);
-
- 
-  const DependencyKey defKey = DependencyKey(kind, aspectOfDefUsed, context, name);
-  
-  auto useKey = [&]() -> DependencyKey {
-  if (defUseStrings.second.empty()) {
-    return DependencyKey(NodeKind::sourceFileProvide,
-                           aspectOfUse,
-                           DependencyKey::computeContextForProvidedEntity<
-                           NodeKind::sourceFileProvide>(swiftDeps),
-                           DependencyKey::computeNameForProvidedEntity<
-                           NodeKind::sourceFileProvide>(
-                                                        swiftDeps));
-  }
-  else {
-    DependencyKey specificUse;
-    parseProvides(defUseStrings.second, kindOfUse, includePrivateDeps,
-                  [&](const DependencyKey &parsedUse, Optional<StringRef> fingerprint) {
-      assert(!fingerprint && "Users have no prints");
-      specificUse = parsedUse.withAspect(aspectOfUse);
-    });
-    return specificUse;
-  }
-  };
-  fn(defKey, useKey());
-}
-
-
-static void forEachEntry(const DependencyDescriptions &dependencyDescriptions,
-                         function_ref<void(NodeKind kind, StringRef entry)> fn) {
-  for (const auto &kindAndEntries: dependencyDescriptions) {
-    for (StringRef s: kindAndEntries.second)
-      fn(kindAndEntries.first, s);
-  }
-}
-
-
-static bool isAProvides(StringRef s) {
-  return s.find(defUseSeparator) == StringRef::npos;
-}
-
-
-static SourceFileDepGraph mockSourceFileDepGraph(
-    std::string swiftDepsFilename,
-    const bool includePrivateDeps,
-    const bool hadCompilationError,
-    std::string interfaceHash,
-    const DependencyDescriptions &dependencyDescriptions) {
-  
-
-  auto forEachMockDefinedDecl = [&](AddDefinedDecl addDefinedDeclFn) {
-      forEachEntry(dependencyDescriptions, [&](NodeKind kind, StringRef s) {
-        if (isAProvides(s))
-        parseProvides(s, kind, includePrivateDeps, addDefinedDeclFn);
-      });
-    };
-
-
-  auto forEachMockUsedDecl = [&] (function_ref<void(const DependencyKey&, const DependencyKey&)> fn) {
-      forEachEntry(dependencyDescriptions, [&](NodeKind kind, StringRef s) {
-        if (!isAProvides(s))
-          parseDefUse(s, kind, includePrivateDeps, swiftDepsFilename, fn);
-      });
-    };
-
-
-  return SourceFileDepGraphConstructor(includePrivateDeps, hadCompilationError)
-  .construct(
-        swiftDepsFilename,
-        interfaceHash,
-        forEachMockDefinedDecl,
-        forEachMockUsedDecl);
-}
-  
-
-
 void mocking_fine_grained_dependency_graphs::simulateLoad(
     ModuleDepGraph &g, const driver::Job *cmd,
     const DependencyDescriptions &dependencyDescriptions,
     StringRef interfaceHashIfNonEmpty, const bool includePrivateDeps,
     const bool hadCompilationError) {
   const auto changes = getChangesForSimulatedLoad(
-      g, cmd, dependencyDescriptions, interfaceHashIfNonEmpty, includePrivateDeps,
-      hadCompilationError);
+      g, cmd, dependencyDescriptions, interfaceHashIfNonEmpty,
+      includePrivateDeps, hadCompilationError);
   assert(changes && "simulated load should always succeed");
 }
-
 
 ModuleDepGraph::Changes
 mocking_fine_grained_dependency_graphs::getChangesForSimulatedLoad(
@@ -205,15 +45,17 @@ mocking_fine_grained_dependency_graphs::getChangesForSimulatedLoad(
   assert(!swiftDeps.empty());
   StringRef interfaceHash =
       interfaceHashIfNonEmpty.empty() ? swiftDeps : interfaceHashIfNonEmpty;
-  auto sfdg =
-      mockSourceFileDepGraph(swiftDeps, includePrivateDeps, hadCompilationError,
-                             interfaceHash, dependencyDescriptions);
+
   SourceManager sm;
   DiagnosticEngine diags(sm);
-  // help for debugging: emit imported file, too
-  if (g.emitFineGrainedDependencyDotFileAfterEveryImport) {
-    sfdg.emitDotFile(swiftDeps, diags);
-  }
+
+  auto sfdg =
+      MockSourceFileDepGraphConstructor(
+          includePrivateDeps, hadCompilationError, swiftDeps, interfaceHash,
+          g.emitFineGrainedDependencyDotFileAfterEveryImport,
+          dependencyDescriptions, diags)
+          .construct();
+
   return g.loadFromSourceFileDepGraph(cmd, sfdg, diags);
 }
 
@@ -224,8 +66,8 @@ mocking_fine_grained_dependency_graphs::simulateReload(
     StringRef interfaceHashIfNonEmpty, const bool includePrivateDeps,
     const bool hadCompilationError) {
   const auto changedNodes = getChangesForSimulatedLoad(
-      g, cmd, dependencyDescriptions, interfaceHashIfNonEmpty, includePrivateDeps,
-      hadCompilationError);
+      g, cmd, dependencyDescriptions, interfaceHashIfNonEmpty,
+      includePrivateDeps, hadCompilationError);
   if (!changedNodes)
     return g.getAllJobs();
   return g.findJobsToRecompileWhenNodesChange(changedNodes.getValue());

--- a/unittests/Driver/MockingFineGrainedDependencyGraphs.h
+++ b/unittests/Driver/MockingFineGrainedDependencyGraphs.h
@@ -1,0 +1,105 @@
+//===----------- MockingFineGrainedDependencyGraphs.h -----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MOCKING_FINE_GRAINED_DEPENDENCY_GRAPHS_H
+#define MOCKING_FINE_GRAINED_DEPENDENCY_GRAPHS_H
+
+#include "swift/AST/FineGrainedDependencies.h"
+#include "swift/Driver/FineGrainedDependencyDriverGraph.h"
+
+namespace swift {
+namespace fine_grained_dependencies {
+
+/// Affordances for testing the \c SourceFileDepGraph and \c ModuleFileDepGraph
+///
+/// Because fine-grained swiftdeps files are somewhat verbose, this file
+/// provides affordances to mock them up in a concise fashion.
+
+namespace mocking_fine_grained_dependency_graphs {
+
+using DependencyDescriptions =
+    std::unordered_multimap<NodeKind, std::vector<std::string>>;
+
+/// Simulate loading for unit testing, as if the driver is reading the swiftdeps
+/// file for the first time.
+///
+/// \param g The graph to load into.
+/// \param cmd The \c Job whose dependency info will be loaded.
+/// \param dependencyDescriptions Dependency info, see below
+/// \param interfaceHashIfNonEmpty If non-empty, overrides the default simulated
+/// interface hash \param includePrivateDeps Include file-private declarations
+/// in the dependency information. \param hadCompilationError Simulate a
+/// compilation error.
+///
+/// Fails an assertion if the information is not valid (for instance a
+/// fingerprint where it should not be).
+///
+/// *Dependency info format:*
+/// A list of entries, each of which is keyed by a \c NodeKind and contains a
+/// list of dependency nodes.
+///
+/// *Dependency node format:*
+/// Each node here is either a "provides" (i.e. a declaration provided by the
+/// file) or a "depends" (i.e. a declaration that is depended upon).
+///
+/// For "provides" (i.e. declarations provided by the source file):
+/// <provides> = [#]<contextAndName>[@<fingerprint>],
+/// where the '#' prefix indicates that the declaration is file-private.
+///
+/// <contextAndName> = <name> |  <context>,<name>
+/// where <context> is a mangled type name, and <name> is a base-name.
+///
+/// For "depends" (i.e. uses of declarations in the source file):
+/// [#][~]<contextAndName>->[<provides>]
+/// where the '#' prefix indicates that the use does not cascade,
+/// the '~' prefix indicates that the holder is private,
+/// <contextAndName> is the depended-upon declaration and the optional
+/// <provides> is the dependent declaration if known. If not known, the
+/// use will be the entire file.
+
+void simulateLoad(ModuleDepGraph &g, const driver::Job *cmd,
+                  const DependencyDescriptions &dependencyDescriptions,
+                  StringRef interfaceHashIfNonEmpty = StringRef(),
+                  const bool includePrivateDeps = true,
+                  const bool hadCompilationError = false);
+
+/// Same as \ref simulateLoad, but returns the specifically changed nodes or
+/// None if the load failed.
+
+ModuleDepGraph::Changes
+getChangesForSimulatedLoad(ModuleDepGraph &g, const driver::Job *cmd,
+                           const DependencyDescriptions &dependencyDescriptions,
+                           StringRef interfaceHashIfNonEmpty = StringRef(),
+                           const bool includePrivateDeps = true,
+                           const bool hadCompilationError = false);
+
+/// Simulates the driver reloading a swiftdeps file after a job has run.
+/// Returns the jobs that must now be run, possibly redundantly including \p
+/// cmd.
+///
+/// See \ref simulateLoad for a parameter description.
+
+std::vector<const driver::Job *>
+simulateReload(ModuleDepGraph &g, const driver::Job *cmd,
+               const DependencyDescriptions &dependencyDescriptions,
+               StringRef interfaceHashIfNonEmpty = StringRef(),
+               const bool includePrivateDeps = true,
+               const bool hadCompilationError = false);
+
+std::vector<const driver::Job *>
+printJobsForDebugging(const std::vector<const driver::Job *> &jobs);
+
+} // end namespace mocking_fine_grained_dependency_graphs
+} // namespace fine_grained_dependencies
+} // end namespace swift
+
+#endif /* MOCKING_FINE_GRAINED_DEPENDENCY_GRAPHS_H */

--- a/unittests/Driver/MockingFineGrainedDependencyGraphs.h
+++ b/unittests/Driver/MockingFineGrainedDependencyGraphs.h
@@ -14,6 +14,7 @@
 #define MOCKING_FINE_GRAINED_DEPENDENCY_GRAPHS_H
 
 #include "swift/AST/FineGrainedDependencies.h"
+#include "swift/AST/SourceFileDepGraphConstructor.h"
 #include "swift/Driver/FineGrainedDependencyDriverGraph.h"
 
 namespace swift {
@@ -25,9 +26,6 @@ namespace fine_grained_dependencies {
 /// provides affordances to mock them up in a concise fashion.
 
 namespace mocking_fine_grained_dependency_graphs {
-
-using DependencyDescriptions =
-    std::unordered_multimap<NodeKind, std::vector<std::string>>;
 
 /// Simulate loading for unit testing, as if the driver is reading the swiftdeps
 /// file for the first time.

--- a/unittests/Driver/TypeBodyFingerprintsDependencyGraphTests.cpp
+++ b/unittests/Driver/TypeBodyFingerprintsDependencyGraphTests.cpp
@@ -1,3 +1,4 @@
+#include "MockingFineGrainedDependencyGraphs.h"
 #include "swift/Basic/ReferenceDependencyKeys.h"
 #include "swift/Driver/CoarseGrainedDependencyGraph.h"
 #include "swift/Driver/FineGrainedDependencyDriverGraph.h"
@@ -7,16 +8,21 @@
 // This file adapts the unit tests from the older, coarse-grained, dependency
 // graph to the new fine-grained graph.
 
-// \c findJobsToRecompileWhenWholeJobChanges and \c
-// findExternallyDependentUntracedJobs may include jobs in their result that
+// \c findJobsToRecompileWhenWholeJobChanges,
+// \c findExternallyDependentUntracedJobs, and \c simulateReload
+// may include jobs in their result that
 // would be excluded in the coarse-grained graph. But since these will be jobs
 // that have already been scheduled, downstream mechanisms will filter them out.
 
-using namespace swift;
-using namespace reference_dependency_keys;
-using namespace fine_grained_dependencies;
-using Job = driver::Job;
+// To debug a test, create the \c ModuleDepGraph and pass true as the second
+// argument to the constructor, then find the dot files in the directory
+// where the tests run,
+// and inspect them with, e.g. OmniGraffle.
 
+using namespace swift;
+using namespace fine_grained_dependencies;
+using namespace mocking_fine_grained_dependency_graphs;
+using Job = driver::Job;
 
 static OutputFileMap OFM;
 
@@ -41,39 +47,31 @@ static bool contains(const Range &range, const T &value) {
          std::end(range);
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, BasicLoad) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, BasicLoad) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{dependsTopLevel, {"a", "b"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsNominal, {"c", "d"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{providesTopLevel, {"e", "f"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job3, {{providesNominal, {"g", "h"}}}));
-  EXPECT_TRUE(
-      graph.simulateLoad( &job4, {{providesDynamicLookup, {"i", "j"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job5, {{dependsDynamicLookup, {"k", "l"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job6, {},
-                           {{providesMember, {{"m", "mm"}, {"n", "nn"}}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job7, {},
-                           {{dependsMember, {{"o", "oo"}, {"p", "pp"}}}}));
-  EXPECT_TRUE(
-      graph.simulateLoad( &job8, {{dependsExternal, {"/foo", "/bar"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a->", "b->"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"c->", "d->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::topLevel, {"e", "f"}}});
+  simulateLoad(graph, &job3, {{NodeKind::nominal, {"g", "h"}}});
+  simulateLoad(graph, &job4, {{NodeKind::dynamicLookup, {"i", "j"}}});
+  simulateLoad(graph, &job5, {{NodeKind::dynamicLookup, {"k->", "l->"}}});
+  simulateLoad(graph, &job6, {{NodeKind::member, {"m,mm", "n,nn"}}});
+  simulateLoad(graph, &job7, {{NodeKind::member, {"o,oo->", "p,pp->"}}});
+  simulateLoad(graph, &job8,
+               {{NodeKind::externalDepend, {"/foo->", "/bar->"}}});
 
-  EXPECT_TRUE(graph.simulateLoad( &job9,
-                           {{providesNominal, {"a", "b"}},
-                            {providesTopLevel, {"b", "c"}},
-                            {dependsNominal, {"c", "d"}},
-                            {dependsTopLevel, {"d", "a"}}}));
+  simulateLoad(graph, &job9,
+               {{NodeKind::nominal, {"a", "b", "c->", "d->"}},
+                {NodeKind::topLevel, {"b", "c", "d->", "a->"}}});
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, IndependentNodes) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, IndependentNodes) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(graph.simulateLoad(
-      &job0, {{dependsTopLevel, {"a"}}, {providesTopLevel, {"a0"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsTopLevel, {"b"}}, {providesTopLevel, {"b0"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job2, {{dependsTopLevel, {"c"}}, {providesTopLevel, {"c0"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a0", "a->"}}});
+  simulateLoad(graph, &job1, {{NodeKind::topLevel, {"b0", "b->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::topLevel, {"c0", "c->"}}});
 
   EXPECT_EQ(1u, graph.findJobsToRecompileWhenWholeJobChanges(&job0).size());
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
@@ -97,41 +95,36 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, IndependentNodes) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, IndependentDepKinds) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, IndependentDepKinds) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(graph.simulateLoad(
-      &job0, {{dependsNominal, {"a"}}, {providesNominal, {"b"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsTopLevel, {"b"}}, {providesTopLevel, {"a"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a", "a->"}}});
+  simulateLoad(graph, &job1, {{NodeKind::topLevel, {"a", "b->"}}});
 
   EXPECT_EQ(1u, graph.findJobsToRecompileWhenWholeJobChanges(&job0).size());
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, IndependentDepKinds2) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, IndependentDepKinds2) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(graph.simulateLoad(
-      &job0, {{dependsNominal, {"a"}}, {providesNominal, {"b"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsTopLevel, {"b"}}, {providesTopLevel, {"a"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a->", "b"}}});
+  simulateLoad(graph, &job1, {{NodeKind::topLevel, {"b->", "a"}}});
 
   EXPECT_EQ(1u, graph.findJobsToRecompileWhenWholeJobChanges(&job1).size());
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job0));
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, IndependentMembers) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, IndependentMembers) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(
-      graph.simulateLoad( &job0, {}, {{providesMember, {{"a", "aa"}}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {}, {{dependsMember, {{"a", "bb"}}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {}, {{dependsMember, {{"a", ""}}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job3, {}, {{dependsMember, {{"b", "aa"}}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job4, {}, {{dependsMember, {{"b", "bb"}}}}));
+  simulateLoad(graph, &job0, {{NodeKind::member, {"a,aa"}}});
+  simulateLoad(graph, &job1, {{NodeKind::member, {"a,bb->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::potentialMember, {"a"}}});
+  simulateLoad(graph, &job3, {{NodeKind::member, {"b,aa->"}}});
+  simulateLoad(graph, &job4, {{NodeKind::member, {"b,bb->"}}});
 
   EXPECT_EQ(1u, graph.findJobsToRecompileWhenWholeJobChanges(&job0).size());
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
@@ -141,12 +134,11 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, IndependentMembers) {
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job4));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, SimpleDependent) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, SimpleDependent) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(
-      graph.simulateLoad( &job0, {{providesTopLevel, {"a", "b", "c"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsTopLevel, {"x", "b", "z"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a", "b", "c"}}});
+  simulateLoad(graph, &job1, {{NodeKind::topLevel, {"x->", "b->", "z->"}}});
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
     EXPECT_EQ(2u, jobs.size());
@@ -160,17 +152,16 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, SimpleDependent) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, SimpleDependentReverse) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, SimpleDependentReverse) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{dependsTopLevel, {"a", "b", "c"}}}));
-  EXPECT_TRUE(
-      graph.simulateLoad( &job1, {{providesTopLevel, {"x", "b", "z"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a->", "b->", "c->"}}});
+  simulateLoad(graph, &job1, {{NodeKind::topLevel, {"x", "b", "z"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job1);
     EXPECT_EQ(2u, jobs.size());
-    EXPECT_EQ(&job0, jobs.front());
+    EXPECT_TRUE(contains(jobs, &job0));
   }
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
@@ -184,31 +175,11 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, SimpleDependentReverse) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, SimpleDependent2) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, SimpleDependent2) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a", "b", "c"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsNominal, {"x", "b", "z"}}}));
-
-  {
-    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
-    EXPECT_EQ(2u, jobs.size());
-    EXPECT_TRUE(contains(jobs, &job1));
-  }
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
-
-  EXPECT_EQ(0u, graph.findJobsToRecompileWhenWholeJobChanges(&job0).size());
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
-}
-
-TEST(ModuleDepGraphWithTypeBodyFingerprints, SimpleDependent3) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
-
-  EXPECT_TRUE(graph.simulateLoad(
-      &job0, {{providesNominal, {"a"}}, {providesTopLevel, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsNominal, {"a"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a", "b", "c"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"x->", "b->", "z->"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
@@ -223,12 +194,12 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, SimpleDependent3) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, SimpleDependent4) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, SimpleDependent3) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsNominal, {"a"}}, {dependsTopLevel, {"a"}}}));
+  simulateLoad(graph, &job0,
+               {{NodeKind::nominal, {"a"}}, {NodeKind::topLevel, {"a"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"a->"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
@@ -243,13 +214,33 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, SimpleDependent4) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, SimpleDependent5) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, SimpleDependent4) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(graph.simulateLoad(
-      &job0, {{providesNominal, {"a"}}, {providesTopLevel, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsNominal, {"a"}}, {dependsTopLevel, {"a"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a"}}});
+  simulateLoad(graph, &job1,
+               {{NodeKind::nominal, {"a->"}}, {NodeKind::topLevel, {"a->"}}});
+
+  {
+    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
+    EXPECT_EQ(2u, jobs.size());
+    EXPECT_TRUE(contains(jobs, &job1));
+  }
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
+
+  EXPECT_EQ(0u, graph.findJobsToRecompileWhenWholeJobChanges(&job0).size());
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleDependent5) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
+
+  simulateLoad(graph, &job0,
+               {{NodeKind::nominal, {"a"}}, {NodeKind::topLevel, {"a"}}});
+  simulateLoad(graph, &job1,
+               {{NodeKind::nominal, {"a->"}}, {NodeKind::topLevel, {"a->"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
@@ -265,13 +256,12 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, SimpleDependent5) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, SimpleDependent6) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, SimpleDependent6) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(
-      graph.simulateLoad( &job0, {{providesDynamicLookup, {"a", "b", "c"}}}));
-  EXPECT_TRUE(
-      graph.simulateLoad( &job1, {{dependsDynamicLookup, {"x", "b", "z"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::dynamicLookup, {"a", "b", "c"}}});
+  simulateLoad(graph, &job1,
+               {{NodeKind::dynamicLookup, {"x->", "b->", "z->"}}});
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
     EXPECT_EQ(2u, jobs.size());
@@ -285,15 +275,12 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, SimpleDependent6) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, SimpleDependentMember) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, SimpleDependentMember) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(graph.simulateLoad(
-      &job0, {},
-      {{providesMember, {{"a", "aa"}, {"b", "bb"}, {"c", "cc"}}}}));
-  EXPECT_TRUE(
-      graph.simulateLoad( &job1, {},
-                   {{dependsMember, {{"x", "xx"}, {"b", "bb"}, {"z", "zz"}}}}));
+  simulateLoad(graph, &job0, {{NodeKind::member, {"a,aa", "b,bb", "c,cc"}}});
+  simulateLoad(graph, &job1,
+               {{NodeKind::member, {"x,xx->", "b,bb->", "z,zz->"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
@@ -308,35 +295,12 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, SimpleDependentMember) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, MultipleDependentsSame) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, MultipleDependentsSame) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a", "b", "c"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsNominal, {"x", "b", "z"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsNominal, {"q", "b", "s"}}}));
-
-  {
-    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
-    EXPECT_EQ(3u, jobs.size());
-    EXPECT_TRUE(contains(jobs, &job1));
-    EXPECT_TRUE(contains(jobs, &job2));
-  }
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
-
-  EXPECT_EQ(0u, graph.findJobsToRecompileWhenWholeJobChanges(&job0).size());
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
-}
-
-TEST(ModuleDepGraphWithTypeBodyFingerprints, MultipleDependentsDifferent) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
-
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a", "b", "c"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsNominal, {"x", "b", "z"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsNominal, {"q", "r", "c"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a", "b", "c"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"x->", "b->", "z->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"q->", "b->", "s->"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
@@ -354,37 +318,12 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, MultipleDependentsDifferent) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, ChainedDependents) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, MultipleDependentsDifferent) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a", "b", "c"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsNominal, {"x", "b"}}, {providesNominal, {"z"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsNominal, {"z"}}}));
-
-  {
-    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
-    EXPECT_EQ(3u, jobs.size());
-    EXPECT_TRUE(contains(jobs, &job1));
-    EXPECT_TRUE(contains(jobs, &job2));
-  }
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
-
-  EXPECT_EQ(0u, graph.findJobsToRecompileWhenWholeJobChanges(&job0).size());
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
-}
-
-TEST(ModuleDepGraphWithTypeBodyFingerprints, ChainedNoncascadingDependents) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
-
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a", "b", "c"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsNominal, {"x", "b"}}, {providesNominal, {SourceFileDepGraph::noncascading("z")}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsNominal, {SourceFileDepGraph::noncascading("z")}}}));
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a", "b", "c"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"x->", "b->", "z->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"q->", "r->", "c->"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
@@ -402,15 +341,60 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, ChainedNoncascadingDependents) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, ChainedNoncascadingDependents2) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, ChainedDependents) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(
-      graph.simulateLoad( &job0, {{providesTopLevel, {"a", SourceFileDepGraph::noncascading("b"), "c"}}}));
-  EXPECT_TRUE(
-      graph.simulateLoad( &job1,
-                   {{dependsTopLevel, {"x", SourceFileDepGraph::noncascading("b")}}, {providesNominal, {"z"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsNominal, {"z"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a", "b", "c"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"x->", "b->", "z"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"z->"}}});
+
+  {
+    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
+    EXPECT_EQ(3u, jobs.size());
+    EXPECT_TRUE(contains(jobs, &job1));
+    EXPECT_TRUE(contains(jobs, &job2));
+  }
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
+
+  EXPECT_EQ(0u, graph.findJobsToRecompileWhenWholeJobChanges(&job0).size());
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
+}
+
+TEST(ModuleDepGraph, ChainedNoncascadingDependents) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
+
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a", "b", "c"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"x->", "b->", "#z"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"#z->"}}});
+
+  {
+    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
+    EXPECT_EQ(3u, jobs.size());
+    EXPECT_TRUE(contains(jobs, &job1));
+    EXPECT_TRUE(contains(jobs, &job2));
+  }
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
+
+  EXPECT_EQ(0u, graph.findJobsToRecompileWhenWholeJobChanges(&job0).size());
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
+}
+
+TEST(ModuleDepGraph, ChainedNoncascadingDependents2) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
+
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a", "b", "c"}}});
+  simulateLoad(
+      graph, &job1,
+      {{NodeKind::topLevel, {"x->", "#b->"}}, {NodeKind::nominal, {"z"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"z->"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
@@ -422,19 +406,15 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, ChainedNoncascadingDependents2) {
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job2));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, MarkTwoNodes) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, MarkTwoNodes) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesTopLevel, {"a", "b"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsTopLevel, {"a"}}, {providesTopLevel, {"z"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsTopLevel, {"z"}}}));
-  EXPECT_TRUE(
-      graph.simulateLoad( &job10,
-                   {{providesTopLevel, {"y", "z"}}, {dependsTopLevel, {"q"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job11, {{dependsTopLevel, {"y"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job12, {{dependsTopLevel, {"q"}}, {providesTopLevel, {"q"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a", "b"}}});
+  simulateLoad(graph, &job1, {{NodeKind::topLevel, {"a->", "z"}}});
+  simulateLoad(graph, &job2, {{NodeKind::topLevel, {"z->"}}});
+  simulateLoad(graph, &job10, {{NodeKind::topLevel, {"y", "z", "q->"}}});
+  simulateLoad(graph, &job11, {{NodeKind::topLevel, {"y->"}}});
+  simulateLoad(graph, &job12, {{NodeKind::topLevel, {"q->", "q"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
@@ -464,41 +444,12 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, MarkTwoNodes) {
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job12));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, MarkOneNodeTwice) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, MarkOneNodeTwice) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsNominal, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsNominal, {"b"}}}));
-
-  {
-    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
-    EXPECT_EQ(2u, jobs.size());
-    EXPECT_TRUE(contains(jobs, &job1));
-  }
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
-  EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job2));
-
-  // Reload 0.
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"b"}}}));
-
-  {
-    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
-    EXPECT_EQ(2u, jobs.size());
-    EXPECT_TRUE(contains(jobs, &job2));
-  }
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
-}
-
-TEST(ModuleDepGraphWithTypeBodyFingerprints, MarkOneNodeTwice2) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
-
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsNominal, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsNominal, {"b"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"a->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"b->"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
@@ -509,11 +460,8 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, MarkOneNodeTwice2) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job2));
 
-  // Reload 0.
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a", "b"}}}));
-
   {
-    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
+    auto jobs = simulateReload(graph, &job0, {{NodeKind::nominal, {"b"}}});
     EXPECT_EQ(2u, jobs.size());
     EXPECT_TRUE(contains(jobs, &job2));
   }
@@ -522,12 +470,38 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, MarkOneNodeTwice2) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, ReloadDetectsChange) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, MarkOneNodeTwice2) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsNominal, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsNominal, {"b"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"a->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"b->"}}});
+
+  {
+    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
+    EXPECT_EQ(2u, jobs.size());
+    EXPECT_TRUE(contains(jobs, &job1));
+  }
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
+  EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job2));
+
+  {
+    auto jobs = simulateReload(graph, &job0, {{NodeKind::nominal, {"a", "b"}}});
+    EXPECT_EQ(2u, jobs.size());
+    EXPECT_TRUE(contains(jobs, &job2));
+  }
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
+  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
+}
+
+TEST(ModuleDepGraph, ReloadDetectsChange) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
+
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"a->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"b->"}}});
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job1);
     EXPECT_EQ(1u, jobs.size());
@@ -537,41 +511,27 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, ReloadDetectsChange) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job2));
 
-  // Reload 1.
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsNominal, {"a"}}, {providesNominal, {"b"}}}));
-
   {
-    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
-    EXPECT_EQ(1u, jobs.size());
-    EXPECT_TRUE(contains(jobs, &job0));
-  }
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
-  EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job2));
-
-  // Re-mark 1.
-  {
-    auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job1);
+    auto jobs =
+        simulateReload(graph, &job1, {{NodeKind::nominal, {"b", "a->"}}});
     EXPECT_EQ(2u, jobs.size());
     EXPECT_TRUE(contains(jobs, &job1));
     EXPECT_TRUE(contains(jobs, &job2));
   }
-
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
+  EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job0));
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, NotTransitiveOnceMarked) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, NotTransitiveOnceMarked) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(graph.simulateLoad( &job0, {{providesNominal, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsNominal, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsNominal, {"b"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"a"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"a->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"b->"}}});
 
   {
-  const auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job1);
+    const auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job1);
     EXPECT_EQ(1u, jobs.size());
     EXPECT_TRUE(contains(jobs, &job1));
   }
@@ -579,41 +539,25 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, NotTransitiveOnceMarked) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job2));
 
-  // Reload 1.
-  EXPECT_TRUE(graph.simulateLoad( &job1,
-  {{dependsNominal, {"a"}}, {providesNominal, {"b"}}}));
-
   {
-  const auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
-    EXPECT_EQ(1u, jobs.size());
-    EXPECT_TRUE(contains(jobs, &job0));
+    const auto jobs =
+        simulateReload(graph, &job1, {{NodeKind::nominal, {"b", "a->"}}});
+    EXPECT_EQ(2u, jobs.size());
+    EXPECT_TRUE(contains(jobs, &job1));
+    EXPECT_TRUE(contains(jobs, &job2));
   }
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
-  EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job2));
-
-  // Re-mark 1.
-  {
-    auto found = graph.findJobsToRecompileWhenWholeJobChanges(&job1);
-    EXPECT_EQ(2u, found.size());
-    EXPECT_TRUE(contains(found, &job1));
-    EXPECT_TRUE(contains(found, &job2));
-  }
-  EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
+  EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job0));
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, DependencyLoops) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, DependencyLoops) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(graph.simulateLoad(
-      &job0,
-      {{providesTopLevel, {"a", "b", "c"}}, {dependsTopLevel, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1,
-      {{providesTopLevel, {"x"}}, {dependsTopLevel, {"x", "b", "z"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job2, {{dependsTopLevel, {"x"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a", "b", "c", "a->"}}});
+  simulateLoad(graph, &job1,
+               {{NodeKind::topLevel, {"x", "x->", "b->", "z->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::topLevel, {"x->"}}});
 
   {
     auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
@@ -634,12 +578,11 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, DependencyLoops) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job2));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, MarkIntransitive) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, MarkIntransitive) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(
-      graph.simulateLoad( &job0, {{providesTopLevel, {"a", "b", "c"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsTopLevel, {"x", "b", "z"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a", "b", "c"}}});
+  simulateLoad(graph, &job1, {{NodeKind::topLevel, {"x->", "b->", "z->"}}});
 
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job0));
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job1));
@@ -653,23 +596,21 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, MarkIntransitive) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, MarkIntransitiveTwice) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, MarkIntransitiveTwice) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(
-      graph.simulateLoad( &job0, {{providesTopLevel, {"a", "b", "c"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsTopLevel, {"x", "b", "z"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a", "b", "c"}}});
+  simulateLoad(graph, &job1, {{NodeKind::topLevel, {"x->", "b->", "z->"}}});
 
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job0));
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, MarkIntransitiveThenIndirect) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, MarkIntransitiveThenIndirect) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(
-      graph.simulateLoad( &job0, {{providesTopLevel, {"a", "b", "c"}}}));
-  EXPECT_TRUE(graph.simulateLoad( &job1, {{dependsTopLevel, {"x", "b", "z"}}}));
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a", "b", "c"}}});
+  simulateLoad(graph, &job1, {{NodeKind::topLevel, {"x->", "b->", "z->"}}});
 
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job0));
   EXPECT_FALSE(graph.haveAnyNodesBeenTraversedIn(&job1));
@@ -684,11 +625,11 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, MarkIntransitiveThenIndirect) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, SimpleExternal) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, SimpleExternal) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(
-      graph.simulateLoad( &job0, {{dependsExternal, {"/foo", "/bar"}}}));
+  simulateLoad(graph, &job0,
+               {{NodeKind::externalDepend, {"/foo->", "/bar->"}}});
 
   EXPECT_TRUE(contains(graph.getExternalDependencies(), "/foo"));
   EXPECT_TRUE(contains(graph.getExternalDependencies(), "/bar"));
@@ -705,11 +646,11 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, SimpleExternal) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, SimpleExternal2) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, SimpleExternal2) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(
-      graph.simulateLoad( &job0, {{dependsExternal, {"/foo", "/bar"}}}));
+  simulateLoad(graph, &job0,
+               {{NodeKind::externalDepend, {"/foo->", "/bar->"}}});
 
   EXPECT_EQ(1u, graph.findExternallyDependentUntracedJobs("/bar").size());
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
@@ -718,13 +659,15 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, SimpleExternal2) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, ChainedExternal) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, ChainedExternal) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(graph.simulateLoad(
-      &job0, {{dependsExternal, {"/foo"}}, {providesTopLevel, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsExternal, {"/bar"}}, {dependsTopLevel, {"a"}}}));
+  simulateLoad(
+      graph, &job0,
+      {{NodeKind::externalDepend, {"/foo->"}}, {NodeKind::topLevel, {"a"}}});
+  simulateLoad(
+      graph, &job1,
+      {{NodeKind::externalDepend, {"/bar->"}}, {NodeKind::topLevel, {"a->"}}});
 
   EXPECT_TRUE(contains(graph.getExternalDependencies(), "/foo"));
   EXPECT_TRUE(contains(graph.getExternalDependencies(), "/bar"));
@@ -746,13 +689,15 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, ChainedExternal) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, ChainedExternalReverse) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, ChainedExternalReverse) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(graph.simulateLoad(
-      &job0, {{dependsExternal, {"/foo"}}, {providesTopLevel, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsExternal, {"/bar"}}, {dependsTopLevel, {"a"}}}));
+  simulateLoad(
+      graph, &job0,
+      {{NodeKind::externalDepend, {"/foo->"}}, {NodeKind::topLevel, {"a"}}});
+  simulateLoad(
+      graph, &job1,
+      {{NodeKind::externalDepend, {"/bar->"}}, {NodeKind::topLevel, {"a->"}}});
 
   {
     auto jobs = graph.findExternallyDependentUntracedJobs("/bar");
@@ -769,19 +714,21 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, ChainedExternalReverse) {
   {
     auto jobs = graph.findExternallyDependentUntracedJobs("/foo");
     EXPECT_EQ(1u, jobs.size());
-    EXPECT_EQ(&job0, jobs.front());
+    EXPECT_TRUE(contains(jobs, &job0));
   }
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job0));
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-TEST(ModuleDepGraphWithTypeBodyFingerprints, ChainedExternalPreMarked) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+TEST(ModuleDepGraph, ChainedExternalPreMarked) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  EXPECT_TRUE(graph.simulateLoad(
-      &job0, {{dependsExternal, {"/foo"}}, {providesTopLevel, {"a"}}}));
-  EXPECT_TRUE(graph.simulateLoad(
-      &job1, {{dependsExternal, {"/bar"}}, {dependsTopLevel, {"a"}}}));
+  simulateLoad(
+      graph, &job0,
+      {{NodeKind::externalDepend, {"/foo->"}}, {NodeKind::topLevel, {"a"}}});
+  simulateLoad(
+      graph, &job1,
+      {{NodeKind::externalDepend, {"/bar->"}}, {NodeKind::topLevel, {"a->"}}});
 
   {
     auto jobs = graph.findExternallyDependentUntracedJobs("/foo");
@@ -793,39 +740,153 @@ TEST(ModuleDepGraphWithTypeBodyFingerprints, ChainedExternalPreMarked) {
   EXPECT_TRUE(graph.haveAnyNodesBeenTraversedIn(&job1));
 }
 
-
-TEST(ModuleDepGraphWithTypeBodyFingerprints, MutualInterfaceHash) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
-  graph.simulateLoad( &job0, {
-    {providesTopLevel, {"a"}},
-    {dependsTopLevel, {"b"}}
-  });
-  graph.simulateLoad( &job1, {
-    {dependsTopLevel, {"a"}},
-    {providesTopLevel, {"b"}}
-  });
+TEST(ModuleDepGraph, MutualInterfaceHash) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
+  simulateLoad(graph, &job0, {{NodeKind::topLevel, {"a", "b->"}}});
+  simulateLoad(graph, &job1, {{NodeKind::topLevel, {"a->", "b"}}});
 
   const auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
   EXPECT_TRUE(contains(jobs, &job1));
 }
 
 TEST(ModuleDepGraph, EnabledTypeBodyFingerprints) {
-  ModuleDepGraph graph(/*EnableTypeFingerprints=*/ true);
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
 
-  graph.simulateLoad(&job0, {{dependsNominal, {"B2"}}});
-  graph.simulateLoad(&job1, {{providesNominal, {"B1", "B2"}}});
-  graph.simulateLoad(&job2, {{dependsNominal, {"B1"}}});
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"B2->"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"B1", "B2"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"B1->"}}});
 
-
-  const DependencyKey k = DependencyKey(NodeKind::nominal,
-                                        DeclAspect::interface, "B1", "");
-  std::vector<ModuleDepGraphNode *> changedNodes;
-  graph.forEachMatchingNode(
-          k,
-          [&](ModuleDepGraphNode* n) {changedNodes.push_back(n);});
   {
-    const auto jobs = graph.findJobsToRecompileWhenNodesChange(changedNodes);
+    const auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job1);
+    EXPECT_EQ(3u, jobs.size());
+    EXPECT_TRUE(contains(jobs, &job0));
+    EXPECT_TRUE(contains(jobs, &job1));
     EXPECT_TRUE(contains(jobs, &job2));
-    EXPECT_FALSE(contains(jobs, &job0));
-    }
+  }
+}
+
+TEST(ModuleDepGraph, BaselineForPrintsAndCrossType) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
+
+  // Because when A1 changes, B1 and not B2 is affected, only jobs1 and job2
+  // should be recompiled, except type fingerprints is off!
+
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"A1", "A2"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"B1", "A1->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"C1", "A2->"}}});
+  simulateLoad(graph, &job3, {{NodeKind::nominal, {"D1"}}});
+
+  {
+    const auto jobs = simulateReload(
+        graph, &job0, {{NodeKind::nominal, {"A1", "A2"}}}, "changed");
+    EXPECT_EQ(3u, jobs.size());
+    EXPECT_TRUE(contains(jobs, &job0));
+    EXPECT_TRUE(contains(jobs, &job1));
+    EXPECT_TRUE(contains(jobs, &job2));
+    EXPECT_FALSE(contains(jobs, &job3));
+  }
+}
+
+TEST(ModuleDepGraph, LoadPassesWithFingerprint) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
+  EXPECT_TRUE(
+      getChangesForSimulatedLoad(graph, &job0, {{NodeKind::nominal, {"A@1"}}}));
+}
+
+TEST(ModuleDepGraph, UseFingerprints) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
+
+  // Because when A1 changes, B1 and not B2 is affected, only jobs1 and job2
+  // should be recompiled, except type fingerprints is off!
+
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"A1@1", "A2@2"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"B1", "A1->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"C1", "A2->"}}});
+  simulateLoad(graph, &job3, {{NodeKind::nominal, {"D1"}}});
+
+  {
+    const auto jobs =
+        simulateReload(graph, &job0, {{NodeKind::nominal, {"A1@11", "A2@2"}}});
+    EXPECT_EQ(2u, jobs.size());
+    EXPECT_TRUE(contains(jobs, &job0));
+    EXPECT_TRUE(contains(jobs, &job1));
+    EXPECT_FALSE(contains(jobs, &job2));
+    EXPECT_FALSE(contains(jobs, &job3));
+  }
+}
+
+TEST(ModuleDepGraph, CrossTypeDependencyBaseline) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"A"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"B", "C", "A->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"B->"}}});
+  simulateLoad(graph, &job3, {{NodeKind::nominal, {"C->"}}});
+
+  const auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
+  EXPECT_TRUE(contains(jobs, &job0));
+  EXPECT_TRUE(contains(jobs, &job1));
+  EXPECT_TRUE(contains(jobs, &job2));
+  EXPECT_TRUE(contains(jobs, &job3));
+}
+
+TEST(ModuleDepGraph, CrossTypeDependency) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
+  // Because of the cross-type dependency, A->B,
+  // when A changes, only B is dirtied in job1.
+
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"A"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"B", "C", "A->B"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"B->"}}});
+  simulateLoad(graph, &job3, {{NodeKind::nominal, {"C->"}}});
+
+  const auto jobs = graph.findJobsToRecompileWhenWholeJobChanges(&job0);
+  EXPECT_TRUE(contains(jobs, &job0));
+  EXPECT_TRUE(contains(jobs, &job1));
+  EXPECT_TRUE(contains(jobs, &job2));
+  EXPECT_FALSE(contains(jobs, &job3));
+}
+
+TEST(ModuleDepGraph, CrossTypeDependencyBaselineWithFingerprints) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"A1@1", "A2@2"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"B1", "C1", "A1->"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"B1->"}}});
+  simulateLoad(graph, &job3, {{NodeKind::nominal, {"C1->"}}});
+  simulateLoad(graph, &job4, {{NodeKind::nominal, {"B2", "C2", "A2->"}}});
+  simulateLoad(graph, &job5, {{NodeKind::nominal, {"B2->"}}});
+  simulateLoad(graph, &job6, {{NodeKind::nominal, {"C2->"}}});
+
+  const auto jobs =
+      simulateReload(graph, &job0, {{NodeKind::nominal, {"A1@11", "A2@2"}}});
+  EXPECT_TRUE(contains(jobs, &job0));
+  EXPECT_TRUE(contains(jobs, &job1));
+  EXPECT_TRUE(contains(jobs, &job2));
+  EXPECT_TRUE(contains(jobs, &job3));
+  EXPECT_FALSE(contains(jobs, &job4));
+  EXPECT_FALSE(contains(jobs, &job5));
+  EXPECT_FALSE(contains(jobs, &job6));
+}
+
+TEST(ModuleDepGraph, CrossTypeDependencyWithFingerprints) {
+  ModuleDepGraph graph(/*EnableTypeFingerprints=*/true);
+  // Because of the cross-type dependency, A->B,
+  // when A changes, only B is dirtied in job1.
+
+  simulateLoad(graph, &job0, {{NodeKind::nominal, {"A1@1", "A2@2"}}});
+  simulateLoad(graph, &job1, {{NodeKind::nominal, {"B1", "C1", "A1->B1"}}});
+  simulateLoad(graph, &job2, {{NodeKind::nominal, {"B1->"}}});
+  simulateLoad(graph, &job3, {{NodeKind::nominal, {"C1->"}}});
+  simulateLoad(graph, &job4, {{NodeKind::nominal, {"B2", "C2", "A2->B2"}}});
+  simulateLoad(graph, &job5, {{NodeKind::nominal, {"B2->"}}});
+  simulateLoad(graph, &job6, {{NodeKind::nominal, {"C2->"}}});
+
+  const auto jobs =
+      simulateReload(graph, &job0, {{NodeKind::nominal, {"A1@11", "A2@2"}}});
+  EXPECT_TRUE(contains(jobs, &job0));
+  EXPECT_TRUE(contains(jobs, &job1));
+  EXPECT_TRUE(contains(jobs, &job2));
+  EXPECT_FALSE(contains(jobs, &job3));
+  EXPECT_FALSE(contains(jobs, &job4));
+  EXPECT_FALSE(contains(jobs, &job5));
+  EXPECT_FALSE(contains(jobs, &job6));
 }


### PR DESCRIPTION
Streamlining, reorganizing, and preparing for cross-type dependencies in the creation and unit testing of `SourceFileDepGraph`s.

1. A more powerful syntax for specifying dependencies in the SwiftDriverTests unit tests.
2. A more streamlined structure for creating the `SourceFileDepGraph` from either a reail `SourceFile` or from unit tests, using a small class ontology.

No externally-observable change to the frontend.