### PR TITLE
[Diagnostics] Cleanup logic related to argument mismatch 

### DIFF
--- a/docs/TypeChecker.rst
+++ b/docs/TypeChecker.rst
@@ -985,4 +985,3 @@ The things in the queue yet to be ported are:
 
   - Missing explicit ``Self.`` and ``self.``
   - Logic related to overload candidate ranking (``CalleeCandidateInfo``)
-  - ``diagnoseParameterErrors``

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3741,21 +3741,13 @@ ConstraintSystem::getFunctionArgApplyInfo(ConstraintLocator *locator) {
     choice = overload->choice;
     rawFnType = overload->openedType;
   } else {
+    assert(isa<CallExpr>(anchor) && "Should always be a CallExpr");
     // If we didn't resolve an overload for the callee, we should be dealing
     // with a call of an arbitrary function expr.
-    if (auto *call = dyn_cast<CallExpr>(anchor)) {
-      assert(!shouldHaveDirectCalleeOverload(call) &&
+    auto *call = cast<CallExpr>(anchor);
+    assert(!shouldHaveDirectCalleeOverload(call) &&
              "Should we have resolved a callee for this?");
-      rawFnType = getType(call->getFn());
-    } else if (auto *apply = dyn_cast<ApplyExpr>(anchor)) {
-      // FIXME: ArgumentMismatchFailure is currently used from CSDiag, meaning
-      // we can end up a BinaryExpr here with an unresolved callee. It should be
-      // possible to remove this once we've gotten rid of the old CSDiag logic
-      // and just assert that we have a CallExpr.
-      rawFnType = getType(apply->getFn());
-    } else {
-      return None;
-    }
+    rawFnType = getType(call->getFn());
   }
 
   // Try to resolve the function type by loading lvalues and looking through

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3741,7 +3741,6 @@ ConstraintSystem::getFunctionArgApplyInfo(ConstraintLocator *locator) {
     choice = overload->choice;
     rawFnType = overload->openedType;
   } else {
-    assert(isa<CallExpr>(anchor) && "Should always be a CallExpr");
     // If we didn't resolve an overload for the callee, we should be dealing
     // with a call of an arbitrary function expr.
     auto *call = cast<CallExpr>(anchor);


### PR DESCRIPTION
Just a minor clean up, since the logic involving arguments e parameter has already been ported, we can remove some of these FIXME's \o/ 
Also updating the documentation now that `FailureDiagnostics::diagnoseParameterErrors` it's gone.

cc @xedin @hborla 