### PR TITLE
[ownership] When we flag an over consume, improve error msg by dumping consuming user list.

### DIFF
--- a/lib/SIL/LinearLifetimeChecker.cpp
+++ b/lib/SIL/LinearLifetimeChecker.cpp
@@ -63,6 +63,12 @@ struct State {
   /// put in missing destroys.
   SmallVectorImpl<SILBasicBlock *> *leakingBlocks;
 
+  /// The list of passed in consuming uses.
+  ArrayRef<BranchPropagatedUser> consumingUses;
+
+  /// The list of passed in non consuming uses.
+  ArrayRef<BranchPropagatedUser> nonConsumingUses;
+
   /// The set of blocks with consuming uses.
   SmallPtrSet<SILBasicBlock *, 8> blocksWithConsumingUses;
 
@@ -80,16 +86,22 @@ struct State {
 
   State(SILValue value, SmallPtrSetImpl<SILBasicBlock *> &visitedBlocks,
         ErrorBehaviorKind errorBehavior,
-        SmallVectorImpl<SILBasicBlock *> *leakingBlocks)
+        SmallVectorImpl<SILBasicBlock *> *leakingBlocks,
+        ArrayRef<BranchPropagatedUser> consumingUses,
+        ArrayRef<BranchPropagatedUser> nonConsumingUses)
       : value(value), beginBlock(value->getParentBlock()), error(errorBehavior),
-        visitedBlocks(visitedBlocks), leakingBlocks(leakingBlocks) {}
+        visitedBlocks(visitedBlocks), leakingBlocks(leakingBlocks),
+        consumingUses(consumingUses), nonConsumingUses(nonConsumingUses) {}
 
   State(SILBasicBlock *beginBlock,
         SmallPtrSetImpl<SILBasicBlock *> &visitedBlocks,
         ErrorBehaviorKind errorBehavior,
-        SmallVectorImpl<SILBasicBlock *> *leakingBlocks)
+        SmallVectorImpl<SILBasicBlock *> *leakingBlocks,
+        ArrayRef<BranchPropagatedUser> consumingUses,
+        ArrayRef<BranchPropagatedUser> nonConsumingUses)
       : value(), beginBlock(beginBlock), error(errorBehavior),
-        visitedBlocks(visitedBlocks), leakingBlocks(leakingBlocks) {}
+        visitedBlocks(visitedBlocks), leakingBlocks(leakingBlocks),
+        consumingUses(consumingUses), nonConsumingUses(nonConsumingUses) {}
 
   void initializeAllNonConsumingUses(
       ArrayRef<BranchPropagatedUser> nonConsumingUsers);
@@ -124,6 +136,22 @@ struct State {
   /// for validity. If this is a linear typed value, return true. Return false
   /// otherwise.
   void checkDataflowEndState(DeadEndBlocks &deBlocks);
+
+  void dumpConsumingUsers() const {
+    llvm::errs() << "Consuming Users:\n";
+    for (auto user : consumingUses) {
+      llvm::errs() << *user.getInst();
+    }
+    llvm::errs() << "\n";
+  }
+
+  void dumpNonConsumingUsers() const {
+    llvm::errs() << "Non Consuming Users:\n";
+    for (auto user : nonConsumingUses) {
+      llvm::errs() << *user.getInst();
+    }
+    llvm::errs() << "\n";
+  }
 };
 
 } // end anonymous namespace
@@ -224,7 +252,8 @@ void State::initializeConsumingUse(BranchPropagatedUser consumingUser,
       llvm::errs() << "Value: N/A\n";
     }
     llvm::errs() << "User: " << *consumingUser << "Block: bb"
-                 << userBlock->getDebugID() << "\n\n";
+                 << userBlock->getDebugID() << "\n";
+    dumpConsumingUsers();
   });
 }
 
@@ -327,7 +356,8 @@ void State::checkPredsForDoubleConsume(BranchPropagatedUser consumingUser,
     }
 
     llvm::errs() << "User: " << *consumingUser << "Block: bb"
-                 << userBlock->getDebugID() << "\n\n";
+                 << userBlock->getDebugID() << "\n";
+    dumpConsumingUsers();
   });
 }
 
@@ -356,7 +386,8 @@ void State::checkPredsForDoubleConsume(SILBasicBlock *userBlock) {
       llvm::errs() << "N/A. \n";
     }
 
-    llvm::errs() << "Block: bb" << userBlock->getDebugID() << "\n\n";
+    llvm::errs() << "Block: bb" << userBlock->getDebugID() << "\n";
+    dumpConsumingUsers();
   });
 }
 
@@ -514,7 +545,8 @@ LinearLifetimeError LinearLifetimeChecker::checkValue(
     SmallVectorImpl<SILBasicBlock *> *leakingBlocks) {
   assert(!consumingUses.empty() && "Must have at least one consuming user?!");
 
-  State state(value, visitedBlocks, errorBehavior, leakingBlocks);
+  State state(value, visitedBlocks, errorBehavior, leakingBlocks, consumingUses,
+              nonConsumingUses);
 
   // First add our non-consuming uses and their blocks to the
   // blocksWithNonConsumingUses map. While we do this, if we have multiple uses


### PR DESCRIPTION
Specifically, there are a few places in the ownership data flow where before
this patch we just dumped the violating user and the block where the overconsume
occurred. Since we only dumped the block rather than consuming user list, it
could require a little bit of time/energy to identify why the block was
considered to already have a consume in it. So at least by dumping the consuming
user list, the compiler writer has more information to reason about this.
