### PR TITLE
SymbolGraph: Serialize source locations and doc comment ranges

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -665,9 +665,10 @@ private:
     SourceLoc Loc;
     SourceLoc StartLoc;
     SourceLoc EndLoc;
+    SmallVector<CharSourceRange, 4> DocRanges;
   };
-  mutable CachedExternalSourceLocs const *CachedLocs = nullptr;
-  const CachedExternalSourceLocs *calculateSerializedLocs() const;
+  mutable CachedExternalSourceLocs const *CachedSerializedLocs = nullptr;
+  const CachedExternalSourceLocs *getSerializedLocs() const;
 protected:
 
   Decl(DeclKind kind, llvm::PointerUnion<DeclContext *, ASTContext *> context)
@@ -828,7 +829,7 @@ public:
   }
 
   /// \returns the unparsed comment attached to this declaration.
-  RawComment getRawComment() const;
+  RawComment getRawComment(bool SerializedOK = false) const;
 
   Optional<StringRef> getGroupName() const;
 

--- a/include/swift/AST/RawComment.h
+++ b/include/swift/AST/RawComment.h
@@ -86,6 +86,7 @@ struct LineColumn {
 
 struct BasicDeclLocs {
   StringRef SourceFilePath;
+  SmallVector<std::pair<LineColumn, uint32_t>, 4> DocRanges;
   LineColumn Loc;
   LineColumn StartLoc;
   LineColumn EndLoc;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -705,6 +705,14 @@ SourceFile::getBasicLocsForDecl(const Decl *D) const {
   SourceManager &SM = getASTContext().SourceMgr;
   BasicDeclLocs Result;
   Result.SourceFilePath = SM.getDisplayNameForLoc(D->getLoc());
+
+  for (const auto &SRC : D->getRawComment().Comments) {
+    Result.DocRanges.push_back(std::make_pair(
+      LineColumn { SRC.StartLine, SRC.StartColumn },
+      SRC.Range.getByteLength())
+    );
+  }
+
   auto setLineColumn = [&SM](LineColumn &Home, SourceLoc Loc) {
     if (Loc.isValid()) {
       std::tie(Home.Line, Home.Column) = SM.getLineAndColumn(Loc);

--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -128,7 +128,7 @@ static RawComment toRawComment(ASTContext &Context, CharSourceRange Range) {
   return Result;
 }
 
-RawComment Decl::getRawComment() const {
+RawComment Decl::getRawComment(bool SerializedOK) const {
   if (!this->canHaveComment())
     return RawComment();
 
@@ -147,9 +147,24 @@ RawComment Decl::getRawComment() const {
   // Ask the parent module.
   if (auto *Unit =
           dyn_cast<FileUnit>(this->getDeclContext()->getModuleScopeContext())) {
+    if (SerializedOK) {
+      if (const auto *CachedLocs = getSerializedLocs()) {
+        if (!CachedLocs->DocRanges.empty()) {
+          SmallVector<SingleRawComment, 4> SRCs;
+          for (const auto &Range : CachedLocs->DocRanges) {
+            SRCs.push_back({ Range, Context.SourceMgr });
+          }
+          auto RC = RawComment(Context.AllocateCopy(llvm::makeArrayRef(SRCs)));
+
+          if (!RC.isEmpty()) {
+            Context.setRawComment(this, RC);
+            return RC;
+          }
+        }
+      }
+    }
+
     if (Optional<CommentInfo> C = Unit->getCommentForDecl(this)) {
-      swift::markup::MarkupContext MC;
-      Context.setBriefComment(this, C->Brief);
       Context.setRawComment(this, C->Raw);
       return C->Raw;
     }

--- a/lib/Markup/LineList.cpp
+++ b/lib/Markup/LineList.cpp
@@ -97,7 +97,7 @@ LineList MarkupContext::getLineList(swift::RawComment RC) {
       auto CleanedStartLoc =
           C.Range.getStart().getAdvancedLocOrInvalid(CommentMarkerBytes);
       auto CleanedEndLoc =
-          C.Range.getStart().getAdvancedLocOrInvalid(Cleaned.size());
+          CleanedStartLoc.getAdvancedLocOrInvalid(Cleaned.size());
       Builder.addLine(Cleaned, { CleanedStartLoc, CleanedEndLoc });
     } else {
       // Skip comment markers at the beginning and at the end.
@@ -139,13 +139,13 @@ LineList MarkupContext::getLineList(swift::RawComment RC) {
         StringRef Line = Cleaned.substr(0, Pos);
         auto CleanedEndLoc = CleanedStartLoc.getAdvancedLocOrInvalid(Pos);
 
+        Builder.addLine(Line, { CleanedStartLoc, CleanedEndLoc });
+
         Cleaned = Cleaned.drop_front(Pos);
         unsigned NewlineBytes = swift::measureNewline(Cleaned);
         Cleaned = Cleaned.drop_front(NewlineBytes);
         Pos += NewlineBytes;
         CleanedStartLoc = CleanedStartLoc.getAdvancedLocOrInvalid(Pos);
-
-        Builder.addLine(Line, { CleanedStartLoc, CleanedEndLoc });
       }
     }
   }

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1460,6 +1460,9 @@ bool ModuleFile::readDeclLocsBlock(llvm::BitstreamCursor &cursor) {
       case decl_locs_block::DECL_USRS:
         DeclUSRsTable = readDeclUSRsTable(scratch, blobData);
         break;
+      case decl_locs_block::DOC_RANGES:
+        DocRangesData = blobData;
+        break;
       default:
         // Unknown index kind, which this version of the compiler won't use.
         break;
@@ -2661,7 +2664,10 @@ ModuleFile::getBasicDeclLocsForDecl(const Decl *D) const {
   // Size of BasicDeclLocs in the buffer.
   // FilePathOffset + LocNum * LineColumn
   uint32_t LineColumnCount = 3;
-  uint32_t RecordSize = NumSize + NumSize * 2 * LineColumnCount;
+  uint32_t RecordSize =
+    NumSize + // Offset into source filename blob
+    NumSize + // Offset into doc ranges blob
+    NumSize * 2 * LineColumnCount; // Line/column of: Loc, StartLoc, EndLoc
   uint32_t RecordOffset = RecordSize * UsrId;
   assert(RecordOffset < BasicDeclLocsData.size());
   assert(BasicDeclLocsData.size() % RecordSize == 0);
@@ -2675,6 +2681,23 @@ ModuleFile::getBasicDeclLocsForDecl(const Decl *D) const {
   size_t TerminatorOffset = FilePath.find('\0');
   assert(TerminatorOffset != StringRef::npos && "unterminated string data");
   Result.SourceFilePath = FilePath.slice(0, TerminatorOffset);
+
+  const auto DocRangesOffset = ReadNext();
+  if (DocRangesOffset) {
+    assert(!DocRangesData.empty());
+    const auto *Data = DocRangesData.data() + DocRangesOffset;
+    const auto NumLocs = endian::readNext<uint32_t, little, unaligned>(Data);
+    assert(NumLocs);
+
+    for (uint32_t i = 0; i < NumLocs; ++i) {
+      LineColumn LC;
+      LC.Line = endian::readNext<uint32_t, little, unaligned>(Data);
+      LC.Column = endian::readNext<uint32_t, little, unaligned>(Data);
+      auto Length = endian::readNext<uint32_t, little, unaligned>(Data);
+      Result.DocRanges.push_back(std::make_pair(LC, Length));
+    }
+  }
+
 #define READ_FIELD(X)                                                         \
 Result.X.Line = ReadNext();                                                   \
 Result.X.Column = ReadNext();

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -422,6 +422,10 @@ private:
   /// \c DeclUSRsTable.
   StringRef BasicDeclLocsData;
 
+  /// An array of fixed-size location data for each `SingleRawComment` piece
+  /// of declaration's documentation `RawComment`s.
+  StringRef DocRangesData;
+
   struct ModuleBits {
     /// The decl ID of the main class in this module file, if it has one.
     unsigned EntryPointDeclID : 31;

--- a/lib/Serialization/SourceInfoFormat.h
+++ b/lib/Serialization/SourceInfoFormat.h
@@ -41,7 +41,7 @@ const unsigned char SWIFTSOURCEINFO_SIGNATURE[] = { 0xF0, 0x9F, 0x8F, 0x8E };
 ///
 /// See docs/StableBitcode.md for information on how to make
 /// backwards-compatible changes using the LLVM bitcode format.
-const uint16_t SWIFTSOURCEINFO_VERSION_MAJOR = 1;
+const uint16_t SWIFTSOURCEINFO_VERSION_MAJOR = 2;
 
 /// Serialized swiftsourceinfo format minor version number.
 ///
@@ -49,7 +49,7 @@ const uint16_t SWIFTSOURCEINFO_VERSION_MAJOR = 1;
 /// interesting to test for. A backwards-compatible change is one where an \e
 /// old compiler can read the new format without any problems (usually by
 /// ignoring new information).
-const uint16_t SWIFTSOURCEINFO_VERSION_MINOR = 1; // Last change: skipping 0 for testing purposes
+const uint16_t SWIFTSOURCEINFO_VERSION_MINOR = 0; // Last change: add doc comment ranges
 
 /// The hash seed used for the string hashes(llvm::djbHash) in a .swiftsourceinfo file.
 const uint32_t SWIFTSOURCEINFO_HASH_SEED = 5387;
@@ -71,6 +71,7 @@ namespace decl_locs_block {
     BASIC_DECL_LOCS = 1,
     DECL_USRS,
     TEXT_DATA,
+    DOC_RANGES,
   };
 
   using BasicDeclLocsLayout = BCRecordLayout<
@@ -87,6 +88,11 @@ namespace decl_locs_block {
   using TextDataLayout = BCRecordLayout<
     TEXT_DATA,        // record ID
     BCBlob            // a list of 0-terminated string segments
+  >;
+
+  using DocRangesLayout = BCRecordLayout<
+    DOC_RANGES,         // record ID
+    BCBlob
   >;
 
 } // namespace sourceinfo_block

--- a/lib/SymbolGraphGen/Symbol.h
+++ b/lib/SymbolGraphGen/Symbol.h
@@ -43,7 +43,8 @@ struct Symbol {
 
   void serializeNames(llvm::json::OStream &OS) const;
 
-  void serializePosition(StringRef Key, unsigned Line, unsigned ByteOffset,
+  void serializePosition(StringRef Key, SourceLoc Loc,
+                         SourceManager &SourceMgr,
                          llvm::json::OStream &OS) const;
 
   void serializeRange(size_t InitialIdentation,
@@ -67,6 +68,8 @@ struct Symbol {
   void serializeDeclarationFragmentMixin(llvm::json::OStream &OS) const;
 
   void serializeAccessLevelMixin(llvm::json::OStream &OS) const;
+
+  void serializeLocationMixin(llvm::json::OStream &OS) const;
 
   llvm::Optional<StringRef>
   getDomain(PlatformAgnosticAvailabilityKind AgnosticKind,

--- a/test/SymbolGraph/Symbols/DocComment.swift
+++ b/test/SymbolGraph/Symbols/DocComment.swift
@@ -1,31 +1,19 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -module-name DocComment -emit-module-path %t/DocComment.swiftmodule
 // RUN: %target-swift-symbolgraph-extract -module-name DocComment -I %t -pretty-print -output-dir %t
-// RUN: %FileCheck %s --input-file %t/DocComment.symbols.json
-
-// CHECK: "text": "Single line."
+// RUN: %FileCheck %s --input-file %t/DocComment.symbols.json "-DTESTFILE=%s"
 
 /// Single line.
 public struct S1 {}
-
-// CHECK: "text": "Two"
-// CHECK: "text": "lines."
 
 /// Two
 /// lines.
 public struct S2 {}
 
-// CHECK: "text": "There are"
-// CHECK: "text": "three lines"
-// CHECK: "text": "here."
-
 /// There are
 /// three lines
 /// here.
 public struct S3 {}
-
-// CHECK: "text": "Comment"
-// CHECK: "text": "block."
 
 /**
  Comment
@@ -33,18 +21,11 @@ public struct S3 {}
 */
 public struct S4 {}
 
-// CHECK: "text": "Comment block"
-// CHECK: "text": "with more indentation."
-
 /**
    Comment block
    with more indentation.
  */
 public struct S5 {}
-
-// CHECK: "text": "With"
-// CHECK: "text": "ASCII"
-// CHECK: "text": "art."
 
 /**
  * With
@@ -52,3 +33,136 @@ public struct S5 {}
  * art.
  */
 public struct S6 {}
+
+// CHECK: range
+// CHECK-NEXT: start
+// CHECK-NEXT:   "line": 5
+// CHECK-NEXT:   "character": 4
+// CHECK: end
+// CHECK-NEXT:   "line": 5
+// CHECK-NEXT:   "character": 16
+// CHECK: "text": "Single line."
+
+// CHECK: range
+// CHECK-NEXT: start
+// CHECK-NEXT:   "line": 8
+// CHECK-NEXT:   "character": 4
+// CHECK: end
+// CHECK-NEXT:   "line": 8
+// CHECK-NEXT:   "character": 7
+// CHECK: "text": "Two"
+
+// CHECK: range
+// CHECK-NEXT: start
+// CHECK-NEXT:   "line": 9
+// CHECK-NEXT:   "character": 4
+// CHECK: end
+// CHECK-NEXT:   "line": 9
+// CHECK-NEXT:   "character": 10
+// CHECK: "text": "lines."
+
+// CHECK: range
+// CHECK-NEXT: start
+// CHECK-NEXT:   "line": 12
+// CHECK-NEXT:   "character": 4
+// CHECK: end
+// CHECK-NEXT:   "line": 12
+// CHECK-NEXT:   "character": 13
+// CHECK: "text": "There are"
+
+// CHECK: range
+// CHECK-NEXT: start
+// CHECK-NEXT:   "line": 13
+// CHECK-NEXT:   "character": 4
+// CHECK: end
+// CHECK-NEXT:   "line": 13
+// CHECK-NEXT:   "character": 15
+// CHECK: "text": "three lines"
+
+// CHECK: range
+// CHECK-NEXT: start
+// CHECK-NEXT:   "line": 14
+// CHECK-NEXT:   "character": 4
+// CHECK: end
+// CHECK-NEXT:   "line": 14
+// CHECK-NEXT:   "character": 9
+// CHECK: "text": "here."
+
+// CHECK: range
+// CHECK-NEXT: start
+// CHECK-NEXT:   "line": 18
+// CHECK-NEXT:   "character": 1
+// CHECK: end
+// CHECK-NEXT:   "line": 18
+// CHECK-NEXT:   "character": 8
+// CHECK: "text": "Comment"
+
+// CHECK: range
+// CHECK-NEXT: start
+// CHECK-NEXT:   "line": 19
+// CHECK-NEXT:   "character": 1
+// CHECK: end
+// CHECK-NEXT:   "line": 19
+// CHECK-NEXT:   "character": 7
+// CHECK: "text": "block."
+
+// CHECK: range
+// CHECK-NEXT: start
+// CHECK-NEXT:   "line": 24
+// CHECK-NEXT:   "character": 3
+// CHECK: end
+// CHECK-NEXT:   "line": 24
+// CHECK-NEXT:   "character": 16
+// CHECK: "text": "Comment block"
+
+// CHECK: range
+// CHECK-NEXT: start
+// CHECK-NEXT:   "line": 25
+// CHECK-NEXT:   "character": 3
+// CHECK: end
+// CHECK-NEXT:   "line": 25
+// CHECK-NEXT:   "character": 25
+// CHECK: "text": "with more indentation."
+
+// CHECK: range
+// CHECK-NEXT: start
+// CHECK-NEXT:   "line": 26
+// CHECK-NEXT:   "character": 3
+// CHECK: end
+// CHECK-NEXT:   "line": 26
+// CHECK-NEXT:   "character": 3
+
+// CHECK: range
+// CHECK-NEXT: start
+// CHECK-NEXT:   "line": 30
+// CHECK-NEXT:   "character": 3
+// CHECK: end
+// CHECK-NEXT:   "line": 30
+// CHECK-NEXT:   "character": 7
+// CHECK: "text": "With"
+
+// CHECK: range
+// CHECK-NEXT: start
+// CHECK-NEXT:   "line": 31
+// CHECK-NEXT:   "character": 3
+// CHECK: end
+// CHECK-NEXT:   "line": 31
+// CHECK-NEXT:   "character": 8
+// CHECK: "text": "ASCII"
+
+// CHECK: range
+// CHECK-NEXT: start
+// CHECK-NEXT:   "line": 32
+// CHECK-NEXT:   "character": 3
+// CHECK: end
+// CHECK-NEXT:   "line": 32
+// CHECK-NEXT:   "character": 7
+// CHECK: "text": "art."
+
+// CHECK: range
+// CHECK-NEXT: start
+// CHECK-NEXT:   "line": 33
+// CHECK-NEXT:   "character": 0
+// CHECK: end
+// CHECK-NEXT:   "line": 33
+// CHECK-NEXT:   "character": 1

--- a/test/SymbolGraph/Symbols/Mixins/Location.swift
+++ b/test/SymbolGraph/Symbols/Mixins/Location.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name Location -emit-module-path %t/Location.swiftmodule
+// RUN: %target-swift-symbolgraph-extract -module-name Location -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/Location.symbols.json "-DTESTFILE=%s"
+
+/// This is a struct.
+public struct MyStruct {
+  public var x = 1 
+}
+
+// CHECK: location
+// CHECK-NEXT: uri
+// CHECK-NEXT: position
+// CHECK-NEXT:   "line": 6
+// CHECK-NEXT:   "character": 14 
+
+// CHECK: location
+// CHECK-NEXT: uri
+// CHECK-NEXT: position
+// CHECK-NEXT:   "line": 7
+// CHECK-NEXT:   "character": 13


### PR DESCRIPTION
- Add DocRangesLayout to the `.swiftsourceinfo`.
  This is a blob containing an array of `SingleRawComment`
  source locations.
    
- Add DocLocWriter for serializing `SingleRawComment` locs into the
  `DocLocsLayout` buffer.
  Serialize start line, start column, and length of `SingleRawComment`
  pieces in `.swiftsourceinfo`
    
- Read doc locs when loading basic declaration locs from a ModuleFile.
  - Load `DOC_LOCS` blob into ModuleFile::DocLocsData
  - Reconstitute RawComment ranges when available from .swiftsourceinfo
    
- Allow requesting serialized raw comment if available

rdar://problem/58339492