### PR TITLE
[ownership] Implement movable guaranteed scopes in ossa.

### DIFF
--- a/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
@@ -91,20 +91,14 @@ public:
   llvm::DenseMap<const SILBasicBlock*, UnreachableInfo> MetaMap;
 };
 
-static void deleteEndBorrows(SILValue v) {
-  SmallVector<SILInstruction *, 4> endBorrowList;
-  for (auto *use : v->getUses()) {
-    if (auto *ebi = dyn_cast<EndBorrowInst>(use->getUser())) {
-      endBorrowList.push_back(ebi);
-    }
-  }
-  while (!endBorrowList.empty()) {
-    endBorrowList.pop_back_val()->eraseFromParent();
-  }
-}
-
 /// Propagate/remove basic block input values when all predecessors
 /// supply the same arguments.
+///
+/// NOTE: Since BranchInst always forwards guaranteed and owned parameters the
+/// same way (like owned parameters), we do not need to add any special handling
+/// for guaranteed parameters here. This is because if all of the incoming
+/// values into my guaranteed phi is the same, then we know that said incoming
+/// value must dominate the phi by definition.
 static void propagateBasicBlockArgs(SILBasicBlock &BB) {
   // This functions would simplify the code as following:
   //
@@ -184,10 +178,6 @@ static void propagateBasicBlockArgs(SILBasicBlock &BB) {
     // FIXME: These could be further propagatable now, we might want to move
     // this to CCP and trigger another round of copy propagation.
     SILArgument *Arg = *AI;
-
-    // If this argument is guaranteed and Args[Idx], delete the end_borrow.
-    if (Arg->getOwnershipKind() == ValueOwnershipKind::Guaranteed)
-      deleteEndBorrows(Arg);
 
     // We were able to fold, so all users should use the new folded value.
     Arg->replaceAllUsesWith(Args[Idx]);

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 540; // differentiability_witness_function instruction
+const uint16_t SWIFTMODULE_VERSION_MINOR = 541; // movable guaranteed scopes
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/test/SIL/Parser/borrow_argument.sil
+++ b/test/SIL/Parser/borrow_argument.sil
@@ -9,10 +9,11 @@ import Builtin
 // CHECK: end_borrow [[PHIBBARG]] : $Builtin.NativeObject
 sil [ossa] @borrow_argument_test : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
-  br bb1(%0 : $Builtin.NativeObject)
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  br bb1(%1 : $Builtin.NativeObject)
 
-bb1(%1 : @guaranteed $Builtin.NativeObject):
-  end_borrow %1 : $Builtin.NativeObject
+bb1(%2 : @guaranteed $Builtin.NativeObject):
+  end_borrow %2 : $Builtin.NativeObject
   %4 = tuple()
   return %4 : $()
 }

--- a/test/SIL/Parser/ownership_arguments.sil
+++ b/test/SIL/Parser/ownership_arguments.sil
@@ -10,7 +10,8 @@ import Builtin
 
 sil [ossa] @simple : $@convention(thin) (@owned Builtin.NativeObject, Builtin.NativeObject, @guaranteed Builtin.NativeObject, Builtin.Int32) -> () {
 bb0(%0 : @owned $Builtin.NativeObject, %1 : @unowned $Builtin.NativeObject, %2 : @guaranteed $Builtin.NativeObject, %3 : $Builtin.Int32):
-  br bb1(%0 : $Builtin.NativeObject, %1 : $Builtin.NativeObject, %2 : $Builtin.NativeObject, %3 : $Builtin.Int32)
+  %2a = begin_borrow %2 : $Builtin.NativeObject
+  br bb1(%0 : $Builtin.NativeObject, %1 : $Builtin.NativeObject, %2a : $Builtin.NativeObject, %3 : $Builtin.Int32)
 
 bb1(%4 : @owned $Builtin.NativeObject, %5 : @unowned $Builtin.NativeObject, %6 : @guaranteed $Builtin.NativeObject, %7 : $Builtin.Int32):
   destroy_value %4 : $Builtin.NativeObject

--- a/test/SIL/Serialization/borrow_argument.sil
+++ b/test/SIL/Serialization/borrow_argument.sil
@@ -13,7 +13,8 @@ import Builtin
 // CHECK: end_borrow [[PHIBBARG]] : $Builtin.NativeObject
 sil [serialized] [ossa] @borrow_argument_test : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
-  br bb1(%0 : $Builtin.NativeObject)
+  %0a = begin_borrow %0 : $Builtin.NativeObject
+  br bb1(%0a : $Builtin.NativeObject)
 
 bb1(%1 : @guaranteed $Builtin.NativeObject):
   end_borrow %1 : $Builtin.NativeObject

--- a/test/SIL/ownership-verifier/arguments.sil
+++ b/test/SIL/ownership-verifier/arguments.sil
@@ -8,6 +8,19 @@ sil_stage canonical
 
 import Builtin
 
+//////////////////
+// Declarations //
+//////////////////
+
+struct NativeObjectPair {
+  var obj1 : Builtin.NativeObject
+  var obj2 : Builtin.NativeObject
+}
+
+///////////
+// Tests //
+///////////
+
 // CHECK-LABEL: Function: 'no_end_borrow_error'
 // CHECK: Non trivial values, non address values, and non guaranteed function args must have at least one lifetime ending use?!
 // CHECK: Value: %2 = argument of bb1 : $Builtin.NativeObject
@@ -22,6 +35,11 @@ bb1(%1 : @guaranteed $Builtin.NativeObject):
   return %9999 : $()
 }
 
+// CHECK-LABEL: Function: 'leak_along_path'
+// CHECK-NEXT: Guaranteed function parameter with life ending uses!
+// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject
+// CHECK-NEXT: Lifetime Ending User:   br bb1(%0 : $Builtin.NativeObject)
+//
 // CHECK-LABEL: Function: 'leak_along_path'
 // CHECK-NEXT: Error! Found a leak due to a consuming post-dominance failure!
 // CHECK-NEXT:     Value: %2 = argument of bb1 : $Builtin.NativeObject
@@ -43,14 +61,47 @@ bb3:
   return %9999 : $()
 }
 
-// Make sure that we only flag the subargument leak and not the parent argument.
+// CHECK-NOT: Guaranteed function parameter with life ending uses!
+// CHECK-LABEL: Function: 'leak_along_path_2'
+// CHECK-NEXT: Error! Found a leak due to a consuming post-dominance failure!
+// CHECK-NEXT:     Value: %3 = argument of bb1 : $Builtin.NativeObject
+// CHECK-NEXT:     Post Dominating Failure Blocks:
+// CHECK-NEXT:         bb3
+sil [ossa] @leak_along_path_2 : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  br bb1(%1 : $Builtin.NativeObject)
+
+bb1(%2 : @guaranteed $Builtin.NativeObject):
+  cond_br undef, bb2, bb3
+
+bb2:
+  end_borrow %2 : $Builtin.NativeObject
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Make sure that we only flag the subargument leak and not the parent
+// argument. Also check for over consuming due to phi nodes.
+//
+// CHECK-LABEL: Function: 'leak_along_subarg_path'
+// CHECK-NEXT: Guaranteed function parameter with life ending uses!
+// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject
+// CHECK-NEXT: Lifetime Ending User:   br bb1(%0 : $Builtin.NativeObject)
+//
+// CHECK-LABEL: Function: 'leak_along_subarg_path'
+// CHECK-NEXT: Found over consume?!
+// CHECK-NEXT: Value: %2 = argument of bb1 : $Builtin.NativeObject
+// CHECK-NEXT: Block: bb2
 //
 // CHECK-LABEL: Function: 'leak_along_subarg_path'
 // CHECK-NEXT: Error! Found a leak due to a consuming post-dominance failure!
 // CHECK-NEXT:     Value: %5 = argument of bb3 : $Builtin.NativeObject
 // CHECK-NEXT:     Post Dominating Failure Blocks:
 // CHECK-NEXT:         bb5
-
 sil [ossa] @leak_along_subarg_path : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   br bb1(%0 : $Builtin.NativeObject)
@@ -74,14 +125,72 @@ bb5:
   return %9999 : $()
 }
 
-// CHECK-NOT: Function: 'good_order'
-sil [ossa] @good_order : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+// CHECK-LABEL: Function: 'leak_along_subarg_path_2'
+// CHECK-NEXT: Error! Found a leak due to a consuming post-dominance failure!
+// CHECK-NEXT: Value: %7 = argument of bb3 : $Builtin.NativeObject      // user: %9
+// CHECK-NEXT:     Post Dominating Failure Blocks:
+// CHECK-NEXT:         bb5
+// CHECK-NOT: Function: 'leak_along_subarg_path_2'
+sil [ossa] @leak_along_subarg_path_2 : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  br bb1(%1 : $Builtin.NativeObject)
+
+bb1(%2 : @guaranteed $Builtin.NativeObject):
+  cond_br undef, bb2, bb5
+
+bb2:
+  %2a = begin_borrow %2 : $Builtin.NativeObject
+  br bb3(%2a : $Builtin.NativeObject)
+
+bb3(%3 : @guaranteed $Builtin.NativeObject):
+  cond_br undef, bb4, bb5
+
+bb4:
+  end_borrow %3 : $Builtin.NativeObject
+  br bb5
+
+bb5:
+  end_borrow %2 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-NOT: Function: 'good_order_1'
+sil [ossa] @good_order_1 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
   cond_br undef, bb1, bb5
 
 bb1:
   br bb2(%1 : $Builtin.NativeObject)
+
+bb2(%2 : @guaranteed $Builtin.NativeObject):
+  end_borrow %2 : $Builtin.NativeObject
+  cond_br undef, bb3, bb4
+
+bb3:
+  br bb4
+
+bb4:
+  destroy_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+
+bb5:
+  end_borrow %1 : $Builtin.NativeObject
+  br bb4
+}
+
+// CHECK-NOT: Function: 'good_order_2'
+sil [ossa] @good_order_2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  cond_br undef, bb1, bb5
+
+bb1:
+  %1a = begin_borrow %1 : $Builtin.NativeObject
+  br bb2(%1a : $Builtin.NativeObject)
 
 bb2(%2 : @guaranteed $Builtin.NativeObject):
   end_borrow %2 : $Builtin.NativeObject
@@ -101,19 +210,21 @@ bb5:
   br bb4
 }
 
+
 // Make sure that we only flag the end_borrow "use after free" in bb2.
 //
 // CHECK-LABEL: Function: 'bad_order'
 // CHECK-NEXT: Found use after free?!
 // CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
 // CHECK-NEXT: Consuming User:   end_borrow %1 : $Builtin.NativeObject
-// CHECK-NEXT: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject           // id: %6
+// CHECK-NEXT: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject
 // CHECK-NEXT: Block: bb2
+//
 // CHECK-LABEL: Function: 'bad_order'
 // CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
 // CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
 // CHECK-NEXT:     Remaining Users:
-// CHECK-NEXT: User:  end_borrow %4 : $Builtin.NativeObject
+// CHECK-NEXT: User:  end_borrow %5 : $Builtin.NativeObject
 // CHECK-NEXT: Block: bb2
 // CHECK-NOT: Block: bb1
 sil [ossa] @bad_order : $@convention(thin) (@owned Builtin.NativeObject) -> () {
@@ -122,7 +233,8 @@ bb0(%0 : @owned $Builtin.NativeObject):
   cond_br undef, bb1, bb5
 
 bb1:
-  br bb2(%1 : $Builtin.NativeObject)
+  %1a = begin_borrow %1 : $Builtin.NativeObject
+  br bb2(%1a : $Builtin.NativeObject)
 
 bb2(%2 : @guaranteed $Builtin.NativeObject):
   end_borrow %1 : $Builtin.NativeObject
@@ -146,7 +258,7 @@ bb5:
 // CHECK-NEXT: Found use after free?!
 // CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
 // CHECK-NEXT: Consuming User:   end_borrow %1 : $Builtin.NativeObject
-// CHECK-NEXT: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject
+// CHECK-NEXT: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject
 // CHECK-NEXT: Block: bb2
 //
 // CHECK-LABEL: Function: 'bad_order_add_a_level'
@@ -168,13 +280,13 @@ bb5:
 // CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
 // CHECK-NEXT: Value: %1 = begin_borrow
 // CHECK-NEXT: Remaining Users:
-// CHECK-NEXT: User: end_borrow %4
+// CHECK-NEXT: User: end_borrow %5
 // CHECK-NEXT: Block: bb2
 //
 // CHECK-LABEL: Function: 'bad_order_add_a_level'
 // CHECK-NEXT: Found over consume?!
-// CHECK-NEXT: Value: %4 = argument of bb2 : $Builtin.NativeObject
-// CHECK-NEXT: User:   end_borrow %4 : $Builtin.NativeObject
+// CHECK-NEXT: Value: %5 = argument of bb2 : $Builtin.NativeObject
+// CHECK-NEXT: User:   end_borrow %5 : $Builtin.NativeObject
 // CHECK-NEXT: Block: bb2
 //
 // CHECK-LABEL: Function: 'bad_order_add_a_level'
@@ -185,7 +297,7 @@ bb5:
 //
 // CHECK-LABEL: Function: 'bad_order_add_a_level'
 // CHECK-NEXT: Non trivial values, non address values, and non guaranteed function args must have at least one lifetime ending use?!
-// CHECK-NEXT: Value: %9 = argument of bb4 : $Builtin.NativeObject
+// CHECK-NEXT: Value: %11 = argument of bb4 : $Builtin.NativeObject
 
 // NOTE: We use the expected numbered value in the output to make it easier to
 // match the filecheck patterns with the input.
@@ -195,7 +307,8 @@ bb0(%0 : @owned $Builtin.NativeObject):
   cond_br undef, bb1, bb7
 
 bb1:
-  br bb2(%1 : $Builtin.NativeObject)
+  %2 = begin_borrow %1 : $Builtin.NativeObject
+  br bb2(%2 : $Builtin.NativeObject)
 
 bb2(%4 : @guaranteed $Builtin.NativeObject):
   end_borrow %1 : $Builtin.NativeObject
@@ -203,7 +316,8 @@ bb2(%4 : @guaranteed $Builtin.NativeObject):
   cond_br undef, bb3, bb5
 
 bb3:
-  br bb4(%4 : $Builtin.NativeObject)
+  %4a = begin_borrow %4 : $Builtin.NativeObject
+  br bb4(%4a : $Builtin.NativeObject)
 
 bb4(%9 : @guaranteed $Builtin.NativeObject):
   br bb6
@@ -234,21 +348,21 @@ bb7:
 // CHECK-NEXT: Found use after free?!
 // CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
 // CHECK-NEXT: Consuming User:   end_borrow %1 : $Builtin.NativeObject
-// CHECK-NEXT: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject
+// CHECK-NEXT: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject
 // CHECK-NEXT: Block: bb2
 //
 // CHECK-LABEL: Function: 'bad_order_add_a_level_2'
 // CHECK-NEXT: Found use after free?!
 // CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
 // CHECK-NEXT: Consuming User:   end_borrow %1 : $Builtin.NativeObject
-// CHECK-NEXT: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject
+// CHECK-NEXT: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject
 // CHECK-NEXT: Block: bb4
 //
 // CHECK-LABEL: Function: 'bad_order_add_a_level_2'
 // CHECK-NEXT: Found use after free?!
 // CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
 // CHECK-NEXT: Consuming User:   end_borrow %1 : $Builtin.NativeObject
-// CHECK-NEXT: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject
+// CHECK-NEXT: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject
 // CHECK-NEXT: Block: bb5
 //
 // CHECK-LABEL: Function: 'bad_order_add_a_level_2'
@@ -272,15 +386,15 @@ bb7:
 //
 // CHECK-LABEL: Function: 'bad_order_add_a_level_2'
 // CHECK-NEXT: Found use after free?!
-// CHECK-NEXT: Value: %4 = argument of bb2 : $Builtin.NativeObject
-// CHECK-NEXT: Consuming User:   end_borrow %4 : $Builtin.NativeObject
-// CHECK-NEXT: Non Consuming User:   end_borrow %9 : $Builtin.NativeObject
+// CHECK-NEXT: Value: %5 = argument of bb2 : $Builtin.NativeObject
+// CHECK-NEXT: Consuming User:   end_borrow %5 : $Builtin.NativeObject
+// CHECK-NEXT: Non Consuming User:   end_borrow %11 : $Builtin.NativeObject
 // CHECK-NEXT: Block: bb4
 
 // CHECK-LABEL: Function: 'bad_order_add_a_level_2'
 // CHECK-NEXT: Found over consume?!
-// CHECK-NEXT: Value: %4 = argument of bb2 : $Builtin.NativeObject
-// CHECK-NEXT: User:   end_borrow %4 : $Builtin.NativeObject
+// CHECK-NEXT: Value: %5 = argument of bb2 : $Builtin.NativeObject
+// CHECK-NEXT: User:   end_borrow %5 : $Builtin.NativeObject
 // CHECK-NEXT: Block: bb2
 sil [ossa] @bad_order_add_a_level_2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
@@ -288,7 +402,8 @@ bb0(%0 : @owned $Builtin.NativeObject):
   cond_br undef, bb1, bb7
 
 bb1:
-  br bb2(%1 : $Builtin.NativeObject)
+  %1a = begin_borrow %1 : $Builtin.NativeObject
+  br bb2(%1a : $Builtin.NativeObject)
 
 bb2(%4 : @guaranteed $Builtin.NativeObject):
   end_borrow %1 : $Builtin.NativeObject
@@ -296,7 +411,8 @@ bb2(%4 : @guaranteed $Builtin.NativeObject):
   cond_br undef, bb3, bb5
 
 bb3:
-  br bb4(%4 : $Builtin.NativeObject)
+  %4a = begin_borrow %4 : $Builtin.NativeObject
+  br bb4(%4a : $Builtin.NativeObject)
 
 bb4(%9 : @guaranteed $Builtin.NativeObject):
   end_borrow %1 : $Builtin.NativeObject
@@ -402,6 +518,336 @@ bb1(%1 : @owned $Builtin.NativeObject):
   br bb2
 
 bb2:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+/////////////////////////////////////////
+// Movable Guaranteed Scope Test Cases //
+/////////////////////////////////////////
+
+// Make sure that we error due to the struct_extract. We require end_borrows to
+// be on the original borrowed value.
+//
+// CHECK-LABEL: Function: simple_non_postdominating_diamond_with_forwarding_uses
+// CHECK-NEXT: Invalid End Borrow!
+// CHECK-NEXT: Original Value:   %5 = begin_borrow %1 : $NativeObjectPair        // user: %6
+// CHECK-NEXT: End Borrow:   br bb3(%6 : $Builtin.NativeObject)              // id: %7
+sil [ossa] @simple_non_postdominating_diamond_with_forwarding_uses : $@convention(thin) (@in_guaranteed Builtin.NativeObject, @guaranteed NativeObjectPair) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : @guaranteed $NativeObjectPair):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %3 = load_borrow %0 : $*Builtin.NativeObject
+  br bb3(%3 : $Builtin.NativeObject)
+
+bb2:
+  // Should error b/c %5 isn't balanced directly.
+  %5 = begin_borrow %1 : $NativeObjectPair
+  %6 = struct_extract %5 : $NativeObjectPair, #NativeObjectPair.obj1
+  br bb3(%6 : $Builtin.NativeObject)
+
+bb3(%7 : @guaranteed $Builtin.NativeObject):
+  end_borrow %7 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We error due to the cycle in the def-use graph that describes %1's borrow
+// scope.
+//
+// TODO: If we ever add simple support for this, we should make sure that we
+// error on %0.
+//
+// CHECK-LABEL: Function: simple_loop_carry_borrow_owned_arg
+// CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
+// CHECK-NEXT: User:   br bb1(%3 : $Builtin.NativeObject)              // id: %6
+// CHECK-NEXT: Initial: BorrowScopeOperand:
+// CHECK-NEXT: Kind: BeginBorrow
+// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // users: %7, %1
+// CHECK-NEXT: User:   %1 = begin_borrow %0 : $Builtin.NativeObject    // user: %2
+sil [ossa] @simple_loop_carry_borrow_owned_arg : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  br bb1(%1 : $Builtin.NativeObject)
+
+bb1(%2 : @guaranteed $Builtin.NativeObject):
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb2a
+
+bb2a:
+  br bb1(%2 : $Builtin.NativeObject)
+
+bb3:
+  // Should error b/c destroy_value before end_borrow.
+  destroy_value %0 : $Builtin.NativeObject
+  end_borrow %2 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// This test makes sure that due to the lifetime of %3 ending in bb2a, we get an
+// error since %3a is live over the loop-carry.
+//
+// TODO: Could we ever figure out a way to support this? Maybe via a special
+// terminator? This works for load_borrow, but not for copy_value +
+// begin_borrow.
+//
+// CHECK-LABEL: Function: 'simple_loop_carry_implicitregularusers_do_not_loop_carry'
+// CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
+// CHECK-NEXT: Value:   %8 = copy_value %4 : $Builtin.NativeObject      // users: %12, %9
+// CHECK-NEXT:     Remaining Users:
+// CHECK-NEXT: User:   %9 = begin_borrow %8 : $Builtin.NativeObject    // user: %12
+// CHECK-NEXT: User:   end_borrow %4 : $Builtin.NativeObject           // id: %13
+// CHECK-NEXT: User:   end_borrow %4 : $Builtin.NativeObject           // id: %10
+sil [ossa] @simple_loop_carry_implicitregularusers_do_not_loop_carry : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  %1a = begin_borrow %0 : $Builtin.NativeObject
+  %1b = copy_value %0 : $Builtin.NativeObject
+  br bb1(%1a : $Builtin.NativeObject, %1b : $Builtin.NativeObject)
+
+bb1(%2a : @guaranteed $Builtin.NativeObject, %2b : @owned $Builtin.NativeObject):
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb2a
+
+bb2a:
+  %3 = copy_value %2a : $Builtin.NativeObject
+  %3a = begin_borrow %3 : $Builtin.NativeObject
+  end_borrow %2a : $Builtin.NativeObject
+  destroy_value %2b : $Builtin.NativeObject
+  br bb1(%3a : $Builtin.NativeObject, %3 : $Builtin.NativeObject)
+
+bb3:
+  end_borrow %2a : $Builtin.NativeObject
+  destroy_value %2b : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We should identify bb0a as consuming the value twice.
+//
+// CHECK-LABEL: Function: 'simple_loop_carry_over_consume'
+// CHECK-NEXT: Found over consume?!
+// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %3, %3
+// CHECK-NEXT: User:   br bb2(%1 : $Builtin.NativeObject, %1 : $Builtin.NativeObject) // id: %3
+// CHECK-NEXT: Block: bb1
+// CHECK-NEXT: Consuming Users:
+// CHECK-NEXT:   br bb2(%1 : $Builtin.NativeObject, %1 : $Builtin.NativeObject) // id: %3
+// CHECK-NEXT:   br bb2(%1 : $Builtin.NativeObject, %1 : $Builtin.NativeObject) // id: %3
+sil [ossa] @simple_loop_carry_over_consume : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  br bb0a
+
+bb0a:
+  br bb1(%1 : $Builtin.NativeObject, %1 : $Builtin.NativeObject)
+
+bb1(%2 : @guaranteed $Builtin.NativeObject, %2a : @guaranteed $Builtin.NativeObject):
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb2a
+
+bb2a:
+  %3 = begin_borrow %2a : $Builtin.NativeObject
+  end_borrow %2 : $Builtin.NativeObject
+  br bb1(%2a : $Builtin.NativeObject, %3 : $Builtin.NativeObject)
+
+bb3:
+  end_borrow %2a : $Builtin.NativeObject
+  end_borrow %2 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: Function: simple_loop_carry_cycle
+// CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
+// CHECK-NEXT: User:   br bb1(%3 : $Builtin.NativeObject)              // id: %6
+// CHECK-NEXT: Initial: BorrowScopeOperand:
+// CHECK-NEXT: Kind: BeginBorrow
+// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // user: %1
+// CHECK-NEXT: User:   %1 = begin_borrow %0 : $Builtin.NativeObject    // user: %2
+sil [ossa] @simple_loop_carry_cycle : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  br bb1(%1 : $Builtin.NativeObject)
+
+bb1(%2 : @guaranteed $Builtin.NativeObject):
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb2a
+
+bb2a:
+  br bb1(%2 : $Builtin.NativeObject)
+
+bb3:
+  end_borrow %2 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// This first test fails since the %2a is considered dead at bb2a's
+// terminator. So the end_borrow of %2a in bb3 is considered a liveness use of
+// %2 due to it consuming %3 via the loop carry.
+//
+// CHECK-LABEL: Function: 'simple_loop_carry_borrows_do_not_loop_carry'
+// CHECK-NEXT: Found use after free?!
+// CHECK-NEXT: Value: %5 = argument of bb1 : $Builtin.NativeObject      // users: %11, %10, %8
+// CHECK-NEXT: Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
+// CHECK-NEXT: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject           // id: %12
+// CHECK-NEXT: Block: bb4
+//
+// CHECK-LABEL: Function: 'simple_loop_carry_borrows_do_not_loop_carry'
+// CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
+// CHECK-NEXT: Value: %5 = argument of bb1 : $Builtin.NativeObject      // users: %11, %10, %8
+// CHECK-NEXT:     Remaining Users:
+// CHECK-NEXT: User:  end_borrow %4 : $Builtin.NativeObject           // id: %12
+// CHECK-NEXT: Block: bb4
+sil [ossa] @simple_loop_carry_borrows_do_not_loop_carry : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  %1a = begin_borrow %0 : $Builtin.NativeObject
+  br bb1(%1 : $Builtin.NativeObject, %1a : $Builtin.NativeObject)
+
+bb1(%2 : @guaranteed $Builtin.NativeObject, %2a : @guaranteed $Builtin.NativeObject):
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb2a
+
+bb2a:
+  %3 = begin_borrow %2a : $Builtin.NativeObject
+  end_borrow %2 : $Builtin.NativeObject
+  br bb1(%2a : $Builtin.NativeObject, %3 : $Builtin.NativeObject)
+
+bb3:
+  end_borrow %2a : $Builtin.NativeObject
+  end_borrow %2 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We could potentially support this in the future if we wanted to have some
+// sort of support for phi node loops.
+//
+// CHECK-LABEL: Function: simple_validate_enclosing_borrow_around_loop
+// CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
+// CHECK-NEXT: User:   br bb1(%6 : $Builtin.NativeObject, %5 : $Builtin.NativeObject) // id: %9
+// CHECK-NEXT: Initial: BorrowScopeOperand:
+// CHECK-NEXT: Kind: BeginBorrow
+// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %12, %3, %2
+// CHECK-NEXT: User:   %2 = begin_borrow %1 : $Builtin.NativeObject    // user: %4
+//
+// CHECK-LABEL: Function: simple_validate_enclosing_borrow_around_loop
+// CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
+// CHECK-NEXT: User:   br bb1(%6 : $Builtin.NativeObject, %5 : $Builtin.NativeObject) // id: %9
+// CHECK-NEXT: Initial: BorrowScopeOperand:
+// CHECK-NEXT: Kind: BeginBorrow
+// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %12, %3, %2
+// CHECK-NEXT: User:   %3 = begin_borrow %1 : $Builtin.NativeObject    // user: %4
+sil [ossa] @simple_validate_enclosing_borrow_around_loop : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  %2 = begin_borrow %1 : $Builtin.NativeObject
+  %3 = begin_borrow %1 : $Builtin.NativeObject
+  br bb1(%2 : $Builtin.NativeObject, %3 : $Builtin.NativeObject)
+
+bb1(%4 : @guaranteed $Builtin.NativeObject, %5 : @guaranteed $Builtin.NativeObject):
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb2a
+
+bb2a:
+  br bb1(%5 : $Builtin.NativeObject, %4 : $Builtin.NativeObject)
+
+bb3:
+  end_borrow %4 : $Builtin.NativeObject
+  end_borrow %5 : $Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Make sure we detect this phi cycle.
+// CHECK-LABEL: Function: simple_validate_enclosing_borrow_around_loop_2
+// CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
+// CHECK-NEXT: User:   br bb1(%5 : $Builtin.NativeObject, %4 : $Builtin.NativeObject) // id: %8
+// CHECK-NEXT: Initial: BorrowScopeOperand:
+// CHECK-NEXT: Kind: BeginBorrow
+// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // users: %2, %1
+// CHECK-NEXT: User:   %1 = begin_borrow %0 : $Builtin.NativeObject    // user: %3
+//
+// CHECK-LABEL: Function: simple_validate_enclosing_borrow_around_loop_2
+// CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
+// CHECK-NEXT: User:   br bb1(%5 : $Builtin.NativeObject, %4 : $Builtin.NativeObject) // id: %8
+// CHECK-NEXT: Initial: BorrowScopeOperand:
+// CHECK-NEXT: Kind: BeginBorrow
+// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // users: %2, %1
+// CHECK-NEXT: User:   %2 = begin_borrow %0 : $Builtin.NativeObject    // user: %3
+sil [ossa] @simple_validate_enclosing_borrow_around_loop_2 : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  %2 = begin_borrow %0 : $Builtin.NativeObject
+  %3 = begin_borrow %0 : $Builtin.NativeObject
+  br bb1(%2 : $Builtin.NativeObject, %3 : $Builtin.NativeObject)
+
+bb1(%4 : @guaranteed $Builtin.NativeObject, %5 : @guaranteed $Builtin.NativeObject):
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb2a
+
+bb2a:
+  br bb1(%5 : $Builtin.NativeObject, %4 : $Builtin.NativeObject)
+
+bb3:
+  end_borrow %4 : $Builtin.NativeObject
+  end_borrow %5 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Same as before, but this time with an owned value as a base.
+//
+// CHECK-LABEL: Function: simple_validate_enclosing_borrow_around_loop_3
+// CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
+// CHECK-NEXT: User:   br bb1(%5 : $Builtin.NativeObject, %4 : $Builtin.NativeObject) // id: %8
+// CHECK-NEXT: Initial: BorrowScopeOperand:
+// CHECK-NEXT: Kind: BeginBorrow
+// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // users: %11, %2, %1
+// CHECK-NEXT: User:   %2 = begin_borrow %0 : $Builtin.NativeObject    // user: %3
+//
+// CHECK-LABEL: Function: simple_validate_enclosing_borrow_around_loop_3
+// CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
+// CHECK-NEXT: User:   br bb1(%5 : $Builtin.NativeObject, %4 : $Builtin.NativeObject) // id: %8
+// CHECK-NEXT: Initial: BorrowScopeOperand:
+// CHECK-NEXT: Kind: BeginBorrow
+// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // users: %11, %2, %1
+// CHECK-NEXT: User:   %1 = begin_borrow %0 : $Builtin.NativeObject    // user: %3
+sil [ossa] @simple_validate_enclosing_borrow_around_loop_3 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %2 = begin_borrow %0 : $Builtin.NativeObject
+  %3 = begin_borrow %0 : $Builtin.NativeObject
+  br bb1(%2 : $Builtin.NativeObject, %3 : $Builtin.NativeObject)
+
+bb1(%4 : @guaranteed $Builtin.NativeObject, %5 : @guaranteed $Builtin.NativeObject):
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb2a
+
+bb2a:
+  br bb1(%5 : $Builtin.NativeObject, %4 : $Builtin.NativeObject)
+
+bb3:
+  end_borrow %4 : $Builtin.NativeObject
+  end_borrow %5 : $Builtin.NativeObject
+  destroy_value %0 : $Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SIL/ownership-verifier/cond_br_crash.sil
+++ b/test/SIL/ownership-verifier/cond_br_crash.sil
@@ -58,11 +58,24 @@ bb2:
 // Now check for use after frees in the consuming block.
 //
 // CHECK-LABEL: Function: 'test3'
-// CHECK: Found use after free?!
-// CHECK: Value:   %0 = argument of bb0 : $Builtin.NativeObject
-// CHECK: Consuming User:   cond_br undef, bb1(%0 : $Builtin.NativeObject), bb2
-// CHECK: Non Consuming User:   end_borrow %3 : $Builtin.NativeObject
-// CHECK: Block: bb1
+// CHECK-NEXT: Found use after free?!
+// CHECK-NEXT: Value:   %0 = argument of bb0 : $Builtin.NativeObject
+// CHECK-NEXT: Consuming User:   cond_br undef, bb1(%0 : $Builtin.NativeObject), bb2
+// CHECK-NEXT: Non Consuming User:   end_borrow %3
+// CHECK-NEXT: Block: bb1
+//
+// CHECK-LABEL: Function: 'test3'
+// CHECK-NEXT: Error! Found a leak due to a consuming post-dominance failure!
+// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject
+// CHECK-NEXT:     Post Dominating Failure Blocks:
+// CHECK-NEXT:         bb2
+//
+// CHECK-LABEL: Function: 'test3'
+// CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
+// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject
+// CHECK-NEXT:     Remaining Users:
+// CHECK-NEXT: User:  end_borrow %3 : $Builtin.NativeObject
+// CHECK-NEXT: Block: bb1
 sil [ossa] @test3 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   cond_br undef, bb1(%0 : $Builtin.NativeObject), bb2

--- a/test/SIL/ownership-verifier/over_consume.sil
+++ b/test/SIL/ownership-verifier/over_consume.sil
@@ -492,7 +492,6 @@ entry(%0 : @owned $Builtin.NativeObject):
   return %9999 : $()
 }
 
-
 // CHECK-LABEL: Function: 'use_after_free_consume_in_same_block'
 // CHECK: Found use after free due to unvisited non lifetime ending uses?!
 // CHECK: Value:   %3 = copy_value %2 : $Builtin.NativeObject

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -880,7 +880,8 @@ bb2:
 
 bb3:
   %2 = enum $ThreeDifferingPayloadEnum, #ThreeDifferingPayloadEnum.nontrivial_payload!enumelt.1, %0 : $Builtin.NativeObject
-  br bb5(%2 : $ThreeDifferingPayloadEnum)
+  %2a = begin_borrow %2 : $ThreeDifferingPayloadEnum
+  br bb5(%2a : $ThreeDifferingPayloadEnum)
 
 bb4:
   %3 = integer_literal $Builtin.Int32, 0
@@ -907,12 +908,14 @@ bb2:
 
 bb3:
   %3 = enum $ThreeDifferingPayloadEnum, #ThreeDifferingPayloadEnum.nontrivial_payload!enumelt.1, %1 : $Builtin.NativeObject
-  br bb5(%3 : $ThreeDifferingPayloadEnum)
+  %3a = begin_borrow %3 : $ThreeDifferingPayloadEnum
+  br bb5(%3a : $ThreeDifferingPayloadEnum)
 
 bb4:
   %4 = integer_literal $Builtin.Int32, 0
   %5 = enum $ThreeDifferingPayloadEnum, #ThreeDifferingPayloadEnum.trivial_payload!enumelt.1, %4 : $Builtin.Int32
-  br bb5(%5 : $ThreeDifferingPayloadEnum)
+  %5a = begin_borrow %5 : $ThreeDifferingPayloadEnum
+  br bb5(%5a : $ThreeDifferingPayloadEnum)
 
 bb5(%6 : @guaranteed $ThreeDifferingPayloadEnum):
   %7 = copy_value %6 : $ThreeDifferingPayloadEnum
@@ -1187,5 +1190,105 @@ bb0(%0 : @guaranteed $Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
   %2 = mark_dependence %0 : $Builtin.NativeObject on %1 : $Builtin.NativeObject
   destroy_value %1 : $Builtin.NativeObject
   %9999 = tuple()
+  return %9999 : $()
+}
+
+/////////////////////////////////////////
+// Movable Guaranteed Scope Test Cases //
+/////////////////////////////////////////
+
+sil [ossa] @simple_non_postdominating_diamond : $@convention(thin) (@in_guaranteed Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : @guaranteed $Builtin.NativeObject):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %3 = load_borrow %0 : $*Builtin.NativeObject
+  br bb3(%3 : $Builtin.NativeObject)
+
+bb2:
+  %5 = begin_borrow %1 : $Builtin.NativeObject
+  br bb3(%5 : $Builtin.NativeObject)
+
+bb3(%7 : @guaranteed $Builtin.NativeObject):
+  end_borrow %7 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil [ossa] @simple_non_postdominating_diamond_with_forwarding_uses : $@convention(thin) (@in_guaranteed Builtin.NativeObject, @guaranteed NonTrivialStructWithTrivialField) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : @guaranteed $NonTrivialStructWithTrivialField):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %3 = load_borrow %0 : $*Builtin.NativeObject
+  br bb3(%3 : $Builtin.NativeObject)
+
+bb2:
+  %5 = struct_extract %1 : $NonTrivialStructWithTrivialField, #NonTrivialStructWithTrivialField.owner
+  %6 = begin_borrow %5 : $Builtin.NativeObject
+  br bb3(%6 : $Builtin.NativeObject)
+
+bb3(%7 : @guaranteed $Builtin.NativeObject):
+  end_borrow %7 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Make sure that we can express a borrow loop carry.
+sil [ossa] @simple_loop_carry : $@convention(thin) (@in_guaranteed Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
+  br bb1
+
+bb1:
+  %2 = begin_borrow %1 : $Builtin.NativeObject
+  br bb2(%2 : $Builtin.NativeObject)
+
+bb2(%3 : @guaranteed $Builtin.NativeObject):
+  cond_br undef, bb3, bb4
+
+bb3:
+  %4 = load_borrow %0 : $*Builtin.NativeObject
+  end_borrow %3 : $Builtin.NativeObject
+  br bb2(%4 : $Builtin.NativeObject)
+
+bb4:
+  end_borrow %3 : $Builtin.NativeObject
+  %9999 = tuple()
+  destroy_value %1 : $Builtin.NativeObject
+  return %9999 : $()
+}
+
+// Make sure that we accept a borrow loop carry over a two backedge loop.
+sil [ossa] @simple_loop_carry_two_backedge : $@convention(thin) (@in_guaranteed Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
+  br bb1
+
+bb1:
+  %2 = begin_borrow %1 : $Builtin.NativeObject
+  br bb2(%2 : $Builtin.NativeObject)
+
+bb2(%3 : @guaranteed $Builtin.NativeObject):
+  br bb2a
+
+bb2a:
+  cond_br undef, bb3, bb4
+
+bb3:
+  cond_br undef, bb3a, bb3b
+
+bb3a:
+  %4 = load_borrow %0 : $*Builtin.NativeObject
+  end_borrow %3 : $Builtin.NativeObject
+  br bb2(%4 : $Builtin.NativeObject)
+
+bb3b:
+  %5 = load_borrow %0 : $*Builtin.NativeObject
+  end_borrow %3 : $Builtin.NativeObject
+  br bb2(%5 : $Builtin.NativeObject)
+
+bb4:
+  end_borrow %3 : $Builtin.NativeObject
+  %9999 = tuple()
+  destroy_value %1 : $Builtin.NativeObject
   return %9999 : $()
 }

--- a/test/SILOptimizer/diagnose_unreachable.sil
+++ b/test/SILOptimizer/diagnose_unreachable.sil
@@ -516,15 +516,20 @@ bb3:
   return %9999 : $()
 }
 
+// Rather than eliminate the end_borrow, we just propagate through since
+// branches now act like phis. We could eliminate the begin_borrow scope though,
+// but this pass does not perform that simplification.
+//
 // CHECK-LABEL: sil [ossa] @eliminate_end_borrow_when_propagating_bb_args : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
-// CHECK-NOT: end_borrow
+// CHECK: %1 = begin_borrow %0
 // CHECK: [[FUNC_REF:%.*]] = function_ref @guaranteed_nativeobject_user
-// CHECK-NEXT: apply [[FUNC_REF]](%0) :
-// CHECK-NOT: end_borrow
+// CHECK-NEXT: apply [[FUNC_REF]](%1) :
+// CHECK: end_borrow %1
 // CHECK: } // end sil function 'eliminate_end_borrow_when_propagating_bb_args'
 sil [ossa] @eliminate_end_borrow_when_propagating_bb_args : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
-  br bb1(%0 : $Builtin.NativeObject)
+  %0a = begin_borrow %0 : $Builtin.NativeObject
+  br bb1(%0a : $Builtin.NativeObject)
 
 bb1(%1 : @guaranteed $Builtin.NativeObject):
   %2 = function_ref @guaranteed_nativeobject_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
@@ -788,20 +793,20 @@ enum EnumWithB {
   func testit() -> Int
 }
 
-// Test propagation of guaranteed phi arguments. The nested end_borrow
-// must be removed, even with the outer borrow is *not* a function
-// argument.
+// Test propagation of guaranteed phi arguments. The nested end_borrow should
+// not be removed since guaranteed phis propagate now.
 //
 // CHECK-LABEL: sil hidden [ossa] @testEliminatePropagateGuaranteedPhiAfterSwitch : $@convention(method) (@guaranteed EnumWithB) -> () {
 // CHECK: bb1([[PHI:%.*]] : @guaranteed $B):
-// CHECK-NOT: end_borrow
+// CHECK: end_borrow
 // CHECK-LABEL: } // end sil function 'testEliminatePropagateGuaranteedPhiAfterSwitch'
 sil hidden [ossa] @testEliminatePropagateGuaranteedPhiAfterSwitch : $@convention(method) (@guaranteed EnumWithB) -> () {
 bb0(%0 : @guaranteed $EnumWithB):
   switch_enum %0 : $EnumWithB, case #EnumWithB.A!enumelt.1: bb1
 
 bb1(%2 : @guaranteed $B):
-  br bb3(%2 : $B)
+  %2a = begin_borrow %2 : $B
+  br bb3(%2a : $B)
 
 bb3(%4 : @guaranteed $B):
   %99 = tuple ()
@@ -811,8 +816,9 @@ bb3(%4 : @guaranteed $B):
 
 // CHECK-LABEL: sil hidden [ossa] @testEliminatePropagateBeginBorrowGuaranteedPhiAfterSwitch : $@convention(method) (@owned B) -> () {
 // CHECK: [[BORROW:%.*]] = begin_borrow
+// CHECK:  bb1:
+// CHECK:  bb2:
 // CHECK: end_borrow [[BORROW]]
-// CHECK-NOT: end_borrow
 // CHECK-LABEL: } // end sil function 'testEliminatePropagateBeginBorrowGuaranteedPhiAfterSwitch'
 sil hidden [ossa] @testEliminatePropagateBeginBorrowGuaranteedPhiAfterSwitch : $@convention(method) (@owned B) -> () {
 bb0(%0 : @owned $B):
@@ -825,8 +831,6 @@ bb1(%2 : @guaranteed $B):
 bb3(%3 : @guaranteed $B):
   %99 = tuple ()
   end_borrow %3 : $B
-  end_borrow %2 : $B
-  end_borrow %1 : $B
   destroy_value %0 : $B
   return %99 : $()
 }
@@ -853,11 +857,12 @@ bb3(%4 : @guaranteed $B):
 // Make sure that we can handle iterated end_borrow.
 //
 // CHECK-LABEL: sil hidden [ossa] @testPropagateGuaranteedPhi : $@convention(method) (@guaranteed B) -> () {
-// CHECK-NOT: end_borrow
+// CHECK: end_borrow
 // CHECK-LABEL: } // end sil function 'testPropagateGuaranteedPhi'
 sil hidden [ossa] @testPropagateGuaranteedPhi : $@convention(method) (@guaranteed B) -> () {
 bb0(%0 : @guaranteed $B):
-  br bb1(%0 : $B)
+  %0a = begin_borrow %0 : $B
+  br bb1(%0a : $B)
 
 bb1(%1 : @guaranteed $B):
   br bb2(%1 : $B)
@@ -865,6 +870,5 @@ bb1(%1 : @guaranteed $B):
 bb2(%2 : @guaranteed $B):
   %99 = tuple ()
   end_borrow %2 : $B
-  end_borrow %1 : $B
   return %99 : $()
 }


### PR DESCRIPTION
This patch implements movable guaranteed scopes in ossa. This pattern is
currently not generated anywhere in the compiler, but my hope is to begin
emitting these in SemanticARCOpts. The idea is that these model true phi nodes
and thus can be used to fuse multiple guaranteed scopes into one using br
instructions. This is treated similarly to how owned instructions are forwarded
through /all/ terminators. This will enable us to use the SILSSAUpdater with
guaranteed arguments as well as enable the expression of sets of borrow scopes
that minimally jointly-dominate a guaranteed argument. This will enable us to
express +0 merge points like the following:

```
bb1:
  %0a = begin_borrow %0 : $Klass
  br bb3(%0a : $Klass)

bb2:
  %1a = load_borrow %1 : $*Klass
  br bb3(%1a : $Klass)

bb3(%2 : @guaranteed $Klass)
  ...
  end_borrow %2 : $Klass
```

I describe below what the semantics of guaranteed block arguments were
previously, what they are now, and a little bit of interesting things from a
semantic perspective around implicit sub-scope users.

Before this patch in ossa, guaranteed block arguments had two different sets of
semantics:

1. Given a checked_cast_br or a switch_enum, the guaranteed block argument was
   treated like a forwarding instruction. As such, the guaranteed argument's did
   not require an end_borrow and its uses were validated as part of the use list
   of the switch_enum/checked_cast_br operand's borrow introducer. It also was
   not classified as a BorrowScopeValueIntroducer since it was not introducing a
   new scope.

2. Given any other predecessor terminator, we treated the guaranteed argument as
   a complete sub-scope of its incoming values. Thus we required the guaranteed
   argument to have its lifetime eneded by an end_borrow and that all incoming
   values of the guaranteed argument to come from a borrow introducer whose set
   of jointly post-dominating end_borrows also jointly post-dominates the set of
   end_borrows associated with the guaranteed argument itself. Consider the
   following example:

```
bb0:
  %1 = begin_borrow %foo : $Foo   // (1)
  %2 = begin_borrow %foo2 : $Foo2 // (2)
  cond_br ..., bb1, bb2

bb1:
  br bb3(%1 : $Foo)

bb2:
  br bb3(%2 : $Foo)

bb3(%3 : @guaranteed $Foo)
  ...
  end_borrow %3 : $Foo            // (3)
  end_borrow %2 : $Foo            // (4)
  end_borrow %1 : $Foo            // (5)
  ...
```

Notice how due to SSA, (1) and (2) must dominate (4) and (5) and thus must
dominate bb3, preventing the borrows from existing within bb1, bb2.

This dominance property is actively harmful to expressivity in SIL since it
means that guaranteed arguments can not be used to express (without contortion)
sil code patterns where an argument is jointly-dominated by a minimal set of
guaranteed incoming values. For instance, consider the following SIL example:

```
bb0:
  cond_br ..., bb1, bb2

bb1:
  %0 = load [copy] %globalAddr : $Foo
  br bb3(%0 : $Foo)

bb2:
  %1 = copy_value %guaranteedFunctionArg : $Foo
  br bb3(%1 : $Foo):

bb3(%2 : @owned $Foo):
  apply %useFoo(%2)
  destroy_value %2 : $Foo
```

As a quick proof: Assume the previous rules for guaranteed arguments. Then to
promote the load [copy] -> load_borrow and the copy_value to a begin_borrow, we
would need to place an end_borrow in bb3. But neither bb1 or bb2 dominates bb3,
so we would violate SSA dominance rules.

To enable SIL to express this pattern, we introduce a third rule for terminator
in ossa that applies only to branch insts. All other branches that obeyed the
previous rules (cond_br), still follow the old rule. This is not on purpose, I
am just being incremental and changing things as I need to. Specifically,
guaranteed arguments whose incoming values are defined by branch instructions
now act as a move on guaranteed values. The intuition here is that these
arguments are acting as true phis in an SSA sense and thus are just new names
for the incoming values. This implies since it is just a new name (not a
semantic change) that the guaranteed incoming value's guaranteed scopes should
be fused into one scope. The natural way to model this is by treating branch
insts as consuming guaranteed values. This then lets us express the example
above without using copies as follows:

```
bb0:
  cond_br ..., bb1, bb2

bb1:
  %0 = load_borrow %globalAddr : $Foo
  br bb3(%0 : $Foo) // consumes %0 and acts as %0's end_borrow.

bb2:
  // We need to introduce a new begin_borrow here since function
  // arguments are required to never be consumed.
  %1 = begin_borrow %guaranteedFunctionArg : $Foo
  br bb3(%1 : $Foo) // consumes %1 and acts as %1's end_borrow

// %2 continues the guaranteed scope of %0, %1. This time fused with one name.
bb3(%2 : @guaranteed $Foo):
  apply %useFoo(%2)
  // End the lifetime of %2 (which implicitly ends the lifetime of %0, %1).
  end_borrow %2 : $Foo
  ...
```

The main complication for users is that now when attempting to discover the set
of implicit users on an owned or guaranteed value caused by their usage as an
argument of a borrow introducer like begin_borrow. For those who are unaware, a
begin_borrow places an implicit requirement on its parent value that the parent
value is alive for the entire part of the CFG where this begin_borrow is
live. Previously, one could just look for the end_borrows of the
begin_borrow. Now one must additionally look for consuming branch insts. This is
because the original value that is being borrowed from must be alive over the
entire web of guaranteed values. That is the entire web of guaranteed values act
as a liveness requirement on the begin_borrow's operand.

The way this is implemented is given a use that we are validating, if the use is
a BorrowScopeOperand (1), we see if the borrow scope operand consumes the given
guaranteed scope and forwards it into a borrow scope introducer. If so, we add
the list of consuming uses of the borrow scope introducer to the worklist to
visit and then iterate.

In order to avoid working with cycles, for now, the ownership verifier bans
liveness requiring uses that have cycles in them. This still allows us to have
loop carried guaranteed values.

(1) A BorrowScopeOperand is a concept that represents an operand to a SIL
instruction that begins a guaranteed scope of some sort. All BorrowScopeOperand
are thus at a minimum able to compute a compile time the static region in which
they implicitly use their operands. NOTE: We do not require the scope to be
represented as a SILValue in the same function.

We achieve some nice benefit by introducing this. Specifically:

1. We can optimize the pattern I mentioned above. This is a common pattern in
   many frameworks that want to return a default object if a computation fails
   (with the default object usually being some sort of global or static
   var). This will let us optimize that case when the global is a let global.

2. The SSA Updater can now be used with guaranteed values without needing to
   introduce extra copies. This will enable predictable mem opts to introduce
   less copies and for semantic arc opts to optimize the remaining copies that
   PMO exposes but does not insert itself.

rdar://56720519

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
