### PR TITLE
[Constraint system] Generate constraints from patterns

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2287,11 +2287,13 @@ namespace {
         return subPatternType;
       }
 
+      case PatternKind::Bool:
+        return CS.getASTContext().getBoolDecl()->getDeclaredType();
+
       // Refutable patterns occur when checking the PatternBindingDecls in an
       // if/let or while/let condition.  They always require an initial value,
       // so they always allow unspecified types.
       case PatternKind::EnumElement:
-      case PatternKind::Bool:
       case PatternKind::Expr:
         // TODO: we could try harder here, e.g. for enum elements to provide the
         // enum type.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2280,6 +2280,7 @@ namespace {
         // checking; if it's impossible, fail.
         if (Type castType =
                 resolveTypeReferenceInExpression(isPattern->getCastTypeLoc())) {
+          castType = CS.openUnboundGenericType(castType, locator);
           CS.addConstraint(
               ConstraintKind::CheckedCast, subPatternType, castType, locator);
         }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2336,7 +2336,7 @@ namespace {
           CS.addValueMemberConstraint(
               parentMetaType, enumPattern->getName(), memberType, CurDC,
               functionRefKind, { },
-              locator.withPathElement(ConstraintLocator::PatternMatch));
+              locator.withPathElement(LocatorPathElt::PatternMatch(pattern)));
 
           // Parent type needs to be convertible to the pattern type; this
           // accounts for cases where the pattern type is existential.
@@ -2349,7 +2349,7 @@ namespace {
           CS.addUnresolvedValueMemberConstraint(
               MetatypeType::get(patternType), enumPattern->getName(),
               memberType, CurDC, functionRefKind,
-              locator.withPathElement(ConstraintLocator::PatternMatch));
+              locator.withPathElement(LocatorPathElt::PatternMatch(pattern)));
 
           baseType = patternType;
         }
@@ -2372,8 +2372,9 @@ namespace {
               CS.getConstraintLocator(locator),
               TVO_CanBindToNoEscape);
           Type functionType = FunctionType::get(params, outputType);
-          CS.addConstraint(ConstraintKind::Equal, functionType, memberType,
-                           locator);
+          CS.addConstraint(
+              ConstraintKind::Equal, functionType, memberType,
+              locator.withPathElement(LocatorPathElt::PatternMatch(pattern)));
 
           CS.addConstraint(ConstraintKind::Conversion, outputType, baseType,
                            locator);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2252,13 +2252,19 @@ namespace {
 
       case PatternKind::Typed: {
         // FIXME: Need a better locator for a pattern as a base.
+        // Compute the type ascribed to the pattern.
         auto contextualPattern =
             ContextualPattern::forRawPattern(pattern, CurDC);
         Type type = TypeChecker::typeCheckPattern(contextualPattern);
         Type openedType = CS.openUnboundGenericType(type, locator);
 
-        // For a typed pattern, simply return the opened type of the pattern.
-        // FIXME: Error recovery if the type is an error type?
+        // Determine the subpattern type. It will be convertible to the
+        // ascribed type.
+        Type subPatternType =
+            getTypeForPattern(
+               cast<TypedPattern>(pattern)->getSubPattern(), locator);
+        CS.addConstraint(
+            ConstraintKind::Conversion, subPatternType, openedType, locator);
         return setType(openedType);
       }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2207,9 +2207,12 @@ namespace {
 
       switch (pattern->getKind()) {
       case PatternKind::Paren:
-        // Parentheses don't affect the type.
-        return getTypeForPattern(cast<ParenPattern>(pattern)->getSubPattern(),
-                                 locator);
+        // Parentheses don't affect the canonical type, but record them as
+        // type sugar.
+        return ParenType::get(
+            CS.getASTContext(),
+            getTypeForPattern(
+              cast<ParenPattern>(pattern)->getSubPattern(), locator));
       case PatternKind::Var:
         // Var doesn't affect the type.
         return getTypeForPattern(cast<VarPattern>(pattern)->getSubPattern(),

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4044,7 +4044,7 @@ void ConstraintSystem::bindVariablesInPattern(
   case PatternKind::Named: {
     auto var = cast<NamedPattern>(pattern)->getDecl();
 
-    /// Create a fresh type variable to describe the type of the
+    /// Create a fresh type variable to describe the type of the bound variable.
     Type varType = createTypeVariable(locator, TVO_CanBindToNoEscape);
 
     auto ROK = ReferenceOwnership::Strong;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2255,13 +2255,22 @@ namespace {
         }
         return TupleType::get(tupleTypeElts, CS.getASTContext());
       }
-      
+
+      case PatternKind::OptionalSome: {
+        // The subpattern must have optional type.
+        Type subPatternType = getTypeForPattern(
+            cast<OptionalSomePattern>(pattern)->getSubPattern(), locator);
+
+        return OptionalType::get(subPatternType);
+      }
+
       // Refutable patterns occur when checking the PatternBindingDecls in an
       // if/let or while/let condition.  They always require an initial value,
       // so they always allow unspecified types.
-#define PATTERN(Id, Parent)
-#define REFUTABLE_PATTERN(Id, Parent) case PatternKind::Id:
-#include "swift/AST/PatternNodes.def"
+      case PatternKind::Is:
+      case PatternKind::EnumElement:
+      case PatternKind::Bool:
+      case PatternKind::Expr:
         // TODO: we could try harder here, e.g. for enum elements to provide the
         // enum type.
         return CS.createTypeVariable(CS.getConstraintLocator(locator),

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6068,6 +6068,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
   // match, unwrap optionals and try again to allow implicit creation of
   // optional "some" patterns (spelled "?").
   if (result.ViableCandidates.empty() && result.UnviableCandidates.empty() &&
+      memberLocator &&
       memberLocator->isLastElement<LocatorPathElt::PatternMatch>() &&
       instanceTy->getOptionalObjectType() &&
       baseObjTy->is<AnyMetatypeType>()) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1658,6 +1658,12 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
             implodeParams(func2Params);
           }
         }
+      } else if (last->getKind() == ConstraintLocator::PatternMatch &&
+          isa<EnumElementPattern>(
+            last->castTo<LocatorPathElt::PatternMatch>().getPattern()) &&
+          isSingleTupleParam(ctx, func1Params) &&
+          canImplodeParams(func2Params)) {
+        implodeParams(func2Params);
       }
     }
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -172,6 +172,8 @@ Solution ConstraintSystem::finalize() {
   solution.contextualTypes.assign(
       contextualTypes.begin(), contextualTypes.end());
 
+  solution.stmtConditionTargets = stmtConditionTargets;
+
   for (auto &e : CheckedConformances)
     solution.Conformances.push_back({e.first, e.second});
 
@@ -241,6 +243,12 @@ void ConstraintSystem::applySolution(const Solution &solution) {
       setContextualType(contextualType.first, contextualType.second.typeLoc,
                         contextualType.second.purpose);
     }
+  }
+
+  // Register the statement condition targets.
+  for (const auto &stmtConditionTarget : solution.stmtConditionTargets) {
+    if (!getStmtConditionTarget(stmtConditionTarget.first))
+      setStmtConditionTarget(stmtConditionTarget.first, stmtConditionTarget.second);
   }
 
   // Register the conformances checked along the way to arrive to solution.
@@ -455,6 +463,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numResolvedOverloads = cs.ResolvedOverloads.size();
   numInferredClosureTypes = cs.ClosureTypes.size();
   numContextualTypes = cs.contextualTypes.size();
+  numStmtConditionTargets = cs.stmtConditionTargets.size();
 
   PreviousScore = cs.CurrentScore;
 
@@ -531,6 +540,9 @@ ConstraintSystem::SolverScope::~SolverScope() {
 
   // Remove any contextual types.
   truncate(cs.contextualTypes, numContextualTypes);
+
+  // Remove any statement condition types.
+  truncate(cs.stmtConditionTargets, numStmtConditionTargets);
 
   // Reset the previous score.
   cs.CurrentScore = PreviousScore;

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -52,6 +52,11 @@ void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
       id.AddPointer(kpElt.getKeyPathDecl());
       break;
     }
+
+    case PatternMatch:
+      id.AddPointer(elt.castTo<LocatorPathElt::PatternMatch>().getPattern());
+      break;
+
     case GenericArgument:
     case NamedTupleElement:
     case TupleElement:

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -117,6 +117,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::DynamicCallable:
   case ConstraintLocator::ImplicitCallAsFunction:
   case ConstraintLocator::TernaryBranch:
+  case ConstraintLocator::PatternMatch:
     return 0;
 
   case ConstraintLocator::FunctionArgument:
@@ -476,10 +477,15 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
       out << "implicit reference to callAsFunction";
       break;
 
-    case TernaryBranch:
+    case TernaryBranch: {
       auto branchElt = elt.castTo<LocatorPathElt::TernaryBranch>();
       out << (branchElt.forThen() ? "'then'" : "'else'")
           << " branch of a ternary operator";
+      break;
+    }
+
+    case PatternMatch:
+      out << "pattern match";
       break;
     }
   }

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -68,6 +68,7 @@ public:
     case GenericParameter:
     case ProtocolRequirement:
     case Witness:
+    case PatternMatch:
       return 0;
 
     case ContextualType:
@@ -119,6 +120,7 @@ public:
       StoredWitness,
       StoredGenericSignature,
       StoredKeyPathDynamicMemberBase,
+      StoredPattern,
       StoredKindAndValue
     };
 
@@ -238,6 +240,9 @@ public:
 
       case StoredKeyPathDynamicMemberBase:
         return PathElementKind::KeyPathDynamicMember;
+
+      case StoredPattern:
+        return PathElementKind::PatternMatch;
 
       case StoredKindAndValue:
         return decodeStorage(storage).first;
@@ -800,6 +805,18 @@ public:
 
   static bool classof(const LocatorPathElt *elt) {
     return elt->getKind() == ConstraintLocator::TernaryBranch;
+  }
+};
+
+class LocatorPathElt::PatternMatch final : public LocatorPathElt {
+public:
+  PatternMatch(Pattern *pattern)
+      : LocatorPathElt(LocatorPathElt::StoredPattern, pattern) {}
+
+  Pattern *getPattern() const { return getStoredPointer<Pattern>(); }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::PatternMatch;
   }
 };
 

--- a/lib/Sema/ConstraintLocatorPathElts.def
+++ b/lib/Sema/ConstraintLocatorPathElts.def
@@ -175,6 +175,9 @@ SIMPLE_LOCATOR_PATH_ELT(DynamicCallable)
 /// The 'true' or 'false' branch of a ternary operator.
 CUSTOM_LOCATOR_PATH_ELT(TernaryBranch)
 
+/// Performing a pattern patch.
+SIMPLE_LOCATOR_PATH_ELT(PatternMatch)
+
 #undef LOCATOR_PATH_ELT
 #undef CUSTOM_LOCATOR_PATH_ELT
 #undef SIMPLE_LOCATOR_PATH_ELT

--- a/lib/Sema/ConstraintLocatorPathElts.def
+++ b/lib/Sema/ConstraintLocatorPathElts.def
@@ -176,7 +176,7 @@ SIMPLE_LOCATOR_PATH_ELT(DynamicCallable)
 CUSTOM_LOCATOR_PATH_ELT(TernaryBranch)
 
 /// Performing a pattern patch.
-SIMPLE_LOCATOR_PATH_ELT(PatternMatch)
+CUSTOM_LOCATOR_PATH_ELT(PatternMatch)
 
 #undef LOCATOR_PATH_ELT
 #undef CUSTOM_LOCATOR_PATH_ELT

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1051,8 +1051,15 @@ struct MemberLookupResult {
   /// If there is a favored candidate in the viable list, this indicates its
   /// index.
   unsigned FavoredChoice = ~0U;
-  
-  
+
+  /// The number of optional unwraps that were applied implicitly in the
+  /// lookup, for contexts where that is permitted.
+  unsigned numImplicitOptionalUnwraps = 0;
+
+  /// The base lookup type used to find the results, which will be non-null
+  /// only when it differs from the provided base type.
+  Type actualBaseType;
+
   /// This enum tracks reasons why a candidate is not viable.
   enum UnviableReason {
     /// This uses a type like Self in its signature that cannot be used on an

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -868,6 +868,10 @@ public:
   /// Contextual types introduced by this solution.
   std::vector<std::pair<const Expr *, ContextualTypeInfo>> contextualTypes;
 
+  /// Maps statement condition entries to their solution application targets.
+  llvm::MapVector<const StmtConditionElement *, SolutionApplicationTarget>
+    stmtConditionTargets;
+
   std::vector<std::pair<ConstraintLocator *, ProtocolConformanceRef>>
       Conformances;
 
@@ -1487,6 +1491,10 @@ private:
   llvm::DenseMap<std::pair<const KeyPathExpr *, unsigned>, TypeBase *>
       KeyPathComponentTypes;
 
+  /// Maps statement condition entries to their solution application targets.
+  llvm::MapVector<const StmtConditionElement *, SolutionApplicationTarget>
+    stmtConditionTargets;
+
   /// Contextual type information for expressions that are part of this
   /// constraint system.
   llvm::MapVector<const Expr *, ContextualTypeInfo> contextualTypes;
@@ -2068,6 +2076,9 @@ public:
     /// The length of \c contextualTypes.
     unsigned numContextualTypes;
 
+    /// The length of \c stmtConditionTargets.
+    unsigned numStmtConditionTargets;
+
     /// The previous score.
     Score PreviousScore;
 
@@ -2353,6 +2364,22 @@ public:
     if (result)
       return result->purpose;
     return CTP_Unused;
+  }
+
+  void setStmtConditionTarget(
+      const StmtConditionElement *element, SolutionApplicationTarget target) {
+    assert(element != nullptr && "Expected non-null condition element!");
+    assert(stmtConditionTargets.count(element) == 0 &&
+           "Already set this condition target");
+    stmtConditionTargets.insert({element, target});
+  }
+
+  Optional<SolutionApplicationTarget> getStmtConditionTarget(
+      const StmtConditionElement *element) const {
+    auto known = stmtConditionTargets.find(element);
+    if (known == stmtConditionTargets.end())
+      return None;
+    return known->second;
   }
 
   /// Retrieve the constraint locator for the given anchor and

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -915,12 +915,7 @@ void repairTupleOrAssociatedValuePatternIfApplicable(
 /// Perform top-down type coercion on the given pattern.
 Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
                                           Type type,
-                                          TypeResolutionOptions options,
-                                          TypeLoc tyLoc) {
-  if (tyLoc.isNull()) {
-    tyLoc = TypeLoc::withoutLoc(type);
-  }
-
+                                          TypeResolutionOptions options) {
   auto P = pattern.getPattern();
   auto dc = pattern.getDeclContext();
   auto &Context = dc->getASTContext();

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -959,8 +959,7 @@ public:
   ///
   /// \returns the coerced pattern, or nullptr if the coercion failed.
   static Pattern *coercePatternToType(ContextualPattern pattern, Type type,
-                                      TypeResolutionOptions options,
-                                      TypeLoc tyLoc = TypeLoc());
+                                      TypeResolutionOptions options);
   static bool typeCheckExprPattern(ExprPattern *EP, DeclContext *DC,
                                    Type type);
 

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -344,7 +344,7 @@ func rdar32241441() {
 
 
 // SR-6100
-struct One<Two> {
+struct One<Two> { // expected-note{{'Two' declared as parameter to type 'One'}}
     public enum E: Error {
         // if you remove associated value, everything works
         case SomeError(String)
@@ -354,7 +354,7 @@ struct One<Two> {
 func testOne() {
   do {
   } catch let error { // expected-warning{{'catch' block is unreachable because no errors are thrown in 'do' block}}
-    if case One.E.SomeError = error {} // expected-error{{generic enum type 'One.E' is ambiguous without explicit generic parameters when matching value of type 'Error'}}
+    if case One.E.SomeError = error {} // expected-error{{generic parameter 'Two' could not be inferred}}
   }
 }
 

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -1982,8 +1982,8 @@ func testThrows006() {
 
 // rdar://21346928
 // Just sample some String API to sanity check.
-// AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal:      unicodeScalars[#String.UnicodeScalarView#]
-// AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal:      utf16[#String.UTF16View#]
+// AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal{{.*}}:      {{.*}}unicodeScalars[#String.UnicodeScalarView#]
+// AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal{{.*}}:      {{.*}}utf16[#String.UTF16View#]
 func testWithAutoClosure1(_ x: String?) {
   (x ?? "autoclosure").#^AUTOCLOSURE1^#
 }

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -8,8 +8,11 @@ import CoreGraphics
 var roomName : String?
 
 if let realRoomName = roomName as! NSString { // expected-warning{{forced cast from 'String?' to 'NSString' only unwraps and bridges; did you mean to use '!' with 'as'?}}
-// expected-error@-1{{initializer for conditional binding must have Optional type, not 'NSString'}}
-
+  // expected-error@-1{{initializer for conditional binding must have Optional type, not 'NSString'}}
+  // expected-warning@-2{{treating a forced downcast to 'NSString' as optional will never produce 'nil'}}
+  // expected-note@-3{{add parentheses around the cast to silence this warning}}
+  // expected-note@-4{{use 'as?' to perform a conditional downcast to 'NSString'}}
+  _ = realRoomName
 }
 
 var pi = 3.14159265358979

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -23,23 +23,25 @@ if var x = foo() {
 
 use(x) // expected-error{{unresolved identifier 'x'}}
 
-if let x = nonOptionalStruct() { } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalStruct'}}
-if let x = nonOptionalEnum() { } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalEnum'}}
+if let x = nonOptionalStruct() { _ = x} // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalStruct'}}
+if let x = nonOptionalEnum() { _ = x} // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalEnum'}}
 
 guard let _ = nonOptionalStruct() else { fatalError() } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalStruct'}}
 guard let _ = nonOptionalEnum() else { fatalError() } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalEnum'}}
 
-if case let x? = nonOptionalStruct() { } // expected-error{{'?' pattern cannot match values of type 'NonOptionalStruct'}}
-if case let x? = nonOptionalEnum() { } // expected-error{{'?' pattern cannot match values of type 'NonOptionalEnum'}}
+if case let x? = nonOptionalStruct() { _ = x } // expected-error{{'?' pattern cannot match values of type 'NonOptionalStruct'}}
+if case let x? = nonOptionalEnum() { _ = x } // expected-error{{'?' pattern cannot match values of type 'NonOptionalEnum'}}
 
 class B {} // expected-note * {{did you mean 'B'?}}
 class D : B {}// expected-note * {{did you mean 'D'?}}
 
 // TODO poor recovery in these cases
 if let {} // expected-error {{expected '{' after 'if' condition}} expected-error {{pattern matching in a condition requires the 'case' keyword}}
-if let x = {} // expected-error{{'{' after 'if'}} expected-error {{variable binding in a condition requires an initializer}} expected-error{{initializer for conditional binding must have Optional type, not '() -> ()'}}
+if let x = { } // expected-error{{'{' after 'if'}} expected-error {{variable binding in a condition requires an initializer}} expected-error{{initializer for conditional binding must have Optional type, not '() -> ()'}}
+// expected-warning@-1{{value 'x' was defined but never used}}
 
 if let x = foo() {
+  _ = x
 } else {
   // TODO: more contextual error? "x is only available on the true branch"?
   use(x) // expected-error{{unresolved identifier 'x'}}
@@ -62,8 +64,8 @@ if var x = opt {} // expected-warning {{value 'x' was defined but never used; co
 
 // <rdar://problem/20800015> Fix error message for invalid if-let
 let someInteger = 1
-if let y = someInteger {}  // expected-error {{initializer for conditional binding must have Optional type, not 'Int'}}
-if case let y? = someInteger {}  // expected-error {{'?' pattern cannot match values of type 'Int'}}
+if let y = someInteger { _ = y }  // expected-error {{initializer for conditional binding must have Optional type, not 'Int'}}
+if case let y? = someInteger { _ = y }  // expected-error {{'?' pattern cannot match values of type 'Int'}}
 
 // Test multiple clauses on "if let".
 if let x = opt, let y = opt, x != y,

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -148,6 +148,7 @@ func testWhileScoping(_ a: Int?) {// expected-note {{did you mean 'a'?}}
 public enum SomeParseResult<T> {
   case error(length: Int)
   case repeated(value: String, repetitions: Int)
+  // expected-note@-1{{'repeated(value:repetitions:)' declared here}}
 
   var _error: Int? {
     if case .error(let result) = self { return result }
@@ -197,5 +198,11 @@ public enum SomeParseResult<T> {
       return (value, repetitions)
     }
     return nil
+  }
+}
+
+func matchImplicitTupling(pr: SomeParseResult<Int>) {
+  if case .repeated(let x) = pr { // expected-warning{{enum case 'repeated' has 2 associated values; matching them as a tuple is deprecated}}
+    let y: Int = x // expected-error{{cannot convert value of type '(value: String, repetitions: Int)' to specified type 'Int'}}
   }
 }

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -144,3 +144,58 @@ func testWhileScoping(_ a: Int?) {// expected-note {{did you mean 'a'?}}
   useInt(x) // expected-error{{use of unresolved identifier 'x'}}
 }
 
+// Matching a case with a single, labeled associated value.
+public enum SomeParseResult<T> {
+  case error(length: Int)
+  case repeated(value: String, repetitions: Int)
+
+  var _error: Int? {
+    if case .error(let result) = self { return result }
+    return nil
+  }
+
+  var _error2: Int? {
+    if case .error(length: let result) = self { return result }
+    return nil
+  }
+
+  var _error3: Int? {
+    if case .error(wrong: let result) = self { return result } // expected-error{{tuple pattern element label 'wrong' must be 'length'}}
+    return nil
+  }
+
+  var _repeated: (String, Int)? {
+    if case .repeated(let value, let repetitions) = self {
+      return (value, repetitions)
+    }
+    return nil
+  }
+
+  var _repeated2: (String, Int)? {
+    if case .repeated(value: let value, let repetitions) = self {
+      return (value, repetitions)
+    }
+    return nil
+  }
+
+  var _repeated3: (String, Int)? {
+    if case .repeated(let value, repetitions: let repetitions) = self {
+      return (value, repetitions)
+    }
+    return nil
+  }
+
+  var _repeated4: (String, Int)? {
+    if case .repeated(value: let value, repetitions: let repetitions) = self {
+      return (value, repetitions)
+    }
+    return nil
+  }
+
+  var _repeated5: (String, Int)? {
+    if case .repeated(value: let value, wrong: let repetitions) = self { // expected-error{{tuple pattern element label 'wrong' must be 'repetitions'}}
+      return (value, repetitions)
+    }
+    return nil
+  }
+}

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -206,3 +206,16 @@ func matchImplicitTupling(pr: SomeParseResult<Int>) {
     let y: Int = x // expected-error{{cannot convert value of type '(value: String, repetitions: Int)' to specified type 'Int'}}
   }
 }
+
+// Cope with an ambiguity between a case name and a static member. Prefer the
+// case.
+enum CaseStaticAmbiguity {
+  case C(Bool)
+
+  var isC: Bool {
+    if case .C = self { return true }
+    return false
+  }
+
+  static func C(_: Int) -> CaseStaticAmbiguity { return .C(true) }
+}

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -554,7 +554,7 @@ func testThrowNil() throws {
 // Even if the condition fails to typecheck, save it in the AST anyway; the old
 // condition may have contained a SequenceExpr.
 func r23684220(_ b: Any) {
-  if let _ = b ?? b {} // expected-error {{initializer for conditional binding must have Optional type, not 'Any'}}
+  if let _ = b ?? b {} // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'Any', so the right side is never used}}
 }
 
 


### PR DESCRIPTION
Generate constraints from the various forms of patterns, so that the well-formedness of the
pattern itself is established while solving the constraint system. Within this pull request:
* Constraints optional "some" patterns (`?`)
* Constraints for "is" patterns, which handle downcasts (spelled via `as`)
* Constraints for "enum element" patterns, which match enums (spelled, e.g., `.caseName(sub pattern)`)
* Mapping "bool" patterns to the `Bool` type
* Constraints for "typed" patterns, which introduce conversion constraints.

These constraints are currently used when type checking `if case` and `guard case`, but not the
more general `switch` cases (yet).
