### PR TITLE
[WebAssembly] Add wasm32 support to stdlib String

### DIFF
--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -76,7 +76,7 @@ internal struct _SmallString {
 extension _SmallString {
   @inlinable @inline(__always)
   internal static var capacity: Int {
-#if arch(i386) || arch(arm)
+#if arch(i386) || arch(arm) || arch(wasm32)
     return 10
 #else
     return 15
@@ -264,7 +264,7 @@ extension _SmallString {
 
     self.init(leading: leading, trailing: trailing, count: count)
   }
-  
+
   @inline(__always)
   internal init(
     initializingUTF8With initializer: (

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -77,7 +77,7 @@ internal struct _StringObject {
     internal init(zero: ()) { self._storage = 0 }
   }
 
-#if arch(i386) || arch(arm)
+#if arch(i386) || arch(arm) || arch(wasm32)
   @usableFromInline @frozen
   internal enum Variant {
     case immortal(UInt)
@@ -512,7 +512,7 @@ extension _StringObject {
     // spare bits (the most significant nibble) in a pointer.
     let word1 = small.rawBits.0.littleEndian
     let word2 = small.rawBits.1.littleEndian
-#if arch(i386) || arch(arm)
+#if arch(i386) || arch(arm) || arch(wasm32)
     // On 32-bit, we need to unpack the small string.
     let smallStringDiscriminatorAndCount: UInt64 = 0xFF00_0000_0000_0000
 
@@ -819,7 +819,7 @@ extension _StringObject {
 
   @inline(__always)
   internal var nativeStorage: __StringStorage {
-#if arch(i386) || arch(arm)
+#if arch(i386) || arch(arm) || arch(wasm32)
     guard case .native(let storage) = _variant else {
       _internalInvariantFailure()
     }
@@ -987,7 +987,7 @@ extension _StringObject {
   ) {
     let countAndFlags = CountAndFlags(sharedCount: length, isASCII: isASCII)
     let discriminator = Nibbles.largeCocoa(providesFastUTF8: providesFastUTF8)
-#if arch(i386) || arch(arm)
+#if arch(i386) || arch(arm) || arch(wasm32)
     self.init(
       variant: .bridged(cocoa),
       discriminator: discriminator,

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -186,7 +186,7 @@ extension __StringStorage {
     let count = try initializer(buffer)
 
     let countAndFlags = CountAndFlags(mortalCount: count, isASCII: false)
-    #if arch(i386) || arch(arm)
+    #if arch(i386) || arch(arm) || arch(wasm32)
     storage._count = countAndFlags.count
     storage._flags = countAndFlags.flags
     #else


### PR DESCRIPTION
Add `arch(wasm32)` checks to the implementation of String in the standard library to enable WebAssembly support.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
This is a part of [SR-9307](https://bugs.swift.org/browse/SR-9307) and #24684.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

(cc @kateinoigakukun)