### PR TITLE
Tbkka radar59302422 swift 5.2

### DIFF
--- a/test/Interpreter/generic_casts.swift
+++ b/test/Interpreter/generic_casts.swift
@@ -140,13 +140,20 @@ class PC: P {}
 class PCSub: PC {}
 
 // `is` checks
-func nongenericAnyIsP(type: Any.Type) -> Bool {
+func nongenericAnyIsPConforming(type: Any.Type) -> Bool {
+  // `is P.Type` tests whether the argument conforms to `P`
+  // Note:  this can only be true for a concrete type, never a protocol
+  return type is P.Type
+}
+func nongenericAnyIsPSubtype(type: Any.Type) -> Bool {
+  // `is P.Protocol` tests whether the argument is a subtype of `P`
+  // In particular, it is true for `P.self`
   return type is P.Protocol
 }
-func nongenericAnyIsPAndAnyObject(type: Any.Type) -> Bool {
-  return type is (P & AnyObject).Protocol
+func nongenericAnyIsPAndAnyObjectConforming(type: Any.Type) -> Bool {
+  return type is (P & AnyObject).Type
 }
-func nongenericAnyIsPAndPCSub(type: Any.Type) -> Bool {
+func nongenericAnyIsPAndPCSubConforming(type: Any.Type) -> Bool {
   return type is (P & PCSub).Type
 }
 func genericAnyIs<T>(type: Any.Type, to: T.Type, expected: Bool) -> Bool {
@@ -159,13 +166,16 @@ func genericAnyIs<T>(type: Any.Type, to: T.Type, expected: Bool) -> Bool {
   }
 }
 // `as?` checks
-func nongenericAnyAsConditionalP(type: Any.Type) -> Bool {
+func nongenericAnyAsConditionalPConforming(type: Any.Type) -> Bool {
+  return (type as? P.Type) != nil
+}
+func nongenericAnyAsConditionalPSubtype(type: Any.Type) -> Bool {
   return (type as? P.Protocol) != nil
 }
-func nongenericAnyAsConditionalPAndAnyObject(type: Any.Type) -> Bool {
-  return (type as? (P & AnyObject).Protocol) != nil
+func nongenericAnyAsConditionalPAndAnyObjectConforming(type: Any.Type) -> Bool {
+  return (type as? (P & AnyObject).Type) != nil
 }
-func nongenericAnyAsConditionalPAndPCSub(type: Any.Type) -> Bool {
+func nongenericAnyAsConditionalPAndPCSubConforming(type: Any.Type) -> Bool {
   return (type as? (P & PCSub).Type) != nil
 }
 func genericAnyAsConditional<T>(type: Any.Type, to: T.Type, expected: Bool) -> Bool {
@@ -180,15 +190,19 @@ func genericAnyAsConditional<T>(type: Any.Type, to: T.Type, expected: Bool) -> B
 // `as!` checks
 func blackhole<T>(_ : T) { }
 
-func nongenericAnyAsUnconditionalP(type: Any.Type) -> Bool {
+func nongenericAnyAsUnconditionalPConforming(type: Any.Type) -> Bool {
+  blackhole(type as! P.Type)
+  return true
+}
+func nongenericAnyAsUnconditionalPSubtype(type: Any.Type) -> Bool {
   blackhole(type as! P.Protocol)
   return true
 }
-func nongenericAnyAsUnconditionalPAndAnyObject(type: Any.Type) -> Bool {
-  blackhole(type as! (P & AnyObject).Protocol)
+func nongenericAnyAsUnconditionalPAndAnyObjectConforming(type: Any.Type) -> Bool {
+  blackhole(type as! (P & AnyObject).Type)
   return true
 }
-func nongenericAnyAsUnconditionalPAndPCSub(type: Any.Type) -> Bool {
+func nongenericAnyAsUnconditionalPAndPCSubConforming(type: Any.Type) -> Bool {
   blackhole(type as! (P & PCSub).Type)
   return true
 }
@@ -201,79 +215,82 @@ func genericAnyAsUnconditional<T>(type: Any.Type, to: T.Type, expected: Bool) ->
 
 // CHECK-LABEL: casting types to protocols with generics:
 print("casting types to protocols with generics:")
-print(nongenericAnyIsP(type: P.self)) // CHECK: true
+print(nongenericAnyIsPConforming(type: P.self)) // CHECK: false
+print(nongenericAnyIsPSubtype(type: P.self)) // CHECK: true
 print(genericAnyIs(type: P.self, to: P.self, expected: true)) // CHECK: true
-print(nongenericAnyIsP(type: PS.self)) // CHECK-ONONE: true
+print(nongenericAnyIsPConforming(type: PS.self)) // CHECK: true
 print(genericAnyIs(type: PS.self, to: P.self, expected: true)) // CHECK-ONONE: true
-print(nongenericAnyIsP(type: PE.self)) // CHECK-ONONE: true
+print(nongenericAnyIsPConforming(type: PE.self)) // CHECK: true
 print(genericAnyIs(type: PE.self, to: P.self, expected: true)) // CHECK-ONONE: true
-print(nongenericAnyIsP(type: PC.self)) // CHECK-ONONE: true
+print(nongenericAnyIsPConforming(type: PC.self)) // CHECK: true
 print(genericAnyIs(type: PC.self, to: P.self, expected: true)) // CHECK-ONONE: true
-print(nongenericAnyIsP(type: PCSub.self)) // CHECK-ONONE: true
+print(nongenericAnyIsPConforming(type: PCSub.self)) // CHECK: true
 print(genericAnyIs(type: PCSub.self, to: P.self, expected: true)) // CHECK-ONONE: true
 
 // CHECK-LABEL: conditionally casting types to protocols with generics:
 print("conditionally casting types to protocols with generics:")
-print(nongenericAnyAsConditionalP(type: P.self)) // CHECK: true
-print(genericAnyAsConditional(type: P.self, to: P.self, expected: true)) // CHECK-ONONE: true
-print(nongenericAnyAsConditionalP(type: PS.self)) // CHECK: true
+print(nongenericAnyAsConditionalPConforming(type: P.self)) // CHECK: false
+print(nongenericAnyAsConditionalPSubtype(type: P.self)) // CHECK: true
+print(genericAnyAsConditional(type: P.self, to: P.self, expected: true)) // CHECK: true
+print(nongenericAnyAsConditionalPConforming(type: PS.self)) // CHECK: true
 print(genericAnyAsConditional(type: PS.self, to: P.self, expected: true)) // CHECK-ONONE: true
-print(nongenericAnyAsConditionalP(type: PE.self)) // CHECK-ONONE: true
+print(nongenericAnyAsConditionalPConforming(type: PE.self)) // CHECK: true
 print(genericAnyAsConditional(type: PE.self, to: P.self, expected: true)) // CHECK-ONONE: true
-print(nongenericAnyAsConditionalP(type: PC.self)) // CHECK-ONONE: true
+print(nongenericAnyAsConditionalPConforming(type: PC.self)) // CHECK: true
 print(genericAnyAsConditional(type: PC.self, to: P.self, expected: true)) // CHECK-ONONE: true
-print(nongenericAnyAsConditionalP(type: PCSub.self)) // CHECK-ONONE: true
+print(nongenericAnyAsConditionalPConforming(type: PCSub.self)) // CHECK: true
 print(genericAnyAsConditional(type: PCSub.self, to: P.self, expected: true)) // CHECK-ONONE: true
 
 // CHECK-LABEL: unconditionally casting types to protocols with generics:
 print("unconditionally casting types to protocols with generics:")
-print(nongenericAnyAsUnconditionalP(type: P.self)) // CHECK: true
+//print(nongenericAnyAsUnconditionalPConforming(type: P.self)) // expected to trap
+print(nongenericAnyAsUnconditionalPSubtype(type: P.self)) // CHECK: true
 print(genericAnyAsUnconditional(type: P.self, to: P.self, expected: true)) // CHECK: true
-print(nongenericAnyAsUnconditionalP(type: PS.self)) // CHECK: true
+print(nongenericAnyAsUnconditionalPConforming(type: PS.self)) // CHECK: true
 print(genericAnyAsUnconditional(type: PS.self, to: P.self, expected: true)) // CHECK: true
-print(nongenericAnyAsUnconditionalP(type: PE.self)) // CHECK: true
+print(nongenericAnyAsUnconditionalPConforming(type: PE.self)) // CHECK: true
 print(genericAnyAsUnconditional(type: PE.self, to: P.self, expected: true)) // CHECK: true
-print(nongenericAnyAsUnconditionalP(type: PC.self)) // CHECK: true
+print(nongenericAnyAsUnconditionalPConforming(type: PC.self)) // CHECK: true
 print(genericAnyAsUnconditional(type: PC.self, to: P.self, expected: true)) // CHECK: true
-print(nongenericAnyAsUnconditionalP(type: PCSub.self)) // CHECK: true
+print(nongenericAnyAsUnconditionalPConforming(type: PCSub.self)) // CHECK: true
 print(genericAnyAsUnconditional(type: PCSub.self, to: P.self, expected: true)) // CHECK: true
 
 // CHECK-LABEL: casting types to protocol & AnyObject existentials:
 print("casting types to protocol & AnyObject existentials:")
-print(nongenericAnyIsPAndAnyObject(type: PS.self)) // CHECK: false
+print(nongenericAnyIsPAndAnyObjectConforming(type: PS.self)) // CHECK: false
 print(genericAnyIs(type: PS.self, to: (P & AnyObject).self, expected: false)) // CHECK: false
-print(nongenericAnyIsPAndAnyObject(type: PE.self)) // CHECK: false
+print(nongenericAnyIsPAndAnyObjectConforming(type: PE.self)) // CHECK: false
 print(genericAnyIs(type: PE.self, to: (P & AnyObject).self, expected: false)) // CHECK: false
-print(nongenericAnyIsPAndAnyObject(type: PC.self)) // CHECK-ONONE: true
+print(nongenericAnyIsPAndAnyObjectConforming(type: PC.self)) // CHECK: true
 print(genericAnyIs(type: PC.self, to: (P & AnyObject).self, expected: true)) // CHECK-ONONE: true
-print(nongenericAnyIsPAndAnyObject(type: PCSub.self)) // CHECK-ONONE: true
+print(nongenericAnyIsPAndAnyObjectConforming(type: PCSub.self)) // CHECK: true
 print(genericAnyIs(type: PCSub.self, to: (P & AnyObject).self, expected: true)) // CHECK-ONONE: true
-print(nongenericAnyAsConditionalPAndAnyObject(type: PS.self)) // CHECK: false
+print(nongenericAnyAsConditionalPAndAnyObjectConforming(type: PS.self)) // CHECK: false
 print(genericAnyAsConditional(type: PS.self, to: (P & AnyObject).self, expected: false)) // CHECK: false
-print(nongenericAnyAsConditionalPAndAnyObject(type: PE.self)) // CHECK: false
+print(nongenericAnyAsConditionalPAndAnyObjectConforming(type: PE.self)) // CHECK: false
 print(genericAnyAsConditional(type: PE.self, to: (P & AnyObject).self, expected: false)) // CHECK: false
-print(nongenericAnyAsConditionalPAndAnyObject(type: PC.self)) // CHECK-ONONE: true
+print(nongenericAnyAsConditionalPAndAnyObjectConforming(type: PC.self)) // CHECK: true
 print(genericAnyAsConditional(type: PC.self, to: (P & AnyObject).self, expected: true)) // CHECK-ONONE: true
-print(nongenericAnyAsConditionalPAndAnyObject(type: PCSub.self)) // CHECK-ONONE: true
+print(nongenericAnyAsConditionalPAndAnyObjectConforming(type: PCSub.self)) // CHECK: true
 print(genericAnyAsConditional(type: PCSub.self, to: (P & AnyObject).self, expected: true)) // CHECK-ONONE: true
 
 // CHECK-LABEL: casting types to protocol & class existentials:
 print("casting types to protocol & class existentials:")
-print(nongenericAnyIsPAndPCSub(type: PS.self)) // CHECK: false
+print(nongenericAnyIsPAndPCSubConforming(type: PS.self)) // CHECK: false
 print(genericAnyIs(type: PS.self, to: (P & PCSub).self, expected: false)) // CHECK: false
-print(nongenericAnyIsPAndPCSub(type: PE.self)) // CHECK: false
+print(nongenericAnyIsPAndPCSubConforming(type: PE.self)) // CHECK: false
 print(genericAnyIs(type: PE.self, to: (P & PCSub).self, expected: false)) // CHECK: false
-//print(nongenericAnyIsPAndPCSub(type: PC.self)) // CHECK-SR-11565: false -- FIXME: reenable this when SR-11565 is fixed
+//print(nongenericAnyIsPAndPCSubConforming(type: PC.self)) // CHECK-SR-11565: false -- FIXME: reenable this when SR-11565 is fixed
 print(genericAnyIs(type: PC.self, to: (P & PCSub).self, expected: false)) // CHECK: false
-print(nongenericAnyIsPAndPCSub(type: PCSub.self)) // CHECK: true
+print(nongenericAnyIsPAndPCSubConforming(type: PCSub.self)) // CHECK: true
 print(genericAnyIs(type: PCSub.self, to: (P & PCSub).self, expected: true)) // CHECK-ONONE: true
-print(nongenericAnyAsConditionalPAndPCSub(type: PS.self)) // CHECK: false
+print(nongenericAnyAsConditionalPAndPCSubConforming(type: PS.self)) // CHECK: false
 print(genericAnyAsConditional(type: PS.self, to: (P & PCSub).self, expected: false)) // CHECK: false
-print(nongenericAnyAsConditionalPAndPCSub(type: PE.self)) // CHECK: false
+print(nongenericAnyAsConditionalPAndPCSubConforming(type: PE.self)) // CHECK: false
 print(genericAnyAsConditional(type: PE.self, to: (P & PCSub).self, expected: false)) // CHECK: false
-//print(nongenericAnyAsConditionalPAndPCSub(type: PC.self)) // CHECK-SR-11565: false -- FIXME: reenable this when SR-11565 is fixed
+//print(nongenericAnyAsConditionalPAndPCSubConforming(type: PC.self)) // CHECK-SR-11565: false -- FIXME: reenable this when SR-11565 is fixed
 print(genericAnyAsConditional(type: PC.self, to: (P & PCSub).self, expected: false)) // CHECK: false
-print(nongenericAnyAsConditionalPAndPCSub(type: PCSub.self)) // CHECK: true
+print(nongenericAnyAsConditionalPAndPCSubConforming(type: PCSub.self)) // CHECK: true
 print(genericAnyAsConditional(type: PCSub.self, to: (P & PCSub).self, expected: true)) // CHECK-ONONE: true
 
 


### PR DESCRIPTION
An earlier fix for certain protocol casts inadvertently disabled
the check for a protocol being cast to its own metatype.
This rearranges the code so that identical types always succeed.
It also updates swift_dynamicCastMetatypeUnconditional to
include recent changes to swift_dynamicCastMetatype.

Note: These fixes only apply to debug/non-optimized builds.
Cast optimizations still break a lot of these cases.

Scope: This restores the ability to cast type identifiers (e.g. `T.self` and `P.self`) to their direct type (`T.Type` and `P.Protocol`, respectively).  It also ensures that `as!` supports the same behaviors for protocol existentials as `as?` does.

Resolves SR-12161
Resolves rdar://59302422

Risk: Minor.  This comprises two code changes:  The first migrates a block of code so that the check for exact type equality always occurs first.  The second duplicates a block of code added to `as?` processing back in October 2019 to also be used in `as!` handling.

Testing:  The unit tests have been expanded to provide good coverage of these cases.
