### PR TITLE
[CSSimplify] Guard against null locator

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5382,7 +5382,8 @@ static bool isSelfRecursiveKeyPathDynamicMemberLookup(
     ConstraintSystem &cs, Type keyPathRootTy, ConstraintLocator *locator) {
   // Let's check whether this is a recursive call to keypath
   // dynamic member lookup on the same type.
-  if (!locator->isLastElement<LocatorPathElt::KeyPathDynamicMember>())
+  if (!locator ||
+      !locator->isLastElement<LocatorPathElt::KeyPathDynamicMember>())
     return false;
 
   auto path = locator->getPath();

--- a/test/Index/Store/dynamic-member-lookup-crash-1.swift
+++ b/test/Index/Store/dynamic-member-lookup-crash-1.swift
@@ -1,0 +1,18 @@
+// Ensure that we don't crash looking for default implementations during indexing.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -index-store-path %t/idx -o %t/file.o -typecheck -primary-file %s -verify
+
+@dynamicMemberLookup
+public protocol Foo {
+  associatedtype Value
+  
+  var value: Value { get }
+  subscript<U>(dynamicMember keyPath: KeyPath<Value, U>) -> U { get }
+}
+
+extension Foo {
+  public var value: Value {
+    fatalError()
+  }
+}


### PR DESCRIPTION
`resolveValueMember` calls `CS.performMemberLookup` with null locator, which is later passed to `isSelfRecursiveKeyPathDynamicMemberLookup`. This leads to a crash while indexing. Make sure the locator is not null before accessing it.

Resolves SR-12174
Resolves rdar://problem/59496015