### PR TITLE
Runtime: Less eager instantiation of type metadata in the conformance cache

### DIFF
--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -527,8 +527,11 @@ namespace {
         return nullptr;
 
       auto proto = existentialType->getProtocols()[0];
+
+#if SWIFT_OBJC_INTEROP
       if (proto.isObjC())
         return nullptr;
+#endif
 
       return proto.getSwiftProtocol();
     }

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -481,7 +481,7 @@ recur:
 
 namespace {
   /// Describes a protocol conformance "candidate" that can be checked
-  /// against the
+  /// against a type metadata.
   class ConformanceCandidate {
     const void *candidate;
     bool candidateIsMetadata;
@@ -492,15 +492,15 @@ namespace {
     ConformanceCandidate(const ProtocolConformanceDescriptor &conformance)
       : ConformanceCandidate()
     {
-      if (auto metadata = conformance.getCanonicalTypeMetadata()) {
-        candidate = metadata;
-        candidateIsMetadata = true;
-        return;
-      }
-
       if (auto description = conformance.getTypeDescriptor()) {
         candidate = description;
         candidateIsMetadata = false;
+        return;
+      }
+
+      if (auto metadata = conformance.getCanonicalTypeMetadata()) {
+        candidate = metadata;
+        candidateIsMetadata = true;
         return;
       }
     }
@@ -513,6 +513,26 @@ namespace {
                                  : nullptr;
     }
 
+    const ContextDescriptor *
+    getContextDescriptor(const Metadata *conformingType) const {
+      const auto *description = conformingType->getTypeContextDescriptor();
+      if (description)
+        return description;
+
+      // Handle single-protocol existential types for self-conformance.
+      auto *existentialType = dyn_cast<ExistentialTypeMetadata>(conformingType);
+      if (existentialType == nullptr ||
+          existentialType->getProtocols().size() != 1 ||
+          existentialType->getSuperclassConstraint() != nullptr)
+        return nullptr;
+
+      auto proto = existentialType->getProtocols()[0];
+      if (proto.isObjC())
+        return nullptr;
+
+      return proto.getSwiftProtocol();
+    }
+
     /// Whether the conforming type exactly matches the conformance candidate.
     bool matches(const Metadata *conformingType) const {
       // Check whether the types match.
@@ -521,7 +541,7 @@ namespace {
 
       // Check whether the nominal type descriptors match.
       if (!candidateIsMetadata) {
-        const auto *description = conformingType->getTypeContextDescriptor();
+        const auto *description = getContextDescriptor(conformingType);
         auto candidateDescription =
           static_cast<const ContextDescriptor *>(candidate);
         if (description && equalContexts(description, candidateDescription))

--- a/validation-test/Evolution/Inputs/backward_deploy_conformance.swift
+++ b/validation-test/Evolution/Inputs/backward_deploy_conformance.swift
@@ -1,0 +1,18 @@
+public func getVersion() -> Int {
+#if BEFORE
+  return 0
+#else
+  return 1
+#endif
+}
+
+#if AFTER
+@_weakLinked
+public struct NewStruct<T> {
+  var t: T
+
+  public init(_ t: T) {
+    self.t = t
+  }
+}
+#endif

--- a/validation-test/Evolution/test_backward_deploy_conformance.swift
+++ b/validation-test/Evolution/test_backward_deploy_conformance.swift
@@ -1,0 +1,28 @@
+// RUN: %target-resilience-test --backward-deployment
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import backward_deploy_conformance
+
+
+var BackwardDeployConformanceTest = TestSuite("BackwardDeployConformance")
+
+public class UsesNewStruct: CustomStringConvertible {
+  public var field: NewStruct<Bool>? = nil
+  public let description = "This is my description"
+}
+
+public class OtherClass {}
+
+@_optimize(none)
+func blackHole<T>(_: T) {}
+
+BackwardDeployConformanceTest.test("ConformanceCache") {
+  if getVersion() == 1 {
+    blackHole(UsesNewStruct())
+  }
+
+  blackHole(OtherClass() as? CustomStringConvertible)
+}
+
+runAllTests()


### PR DESCRIPTION
The ConformanceCandidate constructor would eagerly instantiate metadata for
all non-generic types in the conformance cache. This was not the intention
of the code though, because it can compare nominal type descriptors --
which are emitted statically -- for those types that have them, namely
everything except for foreign and Objective-C classes.

Change the order of two calls so that the lazy path has a chance to run.
This fixes a crash when type metadata uses weakly-linked symbols
which are not available, which can come up in backward deployment
scenarios.

Fixes <rdar://problem/59460603>.