### PR TITLE
[5.2][CSApply] Always use `String` type for ObjC interop key path

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4324,7 +4324,7 @@ namespace {
                                  StringRef(stringCopy, compatStringBuf.size()),
                                  SourceRange(),
                                  /*implicit*/ true);
-          cs.setType(stringExpr, cs.getType(E));
+          cs.setType(stringExpr, TypeChecker::getStringType(cs.getASTContext()));
           E->setObjCStringLiteralExpr(stringExpr);
         }
       }

--- a/validation-test/compiler_crashers_2_fixed/0210-rdar57356196.swift
+++ b/validation-test/compiler_crashers_2_fixed/0210-rdar57356196.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -verify
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc class A : NSObject {
+  @objc var x: Int = 42
+}
+
+@propertyWrapper
+struct Attr<V> {
+  var wrappedValue: V {
+    get { fatalError() }
+  }
+
+  init(wrappedValue: V, key: KeyPath<A, V>) {}
+}
+
+class B {
+  @Attr(key: \.x) var y: Int = 0 // Ok
+}


### PR DESCRIPTION
- **Explanation**:

Objective-C key path implicitly generated for interop purposes (if all elements
of the path are all visible from Objective-C) should always have a `String` type, 
which isn't the case currently because it was getting a type from enclosing 
key path expression.

This fix makes sure that implicit expression for Objective-C key path always
gets assigned a correct type.

- **Issue**: rdar://problem/57356196

- **Scope**: Affects key path expressions where all of the elements are visible
from Objective-C. Crash could only be triggered when implicit expression is
re-typechecked e.g. via old diagnostics or in order to generate an implicit initializer
for a property wrapper.

- **Risk**: Very Low. 

- **Testing**: Added compiler regression tests.

- **Reviewed by**: @CodaFi 

Resolves: rdar://problem/57356196
(cherry picked from commit ae79b0d0bd0d042bebe50dbd08f0fcd365e37e5a)


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
