### PR TITLE
[5.2] [CSSimplify] Guard against null locator

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5336,7 +5336,8 @@ static bool isSelfRecursiveKeyPathDynamicMemberLookup(
     ConstraintSystem &cs, Type keyPathRootTy, ConstraintLocator *locator) {
   // Let's check whether this is a recursive call to keypath
   // dynamic member lookup on the same type.
-  if (!locator->isLastElement<LocatorPathElt::KeyPathDynamicMember>())
+  if (!locator ||
+      !locator->isLastElement<LocatorPathElt::KeyPathDynamicMember>())
     return false;
 
   auto path = locator->getPath();

--- a/test/Index/Store/dynamic-member-lookup-crash-1.swift
+++ b/test/Index/Store/dynamic-member-lookup-crash-1.swift
@@ -1,0 +1,18 @@
+// Ensure that we don't crash looking for default implementations during indexing.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -index-store-path %t/idx -o %t/file.o -typecheck -primary-file %s -verify
+
+@dynamicMemberLookup
+public protocol Foo {
+  associatedtype Value
+  
+  var value: Value { get }
+  subscript<U>(dynamicMember keyPath: KeyPath<Value, U>) -> U { get }
+}
+
+extension Foo {
+  public var value: Value {
+    fatalError()
+  }
+}


### PR DESCRIPTION
- **Explanation**: `resolveValueMember` calls `CS.performMemberLookup` with null locator, which is later passed to `isSelfRecursiveKeyPathDynamicMemberLookup`. This leads to a crash while indexing. Make sure the locator is not null before accessing it.

- **Issue**: SR-12174 | rdar://problem/59496015

- **Scope**: Affects use of `@dynamicMemberLookup` with default implementations.

- **Risk**: Very Low.  This is a regression from Swift 5.1 which is now fixed.

- **Testing**: Added compiler regression test.

- **Reviewed by**: @xedin 

Cherry-pick of #29886