### PR TITLE
[5.2] SILCombine: fix a miscompile in the alloc_stack optimization which causes a use-after-free.

### DIFF
--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -2640,6 +2640,107 @@ bb0(%0 : $*B):
   return %4 : $()
 }
 
+// CHECK-LABEL: sil @moved_retain_prevents_alloc_stack_deletion1
+// CHECK: copy_addr
+// CHECK: strong_retain
+// CHECK: destroy_addr
+// CHECK: } // end sil function 'moved_retain_prevents_alloc_stack_deletion1'
+sil @moved_retain_prevents_alloc_stack_deletion1 : $@convention(thin) (@guaranteed B) -> () {
+bb0(%0 : $B):
+  %3 = alloc_stack $B
+  %4 = alloc_stack $B
+  store %0 to %4 : $*B
+  copy_addr [take] %4 to [initialization] %3 : $*B
+  dealloc_stack %4 : $*B
+  strong_retain %0 : $B
+  destroy_addr %3 : $*B
+  dealloc_stack %3 : $*B
+  %14 = tuple ()
+  return %14 : $()
+}
+
+// CHECK-LABEL: sil @moved_retain_prevents_alloc_stack_deletion2
+// CHECK:   copy_addr
+// CHECK: bb1:
+// CHECK:   strong_retain
+// CHECK:   destroy_addr
+// CHECK: bb2:
+// CHECK:   strong_retain
+// CHECK:   destroy_addr
+// CHECK: } // end sil function 'moved_retain_prevents_alloc_stack_deletion2'
+sil @moved_retain_prevents_alloc_stack_deletion2 : $@convention(thin) (@guaranteed B) -> () {
+bb0(%0 : $B):
+  %3 = alloc_stack $B
+  %4 = alloc_stack $B
+  store %0 to %4 : $*B
+  copy_addr [take] %4 to [initialization] %3 : $*B
+  dealloc_stack %4 : $*B
+  cond_br undef, bb1, bb2
+bb1:
+  strong_retain %0 : $B
+  destroy_addr %3 : $*B
+  dealloc_stack %3 : $*B
+  br bb3
+bb2:
+  strong_retain %0 : $B
+  destroy_addr %3 : $*B
+  dealloc_stack %3 : $*B
+  br bb3
+bb3:
+  %14 = tuple ()
+  return %14 : $()
+}
+
+// CHECK-LABEL: sil @retain_is_after_stack_location
+// CHECK-NOT:   copy_addr
+// CHECK: } // end sil function 'retain_is_after_stack_location'
+sil @retain_is_after_stack_location : $@convention(thin) (@guaranteed B) -> () {
+bb0(%0 : $B):
+  %3 = alloc_stack $B
+  %4 = alloc_stack $B
+  store %0 to %4 : $*B
+  copy_addr [take] %4 to [initialization] %3 : $*B
+  dealloc_stack %4 : $*B
+  cond_br undef, bb1, bb2
+bb1:
+  destroy_addr %3 : $*B
+  strong_retain %0 : $B
+  dealloc_stack %3 : $*B
+  br bb3
+bb2:
+  destroy_addr %3 : $*B
+  strong_retain %0 : $B
+  dealloc_stack %3 : $*B
+  br bb3
+bb3:
+  %14 = tuple ()
+  return %14 : $()
+}
+
+// CHECK-LABEL: sil @moved_retain_prevents_alloc_stack_deletion3
+// CHECK:   copy_addr
+// CHECK: bb2:
+// CHECK:   strong_retain
+// CHECK:   destroy_addr
+// CHECK: } // end sil function 'moved_retain_prevents_alloc_stack_deletion3'
+sil @moved_retain_prevents_alloc_stack_deletion3 : $@convention(thin) (@guaranteed B) -> () {
+bb0(%0 : $B):
+  %3 = alloc_stack $B
+  %4 = alloc_stack $B
+  store %0 to %4 : $*B
+  copy_addr [take] %4 to [initialization] %3 : $*B
+  dealloc_stack %4 : $*B
+  br bb1
+bb1:
+  cond_br undef, bb1, bb2
+bb2:
+  strong_retain %0 : $B
+  destroy_addr %3 : $*B
+  dealloc_stack %3 : $*B
+  %14 = tuple ()
+  return %14 : $()
+}
+
 protocol someProtocol {
     var i: Int { get }
 }
@@ -2942,6 +3043,7 @@ sil @closure_with_in_guaranteed_owned_in_args : $@convention(method) (@in CC2, @
 
 // CHECK: bb0{{.*}}:
 // A new temporary should have been created for each alloc_stack argument passed to partial_apply
+// CHECK: alloc_stack
 // CHECK: [[TMP:%[0-9]+]] = alloc_stack $CC4
 // CHECK: [[CLOSURE:%[0-9]+]] = function_ref @closure_with_in_guaranteed_owned_in_args
 // Copy the original value of the argument into a temporary

--- a/test/SILOptimizer/sil_combine_alloc_stack.swift
+++ b/test/SILOptimizer/sil_combine_alloc_stack.swift
@@ -1,0 +1,43 @@
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift -O %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+protocol E {
+  func f() -> Bool
+}
+
+final class K {
+  deinit {
+    print("deinit")
+  }
+}
+
+
+struct X : E {
+  var x: K
+  func f() -> Bool { return true }
+}
+
+func g<T>(_ x : T) -> Bool {
+  if let y = x as? E { return y.f() }
+  return false
+}
+
+// CHECK that there is no use-after-free in this function.
+@inline(never)
+func foo(_ x: X) -> Bool {
+  return g(x)
+}
+
+@inline(never)
+func testit() {
+  let x = X(x: K())
+  _ = foo(x)
+  print(x)
+}
+
+// CHECK: X(x: a.K)
+// CHECK: deinit
+testit()
+
+


### PR DESCRIPTION
This is a cherry-pick from https://github.com/apple/swift/pull/29882

**Explanation**: This fixes a miscompile in the SILCombine optimization. When trying to remove a "dead" alloc_stack, the optimization didn't take into account that release-instructions could be moved over copy-instructions. This makes the alloc_stack the only instance which keeps an object alive. Removing the alloc_stack resulted in a release of an object, followed by a retain: exactly in the wrong order. The compiled code crashed.
**Scope**: It's difficult to scope. The bug is in the compiler since a very long time. The fact that we didn't see it earlier indicates that this miscompile is unlikely to actually happen. On the other hand it can really be almost any kind of swift source code which can trigger this bug.
**Risk**: Low. It's basically an additional bail-out condition for the optimization.
**Issue**: rdar://problem/59496027
**Testing**: I added a regression test.
**Reviewer**: @aschwaighofer 