### PR TITLE
[android][test] Mark sil_combine_alloc_stack as executable.

### DIFF
--- a/test/SILOptimizer/sil_combine_alloc_stack.swift
+++ b/test/SILOptimizer/sil_combine_alloc_stack.swift
@@ -2,6 +2,8 @@
 // RUN: %target-build-swift -O %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
+// REQUIRES: executable_test
+
 protocol E {
   func f() -> Bool
 }


### PR DESCRIPTION
The Android CI machines cannot execute the test in the target devices. Marking the test as executable makes the test filtering know that this test needs to be executed in the target device.

Seen first in https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android/5385/ and https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/3685/.