### PR TITLE
[SILGen] Reabstract and Materialize Arguments To Property Wrapper Setters If Needed

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1477,9 +1477,15 @@ namespace {
         ManagedValue setterFn = SGF.emitManagedRValueWithCleanup(setterPAI);
 
         // Create the assign_by_wrapper with the allocator and setter.
+        // FIXME: This should use CallEmission instead of doing everything manually.
         assert(value.isRValue());
         ManagedValue Mval = std::move(value).asKnownRValue(SGF).
                               getAsSingleValue(SGF, loc);
+        if (setterConv.getSILArgumentConvention(0).isIndirectConvention() &&
+            !Mval.getType().isAddress()) {
+          Mval = Mval.materialize(SGF, loc);
+        }
+
         SGF.B.createAssignByWrapper(loc, Mval.forward(SGF), proj.forward(SGF),
                                      initFn.getValue(), setterFn.getValue(),
                                      AssignOwnershipQualifier::Unknown);

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1398,15 +1398,21 @@ namespace {
         VarDecl *field = cast<VarDecl>(Storage);
         VarDecl *backingVar = field->getPropertyWrapperBackingProperty();
         assert(backingVar);
-        CanType ValType =
-            SGF.F.mapTypeIntoContext(backingVar->getInterfaceType())
-              ->getCanonicalType();
+        auto FieldType = field->getValueInterfaceType();
+        auto ValType = backingVar->getValueInterfaceType();
+        if (!Substitutions.empty()) {
+          FieldType = FieldType.subst(Substitutions);
+          ValType = ValType.subst(Substitutions);
+        }
+
         // TODO: revist minimal
         SILType varStorageType = SGF.SGM.Types.getSubstitutedStorageType(
-            TypeExpansionContext::minimal(), backingVar, ValType);
+            TypeExpansionContext::minimal(), backingVar,
+            ValType->getCanonicalType());
         auto typeData =
             getLogicalStorageTypeData(SGF.getTypeExpansionContext(), SGF.SGM,
-                                      getTypeData().AccessKind, ValType);
+                                      getTypeData().AccessKind,
+                                      ValType->getCanonicalType());
 
         // Get the address of the storage property.
         ManagedValue proj;
@@ -1426,24 +1432,9 @@ namespace {
             field, SILDeclRef::Kind::PropertyWrapperBackingInitializer);
         SILValue initFRef = SGF.emitGlobalFunctionRef(loc, initConstant);
 
-        SubstitutionMap initSubs;
-        if (auto genericSig = field->getInnermostDeclContext()
-                ->getGenericSignatureOfContext()) {
-          initSubs = SubstitutionMap::get(
-              genericSig,
-              [&](SubstitutableType *type) {
-                if (auto gp = type->getAs<GenericTypeParamType>()) {
-                  return SGF.F.mapTypeIntoContext(gp);
-                }
-
-                return Type(type);
-              },
-              LookUpConformanceInModule(SGF.SGM.M.getSwiftModule()));
-        }
-
         PartialApplyInst *initPAI =
           SGF.B.createPartialApply(loc, initFRef,
-                                   initSubs, ArrayRef<SILValue>(),
+                                   Substitutions, ArrayRef<SILValue>(),
                                    ParameterConvention::Direct_Guaranteed);
         ManagedValue initFn = SGF.emitManagedRValueWithCleanup(initPAI);
 
@@ -1481,6 +1472,25 @@ namespace {
         assert(value.isRValue());
         ManagedValue Mval = std::move(value).asKnownRValue(SGF).
                               getAsSingleValue(SGF, loc);
+        auto substSetterTy = setterTy->substGenericArgs(SGF.SGM.M, Substitutions,
+                                                        SGF.getTypeExpansionContext());
+        auto param = substSetterTy->getParameters()[0];
+        SILType loweredSubstArgType = Mval.getType();
+        if (param.isIndirectInOut()) {
+          loweredSubstArgType =
+            SILType::getPrimitiveAddressType(loweredSubstArgType.getASTType());
+        }
+        auto loweredSubstParamTy = SILType::getPrimitiveType(
+                    param.getArgumentType(SGF.SGM.M, substSetterTy),
+                    loweredSubstArgType.getCategory());
+        // Handle reabstraction differences.
+        if (Mval.getType() != loweredSubstParamTy) {
+          Mval = SGF.emitSubstToOrigValue(loc, Mval,
+                                          SGF.SGM.Types.getAbstractionPattern(field),
+                                          FieldType->getCanonicalType());
+        }
+
+        // If we need the argument in memory, materialize an address.
         if (setterConv.getSILArgumentConvention(0).isIndirectConvention() &&
             !Mval.getType().isAddress()) {
           Mval = Mval.materialize(SGF, loc);
@@ -2151,7 +2161,7 @@ namespace {
       return SGF.emitSubstToOrigValue(loc, std::move(rv), getOrigFormalType(),
                                       getSubstFormalType(), c);
     }
-    
+
     std::unique_ptr<LogicalPathComponent>
     clone(SILGenFunction &SGF, SILLocation loc) const override {
       LogicalPathComponent *clone

--- a/test/SILGen/resilient_assign_by_wrapper.swift
+++ b/test/SILGen/resilient_assign_by_wrapper.swift
@@ -34,3 +34,57 @@ public class AddressOnlySetter {
     self.value = .some
   }
 }
+
+public struct SubstitutedSetter<T> {
+  @WrapGod var value: T
+}
+
+extension SubstitutedSetter where T == Bool {
+  mutating func testAssignment() {
+    // CHECK-LABEL: sil hidden [ossa] @$s27resilient_assign_by_wrapper17SubstitutedSetterVAASbRszlE14testAssignmentyyF
+    // CHECK: [[W:%.*]] = struct_element_addr {{%.*}} : $*SubstitutedSetter<Bool>, #SubstitutedSetter._value
+    // CHECK: [[B:%.*]] = alloc_stack $Bool
+    // CHECK: assign_by_wrapper [[B]] : $*Bool to [[W]] : $*WrapGod<Bool>
+    // CHECK-SAME: init {{%.*}} : $@callee_guaranteed (@in Bool) -> @out WrapGod<Bool>
+    // CHECK-SAME: set {{%.*}} : $@callee_guaranteed (@in Bool) -> ()
+    self.value = true
+  }
+}
+
+public struct ReabstractedSetter<T> {
+  @WrapGod var value: (T) -> ()
+}
+
+extension ReabstractedSetter where T == Int {
+  mutating func testAssignment() {
+    // CHECK-LABEL: sil hidden [ossa] @$s27resilient_assign_by_wrapper18ReabstractedSetterVAASiRszlE14testAssignmentyyF
+    // CHECK: [[F:%.*]] = function_ref @$s27resilient_assign_by_wrapper18ReabstractedSetterVAASiRszlE14testAssignmentyyFySicfU_ : $@convention(thin) (Int) -> ()
+    // CHECK: [[TH_F:%.*]] = thin_to_thick_function [[F]] : $@convention(thin) (Int) -> () to $@callee_guaranteed (Int) -> ()
+    // CHECK: [[THUNK_REF:%.*]] = function_ref @$sSiIegy_SiIegn_TR : $@convention(thin) (@in_guaranteed Int, @guaranteed @callee_guaranteed (Int) -> ()) -> ()
+    // CHECK: [[CF:%.*]] = partial_apply [callee_guaranteed] [[THUNK_REF]]([[TH_F]]) : $@convention(thin) (@in_guaranteed Int, @guaranteed @callee_guaranteed (Int) -> ()) -> ()
+    // CHECK: assign_by_wrapper [[CF]] : $@callee_guaranteed (@in_guaranteed Int) -> ()
+    // CHECK-SAME: to {{%.*}} : $*WrapGod<(Int) -> ()>
+    // CHECK-SAME: init {{%.*}} : $@callee_guaranteed (@owned @callee_guaranteed (@in_guaranteed Int) -> ()) -> @out WrapGod<(Int) -> ()>
+    // CHECK-SAME: set {{%.*}} : $@callee_guaranteed (@owned @callee_guaranteed (@in_guaranteed Int) -> ()) -> ()
+    self.value = { x in }
+  }
+}
+
+public struct ObjectifiedSetter<T: AnyObject> {
+  @WrapGod var value: T
+}
+
+public class SomeObject {}
+
+extension ObjectifiedSetter where T == SomeObject {
+  mutating func testAssignment() {
+    // CHECK-LABEL: sil hidden [ossa] @$s27resilient_assign_by_wrapper17ObjectifiedSetterVA2A10SomeObjectCRszrlE14testAssignmentyyF : $@convention(method) (@inout ObjectifiedSetter<SomeObject>) -> () {
+    // CHECK: [[OBJ:%.*]] = apply {{%.*}}({{%.*}}) : $@convention(method) (@thick SomeObject.Type) -> @owned SomeObject
+    // CHECK: [[STORAGE:%.*]] = struct_element_addr {{%.*}} : $*ObjectifiedSetter<SomeObject>, #ObjectifiedSetter._value
+    // CHECK: assign_by_wrapper [[OBJ]] : $SomeObject to [[STORAGE]] : $*WrapGod<SomeObject>
+    // CHECK-SAME: init {{%.*}} : $@callee_guaranteed (@owned SomeObject) -> @out WrapGod<SomeObject>
+    // CHECK-SAME: set {{%.*}} : $@callee_guaranteed (@owned SomeObject) -> ()
+    self.value = SomeObject()
+  }
+}
+

--- a/test/SILGen/resilient_assign_by_wrapper.swift
+++ b/test/SILGen/resilient_assign_by_wrapper.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-emit-silgen %s -emit-verbose-sil -enable-library-evolution | %FileCheck %s
+
+@propertyWrapper
+public struct WrapGod<T> {
+  private var value: T
+
+  public init(wrappedValue: T) {
+    value = wrappedValue
+  }
+
+  public var wrappedValue: T {
+    get { value }
+    set { value = newValue }
+  }
+}
+
+public protocol Existential {}
+
+public enum AddressOnlyEnum {
+  case some
+  case value(Existential?)
+}
+
+public class AddressOnlySetter {
+  @WrapGod var value: AddressOnlyEnum = .value(nil)
+
+  func testAssignment() {
+    // CHECK-LABEL: sil hidden [ossa] @$s27resilient_assign_by_wrapper17AddressOnlySetterC14testAssignmentyyF
+    // CHECK: [[E:%.*]] = alloc_stack $AddressOnlyEnum
+    // CHECK: inject_enum_addr [[E]] : $*AddressOnlyEnum, #AddressOnlyEnum.some!enumelt
+    // CHECK: [[S:%.*]] = partial_apply [callee_guaranteed] {{%.*}}({{%.*}}) : $@convention(method) (@in AddressOnlyEnum, @guaranteed AddressOnlySetter) -> ()
+    // CHECK: assign_by_wrapper [[E]] : $*AddressOnlyEnum
+    // CHECK-SAME: set [[S]] : $@callee_guaranteed (@in AddressOnlyEnum) -> ()
+    self.value = .some
+  }
+}


### PR DESCRIPTION
Codegen for the assign_by_wrapper instruction emits prepared arguments
directly into the initializer or accessor functions. This means it
misses out on the CC matching code that the general apply path uses.

In this particular case, an enum value was constructed within the
resilience boundary, but passed to the setter for a wrapper property
that expected it to be in memory.

Check the calling convention before we emit the assign_by_wrapper
instruction, and materialize an address for indirect CCs as required.

resolves rdar://59071930 and rdar://59553318