### PR TITLE
Use single quotes instead of backticks in diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -447,12 +447,12 @@ ERROR(constexpr_imported_func_not_onone, none, "imported constant evaluable "
 
 ERROR(non_physical_addressof,none,
       "addressof only works with purely physical lvalues; "
-      "use `withUnsafePointer` or `withUnsafeBytes` unless you're implementing "
-      "`withUnsafePointer` or `withUnsafeBytes`", ())
+      "use 'withUnsafePointer' or 'withUnsafeBytes' unless you're implementing "
+      "'withUnsafePointer' or 'withUnsafeBytes'", ())
 ERROR(non_borrowed_indirect_addressof,none,
       "addressof only works with borrowable in-memory rvalues; "
-      "use `withUnsafePointer` or `withUnsafeBytes` unless you're implementing "
-      "`withUnsafePointer` or `withUnsafeBytes`", ())
+      "use 'withUnsafePointer' or 'withUnsafeBytes' unless you're implementing "
+      "'withUnsafePointer' or 'withUnsafeBytes'", ())
 
 REMARK(opt_remark_passed, none, "%0", (StringRef))
 REMARK(opt_remark_missed, none, "%0", (StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4843,10 +4843,10 @@ ERROR(property_wrapper_type_not_usable_from_inline,none,
       "must be '@usableFromInline' or public",
       (bool, bool))
 WARNING(property_wrapper_wrapperValue,none,
-        "property wrapper's `wrapperValue` property should be renamed to "
+        "property wrapper's 'wrapperValue' property should be renamed to "
         "'projectedValue'; use of 'wrapperValue' is deprecated", ())
 WARNING(property_wrapper_init_initialValue,none,
-        "property wrapper's `init(initialValue:)` should be renamed "
+        "property wrapper's 'init(initialValue:)' should be renamed "
         "to 'init(wrappedValue:)'; use of 'init(initialValue:)' is deprecated",
         ())
 ERROR(property_wrapper_projection_value_missing,none,

--- a/test/decl/var/property_wrapper_aliases.swift
+++ b/test/decl/var/property_wrapper_aliases.swift
@@ -16,7 +16,7 @@ struct Wrapper<T> {
 struct OldWrapper<T> {
   var wrappedValue: T
 
-  var wrapperValue: Wrapper<T> { // expected-warning{{property wrapper's `wrapperValue` property should be renamed to 'projectedValue'; use of 'wrapperValue' is deprecated}}{{7-19=projectedValue}}
+  var wrapperValue: Wrapper<T> { // expected-warning{{property wrapper's 'wrapperValue' property should be renamed to 'projectedValue'; use of 'wrapperValue' is deprecated}}{{7-19=projectedValue}}
     return Wrapper(wrappedValue: wrappedValue)
   }
 }
@@ -25,7 +25,7 @@ struct OldWrapper<T> {
 struct OldWrapperWithInit<T> {
   var wrappedValue: T
 
-  init(initialValue: T) { // expected-warning{{property wrapper's `init(initialValue:)` should be renamed to 'init(wrappedValue:)'; use of 'init(initialValue:)' is deprecated}}{{8-8=wrappedValue }}
+  init(initialValue: T) { // expected-warning{{property wrapper's 'init(initialValue:)' should be renamed to 'init(wrappedValue:)'; use of 'init(initialValue:)' is deprecated}}{{8-8=wrappedValue }}
     self.wrappedValue = initialValue
   }
 }
@@ -34,7 +34,7 @@ struct OldWrapperWithInit<T> {
 struct OldWrapperWithInit2<T> {
   var wrappedValue: T
 
-  init(initialValue value: T) { // expected-warning{{property wrapper's `init(initialValue:)` should be renamed to 'init(wrappedValue:)'; use of 'init(initialValue:)' is deprecated}}{{8-20=wrappedValue}}
+  init(initialValue value: T) { // expected-warning{{property wrapper's 'init(initialValue:)' should be renamed to 'init(wrappedValue:)'; use of 'init(initialValue:)' is deprecated}}{{8-20=wrappedValue}}
     self.wrappedValue = value
   }
 }


### PR DESCRIPTION
Looking through the diagnostics, I noticed found some inconsistencies where `` ` ``s were used in diagnostics. This changes those diagnostics to use single quotes to match the rest of the diagnostics.