### PR TITLE
Sema: Remove a couple of calls to clearLookupCache()

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -257,12 +257,6 @@ public:
 
   bool isImportedImplementationOnly(const ModuleDecl *module) const;
 
-  /// This is a hack for 'main' file parsing and the integrated REPL.
-  ///
-  /// FIXME: Refactor main file parsing to not pump the parser incrementally.
-  /// FIXME: Remove the integrated REPL.
-  void clearLookupCache();
-
   void cacheVisibleDecls(SmallVectorImpl<ValueDecl *> &&globals) const;
   const SmallVectorImpl<ValueDecl *> &getCachedVisibleDecls() const;
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1597,17 +1597,6 @@ void ModuleDecl::clearLookupCache() {
   Cache.reset();
 }
 
-void SourceFile::clearLookupCache() {
-  getParentModule()->clearLookupCache();
-
-  if (!Cache)
-    return;
-
-  // Abandon any current cache. We'll rebuild it on demand.
-  Cache->invalidate();
-  Cache.reset();
-}
-
 void
 SourceFile::cacheVisibleDecls(SmallVectorImpl<ValueDecl*> &&globals) const {
   SmallVectorImpl<ValueDecl*> &cached = getCache().AllVisibleValues;

--- a/lib/Sema/NameBinding.cpp
+++ b/lib/Sema/NameBinding.cpp
@@ -407,10 +407,6 @@ void swift::performNameBinding(SourceFile &SF) {
     return;
   }
 
-  // Reset the name lookup cache so we find new decls.
-  // FIXME: This is inefficient.
-  SF.clearLookupCache();
-
   NameBinder Binder(SF);
 
   SmallVector<SourceFile::ImportedModuleDesc, 8> ImportedModules;

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -496,6 +496,4 @@ void TypeChecker::processREPLTopLevel(SourceFile &SF) {
 
     TypeChecker::contextualizeTopLevelCode(TLCD);
   }
-
-  SF.clearLookupCache();
 }


### PR DESCRIPTION
Tests seem to pass without these.

Two calls still remain, in ModuleDecl::addFiles() and removeFiles().
It will take a bit more refactoring to eliminate those.
