### PR TITLE
Sema: Prefer an outer type named 'Self' over the SE-0068 behavior

### DIFF
--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -287,3 +287,15 @@ class Boxer {
 
   required init() {}
 }
+
+// https://bugs.swift.org/browse/SR-12133 - a type named 'Self' should be found first
+struct OuterType {
+  struct `Self` {
+    let string: String
+  }
+
+  var foo: `Self`? {
+    let optional: String? = "foo"
+    return optional.map { `Self`(string: $0) }
+  }
+}


### PR DESCRIPTION
This fixes a recent source break. We need to perform the normal
unqualified lookup before we handle the special case of 'Self',
because there might be a type named Self defined in an outer
context.

Fixes <https://bugs.swift.org/browse/SR-12133> / <rdar://problem/59216636>