### PR TITLE
Sema: Prefer an outer type named 'Self' over the SE-0068 behavior [5.2]

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1358,7 +1358,7 @@ resolveTopLevelIdentTypeComponent(TypeResolution resolution,
   // If we found nothing, complain and give ourselves a chance to recover.
   if (current.isNull()) {
     // Dynamic 'Self' in the result type of a function body.
-    if (id.isSimpleName(ctx.Id_Self)) {
+    if (id == ctx.Id_Self) {
       if (auto *typeDC = DC->getInnermostTypeContext()) {
         // FIXME: The passed-in TypeRepr should get 'typechecked' as well.
         // The issue is though that ComponentIdentTypeRepr only accepts a ValueDecl

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1299,27 +1299,6 @@ resolveTopLevelIdentTypeComponent(TypeResolution resolution,
   auto DC = resolution.getDeclContext();
   auto id = comp->getIdentifier();
 
-  // Dynamic 'Self' in the result type of a function body.
-  if (id == ctx.Id_Self) {
-    if (auto *typeDC = DC->getInnermostTypeContext()) {
-      // FIXME: The passed-in TypeRepr should get 'typechecked' as well.
-      // The issue is though that ComponentIdentTypeRepr only accepts a ValueDecl
-      // while the 'Self' type is more than just a reference to a TypeDecl.
-      auto selfType = resolution.mapTypeIntoContext(
-        typeDC->getSelfInterfaceType());
-
-      // Check if we can reference Self here, and if so, what kind of Self it is.
-      switch (getSelfTypeKind(DC, options)) {
-      case SelfTypeKind::StaticSelf:
-        return selfType;
-      case SelfTypeKind::DynamicSelf:
-        return DynamicSelfType::get(selfType, ctx);
-      case SelfTypeKind::InvalidSelf:
-        break;
-      }
-    }
-  }
-
   NameLookupOptions lookupOptions = defaultUnqualifiedLookupOptions;
   if (options.contains(TypeResolutionFlags::KnownNonCascadingDependency))
     lookupOptions |= NameLookupFlags::KnownPrivate;
@@ -1378,6 +1357,27 @@ resolveTopLevelIdentTypeComponent(TypeResolution resolution,
 
   // If we found nothing, complain and give ourselves a chance to recover.
   if (current.isNull()) {
+    // Dynamic 'Self' in the result type of a function body.
+    if (id.isSimpleName(ctx.Id_Self)) {
+      if (auto *typeDC = DC->getInnermostTypeContext()) {
+        // FIXME: The passed-in TypeRepr should get 'typechecked' as well.
+        // The issue is though that ComponentIdentTypeRepr only accepts a ValueDecl
+        // while the 'Self' type is more than just a reference to a TypeDecl.
+        auto selfType = resolution.mapTypeIntoContext(
+          typeDC->getSelfInterfaceType());
+
+        // Check if we can reference Self here, and if so, what kind of Self it is.
+        switch (getSelfTypeKind(DC, options)) {
+        case SelfTypeKind::StaticSelf:
+          return selfType;
+        case SelfTypeKind::DynamicSelf:
+          return DynamicSelfType::get(selfType, ctx);
+        case SelfTypeKind::InvalidSelf:
+          break;
+        }
+      }
+    }
+
     // If we're not allowed to complain or we couldn't fix the
     // source, bail out.
     if (options.contains(TypeResolutionFlags::SilenceErrors))

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -287,3 +287,15 @@ class Boxer {
 
   required init() {}
 }
+
+// https://bugs.swift.org/browse/SR-12133 - a type named 'Self' should be found first
+struct OuterType {
+  struct `Self` {
+    let string: String
+  }
+
+  var foo: `Self`? {
+    let optional: String? = "foo"
+    return optional.map { `Self`(string: $0) }
+  }
+}


### PR DESCRIPTION
This fixes a recent source break. We need to perform the normal
unqualified lookup before we handle the special case of 'Self',
because there might be a type named Self defined in an outer
context.

Fixes <https://bugs.swift.org/browse/SR-12133> / <rdar://problem/59216636>