### PR TITLE
Enable better runtime failure messages

### DIFF
--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -33,7 +33,7 @@ using namespace swift;
 using namespace irgen;
 
 static llvm::cl::opt<bool> EnableTrapDebugInfo(
-    "enable-trap-debug-info", llvm::cl::Hidden,
+    "enable-trap-debug-info", llvm::cl::init(true), llvm::cl::Hidden,
     llvm::cl::desc("Generate failure-message functions in the debug info"));
 
 IRGenFunction::IRGenFunction(IRGenModule &IGM, llvm::Function *Fn,

--- a/test/DebugInfo/linetable-codeview.swift
+++ b/test/DebugInfo/linetable-codeview.swift
@@ -1,4 +1,4 @@
-// RUN: %swiftc_driver %s -g -debug-info-format=codeview -Xllvm -enable-trap-debug-info -emit-ir -o - | %FileCheck %s
+// RUN: %swiftc_driver %s -g -debug-info-format=codeview -emit-ir -o - | %FileCheck %s
 // REQUIRES: optimized_stdlib
 
 func markUsed<T>(_ t: T) {}

--- a/test/IRGen/condfail_message.swift
+++ b/test/IRGen/condfail_message.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -primary-file %s -g -Xllvm -enable-trap-debug-info -emit-ir | %FileCheck %s
-// RUN: %target-swift-frontend -primary-file %s -g -Xllvm -enable-trap-debug-info -O -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -g -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -g -O -emit-ir | %FileCheck %s
 // REQUIRES: optimized_stdlib
 
 // CHECK-LABEL: define hidden swiftcc i8 @"$s16condfail_message6testitys4Int8VADF"(i8 %0)


### PR DESCRIPTION
The implementation was done quite a while ago.
Now, that we have support in lldb (https://github.com/apple/llvm-project/pull/773), we can enable it by default in the compiler.

LLDB now shows the runtime failure reason, for example:

```
* thread #1, queue = 'com.apple.main-thread', stop reason = Swift runtime failure: arithmetic overflow
    frame #1: 0x0000000100000f0d a.out`testit(a=127) at trap_message.swift:4
   1   	
   2   	@inline(never)
   3   	func testit(_ a: Int8) -> Int8 {
-> 4   	  return a + 1
   5   	}
   6   	
```

For details, see https://github.com/apple/swift/pull/25978

rdar://problem/51278690