### PR TITLE
[Stdlib] Fix an overrelease in -[__SwiftNativeNSError description].

### DIFF
--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -102,8 +102,14 @@ using namespace swift::hashable_support;
 
 - (id /* NSString */)description {
   auto error = (const SwiftError *)self;
-  return getDescription(const_cast<OpaqueValue *>(error->getValue()),
-                        error->type);
+  auto value = error->getValue();
+
+  // Copy the value, since it will be consumed by getDescription.
+  ValueBuffer copyBuf;
+  auto copy = error->type->allocateBufferIn(&copyBuf);
+  error->type->vw_initializeWithCopy(copy, const_cast<OpaqueValue *>(value));
+
+  return getDescription(copy, error->type);
 }
 
 - (NSInteger)code {

--- a/test/stdlib/ErrorBridged.swift
+++ b/test/stdlib/ErrorBridged.swift
@@ -854,4 +854,35 @@ ErrorBridgingTests.test("Swift Error bridged to NSError description") {
   }
 }
 
+struct SwiftError2: Error, CustomStringConvertible {
+  var description: String
+}
+
+ErrorBridgingTests.test("Swift Error description memory management") {
+  func checkDescription() {
+    // Generate a non-small, non-constant NSString bridged to String.
+    let str = (["""
+      There once was a gigantic genie
+      Who turned out to be a real meanie
+      I wished for flight
+      And with all his might
+      He gave me a propellor beanie
+    """] as NSArray).description
+    let error = SwiftError2(description: str)
+    let bridgedError = error as NSError
+
+    // Ensure that the bridged NSError description method doesn't overrelease
+    // the error value.
+    for _ in 0 ..< 10 {
+      autoreleasepool {
+        expectEqual(str, bridgedError.description)
+      }
+    }
+  }
+
+  if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
+    checkDescription()
+  }
+}
+
 runAllTests()


### PR DESCRIPTION
`getDescription` takes its argument at +1, but the implementation was passing the value directly. This caused the contained error value to be destroyed.

rdar://problem/59512630