### PR TITLE
IRGen: Fix reflection metadata for zero-sized enum cases [5.2]

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -678,7 +678,7 @@ private:
   const NominalTypeDecl *NTD;
 
   void addFieldDecl(const ValueDecl *value, Type type,
-                    GenericSignature genericSig, bool indirect=false) {
+                    bool indirect=false) {
     reflection::FieldRecordFlags flags;
     flags.setIsIndirectCase(indirect);
     if (auto var = dyn_cast<VarDecl>(value))
@@ -689,6 +689,8 @@ private:
     if (!type) {
       B.addInt32(0);
     } else {
+      auto genericSig = NTD->getGenericSignature();
+
       // The standard library's Mirror demangles metadata from field
       // descriptors, so use MangledTypeRefRole::Metadata to ensure
       // runtime metadata is available.
@@ -722,8 +724,7 @@ private:
     auto properties = NTD->getStoredProperties();
     B.addInt32(properties.size());
     for (auto property : properties)
-      addFieldDecl(property, property->getInterfaceType(),
-                   NTD->getGenericSignature());
+      addFieldDecl(property, property->getInterfaceType());
   }
 
   void layoutEnum() {
@@ -748,12 +749,11 @@ private:
       bool indirect = (enumCase.decl->isIndirect() ||
                        enumDecl->isIndirect());
       addFieldDecl(enumCase.decl, enumCase.decl->getArgumentInterfaceType(),
-                   enumDecl->getGenericSignature(),
                    indirect);
     }
 
     for (auto enumCase : strategy.getElementsWithNoPayload()) {
-      addFieldDecl(enumCase.decl, CanType(), nullptr);
+      addFieldDecl(enumCase.decl, enumCase.decl->getArgumentInterfaceType());
     }
   }
 

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -1041,7 +1041,11 @@
 // CHECK-64-NEXT:   (field name=noPayload offset=0
 // CHECK-64-NEXT:     (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=252 bitwise_takable=1))
 // CHECK-64-NEXT:   (field name=sillyNoPayload offset=1
-// CHECK-64-NEXT:     (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=252 bitwise_takable=1))
+// CHECK-64-NEXT:    (multi_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=252 bitwise_takable=1
+// CHECK-64-NEXT:      (field name=A offset=0
+// CHECK-64-NEXT:        (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK-64-NEXT:      (field name=B offset=0
+// CHECK-64-NEXT:        (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=singleton offset=8
 // CHECK-64-NEXT:     (reference kind=strong refcounting=native))
 // CHECK-64-NEXT:   (field name=singlePayload offset=16

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -1039,9 +1039,9 @@
 // CHECK-64-NEXT:   (field name=empty offset=0
 // CHECK-64-NEXT:     (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-64-NEXT:   (field name=noPayload offset=0
-// CHECK-64-NEXT:     (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK-64-NEXT:     (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=252 bitwise_takable=1))
 // CHECK-64-NEXT:   (field name=sillyNoPayload offset=1
-// CHECK-64-NEXT:     (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK-64-NEXT:     (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=252 bitwise_takable=1))
 // CHECK-64-NEXT:   (field name=singleton offset=8
 // CHECK-64-NEXT:     (reference kind=strong refcounting=native))
 // CHECK-64-NEXT:   (field name=singlePayload offset=16

--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -917,6 +917,28 @@ mirrors.test("Enum/SingletonNonGeneric/DefaultMirror") {
   }
 }
 
+enum ZeroSizedEnumWithDefaultMirror {
+  case π
+}
+
+enum SingletonZeroSizedEnumWithDefaultMirror {
+  case wrap(ZeroSizedEnumWithDefaultMirror)
+}
+
+mirrors.test("Enum/SingletonZeroSizedEnumWithDefaultMirror/DefaultMirror") {
+  do {
+    let value = SingletonZeroSizedEnumWithDefaultMirror.wrap(.π)
+    var output = ""
+    dump(value, to: &output)
+
+    let expected =
+      "▿ Mirror.SingletonZeroSizedEnumWithDefaultMirror.wrap\n" +
+      "  - wrap: Mirror.ZeroSizedEnumWithDefaultMirror.π\n"
+
+    expectEqual(expected, output)
+  }
+}
+
 enum SingletonGenericEnumWithDefaultMirror<T> {
   case OnlyOne(T)
 }
@@ -1994,7 +2016,8 @@ if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
     testSTSDump(STSContainer.Cases<Int>.a(.init()),
                 STSContainer℠.Cases<Int>.a(.init()),
                 """
-      - Mirror.STSContainer<Mirror.STSOuter>.Cases<Swift.Int>.a\n
+      ▿ Mirror.STSContainer<Mirror.STSOuter>.Cases<Swift.Int>.a
+        - a: Mirror.STSOuter\n
       """)
 
     testSTSDump(STSContainer.Cases<Int>.b(.init()),

--- a/validation-test/Reflection/reflect_Enum_254CaseNoPayloads.swift
+++ b/validation-test/Reflection/reflect_Enum_254CaseNoPayloads.swift
@@ -1,0 +1,364 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -g -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_254CaseNoPayloads
+// RUN: %target-codesign %t/reflect_Enum_254CaseNoPayloads
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_254CaseNoPayloads | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+
+import SwiftReflectionTest
+
+struct Marker {
+	let value = 1
+	let extra = 2
+}
+
+enum E254CaseNoPayloadsEnum {
+case option0
+case option1
+case option2
+case option3
+case option4
+case option5
+case option6
+case option7
+case option8
+case option9
+case option10
+case option11
+case option12
+case option13
+case option14
+case option15
+case option16
+case option17
+case option18
+case option19
+case option20
+case option21
+case option22
+case option23
+case option24
+case option25
+case option26
+case option27
+case option28
+case option29
+case option30
+case option31
+case option32
+case option33
+case option34
+case option35
+case option36
+case option37
+case option38
+case option39
+case option40
+case option41
+case option42
+case option43
+case option44
+case option45
+case option46
+case option47
+case option48
+case option49
+case option50
+case option51
+case option52
+case option53
+case option54
+case option55
+case option56
+case option57
+case option58
+case option59
+case option60
+case option61
+case option62
+case option63
+case option64
+case option65
+case option66
+case option67
+case option68
+case option69
+case option70
+case option71
+case option72
+case option73
+case option74
+case option75
+case option76
+case option77
+case option78
+case option79
+case option80
+case option81
+case option82
+case option83
+case option84
+case option85
+case option86
+case option87
+case option88
+case option89
+case option90
+case option91
+case option92
+case option93
+case option94
+case option95
+case option96
+case option97
+case option98
+case option99
+case option100
+case option101
+case option102
+case option103
+case option104
+case option105
+case option106
+case option107
+case option108
+case option109
+case option110
+case option111
+case option112
+case option113
+case option114
+case option115
+case option116
+case option117
+case option118
+case option119
+case option120
+case option121
+case option122
+case option123
+case option124
+case option125
+case option126
+case option127
+case option128
+case option129
+case option130
+case option131
+case option132
+case option133
+case option134
+case option135
+case option136
+case option137
+case option138
+case option139
+case option140
+case option141
+case option142
+case option143
+case option144
+case option145
+case option146
+case option147
+case option148
+case option149
+case option150
+case option151
+case option152
+case option153
+case option154
+case option155
+case option156
+case option157
+case option158
+case option159
+case option160
+case option161
+case option162
+case option163
+case option164
+case option165
+case option166
+case option167
+case option168
+case option169
+case option170
+case option171
+case option172
+case option173
+case option174
+case option175
+case option176
+case option177
+case option178
+case option179
+case option180
+case option181
+case option182
+case option183
+case option184
+case option185
+case option186
+case option187
+case option188
+case option189
+case option190
+case option191
+case option192
+case option193
+case option194
+case option195
+case option196
+case option197
+case option198
+case option199
+case option200
+case option201
+case option202
+case option203
+case option204
+case option205
+case option206
+case option207
+case option208
+case option209
+case option210
+case option211
+case option212
+case option213
+case option214
+case option215
+case option216
+case option217
+case option218
+case option219
+case option220
+case option221
+case option222
+case option223
+case option224
+case option225
+case option226
+case option227
+case option228
+case option229
+case option230
+case option231
+case option232
+case option233
+case option234
+case option235
+case option236
+case option237
+case option238
+case option239
+case option240
+case option241
+case option242
+case option243
+case option244
+case option245
+case option246
+case option247
+case option248
+case option249
+case option250
+case option251
+case option252
+case option253
+}
+
+class ClassWith254CaseEnum {
+	var e1: E254CaseNoPayloadsEnum = .option0
+	var e2: E254CaseNoPayloadsEnum?
+	var e3: E254CaseNoPayloadsEnum??
+	var e4: E254CaseNoPayloadsEnum???
+	var e5: E254CaseNoPayloadsEnum????
+}
+
+reflect(object: ClassWith254CaseEnum())
+
+// CHECK-64: Reflecting an object.
+// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-64: Type reference:
+// CHECK-64: (class reflect_Enum_254CaseNoPayloads.ClassWith254CaseEnum)
+
+// CHECK-64: Type info:
+// CHECK-64: (class_instance size=24 alignment=1 stride=24 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:   (field name=e1 offset=16
+// CHECK-64:     (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=2 bitwise_takable=1))
+// CHECK-64:   (field name=e2 offset=17
+// CHECK-64:     (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=1 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=2 bitwise_takable=1))))
+// CHECK-64:   (field name=e3 offset=18
+// CHECK-64:     (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=1 bitwise_takable=1
+// CHECK-64:           (field name=some offset=0
+// CHECK-64:             (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=2 bitwise_takable=1))))))
+// CHECK-64:   (field name=e4 offset=19
+// CHECK-64:     (single_payload_enum size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:           (field name=some offset=0
+// CHECK-64:             (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=1 bitwise_takable=1
+// CHECK-64:               (field name=some offset=0
+// CHECK-64:                 (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=2 bitwise_takable=1))))))))
+// CHECK-64:   (field name=e5 offset=21
+// CHECK-64:     (single_payload_enum size=3 alignment=1 stride=3 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (single_payload_enum size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:           (field name=some offset=0
+// CHECK-64:             (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (field name=some offset=0
+// CHECK-64:                 (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=1 bitwise_takable=1
+// CHECK-64:                   (field name=some offset=0
+// CHECK-64:                     (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=2 bitwise_takable=1)))))))))))
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-32: Type reference:
+// CHECK-32: (class reflect_Enum_254CaseNoPayloads.ClassWith254CaseEnum)
+
+// CHECK-32: Type info:
+// CHECK-32: (class_instance size=16 alignment=1 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:   (field name=e1 offset=8
+// CHECK-32:     (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=2 bitwise_takable=1))
+// CHECK-32:   (field name=e2 offset=9
+// CHECK-32:     (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=1 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=2 bitwise_takable=1))))
+// CHECK-32:   (field name=e3 offset=10
+// CHECK-32:     (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=1 bitwise_takable=1
+// CHECK-32:           (field name=some offset=0
+// CHECK-32:             (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=2 bitwise_takable=1))))))
+// CHECK-32:   (field name=e4 offset=11
+// CHECK-32:     (single_payload_enum size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (field name=some offset=0
+// CHECK-32:             (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=1 bitwise_takable=1
+// CHECK-32:               (field name=some offset=0
+// CHECK-32:                 (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=2 bitwise_takable=1))))))))
+// CHECK-32:   (field name=e5 offset=13
+// CHECK-32:     (single_payload_enum size=3 alignment=1 stride=3 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (single_payload_enum size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (field name=some offset=0
+// CHECK-32:             (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (field name=some offset=0
+// CHECK-32:                 (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=1 bitwise_takable=1
+// CHECK-32:                   (field name=some offset=0
+// CHECK-32:                     (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=2 bitwise_takable=1)))))))))))
+
+doneReflecting()
+
+// CHECK-64: Done.
+
+// CHECK-32: Done.

--- a/validation-test/Reflection/reflect_Enum_NoCase.swift
+++ b/validation-test/Reflection/reflect_Enum_NoCase.swift
@@ -1,0 +1,125 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -g -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_NoCase
+// RUN: %target-codesign %t/reflect_Enum_NoCase
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_NoCase | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+
+import SwiftReflectionTest
+
+enum NoCaseEnum {
+}
+
+class ClassWithNoCaseEnum {
+  var e1: NoCaseEnum?
+  var e2: NoCaseEnum??
+  var e3: NoCaseEnum???
+  var e4: NoCaseEnum????
+  var e5: NoCaseEnum?????
+}
+
+reflect(object: ClassWithNoCaseEnum())
+
+// CHECK-64: Reflecting an object.
+// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-64: Type reference:
+// CHECK-64: (class reflect_Enum_NoCase.ClassWithNoCaseEnum)
+
+// CHECK-64: Type info:
+// CHECK-64: (class_instance size=31 alignment=1 stride=31 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:   (field name=e1 offset=16
+// CHECK-64:     (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-64:   (field name=e2 offset=17
+// CHECK-64:     (single_payload_enum size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:           (field name=some offset=0
+// CHECK-64:             (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-64:   (field name=e3 offset=19
+// CHECK-64:     (single_payload_enum size=3 alignment=1 stride=3 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (single_payload_enum size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:           (field name=some offset=0
+// CHECK-64:             (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (field name=some offset=0
+// CHECK-64:                 (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))))
+// CHECK-64:   (field name=e4 offset=22
+// CHECK-64:     (single_payload_enum size=4 alignment=1 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (single_payload_enum size=3 alignment=1 stride=3 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:           (field name=some offset=0
+// CHECK-64:             (single_payload_enum size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (field name=some offset=0
+// CHECK-64:                 (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:                   (field name=some offset=0
+// CHECK-64:                     (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))))))
+// CHECK-64:   (field name=e5 offset=26
+// CHECK-64:     (single_payload_enum size=5 alignment=1 stride=5 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (single_payload_enum size=4 alignment=1 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:           (field name=some offset=0
+// CHECK-64:             (single_payload_enum size=3 alignment=1 stride=3 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (field name=some offset=0
+// CHECK-64:                 (single_payload_enum size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:                   (field name=some offset=0
+// CHECK-64:                     (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:                       (field name=some offset=0
+// CHECK-64:                         (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))))))))))))
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-32: Type reference:
+// CHECK-32: (class reflect_Enum_NoCase.ClassWithNoCaseEnum)
+
+// CHECK-32: Type info:
+// CHECK-32: (class_instance size=23 alignment=1 stride=23 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:   (field name=e1 offset=8
+// CHECK-32:     (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-32:   (field name=e2 offset=9
+// CHECK-32:     (single_payload_enum size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (field name=some offset=0
+// CHECK-32:             (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-32:   (field name=e3 offset=11
+// CHECK-32:     (single_payload_enum size=3 alignment=1 stride=3 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (single_payload_enum size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (field name=some offset=0
+// CHECK-32:             (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (field name=some offset=0
+// CHECK-32:                 (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))))
+// CHECK-32:   (field name=e4 offset=14
+// CHECK-32:     (single_payload_enum size=4 alignment=1 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (single_payload_enum size=3 alignment=1 stride=3 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (field name=some offset=0
+// CHECK-32:             (single_payload_enum size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (field name=some offset=0
+// CHECK-32:                 (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:                   (field name=some offset=0
+// CHECK-32:                     (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))))))
+// CHECK-32:   (field name=e5 offset=18
+// CHECK-32:     (single_payload_enum size=5 alignment=1 stride=5 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (single_payload_enum size=4 alignment=1 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (field name=some offset=0
+// CHECK-32:             (single_payload_enum size=3 alignment=1 stride=3 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (field name=some offset=0
+// CHECK-32:                 (single_payload_enum size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:                   (field name=some offset=0
+// CHECK-32:                     (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:                       (field name=some offset=0
+// CHECK-32:                         (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))))))))))))
+
+doneReflecting()
+
+// CHECK-64: Done.
+
+// CHECK-32: Done.

--- a/validation-test/Reflection/reflect_Enum_SingleCaseNoPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_SingleCaseNoPayload.swift
@@ -1,0 +1,93 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -g -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_SingleCaseNoPayload
+// RUN: %target-codesign %t/reflect_Enum_SingleCaseNoPayload
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_SingleCaseNoPayload | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+
+import SwiftReflectionTest
+
+struct Marker {
+	let value = 1
+}
+
+enum SingleCaseNoPayloadEnum {
+case `default`
+}
+
+class ClassWithSingleCaseNoPayloadEnum {
+  var e1: SingleCaseNoPayloadEnum?
+  var e2: SingleCaseNoPayloadEnum = .`default`
+  var e3: SingleCaseNoPayloadEnum? = .`default`
+  var e4: SingleCaseNoPayloadEnum??
+  let marker = Marker()
+	
+}
+
+reflect(object: ClassWithSingleCaseNoPayloadEnum())
+
+// CHECK-64: Reflecting an object.
+// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-64: Type reference:
+// CHECK-64: (class reflect_Enum_SingleCaseNoPayload.ClassWithSingleCaseNoPayloadEnum)
+
+// CHECK-64: Type info:
+// CHECK-64: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:   (field name=e1 offset=16
+// CHECK-64:     (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-64:   (field name=e2 offset=17
+// CHECK-64:     (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK-64:   (field name=e3 offset=17
+// CHECK-64:     (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-64:   (field name=e4 offset=18
+// CHECK-64:     (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-64:   (field name=marker offset=24
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (field name=value offset=0
+// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:           (field name=_value offset=0
+// CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))))
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-32: Type reference:
+// CHECK-32: (class reflect_Enum_SingleCaseNoPayload.ClassWithSingleCaseNoPayloadEnum)
+
+// CHECK-32: Type info:
+// CHECK-32: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:   (field name=e1 offset=8
+// CHECK-32:     (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-32:   (field name=e2 offset=9
+// CHECK-32:     (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK-32:   (field name=e3 offset=9
+// CHECK-32:     (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-32:   (field name=e4 offset=10
+// CHECK-32:     (single_payload_enum size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (field name=some offset=0
+// CHECK-32:             (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-32:   (field name=marker offset=12
+// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:       (field name=value offset=0
+// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (field name=_value offset=0
+// CHECK-32:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))))
+
+doneReflecting()
+
+// CHECK-64: Done.
+
+// CHECK-32: Done.

--- a/validation-test/Reflection/reflect_Enum_SingleCasePointerPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_SingleCasePointerPayload.swift
@@ -1,0 +1,81 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -g -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_SingleCasePointerPayload
+// RUN: %target-codesign %t/reflect_Enum_SingleCasePointerPayload
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_SingleCasePointerPayload | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+
+import SwiftReflectionTest
+
+class Marker {
+	let value = 1
+}
+
+enum SingleCasePointerPayloadEnum {
+case only(Marker)
+}
+
+class ClassWithSingleCasePointerPayloadEnum {
+  var e1: SingleCasePointerPayloadEnum?
+  var e2: SingleCasePointerPayloadEnum = .only(Marker())
+  var e3: SingleCasePointerPayloadEnum? = .some(.only(Marker()))
+  var e4: SingleCasePointerPayloadEnum??
+}
+
+reflect(object: ClassWithSingleCasePointerPayloadEnum())
+
+// CHECK-64: Reflecting an object.
+// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-64: Type reference:
+// CHECK-64: (class reflect_Enum_SingleCasePointerPayload.ClassWithSingleCasePointerPayloadEnum)
+
+// CHECK-64: Type info:
+// CHECK-64: (class_instance size=48 alignment=8 stride=48 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:   (field name=e1 offset=16
+// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (reference kind=strong refcounting=native))))
+// CHECK-64:   (field name=e2 offset=24
+// CHECK-64:     (reference kind=strong refcounting=native))
+// CHECK-64:   (field name=e3 offset=32
+// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (reference kind=strong refcounting=native))))
+// CHECK-64:   (field name=e4 offset=40
+// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483645 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64:           (field name=some offset=0
+// CHECK-64:             (reference kind=strong refcounting=native)))))))
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-32: Type reference:
+// CHECK-32: (class reflect_Enum_SingleCasePointerPayload.ClassWithSingleCasePointerPayloadEnum)
+
+// CHECK-32: Type info:
+// CHECK-32: (class_instance size=24 alignment=4 stride=24 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:   (field name=e1 offset=8
+// CHECK-32:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (reference kind=strong refcounting=native))))
+// CHECK-32:   (field name=e2 offset=12
+// CHECK-32:     (reference kind=strong refcounting=native))
+// CHECK-32:   (field name=e3 offset=16
+// CHECK-32:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (reference kind=strong refcounting=native))))
+// CHECK-32:   (field name=e4 offset=20
+// CHECK-32:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4094 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
+// CHECK-32:           (field name=some offset=0
+// CHECK-32:             (reference kind=strong refcounting=native)))))))
+
+doneReflecting()
+
+// CHECK-64: Done.
+
+// CHECK-32: Done.

--- a/validation-test/Reflection/reflect_Enum_TwoCaseNoPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_TwoCaseNoPayload.swift
@@ -1,0 +1,97 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -g -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_TwoCaseNoPayload
+// RUN: %target-codesign %t/reflect_Enum_TwoCaseNoPayload
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_TwoCaseNoPayload | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+
+import SwiftReflectionTest
+
+struct Marker {
+	let value = 1
+}
+
+enum TwoCaseNoPayloadEnum {
+case preferred
+case other
+}
+
+class ClassWithTwoCaseNoPayloadEnum {
+  var e1: TwoCaseNoPayloadEnum?
+  var e2: TwoCaseNoPayloadEnum = .preferred
+  var e3: TwoCaseNoPayloadEnum = .other
+  var e4: TwoCaseNoPayloadEnum? = .preferred
+  var e5: TwoCaseNoPayloadEnum? = .other
+  let marker = Marker()
+
+}
+
+reflect(object: ClassWithTwoCaseNoPayloadEnum())
+
+// CHECK-64: Reflecting an object.
+// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-64: Type reference:
+// CHECK-64: (class reflect_Enum_TwoCaseNoPayload.ClassWithTwoCaseNoPayloadEnum)
+
+// CHECK-64: Type info:
+// CHECK-64: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:   (field name=e1 offset=16
+// CHECK-64:     (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=253 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1))))
+// CHECK-64:   (field name=e2 offset=17
+// CHECK-64:     (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1))
+// CHECK-64:   (field name=e3 offset=18
+// CHECK-64:     (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1))
+// CHECK-64:   (field name=e4 offset=19
+// CHECK-64:     (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=253 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1))))
+// CHECK-64:   (field name=e5 offset=20
+// CHECK-64:     (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=253 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1))))
+// CHECK-64:   (field name=marker offset=24
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (field name=value offset=0
+// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:           (field name=_value offset=0
+// CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))))
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-32: Type reference:
+// CHECK-32: (class reflect_Enum_TwoCaseNoPayload.ClassWithTwoCaseNoPayloadEnum)
+
+// CHECK-32: Type info:
+// CHECK-32: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:   (field name=e1 offset=8
+// CHECK-32:     (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=253 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1))))
+// CHECK-32:   (field name=e2 offset=9
+// CHECK-32:     (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1))
+// CHECK-32:   (field name=e3 offset=10
+// CHECK-32:     (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1))
+// CHECK-32:   (field name=e4 offset=11
+// CHECK-32:     (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=253 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1))))
+// CHECK-32:   (field name=e5 offset=12
+// CHECK-32:     (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=253 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1))))
+// CHECK-32:   (field name=marker offset=16
+// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:       (field name=value offset=0
+// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (field name=_value offset=0
+// CHECK-32:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))))
+
+doneReflecting()
+
+// CHECK-64: Done.
+
+// CHECK-32: Done.

--- a/validation-test/Reflection/reflect_Enum_TwoCaseOnePayload.swift
+++ b/validation-test/Reflection/reflect_Enum_TwoCaseOnePayload.swift
@@ -1,0 +1,168 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -g -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_TwoCaseOnePayload
+// RUN: %target-codesign %t/reflect_Enum_TwoCaseOnePayload
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_TwoCaseOnePayload | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+
+import SwiftReflectionTest
+
+struct Marker {
+	let value = 1
+}
+
+enum TwoCaseOnePayloadEnum {
+case valid(Marker)
+case invalid
+}
+
+class ClassWithTwoCaseOnePayloadEnum {
+  var e1: TwoCaseOnePayloadEnum?
+  var e2: TwoCaseOnePayloadEnum = .valid(Marker())
+  var e3: TwoCaseOnePayloadEnum = .invalid
+  var e4: TwoCaseOnePayloadEnum? = .valid(Marker())
+  var e5: TwoCaseOnePayloadEnum? = .invalid
+	var e6: TwoCaseOnePayloadEnum??
+}
+
+reflect(object: ClassWithTwoCaseOnePayloadEnum())
+
+// CHECK-64: Reflecting an object.
+// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-64: Type reference:
+// CHECK-64: (class reflect_Enum_TwoCaseOnePayload.ClassWithTwoCaseOnePayloadEnum)
+
+// CHECK-64: Type info:
+// CHECK-64: (class_instance size=107 alignment=8 stride=112 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:   (field name=e1 offset=16
+// CHECK-64:     (single_payload_enum size=10 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:           (field name=valid offset=0
+// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (field name=value offset=0
+// CHECK-64:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:                   (field name=_value offset=0
+// CHECK-64:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))))))
+// CHECK-64:   (field name=e2 offset=32
+// CHECK-64:     (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (field name=valid offset=0
+// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:           (field name=value offset=0
+// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (field name=_value offset=0
+// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))))
+// CHECK-64:   (field name=e3 offset=48
+// CHECK-64:     (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (field name=valid offset=0
+// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:           (field name=value offset=0
+// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (field name=_value offset=0
+// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))))
+// CHECK-64:   (field name=e4 offset=64
+// CHECK-64:     (single_payload_enum size=10 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:           (field name=valid offset=0
+// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (field name=value offset=0
+// CHECK-64:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:                   (field name=_value offset=0
+// CHECK-64:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))))))
+// CHECK-64:   (field name=e5 offset=80
+// CHECK-64:     (single_payload_enum size=10 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:           (field name=valid offset=0
+// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (field name=value offset=0
+// CHECK-64:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:                   (field name=_value offset=0
+// CHECK-64:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))))))
+// CHECK-64:   (field name=e6 offset=96
+// CHECK-64:     (single_payload_enum size=11 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (single_payload_enum size=10 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:           (field name=some offset=0
+// CHECK-64:             (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (field name=valid offset=0
+// CHECK-64:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:                   (field name=value offset=0
+// CHECK-64:                     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:                       (field name=_value offset=0
+// CHECK-64:                         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))))))))))
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-32: Type reference:
+// CHECK-32: (class reflect_Enum_TwoCaseOnePayload.ClassWithTwoCaseOnePayloadEnum)
+
+// CHECK-32: Type info:
+// CHECK-32: (class_instance size=55 alignment=4 stride=56 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:   (field name=e1 offset=8
+// CHECK-32:     (single_payload_enum size=6 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (single_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (field name=valid offset=0
+// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (field name=value offset=0
+// CHECK-32:                 (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:                   (field name=_value offset=0
+// CHECK-32:                     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))))))
+// CHECK-32:   (field name=e2 offset=16
+// CHECK-32:     (single_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:       (field name=valid offset=0
+// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (field name=value offset=0
+// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (field name=_value offset=0
+// CHECK-32:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))))
+// CHECK-32:   (field name=e3 offset=24
+// CHECK-32:     (single_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:       (field name=valid offset=0
+// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (field name=value offset=0
+// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (field name=_value offset=0
+// CHECK-32:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))))
+// CHECK-32:   (field name=e4 offset=32
+// CHECK-32:     (single_payload_enum size=6 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (single_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (field name=valid offset=0
+// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (field name=value offset=0
+// CHECK-32:                 (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:                   (field name=_value offset=0
+// CHECK-32:                     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))))))
+// CHECK-32:   (field name=e5 offset=40
+// CHECK-32:     (single_payload_enum size=6 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (single_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (field name=valid offset=0
+// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (field name=value offset=0
+// CHECK-32:                 (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:                   (field name=_value offset=0
+// CHECK-32:                     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))))))
+// CHECK-32:   (field name=e6 offset=48
+// CHECK-32:     (single_payload_enum size=7 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (single_payload_enum size=6 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (field name=some offset=0
+// CHECK-32:             (single_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (field name=valid offset=0
+// CHECK-32:                 (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:                   (field name=value offset=0
+// CHECK-32:                     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:                       (field name=_value offset=0
+// CHECK-32:                         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))))))))))
+
+doneReflecting()
+
+// CHECK-64: Done.
+
+// CHECK-32: Done.

--- a/validation-test/Reflection/reflect_Enum_TwoCaseTwoPayloads.swift
+++ b/validation-test/Reflection/reflect_Enum_TwoCaseTwoPayloads.swift
@@ -1,0 +1,265 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -g -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_TwoCaseTwoPayloads
+// RUN: %target-codesign %t/reflect_Enum_TwoCaseTwoPayloads
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_TwoCaseTwoPayloads | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+
+import SwiftReflectionTest
+
+struct Marker {
+	let value = 1
+	let extra = 2
+}
+
+enum TwoCaseTwoPayloadsEnum {
+case valid(Marker)
+case invalid(Int)
+}
+
+class ClassWithTwoCaseTwoPayloadsEnum {
+  var e1: TwoCaseTwoPayloadsEnum?
+  var e2: TwoCaseTwoPayloadsEnum = .valid(Marker())
+  var e3: TwoCaseTwoPayloadsEnum = .invalid(7)
+  var e4: TwoCaseTwoPayloadsEnum? = .valid(Marker())
+  var e5: TwoCaseTwoPayloadsEnum? = .invalid(7)
+	var e6: TwoCaseTwoPayloadsEnum??
+}
+
+reflect(object: ClassWithTwoCaseTwoPayloadsEnum())
+
+// CHECK-64: Reflecting an object.
+// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-64: Type reference:
+// CHECK-64: (class reflect_Enum_TwoCaseTwoPayloads.ClassWithTwoCaseTwoPayloadsEnum)
+
+// CHECK-64: Type info:
+// CHECK-64: (class_instance size=153 alignment=8 stride=160 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:   (field name=e1 offset=16
+// CHECK-64:     (single_payload_enum size=17 alignment=8 stride=24 num_extra_inhabitants=253 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (multi_payload_enum size=17 alignment=8 stride=24 num_extra_inhabitants=254 bitwise_takable=1
+// CHECK-64:           (field name=valid offset=0
+// CHECK-64:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (field name=value offset=0
+// CHECK-64:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:                   (field name=_value offset=0
+// CHECK-64:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-64:               (field name=extra offset=8
+// CHECK-64:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:                   (field name=_value offset=0
+// CHECK-64:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-64:           (field name=invalid offset=0
+// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (field name=_value offset=0
+// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))))
+// CHECK-64:   (field name=e2 offset=40
+// CHECK-64:     (multi_payload_enum size=17 alignment=8 stride=24 num_extra_inhabitants=254 bitwise_takable=1
+// CHECK-64:       (field name=valid offset=0
+// CHECK-64:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:           (field name=value offset=0
+// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (field name=_value offset=0
+// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-64:           (field name=extra offset=8
+// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (field name=_value offset=0
+// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-64:       (field name=invalid offset=0
+// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:           (field name=_value offset=0
+// CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-64:   (field name=e3 offset=64
+// CHECK-64:     (multi_payload_enum size=17 alignment=8 stride=24 num_extra_inhabitants=254 bitwise_takable=1
+// CHECK-64:       (field name=valid offset=0
+// CHECK-64:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:           (field name=value offset=0
+// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (field name=_value offset=0
+// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-64:           (field name=extra offset=8
+// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (field name=_value offset=0
+// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-64:       (field name=invalid offset=0
+// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:           (field name=_value offset=0
+// CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-64:   (field name=e4 offset=88
+// CHECK-64:     (single_payload_enum size=17 alignment=8 stride=24 num_extra_inhabitants=253 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (multi_payload_enum size=17 alignment=8 stride=24 num_extra_inhabitants=254 bitwise_takable=1
+// CHECK-64:           (field name=valid offset=0
+// CHECK-64:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (field name=value offset=0
+// CHECK-64:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:                   (field name=_value offset=0
+// CHECK-64:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-64:               (field name=extra offset=8
+// CHECK-64:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:                   (field name=_value offset=0
+// CHECK-64:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-64:           (field name=invalid offset=0
+// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (field name=_value offset=0
+// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))))
+// CHECK-64:   (field name=e5 offset=112
+// CHECK-64:     (single_payload_enum size=17 alignment=8 stride=24 num_extra_inhabitants=253 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (multi_payload_enum size=17 alignment=8 stride=24 num_extra_inhabitants=254 bitwise_takable=1
+// CHECK-64:           (field name=valid offset=0
+// CHECK-64:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (field name=value offset=0
+// CHECK-64:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:                   (field name=_value offset=0
+// CHECK-64:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-64:               (field name=extra offset=8
+// CHECK-64:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:                   (field name=_value offset=0
+// CHECK-64:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-64:           (field name=invalid offset=0
+// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (field name=_value offset=0
+// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))))
+// CHECK-64:   (field name=e6 offset=136
+// CHECK-64:     (single_payload_enum size=17 alignment=8 stride=24 num_extra_inhabitants=252 bitwise_takable=1
+// CHECK-64:       (field name=some offset=0
+// CHECK-64:         (single_payload_enum size=17 alignment=8 stride=24 num_extra_inhabitants=253 bitwise_takable=1
+// CHECK-64:           (field name=some offset=0
+// CHECK-64:             (multi_payload_enum size=17 alignment=8 stride=24 num_extra_inhabitants=254 bitwise_takable=1
+// CHECK-64:               (field name=valid offset=0
+// CHECK-64:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:                   (field name=value offset=0
+// CHECK-64:                     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:                       (field name=_value offset=0
+// CHECK-64:                         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-64:                   (field name=extra offset=8
+// CHECK-64:                     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:                       (field name=_value offset=0
+// CHECK-64:                         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-64:               (field name=invalid offset=0
+// CHECK-64:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:                   (field name=_value offset=0
+// CHECK-64:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))))))))
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-32: Type reference:
+// CHECK-32: (class reflect_Enum_TwoCaseTwoPayloads.ClassWithTwoCaseTwoPayloadsEnum)
+
+// CHECK-32: Type info:
+// CHECK-32: (class_instance size=77 alignment=4 stride=80 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:   (field name=e1 offset=8
+// CHECK-32:     (single_payload_enum size=9 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (multi_payload_enum size=9 alignment=4 stride=12 num_extra_inhabitants=254 bitwise_takable=1
+// CHECK-32:           (field name=valid offset=0
+// CHECK-32:             (struct size=8 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (field name=value offset=0
+// CHECK-32:                 (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:                   (field name=_value offset=0
+// CHECK-32:                     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-32:               (field name=extra offset=4
+// CHECK-32:                 (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:                   (field name=_value offset=0
+// CHECK-32:                     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-32:           (field name=invalid offset=0
+// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (field name=_value offset=0
+// CHECK-32:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))))
+// CHECK-32:   (field name=e2 offset=20
+// CHECK-32:     (multi_payload_enum size=9 alignment=4 stride=12 num_extra_inhabitants=254 bitwise_takable=1
+// CHECK-32:       (field name=valid offset=0
+// CHECK-32:         (struct size=8 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (field name=value offset=0
+// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (field name=_value offset=0
+// CHECK-32:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-32:           (field name=extra offset=4
+// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (field name=_value offset=0
+// CHECK-32:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-32:       (field name=invalid offset=0
+// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (field name=_value offset=0
+// CHECK-32:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-32:   (field name=e3 offset=32
+// CHECK-32:     (multi_payload_enum size=9 alignment=4 stride=12 num_extra_inhabitants=254 bitwise_takable=1
+// CHECK-32:       (field name=valid offset=0
+// CHECK-32:         (struct size=8 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (field name=value offset=0
+// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (field name=_value offset=0
+// CHECK-32:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-32:           (field name=extra offset=4
+// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (field name=_value offset=0
+// CHECK-32:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-32:       (field name=invalid offset=0
+// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (field name=_value offset=0
+// CHECK-32:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-32:   (field name=e4 offset=44
+// CHECK-32:     (single_payload_enum size=9 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (multi_payload_enum size=9 alignment=4 stride=12 num_extra_inhabitants=254 bitwise_takable=1
+// CHECK-32:           (field name=valid offset=0
+// CHECK-32:             (struct size=8 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (field name=value offset=0
+// CHECK-32:                 (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:                   (field name=_value offset=0
+// CHECK-32:                     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-32:               (field name=extra offset=4
+// CHECK-32:                 (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:                   (field name=_value offset=0
+// CHECK-32:                     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-32:           (field name=invalid offset=0
+// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (field name=_value offset=0
+// CHECK-32:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))))
+// CHECK-32:   (field name=e5 offset=56
+// CHECK-32:     (single_payload_enum size=9 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (multi_payload_enum size=9 alignment=4 stride=12 num_extra_inhabitants=254 bitwise_takable=1
+// CHECK-32:           (field name=valid offset=0
+// CHECK-32:             (struct size=8 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (field name=value offset=0
+// CHECK-32:                 (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:                   (field name=_value offset=0
+// CHECK-32:                     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-32:               (field name=extra offset=4
+// CHECK-32:                 (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:                   (field name=_value offset=0
+// CHECK-32:                     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-32:           (field name=invalid offset=0
+// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (field name=_value offset=0
+// CHECK-32:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))))
+// CHECK-32:   (field name=e6 offset=68
+// CHECK-32:     (single_payload_enum size=9 alignment=4 stride=12 num_extra_inhabitants=252 bitwise_takable=1
+// CHECK-32:       (field name=some offset=0
+// CHECK-32:         (single_payload_enum size=9 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=1
+// CHECK-32:           (field name=some offset=0
+// CHECK-32:             (multi_payload_enum size=9 alignment=4 stride=12 num_extra_inhabitants=254 bitwise_takable=1
+// CHECK-32:               (field name=valid offset=0
+// CHECK-32:                 (struct size=8 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:                   (field name=value offset=0
+// CHECK-32:                     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:                       (field name=_value offset=0
+// CHECK-32:                         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-32:                   (field name=extra offset=4
+// CHECK-32:                     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:                       (field name=_value offset=0
+// CHECK-32:                         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-32:               (field name=invalid offset=0
+// CHECK-32:                 (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:                   (field name=_value offset=0
+// CHECK-32:                     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))))))))
+
+doneReflecting()
+
+// CHECK-64: Done.
+
+// CHECK-32: Done.


### PR DESCRIPTION
If an enum has a payload case with zero size, we treat it as an empty case
for ABI purposes. Unfortunately, this meant that reflection metadata was
incomplete for such cases, with a Mirror reporting that the enum value
had zero children.

Tweak the field type metadata emission slightly to preserve the payload
type for such enum cases.

Fixes <https://bugs.swift.org/browse/SR-12044> / <rdar://problem/58861157>.