### PR TITLE
SILOptimizer: improvements for dead alloc_stack elimination

### DIFF
--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -224,15 +224,17 @@ static bool canZapInstruction(SILInstruction *Inst, bool acceptRefCountInsts,
   if (isa<DestroyAddrInst>(Inst))
     return true;
 
-  // The only store instructions which is guaranteed to store a trivial value
-  // is an inject_enum_addr witout a payload (i.e. without init_enum_data_addr).
-  // There can also be a 'store [trivial]', but we don't handle that yet.
-  if (onlyAcceptTrivialStores)
-    return false;
-
   // If we see a store here, we have already checked that we are storing into
   // the pointer before we added it to the worklist, so we can skip it.
-  if (isa<StoreInst>(Inst))
+  if (auto *store = dyn_cast<StoreInst>(Inst)) {
+    // TODO: when we have OSSA, we can also accept stores of non trivial values:
+    //       just replace the store with a destroy_value.
+    return !onlyAcceptTrivialStores ||
+           store->getSrc()->getType().isTrivial(*store->getFunction());
+  }
+
+  // Conceptually this instruction has no side-effects.
+  if (isa<InitExistentialAddrInst>(Inst))
     return true;
 
   // If Inst does not read or write to memory, have side effects, and is not a

--- a/test/SILOptimizer/dead_alloc_elim.sil
+++ b/test/SILOptimizer/dead_alloc_elim.sil
@@ -374,3 +374,23 @@ bb0:
   return %1 : $()
 }
 
+protocol P { }
+struct X : P { }
+
+// CHECK-LABEL: sil @remove_dead_optional_existential
+// CHECK:      bb0(%0 : $X):
+// CHECK-NEXT:   %1 = tuple ()
+// CHECK-NEXT:   return %1
+sil @remove_dead_optional_existential : $@convention(thin) (X) -> () {
+bb0(%0 : $X):
+  %3 = alloc_stack $Optional<P>
+  %4 = init_enum_data_addr %3 : $*Optional<P>, #Optional.some!enumelt.1
+  %5 = init_existential_addr %4 : $*P, $X
+  store %0 to %5 : $*X
+  inject_enum_addr %3 : $*Optional<P>, #Optional.some!enumelt.1
+  destroy_addr %3 : $*Optional<P>
+  dealloc_stack %3 : $*Optional<P>
+  %10 = tuple ()
+  return %10 : $()
+}
+

--- a/test/SILOptimizer/dead_alloc_stack.swift
+++ b/test/SILOptimizer/dead_alloc_stack.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend -O -emit-sil -parse-as-library %s | %FileCheck %s
+
+protocol E {
+  func f() -> Bool
+}
+
+protocol P {
+  associatedtype A = Int
+}
+
+public struct X : P, E {
+  func f() -> Bool { return true }
+}
+
+func g<T : P>(_ x : T) -> Bool {
+  if let y = x as? E { return y.f() }
+  return false
+}
+
+// Check that this function can be completely constant folded and no alloc_stack remains.
+
+// CHECK-LABEL: sil @$s16dead_alloc_stack6testitySbAA1XVF
+// CHECK:      bb0({{.*}}):
+// CHECK-NEXT:   integer_literal
+// CHECK-NEXT:   struct
+// CHECK-NEXT:   return
+// CHECK-NEXT: } // end sil function '$s16dead_alloc_stack6testitySbAA1XVF'
+public func testit(_ x: X) -> Bool {
+  return g(x)
+}
+

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -1634,6 +1634,19 @@ bb0(%0 : $*AddressOnlyEnum):
   return %2 : $Builtin.Int32
 }
 
+// CHECK-LABEL: sil @dead_unchecked_take_enum_data_addr
+// CHECK:      bb0(%0 : $*AddressOnlyEnum):
+// CHECK-NEXT:   destroy_addr %0
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   return
+sil @dead_unchecked_take_enum_data_addr : $@convention(thin) (@in AddressOnlyEnum) -> () {
+bb0(%0 : $*AddressOnlyEnum):
+  %1 = unchecked_take_enum_data_addr %0 : $*AddressOnlyEnum, #AddressOnlyEnum.Loadable!enumelt.1
+  destroy_addr %1 : $*Builtin.Int32
+  %r = tuple ()
+  return %r : $()
+}
+
 sil @partial_apply_arg_fun : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> () {
 bb0(%0 : $Builtin.Int32, %1 : $Builtin.Int32):
   %2 = tuple()

--- a/test/SILOptimizer/sil_combine_enum_addr.sil
+++ b/test/SILOptimizer/sil_combine_enum_addr.sil
@@ -10,7 +10,7 @@ import Swift
 // CHECK: inject_enum_addr
 // CHECK-NOT: select_enum_addr
 // CHECK-NOT: bb1
-// CHECK: unchecked_take_enum_data_addr
+// CHECK-NOT: unchecked_take_enum_data_addr
 // CHECK: return
 sil  @convert_inject_enum_addr_select_enum_addr_into_cond_br : $@convention(thin) (@in Int, @inout _Stdout) -> () {
 bb0(%0 : $*Int, %1 : $*_Stdout):
@@ -46,7 +46,7 @@ bb2:
 // CHECK: inject_enum_addr
 // CHECK-NOT: switch_enum_addr
 // CHECK-NOT: bb1
-// CHECK: unchecked_take_enum_data_addr
+// CHECK-NOT: unchecked_take_enum_data_addr
 // CHECK: return
 sil  @convert_inject_enum_addr_switch_enum_addr_into_cond_br : $@convention(thin) (@in Int, @inout _Stdout) -> () {
 bb0(%0 : $*Int, %1 : $*_Stdout):


### PR DESCRIPTION
This allows to eliminate a dead stack location which contains an existential.

rdar://problem/32272199