### PR TITLE
Fix a couple of problems with opaque result types

### DIFF
--- a/lib/SIL/AbstractionPattern.cpp
+++ b/lib/SIL/AbstractionPattern.cpp
@@ -274,11 +274,16 @@ bool AbstractionPattern::matchesTuple(CanTupleType substType) {
     return getNumTupleElements_Stored() == substType->getNumElements();
   case Kind::ClangType:
   case Kind::Type:
-  case Kind::Discard:
+  case Kind::Discard: {
     if (isTypeParameter())
       return true;
-    auto tuple = dyn_cast<TupleType>(getType());
-    return (tuple && tuple->getNumElements() == substType->getNumElements());
+    auto type = getType();
+    if (auto tuple = dyn_cast<TupleType>(type))
+      return (tuple->getNumElements() == substType->getNumElements());
+    if (isa<OpaqueTypeArchetypeType>(type))
+      return true;
+    return false;
+  }
   }
   llvm_unreachable("bad kind");
 }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1539,7 +1539,7 @@ public:
       sgm.TopLevelSGF = new SILGenFunction(sgm, *toplevel, sf);
       sgm.TopLevelSGF->MagicFunctionName = sgm.SwiftModule->getName();
       auto moduleCleanupLoc = CleanupLocation::getModuleCleanupLocation();
-      sgm.TopLevelSGF->prepareEpilog(Type(), true, moduleCleanupLoc);
+      sgm.TopLevelSGF->prepareEpilog(false, true, moduleCleanupLoc);
 
       // Create the argc and argv arguments.
       auto prologueLoc = RegularLocation::getModuleLocation();

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -281,7 +281,7 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
   // Create a basic block to jump to for the implicit 'self' return.
   // We won't emit this until after we've emitted the body.
   // The epilog takes a void return because the return of 'self' is implicit.
-  prepareEpilog(Type(), ctor->hasThrows(), CleanupLocation(ctor));
+  prepareEpilog(false, ctor->hasThrows(), CleanupLocation(ctor));
 
   // If the constructor can fail, set up an alternative epilog for constructor
   // failure.
@@ -659,7 +659,7 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
 
   // Create a basic block to jump to for the implicit 'self' return.
   // We won't emit the block until after we've emitted the body.
-  prepareEpilog(Type(), ctor->hasThrows(),
+  prepareEpilog(false, ctor->hasThrows(),
                 CleanupLocation::get(endOfInitLoc));
 
   auto resultType = ctor->mapTypeIntoContext(ctor->getResultInterfaceType());
@@ -1000,7 +1000,7 @@ void SILGenFunction::emitIVarInitializer(SILDeclRef ivarInitializer) {
   VarLocs[selfDecl] = VarLoc::get(selfArg);
 
   auto cleanupLoc = CleanupLocation::get(loc);
-  prepareEpilog(TupleType::getEmpty(getASTContext()), false, cleanupLoc);
+  prepareEpilog(false, false, cleanupLoc);
 
   // Emit the initializers.
   emitMemberInitializers(cd, selfDecl, cd);

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -33,7 +33,7 @@ void SILGenFunction::emitDestroyingDestructor(DestructorDecl *dd) {
   // Create a basic block to jump to for the implicit destruction behavior
   // of releasing the elements and calling the superclass destructor.
   // We won't actually emit the block until we finish with the destructor body.
-  prepareEpilog(Type(), false, CleanupLocation::get(Loc));
+  prepareEpilog(false, false, CleanupLocation::get(Loc));
 
   emitProfilerIncrement(dd->getBody());
   // Emit the destructor body.
@@ -166,7 +166,7 @@ void SILGenFunction::emitIVarDestroyer(SILDeclRef ivarDestroyer) {
       emitSelfDecl(cd->getDestructor()->getImplicitSelfDecl()));
 
   auto cleanupLoc = CleanupLocation::get(loc);
-  prepareEpilog(TupleType::getEmpty(getASTContext()), false, cleanupLoc);
+  prepareEpilog(false, false, cleanupLoc);
   {
     Scope S(*this, cleanupLoc);
     emitClassMemberDestruction(selfValue, cd, cleanupLoc);
@@ -210,7 +210,7 @@ void SILGenFunction::emitObjCDestructor(SILDeclRef dtor) {
   // Create a basic block to jump to for the implicit destruction behavior
   // of releasing the elements and calling the superclass destructor.
   // We won't actually emit the block until we finish with the destructor body.
-  prepareEpilog(Type(), false, CleanupLocation::get(loc));
+  prepareEpilog(false, false, CleanupLocation::get(loc));
 
   emitProfilerIncrement(dd->getBody());
   // Emit the destructor body.

--- a/lib/SILGen/SILGenEpilog.cpp
+++ b/lib/SILGen/SILGenEpilog.cpp
@@ -18,13 +18,12 @@
 using namespace swift;
 using namespace Lowering;
 
-void SILGenFunction::prepareEpilog(Type resultType, bool isThrowing,
+void SILGenFunction::prepareEpilog(bool hasDirectResults, bool isThrowing,
                                    CleanupLocation CleanupL) {
   auto *epilogBB = createBasicBlock();
 
   // If we have any direct results, receive them via BB arguments.
-  // But callers can disable this by passing a null result type.
-  if (resultType) {
+  if (hasDirectResults) {
     auto fnConv = F.getConventions();
     // Set NeedsReturn for indirect or direct results. This ensures that SILGen
     // emits unreachable if there is no source level return.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2689,33 +2689,35 @@ static SILFunction *getOrCreateKeyPathGetter(SILGenModule &SGM,
   }
 
   // Build the signature of the thunk as expected by the keypath runtime.
-  CanType loweredBaseTy, loweredPropTy;
-  AbstractionPattern opaque = AbstractionPattern::getOpaque();
+  auto signature = [&]() {
+    CanType loweredBaseTy, loweredPropTy;
+    AbstractionPattern opaque = AbstractionPattern::getOpaque();
 
-  loweredBaseTy = SGM.Types.getLoweredRValueType(
-      TypeExpansionContext::minimal(), opaque, baseType);
-  loweredPropTy = SGM.Types.getLoweredRValueType(
-      TypeExpansionContext::minimal(), opaque, propertyType);
-  
-  auto paramConvention = ParameterConvention::Indirect_In_Guaranteed;
+    loweredBaseTy = SGM.Types.getLoweredRValueType(
+        TypeExpansionContext::minimal(), opaque, baseType);
+    loweredPropTy = SGM.Types.getLoweredRValueType(
+        TypeExpansionContext::minimal(), opaque, propertyType);
+    
+    auto paramConvention = ParameterConvention::Indirect_In_Guaranteed;
 
-  SmallVector<SILParameterInfo, 2> params;
-  params.push_back({loweredBaseTy, paramConvention});
-  auto &C = SGM.getASTContext();
-  if (!indexes.empty())
-    params.push_back({C.getUnsafeRawPointerDecl()->getDeclaredType()
-                                                 ->getCanonicalType(),
-                      ParameterConvention::Direct_Unowned});
-  
-  SILResultInfo result(loweredPropTy, ResultConvention::Indirect);
-  
-  auto signature = SILFunctionType::get(genericSig,
-    SILFunctionType::ExtInfo::getThin(),
-    SILCoroutineKind::None,
-    ParameterConvention::Direct_Unowned,
-    params, {}, result, None,
-    SubstitutionMap(), false,
-    SGM.getASTContext());
+    SmallVector<SILParameterInfo, 2> params;
+    params.push_back({loweredBaseTy, paramConvention});
+    auto &C = SGM.getASTContext();
+    if (!indexes.empty())
+      params.push_back({C.getUnsafeRawPointerDecl()->getDeclaredType()
+                                                   ->getCanonicalType(),
+                        ParameterConvention::Direct_Unowned});
+    
+    SILResultInfo result(loweredPropTy, ResultConvention::Indirect);
+    
+    return SILFunctionType::get(genericSig,
+      SILFunctionType::ExtInfo::getThin(),
+      SILCoroutineKind::None,
+      ParameterConvention::Direct_Unowned,
+      params, {}, result, None,
+      SubstitutionMap(), false,
+      SGM.getASTContext());
+  }();
   
   // Find the function and see if we already created it.
   auto name = Mangle::ASTMangler()
@@ -2741,9 +2743,15 @@ static SILFunction *getOrCreateKeyPathGetter(SILGenModule &SGM,
   }
   
   SILGenFunction subSGF(SGM, *thunk, SGM.SwiftModule);
+
+  signature = subSGF.F.getLoweredFunctionTypeInContext(
+    subSGF.F.getTypeExpansionContext());
+
   auto entry = thunk->begin();
-  auto resultArgTy = result.getSILStorageType(SGM.M, signature);
-  auto baseArgTy = params[0].getSILStorageType(SGM.M, signature);
+  auto resultArgTy = signature->getSingleResult().getSILStorageType(
+      SGM.M, signature);
+  auto baseArgTy = signature->getParameters()[0].getSILStorageType(
+      SGM.M, signature);
   if (genericEnv) {
     resultArgTy = genericEnv->mapTypeIntoContext(SGM.M, resultArgTy);
     baseArgTy = genericEnv->mapTypeIntoContext(SGM.M, baseArgTy);
@@ -2752,7 +2760,8 @@ static SILFunction *getOrCreateKeyPathGetter(SILGenModule &SGM,
   auto baseArg = entry->createFunctionArgument(baseArgTy);
   SILValue indexPtrArg;
   if (!indexes.empty()) {
-    auto indexArgTy = params[1].getSILStorageType(SGM.M, signature);
+    auto indexArgTy = signature->getParameters()[1].getSILStorageType(
+        SGM.M, signature);
     indexPtrArg = entry->createFunctionArgument(indexArgTy);
   }
   
@@ -2821,41 +2830,43 @@ static SILFunction *getOrCreateKeyPathSetter(SILGenModule &SGM,
   }
 
   // Build the signature of the thunk as expected by the keypath runtime.
-  CanType loweredBaseTy, loweredPropTy;
-  {
-    AbstractionPattern opaque = AbstractionPattern::getOpaque();
+  auto signature = [&]() {
+    CanType loweredBaseTy, loweredPropTy;
+    {
+      AbstractionPattern opaque = AbstractionPattern::getOpaque();
 
-    loweredBaseTy = SGM.Types.getLoweredRValueType(
-        TypeExpansionContext::minimal(), opaque, baseType);
-    loweredPropTy = SGM.Types.getLoweredRValueType(
-        TypeExpansionContext::minimal(), opaque, propertyType);
-  }
-  
-  auto &C = SGM.getASTContext();
-  
-  auto paramConvention = ParameterConvention::Indirect_In_Guaranteed;
+      loweredBaseTy = SGM.Types.getLoweredRValueType(
+          TypeExpansionContext::minimal(), opaque, baseType);
+      loweredPropTy = SGM.Types.getLoweredRValueType(
+          TypeExpansionContext::minimal(), opaque, propertyType);
+    }
+    
+    auto &C = SGM.getASTContext();
+    
+    auto paramConvention = ParameterConvention::Indirect_In_Guaranteed;
 
-  SmallVector<SILParameterInfo, 3> params;
-  // property value
-  params.push_back({loweredPropTy, paramConvention});
-  // base
-  params.push_back({loweredBaseTy,
-                    property->isSetterMutating()
-                      ? ParameterConvention::Indirect_Inout
-                      : paramConvention});
-  // indexes
-  if (!indexes.empty())
-    params.push_back({C.getUnsafeRawPointerDecl()->getDeclaredType()
-                                                 ->getCanonicalType(),
-                      ParameterConvention::Direct_Unowned});
-  
-  auto signature = SILFunctionType::get(genericSig,
-    SILFunctionType::ExtInfo::getThin(),
-    SILCoroutineKind::None,
-    ParameterConvention::Direct_Unowned,
-    params, {}, {}, None,
-    SubstitutionMap(), false,
-    SGM.getASTContext());
+    SmallVector<SILParameterInfo, 3> params;
+    // property value
+    params.push_back({loweredPropTy, paramConvention});
+    // base
+    params.push_back({loweredBaseTy,
+                      property->isSetterMutating()
+                        ? ParameterConvention::Indirect_Inout
+                        : paramConvention});
+    // indexes
+    if (!indexes.empty())
+      params.push_back({C.getUnsafeRawPointerDecl()->getDeclaredType()
+                                                   ->getCanonicalType(),
+                        ParameterConvention::Direct_Unowned});
+    
+    return SILFunctionType::get(genericSig,
+      SILFunctionType::ExtInfo::getThin(),
+      SILCoroutineKind::None,
+      ParameterConvention::Direct_Unowned,
+      params, {}, {}, None,
+      SubstitutionMap(), false,
+      SGM.getASTContext());
+  }();
   
   // Mangle the name of the thunk to see if we already created it.
   auto name = Mangle::ASTMangler()
@@ -2882,9 +2893,15 @@ static SILFunction *getOrCreateKeyPathSetter(SILGenModule &SGM,
   }
   
   SILGenFunction subSGF(SGM, *thunk, SGM.SwiftModule);
+
+  signature = subSGF.F.getLoweredFunctionTypeInContext(
+    subSGF.F.getTypeExpansionContext());
+
   auto entry = thunk->begin();
-  auto valueArgTy = params[0].getSILStorageType(SGM.M, signature);
-  auto baseArgTy = params[1].getSILStorageType(SGM.M, signature);
+  auto valueArgTy = signature->getParameters()[0].getSILStorageType(
+      SGM.M, signature);
+  auto baseArgTy = signature->getParameters()[1].getSILStorageType(
+      SGM.M, signature);
   if (genericEnv) {
     valueArgTy = genericEnv->mapTypeIntoContext(SGM.M, valueArgTy);
     baseArgTy = genericEnv->mapTypeIntoContext(SGM.M, baseArgTy);
@@ -2894,7 +2911,8 @@ static SILFunction *getOrCreateKeyPathSetter(SILGenModule &SGM,
   SILValue indexPtrArg;
   
   if (!indexes.empty()) {
-    auto indexArgTy = params[2].getSILStorageType(SGM.M, signature);
+    auto indexArgTy = signature->getParameters()[2].getSILStorageType(
+        SGM.M, signature);
     indexPtrArg = entry->createFunctionArgument(indexArgTy);
   }
 

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -487,8 +487,7 @@ void SILGenFunction::emitFunction(FuncDecl *fd) {
   auto captureInfo = SGM.M.Types.getLoweredLocalCaptures(SILDeclRef(fd));
   emitProlog(captureInfo, fd->getParameters(), fd->getImplicitSelfDecl(), fd,
              fd->getResultInterfaceType(), fd->hasThrows(), fd->getThrowsLoc());
-  Type resultTy = fd->mapTypeIntoContext(fd->getResultInterfaceType());
-  prepareEpilog(resultTy, fd->hasThrows(), CleanupLocation(fd));
+  prepareEpilog(true, fd->hasThrows(), CleanupLocation(fd));
 
   emitProfilerIncrement(fd->getBody());
   emitStmt(fd->getBody());
@@ -506,8 +505,7 @@ void SILGenFunction::emitClosure(AbstractClosureExpr *ace) {
     SILDeclRef(ace));
   emitProlog(captureInfo, ace->getParameters(), /*selfParam=*/nullptr,
              ace, resultIfaceTy, ace->isBodyThrowing(), ace->getLoc());
-  prepareEpilog(ace->getResultType(), ace->isBodyThrowing(),
-                CleanupLocation(ace));
+  prepareEpilog(true, ace->isBodyThrowing(), CleanupLocation(ace));
   emitProfilerIncrement(ace);
   if (auto *ce = dyn_cast<ClosureExpr>(ace)) {
     emitStmt(ce->getBody());
@@ -743,7 +741,7 @@ void SILGenFunction::emitGeneratorFunction(SILDeclRef function, Expr *value,
              dc, interfaceType, /*throws=*/false, SourceLoc());
   if (EmitProfilerIncrement)
     emitProfilerIncrement(value);
-  prepareEpilog(value->getType(), false, CleanupLocation::get(Loc));
+  prepareEpilog(true, false, CleanupLocation::get(Loc));
 
   {
     llvm::Optional<SILGenFunction::OpaqueValueRAII> opaqueValue;
@@ -776,7 +774,6 @@ void SILGenFunction::emitGeneratorFunction(SILDeclRef function, VarDecl *var) {
   auto decl = function.getAbstractFunctionDecl();
   auto *dc = decl->getInnermostDeclContext();
   auto interfaceType = var->getValueInterfaceType();
-  auto varType = var->getType();
 
   // If this is the backing storage for a property with an attached
   // wrapper that was initialized with '=', the stored property initializer
@@ -784,13 +781,12 @@ void SILGenFunction::emitGeneratorFunction(SILDeclRef function, VarDecl *var) {
   if (auto originalProperty = var->getOriginalWrappedProperty()) {
     if (originalProperty->isPropertyMemberwiseInitializedWithWrappedType()) {
       interfaceType = originalProperty->getValueInterfaceType();
-      varType = originalProperty->getType();
     }
   }
 
   emitProlog(/*paramList*/ nullptr, /*selfParam*/ nullptr, interfaceType, dc,
              /*throws=*/false, SourceLoc());
-  prepareEpilog(varType, false, CleanupLocation::get(loc));
+  prepareEpilog(true, false, CleanupLocation::get(loc));
 
   auto pbd = var->getParentPatternBinding();
   const auto i = pbd->getPatternEntryIndexForVarDecl(var);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -831,13 +831,12 @@ public:
   /// Create (but do not emit) the epilog branch, and save the
   /// current cleanups depth as the destination for return statement branches.
   ///
-  /// \param returnType  If non-null, the epilog block will be created with an
-  ///                    argument of this type to receive the return value for
-  ///                    the function.
+  /// \param hasDirectResults  If true, the epilog block will be created with
+  ///                    arguments for each direct result of this function.
   /// \param isThrowing  If true, create an error epilog block.
   /// \param L           The SILLocation which should be associated with
   ///                    cleanup instructions.
-  void prepareEpilog(Type returnType, bool isThrowing, CleanupLocation L);
+  void prepareEpilog(bool hasDirectResults, bool isThrowing, CleanupLocation L);
   void prepareRethrowEpilog(CleanupLocation l);
   void prepareCoroutineUnwindEpilog(CleanupLocation l);
   

--- a/test/SILGen/opaque_result_type.swift
+++ b/test/SILGen/opaque_result_type.swift
@@ -165,3 +165,11 @@ public class D {
         return d
     }()
 }
+
+// CHECK-LABEL: sil [ossa] @$s18opaque_result_type10tupleAsAnyQryF : $@convention(thin) () -> @out @_opaqueReturnTypeOf("$s18opaque_result_type10tupleAsAnyQryF", 0) 🦸 {
+public func tupleAsAny() -> some Any {
+// CHECK-NEXT: bb0(%0 : $*()):
+// CHECK-NEXT:   %1 = tuple ()
+// CHECK-NEXT:   return %1 : $()
+  return ()
+}

--- a/test/SILGen/opaque_result_type_class_property.swift
+++ b/test/SILGen/opaque_result_type_class_property.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-emit-silgen %s -enable-library-evolution -disable-availability-checking | %FileCheck %s
+
+public protocol V {}
+public struct E : V {}
+
+public class HasProperty {
+  public var foo: some V = E()
+}
+
+// CHECK-LABEL: sil shared [thunk] [ossa] @$s33opaque_result_type_class_property11HasPropertyC3fooQrvpACTK : $@convention(thin) (@in_guaranteed HasProperty) -> @out @_opaqueReturnTypeOf("$s33opaque_result_type_class_property11HasPropertyC3fooQrvp", 0) 🦸 {
+// CHECK: bb0(%0 : $*E, %1 : $*HasProperty):
+
+// CHECK-LABEL: sil shared [thunk] [ossa] @$s33opaque_result_type_class_property11HasPropertyC3fooQrvpACTk : $@convention(thin) (@in_guaranteed @_opaqueReturnTypeOf("$s33opaque_result_type_class_property11HasPropertyC3fooQrvp", 0) 🦸, @in_guaranteed HasProperty) -> () {
+// CHECK: bb0(%0 : $*E, %1 : $*HasProperty):


### PR DESCRIPTION
While investigating rdar://problem/59107421 I found two problems in SILGen:

- Crash when a function with an opaque return type returns a tuple.
- Crash when emitting a keypath getter or setter thunk for a class property with an opaque result type.