### PR TITLE
[AutoDiff] Improve `@derivative` attribute diagnostics.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2972,18 +2972,18 @@ NOTE(protocol_witness_missing_differentiable_attr,none,
 // @derivative
 ERROR(derivative_attr_expected_result_tuple,none,
       "'@derivative(of:)' attribute requires function to return a two-element "
-      "tuple of type '(value: T..., pullback: (U.TangentVector) -> T.TangentVector...)' "
-      "or '(value: T..., differential: (T.TangentVector...) -> U.TangentVector)'", ())
+      "tuple; first element must have label 'value:' and second element must "
+      "have label 'pullback:' or 'differential:'", ())
 ERROR(derivative_attr_invalid_result_tuple_value_label,none,
       "'@derivative(of:)' attribute requires function to return a two-element "
-      "tuple (first element must have label 'value:')", ())
+      "tuple; first element must have label 'value:'", ())
 ERROR(derivative_attr_invalid_result_tuple_func_label,none,
       "'@derivative(of:)' attribute requires function to return a two-element "
-      "tuple (second element must have label 'pullback:' or 'differential:')",
+      "tuple; second element must have label 'pullback:' or 'differential:'",
       ())
 ERROR(derivative_attr_result_value_not_differentiable,none,
       "'@derivative(of:)' attribute requires function to return a two-element "
-      "tuple (first element type %0 must conform to 'Differentiable')", (Type))
+      "tuple; first element type %0 must conform to 'Differentiable'", (Type))
 ERROR(derivative_attr_result_func_type_mismatch,none,
       "function result's %0 type does not match %1", (Identifier, DeclName))
 NOTE(derivative_attr_result_func_type_mismatch_note,none,

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -61,6 +61,22 @@ func vjpSubtractWrt1(x: Float, y: Float) -> (value: Float, pullback: (Float) -> 
   return (x - y, { $0 })
 }
 
+// Test invalid original function.
+
+// expected-error @+1 {{use of unresolved identifier 'nonexistentFunction'}}
+@derivative(of: nonexistentFunction)
+func vjpOriginalFunctionNotFound(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
+// Test `@derivative` attribute where `value:` result does not conform to `Differentiable`.
+// Invalid original function should be diagnosed first.
+// expected-error @+1 {{use of unresolved identifier 'nonexistentFunction'}}
+@derivative(of: nonexistentFunction)
+func vjpOriginalFunctionNotFound2(_ x: Float) -> (value: Int, pullback: (Float) -> Float) {
+  fatalError()
+}
+
 // Test incorrect `@derivative` declaration type.
 
 // expected-note @+1 {{'incorrectDerivativeType' defined here}}
@@ -83,7 +99,7 @@ func vjpResultIncorrectFirstLabel(x: Float) -> (Float, (Float) -> Float) {
 func vjpResultIncorrectSecondLabel(x: Float) -> (value: Float, (Float) -> Float) {
   return (x, { $0 })
 }
-// expected-error @+1 {{'@derivative(of:)' attribute requires function to return a two-element tuple; first element type 'Int' must conform to 'Differentiable'}}
+// expected-error @+1 {{could not find function 'incorrectDerivativeType' with expected type '(Int) -> Int'}}
 @derivative(of: incorrectDerivativeType)
 func vjpResultNotDifferentiable(x: Int) -> (
   value: Int, pullback: (Int) -> Int

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -68,22 +68,22 @@ func incorrectDerivativeType(_ x: Float) -> Float {
   return x
 }
 
-// expected-error @+1 {{'@derivative(of:)' attribute requires function to return a two-element tuple of type '(value: T..., pullback: (U.TangentVector) -> T.TangentVector...)' or '(value: T..., differential: (T.TangentVector...) -> U.TangentVector)'}}
+// expected-error @+1 {{'@derivative(of:)' attribute requires function to return a two-element tuple; first element must have label 'value:' and second element must have label 'pullback:' or 'differential:'}}
 @derivative(of: incorrectDerivativeType)
 func jvpResultIncorrect(x: Float) -> Float {
   return x
 }
-// expected-error @+1 {{'@derivative(of:)' attribute requires function to return a two-element tuple (first element must have label 'value:'}}
+// expected-error @+1 {{'@derivative(of:)' attribute requires function to return a two-element tuple; first element must have label 'value:'}}
 @derivative(of: incorrectDerivativeType)
 func vjpResultIncorrectFirstLabel(x: Float) -> (Float, (Float) -> Float) {
   return (x, { $0 })
 }
-// expected-error @+1 {{'@derivative(of:)' attribute requires function to return a two-element tuple (second element must have label 'pullback:' or 'differential:')}}
+// expected-error @+1 {{'@derivative(of:)' attribute requires function to return a two-element tuple; second element must have label 'pullback:' or 'differential:'}}
 @derivative(of: incorrectDerivativeType)
 func vjpResultIncorrectSecondLabel(x: Float) -> (value: Float, (Float) -> Float) {
   return (x, { $0 })
 }
-// expected-error @+1 {{'@derivative(of:)' attribute requires function to return a two-element tuple (first element type 'Int' must conform to 'Differentiable')}}
+// expected-error @+1 {{'@derivative(of:)' attribute requires function to return a two-element tuple; first element type 'Int' must conform to 'Differentiable'}}
 @derivative(of: incorrectDerivativeType)
 func vjpResultNotDifferentiable(x: Int) -> (
   value: Int, pullback: (Int) -> Int


### PR DESCRIPTION
Previously, `@derivative` attribute type-checking produced a confusing error
referencing unbound types `T` and `U`:

```
'@derivative(of:)' attribute requires function to return a two-element tuple of
type '(value: T..., pullback: (U.TangentVector) -> T.TangentVector...)' or
'(value: T..., differential: (T.TangentVector...) -> U.TangentVector)'
```

Now, the error is less confusing:

```
'@derivative(of:)' attribute requires function to return a two-element tuple;
first element must have label 'value:' and second element must have label
'pullback:' or 'differential:'
```

---

Attempt to look up original function before checking whether the `value:` result
conforms to `Differentiable`.

This improves diagnostics: "original function not found" should be diagnosed as
early as possible.

---

Add utility for checking whether differentiable programming is enabled.