### PR TITLE
[ConstraintSystem] Rank contextually unavailable overloads lower than…

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -616,7 +616,7 @@ namespace {
       if (!overloadType)
         continue;
 
-      if (!decl->getAttrs().isUnavailable(CS.getASTContext()) &&
+      if (!CS.isDeclUnavailable(decl, constraint->getLocator()) &&
           !decl->getAttrs().hasAttribute<DisfavoredOverloadAttr>() &&
           isFavored(decl, overloadType)) {
         // If we might need to roll back the favored constraints, keep

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5765,7 +5765,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
         auto argType = AnyFunctionType::composeInput(getASTContext(), args,
                                                      /*canonicalVarargs=*/false);
         if (argType->isEqual(favoredType))
-          if (!decl->getAttrs().isUnavailable(getASTContext()))
+          if (!isDeclUnavailable(decl, memberLocator))
             result.FavoredChoice = result.ViableCandidates.size();
       }
     }

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2174,7 +2174,7 @@ void ConstraintSystem::partitionDisjunction(
       if (!funcDecl)
         return false;
 
-      if (!funcDecl->getAttrs().isUnavailable(getASTContext()))
+      if (!isDeclUnavailable(funcDecl, constraint->getLocator()))
         return false;
 
       unavailable.push_back(index);
@@ -2266,6 +2266,9 @@ Constraint *ConstraintSystem::selectDisjunction() {
 }
 
 bool DisjunctionChoice::attempt(ConstraintSystem &cs) const {
+  if (isUnavailable())
+    cs.increaseScore(SK_Unavailable);
+
   cs.simplifyDisjunctionChoice(Choice);
 
   if (ExplicitConversion)

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -273,9 +273,7 @@ LookupResult &ConstraintSystem::lookupMember(Type base, DeclNameRef name) {
 
     // If the entry we recorded was unavailable but this new entry is not,
     // replace the recorded entry with this one.
-    auto &ctx = getASTContext();
-    if (uniqueEntry->getAttrs().isUnavailable(ctx) &&
-        !decl->getAttrs().isUnavailable(ctx)) {
+    if (isDeclUnavailable(uniqueEntry) && !isDeclUnavailable(decl)) {
       uniqueEntry = decl;
     }
   }
@@ -1894,11 +1892,6 @@ isInvalidPartialApplication(ConstraintSystem &cs, const ValueDecl *member,
 std::pair<Type, bool> ConstraintSystem::adjustTypeOfOverloadReference(
     const OverloadChoice &choice, ConstraintLocator *locator,
     Type boundType, Type refType) {
-  // If the declaration is unavailable, note that in the score.
-  if (choice.getDecl()->getAttrs().isUnavailable(getASTContext())) {
-    increaseScore(SK_Unavailable);
-  }
-
   bool bindConstraintCreated = false;
   const auto kind = choice.getKind();
   if (kind != OverloadChoiceKind::DeclViaDynamic &&
@@ -3623,9 +3616,9 @@ void ConstraintSystem::generateConstraints(
 
   if (favoredIndex) {
     const auto &choice = choices[*favoredIndex];
-    assert((!choice.isDecl() ||
-            !choice.getDecl()->getAttrs().isUnavailable(getASTContext())) &&
-           "Cannot make unavailable decl favored!");
+    assert(
+        (!choice.isDecl() || !isDeclUnavailable(choice.getDecl(), locator)) &&
+        "Cannot make unavailable decl favored!");
     recordChoice(constraints, *favoredIndex, choice, /*isFavored=*/true);
   }
 
@@ -4294,4 +4287,27 @@ void ConstraintSystem::diagnoseFailureFor(SolutionApplicationTarget target) {
     DE.diagnose(target.getAsFunction()->getLoc(),
                 diag::failed_to_produce_diagnostic);
   }
+}
+
+bool ConstraintSystem::isDeclUnavailable(const Decl *D,
+                                         ConstraintLocator *locator) const {
+  auto &ctx = getASTContext();
+
+  if (ctx.LangOpts.DisableAvailabilityChecking)
+    return false;
+
+  // First check whether this declaration is universally unavailable.
+  if (D->getAttrs().isUnavailable(ctx))
+    return true;
+
+  SourceLoc loc;
+
+  if (locator) {
+    if (auto *anchor = locator->getAnchor())
+      loc = anchor->getLoc();
+  }
+
+  // If not, let's check contextual unavailability.
+  AvailabilityContext result = AvailabilityContext::alwaysAvailable();
+  return !TypeChecker::isDeclAvailable(D, loc, DC, result);
 }

--- a/test/Sema/availability_with_overloading.swift
+++ b/test/Sema/availability_with_overloading.swift
@@ -1,0 +1,40 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+protocol View {}
+
+extension View {
+  @_disfavoredOverload
+  func frame(width: Double?, height: Double? = nil) {
+  }
+}
+
+@available(macOS 999, *)
+extension View {
+  func frame(width: Double?) {
+  }
+}
+
+func test_disfavored_vs_unavailable(_ view: View) {
+  view.frame(width: 100) // Ok
+  // CHECK: function_ref @$s29availability_with_overloading4ViewPAAE5frame5width6heightySdSg_AGtF
+}
+
+struct S {
+  func foo<T: StringProtocol>(_: T) {}
+  func bar(_: Int, _: Int = 0) {}
+}
+
+@available(macOS 999, *)
+extension S {
+  func foo(_: String) {}
+  func bar(_: Int) {}
+}
+
+func test_generic_vs_unavailable(_ s: S) {
+  s.foo("") // Ok (picks available generic overload)
+  // CHECK: function_ref @$s29availability_with_overloading1SV3fooyyxSyRzlF
+  s.bar(42) // Ok (picks overload with defaulted argument)
+  // CHECK: function_ref @$s29availability_with_overloading1SV3baryySi_SitF
+}


### PR DESCRIPTION
… other choices

Currently constraint solver is only capable of detecting universally unavailable
overloads but that's insufficient because it's still possible to pick a contextually
unavailable overload choice which could be better than e.g. generic overload, or
one with defaulted arguments, marked as disfavored etc.

Let's introduce `ConstraintSystem::isDeclUnavailable` which supports both universal
and contextual unavailability and allow constraint solver to rank all unavailable
overload choices lower than any other possible choice(s).

Resolves: rdar://problem/59056638

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
