### PR TITLE
[5.2][Test] Don't run EmptyCollectionSingletonRealization on older runtimes that aren't fixed.

### DIFF
--- a/test/stdlib/EmptyCollectionSingletonRealization.swift
+++ b/test/stdlib/EmptyCollectionSingletonRealization.swift
@@ -24,25 +24,33 @@ import Foundation
 
 @objc protocol P {}
 
-do {
-  let d: [NSObject: NSObject] = [:]
-  let c: AnyClass? = object_getClass(d)
-  let conforms = class_conformsToProtocol(c, P.self)
-  print("Dictionary: ", conforms) // CHECK: Dictionary: false
-}
 
-do {
-  let a: [NSObject] = []
-  let c: AnyClass? = object_getClass(a)
-  let p = objc_getProtocol("NSObject")
-  let conforms = class_conformsToProtocol(c, p)
-  print("Array:", conforms) // CHECK: Array: false
-}
+if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
+  do {
+    let d: [NSObject: NSObject] = [:]
+    let c: AnyClass? = object_getClass(d)
+    let conforms = class_conformsToProtocol(c, P.self)
+    print("Dictionary: ", conforms) // CHECK: Dictionary: false
+  }
 
-do {
-  let s: Set<NSObject> = []
-  let c: AnyClass? = object_getClass(s)
-  let p = objc_getProtocol("NSObject")
-  let conforms = class_conformsToProtocol(c, p)
-  print("Set:", conforms) // CHECK: Set: false
+  do {
+    let a: [NSObject] = []
+    let c: AnyClass? = object_getClass(a)
+    let p = objc_getProtocol("NSObject")
+    let conforms = class_conformsToProtocol(c, p)
+    print("Array:", conforms) // CHECK: Array: false
+  }
+
+  do {
+    let s: Set<NSObject> = []
+    let c: AnyClass? = object_getClass(s)
+    let p = objc_getProtocol("NSObject")
+    let conforms = class_conformsToProtocol(c, p)
+    print("Set:", conforms) // CHECK: Set: false
+  }
+} else {
+  // When testing against an older runtime that doesn't have this fix, lie.
+  print("Dictionary: false")
+  print("Array: false")
+  print("Set: false")
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/29923 to 5.2

rdar://problem/59590614