### PR TITLE
[swift-lang] Fix dependency on sourcekitd module

### DIFF
--- a/stdlib/tools/swift-lang/CMakeLists.txt
+++ b/stdlib/tools/swift-lang/CMakeLists.txt
@@ -18,6 +18,7 @@ add_swift_target_library(swiftSwiftLang SHARED
   GYB_SOURCES
     UIDs.swift.gyb
 
+  DEPENDS sourcekitd
   SWIFT_MODULE_DEPENDS_OSX Darwin Foundation
   PRIVATE_LINK_LIBRARIES sourcekitd
   SWIFT_COMPILE_FLAGS -F${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib


### PR DESCRIPTION
The link dependency is not sufficient, because this code depends on the
sourcekitd header and module map, which are produced during the build
process.  This started failing after edbe22b63c5, where the dependency
on `sourcekitd-test` was removed. That dependency was itself wrong,
but it happened to be a good enough approximation that we never saw
issues.