### PR TITLE
[Experiment] Nuke special-case UDRE code for enums

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -499,24 +499,6 @@ public:
                                             elt->createNameRef(), elt, nullptr);
   }
   Pattern *visitUnresolvedDeclRefExpr(UnresolvedDeclRefExpr *ude) {
-    // FIXME: This shouldn't be needed.  It is only necessary because of the
-    // poor representation of clang enum aliases and should be removed when
-    // rdar://20879992 is addressed.
-    //
-    // Try looking up an enum element in context.
-    if (EnumElementDecl *referencedElement
-        = lookupUnqualifiedEnumMemberElement(DC, ude->getName(),
-                                             ude->getLoc())) {
-      auto *enumDecl = referencedElement->getParentEnum();
-      auto enumTy = enumDecl->getDeclaredTypeInContext();
-      TypeLoc loc = TypeLoc::withoutLoc(enumTy);
-
-      return new (Context) EnumElementPattern(
-          loc, SourceLoc(), ude->getNameLoc(), ude->getName(),
-          referencedElement, nullptr);
-    }
-      
-    
     // Perform unqualified name lookup to find out what the UDRE is.
     return getSubExprPattern(TypeChecker::resolveDeclRefExpr(ude, DC));
   }

--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -479,7 +479,7 @@ enum SE0036 {
 
   static func staticReferenceInSwitchInStaticMethod() {
     switch SE0036.A {
-    case A: break
+    case A: break // expected-error {{operator function '~=' requires that 'SE0036' conform to 'Equatable'}}
     case B(_): break
     case C(let x): _ = x; break
     }


### PR DESCRIPTION
The comment for this is stale. The actual thing this seems to be holding
up is that you can have un-dotted references to enum cases in static
context. This code would eagerly form a pattern for such cases. Now,
for patterns without arguments, we will run the normal lookup path and
form a value of the enum case instead.

I doubt this will have much impact on Swift code, but the original issue
mentions Clang so let's see what happens.