### PR TITLE
build: correct executable name for swift compiler

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/pythonkit.py
+++ b/utils/swift_build_support/swift_build_support/products/pythonkit.py
@@ -32,7 +32,7 @@ class PythonKit(product.Product):
     def build(self, host_target):
         toolchain_path = targets.toolchain_path(self.args.install_destdir,
                                                 self.args.install_prefix)
-        swiftc = os.path.join(toolchain_path, 'usr', 'bin', 'swift')
+        swiftc = os.path.join(toolchain_path, 'usr', 'bin', 'swiftc')
 
         shell.call([
             self.toolchain.cmake,


### PR DESCRIPTION
The swift compiler is `swiftc` not `swift`.  Correct the spelling.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
