### PR TITLE
[TF] Fix macOS toolchain builds.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2328,10 +2328,11 @@ no-assertions
 [preset: mixin_codesigning]
 darwin-toolchain-application-cert=lldb_codesign
 
-# Note: tensorflow_osx_base does not mix in "buildbot_osx_package" or
-# "mixin_osx_package_base" because they enable ios/tvos/watchos and tests by
-# default.
-# Instead, options are copied here individually.
+# Note: `tensorflow_osx_base` does not mix in `buildbot_osx_package` because
+# they enable ios/tvos/watchos by default. Instead, options are copied here
+# individually.
+# TODO(TF-941): Try to mixin `buildbot_osx_package` directly. This requires
+# options like `skip-ios` to override `ios`.
 [preset: tensorflow_osx_base]
 mixin-preset=mixin_lightweight_assertions
 
@@ -2378,7 +2379,7 @@ test-installable-package
 reconfigure
 
 swift-install-components=compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;parser-lib;toolchain-tools;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
-llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd
+llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;dsymutil
 install-libcxx
 
 # Path to the .tar.gz package.


### PR DESCRIPTION
Fix `tensorflow_osx_base` preset: add `dsymutil` to `llvm-install-components`.

After the recent `master -> tensorflow` merge (https://github.com/apple/swift/pull/29768), SwiftPM fails with an error regarding `dsymutil`.
```
--- bootstrap: note: Building SwiftPM (with swift-build)
...
[101/108] Compiling Xcodeproj PropertyList.swift
[102/108] Compiling XCBuildSupport PIF.swift
[103/108] Compiling Build BuildDelegate.swift
[104/109] Compiling Workspace Destination.swift
warning: base type ref doesn't point to DW_TAG_base_type.
note: while processing /Users/swiftninjas/s4tf/build/buildbot_osx/swiftpm-macosx-x86_64/x86_64-apple-macosx/release/Build.build/BuildDelegate.swift.o
<unknown>:0: error: unable to execute command: Segmentation fault: 11
<unknown>:0: error: generate-dSYM command failed due to signal 11 (use -v to see invocation)
[104/110] Linking libSwiftPM.dylib
```

---

Verified that the fix works: https://github.com/tensorflow/swift/pull/390

This issue surfaced because the `tensorflow_osx_base` preset does not mixin `buildbot_osx_package` directly. There may exist a more robust long-term solution involving `LLVM_DISTRIBUTION_COMPONENTS`.