### PR TITLE
[TF merge] Fix macOS toolchain builds.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2356,10 +2356,11 @@ no-assertions
 [preset: mixin_codesigning]
 darwin-toolchain-application-cert=lldb_codesign
 
-# Note: tensorflow_osx_base does not mix in "buildbot_osx_package" or
-# "mixin_osx_package_base" because they enable ios/tvos/watchos and tests by
-# default.
-# Instead, options are copied here individually.
+# Note: `tensorflow_osx_base` does not mix in `buildbot_osx_package` because
+# they enable ios/tvos/watchos by default. Instead, options are copied here
+# individually.
+# TODO(TF-941): Try to mixin `buildbot_osx_package` directly. This requires
+# options like `skip-ios` to override `ios`.
 [preset: tensorflow_osx_base]
 mixin-preset=mixin_lightweight_assertions
 
@@ -2410,7 +2411,7 @@ test-installable-package
 reconfigure
 
 swift-install-components=compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;parser-lib;toolchain-tools;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
-llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd
+llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;dsymutil
 install-libcxx
 
 # Path to the .tar.gz package.


### PR DESCRIPTION
Fix `tensorflow_osx_base` preset: add `dsymutil` to `llvm-install-components`.

Mirror of https://github.com/apple/swift/pull/29932.