### PR TITLE
[5.2] Refactor AreAllStoredPropertiesDefaultInitableRequest for Property Wrappers

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -797,23 +797,35 @@ llvm::Expected<bool> AreAllStoredPropertiesDefaultInitableRequest::evaluate(
     // synthesize an initial value (e.g. for an optional) then we suppress
     // generation of the default initializer.
     if (auto pbd = dyn_cast<PatternBindingDecl>(member)) {
-      if (pbd->hasStorage() && !pbd->isStatic()) {
-        for (auto idx : range(pbd->getNumPatternEntries())) {
-          if (pbd->isInitialized(idx)) continue;
+      // Static variables are irrelevant.
+      if (pbd->isStatic()) {
+        continue;
+      }
 
+      for (auto idx : range(pbd->getNumPatternEntries())) {
+        bool HasStorage = false;
+        bool CheckDefaultInitializer = true;
+        pbd->getPattern(idx)->forEachVariable([&](VarDecl *VD) {
           // If one of the bound variables is @NSManaged, go ahead no matter
           // what.
-          bool CheckDefaultInitializer = true;
-          pbd->getPattern(idx)->forEachVariable([&](VarDecl *vd) {
-            if (vd->getAttrs().hasAttribute<NSManagedAttr>())
-              CheckDefaultInitializer = false;
-          });
-        
-          // If we cannot default initialize the property, we cannot
-          // synthesize a default initializer for the class.
-          if (CheckDefaultInitializer && !pbd->isDefaultInitializable())
-            return false;
-        }
+          if (VD->getAttrs().hasAttribute<NSManagedAttr>())
+            CheckDefaultInitializer = false;
+
+          if (VD->hasStorage())
+            HasStorage = true;
+          auto *backing = VD->getPropertyWrapperBackingProperty();
+          if (backing && backing->hasStorage())
+            HasStorage = true;
+        });
+
+        if (!HasStorage) continue;
+
+        if (pbd->isInitialized(idx)) continue;
+
+        // If we cannot default initialize the property, we cannot
+        // synthesize a default initializer for the class.
+        if (CheckDefaultInitializer && !pbd->isDefaultInitializable())
+          return false;
       }
     }
   }

--- a/test/SILOptimizer/Inputs/di_property_wrappers_errors_multifile_2.swift
+++ b/test/SILOptimizer/Inputs/di_property_wrappers_errors_multifile_2.swift
@@ -1,0 +1,19 @@
+@propertyWrapper
+ public struct WrapGod<T> {
+   private var value: T
+
+    public init(wrappedValue: T) {
+     value = wrappedValue
+   }
+
+    public var wrappedValue: T {
+     get { value }
+     set { value = newValue }
+   }
+ }
+
+final class TestCaseRunner {}
+
+struct ContentView { // expected-note {{'init(runner:)' declared here}}
+  @WrapGod var runner: TestCaseRunner
+}

--- a/test/SILOptimizer/di_property_wrappers_errors_multifile.swift
+++ b/test/SILOptimizer/di_property_wrappers_errors_multifile.swift
@@ -1,0 +1,8 @@
+// rdar://58495602: The order used to matter here. If use compiles before def
+// then you got a DI error. If def compiles before use then you got a linker error.
+
+// RUN: %target-swift-frontend -emit-sil -verify %s %S/Inputs/di_property_wrappers_errors_multifile_2.swift
+// RUN: %target-swift-frontend -emit-sil -verify %S/Inputs/di_property_wrappers_errors_multifile_2.swift %s
+
+let contentView = ContentView() // expected-error {{missing argument for parameter 'runner' in call}}
+


### PR DESCRIPTION
Cherry-pick #29916 

**Explanation**: The storage for the backing variable for a property wrapper was not considered in the semantic check that precedes synthesis of default initializers. In the linked radar, a simple struct with a single `@ObservedObject` member that added storage accidentally slipped through this check and a default initializer was synthesized. The default initializer does not initialize any of the stored properties of the object - its body is just a single return statement - so cryptic unfixable DI errors got emitted into user code. Expand the check to property wrappers that add storage and ensure that the errant initializer isn't synthesized.
**Scope**: Affects most common use-cases of property wrappers
**Risk**: Very Low. Code referencing this initializer would have failed to build, or currently fails to build because of its presence.
**Issue**: rdar://problem/58495602
**Testing**: Regressions tests added in follow-up commit
**Reviewer**: @slavapestov 
