### PR TITLE
[SE-0274] Stage in #filePath

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -491,7 +491,7 @@ def enable_experimental_differentiable_programming : Flag<["-"], "enable-experim
 def enable_experimental_concise_pound_file : Flag<["-"],
     "enable-experimental-concise-pound-file">,
   Flags<[FrontendOption]>,
-  HelpText<"Enable experimental concise '#file' identifier and '#filePath' alternative">;
+  HelpText<"Enable experimental concise '#file' identifier">;
 
 // Diagnostic control options
 def suppress_warnings : Flag<["-"], "suppress-warnings">,

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1464,16 +1464,9 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
     LLVM_FALLTHROUGH;
   }
 
-  case tok::pound_filePath:
-    // Check twice because of fallthrough--this is ugly but temporary.
-    if (Tok.is(tok::pound_filePath) && !Context.LangOpts.EnableConcisePoundFile)
-      diagnose(Tok.getLoc(), diag::unknown_pound_expr, "filePath");
-    // Continue since we actually do know how to handle it. This avoids extra
-    // diagnostics.
-    LLVM_FALLTHROUGH;
-
   case tok::pound_column:
   case tok::pound_file:
+  case tok::pound_filePath:
   case tok::pound_function:
   case tok::pound_line:
   case tok::pound_dsohandle: {

--- a/test/SILGen/magic_identifier_filepath.swift
+++ b/test/SILGen/magic_identifier_filepath.swift
@@ -27,4 +27,4 @@ func indirectUse() {
 }
 
 public func functionWithFilePathDefaultArgument(file: String = #filePath) {}
-// SWIFTINTERFACE: public func functionWithFilePathDefaultArgument(file: Swift.String = #filePath) {}
+// SWIFTINTERFACE: public func functionWithFilePathDefaultArgument(file: Swift.String = #filePath)

--- a/test/SILGen/magic_identifier_filepath.swift
+++ b/test/SILGen/magic_identifier_filepath.swift
@@ -1,15 +1,19 @@
-// Check that we generate the right code with the flag.
-// RUN: %target-swift-emit-silgen -enable-experimental-concise-pound-file -module-name Foo %/s | %FileCheck %s
+// Check that we generate the right strings.
+// RUN: %target-swift-emit-silgen -module-name Foo %/s | %FileCheck %s
 
-// Check that we give errors for use of #filePath if concise #file isn't enabled.
-// FIXME: Drop if we stop rejecting this.
+// Even if concise #file is not available, we now allow you to write #filePath.
+// Check that we don't diagnose any errors in this file.
 // RUN: %target-typecheck-verify-swift -module-name Foo %s
 
-// FIXME: Once this feature becomes non-experimental, we should duplicate
+// #filePath should appear in swiftinterfaces with this change.
+// RUN: %target-swift-frontend-typecheck -module-name Foo -emit-module-interface-path %t.swiftinterface %s
+// RUN: %FileCheck -check-prefix SWIFTINTERFACE %s < %t.swiftinterface
+
+// FIXME: Once this feature has been fully staged in, we should duplicate
 // existing #file tests and delete this file.
 
 func directUse() {
-  print(#filePath) // expected-error {{use of unknown directive '#filePath'}}
+  print(#filePath)
 
 // CHECK-LABEL: sil {{.*}} @$s3Foo9directUseyyF
 // CHECK: string_literal utf8 "SOURCE_DIR/test/SILGen/magic_identifier_filepath.swift"
@@ -22,5 +26,5 @@ func indirectUse() {
 // CHECK: string_literal utf8 "SOURCE_DIR/test/SILGen/magic_identifier_filepath.swift"
 }
 
-func functionWithFilePathDefaultArgument(file: String = #filePath) {}
-// expected-error@-1 {{use of unknown directive '#filePath'}}
+public func functionWithFilePathDefaultArgument(file: String = #filePath) {}
+// SWIFTINTERFACE: public func functionWithFilePathDefaultArgument(file: Swift.String = #filePath) {}


### PR DESCRIPTION
To give users of `#file` a brief window to transition if necessary, we are first adding `#filePath` without changing `#file`’s behavior. This commit makes that change.

Fixes <rdar://problem/58586626>.