### PR TITLE
[SIL] Fix use-after-free in `SILFunction::print`.

### DIFF
--- a/validation-test/SIL/crashers_fixed/047-swift-silfunction-print.swift
+++ b/validation-test/SIL/crashers_fixed/047-swift-silfunction-print.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -emit-sil %s
+
+// SR-12239: use-after-free in `SILFunction::print`.
+
+func outer<C>(_ x: C) {
+  func inner<C>(_ x: C) {}
+}


### PR DESCRIPTION
Fix use-after-free in helper function `printSILFunctionNameAndType`.
The address of a `DenseMap` local variable was used after the function returned.

Resolves SR-12239.