### PR TITLE
[5.2][CSRanking] Detect cases where overload choices are incomparable

### DIFF
--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -761,6 +761,21 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     if (sameOverloadChoice(choice1, choice2))
       continue;
 
+    // If constraint system is underconstrained e.g. because there are
+    // editor placeholders, it's possible to end up with multiple solutions
+    // where each ambiguous declaration is going to have its own overload kind:
+    //
+    // func foo(_: Int) -> [Int] { ... }
+    // func foo(_: Double) -> (result: String, count: Int) { ... }
+    //
+    // _ = foo(<#arg#>).count
+    //
+    // In this case solver would produce 2 solutions: one where `count`
+    // is a property reference on `[Int]` and another one is tuple access
+    // for a `count:` element.
+    if (choice1.isDecl() != choice2.isDecl())
+      return SolutionCompareResult::Incomparable;
+
     auto decl1 = choice1.getDecl();
     auto dc1 = decl1->getDeclContext();
     auto decl2 = choice2.getDecl();

--- a/test/Sema/editor_placeholders.swift
+++ b/test/Sema/editor_placeholders.swift
@@ -29,3 +29,10 @@ f(<#T##String#>) // expected-error{{editor placeholder in source file}} expected
 for x in <#T#> { // expected-error{{editor placeholder in source file}} expected-error{{for-in loop requires '()' to conform to 'Sequence'}}
 
 }
+
+// rdar://problem/49712598 - crash while trying to rank solutions with different kinds of overloads
+func test_ambiguity_with_placeholders(pairs: [(rank: Int, count: Int)]) -> Bool {
+  return pairs[<#^ARG^#>].count == 2
+  // expected-error@-1 {{editor placeholder in source file}}
+  // expected-error@-2 {{ambiguous use of 'subscript(_:)'}}
+}


### PR DESCRIPTION
- **Explanation**:

If constraint system is underconstrained e.g. because there are
editor placeholders, it's possible to end up with multiple solutions
where each ambiguous declaration is going to have its own overload kind:

```swift
func foo(_: Int) -> [Int] { ... }
func foo(_: Double) -> (result: String, count: Int) { ... }

_ = foo(<#arg#>).count
```

In this case solver would produce 2 solutions: one where `count`
is a property reference on `[Int]` and another one is tuple access
for a `count:` element.

- **Issue**: rdar://problem/49712598

- **Scope**: Affects expressions which placeholders and only in narrow cases where it's possible to produce a solution with overloads of different kind.

- **Risk**: Very Low. 

- **Testing**: Added compiler regression tests.

- **Reviewed by**: @hborla and @nathawes 

Resolves: rdar://problem/49712598
(cherry picked from commit 288a7765fc3f3eece215267b8dca043c1260e5b2)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
