### PR TITLE
[Parse] Improve recovery from and diagnostics for invalid operator names

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -428,8 +428,14 @@ ERROR(operator_decl_inner_scope,none,
       "'operator' may only be declared at file scope", ())
 ERROR(expected_operator_name_after_operator,PointsToFirstBadToken,
       "expected operator name in operator declaration", ())
-ERROR(identifier_when_expecting_operator,PointsToFirstBadToken,
-      "%0 is considered to be an identifier, not an operator", (Identifier))
+ERROR(identifier_within_operator_name,PointsToFirstBadToken,
+      "'%0' is considered an identifier and must not "
+      "appear within an operator name", (StringRef))
+ERROR(operator_name_invalid_char,PointsToFirstBadToken,
+      "'%0' is not allowed in operator names", (StringRef))
+ERROR(postfix_operator_name_cannot_start_with_unwrap,PointsToFirstBadToken,
+      "postfix operator names starting with '?' or '!' are disallowed "
+      "to avoid collisions with built-in unwrapping operators", ())
 
 ERROR(deprecated_operator_body,PointsToFirstBadToken,
       "operator should no longer be declared with body", ())

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -829,7 +829,8 @@ void Lexer::lexOperatorIdentifier() {
   if (CurPtr-TokStart == 1) {
     switch (TokStart[0]) {
     case '=':
-      if (leftBound != rightBound) {
+      // Refrain from emitting this message in operator name position.
+      if (NextToken.isNot(tok::kw_operator) && leftBound != rightBound) {
         auto d = diagnose(TokStart, diag::lex_unary_equal);
         if (leftBound)
           d.fixItInsert(getSourceLoc(TokStart), " ");

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7416,10 +7416,20 @@ Parser::parseDeclOperator(ParseDeclOptions Flags, DeclAttributes &Attributes) {
     return false;
   };
 
+  // Postfix operators starting with ? or ! conflict with builtin
+  // unwrapping operators.
+  if (Attributes.hasAttribute<PostfixAttr>())
+    if (!Tok.getText().empty() && (Tok.getRawText().front() == '?' ||
+                                   Tok.getRawText().front() == '!'))
+      diagnose(Tok, diag::postfix_operator_name_cannot_start_with_unwrap);
+
   // A common error is to try to define an operator with something in the
   // unicode plane considered to be an operator, or to try to define an
   // operator like "not".  Analyze and diagnose this specifically.
-  if (Tok.isAnyOperator()) {
+  if (Tok.isAnyOperator() || Tok.isAny(tok::exclaim_postfix,
+                                       tok::question_infix,
+                                       tok::question_postfix,
+                                       tok::equal, tok::arrow)) {
     if (peekToken().getLoc() == Tok.getRange().getEnd() &&
       maybeDiagnoseInvalidCharInOperatorName(peekToken())) {
       consumeToken();
@@ -7431,9 +7441,7 @@ Parser::parseDeclOperator(ParseDeclOptions Flags, DeclAttributes &Attributes) {
       }
       return nullptr;
     }
-  // We will handle these either below or in Sema.
-  } else if (Tok.isNot(tok::exclaim_postfix, tok::question_infix,
-                       tok::question_postfix)) {
+  } else {
     if (maybeDiagnoseInvalidCharInOperatorName(Tok)) {
       // We're done diagnosing.
     } else {
@@ -7452,13 +7460,6 @@ Parser::parseDeclOperator(ParseDeclOptions Flags, DeclAttributes &Attributes) {
 
   Identifier Name = Context.getIdentifier(Tok.getText());
   SourceLoc NameLoc = consumeToken();
-
-  // Postfix operators starting with ? or ! conflict with builtin
-  // unwrapping operators.
-  if (Attributes.hasAttribute<PostfixAttr>()) {
-    if (!Name.empty() && (Name.get()[0] == '?' || Name.get()[0] == '!'))
-      diagnose(NameLoc, diag::postfix_operator_name_cannot_start_with_unwrap);
-  }
 
   auto Result = parseDeclOperatorImpl(OperatorLoc, Name, NameLoc, Attributes);
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1505,11 +1505,14 @@ static bool isBuiltinOperator(StringRef name, DeclAttribute *attr) {
           (isa<PostfixAttr>(attr) && name == "!") ||   // optional unwrapping
           // FIXME: Not actually a builtin operator, but should probably
           // be allowed and accounted for in Sema?
-          (isa<PrefixAttr>(attr) && name == "?") ||
+          (isa<PrefixAttr>(attr)  && name == "?") ||
           (isa<PostfixAttr>(attr) && name == "?") ||   // optional chaining
-          (isa<InfixAttr>(attr) && name == "?") ||     // ternary operator
+          (isa<InfixAttr>(attr)   && name == "?") ||   // ternary operator
           (isa<PostfixAttr>(attr) && name == ">") ||   // generic argument list
-          (isa<PrefixAttr>(attr)  && name == "<"));    // generic argument list
+          (isa<PrefixAttr>(attr)  && name == "<") ||   // generic argument list
+                                     name == "="  ||   // Assignment
+          // FIXME: Should probably be allowed in expression position?
+                                     name == "->");
 }
 
 void AttributeChecker::checkOperatorAttribute(DeclAttribute *attr) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1503,6 +1503,9 @@ void AttributeChecker::visitFinalAttr(FinalAttr *attr) {
 static bool isBuiltinOperator(StringRef name, DeclAttribute *attr) {
   return ((isa<PrefixAttr>(attr)  && name == "&") ||   // lvalue to inout
           (isa<PostfixAttr>(attr) && name == "!") ||   // optional unwrapping
+          // FIXME: Not actually a builtin operator, but should probably
+          // be allowed and accounted for in Sema?
+          (isa<PrefixAttr>(attr) && name == "?") ||
           (isa<PostfixAttr>(attr) && name == "?") ||   // optional chaining
           (isa<InfixAttr>(attr) && name == "?") ||     // ternary operator
           (isa<PostfixAttr>(attr) && name == ">") ||   // generic argument list

--- a/test/Parse/operator_decl.swift
+++ b/test/Parse/operator_decl.swift
@@ -40,9 +40,16 @@ prefix operator // expected-error {{expected operator name in operator declarati
 prefix operator %%+
 
 prefix operator ??
-postfix operator ?? // expected-error {{expected operator name in operator declaration}}
+postfix operator ?? // expected-error {{postfix operator names starting with '?' or '!' are disallowed}}
 prefix operator !!
-postfix operator !! // expected-error {{expected operator name in operator declaration}}
+postfix operator !! // expected-error {{postfix operator names starting with '?' or '!' are disallowed}}
+
+infix operator --aa // expected-error {{'aa' is considered an identifier and must not appear within an operator name}}
+infix operator aa--: A // expected-error {{'aa' is considered an identifier and must not appear within an operator name}}
+infix operator <<$$@< // expected-error {{'$$' is considered an identifier and must not appear within an operator name}}
+infix operator !!@aa // expected-error {{'@' is not allowed in operator names}}
+infix operator #++= // expected-error {{'#' is not allowed in operator names}}
+infix operator ++=# // expected-error {{'#' is not allowed in operator names}}
 
 infix operator +++=
 infix operator *** : A

--- a/test/Parse/operator_decl.swift
+++ b/test/Parse/operator_decl.swift
@@ -40,9 +40,12 @@ prefix operator // expected-error {{expected operator name in operator declarati
 prefix operator %%+
 
 prefix operator ??
-postfix operator ?? // expected-error {{postfix operator names starting with '?' or '!' are disallowed}}
+postfix operator ?? // expected-error {{postfix operator names starting with '?' or '!' are disallowed to avoid collisions with built-in unwrapping operators}}
 prefix operator !!
-postfix operator !! // expected-error {{postfix operator names starting with '?' or '!' are disallowed}}
+postfix operator !! // expected-error {{postfix operator names starting with '?' or '!' are disallowed to avoid collisions with built-in unwrapping operators}}
+postfix operator ?$$
+// expected-error@-1 {{postfix operator names starting with '?' or '!' are disallowed}}
+// expected-error@-2 {{'$$' is considered an identifier}}
 
 infix operator --aa // expected-error {{'aa' is considered an identifier and must not appear within an operator name}}
 infix operator aa--: A // expected-error {{'aa' is considered an identifier and must not appear within an operator name}}
@@ -50,6 +53,13 @@ infix operator <<$$@< // expected-error {{'$$' is considered an identifier and m
 infix operator !!@aa // expected-error {{'@' is not allowed in operator names}}
 infix operator #++= // expected-error {{'#' is not allowed in operator names}}
 infix operator ++=# // expected-error {{'#' is not allowed in operator names}}
+infix operator -># // expected-error {{'#' is not allowed in operator names}}
+
+// FIXME: Ideally, we shouldn't emit the «consistent whitespace» diagnostic
+// where = cannot possibly mean an assignment.
+infix operator =#=
+// expected-error@-1 {{'#' is not allowed in operator names}}
+// expected-error@-2 {{'=' must have consistent whitespace on both sides}}
 
 infix operator +++=
 infix operator *** : A

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -818,9 +818,12 @@ func test23719432() {
 }
 
 // <rdar://problem/19911096> QoI: terrible recovery when using '·' for an operator
-infix operator · {  // expected-error {{'·' is considered to be an identifier, not an operator}}
+infix operator · {  // expected-error {{'·' is considered an identifier and must not appear within an operator name}}
   associativity none precedence 150
 }
+
+infix operator -@-class Recover1 {} // expected-error {{'@' is not allowed in operator names}}
+prefix operator -фф--class Recover2 {} // expected-error {{'фф' is considered an identifier and must not appear within an operator name}}
 
 // <rdar://problem/21712891> Swift Compiler bug: String subscripts with range should require closing bracket.
 func r21712891(s : String) -> String {

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -179,6 +179,9 @@ prefix operator &  // expected-error {{cannot declare a custom prefix '&' operat
 postfix operator >  // expected-error {{cannot declare a custom postfix '>' operator}}
 prefix operator <  // expected-error {{cannot declare a custom prefix '<' operator}}
 
+infix operator =  // expected-error {{cannot declare a custom infix '=' operator}}
+infix operator ->  // expected-error {{cannot declare a custom infix '->' operator}}
+
 postfix func !(x: Int) { } // expected-error{{cannot declare a custom postfix '!' operator}}
 postfix func!(x: Int8) { } // expected-error{{cannot declare a custom postfix '!' operator}}
 prefix func & (x: Int) {} // expected-error {{cannot declare a custom prefix '&' operator}}
@@ -189,7 +192,6 @@ func operator_in_func_bad () {
 }
 
 infix operator ?  // expected-error {{cannot declare a custom infix '?' operator}}
-
 prefix operator ?  // expected-error {{cannot declare a custom prefix '?' operator}}
 
 infix operator ??=

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -172,7 +172,7 @@ infix prefix func +-+(x: Double, y: Double) {} // expected-error {{'infix' modif
 
 // Don't allow one to define a postfix '!'; it's built into the
 // language. Also illegal to have any postfix operator starting with '!'.
-postfix operator !  // expected-error {{cannot declare a custom postfix '!' operator}} expected-error {{expected operator name in operator declaration}}
+postfix operator !  // expected-error {{cannot declare a custom postfix '!' operator}} expected-error {{postfix operator names starting with '?' or '!' are disallowed}}
 prefix operator &  // expected-error {{cannot declare a custom prefix '&' operator}}
 
 // <rdar://problem/14607026> Restrict use of '<' and '>' as prefix/postfix operator names
@@ -188,7 +188,9 @@ func operator_in_func_bad () {
     prefix func + (input: String) -> String { return "+" + input } // expected-error {{operator functions can only be declared at global or in type scope}}
 }
 
-infix operator ?  // expected-error {{expected operator name in operator declaration}} 
+infix operator ?  // expected-error {{cannot declare a custom infix '?' operator}}
+
+prefix operator ?  // expected-error {{cannot declare a custom prefix '?' operator}}
 
 infix operator ??=
 


### PR DESCRIPTION
More accurate diagnostics for invalid or ambiguous characters in operator names that also improve recovery as a consequence. 

Here are some affected examples:
```swift
infix operator =
infix operator ->
infix operator ?
postfix operator !==
infix operator -oo-
infix operator =#=
infix operator ?#$
```
