### PR TITLE
[AutoDiff] `inout` parameter differentiation mega-patch.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2974,8 +2974,6 @@ ERROR(implements_attr_protocol_not_conformed_to,none,
       (DeclName, DeclName))
 
 // @differentiable
-ERROR(differentiable_attr_void_result,none,
-      "cannot differentiate void function %0", (DeclName))
 ERROR(differentiable_attr_no_vjp_or_jvp_when_linear,none,
       "cannot specify 'vjp:' or 'jvp:' for linear functions; use '@transpose' "
       "attribute for transpose registration instead", ())
@@ -3000,6 +2998,9 @@ ERROR(differentiable_attr_invalid_access,none,
 ERROR(differentiable_attr_result_not_differentiable,none,
       "can only differentiate functions with results that conform to "
       "'Differentiable', but %0 does not conform to 'Differentiable'", (Type))
+ERROR(differentiable_attr_multiple_original_results,none,
+      "cannot yet differentiate functions with more than one semantic result "
+      "(formal function result or 'inout' parameter)", ())
 ERROR(differentiable_attr_protocol_req_where_clause,none,
       "'@differentiable' attribute on protocol requirement cannot specify "
       "'where' clause", ())
@@ -3093,6 +3094,11 @@ ERROR(autodiff_attr_original_decl_none_valid_found,none,
       "could not find function %0 with expected type %1", (DeclNameRef, Type))
 ERROR(autodiff_attr_original_decl_not_same_type_context,none,
       "%0 is not defined in the current type context", (DeclNameRef))
+ERROR(autodiff_attr_original_void_result,none,
+      "cannot differentiate void function %0", (DeclName))
+ERROR(autodiff_attr_original_multiple_semantic_results,none,
+      "cannot yet differentiate functions with more than one semantic result "
+      "(formal function result or 'inout' parameter)", ())
 
 // differentiation `wrt` parameters clause
 ERROR(diff_function_no_parameters,none,

--- a/include/swift/AST/IndexSubset.h
+++ b/include/swift/AST/IndexSubset.h
@@ -108,8 +108,10 @@ public:
   static IndexSubset *get(ASTContext &ctx, unsigned capacity,
                           ArrayRef<unsigned> indices) {
     SmallBitVector indicesBitVec(capacity, false);
-    for (auto index : indices)
+    for (auto index : indices) {
+      assert(index < capacity);
       indicesBitVec.set(index);
+    }
     return IndexSubset::get(ctx, indicesBitVec);
   }
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3213,6 +3213,16 @@ public:
     return getExtInfo().getRepresentation();
   }
 
+  /// Appends the parameters indicated by `parameterIndices` to `results`.
+  ///
+  /// For curried function types: if `reverseCurryLevels` is true, append
+  /// the `self` parameter last instead of first.
+  ///
+  /// TODO(TF-874): Simplify logic and remove the `reverseCurryLevels` flag.
+  void getSubsetParameters(IndexSubset *parameterIndices,
+                           SmallVectorImpl<AnyFunctionType::Param> &results,
+                           bool reverseCurryLevels = false);
+
   /// Returns the derivative function type for the given parameter indices,
   /// result index, derivative function kind, derivative function generic
   /// signature (optional), and other auxiliary parameters.
@@ -3220,8 +3230,8 @@ public:
   /// Preconditions:
   /// - Parameters corresponding to parameter indices must conform to
   ///   `Differentiable`.
-  /// - The result corresponding to the result index must conform to
-  ///   `Differentiable`.
+  /// - There is one semantic function result type: either the formal original
+  ///   result or an `inout` parameter. It must conform to `Differentiable`.
   ///
   /// Typing rules, given:
   /// - Original function type. Three cases:
@@ -3267,6 +3277,11 @@ public:
   ///              original result | deriv. wrt result | deriv. wrt params
   /// \endverbatim
   ///
+  /// The original type may have `inout` parameters. If so, the
+  /// differential/pullback typing rules are more nuanced: see documentation for
+  /// `getAutoDiffReturnedLinearMapFunctionType` for details. Semantically,
+  /// `inout` parameters behave as both parameters and results.
+  ///
   /// By default, if the original type has a `self` parameter list and parameter
   /// indices include `self`, the computed derivative function type will return
   /// a linear map taking/returning self's tangent *last* instead of first, for
@@ -3277,14 +3292,58 @@ public:
   /// derivative function types, e.g. when type-checking `@differentiable` and
   /// `@derivative` attributes.
   AnyFunctionType *getAutoDiffDerivativeFunctionType(
-      IndexSubset *parameterIndices, unsigned resultIndex,
-      AutoDiffDerivativeFunctionKind kind,
+      IndexSubset *parameterIndices, AutoDiffDerivativeFunctionKind kind,
       LookupConformanceFn lookupConformance,
       GenericSignature derivativeGenericSignature = GenericSignature(),
       bool makeSelfParamFirst = false);
 
+  /// Returns the linear map function type returned by the derivative function
+  /// type for the given parameter indices, linear map function kind, and other
+  /// auxiliary parameters.
+  ///
+  /// Preconditions:
+  /// - Parameters corresponding to parameter indices must conform to
+  ///   `Differentiable`.
+  /// - There is one semantic function result type: either the formal original
+  ///   result or an `inout` parameter. It must conform to `Differentiable`.
+  ///
+  /// Differential typing rules: takes "wrt" parameter derivatives and returns a
+  /// "wrt" result derivative.
+  ///
+  /// - Case 1: no `inout` parameters.
+  ///   - Original:     `(T0, T1, ...) -> R`
+  ///   - Differential: `(T0.Tan, T1.Tan, ...) -> R.Tan`
+  /// - Case 2: original function has a non-wrt `inout` parameter.
+  ///   - Original:     `(T0, inout T1, ...) -> Void`
+  ///   - Differential: `(T0.Tan, ...) -> T1.Tan`
+  /// - Case 3: original function has a wrt `inout` parameter.
+  ///   - Original:     `(T0, inout T1, ...) -> R`
+  ///   - Differential: `(T0.Tan, inout T1.Tan, ...) -> Void`
+  ///
+  /// Pullback typing rules: takes a "wrt" result derivative and returns "wrt"
+  /// parameter derivatives.
+  ///
+  /// - Case 1: original function has no `inout` parameters.
+  ///   - Original: `(T0, T1, ...) -> R`
+  ///   - Pullback: `R.Tan -> (T0.Tan, T1.Tan, ...)`
+  /// - Case 2: original function has a non-wrt `inout` parameter.
+  ///   - Original: `(T0, inout T1, ...) -> Void`
+  ///   - Pullback: `(T1.Tan) -> (T0.Tan, ...)`
+  /// - Case 3: original function has a wrt `inout` parameter.
+  ///   - Original: `(T0, inout T1, ...) -> R`
+  ///   - Pullback: `(inout T1.Tan) -> (T0.Tan, ...)`
+  ///
+  /// If `makeSelfParamFirst` is true, `self`'s tangent is reordered to appear
+  /// first. `makeSelfParamFirst` should be true when working with user-facing
+  /// derivative function types, e.g. when type-checking `@differentiable` and
+  /// `@derivative` attributes.
+  AnyFunctionType *getAutoDiffReturnedLinearMapFunctionType(
+      IndexSubset *parameterIndices, AutoDiffLinearMapKind kind,
+      LookupConformanceFn lookupConformance, bool makeSelfParamFirst = false);
+
   // SWIFT_ENABLE_TENSORFLOW
   AnyFunctionType *getWithoutDifferentiability() const;
+  // SWIFT_ENABLE_TENSORFLOW END
 
   /// True if the parameter declaration it is attached to is guaranteed
   /// to not persist the closure for longer than the duration of the call.
@@ -4419,6 +4478,28 @@ public:
     return getParameters().back();
   }
 
+  struct IndirectMutatingParameterFilter {
+    bool operator()(SILParameterInfo param) const {
+      return param.isIndirectMutating();
+    }
+  };
+  using IndirectMutatingParameterIter =
+      llvm::filter_iterator<const SILParameterInfo *,
+                            IndirectMutatingParameterFilter>;
+  using IndirectMutatingParameterRange =
+      iterator_range<IndirectMutatingParameterIter>;
+
+  /// A range of SILParameterInfo for all indirect mutating parameters.
+  IndirectMutatingParameterRange getIndirectMutatingParameters() const {
+    return llvm::make_filter_range(getParameters(),
+                                   IndirectMutatingParameterFilter());
+  }
+
+  /// Returns the number of indirect mutating parameters.
+  unsigned getNumIndirectMutatingParameters() const {
+    return llvm::count_if(getParameters(), IndirectMutatingParameterFilter());
+  }
+
   /// Get the generic signature used to apply the substitutions of a substituted function type
   CanGenericSignature getSubstGenericSignature() const {
     return GenericSigAndIsImplied.getPointer();
@@ -4487,18 +4568,27 @@ public:
   /// - Returns original results, followed by a differential function, which
   ///   takes "wrt" parameter derivatives and returns a "wrt" result derivative.
   ///
+  /// \verbatim
   ///     $(T0, ...) -> (R0, ...,  (T0.Tan, T1.Tan, ...) -> R0.Tan)
   ///                    ^~~~~~~    ^~~~~~~~~~~~~~~~~~~     ^~~~~~
   ///          original results | derivatives wrt params | derivative wrt result
+  /// \endverbatim
   ///
   /// VJP derivative type:
   /// - Takes original parameters.
   /// - Returns original results, followed by a pullback function, which
   ///   takes a "wrt" result derivative and returns "wrt" parameter derivatives.
   ///
+  /// \verbatim
   ///     $(T0, ...) -> (R0, ...,       (R0.Tan)  ->     (T0.Tan, T1.Tan, ...))
   ///                    ^~~~~~~         ^~~~~~            ^~~~~~~~~~~~~~~~~~~
   ///          original results | derivative wrt result | derivatives wrt params
+  /// \endverbatim
+  ///
+  /// The original type may have `inout` parameters. If so, the
+  /// differential/pullback typing rules are more nuanced: see documentation for
+  /// `getAutoDiffReturnedLinearMapFunctionType` for details. Semantically,
+  /// `inout` parameters behave as both parameters and results.
   ///
   /// A "constrained derivative generic signature" is computed from
   /// `derivativeFunctionGenericSignature`, if specified. Otherwise, it is

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -13,6 +13,8 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/AutoDiff.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/Module.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/Types.h"
 
@@ -50,13 +52,11 @@ static unsigned countNumFlattenedElementTypes(Type type) {
 }
 
 // TODO(TF-874): Simplify this helper and remove the `reverseCurryLevels` flag.
-// See TF-874 for WIP.
-void autodiff::getSubsetParameterTypes(IndexSubset *subset,
-                                       AnyFunctionType *type,
-                                       SmallVectorImpl<Type> &results,
-                                       bool reverseCurryLevels) {
+void AnyFunctionType::getSubsetParameters(
+    IndexSubset *parameterIndices,
+    SmallVectorImpl<AnyFunctionType::Param> &results, bool reverseCurryLevels) {
   SmallVector<AnyFunctionType *, 2> curryLevels;
-  unwrapCurryLevels(type, curryLevels);
+  unwrapCurryLevels(this, curryLevels);
 
   SmallVector<unsigned, 2> curryLevelParameterIndexOffsets(curryLevels.size());
   unsigned currentOffset = 0;
@@ -77,9 +77,53 @@ void autodiff::getSubsetParameterTypes(IndexSubset *subset,
     unsigned parameterIndexOffset =
         curryLevelParameterIndexOffsets[curryLevelIndex];
     for (unsigned paramIndex : range(curryLevel->getNumParams()))
-      if (subset->contains(parameterIndexOffset + paramIndex))
-        results.push_back(curryLevel->getParams()[paramIndex].getOldType());
+      if (parameterIndices->contains(parameterIndexOffset + paramIndex))
+        results.push_back(curryLevel->getParams()[paramIndex]);
   }
+}
+
+SemanticFunctionResultType autodiff::getOriginalFunctionSemanticResultType(
+    AnyFunctionType *functionType, Type originalFormalResultType,
+    bool &hasMultipleOriginalSemanticResults,
+    GenericEnvironment *derivativeGenEnv) {
+  auto &ctx = functionType->getASTContext();
+  hasMultipleOriginalSemanticResults = false;
+
+  // Initialize original semantic result type as the original formal result
+  // type, unless it is `Void`.
+  Type originalResultType;
+  bool isOriginalResultInout = false;
+  if (!originalFormalResultType->isEqual(ctx.TheEmptyTupleType))
+    originalResultType = originalFormalResultType;
+
+  auto setOriginalSemanticResultType = [&](Type type) {
+    // If original semantic result type has already been set, unset it and set
+    // `hasMultipleOriginalSemanticResults` to true.
+    if (originalResultType) {
+      hasMultipleOriginalSemanticResults = true;
+      originalResultType = Type();
+      return;
+    }
+    originalResultType = type;
+    isOriginalResultInout = true;
+  };
+
+  // Check for `inout` parameters.
+  for (auto param : functionType->getParams())
+    if (param.isInOut())
+      setOriginalSemanticResultType(param.getPlainType());
+  if (auto *resultFunctionType =
+          functionType->getResult()->getAs<AnyFunctionType>()) {
+    for (auto param : resultFunctionType->getParams())
+      if (param.isInOut())
+        setOriginalSemanticResultType(param.getPlainType());
+  }
+
+  // Map original semantic result type into derivative generic environment.
+  if (originalResultType && derivativeGenEnv)
+    originalResultType =
+        derivativeGenEnv->mapTypeIntoContext(originalResultType);
+  return {originalResultType, isOriginalResultInout};
 }
 
 GenericSignature autodiff::getConstrainedDerivativeGenericSignature(

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1035,7 +1035,7 @@ static ValueDecl *getAutoDiffApplyDerivativeFunction(
   BuiltinFunctionBuilder::LambdaGenerator resultGen{
       [=, &Context](BuiltinFunctionBuilder &builder) -> Type {
         auto derivativeFnTy = diffFnType->getAutoDiffDerivativeFunctionType(
-            paramIndices, /*resultIndex*/ 0, kind,
+            paramIndices, kind,
             LookUpConformanceInModule(Context.TheBuiltinModule));
         return derivativeFnTy->getResult();
       }};

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4931,9 +4931,9 @@ makeFunctionType(ArrayRef<AnyFunctionType::Param> parameters, Type resultType,
 }
 
 AnyFunctionType *AnyFunctionType::getAutoDiffDerivativeFunctionType(
-    IndexSubset *parameterIndices, unsigned resultIndex,
-    AutoDiffDerivativeFunctionKind kind, LookupConformanceFn lookupConformance,
-    GenericSignature derivativeGenSig, bool makeSelfParamFirst) {
+    IndexSubset *parameterIndices, AutoDiffDerivativeFunctionKind kind,
+    LookupConformanceFn lookupConformance, GenericSignature derivativeGenSig,
+    bool makeSelfParamFirst) {
   assert(!parameterIndices->isEmpty() &&
          "Expected at least one differentiability parameter");
   auto &ctx = getASTContext();
@@ -4942,11 +4942,6 @@ AnyFunctionType *AnyFunctionType::getAutoDiffDerivativeFunctionType(
   // generic signature.
   if (!derivativeGenSig)
     derivativeGenSig = getOptGenericSignature();
-
-  // Get differentiability parameter types.
-  SmallVector<Type, 8> diffParamTypes;
-  autodiff::getSubsetParameterTypes(parameterIndices, this, diffParamTypes,
-                                    /*reverseCurryLevels*/ !makeSelfParamFirst);
 
   // Unwrap curry levels. At most, two parameter lists are necessary, for
   // curried method types with a `(Self)` parameter list.
@@ -4961,65 +4956,11 @@ AnyFunctionType *AnyFunctionType::getAutoDiffDerivativeFunctionType(
     currentLevel = currentLevel->getResult()->getAs<AnyFunctionType>();
   }
 
-  Type originalResult = curryLevels.back()->getResult();
+  auto originalResult = curryLevels.back()->getResult();
 
-  // Build the result linear map function type.
-  Type linearMapType;
-  switch (kind) {
-  case AutoDiffDerivativeFunctionKind::JVP: {
-    // Differential function type, a result of the JVP:
-    //   `LinearMapType = (T.TangentVector, ...) -> (R.TangentVector)`
-    SmallVector<AnyFunctionType::Param, 8> differentialParams;
-    for (auto diffParamType : diffParamTypes)
-      differentialParams.push_back(AnyFunctionType::Param(
-          diffParamType->getAutoDiffTangentSpace(lookupConformance)
-              ->getType()));
-    SmallVector<TupleTypeElt, 8> differentialResults;
-    if (auto *resultTuple = originalResult->getAs<TupleType>()) {
-      auto resultTupleEltType = resultTuple->getElementType(resultIndex);
-      differentialResults.push_back(
-          resultTupleEltType->getAutoDiffTangentSpace(lookupConformance)
-              ->getType());
-    } else {
-      assert(resultIndex == 0 && "resultIndex out of bounds");
-      differentialResults.push_back(
-          originalResult->getAutoDiffTangentSpace(lookupConformance)
-              ->getType());
-    }
-    Type differentialResult = differentialResults.size() > 1
-                                  ? TupleType::get(differentialResults, ctx)
-                                  : differentialResults[0].getType();
-    linearMapType = FunctionType::get(differentialParams, differentialResult);
-    break;
-  }
-  case AutoDiffDerivativeFunctionKind::VJP: {
-    // Pullback function type, a result of the VJP:
-    //   `LinearMapType = (R.TangentVector) -> (T.TangentVector, ...)`
-    SmallVector<AnyFunctionType::Param, 8> pullbackParams;
-    if (auto *resultTuple = originalResult->getAs<TupleType>()) {
-      auto resultTupleEltType = resultTuple->getElementType(resultIndex);
-      pullbackParams.push_back(AnyFunctionType::Param(
-          resultTupleEltType->getAutoDiffTangentSpace(lookupConformance)
-              ->getType()));
-    } else {
-      assert(resultIndex == 0 &&
-             "Expected result index 0 for non-tuple result");
-      pullbackParams.push_back(AnyFunctionType::Param(
-          originalResult->getAutoDiffTangentSpace(lookupConformance)
-              ->getType()));
-    }
-    SmallVector<TupleTypeElt, 8> pullbackResults;
-    for (auto diffParamType : diffParamTypes)
-      pullbackResults.push_back(
-          diffParamType->getAutoDiffTangentSpace(lookupConformance)->getType());
-    Type pullbackResult = pullbackResults.size() > 1
-                              ? TupleType::get(pullbackResults, ctx)
-                              : pullbackResults[0].getType();
-    linearMapType = FunctionType::get(pullbackParams, pullbackResult);
-    break;
-  }
-  }
-  assert(linearMapType && "Expected linear map type");
+  Type linearMapType = getAutoDiffReturnedLinearMapFunctionType(
+      parameterIndices, kind.getLinearMapKind(), lookupConformance,
+      makeSelfParamFirst);
 
   // Build the full derivative function type: `(T...) -> (R, LinearMapType)`.
   SmallVector<TupleTypeElt, 2> retElts;
@@ -5044,6 +4985,112 @@ AnyFunctionType *AnyFunctionType::getAutoDiffDerivativeFunctionType(
   }
 
   return derivativeFunctionType;
+}
+
+AnyFunctionType *AnyFunctionType::getAutoDiffReturnedLinearMapFunctionType(
+    IndexSubset *parameterIndices, AutoDiffLinearMapKind kind,
+    LookupConformanceFn lookupConformance, bool makeSelfParamFirst) {
+  assert(!parameterIndices->isEmpty() &&
+         "Expected at least one differentiability parameter");
+  auto &ctx = getASTContext();
+
+  // Get differentiability parameters.
+  SmallVector<AnyFunctionType::Param, 8> diffParams;
+  getSubsetParameters(parameterIndices, diffParams,
+                      /*reverseCurryLevels*/ !makeSelfParamFirst);
+
+  // Get the original semantic result type.
+  auto originalFormalResult = getResult();
+  if (auto *resultFunctionType = originalFormalResult->getAs<AnyFunctionType>())
+    originalFormalResult = resultFunctionType->getResult();
+  bool hasMultipleOriginalSemanticResults = false;
+  auto originalResult = autodiff::getOriginalFunctionSemanticResultType(
+      this, originalFormalResult, hasMultipleOriginalSemanticResults);
+  auto originalResultType = originalResult.type;
+
+  // Get the original semantic result type's `TangentVector` associated type.
+  auto resultTan =
+      originalResultType->getAutoDiffTangentSpace(lookupConformance);
+  assert(resultTan && "Original result has no tangent space?");
+  auto resultTanType = resultTan->getType();
+
+  // Compute the result linear map function type.
+  FunctionType *linearMapType;
+  switch (kind) {
+  case AutoDiffLinearMapKind::Differential: {
+    // Compute the differential type, returned by JVP functions.
+    //
+    // Case 1: no `inout` parameters.
+    // - Original:     `(T0, T1, ...) -> R`
+    // - Differential: `(T0.Tan, T1.Tan, ...) -> R.Tan`
+    //
+    // Case 2: original function has a non-wrt `inout` parameter.
+    // - Original:      `(T0, inout T1, ...) -> Void`
+    // - Differential: `(T0.Tan, ...) -> T1.Tan`
+    //
+    // Case 3: original function has a wrt `inout` parameter.
+    // - Original:     `(T0, inout T1, ...) -> R`
+    // - Differential: `(T0.Tan, inout T1.Tan, ...) -> Void`
+    SmallVector<AnyFunctionType::Param, 4> differentialParams;
+    bool hasInoutDiffParameter = false;
+    for (auto diffParam : diffParams) {
+      auto paramType = diffParam.getPlainType();
+      auto paramTan = paramType->getAutoDiffTangentSpace(lookupConformance);
+      assert(paramTan && "Parameter has no tangent space?");
+      differentialParams.push_back(AnyFunctionType::Param(
+          paramTan->getType(), Identifier(), diffParam.getParameterFlags()));
+      if (diffParam.isInOut())
+        hasInoutDiffParameter = true;
+    }
+    auto differentialResult =
+        hasInoutDiffParameter ? Type(ctx.TheEmptyTupleType) : resultTanType;
+    linearMapType = FunctionType::get(differentialParams, differentialResult);
+    break;
+  }
+  case AutoDiffLinearMapKind::Pullback: {
+    // Compute the pullback type, returned by VJP functions.
+    //
+    // Case 1: original function has no `inout` parameters.
+    // - Original: `(T0, T1, ...) -> R`
+    // - Pullback: `R.Tan -> (T0.Tan, T1.Tan, ...)`
+    //
+    // Case 2: original function has a non-wrt `inout` parameter.
+    // - Original: `(T0, inout T1, ...) -> Void`
+    // - Pullback: `(T1.Tan) -> (T0.Tan, ...)`
+    //
+    // Case 3: original function has a wrt `inout` parameter.
+    // - Original: `(T0, inout T1, ...) -> R`
+    // - Pullback: `(inout T1.Tan) -> (T0.Tan, ...)`
+    SmallVector<TupleTypeElt, 4> pullbackResults;
+    bool hasInoutDiffParameter = false;
+    for (auto diffParam : diffParams) {
+      auto paramType = diffParam.getPlainType();
+      auto paramTan = paramType->getAutoDiffTangentSpace(lookupConformance);
+      assert(paramTan && "Parameter has no tangent space?");
+      if (diffParam.isInOut()) {
+        hasInoutDiffParameter = true;
+        continue;
+      }
+      pullbackResults.push_back(TupleTypeElt(paramTan->getType(), Identifier(),
+                                             diffParam.getParameterFlags()));
+    }
+    Type pullbackResult;
+    if (pullbackResults.empty()) {
+      pullbackResult = ctx.TheEmptyTupleType;
+    } else if (pullbackResults.size() == 1) {
+      pullbackResult = pullbackResults.front().getType();
+    } else {
+      pullbackResult = TupleType::get(pullbackResults, ctx);
+    }
+    auto flags = ParameterTypeFlags().withInOut(hasInoutDiffParameter);
+    auto pullbackParam =
+        AnyFunctionType::Param(resultTanType, Identifier(), flags);
+    linearMapType = FunctionType::get({pullbackParam}, pullbackResult);
+    break;
+  }
+  }
+  assert(linearMapType && "Expected linear map type");
+  return linearMapType;
 }
 
 CanSILFunctionType

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -231,11 +231,11 @@ CanSILFunctionType SILFunctionType::getAutoDiffDerivativeFunctionType(
     LookupConformanceFn lookupConformance,
     CanGenericSignature derivativeFnGenSig, bool isReabstractionThunk) {
   auto &ctx = getASTContext();
+  auto *resultIndices = IndexSubset::get(
+      ctx, getNumResults() + getNumIndirectMutatingParameters(), {resultIndex});
   SILAutoDiffDerivativeFunctionKey key{
-    this, parameterIndices,
-    IndexSubset::get(ctx, getNumResults(), {resultIndex}),
-    kind, derivativeFnGenSig, isReabstractionThunk
-  };
+      this, parameterIndices,   resultIndices,
+      kind, derivativeFnGenSig, isReabstractionThunk};
   auto insertion =
       ctx.SILAutoDiffDerivativeFunctions.try_emplace(key, CanSILFunctionType());
   auto &cachedResult = insertion.first->getSecond();

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -319,6 +319,24 @@ CanSILFunctionType SILFunctionType::getAutoDiffDerivativeFunctionType(
     return {tanType, conv};
   };
 
+  // Compute the original semantic results: they are the original formal
+  // results, followed by non-wrt `inout` parameters in type order.
+  SmallVector<SILResultInfo, 2> originalResults;
+  originalResults.append(getResults().begin(), getResults().end());
+  Optional<SILParameterInfo> inoutParam = None;
+  bool isWrtInoutParameter = false;
+  for (auto i : range(getNumParameters())) {
+    auto param = getParameters()[i];
+    if (!param.isIndirectInOut())
+      continue;
+    inoutParam = param;
+    isWrtInoutParameter = parameterIndices->contains(i);
+    // Non-wrt `inout` parameters are
+    if (!isWrtInoutParameter)
+      originalResults.push_back(
+          SILResultInfo(param.getInterfaceType(), ResultConvention::Indirect));
+  }
+
   CanSILFunctionType closureType;
   switch (kind) {
   case AutoDiffDerivativeFunctionKind::JVP: {
@@ -331,14 +349,15 @@ CanSILFunctionType SILFunctionType::getAutoDiffDerivativeFunctionType(
       differentialParams.push_back(
           {paramTan->getCanonicalType(), param.getConvention()});
     }
-    SmallVector<SILResultInfo, 8> differentialResults;
-    auto &result = getResults()[resultIndex];
-    auto resultTan =
-        result.getInterfaceType()->getAutoDiffTangentSpace(
-            lookupConformance);
-    assert(resultTan && "Result type does not have a tangent space?");
-    differentialResults.push_back(
-        {resultTan->getCanonicalType(), result.getConvention()});
+    SmallVector<SILResultInfo, 1> differentialResults;
+    if (!inoutParam || !isWrtInoutParameter) {
+      auto &result = originalResults[resultIndex];
+      auto resultTan =
+          result.getInterfaceType()->getAutoDiffTangentSpace(lookupConformance);
+      assert(resultTan && "Result type does not have a tangent space?");
+      differentialResults.push_back(
+          {resultTan->getCanonicalType(), result.getConvention()});
+    }
     closureType = SILFunctionType::get(
         /*genericSignature*/ nullptr, ExtInfo(), SILCoroutineKind::None,
         ParameterConvention::Direct_Guaranteed, differentialParams, {},
@@ -347,17 +366,28 @@ CanSILFunctionType SILFunctionType::getAutoDiffDerivativeFunctionType(
     break;
   }
   case AutoDiffDerivativeFunctionKind::VJP: {
-    SmallVector<SILParameterInfo, 8> pullbackParams;
-    auto &origRes = getResults()[resultIndex];
-    auto resultTan =
-        origRes.getInterfaceType()->getAutoDiffTangentSpace(
-            lookupConformance);
-    assert(resultTan && "Result type does not have a tangent space?");
-    pullbackParams.push_back(
-        getTangentParameterInfoForOriginalResult(resultTan->getCanonicalType(),
-                                                 origRes.getConvention()));
+    SmallVector<SILParameterInfo, 1> pullbackParams;
+    if (inoutParam) {
+      auto paramTan = inoutParam->getInterfaceType()->getAutoDiffTangentSpace(
+          lookupConformance);
+      assert(paramTan && "Parameter type does not have a tangent space?");
+      auto paramTanConvention =
+          isWrtInoutParameter ? inoutParam->getConvention()
+                              : ParameterConvention::Indirect_In_Guaranteed;
+      pullbackParams.push_back(
+          SILParameterInfo(paramTan->getCanonicalType(), paramTanConvention));
+    } else {
+      auto &origRes = originalResults[resultIndex];
+      auto resultTan = origRes.getInterfaceType()->getAutoDiffTangentSpace(
+          lookupConformance);
+      assert(resultTan && "Result type does not have a tangent space?");
+      pullbackParams.push_back(getTangentParameterInfoForOriginalResult(
+          resultTan->getCanonicalType(), origRes.getConvention()));
+    }
     SmallVector<SILResultInfo, 8> pullbackResults;
     for (auto &param : diffParams) {
+      if (param.isIndirectInOut())
+        continue;
       auto paramTan =
           param.getInterfaceType()->getAutoDiffTangentSpace(
               lookupConformance);

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -2181,10 +2181,11 @@ CanAnyFunctionType TypeConverter::makeConstantInterfaceType(SILDeclRef c) {
     auto originalFnTy =
         makeConstantInterfaceType(c.asAutoDiffOriginalFunction());
     auto *fnTy = originalFnTy->getAutoDiffDerivativeFunctionType(
-        autoDiffFuncId->getParameterIndices(), /*resultIndex*/ 0,
-        autoDiffFuncId->getKind(), LookUpConformanceInModule(&M));
+        autoDiffFuncId->getParameterIndices(), autoDiffFuncId->getKind(),
+        LookUpConformanceInModule(&M));
     return cast<AnyFunctionType>(fnTy->getCanonicalType());
   }
+  // SWIFT_ENABLE_TENSORFLOW END
 
   auto *vd = c.loc.dyn_cast<ValueDecl *>();
   switch (c.kind) {

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3345,8 +3345,8 @@ static ManagedValue createAutoDiffThunk(SILGenFunction &SGF,
       [&](CanAnyFunctionType fnTy, AutoDiffDerivativeFunctionKind kind)
           -> CanAnyFunctionType {
         auto assocTy = fnTy->getAutoDiffDerivativeFunctionType(
-            parameterIndices, /*resultIndex*/ 0,
-            kind, LookUpConformanceInModule(SGF.SGM.M.getSwiftModule()));
+            parameterIndices, kind,
+            LookUpConformanceInModule(SGF.SGM.M.getSwiftModule()));
         return cast<AnyFunctionType>(assocTy->getCanonicalType());
       };
   auto getDerivativeFnPattern =
@@ -3730,9 +3730,8 @@ SILFunction *SILGenModule::getOrCreateCustomDerivativeThunk(
   if (auto derivativeGenSig = config.derivativeGenericSignature)
     derivativeCanGenSig = derivativeGenSig->getCanonicalSignature();
   auto thunkFnTy = origFnTy->getAutoDiffDerivativeFunctionType(
-      indices.parameters, indices.source,
-      kind, Types, LookUpConformanceInModule(M.getSwiftModule()),
-      derivativeCanGenSig);
+      indices.parameters, indices.source, kind, Types,
+      LookUpConformanceInModule(M.getSwiftModule()), derivativeCanGenSig);
   assert(!thunkFnTy->getExtInfo().hasContext());
 
   // TODO(TF-685): Use principled thunk mangling.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3170,20 +3170,12 @@ static bool checkDifferentiabilityParameters(
   }
 
   // Check that differentiability parameters have allowed types.
-  SmallVector<Type, 4> diffParamTypes;
-  autodiff::getSubsetParameterTypes(diffParamIndices, functionType,
-                                    diffParamTypes);
-  for (unsigned i : range(diffParamTypes.size())) {
+  SmallVector<AnyFunctionType::Param, 4> diffParams;
+  functionType->getSubsetParameters(diffParamIndices, diffParams);
+  for (unsigned i : range(diffParams.size())) {
     SourceLoc loc =
         parsedDiffParams.empty() ? attrLoc : parsedDiffParams[i].getLoc();
-    auto diffParamType = diffParamTypes[i];
-    // `inout` parameters are not yet supported.
-    if (diffParamType->is<InOutType>()) {
-      diags.diagnose(loc,
-                     diag::diff_params_clause_cannot_diff_wrt_inout_parameter,
-                     diffParamType);
-      return true;
-    }
+    auto diffParamType = diffParams[i].getPlainType();
     if (!diffParamType->hasTypeParameter())
       diffParamType = diffParamType->mapTypeOutOfContext();
     if (derivativeGenEnv)
@@ -3341,7 +3333,7 @@ static bool checkFunctionSignature(
   if (!std::equal(required->getParams().begin(), required->getParams().end(),
                   candidateFnTy->getParams().begin(),
                   [&](AnyFunctionType::Param x, AnyFunctionType::Param y) {
-                    return x.getPlainType()->isEqual(mapType(y.getPlainType()));
+                    return x.getOldType()->isEqual(mapType(y.getOldType()));
                   }))
     return false;
 
@@ -3868,9 +3860,8 @@ bool resolveDifferentiableAttrDerivativeFunctions(
   // Resolve the JVP function, if it is specified and exists.
   if (attr->getJVP()) {
     auto *expectedJVPFnTy = originalFnTy->getAutoDiffDerivativeFunctionType(
-        resolvedDiffParamIndices, /*resultIndex*/ 0,
-        AutoDiffDerivativeFunctionKind::JVP, lookupConformance,
-        derivativeGenSig, /*makeSelfParamFirst*/ true);
+        resolvedDiffParamIndices, AutoDiffDerivativeFunctionKind::JVP,
+        lookupConformance, derivativeGenSig, /*makeSelfParamFirst*/ true);
     auto isValidJVP = [&](AbstractFunctionDecl *jvpCandidate) -> bool {
       return checkFunctionSignature(
           cast<AnyFunctionType>(expectedJVPFnTy->getCanonicalType()),
@@ -3889,9 +3880,8 @@ bool resolveDifferentiableAttrDerivativeFunctions(
   // Resolve the VJP function, if it is specified and exists.
   if (attr->getVJP()) {
     auto *expectedVJPFnTy = originalFnTy->getAutoDiffDerivativeFunctionType(
-        resolvedDiffParamIndices, /*resultIndex*/ 0,
-        AutoDiffDerivativeFunctionKind::VJP, lookupConformance,
-        derivativeGenSig, /*makeSelfParamFirst*/ true);
+        resolvedDiffParamIndices, AutoDiffDerivativeFunctionKind::VJP,
+        lookupConformance, derivativeGenSig, /*makeSelfParamFirst*/ true);
     auto isValidVJP = [&](AbstractFunctionDecl *vjpCandidate) -> bool {
       return checkFunctionSignature(
           cast<AnyFunctionType>(expectedVJPFnTy->getCanonicalType()),
@@ -3960,20 +3950,6 @@ llvm::Expected<IndexSubset *> DifferentiableAttributeTypeCheckRequest::evaluate(
   auto *originalFnTy = original->getInterfaceType()->castTo<AnyFunctionType>();
   bool isMethod = original->hasImplicitSelfDecl();
 
-  // If the original function returns the empty tuple type, there is no output
-  // to differentiate from.
-  auto originalResultTy = originalFnTy->getResult();
-  if (isMethod)
-    originalResultTy = originalResultTy->castTo<AnyFunctionType>()->getResult();
-  if (originalResultTy->isEqual(ctx.TheEmptyTupleType)) {
-    diags
-        .diagnose(attr->getLocation(), diag::differentiable_attr_void_result,
-                  original->getFullName())
-        .highlight(original->getSourceRange());
-    attr->setInvalid();
-    return nullptr;
-  }
-
   // Diagnose if original function is an invalid class member.
   bool isOriginalClassMember = original->getDeclContext() &&
                                original->getDeclContext()->getSelfClassDecl();
@@ -4031,11 +4007,36 @@ llvm::Expected<IndexSubset *> DifferentiableAttributeTypeCheckRequest::evaluate(
           resolvedDiffParamIndices))
     return nullptr;
 
-  // Check that original function's result type conforms to `Differentiable`.
-  if (derivativeGenEnv)
-    originalResultTy = derivativeGenEnv->mapTypeIntoContext(originalResultTy);
-  else
-    originalResultTy = original->mapTypeIntoContext(originalResultTy);
+  // Get the original semantic result type.
+  auto originalFormalResultTy = originalFnTy->getResult();
+  if (isMethod)
+    originalFormalResultTy =
+        originalFormalResultTy->castTo<AnyFunctionType>()->getResult();
+  bool hasMultipleOriginalSemanticResults = false;
+  auto originalResult = autodiff::getOriginalFunctionSemanticResultType(
+      originalFnTy, originalFormalResultTy, hasMultipleOriginalSemanticResults,
+      derivativeGenEnv);
+  auto originalResultTy = originalResult.type;
+  // Check that original function does not have multiple semantic results.
+  if (hasMultipleOriginalSemanticResults) {
+    diags
+        .diagnose(attr->getLocation(),
+                  diag::autodiff_attr_original_multiple_semantic_results)
+        .highlight(original->getSourceRange());
+    attr->setInvalid();
+    return nullptr;
+  }
+  // Check that original function has at least one semantic result, i.e.
+  // that the original semantic result type is not `Void`.
+  if (!originalResultTy) {
+    diags
+        .diagnose(attr->getLocation(), diag::autodiff_attr_original_void_result,
+                  original->getFullName())
+        .highlight(original->getSourceRange());
+    attr->setInvalid();
+    return nullptr;
+  }
+  // Check that the original semantic result conforms to `Differentiable`.
   if (!conformsToDifferentiable(originalResultTy, original)) {
     diags.diagnose(attr->getLocation(),
                    diag::differentiable_attr_result_not_differentiable,
@@ -4356,28 +4357,42 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
   // Set the resolved differentiability parameter indices in the attribute.
   attr->setParameterIndices(resolvedDiffParamIndices);
 
-  // Gather differentiability parameters.
-  SmallVector<Type, 4> diffParamTypes;
-  autodiff::getSubsetParameterTypes(resolvedDiffParamIndices, originalFnType,
-                                    diffParamTypes);
-
-  // Get the differentiability parameters' `TangentVector` associated types.
-  auto diffParamTanTypes =
-      map<SmallVector<TupleTypeElt, 4>>(diffParamTypes, [&](Type paramType) {
-        if (paramType->hasTypeParameter())
-          paramType = derivative->mapTypeIntoContext(paramType);
-        auto conf = TypeChecker::conformsToProtocol(paramType, diffableProto,
-                                                    derivative, None);
-        assert(conf &&
-               "Expected resolved parameter to conform to `Differentiable`");
-        auto paramAssocType =
-            conf.getTypeWitnessByName(paramType, Ctx.Id_TangentVector);
-        return TupleTypeElt(paramAssocType);
-      });
-
-  // Get the `TangentVector` associated type of the `value:` result type.
-  auto resultTanType = valueResultConf.getTypeWitnessByName(
-      valueResultType, Ctx.Id_TangentVector);
+  // Get the original semantic result.
+  bool hasMultipleOriginalSemanticResults = false;
+  auto originalResult = autodiff::getOriginalFunctionSemanticResultType(
+      originalFnType, valueResultElt.getType(),
+      hasMultipleOriginalSemanticResults,
+      derivative->getGenericEnvironmentOfContext());
+  auto originalResultType = originalResult.type;
+  // Check that original function does not have multiple semantic results.
+  if (hasMultipleOriginalSemanticResults) {
+    diags
+        .diagnose(attr->getLocation(),
+                  diag::autodiff_attr_original_multiple_semantic_results)
+        .highlight(attr->getOriginalFunctionName().Loc.getSourceRange());
+    attr->setInvalid();
+    return true;
+  }
+  // Check that original function has at least one semantic result, i.e.
+  // that the original semantic result type is not `Void`.
+  if (!originalResultType) {
+    diags
+        .diagnose(attr->getLocation(), diag::autodiff_attr_original_void_result,
+                  derivative->getFullName())
+        .highlight(attr->getOriginalFunctionName().Loc.getSourceRange());
+    attr->setInvalid();
+    return true;
+  }
+  // Check that the original semantic result conforms to `Differentiable`.
+  auto *diffableProto = Ctx.getProtocol(KnownProtocolKind::Differentiable);
+  auto valueResultConf = TypeChecker::conformsToProtocol(
+      originalResultType, diffableProto, derivative->getDeclContext(), None);
+  if (!valueResultConf) {
+    diags.diagnose(attr->getLocation(),
+                   diag::derivative_attr_result_value_not_differentiable,
+                   valueResultElt.getType());
+    return true;
+  }
 
   // Compute the actual differential/pullback type that we use for comparison
   // with the expected type. We must canonicalize the derivative interface type
@@ -4393,19 +4408,14 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
       cast<TupleType>(canActualResultType).getElementType(1);
 
   // Compute expected differential/pullback type.
-  Type expectedFuncEltType;
-  if (kind == AutoDiffDerivativeFunctionKind::JVP) {
-    auto diffParams = map<SmallVector<AnyFunctionType::Param, 4>>(
-        diffParamTanTypes, [&](TupleTypeElt elt) {
-          return AnyFunctionType::Param(elt.getType());
-        });
-    expectedFuncEltType = FunctionType::get(diffParams, resultTanType);
-  } else {
-    expectedFuncEltType =
-        FunctionType::get({AnyFunctionType::Param(resultTanType)},
-                          TupleType::get(diffParamTanTypes, Ctx));
-  }
-  expectedFuncEltType = expectedFuncEltType->mapTypeOutOfContext();
+  Type expectedFuncEltType =
+      originalFnType->getAutoDiffReturnedLinearMapFunctionType(
+          resolvedDiffParamIndices, kind.getLinearMapKind(), lookupConformance,
+          /*makeSelfParamFirst*/ true);
+  if (expectedFuncEltType->hasTypeParameter())
+    expectedFuncEltType = derivative->mapTypeIntoContext(expectedFuncEltType);
+  if (expectedFuncEltType->hasArchetype())
+    expectedFuncEltType = expectedFuncEltType->mapTypeOutOfContext();
 
   // Check if differential/pullback type matches expected type.
   if (!actualFuncEltType->isEqual(expectedFuncEltType)) {

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -3566,10 +3566,13 @@ SILDeserializer::readDifferentiabilityWitness(DeclID DId) {
       MF->getContext(), original->getLoweredFunctionType()->getNumParameters(),
       ArrayRef<unsigned>(parameterAndResultIndices)
           .take_front(numParameterIndices));
-  auto *resultIndices = IndexSubset::get(
-      MF->getContext(), original->getLoweredFunctionType()->getNumResults(),
-      ArrayRef<unsigned>(parameterAndResultIndices)
-          .take_back(numResultIndices));
+  auto numResults =
+      original->getLoweredFunctionType()->getNumResults() +
+      original->getLoweredFunctionType()->getNumIndirectMutatingParameters();
+  auto *resultIndices =
+      IndexSubset::get(MF->getContext(), numResults,
+                       ArrayRef<unsigned>(parameterAndResultIndices)
+                           .take_back(numResultIndices));
 
   AutoDiffConfig config(parameterIndices, resultIndices, derivativeGenSig);
   auto *diffWitness =

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2544,7 +2544,11 @@ void SILSerializer::writeSILDifferentiabilityWitness(
              dw.getParameterIndices()->getCapacity() &&
          "Original function parameter count should match differentiability "
          "witness parameter indices capacity");
-  assert(originalFnType->getNumResults() ==
+  size_t numInoutArguments = llvm::count_if(
+      originalFnType->getParameters(), [](SILParameterInfo paramInfo) {
+        return paramInfo.isIndirectMutating();
+      });
+  assert(originalFnType->getNumResults() + numInoutArguments ==
              dw.getResultIndices()->getCapacity() &&
          "Original function result count should match differentiability "
          "witness result indices capacity");

--- a/stdlib/public/Differentiation/FloatingPointTypesDerivatives.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointTypesDerivatives.swift.gyb
@@ -61,6 +61,26 @@ extension ${Self} {
 
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
+  @derivative(of: +=)
+  static func _vjpAddAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
+    value: Void, pullback: (inout ${Self}) -> ${Self}
+  ) {
+    lhs += rhs
+    return ((), { v in v })
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  @_transparent
+  @derivative(of: +=)
+  static func _jvpAddAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
+    value: Void, differential: (inout ${Self}, ${Self}) -> Void
+  ) {
+    lhs += rhs
+    return ((), { $0 += $1 })
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  @_transparent
   @derivative(of: -)
   static func _vjpSubtract(
     lhs: ${Self}, rhs: ${Self}
@@ -75,6 +95,26 @@ extension ${Self} {
     lhs: ${Self}, rhs: ${Self}
   ) -> (value: ${Self}, differential: (${Self}, ${Self}) -> ${Self}) {
     return (lhs - rhs, { (dlhs, drhs) in dlhs - drhs })
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  @_transparent
+  @derivative(of: -=)
+  static func _vjpSubtractAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
+    value: Void, pullback: (inout ${Self}) -> ${Self}
+  ) {
+    lhs -= rhs
+    return ((), { v in -v })
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  @_transparent
+  @derivative(of: -=)
+  static func _jvpSubtractAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
+    value: Void, differential: (inout ${Self}, ${Self}) -> Void
+  ) {
+    lhs -= rhs
+    return ((), { $0 -= $1 })
   }
 
   @inlinable // FIXME(sil-serialize-all)
@@ -97,6 +137,30 @@ extension ${Self} {
 
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
+  @derivative(of: *=)
+  static func _vjpMultiplyAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
+    value: Void, pullback: (inout ${Self}) -> ${Self}
+  ) {
+    defer { lhs *= rhs }
+    return ((), { [lhs = lhs] v in
+      let drhs = lhs * v
+      v *= rhs
+      return drhs
+    })
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  @_transparent
+  @derivative(of: *=)
+  static func _jvpMultiplyAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
+    value: Void, differential: (inout ${Self}, ${Self}) -> Void
+  ) {
+    lhs *= rhs
+    return ((), { $0 *= $1 })
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  @_transparent
   @derivative(of: /)
   static func _vjpDivide(
     lhs: ${Self}, rhs: ${Self}
@@ -111,6 +175,30 @@ extension ${Self} {
     lhs: ${Self}, rhs: ${Self}
   ) -> (value: ${Self}, differential: (${Self}, ${Self}) -> ${Self}) {
     return (lhs / rhs, { (dlhs, drhs) in dlhs / rhs - lhs / (rhs * rhs) * drhs })
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  @_transparent
+  @derivative(of: /=)
+  static func _vjpDivideAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
+    value: Void, pullback: (inout ${Self}) -> ${Self}
+  ) {
+    defer { lhs /= rhs }
+    return ((), { [lhs = lhs] v in
+      let drhs = -lhs / (rhs * rhs) * v
+      v /= rhs
+      return drhs
+    })
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  @_transparent
+  @derivative(of: /=)
+  static func _jvpDivideAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
+    value: Void, differential: (inout ${Self}, ${Self}) -> Void
+  ) {
+    lhs /= rhs
+    return ((), { $0 /= $1 })
   }
 }
 

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -91,7 +91,7 @@ func vjpResultIncorrectFirstLabel(x: Float) -> (Float, (Float) -> Float) {
 func vjpResultIncorrectSecondLabel(x: Float) -> (value: Float, (Float) -> Float) {
   return (x, { $0 })
 }
-// expected-error @+1 {{'@derivative(of:)' attribute requires function to return a two-element tuple (first element type 'Int' must conform to 'Differentiable')}}
+// expected-error @+1 {{could not find function 'incorrectDerivativeType' with expected type '(Int) -> Int'}}
 @derivative(of: incorrectDerivativeType)
 func vjpResultNotDifferentiable(x: Int) -> (
   value: Int, pullback: (Int) -> Int

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -3,6 +3,14 @@
 
 import _Differentiation
 
+// Dummy `Differentiable`-conforming type.
+struct DummyTangentVector: Differentiable & AdditiveArithmetic {
+  static var zero: Self { Self() }
+  static func + (_: Self, _: Self) -> Self { Self() }
+  static func - (_: Self, _: Self) -> Self { Self() }
+  typealias TangentVector = Self
+}
+
 // Test top-level functions.
 
 func id(_ x: Float) -> Float {
@@ -91,7 +99,7 @@ func vjpResultNotDifferentiable(x: Int) -> (
   return (x, { $0 })
 }
 // expected-error @+2 {{function result's 'pullback' type does not match 'incorrectDerivativeType'}}
-// expected-note @+3 {{'pullback' does not have expected type '(Float.TangentVector) -> (Float.TangentVector)' (aka '(Float) -> Float')}}
+// expected-note @+3 {{'pullback' does not have expected type '(Float.TangentVector) -> Float.TangentVector' (aka '(Float) -> Float')}}
 @derivative(of: incorrectDerivativeType)
 func vjpResultIncorrectPullbackType(x: Float) -> (
   value: Float, pullback: (Double) -> Double
@@ -165,17 +173,6 @@ func vjpFunctionParameter(_ fn: (Float) -> Float) -> (
   value: Float, pullback: (Float) -> Float
 ) {
   return (functionParameter(fn), { $0 })
-}
-
-func inoutParameter(_ x: inout Float) -> Float {
-  return x
-}
-// expected-error @+1 {{cannot differentiate with respect to 'inout' parameter ('inout Float'}}
-@derivative(of: inoutParameter)
-func vjpInoutParameter(x: inout Float) -> (
-  value: Float, pullback: (Float) -> Float
-) {
-  return (inoutParameter(&x), { $0 })
 }
 
 // Test static methods.
@@ -569,6 +566,174 @@ extension ProtocolRequirementDerivative {
   // expected-error @+1 {{could not find function 'requirement' with expected type '<Self where Self : ProtocolRequirementDerivative> (Self) -> (Float) -> Float'}}
   @derivative(of: requirement)
   func vjpRequirement(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+    fatalError()
+  }
+}
+
+// Test `inout` parameters.
+
+func multipleSemanticResults(_ x: inout Float) -> Float {
+  return x
+}
+// expected-error @+1 {{cannot yet differentiate functions with more than one semantic result (formal function result or 'inout' parameter)}}
+@derivative(of: multipleSemanticResults)
+func vjpMultipleSemanticResults(x: inout Float) -> (
+  value: Float, pullback: (Float) -> Float
+) {
+  return (multipleSemanticResults(&x), { $0 })
+}
+
+struct InoutParameters: Differentiable {
+  typealias TangentVector = DummyTangentVector
+  mutating func move(along _: TangentVector) {}
+}
+
+extension InoutParameters {
+  // expected-note @+1 4 {{'staticMethod(_:rhs:)' defined here}}
+  static func staticMethod(_ lhs: inout Self, rhs: Self) {}
+
+  // Test wrt `inout` parameter.
+
+  @derivative(of: staticMethod)
+  static func vjpWrtInout(_ lhs: inout Self, _ rhs: Self) -> (
+    value: Void, pullback: (inout TangentVector) -> TangentVector
+  ) { fatalError() }
+
+  // expected-error @+1 {{function result's 'pullback' type does not match 'staticMethod(_:rhs:)'}}
+  @derivative(of: staticMethod)
+  static func vjpWrtInoutMismatch(_ lhs: inout Self, _ rhs: Self) -> (
+    // expected-note @+1 {{'pullback' does not have expected type '(inout InoutParameters.TangentVector) -> InoutParameters.TangentVector' (aka '(inout DummyTangentVector) -> DummyTangentVector')}}
+    value: Void, pullback: (TangentVector) -> TangentVector
+  ) { fatalError() }
+
+  @derivative(of: staticMethod)
+  static func jvpWrtInout(_ lhs: inout Self, _ rhs: Self) -> (
+    value: Void, differential: (inout TangentVector, TangentVector) -> Void
+  ) { fatalError() }
+
+  // expected-error @+1 {{function result's 'differential' type does not match 'staticMethod(_:rhs:)'}}
+  @derivative(of: staticMethod)
+  static func jvpWrtInoutMismatch(_ lhs: inout Self, _ rhs: Self) -> (
+    // expected-note @+1 {{'differential' does not have expected type '(inout InoutParameters.TangentVector, InoutParameters.TangentVector) -> ()' (aka '(inout DummyTangentVector, DummyTangentVector) -> ()')}}
+    value: Void, differential: (TangentVector, TangentVector) -> Void
+  ) { fatalError() }
+
+  // Test non-wrt `inout` parameter.
+
+  @derivative(of: staticMethod, wrt: rhs)
+  static func vjpNotWrtInout(_ lhs: inout Self, _ rhs: Self) -> (
+    value: Void, pullback: (TangentVector) -> TangentVector
+  ) { fatalError() }
+
+  // expected-error @+1 {{function result's 'pullback' type does not match 'staticMethod(_:rhs:)'}}
+  @derivative(of: staticMethod, wrt: rhs)
+  static func vjpNotWrtInoutMismatch(_ lhs: inout Self, _ rhs: Self) -> (
+    // expected-note @+1 {{'pullback' does not have expected type '(InoutParameters.TangentVector) -> InoutParameters.TangentVector' (aka '(DummyTangentVector) -> DummyTangentVector')}}
+    value: Void, pullback: (inout TangentVector) -> TangentVector
+  ) { fatalError() }
+
+  @derivative(of: staticMethod, wrt: rhs)
+  static func jvpNotWrtInout(_ lhs: inout Self, _ rhs: Self) -> (
+    value: Void, differential: (TangentVector) -> TangentVector
+  ) { fatalError() }
+
+  // expected-error @+1 {{function result's 'differential' type does not match 'staticMethod(_:rhs:)'}}
+  @derivative(of: staticMethod, wrt: rhs)
+  static func jvpNotWrtInout(_ lhs: inout Self, _ rhs: Self) -> (
+    // expected-note @+1 {{'differential' does not have expected type '(InoutParameters.TangentVector) -> InoutParameters.TangentVector' (aka '(DummyTangentVector) -> DummyTangentVector')}}
+    value: Void, differential: (inout TangentVector) -> TangentVector
+  ) { fatalError() }
+}
+
+extension InoutParameters {
+  // expected-note @+1 4 {{'mutatingMethod' defined here}}
+  mutating func mutatingMethod(_ other: Self) {}
+
+  // Test wrt `inout` `self` parameter.
+
+  @derivative(of: mutatingMethod)
+  mutating func vjpWrtInout(_ other: Self) -> (
+    value: Void, pullback: (inout TangentVector) -> TangentVector
+  ) { fatalError() }
+
+  // expected-error @+1 {{function result's 'pullback' type does not match 'mutatingMethod'}}
+  @derivative(of: mutatingMethod)
+  mutating func vjpWrtInoutMismatch(_ other: Self) -> (
+    // expected-note @+1 {{'pullback' does not have expected type '(inout InoutParameters.TangentVector) -> InoutParameters.TangentVector' (aka '(inout DummyTangentVector) -> DummyTangentVector')}}
+    value: Void, pullback: (TangentVector) -> TangentVector
+  ) { fatalError() }
+
+  @derivative(of: mutatingMethod)
+  mutating func jvpWrtInout(_ other: Self) -> (
+    value: Void, differential: (inout TangentVector, TangentVector) -> Void
+  ) { fatalError() }
+
+  // expected-error @+1 {{function result's 'differential' type does not match 'mutatingMethod'}}
+  @derivative(of: mutatingMethod)
+  mutating func jvpWrtInoutMismatch(_ other: Self) -> (
+    // expected-note @+1 {{'differential' does not have expected type '(inout InoutParameters.TangentVector, InoutParameters.TangentVector) -> ()' (aka '(inout DummyTangentVector, DummyTangentVector) -> ()')}}
+    value: Void, differential: (TangentVector, TangentVector) -> Void
+  ) { fatalError() }
+
+  // Test non-wrt `inout` `self` parameter.
+
+  @derivative(of: mutatingMethod, wrt: other)
+  mutating func vjpNotWrtInout(_ other: Self) -> (
+    value: Void, pullback: (TangentVector) -> TangentVector
+  ) { fatalError() }
+
+  // expected-error @+1 {{function result's 'pullback' type does not match 'mutatingMethod'}}
+  @derivative(of: mutatingMethod, wrt: other)
+  mutating func vjpNotWrtInoutMismatch(_ other: Self) -> (
+    // expected-note @+1 {{'pullback' does not have expected type '(InoutParameters.TangentVector) -> InoutParameters.TangentVector' (aka '(DummyTangentVector) -> DummyTangentVector')}}
+    value: Void, pullback: (inout TangentVector) -> TangentVector
+  ) { fatalError() }
+
+  @derivative(of: mutatingMethod, wrt: other)
+  mutating func jvpNotWrtInout(_ other: Self) -> (
+    value: Void, differential: (TangentVector) -> TangentVector
+  ) { fatalError() }
+
+  // expected-error @+1 {{function result's 'differential' type does not match 'mutatingMethod'}}
+  @derivative(of: mutatingMethod, wrt: other)
+  mutating func jvpNotWrtInoutMismatch(_ other: Self) -> (
+    // expected-note @+1 {{'differential' does not have expected type '(InoutParameters.TangentVector) -> InoutParameters.TangentVector' (aka '(DummyTangentVector) -> DummyTangentVector')}}
+    value: Void, differential: (TangentVector, TangentVector) -> Void
+  ) { fatalError() }
+}
+
+// Test multiple semantic results.
+
+extension InoutParameters {
+  func multipleSemanticResults(_ x: inout Float) -> Float { x }
+  // expected-error @+1 {{cannot yet differentiate functions with more than one semantic result (formal function result or 'inout' parameter)}}
+  @derivative(of: multipleSemanticResults)
+  func vjpMultipleSemanticResults(_ x: inout Float) -> (
+    value: Float, pullback: (inout Float) -> Void
+  ) { fatalError() }
+
+  func inoutVoid(_ x: Float, _ void: inout Void) -> Float {}
+  // expected-error @+1 {{cannot yet differentiate functions with more than one semantic result (formal function result or 'inout' parameter)}}
+  @derivative(of: inoutVoid)
+  func vjpInoutVoidParameter(_ x: Float, _ void: inout Void) -> (
+    value: Float, pullback: (inout Float) -> Void
+  ) { fatalError() }
+}
+
+// Test original/derivative function `inout` parameter mismatches.
+
+extension InoutParameters {
+  func inoutParameterMismatch(_ x: Float) {}
+  // expected-error @+1 {{could not find function 'inoutParameterMismatch' with expected type '(InoutParameters) -> (inout Float) -> Void'}}
+  @derivative(of: inoutParameterMismatch)
+  func vjpInoutParameterMismatch(_ x: inout Float) -> (value: Void, pullback: (inout Float) -> Void) {
+    fatalError()
+  }
+
+  func mutatingMismatch(_ x: Float) {}
+  // expected-error @+1 {{could not find function 'mutatingMismatch' with expected type '(inout InoutParameters) -> (Float) -> Void'}}
+  @derivative(of: mutatingMismatch)
+  mutating func vjpMutatingMismatch(_ x: Float) -> (value: Void, pullback: (inout Float) -> Void) {
     fatalError()
   }
 }

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -1020,18 +1020,6 @@ func two9(x: Float, y: Float) -> Float {
   return x + y
 }
 
-// Inout 'wrt:' arguments.
-
-@differentiable(wrt: y) // expected-error {{cannot differentiate void function 'inout1(x:y:)'}}
-func inout1(x: Float, y: inout Float) -> Void {
-  let _ = x + y
-}
-
-@differentiable(wrt: y) // expected-error {{cannot differentiate with respect to 'inout' parameter ('inout Float')}}
-func inout2(x: Float, y: inout Float) -> Float {
-  let _ = x + y
-}
-
 // Test refining protocol requirements with `@differentiable` attribute.
 
 public protocol Distribution {
@@ -1157,6 +1145,42 @@ final class FinalClass: Differentiable {
   init(base: Float) {
     self.base = base
   }
+}
+
+// Test `inout` parameters.
+
+@differentiable(wrt: y)
+func inoutVoid(x: Float, y: inout Float) {}
+
+// expected-error @+1 {{cannot yet differentiate functions with more than one semantic result (formal function result or 'inout' parameter)}}
+@differentiable
+func multipleSemanticResults(_ x: inout Float) -> Float { x }
+
+// expected-error @+1 {{cannot yet differentiate functions with more than one semantic result (formal function result or 'inout' parameter)}}
+@differentiable(wrt: y)
+func swap(x: inout Float, y: inout Float) {}
+
+struct InoutParameters: Differentiable {
+  typealias TangentVector = DummyTangentVector
+  mutating func move(along _: TangentVector) {}
+}
+
+extension InoutParameters {
+  @differentiable
+  static func staticMethod(_ lhs: inout Self, rhs: Self) {}
+
+  // expected-error @+1 {{cannot yet differentiate functions with more than one semantic result (formal function result or 'inout' parameter)}}
+  @differentiable
+  static func multipleSemanticResults(_ lhs: inout Self, rhs: Self) -> Self {}
+}
+
+extension InoutParameters {
+  @differentiable
+  mutating func mutatingMethod(_ other: Self) {}
+
+  // expected-error @+1 {{cannot yet differentiate functions with more than one semantic result (formal function result or 'inout' parameter)}}
+  @differentiable
+  mutating func mutatingMethod(_ other: Self) -> Self {}
 }
 
 // Test unsupported accessors: `set`, `_read`, `_modify`.

--- a/test/AutoDiff/downstream/closures.swift
+++ b/test/AutoDiff/downstream/closures.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-experimental-forward-mode-differentiation -emit-sil %s | %FileCheck %s
 
 struct Foo {
   var x: Float

--- a/test/AutoDiff/downstream/compiler_crashers/tf984-differential-unset-tangent-buffer.swift
+++ b/test/AutoDiff/downstream/compiler_crashers/tf984-differential-unset-tangent-buffer.swift
@@ -11,10 +11,8 @@ extension Mut {
 }
 
 @differentiable(wrt: x)
-func activeInoutArgMutatingMethodVar(_ nonactive: inout Mut, _ x: Mut) -> Mut {
-  var result = nonactive
-  result = result.mutatingMethodWrtMultipleResults(x)
-  return result
+func activeInoutArgMutatingMethodVar(_ nonactive: inout Mut, _ x: Mut) {
+  nonactive.mutatingMethodWrtMultipleResults(x)
 }
 
 // [AD] Original bb0: To differentiate or not to differentiate?

--- a/test/AutoDiff/downstream/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/downstream/derivative_attr_type_checking.swift
@@ -31,13 +31,13 @@ func jvpSinResultInvalid(x: @noDerivative Float) -> Float {
 func vjpSinResultWrongLabel(x: Float) -> (value: Float, (Float) -> Float) {
   return (x, { $0 })
 }
-// expected-error @+1 {{'@derivative(of:)' attribute requires function to return a two-element tuple (first element type 'Int' must conform to 'Differentiable')}}
+// expected-error @+1 {{could not find function 'sin' with expected type '(Int) -> Int'}}
 @derivative(of: sin)
 func vjpSinResultNotDifferentiable(x: Int) -> (value: Int, pullback: (Int) -> Int) {
   return (x, { $0 })
 }
 // expected-error @+2 {{function result's 'pullback' type does not match 'sin'}}
-// expected-note @+2 {{'pullback' does not have expected type '(Float.TangentVector) -> (Float.TangentVector)' (aka '(Float) -> Float')}}
+// expected-note @+2 {{'pullback' does not have expected type '(Float.TangentVector) -> Float.TangentVector' (aka '(Float) -> Float')}}
 @derivative(of: sin)
 func vjpSinResultInvalidSeedType(x: Float) -> (value: Float, pullback: (Double) -> Double) {
   return (x, { $0 })

--- a/test/AutoDiff/downstream/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/downstream/differentiable_attr_type_checking.swift
@@ -975,12 +975,12 @@ func two9(x: Float, y: Float) -> Float {
 
 // Inout 'wrt:' arguments.
 
-@differentiable(wrt: y) // expected-error {{cannot differentiate void function 'inout1(x:y:)'}}
+@differentiable(wrt: y)
 func inout1(x: Float, y: inout Float) -> Void {
   let _ = x + y
 }
 
-@differentiable(wrt: y) // expected-error {{cannot differentiate with respect to 'inout' parameter ('inout Float')}}
+@differentiable(wrt: y) // expected-error {{cannot yet differentiate functions with more than one semantic result (formal function result or 'inout' parameter)}}
 func inout2(x: Float, y: inout Float) -> Float {
   let _ = x + y
 }

--- a/test/AutoDiff/downstream/floating_point.swift.gyb
+++ b/test/AutoDiff/downstream/floating_point.swift.gyb
@@ -1,33 +1,38 @@
-// RUN: %target-run-simple-swiftgyb
+// RUN: %target-run-simple-swiftgyb-forward-mode-differentiation
 // REQUIRES: executable_test
 
 import StdlibUnittest
 
-var FloatingPointTests = TestSuite("FloatingPoint")
+var FloatingPointDerivativeTests = TestSuite("FloatingPointDerivatives")
 
 %for Self in ['Float', 'Double', 'Float80']:
-% if Self == 'Float80':
-#if !os(Windows) && (arch(i386) || arch(x86_64))
-% end
 
-FloatingPointTests.test("${Self}.squareRoot") {
+%if Self == 'Float80':
+#if !os(Windows) && (arch(i386) || arch(x86_64))
+%end
+
+FloatingPointDerivativeTests.test("${Self}.+") {
+  expectEqual((${Self}(1), ${Self}(1)), gradient(at: ${Self}(4), ${Self}(5), in: +))
+  expectEqual(${Self}(2), derivative(at: ${Self}(4), ${Self}(5), in: +))
+}
+
+FloatingPointDerivativeTests.test("${Self}.squareRoot") {
   expectEqual(${Self}(0.5), gradient(at: ${Self}(1), in: { $0.squareRoot() }))
   expectEqual(${Self}(0.25), gradient(at: ${Self}(4), in: { $0.squareRoot() }))
+
+  expectEqual(${Self}(0.5), derivative(at: ${Self}(1), in: { $0.squareRoot() }))
+  expectEqual(${Self}(0.25), derivative(at: ${Self}(4), in: { $0.squareRoot() }))
 }
 
-FloatingPointTests.test("${Self}.addingProduct") {
-  expectEqual(
-    (${Self}(1), ${Self}(2), ${Self}(3)),
-    gradient(
-      at: ${Self}(10), ${Self}(3), ${Self}(2),
-      in: { $0.addingProduct($1, $2) }
-    )
-  )
+// Differential operator specific tests.
+
+FloatingPointDerivativeTests.test("${Self}.addingProduct") {
+  expectEqual((1, 2, 3), gradient(at: ${Self}(10), ${Self}(3), ${Self}(2), in: { $0.addingProduct($1, $2) }))
 }
 
-%   if Self == 'Float80':
+%if Self == 'Float80':
 #endif
-%   end
-% end
+%end
+%end # for Self in ['Float', 'Double', 'Float80']:
 
 runAllTests()

--- a/test/AutoDiff/downstream/forward_mode_diagnostics.swift
+++ b/test/AutoDiff/downstream/forward_mode_diagnostics.swift
@@ -104,9 +104,7 @@ func activeInoutArgControlFlow(_ array: [Float]) -> Float {
 struct Mut: Differentiable {}
 extension Mut {
   @differentiable(wrt: x)
-  mutating func mutatingMethod(_ x: Mut) -> Mut {
-    return x
-  }
+  mutating func mutatingMethod(_ x: Mut) {}
 }
 
 // FIXME(TF-984): Forward-mode crash due to unset tangent buffer.

--- a/test/AutoDiff/downstream/tgmath_derivatives.swift.gyb
+++ b/test/AutoDiff/downstream/tgmath_derivatives.swift.gyb
@@ -19,7 +19,7 @@
 
 import StdlibUnittest
 
-let DerivativeTests = TestSuite("TGMath")
+let DerivativeTests = TestSuite("TGMathDerivatives")
 
 func expectEqualWithTolerance<T>(_ expected: TestLiteralType, _ actual: T,
                                  ulps allowed: T = 3,
@@ -40,8 +40,8 @@ func expectEqualWithTolerance<T>(_ expected: TestLiteralType, _ actual: T,
 func checkGradient<T: BinaryFloatingPoint & Differentiable>(
   _ f: @differentiable (T, T) -> T,
   _ x: T,
-  _ y: T)
-where T == T.TangentVector {
+  _ y: T
+) where T == T.TangentVector {
   let eps = T(0.01)
   let grad = gradient(at: x, y, in: f)
   let dfdx = (f(x + eps, y) - f(x, y)) / eps


### PR DESCRIPTION
`tensorflow` branch mega-patch for TF-129: `inout` parameter differentiation.

---

This patch exists for end-to-end testing. Code will be submitted incrementally.

Current status:
* Derivative registration works for stdlib functions with `inout` parameters, like `Float.+=` and `Array.append`.
* End-to-end `inout` parameter differentiation works with no known issues.