### PR TITLE
[AutoDiff] Type-checking support for `inout` parameter differentiation.

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -114,7 +114,7 @@ struct AutoDiffConfig {
 };
 
 /// A semantic function result type: either a formal function result type or
-/// an `inout` parameter. Used in derivative function type calculation.
+/// an `inout` parameter type. Used in derivative function type calculation.
 struct AutoDiffSemanticFunctionResultType {
   Type type;
   bool isInout;
@@ -269,19 +269,17 @@ using SILDifferentiabilityWitnessKey = std::pair<StringRef, AutoDiffConfig>;
 /// Automatic differentiation utility namespace.
 namespace autodiff {
 
-/// Given a function type, returns its semantic result type: either the formal
-/// result type or an `inout` parameter.
+/// Given a function type, collects its semantic result types in type order
+/// into `result`: first, the formal result type (if non-`Void`), followed by
+/// `inout` parameter types.
 ///
 /// The function type may have at most two parameter lists.
 ///
-/// Sets `hasMultipleOriginalSemanticResults` to true iff there are multiple
-/// semantic results.
-///
 /// Remaps the original semantic result using `genericEnv`, if specified.
-AutoDiffSemanticFunctionResultType
-getFunctionSemanticResultType(AnyFunctionType *functionType,
-                              bool &hasMultipleSemanticResults,
-                              GenericEnvironment *genericEnv = nullptr);
+void getFunctionSemanticResultTypes(
+    AnyFunctionType *functionType,
+    SmallVectorImpl<AutoDiffSemanticFunctionResultType> &result,
+    GenericEnvironment *genericEnv = nullptr);
 
 /// "Constrained" derivative generic signatures require all differentiability
 /// parameters to conform to the `Differentiable` protocol.

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -115,7 +115,7 @@ struct AutoDiffConfig {
 
 /// A semantic function result type: either a formal function result type or
 /// an `inout` parameter. Used in derivative function type calculation.
-struct SemanticFunctionResultType {
+struct AutoDiffSemanticFunctionResultType {
   Type type;
   bool isInout;
 };
@@ -279,7 +279,7 @@ namespace autodiff {
 /// semantic results.
 ///
 /// Remap the original semantic result using `derivativeGenEnv`, if specified.
-SemanticFunctionResultType getOriginalFunctionSemanticResultType(
+AutoDiffSemanticFunctionResultType getOriginalFunctionSemanticResultType(
     AnyFunctionType *functionType, Type originalFormalResultType,
     bool &hasMultipleOriginalSemanticResults,
     GenericEnvironment *derivativeGenEnv = nullptr);

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -269,20 +269,19 @@ using SILDifferentiabilityWitnessKey = std::pair<StringRef, AutoDiffConfig>;
 /// Automatic differentiation utility namespace.
 namespace autodiff {
 
-/// Given an original/derivative function type and the original formal result
-/// type, return the original semantic result type: either the original formal
+/// Given a function type, returns its semantic result type: either the formal
 /// result type or an `inout` parameter.
 ///
-/// The original/derivative function type may have at most two parameter lists.
+/// The function type may have at most two parameter lists.
 ///
 /// Sets `hasMultipleOriginalSemanticResults` to true iff there are multiple
 /// semantic results.
 ///
-/// Remap the original semantic result using `derivativeGenEnv`, if specified.
-AutoDiffSemanticFunctionResultType getOriginalFunctionSemanticResultType(
-    AnyFunctionType *functionType, Type originalFormalResultType,
-    bool &hasMultipleOriginalSemanticResults,
-    GenericEnvironment *derivativeGenEnv = nullptr);
+/// Remaps the original semantic result using `genericEnv`, if specified.
+AutoDiffSemanticFunctionResultType
+getFunctionSemanticResultType(AnyFunctionType *functionType,
+                              bool &hasMultipleSemanticResults,
+                              GenericEnvironment *genericEnv = nullptr);
 
 /// "Constrained" derivative generic signatures require all differentiability
 /// parameters to conform to the `Differentiable` protocol.

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -113,6 +113,13 @@ struct AutoDiffConfig {
   SWIFT_DEBUG_DUMP;
 };
 
+/// A semantic function result type: either a formal function result type or
+/// an `inout` parameter. Used in derivative function type calculation.
+struct SemanticFunctionResultType {
+  Type type;
+  bool isInout;
+};
+
 /// Key for caching SIL derivative function types.
 struct SILAutoDiffDerivativeFunctionKey {
   SILFunctionType *originalType;
@@ -262,11 +269,20 @@ using SILDifferentiabilityWitnessKey = std::pair<StringRef, AutoDiffConfig>;
 /// Automatic differentiation utility namespace.
 namespace autodiff {
 
-/// Appends the subset's parameter's types to `results`, in the order in
-/// which they appear in the function type.
-void getSubsetParameterTypes(IndexSubset *indices, AnyFunctionType *type,
-                             SmallVectorImpl<Type> &results,
-                             bool reverseCurryLevels = false);
+/// Given an original/derivative function type and the original formal result
+/// type, return the original semantic result type: either the original formal
+/// result type or an `inout` parameter.
+///
+/// The original/derivative function type may have at most two parameter lists.
+///
+/// Sets `hasMultipleOriginalSemanticResults` to true iff there are multiple
+/// semantic results.
+///
+/// Remap the original semantic result using `derivativeGenEnv`, if specified.
+SemanticFunctionResultType getOriginalFunctionSemanticResultType(
+    AnyFunctionType *functionType, Type originalFormalResultType,
+    bool &hasMultipleOriginalSemanticResults,
+    GenericEnvironment *derivativeGenEnv = nullptr);
 
 /// "Constrained" derivative generic signatures require all differentiability
 /// parameters to conform to the `Differentiable` protocol.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2936,8 +2936,6 @@ ERROR(implements_attr_protocol_not_conformed_to,none,
       (DeclName, DeclName))
 
 // @differentiable
-ERROR(differentiable_attr_void_result,none,
-      "cannot differentiate void function %0", (DeclName))
 ERROR(differentiable_attr_no_vjp_or_jvp_when_linear,none,
       "cannot specify 'vjp:' or 'jvp:' for linear functions; use '@transpose' "
       "attribute for transpose registration instead", ())
@@ -3034,6 +3032,11 @@ ERROR(autodiff_attr_original_decl_none_valid_found,none,
       "could not find function %0 with expected type %1", (DeclNameRef, Type))
 ERROR(autodiff_attr_original_decl_not_same_type_context,none,
       "%0 is not defined in the current type context", (DeclNameRef))
+ERROR(autodiff_attr_original_void_result,none,
+      "cannot differentiate void function %0", (DeclName))
+ERROR(autodiff_attr_original_multiple_semantic_results,none,
+      "cannot yet differentiate functions with more than one semantic result "
+      "(formal function result or 'inout' parameter)", ())
 
 // differentiation `wrt` parameters clause
 ERROR(diff_function_no_parameters,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3035,8 +3035,8 @@ ERROR(autodiff_attr_original_decl_not_same_type_context,none,
 ERROR(autodiff_attr_original_void_result,none,
       "cannot differentiate void function %0", (DeclName))
 ERROR(autodiff_attr_original_multiple_semantic_results,none,
-      "cannot yet differentiate functions with more than one semantic result "
-      "(formal function result or 'inout' parameter)", ())
+      "cannot differentiate functions with both an 'inout' parameter and a "
+      "result", ())
 
 // differentiation `wrt` parameters clause
 ERROR(diff_function_no_parameters,none,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3269,7 +3269,7 @@ public:
   ///
   /// The original type may have `inout` parameters. If so, the
   /// differential/pullback typing rules are more nuanced: see documentation for
-  /// `getAutoDiffReturnedLinearMapFunctionType` for details. Semantically,
+  /// `getAutoDiffDerivativeFunctionLinearMapType` for details. Semantically,
   /// `inout` parameters behave as both parameters and results.
   ///
   /// By default, if the original type has a `self` parameter list and parameter
@@ -3287,9 +3287,8 @@ public:
       GenericSignature derivativeGenericSignature = GenericSignature(),
       bool makeSelfParamFirst = false);
 
-  /// Returns the linear map function type returned by the derivative function
-  /// type for the given parameter indices, linear map function kind, and other
-  /// auxiliary parameters.
+  /// Returns the corresponding linear map function type for the given parameter
+  /// indices, linear map function kind, and other auxiliary parameters.
   ///
   /// Preconditions:
   /// - Parameters corresponding to parameter indices must conform to
@@ -3307,7 +3306,7 @@ public:
   ///   - Original:     `(T0, inout T1, ...) -> Void`
   ///   - Differential: `(T0.Tan, ...) -> T1.Tan`
   /// - Case 3: original function has a wrt `inout` parameter.
-  ///   - Original:     `(T0, inout T1, ...) -> R`
+  ///   - Original:     `(T0, inout T1, ...) -> Void`
   ///   - Differential: `(T0.Tan, inout T1.Tan, ...) -> Void`
   ///
   /// Pullback typing rules: takes a "wrt" result derivative and returns "wrt"
@@ -3320,7 +3319,7 @@ public:
   ///   - Original: `(T0, inout T1, ...) -> Void`
   ///   - Pullback: `(T1.Tan) -> (T0.Tan, ...)`
   /// - Case 3: original function has a wrt `inout` parameter.
-  ///   - Original: `(T0, inout T1, ...) -> R`
+  ///   - Original: `(T0, inout T1, ...) -> Void`
   ///   - Pullback: `(inout T1.Tan) -> (T0.Tan, ...)`
   ///
   /// If `makeSelfParamFirst` is true, `self`'s tangent is reordered to appear
@@ -4585,7 +4584,7 @@ public:
   ///
   /// The original type may have `inout` parameters. If so, the
   /// differential/pullback typing rules are more nuanced: see documentation for
-  /// `getAutoDiffReturnedLinearMapFunctionType` for details. Semantically,
+  /// `getAutoDiffDerivativeFunctionLinearMapType` for details. Semantically,
   /// `inout` parameters behave as both parameters and results.
   ///
   /// A "constrained derivative generic signature" is computed from

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3327,7 +3327,7 @@ public:
   /// first. `makeSelfParamFirst` should be true when working with user-facing
   /// derivative function types, e.g. when type-checking `@differentiable` and
   /// `@derivative` attributes.
-  AnyFunctionType *getAutoDiffDerivativeFunctionLinearMapResultType(
+  AnyFunctionType *getAutoDiffDerivativeFunctionLinearMapType(
       IndexSubset *parameterIndices, AutoDiffLinearMapKind kind,
       LookupConformanceFn lookupConformance, bool makeSelfParamFirst = false);
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3203,6 +3203,16 @@ public:
     return getExtInfo().getRepresentation();
   }
 
+  /// Appends the parameters indicated by `parameterIndices` to `results`.
+  ///
+  /// For curried function types: if `reverseCurryLevels` is true, append
+  /// the `self` parameter last instead of first.
+  ///
+  /// TODO(TF-874): Simplify logic and remove the `reverseCurryLevels` flag.
+  void getSubsetParameters(IndexSubset *parameterIndices,
+                           SmallVectorImpl<AnyFunctionType::Param> &results,
+                           bool reverseCurryLevels = false);
+
   /// Returns the derivative function type for the given parameter indices,
   /// result index, derivative function kind, derivative function generic
   /// signature (optional), and other auxiliary parameters.
@@ -3210,8 +3220,8 @@ public:
   /// Preconditions:
   /// - Parameters corresponding to parameter indices must conform to
   ///   `Differentiable`.
-  /// - The result corresponding to the result index must conform to
-  ///   `Differentiable`.
+  /// - There is one semantic function result type: either the formal original
+  ///   result or an `inout` parameter. It must conform to `Differentiable`.
   ///
   /// Typing rules, given:
   /// - Original function type. Three cases:
@@ -3257,6 +3267,11 @@ public:
   ///              original result | deriv. wrt result | deriv. wrt params
   /// \endverbatim
   ///
+  /// The original type may have `inout` parameters. If so, the
+  /// differential/pullback typing rules are more nuanced: see documentation for
+  /// `getAutoDiffReturnedLinearMapFunctionType` for details. Semantically,
+  /// `inout` parameters behave as both parameters and results.
+  ///
   /// By default, if the original type has a `self` parameter list and parameter
   /// indices include `self`, the computed derivative function type will return
   /// a linear map taking/returning self's tangent *last* instead of first, for
@@ -3267,11 +3282,54 @@ public:
   /// derivative function types, e.g. when type-checking `@differentiable` and
   /// `@derivative` attributes.
   AnyFunctionType *getAutoDiffDerivativeFunctionType(
-      IndexSubset *parameterIndices, unsigned resultIndex,
-      AutoDiffDerivativeFunctionKind kind,
+      IndexSubset *parameterIndices, AutoDiffDerivativeFunctionKind kind,
       LookupConformanceFn lookupConformance,
       GenericSignature derivativeGenericSignature = GenericSignature(),
       bool makeSelfParamFirst = false);
+
+  /// Returns the linear map function type returned by the derivative function
+  /// type for the given parameter indices, linear map function kind, and other
+  /// auxiliary parameters.
+  ///
+  /// Preconditions:
+  /// - Parameters corresponding to parameter indices must conform to
+  ///   `Differentiable`.
+  /// - There is one semantic function result type: either the formal original
+  ///   result or an `inout` parameter. It must conform to `Differentiable`.
+  ///
+  /// Differential typing rules: takes "wrt" parameter derivatives and returns a
+  /// "wrt" result derivative.
+  ///
+  /// - Case 1: original function has no `inout` parameters.
+  ///   - Original:     `(T0, T1, ...) -> R`
+  ///   - Differential: `(T0.Tan, T1.Tan, ...) -> R.Tan`
+  /// - Case 2: original function has a non-wrt `inout` parameter.
+  ///   - Original:     `(T0, inout T1, ...) -> Void`
+  ///   - Differential: `(T0.Tan, ...) -> T1.Tan`
+  /// - Case 3: original function has a wrt `inout` parameter.
+  ///   - Original:     `(T0, inout T1, ...) -> R`
+  ///   - Differential: `(T0.Tan, inout T1.Tan, ...) -> Void`
+  ///
+  /// Pullback typing rules: takes a "wrt" result derivative and returns "wrt"
+  /// parameter derivatives.
+  ///
+  /// - Case 1: original function has no `inout` parameters.
+  ///   - Original: `(T0, T1, ...) -> R`
+  ///   - Pullback: `R.Tan -> (T0.Tan, T1.Tan, ...)`
+  /// - Case 2: original function has a non-wrt `inout` parameter.
+  ///   - Original: `(T0, inout T1, ...) -> Void`
+  ///   - Pullback: `(T1.Tan) -> (T0.Tan, ...)`
+  /// - Case 3: original function has a wrt `inout` parameter.
+  ///   - Original: `(T0, inout T1, ...) -> R`
+  ///   - Pullback: `(inout T1.Tan) -> (T0.Tan, ...)`
+  ///
+  /// If `makeSelfParamFirst` is true, `self`'s tangent is reordered to appear
+  /// first. `makeSelfParamFirst` should be true when working with user-facing
+  /// derivative function types, e.g. when type-checking `@differentiable` and
+  /// `@derivative` attributes.
+  AnyFunctionType *getAutoDiffDerivativeFunctionLinearMapResultType(
+      IndexSubset *parameterIndices, AutoDiffLinearMapKind kind,
+      LookupConformanceFn lookupConformance, bool makeSelfParamFirst = false);
 
   /// True if the parameter declaration it is attached to is guaranteed
   /// to not persist the closure for longer than the duration of the call.
@@ -4404,6 +4462,28 @@ public:
     return getParameters().back();
   }
 
+  struct IndirectMutatingParameterFilter {
+    bool operator()(SILParameterInfo param) const {
+      return param.isIndirectMutating();
+    }
+  };
+  using IndirectMutatingParameterIter =
+      llvm::filter_iterator<const SILParameterInfo *,
+                            IndirectMutatingParameterFilter>;
+  using IndirectMutatingParameterRange =
+      iterator_range<IndirectMutatingParameterIter>;
+
+  /// A range of SILParameterInfo for all indirect mutating parameters.
+  IndirectMutatingParameterRange getIndirectMutatingParameters() const {
+    return llvm::make_filter_range(getParameters(),
+                                   IndirectMutatingParameterFilter());
+  }
+
+  /// Returns the number of indirect mutating parameters.
+  unsigned getNumIndirectMutatingParameters() const {
+    return llvm::count_if(getParameters(), IndirectMutatingParameterFilter());
+  }
+
   /// Get the generic signature used to apply the substitutions of a substituted function type
   CanGenericSignature getSubstGenericSignature() const {
     return GenericSigAndIsImplied.getPointer();
@@ -4486,18 +4566,27 @@ public:
   /// - Returns original results, followed by a differential function, which
   ///   takes "wrt" parameter derivatives and returns a "wrt" result derivative.
   ///
+  /// \verbatim
   ///     $(T0, ...) -> (R0, ...,  (T0.Tan, T1.Tan, ...) -> R0.Tan)
   ///                    ^~~~~~~    ^~~~~~~~~~~~~~~~~~~     ^~~~~~
   ///          original results | derivatives wrt params | derivative wrt result
+  /// \endverbatim
   ///
   /// VJP derivative type:
   /// - Takes original parameters.
   /// - Returns original results, followed by a pullback function, which
   ///   takes a "wrt" result derivative and returns "wrt" parameter derivatives.
   ///
+  /// \verbatim
   ///     $(T0, ...) -> (R0, ...,       (R0.Tan)  ->     (T0.Tan, T1.Tan, ...))
   ///                    ^~~~~~~         ^~~~~~            ^~~~~~~~~~~~~~~~~~~
   ///          original results | derivative wrt result | derivatives wrt params
+  /// \endverbatim
+  ///
+  /// The original type may have `inout` parameters. If so, the
+  /// differential/pullback typing rules are more nuanced: see documentation for
+  /// `getAutoDiffReturnedLinearMapFunctionType` for details. Semantically,
+  /// `inout` parameters behave as both parameters and results.
   ///
   /// A "constrained derivative generic signature" is computed from
   /// `derivativeFunctionGenericSignature`, if specified. Otherwise, it is

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -103,7 +103,8 @@ void AnyFunctionType::getSubsetParameters(
   }
 }
 
-SemanticFunctionResultType autodiff::getOriginalFunctionSemanticResultType(
+AutoDiffSemanticFunctionResultType
+autodiff::getOriginalFunctionSemanticResultType(
     AnyFunctionType *functionType, Type originalFormalResultType,
     bool &hasMultipleOriginalSemanticResults,
     GenericEnvironment *derivativeGenEnv) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4940,7 +4940,7 @@ AnyFunctionType *AnyFunctionType::getAutoDiffDerivativeFunctionType(
 
   auto originalResult = curryLevels.back()->getResult();
 
-  Type linearMapType = getAutoDiffDerivativeFunctionLinearMapResultType(
+  Type linearMapType = getAutoDiffDerivativeFunctionLinearMapType(
       parameterIndices, kind.getLinearMapKind(), lookupConformance,
       makeSelfParamFirst);
 
@@ -4969,8 +4969,7 @@ AnyFunctionType *AnyFunctionType::getAutoDiffDerivativeFunctionType(
   return derivativeFunctionType;
 }
 
-AnyFunctionType *
-AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapResultType(
+AnyFunctionType *AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
     IndexSubset *parameterIndices, AutoDiffLinearMapKind kind,
     LookupConformanceFn lookupConformance, bool makeSelfParamFirst) {
   assert(!parameterIndices->isEmpty() &&

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4982,12 +4982,9 @@ AnyFunctionType *AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
                       /*reverseCurryLevels*/ !makeSelfParamFirst);
 
   // Get the original semantic result type.
-  auto originalFormalResult = getResult();
-  if (auto *resultFunctionType = originalFormalResult->getAs<AnyFunctionType>())
-    originalFormalResult = resultFunctionType->getResult();
-  bool hasMultipleOriginalSemanticResults = false;
-  auto originalResult = autodiff::getOriginalFunctionSemanticResultType(
-      this, originalFormalResult, hasMultipleOriginalSemanticResults);
+  bool hasMultipleSemanticResults = false;
+  auto originalResult =
+      autodiff::getFunctionSemanticResultType(this, hasMultipleSemanticResults);
   auto originalResultType = originalResult.type;
 
   // Get the original semantic result type's `TangentVector` associated type.

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4913,9 +4913,9 @@ makeFunctionType(ArrayRef<AnyFunctionType::Param> parameters, Type resultType,
 }
 
 AnyFunctionType *AnyFunctionType::getAutoDiffDerivativeFunctionType(
-    IndexSubset *parameterIndices, unsigned resultIndex,
-    AutoDiffDerivativeFunctionKind kind, LookupConformanceFn lookupConformance,
-    GenericSignature derivativeGenSig, bool makeSelfParamFirst) {
+    IndexSubset *parameterIndices, AutoDiffDerivativeFunctionKind kind,
+    LookupConformanceFn lookupConformance, GenericSignature derivativeGenSig,
+    bool makeSelfParamFirst) {
   assert(!parameterIndices->isEmpty() &&
          "Expected at least one differentiability parameter");
   auto &ctx = getASTContext();
@@ -4924,11 +4924,6 @@ AnyFunctionType *AnyFunctionType::getAutoDiffDerivativeFunctionType(
   // generic signature.
   if (!derivativeGenSig)
     derivativeGenSig = getOptGenericSignature();
-
-  // Get differentiability parameter types.
-  SmallVector<Type, 8> diffParamTypes;
-  autodiff::getSubsetParameterTypes(parameterIndices, this, diffParamTypes,
-                                    /*reverseCurryLevels*/ !makeSelfParamFirst);
 
   // Unwrap curry levels. At most, two parameter lists are necessary, for
   // curried method types with a `(Self)` parameter list.
@@ -4943,65 +4938,11 @@ AnyFunctionType *AnyFunctionType::getAutoDiffDerivativeFunctionType(
     currentLevel = currentLevel->getResult()->getAs<AnyFunctionType>();
   }
 
-  Type originalResult = curryLevels.back()->getResult();
+  auto originalResult = curryLevels.back()->getResult();
 
-  // Build the result linear map function type.
-  Type linearMapType;
-  switch (kind) {
-  case AutoDiffDerivativeFunctionKind::JVP: {
-    // Differential function type, a result of the JVP:
-    //   `LinearMapType = (T.TangentVector, ...) -> (R.TangentVector)`
-    SmallVector<AnyFunctionType::Param, 8> differentialParams;
-    for (auto diffParamType : diffParamTypes)
-      differentialParams.push_back(AnyFunctionType::Param(
-          diffParamType->getAutoDiffTangentSpace(lookupConformance)
-              ->getType()));
-    SmallVector<TupleTypeElt, 8> differentialResults;
-    if (auto *resultTuple = originalResult->getAs<TupleType>()) {
-      auto resultTupleEltType = resultTuple->getElementType(resultIndex);
-      differentialResults.push_back(
-          resultTupleEltType->getAutoDiffTangentSpace(lookupConformance)
-              ->getType());
-    } else {
-      assert(resultIndex == 0 && "resultIndex out of bounds");
-      differentialResults.push_back(
-          originalResult->getAutoDiffTangentSpace(lookupConformance)
-              ->getType());
-    }
-    Type differentialResult = differentialResults.size() > 1
-                                  ? TupleType::get(differentialResults, ctx)
-                                  : differentialResults[0].getType();
-    linearMapType = FunctionType::get(differentialParams, differentialResult);
-    break;
-  }
-  case AutoDiffDerivativeFunctionKind::VJP: {
-    // Pullback function type, a result of the VJP:
-    //   `LinearMapType = (R.TangentVector) -> (T.TangentVector, ...)`
-    SmallVector<AnyFunctionType::Param, 8> pullbackParams;
-    if (auto *resultTuple = originalResult->getAs<TupleType>()) {
-      auto resultTupleEltType = resultTuple->getElementType(resultIndex);
-      pullbackParams.push_back(AnyFunctionType::Param(
-          resultTupleEltType->getAutoDiffTangentSpace(lookupConformance)
-              ->getType()));
-    } else {
-      assert(resultIndex == 0 &&
-             "Expected result index 0 for non-tuple result");
-      pullbackParams.push_back(AnyFunctionType::Param(
-          originalResult->getAutoDiffTangentSpace(lookupConformance)
-              ->getType()));
-    }
-    SmallVector<TupleTypeElt, 8> pullbackResults;
-    for (auto diffParamType : diffParamTypes)
-      pullbackResults.push_back(
-          diffParamType->getAutoDiffTangentSpace(lookupConformance)->getType());
-    Type pullbackResult = pullbackResults.size() > 1
-                              ? TupleType::get(pullbackResults, ctx)
-                              : pullbackResults[0].getType();
-    linearMapType = FunctionType::get(pullbackParams, pullbackResult);
-    break;
-  }
-  }
-  assert(linearMapType && "Expected linear map type");
+  Type linearMapType = getAutoDiffDerivativeFunctionLinearMapResultType(
+      parameterIndices, kind.getLinearMapKind(), lookupConformance,
+      makeSelfParamFirst);
 
   // Build the full derivative function type: `(T...) -> (R, LinearMapType)`.
   SmallVector<TupleTypeElt, 2> retElts;
@@ -5026,6 +4967,113 @@ AnyFunctionType *AnyFunctionType::getAutoDiffDerivativeFunctionType(
   }
 
   return derivativeFunctionType;
+}
+
+AnyFunctionType *
+AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapResultType(
+    IndexSubset *parameterIndices, AutoDiffLinearMapKind kind,
+    LookupConformanceFn lookupConformance, bool makeSelfParamFirst) {
+  assert(!parameterIndices->isEmpty() &&
+         "Expected at least one differentiability parameter");
+  auto &ctx = getASTContext();
+
+  // Get differentiability parameters.
+  SmallVector<AnyFunctionType::Param, 8> diffParams;
+  getSubsetParameters(parameterIndices, diffParams,
+                      /*reverseCurryLevels*/ !makeSelfParamFirst);
+
+  // Get the original semantic result type.
+  auto originalFormalResult = getResult();
+  if (auto *resultFunctionType = originalFormalResult->getAs<AnyFunctionType>())
+    originalFormalResult = resultFunctionType->getResult();
+  bool hasMultipleOriginalSemanticResults = false;
+  auto originalResult = autodiff::getOriginalFunctionSemanticResultType(
+      this, originalFormalResult, hasMultipleOriginalSemanticResults);
+  auto originalResultType = originalResult.type;
+
+  // Get the original semantic result type's `TangentVector` associated type.
+  auto resultTan =
+      originalResultType->getAutoDiffTangentSpace(lookupConformance);
+  assert(resultTan && "Original result has no tangent space?");
+  auto resultTanType = resultTan->getType();
+
+  // Compute the result linear map function type.
+  FunctionType *linearMapType;
+  switch (kind) {
+  case AutoDiffLinearMapKind::Differential: {
+    // Compute the differential type, returned by JVP functions.
+    //
+    // Case 1: original function has no `inout` parameters.
+    // - Original:     `(T0, T1, ...) -> R`
+    // - Differential: `(T0.Tan, T1.Tan, ...) -> R.Tan`
+    //
+    // Case 2: original function has a non-wrt `inout` parameter.
+    // - Original:      `(T0, inout T1, ...) -> Void`
+    // - Differential: `(T0.Tan, ...) -> T1.Tan`
+    //
+    // Case 3: original function has a wrt `inout` parameter.
+    // - Original:     `(T0, inout T1, ...) -> R`
+    // - Differential: `(T0.Tan, inout T1.Tan, ...) -> Void`
+    SmallVector<AnyFunctionType::Param, 4> differentialParams;
+    bool hasInoutDiffParameter = false;
+    for (auto diffParam : diffParams) {
+      auto paramType = diffParam.getPlainType();
+      auto paramTan = paramType->getAutoDiffTangentSpace(lookupConformance);
+      assert(paramTan && "Parameter has no tangent space?");
+      differentialParams.push_back(AnyFunctionType::Param(
+          paramTan->getType(), Identifier(), diffParam.getParameterFlags()));
+      if (diffParam.isInOut())
+        hasInoutDiffParameter = true;
+    }
+    auto differentialResult =
+        hasInoutDiffParameter ? Type(ctx.TheEmptyTupleType) : resultTanType;
+    linearMapType = FunctionType::get(differentialParams, differentialResult);
+    break;
+  }
+  case AutoDiffLinearMapKind::Pullback: {
+    // Compute the pullback type, returned by VJP functions.
+    //
+    // Case 1: original function has no `inout` parameters.
+    // - Original: `(T0, T1, ...) -> R`
+    // - Pullback: `R.Tan -> (T0.Tan, T1.Tan, ...)`
+    //
+    // Case 2: original function has a non-wrt `inout` parameter.
+    // - Original: `(T0, inout T1, ...) -> Void`
+    // - Pullback: `(T1.Tan) -> (T0.Tan, ...)`
+    //
+    // Case 3: original function has a wrt `inout` parameter.
+    // - Original: `(T0, inout T1, ...) -> R`
+    // - Pullback: `(inout T1.Tan) -> (T0.Tan, ...)`
+    SmallVector<TupleTypeElt, 4> pullbackResults;
+    bool hasInoutDiffParameter = false;
+    for (auto diffParam : diffParams) {
+      auto paramType = diffParam.getPlainType();
+      auto paramTan = paramType->getAutoDiffTangentSpace(lookupConformance);
+      assert(paramTan && "Parameter has no tangent space?");
+      if (diffParam.isInOut()) {
+        hasInoutDiffParameter = true;
+        continue;
+      }
+      pullbackResults.push_back(TupleTypeElt(paramTan->getType(), Identifier(),
+                                             diffParam.getParameterFlags()));
+    }
+    Type pullbackResult;
+    if (pullbackResults.empty()) {
+      pullbackResult = ctx.TheEmptyTupleType;
+    } else if (pullbackResults.size() == 1) {
+      pullbackResult = pullbackResults.front().getType();
+    } else {
+      pullbackResult = TupleType::get(pullbackResults, ctx);
+    }
+    auto flags = ParameterTypeFlags().withInOut(hasInoutDiffParameter);
+    auto pullbackParam =
+        AnyFunctionType::Param(resultTanType, Identifier(), flags);
+    linearMapType = FunctionType::get({pullbackParam}, pullbackResult);
+    break;
+  }
+  }
+  assert(linearMapType && "Expected linear map type");
+  return linearMapType;
 }
 
 CanSILFunctionType

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4982,9 +4982,11 @@ AnyFunctionType *AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
                       /*reverseCurryLevels*/ !makeSelfParamFirst);
 
   // Get the original semantic result type.
-  bool hasMultipleSemanticResults = false;
-  auto originalResult =
-      autodiff::getFunctionSemanticResultType(this, hasMultipleSemanticResults);
+  SmallVector<AutoDiffSemanticFunctionResultType, 1> originalResults;
+  autodiff::getFunctionSemanticResultTypes(this, originalResults);
+  assert(originalResults.size() == 1 &&
+         "Only functions with one semantic result are currently supported");
+  auto originalResult = originalResults.front();
   auto originalResultType = originalResult.type;
 
   // Get the original semantic result type's `TangentVector` associated type.
@@ -5008,7 +5010,7 @@ AnyFunctionType *AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
     // - Differential: `(T0.Tan, ...) -> T1.Tan`
     //
     // Case 3: original function has a wrt `inout` parameter.
-    // - Original:     `(T0, inout T1, ...) -> R`
+    // - Original:     `(T0, inout T1, ...) -> Void`
     // - Differential: `(T0.Tan, inout T1.Tan, ...) -> Void`
     SmallVector<AnyFunctionType::Param, 4> differentialParams;
     bool hasInoutDiffParameter = false;
@@ -5038,7 +5040,7 @@ AnyFunctionType *AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
     // - Pullback: `(T1.Tan) -> (T0.Tan, ...)`
     //
     // Case 3: original function has a wrt `inout` parameter.
-    // - Original: `(T0, inout T1, ...) -> R`
+    // - Original: `(T0, inout T1, ...) -> Void`
     // - Pullback: `(inout T1.Tan) -> (T0.Tan, ...)`
     SmallVector<TupleTypeElt, 4> pullbackResults;
     bool hasInoutDiffParameter = false;

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -326,6 +326,22 @@ CanSILFunctionType SILFunctionType::getAutoDiffDerivativeFunctionType(
     return {tanType, conv};
   };
 
+  // Compute the original semantic results: original formal results, followed by
+  // `inout` parameters in type order.
+  SmallVector<SILResultInfo, 2> originalResults;
+  originalResults.append(getResults().begin(), getResults().end());
+  Optional<SILParameterInfo> inoutParam = None;
+  bool isWrtInoutParameter = false;
+  for (auto i : range(getNumParameters())) {
+    auto param = getParameters()[i];
+    if (!param.isIndirectInOut())
+      continue;
+    inoutParam = param;
+    isWrtInoutParameter = parameterIndices->contains(i);
+    originalResults.push_back(
+        SILResultInfo(param.getInterfaceType(), ResultConvention::Indirect));
+  }
+
   CanSILFunctionType closureType;
   switch (kind) {
   case AutoDiffDerivativeFunctionKind::JVP: {
@@ -337,13 +353,15 @@ CanSILFunctionType SILFunctionType::getAutoDiffDerivativeFunctionType(
       differentialParams.push_back(
           {paramTan->getCanonicalType(), param.getConvention()});
     }
-    SmallVector<SILResultInfo, 8> differentialResults;
-    auto &result = getResults()[resultIndex];
-    auto resultTan =
-        result.getInterfaceType()->getAutoDiffTangentSpace(lookupConformance);
-    assert(resultTan && "Result type does not have a tangent space?");
-    differentialResults.push_back(
-        {resultTan->getCanonicalType(), result.getConvention()});
+    SmallVector<SILResultInfo, 1> differentialResults;
+    if (!inoutParam || !isWrtInoutParameter) {
+      auto &result = originalResults[resultIndex];
+      auto resultTan =
+          result.getInterfaceType()->getAutoDiffTangentSpace(lookupConformance);
+      assert(resultTan && "Result type does not have a tangent space?");
+      differentialResults.push_back(
+          {resultTan->getCanonicalType(), result.getConvention()});
+    }
     closureType = SILFunctionType::get(
         /*genericSignature*/ nullptr, ExtInfo(), SILCoroutineKind::None,
         ParameterConvention::Direct_Guaranteed, differentialParams, {},
@@ -352,15 +370,28 @@ CanSILFunctionType SILFunctionType::getAutoDiffDerivativeFunctionType(
     break;
   }
   case AutoDiffDerivativeFunctionKind::VJP: {
-    SmallVector<SILParameterInfo, 8> pullbackParams;
-    auto &origRes = getResults()[resultIndex];
-    auto resultTan =
-        origRes.getInterfaceType()->getAutoDiffTangentSpace(lookupConformance);
-    assert(resultTan && "Result type does not have a tangent space?");
-    pullbackParams.push_back(getTangentParameterInfoForOriginalResult(
-        resultTan->getCanonicalType(), origRes.getConvention()));
+    SmallVector<SILParameterInfo, 1> pullbackParams;
+    if (inoutParam) {
+      auto paramTan = inoutParam->getInterfaceType()->getAutoDiffTangentSpace(
+          lookupConformance);
+      assert(paramTan && "Parameter type does not have a tangent space?");
+      auto paramTanConvention =
+          isWrtInoutParameter ? inoutParam->getConvention()
+                              : ParameterConvention::Indirect_In_Guaranteed;
+      pullbackParams.push_back(
+          SILParameterInfo(paramTan->getCanonicalType(), paramTanConvention));
+    } else {
+      auto &origRes = originalResults[resultIndex];
+      auto resultTan = origRes.getInterfaceType()->getAutoDiffTangentSpace(
+          lookupConformance);
+      assert(resultTan && "Result type does not have a tangent space?");
+      pullbackParams.push_back(getTangentParameterInfoForOriginalResult(
+          resultTan->getCanonicalType(), origRes.getConvention()));
+    }
     SmallVector<SILResultInfo, 8> pullbackResults;
     for (auto &param : diffParams) {
+      if (param.isIndirectInOut())
+        continue;
       auto paramTan =
           param.getInterfaceType()->getAutoDiffTangentSpace(lookupConformance);
       assert(paramTan && "Parameter type does not have a tangent space?");

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3932,14 +3932,9 @@ llvm::Expected<IndexSubset *> DifferentiableAttributeTypeCheckRequest::evaluate(
     return nullptr;
 
   // Get the original semantic result type.
-  auto originalFormalResultTy = originalFnTy->getResult();
-  if (isMethod)
-    originalFormalResultTy =
-        originalFormalResultTy->castTo<AnyFunctionType>()->getResult();
   bool hasMultipleOriginalSemanticResults = false;
-  auto originalResult = autodiff::getOriginalFunctionSemanticResultType(
-      originalFnTy, originalFormalResultTy, hasMultipleOriginalSemanticResults,
-      derivativeGenEnv);
+  auto originalResult = autodiff::getFunctionSemanticResultType(
+      originalFnTy, hasMultipleOriginalSemanticResults, derivativeGenEnv);
   auto originalResultTy = originalResult.type;
   // Check that original function does not have multiple semantic results.
   if (hasMultipleOriginalSemanticResults) {
@@ -4264,9 +4259,8 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
 
   // Get the original semantic result.
   bool hasMultipleOriginalSemanticResults = false;
-  auto originalResult = autodiff::getOriginalFunctionSemanticResultType(
-      originalFnType, valueResultElt.getType(),
-      hasMultipleOriginalSemanticResults,
+  auto originalResult = autodiff::getFunctionSemanticResultType(
+      originalFnType, hasMultipleOriginalSemanticResults,
       derivative->getGenericEnvironmentOfContext());
   auto originalResultType = originalResult.type;
   // Check that original function does not have multiple semantic results.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3179,20 +3179,12 @@ static bool checkDifferentiabilityParameters(
   }
 
   // Check that differentiability parameters have allowed types.
-  SmallVector<Type, 4> diffParamTypes;
-  autodiff::getSubsetParameterTypes(diffParamIndices, functionType,
-                                    diffParamTypes);
-  for (unsigned i : range(diffParamTypes.size())) {
+  SmallVector<AnyFunctionType::Param, 4> diffParams;
+  functionType->getSubsetParameters(diffParamIndices, diffParams);
+  for (unsigned i : range(diffParams.size())) {
     SourceLoc loc =
         parsedDiffParams.empty() ? attrLoc : parsedDiffParams[i].getLoc();
-    auto diffParamType = diffParamTypes[i];
-    // `inout` parameters are not yet supported.
-    if (diffParamType->is<InOutType>()) {
-      diags.diagnose(loc,
-                     diag::diff_params_clause_cannot_diff_wrt_inout_parameter,
-                     diffParamType);
-      return true;
-    }
+    auto diffParamType = diffParams[i].getPlainType();
     if (!diffParamType->hasTypeParameter())
       diffParamType = diffParamType->mapTypeOutOfContext();
     if (derivativeGenEnv)
@@ -3350,7 +3342,7 @@ static bool checkFunctionSignature(
   if (!std::equal(required->getParams().begin(), required->getParams().end(),
                   candidateFnTy->getParams().begin(),
                   [&](AnyFunctionType::Param x, AnyFunctionType::Param y) {
-                    return x.getPlainType()->isEqual(mapType(y.getPlainType()));
+                    return x.getOldType()->isEqual(mapType(y.getOldType()));
                   }))
     return false;
 
@@ -3780,9 +3772,8 @@ bool resolveDifferentiableAttrDerivativeFunctions(
   // Resolve the JVP function, if it is specified and exists.
   if (attr->getJVP()) {
     auto *expectedJVPFnTy = originalFnTy->getAutoDiffDerivativeFunctionType(
-        resolvedDiffParamIndices, /*resultIndex*/ 0,
-        AutoDiffDerivativeFunctionKind::JVP, lookupConformance,
-        derivativeGenSig, /*makeSelfParamFirst*/ true);
+        resolvedDiffParamIndices, AutoDiffDerivativeFunctionKind::JVP,
+        lookupConformance, derivativeGenSig, /*makeSelfParamFirst*/ true);
     auto isValidJVP = [&](AbstractFunctionDecl *jvpCandidate) -> bool {
       return checkFunctionSignature(
           cast<AnyFunctionType>(expectedJVPFnTy->getCanonicalType()),
@@ -3801,9 +3792,8 @@ bool resolveDifferentiableAttrDerivativeFunctions(
   // Resolve the VJP function, if it is specified and exists.
   if (attr->getVJP()) {
     auto *expectedVJPFnTy = originalFnTy->getAutoDiffDerivativeFunctionType(
-        resolvedDiffParamIndices, /*resultIndex*/ 0,
-        AutoDiffDerivativeFunctionKind::VJP, lookupConformance,
-        derivativeGenSig, /*makeSelfParamFirst*/ true);
+        resolvedDiffParamIndices, AutoDiffDerivativeFunctionKind::VJP,
+        lookupConformance, derivativeGenSig, /*makeSelfParamFirst*/ true);
     auto isValidVJP = [&](AbstractFunctionDecl *vjpCandidate) -> bool {
       return checkFunctionSignature(
           cast<AnyFunctionType>(expectedVJPFnTy->getCanonicalType()),
@@ -3884,20 +3874,6 @@ llvm::Expected<IndexSubset *> DifferentiableAttributeTypeCheckRequest::evaluate(
   auto *originalFnTy = original->getInterfaceType()->castTo<AnyFunctionType>();
   bool isMethod = original->hasImplicitSelfDecl();
 
-  // If the original function returns the empty tuple type, there is no output
-  // to differentiate from.
-  auto originalResultTy = originalFnTy->getResult();
-  if (isMethod)
-    originalResultTy = originalResultTy->castTo<AnyFunctionType>()->getResult();
-  if (originalResultTy->isEqual(ctx.TheEmptyTupleType)) {
-    diags
-        .diagnose(attr->getLocation(), diag::differentiable_attr_void_result,
-                  original->getFullName())
-        .highlight(original->getSourceRange());
-    attr->setInvalid();
-    return nullptr;
-  }
-
   // Diagnose if original function is an invalid class member.
   bool isOriginalClassMember = original->getDeclContext() &&
                                original->getDeclContext()->getSelfClassDecl();
@@ -3955,11 +3931,36 @@ llvm::Expected<IndexSubset *> DifferentiableAttributeTypeCheckRequest::evaluate(
           resolvedDiffParamIndices))
     return nullptr;
 
-  // Check that original function's result type conforms to `Differentiable`.
-  if (derivativeGenEnv)
-    originalResultTy = derivativeGenEnv->mapTypeIntoContext(originalResultTy);
-  else
-    originalResultTy = original->mapTypeIntoContext(originalResultTy);
+  // Get the original semantic result type.
+  auto originalFormalResultTy = originalFnTy->getResult();
+  if (isMethod)
+    originalFormalResultTy =
+        originalFormalResultTy->castTo<AnyFunctionType>()->getResult();
+  bool hasMultipleOriginalSemanticResults = false;
+  auto originalResult = autodiff::getOriginalFunctionSemanticResultType(
+      originalFnTy, originalFormalResultTy, hasMultipleOriginalSemanticResults,
+      derivativeGenEnv);
+  auto originalResultTy = originalResult.type;
+  // Check that original function does not have multiple semantic results.
+  if (hasMultipleOriginalSemanticResults) {
+    diags
+        .diagnose(attr->getLocation(),
+                  diag::autodiff_attr_original_multiple_semantic_results)
+        .highlight(original->getSourceRange());
+    attr->setInvalid();
+    return nullptr;
+  }
+  // Check that original function has at least one semantic result, i.e.
+  // that the original semantic result type is not `Void`.
+  if (!originalResultTy) {
+    diags
+        .diagnose(attr->getLocation(), diag::autodiff_attr_original_void_result,
+                  original->getFullName())
+        .highlight(original->getSourceRange());
+    attr->setInvalid();
+    return nullptr;
+  }
+  // Check that the original semantic result conforms to `Differentiable`.
   if (!conformsToDifferentiable(originalResultTy, original)) {
     diags.diagnose(attr->getLocation(),
                    diag::differentiable_attr_result_not_differentiable,
@@ -4261,41 +4262,42 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
   // Set the resolved differentiability parameter indices in the attribute.
   attr->setParameterIndices(resolvedDiffParamIndices);
 
-  // Gather differentiability parameters.
-  SmallVector<Type, 4> diffParamTypes;
-  autodiff::getSubsetParameterTypes(resolvedDiffParamIndices, originalFnType,
-                                    diffParamTypes);
-
-  // Get the differentiability parameters' `TangentVector` associated types.
+  // Get the original semantic result.
+  bool hasMultipleOriginalSemanticResults = false;
+  auto originalResult = autodiff::getOriginalFunctionSemanticResultType(
+      originalFnType, valueResultElt.getType(),
+      hasMultipleOriginalSemanticResults,
+      derivative->getGenericEnvironmentOfContext());
+  auto originalResultType = originalResult.type;
+  // Check that original function does not have multiple semantic results.
+  if (hasMultipleOriginalSemanticResults) {
+    diags
+        .diagnose(attr->getLocation(),
+                  diag::autodiff_attr_original_multiple_semantic_results)
+        .highlight(attr->getOriginalFunctionName().Loc.getSourceRange());
+    attr->setInvalid();
+    return true;
+  }
+  // Check that original function has at least one semantic result, i.e.
+  // that the original semantic result type is not `Void`.
+  if (!originalResultType) {
+    diags
+        .diagnose(attr->getLocation(), diag::autodiff_attr_original_void_result,
+                  derivative->getFullName())
+        .highlight(attr->getOriginalFunctionName().Loc.getSourceRange());
+    attr->setInvalid();
+    return true;
+  }
+  // Check that the original semantic result conforms to `Differentiable`.
   auto *diffableProto = Ctx.getProtocol(KnownProtocolKind::Differentiable);
-  auto diffParamTanTypes =
-      map<SmallVector<TupleTypeElt, 4>>(diffParamTypes, [&](Type paramType) {
-        if (paramType->hasTypeParameter())
-          paramType = derivative->mapTypeIntoContext(paramType);
-        auto conf = TypeChecker::conformsToProtocol(paramType, diffableProto,
-                                                    derivative, None);
-        assert(conf &&
-               "Expected resolved parameter to conform to `Differentiable`");
-        auto paramAssocType =
-            conf.getTypeWitnessByName(paramType, Ctx.Id_TangentVector);
-        return TupleTypeElt(paramAssocType);
-      });
-
-  // `value: R` result tuple element must conform to `Differentiable`.
-  // Get the `TangentVector` associated type of the `value:` result type.
-  auto valueResultType = valueResultElt.getType();
-  if (valueResultType->hasTypeParameter())
-    valueResultType = derivative->mapTypeIntoContext(valueResultType);
   auto valueResultConf = TypeChecker::conformsToProtocol(
-      valueResultType, diffableProto, derivative->getDeclContext(), None);
+      originalResultType, diffableProto, derivative->getDeclContext(), None);
   if (!valueResultConf) {
     diags.diagnose(attr->getLocation(),
                    diag::derivative_attr_result_value_not_differentiable,
                    valueResultElt.getType());
     return true;
   }
-  auto resultTanType = valueResultConf.getTypeWitnessByName(
-      valueResultType, Ctx.Id_TangentVector);
 
   // Compute the actual differential/pullback type that we use for comparison
   // with the expected type. We must canonicalize the derivative interface type
@@ -4311,19 +4313,14 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
       cast<TupleType>(canActualResultType).getElementType(1);
 
   // Compute expected differential/pullback type.
-  Type expectedFuncEltType;
-  if (kind == AutoDiffDerivativeFunctionKind::JVP) {
-    auto diffParams = map<SmallVector<AnyFunctionType::Param, 4>>(
-        diffParamTanTypes, [&](TupleTypeElt elt) {
-          return AnyFunctionType::Param(elt.getType());
-        });
-    expectedFuncEltType = FunctionType::get(diffParams, resultTanType);
-  } else {
-    expectedFuncEltType =
-        FunctionType::get({AnyFunctionType::Param(resultTanType)},
-                          TupleType::get(diffParamTanTypes, Ctx));
-  }
-  expectedFuncEltType = expectedFuncEltType->mapTypeOutOfContext();
+  Type expectedFuncEltType =
+      originalFnType->getAutoDiffDerivativeFunctionLinearMapResultType(
+          resolvedDiffParamIndices, kind.getLinearMapKind(), lookupConformance,
+          /*makeSelfParamFirst*/ true);
+  if (expectedFuncEltType->hasTypeParameter())
+    expectedFuncEltType = derivative->mapTypeIntoContext(expectedFuncEltType);
+  if (expectedFuncEltType->hasArchetype())
+    expectedFuncEltType = expectedFuncEltType->mapTypeOutOfContext();
 
   // Check if differential/pullback type matches expected type.
   if (!actualFuncEltType->isEqual(expectedFuncEltType)) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4314,7 +4314,7 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
 
   // Compute expected differential/pullback type.
   Type expectedFuncEltType =
-      originalFnType->getAutoDiffDerivativeFunctionLinearMapResultType(
+      originalFnType->getAutoDiffDerivativeFunctionLinearMapType(
           resolvedDiffParamIndices, kind.getLinearMapKind(), lookupConformance,
           /*makeSelfParamFirst*/ true);
   if (expectedFuncEltType->hasTypeParameter())

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -581,7 +581,7 @@ extension ProtocolRequirementDerivative {
 func multipleSemanticResults(_ x: inout Float) -> Float {
   return x
 }
-// expected-error @+1 {{cannot yet differentiate functions with more than one semantic result (formal function result or 'inout' parameter)}}
+// expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
 @derivative(of: multipleSemanticResults)
 func vjpMultipleSemanticResults(x: inout Float) -> (
   value: Float, pullback: (Float) -> Float
@@ -712,14 +712,14 @@ extension InoutParameters {
 
 extension InoutParameters {
   func multipleSemanticResults(_ x: inout Float) -> Float { x }
-  // expected-error @+1 {{cannot yet differentiate functions with more than one semantic result (formal function result or 'inout' parameter)}}
+  // expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
   @derivative(of: multipleSemanticResults)
   func vjpMultipleSemanticResults(_ x: inout Float) -> (
     value: Float, pullback: (inout Float) -> Void
   ) { fatalError() }
 
   func inoutVoid(_ x: Float, _ void: inout Void) -> Float {}
-  // expected-error @+1 {{cannot yet differentiate functions with more than one semantic result (formal function result or 'inout' parameter)}}
+  // expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
   @derivative(of: inoutVoid)
   func vjpInoutVoidParameter(_ x: Float, _ void: inout Void) -> (
     value: Float, pullback: (inout Float) -> Void

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -1151,11 +1151,11 @@ final class FinalClass: Differentiable {
 @differentiable(wrt: y)
 func inoutVoid(x: Float, y: inout Float) {}
 
-// expected-error @+1 {{cannot yet differentiate functions with more than one semantic result (formal function result or 'inout' parameter)}}
+// expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
 @differentiable
 func multipleSemanticResults(_ x: inout Float) -> Float { x }
 
-// expected-error @+1 {{cannot yet differentiate functions with more than one semantic result (formal function result or 'inout' parameter)}}
+// expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
 @differentiable(wrt: y)
 func swap(x: inout Float, y: inout Float) {}
 
@@ -1168,7 +1168,7 @@ extension InoutParameters {
   @differentiable
   static func staticMethod(_ lhs: inout Self, rhs: Self) {}
 
-  // expected-error @+1 {{cannot yet differentiate functions with more than one semantic result (formal function result or 'inout' parameter)}}
+  // expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
   @differentiable
   static func multipleSemanticResults(_ lhs: inout Self, rhs: Self) -> Self {}
 }
@@ -1177,7 +1177,7 @@ extension InoutParameters {
   @differentiable
   mutating func mutatingMethod(_ other: Self) {}
 
-  // expected-error @+1 {{cannot yet differentiate functions with more than one semantic result (formal function result or 'inout' parameter)}}
+  // expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
   @differentiable
   mutating func mutatingMethod(_ other: Self) -> Self {}
 }


### PR DESCRIPTION
Semantically, an `inout` parameter is both a parameter and a result.

`@differentiable` and `@derivative` attributes now support original functions
with one "semantic result": either a formal result or an `inout` parameter.

The differential/pullback type of a function with `inout` differentiability
parameters also has `inout` parameters. This is ideal for performance.

Differential typing rules:
- Case 1: original function has no `inout` parameters.
  - Original:     `(T0, T1, ...) -> R`
  - Differential: `(T0.Tan, T1.Tan, ...) -> R.Tan`
- Case 2: original function has a non-wrt `inout` parameter.
  - Original:     `(T0, inout T1, ...) -> Void`
  - Differential: `(T0.Tan, ...) -> T1.Tan`
- Case 3: original function has a wrt `inout` parameter.
  - Original:     `(T0, inout T1, ...) -> Void`
  - Differential: `(T0.Tan, inout T1.Tan, ...) -> Void`

Pullback typing rules:
- Case 1: original function has no `inout` parameters.
  - Original: `(T0, T1, ...) -> R`
  - Pullback: `R.Tan -> (T0.Tan, T1.Tan, ...)`
- Case 2: original function has a non-wrt `inout` parameter.
  - Original: `(T0, inout T1, ...) -> Void`
  - Pullback: `(T1.Tan) -> (T0.Tan, ...)`
- Case 3: original function has a wrt `inout` parameter.
  - Original: `(T0, inout T1, ...) -> Void`
  - Pullback: `(inout T1.Tan) -> (T0.Tan, ...)`

Resolves TF-1164.

---

Examples:

```swift
extension Float {
  @derivative(of: *=)
  static func _vjpMultiplyAssign(_ lhs: inout Float, _ rhs: Float) -> (
    value: Void, pullback: (inout Float) -> Float
  ) {
    defer { lhs *= rhs }
    return ((), { [lhs = lhs] v in
      let drhs = lhs * v
      v *= rhs
      return drhs
    })
  }
}

extension Array where Element: Differentiable {
  @derivative(of: append)
  mutating func _vjpAppend(_ element: Element) -> (
    value: Void, pullback: (inout TangentVector) -> Element.TangentVector
  ) {
    let appendedElementIndex = count
    defer { append(element) }
    return ((), { dself in dself.base[appendedElementIndex] })
  }
}
```

---

This patch includes all `inout` parameter differentiation changes currently
relevant to `master` branch, e.g. SIL derivative type calculation changes.

Remaining changes involves code that hasn't yet been upstreamed. Those changes
will be committed to `tensorflow` branch and eventually upstreamed.

End-to-end `inout` parameter differentiation is tested in https://github.com/apple/swift/pull/29956.