### PR TITLE
Disable test_backward_deploy_conformance.swift on Swift-in-the-OS bots

### DIFF
--- a/validation-test/Evolution/test_backward_deploy_conformance.swift
+++ b/validation-test/Evolution/test_backward_deploy_conformance.swift
@@ -1,6 +1,8 @@
 // RUN: %target-resilience-test --backward-deployment
 // REQUIRES: executable_test
 
+// XFAIL: use_os_stdlib
+
 import StdlibUnittest
 import backward_deploy_conformance
 


### PR DESCRIPTION
We need a backward compatibility shim before this can work.

Fixes <rdar://problem/59631880>.
