### PR TITLE
[Tests] Mark some CrossImport tests as unsupported on Windows

### DIFF
--- a/test/CrossImport/horrible.swift
+++ b/test/CrossImport/horrible.swift
@@ -2,6 +2,7 @@
 // RUN: cp -r %S/Inputs/lib-templates/* %t/
 
 // RUN: %target-typecheck-verify-swift -enable-cross-import-overlays -I %t/lib/swift
+// UNSUPPORTED: windows
 
 //
 // This module declares some really bad cross-import files.

--- a/test/CrossImport/module-trace.swift
+++ b/test/CrossImport/module-trace.swift
@@ -4,6 +4,7 @@
 // RUN: cp -r %S/Inputs/lib-templates/* %t/
 
 // RUN: %target-swift-frontend -enable-cross-import-overlays -I %t/lib/swift -typecheck %s -module-name main -swift-version 5 -emit-loaded-module-trace-path - | %FileCheck %s
+// UNSUPPORTED: windows
 
 import DeclaringLibrary
 import BystandingLibrary


### PR DESCRIPTION
Unblock Windows testing by marking some CrossImport tests as
unsupported on Windows.