### PR TITLE
Ignore debug markers that aren't relevant for this test.

### DIFF
--- a/validation-test/Sema/sr8209.swift
+++ b/validation-test/Sema/sr8209.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-// CHECK-LABEL: define {{.+}} @"$s6SR82094test10ObjectiveC8SelectorVyF"() {{#[0-9]+}} {
+// CHECK-LABEL: define {{.+}} @"$s6SR82094test10ObjectiveC8SelectorVyF"() {{#[0-9]+}}
 func test() -> Selector {
   // CHECK: = load {{.+}} @"\01L_selector(isAsynchronous)"
   return #selector(getter: AsyncValueBlockOperation.isAsynchronous)


### PR DESCRIPTION
The previous code expects output like this:
```
define hidden swiftcc i8* @"$s6SR82094test10ObjectiveC8SelectorVyF"() #0 {
```

But in certain build modes, we get extra debug information that looks like this:
```
define hidden swiftcc i8* @"$s6SR82094test10ObjectiveC8SelectorVyF"() #0 !dbg !47 {
```

I stumbled over this while running tests with a variety of different
options.
