### PR TITLE
build: add missing test dependency, sort, reflow

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -57,10 +57,28 @@ function(get_test_dependencies SDK result_var_name)
   endif()
 
   if(NOT SWIFT_BUILT_STANDALONE)
-    list(APPEND deps_binaries FileCheck arcmt-test c-arcmt-test c-index-test
-         clang llc llvm-cov llvm-dwarfdump llvm-link llvm-as llvm-dis
-         llvm-bcanalyzer llvm-nm llvm-readobj llvm-profdata count not
-         llvm-strings llvm-readelf dsymutil)
+    list(APPEND deps_binaries
+      arcmt-test
+      c-arcmt-test
+      c-index-test
+      clang
+      count
+      dsymutil
+      FileCheck
+      llc
+      llvm-as
+      llvm-bcanalyzer
+      llvm-cov
+      llvm-dis
+      llvm-dwarfdump
+      llvm-link
+      llvm-nm
+      llvm-objdump
+      llvm-profdata
+      llvm-readelf
+      llvm-readobj
+      llvm-strings
+      not)
   endif()
 
   if(("${SDK}" STREQUAL "IOS") OR


### PR DESCRIPTION
Reflow the dependencies to be one-per-line, alphabetically sorted.
Add the missing dependency for llvm-objdump.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
