### PR TITLE
build: make tensorflow-swift-apis build with older CMake

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/tensorflow.py
+++ b/utils/swift_build_support/swift_build_support/products/tensorflow.py
@@ -10,8 +10,11 @@
 #
 # ----------------------------------------------------------------------------
 
+import os
+
 from . import product
 from .. import shell
+from .. import targets
 
 
 class TensorFlowSwiftAPIs(product.Product):
@@ -27,21 +30,39 @@ class TensorFlowSwiftAPIs(product.Product):
         return self.args.build_tensorflow_swift_apis
 
     def build(self, host_target):
-        shell.call([
-            self.toolchain.cmake,
-            '-G', 'Ninja',
-            '-D', 'BUILD_SHARED_LIBS=YES',
-            '-D', 'CMAKE_INSTALL_PREFIX={}/usr'.format(
-                self.args.install_destdir),
-            '-D', 'CMAKE_MAKE_PROGRAM={}'.format(self.toolchain.ninja),
-            '-D', 'CMAKE_Swift_COMPILER={}'.format(self.toolchain.swiftc),
-            '-B', self.build_dir,
-            '-S', self.source_dir,
-        ])
-        shell.call([
-            self.toolchain.cmake,
-            '--build', self.build_dir,
-        ])
+        toolchain_path = targets.toolchain_path(self.args.install_destdir,
+                                                self.args.install_prefix)
+        swiftc = os.path.join(toolchain_path, 'usr', 'bin', 'swiftc')
+
+        # FIXME: this is a workaround for CMake <3.16 which does not correctly
+        # generate the build rules if you are not in the build directory.  As a
+        # result, we need to create the build tree before we can use it and
+        # change into it.
+        #
+        # NOTE: unfortunately, we do not know if the build is using Python
+        # 2.7 or Python 3.2+.  In the latter, the `exist_ok` named parameter
+        # would alleviate some of this issue.
+        try:
+            os.makedirs(self.build_dir)
+        except OSError:
+            pass
+
+        with shell.pushd(self.build_dir):
+            shell.call([
+                self.toolchain.cmake,
+                '-G', 'Ninja',
+                '-D', 'BUILD_SHARED_LIBS=YES',
+                '-D', 'CMAKE_INSTALL_PREFIX={}/usr'.format(
+                    self.args.install_destdir),
+                '-D', 'CMAKE_MAKE_PROGRAM={}'.format(self.toolchain.ninja),
+                '-D', 'CMAKE_Swift_COMPILER={}'.format(swiftc),
+                '-B', self.build_dir,
+                '-S', self.source_dir,
+            ])
+            shell.call([
+                self.toolchain.cmake,
+                '--build', self.build_dir,
+            ])
 
     def should_test(self, host_target):
         return False


### PR DESCRIPTION
Support CMake 3.15 for the build which required changing into the build
tree before configuring/building.

Use the just-built `swiftc` to build the product.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
