### PR TITLE
[Parse] Try to preserve the invariant that anything that contains KeyPathDotExpr must be wrapped in KeyPathExpr

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -600,9 +600,10 @@ ParserResult<Expr> Parser::parseExprKeyPath() {
     pathResult = parseExprPostfixSuffix(inner, /*isExprBasic=*/true,
                                         /*periodHasKeyPathBehavior=*/false,
                                         unusedHasBindOptional);
-    if (pathResult.isParseError())
-      return pathResult;
   }
+
+  if (!rootResult.getPtrOrNull() && !pathResult.getPtrOrNull())
+    return pathResult;
 
   auto keypath = new (Context) KeyPathExpr(
       backslashLoc, rootResult.getPtrOrNull(), pathResult.getPtrOrNull());
@@ -618,7 +619,8 @@ ParserResult<Expr> Parser::parseExprKeyPath() {
     return makeParserCodeCompletionResult(keypath);
   }
 
-  return makeParserResult(keypath);
+  ParserStatus parseStatus = ParserStatus(rootResult) | ParserStatus(pathResult);
+  return makeParserResult(parseStatus, keypath);
 }
 
 ///   expr-keypath-objc:

--- a/validation-test/IDE/crashers_fixed/rdar50666427.swift
+++ b/validation-test/IDE/crashers_fixed/rdar50666427.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=COMPLETE -source-filename=%s
+
+struct SD {
+  var array: [Int] = []
+}
+
+func test(sd: SD) {
+  _ = sd[\.array[#^COMPLETE^#]]
+}

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar50666427.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar50666427.swift
@@ -1,0 +1,9 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+struct SD {
+  var array: [Int] = []
+}
+
+func test(sd: SD) {
+  _ = sd[\.array[@]]
+}


### PR DESCRIPTION
Even in the presence of invalid code. Fixes typechecker crash in rdar://50666427
