### PR TITLE
Propagate `--enable-tensorflow` from build-script to CMake.

### DIFF
--- a/test/api-digester/dump-module.swift
+++ b/test/api-digester/dump-module.swift
@@ -1,5 +1,3 @@
-// SWIFT_ENABLE_TENSORFLOW
-// UNSUPPORTED: tensorflow
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)

--- a/test/api-digester/stability-stdlib-abi-with-asserts.swift
+++ b/test/api-digester/stability-stdlib-abi-with-asserts.swift
@@ -1,3 +1,9 @@
+// SWIFT_ENABLE_TENSORFLOW
+// Note: this test is disabled on `tensorflow` branch because `tensorflow`
+// branch adds various public APIs to the stdlib without `@available`
+// attributes. Some of these APIs will be usptreamed to the
+// UNSUPPORTED: tensorflow
+
 // REQUIRES: OS=macosx
 // REQUIRES: swift_stdlib_asserts
 // RUN: %empty-directory(%t.tmp)

--- a/test/api-digester/stability-stdlib-abi-without-asserts.swift
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.swift
@@ -1,5 +1,3 @@
-// SWIFT_ENABLE_TENSORFLOW
-// UNSUPPORTED: tensorflow
 // REQUIRES: OS=macosx
 // REQUIRES: swift_stdlib_no_asserts
 // RUN: %empty-directory(%t.tmp)

--- a/test/api-digester/stability-stdlib-source.swift
+++ b/test/api-digester/stability-stdlib-source.swift
@@ -1,5 +1,3 @@
-// SWIFT_ENABLE_TENSORFLOW
-// UNSUPPORTED: tensorflow
 // REQUIRES: OS=macosx
 // RUN: %empty-directory(%t.tmp)
 // mkdir %t.tmp/module-cache && mkdir %t.tmp/dummy.sdk

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1719,6 +1719,13 @@ for host in "${ALL_HOSTS[@]}"; do
                     )
                 fi
 
+                if [[ "${ENABLE_TENSORFLOW}" ]] ; then
+                    cmake_options=(
+                        "${cmake_options[@]}"
+                        -DSWIFT_ENABLE_TENSORFLOW:BOOL=TRUE
+                    )
+                fi
+
                 if [[ ! "${SKIP_BUILD_LLDB}" ]] ; then
                     lldb_build_dir=$(build_directory ${host} lldb)
                     cmake_options=(


### PR DESCRIPTION
Propagate `--enable-tensorflow` from build-script to CMake as
`-DSWIFT_ENABLE_TENSORFLOW:BOOL=TRUE`.

Partially unreverts 73ebd5b.

This is significant for lit tests, so that `test/lit.site.cfg.in` adds
`tensorflow` as an available feature.

---

Reduce `test/api-digester` tensorflow branch differences.

Disable `test/api-digester/stability-stdlib-abi-with-asserts.swift` with an
explanatory comment.

Revert tensorflow-only changes to other tests, making them in sync with master.