### PR TITLE
[AutoDiff] Fix "'alignof' to an incomplete type" error in AutoDiff.h.

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -23,6 +23,7 @@
 #include "swift/AST/Identifier.h"
 #include "swift/AST/IndexSubset.h"
 #include "swift/AST/Type.h"
+#include "swift/AST/TypeAlignments.h"
 #include "swift/Basic/Range.h"
 #include "swift/Basic/SourceLoc.h"
 

--- a/include/swift/AST/TypeAlignments.h
+++ b/include/swift/AST/TypeAlignments.h
@@ -46,6 +46,7 @@ namespace swift {
   class ProtocolDecl;
   class ProtocolConformance;
   class SILFunction;
+  class SILFunctionType;
   class Stmt;
   class TypeVariableType;
   class TypeBase;
@@ -100,6 +101,8 @@ LLVM_DECLARE_TYPE_ALIGNMENT(swift::ExtensionDecl, swift::DeclAlignInBits)
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::TypeBase, swift::TypeAlignInBits)
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::ArchetypeType, swift::TypeAlignInBits)
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::TypeVariableType, swift::TypeVariableAlignInBits)
+LLVM_DECLARE_TYPE_ALIGNMENT(swift::SILFunctionType,
+                            swift::TypeVariableAlignInBits)
 
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::Stmt, swift::StmtAlignInBits)
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::BraceStmt, swift::StmtAlignInBits)


### PR DESCRIPTION
Using `DenseMap<SILAutoDiffDerivativeFunctionKey, ...>` in a file that includes
`AutoDiff.h` but not `Types.h` produced the following error:
```
swift-master/llvm-project/llvm/include/llvm/Support/PointerLikeTypeTraits.h:59:53: error: invalid application of 'alignof' to an incomplete type 'swift::SILFunctionType'
  enum { NumLowBitsAvailable = detail::ConstantLog2<alignof(T)>::value };
                                                    ^~~~~~~~~~
swift-master/llvm-project/llvm/include/llvm/ADT/DenseMapInfo.h:43:13: note: in instantiation of template class 'llvm::PointerLikeTypeTraits<swift::SILFunctionType *>' requested here
    Val <<= PointerLikeTypeTraits<T*>::NumLowBitsAvailable;
            ^
swift-master/swift/include/swift/AST/AutoDiff.h:383:46: note: in instantiation of member function 'llvm::DenseMapInfo<swift::SILFunctionType *>::getEmptyKey' requested here
    return {DenseMapInfo<SILFunctionType *>::getEmptyKey(),
                                             ^
swift-master/swift/include/swift/AST/AutoDiff.h:33:7: note: forward declaration of 'swift::SILFunctionType'
class SILFunctionType;
      ^
```

Fix the error by:
- Including `TypeAlignments.h` in `AutoDiff.h`.
- Adding an alignment forward declaration for `SILFunctionType` to `TypeAlignments.h`.

---

Resolves comment: https://github.com/apple/swift/pull/29953/files#r382372071.
No tests, since the error didn't surface in the current codebase.

I locally verified that the issue is fixed. The following changes didn't compile but now do:
```diff
diff --git a/lib/AST/AutoDiffTest.cpp b/lib/AST/AutoDiffTest.cpp
new file mode 100644
index 00000000000..ab1d4caa278
--- /dev/null
+++ b/lib/AST/AutoDiffTest.cpp
@@ -0,0 +1,9 @@
+#include "swift/AST/AutoDiff.h"
+#include "llvm/ADT/DenseMap.h"
+
+using namespace swift;
+using namespace autodiff;
+
+static void test() {
+  llvm::DenseMap<SILAutoDiffDerivativeFunctionKey, unsigned> map;
+}
diff --git a/lib/AST/CMakeLists.txt b/lib/AST/CMakeLists.txt
index 0add9c6606c..5c867797a28 100644
--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -27,6 +27,7 @@ add_swift_host_library(swiftAST STATIC
   ASTWalker.cpp
   Attr.cpp
   AutoDiff.cpp
+  AutoDiffTest.cpp
   Availability.cpp
   AvailabilitySpec.cpp
   Builtins.cpp
```