### PR TITLE
[AutoDiff] Fix `@differentiable`-related override matching crash.

### DIFF
--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -689,9 +689,6 @@ static bool hasOverridingDifferentiableAttribute(ValueDecl *derivedDecl,
         overrides = false;
         break;
       }
-      if (!derivedParameters && !baseParameters) {
-        assert(false);
-      }
     }
     if (overrides)
       return true;

--- a/test/AutoDiff/compiler_crashers_fixed/tf1167-differentiable-attr-override-match.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/tf1167-differentiable-attr-override-match.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -typecheck -verify %s
+// REQUIRES: asserts
+
+// TF-1167: `OverrideMatcher::match` crash due to meaningless assertion:
+// `assert(false)`. The assertion was triggered when parameter indices
+// could not be resolved for neither base nor derived declaration
+// `@differentiable` attributes.
+//
+// `import _Differentiation` is intentionally omitted from this test case.
+
+public protocol Base {
+  associatedtype Input
+  // expected-error @+1 {{use of undeclared type 'Differentiable'}}
+  associatedtype Output: Differentiable
+
+  // expected-error @+1 {{@differentiable attribute used without importing module '_Differentiation'}}
+  @differentiable(wrt: self)
+  func callAsFunction(_ input: Input) -> Output
+}
+public protocol Derived: Base {
+  // expected-error @+1 {{@differentiable attribute used without importing module '_Differentiation'}}
+  @differentiable
+  func callAsFunction(_ input: Input) -> Output
+}


### PR DESCRIPTION
Remove meaningless `assert(false)` assertion from
`hasOverridingDifferentiableAttribute` in `TypeCheckDeclOverride.cpp`.

The assertion served no purpose and can safely be removed.

Resolves TF-1167. Add test.

---

This issue was reproducible only on `master` branch, not `tensorflow` branch.

Example:
```swift
public protocol Base {
  associatedtype Input
  associatedtype Output: Differentiable

  @differentiable(wrt: self)
  func callAsFunction(_ input: Input) -> Output
}

public protocol Derived: Base {
  @differentiable
  func callAsFunction(_ input: Input) -> Output
} 
```

Before: crash during declaration override checking.
```console
$ swiftc -Xfrontend -enable-experimental-differentiable-programming tf-1167.swift
Assertion failed: (false), function hasOverridingDifferentiableAttribute, file swift-master/swift/lib/Sema/TypeCheckDeclOverride.cpp, line 693.
Stack dump:
...
1.	Swift version 5.2-dev (LLVM d8c7347891, Swift 8f2e22d672)
2.	While evaluating request TypeCheckSourceFileRequest(source_file "tf-1167.swift")
3.	While type-checking 'Derived' (at tf-1167.swift:9:8)
4.	While type-checking 'callAsFunction(_:)' (at tf-1167.swift:11:3)
5.	While evaluating request OverriddenDeclsRequest(main.(file).Derived.callAsFunction@tf-1167.swift:11:8)
0  swift                    0x0000000113297a55 llvm::sys::PrintStackTrace(llvm::raw_ostream&) + 37
1  swift                    0x0000000113296a08 llvm::sys::RunSignalHandlers() + 248
2  swift                    0x000000011329804c SignalHandler(int) + 268
3  libsystem_platform.dylib 0x00007fff68ed2b5d _sigtramp + 29
4  swift                    0x0000000115b6b868 cmark_strbuf__initbuf + 178715
5  libsystem_c.dylib        0x00007fff68d8c6a6 abort + 127
6  libsystem_c.dylib        0x00007fff68d5520d basename_r + 0
7  swift                    0x0000000113604403 (anonymous namespace)::OverrideMatcher::match((anonymous namespace)::OverrideCheckingAttempt) (.cold.15) + 35
8  swift                    0x000000010f9def22 (anonymous namespace)::OverrideMatcher::match((anonymous namespace)::OverrideCheckingAttempt) + 5090
```

After: no crash.
```console
$ swiftc -Xfrontend -enable-experimental-differentiable-programming tf-1167.swift
tf-1167.swift:3:26: error: use of undeclared type 'Differentiable'
  associatedtype Output: Differentiable
                         ^~~~~~~~~~~~~~
tf-1167.swift:5:4: error: @differentiable attribute used without importing module '_Differentiation'
  @differentiable(wrt: self)
  ~^~~~~~~~~~~~~~~~~~~~~~~~~
tf-1167.swift:10:4: error: @differentiable attribute used without importing module '_Differentiation'
  @differentiable
  ~^~~~~~~~~~~~~~
```