### PR TITLE
[AutoDiff] Require same access level for original/derivative functions.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3072,6 +3072,22 @@ ERROR(derivative_attr_original_already_has_derivative,none,
       "a derivative already exists for %0", (DeclName))
 NOTE(derivative_attr_duplicate_note,none,
      "other attribute declared here", ())
+ERROR(derivative_attr_access_level_lower_than_original,none,
+      "derivative functions for "
+      "%select{private|fileprivate|internal|public or '@usableFromInline'|open}1 "
+      "original function %0 must also be "
+      "%select{private|fileprivate|internal|public or '@usableFromInline'|open}1, "
+      "but %2 is %select{private|fileprivate|internal|public|open}3",
+      (/*original*/ DeclName, /*original*/ AccessLevel,
+       /*derivative*/ DeclName, /*derivative*/ AccessLevel))
+ERROR(derivative_attr_access_level_higher_than_original,none,
+      "the original function of "
+      "%select{a private|a fileprivate|an internal|a public or '@usableFromInline'|an open}3 "
+      "derivative function must also be "
+      "%select{private|fileprivate|internal|public or '@usableFromInline'|open}3, "
+      "but %0 is %select{private|fileprivate|internal|public|open}1",
+      (/*original*/ DeclName, /*original*/ AccessLevel,
+       /*derivative*/ DeclName, /*derivative*/ AccessLevel))
 
 // @transpose
 ERROR(transpose_attr_invalid_linearity_parameter_or_result,none,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4541,6 +4541,37 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
   }
   attr->setOriginalFunction(originalAFD);
 
+  // Returns true if:
+  // - Original function and derivative function has the same access level.
+  // - Original function is public and derivative function is internal
+  //   `@usableFromInline`. This is the only special case.
+  auto compatibleAccessLevels = [&]() {
+    if (originalAFD->getFormalAccess() == derivative->getFormalAccess())
+      return true;
+    return originalAFD->getFormalAccess() == AccessLevel::Public &&
+           derivative->getEffectiveAccess() == AccessLevel::Public;
+  };
+
+  // Check access level compatibility for original and derivative functions.
+  if (!compatibleAccessLevels()) {
+    auto diagID = diag::derivative_attr_access_level_higher_than_original;
+    AccessLevel originalAccess;
+    AccessLevel derivativeAccess;
+    if (originalAFD->getEffectiveAccess() < derivative->getEffectiveAccess()) {
+      originalAccess =
+          originalAFD->getFormalAccessScope().accessLevelForDiagnostics();
+      derivativeAccess = derivative->getEffectiveAccess();
+    } else {
+      diagID = diag::derivative_attr_access_level_lower_than_original;
+      originalAccess = originalAFD->getEffectiveAccess();
+      derivativeAccess =
+          derivative->getFormalAccessScope().accessLevelForDiagnostics();
+    }
+    diags.diagnose(originalName.Loc, diagID, originalAFD->getName(),
+                   originalAccess, derivative->getName(), derivativeAccess);
+    return true;
+  }
+
   // Get the resolved differentiability parameter indices.
   auto *resolvedDiffParamIndices = attr->getParameterIndices();
 

--- a/test/AutoDiff/SILGen/sil_differentiability_witness.swift
+++ b/test/AutoDiff/SILGen/sil_differentiability_witness.swift
@@ -44,7 +44,7 @@ public func foo_vjp(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
 func bar<T>(_ x: Float, _ y: T) -> Float { x }
 
 @derivative(of: bar)
-public func bar_jvp<T>(_ x: Float, _ y: T) -> (value: Float, differential: (Float) -> Float) {
+func bar_jvp<T>(_ x: Float, _ y: T) -> (value: Float, differential: (Float) -> Float) {
   (x, { $0 })
 }
 


### PR DESCRIPTION
Require `@derivative` functions and their original declarations to have the
same effective access level. Diagnose effective access level mismatches.

Resolves TF-1099 and TF-1160.

`@usableFromInline` declarations are effectively public, so public original
functions can be internal `@usableFromInline` derivatives.

This simplifies AutoDiff symbol linkage rules and paves the way for
enabling cross-file derivative registration by default: TF-1097.

Todos:
* Enable cross-file derivative registration by default and delete the
  `-Xfrontend -enable-experimental-cross-file-derivative-registration` flag.
* Upstream changes to `master`.

---

Examples:
```swift
// Good: public original ✅ ~public derivative.
public func original1(_ x: Float) -> Float { x }
@derivative(of: original1)
@usableFromInline
func derivative1(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
  fatalError()
}

// Bad: public original ❌ internal derivative.
public func original2(_ x: Float) -> Float { x }
@derivative(of: original2)
func derivative2(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
  fatalError()
}

// Bad: private original ❌ public derivative.
private func original3(_ x: Float) -> Float { x }
@derivative(of: original3)
public func derivative3(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
  fatalError()
}
```
```console
test.swift:11:17: error: derivative functions for public or '@usableFromInline' original function 'original2' must also be public or '@usableFromInline', but 'derivative2' is internal
@derivative(of: original2)
                ^
test.swift:18:17: error: the original function of a public or '@usableFromInline' derivative function must also be public or '@usableFromInline', but 'original3' is private
@derivative(of: original3)
                ^
```