### PR TITLE
build: de-GYB_SOURCES the host tools

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -4,6 +4,27 @@ include(SwiftXcodeSupport)
 include(SwiftWindowsSupport)
 include(SwiftAndroidSupport)
 
+function(_swift_gyb_target_sources target scope)
+  foreach(source ${ARGN})
+    get_filename_component(generated ${source} NAME_WLE)
+    get_filename_component(absolute ${source} REALPATH)
+
+    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${generated}
+      COMMAND
+        $<TARGET_FILE:Python2::Interpreter> ${SWIFT_SOURCE_DIR}/utils/gyb -D CMAKE_SIZEOF_VOID_P=${CMAKE_SIZEOF_VOID_P} ${SWIFT_GYB_FLAGS} -o ${CMAKE_CURRENT_BINARY_DIR}/${generated}.tmp ${absolute}
+      COMMAND
+        ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/${generated}.tmp ${CMAKE_CURRENT_BINARY_DIR}/${generated}
+      COMMAND
+        ${CMAKE_COMMAND} -E remove ${CMAKE_CURRENT_BINARY_DIR}/${generated}.tmp
+      DEPENDS
+        ${absolute})
+    set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/${generated} PROPERTIES
+      GENERATED TRUE)
+    target_sources(${target} ${scope}
+      ${CMAKE_CURRENT_BINARY_DIR}/${generated})
+  endforeach()
+endfunction()
+
 # SWIFTLIB_DIR is the directory in the build tree where Swift resource files
 # should be placed.  Note that $CMAKE_CFG_INTDIR expands to "." for
 # single-configuration builds.
@@ -532,7 +553,6 @@ function(_add_swift_host_library_single target)
         STATIC)
   set(single_parameter_options)
   set(multiple_parameter_options
-        GYB_SOURCES
         LLVM_LINK_COMPONENTS)
 
   cmake_parse_arguments(ASHLS
@@ -580,14 +600,6 @@ function(_add_swift_host_library_single target)
     set(libkind SHARED)
   elseif(ASHLS_STATIC)
     set(libkind STATIC)
-  endif()
-
-  if(ASHLS_GYB_SOURCES)
-    handle_gyb_sources(
-        gyb_dependency_targets
-        ASHLS_GYB_SOURCES
-        "${SWIFT_HOST_VARIANT_ARCH}")
-      set(ASHLS_SOURCES ${ASHLS_SOURCES} ${ASHLS_GYB_SOURCES})
   endif()
 
   add_library("${target}" ${libkind} ${ASHLS_SOURCES})

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -78,10 +78,10 @@ add_swift_host_library(swiftBasic STATIC
   # Platform-agnostic fallback TaskQueue implementation
   Default/TaskQueue.inc
 
-  GYB_SOURCES
-    UnicodeExtendedGraphemeClusters.cpp.gyb
-
   LLVM_LINK_COMPONENTS support)
+_swift_gyb_target_sources(swiftBasic PRIVATE
+    UnicodeExtendedGraphemeClusters.cpp.gyb)
+
 target_include_directories(swiftBasic PRIVATE
   ${UUID_INCLUDE})
 

--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -22,9 +22,8 @@ add_swift_host_library(swiftParse STATIC
   PersistentParserState.cpp
   Scope.cpp
   SyntaxParsingCache.cpp
-  SyntaxParsingContext.cpp
-
-  GYB_SOURCES
+  SyntaxParsingContext.cpp)
+_swift_gyb_target_sources(swiftParse PRIVATE
     ParsedSyntaxBuilders.cpp.gyb
     ParsedSyntaxNodes.cpp.gyb
     ParsedSyntaxRecorder.cpp.gyb)

--- a/lib/Syntax/CMakeLists.txt
+++ b/lib/Syntax/CMakeLists.txt
@@ -8,9 +8,8 @@ add_swift_host_library(swiftSyntax STATIC
   RawSyntax.cpp
   Syntax.cpp
   SyntaxData.cpp
-  UnknownSyntax.cpp
-
-  GYB_SOURCES
+  UnknownSyntax.cpp)
+_swift_gyb_target_sources(swiftSyntax PRIVATE
     SyntaxNodes.cpp.gyb
     SyntaxBuilders.cpp.gyb
     SyntaxKind.cpp.gyb


### PR DESCRIPTION
Use a newly introduced `swift_gyb_target_sources` to gyb and use the
generated sources when building.  Let CMake figure out when to run the
command, let it invoke the command properly, and indicate that the
sources being added to the target are generated.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
