### PR TITLE
IRGen: correct the typecast (NFC)

### DIFF
--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -988,8 +988,8 @@ DeclContext *LinkEntity::getDeclContextForEmission() const {
   case Kind::ReflectionAssociatedTypeDescriptor:
   case Kind::ProtocolWitnessTableLazyCacheVariable:
   case Kind::ProtocolWitnessTableLazyAccessFunction:
-    return getRootProtocolConformance()->getDeclContext();
-    
+    return getProtocolConformance()->getDeclContext();
+
   case Kind::TypeMetadata: {
     auto ty = getType();
     // Only fully concrete nominal type metadata gets emitted eagerly.


### PR DESCRIPTION
This seems unused currently, as attempting to query the DeclContext of
these types results in an immediate assertion that the kind of entity is
invalid.  These are non-root protocol conformances, use
`getProtocolConformance` instead of the copy-paste value of
`getRootProtocolConformance`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
