### PR TITLE
Disable test_backward_deploy_conformance completely on Swift-in-the-OS bots

### DIFF
--- a/validation-test/Evolution/test_backward_deploy_conformance.swift
+++ b/validation-test/Evolution/test_backward_deploy_conformance.swift
@@ -1,7 +1,10 @@
 // RUN: %target-resilience-test --backward-deployment
 // REQUIRES: executable_test
 
-// XFAIL: use_os_stdlib
+// This is testing a bug fix in the runtime so we don't want to run it on the
+// backward deployment bots.
+
+// UNSUPPORTED: use_os_stdlib
 
 import StdlibUnittest
 import backward_deploy_conformance


### PR DESCRIPTION
Fixes <rdar://problem/59670363>.