### PR TITLE
[5.2] Disable ExistentialSpecializer on generic functions.

### DIFF
--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
@@ -227,6 +227,16 @@ bool ExistentialSpecializer::canSpecializeCalleeFunction(FullApplySite &Apply) {
   if (Callee->hasOwnership())
     return false;
 
+  // Ignore generic functions. Generic functions should be fully specialized
+  // before attempting to introduce new generic parameters for existential
+  // arguments. Otherwise, there's no guarantee that the generic specializer
+  // will be able to specialize the new generic parameter created by this pass.
+  //
+  // Enabling this would require additional implementation work to correctly
+  // substitute the original archetypes into the new generic signature.
+  if (Callee->getLoweredFunctionType()->getSubstGenericSignature())
+    return false;
+
   /// Ignore functions with indirect results.
   if (Callee->getConventions().hasIndirectSILResults())
     return false;

--- a/test/SILOptimizer/existential_specializer_soletype.sil
+++ b/test/SILOptimizer/existential_specializer_soletype.sil
@@ -381,3 +381,66 @@ bb0(%0 : $S, %1 : $*P):
   return %15 : $()
 }
 
+//===----------------------------------------------------------------------===//
+// Test an existential with a generic constraint
+// rdar://56923071; [SR-11714]: Compiler crash when generic class is passed as
+// a parameter to a function accepting a generic class
+//
+// Allowing this results in the error:
+// SIL verification failed: Operand is of an ArchetypeType that does not exist
+// in the Caller's generic param list.: isArchetypeValidInFunction(A, F)
+//
+// This could be fixed by preserving the original function's
+// archetypes when rewriting the generic signature. However, the
+// ExistentialSpecializer should not specialize generic functions in
+// the first place because, without partial specialization, there's no
+// guarantee that the new generic form will be able to be
+// specialized. Preferably, all other generic parameters will be
+// specialized first before attempting to specialize the existential.
+//===----------------------------------------------------------------------===//
+
+public class ClassA<T> { }
+
+public protocol ProtocolA {
+  func foo() -> Int
+}
+
+public class ClassB<T> : ClassA<T> {
+  public func foo() -> Int
+  override init()
+}
+
+extension ClassB : ProtocolA {}
+
+// Pass an existential argument that happens to also have a generic constraint.
+//
+// CHECK-LABEL: sil @testExistentialGenericConstraint : $@convention(thin) <T> (@guaranteed ClassB<T>) -> Int {
+// CHECK:   [[E:%.*]] = init_existential_ref %0 : $ClassB<T> : $ClassB<T>, $ClassA<T> & ProtocolA
+// CHECK:   [[F:%.*]] = function_ref @testExistentialGenericConstraintHelper : $@convention(thin) <τ_0_0> (@guaranteed ClassA<τ_0_0> & ProtocolA) -> Int
+// CHECK:   apply [[F]]<T>([[E]]) : $@convention(thin) <τ_0_0> (@guaranteed ClassA<τ_0_0> & ProtocolA) -> Int
+// CHECK-LABEL: } // end sil function 'testExistentialGenericConstraint'
+sil @testExistentialGenericConstraint : $@convention(thin) <T> (@guaranteed ClassB<T>) -> Int {
+bb0(%0 : $ClassB<T>):
+  strong_retain %0 : $ClassB<T>
+  %3 = init_existential_ref %0 : $ClassB<T> : $ClassB<T>, $ClassA<T> & ProtocolA
+  %4 = function_ref @testExistentialGenericConstraintHelper : $@convention(thin) <τ_0_0> (@guaranteed ClassA<τ_0_0> & ProtocolA) -> Int
+  %5 = apply %4<T>(%3) : $@convention(thin) <τ_0_0> (@guaranteed ClassA<τ_0_0> & ProtocolA) -> Int
+  strong_release %3 : $ClassA<T> & ProtocolA
+  return %5 : $Int
+}
+
+// This generic function should not be "specialized" by ExistentialSpecializer, which would add more generic parameters.
+//
+// CHECK-LABEL: sil hidden @testExistentialGenericConstraintHelper : $@convention(thin) <T> (@guaranteed ClassA<T> & ProtocolA) -> Int {
+// CHECK: bb0(%0 : $ClassA<T> & ProtocolA):
+// CHECK-LABEL: } // end sil function 'testExistentialGenericConstraintHelper'
+sil hidden @testExistentialGenericConstraintHelper : $@convention(thin) <T> (@guaranteed ClassA<T> & ProtocolA) -> Int {
+bb0(%0 : $ClassA<T> & ProtocolA):
+  %2 = open_existential_ref %0 : $ClassA<T> & ProtocolA to $@opened("92C29DA8-5479-11EA-8668-ACDE48001122") ClassA<T> & ProtocolA
+  %3 = alloc_stack $@opened("92C29DA8-5479-11EA-8668-ACDE48001122") ClassA<T> & ProtocolA
+  store %2 to %3 : $*@opened("92C29DA8-5479-11EA-8668-ACDE48001122") ClassA<T> & ProtocolA
+  %5 = witness_method $@opened("92C29DA8-5479-11EA-8668-ACDE48001122") ClassA<T> & ProtocolA, #ProtocolA.foo!1 : <Self where Self : ProtocolA> (Self) -> () -> Int, %2 : $@opened("92C29DA8-5479-11EA-8668-ACDE48001122") ClassA<T> & ProtocolA : $@convention(witness_method: ProtocolA) <τ_0_0 where τ_0_0 : ProtocolA> (@in_guaranteed τ_0_0) -> Int
+  %6 = apply %5<@opened("92C29DA8-5479-11EA-8668-ACDE48001122") ClassA<T> & ProtocolA>(%3) : $@convention(witness_method: ProtocolA) <τ_0_0 where τ_0_0 : ProtocolA> (@in_guaranteed τ_0_0) -> Int
+  dealloc_stack %3 : $*@opened("92C29DA8-5479-11EA-8668-ACDE48001122") ClassA<T> & ProtocolA
+  return %6 : $Int
+}

--- a/test/SILOptimizer/existential_transform.swift
+++ b/test/SILOptimizer/existential_transform.swift
@@ -288,21 +288,17 @@ class GC: GP {
 func wrap_gcp<T:GP>(_ a:T,_ b:GP) -> Int {
   return a.foo() + b.foo()
 }
+// For this case to be handled by ExistentialSpecializer, GenericSpecializer needs to run first to remove the generic argument.
+//
 // CHECK-LABEL: sil hidden [noinline] @$s21existential_transform3gcpySixAA2GPRzlF : $@convention(thin) <T where T : GP> (@in_guaranteed T) -> Int {
 // CHECK: bb0(%0 : $*T):
-// CHECK: debug_value_addr 
-// CHECK: alloc_ref 
-// CHECK: debug_value
-// CHECK: debug_value 
-// CHECK: alloc_stack 
-// CHECK: init_existential_addr 
-// CHECK: store
-// CHECK: function_ref @$s21existential_transform8wrap_gcpySix_AA2GP_ptAaCRzlFTf4ne_n : $@convention(thin) <τ_0_0 where τ_0_0 : GP><τ_1_0 where τ_1_0 : GP> (@in_guaranteed τ_0_0, @in_guaranteed τ_1_0) -> Int 
-// CHECK: open_existential_addr 
-// CHECK: strong_retain 
-// CHECK: apply
+// CHECK: [[REF:%.*]] = alloc_ref
+// CHECK: [[E:%.*]] = alloc_stack
+// CHECK: [[EADR:%.*]] = init_existential_addr [[E]]
+// CHECK: store [[REF]] to [[EADR]]
+// CHECK: [[F:%.*]] = function_ref @$s21existential_transform8wrap_gcpySix_AA2GP_ptAaCRzlF : $@convention(thin) <τ_0_0 where τ_0_0 : GP> (@in_guaranteed τ_0_0, @in_guaranteed GP) -> Int
+// CHECK: apply [[F]]<T>(%0, [[E]]) : $@convention(thin) <τ_0_0 where τ_0_0 : GP> (@in_guaranteed τ_0_0, @in_guaranteed GP) -> Int
 // CHECK: destroy_addr 
-// CHECK: strong_release 
 // CHECK: dealloc_stack
 // CHECK: return 
 // CHECK: } // end sil function '$s21existential_transform3gcpySixAA2GPRzlF'
@@ -314,22 +310,17 @@ func wrap_gcp<T:GP>(_ a:T,_ b:GP) -> Int {
 func wrap_gcp_arch<T:GP>(_ a:T,_ b:GP, _ c:inout Array<T>) -> Int {
   return a.foo() + b.foo() + c[0].foo()
 }
+// For this case to be handled by ExistentialSpecializer, GenericSpecializer needs to run first to remove the generic argument.
+//
 // CHECK-LABEL: sil hidden [noinline] @$s21existential_transform8gcp_archySix_SayxGztAA2GPRzlF : $@convention(thin) <T where T : GP> (@in_guaranteed T, @inout Array<T>) -> Int {
 // CHECK: bb0(%0 : $*T, %1 : $*Array<T>):
-// CHECK: debug_value_addr
-// CHECK: debug_value_addr
-// CHECK: alloc_ref
-// CHECK: debug_value
-// CHECK: debug_value
-// CHECK: alloc_stack
-// CHECK: init_existential_addr
-// CHECK: store
-// CHECK: function_ref @$s21existential_transform13wrap_gcp_archySix_AA2GP_pSayxGztAaCRzlFTf4nen_n : $@convention(thin) <τ_0_0 where τ_0_0 : GP><τ_1_0 where τ_1_0 : GP> (@in_guaranteed τ_0_0, @in_guaranteed τ_1_0, @inout Array<τ_0_0>) -> Int
-// CHECK: open_existential_addr
-// CHECK: strong_retain
-// CHECK: apply
+// CHECK: [[REF:%.*]] = alloc_ref
+// CHECK: [[E:%.*]] = alloc_stack
+// CHECK: [[EADR:%.*]] = init_existential_addr [[E]]
+// CHECK: store [[REF]] to [[EADR]]
+// CHECK: [[F:%.*]] = function_ref @$s21existential_transform13wrap_gcp_archySix_AA2GP_pSayxGztAaCRzlF : $@convention(thin) <τ_0_0 where τ_0_0 : GP> (@in_guaranteed τ_0_0, @in_guaranteed GP, @inout Array<τ_0_0>) -> Int
+// CHECK: apply [[F]]<T>(%0, [[E]], %1) : $@convention(thin) <τ_0_0 where τ_0_0 : GP> (@in_guaranteed τ_0_0, @in_guaranteed GP, @inout Array<τ_0_0>) -> Int
 // CHECK: destroy_addr
-// CHECK: strong_release
 // CHECK: dealloc_stack
 // CHECK: return
 // CHECK-LABEL: } // end sil function '$s21existential_transform8gcp_archySix_SayxGztAA2GPRzlF'


### PR DESCRIPTION
This is not implemented--we don't substitute the original archetypes
properly or even create a well-formed generic signature.

It doesn't make sense to me for the ExistentialSpecializer to work on
a generic before it has been fully specialized anyway. The premise of
this pass is that the generic specializer will be able to fully
specialize after generating a new "temporary" generic parameter.

Fixes rdar://56923071; [SR-11714]: Compiler crash when generic class is passed as
a parameter to a function accepting a generic class

(cherry picked from commit b38ca0c37b7bad1caecab840e85c95ea63c188ca)