### PR TITLE
[build] Fix TensorFlow configure script invocation.

### DIFF
--- a/utils/configure-tensorflow-defaults
+++ b/utils/configure-tensorflow-defaults
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-yes "" | ./configure


### PR DESCRIPTION
Fix TensorFlow configure script invocation: `yes "" | ./configure`

Previously, we invoked a bash script containing `yes "" | ./configure` via
Python `subprocess`. This hangs on macOS with Python 2 (but not Python 3).

Now, pipe commands using Python `subprocess` instead of running the bash script.
This does not hang with Python 2 or Python 3.

---

I'm currently verifying whether this fixes macOS toolchain builds, before merging.