### PR TITLE
[CodeCompletion] Re-implement generic requirement completion

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -507,7 +507,7 @@ enum class CompletionKind {
   AfterPoundDirective,
   PlatformConditon,
   AfterIfStmtElse,
-  GenericParams,
+  GenericRequirement,
   PrecedenceGroup,
 };
 

--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -217,7 +217,7 @@ public:
 
   virtual void completeAfterIfStmt(bool hasElse) {};
 
-  virtual void completeGenericParams(TypeLoc TL) {};
+  virtual void completeGenericRequirement(TypeLoc TL) {};
 
   /// Signals that the AST for the all the delayed-parsed code was
   /// constructed.  No \c complete*() callbacks will be done after this.

--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -217,7 +217,7 @@ public:
 
   virtual void completeAfterIfStmt(bool hasElse) {};
 
-  virtual void completeGenericRequirement(TypeLoc TL) {};
+  virtual void completeGenericRequirement() {};
 
   /// Signals that the AST for the all the delayed-parsed code was
   /// constructed.  No \c complete*() callbacks will be done after this.

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3959,7 +3959,6 @@ public:
   }
 
   void getGenericRequirementCompletions(DeclContext *DC) {
-
     auto genericSig = DC->getGenericSignatureOfContext();
     if (!genericSig)
       return;
@@ -3968,8 +3967,12 @@ public:
       addGenericTypeParamRef(GPT->getDecl(),
                              DeclVisibilityKind::GenericParameter, {});
     }
-    
-    auto selfTy = DC->getSelfTypeInContext();
+
+    auto typeContext = DC->getInnermostTypeContext();
+    if (!typeContext)
+      return;
+
+    auto selfTy = typeContext->getSelfTypeInContext();
     Kind = LookupKind::GenericRequirement;
     this->BaseType = selfTy;
     NeedLeadingDot = false;

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1580,18 +1580,9 @@ private:
     archeTy = archeTy->getRoot();
 
     // For protocol, the 'archeTy' should match with the 'baseTy' which is the
-    // dynamic 'Self' type of the protocol.
-    if (archeTy->isEqual(selfTy))
-      return true;
-
-    // For nominal decls, 'archTy' should be one of the generic parameters.
-    if (selfTy->castTo<BoundGenericType>() &&
-        llvm::any_of(selfTy->castTo<BoundGenericType>()->getGenericArgs(),
-                     [&](const Type &T) { return archeTy->isEqual(T); }))
-      return true;
-
-
-    return false;
+    // dynamic 'Self' type of the protocol. For nominal decls, 'archTy' should
+    // be one of the generic params in 'selfTy'. Search 'archeTy' in 'baseTy'.
+    return selfTy.findIf([&](Type T) { return archeTy->isEqual(T); });
   }
 
 public:

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1375,7 +1375,7 @@ public:
                               Optional<StmtKind> ParentKind) override;
   void completeAfterPoundDirective() override;
   void completePlatformCondition() override;
-  void completeGenericParams(TypeLoc TL) override;
+  void completeGenericRequirement(TypeLoc TL) override;
   void completeAfterIfStmt(bool hasElse) override;
 
   void doneParsing() override;
@@ -3959,7 +3959,6 @@ public:
   }
 
   void getGenericRequirementCompletions(Type BaseType) {
-    llvm::errs() << "getGenericParamCompletions\n";
     auto GTD = BaseType->getAnyGeneric();
     if (!GTD)
       return;
@@ -4886,9 +4885,9 @@ void CodeCompletionCallbacksImpl::completeAfterIfStmt(bool hasElse) {
   }
 }
 
-void CodeCompletionCallbacksImpl::completeGenericParams(TypeLoc TL) {
+void CodeCompletionCallbacksImpl::completeGenericRequirement(TypeLoc TL) {
   CurDeclContext = P.CurDeclContext;
-  Kind = CompletionKind::GenericParams;
+  Kind = CompletionKind::GenericRequirement;
   ParsedTypeLoc = TL;
 }
 
@@ -5024,7 +5023,7 @@ void CodeCompletionCallbacksImpl::addKeywords(CodeCompletionResultSink &Sink,
   case CompletionKind::AfterPoundExpr:
   case CompletionKind::AfterPoundDirective:
   case CompletionKind::PlatformConditon:
-  case CompletionKind::GenericParams:
+  case CompletionKind::GenericRequirement:
   case CompletionKind::KeyPathExprObjC:
   case CompletionKind::KeyPathExprSwift:
   case CompletionKind::PrecedenceGroup:
@@ -5614,7 +5613,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
     break;
   }
 
-  case CompletionKind::GenericParams:
+  case CompletionKind::GenericRequirement:
     Lookup.getGenericRequirementCompletions(ParsedTypeLoc.getType());
     break;
   case CompletionKind::PrecedenceGroup:

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3968,6 +3968,11 @@ public:
                              DeclVisibilityKind::GenericParameter, {});
     }
 
+    // For non-protocol nominal type decls, only suggest generic parameters.
+    if (auto D = DC->getAsDecl())
+      if (isa<NominalTypeDecl>(D) && !isa<ProtocolDecl>(D))
+        return;
+
     auto typeContext = DC->getInnermostTypeContext();
     if (!typeContext)
       return;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4640,7 +4640,7 @@ Parser::parseDeclExtension(ParseDeclOptions Flags, DeclAttributes &Attributes) {
                                                         requirements);
     } else if (whereStatus.hasCodeCompletion()) {
       if (CodeCompletion && firstTypeInComplete) {
-        CodeCompletion->completeGenericParams(extendedType.getPtrOrNull());
+        CodeCompletion->completeGenericRequirement(extendedType.getPtrOrNull());
       } else
         return makeParserCodeCompletionResult<ExtensionDecl>();
     }

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -279,6 +279,14 @@ ParserStatus Parser::parseGenericWhereClause(
     Optional<SyntaxParsingContext> BodyContext;
     BodyContext.emplace(SyntaxContext);
 
+    if (Tok.is(tok::code_complete)) {
+      if (CodeCompletion)
+        CodeCompletion->completeGenericRequirement();
+      consumeToken(tok::code_complete);
+      Status.setHasCodeCompletion();
+      break;
+    }
+
     // Parse the leading type. It doesn't necessarily have to be just a type
     // identifier if we're dealing with a same-type constraint.
     ParserResult<TypeRepr> FirstType = parseType();

--- a/test/IDE/complete_where_clause.swift
+++ b/test/IDE/complete_where_clause.swift
@@ -34,6 +34,10 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_SELF | %FileCheck %s -check-prefix=PROTOCOL_SELF
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NOMINAL_TYPEALIAS | %FileCheck %s -check-prefix=NOMINAL_TYPEALIAS
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NOMINAL_TYPEALIAS_EXT | %FileCheck %s -check-prefix=NOMINAL_TYPEALIAS_EXT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NOMINAL_TYPEALIAS_NESTED1 | %FileCheck %s -check-prefix=NOMINAL_TYPEALIAS_NESTED1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NOMINAL_TYPEALIAS_NESTED2 | %FileCheck %s -check-prefix=NOMINAL_TYPEALIAS_NESTED2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NOMINAL_TYPEALIAS_NESTED1_EXT | %FileCheck %s -check-prefix=NOMINAL_TYPEALIAS_NESTED1_EXT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NOMINAL_TYPEALIAS_NESTED2_EXT | %FileCheck %s -check-prefix=NOMINAL_TYPEALIAS_NESTED2_EXT
 
 class A1<T1, T2, T3> {}
 
@@ -191,3 +195,34 @@ extension TA1 where #^NOMINAL_TYPEALIAS_EXT^# { }
 // NOMINAL_TYPEALIAS_EXT-DAG: Decl[GenericTypeParam]/Local:       T[#T#];
 // NOMINAL_TYPEALIAS_EXT-DAG: Decl[TypeAlias]/CurrNominal:        U[#T.Q#];
 // NOMINAL_TYPEALIAS_EXT: End completions
+
+struct TA2<T: Assoc> {
+  struct Inner1<U> where #^NOMINAL_TYPEALIAS_NESTED1^# {
+    typealias X1 = T
+    typealias X2 = T.Q
+  }
+// NOMINAL_TYPEALIAS_NESTED1: Begin completions, 2 items
+// NOMINAL_TYPEALIAS_NESTED1-DAG: Decl[GenericTypeParam]/Local:       T[#T#];
+// NOMINAL_TYPEALIAS_NESTED1-DAG: Decl[GenericTypeParam]/Local:       U[#U#];
+// NOMINAL_TYPEALIAS_NESTED1: End completions
+  struct Inner2 where #^NOMINAL_TYPEALIAS_NESTED2^# {
+    typealias X1 = T
+    typealias X2 = T.Q
+  }
+// NOMINAL_TYPEALIAS_NESTED2: Begin completions, 1 items
+// NOMINAL_TYPEALIAS_NESTED2-DAG: Decl[GenericTypeParam]/Local:       T[#T#];
+// NOMINAL_TYPEALIAS_NESTED2: End completions
+}
+extension TA2.Inner1 where #^NOMINAL_TYPEALIAS_NESTED1_EXT^# {}
+// NOMINAL_TYPEALIAS_NESTED1_EXT: Begin completions, 4 items
+// NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Decl[GenericTypeParam]/Local:       T[#T#];
+// NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Decl[GenericTypeParam]/Local:       U[#U#];
+// NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Decl[TypeAlias]/CurrNominal:        X1[#T#];
+// NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Decl[TypeAlias]/CurrNominal:        X2[#T.Q#];
+// NOMINAL_TYPEALIAS_NESTED1_EXT: End completions
+extension TA2.Inner2 where #^NOMINAL_TYPEALIAS_NESTED2_EXT^# {}
+// NOMINAL_TYPEALIAS_NESTED2_EXT: Begin completions, 3 items
+// NOMINAL_TYPEALIAS_NESTED2_EXT-DAG: Decl[GenericTypeParam]/Local:       T[#T#];
+// NOMINAL_TYPEALIAS_NESTED2_EXT-DAG: Decl[TypeAlias]/CurrNominal:        X1[#T#];
+// NOMINAL_TYPEALIAS_NESTED2_EXT-DAG: Decl[TypeAlias]/CurrNominal:        X2[#T.Q#];
+// NOMINAL_TYPEALIAS_NESTED2_EXT: End completions

--- a/test/IDE/complete_where_clause.swift
+++ b/test/IDE/complete_where_clause.swift
@@ -32,6 +32,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL | %FileCheck %s -check-prefix=PROTOCOL
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_EXT | %FileCheck %s -check-prefix=PROTOCOL
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_SELF | %FileCheck %s -check-prefix=PROTOCOL_SELF
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NOMINAL_TYPEALIAS | %FileCheck %s -check-prefix=NOMINAL_TYPEALIAS
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NOMINAL_TYPEALIAS_EXT | %FileCheck %s -check-prefix=NOMINAL_TYPEALIAS_EXT
 
 class A1<T1, T2, T3> {}
 
@@ -177,3 +179,15 @@ protocol P4 where Self.#^PROTOCOL_SELF^# {
 // PROTOCOL_SELF-DAG: Decl[TypeAlias]/CurrNominal:        IntAlias[#Int#];
 // PROTOCOL_SELF-DAG: Keyword/None:                       Type[#Self.Type#];
 // PROTOCOL_SELF: End completions
+
+struct TA1<T: Assoc> where #^NOMINAL_TYPEALIAS^# {
+  typealias U = T.Q
+}
+// NOMINAL_TYPEALIAS: Begin completions, 1 items
+// NOMINAL_TYPEALIAS-DAG: Decl[GenericTypeParam]/Local:       T[#T#];
+// NOMINAL_TYPEALIAS: End completions
+extension TA1 where #^NOMINAL_TYPEALIAS_EXT^# { }
+// NOMINAL_TYPEALIAS_EXT: Begin completions, 2 items
+// NOMINAL_TYPEALIAS_EXT-DAG: Decl[GenericTypeParam]/Local:       T[#T#];
+// NOMINAL_TYPEALIAS_EXT-DAG: Decl[TypeAlias]/CurrNominal:        U[#T.Q#];
+// NOMINAL_TYPEALIAS_EXT: End completions

--- a/test/IDE/complete_where_clause.swift
+++ b/test/IDE/complete_where_clause.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GP3 | %FileCheck %s -check-prefix=A1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GP4 | %FileCheck %s -check-prefix=TYPE1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GP5 | %FileCheck %s -check-prefix=TYPE1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GP6 | %FileCheck %s -check-prefix=A1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GP6 | %FileCheck %s -check-prefix=EMPTY
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FUNC_ASSOC_NODUP_1 | %FileCheck %s -check-prefix=GEN_T_ASSOC_E
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FUNC_ASSOC_NODUP_2 | %FileCheck %s -check-prefix=GEN_T_ASSOC_E
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FUNC_1 | %FileCheck %s -check-prefix=GEN_T
@@ -21,7 +21,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ALIAS_2 | %FileCheck %s -check-prefix=GEN_T_DOT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STRUCT_1 | %FileCheck %s -check-prefix=GEN_T_NOMINAL
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STRUCT_2 | %FileCheck %s -check-prefix=GEN_T_DOT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STRUCT_3 | %FileCheck %s -check-prefix=GEN_T_NOMINAL
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STRUCT_3 | %FileCheck %s -check-prefix=ANYTYPE
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STRUCT_4 | %FileCheck %s -check-prefix=GEN_T_DOT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CLASS_1 | %FileCheck %s -check-prefix=GEN_T_NOMINAL
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CLASS_2 | %FileCheck %s -check-prefix=GEN_T_DOT
@@ -29,6 +29,9 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ENUM_2 | %FileCheck %s -check-prefix=GEN_T_DOT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ASSOC_1 | %FileCheck %s -check-prefix=P2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ASSOC_2 | %FileCheck %s -check-prefix=U_DOT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL | %FileCheck %s -check-prefix=PROTOCOL
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_EXT | %FileCheck %s -check-prefix=PROTOCOL
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_SELF | %FileCheck %s -check-prefix=PROTOCOL_SELF
 
 class A1<T1, T2, T3> {}
 
@@ -64,6 +67,10 @@ extension A1 where T1.#^GP6^# {}
 // TYPE1-NOT: T3
 // TYPE1-NOT: T4
 // TYPE1-NOT: T5
+
+// EMPTY: Begin completions, 1 items
+// EMPTY-DAG: Keyword/None: Type[#T1.Type#]; name=Type
+// EMPTY: End completions
 
 protocol A {associatedtype E}
 protocol B {associatedtype E}
@@ -118,20 +125,55 @@ class C1<T> where #^CLASS_1^# {}
 class C2<T> where T.#^CLASS_2^# {}
 enum E1<T> where #^ENUM_1^# {}
 enum E2<T> where T.#^ENUM_2^# {}
+// GEN_T_NOMINAL: Begin completions, 1 items
 // GEN_T_NOMINAL: Decl[GenericTypeParam]/Local: T[#T#]; name=T
+// GEN_T_NOMINAL: End completions
+
+// ANYTYPE: Begin completions
+// ANYTYPE-DAG: Decl[GenericTypeParam]/Local: T[#T#];
+// ANYTYPE-DAG: Decl[Class]/CurrModule: A1[#A1#];
+// ANYTYPE-DAG: Decl[Struct]/OtherModule[Swift]: Int[#Int#];
+// ANYTYPE: End completions
 
 protocol P2 {
   associatedtype T where #^ASSOC_1^#
   associatedtype U: Assoc where U.#^ASSOC_2^#
 }
 
-// P2: Begin completions
+// P2: Begin completions, 3 items
 // P2-DAG: Decl[GenericTypeParam]/Local: Self[#Self#];
 // P2-DAG: Decl[AssociatedType]/{{Super|CurrNominal}}: T;
 // P2-DAG: Decl[AssociatedType]/{{Super|CurrNominal}}: U;
 // P2: End completions
 
-// U_DOT: Begin completions
-// FIXME: Should complete Q from Assoc.
+// U_DOT: Begin completions, 2 items
 // U_DOT-DAG: Keyword/None:                       Type[#Self.U.Type#];
+// U_DOT-DAG: Decl[AssociatedType]/CurrNominal:   Q;
 // U_DOT: End completions
+
+protocol P3 where #^PROTOCOL^# {
+  associatedtype T: Assoc
+  typealias U = T.Q
+  typealias IntAlias = Int
+}
+// PROTOCOL: Begin completions, 3 items
+// PROTOCOL-DAG: Decl[GenericTypeParam]/Local:       Self[#Self#];
+// PROTOCOL-DAG: Decl[AssociatedType]/CurrNominal:   T;
+// PROTOCOL-DAG: Decl[TypeAlias]/CurrNominal:        U[#Self.T.Q#];
+// PROTOCOL: End completions
+
+extension P3 where #^PROTOCOL_EXT^# {
+  // Same as PROTOCOL
+}
+
+protocol P4 where Self.#^PROTOCOL_SELF^# {
+  associatedtype T: Assoc
+  typealias U = T.Q
+  typealias IntAlias = Int
+}
+// PROTOCOL_SELF: Begin completions, 4 items
+// PROTOCOL_SELF-DAG: Decl[AssociatedType]/CurrNominal:   T;
+// PROTOCOL_SELF-DAG: Decl[TypeAlias]/CurrNominal:        U[#Self.T.Q#];
+// PROTOCOL_SELF-DAG: Decl[TypeAlias]/CurrNominal:        IntAlias[#Int#];
+// PROTOCOL_SELF-DAG: Keyword/None:                       Type[#Self.Type#];
+// PROTOCOL_SELF: End completions


### PR DESCRIPTION
- Rename `completeGenericParam()` -> `completeGenericRequirement()` because it also suggests `associatedtype`s
- Get the target generic context from the current decl context
- Generalize `completeGenericRequirement()` to handle all `where` clause (not only `extension` decl).
- Suggest `associatedtype`s in protocol context rdar://problem/58580482 
- Suggest `typealias`es as long as they are aliases of associated types, generic parameters, or their dependent member types.
