### PR TITLE
[ClangImporter] Add a regression test for an refined explicit setter

### DIFF
--- a/test/ClangImporter/Inputs/frameworks/CategoryOverrides.framework/Headers/CategoryOverrides.h
+++ b/test/ClangImporter/Inputs/frameworks/CategoryOverrides.framework/Headers/CategoryOverrides.h
@@ -33,6 +33,10 @@ typedef enum {
 @property (nonatomic, readonly) RefinedSugar sugar /*NS_REFINED_FOR_SWIFT*/ __attribute__((swift_private));
 @end
 
+@interface ExtraRefinery : Base
+@property (nonatomic, readonly) RefinedSugar sugar /*NS_REFINED_FOR_SWIFT*/ __attribute__((swift_private));
+@end
+
 @protocol NullableProtocol
 @property (nonatomic, readonly, nullable) Base *requirement;
 @end

--- a/test/ClangImporter/Inputs/frameworks/CategoryOverrides.framework/PrivateHeaders/Private.h
+++ b/test/ClangImporter/Inputs/frameworks/CategoryOverrides.framework/PrivateHeaders/Private.h
@@ -19,6 +19,10 @@
 @property (nonatomic, readwrite) RefinedSugar sugar;
 @end
 
+@interface ExtraRefinery ()
+- (void)setSugar:(RefinedSugar)sugar;
+@end
+
 @interface MyBaseClass () <NonNullProtocol>
 @end
 

--- a/test/ClangImporter/objc_redeclared_properties_categories.swift
+++ b/test/ClangImporter/objc_redeclared_properties_categories.swift
@@ -78,6 +78,12 @@ func takesARefinery(_ x: Refinery) {
   x.sugar = .caster
 }
 
+func takesAnExtraRefinery(_ x: ExtraRefinery) {
+  // CHECK: has no member 'sugar'
+  x.sugar = .caster
+  x.setSugar(0)
+}
+
 func nullabilityRefinementProto(_ x: MyBaseClass) {
   // CHECK-PUBLIC: has no member 'requirement'
   // CHECK-PRIVATE-NOT: has no member 'requirement'


### PR DESCRIPTION
Ensure that we don't import the setter as a separate property, or in
a way that would clobber the refined property's lack of a setter in
Swift.
