### PR TITLE
[README] Add note about ASCII-only paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ First create a directory for all of the Swift sources:
 **Note:** This is important since update-checkout (see below) checks out
 repositories next to the Swift source directory. This means that if one clones
 Swift and has other unrelated repositories, update-checkout may not clone those
-repositories and will update them instead.
+repositories and will update them instead. Be aware that `update-checkout`
+currently does not support paths with non-ASCII characters. If such characters
+are present in the path to `swift-source`, `update-checkout` will fail.
 
 **Via HTTPS**  For those checking out sources as read-only, HTTPS works best:
 


### PR DESCRIPTION
Add a note to the README that `update-checkout` does not support non-ASCII characters in the path to `swift-source`.

I'm in the process of trying to build the Swift project for the first time and `update-checkout` failed on an error similar to the one described [here](https://forums.swift.org/t/cant-re-checkout-swift-program-due-to-python-unicode-error/30226). @owenv's reply mentions that the problem might be with non-ASCII paths, which turned out to be the problem – I had a folder named `Práce` (Work) in the path.

This is probably a non-issue for folks with English as their primary language, but it might help others.