### PR TITLE
[AutoDiff] Support `inout` argument differentiation.

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -122,6 +122,13 @@ struct AutoDiffConfig {
   SWIFT_DEBUG_DUMP;
 };
 
+/// A semantic function result type: either a formal function result type or
+/// an `inout` parameter type. Used in derivative function type calculation.
+struct AutoDiffSemanticFunctionResultType {
+  Type type;
+  bool isInout;
+};
+
 /// Key for caching SIL derivative function types.
 struct SILAutoDiffDerivativeFunctionKey {
   SILFunctionType *originalType;
@@ -271,11 +278,17 @@ using SILDifferentiabilityWitnessKey = std::pair<StringRef, AutoDiffConfig>;
 /// Automatic differentiation utility namespace.
 namespace autodiff {
 
-/// Appends the subset's parameter's types to `results`, in the order in
-/// which they appear in the function type.
-void getSubsetParameterTypes(IndexSubset *indices, AnyFunctionType *type,
-                             SmallVectorImpl<Type> &results,
-                             bool reverseCurryLevels = false);
+/// Given a function type, collects its semantic result types in type order
+/// into `result`: first, the formal result type (if non-`Void`), followed by
+/// `inout` parameter types.
+///
+/// The function type may have at most two parameter lists.
+///
+/// Remaps the original semantic result using `genericEnv`, if specified.
+void getFunctionSemanticResultTypes(
+    AnyFunctionType *functionType,
+    SmallVectorImpl<AutoDiffSemanticFunctionResultType> &result,
+    GenericEnvironment *genericEnv = nullptr);
 
 /// "Constrained" derivative generic signatures require all differentiability
 /// parameters to conform to the `Differentiable` protocol.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2978,8 +2978,6 @@ ERROR(implements_attr_protocol_not_conformed_to,none,
       (DeclName, DeclName))
 
 // @differentiable
-ERROR(differentiable_attr_void_result,none,
-      "cannot differentiate void function %0", (DeclName))
 ERROR(differentiable_attr_no_vjp_or_jvp_when_linear,none,
       "cannot specify 'vjp:' or 'jvp:' for linear functions; use '@transpose' "
       "attribute for transpose registration instead", ())
@@ -3097,6 +3095,11 @@ ERROR(autodiff_attr_original_decl_none_valid_found,none,
       "could not find function %0 with expected type %1", (DeclNameRef, Type))
 ERROR(autodiff_attr_original_decl_not_same_type_context,none,
       "%0 is not defined in the current type context", (DeclNameRef))
+ERROR(autodiff_attr_original_void_result,none,
+      "cannot differentiate void function %0", (DeclName))
+ERROR(autodiff_attr_original_multiple_semantic_results,none,
+      "cannot differentiate functions with both an 'inout' parameter and a "
+      "result", ())
 
 // differentiation `wrt` parameters clause
 ERROR(diff_function_no_parameters,none,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3214,6 +3214,16 @@ public:
     return getExtInfo().getRepresentation();
   }
 
+  /// Appends the parameters indicated by `parameterIndices` to `results`.
+  ///
+  /// For curried function types: if `reverseCurryLevels` is true, append
+  /// the `self` parameter last instead of first.
+  ///
+  /// TODO(TF-874): Simplify logic and remove the `reverseCurryLevels` flag.
+  void getSubsetParameters(IndexSubset *parameterIndices,
+                           SmallVectorImpl<AnyFunctionType::Param> &results,
+                           bool reverseCurryLevels = false);
+
   /// Returns the derivative function type for the given parameter indices,
   /// result index, derivative function kind, derivative function generic
   /// signature (optional), and other auxiliary parameters.
@@ -3221,8 +3231,8 @@ public:
   /// Preconditions:
   /// - Parameters corresponding to parameter indices must conform to
   ///   `Differentiable`.
-  /// - The result corresponding to the result index must conform to
-  ///   `Differentiable`.
+  /// - There is one semantic function result type: either the formal original
+  ///   result or an `inout` parameter. It must conform to `Differentiable`.
   ///
   /// Typing rules, given:
   /// - Original function type. Three cases:
@@ -3268,6 +3278,11 @@ public:
   ///              original result | deriv. wrt result | deriv. wrt params
   /// \endverbatim
   ///
+  /// The original type may have `inout` parameters. If so, the
+  /// differential/pullback typing rules are more nuanced: see documentation for
+  /// `getAutoDiffDerivativeFunctionLinearMapType` for details. Semantically,
+  /// `inout` parameters behave as both parameters and results.
+  ///
   /// By default, if the original type has a `self` parameter list and parameter
   /// indices include `self`, the computed derivative function type will return
   /// a linear map taking/returning self's tangent *last* instead of first, for
@@ -3278,14 +3293,57 @@ public:
   /// derivative function types, e.g. when type-checking `@differentiable` and
   /// `@derivative` attributes.
   AnyFunctionType *getAutoDiffDerivativeFunctionType(
-      IndexSubset *parameterIndices, unsigned resultIndex,
-      AutoDiffDerivativeFunctionKind kind,
+      IndexSubset *parameterIndices, AutoDiffDerivativeFunctionKind kind,
       LookupConformanceFn lookupConformance,
       GenericSignature derivativeGenericSignature = GenericSignature(),
       bool makeSelfParamFirst = false);
 
+  /// Returns the corresponding linear map function type for the given parameter
+  /// indices, linear map function kind, and other auxiliary parameters.
+  ///
+  /// Preconditions:
+  /// - Parameters corresponding to parameter indices must conform to
+  ///   `Differentiable`.
+  /// - There is one semantic function result type: either the formal original
+  ///   result or an `inout` parameter. It must conform to `Differentiable`.
+  ///
+  /// Differential typing rules: takes "wrt" parameter derivatives and returns a
+  /// "wrt" result derivative.
+  ///
+  /// - Case 1: original function has no `inout` parameters.
+  ///   - Original:     `(T0, T1, ...) -> R`
+  ///   - Differential: `(T0.Tan, T1.Tan, ...) -> R.Tan`
+  /// - Case 2: original function has a non-wrt `inout` parameter.
+  ///   - Original:     `(T0, inout T1, ...) -> Void`
+  ///   - Differential: `(T0.Tan, ...) -> T1.Tan`
+  /// - Case 3: original function has a wrt `inout` parameter.
+  ///   - Original:     `(T0, inout T1, ...) -> Void`
+  ///   - Differential: `(T0.Tan, inout T1.Tan, ...) -> Void`
+  ///
+  /// Pullback typing rules: takes a "wrt" result derivative and returns "wrt"
+  /// parameter derivatives.
+  ///
+  /// - Case 1: original function has no `inout` parameters.
+  ///   - Original: `(T0, T1, ...) -> R`
+  ///   - Pullback: `R.Tan -> (T0.Tan, T1.Tan, ...)`
+  /// - Case 2: original function has a non-wrt `inout` parameter.
+  ///   - Original: `(T0, inout T1, ...) -> Void`
+  ///   - Pullback: `(T1.Tan) -> (T0.Tan, ...)`
+  /// - Case 3: original function has a wrt `inout` parameter.
+  ///   - Original: `(T0, inout T1, ...) -> Void`
+  ///   - Pullback: `(inout T1.Tan) -> (T0.Tan, ...)`
+  ///
+  /// If `makeSelfParamFirst` is true, `self`'s tangent is reordered to appear
+  /// first. `makeSelfParamFirst` should be true when working with user-facing
+  /// derivative function types, e.g. when type-checking `@differentiable` and
+  /// `@derivative` attributes.
+  AnyFunctionType *getAutoDiffDerivativeFunctionLinearMapType(
+      IndexSubset *parameterIndices, AutoDiffLinearMapKind kind,
+      LookupConformanceFn lookupConformance, bool makeSelfParamFirst = false);
+
   // SWIFT_ENABLE_TENSORFLOW
   AnyFunctionType *getWithoutDifferentiability() const;
+  // SWIFT_ENABLE_TENSORFLOW END
 
   /// True if the parameter declaration it is attached to is guaranteed
   /// to not persist the closure for longer than the duration of the call.
@@ -4420,6 +4478,28 @@ public:
     return getParameters().back();
   }
 
+  struct IndirectMutatingParameterFilter {
+    bool operator()(SILParameterInfo param) const {
+      return param.isIndirectMutating();
+    }
+  };
+  using IndirectMutatingParameterIter =
+      llvm::filter_iterator<const SILParameterInfo *,
+                            IndirectMutatingParameterFilter>;
+  using IndirectMutatingParameterRange =
+      iterator_range<IndirectMutatingParameterIter>;
+
+  /// A range of SILParameterInfo for all indirect mutating parameters.
+  IndirectMutatingParameterRange getIndirectMutatingParameters() const {
+    return llvm::make_filter_range(getParameters(),
+                                   IndirectMutatingParameterFilter());
+  }
+
+  /// Returns the number of indirect mutating parameters.
+  unsigned getNumIndirectMutatingParameters() const {
+    return llvm::count_if(getParameters(), IndirectMutatingParameterFilter());
+  }
+
   /// Get the generic signature used to apply the substitutions of a substituted function type
   CanGenericSignature getSubstGenericSignature() const {
     return GenericSigAndIsImplied.getPointer();
@@ -4488,18 +4568,27 @@ public:
   /// - Returns original results, followed by a differential function, which
   ///   takes "wrt" parameter derivatives and returns a "wrt" result derivative.
   ///
+  /// \verbatim
   ///     $(T0, ...) -> (R0, ...,  (T0.Tan, T1.Tan, ...) -> R0.Tan)
   ///                    ^~~~~~~    ^~~~~~~~~~~~~~~~~~~     ^~~~~~
   ///          original results | derivatives wrt params | derivative wrt result
+  /// \endverbatim
   ///
   /// VJP derivative type:
   /// - Takes original parameters.
   /// - Returns original results, followed by a pullback function, which
   ///   takes a "wrt" result derivative and returns "wrt" parameter derivatives.
   ///
+  /// \verbatim
   ///     $(T0, ...) -> (R0, ...,       (R0.Tan)  ->     (T0.Tan, T1.Tan, ...))
   ///                    ^~~~~~~         ^~~~~~            ^~~~~~~~~~~~~~~~~~~
   ///          original results | derivative wrt result | derivatives wrt params
+  /// \endverbatim
+  ///
+  /// The original type may have `inout` parameters. If so, the
+  /// differential/pullback typing rules are more nuanced: see documentation for
+  /// `getAutoDiffDerivativeFunctionLinearMapType` for details. Semantically,
+  /// `inout` parameters behave as both parameters and results.
   ///
   /// A "constrained derivative generic signature" is computed from
   /// `derivativeFunctionGenericSignature`, if specified. Otherwise, it is

--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -1146,8 +1146,7 @@ public:
   /// The arguments are the same as the arguments to
   /// `AnyFunctionType::getAutoDiffDerivativeFunctionType()`.
   AbstractionPattern getAutoDiffDerivativeFunctionType(
-      IndexSubset *indices, unsigned resultIndex,
-      AutoDiffDerivativeFunctionKind kind,
+      IndexSubset *indices, AutoDiffDerivativeFunctionKind kind,
       LookupConformanceFn lookupConformance,
       GenericSignature derivativeGenericSignature = GenericSignature(),
       bool makeSelfParamFirst = false);

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/AST/ASTContext.h"
 #include "swift/AST/AutoDiff.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/Types.h"
@@ -73,13 +73,11 @@ static unsigned countNumFlattenedElementTypes(Type type) {
 }
 
 // TODO(TF-874): Simplify this helper and remove the `reverseCurryLevels` flag.
-// See TF-874 for WIP.
-void autodiff::getSubsetParameterTypes(IndexSubset *subset,
-                                       AnyFunctionType *type,
-                                       SmallVectorImpl<Type> &results,
-                                       bool reverseCurryLevels) {
+void AnyFunctionType::getSubsetParameters(
+    IndexSubset *parameterIndices,
+    SmallVectorImpl<AnyFunctionType::Param> &results, bool reverseCurryLevels) {
   SmallVector<AnyFunctionType *, 2> curryLevels;
-  unwrapCurryLevels(type, curryLevels);
+  unwrapCurryLevels(this, curryLevels);
 
   SmallVector<unsigned, 2> curryLevelParameterIndexOffsets(curryLevels.size());
   unsigned currentOffset = 0;
@@ -100,8 +98,43 @@ void autodiff::getSubsetParameterTypes(IndexSubset *subset,
     unsigned parameterIndexOffset =
         curryLevelParameterIndexOffsets[curryLevelIndex];
     for (unsigned paramIndex : range(curryLevel->getNumParams()))
-      if (subset->contains(parameterIndexOffset + paramIndex))
-        results.push_back(curryLevel->getParams()[paramIndex].getOldType());
+      if (parameterIndices->contains(parameterIndexOffset + paramIndex))
+        results.push_back(curryLevel->getParams()[paramIndex]);
+  }
+}
+
+void autodiff::getFunctionSemanticResultTypes(
+    AnyFunctionType *functionType,
+    SmallVectorImpl<AutoDiffSemanticFunctionResultType> &result,
+    GenericEnvironment *genericEnv) {
+  auto &ctx = functionType->getASTContext();
+
+  // Remap type in `genericEnv`, if specified.
+  auto remap = [&](Type type) {
+    if (!genericEnv)
+      return type;
+    return genericEnv->mapTypeIntoContext(type);
+  };
+
+  // Collect formal result type as a semantic result, unless it is
+  // `Void`.
+  auto formalResultType = functionType->getResult();
+  if (auto *resultFunctionType =
+          functionType->getResult()->getAs<AnyFunctionType>()) {
+    formalResultType = resultFunctionType->getResult();
+  }
+  if (!formalResultType->isEqual(ctx.TheEmptyTupleType))
+    result.push_back({remap(formalResultType), /*isInout*/ false});
+
+  // Collect `inout` parameters as semantic results.
+  for (auto param : functionType->getParams())
+    if (param.isInOut())
+      result.push_back({remap(param.getPlainType()), /*isInout*/ true});
+  if (auto *resultFunctionType =
+          functionType->getResult()->getAs<AnyFunctionType>()) {
+    for (auto param : resultFunctionType->getParams())
+      if (param.isInOut())
+        result.push_back({remap(param.getPlainType()), /*isInout*/ true});
   }
 }
 

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1035,7 +1035,7 @@ static ValueDecl *getAutoDiffApplyDerivativeFunction(
   BuiltinFunctionBuilder::LambdaGenerator resultGen{
       [=, &Context](BuiltinFunctionBuilder &builder) -> Type {
         auto derivativeFnTy = diffFnType->getAutoDiffDerivativeFunctionType(
-            paramIndices, /*resultIndex*/ 0, kind,
+            paramIndices, kind,
             LookUpConformanceInModule(Context.TheBuiltinModule));
         return derivativeFnTy->getResult();
       }};

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4932,9 +4932,9 @@ makeFunctionType(ArrayRef<AnyFunctionType::Param> parameters, Type resultType,
 }
 
 AnyFunctionType *AnyFunctionType::getAutoDiffDerivativeFunctionType(
-    IndexSubset *parameterIndices, unsigned resultIndex,
-    AutoDiffDerivativeFunctionKind kind, LookupConformanceFn lookupConformance,
-    GenericSignature derivativeGenSig, bool makeSelfParamFirst) {
+    IndexSubset *parameterIndices, AutoDiffDerivativeFunctionKind kind,
+    LookupConformanceFn lookupConformance, GenericSignature derivativeGenSig,
+    bool makeSelfParamFirst) {
   assert(!parameterIndices->isEmpty() &&
          "Expected at least one differentiability parameter");
   auto &ctx = getASTContext();
@@ -4943,11 +4943,6 @@ AnyFunctionType *AnyFunctionType::getAutoDiffDerivativeFunctionType(
   // generic signature.
   if (!derivativeGenSig)
     derivativeGenSig = getOptGenericSignature();
-
-  // Get differentiability parameter types.
-  SmallVector<Type, 8> diffParamTypes;
-  autodiff::getSubsetParameterTypes(parameterIndices, this, diffParamTypes,
-                                    /*reverseCurryLevels*/ !makeSelfParamFirst);
 
   // Unwrap curry levels. At most, two parameter lists are necessary, for
   // curried method types with a `(Self)` parameter list.
@@ -4962,65 +4957,11 @@ AnyFunctionType *AnyFunctionType::getAutoDiffDerivativeFunctionType(
     currentLevel = currentLevel->getResult()->getAs<AnyFunctionType>();
   }
 
-  Type originalResult = curryLevels.back()->getResult();
+  auto originalResult = curryLevels.back()->getResult();
 
-  // Build the result linear map function type.
-  Type linearMapType;
-  switch (kind) {
-  case AutoDiffDerivativeFunctionKind::JVP: {
-    // Differential function type, a result of the JVP:
-    //   `LinearMapType = (T.TangentVector, ...) -> (R.TangentVector)`
-    SmallVector<AnyFunctionType::Param, 8> differentialParams;
-    for (auto diffParamType : diffParamTypes)
-      differentialParams.push_back(AnyFunctionType::Param(
-          diffParamType->getAutoDiffTangentSpace(lookupConformance)
-              ->getType()));
-    SmallVector<TupleTypeElt, 8> differentialResults;
-    if (auto *resultTuple = originalResult->getAs<TupleType>()) {
-      auto resultTupleEltType = resultTuple->getElementType(resultIndex);
-      differentialResults.push_back(
-          resultTupleEltType->getAutoDiffTangentSpace(lookupConformance)
-              ->getType());
-    } else {
-      assert(resultIndex == 0 && "resultIndex out of bounds");
-      differentialResults.push_back(
-          originalResult->getAutoDiffTangentSpace(lookupConformance)
-              ->getType());
-    }
-    Type differentialResult = differentialResults.size() > 1
-                                  ? TupleType::get(differentialResults, ctx)
-                                  : differentialResults[0].getType();
-    linearMapType = FunctionType::get(differentialParams, differentialResult);
-    break;
-  }
-  case AutoDiffDerivativeFunctionKind::VJP: {
-    // Pullback function type, a result of the VJP:
-    //   `LinearMapType = (R.TangentVector) -> (T.TangentVector, ...)`
-    SmallVector<AnyFunctionType::Param, 8> pullbackParams;
-    if (auto *resultTuple = originalResult->getAs<TupleType>()) {
-      auto resultTupleEltType = resultTuple->getElementType(resultIndex);
-      pullbackParams.push_back(AnyFunctionType::Param(
-          resultTupleEltType->getAutoDiffTangentSpace(lookupConformance)
-              ->getType()));
-    } else {
-      assert(resultIndex == 0 &&
-             "Expected result index 0 for non-tuple result");
-      pullbackParams.push_back(AnyFunctionType::Param(
-          originalResult->getAutoDiffTangentSpace(lookupConformance)
-              ->getType()));
-    }
-    SmallVector<TupleTypeElt, 8> pullbackResults;
-    for (auto diffParamType : diffParamTypes)
-      pullbackResults.push_back(
-          diffParamType->getAutoDiffTangentSpace(lookupConformance)->getType());
-    Type pullbackResult = pullbackResults.size() > 1
-                              ? TupleType::get(pullbackResults, ctx)
-                              : pullbackResults[0].getType();
-    linearMapType = FunctionType::get(pullbackParams, pullbackResult);
-    break;
-  }
-  }
-  assert(linearMapType && "Expected linear map type");
+  Type linearMapType = getAutoDiffDerivativeFunctionLinearMapType(
+      parameterIndices, kind.getLinearMapKind(), lookupConformance,
+      makeSelfParamFirst);
 
   // Build the full derivative function type: `(T...) -> (R, LinearMapType)`.
   SmallVector<TupleTypeElt, 2> retElts;
@@ -5045,6 +4986,111 @@ AnyFunctionType *AnyFunctionType::getAutoDiffDerivativeFunctionType(
   }
 
   return derivativeFunctionType;
+}
+
+AnyFunctionType *AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
+    IndexSubset *parameterIndices, AutoDiffLinearMapKind kind,
+    LookupConformanceFn lookupConformance, bool makeSelfParamFirst) {
+  assert(!parameterIndices->isEmpty() &&
+         "Expected at least one differentiability parameter");
+  auto &ctx = getASTContext();
+
+  // Get differentiability parameters.
+  SmallVector<AnyFunctionType::Param, 8> diffParams;
+  getSubsetParameters(parameterIndices, diffParams,
+                      /*reverseCurryLevels*/ !makeSelfParamFirst);
+
+  // Get the original semantic result type.
+  SmallVector<AutoDiffSemanticFunctionResultType, 1> originalResults;
+  autodiff::getFunctionSemanticResultTypes(this, originalResults);
+  assert(originalResults.size() == 1 &&
+         "Only functions with one semantic result are currently supported");
+  auto originalResult = originalResults.front();
+  auto originalResultType = originalResult.type;
+
+  // Get the original semantic result type's `TangentVector` associated type.
+  auto resultTan =
+      originalResultType->getAutoDiffTangentSpace(lookupConformance);
+  assert(resultTan && "Original result has no tangent space?");
+  auto resultTanType = resultTan->getType();
+
+  // Compute the result linear map function type.
+  FunctionType *linearMapType;
+  switch (kind) {
+  case AutoDiffLinearMapKind::Differential: {
+    // Compute the differential type, returned by JVP functions.
+    //
+    // Case 1: original function has no `inout` parameters.
+    // - Original:     `(T0, T1, ...) -> R`
+    // - Differential: `(T0.Tan, T1.Tan, ...) -> R.Tan`
+    //
+    // Case 2: original function has a non-wrt `inout` parameter.
+    // - Original:      `(T0, inout T1, ...) -> Void`
+    // - Differential: `(T0.Tan, ...) -> T1.Tan`
+    //
+    // Case 3: original function has a wrt `inout` parameter.
+    // - Original:     `(T0, inout T1, ...) -> Void`
+    // - Differential: `(T0.Tan, inout T1.Tan, ...) -> Void`
+    SmallVector<AnyFunctionType::Param, 4> differentialParams;
+    bool hasInoutDiffParameter = false;
+    for (auto diffParam : diffParams) {
+      auto paramType = diffParam.getPlainType();
+      auto paramTan = paramType->getAutoDiffTangentSpace(lookupConformance);
+      assert(paramTan && "Parameter has no tangent space?");
+      differentialParams.push_back(AnyFunctionType::Param(
+          paramTan->getType(), Identifier(), diffParam.getParameterFlags()));
+      if (diffParam.isInOut())
+        hasInoutDiffParameter = true;
+    }
+    auto differentialResult =
+        hasInoutDiffParameter ? Type(ctx.TheEmptyTupleType) : resultTanType;
+    linearMapType = FunctionType::get(differentialParams, differentialResult);
+    break;
+  }
+  case AutoDiffLinearMapKind::Pullback: {
+    // Compute the pullback type, returned by VJP functions.
+    //
+    // Case 1: original function has no `inout` parameters.
+    // - Original: `(T0, T1, ...) -> R`
+    // - Pullback: `R.Tan -> (T0.Tan, T1.Tan, ...)`
+    //
+    // Case 2: original function has a non-wrt `inout` parameter.
+    // - Original: `(T0, inout T1, ...) -> Void`
+    // - Pullback: `(T1.Tan) -> (T0.Tan, ...)`
+    //
+    // Case 3: original function has a wrt `inout` parameter.
+    // - Original: `(T0, inout T1, ...) -> Void`
+    // - Pullback: `(inout T1.Tan) -> (T0.Tan, ...)`
+    SmallVector<TupleTypeElt, 4> pullbackResults;
+    bool hasInoutDiffParameter = false;
+    for (auto diffParam : diffParams) {
+      auto paramType = diffParam.getPlainType();
+      auto paramTan = paramType->getAutoDiffTangentSpace(lookupConformance);
+      assert(paramTan && "Parameter has no tangent space?");
+      if (diffParam.isInOut()) {
+        hasInoutDiffParameter = true;
+        continue;
+      }
+      pullbackResults.push_back(TupleTypeElt(paramTan->getType(), Identifier(),
+                                             diffParam.getParameterFlags()));
+    }
+    Type pullbackResult;
+    if (pullbackResults.empty()) {
+      pullbackResult = ctx.TheEmptyTupleType;
+    } else if (pullbackResults.size() == 1) {
+      pullbackResult = pullbackResults.front().getType();
+    } else {
+      pullbackResult = TupleType::get(pullbackResults, ctx);
+    }
+    auto flags = ParameterTypeFlags().withInOut(hasInoutDiffParameter);
+    auto pullbackParam =
+        AnyFunctionType::Param(resultTanType, Identifier(), flags);
+    linearMapType = FunctionType::get({pullbackParam}, pullbackResult);
+    break;
+  }
+  }
+  assert(linearMapType && "Expected linear map type");
+  return linearMapType;
 }
 
 CanSILFunctionType

--- a/lib/SIL/AbstractionPattern.cpp
+++ b/lib/SIL/AbstractionPattern.cpp
@@ -926,8 +926,8 @@ const {
 }
 
 AbstractionPattern AbstractionPattern::getAutoDiffDerivativeFunctionType(
-    IndexSubset *indices, unsigned resultIndex,
-    AutoDiffDerivativeFunctionKind kind, LookupConformanceFn lookupConformance,
+    IndexSubset *indices, AutoDiffDerivativeFunctionKind kind,
+    LookupConformanceFn lookupConformance,
     GenericSignature derivativeGenericSignature, bool makeSelfParamFirst) {
   switch (getKind()) {
   case Kind::Type: {
@@ -935,8 +935,8 @@ AbstractionPattern AbstractionPattern::getAutoDiffDerivativeFunctionType(
     if (!fnTy)
       return getOpaqueDerivativeFunction();
     auto derivativeFnTy = fnTy->getAutoDiffDerivativeFunctionType(
-        indices, resultIndex, kind, lookupConformance,
-        derivativeGenericSignature, makeSelfParamFirst);
+        indices, kind, lookupConformance, derivativeGenericSignature,
+        makeSelfParamFirst);
     assert(derivativeFnTy);
     return AbstractionPattern(getGenericSignature(),
                               derivativeFnTy->getCanonicalType());

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -318,6 +318,22 @@ CanSILFunctionType SILFunctionType::getAutoDiffDerivativeFunctionType(
     return {tanType, conv};
   };
 
+  // Compute the original semantic results: original formal results, followed by
+  // `inout` parameters in type order.
+  SmallVector<SILResultInfo, 2> originalResults;
+  originalResults.append(getResults().begin(), getResults().end());
+  Optional<SILParameterInfo> inoutParam = None;
+  bool isWrtInoutParameter = false;
+  for (auto i : range(getNumParameters())) {
+    auto param = getParameters()[i];
+    if (!param.isIndirectInOut())
+      continue;
+    inoutParam = param;
+    isWrtInoutParameter = parameterIndices->contains(i);
+    originalResults.push_back(
+        SILResultInfo(param.getInterfaceType(), ResultConvention::Indirect));
+  }
+
   CanSILFunctionType closureType;
   switch (kind) {
   case AutoDiffDerivativeFunctionKind::JVP: {
@@ -330,14 +346,15 @@ CanSILFunctionType SILFunctionType::getAutoDiffDerivativeFunctionType(
       differentialParams.push_back(
           {paramTan->getCanonicalType(), param.getConvention()});
     }
-    SmallVector<SILResultInfo, 8> differentialResults;
-    auto &result = getResults()[resultIndex];
-    auto resultTan =
-        result.getInterfaceType()->getAutoDiffTangentSpace(
-            lookupConformance);
-    assert(resultTan && "Result type does not have a tangent space?");
-    differentialResults.push_back(
-        {resultTan->getCanonicalType(), result.getConvention()});
+    SmallVector<SILResultInfo, 1> differentialResults;
+    if (!inoutParam || !isWrtInoutParameter) {
+      auto &result = originalResults[resultIndex];
+      auto resultTan =
+          result.getInterfaceType()->getAutoDiffTangentSpace(lookupConformance);
+      assert(resultTan && "Result type does not have a tangent space?");
+      differentialResults.push_back(
+          {resultTan->getCanonicalType(), result.getConvention()});
+    }
     closureType = SILFunctionType::get(
         /*genericSignature*/ nullptr, ExtInfo(), SILCoroutineKind::None,
         ParameterConvention::Direct_Guaranteed, differentialParams, {},
@@ -346,17 +363,28 @@ CanSILFunctionType SILFunctionType::getAutoDiffDerivativeFunctionType(
     break;
   }
   case AutoDiffDerivativeFunctionKind::VJP: {
-    SmallVector<SILParameterInfo, 8> pullbackParams;
-    auto &origRes = getResults()[resultIndex];
-    auto resultTan =
-        origRes.getInterfaceType()->getAutoDiffTangentSpace(
-            lookupConformance);
-    assert(resultTan && "Result type does not have a tangent space?");
-    pullbackParams.push_back(
-        getTangentParameterInfoForOriginalResult(resultTan->getCanonicalType(),
-                                                 origRes.getConvention()));
+    SmallVector<SILParameterInfo, 1> pullbackParams;
+    if (inoutParam) {
+      auto paramTan = inoutParam->getInterfaceType()->getAutoDiffTangentSpace(
+          lookupConformance);
+      assert(paramTan && "Parameter type does not have a tangent space?");
+      auto paramTanConvention =
+          isWrtInoutParameter ? inoutParam->getConvention()
+                              : ParameterConvention::Indirect_In_Guaranteed;
+      pullbackParams.push_back(
+          SILParameterInfo(paramTan->getCanonicalType(), paramTanConvention));
+    } else {
+      auto &origRes = originalResults[resultIndex];
+      auto resultTan = origRes.getInterfaceType()->getAutoDiffTangentSpace(
+          lookupConformance);
+      assert(resultTan && "Result type does not have a tangent space?");
+      pullbackParams.push_back(getTangentParameterInfoForOriginalResult(
+          resultTan->getCanonicalType(), origRes.getConvention()));
+    }
     SmallVector<SILResultInfo, 8> pullbackResults;
     for (auto &param : diffParams) {
+      if (param.isIndirectInOut())
+        continue;
       auto paramTan =
           param.getInterfaceType()->getAutoDiffTangentSpace(
               lookupConformance);

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -231,7 +231,8 @@ CanSILFunctionType SILFunctionType::getAutoDiffDerivativeFunctionType(
     LookupConformanceFn lookupConformance,
     CanGenericSignature derivativeFnGenSig, bool isReabstractionThunk) {
   auto &ctx = getASTContext();
-  auto resultIndices = IndexSubset::get(ctx, getNumResults(), {resultIndex});
+  auto *resultIndices = IndexSubset::get(
+      ctx, getNumResults() + getNumIndirectMutatingParameters(), {resultIndex});
   SILAutoDiffDerivativeFunctionKey key{
       this, parameterIndices,   resultIndices,
       kind, derivativeFnGenSig, isReabstractionThunk};

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -2181,8 +2181,8 @@ CanAnyFunctionType TypeConverter::makeConstantInterfaceType(SILDeclRef c) {
     auto originalFnTy =
         makeConstantInterfaceType(c.asAutoDiffOriginalFunction());
     auto *fnTy = originalFnTy->getAutoDiffDerivativeFunctionType(
-        autoDiffFuncId->getParameterIndices(), /*resultIndex*/ 0,
-        autoDiffFuncId->getKind(), LookUpConformanceInModule(&M));
+        autoDiffFuncId->getParameterIndices(), autoDiffFuncId->getKind(),
+        LookUpConformanceInModule(&M));
     return cast<AnyFunctionType>(fnTy->getCanonicalType());
   }
 

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3342,18 +3342,18 @@ static ManagedValue createAutoDiffThunk(SILGenFunction &SGF,
   auto *parameterIndices = IndexSubset::get(SGF.getASTContext(), parameterBits);
 
   auto getDerivativeFnTy =
-      [&](CanAnyFunctionType fnTy, AutoDiffDerivativeFunctionKind kind)
-          -> CanAnyFunctionType {
-        auto assocTy = fnTy->getAutoDiffDerivativeFunctionType(
-            parameterIndices, /*resultIndex*/ 0,
-            kind, LookUpConformanceInModule(SGF.SGM.M.getSwiftModule()));
-        return cast<AnyFunctionType>(assocTy->getCanonicalType());
-      };
+      [&](CanAnyFunctionType fnTy,
+          AutoDiffDerivativeFunctionKind kind) -> CanAnyFunctionType {
+    auto assocTy = fnTy->getAutoDiffDerivativeFunctionType(
+        parameterIndices, kind,
+        LookUpConformanceInModule(SGF.SGM.M.getSwiftModule()));
+    return cast<AnyFunctionType>(assocTy->getCanonicalType());
+  };
   auto getDerivativeFnPattern =
       [&](AbstractionPattern pattern,
           AutoDiffDerivativeFunctionKind kind) -> AbstractionPattern {
     return pattern.getAutoDiffDerivativeFunctionType(
-        parameterIndices, /*resultIndex*/ 0, kind,
+        parameterIndices, kind,
         LookUpConformanceInModule(SGF.SGM.M.getSwiftModule()));
   };
   auto createDerivativeFnThunk =

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -508,9 +508,10 @@ emitDerivativeFunctionReference(
     auto *originalFn = originalFRI->getReferencedFunctionOrNull();
     assert(originalFn);
     auto originalFnTy = originalFn->getLoweredFunctionType();
-    auto *desiredResultIndices =
-        IndexSubset::get(context.getASTContext(), originalFnTy->getNumResults(),
-                         {desiredIndices.source});
+    auto numResults = originalFnTy->getNumResults() +
+                      originalFnTy->getNumIndirectMutatingParameters();
+    auto *desiredResultIndices = IndexSubset::get(
+        context.getASTContext(), numResults, {desiredIndices.source});
     auto *desiredParameterIndices = desiredIndices.parameters;
     // NOTE(TF-893): Extending capacity is necessary when `originalFnTy` has
     // parameters corresponding to captured variables.
@@ -550,9 +551,19 @@ emitDerivativeFunctionReference(
         }
       }
       // Check and diagnose non-differentiable results.
-      if (!originalFnTy->getResults()[desiredIndices.source]
-               .getSILStorageInterfaceType()
-               .isDifferentiable(context.getModule())) {
+      SILType resultType;
+      if (desiredIndices.source >= originalFnTy->getNumResults()) {
+        auto inoutParamIdx =
+            desiredIndices.source - originalFnTy->getNumResults();
+        auto inoutParam =
+            *std::next(originalFnTy->getIndirectMutatingParameters().begin(),
+                       inoutParamIdx);
+        resultType = inoutParam.getSILStorageInterfaceType();
+      } else {
+        resultType = originalFnTy->getResults()[desiredIndices.source]
+                         .getSILStorageInterfaceType();
+      }
+      if (!resultType.isDifferentiable(context.getModule())) {
         context.emitNondifferentiabilityError(
             original, invoker, diag::autodiff_nondifferentiable_result);
         return None;

--- a/lib/SILOptimizer/Utils/Differentiation/Common.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/Common.cpp
@@ -119,6 +119,15 @@ void collectAllFormalResultsInTypeOrder(SILFunction &function,
   for (auto &resInfo : convs.getResults())
     results.push_back(resInfo.isFormalDirect() ? dirResults[dirResIdx++]
                                                : indResults[indResIdx++]);
+  // Treat `inout` parameters as semantic results.
+  // Append `inout` parameters after formal results.
+  for (auto i : range(convs.getNumParameters())) {
+    auto paramInfo = convs.getParameters()[i];
+    if (!paramInfo.isIndirectMutating())
+      continue;
+    auto *argument = function.getArgumentsWithoutIndirectResults()[i];
+    results.push_back(argument);
+  }
 }
 
 /// Given a function, gathers all of its direct results in an order defined by
@@ -194,8 +203,21 @@ void collectMinimalIndicesForFunctionCall(
       ++indResIdx;
     }
   }
+  // Record all `inout` parameters as results.
+  auto inoutParamResultIndex = calleeFnTy->getNumResults();
+  for (auto &paramAndIdx : enumerate(calleeConvs.getParameters())) {
+    auto &param = paramAndIdx.value();
+    if (!param.isIndirectMutating())
+      continue;
+    unsigned idx = paramAndIdx.index();
+    auto inoutArg = ai->getArgument(idx);
+    results.push_back(inoutArg);
+    resultIndices.push_back(inoutParamResultIndex++);
+  }
   // Make sure the function call has active results.
-  assert(results.size() == calleeFnTy->getNumResults());
+  auto numResults = calleeFnTy->getNumResults() +
+                    calleeFnTy->getNumIndirectMutatingParameters();
+  assert(results.size() == numResults);
   assert(llvm::any_of(results, [&](SILValue result) {
     return activityInfo.isActive(result, parentIndices);
   }));

--- a/lib/SILOptimizer/Utils/Differentiation/JVPEmitter.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/JVPEmitter.cpp
@@ -1000,7 +1000,7 @@ void JVPEmitter::prepareForDifferentialGeneration() {
   // Initialize tangent mapping for indirect results.
   auto origIndResults = original->getIndirectResults();
   auto diffIndResults = differential.getIndirectResults();
-  size_t numInoutParameters = llvm::count_if(
+  unsigned numInoutParameters = llvm::count_if(
       original->getLoweredFunctionType()->getParameters(),
       [](SILParameterInfo paramInfo) { return paramInfo.isIndirectInOut(); });
   assert(origIndResults.size() + numInoutParameters == diffIndResults.size());

--- a/lib/SILOptimizer/Utils/Differentiation/JVPEmitter.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/JVPEmitter.cpp
@@ -1000,10 +1000,12 @@ void JVPEmitter::prepareForDifferentialGeneration() {
   // Initialize tangent mapping for indirect results.
   auto origIndResults = original->getIndirectResults();
   auto diffIndResults = differential.getIndirectResults();
-  assert(origIndResults.size() == diffIndResults.size());
-
+  size_t numInoutParameters = llvm::count_if(
+      original->getLoweredFunctionType()->getParameters(),
+      [](SILParameterInfo paramInfo) { return paramInfo.isIndirectInOut(); });
+  assert(origIndResults.size() + numInoutParameters == diffIndResults.size());
   for (auto &origBB : *original)
-    for (auto i : indices(diffIndResults))
+    for (auto i : indices(origIndResults))
       setTangentBuffer(&origBB, origIndResults[i], diffIndResults[i]);
 }
 
@@ -1036,14 +1038,29 @@ JVPEmitter::createEmptyDifferential(ADContext &context,
   auto indices = witness->getSILAutoDiffIndices();
 
   // Add differential results.
-  auto origResult = origTy->getResults()[indices.source];
-  origResult = origResult.getWithInterfaceType(
-      origResult.getInterfaceType()->getCanonicalType(witnessCanGenSig));
-  dfResults.push_back(
-      SILResultInfo(origResult.getInterfaceType()
-                        ->getAutoDiffTangentSpace(lookupConformance)
-                        ->getCanonicalType(),
-                    origResult.getConvention()));
+  Optional<SILParameterInfo> inoutDiffParam = None;
+  for (auto origParam : origTy->getParameters()) {
+    if (!origParam.isIndirectInOut())
+      continue;
+    inoutDiffParam = origParam;
+  }
+
+  if (inoutDiffParam) {
+    dfResults.push_back(
+        SILResultInfo(inoutDiffParam->getInterfaceType()
+                          ->getAutoDiffTangentSpace(lookupConformance)
+                          ->getCanonicalType(),
+                      ResultConvention::Indirect));
+  } else {
+    auto origResult = origTy->getResults()[indices.source];
+    origResult = origResult.getWithInterfaceType(
+        origResult.getInterfaceType()->getCanonicalType(witnessCanGenSig));
+    dfResults.push_back(
+        SILResultInfo(origResult.getInterfaceType()
+                          ->getAutoDiffTangentSpace(lookupConformance)
+                          ->getCanonicalType(),
+                      origResult.getConvention()));
+  }
 
   // Add differential parameters for the requested wrt parameters.
   for (auto i : indices.parameters->getIndices()) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3185,20 +3185,12 @@ static bool checkDifferentiabilityParameters(
   }
 
   // Check that differentiability parameters have allowed types.
-  SmallVector<Type, 4> diffParamTypes;
-  autodiff::getSubsetParameterTypes(diffParamIndices, functionType,
-                                    diffParamTypes);
-  for (unsigned i : range(diffParamTypes.size())) {
+  SmallVector<AnyFunctionType::Param, 4> diffParams;
+  functionType->getSubsetParameters(diffParamIndices, diffParams);
+  for (unsigned i : range(diffParams.size())) {
     SourceLoc loc =
         parsedDiffParams.empty() ? attrLoc : parsedDiffParams[i].getLoc();
-    auto diffParamType = diffParamTypes[i];
-    // `inout` parameters are not yet supported.
-    if (diffParamType->is<InOutType>()) {
-      diags.diagnose(loc,
-                     diag::diff_params_clause_cannot_diff_wrt_inout_parameter,
-                     diffParamType);
-      return true;
-    }
+    auto diffParamType = diffParams[i].getPlainType();
     if (!diffParamType->hasTypeParameter())
       diffParamType = diffParamType->mapTypeOutOfContext();
     if (derivativeGenEnv)
@@ -3356,7 +3348,7 @@ static bool checkFunctionSignature(
   if (!std::equal(required->getParams().begin(), required->getParams().end(),
                   candidateFnTy->getParams().begin(),
                   [&](AnyFunctionType::Param x, AnyFunctionType::Param y) {
-                    return x.getPlainType()->isEqual(mapType(y.getPlainType()));
+                    return x.getOldType()->isEqual(mapType(y.getOldType()));
                   }))
     return false;
 
@@ -3883,9 +3875,8 @@ bool resolveDifferentiableAttrDerivativeFunctions(
   // Resolve the JVP function, if it is specified and exists.
   if (attr->getJVP()) {
     auto *expectedJVPFnTy = originalFnTy->getAutoDiffDerivativeFunctionType(
-        resolvedDiffParamIndices, /*resultIndex*/ 0,
-        AutoDiffDerivativeFunctionKind::JVP, lookupConformance,
-        derivativeGenSig, /*makeSelfParamFirst*/ true);
+        resolvedDiffParamIndices, AutoDiffDerivativeFunctionKind::JVP,
+        lookupConformance, derivativeGenSig, /*makeSelfParamFirst*/ true);
     auto isValidJVP = [&](AbstractFunctionDecl *jvpCandidate) -> bool {
       return checkFunctionSignature(
           cast<AnyFunctionType>(expectedJVPFnTy->getCanonicalType()),
@@ -3904,9 +3895,8 @@ bool resolveDifferentiableAttrDerivativeFunctions(
   // Resolve the VJP function, if it is specified and exists.
   if (attr->getVJP()) {
     auto *expectedVJPFnTy = originalFnTy->getAutoDiffDerivativeFunctionType(
-        resolvedDiffParamIndices, /*resultIndex*/ 0,
-        AutoDiffDerivativeFunctionKind::VJP, lookupConformance,
-        derivativeGenSig, /*makeSelfParamFirst*/ true);
+        resolvedDiffParamIndices, AutoDiffDerivativeFunctionKind::VJP,
+        lookupConformance, derivativeGenSig, /*makeSelfParamFirst*/ true);
     auto isValidVJP = [&](AbstractFunctionDecl *vjpCandidate) -> bool {
       return checkFunctionSignature(
           cast<AnyFunctionType>(expectedVJPFnTy->getCanonicalType()),
@@ -3985,21 +3975,6 @@ llvm::Expected<IndexSubset *> DifferentiableAttributeTypeCheckRequest::evaluate(
     return nullptr;
 
   auto *originalFnTy = original->getInterfaceType()->castTo<AnyFunctionType>();
-  bool isMethod = original->hasImplicitSelfDecl();
-
-  // If the original function returns the empty tuple type, there is no output
-  // to differentiate from.
-  auto originalResultTy = originalFnTy->getResult();
-  if (isMethod)
-    originalResultTy = originalResultTy->castTo<AnyFunctionType>()->getResult();
-  if (originalResultTy->isEqual(ctx.TheEmptyTupleType)) {
-    diags
-        .diagnose(attr->getLocation(), diag::differentiable_attr_void_result,
-                  original->getFullName())
-        .highlight(original->getSourceRange());
-    attr->setInvalid();
-    return nullptr;
-  }
 
   // Diagnose if original function is an invalid class member.
   bool isOriginalClassMember = original->getDeclContext() &&
@@ -4058,11 +4033,32 @@ llvm::Expected<IndexSubset *> DifferentiableAttributeTypeCheckRequest::evaluate(
           resolvedDiffParamIndices))
     return nullptr;
 
-  // Check that original function's result type conforms to `Differentiable`.
-  if (derivativeGenEnv)
-    originalResultTy = derivativeGenEnv->mapTypeIntoContext(originalResultTy);
-  else
-    originalResultTy = original->mapTypeIntoContext(originalResultTy);
+  // Get the original semantic result type.
+  llvm::SmallVector<AutoDiffSemanticFunctionResultType, 1> originalResults;
+  autodiff::getFunctionSemanticResultTypes(originalFnTy, originalResults,
+                                           derivativeGenEnv);
+  // Check that original function has at least one semantic result, i.e.
+  // that the original semantic result type is not `Void`.
+  if (originalResults.empty()) {
+    diags
+        .diagnose(attr->getLocation(), diag::autodiff_attr_original_void_result,
+                  original->getFullName())
+        .highlight(original->getSourceRange());
+    attr->setInvalid();
+    return nullptr;
+  }
+  // Check that original function does not have multiple semantic results.
+  if (originalResults.size() > 1) {
+    diags
+        .diagnose(attr->getLocation(),
+                  diag::autodiff_attr_original_multiple_semantic_results)
+        .highlight(original->getSourceRange());
+    attr->setInvalid();
+    return nullptr;
+  }
+  auto originalResult = originalResults.front();
+  auto originalResultTy = originalResult.type;
+  // Check that the original semantic result conforms to `Differentiable`.
   if (!conformsToDifferentiable(originalResultTy, original)) {
     diags.diagnose(attr->getLocation(),
                    diag::differentiable_attr_result_not_differentiable,
@@ -4364,41 +4360,42 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
   // Set the resolved differentiability parameter indices in the attribute.
   attr->setParameterIndices(resolvedDiffParamIndices);
 
-  // Gather differentiability parameters.
-  SmallVector<Type, 4> diffParamTypes;
-  autodiff::getSubsetParameterTypes(resolvedDiffParamIndices, originalFnType,
-                                    diffParamTypes);
-
-  // Get the differentiability parameters' `TangentVector` associated types.
+  // Get the original semantic result.
+  llvm::SmallVector<AutoDiffSemanticFunctionResultType, 1> originalResults;
+  autodiff::getFunctionSemanticResultTypes(
+      originalFnType, originalResults,
+      derivative->getGenericEnvironmentOfContext());
+  // Check that original function has at least one semantic result, i.e.
+  // that the original semantic result type is not `Void`.
+  if (originalResults.empty()) {
+    diags
+        .diagnose(attr->getLocation(), diag::autodiff_attr_original_void_result,
+                  derivative->getFullName())
+        .highlight(attr->getOriginalFunctionName().Loc.getSourceRange());
+    attr->setInvalid();
+    return true;
+  }
+  // Check that original function does not have multiple semantic results.
+  if (originalResults.size() > 1) {
+    diags
+        .diagnose(attr->getLocation(),
+                  diag::autodiff_attr_original_multiple_semantic_results)
+        .highlight(attr->getOriginalFunctionName().Loc.getSourceRange());
+    attr->setInvalid();
+    return true;
+  }
+  auto originalResult = originalResults.front();
+  auto originalResultType = originalResult.type;
+  // Check that the original semantic result conforms to `Differentiable`.
   auto *diffableProto = Ctx.getProtocol(KnownProtocolKind::Differentiable);
-  auto diffParamTanTypes =
-      map<SmallVector<TupleTypeElt, 4>>(diffParamTypes, [&](Type paramType) {
-        if (paramType->hasTypeParameter())
-          paramType = derivative->mapTypeIntoContext(paramType);
-        auto conf = TypeChecker::conformsToProtocol(paramType, diffableProto,
-                                                    derivative, None);
-        assert(conf &&
-               "Expected resolved parameter to conform to `Differentiable`");
-        auto paramAssocType =
-            conf.getTypeWitnessByName(paramType, Ctx.Id_TangentVector);
-        return TupleTypeElt(paramAssocType);
-      });
-
-  // `value: R` result tuple element must conform to `Differentiable`.
-  // Get the `TangentVector` associated type of the `value:` result type.
-  auto valueResultType = valueResultElt.getType();
-  if (valueResultType->hasTypeParameter())
-    valueResultType = derivative->mapTypeIntoContext(valueResultType);
   auto valueResultConf = TypeChecker::conformsToProtocol(
-      valueResultType, diffableProto, derivative->getDeclContext(), None);
+      originalResultType, diffableProto, derivative->getDeclContext(), None);
   if (!valueResultConf) {
     diags.diagnose(attr->getLocation(),
                    diag::derivative_attr_result_value_not_differentiable,
                    valueResultElt.getType());
     return true;
   }
-  auto resultTanType = valueResultConf.getTypeWitnessByName(
-      valueResultType, Ctx.Id_TangentVector);
 
   // Compute the actual differential/pullback type that we use for comparison
   // with the expected type. We must canonicalize the derivative interface type
@@ -4414,19 +4411,14 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
       cast<TupleType>(canActualResultType).getElementType(1);
 
   // Compute expected differential/pullback type.
-  Type expectedFuncEltType;
-  if (kind == AutoDiffDerivativeFunctionKind::JVP) {
-    auto diffParams = map<SmallVector<AnyFunctionType::Param, 4>>(
-        diffParamTanTypes, [&](TupleTypeElt elt) {
-          return AnyFunctionType::Param(elt.getType());
-        });
-    expectedFuncEltType = FunctionType::get(diffParams, resultTanType);
-  } else {
-    expectedFuncEltType =
-        FunctionType::get({AnyFunctionType::Param(resultTanType)},
-                          TupleType::get(diffParamTanTypes, Ctx));
-  }
-  expectedFuncEltType = expectedFuncEltType->mapTypeOutOfContext();
+  Type expectedFuncEltType =
+      originalFnType->getAutoDiffDerivativeFunctionLinearMapType(
+          resolvedDiffParamIndices, kind.getLinearMapKind(), lookupConformance,
+          /*makeSelfParamFirst*/ true);
+  if (expectedFuncEltType->hasTypeParameter())
+    expectedFuncEltType = derivative->mapTypeIntoContext(expectedFuncEltType);
+  if (expectedFuncEltType->hasArchetype())
+    expectedFuncEltType = expectedFuncEltType->mapTypeOutOfContext();
 
   // Check if differential/pullback type matches expected type.
   if (!actualFuncEltType->isEqual(expectedFuncEltType)) {

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -3557,19 +3557,22 @@ SILDeserializer::readDifferentiabilityWitness(DeclID DId) {
   }
   auto derivativeGenSig = MF->getGenericSignature(derivativeGenSigID);
 
+  auto originalFnType = original->getLoweredFunctionType();
   SmallVector<unsigned, 8> parameterAndResultIndices(
       rawParameterAndResultIndices.begin(), rawParameterAndResultIndices.end());
   assert(parameterAndResultIndices.size() ==
              numParameterIndices + numResultIndices &&
          "Parameter/result indices count mismatch");
-  auto *parameterIndices = IndexSubset::get(
-      MF->getContext(), original->getLoweredFunctionType()->getNumParameters(),
-      ArrayRef<unsigned>(parameterAndResultIndices)
-          .take_front(numParameterIndices));
-  auto *resultIndices = IndexSubset::get(
-      MF->getContext(), original->getLoweredFunctionType()->getNumResults(),
-      ArrayRef<unsigned>(parameterAndResultIndices)
-          .take_back(numResultIndices));
+  auto *parameterIndices =
+      IndexSubset::get(MF->getContext(), originalFnType->getNumParameters(),
+                       ArrayRef<unsigned>(parameterAndResultIndices)
+                           .take_front(numParameterIndices));
+  auto numResults = originalFnType->getNumResults() +
+                    originalFnType->getNumIndirectMutatingParameters();
+  auto *resultIndices =
+      IndexSubset::get(MF->getContext(), numResults,
+                       ArrayRef<unsigned>(parameterAndResultIndices)
+                           .take_back(numResultIndices));
 
   AutoDiffConfig config(parameterIndices, resultIndices, derivativeGenSig);
   auto *diffWitness =

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2544,7 +2544,7 @@ void SILSerializer::writeSILDifferentiabilityWitness(
              dw.getParameterIndices()->getCapacity() &&
          "Original function parameter count should match differentiability "
          "witness parameter indices capacity");
-  size_t numInoutParameters = llvm::count_if(
+  unsigned numInoutParameters = llvm::count_if(
       originalFnType->getParameters(), [](SILParameterInfo paramInfo) {
         return paramInfo.isIndirectMutating();
       });

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2544,7 +2544,11 @@ void SILSerializer::writeSILDifferentiabilityWitness(
              dw.getParameterIndices()->getCapacity() &&
          "Original function parameter count should match differentiability "
          "witness parameter indices capacity");
-  assert(originalFnType->getNumResults() ==
+  size_t numInoutParameters = llvm::count_if(
+      originalFnType->getParameters(), [](SILParameterInfo paramInfo) {
+        return paramInfo.isIndirectMutating();
+      });
+  assert(originalFnType->getNumResults() + numInoutParameters ==
              dw.getResultIndices()->getCapacity() &&
          "Original function result count should match differentiability "
          "witness result indices capacity");

--- a/stdlib/public/Differentiation/DifferentiationSupport.swift
+++ b/stdlib/public/Differentiation/DifferentiationSupport.swift
@@ -1237,6 +1237,25 @@ extension Array where Element : Differentiable {
 }
 
 extension Array where Element: Differentiable {
+  @derivative(of: append)
+  public mutating func _vjpAppend(_ element: Element) -> (
+    value: Void, pullback: (inout TangentVector) -> Element.TangentVector
+  ) {
+    let appendedElementIndex = count
+    defer { append(element) }
+    return ((), { dself in dself.base[appendedElementIndex] })
+  }
+
+  @derivative(of: append)
+  public mutating func _jvpAppend(_ element: Element) -> (
+    value: Void, differential: (inout TangentVector, Element.TangentVector) -> Void
+  ) {
+    append(element)
+    return ((), { $0.base.append($1) })
+  }
+}
+
+extension Array where Element: Differentiable {
   @usableFromInline
   @derivative(of: init(repeating:count:))
   static func _vjpInit(repeating repeatedValue: Element, count: Int) -> (

--- a/stdlib/public/Differentiation/DifferentiationSupport.swift
+++ b/stdlib/public/Differentiation/DifferentiationSupport.swift
@@ -1202,8 +1202,9 @@ extension Array : EuclideanDifferentiable
 }
 
 extension Array where Element : Differentiable {
+  @usableFromInline
   @derivative(of: subscript)
-  public func _vjpSubscript(index: Int) ->
+  func _vjpSubscript(index: Int) ->
     (value: Element, pullback: (Element.TangentVector) -> TangentVector)
   {
     func pullback(_ gradientIn: Element.TangentVector) -> TangentVector {
@@ -1216,8 +1217,9 @@ extension Array where Element : Differentiable {
     return (self[index], pullback)
   }
 
+  @usableFromInline
   @derivative(of: +)
-  public static func _vjpPlus(_ lhs: [Element], _ rhs: [Element]) ->
+  static func _vjpConcatenate(_ lhs: [Element], _ rhs: [Element]) ->
     (value: [Element], pullback: (TangentVector) -> (TangentVector, TangentVector)) {
       func pullback(_ gradientIn: TangentVector) ->
         (TangentVector, TangentVector) {
@@ -1237,8 +1239,9 @@ extension Array where Element : Differentiable {
 }
 
 extension Array where Element: Differentiable {
+  @usableFromInline
   @derivative(of: append)
-  public mutating func _vjpAppend(_ element: Element) -> (
+  mutating func _vjpAppend(_ element: Element) -> (
     value: Void, pullback: (inout TangentVector) -> Element.TangentVector
   ) {
     let appendedElementIndex = count
@@ -1246,8 +1249,9 @@ extension Array where Element: Differentiable {
     return ((), { dself in dself.base[appendedElementIndex] })
   }
 
+  @usableFromInline
   @derivative(of: append)
-  public mutating func _jvpAppend(_ element: Element) -> (
+  mutating func _jvpAppend(_ element: Element) -> (
     value: Void, differential: (inout TangentVector, Element.TangentVector) -> Void
   ) {
     append(element)

--- a/stdlib/public/Differentiation/FloatingPointTypesDerivatives.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointTypesDerivatives.swift.gyb
@@ -61,6 +61,26 @@ extension ${Self} {
 
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
+  @derivative(of: +=)
+  static func _vjpAddAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
+    value: Void, pullback: (inout ${Self}) -> ${Self}
+  ) {
+    lhs += rhs
+    return ((), { v in v })
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  @_transparent
+  @derivative(of: +=)
+  static func _jvpAddAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
+    value: Void, differential: (inout ${Self}, ${Self}) -> Void
+  ) {
+    lhs += rhs
+    return ((), { $0 += $1 })
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  @_transparent
   @derivative(of: -)
   static func _vjpSubtract(
     lhs: ${Self}, rhs: ${Self}
@@ -75,6 +95,26 @@ extension ${Self} {
     lhs: ${Self}, rhs: ${Self}
   ) -> (value: ${Self}, differential: (${Self}, ${Self}) -> ${Self}) {
     return (lhs - rhs, { (dlhs, drhs) in dlhs - drhs })
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  @_transparent
+  @derivative(of: -=)
+  static func _vjpSubtractAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
+    value: Void, pullback: (inout ${Self}) -> ${Self}
+  ) {
+    lhs -= rhs
+    return ((), { v in -v })
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  @_transparent
+  @derivative(of: -=)
+  static func _jvpSubtractAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
+    value: Void, differential: (inout ${Self}, ${Self}) -> Void
+  ) {
+    lhs -= rhs
+    return ((), { $0 -= $1 })
   }
 
   @inlinable // FIXME(sil-serialize-all)
@@ -97,6 +137,30 @@ extension ${Self} {
 
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
+  @derivative(of: *=)
+  static func _vjpMultiplyAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
+    value: Void, pullback: (inout ${Self}) -> ${Self}
+  ) {
+    defer { lhs *= rhs }
+    return ((), { [lhs = lhs] v in
+      let drhs = lhs * v
+      v *= rhs
+      return drhs
+    })
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  @_transparent
+  @derivative(of: *=)
+  static func _jvpMultiplyAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
+    value: Void, differential: (inout ${Self}, ${Self}) -> Void
+  ) {
+    lhs *= rhs
+    return ((), { $0 *= $1 })
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  @_transparent
   @derivative(of: /)
   static func _vjpDivide(
     lhs: ${Self}, rhs: ${Self}
@@ -111,6 +175,30 @@ extension ${Self} {
     lhs: ${Self}, rhs: ${Self}
   ) -> (value: ${Self}, differential: (${Self}, ${Self}) -> ${Self}) {
     return (lhs / rhs, { (dlhs, drhs) in dlhs / rhs - lhs / (rhs * rhs) * drhs })
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  @_transparent
+  @derivative(of: /=)
+  static func _vjpDivideAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
+    value: Void, pullback: (inout ${Self}) -> ${Self}
+  ) {
+    defer { lhs /= rhs }
+    return ((), { [lhs = lhs] v in
+      let drhs = -lhs / (rhs * rhs) * v
+      v /= rhs
+      return drhs
+    })
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  @_transparent
+  @derivative(of: /=)
+  static func _jvpDivideAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
+    value: Void, differential: (inout ${Self}, ${Self}) -> Void
+  ) {
+    lhs /= rhs
+    return ((), { $0 /= $1 })
   }
 }
 

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -3,6 +3,14 @@
 
 import _Differentiation
 
+// Dummy `Differentiable`-conforming type.
+struct DummyTangentVector: Differentiable & AdditiveArithmetic {
+  static var zero: Self { Self() }
+  static func + (_: Self, _: Self) -> Self { Self() }
+  static func - (_: Self, _: Self) -> Self { Self() }
+  typealias TangentVector = Self
+}
+
 // Test top-level functions.
 
 func id(_ x: Float) -> Float {
@@ -107,7 +115,7 @@ func vjpResultNotDifferentiable(x: Int) -> (
   return (x, { $0 })
 }
 // expected-error @+2 {{function result's 'pullback' type does not match 'incorrectDerivativeType'}}
-// expected-note @+3 {{'pullback' does not have expected type '(Float.TangentVector) -> (Float.TangentVector)' (aka '(Float) -> Float')}}
+// expected-note @+3 {{'pullback' does not have expected type '(Float.TangentVector) -> Float.TangentVector' (aka '(Float) -> Float')}}
 @derivative(of: incorrectDerivativeType)
 func vjpResultIncorrectPullbackType(x: Float) -> (
   value: Float, pullback: (Double) -> Double
@@ -181,17 +189,6 @@ func vjpFunctionParameter(_ fn: (Float) -> Float) -> (
   value: Float, pullback: (Float) -> Float
 ) {
   return (functionParameter(fn), { $0 })
-}
-
-func inoutParameter(_ x: inout Float) -> Float {
-  return x
-}
-// expected-error @+1 {{cannot differentiate with respect to 'inout' parameter ('inout Float'}}
-@derivative(of: inoutParameter)
-func vjpInoutParameter(x: inout Float) -> (
-  value: Float, pullback: (Float) -> Float
-) {
-  return (inoutParameter(&x), { $0 })
 }
 
 // Test static methods.
@@ -585,6 +582,174 @@ extension ProtocolRequirementDerivative {
   // expected-error @+1 {{could not find function 'requirement' with expected type '<Self where Self : ProtocolRequirementDerivative> (Self) -> (Float) -> Float'}}
   @derivative(of: requirement)
   func vjpRequirement(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+    fatalError()
+  }
+}
+
+// Test `inout` parameters.
+
+func multipleSemanticResults(_ x: inout Float) -> Float {
+  return x
+}
+// expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
+@derivative(of: multipleSemanticResults)
+func vjpMultipleSemanticResults(x: inout Float) -> (
+  value: Float, pullback: (Float) -> Float
+) {
+  return (multipleSemanticResults(&x), { $0 })
+}
+
+struct InoutParameters: Differentiable {
+  typealias TangentVector = DummyTangentVector
+  mutating func move(along _: TangentVector) {}
+}
+
+extension InoutParameters {
+  // expected-note @+1 4 {{'staticMethod(_:rhs:)' defined here}}
+  static func staticMethod(_ lhs: inout Self, rhs: Self) {}
+
+  // Test wrt `inout` parameter.
+
+  @derivative(of: staticMethod)
+  static func vjpWrtInout(_ lhs: inout Self, _ rhs: Self) -> (
+    value: Void, pullback: (inout TangentVector) -> TangentVector
+  ) { fatalError() }
+
+  // expected-error @+1 {{function result's 'pullback' type does not match 'staticMethod(_:rhs:)'}}
+  @derivative(of: staticMethod)
+  static func vjpWrtInoutMismatch(_ lhs: inout Self, _ rhs: Self) -> (
+    // expected-note @+1 {{'pullback' does not have expected type '(inout InoutParameters.TangentVector) -> InoutParameters.TangentVector' (aka '(inout DummyTangentVector) -> DummyTangentVector')}}
+    value: Void, pullback: (TangentVector) -> TangentVector
+  ) { fatalError() }
+
+  @derivative(of: staticMethod)
+  static func jvpWrtInout(_ lhs: inout Self, _ rhs: Self) -> (
+    value: Void, differential: (inout TangentVector, TangentVector) -> Void
+  ) { fatalError() }
+
+  // expected-error @+1 {{function result's 'differential' type does not match 'staticMethod(_:rhs:)'}}
+  @derivative(of: staticMethod)
+  static func jvpWrtInoutMismatch(_ lhs: inout Self, _ rhs: Self) -> (
+    // expected-note @+1 {{'differential' does not have expected type '(inout InoutParameters.TangentVector, InoutParameters.TangentVector) -> ()' (aka '(inout DummyTangentVector, DummyTangentVector) -> ()')}}
+    value: Void, differential: (TangentVector, TangentVector) -> Void
+  ) { fatalError() }
+
+  // Test non-wrt `inout` parameter.
+
+  @derivative(of: staticMethod, wrt: rhs)
+  static func vjpNotWrtInout(_ lhs: inout Self, _ rhs: Self) -> (
+    value: Void, pullback: (TangentVector) -> TangentVector
+  ) { fatalError() }
+
+  // expected-error @+1 {{function result's 'pullback' type does not match 'staticMethod(_:rhs:)'}}
+  @derivative(of: staticMethod, wrt: rhs)
+  static func vjpNotWrtInoutMismatch(_ lhs: inout Self, _ rhs: Self) -> (
+    // expected-note @+1 {{'pullback' does not have expected type '(InoutParameters.TangentVector) -> InoutParameters.TangentVector' (aka '(DummyTangentVector) -> DummyTangentVector')}}
+    value: Void, pullback: (inout TangentVector) -> TangentVector
+  ) { fatalError() }
+
+  @derivative(of: staticMethod, wrt: rhs)
+  static func jvpNotWrtInout(_ lhs: inout Self, _ rhs: Self) -> (
+    value: Void, differential: (TangentVector) -> TangentVector
+  ) { fatalError() }
+
+  // expected-error @+1 {{function result's 'differential' type does not match 'staticMethod(_:rhs:)'}}
+  @derivative(of: staticMethod, wrt: rhs)
+  static func jvpNotWrtInout(_ lhs: inout Self, _ rhs: Self) -> (
+    // expected-note @+1 {{'differential' does not have expected type '(InoutParameters.TangentVector) -> InoutParameters.TangentVector' (aka '(DummyTangentVector) -> DummyTangentVector')}}
+    value: Void, differential: (inout TangentVector) -> TangentVector
+  ) { fatalError() }
+}
+
+extension InoutParameters {
+  // expected-note @+1 4 {{'mutatingMethod' defined here}}
+  mutating func mutatingMethod(_ other: Self) {}
+
+  // Test wrt `inout` `self` parameter.
+
+  @derivative(of: mutatingMethod)
+  mutating func vjpWrtInout(_ other: Self) -> (
+    value: Void, pullback: (inout TangentVector) -> TangentVector
+  ) { fatalError() }
+
+  // expected-error @+1 {{function result's 'pullback' type does not match 'mutatingMethod'}}
+  @derivative(of: mutatingMethod)
+  mutating func vjpWrtInoutMismatch(_ other: Self) -> (
+    // expected-note @+1 {{'pullback' does not have expected type '(inout InoutParameters.TangentVector) -> InoutParameters.TangentVector' (aka '(inout DummyTangentVector) -> DummyTangentVector')}}
+    value: Void, pullback: (TangentVector) -> TangentVector
+  ) { fatalError() }
+
+  @derivative(of: mutatingMethod)
+  mutating func jvpWrtInout(_ other: Self) -> (
+    value: Void, differential: (inout TangentVector, TangentVector) -> Void
+  ) { fatalError() }
+
+  // expected-error @+1 {{function result's 'differential' type does not match 'mutatingMethod'}}
+  @derivative(of: mutatingMethod)
+  mutating func jvpWrtInoutMismatch(_ other: Self) -> (
+    // expected-note @+1 {{'differential' does not have expected type '(inout InoutParameters.TangentVector, InoutParameters.TangentVector) -> ()' (aka '(inout DummyTangentVector, DummyTangentVector) -> ()')}}
+    value: Void, differential: (TangentVector, TangentVector) -> Void
+  ) { fatalError() }
+
+  // Test non-wrt `inout` `self` parameter.
+
+  @derivative(of: mutatingMethod, wrt: other)
+  mutating func vjpNotWrtInout(_ other: Self) -> (
+    value: Void, pullback: (TangentVector) -> TangentVector
+  ) { fatalError() }
+
+  // expected-error @+1 {{function result's 'pullback' type does not match 'mutatingMethod'}}
+  @derivative(of: mutatingMethod, wrt: other)
+  mutating func vjpNotWrtInoutMismatch(_ other: Self) -> (
+    // expected-note @+1 {{'pullback' does not have expected type '(InoutParameters.TangentVector) -> InoutParameters.TangentVector' (aka '(DummyTangentVector) -> DummyTangentVector')}}
+    value: Void, pullback: (inout TangentVector) -> TangentVector
+  ) { fatalError() }
+
+  @derivative(of: mutatingMethod, wrt: other)
+  mutating func jvpNotWrtInout(_ other: Self) -> (
+    value: Void, differential: (TangentVector) -> TangentVector
+  ) { fatalError() }
+
+  // expected-error @+1 {{function result's 'differential' type does not match 'mutatingMethod'}}
+  @derivative(of: mutatingMethod, wrt: other)
+  mutating func jvpNotWrtInoutMismatch(_ other: Self) -> (
+    // expected-note @+1 {{'differential' does not have expected type '(InoutParameters.TangentVector) -> InoutParameters.TangentVector' (aka '(DummyTangentVector) -> DummyTangentVector')}}
+    value: Void, differential: (TangentVector, TangentVector) -> Void
+  ) { fatalError() }
+}
+
+// Test multiple semantic results.
+
+extension InoutParameters {
+  func multipleSemanticResults(_ x: inout Float) -> Float { x }
+  // expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
+  @derivative(of: multipleSemanticResults)
+  func vjpMultipleSemanticResults(_ x: inout Float) -> (
+    value: Float, pullback: (inout Float) -> Void
+  ) { fatalError() }
+
+  func inoutVoid(_ x: Float, _ void: inout Void) -> Float {}
+  // expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
+  @derivative(of: inoutVoid)
+  func vjpInoutVoidParameter(_ x: Float, _ void: inout Void) -> (
+    value: Float, pullback: (inout Float) -> Void
+  ) { fatalError() }
+}
+
+// Test original/derivative function `inout` parameter mismatches.
+
+extension InoutParameters {
+  func inoutParameterMismatch(_ x: Float) {}
+  // expected-error @+1 {{could not find function 'inoutParameterMismatch' with expected type '(InoutParameters) -> (inout Float) -> Void'}}
+  @derivative(of: inoutParameterMismatch)
+  func vjpInoutParameterMismatch(_ x: inout Float) -> (value: Void, pullback: (inout Float) -> Void) {
+    fatalError()
+  }
+
+  func mutatingMismatch(_ x: Float) {}
+  // expected-error @+1 {{could not find function 'mutatingMismatch' with expected type '(inout InoutParameters) -> (Float) -> Void'}}
+  @derivative(of: mutatingMismatch)
+  mutating func vjpMutatingMismatch(_ x: Float) -> (value: Void, pullback: (inout Float) -> Void) {
     fatalError()
   }
 }

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -1020,18 +1020,6 @@ func two9(x: Float, y: Float) -> Float {
   return x + y
 }
 
-// Inout 'wrt:' arguments.
-
-@differentiable(wrt: y) // expected-error {{cannot differentiate void function 'inout1(x:y:)'}}
-func inout1(x: Float, y: inout Float) -> Void {
-  let _ = x + y
-}
-
-@differentiable(wrt: y) // expected-error {{cannot differentiate with respect to 'inout' parameter ('inout Float')}}
-func inout2(x: Float, y: inout Float) -> Float {
-  let _ = x + y
-}
-
 // Test refining protocol requirements with `@differentiable` attribute.
 
 public protocol Distribution {
@@ -1157,6 +1145,42 @@ final class FinalClass: Differentiable {
   init(base: Float) {
     self.base = base
   }
+}
+
+// Test `inout` parameters.
+
+@differentiable(wrt: y)
+func inoutVoid(x: Float, y: inout Float) {}
+
+// expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
+@differentiable
+func multipleSemanticResults(_ x: inout Float) -> Float { x }
+
+// expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
+@differentiable(wrt: y)
+func swap(x: inout Float, y: inout Float) {}
+
+struct InoutParameters: Differentiable {
+  typealias TangentVector = DummyTangentVector
+  mutating func move(along _: TangentVector) {}
+}
+
+extension InoutParameters {
+  @differentiable
+  static func staticMethod(_ lhs: inout Self, rhs: Self) {}
+
+  // expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
+  @differentiable
+  static func multipleSemanticResults(_ lhs: inout Self, rhs: Self) -> Self {}
+}
+
+extension InoutParameters {
+  @differentiable
+  mutating func mutatingMethod(_ other: Self) {}
+
+  // expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
+  @differentiable
+  mutating func mutatingMethod(_ other: Self) -> Self {}
 }
 
 // Test unsupported accessors: `set`, `_read`, `_modify`.

--- a/test/AutoDiff/downstream/compiler_crashers/tf984-differential-unset-tangent-buffer.swift
+++ b/test/AutoDiff/downstream/compiler_crashers/tf984-differential-unset-tangent-buffer.swift
@@ -11,10 +11,8 @@ extension Mut {
 }
 
 @differentiable(wrt: x)
-func activeInoutArgMutatingMethodVar(_ nonactive: inout Mut, _ x: Mut) -> Mut {
-  var result = nonactive
-  result = result.mutatingMethodWrtMultipleResults(x)
-  return result
+func activeInoutArgMutatingMethodVar(_ nonactive: inout Mut, _ x: Mut) {
+  nonactive.mutatingMethodWrtMultipleResults(x)
 }
 
 // [AD] Original bb0: To differentiate or not to differentiate?

--- a/test/AutoDiff/downstream/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/downstream/derivative_attr_type_checking.swift
@@ -37,7 +37,7 @@ func vjpSinResultNotDifferentiable(x: Int) -> (value: Int, pullback: (Int) -> In
   return (x, { $0 })
 }
 // expected-error @+2 {{function result's 'pullback' type does not match 'sin'}}
-// expected-note @+2 {{'pullback' does not have expected type '(Float.TangentVector) -> (Float.TangentVector)' (aka '(Float) -> Float')}}
+// expected-note @+2 {{'pullback' does not have expected type '(Float.TangentVector) -> Float.TangentVector' (aka '(Float) -> Float')}}
 @derivative(of: sin)
 func vjpSinResultInvalidSeedType(x: Float) -> (value: Float, pullback: (Double) -> Double) {
   return (x, { $0 })

--- a/test/AutoDiff/downstream/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/downstream/differentiable_attr_type_checking.swift
@@ -975,12 +975,12 @@ func two9(x: Float, y: Float) -> Float {
 
 // Inout 'wrt:' arguments.
 
-@differentiable(wrt: y) // expected-error {{cannot differentiate void function 'inout1(x:y:)'}}
+@differentiable(wrt: y)
 func inout1(x: Float, y: inout Float) -> Void {
   let _ = x + y
 }
-
-@differentiable(wrt: y) // expected-error {{cannot differentiate with respect to 'inout' parameter ('inout Float')}}
+// expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
+@differentiable(wrt: y)
 func inout2(x: Float, y: inout Float) -> Float {
   let _ = x + y
 }

--- a/test/AutoDiff/downstream/differentiation_transform_diagnostics.swift
+++ b/test/AutoDiff/downstream/differentiation_transform_diagnostics.swift
@@ -450,6 +450,28 @@ func activeInoutArgMutatingMethodTuple(_ nonactive: inout Mut, _ x: Mut) {
   nonactive = result.0
 }
 
+func twoInoutParameters(_ x: inout Float, _ y: inout Float) {}
+// expected-error @+1 {{function is not differentiable}}
+@differentiable
+// expected-note @+1 {{when differentiating this function definition}}
+func testTwoInoutParameters(_ x: Float, _ y: Float) -> Float {
+  var x = x
+  var y = y
+  // expected-note @+1 {{cannot differentiate through multiple results}}
+  twoInoutParameters(&x, &y)
+  return x
+}
+
+func inoutParameterAndFormalResult(_ x: inout Float) -> Float { x }
+// expected-error @+1 {{function is not differentiable}}
+@differentiable
+// expected-note @+1 {{when differentiating this function definition}}
+func testInoutParameterAndFormalResult(_ x: Float) -> Float {
+  var x = x
+  // expected-note @+1 {{cannot differentiate through multiple results}}
+  return inoutParameterAndFormalResult(&x)
+}
+
 //===----------------------------------------------------------------------===//
 // Non-varied results
 //===----------------------------------------------------------------------===//

--- a/test/AutoDiff/downstream/floating_point.swift.gyb
+++ b/test/AutoDiff/downstream/floating_point.swift.gyb
@@ -1,33 +1,90 @@
-// RUN: %target-run-simple-swiftgyb
+// RUN: %target-run-simple-swiftgyb-forward-mode-differentiation
 // REQUIRES: executable_test
+
+#if (arch(i386) || arch(x86_64)) && !os(Windows)
+  typealias TestLiteralType = Float80
+#else
+  typealias TestLiteralType = Double
+#endif
 
 import StdlibUnittest
 
-var FloatingPointTests = TestSuite("FloatingPoint")
+var FloatingPointDerivativeTests = TestSuite("FloatingPointDerivatives")
+
+func expectEqualWithTolerance<T>(_ expected: TestLiteralType, _ actual: T,
+                                 ulps allowed: T = 3,
+                                 file: String = #file, line: UInt = #line
+) where T: BinaryFloatingPoint {
+  if actual == T(expected) || actual.isNaN && expected.isNaN {
+    return
+  }
+  //  Compute error in ulp, compare to tolerance.
+  let absoluteError = T(abs(TestLiteralType(actual) - expected))
+  let ulpError = absoluteError / T(expected).ulp
+  expectTrue(ulpError <= allowed,
+             "\(actual) != \(expected) as \(T.self)" +
+             "\n  \(ulpError)-ulp error exceeds \(allowed)-ulp tolerance.",
+             file: file, line: line)
+}
 
 %for Self in ['Float', 'Double', 'Float80']:
-% if Self == 'Float80':
+
+%if Self == 'Float80':
 #if !os(Windows) && (arch(i386) || arch(x86_64))
-% end
+%end
 
-FloatingPointTests.test("${Self}.squareRoot") {
-  expectEqual(${Self}(0.5), gradient(at: ${Self}(1), in: { $0.squareRoot() }))
-  expectEqual(${Self}(0.25), gradient(at: ${Self}(4), in: { $0.squareRoot() }))
+FloatingPointDerivativeTests.test("${Self}.+") {
+  expectEqual((1, 1), gradient(at: ${Self}(4), ${Self}(5), in: +))
+  expectEqual((10, 10), pullback(at: ${Self}(4), ${Self}(5), in: +)(${Self}(10)))
+
+  expectEqual(2, derivative(at: ${Self}(4), ${Self}(5), in: +))
+  expectEqual(20, differential(at: ${Self}(4), ${Self}(5), in: +)(${Self}(10), ${Self}(10)))
 }
 
-FloatingPointTests.test("${Self}.addingProduct") {
-  expectEqual(
-    (${Self}(1), ${Self}(2), ${Self}(3)),
-    gradient(
-      at: ${Self}(10), ${Self}(3), ${Self}(2),
-      in: { $0.addingProduct($1, $2) }
-    )
-  )
+FloatingPointDerivativeTests.test("${Self}.-") {
+  expectEqual((1, -1), gradient(at: ${Self}(4), ${Self}(5), in: -))
+  expectEqual((10, -10), pullback(at: ${Self}(4), ${Self}(5), in: -)(${Self}(10)))
+
+  expectEqual(0, derivative(at: ${Self}(4), ${Self}(5), in: -))
+  expectEqual(-5, differential(at: ${Self}(4), ${Self}(5), in: -)(${Self}(5), ${Self}(10)))
 }
 
-%   if Self == 'Float80':
+FloatingPointDerivativeTests.test("${Self}.*") {
+  expectEqual((5, 4), gradient(at: ${Self}(4), ${Self}(5), in: *))
+  expectEqual((50, 40), pullback(at: ${Self}(4), ${Self}(5), in: *)(${Self}(10)))
+
+  expectEqual(9, derivative(at: ${Self}(4), ${Self}(5), in: *))
+  expectEqual(90, differential(at: ${Self}(4), ${Self}(5), in: *)(${Self}(10), ${Self}(10)))
+}
+
+FloatingPointDerivativeTests.test("${Self}./") {
+  do {
+    let (dx, dy) = gradient(at: ${Self}(4), ${Self}(5), in: /)
+    expectEqual(0.2, dx)
+    expectEqual(-0.16, dy)
+  }
+  do {
+    let (dx, dy) = pullback(at: ${Self}(4), ${Self}(5), in: /)(${Self}(10))
+    expectEqual(2, dx)
+    expectEqualWithTolerance(-1.6, dy)
+  }
+
+  expectEqualWithTolerance(0.04, derivative(at: ${Self}(4), ${Self}(5), in: /))
+  expectEqual(90, differential(at: ${Self}(4), ${Self}(5), in: *)(${Self}(10), ${Self}(10)))
+}
+
+FloatingPointDerivativeTests.test("${Self}.squareRoot") {
+  expectEqual(0.5, gradient(at: 1, in: { $0.squareRoot() }))
+  expectEqual(0.25, gradient(at: 4, in: { $0.squareRoot() }))
+}
+
+FloatingPointDerivativeTests.test("${Self}.addingProduct") {
+  expectEqual((1, 2, 3), gradient(at: ${Self}(10), 3, 2, in: { $0.addingProduct($1, $2) }))
+}
+
+%if Self == 'Float80':
 #endif
-%   end
-% end
+%end
+%end # for Self in ['Float', 'Double', 'Float80']:
 
 runAllTests()

--- a/test/AutoDiff/downstream/forward_mode_diagnostics.swift
+++ b/test/AutoDiff/downstream/forward_mode_diagnostics.swift
@@ -104,9 +104,7 @@ func activeInoutArgControlFlow(_ array: [Float]) -> Float {
 struct Mut: Differentiable {}
 extension Mut {
   @differentiable(wrt: x)
-  mutating func mutatingMethod(_ x: Mut) -> Mut {
-    return x
-  }
+  mutating func mutatingMethod(_ x: Mut) {}
 }
 
 // FIXME(TF-984): Forward-mode crash due to unset tangent buffer.

--- a/test/AutoDiff/downstream/inout_parameters.swift
+++ b/test/AutoDiff/downstream/inout_parameters.swift
@@ -1,0 +1,128 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+// `inout` parameter differentiation tests.
+
+import StdlibUnittest
+
+var InoutParametersTests = TestSuite("InoutParameters")
+
+// TODO(TF-1173): Move floating-point mutating operation tests to
+// `floating_point.swift.gyb` when forward-mode differentiation supports `inout`
+// parameter differentiation.
+
+InoutParametersTests.test("Float.+=") {
+  func mutatingAddWrapper(_ x: Float, _ y: Float) -> Float {
+    var result: Float = x
+    result += y
+    return result
+  }
+  expectEqual((1, 1), gradient(at: 4, 5, in: mutatingAddWrapper))
+  expectEqual((10, 10), pullback(at: 4, 5, in: mutatingAddWrapper)(10))
+}
+
+InoutParametersTests.test("Float.-=") {
+  func mutatingSubtractWrapper(_ x: Float, _ y: Float) -> Float {
+    var result: Float = x
+    result += y
+    return result
+  }
+  expectEqual((1, 1), gradient(at: 4, 5, in: mutatingSubtractWrapper))
+  expectEqual((10, 10), pullback(at: 4, 5, in: mutatingSubtractWrapper)(10))
+}
+
+InoutParametersTests.test("Float.*=") {
+  func mutatingMultiplyWrapper(_ x: Float, _ y: Float) -> Float {
+    var result: Float = x
+    result += y
+    return result
+  }
+  expectEqual((1, 1), gradient(at: 4, 5, in: mutatingMultiplyWrapper))
+  expectEqual((10, 10), pullback(at: 4, 5, in: mutatingMultiplyWrapper)(10))
+}
+
+InoutParametersTests.test("Float./=") {
+  func mutatingDivideWrapper(_ x: Float, _ y: Float) -> Float {
+    var result: Float = x
+    result += y
+    return result
+  }
+  expectEqual((1, 1), gradient(at: 4, 5, in: mutatingDivideWrapper))
+  expectEqual((10, 10), pullback(at: 4, 5, in: mutatingDivideWrapper)(10))
+}
+
+InoutParametersTests.test("InoutIdentity") {
+  // Semantically, an empty function with an `inout` parameter is an identity
+  // function.
+  func inoutIdentity(_ x: inout Float) {}
+
+  func identity(_ x: Float) -> Float {
+    var result = x
+    inoutIdentity(&result)
+    return result
+  }
+  expectEqual(1, gradient(at: 1, in: identity))
+  expectEqual(10, pullback(at: 1, in: identity)(10))
+}
+
+extension Float {
+  // Custom version of `Float.*=`, implemented using `Float.*` and mutation.
+  // Verify that its generated derivative has the same behavior as the
+  // registered derivative for `Float.*=`.
+  @differentiable
+  static func multiplyAssign(_ lhs: inout Float, _ rhs: Float) {
+    lhs = lhs * rhs
+  }
+}
+
+InoutParametersTests.test("ControlFlow") {
+  func sum(_ array: [Float]) -> Float {
+    var result: Float = 0
+    for i in withoutDerivative(at: array.indices) {
+      result += array[i]
+    }
+    return result
+  }
+  expectEqual([1, 1, 1], gradient(at: [1, 2, 3], in: sum))
+
+  func product(_ array: [Float]) -> Float {
+    var result: Float = 1
+    for i in withoutDerivative(at: array.indices) {
+      result *= array[i]
+    }
+    return result
+  }
+  expectEqual([20, 15, 12], gradient(at: [3, 4, 5], in: product))
+
+  func productCustom(_ array: [Float]) -> Float {
+    var result: Float = 1
+    for i in withoutDerivative(at: array.indices) {
+      Float.multiplyAssign(&result, array[i])
+    }
+    return result
+  }
+  expectEqual([20, 15, 12], gradient(at: [3, 4, 5], in: productCustom))
+}
+
+InoutParametersTests.test("SetAccessor") {
+  struct S: Differentiable {
+    var x: Float
+
+    var computed: Float {
+      get { x }
+      set { x = newValue }
+    }
+  }
+
+  // `squared` implemented using a `set` accessor.
+  func squared(_ x: Float) -> Float {
+    var s = S(x: 1)
+    s.x *= x
+    s.computed *= x
+    return s.x
+  }
+  expectEqual(6, gradient(at: 3, in: squared))
+  expectEqual(8, gradient(at: 4, in: squared))
+}
+
+runAllTests()

--- a/test/AutoDiff/downstream/inout_parameters.swift
+++ b/test/AutoDiff/downstream/inout_parameters.swift
@@ -51,6 +51,7 @@ InoutParametersTests.test("Float./=") {
   expectEqual((10, 10), pullback(at: 4, 5, in: mutatingDivideWrapper)(10))
 }
 
+// Simplest possible `inout` parameter differentiation.
 InoutParametersTests.test("InoutIdentity") {
   // Semantically, an empty function with an `inout` parameter is an identity
   // function.
@@ -61,8 +62,8 @@ InoutParametersTests.test("InoutIdentity") {
     inoutIdentity(&result)
     return result
   }
-  expectEqual(1, gradient(at: 1, in: identity))
-  expectEqual(10, pullback(at: 1, in: identity)(10))
+  expectEqual(1, gradient(at: 10, in: identity))
+  expectEqual(10, pullback(at: 10, in: identity)(10))
 }
 
 extension Float {
@@ -123,6 +124,30 @@ InoutParametersTests.test("SetAccessor") {
   }
   expectEqual(6, gradient(at: 3, in: squared))
   expectEqual(8, gradient(at: 4, in: squared))
+}
+
+// Test differentiation wrt `inout` parameters that have a class type.
+InoutParametersTests.test("InoutClassParameter") {
+  class Class: Differentiable {
+    @differentiable
+    var x: Float
+
+    init(_ x: Float) {
+      self.x = x
+    }
+  }
+
+  // Semantically, an empty function with an `inout` parameter is an identity
+  // function.
+  func inoutIdentity(_ c: inout Class) {}
+
+  func identity(_ x: Float) -> Float {
+    var c = Class(x)
+    inoutIdentity(&c)
+    return c.x
+  }
+  expectEqual(1, gradient(at: 10, in: identity))
+  expectEqual(10, pullback(at: 10, in: identity)(10))
 }
 
 runAllTests()

--- a/unittests/AST/IndexSubsetTests.cpp
+++ b/unittests/AST/IndexSubsetTests.cpp
@@ -273,33 +273,35 @@ TEST(IndexSubset, GetSubsetParameterTypes) {
   auto &C = testCtx.Ctx;
   // (T, T) -> ()
   {
-    SmallVector<Type, 8> subset;
-    autodiff::getSubsetParameterTypes(
-        IndexSubset::get(C, 1, {0}),
-        FunctionType::get(
-            {FunctionType::Param(C.TheAnyType),
-             FunctionType::Param(C.TheAnyType)},
-            C.TheEmptyTupleType),
-        subset);
-    Type expected[] = {C.TheAnyType};
-    EXPECT_TRUE(std::equal(subset.begin(), subset.end(), expected,
-                    [](Type ty1, Type ty2) { return ty1->isEqual(ty2); }));
+    SmallVector<AnyFunctionType::Param, 8> params;
+    auto *functionType = FunctionType::get({FunctionType::Param(C.TheAnyType),
+                                            FunctionType::Param(C.TheAnyType)},
+                                           C.TheEmptyTupleType);
+    functionType->getSubsetParameters(IndexSubset::get(C, 1, {0}), params);
+    AnyFunctionType::Param expected[] = {AnyFunctionType::Param(C.TheAnyType)};
+    EXPECT_TRUE(std::equal(params.begin(), params.end(), expected,
+                           [](auto param1, auto param2) {
+                             return param1.getPlainType()->isEqual(param2.getPlainType());
+                           }));
   }
   // (T) -> (T, T) -> ()
   {
-    SmallVector<Type, 8> subset;
-    autodiff::getSubsetParameterTypes(
-        IndexSubset::get(C, 3, {0, 1, 2}),
-        FunctionType::get(
-            {FunctionType::Param(C.TheIEEE16Type)},
-            FunctionType::get(
-                {FunctionType::Param(C.TheAnyType),
-                 FunctionType::Param(C.TheAnyType)},
-                C.TheEmptyTupleType)),
-        subset);
-    Type expected[] = {C.TheIEEE16Type, C.TheAnyType, C.TheAnyType};
-    EXPECT_TRUE(std::equal(subset.begin(), subset.end(), expected,
-                    [](Type ty1, Type ty2) { return ty1->isEqual(ty2); }));
+    SmallVector<AnyFunctionType::Param, 8> params;
+    auto *functionType =
+        FunctionType::get({FunctionType::Param(C.TheIEEE16Type)},
+                          FunctionType::get({FunctionType::Param(C.TheAnyType),
+                                             FunctionType::Param(C.TheAnyType)},
+                                            C.TheEmptyTupleType));
+    functionType->getSubsetParameters(IndexSubset::get(C, 3, {0, 1, 2}),
+                                      params);
+    AnyFunctionType::Param expected[] = {
+        AnyFunctionType::Param(C.TheIEEE16Type),
+        AnyFunctionType::Param(C.TheAnyType),
+        AnyFunctionType::Param(C.TheAnyType)};
+    EXPECT_TRUE(std::equal(
+        params.begin(), params.end(), expected, [](auto param1, auto param2) {
+          return param1.getPlainType()->isEqual(param2.getPlainType());
+        }));
   }
 }
 // SWIFT_ENABLE_TENSORFLOW END


### PR DESCRIPTION
Includes cherry-pick of https://github.com/apple/swift/pull/29959: typing rules for `inout` parameter differentiation.

---

Add reverse-mode differentiation support for `apply` with `inout` arguments.

Notable pullback generation changes:
- If the pullback seed argument is `inout`, assign it (rather than a copy)
  directly as the adjoint buffer of the original result. This is important so
  the value is updated in-place.
- In `visitApplyInst`: skip adjoint accumulation for `inout` arguments.
  Adjoint accumulation for `inout` arguments occurs when callee pullbacks are
  applied, so no extra accumulation is necessary.

Add derivatives for functions with `inout` parameters in the stdlib for testing:
- `FloatingPoint` operations: `+=`, `-=`, `*=`, `/=`
- `Array.append`

Resolves TF-1165.

Todos:
- Add more tests, e.g. SILGen tests for `inout` derivative typing rules.
- Evaluate performance of `inout` derivatives vs functional derivatives + mutation.
- TF-1166: enable `@differentiable` attribute on `set` accessors.
- TF-1173: add forward-mode differentiation support for `apply` with `inout`
  parameters.

Exposes TF-1175: incorrect activity for class arguments.
Exposes TF-1176: incorrect activity for class `modify` accessors.
Add negative tests.

---

Examples:
```swift
// Test `inout` identity function.
func inoutIdentity(_ x: inout Float) {}
func identity(_ x: Float) -> Float {
  var result = x
  inoutIdentity(&result) // here
  return result
}
print(valueWithGradient(at: 10, in: identity))
// (value: 10.0, gradient: 1.0)
```
```swift
// Test `Float.*=` and control flow differentiation.
func product(_ array: [Float]) -> Float {
  var result: Float = 1
  for i in withoutDerivative(at: array.indices) {
    result *= array[i] // here
    // Old functional version:
    // result = result * array[i]
  }
  return result
}
print(valueWithGradient(at: [3, 4, 5], in: product))
// (value: 60.0, gradient: [20.0, 15.0, 12.0])
```
```swift
// Test `Array.append` and control flow differentiation.
func squared(_ array: [Float]) -> [Float] {
  var results: [Float] = []
  for i in withoutDerivative(at: array.indices) {
    results.append(array[i] * array[i]) // here
    // Old functional version:
    // results = results + [array[i] * array[i]]
  }
  return results
}
let v: Array<Float>.TangentVector = [4, -5, 6]
let (value, pb) = valueWithPullback(at: [1, 2, 3], in: squared)
print(value, pb(v))
// [1.0, 4.0, 9.0] [8.0, -20.0, 36.0]
```
```swift
// Test `set` accessor differentiation.
struct S: Differentiable {
  var x: Float

  var computed: Float {
    get { x }
    set { x = newValue }
  }
}
func squared(_ x: Float) -> Float {
  var s = S(x: 1)
  s.x *= x // here
  s.computed *= x // here
  return s.x
}
print(valueWithGradient(at: 10, in: squared))
// (value: 100.0, gradient: 20.0)
```

---

Thanks @marcrasi for peer debugging incorrect `inout` argument derivative values!

We discovered that `Pullback::visitApplyInst` should skip adjoint accumulation for `inout` arguments, which is interesting and not obvious. This made the first exciting test cases pass.

Working together was fun and productive 🙂