### PR TITLE
[build] Fix `--enable-tensorflow` flag propagation.

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -794,6 +794,11 @@ class BuildScriptInvocation(object):
                         args.build_jobs)
                 ]
 
+        # SWIFT_ENABLE_TENSORFLOW
+        if args.enable_tensorflow:
+            impl_args += ["--enable-tensorflow"]
+        # SWIFT_ENABLE_TENSORFLOW END
+
         impl_args += args.build_script_impl_args
 
         if args.dry_run:

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -243,6 +243,10 @@ KNOWN_SETTINGS=(
     skip-merge-lipo-cross-compile-tools           ""                "set to skip running merge-lipo after installing cross-compiled host Swift tools"
     coverage-db                                   ""                "If set, coverage database to use when prioritizing testing"
     skip-local-host-install                       ""                "If we are cross-compiling multiple targets, skip an install pass locally if the hosts match"
+
+    # SWIFT_ENABLE_TENSORFLOW
+    enable-tensorflow                             ""                "If true, enable compiling with TensorFlow support"
+    # SWIFT_ENABLE_TENSORFLOW END
 )
 
 components=(
@@ -1671,6 +1675,10 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DSWIFT_TOOLS_ENABLE_LTO:STRING="${SWIFT_TOOLS_ENABLE_LTO}"
                     -DSWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER:BOOL=$(true_false "${BUILD_RUNTIME_WITH_HOST_COMPILER}")
                     -DLIBDISPATCH_CMAKE_BUILD_TYPE:STRING="${LIBDISPATCH_BUILD_TYPE}"
+
+                    # SWIFT_ENABLE_TENSORFLOW
+                    -DSWIFT_ENABLE_TENSORFLOW:BOOL=$(true_false "${ENABLE_TENSORFLOW}")
+                    # SWIFT_ENABLE_TENSORFLOW END
                     "${swift_cmake_options[@]}"
                 )
 
@@ -1716,13 +1724,6 @@ for host in "${ALL_HOSTS[@]}"; do
                     cmake_options=(
                         "${cmake_options[@]}"
                         -DSWIFT_INSTALL_COMPONENTS:STRING="${SWIFT_INSTALL_COMPONENTS}"
-                    )
-                fi
-
-                if [[ "${ENABLE_TENSORFLOW}" ]] ; then
-                    cmake_options=(
-                        "${cmake_options[@]}"
-                        -DSWIFT_ENABLE_TENSORFLOW:BOOL=TRUE
                     )
                 fi
 


### PR DESCRIPTION
Propagate `--enable-tensorflow` flag from `build-script` to `build-script-impl`.

Resolves TF-1174: macOS test failures due to `no_tensorflow` lit feature.
The `no_tensorflow` issue also exists on Linux, but no tests fail due to it being enabled.