### PR TITLE
[test] REQUIRE cpu arm64 when testing arm64 flags.

### DIFF
--- a/test/Serialization/android-modules.swift
+++ b/test/Serialization/android-modules.swift
@@ -1,3 +1,4 @@
+// REQUIRES: CPU=arm64
 // RUN: %empty-directory(%t)
 // RUN: %swift_driver_plain --driver-mode=swiftc -target aarch64-unknown-linux-android -c %s -parse-stdlib -module-name Swift -emit-module -emit-module-path %t/Swift.swiftmodule
 // RUN: %swift_driver_plain --driver-mode=swiftc -O -target aarch64-unknown-linux-android21 -c %s -I %t


### PR DESCRIPTION
If llvm-targets-to-build doesn't include AArch64, then this test fails
unhelpfully because architecture-specific flags are missing.