### PR TITLE
[build] Fix TensorFlow build product installation.

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/tensorflow.py
+++ b/utils/swift_build_support/swift_build_support/products/tensorflow.py
@@ -176,6 +176,7 @@ class TensorFlow(product.Product):
         return self.args.build_tensorflow_swift_apis
 
     def install(self, host_target):
+        # Install `libtensorflow.{dylib,so}` in the toolchain.
         (suffixed_lib_name, unsuffixed_lib_name) = \
             self._get_tensorflow_library(host_target)
 
@@ -184,7 +185,6 @@ class TensorFlow(product.Product):
             subdir = 'macosx'
         if host_target.startswith('linux'):
             subdir = 'linux'
-
         if not subdir:
             raise RuntimeError('unknown host target {}'.format(host_target))
 
@@ -202,6 +202,12 @@ class TensorFlow(product.Product):
                                  'usr', 'lib', 'swift',
                                  subdir, suffixed_lib_name))
 
+        # Add write permissions to `libtensorflow.{dylib,so}`.
+        # This is required for symbol stripping and code signing.
+        os.chmod(os.path.join(self.install_toolchain_path(),
+                              'usr', 'lib', 'swift', subdir, suffixed_lib_name),
+                 0o755)
+
         try:
             os.unlink(os.path.join(self.install_toolchain_path(),
                                    'usr', 'lib', 'swift',
@@ -213,12 +219,12 @@ class TensorFlow(product.Product):
                                 'usr', 'lib', 'swift',
                                 subdir, unsuffixed_lib_name))
 
+        # Copy TensorFlow headers and `module.modulemap` to the toolchain.
+        toolchain_tensorflow_library_path = os.path.join(
+            self.install_toolchain_path(), 'usr', 'lib', 'swift', 'tensorflow')
         try:
-            shutil.rmtree(os.path.join(self.install_toolchain_path(),
-                                       'usr', 'lib', 'swift', 'tensorflow'))
-            os.makedirs(os.path.join(self.install_toolchain_path(),
-                                     'usr', 'lib', 'swift', 'tensorflow', 'c',
-                                     'eager'))
+            shutil.rmtree(toolchain_tensorflow_library_path, ignore_errors=True)
+            os.makedirs(os.path.join(toolchain_tensorflow_library_path, 'c', 'eager'))
         except OSError:
             pass
         for header in (
@@ -231,9 +237,7 @@ class TensorFlow(product.Product):
                 'eager/c_api.h',
         ):
             shutil.copy(os.path.join(self.source_dir, 'tensorflow', 'c', header),
-                        os.path.join(self.install_toolchain_path(),
-                                     'usr', 'lib', 'swift', 'tensorflow', 'c',
-                                     header))
+                        os.path.join(toolchain_tensorflow_library_path, 'c', header))
 
         for name in (
                 'CTensorFlow.h',
@@ -242,7 +246,6 @@ class TensorFlow(product.Product):
             shutil.copy(os.path.join(self.source_dir, '..',
                                      'tensorflow-swift-apis', 'Sources',
                                      'CTensorFlow', name),
-                        os.path.join(self.install_toolchain_path(),
-                                     'usr', 'lib', 'swift', 'tensorflow', name))
+                        os.path.join(toolchain_tensorflow_library_path, name))
 
 # SWIFT_ENABLE_TENSORFLOW END


### PR DESCRIPTION
Fix TensorFlow build product installation:
- Add write permissions to `libtensorflow.{dylib,so}`.
  - This is important for symbol stripping and code signing.
- Call `shutil.rmtree` with `ignore_errors=True`.
  - This now works when the target directory does not exist.

Incrementally fixes `build-toolchain-tensorflow`.

---

Verifying this patch now. Please do not merge yet.