### PR TITLE
Disabled Result_future on another simulator.

### DIFF
--- a/test/Prototypes/Result_future.swift
+++ b/test/Prototypes/Result_future.swift
@@ -19,6 +19,7 @@
 // Executing on the simulator within __abort_with_payload with "No ABI plugin located for triple x86_64h-apple-ios -- shared libraries will not be registered!"
 // UNSUPPORTED: CPU=x86_64 && OS=ios
 // UNSUPPORTED: CPU=x86_64 && OS=tvos
+// UNSUPPORTED: CPU=x86_64 && OS=watchos
 // UNSUPPORTED: CPU=i386 && OS=watchos
 // UNSUPPORTED: use_os_stdlib
 


### PR DESCRIPTION
The test cannot run on simulator since it requires a "future" target--in this case watchOS 9.99 which is inherently beyond what any simulator is running.