### PR TITLE
[build] Don't reset 'swiftlib_link_flags_all' unnecessarily

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1437,7 +1437,6 @@ function(add_swift_target_library name)
 
       # Add PrivateFrameworks, rdar://28466433
       set(swiftlib_c_compile_flags_all ${SWIFTLIB_C_COMPILE_FLAGS})
-      set(swiftlib_link_flags_all ${SWIFTLIB_LINK_FLAGS})
 
       # Add flags to prepend framework search paths for the parallel framework
       # hierarchy rooted at /System/iOSSupport/...


### PR DESCRIPTION
Done in #29017 but [this variable has already been set just above](https://github.com/apple/swift/blob/79716efbee156d3cce2d5f82676945c99ff24535/cmake/modules/AddSwift.cmake#L2257), so all subsequent flags added are wiped, which breaks setting the soname for target libraries on Android (@SDGGiesbrecht, let me know if this patch fixes [the Android linking issue you mentioned on the forum](https://forums.swift.org/t/ci-for-packages-on-windows-android/32295/65), it should), among others.

@devincoughlin, I don't know if this was a temporary change you needed or if those prior modified flags were affecting your Catalyst work somehow, let me know.