### PR TITLE
[NFC] Minimize uses of 'fileprivate' after SE-0169

### DIFF
--- a/stdlib/public/Darwin/Foundation/AffineTransform.swift
+++ b/stdlib/public/Darwin/Foundation/AffineTransform.swift
@@ -33,7 +33,7 @@ public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConv
         self.tY = tY
     }
     
-    fileprivate init(reference: __shared NSAffineTransform) {
+    private init(reference: __shared NSAffineTransform) {
         m11 = reference.transformStruct.m11
         m12 = reference.transformStruct.m12
         m21 = reference.transformStruct.m21
@@ -42,7 +42,7 @@ public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConv
         tY = reference.transformStruct.tY
     }
     
-    fileprivate var reference : NSAffineTransform {
+    private var reference: NSAffineTransform {
         let ref = NSAffineTransform()
         ref.transformStruct = NSAffineTransformStruct(m11: m11, m12: m12, m21: m21, m22: m22, tX: tX, tY: tY)
         return ref

--- a/stdlib/public/Darwin/Foundation/CharacterSet.swift
+++ b/stdlib/public/Darwin/Foundation/CharacterSet.swift
@@ -32,27 +32,27 @@ private func _utfRangeToCFRange(_ inRange : ClosedRange<Unicode.Scalar>) -> CFRa
 // NOTE: older overlays called this class _CharacterSetStorage.
 // The two must coexist without a conflicting ObjC class name, so it
 // was renamed. The old name must not be used in the new runtime.
-fileprivate final class __CharacterSetStorage : Hashable {
-    fileprivate enum Backing {
+private final class __CharacterSetStorage : Hashable {
+    enum Backing {
         case immutable(CFCharacterSet)
         case mutable(CFMutableCharacterSet)
     }
     
-    fileprivate var _backing : Backing
+    var _backing: Backing
    
     @nonobjc 
-    init(immutableReference r : CFCharacterSet) {
+    init(immutableReference r: CFCharacterSet) {
         _backing = .immutable(r)
     }
 
     @nonobjc
-    init(mutableReference r : CFMutableCharacterSet) {
+    init(mutableReference r: CFMutableCharacterSet) {
         _backing = .mutable(r)
     }
     
     // MARK: -
     
-    fileprivate func hash(into hasher: inout Hasher) {
+    func hash(into hasher: inout Hasher) {
         switch _backing {
         case .immutable(let cs):
             hasher.combine(CFHash(cs))
@@ -61,7 +61,7 @@ fileprivate final class __CharacterSetStorage : Hashable {
         }
     }
 
-    fileprivate static func ==(lhs : __CharacterSetStorage, rhs : __CharacterSetStorage) -> Bool {
+    static func ==(lhs: __CharacterSetStorage, rhs: __CharacterSetStorage) -> Bool {
         switch (lhs._backing, rhs._backing) {
         case (.immutable(let cs1), .immutable(let cs2)):
             return CFEqual(cs1, cs2)
@@ -76,7 +76,7 @@ fileprivate final class __CharacterSetStorage : Hashable {
     
     // MARK: -
     
-    fileprivate func mutableCopy() -> __CharacterSetStorage {
+    func mutableCopy() -> __CharacterSetStorage {
         switch _backing {
         case .immutable(let cs):
             return __CharacterSetStorage(mutableReference: CFCharacterSetCreateMutableCopy(nil, cs))
@@ -88,7 +88,7 @@ fileprivate final class __CharacterSetStorage : Hashable {
     
     // MARK: Immutable Functions
     
-    fileprivate var bitmapRepresentation : Data {
+    var bitmapRepresentation: Data {
         switch _backing {
         case .immutable(let cs):
             return CFCharacterSetCreateBitmapRepresentation(nil, cs) as Data
@@ -97,7 +97,7 @@ fileprivate final class __CharacterSetStorage : Hashable {
         }
     }
     
-    fileprivate func hasMember(inPlane plane: UInt8) -> Bool {
+    func hasMember(inPlane plane: UInt8) -> Bool {
         switch _backing {
         case .immutable(let cs):
             return CFCharacterSetHasMemberInPlane(cs, CFIndex(plane))
@@ -108,7 +108,7 @@ fileprivate final class __CharacterSetStorage : Hashable {
     
     // MARK: Mutable functions
     
-    fileprivate func insert(charactersIn range: Range<Unicode.Scalar>) {
+    func insert(charactersIn range: Range<Unicode.Scalar>) {
         switch _backing {
         case .immutable(let cs):
             let r = CFCharacterSetCreateMutableCopy(nil, cs)!
@@ -119,7 +119,7 @@ fileprivate final class __CharacterSetStorage : Hashable {
         }
     }
     
-    fileprivate func insert(charactersIn range: ClosedRange<Unicode.Scalar>) {
+    func insert(charactersIn range: ClosedRange<Unicode.Scalar>) {
         switch _backing {
         case .immutable(let cs):
             let r = CFCharacterSetCreateMutableCopy(nil, cs)!
@@ -130,7 +130,7 @@ fileprivate final class __CharacterSetStorage : Hashable {
         }
     }
     
-    fileprivate func remove(charactersIn range: Range<Unicode.Scalar>) {
+    func remove(charactersIn range: Range<Unicode.Scalar>) {
         switch _backing {
         case .immutable(let cs):
             let r = CFCharacterSetCreateMutableCopy(nil, cs)!
@@ -141,7 +141,7 @@ fileprivate final class __CharacterSetStorage : Hashable {
         }
     }
     
-    fileprivate func remove(charactersIn range: ClosedRange<Unicode.Scalar>) {
+    func remove(charactersIn range: ClosedRange<Unicode.Scalar>) {
         switch _backing {
         case .immutable(let cs):
             let r = CFCharacterSetCreateMutableCopy(nil, cs)!
@@ -152,7 +152,7 @@ fileprivate final class __CharacterSetStorage : Hashable {
         }
     }
     
-    fileprivate func insert(charactersIn string: String) {
+    func insert(charactersIn string: String) {
         switch _backing {
         case .immutable(let cs):
             let r = CFCharacterSetCreateMutableCopy(nil, cs)!
@@ -163,7 +163,7 @@ fileprivate final class __CharacterSetStorage : Hashable {
         }
     }
     
-    fileprivate func remove(charactersIn string: String) {
+    func remove(charactersIn string: String) {
         switch _backing {
         case .immutable(let cs):
             let r = CFCharacterSetCreateMutableCopy(nil, cs)!
@@ -174,7 +174,7 @@ fileprivate final class __CharacterSetStorage : Hashable {
         }
     }
     
-    fileprivate func invert() {
+    func invert() {
         switch _backing {
         case .immutable(let cs):
             let r = CFCharacterSetCreateMutableCopy(nil, cs)!
@@ -187,31 +187,31 @@ fileprivate final class __CharacterSetStorage : Hashable {
     
     // -----
     // MARK: -
-    // MARK: SetAlgebraType
+    // MARK: SetAlgebra
     
     @discardableResult
-    fileprivate func insert(_ character: Unicode.Scalar) -> (inserted: Bool, memberAfterInsert: Unicode.Scalar) {
+    func insert(_ character: Unicode.Scalar) -> (inserted: Bool, memberAfterInsert: Unicode.Scalar) {
         insert(charactersIn: character...character)
         // TODO: This should probably return the truth, but figuring it out requires two calls into NSCharacterSet
         return (true, character)
     }
     
     @discardableResult
-    fileprivate func update(with character: Unicode.Scalar) -> Unicode.Scalar? {
+    func update(with character: Unicode.Scalar) -> Unicode.Scalar? {
         insert(character)
         // TODO: This should probably return the truth, but figuring it out requires two calls into NSCharacterSet
         return character
     }
     
     @discardableResult
-    fileprivate func remove(_ character: Unicode.Scalar) -> Unicode.Scalar? {
+    func remove(_ character: Unicode.Scalar) -> Unicode.Scalar? {
         // TODO: Add method to CFCharacterSet to do this in one call
         let result : Unicode.Scalar? = contains(character) ? character : nil
         remove(charactersIn: character...character)
         return result
     }
     
-    fileprivate func contains(_ member: Unicode.Scalar) -> Bool {
+    func contains(_ member: Unicode.Scalar) -> Bool {
         switch _backing {
         case .immutable(let cs):
             return CFCharacterSetIsLongCharacterMember(cs, member.value)
@@ -267,7 +267,7 @@ fileprivate final class __CharacterSetStorage : Hashable {
 
     }
     
-    fileprivate var inverted : CharacterSet {
+    var inverted: CharacterSet {
         switch _backing {
         case .immutable(let cs):
             return CharacterSet(_uncopiedStorage: __CharacterSetStorage(immutableReference: CFCharacterSetCreateInvertedSet(nil, cs)))
@@ -277,40 +277,40 @@ fileprivate final class __CharacterSetStorage : Hashable {
         }
     }
 
-    fileprivate func union(_ other: __CharacterSetStorage) -> CharacterSet {
+    func union(_ other: __CharacterSetStorage) -> CharacterSet {
         return __CharacterSetStorage._apply(self, other, CFCharacterSetUnion)
     }
     
-    fileprivate func formUnion(_ other: __CharacterSetStorage) {
+    func formUnion(_ other: __CharacterSetStorage) {
         _applyMutation(other, CFCharacterSetUnion)
     }
     
-    fileprivate func intersection(_ other: __CharacterSetStorage) -> CharacterSet {
+    func intersection(_ other: __CharacterSetStorage) -> CharacterSet {
         return __CharacterSetStorage._apply(self, other, CFCharacterSetIntersect)
     }
     
-    fileprivate func formIntersection(_ other: __CharacterSetStorage) {
+    func formIntersection(_ other: __CharacterSetStorage) {
         _applyMutation(other, CFCharacterSetIntersect)
     }
     
-    fileprivate func subtracting(_ other: __CharacterSetStorage) -> CharacterSet {
+    func subtracting(_ other: __CharacterSetStorage) -> CharacterSet {
         return intersection(other.inverted._storage)
     }
     
-    fileprivate func subtract(_ other: __CharacterSetStorage) {
+    func subtract(_ other: __CharacterSetStorage) {
         _applyMutation(other.inverted._storage, CFCharacterSetIntersect)
     }
     
-    fileprivate func symmetricDifference(_ other: __CharacterSetStorage) -> CharacterSet {
+    func symmetricDifference(_ other: __CharacterSetStorage) -> CharacterSet {
         return union(other).subtracting(intersection(other))
     }
     
-    fileprivate func formSymmetricDifference(_ other: __CharacterSetStorage) {
+    func formSymmetricDifference(_ other: __CharacterSetStorage) {
         // This feels like cheating
         _backing = symmetricDifference(other)._storage._backing
     }
     
-    fileprivate func isSuperset(of other: __CharacterSetStorage) -> Bool {
+    func isSuperset(of other: __CharacterSetStorage) -> Bool {
         switch _backing {
         case .immutable(let cs):
             switch other._backing {
@@ -331,7 +331,7 @@ fileprivate final class __CharacterSetStorage : Hashable {
     
     // MARK: -
     
-    fileprivate var description: String {
+    var description: String {
         switch _backing {
         case .immutable(let cs):
             return CFCopyDescription(cs) as String
@@ -340,7 +340,7 @@ fileprivate final class __CharacterSetStorage : Hashable {
         }
     }
     
-    fileprivate var debugDescription: String {
+    var debugDescription: String {
         return description
     }
     
@@ -366,7 +366,7 @@ fileprivate final class __CharacterSetStorage : Hashable {
 public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgebra {
     public typealias ReferenceType = NSCharacterSet
     
-    fileprivate var _storage : __CharacterSetStorage
+    fileprivate var _storage: __CharacterSetStorage
     
     // MARK: Init methods
     
@@ -418,19 +418,19 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
         }
     }
 
-    fileprivate init(_bridged characterSet: __shared NSCharacterSet) {
+    private init(_bridged characterSet: __shared NSCharacterSet) {
         _storage = __CharacterSetStorage(immutableReference: characterSet.copy() as! CFCharacterSet)
     }
     
-    fileprivate init(_uncopiedImmutableReference characterSet: CFCharacterSet) {
+    private init(_uncopiedImmutableReference characterSet: CFCharacterSet) {
         _storage = __CharacterSetStorage(immutableReference: characterSet)
     }
 
-    fileprivate init(_uncopiedStorage : __CharacterSetStorage) {
+    fileprivate init(_uncopiedStorage: __CharacterSetStorage) {
         _storage = _uncopiedStorage
     }
 
-    fileprivate init(_builtIn: __shared CFCharacterSetPredefinedSet) {
+    private init(_builtIn: __shared CFCharacterSetPredefinedSet) {
         _storage = __CharacterSetStorage(immutableReference: CFCharacterSetGetPredefined(_builtIn))
     }
     
@@ -657,7 +657,7 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
     
     // -----
     // MARK: -
-    // MARK: SetAlgebraType
+    // MARK: SetAlgebra
     
     /// Insert a `Unicode.Scalar` representation of a character into the `CharacterSet`.
     ///

--- a/stdlib/public/Darwin/Foundation/Codable.swift
+++ b/stdlib/public/Darwin/Foundation/Codable.swift
@@ -39,7 +39,7 @@ extension DecodingError {
     /// - parameter value: The value whose type to describe.
     /// - returns: A string describing `value`.
     /// - precondition: `value` is one of the types below.
-    fileprivate static func _typeDescription(of value: Any) -> String {
+    private static func _typeDescription(of value: Any) -> String {
         if value is NSNull {
             return "a null value"
         } else if value is NSNumber /* FIXME: If swift-corelibs-foundation isn't updated to use NSNumber, this check will be necessary: || value is Int || value is Double */ {

--- a/stdlib/public/Darwin/Foundation/Data.swift
+++ b/stdlib/public/Darwin/Foundation/Data.swift
@@ -18,7 +18,7 @@ import Darwin
 import Glibc
 
 @inlinable // This is @inlinable as trivially computable.
-fileprivate func malloc_good_size(_ size: Int) -> Int {
+private func malloc_good_size(_ size: Int) -> Int {
     return size
 }
 

--- a/stdlib/public/Darwin/Foundation/DateComponents.swift
+++ b/stdlib/public/Darwin/Foundation/DateComponents.swift
@@ -265,7 +265,7 @@ public struct DateComponents : ReferenceConvertible, Hashable, Equatable, _Mutab
 
     // MARK: - Bridging Helpers
     
-    fileprivate init(reference: __shared NSDateComponents) {
+    private init(reference: __shared NSDateComponents) {
         _handle = _MutableHandle(reference: reference)
     }
 

--- a/stdlib/public/Darwin/Foundation/IndexSet.swift
+++ b/stdlib/public/Darwin/Foundation/IndexSet.swift
@@ -115,7 +115,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     public typealias ReferenceType = NSIndexSet
     public typealias Element = Int
     
-    fileprivate var _handle: _MutablePairHandle<NSIndexSet, NSMutableIndexSet>
+    private var _handle: _MutablePairHandle<NSIndexSet, NSMutableIndexSet>
     
     /// Initialize an `IndexSet` with a range of integers.
     public init(integersIn range: Range<Element>) {
@@ -664,11 +664,11 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     
     // MARK: - Bridging Support
     
-    fileprivate var reference: NSIndexSet {
+    private var reference: NSIndexSet {
         return _handle.reference
     }
     
-    fileprivate init(reference: __shared NSIndexSet) {
+    private init(reference: __shared NSIndexSet) {
         _handle = _MutablePairHandle(reference)
     }
 }
@@ -700,7 +700,7 @@ private struct IndexSetBoundaryIterator : IteratorProtocol {
     private var i1UsedLower: Bool
     private var i2UsedLower: Bool
     
-    fileprivate init(_ is1: IndexSet, _ is2: IndexSet) {
+    init(_ is1: IndexSet, _ is2: IndexSet) {
         i1 = is1.rangeView.makeIterator()
         i2 = is2.rangeView.makeIterator()
         
@@ -712,7 +712,7 @@ private struct IndexSetBoundaryIterator : IteratorProtocol {
         i2UsedLower = false
     }
     
-    fileprivate mutating func next() -> Element? {
+    mutating func next() -> Element? {
         if i1Range == nil && i2Range == nil {
             return nil
         }
@@ -814,7 +814,7 @@ private enum _MutablePair<ImmutableType, MutableType> {
 /// a.k.a. Box
 private final class _MutablePairHandle<ImmutableType : NSObject, MutableType : NSObject>
   where ImmutableType : NSMutableCopying, MutableType : NSMutableCopying {
-    fileprivate var _pointer: _MutablePair<ImmutableType, MutableType>
+    var _pointer: _MutablePair<ImmutableType, MutableType>
     
     /// Initialize with an immutable reference instance.
     ///

--- a/stdlib/public/Darwin/Foundation/JSONEncoder.swift
+++ b/stdlib/public/Darwin/Foundation/JSONEncoder.swift
@@ -15,12 +15,12 @@
 ///
 /// NOTE: The architecture and environment check is due to a bug in the current (2018-08-08) Swift 4.2
 /// runtime when running on i386 simulator. The issue is tracked in https://bugs.swift.org/browse/SR-8276
-/// Making the protocol `internal` instead of `fileprivate` works around this issue.
-/// Once SR-8276 is fixed, this check can be removed and the protocol always be made fileprivate.
+/// Making the protocol `internal` instead of `private` works around this issue.
+/// Once SR-8276 is fixed, this check can be removed and the protocol always be made private.
 #if arch(i386) || arch(arm)
 internal protocol _JSONStringDictionaryEncodableMarker { }
 #else
-fileprivate protocol _JSONStringDictionaryEncodableMarker { }
+private protocol _JSONStringDictionaryEncodableMarker { }
 #endif
 
 extension Dictionary : _JSONStringDictionaryEncodableMarker where Key == String, Value: Encodable { }
@@ -37,7 +37,7 @@ internal protocol _JSONStringDictionaryDecodableMarker {
     static var elementType: Decodable.Type { get }
 }
 #else
-fileprivate protocol _JSONStringDictionaryDecodableMarker {
+private protocol _JSONStringDictionaryDecodableMarker {
     static var elementType: Decodable.Type { get }
 }
 #endif
@@ -283,14 +283,14 @@ open class JSONEncoder {
 // NOTE: older overlays called this class _JSONEncoder.
 // The two must coexist without a conflicting ObjC class name, so it
 // was renamed. The old name must not be used in the new runtime.
-fileprivate class __JSONEncoder : Encoder {
+private class __JSONEncoder : Encoder {
     // MARK: Properties
 
     /// The encoder's storage.
-    fileprivate var storage: _JSONEncodingStorage
+    var storage: _JSONEncodingStorage
 
     /// Options set on the top-level encoder.
-    fileprivate let options: JSONEncoder._Options
+    let options: JSONEncoder._Options
 
     /// The path to the current point in encoding.
     public var codingPath: [CodingKey]
@@ -303,7 +303,7 @@ fileprivate class __JSONEncoder : Encoder {
     // MARK: - Initialization
 
     /// Initializes `self` with the given top-level encoder options.
-    fileprivate init(options: JSONEncoder._Options, codingPath: [CodingKey] = []) {
+    init(options: JSONEncoder._Options, codingPath: [CodingKey] = []) {
         self.options = options
         self.storage = _JSONEncodingStorage()
         self.codingPath = codingPath
@@ -312,7 +312,7 @@ fileprivate class __JSONEncoder : Encoder {
     /// Returns whether a new element can be encoded at this coding path.
     ///
     /// `true` if an element has not yet been encoded at this coding path; `false` otherwise.
-    fileprivate var canEncodeNewValue: Bool {
+    var canEncodeNewValue: Bool {
         // Every time a new value gets encoded, the key it's encoded for is pushed onto the coding path (even if it's a nil key from an unkeyed container).
         // At the same time, every time a container is requested, a new value gets pushed onto the storage stack.
         // If there are more values on the storage stack than on the coding path, it means the value is requesting more than one container, which violates the precondition.
@@ -365,41 +365,41 @@ fileprivate class __JSONEncoder : Encoder {
 
 // MARK: - Encoding Storage and Containers
 
-fileprivate struct _JSONEncodingStorage {
+private struct _JSONEncodingStorage {
     // MARK: Properties
 
     /// The container stack.
     /// Elements may be any one of the JSON types (NSNull, NSNumber, NSString, NSArray, NSDictionary).
-    private(set) fileprivate var containers: [NSObject] = []
+    private(set) var containers: [NSObject] = []
 
     // MARK: - Initialization
 
     /// Initializes `self` with no containers.
-    fileprivate init() {}
+    init() {}
 
     // MARK: - Modifying the Stack
 
-    fileprivate var count: Int {
+    var count: Int {
         return self.containers.count
     }
 
-    fileprivate mutating func pushKeyedContainer() -> NSMutableDictionary {
+    mutating func pushKeyedContainer() -> NSMutableDictionary {
         let dictionary = NSMutableDictionary()
         self.containers.append(dictionary)
         return dictionary
     }
 
-    fileprivate mutating func pushUnkeyedContainer() -> NSMutableArray {
+    mutating func pushUnkeyedContainer() -> NSMutableArray {
         let array = NSMutableArray()
         self.containers.append(array)
         return array
     }
 
-    fileprivate mutating func push(container: __owned NSObject) {
+    mutating func push(container: __owned NSObject) {
         self.containers.append(container)
     }
 
-    fileprivate mutating func popContainer() -> NSObject {
+    mutating func popContainer() -> NSObject {
         precondition(!self.containers.isEmpty, "Empty container stack.")
         return self.containers.popLast()!
     }
@@ -407,7 +407,7 @@ fileprivate struct _JSONEncodingStorage {
 
 // MARK: - Encoding Containers
 
-fileprivate struct _JSONKeyedEncodingContainer<K : CodingKey> : KeyedEncodingContainerProtocol {
+private struct _JSONKeyedEncodingContainer<K : CodingKey> : KeyedEncodingContainerProtocol {
     typealias Key = K
 
     // MARK: Properties
@@ -424,7 +424,7 @@ fileprivate struct _JSONKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCon
     // MARK: - Initialization
 
     /// Initializes `self` with the given references.
-    fileprivate init(referencing encoder: __JSONEncoder, codingPath: [CodingKey], wrapping container: NSMutableDictionary) {
+    init(referencing encoder: __JSONEncoder, codingPath: [CodingKey], wrapping container: NSMutableDictionary) {
         self.encoder = encoder
         self.codingPath = codingPath
         self.container = container
@@ -555,7 +555,7 @@ fileprivate struct _JSONKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCon
     }
 }
 
-fileprivate struct _JSONUnkeyedEncodingContainer : UnkeyedEncodingContainer {
+private struct _JSONUnkeyedEncodingContainer : UnkeyedEncodingContainer {
     // MARK: Properties
 
     /// A reference to the encoder we're writing to.
@@ -575,7 +575,7 @@ fileprivate struct _JSONUnkeyedEncodingContainer : UnkeyedEncodingContainer {
     // MARK: - Initialization
 
     /// Initializes `self` with the given references.
-    fileprivate init(referencing encoder: __JSONEncoder, codingPath: [CodingKey], wrapping container: NSMutableArray) {
+    init(referencing encoder: __JSONEncoder, codingPath: [CodingKey], wrapping container: NSMutableArray) {
         self.encoder = encoder
         self.codingPath = codingPath
         self.container = container
@@ -645,7 +645,7 @@ fileprivate struct _JSONUnkeyedEncodingContainer : UnkeyedEncodingContainer {
 extension __JSONEncoder : SingleValueEncodingContainer {
     // MARK: - SingleValueEncodingContainer Methods
 
-    fileprivate func assertCanEncodeNewValue() {
+    private func assertCanEncodeNewValue() {
         precondition(self.canEncodeNewValue, "Attempt to encode value through single value container when previously value already encoded.")
     }
 
@@ -732,22 +732,22 @@ extension __JSONEncoder : SingleValueEncodingContainer {
 
 // MARK: - Concrete Value Representations
 
-extension __JSONEncoder {
+private extension __JSONEncoder {
     /// Returns the given value boxed in a container appropriate for pushing onto the container stack.
-    fileprivate func box(_ value: Bool)   -> NSObject { return NSNumber(value: value) }
-    fileprivate func box(_ value: Int)    -> NSObject { return NSNumber(value: value) }
-    fileprivate func box(_ value: Int8)   -> NSObject { return NSNumber(value: value) }
-    fileprivate func box(_ value: Int16)  -> NSObject { return NSNumber(value: value) }
-    fileprivate func box(_ value: Int32)  -> NSObject { return NSNumber(value: value) }
-    fileprivate func box(_ value: Int64)  -> NSObject { return NSNumber(value: value) }
-    fileprivate func box(_ value: UInt)   -> NSObject { return NSNumber(value: value) }
-    fileprivate func box(_ value: UInt8)  -> NSObject { return NSNumber(value: value) }
-    fileprivate func box(_ value: UInt16) -> NSObject { return NSNumber(value: value) }
-    fileprivate func box(_ value: UInt32) -> NSObject { return NSNumber(value: value) }
-    fileprivate func box(_ value: UInt64) -> NSObject { return NSNumber(value: value) }
-    fileprivate func box(_ value: String) -> NSObject { return NSString(string: value) }
+    func box(_ value: Bool)   -> NSObject { return NSNumber(value: value) }
+    func box(_ value: Int)    -> NSObject { return NSNumber(value: value) }
+    func box(_ value: Int8)   -> NSObject { return NSNumber(value: value) }
+    func box(_ value: Int16)  -> NSObject { return NSNumber(value: value) }
+    func box(_ value: Int32)  -> NSObject { return NSNumber(value: value) }
+    func box(_ value: Int64)  -> NSObject { return NSNumber(value: value) }
+    func box(_ value: UInt)   -> NSObject { return NSNumber(value: value) }
+    func box(_ value: UInt8)  -> NSObject { return NSNumber(value: value) }
+    func box(_ value: UInt16) -> NSObject { return NSNumber(value: value) }
+    func box(_ value: UInt32) -> NSObject { return NSNumber(value: value) }
+    func box(_ value: UInt64) -> NSObject { return NSNumber(value: value) }
+    func box(_ value: String) -> NSObject { return NSString(string: value) }
 
-    fileprivate func box(_ float: Float) throws -> NSObject {
+    func box(_ float: Float) throws -> NSObject {
         guard !float.isInfinite && !float.isNaN else {
             guard case let .convertToString(positiveInfinity: posInfString,
                                             negativeInfinity: negInfString,
@@ -767,7 +767,7 @@ extension __JSONEncoder {
         return NSNumber(value: float)
     }
 
-    fileprivate func box(_ double: Double) throws -> NSObject {
+    func box(_ double: Double) throws -> NSObject {
         guard !double.isInfinite && !double.isNaN else {
             guard case let .convertToString(positiveInfinity: posInfString,
                                             negativeInfinity: negInfString,
@@ -787,7 +787,7 @@ extension __JSONEncoder {
         return NSNumber(value: double)
     }
 
-    fileprivate func box(_ date: Date) throws -> NSObject {
+    func box(_ date: Date) throws -> NSObject {
         switch self.options.dateEncodingStrategy {
         case .deferredToDate:
             // Must be called with a surrounding with(pushedKey:) call.
@@ -834,7 +834,7 @@ extension __JSONEncoder {
         }
     }
 
-    fileprivate func box(_ data: Data) throws -> NSObject {
+    func box(_ data: Data) throws -> NSObject {
         switch self.options.dataEncodingStrategy {
         case .deferredToData:
             // Must be called with a surrounding with(pushedKey:) call.
@@ -879,7 +879,7 @@ extension __JSONEncoder {
         }
     }
 
-    fileprivate func box(_ dict: [String : Encodable]) throws -> NSObject? {
+    func box(_ dict: [String : Encodable]) throws -> NSObject? {
         let depth = self.storage.count
         let result = self.storage.pushKeyedContainer()
         do {
@@ -905,12 +905,12 @@ extension __JSONEncoder {
         return self.storage.popContainer()
     }
 
-    fileprivate func box(_ value: Encodable) throws -> NSObject {
+    func box(_ value: Encodable) throws -> NSObject {
         return try self.box_(value) ?? NSDictionary()
     }
 
     // This method is called "box_" instead of "box" to disambiguate it from the overloads. Because the return type here is different from all of the "box" overloads (and is more general), any "box" calls in here would call back into "box" recursively instead of calling the appropriate overload, which is not what we want.
-    fileprivate func box_(_ value: Encodable) throws -> NSObject? {
+    func box_(_ value: Encodable) throws -> NSObject? {
         // Disambiguation between variable and function is required due to
         // issue tracked at: https://bugs.swift.org/browse/SR-1846
         let type = Swift.type(of: value)
@@ -959,7 +959,7 @@ extension __JSONEncoder {
 // NOTE: older overlays called this class _JSONReferencingEncoder.
 // The two must coexist without a conflicting ObjC class name, so it
 // was renamed. The old name must not be used in the new runtime.
-fileprivate class __JSONReferencingEncoder : __JSONEncoder {
+private class __JSONReferencingEncoder : __JSONEncoder {
     // MARK: Reference types.
 
     /// The type of container we're referencing.
@@ -974,7 +974,7 @@ fileprivate class __JSONReferencingEncoder : __JSONEncoder {
     // MARK: - Properties
 
     /// The encoder we're referencing.
-    fileprivate let encoder: __JSONEncoder
+    let encoder: __JSONEncoder
 
     /// The container reference itself.
     private let reference: Reference
@@ -982,7 +982,7 @@ fileprivate class __JSONReferencingEncoder : __JSONEncoder {
     // MARK: - Initialization
 
     /// Initializes `self` by referencing the given array container in the given encoder.
-    fileprivate init(referencing encoder: __JSONEncoder, at index: Int, wrapping array: NSMutableArray) {
+    init(referencing encoder: __JSONEncoder, at index: Int, wrapping array: NSMutableArray) {
         self.encoder = encoder
         self.reference = .array(array, index)
         super.init(options: encoder.options, codingPath: encoder.codingPath)
@@ -991,8 +991,7 @@ fileprivate class __JSONReferencingEncoder : __JSONEncoder {
     }
 
     /// Initializes `self` by referencing the given dictionary container in the given encoder.
-    fileprivate init(referencing encoder: __JSONEncoder,
-                     key: CodingKey, convertedKey: __shared CodingKey, wrapping dictionary: NSMutableDictionary) {
+    init(referencing encoder: __JSONEncoder, key: CodingKey, convertedKey: __shared CodingKey, wrapping dictionary: NSMutableDictionary) {
         self.encoder = encoder
         self.reference = .dictionary(dictionary, convertedKey.stringValue)
         super.init(options: encoder.options, codingPath: encoder.codingPath)
@@ -1002,7 +1001,7 @@ fileprivate class __JSONReferencingEncoder : __JSONEncoder {
 
     // MARK: - Coding Path Operations
 
-    fileprivate override var canEncodeNewValue: Bool {
+    override var canEncodeNewValue: Bool {
         // With a regular encoder, the storage and coding path grow together.
         // A referencing encoder, however, inherits its parents coding path, as well as the key it was created for.
         // We have to take this into account.
@@ -1224,14 +1223,14 @@ open class JSONDecoder {
 // NOTE: older overlays called this class _JSONDecoder. The two must
 // coexist without a conflicting ObjC class name, so it was renamed.
 // The old name must not be used in the new runtime.
-fileprivate class __JSONDecoder : Decoder {
+private class __JSONDecoder : Decoder {
     // MARK: Properties
 
     /// The decoder's storage.
-    fileprivate var storage: _JSONDecodingStorage
+    var storage: _JSONDecodingStorage
 
     /// Options set on the top-level decoder.
-    fileprivate let options: JSONDecoder._Options
+    let options: JSONDecoder._Options
 
     /// The path to the current point in encoding.
     fileprivate(set) public var codingPath: [CodingKey]
@@ -1244,7 +1243,7 @@ fileprivate class __JSONDecoder : Decoder {
     // MARK: - Initialization
 
     /// Initializes `self` with the given top-level container and options.
-    fileprivate init(referencing container: Any, at codingPath: [CodingKey] = [], options: JSONDecoder._Options) {
+    init(referencing container: Any, at codingPath: [CodingKey] = [], options: JSONDecoder._Options) {
         self.storage = _JSONDecodingStorage()
         self.storage.push(container: container)
         self.codingPath = codingPath
@@ -1289,34 +1288,34 @@ fileprivate class __JSONDecoder : Decoder {
 
 // MARK: - Decoding Storage
 
-fileprivate struct _JSONDecodingStorage {
+private struct _JSONDecodingStorage {
     // MARK: Properties
 
     /// The container stack.
     /// Elements may be any one of the JSON types (NSNull, NSNumber, String, Array, [String : Any]).
-    private(set) fileprivate var containers: [Any] = []
+    private(set) var containers: [Any] = []
 
     // MARK: - Initialization
 
     /// Initializes `self` with no containers.
-    fileprivate init() {}
+    init() {}
 
     // MARK: - Modifying the Stack
 
-    fileprivate var count: Int {
+    var count: Int {
         return self.containers.count
     }
 
-    fileprivate var topContainer: Any {
+    var topContainer: Any {
         precondition(!self.containers.isEmpty, "Empty container stack.")
         return self.containers.last!
     }
 
-    fileprivate mutating func push(container: __owned Any) {
+    mutating func push(container: __owned Any) {
         self.containers.append(container)
     }
 
-    fileprivate mutating func popContainer() {
+    mutating func popContainer() {
         precondition(!self.containers.isEmpty, "Empty container stack.")
         self.containers.removeLast()
     }
@@ -1324,7 +1323,7 @@ fileprivate struct _JSONDecodingStorage {
 
 // MARK: Decoding Containers
 
-fileprivate struct _JSONKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProtocol {
+private struct _JSONKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProtocol {
     typealias Key = K
 
     // MARK: Properties
@@ -1341,7 +1340,7 @@ fileprivate struct _JSONKeyedDecodingContainer<K : CodingKey> : KeyedDecodingCon
     // MARK: - Initialization
 
     /// Initializes `self` by referencing the given decoder and container.
-    fileprivate init(referencing decoder: __JSONDecoder, wrapping container: [String : Any]) {
+    init(referencing decoder: __JSONDecoder, wrapping container: [String : Any]) {
         self.decoder = decoder
         switch decoder.options.keyDecodingStrategy {
         case .useDefaultKeys:
@@ -1675,7 +1674,7 @@ fileprivate struct _JSONKeyedDecodingContainer<K : CodingKey> : KeyedDecodingCon
     }
 }
 
-fileprivate struct _JSONUnkeyedDecodingContainer : UnkeyedDecodingContainer {
+private struct _JSONUnkeyedDecodingContainer : UnkeyedDecodingContainer {
     // MARK: Properties
 
     /// A reference to the decoder we're reading from.
@@ -1693,7 +1692,7 @@ fileprivate struct _JSONUnkeyedDecodingContainer : UnkeyedDecodingContainer {
     // MARK: - Initialization
 
     /// Initializes `self` by referencing the given decoder and container.
-    fileprivate init(referencing decoder: __JSONDecoder, wrapping container: [Any]) {
+    init(referencing decoder: __JSONDecoder, wrapping container: [Any]) {
         self.decoder = decoder
         self.container = container
         self.codingPath = decoder.codingPath
@@ -2121,9 +2120,9 @@ extension __JSONDecoder : SingleValueDecodingContainer {
 
 // MARK: - Concrete Value Representations
 
-extension __JSONDecoder {
+private extension __JSONDecoder {
     /// Returns the given value unboxed from a container.
-    fileprivate func unbox(_ value: Any, as type: Bool.Type) throws -> Bool? {
+    func unbox(_ value: Any, as type: Bool.Type) throws -> Bool? {
         guard !(value is NSNull) else { return nil }
 
         if let number = value as? NSNumber {
@@ -2144,7 +2143,7 @@ extension __JSONDecoder {
         throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
     }
 
-    fileprivate func unbox(_ value: Any, as type: Int.Type) throws -> Int? {
+    func unbox(_ value: Any, as type: Int.Type) throws -> Int? {
         guard !(value is NSNull) else { return nil }
 
         guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
@@ -2159,7 +2158,7 @@ extension __JSONDecoder {
         return int
     }
 
-    fileprivate func unbox(_ value: Any, as type: Int8.Type) throws -> Int8? {
+    func unbox(_ value: Any, as type: Int8.Type) throws -> Int8? {
         guard !(value is NSNull) else { return nil }
 
         guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
@@ -2174,7 +2173,7 @@ extension __JSONDecoder {
         return int8
     }
 
-    fileprivate func unbox(_ value: Any, as type: Int16.Type) throws -> Int16? {
+    func unbox(_ value: Any, as type: Int16.Type) throws -> Int16? {
         guard !(value is NSNull) else { return nil }
 
         guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
@@ -2189,7 +2188,7 @@ extension __JSONDecoder {
         return int16
     }
 
-    fileprivate func unbox(_ value: Any, as type: Int32.Type) throws -> Int32? {
+    func unbox(_ value: Any, as type: Int32.Type) throws -> Int32? {
         guard !(value is NSNull) else { return nil }
 
         guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
@@ -2204,7 +2203,7 @@ extension __JSONDecoder {
         return int32
     }
 
-    fileprivate func unbox(_ value: Any, as type: Int64.Type) throws -> Int64? {
+    func unbox(_ value: Any, as type: Int64.Type) throws -> Int64? {
         guard !(value is NSNull) else { return nil }
 
         guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
@@ -2219,7 +2218,7 @@ extension __JSONDecoder {
         return int64
     }
 
-    fileprivate func unbox(_ value: Any, as type: UInt.Type) throws -> UInt? {
+    func unbox(_ value: Any, as type: UInt.Type) throws -> UInt? {
         guard !(value is NSNull) else { return nil }
 
         guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
@@ -2234,7 +2233,7 @@ extension __JSONDecoder {
         return uint
     }
 
-    fileprivate func unbox(_ value: Any, as type: UInt8.Type) throws -> UInt8? {
+    func unbox(_ value: Any, as type: UInt8.Type) throws -> UInt8? {
         guard !(value is NSNull) else { return nil }
 
         guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
@@ -2249,7 +2248,7 @@ extension __JSONDecoder {
         return uint8
     }
 
-    fileprivate func unbox(_ value: Any, as type: UInt16.Type) throws -> UInt16? {
+    func unbox(_ value: Any, as type: UInt16.Type) throws -> UInt16? {
         guard !(value is NSNull) else { return nil }
 
         guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
@@ -2264,7 +2263,7 @@ extension __JSONDecoder {
         return uint16
     }
 
-    fileprivate func unbox(_ value: Any, as type: UInt32.Type) throws -> UInt32? {
+    func unbox(_ value: Any, as type: UInt32.Type) throws -> UInt32? {
         guard !(value is NSNull) else { return nil }
 
         guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
@@ -2279,7 +2278,7 @@ extension __JSONDecoder {
         return uint32
     }
 
-    fileprivate func unbox(_ value: Any, as type: UInt64.Type) throws -> UInt64? {
+    func unbox(_ value: Any, as type: UInt64.Type) throws -> UInt64? {
         guard !(value is NSNull) else { return nil }
 
         guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
@@ -2294,7 +2293,7 @@ extension __JSONDecoder {
         return uint64
     }
 
-    fileprivate func unbox(_ value: Any, as type: Float.Type) throws -> Float? {
+    func unbox(_ value: Any, as type: Float.Type) throws -> Float? {
         guard !(value is NSNull) else { return nil }
 
         if let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse {
@@ -2340,7 +2339,7 @@ extension __JSONDecoder {
         throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
     }
 
-    fileprivate func unbox(_ value: Any, as type: Double.Type) throws -> Double? {
+    func unbox(_ value: Any, as type: Double.Type) throws -> Double? {
         guard !(value is NSNull) else { return nil }
 
         if let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse {
@@ -2375,7 +2374,7 @@ extension __JSONDecoder {
         throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
     }
 
-    fileprivate func unbox(_ value: Any, as type: String.Type) throws -> String? {
+    func unbox(_ value: Any, as type: String.Type) throws -> String? {
         guard !(value is NSNull) else { return nil }
 
         guard let string = value as? String else {
@@ -2385,7 +2384,7 @@ extension __JSONDecoder {
         return string
     }
 
-    fileprivate func unbox(_ value: Any, as type: Date.Type) throws -> Date? {
+    func unbox(_ value: Any, as type: Date.Type) throws -> Date? {
         guard !(value is NSNull) else { return nil }
 
         switch self.options.dateDecodingStrategy {
@@ -2429,7 +2428,7 @@ extension __JSONDecoder {
         }
     }
 
-    fileprivate func unbox(_ value: Any, as type: Data.Type) throws -> Data? {
+    func unbox(_ value: Any, as type: Data.Type) throws -> Data? {
         guard !(value is NSNull) else { return nil }
 
         switch self.options.dataDecodingStrategy {
@@ -2456,7 +2455,7 @@ extension __JSONDecoder {
         }
     }
 
-    fileprivate func unbox(_ value: Any, as type: Decimal.Type) throws -> Decimal? {
+    func unbox(_ value: Any, as type: Decimal.Type) throws -> Decimal? {
         guard !(value is NSNull) else { return nil }
 
         // Attempt to bridge from NSDecimalNumber.
@@ -2468,7 +2467,7 @@ extension __JSONDecoder {
         }
     }
 
-    fileprivate func unbox<T>(_ value: Any, as type: _JSONStringDictionaryDecodableMarker.Type) throws -> T? {
+    func unbox<T>(_ value: Any, as type: _JSONStringDictionaryDecodableMarker.Type) throws -> T? {
         guard !(value is NSNull) else { return nil }
 
         var result = [String : Any]()
@@ -2487,11 +2486,11 @@ extension __JSONDecoder {
         return result as? T
     }
 
-    fileprivate func unbox<T : Decodable>(_ value: Any, as type: T.Type) throws -> T? {
+    func unbox<T : Decodable>(_ value: Any, as type: T.Type) throws -> T? {
         return try unbox_(value, as: type) as? T
     }
 
-    fileprivate func unbox_(_ value: Any, as type: Decodable.Type) throws -> Any? {
+    func unbox_(_ value: Any, as type: Decodable.Type) throws -> Any? {
         if type == Date.self || type == NSDate.self {
             return try self.unbox(value, as: Date.self)
         } else if type == Data.self || type == NSData.self {
@@ -2522,7 +2521,7 @@ extension __JSONDecoder {
 // Shared Key Types
 //===----------------------------------------------------------------------===//
 
-fileprivate struct _JSONKey : CodingKey {
+private struct _JSONKey : CodingKey {
     public var stringValue: String
     public var intValue: Int?
 
@@ -2541,12 +2540,12 @@ fileprivate struct _JSONKey : CodingKey {
         self.intValue = intValue
     }
 
-    fileprivate init(index: Int) {
+    init(index: Int) {
         self.stringValue = "Index \(index)"
         self.intValue = index
     }
 
-    fileprivate static let `super` = _JSONKey(stringValue: "super")!
+    static let `super` = _JSONKey(stringValue: "super")!
 }
 
 //===----------------------------------------------------------------------===//
@@ -2555,7 +2554,7 @@ fileprivate struct _JSONKey : CodingKey {
 
 // NOTE: This value is implicitly lazy and _must_ be lazy. We're compiled against the latest SDK (w/ ISO8601DateFormatter), but linked against whichever Foundation the user has. ISO8601DateFormatter might not exist, so we better not hit this code path on an older OS.
 @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-fileprivate var _iso8601Formatter: ISO8601DateFormatter = {
+private var _iso8601Formatter: ISO8601DateFormatter = {
     let formatter = ISO8601DateFormatter()
     formatter.formatOptions = .withInternetDateTime
     return formatter

--- a/stdlib/public/Darwin/Foundation/NSDictionary.swift
+++ b/stdlib/public/Darwin/Foundation/NSDictionary.swift
@@ -41,7 +41,7 @@ extension Dictionary {
   ///
   /// The provided `NSDictionary` will be copied to ensure that the copy can
   /// not be mutated by other code.
-  fileprivate init(_cocoaDictionary: __shared NSDictionary) {
+  private init(_cocoaDictionary: __shared NSDictionary) {
     assert(
       _isBridgedVerbatimToObjectiveC(Key.self) &&
       _isBridgedVerbatimToObjectiveC(Value.self),

--- a/stdlib/public/Darwin/Foundation/NSFastEnumeration.swift
+++ b/stdlib/public/Darwin/Foundation/NSFastEnumeration.swift
@@ -13,9 +13,9 @@
 @_exported import Foundation // Clang module
 
 /// A dummy value to be used as the target for `mutationsPtr` in fast enumeration implementations.
-fileprivate var _fastEnumerationMutationsTarget: CUnsignedLong = 0
+private var _fastEnumerationMutationsTarget: CUnsignedLong = 0
 /// A dummy pointer to be used as `mutationsPtr` in fast enumeration implementations.
-fileprivate let _fastEnumerationMutationsPtr = UnsafeMutablePointer<CUnsignedLong>(&_fastEnumerationMutationsTarget)
+private let _fastEnumerationMutationsPtr = UnsafeMutablePointer<CUnsignedLong>(&_fastEnumerationMutationsTarget)
 
 //===----------------------------------------------------------------------===//
 // Fast enumeration

--- a/stdlib/public/Darwin/Foundation/NSObject.swift
+++ b/stdlib/public/Darwin/Foundation/NSObject.swift
@@ -36,7 +36,7 @@ public protocol NSKeyValueObservingCustomization : NSObjectProtocol {
     static func automaticallyNotifiesObservers(for key: AnyKeyPath) -> Bool
 }
 
-fileprivate extension NSObject {
+private extension NSObject {
     
     @objc class func __old_unswizzled_automaticallyNotifiesObservers(forKey key: String?) -> Bool {
         fatalError("Should never be reached")
@@ -113,7 +113,7 @@ fileprivate extension NSObject {
     /// Temporarily maps a `String` to an `AnyKeyPath` that can be retrieved with `_bridgeKeyPath(_:)`.
     ///
     /// This uses a per-thread storage so key paths on other threads don't interfere.
-    @nonobjc fileprivate static func _withBridgeableKeyPath(from keyPathString: String, to keyPath: AnyKeyPath, block: () -> Void) {
+    @nonobjc static func _withBridgeableKeyPath(from keyPathString: String, to keyPath: AnyKeyPath, block: () -> Void) {
         _ = __KVOKeyPathBridgeMachinery.swizzler
         let key = BridgeKey(keyPathString)
         let oldValue = Thread.current.threadDictionary[key]
@@ -122,7 +122,7 @@ fileprivate extension NSObject {
         block()
     }
     
-    @nonobjc fileprivate static func _bridgeKeyPath(_ keyPath:String?) -> AnyKeyPath? {
+    @nonobjc static func _bridgeKeyPath(_ keyPath:String?) -> AnyKeyPath? {
         guard let keyPath = keyPath else { return nil }
         return Thread.current.threadDictionary[BridgeKey(keyPath)] as? AnyKeyPath
     }

--- a/stdlib/public/Darwin/Foundation/NSSet.swift
+++ b/stdlib/public/Darwin/Foundation/NSSet.swift
@@ -17,7 +17,7 @@ extension Set {
   ///
   /// The provided `NSSet` will be copied to ensure that the copy can
   /// not be mutated by other code.
-  fileprivate init(_cocoaSet: __shared NSSet) {
+  private init(_cocoaSet: __shared NSSet) {
     assert(_isBridgedVerbatimToObjectiveC(Element.self),
       "Set can be backed by NSSet _variantStorage only when the member type can be bridged verbatim to Objective-C")
     // FIXME: We would like to call CFSetCreateCopy() to avoid doing an

--- a/stdlib/public/Darwin/Foundation/PersonNameComponents.swift
+++ b/stdlib/public/Darwin/Foundation/PersonNameComponents.swift
@@ -21,7 +21,7 @@ public struct PersonNameComponents : ReferenceConvertible, Hashable, Equatable, 
         _handle = _MutableHandle(adoptingReference: NSPersonNameComponents())
     }
     
-    fileprivate init(reference: __shared NSPersonNameComponents) {
+    private init(reference: __shared NSPersonNameComponents) {
         _handle = _MutableHandle(reference: reference)
     }
 

--- a/stdlib/public/Darwin/Foundation/TimeZone.swift
+++ b/stdlib/public/Darwin/Foundation/TimeZone.swift
@@ -25,7 +25,7 @@ import _SwiftFoundationOverlayShims
 public struct TimeZone : Hashable, Equatable, ReferenceConvertible {
     public typealias ReferenceType = NSTimeZone
     
-    fileprivate var _wrapped : NSTimeZone
+    private var _wrapped : NSTimeZone
     private var _autoupdating : Bool
     
     /// The time zone currently used by the system.
@@ -92,7 +92,7 @@ public struct TimeZone : Hashable, Equatable, ReferenceConvertible {
         }
     }
     
-    fileprivate init(reference: NSTimeZone) {
+    private init(reference: NSTimeZone) {
         if __NSTimeZoneIsAutoupdating(reference) {
             // we can't copy this or we lose its auto-ness (27048257)
             // fortunately it's immutable

--- a/stdlib/public/Darwin/Foundation/URL.swift
+++ b/stdlib/public/Darwin/Foundation/URL.swift
@@ -528,7 +528,7 @@ public struct URLResourceValues {
 */
 public struct URL : ReferenceConvertible, Equatable {
     public typealias ReferenceType = NSURL
-    fileprivate var _url : NSURL
+    private var _url: NSURL
     
     public typealias BookmarkResolutionOptions = NSURL.BookmarkResolutionOptions
     public typealias BookmarkCreationOptions = NSURL.BookmarkCreationOptions
@@ -1135,11 +1135,11 @@ public struct URL : ReferenceConvertible, Equatable {
         }
     }
     
-    fileprivate init(reference: __shared NSURL) {
+    private init(reference: __shared NSURL) {
         _url = URL._converted(from: reference).copy() as! NSURL
     }
     
-    private var reference : NSURL {
+    private var reference: NSURL {
         return _url
     }
 

--- a/stdlib/public/Darwin/Foundation/URLRequest.swift
+++ b/stdlib/public/Darwin/Foundation/URLRequest.swift
@@ -41,7 +41,7 @@ public struct URLRequest : ReferenceConvertible, Equatable, Hashable {
         _handle = _MutableHandle(adoptingReference: NSMutableURLRequest(url: url, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval))
     }
 
-    fileprivate init(_bridged request: __shared NSURLRequest) {
+    private init(_bridged request: __shared NSURLRequest) {
         _handle = _MutableHandle(reference: request.mutableCopy() as! NSMutableURLRequest)
     }
     

--- a/stdlib/public/Darwin/Foundation/UUID.swift
+++ b/stdlib/public/Darwin/Foundation/UUID.swift
@@ -30,7 +30,7 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
         }
     }
     
-    fileprivate init(reference: __shared NSUUID) {
+    private init(reference: __shared NSUUID) {
         var bytes: uuid_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
         withUnsafeMutablePointer(to: &bytes) {
             $0.withMemoryRebound(to: UInt8.self, capacity: 16) {
@@ -90,7 +90,7 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
     
     // MARK: - Bridging Support
     
-    fileprivate var reference: NSUUID {
+    private var reference: NSUUID {
         return withUnsafePointer(to: uuid) {
             $0.withMemoryRebound(to: UInt8.self, capacity: 16) {
                 return NSUUID(uuidBytes: $0)

--- a/stdlib/public/core/Diffing.swift
+++ b/stdlib/public/core/Diffing.swift
@@ -179,11 +179,14 @@ extension BidirectionalCollection where Element: Equatable {
 
 // MARK: Internal implementation
 
-// _V is a rudimentary type made to represent the rows of the triangular matrix type used by the Myer's algorithm
+// _V is a rudimentary type made to represent the rows of the triangular matrix
+// type used by the Myer's algorithm.
 //
-// This type is basically an array that only supports indexes in the set `stride(from: -d, through: d, by: 2)` where `d` is the depth of this row in the matrix
-// `d` is always known at allocation-time, and is used to preallocate the structure.
-fileprivate struct _V {
+// This type is basically an array that only supports indexes in the set
+// `stride(from: -d, through: d, by: 2)` where `d` is the depth of this row in
+// the matrix `d` is always known at allocation-time, and is used to preallocate
+// the structure.
+private struct _V {
 
   private var a: [Int]
 #if INTERNAL_CHECKS_ENABLED
@@ -222,7 +225,7 @@ fileprivate struct _V {
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-fileprivate func _myers<C,D>(
+private func _myers<C,D>(
   from old: C, to new: D,
   using cmp: (C.Element, D.Element) -> Bool
 ) -> CollectionDifference<C.Element>


### PR DESCRIPTION
<!-- What's in this pull request? -->
It was declared in SE-0025 that our goal was for `fileprivate` to be used rarely. A number of rules were adopted to help promote this goal:

* At the top level of a file, `private` is equivalent to `fileprivate`.
* Inside any type, the nominal default access level is `internal`, and the compiler does not warn when `private` types have `internal` members. But, the _effective_ visibility of any member is bounded by the visibility of the containing type. Therefore, a `private` type has members with default effective visibility equal to itself.
* [SE-0169](https://github.com/apple/swift-evolution/blob/master/proposals/0169-improve-interaction-between-private-declarations-and-extensions.md) merges all same-file extensions for a type into the same scope.

Although it is said that first-party code is not intended to model ideal usage of the language, users nonetheless study this code and take stylistic cues from it. Therefore, all else being equal, it is useful to demonstrate the intended usage of `private` and `fileprivate` even if we don't call out this code as a model for others.

A manual audit of the standard library and the Foundation overlay reveals ~150 uses of `fileprivate` that can be eliminated without any functional change (all but two of these in Foundation).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
