### PR TITLE
[SR-9839] Fixes ambiguity in convention function argument inference

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2763,14 +2763,21 @@ static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
   if (!diff.overloads.empty())
     return false;
 
-  if (!llvm::all_of(solutions, [](const Solution &solution) -> bool {
+  bool noFixes = llvm::all_of(solutions, [](const Solution &solution) -> bool {
+    return solution.Fixes.empty();
+  });
+
+  bool allMismatches =
+      llvm::all_of(solutions, [](const Solution &solution) -> bool {
         return llvm::all_of(
             solution.Fixes, [](const ConstraintFix *fix) -> bool {
               return fix->getKind() == FixKind::AllowArgumentTypeMismatch ||
                      fix->getKind() == FixKind::AllowFunctionTypeMismatch ||
                      fix->getKind() == FixKind::AllowTupleTypeMismatch;
             });
-      }))
+      });
+
+  if (!noFixes && !allMismatches)
     return false;
 
   auto &DE = cs.getASTContext().Diags;
@@ -2923,6 +2930,11 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
   if (solutions.empty())
     return false;
 
+  SolutionDiff solutionDiff(solutions);
+
+  if (diagnoseConflictingGenericArguments(*this, solutionDiff, solutions))
+    return true;
+  
   if (auto bestScore = solverState->BestScore) {
     solutions.erase(llvm::remove_if(solutions,
                                     [&](const Solution &solution) {
@@ -2937,11 +2949,6 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
         }))
       return false;
   }
-
-  SolutionDiff solutionDiff(solutions);
-
-  if (diagnoseConflictingGenericArguments(*this, solutionDiff, solutions))
-    return true;
 
   if (diagnoseAmbiguityWithEphemeralPointers(*this, solutions))
     return true;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2764,7 +2764,8 @@ static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
     return false;
 
   bool noFixes = llvm::all_of(solutions, [](const Solution &solution) -> bool {
-    return solution.Fixes.empty();
+     const auto score = solution.getFixedScore();
+     return score.Data[SK_Fix] == 0 && solution.Fixes.empty();
   });
 
   bool allMismatches =

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -483,3 +483,24 @@ let closure = { // expected-error {{unable to infer complex closure return type;
   var helper = true
   return helper
 }
+
+// SR-9839
+func SR9839(_ x: @escaping @convention(block) () -> Void) {}
+
+func id<T>(_ x: T) -> T {
+  return x
+}
+
+var qux: () -> Void = {}
+
+SR9839(qux)
+SR9839(id(qux)) // expected-error {{conflicting arguments to generic parameter 'T' ('() -> Void' vs. '@convention(block) () -> Void')}}
+
+func forceUnwrap<T>(_ x: T?) -> T {
+  return x!
+}
+
+var qux1: (() -> Void)? = {}
+
+SR9839(qux1!)
+SR9839(forceUnwrap(qux1))


### PR DESCRIPTION
<!-- What's in this pull request? -->
Resolves the ambiguity issue between @\convention function types where the solver finds two possibilities in this case `() -> Void` and `@convention(block) () -> Void` but couldn't disambiguate them. 
 
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-9839 and SR-9840


cc @xedin @hamishknight 
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
