### PR TITLE
[Diagnostics] Updated diagnostic printing style

### DIFF
--- a/include/swift/AST/DiagnosticConsumer.h
+++ b/include/swift/AST/DiagnosticConsumer.h
@@ -126,6 +126,9 @@ public:
   /// \returns true if an error occurred while finishing-up.
   virtual bool finishProcessing() { return false; }
 
+  /// Flush any in-flight diagnostics.
+  virtual void flush() {}
+
   /// In batch mode, any error causes failure for all primary files, but
   /// anyone consulting .dia files will only see an error for a particular
   /// primary in that primary's serialized diagnostics file. For other

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -705,6 +705,11 @@ namespace swift {
       return state.getShowDiagnosticsAfterFatalError();
     }
 
+    void flushConsumers() {
+      for (auto consumer : Consumers)
+        consumer->flush();
+    }
+
     /// Whether to skip emitting warnings
     void setSuppressWarnings(bool val) { state.setSuppressWarnings(val); }
     bool getSuppressWarnings() const {

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -676,8 +676,8 @@ namespace swift {
     /// Print diagnostic names after their messages
     bool printDiagnosticNames = false;
 
-    /// Use descriptive diagnostic style when available.
-    bool useDescriptiveDiagnostics = false;
+    /// Use educational notes when available.
+    bool useEducationalNotes = false;
 
     /// Path to diagnostic documentation directory.
     std::string diagnosticDocumentationPath = "";
@@ -725,12 +725,8 @@ namespace swift {
       return printDiagnosticNames;
     }
 
-    void setUseDescriptiveDiagnostics(bool val) {
-       useDescriptiveDiagnostics = val;
-    }
-    bool getUseDescriptiveDiagnostics() const {
-      return useDescriptiveDiagnostics;
-    }
+    void setUseEducationalNotes(bool val) { useEducationalNotes = val; }
+    bool getUseEducationalNotes() const { return useEducationalNotes; }
 
     void setDiagnosticDocumentationPath(std::string path) {
       diagnosticDocumentationPath = path;

--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -55,9 +55,13 @@ public:
   // When printing diagnostics, include the diagnostic name at the end
   bool PrintDiagnosticNames = false;
 
-  /// If set to true, produce more descriptive diagnostic output if available.
-  /// Descriptive diagnostic output is not intended to be machine-readable.
-  bool EnableDescriptiveDiagnostics = false;
+  /// If set to true, display educational note content to the user if available.
+  /// Educational notes are documentation which supplement diagnostics.
+  bool EnableEducationalNotes = false;
+
+  // If set to true, use the more descriptive experimental formatting style for
+  // diagnostics.
+  bool EnableExperimentalFormatting = false;
 
   std::string DiagnosticDocumentationPath = "";
 

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -256,6 +256,8 @@ public:
                                SourceLoc();
   }
 
+  std::string getLineString(unsigned BufferID, unsigned LineNumber);
+
   SourceLoc getLocFromExternalSource(StringRef Path, unsigned Line, unsigned Col);
 private:
   const VirtualFile *getVirtualFile(SourceLoc Loc) const;

--- a/include/swift/Frontend/PrintingDiagnosticConsumer.h
+++ b/include/swift/Frontend/PrintingDiagnosticConsumer.h
@@ -47,7 +47,9 @@ public:
 
   virtual bool finishProcessing() override;
 
-  void flush(bool includeTrailingBreak = false);
+  void flush(bool includeTrailingBreak);
+
+  virtual void flush() override { flush(false); }
 
   void forceColors() {
     ForceColors = true;

--- a/include/swift/Frontend/PrintingDiagnosticConsumer.h
+++ b/include/swift/Frontend/PrintingDiagnosticConsumer.h
@@ -60,7 +60,6 @@ public:
 
 private:
   void printDiagnostic(SourceManager &SM, const DiagnosticInfo &Info);
-  void prettyPrintDiagnostic(SourceManager &SM, DiagnosticInfo Info);
 };
   
 }

--- a/include/swift/Frontend/PrintingDiagnosticConsumer.h
+++ b/include/swift/Frontend/PrintingDiagnosticConsumer.h
@@ -47,6 +47,8 @@ public:
 
   virtual bool finishProcessing() override;
 
+  void flush(bool includeTrailingBreak = false);
+
   void forceColors() {
     ForceColors = true;
     llvm::sys::Process::UseANSIEscapeCodes(true);

--- a/include/swift/Frontend/PrintingDiagnosticConsumer.h
+++ b/include/swift/Frontend/PrintingDiagnosticConsumer.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -25,23 +25,34 @@
 #include "llvm/Support/Process.h"
 
 namespace swift {
+class AnnotatedSourceSnippet;
 
 /// Diagnostic consumer that displays diagnostics to standard error.
 class PrintingDiagnosticConsumer : public DiagnosticConsumer {
   llvm::raw_ostream &Stream;
   bool ForceColors = false;
   bool DidErrorOccur = false;
+  bool ExperimentalFormattingEnabled = false;
+  // The current snippet used to display an error/warning/remark and the notes
+  // implicitly associated with it. Uses `std::unique_ptr` so that
+  // `AnnotatedSourceSnippet` can be forward declared.
+  std::unique_ptr<AnnotatedSourceSnippet> currentSnippet;
+
 public:
-  PrintingDiagnosticConsumer(llvm::raw_ostream &stream = llvm::errs()) :
-    Stream(stream) { }
+  PrintingDiagnosticConsumer(llvm::raw_ostream &stream = llvm::errs());
+  ~PrintingDiagnosticConsumer();
 
   virtual void handleDiagnostic(SourceManager &SM,
                                 const DiagnosticInfo &Info) override;
+
+  virtual bool finishProcessing() override;
 
   void forceColors() {
     ForceColors = true;
     llvm::sys::Process::UseANSIEscapeCodes(true);
   }
+
+  void enableExperimentalFormatting() { ExperimentalFormattingEnabled = true; }
 
   bool didErrorOccur() {
     return DidErrorOccur;
@@ -49,6 +60,7 @@ public:
 
 private:
   void printDiagnostic(SourceManager &SM, const DiagnosticInfo &Info);
+  void prettyPrintDiagnostic(SourceManager &SM, DiagnosticInfo Info);
 };
   
 }

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -131,8 +131,12 @@ def enable_cross_import_overlays : Flag<["-"], "enable-cross-import-overlays">,
 def disable_cross_import_overlays : Flag<["-"], "disable-cross-import-overlays">,
   HelpText<"Do not automatically import declared cross-import overlays.">;
 
-def enable_descriptive_diagnostics : Flag<["-"], "enable-descriptive-diagnostics">,
-  HelpText<"Show descriptive diagnostic information, if available.">;
+def enable_educational_notes : Flag<["-"], "enable-educational-notes">,
+  HelpText<"Show educational notes, if available.">;
+  
+def enable_experimental_diagnostic_formatting :
+  Flag<["-"], "enable-experimental-diagnostic-formatting">,
+  HelpText<"Enable experimental diagnostic formatting features.">;
   
 def diagnostic_documentation_path
   : Separate<["-"], "diagnostic-documentation-path">, MetaVarName<"<path>">,

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -984,7 +984,7 @@ void DiagnosticEngine::emitDiagnostic(const Diagnostic &diagnostic) {
     info->ChildDiagnosticInfo = childInfoPtrs;
     
     SmallVector<std::string, 1> educationalNotePaths;
-    if (useDescriptiveDiagnostics) {
+    if (useEducationalNotes) {
       auto associatedNotes = educationalNotes[(uint32_t)diagnostic.getID()];
       while (associatedNotes && *associatedNotes) {
         SmallString<128> notePath(getDiagnosticDocumentationPath());

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -819,8 +819,9 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
   Opts.SuppressWarnings |= Args.hasArg(OPT_suppress_warnings);
   Opts.WarningsAsErrors |= Args.hasArg(OPT_warnings_as_errors);
   Opts.PrintDiagnosticNames |= Args.hasArg(OPT_debug_diagnostic_names);
-  Opts.EnableDescriptiveDiagnostics |=
-      Args.hasArg(OPT_enable_descriptive_diagnostics);
+  Opts.EnableEducationalNotes |= Args.hasArg(OPT_enable_educational_notes);
+  Opts.EnableExperimentalFormatting |=
+      Args.hasArg(OPT_enable_experimental_diagnostic_formatting);
   if (Arg *A = Args.getLastArg(OPT_diagnostic_documentation_path)) {
     Opts.DiagnosticDocumentationPath = A->getValue();
   }

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -353,8 +353,8 @@ void CompilerInstance::setUpDiagnosticOptions() {
   if (Invocation.getDiagnosticOptions().PrintDiagnosticNames) {
     Diagnostics.setPrintDiagnosticNames(true);
   }
-  if (Invocation.getDiagnosticOptions().EnableDescriptiveDiagnostics) {
-    Diagnostics.setUseDescriptiveDiagnostics(true);
+  if (Invocation.getDiagnosticOptions().EnableEducationalNotes) {
+    Diagnostics.setUseEducationalNotes(true);
   }
   Diagnostics.setDiagnosticDocumentationPath(
       Invocation.getDiagnosticOptions().DiagnosticDocumentationPath);

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -194,8 +194,22 @@ namespace {
     bool maybePrintInsertionAfter(int Byte, raw_ostream &Out) {
       for (auto fixIt : FixIts) {
         if ((int)fixIt.EndByte - 1 == Byte) {
-          Out.changeColor(ColoredStream::Colors::GREEN, true);
-          Out << fixIt.Text;
+          Out.changeColor(ColoredStream::Colors::GREEN, /*bold*/ true);
+          for (unsigned i = 0; i < fixIt.Text.size(); ++i) {
+            // Invert text colors for editor placeholders.
+            if (i + 1 < fixIt.Text.size() && fixIt.Text.substr(i, 2) == "<#") {
+              Out.changeColor(ColoredStream::Colors::GREEN, /*bold*/ true,
+                              /*background*/ true);
+              ++i;
+            } else if (i + 1 < fixIt.Text.size() &&
+                       fixIt.Text.substr(i, 2) == "#>") {
+              Out.changeColor(ColoredStream::Colors::GREEN, /*bold*/ true,
+                              /*background*/ false);
+              ++i;
+            } else {
+              Out << fixIt.Text[i];
+            }
+          }
           Out.resetColor();
           return true;
         }

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -85,6 +85,8 @@ namespace {
     size_t preferred_buffer_size() const override { return 0; }
   };
 
+  // MARK: Experimental diagnostic printing.
+
   static void printDiagnosticKind(DiagnosticKind kind, raw_ostream &out) {
     switch (kind) {
     case DiagnosticKind::Error:
@@ -189,9 +191,9 @@ namespace {
     }
 
     // Insert fix-it replacement text at the appropriate point in the line.
-    bool maybePrintInsertionAfter(unsigned Byte, raw_ostream &Out) {
+    bool maybePrintInsertionAfter(int Byte, raw_ostream &Out) {
       for (auto fixIt : FixIts) {
-        if (fixIt.EndByte - 1 == Byte) {
+        if ((int)fixIt.EndByte - 1 == Byte) {
           Out.changeColor(ColoredStream::Colors::GREEN, true);
           Out << fixIt.Text;
           Out.resetColor();
@@ -554,6 +556,7 @@ static void annotateSnippetWithInfo(SourceManager &SM,
   }
 }
 
+// MARK: Main DiagnosticConsumer entrypoint.
 void PrintingDiagnosticConsumer::handleDiagnostic(SourceManager &SM,
                                                   const DiagnosticInfo &Info) {
   if (Info.Kind == DiagnosticKind::Error) {

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -371,12 +371,10 @@ namespace {
     }
 
     unsigned getLineNumberIndent() {
-      unsigned indent = 0;
-      for (auto line : AnnotatedLines) {
-        unsigned digits = floor(1 + log10(line.getLineNumber()));
-        indent = std::max(digits, indent);
-      }
-      return indent;
+      // The lines are already in sorted ascending order, and we render one line
+      // after the last one for context. Use the last line number plus one to
+      // determine the indent.
+      return floor(1 + log10(AnnotatedLines.back().getLineNumber() + 1));
     }
 
     void printNumberedLine(SourceManager &SM, unsigned BufferID,

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -586,14 +586,12 @@ void PrintingDiagnosticConsumer::handleDiagnostic(SourceManager &SM,
     }
   } else {
     printDiagnostic(SM, Info);
-  }
 
-  for (auto path : Info.EducationalNotePaths) {
-    if (auto buffer = SM.getFileSystem()->getBufferForFile(path))
-      Stream << buffer->get()->getBuffer() << "\n";
-  }
+    for (auto path : Info.EducationalNotePaths) {
+      if (auto buffer = SM.getFileSystem()->getBufferForFile(path))
+        Stream << buffer->get()->getBuffer() << "\n";
+    }
 
-  if (!ExperimentalFormattingEnabled) {
     for (auto ChildInfo : Info.ChildDiagnosticInfo) {
       printDiagnostic(SM, *ChildInfo);
     }

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -378,7 +378,9 @@ namespace {
           printDiagnosticKind(msg.Kind, Out);
           Out << " " << msg.Text << "\n";
         } else {
+          Out.changeColor(ColoredStream::Colors::BLUE, /*bold*/true);
           Out << "--> ";
+          Out.resetColor();
           printDiagnosticKind(msg.Kind, Out);
           Out << " " << msg.Text << "\n";
         }

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -242,6 +242,11 @@ namespace {
         if (fixIt.EndByte <= sourceByte)
           mappedByte += fixIt.Text.size();
       }
+      // Tabs are mapped to 2 spaces so they have a known column width.
+      for (unsigned i = 0; i < sourceByte; ++i) {
+        if (LineText[i] == '\t')
+          mappedByte += 1;
+      }
       return mappedByte;
     }
 
@@ -283,7 +288,10 @@ namespace {
       for (unsigned i = 0; i < LineText.size(); ++i) {
         isASCII = isASCII && static_cast<unsigned char>(LineText[i]) <= 127;
         applyStyleForLineByte(i, Out, deleted);
-        Out << LineText[i];
+        if (LineText[i] == '\t')
+          Out << "  ";
+        else
+          Out << LineText[i];
         if (maybePrintInsertionAfter(i, Out)) {
           deleted = false;
         }

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -15,14 +15,17 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
+#include "swift/AST/DiagnosticEngine.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/SourceManager.h"
-#include "swift/AST/DiagnosticEngine.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/Support/FormatAdapters.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
+#include <algorithm>
 
 using namespace swift;
 
@@ -61,24 +64,557 @@ namespace {
       return 0;
     }
   };
+
+  /// A stream which drops all color settings.
+  class NoColorStream : public raw_ostream {
+    raw_ostream &Underlying;
+
+  public:
+    explicit NoColorStream(raw_ostream &underlying) : Underlying(underlying) {}
+    ~NoColorStream() override { flush(); }
+
+    bool has_colors() const override { return false; }
+
+    void write_impl(const char *ptr, size_t size) override {
+      Underlying.write(ptr, size);
+    }
+    uint64_t current_pos() const override {
+      return Underlying.tell() - GetNumBytesInBuffer();
+    }
+
+    size_t preferred_buffer_size() const override { return 0; }
+  };
+
+  static void printDiagnosticKind(DiagnosticKind kind, raw_ostream &out) {
+    switch (kind) {
+    case DiagnosticKind::Error:
+      out.changeColor(ColoredStream::Colors::RED, true);
+      out << "error:";
+      break;
+    case DiagnosticKind::Warning:
+      out.changeColor(ColoredStream::Colors::YELLOW, true);
+      out << "warning:";
+      break;
+    case DiagnosticKind::Note:
+      out.changeColor(ColoredStream::Colors::CYAN, true);
+      out << "note:";
+      break;
+    case DiagnosticKind::Remark:
+      out.changeColor(ColoredStream::Colors::CYAN, true);
+      out << "remark:";
+      break;
+    }
+    out.resetColor();
+  }
+
+  static void printNumberedGutter(unsigned LineNumber,
+                                  unsigned LineNumberIndent, raw_ostream &Out) {
+    Out.changeColor(ColoredStream::Colors::BLUE, true);
+    Out << llvm::formatv(
+        "{0} | ",
+        llvm::fmt_align(LineNumber, llvm::AlignStyle::Right, LineNumberIndent));
+    Out.resetColor();
+  }
+
+  static void printEmptyGutter(unsigned LineNumberIndent, raw_ostream &Out) {
+    Out.changeColor(ColoredStream::Colors::BLUE, true);
+    Out << std::string(LineNumberIndent + 1, ' ') << "| ";
+    Out.resetColor();
+  }
+
+  // Describe a fix-it out-of-line.
+  static void describeFixIt(SourceManager &SM, DiagnosticInfo::FixIt fixIt,
+                            raw_ostream &Out) {
+    if (fixIt.getRange().getByteLength() == 0) {
+      Out << "[insert '" << fixIt.getText() << "']";
+    } else if (fixIt.getText().empty()) {
+      Out << "[remove '" << SM.extractText(fixIt.getRange()) << "']";
+    } else {
+      Out << "[replace '" << SM.extractText(fixIt.getRange()) << "' with '"
+          << fixIt.getText() << "']";
+    }
+  }
+
+  /// Represents a single line of source code annotated with optional messages,
+  /// highlights, and fix-its.
+  class AnnotatedLine {
+    friend class AnnotatedFileExcerpt;
+
+    // A diagnostic message located at a specific byte in the line.
+    struct Message {
+      unsigned Byte;
+      DiagnosticKind Kind;
+      std::string Text;
+    };
+
+    // A half-open byte range which should be highlighted.
+    struct Highlight {
+      unsigned StartByte;
+      unsigned EndByte;
+    };
+
+    // A half-open byte range which should be replaced with the given text.
+    struct FixIt {
+      unsigned StartByte;
+      unsigned EndByte;
+      std::string Text;
+    };
+
+    unsigned LineNumber;
+    std::string LineText;
+    SmallVector<Message, 1> Messages;
+    SmallVector<Highlight, 1> Highlights;
+    SmallVector<FixIt, 1> FixIts;
+
+    // Adjust output color as needed if this byte is part of a fix-it deletion.
+    void applyStyleForLineByte(unsigned Byte, raw_ostream &Out, bool &Deleted) {
+      bool shouldDelete = false;
+
+      for (auto fixIt : FixIts) {
+        if (Byte >= fixIt.StartByte && Byte < fixIt.EndByte)
+          shouldDelete = true;
+      }
+
+      // Only modify deletions when we reach the start or end of
+      // a fix-it. This ensures that so long as the original
+      // SourceLocs pointed to the first byte of a grapheme cluster, we won't
+      // output an ANSI escape sequence in the middle of one.
+      if (shouldDelete != Deleted) {
+        Out.resetColor();
+        if (shouldDelete) {
+          Out.changeColor(ColoredStream::Colors::RED);
+        }
+      }
+      Deleted = shouldDelete;
+    }
+
+    // Insert fix-it replacement text at the appropriate point in the line.
+    bool maybePrintInsertionAfter(unsigned Byte, raw_ostream &Out) {
+      for (auto fixIt : FixIts) {
+        if (fixIt.EndByte - 1 == Byte) {
+          Out.changeColor(ColoredStream::Colors::GREEN, true);
+          Out << fixIt.Text;
+          Out.resetColor();
+          return true;
+        }
+      }
+      return false;
+    }
+
+    // Given a byte number in the original source line, map it to a byte number
+    // in the annotated source line, taking fix-it insertions into account.
+    unsigned mapLineByte(unsigned sourceByte) {
+      unsigned mappedByte = sourceByte;
+      for (auto fixIt : FixIts) {
+        if (fixIt.EndByte <= sourceByte)
+          mappedByte += fixIt.Text.size();
+      }
+      return mappedByte;
+    }
+
+  public:
+    AnnotatedLine(unsigned LineNumber, StringRef LineText)
+        : LineNumber(LineNumber), LineText(LineText) {}
+
+    unsigned getLineNumber() { return LineNumber; }
+
+    void addMessage(Message Message) { Messages.push_back(Message); }
+
+    void addHighlight(Highlight Highlight) { Highlights.push_back(Highlight); }
+
+    void addFixIt(FixIt FixIt) { FixIts.push_back(FixIt); }
+
+    void render(unsigned LineNumberIndent, raw_ostream &Out) {
+      printNumberedGutter(LineNumber, LineNumberIndent, Out);
+
+      // Print the source line byte-by-byte, emitting ANSI escape sequences as
+      // needed to style fix-its, and checking for non-ASCII characters.
+      bool deleted = false;
+      bool isASCII = true;
+      maybePrintInsertionAfter(-1, Out);
+      for (unsigned i = 0; i < LineText.size(); ++i) {
+        isASCII = isASCII && static_cast<unsigned char>(LineText[i]) <= 127;
+        applyStyleForLineByte(i, Out, deleted);
+        Out << LineText[i];
+        if (maybePrintInsertionAfter(i, Out)) {
+          deleted = false;
+        }
+      }
+      maybePrintInsertionAfter(LineText.size(), Out);
+      Out.resetColor();
+      Out << "\n";
+
+      // If the entire line is composed of ASCII characters, we can position '~'
+      // characters in the appropriate columns on the following line to
+      // represent highlights.
+      if (isASCII) {
+        auto highlightLine = std::string(mapLineByte(LineText.size()), ' ');
+        for (auto highlight : Highlights) {
+          for (unsigned i = highlight.StartByte; i < highlight.EndByte; ++i)
+            highlightLine[mapLineByte(i)] = '~';
+        }
+
+        if (!Highlights.empty()) {
+          printEmptyGutter(LineNumberIndent, Out);
+          Out.changeColor(ColoredStream::Colors::BLUE, true);
+          Out << highlightLine << "\n";
+          Out.resetColor();
+        }
+      }
+
+      // Print each message on its own line below the source line. If the source
+      // line is ASCII, we can insert a caret pointing directly to the message
+      // location. If not, use a more generic "-->" indicator.
+      // FIXME: Improve Unicode support so every message can include a direct
+      // location indicator.
+      for (auto msg : Messages) {
+        printEmptyGutter(LineNumberIndent, Out);
+        if (isASCII) {
+          Out << std::string(mapLineByte(msg.Byte), ' ') << "^ ";
+          printDiagnosticKind(msg.Kind, Out);
+          Out << " " << msg.Text << "\n";
+        } else {
+          Out << "--> ";
+          printDiagnosticKind(msg.Kind, Out);
+          Out << " " << msg.Text << "\n";
+        }
+      }
+    }
+  };
+
+  /// Represents an excerpt of a source file which contains one or more
+  /// annotated source lines.
+  class AnnotatedFileExcerpt {
+    SourceManager &SM;
+    unsigned BufferID;
+    /// The primary location of the parent error/warning/remark for this
+    /// diagnostic message. This is printed alongside the file path so it can be
+    /// parsed by editors and other tooling.
+    SourceLoc PrimaryLoc;
+    std::vector<AnnotatedLine> AnnotatedLines;
+
+    /// Return the AnnotatedLine for a given SourceLoc, creating it if it
+    /// doesn't already exist.
+    AnnotatedLine &lineForLoc(SourceLoc Loc) {
+      // FIXME: This call to `getLineAndColumn` is expensive.
+      unsigned lineNo = SM.getLineAndColumn(Loc).first;
+      AnnotatedLine newLine(lineNo, "");
+      auto iter =
+          std::lower_bound(AnnotatedLines.begin(), AnnotatedLines.end(),
+                           newLine, [](AnnotatedLine l1, AnnotatedLine l2) {
+                             return l1.getLineNumber() < l2.getLineNumber();
+                           });
+      if (iter == AnnotatedLines.end() || iter->getLineNumber() != lineNo) {
+        newLine.LineText = SM.getLineString(BufferID, lineNo);
+        return *AnnotatedLines.insert(iter, newLine);
+      } else {
+        return *iter;
+      }
+    }
+
+    unsigned getLineNumberIndent() {
+      unsigned indent = 0;
+      for (auto line : AnnotatedLines) {
+        unsigned digits = floor(1 + log10(line.getLineNumber()));
+        indent = std::max(digits, indent);
+      }
+      return indent;
+    }
+
+    void printNumberedLine(SourceManager &SM, unsigned BufferID,
+                           unsigned LineNumber, unsigned LineNumberIndent,
+                           raw_ostream &Out) {
+      printNumberedGutter(LineNumber, LineNumberIndent, Out);
+      Out << SM.getLineString(BufferID, LineNumber) << "\n";
+    }
+
+    void lineRangesForRange(CharSourceRange Range,
+                            SmallVectorImpl<CharSourceRange> &LineRanges) {
+      // FIXME: The calls to `getLineAndColumn` and `getLocForLineCol` are
+      // expensive.
+      unsigned startLineNo = SM.getLineAndColumn(Range.getStart()).first;
+      unsigned endLineNo = SM.getLineAndColumn(Range.getEnd()).first;
+
+      if (startLineNo == endLineNo) {
+        LineRanges.push_back(Range);
+        return;
+      }
+
+      // Split the range by line.
+      SourceLoc lineEnd = SM.getLocForOffset(
+          BufferID, *SM.resolveOffsetForEndOfLine(BufferID, startLineNo));
+      LineRanges.push_back(CharSourceRange(SM, Range.getStart(), lineEnd));
+
+      for (unsigned intermediateLine = startLineNo + 1;
+           intermediateLine < endLineNo; ++intermediateLine) {
+        SourceLoc lineStart =
+            SM.getLocForLineCol(BufferID, intermediateLine, 1);
+        SourceLoc lineEnd = SM.getLocForOffset(
+            BufferID,
+            *SM.resolveOffsetForEndOfLine(BufferID, intermediateLine));
+        LineRanges.push_back(CharSourceRange(SM, lineStart, lineEnd));
+      }
+
+      SourceLoc lastLineStart = SM.getLocForLineCol(BufferID, endLineNo, 1);
+      LineRanges.push_back(CharSourceRange(SM, lastLineStart, Range.getEnd()));
+    }
+
+    // FIXME: sink into AnnotatedLine
+    unsigned lineByteOffsetForLoc(SourceLoc Loc) {
+      auto line = lineForLoc(Loc);
+      SourceLoc lineStart =
+          SM.getLocForLineCol(BufferID, line.getLineNumber(), 1);
+      return SM.getByteDistance(lineStart, Loc);
+    }
+
+  public:
+    AnnotatedFileExcerpt(SourceManager &SM, unsigned BufferID,
+                         SourceLoc PrimaryLoc)
+        : SM(SM), BufferID(BufferID), PrimaryLoc(PrimaryLoc) {}
+
+    void addMessage(SourceLoc Loc, DiagnosticKind Kind, StringRef Message) {
+      lineForLoc(Loc).addMessage({lineByteOffsetForLoc(Loc), Kind, Message});
+    }
+
+    void addHighlight(CharSourceRange Range) {
+      SmallVector<CharSourceRange, 1> ranges;
+      lineRangesForRange(Range, ranges);
+      for (auto lineRange : ranges)
+        lineForLoc(lineRange.getStart())
+            .addHighlight({lineByteOffsetForLoc(lineRange.getStart()),
+                           lineByteOffsetForLoc(lineRange.getEnd())});
+    }
+
+    void addFixIt(CharSourceRange Range, StringRef Text) {
+      SmallVector<CharSourceRange, 1> ranges;
+      lineRangesForRange(Range, ranges);
+      // The removals are broken down line-by-line, so only add any insertions
+      // to the last replacement.
+      auto last = ranges.pop_back_val();
+      lineForLoc(last.getStart())
+          .addFixIt({lineByteOffsetForLoc(last.getStart()),
+                     lineByteOffsetForLoc(last.getEnd()), Text});
+      for (auto lineRange : ranges)
+        lineForLoc(lineRange.getStart())
+            .addFixIt({lineByteOffsetForLoc(lineRange.getStart()),
+                       lineByteOffsetForLoc(lineRange.getEnd()), ""});
+    }
+
+    void render(raw_ostream &Out) {
+      // Tha maximum number of intermediate lines without annotations to render
+      // between annotated lines before using an ellipsis.
+      static const unsigned maxIntermediateLines = 3;
+
+      assert(!AnnotatedLines.empty() && "File excerpt has no lines");
+      unsigned lineNumberIndent = getLineNumberIndent();
+
+      // Print the file name at the top of each excerpt.
+      auto primaryLineAndColumn = SM.getLineAndColumn(PrimaryLoc);
+      Out.changeColor(ColoredStream::Colors::MAGENTA, /*bold*/ true);
+      Out << SM.getIdentifierForBuffer(BufferID) << ":"
+          << primaryLineAndColumn.first << ":" << primaryLineAndColumn.second
+          << "\n";
+      Out.resetColor();
+
+      // Print one extra line at the top for context.
+      if (AnnotatedLines.front().getLineNumber() > 0)
+        printNumberedLine(SM, BufferID,
+                          AnnotatedLines.front().getLineNumber() - 1,
+                          lineNumberIndent, Out);
+
+      // Render the first annotated line.
+      AnnotatedLines.front().render(lineNumberIndent, Out);
+      unsigned lastLineNumber = AnnotatedLines.front().getLineNumber();
+
+      // Render intermediate lines/ellipsis, followed by the next annotated
+      // line until they have all been output.
+      for (auto line = AnnotatedLines.begin() + 1; line != AnnotatedLines.end();
+           ++line) {
+        unsigned lineNumber = line->getLineNumber();
+        if (lineNumber - lastLineNumber > maxIntermediateLines) {
+          // Use an ellipsis to denote an ommitted part of the file.
+          printNumberedLine(SM, BufferID, lastLineNumber + 1, lineNumberIndent,
+                            Out);
+          Out.changeColor(ColoredStream::Colors::BLUE, true);
+          Out << llvm::formatv("{0}...\n",
+                               llvm::fmt_repeat(" ", lineNumberIndent));
+          Out.resetColor();
+          printNumberedLine(SM, BufferID, lineNumber - 1, lineNumberIndent,
+                            Out);
+        } else {
+          // Print all the intermediate lines.
+          for (unsigned l = lastLineNumber + 1; l < lineNumber; ++l) {
+            printNumberedLine(SM, BufferID, l, lineNumberIndent, Out);
+          }
+        }
+        // Print the annotated line.
+        line->render(lineNumberIndent, Out);
+        lastLineNumber = lineNumber;
+      }
+      // Print one extra line at the bottom for context.
+      printNumberedLine(
+          SM, BufferID,
+          AnnotatedLines[AnnotatedLines.size() - 1].getLineNumber() + 1,
+          lineNumberIndent, Out);
+    }
+  };
 } // end anonymous namespace
+
+namespace swift {
+/// Represents one or more annotated file snippets which together form a
+/// complete diagnostic message.
+class AnnotatedSourceSnippet {
+  SourceManager &SM;
+  std::map<unsigned, AnnotatedFileExcerpt> FileExcerpts;
+  SmallVector<std::pair<DiagnosticKind, std::string>, 1>
+      UnknownLocationMessages;
+
+  AnnotatedFileExcerpt &excerptForLoc(SourceLoc Loc) {
+    unsigned bufID = SM.findBufferContainingLoc(Loc);
+    FileExcerpts.emplace(bufID, AnnotatedFileExcerpt(SM, bufID, Loc));
+    return FileExcerpts.find(bufID)->second;
+  }
+
+public:
+  AnnotatedSourceSnippet(SourceManager &SM) : SM(SM){};
+
+  void addMessage(SourceLoc Loc, DiagnosticKind Kind, StringRef Message) {
+    if (Loc.isInvalid()) {
+      UnknownLocationMessages.push_back({Kind, Message.str()});
+      return;
+    }
+    excerptForLoc(Loc).addMessage(Loc, Kind, Message);
+  }
+
+  void addHighlight(CharSourceRange Range) {
+    if (Range.isInvalid())
+      return;
+    excerptForLoc(Range.getStart()).addHighlight(Range);
+  }
+
+  void addFixIt(CharSourceRange Range, StringRef Text) {
+    if (Range.isInvalid())
+      return;
+    excerptForLoc(Range.getStart()).addFixIt(Range, Text);
+  }
+
+  void render(raw_ostream &Out) {
+    // Print the excerpt for each file.
+    for (auto excerpt : FileExcerpts)
+      excerpt.second.render(Out);
+
+    // Handle messages with invalid locations.
+    if (!UnknownLocationMessages.empty()) {
+      Out.changeColor(ColoredStream::Colors::MAGENTA, /*bold*/ true);
+      Out << "Unknown Location\n";
+      Out.resetColor();
+    }
+    for (auto unknownMessage : UnknownLocationMessages) {
+      printEmptyGutter(2, Out);
+      printDiagnosticKind(unknownMessage.first, Out);
+      Out << " " << unknownMessage.second << "\n";
+    }
+  }
+};
+} // namespace swift
+
+static void annotateSnippetWithInfo(SourceManager &SM,
+                                    const DiagnosticInfo &Info,
+                                    AnnotatedSourceSnippet &Snippet) {
+  llvm::SmallString<256> Text;
+  {
+    llvm::raw_svector_ostream Out(Text);
+    DiagnosticEngine::formatDiagnosticText(Out, Info.FormatString,
+                                           Info.FormatArgs);
+    // For notes, show associated fix-its as part of the message. This is a
+    // better experience when notes offer a choice of fix-its.
+    if (Info.Kind == DiagnosticKind::Note) {
+      for (auto fixIt : Info.FixIts) {
+        Out << " ";
+        describeFixIt(SM, fixIt, Out);
+      }
+    }
+  }
+
+  Snippet.addMessage(Info.Loc, Info.Kind, Text);
+  for (auto range : Info.Ranges) {
+    Snippet.addHighlight(range);
+  }
+
+  // Don't print inline fix-its for notes.
+  if (Info.Kind != DiagnosticKind::Note) {
+    for (auto fixIt : Info.FixIts) {
+      Snippet.addFixIt(fixIt.getRange(), fixIt.getText());
+    }
+  }
+  // Add any explicitly grouped notes to the snippet.
+  for (auto ChildInfo : Info.ChildDiagnosticInfo) {
+    annotateSnippetWithInfo(SM, *ChildInfo, Snippet);
+  }
+}
 
 void PrintingDiagnosticConsumer::handleDiagnostic(SourceManager &SM,
                                                   const DiagnosticInfo &Info) {
+  if (Info.Kind == DiagnosticKind::Error) {
+    DidErrorOccur = true;
+  }
+
   if (Info.IsChildNote)
     return;
 
-  printDiagnostic(SM, Info);
+  if (ExperimentalFormattingEnabled) {
+    if (Info.Kind == DiagnosticKind::Note && currentSnippet) {
+      // If this is a note and we have an in-flight message, add it to that
+      // instead of emitting it separately.
+      annotateSnippetWithInfo(SM, Info, *currentSnippet);
+    } else {
+      // If we encounter a new error/warning/remark, flush any in-flight
+      // snippets.
+      if (currentSnippet) {
+        if (ForceColors) {
+          ColoredStream colorStream{Stream};
+          currentSnippet->render(colorStream);
+          colorStream << "\n\n";
+        } else {
+          NoColorStream noColorStream{Stream};
+          currentSnippet->render(noColorStream);
+          noColorStream << "\n\n";
+        }
+      }
+      currentSnippet = std::make_unique<AnnotatedSourceSnippet>(SM);
+      annotateSnippetWithInfo(SM, Info, *currentSnippet);
+    }
+  } else {
+    printDiagnostic(SM, Info);
+  }
+
   for (auto path : Info.EducationalNotePaths) {
     if (auto buffer = SM.getFileSystem()->getBufferForFile(path))
       Stream << buffer->get()->getBuffer() << "\n";
   }
 
-  for (auto ChildInfo : Info.ChildDiagnosticInfo) {
-    printDiagnostic(SM, *ChildInfo);
+  if (!ExperimentalFormattingEnabled) {
+    for (auto ChildInfo : Info.ChildDiagnosticInfo) {
+      printDiagnostic(SM, *ChildInfo);
+    }
   }
 }
 
+bool PrintingDiagnosticConsumer::finishProcessing() {
+  // If there's an in-flight snippet, flush it.
+  if (currentSnippet) {
+    if (ForceColors) {
+      ColoredStream colorStream{Stream};
+      currentSnippet->render(colorStream);
+    } else {
+      NoColorStream noColorStream{Stream};
+      currentSnippet->render(noColorStream);
+    }
+  }
+  return false;
+}
+
+// MARK: LLVM style diagnostic printing
 void PrintingDiagnosticConsumer::printDiagnostic(SourceManager &SM,
                                                  const DiagnosticInfo &Info) {
 
@@ -99,10 +635,6 @@ void PrintingDiagnosticConsumer::printDiagnostic(SourceManager &SM,
   case DiagnosticKind::Remark:
     SMKind = llvm::SourceMgr::DK_Remark;
     break;
-  }
-
-  if (Info.Kind == DiagnosticKind::Error) {
-    DidErrorOccur = true;
   }
 
   // Translate ranges.
@@ -194,3 +726,28 @@ SourceManager::GetMessage(SourceLoc Loc, llvm::SourceMgr::DiagKind Kind,
                             LineStr, ColRanges, FixIts);
 }
 
+// These must come after the declaration of AnnotatedSourceSnippet due to the
+// `currentSnippet` member.
+PrintingDiagnosticConsumer::PrintingDiagnosticConsumer(
+    llvm::raw_ostream &stream)
+    : Stream(stream) {}
+PrintingDiagnosticConsumer::~PrintingDiagnosticConsumer() = default;
+
+// FIXME: This implementation is inefficient.
+std::string SourceManager::getLineString(unsigned BufferID,
+                                         unsigned LineNumber) {
+  SourceLoc Loc = getLocForLineCol(BufferID, LineNumber, 1);
+  auto CurMB = LLVMSourceMgr.getMemoryBuffer(findBufferContainingLoc(Loc));
+  const char *LineStart = Loc.Value.getPointer();
+  const char *BufStart = CurMB->getBufferStart();
+  while (LineStart != BufStart && LineStart[-1] != '\n' &&
+         LineStart[-1] != '\r')
+    --LineStart;
+
+  // Get the end of the line.
+  const char *LineEnd = Loc.Value.getPointer();
+  const char *BufEnd = CurMB->getBufferEnd();
+  while (LineEnd != BufEnd && LineEnd[0] != '\n' && LineEnd[0] != '\r')
+    ++LineEnd;
+  return std::string(LineStart, LineEnd);
+}

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -513,7 +513,7 @@ namespace {
       Out.resetColor();
 
       // Print one extra line at the top for context.
-      if (AnnotatedLines.front().getLineNumber() > 0)
+      if (AnnotatedLines.front().getLineNumber() > 1)
         printNumberedLine(SM, BufferID,
                           AnnotatedLines.front().getLineNumber() - 1,
                           lineNumberIndent, Out);
@@ -704,7 +704,7 @@ void PrintingDiagnosticConsumer::flush(bool includeTrailingBreak) {
 
 bool PrintingDiagnosticConsumer::finishProcessing() {
   // If there's an in-flight snippet, flush it.
-  flush();
+  flush(false);
   return false;
 }
 
@@ -831,6 +831,9 @@ PrintingDiagnosticConsumer::~PrintingDiagnosticConsumer() = default;
 std::string SourceManager::getLineString(unsigned BufferID,
                                          unsigned LineNumber) {
   SourceLoc Loc = getLocForLineCol(BufferID, LineNumber, 1);
+  if (Loc.isInvalid())
+    return "";
+
   auto CurMB = LLVMSourceMgr.getMemoryBuffer(findBufferContainingLoc(Loc));
   const char *LineStart = Loc.Value.getPointer();
   const char *BufStart = CurMB->getBufferStart();

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -2151,6 +2151,11 @@ int swift::performFrontend(ArrayRef<const char *> Args,
   if (Invocation.getDiagnosticOptions().UseColor)
     PDC.forceColors();
 
+  // Temporarily stage the new diagnostic formatting style behind
+  // -enable-descriptive-diagnostics
+  if (Invocation.getDiagnosticOptions().EnableDescriptiveDiagnostics)
+    PDC.enableExperimentalFormatting();
+
   if (Invocation.getFrontendOptions().DebugTimeCompilation)
     SharedTimer::enableCompilationTimers();
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -2153,7 +2153,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
 
   // Temporarily stage the new diagnostic formatting style behind
   // -enable-descriptive-diagnostics
-  if (Invocation.getDiagnosticOptions().EnableDescriptiveDiagnostics)
+  if (Invocation.getDiagnosticOptions().EnableExperimentalFormatting)
     PDC.enableExperimentalFormatting();
 
   if (Invocation.getFrontendOptions().DebugTimeCompilation)

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -853,6 +853,11 @@ private:
   }
 
   bool executeSwiftSource(llvm::StringRef Line, const ProcessCmdLine &CmdLine) {
+    SWIFT_DEFER {
+      // Always flush diagnostic consumers after executing a line.
+      CI.getDiags().flushConsumers();
+    };
+
     // Parse the current line(s).
     auto InputBuf = llvm::MemoryBuffer::getMemBufferCopy(Line, "<REPL Input>");
     SmallString<8> Name{"REPL_"};

--- a/test/SourceKit/Sema/educational_note_diags.swift
+++ b/test/SourceKit/Sema/educational_note_diags.swift
@@ -1,6 +1,6 @@
 extension (Int, Int) {}
 
-// RUN: %sourcekitd-test -req=sema %s -- -Xfrontend -enable-descriptive-diagnostics -Xfrontend -diagnostic-documentation-path -Xfrontend /educational/notes/path/prefix %s | %FileCheck %s -check-prefix=DESCRIPTIVE
+// RUN: %sourcekitd-test -req=sema %s -- -Xfrontend -enable-educational-notes -Xfrontend -diagnostic-documentation-path -Xfrontend /educational/notes/path/prefix %s | %FileCheck %s -check-prefix=DESCRIPTIVE
 
 // DESCRIPTIVE:      key.description: "non-nominal type
 // DESCRIPTIVE:      key.educational_note_paths: [

--- a/test/diagnostics/educational-notes.swift
+++ b/test/diagnostics/educational-notes.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend -enable-descriptive-diagnostics -diagnostic-documentation-path %S/test-docs/ -typecheck %s 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -enable-educational-notes -diagnostic-documentation-path %S/test-docs/ -typecheck %s 2>&1 | %FileCheck %s
 
 // A diagnostic with no educational notes
 let x = 1 +

--- a/test/diagnostics/pretty-printed-diagnostics.swift
+++ b/test/diagnostics/pretty-printed-diagnostics.swift
@@ -43,6 +43,9 @@ struct B: Decodable {
   let a: Foo
 }
 
+// The line below is indented with tabs, not spaces.
+			foo(b: 1, a: 2)
+
 // Test fallback for non-ASCII characters.
 // CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:35:11
 // CHECK: 34 |
@@ -120,6 +123,13 @@ struct B: Decodable {
 // CHECK: 2 |     init(from decoder: Decoder) throws
 // CHECK:   |     ^ note: protocol requires initializer 'init(from:)' with type 'Decodable'
 // CHECK: 3 | }
+
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:47:14
+// CHECK: 46 | // The line below is indented with tabs, not spaces.
+// CHECK: 47 |       foo(a: 2, b: 1, a: 2)
+// CHECK:    |                 ~~~~  ~~~~
+// CHECK:    |                       ^ error: argument 'a' must precede argument 'b' [remove ', a: 2' and insert 'a: 2, ']
+// CHECK: 48 |
 
 // CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:6:5
 // CHECK: 5 | func foo(a: Int, b: Int) {

--- a/test/diagnostics/pretty-printed-diagnostics.swift
+++ b/test/diagnostics/pretty-printed-diagnostics.swift
@@ -63,7 +63,7 @@ struct B: Decodable {
 // CHECK: 8 |
 // CHECK: 9 | foo(a: 2, b: 1, a: 2)
 // CHECK:   |           ~~~~  ~~~~
-// CHECK:   |                 ^ error: argument 'a' must precede argument 'b'
+// CHECK:   |                 ^ error: argument 'a' must precede argument 'b' [remove ', a: 2' and insert 'a: 2, ']
 // CHECK: 10 |
 
 
@@ -99,7 +99,7 @@ struct B: Decodable {
 // CHECK: 32 |   let x: Int = { 42 }()
 // CHECK:    |                ~~~~~~
 // CHECK:    |                ^ error: function produces expected type 'Int'; did you mean to call it with '()'?
-// CHECK:    |                ^ note: Remove '=' to make 'x' a computed property [remove '= '] [replace 'let' with 'var']
+// CHECK:    |                ^ note: Remove '=' to make 'x' a computed property [remove '= ' and replace 'let' with 'var']
 // CHECK: 33 | }
 
 // CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:37:9

--- a/test/diagnostics/pretty-printed-diagnostics.swift
+++ b/test/diagnostics/pretty-printed-diagnostics.swift
@@ -52,14 +52,14 @@ let 👍👍👍 = {
 }
 
 // Test fallback for non-ASCII characters.
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:11
+// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:11
 // CHECK: [[#LINE-1]] |
 // CHECK: [[#LINE]]   | let abc = "👍
 // CHECK:             | --> error: unterminated string literal
 // CHECK: [[#LINE+1]] |
 
 // Test underlining.
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:3
+// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:3
 // CHECK: [[#LINE-1]] |
 // CHECK: [[#LINE]]   | 1 + 2
 // CHECK:             | ~   ~
@@ -67,7 +67,7 @@ let 👍👍👍 = {
 // CHECK: [[#LINE+1]] |
 
 // Test inline fix-it rendering.
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:11
+// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:11
 // CHECK:  [[#LINE-1]] |
 // CHECK:  [[#LINE]]   | foo(a: 2, b: 1, a: 2)
 // CHECK:              |     ++++++~~~~------
@@ -75,7 +75,7 @@ let 👍👍👍 = {
 // CHECK: [[#LINE+1]]  |
 
 
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:7
+// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:7
 // CHECK: [[#LINE-2]] | struct Foo {
 // CHECK: [[#LINE-1]] |   var x: Int
 // CHECK:             |       ^ note: 'x' previously declared here
@@ -84,7 +84,7 @@ let 👍👍👍 = {
 // CHECK: [[#LINE+1]] | }
 
 // Test out-of-line fix-its on notes.
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:1
+// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:1
 // CHECK: [[#LINE-1]] | }
 // CHECK: [[#LINE]]   | bazz()
 // CHECK:             | ~~~~~~
@@ -95,14 +95,14 @@ let 👍👍👍 = {
 // CHECK: [[#LINE+1]] |
 
 
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:7
+// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:7
 // CHECK: [[#LINE-1]] | extension A {
 // CHECK: [[#LINE]]   |   let x: Int = { 42 }
 // CHECK:             |       ^ error: extensions must not contain stored properties
 // CHECK: [[#LINE+1]] | }
 
 // Test complex out-of-line fix-its.
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:16
+// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:16
 // CHECK: [[#LINE-1]] | extension A {
 // CHECK: [[#LINE]]   |   let x: Int = { 42 }()
 // CHECK:             |                ~~~~~~++
@@ -110,14 +110,14 @@ let 👍👍👍 = {
 // CHECK:             |                ^ note: Remove '=' to make 'x' a computed property [remove '= ' and replace 'let' with 'var']
 // CHECK: [[#LINE+1]] | }
 
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:9
+// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:9
 // CHECK: [[#LINE-1]] |
 // CHECK: [[#LINE]]   | let x = { () -> Result in
 // CHECK:             |          +++++++++++++++++
 // CHECK:             |         ^ error: unable to infer complex closure return type; add explicit type to disambiguate
 // CHECK: [[#LINE+1]] |   let y = 1
 
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:8
+// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:8
 // CHECK: [[#LINE-1]] |
 // CHECK: [[#LINE]]   | struct B: Decodable {
 // CHECK:             |        ^ error: type 'B' does not conform to protocol 'Decodable'
@@ -130,20 +130,20 @@ let 👍👍👍 = {
 // CHECK:   |     ^ note: protocol requires initializer 'init(from:)' with type 'Decodable'
 // CHECK: 3 | }
 
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:14
+// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:14
 // CHECK: [[#LINE-1]] | // The line below is indented with tabs, not spaces.
 // CHECK: [[#LINE]]   |       foo(a: 2, b: 1, a: 2)
 // CHECK:             |           ++++++~~~~------
 // CHECK:             |                       ^ error: argument 'a' must precede argument 'b' [remove ', a: 2' and insert 'a: 2, ']
 // CHECK: [[#LINE+1]] |
 
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:20
+// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:20
 // CHECK: [[#LINE-1]] |
 // CHECK: [[#LINE]]   | let 👍👍👍 = {
 // CHECK:    | --> error: unable to infer complex closure return type; add explicit type to disambiguate [insert ' () -> <#Result#> in ']
 // CHECK: [[#LINE+1]] |   let y = 1
 
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:5
+// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:5
 // CHECK: [[#LINE-1]] | func foo(a: Int, b: Int) {
 // CHECK: [[#LINE]]   |   a + b
 // CHECK:             |   ~   ~
@@ -151,7 +151,7 @@ let 👍👍👍 = {
 // CHECK: [[#LINE+1]] | }
 
 // Test snippet truncation.
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:3
+// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:3
 // CHECK: [[#LINE-1]] | func baz() {
 // CHECK: [[#LINE]]   |   bar(a: "hello, world!")
 // CHECK:             |   ^ error: no exact matches in call to global function 'bar'

--- a/test/diagnostics/pretty-printed-diagnostics.swift
+++ b/test/diagnostics/pretty-printed-diagnostics.swift
@@ -34,6 +34,11 @@ extension A {
 
 let abc = "👍
 
+let x = {
+  let y = 1
+  return y
+}
+
 // Test fallback for non-ASCII characters.
 // CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:35:11
 // CHECK: 34 |
@@ -114,6 +119,11 @@ let abc = "👍
 // CHECK:    |                ^ note: Remove '=' to make 'x' a computed property [remove '= '] [replace 'let' with 'var']
 // CHECK: 33 | }
 
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:37:9
+// CHECK: 36 |
+// CHECK: 37 | let x = { () -> Result in
+// CHECK:    |         ^ error: unable to infer complex closure return type; add explicit type to disambiguate
+// CHECK: 38 |   let y = 1
 
 // CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:6:5
 // CHECK: 5 | func foo(a: Int, b: Int) {

--- a/test/diagnostics/pretty-printed-diagnostics.swift
+++ b/test/diagnostics/pretty-printed-diagnostics.swift
@@ -46,6 +46,11 @@ struct B: Decodable {
 // The line below is indented with tabs, not spaces.
 			foo(b: 1, a: 2)
 
+let 👍👍👍 = {
+  let y = 1
+  return y
+}
+
 // Test fallback for non-ASCII characters.
 // CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:35:11
 // CHECK: 34 |
@@ -65,7 +70,7 @@ struct B: Decodable {
 // CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:9:11
 // CHECK:  8 |
 // CHECK:  9 | foo(a: 2, b: 1, a: 2)
-// CHECK:    |           ~~~~  ~~~~
+// CHECK:    |     ++++++~~~~------
 // CHECK:    |                 ^ error: argument 'a' must precede argument 'b' [remove ', a: 2' and insert 'a: 2, ']
 // CHECK: 10 |
 
@@ -100,7 +105,7 @@ struct B: Decodable {
 // CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:32:16
 // CHECK: 31 | extension A {
 // CHECK: 32 |   let x: Int = { 42 }()
-// CHECK:    |                ~~~~~~
+// CHECK:    |                ~~~~~~++
 // CHECK:    |                ^ error: function produces expected type 'Int'; did you mean to call it with '()'?
 // CHECK:    |                ^ note: Remove '=' to make 'x' a computed property [remove '= ' and replace 'let' with 'var']
 // CHECK: 33 | }
@@ -108,6 +113,7 @@ struct B: Decodable {
 // CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:37:9
 // CHECK: 36 |
 // CHECK: 37 | let x = { () -> Result in
+// CHECK:    |          +++++++++++++++++
 // CHECK:    |         ^ error: unable to infer complex closure return type; add explicit type to disambiguate
 // CHECK: 38 |   let y = 1
 
@@ -127,9 +133,15 @@ struct B: Decodable {
 // CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:47:14
 // CHECK: 46 | // The line below is indented with tabs, not spaces.
 // CHECK: 47 |       foo(a: 2, b: 1, a: 2)
-// CHECK:    |                 ~~~~  ~~~~
+// CHECK:    |           ++++++~~~~------
 // CHECK:    |                       ^ error: argument 'a' must precede argument 'b' [remove ', a: 2' and insert 'a: 2, ']
 // CHECK: 48 |
+
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:49:20
+// CHECK: 48 |
+// CHECK: 49 | let 👍👍👍 = {
+// CHECK:    | --> error: unable to infer complex closure return type; add explicit type to disambiguate [insert ' () -> <#Result#> in ']
+// CHECK: 50 |   let y = 1
 
 // CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:6:5
 // CHECK: 5 | func foo(a: Int, b: Int) {

--- a/test/diagnostics/pretty-printed-diagnostics.swift
+++ b/test/diagnostics/pretty-printed-diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend -enable-descriptive-diagnostics -typecheck %s 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -enable-experimental-diagnostic-formatting -typecheck %s 2>&1 | %FileCheck %s
 
 1 + 2
 

--- a/test/diagnostics/pretty-printed-diagnostics.swift
+++ b/test/diagnostics/pretty-printed-diagnostics.swift
@@ -63,10 +63,10 @@ struct B: Decodable {
 
 // Test inline fix-it rendering.
 // CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:9:11
-// CHECK: 8 |
-// CHECK: 9 | foo(a: 2, b: 1, a: 2)
-// CHECK:   |           ~~~~  ~~~~
-// CHECK:   |                 ^ error: argument 'a' must precede argument 'b' [remove ', a: 2' and insert 'a: 2, ']
+// CHECK:  8 |
+// CHECK:  9 | foo(a: 2, b: 1, a: 2)
+// CHECK:    |           ~~~~  ~~~~
+// CHECK:    |                 ^ error: argument 'a' must precede argument 'b' [remove ', a: 2' and insert 'a: 2, ']
 // CHECK: 10 |
 
 

--- a/test/diagnostics/pretty-printed-diagnostics.swift
+++ b/test/diagnostics/pretty-printed-diagnostics.swift
@@ -1,0 +1,137 @@
+// RUN: not %target-swift-frontend -enable-descriptive-diagnostics -typecheck %s 2>&1 | %FileCheck %s
+
+1 + 2
+
+func foo(a: Int, b: Int) {
+  a + b
+}
+
+foo(b: 1, a: 2)
+
+
+func baz() {
+  bar(a: "hello, world!")
+}
+
+struct Foo: Codable {
+  var x: Int
+  var x: Int
+}
+
+func bar(a: Int) {}
+func bar(a: Float) {}
+
+
+func bazz() throws {
+
+}
+bazz()
+
+struct A {}
+extension A {
+  let x: Int = { 42 }
+}
+
+let abc = "👍
+
+// Test fallback for non-ASCII characters.
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:35:11
+// CHECK: 34 |
+// CHECK: 35 | let abc = "👍
+// CHECK:    | --> error: unterminated string literal
+// CHECK: 36 |
+
+// Test underlining.
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:3:3
+// CHECK: 2 |
+// CHECK: 3 | 1 + 2
+// CHECK:   | ~   ~
+// CHECK:   |   ^ warning: result of operator '+' is unused
+// CHECK: 4 |
+
+// Test inline fix-it rendering.
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:9:11
+// CHECK: 8 |
+// CHECK: 9 | foo(a: 2, b: 1, a: 2)
+// CHECK:   |           ~~~~  ~~~~
+// CHECK:   |                 ^ error: argument 'a' must precede argument 'b'
+// CHECK: 10 |
+
+
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:18:7
+// CHECK: 16 | struct Foo: Codable {
+// CHECK: 17 |   var x: Int
+// CHECK:    |       ^ note: 'x' previously declared here
+// CHECK: 18 |   var x: Int
+// CHECK:    |       ^ error: invalid redeclaration of 'x'
+// CHECK: 19 | }
+
+// Test fallback for invalid locations.
+// CHECK: Unknown Location
+// CHECK:    | error: invalid redeclaration of 'x'
+// CHECK:    | note: 'x' previously declared here
+
+// Test cross-file and decl anchored diagnostics.
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:16:8
+// CHECK: 15 |
+// CHECK: 16 | struct Foo: Codable {
+// CHECK:    |        ^ error: type 'Foo' does not conform to protocol 'Encodable'
+// CHECK: 17 |   var x: Int
+// CHECK: 18 |   var x: Int
+// CHECK:    |       ^ note: cannot automatically synthesize 'Encodable' because
+// CHECK:    |       ^ note: cannot automatically synthesize 'Encodable' because
+// CHECK: 19 | }
+// CHECK: Swift.Encodable:2:10
+// CHECK: 1 | public protocol Encodable {
+// CHECK: 2 |     func encode(to encoder: Encoder) throws
+// CHECK:   |          ^ note: protocol requires function 'encode(to:)' with type 'Encodable'
+// CHECK: 3 | }
+
+// Test out-of-line fix-its on notes.
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:28:1
+// CHECK: 27 | }
+// CHECK: 28 | bazz()
+// CHECK:    | ~~~~~~
+// CHECK:    | ^ error: call can throw but is not marked with 'try'
+// CHECK:    | ^ note: did you mean to use 'try'? [insert 'try ']
+// CHECK:    | ^ note: did you mean to handle error as optional value? [insert 'try? ']
+// CHECK:    | ^ note: did you mean to disable error propagation? [insert 'try! ']
+// CHECK: 29 |
+
+
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:32:7
+// CHECK: 31 | extension A {
+// CHECK: 32 |   let x: Int = { 42 }
+// CHECK:    |       ^ error: extensions must not contain stored properties
+// CHECK: 33 | }
+
+// Test complex out-of-line fix-its.
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:32:16
+// CHECK: 31 | extension A {
+// CHECK: 32 |   let x: Int = { 42 }()
+// CHECK:    |                ~~~~~~
+// CHECK:    |                ^ error: function produces expected type 'Int'; did you mean to call it with '()'?
+// CHECK:    |                ^ note: Remove '=' to make 'x' a computed property [remove '= '] [replace 'let' with 'var']
+// CHECK: 33 | }
+
+
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:6:5
+// CHECK: 5 | func foo(a: Int, b: Int) {
+// CHECK: 6 |   a + b
+// CHECK:   |   ~   ~
+// CHECK:   |     ^ warning: result of operator '+' is unused
+// CHECK: 7 | }
+
+// Test snippet truncation.
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:13:3
+// CHECK: 12 | func baz() {
+// CHECK: 13 |   bar(a: "hello, world!")
+// CHECK:    |   ^ error: no exact matches in call to global function 'bar'
+// CHECK: 14 | }
+// CHECK:   ...
+// CHECK: 20 |
+// CHECK: 21 | func bar(a: Int) {}
+// CHECK:    |      ^ note: candidate expects value of type 'Int' for parameter #1
+// CHECK: 22 | func bar(a: Float) {}
+// CHECK:    |      ^ note: candidate expects value of type 'Float' for parameter #1
+// CHECK: 23 |

--- a/test/diagnostics/pretty-printed-diagnostics.swift
+++ b/test/diagnostics/pretty-printed-diagnostics.swift
@@ -13,7 +13,7 @@ func baz() {
   bar(a: "hello, world!")
 }
 
-struct Foo: Codable {
+struct Foo {
   var x: Int
   var x: Int
 }
@@ -37,6 +37,10 @@ let abc = "👍
 let x = {
   let y = 1
   return y
+}
+
+struct B: Decodable {
+  let a: Foo
 }
 
 // Test fallback for non-ASCII characters.
@@ -64,33 +68,12 @@ let x = {
 
 
 // CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:18:7
-// CHECK: 16 | struct Foo: Codable {
+// CHECK: 16 | struct Foo {
 // CHECK: 17 |   var x: Int
 // CHECK:    |       ^ note: 'x' previously declared here
 // CHECK: 18 |   var x: Int
 // CHECK:    |       ^ error: invalid redeclaration of 'x'
 // CHECK: 19 | }
-
-// Test fallback for invalid locations.
-// CHECK: Unknown Location
-// CHECK:    | error: invalid redeclaration of 'x'
-// CHECK:    | note: 'x' previously declared here
-
-// Test cross-file and decl anchored diagnostics.
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:16:8
-// CHECK: 15 |
-// CHECK: 16 | struct Foo: Codable {
-// CHECK:    |        ^ error: type 'Foo' does not conform to protocol 'Encodable'
-// CHECK: 17 |   var x: Int
-// CHECK: 18 |   var x: Int
-// CHECK:    |       ^ note: cannot automatically synthesize 'Encodable' because
-// CHECK:    |       ^ note: cannot automatically synthesize 'Encodable' because
-// CHECK: 19 | }
-// CHECK: Swift.Encodable:2:10
-// CHECK: 1 | public protocol Encodable {
-// CHECK: 2 |     func encode(to encoder: Encoder) throws
-// CHECK:   |          ^ note: protocol requires function 'encode(to:)' with type 'Encodable'
-// CHECK: 3 | }
 
 // Test out-of-line fix-its on notes.
 // CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:28:1
@@ -124,6 +107,19 @@ let x = {
 // CHECK: 37 | let x = { () -> Result in
 // CHECK:    |         ^ error: unable to infer complex closure return type; add explicit type to disambiguate
 // CHECK: 38 |   let y = 1
+
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:42:8
+// CHECK: 41 |
+// CHECK: 42 | struct B: Decodable {
+// CHECK:    |        ^ error: type 'B' does not conform to protocol 'Decodable'
+// CHECK: 43 |   let a: Foo
+// CHECK:    |       ^ note: cannot automatically synthesize 'Decodable' because 'Foo' does not conform to 'Decodable'
+// CHECK: 44 | }
+// CHECK: Swift.Decodable:2:5
+// CHECK: 1 | public protocol Decodable {
+// CHECK: 2 |     init(from decoder: Decoder) throws
+// CHECK:   |     ^ note: protocol requires initializer 'init(from:)' with type 'Decodable'
+// CHECK: 3 | }
 
 // CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:6:5
 // CHECK: 5 | func foo(a: Int, b: Int) {

--- a/test/diagnostics/pretty-printed-diagnostics.swift
+++ b/test/diagnostics/pretty-printed-diagnostics.swift
@@ -52,114 +52,114 @@ let 👍👍👍 = {
 }
 
 // Test fallback for non-ASCII characters.
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:35:11
-// CHECK: 34 |
-// CHECK: 35 | let abc = "👍
-// CHECK:    | --> error: unterminated string literal
-// CHECK: 36 |
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:11
+// CHECK: [[#LINE-1]] |
+// CHECK: [[#LINE]]   | let abc = "👍
+// CHECK:             | --> error: unterminated string literal
+// CHECK: [[#LINE+1]] |
 
 // Test underlining.
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:3:3
-// CHECK: 2 |
-// CHECK: 3 | 1 + 2
-// CHECK:   | ~   ~
-// CHECK:   |   ^ warning: result of operator '+' is unused
-// CHECK: 4 |
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:3
+// CHECK: [[#LINE-1]] |
+// CHECK: [[#LINE]]   | 1 + 2
+// CHECK:             | ~   ~
+// CHECK:             |   ^ warning: result of operator '+' is unused
+// CHECK: [[#LINE+1]] |
 
 // Test inline fix-it rendering.
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:9:11
-// CHECK:  8 |
-// CHECK:  9 | foo(a: 2, b: 1, a: 2)
-// CHECK:    |     ++++++~~~~------
-// CHECK:    |                 ^ error: argument 'a' must precede argument 'b' [remove ', a: 2' and insert 'a: 2, ']
-// CHECK: 10 |
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:11
+// CHECK:  [[#LINE-1]] |
+// CHECK:  [[#LINE]]   | foo(a: 2, b: 1, a: 2)
+// CHECK:              |     ++++++~~~~------
+// CHECK:              |                 ^ error: argument 'a' must precede argument 'b' [remove ', a: 2' and insert 'a: 2, ']
+// CHECK: [[#LINE+1]]  |
 
 
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:18:7
-// CHECK: 16 | struct Foo {
-// CHECK: 17 |   var x: Int
-// CHECK:    |       ^ note: 'x' previously declared here
-// CHECK: 18 |   var x: Int
-// CHECK:    |       ^ error: invalid redeclaration of 'x'
-// CHECK: 19 | }
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:7
+// CHECK: [[#LINE-2]] | struct Foo {
+// CHECK: [[#LINE-1]] |   var x: Int
+// CHECK:             |       ^ note: 'x' previously declared here
+// CHECK: [[#LINE]]   |   var x: Int
+// CHECK:             |       ^ error: invalid redeclaration of 'x'
+// CHECK: [[#LINE+1]] | }
 
 // Test out-of-line fix-its on notes.
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:28:1
-// CHECK: 27 | }
-// CHECK: 28 | bazz()
-// CHECK:    | ~~~~~~
-// CHECK:    | ^ error: call can throw but is not marked with 'try'
-// CHECK:    | ^ note: did you mean to use 'try'? [insert 'try ']
-// CHECK:    | ^ note: did you mean to handle error as optional value? [insert 'try? ']
-// CHECK:    | ^ note: did you mean to disable error propagation? [insert 'try! ']
-// CHECK: 29 |
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:1
+// CHECK: [[#LINE-1]] | }
+// CHECK: [[#LINE]]   | bazz()
+// CHECK:             | ~~~~~~
+// CHECK:             | ^ error: call can throw but is not marked with 'try'
+// CHECK:             | ^ note: did you mean to use 'try'? [insert 'try ']
+// CHECK:             | ^ note: did you mean to handle error as optional value? [insert 'try? ']
+// CHECK:             | ^ note: did you mean to disable error propagation? [insert 'try! ']
+// CHECK: [[#LINE+1]] |
 
 
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:32:7
-// CHECK: 31 | extension A {
-// CHECK: 32 |   let x: Int = { 42 }
-// CHECK:    |       ^ error: extensions must not contain stored properties
-// CHECK: 33 | }
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:7
+// CHECK: [[#LINE-1]] | extension A {
+// CHECK: [[#LINE]]   |   let x: Int = { 42 }
+// CHECK:             |       ^ error: extensions must not contain stored properties
+// CHECK: [[#LINE+1]] | }
 
 // Test complex out-of-line fix-its.
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:32:16
-// CHECK: 31 | extension A {
-// CHECK: 32 |   let x: Int = { 42 }()
-// CHECK:    |                ~~~~~~++
-// CHECK:    |                ^ error: function produces expected type 'Int'; did you mean to call it with '()'?
-// CHECK:    |                ^ note: Remove '=' to make 'x' a computed property [remove '= ' and replace 'let' with 'var']
-// CHECK: 33 | }
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:16
+// CHECK: [[#LINE-1]] | extension A {
+// CHECK: [[#LINE]]   |   let x: Int = { 42 }()
+// CHECK:             |                ~~~~~~++
+// CHECK:             |                ^ error: function produces expected type 'Int'; did you mean to call it with '()'?
+// CHECK:             |                ^ note: Remove '=' to make 'x' a computed property [remove '= ' and replace 'let' with 'var']
+// CHECK: [[#LINE+1]] | }
 
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:37:9
-// CHECK: 36 |
-// CHECK: 37 | let x = { () -> Result in
-// CHECK:    |          +++++++++++++++++
-// CHECK:    |         ^ error: unable to infer complex closure return type; add explicit type to disambiguate
-// CHECK: 38 |   let y = 1
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:9
+// CHECK: [[#LINE-1]] |
+// CHECK: [[#LINE]]   | let x = { () -> Result in
+// CHECK:             |          +++++++++++++++++
+// CHECK:             |         ^ error: unable to infer complex closure return type; add explicit type to disambiguate
+// CHECK: [[#LINE+1]] |   let y = 1
 
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:42:8
-// CHECK: 41 |
-// CHECK: 42 | struct B: Decodable {
-// CHECK:    |        ^ error: type 'B' does not conform to protocol 'Decodable'
-// CHECK: 43 |   let a: Foo
-// CHECK:    |       ^ note: cannot automatically synthesize 'Decodable' because 'Foo' does not conform to 'Decodable'
-// CHECK: 44 | }
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:8
+// CHECK: [[#LINE-1]] |
+// CHECK: [[#LINE]]   | struct B: Decodable {
+// CHECK:             |        ^ error: type 'B' does not conform to protocol 'Decodable'
+// CHECK: [[#LINE+1]] |   let a: Foo
+// CHECK:             |       ^ note: cannot automatically synthesize 'Decodable' because 'Foo' does not conform to 'Decodable'
+// CHECK: [[#LINE+2]] | }
 // CHECK: Swift.Decodable:2:5
 // CHECK: 1 | public protocol Decodable {
 // CHECK: 2 |     init(from decoder: Decoder) throws
 // CHECK:   |     ^ note: protocol requires initializer 'init(from:)' with type 'Decodable'
 // CHECK: 3 | }
 
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:47:14
-// CHECK: 46 | // The line below is indented with tabs, not spaces.
-// CHECK: 47 |       foo(a: 2, b: 1, a: 2)
-// CHECK:    |           ++++++~~~~------
-// CHECK:    |                       ^ error: argument 'a' must precede argument 'b' [remove ', a: 2' and insert 'a: 2, ']
-// CHECK: 48 |
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:14
+// CHECK: [[#LINE-1]] | // The line below is indented with tabs, not spaces.
+// CHECK: [[#LINE]]   |       foo(a: 2, b: 1, a: 2)
+// CHECK:             |           ++++++~~~~------
+// CHECK:             |                       ^ error: argument 'a' must precede argument 'b' [remove ', a: 2' and insert 'a: 2, ']
+// CHECK: [[#LINE+1]] |
 
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:49:20
-// CHECK: 48 |
-// CHECK: 49 | let 👍👍👍 = {
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:20
+// CHECK: [[#LINE-1]] |
+// CHECK: [[#LINE]]   | let 👍👍👍 = {
 // CHECK:    | --> error: unable to infer complex closure return type; add explicit type to disambiguate [insert ' () -> <#Result#> in ']
-// CHECK: 50 |   let y = 1
+// CHECK: [[#LINE+1]] |   let y = 1
 
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:6:5
-// CHECK: 5 | func foo(a: Int, b: Int) {
-// CHECK: 6 |   a + b
-// CHECK:   |   ~   ~
-// CHECK:   |     ^ warning: result of operator '+' is unused
-// CHECK: 7 | }
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:5
+// CHECK: [[#LINE-1]] | func foo(a: Int, b: Int) {
+// CHECK: [[#LINE]]   |   a + b
+// CHECK:             |   ~   ~
+// CHECK:             |     ^ warning: result of operator '+' is unused
+// CHECK: [[#LINE+1]] | }
 
 // Test snippet truncation.
-// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:13:3
-// CHECK: 12 | func baz() {
-// CHECK: 13 |   bar(a: "hello, world!")
-// CHECK:    |   ^ error: no exact matches in call to global function 'bar'
-// CHECK: 14 | }
+// CHECK: SOURCE_DIR/test/diagnostics/pretty-printed-diagnostics.swift:[[#LINE:]]:3
+// CHECK: [[#LINE-1]] | func baz() {
+// CHECK: [[#LINE]]   |   bar(a: "hello, world!")
+// CHECK:             |   ^ error: no exact matches in call to global function 'bar'
+// CHECK: [[#LINE+1]] | }
 // CHECK:   ...
-// CHECK: 20 |
-// CHECK: 21 | func bar(a: Int) {}
-// CHECK:    |      ^ note: candidate expects value of type 'Int' for parameter #1
-// CHECK: 22 | func bar(a: Float) {}
-// CHECK:    |      ^ note: candidate expects value of type 'Float' for parameter #1
-// CHECK: 23 |
+// CHECK: [[#LINE:]]  |
+// CHECK: [[#LINE+1]] | func bar(a: Int) {}
+// CHECK:             |      ^ note: candidate expects value of type 'Int' for parameter #1
+// CHECK: [[#LINE+2]] | func bar(a: Float) {}
+// CHECK:             |      ^ note: candidate expects value of type 'Float' for parameter #1
+// CHECK: [[#LINE+3]] |


### PR DESCRIPTION
This PR adds a new diag printing style behind the `-enable-experimental-diagnostic-formatting` frontend flag. A few notes:
- This style supports `-no-color-diagnostics`, but mostly just for testing purposes. When this is supported in the driver, I think it would be better just to fallback to the LLVM style if color is unsupported or disabled.
- This relies on a lot of expensive line-breaking SourceManager operations. Perf seems ok so far, but I intend to investigate alternatives before this becomes an officially supported feature.
- Until #28313 lands, enabling this feature will break the verifier.
- I assume vim/emacs can't parse this format out of the box, but I haven't tested it yet.
- I'm not a designer so some of the color/layout decisions here are probably terrible :)

The code/tests aren't the easiest to parse, so here's an example of a program:

```swift
func foo(a: Int, b: Int) {
  a + b
}

foo(b: 1, a: 2)


func baz() {
  bar(a: "hello, world!")
}

struct Foo: Codable {
  var x: Int
  var x: Int
}

func bar(a: Int) {}
func bar(a: Float) {}


func bazz() throws {

}
bazz()

struct A {}
extension A {
  let x: Int = { 42 }
}

let abc = "👍

```
Which produces diags that look like this:

￼
<img width="1150" alt="Owens-MacBook-Pro-3swift-macosx-x86_64 owenvoorhees$ binswift -Xfrontend -enable-experimental-diagnostic-formatting ~Desktop" src="https://user-images.githubusercontent.com/1946221/75123297-0be82f80-565b-11ea-832a-149b2dbac812.png">
<img width="1150" alt="UsersowenvoorheesDesktophello swift241" src="https://user-images.githubusercontent.com/1946221/75123301-11457a00-565b-11ea-9910-42b1b500c1a9.png">

