### PR TITLE
If `-verify` mode saw unexpected diagnostics, print diagnostics from all files.

### DIFF
--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -86,6 +86,16 @@ namespace {
     SourceManager &SM;
     std::vector<llvm::SMDiagnostic> CapturedDiagnostics;
   public:
+    /// Result of verifying a file.
+    struct Result {
+      /// Were there any errors? All of the following are considered errors:
+      /// - Expected diagnostics that were not present
+      /// - Unexpected diagnostics that were present
+      /// - Errors in the definition of expected diagnostics
+      bool HadError;
+      bool HadUnexpectedDiag;
+    };
+
     explicit DiagnosticVerifier(SourceManager &SM) : SM(SM) {}
 
     void addDiagnostic(const llvm::SMDiagnostic &Diag) {
@@ -95,10 +105,12 @@ namespace {
     /// verifyFile - After the file has been processed, check to see if we
     /// got all of the expected diagnostics and check to see if there were any
     /// unexpected ones.
-    bool verifyFile(unsigned BufferID, bool autoApplyFixes);
+    Result verifyFile(unsigned BufferID, bool autoApplyFixes);
 
     /// diagnostics for '<unknown>:0' should be considered as unexpected.
     bool verifyUnknown();
+
+    void printRemainingDiagnostics();
 
     /// If there are any -verify errors (e.g. differences between expectations
     /// and actual diagnostics produced), apply fixits to the original source
@@ -210,8 +222,8 @@ static std::string renderFixits(ArrayRef<llvm::SMFixIt> fixits,
 /// After the file has been processed, check to see if we got all of
 /// the expected diagnostics and check to see if there were any unexpected
 /// ones.
-bool DiagnosticVerifier::verifyFile(unsigned BufferID,
-                                    bool shouldAutoApplyFixes) {
+DiagnosticVerifier::Result
+DiagnosticVerifier::verifyFile(unsigned BufferID, bool shouldAutoApplyFixes) {
   using llvm::SMLoc;
   
   const SourceLoc BufferStartLoc = SM.getLocForBufferStart(BufferID);
@@ -632,15 +644,20 @@ bool DiagnosticVerifier::verifyFile(unsigned BufferID,
   }
   
   // Verify that there are no diagnostics (in MemoryBuffer) left in the list.
-  for (unsigned i = 0, e = CapturedDiagnostics.size(); i != e; ++i) {
-    if (CapturedDiagnostics[i].getFilename() != BufferName)
+  bool HadUnexpectedDiag = false;
+  for (unsigned i = CapturedDiagnostics.size(); i != 0; ) {
+    --i;
+    if (CapturedDiagnostics[i].getFilename() != BufferName) {
       continue;
+    }
 
+    HadUnexpectedDiag = true;
     std::string Message =
       "unexpected "+getDiagKindString(CapturedDiagnostics[i].getKind())+
       " produced: "+CapturedDiagnostics[i].getMessage().str();
     addError(CapturedDiagnostics[i].getLoc().getPointer(),
              Message);
+    CapturedDiagnostics.erase(CapturedDiagnostics.begin() + i);
   }
 
   // Sort the diagnostics by their address in the memory buffer as the primary
@@ -659,8 +676,8 @@ bool DiagnosticVerifier::verifyFile(unsigned BufferID,
   // If auto-apply fixits is on, rewrite the original source file.
   if (shouldAutoApplyFixes)
     autoApplyFixes(BufferID, Errors);
-  
-  return !Errors.empty();
+
+  return Result{!Errors.empty(), HadUnexpectedDiag};
 }
 
 bool DiagnosticVerifier::verifyUnknown() {
@@ -679,6 +696,12 @@ bool DiagnosticVerifier::verifyUnknown() {
     SM.getLLVMSourceMgr().PrintMessage(llvm::errs(), diag);
   }
   return HadError;
+}
+
+void DiagnosticVerifier::printRemainingDiagnostics() {
+  for (const auto &diag: CapturedDiagnostics) {
+    SM.getLLVMSourceMgr().PrintMessage(llvm::errs(), diag);
+  }
 }
 
 /// If there are any -verify errors (e.g. differences between expectations
@@ -776,15 +799,26 @@ bool swift::verifyDiagnostics(SourceManager &SM, ArrayRef<unsigned> BufferIDs,
   auto *Verifier = (DiagnosticVerifier*)SM.getLLVMSourceMgr().getDiagContext();
   SM.getLLVMSourceMgr().setDiagHandler(nullptr, nullptr);
   
-  bool HadError = false;
+  DiagnosticVerifier::Result Result = {false, false};
 
-  for (auto &BufferID : BufferIDs)
-    HadError |= Verifier->verifyFile(BufferID, autoApplyFixes);
-  if (!ignoreUnknown)
-    HadError |= Verifier->verifyUnknown();
+  for (auto &BufferID : BufferIDs) {
+    DiagnosticVerifier::Result FileResult =
+        Verifier->verifyFile(BufferID, autoApplyFixes);
+    Result.HadError |= FileResult.HadError;
+    Result.HadUnexpectedDiag |= FileResult.HadUnexpectedDiag;
+  }
+  if (!ignoreUnknown) {
+    bool HadError = Verifier->verifyUnknown();
+    Result.HadError |= HadError;
+    // For <unknown>, all errors are unexpected.
+    Result.HadUnexpectedDiag |= HadError;
+  }
+
+  if (Result.HadUnexpectedDiag)
+    Verifier->printRemainingDiagnostics();
 
   delete Verifier;
 
-  return HadError;
+  return Result.HadError;
 }
 

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -86,6 +86,12 @@ namespace {
     SourceManager &SM;
     std::vector<llvm::SMDiagnostic> CapturedDiagnostics;
   public:
+    explicit DiagnosticVerifier(SourceManager &SM) : SM(SM) {}
+
+    void addDiagnostic(const llvm::SMDiagnostic &Diag) {
+      CapturedDiagnostics.push_back(Diag);
+    }
+
     /// Result of verifying a file.
     struct Result {
       /// Were there any errors? All of the following are considered errors:
@@ -95,12 +101,6 @@ namespace {
       bool HadError;
       bool HadUnexpectedDiag;
     };
-
-    explicit DiagnosticVerifier(SourceManager &SM) : SM(SM) {}
-
-    void addDiagnostic(const llvm::SMDiagnostic &Diag) {
-      CapturedDiagnostics.push_back(Diag);
-    }
 
     /// verifyFile - After the file has been processed, check to see if we
     /// got all of the expected diagnostics and check to see if there were any

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -110,7 +110,7 @@ namespace {
     /// diagnostics for '<unknown>:0' should be considered as unexpected.
     bool verifyUnknown();
 
-    void printRemainingDiagnostics();
+    void printRemainingDiagnostics() const;
 
     /// If there are any -verify errors (e.g. differences between expectations
     /// and actual diagnostics produced), apply fixits to the original source
@@ -698,9 +698,12 @@ bool DiagnosticVerifier::verifyUnknown() {
   return HadError;
 }
 
-void DiagnosticVerifier::printRemainingDiagnostics() {
-  for (const auto &diag: CapturedDiagnostics) {
-    SM.getLLVMSourceMgr().PrintMessage(llvm::errs(), diag);
+void DiagnosticVerifier::printRemainingDiagnostics() const {
+  for (const auto &diag : CapturedDiagnostics) {
+    SM.getLLVMSourceMgr().PrintMessage(
+        llvm::errs(), diag.getLoc(), diag.getKind(),
+        "diagnostic produced by Clang: " + diag.getMessage(),
+        /*Ranges=*/ {}, diag.getFixIts());
   }
 }
 

--- a/test/Frontend/Inputs/broken-c-module/broken_c.h
+++ b/test/Frontend/Inputs/broken-c-module/broken_c.h
@@ -1,3 +1,2 @@
-// This C code intentionally doesn't compile (note missing parenthesis).
-void foo(int bar {
-}
+// This C code intentionally doesn't compile (note missing semicolon).
+void foo()

--- a/test/Frontend/Inputs/broken-c-module/broken_c.h
+++ b/test/Frontend/Inputs/broken-c-module/broken_c.h
@@ -1,0 +1,3 @@
+// This C code intentionally doesn't compile (note missing parenthesis).
+void foo(int bar {
+}

--- a/test/Frontend/Inputs/broken-c-module/module.modulemap
+++ b/test/Frontend/Inputs/broken-c-module/module.modulemap
@@ -1,0 +1,3 @@
+module BrokenCModule {
+  header "broken_c.h"
+}

--- a/test/Frontend/verify-broken-c-module.swift
+++ b/test/Frontend/verify-broken-c-module.swift
@@ -1,0 +1,14 @@
+// Tests that `-verify` mode outputs diagnostics from a failing C module
+// compilation.
+// This needs to be a separate test from verify.swift because compilation will
+// terminate after the failing import statement.
+
+// Turn off "pipefail" mode because we intend the `swift` invocation to
+// terminate with a non-zero exit code, and we don't want the test to fail
+// because of this.
+// RUN: set +o pipefail && %target-typecheck-verify-swift -I %S/Inputs/broken-c-module 2>&1 | %FileCheck %s
+
+// CHECK: [[@LINE+3]]:8: error: unexpected error produced: could not build C module 
+// CHECK: note: in file included from <module-includes>
+// CHECK: broken_c.h:2:18: error: expected ')'
+import BrokenCModule

--- a/test/Frontend/verify-broken-c-module.swift
+++ b/test/Frontend/verify-broken-c-module.swift
@@ -5,7 +5,7 @@
 
 // RUN: not %target-typecheck-verify-swift -I %S/Inputs/broken-c-module 2>&1 | %FileCheck %s
 
-// CHECK: [[@LINE+3]]:8: error: unexpected error produced: could not build C module 
+// CHECK: [[@LINE+3]]:8: error: unexpected error produced: could not build
 // CHECK: note: in file included from <module-includes>
 // CHECK: broken_c.h:2:11: error: expected function body after function declarator
 import BrokenCModule

--- a/test/Frontend/verify-broken-c-module.swift
+++ b/test/Frontend/verify-broken-c-module.swift
@@ -3,12 +3,9 @@
 // This needs to be a separate test from verify.swift because compilation will
 // terminate after the failing import statement.
 
-// Turn off "pipefail" mode because we intend the `swift` invocation to
-// terminate with a non-zero exit code, and we don't want the test to fail
-// because of this.
-// RUN: set +o pipefail && %target-typecheck-verify-swift -I %S/Inputs/broken-c-module 2>&1 | %FileCheck %s
+// RUN: not %target-typecheck-verify-swift -I %S/Inputs/broken-c-module 2>&1 | %FileCheck %s
 
 // CHECK: [[@LINE+3]]:8: error: unexpected error produced: could not build C module 
 // CHECK: note: in file included from <module-includes>
-// CHECK: broken_c.h:2:18: error: expected ')'
+// CHECK: broken_c.h:2:11: error: expected function body after function declarator
 import BrokenCModule

--- a/test/Frontend/verify-broken-c-module.swift
+++ b/test/Frontend/verify-broken-c-module.swift
@@ -6,6 +6,6 @@
 // RUN: not %target-typecheck-verify-swift -I %S/Inputs/broken-c-module 2>&1 | %FileCheck %s
 
 // CHECK: [[@LINE+3]]:8: error: unexpected error produced: could not build
-// CHECK: note: in file included from <module-includes>
-// CHECK: broken_c.h:2:11: error: expected function body after function declarator
+// CHECK: note: diagnostic produced by Clang: in file included from <module-includes>
+// CHECK: broken_c.h:2:11: error: diagnostic produced by Clang: expected function body after function declarator
 import BrokenCModule

--- a/test/Frontend/verify.swift
+++ b/test/Frontend/verify.swift
@@ -1,9 +1,6 @@
 // Tests for the Swift frontends `-verify` mode.
 
-// Turn off "pipefail" mode because we intend the `swift` invocation to
-// terminate with a non-zero exit code, and we don't want the test to fail
-// because of this.
-// RUN: set +o pipefail && %target-typecheck-verify-swift 2>&1 | %FileCheck %s
+// RUN: not %target-typecheck-verify-swift 2>&1 | %FileCheck %s
 
 // CHECK: [[@LINE+1]]:1: error: unexpected error produced: use of unresolved
 undefinedFunc()

--- a/test/Frontend/verify.swift
+++ b/test/Frontend/verify.swift
@@ -1,0 +1,15 @@
+// Tests for the Swift frontends `-verify` mode.
+
+// Turn off "pipefail" mode because we intend the `swift` invocation to
+// terminate with a non-zero exit code, and we don't want the test to fail
+// because of this.
+// RUN: set +o pipefail && %target-typecheck-verify-swift 2>&1 | %FileCheck %s
+
+// CHECK: [[@LINE+1]]:1: error: unexpected error produced: use of unresolved
+undefinedFunc()
+
+// CHECK: [[@LINE+1]]:4: error: expected error not produced
+// expected-error{{This error message never gets output}}
+
+// CHECK: [[@LINE+1]]:20: error: expected {{{{}} in {{expected}}-{{warning}}
+// expected-warning


### PR DESCRIPTION
This PR causes any remaining diagnostics that weren't in the input file to be output if there were unexpected diagnostics in `-verify` mode.

As an example of how this is useful, consider the case where ClangImporter fails with

```
"unexpected` error produced: could not build C module 'some_module'"
```

It would be useful to know what the underlying Clang error was that caused building the module to fail, but so far, `-verify` mode would not output that; to get the error, it would be necessary to run the compiler invocation again without `-verify`.

The PR adds a test that exercises this use case.

I'm also adding some basic tests for the `-verify` functionality generally, which didn't seem to exist.