### PR TITLE
[ClangImporter] NFC: Remove an unnecessary layer of caching

### DIFF
--- a/include/swift/ClangImporter/ClangModule.h
+++ b/include/swift/ClangImporter/ClangModule.h
@@ -35,7 +35,7 @@ class ClangModuleUnit final : public LoadedFile {
   ClangImporter::Implementation &owner;
   const clang::Module *clangModule;
   llvm::PointerIntPair<ModuleDecl *, 1, bool> overlayModule;
-  mutable Optional<ArrayRef<ModuleDecl::ImportedModule>> importedModulesForLookup;
+
   /// The metadata of the underlying Clang module.
   clang::ExternalASTSource::ASTSourceDescriptor ASTSourceDescriptor;
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3449,15 +3449,6 @@ void ClangModuleUnit::getImportedModules(
 void ClangModuleUnit::getImportedModulesForLookup(
     SmallVectorImpl<ModuleDecl::ImportedModule> &imports) const {
 
-  // Reuse our cached list of imports if we have one.
-  if (importedModulesForLookup.hasValue()) {
-    imports.append(importedModulesForLookup->begin(),
-                   importedModulesForLookup->end());
-    return;
-  }
-
-  size_t firstImport = imports.size();
-
   SmallVector<clang::Module *, 8> imported;
   const clang::Module *topLevel;
   ModuleDecl *topLevelOverlay = getOverlayModule();
@@ -3471,10 +3462,8 @@ void ClangModuleUnit::getImportedModulesForLookup(
     topLevel = clangModule->getTopLevelModule();
   }
 
-  if (imported.empty()) {
-    importedModulesForLookup = ArrayRef<ModuleDecl::ImportedModule>();
+  if (imported.empty())
     return;
-  }
 
   SmallPtrSet<clang::Module *, 32> seen{imported.begin(), imported.end()};
   SmallVector<clang::Module *, 8> tmpBuf;
@@ -3520,10 +3509,6 @@ void ClangModuleUnit::getImportedModulesForLookup(
     assert(actualMod && "Missing imported overlay");
     imports.push_back({ModuleDecl::AccessPathTy(), actualMod});
   }
-
-  // Cache our results for use next time.
-  auto importsToCache = llvm::makeArrayRef(imports).slice(firstImport);
-  importedModulesForLookup = getASTContext().AllocateCopy(importsToCache);
 }
 
 void ClangImporter::getMangledName(raw_ostream &os,


### PR DESCRIPTION
The `ImportCache` caches the result from this call, so there's no need to separately cache the imported modules on the `ClangModuleUnit`.
