### PR TITLE
[stdlib] Change _withUnsafeGuaranteedRef to use Builtin.convertUnownedUnsafeToGuaranteed.

### DIFF
--- a/stdlib/public/core/Unmanaged.swift
+++ b/stdlib/public/core/Unmanaged.swift
@@ -206,10 +206,10 @@ public struct Unmanaged<Instance: AnyObject> {
   public func _withUnsafeGuaranteedRef<Result>(
     _ body: (Instance) throws -> Result
   ) rethrows -> Result {
-    let (guaranteedInstance, token) = Builtin.unsafeGuaranteed(_value)
-    let result = try body(guaranteedInstance)
-    Builtin.unsafeGuaranteedEnd(token)
-    return result
+    var tmp = self
+    let fakeBase: Int? = nil
+    return try body(Builtin.convertUnownedUnsafeToGuaranteed(fakeBase,
+                                                             &tmp._value))
   }
 
   /// Performs an unbalanced retain of the object.


### PR DESCRIPTION
This builtin (which lowers to raw SIL that doesn't use an actual builtin
instruction) allows us to access an unmanaged value at +0 with a language
guarantee rather than relying on the optimizer.

Previously, we did not do this directly since without OSSA, we were scared that
the frontend/optimizer would not be able to safely emit this code. Now that we
have ownership ssa, we are able to ensure that the frontend always copies the +0
value passed into the closure if the value +0 escapes from the closure (either
via a return, storing into memory, or by passing off as a +1 parameter to a
function).

rdar://59735604
