### PR TITLE
IRGen: Separate the concept of "metadata should be cached" from "statically referenced"

### DIFF
--- a/lib/IRGen/LocalTypeData.cpp
+++ b/lib/IRGen/LocalTypeData.cpp
@@ -560,7 +560,7 @@ addAbstractForFulfillments(IRGenFunction &IGF, FulfillmentMap &&fulfillments,
       // the type metadata for Int by chasing through N layers of metadata
       // just because that path happens to be in the cache.
       if (!type->hasArchetype() &&
-          isTypeMetadataAccessTrivial(IGF.IGM, type)) {
+          !shouldCacheTypeMetadataAccess(IGF.IGM, type)) {
         continue;
       }
 

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -556,7 +556,7 @@ irgen::tryEmitConstantTypeMetadataRef(IRGenModule &IGM, CanType type,
                                       SymbolReferenceKind refKind) {
   if (IGM.isStandardLibrary())
     return ConstantReference();
-  if (!isTypeMetadataAccessTrivial(IGM, type))
+  if (isCompleteTypeMetadataStaticallyAddressable(IGM, type))
     return ConstantReference();
   return IGM.getAddrOfTypeMetadata(type, refKind);
 }
@@ -722,7 +722,7 @@ bool irgen::isNominalGenericContextTypeMetadataAccessTrivial(
     };
     auto isExistential = [&]() { return argument->isExistentialType(); };
     auto metadataAccessIsTrivial = [&]() {
-      return irgen::isTypeMetadataAccessTrivial(IGM,
+      return irgen::isCompleteTypeMetadataStaticallyAddressable(IGM,
                                                 argument->getCanonicalType());
     };
     return !isGenericWithoutPrespecializedConformance() && !isExistential() && 
@@ -732,9 +732,9 @@ bool irgen::isNominalGenericContextTypeMetadataAccessTrivial(
   && IGM.getTypeInfoForUnlowered(type).isFixedSize(ResilienceExpansion::Maximal);
 }
 
-/// Is it basically trivial to access the given metadata?  If so, we don't
-/// need a cache variable in its accessor.
-bool irgen::isTypeMetadataAccessTrivial(IRGenModule &IGM, CanType type) {
+/// Is complete metadata for the given type available at a fixed address?
+bool irgen::isCompleteTypeMetadataStaticallyAddressable(IRGenModule &IGM,
+                                                        CanType type) {
   assert(!type->hasArchetype());
 
   // Value type metadata only requires dynamic initialization on first
@@ -775,10 +775,6 @@ bool irgen::isTypeMetadataAccessTrivial(IRGenModule &IGM, CanType type) {
   if (isa<SILBoxType>(type))
     return true;
 
-  // DynamicSelfType is actually local.
-  if (type->hasDynamicSelfType())
-    return true;
-
   if (isa<BoundGenericStructType>(type) || isa<BoundGenericEnumType>(type)) {
     auto nominalType = cast<BoundGenericType>(type);
     auto *nominalDecl = nominalType->getDecl();
@@ -792,6 +788,19 @@ bool irgen::isTypeMetadataAccessTrivial(IRGenModule &IGM, CanType type) {
   }
 
   return false;
+}
+
+/// Should requests for the given type's metadata be cached?
+bool irgen::shouldCacheTypeMetadataAccess(IRGenModule &IGM, CanType type) {
+  // DynamicSelfType is actually local.
+  if (type->hasDynamicSelfType())
+    return false;
+
+  // Statically addressable metadata does not need a cache.
+  if (isCompleteTypeMetadataStaticallyAddressable(IGM, type))
+    return false;
+  
+  return true;
 }
 
 /// Return the standard access strategy for getting a non-dependent
@@ -2016,7 +2025,7 @@ emitDirectTypeMetadataAccessFunctionBody(IRGenFunction &IGF,
   }
 
   // We should not be doing more serious work along this path.
-  assert(isTypeMetadataAccessTrivial(IGF.IGM, type));
+  assert(isCompleteTypeMetadataStaticallyAddressable(IGF.IGM, type));
 
   // Okay, everything else is built from a Swift metadata object.
   llvm::Constant *metadata = IGF.IGM.getAddrOfTypeMetadata(type);
@@ -2064,7 +2073,7 @@ irgen::createTypeMetadataAccessFunction(IRGenModule &IGM, CanType type,
 
   // If our preferred access method is to go via an accessor, it means
   // there is some non-trivial computation that needs to be cached.
-  if (isTypeMetadataAccessTrivial(IGM, type)) {
+  if (!shouldCacheTypeMetadataAccess(IGM, type)) {
     cacheStrategy = CacheStrategy::None;
   } else {
     switch (cacheStrategy) {
@@ -2194,7 +2203,7 @@ static bool shouldAccessByMangledName(IRGenModule &IGM, CanType type) {
       // others may require accessors to trigger instantiation.
       //
       // TODO: Also need to count the parent type's generic arguments.
-      if (isTypeMetadataAccessTrivial(IGM, nom)) {
+      if (!shouldCacheTypeMetadataAccess(IGM, nom)) {
         NumAddresses += 1;
       } else {
         NumCalls += 1;
@@ -2545,8 +2554,7 @@ IRGenFunction::emitTypeMetadataRef(CanType type,
   }
   
   if (type->hasArchetype() ||
-      isTypeMetadataAccessTrivial(IGM, type)) {
-    // FIXME: propagate metadata request!
+      !shouldCacheTypeMetadataAccess(IGM, type)) {
     return emitDirectTypeMetadataRef(*this, type, request);
   }
 

--- a/lib/IRGen/MetadataRequest.h
+++ b/lib/IRGen/MetadataRequest.h
@@ -500,9 +500,10 @@ static inline bool isAccessorLazilyGenerated(MetadataAccessStrategy strategy) {
   llvm_unreachable("bad kind");
 }
 
-/// Is it basically trivial to access the given metadata?  If so, we don't
-/// need a cache variable in its accessor.
-bool isTypeMetadataAccessTrivial(IRGenModule &IGM, CanType type);
+/// Is complete metadata for the given type available at a fixed address?
+bool isCompleteTypeMetadataStaticallyAddressable(IRGenModule &IGM, CanType type);
+/// Should requests for the given type's metadata be cached?
+bool shouldCacheTypeMetadataAccess(IRGenModule &IGM, CanType type);
 
 bool isNominalGenericContextTypeMetadataAccessTrivial(IRGenModule &IGM,
                                                       NominalTypeDecl &nominal,

--- a/test/IRGen/dynamic_self_metadata_future.swift
+++ b/test/IRGen/dynamic_self_metadata_future.swift
@@ -57,23 +57,7 @@ class C {
   // CHECK-SAME:     {{.*}} @"$s28dynamic_self_metadata_future1GVyxGAA1PAAMc" 
   // CHECK-SAME:     to %swift.protocol_conformance_descriptor*
   // CHECK-SAME:   ), 
-  // CHECK-SAME:   %swift.type* getelementptr inbounds (
-  // CHECK-SAME:     %swift.full_type, 
-  // CHECK-SAME:     %swift.full_type* bitcast (
-  // CHECK-SAME:       <{ 
-  // CHECK-SAME:         i8**, 
-  // CHECK-SAME:         [[INT]], 
-  // CHECK-SAME:         %swift.type_descriptor*, 
-  // CHECK-SAME:         %swift.type*, 
-  // CHECK-SAME:         i32, 
-  // CHECK-SAME:         {{(\[4 x i8\])?}}, 
-  // CHECK-SAME:         i64 
-  // CHECK-SAME:       }>* @"$s28dynamic_self_metadata_future1GVyAA1CCXDGMf" 
-  // CHECK-SAME:       to %swift.full_type*
-  // CHECK-SAME:     ), 
-  // CHECK-SAME:     i32 0, 
-  // CHECK-SAME:     i32 1
-  // CHECK-SAME:   ), 
+  // CHECK-SAME:   %swift.type* %{{[0-9]+}},
   // CHECK-SAME:   i8*** undef
   // CHECK-SAME: )
 }


### PR DESCRIPTION
Some metadata may require instantiation, but not in a way that requires us to put an additional
cache layer in front of it. `Self` metadata is also trivial to access from the local cache, but
isn't statically referenceable. Split these concepts and update code to use one or the other
appropriately. This catches an issue with metadata prespecialization where it would try to
make records for dynamic `Self` incorrectly.