### PR TITLE
Requestify scoped import validation

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -20,6 +20,7 @@ namespace clang {
 class ASTContext;
 class CompilerInstance;
 class Decl;
+class Module;
 class Preprocessor;
 class Sema;
 class TargetInfo;
@@ -124,6 +125,10 @@ public:
   /// Returns the module that contains imports and declarations from all loaded
   /// Objective-C header files.
   virtual ModuleDecl *getImportedHeaderModule() const = 0;
+
+  /// Retrieves the Swift wrapper for the given Clang module, creating
+  /// it if necessary.
+  virtual ModuleDecl *getWrapperForModule(const clang::Module *mod) const = 0;
 
   /// Adds a new search path to the Clang CompilerInstance, as if specified with
   /// -I or -F.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1527,8 +1527,6 @@ private:
 
   /// The resolved module.
   ModuleDecl *Mod = nullptr;
-  /// The resolved decls if this is a decl import.
-  ArrayRef<ValueDecl *> Decls;
 
   ImportDecl(DeclContext *DC, SourceLoc ImportLoc, ImportKind K,
              SourceLoc KindLoc, ArrayRef<AccessPathElement> Path);
@@ -1581,8 +1579,9 @@ public:
   ModuleDecl *getModule() const { return Mod; }
   void setModule(ModuleDecl *M) { Mod = M; }
 
-  ArrayRef<ValueDecl *> getDecls() const { return Decls; }
-  void setDecls(ArrayRef<ValueDecl *> Ds) { Decls = Ds; }
+  /// For a scoped import such as 'import class Foundation.NSString', retrieve
+  /// the decls it references. Otherwise, returns an empty array.
+  ArrayRef<ValueDecl *> getDecls() const;
 
   const clang::Module *getClangModule() const {
     return getClangNode().getClangModule();

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -355,6 +355,11 @@ public:
     Bits.ModuleDecl.IsNonSwiftModule = flag;
   }
 
+  /// Retrieve the top-level module. If this module is already top-level, this
+  /// returns itself. If this is a submodule such as \c Foo.Bar.Baz, this
+  /// returns the module \c Foo.
+  ModuleDecl *getTopLevelModule();
+
   bool isResilient() const {
     return getResilienceStrategy() != ResilienceStrategy::Default;
   }

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2073,6 +2073,32 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Looks up the decls that a scoped import references, ensuring the import is
+/// valid.
+///
+/// A "scoped import" is an import which only covers one particular
+/// declaration, such as:
+///
+///     import class Foundation.NSString
+///
+class ScopedImportLookupRequest
+    : public SimpleRequest<ScopedImportLookupRequest,
+                           ArrayRef<ValueDecl *>(ImportDecl *),
+                           CacheKind::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  llvm::Expected<ArrayRef<ValueDecl *>> evaluate(Evaluator &evaluator,
+                                                 ImportDecl *import) const;
+
+public:
+  // Cached.
+  bool isCached() const { return true; }
+};
+
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.
 template<>

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -225,3 +225,5 @@ SWIFT_REQUEST(TypeChecker, ValueWitnessRequest,
 SWIFT_REQUEST(TypeChecker, PatternTypeRequest,
               Type(ContextualPattern),
               Cached, HasNearestLocation)
+SWIFT_REQUEST(TypeChecker, ScopedImportLookupRequest,
+              ArrayRef<ValueDecl *>(ImportDecl *), Cached, NoLocationInfo)

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -328,6 +328,10 @@ public:
   /// \sa importHeader
   ModuleDecl *getImportedHeaderModule() const override;
 
+  /// Retrieves the Swift wrapper for the given Clang module, creating
+  /// it if necessary.
+  ModuleDecl *getWrapperForModule(const clang::Module *mod) const override;
+
   std::string getBridgingHeaderContents(StringRef headerPath, off_t &fileSize,
                                         time_t &fileModTime);
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1174,6 +1174,17 @@ ImportDecl::findBestImportKind(ArrayRef<ValueDecl *> Decls) {
   return FirstKind;
 }
 
+ArrayRef<ValueDecl *> ImportDecl::getDecls() const {
+  // If this isn't a scoped import, there's nothing to do.
+  if (getImportKind() == ImportKind::Module)
+    return {};
+
+  auto &ctx = getASTContext();
+  auto *mutableThis = const_cast<ImportDecl *>(this);
+  return evaluateOrDefault(ctx.evaluator,
+                           ScopedImportLookupRequest{mutableThis}, {});
+}
+
 void NominalTypeDecl::setConformanceLoader(LazyMemberLoader *lazyLoader,
                                            uint64_t contextData) {
   assert(!Bits.NominalTypeDecl.HasLazyConformances &&

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1858,6 +1858,10 @@ ModuleDecl *ClangImporter::getImportedHeaderModule() const {
   return Impl.ImportedHeaderUnit->getParentModule();
 }
 
+ModuleDecl *ClangImporter::getWrapperForModule(const clang::Module *mod) const {
+  return Impl.getWrapperForModule(mod)->getParentModule();
+}
+
 PlatformAvailability::PlatformAvailability(LangOptions &langOpts)
     : platformKind(targetPlatform(langOpts)) {
   switch (platformKind) {

--- a/lib/Sema/NameBinding.cpp
+++ b/lib/Sema/NameBinding.cpp
@@ -23,6 +23,7 @@
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/SubstitutionMap.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/Parse/Parser.h"
@@ -66,10 +67,6 @@ namespace {
     /// If \c options includes \c PrivateImport, the filename we should import
     /// private declarations from.
     StringRef privateImportFileName;
-
-    /// The kind of declaration expected for a scoped import, or \c Module if
-    /// the import is not scoped.
-    Located<ImportKind> importKind;
 
     /// The module names being imported. There will usually be just one for the
     /// top-level module, but a submodule import will have more.
@@ -177,25 +174,8 @@ namespace {
     /// The module we bound \c unbound to.
     ModuleDecl *module;
 
-    /// If \c true, another, more specific \c BoundImport will validate the same
-    /// scope as this import, so validating this one is not necessary.
-    bool scopeValidatedElsewhere = true;
-
     BoundImport(UnboundImport unbound, ImportedModuleDesc desc,
-                ModuleDecl *module, bool scopeValidatedElsewhere);
-
-    /// Validate the scope of the import, if needed.
-    ///
-    /// A "scoped import" is an import which only covers one particular
-    /// declaration, such as:
-    ///
-    ///     import class Foundation.NSString
-    ///
-    /// We validate the scope by making sure that the named declaration exists
-    /// and is of the kind indicated by the keyword. This can't be done until we
-    /// have bound all cross-import overlays, since a cross-import overlay could
-    /// provide the declaration.
-    void validateScope(SourceFile &SF);
+                ModuleDecl *module);
   };
 
   class NameBinder final : public DeclVisitor<NameBinder> {
@@ -256,8 +236,7 @@ namespace {
     void bindImport(UnboundImport &&I);
 
     /// Adds \p I and \p M to \c unvalidatedImports and \c visibleModules.
-    void addImport(const UnboundImport &I, ModuleDecl *M,
-                   bool needsScopeValidation);
+    void addImport(const UnboundImport &I, ModuleDecl *M);
 
     /// Adds \p desc and everything it re-exports to \c visibleModules using
     /// the settings from \c desc.
@@ -412,14 +391,13 @@ void NameBinder::bindImport(UnboundImport &&I) {
   I.validateOptions(topLevelModule, SF);
 
   if (topLevelModule && topLevelModule != M) {
-    // If we have distinct submodule and top-level module, add both, disabling
-    // the top-level module's scoped import validation.
-    addImport(I, M, true);
-    addImport(I, topLevelModule.get(), false);
+    // If we have distinct submodule and top-level module, add both.
+    addImport(I, M);
+    addImport(I, topLevelModule.get());
   }
   else {
     // Add only the import itself.
-    addImport(I, M, false);
+    addImport(I, M);
   }
 
   crossImport(M, I);
@@ -428,12 +406,11 @@ void NameBinder::bindImport(UnboundImport &&I) {
     ID.get()->setModule(M);
 }
 
-void NameBinder::addImport(const UnboundImport &I, ModuleDecl *M,
-                           bool scopeValidatedElsewhere) {
+void NameBinder::addImport(const UnboundImport &I, ModuleDecl *M) {
   auto importDesc = I.makeDesc(M);
 
   addVisibleModules(importDesc);
-  unvalidatedImports.emplace_back(I, importDesc, M, scopeValidatedElsewhere);
+  unvalidatedImports.emplace_back(I, importDesc, M);
 }
 
 //===----------------------------------------------------------------------===//
@@ -498,7 +475,6 @@ UnboundImport::getTopLevelModule(ModuleDecl *M, SourceFile &SF) {
 /// Create an UnboundImport for a user-written import declaration.
 UnboundImport::UnboundImport(ImportDecl *ID)
   : importLoc(ID->getLoc()), options(), privateImportFileName(),
-    importKind(ID->getImportKind(), ID->getKindLoc()),
     modulePath(ID->getModulePath()), declPath(ID->getDeclPath()),
     importOrUnderlyingModuleDecl(ID)
 {
@@ -680,15 +656,13 @@ void UnboundImport::diagnoseInvalidAttr(DeclAttrKind attrKind,
 //===----------------------------------------------------------------------===//
 
 BoundImport::BoundImport(UnboundImport unbound, ImportedModuleDesc desc,
-                         ModuleDecl *module, bool scopeValidatedElsewhere)
-  : unbound(unbound), desc(desc), module(module),
-    scopeValidatedElsewhere(scopeValidatedElsewhere) {
+                         ModuleDecl *module)
+  : unbound(unbound), desc(desc), module(module) {
   assert(module && "Can't have an import bound to nothing");
 }
 
 void NameBinder::finishImports(SmallVectorImpl<ImportedModuleDesc> &imports) {
   for (auto &unvalidated : unvalidatedImports) {
-    unvalidated.validateScope(SF);
     imports.push_back(unvalidated.desc);
   }
 }
@@ -759,65 +733,81 @@ static const char *getImportKindString(ImportKind kind) {
   llvm_unreachable("Unhandled ImportKind in switch.");
 }
 
-void BoundImport::validateScope(SourceFile &SF) {
-  if (unbound.importKind.Item == ImportKind::Module || scopeValidatedElsewhere)
-    return;
-
-  ASTContext &ctx = SF.getASTContext();
-
-  // If we're importing a specific decl, validate the import kind.
+llvm::Expected<ArrayRef<ValueDecl *>>
+ScopedImportLookupRequest::evaluate(Evaluator &evaluator,
+                                    ImportDecl *import) const {
   using namespace namelookup;
 
-  // FIXME: Doesn't handle scoped testable imports correctly.
-  assert(unbound.declPath.size() == 1 && "can't handle sub-decl imports");
-  SmallVector<ValueDecl *, 8> decls;
-  lookupInModule(module, unbound.declPath.front().Item, decls,
-                 NLKind::QualifiedLookup, ResolutionKind::Overloadable,
-                 &SF);
+  auto importKind = import->getImportKind();
+  assert(importKind != ImportKind::Module);
 
+  // If we weren't able to load the module referenced by the import, we're done.
+  // The fact that we failed to load the module has already been diagnosed by
+  // name binding.
+  auto *module = import->getModule();
+  if (!module)
+    return ArrayRef<ValueDecl *>();
+
+  /// Validate the scoped import.
+  ///
+  /// We validate the scope by making sure that the named declaration exists
+  /// and is of the kind indicated by the keyword. This can't be done until
+  /// we've performed name binding, since that can introduce additional imports
+  /// (such as cross-import overlays) which could provide the declaration.
+  auto &ctx = module->getASTContext();
+  auto declPath = import->getDeclPath();
+  auto modulePath = import->getModulePath();
+  auto *topLevelModule = module->getTopLevelModule();
+
+  // Lookup the referenced decl in the top-level module. This is necessary as
+  // the Clang importer currently handles submodules by importing their decls
+  // into the top-level module.
+  // FIXME: Doesn't handle scoped testable imports correctly.
+  assert(declPath.size() == 1 && "can't handle sub-decl imports");
+  SmallVector<ValueDecl *, 8> decls;
+  lookupInModule(topLevelModule, declPath.front().Item, decls,
+                 NLKind::QualifiedLookup, ResolutionKind::Overloadable,
+                 import->getDeclContext()->getModuleScopeContext());
+
+  auto importLoc = import->getLoc();
   if (decls.empty()) {
-    ctx.Diags.diagnose(unbound.importLoc, diag::decl_does_not_exist_in_module,
-                       static_cast<unsigned>(unbound.importKind.Item),
-                       unbound.declPath.front().Item,
-                       unbound.modulePath.front().Item)
-      .highlight(SourceRange(unbound.declPath.front().Loc,
-                             unbound.declPath.back().Loc));
-    return;
+    ctx.Diags.diagnose(importLoc, diag::decl_does_not_exist_in_module,
+                       static_cast<unsigned>(importKind), declPath.front().Item,
+                       modulePath.front().Item)
+      .highlight(SourceRange(declPath.front().Loc, declPath.back().Loc));
+    return ArrayRef<ValueDecl *>();
   }
 
   Optional<ImportKind> actualKind = ImportDecl::findBestImportKind(decls);
   if (!actualKind.hasValue()) {
     // FIXME: print entire module name?
-    ctx.Diags.diagnose(unbound.importLoc, diag::ambiguous_decl_in_module,
-                       unbound.declPath.front().Item, module->getName());
+    ctx.Diags.diagnose(importLoc, diag::ambiguous_decl_in_module,
+                       declPath.front().Item, module->getName());
     for (auto next : decls)
       ctx.Diags.diagnose(next, diag::found_candidate);
 
-  } else if (!isCompatibleImportKind(unbound.importKind.Item, *actualKind)) {
+  } else if (!isCompatibleImportKind(importKind, *actualKind)) {
     Optional<InFlightDiagnostic> emittedDiag;
-    if (*actualKind == ImportKind::Type &&
-        isNominalImportKind(unbound.importKind.Item)) {
+    if (*actualKind == ImportKind::Type && isNominalImportKind(importKind)) {
       assert(decls.size() == 1 &&
              "if we start suggesting ImportKind::Type for, e.g., a mix of "
              "structs and classes, we'll need a different message here");
       assert(isa<TypeAliasDecl>(decls.front()) &&
              "ImportKind::Type is only the best choice for a typealias");
       auto *typealias = cast<TypeAliasDecl>(decls.front());
-      emittedDiag.emplace(ctx.Diags.diagnose(unbound.importLoc,
-          diag::imported_decl_is_wrong_kind_typealias,
+      emittedDiag.emplace(ctx.Diags.diagnose(
+          importLoc, diag::imported_decl_is_wrong_kind_typealias,
           typealias->getDescriptiveKind(),
           TypeAliasType::get(typealias, Type(), SubstitutionMap(),
                              typealias->getUnderlyingType()),
-                             getImportKindString(unbound.importKind.Item)));
+          getImportKindString(importKind)));
     } else {
-      emittedDiag.emplace(ctx.Diags.diagnose(unbound.importLoc,
-          diag::imported_decl_is_wrong_kind,
-          unbound.declPath.front().Item,
-          getImportKindString(unbound.importKind.Item),
-          static_cast<unsigned>(*actualKind)));
+      emittedDiag.emplace(ctx.Diags.diagnose(
+          importLoc, diag::imported_decl_is_wrong_kind, declPath.front().Item,
+          getImportKindString(importKind), static_cast<unsigned>(*actualKind)));
     }
 
-    emittedDiag->fixItReplace(SourceRange(unbound.importKind.Loc),
+    emittedDiag->fixItReplace(SourceRange(import->getKindLoc()),
                               getImportKindString(*actualKind));
     emittedDiag->flush();
 
@@ -825,8 +815,7 @@ void BoundImport::validateScope(SourceFile &SF) {
       ctx.Diags.diagnose(decls.front(), diag::decl_declared_here,
                          decls.front()->getFullName());
   }
-
-  unbound.getImportDecl().get()->setDecls(ctx.AllocateCopy(decls));
+  return ctx.AllocateCopy(decls);
 }
 
 //===----------------------------------------------------------------------===//
@@ -847,12 +836,9 @@ UnboundImport::UnboundImport(ASTContext &ctx,
                              const UnboundImport &base, Identifier overlayName,
                              const ImportedModuleDesc &declaringImport,
                              const ImportedModuleDesc &bystandingImport)
-  : importLoc(base.importLoc), options(), privateImportFileName(),
-    importKind({ ImportKind::Module, SourceLoc() }), modulePath(),
+  : importLoc(base.importLoc), options(), privateImportFileName(), modulePath(),
     // If the declaring import was scoped, inherit that scope in the
-    // overlay's import. Note that we do *not* set importKind; this keeps
-    // BoundImport::validateScope() from unnecessarily revalidating the
-    // scope.
+    // overlay's import.
     declPath(declaringImport.module.first),
     importOrUnderlyingModuleDecl(declaringImport.module.second)
 {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1231,6 +1231,10 @@ public:
   
   void visitImportDecl(ImportDecl *ID) {
     TypeChecker::checkDeclAttributes(ID);
+
+    // Force the lookup of decls referenced by a scoped import in case it emits
+    // diagnostics.
+    (void)ID->getDecls();
   }
 
   void visitOperatorDecl(OperatorDecl *OD) {

--- a/test/ClangImporter/MixedSource/submodule.swift
+++ b/test/ClangImporter/MixedSource/submodule.swift
@@ -3,6 +3,10 @@
 @_exported import Mixed
 @_exported import Mixed.Submodule
 
+// SR-12265: Make sure we can perform a scoped import on a submodule in a mixed
+// source target.
+import func Mixed.Submodule.fromSubmodule
+
 func test() {
   topLevel()
   fromSubmodule()

--- a/test/NameBinding/Inputs/ClangModuleWithOverlay/ClangModuleWithOverlay.h
+++ b/test/NameBinding/Inputs/ClangModuleWithOverlay/ClangModuleWithOverlay.h
@@ -1,0 +1,13 @@
+extern void fromUnderlyingClang(void);
+
+struct ClangType {
+  int instanceMember;
+};
+
+extern void ClangTypeImportAsMemberStaticMethod(void)
+    __attribute__((swift_name("ClangType.importAsMemberStaticMethod()")));
+
+extern void ClangTypeImportAsMemberInstanceMethod(struct ClangType *)
+    __attribute__((swift_name("ClangType.importAsMemberInstanceMethod(self:)")));
+
+typedef int ClangTypeInner __attribute__((swift_name("ClangType.Inner")));

--- a/test/NameBinding/Inputs/ClangModuleWithOverlay/module.modulemap
+++ b/test/NameBinding/Inputs/ClangModuleWithOverlay/module.modulemap
@@ -1,0 +1,4 @@
+module ClangModuleWithOverlay {
+  header "ClangModuleWithOverlay.h"
+  export *
+}

--- a/test/NameBinding/Inputs/overlay.swift
+++ b/test/NameBinding/Inputs/overlay.swift
@@ -1,0 +1,3 @@
+@_exported import ClangModuleWithOverlay
+
+public func fromSwiftOverlay() {}

--- a/test/NameBinding/scoped_imports.swift
+++ b/test/NameBinding/scoped_imports.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -enable-objc-interop -emit-module %S/Inputs/overlay.swift -module-name ClangModuleWithOverlay -I %S/Inputs/ClangModuleWithOverlay -o %t
+// RUN: %target-typecheck-verify-swift -I %t -show-diagnostics-after-fatal
+
+// Make sure we can perform a scoped import on the overlay.
+import func ClangModuleWithOverlay.fromSwiftOverlay
+
+// ... as well as the underlying Clang module.
+import func ClangModuleWithOverlay.fromUnderlyingClang
+
+// We do not currently support scoped imports of type members.
+import var ClangModuleWithOverlay.ClangType.instanceMember // expected-error {{no such module 'ClangModuleWithOverlay.ClangType'}}
+import func ClangModuleWithOverlay.ClangType.importAsMemberStaticMethod // expected-error {{no such module 'ClangModuleWithOverlay.ClangType'}}
+import func ClangModuleWithOverlay.ClangType.importAsMemberInstanceMethod // expected-error {{no such module 'ClangModuleWithOverlay.ClangType'}}
+import struct ClangModuleWithOverlay.ClangType.Inner // expected-error {{no such module 'ClangModuleWithOverlay.ClangType'}}
+
+// We currently allow referring to import-as-member decls by their Clang names.
+// FIXME: Should we reject this? We don't appear to translate the access path,
+// so a lookup for e.g ClangType.Inner will still fail (as shown below).
+import func ClangModuleWithOverlay.ClangTypeImportAsMemberStaticMethod
+import func ClangModuleWithOverlay.ClangTypeImportAsMemberInstanceMethod
+import struct ClangModuleWithOverlay.ClangTypeInner
+
+func foo(_ x: ClangType.Inner) {} // expected-error {{use of undeclared type 'ClangType'}}


### PR DESCRIPTION
Move the lookup and validation of scoped imports into a request, and force the request when we're type-checking a primary file. This avoids having to do an additional pass during name binding, and has the nice bonus of no longer running the validation for secondary files.

This PR also adds `ModuleDecl::getTopLevelModule`, and uses it for the lookup of the scoped import rather than attempting to retrieve a module with the same name as the top-level module. This allows us to correctly retrieve the top-level module for a Clang submodule, rather than potentially retrieving the Swift module in a mixed source project.

Resolves SR-12265.