### PR TITLE
[Profiler] Don't crash visiting IfExpr in argument initializer

### DIFF
--- a/lib/SIL/SILProfiler.cpp
+++ b/lib/SIL/SILProfiler.cpp
@@ -1076,10 +1076,14 @@ public:
       pushRegion(E);
     }
 
-    if (auto *IE = dyn_cast<IfExpr>(E)) {
-      CounterExpr &ThenCounter = assignCounter(IE->getThenExpr());
-      assignCounter(IE->getElseExpr(),
-                    CounterExpr::Sub(getCurrentCounter(), ThenCounter));
+    // If there isn't an active region, we may be visiting a default
+    // initializer for a function argument.
+    if (!RegionStack.empty()) {
+      if (auto *IE = dyn_cast<IfExpr>(E)) {
+        CounterExpr &ThenCounter = assignCounter(IE->getThenExpr());
+        assignCounter(IE->getElseExpr(),
+                      CounterExpr::Sub(getCurrentCounter(), ThenCounter));
+      }
     }
 
     if (hasCounter(E) && !Parent.isNull())

--- a/test/Profiler/coverage_arg_ternary.swift
+++ b/test/Profiler/coverage_arg_ternary.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_arg_ternary %s | %FileCheck %s
+
+var s: String?
+
+// CHECK: sil_coverage_map {{.*}} "$s20coverage_arg_ternary1f0B0ySSSg_tF"
+// CHECK-NEXT:  [[@LINE+2]]:43 -> [[@LINE+2]]:45 : 0
+// CHECK-NEXT: }
+func f(arg: String? = s != nil ? s : nil) {}


### PR DESCRIPTION
When visiting an expression in a function argument initializer, there
may not be an active region on the region stack, so don't try to access
it.

rdar://59695604