### PR TITLE
[ConstraintSystem] Look through l-value while checking whether dynami…

### DIFF
--- a/test/Constraints/keypath_dynamic_member_lookup.swift
+++ b/test/Constraints/keypath_dynamic_member_lookup.swift
@@ -484,15 +484,27 @@ func testDynamicMemberWithDefault(_ x: SR_11933) {
   _ = \SR_11933.[]
 }
 
+// SR-11743 - KeyPath Dynamic Member Lookup crash
 @dynamicMemberLookup
-protocol SR_11743 {
+protocol SR_11743_P {
   subscript(dynamicMember member: KeyPath<Self, Any>) -> Any { get }
 }
 
-extension SR_11743 {
+extension SR_11743_P {
   subscript(dynamicMember member: KeyPath<Self, Any>) -> Any {
     self[keyPath: member] // Ok
     // CHECK: function_ref @swift_getAtKeyPath
     // CHECK-NEXT: apply %{{.*}}<Self, Any>({{.*}})
+  }
+}
+
+@dynamicMemberLookup
+struct SR_11743_Struct {
+  let value: Int
+
+  subscript<T>(dynamicMember member: KeyPath<Self, T>) -> T {
+    return self[keyPath: member]
+    // CHECK: function_ref @swift_getAtKeyPath
+    // CHECK-NEXT: apply %{{.*}}<SR_11743_Struct, T>({{.*}})
   }
 }

--- a/test/Constraints/keypath_dynamic_member_lookup.swift
+++ b/test/Constraints/keypath_dynamic_member_lookup.swift
@@ -483,3 +483,16 @@ func testDynamicMemberWithDefault(_ x: SR_11933) {
   // CHECK: [[OUTER_KP:%[0-9]+]] = keypath $KeyPath<SR_11933, Int>, (root $SR_11933; gettable_property $Int,  id @$s29keypath_dynamic_member_lookup8SR_11933V0B6MemberSis7KeyPathCyAA21HasDefaultedSubscriptVSiG_tcig : $@convention(method) (@guaranteed KeyPath<HasDefaultedSubscript, Int>, SR_11933) -> Int, getter @$s29keypath_dynamic_member_lookup8SR_11933V0B6MemberSis7KeyPathCyAA21HasDefaultedSubscriptVSiG_tcipACTK : $@convention(thin) (@in_guaranteed SR_11933, UnsafeRawPointer) -> @out Int, indices [%$0 : $KeyPath<HasDefaultedSubscript, Int> : $KeyPath<HasDefaultedSubscript, Int>], indices_equals @$ss7KeyPathCy29keypath_dynamic_member_lookup21HasDefaultedSubscriptVSiGTH : $@convention(thin) (UnsafeRawPointer, UnsafeRawPointer) -> Bool, indices_hash @$ss7KeyPathCy29keypath_dynamic_member_lookup21HasDefaultedSubscriptVSiGTh : $@convention(thin) (UnsafeRawPointer) -> Int) ([[INNER_KP]])
   _ = \SR_11933.[]
 }
+
+@dynamicMemberLookup
+protocol SR_11743 {
+  subscript(dynamicMember member: KeyPath<Self, Any>) -> Any { get }
+}
+
+extension SR_11743 {
+  subscript(dynamicMember member: KeyPath<Self, Any>) -> Any {
+    self[keyPath: member] // Ok
+    // CHECK: function_ref @swift_getAtKeyPath
+    // CHECK-NEXT: apply %{{.*}}<Self, Any>({{.*}})
+  }
+}


### PR DESCRIPTION
…c key path is recursive

Fix a crash in dynamic member lookup attempting to recursively
lookup a member on the same base type.

The problem is related to `isSelfRecursiveKeyPathDynamicMemberLookup`
which failed to look through l-value wrapping base type on each side of
the comparison, that's important because it's possible to have l-value
mismatch due to the fact that implicit call always gets l-value base
type but actual subscript which triggered dynamic lookup might be r-value.

Resolves: [SR-11743](https://bugs.swift.org/browse/SR-11743)
Resolves: rdar://problem/57091169

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
