### PR TITLE
Front-end: add an option to not lock interface file when building module

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -260,6 +260,9 @@ public:
   /// module interface file?
   bool RemarkOnRebuildFromModuleInterface = false;
 
+  /// Should we lock .swiftinterface while generating .swiftmodule from it?
+  bool DisableInterfaceFileLock = false;
+
   /// The different modes for validating TBD against the LLVM IR.
   enum class TBDValidationMode {
     Default,        ///< Do the default validation for the current platform.

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -134,17 +134,20 @@ class ModuleInterfaceLoader : public SerializedModuleLoaderBase {
       ASTContext &ctx, StringRef cacheDir, StringRef prebuiltCacheDir,
       DependencyTracker *tracker, ModuleLoadingMode loadMode,
       ArrayRef<std::string> PreferInterfaceForModules,
-      bool RemarkOnRebuildFromInterface, bool IgnoreSwiftSourceInfoFile)
+      bool RemarkOnRebuildFromInterface, bool IgnoreSwiftSourceInfoFile,
+      bool DisableInterfaceFileLock)
   : SerializedModuleLoaderBase(ctx, tracker, loadMode,
                                IgnoreSwiftSourceInfoFile),
   CacheDir(cacheDir), PrebuiltCacheDir(prebuiltCacheDir),
   RemarkOnRebuildFromInterface(RemarkOnRebuildFromInterface),
+  DisableInterfaceFileLock(DisableInterfaceFileLock),
   PreferInterfaceForModules(PreferInterfaceForModules)
   {}
 
   std::string CacheDir;
   std::string PrebuiltCacheDir;
   bool RemarkOnRebuildFromInterface;
+  bool DisableInterfaceFileLock;
   ArrayRef<std::string> PreferInterfaceForModules;
 
   std::error_code findModuleFilesInDirectory(
@@ -163,13 +166,15 @@ public:
          DependencyTracker *tracker, ModuleLoadingMode loadMode,
          ArrayRef<std::string> PreferInterfaceForModules = {},
          bool RemarkOnRebuildFromInterface = false,
-         bool IgnoreSwiftSourceInfoFile = false) {
+         bool IgnoreSwiftSourceInfoFile = false,
+         bool DisableInterfaceFileLock = false) {
     return std::unique_ptr<ModuleInterfaceLoader>(
       new ModuleInterfaceLoader(ctx, cacheDir, prebuiltCacheDir,
                                          tracker, loadMode,
                                          PreferInterfaceForModules,
                                          RemarkOnRebuildFromInterface,
-                                         IgnoreSwiftSourceInfoFile));
+                                         IgnoreSwiftSourceInfoFile,
+                                         DisableInterfaceFileLock));
   }
 
   /// Append visible module names to \p names. Note that names are possibly
@@ -187,7 +192,7 @@ public:
     StringRef CacheDir, StringRef PrebuiltCacheDir,
     StringRef ModuleName, StringRef InPath, StringRef OutPath,
     bool SerializeDependencyHashes, bool TrackSystemDependencies,
-    bool RemarkOnRebuildFromInterface);
+    bool RemarkOnRebuildFromInterface, bool DisableInterfaceFileLock);
 };
 
 /// Extract the specified-or-defaulted -module-cache-path that winds up in

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -681,4 +681,6 @@ def enable_type_layouts : Flag<["-"], "enable-type-layout">,
 def disable_type_layouts : Flag<["-"], "disable-type-layout">,
   HelpText<"Disable type layout based lowering">;
 
+def disable_interface_lockfile : Flag<["-"], "disable-interface-lock">,
+  HelpText<"Don't lock interface file when building module">;
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -86,6 +86,8 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.RemarkOnRebuildFromModuleInterface |=
     Args.hasArg(OPT_Rmodule_interface_rebuild);
 
+  Opts.DisableInterfaceFileLock |= Args.hasArg(OPT_disable_interface_lockfile);
+
   computePrintStatsOptions();
   computeDebugTimeOptions();
   computeTBDOptions();

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -433,7 +433,9 @@ bool CompilerInstance::setUpModuleLoaders() {
     auto PIML = ModuleInterfaceLoader::create(
         *Context, ModuleCachePath, PrebuiltModuleCachePath,
         getDependencyTracker(), MLM, FEOpts.PreferInterfaceForModules,
-        FEOpts.RemarkOnRebuildFromModuleInterface, IgnoreSourceInfoFile);
+        FEOpts.RemarkOnRebuildFromModuleInterface,
+        IgnoreSourceInfoFile,
+        FEOpts.DisableInterfaceFileLock);
     Context->addModuleLoader(std::move(PIML));
   }
 

--- a/lib/Frontend/ModuleInterfaceBuilder.h
+++ b/lib/Frontend/ModuleInterfaceBuilder.h
@@ -42,6 +42,7 @@ class ModuleInterfaceBuilder {
   const bool serializeDependencyHashes;
   const bool trackSystemDependencies;
   const bool remarkOnRebuildFromInterface;
+  const bool disableInterfaceFileLock;
   const SourceLoc diagnosticLoc;
   DependencyTracker *const dependencyTracker;
   CompilerInvocation subInvocation;
@@ -82,6 +83,7 @@ public:
                             bool serializeDependencyHashes = false,
                             bool trackSystemDependencies = false,
                             bool remarkOnRebuildFromInterface = false,
+                            bool disableInterfaceFileLock = false,
                             SourceLoc diagnosticLoc = SourceLoc(),
                             DependencyTracker *tracker = nullptr)
     : fs(*sourceMgr.getFileSystem()), diags(diags),
@@ -90,6 +92,7 @@ public:
       serializeDependencyHashes(serializeDependencyHashes),
       trackSystemDependencies(trackSystemDependencies),
       remarkOnRebuildFromInterface(remarkOnRebuildFromInterface),
+      disableInterfaceFileLock(disableInterfaceFileLock),
       diagnosticLoc(diagnosticLoc), dependencyTracker(tracker) {
     configureSubInvocation(searchPathOpts, langOpts, clangImporter);
   }

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -355,11 +355,13 @@ class ModuleInterfaceLoaderImpl {
   DependencyTracker *const dependencyTracker;
   const ModuleLoadingMode loadMode;
   const bool remarkOnRebuildFromInterface;
+  const bool disableInterfaceLock;
 
   ModuleInterfaceLoaderImpl(
     ASTContext &ctx, StringRef modulePath, StringRef interfacePath,
     StringRef moduleName, StringRef cacheDir, StringRef prebuiltCacheDir,
     SourceLoc diagLoc, bool remarkOnRebuildFromInterface,
+    bool disableInterfaceLock,
     DependencyTracker *dependencyTracker = nullptr,
     ModuleLoadingMode loadMode = ModuleLoadingMode::PreferSerialized)
   : ctx(ctx), fs(*ctx.SourceMgr.getFileSystem()), diags(ctx.Diags),
@@ -367,7 +369,8 @@ class ModuleInterfaceLoaderImpl {
     moduleName(moduleName), prebuiltCacheDir(prebuiltCacheDir),
     cacheDir(cacheDir), diagnosticLoc(diagLoc),
     dependencyTracker(dependencyTracker), loadMode(loadMode),
-    remarkOnRebuildFromInterface(remarkOnRebuildFromInterface) {}
+    remarkOnRebuildFromInterface(remarkOnRebuildFromInterface),
+    disableInterfaceLock(disableInterfaceLock) {}
 
   /// Construct a cache key for the .swiftmodule being generated. There is a
   /// balance to be struck here between things that go in the cache key and
@@ -903,7 +906,8 @@ class ModuleInterfaceLoaderImpl {
       ctx.SourceMgr, ctx.Diags, ctx.SearchPathOpts, ctx.LangOpts,
       ctx.getClangModuleLoader(), interfacePath, moduleName, cacheDir,
       prebuiltCacheDir, /*serializeDependencyHashes*/false,
-      trackSystemDependencies, remarkOnRebuildFromInterface, diagnosticLoc,
+      trackSystemDependencies, remarkOnRebuildFromInterface,
+      disableInterfaceLock, diagnosticLoc,
       dependencyTracker);
     auto &subInvocation = builder.getSubInvocation();
 
@@ -1025,7 +1029,8 @@ std::error_code ModuleInterfaceLoader::findModuleFilesInDirectory(
   ModuleInterfaceLoaderImpl Impl(
                 Ctx, ModPath, InPath, ModuleName,
                 CacheDir, PrebuiltCacheDir, ModuleID.Loc,
-                RemarkOnRebuildFromInterface, dependencyTracker,
+                RemarkOnRebuildFromInterface, DisableInterfaceFileLock,
+                dependencyTracker,
                 llvm::is_contained(PreferInterfaceForModules,
                                    ModuleName) ?
                   ModuleLoadingMode::PreferInterface : LoadMode);
@@ -1063,13 +1068,14 @@ bool ModuleInterfaceLoader::buildSwiftModuleFromSwiftInterface(
     StringRef CacheDir, StringRef PrebuiltCacheDir,
     StringRef ModuleName, StringRef InPath, StringRef OutPath,
     bool SerializeDependencyHashes, bool TrackSystemDependencies,
-    bool RemarkOnRebuildFromInterface) {
+    bool RemarkOnRebuildFromInterface, bool DisableInterfaceFileLock) {
   ModuleInterfaceBuilder builder(SourceMgr, Diags, SearchPathOpts, LangOpts,
                                     /*clangImporter*/nullptr, InPath,
                                     ModuleName, CacheDir, PrebuiltCacheDir,
                                     SerializeDependencyHashes,
                                     TrackSystemDependencies,
-                                    RemarkOnRebuildFromInterface);
+                                    RemarkOnRebuildFromInterface,
+                                    DisableInterfaceFileLock);
   // FIXME: We really only want to serialize 'important' dependencies here, if
   //        we want to ship the built swiftmodules to another machine.
   return builder.buildSwiftModule(OutPath, /*shouldSerializeDeps*/true,

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -778,7 +778,8 @@ static bool buildModuleFromInterface(const CompilerInvocation &Invocation,
       PrebuiltCachePath, Invocation.getModuleName(), InputPath,
       Invocation.getOutputFilename(),
       FEOpts.SerializeModuleInterfaceDependencyHashes,
-      FEOpts.TrackSystemDeps, FEOpts.RemarkOnRebuildFromModuleInterface);
+      FEOpts.TrackSystemDeps, FEOpts.RemarkOnRebuildFromModuleInterface,
+      FEOpts.DisableInterfaceFileLock);
 }
 
 static bool compileLLVMIR(const CompilerInvocation &Invocation,

--- a/test/Driver/lock_interface.swift
+++ b/test/Driver/lock_interface.swift
@@ -1,13 +1,23 @@
 // RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache-lock)
+// RUN: %empty-directory(%t/module-cache-no-lock)
 // RUN: echo 'public func foo() {}' > %t/Foo.swift
 // RUN: %target-swift-frontend-typecheck -emit-module-interface-path %t/Foo.swiftinterface %t/Foo.swift -enable-library-evolution
 // RUN: touch %t/main.swift %t/file-01.swift %t/file-02.swift %t/file-03.swift
 // RUN: echo 'import Foo' > %t/file-01.swift
 // RUN: echo 'import Foo' > %t/file-02.swift
 // RUN: echo 'import Foo' > %t/file-03.swift
-// RUN: %target-swiftc_driver -j20 %t/main.swift %t/file-01.swift %t/file-02.swift %t/file-03.swift -I %t -Xfrontend -Rmodule-interface-rebuild &> %t/result.txt
+// RUN: %target-swiftc_driver -j20 %t/main.swift %t/file-01.swift %t/file-02.swift %t/file-03.swift -I %t -Xfrontend -Rmodule-interface-rebuild -module-cache-path %t/module-cache &> %t/result.txt
 // RUN: %FileCheck %s  -check-prefix=CHECK-REBUILD < %t/result.txt
+
+// RUN: %target-swiftc_driver -j20 %t/main.swift %t/file-01.swift %t/file-02.swift %t/file-03.swift -I %t -Xfrontend -Rmodule-interface-rebuild -Xfrontend -disable-interface-lock -module-cache-path %t/module-cache-no-lock &> %t/result.txt
+
+// RUN: %FileCheck %s  -check-prefix=CHECK-REBUILD-NO-LOCK < %t/result.txt
 
 // Ensure we only build Foo module once from the interface
 // CHECK-REBUILD: rebuilding module 'Foo' from interface
 // CHECK-REBUILD-NOT: rebuilding module 'Foo' from interface
+
+// CHECK-REBUILD-NO-LOCK: rebuilding module 'Foo' from interface
+// CHECK-REBUILD-NO-LOCK: rebuilding module 'Foo' from interface
+// CHECK-REBUILD-NO-LOCK: rebuilding module 'Foo' from interface


### PR DESCRIPTION
This could help fix a flaky test.

Related to: rdar://58578342