### PR TITLE
[silcombine] Eliminate mark_dependence whose base is a trivial object.

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1681,36 +1681,48 @@ SILInstruction *SILCombiner::visitEnumInst(EnumInst *EI) {
   return nullptr;
 }
 
-SILInstruction *SILCombiner::visitMarkDependenceInst(MarkDependenceInst *MDI) {
+SILInstruction *SILCombiner::visitMarkDependenceInst(MarkDependenceInst *mdi) {
   // Simplify the base operand of a MarkDependenceInst to eliminate unnecessary
   // instructions that aren't adding value.
   //
   // Conversions to Optional.Some(x) often happen here, this isn't important
   // for us, we can just depend on 'x' directly.
-  if (auto eiBase = dyn_cast<EnumInst>(MDI->getBase())) {
+  if (auto *eiBase = dyn_cast<EnumInst>(mdi->getBase())) {
     if (eiBase->hasOperand() && eiBase->hasOneUse()) {
-      MDI->setBase(eiBase->getOperand());
+      mdi->setBase(eiBase->getOperand());
       eraseInstFromFunction(*eiBase);
-      return MDI;
+      return mdi;
     }
   }
   
   // Conversions from a class to AnyObject also happen a lot, we can just depend
   // on the class reference.
-  if (auto ier = dyn_cast<InitExistentialRefInst>(MDI->getBase())) {
-    MDI->setBase(ier->getOperand());
+  if (auto *ier = dyn_cast<InitExistentialRefInst>(mdi->getBase())) {
+    mdi->setBase(ier->getOperand());
     if (ier->use_empty())
       eraseInstFromFunction(*ier);
-    return MDI;
+    return mdi;
   }
 
   // Conversions from a class to AnyObject also happen a lot, we can just depend
   // on the class reference.
-  if (auto oeri = dyn_cast<OpenExistentialRefInst>(MDI->getBase())) {
-    MDI->setBase(oeri->getOperand());
+  if (auto *oeri = dyn_cast<OpenExistentialRefInst>(mdi->getBase())) {
+    mdi->setBase(oeri->getOperand());
     if (oeri->use_empty())
       eraseInstFromFunction(*oeri);
-    return MDI;
+    return mdi;
+  }
+
+  // Sometimes due to specialization/builtins, we can get a mark_dependence
+  // whose base is a trivial typed object. In such a case, the mark_dependence
+  // does not have a meaning, so just eliminate it.
+  {
+    SILType baseType = mdi->getBase()->getType();
+    if (baseType.isObject() && baseType.isTrivial(*mdi->getFunction())) {
+      SILValue value = mdi->getValue();
+      mdi->replaceAllUsesWith(value);
+      return eraseInstFromFunction(*mdi);
+    }
   }
 
   return nullptr;

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -3449,6 +3449,19 @@ bb0(%0 : $*Builtin.Int64, %1 : $B):
   return %4 : $Builtin.Int64
 }
 
+// CHECK-LABEL: sil @mark_dependence_trivial_object_base :
+// CHECK: bb0(
+// CHECK-NEXT: strong_retain
+// CHECK-NEXT: return
+// CHECK: } // end sil function 'mark_dependence_trivial_object_base'
+sil @mark_dependence_trivial_object_base : $@convention(thin) (@guaranteed B) -> @owned B {
+bb0(%0 : $B):
+  strong_retain %0 : $B
+  %1 = enum $Optional<Int>, #Optional.none!enumelt
+  %2 = mark_dependence %0 : $B on %1 : $Optional<Int>
+  return %2 : $B
+}
+
 protocol _NSArrayCore {}
 
 // CHECK-LABEL: sil @mark_dependence_base2


### PR DESCRIPTION
This pattern comes up when faking a base using
Builtin.convertUnsafeUnownedToGuaranteed.

rdar://59735604
