### PR TITLE
[Diagnostics][SourceKit] Expose educational notes through SourceKit diagnostics request

### DIFF
--- a/test/SourceKit/Sema/educational_note_diags.swift
+++ b/test/SourceKit/Sema/educational_note_diags.swift
@@ -1,0 +1,13 @@
+extension (Int, Int) {}
+
+// RUN: %sourcekitd-test -req=sema %s -- -Xfrontend -enable-descriptive-diagnostics -Xfrontend -diagnostic-documentation-path -Xfrontend /educational/notes/path/prefix %s | %FileCheck %s -check-prefix=DESCRIPTIVE
+
+// DESCRIPTIVE:      key.description: "non-nominal type
+// DESCRIPTIVE:      key.educational_note_paths: [
+// DESCRIPTIVE-NEXT:   "/educational/notes/path/prefix/nominal-types.md"
+// DESCRIPTIVE-NEXT: ]
+
+// RUN: %sourcekitd-test -req=sema %s -- %s | %FileCheck %s -check-prefix=DESCRIPTIVE-DISABLED
+
+// DESCRIPTIVE-DISABLED:     key.description: "non-nominal type
+// DESCRIPTIVE-DISABLED-NOT: key.educational_note_paths

--- a/tools/SourceKit/docs/Protocol.md
+++ b/tools/SourceKit/docs/Protocol.md
@@ -418,6 +418,7 @@ of diagnostic entries. A diagnostic entry has this format:
     [opts] <key.fixits>:    (array) [fixit+] // one or more entries for fixits
     [opts] <key.ranges>:    (array) [range+] // one or more entries for ranges
     [opts] <key.diagnostics>: (array) [diagnostic+] // one or more sub-diagnostic entries
+    [opts] <key.educational_note_paths>: (array) [string+] // one or more absolute paths of educational notes, formatted as Markdown
 }
 ```
 

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -203,6 +203,7 @@ struct DiagnosticEntryInfoBase {
   std::string Filename;
   SmallVector<std::pair<unsigned, unsigned>, 2> Ranges;
   SmallVector<Fixit, 2> Fixits;
+  SmallVector<std::string, 1> EducationalNotePaths;
 };
 
 struct DiagnosticEntryInfo : DiagnosticEntryInfoBase {

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -110,6 +110,9 @@ void EditorDiagConsumer::handleDiagnostic(SourceManager &SM,
   }
   SKInfo.Description = Text.str();
 
+  for (auto notePath : Info.EducationalNotePaths)
+    SKInfo.EducationalNotePaths.push_back(notePath);
+
   Optional<unsigned> BufferIDOpt;
   if (Info.Loc.isValid()) {
     BufferIDOpt = SM.findBufferContainingLoc(Info.Loc);

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -2686,6 +2686,9 @@ static void fillDictionaryForDiagnosticInfoBase(
   if (!Info.Filename.empty())
     Elem.set(KeyFilePath, Info.Filename);
 
+  if (!Info.EducationalNotePaths.empty())
+    Elem.set(KeyEducationalNotePaths, Info.EducationalNotePaths);
+
   if (!Info.Ranges.empty()) {
     auto RangesArr = Elem.setArray(KeyRanges);
     for (auto R : Info.Ranges) {

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -96,6 +96,7 @@ UID_KEYS = [
     KEY('Ranges', 'key.ranges'),
     KEY('Fixits', 'key.fixits'),
     KEY('Diagnostics', 'key.diagnostics'),
+    KEY('EducationalNotePaths', 'key.educational_note_paths'),
     KEY('FormatOptions', 'key.editor.format.options'),
     KEY('CodeCompleteOptions', 'key.codecomplete.options'),
     KEY('FilterRules', 'key.codecomplete.filterrules'),


### PR DESCRIPTION
Update the SourceKit diagnostics schema to include an optional list of absolute paths to educational note files inside the toolchain. It looks like LSP will support [links in diagnostics](https://github.com/microsoft/language-server-protocol/issues/926) soon, allowing source kit-lsp to expose these via file urls.

Educational notes will only appear in SourceKit responses if `-Xfrontend -enable-descriptive-diagnostics` is passed. 