### PR TITLE
[os log][stdlib/private] Enable precision and alignment values to be dynamic.

### DIFF
--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -20,7 +20,7 @@ using namespace swift;
 
 namespace swift {
 llvm::cl::opt<unsigned>
-    ConstExprLimit("constexpr-limit", llvm::cl::init(2048),
+    ConstExprLimit("constexpr-limit", llvm::cl::init(3072),
                    llvm::cl::desc("Number of instructions interpreted in a"
                                   " constexpr function"));
 }

--- a/stdlib/private/OSLog/OSLogIntegerTypes.swift
+++ b/stdlib/private/OSLog/OSLogIntegerTypes.swift
@@ -102,8 +102,19 @@ extension OSLogInterpolation {
     guard argumentCount < maxOSLogArgumentCount else { return }
     formatString +=
       format.formatSpecifier(for: T.self, align: align, privacy: privacy)
-    addIntHeaders(privacy, sizeForEncoding(T.self))
+    // If minimum column width is specified, append this value first. Note that the
+    // format specifier would use a '*' for width e.g. %*d.
+    if let minColumns = align.minimumColumnWidth {
+      appendPrecisionArgument(minColumns)
+    }
 
+    // If minimum number of digits (precision) is specified, append the precision before
+    // the argument. Note that the format specifier would use a '*' for precision: %.*d.
+    if let minDigits = format.minDigits {
+      appendPrecisionArgument(minDigits)
+    }
+
+    addIntHeaders(privacy, sizeForEncoding(T.self))
     arguments.append(number)
     argumentCount += 1
   }
@@ -130,6 +141,27 @@ extension OSLogInterpolation {
     totalBytesForSerializingArguments += byteCount + 2
 
     preamble = getUpdatedPreamble(privacy: privacy, isScalar: true)
+  }
+
+  // Append argument indicating precision or width of a format specifier to the buffer.
+  // These specify the value of the '*' in a format specifier like: %*.*ld.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  internal mutating func appendPrecisionArgument(_ count: @escaping () -> Int) {
+    // Note that we don't have to update the preamble here.
+    let argumentHeader = getArgumentHeader(privacy: .auto, type: .count)
+    arguments.append(argumentHeader)
+    // Append number of bytes needed to serialize the argument.
+    let byteCount = sizeForEncoding(CInt.self)
+    arguments.append(UInt8(byteCount))
+    // Increment total byte size by the number of bytes needed for this
+    // argument, which is the sum of the byte size of the argument and
+    // two bytes needed for the headers.
+    totalBytesForSerializingArguments += 2 + byteCount
+    // The count is expected to be a CInt.
+    arguments.append({ CInt(count()) })
+    argumentCount += 1
   }
 }
 

--- a/stdlib/private/OSLog/OSLogStringAlignment.swift
+++ b/stdlib/private/OSLog/OSLogStringAlignment.swift
@@ -23,8 +23,9 @@ public enum OSLogCollectionBound {
 public struct OSLogStringAlignment {
   /// Minimum number of characters to be displayed. If the value to be printed
   /// is shorter than this number, the result is padded with spaces. The value
-  /// is not truncated even if the result is larger.
-  public var minimumColumnWidth: Int
+  /// is not truncated even if the result is larger.This value need not be a
+  /// compile-time constant, and is therefore an autoclosure.
+  public var minimumColumnWidth: (() -> Int)?
   /// This captures right/left alignment.
   public var anchor: OSLogCollectionBound
 
@@ -36,8 +37,8 @@ public struct OSLogStringAlignment {
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
-  public init(
-    minimumColumnWidth: Int = 0,
+  internal init(
+    minimumColumnWidth: (() -> Int)? = nil,
     anchor: OSLogCollectionBound = .end
   ) {
     self.minimumColumnWidth = minimumColumnWidth
@@ -70,7 +71,9 @@ public struct OSLogStringAlignment {
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
-  public static func right(columns: Int = 0) -> OSLogStringAlignment {
+  public static func right(
+    columns: @escaping @autoclosure () -> Int
+  ) -> OSLogStringAlignment {
     OSLogStringAlignment(minimumColumnWidth: columns, anchor: .end)
   }
 
@@ -78,7 +81,9 @@ public struct OSLogStringAlignment {
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
-  public static func left(columns: Int = 0) -> OSLogStringAlignment {
+  public static func left(
+    columns: @escaping @autoclosure () -> Int
+  ) -> OSLogStringAlignment {
     OSLogStringAlignment(minimumColumnWidth: columns, anchor: .start)
   }
 }

--- a/stdlib/private/OSLog/OSLogStringTypes.swift
+++ b/stdlib/private/OSLog/OSLogStringTypes.swift
@@ -43,8 +43,14 @@ extension OSLogInterpolation {
     guard argumentCount < maxOSLogArgumentCount else { return }
 
     formatString += getStringFormatSpecifier(align, privacy)
-    addStringHeaders(privacy)
 
+    // If minimum column width is specified, append this value first. Note that the
+    // format specifier would use a '*' for width e.g. %*s.
+    if let minColumns = align.minimumColumnWidth {
+      appendPrecisionArgument(minColumns)
+    }
+
+    addStringHeaders(privacy)
     arguments.append(argumentString)
     argumentCount += 1
   }
@@ -94,8 +100,8 @@ extension OSLogInterpolation {
     if case .start = align.anchor {
       specifier += "-"
     }
-    if align.minimumColumnWidth > 0 {
-      specifier += align.minimumColumnWidth.description
+    if let _ = align.minimumColumnWidth {
+      specifier += "*"
     }
     specifier += "s"
     return specifier

--- a/test/SILOptimizer/OSLogConstantEvaluableTest.swift
+++ b/test/SILOptimizer/OSLogConstantEvaluableTest.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-silgen -primary-file %s -o %t/OSLogConstantEvaluableTest_silgen.sil
+// RUN: %target-swift-frontend -swift-version 5 -emit-silgen -primary-file %s -o %t/OSLogConstantEvaluableTest_silgen.sil
 //
 // Run the (mandatory) passes on which constant evaluator depends, and run the
 // constant evaluator on the SIL produced after the dependent passes are run.
 //
-// RUN: %target-sil-opt -silgen-cleanup -raw-sil-inst-lowering -allocbox-to-stack -mandatory-inlining -constexpr-limit 2048 -test-constant-evaluable-subset %t/OSLogConstantEvaluableTest_silgen.sil > %t/OSLogConstantEvaluableTest.sil 2> %t/error-output
+// RUN: %target-sil-opt -silgen-cleanup -raw-sil-inst-lowering -allocbox-to-stack -mandatory-inlining -constexpr-limit 3072 -test-constant-evaluable-subset %t/OSLogConstantEvaluableTest_silgen.sil > %t/OSLogConstantEvaluableTest.sil 2> %t/error-output
 //
 // RUN: %FileCheck %s < %t/error-output
 //
@@ -46,4 +46,13 @@ func intValueInterpolationTest() -> OSLogMessage {
 @_semantics("test_driver")
 func stringValueInterpolationTest() -> OSLogMessage {
   return "A string value \("xyz")"
+}
+
+@_semantics("test_driver")
+func intValueWithPrecisionTest() -> OSLogMessage {
+  return
+    """
+     An integer value \
+     \(10, format: .decimal(minDigits: 25), align: .right(columns: 10))
+    """
 }


### PR DESCRIPTION
To enable this, the format specifier constructed by the os log implementation uses '*' for
width and precision, and passes those values to the os_log ABIs as additional
arguments of the message. (The precision/alignment arguments have the
type: count).

Update tests to handle this change.