### PR TITLE
[SR-12236] Commit a regression test

### DIFF
--- a/test/decl/circularity.swift
+++ b/test/decl/circularity.swift
@@ -102,3 +102,11 @@ class D4 : C4, P1 { // expected-note 2 {{through reference here}}
     super.init(x: x)
   }
 }
+
+// SR-12236
+// N.B. This used to compile in 5.1.
+protocol SR12236 { }
+class SR12236_A { // expected-note {{through reference here}}
+    typealias Nest = SR12236 // expected-error {{circular reference}} expected-note {{through reference here}}
+}
+extension SR12236_A: SR12236_A.Nest { }


### PR DESCRIPTION
This is technically a source break, but it was always a circularity
issue. It will compile fine in isolation, but all attempts to lookup
nested type via qualified lookup (e.g. witness matching) will re-enter
themselves and potentially produce inconsistent results.

Commit a regression test so we nail down this behavior to see if we can
revisit this.