### PR TITLE
SILGen: Fix substitution map when calling property wrapper backing initializer [5.2]

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5062,24 +5062,10 @@ RValue SILGenFunction::emitApplyMethod(SILLocation loc, ConcreteDeclRef declRef,
 RValue SILGenFunction::emitApplyOfPropertyWrapperBackingInitializer(
     SILLocation loc,
     VarDecl *var,
+    SubstitutionMap subs,
     RValue &&originalValue,
     SGFContext C) {
   SILDeclRef constant(var, SILDeclRef::Kind::PropertyWrapperBackingInitializer);
-
-  SubstitutionMap subs;
-  auto varDC = var->getInnermostDeclContext();
-  if (auto genericSig = varDC->getGenericSignatureOfContext()) {
-    subs = SubstitutionMap::get(
-        genericSig,
-        [&](SubstitutableType *type) {
-          if (auto gp = type->getAs<GenericTypeParamType>()) {
-            return F.mapTypeIntoContext(gp);
-          }
-
-          return Type(type);
-        },
-        LookUpConformanceInModule(varDC->getParentModule()));
-  }
 
   FormalEvaluationScope writebackScope(*this);
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -107,6 +107,7 @@ static RValue maybeEmitPropertyWrapperInitFromValue(
     SILGenFunction &SGF,
     SILLocation loc,
     VarDecl *field,
+    SubstitutionMap subs,
     RValue &&arg) {
   auto originalProperty = field->getOriginalWrappedProperty();
   if (!originalProperty ||
@@ -118,7 +119,33 @@ static RValue maybeEmitPropertyWrapperInitFromValue(
     return std::move(arg);
 
   return SGF.emitApplyOfPropertyWrapperBackingInitializer(loc, originalProperty,
-                                                          std::move(arg));
+                                                          subs, std::move(arg));
+}
+
+static SubstitutionMap getSubstitutionsForPropertyInitializer(
+    DeclContext *dc,
+    NominalTypeDecl *nominal) {
+  // We want a substitution list written in terms of the generic
+  // signature of the type, with replacement archetypes from the
+  // constructor's context (which might be in an extension of
+  // the type, which adds additional generic requirements).
+  if (auto *genericEnv = dc->getGenericEnvironmentOfContext()) {
+    // Generate a set of substitutions for the initialization function,
+    // whose generic signature is that of the type context, and whose
+    // replacement types are the archetypes of the initializer itself.
+    return SubstitutionMap::get(
+      nominal->getGenericSignatureOfContext(),
+      [&](SubstitutableType *type) {
+        if (auto gp = type->getAs<GenericTypeParamType>()) {
+          return genericEnv->mapTypeIntoContext(gp);
+        }
+
+        return Type(type);
+      },
+      LookUpConformanceInModule(dc->getParentModule()));
+  }
+
+  return SubstitutionMap();
 }
 
 static void emitImplicitValueConstructor(SILGenFunction &SGF,
@@ -161,6 +188,8 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
   auto *decl = selfTy.getStructOrBoundGenericStruct();
   assert(decl && "not a struct?!");
 
+  auto subs = getSubstitutionsForPropertyInitializer(decl, decl);
+
   // If we have an indirect return slot, initialize it in-place.
   if (resultSlot) {
     auto elti = elements.begin(), eltEnd = elements.end();
@@ -178,7 +207,8 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
                "number of args does not match number of fields");
         (void)eltEnd;
         FullExpr scope(SGF.Cleanups, field->getParentPatternBinding());
-        maybeEmitPropertyWrapperInitFromValue(SGF, Loc, field, std::move(*elti))
+        maybeEmitPropertyWrapperInitFromValue(SGF, Loc, field, subs,
+                                              std::move(*elti))
           .forwardInto(SGF, Loc, init.get());
         ++elti;
       } else {
@@ -213,7 +243,7 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
       assert(elti != eltEnd && "number of args does not match number of fields");
       (void)eltEnd;
       v = maybeEmitPropertyWrapperInitFromValue(
-          SGF, Loc, field, std::move(*elti))
+          SGF, Loc, field, subs, std::move(*elti))
         .forwardAsSingleStorageValue(SGF, fieldTy, Loc);
       ++elti;
     } else {
@@ -912,6 +942,8 @@ static Type getInitializationTypeInContext(
 void SILGenFunction::emitMemberInitializers(DeclContext *dc,
                                             VarDecl *selfDecl,
                                             NominalTypeDecl *nominal) {
+  auto subs = getSubstitutionsForPropertyInitializer(dc, nominal);
+
   for (auto member : nominal->getMembers()) {
     // Find instance pattern binding declarations that have initializers.
     if (auto pbd = dyn_cast<PatternBindingDecl>(member)) {
@@ -924,30 +956,6 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
         auto *varPattern = pbd->getPattern(i);
         // Cleanup after this initialization.
         FullExpr scope(Cleanups, varPattern);
-
-        // We want a substitution list written in terms of the generic
-        // signature of the type, with replacement archetypes from the
-        // constructor's context (which might be in an extension of
-        // the type, which adds additional generic requirements).
-        SubstitutionMap subs;
-        auto *genericEnv = dc->getGenericEnvironmentOfContext();
-        auto typeGenericSig = nominal->getGenericSignatureOfContext();
-
-        if (genericEnv && typeGenericSig) {
-          // Generate a set of substitutions for the initialization function,
-          // whose generic signature is that of the type context, and whose
-          // replacement types are the archetypes of the initializer itself.
-          subs = SubstitutionMap::get(
-            typeGenericSig,
-            [&](SubstitutableType *type) {
-              if (auto gp = type->getAs<GenericTypeParamType>()) {
-                return genericEnv->mapTypeIntoContext(gp);
-              }
-
-              return Type(type);
-            },
-            LookUpConformanceInModule(dc->getParentModule()));
-        }
 
         // Get the type of the initialization result, in terms
         // of the constructor context's archetypes.
@@ -970,7 +978,7 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
           if (originalVar &&
               originalVar->isPropertyMemberwiseInitializedWithWrappedType()) {
             result = maybeEmitPropertyWrapperInitFromValue(
-                *this, init, singleVar, std::move(result));
+                *this, init, singleVar, subs, std::move(result));
           }
         }
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1499,6 +1499,7 @@ public:
   RValue emitApplyOfPropertyWrapperBackingInitializer(
       SILLocation loc,
       VarDecl *var,
+      SubstitutionMap subs,
       RValue &&originalValue,
       SGFContext C = SGFContext());
 

--- a/test/SILGen/property_wrappers_constrained_extension.swift
+++ b/test/SILGen/property_wrappers_constrained_extension.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-emit-silgen -primary-file %s | %FileCheck %s
+
+@propertyWrapper
+public struct Horse<Value> {
+	private var stored: Value
+	
+	public var wrappedValue: Value {
+		get { stored }
+		set { stored = newValue }
+	}		
+
+	public init(wrappedValue initialValue: Value) {
+		stored = initialValue
+	}
+
+	public var projectedValue: Self {
+		mutating get { self }
+		set { self = newValue }
+	}
+}
+
+public protocol Fuzzball {}
+
+public struct Cat : Fuzzball {}
+
+public struct Dog<Pet : Fuzzball> {
+  @Horse public var foo: Int = 17
+}
+
+extension Dog where Pet == Cat {
+  public init() {}
+}
+
+// CHECK-LABEL: sil [ossa] @$s39property_wrappers_constrained_extension3DogVA2A3CatVRszrlEACyAEGycfC : $@convention(method) (@thin Dog<Cat>.Type) -> Dog<Cat> {
+// CHECK: [[FN:%.*]] = function_ref @$s39property_wrappers_constrained_extension3DogV4_foo33_{{.*}}LLAA5HorseVySiGvpfi : $@convention(thin) <τ_0_0 where τ_0_0 : Fuzzball> () -> Int
+// CHECK: apply [[FN]]<Cat>() : $@convention(thin) <τ_0_0 where τ_0_0 : Fuzzball> () -> Int


### PR DESCRIPTION
If we're emitting a designated constructor inside a constrained extension,
we have to use the correct substitution map for calling the property wrapper
backing initializer.

Factor out the computation of this substitution map and use it consistently.

Fixes <rdar://problem/59245068>.
