### PR TITLE
[Constraint system] Cleanups for function builders support for if let/if case let

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -331,7 +331,7 @@ protected:
       addChild(captureExpr(expr, /*oneWay=*/true, node.get<Expr *>()));
     }
 
-    if (!cs)
+    if (!cs || hadError)
       return nullptr;
 
     // Call Builder.buildBlock(... args ...)
@@ -1353,6 +1353,11 @@ public:
 
     // Otherwise, recurse into the statement normally.
     return std::make_pair(true, S);
+  }
+
+  /// Ignore patterns.
+  std::pair<bool, Pattern*> walkToPatternPre(Pattern *pat) override {
+    return { false, pat };
   }
 };
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7171,13 +7171,8 @@ namespace {
               [&](SolutionApplicationTarget target) {
                 auto resultTarget = rewriteTarget(target);
                 if (resultTarget) {
-
-                  if (auto expr = resultTarget->getAsExpr()) {
+                  if (auto expr = resultTarget->getAsExpr())
                     Rewriter.solution.setExprTypes(expr);
-                  } else if (auto stmtCondition =
-                                 resultTarget->getAsStmtCondition()) {
-
-                  }
                 }
 
                 return resultTarget;
@@ -7454,6 +7449,7 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
           return None;
 
         // Load the condition if needed.
+        solution.setExprTypes(finalCondExpr);
         if (finalCondExpr->getType()->hasLValueType()) {
           ASTContext &ctx = solution.getConstraintSystem().getASTContext();
           finalCondExpr = TypeChecker::addImplicitLoadExpr(ctx, finalCondExpr);
@@ -7470,6 +7466,7 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
         if (!resolvedTarget)
           return None;
 
+        solution.setExprTypes(resolvedTarget->getAsExpr());
         condElement.setInitializer(resolvedTarget->getAsExpr());
         condElement.setPattern(resolvedTarget->getInitializationPattern());
         continue;
@@ -7490,8 +7487,8 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
         [&](SolutionApplicationTarget target) {
           auto resultTarget = rewriteTarget(target);
           if (resultTarget) {
-            SetExprTypes typeSetter(solution);
-            resultTarget->walk(typeSetter);
+            if (auto expr = resultTarget->getAsExpr())
+              solution.setExprTypes(expr);
           }
 
           return resultTarget;

--- a/test/Constraints/function_builder.swift
+++ b/test/Constraints/function_builder.swift
@@ -536,3 +536,30 @@ tuplify(true) { c in
 // CHECK-SAME: Optional("matched without payload")
 // CHECK-SAME: "matched with payload", "hello!", 34
 // CHECK-SAME: "intentional mismatch"
+
+class Super { }
+
+class Sub : Super {
+  func subMethod() -> String {
+    return "subMethod"
+  }
+}
+
+func getSuper(wantSubclass: Bool) -> Super {
+  return wantSubclass ? Sub() : Super()
+}
+
+tuplify(true) { c in
+  "testIfLetAsMatching"
+  if case let sub as Sub = getSuper(wantSubclass: true) {
+    sub.subMethod()
+  }
+  if case let sub as Sub = getSuper(wantSubclass: false) {
+    fatalError("cannot match this")
+  } else {
+    "Superclass instance"
+  }
+}
+// CHECK: testIfLetAsMatching
+// CHECK-SAME: "subMethod"
+// CHECK-SAME: "Superclass instance"

--- a/validation-test/Sema/SwiftUI/rdar57201781.swift
+++ b/validation-test/Sema/SwiftUI/rdar57201781.swift
@@ -8,7 +8,7 @@ struct ContentView : View {
   @State var foo: [String] = Array(repeating: "", count: 5)
 
   var body: some View {
-    VStack {
+    VStack { // expected-error{{type of expression is ambiguous without more context}}
       HStack {
         Text("")
         TextFi // expected-error {{use of unresolved identifier 'TextFi'}}


### PR DESCRIPTION
Various cleanups to improve function builders support for if let/if case let:
* Expand` SolutionApplicationTarget` to `StmtConditions`.
* Properly deal with `as` patterns by not prechecking patterns (oops).