### PR TITLE
[semantic-arc] Update begin_borrow elimination for guaranteed phi args.

### DIFF
--- a/lib/SILOptimizer/Transforms/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Transforms/SemanticARCOpts.cpp
@@ -510,18 +510,22 @@ bool SemanticARCOptVisitor::visitBeginBorrowInst(BeginBorrowInst *bbi) {
   auto kind = bbi->getOperand().getOwnershipKind();
   SmallVector<EndBorrowInst *, 16> endBorrows;
   for (auto *op : bbi->getUses()) {
-    auto *user = op->getUser();
-    switch (user->getKind()) {
-    case SILInstructionKind::EndBorrowInst:
-      endBorrows.push_back(cast<EndBorrowInst>(user));
-      break;
-    default:
+    if (!op->isConsumingUse()) {
       // Make sure that this operand can accept our arguments kind.
       auto map = op->getOwnershipKindMap();
       if (map.canAcceptKind(kind))
         continue;
       return false;
     }
+
+    // Otherwise, this borrow is being consumed. See if our consuming inst is an
+    // end_borrow. If it isn't, then return false, this scope is
+    // needed. Otherwise, add the end_borrow to our list of end borrows.
+    auto *ebi = dyn_cast<EndBorrowInst>(op->getUser());
+    if (!ebi) {
+      return false;
+    }
+    endBorrows.push_back(ebi);
   }
 
   // At this point, we know that the begin_borrow's operand can be

--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -1285,3 +1285,20 @@ bb3:
   %9999 = tuple()
   return %9999 : $()
 }
+
+// TODO: We can support this with time.
+//
+// CHECK-LABEL: sil [ossa] @do_eliminate_begin_borrow_consumed_by_guaranteed_phi : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+// CHECK: begin_borrow
+// CHECK: } // end sil function 'do_eliminate_begin_borrow_consumed_by_guaranteed_phi'
+sil [ossa] @do_eliminate_begin_borrow_consumed_by_guaranteed_phi : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  br bb1(%1 : $Builtin.NativeObject)
+
+bb1(%2 : @guaranteed $Builtin.NativeObject):
+  end_borrow %2 : $Builtin.NativeObject
+  destroy_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
Now, guaranteed phi args can also consume begin_borrow. This means our simple
analysis here is not sufficient. I am going to add support for this in a
forthcoming commit.

Optimizations are still not creating guaranteed phi arguments, so no breakage
can result.
