### PR TITLE
[ConstraintSystem] Don't attempt bindings for closure parameters/resu…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -314,6 +314,20 @@ ConstraintSystem::getPotentialBindingForRelationalConstraint(
     type = first;
     kind = AllowedBindingKind::Supertypes;
   } else {
+    // If the left-hand side of a relational constraint is a
+    // type variable representing a closure type, let's delay
+    // attempting any bindings related to any type variables
+    // on the other side since it could only be either a closure
+    // parameter or a result type, and we can't get a full set
+    // of bindings for them until closure's body is opened.
+    if (auto *typeVar = first->getAs<TypeVariableType>()) {
+      if (typeVar->getImpl().isClosureType()) {
+        result.InvolvesTypeVariables = true;
+        result.FullyBound = true;
+        return None;
+      }
+    }
+
     // Can't infer anything.
     if (result.InvolvesTypeVariables)
       return None;

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -973,3 +973,22 @@ func test_correct_inference_of_closure_result_in_presence_of_optionals() {
     return;
   }
 }
+
+// rdar://problem/59741308 - inference fails with tuple element has to joined to supertype
+func rdar_59741308() {
+  class Base {
+    func foo(_: Int) {}
+  }
+
+  class A : Base {}
+  class B : Base {}
+
+  func test() {
+    // Note that `0`, and `1` here are going to be type variables
+    // which makes join impossible until it's already to late for
+    // it to be useful.
+    [(A(), 0), (B(), 1)].forEach { base, value in
+      base.foo(value) // Ok
+    }
+  }
+}

--- a/test/Constraints/function_builder_one_way.swift
+++ b/test/Constraints/function_builder_one_way.swift
@@ -49,16 +49,16 @@ func tuplify<C: Collection, T>(_ collection: C, @TupleBuilder body: (C.Element) 
 }
 
 // CHECK: ---Connected components---
-// CHECK-NEXT:  0: $T1 $T2 $T3 $T5 $T6 $T7 $T8 $T10 $T11 $T78 $T79 depends on 2
-// CHECK-NEXT:  2: $T13 $T18 $T29 $T43 $T54 $T55 $T56 $T57 $T58 $T59 $T60 $T61 $T62 $T63 $T64 $T65 $T66 $T67 $T69 $T70 $T71 $T72 $T73 $T74 $T75 $T76 $T77 depends on 1, 3, 4, 6, 9
-// CHECK-NEXT:  9: $T49 $T50 $T51 $T52 $T53 depends on 8
-// CHECK-NEXT:  8: $T44 $T45 $T46 $T47 $T48
-// CHECK-NEXT:  6: $T32 $T36 $T37 $T38 $T39 $T40 $T41 $T42 depends on 5, 7
-// CHECK-NEXT:  7: $T33 $T34 $T35
-// CHECK-NEXT:  5: $T31
-// CHECK-NEXT:  4: $T19 $T20 $T21 $T22 $T23 $T24 $T25 $T26 $T27 $T28
-// CHECK-NEXT:  3: $T16 $T17
-// CHECK-NEXT:  1: $T12
+// CHECK-NEXT: 0: $T1 $T2 $T3 $T5 $T6 $T7 $T8 $T10 $T77 $T78 depends on 2
+// CHECK-NEXT: 2: $T12 $T17 $T28 $T42 $T53 $T54 $T55 $T56 $T57 $T58 $T59 $T60 $T61 $T62 $T63 $T64 $T65 $T66 $T68 $T69 $T70 $T71 $T72 $T73 $T74 $T75 $T76 depends on 1, 3, 4, 6, 9
+// CHECK-NEXT: 9: $T48 $T49 $T50 $T51 $T52 depends on 8
+// CHECK-NEXT: 8: $T43 $T44 $T45 $T46 $T47
+// CHECK-NEXT: 6: $T31 $T35 $T36 $T37 $T38 $T39 $T40 $T41 depends on 5, 7
+// CHECK-NEXT: 7: $T32 $T33 $T34
+// CHECK-NEXT: 5: $T30
+// CHECK-NEXT: 4: $T18 $T19 $T20 $T21 $T22 $T23 $T24 $T25 $T26 $T27
+// CHECK-NEXT: 3: $T15 $T16
+// CHECK-NEXT: 1: $T11
 let names = ["Alice", "Bob", "Charlie"]
 let b = true
 var number = 17


### PR DESCRIPTION
…lt until body is opened

Let's delay attempting any bindings for type variables representing
parameters or result type of the closure until the body is "opened"
because it's impossible to infer a full set of bindings until all
constraints related to a closure have been generated.

Resolves: rdar://problem/59741308

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
