### PR TITLE
[WASM] Avoid to emit GOT for WASM

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -1175,6 +1175,13 @@ public:
     if (Triple.isOSBinFormatELF())
       return;
 
+    // Avoid to create GOT because wasm doesn't support
+    // dynamic linking yet
+    if (Triple.isOSBinFormatWasm()) {
+      GV->setDSOLocal(true);
+      return;
+    }
+
     if (IRL.Linkage == llvm::GlobalValue::LinkOnceODRLinkage ||
         IRL.Linkage == llvm::GlobalValue::WeakODRLinkage)
       if (Triple.supportsCOMDAT())

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2910,6 +2910,11 @@ IRGenModule::getAddrOfLLVMVariableOrGOTEquivalent(LinkEntity entity) {
     return {gotEquivalent, ConstantReference::Indirect};
   };
   
+  // Avoid to create GOT because wasm32 doesn't support
+  // dynamic linking yet
+  if (TargetInfo.OutputObjectFormat == llvm::Triple::Wasm) {
+    return direct();
+  }
   // The integrated REPL incrementally adds new definitions, so always use
   // indirect references in this mode.
   if (IRGen.Opts.IntegratedREPL)


### PR DESCRIPTION
WebAssembly doesn't support dynamic linking, so GOT is not necessary now.
LLVM produces virtual GOT when compiler wants to use GOT, but it takes overhead on runtime.

Discussion: https://forums.swift.org/t/wasm-support/16087/19

