### PR TITLE
[ownership] Move TempRValueOpt before Semantic ARC Opts.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -395,16 +395,21 @@ static void addPerfEarlyModulePassPipeline(SILPassPipelinePlan &P) {
   // we do not spend time optimizing them.
   P.addDeadFunctionElimination();
 
+  // Cleanup after SILGen: remove trivial copies to temporaries.
+  P.addTempRValueOpt();
+  // Cleanup after SILGen: remove unneeded borrows/copies.
   P.addSemanticARCOpts();
 
   // Strip ownership from non-transparent functions.
   if (P.getOptions().StripOwnershipAfterSerialization)
     P.addNonTransparentFunctionOwnershipModelEliminator();
 
-  // Start by cloning functions from stdlib.
+  // Start by linking in referenced functions from other modules.
   P.addPerformanceSILLinker();
 
-  // Cleanup after SILGen: remove trivial copies to temporaries.
+  // Cleanup after SILGen: remove trivial copies to temporaries. This version of
+  // temp-rvalue opt is here so that we can hit copies from non-ossa code that
+  // is linked in from the stdlib.
   P.addTempRValueOpt();
 
   // Add the outliner pass (Osize).


### PR DESCRIPTION
There is a natural synergy in between the two passes since TempRValueOpt often
times eliminates temporaries that prevent Semantic ARC Opts from removing ARC
traffic.
