### PR TITLE
[Typechecker] Use getCalledValue() when checking ignored expressions

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1466,8 +1466,8 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
         isa<DotSyntaxCallExpr>(E) ? cast<DotSyntaxCallExpr>(E)->getFn() : E;
 
     if (auto *Fn = dyn_cast<ApplyExpr>(expr)) {
-      if (auto *declRef = dyn_cast<DeclRefExpr>(Fn->getFn())) {
-        if (auto *FD = dyn_cast<AbstractFunctionDecl>(declRef->getDecl())) {
+      if (auto *calledValue = Fn->getCalledValue()) {
+        if (auto *FD = dyn_cast<AbstractFunctionDecl>(calledValue)) {
           if (FD->getAttrs().hasAttribute<DiscardableResultAttr>()) {
             isDiscardable = true;
           }

--- a/test/attr/attr_discardableResult.swift
+++ b/test/attr/attr_discardableResult.swift
@@ -222,3 +222,23 @@ class Discard {
     bar // expected-error {{expression resolves to an unused function}}
   }
 }
+
+// SR-12271
+
+struct SR_12271_S {
+  @discardableResult
+  func bar1() -> () -> Void {
+    return {}
+  }
+
+  @discardableResult
+  static func bar2() -> () -> Void {
+    return {}
+  }
+}
+
+SR_12271_S().bar1() // Okay
+SR_12271_S.bar2() // Okay
+
+SR_12271_S().bar1 // expected-error {{expression resolves to an unused function}}
+SR_12271_S.bar2 // expected-error {{expression resolves to an unused function}}


### PR DESCRIPTION
Instead of extracting the function declaration from the `DeclRefExpr`, use `getCalledValue()` instead. Otherwise, we throw the `expression resolves to an unused function` diagnostic for:

```swift
struct Foo {
  @discardableResult
  func bar() -> () -> Void { return {} }
}

Foo().bar() // error: expression resolves to an unused function
```

because we're not able to get back the function declaration in order to determine if it's been annotated with `@discardableResult` or not.

Fixes SR-12271