### PR TITLE
[NFC] Mark CrossImport test unsupported without assertions.

### DIFF
--- a/test/CrossImport/skip-submodules.swift
+++ b/test/CrossImport/skip-submodules.swift
@@ -4,6 +4,11 @@
 // RUN: %FileCheck %s < %t.txt
 // RUN: %FileCheck --check-prefix=NEGATIVE %s < %t.txt
 
+// Note: It is a bit confusing but the -debug-only flag means that this info
+// will be printed only in the presence of assertions.
+//
+// REQUIRES: asserts
+
 import Darwin
 import ctypes
 


### PR DESCRIPTION
The test is relying on output from `LLVM_DEBUG`, so we won't get any output when `NDEBUG` is set.