### PR TITLE
Swift Basic/Driver recognizes OpenBSD.

### DIFF
--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -45,6 +45,7 @@ static const SupportedConditionalValue SupportedConditionalCompilationOSs[] = {
   "iOS",
   "Linux",
   "FreeBSD",
+  "OpenBSD",
   "Windows",
   "Android",
   "PS4",
@@ -257,6 +258,9 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
     break;
   case llvm::Triple::FreeBSD:
     addPlatformConditionValue(PlatformConditionKind::OS, "FreeBSD");
+    break;
+  case llvm::Triple::OpenBSD:
+    addPlatformConditionValue(PlatformConditionKind::OS, "OpenBSD");
     break;
   case llvm::Triple::Win32:
     if (Target.getEnvironment() == llvm::Triple::Cygnus)

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -180,7 +180,6 @@ StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
   case llvm::Triple::KFreeBSD:
   case llvm::Triple::Lv2:
   case llvm::Triple::NetBSD:
-  case llvm::Triple::OpenBSD:
   case llvm::Triple::Solaris:
   case llvm::Triple::Minix:
   case llvm::Triple::RTEMS:
@@ -207,6 +206,8 @@ StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
     return triple.isAndroid() ? "android" : "linux";
   case llvm::Triple::FreeBSD:
     return "freebsd";
+  case llvm::Triple::OpenBSD:
+    return "openbsd";
   case llvm::Triple::Win32:
     switch (triple.getEnvironment()) {
     case llvm::Triple::Cygnus:

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -267,6 +267,8 @@ Driver::buildToolChain(const llvm::opt::InputArgList &ArgList) {
     return std::make_unique<toolchains::GenericUnix>(*this, target);
   case llvm::Triple::FreeBSD:
     return std::make_unique<toolchains::GenericUnix>(*this, target);
+  case llvm::Triple::OpenBSD:
+    return std::make_unique<toolchains::OpenBSD>(*this, target);
   case llvm::Triple::Win32:
     if (target.isWindowsCygwinEnvironment())
       return std::make_unique<toolchains::Cygwin>(*this, target);

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -157,6 +157,16 @@ public:
   ~Cygwin() = default;
 };
 
+class LLVM_LIBRARY_VISIBILITY OpenBSD : public GenericUnix {
+protected:
+  std::string getDefaultLinker() const override;
+
+public:
+  OpenBSD(const Driver &D, const llvm::Triple &Triple)
+      : GenericUnix(D, Triple) {}
+  ~OpenBSD() = default;
+};
+
 } // end namespace toolchains
 } // end namespace driver
 } // end namespace swift

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -389,3 +389,7 @@ std::string toolchains::Cygwin::getDefaultLinker() const {
 }
 
 std::string toolchains::Cygwin::getTargetForLinker() const { return ""; }
+
+std::string toolchains::OpenBSD::getDefaultLinker() const {
+  return "lld";
+}

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -37,6 +37,9 @@
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-windows-msvc -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.windows.txt
 // RUN: %FileCheck -check-prefix WINDOWS-x86_64 %s < %t.windows.txt
 
+// RUN: %swiftc_driver -driver-print-jobs -target amd64-unknown-openbsd -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.openbsd.txt
+// RUN: %FileCheck -check-prefix OPENBSD-amd64 %s < %t.openbsd.txt
+
 // RUN: %swiftc_driver -driver-print-jobs -emit-library -target x86_64-unknown-linux-gnu %s -Lbar -o dynlib.out 2>&1 > %t.linux.dynlib.txt
 // RUN: %FileCheck -check-prefix LINUX_DYNLIB-x86_64 %s < %t.linux.dynlib.txt
 
@@ -263,6 +266,22 @@
 // WINDOWS-x86_64-DAG: -lboo
 // WINDOWS-x86_64-DAG: -Xlinker -undefined
 // WINDOWS-x86_64: -o linker
+
+// OPENBSD-amd64: swift
+// OPENBSD-amd64: -o [[OBJECTFILE:.*]]
+
+// OPENBSD-amd64: clang
+// OPENBSD-amd64-DAG: -fuse-ld=lld
+// OPENBSD-amd64-DAG: [[OBJECTFILE]]
+// OPENBSD-amd64-DAG: -lswiftCore
+// OPENBSD-amd64-DAG: -L [[STDLIB_PATH:[^ ]+(/|\\\\)lib(/|\\\\)swift(/|\\\\)]]
+// OPENBSD-amd64-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH]]
+// OPENBSD-amd64-DAG: -F foo -iframework car -F cdr
+// OPENBSD-amd64-DAG: -framework bar
+// OPENBSD-amd64-DAG: -L baz
+// OPENBSD-amd64-DAG: -lboo
+// OPENBSD-amd64-DAG: -Xlinker -undefined
+// OPENBSD-amd64: -o linker
 
 
 // COMPLEX: {{(bin/)?}}ld{{"? }}

--- a/test/Parse/ConditionalCompilation/basicParseErrors.swift
+++ b/test/Parse/ConditionalCompilation/basicParseErrors.swift
@@ -78,6 +78,7 @@ struct S {
 // expected-note@-2{{did you mean 'FreeBSD'?}} {{8-15=FreeBSD}}
 // expected-note@-3{{did you mean 'Android'?}} {{8-15=Android}}
 // expected-note@-4{{did you mean 'OSX'?}} {{8-15=OSX}}
+// expected-note@-5{{did you mean 'OpenBSD'?}} {{8-15=OpenBSD}}
 #endif
 
 #if arch(leg) // expected-warning {{unknown architecture for build configuration 'arch'}} expected-note{{did you mean 'arm'?}} {{10-13=arm}}


### PR DESCRIPTION
Add the platform conditional and set up other basics for the toolchain.
    
The ConditionalCompilation tests are updated to match, since otherwise
they seem to trip when building on non-OpenBSD platforms.

This is orthogonal to pr #30082, which needs to wait for pending build system changes. This can proceed independently, but can wait if necessary.