### PR TITLE
[temp-rvalue] Handle promoting alloc_stack that are destroyed via a load [take] in ossa.

### DIFF
--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -18,6 +18,8 @@ class Klass {}
 
 sil @unknown : $@convention(thin) () -> ()
 
+sil @use_gsbase_builtinnativeobject : $@convention(thin) (@guaranteed GS<Builtin.NativeObject>) -> ()
+
 sil [ossa] @inguaranteed_user_without_result : $@convention(thin) (@in_guaranteed Klass) -> () {
 bb0(%0 : $*Klass):
   %9999 = tuple()
@@ -604,25 +606,17 @@ bb3:
   br bb2
 }
 
-///////////////////////////////////////////////////////////////////////////////
-// Test checkTempObjectDestroy
-// <rdar://problem/56393491> Use-after free crashing an XCTest.
-
 sil [ossa] @takeGuaranteedObj : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
 
-// Do not remove a copy that is released via a load (because
-// TempRValueOpt is an address-based optimization does not know how to
-// remove releases, and trying to do that would reduce to ARC
+// Now that we support ossa, eliminate the alloc_stack and change the load
+// [take] to a load [copy] in the process.
 //
-// optimization).
 // CHECK-LABEL: sil [ossa] @copyWithLoadRelease : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> () {
 // CHECK: bb0(%0 : $*Builtin.NativeObject):
-// CHECK:   [[STK:%.*]] = alloc_stack $Builtin.NativeObject
-// CHECK:   copy_addr %0 to [initialization] [[STK]] : $*Builtin.NativeObject
-// CHECK:   [[VAL:%.*]] = load [take] [[STK]] : $*Builtin.NativeObject
+// CHECK-NOT: alloc_stack
+// CHECK:   [[VAL:%.*]] = load [copy] %0 : $*Builtin.NativeObject
 // CHECK:   apply %{{.*}}([[VAL]]) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
 // CHECK:   destroy_value [[VAL]] : $Builtin.NativeObject
-// CHECK:   dealloc_stack [[STK]] : $*Builtin.NativeObject
 // CHECK-LABEL: } // end sil function 'copyWithLoadRelease'
 sil [ossa] @copyWithLoadRelease : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : $*Builtin.NativeObject):
@@ -637,7 +631,8 @@ bb0(%0 : $*Builtin.NativeObject):
   return %v : $()
 }
 
-// Remove a copy that is released via a load as long as it was a copy [take].
+// Remove a copy that is released via a load. Leave the load [take] alone since
+// our copy_addr is taking from source.
 //
 // CHECK-LABEL: sil [ossa] @takeWithLoadRelease : $@convention(thin) (@in Builtin.NativeObject) -> () {
 // CHECK: bb0(%0 : $*Builtin.NativeObject):
@@ -656,4 +651,86 @@ bb0(%0 : $*Builtin.NativeObject):
   dealloc_stack %stk : $*Builtin.NativeObject
   %v = tuple ()
   return %v : $()
+}
+
+// Do not remove a copy that is released via a load of a projection. This is not
+// the pattern from SILGen that we are targeting, so we reduce the state space by banning the pattern.
+//
+// CHECK-LABEL: sil [ossa] @takeWithLoadReleaseOfProjection : $@convention(thin) (@in GS<Builtin.NativeObject>) -> () {
+// CHECK: alloc_stack
+// CHECK: } // end sil function 'takeWithLoadReleaseOfProjection'
+sil [ossa] @takeWithLoadReleaseOfProjection : $@convention(thin) (@in GS<Builtin.NativeObject>) -> () {
+bb0(%0 : $*GS<Builtin.NativeObject>):
+  %stk = alloc_stack $GS<Builtin.NativeObject>
+  copy_addr [take] %0 to [initialization] %stk : $*GS<Builtin.NativeObject>
+  %proj = struct_element_addr %stk : $*GS<Builtin.NativeObject>, #GS._base
+  %obj = load [take] %proj : $*Builtin.NativeObject
+  %f = function_ref @takeGuaranteedObj : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %call = apply %f(%obj) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  destroy_value %obj : $Builtin.NativeObject
+  dealloc_stack %stk : $*GS<Builtin.NativeObject>
+  %v = tuple ()
+  return %v : $()
+}
+
+// Make sure that when we convert the load [take] to a load [copy], we hoist the
+// load of src /before/ the destroy of %0.
+// CHECK-LABEL: sil [ossa] @hoist_load_copy_to_src_copy_addr_site : $@convention(thin) (@in GS<Builtin.NativeObject>) -> @owned GS<Builtin.NativeObject> {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[VAL:%.*]] = load [copy] [[ARG]]
+// CHECK:   destroy_addr [[ARG]]
+// CHECK:   apply {{%.*}}([[VAL]])
+// CHECK:   return [[VAL]]
+// CHECK: } // end sil function 'hoist_load_copy_to_src_copy_addr_site'
+sil [ossa] @hoist_load_copy_to_src_copy_addr_site : $@convention(thin) (@in GS<Builtin.NativeObject>) -> @owned GS<Builtin.NativeObject> {
+bb0(%0 : $*GS<Builtin.NativeObject>):
+  %f = function_ref @use_gsbase_builtinnativeobject : $@convention(thin) (@guaranteed GS<Builtin.NativeObject>) -> ()
+  %stk = alloc_stack $GS<Builtin.NativeObject>
+  copy_addr %0 to [initialization] %stk : $*GS<Builtin.NativeObject>
+  destroy_addr %0 : $*GS<Builtin.NativeObject>
+  %obj = load [take] %stk : $*GS<Builtin.NativeObject>
+  dealloc_stack %stk : $*GS<Builtin.NativeObject>
+  apply %f(%obj) : $@convention(thin) (@guaranteed GS<Builtin.NativeObject>) -> ()
+  return %obj : $GS<Builtin.NativeObject>
+}
+
+// CHECK-LABEL: sil [ossa] @hoist_load_copy_to_src_copy_addr_site_two_takes : $@convention(thin) (@in GS<Builtin.NativeObject>) -> @owned GS<Builtin.NativeObject> {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[COPY_1:%.*]] = load [copy] [[ARG]]
+// CHECK:   [[COPY_2:%.*]] = load [copy] [[ARG]]
+// CHECK:   destroy_addr [[ARG]]
+// CHECK:   cond_br undef, bb1, bb2
+//
+// CHECK: bb1:
+// CHECK:   destroy_value [[COPY_1]]
+// CHECK:   br bb3([[COPY_2]] :
+//
+// CHECK: bb2:
+// CHECK:   destroy_value [[COPY_2]]
+// CHECK:   br bb3([[COPY_1]] :
+//
+// CHECK: bb3([[RESULT:%.*]] : @owned
+// CHECK:   apply {{%.*}}([[RESULT]])
+// CHECK:   return [[RESULT]]
+// CHECK: } // end sil function 'hoist_load_copy_to_src_copy_addr_site_two_takes'
+sil [ossa] @hoist_load_copy_to_src_copy_addr_site_two_takes : $@convention(thin) (@in GS<Builtin.NativeObject>) -> @owned GS<Builtin.NativeObject> {
+bb0(%0 : $*GS<Builtin.NativeObject>):
+  %f = function_ref @use_gsbase_builtinnativeobject : $@convention(thin) (@guaranteed GS<Builtin.NativeObject>) -> ()
+  %stk = alloc_stack $GS<Builtin.NativeObject>
+  copy_addr %0 to [initialization] %stk : $*GS<Builtin.NativeObject>
+  destroy_addr %0 : $*GS<Builtin.NativeObject>
+  cond_br undef, bb1, bb2
+
+bb1:
+  %obj = load [take] %stk : $*GS<Builtin.NativeObject>
+  br bb3(%obj : $GS<Builtin.NativeObject>)
+
+bb2:
+  %obj2 = load [take] %stk : $*GS<Builtin.NativeObject>
+  br bb3(%obj2 : $GS<Builtin.NativeObject>)
+
+bb3(%obj3 : @owned $GS<Builtin.NativeObject>):
+  dealloc_stack %stk : $*GS<Builtin.NativeObject>
+  apply %f(%obj3) : $@convention(thin) (@guaranteed GS<Builtin.NativeObject>) -> ()
+  return %obj3 : $GS<Builtin.NativeObject>
 }


### PR DESCRIPTION
There are a few interesting things here:

1. All of this code is conditionalized implicitly on ossa by us checking for
load [take]. If we are in non-ossa, then we will have unqualified loads and this
code path will be skipped. I left in the old test that made sure we did not
support this in non-ossa code for this purpose.

2. We treat the load [take] like a destroy_addr. Thus the current method of
providing safety via using lifetime analysis to show all "destroys" form a
minimal post-dominating set for the copy_addr.

3. We do not allow for load [take] on sub-element initializations. The reason
why is that SILGen initializes temporaries completely in memory and generally
destroys addresses completely as well. Given that is the pattern we are looking
for, we just reduce the state space by banning this pattern.

4. If we have a copy_addr [init], then we not only change the load [take] to
have the original source address as an argument, but we also change the load
[take] to a load [copy] so we don't lose the +1.

I am doing this to clean up some simple temp rvalue patterns in SIL before
semantic arc opts runs. This ensures that we are more likely to have a load
operation come from a more meaningful semantic entity (for instance a let field
of a guaranteed class) and thus allow us to convert a load [copy] to a
load_borrow.

I am also going to add support in subsequent commits for eliminating alloc_stack
that are stored into as well (another pattern I am seeing).

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
