### PR TITLE
[metadata prespecialization] Support for classes.

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1025,7 +1025,7 @@ struct TargetAnyClassMetadata : public TargetHeapMetadata<Runtime> {
   using TargetMetadata<Runtime>::setClassISA;
 #endif
 
-  // Note that ObjC classes does not have a metadata header.
+  // Note that ObjC classes do not have a metadata header.
 
   /// The metadata for the superclass.  This is null for the root class.
   ConstTargetMetadataPointer<Runtime, swift::TargetClassMetadata> Superclass;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -852,7 +852,17 @@ public:
   /// \returns The superclass of this type, or a null type if it has no
   ///          superclass.
   Type getSuperclass(bool useArchetypes = true);
-  
+
+  /// Retrieve the root class of this type by repeatedly retrieving the
+  /// superclass.
+  ///
+  /// \param useArchetypes Whether to use context archetypes for outer generic
+  /// parameters if the class is nested inside a generic function.
+  ///
+  /// \returns The base class of this type, or this type itself if it has no
+  ///          superclasses.
+  Type getRootClass(bool useArchetypes = true);
+
   /// True if this type is the exact superclass of another type.
   ///
   /// \param ty       The potential subclass.

--- a/include/swift/Demangling/DemangleNodes.def
+++ b/include/swift/Demangling/DemangleNodes.def
@@ -287,5 +287,9 @@ NODE(OpaqueTypeDescriptorAccessorVar)
 NODE(OpaqueReturnType)
 CONTEXT_NODE(OpaqueReturnTypeOf)
 
+// Added in Swift 5.3
+NODE(CanonicalSpecializedGenericMetaclass)
+NODE(CanonicalSpecializedGenericTypeMetadataAccessFunction)
+
 #undef CONTEXT_NODE
 #undef NODE

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -193,7 +193,7 @@ class LinkEntity {
     /// The nominal type descriptor for a nominal type.
     /// The pointer is a NominalTypeDecl*.
     NominalTypeDescriptor,
-    
+
     /// The descriptor for an opaque type.
     /// The pointer is an OpaqueTypeDecl*.
     OpaqueTypeDescriptor,
@@ -295,12 +295,12 @@ class LinkEntity {
     /// The descriptor for an extension.
     /// The pointer is an ExtensionDecl*.
     ExtensionDescriptor,
-    
+
     /// The descriptor for a runtime-anonymous context.
     /// The pointer is the DeclContext* of a child of the context that should
     /// be considered private.
     AnonymousDescriptor,
-    
+
     /// A SIL global variable. The pointer is a SILGlobalVariable*.
     SILGlobalVariable,
 
@@ -384,6 +384,15 @@ class LinkEntity {
 
     /// A global function pointer for dynamically replaceable functions.
     DynamicallyReplaceableFunctionVariable,
+
+    /// A reference to a metaclass-stub for a statically specialized generic
+    /// class.
+    /// The pointer is a canonical TypeBase*.
+    CanonicalSpecializedGenericSwiftMetaclassStub,
+
+    /// An access function for prespecialized type metadata.
+    /// The pointer is a canonical TypeBase*.
+    CanonicalSpecializedGenericTypeMetadataAccessFunction,
   };
   friend struct llvm::DenseMapInfo<LinkEntity>;
 
@@ -1017,6 +1026,22 @@ public:
     LinkEntity entity;
     entity.setForDecl(Kind::DynamicallyReplaceableFunctionImpl, decl);
     entity.SecondaryPointer = isAllocator ? decl : nullptr;
+    return entity;
+  }
+
+  static LinkEntity
+  forSpecializedGenericSwiftMetaclassStub(CanType concreteType) {
+    LinkEntity entity;
+    entity.setForType(Kind::CanonicalSpecializedGenericSwiftMetaclassStub,
+                      concreteType);
+    return entity;
+  }
+
+  static LinkEntity
+  forPrespecializedTypeMetadataAccessFunction(CanType theType) {
+    LinkEntity entity;
+    entity.setForType(
+        Kind::CanonicalSpecializedGenericTypeMetadataAccessFunction, theType);
     return entity;
   }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1546,6 +1546,17 @@ Type TypeBase::getSuperclass(bool useArchetypes) {
   return superclassTy.subst(subMap);
 }
 
+Type TypeBase::getRootClass(bool useArchetypes) {
+  Type iterator = this;
+  assert(iterator);
+
+  while (auto superclass = iterator->getSuperclass(useArchetypes)) {
+    iterator = superclass;
+  }
+
+  return iterator;
+}
+
 bool TypeBase::isExactSuperclassOf(Type ty) {
   // For there to be a superclass relationship, we must be a class, and
   // the potential subtype must be a class, superclass-bounded archetype,

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -1874,6 +1874,9 @@ NodePointer Demangler::demangleMetatype() {
     case 'A':
       return createWithChild(Node::Kind::ReflectionMetadataAssocTypeDescriptor,
                              popProtocolConformance());
+    case 'b':
+      return createWithPoppedType(
+          Node::Kind::CanonicalSpecializedGenericTypeMetadataAccessFunction);
     case 'B':
       return createWithChild(Node::Kind::ReflectionMetadataBuiltinDescriptor,
                                popNode(Node::Kind::Type));
@@ -1917,6 +1920,9 @@ NodePointer Demangler::demangleMetatype() {
       return createWithPoppedType(Node::Kind::TypeMetadataLazyCache);
     case 'm':
       return createWithPoppedType(Node::Kind::Metaclass);
+    case 'M':
+      return createWithPoppedType(
+          Node::Kind::CanonicalSpecializedGenericMetaclass);
     case 'n':
       return createWithPoppedType(Node::Kind::NominalTypeDescriptor);
     case 'o':

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -540,6 +540,8 @@ private:
     case Node::Kind::OpaqueTypeDescriptorSymbolicReference:
     case Node::Kind::OpaqueReturnType:
     case Node::Kind::OpaqueReturnTypeOf:
+    case Node::Kind::CanonicalSpecializedGenericMetaclass:
+    case Node::Kind::CanonicalSpecializedGenericTypeMetadataAccessFunction:
       return false;
     }
     printer_unreachable("bad node kind");
@@ -2417,6 +2419,14 @@ NodePointer NodePrinter::print(NodePointer Node, bool asPrefixContext) {
     return nullptr;
   case Node::Kind::AccessorFunctionReference:
     Printer << "accessor function at " << Node->getIndex();
+    return nullptr;
+  case Node::Kind::CanonicalSpecializedGenericMetaclass:
+    Printer << "specialized generic metaclass for ";
+    print(Node->getFirstChild());
+    return nullptr;
+  case Node::Kind::CanonicalSpecializedGenericTypeMetadataAccessFunction:
+    Printer << "canonical specialized generic type metadata accessor for ";
+    print(Node->getChild(0));
     return nullptr;
   }
   printer_unreachable("bad node kind!");

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -2133,6 +2133,17 @@ void Remangler::mangleAccessorFunctionReference(Node *node) {
   unreachable("can't remangle");
 }
 
+void Remangler::mangleCanonicalSpecializedGenericMetaclass(Node *node) {
+  Buffer << "MM";
+  mangleSingleChildNode(node); // type
+}
+
+void Remangler::mangleCanonicalSpecializedGenericTypeMetadataAccessFunction(
+    Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "Mb";
+}
+
 /// The top-level interface to the remangler.
 std::string Demangle::mangleNodeOld(NodePointer node) {
   if (!node) return "";

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -2533,6 +2533,17 @@ void Remangler::mangleAccessorFunctionReference(Node *node) {
   unreachable("can't remangle");
 }
 
+void Remangler::mangleCanonicalSpecializedGenericMetaclass(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "MM";
+}
+
+void Remangler::mangleCanonicalSpecializedGenericTypeMetadataAccessFunction(
+    Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "Mb";
+}
+
 } // anonymous namespace
 
 /// The top-level interface to the remangler.

--- a/lib/IRGen/ClassTypeInfo.h
+++ b/lib/IRGen/ClassTypeInfo.h
@@ -1,0 +1,66 @@
+//===--- ClassTypeInfo.h - The layout info for class types. -----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file contains layout information for class types.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_IRGEN_CLASSTYPEINFO_H
+#define SWIFT_IRGEN_CLASSTYPEINFO_H
+
+#include "ClassLayout.h"
+#include "HeapTypeInfo.h"
+
+namespace swift {
+namespace irgen {
+
+/// Layout information for class types.
+class ClassTypeInfo : public HeapTypeInfo<ClassTypeInfo> {
+  ClassDecl *TheClass;
+
+  // The resilient layout of the class, without making any assumptions
+  // that violate resilience boundaries. This is used to allocate
+  // and deallocate instances of the class, and to access fields.
+  mutable Optional<ClassLayout> ResilientLayout;
+
+  // A completely fragile layout, used for metadata emission.
+  mutable Optional<ClassLayout> FragileLayout;
+
+  /// Can we use swift reference-counting, or do we have to use
+  /// objc_retain/release?
+  const ReferenceCounting Refcount;
+
+  ClassLayout generateLayout(IRGenModule &IGM, SILType classType,
+                             bool forBackwardDeployment) const;
+
+public:
+  ClassTypeInfo(llvm::PointerType *irType, Size size, SpareBitVector spareBits,
+                Alignment align, ClassDecl *theClass,
+                ReferenceCounting refcount)
+      : HeapTypeInfo(irType, size, std::move(spareBits), align),
+        TheClass(theClass), Refcount(refcount) {}
+
+  ReferenceCounting getReferenceCounting() const { return Refcount; }
+
+  ClassDecl *getClass() const { return TheClass; }
+
+  const ClassLayout &getClassLayout(IRGenModule &IGM, SILType type,
+                                    bool forBackwardDeployment) const;
+
+  StructLayout *createLayoutWithTailElems(IRGenModule &IGM, SILType classType,
+                                          ArrayRef<SILType> tailTypes) const;
+};
+
+} // namespace irgen
+} // namespace swift
+
+#endif

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -32,6 +32,7 @@
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILType.h"
 #include "swift/SIL/SILVTableVisitor.h"
+#include "llvm/ADT/None.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Function.h"
@@ -40,72 +41,29 @@
 
 #include "Callee.h"
 #include "ClassLayout.h"
+#include "ClassTypeInfo.h"
 #include "ConstantBuilder.h"
 #include "Explosion.h"
 #include "GenFunc.h"
+#include "GenHeap.h"
 #include "GenMeta.h"
 #include "GenObjC.h"
 #include "GenPointerAuth.h"
 #include "GenProto.h"
 #include "GenType.h"
+#include "HeapTypeInfo.h"
 #include "IRGenDebugInfo.h"
 #include "IRGenFunction.h"
 #include "IRGenModule.h"
-#include "GenHeap.h"
-#include "HeapTypeInfo.h"
 #include "MemberAccessStrategy.h"
 #include "MetadataLayout.h"
 #include "MetadataRequest.h"
 
-
 using namespace swift;
 using namespace irgen;
 
-namespace {
-  /// Layout information for class types.
-  class ClassTypeInfo : public HeapTypeInfo<ClassTypeInfo> {
-    ClassDecl *TheClass;
-
-    // The resilient layout of the class, without making any assumptions
-    // that violate resilience boundaries. This is used to allocate
-    // and deallocate instances of the class, and to access fields.
-    mutable Optional<ClassLayout> ResilientLayout;
-
-    // A completely fragile layout, used for metadata emission.
-    mutable Optional<ClassLayout> FragileLayout;
-
-    /// Can we use swift reference-counting, or do we have to use
-    /// objc_retain/release?
-    const ReferenceCounting Refcount;
-    
-    ClassLayout generateLayout(IRGenModule &IGM, SILType classType,
-                               bool forBackwardDeployment) const;
-
-  public:
-    ClassTypeInfo(llvm::PointerType *irType, Size size,
-                  SpareBitVector spareBits, Alignment align,
-                  ClassDecl *theClass, ReferenceCounting refcount)
-      : HeapTypeInfo(irType, size, std::move(spareBits), align),
-        TheClass(theClass), Refcount(refcount) {}
-
-    ReferenceCounting getReferenceCounting() const {
-      return Refcount;
-    }
-
-    ClassDecl *getClass() const { return TheClass; }
-
-
-    const ClassLayout &getClassLayout(IRGenModule &IGM, SILType type,
-                                      bool forBackwardDeployment) const;
-
-    StructLayout *createLayoutWithTailElems(IRGenModule &IGM,
-                                            SILType classType,
-                                            ArrayRef<SILType> tailTypes) const;
-  };
-} // end anonymous namespace
-
 /// Return the lowered type for the class's 'self' type within its context.
-static SILType getSelfType(const ClassDecl *base) {
+SILType irgen::getSelfType(const ClassDecl *base) {
   auto loweredTy = base->getDeclaredTypeInContext()->getCanonicalType();
   return SILType::getPrimitiveObjectType(loweredTy);
 }
@@ -328,12 +286,17 @@ namespace {
         auto element = ElementLayout::getIncomplete(*eltType);
         bool isKnownEmpty = !addField(element, LayoutStrategy::Universal);
 
+        bool isSpecializedGeneric =
+            (theClass->isGenericContext() && !classType.getASTType()
+                                                  ->getRecursiveProperties()
+                                                  .hasUnboundGeneric());
+
         // The 'Elements' list only contains superclass fields when we're
         // building a layout for tail allocation.
-        if (!superclass || TailTypes)
+        if (!superclass || TailTypes || isSpecializedGeneric)
           Elements.push_back(element);
 
-        if (!superclass) {
+        if (!superclass || isSpecializedGeneric) {
           AllStoredProperties.push_back(var);
           AllFieldAccesses.push_back(getFieldAccess(isKnownEmpty));
         }
@@ -964,26 +927,49 @@ namespace {
   /// category data (category_t), or protocol data (protocol_t).
   class ClassDataBuilder : public ClassMemberVisitor<ClassDataBuilder> {
     IRGenModule &IGM;
-    PointerUnion<ClassDecl *, ProtocolDecl *> TheEntity;
+    using ClassPair = std::pair<ClassDecl *, CanType>;
+    using ClassUnion = TaggedUnion<ClassDecl *, ClassPair>;
+    TaggedUnion<ClassUnion, ProtocolDecl *> TheEntity;
     ExtensionDecl *TheExtension;
     const ClassLayout *FieldLayout;
     
     ClassDecl *getClass() const {
-      return TheEntity.get<ClassDecl*>();
+      const ClassUnion *classUnion;
+      if (!(classUnion = TheEntity.dyn_cast<ClassUnion>())) {
+        return nullptr;
+      }
+      if (auto *const *theClass = classUnion->dyn_cast<ClassDecl *>()) {
+        return *theClass;
+      }
+      auto pair = classUnion->get<ClassPair>();
+      return pair.first;
     }
     ProtocolDecl *getProtocol() const {
-      return TheEntity.get<ProtocolDecl*>();
+      if (auto *const *theProtocol = TheEntity.dyn_cast<ProtocolDecl *>()) {
+        return *theProtocol;
+      }
+      return nullptr;
     }
-    
+    Optional<CanType> getSpecializedGenericType() const {
+      const ClassUnion *classUnion;
+      if (!(classUnion = TheEntity.dyn_cast<ClassUnion>())) {
+        return llvm::None;
+      }
+      const ClassPair *classPair;
+      if (!(classPair = classUnion->dyn_cast<ClassPair>())) {
+        return llvm::None;
+      }
+      auto &pair = *classPair;
+      return pair.second;
+    }
+
     bool isBuildingClass() const {
-      return TheEntity.is<ClassDecl*>() && !TheExtension;
+      return TheEntity.isa<ClassUnion>() && !TheExtension;
     }
     bool isBuildingCategory() const {
-      return TheEntity.is<ClassDecl*>() && TheExtension;
+      return TheEntity.isa<ClassUnion>() && TheExtension;
     }
-    bool isBuildingProtocol() const {
-      return TheEntity.is<ProtocolDecl*>();
-    }
+    bool isBuildingProtocol() const { return TheEntity.isa<ProtocolDecl *>(); }
 
     bool HasNonTrivialDestructor = false;
     bool HasNonTrivialConstructor = false;
@@ -1063,23 +1049,27 @@ namespace {
   public:
     ClassDataBuilder(IRGenModule &IGM, ClassDecl *theClass,
                      const ClassLayout &fieldLayout)
-        : IGM(IGM), TheEntity(theClass), TheExtension(nullptr),
-          FieldLayout(&fieldLayout)
-    {
-      visitConformances(theClass);
-      visitMembers(theClass);
+        : ClassDataBuilder(IGM, ClassUnion(theClass), fieldLayout) {}
 
-      if (Lowering::usesObjCAllocator(theClass)) {
-        addIVarInitializer(); 
-        addIVarDestroyer(); 
+    ClassDataBuilder(
+        IRGenModule &IGM,
+        TaggedUnion<ClassDecl *, std::pair<ClassDecl *, CanType>> theUnion,
+        const ClassLayout &fieldLayout)
+        : IGM(IGM), TheEntity(theUnion), TheExtension(nullptr),
+          FieldLayout(&fieldLayout) {
+      visitConformances(getClass());
+      visitMembers(getClass());
+
+      if (Lowering::usesObjCAllocator(getClass())) {
+        addIVarInitializer();
+        addIVarDestroyer();
       }
     }
-    
+
     ClassDataBuilder(IRGenModule &IGM, ClassDecl *theClass,
                      ExtensionDecl *theExtension)
-      : IGM(IGM), TheEntity(theClass), TheExtension(theExtension),
-        FieldLayout(nullptr)
-    {
+        : IGM(IGM), TheEntity(ClassUnion(theClass)), TheExtension(theExtension),
+          FieldLayout(nullptr) {
       buildCategoryName(CategoryName);
 
       visitConformances(theExtension);
@@ -1087,7 +1077,7 @@ namespace {
       for (Decl *member : TheExtension->getMembers())
         visit(member);
     }
-    
+
     ClassDataBuilder(IRGenModule &IGM, ProtocolDecl *theProtocol)
       : IGM(IGM), TheEntity(theProtocol), TheExtension(nullptr)
     {
@@ -1143,7 +1133,12 @@ namespace {
       }
     }
 
-    llvm::Constant *getMetaclassRefOrNull(ClassDecl *theClass) {
+    llvm::Constant *getMetaclassRefOrNull(Type specializedGenericType,
+                                          ClassDecl *theClass) {
+      if (specializedGenericType) {
+        return IGM.getAddrOfCanonicalSpecializedGenericMetaclassObject(
+            specializedGenericType->getCanonicalType(), NotForDefinition);
+      }
       if (theClass->isGenericContext() && !theClass->hasClangNode()) {
         return llvm::ConstantPointerNull::get(IGM.ObjCClassPtrTy);
       } else {
@@ -1153,9 +1148,20 @@ namespace {
 
     void buildMetaclassStub() {
       assert(FieldLayout && "can't build a metaclass from a category");
+
+      auto specializedGenericType = getSpecializedGenericType().map(
+          [](auto canType) { return (Type)canType; });
+
       // The isa is the metaclass pointer for the root class.
-      auto rootClass = getRootClassForMetaclass(IGM, TheEntity.get<ClassDecl *>());
-      auto rootPtr = getMetaclassRefOrNull(rootClass);
+      auto rootClass = getRootClassForMetaclass(IGM, getClass());
+      Type rootType;
+      if (specializedGenericType && rootClass->isGenericContext()) {
+        rootType =
+            (*specializedGenericType)->getRootClass(/*useArchetypes=*/false);
+      } else {
+        rootType = Type();
+      }
+      auto rootPtr = getMetaclassRefOrNull(rootType, rootClass);
 
       // The superclass of the metaclass is the metaclass of the
       // superclass.  Note that for metaclass stubs, we can always
@@ -1166,10 +1172,16 @@ namespace {
       llvm::Constant *superPtr;
       if (getClass()->hasSuperclass()) {
         auto base = getClass()->getSuperclassDecl();
-        superPtr = getMetaclassRefOrNull(base);
+        if (specializedGenericType && base->isGenericContext()) {
+          superPtr = getMetaclassRefOrNull(
+              (*specializedGenericType)->getSuperclass(/*useArchetypes=*/false),
+              base);
+        } else {
+          superPtr = getMetaclassRefOrNull(Type(), base);
+        }
       } else {
         superPtr = getMetaclassRefOrNull(
-          IGM.getObjCRuntimeBaseForSwiftRootClass(getClass()));
+            Type(), IGM.getObjCRuntimeBaseForSwiftRootClass(getClass()));
       }
 
       auto dataPtr = emitROData(ForMetaClass, DoesNotHaveUpdateCallback);
@@ -1184,9 +1196,16 @@ namespace {
       };
       auto init = llvm::ConstantStruct::get(IGM.ObjCClassStructTy,
                                             makeArrayRef(fields));
-      auto metaclass =
-        cast<llvm::GlobalVariable>(
-                     IGM.getAddrOfMetaclassObject(getClass(), ForDefinition));
+      llvm::Constant *uncastMetaclass;
+      if (auto theType = getSpecializedGenericType()) {
+        uncastMetaclass =
+            IGM.getAddrOfCanonicalSpecializedGenericMetaclassObject(
+                *theType, ForDefinition);
+      } else {
+        uncastMetaclass =
+            IGM.getAddrOfMetaclassObject(getClass(), ForDefinition);
+      }
+      auto metaclass = cast<llvm::GlobalVariable>(uncastMetaclass);
       metaclass->setInitializer(init);
     }
     
@@ -1349,9 +1368,20 @@ namespace {
         b.addInt32(0);
       }
 
-      //   const uint8_t *ivarLayout;
-      // GC/ARC layout.  TODO.
-      b.addNullPointer(IGM.Int8PtrTy);
+      // union {
+      //     const uint8_t *IvarLayout;
+      //     ClassMetadata *NonMetaClass;
+      // };
+      Optional<CanType> specializedGenericType;
+      if ((specializedGenericType = getSpecializedGenericType()) && forMeta) {
+        //     ClassMetadata *NonMetaClass;
+        b.addBitCast(IGM.getAddrOfTypeMetadata(*specializedGenericType),
+                     IGM.Int8PtrTy);
+      } else {
+        //     const uint8_t *IvarLayout;
+        // GC/ARC layout.  TODO.
+        b.addNullPointer(IGM.Int8PtrTy);
+      }
 
       //   const char *name;
       // It is correct to use the same name for both class and metaclass.
@@ -1383,9 +1413,8 @@ namespace {
       if (hasUpdater) {
         //   Class _Nullable (*metadataUpdateCallback)(Class _Nonnull cls,
         //                                             void * _Nullable arg);
-        auto *impl = IGM.getAddrOfObjCMetadataUpdateFunction(
-                TheEntity.get<ClassDecl *>(),
-                NotForDefinition);
+        auto *impl = IGM.getAddrOfObjCMetadataUpdateFunction(getClass(),
+                                                             NotForDefinition);
         const auto &schema =
           IGM.getOptions().PointerAuth.ObjCMethodListFunctionPointers;
         b.addSignedPointer(impl, schema, PointerAuthEntity());
@@ -1995,14 +2024,14 @@ namespace {
     /// Get the name of the class or protocol to mangle into the ObjC symbol
     /// name.
     StringRef getEntityName(llvm::SmallVectorImpl<char> &buffer) const {
-      if (auto theClass = TheEntity.dyn_cast<ClassDecl*>()) {
+      if (auto theClass = getClass()) {
         return theClass->getObjCRuntimeName(buffer);
       }
-      
-      if (auto theProtocol = TheEntity.dyn_cast<ProtocolDecl*>()) {
+
+      if (auto theProtocol = getProtocol()) {
         return theProtocol->getObjCRuntimeName(buffer);
       }
-      
+
       llvm_unreachable("not a class or protocol?!");
     }
 
@@ -2137,18 +2166,27 @@ void IRGenModule::emitObjCResilientClassStub(ClassDecl *D) {
   defineAlias(entity, objcStub);
 }
 
-/// Emit the private data (RO-data) associated with a class.
-llvm::Constant *irgen::emitClassPrivateData(IRGenModule &IGM,
-                                            ClassDecl *cls) {
+static llvm::Constant *doEmitClassPrivateData(
+    IRGenModule &IGM,
+    TaggedUnion<ClassDecl *, std::pair<ClassDecl *, CanType>> classUnion) {
   assert(IGM.ObjCInterop && "emitting RO-data outside of interop mode");
-  PrettyStackTraceDecl stackTraceRAII("emitting ObjC metadata for", cls);
+
+  ClassDecl *cls;
+
+  if (auto *theClass = classUnion.dyn_cast<ClassDecl *>()) {
+    cls = *theClass;
+  } else {
+    auto pair = classUnion.get<std::pair<ClassDecl *, CanType>>();
+    cls = pair.first;
+  }
+
   SILType selfType = getSelfType(cls);
   auto &classTI = IGM.getTypeInfo(selfType).as<ClassTypeInfo>();
 
   // FIXME: For now, always use the fragile layout when emitting metadata.
   auto &fieldLayout = classTI.getClassLayout(IGM, selfType,
                                              /*forBackwardDeployment=*/true);
-  ClassDataBuilder builder(IGM, cls, fieldLayout);
+  ClassDataBuilder builder(IGM, classUnion, fieldLayout);
 
   // First, build the metaclass object.
   builder.buildMetaclassStub();
@@ -2169,6 +2207,25 @@ llvm::Constant *irgen::emitClassPrivateData(IRGenModule &IGM,
 
   // Then build the class RO-data.
   return builder.emitROData(ForClass, hasUpdater);
+}
+
+llvm::Constant *irgen::emitSpecializedGenericClassPrivateData(
+    IRGenModule &IGM, ClassDecl *theClass, CanType theType) {
+  assert(theType->getClassOrBoundGenericClass() == theClass);
+  assert(theClass->getGenericEnvironment());
+  Type ty = theType;
+  PrettyStackTraceType stackTraceRAII(theClass->getASTContext(),
+                                      "emitting ObjC metadata for", ty);
+  return doEmitClassPrivateData(
+      IGM, TaggedUnion<ClassDecl *, std::pair<ClassDecl *, CanType>>(
+               std::make_pair(theClass, theType)));
+}
+
+/// Emit the private data (RO-data) associated with a class.
+llvm::Constant *irgen::emitClassPrivateData(IRGenModule &IGM, ClassDecl *cls) {
+  PrettyStackTraceDecl stackTraceRAII("emitting ObjC metadata for", cls);
+  return doEmitClassPrivateData(
+      IGM, TaggedUnion<ClassDecl *, std::pair<ClassDecl *, CanType>>(cls));
 }
 
 std::pair<Size, Size>

--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -51,6 +51,9 @@ namespace irgen {
   enum class ClassDeallocationKind : unsigned char;
   enum class FieldAccess : uint8_t;
 
+  /// Return the lowered type for the class's 'self' type within its context.
+  SILType getSelfType(const ClassDecl *base);
+
   OwnedAddress projectPhysicalClassMemberAddress(
       IRGenFunction &IGF, llvm::Value *base,
       SILType baseType, SILType fieldType, VarDecl *field);
@@ -118,6 +121,11 @@ namespace irgen {
                              ClassDecl *cls);
   
   llvm::Constant *emitClassPrivateData(IRGenModule &IGM, ClassDecl *theClass);
+
+  llvm::Constant *emitSpecializedGenericClassPrivateData(IRGenModule &IGM,
+                                                         ClassDecl *theClass,
+                                                         CanType theType);
+
   void emitGenericClassPrivateDataTemplate(IRGenModule &IGM,
                                       ClassDecl *theClass,
                                       llvm::SmallVectorImpl<llvm::Constant*> &fields,

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -38,6 +38,7 @@
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/GlobalDecl.h"
 #include "llvm/ADT/SmallString.h"
+#include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/GlobalAlias.h"
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/Module.h"
@@ -1164,7 +1165,8 @@ void IRGenerator::emitLazyDefinitions() {
          !LazyOpaqueTypeDescriptors.empty() ||
          !LazyFieldDescriptors.empty() ||
          !LazyFunctionDefinitions.empty() ||
-         !LazyWitnessTables.empty()) {
+         !LazyWitnessTables.empty() ||
+         !LazyCanonicalSpecializedMetadataAccessors.empty()) {
 
     // Emit any lazy type metadata we require.
     while (!LazyTypeMetadata.empty()) {
@@ -1219,6 +1221,15 @@ void IRGenerator::emitLazyDefinitions() {
       assert(!f->isPossiblyUsedExternally()
              && "function with externally-visible linkage emitted lazily?");
       IGM->emitSILFunction(f);
+    }
+
+    while (!LazyCanonicalSpecializedMetadataAccessors.empty()) {
+      CanType theType =
+          LazyCanonicalSpecializedMetadataAccessors.pop_back_val();
+      auto *nominal = theType->getAnyNominal();
+      assert(nominal);
+      CurrentIGMPtr IGM = getGenModule(nominal->getDeclContext());
+      emitLazyCanonicalSpecializedMetadataAccessor(*IGM.get(), theType);
     }
   }
 
@@ -1394,14 +1405,30 @@ void IRGenerator::noteUseOfFieldDescriptor(NominalTypeDecl *type) {
   LazyFieldDescriptors.push_back(type);
 }
 
+void IRGenerator::noteUseOfCanonicalSpecializedMetadataAccessor(
+    CanType forType) {
+  auto key = forType->getAnyNominal();
+  assert(key);
+  assert(key->isGenericContext());
+  auto &enqueuedSpecializedAccessors =
+      CanonicalSpecializedAccessorsForGenericTypes[key];
+  if (llvm::all_of(enqueuedSpecializedAccessors,
+                   [&](CanType enqueued) { return enqueued != forType; })) {
+    assert(!FinishedEmittingLazyDefinitions);
+    LazyCanonicalSpecializedMetadataAccessors.insert(forType);
+    enqueuedSpecializedAccessors.push_back(forType);
+  }
+}
+
 void IRGenerator::noteUseOfSpecializedGenericTypeMetadata(CanType type) {
   auto key = type->getAnyNominal();
   assert(key);
-  auto &enqueuedSpecializedTypes = this->SpecializationsForGenericTypes[key];
+  assert(key->isGenericContext());
+  auto &enqueuedSpecializedTypes = CanonicalSpecializationsForGenericTypes[key];
   if (llvm::all_of(enqueuedSpecializedTypes,
                    [&](CanType enqueued) { return enqueued != type; })) {
     assert(!FinishedEmittingLazyDefinitions);
-    this->LazySpecializedTypeMetadataRecords.push_back(type);
+    LazySpecializedTypeMetadataRecords.push_back(type);
     enqueuedSpecializedTypes.push_back(type);
   }
 }
@@ -3516,6 +3543,22 @@ IRGenModule::getAddrOfMetaclassObject(ClassDecl *decl,
   return addr;
 }
 
+llvm::Constant *
+IRGenModule::getAddrOfCanonicalSpecializedGenericMetaclassObject(
+    CanType concreteType, ForDefinition_t forDefinition) {
+  auto *theClass = concreteType->getClassOrBoundGenericClass();
+  assert(theClass && "only classes have metaclasses");
+  assert(concreteType->getClassOrBoundGenericClass()->isGenericContext());
+
+  auto entity =
+      LinkEntity::forSpecializedGenericSwiftMetaclassStub(concreteType);
+
+  auto DbgTy = DebugTypeInfo::getObjCClass(
+      theClass, ObjCClassPtrTy, getPointerSize(), getPointerAlignment());
+  auto addr = getAddrOfLLVMVariable(entity, forDefinition, DbgTy);
+  return addr;
+}
+
 /// Fetch the declaration of an Objective-C metadata update callback.
 llvm::Function *
 IRGenModule::getAddrOfObjCMetadataUpdateFunction(ClassDecl *classDecl,
@@ -3635,6 +3678,38 @@ IRGenModule::getAddrOfGenericTypeMetadataAccessFunction(
   auto fnType = llvm::FunctionType::get(TypeMetadataResponseTy,
                                         paramTypes, false);
   Signature signature(fnType, llvm::AttributeList(), SwiftCC);
+  LinkInfo link = LinkInfo::get(*this, entity, forDefinition);
+  entry = createFunction(*this, link, signature);
+  return entry;
+}
+
+llvm::Function *
+IRGenModule::getAddrOfCanonicalSpecializedGenericTypeMetadataAccessFunction(
+    CanType theType, ForDefinition_t forDefinition) {
+  assert(shouldPrespecializeGenericMetadata());
+  assert(!theType->hasUnboundGenericType());
+  auto *nominal = theType->getAnyNominal();
+  assert(nominal);
+  assert(nominal->isGenericContext());
+
+  IRGen.noteUseOfCanonicalSpecializedMetadataAccessor(theType);
+
+  LinkEntity entity =
+      LinkEntity::forPrespecializedTypeMetadataAccessFunction(theType);
+  llvm::Function *&entry = GlobalFuncs[entity];
+  if (entry) {
+    if (forDefinition)
+      updateLinkageForDefinition(*this, entry, entity);
+    return entry;
+  }
+
+  llvm::Type *paramTypesArray[1];
+  paramTypesArray[0] = SizeTy; // MetadataRequest
+
+  auto paramTypes = llvm::makeArrayRef(paramTypesArray, 1);
+  auto functionType =
+      llvm::FunctionType::get(TypeMetadataResponseTy, paramTypes, false);
+  Signature signature(functionType, llvm::AttributeList(), SwiftCC);
   LinkInfo link = LinkInfo::get(*this, entity, forDefinition);
   entry = createFunction(*this, link, signature);
   return entry;
@@ -3826,14 +3901,19 @@ ConstantReference IRGenModule::getAddrOfTypeMetadata(CanType concreteType,
   llvm::Type *defaultVarTy;
   unsigned adjustmentIndex;
 
-  bool fullMetadata = (nominal && requiresForeignTypeMetadata(nominal)) ||
-                      (concreteType->getAnyGeneric() &&
-                       concreteType->getAnyGeneric()->isGenericContext());
+  bool foreign = nominal && requiresForeignTypeMetadata(nominal);
+  bool fullMetadata =
+      foreign || (concreteType->getAnyGeneric() &&
+                  concreteType->getAnyGeneric()->isGenericContext());
 
   // Foreign classes reference the full metadata with a GEP.
   if (fullMetadata) {
     defaultVarTy = FullTypeMetadataStructTy;
-    adjustmentIndex = MetadataAdjustmentIndex::ValueType;
+    if (concreteType->getClassOrBoundGenericClass() && !foreign) {
+      adjustmentIndex = MetadataAdjustmentIndex::Class;
+    } else {
+      adjustmentIndex = MetadataAdjustmentIndex::ValueType;
+    }
   // The symbol for other nominal type metadata is generated at the address
   // point.
   } else if (nominal) {
@@ -3870,19 +3950,24 @@ ConstantReference IRGenModule::getAddrOfTypeMetadata(CanType concreteType,
   if (fullMetadata) {
     entity = LinkEntity::forTypeMetadata(concreteType,
                                          TypeMetadataAddress::FullMetadata);
-    DbgTy = DebugTypeInfo::getMetadata(MetatypeType::get(concreteType),
-                                       defaultVarTy->getPointerTo(), Size(0),
-                                       Alignment(1));;
   } else {
     entity = LinkEntity::forTypeMetadata(concreteType,
                                          TypeMetadataAddress::AddressPoint);
-    DbgTy = DebugTypeInfo::getMetadata(MetatypeType::get(concreteType),
-                                       defaultVarTy->getPointerTo(), Size(0),
-                                       Alignment(1));;
+  }
+  DbgTy = DebugTypeInfo::getMetadata(MetatypeType::get(concreteType),
+                                     defaultVarTy->getPointerTo(), Size(0),
+                                     Alignment(1));
+
+  ConstantReference addr;
+
+  if (fullMetadata && !foreign) {
+    addr = getAddrOfLLVMVariable(*entity, ConstantInit(), DbgTy, refKind,
+                                 /*overrideDeclType=*/nullptr);
+  } else {
+    addr = getAddrOfLLVMVariable(*entity, ConstantInit(), DbgTy, refKind,
+                                 /*overrideDeclType=*/defaultVarTy);
   }
 
-  auto addr = getAddrOfLLVMVariable(*entity, ConstantInit(), DbgTy, refKind,
-                                    defaultVarTy);
   if (auto *GV = dyn_cast<llvm::GlobalVariable>(addr.getValue()))
     GV->setComdat(nullptr);
 

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -74,6 +74,9 @@ namespace irgen {
   /// Emit the type metadata accessor for a type for which it might be used.
   void emitLazyMetadataAccessor(IRGenModule &IGM, NominalTypeDecl *type);
 
+  void emitLazyCanonicalSpecializedMetadataAccessor(IRGenModule &IGM,
+                                                    CanType theType);
+
   void emitLazySpecializedGenericTypeMetadata(IRGenModule &IGM, CanType type);
 
   /// Emit metadata for a foreign struct, enum or class.
@@ -85,11 +88,19 @@ namespace irgen {
   /// Emit the metadata associated with the given enum declaration.
   void emitEnumMetadata(IRGenModule &IGM, EnumDecl *theEnum);
 
+  /// Emit the metadata associated with a given instantiation of a generic
+  /// struct.
   void emitSpecializedGenericStructMetadata(IRGenModule &IGM, CanType type,
                                             StructDecl &decl);
 
+  /// Emit the metadata associated with a given instantiation of a generic enum.
   void emitSpecializedGenericEnumMetadata(IRGenModule &IGM, CanType type,
                                           EnumDecl &decl);
+
+  /// Emit the metadata associated with a given instantiation of a generic
+  // class.
+  void emitSpecializedGenericClassMetadata(IRGenModule &IGM, CanType type,
+                                           ClassDecl &decl);
 
   /// Get what will be the index into the generic type argument array at the end
   /// of a nominal type's metadata.

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -97,6 +97,11 @@ public:
     return mangleTypeSymbol(type, "Ma");
   }
 
+  std::string
+  mangleCanonicalSpecializedGenericTypeMetadataAccessFunction(Type type) {
+    return mangleTypeSymbol(type, "Mb");
+  }
+
   std::string mangleTypeMetadataLazyCacheVariable(Type type) {
     return mangleTypeSymbol(type, "ML");
   }
@@ -119,6 +124,10 @@ public:
 
   std::string mangleClassMetaClass(const ClassDecl *Decl) {
     return mangleNominalTypeSymbol(Decl, "Mm");
+  }
+
+  std::string mangleSpecializedGenericClassMetaClass(const CanType theType) {
+    return mangleTypeSymbol(theType, "MM");
   }
 
   std::string mangleObjCMetadataUpdateFunction(const ClassDecl *Decl) {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -260,7 +260,10 @@ private:
   /// Maps every generic type that is specialized within the module to its
   /// specializations.
   llvm::DenseMap<NominalTypeDecl *, llvm::SmallVector<CanType, 4>>
-      SpecializationsForGenericTypes;
+      CanonicalSpecializationsForGenericTypes;
+
+  llvm::DenseMap<NominalTypeDecl *, llvm::SmallVector<CanType, 4>>
+      CanonicalSpecializedAccessorsForGenericTypes;
 
   /// The queue of specialized generic types whose prespecialized metadata to
   /// emit.
@@ -271,6 +274,9 @@ private:
   /// The accessors must be emitted after everything else which might result in
   /// a statically-known-canonical prespecialization.
   llvm::SmallSetVector<NominalTypeDecl *, 4> LazyMetadataAccessors;
+
+  /// The queue of prespecialized metadata accessors to emit.
+  llvm::SmallSetVector<CanType, 4> LazyCanonicalSpecializedMetadataAccessors;
 
   struct LazyOpaqueInfo {
     bool IsDescriptorUsed = false;
@@ -412,8 +418,9 @@ public:
 
   void ensureRelativeSymbolCollocation(SILDefaultWitnessTable &wt);
 
-  llvm::SmallVector<CanType, 4> specializationsForType(NominalTypeDecl *type) {
-    return SpecializationsForGenericTypes.lookup(type);
+  llvm::SmallVector<CanType, 4>
+  canonicalSpecializationsForType(NominalTypeDecl *type) {
+    return CanonicalSpecializationsForGenericTypes.lookup(type);
   }
 
   void noteUseOfMetadataAccessor(NominalTypeDecl *decl) {
@@ -427,6 +434,7 @@ public:
   }
 
   void noteUseOfSpecializedGenericTypeMetadata(CanType type);
+  void noteUseOfCanonicalSpecializedMetadataAccessor(CanType forType);
 
   void noteUseOfTypeMetadata(CanType type) {
     type.visit([&](Type t) {
@@ -1405,6 +1413,9 @@ public:
                                              NominalTypeDecl *nominal,
                                              ArrayRef<llvm::Type *> genericArgs,
                                              ForDefinition_t forDefinition);
+  llvm::Function *
+  getAddrOfCanonicalSpecializedGenericTypeMetadataAccessFunction(
+      CanType theType, ForDefinition_t forDefinition);
   llvm::Constant *getAddrOfTypeMetadataLazyCacheVariable(CanType type);
   llvm::Constant *getAddrOfTypeMetadataDemanglingCacheVariable(CanType type,
                                                        ConstantInit definition);
@@ -1470,6 +1481,8 @@ public:
   Address getAddrOfObjCClassRef(ClassDecl *D);
   llvm::Constant *getAddrOfMetaclassObject(ClassDecl *D,
                                            ForDefinition_t forDefinition);
+  llvm::Constant *getAddrOfCanonicalSpecializedGenericMetaclassObject(
+      CanType concreteType, ForDefinition_t forDefinition);
 
   llvm::Function *getAddrOfObjCMetadataUpdateFunction(ClassDecl *D,
                                                       ForDefinition_t forDefinition);

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -147,6 +147,10 @@ std::string LinkEntity::mangleAsString() const {
   case Kind::TypeMetadataAccessFunction:
     return mangler.mangleTypeMetadataAccessFunction(getType());
 
+  case Kind::CanonicalSpecializedGenericTypeMetadataAccessFunction:
+    return mangler.mangleCanonicalSpecializedGenericTypeMetadataAccessFunction(
+        getType());
+
   case Kind::TypeMetadataLazyCacheVariable:
     return mangler.mangleTypeMetadataLazyCacheVariable(getType());
 
@@ -184,6 +188,9 @@ std::string LinkEntity::mangleAsString() const {
 
   case Kind::SwiftMetaclassStub:
     return mangler.mangleClassMetaClass(cast<ClassDecl>(getDecl()));
+
+  case Kind::CanonicalSpecializedGenericSwiftMetaclassStub:
+    return mangler.mangleSpecializedGenericClassMetaClass(getType());
 
   case Kind::ObjCMetadataUpdateFunction:
     return mangler.mangleObjCMetadataUpdateFunction(cast<ClassDecl>(getDecl()));
@@ -526,6 +533,9 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
     }
     llvm_unreachable("bad metadata access kind");
 
+  case Kind::CanonicalSpecializedGenericTypeMetadataAccessFunction:
+    return SILLinkage::Shared;
+
   case Kind::ObjCClassRef:
     return SILLinkage::Private;
 
@@ -596,6 +606,11 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
   case Kind::OpaqueTypeDescriptorAccessorKey:
   case Kind::OpaqueTypeDescriptorAccessorVar:
     return getSILLinkage(getDeclLinkage(getDecl()), forDefinition);
+
+  case Kind::CanonicalSpecializedGenericSwiftMetaclassStub:
+    // Prespecialization of the same generic class' metaclass may be requested
+    // multiple times within the same module, so it needs to be uniqued.
+    return SILLinkage::Shared;
 
   case Kind::AssociatedTypeDescriptor:
     return getSILLinkage(getDeclLinkage(getAssociatedType()->getProtocol()),
@@ -721,6 +736,7 @@ bool LinkEntity::isContextDescriptor() const {
   case Kind::ValueWitnessTable:
   case Kind::TypeMetadata:
   case Kind::TypeMetadataAccessFunction:
+  case Kind::CanonicalSpecializedGenericTypeMetadataAccessFunction:
   case Kind::TypeMetadataLazyCacheVariable:
   case Kind::TypeMetadataDemanglingCacheVariable:
   case Kind::ReflectionBuiltinDescriptor:
@@ -736,6 +752,7 @@ bool LinkEntity::isContextDescriptor() const {
   case Kind::OpaqueTypeDescriptorAccessorKey:
   case Kind::OpaqueTypeDescriptorAccessorVar:
   case Kind::DifferentiabilityWitness:
+  case Kind::CanonicalSpecializedGenericSwiftMetaclassStub:
     return false;
   }
   llvm_unreachable("invalid descriptor");
@@ -765,6 +782,7 @@ llvm::Type *LinkEntity::getDefaultDeclarationType(IRGenModule &IGM) const {
   case Kind::ObjCClass:
   case Kind::ObjCMetaclass:
   case Kind::SwiftMetaclassStub:
+  case Kind::CanonicalSpecializedGenericSwiftMetaclassStub:
     return IGM.ObjCClassStructTy;
   case Kind::TypeMetadataLazyCacheVariable:
     return IGM.TypeMetadataPtrTy;
@@ -882,6 +900,7 @@ Alignment LinkEntity::getAlignment(IRGenModule &IGM) const {
   case Kind::ProtocolWitnessTablePattern:
   case Kind::ObjCMetaclass:
   case Kind::SwiftMetaclassStub:
+  case Kind::CanonicalSpecializedGenericSwiftMetaclassStub:
   case Kind::DynamicallyReplaceableFunctionVariable:
   case Kind::DynamicallyReplaceableFunctionKey:
   case Kind::OpaqueTypeDescriptorAccessorKey:
@@ -925,7 +944,8 @@ bool LinkEntity::isWeakImported(ModuleDecl *module) const {
     return cast<ProtocolDecl>(getDecl())->isWeakImported(module);
 
   case Kind::TypeMetadata:
-  case Kind::TypeMetadataAccessFunction: {
+  case Kind::TypeMetadataAccessFunction:
+  case Kind::CanonicalSpecializedGenericTypeMetadataAccessFunction: {
     if (auto *nominalDecl = getType()->getAnyNominal())
       return nominalDecl->isWeakImported(module);
     return false;
@@ -960,6 +980,9 @@ bool LinkEntity::isWeakImported(ModuleDecl *module) const {
   case Kind::OpaqueTypeDescriptorAccessorKey:
   case Kind::OpaqueTypeDescriptorAccessorVar:
     return getDecl()->isWeakImported(module);
+
+  case Kind::CanonicalSpecializedGenericSwiftMetaclassStub:
+    return getType()->getClassOrBoundGenericClass()->isWeakImported(module);
 
   case Kind::ProtocolWitnessTable:
   case Kind::ProtocolConformanceDescriptor:
@@ -1035,7 +1058,10 @@ DeclContext *LinkEntity::getDeclContextForEmission() const {
   case Kind::OpaqueTypeDescriptorAccessorKey:
   case Kind::OpaqueTypeDescriptorAccessorVar:
     return getDecl()->getDeclContext();
-  
+
+  case Kind::CanonicalSpecializedGenericSwiftMetaclassStub:
+    return getType()->getClassOrBoundGenericClass()->getDeclContext();
+
   case Kind::SILFunction:
   case Kind::DynamicallyReplaceableFunctionVariable:
   case Kind::DynamicallyReplaceableFunctionKey:
@@ -1075,6 +1101,7 @@ DeclContext *LinkEntity::getDeclContextForEmission() const {
   case Kind::AnonymousDescriptor:
   case Kind::ObjCClassRef:
   case Kind::TypeMetadataAccessFunction:
+  case Kind::CanonicalSpecializedGenericTypeMetadataAccessFunction:
   case Kind::TypeMetadataLazyCacheVariable:
   case Kind::TypeMetadataDemanglingCacheVariable:
     assert(isAlwaysSharedLinkage() && "kind should always be shared linkage");
@@ -1099,6 +1126,7 @@ bool LinkEntity::isAlwaysSharedLinkage() const {
   case Kind::AnonymousDescriptor:
   case Kind::ObjCClassRef:
   case Kind::TypeMetadataAccessFunction:
+  case Kind::CanonicalSpecializedGenericTypeMetadataAccessFunction:
   case Kind::TypeMetadataLazyCacheVariable:
   case Kind::TypeMetadataDemanglingCacheVariable:
     return true;

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -596,8 +596,8 @@ llvm::Value *irgen::emitObjCHeapMetadataRef(IRGenFunction &IGF,
 static MetadataResponse emitNominalPrespecializedGenericMetadataRef(
     IRGenFunction &IGF, NominalTypeDecl *theDecl, CanType theType,
     DynamicMetadataRequest request) {
-  assert(isNominalGenericContextTypeMetadataAccessTrivial(IGF.IGM, *theDecl,
-                                                          theType));
+  assert(isCompleteCanonicalSpecializedNominalTypeMetadataStaticallyAddressable(
+      IGF.IGM, *theDecl, theType));
   // We are applying generic parameters to a generic type.
   assert(theType->getAnyNominal() == theDecl);
 
@@ -676,28 +676,43 @@ static MetadataResponse emitNominalMetadataRef(IRGenFunction &IGF,
           theDecl->getGenericSignature()->areAllParamsConcrete()) &&
          "no generic args?!");
 
-  if (isNominalGenericContextTypeMetadataAccessTrivial(IGF.IGM, *theDecl,
-                                                       theType)) {
-    return emitNominalPrespecializedGenericMetadataRef(IGF, theDecl, theType,
-                                                       request);
+  MetadataResponse response;
+
+  if (isCompleteCanonicalSpecializedNominalTypeMetadataStaticallyAddressable(
+          IGF.IGM, *theDecl, theType)) {
+    response = emitNominalPrespecializedGenericMetadataRef(IGF, theDecl,
+                                                           theType, request);
+  } else if (auto theClass = dyn_cast<ClassDecl>(theDecl)) {
+    if (isCanonicalSpecializedNominalTypeMetadataStaticallyAddressable(
+            IGF.IGM, *theClass, theType,
+            /*usingCanonicalSpecializedAccessor=*/true)) {
+      llvm::Function *accessor =
+          IGF.IGM
+              .getAddrOfCanonicalSpecializedGenericTypeMetadataAccessFunction(
+                  theType, NotForDefinition);
+
+      response =
+          IGF.emitGenericTypeMetadataAccessFunctionCall(accessor, {}, request);
+    }
   }
 
-  // Call the generic metadata accessor function.
-  llvm::Function *accessor =
-      IGF.IGM.getAddrOfGenericTypeMetadataAccessFunction(theDecl,
-                                                         genericArgs.Types,
-                                                         NotForDefinition);
+  if (!response.isValid()) {
+    // Call the generic metadata accessor function.
+    llvm::Function *accessor =
+        IGF.IGM.getAddrOfGenericTypeMetadataAccessFunction(
+            theDecl, genericArgs.Types, NotForDefinition);
 
-  auto response =
-    IGF.emitGenericTypeMetadataAccessFunctionCall(accessor, genericArgs.Values,
-                                                  request);
+    response = IGF.emitGenericTypeMetadataAccessFunctionCall(
+        accessor, genericArgs.Values, request);
+  }
 
   IGF.setScopedLocalTypeMetadata(theType, response);
   return response;
 }
 
-bool irgen::isNominalGenericContextTypeMetadataAccessTrivial(
-    IRGenModule &IGM, NominalTypeDecl &nominal, CanType type) {
+bool irgen::isCanonicalSpecializedNominalTypeMetadataStaticallyAddressable(
+    IRGenModule &IGM, NominalTypeDecl &nominal, CanType type,
+    bool usingCanonicalSpecializedAccessor) {
   assert(nominal.isGenericContext());
 
   if (!IGM.shouldPrespecializeGenericMetadata()) {
@@ -734,9 +749,24 @@ bool irgen::isNominalGenericContextTypeMetadataAccessTrivial(
     return false;
   }
 
-  if (isa<ClassType>(type) || isa<BoundGenericClassType>(type)) {
-    // TODO: Support classes.
-    return false;
+  if (auto *theClass = dyn_cast<ClassDecl>(&nominal)) {
+    if (theClass->hasResilientMetadata(IGM.getSwiftModule(),
+                                       ResilienceExpansion::Maximal)) {
+      return false;
+    }
+    AncestryOptions flags = theClass->checkAncestry();
+    if (flags & (AncestryOptions(AncestryFlags::ResilientOther) |
+                 AncestryOptions(AncestryFlags::ClangImported))) {
+      return false;
+    }
+    if (auto *theSuperclass = theClass->getSuperclassDecl()) {
+      auto superclassType =
+          type->getSuperclass(/*useArchetypes=*/false)->getCanonicalType();
+      if (!isInitializableTypeMetadataStaticallyAddressable(IGM,
+                                                            superclassType)) {
+        return false;
+      }
+    }
   }
 
   auto *generic = type.getAnyGeneric();
@@ -771,14 +801,63 @@ bool irgen::isNominalGenericContextTypeMetadataAccessTrivial(
         (protocols.size() > 0);
     };
     auto metadataAccessIsTrivial = [&]() {
-      return irgen::isCompleteTypeMetadataStaticallyAddressable(IGM,
-                                                argument->getCanonicalType());
+      if (usingCanonicalSpecializedAccessor) {
+        // If an accessor is being used, then the accessor will be able to
+        // initialize the arguments, i.e. register classes with the ObjC
+        // runtime.
+        return irgen::isInitializableTypeMetadataStaticallyAddressable(
+            IGM, argument->getCanonicalType());
+      } else {
+        return irgen::isCompleteTypeMetadataStaticallyAddressable(
+            IGM, argument->getCanonicalType());
+      }
     };
     return !isGenericWithoutPrespecializedConformance() &&
            metadataAccessIsTrivial() && witnessTablesAreReferenceable();
   });
   return allWitnessTablesAreReferenceable
   && IGM.getTypeInfoForUnlowered(type).isFixedSize(ResilienceExpansion::Maximal);
+}
+
+bool irgen::
+    isCompleteCanonicalSpecializedNominalTypeMetadataStaticallyAddressable(
+        IRGenModule &IGM, NominalTypeDecl &nominal, CanType type) {
+  if (isa<ClassType>(type) || isa<BoundGenericClassType>(type)) {
+    // TODO: On platforms without ObjC interop, we can do direct access to
+    // class metadata.
+    return false;
+  }
+  // Prespecialized struct/enum metadata gets no dedicated accessor yet and so
+  // cannot do the work of registering the generic arguments which are classes
+  // with the ObjC runtime.  Concretely, the following cannot be prespecialized
+  // yet:
+  //   Struct<Klass<Int>>
+  //   Enum<Klass<Int>>
+  return isCanonicalSpecializedNominalTypeMetadataStaticallyAddressable(
+      IGM, nominal, type, /*usingCanonicalSpecializedAccessor=*/false);
+}
+
+/// Is there a known address for canonical specialized metadata?  The metadata
+/// there may need initialization before it is complete.
+bool irgen::isInitializableTypeMetadataStaticallyAddressable(IRGenModule &IGM,
+                                                             CanType type) {
+  if (isCompleteTypeMetadataStaticallyAddressable(IGM, type)) {
+    // The address of the complete metadata is the address of the abstract
+    // metadata.
+    return true;
+  }
+
+  NominalTypeDecl *nominal;
+  if ((nominal = type->getAnyNominal()) && nominal->isGenericContext()) {
+    // Prespecialized class metadata gets a dedicated accessor which can do
+    // the work of registering the class and its arguments with the ObjC
+    // runtime.
+    // Concretely, Clazz<Klass<Int>> can be prespecialized.
+    return isCanonicalSpecializedNominalTypeMetadataStaticallyAddressable(
+        IGM, *nominal, type, /*usingCanonicalSpecializedAccessor=*/true);
+  }
+
+  return false;
 }
 
 /// Is complete metadata for the given type available at a fixed address?
@@ -797,8 +876,8 @@ bool irgen::isCompleteTypeMetadataStaticallyAddressable(IRGenModule &IGM,
       return false;
 
     if (nominalDecl->isGenericContext())
-      return isNominalGenericContextTypeMetadataAccessTrivial(IGM, *nominalDecl,
-                                                              type);
+      return isCompleteCanonicalSpecializedNominalTypeMetadataStaticallyAddressable(
+          IGM, *nominalDecl, type);
 
     auto expansion = ResilienceExpansion::Maximal;
 
@@ -832,8 +911,8 @@ bool irgen::isCompleteTypeMetadataStaticallyAddressable(IRGenModule &IGM,
     if (isa<ClangModuleUnit>(nominalDecl->getModuleScopeContext()))
       return false;
 
-    return isNominalGenericContextTypeMetadataAccessTrivial(IGM, *nominalDecl,
-                                                            type);
+    return isCompleteCanonicalSpecializedNominalTypeMetadataStaticallyAddressable(
+        IGM, *nominalDecl, type);
   }
 
   return false;
@@ -852,13 +931,17 @@ bool irgen::shouldCacheTypeMetadataAccess(IRGenModule &IGM, CanType type) {
   //
   // TODO: On platforms without ObjC interop, we can do direct access to
   // Swift metadata without a runtime call at all.
-  if (auto clas = dyn_cast<ClassType>(type)) {
-    if (!hasKnownSwiftMetadata(IGM, clas))
+  if (auto classDecl = type.getClassOrBoundGenericClass()) {
+    if (!hasKnownSwiftMetadata(IGM, classDecl))
       return true;
-    auto strategy = IGM.getClassMetadataStrategy(clas->getDecl());
+    if (classDecl->isGenericContext() &&
+        isCanonicalSpecializedNominalTypeMetadataStaticallyAddressable(
+            IGM, *classDecl, type, /*usingCanonicalSpecializedAccessor=*/true))
+      return false;
+    auto strategy = IGM.getClassMetadataStrategy(classDecl);
     return strategy != ClassMetadataStrategy::Fixed;
   }
-  
+
   // Trivially accessible metadata does not need a cache.
   if (isCompleteTypeMetadataStaticallyAddressable(IGM, type))
     return false;
@@ -1844,11 +1927,11 @@ IRGenFunction::emitGenericTypeMetadataAccessFunctionCall(
 }
 
 static void emitCanonicalSpecializationsForGenericTypeMetadataAccessFunction(
-    IRGenFunction &IGF, Explosion &params, NominalTypeDecl *nominal,
+    IRGenFunction &IGF, llvm::Value *request, NominalTypeDecl *nominal,
     GenericArguments &genericArgs,
     std::function<llvm::Value *(int)> valueAtIndex) {
   auto &IGM = IGF.IGM;
-  auto specializations = IGF.IGM.IRGen.specializationsForType(nominal);
+  auto specializations = IGF.IGM.IRGen.canonicalSpecializationsForType(nominal);
   if (specializations.size() > 0) {
     SmallVector<llvm::BasicBlock *, 4> conditionBlocks;
     for (size_t index = 0; index < specializations.size(); ++index) {
@@ -1857,7 +1940,11 @@ static void emitCanonicalSpecializationsForGenericTypeMetadataAccessFunction(
 
     IGF.Builder.CreateBr(conditionBlocks[0]);
 
-    SmallVector<std::pair<llvm::BasicBlock *, llvm::Value *>, 4>
+    SmallVector<std::tuple<llvm::BasicBlock *, CanType,
+                           std::function<llvm::Value *(llvm::Value *, CanType,
+                                                       IRGenFunction &,
+                                                       IRGenModule &)>>,
+                4>
         specializationBlocks;
     auto switchDestination = llvm::BasicBlock::Create(IGM.getLLVMContext());
     unsigned long blockIndex = 0;
@@ -1890,27 +1977,51 @@ static void emitCanonicalSpecializationsForGenericTypeMetadataAccessFunction(
       }
       IGF.Builder.CreateCondBr(condition, specializationBlock, successorBlock);
 
-      auto specializedMetadataAddress =
-          IGM.getAddrOfTypeMetadata(specialization);
-      // Construct a MetadataResponse.  It has three fields in the following
-      // order:
-      //        - const Metadata *Metadata;
-      //        - MetadataState (i32) StaticState;
-      llvm::Value *response = llvm::UndefValue::get(IGM.TypeMetadataResponseTy);
-      response = IGF.Builder.CreateInsertValue(
-          response, specializedMetadataAddress, 0,
-          "insert metadata address into response");
-      auto state =
-          llvm::ConstantInt::get(IGM.SizeTy, (uint32_t)MetadataState::Complete);
-      response = IGF.Builder.CreateInsertValue(
-          response, state, 1, "insert metadata state into response");
-      specializationBlocks.push_back({specializationBlock, response});
+      auto responseBuilder = [](llvm::Value *request, CanType specialization,
+                                IRGenFunction &IGF, IRGenModule &IGM) {
+        auto nominal = specialization->getAnyNominal();
+        llvm::Value *specializedMetadata;
+        if (isa<ClassDecl>(nominal)) {
+          llvm::Function *accessor =
+              IGF.IGM
+                  .getAddrOfCanonicalSpecializedGenericTypeMetadataAccessFunction(
+                      specialization, NotForDefinition);
+
+          specializedMetadata =
+              IGF.emitGenericTypeMetadataAccessFunctionCall(
+                     accessor, {}, DynamicMetadataRequest(request))
+                  .getMetadata();
+        } else {
+          specializedMetadata = IGM.getAddrOfTypeMetadata(specialization);
+        }
+        // Construct a MetadataResponse.  It has three fields in the following
+        // order:
+        //        - const Metadata *Metadata;
+        //        - MetadataState (i32) StaticState;
+        llvm::Value *response =
+            llvm::UndefValue::get(IGM.TypeMetadataResponseTy);
+        response = IGF.Builder.CreateInsertValue(
+            response, specializedMetadata, 0,
+            "insert metadata address into response");
+        auto state = MetadataResponse::getCompletedState(IGM);
+        response = IGF.Builder.CreateInsertValue(
+            response, state, 1, "insert metadata state into response");
+        return response;
+      };
+      specializationBlocks.push_back(std::make_tuple(
+          specializationBlock, specialization, responseBuilder));
       ++blockIndex;
     }
 
-    for (auto pair : specializationBlocks) {
-      IGF.Builder.emitBlock(pair.first);
-      IGF.Builder.CreateRet(pair.second);
+    for (auto tuple : specializationBlocks) {
+      llvm::BasicBlock *block;
+      CanType type;
+      std::function<llvm::Value *(llvm::Value *, CanType, IRGenFunction &,
+                                  IRGenModule &)>
+          builder;
+      std::tie(block, type, builder) = tuple;
+      IGF.Builder.emitBlock(block);
+      IGF.Builder.CreateRet(builder(request, type, IGF, IGM));
     }
     IGF.Builder.emitBlock(switchDestination);
   }
@@ -1950,7 +2061,7 @@ MetadataResponse irgen::emitGenericTypeMetadataAccessFunction(
         IGF.Builder.CreateBitCast(argsBuffer.getAddress(), IGM.Int8PtrPtrTy);
 
     emitCanonicalSpecializationsForGenericTypeMetadataAccessFunction(
-        IGF, params, nominal, genericArgs, [&](int index) {
+        IGF, request, nominal, genericArgs, [&](int index) {
           llvm::Value *indexValue = llvm::ConstantInt::get(IGM.Int64Ty, index);
           llvm::SmallVector<llvm::Value *, 1> indices{indexValue};
           llvm::Value *elementPointer =
@@ -2051,7 +2162,7 @@ MetadataResponse irgen::emitGenericTypeMetadataAccessFunction(
     std::array<llvm::Value *, 3> argValues = {arg0, arg1, arg2};
 
     emitCanonicalSpecializationsForGenericTypeMetadataAccessFunction(
-        IGF, params, nominal, genericArgs,
+        IGF, request, nominal, genericArgs,
         [&](int index) { return argValues[index]; });
 
     auto call = IGF.Builder.CreateCall(thunkFn,
@@ -2064,6 +2175,71 @@ MetadataResponse irgen::emitGenericTypeMetadataAccessFunction(
   }
   
   return MetadataResponse::handle(IGF, DynamicMetadataRequest(request), result);
+}
+
+static void
+emitIdempotentCanonicalSpecializedClassMetadataInitializationComponent(
+    IRGenFunction &IGF, CanType theType,
+    llvm::SmallSet<CanType, 16> &initializedTypes) {
+  if (initializedTypes.count(theType) > 0) {
+    return;
+  }
+  initializedTypes.insert(theType);
+  llvm::Function *accessor =
+      IGF.IGM.getAddrOfCanonicalSpecializedGenericTypeMetadataAccessFunction(
+          theType, NotForDefinition);
+
+  auto request = DynamicMetadataRequest(MetadataState::Complete);
+  IGF.emitGenericTypeMetadataAccessFunctionCall(accessor, {}, request);
+}
+
+MetadataResponse
+irgen::emitCanonicalSpecializedGenericTypeMetadataAccessFunction(
+    IRGenFunction &IGF, Explosion &params, CanType theType) {
+  assert(isa<ClassDecl>(theType->getAnyNominal()));
+
+  auto request = params.claimNext();
+  // The metadata request that is passed to a canonical specialized generic
+  // metadata accessor is ignored because complete metadata is always returned.
+  (void)request;
+  llvm::SmallSet<CanType, 16> initializedTypes;
+
+  auto *nominal = theType->getAnyNominal();
+  assert(nominal);
+  assert(isa<ClassDecl>(nominal));
+  assert(nominal->isGenericContext());
+  assert(!theType->hasUnboundGenericType());
+
+  auto *uninitializedMetadata = IGF.IGM.getAddrOfTypeMetadata(theType);
+  initializedTypes.insert(theType);
+  auto *initializedMetadata =
+      emitIdempotentClassMetadataInitialization(IGF, uninitializedMetadata);
+  auto requirements = GenericTypeRequirements(IGF.IGM, nominal);
+  auto substitutions =
+      theType->getContextSubstitutionMap(IGF.IGM.getSwiftModule(), nominal);
+  for (auto requirement : requirements.getRequirements()) {
+    if (requirement.Protocol) {
+      continue;
+    }
+    auto parameter = requirement.TypeParameter;
+    auto noncanonicalArgument = parameter.subst(substitutions);
+    auto argument = noncanonicalArgument->getCanonicalType();
+    if (auto *classDecl = argument->getClassOrBoundGenericClass()) {
+      emitIdempotentCanonicalSpecializedClassMetadataInitializationComponent(
+          IGF, argument, initializedTypes);
+    }
+  }
+  Type superclassType = theType->getSuperclass(/*useArchetypes=*/false);
+  if (superclassType) {
+    auto superclass = superclassType->getCanonicalType();
+    auto *superclassNominal = superclass->getAnyNominal();
+    if (superclassNominal->isGenericContext()) {
+      emitIdempotentCanonicalSpecializedClassMetadataInitializationComponent(
+          IGF, superclassType->getCanonicalType(), initializedTypes);
+    }
+  }
+
+  return MetadataResponse::forComplete(initializedMetadata);
 }
 
 /// Emit the body of a metadata accessor function for the given type.

--- a/lib/IRGen/MetadataRequest.h
+++ b/lib/IRGen/MetadataRequest.h
@@ -505,9 +505,22 @@ bool isCompleteTypeMetadataStaticallyAddressable(IRGenModule &IGM, CanType type)
 /// Should requests for the given type's metadata be cached?
 bool shouldCacheTypeMetadataAccess(IRGenModule &IGM, CanType type);
 
-bool isNominalGenericContextTypeMetadataAccessTrivial(IRGenModule &IGM,
-                                                      NominalTypeDecl &nominal,
+bool isInitializableTypeMetadataStaticallyAddressable(IRGenModule &IGM,
                                                       CanType type);
+
+/// Is the address of the canonical specialization of a generic metadata
+/// statically known?
+///
+/// In other words, can a canonical specialization be formed for the specified
+/// type. If usingCanonicalSpecializedAccessor is true, then metadata's address
+/// is known, but access to the metadata must go through the canonical
+/// specialized accessor so that initialization of the metadata can occur.
+bool isCanonicalSpecializedNominalTypeMetadataStaticallyAddressable(
+    IRGenModule &IGM, NominalTypeDecl &nominal, CanType type,
+    bool usingCanonicalSpecializedAccessor);
+
+bool isCompleteCanonicalSpecializedNominalTypeMetadataStaticallyAddressable(
+    IRGenModule &IGM, NominalTypeDecl &nominal, CanType type);
 
 /// Determine how the given type metadata should be accessed.
 MetadataAccessStrategy getTypeMetadataAccessStrategy(CanType type);
@@ -593,6 +606,9 @@ MetadataResponse
 emitGenericTypeMetadataAccessFunction(IRGenFunction &IGF, Explosion &params,
                                       NominalTypeDecl *nominal,
                                       GenericArguments &genericArgs);
+
+MetadataResponse emitCanonicalSpecializedGenericTypeMetadataAccessFunction(
+    IRGenFunction &IGF, Explosion &params, CanType theType);
 
 /// Emit a declaration reference to a metatype object.
 void emitMetatypeRef(IRGenFunction &IGF, CanMetatypeType type,

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2357,9 +2357,13 @@ static bool installLazyClassNameHook() {
   return true;
 }
 
+__attribute__((constructor)) SWIFT_RUNTIME_ATTRIBUTE_ALWAYS_INLINE static bool
+supportsLazyObjcClassNames() {
+  return SWIFT_LAZY_CONSTANT(installLazyClassNameHook());
+}
+
 static void setUpGenericClassObjCName(ClassMetadata *theClass) {
-  bool supportsLazyNames = SWIFT_LAZY_CONSTANT(installLazyClassNameHook());
-  if (supportsLazyNames) {
+  if (supportsLazyObjcClassNames()) {
     getROData(theClass)->Name = nullptr;
     auto theMetaclass = (ClassMetadata *)object_getClass((id)theClass);
     getROData(theMetaclass)->Name = nullptr;

--- a/test/IRGen/prespecialized-metadata/Inputs/isPrespecialized.cpp
+++ b/test/IRGen/prespecialized-metadata/Inputs/isPrespecialized.cpp
@@ -20,7 +20,7 @@ bool isCanonicalStaticallySpecializedGenericMetadata(Metadata *self) {
   return false;
 }
 
-int isCanonicalStaticallySpecializedGenericMetadata(void *ptr) {
+bool isCanonicalStaticallySpecializedGenericMetadata(void *ptr) {
   auto metadata = static_cast<Metadata *>(ptr);
   auto isCanonical =
       isCanonicalStaticallySpecializedGenericMetadata(metadata);

--- a/test/IRGen/prespecialized-metadata/Inputs/isPrespecialized.h
+++ b/test/IRGen/prespecialized-metadata/Inputs/isPrespecialized.h
@@ -1,7 +1,12 @@
+#ifndef __cplusplus
+#include <stdbool.h>
+#endif
+
 #ifdef __cplusplus
 extern "C"
 #endif
-int isCanonicalStaticallySpecializedGenericMetadata(void *metadata);
+    bool
+    isCanonicalStaticallySpecializedGenericMetadata(void *metadata);
 
 #ifdef __cplusplus
 extern "C"

--- a/test/IRGen/prespecialized-metadata/class-class-flags-run.swift
+++ b/test/IRGen/prespecialized-metadata/class-class-flags-run.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+// RUN: %clang -c -v %target-cc-options -g -O0 -isysroot %sdk %S/Inputs/isPrespecialized.cpp -o %t/isPrespecialized.o -I %clang-include-dir -I %swift_src_root/include/ -I %swift_src_root/../llvm-project/llvm/include -I %clang-include-dir/../../llvm-macosx-x86_64/include -L %clang-include-dir/../lib/swift/macosx
+
+// RUN: %target-build-swift -v %mcp_opt %s %t/isPrespecialized.o -import-objc-header %S/Inputs/isPrespecialized.h -Xfrontend -prespecialize-generic-metadata -target %module-target-future -lc++ -L %clang-include-dir/../lib/swift/macosx -sdk %sdk -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main
+
+// REQUIRES: OS=macosx
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: swift_test_mode_optimize
+// UNSUPPORTED: swift_test_mode_optimize_size
+// UNSUPPORTED: remote_run
+
+func ptr<T>(to ty: T.Type) -> UnsafeMutableRawPointer {
+    UnsafeMutableRawPointer(mutating: unsafePointerToMetadata(of: ty))!
+}
+
+func unsafePointerToMetadata<T>(of ty: T.Type) -> UnsafePointer<T.Type> {
+  unsafeBitCast(ty, to: UnsafePointer<T.Type>.self)
+}
+
+@inline(never)
+func assertIsPrespecialized<T>(_ t: T.Type, is prespecialized: Bool) {
+  assert(isCanonicalStaticallySpecializedGenericMetadata(ptr(to: t)) == prespecialized)
+}
+
+@inline(never)
+func assertIsPrespecialized<T>(clazzArgument: T.Type, is prespecialized: Bool) {
+  assertIsPrespecialized(Clazz<T>.self, is: prespecialized)
+}
+
+class Clazz<T> {
+  let value: T
+
+  init(value: T) {
+    self.value = value
+  }
+}
+
+func doit() {
+  assertIsPrespecialized(Clazz<Int>.self, is: true)
+  assertIsPrespecialized(clazzArgument: Int.self, is: true) // Clazz<Int> is prespecialized by the preceeding call
+
+  assertIsPrespecialized(clazzArgument: Double.self, is: false) // Clazz<Double> is not prespecialized
+}
+doit()

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_distinct_generic_class.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_distinct_generic_class.swift
@@ -1,0 +1,394 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+//              CHECK: @"$s4main5Value[[UNIQUE_ID_1:[0-9A-Z_]+]]LLCyAA9Argument1ACLLCySiGAA9Argument2ACLLCySSGGMf" = linkonce_odr hidden 
+//   CHECK-apple-SAME: global
+// CHECK-unknown-SAME: constant 
+//         CHECK-SAME: <{
+//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]LLC*)*, 
+//         CHECK-SAME:   i8**, 
+//                   :   [[INT]], 
+//   CHECK-apple-SAME:   %objc_class*,
+// CHECK-unknown-SAME:   %swift.type*, 
+//   CHECK-apple-SAME:   %swift.opaque*, 
+//   CHECK-apple-SAME:   %swift.opaque*, 
+//   CHECK-apple-SAME:   [[INT]], 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i16, 
+//         CHECK-SAME:   i16, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   %swift.type_descriptor*, 
+//         CHECK-SAME:   i8*, 
+//         CHECK-SAME:   %swift.type*, 
+// CHECK-unknown-SAME:   %swift.type*, 
+//         CHECK-SAME:   [[INT]], 
+// CHECK-unknown-SAME:   [[INT]], 
+//   CHECK-apple-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
+//   CHECK-apple-SAME:     %swift.opaque*, 
+//   CHECK-apple-SAME:     %swift.opaque*, 
+//   CHECK-apple-SAME:     %swift.type*
+//         CHECK-SAME:   )* 
+//         CHECK-SAME: }> <{ 
+//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]LLC*)* 
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCfD
+//         CHECK-SAME:   $sBoWV
+//   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAA9Argument2ACLLCySSGGMM
+//   CHECK-apple-SAME:   OBJC_CLASS_$__TtCs12_SwiftObject
+//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache, 
+//   CHECK-apple-SAME:   %swift.opaque* null, 
+//   CHECK-apple-SAME:   [[INT]] add (
+//   CHECK-apple-SAME:     [[INT]] ptrtoint (
+//   CHECK-apple-SAME:       { 
+//   CHECK-apple-SAME:         i32, 
+//   CHECK-apple-SAME:         i32, 
+//   CHECK-apple-SAME:         i32, 
+//                   :         i32, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         {
+//   CHECK-apple-SAME:           i32,
+//   CHECK-apple-SAME:           i32,
+//   CHECK-apple-SAME:           [
+//   CHECK-apple-SAME:             2 x {
+//   CHECK-apple-SAME:               [[INT]]*,
+//   CHECK-apple-SAME:               i8*,
+//   CHECK-apple-SAME:               i8*,
+//   CHECK-apple-SAME:               i32,
+//   CHECK-apple-SAME:               i32
+//   CHECK-apple-SAME:             }
+//   CHECK-apple-SAME:           ]
+//   CHECK-apple-SAME:         }*,
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8* 
+//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP[[UNIQUE_ID_2:[0-9A-Z_]+]]5Value to [[INT]]
+//   CHECK-apple-SAME:     ), 
+//   CHECK-apple-SAME:     [[INT]] 2
+//   CHECK-apple-SAME:   ), 
+// CHECK-unknown-SAME:  [[INT]] 0, 
+// CHECK-unknown-SAME:  %swift.type* null, 
+//         CHECK-SAME:   i32 26, 
+//         CHECK-SAME:   i32 0, 
+//         CHECK-SAME:   i32 {{(32|16)}}, 
+//         CHECK-SAME:   i16 {{(7|3)}}, 
+//         CHECK-SAME:   i16 0, 
+//   CHECK-apple-SAME:   i32 {{(136|80)}}, 
+// CHECK-unknown-SAME:   i32 112,
+//         CHECK-SAME:   i32 {{(16|8)}}, 
+//                   :   %swift.type_descriptor* bitcast (
+//                   :     <{
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i16,
+//                   :       i16,
+//                   :       i16,
+//                   :       i16,
+//                   :       i8,
+//                   :       i8,
+//                   :       i8,
+//                   :       i8,
+//                   :       i32,
+//                   :       i32,
+//                   :       %swift.method_descriptor
+//         CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
+//                   :   ),
+//         CHECK-SAME:   i8* null,
+//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//         CHECK-SAME:     %swift.full_heapmetadata,
+//         CHECK-SAME:     %swift.full_heapmetadata* bitcast (
+//         CHECK-SAME:       <{
+//         CHECK-SAME:         void (
+//         CHECK-SAME:           %T4main9Argument1[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:         )*,
+//         CHECK-SAME:         i8**,
+//                   :         [[INT]],
+//   CHECK-apple-SAME:         %objc_class*,
+// CHECK-unknown-SAME:         %swift.type*,
+//   CHECK-apple-SAME:         %swift.opaque*,
+//   CHECK-apple-SAME:         %swift.opaque*,
+//   CHECK-apple-SAME:         [[INT]],
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i16,
+//         CHECK-SAME:         i16,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         %swift.type_descriptor*,
+//         CHECK-SAME:         i8*,
+//         CHECK-SAME:         %swift.type*,
+//         CHECK-SAME:         [[INT]],
+//         CHECK-SAME:         %T4main9Argument1[[UNIQUE_ID_1]]LLC* (
+//         CHECK-SAME:           %swift.opaque*,
+//         CHECK-SAME:           %swift.type*
+//         CHECK-SAME:         )*
+//         CHECK-SAME:       }>* @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMf" to %swift.full_heapmetadata*
+//         CHECK-SAME:     ),
+//         CHECK-SAME:     i32 0,
+//         CHECK-SAME:     i32 2
+//         CHECK-SAME:   ),
+//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//         CHECK-SAME:     %swift.full_heapmetadata,
+//         CHECK-SAME:     %swift.full_heapmetadata* bitcast (
+//         CHECK-SAME:       <{
+//         CHECK-SAME:         void (
+//         CHECK-SAME:           %T4main9Argument2[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:         )*,
+//         CHECK-SAME:         i8**,
+//                   :         [[INT]],
+//   CHECK-apple-SAME:         %objc_class*,
+// CHECK-unknown-SAME:         %swift.type*,
+//   CHECK-apple-SAME:         %swift.opaque*,
+//   CHECK-apple-SAME:         %swift.opaque*,
+//   CHECK-apple-SAME:         [[INT]],
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i16,
+//         CHECK-SAME:         i16,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         %swift.type_descriptor*,
+//         CHECK-SAME:         i8*,
+//         CHECK-SAME:         %swift.type*,
+//         CHECK-SAME:         [[INT]],
+//         CHECK-SAME:         %T4main9Argument2[[UNIQUE_ID_1]]LLC* (
+//         CHECK-SAME:           %swift.opaque*,
+//         CHECK-SAME:           %swift.type*
+//         CHECK-SAME:         )*
+//         CHECK-SAME:       }>* @"$s4main9Argument2[[UNIQUE_ID_1]]LLCySSGMf" to %swift.full_heapmetadata*
+//         CHECK-SAME:     ),
+//         CHECK-SAME:     i32 0,
+//         CHECK-SAME:     i32 2
+//         CHECK-SAME:   ),
+//         CHECK-SAME:   [[INT]] {{(16|8)}},
+//         CHECK-SAME:   [[INT]] {{(24|12)}},
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
+//         CHECK-SAME:     %swift.opaque*,
+//         CHECK-SAME:     %swift.opaque*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLC5first6secondADyxq_Gx_q_tcfC
+//         CHECK-SAME: }>,
+//         CHECK-SAME: align [[ALIGNMENT]]
+
+fileprivate class Value<First, Second> {
+  let first: First
+  let second: Second
+
+  init(first: First, second: Second) {
+    self.first = first
+    self.second = second
+  }
+}
+
+fileprivate class Argument1<Value> {
+  let value: Value
+
+  init(value: Value) {
+    self.value = value
+  }
+}
+
+fileprivate class Argument2<Value> {
+  let value: Value
+
+  init(value: Value) {
+    self.value = value
+  }
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]LLCyAA9Argument1ACLLCySiGAA9Argument2ACLLCySSGGMb"([[INT]] 0)
+// CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK: }
+func doit() {
+  consume( Value(first: Argument1(value: 13), second: Argument2(value: "13")) )
+}
+doit()
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* [[ARGUMENT1_METADATA:%[0-9]+]], %swift.type* [[ARGUMENT2_METADATA:%[0-9]+]]) #{{[0-9]+}} {
+//      CHECK: entry:
+//      CHECK:   [[ERASED_ARGUMENT1:%[0-9]+]] = bitcast %swift.type* [[ARGUMENT1_METADATA]] to i8*
+//      CHECK:   [[ERASED_ARGUMENT2:%[0-9]+]] = bitcast %swift.type* [[ARGUMENT2_METADATA]] to i8*
+//      CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+//      CHECK: [[TYPE_COMPARISON_LABEL]]:
+//      CHECK:   [[EQUAL_TYPE_1:%[0-9]+]] = icmp eq i8* bitcast (
+//           :     %swift.type* getelementptr inbounds (
+//           :       %swift.full_heapmetadata,
+//           :       %swift.full_heapmetadata* bitcast (
+//           :         <{
+//           :           void (
+//           :             %T4main9Argument1[[UNIQUE_ID_1]]LLC*
+//           :           )*,
+//           :           i8**,
+//           :           [[INT]],
+//           :           %objc_class*,
+//           :           %swift.opaque*,
+//           :           %swift.opaque*,
+//           :           [[INT]],
+//           :           i32,
+//           :           i32,
+//           :           i32,
+//           :           i16,
+//           :           i16,
+//           :           i32,
+//           :           i32,
+//           :           %swift.type_descriptor*,
+//           :           i8*,
+//           :           %swift.type*,
+//           :           [[INT]],
+//           :           %T4main9Argument1[[UNIQUE_ID_1]]LLC* (
+//           :             %swift.opaque*,
+//           :             %swift.type*
+//           :           )*
+//           :         }>* 
+// CHECK-SAME:         @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMf" 
+//           :         to %swift.full_heapmetadata*
+//           :       ),
+//           :       i32 0,
+//           :       i32 2
+//           :     ) to i8*
+// CHECK-SAME:   ), [[ERASED_ARGUMENT1]]
+//      CHECK:   [[EQUAL_TYPES_1:%[0-9]+]] = and i1 true, [[EQUAL_TYPE_1]]
+//      CHECK:   [[EQUAL_TYPE_2:%[0-9]+]] = icmp eq i8* bitcast (
+//           :     %swift.type* getelementptr inbounds (
+//           :       %swift.full_heapmetadata,
+//           :       %swift.full_heapmetadata* bitcast (
+//           :         <{
+//           :           void (
+//           :             %T4main9Argument2[[UNIQUE_ID_1]]LLC*
+//           :           )*,
+//           :           i8**,
+//           :           [[INT]],
+//           :           %objc_class*,
+//           :           %swift.opaque*,
+//           :           %swift.opaque*,
+//           :           [[INT]],
+//           :           i32,
+//           :           i32,
+//           :           i32,
+//           :           i16,
+//           :           i16,
+//           :           i32,
+//           :           i32,
+//           :           %swift.type_descriptor*,
+//           :           i8*,
+//           :           %swift.type*,
+//           :           [[INT]],
+//           :           %T4main9Argument2[[UNIQUE_ID_1]]LLC* (
+//           :             %swift.opaque*,
+//           :             %swift.type*
+//           :           )*
+// CHECK-SAME:         }>* @"$s4main9Argument2[[UNIQUE_ID_1]]LLCySSGMf" to %swift.full_heapmetadata*
+//           :       ),
+//           :       i32 0,
+//           :       i32 2
+//           :     ) to i8*
+//           :   ), [[ERASED_ARGUMENT2]]
+//      CHECK:   [[EQUAL_TYPES_2:%[0-9]+]] = and i1 [[EQUAL_TYPES_1]], [[EQUAL_TYPE_2]]
+//      CHECK:   br i1 [[EQUAL_TYPES_2]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+//      CHECK: [[EXIT_PRESPECIALIZED]]:
+//      CHECK-NEXT:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_3:[0-9A-Z_]+]]LLCyAA9Argument1ACLLCySiGAA9Argument2ACLLCySSGGMb"([[INT]] [[METADATA_REQUEST]])
+//      CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+//      CHECK:   [[PARTIAL_RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[METADATA]], 0
+//      CHECK:   [[RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_RESULT_METADATA]], [[INT]] 0, 1
+//      CHECK:   ret %swift.metadata_response [[RESULT_METADATA]] 
+//      CHECK: [[EXIT_NORMAL]]:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+//      CHECK:     [[INT]] [[METADATA_REQUEST]], 
+//      CHECK:     i8* [[ERASED_ARGUMENT1]], 
+//      CHECK:     i8* [[ERASED_ARGUMENT2]], 
+//      CHECK:     i8* undef, 
+//      CHECK:     %swift.type_descriptor* bitcast (
+//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
+//      CHECK:       $s4main5Value[[UNIQUE_ID_1]]LLCMn
+//      CHECK:       to %swift.type_descriptor*
+//      CHECK:     )
+//      CHECK:   ) #{{[0-9]+}}
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+
+
+//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4]]LLCyAA9Argument1ACLLCySiGAA9Argument2ACLLCySSGGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]}} {
+//         CHECK: entry:
+// CHECK-unknown:  call swiftcc %swift.metadata_response @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
+// CHECK-unknown:  call swiftcc %swift.metadata_response @"$s4main9Argument2[[UNIQUE_ID_1]]LLCySSGMb"([[INT]] 0)
+// CHECK-unknown:  ret
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
+//              :    %objc_class* bitcast (
+//              :      %swift.type* getelementptr inbounds (
+//              :        %swift.full_heapmetadata,
+//              :        %swift.full_heapmetadata* bitcast (
+//              :          <{
+//              :            void (
+//              :              %T4main5Value[[UNIQUE_ID_1]]LLC*
+//              :            )*,
+//              :            i8**,
+//              :            [[INT]],
+//              :            %objc_class*,
+//              :            %swift.opaque*,
+//              :            %swift.opaque*,
+//              :            [[INT]],
+//              :            i32,
+//              :            i32,
+//              :            i32,
+//              :            i16,
+//              :            i16,
+//              :            i32,
+//              :            i32,
+//              :            %swift.type_descriptor*,
+//              :            i8*,
+//              :            %swift.type*,
+//              :            %swift.type*,
+//              :            [[INT]],
+//              :            [[INT]],
+//              :            %T4main5Value[[UNIQUE_ID_1]]LLC* (
+//              :              %swift.opaque*,
+//              :              %swift.opaque*,
+//              :              %swift.type*
+//              :            )*
+//              :          }>* 
+//    CHECK-SAME:          @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAA9Argument2ACLLCySSGGMf" 
+//              :          to %swift.full_heapmetadata*
+//              :        ),
+//              :        i32 0,
+//              :        i32 2
+//              :      ) to %objc_class*
+//              :    )
+//              :  )
+//   CHECK-apple:  [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
+//   CHECK-apple:  call swiftcc %swift.metadata_response @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
+//   CHECK-apple:  call swiftcc %swift.metadata_response @"$s4main9Argument2[[UNIQUE_ID_1]]LLCySSGMb"([[INT]] 0)
+//   CHECK-apple:  [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//   CHECK-apple:  [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
+//   CHECK-apple:  ret %swift.metadata_response [[METADATA_RESPONSE]]
+//         CHECK: }
+

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_same_generic_class_different_value.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_same_generic_class_different_value.swift
@@ -1,0 +1,385 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+//              CHECK: @"$s4main5Value[[UNIQUE_ID_1:[0-9A-Z_]+]]LLCyAA9Argument1ACLLCySiGAFySSGGMf" = linkonce_odr hidden 
+//   CHECK-apple-SAME: global
+// CHECK-unknown-SAME: constant 
+//         CHECK-SAME: <{
+//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]LLC*)*, 
+//         CHECK-SAME:   i8**, 
+//                   :   [[INT]], 
+//   CHECK-apple-SAME:   %objc_class*,
+// CHECK-unknown-SAME:   %swift.type*, 
+//   CHECK-apple-SAME:   %swift.opaque*, 
+//   CHECK-apple-SAME:   %swift.opaque*, 
+//   CHECK-apple-SAME:   [[INT]], 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i16, 
+//         CHECK-SAME:   i16, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   %swift.type_descriptor*, 
+//         CHECK-SAME:   i8*, 
+//         CHECK-SAME:   %swift.type*, 
+//         CHECK-SAME:   [[INT]], 
+//   CHECK-apple-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
+//   CHECK-apple-SAME:     %swift.opaque*, 
+//   CHECK-apple-SAME:     %swift.opaque*, 
+//   CHECK-apple-SAME:     %swift.type*
+//         CHECK-SAME:   )* 
+//         CHECK-SAME: }> <{ 
+//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]LLC*)* 
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCfD
+//         CHECK-SAME:   $sBoWV
+//   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAFySSGGMM
+//   CHECK-apple-SAME:   OBJC_CLASS_$__TtCs12_SwiftObject
+//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache, 
+//   CHECK-apple-SAME:   %swift.opaque* null, 
+//   CHECK-apple-SAME:   [[INT]] add (
+//   CHECK-apple-SAME:     [[INT]] ptrtoint (
+//   CHECK-apple-SAME:       { 
+//   CHECK-apple-SAME:         i32, 
+//   CHECK-apple-SAME:         i32, 
+//   CHECK-apple-SAME:         i32, 
+//                   :         i32, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         {
+//   CHECK-apple-SAME:           i32,
+//   CHECK-apple-SAME:           i32,
+//   CHECK-apple-SAME:           [
+//   CHECK-apple-SAME:             2 x {
+//   CHECK-apple-SAME:               [[INT]]*,
+//   CHECK-apple-SAME:               i8*,
+//   CHECK-apple-SAME:               i8*,
+//   CHECK-apple-SAME:               i32,
+//   CHECK-apple-SAME:               i32
+//   CHECK-apple-SAME:             }
+//   CHECK-apple-SAME:           ]
+//   CHECK-apple-SAME:         }*,
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8* 
+//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP[[UNIQUE_ID_2:[0-9A-Z_]+]]5Value to [[INT]]
+//   CHECK-apple-SAME:     ), 
+//   CHECK-apple-SAME:     [[INT]] 2
+//   CHECK-apple-SAME:   ), 
+// CHECK-unknown-SAME:  [[INT]] 0, 
+// CHECK-unknown-SAME:  %swift.type* null, 
+//         CHECK-SAME:   i32 26, 
+//         CHECK-SAME:   i32 0, 
+//         CHECK-SAME:   i32 {{(32|16)}}, 
+//         CHECK-SAME:   i16 {{(7|3)}}, 
+//         CHECK-SAME:   i16 0, 
+//   CHECK-apple-SAME:   i32 {{(136|80)}}, 
+// CHECK-unknown-SAME:   i32 112,
+//         CHECK-SAME:   i32 {{(16|8)}}, 
+//                   :   %swift.type_descriptor* bitcast (
+//                   :     <{
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i16,
+//                   :       i16,
+//                   :       i16,
+//                   :       i16,
+//                   :       i8,
+//                   :       i8,
+//                   :       i8,
+//                   :       i8,
+//                   :       i32,
+//                   :       i32,
+//                   :       %swift.method_descriptor
+//         CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
+//                   :   ),
+//         CHECK-SAME:   i8* null,
+//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//         CHECK-SAME:     %swift.full_heapmetadata,
+//         CHECK-SAME:     %swift.full_heapmetadata* bitcast (
+//         CHECK-SAME:       <{
+//         CHECK-SAME:         void (
+//         CHECK-SAME:           %T4main9Argument1[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:         )*,
+//         CHECK-SAME:         i8**,
+//                   :         [[INT]],
+//   CHECK-apple-SAME:         %objc_class*,
+// CHECK-unknown-SAME:         %swift.type*,
+//   CHECK-apple-SAME:         %swift.opaque*,
+//   CHECK-apple-SAME:         %swift.opaque*,
+//   CHECK-apple-SAME:         [[INT]],
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i16,
+//         CHECK-SAME:         i16,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         %swift.type_descriptor*,
+//         CHECK-SAME:         i8*,
+//         CHECK-SAME:         %swift.type*,
+//         CHECK-SAME:         [[INT]],
+//         CHECK-SAME:         %T4main9Argument1[[UNIQUE_ID_1]]LLC* (
+//         CHECK-SAME:           %swift.opaque*,
+//         CHECK-SAME:           %swift.type*
+//         CHECK-SAME:         )*
+//         CHECK-SAME:       }>* @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMf" to %swift.full_heapmetadata*
+//         CHECK-SAME:     ),
+//         CHECK-SAME:     i32 0,
+//         CHECK-SAME:     i32 2
+//         CHECK-SAME:   ),
+//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//         CHECK-SAME:     %swift.full_heapmetadata,
+//         CHECK-SAME:     %swift.full_heapmetadata* bitcast (
+//         CHECK-SAME:       <{
+//         CHECK-SAME:         void (
+//         CHECK-SAME:           %T4main9Argument1[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:         )*,
+//         CHECK-SAME:         i8**,
+//                   :         [[INT]],
+//   CHECK-apple-SAME:         %objc_class*,
+// CHECK-unknown-SAME:         %swift.type*,
+//   CHECK-apple-SAME:         %swift.opaque*,
+//   CHECK-apple-SAME:         %swift.opaque*,
+//   CHECK-apple-SAME:         [[INT]],
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i16,
+//         CHECK-SAME:         i16,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         %swift.type_descriptor*,
+//         CHECK-SAME:         i8*,
+//         CHECK-SAME:         %swift.type*,
+//         CHECK-SAME:         [[INT]],
+//         CHECK-SAME:         %T4main9Argument1[[UNIQUE_ID_1]]LLC* (
+//         CHECK-SAME:           %swift.opaque*,
+//         CHECK-SAME:           %swift.type*
+//         CHECK-SAME:         )*
+//         CHECK-SAME:       }>* @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySSGMf" to %swift.full_heapmetadata*
+//         CHECK-SAME:     ),
+//         CHECK-SAME:     i32 0,
+//         CHECK-SAME:     i32 2
+//         CHECK-SAME:   ),
+//         CHECK-SAME:   [[INT]] {{(16|8)}},
+//         CHECK-SAME:   [[INT]] {{(24|12)}},
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
+//         CHECK-SAME:     %swift.opaque*,
+//         CHECK-SAME:     %swift.opaque*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLC5first6secondADyxq_Gx_q_tcfC
+//         CHECK-SAME: }>,
+//         CHECK-SAME: align [[ALIGNMENT]]
+
+fileprivate class Value<First, Second> {
+  let first: First
+  let second: Second
+
+  init(first: First, second: Second) {
+    self.first = first
+    self.second = second
+  }
+}
+
+fileprivate class Argument1<Value> {
+  let value: Value
+
+  init(value: Value) {
+    self.value = value
+  }
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]LLCyAA9Argument1ACLLCySiGAFySSGGMb"([[INT]] 0)
+// CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK: }
+func doit() {
+  consume( Value(first: Argument1(value: 13), second: Argument1(value: "13")) )
+}
+doit()
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* [[ARGUMENT1_METADATA:%[0-9]+]], %swift.type* [[ARGUMENT2_METADATA:%[0-9]+]]) #{{[0-9]+}} {
+//      CHECK: entry:
+//      CHECK:   [[ERASED_ARGUMENT1:%[0-9]+]] = bitcast %swift.type* [[ARGUMENT1_METADATA]] to i8*
+//      CHECK:   [[ERASED_ARGUMENT2:%[0-9]+]] = bitcast %swift.type* [[ARGUMENT2_METADATA]] to i8*
+//      CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+//      CHECK: [[TYPE_COMPARISON_LABEL]]:
+//      CHECK:   [[EQUAL_TYPE_1:%[0-9]+]] = icmp eq i8* bitcast (
+//           :     %swift.type* getelementptr inbounds (
+//           :       %swift.full_heapmetadata,
+//           :       %swift.full_heapmetadata* bitcast (
+//           :         <{
+//           :           void (
+//           :             %T4main9Argument1[[UNIQUE_ID_1]]LLC*
+//           :           )*,
+//           :           i8**,
+//           :           [[INT]],
+//           :           %objc_class*,
+//           :           %swift.opaque*,
+//           :           %swift.opaque*,
+//           :           [[INT]],
+//           :           i32,
+//           :           i32,
+//           :           i32,
+//           :           i16,
+//           :           i16,
+//           :           i32,
+//           :           i32,
+//           :           %swift.type_descriptor*,
+//           :           i8*,
+//           :           %swift.type*,
+//           :           [[INT]],
+//           :           %T4main9Argument1[[UNIQUE_ID_1]]LLC* (
+//           :             %swift.opaque*,
+//           :             %swift.type*
+//           :           )*
+//           :         }>* 
+// CHECK-SAME:         @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMf" 
+//           :         to %swift.full_heapmetadata*
+//           :       ),
+//           :       i32 0,
+//           :       i32 2
+//           :     ) to i8*
+// CHECK-SAME:   ), [[ERASED_ARGUMENT1]]
+//      CHECK:   [[EQUAL_TYPES_1:%[0-9]+]] = and i1 true, [[EQUAL_TYPE_1]]
+//      CHECK:   [[EQUAL_TYPE_2:%[0-9]+]] = icmp eq i8* bitcast (
+//           :     %swift.type* getelementptr inbounds (
+//           :       %swift.full_heapmetadata,
+//           :       %swift.full_heapmetadata* bitcast (
+//           :         <{
+//           :           void (
+//           :             %T4main9Argument1[[UNIQUE_ID_1]]LLC*
+//           :           )*,
+//           :           i8**,
+//           :           [[INT]],
+//           :           %objc_class*,
+//           :           %swift.opaque*,
+//           :           %swift.opaque*,
+//           :           [[INT]],
+//           :           i32,
+//           :           i32,
+//           :           i32,
+//           :           i16,
+//           :           i16,
+//           :           i32,
+//           :           i32,
+//           :           %swift.type_descriptor*,
+//           :           i8*,
+//           :           %swift.type*,
+//           :           [[INT]],
+//           :           %T4main9Argument1[[UNIQUE_ID_1]]LLC* (
+//           :             %swift.opaque*,
+//           :             %swift.type*
+//           :           )*
+// CHECK-SAME:         }>* @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySSGMf" to %swift.full_heapmetadata*
+//           :       ),
+//           :       i32 0,
+//           :       i32 2
+//           :     ) to i8*
+//           :   ), [[ERASED_ARGUMENT2]]
+//      CHECK:   [[EQUAL_TYPES_2:%[0-9]+]] = and i1 [[EQUAL_TYPES_1]], [[EQUAL_TYPE_2]]
+//      CHECK:   br i1 [[EQUAL_TYPES_2]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+//      CHECK: [[EXIT_PRESPECIALIZED]]:
+//      CHECK-NEXT:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_3:[0-9A-Z_]+]]LLCyAA9Argument1ACLLCySiGAFySSGGMb"([[INT]] [[METADATA_REQUEST]])
+//      CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+//      CHECK:   [[PARTIAL_RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[METADATA]], 0
+//      CHECK:   [[RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_RESULT_METADATA]], [[INT]] 0, 1
+//      CHECK:   ret %swift.metadata_response [[RESULT_METADATA]] 
+//      CHECK: [[EXIT_NORMAL]]:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+//      CHECK:     [[INT]] [[METADATA_REQUEST]], 
+//      CHECK:     i8* [[ERASED_ARGUMENT1]], 
+//      CHECK:     i8* [[ERASED_ARGUMENT2]], 
+//      CHECK:     i8* undef, 
+//      CHECK:     %swift.type_descriptor* bitcast (
+//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
+//      CHECK:       $s4main5Value[[UNIQUE_ID_1]]LLCMn
+//      CHECK:       to %swift.type_descriptor*
+//      CHECK:     )
+//      CHECK:   ) #{{[0-9]+}}
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+
+
+//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4]]LLCyAA9Argument1ACLLCySiGAFySSGGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]}} {
+//         CHECK: entry:
+// CHECK-unknown:  call swiftcc %swift.metadata_response @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
+// CHECK-unknown:  call swiftcc %swift.metadata_response @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySSGMb"([[INT]] 0)
+// CHECK-unknown:  ret
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
+//              :    %objc_class* bitcast (
+//              :      %swift.type* getelementptr inbounds (
+//              :        %swift.full_heapmetadata,
+//              :        %swift.full_heapmetadata* bitcast (
+//              :          <{
+//              :            void (
+//              :              %T4main5Value[[UNIQUE_ID_1]]LLC*
+//              :            )*,
+//              :            i8**,
+//              :            [[INT]],
+//              :            %objc_class*,
+//              :            %swift.opaque*,
+//              :            %swift.opaque*,
+//              :            [[INT]],
+//              :            i32,
+//              :            i32,
+//              :            i32,
+//              :            i16,
+//              :            i16,
+//              :            i32,
+//              :            i32,
+//              :            %swift.type_descriptor*,
+//              :            i8*,
+//              :            %swift.type*,
+//              :            %swift.type*,
+//              :            [[INT]],
+//              :            [[INT]],
+//              :            %T4main5Value[[UNIQUE_ID_1]]LLC* (
+//              :              %swift.opaque*,
+//              :              %swift.opaque*,
+//              :              %swift.type*
+//              :            )*
+//              :          }>* 
+//    CHECK-SAME:          @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAFySSGGMf" 
+//              :          to %swift.full_heapmetadata*
+//              :        ),
+//              :        i32 0,
+//              :        i32 2
+//              :      ) to %objc_class*
+//              :    )
+//              :  )
+//   CHECK-apple:  [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
+//   CHECK-apple:  call swiftcc %swift.metadata_response @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
+//   CHECK-apple:  call swiftcc %swift.metadata_response @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySSGMb"([[INT]] 0)
+//   CHECK-apple:  [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//   CHECK-apple:  [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
+//   CHECK-apple:  ret %swift.metadata_response [[METADATA_RESPONSE]]
+//         CHECK: }
+
+

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_same_generic_class_same_value.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_same_generic_class_same_value.swift
@@ -1,0 +1,383 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+//              CHECK: @"$s4main5Value[[UNIQUE_ID_1:[0-9A-Z_]+]]LLCyAA9Argument1ACLLCySiGAGGMf" = linkonce_odr hidden 
+//   CHECK-apple-SAME: global
+// CHECK-unknown-SAME: constant 
+//         CHECK-SAME: <{
+//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]LLC*)*, 
+//         CHECK-SAME:   i8**, 
+//                   :   [[INT]], 
+//   CHECK-apple-SAME:   %objc_class*,
+// CHECK-unknown-SAME:   %swift.type*, 
+//   CHECK-apple-SAME:   %swift.opaque*, 
+//   CHECK-apple-SAME:   %swift.opaque*, 
+//   CHECK-apple-SAME:   [[INT]], 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i16, 
+//         CHECK-SAME:   i16, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   %swift.type_descriptor*, 
+//         CHECK-SAME:   i8*, 
+//         CHECK-SAME:   %swift.type*, 
+//         CHECK-SAME:   [[INT]], 
+//   CHECK-apple-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
+//   CHECK-apple-SAME:     %swift.opaque*, 
+//   CHECK-apple-SAME:     %swift.opaque*, 
+//   CHECK-apple-SAME:     %swift.type*
+//         CHECK-SAME:   )* 
+//         CHECK-SAME: }> <{ 
+//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]LLC*)* 
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCfD
+//         CHECK-SAME:   $sBoWV
+//   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAGGMM
+//   CHECK-apple-SAME:   OBJC_CLASS_$__TtCs12_SwiftObject
+//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache, 
+//   CHECK-apple-SAME:   %swift.opaque* null, 
+//   CHECK-apple-SAME:   [[INT]] add (
+//   CHECK-apple-SAME:     [[INT]] ptrtoint (
+//   CHECK-apple-SAME:       { 
+//   CHECK-apple-SAME:         i32, 
+//   CHECK-apple-SAME:         i32, 
+//   CHECK-apple-SAME:         i32, 
+//                   :         i32, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         {
+//   CHECK-apple-SAME:           i32,
+//   CHECK-apple-SAME:           i32,
+//   CHECK-apple-SAME:           [
+//   CHECK-apple-SAME:             2 x {
+//   CHECK-apple-SAME:               [[INT]]*,
+//   CHECK-apple-SAME:               i8*,
+//   CHECK-apple-SAME:               i8*,
+//   CHECK-apple-SAME:               i32,
+//   CHECK-apple-SAME:               i32
+//   CHECK-apple-SAME:             }
+//   CHECK-apple-SAME:           ]
+//   CHECK-apple-SAME:         }*,
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8* 
+//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP[[UNIQUE_ID_2:[0-9A-Z_]+]]5Value to [[INT]]
+//   CHECK-apple-SAME:     ), 
+//   CHECK-apple-SAME:     [[INT]] 2
+//   CHECK-apple-SAME:   ), 
+// CHECK-unknown-SAME:  [[INT]] 0, 
+// CHECK-unknown-SAME:  %swift.type* null, 
+//         CHECK-SAME:   i32 26, 
+//         CHECK-SAME:   i32 0, 
+//         CHECK-SAME:   i32 {{(32|16)}}, 
+//         CHECK-SAME:   i16 {{(7|3)}}, 
+//         CHECK-SAME:   i16 0, 
+//   CHECK-apple-SAME:   i32 {{(136|80)}}, 
+// CHECK-unknown-SAME:   i32 112,
+//         CHECK-SAME:   i32 {{(16|8)}}, 
+//                   :   %swift.type_descriptor* bitcast (
+//                   :     <{
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i16,
+//                   :       i16,
+//                   :       i16,
+//                   :       i16,
+//                   :       i8,
+//                   :       i8,
+//                   :       i8,
+//                   :       i8,
+//                   :       i32,
+//                   :       i32,
+//                   :       %swift.method_descriptor
+//         CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
+//                   :   ),
+//         CHECK-SAME:   i8* null,
+//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//         CHECK-SAME:     %swift.full_heapmetadata,
+//         CHECK-SAME:     %swift.full_heapmetadata* bitcast (
+//         CHECK-SAME:       <{
+//         CHECK-SAME:         void (
+//         CHECK-SAME:           %T4main9Argument1[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:         )*,
+//         CHECK-SAME:         i8**,
+//                   :         [[INT]],
+//   CHECK-apple-SAME:         %objc_class*,
+// CHECK-unknown-SAME:         %swift.type*,
+//   CHECK-apple-SAME:         %swift.opaque*,
+//   CHECK-apple-SAME:         %swift.opaque*,
+//   CHECK-apple-SAME:         [[INT]],
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i16,
+//         CHECK-SAME:         i16,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         %swift.type_descriptor*,
+//         CHECK-SAME:         i8*,
+//         CHECK-SAME:         %swift.type*,
+//         CHECK-SAME:         [[INT]],
+//         CHECK-SAME:         %T4main9Argument1[[UNIQUE_ID_1]]LLC* (
+//         CHECK-SAME:           %swift.opaque*,
+//         CHECK-SAME:           %swift.type*
+//         CHECK-SAME:         )*
+//         CHECK-SAME:       }>* @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMf" to %swift.full_heapmetadata*
+//         CHECK-SAME:     ),
+//         CHECK-SAME:     i32 0,
+//         CHECK-SAME:     i32 2
+//         CHECK-SAME:   ),
+//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//         CHECK-SAME:     %swift.full_heapmetadata,
+//         CHECK-SAME:     %swift.full_heapmetadata* bitcast (
+//         CHECK-SAME:       <{
+//         CHECK-SAME:         void (
+//         CHECK-SAME:           %T4main9Argument1[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:         )*,
+//         CHECK-SAME:         i8**,
+//                   :         [[INT]],
+//   CHECK-apple-SAME:         %objc_class*,
+// CHECK-unknown-SAME:         %swift.type*,
+//   CHECK-apple-SAME:         %swift.opaque*,
+//   CHECK-apple-SAME:         %swift.opaque*,
+//   CHECK-apple-SAME:         [[INT]],
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i16,
+//         CHECK-SAME:         i16,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         %swift.type_descriptor*,
+//         CHECK-SAME:         i8*,
+//         CHECK-SAME:         %swift.type*,
+//         CHECK-SAME:         [[INT]],
+//         CHECK-SAME:         %T4main9Argument1[[UNIQUE_ID_1]]LLC* (
+//         CHECK-SAME:           %swift.opaque*,
+//         CHECK-SAME:           %swift.type*
+//         CHECK-SAME:         )*
+//         CHECK-SAME:       }>* @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMf" to %swift.full_heapmetadata*
+//         CHECK-SAME:     ),
+//         CHECK-SAME:     i32 0,
+//         CHECK-SAME:     i32 2
+//         CHECK-SAME:   ),
+//         CHECK-SAME:   [[INT]] {{(16|8)}},
+//         CHECK-SAME:   [[INT]] {{(24|12)}},
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
+//         CHECK-SAME:     %swift.opaque*,
+//         CHECK-SAME:     %swift.opaque*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLC5first6secondADyxq_Gx_q_tcfC
+//         CHECK-SAME: }>,
+//         CHECK-SAME: align [[ALIGNMENT]]
+
+fileprivate class Value<First, Second> {
+  let first: First
+  let second: Second
+
+  init(first: First, second: Second) {
+    self.first = first
+    self.second = second
+  }
+}
+
+fileprivate class Argument1<Value> {
+  let value: Value
+
+  init(value: Value) {
+    self.value = value
+  }
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]LLCyAA9Argument1ACLLCySiGAGGMb"([[INT]] 0)
+// CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK: }
+func doit() {
+  consume( Value(first: Argument1(value: 13), second: Argument1(value: 13)) )
+}
+doit()
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* [[ARGUMENT1_METADATA:%[0-9]+]], %swift.type* [[ARGUMENT2_METADATA:%[0-9]+]]) #{{[0-9]+}} {
+//      CHECK: entry:
+//      CHECK:   [[ERASED_ARGUMENT1:%[0-9]+]] = bitcast %swift.type* [[ARGUMENT1_METADATA]] to i8*
+//      CHECK:   [[ERASED_ARGUMENT2:%[0-9]+]] = bitcast %swift.type* [[ARGUMENT2_METADATA]] to i8*
+//      CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+//      CHECK: [[TYPE_COMPARISON_LABEL]]:
+//      CHECK:   [[EQUAL_TYPE_1:%[0-9]+]] = icmp eq i8* bitcast (
+//           :     %swift.type* getelementptr inbounds (
+//           :       %swift.full_heapmetadata,
+//           :       %swift.full_heapmetadata* bitcast (
+//           :         <{
+//           :           void (
+//           :             %T4main9Argument1[[UNIQUE_ID_1]]LLC*
+//           :           )*,
+//           :           i8**,
+//           :           [[INT]],
+//           :           %objc_class*,
+//           :           %swift.opaque*,
+//           :           %swift.opaque*,
+//           :           [[INT]],
+//           :           i32,
+//           :           i32,
+//           :           i32,
+//           :           i16,
+//           :           i16,
+//           :           i32,
+//           :           i32,
+//           :           %swift.type_descriptor*,
+//           :           i8*,
+//           :           %swift.type*,
+//           :           [[INT]],
+//           :           %T4main9Argument1[[UNIQUE_ID_1]]LLC* (
+//           :             %swift.opaque*,
+//           :             %swift.type*
+//           :           )*
+//           :         }>* 
+// CHECK-SAME:         @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMf" 
+//           :         to %swift.full_heapmetadata*
+//           :       ),
+//           :       i32 0,
+//           :       i32 2
+//           :     ) to i8*
+// CHECK-SAME:   ), [[ERASED_ARGUMENT1]]
+//      CHECK:   [[EQUAL_TYPES_1:%[0-9]+]] = and i1 true, [[EQUAL_TYPE_1]]
+//      CHECK:   [[EQUAL_TYPE_2:%[0-9]+]] = icmp eq i8* bitcast (
+//           :     %swift.type* getelementptr inbounds (
+//           :       %swift.full_heapmetadata,
+//           :       %swift.full_heapmetadata* bitcast (
+//           :         <{
+//           :           void (
+//           :             %T4main9Argument1[[UNIQUE_ID_1]]LLC*
+//           :           )*,
+//           :           i8**,
+//           :           [[INT]],
+//           :           %objc_class*,
+//           :           %swift.opaque*,
+//           :           %swift.opaque*,
+//           :           [[INT]],
+//           :           i32,
+//           :           i32,
+//           :           i32,
+//           :           i16,
+//           :           i16,
+//           :           i32,
+//           :           i32,
+//           :           %swift.type_descriptor*,
+//           :           i8*,
+//           :           %swift.type*,
+//           :           [[INT]],
+//           :           %T4main9Argument1[[UNIQUE_ID_1]]LLC* (
+//           :             %swift.opaque*,
+//           :             %swift.type*
+//           :           )*
+// CHECK-SAME:         }>* @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMf" to %swift.full_heapmetadata*
+//           :       ),
+//           :       i32 0,
+//           :       i32 2
+//           :     ) to i8*
+//           :   ), [[ERASED_ARGUMENT2]]
+//      CHECK:   [[EQUAL_TYPES_2:%[0-9]+]] = and i1 [[EQUAL_TYPES_1]], [[EQUAL_TYPE_2]]
+//      CHECK:   br i1 [[EQUAL_TYPES_2]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+//      CHECK: [[EXIT_PRESPECIALIZED]]:
+//      CHECK-NEXT:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_3:[0-9A-Z_]+]]LLCyAA9Argument1ACLLCySiGAGGMb"([[INT]] [[METADATA_REQUEST]])
+//      CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+//      CHECK:   [[PARTIAL_RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[METADATA]], 0
+//      CHECK:   [[RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_RESULT_METADATA]], [[INT]] 0, 1
+//      CHECK:   ret %swift.metadata_response [[RESULT_METADATA]] 
+//      CHECK: [[EXIT_NORMAL]]:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+//      CHECK:     [[INT]] [[METADATA_REQUEST]], 
+//      CHECK:     i8* [[ERASED_ARGUMENT1]], 
+//      CHECK:     i8* [[ERASED_ARGUMENT2]], 
+//      CHECK:     i8* undef, 
+//      CHECK:     %swift.type_descriptor* bitcast (
+//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
+//      CHECK:       $s4main5Value[[UNIQUE_ID_1]]LLCMn
+//      CHECK:       to %swift.type_descriptor*
+//      CHECK:     )
+//      CHECK:   ) #{{[0-9]+}}
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+
+
+//             CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4]]LLCyAA9Argument1ACLLCySiGAGGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]}} {
+//             CHECK: entry:
+//     CHECK-unknown:  call swiftcc %swift.metadata_response @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
+// CHECK-unknown-NOT:  call swiftcc %swift.metadata_response @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
+//     CHECK-unknown:  ret
+//       CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
+//                  :    %objc_class* bitcast (
+//                  :      %swift.type* getelementptr inbounds (
+//                  :        %swift.full_heapmetadata,
+//                  :        %swift.full_heapmetadata* bitcast (
+//                  :          <{
+//                  :            void (
+//                  :              %T4main5Value[[UNIQUE_ID_1]]LLC*
+//                  :            )*,
+//                  :            i8**,
+//                  :            [[INT]],
+//                  :            %objc_class*,
+//                  :            %swift.opaque*,
+//                  :            %swift.opaque*,
+//                  :            [[INT]],
+//                  :            i32,
+//                  :            i32,
+//                  :            i32,
+//                  :            i16,
+//                  :            i16,
+//                  :            i32,
+//                  :            i32,
+//                  :            %swift.type_descriptor*,
+//                  :            i8*,
+//                  :            %swift.type*,
+//                  :            %swift.type*,
+//                  :            [[INT]],
+//                  :            [[INT]],
+//                  :            %T4main5Value[[UNIQUE_ID_1]]LLC* (
+//                  :              %swift.opaque*,
+//                  :              %swift.opaque*,
+//                  :              %swift.type*
+//                  :            )*
+//                  :          }>* 
+//        CHECK-SAME:          @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAGGMf" 
+//                  :          to %swift.full_heapmetadata*
+//                  :        ),
+//                  :        i32 0,
+//                  :        i32 2
+//                  :      ) to %objc_class*
+//                  :    )
+//                  :  )
+//       CHECK-apple:  [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
+//       CHECK-apple:  call swiftcc %swift.metadata_response @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
+//   CHECK-apple-NOT:  call swiftcc %swift.metadata_response @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
+//       CHECK-apple:  [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//       CHECK-apple:  [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
+//       CHECK-apple:  ret %swift.metadata_response [[METADATA_RESPONSE]]
+//             CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_subcls_arg-2nd_anc_gen-1st-arg_subcls_arg.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_subcls_arg-2nd_anc_gen-1st-arg_subcls_arg.swift
@@ -1,0 +1,327 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK-DAG: @"$s4main9Ancestor1[[UNIQUE_ID_1:[0-9A-Za-z_]+]]LLCySiGMf" = 
+// CHECK-DAG: @"$s4main9Ancestor2[[UNIQUE_ID_1]]LLCySiGMf" = 
+
+//              CHECK: @"$s4main5Value[[UNIQUE_ID_1]]LLCySiGMf" = linkonce_odr hidden 
+//   CHECK-apple-SAME: global 
+// CHECK-unknown-SAME: constant 
+//         CHECK-SAME: <{
+//         CHECK-SAME:  void (
+//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:  )*,
+//         CHECK-SAME:  i8**,
+//                   :  [[INT]],
+//         CHECK-SAME:  %swift.type*,
+//   CHECK-apple-SAME:  %swift.opaque*,
+//   CHECK-apple-SAME:  %swift.opaque*,
+//   CHECK-apple-SAME:  [[INT]],
+//         CHECK-SAME:  i32,
+//         CHECK-SAME:  i32,
+//         CHECK-SAME:  i32,
+//         CHECK-SAME:  i16,
+//         CHECK-SAME:  i16,
+//         CHECK-SAME:  i32,
+//         CHECK-SAME:  i32,
+//         CHECK-SAME:  %swift.type_descriptor*,
+//         CHECK-SAME:  void (
+//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:  )*,
+//         CHECK-SAME:  %swift.type*,
+//         CHECK-SAME:  [[INT]],
+//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]LLC* (
+//         CHECK-SAME:    %swift.opaque*,
+//         CHECK-SAME:    %swift.type*
+//         CHECK-SAME:  )*,
+//         CHECK-SAME:  %swift.type*,
+//         CHECK-SAME:  [[INT]],
+//         CHECK-SAME:  %swift.type*,
+//         CHECK-SAME:  [[INT]]
+//         CHECK-SAME:}> <{
+//         CHECK-SAME:  void (
+//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCfD
+//         CHECK-SAME:  $sBoWV
+//   CHECK-apple-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCySiGMM
+// CHECK-unknown-SAME: [[INT]] 0,
+//                   :  %swift.type* getelementptr inbounds (
+//                   :    %swift.full_heapmetadata,
+//                   :    %swift.full_heapmetadata* bitcast (
+//                   :      <{
+//                   :        void (
+//                   :          %T4main9Ancestor1[[UNIQUE_ID_1]]LLC*
+//                   :        )*,
+//                   :        i8**,
+//                   :        [[INT]],
+//                   :        %swift.type*,
+//                   :        %swift.opaque*,
+//                   :        %swift.opaque*,
+//                   :        [[INT]],
+//                   :        i32,
+//                   :        i32,
+//                   :        i32,
+//                   :        i16,
+//                   :        i16,
+//                   :        i32,
+//                   :        i32,
+//                   :        %swift.type_descriptor*,
+//                   :        void (
+//                   :          %T4main9Ancestor1[[UNIQUE_ID_1]]LLC*
+//                   :        )*,
+//                   :        %swift.type*,
+//                   :        [[INT]],
+//                   :        %T4main9Ancestor1[[UNIQUE_ID_1]]LLC* (
+//                   :          %swift.opaque*,
+//                   :          %swift.type*
+//                   :        )*,
+//                   :        %swift.type*,
+//                   :        [[INT]]
+//                   :      }>* @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySiGMf" to %swift.full_heapmetadata*
+//                   :    ),
+//                   :    i32 0,
+//                   :    i32 2
+//                   :  ),
+//   CHECK-apple-SAME:  %swift.opaque* @_objc_empty_cache,
+//   CHECK-apple-SAME:  %swift.opaque* null,
+//   CHECK-apple-SAME:  [[INT]] add (
+//   CHECK-apple-SAME:    [[INT]] ptrtoint (
+//   CHECK-apple-SAME:      {
+//   CHECK-apple-SAME:        i32,
+//   CHECK-apple-SAME:        i32,
+//   CHECK-apple-SAME:        i32,
+//                   :        i32,
+//   CHECK-apple-SAME:        i8*,
+//   CHECK-apple-SAME:        i8*,
+//   CHECK-apple-SAME:        i8*,
+//                   :        i8*,
+//   CHECK-apple-SAME:        {
+//   CHECK-apple-SAME:          i32,
+//   CHECK-apple-SAME:          i32,
+//   CHECK-apple-SAME:          [
+//   CHECK-apple-SAME:            1 x {
+//   CHECK-apple-SAME:              [[INT]]*,
+//   CHECK-apple-SAME:              i8*,
+//   CHECK-apple-SAME:              i8*,
+//   CHECK-apple-SAME:              i32,
+//   CHECK-apple-SAME:              i32
+//   CHECK-apple-SAME:            }
+//   CHECK-apple-SAME:          ]
+//   CHECK-apple-SAME:        }*,
+//   CHECK-apple-SAME:        i8*,
+//   CHECK-apple-SAME:        i8*
+//   CHECK-apple-SAME:      }* @_DATA__TtC4mainP[[UNIQUE_ID_1]]5Value to [[INT]]
+//   CHECK-apple-SAME:    ),
+//   CHECK-apple-SAME:    [[INT]] 2
+//   CHECK-apple-SAME:  ),
+//         CHECK-SAME:  i32 26,
+//         CHECK-SAME:  i32 0,
+//         CHECK-SAME:  i32 {{(40|20)}},
+//         CHECK-SAME:  i16 {{(7|3)}},
+//         CHECK-SAME:  i16 0,
+//   CHECK-apple-SAME:  i32 {{(152|88)}},
+// CHECK-unknown-SAME:  i32 128,
+//         CHECK-SAME:  i32 {{(16|8)}},
+//                   :  %swift.type_descriptor* bitcast (
+//                   :    <{
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i16,
+//                   :      i16,
+//                   :      i16,
+//                   :      i16,
+//                   :      i8,
+//                   :      i8,
+//                   :      i8,
+//                   :      i8,
+//                   :      i32,
+//                   :      %swift.method_override_descriptor
+//                   :    }>* @"$s4main5Value[[UNIQUE_ID_1]]LLCMn" to %swift.type_descriptor*
+//                   :  ),
+//         CHECK-SAME:  void (
+//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCfE
+//         CHECK-SAME:  %swift.type* @"$sSiN",
+//         CHECK-SAME:  [[INT]] {{(16|8)}},
+//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]LLC* (
+//         CHECK-SAME:    %swift.opaque*,
+//         CHECK-SAME:    %swift.type*
+//         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC
+//         CHECK-SAME:  %swift.type* @"$sSiN",
+//         CHECK-SAME:  [[INT]] {{(24|12)}},
+//         CHECK-SAME:  %swift.type* @"$sSiN",
+//         CHECK-SAME:  [[INT]] {{(32|16)}}
+//         CHECK-SAME:}>,
+//         CHECK-SAME:align [[ALIGNMENT]]
+
+fileprivate class Ancestor2<First> {
+  let first_Ancestor2: First
+
+  init(first: First) {
+    self.first_Ancestor2 = first
+  }
+}
+
+fileprivate class Ancestor1<First> : Ancestor2<First> {
+  let first_Ancestor1: First
+
+  override init(first: First) {
+    self.first_Ancestor1 = first
+    super.init(first: first)
+  }
+}
+
+fileprivate class Value<First> : Ancestor1<First> {
+  let first_Value: First
+
+  override init(first: First) {
+    self.first_Value = first
+    super.init(first: first)
+  }
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
+// CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK: }
+func doit() {
+  consume( Value(first: 13) )
+}
+doit()
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* [[ARGUMENT:%[0-9]+]]) #{{[0-9]+}} {
+//      CHECK: entry:
+//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* [[ARGUMENT]] to i8*
+//      CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+//      CHECK: [[TYPE_COMPARISON_LABEL]]:
+//      CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (
+// CHECK-SAME: @"$sSiN"
+// CHECK-SAME: ), [[ERASED_TYPE]]
+//      CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+//      CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+//      CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK-NEXT:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_3:[0-9A-Z_]+]]LLCySiGMb"([[INT]] [[METADATA_REQUEST]])
+//      CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+//      CHECK:   [[PARTIAL_RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[METADATA]], 0
+//      CHECK:   [[RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_RESULT_METADATA]], [[INT]] 0, 1
+//      CHECK:   ret %swift.metadata_response [[RESULT_METADATA]] 
+//      CHECK: [[EXIT_NORMAL]]:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     i8* undef, 
+//           :     %swift.type_descriptor* bitcast (
+//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
+// CHECK-SAME:       $s4main9Ancestor2[[UNIQUE_ID_1]]LLCMn
+//           :       to %swift.type_descriptor*
+//           :     )
+// CHECK-SAME:   ) #{{[0-9]+}}
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* [[ARGUMENT:%[0-9]+]]) #{{[0-9]+}} {
+//      CHECK: entry:
+//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* [[ARGUMENT]] to i8*
+//      CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+//      CHECK: [[TYPE_COMPARISON_LABEL]]:
+//      CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (
+// CHECK-SAME: @"$sSiN"
+// CHECK-SAME: ), [[ERASED_TYPE]]
+//      CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+//      CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+//      CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK-NEXT:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_3:[0-9A-Z_]+]]LLCySiGMb"([[INT]] [[METADATA_REQUEST]])
+//      CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+//      CHECK:   [[PARTIAL_RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[METADATA]], 0
+//      CHECK:   [[RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_RESULT_METADATA]], [[INT]] 0, 1
+//      CHECK:   ret %swift.metadata_response [[RESULT_METADATA]] 
+//      CHECK: [[EXIT_NORMAL]]:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     i8* undef, 
+//           :     %swift.type_descriptor* bitcast (
+//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor, i32, %swift.method_override_descriptor }>* 
+// CHECK-SAME:       $s4main9Ancestor1[[UNIQUE_ID_1]]LLCMn
+//           :       to %swift.type_descriptor*
+//           :     )
+// CHECK-SAME:   ) #{{[0-9]+}}
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* [[ARGUMENT:%[0-9]+]]) #{{[0-9]+}} {
+//      CHECK: entry:
+//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* [[ARGUMENT]] to i8*
+//      CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+//      CHECK: [[TYPE_COMPARISON_LABEL]]:
+//      CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (
+// CHECK-SAME: @"$sSiN"
+// CHECK-SAME: ), [[ERASED_TYPE]]
+//      CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+//      CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+//      CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK-NEXT:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_3:[0-9A-Z_]+]]LLCySiGMb"([[INT]] [[METADATA_REQUEST]])
+//      CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+//      CHECK:   [[PARTIAL_RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[METADATA]], 0
+//      CHECK:   [[RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_RESULT_METADATA]], [[INT]] 0, 1
+//      CHECK:   ret %swift.metadata_response [[RESULT_METADATA]] 
+//      CHECK: [[EXIT_NORMAL]]:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     i8* undef, 
+//           :     %swift.type_descriptor* bitcast (
+//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, %swift.method_override_descriptor }>* 
+// CHECK-SAME:       $s4main5Value[[UNIQUE_ID_1]]LLCMn
+//           :       to %swift.type_descriptor*
+//           :     )
+// CHECK-SAME:   ) #{{[0-9]+}}
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+
+//         CHECK: ; Function Attrs: noinline nounwind readnone
+//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]+}} {
+//         CHECK: entry:
+// CHECK-unknown:   call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
+// CHECK-unknown:   ret
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
+//    CHECK-SAME:        @"$s4main5Value[[UNIQUE_ID_1]]LLCySiGMf" 
+//   CHECK-apple:   [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
+//   CHECK-apple:   call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
+//     CHECK-NOT:   call swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
+//   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
+//         CHECK: }
+
+
+// CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySiGMb"
+
+// CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]LLCySiGMb"

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_generic-1argument-1st_argument_constant_int.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_generic-1argument-1st_argument_constant_int.swift
@@ -1,0 +1,267 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+
+// CHECK: @"$s4main9Ancestor1[[UNIQUE_ID_1:[A-Za-z_0-9]+]]CySiGMf" =
+//              CHECK: @"$s4main5Value[[UNIQUE_ID_1]]CySSGMf" = linkonce_odr hidden 
+//   CHECK-apple-SAME: global
+// CHECK-unknown-SMAE: constant
+//         CHECK-SAME: <{
+//         CHECK-SAME:   void (
+//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]C*
+//         CHECK-SAME:  )*,
+//         CHECK-SAME:  i8**,
+//                   :  [[INT]],
+//         CHECK-SAME:  %swift.type*,
+//   CHECK-apple-SAME:  %swift.opaque*,
+//   CHECK-apple-SAME:  %swift.opaque*,
+//   CHECK-apple-SAME:  [[INT]],
+//         CHECK-SAME:  i32,
+//         CHECK-SAME:  i32,
+//         CHECK-SAME:  i32,
+//         CHECK-SAME:  i16,
+//         CHECK-SAME:  i16,
+//         CHECK-SAME:  i32,
+//         CHECK-SAME:  i32,
+//         CHECK-SAME:  %swift.type_descriptor*,
+//         CHECK-SAME:  void (
+//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]C*
+//         CHECK-SAME:  )*,
+//         CHECK-SAME:  %swift.type*,
+//         CHECK-SAME:  [[INT]],
+//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:    %TSi*,
+//         CHECK-SAME:    %swift.type*
+//         CHECK-SAME:  )*,
+//         CHECK-SAME:  %swift.type*,
+//         CHECK-SAME:  [[INT]],
+//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:    %swift.opaque*,
+//         CHECK-SAME:    %swift.type*
+//         CHECK-SAME:  )*
+//         CHECK-SAME:}> <{
+//         CHECK-SAME:  void (
+//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]C*
+//         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]CfD
+//         CHECK-SAME:  $sBoWV
+//   CHECK-apple-SAME:  $s4main5Value[[UNIQUE_ID_1]]CySSGMM
+// CHECK-unknown-SAME:  [[INT]] 0,
+//                   :  %swift.type* getelementptr inbounds (
+//                   :    %swift.full_heapmetadata,
+//                   :    %swift.full_heapmetadata* bitcast (
+//                   :      <{
+//                   :        void (
+//                   :          %T4main9Ancestor1[[UNIQUE_ID_1]]C*
+//                   :        )*,
+//                   :        i8**,
+//                   :        [[INT]],
+//                   :        %objc_class*,
+//                   :        %swift.type*,
+//                   :        %swift.opaque*,
+//                   :        %swift.opaque*,
+//                   :        [[INT]],
+//                   :        i32,
+//                   :        i32,
+//                   :        i32,
+//                   :        i16,
+//                   :        i16,
+//                   :        i32,
+//                   :        i32,
+//                   :        %swift.type_descriptor*,
+//                   :        i8*,
+//                   :        %swift.type*,
+//                   :        [[INT]],
+//                   :        %T4main9Ancestor1[[UNIQUE_ID_1]]C* (
+//                   :          %swift.opaque*,
+//                   :          %swift.type*
+//                   :        )*
+//                   :      }>* @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMf" to %swift.full_heapmetadata*
+//                   :    ),
+//                   :    i32 0,
+//                   :    i32 2
+//                   :  ),
+//   CHECK-apple-SAME:  %swift.opaque* @_objc_empty_cache,
+//   CHECK-apple-SAME:  %swift.opaque* null,
+//   CHECK-apple-SAME:  [[INT]] add (
+//   CHECK-apple-SAME:    [[INT]] ptrtoint (
+//   CHECK-apple-SAME:      {
+//   CHECK-apple-SAME:        i32,
+//   CHECK-apple-SAME:        i32,
+//   CHECK-apple-SAME:        i32,
+//                   :        i32,
+//   CHECK-apple-SAME:        i8*,
+//   CHECK-apple-SAME:        i8*,
+//   CHECK-apple-SAME:        i8*,
+//                   :        i8*,
+//   CHECK-apple-SAME:        {
+//   CHECK-apple-SAME:          i32,
+//   CHECK-apple-SAME:          i32,
+//   CHECK-apple-SAME:          [
+//   CHECK-apple-SAME:            1 x {
+//   CHECK-apple-SAME:              [[INT]]*,
+//   CHECK-apple-SAME:              i8*,
+//   CHECK-apple-SAME:              i8*,
+//   CHECK-apple-SAME:              i32,
+//   CHECK-apple-SAME:              i32
+//   CHECK-apple-SAME:            }
+//   CHECK-apple-SAME:          ]
+//   CHECK-apple-SAME:        }*,
+//   CHECK-apple-SAME:        i8*,
+//   CHECK-apple-SAME:        i8*
+//   CHECK-apple-SAME:      }* @_DATA__TtC4mainP33_4D007063F2EFC1988130B7D42A21EE4C5Value to [[INT]]
+//   CHECK-apple-SAME:    ),
+//   CHECK-apple-SAME:    [[INT]] 2
+//   CHECK-apple-SAME:  ),
+//         CHECK-SAME:  i32 26,
+//         CHECK-SAME:  i32 0,
+//         CHECK-SAME:  i32 {{(40|24)}},
+//         CHECK-SAME:  i16 {{(7|3)}},
+//         CHECK-SAME:  i16 0,
+//   CHECK-apple-SAME:  i32 {{(144|84)}},
+// CHECK-unknown-SAME:  i32 120,
+//         CHECK-SAME:  i32 {{(16|8)}},
+//                   :  %swift.type_descriptor* bitcast (
+//                   :    <{
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i16,
+//                   :      i16,
+//                   :      i16,
+//                   :      i16,
+//                   :      i8,
+//                   :      i8,
+//                   :      i8,
+//                   :      i8,
+//                   :      i32,
+//                   :      i32,
+//                   :      %swift.method_descriptor,
+//                   :      i32,
+//                   :      %swift.method_override_descriptor
+//                   :    }>* @"$s4main5Value[[UNIQUE_ID_1]]CMn" to %swift.type_descriptor*
+//                   :  ),
+//         CHECK-SAME:  void (
+//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]C*
+//         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]CfE
+//         CHECK-SAME:  %swift.type* @"$sSSN",
+//         CHECK-SAME:  [[INT]] {{(16|8)}},
+//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:    %TSi*,
+//         CHECK-SAME:    %swift.type*
+//         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGSi_tcfCAA9Ancestor1ACLLCAeHyxGx_tcfCTV
+//         CHECK-SAME:  %swift.type* @"$sSSN",
+//         CHECK-SAME:  [[INT]] {{(24|12)}},
+//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:    %swift.opaque*,
+//         CHECK-SAME:    %swift.type*
+//         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGx_tcfC
+//         CHECK-SAME:}>,
+//         CHECK-SAME:align [[ALIGNMENT]]
+
+
+fileprivate class Ancestor1<First> {
+  let first_Ancestor1: First
+
+  init(first: First) {
+    self.first_Ancestor1 = first
+  }
+}
+
+fileprivate class Value<First> : Ancestor1<Int> {
+  let first_Value: First
+
+  init(first: First) {
+    self.first_Value = first
+    super.init(first: 13)
+  }
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+func doit() {
+  consume( Value(first: "13") )
+}
+doit()
+
+//        CHECK-LABEL: define hidden swiftcc void @"$s4main4doityyF"()
+//              CHECK:   call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CySSGMb"
+//              CHECK: }
+
+//              CHECK: ; Function Attrs: noinline nounwind readnone
+//              CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CySSGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]+}} {
+//         CHECK-NEXT: entry:
+//      CHECK-unknown:   [[SUPER_CLASS_METADATA:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
+//      CHECK-unknown:  ret
+//        CHECK-apple:  [[THIS_CLASS_METADATA:%[0-9]+]] = call %objc_class* @objc_opt_self(
+//                   :   %objc_class* bitcast (
+//                   :     %swift.type* getelementptr inbounds (
+//                   :       %swift.full_heapmetadata,
+//                   :       %swift.full_heapmetadata* bitcast (
+//                   :         <{
+//                   :           void (
+//                   :             %T4main5Value[[UNIQUE_ID_1]]C*
+//                   :           )*,
+//                   :           i8**,
+//                   :           i64,
+//                   :           %swift.type*,
+//                   :           %swift.opaque*,
+//                   :           %swift.opaque*,
+//                   :           i64,
+//                   :           i32,
+//                   :           i32,
+//                   :           i32,
+//                   :           i16,
+//                   :           i16,
+//                   :           i32,
+//                   :           i32,
+//                   :           %swift.type_descriptor*,
+//                   :           void (
+//                   :             %T4main5Value[[UNIQUE_ID_1]]C*
+//                   :           )*,
+//                   :           %swift.type*,
+//                   :           i64,
+//                   :           %T4main5Value[[UNIQUE_ID_1]]C* (
+//                   :             %TSi*,
+//                   :             %swift.type*
+//                   :           )*,
+//                   :           %swift.type*,
+//                   :           i64,
+//                   :           %T4main5Value[[UNIQUE_ID_1]]C* (
+//                   :             %swift.opaque*,
+//                   :             %swift.type*
+//                   :           )*
+//                   :         }>* 
+//         CHECK-SAME:         @"$s4main5Value[[UNIQUE_ID_1]]CySSGMf" 
+//                   :         to %swift.full_heapmetadata*
+//                   :       ),
+//                   :       i32 0,
+//                   :       i32 2
+//                   :     ) to %objc_class*
+//                   :   )
+//                   : )
+//        CHECK-apple:   [[THIS_TYPE_METADATA:%[0-9]+]] = bitcast %objc_class* [[THIS_CLASS_METADATA]] to %swift.type*
+//        CHECK-apple:   [[SUPER_CLASS_METADATA:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
+//        CHECK-apple:   [[RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[THIS_TYPE_METADATA]], 0
+//        CHECK-apple:   [[COMPLETE_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response %5, [[INT]] 0, 1
+//        CHECK-apple:   ret %swift.metadata_response [[COMPLETE_RESPONSE]]
+//              CHECK: }
+
+//              CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_generic-1argument-1st_argument_subclass_argument.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_generic-1argument-1st_argument_subclass_argument.swift
@@ -1,0 +1,315 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+//         CHECK: @"$s4main9Ancestor1[[UNIQUE_ID_1:[A-Za-z_0-9]+]]CySiGMf" = linkonce_odr hidden 
+//   CHECK-apple: global 
+// CHECK-unknown: constant 
+//              : <{ 
+//              :   void (%T4main9Ancestor1[[UNIQUE_ID_1]]C*)*, 
+//              :   i8**, 
+//              :   i64, 
+//              :   %objc_class*, 
+//              :   %swift.opaque*, 
+//              :   %swift.opaque*, 
+//              :   i64, 
+//              :   i32, 
+//              :   i32, 
+//              :   i32, 
+//              :   i16, 
+//              :   i16, 
+//              :   i32, 
+//              :   i32, 
+//              :   %swift.type_descriptor*, 
+//              :   i8*, 
+//              :   %swift.type*, 
+//              :   i64, 
+//              :   %T4main9Ancestor1[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)* 
+//              : }> <{ 
+//              :   void (%T4main9Ancestor1[[UNIQUE_ID_1]]C*)* 
+//              :   @"$s4main9Ancestor1[[UNIQUE_ID_1]]CfD", 
+//              :   i8** @"$sBoWV", 
+//              :   i64 ptrtoint (
+//              :     %objc_class* @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMM" to i64
+//              :   ), 
+//              :   %objc_class* @"OBJC_CLASS_$__TtCs12_SwiftObject", 
+//              :   %swift.opaque* @_objc_empty_cache, 
+//              :   %swift.opaque* null, 
+//              :   i64 add (
+//              :     i64 ptrtoint (
+//              :       { 
+//              :         i32, 
+//              :         i32, 
+//              :         i32, 
+//              :         i32, 
+//              :         i8*, 
+//              :         i8*, 
+//              :         i8*, 
+//              :         i8*, 
+//              :         { 
+//              :           i32, 
+//              :           i32, 
+//              :           [1 x { i64*, i8*, i8*, i32, i32 }] 
+//              :         }*, 
+//              :         i8*, 
+//              :         i8* 
+//              :       }* @_DATA__TtC4mainP33_496329636AC05466637A72F247DC6ABC9Ancestor1 to i64
+//              :     ), 
+//              :     i64 2
+//              :   ), 
+//              :   i32 26, 
+//              :   i32 0, 
+//              :   i32 16, 
+//              :   i16 7, 
+//              :   i16 0, 
+//              :   i32 120, 
+//              :   i32 16, 
+//              :   %swift.type_descriptor* bitcast (
+//              :     <{ 
+//              :       i32, 
+//              :       i32, 
+//              :       i32, 
+//              :       i32, 
+//              :       i32, 
+//              :       i32, 
+//              :       i32, 
+//              :       i32, 
+//              :       i32, 
+//              :       i32, 
+//              :       i32, 
+//              :       i32, 
+//              :       i32, 
+//              :       i16, 
+//              :       i16, 
+//              :       i16, 
+//              :       i16, 
+//              :       i8, 
+//              :       i8, 
+//              :       i8, 
+//              :       i8, 
+//              :       i32, 
+//              :       i32, 
+//              :       %swift.method_descriptor 
+//              :     }>* @"$s4main9Ancestor1[[UNIQUE_ID_1]]CMn" 
+//              :     to %swift.type_descriptor*
+//              :   ), 
+//              :   i8* null, 
+//              :   %swift.type* @"$sSiN", 
+//              :   i64 16, 
+//              :   %T4main9Ancestor1[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)* 
+//              :   @"$s4main9Ancestor1[[UNIQUE_ID_1]]C5firstADyxGx_tcfC" 
+//              : }>, align [[ALIGNMENT]]
+
+
+//              CHECK: @"$s4main5Value[[UNIQUE_ID_1]]CySiGMf" = linkonce_odr hidden 
+//   CHECK-apple-SAME: global
+// CHECK-unknown-SAME: constant
+//         CHECK-SAME: <{
+//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]C*)*, 
+//         CHECK-SAME:   i8**, 
+//                   :   [[INT]], 
+//         CHECK-SAME:   %swift.type*, 
+//   CHECK-apple-SAME:   %swift.opaque*, 
+//   CHECK-apple-SAME:   %swift.opaque*, 
+//   CHECK-apple-SAME:   [[INT]], 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i16, 
+//         CHECK-SAME:   i16, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   %swift.type_descriptor*, 
+//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]C*)*, 
+//         CHECK-SAME:   %swift.type*, 
+//         CHECK-SAME:   [[INT]], 
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)*, 
+//         CHECK-SAME:   %swift.type*, 
+//         CHECK-SAME:   [[INT]] 
+//         CHECK-SAME: }> <{ 
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]CfD
+//         CHECK-SAME:   $sBoWV
+//   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]CySiGMM
+// CHECK-unknown-SAME:   [[INT]] 0,
+//                   :   %swift.type* getelementptr inbounds (
+//                   :     %swift.full_heapmetadata, 
+//                   :     %swift.full_heapmetadata* bitcast (
+//                   :       <{ 
+//                   :         void (%T4main9Ancestor1[[UNIQUE_ID_1]]C*)*, 
+//                   :         i8**, 
+//                   :         [[INT]], 
+//                   :         %objc_class*, 
+//                   :         %swift.type*, 
+//                   :         %swift.opaque*, 
+//                   :         %swift.opaque*, 
+//                   :         [[INT]], 
+//                   :         i32, 
+//                   :         i32, 
+//                   :         i32, 
+//                   :         i16, 
+//                   :         i16, 
+//                   :         i32, 
+//                   :         i32, 
+//                   :         %swift.type_descriptor*, 
+//                   :         i8*, 
+//                   :         %swift.type*, 
+//                   :         [[INT]], 
+//                   :         %T4main9Ancestor1[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)* 
+//                   :       }>* @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMf" 
+//                   :       to %swift.full_heapmetadata*
+//                   :     ), 
+//                   :     i32 0, 
+//                   :     i32 2
+//                   :   ), 
+//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache, 
+//   CHECK-apple-SAME:   %swift.opaque* null, 
+//   CHECK-apple-SAME:   [[INT]] add (
+//   CHECK-apple-SAME:     [[INT]] ptrtoint (
+//   CHECK-apple-SAME:       { 
+//   CHECK-apple-SAME:         i32, 
+//   CHECK-apple-SAME:         i32, 
+//   CHECK-apple-SAME:         i32, 
+//                   :         i32, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         { 
+//   CHECK-apple-SAME:           i32, 
+//   CHECK-apple-SAME:           i32, 
+//   CHECK-apple-SAME:           [1 x { [[INT]]*, i8*, i8*, i32, i32 }] 
+//   CHECK-apple-SAME:         }*, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8* 
+//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP33_496329636AC05466637A72F247DC6ABC5Value to [[INT]]
+//   CHECK-apple-SAME:     ), 
+//   CHECK-apple-SAME:     [[INT]] 2
+//   CHECK-apple-SAME:   ), 
+//         CHECK-SAME:   i32 26, 
+//         CHECK-SAME:   i32 0, 
+//         CHECK-SAME:   i32 {{(32|16)}}, 
+//         CHECK-SAME:   i16 {{(7|3)}}, 
+//         CHECK-SAME:   i16 0, 
+//   CHECK-apple-SAME:   i32 {{(136|80)}}, 
+// CHECK-unknown-SAME:   i32 112,
+//         CHECK-SAME:   i32 {{(16|8)}}, 
+//                   :   %swift.type_descriptor* bitcast (
+//                   :     <{ 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i16, 
+//                   :       i16, 
+//                   :       i16, 
+//                   :       i16, 
+//                   :       i8, 
+//                   :       i8, 
+//                   :       i8, 
+//                   :       i8, 
+//                   :       i32, 
+//                   :       %swift.method_override_descriptor 
+//                   :     }>* @"$s4main5Value[[UNIQUE_ID_1]]CMn" 
+//                   :     to %swift.type_descriptor*
+//                   :   ), 
+//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]C*)* 
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]CfE
+//         CHECK-SAME:   %swift.type* @"$sSiN", 
+//         CHECK-SAME:   [[INT]] {{(16|8)}}, 
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)* 
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGx_tcfC
+//         CHECK-SAME:   %swift.type* @"$sSiN", 
+//         CHECK-SAME:   [[INT]] {{(24|12)}}
+//         CHECK-SAME: }>, align [[ALIGNMENT]]
+
+
+fileprivate class Ancestor1<First> {
+  let first_Ancestor1: First
+
+  init(first: First) {
+    self.first_Ancestor1 = first
+  }
+}
+
+fileprivate class Value<First> : Ancestor1<First> {
+  let first_Value: First
+
+  override init(first: First) {
+    self.first_Value = first
+    super.init(first: first)
+  }
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+func doit() {
+  consume( Value(first: 13) )
+}
+doit()
+
+//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CySiGMb"
+//    CHECK-NEXT: entry:
+// CHECK-unknown:   [[SUPER_CLASS_METADATA:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
+//   CHECK-apple:  [[THIS_CLASS_METADATA:%[0-9]+]] = call %objc_class* @objc_opt_self(
+//   CHECK-apple:    %objc_class* bitcast (
+// CHECK-unknown:    ret
+//              :     %objc_class* bitcast (
+//              :       %swift.type* getelementptr inbounds (
+//              :         %swift.full_heapmetadata, 
+//              :         %swift.full_heapmetadata* bitcast (
+//              :           <{ 
+//              :             void (%T4main5Value[[UNIQUE_ID_1]]C*)*, 
+//              :             i8**, 
+//              :             i64, 
+//              :             %swift.type*, 
+//              :             %swift.opaque*, 
+//              :             %swift.opaque*, 
+//              :             i64, 
+//              :             i32, 
+//              :             i32, 
+//              :             i32, 
+//              :             i16, 
+//              :             i16, 
+//              :             i32, 
+//              :             i32, 
+//              :             %swift.type_descriptor*, 
+//              :             void (%T4main5Value[[UNIQUE_ID_1]]C*)*, 
+//              :             %swift.type*, 
+//              :             i64, 
+//              :             %T4main5Value[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)*, 
+//              :             %swift.type*, 
+//              :             i64 
+//              :           }>* 
+//    CHECK-SAME:           @"$s4main5Value[[UNIQUE_ID_1]]CySiGMf" 
+//              :           to %swift.full_heapmetadata*
+//              :         ), 
+//              :         i32 0, 
+//              :         i32 2
+//              :       ) to %objc_class*
+//              :     )
+//              :   )
+//   CHECK-apple:   [[THIS_TYPE_METADATA:%[0-9]+]] = bitcast %objc_class* [[THIS_CLASS_METADATA]] to %swift.type*
+//   CHECK-apple:   [[SUPER_CLASS_METADATA:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
+//   CHECK-apple:   [[RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[THIS_TYPE_METADATA]], 0
+//   CHECK-apple:   [[COMPLETE_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[RESPONSE]], [[INT]] 0, 1
+//   CHECK-apple:   ret %swift.metadata_response [[COMPLETE_RESPONSE]]
+//         CHECK: }
+
+//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"
+

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_generic-1argument-1st_argument_superclass.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_generic-1argument-1st_argument_superclass.swift
@@ -1,0 +1,322 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+
+// CHECK: @"$s4main9Ancestor1[[UNIQUE_ID_1:[A-Za-z_0-9]+]]LLCyADySSGGMf" =
+//              CHECK: @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Ancestor1ACLLCySSGGMf" = linkonce_odr hidden 
+//   CHECK-apple-SAME: global
+// CHECK-unknown-SMAE: constant
+//         CHECK-SAME: <{
+//         CHECK-SAME:   void (
+//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:  )*,
+//         CHECK-SAME:  i8**,
+//                   :  [[INT]],
+//         CHECK-SAME:  %swift.type*,
+//   CHECK-apple-SAME:  %swift.opaque*,
+//   CHECK-apple-SAME:  %swift.opaque*,
+//   CHECK-apple-SAME:  [[INT]],
+//         CHECK-SAME:  i32,
+//         CHECK-SAME:  i32,
+//         CHECK-SAME:  i32,
+//         CHECK-SAME:  i16,
+//         CHECK-SAME:  i16,
+//         CHECK-SAME:  i32,
+//         CHECK-SAME:  i32,
+//         CHECK-SAME:  %swift.type_descriptor*,
+//         CHECK-SAME:  void (
+//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:  )*,
+//         CHECK-SAME:  %swift.type*,
+//         CHECK-SAME:  [[INT]],
+//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]LLC* (
+//         CHECK-SAME:    %swift.opaque*,
+//         CHECK-SAME:    %swift.type*
+//         CHECK-SAME:  )*,
+//         CHECK-SAME:  %swift.type*,
+//         CHECK-SAME:  [[INT]]
+//         CHECK-SAME:}> <{
+//         CHECK-SAME:  void (
+//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCfD
+//         CHECK-SAME:  $sBoWV
+//   CHECK-apple-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCyAA9Ancestor1ACLLCySSGGMM
+// CHECK-unknown-SAME:  [[INT]] 0,
+//                   :  %swift.type* getelementptr inbounds (
+//                   :    %swift.full_heapmetadata,
+//                   :    %swift.full_heapmetadata* bitcast (
+//                   :      <{
+//                   :        void (
+//                   :          %T4main9Ancestor1[[UNIQUE_ID_1]]LLC*
+//                   :        )*,
+//                   :        i8**,
+//                   :        [[INT]],
+//                   :        %objc_class*,
+//                   :        %swift.type*,
+//                   :        %swift.opaque*,
+//                   :        %swift.opaque*,
+//                   :        [[INT]],
+//                   :        i32,
+//                   :        i32,
+//                   :        i32,
+//                   :        i16,
+//                   :        i16,
+//                   :        i32,
+//                   :        i32,
+//                   :        %swift.type_descriptor*,
+//                   :        i8*,
+//                   :        %swift.type*,
+//                   :        [[INT]],
+//                   :        %T4main9Ancestor1[[UNIQUE_ID_1]]LLC* (
+//                   :          %swift.opaque*,
+//                   :          %swift.type*
+//                   :        )*
+//                   :      }>* @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCyADySSGGMf" to %swift.full_heapmetadata*
+//                   :    ),
+//                   :    i32 0,
+//                   :    i32 2
+//                   :  ),
+//   CHECK-apple-SAME:  %swift.opaque* @_objc_empty_cache,
+//   CHECK-apple-SAME:  %swift.opaque* null,
+//   CHECK-apple-SAME:  [[INT]] add (
+//   CHECK-apple-SAME:    [[INT]] ptrtoint (
+//   CHECK-apple-SAME:      {
+//   CHECK-apple-SAME:        i32,
+//   CHECK-apple-SAME:        i32,
+//   CHECK-apple-SAME:        i32,
+//                   :        i32,
+//   CHECK-apple-SAME:        i8*,
+//   CHECK-apple-SAME:        i8*,
+//   CHECK-apple-SAME:        i8*,
+//                   :        i8*,
+//   CHECK-apple-SAME:        {
+//   CHECK-apple-SAME:          i32,
+//   CHECK-apple-SAME:          i32,
+//   CHECK-apple-SAME:          [
+//   CHECK-apple-SAME:            1 x {
+//   CHECK-apple-SAME:              [[INT]]*,
+//   CHECK-apple-SAME:              i8*,
+//   CHECK-apple-SAME:              i8*,
+//   CHECK-apple-SAME:              i32,
+//   CHECK-apple-SAME:              i32
+//   CHECK-apple-SAME:            }
+//   CHECK-apple-SAME:          ]
+//   CHECK-apple-SAME:        }*,
+//   CHECK-apple-SAME:        i8*,
+//   CHECK-apple-SAME:        i8*
+//   CHECK-apple-SAME:      }* @_DATA__TtC4mainP[[UNIQUE_ID_1]]5Value to [[INT]]
+//   CHECK-apple-SAME:    ),
+//   CHECK-apple-SAME:    [[INT]] 2
+//   CHECK-apple-SAME:  ),
+//         CHECK-SAME:  i32 26,
+//         CHECK-SAME:  i32 0,
+//         CHECK-SAME:  i32 {{(32|16)}},
+//         CHECK-SAME:  i16 {{(7|3)}},
+//         CHECK-SAME:  i16 0,
+//   CHECK-apple-SAME:  i32 {{(136|80)}},
+// CHECK-unknown-SAME:  i32 112,
+//   CHECK-apple-SAME:  i32 {{(16|8)}},
+//                   :  %swift.type_descriptor* bitcast (
+//                   :    <{
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i32,
+//                   :      i16,
+//                   :      i16,
+//                   :      i16,
+//                   :      i16,
+//                   :      i8,
+//                   :      i8,
+//                   :      i8,
+//                   :      i8,
+//                   :      i32,
+//                   :      %swift.method_override_descriptor
+//                   :    }>* @"$s4main5Value[[UNIQUE_ID_1]]LLCMn" to %swift.type_descriptor*
+//                   :  ),
+//         CHECK-SAME:  void (
+//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCfE
+//         CHECK-SAME:  %swift.type* getelementptr inbounds (
+//         CHECK-SAME:    %swift.full_heapmetadata,
+//         CHECK-SAME:    %swift.full_heapmetadata* bitcast (
+//         CHECK-SAME:      <{
+//         CHECK-SAME:        void (
+//         CHECK-SAME:          %T4main9Ancestor1[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:        )*,
+//         CHECK-SAME:        i8**,
+//                   :        [[INT]],
+//   CHECK-apple-SAME:        %objc_class*,
+// CHECK-unknown-SAME:        %swift.type*,
+//   CHECK-apple-SAME:        %swift.opaque*,
+//   CHECK-apple-SAME:        %swift.opaque*,
+//   CHECK-apple-SAME:        [[INT]],
+//         CHECK-SAME:        i32,
+//         CHECK-SAME:        i32,
+//         CHECK-SAME:        i32,
+//         CHECK-SAME:        i16,
+//         CHECK-SAME:        i16,
+//         CHECK-SAME:        i32,
+//         CHECK-SAME:        i32,
+//         CHECK-SAME:        %swift.type_descriptor*,
+//         CHECK-SAME:        i8*,
+//         CHECK-SAME:        %swift.type*,
+//         CHECK-SAME:        [[INT]],
+//         CHECK-SAME:        %T4main9Ancestor1[[UNIQUE_ID_1]]LLC* (
+//         CHECK-SAME:          %swift.opaque*,
+//         CHECK-SAME:          %swift.type*
+//         CHECK-SAME:        )*
+//         CHECK-SAME:      }>* @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySSGMf" to %swift.full_heapmetadata*
+//         CHECK-SAME:    ),
+//         CHECK-SAME:    i32 0,
+//         CHECK-SAME:    i32 2
+//         CHECK-SAME:  ),
+//         CHECK-SAME:  [[INT]] {{16|8}},
+//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]LLC* (
+//         CHECK-SAME:    %swift.opaque*,
+//         CHECK-SAME:    %swift.type*
+//         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC
+//         CHECK-SAME:  %swift.type* getelementptr inbounds (
+//         CHECK-SAME:    %swift.full_heapmetadata,
+//         CHECK-SAME:    %swift.full_heapmetadata* bitcast (
+//         CHECK-SAME:      <{
+//         CHECK-SAME:        void (
+//         CHECK-SAME:          %T4main9Ancestor1[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:        )*,
+//         CHECK-SAME:        i8**,
+//                   :        [[INT]],
+//   CHECK-apple-SAME:        %objc_class*,
+// CHECK-unknown-SAME:        %swift.type*,
+//   CHECK-apple-SAME:        %swift.opaque*,
+//   CHECK-apple-SAME:        %swift.opaque*,
+//   CHECK-apple-SAME:        [[INT]],
+//         CHECK-SAME:        i32,
+//         CHECK-SAME:        i32,
+//         CHECK-SAME:        i32,
+//         CHECK-SAME:        i16,
+//         CHECK-SAME:        i16,
+//         CHECK-SAME:        i32,
+//         CHECK-SAME:        i32,
+//         CHECK-SAME:        %swift.type_descriptor*,
+//         CHECK-SAME:        i8*,
+//         CHECK-SAME:        %swift.type*,
+//         CHECK-SAME:        [[INT]],
+//         CHECK-SAME:        %T4main9Ancestor1[[UNIQUE_ID_1]]LLC* (
+//         CHECK-SAME:          %swift.opaque*,
+//         CHECK-SAME:          %swift.type*
+//         CHECK-SAME:        )*
+//         CHECK-SAME:      }>* @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySSGMf" to %swift.full_heapmetadata*
+//         CHECK-SAME:    ),
+//         CHECK-SAME:    i32 0,
+//         CHECK-SAME:    i32 2
+//         CHECK-SAME:  ),
+//         CHECK-SAME:  [[INT]] {{24|12}}
+//         CHECK-SAME:}>,
+//         CHECK-SAME:align [[ALIGNMENT]]
+
+
+fileprivate class Ancestor1<First> {
+  let first_Ancestor1: First
+
+  init(first: First) {
+    self.first_Ancestor1 = first
+  }
+}
+
+fileprivate class Value<First> : Ancestor1<First> {
+  let first_Value: First
+
+  override init(first: First) {
+    self.first_Value = first
+    super.init(first: first)
+  }
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+func doit() {
+  consume( Value(first: Ancestor1(first: "13")) )
+}
+doit()
+
+//        CHECK-LABEL: define hidden swiftcc void @"$s4main4doityyF"()
+//              CHECK:   call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Ancestor1ACLLCySSGGMb"
+//              CHECK: }
+
+//              CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySSGMb"
+
+//              CHECK: ; Function Attrs: noinline nounwind readnone
+//              CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Ancestor1ACLLCySSGGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]+}} {
+//         CHECK-NEXT: entry:
+//      CHECK-unknown:   [[ARGUMENT_CLASS_METADATA:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySSGMb"([[INT]] 0)
+//      CHECK-unknown:   [[SUPER_CLASS_METADATA:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCyADySSGGMb"([[INT]] 0)
+//      CHECK-unknown:   ret
+//        CHECK-apple:   [[THIS_CLASS_METADATA:%[0-9]+]] = call %objc_class* @objc_opt_self(
+//                   :     %objc_class* bitcast (
+//                   :       %swift.type* getelementptr inbounds (
+//                   :         %swift.full_heapmetadata,
+//                   :         %swift.full_heapmetadata* bitcast (
+//                   :           <{
+//                   :             void (
+//                   :               %T4main5Value[[UNIQUE_ID_1]]LLC*
+//                   :             )*,
+//                   :             i8**,
+//                   :             [[INT]],
+//                   :             %swift.type*,
+//                   :             %swift.opaque*,
+//                   :             %swift.opaque*,
+//                   :             [[INT]],
+//                   :             i32,
+//                   :             i32,
+//                   :             i32,
+//                   :             i16,
+//                   :             i16,
+//                   :             i32,
+//                   :             i32,
+//                   :             %swift.type_descriptor*,
+//                   :             void (
+//                   :               %T4main5Value[[UNIQUE_ID_1]]LLC*
+//                   :             )*,
+//                   :             %swift.type*,
+//                   :             [[INT]],
+//                   :             %T4main5Value[[UNIQUE_ID_1]]LLC* (
+//                   :               %swift.opaque*,
+//                   :               %swift.type*
+//                   :             )*,
+//                   :             %swift.type*,
+//                   :             [[INT]]
+//        CHECK-apple:           }>* @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Ancestor1ACLLCySSGGMf" 
+//                   :           to %swift.full_heapmetadata*
+//                   :         ),
+//                   :         i32 0,
+//                   :         i32 2
+//                   :       ) to %objc_class*
+//                   :     )
+//        CHECK-apple:   )
+//        CHECK-apple:   [[THIS_TYPE_METADATA:%[0-9]+]] = bitcast %objc_class* [[THIS_CLASS_METADATA]] to %swift.type*
+//        CHECK-apple:   [[ARGUMENT_CLASS_METADATA:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySSGMb"([[INT]] 0)
+//        CHECK-apple:   [[SUPER_CLASS_METADATA:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCyADySSGGMb"([[INT]] 0)
+//        CHECK-apple:   [[RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[THIS_TYPE_METADATA]], 0
+//        CHECK-apple:   [[COMPLETE_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[RESPONSE]], [[INT]] 0, 1
+//        CHECK-apple:   ret %swift.metadata_response [[COMPLETE_RESPONSE]]
+//              CHECK: }
+
+//              CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main9Ancestor133_51697B6EAB71ECF43599389041BB2421LLCyADySSGGMb"([[INT]] {{%[0-9]+}})
+

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use-1st_argument_generic_class-1argument.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use-1st_argument_generic_class-1argument.swift
@@ -1,0 +1,297 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+//              CHECK: @"$s4main9Argument1[[UNIQUE_ID_1:[0-9A-Z_]+]]CySiGMf" = linkonce_odr hidden 
+//   CHECK-apple-SAME: global 
+// CHECK-unknown-SAME: constant
+//                   : <{ 
+//                   :   void (%T4main9Argument1[[UNIQUE_ID_1]]C*)*, 
+//                   :   i8**, 
+//                   :   i64, 
+//                   :   %objc_class*, 
+//                   :   %swift.opaque*, 
+//                   :   %swift.opaque*, 
+//                   :   i64, 
+//                   :   i32, 
+//                   :   i32, 
+//                   :   i32, 
+//                   :   i16, 
+//                   :   i16, 
+//                   :   i32, 
+//                   :   i32, 
+//                   :   %swift.type_descriptor*, 
+//                   :   i8*, 
+//                   :   %swift.type*, 
+//                   :   i64, 
+//                   :   %T4main9Argument1[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)* 
+//                   : }> <{ 
+//                   :   void (%T4main9Argument1[[UNIQUE_ID_1]]C*)* @"$s4main9Argument1[[UNIQUE_ID_1]]CfD", 
+//                   :   i8** @"$sBoWV", 
+//                   :   i64 ptrtoint (%objc_class* @"$s4main9Argument1[[UNIQUE_ID_1]]CySiGMM" to i64), 
+//                   :   %objc_class* @"OBJC_CLASS_$__TtCs12_SwiftObject", 
+//                   :   %swift.opaque* @_objc_empty_cache, 
+//                   :   %swift.opaque* null, 
+//                   :   i64 add (
+//                   :     i64 ptrtoint (
+//                   :       { 
+//                   :         i32, 
+//                   :         i32, 
+//                   :         i32, 
+//                   :         i32, 
+//                   :         i8*, 
+//                   :         i8*, 
+//                   :         i8*, 
+//                   :         i8*, 
+//                   :         { 
+//                   :           i32, 
+//                   :           i32, 
+//                   :           [1 x { i64*, i8*, i8*, i32, i32 }] 
+//                   :         }*, 
+//                   :         i8*, 
+//                   :         i8* 
+//                   :       }* @_DATA__TtC4mainP33_7FA9B79F85D716E7DB33358C0057E87D9Argument1 to i64
+//                   :     ), 
+//                   :     i64 2
+//                   :   ), 
+//                   :   i32 26, 
+//                   :   i32 0, 
+//                   :   i32 16, 
+//                   :   i16 7, 
+//                   :   i16 0, 
+//                   :   i32 120, 
+//                   :   i32 16, 
+//                   :   %swift.type_descriptor* bitcast (
+//                   :     <{ 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i16, 
+//                   :       i16, 
+//                   :       i16, 
+//                   :       i16, 
+//                   :       i8, 
+//                   :       i8, 
+//                   :       i8, 
+//                   :       i8, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       %swift.method_descriptor 
+//                   :     }>* @"$s4main9Argument1[[UNIQUE_ID_1]]CMn" 
+//                   :     to %swift.type_descriptor*
+//                   :   ), 
+//                   :   i8* null, 
+//                   :   %swift.type* @"$sSiN", 
+//                   :   i64 16, 
+//                   :   %T4main9Argument1[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)* @"$s4main9Argument1[[UNIQUE_ID_1]]C5firstADyxGx_tcfC" 
+//                   : }>, align 8
+
+//              CHECK: @"$s4main5Value[[UNIQUE_ID_1]]CyAA9Argument1ACLLCySiGGMf" = linkonce_odr hidden 
+//   CHECK-apple-SAME: global 
+// CHECK-unknown-SAME: constant
+//         CHECK-SAME: <{ 
+//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]C*)*, 
+//         CHECK-SAME:   i8**, 
+//                   :   [[INT]], 
+//   CHECK-SAME-apple:   %objc_class*, 
+// CHECK-SAME-unknown:   %swift.type*, 
+//   CHECK-apple-SAME:   %swift.opaque*, 
+//   CHECK-apple-SAME:   %swift.opaque*, 
+//   CHECK-apple-SAME:   [[INT]], 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i16, 
+//         CHECK-SAME:   i16, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   %swift.type_descriptor*, 
+//         CHECK-SAME:   i8*, 
+//         CHECK-SAME:   %swift.type*, 
+//         CHECK-SAME:   [[INT]], 
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)*
+//         CHECK-SAME: }> <{ 
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]CfD
+//         CHECK-SAME:   $sBoWV
+//   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]CyAA9Argument1ACLLCySiGGMM
+//   CHECK-apple-SAME:   OBJC_CLASS_$__TtCs12_SwiftObject
+//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache, 
+//   CHECK-apple-SAME:   %swift.opaque* null, 
+//   CHECK-apple-SAME:   [[INT]] add (
+//   CHECK-apple-SAME:     [[INT]] ptrtoint (
+//   CHECK-apple-SAME:       { 
+//   CHECK-apple-SAME:         i32, 
+//   CHECK-apple-SAME:         i32, 
+//   CHECK-apple-SAME:         i32, 
+//                   :         i32, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         { 
+//   CHECK-apple-SAME:           i32, 
+//   CHECK-apple-SAME:           i32, 
+//   CHECK-apple-SAME:           [1 x { [[INT]]*, i8*, i8*, i32, i32 }] 
+//   CHECK-apple-SAME:         }*, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8* 
+//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP33_7FA9B79F85D716E7DB33358C0057E87D5Value to [[INT]]
+//   CHECK-apple-SAME:     ), 
+//   CHECK-apple-SAME:     [[INT]] 2
+//   CHECK-apple-SAME:   ), 
+//         CHECK-SAME:   i32 26, 
+//         CHECK-SAME:   i32 0, 
+//         CHECK-SAME:   i32 {{(24|12)}}, 
+//         CHECK-SAME:   i16 {{(7|3)}}, 
+//         CHECK-SAME:   i16 0, 
+//   CHECK-apple-SAME:   i32 {{(120|72)}}, 
+// CHECK-unknown-SAME:   i32 96,
+//         CHECK-SAME:   i32 {{(16|8)}}, 
+//                   :   %swift.type_descriptor* bitcast (
+//                   :     <{ 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       i16, 
+//                   :       i16, 
+//                   :       i16, 
+//                   :       i16, 
+//                   :       i8, 
+//                   :       i8, 
+//                   :       i8, 
+//                   :       i8, 
+//                   :       i32, 
+//                   :       i32, 
+//                   :       %swift.method_descriptor 
+//                   :     }>* @"$s4main5Value[[UNIQUE_ID_1]]CMn" to %swift.type_descriptor*
+//                   :   ), 
+//         CHECK-SAME:   i8* null, 
+//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//         CHECK-SAME:     %swift.full_heapmetadata, 
+//         CHECK-SAME:     %swift.full_heapmetadata* bitcast (
+//         CHECK-SAME:       <{ 
+//         CHECK-SAME:         void (%T4main9Argument1[[UNIQUE_ID_1]]C*)*, 
+//         CHECK-SAME:         i8**, 
+//                   :         [[INT]], 
+//   CHECK-apple-SAME:         %objc_class*, 
+// CHECK-unknown-SAME:         %swift.type*, 
+//   CHECK-apple-SAME:         %swift.opaque*, 
+//   CHECK-apple-SAME:         %swift.opaque*, 
+//   CHECK-apple-SAME:         [[INT]], 
+//         CHECK-SAME:         i32, 
+//         CHECK-SAME:         i32, 
+//         CHECK-SAME:         i32, 
+//         CHECK-SAME:         i16, 
+//         CHECK-SAME:         i16, 
+//         CHECK-SAME:         i32, 
+//         CHECK-SAME:         i32, 
+//         CHECK-SAME:         %swift.type_descriptor*, 
+//         CHECK-SAME:         i8*, 
+//         CHECK-SAME:         %swift.type*, 
+//         CHECK-SAME:         [[INT]], 
+//         CHECK-SAME:         %T4main9Argument1[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)* 
+//         CHECK-SAME:       }>* @"$s4main9Argument1[[UNIQUE_ID_1]]CySiGMf" 
+//         CHECK-SAME:       to %swift.full_heapmetadata*
+//         CHECK-SAME:     ), 
+//         CHECK-SAME:     i32 0, 
+//         CHECK-SAME:     i32 2
+//         CHECK-SAME:   ), 
+//         CHECK-SAME:   [[INT]] {{(16|8)}}, 
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:     %swift.opaque*, 
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGx_tcfC
+//         CHECK-SAME: }>, align [[ALIGNMENT]]
+
+fileprivate class Argument1<First> {
+  let first_Argument1: First
+
+  init(first: First) {
+    self.first_Argument1 = first
+  }
+}
+
+fileprivate class Value<First> {
+  let first_Value: First
+
+  init(first: First) {
+    self.first_Value = first
+  }
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+func doit() {
+  consume( Value(first: Argument1(first: 13)) )
+}
+doit()
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {
+//      CHECK: entry:
+//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+//      CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+//      CHECK: [[TYPE_COMPARISON_LABEL]]:
+//      CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (
+// CHECK-SAME: @"$s4main9Argument1[[UNIQUE_ID_1]]CySiGMf"
+// CHECK-SAME: ), [[ERASED_TYPE]]
+//      CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+//      CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+//      CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK-NEXT:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_3:[0-9A-Z_]+]]CyAA9Argument1ACLLCySiGGMb"([[INT]] [[METADATA_REQUEST]])
+//      CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+//      CHECK:   [[PARTIAL_RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[METADATA]], 0
+//      CHECK:   [[RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_RESULT_METADATA]], [[INT]] 0, 1
+//      CHECK:   ret %swift.metadata_response [[RESULT_METADATA]] 
+//      CHECK: [[EXIT_NORMAL]]:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+//      CHECK:     [[INT]] [[METADATA_REQUEST]], 
+//      CHECK:     i8* [[ERASED_TYPE]], 
+//      CHECK:     i8* undef, 
+//      CHECK:     i8* undef, 
+//      CHECK:     %swift.type_descriptor* bitcast (
+//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
+//      CHECK:       $s4main5Value[[UNIQUE_ID_1]]CMn
+//      CHECK:       to %swift.type_descriptor*
+//      CHECK:     )
+//      CHECK:   ) #{{[0-9]+}}
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+
+// CHECK:; Function Attrs: noinline nounwind readnone
+// CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CyAA9Argument1ACLLCySiGGMb"([[INT]] [[REQUEST:%[0-9]+]]) #4 {
+// CHECK: entry:
+// CHECK-unknown:    ret
+// CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
+// CHECK-SAME: @"$s4main5Value[[UNIQUE_ID_1]]CyAA9Argument1ACLLCySiGGMf"
+// CHECK-apple:   [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
+// CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+// CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
+// CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use.swift
@@ -1,0 +1,141 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+//              CHECK: @"$s4main5Value[[UNIQUE_ID_1:[0-9A-Z_]+]]CySiGMf" = linkonce_odr hidden 
+//   CHECK-apple-SAME: global
+// CHECK-unknown-SAME: constant 
+//         CHECK-SAME: <{
+//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]C*)*, 
+//         CHECK-SAME:   i8**, 
+//                   :   [[INT]], 
+//   CHECK-apple-SAME:   %objc_class*
+// CHECK-unknown-SAME:   %swift.type*, 
+//   CHECK-apple-SAME:   %swift.opaque*, 
+//   CHECK-apple-SAME:   %swift.opaque*, 
+//   CHECK-apple-SAME:   [[INT]], 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i16, 
+//         CHECK-SAME:   i16, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   i32, 
+//         CHECK-SAME:   %swift.type_descriptor*, 
+//         CHECK-SAME:   i8*, 
+//         CHECK-SAME:   %swift.type*, 
+//         CHECK-SAME:   [[INT]], 
+//   CHECK-apple-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)* 
+//         CHECK-SAME: }> <{ 
+//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]C*)* 
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]CfD
+//         CHECK-SAME:   $sBoWV
+//   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]CySiGMM
+//   CHECK-apple-SAME:   OBJC_CLASS_$__TtCs12_SwiftObject
+//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache, 
+//   CHECK-apple-SAME:   %swift.opaque* null, 
+//   CHECK-apple-SAME:   [[INT]] add (
+//   CHECK-apple-SAME:     [[INT]] ptrtoint (
+//   CHECK-apple-SAME:       { 
+//   CHECK-apple-SAME:         i32, 
+//   CHECK-apple-SAME:         i32, 
+//   CHECK-apple-SAME:         i32, 
+//                   :         i32, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         { i32, i32, [1 x { [[INT]]*, i8*, i8*, i32, i32 }] }*, 
+//   CHECK-apple-SAME:         i8*, 
+//   CHECK-apple-SAME:         i8* 
+//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP[[UNIQUE_ID_2:[0-9A-Z_]+]]5Value to [[INT]]
+//   CHECK-apple-SAME:     ), 
+//   CHECK-apple-SAME:     [[INT]] 2
+//   CHECK-apple-SAME:   ), 
+// CHECK-unknown-SAME:  i64 0, 
+//         CHECK-SAME:   i32 26, 
+//         CHECK-SAME:   i32 0, 
+//         CHECK-SAME:   i32 {{(24|12)}}, 
+//         CHECK-SAME:   i16 {{(7|3)}}, 
+//         CHECK-SAME:   i16 0, 
+//   CHECK-apple-SAME:   i32 {{(120|72)}}, 
+// CHECK-unknown-SAME:   i32 96,
+//         CHECK-SAME:   i32 {{(16|8)}}, 
+//                   :   %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* @"$s4main5Value[[UNIQUE_ID_1]]CMn" to %swift.type_descriptor*), 
+//         CHECK-SAME:   i8* null, 
+//         CHECK-SAME:   %swift.type* @"$sSiN", 
+//         CHECK-SAME:   [[INT]] {{(16|8)}}, 
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)* 
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGx_tcfC
+//         CHECK-SAME: }>, align [[ALIGNMENT]]
+
+fileprivate class Value<First> {
+  let first: First
+
+  init(first: First) {
+    self.first = first
+  }
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]CySiGMb"([[INT]] 0)
+// CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK: }
+func doit() {
+  consume( Value(first: 13) )
+}
+doit()
+
+// CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_LABEL]]:
+// CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE]]
+// CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+// CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK-NEXT:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_3:[0-9A-Z_]+]]CySiGMb"([[INT]] [[METADATA_REQUEST]])
+// CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+// CHECK:   [[PARTIAL_RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[METADATA]], 0
+// CHECK:   [[RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_RESULT_METADATA]], [[INT]] 0, 1
+// CHECK:   ret %swift.metadata_response [[RESULT_METADATA]] 
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK:     i8* [[ERASED_TYPE]], 
+// CHECK:     i8* undef, 
+// CHECK:     i8* undef, 
+// CHECK:     %swift.type_descriptor* bitcast (
+//      :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
+// CHECK:       $s4main5Value[[UNIQUE_ID_1]]CMn
+// CHECK:       to %swift.type_descriptor*
+// CHECK:     )
+// CHECK:   ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }
+
+
+// CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4]]CySiGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]}} {
+// CHECK: entry:
+// CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
+// CHECK-apple:    %objc_class* bitcast (
+// CHECK-unknown:    ret
+// CHECK-SAME:   @"$s4main5Value[[UNIQUE_ID_1]]CySiGMf" 
+// CHECK-apple:   [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
+// CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+// CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
+// CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_class.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_class.swift
@@ -1,0 +1,50 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+fileprivate class Value<First> {
+  let first_Value: First
+
+  init(first: First) {
+    self.first_Value = first
+  }
+}
+
+fileprivate class Box {
+  let value: Int
+
+  init(value: Int) {
+    self.value = value
+  }
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// TODO: Prespecialize for Klazz<C> for C a class by initializing C in the
+//       canonical specialized metadata accessor for Klazz<C>.  At that point,
+//       there should be no call to
+//       __swift_instantiateConcreteTypeFromMangledName.
+
+//      CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+//      CHECK:   [[METADATA:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName(
+// CHECK-SAME:     @"$s4main5Value[[UNIQUE_ID_1:[A-Za-z0-9_]+]]LLCyAA3BoxACLLCGMD"
+//      CHECK:   {{%[0-9]+}} = call swiftcc %T4main5Value[[UNIQUE_ID_1]]LLC* @"$s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* swiftself [[METADATA]]
+// CHECK-SAME:   )
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK: }
+func doit() {
+  consume( Value(first: Box(value: 13)) )
+}
+doit()
+

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_function.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_function.swift
@@ -1,0 +1,39 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+fileprivate class Value<First> {
+  let first_Value: First
+
+  init(first: First) {
+    self.first_Value = first
+  }
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// TODO: Once metadata records for structural types are prespecialized, there
+//       should be no call to __swift_instantiateConcreteTypeFromMangledName.
+
+//      CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+//      CHECK:   [[METADATA:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName(
+// CHECK-SAME:     @"$s4main5Value[[UNIQUE_ID_1:[A-Za-z0-9_]+]]LLCySSSicGMD"
+//      CHECK:   {{%[0-9]+}} = call swiftcc %T4main5Value[[UNIQUE_ID_1]]LLC* @"$s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* swiftself [[METADATA]]
+// CHECK-SAME:   )
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK: }
+func doit() {
+  consume( Value(first: { (i: Int) -> String in fatalError() }) )
+}
+doit()

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_class.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_class.swift
@@ -1,0 +1,306 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$s4main3Box[[UNIQUE_ID_1:[A-Za-z0-9_]+]]LLCySiGMf" = 
+
+//              CHECK: @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCySiGGMf" = linkonce_odr hidden 
+//   CHECK-apple-SAME: global 
+// CHECK-unknown-SAME: constant 
+//         CHECK-SAME: <{
+//         CHECK-SAME:   void (
+//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:   )*,
+//         CHECK-SAME:   i8**,
+//                   :   [[INT]],
+//   CHECK-apple-SAME:   %objc_class*,
+// CHECK-unknown-SAME:   %swift.type*,
+//   CHECK-apple-SAME:   %swift.opaque*,
+//   CHECK-apple-SAME:   %swift.opaque*,
+//   CHECK-apple-SAME:   [[INT]],
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i16,
+//         CHECK-SAME:   i16,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   %swift.type_descriptor*,
+//         CHECK-SAME:   i8*,
+//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   [[INT]],
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
+//         CHECK-SAME:     %swift.opaque*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   )*
+//         CHECK-SAME: }> <{
+//         CHECK-SAME:   void (
+//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCfD
+//         CHECK-SAME:   $sBoWV
+//   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCySiGGMM
+// CHECK-unknown-SAME:   [[INT]] 0,
+//   CHECK-apple-SAME:   OBJC_CLASS_$__TtCs12_SwiftObject
+// CHECK-unknown-SAME:   %swift.type* null,
+//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache,
+//   CHECK-apple-SAME:   %swift.opaque* null,
+//   CHECK-apple-SAME:   [[INT]] add (
+//   CHECK-apple-SAME:     [[INT]] ptrtoint (
+//   CHECK-apple-SAME:      {
+//   CHECK-apple-SAME:        i32,
+//   CHECK-apple-SAME:        i32,
+//   CHECK-apple-SAME:        i32,
+//                   :        i32,
+//   CHECK-apple-SAME:        i8*,
+//   CHECK-apple-SAME:        i8*,
+//   CHECK-apple-SAME:        i8*,
+//   CHECK-apple-SAME:        i8*,
+//   CHECK-apple-SAME:        {
+//   CHECK-apple-SAME:          i32,
+//   CHECK-apple-SAME:          i32,
+//   CHECK-apple-SAME:          [
+//   CHECK-apple-SAME:            1 x {
+//   CHECK-apple-SAME:              [[INT]]*,
+//   CHECK-apple-SAME:              i8*,
+//   CHECK-apple-SAME:              i8*,
+//   CHECK-apple-SAME:              i32,
+//   CHECK-apple-SAME:              i32
+//   CHECK-apple-SAME:            }
+//   CHECK-apple-SAME:          ]
+//   CHECK-apple-SAME:        }*,
+//   CHECK-apple-SAME:        i8*,
+//   CHECK-apple-SAME:        i8*
+//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP[[UNIQUE_ID_1]]5Value to [[INT]]
+//   CHECK-apple-SAME:     ),
+//   CHECK-apple-SAME:     [[INT]] 2
+//   CHECK-apple-SAME:   ),
+//         CHECK-SAME:   i32 26,
+//         CHECK-SAME:   i32 0,
+//         CHECK-SAME:   i32 {{(24|12)}},
+//         CHECK-SAME:   i16 {{(7|3)}},
+//         CHECK-SAME:   i16 0,
+//   CHECK-apple-SAME:   i32 {{(120|72)}},
+// CHECK-unknown-SAME:   i32 96,
+//         CHECK-SAME:   i32 {{(16|8)}},
+//                   :   %swift.type_descriptor* bitcast (
+//                   :     <{
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i16,
+//                   :       i16,
+//                   :       i16,
+//                   :       i16,
+//                   :       i8,
+//                   :       i8,
+//                   :       i8,
+//                   :       i8,
+//                   :       i32,
+//                   :       i32,
+//                   :       %swift.method_descriptor
+//                   :     }>* @"$s4main5Value[[UNIQUE_ID_1]]LLCMn" to %swift.type_descriptor*
+//                   :   ),
+//         CHECK-SAME:   i8* null,
+//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//         CHECK-SAME:     %swift.full_heapmetadata,
+//         CHECK-SAME:     %swift.full_heapmetadata* bitcast (
+//         CHECK-SAME:       <{
+//         CHECK-SAME:         void (
+//         CHECK-SAME:           %T4main3Box[[UNIQUE_ID_1:[a-zA-Z0-9_]+]]LLC*
+//         CHECK-SAME:         )*,
+//         CHECK-SAME:         i8**,
+//                   :         [[INT]],
+//   CHECK-apple-SAME:         %objc_class*,
+// CHECK-unknown-SAME:         %swift.type*,
+//   CHECK-apple-SAME:         %swift.opaque*,
+//   CHECK-apple-SAME:         %swift.opaque*,
+//   CHECK-apple-SAME:         [[INT]],
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i16,
+//         CHECK-SAME:         i16,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         %swift.type_descriptor*,
+//         CHECK-SAME:         i8*,
+//         CHECK-SAME:         %swift.type*,
+//         CHECK-SAME:         [[INT]],
+//         CHECK-SAME:         %T4main3Box[[UNIQUE_ID_1]]LLC* (
+//         CHECK-SAME:           %swift.opaque*,
+//         CHECK-SAME:           %swift.type*
+//         CHECK-SAME:         )*
+//         CHECK-SAME:       }>* @"$s4main3Box[[UNIQUE_ID_1]]LLCySiGMf" to %swift.full_heapmetadata*
+//         CHECK-SAME:     ),
+//         CHECK-SAME:     i32 0,
+//         CHECK-SAME:     i32 2
+//         CHECK-SAME:   ),
+//         CHECK-SAME:   [[INT]] {{(16|8)}},
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
+//         CHECK-SAME:     %swift.opaque*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC
+//         CHECK-SAME: }>,
+//         CHECK-SAME: align [[ALIGNMENT]]
+
+fileprivate class Value<First> {
+  let first_Value: First
+
+  init(first: First) {
+    self.first_Value = first
+  }
+}
+
+fileprivate class Box<Value> {
+  let value: Value
+
+  init(value: Value) {
+    self.value = value
+  }
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]LLCyAA3BoxACLLCySiGGMb"([[INT]] 0)
+// CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK: }
+func doit() {
+  consume( Value(first: Box(value: 13)) )
+}
+doit()
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {
+//      CHECK: entry:
+//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+//      CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+//      CHECK: [[TYPE_COMPARISON_LABEL]]:
+//      CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (
+//           :     %swift.type* getelementptr inbounds (
+//           :       %swift.full_heapmetadata,
+//           :       %swift.full_heapmetadata* bitcast (
+//           :         <{
+//           :           void (
+//           :             %T4main3Box[[UNIQUE_ID_2]]LLC*
+//           :           )*,
+//           :           i8**,
+//           :           [[INT]],
+//           :           %objc_class*,
+//           :           %swift.opaque*,
+//           :           %swift.opaque*,
+//           :           [[INT]],
+//           :           i32,
+//           :           i32,
+//           :           i32,
+//           :           i16,
+//           :           i16,
+//           :           i32,
+//           :           i32,
+//           :           %swift.type_descriptor*,
+//           :           i8*,
+//           :           %swift.type*,
+//           :           [[INT]],
+//           :           %T4main3Box[[UNIQUE_ID_2]]LLC* (
+//           :             %swift.opaque*,
+//           :             %swift.type*
+//           :           )*
+//           :         }>* 
+// CHECK-SAME:         @"$s4main3Box[[UNIQUE_ID_1]]LLCySiGMf" 
+//           :         to %swift.full_heapmetadata*
+//           :       ),
+// CHECK-SAME:       i32 0,
+// CHECK-SAME:       i32 2
+// CHECK-SAME:     ) to i8*
+// CHECK-SAME:   ),
+// CHECK-SAME:   [[ERASED_TYPE]]
+//      CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+//      CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+//      CHECK: [[EXIT_PRESPECIALIZED]]:
+//      CHECK-NEXT:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_3:[0-9A-Z_]+]]LLCyAA3BoxACLLCySiGGMb"([[INT]] [[METADATA_REQUEST]])
+//      CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+//      CHECK:   [[PARTIAL_RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[METADATA]], 0
+//      CHECK:   [[RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_RESULT_METADATA]], [[INT]] 0, 1
+//      CHECK:   ret %swift.metadata_response [[RESULT_METADATA]] 
+//      CHECK: [[EXIT_NORMAL]]:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+//      CHECK:     [[INT]] [[METADATA_REQUEST]], 
+//      CHECK:     i8* [[ERASED_TYPE]], 
+//      CHECK:     i8* undef, 
+//      CHECK:     i8* undef, 
+//      CHECK:     %swift.type_descriptor* bitcast (
+//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
+//      CHECK:       $s4main5Value[[UNIQUE_ID_1]]LLCMn
+//      CHECK:       to %swift.type_descriptor*
+//      CHECK:     )
+//      CHECK:   ) #{{[0-9]+}}
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+
+//         CHECK: ; Function Attrs: noinline nounwind readnone
+//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCySiGGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]+}} {
+//         CHECK: entry:
+// CHECK-unknown: ret
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
+//              :    %objc_class* bitcast (
+//              :      %swift.type* getelementptr inbounds (
+//              :        %swift.full_heapmetadata,
+//              :        %swift.full_heapmetadata* bitcast (
+//              :          <{
+//              :            void (
+//              :              %T4main5Value33_9100AE3EFBE408E03C856CED54B18B61LLC*
+//              :            )*,
+//              :            i8**,
+//              :            [[INT]],
+//              :            %objc_class*,
+//              :            %swift.opaque*,
+//              :            %swift.opaque*,
+//              :            [[INT]],
+//              :            i32,
+//              :            i32,
+//              :            i32,
+//              :            i16,
+//              :            i16,
+//              :            i32,
+//              :            i32,
+//              :            %swift.type_descriptor*,
+//              :            i8*,
+//              :            %swift.type*,
+//              :            [[INT]],
+//              :            %T4main5Value33_9100AE3EFBE408E03C856CED54B18B61LLC* (
+//              :              %swift.opaque*,
+//              :              %swift.type*
+//              :            )*
+//    CHECK-SAME:           @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCySiGGMf" 
+//              :           to %swift.full_heapmetadata*
+//              :         ),
+//              :         i32 0,
+//              :         i32 2
+//              :       ) to %objc_class*
+//              :     )
+//              :   )
+//   CHECK-apple:   [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
+//   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
+//         CHECK: }
+

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_class_specialized_at_generic_class.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_class_specialized_at_generic_class.swift
@@ -1,0 +1,314 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$s4main3Box[[UNIQUE_ID_1:[A-Za-z0-9_]+]]LLCyAA5InnerACLLCySiGGMf" =
+
+//              CHECK: @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCyAA5InnerACLLCySiGGGMf" = linkonce_odr hidden
+//   CHECK-apple-SAME: global
+// CHECK-unknown-SAME: constant
+//         CHECK-SAME: <{
+//         CHECK-SAME:   void (
+//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:   )*,
+//         CHECK-SAME:   i8**,
+//                   :   [[INT]],
+//   CHECK-apple-SAME:   %objc_class*,
+// CHECK-unknown-SAME:   %swift.type*,
+//   CHECK-apple-SAME:   %swift.opaque*,
+//   CHECK-apple-SAME:   %swift.opaque*,
+//   CHECK-apple-SAME:   [[INT]],
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i16,
+//         CHECK-SAME:   i16,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   %swift.type_descriptor*,
+//         CHECK-SAME:   i8*,
+//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   [[INT]],
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
+//         CHECK-SAME:     %swift.opaque*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   )*
+//         CHECK-SAME: }> <{
+//         CHECK-SAME:   void (
+//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCfD
+//         CHECK-SAME:   $sBoWV
+//   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCyAA5InnerACLLCySiGGGMM
+// CHECK-unknown-SAME:   [[INT]] 0,
+//   CHECK-apple-SAME:   OBJC_CLASS_$__TtCs12_SwiftObject
+//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache,
+//   CHECK-apple-SAME:   %swift.opaque* null,
+//   CHECK-apple-SAME:   [[INT]] add (
+//   CHECK-apple-SAME:     [[INT]] ptrtoint (
+//   CHECK-apple-SAME:      {
+//   CHECK-apple-SAME:        i32,
+//   CHECK-apple-SAME:        i32,
+//   CHECK-apple-SAME:        i32,
+//                   :        i32,
+//   CHECK-apple-SAME:        i8*,
+//   CHECK-apple-SAME:        i8*,
+//   CHECK-apple-SAME:        i8*,
+//   CHECK-apple-SAME:        i8*,
+//   CHECK-apple-SAME:        {
+//   CHECK-apple-SAME:          i32,
+//   CHECK-apple-SAME:          i32,
+//   CHECK-apple-SAME:          [
+//   CHECK-apple-SAME:            1 x {
+//   CHECK-apple-SAME:              [[INT]]*,
+//   CHECK-apple-SAME:              i8*,
+//   CHECK-apple-SAME:              i8*,
+//   CHECK-apple-SAME:              i32,
+//   CHECK-apple-SAME:              i32
+//   CHECK-apple-SAME:            }
+//   CHECK-apple-SAME:          ]
+//   CHECK-apple-SAME:        }*,
+//   CHECK-apple-SAME:        i8*,
+//   CHECK-apple-SAME:        i8*
+//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP[[UNIQUE_ID_1]]5Value to [[INT]]
+//   CHECK-apple-SAME:     ),
+//   CHECK-apple-SAME:     [[INT]] 2
+//   CHECK-apple-SAME:   ),
+//         CHECK-SAME:   i32 26,
+//         CHECK-SAME:   i32 0,
+//         CHECK-SAME:   i32 {{(24|12)}},
+//         CHECK-SAME:   i16 {{(7|3)}},
+//         CHECK-SAME:   i16 0,
+//   CHECK-apple-SAME:   i32 {{(120|72)}},
+// CHECK-unknown-SAME:   i32 96,
+//         CHECK-SAME:   i32 {{(16|8)}},
+//                   :   %swift.type_descriptor* bitcast (
+//                   :     <{
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i16,
+//                   :       i16,
+//                   :       i16,
+//                   :       i16,
+//                   :       i8,
+//                   :       i8,
+//                   :       i8,
+//                   :       i8,
+//                   :       i32,
+//                   :       i32,
+//                   :       %swift.method_descriptor
+//                   :     }>* @"$s4main5Value[[UNIQUE_ID_1]]LLCMn" to %swift.type_descriptor*
+//                   :   ),
+//         CHECK-SAME:   i8* null,
+//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//         CHECK-SAME:     %swift.full_heapmetadata,
+//         CHECK-SAME:     %swift.full_heapmetadata* bitcast (
+//         CHECK-SAME:       <{
+//         CHECK-SAME:         void (
+//         CHECK-SAME:           %T4main3Box[[UNIQUE_ID_1:[a-zA-Z0-9_]+]]LLC*
+//         CHECK-SAME:         )*,
+//         CHECK-SAME:         i8**,
+//                   :         [[INT]],
+//   CHECK-apple-SAME:         %objc_class*,
+// CHECK-unknown-SAME:         %swift.type*,
+//   CHECK-apple-SAME:         %swift.opaque*,
+//   CHECK-apple-SAME:         %swift.opaque*,
+//   CHECK-apple-SAME:         [[INT]],
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i16,
+//         CHECK-SAME:         i16,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         i32,
+//         CHECK-SAME:         %swift.type_descriptor*,
+//         CHECK-SAME:         i8*,
+//         CHECK-SAME:         %swift.type*,
+//         CHECK-SAME:         [[INT]],
+//         CHECK-SAME:         %T4main3Box[[UNIQUE_ID_1]]LLC* (
+//         CHECK-SAME:           %swift.opaque*,
+//         CHECK-SAME:           %swift.type*
+//         CHECK-SAME:         )*
+//         CHECK-SAME:       }>* @"$s4main3Box[[UNIQUE_ID_1]]LLCyAA5InnerACLLCySiGGMf" to %swift.full_heapmetadata*
+//         CHECK-SAME:     ),
+//         CHECK-SAME:     i32 0,
+//         CHECK-SAME:     i32 2
+//         CHECK-SAME:   ),
+//         CHECK-SAME:   [[INT]] {{(16|8)}},
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
+//         CHECK-SAME:     %swift.opaque*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC
+//         CHECK-SAME: }>,
+//         CHECK-SAME: align [[ALIGNMENT]]
+
+fileprivate class Value<First> {
+  let first_Value: First
+
+  init(first: First) {
+    self.first_Value = first
+  }
+}
+
+fileprivate class Box<Value> {
+  let value: Value
+
+  init(value: Value) {
+    self.value = value
+  }
+}
+
+fileprivate class Inner<Value> {
+  let value: Value
+
+  init(value: Value) {
+    self.value = value
+  }
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]LLCyAA3BoxACLLCyAA5InnerACLLCySiGGGMb"([[INT]] 0)
+// CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}},
+// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK: }
+func doit() {
+  consume( Value(first: Box(value: Inner(value: 13))) )
+}
+doit()
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {
+//      CHECK: entry:
+//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+//      CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+//      CHECK: [[TYPE_COMPARISON_LABEL]]:
+//      CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (
+//           :     %swift.type* getelementptr inbounds (
+//           :       %swift.full_heapmetadata,
+//           :       %swift.full_heapmetadata* bitcast (
+//           :         <{
+//           :           void (
+//           :             %T4main3Box[[UNIQUE_ID_2]]LLC*
+//           :           )*,
+//           :           i8**,
+//           :           [[INT]],
+//           :           %objc_class*,
+//           :           %swift.opaque*,
+//           :           %swift.opaque*,
+//           :           [[INT]],
+//           :           i32,
+//           :           i32,
+//           :           i32,
+//           :           i16,
+//           :           i16,
+//           :           i32,
+//           :           i32,
+//           :           %swift.type_descriptor*,
+//           :           i8*,
+//           :           %swift.type*,
+//           :           [[INT]],
+//           :           %T4main3Box[[UNIQUE_ID_2]]LLC* (
+//           :             %swift.opaque*,
+//           :             %swift.type*
+//           :           )*
+//           :         }>*
+// CHECK-SAME:         @"$s4main3Box[[UNIQUE_ID_1]]LLCyAA5InnerACLLCySiGGMf"
+//           :         to %swift.full_heapmetadata*
+//           :       ),
+// CHECK-SAME:       i32 0,
+// CHECK-SAME:       i32 2
+// CHECK-SAME:     ) to i8*
+// CHECK-SAME:   ),
+// CHECK-SAME:   [[ERASED_TYPE]]
+//      CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+//      CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+//      CHECK: [[EXIT_PRESPECIALIZED]]:
+//      CHECK-NEXT:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_3:[0-9A-Z_]+]]LLCyAA3BoxACLLCyAA5InnerACLLCySiGGGMb"([[INT]] [[METADATA_REQUEST]])
+//      CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+//      CHECK:   [[PARTIAL_RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[METADATA]], 0
+//      CHECK:   [[RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_RESULT_METADATA]], [[INT]] 0, 1
+//      CHECK:   ret %swift.metadata_response [[RESULT_METADATA]]
+//      CHECK: [[EXIT_NORMAL]]:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+//      CHECK:     [[INT]] [[METADATA_REQUEST]],
+//      CHECK:     i8* [[ERASED_TYPE]],
+//      CHECK:     i8* undef,
+//      CHECK:     i8* undef,
+//      CHECK:     %swift.type_descriptor* bitcast (
+//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>*
+//      CHECK:       $s4main5Value[[UNIQUE_ID_1]]LLCMn
+//      CHECK:       to %swift.type_descriptor*
+//      CHECK:     )
+//      CHECK:   ) #{{[0-9]+}}
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+
+//         CHECK: ; Function Attrs: noinline nounwind readnone
+//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCyAA5InnerACLLCySiGGGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]+}} {
+//         CHECK: entry:
+// CHECK-unknown: ret
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
+//              :    %objc_class* bitcast (
+//              :      %swift.type* getelementptr inbounds (
+//              :        %swift.full_heapmetadata,
+//              :        %swift.full_heapmetadata* bitcast (
+//              :          <{
+//              :            void (
+//              :              %T4main5Value33_9100AE3EFBE408E03C856CED54B18B61LLC*
+//              :            )*,
+//              :            i8**,
+//              :            [[INT]],
+//              :            %objc_class*,
+//              :            %swift.opaque*,
+//              :            %swift.opaque*,
+//              :            [[INT]],
+//              :            i32,
+//              :            i32,
+//              :            i32,
+//              :            i16,
+//              :            i16,
+//              :            i32,
+//              :            i32,
+//              :            %swift.type_descriptor*,
+//              :            i8*,
+//              :            %swift.type*,
+//              :            [[INT]],
+//              :            %T4main5Value33_9100AE3EFBE408E03C856CED54B18B61LLC* (
+//              :              %swift.opaque*,
+//              :              %swift.type*
+//              :            )*
+//    CHECK-SAME:           @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCyAA5InnerACLLCySiGGGMf"
+//              :           to %swift.full_heapmetadata*
+//              :         ),
+//              :         i32 0,
+//              :         i32 2
+//              :       ) to %objc_class*
+//              :     )
+//              :   )
+//   CHECK-apple:   [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
+//   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
+//         CHECK: }
+
+

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_enum.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_enum.swift
@@ -1,0 +1,272 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+//              CHECK: @"$s4main5Value[[UNIQUE_ID_1:[A-Za-z0-9_]+]]CyAA6EitherACLLOySiGGMf" = linkonce_odr hidden 
+//   CHECK-apple-SAME: global 
+// CHECK-unknown-SAME: constant 
+//         CHECK-SAME: <{
+//         CHECK-SAME:   void (
+//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
+//         CHECK-SAME:   )*,
+//         CHECK-SAME:   i8**,
+//                   :   [[INT]],
+//   CHECK-apple-SAME:   %objc_class*,
+// CHECK-unknown-SAME:   %swift.type*,
+//   CHECK-apple-SAME:   %swift.opaque*,
+//   CHECK-apple-SAME:   %swift.opaque*,
+//   CHECK-apple-SAME:   [[INT]],
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i16,
+//         CHECK-SAME:   i16,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   %swift.type_descriptor*,
+//         CHECK-SAME:   i8*,
+//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   [[INT]],
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:     %swift.opaque*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   )*
+//         CHECK-SAME: }> <{
+//         CHECK-SAME:   void (
+//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]CfD
+//         CHECK-SAME:   $sBoWV
+//   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]CyAA6EitherACLLOySiGGMM
+// CHECK-unknown-SAME:   [[INT]] 0,
+//   CHECK-apple-SAME:   OBJC_CLASS_$__TtCs12_SwiftObject
+// CHECK-unknown-SAME:   %swift.type* null,
+//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache,
+//   CHECK-apple-SAME:   %swift.opaque* null,
+//   CHECK-apple-SAME:   [[INT]] add (
+//   CHECK-apple-SAME:     [[INT]] ptrtoint (
+//   CHECK-apple-SAME:       {
+//   CHECK-apple-SAME:         i32,
+//   CHECK-apple-SAME:         i32,
+//   CHECK-apple-SAME:         i32,
+//                   :         i32,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         {
+//   CHECK-apple-SAME:           i32,
+//   CHECK-apple-SAME:           i32,
+//   CHECK-apple-SAME:           [
+//   CHECK-apple-SAME:             1 x {
+//   CHECK-apple-SAME:               [[INT]]*,
+//   CHECK-apple-SAME:               i8*,
+//   CHECK-apple-SAME:               i8*,
+//   CHECK-apple-SAME:               i32,
+//   CHECK-apple-SAME:               i32
+//   CHECK-apple-SAME:             }
+//   CHECK-apple-SAME:           ]
+//   CHECK-apple-SAME:         }*,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         i8*
+//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP[[UNIQUE_ID_2:[a-zA-Z0-9_]+]]5Value to [[INT]]
+//   CHECK-apple-SAME:     ),
+//   CHECK-apple-SAME:     [[INT]] 2
+//   CHECK-apple-SAME:   ),
+//         CHECK-SAME:   i32 26,
+//         CHECK-SAME:   i32 0,
+//         CHECK-SAME:   i32 {{(25|13)}},
+//         CHECK-SAME:   i16 {{(7|3)}},
+//         CHECK-SAME:   i16 0,
+//   CHECK-apple-SAME:   i32 {{(120|72)}},
+// CHECK-unknown-SAME:   i32 96,
+//         CHECK-SAME:   i32 {{(16|8)}},
+//                   :   %swift.type_descriptor* bitcast (
+//                   :     <{
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i16,
+//                   :       i16,
+//                   :       i16,
+//                   :       i16,
+//                   :       i8,
+//                   :       i8,
+//                   :       i8,
+//                   :       i8,
+//                   :       i32,
+//                   :       i32,
+//                   :       %swift.method_descriptor
+//                   :     }>* @"$s4main5Value[[UNIQUE_ID_1]]CMn" to %swift.type_descriptor*
+//                   :   ),
+//         CHECK-SAME:   i8* null,
+//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//         CHECK-SAME:     %swift.full_type,
+//         CHECK-SAME:     %swift.full_type* bitcast (
+//         CHECK-SAME:       <{
+//         CHECK-SAME:         i8**,
+//         CHECK-SAME:         [[INT]],
+//         CHECK-SAME:         %swift.type_descriptor*,
+//         CHECK-SAME:         %swift.type*,
+//         CHECK-SAME:         [[INT]],
+//         CHECK-SAME:         i64
+//         CHECK-SAME:       }>* @"$s4main6Either[[UNIQUE_ID_1]]OySiGMf" to %swift.full_type*
+//         CHECK-SAME:     ),
+//         CHECK-SAME:     i32 0,
+//         CHECK-SAME:     i32 1
+//         CHECK-SAME:   ),
+//         CHECK-SAME:   [[INT]] {{(16|8)}},
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:     %swift.opaque*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGx_tcfC
+//         CHECK-SAME: }>,
+//         CHECK-SAME: align [[ALIGNMENT]]
+
+// CHECK: @"$s4main6Either[[UNIQUE_ID_1]]OySiGMf" =
+
+fileprivate class Value<First> {
+  let first_Value: First
+
+  init(first: First) {
+    self.first_Value = first
+  }
+}
+
+fileprivate enum Either<Value> {
+    case left(Value)
+    case right(Int)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]CyAA6EitherACLLOySiGGMb"([[INT]] 0)
+// CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK: }
+func doit() {
+  consume( Value(first: Either.left(13)) )
+}
+doit()
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {
+//      CHECK: entry:
+//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+//      CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+//      CHECK: [[TYPE_COMPARISON_LABEL]]:
+//      CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type,
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{
+// CHECK-SAME:           i8**,
+// CHECK-SAME:           [[INT]],
+// CHECK-SAME:           %swift.type_descriptor*,
+// CHECK-SAME:           %swift.type*,
+// CHECK-SAME:           [[INT]],
+// CHECK-SAME:           i64
+// CHECK-SAME:         }>* @"$s4main6Either[[UNIQUE_ID_1]]OySiGMf" to %swift.full_type*
+// CHECK-SAME:       ),
+// CHECK-SAME:       i32 0,
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ) to i8*
+// CHECK-SAME:   ),
+// CHECK-SAME:   [[ERASED_TYPE]]
+//      CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+//      CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+//      CHECK: [[EXIT_PRESPECIALIZED]]:
+//      CHECK-NEXT:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_3:[0-9A-Z_]+]]CyAA6EitherACLLOySiGGMb"([[INT]] [[METADATA_REQUEST]])
+//      CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+//      CHECK:   [[PARTIAL_RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[METADATA]], 0
+//      CHECK:   [[RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_RESULT_METADATA]], [[INT]] 0, 1
+//      CHECK:   ret %swift.metadata_response [[RESULT_METADATA]] 
+//      CHECK: [[EXIT_NORMAL]]:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+//      CHECK:     [[INT]] [[METADATA_REQUEST]], 
+//      CHECK:     i8* [[ERASED_TYPE]], 
+//      CHECK:     i8* undef, 
+//      CHECK:     i8* undef, 
+//      CHECK:     %swift.type_descriptor* bitcast (
+//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
+//      CHECK:       $s4main5Value[[UNIQUE_ID_1]]CMn
+//      CHECK:       to %swift.type_descriptor*
+//      CHECK:     )
+//      CHECK:   ) #{{[0-9]+}}
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+
+//         CHECK: ; Function Attrs: noinline nounwind readnone
+//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CyAA6EitherACLLOySiGGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]+}} {
+//         CHECK: entry:
+// CHECK-unknown: ret
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
+//              :     %objc_class* bitcast (
+//              :       %swift.type* getelementptr inbounds (
+//              :         %swift.full_heapmetadata,
+//              :         %swift.full_heapmetadata* bitcast (
+//              :           <{
+//              :             void (
+//              :               %T4main5Value[
+//              :                 [
+//              :                   UNIQUE_ID_1
+//              :                 ]
+//              :               ]C*
+//              :             )*,
+//              :             i8**,
+//              :             [[INT]],
+//              :             %objc_class*,
+//              :             %swift.opaque*,
+//              :             %swift.opaque*,
+//              :             [[INT]],
+//              :             i32,
+//              :             i32,
+//              :             i32,
+//              :             i16,
+//              :             i16,
+//              :             i32,
+//              :             i32,
+//              :             %swift.type_descriptor*,
+//              :             i8*,
+//              :             %swift.type*,
+//              :             [[INT]],
+//              :             %T4main5Value[
+//              :               [
+//              :                 UNIQUE_ID_1
+//              :               ]
+//              :             ]C* (
+//              :               %swift.opaque*,
+//              :               %swift.type*
+//              :             )*
+//              :           }>* 
+//    CHECK-SAME:           @"$s4main5Value[[UNIQUE_ID_1]]CyAA6EitherACLLOySiGGMf" 
+//              :           to %swift.full_heapmetadata*
+//              :         ),
+//              :         i32 0,
+//              :         i32 2
+//              :       ) to %objc_class*
+//              :     )
+//              :   )
+//   CHECK-apple:   [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
+//   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
+//         CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_struct.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_struct.swift
@@ -1,0 +1,277 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+//              CHECK: @"$s4main5Value[[UNIQUE_ID_1:[A-Za-z0-9_]+]]CyAA4LeftACLLVySiGGMf" = linkonce_odr hidden 
+//   CHECK-apple-SAME: global 
+// CHECK-unknown-SAME: constant 
+//         CHECK-SAME: <{
+//         CHECK-SAME:   void (
+//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
+//         CHECK-SAME:   )*,
+//         CHECK-SAME:   i8**,
+//                   :   [[INT]],
+//   CHECK-apple-SAME:   %objc_class*,
+// CHECK-unknown-SAME:   %swift.type*,
+//   CHECK-apple-SAME:   %swift.opaque*,
+//   CHECK-apple-SAME:   %swift.opaque*,
+//   CHECK-apple-SAME:   [[INT]],
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i16,
+//         CHECK-SAME:   i16,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   %swift.type_descriptor*,
+//         CHECK-SAME:   i8*,
+//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   [[INT]],
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:     %swift.opaque*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   )*
+//         CHECK-SAME: }> <{
+//         CHECK-SAME:   void (
+//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
+//                   :   $s4main5Value[[UNIQUE_ID_1]]CfD
+//         CHECK-SAME:   $sBoWV
+//   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]CyAA4LeftACLLVySiGGMM
+// CHECK-unknown-SAME:   [[INT]] 0,
+//   CHECK-apple-SAME:   OBJC_CLASS_$__TtCs12_SwiftObject
+// CHECK-unknown-SAME:   %swift.type* null,
+//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache,
+//   CHECK-apple-SAME:   %swift.opaque* null,
+//   CHECK-apple-SAME:   [[INT]] add (
+//   CHECK-apple-SAME:     [[INT]] ptrtoint (
+//   CHECK-apple-SAME:       {
+//   CHECK-apple-SAME:         i32,
+//   CHECK-apple-SAME:         i32,
+//   CHECK-apple-SAME:         i32,
+//                   :         i32,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         {
+//   CHECK-apple-SAME:           i32,
+//   CHECK-apple-SAME:           i32,
+//   CHECK-apple-SAME:           [
+//   CHECK-apple-SAME:             1 x {
+//   CHECK-apple-SAME:               [[INT]]*,
+//   CHECK-apple-SAME:               i8*,
+//   CHECK-apple-SAME:               i8*,
+//   CHECK-apple-SAME:               i32,
+//   CHECK-apple-SAME:               i32
+//   CHECK-apple-SAME:             }
+//   CHECK-apple-SAME:           ]
+//   CHECK-apple-SAME:         }*,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         i8*
+//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP[[UNIQUE_ID_2:[a-zA-Z0-9_]+]]5Value to [[INT]]
+//   CHECK-apple-SAME:     ),
+//   CHECK-apple-SAME:     [[INT]] 2
+//   CHECK-apple-SAME:   ),
+//         CHECK-SAME:   i32 26,
+//         CHECK-SAME:   i32 0,
+//         CHECK-SAME:   i32 {{(24|12)}},
+//         CHECK-SAME:   i16 {{(7|3)}},
+//         CHECK-SAME:   i16 0,
+//   CHECK-apple-SAME:   i32 {{(120|72)}},
+// CHECK-unknown-SAME:   i32 96,
+//         CHECK-SAME:   i32 {{(16|8)}},
+//                   :   %swift.type_descriptor* bitcast (
+//                   :     <{
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i16,
+//                   :       i16,
+//                   :       i16,
+//                   :       i16,
+//                   :       i8,
+//                   :       i8,
+//                   :       i8,
+//                   :       i8,
+//                   :       i32,
+//                   :       i32,
+//                   :       %swift.method_descriptor
+//                   :     }>* @"$s4main5Value[[UNIQUE_ID_1]]CMn" to %swift.type_descriptor*
+//                   :   ),
+//         CHECK-SAME:   i8* null,
+//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//         CHECK-SAME:     %swift.full_type,
+//         CHECK-SAME:     %swift.full_type* bitcast (
+//         CHECK-SAME:       <{
+//         CHECK-SAME:         i8**,
+//         CHECK-SAME:         [[INT]],
+//         CHECK-SAME:         %swift.type_descriptor*,
+//         CHECK-SAME:         %swift.type*,
+//         CHECK-SAME:         i32,
+//                   :         [
+//                   :           4 x i8
+//                   :         ],
+//         CHECK-SAME:         i64
+//         CHECK-SAME:       }>* @"$s4main4Left[[UNIQUE_ID_1]]VySiGMf" to %swift.full_type*
+//         CHECK-SAME:     ),
+//         CHECK-SAME:     i32 0,
+//         CHECK-SAME:     i32 1
+//         CHECK-SAME:   ),
+//         CHECK-SAME:   [[INT]] {{(16|8)}},
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:     %swift.opaque*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGx_tcfC
+//         CHECK-SAME: }>,
+//         CHECK-SAME: align [[ALIGNMENT]]
+
+// CHECK: @"$s4main4Left[[UNIQUE_ID_1]]VySiGMf" =
+
+fileprivate class Value<First> {
+  let first_Value: First
+
+  init(first: First) {
+    self.first_Value = first
+  }
+}
+
+fileprivate struct Left<Value> {
+    let left: Value
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]CyAA4LeftACLLVySiGGMb"([[INT]] 0)
+// CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK: }
+func doit() {
+  consume( Value(first: Left(left: 13)) )
+}
+doit()
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {
+//      CHECK: entry:
+//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+//      CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+//      CHECK: [[TYPE_COMPARISON_LABEL]]:
+//      CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type,
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{
+// CHECK-SAME:           i8**,
+// CHECK-SAME:           [[INT]],
+// CHECK-SAME:           %swift.type_descriptor*,
+// CHECK-SAME:           %swift.type*,
+// CHECK-SAME:           i32,
+//           :           [
+//           :             4 x i8
+//           :           ],
+// CHECK-SAME:           i64
+// CHECK-SAME:         }>* @"$s4main4Left[[UNIQUE_ID_1]]VySiGMf" to %swift.full_type*
+// CHECK-SAME:       ),
+// CHECK-SAME:       i32 0,
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ) to i8*
+// CHECK-SAME:   ),
+// CHECK-SAME:   [[ERASED_TYPE]]
+//      CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+//      CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+//      CHECK: [[EXIT_PRESPECIALIZED]]:
+//      CHECK-NEXT:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_3:[0-9A-Z_]+]]CyAA4LeftACLLVySiGGMb"([[INT]] [[METADATA_REQUEST]])
+//      CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+//      CHECK:   [[PARTIAL_RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[METADATA]], 0
+//      CHECK:   [[RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_RESULT_METADATA]], [[INT]] 0, 1
+//      CHECK:   ret %swift.metadata_response [[RESULT_METADATA]] 
+//      CHECK: [[EXIT_NORMAL]]:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+//      CHECK:     [[INT]] [[METADATA_REQUEST]], 
+//      CHECK:     i8* [[ERASED_TYPE]], 
+//      CHECK:     i8* undef, 
+//      CHECK:     i8* undef, 
+//      CHECK:     %swift.type_descriptor* bitcast (
+//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
+//      CHECK:       $s4main5Value[[UNIQUE_ID_1]]CMn
+//      CHECK:       to %swift.type_descriptor*
+//      CHECK:     )
+//      CHECK:   ) #{{[0-9]+}}
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+
+//         CHECK: ; Function Attrs: noinline nounwind readnone
+//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CyAA4LeftACLLVySiGGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]+}} {
+//         CHECK: entry:
+// CHECK-unknown: ret
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
+//              :     %objc_class* bitcast (
+//              :       %swift.type* getelementptr inbounds (
+//              :         %swift.full_heapmetadata,
+//              :         %swift.full_heapmetadata* bitcast (
+//              :           <{
+//              :             void (
+//              :               %T4main5Value[
+//              :                 [
+//              :                   UNIQUE_ID_1
+//              :                 ]
+//              :               ]C*
+//              :             )*,
+//              :             i8**,
+//              :             [[INT]],
+//              :             %objc_class*,
+//              :             %swift.opaque*,
+//              :             %swift.opaque*,
+//              :             [[INT]],
+//              :             i32,
+//              :             i32,
+//              :             i32,
+//              :             i16,
+//              :             i16,
+//              :             i32,
+//              :             i32,
+//              :             %swift.type_descriptor*,
+//              :             i8*,
+//              :             %swift.type*,
+//              :             [[INT]],
+//              :             %T4main5Value[
+//              :               [
+//              :                 UNIQUE_ID_1
+//              :               ]
+//              :             ]C* (
+//              :               %swift.opaque*,
+//              :               %swift.type*
+//              :             )*
+//              :           }>* 
+//    CHECK-SAME:           @"$s4main5Value[[UNIQUE_ID_1]]CyAA4LeftACLLVySiGGMf" 
+//              :           to %swift.full_heapmetadata*
+//              :         ),
+//              :         i32 0,
+//              :         i32 2
+//              :       ) to %objc_class*
+//              :     )
+//              :   )
+//   CHECK-apple:   [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
+//   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
+//         CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_tuple.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_tuple.swift
@@ -1,0 +1,39 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+fileprivate class Value<First> {
+  let first_Value: First
+
+  init(first: First) {
+    self.first_Value = first
+  }
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// TODO: Once metadata records for structural types are prespecialized, there
+//       should be no call to __swift_instantiateConcreteTypeFromMangledName.
+
+//      CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+//      CHECK:   [[METADATA:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName(
+// CHECK-SAME:     @"$s4main5Value[[UNIQUE_ID_1:[A-Za-z0-9_]+]]LLCySi_SStGMD"
+//      CHECK:   {{%[0-9]+}} = call swiftcc %T4main5Value[[UNIQUE_ID_1]]LLC* @"$s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* swiftself [[METADATA]]
+// CHECK-SAME:   )
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK: }
+func doit() {
+  consume( Value(first: (13, "13")) )
+}
+doit()

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-2ancestors-1distinct_use-1st_ancestor_generic-1argument-1st_argument_constant_int-2nd_ancestor_generic-1st-argument_constant_double.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-2ancestors-1distinct_use-1st_ancestor_generic-1argument-1st_argument_constant_int-2nd_ancestor_generic-1st-argument_constant_double.swift
@@ -1,0 +1,351 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK-DAG: @"$s4main9Ancestor1[[UNIQUE_ID_1:[0-9a-zA-Z_]+]]CySiGMf" =
+// CHECK-DAG: @"$s4main9Ancestor2[[UNIQUE_ID_1]]CySdGMf" = 
+
+//              CHECK: @"$s4main5Value[[UNIQUE_ID_1]]CySSGMf" = linkonce_odr hidden 
+// CHECK-unknown-SAME: constant 
+//   CHECK-apple-SAME: global 
+//         CHECK-SAME: <{
+//         CHECK-SAME:   void (
+//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
+//         CHECK-SAME:   )*,
+//         CHECK-SAME:   i8**,
+//                   :   [[INT]],
+//         CHECK-SAME:   %swift.type*,
+//   CHECK-apple-SAME:   %swift.opaque*,
+//   CHECK-apple-SAME:   %swift.opaque*,
+//   CHECK-apple-SAME:   [[INT]],
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i16,
+//         CHECK-SAME:   i16,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   %swift.type_descriptor*,
+//         CHECK-SAME:   void (
+//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
+//         CHECK-SAME:   )*,
+//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   [[INT]],
+//         CHECK-SAME:   %T4main9Ancestor1[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:     %TSd*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   )*,
+//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   [[INT]],
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:     %TSi*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   )*,
+//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   [[INT]],
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:     %swift.opaque*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   )*
+//         CHECK-SAME: }> <{
+//         CHECK-SAME:   void (
+//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]CfD
+//         CHECK-SAME:   $sBoWV
+//   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]CySSGMM
+// CHECK-unknown-SAME:   [[INT]] 0,
+//                   :   %swift.type* getelementptr inbounds (
+//                   :     %swift.full_heapmetadata,
+//                   :     %swift.full_heapmetadata* bitcast (
+//                   :       <{
+//                   :         void (
+//                   :           %T4main9Ancestor1[[UNIQUE_ID_1]]C*
+//                   :         )*,
+//                   :         i8**,
+//                   :         [[INT]],
+//                   :         %swift.type*,
+//                   :         %swift.opaque*,
+//                   :         %swift.opaque*,
+//                   :         [[INT]],
+//                   :         i32,
+//                   :         i32,
+//                   :         i32,
+//                   :         i16,
+//                   :         i16,
+//                   :         i32,
+//                   :         i32,
+//                   :         %swift.type_descriptor*,
+//                   :         void (
+//                   :           %T4main9Ancestor1[[UNIQUE_ID_1]]C*
+//                   :         )*,
+//                   :         %swift.type*,
+//                   :         [[INT]],
+//                   :         %T4main9Ancestor1[[UNIQUE_ID_1]]C* (
+//                   :           %TSd*,
+//                   :           %swift.type*
+//                   :         )*,
+//                   :         %swift.type*,
+//                   :         [[INT]],
+//                   :         %T4main9Ancestor1[[UNIQUE_ID_1]]C* (
+//                   :           %swift.opaque*,
+//                   :           %swift.type*
+//                   :         )*
+//                   :       }>* @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMf" to %swift.full_heapmetadata*
+//                   :     ),
+//                   :     i32 0,
+//                   :     i32 2
+//                   :   ),
+//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache,
+//   CHECK-apple-SAME:   %swift.opaque* null,
+//   CHECK-apple-SAME:   [[INT]] add (
+//   CHECK-apple-SAME:     [[INT]] ptrtoint (
+//   CHECK-apple-SAME:       {
+//   CHECK-apple-SAME:         i32,
+//   CHECK-apple-SAME:         i32,
+//   CHECK-apple-SAME:         i32,
+//                   :         i32,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         {
+//   CHECK-apple-SAME:           i32,
+//   CHECK-apple-SAME:           i32,
+//   CHECK-apple-SAME:           [
+//   CHECK-apple-SAME:             1 x {
+//   CHECK-apple-SAME:               [[INT]]*,
+//   CHECK-apple-SAME:               i8*,
+//   CHECK-apple-SAME:               i8*,
+//   CHECK-apple-SAME:               i32,
+//   CHECK-apple-SAME:               i32
+//   CHECK-apple-SAME:             }
+//   CHECK-apple-SAME:           ]
+//   CHECK-apple-SAME:         }*,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         i8*
+//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP[[UNIQUE_ID_2:[0-9A-Za-z_]+]]5Value to [[INT]]
+//   CHECK-apple-SAME:     ),
+//   CHECK-apple-SAME:     [[INT]] 2
+//   CHECK-apple-SAME:   ),
+//         CHECK-SAME:   i32 26,
+//         CHECK-SAME:   i32 0,
+//         CHECK-SAME:   i32 {{(48|32)}},
+//         CHECK-SAME:   i16 {{(7|3)}},
+//         CHECK-SAME:   i16 0,
+//   CHECK-apple-SAME:   i32 {{(168|96)}},
+// CHECK-unknown-SAME:   i32 144,
+//         CHECK-SAME:   i32 {{(16|8)}},
+//                   :   %swift.type_descriptor* bitcast (
+//                   :     <{
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i16,
+//                   :       i16,
+//                   :       i16,
+//                   :       i16,
+//                   :       i8,
+//                   :       i8,
+//                   :       i8,
+//                   :       i8,
+//                   :       i32,
+//                   :       i32,
+//                   :       %swift.method_descriptor,
+//                   :       i32,
+//                   :       %swift.method_override_descriptor
+//                   :     }>* @"$s4main5Value[[UNIQUE_ID_1]]CMn" to %swift.type_descriptor*
+//                   :   ),
+//         CHECK-SAME:   void (
+//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]CfE
+//         CHECK-SAME:   %swift.type* @"$sSSN",
+//         CHECK-SAME:   [[INT]] {{(16|8)}},
+//         CHECK-SAME:   %T4main9Ancestor1[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:     %TSd*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   $s4main9Ancestor1[[UNIQUE_ID_1]]C5firstADyxGSd_tcfCAA9Ancestor2ACLLCAeHyxGx_tcfCTV
+//         CHECK-SAME:   %swift.type* @"$sSSN",
+//         CHECK-SAME:   [[INT]] {{(24|16)}},
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:     %TSi*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGSi_tcfCAA9Ancestor1ACLLCAeHyxGx_tcfCTV
+//         CHECK-SAME:   %swift.type* @"$sSSN", 
+//         CHECK-SAME:   [[INT]] {{(32|20)}},
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:     %swift.opaque*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGx_tcfC
+//         CHECK-SAME: }>,
+//         CHECK-SAME: align [[ALIGNMENT]]
+
+fileprivate class Ancestor2<First> {
+  let first_Ancestor2: First
+
+  init(first: First) {
+    self.first_Ancestor2 = first
+  }
+}
+
+fileprivate class Ancestor1<First> : Ancestor2<Double> {
+  let first_Ancestor1: First
+
+  init(first: First) {
+    self.first_Ancestor1 = first
+    super.init(first: 13.0)
+  }
+}
+
+fileprivate class Value<First> : Ancestor1<Int> {
+  let first_Value: First
+
+  init(first: First) {
+    self.first_Value = first
+    super.init(first: 13)
+  }
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CySSGMb"([[INT]] 0)
+// CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK: }
+func doit() {
+  consume( Value(first: "13") )
+}
+doit()
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {
+//      CHECK: entry:
+//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+//      CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+//      CHECK: [[TYPE_COMPARISON_LABEL]]:
+//      CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (
+// CHECK-SAME: @"$sSdN"
+// CHECK-SAME: ), [[ERASED_TYPE]]
+//      CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+//      CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+//      CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK-NEXT:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_3:[0-9A-Z_]+]]CySdGMb"([[INT]] [[METADATA_REQUEST]])
+//      CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+//      CHECK:   [[PARTIAL_RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[METADATA]], 0
+//      CHECK:   [[RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_RESULT_METADATA]], [[INT]] 0, 1
+//      CHECK:   ret %swift.metadata_response [[RESULT_METADATA]] 
+//      CHECK: [[EXIT_NORMAL]]:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     i8* undef, 
+//           :     %swift.type_descriptor* bitcast (
+//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
+// CHECK-SAME:       $s4main9Ancestor2[[UNIQUE_ID_1]]CMn
+//           :       to %swift.type_descriptor*
+//           :     )
+// CHECK-SAME:   ) #{{[0-9]+}}
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {
+//      CHECK: entry:
+//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+//      CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+//      CHECK: [[TYPE_COMPARISON_LABEL]]:
+//      CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (
+// CHECK-SAME: @"$sSiN"
+// CHECK-SAME: ), [[ERASED_TYPE]]
+//      CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+//      CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+//      CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK-NEXT:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_3:[0-9A-Z_]+]]CySiGMb"([[INT]] [[METADATA_REQUEST]])
+//      CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+//      CHECK:   [[PARTIAL_RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[METADATA]], 0
+//      CHECK:   [[RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_RESULT_METADATA]], [[INT]] 0, 1
+//      CHECK:   ret %swift.metadata_response [[RESULT_METADATA]] 
+//      CHECK: [[EXIT_NORMAL]]:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     i8* undef, 
+//           :     %swift.type_descriptor* bitcast (
+//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor, i32, %swift.method_override_descriptor }>* 
+// CHECK-SAME:       $s4main9Ancestor1[[UNIQUE_ID_1]]CMn
+//           :       to %swift.type_descriptor*
+//           :     )
+// CHECK-SAME:   ) #{{[0-9]+}}
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {
+//      CHECK: entry:
+//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+//      CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+//      CHECK: [[TYPE_COMPARISON_LABEL]]:
+//      CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (
+// CHECK-SAME: @"$sSSN"
+// CHECK-SAME: ), [[ERASED_TYPE]]
+//      CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+//      CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+//      CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK-NEXT:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_3:[0-9A-Z_]+]]CySSGMb"([[INT]] [[METADATA_REQUEST]])
+//      CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+//      CHECK:   [[PARTIAL_RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[METADATA]], 0
+//      CHECK:   [[RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_RESULT_METADATA]], [[INT]] 0, 1
+//      CHECK:   ret %swift.metadata_response [[RESULT_METADATA]] 
+//      CHECK: [[EXIT_NORMAL]]:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     i8* undef, 
+//           :     %swift.type_descriptor* bitcast (
+//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, %swift.method_override_descriptor }>* 
+// CHECK-SAME:       $s4main5Value[[UNIQUE_ID_1]]CMn
+//           :       to %swift.type_descriptor*
+//           :     )
+// CHECK-SAME:   ) #{{[0-9]+}}
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+
+//         CHECK: ; Function Attrs: noinline nounwind readnone
+//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CySSGMb"([[INT]] {{%[0-9]+}}) #4 {
+//         CHECK: entry:
+// CHECK-unknown:   call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
+// CHECK-unknown:   ret
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
+//    CHECK-SAME:        @"$s4main5Value[[UNIQUE_ID_1]]CySSGMf" 
+//   CHECK-apple:   [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
+//   CHECK-apple:   call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
+//     CHECK-NOT:   call swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
+//   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
+//         CHECK: }
+
+// CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"([[INT]] {{%[0-9]+}})
+
+// CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]CySdGMb"([[INT]] {{%[0-9]+}})
+
+

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-2ancestors-1distinct_use-1st_ancestor_generic-1argument-1st_argument_constant_int-2nd_ancestor_generic-1st-argument_subclass_argument.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-2ancestors-1distinct_use-1st_ancestor_generic-1argument-1st_argument_constant_int-2nd_ancestor_generic-1st-argument_subclass_argument.swift
@@ -1,0 +1,335 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK-DAG: @"$s4main9Ancestor1[[UNIQUE_ID_1:[0-9a-zA-Z_]+]]CySiGMf" =
+// CHECK-DAG: @"$s4main9Ancestor2[[UNIQUE_ID_1]]CySiGMf" = 
+
+//              CHECK: @"$s4main5Value[[UNIQUE_ID_1]]CySSGMf" = linkonce_odr hidden 
+// CHECK-unknown-SAME: constant 
+//   CHECK-apple-SAME: global 
+//         CHECK-SAME: <{
+//         CHECK-SAME:   void (
+//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
+//         CHECK-SAME:   )*,
+//         CHECK-SAME:   i8**,
+//                   :   [[INT]],
+//         CHECK-SAME:   %swift.type*,
+//   CHECK-apple-SAME:   %swift.opaque*,
+//   CHECK-apple-SAME:   %swift.opaque*,
+//   CHECK-apple-SAME:   [[INT]],
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i16,
+//         CHECK-SAME:   i16,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   %swift.type_descriptor*,
+//         CHECK-SAME:   void (
+//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
+//         CHECK-SAME:   )*,
+//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   [[INT]],
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:     %TSi*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   )*,
+//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   [[INT]],
+//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   [[INT]],
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:     %swift.opaque*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   )*
+//         CHECK-SAME: }> <{
+//         CHECK-SAME:   void (
+//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]CfD
+//         CHECK-SAME:   $sBoWV
+//   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]CySSGMM
+// CHECK-unknown-SAME:   [[INT]] 0,
+//                   :   %swift.type* getelementptr inbounds (
+//                   :     %swift.full_heapmetadata,
+//                   :     %swift.full_heapmetadata* bitcast (
+//                   :       <{
+//                   :         void (
+//                   :           %T4main9Ancestor1[[UNIQUE_ID_1]]C*
+//                   :         )*,
+//                   :         i8**,
+//                   :         [[INT]],
+//                   :         %swift.type*,
+//                   :         %swift.opaque*,
+//                   :         %swift.opaque*,
+//                   :         [[INT]],
+//                   :         i32,
+//                   :         i32,
+//                   :         i32,
+//                   :         i16,
+//                   :         i16,
+//                   :         i32,
+//                   :         i32,
+//                   :         %swift.type_descriptor*,
+//                   :         void (
+//                   :           %T4main9Ancestor1[[UNIQUE_ID_1]]C*
+//                   :         )*,
+//                   :         %swift.type*,
+//                   :         [[INT]],
+//                   :         %T4main9Ancestor1[[UNIQUE_ID_1]]C* (
+//                   :           %swift.opaque*,
+//                   :           %swift.type*
+//                   :         )*,
+//                   :         %swift.type*,
+//                   :         [[INT]]
+//                   :       }>* @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMf" to %swift.full_heapmetadata*
+//                   :     ),
+//                   :     i32 0,
+//                   :     i32 2
+//                   :   ),
+//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache,
+//   CHECK-apple-SAME:   %swift.opaque* null,
+//   CHECK-apple-SAME:   [[INT]] add (
+//   CHECK-apple-SAME:     [[INT]] ptrtoint (
+//   CHECK-apple-SAME:       {
+//   CHECK-apple-SAME:         i32,
+//   CHECK-apple-SAME:         i32,
+//   CHECK-apple-SAME:         i32,
+//                   :         i32,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         {
+//   CHECK-apple-SAME:           i32,
+//   CHECK-apple-SAME:           i32,
+//   CHECK-apple-SAME:           [
+//   CHECK-apple-SAME:             1 x {
+//   CHECK-apple-SAME:               [[INT]]*,
+//   CHECK-apple-SAME:               i8*,
+//   CHECK-apple-SAME:               i8*,
+//   CHECK-apple-SAME:               i32,
+//   CHECK-apple-SAME:               i32
+//   CHECK-apple-SAME:             }
+//   CHECK-apple-SAME:           ]
+//   CHECK-apple-SAME:         }*,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         i8*
+//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP[[UNIQUE_ID_2:[0-9A-Za-z_]+]]5Value to [[INT]]
+//   CHECK-apple-SAME:     ),
+//   CHECK-apple-SAME:     [[INT]] 2
+//   CHECK-apple-SAME:   ),
+//         CHECK-SAME:   i32 26,
+//         CHECK-SAME:   i32 0,
+//         CHECK-SAME:   i32 {{(48|28)}},
+//         CHECK-SAME:   i16 {{(7|3)}},
+//         CHECK-SAME:   i16 0,
+//   CHECK-apple-SAME:   i32 {{(160|92)}},
+// CHECK-unknown-SAME:   i32 136,
+//         CHECK-SAME:   i32 {{(16|8)}},
+//                   :   %swift.type_descriptor* bitcast (
+//                   :     <{
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i16,
+//                   :       i16,
+//                   :       i16,
+//                   :       i16,
+//                   :       i8,
+//                   :       i8,
+//                   :       i8,
+//                   :       i8,
+//                   :       i32,
+//                   :       %swift.method_override_descriptor
+//                   :     }>* @"$s4main5Value[[UNIQUE_ID_1]]CMn" to %swift.type_descriptor*
+//                   :   ),
+//         CHECK-SAME:   void (
+//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]CfE
+//         CHECK-SAME:   %swift.type* @"$sSSN",
+//         CHECK-SAME:   [[INT]] {{(16|8)}},
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:     %TSi*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGSi_tcfCAA9Ancestor2ACLLCAeHyxGx_tcfCTV
+//         CHECK-SAME:   %swift.type* @"$sSSN",
+//         CHECK-SAME:   [[INT]] {{(24|12)}},
+//         CHECK-SAME:   %swift.type* @"$sSSN",
+//         CHECK-SAME:   [[INT]] {{(32|16)}},
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:     %swift.opaque*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGx_tcfC
+//         CHECK-SAME: }>,
+//         CHECK-SAME: align [[ALIGNMENT]]
+
+fileprivate class Ancestor2<First> {
+  let first_Ancestor2: First
+
+  init(first: First) {
+    self.first_Ancestor2 = first
+  }
+}
+
+fileprivate class Ancestor1<First> : Ancestor2<First> {
+  let first_Ancestor1: First
+
+  override init(first: First) {
+    self.first_Ancestor1 = first
+    super.init(first: first)
+  }
+}
+
+fileprivate class Value<First> : Ancestor1<Int> {
+  let first_Value: First
+
+  init(first: First) {
+    self.first_Value = first
+    super.init(first: 13)
+  }
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CySSGMb"([[INT]] 0)
+// CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK: }
+func doit() {
+  consume( Value(first: "13") )
+}
+doit()
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {
+//      CHECK: entry:
+//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+//      CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+//      CHECK: [[TYPE_COMPARISON_LABEL]]:
+//      CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (
+// CHECK-SAME: @"$sSiN"
+// CHECK-SAME: ), [[ERASED_TYPE]]
+//      CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+//      CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+//      CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK-NEXT:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_3:[0-9A-Z_]+]]CySiGMb"([[INT]] [[METADATA_REQUEST]])
+//      CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+//      CHECK:   [[PARTIAL_RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[METADATA]], 0
+//      CHECK:   [[RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_RESULT_METADATA]], [[INT]] 0, 1
+//      CHECK:   ret %swift.metadata_response [[RESULT_METADATA]] 
+//      CHECK: [[EXIT_NORMAL]]:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     i8* undef, 
+//           :     %swift.type_descriptor* bitcast (
+//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
+// CHECK-SAME:       $s4main9Ancestor2[[UNIQUE_ID_1]]CMn
+//           :       to %swift.type_descriptor*
+//           :     )
+// CHECK-SAME:   ) #{{[0-9]+}}
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {
+//      CHECK: entry:
+//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+//      CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+//      CHECK: [[TYPE_COMPARISON_LABEL]]:
+//      CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (
+// CHECK-SAME: @"$sSiN"
+// CHECK-SAME: ), [[ERASED_TYPE]]
+//      CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+//      CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+//      CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK-NEXT:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_3:[0-9A-Z_]+]]CySiGMb"([[INT]] [[METADATA_REQUEST]])
+//      CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+//      CHECK:   [[PARTIAL_RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[METADATA]], 0
+//      CHECK:   [[RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_RESULT_METADATA]], [[INT]] 0, 1
+//      CHECK:   ret %swift.metadata_response [[RESULT_METADATA]] 
+//      CHECK: [[EXIT_NORMAL]]:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     i8* undef, 
+//           :     %swift.type_descriptor* bitcast (
+//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor, i32, %swift.method_override_descriptor }>* 
+// CHECK-SAME:       $s4main9Ancestor1[[UNIQUE_ID_1]]CMn
+//           :       to %swift.type_descriptor*
+//           :     )
+// CHECK-SAME:   ) #{{[0-9]+}}
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {
+//      CHECK: entry:
+//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+//      CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+//      CHECK: [[TYPE_COMPARISON_LABEL]]:
+//      CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (
+// CHECK-SAME: @"$sSSN"
+// CHECK-SAME: ), [[ERASED_TYPE]]
+//      CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+//      CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+//      CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK-NEXT:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_3:[0-9A-Z_]+]]CySSGMb"([[INT]] [[METADATA_REQUEST]])
+//      CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+//      CHECK:   [[PARTIAL_RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[METADATA]], 0
+//      CHECK:   [[RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_RESULT_METADATA]], [[INT]] 0, 1
+//      CHECK:   ret %swift.metadata_response [[RESULT_METADATA]] 
+//      CHECK: [[EXIT_NORMAL]]:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     i8* undef, 
+//           :     %swift.type_descriptor* bitcast (
+//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, %swift.method_override_descriptor }>* 
+// CHECK-SAME:       $s4main5Value[[UNIQUE_ID_1]]CMn
+//           :       to %swift.type_descriptor*
+//           :     )
+// CHECK-SAME:   ) #{{[0-9]+}}
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+
+//         CHECK: ; Function Attrs: noinline nounwind readnone
+//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CySSGMb"([[INT]] {{%[0-9]+}}) #4 {
+//         CHECK: entry:
+// CHECK-unknown:   call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
+// CHECK-unknown:   ret
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
+//    CHECK-SAME:        @"$s4main5Value[[UNIQUE_ID_1]]CySSGMf" 
+//   CHECK-apple:   [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
+//   CHECK-apple:   call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
+//     CHECK-NOT:   call swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
+//   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
+//         CHECK: }
+
+// CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"([[INT]] {{%[0-9]+}})
+
+// CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]CySiGMb"([[INT]] {{%[0-9]+}})
+

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-2ancestors-1distinct_use-1st_ancestor_generic-1argument-1st_argument_subclass_argument-2nd_ancestor_generic-1st-argument_constant_int.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-2ancestors-1distinct_use-1st_ancestor_generic-1argument-1st_argument_subclass_argument-2nd_ancestor_generic-1st-argument_constant_int.swift
@@ -1,0 +1,338 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK-DAG: @"$s4main9Ancestor1[[UNIQUE_ID_1:[0-9a-zA-Z_]+]]CySSGMf" =
+// CHECK-DAG: @"$s4main9Ancestor2[[UNIQUE_ID_1]]CySiGMf" = 
+
+//              CHECK: @"$s4main5Value[[UNIQUE_ID_1]]CySSGMf" = linkonce_odr hidden 
+// CHECK-unknown-SAME: constant 
+//   CHECK-apple-SAME: global 
+//         CHECK-SAME: <{
+//         CHECK-SAME:   void (
+//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
+//         CHECK-SAME:   )*,
+//         CHECK-SAME:   i8**,
+//                   :   [[INT]],
+//         CHECK-SAME:   %swift.type*,
+//   CHECK-apple-SAME:   %swift.opaque*,
+//   CHECK-apple-SAME:   %swift.opaque*,
+//   CHECK-apple-SAME:   [[INT]],
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i16,
+//         CHECK-SAME:   i16,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   i32,
+//         CHECK-SAME:   %swift.type_descriptor*,
+//         CHECK-SAME:   void (
+//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
+//         CHECK-SAME:   )*,
+//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   [[INT]],
+//         CHECK-SAME:   %T4main9Ancestor1[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:     %TSi*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   )*,
+//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   [[INT]],
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:     %swift.opaque*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   )*,
+//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   [[INT]]
+//         CHECK-SAME: }> <{
+//         CHECK-SAME:   void (
+//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]CfD
+//         CHECK-SAME:   $sBoWV
+//   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]CySSGMM
+// CHECK-unknown-SAME:   [[INT]] 0,
+//                   :   %swift.type* getelementptr inbounds (
+//                   :     %swift.full_heapmetadata,
+//                   :     %swift.full_heapmetadata* bitcast (
+//                   :       <{
+//                   :         void (
+//                   :           %T4main9Ancestor1[[UNIQUE_ID_1]]C*
+//                   :         )*,
+//                   :         i8**,
+//                   :         [[INT]],
+//                   :         %swift.type*,
+//                   :         %swift.opaque*,
+//                   :         %swift.opaque*,
+//                   :         [[INT]],
+//                   :         i32,
+//                   :         i32,
+//                   :         i32,
+//                   :         i16,
+//                   :         i16,
+//                   :         i32,
+//                   :         i32,
+//                   :         %swift.type_descriptor*,
+//                   :         void (
+//                   :           %T4main9Ancestor1[[UNIQUE_ID_1]]C*
+//                   :         )*,
+//                   :         %swift.type*,
+//                   :         [[INT]],
+//                   :         %T4main9Ancestor1[[UNIQUE_ID_1]]C* (
+//                   :           %TSi*,
+//                   :           %swift.type*
+//                   :         )*,
+//                   :         %swift.type*,
+//                   :         [[INT]],
+//                   :         %T4main9Ancestor1[[UNIQUE_ID_1]]C* (
+//                   :           %swift.opaque*,
+//                   :           %swift.type*
+//                   :         )*
+//                   :       }>* @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySSGMf" to %swift.full_heapmetadata*
+//                   :     ),
+//                   :     i32 0,
+//                   :     i32 2
+//                   :   ),
+//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache,
+//   CHECK-apple-SAME:   %swift.opaque* null,
+//   CHECK-apple-SAME:   [[INT]] add (
+//   CHECK-apple-SAME:     [[INT]] ptrtoint (
+//   CHECK-apple-SAME:       {
+//   CHECK-apple-SAME:         i32,
+//   CHECK-apple-SAME:         i32,
+//   CHECK-apple-SAME:         i32,
+//                   :         i32,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         {
+//   CHECK-apple-SAME:           i32,
+//   CHECK-apple-SAME:           i32,
+//   CHECK-apple-SAME:           [
+//   CHECK-apple-SAME:             1 x {
+//   CHECK-apple-SAME:               [[INT]]*,
+//   CHECK-apple-SAME:               i8*,
+//   CHECK-apple-SAME:               i8*,
+//   CHECK-apple-SAME:               i32,
+//   CHECK-apple-SAME:               i32
+//   CHECK-apple-SAME:             }
+//   CHECK-apple-SAME:           ]
+//   CHECK-apple-SAME:         }*,
+//   CHECK-apple-SAME:         i8*,
+//   CHECK-apple-SAME:         i8*
+//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP33_3988F8479474ED01F0E6D128C27960415Value to [[INT]]
+//   CHECK-apple-SAME:     ),
+//   CHECK-apple-SAME:     [[INT]] 2
+//   CHECK-apple-SAME:   ),
+//         CHECK-SAME:   i32 26,
+//         CHECK-SAME:   i32 0,
+//         CHECK-SAME:   i32 {{(56|36)}},
+//         CHECK-SAME:   i16 {{(7|3)}},
+//         CHECK-SAME:   i16 0,
+//   CHECK-apple-SAME:   i32 {{(160|92)}},
+// CHECK-unknown-SAME:   i32 136,
+//         CHECK-SAME:   i32 {{(16|8)}},
+//                   :   %swift.type_descriptor* bitcast (
+//                   :     <{
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i32,
+//                   :       i16,
+//                   :       i16,
+//                   :       i16,
+//                   :       i16,
+//                   :       i8,
+//                   :       i8,
+//                   :       i8,
+//                   :       i8,
+//                   :       i32,
+//                   :       %swift.method_override_descriptor
+//                   :     }>* @"$s4main5Value[[UNIQUE_ID_1]]CMn" to %swift.type_descriptor*
+//                   :   ),
+//         CHECK-SAME:   void (
+//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]CfE
+//         CHECK-SAME:   %swift.type* @"$sSSN",
+//         CHECK-SAME:   [[INT]] {{(16|8)}},
+//         CHECK-SAME:   %T4main9Ancestor1[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:     %TSi*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   $s4main9Ancestor1[[UNIQUE_ID_1]]C5firstADyxGSi_tcfCAA9Ancestor2ACLLCAeHyxGx_tcfCTV
+//         CHECK-SAME:   %swift.type* @"$sSSN",
+//         CHECK-SAME:   [[INT]] {{(24|12)}},
+//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
+//         CHECK-SAME:     %swift.opaque*,
+//         CHECK-SAME:     %swift.type*
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGx_tcfC
+//         CHECK-SAME:   %swift.type* @"$sSSN",
+//         CHECK-SAME:   [[INT]] {{(40|24)}}
+//         CHECK-SAME: }>,
+//         CHECK-SAME: align [[ALIGNMENT]]
+
+fileprivate class Ancestor2<First> {
+  let first_Ancestor2: First
+
+  init(first: First) {
+    self.first_Ancestor2 = first
+  }
+}
+
+fileprivate class Ancestor1<First> : Ancestor2<Int> {
+  let first_Ancestor1: First
+
+  init(first: First) {
+    self.first_Ancestor1 = first
+    super.init(first: 13)
+  }
+}
+
+fileprivate class Value<First> : Ancestor1<First> {
+  let first_Value: First
+
+  override init(first: First) {
+    self.first_Value = first
+    super.init(first: first)
+  }
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CySSGMb"([[INT]] 0)
+// CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK: }
+func doit() {
+  consume( Value(first: "13") )
+}
+doit()
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {
+//      CHECK: entry:
+//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+//      CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+//      CHECK: [[TYPE_COMPARISON_LABEL]]:
+//      CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (
+// CHECK-SAME: @"$sSiN"
+// CHECK-SAME: ), [[ERASED_TYPE]]
+//      CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+//      CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+//      CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK-NEXT:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_3:[0-9A-Z_]+]]CySiGMb"([[INT]] [[METADATA_REQUEST]])
+//      CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+//      CHECK:   [[PARTIAL_RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[METADATA]], 0
+//      CHECK:   [[RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_RESULT_METADATA]], [[INT]] 0, 1
+//      CHECK:   ret %swift.metadata_response [[RESULT_METADATA]] 
+//      CHECK: [[EXIT_NORMAL]]:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     i8* undef, 
+//           :     %swift.type_descriptor* bitcast (
+//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
+// CHECK-SAME:       $s4main9Ancestor2[[UNIQUE_ID_1]]CMn
+//           :       to %swift.type_descriptor*
+//           :     )
+// CHECK-SAME:   ) #{{[0-9]+}}
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {
+//      CHECK: entry:
+//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+//      CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+//      CHECK: [[TYPE_COMPARISON_LABEL]]:
+//      CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (
+// CHECK-SAME: @"$sSSN"
+// CHECK-SAME: ), [[ERASED_TYPE]]
+//      CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+//      CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+//      CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK-NEXT:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_3:[0-9A-Z_]+]]CySSGMb"([[INT]] [[METADATA_REQUEST]])
+//      CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+//      CHECK:   [[PARTIAL_RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[METADATA]], 0
+//      CHECK:   [[RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_RESULT_METADATA]], [[INT]] 0, 1
+//      CHECK:   ret %swift.metadata_response [[RESULT_METADATA]] 
+//      CHECK: [[EXIT_NORMAL]]:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     i8* undef, 
+//           :     %swift.type_descriptor* bitcast (
+//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor, i32, %swift.method_override_descriptor }>* 
+// CHECK-SAME:       $s4main9Ancestor1[[UNIQUE_ID_1]]CMn
+//           :       to %swift.type_descriptor*
+//           :     )
+// CHECK-SAME:   ) #{{[0-9]+}}
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {
+//      CHECK: entry:
+//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+//      CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+//      CHECK: [[TYPE_COMPARISON_LABEL]]:
+//      CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (
+// CHECK-SAME: @"$sSSN"
+// CHECK-SAME: ), [[ERASED_TYPE]]
+//      CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+//      CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+//      CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK-NEXT:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_3:[0-9A-Z_]+]]CySSGMb"([[INT]] [[METADATA_REQUEST]])
+//      CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+//      CHECK:   [[PARTIAL_RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[METADATA]], 0
+//      CHECK:   [[RESULT_METADATA:%[\" a-zA-Z0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_RESULT_METADATA]], [[INT]] 0, 1
+//      CHECK:   ret %swift.metadata_response [[RESULT_METADATA]] 
+//      CHECK: [[EXIT_NORMAL]]:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     i8* undef, 
+//           :     %swift.type_descriptor* bitcast (
+//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, %swift.method_override_descriptor }>* 
+// CHECK-SAME:       $s4main5Value[[UNIQUE_ID_1]]CMn
+//           :       to %swift.type_descriptor*
+//           :     )
+// CHECK-SAME:   ) #{{[0-9]+}}
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+
+//         CHECK: ; Function Attrs: noinline nounwind readnone
+//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CySSGMb"([[INT]] {{%[0-9]+}}) #4 {
+//         CHECK: entry:
+// CHECK-unknown:   call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySSGMb"([[INT]] 0)
+// CHECK-unknown:   ret
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
+//    CHECK-SAME:        @"$s4main5Value[[UNIQUE_ID_1]]CySSGMf" 
+//   CHECK-apple:   [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
+//   CHECK-apple:   call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySSGMb"([[INT]] 0)
+//     CHECK-NOT:   call swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
+//   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
+//         CHECK: }
+
+// CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySSGMb"([[INT]] {{%[0-9]+}})
+
+// CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]CySiGMb"([[INT]] {{%[0-9]+}})

--- a/test/IRGen/prespecialized-metadata/class-inmodule-1argument-metatype-run.swift
+++ b/test/IRGen/prespecialized-metadata/class-inmodule-1argument-metatype-run.swift
@@ -1,0 +1,28 @@
+// RUN: %target-run-simple-swift(%S/Inputs/main.swift %S/Inputs/consume-logging-metadata-value.swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future) | %FileCheck %s
+// REQUIRES: executable_test
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+// Executing on the simulator within __abort_with_payload with "No ABI plugin located for triple x86_64h-apple-ios -- shared libraries will not be registered!"
+// UNSUPPORTED: CPU=x86_64 && OS=ios
+// UNSUPPORTED: CPU=x86_64 && OS=tvos
+// UNSUPPORTED: CPU=x86_64 && OS=watchos
+// UNSUPPORTED: CPU=i386 && OS=watchos
+// UNSUPPORTED: use_os_stdlib
+
+class MyGenericClazz<T> {
+}
+
+func consume<T>(clazzType: MyGenericClazz<T>.Type) {
+  consume( clazzType )
+}
+
+func doit() {
+    // CHECK: [[METATYPE_ADDRESS:0x[0-9a-f]+]] MyGenericClazz<Int>
+    consume( MyGenericClazz<Int>.self )
+    // CHECK: [[METATYPE_ADDRESS]] MyGenericClazz<Int>
+    consume(clazzType: MyGenericClazz<Int>.self)
+}
+

--- a/test/IRGen/prespecialized-metadata/class-inmodule-1argument-run.swift
+++ b/test/IRGen/prespecialized-metadata/class-inmodule-1argument-run.swift
@@ -1,0 +1,74 @@
+// RUN: %target-run-simple-swift(%S/Inputs/main.swift %S/Inputs/consume-logging-metadata-value.swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future) | %FileCheck %s
+// REQUIRES: executable_test
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+// Executing on the simulator within __abort_with_payload with "No ABI plugin located for triple x86_64h-apple-ios -- shared libraries will not be registered!"
+// UNSUPPORTED: CPU=x86_64 && OS=ios
+// UNSUPPORTED: CPU=x86_64 && OS=tvos
+// UNSUPPORTED: CPU=x86_64 && OS=watchos
+// UNSUPPORTED: CPU=i386 && OS=watchos
+// UNSUPPORTED: use_os_stdlib
+
+class MyGenericClazz<T> {
+
+  let line: UInt
+
+  init(line: UInt = #line) {
+    self.line = line
+  }
+
+}
+
+extension MyGenericClazz : CustomStringConvertible {
+
+  var description: String {
+    "\(type(of: self)) @ \(line)"
+  }
+
+}
+
+@inline(never)
+func consume<T>(clazz: MyGenericClazz<T>) {
+  consume(clazz)
+}
+
+@inline(never)
+func consume<T>(clazzType: MyGenericClazz<T>.Type) {
+  consume(clazzType)
+}
+
+
+public func doit() {
+  // CHECK: [[FLOAT_METADATA_ADDRESS:[0-9a-f]+]] MyGenericClazz<Float> @ 46
+  consume(MyGenericClazz<Float>())
+  // CHECK: [[FLOAT_METADATA_ADDRESS]] MyGenericClazz<Float> @ 48
+  consume(clazz: MyGenericClazz<Float>())
+
+  // CHECK: [[DOUBLE_METADATA_ADDRESS:[0-9a-f]+]] MyGenericClazz<Double> @ 51
+  consume(MyGenericClazz<Double>())
+  // CHECK: [[DOUBLE_METADATA_ADDRESS]] MyGenericClazz<Double> @ 53
+  consume(clazz: MyGenericClazz<Double>())
+
+  // CHECK: [[INT_METADATA_ADDRESS:[0-9a-f]+]] MyGenericClazz<Int> @ 56
+  consume(MyGenericClazz<Int>())
+  // CHECK: [[INT_METADATA_ADDRESS]] MyGenericClazz<Int> @ 58
+  consume(clazz: MyGenericClazz<Int>())
+
+  // CHECK: [[STRING_METADATA_ADDRESS:[0-9a-f]+]] MyGenericClazz<String> @ 61
+  consume(MyGenericClazz<String>())
+  // CHECK: [[STRING_METADATA_ADDRESS]] MyGenericClazz<String> @ 63
+  consume(clazz: MyGenericClazz<String>())
+
+  // CHECK: [[NESTED_METADATA_ADDRESS:[0-9a-f]+]] MyGenericClazz<MyGenericClazz<String>> @ 66
+  consume(MyGenericClazz<MyGenericClazz<String>>())
+  // CHECK: [[NESTED_METADATA_ADDRESS:[0-9a-f]+]] MyGenericClazz<MyGenericClazz<String>> @ 68
+  consume(clazz: MyGenericClazz<MyGenericClazz<String>>())
+
+  // CHECK: [[FLOAT_METADATA_METATYPE_ADDRESS:[0-9a-f]+]] MyGenericClazz<Float>
+  consume(MyGenericClazz<Float>.self)
+  // CHECK: [[FLOAT_METADATA_METATYPE_ADDRESS]] MyGenericClazz<Float>
+  consume(clazzType: MyGenericClazz<Float>.self)
+}

--- a/test/IRGen/prespecialized-metadata/class-inmodule-2argument-1super-2argument-run.swift
+++ b/test/IRGen/prespecialized-metadata/class-inmodule-2argument-1super-2argument-run.swift
@@ -1,0 +1,85 @@
+// RUN: %target-run-simple-swift(%S/Inputs/main.swift %S/Inputs/consume-logging-metadata-value.swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future) | %FileCheck %s
+// REQUIRES: executable_test
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+// Executing on the simulator within __abort_with_payload with "No ABI plugin located for triple x86_64h-apple-ios -- shared libraries will not be registered!"
+// UNSUPPORTED: CPU=x86_64 && OS=ios
+// UNSUPPORTED: CPU=x86_64 && OS=tvos
+// UNSUPPORTED: CPU=x86_64 && OS=watchos
+// UNSUPPORTED: CPU=i386 && OS=watchos
+// UNSUPPORTED: use_os_stdlib
+
+class WeakMutableInstanceMethodBox<Input, Output> {
+    let line: UInt
+
+    init(line: UInt = #line) {
+      self.line = line
+    }
+
+    private var work: ((Input) -> Output?)?
+
+    func bind<T: AnyObject>(to object: T, method: @escaping (T) -> (Input) -> Output?) {
+        self.work = { [weak object] input in
+            guard let object = object else { return nil }
+            return method(object)(input)
+        }
+    }
+
+    func call(_ input: Input) -> Output? {
+        return work?(input)
+    }
+}
+
+extension WeakMutableInstanceMethodBox : CustomStringConvertible {
+
+  var description: String {
+    "\(type(of: self)) @ \(line)"
+  }
+
+}
+
+class MyWeakMutableInstanceMethodBox<Input, Output> : WeakMutableInstanceMethodBox<Input, Output> {
+
+    override init(line: UInt = #line) {
+        super.init(line: line)
+    }
+
+}
+
+@inline(never)
+func consume<Input, Output>(base: WeakMutableInstanceMethodBox<Input, Output>) {
+  consume(base)
+}
+
+func consume<Input, Output>(derived: MyWeakMutableInstanceMethodBox<Input,  Output>) {
+  consume(derived)
+}
+
+func doit() {
+    // CHECK: [[SUPERCLASS_METADATA_INT_BOOL_ADDRESS:[0-9a-f]+]] WeakMutableInstanceMethodBox<Int, Bool> @ 63
+    consume(WeakMutableInstanceMethodBox<Int, Bool>())
+    // CHECK: [[SUPERCLASS_METADATA_INT_BOOL_ADDRESS]] WeakMutableInstanceMethodBox<Int, Bool> @ 65
+    consume(base: WeakMutableInstanceMethodBox<Int, Bool>())
+    // CHECK: [[SUPERCLASS_METADATA_DOUBLE_FLOAT_ADDRESS:[0-9a-f]+]] WeakMutableInstanceMethodBox<Double, Float> @ 67
+    consume(WeakMutableInstanceMethodBox<Double, Float>())
+    // CHECK: [[SUPERCLASS_METADATA_DOUBLE_FLOAT_ADDRESS]] WeakMutableInstanceMethodBox<Double, Float> @ 69
+    consume(base: WeakMutableInstanceMethodBox<Double, Float>())
+
+    // CHECK: [[SUBCLASS_METADATA_INT_BOOL_ADDRESS:[0-9a-f]+]] MyWeakMutableInstanceMethodBox<Int, Bool> @ 72
+    consume(MyWeakMutableInstanceMethodBox<Int, Bool>())
+    // CHECK: [[SUPERCLASS_METADATA_INT_BOOL_ADDRESS]] MyWeakMutableInstanceMethodBox<Int, Bool> @ 74
+    consume(base: MyWeakMutableInstanceMethodBox<Int, Bool>())
+    // CHECK: [[SUBCLASS_METADATA_INT_BOOL_ADDRESS]] MyWeakMutableInstanceMethodBox<Int, Bool> @ 76
+    consume(derived: MyWeakMutableInstanceMethodBox<Int, Bool>())
+
+    // CHECK: [[SUBCLASS_METADATA_DOUBLE_FLOAT_ADDRESS:[0-9a-f]+]] MyWeakMutableInstanceMethodBox<Double, Float>
+    consume(MyWeakMutableInstanceMethodBox<Double, Float>())
+    // CHECK: [[SUPERCLASS_METADATA_DOUBLE_FLOAT_ADDRESS]] MyWeakMutableInstanceMethodBox<Double, Float>
+    consume(base: MyWeakMutableInstanceMethodBox<Double, Float>())
+    // CHECK: [[SUBCLASS_METADATA_DOUBLE_FLOAT_ADDRESS]] MyWeakMutableInstanceMethodBox<Double, Float>
+    consume(derived: MyWeakMutableInstanceMethodBox<Double, Float>())
+}
+

--- a/test/IRGen/prespecialized-metadata/enum-trailing-flags-run.swift
+++ b/test/IRGen/prespecialized-metadata/enum-trailing-flags-run.swift
@@ -47,7 +47,7 @@ extension Natural {
     )
         -> Invocation.Return
     {
-        if isCanonicalStaticallySpecializedGenericMetadata(ptr(to: Self.self)) != 0 {
+        if isCanonicalStaticallySpecializedGenericMetadata(ptr(to: Self.self)) {
             fatalError()
         }
         switch count {

--- a/test/IRGen/prespecialized-metadata/struct-trailing-flags-run.swift
+++ b/test/IRGen/prespecialized-metadata/struct-trailing-flags-run.swift
@@ -48,7 +48,7 @@ extension Natural {
     )
         -> Invocation.Return
     {
-        if isCanonicalStaticallySpecializedGenericMetadata(ptr(to: Self.self)) != 0 {
+        if isCanonicalStaticallySpecializedGenericMetadata(ptr(to: Self.self)) {
             fatalError()
         }
         switch count {

--- a/test/Inputs/conditional_conformance_subclass_future.swift
+++ b/test/Inputs/conditional_conformance_subclass_future.swift
@@ -66,7 +66,8 @@ public func subclassgeneric_concrete() {
 
 // CHECK-LABEL: define{{( dllexport| protected)?}} swiftcc void @"$s32conditional_conformance_subclass24subclassgeneric_concreteyyF"()
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[SubclassGeneric_TYPE:%.*]] = call {{.*}}@"$s32conditional_conformance_subclass15SubclassGenericCyAA4IsP2VGMD"
+// CHECK-NEXT:    [[SubclassGeneric_RESPONSE:%.*]] = call {{.*}}@"$s32conditional_conformance_subclass15SubclassGenericCyAA4IsP2VGMb"
+// CHECK-NEXT:    [[SubclassGeneric_TYPE:%.*]] = extractvalue %swift.metadata_response [[SubclassGeneric_RESPONSE]], 0
 // CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @"$s32conditional_conformance_subclass15SubclassGenericCyAA4IsP2VGAA4BaseCyxGAA2P1A2A0G0RzlWl"()
 // CHECK-NEXT:    call swiftcc void @"$s32conditional_conformance_subclass8takes_p1yyxmAA2P1RzlF"(%swift.type* [[SubclassGeneric_TYPE]], %swift.type* [[SubclassGeneric_TYPE]], i8** [[Base_P1]])
 // CHECK-NEXT:    ret void

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -685,6 +685,7 @@ config.substitutions.append(('%target-mandates-stable-abi',
 config.substitutions.append(('%target-endian', run_endian))
 config.substitutions.append(('%target-os', run_os))
 config.substitutions.append(('%target-ptrsize', run_ptrsize))
+config.substitutions.append(('%target-vendor', run_vendor))
 config.substitutions.append(('%target-alignment', "%d" % (int(run_ptrsize)/8)))
 
 # Enable Darwin SDK-dependent tests if we have an SDK.


### PR DESCRIPTION
When generic metadata for a class is requested in the same module where the class is defined, rather than a call to the generic metadata accessor or to a variant of `typeForMangledNode`, a call to a new accessor--a canonical specialized generic metadata accessor--is emitted.
The new function is defined schematically as follows:

```
    MetadataResponse `canonical specialized metadata accessor for C<K>`(MetadataRequest request) {
      (void)`canonical specialized metadata accessor for superclass(C<K>)`(::Complete)
      (void)`canonical specialized metadata accessor for generic_argument_class(C<K>, 1)`(::Complete)
      ...
      (void)`canonical specialized metadata accessor for generic_argument_class(C<K>, count)`(::Complete)
      auto *metadata = objc_opt_self(`canonical specialized metadata for C<K>`);
      return {metadata, MetadataState::Complete};
    }
```

To enable these new canonical specialized generic metadata accessors, metadata for generic classes is prespecialized as needed.  So are the metaclasses and the corresponding rodata.

Previously, the lazy objc naming hook was registered during process execution when the first generic class metadata was instantiated.  Since that instantiation may occur "before process launch" (i.e. if the generic metadata is prespecialized), the lazy naming hook is now
installed at process launch.