### PR TITLE
[semantic-arc-opts] When eliminating trivially dead insts exposed by eliminating ARC, explicitly mark madeChange true.

### DIFF
--- a/lib/SILOptimizer/Transforms/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Transforms/SemanticARCOpts.cpp
@@ -491,6 +491,7 @@ bool SemanticARCOptVisitor::processWorklist() {
       if (isInstructionTriviallyDead(defInst)) {
         deleteAllDebugUses(defInst);
         eraseInstruction(defInst);
+        madeChange = true;
         continue;
       }
     }


### PR DESCRIPTION
Otherwise, on the face of it we do not invalidate analyses as we should. That
being said, I do not think we actually could hit this in practice today since a
trivially dead instruction can only enter the worklist as a result of us
removing some sort of other instruction causing madeChange to be already true.

That being said, I would rather not rely on that in the face of future
change. Found via site reading code.
