### PR TITLE
[SourceKit] don't install libdispatch and libBlocksRuntime twice, outside of Mac/Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1028,11 +1028,13 @@ if(SWIFT_BUILD_SYNTAXPARSERLIB OR SWIFT_BUILD_SOURCEKIT)
       set(SOURCEKIT_RUNTIME_DIR lib)
     endif()
     add_dependencies(sourcekit-inproc BlocksRuntime dispatch)
-    swift_install_in_component(FILES
-                                 $<TARGET_FILE:dispatch>
-                                 $<TARGET_FILE:BlocksRuntime>
-                               DESTINATION ${SOURCEKIT_RUNTIME_DIR}
-                               COMPONENT sourcekit-inproc)
+    if("${SWIFT_HOST_VARIANT_SDK}" MATCHES "OSX|WINDOWS")
+      swift_install_in_component(FILES
+                                   $<TARGET_FILE:dispatch>
+                                   $<TARGET_FILE:BlocksRuntime>
+                                 DESTINATION ${SOURCEKIT_RUNTIME_DIR}
+                                 COMPONENT sourcekit-inproc)
+    endif()
     if(SWIFT_HOST_VARIANT_SDK STREQUAL WINDOWS)
       swift_install_in_component(FILES
                                    $<TARGET_LINKER_FILE:dispatch>


### PR DESCRIPTION
Added in #19800, but unused on [linux](https://github.com/apple/swift/blob/a1c971907bef1f7d174da197e7f4f98ac2c3c9a8/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake#L171) and [Android](https://github.com/apple/swift/blob/a1c971907bef1f7d174da197e7f4f98ac2c3c9a8/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake#L178), as their rpath uses the libdispatch.so in lib/swift/os. I don't know what happens on a mac, as [I don't know what `@rpath` does](https://github.com/apple/swift/blob/a1c971907bef1f7d174da197e7f4f98ac2c3c9a8/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake#L164), so I left it in for macOS.

I've had to [hack around](https://github.com/termux/termux-packages/commit/2a7dfdac34264625233776d091243ab9bd862fe4#diff-4d82ce439ff2bae2157f6c5fc393a3c1R68) this [install before](https://github.com/termux/termux-packages/commit/2a7dfdac34264625233776d091243ab9bd862fe4#diff-4d82ce439ff2bae2157f6c5fc393a3c1R95), but now [I just patch it out for the Android package of Swift](https://github.com/buttaface/termux-packages/commit/5d24726a51f33aa14e910d1e043b3b4e5618d497#diff-888a4dab0d42ccd0625c34069c0b6eb2R50).  Better to just not install it twice for platforms where it's not used, which may include macOS for all I know.