### PR TITLE
Sema: Diagnose unbound method references on 'super.'

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3285,14 +3285,16 @@ ERROR(partial_application_of_function_invalid,none,
       "partial application of %select{"
         "'mutating' method|"
         "'super.init' initializer chain|"
-        "'self.init' initializer delegation"
+        "'self.init' initializer delegation|"
+        "'super' instance method with metatype base"
       "}0 is not allowed",
       (unsigned))
 WARNING(partial_application_of_function_invalid_swift4,none,
       "partial application of %select{"
         "'mutating' method|"
         "'super.init' initializer chain|"
-        "'self.init' initializer delegation"
+        "'self.init' initializer delegation|"
+        "'super' instance method with metatype base"
       "}0 is not allowed; calling the function has undefined behavior and will "
       "be an error in future Swift versions",
       (unsigned))

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3756,6 +3756,8 @@ bool PartialApplicationFailure::diagnoseAsError() {
           anchor, ConstraintLocator::ConstructorMember))) {
     kind = anchor->getBase()->isSuperExpr() ? RefKind::SuperInit
                                             : RefKind::SelfInit;
+  } else if (anchor->getBase()->isSuperExpr()) {
+    kind = RefKind::SuperMethod;
   }
 
   auto diagnostic = CompatibilityWarning

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1091,6 +1091,7 @@ class PartialApplicationFailure final : public FailureDiagnostic {
     MutatingMethod,
     SuperInit,
     SelfInit,
+    SuperMethod,
   };
 
   bool CompatibilityWarning;

--- a/test/Constraints/mutating_members.swift
+++ b/test/Constraints/mutating_members.swift
@@ -27,10 +27,10 @@ func bar() -> Foo.Type { fatalError() }
 
 _ = bar().boom       // expected-error{{partial application of 'mutating' method}}
 _ = bar().boom(&y)   // expected-error{{partial application of 'mutating' method}}
-_ = bar().boom(&y)() // ok
+_ = bar().boom(&y)() // expected-error{{partial application of 'mutating' method}}
 
 func foo(_ foo: Foo.Type) {
   _ = foo.boom       // expected-error{{partial application of 'mutating' method}}
   _ = foo.boom(&y)   // expected-error{{partial application of 'mutating' method}}
-  _ = foo.boom(&y)() // ok
+  _ = foo.boom(&y)() // expected-error{{partial application of 'mutating' method}}
 }

--- a/test/Constraints/mutating_members_compat.swift
+++ b/test/Constraints/mutating_members_compat.swift
@@ -27,10 +27,10 @@ func bar() -> Foo.Type { fatalError() }
 
 _ = bar().boom       // expected-warning{{partial application of 'mutating' method}}
 _ = bar().boom(&y)   // expected-error{{partial application of 'mutating' method}}
-_ = bar().boom(&y)() // ok
+_ = bar().boom(&y)() // expected-error{{partial application of 'mutating' method}}
 
 func foo(_ foo: Foo.Type) {
   _ = foo.boom       // expected-warning{{partial application of 'mutating' method}}
   _ = foo.boom(&y)   // expected-error{{partial application of 'mutating' method}}
-  _ = foo.boom(&y)() // ok
+  _ = foo.boom(&y)() // expected-error{{partial application of 'mutating' method}}
 }

--- a/test/NameBinding/name_lookup.swift
+++ b/test/NameBinding/name_lookup.swift
@@ -292,9 +292,11 @@ class ThisDerived1 : ThisBase1 {
     super.baseInstanceVar = 42 // expected-error {{member 'baseInstanceVar' cannot be used on type 'ThisBase1'}}
     super.baseProp = 42 // expected-error {{member 'baseProp' cannot be used on type 'ThisBase1'}}
     super.baseFunc0() // expected-error {{instance member 'baseFunc0' cannot be used on type 'ThisBase1'}}
-    super.baseFunc0(ThisBase1())()
+    // expected-error@-1 {{partial application of 'super' instance method with metatype base is not allowed}}
+    super.baseFunc0(ThisBase1())() // expected-error {{partial application of 'super' instance method with metatype base is not allowed}}
     super.baseFunc1(42) // expected-error {{instance member 'baseFunc1' cannot be used on type 'ThisBase1'}}
-    super.baseFunc1(ThisBase1())(42)
+    // expected-error@-1 {{partial application of 'super' instance method with metatype base is not allowed}}
+    super.baseFunc1(ThisBase1())(42) // expected-error {{partial application of 'super' instance method with metatype base is not allowed}}
     super[0] = 42.0 // expected-error {{instance member 'subscript' cannot be used on type 'ThisBase1'}}
     super.baseStaticVar = 42
     super.baseStaticProp = 42
@@ -302,6 +304,7 @@ class ThisDerived1 : ThisBase1 {
 
     super.baseExtProp = 42 // expected-error {{member 'baseExtProp' cannot be used on type 'ThisBase1'}}
     super.baseExtFunc0() // expected-error {{instance member 'baseExtFunc0' cannot be used on type 'ThisBase1'}}
+    // expected-error@-1 {{partial application of 'super' instance method with metatype base is not allowed}}
     super.baseExtStaticVar = 42 // expected-error {{instance member 'baseExtStaticVar' cannot be used on type 'ThisBase1'}}
     super.baseExtStaticProp = 42 // expected-error {{member 'baseExtStaticProp' cannot be used on type 'ThisBase1'}}
     super.baseExtStaticFunc0()


### PR DESCRIPTION
This is something I noticed by inspection while working on
<https://bugs.swift.org/browse/SR-75>.

Inside a static method, 'self' is a metatype value, so
'self.instanceMethod' produces an unbound reference of type
(Self) -> (Args...) -> Results.

You might guess that 'super.instanceMethod' can similarly
be used to produce an unbound method reference that calls
the superclass method given any 'self' value, but unfortunately
it doesn't work.

Instead, 'super.instanceMethod' would produce the same
result as 'self.instanceMethod'. Maybe we can implement this
later, but for now, let's just diagnose the problem.

Note that partially-applied method references with 'super.'
-- namely, 'self.staticMethod' inside a static context, or
'self.instanceMethod' inside an instance context, continue
to work as before.

They have the type (Args...) -> Result; since the self value
has already been applied we don't hit the representational
issue.