### PR TITLE
[5.2] Suppress KVO warning when the property has an explicit setter

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4046,7 +4046,10 @@ static void maybeDiagnoseCallToKeyValueObserveMethod(const Expr *E,
       auto property = lastComponent.getDeclRef().getDecl();
       if (!property)
         return;
-      if (property->isObjCDynamic())
+      auto propertyVar = cast<VarDecl>(property);
+      if (propertyVar->isObjCDynamic() ||
+          (propertyVar->isObjC() &&
+           propertyVar->getParsedAccessor(AccessorKind::Set)))
         return;
       C.Diags
           .diagnose(expr->getLoc(),

--- a/test/expr/primary/keypath/keypath-observe-objc.swift
+++ b/test/expr/primary/keypath/keypath-observe-objc.swift
@@ -8,6 +8,10 @@ class Foo: NSObject {
   dynamic var number2 = 2
   @objc var number3 = 3
   @objc dynamic var number4 = 4
+  @objc var number5: Int {
+    get { return 5 }
+    set {}
+  }
 }
 
 class Bar: NSObject {
@@ -33,6 +37,10 @@ class Bar: NSObject {
     }
     
     _ = observe(\.foo.number4, options: [.new]) { _, change in // Okay
+      print("observer4")
+    }
+
+    _ = observe(\.foo.number5, options: [.new]) { _, change in // Okay
       print("observer4")
     }
   }


### PR DESCRIPTION
- **Explanation**: 

In #28135, we added a new warning when a non-`@objc dynamic` property is passed to the KVO `observe` method, because passing such a property can lead to unexpected behaviour or runtime trap.

However, the user might have an `@objc` property (without the `dynamic` modifier) and perform the updates manually, by calling `willChangeValue` and `didChangeValue`:

```swift
private var _bar: Int = 0
@objc var bar: Int {
    get { _bar }
    set {
     guard newValue != _bar else { return }
     willChangeValue(for: \.bar)
     _bar = newValue
     didChangeValue(for: \.bar)
    }
  }
```

This is okay to do, so suppress the warning if we have an explicit setter on the `@objc` property. We could go further and check for those specific calls, but it's probably safe to assume that those calls are being made if there's an explicit setter.

- **Issue**: SR-12286 | rdar://problem/59702530 | FB7595420

- **Scope**: Affects use of `@objc` properties with manual KVO events when passed to the KVO `observe` method.

- **Risk**: Very Low.  We're just suppressing a warning diagnostic, which shouldn't appear in the above scenario.

- **Testing**: Added a new test case.

- **Reviewed by**: @xedin 

Cherry pick of #30098

Resolves: rdar://problem/59702530