### PR TITLE
[Property wrappers] Modernize self enclosing test

### DIFF
--- a/test/Interpreter/property_wrappers.swift
+++ b/test/Interpreter/property_wrappers.swift
@@ -18,8 +18,8 @@ struct Observable<Value: Equatable> {
   private var stored: Value
 
   
-  init(initialValue: Value) {
-    self.stored = initialValue
+  init(wrappedValue: Value) {
+    self.stored = wrappedValue
   }
 
   var wrappedValue: Value {


### PR DESCRIPTION
The init parameter name changed to `wrappedValue` as of Swift 5.2.