### PR TITLE
IRGen: Invoke objc_opt_self directly when available.

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1313,6 +1313,12 @@ FUNCTION(ProtocolAddProtocol, protocol_addProtocol,
          ARGS(ProtocolDescriptorPtrTy, ProtocolDescriptorPtrTy),
          ATTRS(NoUnwind))
 
+FUNCTION(ObjCOptSelf, objc_opt_self,
+         C_CC, AlwaysAvailable,
+         RETURNS(ObjCClassPtrTy),
+         ARGS(ObjCClassPtrTy),
+         ATTRS(NoUnwind))
+
 FUNCTION(Malloc, malloc, C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(SizeTy),

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1224,6 +1224,8 @@ private:                            \
   llvm::Constant *Id##Fn = nullptr;
 #include "swift/Runtime/RuntimeFunctions.def"
   
+  Optional<llvm::Constant *> FixedClassInitializationFn;
+  
   llvm::Constant *FixLifetimeFn = nullptr;
 
   mutable Optional<SpareBitVector> HeapPointerSpareBits;
@@ -1231,6 +1233,8 @@ private:                            \
 //--- Generic ---------------------------------------------------------------
 public:
   llvm::Constant *getFixLifetimeFn();
+  
+  llvm::Constant *getFixedClassInitializationFn();
 
   /// The constructor used when generating code.
   ///

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -587,7 +587,7 @@ llvm::Value *irgen::emitObjCHeapMetadataRef(IRGenFunction &IGF,
   if (allowUninitialized) return classObject;
 
   // TODO: memoize this the same way that we memoize Swift type metadata?
-  return IGF.Builder.CreateCall(IGF.IGM.getGetInitializedObjCClassFn(),
+  return IGF.Builder.CreateCall(IGF.IGM.getFixedClassInitializationFn(),
                                 classObject);
 }
 
@@ -612,7 +612,7 @@ emitIdempotentClassMetadataInitialization(IRGenFunction &IGF,
                                           llvm::Value *metadata) {
   if (IGF.IGM.ObjCInterop) {
     metadata = IGF.Builder.CreateBitCast(metadata, IGF.IGM.ObjCClassPtrTy);
-    metadata = IGF.Builder.CreateCall(IGF.IGM.getGetInitializedObjCClassFn(),
+    metadata = IGF.Builder.CreateCall(IGF.IGM.getFixedClassInitializationFn(),
                                       metadata);
     metadata = IGF.Builder.CreateBitCast(metadata, IGF.IGM.TypeMetadataPtrTy);
   }

--- a/test/ClangImporter/objc_ir.swift
+++ b/test/ClangImporter/objc_ir.swift
@@ -87,7 +87,7 @@ func propertyAccess(b b: B) {
 // CHECK-LABEL: define hidden swiftcc %TSo1BC* @"$s7objc_ir8downcast1aSo1BCSo1AC_tF"(
 func downcast(a a: A) -> B {
   // CHECK: [[CLASS:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_B"
-  // CHECK: [[T0:%.*]] = call %objc_class* @swift_getInitializedObjCClass(%objc_class* [[CLASS]])
+  // CHECK: [[T0:%.*]] = call %objc_class* @{{.*}}(%objc_class* [[CLASS]])
   // CHECK: [[T1:%.*]] = bitcast %objc_class* [[T0]] to i8*
   // CHECK: call i8* @swift_dynamicCastObjCClassUnconditional(i8* [[A:%.*]], i8* [[T1]], {{.*}}) [[NOUNWIND:#[0-9]+]]
   return a as! B

--- a/test/IRGen/fixed_class_initialization.swift
+++ b/test/IRGen/fixed_class_initialization.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.15 -module-name main -emit-ir %s | %FileCheck --check-prefix=CHECK --check-prefix=HAS_OPT_SELF %s
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.14 -module-name main -emit-ir %s | %FileCheck --check-prefix=CHECK --check-prefix=NO_OPT_SELF %s
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+class C {
+  var x: Int = 0
+}
+
+public func foof() -> Any.Type {
+  return C.self
+}
+
+// CHECK-LABEL: define {{.*}} %swift.metadata_response @"$s4main1CCMa"
+// HAS_OPT_SELF:  call {{.*}} @objc_opt_self
+// NO_OPT_SELF:  call {{.*}} @swift_getInitializedObjCClass

--- a/test/IRGen/objc_casts.sil
+++ b/test/IRGen/objc_casts.sil
@@ -36,7 +36,7 @@ bb0(%unused : $@thick T.Type, %obj : $NSObject):
 //   TODO: is this really necessary? also, this really shouldn't use a direct reference
 // CHECK-NEXT:  [[T1:%.*]] = bitcast %objc_object* [[T0]] to i8*
 // CHECK-NEXT:  [[T2a:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_Foo"
-// CHECK-NEXT:  [[T2:%.*]] = call %objc_class* @swift_getInitializedObjCClass(%objc_class* [[T2a]])
+// CHECK-NEXT:  [[T2:%.*]] = call %objc_class* @{{.*}}(%objc_class* [[T2a]])
 // CHECK-NEXT:  [[T3:%.*]] = bitcast %objc_class* [[T2]] to i8*
 // CHECK-NEXT:  call i8* @swift_dynamicCastObjCClassUnconditional(i8* [[T1]], i8* [[T3]], {{.*}})
 sil hidden @metatype_to_objc_class : $@convention(thin) <T> (@thick T.Type) -> () {
@@ -52,7 +52,7 @@ bb0(%metatype : $@thick T.Type):
 //   TODO: is this really necessary? also, this really shouldn't use a direct reference
 // CHECK-NEXT:  [[T1:%.*]] = bitcast %objc_object* [[T0]] to i8*
 // CHECK-NEXT:  [[T2a:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_Foo"
-// CHECK-NEXT:  [[T2:%.*]] = call %objc_class* @swift_getInitializedObjCClass(%objc_class* [[T2a]])
+// CHECK-NEXT:  [[T2:%.*]] = call %objc_class* @{{.*}}(%objc_class* [[T2a]])
 // CHECK-NEXT:  [[T3:%.*]] = bitcast %objc_class* [[T2]] to i8*
 // CHECK-NEXT:  call i8* @swift_dynamicCastObjCClassUnconditional(i8* [[T1]], i8* [[T3]], {{.*}})
 sil hidden @opt_metatype_to_objc_class : $@convention(thin) <T> (Optional<@thick T.Type>) -> () {

--- a/test/IRGen/objc_generic_class_metadata.sil
+++ b/test/IRGen/objc_generic_class_metadata.sil
@@ -39,7 +39,7 @@ entry:
   apply %z<GenericClass<NSObject>>(%b) : $@convention(thin) <T> (@thick T.Type) -> ()
 
   // CHECK: [[T0:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_GenericClass",
-  // CHECK: [[OBJC_CLASS:%.*]] = call %objc_class* @swift_getInitializedObjCClass(%objc_class* [[T0]])
+  // CHECK: [[OBJC_CLASS:%.*]] = call %objc_class* @{{.*}}(%objc_class* [[T0]])
   // CHECK: call swiftcc void @objc_class_sink(%objc_class* [[OBJC_CLASS]], %swift.type* [[METADATA]])
   %c = metatype $@objc_metatype GenericClass<NSString>.Type
   apply %y<GenericClass<NSString>>(%c) : $@convention(thin) <T: AnyObject> (@objc_metatype T.Type) -> ()

--- a/test/IRGen/objc_properties_jit.swift
+++ b/test/IRGen/objc_properties_jit.swift
@@ -15,7 +15,7 @@ extension NSString {
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} private void @runtime_registration
 // CHECK:         [[NSOBJECT_UNINIT:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_NSString"
-// CHECK:         [[NSOBJECT:%.*]] = call %objc_class* @swift_getInitializedObjCClass(%objc_class* [[NSOBJECT_UNINIT]])
+// CHECK:         [[NSOBJECT:%.*]] = call %objc_class* @{{.*}}(%objc_class* [[NSOBJECT_UNINIT]])
 // CHECK:         [[GET_CLASS_PROP:%.*]] = call i8* @sel_registerName({{.*}}(classProp)
 // CHECK:         call i8* @class_replaceMethod(%objc_class* @"OBJC_METACLASS_$_NSString", i8* [[GET_CLASS_PROP]]
 // CHECK:         [[SET_CLASS_PROP:%.*]] = call i8* @sel_registerName({{.*}}(setClassProp:)

--- a/validation-test/Reflection/reflect_empty_struct.swift
+++ b/validation-test/Reflection/reflect_empty_struct.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -lswiftSwiftReflectionTest -I %S/Inputs/EmptyStruct/ %s -o %t/reflect_empty_struct -target x86_64-apple-macosx10.99.0
+// RUN: %target-build-swift -lswiftSwiftReflectionTest -I %S/Inputs/EmptyStruct/ %s -o %t/reflect_empty_struct
 // RUN: %target-codesign %t/reflect_empty_struct
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_empty_struct | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --dump-input fail
@@ -32,13 +32,13 @@ reflect(object: obj)
 // CHECK-64: Type info:
 // CHECK-64: (class_instance size=80 alignment=8 stride=80 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=a offset=16
-// CHECK-64:     (builtin size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK-64:     ({{builtin|struct}} size=0 alignment={{1|4}} stride=1 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-64:   (field name=b offset=16
 // CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64:       (field name=metadata offset=24
 // CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))
 // CHECK-64:   (field name=c offset=48
-// CHECK-64:     (builtin size=0 alignment=4 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK-64:     ({{builtin|struct}} size=0 alignment={{1|4}} stride=1 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-64:   (field name=d offset=48
 // CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64:       (field name=metadata offset=24
@@ -52,13 +52,13 @@ reflect(object: obj)
 // CHECK-32: Type info:
 // CHECK-32: (class_instance size=40 alignment=4 stride=40 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=a offset=8
-// CHECK-32:     (builtin size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK-32:     ({{builtin|struct}} size=0 alignment={{1|4}} stride=1 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-32:   (field name=b offset=8
 // CHECK-32:     (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32:       (field name=metadata offset=12
 // CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))))
 // CHECK-32:   (field name=c offset=24
-// CHECK-32:     (builtin size=0 alignment=4 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK-32:     ({{builtin|struct}} size=0 alignment={{1|4}} stride=1 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-32:   (field name=d offset=24
 // CHECK-32:     (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32:       (field name=metadata offset=12

--- a/validation-test/Reflection/reflect_empty_struct_compat.swift
+++ b/validation-test/Reflection/reflect_empty_struct_compat.swift
@@ -1,10 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift -lswiftSwiftReflectionTest -I %S/Inputs/EmptyStruct/ %s -o %t/reflect_empty_struct -target x86_64-apple-macosx10.15.0
-// RUN: %target-codesign %t/reflect_empty_struct
-// RUN: %target-run %target-swift-reflection-test %t/reflect_empty_struct | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --dump-input fail
-
-// RUN: %target-build-swift -lswiftSwiftReflectionTest -I %S/Inputs/EmptyStruct/ %s -o %t/reflect_empty_struct -target x86_64-apple-macosx10.14.0
+// RUN: %target-build-swift -lswiftSwiftReflectionTest -I %S/Inputs/EmptyStruct/ %s -o %t/reflect_empty_struct
 // RUN: %target-codesign %t/reflect_empty_struct
 // RUN: %target-run %target-swift-reflection-test %t/reflect_empty_struct | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --dump-input fail
 


### PR DESCRIPTION
We don't need swift_getInitializedObjCClass on new enough Apple OSes because
the ObjC runtime provides an equivalent call for us.