### PR TITLE
[Frontend] Clean Up Usage of UnifiedStatsReporter

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -404,6 +404,9 @@ class CompilerInstance {
 
   /// Null if no tracker.
   std::unique_ptr<DependencyTracker> DepTracker;
+  /// If there is no stats output directory by the time the
+  /// instance has completed its setup, this will be null.
+  std::unique_ptr<UnifiedStatsReporter> Stats;
 
   mutable ModuleDecl *MainModule = nullptr;
   SerializedModuleLoader *SML = nullptr;
@@ -488,6 +491,8 @@ public:
   DependencyTracker *getDependencyTracker() { return DepTracker.get(); }
   const DependencyTracker *getDependencyTracker() const { return DepTracker.get(); }
 
+  UnifiedStatsReporter *getStatsReporter() const { return Stats.get(); }
+
   SILModule *getSILModule() {
     return TheSILModule.get();
   }
@@ -571,6 +576,7 @@ private:
 
   bool setUpInputs();
   bool setUpASTContextIfNeeded();
+  void setupStatsReporter();
   Optional<unsigned> setUpCodeCompletionBuffer();
 
   /// Set up all state in the CompilerInstance to process the given input file.

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -625,8 +625,7 @@ public:
   /// \param silModule The SIL module that was generated during SILGen.
   /// \param stats A stats reporter that will report optimization statistics.
   /// \returns true if any errors occurred.
-  bool performSILProcessing(SILModule *silModule,
-                            UnifiedStatsReporter *stats = nullptr);
+  bool performSILProcessing(SILModule *silModule);
 
 private:
   SourceFile *

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -61,6 +61,7 @@ namespace swift {
   class SILModule;
   class SILParserTUState;
   class SourceFile;
+  enum class SourceFileKind;
   class SourceManager;
   class SyntaxParseActions;
   class SyntaxParsingCache;
@@ -70,7 +71,6 @@ namespace swift {
   class TypeCheckerOptions;
   struct TypeLoc;
   class UnifiedStatsReporter;
-  enum class SourceFileKind;
 
   namespace Lowering {
     class TypeConverter;
@@ -286,29 +286,31 @@ namespace swift {
                                    StringRef OutputPath);
 
   /// Turn the given LLVM module into native code and return true on error.
-  bool performLLVM(const IRGenOptions &Opts, ASTContext &Ctx, llvm::Module *Module,
-                   StringRef OutputFilename,
-                   UnifiedStatsReporter *Stats=nullptr);
+  bool performLLVM(const IRGenOptions &Opts,
+                   ASTContext &Ctx,
+                   llvm::Module *Module,
+                   StringRef OutputFilename);
 
   /// Run the LLVM passes. In multi-threaded compilation this will be done for
   /// multiple LLVM modules in parallel.
-  /// \param Diags may be null if LLVM code gen diagnostics are not required.
-  /// \param DiagMutex may also be null if a mutex around \p Diags is not
-  ///                  required.
+  /// \param Diags The Diagnostic Engine.
+  /// \param DiagMutex in contexts that require parallel codegen, a mutex that the
+  ///                  diagnostic engine uses to synchronize emission.
   /// \param HashGlobal used with incremental LLVMCodeGen to know if a module
   ///                   was already compiled, may be null if not desired.
   /// \param Module LLVM module to code gen, required.
   /// \param TargetMachine target of code gen, required.
   /// \param effectiveLanguageVersion version of the language, effectively.
   /// \param OutputFilename Filename for output.
-  bool performLLVM(const IRGenOptions &Opts, DiagnosticEngine *Diags,
+  bool performLLVM(const IRGenOptions &Opts,
+                   DiagnosticEngine &Diags,
                    llvm::sys::Mutex *DiagMutex,
                    llvm::GlobalVariable *HashGlobal,
                    llvm::Module *Module,
                    llvm::TargetMachine *TargetMachine,
                    const version::Version &effectiveLanguageVersion,
                    StringRef OutputFilename,
-                   UnifiedStatsReporter *Stats=nullptr);
+                   UnifiedStatsReporter *Stats);
 
   /// Dump YAML describing all fixed-size types imported from the given module.
   bool performDumpTypeInfo(const IRGenOptions &Opts,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -617,13 +617,12 @@ llvm::BumpPtrAllocator &ASTContext::getAllocator(AllocationArena arena) const {
 
 /// Set a new stats reporter.
 void ASTContext::setStatsReporter(UnifiedStatsReporter *stats) {
-  Stats = stats;
-  evaluator.setStatsReporter(stats);
-
   if (stats) {
     stats->getFrontendCounters().NumASTBytesAllocated =
         getAllocator().getBytesAllocated();
   }
+  evaluator.setStatsReporter(stats);
+  Stats = stats;
 }
 
 RC<syntax::SyntaxArena> ASTContext::getSyntaxArena() const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5018,8 +5018,8 @@ ProtocolDecl::setLazyRequirementSignature(LazyMemberLoader *lazyLoader,
 
   ++NumLazyRequirementSignatures;
   // FIXME: (transitional) increment the redundant "always-on" counter.
-  if (getASTContext().Stats)
-    getASTContext().Stats->getFrontendCounters().NumLazyRequirementSignatures++;
+  if (auto *Stats = getASTContext().Stats)
+    Stats->getFrontendCounters().NumLazyRequirementSignatures++;
 }
 
 ArrayRef<Requirement> ProtocolDecl::getCachedRequirementSignature() const {

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3458,8 +3458,8 @@ void EquivalenceClass::modified(GenericSignatureBuilder &builder) {
 GenericSignatureBuilder::GenericSignatureBuilder(
                                ASTContext &ctx)
   : Context(ctx), Diags(Context.Diags), Impl(new Implementation) {
-  if (Context.Stats)
-    Context.Stats->getFrontendCounters().NumGenericSignatureBuilders++;
+  if (auto *Stats = Context.Stats)
+    Stats->getFrontendCounters().NumGenericSignatureBuilders++;
 }
 
 GenericSignatureBuilder::GenericSignatureBuilder(

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -629,7 +629,8 @@ void ModuleDecl::lookupClassMember(AccessPathTy accessPath,
     stats->getFrontendCounters().NumModuleLookupClassMember++;
 
   if (isParsedModule(this)) {
-    FrontendStatsTracer tracer(getASTContext().Stats, "source-file-lookup-class-member");
+    FrontendStatsTracer tracer(getASTContext().Stats,
+                               "source-file-lookup-class-member");
     auto &cache = getSourceLookupCache();
     cache.populateMemberCache(*this);
     cache.lookupClassMember(accessPath, name, results);
@@ -642,7 +643,8 @@ void ModuleDecl::lookupClassMember(AccessPathTy accessPath,
 void SourceFile::lookupClassMember(ModuleDecl::AccessPathTy accessPath,
                                    DeclName name,
                                    SmallVectorImpl<ValueDecl*> &results) const {
-  FrontendStatsTracer tracer(getASTContext().Stats, "source-file-lookup-class-member");
+  FrontendStatsTracer tracer(getASTContext().Stats,
+                             "source-file-lookup-class-member");
   auto &cache = getCache();
   cache.populateMemberCache(*this);
   cache.lookupClassMember(accessPath, name, results);

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -490,7 +490,8 @@ void UnqualifiedLookupFactory::performUnqualifiedLookup() {
   auto localCounter = lookupCounter;
   (void)localCounter; // for debugging
 #endif
-  FrontendStatsTracer StatsTracer(Ctx.Stats, "performUnqualifedLookup",
+  FrontendStatsTracer StatsTracer(Ctx.Stats,
+                                  "performUnqualifedLookup",
                                   DC->getParentSourceFile());
 
   const Optional<bool> initialIsCascadingUse = getInitialIsCascadingUse();

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7859,8 +7859,8 @@ ClangImporter::Implementation::importDeclImpl(const clang::NamedDecl *ClangDecl,
 void ClangImporter::Implementation::startedImportingEntity() {
   ++NumTotalImportedEntities;
   // FIXME: (transitional) increment the redundant "always-on" counter.
-  if (SwiftContext.Stats)
-    SwiftContext.Stats->getFrontendCounters().NumTotalClangImportedEntities++;
+  if (auto *Stats = SwiftContext.Stats)
+    Stats->getFrontendCounters().NumTotalClangImportedEntities++;
 }
 
 /// Look up associated type requirements in the conforming type.
@@ -8563,7 +8563,8 @@ static void loadAllMembersOfSuperclassIfNeeded(ClassDecl *CD) {
 void
 ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
 
-  FrontendStatsTracer tracer(D->getASTContext().Stats, "load-all-members", D);
+  FrontendStatsTracer tracer(D->getASTContext().Stats,
+                             "load-all-members", D);
   assert(D);
 
   // Check whether we're importing an Objective-C container of some sort.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2687,8 +2687,8 @@ llvm::Constant *IRGenModule::getOrCreateGOTEquivalent(llvm::Constant *global,
     return gotEntry;
   }
 
-  if (Context.Stats)
-    Context.Stats->getFrontendCounters().NumGOTEntries++;
+  if (auto *Stats = Context.Stats)
+    Stats->getFrontendCounters().NumGOTEntries++;
 
   // Use the global as the initializer for an anonymous constant. LLVM can treat
   // this as equivalent to the global's GOT entry.

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -454,15 +454,13 @@ static void countStatsPostIRGen(UnifiedStatsReporter &Stats,
 
 template<typename ...ArgTypes>
 void
-diagnoseSync(DiagnosticEngine *Diags, llvm::sys::Mutex *DiagMutex,
+diagnoseSync(DiagnosticEngine &Diags, llvm::sys::Mutex *DiagMutex,
              SourceLoc Loc, Diag<ArgTypes...> ID,
              typename swift::detail::PassArgument<ArgTypes>::type... Args) {
-  if (!Diags)
-    return;
   if (DiagMutex)
     DiagMutex->lock();
 
-  Diags->diagnose(Loc, ID, std::move(Args)...);
+  Diags.diagnose(Loc, ID, std::move(Args)...);
 
   if (DiagMutex)
     DiagMutex->unlock();
@@ -470,7 +468,8 @@ diagnoseSync(DiagnosticEngine *Diags, llvm::sys::Mutex *DiagMutex,
 
 /// Run the LLVM passes. In multi-threaded compilation this will be done for
 /// multiple LLVM modules in parallel.
-bool swift::performLLVM(const IRGenOptions &Opts, DiagnosticEngine *Diags,
+bool swift::performLLVM(const IRGenOptions &Opts,
+                        DiagnosticEngine &Diags,
                         llvm::sys::Mutex *DiagMutex,
                         llvm::GlobalVariable *HashGlobal,
                         llvm::Module *Module,
@@ -975,7 +974,7 @@ performIRGeneration(const IRGenOptions &Opts, ModuleDecl *M,
     FrontendStatsTracer tracer(Ctx.Stats, "LLVM pipeline");
 
     // Since no out module hash was set, we need to performLLVM.
-    if (performLLVM(Opts, &IGM.Context.Diags, nullptr, IGM.ModuleHash,
+    if (performLLVM(Opts, IGM.Context.Diags, nullptr, IGM.ModuleHash,
                     IGM.getModule(), IGM.TargetMachine.get(),
                     IGM.Context.LangOpts.EffectiveLanguageVersion,
                     IGM.OutputFilename, IGM.Context.Stats))
@@ -1010,7 +1009,7 @@ struct LLVMCodeGenThreads {
                           << IGM->OutputFilename << "\n";
                    diagMutex->unlock(););
         embedBitcode(IGM->getModule(), parent.irgen->Opts);
-        performLLVM(parent.irgen->Opts, &IGM->Context.Diags, diagMutex,
+        performLLVM(parent.irgen->Opts, IGM->Context.Diags, diagMutex,
                     IGM->ModuleHash, IGM->getModule(), IGM->TargetMachine.get(),
                     IGM->Context.LangOpts.EffectiveLanguageVersion,
                     IGM->OutputFilename, IGM->Context.Stats);
@@ -1363,15 +1362,14 @@ swift::createSwiftModuleObjectFile(SILModule &SILMod, StringRef Buffer,
   }
   ASTSym->setSection(Section);
   ASTSym->setAlignment(llvm::MaybeAlign(serialization::SWIFTMODULE_ALIGNMENT));
-  ::performLLVM(Opts, &Ctx.Diags, nullptr, nullptr, IGM.getModule(),
+  ::performLLVM(Opts, Ctx.Diags, nullptr, nullptr, IGM.getModule(),
                 IGM.TargetMachine.get(),
                 Ctx.LangOpts.EffectiveLanguageVersion,
-                OutputPath);
+                OutputPath, Ctx.Stats);
 }
 
 bool swift::performLLVM(const IRGenOptions &Opts, ASTContext &Ctx,
-                        llvm::Module *Module, StringRef OutputFilename,
-                        UnifiedStatsReporter *Stats) {
+                        llvm::Module *Module, StringRef OutputFilename) {
   // Build TargetMachine.
   auto TargetMachine = createTargetMachine(Opts, Ctx);
   if (!TargetMachine)
@@ -1382,10 +1380,10 @@ bool swift::performLLVM(const IRGenOptions &Opts, ASTContext &Ctx,
   Module->setDataLayout(Clang->getTargetInfo().getDataLayout());
 
   embedBitcode(Module, Opts);
-  if (::performLLVM(Opts, &Ctx.Diags, nullptr, nullptr, Module,
+  if (::performLLVM(Opts, Ctx.Diags, nullptr, nullptr, Module,
                     TargetMachine.get(),
                     Ctx.LangOpts.EffectiveLanguageVersion,
-                    OutputFilename, Stats))
+                    OutputFilename, Ctx.Stats))
     return true;
   return false;
 }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6413,8 +6413,8 @@ Parser::parseAbstractFunctionBodyImpl(AbstractFunctionDecl *AFD) {
   ParseFunctionBody CC(*this, AFD);
   setLocalDiscriminatorToParamList(AFD->getParameters());
 
-  if (Context.Stats)
-    Context.Stats->getFrontendCounters().NumFunctionsParsed++;
+  if (auto *Stats = Context.Stats)
+    Stats->getFrontendCounters().NumFunctionsParsed++;
 
   // In implicit getter, if a CC token is the first token after '{', it might
   // be a start of an accessor block. Perform special completion for that.

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -121,7 +121,8 @@ void swift::performCodeCompletionSecondPass(
   auto &SF = *state->ParentContext->getParentSourceFile();
   auto &Ctx = SF.getASTContext();
 
-  FrontendStatsTracer tracer(Ctx.Stats, "CodeCompletionSecondPass");
+  FrontendStatsTracer tracer(Ctx.Stats,
+                             "CodeCompletionSecondPass");
 
   auto BufferID = Ctx.SourceMgr.getCodeCompletionBufferID();
   Parser TheParser(BufferID, SF, nullptr, &ParserState, nullptr);

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -133,7 +133,8 @@ void swift::parseIntoSourceFile(SourceFile &SF, unsigned int BufferID,
   if (SF.shouldBuildSyntaxTree())
     DelayBodyParsing = false;
 
-  FrontendStatsTracer tracer(SF.getASTContext().Stats, "Parsing");
+  FrontendStatsTracer tracer(SF.getASTContext().Stats,
+                             "Parsing");
   Parser P(BufferID, SF, /*SIL*/ nullptr, PersistentState, STreeCreator,
            DelayBodyParsing);
   PrettyStackTraceParser StackTrace(P);
@@ -152,7 +153,8 @@ void swift::parseSourceFileSIL(SourceFile &SF, SILParserState *sil) {
   auto bufferID = SF.getBufferID();
   assert(bufferID);
 
-  FrontendStatsTracer tracer(SF.getASTContext().Stats, "Parsing SIL");
+  FrontendStatsTracer tracer(SF.getASTContext().Stats,
+                             "Parsing SIL");
   Parser parser(*bufferID, SF, sil->Impl.get(),
                 /*persistentParserState*/ nullptr,
                 /*syntaxTreeCreator*/ nullptr, /*delayBodyParsing*/ false);

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -812,7 +812,8 @@ void SILGenModule::emitFunction(FuncDecl *fd) {
   emitAbstractFuncDecl(fd);
 
   if (fd->hasBody()) {
-    FrontendStatsTracer Tracer(getASTContext().Stats, "SILGen-funcdecl", fd);
+    FrontendStatsTracer Tracer(getASTContext().Stats,
+                               "SILGen-funcdecl", fd);
     PrettyStackTraceDecl stackTrace("emitting SIL for", fd);
 
     SILDeclRef constant(decl);

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -41,7 +41,8 @@ SILGenFunction::SILGenFunction(SILGenModule &SGM, SILFunction &F,
     : SGM(SGM), F(F), silConv(SGM.M), FunctionDC(DC),
       StartOfPostmatter(F.end()), B(*this), OpenedArchetypesTracker(&F),
       CurrentSILLoc(F.getLocation()), Cleanups(*this),
-      StatsTracer(SGM.M.getASTContext().Stats, "SILGen-function", &F) {
+      StatsTracer(SGM.M.getASTContext().Stats,
+                  "SILGen-function", &F) {
   assert(DC && "creating SGF without a DeclContext?");
   B.setInsertionPoint(createBasicBlock());
   B.setCurrentDebugScope(F.getDebugScope());

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1240,7 +1240,8 @@ SynthesizeDefaultInitRequest::evaluate(Evaluator &evaluator,
                                        NominalTypeDecl *decl) const {
   auto &ctx = decl->getASTContext();
 
-  FrontendStatsTracer StatsTracer(ctx.Stats, "define-default-ctor", decl);
+  FrontendStatsTracer StatsTracer(ctx.Stats,
+                                  "define-default-ctor", decl);
   PrettyStackTraceDecl stackTrace("defining default constructor for",
                                   decl);
 

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -1312,9 +1312,10 @@ void ConstraintGraph::optimize() {
 void ConstraintGraph::incrementConstraintsPerContractionCounter() {
   SWIFT_FUNC_STAT;
   auto &context = CS.getASTContext();
-  if (context.Stats)
-    context.Stats->getFrontendCounters()
+  if (auto *Stats = context.Stats) {
+    Stats->getFrontendCounters()
         .NumConstraintsConsideredForEdgeContraction++;
+  }
 }
 
 #pragma mark Debugging output

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -91,13 +91,13 @@ ConstraintSystem::~ConstraintSystem() {
 void ConstraintSystem::incrementScopeCounter() {
   CountScopes++;
   // FIXME: (transitional) increment the redundant "always-on" counter.
-  if (getASTContext().Stats)
-    getASTContext().Stats->getFrontendCounters().NumConstraintScopes++;
+  if (auto *Stats = getASTContext().Stats)
+    Stats->getFrontendCounters().NumConstraintScopes++;
 }
 
 void ConstraintSystem::incrementLeafScopes() {
-  if (getASTContext().Stats)
-    getASTContext().Stats->getFrontendCounters().NumLeafScopes++;
+  if (auto *Stats = getASTContext().Stats)
+    Stats->getFrontendCounters().NumLeafScopes++;
 }
 
 bool ConstraintSystem::hasFreeTypeVariables() {

--- a/lib/Sema/NameBinding.cpp
+++ b/lib/Sema/NameBinding.cpp
@@ -265,7 +265,8 @@ namespace {
 ///
 /// Name binding operates on a parsed but otherwise unvalidated AST.
 void swift::performNameBinding(SourceFile &SF) {
-  FrontendStatsTracer tracer(SF.getASTContext().Stats, "Name binding");
+  FrontendStatsTracer tracer(SF.getASTContext().Stats,
+                             "Name binding");
 
   // Make sure we skip adding the standard library imports if the
   // source file is empty.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2033,7 +2033,8 @@ TypeChecker::typeCheckExpression(
   Expr *expr = target.getAsExpr();
   DeclContext *dc = target.getDeclContext();
   auto &Context = dc->getASTContext();
-  FrontendStatsTracer StatsTracer(Context.Stats, "typecheck-expr", expr);
+  FrontendStatsTracer StatsTracer(Context.Stats,
+                                  "typecheck-expr", expr);
   PrettyStackTraceExpr stackTrace(Context, "type-checking", expr);
 
   // First, pre-check the expression, validating any types that occur in the
@@ -2144,7 +2145,8 @@ getTypeOfExpressionWithoutApplying(Expr *&expr, DeclContext *dc,
                                  FreeTypeVariableBinding allowFreeTypeVariables,
                                    ExprTypeCheckListener *listener) {
   auto &Context = dc->getASTContext();
-  FrontendStatsTracer StatsTracer(Context.Stats, "typecheck-expr-no-apply", expr);
+  FrontendStatsTracer StatsTracer(Context.Stats,
+                                  "typecheck-expr-no-apply", expr);
   PrettyStackTraceExpr stackTrace(Context, "type-checking", expr);
   referencedDecl = nullptr;
 
@@ -2229,7 +2231,8 @@ void TypeChecker::getPossibleTypesOfExpressionWithoutApplying(
     FreeTypeVariableBinding allowFreeTypeVariables,
     ExprTypeCheckListener *listener) {
   auto &Context = dc->getASTContext();
-  FrontendStatsTracer StatsTracer(Context.Stats, "get-possible-types-no-apply", expr);
+  FrontendStatsTracer StatsTracer(Context.Stats,
+                                  "get-possible-types-no-apply", expr);
   PrettyStackTraceExpr stackTrace(Context, "type-checking", expr);
 
   // Construct a constraint system from this expression.
@@ -2831,7 +2834,8 @@ bool TypeChecker::typeCheckStmtCondition(StmtCondition &cond, DeclContext *dc,
 bool TypeChecker::typeCheckExprPattern(ExprPattern *EP, DeclContext *DC,
                                        Type rhsType) {
   auto &Context = DC->getASTContext();
-  FrontendStatsTracer StatsTracer(Context.Stats, "typecheck-expr-pattern", EP);
+  FrontendStatsTracer StatsTracer(Context.Stats,
+                                  "typecheck-expr-pattern", EP);
   PrettyStackTracePattern stackTrace(Context, "type-checking", EP);
 
   // Create a 'let' binding to stand in for the RHS value.

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1172,11 +1172,11 @@ public:
   ASTContext &getASTContext() const { return Ctx; }
 
   void visit(Decl *decl) {
-    if (getASTContext().Stats)
-      getASTContext().Stats->getFrontendCounters().NumDeclsTypechecked++;
+    if (auto *Stats = getASTContext().Stats)
+      Stats->getFrontendCounters().NumDeclsTypechecked++;
 
-    FrontendStatsTracer StatsTracer(getASTContext().Stats, "typecheck-decl",
-                                    decl);
+    FrontendStatsTracer StatsTracer(getASTContext().Stats,
+                                    "typecheck-decl", decl);
     PrettyStackTraceDecl StackTrace("type-checking", decl);
     
     DeclVisitor<DeclChecker>::visit(decl);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4087,8 +4087,8 @@ void ConformanceChecker::resolveValueWitnesses() {
 void ConformanceChecker::checkConformance(MissingWitnessDiagnosisKind Kind) {
   assert(!Conformance->isComplete() && "Conformance is already complete");
 
-  FrontendStatsTracer statsTracer(getASTContext().Stats, "check-conformance",
-                                  Conformance);
+  FrontendStatsTracer statsTracer(getASTContext().Stats,
+                                  "check-conformance", Conformance);
 
   llvm::SaveAndRestore<bool> restoreSuppressDiagnostics(SuppressDiagnostics);
   SuppressDiagnostics = false;

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -408,7 +408,8 @@ public:
   
   template<typename StmtTy>
   bool typeCheckStmt(StmtTy *&S) {
-    FrontendStatsTracer StatsTracer(getASTContext().Stats, "typecheck-stmt", S);
+    FrontendStatsTracer StatsTracer(getASTContext().Stats,
+                                    "typecheck-stmt", S);
     PrettyStackTraceStmt trace(getASTContext(), "type-checking", S);
     StmtTy *S2 = cast_or_null<StmtTy>(visit(S));
     if (S2 == nullptr)

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1743,8 +1743,8 @@ bool TypeChecker::validateType(ASTContext &Context, TypeLoc &Loc,
   if (Loc.wasValidated())
     return Loc.isError();
 
-  if (Context.Stats)
-    Context.Stats->getFrontendCounters().NumTypesValidated++;
+  if (auto *Stats = Context.Stats)
+    Stats->getFrontendCounters().NumTypesValidated++;
 
   Type type = resolution.resolveType(Loc.getTypeRepr(), options);
   Loc.setType(type);
@@ -1865,7 +1865,8 @@ namespace {
 Type TypeResolution::resolveType(TypeRepr *TyR,
                               TypeResolutionOptions options) {
   auto &ctx = getASTContext();
-  FrontendStatsTracer StatsTracer(ctx.Stats, "resolve-type", TyR);
+  FrontendStatsTracer StatsTracer(ctx.Stats,
+                                  "resolve-type", TyR);
   PrettyStackTraceTypeRepr stackTrace(ctx, "resolving", TyR);
 
   TypeResolver typeResolver(*this);

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -355,7 +355,8 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
   // Could build scope maps here because the AST is stable now.
 
   {
-    FrontendStatsTracer tracer(Ctx.Stats, "Type checking and Semantic analysis");
+    FrontendStatsTracer tracer(Ctx.Stats,
+                               "Type checking and Semantic analysis");
 
     if (Ctx.TypeCheckerOpts.SkipNonInlinableFunctionBodies)
       // Disable this optimization if we're compiling SwiftOnoneSupport, because
@@ -404,7 +405,8 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
 
 void swift::performWholeModuleTypeChecking(SourceFile &SF) {
   auto &Ctx = SF.getASTContext();
-  FrontendStatsTracer tracer(Ctx.Stats, "perform-whole-module-type-checking");
+  FrontendStatsTracer tracer(Ctx.Stats,
+                             "perform-whole-module-type-checking");
   diagnoseAttrsRequiringFoundation(SF);
   diagnoseObjCMethodConflicts(SF);
   diagnoseObjCUnsatisfiedOptReqConflicts(SF);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -477,8 +477,8 @@ ModuleFile::readConformanceChecked(llvm::BitstreamCursor &Cursor,
       fatalIfUnexpected(Cursor.advance(AF_DontPopBlockAtEnd));
   assert(next.Kind == llvm::BitstreamEntry::Record);
 
-  if (getContext().Stats)
-    getContext().Stats->getFrontendCounters().NumConformancesDeserialized++;
+  if (auto *Stats = getContext().Stats)
+    Stats->getFrontendCounters().NumConformancesDeserialized++;
 
   unsigned kind = fatalIfUnexpected(Cursor.readRecord(next.ID, scratch));
   switch (kind) {


### PR DESCRIPTION
This patch does a bunch of NFC things, and one particularly not NFC thing to fix a gigantic use-after-free in frontend jobs that pass `-dump-api-path`.

NFC Stuff:

- Centralize ownership of UnifiedStatsReporter in the CompilerInstance and automatically set it up along with the rest of its state.
- Delete a bunch of useless UnifiedStatsReporter parameters
- Reduce reliance on the ASTContext as a source of truth for how to recover the UnifiedStatsReporter - it will be deallocated if we reach LLVM codegen.

Not-so-NFC Stuff:

- Fix a use-after-free involving `-dump-api-path` and codegen with single primaries. 

The routine that frees up some memory by releasing the ASTContext and SILModules conditionally could potentially be run which would destroy the resources needed by that frontend action. See the last commit.