### PR TITLE
build: use the correct install location

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/pythonkit.py
+++ b/utils/swift_build_support/swift_build_support/products/pythonkit.py
@@ -53,7 +53,7 @@ class PythonKit(product.Product):
                 '-G', 'Ninja',
                 '-D', 'BUILD_SHARED_LIBS=YES',
                 '-D', 'CMAKE_INSTALL_PREFIX={}/usr'.format(
-                    self.args.install_destdir),
+                    self.install_toolchain_path()),
                 '-D', 'CMAKE_MAKE_PROGRAM={}'.format(self.toolchain.ninja),
                 '-D', 'CMAKE_Swift_COMPILER={}'.format(swiftc),
                 '-B', self.build_dir,

--- a/utils/swift_build_support/swift_build_support/products/tensorflow.py
+++ b/utils/swift_build_support/swift_build_support/products/tensorflow.py
@@ -53,7 +53,7 @@ class TensorFlowSwiftAPIs(product.Product):
                 '-G', 'Ninja',
                 '-D', 'BUILD_SHARED_LIBS=YES',
                 '-D', 'CMAKE_INSTALL_PREFIX={}/usr'.format(
-                    self.args.install_destdir),
+                    self.install_toolchain_path()),
                 '-D', 'CMAKE_MAKE_PROGRAM={}'.format(self.toolchain.ninja),
                 '-D', 'CMAKE_Swift_COMPILER={}'.format(swiftc),
                 '-B', self.build_dir,


### PR DESCRIPTION
Use the correct installation location path computation
`toolchain_install_path` rather than trying to compute it ourselves.
This ensures that the files are installed into the right location.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
