### PR TITLE
[CSBindings] Open collection before binding parameter only if origina…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3799,9 +3799,11 @@ bool ConstraintSystem::repairFailures(
     if (tupleLocator->isLastElement<LocatorPathElt::SequenceElementType>())
       break;
 
-    // Generic argument failures have a more general fix which is attached to a
-    // parent type and aggregates all argument failures into a single fix.
-    if (tupleLocator->isLastElement<LocatorPathElt::GenericArgument>())
+    // Generic argument/requirement failures have a more general fix which
+    // is attached to a parent type and aggregates all argument failures
+    // into a single fix.
+    if (tupleLocator->isLastElement<LocatorPathElt::AnyRequirement>() ||
+        tupleLocator->isLastElement<LocatorPathElt::GenericArgument>())
       break;
 
     ConstraintFix *fix;

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -216,7 +216,6 @@ func rdar_50668864() {
   struct Foo {
     init(anchors: [Int]) { // expected-note {{'init(anchors:)' declared here}}
       self = .init { _ in [] } // expected-error {{trailing closure passed to parameter of type '[Int]' that does not accept a closure}}
-      // expected-error@-1 {{generic parameter 'Element' could not be inferred}}
     }
   }
 }

--- a/validation-test/Sema/type_checker_perf/fast/rdar54580427.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar54580427.swift
@@ -1,7 +1,5 @@
-// FIXME: This should be linear instead of exponential.
-// RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes --invert-result %s -Xfrontend=-solver-expression-time-threshold=1
+// RUN: %scale-test --begin 1 --end 20 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-expression-time-threshold=1
 // REQUIRES: asserts,no_asan
-// REQUIRES: rdar57138194,SR11770
 
 enum Val {
   case d([String: Val])


### PR DESCRIPTION
…l argument type failed

Instead of always opening argument type represented by a collection
without type variables (to support subtyping when element is a labeled tuple),
let's try original type first and if that fails use a slower path with
indirection which attempts `array upcast`. Doing it this way helps to
propagate contextual information faster which fixes a performance regression.

Resolves: rdar://problem/54580247
Resolves: rdar://problem/57138194

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
