### PR TITLE
[Diagnostics] Tweak @propertyWrapper diags and add an educational note

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4795,7 +4795,7 @@ ERROR(property_wrapper_wrong_initial_value_init, none,
       "'wrappedValue' property type (%2) or an @autoclosure thereof",
       (DeclName, Type, Type))
 ERROR(property_wrapper_failable_init, none,
-      "%0 cannot be failable", (DeclName))
+      "property wrapper initializer %0 cannot be failable", (DeclName))
 ERROR(property_wrapper_type_requirement_not_accessible,none,
       "%select{private|fileprivate|internal|public|open}0 %1 %2 cannot have "
       "more restrictive access than its enclosing property wrapper type %3 "

--- a/include/swift/AST/EducationalNotes.def
+++ b/include/swift/AST/EducationalNotes.def
@@ -34,4 +34,13 @@ EDUCATIONAL_NOTES(invalid_dynamic_callable_type,
 EDUCATIONAL_NOTES(missing_dynamic_callable_kwargs_method,
                   "dynamic-callable-requirements.md")
 
+EDUCATIONAL_NOTES(property_wrapper_no_value_property,
+                  "property-wrapper-requirements.md")
+EDUCATIONAL_NOTES(property_wrapper_wrong_initial_value_init,
+                  "property-wrapper-requirements.md")
+EDUCATIONAL_NOTES(property_wrapper_failable_init,
+                  "property-wrapper-requirements.md")
+EDUCATIONAL_NOTES(property_wrapper_type_requirement_not_accessible,
+                  "property-wrapper-requirements.md")
+
 #undef EDUCATIONAL_NOTES

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -112,7 +112,7 @@ struct MultipleInitialValues<Value> {
 struct InitialValueFailable<Value> {
   var wrappedValue: Value
 
-  init?(wrappedValue initialValue: Value) { // expected-error{{'init(wrappedValue:)' cannot be failable}}
+  init?(wrappedValue initialValue: Value) { // expected-error{{property wrapper initializer 'init(wrappedValue:)' cannot be failable}}
     return nil
   }
 }
@@ -121,7 +121,7 @@ struct InitialValueFailable<Value> {
 struct InitialValueFailableIUO<Value> {
   var wrappedValue: Value
 
-  init!(wrappedValue initialValue: Value) {  // expected-error{{'init(wrappedValue:)' cannot be failable}}
+  init!(wrappedValue initialValue: Value) {  // expected-error{{property wrapper initializer 'init(wrappedValue:)' cannot be failable}}
     return nil
   }
 }

--- a/userdocs/diagnostics/property-wrapper-requirements.md
+++ b/userdocs/diagnostics/property-wrapper-requirements.md
@@ -1,0 +1,7 @@
+Property Wrapper Implementation Requirements
+---
+If a type is marked with the `@propertyWrapper` attribute, it must meet certain requirements to be a valid property wrapper.
+
+First, all property wrapper types must have a property named `wrappedValue`. This property cannot be static and must have the same access level as the property wrapper type. If the property wrapper provides a `projectedValue` property, it is subject to the same requirements.
+
+Second, none of a property wrapper's initializers may be failable. Additionally, if a property wrapper initializer has a `wrappedValue` parameter, the type of that parameter must either be the same as the type of the `wrappedValue` property or an `@autoclosure` of that type.


### PR DESCRIPTION
Changed `init(...)' cannot be failable` to `property wrapper initializer 'init(...)' cannot be failable` to make it clear why the init has special requirements.

The educational note doesn't add anything that isn't covered by the existing diags, but IMO it's useful to be able to see all the different requirements together in one place, especially if someone is writing their very first wrapper.