### PR TITLE
stdlib: repair the macOS -stdlib build

### DIFF
--- a/stdlib/toolchain/CMakeLists.txt
+++ b/stdlib/toolchain/CMakeLists.txt
@@ -1,5 +1,8 @@
 # Toolchain-only build products
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../cmake/modules)
+include(AddSwiftStdlib)
+
 set(CXX_COMPILE_FLAGS)
 set(CXX_LINK_FLAGS)
 


### PR DESCRIPTION
When building on macOS without the standard library but building the
extra toolchain content, we would fail to configure due to the missing
include of the `AddSwiftStdlib`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
