### PR TITLE
build: specify a compiler target for tensorflow-swift-apis on macOS

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/tensorflow.py
+++ b/utils/swift_build_support/swift_build_support/products/tensorflow.py
@@ -60,8 +60,13 @@ class TensorFlowSwiftAPIs(product.Product):
         except OSError:
             pass
 
-        with shell.pushd(self.build_dir):
+        # SWIFT_ENABLE_TENSORFLOW
+        target = ''
+        if host_target.startswith('macosx'):
+            target = '-DCMAKE_Swift_COMPILER_TARGET=x86_64-apple-macosx10.13'
+        # SWIFT_ENABLE_TENSORFLOW END
 
+        with shell.pushd(self.build_dir):
             shell.call([
                 self.toolchain.cmake,
                 '-G', 'Ninja',
@@ -71,8 +76,8 @@ class TensorFlowSwiftAPIs(product.Product):
                 '-D', 'CMAKE_MAKE_PROGRAM={}'.format(self.toolchain.ninja),
                 '-D', 'CMAKE_Swift_COMPILER={}'.format(swiftc),
                 # SWIFT_ENABLE_TENSORFLOW
+                target,
                 '-D', 'USE_BUNDLED_CTENSORFLOW=YES',
-                # SWIFT_ENABLE_TENSORFLOW END
                 '-D', 'TensorFlow_INCLUDE_DIR={}'.format(tensorflow_source_dir),
                 '-D', 'TensorFlow_LIBRARY={}'.format(
                     os.path.join(tensorflow_source_dir, 'bazel-bin', 'tensorflow',
@@ -80,6 +85,7 @@ class TensorFlowSwiftAPIs(product.Product):
                 '-D', 'CMAKE_Swift_FLAGS={}'.format('-L{}'.format(
                     os.path.join(tensorflow_source_dir, 'bazel-bin', 'tensorflow'))
                 ),
+                # SWIFT_ENABLE_TENSORFLOW END
                 '-B', self.build_dir,
                 '-S', self.source_dir,
             ])


### PR DESCRIPTION
Because the rest of the components have a deployment target of 10.13 explicitly, pass the same triple for the tensorflow-swift-apis build.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
