### PR TITLE
build: specify a compiler target for pythonkit on macOS

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/pythonkit.py
+++ b/utils/swift_build_support/swift_build_support/products/pythonkit.py
@@ -47,6 +47,12 @@ class PythonKit(product.Product):
         except OSError:
             pass
 
+        # SWIFT_ENABLE_TENSORFLOW
+        target = ''
+        if host_target.startswith('macosx'):
+            target = '-DCMAKE_Swift_COMPILER_TARGET=x86_64-apple-macosx10.13'
+        # SWIFT_ENABLE_TENSORFLOW END
+
         with shell.pushd(self.build_dir):
             shell.call([
                 self.toolchain.cmake,
@@ -56,6 +62,9 @@ class PythonKit(product.Product):
                     self.install_toolchain_path()),
                 '-D', 'CMAKE_MAKE_PROGRAM={}'.format(self.toolchain.ninja),
                 '-D', 'CMAKE_Swift_COMPILER={}'.format(swiftc),
+                # SWIFT_ENABLE_TENSORFLOW
+                target,
+                # SWIFT_ENABLE_TENSORFLOW END
                 '-B', self.build_dir,
                 '-S', self.source_dir,
             ])


### PR DESCRIPTION
Because the rest of the components have a deployment target of 10.13 explicitly, pass the same triple for the PythonKit build.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
