### PR TITLE
[Sema] Fix erroneous partial application errors

### DIFF
--- a/test/Constraints/mutating_members.swift
+++ b/test/Constraints/mutating_members.swift
@@ -27,10 +27,10 @@ func bar() -> Foo.Type { fatalError() }
 
 _ = bar().boom       // expected-error{{partial application of 'mutating' method}}
 _ = bar().boom(&y)   // expected-error{{partial application of 'mutating' method}}
-_ = bar().boom(&y)() // expected-error{{partial application of 'mutating' method}}
+_ = bar().boom(&y)() // ok
 
 func foo(_ foo: Foo.Type) {
   _ = foo.boom       // expected-error{{partial application of 'mutating' method}}
   _ = foo.boom(&y)   // expected-error{{partial application of 'mutating' method}}
-  _ = foo.boom(&y)() // expected-error{{partial application of 'mutating' method}}
+  _ = foo.boom(&y)() // ok
 }

--- a/test/Constraints/mutating_members_compat.swift
+++ b/test/Constraints/mutating_members_compat.swift
@@ -27,10 +27,10 @@ func bar() -> Foo.Type { fatalError() }
 
 _ = bar().boom       // expected-warning{{partial application of 'mutating' method}}
 _ = bar().boom(&y)   // expected-error{{partial application of 'mutating' method}}
-_ = bar().boom(&y)() // expected-error{{partial application of 'mutating' method}}
+_ = bar().boom(&y)() // ok
 
 func foo(_ foo: Foo.Type) {
   _ = foo.boom       // expected-warning{{partial application of 'mutating' method}}
   _ = foo.boom(&y)   // expected-error{{partial application of 'mutating' method}}
-  _ = foo.boom(&y)() // expected-error{{partial application of 'mutating' method}}
+  _ = foo.boom(&y)() // ok
 }


### PR DESCRIPTION
After #30097, some valid full applications are diagnosed as partial
application failures. This restores the old behavior while preserving
the `super` related fixes in #30097.