### PR TITLE
[Gardening] Squelch a missing parameter warning

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -623,7 +623,6 @@ public:
 
   /// Performs mandatory, diagnostic, and optimization passes over the SIL.
   /// \param silModule The SIL module that was generated during SILGen.
-  /// \param stats A stats reporter that will report optimization statistics.
   /// \returns true if any errors occurred.
   bool performSILProcessing(SILModule *silModule);
 


### PR DESCRIPTION
Fix a warning cascade I caused in #30109 