### PR TITLE
[CSSimplify] Attempt property wrapper fix after restrictions

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2551,6 +2551,9 @@ static ConstraintFix *fixPropertyWrapperFailure(
     if (baseTy->isEqual(type))
       return nullptr;
 
+    if (baseTy->is<TypeVariableType>() || type->is<TypeVariableType>())
+      return nullptr;
+
     if (!attemptFix(*resolvedOverload, decl, type))
       return nullptr;
 
@@ -3295,24 +3298,6 @@ bool ConstraintSystem::repairFailures(
     if (elt.getKind() != ConstraintLocator::ApplyArgToParam)
       break;
 
-    if (auto *fix = fixPropertyWrapperFailure(
-            *this, lhs, loc,
-            [&](SelectedOverload overload, VarDecl *decl, Type newBase) {
-              // FIXME: There is currently no easy way to avoid attempting
-              // fixes, matchTypes do not propagate `TMF_ApplyingFix` flag.
-              llvm::SaveAndRestore<ConstraintSystemOptions> options(
-                  Options, Options - ConstraintSystemFlags::AllowFixes);
-
-              TypeMatchOptions flags;
-              return matchTypes(newBase, rhs, ConstraintKind::Subtype, flags,
-                                getConstraintLocator(locator))
-                  .isSuccess();
-            },
-            rhs)) {
-      conversionsOrFixes.push_back(fix);
-      break;
-    }
-
     // If argument in l-value type and parameter is `inout` or a pointer,
     // let's see if it's generic parameter matches and suggest adding explicit
     // `&`.
@@ -3381,6 +3366,24 @@ bool ConstraintSystem::repairFailures(
                        return bool(correction.getRestriction());
                      }))
       break;
+
+    if (auto *fix = fixPropertyWrapperFailure(
+            *this, lhs, loc,
+            [&](SelectedOverload overload, VarDecl *decl, Type newBase) {
+              // FIXME: There is currently no easy way to avoid attempting
+              // fixes, matchTypes do not propagate `TMF_ApplyingFix` flag.
+              llvm::SaveAndRestore<ConstraintSystemOptions> options(
+                  Options, Options - ConstraintSystemFlags::AllowFixes);
+
+              TypeMatchOptions flags;
+              return matchTypes(newBase, rhs, ConstraintKind::Subtype, flags,
+                                getConstraintLocator(locator))
+                  .isSuccess();
+            },
+            rhs)) {
+      conversionsOrFixes.push_back(fix);
+      break;
+    }
 
     // If this is an implicit 'something-to-pointer' conversion
     // it's going to be diagnosed by specialized fix which deals

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1880,3 +1880,18 @@ open class OpenPropertyWrapperWithPublicInit {
   
   open var wrappedValue: String = "Hello, world"
 }
+
+// SR-11654
+
+struct SR_11654_S {}
+
+class SR_11654_C {
+  @Foo var property: SR_11654_S?
+}
+
+func sr_11654_generic_func<T>(_ argument: T?) -> T? {
+  return argument
+}
+
+let sr_11654_c = SR_11654_C()
+_ = sr_11654_generic_func(sr_11654_c.property) // Okay


### PR DESCRIPTION
The following code:

```swift
struct User {}

@propertyWrapper struct Wrapper<T> {
  var wrappedValue: T
}

class Test {
  @Wrapper var user: User?
}

func genericFunc<T>(_ argument: T?) -> T? {
  return argument
}

let test = Test()
genericFunc(test.user)
```

fails to compile with a very strange error - `cannot convert value 'user' of type 'User?' to expected type 'Wrapper<User?>?', use wrapper instead`.

This seems to be because we're attempting property wrapper fix (and creating subtype constraints) before we've given `simplifyRestrictedConstraintImpl` a chance to handle any restrictions. So, delay the attempt to create a fix so restrictions can be handled first.

Resolves SR-11654, SR-12233
Resolves rdar://problem/56543018