### PR TITLE
Removes redundant buffer zeroing in StringGuts.swift by using `init(unsafeUninitializedCapacity:initializingWith:)

### DIFF
--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -324,9 +324,12 @@ public // SPI(corelibs-foundation)
 func _persistCString(_ p: UnsafePointer<CChar>?) -> [CChar]? {
   guard let s = p else { return nil }
   let count = Int(_swift_stdlib_strlen(s))
-  var result = [CChar](repeating: 0, count: count + 1)
-  for i in 0..<count {
-    result[i] = s[i]
+  let result = [CChar](unsafeUninitializedCapacity: count + 1) { buf, initializedCount in
+    for i in 0..<count {
+      buf[i] = s[i]
+    }
+    buf[count] = 0
+    initializedCount = count + 1
   }
   return result
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Removes redundant buffer zeroing by using `init(unsafeUninitializedCapacity:initializingWith:)` instead of `init(repeating:count:)`

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
