### PR TITLE
Removes redundant buffer zeroing in StringGraphemeBreaking.swift by using `init(unsafeUninitializedCapacity:initializingWith:)

### DIFF
--- a/stdlib/public/core/StringGraphemeBreaking.swift
+++ b/stdlib/public/core/StringGraphemeBreaking.swift
@@ -225,13 +225,12 @@ extension _StringGuts {
 
     // TODO(String performance): Local small stack first, before making large
     // array. Also, make a smaller initial array and grow over time.
-    var codeUnits = Array<UInt16>(repeating: 0, count: count)
-
-    codeUnits.withUnsafeMutableBufferPointer {
-      _cocoaStringCopyCharacters(
-        from: cocoa,
-        range: 0..<count,
-        into: $0.baseAddress._unsafelyUnwrappedUnchecked)
+    let codeUnits = Array<UInt16>(unsafeUninitializedCapacity: count) { buf, initializedCount in
+        _cocoaStringCopyCharacters(
+          from: cocoa,
+          range: 0..<count,
+          into: buf.baseAddress._unsafelyUnwrappedUnchecked)
+        initializedCount = count
     }
     return codeUnits.withUnsafeBufferPointer {
       _measureCharacterStrideICU(of: $0, startingAt: i)
@@ -291,13 +290,12 @@ extension _StringGuts {
 
     // TODO(String performance): Local small stack first, before making large
     // array. Also, make a smaller initial array and grow over time.
-    var codeUnits = Array<UInt16>(repeating: 0, count: count)
-
-    codeUnits.withUnsafeMutableBufferPointer {
-      _cocoaStringCopyCharacters(
-        from: cocoa,
-        range: 0..<count,
-        into: $0.baseAddress._unsafelyUnwrappedUnchecked)
+    let codeUnits = Array<UInt16>(unsafeUninitializedCapacity: count) { buf, initializedCount in
+        _cocoaStringCopyCharacters(
+          from: cocoa,
+          range: 0..<count,
+          into: buf.baseAddress._unsafelyUnwrappedUnchecked)
+        initializedCount = count
     }
     return codeUnits.withUnsafeBufferPointer {
       _measureCharacterStrideICU(of: $0, endingAt: i)


### PR DESCRIPTION
<!-- What's in this pull request? -->
Removes redundant buffer zeroing by using `init(unsafeUninitializedCapacity:initializingWith:)` instead of `init(repeating:count:)`

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
