### PR TITLE
Removes redundant buffer zeroing in CGColorSpace.swift by using `init(unsafeUninitializedCapacity:initializingWith:)

### DIFF
--- a/stdlib/public/Darwin/CoreGraphics/CoreGraphics.swift
+++ b/stdlib/public/Darwin/CoreGraphics/CoreGraphics.swift
@@ -102,7 +102,7 @@ extension CGColorSpace {
     let components = self.baseColorSpace?.numberOfComponents ?? 1
     let count = self.__colorTableCount * components
     return [UInt8](unsafeUninitializedCapacity: count) { buf, initializedCount in
-        self.__unsafeGetColorTable(buf)
+        self.__unsafeGetColorTable(buf.baseAddress!)
         initializedCount = count
     }
   }

--- a/stdlib/public/Darwin/CoreGraphics/CoreGraphics.swift
+++ b/stdlib/public/Darwin/CoreGraphics/CoreGraphics.swift
@@ -100,9 +100,11 @@ extension CGColorSpace {
   public var colorTable: [UInt8]? {
     guard self.model == .indexed else { return nil }
     let components = self.baseColorSpace?.numberOfComponents ?? 1
-    var table = [UInt8](repeating: 0, count: self.__colorTableCount * components)
-    self.__unsafeGetColorTable(&table)
-    return table
+    let count = self.__colorTableCount * components
+    return [UInt8](unsafeUninitializedCapacity: count) { buf, initializedCount in
+        self.__unsafeGetColorTable(buf)
+        initializedCount = count
+    }
   }
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
In `colorTable` getter removes redundant buffer zeroing by using `init(unsafeUninitializedCapacity:initializingWith:)` instead of `init(repeating:count:)`

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
