### PR TITLE
[Incremental] Introducing: DependencyVerifier 

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -159,6 +159,9 @@ WARNING(warn_ignore_embed_bitcode_marker, none,
 WARNING(verify_debug_info_requires_debug_option,none,
         "ignoring '-verify-debug-info'; no debug info is being generated", ())
 
+ERROR(verify_incremental_dependencies_needs_incremental,none,
+      "'-verify-incremental-dependencies' requires '-incremental'", ())
+
 ERROR(error_profile_missing,none,
       "no profdata file exists at '%0'", (StringRef))
 

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -21,6 +21,7 @@
 #include "swift/Basic/LLVM.h"
 
 namespace swift {
+  class DependencyTracker;
   class FileUnit;
   class SourceManager;
   class SourceFile;
@@ -37,8 +38,10 @@ namespace swift {
   bool verifyDiagnostics(SourceManager &SM, ArrayRef<unsigned> BufferIDs,
                          bool autoApplyFixes, bool ignoreUnknown);
 
-  bool verifyDependencies(SourceManager &SM, ArrayRef<FileUnit *> SFs);
-  bool verifyDependencies(SourceManager &SM, ArrayRef<SourceFile *> SFs);
+  bool verifyDependencies(SourceManager &SM, const DependencyTracker &DT,
+                          ArrayRef<FileUnit *> SFs);
+  bool verifyDependencies(SourceManager &SM, const DependencyTracker &DT,
+                          ArrayRef<SourceFile *> SFs);
 }
 
 #endif

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -21,7 +21,9 @@
 #include "swift/Basic/LLVM.h"
 
 namespace swift {
+  class FileUnit;
   class SourceManager;
+  class SourceFile;
 
   /// Set up the specified source manager so that diagnostics are captured
   /// instead of being printed.
@@ -34,6 +36,9 @@ namespace swift {
   /// This returns true if there are any mismatches found.
   bool verifyDiagnostics(SourceManager &SM, ArrayRef<unsigned> BufferIDs,
                          bool autoApplyFixes, bool ignoreUnknown);
+
+  bool verifyDependencies(SourceManager &SM, ArrayRef<FileUnit *> SFs);
+  bool verifyDependencies(SourceManager &SM, ArrayRef<SourceFile *> SFs);
 }
 
 #endif

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -263,6 +263,9 @@ public:
   /// Should we lock .swiftinterface while generating .swiftmodule from it?
   bool DisableInterfaceFileLock = false;
 
+  /// Should we enable the dependency verifier for all primary files known to this frontend?
+  bool VerifyDependencies = false;
+
   /// The different modes for validating TBD against the LLVM IR.
   enum class TBDValidationMode {
     Default,        ///< Do the default validation for the current platform.

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -264,7 +264,7 @@ public:
   bool DisableInterfaceFileLock = false;
 
   /// Should we enable the dependency verifier for all primary files known to this frontend?
-  bool VerifyDependencies = false;
+  bool EnableIncrementalDependencyVerifier = false;
 
   /// The different modes for validating TBD against the LLVM IR.
   enum class TBDValidationMode {

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -184,6 +184,11 @@ Flag<["-"], "driver-verify-fine-grained-dependency-graph-after-every-import">,
 InternalDebugOpt,
 HelpText<"Debug DriverGraph by verifying it after every import">;
 
+def verify_incremental_dependencies :
+  Flag<["-"], "verify-incremental-dependencies">,
+  Flags<[FrontendOption, HelpHidden]>,
+  HelpText<"Enable the dependency verifier for each frontend job">;
+
 def driver_emit_fine_grained_dependency_dot_file_after_every_import :
 Flag<["-"], "driver-emit-fine-grained-dependency-dot-file-after-every-import">,
 InternalDebugOpt,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -179,8 +179,8 @@ static void validateDebugInfoArgs(DiagnosticEngine &diags,
       diags.diagnose(SourceLoc(), diag::error_invalid_debug_prefix_map, A);
 }
 
-static void validateVerifyIncrementalArgs(DiagnosticEngine &diags,
-                                          const ArgList &args) {
+static void validateVerifyIncrementalDependencyArgs(DiagnosticEngine &diags,
+                                                    const ArgList &args) {
   // No option? No problem!
   if (!args.hasArg(options::OPT_verify_incremental_dependencies)) {
     return;
@@ -257,7 +257,7 @@ static void validateArgs(DiagnosticEngine &diags, const ArgList &args,
   validateCompilationConditionArgs(diags, args);
   validateSearchPathArgs(diags, args);
   validateAutolinkingArgs(diags, args, T);
-  validateVerifyIncrementalArgs(diags, args);
+  validateVerifyIncrementalDependencyArgs(diags, args);
 }
 
 std::unique_ptr<ToolChain>

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -179,6 +179,24 @@ static void validateDebugInfoArgs(DiagnosticEngine &diags,
       diags.diagnose(SourceLoc(), diag::error_invalid_debug_prefix_map, A);
 }
 
+static void validateVerifyIncrementalArgs(DiagnosticEngine &diags,
+                                          const ArgList &args) {
+  // No option? No problem!
+  if (!args.hasArg(options::OPT_verify_incremental_dependencies)) {
+    return;
+  }
+
+  // Make sure we see -incremental but not -wmo, no matter in what order they're
+  // in - the build systems can pass them both and just hope the last one wins.
+  if (args.hasArg(options::OPT_incremental) &&
+      !args.hasArg(options::OPT_whole_module_optimization)) {
+    return;
+  }
+
+  diags.diagnose(SourceLoc(),
+                 diag::verify_incremental_dependencies_needs_incremental);
+}
+
 static void validateCompilationConditionArgs(DiagnosticEngine &diags,
                                              const ArgList &args) {
   for (const Arg *A : args.filtered(options::OPT_D)) {
@@ -239,6 +257,7 @@ static void validateArgs(DiagnosticEngine &diags, const ArgList &args,
   validateCompilationConditionArgs(diags, args);
   validateSearchPathArgs(diags, args);
   validateAutolinkingArgs(diags, args, T);
+  validateVerifyIncrementalArgs(diags, args);
 }
 
 std::unique_ptr<ToolChain>

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -254,7 +254,9 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_disable_parser_lookup);
   inputArgs.AddLastArg(arguments,
                        options::OPT_enable_experimental_concise_pound_file);
-
+  inputArgs.AddLastArg(arguments,
+                       options::OPT_verify_incremental_dependencies);
+  
   // Pass on any build config options
   inputArgs.AddAllArgs(arguments, options::OPT_D);
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -176,7 +176,7 @@ bool ArgsToFrontendOptionsConverter::convert(
 
   Opts.EnableSourceImport |= Args.hasArg(OPT_enable_source_import);
   Opts.ImportUnderlyingModule |= Args.hasArg(OPT_import_underlying_module);
-  Opts.VerifyDependencies |= Args.hasArg(OPT_verify_incremental_dependencies);
+  Opts.EnableIncrementalDependencyVerifier |= Args.hasArg(OPT_verify_incremental_dependencies);
 
   computeImportObjCHeaderOptions();
   computeImplicitImportModuleNames();

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -176,6 +176,7 @@ bool ArgsToFrontendOptionsConverter::convert(
 
   Opts.EnableSourceImport |= Args.hasArg(OPT_enable_source_import);
   Opts.ImportUnderlyingModule |= Args.hasArg(OPT_import_underlying_module);
+  Opts.VerifyDependencies |= Args.hasArg(OPT_verify_incremental_dependencies);
 
   computeImportObjCHeaderOptions();
   computeImplicitImportModuleNames();

--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -3,6 +3,7 @@ add_swift_host_library(swiftFrontend STATIC
   ArgsToFrontendOptionsConverter.cpp
   ArgsToFrontendOutputsConverter.cpp
   CompilerInvocation.cpp
+  DependencyVerifier.cpp
   DiagnosticVerifier.cpp
   Frontend.cpp
   FrontendInputsAndOutputs.cpp

--- a/lib/Frontend/DependencyVerifier.cpp
+++ b/lib/Frontend/DependencyVerifier.cpp
@@ -1,0 +1,680 @@
+//===--- DependencyVerifier.cpp - Dependency Verifier ---------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Implements a verifier for dependencies registered against the
+//  ReferencedNameTracker in a SourceFile.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/ASTMangler.h"
+#include "swift/AST/ASTPrinter.h"
+#include "swift/AST/SourceFile.h"
+#include "swift/Basic/OptionSet.h"
+#include "swift/Frontend/DiagnosticVerifier.h"
+#include "swift/Parse/Lexer.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/Support/FormatVariadic.h"
+
+using namespace swift;
+
+namespace {
+
+/// An \c Expectation represents a user-provided expectation for a particular
+/// dependency entry. An expectation is usually written in-line in a comment
+/// attached near the relevant declaration and takes one of the following forms:
+///
+/// // expected-provides {{ProvidedName}}
+/// // expected-private-member {{some.User.member}}
+///
+/// An expectation contains additional information about the expectation
+/// \c Kind, which matches one of the few kinds of dependency entry that are
+/// currently representable in the dependency graph, and an expectation
+/// \c Flavor which must either be \c private or \c cascading.
+///
+/// The supported set of expectations is given by the following matrix:
+///
+#define EXPECTATION_MATRIX                                                     \
+  MATRIX_ENTRY("expected-no-dependency", None, Negative)                       \
+  MATRIX_ENTRY("expected-provides", None, Provides)                            \
+  MATRIX_ENTRY("expected-private-superclass", Private, Superclass)             \
+  MATRIX_ENTRY("expected-cascading-superclass", Cascading, Superclass)         \
+  MATRIX_ENTRY("expected-private-conformance", Private, Conformance)           \
+  MATRIX_ENTRY("expected-cascading-conformance", Cascading, Conformance)       \
+  MATRIX_ENTRY("expected-private-member", Private, Member)                     \
+  MATRIX_ENTRY("expected-cascading-member", Cascading, Member)                 \
+  MATRIX_ENTRY("expected-private-dynamic-member", Private, DynamicMember)      \
+  MATRIX_ENTRY("expected-cascading-dynamic-member", Cascading, DynamicMember)
+struct Expectation {
+public:
+  enum class Kind : uint8_t {
+    Negative,
+    Provides,
+    Member,
+    PotentialMember,
+    Superclass = PotentialMember,
+    Conformance = PotentialMember,
+    DynamicMember,
+  };
+
+  enum class Flavor : uint8_t {
+    None,
+    Private,
+    Cascading,
+  };
+
+  /// The full range of the "expected-foo {{}}".
+  const char *ExpectedStart, *ExpectedEnd = nullptr;
+
+  /// Additional information about the expectation.
+  std::pair<Expectation::Kind, Expectation::Flavor> Info;
+
+  /// The raw input buffer for the message text, the part in the {{...}}
+  StringRef MessageRange;
+
+public:
+  Expectation(const char *ExpectedStart, Expectation::Kind k,
+              Expectation::Flavor f)
+      : ExpectedStart(ExpectedStart), Info{k, f} {}
+
+  bool isCascading() const {
+    return Info.second == Expectation::Flavor::Cascading;
+  }
+};
+
+/// An \c Obligation represents a compiler-provided entry in the set of
+/// dependencies for a given source file. Similar to an \c Expectation an \c
+/// Obligation contains a name, information about its kind and flavor, and an
+/// extra source location that can be used to guide where diagnostics are
+/// emitted. Unlike an \c Obligation, it provides an extra piece of state that
+/// represents the obligation's "fulfillment status".
+///
+/// All \c Obligations begin in the \c Active state. Once an obligation has been
+/// paired with a matching \c Expectation, the obligation may then transition to
+/// either \c Fulfilled if it has been satisfied completely, or \c Failed
+/// otherwise. The verifier turns all unfulfilled obligations into errors.
+struct Obligation {
+  /// The state of an \c Obligation
+  enum class State : uint8_t {
+    /// The \c Obligation is active and has not been paired with a corresponding
+    /// \c Expectation.
+    Active,
+    /// The \c Obligation is fulfilled.
+    Fulfilled,
+    /// The \c Obligation was matched against an \c Expectation, but that
+    /// expectation could not
+    /// fulfill the obligation because additional requirements did not pass.
+    Failed,
+  };
+
+  /// A token returned when an \c Obligation is fulfilled or failed. An \c
+  /// Obligation is the only type that may construct fulfillment tokens.
+  struct FullfillmentToken {
+    friend Obligation;
+
+  private:
+    FullfillmentToken() = default;
+  };
+
+  /// An \c Obligation::Key is a reduced set of the common data contained in an
+  /// \c Obligation and an \c Expectation.
+  ///
+  /// This provides a way to use a value of either type to index into an  \c
+  /// ObligationMap.
+  struct Key {
+    StringRef Name;
+    Expectation::Kind Kind;
+
+  public:
+    Key() = delete;
+
+  public:
+    static Key forNegative(StringRef name) {
+      return Key{name, Expectation::Kind::Negative};
+    }
+
+    static Key forProvides(StringRef name) {
+      return Key{name, Expectation::Kind::Provides};
+    }
+
+    static Key forDynamicMember(StringRef name) {
+      return Key{name, Expectation::Kind::DynamicMember};
+    }
+
+    static Key forPotentialMember(StringRef name) {
+      return Key{name, Expectation::Kind::PotentialMember};
+    }
+
+    static Key forMember(StringRef name) {
+      return Key{name, Expectation::Kind::Member};
+    }
+
+    static Key forExpectation(const Expectation &E) {
+      switch (E.Info.first) {
+      case Expectation::Kind::Negative:
+        return Key::forNegative(E.MessageRange);
+      case Expectation::Kind::Provides:
+        return Key::forProvides(E.MessageRange);
+      case Expectation::Kind::Member:
+        return Key::forMember(E.MessageRange);
+      case Expectation::Kind::PotentialMember:
+        return Key::forPotentialMember(E.MessageRange);
+      case Expectation::Kind::DynamicMember:
+        return Key::forDynamicMember(E.MessageRange);
+      }
+    }
+
+  public:
+    struct Info {
+      static inline Obligation::Key getEmptyKey() {
+        return Obligation::Key{llvm::DenseMapInfo<StringRef>::getEmptyKey(),
+                               static_cast<Expectation::Kind>(~0)};
+      }
+      static inline Obligation::Key getTombstoneKey() {
+        return Obligation::Key{llvm::DenseMapInfo<StringRef>::getTombstoneKey(),
+                               static_cast<Expectation::Kind>(~0U - 1)};
+      }
+      static unsigned getHashValue(const Obligation::Key &Val) {
+        return llvm::hash_combine(Val.Name, Val.Kind);
+      }
+      static bool isEqual(const Obligation::Key &LHS,
+                          const Obligation::Key &RHS) {
+        return LHS.Name == RHS.Name && LHS.Kind == RHS.Kind;
+      }
+    };
+  };
+
+private:
+  DeclBaseName name;
+  std::pair<Expectation::Kind, Expectation::Flavor> info;
+  SourceLoc contextLoc;
+  State state;
+
+public:
+  Obligation(DeclBaseName name, Expectation::Kind k, Expectation::Flavor f,
+             SourceLoc loc)
+      : name(name), info{k, f}, contextLoc{loc}, state(State::Active) {
+    assert(k != Expectation::Kind::Negative &&
+           "Cannot form negative obligation!");
+  }
+
+  Expectation::Kind getKind() const { return info.first; }
+  DeclBaseName getName() const { return name; }
+  bool getCascades() const {
+    return info.second == Expectation::Flavor::Cascading;
+  }
+  StringRef describeCascade() const {
+    switch (info.second) {
+    case Expectation::Flavor::None:
+      llvm_unreachable("Cannot describe obligation with no cascade info");
+    case Expectation::Flavor::Private:
+      return "non-cascading";
+    case Expectation::Flavor::Cascading:
+      return "cascading";
+    }
+  }
+
+public:
+  SourceLoc getLocation() const { return contextLoc; }
+
+public:
+  bool isActive() const { return state == State::Active; }
+  FullfillmentToken fullfill() {
+    assert(state == State::Active &&
+           "Cannot fulfill an obligation more than once!");
+    state = State::Fulfilled;
+    return FullfillmentToken{};
+  }
+  FullfillmentToken fail() {
+    assert(state == State::Active &&
+           "Cannot fail an obligation more than once!");
+    state = State::Failed;
+    return FullfillmentToken{};
+  }
+};
+
+/// The \c DependencyVerifier implements routines to verify a set of \c
+/// Expectations in a given source file meet and match a set of \c Obligations
+/// in the referenced name trackers associated with that file.
+class DependencyVerifier {
+  SourceManager &SM;
+  std::vector<llvm::SMDiagnostic> Errors = {};
+  llvm::BumpPtrAllocator StringAllocator;
+
+public:
+  explicit DependencyVerifier(SourceManager &SM) : SM(SM) {}
+
+  bool verifyFile(const SourceFile *SF);
+
+public:
+  using ObligationMap = llvm::MapVector<
+      Obligation::Key, Obligation,
+      llvm::DenseMap<Obligation::Key, unsigned, Obligation::Key::Info>>;
+  using NegativeExpectationMap = llvm::StringMap<Expectation>;
+
+private:
+  bool parseExpectations(const SourceFile *SF,
+                         std::vector<Expectation> &Expectations);
+  bool constructObligations(const SourceFile *SF, ObligationMap &map);
+
+  bool verifyObligations(const SourceFile *SF,
+                         const std::vector<Expectation> &Exs,
+                         ObligationMap &Obs,
+                         NegativeExpectationMap &NegativeExpectations);
+
+  bool verifyNegativeExpectations(ObligationMap &Obs,
+                                  NegativeExpectationMap &Negs);
+
+  bool diagnoseUnfulfilledObligations(const SourceFile *SF, ObligationMap &OM);
+
+private:
+  /// Given an \c ObligationMap and an \c Expectation, attempt to identify a
+  /// corresponding active \c Obligation and verify it. If there is a matching
+  /// obligation, the \p fulfill callback is given the obligation. Otherwise \p
+  /// fail is called with the unmatched expectation value.
+  void matchExpectationOrFail(
+      ObligationMap &OM, const Expectation &expectation,
+      llvm::function_ref<Obligation::FullfillmentToken(Obligation &)> fulfill,
+      llvm::function_ref<void(const Expectation &)> fail) {
+    auto entry = OM.find(Obligation::Key::forExpectation(expectation));
+    if (entry == OM.end()) {
+      return fail(expectation);
+    }
+
+    fulfill(entry->second);
+  }
+
+  /// For each active \c Obligation, call the provided callback with its
+  /// relevant name data and the Obligation itself.
+  void
+  forEachActiveObligation(ObligationMap &OM,
+                          llvm::function_ref<void(StringRef, Obligation &)> f) {
+    for (auto &p : OM) {
+      if (p.second.isActive())
+        f(p.first.Name, p.second);
+    }
+  }
+
+private:
+  StringRef bumpAllocateData(const char *Data, size_t Length) {
+    char *Ptr = StringAllocator.Allocate<char>(Length + 1);
+    memcpy(Ptr, Data, Length);
+    *(Ptr + Length) = 0;
+    return StringRef(Ptr, Length);
+  }
+
+  StringRef allocateString(StringRef S) {
+    return bumpAllocateData(S.data(), S.size());
+  }
+
+private:
+  template <typename... Ts>
+  inline auto addFormattedDiagnostic(const Expectation &dep, const char *Fmt,
+                                     Ts &&... Vals) {
+    return addFormattedDiagnostic(dep.MessageRange.begin(), Fmt,
+                                  std::forward<Ts>(Vals)...);
+  }
+
+  template <typename... Ts>
+  inline auto addFormattedDiagnostic(const char *Loc, const char *Fmt,
+                                     Ts &&... Vals) {
+    auto loc = SourceLoc(llvm::SMLoc::getFromPointer(Loc));
+    auto diag =
+        SM.GetMessage(loc, llvm::SourceMgr::DK_Error,
+                      llvm::formatv(Fmt, std::forward<Ts>(Vals)...), {}, {});
+    Errors.push_back(diag);
+  }
+
+  void addError(const char *Loc, const Twine &Msg,
+                ArrayRef<llvm::SMFixIt> FixIts = {}) {
+    auto loc = SourceLoc(llvm::SMLoc::getFromPointer(Loc));
+    auto diag = SM.GetMessage(loc, llvm::SourceMgr::DK_Error, Msg, {}, FixIts);
+    Errors.push_back(diag);
+  };
+};
+} // end anonymous namespace
+
+bool DependencyVerifier::parseExpectations(
+    const SourceFile *SF, std::vector<Expectation> &Expectations) {
+  const auto MaybeBufferID = SF->getBufferID();
+  if (!MaybeBufferID) {
+    llvm::errs() << "source file has no buffer: " << SF->getFilename();
+    return true;
+  }
+
+  const auto BufferID = MaybeBufferID.getValue();
+  CharSourceRange EntireRange = SM.getRangeForBuffer(BufferID);
+  StringRef InputFile = SM.extractText(EntireRange);
+
+  for (size_t Match = InputFile.find("expected-"); Match != StringRef::npos;
+       Match = InputFile.find("expected-", Match + 1)) {
+    StringRef MatchStart = InputFile.substr(Match);
+    const char *DiagnosticLoc = MatchStart.data();
+
+    Expectation::Kind ExpectedKind;
+    Expectation::Flavor ExpectedFlavor;
+    {
+#define MATRIX_ENTRY(STRING, FLAVOR, KIND)                                     \
+  .StartsWith(STRING, [&]() {                                                  \
+    ExpectedKind = Expectation::Kind::KIND;                                    \
+    ExpectedFlavor = Expectation::Flavor::FLAVOR;                              \
+    MatchStart = MatchStart.substr(strlen(STRING));                            \
+  })
+
+      // clang-format off
+        llvm::StringSwitch<llvm::function_ref<void(void)>>{MatchStart}
+          EXPECTATION_MATRIX
+          .Default([]() {})();
+      // clang-format on
+#undef MATRIX_ENTRY
+    }
+
+    // Skip any whitespace before the {{.
+    MatchStart = MatchStart.substr(MatchStart.find_first_not_of(" \t"));
+
+    size_t TextStartIdx = MatchStart.find("{{");
+    if (TextStartIdx == StringRef::npos) {
+      addError(MatchStart.data(), "expected {{ in expectation");
+      continue;
+    }
+
+    Expectation Expected(DiagnosticLoc, ExpectedKind, ExpectedFlavor);
+
+    size_t End = MatchStart.find("}}");
+    if (End == StringRef::npos) {
+      addError(MatchStart.data(),
+               "didn't find '}}' to match '{{' in expectation");
+      continue;
+    }
+
+    llvm::SmallString<256> Buf;
+    Expected.MessageRange = MatchStart.slice(2, End);
+
+    // Check if the next expectation should be in the same line.
+    StringRef AfterEnd = MatchStart.substr(End + strlen("}}"));
+    AfterEnd = AfterEnd.substr(AfterEnd.find_first_not_of(" \t"));
+    Expected.ExpectedEnd = AfterEnd.data();
+
+    // Strip out the trailing whitespace.
+    while (isspace(Expected.ExpectedEnd[-1]))
+      --Expected.ExpectedEnd;
+
+    Expectations.push_back(Expected);
+  }
+  return false;
+}
+
+bool DependencyVerifier::constructObligations(const SourceFile *SF,
+                                              ObligationMap &Obligations) {
+  auto *tracker = SF->getReferencedNameTracker();
+  assert(tracker && "Constructed source file without referenced name tracker!");
+
+  // Top-level names match via unqualified references.
+  for (const auto &p : tracker->getTopLevelNames()) {
+    auto str = p.getFirst().userFacingName();
+    Obligations.insert({Obligation::Key::forProvides(str),
+                        {p.getFirst(), Expectation::Kind::Provides,
+                         Expectation::Flavor::None, SourceLoc()}});
+  }
+
+  // Dynamic member names match via unqualified references.
+  for (const auto &p : tracker->getDynamicLookupNames()) {
+    auto str = p.getFirst().userFacingName();
+    Obligations.insert({Obligation::Key::forDynamicMember(str),
+                        {p.getFirst(), Expectation::Kind::DynamicMember,
+                         p.getSecond() ? Expectation::Flavor::Cascading
+                                       : Expectation::Flavor::Private,
+                         SourceLoc()}});
+  }
+
+  llvm::SmallString<128> Str;
+  llvm::raw_svector_ostream OS(Str);
+
+  PrintOptions Options = PrintOptions::printEverything();
+  Options.FullyQualifiedTypes = true;
+  for (const auto &p : tracker->getUsedMembers()) {
+    Str.clear();
+    StreamPrinter printer{OS};
+
+    auto *nominalDeclContext = p.getFirst().first;
+    nominalDeclContext->getDeclaredType().print(printer, Options);
+
+    // Potential members match via qualified reference to the subject.
+    auto memberName = p.getFirst().second;
+    if (memberName.empty()) {
+      auto key = allocateString(OS.str());
+      Obligations.insert(
+          {Obligation::Key::forPotentialMember(key),
+           {p.getFirst().second, Expectation::Kind::PotentialMember,
+            p.getSecond() ? Expectation::Flavor::Cascading
+                          : Expectation::Flavor::Private,
+            SourceLoc()}});
+    } else {
+      // Member constraints match via fully-qualified name.
+      OS << "." << memberName.userFacingName();
+      auto key = allocateString(OS.str());
+      Obligations.insert({Obligation::Key::forMember(key),
+                          {p.getFirst().second, Expectation::Kind::Member,
+                           p.getSecond() ? Expectation::Flavor::Cascading
+                                         : Expectation::Flavor::Private,
+                           nominalDeclContext->getLoc()}});
+    }
+  }
+
+  return false;
+}
+
+bool DependencyVerifier::verifyObligations(
+    const SourceFile *SF, const std::vector<Expectation> &ExpectedDependencies,
+    ObligationMap &OM, llvm::StringMap<Expectation> &NegativeExpectations) {
+  auto *tracker = SF->getReferencedNameTracker();
+  assert(tracker && "Constructed source file without referenced name tracker!");
+
+  for (auto &expectation : ExpectedDependencies) {
+    const bool wantsCascade = expectation.isCascading();
+    switch (expectation.Info.first) {
+    case Expectation::Kind::Negative:
+      // We'll verify negative expectations separately.
+      NegativeExpectations.insert({expectation.MessageRange, expectation});
+      break;
+    case Expectation::Kind::Member:
+      matchExpectationOrFail(
+          OM, expectation,
+          [&](Obligation &p) {
+            const auto haveCascade = p.getCascades();
+            if (haveCascade != wantsCascade) {
+              addFormattedDiagnostic(
+                  expectation,
+                  "expected {0} dependency; found {1} dependency instead",
+                  wantsCascade ? "cascading" : "non-cascading",
+                  haveCascade ? "cascading" : "non-cascading");
+              return p.fail();
+            }
+
+            return p.fullfill();
+          },
+          [this](const Expectation &e) {
+            addFormattedDiagnostic(
+                e, "expected member dependency does not exist: {0}",
+                e.MessageRange);
+          });
+      break;
+    case Expectation::Kind::PotentialMember:
+      matchExpectationOrFail(
+          OM, expectation,
+          [&](Obligation &p) {
+            assert(p.getName().empty());
+            const auto haveCascade = p.getCascades();
+            if (haveCascade != wantsCascade) {
+              addFormattedDiagnostic(
+                  expectation,
+                  "expected {0} potential member dependency; found {1} "
+                  "potential member dependency instead",
+                  wantsCascade ? "cascading" : "non-cascading",
+                  haveCascade ? "cascading" : "non-cascading");
+              return p.fail();
+            }
+
+            return p.fullfill();
+          },
+          [this](const Expectation &e) {
+            addFormattedDiagnostic(
+                e, "expected superclass dependency does not exist: {0}",
+                e.MessageRange);
+          });
+      break;
+    case Expectation::Kind::Provides:
+      matchExpectationOrFail(
+          OM, expectation, [](Obligation &O) { return O.fullfill(); },
+          [this](const Expectation &e) {
+            addFormattedDiagnostic(
+                e, "expected provided dependency does not exist: {0}",
+                e.MessageRange);
+          });
+      break;
+    case Expectation::Kind::DynamicMember:
+      matchExpectationOrFail(
+          OM, expectation, [](Obligation &O) { return O.fullfill(); },
+          [this](const Expectation &e) {
+            addFormattedDiagnostic(
+                e, "expected dynamic member dependency does not exist: {0}",
+                e.MessageRange);
+          });
+      break;
+    }
+  }
+
+  return false;
+}
+
+bool DependencyVerifier::verifyNegativeExpectations(
+    ObligationMap &Obligations, NegativeExpectationMap &NegativeExpectations) {
+  forEachActiveObligation(Obligations, [&](StringRef key, Obligation &p) {
+    auto entry = NegativeExpectations.find(key);
+    if (entry == NegativeExpectations.end()) {
+      return;
+    }
+
+    auto &expectation = entry->second;
+    addFormattedDiagnostic(expectation, "unexpected dependency exists: {0}",
+                           expectation.MessageRange);
+    p.fail();
+  });
+  return false;
+}
+
+bool DependencyVerifier::diagnoseUnfulfilledObligations(
+    const SourceFile *SF, ObligationMap &Obligations) {
+  CharSourceRange EntireRange = SM.getRangeForBuffer(*SF->getBufferID());
+  StringRef InputFile = SM.extractText(EntireRange);
+  forEachActiveObligation(Obligations, [&](StringRef key, Obligation &p) {
+    const char *Loc = NULL;
+    if (p.getLocation().isValid()) {
+      // If we have a recommended location, try to use it.
+      Loc = (const char *)p.getLocation().getOpaquePointerValue();
+    } else {
+      // Otherwise diagnose the input buffer.
+      // HACK: Diagnosing the end of the buffer will print a carat pointing
+      // at the file path, but not print any of the buffer's contents, which
+      // might be misleading.
+      Loc = InputFile.end();
+    }
+
+    switch (p.getKind()) {
+    case Expectation::Kind::Negative:
+      llvm_unreachable("Obligations may not be negative; only Expectations!");
+    case Expectation::Kind::Member:
+      addFormattedDiagnostic(Loc, "unexpected {0} dependency: {1}",
+                             p.describeCascade(), key);
+      break;
+    case Expectation::Kind::DynamicMember:
+      addFormattedDiagnostic(Loc,
+                             "unexpected {0} dynamic member dependency: {1}",
+                             p.describeCascade(), p.getName().userFacingName());
+      break;
+    case Expectation::Kind::PotentialMember:
+      addFormattedDiagnostic(Loc,
+                             "unexpected {0} potential member dependency: {1}",
+                             p.describeCascade(), key);
+      break;
+    case Expectation::Kind::Provides:
+      addFormattedDiagnostic(Loc, "unexpected provided entity: {0}",
+                             p.getName().userFacingName());
+      break;
+    }
+  });
+
+  return false;
+}
+
+bool DependencyVerifier::verifyFile(const SourceFile *SF) {
+  std::vector<Expectation> ExpectedDependencies;
+  if (parseExpectations(SF, ExpectedDependencies)) {
+    return true;
+  }
+
+  ObligationMap Obligations;
+  if (constructObligations(SF, Obligations)) {
+    return true;
+  }
+
+  NegativeExpectationMap Negatives;
+  if (verifyObligations(SF, ExpectedDependencies, Obligations, Negatives)) {
+    return true;
+  }
+
+  if (verifyNegativeExpectations(Obligations, Negatives)) {
+    return true;
+  }
+
+  if (diagnoseUnfulfilledObligations(SF, Obligations)) {
+    return true;
+  }
+
+  // Sort the diagnostics by location so we get a stable ordering.
+  std::sort(Errors.begin(), Errors.end(),
+            [&](const llvm::SMDiagnostic &lhs,
+                const llvm::SMDiagnostic &rhs) -> bool {
+              return lhs.getLoc().getPointer() < rhs.getLoc().getPointer();
+            });
+
+  for (auto Err : Errors)
+    SM.getLLVMSourceMgr().PrintMessage(llvm::errs(), Err);
+
+  return !Errors.empty();
+}
+
+//===----------------------------------------------------------------------===//
+// Main entrypoints
+//===----------------------------------------------------------------------===//
+
+bool swift::verifyDependencies(SourceManager &SM, ArrayRef<FileUnit *> SFs) {
+  bool HadError = false;
+  DependencyVerifier Verifier{SM};
+  for (const auto *FU : SFs) {
+    if (const auto *SF = dyn_cast<SourceFile>(FU))
+      HadError |= Verifier.verifyFile(SF);
+  }
+  return HadError;
+}
+
+bool swift::verifyDependencies(SourceManager &SM, ArrayRef<SourceFile *> SFs) {
+  bool HadError = false;
+  DependencyVerifier Verifier{SM};
+  for (const auto *SF : SFs) {
+    HadError |= Verifier.verifyFile(SF);
+  }
+  return HadError;
+}
+
+#undef EXPECTATION_MATRIX

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -2197,6 +2197,18 @@ int swift::performFrontend(ArrayRef<const char *> Args,
                        Invocation.getFrontendOptions().DumpAPIPath);
   }
 
+  // Verify reference dependencies of the current compilation job *before*
+  // verifying diagnostics so that the former can be tested via the latter.
+  if (Invocation.getFrontendOptions().VerifyDependencies) {
+    if (!Instance->getPrimarySourceFiles().empty()) {
+      HadError |= swift::verifyDependencies(Instance->getSourceMgr(),
+                                            Instance->getPrimarySourceFiles());
+    } else {
+      HadError |= swift::verifyDependencies(Instance->getSourceMgr(),
+                                            Instance->getMainModule()->getFiles());
+    }
+  }
+
   if (diagOpts.VerifyMode != DiagnosticOptions::NoVerify) {
     HadError = verifyDiagnostics(
         Instance->getSourceMgr(),

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1482,7 +1482,7 @@ computeDeallocatableResources(const CompilerInvocation &Invocation,
 
   // Verifying incremental dependencies relies on access to the Swift Module's
   // source files. We can still free the SIL module, though.
-  if (Invocation.getFrontendOptions().VerifyDependencies) {
+  if (Invocation.getFrontendOptions().EnableIncrementalDependencyVerifier) {
     return DeallocatableResources::SILModule;
   }
 
@@ -2199,13 +2199,15 @@ int swift::performFrontend(ArrayRef<const char *> Args,
 
   // Verify reference dependencies of the current compilation job *before*
   // verifying diagnostics so that the former can be tested via the latter.
-  if (Invocation.getFrontendOptions().VerifyDependencies) {
+  if (Invocation.getFrontendOptions().EnableIncrementalDependencyVerifier) {
     if (!Instance->getPrimarySourceFiles().empty()) {
       HadError |= swift::verifyDependencies(Instance->getSourceMgr(),
+                                            *Instance->getDependencyTracker(),
                                             Instance->getPrimarySourceFiles());
     } else {
-      HadError |= swift::verifyDependencies(Instance->getSourceMgr(),
-                                            Instance->getMainModule()->getFiles());
+      HadError |= swift::verifyDependencies(
+          Instance->getSourceMgr(), *Instance->getDependencyTracker(),
+          Instance->getMainModule()->getFiles());
     }
   }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1480,6 +1480,12 @@ computeDeallocatableResources(const CompilerInvocation &Invocation,
     return DeallocatableResources::SILModule;
   }
 
+  // Verifying incremental dependencies relies on access to the Swift Module's
+  // source files. We can still free the SIL module, though.
+  if (Invocation.getFrontendOptions().VerifyDependencies) {
+    return DeallocatableResources::SILModule;
+  }
+
   // If there are multiple primary inputs it is too soon to free
   // the ASTContext, etc.. OTOH, if this compilation generates code for > 1
   // primary input, then freeing it after processing the last primary is

--- a/test/Incremental/fail/Inputs/One.swift
+++ b/test/Incremental/fail/Inputs/One.swift
@@ -1,0 +1,3 @@
+open class Base {}
+
+public protocol BaseProtocol {}

--- a/test/Incremental/fail/Inputs/Two.swift
+++ b/test/Incremental/fail/Inputs/Two.swift
@@ -1,0 +1,5 @@
+final public class Subclass: Base {}
+
+public protocol PublicProtocol: BaseProtocol {}
+
+// expected-no-dependency {{main.BaseProtocol}}

--- a/test/Incremental/fail/main.swift
+++ b/test/Incremental/fail/main.swift
@@ -1,21 +1,15 @@
-// UNSUPPORTED: OS=windows-msvc
-// 'find' trick is non-portable...
-
 // RUN: %empty-directory(%t)
-// RUN: %{python} %S/../gen-output-file-map.py -o %t %S/Inputs
-// RUN: find %S -name "*.swift" > %t/Sources.resp
+// RUN: %{python} %S/../gen-output-file-map.py -o %t %S/Inputs -r %t.resp
+// RUN: cat %t.resp
 // RUN: cd %t
-// RUN: not %target-swiftc_driver -no-color-diagnostics -typecheck -output-file-map %t/output.json -incremental -module-name main -verify-incremental-dependencies @%t/Sources.resp 2>&1 | %FileCheck %s
+// RUN: not %target-swiftc_driver -no-color-diagnostics -typecheck -output-file-map %t/output.json -incremental -module-name main -verify-incremental-dependencies @%t.resp 2>&1 | sort | %FileCheck %s
 
-// N.B. We use CHECK-DAG so we aren't subject to ordering problems caused by the
-// driver choosing to reschedule different frontend processes, and various
-// terminal emulators choosing to buffer rerouted file descriptors differently.
-
-// CHECK-DAG: unexpected cascading dependency: main.Subclass.init
-// CHECK-DAG: unexpected cascading dependency: main.Subclass.deinit
-// CHECK-DAG: unexpected provided entity: PublicProtocol
-// CHECK-DAG: unexpected provided entity: BaseProtocol
-// CHECK-DAG: unexpected provided entity: Base
-// CHECK-DAG: unexpected provided entity: Subclass
-// CHECK-DAG: unexpected cascading dependency: main.Base.init
-// CHECK-DAG: unexpected dependency exists: main.BaseProtocol
+// CHECK: unexpected dependency exists: main.BaseProtocol
+// CHECK: unexpected cascading dependency: main.Base.init
+// CHECK: unexpected cascading dependency: main.Subclass.deinit
+// CHECK: unexpected cascading dependency: main.Subclass.init
+// CHECK: unexpected cascading potential member dependency: main.Base
+// CHECK: unexpected provided entity: Base
+// CHECK: unexpected provided entity: BaseProtocol
+// CHECK: unexpected provided entity: PublicProtocol
+// CHECK: unexpected provided entity: Subclass

--- a/test/Incremental/fail/main.swift
+++ b/test/Incremental/fail/main.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %S/../gen-output-file-map.py -o %t %S/Inputs
+// RUN: find %S -name "*.swift" > %t/Sources.resp
+// RUN: cd %t
+// RUN: not %target-swiftc_driver -no-color-diagnostics -typecheck -output-file-map %t/output.json -incremental -module-name main -verify-incremental-dependencies @%t/Sources.resp 2>&1 | %FileCheck %s
+
+// N.B. We use CHECK-DAG so we aren't subject to ordering problems caused by the
+// driver choosing to reschedule different frontend processes, and various
+// terminal emulators choosing to buffer rerouted file descriptors differently.
+
+// CHECK-DAG: unexpected cascading dependency: main.Subclass.init
+// CHECK-DAG: unexpected cascading dependency: main.Subclass.deinit
+// CHECK-DAG: unexpected provided entity: PublicProtocol
+// CHECK-DAG: unexpected provided entity: BaseProtocol
+// CHECK-DAG: unexpected provided entity: Base
+// CHECK-DAG: unexpected provided entity: Subclass
+// CHECK-DAG: unexpected cascading dependency: main.Base.init
+// CHECK-DAG: unexpected dependency exists: main.BaseProtocol

--- a/test/Incremental/fail/main.swift
+++ b/test/Incremental/fail/main.swift
@@ -1,3 +1,6 @@
+// UNSUPPORTED: OS=windows-msvc
+// 'find' trick is non-portable...
+
 // RUN: %empty-directory(%t)
 // RUN: %{python} %S/../gen-output-file-map.py -o %t %S/Inputs
 // RUN: find %S -name "*.swift" > %t/Sources.resp

--- a/test/Incremental/gen-output-file-map.py
+++ b/test/Incremental/gen-output-file-map.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import argparse
+import json
+import os
+import sys
+
+
+def fatal(msg):
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def find_swift_files(path):
+    for parent, dirs, files in os.walk(path, topdown=True):
+        for filename in files:
+            if not filename.endswith('.swift'):
+                continue
+            yield filename
+
+
+def main(arguments):
+    parser = argparse.ArgumentParser(
+        description='Generate an output file map for the given directory')
+    parser.add_argument('-o', dest='output_dir',
+                        help='Directory to which the file map will be emitted')
+    parser.add_argument('input_dir', help='a directory of swift files')
+    args = parser.parse_args(arguments)
+
+    if not args.output_dir:
+        fatal("output directory is required")
+
+    # Create the output directory if it doesn't already exist.
+    if not os.path.isdir(args.output_dir):
+        os.makedirs(args.output_dir)
+
+    output_path = os.path.join(args.output_dir, 'output.json')
+
+    if not os.path.isdir(args.input_dir):
+        fatal("input directory does not exist, or is not a directory")
+
+    swift_files = find_swift_files(args.input_dir)
+    if not swift_files:
+        fatal("no swift files in the given input directory")
+
+    all_records = {}
+    for swift_file in swift_files:
+        file_name = os.path.splitext(swift_file)[0]
+        all_records['./' + swift_file] = {
+            'object': './' + file_name + '.o',
+            'swift-dependencies': './' + file_name + '.swiftdeps',
+        }
+    all_records[""] = {
+        'swift-dependencies': './main-buildrecord.swiftdeps'
+    }
+
+    with open(output_path, 'w') as f:
+        json.dump(all_records, f)
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/test/Incremental/multi-file/Inputs/Base.swift
+++ b/test/Incremental/multi-file/Inputs/Base.swift
@@ -1,0 +1,39 @@
+open class OpenBase {} // expected-provides {{OpenBase}}
+// expected-cascading-member {{main.OpenBase.init}}
+// expected-cascading-member {{main.OpenBase.deinit}}
+
+public class PublicBase {} // expected-provides {{PublicBase}}
+// expected-cascading-member {{main.PublicBase.init}}
+// expected-cascading-member {{main.PublicBase.deinit}}
+
+internal class InternalBase {} // expected-provides {{InternalBase}}
+// expected-cascading-member {{main.InternalBase.init}}
+// expected-cascading-member {{main.InternalBase.deinit}}
+
+fileprivate class FilePrivateBase {} // expected-provides {{FilePrivateBase}}
+// expected-cascading-member {{main.FilePrivateBase.init}}
+// expected-private-member {{main.FilePrivateBase.deinit}}
+
+private class PrivateBase {} // expected-provides {{PrivateBase}}
+// expected-cascading-member {{main.PrivateBase.init}}
+// expected-private-member {{main.PrivateBase.deinit}}
+
+final fileprivate class FilePrivateSubclass: FilePrivateBase {} // expected-provides {{FilePrivateSubclass}} expected-private-superclass {{main.FilePrivateBase}}
+// expected-cascading-member {{main.FilePrivateSubclass.init}}
+// expected-private-member {{main.FilePrivateSubclass.deinit}}
+
+final private class PrivateSubclass: PrivateBase {} // expected-provides {{PrivateSubclass}} expected-private-superclass {{main.PrivateBase}}
+// expected-cascading-member {{main.PrivateSubclass.init}}
+// expected-private-member {{main.PrivateSubclass.deinit}}
+
+public protocol PublicBaseProtocol {} // expected-provides {{PublicBaseProtocol}}
+
+internal protocol InternalBaseProtocol {} // expected-provides {{InternalBaseProtocol}}
+
+fileprivate protocol FilePrivateBaseProtocol {} // expected-provides {{FilePrivateBaseProtocol}}
+
+private protocol PrivateBaseProtocol {} // expected-provides {{PrivateBaseProtocol}}
+
+fileprivate protocol FilePrivateProtocol: FilePrivateBaseProtocol {} // expected-provides {{FilePrivateProtocol}} expected-private-conformance {{main.FilePrivateBaseProtocol}}
+
+private protocol PrivateProtocol: PrivateBaseProtocol {} // expected-provides {{PrivateProtocol}} expected-private-conformance {{main.PrivateBaseProtocol}}

--- a/test/Incremental/multi-file/Inputs/Derived.swift
+++ b/test/Incremental/multi-file/Inputs/Derived.swift
@@ -1,0 +1,27 @@
+final public class OpenSubclass: OpenBase {} // expected-provides {{OpenSubclass}} expected-cascading-superclass {{main.OpenBase}}
+// expected-provides {{OpenBase}}
+// expected-cascading-member {{main.OpenBase.init}}
+// expected-cascading-member {{main.OpenSubclass.init}}
+// expected-cascading-member {{main.OpenSubclass.deinit}}
+
+final public class PublicSubclass: PublicBase {} // expected-provides {{PublicSubclass}} expected-cascading-superclass {{main.PublicBase}}
+// expected-provides {{PublicBase}}
+// expected-cascading-member {{main.PublicBase.init}}
+// expected-cascading-member {{main.PublicSubclass.init}}
+// expected-cascading-member {{main.PublicSubclass.deinit}}
+
+final internal class InternalSubclass: InternalBase {} // expected-provides {{InternalSubclass}} expected-cascading-superclass {{main.InternalBase}}
+// expected-provides {{InternalBase}}
+// expected-cascading-member {{main.InternalBase.init}}
+// expected-cascading-member {{main.InternalSubclass.init}}
+// expected-cascading-member {{main.InternalSubclass.deinit}}
+
+public protocol PublicProtocol: PublicBaseProtocol {}
+// expected-provides {{PublicProtocol}}
+// expected-provides {{PublicBaseProtocol}}
+// expected-cascading-conformance {{main.PublicBaseProtocol}}
+
+internal protocol InternalProtocol: InternalBaseProtocol {}
+// expected-provides {{InternalProtocol}}
+// expected-provides {{InternalBaseProtocol}}
+// expected-cascading-conformance {{main.InternalBaseProtocol}}

--- a/test/Incremental/multi-file/main.swift
+++ b/test/Incremental/multi-file/main.swift
@@ -1,0 +1,9 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %S/../gen-output-file-map.py -o %t %S/Inputs
+// RUN: find %S -name "*.swift" > %t/Sources.resp
+// RUN: cd %t && %target-swiftc_driver -typecheck -output-file-map %t/output.json -incremental -module-name main -verify-incremental-dependencies @%t/Sources.resp
+// RUN: cd %t && %target-swiftc_driver -typecheck -output-file-map %t/output.json -incremental -enable-batch-mode -module-name main -verify-incremental-dependencies @%t/Sources.resp
+
+// N.B. These tests are meant to continue to expand to more and more input files
+// as more kinds of cross-type dependencies are discovered. This will naturally
+// increase the chance that input ordering bugs will be surfaced by batch mode.

--- a/test/Incremental/multi-file/main.swift
+++ b/test/Incremental/multi-file/main.swift
@@ -1,11 +1,7 @@
-// UNSUPPORTED: OS=windows-msvc
-// 'find' trick is non-portable...
-
 // RUN: %empty-directory(%t)
-// RUN: %{python} %S/../gen-output-file-map.py -o %t %S/Inputs
-// RUN: find %S -name "*.swift" > %t/Sources.resp
-// RUN: cd %t && %target-swiftc_driver -typecheck -output-file-map %t/output.json -incremental -module-name main -verify-incremental-dependencies @%t/Sources.resp
-// RUN: cd %t && %target-swiftc_driver -typecheck -output-file-map %t/output.json -incremental -enable-batch-mode -module-name main -verify-incremental-dependencies @%t/Sources.resp
+// RUN: %{python} %S/../gen-output-file-map.py -o %t %S/Inputs -r %t.resp
+// RUN: cd %t && %target-swiftc_driver -typecheck -output-file-map %t/output.json -incremental -module-name main -verify-incremental-dependencies @%t.resp
+// RUN: cd %t && %target-swiftc_driver -typecheck -output-file-map %t/output.json -incremental -enable-batch-mode -module-name main -verify-incremental-dependencies @%t.resp
 
 // N.B. These tests are meant to continue to expand to more and more input files
 // as more kinds of cross-type dependencies are discovered. This will naturally

--- a/test/Incremental/multi-file/main.swift
+++ b/test/Incremental/multi-file/main.swift
@@ -1,3 +1,6 @@
+// UNSUPPORTED: OS=windows-msvc
+// 'find' trick is non-portable...
+
 // RUN: %empty-directory(%t)
 // RUN: %{python} %S/../gen-output-file-map.py -o %t %S/Inputs
 // RUN: find %S -name "*.swift" > %t/Sources.resp

--- a/test/Incremental/single-file/AnyObject.swift
+++ b/test/Incremental/single-file/AnyObject.swift
@@ -1,0 +1,53 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %S/../gen-output-file-map.py -o %t %S
+// RUN: cd %t && %target-swiftc_driver -typecheck -output-file-map %t/output.json -incremental -module-name main -verify-incremental-dependencies %s
+
+import Foundation
+
+// expected-provides {{LookupFactory}}
+// expected-provides {{NSObject}}
+// expected-private-superclass {{ObjectiveC.NSObject}}
+// expected-private-conformance {{Foundation._KeyValueCodingAndObserving}}
+// expected-private-conformance {{Swift.Hashable}}
+// expected-private-conformance {{Swift.Equatable}}
+// expected-private-conformance {{Swift.CustomDebugStringConvertible}}
+// expected-private-conformance {{Swift.CVarArg}}
+// expected-private-conformance {{ObjectiveC.NSObjectProtocol}}
+// expected-private-conformance {{Swift.CustomStringConvertible}}
+@objc private class LookupFactory: NSObject {
+  // expected-provides {{AssignmentPrecedence}}
+  // expected-provides {{IntegerLiteralType}}
+  // expected-provides {{FloatLiteralType}}
+  // expected-provides {{Int}}
+  // expected-cascading-member {{ObjectiveC.NSObject.someMember}}
+  // expected-cascading-member {{ObjectiveC.NSObject.Int}}
+  // expected-cascading-member {{main.LookupFactory.Int}}
+  @objc var someMember: Int = 0
+  // expected-cascading-member {{ObjectiveC.NSObject.someMethod}}
+  @objc func someMethod() {}
+
+  // expected-cascading-member {{ObjectiveC.NSObject.init}}
+  // expected-cascading-member {{main.LookupFactory.init}}
+  // expected-cascading-member {{main.LookupFactory.deinit}}
+  // expected-cascading-member {{main.LookupFactory.someMember}}
+  // expected-cascading-member {{main.LookupFactory.someMethod}}
+}
+
+// expected-private-member {{Swift.ExpressibleByNilLiteral.callAsFunction}}
+// expected-private-member {{Swift.CustomReflectable.callAsFunction}}
+// expected-private-member {{Swift._ObjectiveCBridgeable.callAsFunction}}
+// expected-private-member {{Swift.Optional.callAsFunction}}
+// expected-private-member {{Swift.CustomDebugStringConvertible.callAsFunction}}
+// expected-private-member {{Swift.Equatable.callAsFunction}}
+// expected-private-member {{Swift.Hashable.callAsFunction}}
+// expected-private-member {{Swift.Encodable.callAsFunction}}
+// expected-private-member {{Swift.Decodable.callAsFunction}}
+// expected-private-member {{Foundation._OptionalForKVO.callAsFunction}}
+
+// expected-provides {{AnyObject}}
+func lookupOnAnyObject(object: AnyObject) { // expected-provides {{lookupOnAnyObject}}
+  _ = object.someMember // expected-private-dynamic-member {{someMember}}
+  object.someMethod() // expected-private-dynamic-member {{someMethod}}
+}

--- a/test/Incremental/single-file/AnyObject.swift
+++ b/test/Incremental/single-file/AnyObject.swift
@@ -8,27 +8,26 @@ import Foundation
 
 // expected-provides {{LookupFactory}}
 // expected-provides {{NSObject}}
-// expected-private-superclass {{ObjectiveC.NSObject}}
+// expected-private-superclass {{__C.NSObject}}
 // expected-private-conformance {{Foundation._KeyValueCodingAndObserving}}
 // expected-private-conformance {{Swift.Hashable}}
 // expected-private-conformance {{Swift.Equatable}}
 // expected-private-conformance {{Swift.CustomDebugStringConvertible}}
 // expected-private-conformance {{Swift.CVarArg}}
-// expected-private-conformance {{ObjectiveC.NSObjectProtocol}}
 // expected-private-conformance {{Swift.CustomStringConvertible}}
 @objc private class LookupFactory: NSObject {
   // expected-provides {{AssignmentPrecedence}}
   // expected-provides {{IntegerLiteralType}}
   // expected-provides {{FloatLiteralType}}
   // expected-provides {{Int}}
-  // expected-cascading-member {{ObjectiveC.NSObject.someMember}}
-  // expected-cascading-member {{ObjectiveC.NSObject.Int}}
+  // expected-cascading-member {{__C.NSObject.someMember}}
+  // expected-cascading-member {{__C.NSObject.Int}}
   // expected-cascading-member {{main.LookupFactory.Int}}
   @objc var someMember: Int = 0
-  // expected-cascading-member {{ObjectiveC.NSObject.someMethod}}
+  // expected-cascading-member {{__C.NSObject.someMethod}}
   @objc func someMethod() {}
 
-  // expected-cascading-member {{ObjectiveC.NSObject.init}}
+  // expected-cascading-member {{__C.NSObject.init}}
   // expected-cascading-member {{main.LookupFactory.init}}
   // expected-cascading-member {{main.LookupFactory.deinit}}
   // expected-cascading-member {{main.LookupFactory.someMember}}

--- a/test/Incremental/single-file/Conformances.swift
+++ b/test/Incremental/single-file/Conformances.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %S/../gen-output-file-map.py -o %t %S
+// RUN: cd %t && %target-swiftc_driver -typecheck -output-file-map %t/output.json -incremental -module-name main -verify-incremental-dependencies %s
+
+public protocol PublicProtocol { } // expected-provides {{PublicProtocol}}
+internal protocol InternalProtocol { } // expected-provides {{InternalProtocol}}
+fileprivate protocol FilePrivateProtocol { } // expected-provides {{FilePrivateProtocol}}
+private protocol PrivateProtocol { } // expected-provides {{PrivateProtocol}}
+
+public struct PublicConformance { } // expected-provides {{PublicConformance}}
+// expected-cascading-member {{main.PublicConformance.init}}
+
+// expected-cascading-member {{main.PublicConformance.deinit}}
+extension PublicConformance: PublicProtocol { }
+extension PublicConformance: InternalProtocol { }
+extension PublicConformance: FilePrivateProtocol { }
+extension PublicConformance: PrivateProtocol { }
+
+
+private struct PrivateConformance { } // expected-provides {{PrivateConformance}}
+// expected-cascading-member {{main.PrivateConformance.init}}
+
+// FIXME: This could be a private dependency...
+// expected-cascading-member {{main.PrivateConformance.deinit}}
+extension PrivateConformance: PublicProtocol { } // expected-cascading-conformance {{main.PublicProtocol}}
+extension PrivateConformance: InternalProtocol { } // expected-cascading-conformance {{main.InternalProtocol}}
+extension PrivateConformance: FilePrivateProtocol { } // expected-cascading-conformance {{main.FilePrivateProtocol}}
+extension PrivateConformance: PrivateProtocol { } // expected-cascading-conformance {{main.PrivateProtocol}}
+


### PR DESCRIPTION
The DependencyVerifier is a DiagnosticVerifier-alike utility that takes annotations in user code and transforms them into a set of expectations. Those expectations are met by corresponding "obligations", which are constructed by reading the contents of the referenced name tracker associated with the source files for each of the primary inputs to a frontend job. The verifier will then pair off expectations and obligations, and ensure that any remaining unpaired obligations are diagnosed as failures.

This tool will not only ensure the correctness of the referenced name tracker's output, it will provide us with tests that ensure its output is stable, and give us the confidence to replace it with an evaluator-based tracking scheme in the future.

Resolves rdar://59773883