### PR TITLE
[CodeCompletion] Primarily use getPossibleCallees() for calling signature completion

### DIFF
--- a/lib/IDE/ExprContextAnalysis.h
+++ b/lib/IDE/ExprContextAnalysis.h
@@ -24,6 +24,7 @@ class ValueDecl;
 class AnyFunctionType;
 
 namespace ide {
+enum class SemanticContextKind;
 
 /// Type check parent contexts of the given decl context, and the body of the
 /// given context until \c Loc if the context is a function body.
@@ -37,7 +38,17 @@ Expr *findParsedExpr(const DeclContext *DC, SourceRange TargetRange);
 /// \p DC should be an \c AbstractFunctionDecl or an \c AbstractClosureExpr.
 Type getReturnTypeFromContext(const DeclContext *DC);
 
-using FunctionTypeAndDecl = std::pair<AnyFunctionType *, ValueDecl *>;
+struct FunctionTypeAndDecl {
+  AnyFunctionType *Type;
+  ValueDecl *Decl;
+  Optional<SemanticContextKind> SemanticContext;
+
+  FunctionTypeAndDecl(AnyFunctionType *Type, ValueDecl *Decl)
+      : Type(Type), Decl(Decl) {}
+  FunctionTypeAndDecl(AnyFunctionType *Type, ValueDecl *Decl,
+                      SemanticContextKind SemanticContext)
+      : Type(Type), Decl(Decl), SemanticContext(SemanticContext) {}
+};
 
 /// Given an expression and its decl context, the analyzer tries to figure out
 /// the expected type of the expression by analyzing its context.

--- a/test/IDE/complete_at_top_level.swift
+++ b/test/IDE/complete_at_top_level.swift
@@ -470,7 +470,7 @@ func resyncParserB14() {}
 var stringInterp = "\(#^STRING_INTERP_3^#)"
 _ = "" + "\(#^STRING_INTERP_4^#)" + ""
 // STRING_INTERP: Begin completions
-// STRING_INTERP-DAG: Decl[InstanceMethod]/CurrNominal:   ['(']{#(value): _#}[')'][#Void#]; name=value: _
+// STRING_INTERP-DAG: Decl[InstanceMethod]/CurrNominal:   ['(']{#(value): T#}[')'][#Void#];
 // STRING_INTERP-DAG: Decl[Struct]/CurrModule: FooStruct[#FooStruct#];
 // STRING_INTERP-DAG: Decl[FreeFunction]/CurrModule/NotRecommended/TypeRelation[Invalid]: fooFunc1()[#Void#];
 // STRING_INTERP-DAG: Decl[FreeFunction]/CurrModule: optStr()[#String?#];

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -93,6 +93,7 @@
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARCHETYPE_GENERIC_1 | %FileCheck %s -check-prefix=ARCHETYPE_GENERIC_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PARAM_WITH_ERROR_AUTOCLOSURE| %FileCheck %s -check-prefix=PARAM_WITH_ERROR_AUTOCLOSURE
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPECHECKED_OVERLOADED | %FileCheck %s -check-prefix=TYPECHECKED_OVERLOADED
 
 var i1 = 1
 var i2 = 2
@@ -737,7 +738,7 @@ struct Wrap<T> {
 func testGenricMethodOnGenericOfArchetype<Wrapped>(value: Wrap<Wrapped>) {
   value.method(#^ARCHETYPE_GENERIC_1^#)
 // ARCHETYPE_GENERIC_1: Begin completions
-// ARCHETYPE_GENERIC_1: Decl[InstanceMethod]/CurrNominal:   ['(']{#(fn): (Wrapped) -> _##(Wrapped) -> _#}[')'][#Wrap<_>#];
+// ARCHETYPE_GENERIC_1: Decl[InstanceMethod]/CurrNominal:   ['(']{#(fn): (Wrapped) -> U##(Wrapped) -> U#}[')'][#Wrap<U>#];
 }
 
 struct TestHasErrorAutoclosureParam {
@@ -750,4 +751,18 @@ struct TestHasErrorAutoclosureParam {
 // PARAM_WITH_ERROR_AUTOCLOSURE: Decl[InstanceMethod]/CurrNominal:   ['(']{#value: <<error type>>#}[')'][#Void#];
 // PARAM_WITH_ERROR_AUTOCLOSURE: End completions
   }
+}
+
+struct MyType {
+  func overloaded() {}
+  func overloaded(_ int: Int) {}
+  func overloaded(name: String, value: String) {}
+}
+func testTypecheckedOverloaded(value: MyType) {
+  value.overloaded(#^TYPECHECKED_OVERLOADED^#)
+// TYPECHECKED_OVERLOADED: Begin completions
+// TYPECHECKED_OVERLOADED-DAG: Decl[InstanceMethod]/CurrNominal:   ['('][')'][#Void#];
+// TYPECHECKED_OVERLOADED-DAG: Decl[InstanceMethod]/CurrNominal:   ['(']{#(int): Int#}[')'][#Void#];
+// TYPECHECKED_OVERLOADED-DAG: Decl[InstanceMethod]/CurrNominal:   ['(']{#name: String#}, {#value: String#}[')'][#Void#];
+// TYPECHECKED_OVERLOADED: End completions
 }

--- a/test/IDE/complete_subscript.swift
+++ b/test/IDE/complete_subscript.swift
@@ -111,8 +111,8 @@ class Derived: Base {
   func testInstance() {
     let _ = self[#^SELF_IN_INSTANCEMETHOD^#]
 // SELF_IN_INSTANCEMETHOD: Begin completions, 2 items
-// SELF_IN_INSTANCEMETHOD-DAG: Decl[Subscript]/CurrNominal:        ['[']{#derivedInstance: Int#}[']'][#Int#];
-// SELF_IN_INSTANCEMETHOD-DAG: Decl[Subscript]/CurrNominal:        ['[']{#instance: Int#}[']'][#Int#];
+// SELF_IN_INSTANCEMETHOD-DAG: Decl[Subscript]/CurrNominal: ['[']{#derivedInstance: Int#}[']'][#Int#];
+// SELF_IN_INSTANCEMETHOD-DAG: Decl[Subscript]/Super:       ['[']{#instance: Int#}[']'][#Int#];
 // SELF_IN_INSTANCEMETHOD: End completions
 
     let _ = super[#^SUPER_IN_INSTANCEMETHOD^#]
@@ -124,8 +124,8 @@ class Derived: Base {
   static func testStatic() {
     let _ = self[#^SELF_IN_STATICMETHOD^#]
 // SELF_IN_STATICMETHOD: Begin completions, 2 items
-// SELF_IN_STATICMETHOD-DAG: Decl[Subscript]/CurrNominal:        ['[']{#derivedStatic: Int#}[']'][#Int#];
-// SELF_IN_STATICMETHOD-DAG: Decl[Subscript]/CurrNominal:        ['[']{#static: Int#}[']'][#Int#];
+// SELF_IN_STATICMETHOD-DAG: Decl[Subscript]/CurrNominal: ['[']{#derivedStatic: Int#}[']'][#Int#];
+// SELF_IN_STATICMETHOD-DAG: Decl[Subscript]/Super:       ['[']{#static: Int#}[']'][#Int#];
 // SELF_IN_STATICMETHOD: End completions
 
     let _ = super[#^SUPER_IN_STATICMETHOD^#]

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -1433,8 +1433,8 @@ func testInterpolatedString1() {
 }
 
 // FOO_OBJECT_DOT1: Begin completions
-// FOO_OBJECT_DOT1-DAG: Decl[InstanceVar]/CurrNominal:      lazyInstanceVar[#Int#]{{; name=.+$}}
-// FOO_OBJECT_DOT1-DAG: Decl[InstanceVar]/CurrNominal:      instanceVar[#Int#]{{; name=.+$}}
+// FOO_OBJECT_DOT1-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]:      lazyInstanceVar[#Int#]{{; name=.+$}}
+// FOO_OBJECT_DOT1-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]:      instanceVar[#Int#]{{; name=.+$}}
 // FOO_OBJECT_DOT1-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: instanceFunc0()[#Void#]{{; name=.+$}}
 // FOO_OBJECT_DOT1-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: instanceFunc1({#(a): Int#})[#Void#]{{; name=.+$}}
 // FOO_OBJECT_DOT1-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: instanceFunc2({#(a): Int#}, {#b: &Double#})[#Void#]{{; name=.+$}}

--- a/test/IDE/complete_vararg.swift
+++ b/test/IDE/complete_vararg.swift
@@ -89,7 +89,7 @@ func testGenericFreeFunc() {
   genericFreeFunc1(#^GENERIC_FREE_FUNC_1^#
 }
 // GENERIC_FREE_FUNC_1: Begin completions, 1 items
-// GENERIC_FREE_FUNC_1: Decl[FreeFunction]/CurrModule: ['(']{#t: _...#}[')'][#Void#]{{; name=.+$}}
+// GENERIC_FREE_FUNC_1: Decl[FreeFunction]/CurrModule: ['(']{#t: T...#}[')'][#Void#]{{; name=.+$}}
 // GENERIC_FREE_FUNC_1: End completions
 
 


### PR DESCRIPTION
instead of the pre-typechecked type and the referenced decl in the AST, so that we can suggests all overloads even if the expression happen to be typechecked to a method. For example.

```swift
    struct MyType {
      func foo() {}
      func foo(_ int: Int) {}
      func foo(name: String, value: String) {}
    }
    func test(val: MyType) {
      value.foo(#^COMPLETE^#)
    }
```
In this case, the call is typechecked to 'MyType.foo(_:)', but we want to suggest all overloads.

rdar://problem/59285399