### PR TITLE
Add the fallthrough attribute to silence a warning

### DIFF
--- a/stdlib/public/Darwin/os/format.m
+++ b/stdlib/public/Darwin/os/format.m
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -63,7 +63,7 @@ _os_log_encode(char buf[OS_LOG_FMT_BUF_SIZE], const char *format, va_list args,
               break;
             }
             percent++;
-            // FALLTHROUGH
+            __attribute__((fallthrough));
           case '.': // precision
             if ((percent[1]) == '*') {
               prect = T_C_DYNAMIC;


### PR DESCRIPTION
> stdlib/public/Darwin/os/format.m:67:11: warning: 
> unannotated fall-through between switch labels [-Wimplicit-fallthrough]