### PR TITLE
Preliminary support for OpenBSD in the stdlib.

### DIFF
--- a/include/swift/Runtime/Mutex.h
+++ b/include/swift/Runtime/Mutex.h
@@ -20,7 +20,7 @@
 
 #include <type_traits>
 
-#if (defined(__APPLE__) || defined(__linux__) || defined(__CYGWIN__) || defined(__FreeBSD__) || defined(__HAIKU__))
+#if (defined(__APPLE__) || defined(__linux__) || defined(__CYGWIN__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__HAIKU__))
 #include "swift/Runtime/MutexPThread.h"
 #elif defined(_WIN32)
 #include "swift/Runtime/MutexWin32.h"

--- a/stdlib/private/StdlibUnittest/RaceTest.swift
+++ b/stdlib/private/StdlibUnittest/RaceTest.swift
@@ -41,7 +41,7 @@ import SwiftPrivateLibcExtras
 import SwiftPrivateThreadExtras
 #if os(macOS) || os(iOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
 import Glibc
 #elseif os(Windows)
 import MSVCRT

--- a/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
+++ b/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
@@ -14,7 +14,7 @@ import SwiftPrivate
 import SwiftPrivateLibcExtras
 #if os(macOS) || os(iOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
 import Glibc
 #elseif os(Windows)
 import MSVCRT

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -18,7 +18,7 @@ import SwiftPrivateLibcExtras
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Foundation
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
 import Glibc
 #elseif os(Windows)
 import MSVCRT
@@ -1744,6 +1744,7 @@ public enum OSVersion : CustomStringConvertible {
   case watchOSSimulator
   case linux
   case freeBSD
+  case openBSD
   case android
   case ps4
   case windowsCygnus
@@ -1771,6 +1772,8 @@ public enum OSVersion : CustomStringConvertible {
       return "Linux"
     case .freeBSD:
       return "FreeBSD"
+    case .openBSD:
+      return "OpenBSD"
     case .ps4:
       return "PS4"
     case .android:
@@ -1817,6 +1820,8 @@ func _getOSVersion() -> OSVersion {
   return .linux
 #elseif os(FreeBSD)
   return .freeBSD
+#elseif os(OpenBSD)
+  return .openBSD
 #elseif os(PS4)
   return .ps4
 #elseif os(Android)

--- a/stdlib/private/StdlibUnittest/SymbolLookup.swift
+++ b/stdlib/private/StdlibUnittest/SymbolLookup.swift
@@ -12,7 +12,7 @@
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
   import Glibc
 #elseif os(Windows)
   import MSVCRT
@@ -21,7 +21,7 @@
 #error("Unsupported platform")
 #endif
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(OpenBSD)
   let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: -2)
 #elseif os(Linux)
   let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: 0)

--- a/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
@@ -13,7 +13,7 @@
 import SwiftPrivate
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
 import Glibc
 #elseif os(Windows)
 import MSVCRT

--- a/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
@@ -13,7 +13,7 @@
 import SwiftPrivate
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
 import Glibc
 #elseif os(Windows)
 import MSVCRT

--- a/stdlib/private/SwiftPrivateThreadExtras/SwiftPrivateThreadExtras.swift
+++ b/stdlib/private/SwiftPrivateThreadExtras/SwiftPrivateThreadExtras.swift
@@ -17,7 +17,7 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || os(Cygwin) || os(Haiku)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
 import Glibc
 #elseif os(Windows)
 import MSVCRT

--- a/stdlib/private/SwiftPrivateThreadExtras/SwiftPrivateThreadExtras.swift
+++ b/stdlib/private/SwiftPrivateThreadExtras/SwiftPrivateThreadExtras.swift
@@ -17,7 +17,7 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || os(Cygwin) || os(Haiku)
 import Glibc
 #elseif os(Windows)
 import MSVCRT

--- a/stdlib/private/SwiftPrivateThreadExtras/ThreadBarriers.swift
+++ b/stdlib/private/SwiftPrivateThreadExtras/ThreadBarriers.swift
@@ -12,7 +12,7 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(OpenBSD)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
 import Glibc
 #elseif os(Windows)
 import MSVCRT

--- a/stdlib/private/SwiftPrivateThreadExtras/ThreadBarriers.swift
+++ b/stdlib/private/SwiftPrivateThreadExtras/ThreadBarriers.swift
@@ -12,7 +12,7 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(OpenBSD)
 import Glibc
 #elseif os(Windows)
 import MSVCRT
@@ -33,7 +33,7 @@ public struct _stdlib_thread_barrier_t {
 #if os(Windows)
   var mutex: UnsafeMutablePointer<SRWLOCK>?
   var cond: UnsafeMutablePointer<CONDITION_VARIABLE>?
-#elseif os(Cygwin) || os(FreeBSD)
+#elseif os(Cygwin) || os(FreeBSD) || os(OpenBSD)
   var mutex: UnsafeMutablePointer<pthread_mutex_t?>?
   var cond: UnsafeMutablePointer<pthread_cond_t?>?
 #else

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -80,6 +80,8 @@ foreach(sdk ${SWIFT_SDKS})
 
     if(${sdk} STREQUAL ANDROID)
       set(glibc_modulemap_source "bionic.modulemap.gyb")
+    elseif(${sdk} STREQUAL OPENBSD)
+      set(glibc_modulemap_source "libc-openbsd.modulemap.gyb")
     else()
       set(glibc_modulemap_source "glibc.modulemap.gyb")
     endif()

--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -332,6 +332,11 @@ public var SIG_DFL: sig_t? { return nil }
 public var SIG_IGN: sig_t { return unsafeBitCast(1, to: sig_t.self) }
 public var SIG_ERR: sig_t { return unsafeBitCast(-1, to: sig_t.self) }
 public var SIG_HOLD: sig_t { return unsafeBitCast(5, to: sig_t.self) }
+#elseif os(OpenBSD)
+public var SIG_DFL: sig_t? { return nil }
+public var SIG_IGN: sig_t { return unsafeBitCast(1, to: sig_t.self) }
+public var SIG_ERR: sig_t { return unsafeBitCast(-1, to: sig_t.self) }
+public var SIG_HOLD: sig_t { return unsafeBitCast(3, to: sig_t.self) }
 #elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Haiku)
 public typealias sighandler_t = __sighandler_t
 
@@ -382,7 +387,7 @@ public var SEM_FAILED: UnsafeMutablePointer<sem_t>? {
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
   // The value is ABI.  Value verified to be correct for OS X, iOS, watchOS, tvOS.
   return UnsafeMutablePointer<sem_t>(bitPattern: -1)
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
   // The value is ABI.  Value verified to be correct on Glibc.
   return UnsafeMutablePointer<sem_t>(bitPattern: 0)
 #else
@@ -412,7 +417,7 @@ public func sem_open(
 //===----------------------------------------------------------------------===//
 
 // Some platforms don't have `extern char** environ` imported from C.
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(FreeBSD) || os(PS4)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(FreeBSD) || os(OpenBSD) || os(PS4)
 public var environ: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?> {
   return _swift_stdlib_getEnviron()
 }

--- a/stdlib/public/Platform/libc-openbsd.modulemap.gyb
+++ b/stdlib/public/Platform/libc-openbsd.modulemap.gyb
@@ -1,0 +1,311 @@
+//===--- libc-openbsd.modulemap.gyb ----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Partial modulemap for libc on OpenBSD.
+module SwiftGlibc [system] {
+  link "pthread"
+  link "util"
+
+  // C standard library
+  module C {
+    module complex {
+      header "${GLIBC_INCLUDE_PATH}/complex.h"
+      export *
+    }
+    module ctype {
+      header "${GLIBC_INCLUDE_PATH}/ctype.h"
+      export *
+    }
+    module errno {
+      header "${GLIBC_INCLUDE_PATH}/errno.h"
+      export *
+    }
+    module fenv {
+      header "${GLIBC_INCLUDE_PATH}/fenv.h"
+      export *
+    }
+    module inttypes {
+      header "${GLIBC_INCLUDE_PATH}/inttypes.h"
+      export *
+    }
+    module locale {
+      header "${GLIBC_INCLUDE_PATH}/locale.h"
+      export *
+    }
+    module math {
+      link "m"
+      header "${GLIBC_INCLUDE_PATH}/math.h"
+      export *
+    }
+    module setjmp {
+      header "${GLIBC_INCLUDE_PATH}/setjmp.h"
+      export *
+    }
+    module signal {
+      header "${GLIBC_INCLUDE_PATH}/signal.h"
+      export *
+    }
+
+    module stdio {
+      header "${GLIBC_INCLUDE_PATH}/stdio.h"
+      export *
+    }
+    module stdlib {
+      header "${GLIBC_INCLUDE_PATH}/stdlib.h"
+      export *
+      export stddef
+    }
+    module string {
+      header "${GLIBC_INCLUDE_PATH}/string.h"
+      export *
+    }
+    module time {
+      header "${GLIBC_INCLUDE_PATH}/time.h"
+      export *
+    }
+  }
+
+  // POSIX
+  module POSIX {
+    module cpio {
+      header "${GLIBC_INCLUDE_PATH}/cpio.h"
+      export *
+    }
+    module nl_types {
+      header "${GLIBC_INCLUDE_PATH}/nl_types.h"
+      export *
+    }
+    module ftw {
+      header "${GLIBC_INCLUDE_PATH}/ftw.h"
+      export *
+    }
+    module glob {
+      header "${GLIBC_INCLUDE_PATH}/glob.h"
+      export *
+    }
+    module langinfo {
+      header "${GLIBC_INCLUDE_PATH}/langinfo.h"
+      export *
+    }
+    module netdb {
+      header "${GLIBC_INCLUDE_PATH}/netdb.h"
+      export *
+    }
+    module ifaddrs {
+      header "${GLIBC_INCLUDE_PATH}/ifaddrs.h"
+      export *
+    }
+    module search {
+      header "${GLIBC_INCLUDE_PATH}/search.h"
+      export *
+    }
+    module spawn {
+      header "${GLIBC_INCLUDE_PATH}/spawn.h"
+      export *
+    }
+    module syslog {
+      header "${GLIBC_INCLUDE_PATH}/syslog.h"
+      export *
+    }
+    module tar {
+      header "${GLIBC_INCLUDE_PATH}/tar.h"
+      export *
+    }
+    module utmp {
+      header "${GLIBC_INCLUDE_PATH}/utmp.h"
+      export *
+    }
+    module arpa {
+      module inet {
+        header "${GLIBC_INCLUDE_PATH}/arpa/inet.h"
+        export *
+      }
+      export *
+    }
+    module dirent {
+      header "${GLIBC_INCLUDE_PATH}/dirent.h"
+      export *
+    }
+    module dl {
+      header "${GLIBC_INCLUDE_PATH}/link.h"
+      export *
+    }
+    module dlfcn {
+      header "${GLIBC_INCLUDE_PATH}/dlfcn.h"
+      export *
+    }
+    module fcntl {
+      header "${GLIBC_INCLUDE_PATH}/fcntl.h"
+      export *
+    }
+    module fnmatch {
+      header "${GLIBC_INCLUDE_PATH}/fnmatch.h"
+      export *
+    }
+    module grp {
+      header "${GLIBC_INCLUDE_PATH}/grp.h"
+      export *
+    }
+    module ioctl {
+      header "${GLIBC_ARCH_INCLUDE_PATH}/sys/ioctl.h"
+      export *
+    }
+    module libgen {
+      header "${GLIBC_INCLUDE_PATH}/libgen.h"
+      export *
+    }
+    module net {
+      module if {
+        header "${GLIBC_INCLUDE_PATH}/net/if.h"
+        export *
+      }
+    }
+    module netinet {
+      module in {
+        header "${GLIBC_INCLUDE_PATH}/netinet/in.h"
+        export *
+
+        exclude header "${GLIBC_INCLUDE_PATH}/netinet6/in6.h"
+      }
+      module tcp {
+        header "${GLIBC_INCLUDE_PATH}/netinet/tcp.h"
+        export *
+      }
+    }
+    module poll {
+      header "${GLIBC_INCLUDE_PATH}/poll.h"
+      export *
+    }
+    module pthread {
+      header "${GLIBC_INCLUDE_PATH}/pthread.h"
+      export *
+    }
+    module pwd {
+      header "${GLIBC_INCLUDE_PATH}/pwd.h"
+      export *
+    }
+    module regex {
+      header "${GLIBC_INCLUDE_PATH}/regex.h"
+      export *
+    }
+    module sched {
+      header "${GLIBC_INCLUDE_PATH}/sched.h"
+      export *
+    }
+    module semaphore {
+      header "${GLIBC_INCLUDE_PATH}/semaphore.h"
+      export *
+    }
+    module strings {
+      header "${GLIBC_INCLUDE_PATH}/strings.h"
+      export *
+    }
+
+    module sys {
+      export *
+
+      module file {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/file.h"
+        export *
+      }
+      module sem {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/sem.h"
+        export *
+      }
+      module shm {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/shm.h"
+        export *
+      }
+      module statvfs {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/statvfs.h"
+        export *
+      }
+      module ipc {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/ipc.h"
+        export *
+      }
+      module mman {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/mman.h"
+        export *
+      }
+      module msg {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/msg.h"
+        export *
+      }
+      module resource {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/resource.h"
+        export *
+      }
+      module select {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/select.h"
+        export *
+      }
+      module socket {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/socket.h"
+        export *
+      }
+      module stat {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/stat.h"
+        export *
+      }
+      module time {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/time.h"
+        export *
+      }
+      module times {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/times.h"
+        export *
+      }
+      module types {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/types.h"
+        export *
+      }
+      module event {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/event.h"
+        export *
+      }
+      module uio {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/uio.h"
+        export *
+      }
+      module un {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/un.h"
+        export *
+      }
+      module user {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/user.h"
+        export *
+      }
+      module utsname {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/utsname.h"
+        export *
+      }
+      module wait {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/wait.h"
+        export *
+      }
+    }
+    module termios {
+      header "${GLIBC_INCLUDE_PATH}/termios.h"
+      export *
+    }
+    module unistd {
+      header "${GLIBC_INCLUDE_PATH}/unistd.h"
+      export *
+    }
+  }
+}
+
+module CUUID [system] {
+  header "${GLIBC_INCLUDE_PATH}/uuid.h"
+  export *
+}

--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -290,7 +290,7 @@ public func ${bfunc}(_ lhs: ${T}, _ rhs: ${T}) -> ${T} {
 % # This is AllFloatTypes not OverlayFloatTypes because of the tuple return.
 % for T, CT, f in AllFloatTypes():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || os(OpenBSD))
 %  else:
 //  lgamma not available on Windows, apparently?
 #if !os(Windows)

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -45,6 +45,8 @@ typedef __swift_uint16_t __swift_mode_t;
 typedef __swift_int32_t __swift_mode_t;
 #elif defined(__wasi__)
 typedef __swift_uint32_t __swift_mode_t;
+#elif defined(__OpenBSD__)
+typedef __swift_uint32_t __swift_mode_t;
 #else  // just guessing
 typedef __swift_uint16_t __swift_mode_t;
 #endif

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -93,6 +93,8 @@ public typealias CLongDouble = Double
 #if arch(arm)
 public typealias CLongDouble = Double
 #endif
+#elseif os(OpenBSD)
+public typealias CLongDouble = Float80
 #endif
 
 // FIXME: Is it actually UTF-32 on Darwin?

--- a/stdlib/public/runtime/ThreadLocalStorage.h
+++ b/stdlib/public/runtime/ThreadLocalStorage.h
@@ -77,6 +77,8 @@ typedef unsigned int __swift_thread_key_t;
 #  endif
 # elif defined(__FreeBSD__)
 typedef int __swift_thread_key_t;
+# elif defined(__OpenBSD__)
+typedef int __swift_thread_key_t;
 # elif defined(_WIN32)
 typedef unsigned long __swift_thread_key_t;
 # elif defined(__HAIKU__)

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -41,7 +41,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#if defined(__CYGWIN__) || defined(_WIN32) || defined(__HAIKU__)
+#if defined(__CYGWIN__) || defined(_WIN32) || defined(__HAIKU__) || defined(__OpenBSD__)
 #include <sstream>
 #include <cmath>
 #elif defined(__ANDROID__)
@@ -357,7 +357,7 @@ static bool swift_stringIsSignalingNaN(const char *nptr) {
   return strcasecmp(nptr, "snan") == 0;
 }
 
-#if defined(__CYGWIN__) || defined(_WIN32) || defined(__HAIKU__)
+#if defined(__CYGWIN__) || defined(_WIN32) || defined(__HAIKU__) || defined(__OpenBSD__)
 // Cygwin does not support uselocale(), but we can use the locale feature 
 // in stringstream object.
 template <typename T>

--- a/test/stdlib/tgmath.swift.gyb
+++ b/test/stdlib/tgmath.swift.gyb
@@ -81,7 +81,7 @@ internal protocol TGMath: BinaryFloatingPoint {
 %end
   static func _remquo(_ x: Self, _ y: Self) -> (Self, Int)
   static func _fma(_ x: Self, _ y: Self, _ z: Self) -> Self
-#if !os(Windows)
+#if !os(Windows) && !os(OpenBSD)
   static func _lgamma(_ x: Self) -> (Self, Int)
 #endif
   static func _modf(_ x: Self) -> (Self, Self)
@@ -122,7 +122,7 @@ internal extension TGMath {
     expectEqualWithTolerance(0.4041169094348222983238250859191217675, Self._erf(0.375))
     expectEqualWithTolerance(0.5958830905651777016761749140808782324, Self._erfc(0.375))
     expectEqualWithTolerance(2.3704361844166009086464735041766525098, Self._tgamma(0.375))
-#if !os(Windows)
+#if !os(Windows) && !os(OpenBSD)
     expectEqualWithTolerance( -0.11775527074107877445136203331798850, Self._lgamma(1.375).0, ulps: 16)
     expectEqual(1, Self._lgamma(1.375).1)
 #endif
@@ -189,7 +189,7 @@ extension ${T}: TGMath {
 %end
   static func _remquo(_ x: ${T}, _ y: ${T}) -> (${T}, Int) { return remquo(x, y) }
   static func _fma(_ x: ${T}, _ y: ${T}, _ z: ${T}) -> ${T} { return fma(x, y, z) }
-#if !os(Windows)
+#if !os(Windows) && !os(OpenBSD)
   static func _lgamma(_ x: ${T}) -> (${T}, Int) { return lgamma(x) }
 #endif
   static func _modf(_ x: ${T}) -> (${T}, ${T}) { return modf(x) }


### PR DESCRIPTION
Preliminary support for OpenBSD in the stdlib.
    
These should hopefully all be uncontroversial, minimal changes to deal
with progressing the build to completion on OpenBSD or addressing minor
portability issues. This is not the full set of changes to get a
successful build; other portability issues will be addressed in future
commits.
    
Most of this is just adding the relevant clauses to the ifdefs, but of
note in this commit:
    
* StdlibUnittest.swift: the default conditional in _getOSVersion assumes
  an Apple platform, therefore the explicit conditional and the relevant
  enums need filling out. The default conditional should be #error, but
  we'll fix this in a different commit.
    
* tgmath.swift.gyb: inexplicably, OpenBSD is missing just lgammal_r.
  Tests are updated correspondingly.
    
* ThreadLocalStorage.h: we use the pthread implementation, so it
  seems we should typedef __swift_thread_key_t as pthread_key_t.
  However, that's also a tweak for another commit.
    
* libc-openbsd.modulemap.gyb: separate libc modulemap for OpenBSD.
  sdk in CMake will be set in a future commit, but it should be safe to add
  this here now.