### PR TITLE
[ownership] Create a single introducer version of getUnderlyingBorrowIntroducingValues and rename it to getAllBorrowIntroducingValues(...).

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -541,13 +541,24 @@ private:
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                               const BorrowScopeIntroducingValue &value);
 
-/// Look up through the def-use chain of \p inputValue, recording any "borrow"
-/// introducing values that we find into \p out. If at any point, we find a
-/// point in the chain we do not understand, we bail and return false. If we are
-/// able to understand all of the def-use graph, we know that we have found all
-/// of the borrow introducing values, we return true.
-bool getUnderlyingBorrowIntroducingValues(
-    SILValue inputValue, SmallVectorImpl<BorrowScopeIntroducingValue> &out);
+/// Look up the def-use graph starting at use \p inputOperand, recording any
+/// "borrow" introducing values that we find into \p out. If at any point, we
+/// find a point in the chain we do not understand, we bail and return false. If
+/// we are able to understand all of the def-use graph, we know that we have
+/// found all of the borrow introducing values, we return true.
+///
+/// NOTE: This may return multiple borrow introducing values in cases where
+/// there are phi-like nodes in the IR like any true phi block arguments or
+/// aggregate literal instructions (struct, tuple, enum, etc.).
+bool getAllBorrowIntroducingValues(
+    SILValue value, SmallVectorImpl<BorrowScopeIntroducingValue> &out);
+
+/// Look up the def-use graph starting at \p inputOperand and see if
+/// we can find a single BorrowScopeIntroducingValue for \p
+/// inputOperand. Returns None if there are multiple such introducers
+/// or if while processing we find a user we do not understand.
+Optional<BorrowScopeIntroducingValue>
+getSingleBorrowIntroducingValue(SILValue value);
 
 } // namespace swift
 

--- a/lib/SIL/OwnershipUtils.cpp
+++ b/lib/SIL/OwnershipUtils.cpp
@@ -305,57 +305,6 @@ void BorrowScopeIntroducingValue::visitLocalScopeEndingUses(
   llvm_unreachable("Covered switch isn't covered?!");
 }
 
-bool swift::getUnderlyingBorrowIntroducingValues(
-    SILValue inputValue, SmallVectorImpl<BorrowScopeIntroducingValue> &out) {
-  if (inputValue.getOwnershipKind() != ValueOwnershipKind::Guaranteed)
-    return false;
-
-  SmallVector<SILValue, 32> worklist;
-  worklist.emplace_back(inputValue);
-
-  while (!worklist.empty()) {
-    SILValue v = worklist.pop_back_val();
-
-    // First check if v is an introducer. If so, stash it and continue.
-    if (auto scopeIntroducer = BorrowScopeIntroducingValue::get(v)) {
-      out.push_back(*scopeIntroducer);
-      continue;
-    }
-
-    // If v produces .none ownership, then we can ignore it. It is important
-    // that we put this before checking for guaranteed forwarding instructions,
-    // since we want to ignore guaranteed forwarding instructions that in this
-    // specific case produce a .none value.
-    if (v.getOwnershipKind() == ValueOwnershipKind::None)
-      continue;
-
-    // Otherwise if v is an ownership forwarding value, add its defining
-    // instruction
-    if (isGuaranteedForwardingValue(v)) {
-      if (auto *i = v->getDefiningInstruction()) {
-        llvm::transform(i->getAllOperands(), std::back_inserter(worklist),
-                        [](const Operand &op) -> SILValue { return op.get(); });
-        continue;
-      }
-
-      // Otherwise, we should have a block argument that is defined by a single
-      // predecessor terminator.
-      auto *arg = cast<SILPhiArgument>(v);
-      auto *termInst = arg->getSingleTerminator();
-      assert(termInst && termInst->isTransformationTerminator());
-      llvm::transform(termInst->getAllOperands(), std::back_inserter(worklist),
-                      [](const Operand &op) -> SILValue { return op.get(); });
-      continue;
-    }
-
-    // Otherwise, this is an introducer we do not understand. Bail and return
-    // false.
-    return false;
-  }
-
-  return true;
-}
-
 llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
                                      BorrowScopeIntroducingValueKind kind) {
   kind.print(os);
@@ -437,4 +386,108 @@ bool BorrowScopeIntroducingValue::visitLocalScopeTransitiveEndingUses(
   }
 
   return foundError;
+}
+
+//===----------------------------------------------------------------------===//
+//                       Introducer Searching Routines
+//===----------------------------------------------------------------------===//
+
+bool swift::getAllBorrowIntroducingValues(
+    SILValue inputValue, SmallVectorImpl<BorrowScopeIntroducingValue> &out) {
+  if (inputValue.getOwnershipKind() != ValueOwnershipKind::Guaranteed)
+    return false;
+
+  SmallVector<SILValue, 32> worklist;
+  worklist.emplace_back(inputValue);
+
+  while (!worklist.empty()) {
+    SILValue value = worklist.pop_back_val();
+
+    // First check if v is an introducer. If so, stash it and continue.
+    if (auto scopeIntroducer = BorrowScopeIntroducingValue::get(value)) {
+      out.push_back(*scopeIntroducer);
+      continue;
+    }
+
+    // If v produces .none ownership, then we can ignore it. It is important
+    // that we put this before checking for guaranteed forwarding instructions,
+    // since we want to ignore guaranteed forwarding instructions that in this
+    // specific case produce a .none value.
+    if (value.getOwnershipKind() == ValueOwnershipKind::None)
+      continue;
+
+    // Otherwise if v is an ownership forwarding value, add its defining
+    // instruction
+    if (isGuaranteedForwardingValue(value)) {
+      if (auto *i = value->getDefiningInstruction()) {
+        llvm::copy(i->getOperandValues(true /*skip type dependent ops*/),
+                   std::back_inserter(worklist));
+        continue;
+      }
+
+      // Otherwise, we should have a block argument that is defined by a single
+      // predecessor terminator.
+      auto *arg = cast<SILPhiArgument>(value);
+      auto *termInst = arg->getSingleTerminator();
+      assert(termInst && termInst->isTransformationTerminator());
+      assert(termInst->getNumOperands() == 1 &&
+             "Transforming terminators should always have a single operand");
+      worklist.push_back(termInst->getAllOperands()[0].get());
+      continue;
+    }
+
+    // Otherwise, this is an introducer we do not understand. Bail and return
+    // false.
+    return false;
+  }
+
+  return true;
+}
+
+Optional<BorrowScopeIntroducingValue>
+swift::getSingleBorrowIntroducingValue(SILValue inputValue) {
+  if (inputValue.getOwnershipKind() != ValueOwnershipKind::Guaranteed)
+    return None;
+
+  SILValue currentValue = inputValue;
+  while (true) {
+    // First check if our initial value is an introducer. If we have one, just
+    // return it.
+    if (auto scopeIntroducer = BorrowScopeIntroducingValue::get(currentValue)) {
+      return scopeIntroducer;
+    }
+
+    // Otherwise if v is an ownership forwarding value, add its defining
+    // instruction
+    if (isGuaranteedForwardingValue(currentValue)) {
+      if (auto *i = currentValue->getDefiningInstruction()) {
+        auto instOps = i->getOperandValues(true /*ignore type dependent ops*/);
+        // If we have multiple incoming values, return .None. We can't handle
+        // this.
+        auto begin = instOps.begin();
+        if (std::next(begin) != instOps.end()) {
+          return None;
+        }
+        // Otherwise, set currentOp to the single operand and continue.
+        currentValue = *begin;
+        continue;
+      }
+
+      // Otherwise, we should have a block argument that is defined by a single
+      // predecessor terminator.
+      auto *arg = cast<SILPhiArgument>(currentValue);
+      auto *termInst = arg->getSingleTerminator();
+      assert(termInst && termInst->isTransformationTerminator());
+      assert(termInst->getNumOperands() == 1 &&
+             "Transformation terminators should only have single operands");
+      currentValue = termInst->getAllOperands()[0].get();
+      continue;
+    }
+
+    // Otherwise, this is an introducer we do not understand. Bail and return
+    // None.
+    return None;
+  }
+
+  llvm_unreachable("Should never hit this");
 }

--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -871,13 +871,7 @@ static Optional<BorrowScopeIntroducingValue>
 getUniqueBorrowScopeIntroducingValue(SILValue value) {
   assert(value.getOwnershipKind() == ValueOwnershipKind::Guaranteed &&
          "parameter must be a guarenteed value");
-  SmallVector<BorrowScopeIntroducingValue, 4> borrowIntroducers;
-  getUnderlyingBorrowIntroducingValues(value, borrowIntroducers);
-  assert(borrowIntroducers.size() > 0 &&
-         "folding guaranteed value with no borrow introducer");
-  if (borrowIntroducers.size() > 1)
-    return None;
-  return borrowIntroducers[0];
+  return getSingleBorrowIntroducingValue(value);
 }
 
 /// Replace all uses of \c originalVal by \c foldedVal and adjust lifetimes of

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -609,7 +609,7 @@ SILValue AvailableValueAggregator::aggregateValues(SILType LoadTy,
       result = builder.emitCopyValueOperation(Loc, borrowedResult);
       SmallVector<BorrowScopeIntroducingValue, 4> introducers;
       bool foundIntroducers =
-          getUnderlyingBorrowIntroducingValues(borrowedResult, introducers);
+          getAllBorrowIntroducingValues(borrowedResult, introducers);
       (void)foundIntroducers;
       assert(foundIntroducers);
       for (auto value : introducers) {
@@ -631,7 +631,7 @@ SILValue AvailableValueAggregator::aggregateValues(SILType LoadTy,
       result = builder.emitCopyValueOperation(Loc, borrowedResult);
       SmallVector<BorrowScopeIntroducingValue, 4> introducers;
       bool foundIntroducers =
-          getUnderlyingBorrowIntroducingValues(borrowedResult, introducers);
+          getAllBorrowIntroducingValues(borrowedResult, introducers);
       (void)foundIntroducers;
       assert(foundIntroducers);
       for (auto value : introducers) {

--- a/lib/SILOptimizer/Transforms/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Transforms/SemanticARCOpts.cpp
@@ -657,8 +657,10 @@ bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(CopyValueInst
   // Find all borrow introducers for our copy operand. If we are unable to find
   // all of the reproducers (due to pattern matching failure), conservatively
   // return false. We can not optimize.
-  if (!getUnderlyingBorrowIntroducingValues(cvi->getOperand(),
-                                            borrowScopeIntroducers))
+  //
+  // NOTE: We can get multiple introducers if our copy_value's operand
+  // value runs through a phi or an aggregate forming instruction.
+  if (!getAllBorrowIntroducingValues(cvi->getOperand(), borrowScopeIntroducers))
     return false;
 
   // Then go over all of our uses and see if the value returned by our copy


### PR DESCRIPTION
I also added a comment to getAllBorrowIntroducingValues(...) that explained the
situations where one could have multiple borrow introducing values:

1. True phi arguments.
2. Aggregate forming instructions.
