### PR TITLE
[semantic-arc-opts] Shrink size of arrays in LiveRange.

### DIFF
--- a/lib/SILOptimizer/Transforms/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Transforms/SemanticARCOpts.cpp
@@ -46,16 +46,16 @@ namespace {
 
 class LiveRange {
   /// A list of destroy_values of the live range.
-  SmallVector<SILInstruction *, 16> destroys;
+  SmallVector<SILInstruction *, 2> destroys;
 
   /// A list of forwarding instructions that forward our destroys ownership, but
   /// that are also able to forward guaranteed ownership.
-  SmallVector<SILInstruction *, 16> generalForwardingInsts;
+  SmallVector<SILInstruction *, 2> generalForwardingInsts;
 
   /// Consuming users that we were not able to understand as a forwarding
   /// instruction or a destroy_value. These must be passed a strongly control
   /// equivalent +1 value.
-  SmallVector<SILInstruction *, 16> unknownConsumingUsers;
+  SmallVector<SILInstruction *, 2> unknownConsumingUsers;
 
 public:
   LiveRange(SILValue value);


### PR DESCRIPTION
I looked when building the stdlib/overlays and the vast majority of uses were < 2 for all
of these values, so it makes sense to shrink them.

Part of the reason I am doing this is that I think the pass is starting to
coalesce a little bit and also I want to start optimizing owned phi arguments so
I am going to need to start storing these. I don't want to be storing such large
small arrays in any data structure anywhere.
