### PR TITLE
[test] remove xfail on validation-test/SIL/verify_all_overlays.py

### DIFF
--- a/validation-test/SIL/verify_all_overlays.py
+++ b/validation-test/SIL/verify_all_overlays.py
@@ -7,7 +7,6 @@
 # REQUIRES: long_test
 # REQUIRES: nonexecutable_test
 
-# XFAIL: OS=macosx
 # https://bugs.swift.org/browse/SR-9847
 
 from __future__ import print_function


### PR DESCRIPTION
Looks like it started passing:
https://ci.swift.org/job/oss-swift_tools-RA_stdlib-RDA_long-test/3521/