### PR TITLE
[ConstraintSystem] Don't record general contextual mismatch if there are restrictions present

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1878,6 +1878,12 @@ bool ContextualFailure::diagnoseAsError() {
     if (diagnoseCoercionToUnrelatedType())
       return true;
 
+    if (isa<OptionalTryExpr>(anchor)) {
+      emitDiagnostic(anchor->getLoc(), diag::cannot_convert_initializer_value,
+                     getFromType(), getToType());
+      return true;
+    }
+
     return false;
   }
 

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -234,18 +234,15 @@ bool ConstraintLocator::isForContextualType() const {
 }
 
 bool ConstraintLocator::isForAssignment() const {
-  auto *anchor = getAnchor();
-  return anchor && isa<AssignExpr>(anchor) && getPath().empty();
+  return directlyAt<AssignExpr>();
 }
 
 bool ConstraintLocator::isForCoercion() const {
-  auto *anchor = getAnchor();
-  return anchor && isa<CoerceExpr>(anchor) && getPath().empty();
+  return directlyAt<CoerceExpr>();
 }
 
 bool ConstraintLocator::isForOptionalTry() const {
-  auto *anchor = getAnchor();
-  return anchor && isa<OptionalTryExpr>(anchor) && getPath().empty();
+  return directlyAt<OptionalTryExpr>();
 }
 
 GenericTypeParamType *ConstraintLocator::getGenericParameter() const {

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -243,6 +243,11 @@ bool ConstraintLocator::isForCoercion() const {
   return anchor && isa<CoerceExpr>(anchor) && getPath().empty();
 }
 
+bool ConstraintLocator::isForOptionalTry() const {
+  auto *anchor = getAnchor();
+  return anchor && isa<OptionalTryExpr>(anchor) && getPath().empty();
+}
+
 GenericTypeParamType *ConstraintLocator::getGenericParameter() const {
   // Check whether we have a path that terminates at a generic parameter.
   return isForGenericParameter() ?

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -374,6 +374,12 @@ public:
   /// Determine whether this locator points to the `try?` expression.
   bool isForOptionalTry() const;
 
+  /// Determine whether this locator points directly to a given expression.
+  template <class E> bool directlyAt() const {
+    auto *anchor = getAnchor();
+    return anchor && isa<E>(anchor) && getPath().empty();
+  }
+
   /// Attempts to cast the first path element of the locator to a specific
   /// \c LocatorPathElt subclass, returning \c None if either unsuccessful or
   /// the locator has no path elements.

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -371,6 +371,9 @@ public:
   /// Determine whether this locator points to the coercion expression.
   bool isForCoercion() const;
 
+  /// Determine whether this locator points to the `try?` expression.
+  bool isForOptionalTry() const;
+
   /// Attempts to cast the first path element of the locator to a specific
   /// \c LocatorPathElt subclass, returning \c None if either unsuccessful or
   /// the locator has no path elements.

--- a/test/Constraints/enum_cases.swift
+++ b/test/Constraints/enum_cases.swift
@@ -93,17 +93,16 @@ foo(Foo.a, Foo.b) // Ok in Swift 4 because we strip labels from the arguments
 
 // rdar://problem/32551313 - Useless SE-0110 diagnostic
 
-enum E_32551313<L, R> { // expected-note {{'R' declared as parameter to type 'E_32551313'}}
+enum E_32551313<L, R> {
   case Left(L)
   case Right(R)
 }
 
 struct Foo_32551313 {
-  // FIXME(diagnostics): We should be able to figure out L and R from contextual type
   static func bar() -> E_32551313<(String, Foo_32551313?), (String, String)>? {
-    return E_32551313.Left("", Foo_32551313()) // expected-error {{extra argument in call}}
-    // expected-error@-1 {{generic parameter 'R' could not be inferred}} expected-note@-1 {{explicitly specify the generic arguments to fix this issue}}
-    // expected-error@-2 {{cannot convert return expression of type 'E_32551313<String, R>' to return type 'E_32551313<(String, Foo_32551313?), (String, String)>?'}}
+    return E_32551313.Left("", Foo_32551313())
+    // expected-error@-1 {{cannot convert value of type 'String' to expected argument type '(String, Foo_32551313?)'}}
+    // expected-error@-2 {{extra argument in call}}
   }
 }
 

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -159,17 +159,15 @@ struct Q {
 }
 let q = Q(s: nil)
 let a: Int? = q.s.utf8 // expected-error{{value of optional type 'String?' must be unwrapped to refer to member 'utf8' of wrapped base type 'String'}}
-// expected-error@-1 {{cannot convert value of type 'String.UTF8View' to specified type 'Int?'}}
+// expected-error@-1 {{cannot convert value of type 'String.UTF8View?' to specified type 'Int?'}}
 // expected-note@-2{{chain the optional using '?'}}{{18-18=?}}
-// expected-note@-3{{force-unwrap using '!'}}{{18-18=!}}
 let b: Int = q.s.utf8 // expected-error{{value of optional type 'String?' must be unwrapped to refer to member 'utf8' of wrapped base type 'String'}}
 // expected-error@-1 {{cannot convert value of type 'String.UTF8View' to specified type 'Int'}}
 // expected-note@-2{{chain the optional using '?'}}{{17-17=?}}
 // expected-note@-3{{force-unwrap using '!'}}{{17-17=!}}
 let d: Int! = q.s.utf8 // expected-error{{value of optional type 'String?' must be unwrapped to refer to member 'utf8' of wrapped base type 'String'}}
-// expected-error@-1 {{cannot convert value of type 'String.UTF8View' to specified type 'Int?'}}
+// expected-error@-1 {{cannot convert value of type 'String.UTF8View?' to specified type 'Int?'}}
 // expected-note@-2{{chain the optional using '?'}}{{18-18=?}}
-// expected-note@-3{{force-unwrap using '!'}}{{18-18=!}}
 let c = q.s.utf8 // expected-error{{value of optional type 'String?' must be unwrapped to refer to member 'utf8' of wrapped base type 'String'}}
 // expected-note@-1{{chain the optional using '?' to access member 'utf8' only for non-'nil' base values}}{{12-12=?}}
 // expected-note@-2{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}{{12-12=!}}

--- a/test/Constraints/function_conversion.swift
+++ b/test/Constraints/function_conversion.swift
@@ -63,3 +63,8 @@ noEscapeParam = escapingParam // expected-error {{converting non-escaping value 
 
 escapingParam = takesAny
 noEscapeParam = takesAny // expected-error {{converting non-escaping value to 'Any' may allow it to escape}}
+
+// rdar://problem/59773317 - Improve type error message when returning (or escaping) a function-typed value as an optional of that type
+func rdar_59773317(x: () -> Int) -> (() -> Int)? { // expected-note {{parameter 'x' is implicitly non-escaping}}
+  return x // expected-error {{using non-escaping parameter 'x' in a context expecting an @escaping closure}}
+}

--- a/test/FixCode/fixits-apply-objc.swift.result
+++ b/test/FixCode/fixits-apply-objc.swift.result
@@ -107,5 +107,5 @@ func foo1(_ an : Any) {
 }
 
 func foo2(_ messageData: Any?) -> AnyObject? {
-  return messageData as AnyObject?
+  return messageData as AnyObject
 }


### PR DESCRIPTION
If there are any conversion restrictions present while trying to repair
failures related to contextual type, let's give `simplifyRestrictedConstraintImpl`
a chance to run and fix the problem.

Resolves: rdar://problem/59773317

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
