### PR TITLE
ABI checker: remove assert-only decls from the generated stdlib ABI baseline

### DIFF
--- a/test/api-digester/Outputs/stability-stdlib-abi.asserts.additional.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.asserts.additional.swift.expected
@@ -1,1 +1,7 @@
-
+Func _collectReferencesInsideObject(_:) is a new API without @available attribute
+Func _loadDestroyTLSCounter() is a new API without @available attribute
+Func _measureRuntimeFunctionCountersDiffs(objects:_:) is a new API without @available attribute
+Protocol _RuntimeFunctionCountersStats is a new API without @available attribute
+Struct _GlobalRuntimeFunctionCountersState is a new API without @available attribute
+Struct _ObjectRuntimeFunctionCountersState is a new API without @available attribute
+Struct _RuntimeFunctionCounters is a new API without @available attribute

--- a/test/api-digester/stability-stdlib-abi-without-asserts.swift
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar59812778
 // REQUIRES: OS=macosx
 // REQUIRES: swift_stdlib_no_asserts
 // RUN: %empty-directory(%t.tmp)


### PR DESCRIPTION
rdar://59772479
