### PR TITLE
[Typechecker] Diagnose key paths with contextual root type but no leading dot

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -577,6 +577,9 @@ ERROR(expr_swift_keypath_invalid_component,none,
       "invalid component of Swift key path", ())
 ERROR(expr_swift_keypath_not_starting_with_type,none,
       "a Swift key path must begin with a type", ())
+ERROR(expr_swift_keypath_not_starting_with_dot,none,
+      "a Swift key path with contextual root must begin with a leading dot",
+      ())
 ERROR(expr_smart_keypath_value_covert_to_contextual_type,none,
       "key path value type %0 cannot be converted to contextual type %1",
       (Type, Type))

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1774,15 +1774,30 @@ void PreCheckExpression::resolveKeyPathExpr(KeyPathExpr *KPE) {
   auto traversePath = [&](Expr *expr, bool isInParsedPath,
                           bool emitErrors = true) {
     Expr *outermostExpr = expr;
+    // We can end up in scenarios where the key path has contextual type,
+    // but is missing a leading dot. This can happen when we have an
+    // implicit TypeExpr or an implicit DeclRefExpr.
+    auto diagnoseMissingDot = [&]() {
+      DE.diagnose(expr->getLoc(),
+                  diag::expr_swift_keypath_not_starting_with_dot)
+          .fixItInsert(expr->getStartLoc(), ".");
+    };
     while (1) {
       // Base cases: we've reached the top.
       if (auto TE = dyn_cast<TypeExpr>(expr)) {
         assert(!isInParsedPath);
         rootType = TE->getTypeRepr();
+        if (TE->isImplicit()) {
+          diagnoseMissingDot();
+        }
         return;
       } else if (isa<KeyPathDotExpr>(expr)) {
         assert(isInParsedPath);
         // Nothing here: the type is either the root, or is inferred.
+        return;
+      } else if (expr->isImplicit() && isa<DeclRefExpr>(expr)) {
+        assert(!isInParsedPath);
+        diagnoseMissingDot();
         return;
       }
 

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -864,6 +864,25 @@ func sr11562() {
   // expected-error@-1 {{subscript index of type '(Int, Int)' in a key path must be Hashable}}
 }
 
+// SR-12290: Ban keypaths with contextual root and without a leading dot
+struct SR_12290 {
+  let property: [Int] = []
+  let kp1: KeyPath<SR_12290, Int> = \property.count // expected-error {{a Swift key path with contextual root must begin with a leading dot}}{{38-38=.}}
+  let kp2: KeyPath<SR_12290, Int> = \.property.count // Ok
+  let kp3: KeyPath<SR_12290, Int> = \SR_12290.property.count // Ok
+
+  func foo1(_: KeyPath<SR_12290, Int> = \property.count) {} // expected-error {{a Swift key path with contextual root must begin with a leading dot}}{{42-42=.}}
+  func foo2(_: KeyPath<SR_12290, Int> = \.property.count) {} // Ok
+  func foo3(_: KeyPath<SR_12290, Int> = \SR_12290.property.count) {} // Ok
+
+  func foo4<T>(_: KeyPath<SR_12290, T>) {}
+  func useFoo4() {
+    foo4(\property.count) // expected-error {{a Swift key path with contextual root must begin with a leading dot}}{{11-11=.}}
+    foo4(\.property.count) // Ok
+    foo4(\SR_12290.property.count) // Ok
+  }
+}
+
 func testSyntaxErrors() { // expected-note{{}}
   _ = \.  ; // expected-error{{expected member name following '.'}}
   _ = \.a ;


### PR DESCRIPTION
If a Swift key path has root type inferred but does not have a leading dot, then diagnose it, because it's not valid. For example:

```swift
struct Foo {
  let property: [Int] = []
  let kp: KeyPath<Foo, Int> = \property.count // error
}
```

The key path's path starts with an _implicit_ `TypeExpr`/`DeclRefExpr` as root, which only happens if the type is supposed to be inferred and the leading dot is missing. In all other scenarios, we have either an _implicit_ `KeyPathDotExpr` or an _explicit_ `TypeExpr`. So, I use this information to detect this scenario and diagnose.

Resolves SR-12290
Resolves rdar://problem/59874355