### PR TITLE
Move parsing flags onto SourceFile

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -569,6 +569,10 @@ public:
 
   bool isSuitableForASTScopes() const { return canBeParsedInFull(); }
 
+  /// Whether the bodies of types and functions within this file can be lazily
+  /// parsed.
+  bool hasDelayedBodyParsing() const;
+
   syntax::SourceFileSyntax getSyntaxRoot() const;
   void setSyntaxRoot(syntax::SourceFileSyntax &&Root);
   bool hasSyntaxRoot() const;

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -632,7 +632,8 @@ private:
   SourceFile *
   createSourceFileForMainModule(SourceFileKind FileKind,
                                 SourceFile::ImplicitModuleImportKind ImportKind,
-                                Optional<unsigned> BufferID);
+                                Optional<unsigned> BufferID,
+                                SourceFile::ParsingOptions options = {});
 
 public:
   void freeASTContext();

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -173,9 +173,9 @@ public:
 
   LocalContext *CurLocalContext = nullptr;
 
-  bool isDelayedParsingEnabled() const {
-    return DelayBodyParsing || isCodeCompletionFirstPass();
-  }
+  /// Whether we should delay parsing nominal type, extension, and function
+  /// bodies.
+  bool isDelayedParsingEnabled() const;
 
   void setCodeCompletionCallbacks(CodeCompletionCallbacks *Callbacks) {
     CodeCompletion = Callbacks;
@@ -212,16 +212,6 @@ public:
   /// trailing trivias for \c Tok.
   /// Always empty if !SF.shouldBuildSyntaxTree().
   ParsedTrivia TrailingTrivia;
-
-  /// Whether we should delay parsing nominal type and extension bodies,
-  /// and skip function bodies.
-  ///
-  /// This is false in primary files, since we want to type check all
-  /// declarations and function bodies.
-  ///
-  /// This is true for non-primary files, where declarations only need to be
-  /// lazily parsed and type checked.
-  bool DelayBodyParsing;
 
   /// Whether to evaluate the conditions of #if decls, meaning that the bodies
   /// of any active clauses are hoisted such that they become sibling nodes with
@@ -408,16 +398,16 @@ public:
          SILParserTUStateBase *SIL,
          PersistentParserState *PersistentState,
          std::shared_ptr<SyntaxParseActions> SPActions = nullptr,
-         bool DelayBodyParsing = true, bool EvaluateConditionals = true);
+         bool EvaluateConditionals = true);
   Parser(unsigned BufferID, SourceFile &SF, SILParserTUStateBase *SIL,
          PersistentParserState *PersistentState = nullptr,
          std::shared_ptr<SyntaxParseActions> SPActions = nullptr,
-         bool DelayBodyParsing = true, bool EvaluateConditionals = true);
+         bool EvaluateConditionals = true);
   Parser(std::unique_ptr<Lexer> Lex, SourceFile &SF,
          SILParserTUStateBase *SIL = nullptr,
          PersistentParserState *PersistentState = nullptr,
          std::shared_ptr<SyntaxParseActions> SPActions = nullptr,
-         bool DelayBodyParsing = true, bool EvaluateConditionals = true);
+         bool EvaluateConditionals = true);
   ~Parser();
 
   /// Returns true if the buffer being parsed is allowed to contain SIL.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -177,6 +177,11 @@ public:
   /// bodies.
   bool isDelayedParsingEnabled() const;
 
+  /// Whether to evaluate the conditions of #if decls, meaning that the bodies
+  /// of any active clauses are hoisted such that they become sibling nodes with
+  /// the #if decl.
+  bool shouldEvaluatePoundIfDecls() const;
+
   void setCodeCompletionCallbacks(CodeCompletionCallbacks *Callbacks) {
     CodeCompletion = Callbacks;
   }
@@ -212,13 +217,6 @@ public:
   /// trailing trivias for \c Tok.
   /// Always empty if !SF.shouldBuildSyntaxTree().
   ParsedTrivia TrailingTrivia;
-
-  /// Whether to evaluate the conditions of #if decls, meaning that the bodies
-  /// of any active clauses are hoisted such that they become sibling nodes with
-  /// the #if decl.
-  // FIXME: When condition evaluation moves to a later phase, remove this bit
-  // and adjust the client call 'performParseOnly'.
-  bool EvaluateConditionals;
 
   /// The receiver to collect all consumed tokens.
   ConsumeTokenReceiver *TokReceiver;
@@ -397,17 +395,14 @@ public:
   Parser(unsigned BufferID, SourceFile &SF, DiagnosticEngine* LexerDiags,
          SILParserTUStateBase *SIL,
          PersistentParserState *PersistentState,
-         std::shared_ptr<SyntaxParseActions> SPActions = nullptr,
-         bool EvaluateConditionals = true);
+         std::shared_ptr<SyntaxParseActions> SPActions = nullptr);
   Parser(unsigned BufferID, SourceFile &SF, SILParserTUStateBase *SIL,
          PersistentParserState *PersistentState = nullptr,
-         std::shared_ptr<SyntaxParseActions> SPActions = nullptr,
-         bool EvaluateConditionals = true);
+         std::shared_ptr<SyntaxParseActions> SPActions = nullptr);
   Parser(std::unique_ptr<Lexer> Lex, SourceFile &SF,
          SILParserTUStateBase *SIL = nullptr,
          PersistentParserState *PersistentState = nullptr,
-         std::shared_ptr<SyntaxParseActions> SPActions = nullptr,
-         bool EvaluateConditionals = true);
+         std::shared_ptr<SyntaxParseActions> SPActions = nullptr);
   ~Parser();
 
   /// Returns true if the buffer being parsed is allowed to contain SIL.

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -108,8 +108,7 @@ namespace swift {
   /// \param SF The file within the module being parsed.
   ///
   /// \param BufferID The buffer to parse from.
-  void parseIntoSourceFile(SourceFile &SF, unsigned BufferID,
-                           bool EvaluateConditionals = true);
+  void parseIntoSourceFile(SourceFile &SF, unsigned BufferID);
 
   /// Parse a source file's SIL declarations into a given SIL module.
   void parseSourceFileSIL(SourceFile &SF, SILParserState *sil);

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -108,11 +108,7 @@ namespace swift {
   /// \param SF The file within the module being parsed.
   ///
   /// \param BufferID The buffer to parse from.
-  ///
-  /// \param DelayBodyParsing Whether parsing of type and function bodies can be
-  /// delayed.
   void parseIntoSourceFile(SourceFile &SF, unsigned BufferID,
-                           bool DelayBodyParsing = true,
                            bool EvaluateConditionals = true);
 
   /// Parse a source file's SIL declarations into a given SIL module.

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1896,10 +1896,11 @@ static void performAutoImport(
 SourceFile::SourceFile(ModuleDecl &M, SourceFileKind K,
                        Optional<unsigned> bufferID,
                        ImplicitModuleImportKind ModImpKind,
-                       bool KeepParsedTokens, bool BuildSyntaxTree)
-  : FileUnit(FileUnitKind::Source, M),
-    BufferID(bufferID ? *bufferID : -1),
-    Kind(K), SyntaxInfo(new SourceFileSyntaxInfo(BuildSyntaxTree)) {
+                       bool KeepParsedTokens, bool BuildSyntaxTree,
+                       ParsingOptions parsingOpts)
+    : FileUnit(FileUnitKind::Source, M), BufferID(bufferID ? *bufferID : -1),
+      ParsingOpts(parsingOpts), Kind(K),
+      SyntaxInfo(new SourceFileSyntaxInfo(BuildSyntaxTree)) {
   M.getASTContext().addDestructorCleanup(*this);
   performAutoImport(*this, ModImpKind);
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1954,6 +1954,23 @@ bool SourceFile::canBeParsedInFull() const {
   llvm_unreachable("unhandled kind");
 }
 
+bool SourceFile::hasDelayedBodyParsing() const {
+  if (ParsingOpts.contains(ParsingFlags::DisableDelayedBodies))
+    return false;
+
+  // Not supported right now.
+  if (Kind == SourceFileKind::REPL || Kind == SourceFileKind::SIL)
+    return false;
+  if (hasInterfaceHash())
+    return false;
+  if (shouldCollectToken())
+    return false;
+  if (shouldBuildSyntaxTree())
+    return false;
+
+  return true;
+}
+
 bool FileUnit::walk(ASTWalker &walker) {
   SmallVector<Decl *, 64> Decls;
   getTopLevelDecls(Decls);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -970,16 +970,7 @@ void CompilerInstance::parseLibraryFile(
       SourceFileKind::Library, implicitImports.kind, BufferID);
   addAdditionalInitialImportsTo(NextInput, implicitImports);
 
-  auto IsPrimary = isWholeModuleCompilation() || isPrimaryInput(BufferID);
-
-  auto &Diags = NextInput->getASTContext().Diags;
-  auto DidSuppressWarnings = Diags.getSuppressWarnings();
-  Diags.setSuppressWarnings(DidSuppressWarnings || !IsPrimary);
-
   parseIntoSourceFile(*NextInput, BufferID);
-
-  Diags.setSuppressWarnings(DidSuppressWarnings);
-
   performNameBinding(*NextInput);
 }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1147,7 +1147,7 @@ void CompilerInstance::performParseOnly(bool EvaluateConditionals,
         SourceFileKind::Library, SourceFile::ImplicitModuleImportKind::None,
         BufferID, parsingOpts);
 
-    parseIntoSourceFile(*NextInput, BufferID, EvaluateConditionals);
+    parseIntoSourceFile(*NextInput, BufferID);
   }
 
   // Now parse the main file.
@@ -1157,7 +1157,7 @@ void CompilerInstance::performParseOnly(bool EvaluateConditionals,
     MainFile.SyntaxParsingCache = Invocation.getMainFileSyntaxParsingCache();
     assert(MainBufferID == MainFile.getBufferID());
 
-    parseIntoSourceFile(MainFile, MainBufferID, EvaluateConditionals);
+    parseIntoSourceFile(MainFile, MainBufferID);
   }
 
   assert(Context->LoadedModules.size() == 1 &&

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4569,7 +4569,7 @@ Parser::parseDeclList(SourceLoc LBLoc, SourceLoc &RBLoc, Diag<> ErrorDiag,
 bool Parser::canDelayMemberDeclParsing(bool &HasOperatorDeclarations,
                                        bool &HasNestedClassDeclarations) {
   // If explicitly disabled, respect the flag.
-  if (!DelayBodyParsing)
+  if (!isDelayedParsingEnabled())
     return false;
   // Recovering parser status later for #sourceLocation is not-trivial and
   // it may not worth it.
@@ -6449,7 +6449,10 @@ void Parser::parseAbstractFunctionBody(AbstractFunctionDecl *AFD) {
 
   llvm::SaveAndRestore<NullablePtr<llvm::MD5>> T(CurrentTokenHash, nullptr);
 
-  if (isDelayedParsingEnabled()) {
+  // If we can delay parsing this body, or this is the first pass of code
+  // completion, skip until the end. If we encounter a code completion token
+  // while skipping, we'll make a note of it.
+  if (isDelayedParsingEnabled() || isCodeCompletionFirstPass()) {
     consumeAbstractFunctionBody(AFD, AFD->getAttrs());
     return;
   }

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -609,7 +609,7 @@ ParserResult<IfConfigDecl> Parser::parseIfConfig(
 
   bool shouldEvaluate =
       // Don't evaluate if it's in '-parse' mode, etc.
-      EvaluateConditionals &&
+      shouldEvaluatePoundIfDecls() &&
       // If it's in inactive #if ... #endif block, there's no point to do it.
       !getScopeInfo().isInactiveConfigBlock();
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1174,7 +1174,8 @@ struct ParserUnit::Implementation {
         SF(new (Ctx) SourceFile(
             *ModuleDecl::create(Ctx.getIdentifier(ModuleName), Ctx), SFKind,
             BufferID, SourceFile::ImplicitModuleImportKind::None,
-            Opts.CollectParsedToken, Opts.BuildSyntaxTree)) {}
+            Opts.CollectParsedToken, Opts.BuildSyntaxTree,
+            SourceFile::ParsingFlags::DisableDelayedBodies)) {}
 
   ~Implementation() {
     // We need to delete the parser before the context so that it can finalize

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -120,7 +120,6 @@ static void deletePersistentParserState(PersistentParserState *state) {
 }
 
 void swift::parseIntoSourceFile(SourceFile &SF, unsigned int BufferID,
-                                bool DelayBodyParsing,
                                 bool EvaluateConditionals) {
   auto &ctx = SF.getASTContext();
   std::shared_ptr<SyntaxTreeCreator> STreeCreator;
@@ -129,16 +128,6 @@ void swift::parseIntoSourceFile(SourceFile &SF, unsigned int BufferID,
         SF.getASTContext().SourceMgr, BufferID,
         SF.SyntaxParsingCache, SF.getASTContext().getSyntaxArena());
   }
-
-  // Not supported right now.
-  if (SF.Kind == SourceFileKind::REPL)
-    DelayBodyParsing = false;
-  if (SF.hasInterfaceHash())
-    DelayBodyParsing = false;
-  if (SF.shouldCollectToken())
-    DelayBodyParsing = false;
-  if (SF.shouldBuildSyntaxTree())
-    DelayBodyParsing = false;
 
   // If this buffer is for code completion, hook up the state needed by its
   // second pass.
@@ -150,7 +139,7 @@ void swift::parseIntoSourceFile(SourceFile &SF, unsigned int BufferID,
 
   FrontendStatsTracer tracer(SF.getASTContext().Stats,
                              "Parsing");
-  Parser P(BufferID, SF, /*SIL*/ nullptr, state, STreeCreator, DelayBodyParsing,
+  Parser P(BufferID, SF, /*SIL*/ nullptr, state, STreeCreator,
            EvaluateConditionals);
   PrettyStackTraceParser StackTrace(P);
 
@@ -172,7 +161,7 @@ void swift::parseSourceFileSIL(SourceFile &SF, SILParserState *sil) {
                              "Parsing SIL");
   Parser parser(*bufferID, SF, sil->Impl.get(),
                 /*persistentParserState*/ nullptr,
-                /*syntaxTreeCreator*/ nullptr, /*delayBodyParsing*/ false);
+                /*syntaxTreeCreator*/ nullptr);
   PrettyStackTraceParser StackTrace(parser);
   parser.parseTopLevelSIL();
 }

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -119,8 +119,7 @@ static void deletePersistentParserState(PersistentParserState *state) {
   delete state;
 }
 
-void swift::parseIntoSourceFile(SourceFile &SF, unsigned int BufferID,
-                                bool EvaluateConditionals) {
+void swift::parseIntoSourceFile(SourceFile &SF, unsigned int BufferID) {
   auto &ctx = SF.getASTContext();
   std::shared_ptr<SyntaxTreeCreator> STreeCreator;
   if (SF.shouldBuildSyntaxTree()) {
@@ -139,8 +138,7 @@ void swift::parseIntoSourceFile(SourceFile &SF, unsigned int BufferID,
 
   FrontendStatsTracer tracer(SF.getASTContext().Stats,
                              "Parsing");
-  Parser P(BufferID, SF, /*SIL*/ nullptr, state, STreeCreator,
-           EvaluateConditionals);
+  Parser P(BufferID, SF, /*SIL*/ nullptr, state, STreeCreator);
   PrettyStackTraceParser StackTrace(P);
 
   llvm::SaveAndRestore<NullablePtr<llvm::MD5>> S(P.CurrentTokenHash,

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -128,6 +128,15 @@ void swift::parseIntoSourceFile(SourceFile &SF, unsigned int BufferID) {
         SF.SyntaxParsingCache, SF.getASTContext().getSyntaxArena());
   }
 
+  // If we've been asked to silence warnings, do so now. This is needed for
+  // secondary files, which can be parsed multiple times.
+  auto &diags = ctx.Diags;
+  auto didSuppressWarnings = diags.getSuppressWarnings();
+  auto shouldSuppress = SF.getParsingOptions().contains(
+      SourceFile::ParsingFlags::SuppressWarnings);
+  diags.setSuppressWarnings(didSuppressWarnings || shouldSuppress);
+  SWIFT_DEFER { diags.setSuppressWarnings(didSuppressWarnings); };
+
   // If this buffer is for code completion, hook up the state needed by its
   // second pass.
   PersistentParserState *state = nullptr;

--- a/test/swift-indent/main.swift
+++ b/test/swift-indent/main.swift
@@ -34,3 +34,11 @@ break
            collatz(r)
     }
 }
+
+  #if true
+   func foo() -> Int {
+        0
+     }
+ #else
+   1
+     #endif

--- a/test/swift-indent/main.swift.indent2.response
+++ b/test/swift-indent/main.swift.indent2.response
@@ -34,3 +34,11 @@ func collatz(n: Int, m: String?) {
     collatz(r)
   }
 }
+
+#if true
+func foo() -> Int {
+  0
+}
+#else
+1
+#endif

--- a/test/swift-indent/main.swift.indentswitch.response
+++ b/test/swift-indent/main.swift.indentswitch.response
@@ -34,3 +34,11 @@ func collatz(n: Int, m: String?) {
         collatz(r)
     }
 }
+
+#if true
+func foo() -> Int {
+    0
+}
+#else
+1
+#endif

--- a/test/swift-indent/main.swift.lines.response
+++ b/test/swift-indent/main.swift.lines.response
@@ -34,3 +34,11 @@ break
            collatz(r)
     }
 }
+
+  #if true
+   func foo() -> Int {
+        0
+     }
+ #else
+   1
+     #endif

--- a/test/swift-indent/main.swift.response
+++ b/test/swift-indent/main.swift.response
@@ -34,3 +34,11 @@ func collatz(n: Int, m: String?) {
         collatz(r)
     }
 }
+
+#if true
+func foo() -> Int {
+    0
+}
+#else
+1
+#endif

--- a/test/swift-indent/main.swift.tabs.response
+++ b/test/swift-indent/main.swift.tabs.response
@@ -34,3 +34,11 @@ func collatz(n: Int, m: String?) {
 		collatz(r)
 	}
 }
+
+#if true
+func foo() -> Int {
+	0
+}
+#else
+1
+#endif

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -714,9 +714,6 @@ public:
         Parser->getParser().Context.evaluator);
     Parser->getDiagnosticEngine().addConsumer(DiagConsumer);
 
-    // Collecting syntactic information shouldn't evaluate # conditions.
-    Parser->getParser().EvaluateConditionals = false;
-
     // If there is a syntax parsing cache, incremental syntax parsing is
     // performed and thus the generated AST may not be up-to-date.
     HasUpToDateAST = CompInv.getMainFileSyntaxParsingCache() == nullptr;

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -289,8 +289,6 @@ swiftparse_client_node_t SynParser::parse(const char *source) {
   ParserUnit PU(SM, SourceFileKind::Main, bufID, langOpts, tyckOpts,
                 "syntax_parse_module", std::move(parseActions),
                 /*SyntaxCache=*/nullptr);
-  // Evaluating pound conditions may lead to unknown syntax.
-  PU.getParser().EvaluateConditionals = false;
   std::unique_ptr<SynParserDiagConsumer> pConsumer;
   if (DiagHandler) {
     pConsumer = std::make_unique<SynParserDiagConsumer>(*this, bufID);

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1123,8 +1123,6 @@ static int doSyntaxColoring(const CompilerInvocation &InitInvok,
     registerParseRequestFunctions(Parser.getParser().Context.evaluator);
     registerTypeCheckerRequestFunctions(Parser.getParser().Context.evaluator);
 
-    // Collecting syntactic information shouldn't evaluate # conditions.
-    Parser.getParser().EvaluateConditionals = false;
     Parser.getDiagnosticEngine().addConsumer(PrintDiags);
 
     (void)Parser.parse();
@@ -1359,9 +1357,6 @@ static int doStructureAnnotation(const CompilerInvocation &InitInvok,
   registerParseRequestFunctions(Parser.getParser().Context.evaluator);
   registerTypeCheckerRequestFunctions(
       Parser.getParser().Context.evaluator);
-
-  // Collecting syntactic information shouldn't evaluate # conditions.
-  Parser.getParser().EvaluateConditionals = false;
 
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;


### PR DESCRIPTION
Move the flags for whether delayed body parsing or `#if` condition is evaluation is disabled from the `Parser` and onto `SourceFile`. This is in preparation for the requestification of source file parsing where the `SourceFile` will need to be able to parse itself on demand.

This PR also changes `ParserUnit` such that it doesn't evaluate `#if` conditions by default, as none of its clients appear to require it. The only client that wasn't explicitly disabling `#if` evaluation and is processing the resulting AST is `swift-indent`, so this PR also adds a test to ensure it continues to work correctly with `#if` decls.