### PR TITLE
[NFC, Incremental] Factor used Decl enumeration in preparation for dependency verifier

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -920,6 +920,9 @@ public:
   /// If this returns true, the decl can be safely casted to ValueDecl.
   bool isPotentiallyOverridable() const;
 
+  /// Returns true if this Decl cannot be seen by any other source file
+  bool isPrivateToEnclosingFile() const;
+
   /// If an alternative module name is specified for this decl, e.g. using
   /// @_originalDefinedIn attribute, this function returns this module name.
   StringRef getAlternateModuleName() const;

--- a/include/swift/AST/FineGrainedDependencies.h
+++ b/include/swift/AST/FineGrainedDependencies.h
@@ -17,6 +17,7 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/NullablePtr.h"
 #include "swift/Basic/Range.h"
+#include "swift/Basic/ReferenceDependencyKeys.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/Support/MD5.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -350,33 +351,6 @@ bool emitReferenceDependencies(DiagnosticEngine &diags, SourceFile *SF,
 // MARK: Enums
 //==============================================================================
 
-/// Encode the current sorts of dependencies as kinds of nodes in the dependency
-/// graph, splitting the current *member* into \ref member and \ref
-/// potentialMember and adding \ref sourceFileProvide.
-
-enum class NodeKind {
-  topLevel,
-  nominal,
-  /// In the status quo scheme, *member* dependencies could have blank names
-  /// for the member, to indicate that the provider might add members.
-  /// This code uses a separate kind, \ref potentialMember. The holder field is
-  /// unused.
-  potentialMember,
-  /// Corresponding to the status quo *member* dependency with a non-blank
-  /// member.
-  member,
-  dynamicLookup,
-  externalDepend,
-  sourceFileProvide,
-  /// For iterating through the NodeKinds.
-  kindCount
-};
-
-/// Used for printing out NodeKinds to dot files, and dumping nodes for
-/// debugging.
-const std::string NodeKindNames[]{
-    "topLevel",      "nominal",        "potentialMember",  "member",
-    "dynamicLookup", "externalDepend", "sourceFileProvide"};
 
 /// Instead of the status quo scheme of two kinds of "Depends", cascading and
 /// non-cascading this code represents each entity ("Provides" in the status

--- a/include/swift/Basic/ReferenceDependencyKeys.h
+++ b/include/swift/Basic/ReferenceDependencyKeys.h
@@ -33,6 +33,36 @@ static constexpr StringLiteral dependsExternal("depends-external");
 
 static constexpr StringLiteral interfaceHash("interface-hash");
 } // end namespace reference_dependency_keys
+
+namespace fine_grained_dependencies {
+/// Encode the current sorts of dependencies as kinds of nodes in the dependency
+/// graph, splitting the current *member* into \ref member and \ref
+/// potentialMember and adding \ref sourceFileProvide.
+
+enum class NodeKind {
+  topLevel,
+  nominal,
+  /// In the status quo scheme, *member* dependencies could have blank names
+  /// for the member, to indicate that the provider might add members.
+  /// This code uses a separate kind, \ref potentialMember. The holder field is
+  /// unused.
+  potentialMember,
+  /// Corresponding to the status quo *member* dependency with a non-blank
+  /// member.
+  member,
+  dynamicLookup,
+  externalDepend,
+  sourceFileProvide,
+  /// For iterating through the NodeKinds.
+  kindCount
+};
+
+/// Used for printing out NodeKinds to dot files, and dumping nodes for
+/// debugging.
+const std::string NodeKindNames[]{
+    "topLevel",      "nominal",        "potentialMember",  "member",
+    "dynamicLookup", "externalDepend", "sourceFileProvide"};
+} // end namespace fine_grained_dependencies
 } // end namespace swift
 
 #endif

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -66,6 +66,7 @@ add_swift_host_library(swiftAST STATIC
   PrettyStackTrace.cpp
   ProtocolConformance.cpp
   RawComment.cpp
+  ReferencedNameTracker.cpp
   RequirementEnvironment.cpp
   SyntaxASTMap.cpp
   SILLayout.cpp

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8068,3 +8068,26 @@ void swift::simple_display(llvm::raw_ostream &out, AnyFunctionRef fn) {
   else
     out << "closure";
 }
+
+bool Decl::isPrivateToEnclosingFile() const {
+  if (auto *VD = dyn_cast<ValueDecl>(this))
+    return VD->getFormalAccess() <= AccessLevel::FilePrivate;
+  switch (getKind()) {
+  case DeclKind::Import:
+  case DeclKind::PatternBinding:
+  case DeclKind::EnumCase:
+  case DeclKind::TopLevelCode:
+  case DeclKind::IfConfig:
+  case DeclKind::PoundDiagnostic:
+    return true;
+
+  case DeclKind::Extension:
+  case DeclKind::InfixOperator:
+  case DeclKind::PrefixOperator:
+  case DeclKind::PostfixOperator:
+    return false;
+
+  default:
+    llvm_unreachable("everything else is a ValueDecl");
+  }
+}

--- a/lib/AST/ReferencedNameTracker.cpp
+++ b/lib/AST/ReferencedNameTracker.cpp
@@ -1,0 +1,143 @@
+//===---------------------------- ReferencedNameTracker.cpp ---------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// This file implements unqualified lookup, which searches for an identifier
+/// from a given context.
+///
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/ReferencedNameTracker.h"
+
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/ASTMangler.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/DiagnosticsFrontend.h"
+#include "swift/AST/FineGrainedDependencies.h"
+#include "swift/AST/Module.h"
+#include "swift/AST/ModuleLoader.h"
+#include "swift/AST/NameLookup.h"
+#include "swift/AST/SourceFile.h"
+#include "swift/AST/Types.h"
+#include "swift/Basic/FileSystem.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/ReferenceDependencyKeys.h"
+#include "swift/Demangling/Demangle.h"
+#include "swift/Frontend/FrontendOptions.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
+
+using namespace swift;
+using NodeKind = fine_grained_dependencies::NodeKind;
+using EnumerateUsedDecl = ReferencedNameTracker::EnumerateUsedDecl;
+using DependencyKey = fine_grained_dependencies::DependencyKey;
+
+void ReferencedNameTracker::enumerateAllUses(
+    bool includeIntrafileDeps, const DependencyTracker &depTracker,
+    EnumerateUsedDecl enumerateUsedDecl) const {
+  enumerateSimpleUses<NodeKind::topLevel>(getTopLevelNames(),
+                                          enumerateUsedDecl);
+  enumerateSimpleUses<NodeKind::dynamicLookup>(getDynamicLookupNames(),
+                                               enumerateUsedDecl);
+  enumerateExternalUses(depTracker, enumerateUsedDecl);
+  enumerateCompoundUses(includeIntrafileDeps, enumerateUsedDecl);
+}
+
+template <NodeKind kind>
+void ReferencedNameTracker::enumerateSimpleUses(
+    llvm::DenseMap<DeclBaseName, bool> cascadesByName,
+    EnumerateUsedDecl enumerateUsedDecl) const {
+  for (const auto &p : cascadesByName)
+    enumerateUsedDecl(kind, "", p.getFirst().userFacingName(), p.getSecond());
+}
+
+void ReferencedNameTracker::enumerateExternalUses(
+    const DependencyTracker &depTracker,
+    EnumerateUsedDecl enumerateUsedDecl) const {
+  // external dependencies always cascade
+  for (StringRef s : depTracker.getDependencies())
+    enumerateUsedDecl(NodeKind::externalDepend, "", s, true);
+}
+
+void ReferencedNameTracker::enumerateCompoundUses(
+    bool includeIntrafileDeps, EnumerateUsedDecl enumerateUsedDecl) const {
+  enumerateNominalUses(
+      includeIntrafileDeps,
+      std::move(computeHoldersOfCascadingMembers(includeIntrafileDeps)),
+      enumerateUsedDecl);
+  enumerateMemberUses(enumerateUsedDecl);
+}
+
+std::unordered_set<std::string>
+ReferencedNameTracker::computeHoldersOfCascadingMembers(
+    const bool includeIntrafileDeps) const {
+  std::unordered_set<std::string> holdersOfCascadingMembers;
+  for (const auto &p : getUsedMembers()) {
+    {
+      bool isPrivate = p.getFirst().first->isPrivateToEnclosingFile();
+      if (isPrivate && !includeIntrafileDeps)
+        continue;
+    }
+    std::string context =
+        DependencyKey::computeContextForProvidedEntity<NodeKind::nominal>(
+            p.getFirst().first);
+    bool isCascading = p.getSecond();
+    if (isCascading)
+      holdersOfCascadingMembers.insert(context);
+  }
+  return holdersOfCascadingMembers;
+}
+
+void ReferencedNameTracker::enumerateNominalUses(
+    const bool includeIntrafileDeps,
+    const std::unordered_set<std::string> &&holdersOfCascadingMembers,
+    EnumerateUsedDecl enumerateUsedDecl) const {
+  for (const auto &p : getUsedMembers()) {
+    {
+      bool isPrivate = p.getFirst().first->isPrivateToEnclosingFile();
+      if (isPrivate && !includeIntrafileDeps)
+        continue;
+    }
+
+    const NominalTypeDecl *nominal = p.getFirst().first;
+
+    std::string context =
+        DependencyKey::computeContextForProvidedEntity<NodeKind::nominal>(
+            nominal);
+    const bool isCascadingUse = holdersOfCascadingMembers.count(context) != 0;
+    enumerateUsedDecl(NodeKind::nominal, context, "", isCascadingUse);
+  }
+}
+
+void ReferencedNameTracker::enumerateMemberUses(
+    EnumerateUsedDecl enumerateUsedDecl) const {
+  for (const auto &p : getUsedMembers()) {
+    const NominalTypeDecl *nominal = p.getFirst().first;
+    const auto rawName = p.getFirst().second;
+    const bool isPotentialMember = rawName.empty();
+    const bool isCascadingUse = p.getSecond();
+    if (isPotentialMember) {
+      std::string context = DependencyKey::computeContextForProvidedEntity<
+          NodeKind::potentialMember>(nominal);
+      enumerateUsedDecl(NodeKind::potentialMember, context, "", isCascadingUse);
+    } else {
+      std::string context =
+          DependencyKey::computeContextForProvidedEntity<NodeKind::member>(
+              nominal);
+      std::string name = rawName.userFacingName();
+      enumerateUsedDecl(NodeKind::member, context, name, isCascadingUse);
+    }
+  }
+}


### PR DESCRIPTION
@CodaFi 's Dependency verifier will need to do the same enumeration that `FrontendSourceFileDepGraphFactory`does. So, factor out that functionality so it can be used outside of that factory.

rdar://59962406