### PR TITLE
[build] rewrite #21707 so that it doesn't break cross-compilation

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1931,6 +1931,12 @@ function(add_swift_target_library name)
       set(swiftlib_module_dependency_targets)
       set(swiftlib_private_link_libraries_targets)
 
+      if(name STREQUAL swiftCore)
+        # This initializes swiftlib_private_link_libraries_targets for swiftCore,
+        # so don't move it away from the variable declaration just above.
+        swift_core_private_libraries(${sdk} ${arch} swiftlib_private_link_libraries_targets)
+      endif()
+
       if(NOT BUILD_STANDALONE)
         foreach(mod ${swiftlib_module_depends_flattened})
           if(DEFINED maccatalyst_build_flavor)

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -236,23 +236,27 @@ set(SWIFTLIB_GYB_SOURCES
 set(GROUP_INFO_JSON_FILE ${CMAKE_CURRENT_SOURCE_DIR}/GroupInfo.json)
 set(swift_core_link_flags "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}")
 set(swift_core_framework_depends)
-set(swift_core_private_link_libraries)
 set(swift_stdlib_compile_flags "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}")
 
-if(SWIFT_PRIMARY_VARIANT_SDK STREQUAL CYGWIN)
-  # TODO(compnerd) cache this variable to permit re-configuration
-  execute_process(COMMAND "cygpath" "-u" "$ENV{SYSTEMROOT}" OUTPUT_VARIABLE ENV_SYSTEMROOT)
-  list(APPEND swift_core_private_link_libraries "${ENV_SYSTEMROOT}/system32/psapi.dll")
-elseif(SWIFT_PRIMARY_VARIANT_SDK STREQUAL FREEBSD)
-  find_library(EXECINFO_LIBRARY execinfo)
-  list(APPEND swift_core_private_link_libraries ${EXECINFO_LIBRARY})
-elseif(SWIFT_PRIMARY_VARIANT_SDK STREQUAL LINUX)
-  if(SWIFT_BUILD_STATIC_STDLIB)
-    list(APPEND swift_core_private_link_libraries)
+function(swift_core_private_libraries sdk arch libraries_var_name)
+  set(private_link_libraries)
+  if(${sdk} STREQUAL CYGWIN)
+    if(${sdk} STREQUAL ${SWIFT_HOST_VARIANT_SDK})
+      # TODO(compnerd) cache this variable to permit re-configuration
+      execute_process(COMMAND "cygpath" "-u" "$ENV{SYSTEMROOT}" OUTPUT_VARIABLE ENV_SYSTEMROOT)
+      list(APPEND private_link_libraries "${ENV_SYSTEMROOT}/system32/psapi.dll")
+    else()
+      message(FATAL_ERROR "CYGWIN cross-compilation doesn't know where to find psapi.dll.")
+    endif()
+  elseif(${sdk} STREQUAL FREEBSD)
+    find_library(EXECINFO_LIBRARY execinfo)
+    list(APPEND private_link_libraries ${EXECINFO_LIBRARY})
+  elseif(${sdk} STREQUAL WINDOWS)
+    list(APPEND private_link_libraries shell32;DbgHelp)
   endif()
-elseif(SWIFT_PRIMARY_VARIANT_SDK STREQUAL WINDOWS)
-  list(APPEND swift_core_private_link_libraries shell32;DbgHelp)
-endif()
+
+  set(${libraries_var_name} ${private_link_libraries} PARENT_SCOPE)
+endfunction()
 
 option(SWIFT_CHECK_ESSENTIAL_STDLIB
     "Check core standard library layering by linking its essential subset"
@@ -298,8 +302,6 @@ set(swiftCore_common_options
                     ${SWIFTLIB_GYB_SOURCES}
                   LINK_FLAGS
                     ${swift_core_link_flags}
-                  PRIVATE_LINK_LIBRARIES
-                    ${swift_core_private_link_libraries}
                   INCORPORATE_OBJECT_LIBRARIES
                     ${swift_core_incorporate_object_libraries}
                   FRAMEWORK_DEPENDS

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -82,31 +82,6 @@ set(swift_runtime_library_compile_flags ${swift_runtime_compile_flags})
 list(APPEND swift_runtime_library_compile_flags -DswiftCore_EXPORTS)
 list(APPEND swift_runtime_library_compile_flags -I${SWIFT_SOURCE_DIR}/stdlib/include/llvm/Support -I${SWIFT_SOURCE_DIR}/include)
 
-set(sdk "${SWIFT_HOST_VARIANT_SDK}")
-if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
-  set(static_binary_lnk_file_list)
-  string(TOLOWER "${sdk}" lowercase_sdk)
-
-  # Generate the static-executable-args.lnk file used for ELF systems (eg linux)
-  set(linkfile "${lowercase_sdk}/static-executable-args.lnk")
-  add_custom_command_target(swift_static_binary_${sdk}_args
-    COMMAND
-      "${CMAKE_COMMAND}" -E copy
-      "${SWIFT_SOURCE_DIR}/utils/static-executable-args.lnk"
-      "${SWIFTSTATICLIB_DIR}/${linkfile}"
-    OUTPUT
-      "${SWIFTSTATICLIB_DIR}/${linkfile}"
-    DEPENDS
-      "${SWIFT_SOURCE_DIR}/utils/static-executable-args.lnk")
-
-  list(APPEND static_binary_lnk_file_list ${swift_static_binary_${sdk}_args})
-  swift_install_in_component(FILES "${SWIFTSTATICLIB_DIR}/${linkfile}"
-                             DESTINATION "lib/swift_static/${lowercase_sdk}"
-                             COMPONENT stdlib)
-  add_dependencies(stdlib ${static_binary_lnk_file_list})
-  add_custom_target(static_binary_magic ALL DEPENDS ${static_binary_lnk_file_list})
-endif()
-
 add_swift_target_library(swiftRuntime OBJECT_LIBRARY
   ${swift_runtime_sources}
   ${swift_runtime_objc_sources}
@@ -148,6 +123,30 @@ add_swift_target_library(swiftImageRegistrationObjectCOFF
                   INSTALL_IN_COMPONENT none)
 
 foreach(sdk ${SWIFT_SDKS})
+  if(SWIFT_BUILD_STATIC_STDLIB AND "${SWIFT_SDK_${sdk}_OBJECT_FORMAT}" STREQUAL "ELF")
+    set(static_binary_lnk_file_list)
+    string(TOLOWER "${sdk}" lowercase_sdk)
+
+    # Generate the static-executable-args.lnk file used for ELF systems (eg linux)
+    set(linkfile "${lowercase_sdk}/static-executable-args.lnk")
+    add_custom_command_target(swift_static_binary_${sdk}_args
+      COMMAND
+        "${CMAKE_COMMAND}" -E copy
+        "${SWIFT_SOURCE_DIR}/utils/static-executable-args.lnk"
+        "${SWIFTSTATICLIB_DIR}/${linkfile}"
+      OUTPUT
+        "${SWIFTSTATICLIB_DIR}/${linkfile}"
+      DEPENDS
+        "${SWIFT_SOURCE_DIR}/utils/static-executable-args.lnk")
+
+    list(APPEND static_binary_lnk_file_list ${swift_static_binary_${sdk}_args})
+    swift_install_in_component(FILES "${SWIFTSTATICLIB_DIR}/${linkfile}"
+                               DESTINATION "lib/swift_static/${lowercase_sdk}"
+                               COMPONENT stdlib)
+    add_dependencies(stdlib ${static_binary_lnk_file_list})
+    add_custom_target(static_binary_${lowercase_sdk}_magic ALL DEPENDS ${static_binary_lnk_file_list})
+  endif()
+
   foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
     set(arch_subdir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}")
     set(arch_suffix "${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")


### PR DESCRIPTION
Passing swift_core_private_link_libraries to PRIVATE_LINK_LIBRARIES only works either when building a single host SDK alone or when needed by all SDKs, so move all that configuration to a swift_core_private_libraries() function that's called from add_swift_target_library() for each SDK/arch instead. Similarly, call a swift_runtime_static_libraries() function to split off libraries for the static stdlib with linux. Finally, remove the last uses of `SWIFT_CONFIGURED_SDKS` for anything more than checking, using `SWIFT_SDKS` instead, and move the static-stdlib linker file generation to the `stdlib/` directory.

I ran into this when trying out the Android cross-compilation commands in #29439 with Swift 5.1.4 built from source on linux x86_64, which I fixed back then with a much simpler version of this pull. It broke because I wasn't building `SWIFT_PATH_TO_LIBICU_BUILD`, instead linking the linux SDK against the system libicu package and the Android SDK against a pre-built libicu for Android.

That would make the prior CMake config from #21707 try to link the Android swiftCore against the linux libicu, ie the libicu of the primary variant SDK. The Android CI didn't detect this because [it builds libicu from source](https://github.com/apple/swift/blob/0a46bd457be2fc16c8efcd64268b06580ba87da3/utils/build-presets.ini#L882), not using the system libicu for linux like I did. The rest of these non-Android SDKs aren't cross-compiled on any CI, so the cross-compilation regression wasn't found.

`SWIFT_PRIMARY_VARIANT_SDK` seems to be a meaningless variable, which AFAICT means "usually the host SDK but not always." It should either be defined much more precisely, or removed altogether and replaced with checking if an sdk is in `SWIFT_SDKS` or something.

This pull was tested by back-porting to that Swift 5.1.4 and now 5.2.1 cross-compilation setup and running the same commands to produce a working executable on Android.