### PR TITLE
[Sema] Don't Emit @objc Fixits Into Extant Modules

### DIFF
--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1772,7 +1772,11 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
     bool baseCanBeObjC = canBeRepresentedInObjC(base);
     diags.diagnose(override, diag::override_decl_extension, baseCanBeObjC,
                    !isa<ExtensionDecl>(base->getDeclContext()));
-    if (baseCanBeObjC) {
+    // If the base and the override come from the same module, try to fix
+    // the base declaration. Otherwise we can wind up diagnosing into e.g. the
+    // SDK overlay modules.
+    if (baseCanBeObjC &&
+        base->getModuleContext() == override->getModuleContext()) {
       SourceLoc insertionLoc =
         override->getAttributeInsertionLoc(/*forModifier=*/false);
       diags.diagnose(base, diag::overridden_here_can_be_objc)

--- a/test/ClangImporter/Inputs/custom-modules/ImageInitializers.h
+++ b/test/ClangImporter/Inputs/custom-modules/ImageInitializers.h
@@ -1,0 +1,7 @@
+@import Foundation;
+
+@interface Image: NSObject
+
++ (instancetype)imageNamed:(NSString *)string;
+
+@end

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -59,6 +59,11 @@ module HasSubmodule {
   }
 }
 
+module ImageInitializers {
+  header "ImageInitializers.h"
+  export *
+}
+
 module ImportsMissingHeader {
   header "ImportsMissingHeader.h"
   export *

--- a/test/ClangImporter/Inputs/overlay_extension_initializer.swift
+++ b/test/ClangImporter/Inputs/overlay_extension_initializer.swift
@@ -1,0 +1,12 @@
+@_exported import ImageInitializers
+
+extension Image : _ExpressibleByImageLiteral {
+  private convenience init!(failableImageLiteral name: String) {
+    self.init(named: .init(name))
+  }
+
+  @nonobjc
+  public required convenience init(imageLiteralResourceName name: String) {
+    self.init(failableImageLiteral: name)
+  }
+}

--- a/test/ClangImporter/objc-cross-module-override.swift
+++ b/test/ClangImporter/objc-cross-module-override.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module %S/Inputs/overlay_extension_initializer.swift -Xcc -isystem -Xcc %S/Inputs/custom-modules -module-name ImageInitializers -o %t
+// RUN: not %target-swift-frontend -I %S/Inputs/custom-modules -I %t -typecheck -primary-file %s 2>&1 | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+// N.B. This test is a bit odd since we are going to check for the presence of a
+// diagnostic being emitted in a different module. The diagnostic verifier isn't
+// really setup to test that yet.
+
+import ImageInitializers
+
+final class MyImage : Image {
+  // CHECK: overriding non-@objc declarations from extensions is not supported
+  // Make sure we aren't emitting a fixit into the extant module...
+  // CHECK-NOT: add '@objc' to make this declaration overridable
+  // CHECK: ImageInitializers.Image:{{.*}}: note: overridden declaration is here
+  override required convenience init(imageLiteralResourceName name: String) { }
+}


### PR DESCRIPTION
Overlays are specifically allowed to do magic things that regular Swift
modules are not. In this case, the UIImage and NSImage overlays have
extensions that allow them to conform to `_ExpressibleByImageLiteral`.
This, unfortunately, means that subclassing these classes with the
overlays present is impossible as one must override the required
initializers, but one cannot override these initializers since they are
declared in an extension.

While we cannot correct the overlays without breaking ABI, we can at
least make sure we don't attempt to stick @objc into them when users
have a go at subclassing these classes.

Resolves rdar://59610201