### PR TITLE
Fix MemBehavior and TempRValueOpt to handle access markers

### DIFF
--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -25,13 +25,6 @@ namespace swift {
 /// nothing left to strip.
 SILValue getUnderlyingObject(SILValue V);
 
-/// Strip off indexing and address projections.
-///
-/// This is similar to getUnderlyingObject, except that it does not strip any
-/// object-to-address projections, like ref_element_addr. In other words, the
-/// result is always an address value.
-SILValue getUnderlyingAddressRoot(SILValue V);
-
 SILValue getUnderlyingObjectStopAtMarkDependence(SILValue V);
 
 SILValue stripSinglePredecessorArgs(SILValue V);
@@ -55,11 +48,6 @@ SILValue stripUpCasts(SILValue V);
 /// Return the underlying SILValue after stripping off all
 /// upcasts and downcasts.
 SILValue stripClassCasts(SILValue V);
-
-/// Return the underlying SILValue after stripping off non-projection address
-/// casts. The result will still be an address--this does not look through
-/// pointer-to-address.
-SILValue stripAddressAccess(SILValue V);
 
 /// Return the underlying SILValue after stripping off all address projection
 /// instructions.

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -591,6 +591,9 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
                     SingleValueInstruction, MayHaveSideEffects, DoesNotRelease)
   SINGLE_VALUE_INST(StoreBorrowInst, store_borrow,
                     SILInstruction, MayWrite, DoesNotRelease)
+  // begin_access may trap. Trapping is unordered with respect to memory access,
+  // and with respect to other traps, but it is still conservatively considered
+  // a side effect.
   SINGLE_VALUE_INST(BeginAccessInst, begin_access,
                     SingleValueInstruction, MayHaveSideEffects, DoesNotRelease)
 #define NEVER_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...) \
@@ -803,6 +806,10 @@ NON_VALUE_INST(DestroyValueInst, destroy_value,
                SILInstruction, MayHaveSideEffects, MayRelease)
 NON_VALUE_INST(EndBorrowInst, end_borrow,
                SILInstruction, MayHaveSideEffects, DoesNotRelease)
+// end_access is considered to have side effects because it modifies runtime
+// state outside of the memory modified by the access that is visible to
+// Swift. This "side effect" only needs to creates a dependency on begin_access
+// instructions.
 NON_VALUE_INST(EndAccessInst, end_access,
                SILInstruction, MayHaveSideEffects, DoesNotRelease)
 NON_VALUE_INST(BeginUnpairedAccessInst, begin_unpaired_access,

--- a/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
@@ -299,10 +299,6 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
 /// Otherwise, return an empty type.
 SILType computeTBAAType(SILValue V);
 
-/// Check if \p V points to a let-member.
-/// Nobody can write into let members.
-bool isLetPointer(SILValue V);
-
 } // end namespace swift
 
 namespace llvm {

--- a/include/swift/SILOptimizer/Analysis/ValueTracking.h
+++ b/include/swift/SILOptimizer/Analysis/ValueTracking.h
@@ -17,7 +17,7 @@
 #ifndef SWIFT_SILOPTIMIZER_ANALYSIS_VALUETRACKING_H
 #define SWIFT_SILOPTIMIZER_ANALYSIS_VALUETRACKING_H
 
-#include "swift/SIL/InstructionUtils.h"
+#include "swift/SIL/MemAccessUtils.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILInstruction.h"
 
@@ -50,7 +50,8 @@ bool pointsToLocalObject(SILValue V);
 /// indirection (e.g. ref_element_addr, project_box, etc.).
 inline bool isUniquelyIdentified(SILValue V) {
   return pointsToLocalObject(V)
-         || isExclusiveArgument(getUnderlyingAddressRoot(V));
+         || (V->getType().isAddress()
+             && isExclusiveArgument(getAccessedAddress(V)));
 }
 
 enum class IsZeroKind {

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -16,32 +16,19 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "irgensil"
-#include "llvm/IR/DIBuilder.h"
-#include "llvm/IR/Function.h"
-#include "llvm/IR/Module.h"
-#include "llvm/IR/Instructions.h"
-#include "llvm/IR/IntrinsicInst.h"
-#include "llvm/IR/InlineAsm.h"
-#include "llvm/IR/Intrinsics.h"
-#include "llvm/ADT/MapVector.h"
-#include "llvm/ADT/SmallBitVector.h"
-#include "llvm/ADT/TinyPtrVector.h"
-#include "llvm/Support/SaveAndRestore.h"
-#include "llvm/Support/Debug.h"
-#include "llvm/Transforms/Utils/Local.h"
-#include "clang/AST/ASTContext.h"
-#include "clang/Basic/TargetInfo.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/IRGenOptions.h"
+#include "swift/AST/ParameterList.h"
+#include "swift/AST/Pattern.h"
+#include "swift/AST/SubstitutionMap.h"
+#include "swift/AST/Types.h"
 #include "swift/Basic/ExternalUnion.h"
 #include "swift/Basic/Range.h"
 #include "swift/Basic/STLExtras.h"
-#include "swift/AST/ASTContext.h"
-#include "swift/AST/IRGenOptions.h"
-#include "swift/AST/Pattern.h"
-#include "swift/AST/ParameterList.h"
-#include "swift/AST/SubstitutionMap.h"
-#include "swift/AST/Types.h"
 #include "swift/SIL/ApplySite.h"
 #include "swift/SIL/Dominance.h"
+#include "swift/SIL/InstructionUtils.h"
+#include "swift/SIL/MemAccessUtils.h"
 #include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILDeclRef.h"
@@ -49,8 +36,22 @@
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILType.h"
 #include "swift/SIL/SILVisitor.h"
-#include "swift/SIL/InstructionUtils.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/Basic/TargetInfo.h"
 #include "clang/CodeGen/CodeGenABITypes.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/SmallBitVector.h"
+#include "llvm/ADT/TinyPtrVector.h"
+#include "llvm/IR/DIBuilder.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/InlineAsm.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/SaveAndRestore.h"
+#include "llvm/Transforms/Utils/Local.h"
 
 #include "CallEmission.h"
 #include "Explosion.h"
@@ -3567,8 +3568,11 @@ void IRGenSILFunction::visitRefTailAddrInst(RefTailAddrInst *i) {
 }
 
 static bool isInvariantAddress(SILValue v) {
-  auto root = getUnderlyingAddressRoot(v);
-  if (auto ptrRoot = dyn_cast<PointerToAddressInst>(root)) {
+  SILValue accessedAddress = getAccessedAddress(v);
+  if (accessedAddress->getType().isAddress() && isLetAddress(accessedAddress)) {
+    return true;
+  }
+  if (auto *ptrRoot = dyn_cast<PointerToAddressInst>(accessedAddress)) {
     return ptrRoot->isInvariant();
   }
   // TODO: We could be more aggressive about considering addresses based on

--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -52,28 +52,6 @@ SILValue swift::getUnderlyingObject(SILValue v) {
   }
 }
 
-/// Strip off casts and address projections into the interior of a value. Unlike
-/// getUnderlyingObject, this does not find the root of a heap object--a class
-/// property is itself an address root.
-SILValue swift::getUnderlyingAddressRoot(SILValue v) {
-  while (true) {
-    SILValue v2 = stripIndexingInsts(stripCasts(v));
-    v2 = stripOwnershipInsts(v2);
-    switch (v2->getKind()) {
-    case ValueKind::StructElementAddrInst:
-    case ValueKind::TupleElementAddrInst:
-    case ValueKind::UncheckedTakeEnumDataAddrInst:
-      v2 = cast<SingleValueInstruction>(v2)->getOperand(0);
-      break;
-    default:
-      break;
-    }
-    if (v2 == v)
-      return v2;
-    v = v2;
-  }
-}
-
 SILValue swift::getUnderlyingObjectStopAtMarkDependence(SILValue v) {
   while (true) {
     SILValue v2 = stripCastsWithoutMarkDependence(v);
@@ -221,18 +199,6 @@ SILValue swift::stripClassCasts(SILValue v) {
     }
 
     return v;
-  }
-}
-
-SILValue swift::stripAddressAccess(SILValue V) {
-  while (true) {
-    switch (V->getKind()) {
-    default:
-      return V;
-    case ValueKind::BeginBorrowInst:
-    case ValueKind::BeginAccessInst:
-      V = cast<SingleValueInstruction>(V)->getOperand(0);
-    }
   }
 }
 

--- a/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
@@ -330,14 +330,18 @@ static bool isTypedAccessOracle(SILInstruction *I) {
 /// given value is directly derived from a memory location, it cannot
 /// alias. Call arguments also cannot alias because they must follow \@in, @out,
 /// @inout, or \@in_guaranteed conventions.
-static bool isAddressRootTBAASafe(SILValue V) {
-  if (isa<SILFunctionArgument>(V))
+static bool isAccessedAddressTBAASafe(SILValue V) {
+  if (!V->getType().isAddress())
+    return false;
+
+  SILValue accessedAddress = getAccessedAddress(V);
+  if (isa<SILFunctionArgument>(accessedAddress))
     return true;
 
-  if (auto *PtrToAddr = dyn_cast<PointerToAddressInst>(V))
+  if (auto *PtrToAddr = dyn_cast<PointerToAddressInst>(accessedAddress))
     return PtrToAddr->isStrict();
 
-  switch (V->getKind()) {
+  switch (accessedAddress->getKind()) {
   default:
     return false;
   case ValueKind::AllocStackInst:
@@ -352,6 +356,8 @@ static bool isAddressRootTBAASafe(SILValue V) {
 /// TypedAccessOracle which enable one to ascertain via undefined behavior the
 /// "true" type of the instruction.
 static SILType findTypedAccessType(SILValue V) {
+  assert(V->getType().isAddress());
+
   // First look at the origin of V and see if we have any instruction that is a
   // typed oracle.
   // TODO: MultiValueInstruction
@@ -370,7 +376,7 @@ static SILType findTypedAccessType(SILValue V) {
 }
 
 SILType swift::computeTBAAType(SILValue V) {
-  if (isAddressRootTBAASafe(getUnderlyingAddressRoot(V)))
+  if (isAccessedAddressTBAASafe(V))
     return findTypedAccessType(V);
 
   // FIXME: add ref_element_addr check here. TBAA says that objects cannot be
@@ -741,34 +747,6 @@ bool AliasAnalysis::mayValueReleaseInterfereWithInstruction(
   // object are irrelevant--they must already have sufficient refcount that they
   // won't be released when releasing Ptr.
   return EA->mayReleaseContent(releasedReference, accessedPointer);
-}
-
-bool swift::isLetPointer(SILValue V) {
-  // Traverse the "access" path for V and check that it starts with "let"
-  // and everything along this path is a value-type (i.e. struct or tuple).
-
-  // Is this an address of a "let" class member?
-  if (auto *REA = dyn_cast<RefElementAddrInst>(V))
-    return REA->getField()->isLet();
-
-  // Is this an address of a global "let"?
-  if (auto *GAI = dyn_cast<GlobalAddrInst>(V)) {
-    auto *GlobalDecl = GAI->getReferencedGlobal()->getDecl();
-    return GlobalDecl && GlobalDecl->isLet();
-  }
-
-  // Is this an address of a struct "let" member?
-  if (auto *SEA = dyn_cast<StructElementAddrInst>(V))
-    // Check if it is a "let" in the parent struct.
-    // Check if its parent is a "let".
-    return isLetPointer(SEA->getOperand());
-
-
-  // Check if a parent of a tuple is a "let"
-  if (auto *TEA = dyn_cast<TupleElementAddrInst>(V))
-    return isLetPointer(TEA->getOperand());
-
-  return false;
 }
 
 void AliasAnalysis::initialize(SILPassManager *PM) {

--- a/lib/SILOptimizer/UtilityPasses/EscapeAnalysisDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/EscapeAnalysisDumper.cpp
@@ -19,7 +19,7 @@
 using namespace swift;
 
 // For manual debugging, dump graphs in DOT format.
-llvm::cl::opt<bool> EnableGraphWriter(
+static llvm::cl::opt<bool> EnableGraphWriter(
     "escapes-enable-graphwriter", llvm::cl::init(false),
     llvm::cl::desc("With -escapes-dump, also write .dot files."));
 

--- a/test/IRGen/invariant_load.sil
+++ b/test/IRGen/invariant_load.sil
@@ -9,6 +9,10 @@ struct X {
   var z: Builtin.Int32
 }
 
+class C {
+  @_hasStorage @_hasInitialValue final let prop: Builtin.Int32 { get }
+}
+
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @invariant_load
 sil [ossa] @invariant_load : $@convention(thin) (Builtin.RawPointer) -> () {
 entry(%p : $Builtin.RawPointer):
@@ -24,3 +28,13 @@ entry(%p : $Builtin.RawPointer):
   %z = load [trivial] %zp : $*Builtin.Int32
   return undef : $()
 }
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @testLetProp
+sil @testLetProp : $@convention(thin) (@guaranteed C) -> Builtin.Int32 {
+bb0(%0 : $C):
+  %propAdr = ref_element_addr %0 : $C, #C.prop
+  // CHECK: load i32, {{.*}} !invariant.load
+  %val = load %propAdr : $*Builtin.Int32
+  return %val : $Builtin.Int32
+}
+

--- a/test/SILOptimizer/bridged_casts_folding.swift
+++ b/test/SILOptimizer/bridged_casts_folding.swift
@@ -904,14 +904,9 @@ var anyHashable: AnyHashable = 0
 
 // CHECK-LABEL: $s21bridged_casts_folding29testUncondCastSwiftToSubclassAA08NSObjectI0CyF
 // CHECK: [[GLOBAL:%[0-9]+]] = global_addr @$s21bridged_casts_folding11anyHashables03AnyE0Vv
-// CHECK: [[GLOBAL_COPY:%[0-9]+]] = alloc_stack
-// CHECK: [[GLOBAL_EXCL:%[0-9]+]] = begin_access [read] [static] [no_nested_conflict] [[GLOBAL]]
-
-// TODO: this copy_addr should be eliminated: rdar://problem/59345115
-// CHECK: copy_addr [[GLOBAL_EXCL]] to [initialization] [[GLOBAL_COPY]]
 // CHECK: [[FUNC:%.*]] = function_ref @$ss11AnyHashableV10FoundationE19_bridgeToObjectiveCSo8NSObjectCyF
-// CHECK: apply [[FUNC]]([[GLOBAL_COPY]])
-// CHECK: unconditional_checked_cast {{%.*}} : $NSObject to NSObjectSubclass
+// CHECK-NEXT: apply [[FUNC]]([[GLOBAL]])
+// CHECK-NEXT: unconditional_checked_cast {{%.*}} : $NSObject to NSObjectSubclass
 // CHECK: } // end sil function '$s21bridged_casts_folding29testUncondCastSwiftToSubclassAA08NSObjectI0CyF'
 @inline(never)
 public func testUncondCastSwiftToSubclass() -> NSObjectSubclass {

--- a/test/SILOptimizer/mem-behavior-all.sil
+++ b/test/SILOptimizer/mem-behavior-all.sil
@@ -1,0 +1,114 @@
+// RUN: %target-sil-opt %s -aa-kind=basic-aa -mem-behavior-dump -enable-mem-behavior-dump-all -o /dev/null | %FileCheck %s
+
+// REQUIRES: asserts
+
+import Builtin
+import Swift
+
+class C {
+  @_hasStorage @_hasInitialValue final let prop: Builtin.Int32 { get }
+}
+
+class Parent {
+  @_hasStorage var child: C { get set }
+}
+
+// Check the memory behavior of a read-only load relative to an
+// unknown instruction with side effects.
+//
+// CHECK-LABEL: @testLetSideEffects
+//
+// The store does not affect the let-load (ref_element_addr).
+// CHECK: PAIR #35.
+// CHECK-NEXT:    %7 = begin_access [modify] [static] %1 : $*Builtin.Int32
+// CHECK-NEXT:    %11 = ref_element_addr %10 : $C, #C.prop
+// CHECK-NEXT:  r=0,w=0,se=0
+//
+// Any unknown instructions with side effects does affect the let-load.
+// CHECK: PAIR #83.
+// CHECK-NEXT:     end_borrow %{{.*}} : $C
+// CHECK-NEXT:     ref_element_addr %{{.*}} : $C, #C.prop
+// CHECK-NEXT:   r=1,w=1,se=1
+// CHECK: PAIR #103.
+// CHECK-NEXT:     destroy_value %0 : $Parent
+// CHECK-NEXT:     ref_element_addr %{{.*}} : $C, #C.prop
+// CHECK-NEXT:   r=1,w=1,se=1
+sil [ossa] @testLetSideEffects : $@convention(thin) (@owned Parent, @inout Builtin.Int32) -> Builtin.Int32 {
+bb0(%0 : @owned $Parent, %1 : $*Builtin.Int32):
+  %borrow1 = begin_borrow %0 : $Parent
+  %childAdr = ref_element_addr %borrow1 : $Parent, #Parent.child
+  %child = load_borrow %childAdr : $*C
+  end_borrow %borrow1 : $Parent
+
+  %three = integer_literal $Builtin.Int32, 3
+  %access = begin_access [modify] [static] %1 : $*Builtin.Int32
+  store %three to [trivial] %access : $*Builtin.Int32
+  end_access %access : $*Builtin.Int32
+
+  %borrow2 = begin_borrow %child : $C
+  %propAdr = ref_element_addr %borrow2 : $C, #C.prop
+  %val = load [trivial] %propAdr : $*Builtin.Int32
+  end_borrow %borrow2 : $C
+  end_borrow %child : $C
+  destroy_value %0 : $Parent
+  return %val : $Builtin.Int32
+}
+
+// Check the memory behavior of access markers.
+//
+// CHECK-LABEL: @testReadWriteAccess
+// CHECK: PAIR #0.
+// CHECK-NEXT:     %{{.*}} = begin_access [read] [static] %0 : $*Builtin.Int32
+// CHECK-NEXT:     %0 = argument of bb0 : $*Builtin.Int32
+// CHECK-NEXT:   r=1,w=0,se=0
+// CHECK: PAIR #1.
+// CHECK-NEXT:     %{{.*}} = begin_access [read] [static] %0 : $*Builtin.Int32
+// CHECK-NEXT:     load [trivial] %{{.*}} : $*Builtin.Int32
+// CHECK-NEXT:   r=1,w=0,se=0
+// CHECK: PAIR #3.
+// CHECK-NEXT:     %{{.*}} = begin_access [read] [static] %0 : $*Builtin.Int32
+// CHECK-NEXT:     %{{.*}} = begin_access [modify] [static] %0 : $*Builtin.Int32
+// CHECK-NEXT:   r=1,w=0,se=0
+// CHECK: PAIR #8.
+// CHECK-NEXT:     end_access %{{.*}} : $*Builtin.Int32
+// CHECK-NEXT:   %0 = argument of bb0 : $*Builtin.Int32
+// CHECK-NEXT:   r=1,w=0,se=0
+// CHECK: PAIR #9.
+// CHECK-NEXT:    end_access %{{.*}} : $*Builtin.Int32
+// CHECK-NEXT:    %{{.*}} = begin_access [read] [static] %0 : $*Builtin.Int32
+// CHECK-NEXT:  r=1,w=0,se=0
+// CHECK: PAIR #12.
+// CHECK-NEXT:    end_access %{{.*}} : $*Builtin.Int32
+// CHECK-NEXT:    %{{.*}} = begin_access [modify] [static] %0 : $*Builtin.Int32
+// CHECK-NEXT:  r=1,w=0,se=0
+// CHECK: PAIR #13.
+// CHECK-NEXT:    %{{.*}} = begin_access [modify] [static] %0 : $*Builtin.Int32
+// CHECK-NEXT:    %0 = argument of bb0 : $*Builtin.Int32
+// CHECK-NEXT:  r=0,w=1,se=1
+// CHECK: PAIR #14.
+// CHECK-NEXT:    %{{.*}} = begin_access [modify] [static] %0 : $*Builtin.Int32
+// CHECK-NEXT:    %{{.*}} = begin_access [read] [static] %0 : $*Builtin.Int32
+// CHECK-NEXT:  r=0,w=1,se=1
+// CHECK: PAIR #22.
+// CHECK-NEXT:    end_access %{{.*}} : $*Builtin.Int32
+// CHECK-NEXT:    %0 = argument of bb0 : $*Builtin.Int32
+// CHECK-NEXT:  r=0,w=1,se=1
+// CHECK: PAIR #23.
+// CHECK-NEXT:    end_access %{{.*}} : $*Builtin.Int32
+// CHECK-NEXT:    %{{.*}} = begin_access [read] [static] %0 : $*Builtin.Int32
+// CHECK-NEXT:  r=0,w=1,se=1
+// CHECK: PAIR #26.
+// CHECK-NEXT:    end_access %{{.*}} : $*Builtin.Int32
+// CHECK-NEXT:    %{{.*}} = begin_access [modify] [static] %0 : $*Builtin.Int32
+// CHECK-NEXT:  r=0,w=1,se=1
+sil [ossa] @testReadWriteAccess : $@convention(thin) (@inout Builtin.Int32) -> Builtin.Int32 {
+bb0(%0 : $*Builtin.Int32):
+  %read = begin_access [read] [static] %0 : $*Builtin.Int32
+  %val = load [trivial] %read : $*Builtin.Int32
+  end_access %read : $*Builtin.Int32
+  %three = integer_literal $Builtin.Int32, 3
+  %write = begin_access [modify] [static] %0 : $*Builtin.Int32
+  store %three to [trivial] %write : $*Builtin.Int32
+  end_access %write : $*Builtin.Int32
+  return %val : $Builtin.Int32
+}

--- a/test/SILOptimizer/sil_combine_protocol_conf.swift
+++ b/test/SILOptimizer/sil_combine_protocol_conf.swift
@@ -237,24 +237,14 @@ internal class OtherClass {
 // CHECK-LABEL: sil hidden [noinline] @$s25sil_combine_protocol_conf10OtherClassC12doWorkStructSiyF : $@convention(method) (@guaranteed OtherClass) -> Int {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK: debug_value
-// CHECK: [[STACK1:%.*]] = alloc_stack $PropProtocol
 // CHECK: [[R1:%.*]] = ref_element_addr [[ARG]] : $OtherClass, #OtherClass.arg1
-// CHECK: [[ACC1:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[R1]]
-
-// TODO: this copy_addr should be eliminated: rdar://problem/59345115
-// CHECK: copy_addr [[ACC1]] to [initialization] [[STACK1]]
-// CHECK: [[O1:%.*]] = open_existential_addr immutable_access [[STACK1]] : $*PropProtocol to $*@opened("{{.*}}") PropProtocol
+// CHECK: [[O1:%.*]] = open_existential_addr immutable_access [[R1]] : $*PropProtocol to $*@opened("{{.*}}") PropProtocol
 // CHECK: [[U1:%.*]] = unchecked_addr_cast [[O1]] : $*@opened("{{.*}}") PropProtocol to $*PropClass 
 // CHECK: [[S1:%.*]] = struct_element_addr [[U1]] : $*PropClass, #PropClass.val
 // CHECK: [[S11:%.*]] = struct_element_addr [[S1]] : $*Int, #Int._value
 // CHECK: load [[S11]] 
-// CHECK: [[STACK2:%.*]] = alloc_stack $GenericPropProtocol
 // CHECK: [[R2:%.*]] = ref_element_addr [[ARG]] : $OtherClass, #OtherClass.arg2
-// CHECK: [[ACC2:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[R2]]
-
-// TODO: this copy_addr should be eliminated: rdar://problem/59345115
-// CHECK: copy_addr [[ACC2]] to [initialization] [[STACK2]]
-// CHECK: [[O2:%.*]] = open_existential_addr immutable_access [[STACK2]] : $*GenericPropProtocol to $*@opened("{{.*}}") GenericPropProtocol
+// CHECK: [[O2:%.*]] = open_existential_addr immutable_access [[R2]] : $*GenericPropProtocol to $*@opened("{{.*}}") GenericPropProtocol
 // CHECK: [[W2:%.*]] = witness_method $@opened("{{.*}}") GenericPropProtocol, #GenericPropProtocol.val!getter.1 : <Self where Self : GenericPropProtocol> (Self) -> () -> Int, [[O2]] : $*@opened("{{.*}}") GenericPropProtocol : $@convention(witness_method: GenericPropProtocol) <τ_0_0 where τ_0_0 : GenericPropProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK: apply [[W2]]<@opened("{{.*}}") GenericPropProtocol>([[O2]]) : $@convention(witness_method: GenericPropProtocol) <τ_0_0 where τ_0_0 : GenericPropProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK: struct_extract
@@ -263,13 +253,8 @@ internal class OtherClass {
 // CHECK: tuple_extract
 // CHECK: tuple_extract
 // CHECK: cond_fail
-// CHECK: [[STACK4:%.*]] = alloc_stack $NestedPropProtocol
 // CHECK: [[R4:%.*]] = ref_element_addr [[ARG]] : $OtherClass, #OtherClass.arg3
-// CHECK: [[ACC4:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[R4]]
-
-// TODO: this copy_addr should be eliminated: rdar://problem/59345115
-// CHECK: copy_addr [[ACC4]] to [initialization] [[STACK4]]
-// CHECK: [[O4:%.*]] = open_existential_addr immutable_access [[STACK4]] : $*NestedPropProtocol to $*@opened("{{.*}}") NestedPropProtocol
+// CHECK: [[O4:%.*]] = open_existential_addr immutable_access [[R4]] : $*NestedPropProtocol to $*@opened("{{.*}}") NestedPropProtocol
 // CHECK: [[U4:%.*]] = unchecked_addr_cast [[O4]] : $*@opened("{{.*}}") NestedPropProtocol to $*Outer.Inner
 // CHECK: [[S4:%.*]] = struct_element_addr [[U4]] : $*Outer.Inner, #Outer.Inner.val
 // CHECK: [[S41:%.*]] = struct_element_addr [[S4]] : $*Int, #Int._value
@@ -278,13 +263,8 @@ internal class OtherClass {
 // CHECK: tuple_extract
 // CHECK: tuple_extract
 // CHECK: cond_fail
-// CHECK: [[STACK5:%.*]] = alloc_stack $GenericNestedPropProtocol
 // CHECK: [[R5:%.*]] = ref_element_addr [[ARG]] : $OtherClass, #OtherClass.arg4
-// CHECK: [[ACC5:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[R5]]
-
-// TODO: this copy_addr should be eliminated: rdar://problem/59345115
-// CHECK: copy_addr [[ACC5]] to [initialization] [[STACK5]]
-// CHECK: [[O5:%.*]] = open_existential_addr immutable_access [[STACK5]] : $*GenericNestedPropProtocol to $*@opened("{{.*}}") GenericNestedPropProtocol
+// CHECK: [[O5:%.*]] = open_existential_addr immutable_access [[R5]] : $*GenericNestedPropProtocol to $*@opened("{{.*}}") GenericNestedPropProtocol
 // CHECK: [[W5:%.*]] = witness_method $@opened("{{.*}}") GenericNestedPropProtocol, #GenericNestedPropProtocol.val!getter.1 : <Self where Self : GenericNestedPropProtocol> (Self) -> () -> Int, [[O5:%.*]] : $*@opened("{{.*}}") GenericNestedPropProtocol : $@convention(witness_method: GenericNestedPropProtocol) <τ_0_0 where τ_0_0 : GenericNestedPropProtocol> (@in_guaranteed τ_0_0) -> Int 
 // CHECK: apply [[W5]]<@opened("{{.*}}") GenericNestedPropProtocol>([[O5]]) : $@convention(witness_method: GenericNestedPropProtocol) <τ_0_0 where τ_0_0 : GenericNestedPropProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK: struct_extract
@@ -351,13 +331,8 @@ internal class OtherKlass {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK: debug_value
 // CHECK: integer_literal
-// CHECK: [[STACK1:%.*]] = alloc_stack $AGenericProtocol
 // CHECK: [[R1:%.*]] = ref_element_addr [[ARG]] : $OtherKlass, #OtherKlass.arg2
-// CHECK: [[ACC1:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[R1]]
-
-// TODO: this copy_addr should be eliminated: rdar://problem/59345115
-// CHECK: copy_addr [[ACC1]] to [initialization] [[STACK1]]
-// CHECK: [[O1:%.*]] = open_existential_addr immutable_access [[STACK1]] : $*AGenericProtocol to $*@opened("{{.*}}") AGenericProtocol
+// CHECK: [[O1:%.*]] = open_existential_addr immutable_access [[R1]] : $*AGenericProtocol to $*@opened("{{.*}}") AGenericProtocol
 // CHECK: [[W1:%.*]] = witness_method $@opened("{{.*}}") AGenericProtocol, #AGenericProtocol.val!getter.1 : <Self where Self : AGenericProtocol> (Self) -> () -> Int, [[O1]] : $*@opened("{{.*}}") AGenericProtocol : $@convention(witness_method: AGenericProtocol) <τ_0_0 where τ_0_0 : AGenericProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK: apply [[W1]]<@opened("{{.*}}") AGenericProtocol>([[O1]]) : $@convention(witness_method: AGenericProtocol) <τ_0_0 where τ_0_0 : AGenericProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK: struct_extract

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -734,3 +734,28 @@ bb3(%obj3 : @owned $GS<Builtin.NativeObject>):
   apply %f(%obj3) : $@convention(thin) (@guaranteed GS<Builtin.NativeObject>) -> ()
   return %obj3 : $GS<Builtin.NativeObject>
 }
+
+// Test copy elimination with access markers on both the source and dest.
+//
+// CHECK-LABEL: sil [ossa] @takeWithAccess : $@convention(thin) (@in Klass) -> () {
+// CHECK: bb0(%0 : $*Klass):
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [static] %0 : $*Klass
+// CHECK:   apply %{{.*}}([[ACCESS]]) : $@convention(thin) (@in_guaranteed Klass) -> ()
+// CHECK:   end_access [[ACCESS]] : $*Klass
+// CHECK:   destroy_addr %0 : $*Klass
+// CHECK-LABEL: } // end sil function 'takeWithAccess'
+sil [ossa] @takeWithAccess : $@convention(thin) (@in Klass) -> () {
+bb0(%0 : $*Klass):
+  %stack = alloc_stack $Klass
+  %access = begin_access [read] [static] %0 : $*Klass
+  copy_addr [take] %access to [initialization] %stack : $*Klass
+  end_access %access : $*Klass
+  %f = function_ref @inguaranteed_user_without_result : $@convention(thin) (@in_guaranteed Klass) -> ()
+  %access2 = begin_access [read] [static] %stack : $*Klass
+  %call = apply %f(%access2) : $@convention(thin) (@in_guaranteed Klass) -> ()
+  end_access %access2 : $*Klass
+  destroy_addr %stack : $*Klass
+  dealloc_stack %stack : $*Klass
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
The first commit cleans up the infrastructure and improves MemBehavior.

The second commit fixes the TempRValue pass to correctly handle access markers.

Both commits are required together for correct behavior, so I'm smashing them into one PR.