### PR TITLE
[Constraint system] Implement switch support for function builders.

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -622,12 +622,104 @@ protected:
         DeclNameLoc(endLoc), /*implicit=*/true);
   }
 
+  VarDecl *visitSwitchStmt(SwitchStmt *switchStmt) {
+    // Generate constraints for the subject expression, and capture its
+    // type for use in matching the various patterns.
+    Expr *subjectExpr = switchStmt->getSubjectExpr();
+    if (cs) {
+      // FIXME: Add contextual type purpose for switch subjects?
+      SolutionApplicationTarget target(subjectExpr, dc, CTP_Unused, Type(),
+                                       /*isDiscarded=*/false);
+      if (cs->generateConstraints(target, FreeTypeVariableBinding::Disallow)) {
+        hadError = true;
+        return nullptr;
+      }
+
+      cs->setSolutionApplicationTarget(switchStmt, target);
+      subjectExpr = target.getAsExpr();
+      assert(subjectExpr && "Must have a subject expression here");
+    }
+
+    // Generate constraints and capture variables for all of the cases.
+    SmallVector<std::pair<CaseStmt *, VarDecl *>, 4> capturedCaseVars;
+    for (auto *caseStmt : switchStmt->getCases()) {
+      if (auto capturedCaseVar = visitCaseStmt(caseStmt, subjectExpr)) {
+        capturedCaseVars.push_back({caseStmt, capturedCaseVar});
+      }
+    }
+
+    if (!cs)
+      return nullptr;
+
+    // Form the expressions that inject the result of each case into the
+    // appropriate
+    llvm::TinyPtrVector<Expr *> injectedCaseExprs;
+    SmallVector<std::pair<Type, ConstraintLocator *>, 4> injectedCaseTerms;
+    for (unsigned idx : indices(capturedCaseVars)) {
+      auto caseStmt = capturedCaseVars[idx].first;
+      auto caseVar = capturedCaseVars[idx].second;
+
+      // Build the expression that injects the case variable into appropriate
+      // buildEither(first:)/buildEither(second:) chain.
+      Expr *caseVarRef = buildVarRef(caseVar, caseStmt->getEndLoc());
+      Expr *injectedCaseExpr = buildWrappedChainPayload(
+          caseVarRef, idx, capturedCaseVars.size(), /*isOptional=*/false);
+
+      // Generate constraints for this injected case result.
+      injectedCaseExpr = cs->generateConstraints(injectedCaseExpr, dc);
+      if (!injectedCaseExpr) {
+        hadError = true;
+        return nullptr;
+      }
+
+      // Record this injected case expression.
+      injectedCaseExprs.push_back(injectedCaseExpr);
+
+      // Record the type and locator for this injected case expression, to be
+      // used in the "join" constraint later.
+      injectedCaseTerms.push_back(
+        { cs->getType(injectedCaseExpr)->getRValueType(),
+          cs->getConstraintLocator(injectedCaseExpr) });
+    }
+
+    // Form the type of the switch itself.
+    // FIXME: Need a locator for the "switch" statement.
+    Type resultType = cs->addJoinConstraint(nullptr, injectedCaseTerms);
+    if (!resultType) {
+      hadError = true;
+      return nullptr;
+    }
+
+    // Create a variable to capture the result of evaluating the switch.
+    auto switchVar = buildVar(switchStmt->getStartLoc());
+    cs->setType(switchVar, resultType);
+    applied.capturedStmts.insert(
+        {switchStmt, { switchVar, std::move(injectedCaseExprs) } });
+    return switchVar;
+  }
+
+  VarDecl *visitCaseStmt(CaseStmt *caseStmt, Expr *subjectExpr) {
+    // If needed, generate constraints for everything in the case statement.
+    if (cs) {
+      auto locator = cs->getConstraintLocator(
+          subjectExpr, LocatorPathElt::ContextualType());
+      Type subjectType = cs->getType(subjectExpr);
+
+      if (cs->generateConstraints(caseStmt, dc, subjectType, locator)) {
+        hadError = true;
+        return nullptr;
+      }
+    }
+
+    // Translate the body.
+    return visit(caseStmt->getBody());
+  }
+
   CONTROL_FLOW_STMT(Guard)
   CONTROL_FLOW_STMT(While)
   CONTROL_FLOW_STMT(DoCatch)
   CONTROL_FLOW_STMT(RepeatWhile)
   CONTROL_FLOW_STMT(ForEach)
-  CONTROL_FLOW_STMT(Switch)
   CONTROL_FLOW_STMT(Case)
   CONTROL_FLOW_STMT(Catch)
   CONTROL_FLOW_STMT(Break)
@@ -996,6 +1088,63 @@ public:
     return doStmt;
   }
 
+  Stmt *visitSwitchStmt(SwitchStmt *switchStmt, FunctionBuilderTarget target) {
+    // Translate the subject expression.
+    ConstraintSystem &cs = solution.getConstraintSystem();
+    auto subjectTarget =
+        rewriteTarget(*cs.getSolutionApplicationTarget(switchStmt));
+    if (!subjectTarget)
+      return nullptr;
+
+    switchStmt->setSubjectExpr(subjectTarget->getAsExpr());
+
+    // Handle any declaration nodes within the case list first; we'll
+    // handle the cases in a second pass.
+    for (auto child : switchStmt->getRawCases()) {
+      if (auto decl = child.dyn_cast<Decl *>()) {
+        TypeChecker::typeCheckDecl(decl);
+      }
+    }
+
+    // Translate all of the cases.
+    assert(target.kind == FunctionBuilderTarget::TemporaryVar);
+    auto temporaryVar = target.captured.first;
+    unsigned caseIndex = 0;
+    for (auto caseStmt : switchStmt->getCases()) {
+      if (!visitCaseStmt(
+            caseStmt,
+            FunctionBuilderTarget::forAssign(
+              temporaryVar, {target.captured.second[caseIndex]})))
+        return nullptr;
+
+      ++caseIndex;
+    }
+
+    return switchStmt;
+  }
+
+  Stmt *visitCaseStmt(CaseStmt *caseStmt, FunctionBuilderTarget target) {
+    // Translate the patterns and guard expressions for each case label item.
+    for (auto &caseLabelItem : caseStmt->getMutableCaseLabelItems()) {
+      SolutionApplicationTarget caseLabelTarget(&caseLabelItem, dc);
+      if (!rewriteTarget(caseLabelTarget))
+        return nullptr;
+    }
+
+    // Transform the body of the case.
+    auto body = cast<BraceStmt>(caseStmt->getBody());
+    auto captured = takeCapturedStmt(body);
+    auto newInnerBody = cast<BraceStmt>(
+        visitBraceStmt(
+          body,
+          target,
+          FunctionBuilderTarget::forAssign(
+            captured.first, {captured.second.front()})));
+    caseStmt->setBody(newInnerBody);
+
+    return caseStmt;
+  }
+
 #define UNHANDLED_FUNCTION_BUILDER_STMT(STMT) \
   Stmt *visit##STMT##Stmt(STMT##Stmt *stmt, FunctionBuilderTarget target) { \
     llvm_unreachable("Function builders do not allow statement of kind " \
@@ -1010,8 +1159,6 @@ public:
   UNHANDLED_FUNCTION_BUILDER_STMT(DoCatch)
   UNHANDLED_FUNCTION_BUILDER_STMT(RepeatWhile)
   UNHANDLED_FUNCTION_BUILDER_STMT(ForEach)
-  UNHANDLED_FUNCTION_BUILDER_STMT(Switch)
-  UNHANDLED_FUNCTION_BUILDER_STMT(Case)
   UNHANDLED_FUNCTION_BUILDER_STMT(Catch)
   UNHANDLED_FUNCTION_BUILDER_STMT(Break)
   UNHANDLED_FUNCTION_BUILDER_STMT(Continue)

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -627,6 +627,9 @@ protected:
     // type for use in matching the various patterns.
     Expr *subjectExpr = switchStmt->getSubjectExpr();
     if (cs) {
+      // Form a one-way constraint to prevent backward propagation.
+      subjectExpr = new (ctx) OneWayExpr(subjectExpr);
+
       // FIXME: Add contextual type purpose for switch subjects?
       SolutionApplicationTarget target(subjectExpr, dc, CTP_Unused, Type(),
                                        /*isDiscarded=*/false);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7461,7 +7461,7 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
 
       case StmtConditionElement::CK_PatternBinding: {
         ConstraintSystem &cs = solution.getConstraintSystem();
-        auto target = *cs.getStmtConditionTarget(&condElement);
+        auto target = *cs.getSolutionApplicationTarget(&condElement);
         auto resolvedTarget = rewriteTarget(target);
         if (!resolvedTarget)
           return None;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4214,7 +4214,7 @@ bool ConstraintSystem::generateConstraints(StmtCondition condition,
       if (generateConstraints(target, FreeTypeVariableBinding::Disallow))
         return true;
 
-      setStmtConditionTarget(&condElement, target);
+      setSolutionApplicationTarget(&condElement, target);
       continue;
     }
     }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4223,6 +4223,62 @@ bool ConstraintSystem::generateConstraints(StmtCondition condition,
   return false;
 }
 
+bool ConstraintSystem::generateConstraints(
+    CaseStmt *caseStmt, DeclContext *dc, Type subjectType,
+    ConstraintLocator *locator) {
+  // Pre-bind all of the pattern variables within the case.
+  bindSwitchCasePatternVars(caseStmt);
+
+  for (auto &caseLabelItem : caseStmt->getMutableCaseLabelItems()) {
+    // Resolve the pattern.
+    auto *pattern = TypeChecker::resolvePattern(
+        caseLabelItem.getPattern(), dc, /*isStmtCondition=*/false);
+    if (!pattern)
+      return true;
+
+    // Generate constraints for the pattern, including one-way bindings for
+    // any variables that show up in this pattern, because those variables
+    // can be referenced in the guard expressions and the body.
+    Type patternType = generateConstraints(
+        pattern, locator, /* bindPatternVarsOneWay=*/true);
+
+    // Convert the subject type to the pattern, which establishes the
+    // bindings.
+    addConstraint(
+        ConstraintKind::Conversion, subjectType, patternType, locator);
+
+    // Generate constraints for the guard expression, if there is one.
+    Expr *guardExpr = caseLabelItem.getGuardExpr();
+    if (guardExpr) {
+      guardExpr = generateConstraints(guardExpr, dc);
+      if (!guardExpr)
+        return true;
+    }
+
+    // Save this info.
+    setCaseLabelItemInfo(&caseLabelItem, {pattern, guardExpr});
+
+    // For any pattern variable that has a parent variable (i.e., another
+    // pattern variable with the same name in the same case), require that
+    // the types be equivalent.
+    pattern->forEachVariable([&](VarDecl *var) {
+      if (auto parentVar = var->getParentVarDecl()) {
+        addConstraint(
+            ConstraintKind::Equal, getType(parentVar), getType(var), locator);
+      }
+    });
+  }
+
+  // Bind the types of the case body variables.
+  for (auto caseBodyVar : caseStmt->getCaseBodyVariablesOrEmptyArray()) {
+    auto parentVar = caseBodyVar->getParentVarDecl();
+    assert(parentVar && "Case body variables always have parents");
+    setType(caseBodyVar, getType(parentVar));
+  }
+
+  return false;
+}
+
 void ConstraintSystem::optimizeConstraints(Expr *e) {
   if (getASTContext().TypeCheckerOpts.DisableConstraintSolverPerformanceHacks)
     return;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -172,7 +172,7 @@ Solution ConstraintSystem::finalize() {
   solution.contextualTypes.assign(
       contextualTypes.begin(), contextualTypes.end());
 
-  solution.stmtConditionTargets = stmtConditionTargets;
+  solution.solutionApplicationTargets = solutionApplicationTargets;
 
   for (auto &e : CheckedConformances)
     solution.Conformances.push_back({e.first, e.second});
@@ -246,9 +246,10 @@ void ConstraintSystem::applySolution(const Solution &solution) {
   }
 
   // Register the statement condition targets.
-  for (const auto &stmtConditionTarget : solution.stmtConditionTargets) {
-    if (!getStmtConditionTarget(stmtConditionTarget.first))
-      setStmtConditionTarget(stmtConditionTarget.first, stmtConditionTarget.second);
+  for (const auto &target : solution.solutionApplicationTargets) {
+    if (!getSolutionApplicationTarget(target.first))
+      setSolutionApplicationTarget(target.first, target.second);
+  }
   }
 
   // Register the conformances checked along the way to arrive to solution.
@@ -463,7 +464,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numResolvedOverloads = cs.ResolvedOverloads.size();
   numInferredClosureTypes = cs.ClosureTypes.size();
   numContextualTypes = cs.contextualTypes.size();
-  numStmtConditionTargets = cs.stmtConditionTargets.size();
+  numSolutionApplicationTargets = cs.solutionApplicationTargets.size();
 
   PreviousScore = cs.CurrentScore;
 
@@ -541,8 +542,8 @@ ConstraintSystem::SolverScope::~SolverScope() {
   // Remove any contextual types.
   truncate(cs.contextualTypes, numContextualTypes);
 
-  // Remove any statement condition types.
-  truncate(cs.stmtConditionTargets, numStmtConditionTargets);
+  // Remove any solution application targets.
+  truncate(cs.solutionApplicationTargets, numSolutionApplicationTargets);
 
   // Reset the previous score.
   cs.CurrentScore = PreviousScore;

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2065,3 +2065,34 @@ void TypeChecker::typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD) {
   checkTopLevelErrorHandling(TLCD);
   performTopLevelDeclDiagnostics(TLCD);
 }
+
+void swift::bindSwitchCasePatternVars(CaseStmt *caseStmt) {
+  llvm::SmallDenseMap<Identifier, VarDecl *, 4> latestVars;
+  auto recordVar = [&](VarDecl *var) {
+    if (!var->hasName())
+      return;
+
+    // If there is an existing variable with this name, set it as the
+    // parent of this new variable.
+    auto &entry = latestVars[var->getName()];
+    if (entry) {
+      assert(!var->getParentVarDecl() ||
+             var->getParentVarDecl() == entry);
+      var->setParentVarDecl(entry);
+    }
+
+    // Record this variable as the latest with this name.
+    entry = var;
+  };
+
+  // Wire up the parent var decls for each variable that occurs within
+  // the patterns of each case item. in source order.
+  for (const auto &caseItem : caseStmt->getCaseLabelItems()) {
+    caseItem.getPattern()->forEachVariable(recordVar);
+  }
+
+  // Wire up the case body variables to the latest patterns.
+  for (auto bodyVar : caseStmt->getCaseBodyVariablesOrEmptyArray()) {
+    recordVar(bodyVar);
+  }
+}

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1659,6 +1659,28 @@ bool areGenericRequirementsSatisfied(const DeclContext *DC,
                                      GenericSignature sig,
                                      SubstitutionMap Substitutions,
                                      bool isExtension);
+
+/// Bind all of the pattern variables that occur within a case statement and
+/// all of its case items to their "parent" pattern variables, forming chains
+/// of variables with the same name.
+///
+/// Given a case such as:
+/// \code
+/// case .a(let x), .b(let x), .c(let x):
+/// \endcode
+///
+/// Each case item contains a (different) pattern variable named.
+/// "x". This function will set the "parent" variable of the
+/// second and third "x" variables to the "x" variable immediately
+/// to its left. A fourth "x" will be the body case variable,
+/// whose parent will be set to the "x" within the final case
+/// item.
+///
+/// Each of the "x" variables must eventually have the same type, and agree on
+/// let vs. var. This function does not perform any of that validation, leaving
+/// it to later stages.
+void bindSwitchCasePatternVars(CaseStmt *stmt);
+
 } // end namespace swift
 
 #endif

--- a/test/Constraints/function_builder.swift
+++ b/test/Constraints/function_builder.swift
@@ -563,3 +563,56 @@ tuplify(true) { c in
 // CHECK: testIfLetAsMatching
 // CHECK-SAME: "subMethod"
 // CHECK-SAME: "Superclass instance"
+
+
+// switch statements
+func testSwitch(_ e: E) {
+  tuplify(true) { c in
+    "testSwitch"
+    switch e {
+    case .a:
+      "a"
+    case .b(let i, let s?):
+      i * 2
+      s + "!"
+    case .b(let i, nil):
+      "just \(i)"
+    }
+  }
+}
+
+// CHECK: testSwitch
+// CHECK-SAME: first(main.Either<Swift.String, (Swift.Int, Swift.String)>.first("a"))
+testSwitch(getE(0))
+
+// CHECK: testSwitch
+// CHECK-SAME: first(main.Either<Swift.String, (Swift.Int, Swift.String)>.second(34, "hello!"))
+testSwitch(getE(1))
+
+// CHECK: testSwitch
+// CHECK-SAME: second("just 42")
+testSwitch(getE(2))
+
+func testSwitchCombined(_ e: E) {
+  tuplify(true) { c in
+    "testSwitchCombined"
+    switch e {
+    case .a:
+      "a"
+    case .b(let i, _?), .b(let i, nil):
+      "just \(i)"
+    }
+  }
+}
+
+// CHECK: testSwitchCombined
+// CHECK-SAME: main.Either<Swift.String, Swift.String>.first("a")
+testSwitchCombined(getE(0))
+
+// CHECK: testSwitchCombined
+// CHECK-SAME: second("just 17")
+testSwitchCombined(getE(1))
+
+// CHECK: testSwitchCombined
+// CHECK-SAME: second("just 42")
+testSwitchCombined(getE(2))

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -377,3 +377,25 @@ func testSwitch(e: E) {
   }
 }
 
+// Ensure that we don't back-propagate constraints to the subject
+// expression. This is a potential avenue for future exploration, but
+// is currently not supported by switch statements outside of function
+// builders. It's better to be consistent for now.
+enum E2 {
+  case b(Int, String?) // expected-note{{'b' declared here}}
+}
+
+func getSomeEnumOverloaded(_: Double) -> E { return .a }
+func getSomeEnumOverloaded(_: Int) -> E2 { return .b(0, nil) }
+
+func testOverloadedSwitch() {
+  tuplify(true) { c in
+    // FIXME: Bad source location.
+    switch getSomeEnumOverloaded(17) { // expected-error{{type 'E2' has no member 'a'; did you mean 'b'?}}
+    case .a:
+      "a"
+    default:
+      "default"
+    }
+  }
+}


### PR DESCRIPTION
Implement support for switch statements within function builders. Cases can
perform arbitrary pattern matches, e.g.,

    tuplify(true) { c in
      "testSwitchCombined"
      switch e {
      case .a:
        "a"
      case .b(let i, _?), .b(let i, nil):
        i + 17
      }
    }

subject to the normal rules of switch statements. Cases within function
builders cannot, however, include “fallthrough” statements, because those
(like “break” and “continue”) are control flow.

The translation of performed for `switch` statements is similar to that of
`if` statements, using `buildEither(first:)` and `buildEither(second:)` on
the function builder type.

This is the bulk of switch support, tracked by rdar://problem/50426203.