### PR TITLE
[AutoDiff] Enable `@differentiable` attribute on setters.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3659,11 +3659,10 @@ resolveDifferentiableAttrOriginalFunction(DifferentiableAttr *attr) {
     }
   }
   // Non-`get` accessors are not yet supported: `set`, `read`, and `modify`.
-  // TODO(TF-129): Enable `set` when differentiation supports inout parameters.
   // TODO(TF-1080): Enable `read` and `modify` when differentiation supports
   // coroutines.
   if (auto *accessor = dyn_cast_or_null<AccessorDecl>(original))
-    if (!accessor->isGetter())
+    if (!accessor->isGetter() && !accessor->isSetter())
       original = nullptr;
   // Diagnose if original `AbstractFunctionDecl` could not be resolved.
   if (!original) {

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -154,7 +154,10 @@ struct DifferentiableInstanceMethod: Differentiable {
 }
 
 // Test subscript methods.
-struct SubscriptMethod {
+struct SubscriptMethod: Differentiable {
+  typealias TangentVector = DummyTangentVector
+  mutating func move(along _: TangentVector) {}
+
   @differentiable // ok
   subscript(implicitGetter x: Float) -> Float {
     return x
@@ -169,14 +172,14 @@ struct SubscriptMethod {
   subscript(explicit x: Float) -> Float {
     @differentiable // ok
     get { return x }
-    @differentiable // expected-error {{'@differentiable' attribute cannot be applied to this declaration}}
+    @differentiable // ok
     set {}
   }
 
   subscript(x: Float, y: Float) -> Float {
     @differentiable // ok
     get { return x + y }
-    @differentiable // expected-error {{'@differentiable' attribute cannot be applied to this declaration}}
+    @differentiable // ok
     set {}
   }
 }
@@ -370,9 +373,7 @@ extension JVPStruct {
     get {
       return 0
     }
-    // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
-    // expected-error @+1 {{'@differentiable' attribute cannot be applied to this declaration}}
-    @differentiable(jvp: computedPropJVP)
+    @differentiable
     set {
       fatalError("unimplemented")
     }
@@ -532,9 +533,7 @@ extension VJPStruct {
     get {
       return 0
     }
-    // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
-    // expected-error @+1 {{'@differentiable' attribute cannot be applied to this declaration}}
-    @differentiable(vjp: computedPropVJP)
+    @differentiable
     set {
       fatalError("unimplemented")
     }
@@ -1213,16 +1212,15 @@ extension InoutParameters {
   mutating func mutatingMethod(_ other: Self) -> Self {}
 }
 
-// Test unsupported accessors: `set`, `_read`, `_modify`.
+// Test accessors: `set`, `_read`, `_modify`.
 
-struct UnsupportedAccessors: Differentiable {
+struct Accessors: Differentiable {
   typealias TangentVector = DummyTangentVector
   mutating func move(along _: TangentVector) {}
 
   var stored: Float
   var computed: Float {
     // `set` has an `inout` parameter: `(inout Self) -> (Float) -> ()`.
-    // expected-error @+1 {{'@differentiable' attribute cannot be applied to this declaration}}
     @differentiable
     set { stored = newValue }
 

--- a/test/AutoDiff/downstream/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/downstream/differentiable_attr_type_checking.swift
@@ -134,7 +134,7 @@ struct DifferentiableInstanceMethod : Differentiable {
 }
 
 // Test subscript methods.
-struct SubscriptMethod {
+struct SubscriptMethod: Differentiable {
   @differentiable // ok
   subscript(implicitGetter x: Float) -> Float {
     return x
@@ -149,14 +149,14 @@ struct SubscriptMethod {
   subscript(explicit x: Float) -> Float {
     @differentiable // ok
     get { return x }
-    @differentiable // expected-error {{'@differentiable' attribute cannot be applied to this declaration}}
+    @differentiable // ok
     set {}
   }
 
   subscript(x: Float, y: Float) -> Float {
     @differentiable // ok
     get { return x + y }
-    @differentiable // expected-error {{'@differentiable' attribute cannot be applied to this declaration}}
+    @differentiable // ok
     set {}
   }
 }
@@ -350,9 +350,7 @@ extension JVPStruct {
     get {
       return 0
     }
-    // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
-    // expected-error @+1 {{'@differentiable' attribute cannot be applied to this declaration}}
-    @differentiable(jvp: computedPropJVP)
+    @differentiable
     set {
       fatalError("unimplemented")
     }
@@ -512,9 +510,7 @@ extension VJPStruct {
     get {
       return 0
     }
-    // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
-    // expected-error @+1 {{'@differentiable' attribute cannot be applied to this declaration}}
-    @differentiable(vjp: computedPropVJP)
+    @differentiable
     set {
       fatalError("unimplemented")
     }
@@ -1137,13 +1133,11 @@ final class FinalClass: Differentiable {
   }
 }
 
-// Test unsupported accessors: `set`, `_read`, `_modify`.
+// Test accessors: `set`, `_read`, `_modify`.
 
-struct UnsupportedAccessors: Differentiable {
+struct Accessors: Differentiable {
   var stored: Float
   var computed: Float {
-    // `set` has an `inout` parameter: `(inout Self) -> (Float) -> ()`.
-    // expected-error @+1 {{'@differentiable' attribute cannot be applied to this declaration}}
     @differentiable
     set { stored = newValue }
 


### PR DESCRIPTION
Enable `@differentiable` attribute on setters of properties in
`Differentiable`-conforming types.

Resolves TF-1166.

Todos:
- TF-1184: make `@differentiable` on `var` and `subscript` declarations imply
  `@differentiable` on both the getter and setter, not just the getter.
- Upstream changes.