### PR TITLE
Demangler: print substitutions in Demangler::dump()

### DIFF
--- a/lib/Demangling/NodeDumper.cpp
+++ b/lib/Demangling/NodeDumper.cpp
@@ -61,6 +61,12 @@ void swift::Demangle::Node::dump() {
 }
 
 void Demangler::dump() {
+  for (unsigned Idx = 0; Idx < Substitutions.size(); ++Idx) {
+    fprintf(stderr, "Substitution[%c]:\n", Idx + 'A');
+    Substitutions[Idx]->dump();
+    fprintf(stderr, "\n");
+  }
+
   for (unsigned Idx = 0; Idx < NodeStack.size(); ++Idx) {
     fprintf(stderr, "NodeStack[%u]:\n", Idx);
     NodeStack[Idx]->dump();


### PR DESCRIPTION
For better debugging of the demangler.
