### PR TITLE
[interface-gen] Avoid double-printing `mutating`

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2846,7 +2846,9 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
     if (!Options.SkipIntroducerKeywords) {
       if (decl->isStatic() && Options.PrintStaticKeyword)
         printStaticKeyword(decl->getCorrectStaticSpelling());
-      if (decl->isMutating() && !Options.excludeAttrKind(DAK_Mutating)) {
+      if (decl->isMutating() &&
+          !decl->getAttrs().hasAttribute<MutatingAttr>() &&
+          !Options.excludeAttrKind(DAK_Mutating)) {
         Printer.printKeyword("mutating", Options, " ");
       } else if (decl->isConsuming() && !decl->getAttrs().hasAttribute<ConsumingAttr>()) {
         Printer.printKeyword("__consuming", Options, " ");

--- a/test/SourceKit/InterfaceGen/Inputs/Foo3.swift
+++ b/test/SourceKit/InterfaceGen/Inputs/Foo3.swift
@@ -6,3 +6,11 @@ public class C {
     }
   }
 }
+
+public struct MyStruct {
+  public mutating func mutatingFunc() {}
+  public var mutVar: Int {
+    mutating get { 1 }
+    nonmutating set {}
+  }
+}

--- a/test/SourceKit/InterfaceGen/Inputs/swift_mod.swift
+++ b/test/SourceKit/InterfaceGen/Inputs/swift_mod.swift
@@ -9,3 +9,11 @@ public func pub_function() {}
 internal func int_function() {}
 fileprivate func fp_function() {}
 private func priv_function() {}
+
+public struct MyStruct {
+  public mutating func mutatingFunc() {}
+  public var mutVar: Int {
+    mutating get { 1 }
+    nonmutating set {}
+  }
+}

--- a/test/SourceKit/InterfaceGen/gen_swift_module.swift.from_swiftinterface.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module.swift.from_swiftinterface.response
@@ -4,6 +4,13 @@ public class MyClass {
     public func pub_method()
 }
 
+public struct MyStruct {
+
+    public mutating func mutatingFunc()
+
+    public var mutVar: Int { mutating get nonmutating set }
+}
+
 public func pub_function()
 
 
@@ -46,15 +53,97 @@ public func pub_function()
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 64,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 71,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 87,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 94,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 103,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 69,
+    key.offset: 108,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 128,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 135,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 139,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 147,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 153,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 162,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 166,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 178,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 187,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 194,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 199,
     key.length: 12
   }
 ]
-<<NULL>>
+[
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 147,
+    key.length: 3,
+    key.is_system: 1
+  }
+]
 [
   {
     key.kind: source.lang.swift.decl.class,
@@ -93,16 +182,76 @@ public func pub_function()
     ]
   },
   {
-    key.kind: source.lang.swift.decl.function.free,
+    key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.name: "pub_function()",
+    key.name: "MyStruct",
     key.offset: 64,
-    key.length: 19,
-    key.nameoffset: 69,
-    key.namelength: 14,
+    key.length: 121,
+    key.nameoffset: 71,
+    key.namelength: 8,
+    key.bodyoffset: 81,
+    key.bodylength: 103,
     key.attributes: [
       {
         key.offset: 57,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.function.method.instance,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "mutatingFunc()",
+        key.offset: 103,
+        key.length: 19,
+        key.nameoffset: 108,
+        key.namelength: 14,
+        key.attributes: [
+          {
+            key.offset: 94,
+            key.length: 8,
+            key.attribute: source.decl.attribute.mutating
+          },
+          {
+            key.offset: 87,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      },
+      {
+        key.kind: source.lang.swift.decl.var.instance,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "mutVar",
+        key.offset: 135,
+        key.length: 48,
+        key.typename: "Int",
+        key.nameoffset: 139,
+        key.namelength: 6,
+        key.bodyoffset: 152,
+        key.bodylength: 30,
+        key.attributes: [
+          {
+            key.offset: 128,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "pub_function()",
+    key.offset: 194,
+    key.length: 19,
+    key.nameoffset: 199,
+    key.namelength: 14,
+    key.attributes: [
+      {
+        key.offset: 187,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/test/SourceKit/InterfaceGen/gen_swift_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module.swift.response
@@ -5,6 +5,13 @@ public class MyClass {
     public func pub_method()
 }
 
+public struct MyStruct {
+
+    public mutating func mutatingFunc()
+
+    public var mutVar: Int { mutating get nonmutating set }
+}
+
 public func pub_function()
 
 
@@ -57,11 +64,86 @@ public func pub_function()
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 89,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 96,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 112,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 119,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 128,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 94,
+    key.offset: 133,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 153,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 160,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 164,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 172,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 178,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 187,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 191,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 203,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 212,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 219,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 224,
     key.length: 12
   }
 ]
@@ -70,6 +152,12 @@ public func pub_function()
     key.kind: source.lang.swift.ref.module,
     key.offset: 7,
     key.length: 17,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 172,
+    key.length: 3,
     key.is_system: 1
   }
 ]
@@ -111,16 +199,76 @@ public func pub_function()
     ]
   },
   {
-    key.kind: source.lang.swift.decl.function.free,
+    key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.name: "pub_function()",
+    key.name: "MyStruct",
     key.offset: 89,
-    key.length: 19,
-    key.nameoffset: 94,
-    key.namelength: 14,
+    key.length: 121,
+    key.nameoffset: 96,
+    key.namelength: 8,
+    key.bodyoffset: 106,
+    key.bodylength: 103,
     key.attributes: [
       {
         key.offset: 82,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.function.method.instance,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "mutatingFunc()",
+        key.offset: 128,
+        key.length: 19,
+        key.nameoffset: 133,
+        key.namelength: 14,
+        key.attributes: [
+          {
+            key.offset: 119,
+            key.length: 8,
+            key.attribute: source.decl.attribute.mutating
+          },
+          {
+            key.offset: 112,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      },
+      {
+        key.kind: source.lang.swift.decl.var.instance,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "mutVar",
+        key.offset: 160,
+        key.length: 48,
+        key.typename: "Int",
+        key.nameoffset: 164,
+        key.namelength: 6,
+        key.bodyoffset: 177,
+        key.bodylength: 30,
+        key.attributes: [
+          {
+            key.offset: 153,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "pub_function()",
+    key.offset: 219,
+    key.length: 19,
+    key.nameoffset: 224,
+    key.namelength: 14,
+    key.attributes: [
+      {
+        key.offset: 212,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/test/SourceKit/InterfaceGen/gen_swift_source.swift
+++ b/test/SourceKit/InterfaceGen/gen_swift_source.swift
@@ -16,3 +16,6 @@
 
 // RUN: %sourcekitd-test -req=interface-gen %S/Inputs/Foo3.swift -- %S/Inputs/Foo3.swift | %FileCheck -check-prefix=CHECK3 %s
 // CHECK3: public class C {
+// CHECK3: public struct MyStruct {
+// CHECK3:   public mutating func mutatingFunc()
+// CHECK3:   public var mutVar: Int { mutating get nonmutating set }


### PR DESCRIPTION
Revert a small change from dfe00c3 that caused us to start
double-printing the `mutating` keyword on functions.

rdar://59899776