### PR TITLE
Fix master-next

### DIFF
--- a/include/swift/AST/SimpleRequest.h
+++ b/include/swift/AST/SimpleRequest.h
@@ -24,6 +24,7 @@
 #include "swift/Basic/TypeID.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Error.h"
 #include <tuple>
 #include <type_traits>
 

--- a/include/swift/Frontend/FrontendInputsAndOutputs.h
+++ b/include/swift/Frontend/FrontendInputsAndOutputs.h
@@ -18,6 +18,7 @@
 #include "swift/Frontend/InputFile.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/StringMap.h"
 
 #include <string>
 #include <vector>

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -19,6 +19,7 @@
 
 #include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMapInfo.h"
+#include "llvm/Support/PointerLikeTypeTraits.h"
 #include "swift/Basic/InlineBitfield.h"
 #include "swift/Basic/LLVM.h"
 #include <type_traits>

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -46,6 +46,7 @@
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/Basic/Module.h"
+#include "clang/Basic/SourceManager.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/ConvertUTF.h"

--- a/lib/AST/ReferencedNameTracker.cpp
+++ b/lib/AST/ReferencedNameTracker.cpp
@@ -136,7 +136,7 @@ void ReferencedNameTracker::enumerateMemberUses(
       std::string context =
           DependencyKey::computeContextForProvidedEntity<NodeKind::member>(
               nominal);
-      std::string name = rawName.userFacingName();
+      std::string name = std::string(rawName.userFacingName());
       enumerateUsedDecl(NodeKind::member, context, name, isCascadingUse);
     }
   }

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -254,7 +254,7 @@ namespace {
 
     void addMessage(SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
                     StringRef Message) {
-      Messages.push_back({lineByteOffsetForLoc(SM, Loc), Kind, Message});
+      Messages.push_back({lineByteOffsetForLoc(SM, Loc), Kind, std::string(Message)});
     }
 
     void addHighlight(SourceManager &SM, CharSourceRange Range) {
@@ -264,7 +264,7 @@ namespace {
 
     void addFixIt(SourceManager &SM, CharSourceRange Range, StringRef Text) {
       FixIts.push_back({lineByteOffsetForLoc(SM, Range.getStart()),
-                        lineByteOffsetForLoc(SM, Range.getEnd()), Text});
+                        lineByteOffsetForLoc(SM, Range.getEnd()), std::string(Text)});
     }
 
     void render(unsigned LineNumberIndent, raw_ostream &Out) {

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -24,6 +24,7 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/Basic/Module.h"
+#include "clang/Basic/SourceManager.h"
 #include "clang/Index/USRGeneration.h"
 #include "clang/Lex/Lexer.h"
 #include "clang/Basic/CharInfo.h"

--- a/lib/IRGen/GenCoverage.cpp
+++ b/lib/IRGen/GenCoverage.cpp
@@ -145,6 +145,7 @@ void IRGenModule::emitCoverageMapping() {
   auto *RecordsVal = llvm::ConstantArray::get(RecordsTy, FunctionRecords);
 
   // Create the coverage data header.
+  const unsigned NRecords = 0;
   llvm::Type *CovDataHeaderTypes[] = {
 #define COVMAP_HEADER(Type, LLVMType, Name, Init) LLVMType,
 #include "llvm/ProfileData/InstrProfData.inc"

--- a/lib/IRGen/TypeLayout.h
+++ b/lib/IRGen/TypeLayout.h
@@ -16,6 +16,7 @@
 #include "TypeInfo.h"
 #include "swift/SIL/SILType.h"
 #include "llvm/ADT/FoldingSet.h"
+#include "llvm/Support/Debug.h"
 
 namespace swift {
 namespace irgen {

--- a/lib/PrintAsObjC/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.cpp
@@ -32,6 +32,7 @@
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/Basic/CharInfo.h"
+#include "clang/Basic/SourceManager.h"
 
 using namespace swift;
 using namespace swift::objc_translation;

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -284,7 +284,7 @@ bool SILGlobalOpt::isInLoop(SILBasicBlock *CurBB) {
 
   if (LoopCheckedFunctions.insert(F).second) {
     for (auto I = scc_begin(F); !I.isAtEnd(); ++I) {
-      if (I.hasLoop())
+      if (I.hasCycle())
         for (SILBasicBlock *BB : *I)
           LoopBlocks.insert(BB);
     }

--- a/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
@@ -1020,7 +1020,7 @@ static bool mergeAccesses(
   info.id = 0;
   for (auto sccIt = scc_begin(F); !sccIt.isAtEnd(); ++sccIt) {
     ++info.id;
-    info.hasLoop = sccIt.hasLoop();
+    info.hasLoop = sccIt.hasCycle();
     for (auto *bb : *sccIt) {
       blockToSCCMap.insert(std::make_pair(bb, info));
     }


### PR DESCRIPTION
Most of the fixes were fairly mechanical. Specifically, we needed to include some headers from llvm and clang, add some explicit StringRef to std::string conversions, and handle a method rename (SCCIterator::hasLoop -> SCCIterator::hasCycle).

cc @compnerd @JDevlieghere @smeenai 