### PR TITLE
[Constraint solver] Check switch exhaustiveness in function builders

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1123,6 +1123,8 @@ public:
       ++caseIndex;
     }
 
+    TypeChecker::checkSwitchExhaustiveness(switchStmt, dc, /*limited=*/false);
+
     return switchStmt;
   }
 

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -399,3 +399,18 @@ func testOverloadedSwitch() {
     }
   }
 }
+
+// Check exhaustivity.
+func testNonExhaustiveSwitch(e: E) {
+    tuplify(true) { c in
+    "testSwitch"
+    switch e { // expected-error{{switch must be exhaustive}}
+      // expected-note @-1{{add missing case: '.b(_, .none)'}}
+    case .a:
+      "a"
+    case .b(let i, let s?):
+      i * 2
+      s + "!"
+    }
+  }
+}


### PR DESCRIPTION
More to ensure that `switch` behaves the same way in function builders and outside.