### PR TITLE
Requestify SourceFile parsing

### DIFF
--- a/include/swift/AST/ParseRequests.h
+++ b/include/swift/AST/ParseRequests.h
@@ -80,6 +80,27 @@ public:
   void cacheResult(BraceStmt *value) const;
 };
 
+/// Parse the top-level decls of a SourceFile.
+class ParseSourceFileRequest
+    : public SimpleRequest<ParseSourceFileRequest,
+                           ArrayRef<Decl *>(SourceFile *),
+                           CacheKind::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  ArrayRef<Decl *> evaluate(Evaluator &evaluator, SourceFile *SF) const;
+
+public:
+  // Caching.
+  bool isCached() const { return true; }
+  Optional<ArrayRef<Decl *>> getCachedResult() const;
+  void cacheResult(ArrayRef<Decl *> decls) const;
+};
+
 /// The zone number for the parser.
 #define SWIFT_TYPEID_ZONE Parse
 #define SWIFT_TYPEID_HEADER "swift/AST/ParseTypeIDZone.def"

--- a/include/swift/AST/ParseTypeIDZone.def
+++ b/include/swift/AST/ParseTypeIDZone.def
@@ -19,3 +19,6 @@ SWIFT_REQUEST(Parse, ParseMembersRequest,
 SWIFT_REQUEST(Parse, ParseAbstractFunctionBodyRequest,
               BraceStmt *(AbstractFunctionDecl *), SeparatelyCached,
               NoLocationInfo)
+SWIFT_REQUEST(Parse, ParseSourceFileRequest,
+              ArrayRef<Decl *>(SourceFile *), SeparatelyCached,
+              NoLocationInfo)

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -306,10 +306,8 @@ public:
   const SourceFileKind Kind;
 
   enum ASTStage_t {
-    /// Parsing is underway.
-    Parsing,
-    /// Parsing has completed.
-    Parsed,
+    /// The source file is not name bound or type checked.
+    Unprocessed,
     /// Name binding has completed.
     NameBound,
     /// Type checking has completed.
@@ -321,7 +319,7 @@ public:
   ///
   /// Only files that have been fully processed (i.e. type-checked) will be
   /// forwarded on to IRGen.
-  ASTStage_t ASTStage = Parsing;
+  ASTStage_t ASTStage = Unprocessed;
 
   SourceFile(ModuleDecl &M, SourceFileKind K, Optional<unsigned> bufferID,
              ImplicitModuleImportKind ModImpKind, bool KeepParsedTokens = false,

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -27,6 +27,8 @@ class PersistentParserState;
 /// before being used for anything; a full type-check is also necessary for
 /// IR generation.
 class SourceFile final : public FileUnit {
+  friend class ParseSourceFileRequest;
+
 public:
   class Impl;
   struct SourceFileSyntaxInfo;
@@ -175,8 +177,11 @@ private:
   /// been validated.
   llvm::SetVector<ValueDecl *> UnvalidatedDeclsWithOpaqueReturnTypes;
 
-  /// The list of top-level declarations in the source file.
-  std::vector<Decl *> Decls;
+  /// The list of top-level declarations in the source file. This is \c None if
+  /// they have not yet been parsed.
+  /// FIXME: Once addTopLevelDecl/prependTopLevelDecl/truncateTopLevelDecls
+  /// have been removed, this can become an optional ArrayRef.
+  Optional<std::vector<Decl *>> Decls;
 
   using SeparatelyImportedOverlayMap =
     llvm::SmallDenseMap<ModuleDecl *, llvm::SmallPtrSet<ModuleDecl *, 1>>;
@@ -203,9 +208,12 @@ private:
   friend Impl;
 
 public:
-  /// Appends the given declaration to the end of the top-level decls list.
+  /// Appends the given declaration to the end of the top-level decls list. Do
+  /// not add any additional uses of this function.
   void addTopLevelDecl(Decl *d) {
-    Decls.push_back(d);
+    // Force decl parsing if we haven't already.
+    (void)getTopLevelDecls();
+    Decls->push_back(d);
   }
 
   /// Prepends a declaration to the top-level decls list.
@@ -215,18 +223,29 @@ public:
   ///
   /// See rdar://58355191
   void prependTopLevelDecl(Decl *d) {
-    Decls.insert(Decls.begin(), d);
+    // Force decl parsing if we haven't already.
+    (void)getTopLevelDecls();
+    Decls->insert(Decls->begin(), d);
   }
 
   /// Retrieves an immutable view of the list of top-level decls in this file.
-  ArrayRef<Decl *> getTopLevelDecls() const {
-    return Decls;
+  ArrayRef<Decl *> getTopLevelDecls() const;
+
+  /// Retrieves an immutable view of the top-level decls if they have already
+  /// been parsed, or \c None if they haven't. Should only be used for dumping.
+  Optional<ArrayRef<Decl *>> getCachedTopLevelDecls() const {
+    if (!Decls)
+      return None;
+    return llvm::makeArrayRef(*Decls);
   }
 
-  /// Truncates the list of top-level decls so it contains \c count elements.
+  /// Truncates the list of top-level decls so it contains \c count elements. Do
+  /// not add any additional uses of this function.
   void truncateTopLevelDecls(unsigned count) {
-    assert(count <= Decls.size() && "Can only truncate top-level decls!");
-    Decls.resize(count);
+    // Force decl parsing if we haven't already.
+    (void)getTopLevelDecls();
+    assert(count <= Decls->size() && "Can only truncate top-level decls!");
+    Decls->resize(count);
   }
 
   /// Retrieve the parsing options for the file.
@@ -456,6 +475,13 @@ public:
   /// Retrieves the previously set delayed parser state, asserting that it
   /// exists.
   PersistentParserState *getDelayedParserState() {
+    // Force parsing of the top-level decls, which will set DelayedParserState
+    // if necessary.
+    // FIXME: Ideally the parser state should be an output of
+    // ParseSourceFileRequest, but the evaluator doesn't currently support
+    // move-only outputs for cached requests.
+    (void)getTopLevelDecls();
+
     auto *state = DelayedParserState.get();
     assert(state && "Didn't set any delayed parser state!");
     return state;

--- a/include/swift/Parse/ParseSILSupport.h
+++ b/include/swift/Parse/ParseSILSupport.h
@@ -37,15 +37,6 @@ namespace swift {
     virtual bool parseSILProperty(Parser &P) = 0;
     virtual bool parseSILScope(Parser &P) = 0;
   };
-
-  /// To assist debugging parser crashes, tell us the location of the
-  /// current token.
-  class PrettyStackTraceParser : public llvm::PrettyStackTraceEntry {
-    Parser &P;
-  public:
-    explicit PrettyStackTraceParser(Parser &P) : P(P) {}
-    void print(llvm::raw_ostream &out) const override;
-  };
 } // end namespace swift
 
 #endif // SWIFT_PARSER_PARSESILSUPPORT_H

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -103,13 +103,6 @@ namespace swift {
 
   /// @}
 
-  /// Parse a single buffer into the given source file.
-  ///
-  /// \param SF The file within the module being parsed.
-  ///
-  /// \param BufferID The buffer to parse from.
-  void parseIntoSourceFile(SourceFile &SF, unsigned BufferID);
-
   /// Parse a source file's SIL declarations into a given SIL module.
   void parseSourceFileSIL(SourceFile &SF, SILParserState *sil);
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -781,13 +781,15 @@ namespace {
       PrintWithColorRAII(OS, ParenthesisColor) << '(';
       PrintWithColorRAII(OS, ASTNodeColor) << "source_file ";
       PrintWithColorRAII(OS, LocationColor) << '\"' << SF.getFilename() << '\"';
-      
-      for (Decl *D : SF.getTopLevelDecls()) {
-        if (D->isImplicit())
-          continue;
 
-        OS << '\n';
-        printRec(D);
+      if (auto decls = SF.getCachedTopLevelDecls()) {
+        for (Decl *D : *decls) {
+          if (D->isImplicit())
+            continue;
+
+          OS << '\n';
+          printRec(D);
+        }
       }
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1192,7 +1192,14 @@ void ModuleDecl::getImportedModules(SmallVectorImpl<ImportedModule> &modules,
 void
 SourceFile::getImportedModules(SmallVectorImpl<ModuleDecl::ImportedModule> &modules,
                                ModuleDecl::ImportFilter filter) const {
-  assert(ASTStage >= Parsed || Kind == SourceFileKind::SIL);
+  // FIXME: Ideally we should assert that the file has been name bound before
+  // calling this function. However unfortunately that can cause issues for
+  // overlays which can depend on a Clang submodule for the underlying framework
+  // they are overlaying, which causes us to attempt to load the overlay again.
+  // We need to find a way to ensure that an overlay dependency with the same
+  // name as the overlay always loads the underlying Clang module. We currently
+  // handle this for a direct import from the overlay, but not when it happens
+  // through other imports.
   assert(filter && "no imports requested?");
   for (auto desc : Imports) {
     ModuleDecl::ImportFilter requiredFilter;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -759,11 +759,7 @@ void CompilerInstance::performSema() {
 }
 
 void CompilerInstance::performSemaUpTo(SourceFile::ASTStage_t LimitStage) {
-  // FIXME: A lot of the logic in `performParseOnly` is a stripped-down version
-  // of the logic in `performSemaUpTo`.  We should try to unify them over time.
-  if (LimitStage <= SourceFile::Parsed) {
-    return performParseOnly();
-  }
+  assert(LimitStage > SourceFile::Unprocessed);
 
   FrontendStatsTracer tracer(getStatsReporter(), "perform-sema");
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -970,7 +970,7 @@ void CompilerInstance::parseLibraryFile(
       SourceFileKind::Library, implicitImports.kind, BufferID);
   addAdditionalInitialImportsTo(NextInput, implicitImports);
 
-  parseIntoSourceFile(*NextInput, BufferID);
+  // Name binding will lazily trigger parsing of the file.
   performNameBinding(*NextInput);
 }
 
@@ -1013,11 +1013,8 @@ void CompilerInstance::parseAndTypeCheckMainFileUpTo(
   auto DidSuppressWarnings = Diags.getSuppressWarnings();
   Diags.setSuppressWarnings(DidSuppressWarnings || !mainIsPrimary);
 
-  // Parse the Swift decls into the source file.
-  parseIntoSourceFile(MainFile, MainBufferID);
-
-  // For a primary, also perform type checking if needed. Otherwise, just do
-  // name binding.
+  // For a primary, perform type checking if needed. Otherwise, just do name
+  // binding.
   if (mainIsPrimary && LimitStage >= SourceFile::TypeChecked) {
     performTypeChecking(MainFile);
   } else {
@@ -1138,7 +1135,8 @@ void CompilerInstance::performParseOnly(bool EvaluateConditionals,
         SourceFileKind::Library, SourceFile::ImplicitModuleImportKind::None,
         BufferID, parsingOpts);
 
-    parseIntoSourceFile(*NextInput, BufferID);
+    // Force the parsing of the top level decls.
+    (void)NextInput->getTopLevelDecls();
   }
 
   // Now parse the main file.
@@ -1146,9 +1144,9 @@ void CompilerInstance::performParseOnly(bool EvaluateConditionals,
     SourceFile &MainFile =
         MainModule->getMainSourceFile(Invocation.getSourceFileKind());
     MainFile.SyntaxParsingCache = Invocation.getMainFileSyntaxParsingCache();
-    assert(MainBufferID == MainFile.getBufferID());
 
-    parseIntoSourceFile(MainFile, MainBufferID);
+    // Force the parsing of the top level decls.
+    (void)MainFile.getTopLevelDecls();
   }
 
   assert(Context->LoadedModules.size() == 1 &&

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -199,6 +199,7 @@ bool CompletionInstance::performCachedOperaitonIfPossible(
   DiagnosticEngine tmpDiags(tmpSM);
   std::unique_ptr<ASTContext> tmpCtx(
       ASTContext::get(langOpts, typeckOpts, searchPathOpts, tmpSM, tmpDiags));
+  registerParseRequestFunctions(tmpCtx->evaluator);
   registerIDERequestFunctions(tmpCtx->evaluator);
   registerTypeCheckerRequestFunctions(tmpCtx->evaluator);
   registerSILGenRequestFunctions(tmpCtx->evaluator);
@@ -209,7 +210,6 @@ bool CompletionInstance::performCachedOperaitonIfPossible(
   tmpSF->enableInterfaceHash();
   // Ensure all non-function-body tokens are hashed into the interface hash
   tmpCtx->LangOpts.EnableTypeFingerprints = false;
-  parseIntoSourceFile(*tmpSF, tmpBufferID);
 
   // Couldn't find any completion token?
   auto *newState = tmpSF->getDelayedParserState();
@@ -324,8 +324,8 @@ bool CompletionInstance::performCachedOperaitonIfPossible(
     // Tell the compiler instance we've replaced the code completion file.
     CI.setCodeCompletionFile(newSF);
 
-    // Re-parse the whole file. Still re-use imported modules.
-    parseIntoSourceFile(*newSF, newBufferID);
+    // Re-process the whole file (parsing will be lazily triggered). Still
+    // re-use imported modules.
     performNameBinding(*newSF);
     bindExtensions(*newSF);
 

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -232,7 +232,6 @@ doCodeCompletion(SourceFile &SF, StringRef EnteredCode, unsigned *BufferID,
     newSF.addImports(importsWithOptions);
   }
 
-  parseIntoSourceFile(newSF, *BufferID);
   performTypeChecking(newSF);
 
   performCodeCompletionSecondPass(newSF, *CompletionCallbacksFactory);

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -185,7 +185,6 @@ typeCheckREPLInput(ModuleDecl *MostRecentModule, StringRef Name,
     REPLInputFile.addImports(ImportsWithOptions);
   }
 
-  parseIntoSourceFile(REPLInputFile, BufferID);
   performTypeChecking(REPLInputFile);
   return REPLModule;
 }

--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -30,6 +30,7 @@ add_swift_host_library(swiftParse STATIC
     ParsedSyntaxRecorder.cpp.gyb)
 target_link_libraries(swiftParse PRIVATE
   swiftAST
-  swiftSyntax)
+  swiftSyntax
+  swiftSyntaxParse)
 
 add_dependencies(swiftParse swift-parse-syntax-generated-headers)

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -177,8 +177,7 @@ void ParseSourceFileRequest::cacheResult(ArrayRef<Decl *> decls) const {
   assert(!SF->Decls);
   SF->Decls = decls;
 
-  // Note that the source file is fully parsed and verify it.
-  SF->ASTStage = SourceFile::Parsed;
+  // Verify the parsed source file.
   verify(*SF);
 }
 

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -21,6 +21,8 @@
 #include "swift/AST/SourceFile.h"
 #include "swift/Parse/Parser.h"
 #include "swift/Subsystems.h"
+#include "swift/Syntax/SyntaxArena.h"
+#include "swift/SyntaxParse/SyntaxTreeCreator.h"
 
 using namespace swift;
 
@@ -105,6 +107,80 @@ BraceStmt *ParseAbstractFunctionBodyRequest::evaluate(
   llvm_unreachable("Unhandled BodyKind in switch");
 }
 
+//----------------------------------------------------------------------------//
+// ParseSourceFileRequest computation.
+//----------------------------------------------------------------------------//
+
+/// A thunk that deletes an allocated PersistentParserState. This is needed for
+/// us to be able to forward declare a unique_ptr to the state in the AST.
+static void deletePersistentParserState(PersistentParserState *state) {
+  delete state;
+}
+
+ArrayRef<Decl *> ParseSourceFileRequest::evaluate(Evaluator &evaluator,
+                                                  SourceFile *SF) const {
+  assert(SF);
+  auto &ctx = SF->getASTContext();
+  auto bufferID = SF->getBufferID();
+
+  // If there's no buffer, there's nothing to parse.
+  if (!bufferID)
+    return {};
+
+  std::shared_ptr<SyntaxTreeCreator> sTreeCreator;
+  if (SF->shouldBuildSyntaxTree()) {
+    sTreeCreator = std::make_shared<SyntaxTreeCreator>(
+        ctx.SourceMgr, *bufferID, SF->SyntaxParsingCache, ctx.getSyntaxArena());
+  }
+
+  // If we've been asked to silence warnings, do so now. This is needed for
+  // secondary files, which can be parsed multiple times.
+  auto &diags = ctx.Diags;
+  auto didSuppressWarnings = diags.getSuppressWarnings();
+  auto shouldSuppress = SF->getParsingOptions().contains(
+      SourceFile::ParsingFlags::SuppressWarnings);
+  diags.setSuppressWarnings(didSuppressWarnings || shouldSuppress);
+  SWIFT_DEFER { diags.setSuppressWarnings(didSuppressWarnings); };
+
+  // If this buffer is for code completion, hook up the state needed by its
+  // second pass.
+  PersistentParserState *state = nullptr;
+  if (ctx.SourceMgr.getCodeCompletionBufferID() == bufferID) {
+    state = new PersistentParserState();
+    SF->setDelayedParserState({state, &deletePersistentParserState});
+  }
+
+  FrontendStatsTracer tracer(ctx.Stats, "Parsing");
+  Parser parser(*bufferID, *SF, /*SIL*/ nullptr, state, sTreeCreator);
+  PrettyStackTraceParser StackTrace(parser);
+
+  llvm::SaveAndRestore<NullablePtr<llvm::MD5>> S(parser.CurrentTokenHash,
+                                                 SF->getInterfaceHashPtr());
+
+  SmallVector<Decl *, 128> decls;
+  parser.parseTopLevel(decls);
+
+  if (sTreeCreator) {
+    auto rawNode = parser.finalizeSyntaxTree();
+    sTreeCreator->acceptSyntaxRoot(rawNode, *SF);
+  }
+  return ctx.AllocateCopy(decls);
+}
+
+Optional<ArrayRef<Decl *>> ParseSourceFileRequest::getCachedResult() const {
+  auto *SF = std::get<0>(getStorage());
+  return SF->getCachedTopLevelDecls();
+}
+
+void ParseSourceFileRequest::cacheResult(ArrayRef<Decl *> decls) const {
+  auto *SF = std::get<0>(getStorage());
+  assert(!SF->Decls);
+  SF->Decls = decls;
+
+  // Note that the source file is fully parsed and verify it.
+  SF->ASTStage = SourceFile::Parsed;
+  verify(*SF);
+}
 
 // Define request evaluation functions for each of the type checker requests.
 static AbstractRequestFunction *parseRequestFunctions[] = {

--- a/lib/ParseSIL/CMakeLists.txt
+++ b/lib/ParseSIL/CMakeLists.txt
@@ -2,6 +2,5 @@ add_swift_host_library(swiftParseSIL STATIC
   ParseSIL.cpp)
 target_link_libraries(swiftParseSIL PRIVATE
   swiftSema
-  swiftSIL
-  swiftSyntaxParse)
+  swiftSIL)
 

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -129,8 +129,6 @@ ModuleDecl *SourceLoader::loadModule(SourceLoc importLoc,
                                           Ctx.LangOpts.CollectParsedToken,
                                           Ctx.LangOpts.BuildSyntaxTree);
   importMod->addFile(*importFile);
-
-  parseIntoSourceFile(*importFile, bufferID);
   performNameBinding(*importFile);
   importMod->setHasResolvedImports();
   return importMod;

--- a/unittests/Parse/TokenizerTests.cpp
+++ b/unittests/Parse/TokenizerTests.cpp
@@ -84,7 +84,8 @@ public:
   std::vector<Token> parseAndGetSplitTokens(unsigned BufID) {
     swift::ParserUnit PU(SM, SourceFileKind::Main, BufID,
                          LangOpts, TypeCheckerOptions(), "unknown");
-    PU.getParser().parseTopLevel();
+    SmallVector<Decl *, 8> decls;
+    PU.getParser().parseTopLevel(decls);
     return PU.getParser().getSplitTokens();
   }
   


### PR DESCRIPTION
Add `ParseSourceFileRequest` that parses a SourceFile for its top-level decls, and remove the parsing AST stages.