### PR TITLE
Sema: Stricter 'Subtype' constraint on tuple types

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1151,8 +1151,13 @@ ConstraintSystem::matchTupleTypes(TupleType *tuple1, TupleType *tuple2,
         if (kind <= ConstraintKind::Equal)
           return getTypeMatchFailure(locator);
 
-        // For subtyping constraints, just make sure that this name isn't
-        // used at some other position.
+        // With a subtype constraint, we require an exact name match if both
+        // labels are provided.
+        if (elt1.hasName() && elt2.hasName())
+          return getTypeMatchFailure(locator);
+
+        // Otherwise, we're allowed to introduce or eliminate labels, as long
+        // as the labels are disjoint.
         if (elt2.hasName() && tuple1->getNamedElementId(elt2.getName()) != -1)
           return getTypeMatchFailure(locator);
       }

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -318,3 +318,44 @@ struct DupLabelSubscript {
 
 let dupLabelSubscriptStruct = DupLabelSubscript()
 let _ = dupLabelSubscriptStruct[foo: 5, foo: 5] // ok
+
+// Bogus behavior of subtype constraints with tuple types
+// https://bugs.swift.org/browse/SR-12261
+
+func mismatchedLabelsAreNotOK1(
+  _ x: @escaping ((id: Int, data: String), Int) -> ())
+    -> ((id: Int, daata: String), Int) -> () {
+  return x
+  // expected-error@-1 {{cannot convert return expression of type '((id: Int, data: String), Int) -> ()' to return type '((id: Int, daata: String), Int) -> ()'}}
+}
+
+func mismatchedLabelsAreNotOK2(
+  _ x: @escaping ((id: Int, String), Int) -> ())
+    -> ((Int, id: String), Int) -> () {
+  return x
+  // expected-error@-1 {{cannot convert return expression of type '((id: Int, String), Int) -> ()' to return type '((Int, id: String), Int) -> ()'}}
+}
+
+func introducingLabelsIsOK(
+  _ x: @escaping ((id: Int, data: String), Int) -> ())
+    -> ((Int, String), Int) -> () {
+  return x
+}
+
+func eliminatingLabelsIsOK(
+  _ x: @escaping ((Int, String), Int) -> ())
+    -> ((id: Int, data: String), Int) -> () {
+  return x
+}
+
+func introducingAndEliminatingLabelsIsOK(
+  _ x: @escaping ((Int, data: String), Int) -> ())
+    -> ((id: Int, String), Int) -> () {
+  return x
+}
+
+func eliminatingAndIntroducingLabelsIsOK(
+  _ x: @escaping ((id: Int, String), Int) -> ())
+    -> ((Int, data: String), Int) -> () {
+  return x
+}


### PR DESCRIPTION
The 'ConstraintKind::Subtype' relation is meant to be a subset of the
'ConstraintKind::Conversion' relation, however for tuples we allowed some
subtypes that were not valid conversions. I believe this was an oversight.

Recall the rule for the 'ConstraintKind::Conversion' relation on tuple types:

1) Labeled elements can be shuffled; if a label appears on the left hand
   side and on the right hand side, we match the types regardless of
   the index.

2) Then, we remove all elements thus matched, and compare the remaining
   elements by index:

   - Labels can be introduced; if an element on the left has no label and
     the corresponding element on the right has a label, we match the types
     at that index.
   - Similarly, labels can be eliminated; if an element on the left has a
     label and the corresponding element on the right has no label, we
     match the types at that index.
   - Otherwise, the only remaining possibility is we have two elements with
     mismatched labels, where neither labels occurs in the other tuple
     (because if it did, we would have handled it as a 'shuffle' in step 1).
     The conversion fails in this case.

For subtype conversions, I believe the intent was to disallow 1) but
allow 2), so that for example (x: Int, y: String) was a subtype of
(Int, String), and vice versa. However, the check was too permissive, and
would accept a subtype conversion where the tuple labels had different names,
as long as the name on the right hand side did not appear on the left hand
side.

This allowed some weird subtype relations, such as the one in the original
bug report:

(id: Int, data: String) < (id: Int, dataa: String)

This patch changes the rule so that solving a subtype constraint on tuple
types only tolerates a label mismatch if one of the two labels was not
provided at all. Otherwise, we reject the constraint.

This is a source-breaking change. If there is significant fallout, we will
need to downgrade this to a warning. However, I believe the impact is going
to be very limited, since Subtype conversions don't come up much in
practice. Also, some cases we used to allow, such as the one in the bug
report, would actually cause runtime crashes.

Fixes <https://bugs.swift.org/browse/SR-12261>, <rdar://problem/59739719>.