### PR TITLE
[stdlib] Fix generic floating-point conversion when two representable values are equally close

### DIFF
--- a/test/stdlib/FloatingPoint.swift.gyb
+++ b/test/stdlib/FloatingPoint.swift.gyb
@@ -206,6 +206,16 @@ FloatingPoint.test("BinaryFloatingPoint/genericFloatingPointConversion") {
     Float._convert(
       from: Double._convert(from: Float.leastNonzeroMagnitude).value).value,
     Float.leastNonzeroMagnitude)
+
+  // Let's make sure that the correct value is returned when two representable
+  // values are equally close to the original value.
+  let bitPattern: UInt64 = 0b01111111111_0000000000000000000000110000000000000000000000000000
+  var z = Double(bitPattern: bitPattern)
+  expectEqual(Float._convert(from: z).value, Float(z))
+
+  z = Double(Float.greatestFiniteMagnitude) +
+      Double(Float.greatestFiniteMagnitude.ulp / 2)
+  expectEqual(Float._convert(from: z).value, Float(z))
 }
 
 func positiveOne<T: ExpressibleByIntegerLiteral>() -> T {


### PR DESCRIPTION
<!-- What's in this pull request? -->
The documentation for conversion between two floating-point types promises as follows:

> If two representable values are equally close, the result is the value with more trailing zeros in its significand bit pattern.

This promise is broken due to a straightfoward think-o: the existing implementation (by me 😢) compares the trailing zeros in the exponents' bit pattern instead of the significands'. We should fix this.

This PR addresses that problem, improves the readability of the conditions being tested, and adds tests.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-12312](https://bugs.swift.org/browse/SR-12312).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
