### PR TITLE
[ConstraintSystem] Bail out of applyFunctionBuilderBodyTransform if there is a failure in constraint generation.

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1297,11 +1297,13 @@ Optional<BraceStmt *> TypeChecker::applyFunctionBuilderBodyTransform(
     func->getBody()->walk(walker);
   }
 
-  // FIXME: check the result
-  cs.matchFunctionBuilder(func, builderType, resultContextType,
-                          resultConstraintKind,
-                          /*calleeLocator=*/cs.getConstraintLocator(fakeAnchor),
-                          /*FIXME:*/cs.getConstraintLocator(fakeAnchor));
+  if (auto result = cs.matchFunctionBuilder(
+          func, builderType, resultContextType, resultConstraintKind,
+          /*calleeLocator=*/cs.getConstraintLocator(fakeAnchor),
+          /*FIXME:*/cs.getConstraintLocator(fakeAnchor))) {
+    if (result->isFailure())
+      return nullptr;
+  }
 
   // Solve the constraint system.
   SmallVector<Solution, 4> solutions;

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -414,3 +414,16 @@ func testNonExhaustiveSwitch(e: E) {
     }
   }
 }
+
+// rdar://problem/59856491
+struct TestConstraintGenerationErrors {
+  @TupleBuilder var buildTupleFnBody: String {
+    String(nothing) // expected-error {{use of unresolved identifier 'nothing'}}
+  }
+
+  func buildTupleClosure() {
+    tuplify(true) { _ in
+      String(nothing) // expected-error {{use of unresolved identifier 'nothing'}}
+    }
+  }
+}


### PR DESCRIPTION
Previously, this crashed in cases where the function builder transform was applied to a function body and there were constraint generation errors:
```swift
@ViewBuilder var body: some View {
  Text(undeclared)
}
```
Resolves: rdar://problem/59856491
