### PR TITLE
AST: Centralize ABI-related deployment target checks

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -623,9 +623,26 @@ public:
   void addDestructorCleanup(T &object) {
     addCleanup([&object]{ object.~T(); });
   }
+
+  /// Get the runtime availability of the class metadata update callback
+  /// mechanism for the target platform.
+  AvailabilityContext getObjCMetadataUpdateCallbackAvailability();
+
+  /// Get the runtime availability of the objc_getClass() hook for the target
+  /// platform.
+  AvailabilityContext getObjCGetClassHookAvailability();
   
-  /// Get the runtime availability of the opaque types language feature for the target platform.
+  /// Get the runtime availability of features introduced in the Swift 5.0
+  /// compiler for the target platform.
+  AvailabilityContext getSwift50Availability();
+
+  /// Get the runtime availability of the opaque types language feature for the
+  /// target platform.
   AvailabilityContext getOpaqueTypeAvailability();
+
+  /// Get the runtime availability of the objc_loadClassref() entry point for
+  /// the target platform.
+  AvailabilityContext getObjCClassStubsAvailability();
 
   /// Get the runtime availability of features introduced in the Swift 5.1
   /// compiler for the target platform.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -390,33 +390,6 @@ namespace swift {
       return EffectiveLanguageVersion.isVersionAtLeast(major, minor);
     }
 
-    // The following deployment targets ship an Objective-C runtime supporting
-    // the class metadata update callback mechanism:
-    //
-    // - macOS 10.14.4
-    // - iOS 12.2
-    // - tvOS 12.2
-    // - watchOS 5.2
-    bool doesTargetSupportObjCMetadataUpdateCallback() const;
-
-    // The following deployment targets ship an Objective-C runtime supporting
-    // the objc_getClass() hook:
-    //
-    // - macOS 10.14.4
-    // - iOS 12.2
-    // - tvOS 12.2
-    // - watchOS 5.2
-    bool doesTargetSupportObjCGetClassHook() const;
-
-    // The following deployment targets ship an Objective-C runtime supporting
-    // the objc_loadClassref() entry point:
-    //
-    // - macOS 10.15
-    // - iOS 13
-    // - tvOS 13
-    // - watchOS 6
-    bool doesTargetSupportObjCClassStubs() const;
-
     /// Returns true if the given platform condition argument represents
     /// a supported target operating system.
     ///

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -217,7 +217,36 @@ AvailabilityContext AvailabilityInference::inferForType(Type t) {
   return walker.AvailabilityInfo;
 }
 
+AvailabilityContext ASTContext::getObjCMetadataUpdateCallbackAvailability() {
+  return getSwift50Availability();
+}
+
+AvailabilityContext ASTContext::getObjCGetClassHookAvailability() {
+  return getSwift50Availability();
+}
+
+AvailabilityContext ASTContext::getSwift50Availability() {
+  auto target = LangOpts.Target;
+  
+  if (target.isMacOSX()) {
+    return AvailabilityContext(
+                            VersionRange::allGTE(llvm::VersionTuple(10,14,4)));
+  } else if (target.isiOS()) {
+    return AvailabilityContext(
+                            VersionRange::allGTE(llvm::VersionTuple(12,2)));
+  } else if (target.isWatchOS()) {
+    return AvailabilityContext(
+                            VersionRange::allGTE(llvm::VersionTuple(5,2)));
+  } else {
+    return AvailabilityContext::alwaysAvailable();
+  }
+}
+
 AvailabilityContext ASTContext::getOpaqueTypeAvailability() {
+  return getSwift51Availability();
+}
+
+AvailabilityContext ASTContext::getObjCClassStubsAvailability() {
   return getSwift51Availability();
 }
 

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -360,33 +360,3 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
 
   return { false, false };
 }
-
-bool LangOptions::doesTargetSupportObjCMetadataUpdateCallback() const {
-  if (Target.isMacOSX())
-    return !Target.isMacOSXVersionLT(10, 14, 4);
-  if (Target.isiOS()) // also returns true on tvOS
-    return !Target.isOSVersionLT(12, 2);
-  if (Target.isWatchOS())
-    return !Target.isOSVersionLT(5, 2);
-
-  // Don't assert if we're running on a non-Apple platform; we still
-  // want to allow running tests that -enable-objc-interop.
-  return false;
-}
-
-bool LangOptions::doesTargetSupportObjCGetClassHook() const {
-  return doesTargetSupportObjCMetadataUpdateCallback();
-}
-
-bool LangOptions::doesTargetSupportObjCClassStubs() const {
-  if (Target.isMacOSX())
-    return !Target.isMacOSXVersionLT(10, 15);
-  if (Target.isiOS()) // also returns true on tvOS
-    return !Target.isOSVersionLT(13);
-  if (Target.isWatchOS())
-    return !Target.isOSVersionLT(6);
-
-  // Don't assert if we're running on a non-Apple platform; we still
-  // want to allow running tests that -enable-objc-interop.
-  return false;
-}

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -2347,7 +2347,10 @@ IRGenModule::getClassMetadataStrategy(const ClassDecl *theClass) {
 
     // If the Objective-C runtime is new enough, we can just use the update
     // pattern unconditionally.
-    if (Context.LangOpts.doesTargetSupportObjCMetadataUpdateCallback())
+    auto deploymentAvailability =
+      AvailabilityContext::forDeploymentTarget(Context);
+    if (deploymentAvailability.isContainedIn(
+          Context.getObjCMetadataUpdateCallbackAvailability()))
       return ClassMetadataStrategy::Update;
 
     // Otherwise, check if we have legacy type info for backward deployment.

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1294,8 +1294,11 @@ TypeConverter::TypeConverter(IRGenModule &IGM)
   // Whether the Objective-C runtime is guaranteed to invoke the class
   // metadata update callback when realizing a Swift class referenced from
   // Objective-C.
+  auto deploymentAvailability =
+    AvailabilityContext::forDeploymentTarget(IGM.Context);
   bool supportsObjCMetadataUpdateCallback =
-    IGM.Context.LangOpts.doesTargetSupportObjCMetadataUpdateCallback();
+    deploymentAvailability.isContainedIn(
+        IGM.Context.getObjCMetadataUpdateCallbackAvailability());
 
   // If our deployment target allows us to rely on the metadata update
   // callback being called, we don't have to emit a legacy layout for a

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4896,7 +4896,10 @@ static void inferStaticInitializeObjCMetadata(ClassDecl *classDecl) {
   // If the class does not have a custom @objc name and the deployment target
   // supports the objc_getClass() hook, the workaround is unnecessary.
   ASTContext &ctx = classDecl->getASTContext();
-  if (ctx.LangOpts.doesTargetSupportObjCGetClassHook() &&
+  auto deploymentAvailability =
+      AvailabilityContext::forDeploymentTarget(ctx);
+  if (deploymentAvailability.isContainedIn(
+        ctx.getObjCGetClassHookAvailability()) &&
       !hasExplicitObjCName(classDecl))
     return;
 


### PR DESCRIPTION
There were a couple of methods in LangOptions and some related ones in
Availability and ASTContext that were added more recently.

Refactor the three older checks to the newer scheme.