### PR TITLE
Disable LetPropertiesOpt on struct 'let's.

### DIFF
--- a/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
+++ b/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -16,7 +16,96 @@
 // if this pass can prove that it has analyzed all assignments of an initial
 // value to this property and all those assignments assign the same value
 // to this property.
-//===----------------------------------------------------------------------===//
+//
+// FIXME:
+//
+// This pass makes assumptions about the visibility of a type's memory
+// based on the visibility of its properties. This is the wrong way to think
+// about memory visibility.
+//
+// This pass wants assume that the contents of a property is known based on
+// whether the property is declared as a 'let' and the visibility of the
+// initializers that access the property. For example:
+//
+// public struct X<T> {
+//   public let hidden: T
+//
+//   init(t: T) { self.hidden = t }
+// }
+//
+// The pass currently assumes that `X` only takes on values that are
+// assigned by the invocations of `X.init`, which is only visible in `X`s
+// module. This is wrong if the layout of `Impl` is exposed to other
+// modules. A struct's memory may be initialized by any module with
+// access to the struct's layout.
+// 
+// In fact, this assumption is wrong even if the struct, and it's let
+// property cannot be accessed externally by name. In this next example,
+// external modules cannot access `Impl` or `Impl.hidden` by name, but
+// can still access the memory because the layout is exposed via a public type
+// that contains it.
+// 
+// ```
+// internal struct Impl<T> {
+//   let hidden: T
+// 
+//   init(t: T) { self.hidden = t }
+// }
+// 
+// public struct Wrapper<T> {
+//   var impl: Impl<T>
+//   
+//   public var property: T {
+//     get {
+//       return impl.hidden
+//     }
+//   }
+// }
+// ```
+// 
+// As long as `Wrapper`s layout is exposed to other modules, the contents of
+// `Wrapper`, `Impl`, and `hidden' can all be initialized in another
+// module. This following code is legal if Wrapper's home module is *not*
+// built with library evolution (or if Wrapper is declared `@frozen`).
+// 
+// func inExternalModule(buffer: UnsafeRawPointer) -> Wrapper<Int64> {
+//   return buffer.load(as: Wrapper<Int64>.self)
+// }
+// 
+// If library evolution is enabled and a `public` struct is not declared
+// `@frozen` then external modules cannot assume its layout, and therefore
+// cannot initialize the struct memory. In that case, it is possible to optimize
+// `X.hidden` and `Impl.hidden` as if the properties are only initialized inside
+// their home module.
+// 
+// The right way to view a type's memory visibility is to consider whether
+// external modules have access to the layout of the type. If not, then the
+// property can still be optimized As long as a struct is never enclosed in a
+// public effectively-`@frozen` type. However, finding all places where a struct
+// is explicitly created is still insufficient. Instead, the optimization needs
+// to find all uses of enclosing types and determine if every use has a known
+// constant initialization, or is simply copied from another value. If an
+// escaping unsafe pointer to any enclosing type is created, then the
+// optimization is not valid.
+// 
+// When viewed this way, the fact that a property is declared 'let' is mostly
+// irrelevant to this optimization--it can be expanded to handle non-'let'
+// properties. The more salient feature is whether the propery has a public
+// setter.
+//
+// For now, this optimization only recognizes class properties because class
+// properties are only accessibly via a ref_element_addr instruction. This is a
+// side effect of the fact that accessing a class property requires a "formal
+// access". This means that begin_access marker must be emitted directly on the
+// address produced by a ref_element_addr. Struct properties are not handled, as
+// explained above, because they can be indirectly accessed via addresses of
+// outer types.
+//
+// Note: Propagating the initialized constants of non-addressable aggregate
+// values (formation of 'struct's and 'tuple's) is a significantly different
+// problem. It can be done better in a separate constant-propagation pass that
+// propagates partial-constants into call arguments and out of returned values.
+// ===---------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "let-properties-opt"
 #include "swift/SIL/DebugUtils.h"
@@ -53,9 +142,9 @@ struct InitSequence {
 /// TODO: Don't occupy any storage for such let properties with constant
 /// initializers.
 ///
-/// Note: Storage from a let property can only be removed if this
-/// property can never be referenced from another module.
-
+/// Note: Storage from a 'let' property can only be removed if this property if
+/// the type is resilient (not fixed-layout) and the property cannot be read
+/// from another module.
 class LetPropertiesOpt {
   SILModule *Module;
 
@@ -88,8 +177,8 @@ public:
 
 protected:
   bool isConstantLetProperty(VarDecl *Property);
-  void collectPropertyAccess(SILInstruction *I, VarDecl *Property, bool NonRemovable);
-  void collectStructPropertiesAccess(StructInst *SI, bool NonRemovable);
+  void collectPropertyAccess(SingleValueInstruction *I, VarDecl *Property,
+                             bool NonRemovable);
   void optimizeLetPropertyAccess(VarDecl *SILG, const InitSequence &Init);
   bool analyzeInitValue(SILInstruction *I, VarDecl *Prop);
 };
@@ -204,44 +293,25 @@ void LetPropertiesOpt::optimizeLetPropertyAccess(VarDecl *Property,
     };
 
     // Look for any instructions accessing let properties.
-    if (isa<RefElementAddrInst>(Load) || isa<StructElementAddrInst>(Load) ||
-        isa<BeginAccessInst>(Load) || isa<BeginBorrowInst>(Load)) {
-      auto proj = cast<SingleValueInstruction>(Load);
+    auto *proj = cast<RefElementAddrInst>(Load);
 
-      // Copy the initializer into the function
-      // Replace the access to a let property by the value
-      // computed by this initializer.
-      SILValue clonedInit = cloneInitAt(proj);
-      for (auto UI = proj->use_begin(), E = proj->use_end(); UI != E;) {
-        auto *User = UI->getUser();
-        ++UI;
+    // Copy the initializer into the function
+    // Replace the access to a let property by the value
+    // computed by this initializer.
+    SILValue clonedInit = cloneInitAt(proj);
+    for (auto UI = proj->use_begin(), E = proj->use_end(); UI != E;) {
+      auto *User = UI->getUser();
+      ++UI;
 
-        // A nested begin_access will be mapped as a separate "Load".
-        if (isa<BeginAccessInst>(User) || isa<BeginBorrowInst>(User))
-          continue;
+      if (!canReplaceLoadSequence(User))
+        continue;
 
-        if (!canReplaceLoadSequence(User))
-          continue;
-
-        replaceLoadSequence(User, clonedInit);
-        eraseUsesOfInstruction(User);
-        User->eraseFromParent();
-        ++NumReplaced;
-      }
-      ChangedFunctions.insert(F);
-    } else if (auto proj = dyn_cast<StructExtractInst>(Load)) {
-      // Copy the initializer into the function
-      // Replace the access to a let property by the value
-      // computed by this initializer.
-      SILValue clonedInit = cloneInitAt(proj);
-      proj->replaceAllUsesWith(clonedInit);
-      LLVM_DEBUG(llvm::dbgs() << "Access to " << *Property <<" was replaced:\n";
-            clonedInit->dumpInContext());
-
-      proj->eraseFromParent();
+      replaceLoadSequence(User, clonedInit);
+      eraseUsesOfInstruction(User);
+      User->eraseFromParent();
       ++NumReplaced;
-      ChangedFunctions.insert(F);
     }
+    ChangedFunctions.insert(F);
   }
 
   LLVM_DEBUG(llvm::dbgs() << "Access to " << *Property << " was replaced "
@@ -379,11 +449,9 @@ bool LetPropertiesOpt::isConstantLetProperty(VarDecl *Property) {
 }
 
 static bool isProjectionOfProperty(SILValue addr, VarDecl *Property) {
+  addr = stripAccessMarkers(addr);
   if (auto *REA = dyn_cast<RefElementAddrInst>(addr)) {
     return REA->getField() == Property;
-  }
-  if (auto *SEA = dyn_cast<StructElementAddrInst>(addr)) {
-    return SEA->getField() == Property;
   }
   return false;
 }
@@ -392,19 +460,19 @@ static bool isProjectionOfProperty(SILValue addr, VarDecl *Property) {
 bool
 LetPropertiesOpt::analyzeInitValue(SILInstruction *I, VarDecl *Property) {
   SILValue value;
-  if (auto SI = dyn_cast<StructInst>(I)) {
-    value = SI->getFieldValue(Property);
-  } else if (auto SI = dyn_cast<StoreInst>(I)) {
-    auto Dest = stripAccessMarkers(SI->getDest());
-
-    assert(isProjectionOfProperty(stripAccessMarkers(SI->getDest()), Property)
-           && "Store instruction should store into a proper let property");
-    (void) Dest;
+  SILValue dest;
+  if (auto SI = dyn_cast<StoreInst>(I)) {
+    dest = stripAccessMarkers(SI->getDest());
     value = SI->getSrc();
   } else if (auto *copyAddr = dyn_cast<CopyAddrInst>(I)) {
+    dest = stripAccessMarkers(copyAddr->getDest());
     value = copyAddr->getSrc();
+  } else {
+    return false;
   }
-
+  assert(isProjectionOfProperty(dest, Property)
+         && "Store instruction should store into a proper let property");
+  (void)dest;
   // Check if it's just a copy from another instance of the struct.
   if (auto *LI = dyn_cast<LoadInst>(value)) {
     SILValue addr = LI->getOperand();
@@ -432,61 +500,6 @@ LetPropertiesOpt::analyzeInitValue(SILInstruction *I, VarDecl *Property) {
   }
 }
 
-// Analyze the 'struct' instruction and check if it initializes
-// any let properties by statically known constant initializers.
-void LetPropertiesOpt::collectStructPropertiesAccess(StructInst *SI,
-                                                     bool NonRemovable) {
-  auto structDecl = SI->getStructDecl();
-  // Check if this struct has any let properties.
-
-  // Bail, if this struct is known to contain nothing interesting.
-  if (SkipTypeProcessing.count(structDecl))
-    return;
-
-  // Get the set of let properties defined by this struct.
-  if (!NominalTypeLetProperties.count(structDecl)) {
-    // Compute the let properties of this struct.
-    SmallVector<VarDecl *, 4> LetProps;
-
-    for (auto Prop : structDecl->getStoredProperties()) {
-      if (!isConstantLetProperty(Prop))
-        continue;
-      LetProps.push_back(Prop);
-    }
-
-    if (LetProps.empty()) {
-      // No interesting let properties in this struct.
-      SkipTypeProcessing.insert(structDecl);
-      return;
-    }
-
-    NominalTypeLetProperties[structDecl] = LetProps;
-    LLVM_DEBUG(llvm::dbgs() << "Computed set of let properties for struct '"
-                            << structDecl->getName() << "'\n");
-  }
-
-  auto &Props = NominalTypeLetProperties[structDecl];
-
-  LLVM_DEBUG(llvm::dbgs() << "Found a struct instruction initializing some "
-                             "let properties: ";
-             SI->dumpInContext());
-  // Figure out the initializing sequence for each
-  // of the properties.
-  for (auto Prop : Props) {
-    if (SkipProcessing.count(Prop))
-      continue;
-    SILValue PropValue = SI->getOperandForField(Prop)->get();
-    LLVM_DEBUG(llvm::dbgs() << "Check the value of property '" << *Prop
-                            << "' :" << PropValue << "\n");
-    if (!analyzeInitValue(SI, Prop)) {
-      SkipProcessing.insert(Prop);
-      LLVM_DEBUG(llvm::dbgs() << "The value of a let property '" << *Prop
-                              << "' is not statically known\n");
-    }
-    (void) PropValue;
-  }
-}
-
 /// Check if I is a sequence of projections followed by a load.
 /// Since it is supposed to be a load from a let property with
 /// statically known constant initializer, only struct_element_addr
@@ -495,7 +508,8 @@ static bool isValidPropertyLoad(SILInstruction *I) {
   if (isa<LoadInst>(I))
     return true;
 
-  if (isa<StructElementAddrInst>(I) || isa<TupleElementAddrInst>(I)) {
+  if (isa<StructElementAddrInst>(I) || isa<TupleElementAddrInst>(I)
+      || isa<BeginAccessInst>(I)) {
     auto projection = cast<SingleValueInstruction>(I);
     for (auto Use : getNonDebugUses(projection)) {
       if (isIncidentalUse(Use->getUser()))
@@ -511,7 +525,7 @@ static bool isValidPropertyLoad(SILInstruction *I) {
 
 
 /// Remember where this property is accessed.
-void LetPropertiesOpt::collectPropertyAccess(SILInstruction *I,
+void LetPropertiesOpt::collectPropertyAccess(SingleValueInstruction *I,
                                              VarDecl *Property,
                                              bool NonRemovable) {
   if (!isConstantLetProperty(Property))
@@ -521,23 +535,24 @@ void LetPropertiesOpt::collectPropertyAccess(SILInstruction *I,
                           << *Property << "':\n";
              llvm::dbgs() << "The instructions are:\n"; I->dumpInContext());
 
-  if (isa<RefElementAddrInst>(I) || isa<StructElementAddrInst>(I) ||
-      isa<BeginAccessInst>(I) || isa<CopyAddrInst>(I) ||
-      isa<BeginBorrowInst>(I)) {
+  // Ignore the possibility of duplicate worklist entries. They cannot effect
+  // the SkipProcessing result, and we don't expect any exponential path
+  // explosion because none of the instructions have multiple address operands.
+  SmallVector<SingleValueInstruction *, 8> worklist = {I};
+  while (!worklist.empty()) {
     // Check if there is a store to this property.
-    auto projection = cast<SingleValueInstruction>(I);
+    auto *projection = worklist.pop_back_val();
     for (auto Use : getNonDebugUses(projection)) {
       auto *User = Use->getUser();
-      if (isIncidentalUse(User))
+      if (isIncidentalUse(User)) {
         continue;
-
-      // Each begin_access is analyzed as a separate property access. Do not
-      // consider a begin_access a use of the current projection.
-      if (isa<BeginAccessInst>(User) || isa<BeginBorrowInst>(I))
+      }
+      if (auto *bai = dyn_cast<BeginAccessInst>(User)) {
+        worklist.push_back(bai);
         continue;
-
+      }
       if (auto *copyAddr = dyn_cast<CopyAddrInst>(User)) {
-        if (copyAddr->getSrc() != projection ||
+        if (copyAddr->getDest() != projection ||
             !analyzeInitValue(copyAddr, Property)) {
           SkipProcessing.insert(Property);
           return;
@@ -584,25 +599,10 @@ void LetPropertiesOpt::run(SILModuleTransform *T) {
     bool NonRemovable = !F.shouldOptimize();
 
     for (auto &BB : F) {
-      for (auto &I : BB)
-        // Look for any instructions accessing let properties.
-        // It includes referencing this specific property (both reads and
-        // stores), as well as implicit stores by means of e.g.
-        // a struct instruction.
-        if (auto *BAI = dyn_cast<BeginAccessInst>(&I)) {
-          if (auto *REAI =
-                  dyn_cast<RefElementAddrInst>(stripAccessMarkers(BAI))) {
-            collectPropertyAccess(BAI, REAI->getField(), NonRemovable);
-          }
-        } else if (auto *REAI = dyn_cast<RefElementAddrInst>(&I)) {
+      for (auto &I : BB) {
+        if (auto *REAI = dyn_cast<RefElementAddrInst>(&I))
           collectPropertyAccess(REAI, REAI->getField(), NonRemovable);
-        } else if (auto *SEI = dyn_cast<StructExtractInst>(&I)) {
-          collectPropertyAccess(SEI, SEI->getField(), NonRemovable);
-        }  else if (auto *SEAI = dyn_cast<StructElementAddrInst>(&I)) {
-          collectPropertyAccess(SEAI, SEAI->getField(), NonRemovable);
-        } else if (auto *SI = dyn_cast<StructInst>(&I)) {
-          collectStructPropertiesAccess(SI, NonRemovable);
-        }
+      }
     }
   }
 

--- a/test/SILOptimizer/let_propagation.swift
+++ b/test/SILOptimizer/let_propagation.swift
@@ -173,6 +173,13 @@ public func testUseGlobalLet() -> Int32 {
 }
 */
 
+// FIXME: 'A1's let properties cannot be optimized in -primary-file
+// mode. However, this case could potentially be handled in WMO mode
+// by finding all enclosing types that reference 'A1'. If they are all
+// either internal or resilient and no pointers to these types escape,
+// then it may be possible to prove that code outside this module
+// never overwrites a value of type 'A1'. This will be easier to do
+// when access markers are guaranteed complete in the -O pipeline.
 struct A1 {
   private let x: Int32
   
@@ -190,14 +197,14 @@ struct A1 {
   }
 
   // CHECK-LABEL: sil hidden @$s15let_propagation2A1V2f1{{[_0-9a-zA-Z]*}}F
-  // CHECK: bb0
-  // CHECK: struct_extract {{.*}}#A1.x
-  // CHECK: struct_extract {{.*}}#Int32._value
-  // CHECK-NOT: load
-  // CHECK-NOT: struct_extract
-  // CHECK-NOT: struct_element_addr
-  // CHECK-NOT: ref_element_addr
-  // CHECK-NOT: bb1
+  // FIX_CHECK: bb0
+  // FIX_CHECK: struct_extract {{.*}}#A1.x
+  // FIX_CHECK: struct_extract {{.*}}#Int32._value
+  // FIX_CHECK-NOT: load
+  // FIX_CHECK-NOT: struct_extract
+  // FIX_CHECK-NOT: struct_element_addr
+  // FIX_CHECK-NOT: ref_element_addr
+  // FIX_CHECK-NOT: bb1
   // CHECK: return
   func f1() -> Int32 {
     // x should be loaded only once.
@@ -206,9 +213,9 @@ struct A1 {
 
   // CHECK-LABEL: sil hidden @$s15let_propagation2A1V2f2{{[_0-9a-zA-Z]*}}F
   // CHECK: bb0
-  // CHECK: integer_literal $Builtin.Int32, 200
-  // CHECK-NEXT: struct $Int32
-  // CHECK-NEXT: return
+  // FIX_CHECK: integer_literal $Builtin.Int32, 200
+  // FIX_CHECK-NEXT: struct $Int32
+  // FIX_CHECK-NEXT: return
   func f2() -> Int32 {
     // load y only once.
     return y + y

--- a/test/SILOptimizer/let_properties_opts.sil
+++ b/test/SILOptimizer/let_properties_opts.sil
@@ -78,3 +78,64 @@ bb0(%0 : @owned $HasCenter):
   destroy_value %0 : $HasCenter
   return %9 : $HasCenter
 }
+
+// -----------------------------------------------------------------------------
+// Test that struct 'let's are not replaced with constants. A struct
+// 'let' is part of a larger mutable value.
+
+private struct Inner {
+  @_hasStorage let val: Int32 { get }
+  init(val: Int32)
+}
+
+private struct Outer {
+  @_hasStorage @_hasInitialValue var inner: Inner { get set }
+  init(inner: Inner)
+}
+
+sil [transparent] @initInnerLet : $@convention(thin) () -> Inner {
+bb0:
+  %0 = integer_literal $Builtin.Int32, 1
+  %1 = struct $Int32 (%0 : $Builtin.Int32)
+  %2 = struct $Inner (%1 : $Int32)
+  return %2 : $Inner
+}
+
+// Check that the returned value is reloaded from inner.val after the memcpy.
+//
+// CHECK-LABEL: sil hidden @testStructLet : $@convention(thin) (@inout Outer) -> Int32 {
+// CHECK: bb0(%0 : $*Outer):
+// CHECK: [[OUTADR:%.*]] = address_to_pointer %0 : $*Outer to $Builtin.RawPointer
+// CHECK: builtin "int_memcpy_RawPointer_RawPointer_Int64"([[OUTADR]] : $Builtin.RawPointer, %{{.*}} : $Builtin.RawPointer, %{{.*}} : $Builtin.Int64, %{{.*}} : $Builtin.Int1) : $()
+// CHECK: [[INADR:%.*]] = struct_element_addr %0 : $*Outer, #Outer.inner
+// CHECK: [[VALADR:%.*]] = struct_element_addr [[INADR]] : $*Inner, #Inner.val
+// CHECK: [[VAL:%.*]] = load %22 : $*Int32
+// CHECK: return [[VAL]] : $Int32
+// CHECK-LABEL: } // end sil function 'testStructLet'
+sil hidden @testStructLet : $@convention(thin) (@inout Outer) -> Int32 {
+bb0(%0 : $*Outer):
+  %1 = address_to_pointer %0 : $*Outer to $Builtin.RawPointer
+  %2 = metatype $@thick Outer.Type
+  %3 = builtin "sizeof"<Outer>(%2 : $@thick Outer.Type) : $Builtin.Word
+  %4 = builtin "sextOrBitCast_Word_Int64"(%3 : $Builtin.Word) : $Builtin.Int64
+  %5 = integer_literal $Builtin.Int64, 0
+  %6 = builtin "cmp_slt_Int64"(%4 : $Builtin.Int64, %5 : $Builtin.Int64) : $Builtin.Int1
+  cond_fail %6 : $Builtin.Int1, "UnsafeMutableRawBufferPointer with negative count"
+  %8 = integer_literal $Builtin.Int32, 0
+  %9 = struct $Int32 (%8 : $Builtin.Int32)
+  %10 = integer_literal $Builtin.Int1, 0
+  %11 = alloc_stack $Int32
+  store %9 to %11 : $*Int32
+  %13 = address_to_pointer %11 : $*Int32 to $Builtin.RawPointer
+  %14 = metatype $@thick Int32.Type
+  %15 = builtin "sizeof"<Int32>(%14 : $@thick Int32.Type) : $Builtin.Word
+  %16 = builtin "sextOrBitCast_Word_Int64"(%15 : $Builtin.Word) : $Builtin.Int64
+  %17 = builtin "cmp_slt_Int64"(%16 : $Builtin.Int64, %5 : $Builtin.Int64) : $Builtin.Int1
+  cond_fail %17 : $Builtin.Int1, "Negative value is not representable"
+  %19 = builtin "int_memcpy_RawPointer_RawPointer_Int64"(%1 : $Builtin.RawPointer, %13 : $Builtin.RawPointer, %16 : $Builtin.Int64, %10 : $Builtin.Int1) : $()
+  dealloc_stack %11 : $*Int32
+  %21 = struct_element_addr %0 : $*Outer, #Outer.inner
+  %22 = struct_element_addr %21 : $*Inner, #Inner.val
+  %23 = load %22 : $*Int32
+  return %23 : $Int32
+}

--- a/test/SILOptimizer/let_properties_opts.swift
+++ b/test/SILOptimizer/let_properties_opts.swift
@@ -1,4 +1,3 @@
-
 // RUN: %target-swift-frontend -module-name let_properties_opts %s -O -enforce-exclusivity=checked -emit-sil | %FileCheck -check-prefix=CHECK-WMO %s
 // RUN: %target-swift-frontend -module-name let_properties_opts -primary-file %s -O -emit-sil | %FileCheck %s
 
@@ -78,6 +77,11 @@ public class Foo1 {
   }
 }
 
+// FIXME: Handle properties of non-private structs in WMO mode at
+// least. All enclosing types need to be analyzed to determine if any
+// pointer that may reach the struct property has unknown uses. This
+// will be easier to do when access markers are guaranteed complete in
+// the -O pipeline.
 public struct Boo {
   public let Prop0: Int32 = 1
   let Prop1: Int32 = 1 + 4/2 + 8  
@@ -101,6 +105,11 @@ public class Foo2 {
 
 public class C {}
 
+// FIXME: Handle properties of non-private structs in WMO mode at
+// least. All enclosing types need to be analyzed to determine if any
+// pointer that may reach the struct property has unknown uses. This
+// will be easier to do when access markers are guaranteed complete in
+// the -O pipeline.
 struct Boo3 {
   //public 
   let Prop0: Int32
@@ -126,6 +135,12 @@ struct Boo3 {
 
 // The initializer of this struct can be defined elsewhere,
 // e.g. in an extension of this struct in a different module.
+//
+// FIXME: Handle properties of non-private structs in WMO mode at
+// least. All enclosing types need to be analyzed to determine if any
+// pointer that may reach the struct property has unknown uses. This
+// will be easier to do when access markers are guaranteed complete in
+// the -O pipeline.
 public struct StructWithOnlyPublicLetProperties {
   public let Prop0: Int32
   public let Prop1: Int32
@@ -139,6 +154,12 @@ public struct StructWithOnlyPublicLetProperties {
 // The initializer of this struct cannot be defined outside
 // of the current module, because it contains an internal stored
 // property, which is impossible to initialize outside of this module.
+//
+// FIXME: Handle properties of non-private structs in WMO mode at
+// least. All enclosing types need to be analyzed to determine if any
+// pointer that may reach the struct property has unknown uses. This
+// will be easier to do when access markers are guaranteed complete in
+// the -O pipeline.
 public struct StructWithPublicAndInternalLetProperties {
   public let Prop0: Int32
   internal let Prop1: Int32
@@ -152,6 +173,12 @@ public struct StructWithPublicAndInternalLetProperties {
 // The initializer of this struct cannot be defined elsewhere,
 // because it contains a fileprivate stored property, which is
 // impossible to initialize outside of this file.
+//
+// FIXME: Handle properties of non-private structs in WMO mode at
+// least. All enclosing types need to be analyzed to determine if any
+// pointer that may reach the struct property has unknown uses. This
+// will be easier to do when access markers are guaranteed complete in
+// the -O pipeline.
 public struct StructWithPublicAndInternalAndPrivateLetProperties {
   public let Prop0: Int32
   internal let Prop1: Int32
@@ -221,29 +248,42 @@ public func testClassPublicLet(_ f: Foo) -> Int32 {
   return f.Prop0
 }
 
+// FIXME: Handle struct properties.
+//
 // CHECK-LABEL: sil @$s19let_properties_opts13testStructLetys5Int32VAA3BooVF : $@convention(thin) (Boo) -> Int32
-// CHECK: bb0
-// CHECK: integer_literal $Builtin.Int32, 75
-// CHECK-NEXT: struct $Int32
-// CHECK-NEXT: return
+// FIX_CHECK: integer_literal $Builtin.Int32, 75
+// FIX_CHECK-NEXT: struct $Int32
+// FIX_CHECK-NEXT: return
+// CHECK: struct_extract %0 : $Boo, #Boo.Prop1
+// CHECK: struct_extract %0 : $Boo, #Boo.Prop2
+// CHECK: struct_extract %0 : $Boo, #Boo.Prop3
+// CHECK-LABEL: } // end sil function '$s19let_properties_opts13testStructLetys5Int32VAA3BooVF'
 public func testStructLet(_ b: Boo) -> Int32 {
   return b.Prop1 + b.Prop1 + b.Prop2 + b.Prop3
 }
 
+// FIXME: Handle struct properties.
+//
 // CHECK-LABEL: sil @$s19let_properties_opts13testStructLetys5Int32VAA3BooVzF : $@convention(thin) (@inout Boo) -> Int32
-// CHECK: bb0
-// CHECK: integer_literal $Builtin.Int32, 75
-// CHECK-NEXT: struct $Int32
-// CHECK-NEXT: return
+// FIX_CHECK: integer_literal $Builtin.Int32, 75
+// FIX_CHECK-NEXT: struct $Int32
+// FIX_CHECK-NEXT: return
+// CHECK: struct_element_addr %0 : $*Boo, #Boo.Prop1
+// CHECK: struct_element_addr %0 : $*Boo, #Boo.Prop2
+// CHECK: struct_element_addr %0 : $*Boo, #Boo.Prop3
+// CHECK-LABEL: } // end sil function '$s19let_properties_opts13testStructLetys5Int32VAA3BooVzF'
 public func testStructLet(_ b: inout Boo) -> Int32 {
   return b.Prop1 + b.Prop1 + b.Prop2 + b.Prop3
 }
 
+// FIXME: Handle struct properties.
+//
 // CHECK-LABEL: sil @$s19let_properties_opts19testStructPublicLetys5Int32VAA3BooVF : $@convention(thin) (Boo) -> Int32
-// CHECK: bb0
-// CHECK: integer_literal $Builtin.Int32, 1
-// CHECK-NEXT: struct $Int32
-// CHECK-NEXT: return
+// FIX_CHECK: integer_literal $Builtin.Int32, 1
+// FIX_CHECK-NEXT: struct $Int32
+// FIX_CHECK-NEXT: return
+// CHECK: struct_extract %0 : $Boo, #Boo.Prop0
+// CHECK-LABEL: } // end sil function '$s19let_properties_opts19testStructPublicLetys5Int32VAA3BooVF'
 public func testStructPublicLet(_ b: Boo) -> Int32 {
   return b.Prop0
 }
@@ -251,11 +291,10 @@ public func testStructPublicLet(_ b: Boo) -> Int32 {
 // Check that f.x is not constant folded, because the initializer of Foo2 has multiple
 // assignments to the property x with different values.
 // CHECK-LABEL: sil @$s19let_properties_opts13testClassLet2ys5Int32VAA4Foo2CF : $@convention(thin) (@guaranteed Foo2) -> Int32
-// bb0
 // CHECK: ref_element_addr %{{[0-9]+}} : $Foo2, #Foo2.x
 // CHECK-NOT: ref_element_addr %{{[0-9]+}} : $Foo2, #Foo2.x
 // CHECK-NOT: ref_element_addr %{{[0-9]+}} : $Foo2, #Foo2.x
-// CHECK: return
+// CHECK-LABEL: } // end sil function '$s19let_properties_opts13testClassLet2ys5Int32VAA4Foo2CF'
 public func testClassLet2(_ f: Foo2) -> Int32 {
   return f.x + f.x
 }
@@ -266,7 +305,7 @@ public func testClassLet2(_ f: Foo2) -> Int32 {
 // No constant folding should have been performed.
 // CHECK-WMO-NOT: integer_literal $Builtin.Int32, 92
 // CHECK-WMO: struct_extract
-// CHECK-WMO: }
+// CHECK-WMO-LABEL: } // end sil function '$s19let_properties_opts27testStructWithMultipleInitsys5Int32VAA4Boo3V_AFtF'
 @inline(never)
 func testStructWithMultipleInits( _ boos1: Boo3, _ boos2: Boo3) -> Int32 {
   let count1 =  boos1.Prop0 + boos1.Prop1 + boos1.Prop2 + boos1.Prop3
@@ -315,28 +354,43 @@ public func testStructPropertyAccessibility(_ b: StructWithOnlyPublicLetProperti
 // CHECK: struct_extract %0 : $StructWithPublicAndInternalLetProperties, #StructWithPublicAndInternalLetProperties.Prop0
 // CHECK-NOT: integer_literal $Builtin.Int32, 21
 // CHECK: return
+// CHECK-LABEL: } // end sil function '$s19let_properties_opts31testStructPropertyAccessibilityys5Int32VAA0E34WithPublicAndInternalLetPropertiesVF'
 
+// FIXME: Handle struct properties.
+//
 // CHECK-WMO-LABEL: sil @$s19let_properties_opts31testStructPropertyAccessibilityys5Int32VAA0E34WithPublicAndInternalLetPropertiesVF
-// CHECK-WMO: integer_literal $Builtin.Int32, 21
-// CHECK-WMO-NEXT: struct $Int32
-// CHECK-WMO-NEXT: return
+// FIX_CHECK-WMO: integer_literal $Builtin.Int32, 21
+// FIX_CHECK-WMO-NEXT: struct $Int32
+// FIX_CHECK-WMO-NEXT: return
+// CHECK-WMO: struct_extract %0 : $StructWithPublicAndInternalLetProperties, #StructWithPublicAndInternalLetProperties.Prop0
+// CHECK-WMO: struct_extract %0 : $StructWithPublicAndInternalLetProperties, #StructWithPublicAndInternalLetProperties.Prop1
+// CHECK-WMO-LABEL: } // end sil function '$s19let_properties_opts31testStructPropertyAccessibilityys5Int32VAA0E34WithPublicAndInternalLetPropertiesVF'
 public func testStructPropertyAccessibility(_ b: StructWithPublicAndInternalLetProperties) -> Int32 {
   return b.Prop0 + b.Prop1
 }
 
+// FIXME: Handle struct properties.
+//
 // Properties can be initialized only in this file, because one of the
 // properties is fileprivate.
 // Therefore their values are known and can be propagated.
 
-// CHECK: sil @$s19let_properties_opts31testStructPropertyAccessibilityys5Int32VAA0e21WithPublicAndInternalK20PrivateLetPropertiesVF
-// CHECK: integer_literal $Builtin.Int32, 33
-// CHECK-NEXT: struct $Int32
-// CHECK-NEXT: return
+// CHECK-LABEL: sil @$s19let_properties_opts31testStructPropertyAccessibilityys5Int32VAA0e21WithPublicAndInternalK20PrivateLetPropertiesVF
+// FIX_CHECK: integer_literal $Builtin.Int32, 33
+// FIX_CHECK-NEXT: struct $Int32
+// FIX_CHECK-NEXT: return
+// CHECK: struct_extract %0 : $StructWithPublicAndInternalAndPrivateLetProperties, #StructWithPublicAndInternalAndPrivateLetProperties.Prop0
+// CHECK: struct_extract %0 : $StructWithPublicAndInternalAndPrivateLetProperties, #StructWithPublicAndInternalAndPrivateLetProperties.Prop1
+// CHECK: struct_extract %0 : $StructWithPublicAndInternalAndPrivateLetProperties, #StructWithPublicAndInternalAndPrivateLetProperties.Prop2
+// CHECK-LABEL: } // end sil function '$s19let_properties_opts31testStructPropertyAccessibilityys5Int32VAA0e21WithPublicAndInternalK20PrivateLetPropertiesVF'
 
 // CHECK-WMO-LABEL: sil @$s19let_properties_opts31testStructPropertyAccessibilityys5Int32VAA0e21WithPublicAndInternalK20PrivateLetPropertiesVF
-// CHECK-WMO: integer_literal $Builtin.Int32, 33
-// CHECK-WMO-NEXT: struct $Int32
-// CHECK-WMO-NEXT: return
+// FIX_CHECK-WMO: integer_literal $Builtin.Int32, 33
+// FIX_CHECK-WMO-NEXT: struct $Int32
+// FIX_CHECK-WMO-NEXT: return
+// CHECK-WMO:struct_extract %0 : $StructWithPublicAndInternalAndPrivateLetProperties, #StructWithPublicAndInternalAndPrivateLetProperties.Prop0
+// CHECK-WMO:struct_extract %0 : $StructWithPublicAndInternalAndPrivateLetProperties, #StructWithPublicAndInternalAndPrivateLetProperties.Prop1
+// CHECK-WMO-LABEL: } // end sil function '$s19let_properties_opts31testStructPropertyAccessibilityys5Int32VAA0e21WithPublicAndInternalK20PrivateLetPropertiesVF'
 public func testStructPropertyAccessibility(_ b: StructWithPublicAndInternalAndPrivateLetProperties) -> Int32 {
   return b.Prop0 + b.Prop1 + b.Prop2
 }
@@ -361,12 +415,16 @@ struct RACStruct {
     var startIndex: Int { return 0 }
 
 
+    // FIXME: Handle struct properties.
+    //
     // CHECK-LABEL: RACStruct.endIndex.getter
     // CHECK-NEXT: sil hidden @{{.*}}endIndexSivg
-    // CHECK-NEXT: bb0
-    // CHECK-NEXT:   %1 = integer_literal $Builtin.Int{{.*}}, 27
-    // CHECK-NEXT:   %2 = struct $Int (%1 : $Builtin.Int{{.*}})
-    // CHECK-NEXT:   return %2 : $Int
+    // FIX_CHECK-NEXT: bb0
+    // FIX_CHECK-NEXT:   %1 = integer_literal $Builtin.Int{{.*}}, 27
+    // FIX_CHECK-NEXT:   %2 = struct $Int (%1 : $Builtin.Int{{.*}})
+    // FIX_CHECK-NEXT:   return %2 : $Int
+    // CHECK: struct_extract %0 : $RACStruct, #RACStruct.end
+    // CHECK-LABEL: } // end sil function '${{.*}}9RACStructV8endIndexSivg'
     var endIndex: Int { return end }
     
     subscript(_ bitIndex: Int) -> Bool {
@@ -376,3 +434,74 @@ struct RACStruct {
 }
 
 extension RACStruct : RandomAccessCollection {}
+
+// -----------------------------------------------------------------------------
+// Test that struct 'let's are not replaced with constants. A struct
+// 'let' is part of a larger mutable value.
+
+fileprivate struct Inner {
+  let val: Int32
+}
+
+fileprivate struct Outer {
+  var inner = Inner(val:1)
+}
+
+// CHECK-LABEL: sil private [noinline] @$s19let_properties_opts19testInnerStructLet1{{.*}}ys5Int32VAA5OuterACLLVzF : $@convention(thin) (@inout Outer) -> Int32 {
+// CHECK: bb0(%0 : $*Outer):
+// CHECK: [[OUTADR:%.*]] = address_to_pointer %0 : $*Outer to $Builtin.RawPointer
+// CHECK: builtin "int_memcpy_RawPointer_RawPointer_Int64"([[OUTADR]] : $Builtin.RawPointer, %{{.*}} : $Builtin.RawPointer, %{{.*}} : $Builtin.Int64, %{{.*}} : $Builtin.Int1) : $()
+// CHECK: [[INADR:%.*]] = struct_element_addr %0 : $*Outer, #Outer.inner
+// CHECK: [[VALADR:%.*]] = struct_element_addr [[INADR]] : $*Inner, #Inner.val
+// CHECK: [[VAL:%.*]] = load [[VALADR]] : $*Int32
+// CHECK: return [[VAL]] : $Int32
+// CHECK-LABEL: } // end sil function '$s19let_properties_opts19testInnerStructLet1{{.*}}ys5Int32VAA5OuterACLLVzF'
+//
+// CHECK-WMO-LABEL: sil private [noinline] @$s19let_properties_opts19testInnerStructLet1{{.*}} : $@convention(thin) (@inout Outer) -> Int32 {
+// CHECK-WMO: bb0(%0 : $*Outer):
+// CHECK-WMO: [[OUTADR:%.*]] = address_to_pointer %0 : $*Outer to $Builtin.RawPointer
+// CHECK-WMO: builtin "int_memcpy_RawPointer_RawPointer_Int64"([[OUTADR]] : $Builtin.RawPointer, %{{.*}} : $Builtin.RawPointer, %{{.*}} : $Builtin.Int64, %{{.*}} : $Builtin.Int1) : $()
+// CHECK-WMO: [[INADR:%.*]] = struct_element_addr %0 : $*Outer, #Outer.inner
+// CHECK-WMO: [[VALADR:%.*]] = struct_element_addr [[INADR]] : $*Inner, #Inner.val
+// CHECK-WMO: [[VAL:%.*]] = load [[VALADR]] : $*Int32
+// CHECK-WMO: return [[VAL]] : $Int32
+// CHECK-WMO-LABEL: } // end sil function '$s19let_properties_opts19testInnerStructLet
+@inline(never)
+private func testInnerStructLet1(_ outer: inout Outer) -> Int32 {
+  withUnsafeMutableBytes(of: &outer) {
+    $0.storeBytes(of: 0, as: Int32.self)
+  }
+  return outer.inner.val
+}
+
+// CHECK-LABEL: sil private [noinline] @$s19let_properties_opts19testInnerStructLet2{{.*}}ys5Int32VAA5OuterACLLVzF : $@convention(thin) (@inout Outer) -> Int32 {
+// CHECK: bb0(%0 : $*Outer):
+// CHECK: [[INADR:%.*]] = struct_element_addr %0 : $*Outer, #Outer.inner
+// CHECK: [[OUTADR:%.*]] = address_to_pointer [[INADR]] : $*Inner to $Builtin.RawPointer
+// CHECK: builtin "int_memcpy_RawPointer_RawPointer_Int64"([[OUTADR]] : $Builtin.RawPointer, %{{.*}} : $Builtin.RawPointer, %{{.*}} : $Builtin.Int64, %{{.*}} : $Builtin.Int1) : $()
+// CHECK: [[VALADR:%.*]] = struct_element_addr [[INADR]] : $*Inner, #Inner.val
+// CHECK: [[VAL:%.*]] = load [[VALADR]] : $*Int32
+// CHECK: return [[VAL]] : $Int32
+// CHECK-LABEL: } // end sil function '$s19let_properties_opts19testInnerStructLet2{{.*}}ys5Int32VAA5OuterACLLVzF'
+//
+// CHECK-WMO-LABEL: sil private [noinline] @$s19let_properties_opts19testInnerStructLet2{{.*}} : $@convention(thin) (@inout Outer) -> Int32 {
+// CHECK-WMO: bb0(%0 : $*Outer):
+// CHECK-WMO: [[INADR:%.*]] = struct_element_addr %0 : $*Outer, #Outer.inner
+// CHECK-WMO: [[OUTADR:%.*]] = address_to_pointer [[INADR]] : $*Inner to $Builtin.RawPointer
+// CHECK-WMO: builtin "int_memcpy_RawPointer_RawPointer_Int64"([[OUTADR]] : $Builtin.RawPointer, %{{.*}} : $Builtin.RawPointer, %{{.*}} : $Builtin.Int64, %{{.*}} : $Builtin.Int1) : $()
+// CHECK-WMO: [[VALADR:%.*]] = struct_element_addr [[INADR]] : $*Inner, #Inner.val
+// CHECK-WMO: [[VAL:%.*]] = load [[VALADR]] : $*Int32
+// CHECK-WMO: return [[VAL]] : $Int32
+// CHECK-WMO-LABEL: } // end sil function '$s19let_properties_opts19testInnerStructLet2
+@inline(never)
+private func testInnerStructLet2(_ outer: inout Outer) -> Int32 {
+  withUnsafeMutableBytes(of: &outer.inner) {
+    $0.storeBytes(of: 0, as: Int32.self)
+  }
+  return outer.inner.val
+}
+
+public func testInnerStructLetEntry() -> Int32 {
+  var outer = Outer()
+  return testInnerStructLet1(&outer) + testInnerStructLet2(&outer)
+}


### PR DESCRIPTION
This pass makes assumptions about the visibility of a type's memory based on the visibility of its properties. This is the wrong way to think about memory visibility.

Fixes <rdar://57564377> Struct component with 'let', unexpected behavior

This pass wants assume that the contents of a property is known based on whether the property is declared as a 'let' and the visibility of the initializers that access the property. For example:

```
public struct X<T> {
  public let hidden: T

  init(t: T) { self.hidden = t }
}
```

The pass currently assumes that `X` only takes on values that are
assigned by the invocations of `X.init`, which is only visible in `X`s
module. This is wrong if the layout of `Impl` is exposed to other
modules. A struct's memory may be initialized by any module with
access to the struct's layout.

In fact, this assumption is wrong even if the struct, and it's let
property cannot be accessed externally by name. In this next example,
external modules cannot access `Impl` or `Impl.hidden` by name, but
can still access the memory.

```
internal struct Impl<T> {
  let hidden: T

  init(t: T) { self.hidden = t }
}

public struct Wrapper<T> {
  var impl: Impl<T>
  
  public var property: T {
    get {
      return impl.hidden
    }
  }
}
```

As long as `Wrapper`s layout is exposed to other modules, the contents of `Wrapper`, `Impl`, and `hidden` can all be initialized in another module

```
// Legal as long Wrapper's home module is *not* built with library evolution
// (or if Wrapper is declared `@frozen`).
func inExternalModule(buffer: UnsafeRawPointer) -> Wrapper<Int64> {
  return buffer.load(as: Wrapper<Int64>.self)
}
```

This changes when library evolution is enabled. As long as a `public` struct is not declared `@frozen` then external modules cannot assume its layout, and cannot initialize the struct memory. In that case, it is possible to optimize `X.hidden` and `Impl.hidden` as if the properties are only initialized inside their home module.

The right way to view a type's memory visibility is whether external modules have access to the layout of the type. If not, then the property can still be optimized as a constant by finding all uses of it's enclosing types. As long as a struct is never enclosed in a public effectively-`@frozen` type, then the optimization still applies. However, finding all places where a struct is explicitly created is still insufficient. Instead, the optimization needs to find all uses of enclosing types and determine if every use has a known constant initialization, or is simply copied from another value. If an escaping unsafe pointer to any enclosing type is created, then the optimization is not valid.

When viewed this way, the fact that a property is declared 'let' is completely irrelevant to this optimization.