### PR TITLE
[ConstraintSystem] Refactor matchCallArguments

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -493,10 +493,10 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
   if (numClaimedArgs != numArgs) {
     // Find all of the named, unclaimed arguments.
     llvm::SmallVector<unsigned, 4> unclaimedNamedArgs;
-    for (nextArgIdx = 0; skipClaimedArgs(), nextArgIdx != numArgs;
-         ++nextArgIdx) {
-      if (!args[nextArgIdx].getLabel().empty())
-        unclaimedNamedArgs.push_back(nextArgIdx);
+    for (auto argIdx : indices(args)) {
+      if (claimedArgs[argIdx]) continue;
+      if (!args[argIdx].getLabel().empty())
+        unclaimedNamedArgs.push_back(argIdx);
     }
 
     if (!unclaimedNamedArgs.empty()) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -258,7 +258,7 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
       actualArgNames.resize(numArgs);
 
       // Figure out previous argument names from the parameter bindings.
-      for (unsigned i = 0; i != numParams; ++i) {
+      for (auto i : indices(params)) {
         const auto &param = params[i];
         bool firstArg = true;
 
@@ -526,7 +526,7 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
           // Find the closest matching unfulfilled named parameter.
           unsigned bestScore = 0;
           unsigned best = 0;
-          for (unsigned i = 0, n = unfulfilledNamedParams.size(); i != n; ++i) {
+          for (auto i : indices(unfulfilledNamedParams)) {
             unsigned param = unfulfilledNamedParams[i];
             auto paramName = params[param].getLabel();
 
@@ -583,7 +583,7 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
     // labels don't line up, if so let's try to claim arguments
     // with incorrect labels, and let OoO/re-labeling logic diagnose that.
     if (numArgs == numParams && numClaimedArgs != numArgs) {
-      for (unsigned i = 0; i < numArgs; ++i) {
+      for (auto i : indices(args)) {
         if (claimedArgs[i] || !parameterBindings[i].empty())
           continue;
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -539,12 +539,10 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
           // If we found a parameter to fulfill, do it.
           if (bestScore > 0) {
             // Bind this parameter to the argument.
-            nextArgIdx = argIdx;
             paramIdx = unfulfilledNamedParams[best];
             auto paramLabel = params[paramIdx].getLabel();
 
             parameterBindings[paramIdx].push_back(claim(paramLabel, argIdx));
-            skipClaimedArgs();
 
             // Erase this parameter from the list of unfulfilled named
             // parameters, so we don't try to fulfill it again.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -476,8 +476,8 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
     }
 
     // Claim the parameter/argument pair.
-    claimedArgs[numArgs-1] = true;
-    ++numClaimedArgs;
+    claim(params[lastParamIdx].getLabel(), numArgs - 1,
+          /*ignoreNameClash=*/true);
     // Let's claim the trailing closure unless it's an extra argument.
     if (!isExtraClosure)
       parameterBindings[lastParamIdx].push_back(numArgs - 1);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -400,7 +400,6 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
       // If the argument is itself variadic, we're forwarding varargs
       // with a VarargExpansionExpr; don't collect any more arguments.
       if (args[*claimed].isVariadic()) {
-        skipClaimedArgs();
         return;
       }
 
@@ -414,14 +413,12 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
       }
 
       nextArgIdx = currentNextArgIdx;
-      skipClaimedArgs();
       return;
     }
 
     // Try to claim an argument for this parameter.
     if (auto claimed = claimNextNamed(param.getLabel(), ignoreNameMismatch)) {
       parameterBindings[paramIdx].push_back(*claimed);
-      skipClaimedArgs();
       return;
     }
 
@@ -564,7 +561,6 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
     if (numClaimedArgs != numArgs) {
       // Restart at the first argument/parameter.
       nextArgIdx = 0;
-      skipClaimedArgs();
       haveUnfulfilledParams = false;
       for (paramIdx = 0; paramIdx != numParams; ++paramIdx) {
         // Skip fulfilled parameters.


### PR DESCRIPTION
This PR contains multiple small refactors for `matchCallArguments`.

@xedin Please review this PR.

I checked all commits by primary test suite.

I explain details here.

## use claim for trailing closure

Argument claiming is operated by modification of `claimedArgs` and `numClaimedArgs`.
There is a helper function `claim` for doing it.
But code for trailing closure in `bindNextParameter` modifies them directly.
This patch changes it to use `claim` function.

## remove unused nextArgIdx operation

This operation for `nextArgIdx` is meaningless.
It seems to come from old code and some changes make it meaningless.
This patch removes it.
 
## use local variable for temporary loop

This simple loop uses `nextArgIdx`.
But it doesn't relate to role of this variable which has a large scope.
This patch changes it to use individual local variable.

## remove unnecessary skipClaimedArgs call

There are multiple call of `skipClaimedArgs`.
But almost of them are meaningless.
Because the only use position of `nextArgIdx` which is `claimNextNamed` calls `skipClaimedArgs` on beginning of it before use `nextArgIdx`.
This patch removes them.
After this, use position of `skipClaimedArgs` is a only one in `claimNextNamed`.

## change nextArgIdx to local variable

A `matchCallArguments` is large function.
So it's local variable `nextArgIdx` also has large scope.
And it is reference captured by some nested function.
Splitting this variable into individuals which has small scope makes code more readable.
This patch does it.

## change paramIdx to local variable

Same idea with `nextArgIdx`.

There are some for-loops with `paramIdx`.
All of them doesn't need to use shared large scope variable.

This patch changes it.

And I replaced them to `for-in` style from three statements style if it can be.

## use for-in

This patch changes to `for-in` style if it can be.