### PR TITLE
Fix build breaks for master-next against llvm.org.

### DIFF
--- a/unittests/Basic/PrefixMapTest.cpp
+++ b/unittests/Basic/PrefixMapTest.cpp
@@ -40,7 +40,7 @@ struct Tester {
   // Performs an insert operation and tests that the result matches what
   // we get from the std::map.
   void insert(StringRef key, int value) {
-    auto stdmapResult = StdMap.insert({key, value});
+    auto stdmapResult = StdMap.insert({key.str(), value});
     auto premapResult = PreMap.insert(asArray(key), value);
 
     // Whether or not we modified the map should be the same in both
@@ -57,7 +57,7 @@ struct Tester {
   // Tests that the result of a findPrefix matches what we expect from
   // the std::map.
   void find(StringRef key) {
-    auto stdmapResult = StdMap.lower_bound(key);
+    auto stdmapResult = StdMap.lower_bound(key.str());
     while (stdmapResult == StdMap.end() ||
            !key.startswith(stdmapResult->first)) {
       if (stdmapResult == StdMap.begin()) {

--- a/unittests/ClangImporter/ClangImporterTests.cpp
+++ b/unittests/ClangImporter/ClangImporterTests.cpp
@@ -25,7 +25,7 @@ static bool emitFileWithContents(StringRef path, StringRef contents,
   if (llvm::sys::fs::openFileForWrite(path, FD))
     return true;
   if (pathOut)
-    *pathOut = path;
+    *pathOut = path.str();
   llvm::raw_fd_ostream file(FD, /*shouldClose=*/true);
   file << contents;
   return false;

--- a/unittests/FrontendTool/ModuleLoadingTests.cpp
+++ b/unittests/FrontendTool/ModuleLoadingTests.cpp
@@ -33,7 +33,7 @@ static bool emitFileWithContents(StringRef path, StringRef contents,
   if (llvm::sys::fs::openFileForWrite(path, fd))
     return true;
   if (pathOut)
-    *pathOut = path;
+    *pathOut = path.str();
   llvm::raw_fd_ostream file(fd, /*shouldClose=*/true);
   file << contents;
   return false;

--- a/unittests/IDE/Placeholders.cpp
+++ b/unittests/IDE/Placeholders.cpp
@@ -11,7 +11,7 @@ static std::string replaceFromString(const std::string &S,
   auto Buf = llvm::MemoryBuffer::getMemBufferCopy(S, "");
 
   Buf = ide::replacePlaceholders(std::move(Buf), HadPH);
-  return Buf->getBuffer();
+  return Buf->getBuffer().str();
 }
 
 TEST(Placeholders, Replace) {
@@ -83,6 +83,6 @@ TEST(Placeholders, TooShort) {
     Source += "<##>\n";
   }
   std::string Out = replaceFromString(Source);
-  std::string Last = StringRef(Out).substr(Out.size()-15);
+  std::string Last(StringRef(Out).substr(Out.size()-15));
   EXPECT_EQ("$_99\n$___\n$___\n", Last);
 }

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -151,14 +151,14 @@ public:
       [&](const RequestResult<CursorInfoData> &Result) {
         assert(!Result.isCancelled());
         if (Result.isError()) {
-          TestInfo.Error = Result.getError();
+          TestInfo.Error = Result.getError().str();
           sema.signal();
           return;
         }
         const CursorInfoData &Info = Result.value();
-        TestInfo.Name = Info.Name;
-        TestInfo.Typename = Info.TypeName;
-        TestInfo.Filename = Info.Filename;
+        TestInfo.Name = Info.Name.str();
+        TestInfo.Typename = Info.TypeName.str();
+        TestInfo.Filename = Info.Filename.str();
         TestInfo.DeclarationLoc = Info.DeclarationLoc;
         sema.signal();
       });


### PR DESCRIPTION
StringRef conversion to std::string needs to be explicit now.