### PR TITLE
[Runtime] Reject suffixes on ObjC mangled class names.

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -213,6 +213,9 @@ public:
   NodePointer getFirstChild() const {
     return getChild(0);
   }
+  NodePointer getLastChild() const {
+    return getChild(getNumChildren() - 1);
+  }
   NodePointer getChild(size_t index) const {
     assert(getNumChildren() > index);
     return begin()[index];

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1687,6 +1687,13 @@ getObjCClassByMangledName(const char * _Nonnull typeName,
     auto node = demangler.demangleSymbol(typeName);
     if (!node)
       return NO;
+
+    // If we successfully demangled but there is a suffix, then we did NOT use
+    // the entire name, and this is NOT a match. Reject it.
+    if (node->hasChildren() &&
+        node->getLastChild()->getKind() == Node::Kind::Suffix)
+      return NO;
+
     metadata = swift_getTypeByMangledNode(
       MetadataState::Complete, demangler, node,
       nullptr,

--- a/test/Interpreter/SDK/objc_getClass.swift
+++ b/test/Interpreter/SDK/objc_getClass.swift
@@ -261,6 +261,12 @@ testSuite.test("NotPresent") {
   expectNil(NSClassFromString("\u{1}badnews"));
   expectNil(NSClassFromString("$s\u{1}badnews"));
   expectNil(NSClassFromString("_T\u{1}badnews"));
+
+  // Correct mangled names with additional text afterwards should not resolve.
+  expectNil(NSClassFromString("_TtC4main20MangledSwiftSubclass_"))
+  expectNil(NSClassFromString("_TtC4main22MangledSwiftSuperclassXYZ"))
+  expectNil(NSClassFromString("_TtC4main19MangledObjCSubclass123"))
+  expectNil(NSClassFromString("_TtC4main21MangledObjCSuperclasswhee"))
 }
 
 runAllTests()


### PR DESCRIPTION
The demangler tolerates arbitrary suffixes on mangled names, and parses them as a Suffix node. When looking up a class by an ObjC mangled name, we don't want such demanglings to succeed, because this will result in false positives. It's expected that NSClassFromString(someClassName + "some suffix") will fail, unless something has actually created a class with that suffix.

rdar://problem/60012296