### PR TITLE
Updating the tensorflow_linux_* presets to pass enable-tensorflow

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2418,31 +2418,35 @@ mixin-preset=
     mixin_codesigning
 darwin-toolchain-installer-package=%(darwin_toolchain_installer_package)s
 
-[preset: tensorflow_linux]
-mixin-preset=buildbot_linux
+[preset: tensorflow_linux_base]
+enable-tensorflow
+install-tensorflow
+
 tensorflow-swift-apis
+install-tensorflow-swift-apis
+
 pythonkit
 install-pythonkit
 # The swift-package-tests fail when run with python3.
 test-installable-package=
 
+[preset: tensorflow_linux]
+mixin-preset=
+    buildbot_linux
+    tensorflow_linux_base
+
 [preset: tensorflow_linux,no_test]
-mixin-preset=buildbot_linux,no_test
-tensorflow-swift-apis
-pythonkit
-install-pythonkit
-# The swift-package-tests fail when run with python3.
-test-installable-package=
+mixin-preset=
+    buildbot_linux,no_test
+    tensorflow_linux_base
 
 [preset: tensorflow_linux,gpu]
 mixin-preset=tensorflow_linux
 enable-tensorflow-gpu
-install-tensorflow
 
 [preset: tensorflow_linux,gpu,no_test]
 mixin-preset=tensorflow_linux,no_test
 enable-tensorflow-gpu
-install-tensorflow
 
 #===------------------------------------------------------------------------===#
 # Swift for TensorFlow Preset


### PR DESCRIPTION
Updating the tensorflow_linux_* presets to pass enable-tensorflow.  Seems this was lost in the recent build shuffle.

@dan-zheng debugged this.