### PR TITLE
[test] Make sure tests use just-built libraries if use_os_stdlib isn't set

### DIFF
--- a/test/Interpreter/objc_class_properties_runtime.swift
+++ b/test/Interpreter/objc_class_properties_runtime.swift
@@ -3,7 +3,7 @@
 // RUN: %clang -arch x86_64 -mmacosx-version-min=10.11 -isysroot %sdk -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o
 
 // RUN: %swiftc_driver -target $(echo '%target-triple' | sed -E -e 's/macosx10.(9|10).*/macosx10.11/') -sdk %sdk -I %S/Inputs/ObjCClasses/ %t/ObjCClasses.o %s -o %t/a.out
-// RUN: %t/a.out
+// RUN: %target-run %t/a.out
 
 // REQUIRES: OS=macosx
 // REQUIRES: executable_test

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1523,22 +1523,6 @@ rth_flags = ''
 if swift_execution_tests_extra_flags:
     rth_flags = swift_execution_tests_extra_flags + ' -wmo'
 
-# FIXME: why can we not use %rth and have that be expanded out?
-config.target_resilience_test = (
-     '%r %s --target-build-swift "%s" --target-run "%s" --t %%t --S %%S '
-     '--s %%s --lib-prefix "%s" --lib-suffix "%s" --target-codesign "%s" '
-     '--additional-compile-flags "%s" --triple "%s"'
-     % (sys.executable, config.rth, config.target_build_swift,
-        config.target_run, config.target_shared_library_prefix,
-        config.target_shared_library_suffix, config.target_codesign,
-        rth_flags, config.variant_triple))
-
-# FIXME: Get symbol diffing working with binutils nm as well. The flags are slightly
-# different.
-if platform.system() != 'Darwin' or swift_test_mode == 'optimize_none_with_implicit_dynamic':
-    config.target_resilience_test = ('%s --no-symbol-diff' %
-                                     config.target_resilience_test)
-
 platform_module_dir = make_path(test_resource_dir, config.target_sdk_name)
 if run_vendor != 'apple':
     platform_module_dir = make_path(platform_module_dir, run_cpu)
@@ -1638,6 +1622,22 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%%line-directive %%t/main.swift -- '
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
+
+# FIXME: why can we not use %rth and have that be expanded out?
+config.target_resilience_test = (
+     '%r %s --target-build-swift "%s" --target-run "%s" --t %%t --S %%S '
+     '--s %%s --lib-prefix "%s" --lib-suffix "%s" --target-codesign "%s" '
+     '--additional-compile-flags "%s" --triple "%s"'
+     % (sys.executable, config.rth, config.target_build_swift,
+        config.target_run, config.target_shared_library_prefix,
+        config.target_shared_library_suffix, config.target_codesign,
+        rth_flags, config.variant_triple))
+
+# FIXME: Get symbol diffing working with binutils nm as well. The flags are slightly
+# different.
+if platform.system() != 'Darwin' or swift_test_mode == 'optimize_none_with_implicit_dynamic':
+    config.target_resilience_test = ('%s --no-symbol-diff' %
+                                     config.target_resilience_test)
 
 #
 # When changing substitutions, update docs/Testing.md.


### PR DESCRIPTION
In some cases, tests are trying to load OS-supplied libswift* libraries instead of the ones we just built. (This was uncovered by the recent work to create a new stdlib module in #27229.)