### PR TITLE
TBDGen: pass-down target variant when generating textual interface stubs

### DIFF
--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -978,7 +978,11 @@ GenerateTBDRequest::evaluate(Evaluator &evaluator,
 
   llvm::MachO::Target target(triple);
   file.addTarget(target);
-
+  // Add target variant
+  if (ctx.LangOpts.TargetVariant.hasValue()) {
+    llvm::MachO::Target targetVar(*ctx.LangOpts.TargetVariant);
+    file.addTarget(targetVar);
+  }
   StringSet symbols;
   auto *clang = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
   TBDGenVisitor visitor(file, {target}, &symbols,

--- a/test/TBD/app-extension.swift
+++ b/test/TBD/app-extension.swift
@@ -8,3 +8,8 @@
 
 // EXTENSIONSAFE-NOT: not_app_extension_safe
 // NOTEXTENSIONSAFE: not_app_extension_safe
+
+// RUN: %target-swift-frontend -target-variant x86_64-apple-ios13.0-macabi -typecheck %s -application-extension -emit-tbd -emit-tbd-path %t/target-variant.tbd
+// RUN: %FileCheck %s --check-prefix ZIPPERED < %t/target-variant.tbd
+
+// ZIPPERED: platform: zippered


### PR DESCRIPTION
rdar://60057760
