### PR TITLE
[Diagnostics] Emit a warning when an immutable decodable property has an initial value

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2716,8 +2716,8 @@ NOTE(codable_suggest_overriding_init_here,none,
      "did you mean to override 'init(from:)' and 'encode(to:)'?", ())
 
 WARNING(decodable_property_will_not_be_decoded, none,
-        "immutable property %0 will not be decoded because it is declared with "
-        "an initial value which cannot be overwritten", (DeclName))
+        "immutable property will not be decoded because it is declared with "
+        "an initial value which cannot be overwritten", ())
 NOTE(decodable_property_init_or_codingkeys_implicit, none,
      "set the initial value via the initializer or explicitly define a "
      "CodingKeys enum %select{including|without}0 a %1 case to silence "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2715,6 +2715,19 @@ NOTE(decodable_suggest_overriding_init_here,none,
 NOTE(codable_suggest_overriding_init_here,none,
      "did you mean to override 'init(from:)' and 'encode(to:)'?", ())
 
+WARNING(decodable_property_will_not_be_decoded, none,
+        "immutable property %0 will not be decoded because it is declared with "
+        "an initial value which cannot be overwritten", (DeclName))
+NOTE(decodable_property_init_or_codingkeys_implicit, none,
+     "set the initial value via the initializer or explicitly define a "
+     "CodingKeys enum %select{including|without}0 a %1 case to silence "
+     "this warning", (unsigned, DeclName))
+NOTE(decodable_property_init_or_codingkeys_explicit, none,
+     "set the initial value via the initializer or remove the %0 case from "
+     "the CodingKeys enum to silence this warning", (DeclName))
+NOTE(decodable_make_property_mutable, none,
+     "make the property mutable instead", ())
+
 NOTE(missing_member_type_conformance_prevents_synthesis, none,
      "%select{associated value|stored property}0 type %1 does not conform to "
      "protocol %2, preventing synthesized conformance "

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -876,8 +876,7 @@ deriveBodyDecodable_init(AbstractFunctionDecl *initDecl, void *) {
           }
         }
 
-        varDecl->diagnose(diag::decodable_property_will_not_be_decoded,
-                          varDecl->getName());
+        varDecl->diagnose(diag::decodable_property_will_not_be_decoded);
         if (codingKeysEnum->isImplicit()) {
           varDecl->diagnose(
               diag::decodable_property_init_or_codingkeys_implicit,

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -876,20 +876,18 @@ deriveBodyDecodable_init(AbstractFunctionDecl *initDecl, void *) {
           }
         }
 
-        C.Diags.diagnose(varDecl->getLoc(),
-                         diag::decodable_property_will_not_be_decoded,
-                         varDecl->getName());
+        varDecl->diagnose(diag::decodable_property_will_not_be_decoded,
+                          varDecl->getName());
         if (codingKeysEnum->isImplicit()) {
-          C.Diags.diagnose(varDecl->getLoc(),
-                           diag::decodable_property_init_or_codingkeys_implicit,
-                           conformsToEncodable ? 0 : 1, varDecl->getName());
+          varDecl->diagnose(
+              diag::decodable_property_init_or_codingkeys_implicit,
+              conformsToEncodable ? 0 : 1, varDecl->getName());
         } else {
-          C.Diags.diagnose(varDecl->getLoc(),
-                           diag::decodable_property_init_or_codingkeys_explicit,
-                           varDecl->getName());
+          varDecl->diagnose(
+              diag::decodable_property_init_or_codingkeys_explicit,
+              varDecl->getName());
         }
-        C.Diags
-            .diagnose(varDecl->getLoc(), diag::decodable_make_property_mutable)
+        varDecl->diagnose(diag::decodable_make_property_mutable)
             .fixItReplace(varDecl->getAttributeInsertionLoc(true), "var");
 
         continue;

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -830,9 +830,70 @@ deriveBodyDecodable_init(AbstractFunctionDecl *initDecl, void *) {
       std::tie(varDecl, varType, useIfPresentVariant) =
           lookupVarDeclForCodingKeysCase(conformanceDC, elt, targetDecl);
 
-      // Don't output a decode statement for a var let with a default value.
-      if (varDecl->isLet() && varDecl->isParentInitialized())
+      // Don't output a decode statement for a let with an initial value.
+      if (varDecl->isLet() && varDecl->isParentInitialized()) {
+        // But emit a warning to let the user know that it won't be decoded.
+        auto lookupResult =
+            codingKeysEnum->lookupDirect(varDecl->getBaseName());
+        auto keyExistsInCodingKeys =
+            llvm::any_of(lookupResult, [&](ValueDecl *VD) {
+              if (isa<EnumElementDecl>(VD)) {
+                return VD->getBaseName() == varDecl->getBaseName();
+              }
+              return false;
+            });
+        auto *encodableProto = C.getProtocol(KnownProtocolKind::Encodable);
+        bool conformsToEncodable =
+            TypeChecker::conformsToProtocol(
+                targetDecl->getDeclaredInterfaceType(), encodableProto,
+                conformanceDC,
+                ConformanceCheckFlags::SkipConditionalRequirements) != nullptr;
+
+        // Strategy to use for CodingKeys enum diagnostic part - this is to
+        // make the behaviour more explicit:
+        //
+        // 1. If we have an *implicit* CodingKeys enum:
+        // (a) If the type is Decodable only, explicitly define the enum and
+        //     remove the key from it. This makes it explicit that the key
+        //     will not be decoded.
+        // (b) If the type is Codable, explicitly define the enum and keep the
+        //     key in it. This is because removing the key will break encoding
+        //     which is mostly likely not what the user expects.
+        //
+        // 2. If we have an *explicit* CodingKeys enum:
+        // (a) If the type is Decodable only and the key exists in the enum,
+        //     then explicitly remove the key from the enum. This makes it
+        //     explicit that the key will not be decoded.
+        // (b) If the type is Decodable only and the key does not exist in
+        //     the enum, do nothing. This is because the user has explicitly
+        //     made it clear that that they don't want the key to be decoded.
+        // (c) If the type is Codable, do nothing. This is because removing
+        //     the key will break encoding which is most likely not what the
+        //     user expects.
+        if (!codingKeysEnum->isImplicit()) {
+          if (conformsToEncodable || !keyExistsInCodingKeys) {
+            continue;
+          }
+        }
+
+        C.Diags.diagnose(varDecl->getLoc(),
+                         diag::decodable_property_will_not_be_decoded,
+                         varDecl->getName());
+        if (codingKeysEnum->isImplicit()) {
+          C.Diags.diagnose(varDecl->getLoc(),
+                           diag::decodable_property_init_or_codingkeys_implicit,
+                           conformsToEncodable ? 0 : 1, varDecl->getName());
+        } else {
+          C.Diags.diagnose(varDecl->getLoc(),
+                           diag::decodable_property_init_or_codingkeys_explicit,
+                           varDecl->getName());
+        }
+        C.Diags
+            .diagnose(varDecl->getLoc(), diag::decodable_make_property_mutable)
+            .fixItReplace(varDecl->getAttributeInsertionLoc(true), "var");
+
         continue;
+      }
 
       auto methodName =
           useIfPresentVariant ? C.Id_decodeIfPresent : C.Id_decode;

--- a/test/decl/protocol/special/coding/class_codable_member_lookup.swift
+++ b/test/decl/protocol/special/coding/class_codable_member_lookup.swift
@@ -2,6 +2,9 @@
 
 class SynthesizedSuperclass : Codable {
   let superValue: Double = .pi
+  // expected-warning@-1 {{immutable property will not be decoded because it is declared with an initial value which cannot be overwritten}}
+  // expected-note@-2 {{set the initial value via the initializer or explicitly define a CodingKeys enum including a 'superValue' case to silence this warning}}
+  // expected-note@-3 {{make the property mutable instead}}{{3-6=var}}
 }
 
 // Classes which subclass something Codable should be able to override their

--- a/test/decl/protocol/special/coding/class_codable_member_type_lookup.swift
+++ b/test/decl/protocol/special/coding/class_codable_member_type_lookup.swift
@@ -11,6 +11,9 @@ public enum CodingKeys : String, CodingKey {
 // CodingKey enums during member type lookup.
 struct SynthesizedClass : Codable {
   let value: String = "foo"
+  // expected-warning@-1 {{immutable property will not be decoded because it is declared with an initial value which cannot be overwritten}}
+  // expected-note@-2 {{set the initial value via the initializer or explicitly define a CodingKeys enum including a 'value' case to silence this warning}}
+  // expected-note@-3 {{make the property mutable instead}}{{3-6=var}}
 
   // Qualified type lookup should always be unambiguous.
   public func qualifiedFoo(_ key: SynthesizedClass.CodingKeys) {} // expected-error {{method cannot be declared public because its parameter uses a private type}}

--- a/test/decl/protocol/special/coding/class_codable_nonconforming_property.swift
+++ b/test/decl/protocol/special/coding/class_codable_nonconforming_property.swift
@@ -10,6 +10,9 @@ struct NonCodable : Hashable {
 
 struct CodableGeneric<T> : Codable {
     let value: Int = 5
+    // expected-warning@-1 {{immutable property will not be decoded because it is declared with an initial value which cannot be overwritten}}
+    // expected-note@-2 {{set the initial value via the initializer or explicitly define a CodingKeys enum including a 'value' case to silence this warning}}
+    // expected-note@-3 {{make the property mutable instead}}{{5-8=var}}
 }
 
 // Classes whose properties are not all Codable should fail to synthesize

--- a/test/decl/protocol/special/coding/codable_immutable_property_with_initial_value.swift
+++ b/test/decl/protocol/special/coding/codable_immutable_property_with_initial_value.swift
@@ -6,7 +6,7 @@
 
 struct Foo1: Codable {
   let bar: Int = 1
-  // expected-warning@-1 {{immutable property 'bar' will not be decoded because it is declared with an initial value which cannot be overwritten}}
+  // expected-warning@-1 {{immutable property will not be decoded because it is declared with an initial value which cannot be overwritten}}
   // expected-note@-2 {{set the initial value via the initializer or explicitly define a CodingKeys enum including a 'bar' case to silence this warning}}
   // expected-note@-3 {{make the property mutable instead}}{{3-6=var}}
   let baz1: String
@@ -15,7 +15,7 @@ struct Foo1: Codable {
 
 struct Foo2: Decodable {
   let bar: Int = 1
-  // expected-warning@-1 {{immutable property 'bar' will not be decoded because it is declared with an initial value which cannot be overwritten}}
+  // expected-warning@-1 {{immutable property will not be decoded because it is declared with an initial value which cannot be overwritten}}
   // expected-note@-2 {{set the initial value via the initializer or explicitly define a CodingKeys enum without a 'bar' case to silence this warning}}
   // expected-note@-3 {{make the property mutable instead}}{{3-6=var}}
   let baz1: String
@@ -44,7 +44,7 @@ struct Foo4: Codable {
 
 struct Foo5: Decodable {
   let bar: Int = 1
-  // expected-warning@-1 {{immutable property 'bar' will not be decoded because it is declared with an initial value which cannot be overwritten}}
+  // expected-warning@-1 {{immutable property will not be decoded because it is declared with an initial value which cannot be overwritten}}
   // expected-note@-2 {{set the initial value via the initializer or remove the 'bar' case from the CodingKeys enum to silence this warning}}
   // expected-note@-3 {{make the property mutable instead}}{{3-6=var}}
   let baz1: String

--- a/test/decl/protocol/special/coding/codable_immutable_property_with_initial_value.swift
+++ b/test/decl/protocol/special/coding/codable_immutable_property_with_initial_value.swift
@@ -1,0 +1,103 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+// SR-11996 - Warning when a immutable decodable property has an initial value
+
+// Implicit CodingKeys enum //
+
+struct Foo1: Codable {
+  let bar: Int = 1
+  // expected-warning@-1 {{immutable property 'bar' will not be decoded because it is declared with an initial value which cannot be overwritten}}
+  // expected-note@-2 {{set the initial value via the initializer or explicitly define a CodingKeys enum including a 'bar' case to silence this warning}}
+  // expected-note@-3 {{make the property mutable instead}}{{3-6=var}}
+  let baz1: String
+  var baz2 = 8
+}
+
+struct Foo2: Decodable {
+  let bar: Int = 1
+  // expected-warning@-1 {{immutable property 'bar' will not be decoded because it is declared with an initial value which cannot be overwritten}}
+  // expected-note@-2 {{set the initial value via the initializer or explicitly define a CodingKeys enum without a 'bar' case to silence this warning}}
+  // expected-note@-3 {{make the property mutable instead}}{{3-6=var}}
+  let baz1: String
+  var baz2 = 8
+}
+
+struct Foo3: Encodable {
+  let bar: Int = 1 // Ok, since 'Foo3' isn't decodable
+  let baz1: String
+  var baz2 = 8
+}
+
+// Explicit CodingKeys enum //
+
+struct Foo4: Codable {
+  let bar: Int = 1 // Ok, since removing 'bar' from 'CodingKeys' will break encoding
+  let baz1: String
+  var baz2 = 8
+
+  private enum CodingKeys: String, CodingKey {
+    case bar
+    case baz1
+    case baz2
+  }
+}
+
+struct Foo5: Decodable {
+  let bar: Int = 1
+  // expected-warning@-1 {{immutable property 'bar' will not be decoded because it is declared with an initial value which cannot be overwritten}}
+  // expected-note@-2 {{set the initial value via the initializer or remove the 'bar' case from the CodingKeys enum to silence this warning}}
+  // expected-note@-3 {{make the property mutable instead}}{{3-6=var}}
+  let baz1: String
+  var baz2 = 8
+
+  private enum CodingKeys: String, CodingKey {
+    case bar
+    case baz1
+    case baz2
+  }
+}
+
+struct Foo6: Encodable {
+  let bar: Int = 1 // Ok, since 'Foo6' isn't decodable
+  let baz1: String
+  var baz2 = 8
+
+  private enum CodingKeys: String, CodingKey {
+    case bar
+    case baz1
+    case baz2
+  }
+}
+
+struct Foo7: Codable {
+  let bar: Int = 1 // Ok, since 'bar' doesn't exist in CodingKeys enum
+  let baz1: String
+  var baz2 = 8
+
+  private enum CodingKeys: String, CodingKey {
+    case baz1
+    case baz2
+  }
+}
+
+struct Foo8: Decodable {
+  let bar: Int = 1 // Ok, since 'bar' does not exist in CodingKeys enum
+  let baz1: String
+  var baz2 = 8
+
+  private enum CodingKeys: String, CodingKey {
+    case baz1
+    case baz2
+  }
+}
+
+struct Foo9: Encodable {
+  let bar: Int = 1 // Ok, since 'Foo9' isn't decodable (and 'bar' doesn't exist in CodingKeys enum anyway)
+  let baz1: String
+  var baz2 = 8
+
+  private enum CodingKeys: String, CodingKey {
+    case baz1
+    case baz2
+  }
+}

--- a/test/decl/protocol/special/coding/struct_codable_member_type_lookup.swift
+++ b/test/decl/protocol/special/coding/struct_codable_member_type_lookup.swift
@@ -11,6 +11,9 @@ public enum CodingKeys : String, CodingKey {
 // CodingKey enums during member type lookup.
 struct SynthesizedStruct : Codable {
   let value: String = "foo"
+  // expected-warning@-1 {{immutable property will not be decoded because it is declared with an initial value which cannot be overwritten}}
+  // expected-note@-2 {{set the initial value via the initializer or explicitly define a CodingKeys enum including a 'value' case to silence this warning}}
+  // expected-note@-3 {{make the property mutable instead}}{{3-6=var}}
 
   // Qualified type lookup should always be unambiguous.
   public func qualifiedFoo(_ key: SynthesizedStruct.CodingKeys) {} // expected-error {{method cannot be declared public because its parameter uses a private type}}
@@ -660,4 +663,7 @@ struct sr6886 {
 struct StaticInstanceNameDisambiguation : Codable {
   static let version: Float = 0.42
   let version: Int = 42
+  // expected-warning@-1 {{immutable property will not be decoded because it is declared with an initial value which cannot be overwritten}}
+  // expected-note@-2 {{set the initial value via the initializer or explicitly define a CodingKeys enum including a 'version' case to silence this warning}}
+  // expected-note@-3 {{make the property mutable instead}}{{3-6=var}}
 }

--- a/test/decl/protocol/special/coding/struct_codable_nonconforming_property.swift
+++ b/test/decl/protocol/special/coding/struct_codable_nonconforming_property.swift
@@ -10,6 +10,9 @@ struct NonCodable : Hashable {
 
 struct CodableGeneric<T> : Codable {
     let value: Int = 5
+    // expected-warning@-1 {{immutable property will not be decoded because it is declared with an initial value which cannot be overwritten}}
+    // expected-note@-2 {{set the initial value via the initializer or explicitly define a CodingKeys enum including a 'value' case to silence this warning}}
+    // expected-note@-3 {{make the property mutable instead}}{{5-8=var}}
 }
 
 // Structs whose properties are not all Codable should fail to synthesize


### PR DESCRIPTION
When a decodable immutable property has an initial value, it will not be decoded and get skipped. This is a common source of confusion among users (example [here](https://twitter.com/krugazor/status/1214108579793448960) and [here](https://forums.swift.org/t/how-to-exclude-members-from-parsing/34325/5)), so emit a specialised warning for it.

```swift
struct Foo: Decodable {
  let someProperty: Int = 0 // warning because it won't be decoded
}
```

To silence the warning, the user can do one of the following things:

1. Set the initial value in the initializer (99% of the time this is what they really meant to do - set the value via the initializer by using it as a default argument)
2. Explicitly define a `CodingKeys` enum without the key in it to make it explicit that it's not meant to be decoded.
3. Make the property mutable (change `let` to `var`)

This won't trigger in some cases when the type is `Codable` because removing the key will break encoding which is most likely not what the user would expect.

Also, if the key has been explicitly specified and the type is just `Decodable`, then this warning will be triggered because explicitly declaring a key in the `CodingKeys` enum means it's meant to be decoded.

This strategy was mentioned here: https://forums.swift.org/t/revisit-synthesized-init-from-decoder-for-structs-with-default-property-values/12296/2

Resolves SR-11996
Resolves rdar://problem/58455438