### PR TITLE
[CS] Use The Full Opened Type When Forming Subscripts

### DIFF
--- a/test/SILGen/protocols.swift
+++ b/test/SILGen/protocols.swift
@@ -429,6 +429,22 @@ public func test(_ p: Proto) {
 // CHECK: end_apply [[TOKEN]]
 // CHECK: return
 
+// SR-11748
+
+protocol SelfReturningSubscript {
+  subscript(b: Int) -> Self { get }
+}
+
+public func testSelfReturningSubscript() {
+  // CHECK-LABEL: sil private [ossa] @$s9protocols26testSelfReturningSubscriptyyFAA0cdE0_pAaC_pXEfU_
+  // CHECK: [[OPEN:%.*]] = open_existential_addr immutable_access
+  // CHECK: [[OPEN_ADDR:%.*]] = alloc_stack $@opened("{{.*}}") SelfReturningSubscript
+  // CHECK: copy_addr [[OPEN]] to [initialization] [[OPEN_ADDR]] : $*@opened("{{.*}}") SelfReturningSubscript
+  // CHECK: [[WIT_M:%.*]] = witness_method $@opened("{{.*}}") SelfReturningSubscript, #SelfReturningSubscript.subscript!getter.1
+  // CHECK: apply [[WIT_M]]<@opened("{{.*}}") SelfReturningSubscript>({{%.*}}, {{%.*}}, [[OPEN_ADDR]])
+  _ = [String: SelfReturningSubscript]().mapValues { $0[2] }
+}
+
 // CHECK-LABEL: sil_witness_table hidden ClassWithGetter: PropertyWithGetter module protocols {
 // CHECK-NEXT:  method #PropertyWithGetter.a!getter.1: {{.*}} : @$s9protocols15ClassWithGetterCAA08PropertycD0A2aDP1aSivgTW
 // CHECK-NEXT: }


### PR DESCRIPTION
The "opened type" of a subscript reference has all references to Self
immediately substituted out, which destroys the link between Self and
the opened existential type we form for the "fully opened type". This
means, in general, we cannot use this type when rewriting subscript
applies, or we'll miss closing opened existentials.

Use the "fully opened type" everywhere except the AnyObject subscript
path. Then, add an assertion that AnyObject subscripts never involve
opened archetypes that we would have to close.

Resolves SR-11748, rdar://57092093