### PR TITLE
[ConstraintSystem] Preserve label matching rules in pattern matching …

### DIFF
--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -433,3 +433,25 @@ switch sr7799_1 {
 
 if case .baz = sr7799_1 {} // Ok
 if case .bar? = sr7799_1 {} // Ok
+
+// rdar://problem/60048356 - `if case` fails when `_` pattern doesn't have a label
+func rdar_60048356() {
+  typealias Info = (code: ErrorCode, reason: String)
+
+  enum ErrorCode {
+    case normalClosure
+  }
+
+  enum Failure {
+    case closed(Info)
+  }
+
+  enum Reason {
+    case close(Failure)
+  }
+
+  func test(_ reason: Reason) {
+    if case .close(.closed((code: .normalClosure, _))) = reason { // Ok
+    }
+  }
+}


### PR DESCRIPTION
…context

Since constraint system now handles pattern matching it has
to preverse label matching semantics which existed in original
code: if pattern element has a label it has to match the one
in the tuple type it's matched against.

Resolves: rdar://problem/60048356

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
