### PR TITLE
Disable !invariant metadata for 'let' variables.

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3569,16 +3569,16 @@ void IRGenSILFunction::visitRefTailAddrInst(RefTailAddrInst *i) {
 
 static bool isInvariantAddress(SILValue v) {
   SILValue accessedAddress = getAccessedAddress(v);
-  if (accessedAddress->getType().isAddress() && isLetAddress(accessedAddress)) {
-    return true;
-  }
   if (auto *ptrRoot = dyn_cast<PointerToAddressInst>(accessedAddress)) {
     return ptrRoot->isInvariant();
   }
   // TODO: We could be more aggressive about considering addresses based on
   // `let` variables as invariant when the type of the address is known not to
   // have any sharably-mutable interior storage (in other words, no weak refs,
-  // atomics, etc.)
+  // atomics, etc.). However, this currently miscompiles some programs.
+  // if (accessedAddress->getType().isAddress() && isLetAddress(accessedAddress)) {
+  //  return true;
+  // }
   return false;
 }
 

--- a/test/IRGen/invariant_load.sil
+++ b/test/IRGen/invariant_load.sil
@@ -1,5 +1,9 @@
 // RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
+// REQUIRES: rdar60068448
+// FIXME Reenable the !invariant.load metadata after debugging miscompiles...
+// <rdar://60068448> Teach IRGen to emit !invariant metadata for 'let' variables
+
 sil_stage lowered
 
 import Builtin


### PR DESCRIPTION
I enabled this recently by piggybacking it in the mega-commit:

commit badc5658bb262b548063a8aa7d90f9272a9d4b1e
Author: Andrew Trick <atrick@apple.com>
Date:   Mon Mar 2 16:23:53 2020

    Fix SIL MemBehavior queries with access markers.

It miscompiles SwiftNIO's NIOPerformanceTester benchmark causing it to
segfault immediately.

We may consider debugging this to reenable it in the future...
<rdar://60068448> Teach IRGen to emit !invariant metadata for 'let' variables

Fixes <rdar://60038603> Swift CI: SwiftNIO_macOS NIOHTTP2_macOS fails

(I have no time currently to pursue small optimizations)