### PR TITLE
SIL: Verify that the substitution map of an apply instruction matches the callee

### DIFF
--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -82,9 +82,7 @@ class TypeSubstCloner : public SILClonerWithScopes<ImplClass> {
             // substitutions may be different from the original ones, e.g.
             // there can be less substitutions.
             RecursiveSubs = SubstitutionMap::get(
-              AI.getFunction()
-                ->getLoweredFunctionType()
-                ->getInvocationGenericSignature(),
+              LoweredFnTy->getSubstGenericSignature(),
               Subs);
 
             // Use the new set of substitutions to compute the new

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1308,6 +1308,17 @@ public:
       });
     }
 
+    if (subs.getGenericSignature()->getCanonicalSignature() !=
+          fnTy->getSubstGenericSignature()->getCanonicalSignature()) {
+      llvm::dbgs() << "substitution map's generic signature: ";
+      subs.getGenericSignature()->print(llvm::dbgs());
+      llvm::dbgs() << "\n";
+      llvm::dbgs() << "callee's generic signature: ";
+      fnTy->getSubstGenericSignature()->print(llvm::dbgs());
+      llvm::dbgs() << "\n";
+      require(false,
+              "Substitution map does not match callee in apply instruction");
+    }
     // Apply the substitutions.
     return fnTy->substGenericArgs(F.getModule(), subs, F.getTypeExpansionContext());
   }

--- a/test/SILOptimizer/devirt_default_witness_method.sil
+++ b/test/SILOptimizer/devirt_default_witness_method.sil
@@ -43,7 +43,7 @@ public protocol ResilientProtocolWithGeneric {
   func defaultB<T: Q>(_: T)
 }
 
-sil @defaultB : $@convention(witness_method: ResilientProtocolWithGeneric) <Self where Self : ResilientProtocolWithGeneric><T where T : P> (@in T, @in_guaranteed Self) -> () {
+sil @defaultB : $@convention(witness_method: ResilientProtocolWithGeneric) <Self where Self : ResilientProtocolWithGeneric><T where T : Q> (@in T, @in_guaranteed Self) -> () {
 bb0(%0 : $*T, %1 : $*Self):
   %result = tuple ()
   return %result : $()
@@ -89,8 +89,8 @@ bb0(%0 : $*ConformingGenericStruct<Int>):
 
 // CHECK-LABEL: test_devirt_of_inner_generic_default_witness_method
 // CHECK:       bb0(%0 : $*ConformingGenericStruct<Int>, %1 : $*Int):
-// CHECK:       [[FN:%[0-9]+]] = function_ref @defaultB : $@convention(witness_method: ResilientProtocolWithGeneric) <τ_0_0 where τ_0_0 : ResilientProtocolWithGeneric><τ_1_0 where τ_1_0 : P> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
-// CHECK:       [[RESULT:%[0-9]+]] = apply [[FN]]<ConformingGenericStruct<Int>, Int>(%1, %0) : $@convention(witness_method: ResilientProtocolWithGeneric) <τ_0_0 where τ_0_0 : ResilientProtocolWithGeneric><τ_1_0 where τ_1_0 : P> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+// CHECK:       [[FN:%[0-9]+]] = function_ref @defaultB : $@convention(witness_method: ResilientProtocolWithGeneric) <τ_0_0 where τ_0_0 : ResilientProtocolWithGeneric><τ_1_0 where τ_1_0 : Q> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+// CHECK:       [[RESULT:%[0-9]+]] = apply [[FN]]<ConformingGenericStruct<Int>, Int>(%1, %0) : $@convention(witness_method: ResilientProtocolWithGeneric) <τ_0_0 where τ_0_0 : ResilientProtocolWithGeneric><τ_1_0 where τ_1_0 : Q> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
 // CHECK:       return [[RESULT]] : $()
 // CHECK:     }
 sil hidden @test_devirt_of_inner_generic_default_witness_method : $@convention(thin) (@in_guaranteed ConformingGenericStruct<Int>, @in Int) -> () {

--- a/test/SILOptimizer/devirt_default_witness_method_ownership.sil
+++ b/test/SILOptimizer/devirt_default_witness_method_ownership.sil
@@ -43,7 +43,7 @@ public protocol ResilientProtocolWithGeneric {
   func defaultB<T: Q>(_: T)
 }
 
-sil @defaultB : $@convention(witness_method: ResilientProtocolWithGeneric) <Self where Self : ResilientProtocolWithGeneric><T where T : P> (@in T, @in_guaranteed Self) -> () {
+sil @defaultB : $@convention(witness_method: ResilientProtocolWithGeneric) <Self where Self : ResilientProtocolWithGeneric><T where T : Q> (@in T, @in_guaranteed Self) -> () {
 bb0(%0 : $*T, %1 : $*Self):
   %result = tuple ()
   return %result : $()
@@ -89,8 +89,8 @@ bb0(%0 : $*ConformingGenericStruct<Int>):
 
 // CHECK-LABEL: test_devirt_of_inner_generic_default_witness_method
 // CHECK:       bb0(%0 : $*ConformingGenericStruct<Int>, %1 : $*Int):
-// CHECK:       [[FN:%[0-9]+]] = function_ref @defaultB : $@convention(witness_method: ResilientProtocolWithGeneric) <τ_0_0 where τ_0_0 : ResilientProtocolWithGeneric><τ_1_0 where τ_1_0 : P> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
-// CHECK:       [[RESULT:%[0-9]+]] = apply [[FN]]<ConformingGenericStruct<Int>, Int>(%1, %0) : $@convention(witness_method: ResilientProtocolWithGeneric) <τ_0_0 where τ_0_0 : ResilientProtocolWithGeneric><τ_1_0 where τ_1_0 : P> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+// CHECK:       [[FN:%[0-9]+]] = function_ref @defaultB : $@convention(witness_method: ResilientProtocolWithGeneric) <τ_0_0 where τ_0_0 : ResilientProtocolWithGeneric><τ_1_0 where τ_1_0 : Q> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+// CHECK:       [[RESULT:%[0-9]+]] = apply [[FN]]<ConformingGenericStruct<Int>, Int>(%1, %0) : $@convention(witness_method: ResilientProtocolWithGeneric) <τ_0_0 where τ_0_0 : ResilientProtocolWithGeneric><τ_1_0 where τ_1_0 : Q> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
 // CHECK:       return [[RESULT]] : $()
 // CHECK:     }
 sil hidden [ossa] @test_devirt_of_inner_generic_default_witness_method : $@convention(thin) (@in_guaranteed ConformingGenericStruct<Int>, @in Int) -> () {


### PR DESCRIPTION
This fixes part of the problem in <rdar://problem/49509247>, but not the
actual bug.