### PR TITLE
[Constraint system] Semantic checking for switch statements in function builders

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1114,6 +1114,7 @@ public:
     }
 
     // Translate all of the cases.
+    bool limitExhaustivityChecks = false;
     assert(target.kind == FunctionBuilderTarget::TemporaryVar);
     auto temporaryVar = target.captured.first;
     unsigned caseIndex = 0;
@@ -1124,10 +1125,18 @@ public:
               temporaryVar, {target.captured.second[caseIndex]})))
         return nullptr;
 
+      // Check restrictions on '@unknown'.
+      if (caseStmt->hasUnknownAttr()) {
+        checkUnknownAttrRestrictions(
+            cs.getASTContext(), caseStmt, /*fallthroughDest=*/nullptr,
+            limitExhaustivityChecks);
+      }
+
       ++caseIndex;
     }
 
-    TypeChecker::checkSwitchExhaustiveness(switchStmt, dc, /*limited=*/false);
+    TypeChecker::checkSwitchExhaustiveness(
+        switchStmt, dc, limitExhaustivityChecks);
 
     return switchStmt;
   }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1654,6 +1654,12 @@ bool areGenericRequirementsSatisfied(const DeclContext *DC,
                                      SubstitutionMap Substitutions,
                                      bool isExtension);
 
+/// Check for restrictions on the use of the @unknown attribute on a
+/// case statement.
+void checkUnknownAttrRestrictions(
+    ASTContext &ctx, CaseStmt *caseBlock, CaseStmt *fallthroughDest,
+    bool &limitExhaustivityChecks);
+
 /// Bind all of the pattern variables that occur within a case statement and
 /// all of its case items to their "parent" pattern variables, forming chains
 /// of variables with the same name.

--- a/test/Constraints/function_builder.swift
+++ b/test/Constraints/function_builder.swift
@@ -593,7 +593,8 @@ testSwitch(getE(1))
 // CHECK-SAME: second("just 42")
 testSwitch(getE(2))
 
-func testSwitchCombined(_ e: E) {
+func testSwitchCombined(_ eIn: E) {
+  var e = eIn
   tuplify(true) { c in
     "testSwitchCombined"
     switch e {

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -427,3 +427,19 @@ struct TestConstraintGenerationErrors {
     }
   }
 }
+
+// Check @unknown
+func testUnknownInSwitchSwitch(e: E) {
+    tuplify(true) { c in
+    "testSwitch"
+    switch e {
+    @unknown case .a: // expected-error{{'@unknown' is only supported for catch-all cases ("case _")}}
+      "a"
+    case .b(let i, let s?):
+      i * 2
+      s + "!"
+    default:
+      "nothing"
+    }
+  }
+}

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -443,3 +443,26 @@ func testUnknownInSwitchSwitch(e: E) {
     }
   }
 }
+
+// Check for mutability mismatches when there are multiple case items
+// referring to same-named variables.
+enum E3 {
+  case a(Int, String)
+  case b(String, Int)
+  case c(String, Int)
+}
+
+func testCaseMutabilityMismatches(e: E3) {
+    tuplify(true) { c in
+    "testSwitch"
+    switch e {
+    case .a(let x, var y),
+         .b(let y, // expected-error{{'let' pattern binding must match previous 'var' pattern binding}}
+            var x), // expected-error{{'var' pattern binding must match previous 'let' pattern binding}}
+         .c(let y, // expected-error{{'let' pattern binding must match previous 'var' pattern binding}}
+            var x): // expected-error{{'var' pattern binding must match previous 'let' pattern binding}}
+      x
+      y += "a"
+    }
+  }
+}


### PR DESCRIPTION
More semantic checking for `switch` statements in function builders to line them up with
normal semantic checking:
* Checking for correct use of `@unknown`
* Checking for `let`/`var` consistency among different case items that have the same variable names