### PR TITLE
[ConstraintSystem] Check availability as part of resolving overload c…

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2292,9 +2292,6 @@ Constraint *ConstraintSystem::selectDisjunction() {
 }
 
 bool DisjunctionChoice::attempt(ConstraintSystem &cs) const {
-  if (isUnavailable())
-    cs.increaseScore(SK_Unavailable);
-
   cs.simplifyDisjunctionChoice(Choice);
 
   if (ExplicitConversion)

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1885,6 +1885,10 @@ isInvalidPartialApplication(ConstraintSystem &cs,
 std::pair<Type, bool> ConstraintSystem::adjustTypeOfOverloadReference(
     const OverloadChoice &choice, ConstraintLocator *locator,
     Type boundType, Type refType) {
+  // If the declaration is unavailable, note that in the score.
+  if (isDeclUnavailable(choice.getDecl(), locator))
+    increaseScore(SK_Unavailable);
+
   bool bindConstraintCreated = false;
   const auto kind = choice.getKind();
   if (kind != OverloadChoiceKind::DeclViaDynamic &&

--- a/test/Constraints/availability.swift
+++ b/test/Constraints/availability.swift
@@ -15,3 +15,22 @@ class C : P {
 func f(c: C) {
   let _: C? = C(c)
 }
+
+// rdar://problem/60047439 - unable to disambiguite expression based on availablity
+func test_contextual_member_with_availability() {
+  struct A {
+    static var foo: A = A()
+  }
+
+  struct B {
+    @available(*, unavailable, renamed: "bar")
+    static var foo: B = B()
+  }
+
+  struct Test {
+    init(_: A) {}
+    init(_: B) {}
+  }
+
+  _ = Test(.foo) // Ok
+}


### PR DESCRIPTION
…hoice

This is a follow up to changes related to contextual availability
(https://github.com/apple/swift/pull/29921) which increased score
for unavailable declarations only if they were overloaded but
overlooked a case of a single unavailable choice.

Resolve: rdar://problem/60047439

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
