### PR TITLE
[build][android] set INSTALL_RPATH properly for shared libraries

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -628,14 +628,9 @@ function(_add_swift_host_library_single target)
       PROPERTIES
       INSTALL_RPATH "$ORIGIN:/usr/lib/swift/cygwin")
   elseif("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "ANDROID")
-    # Only set the install RPATH if cross-compiling the host tools, in which
-    # case both the NDK and Sysroot paths must be set.
-    if(NOT "${SWIFT_ANDROID_NDK_PATH}" STREQUAL "" AND
-       NOT "${SWIFT_ANDROID_NATIVE_SYSROOT}" STREQUAL "")
-      set_target_properties("${target}"
-        PROPERTIES
-        INSTALL_RPATH "$ORIGIN")
-    endif()
+    set_target_properties("${target}"
+      PROPERTIES
+      INSTALL_RPATH "$ORIGIN")
   endif()
 
   set_target_properties("${target}" PROPERTIES BUILD_WITH_INSTALL_RPATH YES)

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -527,10 +527,9 @@ function(_add_swift_target_library_single target name)
     if(SWIFTLIB_SINGLE_TARGET_LIBRARY)
       set_target_properties("${target}" PROPERTIES NO_SONAME TRUE)
     endif()
-    # Only set the install RPATH if cross-compiling the host tools, in which
-    # case both the NDK and Sysroot paths must be set.
-    if(NOT "${SWIFT_ANDROID_NDK_PATH}" STREQUAL "" AND
-       NOT "${SWIFT_ANDROID_NATIVE_SYSROOT}" STREQUAL "")
+    # Only set the install RPATH if the toolchain and stdlib will be in Termux
+    # or some other native sysroot on Android.
+    if(NOT "${SWIFT_ANDROID_NATIVE_SYSROOT}" STREQUAL "")
       set_target_properties("${target}"
         PROPERTIES
         INSTALL_RPATH "$ORIGIN")


### PR DESCRIPTION
~This finally allows removing the toolchain/SDK rpaths that are currently automatically added when compiling Swift shared libraries and executables on non-Darwin platforms. Also,~ Similar flag added in #30430 instead. Remove unnecessary checks for Android's INSTALL_RPATH, now that the CMake setup has been refactored to separate host and target library configuration.

~I've [backported this swiftc flag to the Swift 5.1.4 package script for Android](https://github.com/buttaface/termux-packages/commit/8e733afe84b7a8d0324a4825abe6e610ea3a17aa#diff-f2454b0e4d1c9024e7f8ba47e3d7703aR20) and then use it [to avoid adding the toolchain rpath for Foundation](https://github.com/buttaface/termux-packages/commit/8e733afe84b7a8d0324a4825abe6e610ea3a17aa#diff-3cdf9fd33dc2ba4aa8334a1067babff2R19) and other Swift shared libraries in the toolchain.~

~That would be useful for the official releases for linux too, here's what the 5.1.4 release and the latest 5.2 snapshot show:~
```
> readelf -d swift-5.1.4-RELEASE-ubuntu18.04/usr/lib/swift/linux/libFoundation.so | ag runpath
0x000000000000001d (RUNPATH)            Library runpath: [/home/buildnode/jenkins/workspace/oss-swift-5.1-package-linux-ubuntu-18_04/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux:/home/buildnode/jenkins/workspace/oss-swift-5.1-package-linux-ubuntu-18_04/build/buildbot_linux/libdispatch-linux-x86_64/src:$ORIGIN]
> readelf -d swift-5.2-DEVELOPMENT-SNAPSHOT-2020-03-03-a-ubuntu18.04/usr/lib/swift/linux/libFoundation.so | ag runpath
0x000000000000001d (RUNPATH)            Library runpath: [/home/buildnode/jenkins/workspace/oss-swift-5.2-package-linux-ubuntu-18_04/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux:/home/buildnode/jenkins/workspace/oss-swift-5.2-package-linux-ubuntu-18_04/build/buildbot_linux/libdispatch-linux-x86_64:$ORIGIN]
```
~@brentdax, you modified some of this rpath config last year, let me know what you think.~ @drodriguez, let me know about the Android part. ~@tachoknight, this should be useful for all Swift packagers.~