### PR TITLE
Changes implementation of _persistCString from _StringGuts

### DIFF
--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -323,13 +323,10 @@ extension _StringGuts {
 public // SPI(corelibs-foundation)
 func _persistCString(_ p: UnsafePointer<CChar>?) -> [CChar]? {
   guard let s = p else { return nil }
-  let count = Int(_swift_stdlib_strlen(s))
-  let result = [CChar](unsafeUninitializedCapacity: count + 1) { buf, initializedCount in
-    for i in 0..<count {
-      buf[i] = s[i]
-    }
-    buf[count] = 0
-    initializedCount = count + 1
+  let bytesToCopy = UTF8._nullCodeUnitOffset(in: s) + 1 // +1 for the terminating NUL
+  let result = [CChar](unsafeUninitializedCapacity: bytesToCopy) { buf, initedCount in
+    buf.baseAddress!.assign(from: cString, count: bytesToCopy)
+    initedCount = bytesToCopy
   }
   return result
 }

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -325,7 +325,7 @@ func _persistCString(_ p: UnsafePointer<CChar>?) -> [CChar]? {
   guard let s = p else { return nil }
   let bytesToCopy = UTF8._nullCodeUnitOffset(in: s) + 1 // +1 for the terminating NUL
   let result = [CChar](unsafeUninitializedCapacity: bytesToCopy) { buf, initedCount in
-    buf.baseAddress!.assign(from: cString, count: bytesToCopy)
+    buf.baseAddress!.assign(from: s, count: bytesToCopy)
     initedCount = bytesToCopy
   }
   return result


### PR DESCRIPTION
Changes implementation of _persistCString from _StringGuts to be in sync with implementation from stdlib [PR](https://github.com/apple/swift-corelibs-foundation/pull/2701)

<!-- What's in this pull request? -->

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
