### PR TITLE
[string] Shrink storage class sizes

### DIFF
--- a/stdlib/public/core/LegacyABI.swift
+++ b/stdlib/public/core/LegacyABI.swift
@@ -79,3 +79,11 @@ extension String {
     range: Range<String.Index>
   ) { fatalError() }
 }
+
+extension String.UTF16View {
+  // Swift 5.x: This was accidentally shipped as inlinable, but was never used
+  // from an inlinable context. The definition is kept around for techincal ABI
+  // compatibility (even though it shouldn't matter), but is unused.
+  @inlinable @inline(__always)
+  internal var _shortHeuristic: Int { return 32 }
+}

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -462,6 +462,7 @@ extension String {
         // and bridge that instead. Also avoids CF deleting any BOM that may be
         // present
         var copy = self
+        // TODO: small capacity minimum is lifted, just need to make native
         copy._guts.grow(_SmallString.capacity + 1)
         _internalInvariant(!copy._guts.isSmall)
         return copy._bridgeToObjectiveCImpl()

--- a/stdlib/public/core/StringCreate.swift
+++ b/stdlib/public/core/StringCreate.swift
@@ -109,7 +109,7 @@ extension String {
     ) throws -> Int
   ) rethrows -> String {
     let result = try __StringStorage.create(
-      uninitializedCapacity: capacity,
+      uninitializedCodeUnitCapacity: capacity,
       initializingUncheckedUTF8With: initializer)
     
     switch validateUTF8(result.codeUnits) {

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -120,8 +120,10 @@ extension _StringGuts {
 
   internal var hasSharedStorage: Bool { return _object.hasSharedStorage }
 
+  // Whether this string has breadcrumbs
   internal var hasBreadcrumbs: Bool {
-    return hasNativeStorage || hasSharedStorage
+    return hasSharedStorage
+      || (hasNativeStorage && _object.nativeStorage.hasBreadcrumbs)
   }
 }
 

--- a/stdlib/public/core/StringGutsRangeReplaceable.swift
+++ b/stdlib/public/core/StringGutsRangeReplaceable.swift
@@ -79,13 +79,16 @@ extension _StringGuts {
     _internalInvariant(
       self.uniqueNativeCapacity == nil || self.uniqueNativeCapacity! < n)
 
+    // TODO: Dont' do this! Growth should only happen for append...
     let growthTarget = Swift.max(n, (self.uniqueNativeCapacity ?? 0) * 2)
 
     if _fastPath(isFastUTF8) {
       let isASCII = self.isASCII
       let storage = self.withFastUTF8 {
         __StringStorage.create(
-          initializingFrom: $0, capacity: growthTarget, isASCII: isASCII)
+          initializingFrom: $0,
+          codeUnitCapacity: growthTarget,
+          isASCII: isASCII)
       }
 
       self = _StringGuts(storage)

--- a/stdlib/public/core/StringGutsRangeReplaceable.swift
+++ b/stdlib/public/core/StringGutsRangeReplaceable.swift
@@ -58,7 +58,7 @@ extension _StringGuts {
   internal init(_initialCapacity capacity: Int) {
     self.init()
     if _slowPath(capacity > _SmallString.capacity) {
-      self.grow(capacity)
+      self.grow(capacity) // TODO: no factor should be applied
     }
   }
 
@@ -68,7 +68,7 @@ extension _StringGuts {
     if let currentCap = self.uniqueNativeCapacity, currentCap >= n { return }
 
     // Grow
-    self.grow(n)
+    self.grow(n) // TODO: no factor should be applied
   }
 
   // Grow to accomodate at least `n` code units
@@ -128,11 +128,11 @@ extension _StringGuts {
     } else {
       sufficientCapacity = false
     }
-        
+
     if self.isUniqueNative && sufficientCapacity {
       return
     }
-    
+
     // If we have to resize anyway, and we fit in smol, we should have made one
     _internalInvariant(totalCount > _SmallString.capacity)
 
@@ -145,7 +145,7 @@ extension _StringGuts {
       growthTarget = Swift.max(
         totalCount, _growArrayCapacity(nativeCapacity ?? 0))
     }
-    self.grow(growthTarget)
+    self.grow(growthTarget) // NOTE: this already has exponential growth...
   }
 
   internal mutating func append(_ other: _StringGuts) {
@@ -157,7 +157,7 @@ extension _StringGuts {
     }
     append(_StringGutsSlice(other))
   }
-  
+
   @inline(never)
   @_effects(readonly)
   private func _foreignConvertedToSmall() -> _SmallString {
@@ -170,7 +170,7 @@ extension _StringGuts {
     _internalInvariant(smol._guts.isSmall)
     return smol._guts.asSmall
   }
-  
+
   private func _convertedToSmall() -> _SmallString {
     _internalInvariant(utf8Count <= _SmallString.capacity)
     if _fastPath(isSmall) {
@@ -186,25 +186,25 @@ extension _StringGuts {
     defer { self._invariantCheck() }
 
     let otherCount = slicedOther.utf8Count
-    
+
     let totalCount = utf8Count + otherCount
-    
+
     /*
      Goal: determine if we need to allocate new native capacity
      Possible scenarios in which we need to allocate:
      • Not uniquely owned and native: we can't use the capacity to grow into,
         have to become unique + native by allocating
      • Not enough capacity: have to allocate to grow
-     
+
      Special case: a non-smol String that can fit in a smol String but doesn't
         meet the above criteria shouldn't throw away its buffer just to be smol.
         The reasoning here is that it may be bridged or have reserveCapacity'd
         in preparation for appending more later, in which case we would end up
         have to allocate anyway to convert back from smol.
-     
+
         If we would have to re-allocate anyway then that's not a problem and we
         should just be smol.
-     
+
         e.g. consider
         var str = "" // smol
         str.reserveCapacity(100) // large native unique
@@ -215,7 +215,7 @@ extension _StringGuts {
       nativeUnusedCapacity! >= otherCount
     let shouldBeSmol = totalCount <= _SmallString.capacity &&
       (isSmall || !hasEnoughUsableSpace)
-    
+
     if shouldBeSmol {
       let smolSelf = _convertedToSmall()
       let smolOther = String(Substring(slicedOther))._guts._convertedToSmall()
@@ -223,7 +223,7 @@ extension _StringGuts {
       self = _StringGuts(_SmallString(smolSelf, appending: smolOther)!)
       return
     }
-    
+
     prepareForAppendInPlace(totalCount: totalCount, otherUTF8Count: otherCount)
 
     if slicedOther.isFastUTF8 {

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -256,7 +256,6 @@ final internal class __StringStorage
 
   @inline(__always)
   fileprivate var _capacityAndFlags: _CapacityAndFlags {
-    // TODO: ...
     _CapacityAndFlags(realCapacity: _realCapacity, flags: _capacityFlags)
   }
 #else
@@ -289,7 +288,6 @@ final internal class __StringStorage
 
 // Creation
 extension __StringStorage {
-  // TODO: Test effect of asking for exactly 62, 63, 64, 65 code units...
   @_effects(releasenone)
   private static func create(
     codeUnitCapacity capacity: Int, countAndFlags: _CountAndFlags
@@ -330,17 +328,6 @@ extension __StringStorage {
     // initialized so we can't verify e.g. ASCII-ness
     storage._invariantCheck(initialized: false)
     return storage
-  }
-
-  // DO NOT PUSH: For stats gathering only...
-  internal static func create(
-    count: Int, codeUnitCapacity capacity: Int
-  ) -> __StringStorage {
-    __StringStorage.create(
-      codeUnitCapacity: capacity,
-      countAndFlags: _CountAndFlags(mortalCount: count, isASCII: false))
-    // NOTE: content is garbage and not necessarily validy endcoded. Please
-    // delete this entry point...
   }
 
   // The caller is expected to check UTF8 validity and ASCII-ness and update
@@ -447,7 +434,6 @@ extension __StringStorage {
 
   // @opaque
   fileprivate var _breadcrumbsAddress: UnsafeMutablePointer<_StringBreadcrumbs?> {
-    // TODO: better message
     precondition(
       hasBreadcrumbs, "Internal error: string breadcrumbs not present")
     return UnsafeMutablePointer(_realCapacityEnd)

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -33,13 +33,205 @@ internal protocol _AbstractStringStorage {
 
 #endif
 
-private typealias CountAndFlags = _StringObject.CountAndFlags
+private typealias _CountAndFlags = _StringObject.CountAndFlags
 
-//
-// TODO(String docs): Documentation about the runtime layout of these instances,
-// which is a little complex. The second trailing allocation holds an
-// Optional<_StringBreadcrumbs>.
-//
+/*
+
+_CapacityAndFlags has the following layout. It is stored directly in
+___StringStorage on 64-bit systems. On 32-bit systems, a 32-bit count and 16-bit
+_flags are stored separately (for more efficient layout), and this is
+_materialized as needed.
+
+┌────────────────┬────────┬───────┐
+│ b63            │ b62:48 │ b47:0 │
+├────────────────┼────────┼───────┤
+│ hasBreadcrumbs │ TBD    │ count │
+└────────────────┴────────┴───────┘
+
+*/
+fileprivate struct _CapacityAndFlags {
+  // Stores the "real capacity" (capacity + 1 for null terminator)
+  // in the bottom 48 bits, and flags in the top 16.
+  fileprivate var _storage: UInt64
+
+#if arch(i386) || arch(arm) || arch(wasm32)
+  fileprivate init(realCapacity: Int, flags: UInt16) {
+    let realCapUInt = UInt64(UInt(bitPattern: realCapacity))
+    _internalInvariant(realCapUInt == realCapUInt & _CountAndFlags.countMask)
+    self._storage = (UInt64(flags) &<< 48) | realCapUInt
+
+    _internalInvariant(self.flags == flags)
+  }
+
+  fileprivate var flags: UInt16 {
+    return UInt16(
+      truncatingIfNeeded: (self._storage & _CountAndFlags.flagsMask) &>> 48)
+  }
+#endif
+
+  internal init(hasBreadcrumbs crumbs: Bool, realCapacity: Int) {
+    let realCapUInt = UInt64(UInt(bitPattern: realCapacity))
+    _internalInvariant(realCapUInt == realCapUInt & _CountAndFlags.countMask)
+
+    let crumbsFlag = crumbs ? _CapacityAndFlags.hasBreadcrumbsMask : 0
+    self._storage = crumbsFlag | realCapUInt
+
+    _internalInvariant(
+      crumbs == self.hasBreadcrumbs && realCapacity == self._realCapacity)
+  }
+
+  // The capacity of our allocation. Note that this includes the nul-terminator,
+  // which is not available for overriding.
+  internal var _realCapacity: Int {
+    Int(truncatingIfNeeded: self._storage & _CountAndFlags.countMask)
+  }
+
+  private static var hasBreadcrumbsMask: UInt64 { 0x8000_0000_0000_0000 }
+
+  // Code unit capacity (excluding null terminator)
+  fileprivate var capacity: Int { _realCapacity &- 1 }
+
+  fileprivate var hasBreadcrumbs: Bool {
+    (self._storage & _CapacityAndFlags.hasBreadcrumbsMask) != 0
+  }
+}
+
+/*
+
+ String's storage class has a header, which includes the isa pointer, reference
+ count, and stored properties (count and capacity). After the header is a tail
+ allocation for the UTF-8 code units, a null terminator, and some spare capacity
+ (if available). After that, it optionally contains another tail allocation for
+ the breadcrumbs pointer.
+
+ If the requested code unit capacity is less than the breadcrumbs stride, no
+ pointer is allocated. This has the effect of either allowing us to save space
+ with a smaller allocation, or claim additional excess capacity, depending on
+ which half of the malloc bucket the requested capacity lies within.
+
+
+ Class Header: Below is the 64-bit and then 32-bit class header for
+ __StringStorage. `B` denotes the byte number (starting at 0)
+
+ 0                                                                            32
+ ├─────────────────────────────────────────────────────────────────────────────┤
+ │ Class Header (64 bit)                                                       │
+ ├─────────────┬─────────────────┬────────────────────┬────────────────────────┤
+ │ B0 ..< B8   │ B8 ..< B16      │ B16 ..< B24        │ B24 ..< B32            │
+ ├─────────────┼─────────────────┼────────────────────┼────────────────────────┤
+ │ isa pointer │ reference count │ capacity and flags │ count and flags        │
+ └─────────────┴─────────────────┴────────────────────┴────────────────────────┘
+
+ 0                                                                            20
+ ├─────────────────────────────────────────────────────────────────────────────┤
+ │ Class Header (32 bit)                                                       │
+ ├─────────┬───────────┬────────────┬─────────────┬─────────────┬──────────────┤
+ │ B0..<B4 │ B4 ..< B8 │ B8 ..< B12 │ B12 ..< B16 │ B16 ..< B18 │ B18 ..< B20  │
+ ├─────────┼───────────┼────────────┼─────────────┼─────────────┼──────────────┤
+ │ isa     │ ref count │ capacity   │ count       │ countFlags  │ capacityFlags│
+ └─────────┴───────────┴────────────┴─────────────┴─────────────┴──────────────┘
+
+ Tail Allocations:
+
+ `__StringStorage.create` takes a requested minimum code unit capacity and a
+ count (which it uses to gurantee null-termination invariant). This will
+ allocate the class header and a tail allocation for the requested capacity plus
+ one (for the null-terminator), plus any excess `malloc` bucket space. If
+ breadcrumbs need be present, they appear at the very end of the allocation.
+
+ For small allocations, `__StringStorage.create` will round up the total
+ allocation to a malloc bucket estimate (16 bytes) and claim any excess capacity
+ as additional code unit capacity. For large allocations, `malloc_size` is
+ consulted and any excess capacity is likewise claimed as additional code unit
+ capacity.
+
+ H                                                                             n
+ ├─────────────────────────────────────────────────────────────────────────────┤
+ │ Tail allocation, no breadcrumbs pointer                                     │
+ ├───────────────────┬────────┬────────────────────────────────────────────────┤
+ │ B<H> ..< B<H+c>   │ B<H+c> │ B<H+c+1> ..< B<n>                              │
+ ├───────────────────┼────────┼────────────────────────────────────────────────┤
+ │ code unit count   │ null   │ spare code unit capacity                       │
+ └───────────────────┴────────┴────────────────────────────────────────────────┘
+
+ H                                                                             n
+ ├─────────────────────────────────────────────────────────────────────────────┤
+ │ Tail allocations, with breadcrumbs pointer                                  │
+ ├───────────────────┬────────┬──────────────────────────┬─────────────────────┤
+ │ B<H> ..< B<H+c>   │ B<H+c> │ B<H+c+1> ..< B<n-P>      │ B<n-P> ..< B<n>     │
+ ├───────────────────┼────────┼──────────────────────────┼─────────────────────┤
+ │ code unit count   │ null   │ spare code unit capacity │ breadcrumbs pointer │
+ └───────────────────┴────────┴──────────────────────────┴─────────────────────┘
+
+ where:
+  * `H` is the class header size (32/20 on 64/32 bit, constant)
+  * `n` is the total allocation size (estimate or `malloc_size`)
+  * `c` is the given count
+  * `P` is the size of the breadcrumbs pointer (8/4 on 64/32 bit, constant)
+
+*/
+
+// TODO: Migrate this to somewhere it can be shared with Array
+import SwiftShims
+fileprivate func _allocate<T: AnyObject>(
+  numHeaderBytes: Int,        // The size of the class header
+  numTailBytes: Int,          // The desired number of tail bytes
+  growthFactor: Float? = nil, // Exponential growth factor for large allocs
+  tailAllocator: (_ numTailBytes: Int) -> T // Do the actual tail allocation
+) -> (T, realNumTailBytes: Int) {
+  _internalInvariant(getSwiftClassInstanceExtents(T.self).1 == numHeaderBytes)
+
+  let numBytes = numHeaderBytes + numTailBytes
+
+  let linearBucketThreshold = 128
+  if _fastPath(numBytes < linearBucketThreshold) {
+    // Allocate up to the nearest bucket of 16
+    let realNumBytes = (numBytes+15) & ~15
+    let realNumTailBytes = realNumBytes - numHeaderBytes
+    _internalInvariant(realNumTailBytes >= numTailBytes)
+    let object = tailAllocator(realNumTailBytes)
+    return (object, realNumTailBytes)
+  }
+
+  let growTailBytes: Int
+  if let growth = growthFactor {
+    growTailBytes = Swift.max(numTailBytes, Int(Float(numTailBytes) * growth))
+  } else {
+    growTailBytes = numTailBytes
+  }
+
+  let object = tailAllocator(growTailBytes)
+  let mallocSize = _swift_stdlib_malloc_size(
+    UnsafeRawPointer(Builtin.bridgeToRawPointer(object)))
+  let realNumTailBytes = mallocSize - numHeaderBytes
+  _internalInvariant(realNumTailBytes >= numTailBytes)
+  return (object, realNumTailBytes)
+}
+
+fileprivate func _allocateStringStorage(
+  codeUnitCapacity capacity: Int
+) -> (__StringStorage, _CapacityAndFlags) {
+  let pointerSize = MemoryLayout<Int>.stride
+  let headerSize = Int(_StringObject.nativeBias)
+  let codeUnitSize = capacity + 1 /* code units and null */
+  let needBreadcrumbs = capacity >= _StringBreadcrumbs.breadcrumbStride
+  let breadcrumbSize = needBreadcrumbs ? pointerSize : 0
+
+  let (storage, numTailBytes) = _allocate(
+    numHeaderBytes: headerSize,
+    numTailBytes: codeUnitSize + breadcrumbSize
+  ) { tailBytes in
+      Builtin.allocWithTailElems_1(
+        __StringStorage.self, tailBytes._builtinWordValue, UInt8.self)
+  }
+
+  let capAndFlags = _CapacityAndFlags(
+    hasBreadcrumbs: needBreadcrumbs,
+    realCapacity: numTailBytes - breadcrumbSize)
+
+  _internalInvariant(numTailBytes >= codeUnitSize + breadcrumbSize)
+  return (storage, capAndFlags)
+}
 
 // NOTE: older runtimes called this class _StringStorage. The two
 // must coexist without conflicting ObjC class names, so it was
@@ -49,42 +241,38 @@ final internal class __StringStorage
 #if arch(i386) || arch(arm) || arch(wasm32)
   // The total allocated storage capacity. Note that this includes the required
   // nul-terminator.
-  internal var _realCapacity: Int
-  internal var _count: Int
-  internal var _flags: UInt16
-  internal var _reserved: UInt16
+  private var _realCapacity: Int
+  private var _count: Int
+  private var _countFlags: UInt16
+  private var _capacityFlags: UInt16
 
   @inline(__always)
-  internal var count: Int { return _count }
+  internal var count: Int { _count }
 
   @inline(__always)
   internal var _countAndFlags: _StringObject.CountAndFlags {
-    return CountAndFlags(count: _count, flags: _flags)
+    _CountAndFlags(count: _count, flags: _countFlags)
+  }
+
+  @inline(__always)
+  fileprivate var _capacityAndFlags: _CapacityAndFlags {
+    // TODO: ...
+    _CapacityAndFlags(realCapacity: _realCapacity, flags: _capacityFlags)
   }
 #else
-  // The capacity of our allocation. Note that this includes the nul-terminator,
-  // which is not available for overriding.
-  internal var _realCapacityAndFlags: UInt64
+  fileprivate var _capacityAndFlags: _CapacityAndFlags
   internal var _countAndFlags: _StringObject.CountAndFlags
 
   @inline(__always)
-  internal var count: Int { return _countAndFlags.count }
-
-  // The total allocated storage capacity. Note that this includes the required
-  // nul-terminator.
-  @inline(__always)
-  internal var _realCapacity: Int {
-    return Int(truncatingIfNeeded:
-      _realCapacityAndFlags & CountAndFlags.countMask)
-  }
+  internal var count: Int { _countAndFlags.count }
 #endif
 
   @inline(__always)
-  final internal var isASCII: Bool { return _countAndFlags.isASCII }
+  final internal var isASCII: Bool { _countAndFlags.isASCII }
 
   final internal var asString: String {
     @_effects(readonly) @inline(__always)
-    get { return String(_StringGuts(self)) }
+    get { String(_StringGuts(self)) }
   }
 
 
@@ -93,102 +281,88 @@ final internal class __StringStorage
   }
 
   deinit {
-    _breadcrumbsAddress.deinitialize(count: 1)
+    if hasBreadcrumbs {
+      _breadcrumbsAddress.deinitialize(count: 1)
+    }
   }
-}
-
-// Determine the actual number of code unit capacity to request from malloc. We
-// round up the nearest multiple of 8 that isn't a mulitple of 16, to fully
-// utilize malloc's small buckets while accounting for the trailing
-// _StringBreadCrumbs.
-//
-// NOTE: We may still under-utilize the spare bytes from the actual allocation
-// for Strings ~1KB or larger, though at this point we're well into our growth
-// curve.
-private func determineCodeUnitCapacity(_ desiredCapacity: Int) -> Int {
-#if arch(i386) || arch(arm) || arch(wasm32)
-  // FIXME: Adapt to actual 32-bit allocator. For now, let's arrange things so
-  // that the instance size will be a multiple of 4.
-  let bias = Int(bitPattern: _StringObject.nativeBias)
-  let minimum = bias + desiredCapacity + 1
-  let size = (minimum + 3) & ~3
-  _internalInvariant(size % 4 == 0)
-  let capacity = size - bias
-  _internalInvariant(capacity > desiredCapacity)
-  return capacity
-#else
-  // Bigger than _SmallString, and we need 1 extra for nul-terminator.
-  let minCap = 1 + Swift.max(desiredCapacity, _SmallString.capacity)
-  _internalInvariant(minCap < 0x1_0000_0000_0000, "max 48-bit length")
-
-  // Round up to the nearest multiple of 8 that isn't also a multiple of 16.
-  let capacity = ((minCap + 7) & -16) + 8
-  _internalInvariant(
-    capacity > desiredCapacity && capacity % 8 == 0 && capacity % 16 != 0)
-  return capacity
-#endif
 }
 
 // Creation
 extension __StringStorage {
+  // TODO: Test effect of asking for exactly 62, 63, 64, 65 code units...
   @_effects(releasenone)
   private static func create(
-    realCodeUnitCapacity: Int, countAndFlags: CountAndFlags
+    codeUnitCapacity capacity: Int, countAndFlags: _CountAndFlags
   ) -> __StringStorage {
-    let storage = Builtin.allocWithTailElems_2(
-      __StringStorage.self,
-      realCodeUnitCapacity._builtinWordValue, UInt8.self,
-      1._builtinWordValue, Optional<_StringBreadcrumbs>.self)
+    _internalInvariant(capacity >= countAndFlags.count)
+    _internalInvariant(
+      countAndFlags.isNativelyStored && countAndFlags.isTailAllocated)
+
+    let (storage, capAndFlags) = _allocateStringStorage(
+      codeUnitCapacity: capacity)
+
+    _internalInvariant(capAndFlags.capacity >= capacity)
+
 #if arch(i386) || arch(arm) || arch(wasm32)
-    storage._realCapacity = realCodeUnitCapacity
+    storage._realCapacity = capAndFlags._realCapacity
     storage._count = countAndFlags.count
-    storage._flags = countAndFlags.flags
+    storage._countFlags = countAndFlags.flags
+    storage._capacityFlags = capAndFlags.flags
 #else
-    storage._realCapacityAndFlags =
-      UInt64(truncatingIfNeeded: realCodeUnitCapacity)
+    storage._capacityAndFlags = capAndFlags
     storage._countAndFlags = countAndFlags
 #endif
 
-    storage._breadcrumbsAddress.initialize(to: nil)
+    _internalInvariant(
+      storage._countAndFlags._storage == countAndFlags._storage)
+    _internalInvariant(
+      storage._capacityAndFlags._storage == capAndFlags._storage)
+    _internalInvariant(
+      storage.unusedCapacity == capAndFlags.capacity - countAndFlags.count)
+
+    if storage.hasBreadcrumbs {
+      storage._breadcrumbsAddress.initialize(to: nil)
+    }
+
     storage.terminator.pointee = 0 // nul-terminated
 
-    // NOTE: We can't _invariantCheck() now, because code units have not been
-    // initialized. But, _StringGuts's initializer will.
+    // We can check layout invariants, but our code units have not yet been
+    // initialized so we can't verify e.g. ASCII-ness
+    storage._invariantCheck(initialized: false)
     return storage
   }
 
-  @_effects(releasenone)
-  private static func create(
-    capacity: Int, countAndFlags: CountAndFlags
+  // DO NOT PUSH: For stats gathering only...
+  internal static func create(
+    count: Int, codeUnitCapacity capacity: Int
   ) -> __StringStorage {
-    _internalInvariant(capacity >= countAndFlags.count)
-
-    let realCapacity = determineCodeUnitCapacity(capacity)
-    _internalInvariant(realCapacity > capacity)
-    return __StringStorage.create(
-      realCodeUnitCapacity: realCapacity, countAndFlags: countAndFlags)
+    __StringStorage.create(
+      codeUnitCapacity: capacity,
+      countAndFlags: _CountAndFlags(mortalCount: count, isASCII: false))
+    // NOTE: content is garbage and not necessarily validy endcoded. Please
+    // delete this entry point...
   }
 
   // The caller is expected to check UTF8 validity and ASCII-ness and update
   // the resulting StringStorage accordingly
   internal static func create(
-    uninitializedCapacity capacity: Int,
+    uninitializedCodeUnitCapacity capacity: Int,
     initializingUncheckedUTF8With initializer: (
       _ buffer: UnsafeMutableBufferPointer<UInt8>
     ) throws -> Int
   ) rethrows -> __StringStorage {
     let storage = __StringStorage.create(
-      capacity: capacity,
-      countAndFlags: CountAndFlags(mortalCount: 0, isASCII: false)
+      codeUnitCapacity: capacity,
+      countAndFlags: _CountAndFlags(mortalCount: 0, isASCII: false)
     )
     let buffer = UnsafeMutableBufferPointer(start: storage.mutableStart,
                                             count: capacity)
     let count = try initializer(buffer)
 
-    let countAndFlags = CountAndFlags(mortalCount: count, isASCII: false)
+    let countAndFlags = _CountAndFlags(mortalCount: count, isASCII: false)
     #if arch(i386) || arch(arm) || arch(wasm32)
     storage._count = countAndFlags.count
-    storage._flags = countAndFlags.flags
+    storage._countFlags = countAndFlags.flags
     #else
     storage._countAndFlags = countAndFlags
     #endif
@@ -200,14 +374,14 @@ extension __StringStorage {
   @_effects(releasenone)
   internal static func create(
     initializingFrom bufPtr: UnsafeBufferPointer<UInt8>,
-    capacity: Int,
+    codeUnitCapacity capacity: Int,
     isASCII: Bool
   ) -> __StringStorage {
-    let countAndFlags = CountAndFlags(
+    let countAndFlags = _CountAndFlags(
       mortalCount: bufPtr.count, isASCII: isASCII)
     _internalInvariant(capacity >= bufPtr.count)
     let storage = __StringStorage.create(
-      capacity: capacity, countAndFlags: countAndFlags)
+      codeUnitCapacity: capacity, countAndFlags: countAndFlags)
     let addr = bufPtr.baseAddress._unsafelyUnwrappedUnchecked
     storage.mutableStart.initialize(from: addr, count: bufPtr.count)
     storage._invariantCheck()
@@ -218,58 +392,70 @@ extension __StringStorage {
   internal static func create(
     initializingFrom bufPtr: UnsafeBufferPointer<UInt8>, isASCII: Bool
   ) -> __StringStorage {
-    return __StringStorage.create(
-      initializingFrom: bufPtr, capacity: bufPtr.count, isASCII: isASCII)
+    __StringStorage.create(
+      initializingFrom: bufPtr,
+      codeUnitCapacity: bufPtr.count,
+      isASCII: isASCII)
   }
 }
 
 // Usage
 extension __StringStorage {
+  internal var hasBreadcrumbs: Bool { _capacityAndFlags.hasBreadcrumbs }
+
   @inline(__always)
-  private var mutableStart: UnsafeMutablePointer<UInt8> {
-    return UnsafeMutablePointer(Builtin.projectTailElems(self, UInt8.self))
+  internal var mutableStart: UnsafeMutablePointer<UInt8> {
+    UnsafeMutablePointer(Builtin.projectTailElems(self, UInt8.self))
   }
   @inline(__always)
   private var mutableEnd: UnsafeMutablePointer<UInt8> {
-     return mutableStart + count
+     mutableStart + count
   }
 
   @inline(__always)
   internal var start: UnsafePointer<UInt8> {
-     return UnsafePointer(mutableStart)
+     UnsafePointer(mutableStart)
   }
 
   @inline(__always)
   private final var end: UnsafePointer<UInt8> {
-    return UnsafePointer(mutableEnd)
+    UnsafePointer(mutableEnd)
   }
 
   // Point to the nul-terminator.
   @inline(__always)
-  private final var terminator: UnsafeMutablePointer<UInt8> {
-    return mutableEnd
+  internal final var terminator: UnsafeMutablePointer<UInt8> {
+    mutableEnd
   }
 
   @inline(__always)
   internal var codeUnits: UnsafeBufferPointer<UInt8> {
-    return UnsafeBufferPointer(start: start, count: count)
+    UnsafeBufferPointer(start: start, count: count)
+  }
+
+  // The address after the last bytes of capacity
+  //
+  // If breadcrumbs are present, this will point to them, otherwise it will
+  // point to the end of the allocation (as far as Swift is concerned).
+  fileprivate var _realCapacityEnd: Builtin.RawPointer {
+    Builtin.getTailAddr_Word(
+      start._rawValue,
+      _capacityAndFlags._realCapacity._builtinWordValue,
+      UInt8.self,
+      Optional<_StringBreadcrumbs>.self)
   }
 
   // @opaque
-  internal var _breadcrumbsAddress: UnsafeMutablePointer<_StringBreadcrumbs?> {
-    let raw = Builtin.getTailAddr_Word(
-      start._rawValue,
-      _realCapacity._builtinWordValue,
-      UInt8.self,
-      Optional<_StringBreadcrumbs>.self)
-    return UnsafeMutablePointer(raw)
+  fileprivate var _breadcrumbsAddress: UnsafeMutablePointer<_StringBreadcrumbs?> {
+    // TODO: better message
+    precondition(
+      hasBreadcrumbs, "Internal error: string breadcrumbs not present")
+    return UnsafeMutablePointer(_realCapacityEnd)
   }
 
   // The total capacity available for code units. Note that this excludes the
   // required nul-terminator.
-  internal var capacity: Int {
-    return _realCapacity &- 1
-  }
+  internal var capacity: Int { _capacityAndFlags.capacity }
 
   // The unused capacity available for appending. Note that this excludes the
   // required nul-terminator.
@@ -277,37 +463,44 @@ extension __StringStorage {
   // NOTE: Callers who wish to mutate this storage should enfore nul-termination
   @inline(__always)
   private var unusedStorage: UnsafeMutableBufferPointer<UInt8> {
-    return UnsafeMutableBufferPointer(
+    UnsafeMutableBufferPointer(
       start: mutableEnd, count: unusedCapacity)
   }
 
   // The capacity available for appending. Note that this excludes the required
   // nul-terminator.
-  internal var unusedCapacity: Int { return _realCapacity &- count &- 1 }
+  internal var unusedCapacity: Int { capacity &- count }
 
   #if !INTERNAL_CHECKS_ENABLED
-  @inline(__always) internal func _invariantCheck() {}
+  @inline(__always) internal func _invariantCheck(initialized: Bool = true) {}
   #else
-  internal func _invariantCheck() {
+  internal func _invariantCheck(initialized: Bool = true) {
     let rawSelf = UnsafeRawPointer(Builtin.bridgeToRawPointer(self))
     let rawStart = UnsafeRawPointer(start)
     _internalInvariant(unusedCapacity >= 0)
     _internalInvariant(count <= capacity)
     _internalInvariant(rawSelf + Int(_StringObject.nativeBias) == rawStart)
-    _internalInvariant(self._realCapacity > self.count, "no room for nul-terminator")
+    _internalInvariant(
+      self._capacityAndFlags._realCapacity > self.count,
+      "no room for nul-terminator")
     _internalInvariant(self.terminator.pointee == 0, "not nul terminated")
     let str = asString
     _internalInvariant(str._guts._object.isPreferredRepresentation)
 
     _countAndFlags._invariantCheck()
-    if isASCII {
+    if isASCII && initialized {
       _internalInvariant(_allASCII(self.codeUnits))
     }
-    if let crumbs = _breadcrumbsAddress.pointee {
+    if hasBreadcrumbs, let crumbs = _breadcrumbsAddress.pointee {
       crumbs._invariantCheck(for: self.asString)
     }
     _internalInvariant(_countAndFlags.isNativelyStored)
     _internalInvariant(_countAndFlags.isTailAllocated)
+
+    // Check that capacity end matches our notion of unused storage, and also
+    // checks that breadcrumbs were dutifully aligned.
+    _internalInvariant(UnsafeMutablePointer<UInt8>(_realCapacityEnd)
+      == unusedStorage.baseAddress! + (unusedStorage.count + 1))
   }
   #endif // INTERNAL_CHECKS_ENABLED
 }
@@ -317,18 +510,20 @@ extension __StringStorage {
   // Perform common post-RRC adjustments and invariant enforcement.
   @_effects(releasenone)
   internal func _updateCountAndFlags(newCount: Int, newIsASCII: Bool) {
-    let countAndFlags = CountAndFlags(
+    let countAndFlags = _CountAndFlags(
       mortalCount: newCount, isASCII: newIsASCII)
 #if arch(i386) || arch(arm) || arch(wasm32)
     self._count = countAndFlags.count
-    self._flags = countAndFlags.flags
+    self._countFlags = countAndFlags.flags
 #else
     self._countAndFlags = countAndFlags
 #endif
     self.terminator.pointee = 0
 
     // TODO(String performance): Consider updating breadcrumbs when feasible.
-    self._breadcrumbsAddress.pointee = nil
+    if hasBreadcrumbs {
+      self._breadcrumbsAddress.pointee = nil
+    }
     _invariantCheck()
   }
 
@@ -465,11 +660,11 @@ final internal class __SharedStringStorage
 
 #if arch(i386) || arch(arm) || arch(wasm32)
   internal var _count: Int
-  internal var _flags: UInt16
+  internal var _countFlags: UInt16
 
   @inline(__always)
   internal var _countAndFlags: _StringObject.CountAndFlags {
-    return CountAndFlags(count: _count, flags: _flags)
+    _CountAndFlags(count: _count, flags: _countFlags)
   }
 #else
   internal var _countAndFlags: _StringObject.CountAndFlags
@@ -477,7 +672,7 @@ final internal class __SharedStringStorage
 
   internal var _breadcrumbs: _StringBreadcrumbs? = nil
 
-  internal var count: Int { return _countAndFlags.count }
+  internal var count: Int { _countAndFlags.count }
 
   internal init(
     immortal ptr: UnsafePointer<UInt8>,
@@ -487,7 +682,7 @@ final internal class __SharedStringStorage
     self.start = ptr
 #if arch(i386) || arch(arm) || arch(wasm32)
     self._count = countAndFlags.count
-    self._flags = countAndFlags.flags
+    self._countFlags = countAndFlags.flags
 #else
     self._countAndFlags = countAndFlags
 #endif
@@ -522,3 +717,40 @@ extension __SharedStringStorage {
   }
 #endif // INTERNAL_CHECKS_ENABLED
 }
+
+// Get and populate breadcrumbs
+extension _StringGuts {
+  @_effects(releasenone)
+  internal func getBreadcrumbsPtr() -> UnsafePointer<_StringBreadcrumbs> {
+    _internalInvariant(hasBreadcrumbs)
+
+    let mutPtr: UnsafeMutablePointer<_StringBreadcrumbs?>
+    if hasNativeStorage {
+      mutPtr = _object.nativeStorage._breadcrumbsAddress
+    } else {
+      mutPtr = UnsafeMutablePointer(
+        Builtin.addressof(&_object.sharedStorage._breadcrumbs))
+    }
+
+    if _slowPath(mutPtr.pointee == nil) {
+      populateBreadcrumbs(mutPtr)
+    }
+
+    _internalInvariant(mutPtr.pointee != nil)
+    // assuming optional class reference and class reference can alias
+    return UnsafeRawPointer(mutPtr).assumingMemoryBound(to: _StringBreadcrumbs.self)
+  }
+
+  @inline(never) // slow-path
+  @_effects(releasenone)
+  internal func populateBreadcrumbs(
+    _ mutPtr: UnsafeMutablePointer<_StringBreadcrumbs?>
+  ) {
+    // Thread-safe compare-and-swap
+    let crumbs = _StringBreadcrumbs(String(self))
+    _stdlib_atomicInitializeARCRef(
+      object: UnsafeMutableRawPointer(mutPtr).assumingMemoryBound(to: Optional<AnyObject>.self),
+      desired: crumbs)
+  }
+}
+

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -531,6 +531,8 @@ extension String.UTF16View {
     let idx = _utf16AlignNativeIndex(idx)
 
     guard _guts._useBreadcrumbs(forEncodedOffset: idx._encodedOffset) else {
+      // TODO: Generic _distance is still very slow. We should be able to
+      // skip over ASCII substrings quickly
       return _distance(from: startIndex, to: idx)
     }
 

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -509,11 +509,14 @@ extension String.Index {
 }
 
 // Breadcrumb-aware acceleration
-extension String.UTF16View {
-  // A simple heuristic we can always tweak later. Not needed for correctness
-  @inlinable @inline(__always)
-  internal var _shortHeuristic: Int { return 32 }
+extension _StringGuts {
+  @inline(__always)
+  fileprivate func _useBreadcrumbs(forEncodedOffset offset: Int) -> Bool {
+    return hasBreadcrumbs && offset >= _StringBreadcrumbs.breadcrumbStride
+  }
+}
 
+extension String.UTF16View {
   @usableFromInline
   @_effects(releasenone)
   internal func _nativeGetOffset(for idx: Index) -> Int {
@@ -526,7 +529,8 @@ extension String.UTF16View {
     }
 
     let idx = _utf16AlignNativeIndex(idx)
-    if idx._encodedOffset < _shortHeuristic || !_guts.hasBreadcrumbs {
+
+    guard _guts._useBreadcrumbs(forEncodedOffset: idx._encodedOffset) else {
       return _distance(from: startIndex, to: idx)
     }
 
@@ -548,7 +552,7 @@ extension String.UTF16View {
 
     if _guts.isASCII { return Index(_encodedOffset: offset) }
 
-    if offset < _shortHeuristic || !_guts.hasBreadcrumbs {
+    guard _guts._useBreadcrumbs(forEncodedOffset: offset) else {
       return _index(startIndex, offsetBy: offset)
     }
 

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -146,8 +146,7 @@ extension String.UTF16View: BidirectionalCollection {
     // For a BMP scalar (1-3 UTF-8 code units), advance past it. For a non-BMP
     // scalar, use a transcoded offset first.
 
-    // TODO: do the ugly if non-transcoded make sure to scalar align thing...
-    // Also, can we just jump ahead 4 is transcoded is 1?
+    // TODO: If transcoded is 1, can we just skip ahead 4?
 
     let idx = _utf16AlignNativeIndex(idx)
     let len = _guts.fastUTF8ScalarLength(startingAt: idx._encodedOffset)

--- a/test/stdlib/NewStringAppending.swift
+++ b/test/stdlib/NewStringAppending.swift
@@ -63,23 +63,23 @@ var s = "⓪" // start non-empty
 // explicitly request initial capacity.
 s.reserveCapacity(16)
 
-// CHECK-NEXT: String(Native(owner: @[[storage0:[x0-9a-f]+]], count: 3, capacity: 23)) = "⓪"
+// CHECK-NEXT: String(Native(owner: @[[storage0:[x0-9a-f]+]], count: 3, capacity: 31)) = "⓪"
 print("\(repr(s))")
 
-// CHECK-NEXT: String(Native(owner: @[[storage0]], count: 4, capacity: 23)) = "⓪1"
+// CHECK-NEXT: String(Native(owner: @[[storage0]], count: 4, capacity: 31)) = "⓪1"
 s += "1"
 print("\(repr(s))")
 
-// CHECK-NEXT: String(Native(owner: @[[storage0]], count: 10, capacity: 23)) = "⓪1234567"
+// CHECK-NEXT: String(Native(owner: @[[storage0]], count: 10, capacity: 31)) = "⓪1234567"
 s += "234567"
 print("\(repr(s))")
 
-// CHECK-NEXT: String(Native(owner: @[[storage0]], count: 11, capacity: 23)) = "⓪12345678"
+// CHECK-NEXT: String(Native(owner: @[[storage0]], count: 11, capacity: 31)) = "⓪12345678"
 // CHECK-NOT: @[[storage0]],
 s += "8"
 print("\(repr(s))")
 
-// CHECK-NEXT: String(Native(owner: @[[storage0]], count: 18, capacity: 23)) = "⓪123456789012345"
+// CHECK-NEXT: String(Native(owner: @[[storage0]], count: 18, capacity: 31)) = "⓪123456789012345"
 s += "9012345"
 print("\(repr(s))")
 
@@ -95,12 +95,12 @@ print("(expecting reallocation)")
 // more capacity.  It might be better to always grow to a multiple of
 // the current capacity when the capacity is exceeded.
 
-// CHECK-NEXT: String(Native(owner: @[[storage1:[x0-9a-f]+]], count: 54, capacity: 55))
+// CHECK-NEXT: String(Native(owner: @[[storage1:[x0-9a-f]+]], count: 54, capacity: 63))
 // CHECK-NOT: @[[storage1]],
 s += s + s
 print("\(repr(s))")
 
-// CHECK-NEXT: String(Native(owner: @[[storage1]], count: 55, capacity: 55))
+// CHECK-NEXT: String(Native(owner: @[[storage1]], count: 55, capacity: 63))
 s += "C"
 print("\(repr(s))")
 
@@ -108,7 +108,7 @@ print("\(repr(s))")
 // CHECK-LABEL: (expecting second reallocation)
 print("(expecting second reallocation)")
 
-// CHECK-NEXT: String(Native(owner: @[[storage2:[x0-9a-f]+]], count: 56, capacity: 119))
+// CHECK-NEXT: String(Native(owner: @[[storage2:[x0-9a-f]+]], count: 56, capacity: 63))
 // CHECK-NOT: @[[storage1]],
 s += "C"
 print("\(repr(s))")
@@ -117,14 +117,14 @@ print("\(repr(s))")
 // CHECK-LABEL: (expecting third reallocation)
 print("(expecting third reallocation)")
 
-// CHECK-NEXT: String(Native(owner: @[[storage3:[x0-9a-f]+]], count: 72, capacity: 119))
+// CHECK-NEXT: String(Native(owner: @[[storage3:[x0-9a-f]+]], count: 72, capacity: 135))
 // CHECK-NOT: @[[storage2]],
 s += "1234567890123456"
 print("\(repr(s))")
 
 var s1 = s
 
-// CHECK-NEXT: String(Native(owner: @[[storage3]], count: 72, capacity: 119))
+// CHECK-NEXT: String(Native(owner: @[[storage3]], count: 72, capacity: 135))
 print("\(repr(s1))")
 
 /// The use of later buffer capacity by another string forces
@@ -140,7 +140,7 @@ print("\(repr(s1))")
 
 /// The original copy is left unchanged
 
-// CHECK-NEXT: String(Native(owner: @[[storage3]], count: 72, capacity: 119))
+// CHECK-NEXT: String(Native(owner: @[[storage3]], count: 72, capacity: 135))
 print("\(repr(s))")
 
 /// Appending to an empty string re-uses the RHS


### PR DESCRIPTION
[string] Shrink storage class sizes.

* Don't allocate breadrumbs pointer if under threshold
* Increase breadrumbs threshold
* Linear 16-byte bucketing until 128 bytes, malloc_size after
* Allow cap less than _SmallString.capacity (bridging non-ASCII)

This change decreases the amount of heap usage for moderate-length
strings (< 64 UTF-8 code units in length) and increases the amount of
spare code unit capacity available (less growth needed).

Average improvements for moderate-length strings:

* 64-bit: on average, 8 bytes saved and 4 bytes of extra capacity
* 32-bit: on average, 4 bytes saved and 6 bytes of extra capacity

Additionally, on 32-bit, large-length strings also gain an average of
6 bytes of extra spare capacity.

Details:

On 64-bit, half of moderate-length allocations will save 16 bytes
while the other half get an extra 8 bytes of spare capacity.

On 32-bit, a quarter of moderate-length allocations will save 16
bytes, and the rest get an extra 4 bytes of spare
capacity. Additionally, 32-bit string's storage class now claims its
full allocation, which is its birthright. Prior to this change, we'd
have on average 1.5 bytes of spare capacity, and now we have 7.5 bytes
of spare capacity.

Breadcrumbs threshold is increased from the super-conservative 32 to
the pretty-conservative 64. Some speed improvements are incorporated
in this change, but more are in flight. Even without those eventual
improvements, this is a worthwhile change (ASCII is still fast-pathed
and irrelevant to breadcrumbing).

For a complex real-world workload, this amounts to around a 5%
improvement to transient heap usage due to all strings and a 4%
improvement to peak heap usage due to all strings. For moderate-length
strings specifically, this gives around 11% improvement to both.

rdar://problem/59685567