### PR TITLE
[ConstraintSystem] Make sure pattern matching tuple destructuring works both ways

### DIFF
--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -443,7 +443,7 @@ func rdar_60048356() {
   }
 
   enum Failure {
-    case closed(Info)
+    case closed(Info) // expected-note {{'closed' declared here}}
   }
 
   enum Reason {
@@ -452,6 +452,29 @@ func rdar_60048356() {
 
   func test(_ reason: Reason) {
     if case .close(.closed((code: .normalClosure, _))) = reason { // Ok
+    }
+  }
+
+  // rdar://problem/60061646
+  func test(e: Failure) {
+    if case .closed(code: .normalClosure, _) = e { // Ok
+    // expected-warning@-1 {{enum case 'closed' has one associated value that is a tuple of 2 elements}}
+    }
+  }
+
+  enum E {
+    case foo((x: Int, y: Int)) // expected-note {{declared here}}
+    case bar(x: Int, y: Int)   // expected-note {{declared here}}
+  }
+
+  func test_destructing(e: E) {
+    if case .foo(let x, let y) = e { // Ok (destructring)
+    // expected-warning@-1 {{enum case 'foo' has one associated value that is a tuple of 2 elements}}
+      _ = x == y
+    }
+    if case .bar(let tuple) = e { // Ok (matching via tuple)
+    // expected-warning@-1 {{enum case 'bar' has 2 associated values; matching them as a tuple is deprecated}}
+      _ = tuple.0 == tuple.1
     }
   }
 }


### PR DESCRIPTION
Consider following example:

```swift
enum E {
  case foo((x: Int, y: Int))
  case bar(x: Int, y: Int)
}

func test(e: E) {
  if case .foo(let x, let y) = e {}
  if case .bar(let tuple) = e {}
}
```

Both of `if case` expressions have to be supported:

1. `case .foo(let x, let y) = e` allows a single tuple
    parameter to be "destructured" into multiple arguments.

2. `case .bar(let tuple) = e` allows to match multiple
     parameters with a single tuple argument.

Resolves: rdar://problem/60061646

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
