### PR TITLE
[DependencyVerifier] Route DependencyVerifier diags through DiagnosticEngine

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -381,6 +381,32 @@ REMARK(interface_file_lock_failure,none,
 REMARK(interface_file_lock_timed_out,none,
       "timed out waiting to acquire lock file for module interface '%0'", (StringRef))
 
+// Dependency Verifier Diagnostics
+ERROR(dependency_cascading_mismatch,none,
+      "expected %select{cascading|non-cascading}0 dependency; found "
+      "%select{cascading|non-cascading}1 dependency instead",
+      (bool, bool))
+ERROR(potential_dependency_cascading_mismatch,none,
+      "expected %select{cascading|non-cascading}0 potential member dependency; "
+      "found %select{cascading|non-cascading}1 potential member dependency "
+      "instead", (bool, bool))
+ERROR(missing_member_dependency,none,
+      "expected "
+      "%select{%error|provided|member|potential member|dynamic member}0 "
+      "dependency does not exist: %1",
+      (/*Expectation::Kind*/uint8_t, StringRef))
+ERROR(unexpected_dependency,none,
+      "unexpected %0 %select{%error|%error||potential member|dynamic member}1 "
+      "dependency: %2", (StringRef, /*Expectation::Kind*/uint8_t, StringRef))
+ERROR(unexpected_provided_entity,none,
+      "unexpected provided entity: %0", (StringRef))
+ERROR(negative_expectation_violated,none,
+      "unexpected dependency exists: %0", (StringRef))
+ERROR(expectation_missing_opening_braces,none,
+      "expected {{ in expectation", ())
+ERROR(expectation_missing_closing_braces,none,
+      "didn't find '}}' to match '{{' in expectation", ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG


### PR DESCRIPTION
This will help ensure it can be tested using `DiagnosticVerifier` without relying on hooking `SMDiagnostic` emission. https://github.com/apple/swift/pull/28313 has some discussion of why this is desirable.
