### PR TITLE
Support the combination of -enable-educational-notes and -enable-experimental-diagnostic-formatting

### DIFF
--- a/include/swift/Frontend/PrintingDiagnosticConsumer.h
+++ b/include/swift/Frontend/PrintingDiagnosticConsumer.h
@@ -37,6 +37,9 @@ class PrintingDiagnosticConsumer : public DiagnosticConsumer {
   // implicitly associated with it. Uses `std::unique_ptr` so that
   // `AnnotatedSourceSnippet` can be forward declared.
   std::unique_ptr<AnnotatedSourceSnippet> currentSnippet;
+  // Educational notes which are buffered until the consumer is finished
+  // constructing a snippet.
+  SmallVector<std::string, 1> BufferedEducationalNotes;
 
 public:
   PrintingDiagnosticConsumer(llvm::raw_ostream &stream = llvm::errs());

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -898,6 +898,10 @@ void PrintingDiagnosticConsumer::handleDiagnostic(SourceManager &SM,
       currentSnippet = std::make_unique<AnnotatedSourceSnippet>(SM);
       annotateSnippetWithInfo(SM, Info, *currentSnippet);
     }
+    for (auto path : Info.EducationalNotePaths) {
+      if (auto buffer = SM.getFileSystem()->getBufferForFile(path))
+        BufferedEducationalNotes.push_back(buffer->get()->getBuffer().str());
+    }
   } else {
     printDiagnostic(SM, Info);
 
@@ -929,6 +933,13 @@ void PrintingDiagnosticConsumer::flush(bool includeTrailingBreak) {
     }
     currentSnippet.reset();
   }
+
+  for (auto note : BufferedEducationalNotes) {
+    printMarkdown(note, Stream, ForceColors);
+    Stream << "\n";
+  }
+
+  BufferedEducationalNotes.clear();
 }
 
 bool PrintingDiagnosticConsumer::finishProcessing() {

--- a/test/diagnostics/educational-notes.swift
+++ b/test/diagnostics/educational-notes.swift
@@ -1,5 +1,6 @@
 // RUN: not %target-swift-frontend -color-diagnostics -enable-educational-notes -diagnostic-documentation-path %S/test-docs/ -typecheck %s 2>&1 | %FileCheck %s --match-full-lines --strict-whitespace
 // RUN: not %target-swift-frontend -no-color-diagnostics -enable-educational-notes -diagnostic-documentation-path %S/test-docs/ -typecheck %s 2>&1 | %FileCheck %s --match-full-lines --strict-whitespace --check-prefix=NO-COLOR
+// RUN: not %target-swift-frontend -enable-experimental-diagnostic-formatting -enable-educational-notes -diagnostic-documentation-path %S/test-docs/ -typecheck %s 2>&1 | %FileCheck %s --check-prefix=CHECK-DESCRIPTIVE
 
 // A diagnostic with no educational notes
 let x = 1 +
@@ -66,3 +67,18 @@ extension (Int, Int) {}
 // NO-COLOR-NEXT:--------------
 // NO-COLOR-NEXT:Header 1
 // NO-COLOR-NEXT:Header 3
+
+// CHECK-DESCRIPTIVE: educational-notes.swift
+// CHECK-DESCRIPTIVE-NEXT:  | // A diagnostic with an educational note
+// CHECK-DESCRIPTIVE-NEXT:  | extension (Int, Int) {}
+// CHECK-DESCRIPTIVE-NEXT:  | ^ error: expected expression after operator
+// CHECK-DESCRIPTIVE-NEXT:  |
+
+// CHECK-DESCRIPTIVE: educational-notes.swift
+// CHECK-DESCRIPTIVE-NEXT:  | // A diagnostic with an educational note
+// CHECK-DESCRIPTIVE-NEXT:  | extension (Int, Int) {}
+// CHECK-DESCRIPTIVE-NEXT:  |           ~~~~~~~~~~
+// CHECK-DESCRIPTIVE-NEXT:  | ^ error: non-nominal type '(Int, Int)' cannot be extended
+// CHECK-DESCRIPTIVE-NEXT:  |
+// CHECK-DESCRIPTIVE-NEXT: Nominal Types
+// CHECK-DESCRIPTIVE-NEXT: -------------


### PR DESCRIPTION
Because `-enable-experimental-diagnostic-formatting` implicitly groups diagnostics, we need to buffer up educational notes associated with the current snippet and output them all at once at the end. 

In the long term, we can avoid this buffering by using transactions or a similar mechanism to explicitly group diagnostics and emit them all at once. That will be a very large refactor though.