### PR TITLE
[Parse] Mark closure parameters as definitively not destructured in parseClosureSignatureIfPresent.

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2738,8 +2738,10 @@ parseClosureSignatureIfPresent(SourceRange &bracketRange,
 
   for (unsigned i = 0, e = params->size(); i != e; ++i) {
     auto *param = params->get(i);
-    if (!isTupleDestructuring(param))
+    if (!isTupleDestructuring(param)) {
+      param->setDestructured(false);
       continue;
+    }
 
     auto argName = "arg" + std::to_string(i);
 

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -992,3 +992,10 @@ func rdar_59741308() {
     }
   }
 }
+
+func r60074136() {
+  func takesClosure(_ closure: ((Int) -> Void) -> Void) {}
+
+  takesClosure { ((Int) -> Void) -> Void in // expected-warning {{unnamed parameters must be written with the empty name '_'}}
+  }
+}


### PR DESCRIPTION
Otherwise, closure parameters that were parsed as "potentially destructured" will fail constraint generation, even after the parser has decided they are not destructured.

Resolves: rdar://problem/60074136