### PR TITLE
[ownership] Implement InteriorPointer abstraction/validate current recognized ones addresses are not used outside of parent object's borrowed lifetime.

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -24,6 +24,7 @@
 #include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/DynamicCasts.h"
+#include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/LinearLifetimeChecker.h"
 #include "swift/SIL/OwnershipUtils.h"
 #include "swift/SIL/PrettyStackTrace.h"
@@ -164,10 +165,12 @@ private:
   bool isSubobjectProjectionWithLifetimeEndingUses(
       SILValue value,
       const SmallVectorImpl<Operand *> &lifetimeEndingUsers) const;
-  bool
-  discoverImplicitRegularUsers(const BorrowScopeOperand &initialScopedOperand,
-                               SmallVectorImpl<Operand *> &implicitRegularUsers,
-                               bool isGuaranteed);
+  bool discoverBorrowOperandImplicitRegularUsers(
+      const BorrowScopeOperand &initialScopedOperand,
+      SmallVectorImpl<Operand *> &implicitRegularUsers, bool isGuaranteed);
+  bool discoverInteriorPointerOperandImplicitRegularUsers(
+      const InteriorPointerOperand &interiorPointerOperand,
+      SmallVectorImpl<Operand *> &implicitRegularUsers);
 };
 
 } // end anonymous namespace
@@ -240,7 +243,7 @@ bool SILValueOwnershipChecker::isCompatibleDefUse(
 }
 
 /// Returns true if an error was found.
-bool SILValueOwnershipChecker::discoverImplicitRegularUsers(
+bool SILValueOwnershipChecker::discoverBorrowOperandImplicitRegularUsers(
     const BorrowScopeOperand &initialScopedOperand,
     SmallVectorImpl<Operand *> &implicitRegularUsers, bool isGuaranteed) {
   if (!initialScopedOperand.areAnyUserResultsBorrowIntroducers()) {
@@ -285,6 +288,115 @@ bool SILValueOwnershipChecker::discoverImplicitRegularUsers(
         });
   }
 
+  return foundError;
+}
+
+bool SILValueOwnershipChecker::
+    discoverInteriorPointerOperandImplicitRegularUsers(
+        const InteriorPointerOperand &interiorPointerOperand,
+        SmallVectorImpl<Operand *> &implicitRegularUsers) {
+  SILValue projectedAddress = interiorPointerOperand.getProjectedAddress();
+  SmallVector<Operand *, 8> worklist(projectedAddress->getUses());
+
+  bool foundError = false;
+
+  while (!worklist.empty()) {
+    auto *op = worklist.pop_back_val();
+
+    // Skip type dependent operands.
+    if (op->isTypeDependent())
+      continue;
+
+    // Before we do anything, add this operand to our implicit regular user
+    // list.
+    implicitRegularUsers.push_back(op);
+
+    // Then update the worklist with new things to find if we recognize this
+    // inst and then continue. If we fail, we emit an error at the bottom of the
+    // loop that we didn't recognize the user.
+    auto *user = op->getUser();
+
+    // First, eliminate "end point uses" that we just need to check liveness at
+    // and do not need to check transitive uses of.
+    if (isa<LoadInst>(user) || isa<CopyAddrInst>(user) ||
+        isIncidentalUse(user) || isa<StoreInst>(user) ||
+        isa<StoreBorrowInst>(user) || isa<PartialApplyInst>(user) ||
+        isa<DestroyAddrInst>(user) || isa<AssignInst>(user) ||
+        isa<AddressToPointerInst>(user) || isa<YieldInst>(user) ||
+        isa<LoadUnownedInst>(user) || isa<StoreUnownedInst>(user) ||
+        isa<EndApplyInst>(user) || isa<LoadWeakInst>(user) ||
+        isa<StoreWeakInst>(user) || isa<AssignByWrapperInst>(user) ||
+        isa<BeginUnpairedAccessInst>(user) ||
+        isa<EndUnpairedAccessInst>(user) || isa<WitnessMethodInst>(user) ||
+        isa<SwitchEnumAddrInst>(user) || isa<CheckedCastAddrBranchInst>(user) ||
+        isa<SelectEnumAddrInst>(user)) {
+      continue;
+    }
+
+    // Then handle users that we need to look at transitive uses of.
+    if (Projection::isAddressProjection(user) ||
+        isa<ProjectBlockStorageInst>(user) ||
+        isa<OpenExistentialAddrInst>(user) ||
+        isa<InitExistentialAddrInst>(user) || isa<BeginAccessInst>(user) ||
+        isa<TailAddrInst>(user) || isa<IndexAddrInst>(user)) {
+      for (SILValue r : user->getResults()) {
+        llvm::copy(r->getUses(), std::back_inserter(worklist));
+      }
+      continue;
+    }
+
+    if (auto *builtin = dyn_cast<BuiltinInst>(user)) {
+      if (auto kind = builtin->getBuiltinKind()) {
+        if (*kind == BuiltinValueKind::TSanInoutAccess) {
+          continue;
+        }
+      }
+    }
+
+    // If we have a load_borrow, add it's end scope to the liveness requirement.
+    if (auto *lbi = dyn_cast<LoadBorrowInst>(user)) {
+      transform(lbi->getEndBorrows(), std::back_inserter(implicitRegularUsers),
+                [](EndBorrowInst *ebi) { return &ebi->getAllOperands()[0]; });
+      continue;
+    }
+
+    // TODO: Merge this into the full apply site code below.
+    if (auto *beginApply = dyn_cast<BeginApplyInst>(user)) {
+      // TODO: Just add this to implicit regular user list?
+      llvm::copy(beginApply->getTokenResult()->getUses(),
+                 std::back_inserter(implicitRegularUsers));
+      continue;
+    }
+
+    if (auto fas = FullApplySite::isa(user)) {
+      continue;
+    }
+
+    if (auto *mdi = dyn_cast<MarkDependenceInst>(user)) {
+      // If this is the base, just treat it as a liveness use.
+      if (op->get() == mdi->getBase()) {
+        continue;
+      }
+
+      // If we are the value use, look through it.
+      llvm::copy(mdi->getValue()->getUses(), std::back_inserter(worklist));
+      continue;
+    }
+
+    // We were unable to recognize this user, so return true that we failed.
+    handleError([&] {
+      llvm::errs()
+          << "Function: " << op->getUser()->getFunction()->getName() << "\n"
+          << "Could not recognize address user of interior pointer operand!\n"
+          << "Interior Pointer Operand: "
+          << *interiorPointerOperand.operand->getUser()
+          << "Address User: " << *op->getUser();
+    });
+    foundError = true;
+  }
+
+  // We were able to recognize all of the uses of the address, so return false
+  // that we did not find any errors.
   return foundError;
 }
 
@@ -348,8 +460,8 @@ bool SILValueOwnershipChecker::gatherNonGuaranteedUsers(
     // initial end scope instructions without any further work.
     //
     // Maybe: Is borrow scope non-local?
-    foundError |= discoverImplicitRegularUsers(*initialScopedOperand,
-                                               implicitRegularUsers, false);
+    foundError |= discoverBorrowOperandImplicitRegularUsers(
+        *initialScopedOperand, implicitRegularUsers, false);
   }
 
   return foundError;
@@ -441,11 +553,19 @@ bool SILValueOwnershipChecker::gatherUsers(
       if (auto scopedOperand = BorrowScopeOperand::get(op)) {
         assert(!scopedOperand->consumesGuaranteedValues());
 
-        foundError |= discoverImplicitRegularUsers(*scopedOperand,
-                                                   implicitRegularUsers, true);
+        foundError |= discoverBorrowOperandImplicitRegularUsers(
+            *scopedOperand, implicitRegularUsers, true);
       }
 
-      // And then add the op to the non lifetime ending user list.
+      // Next see if our use is an interior pointer operand. If we have an
+      // interior pointer, we need to add all of its address uses as "implicit
+      // regular users" of our consumed value.
+      if (auto interiorPointerOperand = InteriorPointerOperand::get(op)) {
+        foundError |= discoverInteriorPointerOperandImplicitRegularUsers(
+            *interiorPointerOperand, implicitRegularUsers);
+      }
+
+      // Finally add the op to the non lifetime ending user list.
       LLVM_DEBUG(llvm::dbgs() << "        Regular User: " << *user);
       nonLifetimeEndingUsers.push_back(op);
       continue;

--- a/test/SILOptimizer/mem-behavior-all.sil
+++ b/test/SILOptimizer/mem-behavior-all.sil
@@ -19,9 +19,9 @@ class Parent {
 // CHECK-LABEL: @testLetSideEffects
 //
 // The store does not affect the let-load (ref_element_addr).
-// CHECK: PAIR #35.
-// CHECK-NEXT:    %7 = begin_access [modify] [static] %1 : $*Builtin.Int32
-// CHECK-NEXT:    %11 = ref_element_addr %10 : $C, #C.prop
+// CHECK: PAIR #25.
+// CHECK-NEXT:    %6 = begin_access [modify] [static] %1 : $*Builtin.Int32
+// CHECK-NEXT:    %10 = ref_element_addr %9 : $C, #C.prop
 // CHECK-NEXT:  r=0,w=0,se=0
 //
 // Any unknown instructions with side effects does affect the let-load.
@@ -38,7 +38,6 @@ bb0(%0 : @owned $Parent, %1 : $*Builtin.Int32):
   %borrow1 = begin_borrow %0 : $Parent
   %childAdr = ref_element_addr %borrow1 : $Parent, #Parent.child
   %child = load_borrow %childAdr : $*C
-  end_borrow %borrow1 : $Parent
 
   %three = integer_literal $Builtin.Int32, 3
   %access = begin_access [modify] [static] %1 : $*Builtin.Int32
@@ -50,6 +49,7 @@ bb0(%0 : @owned $Parent, %1 : $*Builtin.Int32):
   %val = load [trivial] %propAdr : $*Builtin.Int32
   end_borrow %borrow2 : $C
   end_borrow %child : $C
+  end_borrow %borrow1 : $Parent
   destroy_value %0 : $Parent
   return %val : $Builtin.Int32
 }


### PR DESCRIPTION
Currently, we only classify ref_element_addr and ref_tail_addr. But we should
expand this to project_box, project_existential_box and open_existential_box as
well.
