### PR TITLE
[ConstraintSystem] Don't assume the lhs type is for a generic parameter in simplifyConformsToConstraint.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5136,11 +5136,12 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
       // collection type couldn't be determined without unification to
       // `Any` and `+` failing for all numeric overloads is just a consequence.
       if (typeVar && type->isAny()) {
-        auto *GP = typeVar->getImpl().getGenericParameter();
-        if (auto *GPD = GP->getDecl()) {
-          auto *DC = GPD->getDeclContext();
-          if (DC->isTypeContext() && DC->getSelfInterfaceType()->isEqual(GP))
-            return SolutionKind::Error;
+        if (auto *GP = typeVar->getImpl().getGenericParameter()) {
+          if (auto *GPD = GP->getDecl()) {
+            auto *DC = GPD->getDeclContext();
+            if (DC->isTypeContext() && DC->getSelfInterfaceType()->isEqual(GP))
+              return SolutionKind::Error;
+          }
         }
       }
 

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -420,3 +420,10 @@ func test_force_unwrap_not_being_too_eager() {
   if let _ = obj.delegate?.window { // Ok
   }
 }
+
+// rdar://problem/57097401
+func invalidOptionalChaining(a: Any) {
+  a == "="? // expected-error {{cannot use optional chaining on non-optional value of type 'String'}}
+  // expected-error@-1 {{value of protocol type 'Any' cannot conform to 'Equatable'; only struct/enum/class types can conform to protocols}}
+  // expected-note@-2 {{requirement from conditional conformance of 'Any?' to 'Equatable'}}
+}


### PR DESCRIPTION
Fixes cases where we use invalid optional chaining on a type inferred to be `Any`, and a conformance is required, which previously would crash:

```swift
func test(a: Any) {
  a == "str"?
}
```

Resolves: rdar://problem/57097401