### PR TITLE
[Clang importer] Suppress method imports found via selector lookup.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3134,6 +3134,9 @@ void ClangModuleUnit::lookupObjCMethods(
     auto owningClangModule = getClangTopLevelOwningModule(objcMethod, clangCtx);
     if (owningClangModule != clangModule) continue;
 
+    if (shouldSuppressDeclImport(objcMethod))
+      continue;
+
     // If we found a property accessor, import the property.
     if (objcMethod->isPropertyAccessor())
       (void)owner.importDecl(objcMethod->findPropertyDecl(true),

--- a/test/ClangImporter/Inputs/frameworks/MismatchedNames.framework/Headers/MismatchedNames-Swift.h
+++ b/test/ClangImporter/Inputs/frameworks/MismatchedNames.framework/Headers/MismatchedNames-Swift.h
@@ -1,0 +1,16 @@
+#import <objc/NSObject.h>
+
+#  define OBJC_DESIGNATED_INITIALIZER __attribute__((objc_designated_initializer))
+#  define SWIFT_COMPILE_NAME(X) __attribute__((swift_name(X)))
+
+#  define SWIFT_CLASS_NAMED(SWIFT_NAME) __attribute__((objc_subclassing_restricted)) SWIFT_COMPILE_NAME(SWIFT_NAME)
+
+# pragma clang attribute push(__attribute__((external_source_symbol(language="Swift", defined_in="ObjCExportingFramework",generated_declaration))), apply_to=any(function,enum,objc_interface,objc_category,objc_protocol))
+
+SWIFT_CLASS_NAMED("SwiftClass")
+@interface SwiftClass : NSObject
++ (id _Nullable)usingIndex:(id _Nonnull)index;
+- (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
+@end
+
+# pragma clang attribute pop

--- a/test/ClangImporter/Inputs/frameworks/MismatchedNames.framework/MismatchedNamesSwift.swift
+++ b/test/ClangImporter/Inputs/frameworks/MismatchedNames.framework/MismatchedNamesSwift.swift
@@ -1,0 +1,6 @@
+import Foundation
+@_exported import MismatchedNames
+
+@objc public class SwiftClass : NSObject {
+  @objc public class func using(index: AnyObject) -> AnyObject? { return nil }
+}

--- a/test/ClangImporter/Inputs/frameworks/MismatchedNames.framework/Modules/module.modulemap
+++ b/test/ClangImporter/Inputs/frameworks/MismatchedNames.framework/Modules/module.modulemap
@@ -1,0 +1,6 @@
+framework module MismatchedNames {
+}
+
+module MismatchedNames.Swift {
+  header "MismatchedNames-Swift.h"
+}

--- a/test/ClangImporter/objc_mismatched_names.swift
+++ b/test/ClangImporter/objc_mismatched_names.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/modules
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -module-name MismatchedNames -F %S/Inputs/frameworks -o %t/modules/MismatchedNames.swiftmodule %S/Inputs/frameworks/MismatchedNames.framework/MismatchedNamesSwift.swift
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -I %t/modules %s -verify -verify-ignore-unknown
+
+// REQUIRES: objc_interop
+
+
+import Foundation
+import ObjectiveC
+import MismatchedNames
+
+// Ensure that we don't crash when looking up via Objective-C selector and
+// finding a method in the generated header that (due to a missing swift_name
+// attribute) isn't "obviously" matching its corresponding Swift method.
+//
+// rdar://problem/60046206 covers this crash.
+func test() {
+  _ = Selector(("usingIndex:")) // expected-warning{{use '#selector' instead of explicitly constructing a 'Selector'}}
+}


### PR DESCRIPTION
When we found Objective-C methods via selector lookup, we would skip the
“should we even try to import this?” check. If the Swift-name-as-derived-
from-Objective-C is different from the actual Swift name, we might try to
(redundantly) import something from the generated Objective-C header,
which can lead to crashes. The specific method causing problems was defined
like this in Swift:

    @objc public class func using(index: AnyObject) -> AnyObject? { return nil }

which produced an Objective-C method like this:

    + (id _Nullable)usingIndex:(id _Nonnull)index;

The Swift name derived from the Objective-C method is `usingIndex(_:)`, which
of course does not match `using(index:)`, meaning that we think these two
methods are different (they aren’t).

The safe fix is to check whether we should import a given Objective-C method
declaration along the found-via-Objective-C-selector path, like we do with
normal name lookup. A longer term fix is to emit swift_name attributes for
such methods.

Fixes the fiendish Clang importer crash in rdar://problem/60046206.
