### PR TITLE
[Constant Evaluator] Make the constant evaluator skip tsan instrumentation builtin

### DIFF
--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -21,6 +21,7 @@
 #include "swift/SIL/ApplySite.h"
 #include "swift/SIL/DynamicCasts.h"
 #include "swift/SIL/FormalLinkage.h"
+#include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILConstants.h"
 #include "swift/SILOptimizer/Utils/Devirtualize.h"
@@ -1718,7 +1719,9 @@ ConstExprFunctionState::evaluateFlowSensitive(SILInstruction *inst) {
       isa<DestroyAddrInst>(inst) || isa<RetainValueInst>(inst) ||
       isa<ReleaseValueInst>(inst) || isa<StrongRetainInst>(inst) ||
       isa<StrongReleaseInst>(inst) || isa<DestroyValueInst>(inst) ||
-      isa<EndBorrowInst>(inst))
+      isa<EndBorrowInst>(inst) ||
+      // Skip sanitizer instrumentation
+      isSanitizerInstrumentation(inst))
     return None;
 
   // If this is a special flow-sensitive instruction like a stack allocation,

--- a/test/SILOptimizer/constant_evaluator_test.sil
+++ b/test/SILOptimizer/constant_evaluator_test.sil
@@ -1531,3 +1531,16 @@ bb0:
   dealloc_stack %2 : $*UInt64
   return %5 : $String
 } // CHECK: Returns string: "18446744073709551615"
+
+// CHECK-LABEL: @interpretTsanInstrumentationSkip
+sil [ossa] @interpretTsanInstrumentationSkip : $@convention(thin) () -> Builtin.Int32 {
+bb0:
+  %0 = integer_literal $Builtin.Int32, 23
+  %1 = alloc_stack $Builtin.Int32
+  store %0 to [trivial] %1 : $*Builtin.Int32
+  // This builtin should be skipped and should not affect the value of the argument
+  %2 = builtin "tsanInoutAccess"(%1 : $*Builtin.Int32) : $()
+  %3 = load [trivial] %1 : $*Builtin.Int32
+  dealloc_stack %1 : $*Builtin.Int32
+  return %3 : $Builtin.Int32
+} // CHECK: Returns int: 23


### PR DESCRIPTION
This patch makes the constant evaluator consider the calls to the builtin: tsanInoutAccess as a noop. This is necessary to make the new os log APIs work with thread sanitizers.

<rdar://problem/59573518>