### PR TITLE
[silargument] Implement getIncomingPhiOperand methods and reimplement getIncomingPhiValue methods ontop.

### DIFF
--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -144,6 +144,11 @@ public:
   getIncomingPhiValues(SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
                            &returnedPredAndPhiValuePairs) const;
 
+  /// If this argument is a true phi, populate `OutArray` with the operand in
+  /// each predecessor block associated with an incoming value.
+  bool
+  getIncomingPhiOperands(SmallVectorImpl<Operand *> &returnedPhiOperands) const;
+
   /// Returns true if we were able to find a single terminator operand value for
   /// each predecessor of this arguments basic block. The found values are
   /// stored in OutArray.
@@ -238,6 +243,11 @@ public:
   bool
   getIncomingPhiValues(SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
                            &returnedPredAndPhiValuePairs) const;
+
+  /// If this argument is a true phi, populate `OutArray` with the operand in
+  /// each predecessor block associated with an incoming value.
+  bool
+  getIncomingPhiOperands(SmallVectorImpl<Operand *> &returnedPhiOperands) const;
 
   /// Returns true if we were able to find a single terminator operand value for
   /// each predecessor of this arguments basic block. The found values are
@@ -417,6 +427,18 @@ inline TermInst *SILArgument::getSingleTerminator() const {
     return cast<SILPhiArgument>(this)->getSingleTerminator();
   case SILArgumentKind::SILFunctionArgument:
     return nullptr;
+  }
+  llvm_unreachable("Covered switch is not covered?!");
+}
+
+inline bool SILArgument::getIncomingPhiOperands(
+    SmallVectorImpl<Operand *> &returnedPhiOperands) const {
+  switch (getKind()) {
+  case SILArgumentKind::SILPhiArgument:
+    return cast<SILPhiArgument>(this)->getIncomingPhiOperands(
+        returnedPhiOperands);
+  case SILArgumentKind::SILFunctionArgument:
+    return false;
   }
   llvm_unreachable("Covered switch is not covered?!");
 }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7420,15 +7420,35 @@ public:
            OpIndex <= Operands.back().getOperandNumber();
   }
 
+  /// Returns the operand on the cond_br terminator associated with the value
+  /// that will be passed to DestBB in A.
+  Operand *getOperandForDestBB(const SILBasicBlock *DestBB,
+                               const SILArgument *A) const;
+
+  /// Returns the operand on the cond_br terminator associated with the value
+  /// that will be passed as the \p Index argument to DestBB.
+  Operand *getOperandForDestBB(const SILBasicBlock *DestBB,
+                               unsigned ArgIndex) const;
+
   /// Returns the argument on the cond_br terminator that will be passed to
   /// DestBB in A.
   SILValue getArgForDestBB(const SILBasicBlock *DestBB,
-                           const SILArgument *A) const;
+                           const SILArgument *A) const {
+    if (auto *op = getOperandForDestBB(DestBB, A)) {
+      return op->get();
+    }
+    return SILValue();
+  }
 
   /// Returns the argument on the cond_br terminator that will be passed as the
   /// \p Index argument to DestBB.
   SILValue getArgForDestBB(const SILBasicBlock *DestBB,
-                           unsigned ArgIndex) const;
+                           unsigned ArgIndex) const {
+    if (auto *op = getOperandForDestBB(DestBB, ArgIndex)) {
+      return op->get();
+    }
+    return SILValue();
+  }
 
   /// Return the SILPhiArgument from either the true or false destination for
   /// the given operand.

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -1348,26 +1348,29 @@ CondBranchInst::create(SILDebugLocation Loc, SILValue Condition,
                                        TrueBBCount, FalseBBCount);
 }
 
-SILValue CondBranchInst::getArgForDestBB(const SILBasicBlock *DestBB,
-                                         const SILArgument *Arg) const {
-  return getArgForDestBB(DestBB, Arg->getIndex());
+Operand *CondBranchInst::getOperandForDestBB(const SILBasicBlock *destBlock,
+                                             const SILArgument *arg) const {
+  return getOperandForDestBB(destBlock, arg->getIndex());
 }
 
-SILValue CondBranchInst::getArgForDestBB(const SILBasicBlock *DestBB,
-                                         unsigned ArgIndex) const {
+Operand *CondBranchInst::getOperandForDestBB(const SILBasicBlock *destBlock,
+                                             unsigned argIndex) const {
   // If TrueBB and FalseBB equal, we cannot find an arg for this DestBB so
   // return an empty SILValue.
   if (getTrueBB() == getFalseBB()) {
-    assert(DestBB == getTrueBB() && "DestBB is not a target of this cond_br");
-    return SILValue();
+    assert(destBlock == getTrueBB() &&
+           "DestBB is not a target of this cond_br");
+    return nullptr;
   }
 
-  if (DestBB == getTrueBB())
-    return getAllOperands()[NumFixedOpers + ArgIndex].get();
+  auto *self = const_cast<CondBranchInst *>(this);
+  if (destBlock == getTrueBB()) {
+    return &self->getAllOperands()[NumFixedOpers + argIndex];
+  }
 
-  assert(DestBB == getFalseBB()
-         && "By process of elimination BB must be false BB");
-  return getAllOperands()[NumFixedOpers + getNumTrueArgs() + ArgIndex].get();
+  assert(destBlock == getFalseBB() &&
+         "By process of elimination BB must be false BB");
+  return &self->getAllOperands()[NumFixedOpers + getNumTrueArgs() + argIndex];
 }
 
 void CondBranchInst::swapSuccessors() {


### PR DESCRIPTION
Operands are generally better to return than values since the operand also
enables you to get to the terminator instruction as well. Since so much code in
the compiler already uses the getIncomingPhiValue methods, I reimplemented them
on top of the operand methods.
