### PR TITLE
[AutoDiff] Fix `Differentiable` derivation + property wrappers crash.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2759,10 +2759,10 @@ ERROR(broken_tensor_array_protocol_requirement,none,
 ERROR(broken_tensor_group_requirement,none,
       "TensorGroup protocol is broken: unexpected requirement", ())
 WARNING(differentiable_nondiff_type_implicit_noderivative_fixit,none,
-      "stored property %0 has no derivative because it does not conform to "
+      "stored property %0 has no derivative because %1 does not conform to "
       "'Differentiable'; add an explicit '@noDerivative' attribute"
-      "%select{|, or conform %1 to 'AdditiveArithmetic'}2",
-      (Identifier, Identifier, bool))
+      "%select{|, or conform %2 to 'AdditiveArithmetic'}3",
+      (Identifier, Type, Identifier, bool))
 WARNING(differentiable_let_property_implicit_noderivative_fixit,none,
       "synthesis of the 'Differentiable.move(along:)' requirement for %1 "
       "requires all stored properties to be mutable; use 'var' instead, or add "

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -55,8 +55,16 @@ getStoredPropertiesForDifferentiation(NominalTypeDecl *nominal, DeclContext *DC,
   auto &C = nominal->getASTContext();
   auto *diffableProto = C.getProtocol(KnownProtocolKind::Differentiable);
   for (auto *vd : nominal->getStoredProperties()) {
+    // Skip stored properties with `@noDerivative` attribute.
     if (vd->getAttrs().hasAttribute<NoDerivativeAttr>())
       continue;
+    // For property wrapper backing storage properties, skip if original
+    // property has `@noDerivative` attribute.
+    if (auto *originalProperty = vd->getOriginalWrappedProperty())
+      if (originalProperty->getAttrs().hasAttribute<NoDerivativeAttr>())
+        continue;
+    // Skip `let` stored properties. `mutating func move(along:)` cannot be
+    // synthesized to update these properties.
     if (vd->isLet())
       continue;
     if (vd->getInterfaceType()->hasError())
@@ -699,10 +707,16 @@ static void checkAndDiagnoseImplicitNoDerivative(ASTContext &Context,
   for (auto *vd : nominal->getStoredProperties()) {
     if (vd->getInterfaceType()->hasError())
       continue;
-    auto varType = DC->mapTypeIntoContext(vd->getValueInterfaceType());
+    // Skip stored properties with `@noDerivative` attribute.
     if (vd->getAttrs().hasAttribute<NoDerivativeAttr>())
       continue;
+    // For property wrapper backing storage properties, skip if original
+    // property has `@noDerivative` attribute.
+    if (auto *originalProperty = vd->getOriginalWrappedProperty())
+      if (originalProperty->getAttrs().hasAttribute<NoDerivativeAttr>())
+        continue;
     // Check whether to diagnose stored property.
+    auto varType = DC->mapTypeIntoContext(vd->getValueInterfaceType());
     bool conformsToDifferentiable =
         !TypeChecker::conformsToProtocol(varType, diffableProto, nominal, None)
              .isInvalid();
@@ -712,6 +726,8 @@ static void checkAndDiagnoseImplicitNoDerivative(ASTContext &Context,
     // Otherwise, add an implicit `@noDerivative` attribute.
     vd->getAttrs().add(new (Context) NoDerivativeAttr(/*Implicit*/ true));
     auto loc = vd->getAttributeInsertionLoc(/*forModifier*/ false);
+    if (auto *originalProperty = vd->getOriginalWrappedProperty())
+      loc = originalProperty->getAttributeInsertionLoc(/*forModifier*/ false);
     assert(loc.isValid() && "Expected valid source location");
     // If nominal type can conform to `AdditiveArithmetic`, suggest conforming
     // adding a conformance to `AdditiveArithmetic`.
@@ -723,7 +739,7 @@ static void checkAndDiagnoseImplicitNoDerivative(ASTContext &Context,
           .diagnose(
               loc,
               diag::differentiable_nondiff_type_implicit_noderivative_fixit,
-              vd->getName(), nominal->getName(),
+              vd->getName(), vd->getType(), nominal->getName(),
               nominalCanDeriveAdditiveArithmetic)
           .fixItInsert(loc, "@noDerivative ");
       continue;


### PR DESCRIPTION
Fix crash during `Differentiable` derived conformances when determining source
location for emitting `@noDerivative` warnings on property wrapper backing
storage properties. Use the source location of the original wrapped property.

Resolves TF-1190.

---

Example:
```swift
@propertyWrapper
struct Wrapper<Value> {
  private var value: Value
  var wrappedValue: Value {
    value
  }
}
struct Tensor<T> {}
struct Struct: Differentiable {
  @Wrapper var x: Tensor<Float>
  @noDerivative @Wrapper var y: Tensor<Float>
}
```

Before:
```console
$ swift tf-1190.swift
Assertion failed: (loc.isValid() && "Expected valid source location"), function checkAndDiagnoseImplicitNoDerivative, file /Users/swiftninjas/s4tf/swift/lib/Sema/DerivedConformanceDifferentiable.cpp, line 715.
Stack dump: ...
```

After:
```console
$ swift tf-1190.swift
tf-1190.swift:10:3: warning: stored property '_x' has no derivative because 'Wrapper<Tensor<Float>>' does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute
  @Wrapper var x: Tensor<Float>
  ^
  @noDerivative
```