### PR TITLE
[Constraint system] Clean up constraints associated with patterns.

### DIFF
--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -466,3 +466,17 @@ func testCaseMutabilityMismatches(e: E3) {
     }
   }
 }
+
+// Check for type equivalence among different case variables with the same name.
+func testCaseVarTypes(e: E3) {
+    // FIXME: Terrible diagnostic
+    tuplify(true) { c in  // expected-error{{type of expression is ambiguous without more context}}
+    "testSwitch"
+    switch e {
+    case .a(let x, let y),
+         .c(let x, let y):
+      x
+      y + "a"
+    }
+  }
+}


### PR DESCRIPTION
Wherever we have constraints that involve pattern matching, use the
PatternMatch locator element. Additionally, don't use the TupleElement
locator element for tuple patterns, because it violates assumptions used
for diagnostics.

The new test was crashing; now it has a terrible diagnostic for which I
need to think harder about a fix.
