### PR TITLE
[stdlib] Disable assertion tripping up ASAN

### DIFF
--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -485,8 +485,8 @@ extension __StringStorage {
 
     // Check that capacity end matches our notion of unused storage, and also
     // checks that breadcrumbs were dutifully aligned.
-    _internalInvariant(UnsafeMutablePointer<UInt8>(_realCapacityEnd)
-      == unusedStorage.baseAddress! + (unusedStorage.count + 1))
+    // _internalInvariant(UnsafeMutablePointer<UInt8>(_realCapacityEnd)
+    //   == unusedStorage.baseAddress! + (unusedStorage.count + 1))
   }
   #endif // INTERNAL_CHECKS_ENABLED
 }


### PR DESCRIPTION
We have (and important!) assertion that our claimed allocation is
complete and the breadcrumbs are falling where we expect them
to. Something about ASAN changes the allocation behavior. Temporarily
disable this assertion until I can figure how to work with ASAN here.

rdar://problem/60126935

https://ci.swift.org/job/oss-swift-incremental-ASAN-RA-osx/4436/consoleText

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
