### PR TITLE
[CMake] Stop requiring ${SDK}/System/Library/Frameworks/module.modulemap

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -127,12 +127,9 @@ macro(configure_sdk_darwin
         COMMAND "xcrun" "--sdk" "${xcrun_name}" "--show-sdk-path"
         OUTPUT_VARIABLE SWIFT_SDK_${prefix}_PATH
         OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if(NOT EXISTS "${SWIFT_SDK_${prefix}_PATH}/System/Library/Frameworks/module.map")
-      message(FATAL_ERROR "${name} SDK not found at ${SWIFT_SDK_${prefix}_PATH}.")
-    endif()
   endif()
 
-  if(NOT EXISTS "${SWIFT_SDK_${prefix}_PATH}/System/Library/Frameworks/module.map")
+  if(NOT EXISTS "${SWIFT_SDK_${prefix}_PATH}/SDKSettings.plist")
     message(FATAL_ERROR "${name} SDK not found at SWIFT_SDK_${prefix}_PATH.")
   endif()
 


### PR DESCRIPTION
Remove anachronistic check for a "blanket" module map in
/System/Library/Frameworks from Darwin SDK configuration. We already
extract other information from the SDK that we actually need, so check
for that directly instead.

Fixes rdar://problem/60084609.
