### PR TITLE
ConstraintSystem] Remove `baseCS` since CSDiag has been removed

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3685,12 +3685,7 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
     }
 
     // Determine the contextual type of the expression
-    Type contextualType;
-    for (auto iterateCS = &cs; contextualType.isNull() && iterateCS;
-         iterateCS = iterateCS->baseCS) {
-      contextualType = iterateCS->getContextualType(getRawAnchor());
-    }
-    
+    Type contextualType = cs.getContextualType(getRawAnchor());
     // Try to provide a fix-it that only contains a '.'
     if (contextualType && baseTy->isEqual(contextualType)) {
       Diag->fixItInsert(loc, ".");
@@ -3700,11 +3695,7 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
     // Check if the expression is the matching operator ~=, most often used in
     // case statements. If so, try to provide a single dot fix-it
     const Expr *contextualTypeNode = getRootExpr(getAnchor());
-    ConstraintSystem *lastCS = nullptr;
-    for (auto iterateCS = &cs; iterateCS; iterateCS = iterateCS->baseCS) {
-      lastCS = iterateCS;
-    }
-    
+
     // The '~=' operator is an overloaded decl ref inside a binaryExpr
     if (auto binaryExpr = dyn_cast<BinaryExpr>(contextualTypeNode)) {
       if (auto overloadedFn
@@ -3719,7 +3710,7 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
             // If the rhs of '~=' is the enum type, a single dot suffixes
             // since the type can be inferred
             Type secondArgType =
-            lastCS->getType(binaryExpr->getArg()->getElement(1));
+                cs.getType(binaryExpr->getArg()->getElement(1));
             if (secondArgType->isEqual(baseTy)) {
               Diag->fixItInsert(loc, ".");
               return true;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -619,7 +619,6 @@ bool ConstraintSystem::Candidate::solve(
 
   // Allocate new constraint system for sub-expression.
   ConstraintSystem cs(DC, None);
-  cs.baseCS = &BaseCS;
 
   // Set up expression type checker timer for the candidate.
   cs.Timer.emplace(E, cs);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -41,15 +41,6 @@ ExpressionTimer::ExpressionTimer(Expr *E, ConstraintSystem &CS)
       StartTime(llvm::TimeRecord::getCurrentTime()),
       PrintDebugTiming(CS.getASTContext().TypeCheckerOpts.DebugTimeExpressions),
       PrintWarning(true) {
-  if (auto *baseCS = CS.baseCS) {
-    // If we already have a timer in the base constraint
-    // system, let's seed its start time to the child.
-    if (baseCS->Timer) {
-      StartTime = baseCS->Timer->startedAt();
-      PrintWarning = false;
-      PrintDebugTiming = false;
-    }
-  }
 }
 
 ExpressionTimer::~ExpressionTimer() {
@@ -598,12 +589,6 @@ static void extendDepthMap(
 
 Optional<std::pair<unsigned, Expr *>> ConstraintSystem::getExprDepthAndParent(
     Expr *expr) {
-  // Check whether the parent has this information.
-  if (baseCS && baseCS != this) {
-    if (auto known = baseCS->getExprDepthAndParent(expr))
-      return *known;
-  }
-
   // Bring the set of expression weights up to date.
   while (NumInputExprsInWeights < InputExprs.size()) {
     extendDepthMap(InputExprs[NumInputExprsInWeights], ExprWeights);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1693,8 +1693,6 @@ private:
     DeclContext *DC;
     llvm::BumpPtrAllocator &Allocator;
 
-    ConstraintSystem &BaseCS;
-
     // Contextual Information.
     Type CT;
     ContextualTypePurpose CTP;
@@ -1702,8 +1700,7 @@ private:
   public:
     Candidate(ConstraintSystem &cs, Expr *expr, Type ct = Type(),
               ContextualTypePurpose ctp = ContextualTypePurpose::CTP_Unused)
-        : E(expr), DC(cs.DC), Allocator(cs.Allocator), BaseCS(cs),
-          CT(ct), CTP(ctp) {}
+        : E(expr), DC(cs.DC), Allocator(cs.Allocator), CT(ct), CTP(ctp) {}
 
     /// Return underlying expression.
     Expr *getExpr() const { return E; }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1516,9 +1516,6 @@ public:
   /// Note: this is only used to support ObjCSelectorExpr at the moment.
   llvm::SmallPtrSet<Expr *, 2> UnevaluatedRootExprs;
 
-  /// The original CS if this CS was created as a simplification of another CS
-  ConstraintSystem *baseCS = nullptr;
-
   /// The total number of disjunctions created.
   unsigned CountDisjunctions = 0;
 


### PR DESCRIPTION
* There is no more sub-expression re-typechecking so no need to keep
    parent constraint systems around.

* No need to keep `BaseCS` in `ConstraintSystem::Candidate` either.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
