### PR TITLE
Initial support for x10 in the toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,4 +369,4 @@ next to the other projects and it will be bootstrapped automatically:
 The Bazel website has detailed installation instructions for
 [macOS](https://docs.bazel.build/versions/master/install-os-x.html) and
 [Ubuntu](https://docs.bazel.build/versions/master/install-ubuntu.html).
-When picking the version to download in step 2, select a version between v0.27.1 and v0.29.1 (inclusive) which can be found in the release notes [here (v0.29.1)](https://github.com/bazelbuild/bazel/releases/tag/0.29.1).
+When picking the version to download in step 2, select version 2.0.0 which can be found in the release notes [here (v2.0.0)](https://github.com/bazelbuild/bazel/releases/tag/2.0.0).

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2448,6 +2448,16 @@ enable-tensorflow-gpu
 mixin-preset=tensorflow_linux,no_test
 enable-tensorflow-gpu
 
+[preset: tensorflow_linux,x10]
+mixin-preset=tensorflow_linux
+enable-x10
+install-tensorflow
+
+[preset: tensorflow_linux,x10,no_test]
+mixin-preset=tensorflow_linux,no_test
+enable-x10
+install-tensorflow
+
 #===------------------------------------------------------------------------===#
 # Swift for TensorFlow Preset
 # Tools: DebInfo and Assertions

--- a/utils/build-toolchain-tensorflow
+++ b/utils/build-toolchain-tensorflow
@@ -47,6 +47,7 @@ BUNDLE_PREFIX=
 INSTALLER_PACKAGE=
 SWIFT_PACKAGE_BASE=
 SWIFT_PACKAGE_GPU=
+SWIFT_PACKAGE_X10=
 SWIFT_PACKAGE_NOTEST=
 SWIFT_PACKAGE_INSTALLER=
 # SWIFT_ENABLE_TENSORFLOW
@@ -98,6 +99,14 @@ while [ $# -ne 0 ]; do
       exit 1
     fi
   ;;
+  -x|--x10)
+    if [ "$(uname -s)" == "Linux" ]; then
+      SWIFT_PACKAGE_X10=,x10
+    else
+      echo "--x10 is not supported on \"$(uname -s)\". See --help"
+      exit 1
+    fi
+  ;;
   *)
     if [ ${FIRST_ARG_PROCESSED} -ne 0 ]; then
       echo "Unrecognised argument \"$1\""
@@ -109,7 +118,7 @@ while [ $# -ne 0 ]; do
   shift
 done
 
-SWIFT_PACKAGE="${SWIFT_PACKAGE_BASE}${SWIFT_PACKAGE_GPU}${SWIFT_PACKAGE_NOTEST}${SWIFT_PACKAGE_INSTALLER}"
+SWIFT_PACKAGE="${SWIFT_PACKAGE_BASE}${SWIFT_PACKAGE_GPU}${SWIFT_PACKAGE_X10}${SWIFT_PACKAGE_NOTEST}${SWIFT_PACKAGE_INSTALLER}"
 
 # Get host name.
 HOST=

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1099,6 +1099,9 @@ def create_argument_parser():
     option('--enable-tensorflow-gpu', toggle_true,
            default=False,
            help='If true, build Swift with TensorFlow GPU support.')
+    option('--enable-x10', toggle_true,
+           default=False,
+           help='If true, build Swift with X10 support.')
     option('--tensorflow-host-lib-dir', store_path,
            default=None,
            help='Path to a directory containing TensorFlow libraries '

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -235,6 +235,7 @@ EXPECTED_DEFAULTS = {
     # SWIFT_ENABLE_TENSORFLOW
     'enable_tensorflow': False,
     'enable_tensorflow_gpu': False,
+    'enable_x10': False,
     'build_tensorflow': False,
     'tensorflow_host_lib_dir': None,
     'tensorflow_host_include_dir': None,
@@ -676,6 +677,7 @@ EXPECTED_OPTIONS = [
     # SWIFT_ENABLE_TENSORFLOW
     EnableOption('--enable-tensorflow'),
     EnableOption('--enable-tensorflow-gpu'),
+    EnableOption('--enable-x10'),
     EnableOption('--build-tensorflow'),
     PathOption('--tensorflow-host-lib-dir'),
     PathOption('--tensorflow-host-include-dir'),

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -331,8 +331,8 @@
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2020-02-20-a",
                 "PythonKit": "master",
                 "swift-format": "master",
-                "tensorflow": "v2.1.0-rc1",
-                "tensorflow-swift-apis": "cc2122763611f1be0c6cf8c4339547c3cf155a41",
+                "tensorflow": "v2.2.0-rc0",
+                "tensorflow-swift-apis": "322979efbe50fee39d9b1d686b7625e89ffc5986",
                 "tensorflow-swift-quote": "46c3d2996541d0ea902630eda11be5a9ccdeaba3"
             }
         }


### PR DESCRIPTION
This adds a new flag to the to `utils/build-toolchain-tensorflow`, `--x10` (or `-x`) which creates a build with support for TPUs using the x10 library. It mainly does two things:

* Replaces `libtensorflow.so` with a superset, `libx10.so`, which contains the added lazy XLA tensor functionality.
* Collects relevant C++ headers to be used by the x10 build to land in swift-apis, setting the `X10_INCLUDE_DIR` to the folder in which they're collected.