### PR TITLE
[ObjC] Only Diagnose Selector Conflicts From Classes

### DIFF
--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -2035,6 +2035,11 @@ bool swift::diagnoseUnintendedObjCMethodOverrides(SourceFile &sf) {
         continue;
     }
 
+    // Require the declaration to actually come from a class. Selectors that
+    // come from protocol requirements are not actually overrides.
+    if (!overriddenMethod->getDeclContext()->getSelfClassDecl())
+      continue;
+
     // Diagnose the override.
     auto methodDiagInfo = getObjCMethodDiagInfo(method);
     auto overriddenDiagInfo = getObjCMethodDiagInfo(overriddenMethod);


### PR DESCRIPTION
Clang 1200 appears to be returning us results from protocol
declarations when we run lookup for an Objective-C selector. This code
path can therefore see protocol requirements, and would erroneously
diagnose witnesses from Swift subclasses of Objective-C classes
as an attempt to conflict with the requirement in the
protocol itself.

This fix is super narrow to try to unblock our builds. Tests will follow
once I can reduce the issue.

Resolves rdar://60005962