### PR TITLE
[SR-12019] Fix assert when dynamicallyCall parameter does not satisfy generic constraint

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1999,6 +1999,29 @@ public:
   }
 };
 
+/// Computes whether the specified type or a super-class/super-protocol has the
+/// @dynamicCallable attribute on it.
+class HasDynamicCallableAttributeRequest
+    : public SimpleRequest<HasDynamicCallableAttributeRequest,
+                           bool(CanType), CacheKind::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  llvm::Expected<bool> evaluate(Evaluator &evaluator, CanType ty) const;
+
+public:
+  bool isCached() const {
+    // Don't cache types containing type variables, as they must not outlive
+    // the constraint system that created them.
+    auto ty = std::get<0>(getStorage());
+    return !ty->hasTypeVariable();
+  }
+};
+
 /// Determines the type of a given pattern.
 ///
 /// Note that this returns the "raw" pattern type, which can involve

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -81,6 +81,8 @@ SWIFT_REQUEST(TypeChecker, HasCircularRawValueRequest,
               bool(EnumDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, HasDynamicMemberLookupAttributeRequest,
               bool(CanType), Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, HasDynamicCallableAttributeRequest,
+              bool(CanType), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, InferredGenericSignatureRequest,
               GenericSignature (ModuleDecl *, GenericSignatureImpl *,
                                  GenericParamList *,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -836,6 +836,10 @@ public:
   /// Return true if the specified type or a super-class/super-protocol has the
   /// @dynamicMemberLookup attribute on it.
   bool hasDynamicMemberLookupAttribute();
+  
+  /// Return true if the specified type or a super-class/super-protocol has the
+  /// @dynamicCallable attribute on it.
+  bool hasDynamicCallableAttribute();
 
   /// Retrieve the superclass of this type.
   ///

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1499,6 +1499,13 @@ bool TypeBase::hasDynamicMemberLookupAttribute() {
       ctx.evaluator, HasDynamicMemberLookupAttributeRequest{canTy}, false);
 }
 
+bool TypeBase::hasDynamicCallableAttribute() {
+  auto canTy = getCanonicalType();
+  auto &ctx = canTy->getASTContext();
+  return evaluateOrDefault(
+      ctx.evaluator, HasDynamicCallableAttributeRequest{canTy}, false);
+}
+
 Type TypeBase::getSuperclass(bool useArchetypes) {
   auto *nominalDecl = getAnyNominal();
   auto *classDecl = dyn_cast_or_null<ClassDecl>(nominalDecl);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1493,6 +1493,9 @@ bool TypeBase::isCallableNominalType(DeclContext *dc) {
 }
 
 bool TypeBase::hasDynamicMemberLookupAttribute() {
+  if (!mayHaveMembers())
+    return false;
+
   auto canTy = getCanonicalType();
   auto &ctx = canTy->getASTContext();
   return evaluateOrDefault(
@@ -1500,6 +1503,9 @@ bool TypeBase::hasDynamicMemberLookupAttribute() {
 }
 
 bool TypeBase::hasDynamicCallableAttribute() {
+  if (!mayHaveMembers())
+    return false;
+
   auto canTy = getCanonicalType();
   auto &ctx = canTy->getASTContext();
   return evaluateOrDefault(

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -513,6 +513,13 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
                                   {LocatorPathElt::ApplyFunction(),
                                    LocatorPathElt::ImplicitCallAsFunction()});
     }
+
+    // Handling an apply for a nominal type that supports @dynamicCallable.
+    auto nominal = fnTy->getAnyNominal();
+    if (nominal && nominal->getAttrs().hasAttribute<DynamicCallableAttr>()) {
+      return getConstraintLocator(anchor, LocatorPathElt::ApplyFunction());
+    }
+
     return nullptr;
   };
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -515,8 +515,7 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
     }
 
     // Handling an apply for a nominal type that supports @dynamicCallable.
-    auto nominal = fnTy->getAnyNominal();
-    if (nominal && nominal->getAttrs().hasAttribute<DynamicCallableAttr>()) {
+    if (fnTy->hasDynamicCallableAttribute()) {
       return getConstraintLocator(anchor, LocatorPathElt::ApplyFunction());
     }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -4259,7 +4259,7 @@ static bool checkForDynamicAttribute(CanType ty,
   }
 
   // Otherwise, this must be a nominal type.
-  // Neither Dynamic member lookup or Dynamic Callable doesn't
+  // Neither Dynamic member lookup nor Dynamic Callable doesn't
   // work for tuples, etc.
   auto nominal = ty->getAnyNominal();
   if (!nominal)

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -4233,18 +4233,18 @@ IsCallableNominalTypeRequest::evaluate(Evaluator &evaluator, CanType ty,
   });
 }
 
-llvm::Expected<bool>
-HasDynamicMemberLookupAttributeRequest::evaluate(Evaluator &evaluator,
-                                                 CanType ty) const {
+template <class DynamicAttribute>
+static bool checkForDynamicAttribute(CanType ty,
+                                     llvm::function_ref<bool (Type)> hasAttribute) {
   // If this is an archetype type, check if any types it conforms to
   // (superclass or protocols) have the attribute.
   if (auto archetype = dyn_cast<ArchetypeType>(ty)) {
     for (auto proto : archetype->getConformsTo()) {
-      if (proto->getDeclaredType()->hasDynamicMemberLookupAttribute())
+      if (hasAttribute(proto->getDeclaredType()))
         return true;
     }
     if (auto superclass = archetype->getSuperclass()) {
-      if (superclass->hasDynamicMemberLookupAttribute())
+      if (hasAttribute(superclass))
         return true;
     }
   }
@@ -4253,33 +4253,50 @@ HasDynamicMemberLookupAttributeRequest::evaluate(Evaluator &evaluator,
   // attribute.
   if (auto protocolComp = dyn_cast<ProtocolCompositionType>(ty)) {
     for (auto member : protocolComp->getMembers()) {
-      if (member->hasDynamicMemberLookupAttribute())
+      if (hasAttribute(member))
         return true;
     }
   }
 
   // Otherwise, this must be a nominal type.
-  // Dynamic member lookup doesn't work for tuples, etc.
+  // Neither Dynamic member lookup or Dynamic Callable doesn't
+  // work for tuples, etc.
   auto nominal = ty->getAnyNominal();
   if (!nominal)
     return false;
 
   // If this type has the attribute on it, then yes!
-  if (nominal->getAttrs().hasAttribute<DynamicMemberLookupAttr>())
+  if (nominal->getAttrs().hasAttribute<DynamicAttribute>())
     return true;
 
   // Check the protocols the type conforms to.
   for (auto proto : nominal->getAllProtocols()) {
-    if (proto->getDeclaredType()->hasDynamicMemberLookupAttribute())
+    if (hasAttribute(proto->getDeclaredType()))
       return true;
   }
 
   // Check the superclass if present.
   if (auto classDecl = dyn_cast<ClassDecl>(nominal)) {
     if (auto superclass = classDecl->getSuperclass()) {
-      if (superclass->hasDynamicMemberLookupAttribute())
+      if (hasAttribute(superclass))
         return true;
     }
   }
   return false;
+}
+
+llvm::Expected<bool>
+HasDynamicMemberLookupAttributeRequest::evaluate(Evaluator &evaluator,
+                                                 CanType ty) const {
+  return checkForDynamicAttribute<DynamicMemberLookupAttr>(ty, [](Type type) {
+    return type->hasDynamicMemberLookupAttribute();
+  });
+}
+
+llvm::Expected<bool>
+HasDynamicCallableAttributeRequest::evaluate(Evaluator &evaluator,
+                                             CanType ty) const {
+  return checkForDynamicAttribute<DynamicCallableAttr>(ty, [](Type type) {
+    return type->hasDynamicCallableAttribute();
+  });
 }

--- a/test/Misc/stats_dir_tracer.swift
+++ b/test/Misc/stats_dir_tracer.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t %s -trace-stats-events
 // RUN: %FileCheck -input-file %t/*.csv %s
 
-// CHECK-DAG: {{[0-9]+,[0-9]+,"exit","typecheck-expr","Sema.NumConstraintScopes",[0-9]+,[0-9]+,"Sequence","\[.*stats_dir_tracer.swift.*\]"}}
+// CHECK-DAG: {{[0-9]+,[0-9]+,"exit","check-conformance","Sema.NumConstraintScopes",[0-9]+,[0-9]+,"Bar: Proto module main",".*stats_dir_tracer.swift.*"}}
 // CHECK-DAG: {{[0-9]+,[0-9]+,"exit","SuperclassDeclRequest","Sema.SuperclassDeclRequest",[0-9]+,[0-9]+,"Bar","\[.*stats_dir_tracer.swift.*\]"}}
 
 public func foo() {

--- a/test/attr/attr_dynamic_callable.swift
+++ b/test/attr/attr_dynamic_callable.swift
@@ -487,3 +487,14 @@ struct B {
 
 B()("hello") // ok
 B()("\(1)") // ok
+
+// SR-12019
+@dynamicCallable 
+struct SR12019 {
+  func dynamicallyCall<T: StringProtocol>(withArguments: [T]) { // expected-note {{where 'T' = 'Int'}}
+    print("hi")	
+  }
+}
+
+let sr12019 = SR12019()
+sr12019(1) // expected-error {{instance method 'dynamicallyCall(withArguments:)' requires that 'Int' conform to 'StringProtocol'}}

--- a/test/attr/attr_dynamic_callable.swift
+++ b/test/attr/attr_dynamic_callable.swift
@@ -490,11 +490,34 @@ B()("\(1)") // ok
 
 // SR-12019
 @dynamicCallable 
-struct SR12019 {
+struct SR12019_S {
   func dynamicallyCall<T: StringProtocol>(withArguments: [T]) { // expected-note {{where 'T' = 'Int'}}
     print("hi")	
   }
 }
 
-let sr12019 = SR12019()
+@dynamicCallable
+protocol SR12019 {
+  func dynamicallyCall<T: StringProtocol>(withArguments: [T])  // expected-note 2{{where 'T' = 'Int'}}
+}
+
+class SR12019Class: SR12019 {
+  func dynamicallyCall<T: StringProtocol>(withArguments: [T]) {} // expected-note {{where 'T' = 'Int'}}
+}
+
+class SR12019SubClass: SR12019Class {}
+
+let sr12019s = SR12019_S()
+sr12019s(1) // expected-error {{instance method 'dynamicallyCall(withArguments:)' requires that 'Int' conform to 'StringProtocol'}}
+
+// Protocol composition
+let sr12019: SR12019&AnyObject = SR12019Class()
 sr12019(1) // expected-error {{instance method 'dynamicallyCall(withArguments:)' requires that 'Int' conform to 'StringProtocol'}}
+
+// Protocol
+let sr12019c: SR12019 = SR12019Class()
+sr12019c(1) // expected-error {{instance method 'dynamicallyCall(withArguments:)' requires that 'Int' conform to 'StringProtocol'}}
+
+// Subclass
+let sr12019sub = SR12019SubClass()
+sr12019sub(1) // expected-error {{instance method 'dynamicallyCall(withArguments:)' requires that 'Int' conform to 'StringProtocol'}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes the asserting where `MissingConformance` couldn't find the `getRequirementDC()`.

cc @owenv 

Edit: Seems like I can't request reviewers so cc @xedin @hamishknight :)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-12019.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
