### PR TITLE
[fix] Eager specialization shouldn't optimize functions with ownership (yet)

### DIFF
--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -736,9 +736,12 @@ void EagerSpecializerTransform::run() {
 
   // Process functions in any order.
   for (auto &F : *getModule()) {
-    if (!F.shouldOptimize()) {
+    // TODO: we should support ownership here but first we'll have to support
+    // ownership in GenericFuncSpecializer.
+    if (!F.shouldOptimize() || F.hasOwnership()) {
       LLVM_DEBUG(dbgs() << "  Cannot specialize function " << F.getName()
-                        << " marked to be excluded from optimizations.\n");
+                        << " because it has ownership or is marked to be "
+                           "excluded from optimizations.\n");
       continue;
     }
     // Only specialize functions in their home module.


### PR DESCRIPTION
<!-- What's in this pull request? -->
This patch updates `EagerSpecializer` to skip functions with ownership. The next step for this pass supporting ownership is updating `GenericFuncSpecializer`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
