### PR TITLE
[fix] [ownership] check that both function have the same ownership

### DIFF
--- a/include/swift/SILOptimizer/Utils/SILInliner.h
+++ b/include/swift/SILOptimizer/Utils/SILInliner.h
@@ -65,7 +65,7 @@ public:
   ///
   /// *NOTE* This must be checked before attempting to inline \arg AI. If one
   /// attempts to inline \arg AI and this returns false, an assert will fire.
-  static bool canInlineApplySite(FullApplySite apply);
+  static bool canInlineApplySite(FullApplySite apply, SILFunction *callee);
 
   /// Returns true if inlining \arg apply can result in improperly nested stack
   /// allocations.

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -896,7 +896,7 @@ runOnFunctionRecursively(SILOptFunctionBuilder &FuncBuilder,
 
       SILInliner Inliner(FuncBuilder, SILInliner::InlineKind::MandatoryInline,
                          Subs, OpenedArchetypesTracker);
-      if (!Inliner.canInlineApplySite(InnerAI))
+      if (!Inliner.canInlineApplySite(InnerAI, CalleeFunction))
         continue;
 
       // Inline function at I, which also changes I to refer to the first

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -634,7 +634,7 @@ SILFunction *swift::getEligibleFunction(FullApplySite AI,
   }
 
   // Not all apply sites can be inlined, even if they're direct.
-  if (!SILInliner::canInlineApplySite(AI))
+  if (!SILInliner::canInlineApplySite(AI, Callee))
     return nullptr;
 
   ModuleDecl *SwiftModule = Callee->getModule().getSwiftModule();

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -63,7 +63,10 @@ static bool canInlineBeginApply(BeginApplyInst *BA) {
 }
 
 bool SILInliner::canInlineApplySite(FullApplySite apply) {
-  if (!apply.canOptimize())
+  if (!apply.canOptimize() ||
+      (apply.getReferencedFunctionOrNull() &&
+       apply.getFunction()->hasOwnership() !=
+           apply.getReferencedFunctionOrNull()->hasOwnership()))
     return false;
 
   if (auto BA = dyn_cast<BeginApplyInst>(apply))

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -62,11 +62,9 @@ static bool canInlineBeginApply(BeginApplyInst *BA) {
   return true;
 }
 
-bool SILInliner::canInlineApplySite(FullApplySite apply) {
+bool SILInliner::canInlineApplySite(FullApplySite apply, SILFunction *callee) {
   if (!apply.canOptimize() ||
-      (apply.getReferencedFunctionOrNull() &&
-       apply.getFunction()->hasOwnership() !=
-           apply.getReferencedFunctionOrNull()->hasOwnership()))
+      apply.getFunction()->hasOwnership() != callee->hasOwnership())
     return false;
 
   if (auto BA = dyn_cast<BeginApplyInst>(apply))
@@ -338,8 +336,8 @@ SILInliner::inlineFunction(SILFunction *calleeFunction, FullApplySite apply,
                            ArrayRef<SILValue> appliedArgs) {
   PrettyStackTraceSILFunction calleeTraceRAII("inlining", calleeFunction);
   PrettyStackTraceSILFunction callerTraceRAII("...into", apply.getFunction());
-  assert(canInlineApplySite(apply)
-         && "Asked to inline function that is unable to be inlined?!");
+  assert(canInlineApplySite(apply, calleeFunction) &&
+         "Asked to inline function that is unable to be inlined?!");
 
   SILInlineCloner cloner(calleeFunction, apply, FuncBuilder, IKind, ApplySubs,
                          OpenedArchetypesTracker, DeletionCallback);

--- a/test/SILOptimizer/mandatory_inlining_ownership.sil
+++ b/test/SILOptimizer/mandatory_inlining_ownership.sil
@@ -578,6 +578,22 @@ bb3:
   return %9999 : $()
 }
 
+sil [transparent] @do_not_inline_me : $@convention(thin) (@in Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject):
+  // Unqualified load is OK *only* in non-ossa.
+  load %0 : $*Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// If @do_not_inline_me is inlined the verifier will assert so, we don't need a filecheck.
+sil [ossa] @do_not_inline_non_ossa_into_me : $@convention(thin) (@in Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject):
+  %1 = function_ref @do_not_inline_me : $@convention(thin) (@in Builtin.NativeObject) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (@in Builtin.NativeObject) -> ()
+  return %2 : $()
+}
+
 
 sil_vtable C2 {
   #C2.i!modify.1: (C2) -> () -> () : @devirt_callee


### PR DESCRIPTION
<!-- What's in this pull request? -->
This patch updates `canInlineApplySite` to check that both functions have the same ownership (are both ossa or both not ossa). 

It also adds the argument `callee` which is needed because otherwise we can't handle applies of non-function-refs (which might be okay in which case I can remove the second commit). 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
