### PR TITLE
removed scalar from test string as it is logically invalid/undefined …

### DIFF
--- a/test/stdlib/TestJSONEncoder.swift
+++ b/test/stdlib/TestJSONEncoder.swift
@@ -609,7 +609,7 @@ class TestJSONEncoder : TestJSONEncoderSuper {
       ("_test_", "_test_"),
       ("__test", "__test"),
       ("test__", "test__"),
-      ("m͉̟̹y̦̳G͍͚͎̳r̤͉̤͕ͅea̲͕t͇̥̼͖U͇̝̠R͙̻̥͓̣L̥̖͎͓̪̫ͅR̩͖̩eq͈͓u̞e̱s̙t̤̺ͅ", "m͉̟̹y̦̳_g͍͚͎̳r̤͉̤͕ͅea̲͕t͇̥̼͖_u͇̝̠r͙̻̥͓̣l̥̖͎͓̪̫ͅ_r̩͖̩eq͈͓u̞e̱s̙t̤̺ͅ"), // because Itai wanted to test this
+      ("m͉̟̹y̦̳G͍͚͎̳r̤͉̤͕ͅea̲͕t͇̥̼͖U͇̝̠R͙̻̥͓̣L̥̖͎͓̪̫R̩͖̩eq͈͓u̞e̱s̙t̤̺ͅ", "m͉̟̹y̦̳_g͍͚͎̳r̤͉̤͕ͅea̲͕t͇̥̼͖_u͇̝̠r͙̻̥͓̣l̥̖͎͓̪̫_r̩͖̩eq͈͓u̞e̱s̙t̤̺ͅ"), // because Itai wanted to test this
       ("🐧🐟", "🐧🐟") // fishy emoji example?
     ]
 
@@ -788,7 +788,7 @@ class TestJSONEncoder : TestJSONEncoderSuper {
       ("_", "_"),
       ("__", "__"),
       ("___", "___"),
-      ("m͉̟̹y̦̳G͍͚͎̳r̤͉̤͕ͅea̲͕t͇̥̼͖U͇̝̠R͙̻̥͓̣L̥̖͎͓̪̫ͅR̩͖̩eq͈͓u̞e̱s̙t̤̺ͅ", "m͉̟̹y̦̳G͍͚͎̳r̤͉̤͕ͅea̲͕t͇̥̼͖U͇̝̠R͙̻̥͓̣L̥̖͎͓̪̫ͅR̩͖̩eq͈͓u̞e̱s̙t̤̺ͅ"), // because Itai wanted to test this
+      ("m͉̟̹y̦̳G͍͚͎̳r̤͉̤͕ͅea̲͕t͇̥̼͖U͇̝̠R͙̻̥͓̣L̥̖͎͓̪̫R̩͖̩eq͈͓u̞e̱s̙t̤̺ͅ", "m͉̟̹y̦̳G͍͚͎̳r̤͉̤͕ͅea̲͕t͇̥̼͖U͇̝̠R͙̻̥͓̣L̥̖͎͓̪̫R̩͖̩eq͈͓u̞e̱s̙t̤̺ͅ"), // because Itai wanted to test this
       ("🐧_🐟", "🐧🐟") // fishy emoji example?
     ]
     


### PR DESCRIPTION
Removes a scalar from test input that is logically invalid when converting a string to and from snake case in JSONEncoder and JSONDecoder.

As discussed in this  [`forum post`](https://forums.swift.org/t/is-this-a-bug-in-swift-stdlib-character-isuppercase/34385/6) the generated string used in this test includes a scalar in the character L̥̖͎͓̪̫ͅ that is logically invalid. With this scalar it is undefined if the character is in fact uppercase. This PR removes the scalar from the character in the test strings.
