### PR TITLE
Require types to be contextually canonical in AbstractionPatterns

### DIFF
--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -323,8 +323,10 @@ class AbstractionPattern {
     TheKind = unsigned(kind);
     OrigType = origType;
     GenericSig = CanGenericSignature();
-    if (OrigType->hasTypeParameter())
+    if (OrigType->hasTypeParameter()) {
+      assert(OrigType == signature->getCanonicalTypeInContext(origType));
       GenericSig = signature;
+    }
   }
 
   void initClangType(CanGenericSignature signature,

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -293,6 +293,8 @@ CanSILFunctionType SILFunctionType::getAutoDiffDerivativeFunctionType(
   // Given a type, returns its formal SIL parameter info.
   auto getTangentParameterInfoForOriginalResult =
       [&](CanType tanType, ResultConvention origResConv) -> SILParameterInfo {
+    if (derivativeFnGenSig)
+      tanType = derivativeFnGenSig->getCanonicalTypeInContext(tanType);
     AbstractionPattern pattern(derivativeFnGenSig, tanType);
     auto &tl =
         TC.getTypeLowering(pattern, tanType, TypeExpansionContext::minimal());
@@ -317,6 +319,8 @@ CanSILFunctionType SILFunctionType::getAutoDiffDerivativeFunctionType(
   // Given a type, returns its formal SIL result info.
   auto getTangentResultInfoForOriginalParameter =
       [&](CanType tanType, ParameterConvention origParamConv) -> SILResultInfo {
+    if (derivativeFnGenSig)
+      tanType = derivativeFnGenSig->getCanonicalTypeInContext(tanType);
     AbstractionPattern pattern(derivativeFnGenSig, tanType);
     auto &tl =
         TC.getTypeLowering(pattern, tanType, TypeExpansionContext::minimal());


### PR DESCRIPTION
Because violations of this might have made an AbstractionPattern incorrectly show up as abstract, it's possible that this will cause an ABI change.  However, I haven't been able to find any examples where it does, and certainly there's no way we can promise to maintain the old behavior, especially since it's not done consistently.