### PR TITLE
WinSDK: extend the WinSock module further

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -14,6 +14,7 @@ module WinSDK [system] [extern_c] {
   module WinSock2 {
     header "WinSock2.h"
     header "WS2tcpip.h"
+    header "MSWSock.h"
     export *
 
     link "WS2_32.Lib"


### PR DESCRIPTION
This enables the use of `TransmitFile` more fully by adding the
Microsoft extensions to the WinSock module.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
