### PR TITLE
IRGen: improve DLLStorage computation for Windows

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -1155,6 +1155,8 @@ public:
   /// Get the default LLVM type to use for forward declarations of this
   /// entity.
   llvm::Type *getDefaultDeclarationType(IRGenModule &IGM) const;
+
+  bool isAlwaysSharedLinkage() const;
 #undef LINKENTITY_GET_FIELD
 #undef LINKENTITY_SET_FIELD
 };

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -1077,6 +1077,7 @@ DeclContext *LinkEntity::getDeclContextForEmission() const {
   case Kind::TypeMetadataAccessFunction:
   case Kind::TypeMetadataLazyCacheVariable:
   case Kind::TypeMetadataDemanglingCacheVariable:
+    assert(isAlwaysSharedLinkage() && "kind should always be shared linkage");
     return nullptr;
 
   // TODO
@@ -1087,5 +1088,21 @@ DeclContext *LinkEntity::getDeclContextForEmission() const {
   case Kind::ValueWitnessTable:
   case Kind::DifferentiabilityWitness:
     return nullptr;
+  }
+}
+
+bool LinkEntity::isAlwaysSharedLinkage() const {
+  switch (getKind()) {
+  case Kind::ModuleDescriptor:
+  case Kind::ExtensionDescriptor:
+  case Kind::AnonymousDescriptor:
+  case Kind::ObjCClassRef:
+  case Kind::TypeMetadataAccessFunction:
+  case Kind::TypeMetadataLazyCacheVariable:
+  case Kind::TypeMetadataDemanglingCacheVariable:
+    return true;
+
+  default:
+    return false;
   }
 }


### PR DESCRIPTION
This slightly regresses the standard library build (intentionally) while
generally improving the build of dispatch, foundation, xctest.

Rather than continuing to rely on the short-term hack of special casing
the standard library, identify the module where the decl originates
from.  If the module is the current module, then assume that the symbol
need not be imported (static linking does not currently work on Windows
anyways).  This allows for properly identifying the module where the
symbol will be homed.

Because we no longer special case the standard library here, a few known
metadata types will be incorrectly marked as being imported rather than
local.

Since linked entities which have `Shared` SILLinkage should be module
local, special case them to always be local.  Without this the metadata
access function is still marked incorrectly.

With this computation we now get nearly all the cases correct.  Dispatch
no longer has to rely on the linker relaxing the import to a local
binding.  XCTest is also clean.  Foundation misses the following case:
- `$sSS10FoundationE19_bridgeToObjectiveCAA8NSStringCyF`

The regressed cases in swiftCore are:
- `$sBi64_WV`
- `$sBi8_WV`
- `$sBi16_WV`
- `$sBi32_WV`
- `$sBpWV`
- `$syycWV`
- `$sBoWV`
- `$sBOWV`
- `$sBbWV`
- `$sytWV`

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
