### PR TITLE
[temp-rvalue] Teach how to optimize unchecked_take_enum_data_addr of an Optional type.

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -615,6 +615,19 @@ struct ImmutableAddressUseVerifier {
           llvm::copy(result->getUses(), std::back_inserter(worklist));
         }
         break;
+      case SILInstructionKind::UncheckedTakeEnumDataAddrInst: {
+        auto type =
+            cast<UncheckedTakeEnumDataAddrInst>(inst)->getOperand()->getType();
+        if (type.getOptionalObjectType()) {
+          for (auto result : inst->getResults()) {
+            llvm::copy(result->getUses(), std::back_inserter(worklist));
+          }
+          break;
+        }
+        llvm::errs() << "Unhandled, unexpected instruction: " << *inst;
+        llvm_unreachable("invoking standard assertion failure");
+        break;
+      }
       default:
         llvm::errs() << "Unhandled, unexpected instruction: " << *inst;
         llvm_unreachable("invoking standard assertion failure");

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -1075,3 +1075,52 @@ bb0(%0 : @owned $GS<Builtin.NativeObject>):
   %v = tuple ()
   return %v : $()
 }
+
+////////////////////////////////////////
+// Unchecked Take Enum Data Addr Inst //
+////////////////////////////////////////
+
+// Make sure we only handle this in the copy_addr case. With time, we should
+// also handle the store case.
+//
+// CHECK-LABEL: sil [ossa] @unchecked_take_enum_data_addr_rvalue_simple : $@convention(thin) <B> (@in_guaranteed Optional<GS<B>>, @inout Optional<GS<B>>) -> () {
+// CHECK-NOT: alloc_stack
+// CHECK: } // end sil function 'unchecked_take_enum_data_addr_rvalue_simple'
+sil [ossa] @unchecked_take_enum_data_addr_rvalue_simple : $@convention(thin) <B> (@in_guaranteed Optional<GS<B>>, @inout Optional<GS<B>>) -> () {
+bb0(%0 : $*Optional<GS<B>>, %1 : $*Optional<GS<B>>):
+  %0a = unchecked_take_enum_data_addr %0 : $*Optional<GS<B>>, #Optional.some!enumelt.1
+  %2 = struct_element_addr %0a : $*GS<B>, #GS._value
+  %3 = load [trivial] %2 : $*Builtin.Int64
+  %4 = alloc_stack $Optional<GS<B>>
+  copy_addr %1 to [initialization] %4 : $*Optional<GS<B>>
+  %4a = unchecked_take_enum_data_addr %4 : $*Optional<GS<B>>, #Optional.some!enumelt.1
+  %6 = struct_element_addr %4a : $*GS<B>, #GS._value
+  %7 = load [trivial] %6 : $*Builtin.Int64
+  %8 = builtin "cmp_slt_Int64"(%3 : $Builtin.Int64, %7 : $Builtin.Int64) : $Builtin.Int1
+  destroy_addr %4 : $*Optional<GS<B>>
+  dealloc_stack %4 : $*Optional<GS<B>>
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We do not support this today, since I am still bringing up store support.
+//
+// CHECK-LABEL: sil [ossa] @unchecked_take_enum_data_addr_store_rvalue_simple : $@convention(thin) (@in_guaranteed Optional<GS<Klass>>, @owned Optional<GS<Klass>>) -> () {
+// CHECK: alloc_stack
+// CHECK: } // end sil function 'unchecked_take_enum_data_addr_store_rvalue_simple'
+sil [ossa] @unchecked_take_enum_data_addr_store_rvalue_simple : $@convention(thin) (@in_guaranteed Optional<GS<Klass>>, @owned Optional<GS<Klass>>) -> () {
+bb0(%0 : $*Optional<GS<Klass>>, %1 : @owned $Optional<GS<Klass>>):
+  %0a = unchecked_take_enum_data_addr %0 : $*Optional<GS<Klass>>, #Optional.some!enumelt.1
+  %2 = struct_element_addr %0a : $*GS<Klass>, #GS._value
+  %3 = load [trivial] %2 : $*Builtin.Int64
+  %4 = alloc_stack $Optional<GS<Klass>>
+  store %1 to [init] %4 : $*Optional<GS<Klass>>
+  %4a = unchecked_take_enum_data_addr %4 : $*Optional<GS<Klass>>, #Optional.some!enumelt.1
+  %6 = struct_element_addr %4a : $*GS<Klass>, #GS._value
+  %7 = load [trivial] %6 : $*Builtin.Int64
+  %8 = builtin "cmp_slt_Int64"(%3 : $Builtin.Int64, %7 : $Builtin.Int64) : $Builtin.Int1
+  destroy_addr %4 : $*Optional<GS<Klass>>
+  dealloc_stack %4 : $*Optional<GS<Klass>>
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
unchecked_take_enum_data_addr only writes to memory in certain cases. Optional
is not one of those cases luckily.

Given that I am adding support here just for optionals so that we can get rid of
temporaries that are used with a switch_enum_addr. This is an example of a case
where we need to eliminate temporary allocations to allow for Semantic ARC Opts
to eliminate further traffic.
