### PR TITLE
[temp-rvalueopt] Teach how to promote fix_lifetime.

### DIFF
--- a/test/SILOptimizer/temp_rvalue_opt.sil
+++ b/test/SILOptimizer/temp_rvalue_opt.sil
@@ -655,3 +655,19 @@ bb0(%0 : $*Builtin.NativeObject):
   %v = tuple ()
   return %v : $()
 }
+
+// CHECK-LABEL: sil @eliminate_fix_lifetime_on_dest_copyaddr : $@convention(thin) (@inout Klass) -> () {
+// CHECK-NOT: alloc_stack
+// CHECK: fix_lifetime %0
+// CHECK-NOT: alloc_stack
+// CHECK: } // end sil function 'eliminate_fix_lifetime_on_dest_copyaddr'
+sil @eliminate_fix_lifetime_on_dest_copyaddr : $@convention(thin) (@inout Klass) -> () {
+bb0(%0 : $*Klass):
+  %3 = alloc_stack $Klass
+  copy_addr %0 to [initialization] %3 : $*Klass
+  fix_lifetime %3 : $*Klass
+  destroy_addr %3 : $*Klass
+  dealloc_stack %3 : $*Klass
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -1124,3 +1124,38 @@ bb0(%0 : $*Optional<GS<Klass>>, %1 : @owned $Optional<GS<Klass>>):
   %9999 = tuple()
   return %9999 : $()
 }
+
+// CHECK-LABEL: sil [ossa] @eliminate_fix_lifetime_on_dest_copyaddr : $@convention(thin) (@inout Klass) -> () {
+// CHECK-NOT: alloc_stack
+// CHECK: fix_lifetime %0
+// CHECK-NOT: alloc_stack
+// CHECK: } // end sil function 'eliminate_fix_lifetime_on_dest_copyaddr'
+sil [ossa] @eliminate_fix_lifetime_on_dest_copyaddr : $@convention(thin) (@inout Klass) -> () {
+bb0(%0 : $*Klass):
+  %3 = alloc_stack $Klass
+  copy_addr %0 to [initialization] %3 : $*Klass
+  fix_lifetime %3 : $*Klass
+  destroy_addr %3 : $*Klass
+  dealloc_stack %3 : $*Klass
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @eliminate_fix_lifetime_on_dest_store : $@convention(thin) (@inout Klass) -> () {
+// CHECK-NOT: alloc_stack
+// CHECK:  [[VALUE:%.*]] = load [copy] %0
+// CHECK-NEXT: fix_lifetime [[VALUE]]
+// CHECK-NEXT: destroy_value [[VALUE]]
+// CHECK-NOT: alloc_stack
+// CHECK: } // end sil function 'eliminate_fix_lifetime_on_dest_store'
+sil [ossa] @eliminate_fix_lifetime_on_dest_store : $@convention(thin) (@inout Klass) -> () {
+bb0(%0 : $*Klass):
+  %2 = load [copy] %0 : $*Klass
+  %3 = alloc_stack $Klass
+  store %2 to [init] %3 : $*Klass
+  fix_lifetime %3 : $*Klass
+  destroy_addr %3 : $*Klass
+  dealloc_stack %3 : $*Klass
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
In the case of copy_addr, we move it onto the source address and in the case of
a store, put it on the source object.

I just noted this pattern happening a bunch in the stdlib when I was looking
through it for ownership patterns.
