### PR TITLE
[PrintAsObjC] Don't print imports for empty extensions

### DIFF
--- a/lib/PrintAsObjC/DeclAndTypePrinter.h
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.h
@@ -70,6 +70,9 @@ public:
   void print(const Decl *D);
   void print(Type ty);
 
+  /// Is \p ED empty of members and protocol conformances to include?
+  bool isEmptyExtensionDecl(const ExtensionDecl *ED);
+
   /// Prints a category declaring the given members.
   ///
   /// All members must have the same parent type. The list must not be empty.

--- a/lib/PrintAsObjC/ModuleContentsWriter.cpp
+++ b/lib/PrintAsObjC/ModuleContentsWriter.cpp
@@ -400,6 +400,9 @@ public:
   }
 
   bool writeExtension(const ExtensionDecl *ED) {
+    if (printer.isEmptyExtensionDecl(ED))
+      return true;
+
     bool allRequirementsSatisfied = true;
 
     const ClassDecl *CD = ED->getSelfClassDecl();

--- a/test/PrintAsObjC/Inputs/custom-modules/MiserablePileOfSecrets.h
+++ b/test/PrintAsObjC/Inputs/custom-modules/MiserablePileOfSecrets.h
@@ -3,3 +3,6 @@
 @interface NSObject (Secrets)
 - (void)secretMethod;
 @end
+
+@interface SecretClass : NSObject
+@end

--- a/test/PrintAsObjC/imports.swift
+++ b/test/PrintAsObjC/imports.swift
@@ -77,3 +77,7 @@ import MostlyPrivate2_Private
 @objc public class TestSubclass: NSObject {
   @_implementationOnly public override func secretMethod() {}
 }
+
+extension SecretClass {
+  private func somethingThatShouldNotBeIncluded() {}
+}


### PR DESCRIPTION
Fix an issue in generated compatibility headers where an extension that is not printed would still trigger the inclusion of the extended type's origin module. This was mostly noticeable with `@implementationOnly` imports when imported types were extended with only private members.

rdar://problem/57133517