### PR TITLE
[ConstraintSystem] Respect the constraint solver performance thresholds,

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4475,14 +4475,11 @@ public:
   /// Determine if we've already explored too many paths in an
   /// attempt to solve this expression.
   bool isExpressionAlreadyTooComplex = false;
-  bool getExpressionTooComplex(SmallVectorImpl<Solution> const &solutions) {
+  bool getExpressionTooComplex(size_t solutionMemory) {
     if (isExpressionAlreadyTooComplex)
       return true;
 
-    auto used = getASTContext().getSolverMemory();
-    for (auto const& s : solutions) {
-      used += s.getTotalMemory();
-    }
+    auto used = getASTContext().getSolverMemory() + solutionMemory;
     MaxMemory = std::max(used, MaxMemory);
     auto threshold = getASTContext().TypeCheckerOpts.SolverMemoryThreshold;
     if (MaxMemory > threshold) {
@@ -4507,6 +4504,14 @@ public:
     }
 
     return false;
+  }
+
+  bool getExpressionTooComplex(SmallVectorImpl<Solution> const &solutions) {
+    size_t solutionMemory = 0;
+    for (auto const& s : solutions) {
+      solutionMemory += s.getTotalMemory();
+    }
+    return getExpressionTooComplex(solutionMemory);
   }
 
   // Utility class that can collect information about the type of an

--- a/validation-test/Sema/type_checker_perf/slow/rdar53589951.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar53589951.swift
@@ -1,0 +1,27 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asan
+
+class Color {
+  init(hue: Double, saturation: Double, brightness: Double, alpha: Double) {}
+  init(red: Double, green: Double, blue: Double, alpha: Double) {}
+}
+
+// expected-error@+1 {{reasonable time}}
+let _: [Color] = [
+    Color(r: 3, g: 72, b: 14, a: 48),
+    Color(r: 0, g: 240, b: 64, a: 77),
+    Color(r: 0, g: 255, b: 0, a: 160),
+    Color(r: 0, g: 168, b: 0, a: 255),
+    Color(r: 0, g: 140, b: 0, a: 255),
+    Color(r: 0, g: 112, b: 0, a: 255),
+    Color(r: 255, g: 255, b: 0, a: 255),
+    Color(r: 184, g: 184, b: 0, a: 255),
+    Color(r: 224, g: 112, b: 0, a: 255),
+    Color(r: 255, g: 0, b: 0, a: 255),
+    Color(r: 184, g: 0, b: 0, a: 255),
+    Color(r: 112, g: 0, b: 0, a: 255),
+    Color(r: 255, g: 0, b: 255, a: 255),
+    Color(r: 255, g: 0, b: 255, a: 255),
+    Color(r: 255, g: 0, b: 255, a: 255),
+    Color(r: 0, g: 0, b: 0, a: 0),
+]


### PR DESCRIPTION
including time and allocated memory, in mergePartialSolutions.

Previously, the solver could get stuck in `mergePartialSolutions` in the do/while loop and never recover because it didn't consider the performance thresholds.

Resolves: rdar://problem/53589951
Resolves: rdar://problem/60062211