### PR TITLE
[CodeCompletion] Re-typecheck TypeExpr without call arguments

### DIFF
--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -351,6 +351,14 @@ static void collectPossibleCalleesByQualifiedLookup(
     DeclContext &DC, Expr *baseExpr, DeclNameRef name,
     SmallVectorImpl<FunctionTypeAndDecl> &candidates) {
   ConcreteDeclRef ref = nullptr;
+
+  // Re-typecheck TypeExpr so it's typechecked without the arguments which may
+  // affects the inference of the generic arguments.
+  if (TypeExpr *tyExpr = dyn_cast<TypeExpr>(baseExpr)) {
+    tyExpr->setType(nullptr);
+    tyExpr->getTypeLoc().setType(nullptr);
+  }
+
   auto baseTyOpt = getTypeOfCompletionContextExpr(
       DC.getASTContext(), &DC, CompletionTypeCheckKind::Normal, baseExpr, ref);
   if (!baseTyOpt)
@@ -435,7 +443,7 @@ static bool collectPossibleCalleesForApply(
     auto baseTy = AMT->getInstanceType();
     if (isa<TypeExpr>(fnExpr) && baseTy->mayHaveMembers()) {
       collectPossibleCalleesByQualifiedLookup(
-          DC, AMT, DeclNameRef::createConstructor(), candidates);
+          DC, fnExpr, DeclNameRef::createConstructor(), candidates);
     }
   }
 

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -94,6 +94,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARCHETYPE_GENERIC_1 | %FileCheck %s -check-prefix=ARCHETYPE_GENERIC_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PARAM_WITH_ERROR_AUTOCLOSURE| %FileCheck %s -check-prefix=PARAM_WITH_ERROR_AUTOCLOSURE
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPECHECKED_OVERLOADED | %FileCheck %s -check-prefix=TYPECHECKED_OVERLOADED
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPECHECKED_TYPEEXPR | %FileCheck %s -check-prefix=TYPECHECKED_TYPEEXPR
 
 var i1 = 1
 var i2 = 2
@@ -753,12 +754,13 @@ struct TestHasErrorAutoclosureParam {
   }
 }
 
-struct MyType {
+struct MyType<T> {
+  init(arg1: String, arg2: T) {}
   func overloaded() {}
   func overloaded(_ int: Int) {}
   func overloaded(name: String, value: String) {}
 }
-func testTypecheckedOverloaded(value: MyType) {
+func testTypecheckedOverloaded<T>(value: MyType<T>) {
   value.overloaded(#^TYPECHECKED_OVERLOADED^#)
 // TYPECHECKED_OVERLOADED: Begin completions
 // TYPECHECKED_OVERLOADED-DAG: Decl[InstanceMethod]/CurrNominal:   ['('][')'][#Void#];
@@ -766,3 +768,14 @@ func testTypecheckedOverloaded(value: MyType) {
 // TYPECHECKED_OVERLOADED-DAG: Decl[InstanceMethod]/CurrNominal:   ['(']{#name: String#}, {#value: String#}[')'][#Void#];
 // TYPECHECKED_OVERLOADED: End completions
 }
+
+extension MyType where T == Int {
+  init(_ intVal: T) {}
+}
+func testTypecheckedTypeExpr() {
+  MyType(#^TYPECHECKED_TYPEEXPR^#
+}
+// TYPECHECKED_TYPEEXPR: Begin completions
+// TYPECHECKED_TYPEEXPR: Decl[Constructor]/CurrNominal:      ['(']{#arg1: String#}, {#arg2: _#}[')'][#MyType<_>#]; name=arg1: String, arg2: _
+// TYPECHECKED_TYPEEXPR: Decl[Constructor]/CurrNominal:      ['(']{#(intVal): Int#}[')'][#MyType<Int>#]; name=intVal: Int
+// TYPECHECKED_TYPEEXPR: End completions


### PR DESCRIPTION
Call arguments sometimes affect the inference for the generic parameters of the type expression. When we want to show all initializers from all extensions, we do not want to infer any generic arguments.

rdar://problem/53516588