### PR TITLE
[expand-placeholder] Add support for multiple-trailing closures

### DIFF
--- a/test/SourceKit/CodeExpand/code-expand-multiple-trailing-closures.swift
+++ b/test/SourceKit/CodeExpand/code-expand-multiple-trailing-closures.swift
@@ -1,0 +1,118 @@
+// RUN: %sourcekitd-test -req=expand-placeholder %s | %FileCheck %s
+
+withMulti1Labeled(a: <#T##() -> ()#>, b: <#T##() -> ()#>)
+// CHECK:      withMulti1Labeled {
+// CHECK-NEXT: a: { 
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+// CHECK-NEXT: b: { 
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+
+withMulti2Unlabled(<#T##() -> ()#>, _: <#T##() -> ()#>)
+// CHECK:      withMulti2Unlabled {
+// CHECK-NEXT: _: { 
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+// CHECK-NEXT: _: { 
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+
+withMulti3SecondArg(a: <#T##__skip__##() -> ()#>, b: <#T##() -> ()#>)
+// CHECK:      withMulti3SecondArg {
+// CHECK-NEXT: a: { 
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+// CHECK-NEXT: b: { 
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+
+withMulti4MiddleArg(a: <#T##() -> ()#>, b: <#T##__skip__##() -> ()#>, c: <#T##() -> ()#>)
+// CHECK:      withMulti4MiddleArg {
+// CHECK-NEXT: a: { 
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+// CHECK-NEXT: b: { 
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+// CHECK-NEXT: c: { 
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+
+singleAlreadyExpand(a: { print("hi") }, b: <#T##() -> ()#>)
+// CHECK:      singleAlreadyExpand(a: { print("hi") }) { 
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+
+nonTrailing1(a: <#T##() -> ()#>, b: { print("hi") })
+// CHECK:      nonTrailing1(a: {
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }, b: { print("hi") })
+
+nonTrailingAndTrailing1(a: <#T##() -> ()#>, b: { print("hi") }, c: <#T##() -> ()#>)
+// CHECK:      nonTrailingAndTrailing1(a: {
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }, b: { print("hi") }) {
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+
+singleNonClosure(a: <#T##Int#>, b: <#T##() -> ()#>)
+// CHECK:      singleNonClosure(a: Int) { 
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+
+nonTrailing2(a: <#T##() -> ()#>, b: <#T##Int#>)
+// CHECK:      nonTrailing2(a: {
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }, b: Int)
+
+nonTrailingAndTrailing2(a: <#T##() -> ()#>, b: <#T##Int#> c: <#T##() -> ()#>)
+// CHECK:      nonTrailingAndTrailing2(a: {
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }, b: Int) {
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+
+withTypes1(a: <#T##(Bool, Int) -> ()#>, b: <#T##() -> Int#>)
+// CHECK:      withTypes1 {
+// CHECK-NEXT: a: { (<#Bool#>, <#Int#>) in
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+// CHECK-NEXT: b: { () -> Int in
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+
+withTypesAndLabels1(a: <#T##(_ booly: Bool, inty: Int) -> ()#>, b: <#T##(solo: Xyz) -> ()#>)
+// CHECK:      withTypesAndLabels1 {
+// CHECK-NEXT: a: { (booly, inty) in
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+// CHECK-NEXT: b: { (solo) in
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+
+mixedFull1(arg1: <#T##Something#>, arg2: <#T##Other#>, callback1: <#T##() -> Void#>, callback2: <#T##() -> Void#>)
+// CHECK:      mixedFull1(arg1: Something, arg2: Other) {
+// CHECK-NEXT: callback1: { 
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+// CHECK-NEXT: callback2: { 
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+
+mixedFull2(arg1: 1, arg2: "2"/*comment*/, callback1: <#T##() -> Void#>, callback2: <#T##() -> Void#>)
+// CHECK:      mixedFull2(arg1: 1, arg2: "2") {
+// CHECK-NEXT: callback1: { 
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+// CHECK-NEXT: callback2: { 
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+// CHECK-NEXT: }

--- a/test/SourceKit/CodeExpand/code-expand-multiple-trailing-closures.swift
+++ b/test/SourceKit/CodeExpand/code-expand-multiple-trailing-closures.swift
@@ -2,45 +2,55 @@
 
 withMulti1Labeled(a: <#T##() -> ()#>, b: <#T##() -> ()#>)
 // CHECK:      withMulti1Labeled {
-// CHECK-NEXT: a: { 
 // CHECK-NEXT: <#code#>
-// CHECK-NEXT: }
-// CHECK-NEXT: b: { 
+// CHECK-NEXT: } b: {
 // CHECK-NEXT: <#code#>
-// CHECK-NEXT: }
 // CHECK-NEXT: }
 
-withMulti2Unlabled(<#T##() -> ()#>, _: <#T##() -> ()#>)
+withMulti2UnlabeledFirst(<#T##() -> ()#>, b: <#T##() -> ()#>)
+// CHECK:      withMulti2UnlabeledFirst {
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: } b: {
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+
+withMulti2UnlabeledFirst(_: <#T##() -> ()#>, b: <#T##() -> ()#>)
+// CHECK:      withMulti2UnlabeledFirst {
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: } b: {
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+
+// FIXME: we may ban second argument unlabeled.
+withMulti2Unlabled(_: <#T##() -> ()#>, _: <#T##() -> ()#>)
 // CHECK:      withMulti2Unlabled {
-// CHECK-NEXT: _: { 
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: } _: {
 // CHECK-NEXT: <#code#>
 // CHECK-NEXT: }
-// CHECK-NEXT: _: { 
+
+// FIXME: we may ban second argument unlabeled.
+withMulti2Unlabled(<#T##() -> ()#>, <#T##() -> ()#>)
+// CHECK:      withMulti2Unlabled {
 // CHECK-NEXT: <#code#>
-// CHECK-NEXT: }
+// CHECK-NEXT: } _: {
+// CHECK-NEXT: <#code#>
 // CHECK-NEXT: }
 
 withMulti3SecondArg(a: <#T##__skip__##() -> ()#>, b: <#T##() -> ()#>)
 // CHECK:      withMulti3SecondArg {
-// CHECK-NEXT: a: { 
 // CHECK-NEXT: <#code#>
-// CHECK-NEXT: }
-// CHECK-NEXT: b: { 
+// CHECK-NEXT: } b: {
 // CHECK-NEXT: <#code#>
-// CHECK-NEXT: }
 // CHECK-NEXT: }
 
 withMulti4MiddleArg(a: <#T##() -> ()#>, b: <#T##__skip__##() -> ()#>, c: <#T##() -> ()#>)
 // CHECK:      withMulti4MiddleArg {
-// CHECK-NEXT: a: { 
 // CHECK-NEXT: <#code#>
-// CHECK-NEXT: }
-// CHECK-NEXT: b: { 
+// CHECK-NEXT: } b: {
 // CHECK-NEXT: <#code#>
-// CHECK-NEXT: }
-// CHECK-NEXT: c: { 
+// CHECK-NEXT: } c: {
 // CHECK-NEXT: <#code#>
-// CHECK-NEXT: }
 // CHECK-NEXT: }
 
 singleAlreadyExpand(a: { print("hi") }, b: <#T##() -> ()#>)
@@ -77,42 +87,35 @@ nonTrailingAndTrailing2(a: <#T##() -> ()#>, b: <#T##Int#> c: <#T##() -> ()#>)
 // CHECK-NEXT: <#code#>
 // CHECK-NEXT: }
 
-withTypes1(a: <#T##(Bool, Int) -> ()#>, b: <#T##() -> Int#>)
-// CHECK:      withTypes1 {
-// CHECK-NEXT: a: { (<#Bool#>, <#Int#>) in
-// CHECK-NEXT: <#code#>
-// CHECK-NEXT: }
-// CHECK-NEXT: b: { () -> Int in
-// CHECK-NEXT: <#code#>
-// CHECK-NEXT: }
-// CHECK-NEXT: }
 
 withTypesAndLabels1(a: <#T##(_ booly: Bool, inty: Int) -> ()#>, b: <#T##(solo: Xyz) -> ()#>)
-// CHECK:      withTypesAndLabels1 {
-// CHECK-NEXT: a: { (booly, inty) in
+// CHECK:      withTypesAndLabels1 { (booly, inty) in
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: } b: { (solo) in
 // CHECK-NEXT: <#code#>
 // CHECK-NEXT: }
-// CHECK-NEXT: b: { (solo) in
+
+func reset_parser1() {}
+
+withTypes1(a: <#T##(Bool, Int) -> ()#>, b: <#T##() -> Int#>)
+// CHECK:      withTypes1 { (<#Bool#>, <#Int#>) in
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: } b: { () -> Int in
 // CHECK-NEXT: <#code#>
 // CHECK-NEXT: }
-// CHECK-NEXT: }
+
+func reset_parser2() {}
 
 mixedFull1(arg1: <#T##Something#>, arg2: <#T##Other#>, callback1: <#T##() -> Void#>, callback2: <#T##() -> Void#>)
 // CHECK:      mixedFull1(arg1: Something, arg2: Other) {
-// CHECK-NEXT: callback1: { 
 // CHECK-NEXT: <#code#>
-// CHECK-NEXT: }
-// CHECK-NEXT: callback2: { 
+// CHECK-NEXT: } callback2: {
 // CHECK-NEXT: <#code#>
-// CHECK-NEXT: }
 // CHECK-NEXT: }
 
 mixedFull2(arg1: 1, arg2: "2"/*comment*/, callback1: <#T##() -> Void#>, callback2: <#T##() -> Void#>)
 // CHECK:      mixedFull2(arg1: 1, arg2: "2") {
-// CHECK-NEXT: callback1: { 
 // CHECK-NEXT: <#code#>
-// CHECK-NEXT: }
-// CHECK-NEXT: callback2: { 
+// CHECK-NEXT: } callback2: {
 // CHECK-NEXT: <#code#>
-// CHECK-NEXT: }
 // CHECK-NEXT: }

--- a/test/SourceKit/CodeExpand/code-expand.swift
+++ b/test/SourceKit/CodeExpand/code-expand.swift
@@ -67,24 +67,41 @@ func f1() {
 // CHECK-NEXT: <#code#>
 // CHECK-NEXT: }
 
+// FIXME: whether we get a trailing closure or not depends on the order we
+// expand the placeholders.
+func f1() {
+  bar(<#T##__skip__: () -> ()##() -> ()#>, <#T##d: () -> ()##() -> ()#>)
+}
+// CHECK:   bar(<#T##__skip__: () -> ()##() -> ()#>, {
+// CHECK-NEXT:	<#code#>
+// CHECK-NEXT:	})
+
 func f1() {
   bar(<#T##d: () -> ()##() -> ()#>, <#T##d: () -> ()##() -> ()#>)
 }
 // CHECK:   bar({
-// CHECK-NEXT:	<#code#>
-// CHECK-NEXT:	}, {
-// CHECK-NEXT:	<#code#>
-// CHECK-NEXT:	})
+// CHECK-NEXT:  <#code#>
+// CHECK-NEXT:  }) {
+// CHECK-NEXT:  <#code#>
+// CHECK-NEXT:  }
 
+// FIXME: whether we get a trailing closure or not depends on the order we
+// expand the placeholders.
+func f1() {
+  bar(a : <#T##__skip__: () -> ()##() -> ()#>, b : <#T##d: () -> ()##() -> ()#>)
+}
+// CHECK: bar(a : <#T##__skip__: () -> ()##() -> ()#>, b : {
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: })
 
 func f1() {
   bar(a : <#T##d: () -> ()##() -> ()#>, b : <#T##d: () -> ()##() -> ()#>)
 }
 // CHECK: bar(a : {
 // CHECK-NEXT: <#code#>
-// CHECK-NEXT: }, b : {
+// CHECK-NEXT: }) {
 // CHECK-NEXT: <#code#>
-// CHECK-NEXT: })
+// CHECK-NEXT: }
 
 
 func f1() {

--- a/test/SourceKit/CodeExpand/code-expand.swift
+++ b/test/SourceKit/CodeExpand/code-expand.swift
@@ -71,48 +71,36 @@ func f1() {
   bar(<#T##__skip__: () -> ()##() -> ()#>, <#T##d: () -> ()##() -> ()#>)
 }
 // CHECK:   bar {
-// CHECK-NEXT:  _: { 
 // CHECK-NEXT:	<#code#>
-// CHECK-NEXT:	}
-// CHECK-NEXT:  _: { 
+// CHECK-NEXT:	} _: {
 // CHECK-NEXT:  <#code#>
-// CHECK-NEXT:  }
 // CHECK-NEXT:  }
 
 func f1() {
   bar(<#T##d: () -> ()##() -> ()#>, <#T##d: () -> ()##() -> ()#>)
 }
 // CHECK:   bar {
-// CHECK-NEXT:  _: { 
 // CHECK-NEXT:  <#code#>
-// CHECK-NEXT:  }
-// CHECK-NEXT:  _: { 
+// CHECK-NEXT:  } _: {
 // CHECK-NEXT:  <#code#>
-// CHECK-NEXT:  }
 // CHECK-NEXT:  }
 
 func f1() {
   bar(a : <#T##__skip__: () -> ()##() -> ()#>, b : <#T##d: () -> ()##() -> ()#>)
 }
 // CHECK: bar {
-// CHECK-NEXT: a: { 
 // CHECK-NEXT: <#code#>
-// CHECK-NEXT: }
-// CHECK-NEXT: b: { 
+// CHECK-NEXT: } b: {
 // CHECK-NEXT: <#code#>
-// CHECK-NEXT: }
 // CHECK-NEXT: }
 
 func f1() {
   bar(a : <#T##d: () -> ()##() -> ()#>, b : <#T##d: () -> ()##() -> ()#>)
 }
 // CHECK: bar {
-// CHECK-NEXT: a: { 
 // CHECK-NEXT: <#code#>
-// CHECK-NEXT: }
-// CHECK-NEXT: b: { 
+// CHECK-NEXT: } b: {
 // CHECK-NEXT: <#code#>
-// CHECK-NEXT: }
 // CHECK-NEXT: }
 
 func f1() {

--- a/test/SourceKit/CodeExpand/code-expand.swift
+++ b/test/SourceKit/CodeExpand/code-expand.swift
@@ -67,42 +67,53 @@ func f1() {
 // CHECK-NEXT: <#code#>
 // CHECK-NEXT: }
 
-// FIXME: whether we get a trailing closure or not depends on the order we
-// expand the placeholders.
 func f1() {
   bar(<#T##__skip__: () -> ()##() -> ()#>, <#T##d: () -> ()##() -> ()#>)
 }
-// CHECK:   bar(<#T##__skip__: () -> ()##() -> ()#>, {
+// CHECK:   bar {
+// CHECK-NEXT:  _: { 
 // CHECK-NEXT:	<#code#>
-// CHECK-NEXT:	})
+// CHECK-NEXT:	}
+// CHECK-NEXT:  _: { 
+// CHECK-NEXT:  <#code#>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  }
 
 func f1() {
   bar(<#T##d: () -> ()##() -> ()#>, <#T##d: () -> ()##() -> ()#>)
 }
-// CHECK:   bar({
-// CHECK-NEXT:  <#code#>
-// CHECK-NEXT:  }) {
+// CHECK:   bar {
+// CHECK-NEXT:  _: { 
 // CHECK-NEXT:  <#code#>
 // CHECK-NEXT:  }
+// CHECK-NEXT:  _: { 
+// CHECK-NEXT:  <#code#>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  }
 
-// FIXME: whether we get a trailing closure or not depends on the order we
-// expand the placeholders.
 func f1() {
   bar(a : <#T##__skip__: () -> ()##() -> ()#>, b : <#T##d: () -> ()##() -> ()#>)
 }
-// CHECK: bar(a : <#T##__skip__: () -> ()##() -> ()#>, b : {
+// CHECK: bar {
+// CHECK-NEXT: a: { 
 // CHECK-NEXT: <#code#>
-// CHECK-NEXT: })
+// CHECK-NEXT: }
+// CHECK-NEXT: b: { 
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+// CHECK-NEXT: }
 
 func f1() {
   bar(a : <#T##d: () -> ()##() -> ()#>, b : <#T##d: () -> ()##() -> ()#>)
 }
-// CHECK: bar(a : {
-// CHECK-NEXT: <#code#>
-// CHECK-NEXT: }) {
+// CHECK: bar {
+// CHECK-NEXT: a: { 
 // CHECK-NEXT: <#code#>
 // CHECK-NEXT: }
-
+// CHECK-NEXT: b: { 
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+// CHECK-NEXT: }
 
 func f1() {
   bar(a : {}}, <#T##d: () -> ()##() -> ()#>)

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1468,16 +1468,13 @@ public:
       :NameRange(NameRange), TypeRange(TypeRange) { }
   };
 
-private:
-
   struct ClosureInfo {
     std::vector<Param> Params;
     CharSourceRange ReturnTypeRange;
   };
 
+private:
   SourceManager &SM;
-  ClosureInfo TargetClosureInfo;
-  EditorPlaceholderExpr *PHE = nullptr;
 
   class PlaceholderFinder: public ASTWalker {
     SourceLoc PlaceholderLoc;
@@ -1571,12 +1568,11 @@ private:
     return ClosureWalker.FoundFunctionTypeRepr;
   }
 
-  bool scanClosureType(SourceFile &SF, SourceLoc PlaceholderLoc) {
+  bool scanClosureType(EditorPlaceholderExpr *PHE,
+                       ClosureInfo &TargetClosureInfo) {
     TargetClosureInfo.Params.clear();
     TargetClosureInfo.ReturnTypeRange = CharSourceRange();
-    PlaceholderFinder Finder(PlaceholderLoc, PHE);
-    SF.walk(Finder);
-    if (!PHE || !PHE->getTypeForExpansion())
+    if (!PHE->getTypeForExpansion())
       return false;
     ClosureTypeWalker PW(SM, TargetClosureInfo);
     PHE->getTypeForExpansion()->walk(PW);
@@ -1699,33 +1695,61 @@ private:
     return std::make_pair(CE, true);
   }
 
-  bool shouldUseTrailingClosureInTuple(TupleExpr *TE,
-                                       SourceLoc PlaceHolderStartLoc,
-                                       bool &isWrappedWithBraces) {
+  struct ParamClosureInfo {
+    Optional<ClosureInfo> placeholderClosure;
+    bool isNonPlacholderClosure = false;
+    bool isWrappedWithBraces = false;
+  };
+
+  /// Scan the given TupleExpr collecting parameter closure information and
+  /// returning the index of the given target placeholder (if found).
+  Optional<unsigned> scanTupleExpr(TupleExpr *TE, SourceLoc targetPlacholderLoc,
+                                   std::vector<ParamClosureInfo> &outParams) {
     if (TE->getElements().empty())
-      return false;
+      return llvm::None;
 
-    for (unsigned I = 0, N = TE->getNumElements(); I < N; ++ I) {
-      bool IsLast = I == N - 1;
-      Expr *E = TE->getElement(I);
+    outParams.clear();
+    outParams.reserve(TE->getNumElements());
 
-      // Placeholders wrapped in braces {<#T##() -> Int#>} can also
-      // be valid for trailing syntax.
+    Optional<unsigned> targetPlacholderIndex;
+
+    for (Expr *E : TE->getElements()) {
+      outParams.emplace_back();
+      auto &outParam = outParams.back();
+
       if (auto CE = dyn_cast<ClosureExpr>(E)) {
         if (CE->hasSingleExpressionBody() &&
-            CE->getSingleExpressionBody()->getStartLoc()
-              == PlaceHolderStartLoc) {
-          // We found the placeholder.
-          isWrappedWithBraces = true;
-          return IsLast;
+            CE->getSingleExpressionBody()->getStartLoc() ==
+                targetPlacholderLoc) {
+          targetPlacholderIndex = outParams.size() - 1;
+          if (auto *PHE = dyn_cast<EditorPlaceholderExpr>(
+                  CE->getSingleExpressionBody())) {
+            outParam.isWrappedWithBraces = true;
+            ClosureInfo info;
+            if (scanClosureType(PHE, info))
+              outParam.placeholderClosure = info;
+            continue;
+          }
         }
-      } else if (IsLast) {
-        return E->getStartLoc() == PlaceHolderStartLoc;
+        // else...
+        outParam.isNonPlacholderClosure = true;
+        continue;
+      }
+
+      if (auto *PHE = dyn_cast<EditorPlaceholderExpr>(E)) {
+        ClosureInfo info;
+        if (scanClosureType(PHE, info))
+          outParam.placeholderClosure = info;
       } else if (containClosure(E)) {
-        return false;
+        outParam.isNonPlacholderClosure = true;
+      }
+
+      if (E->getStartLoc() == targetPlacholderLoc) {
+        targetPlacholderIndex = outParams.size() - 1;
       }
     }
-    return false;
+
+    return targetPlacholderIndex;
   }
 
 public:
@@ -1734,45 +1758,91 @@ public:
   /// Retrieves the parameter list, return type and context info for
   /// a typed completion placeholder in a function call.
   /// For example: foo.bar(aaa, <#T##(Int, Int) -> Bool#>).
-  bool scan(SourceFile &SF, unsigned BufID, unsigned Offset,
-             unsigned Length, std::function<void(Expr *Args,
-                                                 bool UseTrailingClosure,
-                                                 bool isWrappedWithBraces,
-                                                 ArrayRef<Param>,
-                                                 CharSourceRange)> Callback,
-            std::function<bool(EditorPlaceholderExpr*)> NonClosureCallback) {
+  bool scan(SourceFile &SF, unsigned BufID, unsigned Offset, unsigned Length,
+            std::function<void(Expr *Args, bool UseTrailingClosure,
+                               bool isWrappedWithBraces, const ClosureInfo &)>
+                OneClosureCallback,
+            std::function<void(TupleExpr *Args, unsigned FirstTrailingIndex,
+                               ArrayRef<ClosureInfo> trailingClosures)>
+                MultiClosureCallback,
+            std::function<bool(EditorPlaceholderExpr *)> NonClosureCallback) {
 
     SourceLoc PlaceholderStartLoc = SM.getLocForOffset(BufID, Offset);
 
     // See if the placeholder is encapsulated with an EditorPlaceholderExpr
-    // and retrieve parameter and return type ranges.
-    if (!scanClosureType(SF, PlaceholderStartLoc)) {
+    EditorPlaceholderExpr *PHE = nullptr;
+    PlaceholderFinder Finder(PlaceholderStartLoc, PHE);
+    SF.walk(Finder);
+    if (!PHE)
       return NonClosureCallback(PHE);
-    }
+
+    // Retrieve parameter and return type ranges.
+    ClosureInfo TargetClosureInfo;
+    if (!scanClosureType(PHE, TargetClosureInfo))
+      return NonClosureCallback(PHE);
 
     // Now we need to see if we can suggest trailing closure expansion,
     // and if the call parens can be removed in that case.
     // We'll first find the enclosing CallExpr, and then do further analysis.
-    bool UseTrailingClosure = false;
-    bool isWrappedWithBraces = false;
+    std::vector<ParamClosureInfo> params;
+    Optional<unsigned> targetPlacholderIndex;
     auto ECE = enclosingCallExprArg(SF, PlaceholderStartLoc);
     Expr *Args = ECE.first;
     if (Args && ECE.second) {
       if (isa<ParenExpr>(Args)) {
-        UseTrailingClosure = true;
+        params.emplace_back();
+        params.back().placeholderClosure = TargetClosureInfo;
+        targetPlacholderIndex = 0;
       } else if (auto *TE = dyn_cast<TupleExpr>(Args)) {
-        UseTrailingClosure = shouldUseTrailingClosureInTuple(
-                               TE, PlaceholderStartLoc,
-                               isWrappedWithBraces);
+        targetPlacholderIndex = scanTupleExpr(TE, PlaceholderStartLoc, params);
       }
     }
 
-    Callback(Args, UseTrailingClosure, isWrappedWithBraces,
-             TargetClosureInfo.Params,
-             TargetClosureInfo.ReturnTypeRange);
+    // If there was no appropriate parent call expression, it's non-trailing.
+    if (!targetPlacholderIndex.hasValue()) {
+      OneClosureCallback(Args, /*useTrailingClosure=*/false,
+                         /*isWrappedWithBraces=*/false, TargetClosureInfo);
+      return true;
+    }
+
+    const unsigned end = params.size();
+    unsigned firstTrailingIndex = end;
+
+    // Find the first parameter eligible to be trailing.
+    while (firstTrailingIndex != 0) {
+      unsigned i = firstTrailingIndex - 1;
+      if (params[i].isNonPlacholderClosure ||
+          !params[i].placeholderClosure.hasValue())
+        break;
+      firstTrailingIndex = i;
+    }
+
+    if (firstTrailingIndex > targetPlacholderIndex) {
+      // Target comes before the eligible trailing closures.
+      OneClosureCallback(Args, /*isTrailing=*/false,
+                         params[*targetPlacholderIndex].isWrappedWithBraces,
+                         TargetClosureInfo);
+      return true;
+    } else if (targetPlacholderIndex == end - 1 &&
+               firstTrailingIndex == end - 1) {
+      // Target is the only eligible trailing closure.
+      OneClosureCallback(Args, /*isTrailing=*/true,
+                         params[*targetPlacholderIndex].isWrappedWithBraces,
+                         TargetClosureInfo);
+      return true;
+    }
+
+    // There are multiple trailing closures.
+    SmallVector<ClosureInfo, 4> trailingClosures;
+    trailingClosures.reserve(params.size() - firstTrailingIndex);
+    for (const auto &param :
+         llvm::makeArrayRef(params).slice(firstTrailingIndex)) {
+      trailingClosures.push_back(*param.placeholderClosure);
+    }
+    MultiClosureCallback(cast<TupleExpr>(Args), firstTrailingIndex,
+                         trailingClosures);
     return true;
   }
-
 };
 
 } // anonymous namespace
@@ -2059,11 +2129,55 @@ void SwiftEditorDocument::formatText(unsigned Line, unsigned Length,
   Consumer.recordAffectedLineRange(LineRange.startLine(), LineRange.lineCount());
 }
 
-bool isReturningVoid(SourceManager &SM, CharSourceRange Range) {
+bool isReturningVoid(const SourceManager &SM, CharSourceRange Range) {
   if (Range.isInvalid())
     return false;
   StringRef Text = SM.extractText(Range);
   return "()" == Text || "Void" == Text;
+}
+
+static void
+printClosureBody(const PlaceholderExpansionScanner::ClosureInfo &closure,
+                 llvm::raw_ostream &OS, const SourceManager &SM) {
+  bool ReturningVoid = isReturningVoid(SM, closure.ReturnTypeRange);
+
+  bool HasSignature = !closure.Params.empty() ||
+                      (closure.ReturnTypeRange.isValid() && !ReturningVoid);
+  bool FirstParam = true;
+  if (HasSignature)
+    OS << "(";
+  for (auto &Param : closure.Params) {
+    if (!FirstParam)
+      OS << ", ";
+    FirstParam = false;
+    if (Param.NameRange.isValid()) {
+      // If we have a parameter name, just output the name as is and skip
+      // the type. For example:
+      // <#(arg1: Int, arg2: Int)#> turns into (arg1, arg2).
+      OS << SM.extractText(Param.NameRange);
+    } else {
+      // If we only have the parameter type, output the type as a
+      // placeholder. For example:
+      // <#(Int, Int)#> turns into (<#Int#>, <#Int#>).
+      OS << "<#";
+      OS << SM.extractText(Param.TypeRange);
+      OS << "#>";
+    }
+  }
+  if (HasSignature)
+    OS << ") ";
+  if (closure.ReturnTypeRange.isValid()) {
+    auto ReturnTypeText = SM.extractText(closure.ReturnTypeRange);
+
+    // We need return type if it is not Void.
+    if (!ReturningVoid) {
+      OS << "-> ";
+      OS << ReturnTypeText << " ";
+    }
+  }
+  if (HasSignature)
+    OS << "in";
+  OS << "\n" << getCodePlaceholder() << "\n";
 }
 
 void SwiftEditorDocument::expandPlaceholder(unsigned Offset, unsigned Length,
@@ -2086,8 +2200,7 @@ void SwiftEditorDocument::expandPlaceholder(unsigned Offset, unsigned Length,
   Scanner.scan(SF, BufID, Offset, Length,
           [&](Expr *Args,
               bool UseTrailingClosure, bool isWrappedWithBraces,
-              ArrayRef<PlaceholderExpansionScanner::Param> ClosureParams,
-              CharSourceRange ClosureReturnTypeRange) {
+              const PlaceholderExpansionScanner::ClosureInfo &closure) {
 
       unsigned EffectiveOffset = Offset;
       unsigned EffectiveLength = Length;
@@ -2131,54 +2244,56 @@ void SwiftEditorDocument::expandPlaceholder(unsigned Offset, unsigned Length,
         }
         // Trailing closure syntax handling will replace braces anyway.
         bool printBraces = !isWrappedWithBraces || UseTrailingClosure;
+
         if (printBraces)
           OS << "{ ";
-
-        bool ReturningVoid = isReturningVoid(SM, ClosureReturnTypeRange);
-
-        bool HasSignature = !ClosureParams.empty() ||
-                            (ClosureReturnTypeRange.isValid() && !ReturningVoid);
-        bool FirstParam = true;
-        if (HasSignature)
-          OS << "(";
-        for (auto &Param: ClosureParams) {
-          if (!FirstParam)
-            OS << ", ";
-          FirstParam = false;
-          if (Param.NameRange.isValid()) {
-            // If we have a parameter name, just output the name as is and skip
-            // the type. For example:
-            // <#(arg1: Int, arg2: Int)#> turns into (arg1, arg2).
-            OS << SM.extractText(Param.NameRange);
-          }
-          else {
-            // If we only have the parameter type, output the type as a
-            // placeholder. For example:
-            // <#(Int, Int)#> turns into (<#Int#>, <#Int#>).
-            OS << "<#";
-            OS << SM.extractText(Param.TypeRange);
-            OS << "#>";
-          }
-        }
-        if (HasSignature)
-          OS << ") ";
-        if (ClosureReturnTypeRange.isValid()) {
-          auto ReturnTypeText = SM.extractText(ClosureReturnTypeRange);
-
-          // We need return type if it is not Void.
-          if (!ReturningVoid) {
-            OS << "-> ";
-            OS << ReturnTypeText << " ";
-          }
-        }
-        if (HasSignature)
-          OS << "in";
-        OS << "\n" << getCodePlaceholder() << "\n";
+        printClosureBody(closure, OS, SM);
         if (printBraces)
           OS << "}";
       }
       Consumer.handleSourceText(ExpansionStr);
       Consumer.recordAffectedRange(EffectiveOffset, EffectiveLength);
+
+    },[&](TupleExpr *args, unsigned firstTrailingIndex,
+          ArrayRef<PlaceholderExpansionScanner::ClosureInfo> trailingClosures) {
+      unsigned EffectiveOffset = Offset;
+      unsigned EffectiveLength = Length;
+      llvm::SmallString<128> ExpansionStr;
+      {
+        llvm::raw_svector_ostream OS(ExpansionStr);
+
+        assert(args->getNumElements() - firstTrailingIndex == trailingClosures.size());
+        if (firstTrailingIndex == 0) {
+          // foo(<....>) -> foo { <...> }
+          EffectiveOffset = SM.getLocOffsetInBuffer(args->getStartLoc(), BufID);
+          OS << " ";
+        } else {
+          // foo(blah, <....>) -> foo(blah) { <...> }
+          SourceLoc beforeTrailingLoc = Lexer::getLocForEndOfToken(SM,
+              args->getElements()[firstTrailingIndex - 1]->getEndLoc());
+          EffectiveOffset = SM.getLocOffsetInBuffer(beforeTrailingLoc, BufID);
+          OS << ") ";
+        }
+
+        unsigned End = SM.getLocOffsetInBuffer(args->getEndLoc(), BufID);
+        EffectiveLength = (End + 1) - EffectiveOffset;
+
+        OS << "{\n";
+
+        unsigned argI = firstTrailingIndex;
+        for (unsigned i = 0; argI != args->getNumElements(); ++i, ++argI) {
+          const auto &closure = trailingClosures[i];
+          auto label = args->getElementName(argI);
+          OS << (label.empty() ? "_" : label.str()) << ": { ";
+          printClosureBody(closure, OS, SM);
+          OS << "}\n";
+        }
+        OS << "}";
+      }
+
+      Consumer.handleSourceText(ExpansionStr);
+      Consumer.recordAffectedRange(EffectiveOffset, EffectiveLength);
+
     }, [&](EditorPlaceholderExpr *PHE) {
       if (!PHE)
         return false;

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -2278,17 +2278,19 @@ void SwiftEditorDocument::expandPlaceholder(unsigned Offset, unsigned Length,
         unsigned End = SM.getLocOffsetInBuffer(args->getEndLoc(), BufID);
         EffectiveLength = (End + 1) - EffectiveOffset;
 
-        OS << "{\n";
-
         unsigned argI = firstTrailingIndex;
         for (unsigned i = 0; argI != args->getNumElements(); ++i, ++argI) {
           const auto &closure = trailingClosures[i];
-          auto label = args->getElementName(argI);
-          OS << (label.empty() ? "_" : label.str()) << ": { ";
+          if (i == 0) {
+            OS << "{ ";
+          } else {
+            auto label = args->getElementName(argI);
+            OS << " " << (label.empty() ? "_" : label.str()) << ": { ";
+          }
           printClosureBody(closure, OS, SM);
-          OS << "}\n";
+          OS << "}";
         }
-        OS << "}";
+        OS << "\n";
       }
 
       Consumer.handleSourceText(ExpansionStr);

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -15,7 +15,6 @@
 #include "SourceKit/Support/Concurrency.h"
 #include "TestOptions.h"
 #include "swift/Demangling/ManglingMacros.h"
-#include "clang/Rewrite/Core/RewriteBuffer.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/Optional.h"
@@ -2081,53 +2080,85 @@ static void printStatistics(sourcekitd_variant_t Info, raw_ostream &OS) {
   });
 }
 
-static void initializeRewriteBuffer(StringRef Input,
-                                    clang::RewriteBuffer &RewriteBuf) {
-  RewriteBuf.Initialize(Input);
-  StringRef CheckStr = "CHECK";
-  size_t Pos = 0;
-  while (true) {
-    Pos = Input.find(CheckStr, Pos);
-    if (Pos == StringRef::npos)
-      break;
-    Pos = Input.substr(0, Pos).rfind("//");
-    assert(Pos != StringRef::npos);
-    size_t EndLine = Input.find('\n', Pos);
-    assert(EndLine != StringRef::npos);
-    ++EndLine;
-    RewriteBuf.RemoveText(Pos, EndLine-Pos);
-    Pos = EndLine;
+static std::string initializeSource(StringRef Input) {
+  std::string result;
+  {
+    llvm::raw_string_ostream OS(result);
+    StringRef CheckStr = "CHECK";
+    size_t Pos = 0;
+    while (true) {
+      auto checkPos = Input.find(CheckStr, Pos);
+      if (checkPos == StringRef::npos)
+        break;
+      checkPos = Input.substr(0, checkPos).rfind("//");
+      assert(checkPos != StringRef::npos);
+      size_t EndLine = Input.find('\n', checkPos);
+      assert(EndLine != StringRef::npos);
+      ++EndLine;
+      OS << Input.slice(Pos, checkPos);
+      Pos = EndLine;
+    }
+
+    OS << Input.slice(Pos, StringRef::npos);
   }
+  return result;
 }
 
-static std::vector<std::pair<unsigned, unsigned>>
-getPlaceholderRanges(StringRef Source) {
+static Optional<std::pair<unsigned, unsigned>>
+firstPlaceholderRange(StringRef Source, unsigned from) {
   const char *StartPtr = Source.data();
-  std::vector<std::pair<unsigned, unsigned>> Ranges;
+  Source = Source.drop_front(from);
+
   while (true) {
     size_t Pos = Source.find("<#");
     if (Pos == StringRef::npos)
       break;
     unsigned OffsetStart = Source.data() + Pos - StartPtr;
     Source = Source.substr(Pos+2);
+    if (Source.startswith("__skip__") || Source.startswith("T##__skip__"))
+      continue;
     Pos = Source.find("#>");
     if (Pos == StringRef::npos)
       break;
     unsigned OffsetEnd = Source.data() + Pos + 2 - StartPtr;
     Source = Source.substr(Pos+2);
-    Ranges.emplace_back(OffsetStart, OffsetEnd-OffsetStart);
+    return std::make_pair(OffsetStart, OffsetEnd-OffsetStart);
   }
-  return Ranges;
+  return llvm::None;
 }
 
 static void expandPlaceholders(llvm::MemoryBuffer *SourceBuf,
                                llvm::raw_ostream &OS) {
-  clang::RewriteBuffer RewriteBuf;
-  initializeRewriteBuffer(SourceBuf->getBuffer(), RewriteBuf);
-  auto Ranges = getPlaceholderRanges(SourceBuf->getBuffer());
-  for (auto Range : Ranges) {
-    unsigned Offset = Range.first;
-    unsigned Length = Range.second;
+  auto syncEdit = [=](unsigned offset, unsigned length, const char *text) {
+    auto SourceBufID = SourceBuf->getBufferIdentifier();
+    auto req = sourcekitd_request_dictionary_create(nullptr, nullptr, 0);
+    sourcekitd_request_dictionary_set_uid(req, KeyRequest,
+                                          RequestEditorReplaceText);
+    sourcekitd_request_dictionary_set_stringbuf(req, KeyName,
+                                                SourceBufID.data(),
+                                                SourceBufID.size());
+    sourcekitd_request_dictionary_set_int64(req, KeyOffset, offset);
+    sourcekitd_request_dictionary_set_int64(req, KeyLength, length);
+    sourcekitd_request_dictionary_set_string(req, KeySourceText, text);
+
+    sourcekitd_response_t resp = sourcekitd_send_request_sync(req);
+    if (sourcekitd_response_is_error(resp)) {
+      sourcekitd_response_description_dump(resp);
+      exit(1);
+    }
+    sourcekitd_request_release(req);
+    sourcekitd_response_dispose(resp);
+  };
+
+  std::string source = initializeSource(SourceBuf->getBuffer());
+  // Sync contents with modified source.
+  syncEdit(0, SourceBuf->getBuffer().size(), source.c_str());
+
+  unsigned cursor = 0;
+
+  while (auto Range = firstPlaceholderRange(source, cursor)) {
+    unsigned Offset = Range->first;
+    unsigned Length = Range->second;
     sourcekitd_object_t Exp = sourcekitd_request_dictionary_create(nullptr,
                                                                    nullptr, 0);
     sourcekitd_request_dictionary_set_uid(Exp, KeyRequest,
@@ -2149,16 +2180,25 @@ static void expandPlaceholders(llvm::MemoryBuffer *SourceBuf,
     sourcekitd_variant_t Info = sourcekitd_response_get_value(Resp);
     const char *Text = sourcekitd_variant_dictionary_get_string(Info, KeySourceText);
     if (!Text) {
+      cursor = Offset + Length;
       sourcekitd_response_dispose(Resp);
       continue;
     }
     unsigned EditOffset = sourcekitd_variant_dictionary_get_int64(Info, KeyOffset);
     unsigned EditLength = sourcekitd_variant_dictionary_get_int64(Info, KeyLength);
-    RewriteBuf.ReplaceText(EditOffset, EditLength, Text);
+
+    // Apply edit locally.
+    source.replace(EditOffset, EditLength, Text);
+
+    // Apply edit on server.
+    syncEdit(EditOffset, EditLength, Text);
+
+    // Adjust cursor to after the edit (we do not expand recursively).
+    cursor = EditOffset + strlen(Text);
     sourcekitd_response_dispose(Resp);
   }
 
-  RewriteBuf.write(OS);
+  OS << source;
 }
 
 static std::pair<unsigned, unsigned>


### PR DESCRIPTION
Conceptually this depends on https://github.com/apple/swift/pull/31052

---

Since placeholder expansion works with a single placeholder, which is
somewhat at odds with multiple-trailing closures, we eagerly attempt to
expand all consecutive placeholders of closure type. That is, if the API
has multiple closure parameters at the end, expanding any one of them
will transform all of them to the new syntax.

Example

```swift
foo(a: <#T##()->()#>, b: <#T##()->()#>)
```

expanding *either* parameter will produce the following:

```swift
foo {
  <#code#>
} b: {
  <#code#>
}
```

(caveat: the indentation is not part of placeholder expansion, but it's
added here for clarity)

At least for now we do not attempt to corral an existing closure into
the new syntax, so for

```swift
foo(a: { bar() }, b: <#T##()->()#>)
```

The exansion will be

```swift
foo(a: { bar() }) {
  <#code#>
}
```

as it was before.

rdar://59688632