### PR TITLE
test: add missing tool dependency

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,6 +66,7 @@ function(get_test_dependencies SDK result_var_name)
       dsymutil
       FileCheck
       llc
+      llvm-ar
       llvm-as
       llvm-bcanalyzer
       llvm-cov


### PR DESCRIPTION
The tests depend on the archiver, and may opt to use the LLVM archiver.
Add a dependency for the test suite.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
