### PR TITLE
[ownership] Now that cond_br only takes trivial operands in ossa, eliminate all special code for handling it.

### DIFF
--- a/lib/SIL/OperandOwnership.cpp
+++ b/lib/SIL/OperandOwnership.cpp
@@ -435,27 +435,9 @@ OperandOwnershipKindClassifier::visitBranchInst(BranchInst *bi) {
 
 OperandOwnershipKindMap
 OperandOwnershipKindClassifier::visitCondBranchInst(CondBranchInst *cbi) {
-  // If our conditional branch is the condition, it is trivial. Check that the
-  // ownership kind is trivial.
-  if (cbi->isConditionOperandIndex(getOperandIndex()))
-    return Map::allLive();
-
-  // Otherwise, make sure that our operand matches the ownership of the relevant
-  // argument.
-  //
-  // TODO: Use more updated APIs here to get the operands/etc.
-  if (cbi->isTrueOperandIndex(getOperandIndex())) {
-    unsigned trueOffset = 1;
-    return checkTerminatorArgumentMatchesDestBB(cbi->getTrueBB(),
-                                                getOperandIndex() - trueOffset);
-  }
-
-  assert(cbi->isFalseOperandIndex(getOperandIndex()) &&
-         "If an operand is not the condition index or a true operand index, it "
-         "must be a false operand index");
-  unsigned falseOffset = 1 + cbi->getTrueOperands().size();
-  return checkTerminatorArgumentMatchesDestBB(cbi->getFalseBB(),
-                                              getOperandIndex() - falseOffset);
+  // In ossa, cond_br insts are not allowed to take non-trivial values. Thus, we
+  // just accept anything since we know all of our operands will be trivial.
+  return Map::allLive();
 }
 
 OperandOwnershipKindMap

--- a/lib/SIL/OwnershipUtils.cpp
+++ b/lib/SIL/OwnershipUtils.cpp
@@ -42,7 +42,6 @@ bool swift::isOwnershipForwardingValueKind(SILNodeKind kind) {
   case SILNodeKind::SelectEnumInst:
   case SILNodeKind::SwitchEnumInst:
   case SILNodeKind::CheckedCastBranchInst:
-  case SILNodeKind::CondBranchInst:
   case SILNodeKind::DestructureStructInst:
   case SILNodeKind::DestructureTupleInst:
   case SILNodeKind::MarkDependenceInst:

--- a/lib/SILOptimizer/Transforms/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Transforms/SemanticARCOpts.cpp
@@ -609,7 +609,6 @@ struct SemanticARCOptVisitor
   FORWARDING_TERM(SwitchEnum)
   FORWARDING_TERM(CheckedCastBranch)
   FORWARDING_TERM(Branch)
-  FORWARDING_TERM(CondBranch)
 #undef FORWARDING_TERM
 
   bool isWrittenTo(LoadInst *li, const LiveRange &lr);


### PR DESCRIPTION
I banned this in an earlier commit since it wasn't really useful and introduced
a bunch of unneeded complexity into the ownership system (namely the name for
BranchPropagatedUser). Now that we are free of that, we can clean up the
ownership code and just treat cond_br simply! I left in a special section in
OperandOwnership so I could put in a nice comment there.
