### PR TITLE
[SymbolGraph] Track conditional conformance

### DIFF
--- a/lib/SymbolGraphGen/Edge.cpp
+++ b/lib/SymbolGraphGen/Edge.cpp
@@ -43,5 +43,14 @@ void Edge::serialize(llvm::json::OStream &OS) const {
       Target.printPath(PathOS);
       OS.attribute("targetFallback", Scratch.str());
     }
+
+    if (ConformanceExtension &&
+        !ConformanceExtension->getGenericRequirements().empty()) {
+      OS.attributeArray("swiftConstraints", [&](){
+        for (const auto &Req : ConformanceExtension->getGenericRequirements()) {
+          ::serialize(Req, OS);
+        }
+      });
+    }
   });
 }

--- a/lib/SymbolGraphGen/JSON.h
+++ b/lib/SymbolGraphGen/JSON.h
@@ -38,6 +38,8 @@ struct AttributeRAII {
 
 void serialize(const llvm::VersionTuple &VT, llvm::json::OStream &OS);
 void serialize(const llvm::Triple &T, llvm::json::OStream &OS);
+void serialize(const ExtensionDecl *Extension, llvm::json::OStream &OS);
+void serialize(const Requirement &Req, llvm::json::OStream &OS);
 
 } // end namespace symbolgraphgen
 } // end namespace swift

--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -241,30 +241,6 @@ void Symbol::serializeGenericParam(const swift::GenericTypeParamType &Param,
   });
 }
 
-void Symbol::serializeGenericRequirement(const swift::Requirement &Req,
-                                         llvm::json::OStream &OS) const {
-  StringRef Kind;
-  switch (Req.getKind()) {
-    case swift::RequirementKind::Conformance:
-      Kind = "conformance";
-      break;
-    case swift::RequirementKind::Superclass:
-      Kind = "superclass";
-      break;
-    case swift::RequirementKind::SameType:
-      Kind = "sameType";
-      break;
-    case swift::RequirementKind::Layout:
-      return;
-  }
-
-  OS.object([&](){
-    OS.attribute("kind", Kind);
-    OS.attribute("lhs", Req.getFirstType()->getString());
-    OS.attribute("rhs", Req.getSecondType()->getString());
-  });
-}
-
 void Symbol::serializeSwiftGenericMixin(llvm::json::OStream &OS) const {
   if (const auto *GC = VD->getAsGenericContext()) {
       if (const auto Generics = GC->getGenericSignature()) {
@@ -286,7 +262,7 @@ void Symbol::serializeSwiftGenericMixin(llvm::json::OStream &OS) const {
         if (!Generics->getRequirements().empty()) {
           OS.attributeArray("constraints", [&](){
             for (const auto &Requirement : Generics->getRequirements()) {
-              serializeGenericRequirement(Requirement, OS);
+              ::serialize(Requirement, OS);
             }
           }); // end constraints:
         }
@@ -299,21 +275,7 @@ void Symbol::serializeSwiftGenericMixin(llvm::json::OStream &OS) const {
 void Symbol::serializeSwiftExtensionMixin(llvm::json::OStream &OS) const {
   if (const auto *Extension
           = dyn_cast_or_null<ExtensionDecl>(VD->getInnermostDeclContext())) {
-    OS.attributeObject("swiftExtension", [&](){
-      if (const auto *ExtendedNominal = Extension->getExtendedNominal()) {
-        if (const auto *ExtendedModule = ExtendedNominal->getModuleContext()) {
-          OS.attribute("extendedModule", ExtendedModule->getNameStr());
-        }
-      }
-      auto Generics = Extension->getGenericSignature();
-      if (Generics && !Generics->getRequirements().empty()) {
-        OS.attributeArray("constraints", [&](){
-          for (const auto &Requirement : Generics->getRequirements()) {
-            serializeGenericRequirement(Requirement, OS);
-          }
-        }); // end constraints:
-      }
-    }); // end swiftExtension:
+    ::serialize(Extension, OS);
   }
 }
 

--- a/lib/SymbolGraphGen/Symbol.h
+++ b/lib/SymbolGraphGen/Symbol.h
@@ -58,9 +58,6 @@ class Symbol {
   void serializeGenericParam(const swift::GenericTypeParamType &Param,
                              llvm::json::OStream &OS) const;
 
-  void serializeGenericRequirement(const swift::Requirement &Req,
-                                   llvm::json::OStream &OS) const;
-
   void serializeSwiftGenericMixin(llvm::json::OStream &OS) const;
 
   void serializeSwiftExtensionMixin(llvm::json::OStream &OS) const;

--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
@@ -25,22 +25,25 @@ SymbolGraphASTWalker::SymbolGraphASTWalker(ModuleDecl &M,
                                            const SymbolGraphOptions &Options)
   : Options(Options),
     M(M),
-    Graph(Options, M, None, Options.Target, Ctx) {}
+    MainGraph(*this, M, None, Ctx) {}
 
-/// Get a "sub" symbol graph for the parent module of a type that the main module `M` is extending.
-SymbolGraph &SymbolGraphASTWalker::getExtendedModuleSymbolGraph(ModuleDecl *M) {
+/// Get a "sub" symbol graph for the parent module of a type that
+/// the main module `M` is extending.
+SymbolGraph *SymbolGraphASTWalker::getModuleSymbolGraph(ModuleDecl *M) {
+  if (this->M.getNameStr().equals(M->getNameStr())) {
+    return &MainGraph;
+  }
   auto Found = ExtendedModuleGraphs.find(M);
   if (Found != ExtendedModuleGraphs.end()) {
-    return *Found->getSecond();
+    return Found->getSecond();
   }
   auto *Memory = Ctx.allocate(sizeof(SymbolGraph), alignof(SymbolGraph));  
-  auto *SG = new (Memory) SymbolGraph(Options,
-                                      Graph.M,
+  auto *SG = new (Memory) SymbolGraph(*this,
+                                      MainGraph.M,
                                       Optional<ModuleDecl *>(M),
-                                      Options.Target,
                                       Ctx);
   ExtendedModuleGraphs.insert({M, SG});
-  return *SG;
+  return SG;
 }
 
 bool SymbolGraphASTWalker::walkToDeclPre(Decl *D, CharSourceRange Range) {
@@ -58,38 +61,107 @@ bool SymbolGraphASTWalker::walkToDeclPre(Decl *D, CharSourceRange Range) {
     case swift::DeclKind::Subscript:
     case swift::DeclKind::TypeAlias:
     case swift::DeclKind::AssociatedType:
-      break;
     case swift::DeclKind::Extension:
-      // We don't want to descend into extensions on underscored types.
-      return !cast<ExtensionDecl>(D)->getExtendedNominal()->hasUnderscoredNaming();
+      break;
       
     // We'll descend into everything else.
     default:
       return true;
   }
 
-  if (!Graph.canIncludeDeclAsNode(D)) {
-    return false;
+  auto SG = getModuleSymbolGraph(D->getModuleContext());
+
+  // If this is an extension, let's check that it implies some new conformances,
+  // potentially with generic requirements.
+  if (const auto *Extension = dyn_cast<ExtensionDecl>(D)) {
+    const auto *ExtendedNominal = Extension->getExtendedNominal();
+    // Ignore effecively private decls.
+    if (ExtendedNominal->hasUnderscoredNaming()) {
+      return false;
+    }
+
+    // If there are some protocol conformances on this extension, we'll
+    // grab them for some new conformsTo relationships.
+    if (!Extension->getInherited().empty()) {
+      auto ExtendedSG =
+          getModuleSymbolGraph(ExtendedNominal->getModuleContext());
+
+      // The symbol graph to use to record these relationships.
+      SmallVector<const ProtocolDecl *, 4> Protocols;
+      SmallVector<const ProtocolCompositionType *, 4> UnexpandedCompositions;
+
+      auto HandleProtocolOrComposition = [&](Type Ty) {
+        if (const auto *Proto =
+            dyn_cast_or_null<ProtocolDecl>(Ty->getAnyNominal())) {
+          Protocols.push_back(Proto);
+        } else if (const auto *Comp = Ty->getAs<ProtocolCompositionType>()) {
+          UnexpandedCompositions.push_back(Comp);
+        } else {
+          abort();
+        }
+      };
+
+      for (const auto InheritedLoc : Extension->getInherited()) {
+        auto InheritedTy = InheritedLoc.getType();
+        if (!InheritedTy) {
+          continue;
+        }
+        HandleProtocolOrComposition(InheritedTy);
+      }
+
+      while (!UnexpandedCompositions.empty()) {
+        const auto *Comp = UnexpandedCompositions.pop_back_val();
+        for (const auto Member : Comp->getMembers()) {
+          HandleProtocolOrComposition(Member);
+        }
+      }
+
+      Symbol Source(ExtendedSG, ExtendedNominal, nullptr);
+
+      for (const auto *Proto : Protocols) {
+        Symbol Target(&MainGraph, Proto, nullptr);
+        ExtendedSG->recordEdge(Source, Target, RelationshipKind::ConformsTo(),
+                               Extension);
+      }
+
+      // While we won't record this node per se, or all of the other kinds of
+      // relationships, we might establish some synthesized members because we
+      // extended an external type.
+      if (ExtendedNominal->getModuleContext() != &M) {
+        ExtendedSG->recordConformanceSynthesizedMemberRelationships({
+          ExtendedSG,
+          ExtendedNominal,
+          nullptr
+        });
+      }
+    }
+
+    // Continue looking into the extension.
+    return true;
   }
 
   auto *VD = cast<ValueDecl>(D);
 
+  if (!SG->canIncludeDeclAsNode(VD)) {
+    return false;
+  }
+
   // If this symbol extends a type from another module, record it in that
   // module's symbol graph, which will be emitted separately.
   if (const auto *Extension
-          = dyn_cast_or_null<ExtensionDecl>(VD->getInnermostDeclContext())) {
+      = dyn_cast_or_null<ExtensionDecl>(VD->getDeclContext())) {
     if (const auto *ExtendedNominal = Extension->getExtendedNominal()) {
       auto ExtendedModule = ExtendedNominal->getModuleContext();
+      auto ExtendedSG = getModuleSymbolGraph(ExtendedModule);
       if (ExtendedModule != &M) {
-        auto &SG = getExtendedModuleSymbolGraph(ExtendedModule);
-        SG.recordNode(Symbol(&Graph, VD, nullptr));
+        ExtendedSG->recordNode(Symbol(ExtendedSG, VD, nullptr));
         return true;
       }
     }
   }
 
   // Otherwise, record this in the main module `M`'s symbol graph.
-  Graph.recordNode(Symbol(&Graph, VD, nullptr));
+  SG->recordNode(Symbol(SG, VD, nullptr));
 
   return true;
 }

--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.h
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.h
@@ -47,8 +47,8 @@ struct SymbolGraphASTWalker : public SourceEntityWalker {
   /// The module that this symbol graph will represent.
   const ModuleDecl &M;
 
-  /// The symbol graph for a module.
-  SymbolGraph Graph;
+  /// The symbol graph for the main module of interest.
+  SymbolGraph MainGraph;
 
   /// A map of modules whose types were extended by the main module of interest `M`.
   llvm::DenseMap<ModuleDecl *, SymbolGraph *> ExtendedModuleGraphs;
@@ -61,7 +61,7 @@ struct SymbolGraphASTWalker : public SourceEntityWalker {
   // MARK: - Utilities
 
   /// Get a "sub" symbol graph for the parent module of a type that the main module `M` is extending.
-  SymbolGraph &getExtendedModuleSymbolGraph(ModuleDecl *M);
+  SymbolGraph *getModuleSymbolGraph(ModuleDecl *M);
 
   // MARK: - SourceEntityWalker
 

--- a/lib/SymbolGraphGen/SymbolGraphGen.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphGen.cpp
@@ -66,12 +66,12 @@ symbolgraphgen::emitSymbolGraphForModule(ModuleDecl *M,
   }
 
   llvm::errs()
-    << "Found " << Walker.Graph.Nodes.size() << " symbols and "
-    << Walker.Graph.Edges.size() << " relationships.\n";
+    << "Found " << Walker.MainGraph.Nodes.size() << " symbols and "
+    << Walker.MainGraph.Edges.size() << " relationships.\n";
 
   int Success = EXIT_SUCCESS;
 
-  Success |= serializeSymbolGraph(Walker.Graph, Options);
+  Success |= serializeSymbolGraph(Walker.MainGraph, Options);
 
   for (auto Pair : Walker.ExtendedModuleGraphs) {
     Success |= serializeSymbolGraph(*Pair.getSecond(), Options);

--- a/test/SymbolGraph/Relationships/Synthesized/ConditionalConformance.swift
+++ b/test/SymbolGraph/Relationships/Synthesized/ConditionalConformance.swift
@@ -1,0 +1,66 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name ConditionalConformance -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name ConditionalConformance -I %t -pretty-print -output-dir %t
+
+// R\UN: %FileCheck %s --input-file %t/ConditionalConformance.symbols.json
+// RUN: %FileCheck %s --input-file %t/ConditionalConformance.symbols.json --check-prefix=SYNTH
+// RUN: %FileCheck %s --input-file %t/ConditionalConformance.symbols.json --check-prefix=CONFORMS
+// RUN: %FileCheck %s --input-file %t/ConditionalConformance.symbols.json --check-prefix=MEMBER
+
+// RUN: %FileCheck %s --input-file %t/ConditionalConformance@Swift.symbols.json --check-prefix=SYNTHEXT
+// RUN: %FileCheck %s --input-file %t/ConditionalConformance@Swift.symbols.json --check-prefix=CONFORMSEXT
+// RUN: %FileCheck %s --input-file %t/ConditionalConformance@Swift.symbols.json --check-prefix=MEMBEREXT
+
+// Relationships to Swift.Array should only go into the @Swift file.
+// C\HECK-NOT: "s:Sa"
+
+public protocol P {
+  func foo()
+}
+
+extension P {
+  public func foo() {}
+}
+
+public struct S<T> {
+  var x: T
+  public init(x: T) {
+    self.x = x
+  }
+}
+
+// CONFORMS: "kind": "conformsTo"
+// CONFORMS-NEXT: "source": "s:22ConditionalConformance1SV"
+// CONFORMS-NEXT: "target": "s:22ConditionalConformance1PP"
+// CONFORMS-NEXT: swiftConstraints
+// CONFORMS: "kind": "sameType"
+// CONFORMS-NEXT: "lhs": "T"
+// CONFORMS-NEXT: "rhs": "Int"
+
+extension S: P where T == Int {
+  // SYNTH: "source": "s:22ConditionalConformance1PPAAE3fooyyF::SYNTHESIZED::s:22ConditionalConformance1SV"
+  // SYNTH-NEXT: "target": "s:22ConditionalConformance1SV"
+
+  // MEMBER: "source": "s:22ConditionalConformance1SVAASiRszlE3baryyF",
+  // MEMBER-NEXT: "target": "s:22ConditionalConformance1SV"
+  public func bar() {
+    foo()
+  }
+}
+
+// CONFORMSEXT: "kind": "conformsTo"
+// CONFORMSEXT-NEXT: "source": "s:Sa"
+// CONFORMSEXT-NEXT: "target": "s:22ConditionalConformance1PP"
+// CONFORMSEXT-NEXT: swiftConstraints
+// CONFORMSEXT: "kind": "sameType"
+// CONFORMSEXT-NEXT: "lhs": "Element"
+// CONFORMSEXT-NEXT: "rhs": "Int"
+
+extension Array: P where Element == Int {
+  // SYNTHEXT: "source": "s:22ConditionalConformance1PPAAE3fooyyF::SYNTHESIZED::s:Sa"
+  // SYNTHEXT-NEXT: "target": "s:Sa"
+
+  // MEMBEREXT: "source": "s:Sa22ConditionalConformanceSiRszlE3baryyF",
+  // MEMBEREXT-NEXT: "target": "s:Sa",
+  public func bar() {}
+}


### PR DESCRIPTION
Requirements on extensions were only being gathered indirectly. This adds a new
optional field to `conformsTo` relationship edges, `swiftConstraints`, which
provides the requirements there.

rdar://60091161