### PR TITLE
Add _mangledTypeName to allow round trips T->mangledName->T

### DIFF
--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -1082,7 +1082,14 @@ struct TypeNamePair {
 ///   -> (UnsafePointer<UInt8>, Int)
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
 TypeNamePair
-swift_getTypeName(const Metadata *type, bool qualified);  
+swift_getTypeName(const Metadata *type, bool qualified);
+
+/// Return the mangled name of a Swift type represented by a metadata object.
+/// func _getMangledTypeName(_ type: Any.Type)
+///   -> (UnsafePointer<UInt8>, Int)
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+TypeNamePair
+swift_getMangledTypeName(const Metadata *type);
 
 } // end namespace swift
 

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -78,6 +78,23 @@ func _typeName(_ type: Any.Type, qualified: Bool = true) -> String {
     UnsafeBufferPointer(start: stringPtr, count: count)).0
 }
 
+@_silgen_name("swift_getMangledTypeName")
+public func _getMangledTypeName(_ type: Any.Type)
+  -> (UnsafePointer<UInt8>, Int)
+
+/// Returns the mangled name for a given type.
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+public // SPI
+func _mangledTypeName<T>(_ type: T.Type) -> String? {
+  let (stringPtr, count) = _getMangledTypeName(type)
+  guard count > 0 else {
+    return nil
+  }
+
+  return String._fromUTF8Repairing(
+      UnsafeBufferPointer(start: stringPtr, count: count)).0
+}
+
 /// Lookup a class given a name. Until the demangled encoding of type
 /// names is stabilized, this is limited to top-level class names (Foo.bar).
 public // SPI(Foundation)

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -92,8 +92,12 @@ func _mangledTypeName<T>(_ type: T.Type) -> String? {
     return nil
   }
 
-  return String._fromUTF8Repairing(
-      UnsafeBufferPointer(start: stringPtr, count: count)).0
+  let (result, repairsMade) = String._fromUTF8Repairing(
+      UnsafeBufferPointer(start: stringPtr, count: count))
+
+  precondition(!repairsMade, "repairs made to _mangledTypeName, this is not expected since names should always valid UTF-8")
+
+  return result
 }
 
 /// Lookup a class given a name. Until the demangled encoding of type

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -78,6 +78,7 @@ func _typeName(_ type: Any.Type, qualified: Bool = true) -> String {
     UnsafeBufferPointer(start: stringPtr, count: count)).0
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 @_silgen_name("swift_getMangledTypeName")
 public func _getMangledTypeName(_ type: Any.Type)
   -> (UnsafePointer<UInt8>, Int)

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -441,5 +441,34 @@ DemangleToMetadataTests.test("Nested types in same-type-constrained extensions")
   // V !: P3 in InnerTEqualsConformsToP1
 }
 
+if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
+  DemangleToMetadataTests.test("Round-trip with _mangledTypeName and _typeByName") {
+    func roundTrip<T>(_ type: T.Type) {
+      let mangledName: String? = _mangledTypeName(type)
+      let recoveredType: Any.Type? = _typeByName(mangledName!)
+      expectEqual(String(reflecting: type), String(reflecting: recoveredType!))
+      expectEqual(type, recoveredType! as! T.Type)
+    }
+
+    roundTrip(Int.self)
+    roundTrip(String.self)
+    roundTrip(ConformsToP2AndP3.self)
+    roundTrip(SG12<ConformsToP1AndP2, ConformsToP1AndP2>.self)
+    roundTrip(SG12<ConformsToP1AndP2, ConformsToP1AndP2>.InnerTEqualsU<ConformsToP3>.self)
+    roundTrip(SG12<ConformsToP1, ConformsToP2>.InnerTEqualsConformsToP1<ConformsToP3>.self)
+    roundTrip(SG12<ConformsToP1, ConformsToP2>.InnerUEqualsConformsToP2<ConformsToP3>.self)
+  }
+
+  DemangleToMetadataTests.test("Check _mangledTypeName, _typeName use appropriate cache keys") {
+    // sanity check that name functions use the right keys to store cached names:
+    for _ in 1...2 {
+      expectEqual("Si", _mangledTypeName(Int.self)!)
+      expectEqual("Swift.Int", _typeName(Int.self, qualified: true))
+      expectEqual("Int", _typeName(Int.self, qualified: false))
+    }
+  }
+}
+
+
 runAllTests()
 


### PR DESCRIPTION
This introduces a new __underscored_ function that allows to perform name mangling of types in-process. This can be used to perform round-trips from a type, to a mangled name, and back again.

This is useful in certain serialization scenarios, and just generally "completes the package" - since we can go from mangled names to Types, why not go the other way around in runtime as well.

cc @DougGregor @jckarter 
cc @milseman in case there's something stdlib specific I should adjust here (naming, attributes etc)

--- 

While this does_ NOT_ address any of the API needs as discussed in [SE-0262: Demangle function](https://forums.swift.org/t/returned-for-revision-se-0262-demangle-function/28186), it adds another piece to eventually complete the puzzle. I.e. perhaps in the future we can revise SE-262 to be about _mangling_ in general, and then would also include this ability there? 

This is out of scope of this PR and would be taken through the Swift Evolution process however.