### PR TITLE
[semantic-arc-opts] Refactor out reinitializing the worklist into method drainVisitedSinceLastMutationIntoWorklist and add some types/comments.

### DIFF
--- a/lib/SILOptimizer/Transforms/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Transforms/SemanticARCOpts.cpp
@@ -673,6 +673,18 @@ struct SemanticARCOptVisitor
     eraseInstruction(i);
   }
 
+  /// Pop values off of visitedSinceLastMutation, adding .some values to the
+  /// worklist.
+  void drainVisitedSinceLastMutationIntoWorklist() {
+    while (!visitedSinceLastMutation.empty()) {
+      Optional<SILValue> nextValue = visitedSinceLastMutation.pop_back_val();
+      if (!nextValue.hasValue()) {
+        continue;
+      }
+      worklist.insert(*nextValue);
+    }
+  }
+
   /// Remove all results of the given instruction from the worklist and then
   /// erase the instruction. Assumes that the instruction does not have any
   /// users left.
@@ -686,13 +698,7 @@ struct SemanticARCOptVisitor
     i->eraseFromParent();
 
     // Add everything else from visitedSinceLastMutation to the worklist.
-    for (auto opt : visitedSinceLastMutation) {
-      if (!opt.hasValue()) {
-        continue;
-      }
-      worklist.insert(*opt);
-    }
-    visitedSinceLastMutation.clear();
+    drainVisitedSinceLastMutationIntoWorklist();
   }
 
   InstModCallbacks getCallbacks() {
@@ -999,14 +1005,9 @@ bool SemanticARCOptVisitor::optimize() {
     assumingAtFixedPoint = true;
     SWIFT_DEFER { assumingAtFixedPoint = false; };
 
-    // Add everything in visitedSinceLastMutation to the worklist.
-    for (auto opt : visitedSinceLastMutation) {
-      if (!opt.hasValue()) {
-        continue;
-      }
-      worklist.insert(*opt);
-    }
-    visitedSinceLastMutation.clear();
+    // Add everything in visitedSinceLastMutation to the worklist so we
+    // recompute our fixed point.
+    drainVisitedSinceLastMutationIntoWorklist();
 
     // Then re-run the worklist. We shouldn't modify anything since we are at a
     // fixed point and are just using this to seed the


### PR DESCRIPTION
I was doing this in two places. It makes sense to refactor it out as such.

NFC.