### PR TITLE
[stdlib] speed up `reversed()` of `Sequence`

### DIFF
--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -714,18 +714,21 @@ extension Sequence {
       var result = Array(self)
       let count = result.count
       for i in 0..<count/2 {
-        result.swapAt(i, count - ((i + 1) as Int))      }
+        result.swapAt(i, count - ((i + 1) as Int))
+      }
       return result
     } else {
       var iterator = makeIterator()
-      var result = [Element](unsafeUninitializedCapacity: underestimatedCount) { buf, initedCount in
+      var result: [Element] =
+        .init(unsafeUninitializedCapacity: underestimatedCount)
+      { buf, initializedCount in
         for i in 0..<underestimatedCount {
           guard let next = iterator.next() else {
-              preconditionFailure("underestimatedCount greater than count")
+            _internalInvariantFailure("underestimatedCount greater than count")
           }
           buf[underestimatedCount - i - 1] = next
         }
-        initedCount = underestimatedCount
+        initializedCount = underestimatedCount
       }
       while let next = iterator.next() {
         result.insert(next, at: 0)

--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -718,14 +718,14 @@ extension Sequence {
       return result
     } else {
       var iterator = makeIterator()
-      var result = [Element](unsafeUninitializedCapacity: underestimatedCount) { buf, count in
+      var result = [Element](unsafeUninitializedCapacity: underestimatedCount) { buf, initedCount in
         for i in 0..<underestimatedCount {
           guard let next = iterator.next() else {
               preconditionFailure("underestimatedCount greater than count")
           }
           buf[underestimatedCount - i - 1] = next
         }
-        count = underestimatedCount
+        initedCount = underestimatedCount
       }
       while let next = iterator.next() {
         result.insert(next, at: 0)

--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -712,10 +712,7 @@ extension Sequence {
     let underestimatedCount = self.underestimatedCount
     if underestimatedCount == 0 {
       var result = Array(self)
-      let count = result.count
-      for i in 0..<count/2 {
-        result.swapAt(i, count - ((i + 1) as Int))
-      }
+      result.reverse()
       return result
     } else {
       var iterator = makeIterator()

--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -710,28 +710,32 @@ extension Sequence {
   @inlinable
   public __consuming func reversed() -> [Element] {
     let underestimatedCount = self.underestimatedCount
-    if underestimatedCount == 0 {
+    guard underestimatedCount > 0 else {
       var result = Array(self)
       result.reverse()
       return result
-    } else {
-      var iterator = makeIterator()
-      var result: [Element] =
-        .init(unsafeUninitializedCapacity: underestimatedCount)
-      { buf, initializedCount in
-        for i in 0..<underestimatedCount {
-          guard let next = iterator.next() else {
-            _internalInvariantFailure("underestimatedCount greater than count")
-          }
-          buf[underestimatedCount - i - 1] = next
-        }
-        initializedCount = underestimatedCount
-      }
-      while let next = iterator.next() {
-        result.insert(next, at: 0)
-      }
-      return result
     }
+    var iterator = makeIterator()
+    var result: [Element] =
+      .init(unsafeUninitializedCapacity: underestimatedCount)
+    { buf, initializedCount in
+      for i in 0..<underestimatedCount {
+        guard let next = iterator.next() else {
+          _internalInvariantFailure("underestimatedCount greater than count")
+        }
+        buf[underestimatedCount - i - 1] = next
+      }
+      initializedCount = underestimatedCount
+    }
+    var undercountedElements: [Element] = []
+    while let next = iterator.next() {
+      undercountedElements.append(next)
+    }
+    guard undercountedElements.isEmpty else {
+      undercountedElements.reverse()
+      return undercountedElements + result
+    }
+    return result
   }
 }
 

--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -716,7 +716,7 @@ extension Sequence {
       return result
     }
     var iterator = makeIterator()
-    var result: [Element] =
+    let result: [Element] =
       .init(unsafeUninitializedCapacity: underestimatedCount)
     { buf, initializedCount in
       for i in 0..<underestimatedCount {

--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -734,6 +734,11 @@ extension Sequence {
     guard undercountedElements.isEmpty else {
       undercountedElements.reverse()
       return undercountedElements + result
+      // is there more effective way to do this 👆🏻?
+      //underestimatedCount.append(result)
+      //return underestimatedCount
+      //result.insert(contentsOf: undercountedElements, at: 0)
+      //return result
     }
     return result
   }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Speeds up reversing of sequences which provide reasonable `underestimatedCount`.
For sequence with count 1000  and underestimatedCount 990 speed up is 7 times.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
