### PR TITLE
Module version checking

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -171,6 +171,9 @@ Globals
   global ::= entity 'Wvd'                // field offset
   global ::= entity 'WC'                 // resilient enum tag index
 
+  global ::= module identifier 'Tw'      // module hash for version checking
+  global ::= module 'Tw'                 // module version table
+
 A direct symbol resolves directly to the address of an object.  An
 indirect symbol resolves to the address of a pointer to the object.
 They are distinct manglings to make a certain class of bugs

--- a/include/swift/Demangling/DemangleNodes.def
+++ b/include/swift/Demangling/DemangleNodes.def
@@ -280,5 +280,8 @@ NODE(OpaqueTypeDescriptorAccessorVar)
 NODE(OpaqueReturnType)
 CONTEXT_NODE(OpaqueReturnTypeOf)
 
+// Added in Swift 5.1
+NODE(ModuleHash)
+
 #undef CONTEXT_NODE
 #undef NODE

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -266,6 +266,9 @@ public:
   /// Should we enable the dependency verifier for all primary files known to this frontend?
   bool EnableIncrementalDependencyVerifier = false;
 
+  /// Disable version checking for swiftmodule files.
+  bool DisableModuleVersionChecking = false;
+
   /// The different modes for validating TBD against the LLVM IR.
   enum class TBDValidationMode {
     Default,        ///< Do the default validation for the current platform.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -189,6 +189,11 @@ def verify_incremental_dependencies :
   Flags<[FrontendOption, HelpHidden]>,
   HelpText<"Enable the dependency verifier for each frontend job">;
 
+def disable_module_version_checking :
+  Flag<["-"], "disable-module-version-checking">,
+  Flags<[FrontendOption, HelpHidden]>,
+  HelpText<"Disable module version checking">;
+
 def driver_emit_fine_grained_dependency_dot_file_after_every_import :
 Flag<["-"], "driver-emit-fine-grained-dependency-dot-file-after-every-import">,
 InternalDebugOpt,

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -131,6 +131,7 @@ namespace swift {
     bool SerializeAllSIL = false;
     bool SerializeOptionsForDebugging = false;
     bool IsSIB = false;
+    bool writeModuleHash = false;
   };
 
 } // end namespace swift

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -2369,6 +2369,14 @@ NodePointer Demangler::demangleThunkOrSpecialization() {
         return nullptr;
       return createNode(Node::Kind::OutlinedBridgedMethod, Params);
     }
+    case 'w': {
+      NodePointer hash = popNode(Node::Kind::Identifier);
+      NodePointer module = popNode(Node::Kind::Identifier);
+      if (module)
+        return createWithChildren(Node::Kind::ModuleHash, module, hash);
+      module = hash;
+      return createWithChild(Node::Kind::ModuleHash, module);
+    }
     default:
       return nullptr;
   }

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -533,6 +533,7 @@ private:
     case Node::Kind::OpaqueTypeDescriptorSymbolicReference:
     case Node::Kind::OpaqueReturnType:
     case Node::Kind::OpaqueReturnTypeOf:
+    case Node::Kind::ModuleHash:
       return false;
     }
     printer_unreachable("bad node kind");
@@ -2370,6 +2371,18 @@ NodePointer NodePrinter::print(NodePointer Node, bool asPrefixContext) {
     return nullptr;
   case Node::Kind::AccessorFunctionReference:
     Printer << "accessor function at " << Node->getIndex();
+    return nullptr;
+  case Node::Kind::ModuleHash:
+    if (Node->getNumChildren() == 2) {
+      Printer << "matching version ";
+      print(Node->getChild(1));
+      Printer << " of module ";
+      print(Node->getChild(0));
+    } else {
+      Printer << "module ";
+      print(Node->getChild(0));
+      Printer << " version table";
+    }
     return nullptr;
   }
   printer_unreachable("bad node kind!");

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -2089,6 +2089,9 @@ void Remangler::mangleOpaqueTypeDescriptorAccessorVar(Node *node) {
 void Remangler::mangleAccessorFunctionReference(Node *node) {
   unreachable("can't remangle");
 }
+void Remangler::mangleModuleHash(Node *node) {
+  unreachable("can't remangle");
+}
 
 /// The top-level interface to the remangler.
 std::string Demangle::mangleNodeOld(NodePointer node) {

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -2477,6 +2477,14 @@ void Remangler::mangleOpaqueType(Node *node) {
 
   addSubstitution(entry);
 }
+
+void Remangler::mangleModuleHash(Node *node) {
+  mangle(node->getChild(0));
+  if (node->getNumChildren() > 1)
+    mangle(node->getChild(1));
+  Buffer << "Tw";
+}
+
 void Remangler::mangleAccessorFunctionReference(Node *node) {
   unreachable("can't remangle");
 }

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -178,6 +178,9 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.ImportUnderlyingModule |= Args.hasArg(OPT_import_underlying_module);
   Opts.EnableIncrementalDependencyVerifier |= Args.hasArg(OPT_verify_incremental_dependencies);
 
+  Opts.DisableModuleVersionChecking |=
+    Args.hasArg(OPT_disable_module_version_checking);
+
   computeImportObjCHeaderOptions();
   computeImplicitImportModuleNames();
   computeLLVMArgs();

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -173,6 +173,12 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
   serializationOpts.SerializeOptionsForDebugging =
       opts.SerializeOptionsForDebugging.getValueOr(!moduleIsPublic);
 
+  serializationOpts.writeModuleHash =
+      !opts.DisableModuleVersionChecking &&
+      !opts.EnableLibraryEvolution &&
+      opts.InputsAndOutputs.isWholeModule() &&
+      opts.RequestedAction != FrontendOptions::ActionType::MergeModules;
+
   return serializationOpts;
 }
 

--- a/lib/FrontendTool/TBD.cpp
+++ b/lib/FrontendTool/TBD.cpp
@@ -94,6 +94,10 @@ static bool validateSymbolSet(DiagnosticEngine &diags,
     llvm::Mangler::getNameWithPrefix(name, unmangledName,
                                      IRModule.getDataLayout());
 
+    // Ignore module hash symbols.
+    if (name.endswith("Tw"))
+      continue;
+
     auto value = nameValue.getValue();
     if (auto GV = dyn_cast<llvm::GlobalValue>(value)) {
       // Is this a symbol that should be listed?

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -327,3 +327,16 @@ std::string IRGenMangler::mangleSymbolNameForGenericEnvironment(
   appendGenericSignature(genericSig);
   return finalize();
 }
+
+std::string IRGenMangler::mangleModuleHash(ModuleDecl *module) {
+  beginMangling();
+  appendIdentifier(module->getName().str());
+  if (module->hash.isValid()) {
+    SmallString<32> hashStr("V");
+    hashStr += module->hash.readableStr();
+    appendIdentifier(hashStr.str());
+  }
+  appendOperator("Tw");
+  return finalize();
+}
+                                                

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -550,6 +550,9 @@ public:
 
   std::string mangleSymbolNameForGenericEnvironment(
                                                 CanGenericSignature genericSig);
+                                                
+  std::string mangleModuleHash(ModuleDecl *module);
+                                                
 protected:
   SymbolicMangling
   withSymbolicReferences(IRGenModule &IGM,

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -95,6 +95,9 @@ class ModuleFile
   /// A callback to be invoked every time a type was deserialized.
   std::function<void(Type)> DeserializedTypeCallback;
 
+  /// A hash of the written swiftmodule file.
+  ModuleDecl::Hash moduleHash;
+
   /// Is this module file actually a .sib file? .sib files are serialized SIL at
   /// arbitrary granularity and arbitrary stage; unlike serialized Swift
   /// modules, which are assumed to contain canonical SIL for an entire module.
@@ -513,6 +516,8 @@ public:
     assert(FileContext && "no associated context yet");
     return FileContext;
   }
+
+  const ModuleDecl::Hash &getModuleHash() const { return moduleHash; }
 
 private:
   /// Read an on-disk decl hash table stored in index_block::DeclListLayout

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 545; // SILFunctionType pattern sigs/subs
+const uint16_t SWIFTMODULE_VERSION_MINOR = 546; // Module hashes
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -704,6 +704,12 @@ enum BlockID {
   ///
   /// \sa decl_locs_block
   DECL_LOCS_BLOCK_ID,
+  
+  /// The hash block, which contains a MD5 hash of the whole module file.
+  ///
+  /// This block is optional and only written if the module is not compiled
+  /// with library evolution.
+  HASH_BLOCK_ID
 };
 
 /// The record types within the control block.
@@ -2026,6 +2032,15 @@ namespace decl_member_tables_block {
     BCBlob  // maps from DeclIDs to DeclID vectors
   >;
 }
+
+namespace hash_block {
+  enum RecordKind {
+    HASH_DATA = 1,
+  };
+
+  using HashLayout = BCRecordLayout<HASH_DATA, BCBlob>;
+}
+
 
 } // end namespace serialization
 } // end namespace swift

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -283,6 +283,8 @@ private:
   /// if the module can be loaded.
   void writeHeader(const SerializationOptions &options = {});
 
+  void writeHash(ModuleDecl *M);
+
   /// Writes the dependencies used to build this module: its imported
   /// modules and its source files.
   void writeInputBlock(const SerializationOptions &options);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -637,6 +637,7 @@ FileUnit *SerializedModuleLoaderBase::loadAST(
                        &extendedInfo);
   if (loadInfo.status == serialization::Status::Valid) {
     M.setResilienceStrategy(extendedInfo.getResilienceStrategy());
+    M.hash = loadedModuleFile->getModuleHash();
 
     // We've loaded the file. Now try to bring it into the AST.
     auto fileUnit = new (Ctx) SerializedASTFile(M, *loadedModuleFile,

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -329,6 +329,8 @@ _$S3BBBBf0602365061_ ---> _$S3BBBBf0602365061_
 _$S3BBBBi0602365061_ ---> _$S3BBBBi0602365061_
 _$S3BBBBv0602365061_ ---> _$S3BBBBv0602365061_
 _T0lxxxmmmTk ---> _T0lxxxmmmTk
+$s3Mod33V373144c8ea0e67bb515b6c5ae528888dTw ---> matching version V373144c8ea0e67bb515b6c5ae528888d of module Mod
+$s3ModTw ---> module Mod version table
 $s4Test5ProtoP8IteratorV10collectionAEy_qd__Gqd___tcfc ---> Test.Proto.Iterator.init(collection: A1) -> Test.Proto.Iterator<A1>
 $s4test3fooV4blahyAA1SV1fQryFQOy_Qo_AHF ---> test.foo.blah(<<opaque return type of test.S.f() -> some>>.0) -> <<opaque return type of test.S.f() -> some>>.0
 $S3nix8MystructV1xACyxGx_tcfc7MyaliasL_ayx__GD ---> Myalias #1 in nix.Mystruct<A>.init(x: A) -> nix.Mystruct<A>

--- a/test/Interpreter/SDK/autolinking.swift
+++ b/test/Interpreter/SDK/autolinking.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: echo "int global() { return 42; }" | %clang -dynamiclib -o %t/libLinkMe.dylib -x c -
-// RUN: %target-swift-frontend -emit-module -parse-stdlib -o %t -module-name LinkMe -module-link-name LinkMe %S/../../Inputs/empty.swift
+// RUN: %target-swift-frontend -emit-module -parse-stdlib -disable-module-version-checking -o %t -module-name LinkMe -module-link-name LinkMe %S/../../Inputs/empty.swift
 
 // RUN: %target-jit-run -DIMPORT %s -I %t -L %t 2>&1
 // RUN: %target-jit-run -lLinkMe %s -L %t 2>&1

--- a/test/Serialization/module-version-check.swift
+++ b/test/Serialization/module-version-check.swift
@@ -1,0 +1,38 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-library -o %t/%target-library-name(Test) -emit-module -module-link-name Test -DWRONG_MODULE -wmo %s
+// RUN: cp  %t/%target-library-name(Test)  %t/wrong_%target-library-name(Test)
+// RUN: %target-build-swift -emit-library -o %t/%target-library-name(Test) -emit-module -module-link-name Test -DMODULE -wmo %s
+// RUN: cp  %t/wrong_%target-library-name(Test)  %t/%target-library-name(Test)
+// RUN: not %target-build-swift -I %t -L %t -wmo -o %t/a.out -DMAIN %s 2>&1 | %FileCheck %s
+
+
+// CHECK: Undefined symbols
+// CHECK-NEXT: "_$s4Test{{.*}}Tw"
+
+#if MODULE
+
+@inlinable
+public func foo(_ x: Int) -> Int {
+  return x + 1
+}
+
+#endif
+
+#if WRONG_MODULE
+
+@inlinable
+public func foo(_ x: Int) -> Int {
+  return x + 2
+}
+
+#endif
+
+#if MAIN
+
+import Test
+
+public func callit() {
+  print(foo(27))
+}
+ 
+#endif

--- a/test/Serialization/operator.swift
+++ b/test/Serialization/operator.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_operator.swift
+// RUN: %target-swift-frontend -emit-module -disable-module-version-checking -o %t %S/Inputs/def_operator.swift
 // RUN: llvm-bcanalyzer %t/def_operator.swiftmodule | %FileCheck %s
 // RUN: %target-swift-frontend -typecheck -I%t %s
 // RUN: %target-swift-frontend -interpret -I %t -DINTERP %s | %FileCheck --check-prefix=OUTPUT %s


### PR DESCRIPTION
Emit symbols in the binary which let the linker issue an error if the swiftmodule file does not match the generated archive/dylib.

Store an MD5 hash in the swiftmodule file and generate a symbol in the binary which encodes that hash.
For each imported module, reference the module hash symbol.
If the swiftmodule does not match, the linker will issue an undefined-symbol error.

Of course, this is only done for modules which are not compiled with library evolution.
In the current implementation version checking only works with whole-module-compilation.

The reason for this feature is that I spent too many days of my life with debugging horrible crashes which turned out to be just such version mismatches.