### PR TITLE
Memoize the ObjCBridgeable conformance for Swift.String

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -2876,8 +2876,50 @@ id _bridgeAnythingNonVerbatimToObjectiveC(OpaqueValue *src,
 extern "C" const _ObjectiveCBridgeableWitnessTable BRIDGING_CONFORMANCE_SYM;
 #endif
 
+struct ObjCBridgeConformanceMemo {
+  // TODO: If asserts are not being compiled, don't allocate this extra var
+  const Metadata *destType;
+  const _ObjectiveCBridgeableWitnessTable *destBridgeWitness;
+  swift_once_t fetchWitnessOnce;
+
+  const _ObjectiveCBridgeableWitnessTable *
+  findBridgeWitness(const Metadata *T) {
+    struct SetupData {
+      const Metadata *destType;
+      struct ObjCBridgeConformanceMemo *memo;
+    } setupData { T, this };
+
+    swift_once(&fetchWitnessOnce,
+               [](void *data) {
+                 struct SetupData *setupData = (struct SetupData *)data;
+                 struct ObjCBridgeConformanceMemo *memo = setupData->memo;
+                 // Check that this always gets called with the same destType.
+                 assert((memo->destType == nullptr) || (memo->destType == setupData->destType));
+                 memo->destType = setupData->destType;
+                 auto w = swift_conformsToProtocol(
+                   memo->destType, &PROTOCOL_DESCR_SYM(s21_ObjectiveCBridgeable));
+                 memo->destBridgeWitness =
+                   reinterpret_cast<const _ObjectiveCBridgeableWitnessTable *>(w);
+               }, (void *)&setupData);
+    return destBridgeWitness;
+  }
+};
+
+/// Nominal type descriptor for Swift.String.
+extern "C" const StructDescriptor NOMINAL_TYPE_DESCR_SYM(SS);
+
 static const _ObjectiveCBridgeableWitnessTable *
 findBridgeWitness(const Metadata *T) {
+  // Special case: Memoize the bridge witness for Swift.String.
+  // Swift.String is the most heavily used bridge because of the prevalence of
+  // string-keyed dictionaries in Obj-C.  It's worth burning a few words of static
+  // storage to avoid repeatedly looking up this conformance.
+  if (T->getKind() == MetadataKind::Struct
+      && (cast<StructMetadata>(T)->Description == &NOMINAL_TYPE_DESCR_SYM(SS))) {
+    static ObjCBridgeConformanceMemo memo;
+    return memo.findBridgeWitness(T);
+  }
+
   auto w = swift_conformsToProtocol(T,
                                 &PROTOCOL_DESCR_SYM(s21_ObjectiveCBridgeable));
   if (LLVM_LIKELY(w))

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -2893,19 +2893,9 @@ findBridgeWitness(const Metadata *T) {
   // storage to avoid repeatedly looking up this conformance.
   if (T->getKind() == MetadataKind::Struct) {
     auto structDescription = cast<StructMetadata>(T)->Description;
-    // Check for a _very_ small number of heavily-used types.
-    // Cache the protocol witness for these to avoid lookup overhead.
     if (structDescription == &NOMINAL_TYPE_DESCR_SYM(SS)) {
       static auto *Swift_String_ObjectiveCBridgeable = swift_conformsToObjectiveCBridgeable(T);
       return Swift_String_ObjectiveCBridgeable;
-    }
-    if (structDescription == &NOMINAL_TYPE_DESCR_SYM(SD)) {
-      static auto *Swift_Dictionary_ObjectiveCBridgeable = swift_conformsToObjectiveCBridgeable(T);
-      return Swift_Dictionary_ObjectiveCBridgeable;
-    }
-    if (structDescription == &NOMINAL_TYPE_DESCR_SYM(Sa)) {
-      static auto *Swift_Array_ObjectiveCBridgeable = swift_conformsToObjectiveCBridgeable(T);
-      return Swift_Array_ObjectiveCBridgeable;
     }
   }
 

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -2893,9 +2893,19 @@ findBridgeWitness(const Metadata *T) {
   // storage to avoid repeatedly looking up this conformance.
   if (T->getKind() == MetadataKind::Struct) {
     auto structDescription = cast<StructMetadata>(T)->Description;
+    // Check for a _very_ small number of heavily-used types.
+    // Cache the protocol witness for these to avoid lookup overhead.
     if (structDescription == &NOMINAL_TYPE_DESCR_SYM(SS)) {
       static auto *Swift_String_ObjectiveCBridgeable = swift_conformsToObjectiveCBridgeable(T);
       return Swift_String_ObjectiveCBridgeable;
+    }
+    if (structDescription == &NOMINAL_TYPE_DESCR_SYM(SD)) {
+      static auto *Swift_Dictionary_ObjectiveCBridgeable = swift_conformsToObjectiveCBridgeable(T);
+      return Swift_Dictionary_ObjectiveCBridgeable;
+    }
+    if (structDescription == &NOMINAL_TYPE_DESCR_SYM(Sa)) {
+      static auto *Swift_Array_ObjectiveCBridgeable = swift_conformsToObjectiveCBridgeable(T);
+      return Swift_Array_ObjectiveCBridgeable;
     }
   }
 


### PR DESCRIPTION
This seems to be the single most common bridge cast,
and repeated lookup seems to be a performance issue
for the common operation of bridging a string-valued
NSDictionary into Swift.  Spending a couple of static
words of memory to memoize it could be a nice perf win.

Resolves rdar://55237013
