### PR TITLE
Push Defined Functions List into DeclChecker

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1131,8 +1131,8 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
     // synthesized, it will be synthesized.
     auto *decodableProto = Context.getProtocol(KnownProtocolKind::Decodable);
     auto *encodableProto = Context.getProtocol(KnownProtocolKind::Encodable);
-    if (!evaluateTargetConformanceTo(decodableProto)) {
-      (void)evaluateTargetConformanceTo(encodableProto);
+    if (!evaluateTargetConformanceTo(encodableProto)) {
+      (void)evaluateTargetConformanceTo(decodableProto);
     }
   }
     break;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -290,20 +290,8 @@ static void bindExtensions(SourceFile &SF) {
 }
 
 static void typeCheckFunctionsAndExternalDecls(SourceFile &SF, TypeChecker &TC) {
-  unsigned currentFunctionIdx = 0;
   unsigned currentSynthesizedDecl = SF.LastCheckedSynthesizedDecl;
   do {
-    // Type check the body of each of the function in turn.  Note that outside
-    // functions must be visited before nested functions for type-checking to
-    // work correctly.
-    for (unsigned n = TC.definedFunctions.size(); currentFunctionIdx != n;
-         ++currentFunctionIdx) {
-      auto *AFD = TC.definedFunctions[currentFunctionIdx];
-      assert(!AFD->getDeclContext()->isLocalContext());
-
-      TypeChecker::typeCheckAbstractFunctionBody(AFD);
-    }
-
     // Type check synthesized functions and their bodies.
     for (unsigned n = SF.SynthesizedDecls.size();
          currentSynthesizedDecl != n;
@@ -312,15 +300,7 @@ static void typeCheckFunctionsAndExternalDecls(SourceFile &SF, TypeChecker &TC) 
       TypeChecker::typeCheckDecl(decl);
     }
 
-  } while (currentFunctionIdx < TC.definedFunctions.size() ||
-           currentSynthesizedDecl < SF.SynthesizedDecls.size());
-
-
-  for (AbstractFunctionDecl *FD : llvm::reverse(TC.definedFunctions)) {
-    TypeChecker::computeCaptures(FD);
-  }
-
-  TC.definedFunctions.clear();
+  } while (currentSynthesizedDecl < SF.SynthesizedDecls.size());
 }
 
 void swift::performTypeChecking(SourceFile &SF) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -407,10 +407,6 @@ enum class CheckedCastContextKind {
 /// The Swift type checker, which takes a parsed AST and performs name binding,
 /// type checking, and semantic analysis to produce a type-annotated AST.
 class TypeChecker final {
-public:
-  /// The list of function definitions we've encountered.
-  std::vector<AbstractFunctionDecl *> definedFunctions;
-
 private:
   TypeChecker() = default;
   ~TypeChecker() = default;

--- a/test/SILGen/synthesized_conformance_struct.swift
+++ b/test/SILGen/synthesized_conformance_struct.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-silgen %s -swift-version 4 | %FileCheck -check-prefix CHECK -check-prefix CHECK-FRAGILE %s
-// RUN: %target-swift-frontend -emit-silgen %s -swift-version 4 -enable-library-evolution | %FileCheck -check-prefix CHECK -check-prefix CHECK-RESILIENT %s
 
 struct Struct<T> {
     var x: T
@@ -29,8 +28,8 @@ struct Struct<T> {
 // CHECK:   func hash(into hasher: inout Hasher)
 // CHECK: }
 // CHECK-LABEL: extension Struct : Decodable & Encodable where T : Decodable, T : Encodable {
-// CHECK:   init(from decoder: Decoder) throws
 // CHECK:   func encode(to encoder: Encoder) throws
+// CHECK:   init(from decoder: Decoder) throws
 // CHECK: }
 
 extension Struct: Equatable where T: Equatable {}
@@ -47,11 +46,11 @@ extension Struct: Hashable where T: Hashable {}
 // CHECK-NEXT: sil hidden [ossa] @$s30synthesized_conformance_struct6StructVAASHRzlE4hash4intoys6HasherVz_tF : $@convention(method) <T where T : Hashable> (@inout Hasher, @in_guaranteed Struct<T>) -> () {
 
 extension Struct: Codable where T: Codable {}
-// CHECK-LABEL: // Struct<A>.init(from:)
-// CHECK-NEXT: sil hidden [ossa] @$s30synthesized_conformance_struct6StructVAASeRzSERzlE4fromACyxGs7Decoder_p_tKcfC : $@convention(method) <T where T : Decodable, T : Encodable> (@in Decoder, @thin Struct<T>.Type) -> (@out Struct<T>, @error Error)
-
 // CHECK-LABEL: // Struct<A>.encode(to:)
 // CHECK-NEXT: sil hidden [ossa] @$s30synthesized_conformance_struct6StructVAASeRzSERzlE6encode2toys7Encoder_p_tKF : $@convention(method) <T where T : Decodable, T : Encodable> (@in_guaranteed Encoder, @in_guaranteed Struct<T>) -> @error Error {
+
+// CHECK-LABEL: // Struct<A>.init(from:)
+// CHECK-NEXT: sil hidden [ossa] @$s30synthesized_conformance_struct6StructVAASeRzSERzlE4fromACyxGs7Decoder_p_tKcfC : $@convention(method) <T where T : Decodable, T : Encodable> (@in Decoder, @thin Struct<T>.Type) -> (@out Struct<T>, @error Error)
 
 
 // Witness tables

--- a/test/Sema/typo_correction.swift
+++ b/test/Sema/typo_correction.swift
@@ -113,13 +113,13 @@ struct Generic<T> { // expected-note {{'T' declared as parameter to type 'Generi
 }
 
 protocol P { // expected-note {{'P' previously declared here}}
-  // expected-note@-1 2{{did you mean 'P'?}}
+  // expected-note@-1 {{did you mean 'P'?}}
   // expected-note@-2 {{'P' declared here}}
   typealias a = Generic
 }
 
 protocol P {} // expected-error {{invalid redeclaration of 'P'}}
-// expected-note@-1 2{{did you mean 'P'?}}
+// expected-note@-1 {{did you mean 'P'?}}
 // expected-note@-2 {{'P' declared here}}
 
 func hasTypo() {
@@ -175,7 +175,7 @@ class CircularValidationWithTypo {
 // Crash with invalid extension that has not been bound -- https://bugs.swift.org/browse/SR-8984
 protocol PP {}
 
-func boo() {
+func boo() { // expected-note {{did you mean 'boo'?}}
   extension PP { // expected-error {{declaration is only valid at file scope}}
     func g() {
       booo() // expected-error {{use of unresolved identifier 'booo'}}
@@ -217,7 +217,7 @@ protocol P2 {
 }
 
 extension P2 {
-  func f() { // expected-note {{did you mean 'f'?}}
+  func f() {
     _ = a // expected-error {{use of unresolved identifier 'a'}}
   }
 }

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -407,7 +407,7 @@ var x23: Int, x24: Int { // expected-error{{'var' declarations with multiple var
 
 var x25: Int { // expected-error{{'var' declarations with multiple variables cannot have explicit getters/setters}}
   return 42
-}, x26: Int // expected-warning{{variable 'x26' was never used; consider replacing with '_' or removing it}}
+}, x26: Int
 
 // Properties of struct/enum/extensions
 struct S {

--- a/test/diagnostics/pretty-printed-diagnostics.swift
+++ b/test/diagnostics/pretty-printed-diagnostics.swift
@@ -80,6 +80,13 @@ foo(b:
 // CHECK:             |   ^ warning: result of operator '+' is unused
 // CHECK: [[#LINE+1]] |
 
+// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:5
+// CHECK: [[#LINE-1]] | func foo(a: Int, b: Int) {
+// CHECK: [[#LINE]]   |   a + b
+// CHECK:             |   ~   ~
+// CHECK:             |     ^ warning: result of operator '+' is unused
+// CHECK: [[#LINE+1]] | }
+
 // Test inline fix-it rendering.
 // CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:11
 // CHECK:  [[#LINE-1]] |
@@ -88,6 +95,19 @@ foo(b:
 // CHECK:              |                 ^ error: argument 'a' must precede argument 'b' [remove ', a: 2' and insert 'a: 2, ']
 // CHECK: [[#LINE+1]]  |
 
+// Test snippet truncation.
+// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:3
+// CHECK: [[#LINE-1]] | func baz() {
+// CHECK: [[#LINE]]   |   bar(a: "hello, world!")
+// CHECK:             |   ^ error: no exact matches in call to global function 'bar'
+// CHECK: [[#LINE+1]] | }
+// CHECK:   ...
+// CHECK: [[#LINE:]]  |
+// CHECK: [[#LINE+1]] | func bar(a: Int) {}
+// CHECK:             |      ^ note: candidate expects value of type 'Int' for parameter #1
+// CHECK: [[#LINE+2]] | func bar(a: Float) {}
+// CHECK:             |      ^ note: candidate expects value of type 'Float' for parameter #1
+// CHECK: [[#LINE+3]] |
 
 // CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:7
 // CHECK: [[#LINE-2]] | struct Foo {
@@ -191,24 +211,3 @@ foo(b:
 // CHECK:             |     ----
 // CHECK:             |     ^ error: argument 'a' must precede argument 'b' [remove ',\n    a: 2' and insert 'a: 2, ']
 // CHECK: [[#LINE+1]] |
-
-// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:5
-// CHECK: [[#LINE-1]] | func foo(a: Int, b: Int) {
-// CHECK: [[#LINE]]   |   a + b
-// CHECK:             |   ~   ~
-// CHECK:             |     ^ warning: result of operator '+' is unused
-// CHECK: [[#LINE+1]] | }
-
-// Test snippet truncation.
-// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:3
-// CHECK: [[#LINE-1]] | func baz() {
-// CHECK: [[#LINE]]   |   bar(a: "hello, world!")
-// CHECK:             |   ^ error: no exact matches in call to global function 'bar'
-// CHECK: [[#LINE+1]] | }
-// CHECK:   ...
-// CHECK: [[#LINE:]]  |
-// CHECK: [[#LINE+1]] | func bar(a: Int) {}
-// CHECK:             |      ^ note: candidate expects value of type 'Int' for parameter #1
-// CHECK: [[#LINE+2]] | func bar(a: Float) {}
-// CHECK:             |      ^ note: candidate expects value of type 'Float' for parameter #1
-// CHECK: [[#LINE+3]] |


### PR DESCRIPTION
Pull from the previous attempt to do this, but take a less radical tact and make the list local to the DeclChecker because there are still ordering issues with witness matching.