### PR TITLE
PrintAsObjc: strip Headers and PrivateHeaders component in header paths explicitly

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -325,9 +325,12 @@ static void writeImports(raw_ostream &out,
                               const clang::Module *module) {
     auto startIdx = allPaths.size();
     if (module->IsFramework) {
+      SmallString<64> Buffer(header.NameAsWritten);
+      llvm::sys::path::replace_path_prefix(Buffer, "Headers/", StringRef());
+      llvm::sys::path::replace_path_prefix(Buffer, "PrivateHeaders/", StringRef());
       // For framworks, the header import should start from the framework name.
       allPaths.append(module->getTopLevelModuleName());
-      llvm::sys::path::append(allPaths, header.NameAsWritten);
+      llvm::sys::path::append(allPaths, Buffer.str());
     } else {
       // Otherwise, import the header directly.
       allPaths.append(header.NameAsWritten);


### PR DESCRIPTION
We use Header::NameAsWritten to collect the path of a header belongs to a module. Due
to an unclear clang-side issue, the path may contain "Headers/" and "PrivateHeaders/". To
walk-around this potential issue, we explicit check and remove these path components
from the Swift side.

rdar://problem/60249751