### PR TITLE
[build] set linker parameters in a single way

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -732,26 +732,18 @@ function(_add_swift_host_library_single target)
     # Include LLVM Bitcode slices for iOS, Watch OS, and Apple TV OS device libraries.
     if(SWIFT_EMBED_BITCODE_SECTION)
       if(${SWIFT_HOST_VARIANT_SDK} MATCHES "(I|TV|WATCH)OS")
-        # The two branches of this if statement accomplish the same end result
-        # We are simply accounting for the fact that on CMake < 3.16
-        # using a generator expression to
-        # specify a LINKER: argument does not work,
+        target_link_options(${target} PRIVATE
+          "LINKER:-bitcode_bundle"
+          "LINKER:-lto_library,${LLVM_LIBRARY_DIR}/libLTO.dylib")
+
+        # Please note that using a generator expression to fit
+        # this in a single target_link_options does not work
+        # (at least in CMake 3.15 and 3.16),
         # since that seems not to allow the LINKER: prefix to be
         # evaluated (i.e. it will be added as-is to the linker parameters)
-        if(CMAKE_VERSION VERSION_LESS 3.16)
+        if(SWIFT_EMBED_BITCODE_SECTION_HIDE_SYMBOLS)
           target_link_options(${target} PRIVATE
-            "LINKER:-bitcode_bundle"
-            "LINKER:-lto_library,${LLVM_LIBRARY_DIR}/libLTO.dylib")
-
-          if(SWIFT_EMBED_BITCODE_SECTION_HIDE_SYMBOLS)
-            target_link_options(${target} PRIVATE
-              "LINKER:-bitcode_hide_symbols")
-          endif()
-        else()
-          target_link_options(${target} PRIVATE
-            "LINKER:-bitcode_bundle"
-            $<$<BOOL:SWIFT_EMBED_BITCODE_SECTION_HIDE_SYMBOLS>:"LINKER:-bitcode_hide_symbols">
-            "LINKER:-lto_library,${LLVM_LIBRARY_DIR}/libLTO.dylib")
+            "LINKER:-bitcode_hide_symbols")
         endif()
       endif()
     endif()


### PR DESCRIPTION
After noticing that also in CMake 3.16 the LINKER: prefix is not
expanded correctly when used in `target_link_options`, prefer to set the
linker parameters in a more verbose way and leave a comment behind on
when this behavior was observed in case we want to change the
implementation later.

Follow up to #29636.
Addresses rdar://problem/59732421



<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
