### PR TITLE
[SymbolGraph] Install `swift-symbolgraph-extract` in `compiler` insta…

### DIFF
--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -34,9 +34,9 @@ swift_create_post_build_symlink(swift
   WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
 
 add_swift_tool_symlink(swiftc swift compiler)
+add_swift_tool_symlink(swift-symbolgraph-extract swift compiler)
 add_swift_tool_symlink(swift-autolink-extract swift autolink-driver)
 add_swift_tool_symlink(swift-indent swift editor-integration)
-add_swift_tool_symlink(swift-symbolgraph-extract swift toolchain-tools)
 
 # If building as part of clang, make sure the headers are installed.
 if(NOT SWIFT_BUILT_STANDALONE)
@@ -47,6 +47,9 @@ add_dependencies(compiler swift)
 swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swiftc${CMAKE_EXECUTABLE_SUFFIX}"
                            DESTINATION "bin"
                            COMPONENT compiler)
+swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-symbolgraph-extract${CMAKE_EXECUTABLE_SUFFIX}"
+                           DESTINATION "bin"
+                           COMPONENT compiler)
 add_dependencies(autolink-driver swift)
 swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-autolink-extract${CMAKE_EXECUTABLE_SUFFIX}"
                            DESTINATION "bin"
@@ -55,7 +58,4 @@ add_dependencies(editor-integration swift)
 swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-indent${CMAKE_EXECUTABLE_SUFFIX}"
                            DESTINATION "bin"
                            COMPONENT editor-integration)
-add_dependencies(toolchain-tools swift)
-swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-symbolgraph-extract${CMAKE_EXECUTABLE_SUFFIX}"
-                           DESTINATION "bin"
-                           COMPONENT toolchain-tools)
+


### PR DESCRIPTION
…ll component

To make it show up in the default Xcode toolchain.

rdar://60241049