### PR TITLE
[OSLogOptimization] Fix a crash in OSLogOptimization pass due to capturing SIL address in closures

### DIFF
--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -606,9 +606,8 @@ SILInstruction *getInstructionFollowingValueDefinition(SILValue value) {
 /// \p value is a trivial type, return the value itself.
 SILValue makeOwnedCopyOfSILValue(SILValue value, SILFunction &fun) {
   SILType type = value->getType();
-  if (type.isTrivial(fun))
+  if (type.isTrivial(fun) || type.isAddress())
     return value;
-  assert(!type.isAddress() && "cannot make owned copy of addresses");
 
   SILInstruction *instAfterValueDefinition =
       getInstructionFollowingValueDefinition(value);

--- a/test/SILOptimizer/OSLogPrototypeCompileDiagnostics.swift
+++ b/test/SILOptimizer/OSLogPrototypeCompileDiagnostics.swift
@@ -75,7 +75,7 @@ internal enum Color {
 
 if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
 
-  // No error is expected here.
+  // Invoking the log calls in unreachable code should not crash the compiler.
   func testUnreachableLogCall(h: Logger, c: Color)  {
     let arg = 10
     switch c {
@@ -92,6 +92,14 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
         \(arg, align: .right(columns: 10))
         """)
     }
+  }
+
+  // Passing InOut values to the logger should not crash the compiler.
+  func foo(_ logger: Logger, _ mutableValue: inout String) {
+     logger.log("FMFLabelledLocation: initialized with coder \(mutableValue)")
+      // expected-error@-1 {{escaping closure captures 'inout' parameter 'mutableValue'}}
+      // expected-note@-3 {{parameter 'mutableValue' is declared 'inout'}}
+      // expected-note@-3 {{captured here}}
   }
 }
 

--- a/test/SILOptimizer/OSLogPrototypeCompileTest.swift
+++ b/test/SILOptimizer/OSLogPrototypeCompileTest.swift
@@ -600,3 +600,21 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
   }
 }
 
+protocol Proto {
+  var property: String { get set }
+}
+
+// Test capturing of address-only types in autoclosures.
+
+if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+  // CHECK-LABEL: @${{.*}}testInterpolationOfExistentialsL_
+  func testInterpolationOfExistentials(h: Logger, p: Proto) {
+    h.debug("A protocol's property \(p.property)")
+  }
+
+  // CHECK-LABEL: @${{.*}}testInterpolationOfGenericsL_
+  func testInterpolationOfGenerics<T : Proto>(h: Logger, p: T) {
+    h.debug("A generic argument's property \(p.property)")
+  }
+}
+


### PR DESCRIPTION
This bug happens in code where a exclusivity error has already been diagnosed. Passing inout to the log calls results in a compiler error since they are autoclosured and the closure is @escaping. However, this also results in a crash in the OSLogOptimization pass which hides the error from getting displayed. This commit fixes this crash

<rdar://problem/60015040>