### PR TITLE
[ConstraintSystem] Fix bug of argument reordering in matchCallArguments

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -651,58 +651,67 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
     // parameter (or even worse - OoO parameter with label re-naming),
     // we most likely have no idea what would be the best
     // diagnostic for this situation, so let's just try to re-label.
-    auto isOutOfOrderArgument = [&](bool hadLabelMismatch, unsigned argIdx,
-                                    unsigned prevArgIdx) {
-      if (hadLabelMismatch)
+    auto isOutOfOrderArgument = [&](unsigned toParamIdx, unsigned fromArgIdx,
+                                    unsigned toArgIdx) {
+      if (fromArgIdx <= toArgIdx) {
         return false;
+      }
 
-      auto newLabel = args[argIdx].getLabel();
-      auto oldLabel = args[prevArgIdx].getLabel();
+      auto newLabel = args[fromArgIdx].getLabel();
+      auto oldLabel = args[toArgIdx].getLabel();
 
-      unsigned actualIndex = prevArgIdx;
-      for (; actualIndex != argIdx; ++actualIndex) {
+      if (newLabel != params[toParamIdx].getLabel()) {
+        return false;
+      }
+
+      auto paramIdx = toParamIdx + 1;
+      for (; paramIdx < params.size(); ++paramIdx) {
         // Looks like new position (excluding defaulted parameters),
         // has a valid label.
-        if (newLabel == params[actualIndex].getLabel())
+        if (oldLabel == params[paramIdx].getLabel())
           break;
 
         // If we are moving the the position with a different label
         // and there is no default value for it, can't diagnose the
         // problem as a simple re-ordering.
-        if (!paramInfo.hasDefaultArgument(actualIndex))
+        if (!paramInfo.hasDefaultArgument(paramIdx))
           return false;
       }
 
-      for (unsigned i = actualIndex + 1, n = params.size(); i != n; ++i) {
-        if (oldLabel == params[i].getLabel())
-          break;
-
-        if (!paramInfo.hasDefaultArgument(i))
-          return false;
+      // label was not found
+      if (paramIdx == params.size()) {
+        return false;
       }
 
       return true;
     };
 
-    unsigned argIdx = 0;
+    SmallVector<unsigned, 4> paramToArgMap;
+    paramToArgMap.reserve(params.size());
+    {
+      unsigned argIdx = 0;
+      for (const auto &binding : parameterBindings) {
+        paramToArgMap.push_back(argIdx);
+        argIdx += binding.size();
+      }
+    }
+
     // Enumerate the parameters and their bindings to see if any arguments are
     // our of order
     bool hadLabelMismatch = false;
-    for (auto binding : parameterBindings) {
-      for (auto boundArgIdx : binding) {
+    for (const auto paramIdx : indices(params)) {
+      const auto toArgIdx = paramToArgMap[paramIdx];
+      const auto &binding = parameterBindings[paramIdx];
+      for (const auto paramBindIdx : indices(binding)) {
         // We've found the parameter that has an out of order
         // argument, and know the indices of the argument that
         // needs to move (fromArgIdx) and the argument location
         // it should move to (toArgIdx).
-        auto fromArgIdx = boundArgIdx;
-        auto toArgIdx = argIdx;
+        const auto fromArgIdx = binding[paramBindIdx];
 
-        // If there is no re-ordering going on, and index is past
-        // the number of parameters, it could only mean that this
-        // is variadic parameter, so let's just move on.
-        if (fromArgIdx == toArgIdx && toArgIdx >= params.size()) {
+        // Does nothing for variadic tail.
+        if (params[paramIdx].isVariadic() && paramBindIdx > 0) {
           assert(args[fromArgIdx].getLabel().empty());
-          argIdx++;
           continue;
         }
 
@@ -711,40 +720,40 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
         // one argument requires label and another one doesn't, but caller
         // doesn't provide either, problem is going to be identified as
         // out-of-order argument instead of label mismatch.
-        auto expectedLabel = params[toArgIdx].getLabel();
-        auto argumentLabel = args[fromArgIdx].getLabel();
+        const auto expectedLabel = params[paramIdx].getLabel();
+        const auto argumentLabel = args[fromArgIdx].getLabel();
 
         if (argumentLabel != expectedLabel) {
           // - The parameter is unnamed, in which case we try to fix the
           //   problem by removing the name.
           if (expectedLabel.empty()) {
             hadLabelMismatch = true;
-            if (listener.extraneousLabel(toArgIdx))
+            if (listener.extraneousLabel(paramIdx))
               return true;
           // - The argument is unnamed, in which case we try to fix the
           //   problem by adding the name.
           } else if (argumentLabel.empty()) {
             hadLabelMismatch = true;
-            if (listener.missingLabel(toArgIdx))
+            if (listener.missingLabel(paramIdx))
               return true;
           // - The argument label has a typo at the same position.
           } else if (fromArgIdx == toArgIdx) {
             hadLabelMismatch = true;
-            if (listener.incorrectLabel(toArgIdx))
-                return true;
+            if (listener.incorrectLabel(paramIdx))
+              return true;
           }
         }
 
-        if (boundArgIdx == argIdx) {
+        if (fromArgIdx == toArgIdx) {
           // If the argument is in the right location, just continue
-          argIdx++;
           continue;
         }
 
         // This situation looks like out-of-order argument but it's hard
         // to say exactly without considering other factors, because it
         // could be invalid labeling too.
-        if (isOutOfOrderArgument(hadLabelMismatch, fromArgIdx, toArgIdx))
+        if (!hadLabelMismatch &&
+            isOutOfOrderArgument(paramIdx, fromArgIdx, toArgIdx))
           return listener.outOfOrderArgument(fromArgIdx, toArgIdx);
 
         SmallVector<Identifier, 8> expectedLabels;

--- a/test/Constraints/keyword_arguments.swift
+++ b/test/Constraints/keyword_arguments.swift
@@ -240,6 +240,100 @@ func outOfOrder(_ a : Int, b: Int) {
   outOfOrder(b: 42, 52)  // expected-error {{unnamed argument #2 must precede argument 'b'}} {{14-14=52, }} {{19-23=}}
 }
 
+struct Variadics7 {
+  func f(alpha: Int..., bravo: Int) {} // expected-note {{'f(alpha:bravo:)' declared here}}
+  // expected-note@-1 {{'f(alpha:bravo:)' declared here}}
+
+  func test() {
+    // no error
+    f(bravo: 0)
+    f(alpha: 0, bravo: 3)
+    f(alpha: 0, 1, bravo: 3)
+    f(alpha: 0, 1, 2, bravo: 3)
+
+    // OoO
+    f(bravo: 0, alpha: 1) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
+    f(bravo: 0, alpha: 1, 2) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
+    f(bravo: 0, alpha: 1, 2, 3) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
+
+    // typo A
+    f(alphax: 0, bravo: 3) // expected-error {{incorrect argument label in call (have 'alphax:bravo:', expected 'alpha:bravo:')}}
+    f(alphax: 0, 1, bravo: 3) // expected-error {{extra argument in call}}
+    f(alphax: 0, 1, 2, bravo: 3) // expected-error {{extra arguments at positions #2, #3 in call}}
+
+    // typo B
+    f(bravox: 0) // expected-error {{incorrect argument label in call (have 'bravox:', expected 'bravo:')}}
+    f(alpha: 0, bravox: 3) // expected-error {{incorrect argument label in call (have 'alpha:bravox:', expected 'alpha:bravo:')}}
+    f(alpha: 0, 1, bravox: 3) // expected-error {{incorrect argument label in call (have 'alpha:_:bravox:', expected 'alpha:_:bravo:')}}
+    f(alpha: 0, 1, 2, bravox: 3) // expected-error {{incorrect argument label in call (have 'alpha:_:_:bravox:', expected 'alpha:_:_:bravo:')}}
+
+    // OoO + typo A B
+    f(bravox: 0, alphax: 1) // expected-error {{incorrect argument labels in call (have 'bravox:alphax:', expected 'alpha:bravo:')}}
+    f(bravox: 0, alphax: 1, 2) // expected-error {{extra argument in call}}
+    f(bravox: 0, alphax: 1, 2, 3) // expected-error {{extra arguments at positions #3, #4 in call}}
+  }
+}
+
+struct Variadics8 {
+  func f(alpha: Int..., bravo: Int, charlie: Int) {} // expected-note {{'f(alpha:bravo:charlie:)' declared here}}
+
+  func test() {
+    // no error
+    f(bravo: 3, charlie: 4)
+    f(alpha: 0, bravo: 3, charlie: 4)
+    f(alpha: 0, 1, bravo: 3, charlie: 4)
+    f(alpha: 0, 1, 2, bravo: 3, charlie: 4)
+
+    // OoO ACB
+    f(charlie: 3, bravo: 4) // expected-error {{argument 'bravo' must precede argument 'charlie'}}
+    f(alpha: 0, charlie: 3, bravo: 4) // expected-error {{argument 'bravo' must precede argument 'charlie'}}
+    f(alpha: 0, 1, charlie: 3, bravo: 4) // expected-error {{argument 'bravo' must precede argument 'charlie'}}
+    f(alpha: 0, 1, 2, charlie: 3, bravo: 4) // expected-error {{argument 'bravo' must precede argument 'charlie'}}
+    // OoO CAB
+    f(charlie: 0, alpha: 1, bravo: 4) // expected-error {{incorrect argument labels in call (have 'charlie:alpha:bravo:', expected 'alpha:bravo:charlie:')}}
+    f(charlie: 0, alpha: 1, 2, bravo: 4) // expected-error {{incorrect argument labels in call (have 'charlie:alpha:_:bravo:', expected 'alpha:bravo:charlie:')}}
+    f(charlie: 0, alpha: 1, 2, 3, bravo: 4) // expected-error {{incorrect argument labels in call (have 'charlie:alpha:_:_:bravo:', expected 'alpha:bravo:charlie:')}}
+    // OoO BAC
+    f(bravo: 0, alpha: 1, charlie: 4) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
+    f(bravo: 0, alpha: 1, 2, charlie: 4) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
+    f(bravo: 0, alpha: 1, 2, 3, charlie: 4) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
+
+    // typo A
+    f(alphax: 0, bravo: 3, charlie: 4) // expected-error {{incorrect argument label in call (have 'alphax:bravo:charlie:', expected 'alpha:bravo:charlie:')}}
+    f(alphax: 0, 1, bravo: 3, charlie: 4) // expected-error {{extra argument in call}}
+    f(alphax: 0, 1, 2, bravo: 3, charlie: 4) // expected-error {{extra arguments at positions #2, #3 in call}}
+    // typo B
+    f(bravox: 3, charlie: 4) // expected-error {{incorrect argument label in call (have 'bravox:charlie:', expected 'bravo:charlie:')}}
+    f(alpha: 0, bravox: 3, charlie: 4) // expected-error {{incorrect argument label in call (have 'alpha:bravox:charlie:', expected 'alpha:bravo:charlie:')}}
+    f(alpha: 0, 1, bravox: 3, charlie: 4) // expected-error {{incorrect argument label in call (have 'alpha:_:bravox:charlie:', expected 'alpha:_:bravo:charlie:')}}
+    f(alpha: 0, 1, 2, bravox: 3, charlie: 4) // expected-error {{incorrect argument label in call (have 'alpha:_:_:bravox:charlie:', expected 'alpha:_:_:bravo:charlie:')}}
+    // typo C
+    f(bravo: 3, charliex: 4) // expected-error {{incorrect argument label in call (have 'bravo:charliex:', expected 'bravo:charlie:')}}
+    f(alpha: 0, bravo: 3, charliex: 4) // expected-error {{incorrect argument label in call (have 'alpha:bravo:charliex:', expected 'alpha:bravo:charlie:')}}
+    f(alpha: 0, 1, bravo: 3, charliex: 4) // expected-error {{incorrect argument label in call (have 'alpha:_:bravo:charliex:', expected 'alpha:_:bravo:charlie:')}}
+    f(alpha: 0, 1, 2, bravo: 3, charliex: 4) // expected-error {{incorrect argument label in call (have 'alpha:_:_:bravo:charliex:', expected 'alpha:_:_:bravo:charlie:')}}
+
+    // OoO ACB + typo B
+    f(alpha: 0, charlie: 3, bravox: 4) // expected-error {{incorrect argument labels in call (have 'alpha:charlie:bravox:', expected 'alpha:bravo:charlie:')}}
+    f(alpha: 0, 1, charlie: 3, bravox: 4) // expected-error {{incorrect argument labels in call (have 'alpha:_:charlie:bravox:', expected 'alpha:bravo:charlie:')}}
+    f(alpha: 0, 1, 2, charlie: 3, bravox: 4) // expected-error {{incorrect argument labels in call (have 'alpha:_:_:charlie:bravox:', expected 'alpha:bravo:charlie:')}}
+    // OoO ACB + typo C
+    f(charliex: 3, bravo: 4) // expected-error {{incorrect argument labels in call (have 'charliex:bravo:', expected 'alpha:bravo:charlie:')}}
+    f(alpha: 0, charliex: 3, bravo: 4) // expected-error {{incorrect argument labels in call (have 'alpha:charliex:bravo:', expected 'alpha:bravo:charlie:')}}
+    f(alpha: 0, 1, charliex: 3, bravo: 4) // expected-error {{incorrect argument labels in call (have 'alpha:_:charliex:bravo:', expected 'alpha:bravo:charlie:')}}
+    f(alpha: 0, 1, 2, charliex: 3, bravo: 4) // expected-error {{incorrect argument labels in call (have 'alpha:_:_:charliex:bravo:', expected 'alpha:bravo:charlie:')}}
+
+    // OoO BAC + typo B
+    f(bravox: 0, alpha: 1, charlie: 4) // expected-error {{incorrect argument labels in call (have 'bravox:alpha:charlie:', expected 'alpha:bravo:charlie:')}}
+    f(bravox: 0, alpha: 1, 2, charlie: 4) // expected-error {{incorrect argument labels in call (have 'bravox:alpha:_:charlie:', expected 'alpha:bravo:charlie:')}}
+    f(bravox: 0, alpha: 1, 2, 3, charlie: 4) // expected-error {{incorrect argument labels in call (have 'bravox:alpha:_:_:charlie:', expected 'alpha:bravo:charlie:')}}
+    // OoO BAC + typo C
+    f(bravo: 0, alpha: 1, charliex: 4) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
+    f(bravo: 0, alpha: 1, 2, charliex: 4) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
+    f(bravo: 0, alpha: 1, 2, 3, charliex: 4) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
+  }
+}
+
 // -------------------------------------------
 // Positions around defaults and variadics 
 // -------------------------------------------
@@ -267,13 +361,18 @@ struct PositionsAroundDefaultsAndVariadics {
 
     f1(c: "3", [4])
 
-    f1(b: "2", [3]) // expected-error {{unnamed argument #2 must precede argument 'b'}}
+    f1(b: "2", [3]) // expected-error {{incorrect argument labels in call (have 'b:_:', expected '_:_:c:_:')}}
+    // expected-error@-1 {{cannot convert value of type '[Int]' to expected argument type 'Bool'}}
     
-    f1(b: "2", 1) // expected-error {{unnamed argument #2 must precede argument 'b'}}
+    f1(b: "2", 1) // expected-error {{incorrect argument labels in call (have 'b:_:', expected '_:_:c:_:')}}
+    // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
 
-    f1(b: "2", [3], 1) // expected-error {{unnamed argument #2 must precede argument 'b'}}
+    f1(b: "2", [3], 1) // expected-error {{incorrect argument labels in call (have 'b:_:_:', expected '_:_:c:_:')}}
+    // expected-error@-1 {{cannot convert value of type '[Int]' to expected argument type 'Bool'}}
 
-    f1(b: "2", 1, [3]) // expected-error {{unnamed argument #2 must precede argument 'b'}}
+    f1(b: "2", 1, [3]) // expected-error {{incorrect argument labels in call (have 'b:_:_:', expected '_:_:c:_:')}}
+    // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+    // expected-error@-2 {{cannot convert value of type '[Int]' to expected argument type 'Int'}}
   }
 
   // unlabeled variadics before labeled parameter
@@ -375,13 +474,13 @@ struct PositionsAroundDefaultsAndVariadics {
     
     f3()
 
-    f3(c: "3", b: 21) // expected-error {{incorrect argument labels in call (have 'c:b:', expected '_:b:c:_:')}}
+    f3(c: "3", b: 21) // expected-error {{argument 'b' must precede argument 'c'}}
 
-    f3(c: "3", b: 21, [4]) // expected-error {{incorrect argument labels in call (have 'c:b:_:', expected '_:b:c:_:')}}
+    f3(c: "3", b: 21, [4]) // expected-error {{argument 'b' must precede argument 'c'}}
     // expected-error@-1 {{cannot pass array of type '[Int]' as variadic arguments of type 'Int'}}
     // expected-note@-2 {{remove brackets to pass array elements directly}}
 
-    f3(c: "3", [4], b: 21) // expected-error {{incorrect argument labels in call (have 'c:_:b:', expected '_:b:c:_:')}}
+    f3(c: "3", [4], b: 21) // expected-error {{argument 'b' must precede argument 'c'}}
   }
 
   // unlabeled variadics after labeled parameter
@@ -485,9 +584,9 @@ struct PositionsAroundDefaultsAndVariadics {
     f5(b: "2", c: 31, d: [4])
     f5(b: "2", d: [4])
 
-    f5(c: 31, b: "2", d: [4]) // expected-error {{incorrect argument labels in call (have 'c:b:d:', expected '_:b:c:d:')}}
+    f5(c: 31, b: "2", d: [4]) // expected-error {{argument 'b' must precede argument 'c'}}
 
-    f5(b: "2", d: [4], c: 31) // expected-error {{incorrect argument labels in call (have 'b:d:c:', expected '_:b:c:d:')}}
+    f5(b: "2", d: [4], c: 31) // expected-error {{argument 'c' must precede argument 'd'}}
 
     f5(b: "2", c: 31)
     f5(b: "2", c: 31, 32)
@@ -530,6 +629,102 @@ func mismatch1(thisFoo: Int = 0, bar: Int = 0, wibble: Int = 0) { } // expected-
 mismatch1(foo: 5) // expected-error {{extra argument 'foo' in call}}
 mismatch1(baz: 1, wobble: 2) // expected-error{{incorrect argument labels in call (have 'baz:wobble:', expected 'bar:wibble:')}} {{11-14=bar}} {{19-25=wibble}}
 mismatch1(food: 1, zap: 2) // expected-error{{extra arguments at positions #1, #2 in call}}
+
+// -------------------------------------------
+// Out of order and default
+// -------------------------------------------
+
+struct OutOfOrderAndDefault {
+  func f11(alpha: Int, bravo: Int) {}
+  func f12(alpha: Int = -1, bravo: Int) {}
+  func f13(alpha: Int, bravo: Int = -1) {}
+  func f14(alpha: Int = -1, bravo: Int = -1) {}
+
+  func test1() {
+    // typo
+    f11(bravo: 0, alphax: 1) // expected-error {{incorrect argument labels in call (have 'bravo:alphax:', expected 'alpha:bravo:')}}
+    f11(bravox: 0, alpha: 1) // expected-error {{incorrect argument labels in call (have 'bravox:alpha:', expected 'alpha:bravo:')}}
+    f12(bravo: 0, alphax: 1) // expected-error {{incorrect argument labels in call (have 'bravo:alphax:', expected 'alpha:bravo:')}}
+    f12(bravox: 0, alpha: 1) // expected-error {{incorrect argument labels in call (have 'bravox:alpha:', expected 'alpha:bravo:')}}
+    f13(bravo: 0, alphax: 1) // expected-error {{incorrect argument labels in call (have 'bravo:alphax:', expected 'alpha:bravo:')}}
+    f13(bravox: 0, alpha: 1) // expected-error {{incorrect argument labels in call (have 'bravox:alpha:', expected 'alpha:bravo:')}}
+    f14(bravo: 0, alphax: 1) // expected-error {{incorrect argument labels in call (have 'bravo:alphax:', expected 'alpha:bravo:')}}
+    f14(bravox: 0, alpha: 1) // expected-error {{incorrect argument labels in call (have 'bravox:alpha:', expected 'alpha:bravo:')}}
+  }
+
+  func f21(alpha: Int, bravo: Int, charlie: Int) {}
+  func f22(alpha: Int = -1, bravo: Int, charlie: Int) {}
+  func f23(alpha: Int = -1, bravo: Int = -1, charlie: Int) {}
+
+  func test2() {
+    // BAC
+    f21(bravo: 0, alphax: 1, charlie: 2) // expected-error {{incorrect argument labels in call (have 'bravo:alphax:charlie:', expected 'alpha:bravo:charlie:')}}
+    f21(bravox: 0, alpha: 1, charlie: 2) // expected-error {{incorrect argument labels in call (have 'bravox:alpha:charlie:', expected 'alpha:bravo:charlie:')}}
+    f21(bravo: 0, alpha: 1, charliex: 2) // expected-error {{'alpha' must precede argument 'bravo'}}
+    f22(bravo: 0, alphax: 1, charlie: 2) // expected-error {{incorrect argument labels in call (have 'bravo:alphax:charlie:', expected 'alpha:bravo:charlie:')}}
+    f22(bravox: 0, alpha: 1, charlie: 2) // expected-error {{incorrect argument labels in call (have 'bravox:alpha:charlie:', expected 'alpha:bravo:charlie:')}}
+    f22(bravo: 0, alpha: 1, charliex: 2) // expected-error {{'alpha' must precede argument 'bravo'}}
+    f23(bravo: 0, alphax: 1, charlie: 2) // expected-error {{incorrect argument labels in call (have 'bravo:alphax:charlie:', expected 'alpha:bravo:charlie:')}}
+    f23(bravox: 0, alpha: 1, charlie: 2) // expected-error {{incorrect argument labels in call (have 'bravox:alpha:charlie:', expected 'alpha:bravo:charlie:')}}
+    f23(bravo: 0, alpha: 1, charliex: 2) // expected-error {{'alpha' must precede argument 'bravo'}}
+
+    // BCA
+    f21(bravo: 0, charlie: 1, alphax: 2) // expected-error {{incorrect argument labels in call (have 'bravo:charlie:alphax:', expected 'alpha:bravo:charlie:')}}
+    f21(bravox: 0, charlie: 1, alpha: 2) // expected-error {{incorrect argument labels in call (have 'bravox:charlie:alpha:', expected 'alpha:bravo:charlie:')}}
+    f21(bravo: 0, charliex: 1, alpha: 2) // expected-error {{'alpha' must precede argument 'bravo'}}
+    f22(bravo: 0, charlie: 1, alphax: 2) // expected-error {{incorrect argument labels in call (have 'bravo:charlie:alphax:', expected 'alpha:bravo:charlie:')}}
+    f22(bravox: 0, charlie: 1, alpha: 2) // expected-error {{incorrect argument labels in call (have 'bravox:charlie:alpha:', expected 'alpha:bravo:charlie:')}}
+    f22(bravo: 0, charliex: 1, alpha: 2) // expected-error {{'alpha' must precede argument 'bravo'}}
+    f23(bravo: 0, charlie: 1, alphax: 2) // expected-error {{incorrect argument labels in call (have 'bravo:charlie:alphax:', expected 'alpha:bravo:charlie:')}}
+    f23(bravox: 0, charlie: 1, alpha: 2) // expected-error {{incorrect argument labels in call (have 'bravox:charlie:alpha:', expected 'alpha:bravo:charlie:')}}
+    f23(bravo: 0, charliex: 1, alpha: 2) // expected-error {{'alpha' must precede argument 'bravo'}}
+
+    // CAB
+    f21(charlie: 0, alphax: 1, bravo: 2) // expected-error {{incorrect argument labels in call (have 'charlie:alphax:bravo:', expected 'alpha:bravo:charlie:')}}
+    f21(charlie: 0, alpha: 1, bravox: 2) // expected-error {{incorrect argument labels in call (have 'charlie:alpha:bravox:', expected 'alpha:bravo:charlie:')}}
+    f21(charliex: 0, alpha: 1, bravo: 2) // expected-error {{incorrect argument labels in call (have 'charliex:alpha:bravo:', expected 'alpha:bravo:charlie:')}}
+    f22(charlie: 0, alphax: 1, bravo: 2) // expected-error {{incorrect argument labels in call (have 'charlie:alphax:bravo:', expected 'alpha:bravo:charlie:')}}
+    f22(charlie: 0, alpha: 1, bravox: 2) // expected-error {{incorrect argument labels in call (have 'charlie:alpha:bravox:', expected 'alpha:bravo:charlie:')}}
+    f22(charliex: 0, alpha: 1, bravo: 2) // expected-error {{incorrect argument labels in call (have 'charliex:alpha:bravo:', expected 'alpha:bravo:charlie:')}}
+    f23(charlie: 0, alphax: 1, bravo: 2) // expected-error {{incorrect argument labels in call (have 'charlie:alphax:bravo:', expected 'alpha:bravo:charlie:')}}
+    f23(charlie: 0, alpha: 1, bravox: 2) // expected-error {{argument 'alpha' must precede argument 'charlie'}}
+    f23(charliex: 0, alpha: 1, bravo: 2) // expected-error {{incorrect argument labels in call (have 'charliex:alpha:bravo:', expected 'alpha:bravo:charlie:')}}
+  }
+
+  func f31(alpha: Int, bravo: Int, charlie: Int, delta: Int) {}
+  func f32(alpha: Int = -1, bravo: Int = -1, charlie: Int, delta: Int) {}
+  func f33(alpha: Int = -1, bravo: Int = -1, charlie: Int, delta: Int = -1) {}
+
+  func test3() {
+    // BACD
+    f31(bravo: 0, alphax: 2, charlie: 2, delta: 3) // expected-error {{incorrect argument labels in call (have 'bravo:alphax:charlie:delta:', expected 'alpha:bravo:charlie:delta:')}}
+    f31(bravox: 0, alpha: 2, charlie: 2, delta: 3) // expected-error {{incorrect argument labels in call (have 'bravox:alpha:charlie:delta:', expected 'alpha:bravo:charlie:delta:')}}
+    f31(bravo: 0, alpha: 2, charliex: 2, delta: 3) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
+    f31(bravo: 0, alpha: 2, charlie: 2, deltax: 3) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
+    f32(bravo: 0, alphax: 2, charlie: 2, delta: 3) // expected-error {{incorrect argument labels in call (have 'bravo:alphax:charlie:delta:', expected 'alpha:bravo:charlie:delta:')}}
+    f32(bravox: 0, alpha: 2, charlie: 2, delta: 3) // expected-error {{incorrect argument labels in call (have 'bravox:alpha:charlie:delta:', expected 'alpha:bravo:charlie:delta:')}}
+    f32(bravo: 0, alpha: 2, charliex: 2, delta: 3) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
+    f32(bravo: 0, alpha: 2, charlie: 2, deltax: 3) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
+    f33(bravo: 0, alphax: 2, charlie: 2, delta: 3) // expected-error {{incorrect argument labels in call (have 'bravo:alphax:charlie:delta:', expected 'alpha:bravo:charlie:delta:')}}
+    f33(bravox: 0, alpha: 2, charlie: 2, delta: 3) // expected-error {{incorrect argument labels in call (have 'bravox:alpha:charlie:delta:', expected 'alpha:bravo:charlie:delta:')}}
+    f33(bravo: 0, alpha: 2, charliex: 2, delta: 3) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
+    f33(bravo: 0, alpha: 2, charlie: 2, deltax: 3) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
+
+    // BCAD
+    f31(bravo: 0, charlie: 1, alphax: 2, delta: 3) // expected-error {{incorrect argument labels in call (have 'bravo:charlie:alphax:delta:', expected 'alpha:bravo:charlie:delta:')}}
+    f31(bravox: 0, charlie: 1, alpha: 2, delta: 3) // expected-error {{incorrect argument labels in call (have 'bravox:charlie:alpha:delta:', expected 'alpha:bravo:charlie:delta:')}}
+    f31(bravo: 0, charliex: 1, alpha: 2, delta: 3) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
+    f31(bravo: 0, charlie: 1, alpha: 2, deltax: 3) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
+    f32(bravo: 0, charlie: 1, alphax: 2, delta: 3) // expected-error {{incorrect argument labels in call (have 'bravo:charlie:alphax:delta:', expected 'alpha:bravo:charlie:delta:')}}
+    f32(bravox: 0, charlie: 1, alpha: 2, delta: 3) // expected-error {{incorrect argument labels in call (have 'bravox:charlie:alpha:delta:', expected 'alpha:bravo:charlie:delta:')}}
+    f32(bravo: 0, charliex: 1, alpha: 2, delta: 3) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
+    f32(bravo: 0, charlie: 1, alpha: 2, deltax: 3) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
+    f33(bravo: 0, charlie: 1, alphax: 2, delta: 3) // expected-error {{incorrect argument labels in call (have 'bravo:charlie:alphax:delta:', expected 'alpha:bravo:charlie:delta:')}}
+    f33(bravox: 0, charlie: 1, alpha: 2, delta: 3) // expected-error {{incorrect argument labels in call (have 'bravox:charlie:alpha:delta:', expected 'alpha:bravo:charlie:delta:')}}
+    f33(bravo: 0, charliex: 1, alpha: 2, delta: 3) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
+    f33(bravo: 0, charlie: 1, alpha: 2, deltax: 3) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
+  }
+}
 
 // -------------------------------------------
 // Subscript keyword arguments


### PR DESCRIPTION
## Summary

I found some bugs around codes which handles out of order arguments in `matchCallArguments`.

I fixed them and refactored.
I added test cases.

@xedin Please review this.

## Bugs

### Bug. 1

```swift
func f(alpha: Int..., bravo: Int) {}
f(alpha: 1, 2, bravox: 2)
```

Compiler crashes with this swift code.
Typo of an argument label `bravox` is intended.
Typo correction happened here is a one of reason of bug.

Related original compiler code is here.
https://github.com/apple/swift/blob/46bba7aa58e6ae93039452e5a93a1b08c1dd1c92/lib/Sema/CSSimplify.cpp#L687-L757

When there are variadics at not last, argument index and parameter index are misaligned.
But original code doesn't consider about this case and always assumes they are aligned.
So using same index for argument array and parameter array causes some problems.

Not only about variadics, omitted parameters which has a default parameter are also problem.
They cause misaligned index too.

### Bug. 2

This is essentially same problem with Bug. 1.

```swift
func f(alpha: Int..., bravo: Int, charlie: Int) {}
f(alpha: 1, 2, 3, charlie: 1, bravo: 2)
```

Compiler crashes with this swift code.
There are no typo but arguments are out of order.

### Bug. 3

I found that weird behavior of argument reordering.

See this.

```swift
// All pair of function definition and call are isolated.
// So there `f` are not overloaded.

// (1-1)
func f(alpha: Int, bravo: Int) {}
f(bravo: 0, alphax: 1)
// => error: incorrect argument labels in call (have 'bravo:alphax:', expected 'alpha:bravo:')

// (1-2)
func f(alpha: Int = -1, bravo: Int) {}
f(bravo: 0, alphax: 1)
// => error: argument 'alpha' must precede argument 'bravo'

// (2-1)
func f(alpha: Int, bravo: Int, charlie: Int) {}
f(bravo: 0, charlie: 1, alphax: 2)
// => error: incorrect argument labels in call (have 'bravo:charlie:alphax:', expected 'alpha:bravo:charlie:')

// (2-2)
func f(alpha: Int = -1, bravo: Int, charlie: Int) {}
f(bravo: 0, charlie: 1, alphax: 2)
// => error: incorrect argument labels in call (have 'bravo:charlie:alphax:', expected 'alpha:bravo:charlie:')

// (2-3)
func f(alpha: Int = -1, bravo: Int = -1, charlie: Int) {}
f(bravo: 0, charlie: 1, alphax: 2)
// => error: argument 'alphax' must precede argument 'bravo'

// (3-1)
func f(alpha: Int = -1, bravo: Int = -1, charlie: Int, delta: Int) {}
f(bravo: 0, charlie: 1, alphax: 2, delta: 3)
// => error: incorrect argument labels in call (have 'bravo:charlie:alphax:delta:', expected 'alpha:bravo:charlie:delta:')

// (3-2)
func f(alpha: Int = -1, bravo: Int = -1, charlie: Int, delta: Int = -1) {}
f(bravo: 0, charlie: 1, alphax: 2, delta: 3)
// => error: argument 'alphax' must precede argument 'bravo'
```

Typo corrected argument are reordered in some cases (1-2, 2-3, 3-2).
Other cases are treated as relabeling all arguments (1-1, 2-1, 2-2, 3-1).

These difference are come from only whether some default parameters exist or not.
In particular, case (3-1) and (3-2) are affected from parameter `delta`.
It is at right of arguments `alpha`, `bravo`, `charlie` which are reordered.

I thought that it isn't intended behavior of original author (is @xedin).

Related original compiler code is here.
https://github.com/apple/swift/blob/46bba7aa58e6ae93039452e5a93a1b08c1dd1c92/lib/Sema/CSSimplify.cpp#L654-L685

Original code doesn't consider about parameter binding with typo correction.

## Patch content

I added new concept that is `paramToArgMap` variable.
It has a corrected argument positions corresponding each parameter which are from all arguments are aligned to correct position with using mapping built in `parameterBindings`.

I rewrite code here and carefully separate argument index and parameter index.

I added test cases of I talked above and variations of them.
I consider combination of typo, reorder and default parameters.
So it is a lot.

## Changes of test result which already exists

I think all changes of test result which already exists are improvement.
Details are below.

### About `PositionsAroundDefaultsAndVariadics.f1`

This patch changes compiler result from reordering arguments to relabeling.

For example,

```swift
func f1(_ a: Bool = false, _ b: Int = 0, c: String = "", _ d: [Int] = []) {}

-    f1(b: "2", [3]) // expected-error {{unnamed argument #2 must precede argument 'b'}}
+    f1(b: "2", [3]) // expected-error {{incorrect argument labels in call (have 'b:_:', expected '_:_:c:_:')}}
```

Even if reorder `[3]` to left of `b`,
because `f1` doesn't have parameter label `b`,
result of reordering isn't valid.

So this change makes sense.

### About `PositionsAroundDefaultsAndVariadics.f3`, `f5`

This patch changes compiler result from relabeling to reordering.

```swift
func f3(_ a: Bool = false, b: Int..., c: String = "", _ d: [Int] = []) {}

-    f3(c: "3", b: 21) // expected-error {{incorrect argument labels in call (have 'c:b:', expected '_:b:c:_:')}}
+    f3(c: "3", b: 21) // expected-error {{argument 'b' must precede argument 'c'}}

func f5(_ a: Bool = false, b: String = "", c: Int..., d: [Int] = []) {}

-    f5(c: 31, b: "2", d: [4]) // expected-error {{incorrect argument labels in call (have 'c:b:d:', expected '_:b:c:d:')}}
+    f5(c: 31, b: "2", d: [4]) // expected-error {{argument 'b' must precede argument 'c'}}
```

Its better.
