### PR TITLE
[gardening] Move class local to a .cpp file into anonymous namespace instead of the swift namespace.

### DIFF
--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1091,7 +1091,7 @@ shouldBePartiallySpecialized(Type Replacement,
   return true;
 }
 
-namespace swift {
+namespace {
 
 /// A helper class for creating partially specialized function signatures.
 ///
@@ -1257,7 +1257,7 @@ public:
   void computeCallerInterfaceSubs(SubstitutionMap &CallerInterfaceSubs);
 };
 
-} // end of namespace
+} // end anonymous namespace
 
 GenericTypeParamType *
 FunctionSignaturePartialSpecializer::createGenericParam() {


### PR DESCRIPTION
Anonymous namespaces are how one communicates in c++ that a class is only
available in the local file. It allows for the optimizer then to make more
aggressive assumptions around the class's invariants since it is file local.
