### PR TITLE
[SDK] Fix potential memory leak

### DIFF
--- a/stdlib/public/Darwin/Foundation/NSObject.swift
+++ b/stdlib/public/Darwin/Foundation/NSObject.swift
@@ -168,7 +168,7 @@ public class NSKeyValueObservation : NSObject {
     private class Helper : NSObject {
         @nonobjc weak var object : NSObject?
         @nonobjc let path: String
-        @nonobjc let callback : (NSObject, NSKeyValueObservedChange<Any>) -> Void
+        @nonobjc var callback: ((NSObject, NSKeyValueObservedChange<Any>) -> Void)?
         
         // workaround for <rdar://problem/31640524> Erroneous (?) error when using bridging in the Foundation overlay
         // specifically, overriding observeValue(forKeyPath:of:change:context:) complains that it's not Obj-C-compatible
@@ -194,6 +194,7 @@ public class NSKeyValueObservation : NSObject {
         }
         
         @nonobjc func invalidate() {
+            callback = nil
             guard let object = self.object else { return }
             object.removeObserver(self, forKeyPath: path, context: nil)
             objc_setAssociatedObject(object, associationKey(), nil, .OBJC_ASSOCIATION_ASSIGN)
@@ -213,7 +214,7 @@ public class NSKeyValueObservation : NSObject {
                                                         oldValue: change[NSKeyValueChangeKey.oldKey.rawValue as NSString],
                                                         indexes: change[NSKeyValueChangeKey.indexesKey.rawValue as NSString] as! IndexSet?,
                                                         isPrior: change[NSKeyValueChangeKey.notificationIsPriorKey.rawValue as NSString] as? Bool ?? false)
-            callback(object, notification)
+            callback?(object, notification)
         }
     }
     


### PR DESCRIPTION
<!-- What's in this pull request? -->
When clients call `invalidate()`, they expect everything related to their `NSKeyValueObservation` instance is cleaned. However, in the previous implementation, `changeHandler` is not cleaned during invalidation, which may causing memory leak. This implementation cleans `changeHandler` during invalidation.
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
