### PR TITLE
[SDK] Fix potential memory leak

### DIFF
--- a/stdlib/public/Darwin/Foundation/NSObject.swift
+++ b/stdlib/public/Darwin/Foundation/NSObject.swift
@@ -166,9 +166,9 @@ public class NSKeyValueObservation : NSObject {
     //
     // For the associated object, we use the Helper instance itself as its own key. This guarantees key uniqueness.
     private class Helper : NSObject {
-        @nonobjc weak var object : NSObject?
+        @nonobjc weak var object: NSObject?
         @nonobjc let path: String
-        @nonobjc let callback : (NSObject, NSKeyValueObservedChange<Any>) -> Void
+        @nonobjc var callback: ((NSObject, NSKeyValueObservedChange<Any>) -> Void)?
         
         // workaround for <rdar://problem/31640524> Erroneous (?) error when using bridging in the Foundation overlay
         // specifically, overriding observeValue(forKeyPath:of:change:context:) complains that it's not Obj-C-compatible
@@ -194,6 +194,7 @@ public class NSKeyValueObservation : NSObject {
         }
         
         @nonobjc func invalidate() {
+            callback = nil
             guard let object = self.object else { return }
             object.removeObserver(self, forKeyPath: path, context: nil)
             objc_setAssociatedObject(object, associationKey(), nil, .OBJC_ASSOCIATION_ASSIGN)
@@ -213,7 +214,7 @@ public class NSKeyValueObservation : NSObject {
                                                         oldValue: change[NSKeyValueChangeKey.oldKey.rawValue as NSString],
                                                         indexes: change[NSKeyValueChangeKey.indexesKey.rawValue as NSString] as! IndexSet?,
                                                         isPrior: change[NSKeyValueChangeKey.notificationIsPriorKey.rawValue as NSString] as? Bool ?? false)
-            callback(object, notification)
+            callback?(object, notification)
         }
     }
     


### PR DESCRIPTION
When clients call `NSKeyValueObservation.invalidate()`, they expect everything related to their `NSKeyValueObservation` instance is cleared. However, in the previous implementation, `changeHandler` is not cleared during invalidation, which may causing memory leak. This implementation clears `changeHandler` during invalidation.