### PR TITLE
Partially revert "Keep gyb from messing up line endings on Windows"

### DIFF
--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -1208,13 +1208,12 @@ def main():
         help='''Bindings to be set in the template's execution context''')
 
     parser.add_argument(
-        'file', type=argparse.FileType('rb'),
+        'file', type=argparse.FileType(),
         help='Path to GYB template file (defaults to stdin)', nargs='?',
-        default=sys.stdin)    # FIXME: stdin not binary mode on Windows
+        default=sys.stdin)
     parser.add_argument(
-        '-o', dest='target', type=argparse.FileType('wb'),
-        help='Output file (defaults to stdout)',
-        default=sys.stdout)    # FIXME: stdout not binary mode on Windows
+        '-o', dest='target', type=argparse.FileType('w'),
+        help='Output file (defaults to stdout)', default=sys.stdout)
     parser.add_argument(
         '--test', action='store_true',
         default=False, help='Run a self-test')


### PR DESCRIPTION
This reverts most of commit 85599f7582b8809be889f589fe4d1d95e09ec945; it turns out the ‘b’ flag changes behavior more drastically in Python 3.

Fixes SR-12328, rdar://problem/60230415.