### PR TITLE
[CS] Move getUnopenedTypeOfReference out of TypeChecker

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -925,7 +925,7 @@ Type ConstraintSystem::getUnopenedTypeOfReference(VarDecl *value, Type baseType,
                                                   DeclContext *UseDC,
                                                   const DeclRefExpr *base,
                                                   bool wantInterfaceType) {
-  return TypeChecker::getUnopenedTypeOfReference(
+  return ConstraintSystem::getUnopenedTypeOfReference(
       value, baseType, UseDC,
       [&](VarDecl *var) -> Type {
         if (Type type = getTypeIfAvailable(var))
@@ -940,7 +940,7 @@ Type ConstraintSystem::getUnopenedTypeOfReference(VarDecl *value, Type baseType,
       base, wantInterfaceType);
 }
 
-Type TypeChecker::getUnopenedTypeOfReference(
+Type ConstraintSystem::getUnopenedTypeOfReference(
     VarDecl *value, Type baseType, DeclContext *UseDC,
     llvm::function_ref<Type(VarDecl *)> getType, const DeclRefExpr *base,
     bool wantInterfaceType) {
@@ -1405,9 +1405,9 @@ ConstraintSystem::getTypeOfMemberReference(
                               ->castTo<AnyFunctionType>()->getParams();
       refType = FunctionType::get(indices, elementTy);
     } else {
-      refType = TypeChecker::getUnopenedTypeOfReference(
-          cast<VarDecl>(value), baseTy, useDC, base,
-          /*wantInterfaceType=*/true);
+      refType =
+          getUnopenedTypeOfReference(cast<VarDecl>(value), baseTy, useDC, base,
+                                     /*wantInterfaceType=*/true);
     }
 
     auto selfTy = outerDC->getSelfInterfaceType();

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3260,6 +3260,25 @@ public:
                                   const DeclRefExpr *base = nullptr,
                                   bool wantInterfaceType = false);
 
+  /// Return the type-of-reference of the given value.
+  ///
+  /// \param baseType if non-null, return the type of a member reference to
+  ///   this value when the base has the given type
+  ///
+  /// \param UseDC The context of the access.  Some variables have different
+  ///   types depending on where they are used.
+  ///
+  /// \param base The optional base expression of this value reference
+  ///
+  /// \param wantInterfaceType Whether we want the interface type, if available.
+  ///
+  /// \param getType Optional callback to extract a type for given declaration.
+  static Type
+  getUnopenedTypeOfReference(VarDecl *value, Type baseType, DeclContext *UseDC,
+                             llvm::function_ref<Type(VarDecl *)> getType,
+                             const DeclRefExpr *base = nullptr,
+                             bool wantInterfaceType = false);
+
   /// Retrieve the type of a reference to the given value declaration,
   /// as a member with a base of the given type.
   ///

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -23,6 +23,8 @@
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Parse/Lexer.h"
+#include "ConstraintSystem.h"
+
 using namespace swift;
 
 //===----------------------------------------------------------------------===//
@@ -591,7 +593,9 @@ bool TypeChecker::requireArrayLiteralIntrinsics(ASTContext &ctx,
 
 Expr *TypeChecker::buildCheckedRefExpr(VarDecl *value, DeclContext *UseDC,
                                        DeclNameLoc loc, bool Implicit) {
-  auto type = TypeChecker::getUnopenedTypeOfReference(value, Type(), UseDC);
+  auto type = constraints::ConstraintSystem::getUnopenedTypeOfReference(
+      value, Type(), UseDC,
+      [&](VarDecl *var) -> Type { return value->getType(); });
   auto semantics = value->getAccessSemanticsFromContext(UseDC,
                                                        /*isAccessOnSelf*/false);
   return new (value->getASTContext())

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -989,49 +989,6 @@ public:
   static bool contextualizeInitializer(Initializer *DC, Expr *init);
   static void contextualizeTopLevelCode(TopLevelCodeDecl *TLCD);
 
-  /// Return the type-of-reference of the given value.
-  ///
-  /// \param baseType if non-null, return the type of a member reference to
-  ///   this value when the base has the given type
-  ///
-  /// \param UseDC The context of the access.  Some variables have different
-  ///   types depending on where they are used.
-  ///
-  /// \param base The optional base expression of this value reference
-  ///
-  /// \param wantInterfaceType Whether we want the interface type, if available.
-  ///
-  /// \param getType Optional callback to extract a type for given declaration.
-  static Type
-  getUnopenedTypeOfReference(VarDecl *value, Type baseType, DeclContext *UseDC,
-                             llvm::function_ref<Type(VarDecl *)> getType,
-                             const DeclRefExpr *base = nullptr,
-                             bool wantInterfaceType = false);
-
-  /// Return the type-of-reference of the given value.
-  ///
-  /// \param baseType if non-null, return the type of a member reference to
-  ///   this value when the base has the given type
-  ///
-  /// \param UseDC The context of the access.  Some variables have different
-  ///   types depending on where they are used.
-  ///
-  /// \param base The optional base expression of this value reference
-  ///
-  /// \param wantInterfaceType Whether we want the interface type, if available.
-  static Type getUnopenedTypeOfReference(VarDecl *value, Type baseType,
-                                         DeclContext *UseDC,
-                                         const DeclRefExpr *base = nullptr,
-                                         bool wantInterfaceType = false) {
-    return getUnopenedTypeOfReference(
-        value, baseType, UseDC,
-        [&](VarDecl *var) -> Type {
-          return wantInterfaceType ? value->getInterfaceType()
-                                   : value->getType();
-        },
-        base, wantInterfaceType);
-  }
-
   /// Retrieve the default type for the given protocol.
   ///
   /// Some protocols, particularly those that correspond to literals, have


### PR DESCRIPTION
For some reason, the changed caller in CS wasn't actually going to use any of the types in the constraint system from the entrypoint it was calling. Switch over to using the constraint-system based entrypoint so we can pick up expression types consistently. Then, move the TypeChecker entrypoint onto ConstraintSystem to reduce the duplication here.

The remaining callers of buildCheckedRefExpr should probably be migrated to use a more principled method of building typechecked ASTs.