### PR TITLE
test: adjust the test to improve the viability on Windows

### DIFF
--- a/test/SILGen/magic_identifier_file_conflicting.swift.gyb
+++ b/test/SILGen/magic_identifier_file_conflicting.swift.gyb
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %gyb -D TEMPDIR=%t %s -o %t/magic_identifier_file_conflicting.swift
+// RUN: %gyb -D TEMPDIR=%t %s > %t/magic_identifier_file_conflicting.swift
+// RUN: %{python} -c "import sys; t = open(sys.argv[1], 'rb').read().replace('\r\n', '\n'); open(sys.argv[1], 'wb').write(t)" %t/magic_identifier_file_conflicting.swift
 
 // We want to check both the diagnostics and the SIL output.
 // RUN: %target-swift-emit-silgen -verify -emit-sorted-sil -enable-experimental-concise-pound-file -module-name Foo %t/magic_identifier_file_conflicting.swift %S/Inputs/magic_identifier_file_conflicting_other.swift | %FileCheck %s
@@ -11,12 +12,14 @@
 
 %{
 TEMPDIR_ESC = TEMPDIR.replace('\\', '\\\\')
+
+import os
 def fixit_loc(start_col, orig_suffix):
   """
   Computes a "start-end" string for a fix-it replacing a string literal which
   starts at start_col and joins orig_suffix to TEMPDIR with a slash.
   """
-  original = '"{0}/{1}"'.format(TEMPDIR, orig_suffix)
+  original = '"{0}"'.format(os.path.join(TEMPDIR, orig_suffix))
   end_col = start_col + len(original)
   return '{0}-{1}'.format(start_col, end_col)
 }%


### PR DESCRIPTION
Convert the line endings manually since the parser is sensitive to the
trailing whitespace (the writing of the file will create a `\r\n` rather
than `\n`).  This largely fixes the issues for Windows with the issue
that the processing of the file location is currently not properly
processing escape characters and results in issues.

In theory, it should be possible for `getStringLiteralIfNotInterpolated`
to process the literal segments with `getEncodedStringSegment` for each
segment and then return a literal value cooked.  However, doing so will
require that the function return a `std::string` rather than `StringRef`
since the cooking means that we cannot simply provide a reference to the
SourceManager view.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
