### PR TITLE
Create an inherited conformance in SubstitutionMap::lookupConformance when needed.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -322,6 +322,9 @@ namespace swift {
     /// `@differentiable` declaration attribute, etc.
     bool EnableExperimentalDifferentiableProgramming = false;
 
+    /// Enable verification when every SubstitutionMap is constructed.
+    bool VerifyAllSubstitutionMaps = false;
+
     /// Sets the target we are building for and updates platform conditions
     /// to match.
     ///
@@ -512,6 +515,7 @@ namespace swift {
     /// Enable constraint solver support for experimental
     ///        operator protocol designator feature.
     bool SolverEnableOperatorDesignatedTypes = false;
+    
   };
 } // end namespace swift
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -548,6 +548,9 @@ def sil_merge_partial_modules : Flag<["-"], "sil-merge-partial-modules">,
 
 def sil_verify_all : Flag<["-"], "sil-verify-all">,
   HelpText<"Verify SIL after each transform">;
+  
+def verify_all_substitution_maps : Flag<["-"], "verify-all-substitution-maps">,
+  HelpText<"Verify all SubstitutionMaps on construction">;
 
 def sil_debug_serialization : Flag<["-"], "sil-debug-serialization">,
   HelpText<"Do not eliminate functions in Mandatory Inlining/SILCombine dead "

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3654,8 +3654,26 @@ namespace {
 
     void visitSILFunctionType(SILFunctionType *T, StringRef label) {
       printCommon(label, "sil_function_type");
-      // FIXME: Print the structure of the type.
       printField("type", T->getString());
+
+      for (auto param : T->getParameters()) {
+        printRec("input", param.getInterfaceType());
+      }
+      for (auto yield : T->getYields()) {
+        printRec("yield", yield.getInterfaceType());
+      }
+      for (auto result : T->getResults()) {
+        printRec("result", result.getInterfaceType());
+      }
+      if (auto error  = T->getOptionalErrorResult()) {
+        printRec("error", error->getInterfaceType());
+      }
+      OS << '\n';
+      T->getPatternSubstitutions().dump(OS, SubstitutionMap::DumpStyle::Full,
+                                        Indent+2);
+      OS << '\n';
+      T->getInvocationSubstitutions().dump(OS, SubstitutionMap::DumpStyle::Full,
+                                           Indent+2);
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
 

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -355,8 +355,10 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
   // Check whether the superclass conforms.
   if (auto superclass = genericSig->getSuperclassBound(type)) {
     LookUpConformanceInSignature lookup(getGenericSignature().getPointer());
-    if (auto conformance = lookup(type->getCanonicalType(), superclass, proto))
+    auto substType = type.subst(*this);
+    if (auto conformance = lookup(type->getCanonicalType(), substType, proto)){
       return conformance;
+    }
   }
 
   // If the type doesn't conform to this protocol, the result isn't formed

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -56,7 +56,12 @@ SubstitutionMap::SubstitutionMap(
                                 GenericSignature genericSig,
                                 ArrayRef<Type> replacementTypes,
                                 ArrayRef<ProtocolConformanceRef> conformances)
-  : storage(Storage::get(genericSig, replacementTypes, conformances)) { }
+  : storage(Storage::get(genericSig, replacementTypes, conformances)) {
+#ifndef NDEBUG
+  if (genericSig->getASTContext().LangOpts.VerifyAllSubstitutionMaps)
+    verify();
+#endif
+}
 
 ArrayRef<Type> SubstitutionMap::getReplacementTypesBuffer() const {
   return storage ? storage->getReplacementTypes() : ArrayRef<Type>();
@@ -476,7 +481,7 @@ SubstitutionMap SubstitutionMap::subst(TypeSubstitutionFn subs,
       newConformances.push_back(
         conformance.subst(substType, subs, conformances, options));
     }
-
+    
     oldConformances = oldConformances.slice(1);
   }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2400,7 +2400,7 @@ getForeignRepresentable(Type type, ForeignLanguage language,
 
   if (wasOptional && !result.isRepresentableAsOptional())
     return failure();
-
+  
   // If our nominal type has type arguments, make sure they are
   // representable as well. Because type arguments are not actually
   // translated separately, whether they are trivially representable
@@ -2446,6 +2446,16 @@ getForeignRepresentable(Type type, ForeignLanguage language,
       case ForeignRepresentableKind::BridgedError:
         break;
       }
+    }
+    
+    // Specialize the conformance we were given for the type we're testing.
+    if (result.getKind() == ForeignRepresentableKind::Bridged
+        && !result.getConformance()->getType()->isEqual(type)) {
+      auto specialized = type->getASTContext()
+        .getSpecializedConformance(type, result.getConformance(),
+             boundGenericType->getContextSubstitutionMap(dc->getParentModule(),
+                                                 boundGenericType->getDecl()));
+      result = ForeignRepresentationInfo::forBridged(specialized);
     }
   }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -565,6 +565,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
                    Target.isOSDarwin());
   Opts.EnableSILOpaqueValues |= Args.hasArg(OPT_enable_sil_opaque_values);
 
+  Opts.VerifyAllSubstitutionMaps |= Args.hasArg(OPT_verify_all_substitution_maps);
+
   Opts.UseDarwinPreStableABIBit =
     (Target.isMacOSX() && Target.isMacOSXVersionLT(10, 14, 4)) ||
     (Target.isiOS() && Target.isOSVersionLT(12, 2)) ||
@@ -795,7 +797,7 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts,
   // Assumes exactly one of setMainExecutablePath() or setRuntimeIncludePath() 
   // is called before setTargetTriple() and parseArgs().
   // TODO: improve the handling of RuntimeIncludePath.
-
+  
   return false;
 }
 

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -749,7 +749,7 @@ static SILFunction *emitSelfConformanceWitness(SILGenModule &SGM,
   auto protocolType = protocol->getDeclaredInterfaceType();
   auto reqtSubs = SubstitutionMap::getProtocolSubstitutions(protocol,
                                           protocolType,
-                                          ProtocolConformanceRef(protocol));
+                                          ProtocolConformanceRef(conformance));
 
   // Open the protocol type.
   auto openedType = OpenedArchetypeType::get(protocolType);

--- a/test/SILGen/function_type_lowering_inherited_conformance.swift
+++ b/test/SILGen/function_type_lowering_inherited_conformance.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+protocol P {}
+
+class C: P {}
+class D: C {}
+
+struct Butt<T: P> {}
+
+func foo<T: P>(_: (Butt<T>) -> ()) {}
+
+// CHECK-LABEL: sil{{.*}}3bar
+func bar(_ f: (Butt<D>) -> ()) {
+  // CHECK: convert_function {{.*}} $@noescape @callee_guaranteed (Butt<D>) -> () to $@noescape @callee_guaranteed @substituted <τ_0_0 where τ_0_0 : P> (Butt<τ_0_0>) -> () for <D>
+  foo(f)
+}


### PR DESCRIPTION
If the substituted type for a conformance found via a superclass constraint is a subclass of that
superclass, then we should represent that with an InheritedProtocolConformance rather than with
the original root conformance that applies to the superclass. If we don't do this, then we end up
with spurious inequalities in generic signatures that ought to be equivalent, because some
paths use the inherited conformance and some don't, as in SR-12330 | rdar://problem/60174186.