### PR TITLE
PrintAsObjC: allow users to specify bridging header relative path for printing

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -266,6 +266,10 @@ public:
   /// Should we enable the dependency verifier for all primary files known to this frontend?
   bool EnableIncrementalDependencyVerifier = false;
 
+  /// The directory path we should use when print #include for the bridging header.
+  /// By default, we include ImplicitObjCHeaderPath directly.
+  llvm::Optional<std::string> BridgingHeaderDirForPrint;
+
   /// The different modes for validating TBD against the LLVM IR.
   enum class TBDValidationMode {
     Default,        ///< Do the default validation for the current platform.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -687,4 +687,8 @@ def disable_type_layouts : Flag<["-"], "disable-type-layout">,
 
 def disable_interface_lockfile : Flag<["-"], "disable-interface-lock">,
   HelpText<"Don't lock interface file when building module">;
+
+def bridging_header_directory_for_print: Separate<["-"], "bridging-header-directory-for-print">, MetaVarName<"<path>">,
+    HelpText<"Directory for bridging header to be printed in compatibility header">;
+
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -63,7 +63,9 @@ bool ArgsToFrontendOptionsConverter::convert(
   if (const Arg *A = Args.getLastArg(OPT_prebuilt_module_cache_path)) {
     Opts.PrebuiltModuleCachePath = A->getValue();
   }
-
+  if (const Arg *A = Args.getLastArg(OPT_bridging_header_directory_for_print)) {
+    Opts.BridgingHeaderDirForPrint = A->getValue();
+  }
   Opts.IndexSystemModules |= Args.hasArg(OPT_index_system_modules);
 
   Opts.EmitVerboseSIL |= Args.hasArg(OPT_emit_verbose_sil);

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1174,9 +1174,22 @@ static bool emitAnyWholeModulePostTypeCheckSupplementaryOutputs(
   bool hadAnyError = false;
 
   if (opts.InputsAndOutputs.hasObjCHeaderOutputPath()) {
+    std::string BridgingHeaderPathForPrint;
+    if (!opts.ImplicitObjCHeaderPath.empty()) {
+      if (opts.BridgingHeaderDirForPrint.hasValue()) {
+        // User specified preferred directory for including, use that dir.
+        llvm::SmallString<32> Buffer(*opts.BridgingHeaderDirForPrint);
+        llvm::sys::path::append(Buffer,
+          llvm::sys::path::filename(opts.ImplicitObjCHeaderPath));
+        BridgingHeaderPathForPrint = Buffer.str();
+      } else {
+        // By default, include the given bridging header path directly.
+        BridgingHeaderPathForPrint = opts.ImplicitObjCHeaderPath;
+      }
+    }
     hadAnyError |= printAsObjCIfNeeded(
         Invocation.getObjCHeaderOutputPathForAtMostOnePrimary(),
-        Instance.getMainModule(), opts.ImplicitObjCHeaderPath, moduleIsPublic);
+        Instance.getMainModule(), BridgingHeaderPathForPrint, moduleIsPublic);
   }
 
   if (opts.InputsAndOutputs.hasModuleInterfaceOutputPath()) {

--- a/test/PrintAsObjC/Inputs/CoreGraphics-Bridging-Header.h
+++ b/test/PrintAsObjC/Inputs/CoreGraphics-Bridging-Header.h
@@ -1,0 +1,6 @@
+@import Foundation;
+
+@interface UIColor : NSObject
+- (UIColor *)colorWithAlphaComponent:(CGFloat)alpha;
+- (UIColor *)resolvedColorWithTraitCollection:(CGFloat)traitCollection;
+@end

--- a/test/PrintAsObjC/include-underlying.swift
+++ b/test/PrintAsObjC/include-underlying.swift
@@ -1,0 +1,15 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %s -typecheck -emit-objc-header-path %t/emit.h -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/CoreGraphics-Bridging-Header.h -import-underlying-module -module-name CoreGraphics -bridging-header-directory-for-print ""
+// RUN: %FileCheck -check-prefix=CHECK-DEFAULT %s < %t/emit.h
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %s -typecheck -emit-objc-header-path %t/emit.h -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/CoreGraphics-Bridging-Header.h -import-underlying-module -module-name CoreGraphics -bridging-header-directory-for-print "Headers/PrivateHeaders/"
+// RUN: %FileCheck -check-prefix=CHECK-DIR %s < %t/emit.h
+
+@objc public class X: UIColor {
+  @objc public func draw(_: UIColor) { }
+}
+
+// CHECK-DEFAULT: #import "CoreGraphics-Bridging-Header.h"
+// CHECK-DIR: #import "Headers/PrivateHeaders/CoreGraphics-Bridging-Header.h"


### PR DESCRIPTION
Compatibility header may #import bridging header if specified with -import-underlying-module.
How these two headers are relative to each other is subject to project setting. To accommodate
this, we should allow users to specify bridging header directory for header generating purposes.

rdar://59110975