### PR TITLE
Fix MemBehavior calls to getAccessedAddress to avoid an assert.

### DIFF
--- a/test/SILOptimizer/access_marker_verify.swift
+++ b/test/SILOptimizer/access_marker_verify.swift
@@ -1080,3 +1080,27 @@ public func getStaticProp() -> HasStaticProp {
 // CHECK: [[ADR:%.*]] = pointer_to_address [[RP]] : $Builtin.RawPointer to [strict] $*HasStaticProp
 // CHECK: load [copy] [[ADR]] : $*HasStaticProp
 // CHECK-LABEL: } // end sil function '$s20access_marker_verify13getStaticPropAA03HaseF0CyF'
+
+// ===-----------------------------------------------------------------------===
+// Test computeMemBehavior with a non-address value. In this case, the
+// address for an access of StreamClass.buffer is compared with the
+// ContiguousArrayStorageBase value.
+//
+// <rdar://60046018> assert: (v->getType().isAddress()) in getAccessedAddress.
+
+public final class StreamClass {
+    private var buffer: [UInt8]
+
+    public init() {
+        self.buffer = []
+    }
+}
+
+// CHECK-LABEL: sil [ossa] @$s20access_marker_verify25testNonAddressMemBehavioryySiF : $@convention(thin) (Int) -> () {
+// The relevant SIL instructions for this test don't appear until the string interpolation is inlined.
+// Just make sure it does not assert.
+// CHECK-LABEL: } // end sil function '$s20access_marker_verify25testNonAddressMemBehavioryySiF'
+public func testNonAddressMemBehavior(_ N: Int) {
+  let listOfStrings: [String] = (0..<10).map { "This is the number: \($0)!\n" }
+  let stream = StreamClass()
+}

--- a/test/SILOptimizer/mem-behavior-all.sil
+++ b/test/SILOptimizer/mem-behavior-all.sil
@@ -112,3 +112,32 @@ bb0(%0 : $*Builtin.Int32):
   end_access %write : $*Builtin.Int32
   return %val : $Builtin.Int32
 }
+
+// ===-----------------------------------------------------------------------===
+// Test the effect of a [deinit] access on a global 'let'
+//
+// Test <rdar://60046018> Assert: (v->getType().isAddress()), getAccessedAddress
+
+sil_global hidden [let] @globalC : $C
+
+// CHECK-LABEL: @testDeinitInstVsNonAddressValue
+// CHECK:      PAIR #5.
+// CHECK-NEXT:     load %{{.*}} : $*C
+// CHECK-NEXT:     begin_access [deinit] [static] %{{.*}} : $*Builtin.Int32
+// CHECK-NEXT:   r=1,w=0,se=0
+// CHECK:      PAIR #16.
+// CHECK-NEXT:    %6 = begin_access [deinit] [static] %5 : $*Builtin.Int32 // user: %7
+// CHECK-NEXT:    %2 = load %1 : $*C                              // user: %3
+// CHECK-NEXT:  r=1,w=0,se=0
+sil hidden @testDeinitInstVsNonAddressValue : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : $C):
+  %1 = global_addr @globalC : $*C
+  %2 = load %1 : $*C
+  %3 = ref_element_addr %2 : $C, #C.prop
+  %4 = load %3 : $*Builtin.Int32
+  %5 = ref_element_addr %0 : $C, #C.prop
+  %6 = begin_access [deinit] [static] %5 : $*Builtin.Int32
+  end_access %6 : $*Builtin.Int32
+  %8 = tuple ()
+  return %8 : $()
+}


### PR DESCRIPTION
Fixes <rdar://60046018> assert: (v->getType().isAddress())
in getAccessedAddress.

MemBehavior compares known memory accesses with some arbitrary value,
which may not be an address. However, we should not call utilities
that work on accessed addresses with an arbitrary value.

This assert is a result of very recent changes to gradually make
memory access utilities more type safe and introduce the concept of a
canonical accessed address. In the future, we may even have a wrapper
type for such a thing. In the SIL optimizer, there are several
different notions of what constitutes the base of a memory
access. Mismatches can lead to subtle bugs.
