### PR TITLE
Plumb a result SILType through SILGen's emitTransformedValue

### DIFF
--- a/lib/SILGen/ArgumentSource.cpp
+++ b/lib/SILGen/ArgumentSource.cpp
@@ -78,9 +78,11 @@ ManagedValue ArgumentSource::getAsSingleValue(SILGenFunction &SGF,
 
 ManagedValue ArgumentSource::getAsSingleValue(SILGenFunction &SGF,
                                               AbstractionPattern origFormalType,
+                                              SILType loweredTy,
                                               SGFContext C) && {
   auto substFormalType = getSubstRValueType();
-  auto conversion = Conversion::getSubstToOrig(origFormalType, substFormalType);
+  auto conversion =
+    Conversion::getSubstToOrig(origFormalType, substFormalType, loweredTy);
   return std::move(*this).getConverted(SGF, conversion, C);
 }
 
@@ -209,6 +211,7 @@ void ArgumentSource::forwardInto(SILGenFunction &SGF,
   SILLocation loc = getLocation();
   ManagedValue outputValue =
       std::move(*this).getAsSingleValue(SGF, origFormalType,
+                                        destTL.getLoweredType(),
                                         SGFContext(dest));
 
   if (outputValue.isInContext()) return;

--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -242,6 +242,7 @@ public:
                                 SGFContext C = SGFContext()) &&;
   ManagedValue getAsSingleValue(SILGenFunction &SGF,
                                 AbstractionPattern origFormalType,
+                                SILType loweredResultTy,
                                 SGFContext C = SGFContext()) &&;
 
   ManagedValue getConverted(SILGenFunction &SGF, const Conversion &conversion,

--- a/lib/SILGen/Conversion.h
+++ b/lib/SILGen/Conversion.h
@@ -73,6 +73,7 @@ private:
   struct ReabstractionTypes {
     AbstractionPattern OrigType;
     CanType SubstType;
+    SILType LoweredResultType;
   };
 
   using Members = ExternalUnionMembers<BridgingTypes, ReabstractionTypes>;
@@ -104,20 +105,24 @@ private:
                                           loweredResultTy, isExplicit);
   }
 
-  Conversion(KindTy kind, AbstractionPattern origType, CanType substType)
+  Conversion(KindTy kind, AbstractionPattern origType, CanType substType,
+             SILType loweredResultTy)
       : Kind(kind) {
-    Types.emplaceAggregate<ReabstractionTypes>(kind, origType, substType);
+    Types.emplaceAggregate<ReabstractionTypes>(kind, origType, substType,
+                                               loweredResultTy);
   }
 
 public:
   static Conversion getOrigToSubst(AbstractionPattern origType,
-                                   CanType substType) {
-    return Conversion(OrigToSubst, origType, substType);
+                                   CanType substType,
+                                   SILType loweredResultTy) {
+    return Conversion(OrigToSubst, origType, substType, loweredResultTy);
   }
 
   static Conversion getSubstToOrig(AbstractionPattern origType,
-                                   CanType substType) {
-    return Conversion(SubstToOrig, origType, substType);
+                                   CanType substType,
+                                   SILType loweredResultTy) {
+    return Conversion(SubstToOrig, origType, substType, loweredResultTy);
   }
 
   static Conversion getBridging(KindTy kind, CanType origType,
@@ -141,6 +146,10 @@ public:
 
   CanType getReabstractionSubstType() const {
     return Types.get<ReabstractionTypes>(Kind).SubstType;
+  }
+
+  SILType getReabstractionLoweredResultType() const {
+    return Types.get<ReabstractionTypes>(Kind).LoweredResultType;
   }
 
   bool isBridgingExplicit() const {

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -249,7 +249,8 @@ public:
                                          origType.getType(), substType,
                                          loweredResultTy);
         } else {
-          return Conversion::getOrigToSubst(origType, substType);
+          return Conversion::getOrigToSubst(origType, substType,
+                                            loweredResultTy);
         }
       }();
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2950,7 +2950,8 @@ private:
         switch (getSILFunctionLanguage(Rep)) {
         case SILFunctionLanguage::Swift:
           return Conversion::getSubstToOrig(origParamType,
-                                            arg.getSubstRValueType());
+                                            arg.getSubstRValueType(),
+                                            param.getSILStorageInterfaceType());
         case SILFunctionLanguage::C:
           return Conversion::getBridging(Conversion::BridgeToObjC,
              arg.getSubstRValueType(),
@@ -4789,7 +4790,8 @@ ManagedValue SILGenFunction::emitInjectEnum(SILLocation loc,
     if (!payloadMV) {
       // If the payload was indirect, we already evaluated it and
       // have a single value. Otherwise, evaluate the payload.
-      payloadMV = std::move(payload).getAsSingleValue(*this, origFormalType);
+      payloadMV = std::move(payload).getAsSingleValue(*this, origFormalType,
+                                                      loweredPayloadType);
     }
 
     SILValue argValue = payloadMV.forward(*this);
@@ -4812,7 +4814,9 @@ ManagedValue SILGenFunction::emitInjectEnum(SILLocation loc,
         } else if (payloadTL.isLoadable()) {
           // The payload of this specific enum case might be loadable
           // even if the overall enum is address-only.
-          payloadMV = std::move(payload).getAsSingleValue(*this, origFormalType);
+          payloadMV =
+            std::move(payload).getAsSingleValue(*this, origFormalType,
+                                                loweredPayloadType);
           B.emitStoreValueOperation(loc, payloadMV.forward(*this), resultData,
                                     StoreOwnershipQualifier::Init);
         } else {

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -37,14 +37,16 @@ static ManagedValue emitUnabstractedCast(SILGenFunction &SGF, SILLocation loc,
                                          ManagedValue value,
                                          CanType sourceFormalType,
                                          CanType targetFormalType) {
-  if (value.getType() == SGF.getLoweredType(targetFormalType))
+  SILType loweredResultTy = SGF.getLoweredType(targetFormalType);
+  if (value.getType() == loweredResultTy)
     return value;
 
   return SGF.emitTransformedValue(loc, value,
                                   AbstractionPattern(sourceFormalType),
                                   sourceFormalType,
                                   AbstractionPattern(targetFormalType),
-                                  targetFormalType);
+                                  targetFormalType,
+                                  loweredResultTy);
 }
 
 static bool shouldBridgeThroughError(SILGenModule &SGM, CanType type,

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -1164,12 +1164,14 @@ ManagedValue Conversion::emit(SILGenFunction &SGF, SILLocation loc,
   case SubstToOrig:
     return SGF.emitSubstToOrigValue(loc, value,
                                     getReabstractionOrigType(),
-                                    getReabstractionSubstType(), C);
+                                    getReabstractionSubstType(),
+                                    getReabstractionLoweredResultType(), C);
 
   case OrigToSubst:
     return SGF.emitOrigToSubstValue(loc, value,
                                     getReabstractionOrigType(),
-                                    getReabstractionSubstType(), C);
+                                    getReabstractionSubstType(),
+                                    getReabstractionLoweredResultType(), C);
   }
   llvm_unreachable("bad kind");
 }
@@ -1231,6 +1233,8 @@ static void printReabstraction(const Conversion &conversion,
   conversion.getReabstractionOrigType().print(out);
   out << ", subst: ";
   conversion.getReabstractionSubstType().print(out);
+  out << ", loweredResult: ";
+  conversion.getReabstractionLoweredResultType().print(out);
   out << ')';
 }
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1778,9 +1778,19 @@ public:
                                     AbstractionPattern origType,
                                     CanType substType,
                                     SGFContext ctx = SGFContext());
+  ManagedValue emitOrigToSubstValue(SILLocation loc, ManagedValue input,
+                                    AbstractionPattern origType,
+                                    CanType substType,
+                                    SILType loweredResultTy,
+                                    SGFContext ctx = SGFContext());
   RValue emitOrigToSubstValue(SILLocation loc, RValue &&input,
                               AbstractionPattern origType,
                               CanType substType,
+                              SGFContext ctx = SGFContext());
+  RValue emitOrigToSubstValue(SILLocation loc, RValue &&input,
+                              AbstractionPattern origType,
+                              CanType substType,
+                              SILType loweredResultTy,
                               SGFContext ctx = SGFContext());
 
   /// Convert a value with the abstraction patterns of the substituted
@@ -1792,6 +1802,16 @@ public:
   RValue emitSubstToOrigValue(SILLocation loc, RValue &&input,
                               AbstractionPattern origType,
                               CanType substType,
+                              SGFContext ctx = SGFContext());
+  ManagedValue emitSubstToOrigValue(SILLocation loc, ManagedValue input,
+                                    AbstractionPattern origType,
+                                    CanType substType,
+                                    SILType loweredResultTy,
+                                    SGFContext ctx = SGFContext());
+  RValue emitSubstToOrigValue(SILLocation loc, RValue &&input,
+                              AbstractionPattern origType,
+                              CanType substType,
+                              SILType loweredResultTy,
                               SGFContext ctx = SGFContext());
 
   /// Transform the AST-level types in the function signature without an
@@ -1807,12 +1827,14 @@ public:
                                     CanType inputSubstType,
                                     AbstractionPattern outputOrigType,
                                     CanType outputSubstType,
+                                    SILType loweredResultTy,
                                     SGFContext ctx = SGFContext());
   RValue emitTransformedValue(SILLocation loc, RValue &&input,
                               AbstractionPattern inputOrigType,
                               CanType inputSubstType,
                               AbstractionPattern outputOrigType,
                               CanType outputSubstType,
+                              SILType loweredResultTy,
                               SGFContext ctx = SGFContext());
 
   /// Used for emitting SILArguments of bare functions, such as thunks.

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1969,8 +1969,11 @@ namespace {
                                        keyPathTy->getGenericArgs(),
                                        ArrayRef<ProtocolConformanceRef>());
 
+      auto origType = AbstractionPattern::getOpaque();
+      auto loweredTy = SGF.getLoweredType(origType, value.getSubstRValueType());
+
       auto setValue =
-        std::move(value).getAsSingleValue(SGF, AbstractionPattern::getOpaque());
+        std::move(value).getAsSingleValue(SGF, origType, loweredTy);
       if (!setValue.getType().isAddress()) {
         setValue = setValue.materialize(SGF, loc);
       }
@@ -3523,7 +3526,8 @@ ManagedValue SILGenFunction::emitLoad(SILLocation loc, SILValue addr,
       ? Conversion::getBridging(Conversion::BridgeFromObjC,
                                 origFormalType.getType(),
                                 substFormalType, rvalueTL.getLoweredType())
-      : Conversion::getOrigToSubst(origFormalType, substFormalType);
+      : Conversion::getOrigToSubst(origFormalType, substFormalType,
+                                   rvalueTL.getLoweredType());
 
   return emitConvertedRValue(loc, conversion, C,
       [&](SILGenFunction &SGF, SILLocation loc, SGFContext C) {

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -211,7 +211,8 @@ void SILGenFunction::emitCurryThunk(SILDeclRef thunk) {
       toClosure =
         emitTransformedValue(loc, toClosure,
                              appliedFnPattern, formalType,
-                             appliedThunkPattern, formalType);
+                             appliedThunkPattern, formalType,
+                             resultTy);
     }
   }
   toClosure = S.popPreservingValue(toClosure);

--- a/test/SILGen/variant_overrides.swift
+++ b/test/SILGen/variant_overrides.swift
@@ -12,6 +12,28 @@ class B<T> : A {
   override func foo(block: @escaping (B<T>) -> Void) {}
 }
 
+// CHECK-LABEL: sil hidden [ossa] @$s17variant_overrides12useAtGeneric1byAA1BCyxG_tlF
+func useAtGeneric<T>(b: B<T>) {
+  // CHECK: [[CLOSURE_FUNC:%.*]] = function_ref @$s17variant_overrides12useAtGeneric1byAA1BCyxG_tlFyAFcfU_ : $@convention(thin) <τ_0_0> (@guaranteed B<τ_0_0>) -> ()
+  // CHECK: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_FUNC]]<T>() : $@convention(thin) <τ_0_0> (@guaranteed B<τ_0_0>) -> ()
+  // CHECK: [[CLOSURE_CONVERTED:%.*]] = convert_function [[CLOSURE]] : $@callee_guaranteed (@guaranteed B<T>) -> () to $@callee_guaranteed @substituted <τ_0_0> (@guaranteed B<τ_0_0>) -> () for <T>
+  // CHECK: [[METHOD:%.*]] =  class_method %0 : $B<T>, #B.foo!1 : <T> (B<T>) -> (@escaping (B<T>) -> ()) -> (), $@convention(method) <τ_0_0> (@guaranteed @callee_guaranteed @substituted <τ_0_0> (@guaranteed B<τ_0_0>) -> () for <τ_0_0>, @guaranteed B<τ_0_0>) -> ()
+  // CHECK: apply [[METHOD]]<T>(%4, %0) : $@convention(method) <τ_0_0> (@guaranteed @callee_guaranteed @substituted <τ_0_0> (@guaranteed B<τ_0_0>) -> () for <τ_0_0>, @guaranteed B<τ_0_0>) -> ()
+
+  b.foo {_ in ()}
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s17variant_overrides13useAtConcrete1byAA1BCySiG_tF
+func useAtConcrete(b: B<Int>) {
+  // CHECK: [[CLOSURE_FUNC:%.*]] = function_ref @$s17variant_overrides13useAtConcrete1byAA1BCySiG_tFyAFcfU_ : $@convention(thin) (@guaranteed B<Int>) -> ()
+  // CHECK: [[CLOSURE:%.*]] = thin_to_thick_function [[CLOSURE_FUNC]] : $@convention(thin) (@guaranteed B<Int>) -> () to $@callee_guaranteed (@guaranteed B<Int>) -> ()
+  // CHECK: [[CLOSURE_CONVERTED:%.*]] = convert_function [[CLOSURE]] : $@callee_guaranteed (@guaranteed B<Int>) -> () to $@callee_guaranteed @substituted <τ_0_0> (@guaranteed B<τ_0_0>) -> () for <Int>
+  // CHECK: [[METHOD:%.*]] =  class_method %0 : $B<Int>, #B.foo!1 : <T> (B<T>) -> (@escaping (B<T>) -> ()) -> (), $@convention(method) <τ_0_0> (@guaranteed @callee_guaranteed @substituted <τ_0_0> (@guaranteed B<τ_0_0>) -> () for <τ_0_0>, @guaranteed B<τ_0_0>) -> ()
+  // CHECK: apply [[METHOD]]<Int>(%4, %0) : $@convention(method) <τ_0_0> (@guaranteed @callee_guaranteed @substituted <τ_0_0> (@guaranteed B<τ_0_0>) -> () for <τ_0_0>, @guaranteed B<τ_0_0>) -> ()
+
+  b.foo {_ in ()}
+}
+
 //   FIXME: allowing this without a thunk silently reinterprets the function to a different abstraction!
 // CHECK-LABEL: sil_vtable B {
 // CHECK:          #A.foo!1: (A) -> (@escaping (A) -> ()) -> () : @$s17variant_overrides1BC3foo5blockyyACyxGc_tF [override]


### PR DESCRIPTION
This fixes an immediate bug with subst-to-orig conversion of parameter functions that I'm surprised isn't otherwise tested. More importantly, it preserves valuable information that should let us handle a much wider variety of variant representations that aren't necessarily expressed in the AbstractionPattern.