### PR TITLE
Removed a catch-all default implementation of ASTVisitor::visitTypeRepr

### DIFF
--- a/include/swift/AST/ASTVisitor.h
+++ b/include/swift/AST/ASTVisitor.h
@@ -127,10 +127,6 @@ public:
     llvm_unreachable("Not reachable, all cases handled");
   }
 
-  TypeReprRetTy visitTypeRepr(TypeRepr *T, Args... AA) {
-    return TypeReprRetTy();
-  }
-
 #define TYPEREPR(CLASS, PARENT) \
   TypeReprRetTy visit##CLASS##TypeRepr(CLASS##TypeRepr *T, Args... AA) {\
     return static_cast<ImplClass*>(this)->visit##PARENT(T, \

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3003,6 +3003,31 @@ public:
     OS << " type="; Ty.dump(OS);
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
+
+  void visitSILBoxTypeRepr(SILBoxTypeRepr *T) {
+    printCommon("sil_box");
+    Indent += 2;
+
+    ArrayRef<SILBoxTypeReprField> Fields = T->getFields();
+    for (unsigned i = 0, end = Fields.size(); i != end; ++i) {
+      OS << '\n';
+      printCommon("sil_box_field");
+      if (Fields[i].isMutable()) {
+        OS << " mutable";
+      }
+      OS << '\n';
+      printRec(Fields[i].getFieldType());
+      PrintWithColorRAII(OS, ParenthesisColor) << ')';
+    }
+
+    for (auto genArg : T->getGenericArguments()) {
+      OS << '\n';
+      printRec(genArg);
+    }
+
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
+    Indent -= 2;
+  }
 };
 
 } // end anonymous namespace

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3674,6 +3674,10 @@ public:
     return !checkStatements;
   }
 
+  void visitTypeRepr(TypeRepr *T) {
+    // Do nothing for all TypeReprs except the ones listed below.
+  }
+
   void visitIdentTypeRepr(IdentTypeRepr *T) {
     if (T->isInvalid())
       return;


### PR DESCRIPTION
Other AST nodes don't have such functionality now, and it was removed from them previously. Not having a default implementation means that users of ASTVisitor have to either explicitly write a catch-all default, or handle all cases. Making this decision consciously is a good practice.