### PR TITLE
Improve optimization of lazy properties.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -938,6 +938,19 @@ function itself does not need this attribute. It is private and only
 called within the addressor.
 ::
 
+  sil-function-purpose ::= 'lazy_getter'
+
+The function is a getter of a lazy property for which the backing storage is
+an ``Optional`` of the property's type. The getter contains a top-level
+``switch_enum`` (or ``switch_enum_addr``), which tests if the lazy property
+is already computed. In the ``None``-case, the property is computed and stored
+to the backing storage of the property.
+
+After the first call of a lazy property getter, it is guaranteed that the
+property is computed and consecutive calls always execute the ``Some``-case of
+the top-level ``switch_enum``.
+::
+
   sil-function-attribute ::= '[weak_imported]'
 
 Cross-module references to this function should always use weak linking.

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -118,6 +118,13 @@ class SILFunction
 public:
   using BlockListType = llvm::iplist<SILBasicBlock>;
 
+  // For more information see docs/SIL.rst
+  enum class Purpose : uint8_t {
+    None,
+    GlobalInit,
+    LazyPropertyGetter
+  };
+
 private:
   friend class SILBasicBlock;
   friend class SILModule;
@@ -182,6 +189,8 @@ private:
   /// The availability used to determine if declarations of this function
   /// should use weak linking.
   AvailabilityContext Availability;
+
+  Purpose specialPurpose = Purpose::None;
 
   /// This is the number of uses of this SILFunction inside the SIL.
   /// It does not include references from debug scopes.
@@ -806,6 +815,8 @@ public:
   void setEffectsKind(EffectsKind E) {
     EffectsKindAttr = unsigned(E);
   }
+  
+  Purpose getSpecialPurpose() const { return specialPurpose; }
 
   /// Get this function's global_init attribute.
   ///
@@ -819,8 +830,13 @@ public:
   /// generated from a global variable access. Note that the initialization
   /// function itself does not need this attribute. It is private and only
   /// called within the addressor.
-  bool isGlobalInit() const { return GlobalInitFlag; }
-  void setGlobalInit(bool isGI) { GlobalInitFlag = isGI; }
+  bool isGlobalInit() const { return specialPurpose == Purpose::GlobalInit; }
+
+  bool isLazyPropertyGetter() const {
+    return specialPurpose == Purpose::LazyPropertyGetter;
+  }
+
+  void setSpecialPurpose(Purpose purpose) { specialPurpose = purpose; }
 
   /// Return whether this function has a foreign implementation which can
   /// be emitted on demand.

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2444,8 +2444,16 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
   if (isWithoutActuallyEscapingThunk())
     OS << "[without_actually_escaping] ";
 
-  if (isGlobalInit())
+  switch (getSpecialPurpose()) {
+  case SILFunction::Purpose::None:
+    break;
+  case SILFunction::Purpose::GlobalInit:
     OS << "[global_init] ";
+    break;
+  case SILFunction::Purpose::LazyPropertyGetter:
+    OS << "[lazy_getter] ";
+    break;
+  }
   if (isAlwaysWeakImported())
     OS << "[weak_imported] ";
   auto availability = getAvailabilityForLinkage();

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -31,6 +31,9 @@
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
+#include "swift/SILOptimizer/Utils/SILInliner.h"
+#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
+#include "swift/SILOptimizer/Utils/BasicBlockOptUtils.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopedHashTable.h"
@@ -444,6 +447,10 @@ namespace swift {
 /// eliminating trivially redundant instructions and using simplifyInstruction
 /// to canonicalize things as it goes. It is intended to be fast and catch
 /// obvious cases so that SILCombine and other passes are more effective.
+///
+/// It also optimizes calls to lazy property getters: If such a call is
+/// dominated by another call to the same getter, it is replaced by a direct
+/// load of the property - assuming that it is already computed.
 class CSE {
 public:
   typedef llvm::ScopedHashTableVal<SimpleValue, ValueBase *> SimpleValueHTType;
@@ -462,11 +469,21 @@ public:
 
   SideEffectAnalysis *SEA;
 
-  CSE(bool RunsOnHighLevelSil, SideEffectAnalysis *SEA)
-      : SEA(SEA), RunsOnHighLevelSil(RunsOnHighLevelSil) {}
+  SILOptFunctionBuilder &FuncBuilder;
+  
+  /// The set of calls to lazy property getters which can be replace by a direct
+  /// load of the property value.
+  llvm::SmallVector<ApplyInst *, 8> lazyPropertyGetters;
+
+  CSE(bool RunsOnHighLevelSil, SideEffectAnalysis *SEA,
+      SILOptFunctionBuilder &FuncBuilder)
+      : SEA(SEA), FuncBuilder(FuncBuilder),
+        RunsOnHighLevelSil(RunsOnHighLevelSil) {}
 
   bool processFunction(SILFunction &F, DominanceInfo *DT);
-  
+
+  bool processLazyPropertyGetters();
+
   bool canHandle(SILInstruction *Inst);
 
 private:
@@ -574,6 +591,40 @@ bool CSE::processFunction(SILFunction &Fm, DominanceInfo *DT) {
   } // while (!nodes...)
 
   return Changed;
+}
+
+/// Replace lazy property getters (which are dominated by the same getter)
+/// by a direct load of the value.
+bool CSE::processLazyPropertyGetters() {
+  bool changed = false;
+  for (ApplyInst *ai : lazyPropertyGetters) {
+    SILFunction *getter = ai->getReferencedFunctionOrNull();
+    assert(getter && getter->isLazyPropertyGetter());
+    SILBasicBlock *callBlock = ai->getParent();
+
+    // Inline the getter...
+    SILInliner::inlineFullApply(ai, SILInliner::InlineKind::PerformanceInline,
+                                FuncBuilder);
+    
+    // ...and fold the switch_enum in the first block to the Optional.some case.
+    // The Optional.none branch becomes dead.
+    auto *sei = cast<SwitchEnumInst>(callBlock->getTerminator());
+    ASTContext &ctxt = callBlock->getParent()->getModule().getASTContext();
+    EnumElementDecl *someDecl = ctxt.getOptionalSomeDecl();
+    SILBasicBlock *someDest = sei->getCaseDestination(someDecl);
+    assert(someDest->getNumArguments() == 1);
+    SILValue enumVal = sei->getOperand();
+    SILBuilder builder(sei);
+    SILType ty = enumVal->getType().getEnumElementType(someDecl,
+                           sei->getModule(), builder.getTypeExpansionContext());
+    auto *ued =
+        builder.createUncheckedEnumData(sei->getLoc(), enumVal, someDecl, ty);
+    builder.createBranch(sei->getLoc(), someDest, { ued });
+    sei->eraseFromParent();
+    changed = true;
+    ++NumCSE;
+  }
+  return changed;
 }
 
 namespace {
@@ -768,6 +819,34 @@ bool CSE::processOpenExistentialRef(OpenExistentialRefInst *Inst,
   return true;
 }
 
+/// Returns true if \p ai is a call to a lazy property getter, which we can
+/// handle.
+static bool isLazyPropertyGetter(ApplyInst *ai) {
+  SILFunction *callee = ai->getReferencedFunctionOrNull();
+  if (!callee || callee->isExternalDeclaration() ||
+      !callee->isLazyPropertyGetter())
+    return false;
+
+  // Check if the first block has a switch_enum of an Optional.
+  // We don't handle getters of generic types, which have a switch_enum_addr.
+  // This will be obsolete with opaque values anyway.
+  auto *SEI = dyn_cast<SwitchEnumInst>(callee->getEntryBlock()->getTerminator());
+  if (!SEI)
+    return false;
+
+  ASTContext &ctxt = SEI->getFunction()->getModule().getASTContext();
+  EnumElementDecl *someDecl = ctxt.getOptionalSomeDecl();
+
+  for (unsigned i = 0, e = SEI->getNumCases(); i != e; ++i) {
+    auto Entry = SEI->getCase(i);
+    if (Entry.first == someDecl) {
+      SILBasicBlock *destBlock = Entry.second;
+      return destBlock->getNumArguments() == 1;
+    }
+  }
+  return false;
+}
+
 bool CSE::processNode(DominanceInfoNode *Node) {
   SILBasicBlock *BB = Node->getBlock();
   bool Changed = false;
@@ -817,6 +896,16 @@ bool CSE::processNode(DominanceInfoNode *Node) {
     if (SILInstruction *AvailInst = AvailableValues->lookup(Inst)) {
       LLVM_DEBUG(llvm::dbgs() << "SILCSE CSE: " << *Inst << "  to: "
                               << *AvailInst << '\n');
+
+      auto *AI = dyn_cast<ApplyInst>(Inst);
+      if (AI && isLazyPropertyGetter(AI)) {
+        // We do the actual transformation for lazy property getters later. It
+        // changes the CFG and we don't want to disturb the dominator tree walk
+        // here.
+        lazyPropertyGetters.push_back(AI);
+        continue;
+      }
+                              
       // Instructions producing a new opened archetype need a special handling,
       // because replacing these instructions may require a replacement
       // of the opened archetype type operands in some of the uses.
@@ -872,6 +961,9 @@ bool CSE::canHandle(SILInstruction *Inst) {
     // _convert_ a global_addr to a reference and retain it.
     auto MB = Effects.getMemBehavior(RetainObserveKind::ObserveRetains);
     if (MB == SILInstruction::MemoryBehavior::None)
+      return true;
+    
+    if (isLazyPropertyGetter(AI))
       return true;
     
     return false;
@@ -1172,8 +1264,9 @@ class SILCSE : public SILFunctionTransform {
     DominanceAnalysis* DA = getAnalysis<DominanceAnalysis>();
 
     auto *SEA = PM->getAnalysis<SideEffectAnalysis>();
+    SILOptFunctionBuilder FuncBuilder(*this);
 
-    CSE C(RunsOnHighLevelSil, SEA);
+    CSE C(RunsOnHighLevelSil, SEA, FuncBuilder);
     bool Changed = false;
 
     // Perform the traditional CSE.
@@ -1182,7 +1275,15 @@ class SILCSE : public SILFunctionTransform {
     // Perform CSE of existential and witness_method instructions.
     Changed |= CSEExistentialCalls(getFunction(),
                                           DA->get(getFunction()));
-    if (Changed) {
+
+    // Handle calls to lazy property getters, which are collected in
+    // processFunction().
+    if (C.processLazyPropertyGetters()) {
+      // Cleanup the dead blocks from the inlined lazy property getters.
+      removeUnreachableBlocks(*getFunction());
+
+      invalidateAnalysis(SILAnalysis::InvalidationKind::Everything);
+    } else if (Changed) {
       invalidateAnalysis(SILAnalysis::InvalidationKind::CallsAndInstructions);
     }
   }

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -511,14 +511,14 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
   IdentifierID replacedFunctionID;
   GenericSignatureID genericSigID;
   unsigned rawLinkage, isTransparent, isSerialized, isThunk,
-      isWithoutactuallyEscapingThunk, isGlobal, inlineStrategy,
+      isWithoutactuallyEscapingThunk, specialPurpose, inlineStrategy,
       optimizationMode, effect, numSpecAttrs, hasQualifiedOwnership,
       isWeakImported, LIST_VER_TUPLE_PIECES(available),
       isDynamic, isExactSelfClass;
   ArrayRef<uint64_t> SemanticsIDs;
   SILFunctionLayout::readRecord(
       scratch, rawLinkage, isTransparent, isSerialized, isThunk,
-      isWithoutactuallyEscapingThunk, isGlobal, inlineStrategy,
+      isWithoutactuallyEscapingThunk, specialPurpose, inlineStrategy,
       optimizationMode, effect, numSpecAttrs, hasQualifiedOwnership,
       isWeakImported, LIST_VER_TUPLE_PIECES(available),
       isDynamic, isExactSelfClass,
@@ -630,7 +630,7 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     fn->setThunk(IsThunk_t(isThunk));
     fn->setWithoutActuallyEscapingThunk(bool(isWithoutactuallyEscapingThunk));
     fn->setInlineStrategy(Inline_t(inlineStrategy));
-    fn->setGlobalInit(isGlobal == 1);
+    fn->setSpecialPurpose(SILFunction::Purpose(specialPurpose));
     fn->setEffectsKind(EffectsKind(effect));
     fn->setOptimizationMode(OptimizationMode(optimizationMode));
     fn->setAlwaysWeakImported(isWeakImported);

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 546; // Avoid conflict with downstream bump
+const uint16_t SWIFTMODULE_VERSION_MINOR = 547; // lazyPropertyGetter flag
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -273,7 +273,7 @@ namespace sil_block {
                      BCFixed<2>,  // serialized
                      BCFixed<2>,  // thunks: signature optimized/reabstraction
                      BCFixed<1>,  // without_actually_escaping
-                     BCFixed<1>,  // global_init
+                     BCFixed<3>,  // specialPurpose
                      BCFixed<2>,  // inlineStrategy
                      BCFixed<2>,  // optimizationMode
                      BCFixed<3>,  // side effect info.

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -434,7 +434,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
       Out, ScratchRecord, abbrCode, toStableSILLinkage(Linkage),
       (unsigned)F.isTransparent(), (unsigned)F.isSerialized(),
       (unsigned)F.isThunk(), (unsigned)F.isWithoutActuallyEscapingThunk(),
-      (unsigned)F.isGlobalInit(), (unsigned)F.getInlineStrategy(),
+      (unsigned)F.getSpecialPurpose(), (unsigned)F.getInlineStrategy(),
       (unsigned)F.getOptimizationMode(), (unsigned)F.getEffectsKind(),
       (unsigned)numSpecAttrs, (unsigned)F.hasOwnership(),
       F.isAlwaysWeakImported(), LIST_VER_TUPLE_PIECES(available),

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -1651,6 +1651,13 @@ bb0:
   return %0 : $()
 }
 
+// CHECK-LABEL: sil [lazy_getter] @test_lazy_getter
+sil [lazy_getter] @test_lazy_getter : $@convention(thin) () -> () {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+}
+
 struct EmptyStruct {}
 
 sil @test_empty_destructure : $@convention(thin) () -> () {

--- a/test/SIL/Serialization/basic.sil
+++ b/test/SIL/Serialization/basic.sil
@@ -58,6 +58,14 @@ entry(%0 : @guaranteed $@callee_guaranteed @substituted <C, D> (@in C, @in D) ->
   return undef : $()
 }
 
+// CHECK-LABEL: sil [lazy_getter] @test_lazy_getter
+sil [lazy_getter] @test_lazy_getter : $@convention(thin) () -> () {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+}
+
+
 struct EmptyStruct {}
 
 sil @test_empty_destructure : $@convention(thin) () -> () {

--- a/test/SILGen/lazy_properties.swift
+++ b/test/SILGen/lazy_properties.swift
@@ -2,7 +2,7 @@
 
 // <rdar://problem/17405715> lazy property crashes silgen of implicit memberwise initializer
 
-// CHECK-LABEL: sil hidden [ossa] @$s15lazy_properties19StructWithLazyFieldV4onceSivg : $@convention(method) (@inout StructWithLazyField) -> Int
+// CHECK-LABEL: sil hidden [lazy_getter] [ossa] @$s15lazy_properties19StructWithLazyFieldV4onceSivg : $@convention(method) (@inout StructWithLazyField) -> Int
 
 // CHECK-LABEL: sil hidden [ossa] @$s15lazy_properties19StructWithLazyFieldV4onceSivs : $@convention(method) (Int, @inout StructWithLazyField) -> ()
 
@@ -23,7 +23,7 @@ func test21057425() {
 
 // Anonymous closure parameters in lazy initializer crash SILGen
 
-// CHECK-LABEL: sil hidden [ossa] @$s15lazy_properties22HasAnonymousParametersV1xSivg : $@convention(method) (@inout HasAnonymousParameters) -> Int
+// CHECK-LABEL: sil hidden [lazy_getter] [ossa] @$s15lazy_properties22HasAnonymousParametersV1xSivg : $@convention(method) (@inout HasAnonymousParameters) -> Int
 
 // CHECK-LABEL: sil private [ossa] @$s15lazy_properties22HasAnonymousParametersV1xSivgS2iXEfU_ : $@convention(thin) (Int) -> Int
 
@@ -39,7 +39,7 @@ class LazyClass {
   lazy var x = 0
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s15lazy_properties9LazyClassC1xSivg : $@convention(method) (@guaranteed LazyClass) -> Int
+// CHECK-LABEL: sil hidden [lazy_getter] [ossa] @$s15lazy_properties9LazyClassC1xSivg : $@convention(method) (@guaranteed LazyClass) -> Int
 // CHECK: ref_element_addr %0 : $LazyClass, #LazyClass.$__lazy_storage_$_x
 // CHECK: return
 

--- a/test/SILGen/lazy_properties.swift
+++ b/test/SILGen/lazy_properties.swift
@@ -2,7 +2,7 @@
 
 // <rdar://problem/17405715> lazy property crashes silgen of implicit memberwise initializer
 
-// CHECK-LABEL: sil hidden [lazy_getter] [ossa] @$s15lazy_properties19StructWithLazyFieldV4onceSivg : $@convention(method) (@inout StructWithLazyField) -> Int
+// CHECK-LABEL: sil hidden [lazy_getter] [noinline] [ossa] @$s15lazy_properties19StructWithLazyFieldV4onceSivg : $@convention(method) (@inout StructWithLazyField) -> Int
 
 // CHECK-LABEL: sil hidden [ossa] @$s15lazy_properties19StructWithLazyFieldV4onceSivs : $@convention(method) (Int, @inout StructWithLazyField) -> ()
 
@@ -23,7 +23,7 @@ func test21057425() {
 
 // Anonymous closure parameters in lazy initializer crash SILGen
 
-// CHECK-LABEL: sil hidden [lazy_getter] [ossa] @$s15lazy_properties22HasAnonymousParametersV1xSivg : $@convention(method) (@inout HasAnonymousParameters) -> Int
+// CHECK-LABEL: sil hidden [lazy_getter] [noinline] [ossa] @$s15lazy_properties22HasAnonymousParametersV1xSivg : $@convention(method) (@inout HasAnonymousParameters) -> Int
 
 // CHECK-LABEL: sil private [ossa] @$s15lazy_properties22HasAnonymousParametersV1xSivgS2iXEfU_ : $@convention(thin) (Int) -> Int
 
@@ -39,7 +39,7 @@ class LazyClass {
   lazy var x = 0
 }
 
-// CHECK-LABEL: sil hidden [lazy_getter] [ossa] @$s15lazy_properties9LazyClassC1xSivg : $@convention(method) (@guaranteed LazyClass) -> Int
+// CHECK-LABEL: sil hidden [lazy_getter] [noinline] [ossa] @$s15lazy_properties9LazyClassC1xSivg : $@convention(method) (@guaranteed LazyClass) -> Int
 // CHECK: ref_element_addr %0 : $LazyClass, #LazyClass.$__lazy_storage_$_x
 // CHECK: return
 

--- a/test/SILGen/objc_properties.swift
+++ b/test/SILGen/objc_properties.swift
@@ -242,7 +242,7 @@ class HasLazyProperty : NSObject, HasProperty {
   lazy var window = self.instanceMethod()
 }
 
-// CHECK-LABEL: sil hidden [lazy_getter] [ossa] @$s15objc_properties15HasLazyPropertyC6windowSo8NSObjectCSgvg : $@convention(method) (@guaranteed HasLazyProperty) -> @owned Optional<NSObject> {
+// CHECK-LABEL: sil hidden [lazy_getter] [noinline] [ossa] @$s15objc_properties15HasLazyPropertyC6windowSo8NSObjectCSgvg : $@convention(method) (@guaranteed HasLazyProperty) -> @owned Optional<NSObject> {
 // CHECK: class_method %0 : $HasLazyProperty, #HasLazyProperty.instanceMethod!1 : (HasLazyProperty) -> () -> NSObject?
 // CHECK: return
 

--- a/test/SILGen/objc_properties.swift
+++ b/test/SILGen/objc_properties.swift
@@ -242,7 +242,7 @@ class HasLazyProperty : NSObject, HasProperty {
   lazy var window = self.instanceMethod()
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s15objc_properties15HasLazyPropertyC6windowSo8NSObjectCSgvg : $@convention(method) (@guaranteed HasLazyProperty) -> @owned Optional<NSObject> {
+// CHECK-LABEL: sil hidden [lazy_getter] [ossa] @$s15objc_properties15HasLazyPropertyC6windowSo8NSObjectCSgvg : $@convention(method) (@guaranteed HasLazyProperty) -> @owned Optional<NSObject> {
 // CHECK: class_method %0 : $HasLazyProperty, #HasLazyProperty.instanceMethod!1 : (HasLazyProperty) -> () -> NSObject?
 // CHECK: return
 

--- a/test/SILGen/opaque_result_type.swift
+++ b/test/SILGen/opaque_result_type.swift
@@ -157,7 +157,7 @@ class Sub2 : Base {}
 
 public class D {
    var cond = true
-   // CHECK-LABEL: sil private [ossa] @$s18opaque_result_type1DC1c33_C2C55A4BAF30C3244D4A165D48A91142LLQrvg
+   // CHECK-LABEL: sil private [lazy_getter] [ossa] @$s18opaque_result_type1DC1c33_C2C55A4BAF30C3244D4A165D48A91142LLQrvg
    // CHECK: bb3([[RET:%[0-9]+]] : @owned $Base):
    // CHECH:  return [[RET]]
    // CHECK: } // end sil function '$s18opaque_result_type1DC1c33_C2C55A4BAF30C3244D4A165D48A91142LLQrvg'

--- a/test/SILGen/opaque_result_type.swift
+++ b/test/SILGen/opaque_result_type.swift
@@ -157,7 +157,7 @@ class Sub2 : Base {}
 
 public class D {
    var cond = true
-   // CHECK-LABEL: sil private [lazy_getter] [ossa] @$s18opaque_result_type1DC1c33_C2C55A4BAF30C3244D4A165D48A91142LLQrvg
+   // CHECK-LABEL: sil private [lazy_getter] [noinline] [ossa] @$s18opaque_result_type1DC1c33_C2C55A4BAF30C3244D4A165D48A91142LLQrvg
    // CHECK: bb3([[RET:%[0-9]+]] : @owned $Base):
    // CHECH:  return [[RET]]
    // CHECK: } // end sil function '$s18opaque_result_type1DC1c33_C2C55A4BAF30C3244D4A165D48A91142LLQrvg'

--- a/test/SILGen/optional_to_bool.swift
+++ b/test/SILGen/optional_to_bool.swift
@@ -5,10 +5,10 @@ extension Int: P {}
 
 public class A {}
 public class B: A {
-  // CHECK-LABEL: sil [ossa] @$s16optional_to_bool1BC1x{{[_0-9a-zA-Z]*}}vg
+  // CHECK-LABEL: sil [lazy_getter] [ossa] @$s16optional_to_bool1BC1x{{[_0-9a-zA-Z]*}}vg
   // CHECK:         switch_enum {{%.*}} : $Optional<Int>
   public lazy var x: Int = 0
-  // CHECK-LABEL: sil [ossa] @$s16optional_to_bool1BC1y{{[_0-9a-zA-Z]*}}vg
+  // CHECK-LABEL: sil [lazy_getter] [ossa] @$s16optional_to_bool1BC1y{{[_0-9a-zA-Z]*}}vg
   // CHECK:         switch_enum_addr {{%.*}} : $*Optional<P>
   public lazy var y: P = 0
 }

--- a/test/SILGen/optional_to_bool.swift
+++ b/test/SILGen/optional_to_bool.swift
@@ -5,10 +5,10 @@ extension Int: P {}
 
 public class A {}
 public class B: A {
-  // CHECK-LABEL: sil [lazy_getter] [ossa] @$s16optional_to_bool1BC1x{{[_0-9a-zA-Z]*}}vg
+  // CHECK-LABEL: sil [lazy_getter] [noinline] [ossa] @$s16optional_to_bool1BC1x{{[_0-9a-zA-Z]*}}vg
   // CHECK:         switch_enum {{%.*}} : $Optional<Int>
   public lazy var x: Int = 0
-  // CHECK-LABEL: sil [lazy_getter] [ossa] @$s16optional_to_bool1BC1y{{[_0-9a-zA-Z]*}}vg
+  // CHECK-LABEL: sil [lazy_getter] [noinline] [ossa] @$s16optional_to_bool1BC1y{{[_0-9a-zA-Z]*}}vg
   // CHECK:         switch_enum_addr {{%.*}} : $*Optional<P>
   public lazy var y: P = 0
 }

--- a/test/SILOptimizer/lazy_property_getters.swift
+++ b/test/SILOptimizer/lazy_property_getters.swift
@@ -1,0 +1,138 @@
+// RUN: %target-swift-frontend  -primary-file %s -O -sil-verify-all -module-name=test -emit-sil | %FileCheck %s
+
+// Also do an end-to-end test to check if the generated code is correct.
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift -O -Xllvm -module-name=test %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
+// REQUIRES: executable_test
+
+var g = 0
+
+final class Myclass {
+  lazy var lvar: Int = {
+    print("lvar init")
+    return g
+  }()
+}
+
+struct Mystruct {
+  lazy var lvar: Int = {
+    print("lvar init")
+    return g
+  }()
+}
+
+// CHECK-LABEL: sil {{.*}} @$s4test0A7_simpleySiAA7MyclassCF
+// CHECK:   [[GETTER:%[0-9]+]] = function_ref @$s4test7MyclassC4lvarSivg
+// CHECK:   [[V1:%[0-9]+]] = apply [[GETTER]](%0)
+// CHECK:   [[V2OPT:%[0-9]+]] = load
+// CHECK:   [[V2:%[0-9]+]] = unchecked_enum_data [[V2OPT]]
+// CHECK:   [[V1VAL:%[0-9]+]] = struct_extract [[V1]]
+// CHECK:   [[V2VAL:%[0-9]+]] = struct_extract [[V2]]
+// CHECK:   builtin "sadd{{.*}}"([[V1VAL]] {{.*}}, [[V2VAL]]
+// CHECK: } // end sil function '$s4test0A7_simpleySiAA7MyclassCF'
+@inline(never)
+func test_simple(_ c: Myclass) -> Int {
+  g = 27
+  let v1 = c.lvar
+  let v2 = c.lvar
+  return v1 &+ v2
+}
+
+// CHECK-LABEL: sil {{.*}} @$s4test0A4_cfgySiAA7MyclassC_SbtF
+// CHECK:   [[GETTER:%[0-9]+]] = function_ref @$s4test7MyclassC4lvarSivg
+// CHECK:   [[V1:%[0-9]+]] = apply [[GETTER]](%0)
+// CHECK: bb1:
+// CHECK:   [[V2OPT:%[0-9]+]] = load
+// CHECK:   [[V2:%[0-9]+]] = unchecked_enum_data [[V2OPT]]
+// CHECK:   [[V2VAL:%[0-9]+]] = struct_extract [[V2]]
+// CHECK:   br bb3([[V2VAL]]
+// CHECK: bb2:
+// CHECK: bb3([[V2PHI:%[0-9]+]] {{.*}}):
+// CHECK:   [[V1VAL:%[0-9]+]] = struct_extract [[V1]]
+// CHECK:   builtin "sadd{{.*}}"([[V1VAL]] {{.*}}, [[V2PHI]]
+// CHECK: } // end sil function '$s4test0A4_cfgySiAA7MyclassC_SbtF'
+@inline(never)
+func test_cfg(_ c: Myclass, _ b: Bool) -> Int {
+  g = 10
+  let v1 = c.lvar
+  var v2: Int
+  if b {
+    v2 = c.lvar
+  } else {
+    v2 = 0
+  }
+  return v1 &+ v2
+}
+
+// CHECK-LABEL: sil {{.*}} @$s4test0A12_no_hoistingySiAA7MyclassC_SbtF
+// CHECK: bb1:
+// CHECK:   [[GETTER1:%[0-9]+]] = function_ref @$s4test7MyclassC4lvarSivg
+// CHECK:    = apply [[GETTER1]](%0)
+// CHECK: bb2:
+// CHECK:   [[GETTER2:%[0-9]+]] = function_ref @$s4test7MyclassC4lvarSivg
+// CHECK:    = apply [[GETTER2]](%0)
+// CHECK: bb3({{.*}}):
+// CHECK: } // end sil function '$s4test0A12_no_hoistingySiAA7MyclassC_SbtF'
+@inline(never)
+func test_no_hoisting(_ c: Myclass, _ b: Bool) -> Int {
+  var v: Int
+  if b {
+    g = 20
+    v = c.lvar + 2
+  } else {
+    g = 30
+    v = c.lvar + 3
+  }
+  return v
+}
+
+// CHECK-LABEL: sil {{.*}} @$s4test0A7_structySiAA8MystructVF
+// CHECK:   [[GETTER:%[0-9]+]] = function_ref @$s4test8MystructV4lvarSivg
+// CHECK:   [[V1:%[0-9]+]] = apply [[GETTER]]({{.*}})
+// CHECK:   [[V2OPT:%[0-9]+]] = load
+// CHECK:   [[V2:%[0-9]+]] = unchecked_enum_data [[V2OPT]]
+// CHECK:   [[V1VAL:%[0-9]+]] = struct_extract [[V1]]
+// CHECK:   [[V2VAL:%[0-9]+]] = struct_extract [[V2]]
+// CHECK:   builtin "sadd{{.*}}"([[V1VAL]] {{.*}}, [[V2VAL]]
+// CHECK: } // end sil function '$s4test0A7_structySiAA8MystructVF'
+@inline(never)
+func test_struct(_ s: Mystruct) -> Int {
+  var sm = s
+  g = 42
+  let v1 = sm.lvar
+  let v2 = sm.lvar
+  return v1 &+ v2
+}
+
+func calltests() {
+  // CHECK-OUTPUT-LABEL: test_simple
+  print("test_simple")
+  // CHECK-OUTPUT-NEXT:  lvar init
+  // CHECK-OUTPUT-NEXT:  54
+  print(test_simple(Myclass()))
+
+  // CHECK-OUTPUT-LABEL: test_cfg
+  print("test_cfg")
+  // CHECK-OUTPUT-NEXT:  lvar init
+  // CHECK-OUTPUT-NEXT:  20
+  print(test_cfg(Myclass(), true))
+
+  // CHECK-OUTPUT-LABEL: test_no_hoisting
+  print("test_no_hoisting")
+  // CHECK-OUTPUT-NEXT:  lvar init
+  // CHECK-OUTPUT-NEXT:  22
+  print(test_no_hoisting(Myclass(), true))
+  // CHECK-OUTPUT-NEXT:  lvar init
+  // CHECK-OUTPUT-NEXT:  33
+  print(test_no_hoisting(Myclass(), false))
+
+  // CHECK-OUTPUT-LABEL: test_struct
+  print("test_struct")
+  // CHECK-OUTPUT-NEXT:  lvar init
+  // CHECK-OUTPUT-NEXT:  84
+  print(test_struct(Mystruct()))
+}
+
+calltests()
+


### PR DESCRIPTION
There are two main changes here:

* Prevent inlining of lazy property getters

Lazy property getters are usually non tivial functions (otherwise the user would not implement it as lazy property).
Inlining such getters would most likely not benefit other optimizations because the top-level switch_enum cannot be constant folded in most cases.
Also, not inlining lazy property getters enables optimizing them in CSE.

* Optimize calls of lazy property getters

If such a call is dominated by another call to the same getter, it is replaced by a direct load of the property - assuming that it is already computed.

rdar://problem/34715412