### PR TITLE
[CodeCompletion] Call argument label with value placeholder

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3936,14 +3936,23 @@ public:
     }
   }
 
-  void addArgNameCompletionResults(ArrayRef<StringRef> Names) {
-    for (auto Name : Names) {
-      CodeCompletionResultBuilder Builder(Sink,
-                                          CodeCompletionResult::ResultKind::Keyword,
-                                          SemanticContextKind::ExpressionSpecific, {});
-      Builder.addTextChunk(Name);
-      Builder.addCallParameterColon();
-      Builder.addTypeAnnotation("Argument name");
+  void addCallArgumentCompletionResults(
+      ArrayRef<const AnyFunctionType::Param *> Args) {
+    Type ContextType;
+    if (auto typeContext = CurrDeclContext->getInnermostTypeContext())
+      ContextType = typeContext->getDeclaredTypeInContext();
+
+    for (auto *Arg : Args) {
+      CodeCompletionResultBuilder Builder(
+          Sink, CodeCompletionResult::ResultKind::Pattern,
+          SemanticContextKind::ExpressionSpecific, {});
+      Builder.addCallParameter(Arg->getLabel(), Identifier(),
+                               Arg->getPlainType(), ContextType,
+                               Arg->isVariadic(), Arg->isInOut(),
+                               /*isIUO=*/false, Arg->isAutoClosure());
+      Builder.addTypeAnnotation("Argument");
+      Builder.setExpectedTypeRelation(
+          CodeCompletionResult::ExpectedTypeRelation::NotApplicable);
     }
   }
 
@@ -5432,7 +5441,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
       }
     } else {
       // Add argument labels, then fallthrough to get values.
-      Lookup.addArgNameCompletionResults(ContextInfo.getPossibleNames());
+      Lookup.addCallArgumentCompletionResults(ContextInfo.getPossibleParams());
     }
 
     if (!Lookup.FoundFunctionCalls ||
@@ -5570,8 +5579,8 @@ void CodeCompletionCallbacksImpl::doneParsing() {
           !Lookup.FoundFunctionCalls ||
           (Lookup.FoundFunctionCalls &&
            Lookup.FoundFunctionsWithoutFirstKeyword);
-    } else if (!ContextInfo.getPossibleNames().empty()) {
-      Lookup.addArgNameCompletionResults(ContextInfo.getPossibleNames());
+    } else if (!ContextInfo.getPossibleParams().empty()) {
+      Lookup.addCallArgumentCompletionResults(ContextInfo.getPossibleParams());
 
       shouldPerformGlobalCompletion = !ContextInfo.getPossibleTypes().empty();
     }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3950,7 +3950,15 @@ public:
                                Arg->getPlainType(), ContextType,
                                Arg->isVariadic(), Arg->isInOut(),
                                /*isIUO=*/false, Arg->isAutoClosure());
-      Builder.addTypeAnnotation("Argument");
+      auto Ty = Arg->getPlainType();
+      if (Arg->isInOut()) {
+        Ty = InOutType::get(Ty);
+      } else if (Arg->isAutoClosure()) {
+        // 'Ty' may be ErrorType.
+        if (auto funcTy = Ty->getAs<FunctionType>())
+          Ty = funcTy->getResult();
+      }
+      addTypeAnnotation(Builder, Ty);
       Builder.setExpectedTypeRelation(
           CodeCompletionResult::ExpectedTypeRelation::NotApplicable);
     }

--- a/lib/IDE/ExprContextAnalysis.h
+++ b/lib/IDE/ExprContextAnalysis.h
@@ -14,6 +14,7 @@
 #define SWIFT_IDE_EXPRCONTEXTANALYSIS_H
 
 #include "swift/AST/Type.h"
+#include "swift/AST/Types.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/SourceLoc.h"
 
@@ -21,7 +22,6 @@ namespace swift {
 class DeclContext;
 class Expr;
 class ValueDecl;
-class AnyFunctionType;
 
 namespace ide {
 enum class SemanticContextKind;
@@ -54,7 +54,7 @@ struct FunctionTypeAndDecl {
 /// the expected type of the expression by analyzing its context.
 class ExprContextInfo {
   SmallVector<Type, 2> PossibleTypes;
-  SmallVector<StringRef, 2> PossibleNames;
+  SmallVector<const AnyFunctionType::Param *, 2> PossibleParams;
   SmallVector<FunctionTypeAndDecl, 2> PossibleCallees;
   bool singleExpressionBody = false;
 
@@ -73,7 +73,9 @@ public:
 
   // Returns a list of possible argument label names.
   // Valid only if \c getKind() is \c CallArgument.
-  ArrayRef<StringRef> getPossibleNames() const { return PossibleNames; }
+  ArrayRef<const AnyFunctionType::Param *> getPossibleParams() const {
+    return PossibleParams;
+  }
 
   // Returns a list of possible callee
   // Valid only if \c getKind() is \c CallArgument.

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -3,8 +3,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARG3 | %FileCheck %s -check-prefix=ARG-NAME2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARG4 | %FileCheck %s -check-prefix=EXPECT_INT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARG5 | %FileCheck %s -check-prefix=EXPECT_OSTRING
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARG6 | %FileCheck %s -check-prefix=ARG-NAME2
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARG7 | %FileCheck %s -check-prefix=ARG-NAME1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARG6 | %FileCheck %s -check-prefix=ARG-NAME3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARG7 | %FileCheck %s -check-prefix=ARG-NAME4
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARG8 | %FileCheck %s -check-prefix=EXPECT_STRING
 
 // RUN-FIXME: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERLOAD1 | %FileCheck %s -check-prefix=OVERLOAD1
@@ -171,11 +171,19 @@ class C1 {
 }
 
 // ARG-NAME1: Begin completions, 2 items
-// ARG-NAME1-DAG: Keyword/ExprSpecific:               b1: [#Argument name#]; name=b1:
-// ARG-NAME1-DAG: Keyword/ExprSpecific:               b2: [#Argument name#]; name=b2:
+// ARG-NAME1-DAG: Pattern/ExprSpecific: {#b1: Int?#}[#Argument#];
+// ARG-NAME1-DAG: Pattern/ExprSpecific: {#b2: Int?#}[#Argument#];
 
 // ARG-NAME2: Begin completions, 1 items
-// ARG-NAME2-DAG: Keyword/ExprSpecific:               b: [#Argument name#]; name=b:
+// ARG-NAME2-DAG: Pattern/ExprSpecific: {#b: Int#}[#Argument#];
+
+// ARG-NAME3: Begin completions, 1 items
+// ARG-NAME3-DAG: Pattern/ExprSpecific: {#b: String?#}[#Argument#];
+
+// ARG-NAME4: Begin completions, 2 items
+// ARG-NAME4-DAG: Pattern/ExprSpecific: {#b1: String#}[#Argument#];
+// ARG-NAME4-DAG: Pattern/ExprSpecific: {#b2: String#}[#Argument#];
+// ARG-NAME4: End completions
 
 // EXPECT_OINT: Begin completions
 // EXPECT_OINT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: f1()[#Void#]; name=f1()
@@ -336,7 +344,7 @@ extension C3 {
 // HASERROR2: End completions
 
 // HASERROR3: Begin completions
-// HASERROR3-DAG: Keyword/ExprSpecific:               b1: [#Argument name#];
+// HASERROR3-DAG: Pattern/ExprSpecific: {#b1: <<error type>>#}[#Argument#];
 // HASERROR3: End completions
 
 // HASERROR4: Begin completions
@@ -464,7 +472,7 @@ func testArg2Name1() {
 func testArg2Name3() {
   firstArg(#^FIRST_ARG_NAME_3^#,
 }
-// FIRST_ARG_NAME_3: Keyword/ExprSpecific: arg1: [#Argument name#]
+// FIRST_ARG_NAME_3: Pattern/ExprSpecific: {#arg1: Int#}[#Argument#];
 // FIRST_ARG_NAME_4: Decl[FreeFunction]/CurrModule: ['(']{#arg1: Int#}, {#arg2: Int#}[')'][#Void#];
 
 func takeArray<T>(_ x: [T]) {}
@@ -582,7 +590,7 @@ func testSubscript(obj: HasSubscript, intValue: Int, strValue: String) {
 
   let _ = obj[42, #^SUBSCRIPT_2^#
 // SUBSCRIPT_2: Begin completions, 1 items
-// SUBSCRIPT_2-NEXT: Keyword/ExprSpecific:               default: [#Argument name#]; name=default: 
+// SUBSCRIPT_2-NEXT: Pattern/ExprSpecific: {#default: String#}[#Argument#];
 
   let _ = obj[42, .#^SUBSCRIPT_2_DOT^#
 // SUBSCRIPT_2_DOT-NOT: Begin completions
@@ -659,16 +667,16 @@ func testStaticMemberCall() {
 
   let _ = TestStaticMemberCall.create2(1, #^STATIC_METHOD_SECOND^#)
 // STATIC_METHOD_SECOND: Begin completions, 3 items
-// STATIC_METHOD_SECOND: Keyword/ExprSpecific:               arg2: [#Argument name#];
-// STATIC_METHOD_SECOND: Keyword/ExprSpecific:               arg3: [#Argument name#];
-// STATIC_METHOD_SECOND: Keyword/ExprSpecific:               arg4: [#Argument name#];
+// STATIC_METHOD_SECOND: Pattern/ExprSpecific: {#arg2: Int#}[#Argument#];
+// STATIC_METHOD_SECOND: Pattern/ExprSpecific: {#arg3: Int#}[#Argument#];
+// STATIC_METHOD_SECOND: Pattern/ExprSpecific: {#arg4: Int#}[#Argument#];
 // STATIC_METHOD_SECOND: End completions
 
   let _ = TestStaticMemberCall.create2(1, arg3: 2, #^STATIC_METHOD_SKIPPED^#)
 // STATIC_METHOD_SKIPPED: Begin completions, 2 items
 // FIXME: 'arg3' shouldn't be suggested.
-// STATIC_METHOD_SKIPPED: Keyword/ExprSpecific:               arg3: [#Argument name#];
-// STATIC_METHOD_SKIPPED: Keyword/ExprSpecific:               arg4: [#Argument name#];
+// STATIC_METHOD_SKIPPED: Pattern/ExprSpecific: {#arg3: Int#}[#Argument#];
+// STATIC_METHOD_SKIPPED: Pattern/ExprSpecific: {#arg4: Int#}[#Argument#];
 // STATIC_METHOD_SKIPPED: End completions
 }
 func testImplicitMember() {
@@ -687,16 +695,16 @@ func testImplicitMember() {
 
   let _: TestStaticMemberCall = .create2(1, #^IMPLICIT_MEMBER_SECOND^#)
 // IMPLICIT_MEMBER_SECOND: Begin completions, 3 items
-// IMPLICIT_MEMBER_SECOND: Keyword/ExprSpecific:               arg2: [#Argument name#];
-// IMPLICIT_MEMBER_SECOND: Keyword/ExprSpecific:               arg3: [#Argument name#];
-// IMPLICIT_MEMBER_SECOND: Keyword/ExprSpecific:               arg4: [#Argument name#];
+// IMPLICIT_MEMBER_SECOND: Pattern/ExprSpecific: {#arg2: Int#}[#Argument#];
+// IMPLICIT_MEMBER_SECOND: Pattern/ExprSpecific: {#arg3: Int#}[#Argument#];
+// IMPLICIT_MEMBER_SECOND: Pattern/ExprSpecific: {#arg4: Int#}[#Argument#];
 // IMPLICIT_MEMBER_SECOND: End completions
 
   let _: TestStaticMemberCall = .create2(1, arg3: 2, #^IMPLICIT_MEMBER_SKIPPED^#)
 // IMPLICIT_MEMBER_SKIPPED: Begin completions, 2 items
 // FIXME: 'arg3' shouldn't be suggested.
-// IMPLICIT_MEMBER_SKIPPED: Keyword/ExprSpecific:               arg3: [#Argument name#];
-// IMPLICIT_MEMBER_SKIPPED: Keyword/ExprSpecific:               arg4: [#Argument name#];
+// IMPLICIT_MEMBER_SKIPPED: Pattern/ExprSpecific: {#arg3: Int#}[#Argument#];
+// IMPLICIT_MEMBER_SKIPPED: Pattern/ExprSpecific: {#arg4: Int#}[#Argument#];
 // IMPLICIT_MEMBER_SKIPPED: End completions
 }
 func testImplicitMemberInArrayLiteral() {

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -96,6 +96,12 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPECHECKED_OVERLOADED | %FileCheck %s -check-prefix=TYPECHECKED_OVERLOADED
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPECHECKED_TYPEEXPR | %FileCheck %s -check-prefix=TYPECHECKED_TYPEEXPR
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARG_PARAMFLAG_INOUT | %FileCheck %s -check-prefix=ARG_PARAMFLAG_INOUT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARG_PARAMFLAG_AUTOCLOSURE| %FileCheck %s -check-prefix=ARG_PARAMFLAG_AUTOCLOSURE
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARG_PARAMFLAG_IUO | %FileCheck %s -check-prefix=ARG_PARAMFLAG_IUO
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARG_PARAMFLAG_VARIADIC | %FileCheck %s -check-prefix=ARG_PARAMFLAG_VARIADIC
+
+
 var i1 = 1
 var i2 = 2
 var oi1 : Int?
@@ -171,18 +177,18 @@ class C1 {
 }
 
 // ARG-NAME1: Begin completions, 2 items
-// ARG-NAME1-DAG: Pattern/ExprSpecific: {#b1: Int?#}[#Argument#];
-// ARG-NAME1-DAG: Pattern/ExprSpecific: {#b2: Int?#}[#Argument#];
+// ARG-NAME1-DAG: Pattern/ExprSpecific: {#b1: Int?#}[#Int?#];
+// ARG-NAME1-DAG: Pattern/ExprSpecific: {#b2: Int?#}[#Int?#];
 
 // ARG-NAME2: Begin completions, 1 items
-// ARG-NAME2-DAG: Pattern/ExprSpecific: {#b: Int#}[#Argument#];
+// ARG-NAME2-DAG: Pattern/ExprSpecific: {#b: Int#}[#Int#];
 
 // ARG-NAME3: Begin completions, 1 items
-// ARG-NAME3-DAG: Pattern/ExprSpecific: {#b: String?#}[#Argument#];
+// ARG-NAME3-DAG: Pattern/ExprSpecific: {#b: String?#}[#String?#];
 
 // ARG-NAME4: Begin completions, 2 items
-// ARG-NAME4-DAG: Pattern/ExprSpecific: {#b1: String#}[#Argument#];
-// ARG-NAME4-DAG: Pattern/ExprSpecific: {#b2: String#}[#Argument#];
+// ARG-NAME4-DAG: Pattern/ExprSpecific: {#b1: String#}[#String#];
+// ARG-NAME4-DAG: Pattern/ExprSpecific: {#b2: String#}[#String#];
 // ARG-NAME4: End completions
 
 // EXPECT_OINT: Begin completions
@@ -344,7 +350,7 @@ extension C3 {
 // HASERROR2: End completions
 
 // HASERROR3: Begin completions
-// HASERROR3-DAG: Pattern/ExprSpecific: {#b1: <<error type>>#}[#Argument#];
+// HASERROR3-DAG: Pattern/ExprSpecific: {#b1: <<error type>>#}[#<<error type>>#];
 // HASERROR3: End completions
 
 // HASERROR4: Begin completions
@@ -472,7 +478,7 @@ func testArg2Name1() {
 func testArg2Name3() {
   firstArg(#^FIRST_ARG_NAME_3^#,
 }
-// FIRST_ARG_NAME_3: Pattern/ExprSpecific: {#arg1: Int#}[#Argument#];
+// FIRST_ARG_NAME_3: Pattern/ExprSpecific: {#arg1: Int#}[#Int#];
 // FIRST_ARG_NAME_4: Decl[FreeFunction]/CurrModule: ['(']{#arg1: Int#}, {#arg2: Int#}[')'][#Void#];
 
 func takeArray<T>(_ x: [T]) {}
@@ -590,7 +596,7 @@ func testSubscript(obj: HasSubscript, intValue: Int, strValue: String) {
 
   let _ = obj[42, #^SUBSCRIPT_2^#
 // SUBSCRIPT_2: Begin completions, 1 items
-// SUBSCRIPT_2-NEXT: Pattern/ExprSpecific: {#default: String#}[#Argument#];
+// SUBSCRIPT_2-NEXT: Pattern/ExprSpecific: {#default: String#}[#String#];
 
   let _ = obj[42, .#^SUBSCRIPT_2_DOT^#
 // SUBSCRIPT_2_DOT-NOT: Begin completions
@@ -667,16 +673,16 @@ func testStaticMemberCall() {
 
   let _ = TestStaticMemberCall.create2(1, #^STATIC_METHOD_SECOND^#)
 // STATIC_METHOD_SECOND: Begin completions, 3 items
-// STATIC_METHOD_SECOND: Pattern/ExprSpecific: {#arg2: Int#}[#Argument#];
-// STATIC_METHOD_SECOND: Pattern/ExprSpecific: {#arg3: Int#}[#Argument#];
-// STATIC_METHOD_SECOND: Pattern/ExprSpecific: {#arg4: Int#}[#Argument#];
+// STATIC_METHOD_SECOND: Pattern/ExprSpecific: {#arg2: Int#}[#Int#];
+// STATIC_METHOD_SECOND: Pattern/ExprSpecific: {#arg3: Int#}[#Int#];
+// STATIC_METHOD_SECOND: Pattern/ExprSpecific: {#arg4: Int#}[#Int#];
 // STATIC_METHOD_SECOND: End completions
 
   let _ = TestStaticMemberCall.create2(1, arg3: 2, #^STATIC_METHOD_SKIPPED^#)
 // STATIC_METHOD_SKIPPED: Begin completions, 2 items
 // FIXME: 'arg3' shouldn't be suggested.
-// STATIC_METHOD_SKIPPED: Pattern/ExprSpecific: {#arg3: Int#}[#Argument#];
-// STATIC_METHOD_SKIPPED: Pattern/ExprSpecific: {#arg4: Int#}[#Argument#];
+// STATIC_METHOD_SKIPPED: Pattern/ExprSpecific: {#arg3: Int#}[#Int#];
+// STATIC_METHOD_SKIPPED: Pattern/ExprSpecific: {#arg4: Int#}[#Int#];
 // STATIC_METHOD_SKIPPED: End completions
 }
 func testImplicitMember() {
@@ -695,16 +701,16 @@ func testImplicitMember() {
 
   let _: TestStaticMemberCall = .create2(1, #^IMPLICIT_MEMBER_SECOND^#)
 // IMPLICIT_MEMBER_SECOND: Begin completions, 3 items
-// IMPLICIT_MEMBER_SECOND: Pattern/ExprSpecific: {#arg2: Int#}[#Argument#];
-// IMPLICIT_MEMBER_SECOND: Pattern/ExprSpecific: {#arg3: Int#}[#Argument#];
-// IMPLICIT_MEMBER_SECOND: Pattern/ExprSpecific: {#arg4: Int#}[#Argument#];
+// IMPLICIT_MEMBER_SECOND: Pattern/ExprSpecific: {#arg2: Int#}[#Int#];
+// IMPLICIT_MEMBER_SECOND: Pattern/ExprSpecific: {#arg3: Int#}[#Int#];
+// IMPLICIT_MEMBER_SECOND: Pattern/ExprSpecific: {#arg4: Int#}[#Int#];
 // IMPLICIT_MEMBER_SECOND: End completions
 
   let _: TestStaticMemberCall = .create2(1, arg3: 2, #^IMPLICIT_MEMBER_SKIPPED^#)
 // IMPLICIT_MEMBER_SKIPPED: Begin completions, 2 items
 // FIXME: 'arg3' shouldn't be suggested.
-// IMPLICIT_MEMBER_SKIPPED: Pattern/ExprSpecific: {#arg3: Int#}[#Argument#];
-// IMPLICIT_MEMBER_SKIPPED: Pattern/ExprSpecific: {#arg4: Int#}[#Argument#];
+// IMPLICIT_MEMBER_SKIPPED: Pattern/ExprSpecific: {#arg3: Int#}[#Int#];
+// IMPLICIT_MEMBER_SKIPPED: Pattern/ExprSpecific: {#arg4: Int#}[#Int#];
 // IMPLICIT_MEMBER_SKIPPED: End completions
 }
 func testImplicitMemberInArrayLiteral() {
@@ -787,3 +793,26 @@ func testTypecheckedTypeExpr() {
 // TYPECHECKED_TYPEEXPR: Decl[Constructor]/CurrNominal:      ['(']{#arg1: String#}, {#arg2: _#}[')'][#MyType<_>#]; name=arg1: String, arg2: _
 // TYPECHECKED_TYPEEXPR: Decl[Constructor]/CurrNominal:      ['(']{#(intVal): Int#}[')'][#MyType<Int>#]; name=intVal: Int
 // TYPECHECKED_TYPEEXPR: End completions
+
+func testPamrameterFlags(_: Int, inoutArg: inout Int, autoclosureArg: @autoclosure () -> Int, iuoArg: Int!, variadicArg: Int...) {
+  var intVal = 1
+  testPamrameterFlags(intVal, #^ARG_PARAMFLAG_INOUT^#)
+// ARG_PARAMFLAG_INOUT: Begin completions, 1 items
+// ARG_PARAMFLAG_INOUT-DAG: Pattern/ExprSpecific: {#inoutArg: &Int#}[#inout Int#]; name=inoutArg:
+// ARG_PARAMFLAG_INOUT: End completions
+
+  testPamrameterFlags(intVal, inoutArg: &intVal, #^ARG_PARAMFLAG_AUTOCLOSURE^#)
+// ARG_PARAMFLAG_AUTOCLOSURE: Begin completions, 1 items
+// ARG_PARAMFLAG_AUTOCLOSURE-DAG: Pattern/ExprSpecific: {#autoclosureArg: Int#}[#Int#];
+// ARG_PARAMFLAG_AUTOCLOSURE: End completions
+
+  testPamrameterFlags(intVal, inoutArg: &intVal, autoclosureArg: intVal, #^ARG_PARAMFLAG_IUO^#)
+// ARG_PARAMFLAG_IUO: Begin completions, 1 items
+// ARG_PARAMFLAG_IUO-DAG: Pattern/ExprSpecific: {#iuoArg: Int?#}[#Int?#];
+// ARG_PARAMFLAG_IUO: End completions
+
+  testPamrameterFlags(intVal, inoutArg: &intVal, autoclosureArg: intVal, iuoArg: intVal, #^ARG_PARAMFLAG_VARIADIC^#)
+// ARG_PARAMFLAG_VARIADIC: Begin completions, 1 items
+// ARG_PARAMFLAG_VARIADIC-DAG: Pattern/ExprSpecific: {#variadicArg: Int...#}[#Int#];
+// ARG_PARAMFLAG_VARIADIC: End completions
+}

--- a/test/IDE/complete_call_as_function.swift
+++ b/test/IDE/complete_call_as_function.swift
@@ -39,7 +39,7 @@ func testCallAsFunction(add: Adder, addTy: Adder.Type) {
 
   let _ = add(x: 12, #^INSTANCE_ARG2^#)
 // INSTANCE_ARG2: Begin completions, 1 items
-// INSTANCE_ARG2: Keyword/ExprSpecific:               y: [#Argument name#];
+// INSTANCE_ARG2: Pattern/ExprSpecific:               {#y: Int#}[#Argument#];
 // INSTANCE_ARG2: End completions
 
   let _ = addTy#^METATYPE_NO_DOT^#;
@@ -105,8 +105,8 @@ func testCallAsFunctionOverloaded(fn: Functor) {
   fn(h: .left, #^OVERLOADED_ARG2_LABEL^#)
 // FIXME: Should only suggest 'v:' (rdar://problem/60346573).
 //OVERLOADED_ARG2_LABEL: Begin completions, 2 items
-//OVERLOADED_ARG2_LABEL-DAG: Keyword/ExprSpecific:               v: [#Argument name#];
-//OVERLOADED_ARG2_LABEL-DAG: Keyword/ExprSpecific:               h: [#Argument name#];
+//OVERLOADED_ARG2_LABEL-DAG: Pattern/ExprSpecific:               {#v: Functor.Vertical#}[#Argument#];
+//OVERLOADED_ARG2_LABEL-DAG: Pattern/ExprSpecific:               {#h: Functor.Horizontal#}[#Argument#];
 //OVERLOADED_ARG2_LABEL: End completions
 
   fn(h: .left, v: .#^OVERLOADED_ARG2_VALUE^#)

--- a/test/IDE/complete_call_as_function.swift
+++ b/test/IDE/complete_call_as_function.swift
@@ -39,7 +39,7 @@ func testCallAsFunction(add: Adder, addTy: Adder.Type) {
 
   let _ = add(x: 12, #^INSTANCE_ARG2^#)
 // INSTANCE_ARG2: Begin completions, 1 items
-// INSTANCE_ARG2: Pattern/ExprSpecific:               {#y: Int#}[#Argument#];
+// INSTANCE_ARG2: Pattern/ExprSpecific:               {#y: Int#}[#Int#];
 // INSTANCE_ARG2: End completions
 
   let _ = addTy#^METATYPE_NO_DOT^#;
@@ -105,8 +105,8 @@ func testCallAsFunctionOverloaded(fn: Functor) {
   fn(h: .left, #^OVERLOADED_ARG2_LABEL^#)
 // FIXME: Should only suggest 'v:' (rdar://problem/60346573).
 //OVERLOADED_ARG2_LABEL: Begin completions, 2 items
-//OVERLOADED_ARG2_LABEL-DAG: Pattern/ExprSpecific:               {#v: Functor.Vertical#}[#Argument#];
-//OVERLOADED_ARG2_LABEL-DAG: Pattern/ExprSpecific:               {#h: Functor.Horizontal#}[#Argument#];
+//OVERLOADED_ARG2_LABEL-DAG: Pattern/ExprSpecific:               {#v: Functor.Vertical#}[#Functor.Vertical#];
+//OVERLOADED_ARG2_LABEL-DAG: Pattern/ExprSpecific:               {#h: Functor.Horizontal#}[#Functor.Horizontal#];
 //OVERLOADED_ARG2_LABEL: End completions
 
   fn(h: .left, v: .#^OVERLOADED_ARG2_VALUE^#)

--- a/test/IDE/complete_subscript.swift
+++ b/test/IDE/complete_subscript.swift
@@ -91,12 +91,12 @@ func test2<U>(value: MyStruct<U>) {
 
   let _ = MyStruct<U>[42, #^METATYPE_LABEL^#
 // METATYPE_LABEL: Begin completions, 1 items
-// METATYPE_LABEL-DAG: Keyword/ExprSpecific:               static: [#Argument name#];
+// METATYPE_LABEL-DAG: Pattern/ExprSpecific: {#static: U#}[#Argument#];
 // METATYPE_LABEL: End completions
 
   let _ = value[42, #^INSTANCE_LABEL^#
 // INSTANCE_LABEL: Begin completions, 1 items
-// INSTANCE_LABEL-DAG: Keyword/ExprSpecific:               instance: [#Argument name#];
+// INSTANCE_LABEL-DAG: Pattern/ExprSpecific: {#instance: U#}[#Argument#];
 // INSTANCE_LABEL: End completions
 }
 

--- a/test/IDE/complete_subscript.swift
+++ b/test/IDE/complete_subscript.swift
@@ -91,12 +91,12 @@ func test2<U>(value: MyStruct<U>) {
 
   let _ = MyStruct<U>[42, #^METATYPE_LABEL^#
 // METATYPE_LABEL: Begin completions, 1 items
-// METATYPE_LABEL-DAG: Pattern/ExprSpecific: {#static: U#}[#Argument#];
+// METATYPE_LABEL-DAG: Pattern/ExprSpecific: {#static: U#}[#U#];
 // METATYPE_LABEL: End completions
 
   let _ = value[42, #^INSTANCE_LABEL^#
 // INSTANCE_LABEL: Begin completions, 1 items
-// INSTANCE_LABEL-DAG: Pattern/ExprSpecific: {#instance: U#}[#Argument#];
+// INSTANCE_LABEL-DAG: Pattern/ExprSpecific: {#instance: U#}[#U#];
 // INSTANCE_LABEL: End completions
 }
 

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -768,7 +768,7 @@ func testInsideFunctionCall4() {
 func testInsideFunctionCall5() {
   FooStruct().instanceFunc2(42, #^INSIDE_FUNCTION_CALL_5^#
 // INSIDE_FUNCTION_CALL_5: Begin completions
-// INSIDE_FUNCTION_CALL_5-DAG: Pattern/ExprSpecific: {#b: &Double#}[#Argument#];
+// INSIDE_FUNCTION_CALL_5-DAG: Pattern/ExprSpecific: {#b: &Double#}[#inout Double#];
 // INSIDE_FUNCTION_CALL_5: End completions
 }
 

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -768,7 +768,7 @@ func testInsideFunctionCall4() {
 func testInsideFunctionCall5() {
   FooStruct().instanceFunc2(42, #^INSIDE_FUNCTION_CALL_5^#
 // INSIDE_FUNCTION_CALL_5: Begin completions
-// INSIDE_FUNCTION_CALL_5-DAG: Keyword/ExprSpecific:               b: [#Argument name#]; name=b:
+// INSIDE_FUNCTION_CALL_5-DAG: Pattern/ExprSpecific: {#b: &Double#}[#Argument#];
 // INSIDE_FUNCTION_CALL_5: End completions
 }
 


### PR DESCRIPTION
When a completion happens at a call argument position, insert `label: <#T##TypeName#>` instead of just `label: `.

rdar://problem/60379654
