### PR TITLE
[Serialization] Bump swiftmodule version number

### DIFF
--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 545; // SILFunctionType pattern sigs/subs
+const uint16_t SWIFTMODULE_VERSION_MINOR = 546; // Avoid conflict with downstream bump
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///


### PR DESCRIPTION
A downstream compiler bumped the swiftmodule version number ahead of the compiler on master which was later bumped to the same version number for a different change. This is causing different compilers to generate swiftmodule with incompatible formats but with the same version number (545). Let's bump the version once more to clear the conflict.

rdar://problem/60350100