### PR TITLE
[OSLogOptimization] Fix folding of symbolic closures to handle @in_guaranteed captures

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -733,6 +733,8 @@ public:
   SILType getClosureType() { return closureInst->getType(); }
 
   SubstitutionMap getCallSubstitutionMap() { return substitutionMap; }
+
+  bool hasOnlyConstantCaptures() { return !hasNonConstantCaptures; }
 };
 
 } // end namespace swift

--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -763,9 +763,23 @@ SymbolicClosure *SymbolicClosure::create(SILFunction *target,
                                          SingleValueInstruction *closureInst,
                                          SymbolicValueAllocator &allocator) {
   // Determine whether there are captured arguments without a symbolic value.
+  // Consider indirectly captured arguments as well, which can happen with
+  // @in_guaranteed convention for captures.
   bool hasNonConstantCapture = false;
   for (SymbolicClosureArgument closureArg : args) {
     if (!closureArg.second) {
+      hasNonConstantCapture = true;
+      break;
+    }
+    SymbolicValue closureValue = closureArg.second.getValue();
+    // Is capture non-constant?
+    if (!closureValue.isConstant()) {
+      hasNonConstantCapture = true;
+      break;
+    }
+    // Is the indirect capture non-constant?
+    if (closureValue.getKind() == SymbolicValue::Address &&
+        !closureValue.getAddressValueMemoryObject()->getValue().isConstant()) {
       hasNonConstantCapture = true;
       break;
     }

--- a/test/SILOptimizer/OSLogPrototypeCompileTest.sil
+++ b/test/SILOptimizer/OSLogPrototypeCompileTest.sil
@@ -733,16 +733,15 @@ bb0(%0 : @guaranteed $String):
   destroy_value %6 : $OSLogMessageStringCapture
   %18 = tuple ()
   return %18 : $()
-    // The first instance of function_ref @idString will be dead code eliminated.
-    // CHECK: [[ORIGCAPTURE:%[0-9]+]] = copy_value %0 : $String
-    // CHECK: [[NEWCAPTURE:%[0-9]+]] = copy_value [[ORIGCAPTURE]] : $String
     // CHECK: [[FUNREF:%[0-9]+]] = function_ref @idString
-    // CHECK: [[CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[FUNREF]]([[NEWCAPTURE]])
-    // CHECK: [[BORROW:%[0-9]+]] = begin_borrow [[CLOSURE]] : $@callee_guaranteed () -> @owned String
+    // CHECK: [[ORIGCAPTURE:%[0-9]+]] = copy_value %0 : $String
+    // CHECK: [[CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[FUNREF]]([[ORIGCAPTURE]])
+    // CHECK: [[CLOSURECOPY:%[0-9]+]] = copy_value [[CLOSURE]]
+    // CHECK: [[BORROW:%[0-9]+]] = begin_borrow [[CLOSURECOPY]] : $@callee_guaranteed () -> @owned String
     // CHECK: [[USE:%[0-9]+]] = function_ref @useStringCapture
     // CHECK: apply [[USE]]([[BORROW]])
     // CHECK: end_borrow [[BORROW]]
-    // CHECK: destroy_value [[CLOSURE]]
+    // CHECK: destroy_value [[CLOSURECOPY]]
 }
 
 sil [ossa] @genericFunction : $@convention(thin) <U, V> (@in_guaranteed U, @in_guaranteed V) -> Int32 {
@@ -790,11 +789,12 @@ bb0:
     // The first instance of function_ref @genericFunction will be dead-code eliminated.
     // CHECK: [[FUNREF:%[0-9]+]] = function_ref @genericFunction
     // CHECK: [[CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[FUNREF]]<Int64, Bool>([[CAPTURE1:%[0-9]+]], [[CAPTURE2:%[0-9]+]])
-    // CHECK: [[BORROW:%[0-9]+]] = begin_borrow [[CLOSURE]] : $@callee_guaranteed () -> Int32
+    // CHECK: [[CLOSURECOPY:%[0-9]+]] = copy_value [[CLOSURE]]
+    // CHECK: [[BORROW:%[0-9]+]] = begin_borrow [[CLOSURECOPY]] : $@callee_guaranteed () -> Int32
     // CHECK: [[USE:%[0-9]+]] = function_ref @useClosure
     // CHECK: apply [[USE]]([[BORROW]])
     // CHECK: end_borrow [[BORROW]]
-    // CHECK: destroy_value [[CLOSURE]]
+    // CHECK: destroy_value [[CLOSURECOPY]]
 }
 
 // Check folding of array of closures. This is essentially the feature needed


### PR DESCRIPTION
Fix the symbolic-closure folding code to create new closures only when all captures of the symbolic closure, including address-typed captures, are symbolic constants. In all other cases, the closure must be an autoclosure passed to the log call and therefore it need not be duplicated
and can be reused as such.

This eliminates the need to copy the non-constant captured values of
closures. Instead the closure itself is copied as a whole.

Fixes <rdar://problem/60344043>

cc @meg-gupta 