### PR TITLE
[index] Add implicit callAsFunction reference to index

### DIFF
--- a/include/swift/IDE/SourceEntityWalker.h
+++ b/include/swift/IDE/SourceEntityWalker.h
@@ -120,6 +120,16 @@ public:
                                        ReferenceMetaData Data,
                                        bool IsOpenBracket);
 
+  /// This method is called when a ValueDecl for a callAsFunction decl is
+  /// referenced in source. If it returns false, the remaining traversal is
+  /// terminated and returns failure.
+  ///
+  /// \param D the referenced decl.
+  /// \param Range the source range of the source reference.
+  /// \param Data whether this is a read, write or read/write access, etc.
+  virtual bool visitCallAsFunctionReference(ValueDecl *D, CharSourceRange Range,
+                                            ReferenceMetaData Data);
+
   /// This method is called for each keyword argument in a call expression.
   /// If it returns false, the remaining traversal is terminated and returns
   /// failure.

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -495,6 +495,13 @@ private:
     return finishSourceEntity(Info.symInfo, Info.roles);
   }
 
+  bool visitCallAsFunctionReference(ValueDecl *D, CharSourceRange Range,
+                                    ReferenceMetaData Data) override {
+    // Index implicit callAsFunction reference.
+    return visitDeclReference(D, Range, /*CtorTyRef*/ nullptr,
+                              /*ExtTyRef*/ nullptr, Type(), Data);
+  }
+
   Decl *getParentDecl() const {
     if (!EntitiesStack.empty())
       return EntitiesStack.back().D;

--- a/test/Index/index_callasfunction.swift
+++ b/test/Index/index_callasfunction.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
+
+struct Adder {
+    var base: Int
+    func callAsFunction(_ x: Int) -> Int {
+// CHECK: [[@LINE-1]]:10 | instance-method/Swift | callAsFunction(_:) | [[callAsFunc1:.*]] | Def
+        return base + x
+    }
+    func callAsFunction(x: Int, y: Int) -> Int {
+// CHECK: [[@LINE-1]]:10 | instance-method/Swift | callAsFunction(x:y:) | [[callAsFunc2:.*]] | Def
+        return base + x + y
+    }
+}
+
+let add3 = Adder(base: 3)
+// CHECK: [[@LINE-1]]:5 | variable/Swift | add3 | [[add3:.*]] | Def
+let global = 1
+
+add3(global)
+// CHECK: [[@LINE-1]]:1 | variable/Swift | add3 | [[add3]] | Ref,Read |
+// CHECK: [[@LINE-2]]:1 | instance-method/Swift | callAsFunction(_:) | [[callAsFunc1]] | Ref,Call,RelRec | rel: 1
+// CHECK:   RelRec | struct/Swift | Adder |
+// CHECK: [[@LINE-4]]:6 | variable/Swift | global | {{.*}} | Ref,Read |
+
+add3(x: 10, y: 11)
+// CHECK: [[@LINE-1]]:1 | variable/Swift | add3 | [[add3]] | Ref,Read |
+// CHECK: [[@LINE-2]]:1 | instance-method/Swift | callAsFunction(x:y:) | [[callAsFunc2]] | Ref,Call,RelRec | rel: 1
+// CHECK:   RelRec | struct/Swift | Adder |


### PR DESCRIPTION
* Reference is marked "explicit", which may be unexpected - the reason is that the *call* is explicit, so we want to find it with e.g. rename, or looking up callers, even though the identifier callAsFunction is implicit. This matches the behaviour of initializers.

* The source location is the same as the base name (e.g. in `add3(5)`, it would be at `add3`), which matches the behaviour of initializers.

rdar://problem/60327632