### PR TITLE
[android][armv7] Mark let_properties_opts.swift as XFAIL.

### DIFF
--- a/test/SILOptimizer/let_properties_opts.swift
+++ b/test/SILOptimizer/let_properties_opts.swift
@@ -3,6 +3,9 @@
 
 // REQUIRES: optimized_stdlib
 
+// See https://bugs.swift.org/browse/SR-12370
+// XFAIL: OS=linux-androideabi && CPU=armv7
+
 // Test propagation of non-static let properties with compile-time constant values.
 
 // TODO: Once this optimization can remove the propagated fileprivate/internal let properties or


### PR DESCRIPTION
Looks like Android ARMv7 is not inline storeBytes so the test were
failing. Mark the test as XFAIL and open a bug in the tracker to keep
the CI green for the moment.

The problem appeared after https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android/5667/ (probably 5668, but it is not longer available). One can see the error in https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android/5691/. From running the code, it looks like in ARMv7 (32 bits) the code is not inlined, so the generated SIL is different.