### PR TITLE
[android][aarch64] Add Android to set of stable ABI testing targets.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -699,7 +699,7 @@ if (run_os == 'maccatalyst'):
   target_os_abi = 'macosx'
   target_os_is_maccatalyst = "TRUE"
   config.available_features.add("OS=ios")
-if (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'windows-gnu', 'windows-msvc']):
+if (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'windows-gnu', 'windows-msvc', 'linux-android']):
   target_mandates_stable_abi = "TRUE"
   config.available_features.add('swift_only_stable_abi')
 config.substitutions.append(('%target-os-abi', target_os_abi))


### PR DESCRIPTION
IRGen/conditional_conformances.swift was failing because Android AArch64
was taking the non ABI stable checks, but generating the ABI stable
code.

The problem appeared after https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/3960/ (probably in 3961, but it is not longer available). https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/3998/ still shows the error.