### PR TITLE
[SymbolGraph] Add macCatalyst compatibility

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -203,6 +203,12 @@ public:
 
   void setRuntimeResourcePath(StringRef Path);
 
+  /// If we haven't explicitly passed -prebuilt-module-cache-path, set it to
+  /// the default value of <resource-dir>/<platform>/prebuilt-modules.
+  /// @note This should be called once, after search path options and frontend
+  ///       options have been parsed.
+  void setDefaultPrebuiltCacheIfNecessary();
+
   /// Computes the runtime resource path relative to the given Swift
   /// executable.
   static void computeRuntimeResourcePathFromExecutablePath(

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -59,30 +59,24 @@ void CompilerInvocation::setMainExecutablePath(StringRef Path) {
   DiagnosticOpts.DiagnosticDocumentationPath = DiagnosticDocsPath.str();
 }
 
-/// If we haven't explicitly passed -prebuilt-module-cache-path, set it to
-/// the default value of <resource-dir>/<platform>/prebuilt-modules.
-/// @note This should be called once, after search path options and frontend
-///       options have been parsed.
-static void setDefaultPrebuiltCacheIfNecessary(
-  FrontendOptions &frontendOpts, const SearchPathOptions &searchPathOpts,
-  const llvm::Triple &triple) {
+void CompilerInvocation::setDefaultPrebuiltCacheIfNecessary() {
 
-  if (!frontendOpts.PrebuiltModuleCachePath.empty())
+  if (!FrontendOpts.PrebuiltModuleCachePath.empty())
     return;
-  if (searchPathOpts.RuntimeResourcePath.empty())
+  if (SearchPathOpts.RuntimeResourcePath.empty())
     return;
 
-  SmallString<64> defaultPrebuiltPath{searchPathOpts.RuntimeResourcePath};
+  SmallString<64> defaultPrebuiltPath{SearchPathOpts.RuntimeResourcePath};
   StringRef platform;
-  if (tripleIsMacCatalystEnvironment(triple)) {
+  if (tripleIsMacCatalystEnvironment(LangOpts.Target)) {
     // The prebuilt cache for macCatalyst is the same as the one for macOS, not iOS
     // or a separate location of its own.
     platform = "macosx";
   } else {
-    platform = getPlatformNameForTriple(triple);
+    platform = getPlatformNameForTriple(LangOpts.Target);
   }
   llvm::sys::path::append(defaultPrebuiltPath, platform, "prebuilt-modules");
-  frontendOpts.PrebuiltModuleCachePath = defaultPrebuiltPath.str();
+  FrontendOpts.PrebuiltModuleCachePath = defaultPrebuiltPath.str();
 }
 
 static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
@@ -1597,8 +1591,7 @@ bool CompilerInvocation::parseArgs(
   }
 
   updateRuntimeLibraryPaths(SearchPathOpts, LangOpts.Target);
-  setDefaultPrebuiltCacheIfNecessary(FrontendOpts, SearchPathOpts,
-                                     LangOpts.Target);
+  setDefaultPrebuiltCacheIfNecessary();
 
   // Now that we've parsed everything, setup some inter-option-dependent state.
   setIRGenOutputOptsFromFrontendOptions(IRGenOpts, FrontendOpts);


### PR DESCRIPTION
- Add `setDefaultPrebuiltCacheIfNecessary` a `CompilerInvocation` method
- Call that while setting up the invocation in `swift-symbolgraph-extract`
- Add `Fsystem` argument to add iOSSupport directory to the search paths
- Add `resource-dir` argument for local builds

rdar://59262057