### PR TITLE
[NFC] Fixing redundant discard assign void type warn on stdlib

### DIFF
--- a/stdlib/public/Darwin/Accelerate/vImage_Buffer.swift
+++ b/stdlib/public/Darwin/Accelerate/vImage_Buffer.swift
@@ -217,7 +217,7 @@ extension vImage_Buffer {
 
         var error = kvImageNoError
         
-        _ = withUnsafePointer(to: self) {
+        withUnsafePointer(to: self) {
             error =  vImageCopyBuffer($0,
                                       &destinationBuffer,
                                       pixelSize,

--- a/stdlib/public/Darwin/Accelerate/vImage_Converter.swift
+++ b/stdlib/public/Darwin/Accelerate/vImage_Converter.swift
@@ -224,7 +224,7 @@ extension vImageConverter {
         
         var error = kvImageNoError
         
-        _ = withUnsafePointer(to: source) { src in
+        withUnsafePointer(to: source) { src in
             error = vImageConvert_AnyToAny(self,
                                            src,
                                            &destination,


### PR DESCRIPTION
Really simple, just fixing some build stdlib warnings.

![Screen Shot 2020-03-12 at 22 34 14](https://user-images.githubusercontent.com/8292651/76582770-f9bd1c80-64b5-11ea-9c88-ccca4ab3e225.png)

cc @theblixguy I remember you implemented this warning, so pinging for review :)) 