### PR TITLE
[AutoDiff] ensure diff witness original function is alive

### DIFF
--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -591,6 +591,7 @@ class DeadFunctionElimination : FunctionLivenessComputation {
     // SWIFT_ENABLE_TENSORFLOW
     // Check differentiable function witness entries.
     for (auto &dw : Module->getDifferentiabilityWitnessList()) {
+      ensureAlive(dw.getOriginalFunction());
       if (dw.getJVP())
         ensureAlive(dw.getJVP());
       if (dw.getVJP())

--- a/test/AutoDiff/downstream/compiler_crashers_fixed/Inputs/tf1202-eliminating-differentiability-witness-original-function.swift
+++ b/test/AutoDiff/downstream/compiler_crashers_fixed/Inputs/tf1202-eliminating-differentiability-witness-original-function.swift
@@ -1,0 +1,7 @@
+@inlinable
+@differentiable(where T: Differentiable)
+public func identity<T>(_ x: T) -> T { x }
+
+public func foo<T: Differentiable>(_ f: @differentiable (T) -> T = identity) -> T {
+    fatalError()
+}

--- a/test/AutoDiff/downstream/compiler_crashers_fixed/tf1202-eliminating-differentiability-witness-original-function.swift
+++ b/test/AutoDiff/downstream/compiler_crashers_fixed/tf1202-eliminating-differentiability-witness-original-function.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-module -module-name tf1202 -emit-module-path %t/tf1202.swiftmodule %S/Inputs/tf1202-eliminating-differentiability-witness-original-function.swift
+// RUN: %target-build-swift -I%t -emit-module -O %s
+
+// This situation exposed a bug where DeadFunctionElimination eliminated the
+// SILFunction for `identity<T>` even though a differentiability witness for it
+// still existed. This causes deserialization of this module to crash when
+// trying to deserialize the differentiability witness because it can't find
+// the original function `identity<T>`.
+
+import tf1202
+
+func callit() -> Float {
+    return foo()
+}

--- a/test/AutoDiff/downstream/cross_module_derivative_attr_e2e.swift
+++ b/test/AutoDiff/downstream/cross_module_derivative_attr_e2e.swift
@@ -3,6 +3,3 @@
 // RUN: %target-build-swift -I%t -L%t %S/Inputs/cross_module_derivative_attr_e2e/main/main.swift -o %t/a.out -lm -lmodule1 -Xfrontend -enable-experimental-cross-file-derivative-registration -Xfrontend -validate-tbd-against-ir=none
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
-
-// TODO(TF-1104): Fix.
-// XFAIL: swift_test_mode_optimize


### PR DESCRIPTION
This situation exposed a bug where DeadFunctionElimination eliminated the
SILFunction for `identity<T>` even though a differentiability witness for it
still existed. This causes deserialization of this module to crash when
trying to deserialize the differentiability witness because it can't find
the original function `identity<T>`.

I fixed it by keeping the original function of differentiability witnesses always alive.

A better solution might be to teach DeadFunctionElimination how to eliminate
differentiability witnesses, because I think that the differentiability witness involved
in this situation is actually dead and could be eliminated, but that would be more
work and I just wanted to fix the immediate problem for now.

Fixes TF-1202.