### PR TITLE
[IDE/CodeCompletion] Add code completion support for cross import overlays.

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -194,6 +194,16 @@ private:
   /// mechanism which is not SourceFile-dependent.)
   SeparatelyImportedOverlayMap separatelyImportedOverlays;
 
+  using SeparatelyImportedOverlayReverseMap =
+    llvm::SmallDenseMap<ModuleDecl *, ModuleDecl *>;
+
+  /// A lazily populated mapping from a separately imported overlay to its
+  /// underlying shadowed module.
+  ///
+  /// This is used by tooling to substitute the name of the underlying module
+  /// wherever the overlay's name would otherwise be reported.
+  SeparatelyImportedOverlayReverseMap separatelyImportedOverlaysReversed;
+
   /// A pointer to PersistentParserState with a function reference to its
   /// deleter to handle the fact that it's forward declared.
   using ParserStatePtr =
@@ -371,6 +381,7 @@ public:
   /// \returns true if the overlay was added; false if it already existed.
   bool addSeparatelyImportedOverlay(ModuleDecl *overlay,
                                     ModuleDecl *declaring) {
+    separatelyImportedOverlaysReversed.clear();
     return std::get<1>(separatelyImportedOverlays[declaring].insert(overlay));
   }
 
@@ -387,6 +398,12 @@ public:
     auto &value = std::get<1>(*i);
     overlays.append(value.begin(), value.end());
   }
+
+  /// Retrieves a module shadowed by the provided separately imported overlay
+  /// \p shadowed. If such a module is returned, it should be presented to users
+  /// as owning the symbols in \p overlay.
+  ModuleDecl *
+  getModuleShadowedBySeparatelyImportedOverlay(const ModuleDecl *overlay);
 
   void cacheVisibleDecls(SmallVectorImpl<ValueDecl *> &&globals) const;
   const SmallVectorImpl<ValueDecl *> &getCachedVisibleDecls() const;

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -767,17 +767,29 @@ void CodeCompletionResultBuilder::addChunkWithText(
   addChunkWithTextNoCopy(Kind, copyString(*Sink.Allocator, Text));
 }
 
-void CodeCompletionResultBuilder::setAssociatedDecl(const Decl *D) {
+void CodeCompletionResultBuilder::setAssociatedDecl(const Decl *D,
+                                                    SourceFile *SF) {
   assert(Kind == CodeCompletionResult::ResultKind::Declaration);
   AssociatedDecl = D;
-
   if (auto *ClangD = D->getClangDecl())
     CurrentModule = ClangD->getImportedOwningModule();
   // FIXME: macros
   // FIXME: imported header module
 
-  if (!CurrentModule)
-    CurrentModule = D->getModuleContext();
+  if (!CurrentModule) {
+    ModuleDecl *MD = D->getModuleContext();
+    // If this is an underscored cross-import overlay, map it to its underlying
+    // module instead.
+    if (SF) {
+      while (MD->getNameStr().startswith("_")) {
+        auto *Underlying = SF->getModuleShadowedBySeparatelyImportedOverlay(MD);
+        if (!Underlying)
+          break;
+        MD = Underlying;
+      }
+    }
+    CurrentModule = MD;
+  }
 
   if (D->getAttrs().getDeprecated(D->getASTContext()))
     setNotRecommended(CodeCompletionResult::Deprecated);
@@ -1549,6 +1561,15 @@ private:
     Builder.addDeclDocCommentWords(llvm::makeArrayRef(Pairs));
   }
 
+  /// Sets the given declaration \p D as the associated declaration of the
+  /// completion result being built in \p Builder.
+  void setAssociatedDecl(const Decl *D, CodeCompletionResultBuilder &Builder) {
+    SourceFile *SF = nullptr;
+    if (CurrDeclContext)
+      SF = CurrDeclContext->getParentSourceFile();
+    Builder.setAssociatedDecl(D, SF);
+  }
+
   bool shouldUseFunctionReference(AbstractFunctionDecl *D) {
     if (PreferFunctionReferencesToCalls)
       return true;
@@ -1726,7 +1747,7 @@ public:
                                           SemanticContextKind::None,
                                           expectedTypeContext);
       auto MD = ModuleDecl::create(Ctx.getIdentifier(Pair.first), Ctx);
-      Builder.setAssociatedDecl(MD);
+      setAssociatedDecl(MD, Builder);
       Builder.addTextChunk(MD->getNameStr());
       Builder.addTypeAnnotation("Module");
       if (Pair.second)
@@ -1740,7 +1761,6 @@ public:
     ImportFilter |= ModuleDecl::ImportFilterKind::Public;
     ImportFilter |= ModuleDecl::ImportFilterKind::Private;
     ImportFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
-    // FIXME: ImportFilterKind::ShadowedBySeparateOverlay?
 
     SmallVector<ModuleDecl::ImportedModule, 16> Imported;
     SmallVector<ModuleDecl::ImportedModule, 16> FurtherImported;
@@ -1755,21 +1775,27 @@ public:
       MD->getImportedModules(FurtherImported,
                              ModuleDecl::ImportFilterKind::Public);
       Imported.append(FurtherImported.begin(), FurtherImported.end());
-      for (auto SubMod : FurtherImported) {
-        Imported.push_back(SubMod);
-      }
     }
   }
 
   void addModuleName(
       const ModuleDecl *MD,
       Optional<CodeCompletionResult::NotRecommendedReason> R = None) {
+
+    // Don't add underscored cross-import overlay modules.
+    if (CurrDeclContext && MD->getNameStr().startswith("_")) {
+      if (auto SF = CurrDeclContext->getParentSourceFile()) {
+        if (SF->getModuleShadowedBySeparatelyImportedOverlay(MD))
+          return;
+      }
+    }
+
     CodeCompletionResultBuilder Builder(
         Sink,
         CodeCompletionResult::ResultKind::Declaration,
         SemanticContextKind::None,
         expectedTypeContext);
-    Builder.setAssociatedDecl(MD);
+    setAssociatedDecl(MD, Builder);
     Builder.addTextChunk(MD->getNameStr());
     Builder.addTypeAnnotation("Module");
     if (R)
@@ -2163,7 +2189,7 @@ public:
     CodeCompletionResultBuilder Builder(
         Sink, CodeCompletionResult::ResultKind::Declaration,
         getSemanticContext(VD, Reason, dynamicLookupInfo), expectedTypeContext);
-    Builder.setAssociatedDecl(VD);
+    setAssociatedDecl(VD, Builder);
     addLeadingDot(Builder);
     addValueBaseName(Builder, Name);
     setClangDeclKeywords(VD, Pairs, Builder);
@@ -2413,7 +2439,7 @@ public:
         Sink, CodeCompletionResult::ResultKind::Declaration,
         SemanticContext ? *SemanticContext : getSemanticContextKind(SD),
         expectedTypeContext);
-    Builder.setAssociatedDecl(SD);
+    setAssociatedDecl(SD, Builder);
     setClangDeclKeywords(SD, Pairs, Builder);
     if (!HaveLParen)
       Builder.addLeftBracket();
@@ -2452,7 +2478,7 @@ public:
           SemanticContext ? *SemanticContext : getSemanticContextKind(AFD),
           expectedTypeContext);
       if (AFD) {
-        Builder.setAssociatedDecl(AFD);
+        setAssociatedDecl(AFD, Builder);
         setClangDeclKeywords(AFD, Pairs, Builder);
       }
 
@@ -2583,7 +2609,7 @@ public:
           getSemanticContext(FD, Reason, dynamicLookupInfo),
           expectedTypeContext);
       setClangDeclKeywords(FD, Pairs, Builder);
-      Builder.setAssociatedDecl(FD);
+      setAssociatedDecl(FD, Builder);
       addLeadingDot(Builder);
       addValueBaseName(Builder, Name);
       if (IsDynamicLookup)
@@ -2696,7 +2722,7 @@ public:
           getSemanticContext(CD, Reason, dynamicLookupInfo),
           expectedTypeContext);
       setClangDeclKeywords(CD, Pairs, Builder);
-      Builder.setAssociatedDecl(CD);
+      setAssociatedDecl(CD, Builder);
       if (needInit) {
         assert(addName.empty());
         addLeadingDot(Builder);
@@ -2787,7 +2813,7 @@ public:
     CodeCompletionResultBuilder Builder(
         Sink, CodeCompletionResult::ResultKind::Declaration,
         getSemanticContext(SD, Reason, dynamicLookupInfo), expectedTypeContext);
-    Builder.setAssociatedDecl(SD);
+    setAssociatedDecl(SD, Builder);
     setClangDeclKeywords(SD, Pairs, Builder);
 
     // '\TyName#^TOKEN^#' requires leading dot.
@@ -2822,7 +2848,7 @@ public:
         Sink, CodeCompletionResult::ResultKind::Declaration,
         getSemanticContext(NTD, Reason, dynamicLookupInfo),
         expectedTypeContext);
-    Builder.setAssociatedDecl(NTD);
+    setAssociatedDecl(NTD, Builder);
     setClangDeclKeywords(NTD, Pairs, Builder);
     addLeadingDot(Builder);
     Builder.addTextChunk(NTD->getName().str());
@@ -2838,7 +2864,7 @@ public:
         Sink, CodeCompletionResult::ResultKind::Declaration,
         getSemanticContext(TAD, Reason, dynamicLookupInfo),
         expectedTypeContext);
-    Builder.setAssociatedDecl(TAD);
+    setAssociatedDecl(TAD, Builder);
     setClangDeclKeywords(TAD, Pairs, Builder);
     addLeadingDot(Builder);
     Builder.addTextChunk(TAD->getName().str());
@@ -2868,7 +2894,7 @@ public:
         Sink, CodeCompletionResult::ResultKind::Declaration,
         getSemanticContext(GP, Reason, dynamicLookupInfo), expectedTypeContext);
     setClangDeclKeywords(GP, Pairs, Builder);
-    Builder.setAssociatedDecl(GP);
+    setAssociatedDecl(GP, Builder);
     addLeadingDot(Builder);
     Builder.addTextChunk(GP->getName().str());
     addTypeAnnotation(Builder, GP->getDeclaredInterfaceType());
@@ -2882,7 +2908,7 @@ public:
         Sink, CodeCompletionResult::ResultKind::Declaration,
         getSemanticContext(AT, Reason, dynamicLookupInfo), expectedTypeContext);
     setClangDeclKeywords(AT, Pairs, Builder);
-    Builder.setAssociatedDecl(AT);
+    setAssociatedDecl(AT, Builder);
     addLeadingDot(Builder);
     Builder.addTextChunk(AT->getName().str());
     if (Type T = getAssociatedTypeType(AT))
@@ -2897,7 +2923,7 @@ public:
       semanticContext, {});
 
     builder.addTextChunk(PGD->getName().str());
-    builder.setAssociatedDecl(PGD);
+    setAssociatedDecl(PGD, builder);
   };
 
   void addEnumElementRef(const EnumElementDecl *EED, DeclVisibilityKind Reason,
@@ -2914,7 +2940,7 @@ public:
         HasTypeContext ? SemanticContextKind::ExpressionSpecific
                        : getSemanticContext(EED, Reason, dynamicLookupInfo),
         expectedTypeContext);
-    Builder.setAssociatedDecl(EED);
+    setAssociatedDecl(EED, Builder);
     setClangDeclKeywords(EED, Pairs, Builder);
     addLeadingDot(Builder);
     addValueBaseName(Builder, EED->getName());
@@ -2996,7 +3022,7 @@ public:
         getSemanticContext(AFD, Reason, dynamicLookupInfo),
         expectedTypeContext);
     setClangDeclKeywords(AFD, Pairs, Builder);
-    Builder.setAssociatedDecl(AFD);
+    setAssociatedDecl(AFD, Builder);
 
     // Base name
     addLeadingDot(Builder);
@@ -3469,7 +3495,7 @@ public:
     // FIXME: handle variable amounts of space.
     if (HaveLeadingSpace)
       builder.setNumBytesToErase(1);
-    builder.setAssociatedDecl(op);
+    setAssociatedDecl(op, builder);
     builder.addTextChunk(op->getName().str());
     assert(resultType);
     addTypeAnnotation(builder, resultType);
@@ -3515,7 +3541,7 @@ public:
     CodeCompletionResultBuilder builder(
         Sink, CodeCompletionResult::ResultKind::Declaration, semanticContext,
         {});
-    builder.setAssociatedDecl(op);
+    setAssociatedDecl(op, builder);
 
     if (HaveLeadingSpace)
       builder.addAnnotatedWhitespace(" ");
@@ -4179,6 +4205,15 @@ class CompletionOverrideLookup : public swift::VisibleDeclConsumer {
   bool hasOverridabilityModifier = false;
   bool hasStaticOrClass = false;
 
+  /// Sets the given declaration \p D as the associated declaration of the
+  /// completion result being built in \p Builder.
+  void setAssociatedDecl(const Decl *D, CodeCompletionResultBuilder &Builder) {
+    SourceFile *SF = nullptr;
+    if (CurrDeclContext)
+      SF = CurrDeclContext->getParentSourceFile();
+    Builder.setAssociatedDecl(D, SF);
+  }
+
 public:
   CompletionOverrideLookup(CodeCompletionResultSink &Sink, ASTContext &Ctx,
                            const DeclContext *CurrDeclContext,
@@ -4407,7 +4442,7 @@ public:
         SemanticContextKind::Super, {});
     Builder.setExpectedTypeRelation(
         CodeCompletionResult::ExpectedTypeRelation::NotApplicable);
-    Builder.setAssociatedDecl(FD);
+    setAssociatedDecl(FD, Builder);
     addValueOverride(FD, Reason, dynamicLookupInfo, Builder, hasFuncIntroducer);
     Builder.addBraceStmtWithCursor();
   }
@@ -4425,7 +4460,7 @@ public:
     CodeCompletionResultBuilder Builder(
         Sink, CodeCompletionResult::ResultKind::Declaration,
         SemanticContextKind::Super, {});
-    Builder.setAssociatedDecl(VD);
+    setAssociatedDecl(VD, Builder);
     addValueOverride(VD, Reason, dynamicLookupInfo, Builder, hasVarIntroducer);
   }
 
@@ -4436,7 +4471,7 @@ public:
         SemanticContextKind::Super, {});
     Builder.setExpectedTypeRelation(
         CodeCompletionResult::ExpectedTypeRelation::NotApplicable);
-    Builder.setAssociatedDecl(SD);
+    setAssociatedDecl(SD, Builder);
     addValueOverride(SD, Reason, dynamicLookupInfo, Builder, false);
     Builder.addBraceStmtWithCursor();
   }
@@ -4448,7 +4483,7 @@ public:
       SemanticContextKind::Super, {});
     Builder.setExpectedTypeRelation(
         CodeCompletionResult::ExpectedTypeRelation::NotApplicable);
-    Builder.setAssociatedDecl(ATD);
+    setAssociatedDecl(ATD, Builder);
     if (!hasTypealiasIntroducer && !hasAccessModifier)
       addAccessControl(ATD, Builder);
     if (!hasTypealiasIntroducer)
@@ -4466,7 +4501,7 @@ public:
         SemanticContextKind::Super, {});
     Builder.setExpectedTypeRelation(
         CodeCompletionResult::ExpectedTypeRelation::NotApplicable);
-    Builder.setAssociatedDecl(CD);
+    setAssociatedDecl(CD, Builder);
 
     if (!hasAccessModifier)
       addAccessControl(CD, Builder);
@@ -5730,7 +5765,6 @@ void CodeCompletionCallbacksImpl::doneParsing() {
       ImportFilter |= ModuleDecl::ImportFilterKind::Public;
       ImportFilter |= ModuleDecl::ImportFilterKind::Private;
       ImportFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
-      // FIXME: ImportFilterKind::ShadowedBySeparateOverlay?
       SmallVector<ModuleDecl::ImportedModule, 4> Imports;
       auto *SF = CurDeclContext->getParentSourceFile();
       SF->getImportedModules(Imports, ImportFilter);

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -114,7 +114,7 @@ public:
     NumBytesToErase = N;
   }
 
-  void setAssociatedDecl(const Decl *D);
+  void setAssociatedDecl(const Decl *D, SourceFile *SF);
 
   void setLiteralKind(CodeCompletionLiteralKind kind) { LiteralKind = kind; }
   void setKeywordKind(CodeCompletionKeywordKind kind) { KeywordKind = kind; }

--- a/test/IDE/Inputs/CrossImport/A.swiftcrossimport/B.swiftoverlay
+++ b/test/IDE/Inputs/CrossImport/A.swiftcrossimport/B.swiftoverlay
@@ -1,0 +1,5 @@
+%YAML 1.2
+---
+version: 1
+modules:
+  - name: _ABAdditions

--- a/test/IDE/Inputs/CrossImport/A.swiftinterface
+++ b/test/IDE/Inputs/CrossImport/A.swiftinterface
@@ -1,0 +1,6 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -swift-version 5 -enable-library-evolution -module-name A
+
+import Swift
+
+public func fromA()

--- a/test/IDE/Inputs/CrossImport/B.swiftinterface
+++ b/test/IDE/Inputs/CrossImport/B.swiftinterface
@@ -1,0 +1,6 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -swift-version 5 -enable-library-evolution -module-name B
+
+import Swift
+
+public func fromB()

--- a/test/IDE/Inputs/CrossImport/C.swiftinterface
+++ b/test/IDE/Inputs/CrossImport/C.swiftinterface
@@ -1,0 +1,8 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -swift-version 5 -enable-library-evolution -module-name C
+
+import Swift
+@_exported import A
+@_exported import B
+
+public func fromC()

--- a/test/IDE/Inputs/CrossImport/D.swiftcrossimport/B.swiftoverlay
+++ b/test/IDE/Inputs/CrossImport/D.swiftcrossimport/B.swiftoverlay
@@ -1,0 +1,5 @@
+%YAML 1.2
+---
+version: 1
+modules:
+  - name: DBAdditions

--- a/test/IDE/Inputs/CrossImport/D.swiftinterface
+++ b/test/IDE/Inputs/CrossImport/D.swiftinterface
@@ -1,0 +1,6 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -swift-version 5 -enable-library-evolution -module-name D
+
+import Swift
+
+public func fromD()

--- a/test/IDE/Inputs/CrossImport/DBAdditions.swiftinterface
+++ b/test/IDE/Inputs/CrossImport/DBAdditions.swiftinterface
@@ -1,0 +1,8 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -swift-version 5 -enable-library-evolution -module-name DBAdditions
+
+import Swift
+@_exported import D
+import B
+
+public func fromDBAdditions()

--- a/test/IDE/Inputs/CrossImport/_ABAdditions.swiftcrossimport/D.swiftoverlay
+++ b/test/IDE/Inputs/CrossImport/_ABAdditions.swiftcrossimport/D.swiftoverlay
@@ -1,0 +1,5 @@
+%YAML 1.2
+---
+version: 1
+modules:
+  - name: __ABAdditionsDAdditions

--- a/test/IDE/Inputs/CrossImport/_ABAdditions.swiftinterface
+++ b/test/IDE/Inputs/CrossImport/_ABAdditions.swiftinterface
@@ -1,0 +1,8 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -swift-version 5 -enable-library-evolution -module-name _ABAdditions
+
+import Swift
+@_exported import A
+import B
+
+public func from_ABAdditions()

--- a/test/IDE/Inputs/CrossImport/__ABAdditionsDAdditions.swiftinterface
+++ b/test/IDE/Inputs/CrossImport/__ABAdditionsDAdditions.swiftinterface
@@ -1,0 +1,8 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -swift-version 5 -enable-library-evolution -module-name __ABAdditionsDAdditions
+
+import Swift
+@_exported import _ABAdditions
+import D
+
+public func from__ABAdditionsDAdditions()

--- a/test/IDE/complete_cross_import.swift
+++ b/test/IDE/complete_cross_import.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -enable-cross-import-overlays -I %S/Inputs/CrossImport -code-completion-token=COMPLETE > %t/results.tmp
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=COMPLETE %s
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=COMPLETE-NEGATIVE %s
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -enable-cross-import-overlays -I %S/Inputs/CrossImport -code-completion-token=IMPORT > %t/results.tmp
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=IMPORT %s
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=IMPORT-NEGATIVE %s
+
+import A
+import B
+
+func foo() {
+  #^COMPLETE^#
+}
+
+// COMPLETE-DAG: Decl[Module]/None:  swift_ide_test[#Module#]; name=swift_ide_test
+// COMPLETE-DAG: Decl[Module]/None:  Swift[#Module#]; name=Swift
+// COMPLETE-DAG: Decl[Module]/None:  B[#Module#]; name=B
+// COMPLETE-DAG: Decl[Module]/None:  A[#Module#]; name=A
+// COMPLETE-DAG: Decl[FreeFunction]/OtherModule[B]:  fromB()[#Void#]; name=fromB()
+// COMPLETE-DAG: Decl[FreeFunction]/OtherModule[A]:  from_ABAdditions()[#Void#]; name=from_ABAdditions()
+// COMPLETE-DAG: Decl[FreeFunction]/OtherModule[A]:  fromA()[#Void#]; name=fromA()
+
+// COMPLETE-NEGATIVE-NOT: [_ABAdditions]
+// COMPLETE-NEGATIVE-NOT: [__ABAdditionsDAdditions]
+// COMPLETE-NEGATIVE-NOT: name=_ABAdditions
+// COMPLETE-NEGATIVE-NOT: name=__ABAdditionsDAdditions
+
+
+import #^IMPORT^#
+
+// IMPORT-DAG: Decl[Module]/None/NotRecommended:   A[#Module#]; name=A
+// IMPORT-DAG: Decl[Module]/None/NotRecommended:   B[#Module#]; name=B
+// IMPORT-DAG: Decl[Module]/None:                  C[#Module#]; name=C
+// IMPORT-DAG: Decl[Module]/None:                  D[#Module#]; name=D
+// IMPORT-DAG: Decl[Module]/None:                  DBAdditions[#Module#]; name=DBAdditions
+
+// IMPORT-NEGATIVE-NOT: _ABAdditions
+// IMPORT-NEGATIVE-NOT: __ABAdditionsDAdditions
+

--- a/test/IDE/complete_cross_import_indirect.swift
+++ b/test/IDE/complete_cross_import_indirect.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -enable-cross-import-overlays -I %S/Inputs/CrossImport -code-completion-token=COMPLETE > %t/results.tmp
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=COMPLETE %s
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=COMPLETE-NEGATIVE %s
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -enable-cross-import-overlays -I %S/Inputs/CrossImport -code-completion-token=IMPORT > %t/results.tmp
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=IMPORT %s
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=IMPORT-NEGATIVE %s
+
+// C exports A and B, and A has a cross import with B of _ABAdditions
+import C
+
+func foo() {
+  #^COMPLETE^#
+}
+
+// COMPLETE-DAG: Decl[Module]/None:  swift_ide_test[#Module#]; name=swift_ide_test
+// COMPLETE-DAG: Decl[Module]/None:  Swift[#Module#]; name=Swift
+// COMPLETE-DAG: Decl[Module]/None:  B[#Module#]; name=B
+// COMPLETE-DAG: Decl[Module]/None:  A[#Module#]; name=A
+// COMPLETE-DAG: Decl[FreeFunction]/OtherModule[C]:  fromC()[#Void#]; name=fromC()
+// COMPLETE-DAG: Decl[FreeFunction]/OtherModule[B]:  fromB()[#Void#]; name=fromB()
+// COMPLETE-DAG: Decl[FreeFunction]/OtherModule[A]:  fromA()[#Void#]; name=fromA()
+// COMPLETE-DAG: Decl[FreeFunction]/OtherModule[A]:  from_ABAdditions()[#Void#]; name=from_ABAdditions()
+
+// COMPLETE-NEGATIVE-NOT: [_ABAdditions]
+// COMPLETE-NEGATIVE-NOT: [__ABAdditionsDAdditions]
+// COMPLETE-NEGATIVE-NOT: name=_ABAdditions
+// COMPLETE-NEGATIVE-NOT: name=__ABAdditionsDAdditions
+
+
+import #^IMPORT^#
+
+// IMPORT-DAG: Decl[Module]/None/NotRecommended:   A[#Module#]; name=A
+// IMPORT-DAG: Decl[Module]/None/NotRecommended:   B[#Module#]; name=B
+// IMPORT-DAG: Decl[Module]/None/NotRecommended:   C[#Module#]; name=C
+// IMPORT-DAG: Decl[Module]/None:                  D[#Module#]; name=D
+// IMPORT-DAG: Decl[Module]/None:                  DBAdditions[#Module#]; name=DBAdditions
+
+// IMPORT-NEGATIVE-NOT: _ABAdditions
+// IMPORT-NEGATIVE-NOT: __ABAdditionsDAdditions
+

--- a/test/IDE/complete_cross_import_multiple.swift
+++ b/test/IDE/complete_cross_import_multiple.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -enable-cross-import-overlays -I %S/Inputs/CrossImport -code-completion-token=COMPLETE > %t/results.tmp
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=COMPLETE %s
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=COMPLETE-NEGATIVE %s
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -enable-cross-import-overlays -I %S/Inputs/CrossImport -code-completion-token=IMPORT > %t/results.tmp
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=IMPORT %s
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=IMPORT-NEGATIVE %s
+
+// A has a cross import with B of _ABAdditions, which has a cross import with D of __ABAdditionsDAdditions
+import A
+import B
+import D
+
+func foo() {
+  #^COMPLETE^#
+}
+
+// COMPLETE-DAG: Decl[Module]/None:  swift_ide_test[#Module#]; name=swift_ide_test
+// COMPLETE-DAG: Decl[Module]/None:  Swift[#Module#]; name=Swift
+// COMPLETE-DAG: Decl[Module]/None:  B[#Module#]; name=B
+// COMPLETE-DAG: Decl[Module]/None:  A[#Module#]; name=A
+// COMPLETE-DAG: Decl[Module]/None:  D[#Module#]; name=D
+// COMPLETE-DAG: Decl[FreeFunction]/OtherModule[B]:  fromB()[#Void#]; name=fromB()
+// COMPLETE-DAG: Decl[FreeFunction]/OtherModule[A]:  fromA()[#Void#]; name=fromA()
+// COMPLETE-DAG: Decl[FreeFunction]/OtherModule[A]:  from_ABAdditions()[#Void#]; name=from_ABAdditions()
+// COMPLETE-DAG: Decl[FreeFunction]/OtherModule[A]:  from__ABAdditionsDAdditions()[#Void#]; name=from__ABAdditionsDAdditions()
+
+// COMPLETE-NEGATIVE-NOT: [_ABAdditions]
+// COMPLETE-NEGATIVE-NOT: [__ABAdditionsDAdditions]
+// COMPLETE-NEGATIVE-NOT: name=_ABAdditions
+// COMPLETE-NEGATIVE-NOT: name=__ABAdditionsDAdditions
+
+
+import #^IMPORT^#
+
+// IMPORT-DAG: Decl[Module]/None/NotRecommended:   A[#Module#]; name=A
+// IMPORT-DAG: Decl[Module]/None/NotRecommended:   B[#Module#]; name=B
+// IMPORT-DAG: Decl[Module]/None:                  C[#Module#]; name=C
+// IMPORT-DAG: Decl[Module]/None/NotRecommended:   D[#Module#]; name=D
+// IMPORT-DAG: Decl[Module]/None/NotRecommended:   DBAdditions[#Module#]; name=DBAdditions
+
+// IMPORT-NEGATIVE-NOT: _ABAdditions
+// IMPORT-NEGATIVE-NOT: __ABAdditionsDAdditions
+

--- a/test/IDE/complete_cross_import_no_underscore.swift
+++ b/test/IDE/complete_cross_import_no_underscore.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -enable-cross-import-overlays -I %S/Inputs/CrossImport -code-completion-token=COMPLETE > %t/results.tmp
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=COMPLETE %s
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=COMPLETE-NEGATIVE %s
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -enable-cross-import-overlays -I %S/Inputs/CrossImport -code-completion-token=IMPORT > %t/results.tmp
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=IMPORT %s
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=IMPORT-NEGATIVE %s
+
+// D has a cross import with B, DBAdditions, that isn't underscored.
+import D
+import B
+
+func foo() {
+  #^COMPLETE^#
+}
+
+// COMPLETE-DAG: Decl[Module]/None:  swift_ide_test[#Module#]; name=swift_ide_test
+// COMPLETE-DAG: Decl[Module]/None:  Swift[#Module#]; name=Swift
+// COMPLETE-DAG: Decl[Module]/None:  B[#Module#]; name=B
+// COMPLETE-DAG: Decl[Module]/None:  D[#Module#]; name=D
+// COMPLETE-DAG: Decl[FreeFunction]/OtherModule[B]:  fromB()[#Void#]; name=fromB()
+// COMPLETE-DAG: Decl[FreeFunction]/OtherModule[DBAdditions]:  fromDBAdditions()[#Void#]; name=fromDBAdditions()
+// COMPLETE-DAG: Decl[FreeFunction]/OtherModule[D]:  fromD()[#Void#]; name=fromD()
+
+// COMPLETE-NEGATIVE-NOT: [_ABAdditions]
+// COMPLETE-NEGATIVE-NOT: [__ABAdditionsDAdditions]
+// COMPLETE-NEGATIVE-NOT: name=_ABAdditions
+// COMPLETE-NEGATIVE-NOT: name=__ABAdditionsDAdditions
+
+
+import #^IMPORT^#
+
+// IMPORT-DAG: Decl[Module]/None:                  A[#Module#]; name=A
+// IMPORT-DAG: Decl[Module]/None/NotRecommended:   B[#Module#]; name=B
+// IMPORT-DAG: Decl[Module]/None:                  C[#Module#]; name=C
+// IMPORT-DAG: Decl[Module]/None/NotRecommended:   D[#Module#]; name=D
+// IMPORT-DAG: Decl[Module]/None/NotRecommended:   DBAdditions[#Module#]; name=DBAdditions
+
+// IMPORT-NEGATIVE-NOT: _ABAdditions
+// IMPORT-NEGATIVE-NOT: __ABAdditionsDAdditions

--- a/test/IDE/complete_cross_import_no_underscore_imported.swift
+++ b/test/IDE/complete_cross_import_no_underscore_imported.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -enable-cross-import-overlays -I %S/Inputs/CrossImport -code-completion-token=COMPLETE > %t/results.tmp
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=COMPLETE %s
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=COMPLETE-NEGATIVE %s
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -enable-cross-import-overlays -I %S/Inputs/CrossImport -code-completion-token=IMPORT > %t/results.tmp
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=IMPORT %s
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=IMPORT-NEGATIVE %s
+
+// DBAdditions is explicitly imported.
+import DBAdditions
+import B
+
+func foo() {
+  #^COMPLETE^#
+}
+
+// COMPLETE-DAG: Decl[Module]/None:  swift_ide_test[#Module#]; name=swift_ide_test
+// COMPLETE-DAG: Decl[Module]/None:  Swift[#Module#]; name=Swift
+// COMPLETE-DAG: Decl[Module]/None:  B[#Module#]; name=B
+// COMPLETE-DAG: Decl[Module]/None:  D[#Module#]; name=D
+// COMPLETE-DAG: Decl[FreeFunction]/OtherModule[B]:  fromB()[#Void#]; name=fromB()
+// COMPLETE-DAG: Decl[FreeFunction]/OtherModule[DBAdditions]:  fromDBAdditions()[#Void#]; name=fromDBAdditions()
+// COMPLETE-DAG: Decl[FreeFunction]/OtherModule[D]:  fromD()[#Void#]; name=fromD()
+
+// COMPLETE-NEGATIVE-NOT: [_ABAdditions]
+// COMPLETE-NEGATIVE-NOT: [__ABAdditionsDAdditions]
+// COMPLETE-NEGATIVE-NOT: name=_ABAdditions
+// COMPLETE-NEGATIVE-NOT: name=__ABAdditionsDAdditions
+
+
+import #^IMPORT^#
+
+// IMPORT-DAG: Decl[Module]/None:                  A[#Module#]; name=A
+// IMPORT-DAG: Decl[Module]/None/NotRecommended:   B[#Module#]; name=B
+// IMPORT-DAG: Decl[Module]/None:                  C[#Module#]; name=C
+// IMPORT-DAG: Decl[Module]/None/NotRecommended:   D[#Module#]; name=D
+// IMPORT-DAG: Decl[Module]/None/NotRecommended:   DBAdditions[#Module#]; name=DBAdditions
+
+// IMPORT-NEGATIVE-NOT: _ABAdditions
+// IMPORT-NEGATIVE-NOT: __ABAdditionsDAdditions

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -315,6 +315,12 @@ EnableSourceImport("enable-source-import", llvm::cl::Hidden,
                    llvm::cl::cat(Category), llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
+EnableCrossImportOverlays("enable-cross-import-overlays",
+                          llvm::cl::desc("Automatically import declared cross-import overlays."),
+                          llvm::cl::cat(Category),
+                          llvm::cl::init(false));
+
+static llvm::cl::opt<bool>
 SkipDeinit("skip-deinit",
            llvm::cl::desc("Whether to skip printing destructors"),
            llvm::cl::cat(Category),
@@ -3357,6 +3363,8 @@ int main(int argc, char *argv[]) {
   InitInvok.getLangOptions().BuildSyntaxTree = true;
   InitInvok.getLangOptions().RequestEvaluatorGraphVizPath =
     options::GraphVisPath;
+  InitInvok.getLangOptions().EnableCrossImportOverlays =
+    options::EnableCrossImportOverlays;
   if (options::DisableObjCInterop) {
     InitInvok.getLangOptions().EnableObjCInterop = false;
   } else if (options::EnableObjCInterop) {


### PR DESCRIPTION
If a cross-import overlay shadows another module and has a name starting with `_`, don't present that overlay in places where module name completions are offered and present symbols coming from that module as if they came from the shadowed module instead (or its shadowed module if the directly shadowed module is itself an underscored cross-import-overlay, recursively).

Resolves rdar://problem/59445688