### PR TITLE
Debug Info: Store the SDK in the DICompileUnit.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1696,6 +1696,15 @@ IRGenDebugInfoImpl::IRGenDebugInfoImpl(const IRGenOptions &Opts,
                           DebugPrefixMap.remapPath(Opts.DebugCompilationDir));
 
   StringRef Sysroot = IGM.Context.SearchPathOpts.SDKPath;
+  StringRef SDK;
+  {
+    auto B = llvm::sys::path::rbegin(Sysroot);
+    auto E = llvm::sys::path::rend(Sysroot);
+    auto It = std::find_if(B, E, [](auto SDK) { return SDK.endswith(".sdk"); });
+    if (It != E)
+      SDK = *It;
+  }
+
   TheCU = DBuilder.createCompileUnit(
       Lang, MainFile,
       Producer, Opts.shouldOptimize(), Opts.getDebugFlags(PD),
@@ -1706,7 +1715,7 @@ IRGenDebugInfoImpl::IRGenDebugInfoImpl(const IRGenOptions &Opts,
       /* DWOId */ 0, /* SplitDebugInlining */ true,
       /* DebugInfoForProfiling */ false,
       llvm::DICompileUnit::DebugNameTableKind::Default,
-      /* RangesBaseAddress */ false, Sysroot);
+      /* RangesBaseAddress */ false, Sysroot, SDK);
 
   // Because the swift compiler relies on Clang to setup the Module,
   // the clang CU is always created first.  Several dwarf-reading

--- a/test/DebugInfo/compileunit-sysroot-sdk.swift
+++ b/test/DebugInfo/compileunit-sysroot-sdk.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - \
+// RUN:    -sdk /SWIFT_SYSROOT/MacOSX.sdk | %FileCheck %s
+// Test that sysroot and SDK are stored in the debug info.
+// CHECK: distinct !DICompileUnit({{.*}}sysroot: "/SWIFT_SYSROOT/MacOSX.sdk",
+// LLDB-SAME:                          sdk: "MacOSX.sdk"


### PR DESCRIPTION
This an intermediate step for PR44213
(https://bugs.llvm.org/show_bug.cgi?id=44213).

This stores the SDK *name* in the debug info, to make it possible to
`-fdebug-prefix-map`-replace the sysroot with a recognizable string and allowing
the debugger to find a fitting SDK relative to itself, not the machine the
executable was compiled on.

rdar://problem/51645582
