### PR TITLE
TBDGen: omit witness table symbol for imported resilient protocols

### DIFF
--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -451,8 +451,12 @@ void TBDGenVisitor::addConformances(DeclContext *DC) {
     if (!rootConformance) {
       continue;
     }
-
-    addSymbol(LinkEntity::forProtocolWitnessTable(rootConformance));
+    // We cannot emit the witness table symbol if the protocol is imported from
+    // another module and it's resilient, because initialization of that protocol
+    // is necessary in this case
+    if (!rootConformance->getProtocol()->isResilient(DC->getParentModule(),
+                                                     ResilienceExpansion::Maximal))
+      addSymbol(LinkEntity::forProtocolWitnessTable(rootConformance));
     addSymbol(LinkEntity::forProtocolConformanceDescriptor(rootConformance));
 
     // FIXME: the logic around visibility in extensions is confusing, and

--- a/test/TBD/omit-witness-table.swift
+++ b/test/TBD/omit-witness-table.swift
@@ -1,0 +1,7 @@
+// REQUIRES: VENDOR=apple
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-library-evolution -emit-tbd -emit-tbd-path %t.result.tbd -tbd-is-installapi -parse-as-library -emit-ir -o/dev/null
+
+public enum TestError : Error {
+  case unsupportedVersion(Int)
+}


### PR DESCRIPTION
For imported resilient protocols, we cannot directly emit witness table
symbol when a local type conforms to them because initializing these
protocols are required.

rdar://60429448