### PR TITLE
[Immediate] Fix static constructor/destructor calls in RunImmediately.

### DIFF
--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -350,6 +350,7 @@ int swift::RunImmediately(CompilerInstance &CI,
 
   using MainFnTy = int(*)(int, char*[]);
 
+  LLVM_DEBUG(llvm::dbgs() << "Running static constructors\n");
   if (auto Err = JIT->runConstructors()) {
     llvm::logAllUnhandledErrors(std::move(Err), llvm::errs(), "");
     return -1;
@@ -363,11 +364,14 @@ int swift::RunImmediately(CompilerInstance &CI,
     return -1;
   }
 
-  LLVM_DEBUG(llvm::dbgs() << "Running static constructors\n");
-  if (auto Err = JIT->runConstructors()) {
+  LLVM_DEBUG(llvm::dbgs() << "Running main\n");
+  int Result = llvm::orc::runAsMain(JITMain, CmdLine);
+
+  LLVM_DEBUG(llvm::dbgs() << "Running static destructors\n");
+  if (auto Err = JIT->runDestructors()) {
     logAllUnhandledErrors(std::move(Err), llvm::errs(), "");
     return -1;
   }
-  LLVM_DEBUG(llvm::dbgs() << "Running main\n");
-  return llvm::orc::runAsMain(JITMain, CmdLine);
+
+  return Result;
 }


### PR DESCRIPTION
Removes a redundant call to LLJIT::runConstructors and adds a call to LLJIT::runDestructors.