### PR TITLE
swift-syntax-parser-tool: tweak the build rules

### DIFF
--- a/tools/swift-syntax-parser-test/CMakeLists.txt
+++ b/tools/swift-syntax-parser-test/CMakeLists.txt
@@ -7,23 +7,21 @@ add_swift_host_tool(swift-syntax-parser-test
     Support
   SWIFT_COMPONENT tools
 )
-if(NOT SWIFT_BUILT_STANDALONE AND NOT CMAKE_C_COMPILER_ID MATCHES Clang)
-  add_dependencies(swift-syntax-parser-test clang)
-endif()
-target_link_libraries(swift-syntax-parser-test
-  PRIVATE
-    libSwiftSyntaxParser
-)
-
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   set_target_properties(swift-syntax-parser-test PROPERTIES
     BUILD_WITH_INSTALL_RPATH YES
     INSTALL_RPATH @executable_path/../lib)
+elseif(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
+  set_target_properties(swift-syntax-parser-test PROPERTIES
+    BUILD_WITH_INSTALL_RPATH YES
+    INSTALL_RPATH ${SWIFT_LIBRARY_OUTPUT_INTDIR})
 endif()
+target_compile_options(swift-syntax-parser-test PRIVATE
+  -fblocks)
+target_link_libraries(swift-syntax-parser-test PRIVATE
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:BlocksRuntime>
+  libSwiftSyntaxParser)
 
-set_property(TARGET swift-syntax-parser-test APPEND_STRING PROPERTY
-  COMPILE_FLAGS " -fblocks")
-if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  target_link_libraries(swift-syntax-parser-test PRIVATE
-    BlocksRuntime)
+if(NOT SWIFT_BUILT_STANDALONE AND NOT CMAKE_C_COMPILER_ID MATCHES Clang)
+  add_dependencies(swift-syntax-parser-test clang)
 endif()


### PR DESCRIPTION
Adjust the build rules to add a build RPATH into the executable to
ensure that `lib_InternalSwiftSyntaxParser.so` is properly found when
running the tests.  This also should ensure that we always use the
correct version, irrespective of the setting of `LD_LIBRARY_PATH`.  This
RPATH is marked as a `BUILD_RPATH` and will be stripped if the tool is
installed.

Adjust the dependencies to be clearer using generator expressions and
use the `target_compile_options` rather than the more fragile
`set_target_properties` to add `-fblocks` to the compilation.  This is
now possible as we are ensured that we are using CMake 3.15+.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
