### PR TITLE
[CSGen] Force unwrapping 'nil' compiles without warning

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3197,6 +3197,8 @@ ERROR(cannot_infer_base_of_unresolved_member,none,
       "cannot infer contextual base in reference to member %0", (DeclNameRef))
 ERROR(unresolved_nil_literal,none,
       "'nil' requires a contextual type", ())
+ERROR(cannot_force_unwrap_nil_literal,none,
+      "'nil' literal cannot be force unwrapped", ())
 
 ERROR(type_of_expression_is_ambiguous,none,
       "type of expression is ambiguous without more context", ())

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3207,6 +3207,15 @@ namespace {
     }
 
     Type visitForceValueExpr(ForceValueExpr *expr) {
+      // Diagnose force-unwrapping a 'nil' literal
+      auto &DE = CS.getASTContext().Diags;
+      auto subExpr = expr->getSubExpr();
+      if (isa<NilLiteralExpr>(subExpr)) {
+          DE.diagnose(subExpr->getLoc(), diag::cannot_force_unwrap_nil_literal);
+          return Type();
+      }
+
+
       // Force-unwrap an optional of type T? to produce a T.
       auto locator = CS.getConstraintLocator(expr);
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3208,13 +3208,12 @@ namespace {
 
     Type visitForceValueExpr(ForceValueExpr *expr) {
       // Diagnose force-unwrapping a 'nil' literal
-      auto &DE = CS.getASTContext().Diags;
       auto subExpr = expr->getSubExpr();
       if (isa<NilLiteralExpr>(subExpr)) {
-          DE.diagnose(subExpr->getLoc(), diag::cannot_force_unwrap_nil_literal);
-          return Type();
+        auto &DE = CS.getASTContext().Diags;
+        DE.diagnose(subExpr->getLoc(), diag::cannot_force_unwrap_nil_literal);
+        return Type();
       }
-
 
       // Force-unwrap an optional of type T? to produce a T.
       auto locator = CS.getConstraintLocator(expr);

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -427,3 +427,16 @@ func invalidOptionalChaining(a: Any) {
   // expected-error@-1 {{value of protocol type 'Any' cannot conform to 'Equatable'; only struct/enum/class types can conform to protocols}}
   // expected-note@-2 {{requirement from conditional conformance of 'Any?' to 'Equatable'}}
 }
+
+// SR-12309 - Force unwrapping 'nil' compiles without warning
+func sr_12309() {
+  struct S {
+    var foo: Int
+  }
+
+  _ = S(foo: nil!) // expected-error {{'nil' literal cannot be force unwrapped}}
+  _ = nil! // expected-error {{'nil' literal cannot be force unwrapped}}
+  _ = nil? // expected-error {{value of optional type 'Optional<_>' must be unwrapped to a value of type '_'}}
+           // expected-note@-1 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+           // expected-note@-2 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+}

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -439,4 +439,6 @@ func sr_12309() {
   _ = nil? // expected-error {{value of optional type 'Optional<_>' must be unwrapped to a value of type '_'}}
            // expected-note@-1 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
            // expected-note@-2 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+  _ = (nil) // expected-error {{'nil' requires a contextual type}}
+  _ = nil // expected-error {{'nil' requires a contextual type}}
 }

--- a/test/Constraints/sr12309.swift
+++ b/test/Constraints/sr12309.swift
@@ -1,7 +1,0 @@
-// RUN: %target-typecheck-verify-swift
-
-struct Foo {
-  var bar: Int
-}
-
-let f = Foo(bar: nil!) // expected-error {{'nil' literal cannot be force unwrapped}}

--- a/test/Constraints/sr12309.swift
+++ b/test/Constraints/sr12309.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift
+
+struct Foo {
+  var bar: Int
+}
+
+let f = Foo(bar: nil!) // expected-error {{'nil' literal cannot be force unwrapped}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
I added an extra type checking in `ForceValueExpr` to check to if the base type is a 'nil' literal and if it's I display a diagnostic message. 
I also added a test for it. 

I struggled with this bug so thanks for everyone who helped me :) 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-12309](https://bugs.swift.org/browse/SR-12309).
Resolves: rdar://problem/60090857
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
