### PR TITLE
[Diagnostics] Switch `FailureDiagnostic` to use a solution

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7326,7 +7326,8 @@ bool ConstraintSystem::applySolutionFixes(const Solution &solution) {
         auto *primaryFix = fixes[0];
         ArrayRef<ConstraintFix *> secondaryFixes{fixes.begin() + 1, fixes.end()};
 
-        auto diagnosed = primaryFix->coalesceAndDiagnose(secondaryFixes);
+        auto diagnosed =
+            primaryFix->coalesceAndDiagnose(solution, secondaryFixes);
         if (primaryFix->isWarning()) {
           assert(diagnosed && "warnings should always be diagnosed");
           (void)diagnosed;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -165,6 +165,13 @@ ConstraintLocator *Solution::getCalleeLocator(ConstraintLocator *locator,
       });
 }
 
+ConstraintLocator *
+Solution::getConstraintLocator(Expr *anchor,
+                               ArrayRef<LocatorPathElt> path) const {
+  auto &cs = getConstraintSystem();
+  return cs.getConstraintLocator(anchor, path);
+}
+
 /// Return the implicit access kind for a MemberRefExpr with the
 /// specified base and member in the specified DeclContext.
 static AccessSemantics
@@ -7700,6 +7707,15 @@ ProtocolConformanceRef Solution::resolveConformance(
   }
 
   return ProtocolConformanceRef::forInvalid();
+}
+
+Type Solution::getType(TypedNode node) const {
+  auto result = nodeTypes.find(node);
+  if (result != nodeTypes.end())
+    return result->second;
+
+  auto &cs = getConstraintSystem();
+  return cs.getType(node);
 }
 
 void Solution::setExprTypes(Expr *expr) const {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7701,15 +7701,6 @@ ProtocolConformanceRef Solution::resolveConformance(
   return ProtocolConformanceRef::forInvalid();
 }
 
-Type Solution::getType(const Expr *expr) const {
-  auto result = nodeTypes.find(expr);
-  if (result != nodeTypes.end())
-    return result->second;
-
-  auto &cs = getConstraintSystem();
-  return cs.getType(expr);
-}
-
 void Solution::setExprTypes(Expr *expr) const {
   if (!expr)
     return;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -178,6 +178,11 @@ protected:
     return cs.getConstraintLocator(anchor, path);
   }
 
+  Optional<FunctionArgApplyInfo>
+  getFunctionArgApplyInfo(ConstraintLocator *locator) const {
+    return S.getFunctionArgApplyInfo(locator);
+  }
+
   /// \returns true is locator hasn't been simplified down to expression.
   bool hasComplexLocator() const { return HasComplexLocator; }
 
@@ -1717,7 +1722,7 @@ public:
   ArgumentMismatchFailure(const Solution &solution, Type argType,
                           Type paramType, ConstraintLocator *locator)
       : ContextualFailure(solution, argType, paramType, locator),
-        Info(*cs.getFunctionArgApplyInfo(getLocator())) {}
+        Info(*getFunctionArgApplyInfo(getLocator())) {}
 
   bool diagnoseAsError() override;
   bool diagnoseAsNote() override;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1223,13 +1223,13 @@ public:
 };
 
 class MissingArgumentsFailure final : public FailureDiagnostic {
-  using Param = AnyFunctionType::Param;
+  using SynthesizedParam = std::pair<unsigned, AnyFunctionType::Param>;
 
-  SmallVector<Param, 4> SynthesizedArgs;
+  SmallVector<SynthesizedParam, 4> SynthesizedArgs;
 
 public:
   MissingArgumentsFailure(const Solution &solution,
-                          ArrayRef<Param> synthesizedArgs,
+                          ArrayRef<SynthesizedParam> synthesizedArgs,
                           ConstraintLocator *locator)
       : FailureDiagnostic(solution, locator),
         SynthesizedArgs(synthesizedArgs.begin(), synthesizedArgs.end()) {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -38,7 +38,7 @@ class FunctionArgApplyInfo;
 /// provides most basic information such as location of
 /// the problem, parent expression and some utility methods.
 class FailureDiagnostic {
-  ConstraintSystem &CS;
+  const Solution &S;
   ConstraintLocator *Locator;
 
   /// The original anchor before any simplification.
@@ -50,8 +50,8 @@ class FailureDiagnostic {
   bool HasComplexLocator;
 
 public:
-  FailureDiagnostic(ConstraintSystem &cs, ConstraintLocator *locator)
-      : CS(cs), Locator(locator), RawAnchor(locator->getAnchor()) {
+  FailureDiagnostic(const Solution &solution, ConstraintLocator *locator)
+      : S(solution), Locator(locator), RawAnchor(locator->getAnchor()) {
     std::tie(Anchor, HasComplexLocator) = computeAnchor();
   }
 
@@ -78,10 +78,6 @@ public:
   /// e.g. ambiguity error.
   virtual bool diagnoseAsNote();
 
-  ConstraintSystem &getConstraintSystem() const {
-    return CS;
-  }
-
   Expr *getRawAnchor() const { return RawAnchor; }
 
   Expr *getAnchor() const { return Anchor; }
@@ -101,46 +97,76 @@ public:
     }
 
     auto &cs = getConstraintSystem();
-    return cs.simplifyTypeImpl(rawType,
-        [&](TypeVariableType *typeVar) -> Type {
-          if (auto fixed = cs.getFixedType(typeVar)) {
-            auto *genericParam = typeVar->getImpl().getGenericParameter();
-            if (fixed->isHole() && genericParam)
-                return genericParam;
-            return resolveType(fixed, reconstituteSugar, wantRValue);
-          }
-          return cs.getRepresentative(typeVar);
-        });
+    return cs.simplifyTypeImpl(rawType, [&](TypeVariableType *typeVar) -> Type {
+      auto fixed = S.simplifyType(typeVar);
+      auto *genericParam = typeVar->getImpl().getGenericParameter();
+      if (fixed->isHole() && genericParam)
+        return genericParam;
+      return resolveType(fixed, reconstituteSugar, wantRValue);
+    });
   }
 
   template <typename... ArgTypes>
   InFlightDiagnostic emitDiagnostic(ArgTypes &&... Args) const;
 
 protected:
-  DeclContext *getDC() const { return CS.DC; }
+  const Solution &getSolution() const { return S; }
 
-  ASTContext &getASTContext() const { return CS.getASTContext(); }
+  ConstraintSystem &getConstraintSystem() const {
+    return S.getConstraintSystem();
+  }
+
+  Type getContextualType(Expr *anchor) const {
+    auto &cs = getConstraintSystem();
+    return cs.getContextualType(anchor);
+  }
+
+  TypeLoc getContextualTypeLoc(Expr *anchor) const {
+    auto &cs = getConstraintSystem();
+    return cs.getContextualTypeLoc(anchor);
+  }
+
+  ContextualTypePurpose getContextualTypePurpose(Expr *anchor) const {
+    auto &cs = getConstraintSystem();
+    return cs.getContextualTypePurpose(anchor);
+  }
+
+  DeclContext *getDC() const {
+    auto &cs = getConstraintSystem();
+    return cs.DC;
+  }
+
+  ASTContext &getASTContext() const {
+    auto &cs = getConstraintSystem();
+    return cs.getASTContext();
+  }
 
   Optional<std::pair<Type, ConversionRestrictionKind>>
   getRestrictionForType(Type type) const {
-    for (auto &restriction : CS.ConstraintRestrictions) {
-      if (std::get<0>(restriction)->isEqual(type))
-        return std::pair<Type, ConversionRestrictionKind>(
-            std::get<1>(restriction), std::get<2>(restriction));
+    for (auto &e : S.ConstraintRestrictions) {
+      auto &location = e.first;
+      auto &restriction = e.second;
+
+      if (std::get<0>(location)->isEqual(type))
+        return std::pair<Type, ConversionRestrictionKind>(std::get<1>(location),
+                                                          restriction);
     }
     return None;
   }
 
   ValueDecl *getResolvedMemberRef(UnresolvedDotExpr *member) const {
-    auto locator = CS.getConstraintLocator(member, ConstraintLocator::Member);
-    return CS.findResolvedMemberRef(locator);
+    auto &cs = getConstraintSystem();
+    auto locator = cs.getConstraintLocator(member, ConstraintLocator::Member);
+    if (auto overload = getOverloadChoiceIfAvailable(locator))
+      return overload->choice.getDeclOrNull();
+    return nullptr;
   }
 
   /// Retrieve overload choice resolved for a given locator
   /// by the constraint solver.
   Optional<SelectedOverload>
   getOverloadChoiceIfAvailable(ConstraintLocator *locator) const {
-    return CS.findSelectedOverloadFor(locator);
+    return S.getOverloadChoiceIfAvailable(locator);
   }
 
   /// Retrive the constraint locator for the given anchor and
@@ -148,7 +174,8 @@ protected:
   ConstraintLocator *
   getConstraintLocator(Expr *anchor,
                        ArrayRef<ConstraintLocator::PathElement> path) {
-    return CS.getConstraintLocator(anchor, path);
+    auto &cs = getConstraintSystem();
+    return cs.getConstraintLocator(anchor, path);
   }
 
   /// \returns true is locator hasn't been simplified down to expression.
@@ -214,9 +241,9 @@ protected:
   Type LHS, RHS;
 
 public:
-  RequirementFailure(ConstraintSystem &cs, Type lhs, Type rhs,
+  RequirementFailure(const Solution &solution, Type lhs, Type rhs,
                      ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator),
+      : FailureDiagnostic(solution, locator),
         Conformance(getConformanceForConditionalReq(locator)),
         Signature(getSignature(locator)), AffectedDecl(getDeclRef()),
         LHS(resolveType(lhs)), RHS(resolveType(rhs)) {
@@ -302,10 +329,10 @@ private:
 /// ```
 class MissingConformanceFailure final : public RequirementFailure {
 public:
-  MissingConformanceFailure(ConstraintSystem &cs,
+  MissingConformanceFailure(const Solution &solution,
                             ConstraintLocator *locator,
                             std::pair<Type, Type> conformance)
-      : RequirementFailure(cs, conformance.first, conformance.second,
+      : RequirementFailure(solution, conformance.first, conformance.second,
                            locator) {
     auto reqElt = locator->castLastElementTo<LocatorPathElt::AnyRequirement>();
     assert(reqElt.getRequirementKind() == RequirementKind::Conformance ||
@@ -361,9 +388,9 @@ private:
 /// `S.T` is not the same type as `Int`, which is required by `foo`.
 class SameTypeRequirementFailure final : public RequirementFailure {
 public:
-  SameTypeRequirementFailure(ConstraintSystem &cs, Type lhs,
-                             Type rhs, ConstraintLocator *locator)
-      : RequirementFailure(cs, lhs, rhs, locator) {
+  SameTypeRequirementFailure(const Solution &solution, Type lhs, Type rhs,
+                             ConstraintLocator *locator)
+      : RequirementFailure(solution, lhs, rhs, locator) {
     auto reqElt = locator->castLastElementTo<LocatorPathElt::AnyRequirement>();
     assert(reqElt.getRequirementKind() == RequirementKind::SameType);
   }
@@ -397,9 +424,9 @@ protected:
 /// `A` is not the superclass of `B`, which is required by `foo<T>`.
 class SuperclassRequirementFailure final : public RequirementFailure {
 public:
-  SuperclassRequirementFailure(ConstraintSystem &cs, Type lhs,
-                               Type rhs, ConstraintLocator *locator)
-      : RequirementFailure(cs, lhs, rhs, locator) {
+  SuperclassRequirementFailure(const Solution &solution, Type lhs, Type rhs,
+                               ConstraintLocator *locator)
+      : RequirementFailure(solution, lhs, rhs, locator) {
     auto reqElt = locator->castLastElementTo<LocatorPathElt::AnyRequirement>();
     assert(reqElt.getRequirementKind() == RequirementKind::Superclass);
   }
@@ -430,9 +457,9 @@ class LabelingFailure final : public FailureDiagnostic {
   ArrayRef<Identifier> CorrectLabels;
 
 public:
-  LabelingFailure(ConstraintSystem &cs, ConstraintLocator *locator,
+  LabelingFailure(const Solution &solution, ConstraintLocator *locator,
                   ArrayRef<Identifier> labels)
-      : FailureDiagnostic(cs, locator), CorrectLabels(labels) {}
+      : FailureDiagnostic(solution, locator), CorrectLabels(labels) {}
 
   bool diagnoseAsError() override;
   bool diagnoseAsNote() override;
@@ -445,10 +472,10 @@ class MemberAccessOnOptionalBaseFailure final : public FailureDiagnostic {
   bool ResultTypeIsOptional;
 
 public:
-  MemberAccessOnOptionalBaseFailure(ConstraintSystem &cs,
+  MemberAccessOnOptionalBaseFailure(const Solution &solution,
                                     ConstraintLocator *locator,
                                     DeclNameRef memberName, bool resultOptional)
-      : FailureDiagnostic(cs, locator), Member(memberName),
+      : FailureDiagnostic(solution, locator), Member(memberName),
         ResultTypeIsOptional(resultOptional) {}
 
   bool diagnoseAsError() override;
@@ -459,8 +486,9 @@ public:
 class RValueTreatedAsLValueFailure final : public FailureDiagnostic {
 
 public:
-  RValueTreatedAsLValueFailure(ConstraintSystem &cs, ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator) {}
+  RValueTreatedAsLValueFailure(const Solution &solution,
+                               ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator) {}
 
   bool diagnoseAsError() override;
   bool diagnoseAsNote() override;
@@ -470,10 +498,9 @@ class TrailingClosureAmbiguityFailure final : public FailureDiagnostic {
   ArrayRef<OverloadChoice> Choices;
 
 public:
-  TrailingClosureAmbiguityFailure(ConstraintSystem &cs,
-                                  Expr *anchor,
+  TrailingClosureAmbiguityFailure(const Solution &solution, Expr *anchor,
                                   ArrayRef<OverloadChoice> choices)
-      : FailureDiagnostic(cs, cs.getConstraintLocator(anchor)),
+      : FailureDiagnostic(solution, cs.getConstraintLocator(anchor)),
         Choices(choices) {}
 
   bool diagnoseAsError() override { return false; }
@@ -491,16 +518,15 @@ class AssignmentFailure final : public FailureDiagnostic {
   Diag<Type> TypeDiagnostic;
 
 public:
-  AssignmentFailure(Expr *destExpr, ConstraintSystem &cs,
+  AssignmentFailure(Expr *destExpr, const Solution &solution,
                     SourceLoc diagnosticLoc);
 
-  AssignmentFailure(Expr *destExpr, ConstraintSystem &cs,
+  AssignmentFailure(Expr *destExpr, const Solution &solution,
                     SourceLoc diagnosticLoc, Diag<StringRef> declDiag,
                     Diag<Type> typeDiag)
-      : FailureDiagnostic(cs, cs.getConstraintLocator(destExpr)),
+      : FailureDiagnostic(solution, cs.getConstraintLocator(destExpr)),
         DestExpr(destExpr), Loc(diagnosticLoc), DeclDiagnostic(declDiag),
-        TypeDiagnostic(typeDiag) {
-  }
+        TypeDiagnostic(typeDiag) {}
 
   bool diagnoseAsError() override;
 
@@ -530,15 +556,17 @@ class ContextualFailure : public FailureDiagnostic {
   Type RawFromType, RawToType;
 
 public:
-  ContextualFailure(ConstraintSystem &cs, Type lhs, Type rhs,
+  ContextualFailure(const Solution &solution, Type lhs, Type rhs,
                     ConstraintLocator *locator)
-      : ContextualFailure(cs,
-                          cs.getContextualTypePurpose(locator->getAnchor()),
-                          lhs, rhs, locator) {}
+      : ContextualFailure(
+            solution,
+            solution.getConstraintSystem().getContextualTypePurpose(
+                locator->getAnchor()),
+            lhs, rhs, locator) {}
 
-  ContextualFailure(ConstraintSystem &cs, ContextualTypePurpose purpose,
+  ContextualFailure(const Solution &solution, ContextualTypePurpose purpose,
                     Type lhs, Type rhs, ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator), CTP(purpose), RawFromType(lhs),
+      : FailureDiagnostic(solution, locator), CTP(purpose), RawFromType(lhs),
         RawToType(rhs) {}
 
   Type getFromType() const { return resolve(RawFromType); }
@@ -651,9 +679,9 @@ protected:
 /// isn't explicitly '@escaping' to some other type.
 class NoEscapeFuncToTypeConversionFailure final : public ContextualFailure {
 public:
-  NoEscapeFuncToTypeConversionFailure(ConstraintSystem &cs, Type fromType,
+  NoEscapeFuncToTypeConversionFailure(const Solution &solution, Type fromType,
                                       Type toType, ConstraintLocator *locator)
-      : ContextualFailure(cs, fromType, toType, locator) {}
+      : ContextualFailure(solution, fromType, toType, locator) {}
 
   bool diagnoseAsError() override;
 
@@ -668,9 +696,9 @@ private:
 /// which require some type of force-unwrap e.g. "!" or "try!".
 class MissingOptionalUnwrapFailure final : public ContextualFailure {
 public:
-  MissingOptionalUnwrapFailure(ConstraintSystem &cs, Type fromType, Type toType,
-                               ConstraintLocator *locator)
-      : ContextualFailure(cs, fromType, toType, locator) {}
+  MissingOptionalUnwrapFailure(const Solution &solution, Type fromType,
+                               Type toType, ConstraintLocator *locator)
+      : ContextualFailure(solution, fromType, toType, locator) {}
 
   bool diagnoseAsError() override;
 
@@ -699,11 +727,11 @@ class GenericArgumentsMismatchFailure final : public ContextualFailure {
   ArrayRef<unsigned> Mismatches;
 
 public:
-  GenericArgumentsMismatchFailure(ConstraintSystem &cs,
-                                  Type actualType, Type requiredType,
+  GenericArgumentsMismatchFailure(const Solution &solution, Type actualType,
+                                  Type requiredType,
                                   ArrayRef<unsigned> mismatches,
                                   ConstraintLocator *locator)
-      : ContextualFailure(cs, actualType, requiredType, locator),
+      : ContextualFailure(solution, actualType, requiredType, locator),
         Mismatches(mismatches) {
     assert(actualType->is<BoundGenericType>());
     assert(requiredType->is<BoundGenericType>());
@@ -743,10 +771,9 @@ private:
 /// ```
 class ThrowingFunctionConversionFailure final : public ContextualFailure {
 public:
-  ThrowingFunctionConversionFailure(ConstraintSystem &cs,
-                                    Type fromType, Type toType,
-                                    ConstraintLocator *locator)
-      : ContextualFailure(cs, fromType, toType, locator) {
+  ThrowingFunctionConversionFailure(const Solution &solution, Type fromType,
+                                    Type toType, ConstraintLocator *locator)
+      : ContextualFailure(solution, fromType, toType, locator) {
     auto fnType1 = fromType->castTo<FunctionType>();
     auto fnType2 = toType->castTo<FunctionType>();
     assert(fnType1->throws() != fnType2->throws());
@@ -760,10 +787,9 @@ public:
 /// "as" or "as!" has to be specified explicitly in cases like that.
 class MissingExplicitConversionFailure final : public ContextualFailure {
 public:
-  MissingExplicitConversionFailure(ConstraintSystem &cs,
-                                   Type fromType, Type toType,
-                                   ConstraintLocator *locator)
-      : ContextualFailure(cs, fromType, toType, locator) {}
+  MissingExplicitConversionFailure(const Solution &solution, Type fromType,
+                                   Type toType, ConstraintLocator *locator)
+      : ContextualFailure(solution, fromType, toType, locator) {}
 
   bool diagnoseAsError() override;
 
@@ -792,9 +818,9 @@ private:
 /// to `inout` or pointer parameter, without explicitly specifying `&`.
 class MissingAddressOfFailure final : public ContextualFailure {
 public:
-  MissingAddressOfFailure(ConstraintSystem &cs, Type argTy,
-                          Type paramTy, ConstraintLocator *locator)
-      : ContextualFailure(cs, argTy, paramTy, locator) {}
+  MissingAddressOfFailure(const Solution &solution, Type argTy, Type paramTy,
+                          ConstraintLocator *locator)
+      : ContextualFailure(solution, argTy, paramTy, locator) {}
 
   bool diagnoseAsError() override;
 };
@@ -812,9 +838,9 @@ public:
 /// ```
 class InvalidUseOfAddressOf final : public ContextualFailure {
 public:
-  InvalidUseOfAddressOf(ConstraintSystem &cs, Type lhs, Type rhs,
+  InvalidUseOfAddressOf(const Solution &solution, Type lhs, Type rhs,
                         ConstraintLocator *locator)
-      : ContextualFailure(cs, lhs, rhs, locator) {}
+      : ContextualFailure(solution, lhs, rhs, locator) {}
 
   bool diagnoseAsError() override;
 
@@ -829,10 +855,11 @@ class TupleContextualFailure final : public ContextualFailure {
   llvm::SmallVector<unsigned, 4> Indices;
 
 public:
-  TupleContextualFailure(ConstraintSystem &cs, ContextualTypePurpose purpose,
-                         Type lhs, Type rhs, llvm::ArrayRef<unsigned> indices,
+  TupleContextualFailure(const Solution &solution,
+                         ContextualTypePurpose purpose, Type lhs, Type rhs,
+                         llvm::ArrayRef<unsigned> indices,
                          ConstraintLocator *locator)
-      : ContextualFailure(cs, purpose, lhs, rhs, locator),
+      : ContextualFailure(solution, purpose, lhs, rhs, locator),
         Indices(indices.begin(), indices.end()) {
     std::sort(Indices.begin(), Indices.end());
     assert(getFromType()->is<TupleType>() && getToType()->is<TupleType>());
@@ -852,10 +879,10 @@ class FunctionTypeMismatch final : public ContextualFailure {
   llvm::SmallVector<unsigned, 4> Indices;
 
 public:
-  FunctionTypeMismatch(ConstraintSystem &cs, ContextualTypePurpose purpose,
-                         Type lhs, Type rhs, llvm::ArrayRef<unsigned> indices,
-                         ConstraintLocator *locator)
-      : ContextualFailure(cs, purpose, lhs, rhs, locator),
+  FunctionTypeMismatch(const Solution &solution, ContextualTypePurpose purpose,
+                       Type lhs, Type rhs, llvm::ArrayRef<unsigned> indices,
+                       ConstraintLocator *locator)
+      : ContextualFailure(solution, purpose, lhs, rhs, locator),
         Indices(indices.begin(), indices.end()) {
     std::sort(Indices.begin(), Indices.end());
     assert(getFromType()->is<AnyFunctionType>() && getToType()->is<AnyFunctionType>());
@@ -868,8 +895,9 @@ public:
 /// parameter directly without calling it first.
 class AutoClosureForwardingFailure final : public FailureDiagnostic {
 public:
-  AutoClosureForwardingFailure(ConstraintSystem &cs, ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator) {}
+  AutoClosureForwardingFailure(const Solution &solution,
+                               ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator) {}
 
   bool diagnoseAsError() override;
 };
@@ -884,10 +912,10 @@ public:
 /// \endcode
 class AutoClosurePointerConversionFailure final : public ContextualFailure {
 public:
-  AutoClosurePointerConversionFailure(ConstraintSystem &cs,
+  AutoClosurePointerConversionFailure(const Solution &solution,
                                       Type pointeeType, Type pointerType,
                                       ConstraintLocator *locator)
-      : ContextualFailure(cs, pointeeType, pointerType, locator) {}
+      : ContextualFailure(solution, pointeeType, pointerType, locator) {}
 
   bool diagnoseAsError() override;
 };
@@ -908,18 +936,17 @@ class NonOptionalUnwrapFailure final : public FailureDiagnostic {
   Type BaseType;
 
 public:
-  NonOptionalUnwrapFailure(ConstraintSystem &cs, Type baseType,
+  NonOptionalUnwrapFailure(const Solution &solution, Type baseType,
                            ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator), BaseType(baseType) {}
+      : FailureDiagnostic(solution, locator), BaseType(baseType) {}
 
   bool diagnoseAsError() override;
 };
 
 class MissingCallFailure final : public FailureDiagnostic {
 public:
-  MissingCallFailure(ConstraintSystem &cs,
-                     ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator) {}
+  MissingCallFailure(const Solution &solution, ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator) {}
 
   bool diagnoseAsError() override;
 };
@@ -929,11 +956,10 @@ class PropertyWrapperReferenceFailure : public ContextualFailure {
   bool UsingStorageWrapper;
 
 public:
-  PropertyWrapperReferenceFailure(ConstraintSystem &cs,
-                                  VarDecl *property, bool usingStorageWrapper,
-                                  Type base, Type wrapper,
-                                  ConstraintLocator *locator)
-      : ContextualFailure(cs, base, wrapper, locator), Property(property),
+  PropertyWrapperReferenceFailure(const Solution &solution, VarDecl *property,
+                                  bool usingStorageWrapper, Type base,
+                                  Type wrapper, ConstraintLocator *locator)
+      : ContextualFailure(solution, base, wrapper, locator), Property(property),
         UsingStorageWrapper(usingStorageWrapper) {}
 
   VarDecl *getProperty() const { return Property; }
@@ -953,12 +979,12 @@ public:
 class ExtraneousPropertyWrapperUnwrapFailure final
     : public PropertyWrapperReferenceFailure {
 public:
-  ExtraneousPropertyWrapperUnwrapFailure(ConstraintSystem &cs,
+  ExtraneousPropertyWrapperUnwrapFailure(const Solution &solution,
                                          VarDecl *property,
                                          bool usingStorageWrapper, Type base,
                                          Type wrapper,
                                          ConstraintLocator *locator)
-      : PropertyWrapperReferenceFailure(cs, property, usingStorageWrapper,
+      : PropertyWrapperReferenceFailure(solution, property, usingStorageWrapper,
                                         base, wrapper, locator) {}
 
   bool diagnoseAsError() override;
@@ -967,11 +993,11 @@ public:
 class MissingPropertyWrapperUnwrapFailure final
     : public PropertyWrapperReferenceFailure {
 public:
-  MissingPropertyWrapperUnwrapFailure(ConstraintSystem &cs,
+  MissingPropertyWrapperUnwrapFailure(const Solution &solution,
                                       VarDecl *property,
                                       bool usingStorageWrapper, Type base,
                                       Type wrapper, ConstraintLocator *locator)
-      : PropertyWrapperReferenceFailure(cs, property, usingStorageWrapper,
+      : PropertyWrapperReferenceFailure(solution, property, usingStorageWrapper,
                                         base, wrapper, locator) {}
 
   bool diagnoseAsError() override;
@@ -979,9 +1005,8 @@ public:
 
 class SubscriptMisuseFailure final : public FailureDiagnostic {
 public:
-  SubscriptMisuseFailure(ConstraintSystem &cs,
-                         ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator) {}
+  SubscriptMisuseFailure(const Solution &solution, ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator) {}
 
   bool diagnoseAsError() override;
   bool diagnoseAsNote() override;
@@ -992,10 +1017,10 @@ class InvalidMemberRefFailure : public FailureDiagnostic {
   DeclNameRef Name;
 
 public:
-  InvalidMemberRefFailure(ConstraintSystem &cs, Type baseType,
+  InvalidMemberRefFailure(const Solution &solution, Type baseType,
                           DeclNameRef memberName, ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator), BaseType(baseType->getRValueType()),
-        Name(memberName) {}
+      : FailureDiagnostic(solution, locator),
+        BaseType(baseType->getRValueType()), Name(memberName) {}
 
 protected:
   Type getBaseType() const { return BaseType; }
@@ -1013,9 +1038,9 @@ protected:
 /// ```
 class MissingMemberFailure final : public InvalidMemberRefFailure {
 public:
-  MissingMemberFailure(ConstraintSystem &cs, Type baseType,
+  MissingMemberFailure(const Solution &solution, Type baseType,
                        DeclNameRef memberName, ConstraintLocator *locator)
-      : InvalidMemberRefFailure(cs, baseType, memberName, locator) {}
+      : InvalidMemberRefFailure(solution, baseType, memberName, locator) {}
 
   bool diagnoseAsError() override;
 
@@ -1046,9 +1071,10 @@ private:
 /// ```
 class InvalidMemberRefOnExistential final : public InvalidMemberRefFailure {
 public:
-  InvalidMemberRefOnExistential(ConstraintSystem &cs, Type baseType,
-                                DeclNameRef memberName, ConstraintLocator *locator)
-      : InvalidMemberRefFailure(cs, baseType, memberName, locator) {}
+  InvalidMemberRefOnExistential(const Solution &solution, Type baseType,
+                                DeclNameRef memberName,
+                                ConstraintLocator *locator)
+      : InvalidMemberRefFailure(solution, baseType, memberName, locator) {}
 
   bool diagnoseAsError() override;
 };
@@ -1075,10 +1101,10 @@ class AllowTypeOrInstanceMemberFailure final : public FailureDiagnostic {
   DeclNameRef Name;
 
 public:
-  AllowTypeOrInstanceMemberFailure(ConstraintSystem &cs,
-                                   Type baseType, ValueDecl *member,
-                                   DeclNameRef name, ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator),
+  AllowTypeOrInstanceMemberFailure(const Solution &solution, Type baseType,
+                                   ValueDecl *member, DeclNameRef name,
+                                   ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator),
         BaseType(baseType->getRValueType()), Member(member), Name(name) {
     assert(member);
   }
@@ -1097,9 +1123,9 @@ class PartialApplicationFailure final : public FailureDiagnostic {
   bool CompatibilityWarning;
 
 public:
-  PartialApplicationFailure(bool warning, ConstraintSystem &cs,
+  PartialApplicationFailure(bool warning, const Solution &solution,
                             ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator), CompatibilityWarning(warning) {}
+      : FailureDiagnostic(solution, locator), CompatibilityWarning(warning) {}
 
   bool diagnoseAsError() override;
 };
@@ -1110,10 +1136,10 @@ protected:
   const ConstructorDecl *Init;
   SourceRange BaseRange;
 
-  InvalidInitRefFailure(ConstraintSystem &cs, Type baseTy,
+  InvalidInitRefFailure(const Solution &solution, Type baseTy,
                         const ConstructorDecl *init, SourceRange baseRange,
                         ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator), BaseType(baseTy), Init(init),
+      : FailureDiagnostic(solution, locator), BaseType(baseTy), Init(init),
         BaseRange(baseRange) {}
 
 public:
@@ -1134,11 +1160,11 @@ public:
 /// ```
 class InvalidDynamicInitOnMetatypeFailure final : public InvalidInitRefFailure {
 public:
-  InvalidDynamicInitOnMetatypeFailure(ConstraintSystem &cs,
-                                      Type baseTy, const ConstructorDecl *init,
+  InvalidDynamicInitOnMetatypeFailure(const Solution &solution, Type baseTy,
+                                      const ConstructorDecl *init,
                                       SourceRange baseRange,
                                       ConstraintLocator *locator)
-      : InvalidInitRefFailure(cs, baseTy, init, baseRange, locator) {}
+      : InvalidInitRefFailure(solution, baseTy, init, baseRange, locator) {}
 
   bool diagnoseAsError() override;
 };
@@ -1158,11 +1184,11 @@ class InitOnProtocolMetatypeFailure final : public InvalidInitRefFailure {
   bool IsStaticallyDerived;
 
 public:
-  InitOnProtocolMetatypeFailure(ConstraintSystem &cs, Type baseTy,
+  InitOnProtocolMetatypeFailure(const Solution &solution, Type baseTy,
                                 const ConstructorDecl *init,
                                 bool isStaticallyDerived, SourceRange baseRange,
                                 ConstraintLocator *locator)
-      : InvalidInitRefFailure(cs, baseTy, init, baseRange, locator),
+      : InvalidInitRefFailure(solution, baseTy, init, baseRange, locator),
         IsStaticallyDerived(isStaticallyDerived) {}
 
   bool diagnoseAsError() override;
@@ -1178,11 +1204,10 @@ public:
 class ImplicitInitOnNonConstMetatypeFailure final
     : public InvalidInitRefFailure {
 public:
-  ImplicitInitOnNonConstMetatypeFailure(ConstraintSystem &cs,
-                                        Type baseTy,
+  ImplicitInitOnNonConstMetatypeFailure(const Solution &solution, Type baseTy,
                                         const ConstructorDecl *init,
                                         ConstraintLocator *locator)
-      : InvalidInitRefFailure(cs, baseTy, init, SourceRange(), locator) {}
+      : InvalidInitRefFailure(solution, baseTy, init, SourceRange(), locator) {}
 
   bool diagnoseAsError() override;
 };
@@ -1193,10 +1218,10 @@ class MissingArgumentsFailure final : public FailureDiagnostic {
   SmallVector<Param, 4> SynthesizedArgs;
 
 public:
-  MissingArgumentsFailure(ConstraintSystem &cs,
+  MissingArgumentsFailure(const Solution &solution,
                           ArrayRef<Param> synthesizedArgs,
                           ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator),
+      : FailureDiagnostic(solution, locator),
         SynthesizedArgs(synthesizedArgs.begin(), synthesizedArgs.end()) {
     assert(!SynthesizedArgs.empty() && "No missing arguments?!");
   }
@@ -1243,7 +1268,7 @@ public:
   /// In this case first argument is missing, but we end up with
   /// two fixes - argument mismatch (for #1) and missing argument
   /// (for #2), which is incorrect so it has to be handled specially.
-  static bool isMisplacedMissingArgument(ConstraintSystem &cs,
+  static bool isMisplacedMissingArgument(const Solution &solution,
                                          ConstraintLocator *locator);
 };
 
@@ -1253,10 +1278,10 @@ class ExtraneousArgumentsFailure final : public FailureDiagnostic {
 
 public:
   ExtraneousArgumentsFailure(
-      ConstraintSystem &cs, FunctionType *contextualType,
+      const Solution &solution, FunctionType *contextualType,
       ArrayRef<std::pair<unsigned, AnyFunctionType::Param>> extraArgs,
       ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator),
+      : FailureDiagnostic(solution, locator),
         ContextualType(resolveType(contextualType)->castTo<FunctionType>()),
         ExtraArgs(extraArgs.begin(), extraArgs.end()) {}
 
@@ -1286,12 +1311,11 @@ class OutOfOrderArgumentFailure final : public FailureDiagnostic {
   SmallVector<ParamBinding, 4> Bindings;
 
 public:
-  OutOfOrderArgumentFailure(ConstraintSystem &cs,
-                            unsigned argIdx,
+  OutOfOrderArgumentFailure(const Solution &solution, unsigned argIdx,
                             unsigned prevArgIdx,
                             ArrayRef<ParamBinding> bindings,
                             ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator), ArgIdx(argIdx),
+      : FailureDiagnostic(solution, locator), ArgIdx(argIdx),
         PrevArgIdx(prevArgIdx), Bindings(bindings.begin(), bindings.end()) {}
 
   bool diagnoseAsError() override;
@@ -1307,10 +1331,10 @@ class ClosureParamDestructuringFailure final : public FailureDiagnostic {
   FunctionType *ContextualType;
 
 public:
-  ClosureParamDestructuringFailure(ConstraintSystem &cs,
+  ClosureParamDestructuringFailure(const Solution &solution,
                                    FunctionType *contextualType,
                                    ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator), ContextualType(contextualType) {}
+      : FailureDiagnostic(solution, locator), ContextualType(contextualType) {}
 
   bool diagnoseAsError() override;
 
@@ -1337,9 +1361,9 @@ class InaccessibleMemberFailure final : public FailureDiagnostic {
   ValueDecl *Member;
 
 public:
-  InaccessibleMemberFailure(ConstraintSystem &cs, ValueDecl *member,
+  InaccessibleMemberFailure(const Solution &solution, ValueDecl *member,
                             ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator), Member(member) {}
+      : FailureDiagnostic(solution, locator), Member(member) {}
 
   bool diagnoseAsError() override;
 };
@@ -1361,10 +1385,9 @@ class MutatingMemberRefOnImmutableBase final : public FailureDiagnostic {
   ValueDecl *Member;
 
 public:
-  MutatingMemberRefOnImmutableBase(ConstraintSystem &cs,
-                                   ValueDecl *member,
+  MutatingMemberRefOnImmutableBase(const Solution &solution, ValueDecl *member,
                                    ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator), Member(member) {}
+      : FailureDiagnostic(solution, locator), Member(member) {}
 
   bool diagnoseAsError() override;
 };
@@ -1377,10 +1400,10 @@ public:
 class AnyObjectKeyPathRootFailure final : public FailureDiagnostic {
 
 public:
-  AnyObjectKeyPathRootFailure(ConstraintSystem &cs,
+  AnyObjectKeyPathRootFailure(const Solution &solution,
                               ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator) {}
-  
+      : FailureDiagnostic(solution, locator) {}
+
   bool diagnoseAsError() override;
 };
 
@@ -1402,9 +1425,9 @@ class KeyPathSubscriptIndexHashableFailure final : public FailureDiagnostic {
   Type NonConformingType;
 
 public:
-  KeyPathSubscriptIndexHashableFailure(ConstraintSystem &cs,
-                                       Type type, ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator), NonConformingType(type) {
+  KeyPathSubscriptIndexHashableFailure(const Solution &solution, Type type,
+                                       ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator), NonConformingType(type) {
     assert(locator->isResultOfKeyPathDynamicMemberLookup() ||
            locator->isKeyPathSubscriptComponent());
   }
@@ -1416,9 +1439,9 @@ class InvalidMemberRefInKeyPath : public FailureDiagnostic {
   ValueDecl *Member;
 
 public:
-  InvalidMemberRefInKeyPath(ConstraintSystem &cs, ValueDecl *member,
+  InvalidMemberRefInKeyPath(const Solution &solution, ValueDecl *member,
                             ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator), Member(member) {
+      : FailureDiagnostic(solution, locator), Member(member) {
     assert(member->hasName());
     assert(locator->isForKeyPathComponent() ||
            locator->isForKeyPathDynamicMemberLookup());
@@ -1451,9 +1474,9 @@ protected:
 /// ```
 class InvalidStaticMemberRefInKeyPath final : public InvalidMemberRefInKeyPath {
 public:
-  InvalidStaticMemberRefInKeyPath(ConstraintSystem &cs,
-                                  ValueDecl *member, ConstraintLocator *locator)
-      : InvalidMemberRefInKeyPath(cs, member, locator) {}
+  InvalidStaticMemberRefInKeyPath(const Solution &solution, ValueDecl *member,
+                                  ConstraintLocator *locator)
+      : InvalidMemberRefInKeyPath(solution, member, locator) {}
 
   bool diagnoseAsError() override;
 };
@@ -1478,10 +1501,10 @@ public:
 class InvalidMemberWithMutatingGetterInKeyPath final
     : public InvalidMemberRefInKeyPath {
 public:
-  InvalidMemberWithMutatingGetterInKeyPath(ConstraintSystem &cs,
+  InvalidMemberWithMutatingGetterInKeyPath(const Solution &solution,
                                            ValueDecl *member,
                                            ConstraintLocator *locator)
-      : InvalidMemberRefInKeyPath(cs, member, locator) {}
+      : InvalidMemberRefInKeyPath(solution, member, locator) {}
 
   bool diagnoseAsError() override;
 };
@@ -1500,9 +1523,9 @@ public:
 /// ```
 class InvalidMethodRefInKeyPath final : public InvalidMemberRefInKeyPath {
 public:
-  InvalidMethodRefInKeyPath(ConstraintSystem &cs, ValueDecl *method,
+  InvalidMethodRefInKeyPath(const Solution &solution, ValueDecl *method,
                             ConstraintLocator *locator)
-      : InvalidMemberRefInKeyPath(cs, method, locator) {
+      : InvalidMemberRefInKeyPath(solution, method, locator) {
     assert(isa<FuncDecl>(method));
   }
 
@@ -1517,9 +1540,8 @@ public:
 /// ```
 class ExtraneousReturnFailure final : public FailureDiagnostic {
 public:
-  ExtraneousReturnFailure(ConstraintSystem &cs,
-                          ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator) {}
+  ExtraneousReturnFailure(const Solution &solution, ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator) {}
 
   bool diagnoseAsError() override;
 };
@@ -1533,10 +1555,10 @@ public:
 /// ```
 class CollectionElementContextualFailure final : public ContextualFailure {
 public:
-  CollectionElementContextualFailure(ConstraintSystem &cs,
-                                     Type eltType, Type contextualType,
+  CollectionElementContextualFailure(const Solution &solution, Type eltType,
+                                     Type contextualType,
                                      ConstraintLocator *locator)
-      : ContextualFailure(cs, eltType, contextualType, locator) {}
+      : ContextualFailure(solution, eltType, contextualType, locator) {}
 
   bool diagnoseAsError() override;
 };
@@ -1545,11 +1567,11 @@ class MissingContextualConformanceFailure final : public ContextualFailure {
   ContextualTypePurpose Context;
 
 public:
-  MissingContextualConformanceFailure(ConstraintSystem &cs,
+  MissingContextualConformanceFailure(const Solution &solution,
                                       ContextualTypePurpose context, Type type,
                                       Type protocolType,
                                       ConstraintLocator *locator)
-      : ContextualFailure(cs, type, protocolType, locator),
+      : ContextualFailure(solution, type, protocolType, locator),
         Context(context) {
     assert(protocolType->is<ProtocolType>() ||
            protocolType->is<ProtocolCompositionType>());
@@ -1565,9 +1587,9 @@ public:
 /// argument type of `inout` parameter, they have to be equal.
 class InOutConversionFailure final : public ContextualFailure {
 public:
-  InOutConversionFailure(ConstraintSystem &cs, Type argType,
-                         Type paramType, ConstraintLocator *locator)
-      : ContextualFailure(cs, argType, paramType, locator) {}
+  InOutConversionFailure(const Solution &solution, Type argType, Type paramType,
+                         ConstraintLocator *locator)
+      : ContextualFailure(solution, argType, paramType, locator) {}
 
   bool diagnoseAsError() override;
 
@@ -1589,10 +1611,10 @@ class MissingGenericArgumentsFailure final : public FailureDiagnostic {
   SmallVector<GenericTypeParamType *, 4> Parameters;
 
 public:
-  MissingGenericArgumentsFailure(ConstraintSystem &cs,
+  MissingGenericArgumentsFailure(const Solution &solution,
                                  ArrayRef<GenericTypeParamType *> missingParams,
                                  ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator) {
+      : FailureDiagnostic(solution, locator) {
     assert(!missingParams.empty());
     Parameters.append(missingParams.begin(), missingParams.end());
   }
@@ -1634,13 +1656,12 @@ public:
   void diagnosePrimary(bool asNote);
 
 public:
-  SkipUnhandledConstructInFunctionBuilderFailure(ConstraintSystem &cs,
+  SkipUnhandledConstructInFunctionBuilderFailure(const Solution &solution,
                                                  UnhandledNode unhandled,
                                                  NominalTypeDecl *builder,
                                                  ConstraintLocator *locator)
-    : FailureDiagnostic(cs, locator),
-      unhandled(unhandled),
-      builder(builder) { }
+      : FailureDiagnostic(solution, locator), unhandled(unhandled),
+        builder(builder) {}
 
   bool diagnoseAsError() override;
   bool diagnoseAsNote() override;
@@ -1657,10 +1678,10 @@ class InvalidTupleSplatWithSingleParameterFailure final
   Type ParamType;
 
 public:
-  InvalidTupleSplatWithSingleParameterFailure(ConstraintSystem &cs,
+  InvalidTupleSplatWithSingleParameterFailure(const Solution &solution,
                                               Type paramTy,
                                               ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator), ParamType(paramTy) {}
+      : FailureDiagnostic(solution, locator), ParamType(paramTy) {}
   bool diagnoseAsError() override;
 };
 
@@ -1672,9 +1693,9 @@ public:
 /// ```
 class ExpandArrayIntoVarargsFailure final : public ContextualFailure {
 public:
-  ExpandArrayIntoVarargsFailure(ConstraintSystem &cs, Type lhs,
-                                Type rhs, ConstraintLocator *locator)
-      : ContextualFailure(cs, lhs, rhs, locator) {}
+  ExpandArrayIntoVarargsFailure(const Solution &solution, Type lhs, Type rhs,
+                                ConstraintLocator *locator)
+      : ContextualFailure(solution, lhs, rhs, locator) {}
 
   bool diagnoseAsError() override;
   bool diagnoseAsNote() override;
@@ -1693,9 +1714,9 @@ class ArgumentMismatchFailure : public ContextualFailure {
   FunctionArgApplyInfo Info;
 
 public:
-  ArgumentMismatchFailure(ConstraintSystem &cs, Type argType, Type paramType,
-                          ConstraintLocator *locator)
-      : ContextualFailure(cs, argType, paramType, locator),
+  ArgumentMismatchFailure(const Solution &solution, Type argType,
+                          Type paramType, ConstraintLocator *locator)
+      : ContextualFailure(solution, argType, paramType, locator),
         Info(*cs.getFunctionArgApplyInfo(getLocator())) {}
 
   bool diagnoseAsError() override;
@@ -1817,27 +1838,26 @@ protected:
 /// Replace a coercion ('as') with a forced checked cast ('as!').
 class MissingForcedDowncastFailure final : public ContextualFailure {
 public:
-  MissingForcedDowncastFailure(ConstraintSystem &cs, Type fromType,
+  MissingForcedDowncastFailure(const Solution &solution, Type fromType,
                                Type toType, ConstraintLocator *locator)
-      : ContextualFailure(cs, fromType, toType, locator) {}
+      : ContextualFailure(solution, fromType, toType, locator) {}
 
   bool diagnoseAsError() override;
 };
 
 class ExtraneousCallFailure final : public FailureDiagnostic {
 public:
-  ExtraneousCallFailure(ConstraintSystem &cs,
-                        ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator) {}
+  ExtraneousCallFailure(const Solution &solution, ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator) {}
 
   bool diagnoseAsError() override;
 };
 
 class InvalidUseOfTrailingClosure final : public ArgumentMismatchFailure {
 public:
-  InvalidUseOfTrailingClosure(ConstraintSystem &cs, Type argType,
+  InvalidUseOfTrailingClosure(const Solution &solution, Type argType,
                               Type paramType, ConstraintLocator *locator)
-      : ArgumentMismatchFailure(cs, argType, paramType, locator) {}
+      : ArgumentMismatchFailure(solution, argType, paramType, locator) {}
 
   bool diagnoseAsError() override;
 };
@@ -1855,12 +1875,12 @@ class NonEphemeralConversionFailure final : public ArgumentMismatchFailure {
   bool DowngradeToWarning;
 
 public:
-  NonEphemeralConversionFailure(ConstraintSystem &cs,
-                                ConstraintLocator *locator,
-                                Type fromType, Type toType,
+  NonEphemeralConversionFailure(const Solution &solution,
+                                ConstraintLocator *locator, Type fromType,
+                                Type toType,
                                 ConversionRestrictionKind conversionKind,
                                 bool downgradeToWarning)
-      : ArgumentMismatchFailure(cs, fromType, toType, locator),
+      : ArgumentMismatchFailure(solution, fromType, toType, locator),
         ConversionKind(conversionKind), DowngradeToWarning(downgradeToWarning) {
   }
 
@@ -1880,10 +1900,10 @@ private:
 
 class AssignmentTypeMismatchFailure final : public ContextualFailure {
 public:
-  AssignmentTypeMismatchFailure(ConstraintSystem &cs,
+  AssignmentTypeMismatchFailure(const Solution &solution,
                                 ContextualTypePurpose context, Type srcType,
                                 Type dstType, ConstraintLocator *locator)
-      : ContextualFailure(cs, context, srcType, dstType, locator) {}
+      : ContextualFailure(solution, context, srcType, dstType, locator) {}
 
   bool diagnoseAsError() override;
   bool diagnoseAsNote() override;
@@ -1896,28 +1916,28 @@ class MissingContextualBaseInMemberRefFailure final : public FailureDiagnostic {
   DeclNameRef MemberName;
 
 public:
-  MissingContextualBaseInMemberRefFailure(ConstraintSystem &cs,
+  MissingContextualBaseInMemberRefFailure(const Solution &solution,
                                           DeclNameRef member,
                                           ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator), MemberName(member) {}
+      : FailureDiagnostic(solution, locator), MemberName(member) {}
 
   bool diagnoseAsError();
 };
 
 class UnableToInferClosureReturnType final : public FailureDiagnostic {
 public:
-  UnableToInferClosureReturnType(ConstraintSystem &cs,
+  UnableToInferClosureReturnType(const Solution &solution,
                                  ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator) {}
+      : FailureDiagnostic(solution, locator) {}
 
   bool diagnoseAsError();
 };
 
 class UnableToInferProtocolLiteralType final : public FailureDiagnostic {
 public:
-  UnableToInferProtocolLiteralType(ConstraintSystem &cs,
+  UnableToInferProtocolLiteralType(const Solution &solution,
                                    ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator) {}
+      : FailureDiagnostic(solution, locator) {}
 
   bool diagnoseAsError();
 };
@@ -1938,9 +1958,9 @@ public:
 /// has a member named `max` which accepts a single argument.
 class MissingQuialifierInMemberRefFailure final : public FailureDiagnostic {
 public:
-  MissingQuialifierInMemberRefFailure(ConstraintSystem &cs,
+  MissingQuialifierInMemberRefFailure(const Solution &solution,
                                       ConstraintLocator *locator)
-      : FailureDiagnostic(cs, locator) {}
+      : FailureDiagnostic(solution, locator) {}
 
   bool diagnoseAsError();
 };

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -188,6 +188,7 @@ bool MissingConformance::diagnose(const Solution &solution, bool asNote) const {
   auto *locator = getLocator();
 
   if (IsContextual) {
+    auto &cs = solution.getConstraintSystem();
     auto context = cs.getContextualTypePurpose(locator->getAnchor());
     MissingContextualConformanceFailure failure(
         solution, context, NonConformingType, ProtocolType, locator);

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -636,9 +636,9 @@ bool AddMissingArguments::diagnose(const Solution &solution,
 
 AddMissingArguments *
 AddMissingArguments::create(ConstraintSystem &cs,
-                            llvm::ArrayRef<Param> synthesizedArgs,
+                            ArrayRef<SynthesizedParam> synthesizedArgs,
                             ConstraintLocator *locator) {
-  unsigned size = totalSizeToAlloc<Param>(synthesizedArgs.size());
+  unsigned size = totalSizeToAlloc<SynthesizedParam>(synthesizedArgs.size());
   void *mem = cs.getAllocator().Allocate(size, alignof(AddMissingArguments));
   return new (mem) AddMissingArguments(cs, synthesizedArgs, locator);
 }

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -268,7 +268,7 @@ getStructuralTypeContext(const Solution &solution, ConstraintLocator *locator) {
     auto exprType = cs.getType(anchor);
     return std::make_tuple(cs.getContextualTypePurpose(anchor), exprType,
                            contextualType);
-  } else if (auto argApplyInfo = cs.getFunctionArgApplyInfo(locator)) {
+  } else if (auto argApplyInfo = solution.getFunctionArgApplyInfo(locator)) {
     return std::make_tuple(CTP_CallArgument,
                            argApplyInfo->getArgType(),
                            argApplyInfo->getParamType());

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -56,9 +56,8 @@ std::string ForceDowncast::getName() const {
   return name.c_str();
 }
 
-bool ForceDowncast::diagnose(bool asNote) const {
-  auto &cs = getConstraintSystem();
-  MissingExplicitConversionFailure failure(cs, getFromType(), getToType(),
+bool ForceDowncast::diagnose(const Solution &solution, bool asNote) const {
+  MissingExplicitConversionFailure failure(solution, getFromType(), getToType(),
                                            getLocator());
   return failure.diagnose(asNote);
 }
@@ -68,9 +67,9 @@ ForceDowncast *ForceDowncast::create(ConstraintSystem &cs, Type fromType,
   return new (cs.getAllocator()) ForceDowncast(cs, fromType, toType, locator);
 }
 
-bool ForceOptional::diagnose(bool asNote) const {
-  MissingOptionalUnwrapFailure failure(getConstraintSystem(), getFromType(),
-                                       getToType(), getLocator());
+bool ForceOptional::diagnose(const Solution &solution, bool asNote) const {
+  MissingOptionalUnwrapFailure failure(solution, getFromType(), getToType(),
+                                       getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -79,11 +78,11 @@ ForceOptional *ForceOptional::create(ConstraintSystem &cs, Type fromType,
   return new (cs.getAllocator()) ForceOptional(cs, fromType, toType, locator);
 }
 
-bool UnwrapOptionalBase::diagnose(bool asNote) const {
+bool UnwrapOptionalBase::diagnose(const Solution &solution, bool asNote) const {
   bool resultIsOptional =
       getKind() == FixKind::UnwrapOptionalBaseWithOptionalResult;
-  MemberAccessOnOptionalBaseFailure failure(
-      getConstraintSystem(), getLocator(), MemberName, resultIsOptional);
+  MemberAccessOnOptionalBaseFailure failure(solution, getLocator(), MemberName,
+                                            resultIsOptional);
   return failure.diagnose(asNote);
 }
 
@@ -100,9 +99,8 @@ UnwrapOptionalBase *UnwrapOptionalBase::createWithOptionalResult(
       cs, FixKind::UnwrapOptionalBaseWithOptionalResult, member, locator);
 }
 
-bool AddAddressOf::diagnose(bool asNote) const {
-  auto &cs = getConstraintSystem();
-  MissingAddressOfFailure failure(cs, getFromType(), getToType(),
+bool AddAddressOf::diagnose(const Solution &solution, bool asNote) const {
+  MissingAddressOfFailure failure(solution, getFromType(), getToType(),
                                   getLocator());
   return failure.diagnose(asNote);
 }
@@ -112,8 +110,9 @@ AddAddressOf *AddAddressOf::create(ConstraintSystem &cs, Type argTy,
   return new (cs.getAllocator()) AddAddressOf(cs, argTy, paramTy, locator);
 }
 
-bool TreatRValueAsLValue::diagnose(bool asNote) const {
-  RValueTreatedAsLValueFailure failure(getConstraintSystem(), getLocator());
+bool TreatRValueAsLValue::diagnose(const Solution &solution,
+                                   bool asNote) const {
+  RValueTreatedAsLValueFailure failure(solution, getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -122,9 +121,9 @@ TreatRValueAsLValue *TreatRValueAsLValue::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) TreatRValueAsLValue(cs, locator);
 }
 
-bool CoerceToCheckedCast::diagnose(bool asNote) const {
-  MissingForcedDowncastFailure failure(getConstraintSystem(),
-                                       getFromType(), getToType(),
+bool CoerceToCheckedCast::diagnose(const Solution &solution,
+                                   bool asNote) const {
+  MissingForcedDowncastFailure failure(solution, getFromType(), getToType(),
                                        getLocator());
   return failure.diagnose(asNote);
 }
@@ -132,7 +131,7 @@ bool CoerceToCheckedCast::diagnose(bool asNote) const {
 CoerceToCheckedCast *CoerceToCheckedCast::attempt(ConstraintSystem &cs,
                                                   Type fromType, Type toType,
                                                   ConstraintLocator *locator) {
-  // If any of the types has a type variable, don't add the fix. 
+  // If any of the types has a type variable, don't add the fix.
   if (fromType->hasTypeVariable() || toType->hasTypeVariable())
     return nullptr;
 
@@ -158,10 +157,10 @@ CoerceToCheckedCast *CoerceToCheckedCast::attempt(ConstraintSystem &cs,
       CoerceToCheckedCast(cs, fromType, toType, locator);
 }
 
-bool MarkExplicitlyEscaping::diagnose(bool asNote) const {
-  auto &cs = getConstraintSystem();
-  NoEscapeFuncToTypeConversionFailure failure(cs, getFromType(), getToType(),
-                                              getLocator());
+bool MarkExplicitlyEscaping::diagnose(const Solution &solution,
+                                      bool asNote) const {
+  NoEscapeFuncToTypeConversionFailure failure(solution, getFromType(),
+                                              getToType(), getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -171,9 +170,8 @@ MarkExplicitlyEscaping::create(ConstraintSystem &cs, Type lhs, Type rhs,
   return new (cs.getAllocator()) MarkExplicitlyEscaping(cs, lhs, rhs, locator);
 }
 
-bool RelabelArguments::diagnose(bool asNote) const {
-  LabelingFailure failure(getConstraintSystem(), getLocator(),
-                          getLabels());
+bool RelabelArguments::diagnose(const Solution &solution, bool asNote) const {
+  LabelingFailure failure(solution, getLocator(), getLabels());
   return failure.diagnose(asNote);
 }
 
@@ -186,19 +184,18 @@ RelabelArguments::create(ConstraintSystem &cs,
   return new (mem) RelabelArguments(cs, correctLabels, locator);
 }
 
-bool MissingConformance::diagnose(bool asNote) const {
-  auto &cs = getConstraintSystem();
+bool MissingConformance::diagnose(const Solution &solution, bool asNote) const {
   auto *locator = getLocator();
 
   if (IsContextual) {
     auto context = cs.getContextualTypePurpose(locator->getAnchor());
     MissingContextualConformanceFailure failure(
-        cs, context, NonConformingType, ProtocolType, locator);
+        solution, context, NonConformingType, ProtocolType, locator);
     return failure.diagnose(asNote);
   }
 
   MissingConformanceFailure failure(
-      cs, locator, std::make_pair(NonConformingType, ProtocolType));
+      solution, locator, std::make_pair(NonConformingType, ProtocolType));
   return failure.diagnose(asNote);
 }
 
@@ -218,9 +215,9 @@ MissingConformance::forRequirement(ConstraintSystem &cs, Type type,
       cs, /*isContextual=*/false, type, protocolType, locator);
 }
 
-bool SkipSameTypeRequirement::diagnose(bool asNote) const {
-  SameTypeRequirementFailure failure(getConstraintSystem(), LHS, RHS,
-                                     getLocator());
+bool SkipSameTypeRequirement::diagnose(const Solution &solution,
+                                       bool asNote) const {
+  SameTypeRequirementFailure failure(solution, LHS, RHS, getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -230,9 +227,9 @@ SkipSameTypeRequirement::create(ConstraintSystem &cs, Type lhs, Type rhs,
   return new (cs.getAllocator()) SkipSameTypeRequirement(cs, lhs, rhs, locator);
 }
 
-bool SkipSuperclassRequirement::diagnose(bool asNote) const {
-  SuperclassRequirementFailure failure(getConstraintSystem(), LHS, RHS,
-                                       getLocator());
+bool SkipSuperclassRequirement::diagnose(const Solution &solution,
+                                         bool asNote) const {
+  SuperclassRequirementFailure failure(solution, LHS, RHS, getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -243,9 +240,8 @@ SkipSuperclassRequirement::create(ConstraintSystem &cs, Type lhs, Type rhs,
       SkipSuperclassRequirement(cs, lhs, rhs, locator);
 }
 
-bool ContextualMismatch::diagnose(bool asNote) const {
-  auto failure = ContextualFailure(getConstraintSystem(), getFromType(),
-                                   getToType(), getLocator());
+bool ContextualMismatch::diagnose(const Solution &solution, bool asNote) const {
+  ContextualFailure failure(solution, getFromType(), getToType(), getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -261,11 +257,12 @@ ContextualMismatch *ContextualMismatch::create(ConstraintSystem &cs, Type lhs,
 /// \returns A tuple containing the contextual type purpose, the source type,
 /// and the contextual type.
 static Optional<std::tuple<ContextualTypePurpose, Type, Type>>
-getStructuralTypeContext(ConstraintSystem &cs, ConstraintLocator *locator) {
+getStructuralTypeContext(const Solution &solution, ConstraintLocator *locator) {
   if (locator->findLast<LocatorPathElt::ContextualType>()) {
     assert(locator->isLastElement<LocatorPathElt::ContextualType>() ||
            locator->isLastElement<LocatorPathElt::FunctionArgument>());
 
+    auto &cs = solution.getConstraintSystem();
     auto *anchor = locator->getAnchor();
     auto contextualType = cs.getContextualType(anchor);
     auto exprType = cs.getType(anchor);
@@ -277,24 +274,26 @@ getStructuralTypeContext(ConstraintSystem &cs, ConstraintLocator *locator) {
                            argApplyInfo->getParamType());
   } else if (auto *coerceExpr = dyn_cast<CoerceExpr>(locator->getAnchor())) {
     return std::make_tuple(CTP_CoerceOperand,
-                           cs.getType(coerceExpr->getSubExpr()),
-                           cs.getType(coerceExpr));
+                           solution.getType(coerceExpr->getSubExpr()),
+                           solution.getType(coerceExpr));
   } else if (auto *assignExpr = dyn_cast<AssignExpr>(locator->getAnchor())) {
     return std::make_tuple(CTP_AssignSource,
-                           cs.getType(assignExpr->getSrc()),
-                           cs.getType(assignExpr->getDest()));
+                           solution.getType(assignExpr->getSrc()),
+                           solution.getType(assignExpr->getDest()));
   } else if (auto *call = dyn_cast<CallExpr>(locator->getAnchor())) {
     assert(isa<TypeExpr>(call->getFn()));
-    return std::make_tuple(CTP_Initialization,
-                           cs.getType(call->getFn())->getMetatypeInstanceType(),
-                           cs.getType(call->getArg()));
+    return std::make_tuple(
+        CTP_Initialization,
+        solution.getType(call->getFn())->getMetatypeInstanceType(),
+        solution.getType(call->getArg()));
   }
 
   return None;
 }
 
 bool AllowTupleTypeMismatch::coalesceAndDiagnose(
-    ArrayRef<ConstraintFix *> fixes, bool asNote) const {
+    const Solution &solution, ArrayRef<ConstraintFix *> fixes,
+    bool asNote) const {
   llvm::SmallVector<unsigned, 4> indices;
   if (isElementMismatch())
     indices.push_back(*Index);
@@ -316,18 +315,21 @@ bool AllowTupleTypeMismatch::coalesceAndDiagnose(
     purpose = cs.getContextualTypePurpose(locator->getAnchor());
     fromType = getFromType();
     toType = getToType();
-  } else if (auto contextualTypeInfo = getStructuralTypeContext(cs, locator)) {
+  } else if (auto contextualTypeInfo =
+                 getStructuralTypeContext(solution, locator)) {
     std::tie(purpose, fromType, toType) = *contextualTypeInfo;
   } else {
     return false;
   }
 
-  TupleContextualFailure failure(cs, purpose, fromType, toType, indices, locator);
+  TupleContextualFailure failure(solution, purpose, fromType, toType, indices,
+                                 locator);
   return failure.diagnose(asNote);
 }
 
-bool AllowTupleTypeMismatch::diagnose(bool asNote) const {
-  return coalesceAndDiagnose({}, asNote);
+bool AllowTupleTypeMismatch::diagnose(const Solution &solution,
+                                      bool asNote) const {
+  return coalesceAndDiagnose(solution, {}, asNote);
 }
 
 AllowTupleTypeMismatch *
@@ -339,7 +341,8 @@ AllowTupleTypeMismatch::create(ConstraintSystem &cs, Type lhs, Type rhs,
 }
 
 bool AllowFunctionTypeMismatch::coalesceAndDiagnose(
-    ArrayRef<ConstraintFix *> fixes, bool asNote) const {
+    const Solution &solution, ArrayRef<ConstraintFix *> fixes,
+    bool asNote) const {
   llvm::SmallVector<unsigned, 4> indices{ParamIndex};
 
   for (auto fix : fixes) {
@@ -347,23 +350,24 @@ bool AllowFunctionTypeMismatch::coalesceAndDiagnose(
       indices.push_back(fnFix->ParamIndex);
   }
 
-  auto &cs = getConstraintSystem();
   auto *locator = getLocator();
   ContextualTypePurpose purpose;
   Type fromType;
   Type toType;
 
-  auto contextualTypeInfo = getStructuralTypeContext(cs, locator);
+  auto contextualTypeInfo = getStructuralTypeContext(solution, locator);
   if (!contextualTypeInfo)
     return false;
 
   std::tie(purpose, fromType, toType) = *contextualTypeInfo;
-  FunctionTypeMismatch failure(cs, purpose, fromType, toType, indices, locator);
+  FunctionTypeMismatch failure(solution, purpose, fromType, toType, indices,
+                               locator);
   return failure.diagnose(asNote);
 }
 
-bool AllowFunctionTypeMismatch::diagnose(bool asNote) const {
-  return coalesceAndDiagnose({}, asNote);
+bool AllowFunctionTypeMismatch::diagnose(const Solution &solution,
+                                         bool asNote) const {
+  return coalesceAndDiagnose(solution, {}, asNote);
 }
 
 AllowFunctionTypeMismatch *
@@ -373,9 +377,9 @@ AllowFunctionTypeMismatch::create(ConstraintSystem &cs, Type lhs, Type rhs,
       AllowFunctionTypeMismatch(cs, lhs, rhs, locator, index);
 }
 
-bool GenericArgumentsMismatch::diagnose(bool asNote) const {
-  auto &cs = getConstraintSystem();
-  GenericArgumentsMismatchFailure failure(cs, getFromType(), getToType(),
+bool GenericArgumentsMismatch::diagnose(const Solution &solution,
+                                        bool asNote) const {
+  GenericArgumentsMismatchFailure failure(solution, getFromType(), getToType(),
                                           getMismatches(), getLocator());
   return failure.diagnose(asNote);
 }
@@ -390,9 +394,9 @@ GenericArgumentsMismatch *GenericArgumentsMismatch::create(
       GenericArgumentsMismatch(cs, actual, required, mismatches, locator);
 }
 
-bool AutoClosureForwarding::diagnose(bool asNote) const {
-  auto failure =
-      AutoClosureForwardingFailure(getConstraintSystem(), getLocator());
+bool AutoClosureForwarding::diagnose(const Solution &solution,
+                                     bool asNote) const {
+  AutoClosureForwardingFailure failure(solution, getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -401,9 +405,10 @@ AutoClosureForwarding *AutoClosureForwarding::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) AutoClosureForwarding(cs, locator);
 }
 
-bool AllowAutoClosurePointerConversion::diagnose(bool asNote) const {
-  auto failure = AutoClosurePointerConversionFailure(getConstraintSystem(),
-      getFromType(), getToType(), getLocator());
+bool AllowAutoClosurePointerConversion::diagnose(const Solution &solution,
+                                                 bool asNote) const {
+  AutoClosurePointerConversionFailure failure(solution, getFromType(),
+                                              getToType(), getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -415,9 +420,8 @@ AllowAutoClosurePointerConversion::create(ConstraintSystem &cs, Type pointeeType
       AllowAutoClosurePointerConversion(cs, pointeeType, pointerType, locator);
 }
 
-bool RemoveUnwrap::diagnose(bool asNote) const {
-  auto failure = NonOptionalUnwrapFailure(getConstraintSystem(), BaseType,
-                                          getLocator());
+bool RemoveUnwrap::diagnose(const Solution &solution, bool asNote) const {
+  NonOptionalUnwrapFailure failure(solution, BaseType, getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -426,8 +430,8 @@ RemoveUnwrap *RemoveUnwrap::create(ConstraintSystem &cs, Type baseType,
   return new (cs.getAllocator()) RemoveUnwrap(cs, baseType, locator);
 }
 
-bool InsertExplicitCall::diagnose(bool asNote) const {
-  auto failure = MissingCallFailure(getConstraintSystem(), getLocator());
+bool InsertExplicitCall::diagnose(const Solution &solution, bool asNote) const {
+  MissingCallFailure failure(solution, getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -436,10 +440,9 @@ InsertExplicitCall *InsertExplicitCall::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) InsertExplicitCall(cs, locator);
 }
 
-bool UsePropertyWrapper::diagnose(bool asNote) const {
-  auto &cs = getConstraintSystem();
-  auto failure = ExtraneousPropertyWrapperUnwrapFailure(
-      cs, Wrapped, UsingStorageWrapper, Base, Wrapper, getLocator());
+bool UsePropertyWrapper::diagnose(const Solution &solution, bool asNote) const {
+  ExtraneousPropertyWrapperUnwrapFailure failure(
+      solution, Wrapped, UsingStorageWrapper, Base, Wrapper, getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -452,11 +455,10 @@ UsePropertyWrapper *UsePropertyWrapper::create(ConstraintSystem &cs,
       cs, wrapped, usingStorageWrapper, base, wrapper, locator);
 }
 
-bool UseWrappedValue::diagnose(bool asNote) const {
-  auto &cs = getConstraintSystem();
-  auto failure = MissingPropertyWrapperUnwrapFailure(
-      cs, PropertyWrapper, usingStorageWrapper(), Base, Wrapper,
-      getLocator());
+bool UseWrappedValue::diagnose(const Solution &solution, bool asNote) const {
+  MissingPropertyWrapperUnwrapFailure failure(solution, PropertyWrapper,
+                                              usingStorageWrapper(), Base,
+                                              Wrapper, getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -468,8 +470,9 @@ UseWrappedValue *UseWrappedValue::create(ConstraintSystem &cs,
       UseWrappedValue(cs, propertyWrapper, base, wrapper, locator);
 }
 
-bool UseSubscriptOperator::diagnose(bool asNote) const {
-  auto failure = SubscriptMisuseFailure(getConstraintSystem(), getLocator());
+bool UseSubscriptOperator::diagnose(const Solution &solution,
+                                    bool asNote) const {
+  SubscriptMisuseFailure failure(solution, getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -478,9 +481,9 @@ UseSubscriptOperator *UseSubscriptOperator::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) UseSubscriptOperator(cs, locator);
 }
 
-bool DefineMemberBasedOnUse::diagnose(bool asNote) const {
-  auto failure = MissingMemberFailure(getConstraintSystem(), BaseType,
-                                      Name, getLocator());
+bool DefineMemberBasedOnUse::diagnose(const Solution &solution,
+                                      bool asNote) const {
+  MissingMemberFailure failure(solution, BaseType, Name, getLocator());
   return AlreadyDiagnosed || failure.diagnose(asNote);
 }
 
@@ -499,7 +502,7 @@ DefineMemberBasedOnUse::diagnoseForAmbiguity(ArrayRef<Solution> solutions) const
     }
   }
 
-  return diagnose();
+  return diagnose(solutions.front());
 }
 
 DefineMemberBasedOnUse *
@@ -518,17 +521,17 @@ AllowMemberRefOnExistential::create(ConstraintSystem &cs, Type baseType,
       AllowMemberRefOnExistential(cs, baseType, memberName, member, locator);
 }
 
-bool AllowMemberRefOnExistential::diagnose(bool asNote) const {
-  auto failure =
-      InvalidMemberRefOnExistential(getConstraintSystem(), getBaseType(),
-                                    getMemberName(), getLocator());
+bool AllowMemberRefOnExistential::diagnose(const Solution &solution,
+                                           bool asNote) const {
+  InvalidMemberRefOnExistential failure(solution, getBaseType(),
+                                        getMemberName(), getLocator());
   return failure.diagnose(asNote);
 }
 
-bool AllowTypeOrInstanceMember::diagnose(bool asNote) const {
-  auto failure = AllowTypeOrInstanceMemberFailure(
-      getConstraintSystem(), getBaseType(), getMember(), getMemberName(),
-      getLocator());
+bool AllowTypeOrInstanceMember::diagnose(const Solution &solution,
+                                         bool asNote) const {
+  AllowTypeOrInstanceMemberFailure failure(solution, getBaseType(), getMember(),
+                                           getMemberName(), getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -540,9 +543,9 @@ AllowTypeOrInstanceMember::create(ConstraintSystem &cs, Type baseType,
       AllowTypeOrInstanceMember(cs, baseType, member, usedName, locator);
 }
 
-bool AllowInvalidPartialApplication::diagnose(bool asNote) const {
-  auto failure = PartialApplicationFailure(isWarning(),
-                                           getConstraintSystem(), getLocator());
+bool AllowInvalidPartialApplication::diagnose(const Solution &solution,
+                                              bool asNote) const {
+  PartialApplicationFailure failure(isWarning(), solution, getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -553,24 +556,24 @@ AllowInvalidPartialApplication::create(bool isWarning, ConstraintSystem &cs,
       AllowInvalidPartialApplication(isWarning, cs, locator);
 }
 
-bool AllowInvalidInitRef::diagnose(bool asNote) const {
+bool AllowInvalidInitRef::diagnose(const Solution &solution,
+                                   bool asNote) const {
   switch (Kind) {
   case RefKind::DynamicOnMetatype: {
-    InvalidDynamicInitOnMetatypeFailure failure(
-        getConstraintSystem(), BaseType, Init, BaseRange, getLocator());
+    InvalidDynamicInitOnMetatypeFailure failure(solution, BaseType, Init,
+                                                BaseRange, getLocator());
     return failure.diagnose(asNote);
   }
 
   case RefKind::ProtocolMetatype: {
-    InitOnProtocolMetatypeFailure failure(getConstraintSystem(), BaseType,
-                                          Init, IsStaticallyDerived, BaseRange,
-                                          getLocator());
+    InitOnProtocolMetatypeFailure failure(
+        solution, BaseType, Init, IsStaticallyDerived, BaseRange, getLocator());
     return failure.diagnose(asNote);
   }
 
   case RefKind::NonConstMetatype: {
-    ImplicitInitOnNonConstMetatypeFailure failure(getConstraintSystem(),
-                                                  BaseType, Init, getLocator());
+    ImplicitInitOnNonConstMetatypeFailure failure(solution, BaseType, Init,
+                                                  getLocator());
     return failure.diagnose(asNote);
   }
   }
@@ -608,9 +611,10 @@ AllowInvalidInitRef::create(RefKind kind, ConstraintSystem &cs, Type baseTy,
       cs, kind, baseTy, init, isStaticallyDerived, baseRange, locator);
 }
 
-bool AllowClosureParamDestructuring::diagnose(bool asNote) const {
-  ClosureParamDestructuringFailure failure(getConstraintSystem(),
-                                           ContextualType, getLocator());
+bool AllowClosureParamDestructuring::diagnose(const Solution &solution,
+                                              bool asNote) const {
+  ClosureParamDestructuringFailure failure(solution, ContextualType,
+                                           getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -622,9 +626,9 @@ AllowClosureParamDestructuring::create(ConstraintSystem &cs,
       AllowClosureParamDestructuring(cs, contextualType, locator);
 }
 
-bool AddMissingArguments::diagnose(bool asNote) const {
-  auto &cs = getConstraintSystem();
-  MissingArgumentsFailure failure(cs, getSynthesizedArguments(),
+bool AddMissingArguments::diagnose(const Solution &solution,
+                                   bool asNote) const {
+  MissingArgumentsFailure failure(solution, getSynthesizedArguments(),
                                   getLocator());
   return failure.diagnose(asNote);
 }
@@ -638,10 +642,10 @@ AddMissingArguments::create(ConstraintSystem &cs,
   return new (mem) AddMissingArguments(cs, synthesizedArgs, locator);
 }
 
-bool RemoveExtraneousArguments::diagnose(bool asNote) const {
-  ExtraneousArgumentsFailure failure(getConstraintSystem(),
-                                     ContextualType, getExtraArguments(),
-                                     getLocator());
+bool RemoveExtraneousArguments::diagnose(const Solution &solution,
+                                         bool asNote) const {
+  ExtraneousArgumentsFailure failure(solution, ContextualType,
+                                     getExtraArguments(), getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -674,9 +678,10 @@ RemoveExtraneousArguments *RemoveExtraneousArguments::create(
       RemoveExtraneousArguments(cs, contextualType, extraArgs, locator);
 }
 
-bool MoveOutOfOrderArgument::diagnose(bool asNote) const {
-  OutOfOrderArgumentFailure failure(getConstraintSystem(), ArgIdx,
-                                    PrevArgIdx, Bindings, getLocator());
+bool MoveOutOfOrderArgument::diagnose(const Solution &solution,
+                                      bool asNote) const {
+  OutOfOrderArgumentFailure failure(solution, ArgIdx, PrevArgIdx, Bindings,
+                                    getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -687,9 +692,9 @@ MoveOutOfOrderArgument *MoveOutOfOrderArgument::create(
       MoveOutOfOrderArgument(cs, argIdx, prevArgIdx, bindings, locator);
 }
 
-bool AllowInaccessibleMember::diagnose(bool asNote) const {
-  InaccessibleMemberFailure failure(getConstraintSystem(), getMember(),
-                                    getLocator());
+bool AllowInaccessibleMember::diagnose(const Solution &solution,
+                                       bool asNote) const {
+  InaccessibleMemberFailure failure(solution, getMember(), getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -701,8 +706,9 @@ AllowInaccessibleMember::create(ConstraintSystem &cs, Type baseType,
       AllowInaccessibleMember(cs, baseType, member, name, locator);
 }
 
-bool AllowAnyObjectKeyPathRoot::diagnose(bool asNote) const {
-  AnyObjectKeyPathRootFailure failure(getConstraintSystem(), getLocator());
+bool AllowAnyObjectKeyPathRoot::diagnose(const Solution &solution,
+                                         bool asNote) const {
+  AnyObjectKeyPathRootFailure failure(solution, getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -712,9 +718,10 @@ AllowAnyObjectKeyPathRoot::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) AllowAnyObjectKeyPathRoot(cs, locator);
 }
 
-bool TreatKeyPathSubscriptIndexAsHashable::diagnose(bool asNote) const {
-  KeyPathSubscriptIndexHashableFailure failure(getConstraintSystem(),
-                                               NonConformingType, getLocator());
+bool TreatKeyPathSubscriptIndexAsHashable::diagnose(const Solution &solution,
+                                                    bool asNote) const {
+  KeyPathSubscriptIndexHashableFailure failure(solution, NonConformingType,
+                                               getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -725,23 +732,22 @@ TreatKeyPathSubscriptIndexAsHashable::create(ConstraintSystem &cs, Type type,
       TreatKeyPathSubscriptIndexAsHashable(cs, type, locator);
 }
 
-bool AllowInvalidRefInKeyPath::diagnose(bool asNote) const {
+bool AllowInvalidRefInKeyPath::diagnose(const Solution &solution,
+                                        bool asNote) const {
   switch (Kind) {
   case RefKind::StaticMember: {
-    InvalidStaticMemberRefInKeyPath failure(getConstraintSystem(), Member,
-                                            getLocator());
+    InvalidStaticMemberRefInKeyPath failure(solution, Member, getLocator());
     return failure.diagnose(asNote);
   }
 
   case RefKind::MutatingGetter: {
-    InvalidMemberWithMutatingGetterInKeyPath failure(
-        getConstraintSystem(), Member, getLocator());
+    InvalidMemberWithMutatingGetterInKeyPath failure(solution, Member,
+                                                     getLocator());
     return failure.diagnose(asNote);
   }
 
   case RefKind::Method: {
-    InvalidMethodRefInKeyPath failure(getConstraintSystem(), Member,
-                                      getLocator());
+    InvalidMethodRefInKeyPath failure(solution, Member, getLocator());
     return failure.diagnose(asNote);
   }
   }
@@ -788,9 +794,9 @@ KeyPathContextualMismatch::create(ConstraintSystem &cs, Type lhs, Type rhs,
       KeyPathContextualMismatch(cs, lhs, rhs, locator);
 }
 
-bool RemoveAddressOf::diagnose(bool asNote) const {
-  InvalidUseOfAddressOf failure(getConstraintSystem(), getFromType(),
-                                getToType(), getLocator());
+bool RemoveAddressOf::diagnose(const Solution &solution, bool asNote) const {
+  InvalidUseOfAddressOf failure(solution, getFromType(), getToType(),
+                                getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -799,8 +805,8 @@ RemoveAddressOf *RemoveAddressOf::create(ConstraintSystem &cs, Type lhs, Type rh
   return new (cs.getAllocator()) RemoveAddressOf(cs, lhs, rhs, locator);
 }
 
-bool RemoveReturn::diagnose(bool asNote) const {
-  ExtraneousReturnFailure failure(getConstraintSystem(), getLocator());
+bool RemoveReturn::diagnose(const Solution &solution, bool asNote) const {
+  ExtraneousReturnFailure failure(solution, getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -809,9 +815,10 @@ RemoveReturn *RemoveReturn::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) RemoveReturn(cs, locator);
 }
 
-bool CollectionElementContextualMismatch::diagnose(bool asNote) const {
-  CollectionElementContextualFailure failure(
-      getConstraintSystem(), getFromType(), getToType(), getLocator());
+bool CollectionElementContextualMismatch::diagnose(const Solution &solution,
+                                                   bool asNote) const {
+  CollectionElementContextualFailure failure(solution, getFromType(),
+                                             getToType(), getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -824,7 +831,8 @@ CollectionElementContextualMismatch::create(ConstraintSystem &cs, Type srcType,
 }
 
 bool DefaultGenericArgument::coalesceAndDiagnose(
-    ArrayRef<ConstraintFix *> fixes, bool asNote) const {
+    const Solution &solution, ArrayRef<ConstraintFix *> fixes,
+    bool asNote) const {
   llvm::SmallVector<GenericTypeParamType *, 4> missingParams{Param};
 
   for (auto *otherFix : fixes) {
@@ -832,13 +840,13 @@ bool DefaultGenericArgument::coalesceAndDiagnose(
       missingParams.push_back(fix->Param);
   }
 
-  auto &cs = getConstraintSystem();
-  MissingGenericArgumentsFailure failure(cs, missingParams, getLocator());
+  MissingGenericArgumentsFailure failure(solution, missingParams, getLocator());
   return failure.diagnose(asNote);
 }
 
-bool DefaultGenericArgument::diagnose(bool asNote) const {
-  return coalesceAndDiagnose({}, asNote);
+bool DefaultGenericArgument::diagnose(const Solution &solution,
+                                      bool asNote) const {
+  return coalesceAndDiagnose(solution, {}, asNote);
 }
 
 DefaultGenericArgument *
@@ -856,15 +864,16 @@ SkipUnhandledConstructInFunctionBuilder::create(ConstraintSystem &cs,
     SkipUnhandledConstructInFunctionBuilder(cs, unhandled, builder, locator);
 }
 
-bool SkipUnhandledConstructInFunctionBuilder::diagnose(bool asNote) const {
-  SkipUnhandledConstructInFunctionBuilderFailure failure(
-      getConstraintSystem(), unhandled, builder, getLocator());
+bool SkipUnhandledConstructInFunctionBuilder::diagnose(const Solution &solution,
+                                                       bool asNote) const {
+  SkipUnhandledConstructInFunctionBuilderFailure failure(solution, unhandled,
+                                                         builder, getLocator());
   return failure.diagnose(asNote);
 }
 
-bool AllowMutatingMemberOnRValueBase::diagnose(bool asNote) const {
-  auto &cs = getConstraintSystem();
-  MutatingMemberRefOnImmutableBase failure(cs, getMember(), getLocator());
+bool AllowMutatingMemberOnRValueBase::diagnose(const Solution &solution,
+                                               bool asNote) const {
+  MutatingMemberRefOnImmutableBase failure(solution, getMember(), getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -876,9 +885,9 @@ AllowMutatingMemberOnRValueBase::create(ConstraintSystem &cs, Type baseType,
       AllowMutatingMemberOnRValueBase(cs, baseType, member, name, locator);
 }
 
-bool AllowTupleSplatForSingleParameter::diagnose(bool asNote) const {
-  auto &cs = getConstraintSystem();
-  InvalidTupleSplatWithSingleParameterFailure failure(cs, ParamType,
+bool AllowTupleSplatForSingleParameter::diagnose(const Solution &solution,
+                                                 bool asNote) const {
+  InvalidTupleSplatWithSingleParameterFailure failure(solution, ParamType,
                                                       getLocator());
   return failure.diagnose(asNote);
 }
@@ -950,9 +959,9 @@ bool AllowTupleSplatForSingleParameter::attempt(
   return cs.recordFix(fix);
 }
 
-bool DropThrowsAttribute::diagnose(bool asNote) const {
-  auto &cs = getConstraintSystem();
-  ThrowingFunctionConversionFailure failure(cs, getFromType(),
+bool DropThrowsAttribute::diagnose(const Solution &solution,
+                                   bool asNote) const {
+  ThrowingFunctionConversionFailure failure(solution, getFromType(),
                                             getToType(), getLocator());
   return failure.diagnose(asNote);
 }
@@ -965,9 +974,9 @@ DropThrowsAttribute *DropThrowsAttribute::create(ConstraintSystem &cs,
       DropThrowsAttribute(cs, fromType, toType, locator);
 }
 
-bool IgnoreContextualType::diagnose(bool asNote) const {
-  auto &cs = getConstraintSystem();
-  ContextualFailure failure(cs, getFromType(), getToType(), getLocator());
+bool IgnoreContextualType::diagnose(const Solution &solution,
+                                    bool asNote) const {
+  ContextualFailure failure(solution, getFromType(), getToType(), getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -979,7 +988,8 @@ IgnoreContextualType *IgnoreContextualType::create(ConstraintSystem &cs,
       IgnoreContextualType(cs, resultTy, specifiedTy, locator);
 }
 
-bool IgnoreAssignmentDestinationType::diagnose(bool asNote) const {
+bool IgnoreAssignmentDestinationType::diagnose(const Solution &solution,
+                                               bool asNote) const {
   auto &cs = getConstraintSystem();
   auto *AE = cast<AssignExpr>(getAnchor());
 
@@ -1000,7 +1010,7 @@ bool IgnoreAssignmentDestinationType::diagnose(bool asNote) const {
                                                : CTP_AssignSource;
 
   AssignmentTypeMismatchFailure failure(
-      cs, CTP, getFromType(), getToType(),
+      solution, CTP, getFromType(), getToType(),
       cs.getConstraintLocator(AE->getSrc(), LocatorPathElt::ContextualType()));
   return failure.diagnose(asNote);
 }
@@ -1013,9 +1023,9 @@ IgnoreAssignmentDestinationType::create(ConstraintSystem &cs, Type sourceTy,
       IgnoreAssignmentDestinationType(cs, sourceTy, destTy, locator);
 }
 
-bool AllowInOutConversion::diagnose(bool asNote) const {
-  auto &cs = getConstraintSystem();
-  InOutConversionFailure failure(cs, getFromType(), getToType(),
+bool AllowInOutConversion::diagnose(const Solution &solution,
+                                    bool asNote) const {
+  InOutConversionFailure failure(solution, getFromType(), getToType(),
                                  getLocator());
   return failure.diagnose(asNote);
 }
@@ -1077,9 +1087,10 @@ ExpandArrayIntoVarargs::attempt(ConstraintSystem &cs, Type argType,
       ExpandArrayIntoVarargs(cs, argType, paramType, locator);
 }
 
-bool ExpandArrayIntoVarargs::diagnose(bool asNote) const {
-  ExpandArrayIntoVarargsFailure failure(
-      getConstraintSystem(), getFromType(), getToType(), getLocator());
+bool ExpandArrayIntoVarargs::diagnose(const Solution &solution,
+                                      bool asNote) const {
+  ExpandArrayIntoVarargsFailure failure(solution, getFromType(), getToType(),
+                                        getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -1117,9 +1128,9 @@ unsigned AllowArgumentMismatch::getParamIdx() const {
   return elt.getParamIdx();
 }
 
-bool AllowArgumentMismatch::diagnose(bool asNote) const {
-  auto &cs = getConstraintSystem();
-  ArgumentMismatchFailure failure(cs, getFromType(), getToType(),
+bool AllowArgumentMismatch::diagnose(const Solution &solution,
+                                     bool asNote) const {
+  ArgumentMismatchFailure failure(solution, getFromType(), getToType(),
                                   getLocator());
   return failure.diagnose(asNote);
 }
@@ -1131,8 +1142,8 @@ AllowArgumentMismatch::create(ConstraintSystem &cs, Type argType,
       AllowArgumentMismatch(cs, argType, paramType, locator);
 }
 
-bool RemoveInvalidCall::diagnose(bool asNote) const {
-  ExtraneousCallFailure failure(getConstraintSystem(), getLocator());
+bool RemoveInvalidCall::diagnose(const Solution &solution, bool asNote) const {
+  ExtraneousCallFailure failure(solution, getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -1141,9 +1152,9 @@ RemoveInvalidCall *RemoveInvalidCall::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) RemoveInvalidCall(cs, locator);
 }
 
-bool AllowInvalidUseOfTrailingClosure::diagnose(bool asNote) const {
-  auto &cs = getConstraintSystem();
-  InvalidUseOfTrailingClosure failure(cs, getFromType(), getToType(),
+bool AllowInvalidUseOfTrailingClosure::diagnose(const Solution &solution,
+                                                bool asNote) const {
+  InvalidUseOfTrailingClosure failure(solution, getFromType(), getToType(),
                                       getLocator());
   return failure.diagnose(asNote);
 }
@@ -1156,10 +1167,11 @@ AllowInvalidUseOfTrailingClosure::create(ConstraintSystem &cs, Type argType,
       AllowInvalidUseOfTrailingClosure(cs, argType, paramType, locator);
 }
 
-bool TreatEphemeralAsNonEphemeral::diagnose(bool asNote) const {
-  NonEphemeralConversionFailure failure(
-      getConstraintSystem(), getLocator(), getFromType(), getToType(),
-      ConversionKind, isWarning());
+bool TreatEphemeralAsNonEphemeral::diagnose(const Solution &solution,
+                                            bool asNote) const {
+  NonEphemeralConversionFailure failure(solution, getLocator(), getFromType(),
+                                        getToType(), ConversionKind,
+                                        isWarning());
   return failure.diagnose(asNote);
 }
 
@@ -1178,9 +1190,10 @@ std::string TreatEphemeralAsNonEphemeral::getName() const {
   return name;
 }
 
-bool SpecifyBaseTypeForContextualMember::diagnose(bool asNote) const {
-  auto &cs = getConstraintSystem();
-  MissingContextualBaseInMemberRefFailure failure(cs, MemberName, getLocator());
+bool SpecifyBaseTypeForContextualMember::diagnose(const Solution &solution,
+                                                  bool asNote) const {
+  MissingContextualBaseInMemberRefFailure failure(solution, MemberName,
+                                                  getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -1190,9 +1203,9 @@ SpecifyBaseTypeForContextualMember *SpecifyBaseTypeForContextualMember::create(
       SpecifyBaseTypeForContextualMember(cs, member, locator);
 }
 
-bool SpecifyClosureReturnType::diagnose(bool asNote) const {
-  auto &cs = getConstraintSystem();
-  UnableToInferClosureReturnType failure(cs, getLocator());
+bool SpecifyClosureReturnType::diagnose(const Solution &solution,
+                                        bool asNote) const {
+  UnableToInferClosureReturnType failure(solution, getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -1202,9 +1215,9 @@ SpecifyClosureReturnType::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) SpecifyClosureReturnType(cs, locator);
 }
 
-bool SpecifyObjectLiteralTypeImport::diagnose(bool asNote) const {
-  auto &cs = getConstraintSystem();
-  UnableToInferProtocolLiteralType failure(cs, getLocator());
+bool SpecifyObjectLiteralTypeImport::diagnose(const Solution &solution,
+                                              bool asNote) const {
+  UnableToInferProtocolLiteralType failure(solution, getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -1220,28 +1233,22 @@ AllowNonClassTypeToConvertToAnyObject::AllowNonClassTypeToConvertToAnyObject(
                          type, cs.getASTContext().getAnyObjectType(), locator) {
 }
 
-bool AllowNonClassTypeToConvertToAnyObject::diagnose(bool asNote) const {
-  auto &cs = getConstraintSystem();
-
+bool AllowNonClassTypeToConvertToAnyObject::diagnose(const Solution &solution,
+                                                     bool asNote) const {
   auto *locator = getLocator();
-  if (locator->getPath().empty())
-    return false;
 
-  const auto &last = locator->getPath().back();
-  switch (last.getKind()) {
-  case ConstraintLocator::ContextualType: {
-    ContextualFailure failure(cs, getFromType(), getToType(), locator);
+  if (locator->isForContextualType()) {
+    ContextualFailure failure(solution, getFromType(), getToType(), locator);
     return failure.diagnose(asNote);
   }
 
-  case ConstraintLocator::ApplyArgToParam: {
-    ArgumentMismatchFailure failure(cs, getFromType(), getToType(), locator);
+  if (locator->isLastElement<LocatorPathElt::ApplyArgToParam>()) {
+    ArgumentMismatchFailure failure(solution, getFromType(), getToType(),
+                                    locator);
     return failure.diagnose(asNote);
   }
 
-  default:
-    return false;
-  }
+  return false;
 }
 
 AllowNonClassTypeToConvertToAnyObject *
@@ -1251,9 +1258,9 @@ AllowNonClassTypeToConvertToAnyObject::create(ConstraintSystem &cs, Type type,
       AllowNonClassTypeToConvertToAnyObject(cs, type, locator);
 }
 
-bool AddQualifierToAccessTopLevelName::diagnose(bool asNote) const {
-  auto &cs = getConstraintSystem();
-  MissingQuialifierInMemberRefFailure failure(cs, getLocator());
+bool AddQualifierToAccessTopLevelName::diagnose(const Solution &solution,
+                                                bool asNote) const {
+  MissingQuialifierInMemberRefFailure failure(solution, getLocator());
   return failure.diagnose(asNote);
 }
 

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -1091,16 +1091,16 @@ public:
 
 class AddMissingArguments final
     : public ConstraintFix,
-      private llvm::TrailingObjects<AddMissingArguments,
-                                    AnyFunctionType::Param> {
+      private llvm::TrailingObjects<
+          AddMissingArguments, std::pair<unsigned, AnyFunctionType::Param>> {
   friend TrailingObjects;
 
-  using Param = AnyFunctionType::Param;
+  using SynthesizedParam = std::pair<unsigned, AnyFunctionType::Param>;
 
   unsigned NumSynthesized;
 
   AddMissingArguments(ConstraintSystem &cs,
-                      llvm::ArrayRef<Param> synthesizedArgs,
+                      ArrayRef<SynthesizedParam> synthesizedArgs,
                       ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::AddMissingArguments, locator),
         NumSynthesized(synthesizedArgs.size()) {
@@ -1111,8 +1111,8 @@ class AddMissingArguments final
 public:
   std::string getName() const override { return "synthesize missing argument(s)"; }
 
-  ArrayRef<Param> getSynthesizedArguments() const {
-    return {getTrailingObjects<Param>(), NumSynthesized};
+  ArrayRef<SynthesizedParam> getSynthesizedArguments() const {
+    return {getTrailingObjects<SynthesizedParam>(), NumSynthesized};
   }
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
@@ -1122,12 +1122,12 @@ public:
   }
 
   static AddMissingArguments *create(ConstraintSystem &cs,
-                                     llvm::ArrayRef<Param> synthesizedArgs,
+                                     ArrayRef<SynthesizedParam> synthesizedArgs,
                                      ConstraintLocator *locator);
 
 private:
-  MutableArrayRef<Param> getSynthesizedArgumentsBuf() {
-    return {getTrailingObjects<Param>(), NumSynthesized};
+  MutableArrayRef<SynthesizedParam> getSynthesizedArgumentsBuf() {
+    return {getTrailingObjects<SynthesizedParam>(), NumSynthesized};
   }
 };
 

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -281,13 +281,15 @@ public:
   ///
   /// The default implementation ignores \c secondaryFixes and calls
   /// \c diagnose.
-  virtual bool coalesceAndDiagnose(ArrayRef<ConstraintFix *> secondaryFixes,
+  virtual bool coalesceAndDiagnose(const Solution &solution,
+                                   ArrayRef<ConstraintFix *> secondaryFixes,
                                    bool asNote = false) const {
-    return diagnose(asNote);
+    return diagnose(solution, asNote);
   }
 
   /// Diagnose a failure associated with this fix.
-  virtual bool diagnose(bool asNote = false) const = 0;
+  virtual bool diagnose(const Solution &solution,
+                        bool asNote = false) const = 0;
 
   virtual bool diagnoseForAmbiguity(ArrayRef<Solution> solutions) const { return false; }
 
@@ -321,7 +323,7 @@ public:
     return "unwrap optional base of member lookup";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static UnwrapOptionalBase *create(ConstraintSystem &cs, DeclNameRef member,
                                     ConstraintLocator *locator);
@@ -339,7 +341,7 @@ class TreatRValueAsLValue final : public ConstraintFix {
 public:
   std::string getName() const override { return "treat rvalue as lvalue"; }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static TreatRValueAsLValue *create(ConstraintSystem &cs,
                                      ConstraintLocator *locator);
@@ -370,7 +372,7 @@ public:
     return {getTrailingObjects<Identifier>(), NumLabels};
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static RelabelArguments *create(ConstraintSystem &cs,
                                   llvm::ArrayRef<Identifier> correctLabels,
@@ -403,7 +405,7 @@ public:
     return "add missing protocol conformance";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static MissingConformance *forRequirement(ConstraintSystem &cs, Type type,
                                             Type protocolType,
@@ -433,7 +435,7 @@ public:
     return "skip same-type generic requirement";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   Type lhsType() { return LHS; }
   Type rhsType() { return RHS; }
@@ -457,7 +459,7 @@ public:
     return "skip superclass generic requirement";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   Type subclassType() { return LHS; }
   Type superclassType() { return RHS; }
@@ -492,7 +494,7 @@ public:
   Type getFromType() const { return LHS; }
   Type getToType() const { return RHS; }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static ContextualMismatch *create(ConstraintSystem &cs, Type lhs, Type rhs,
                                     ConstraintLocator *locator);
@@ -508,7 +510,7 @@ class MarkExplicitlyEscaping final : public ContextualMismatch {
 public:
   std::string getName() const override { return "add @escaping"; }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static MarkExplicitlyEscaping *create(ConstraintSystem &cs, Type lhs,
                                         Type rhs, ConstraintLocator *locator);
@@ -528,7 +530,7 @@ class ForceOptional final : public ContextualMismatch {
 public:
   std::string getName() const override { return "force optional"; }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static ForceOptional *create(ConstraintSystem &cs, Type fromType, Type toType,
                                ConstraintLocator *locator);
@@ -546,7 +548,7 @@ class DropThrowsAttribute final : public ContextualMismatch {
 public:
   std::string getName() const override { return "drop 'throws' attribute"; }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static DropThrowsAttribute *create(ConstraintSystem &cs,
                                      FunctionType *fromType,
@@ -564,7 +566,7 @@ class ForceDowncast final : public ContextualMismatch {
 public:
   std::string getName() const override;
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static ForceDowncast *create(ConstraintSystem &cs, Type fromType, Type toType,
                                ConstraintLocator *locator);
@@ -579,7 +581,7 @@ class AddAddressOf final : public ContextualMismatch {
 public:
   std::string getName() const override { return "add address-of"; }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static AddAddressOf *create(ConstraintSystem &cs, Type argTy, Type paramTy,
                               ConstraintLocator *locator);
@@ -595,7 +597,7 @@ public:
     return "remove extraneous use of `&`";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static RemoveAddressOf *create(ConstraintSystem &cs, Type lhs, Type rhs,
                                  ConstraintLocator *locator);
@@ -637,7 +639,7 @@ public:
     return {getTrailingObjects<unsigned>(), NumMismatches};
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static GenericArgumentsMismatch *create(ConstraintSystem &cs, Type actual,
                                           Type required,
@@ -692,7 +694,7 @@ class AutoClosureForwarding final : public ConstraintFix {
 public:
   std::string getName() const override { return "fix @autoclosure forwarding"; }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static AutoClosureForwarding *create(ConstraintSystem &cs,
                                        ConstraintLocator *locator);
@@ -710,7 +712,7 @@ public:
     return "allow pointer conversion for autoclosure result type";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static AllowAutoClosurePointerConversion *create(ConstraintSystem &cs,
                                                    Type pointeeType,
@@ -729,7 +731,7 @@ public:
     return "remove unwrap operator `!` or `?`";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static RemoveUnwrap *create(ConstraintSystem &cs, Type baseType,
                               ConstraintLocator *locator);
@@ -744,7 +746,7 @@ public:
     return "insert explicit `()` to make a call";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static InsertExplicitCall *create(ConstraintSystem &cs,
                                     ConstraintLocator *locator);
@@ -768,7 +770,7 @@ public:
     return "insert '$' or '_' to use property wrapper type instead of wrapped type";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static UsePropertyWrapper *create(ConstraintSystem &cs, VarDecl *wrapped,
                                     bool usingStorageWrapper, Type base,
@@ -795,7 +797,7 @@ public:
     return "remove '$' or _ to use wrapped type instead of wrapper type";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static UseWrappedValue *create(ConstraintSystem &cs, VarDecl *propertyWrapper,
                                  Type base, Type wrapper,
@@ -811,7 +813,7 @@ public:
     return "replace '.subscript(...)' with subscript operator";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static UseSubscriptOperator *create(ConstraintSystem &cs,
                                       ConstraintLocator *locator);
@@ -843,7 +845,7 @@ public:
            "' based on its use";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   bool diagnoseForAmbiguity(ArrayRef<Solution> solutions) const override;
 
@@ -887,7 +889,7 @@ public:
            "' on value of protocol type";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static AllowMemberRefOnExistential *create(ConstraintSystem &cs,
                                              Type baseType, ValueDecl *member,
@@ -909,7 +911,7 @@ public:
     return "allow access to instance member on type or a type member on instance";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static AllowTypeOrInstanceMember *create(ConstraintSystem &cs, Type baseType,
                                            ValueDecl *member, DeclNameRef usedName,
@@ -927,7 +929,7 @@ public:
     return "allow partially applied 'mutating' method";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static AllowInvalidPartialApplication *create(bool isWarning,
                                                 ConstraintSystem &cs,
@@ -958,7 +960,7 @@ public:
     return "allow invalid initializer reference";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static AllowInvalidInitRef *
   dynamicOnMetatype(ConstraintSystem &cs, Type baseTy, ConstructorDecl *init,
@@ -1010,10 +1012,11 @@ public:
     return Index.hasValue();
   }
 
-  bool coalesceAndDiagnose(ArrayRef<ConstraintFix *> secondaryFixes,
+  bool coalesceAndDiagnose(const Solution &solution,
+                           ArrayRef<ConstraintFix *> secondaryFixes,
                            bool asNote = false) const override;
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 };
 
 class AllowFunctionTypeMismatch final : public ContextualMismatch {
@@ -1038,10 +1041,11 @@ public:
     return "allow function type mismatch";
   }
 
-  bool coalesceAndDiagnose(ArrayRef<ConstraintFix *> secondaryFixes,
+  bool coalesceAndDiagnose(const Solution &solution,
+                           ArrayRef<ConstraintFix *> secondaryFixes,
                            bool asNote = false) const override;
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 };
 
 
@@ -1057,7 +1061,7 @@ public:
     return "allow `mutating` method on r-value base";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static AllowMutatingMemberOnRValueBase *
   create(ConstraintSystem &cs, Type baseType, ValueDecl *member,
@@ -1078,7 +1082,7 @@ public:
     return "allow closure parameter destructuring";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static AllowClosureParamDestructuring *create(ConstraintSystem &cs,
                                                 FunctionType *contextualType,
@@ -1111,10 +1115,10 @@ public:
     return {getTrailingObjects<Param>(), NumSynthesized};
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   bool diagnoseForAmbiguity(ArrayRef<Solution> solutions) const override {
-    return diagnose();
+    return diagnose(solutions.front());
   }
 
   static AddMissingArguments *create(ConstraintSystem &cs,
@@ -1155,10 +1159,10 @@ public:
     return {getTrailingObjects<IndexedParam>(), NumExtraneous};
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   bool diagnoseForAmbiguity(ArrayRef<Solution> solutions) const override {
-    return diagnose();
+    return diagnose(solutions.front());
   }
 
   /// FIXME(diagnostics): Once `resolveDeclRefExpr` is gone this
@@ -1200,7 +1204,7 @@ public:
     return "move out-of-order argument to correct position";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static MoveOutOfOrderArgument *create(ConstraintSystem &cs,
                                         unsigned argIdx,
@@ -1221,7 +1225,7 @@ public:
     return "allow inaccessible member reference";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static AllowInaccessibleMember *create(ConstraintSystem &cs, Type baseType,
                                          ValueDecl *member, DeclNameRef name,
@@ -1238,7 +1242,7 @@ public:
     return "allow anyobject as root type for a keypath";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static AllowAnyObjectKeyPathRoot *create(ConstraintSystem &cs,
                                            ConstraintLocator *locator);
@@ -1258,7 +1262,7 @@ public:
     return "treat keypath subscript index as conforming to Hashable";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static TreatKeyPathSubscriptIndexAsHashable *
   create(ConstraintSystem &cs, Type type, ConstraintLocator *locator);
@@ -1297,7 +1301,7 @@ public:
     llvm_unreachable("covered switch");
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   /// Determine whether give reference requires a fix and produce one.
   static AllowInvalidRefInKeyPath *
@@ -1316,7 +1320,7 @@ class RemoveReturn final : public ConstraintFix {
 public:
   std::string getName() const override { return "remove or omit return type"; }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static RemoveReturn *create(ConstraintSystem &cs, ConstraintLocator *locator);
 };
@@ -1331,7 +1335,7 @@ public:
     return "fix collection element contextual mismatch";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static CollectionElementContextualMismatch *
   create(ConstraintSystem &cs, Type srcType, Type dstType,
@@ -1356,13 +1360,14 @@ public:
     return "default generic argument '" + paramName + "' to 'Any'";
   }
 
-  bool coalesceAndDiagnose(ArrayRef<ConstraintFix *> secondaryFixes,
+  bool coalesceAndDiagnose(const Solution &solution,
+                           ArrayRef<ConstraintFix *> secondaryFixes,
                            bool asNote = false) const override;
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   bool diagnoseForAmbiguity(ArrayRef<Solution> solutions) const override {
-    return diagnose();
+    return diagnose(solutions.front());
   }
 
   static DefaultGenericArgument *create(ConstraintSystem &cs,
@@ -1391,7 +1396,7 @@ public:
     return "skip unhandled constructs when applying a function builder";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static SkipUnhandledConstructInFunctionBuilder *
   create(ConstraintSystem &cs, UnhandledNode unhandledNode,
@@ -1413,7 +1418,7 @@ public:
     return "allow single parameter tuple splat";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   /// Apply this fix to given arguments/parameters and return `true`
   /// this fix is not applicable and solver can't continue, `false`
@@ -1434,10 +1439,10 @@ public:
     return "ignore specified contextual type";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   bool diagnoseForAmbiguity(ArrayRef<Solution> solutions) const override {
-    return diagnose();
+    return diagnose(solutions.front());
   }
 
   static IgnoreContextualType *create(ConstraintSystem &cs, Type resultTy,
@@ -1455,7 +1460,7 @@ public:
     return "ignore type of the assignment destination";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static IgnoreAssignmentDestinationType *create(ConstraintSystem &cs,
                                                  Type sourceTy, Type destTy,
@@ -1475,7 +1480,7 @@ public:
     return "allow conversions between argument/parameter marked as `inout`";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static AllowInOutConversion *create(ConstraintSystem &cs, Type argType,
                                       Type paramType,
@@ -1501,7 +1506,7 @@ public:
 
   unsigned getParamIdx() const;
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static AllowArgumentMismatch *create(ConstraintSystem &cs, Type argType,
                                        Type paramType,
@@ -1524,7 +1529,7 @@ public:
     return "cannot pass Array elements as variadic arguments";
   }
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static ExpandArrayIntoVarargs *attempt(ConstraintSystem &cs, Type argType,
                                          Type paramType,
@@ -1574,7 +1579,7 @@ class CoerceToCheckedCast final : public ContextualMismatch {
 public:
   std::string getName() const { return "as to as!"; }
 
-  bool diagnose(bool asNote = false) const;
+  bool diagnose(const Solution &solution, bool asNote = false) const;
 
   static CoerceToCheckedCast *attempt(ConstraintSystem &cs, Type fromType,
                                       Type toType, ConstraintLocator *locator);
@@ -1589,7 +1594,7 @@ public:
     return "remove extraneous call from value of non-function type";
   }
 
-  bool diagnose(bool asNote = false) const;
+  bool diagnose(const Solution &solution, bool asNote = false) const;
 
   static RemoveInvalidCall *create(ConstraintSystem &cs,
                                    ConstraintLocator *locator);
@@ -1606,7 +1611,7 @@ public:
     return "allow invalid use of trailing closure";
   }
 
-  bool diagnose(bool asNote = false) const;
+  bool diagnose(const Solution &solution, bool asNote = false) const;
 
   static AllowInvalidUseOfTrailingClosure *create(ConstraintSystem &cs,
                                                   Type argType, Type paramType,
@@ -1628,7 +1633,7 @@ public:
   ConversionRestrictionKind getConversionKind() const { return ConversionKind; }
   std::string getName() const override;
 
-  bool diagnose(bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static TreatEphemeralAsNonEphemeral *
   create(ConstraintSystem &cs, ConstraintLocator *locator, Type srcType,
@@ -1651,7 +1656,7 @@ public:
            baseName.userFacingName().str() + "'";
   }
 
-  bool diagnose(bool asNote = false) const;
+  bool diagnose(const Solution &solution, bool asNote = false) const;
 
   static SpecifyBaseTypeForContextualMember *
   create(ConstraintSystem &cs, DeclNameRef member, ConstraintLocator *locator);
@@ -1666,7 +1671,7 @@ public:
     return "specify closure return type";
   }
 
-  bool diagnose(bool asNote = false) const;
+  bool diagnose(const Solution &solution, bool asNote = false) const;
 
   static SpecifyClosureReturnType *create(ConstraintSystem &cs,
                                           ConstraintLocator *locator);
@@ -1681,7 +1686,7 @@ public:
     return "import required module to gain access to a default literal type";
   }
 
-  bool diagnose(bool asNote = false) const;
+  bool diagnose(const Solution &solution, bool asNote = false) const;
 
   static SpecifyObjectLiteralTypeImport *create(ConstraintSystem &cs,
                                                 ConstraintLocator *locator);
@@ -1697,7 +1702,7 @@ public:
     return "qualify reference to access top-level function";
   }
 
-  bool diagnose(bool asNote = false) const;
+  bool diagnose(const Solution &solution, bool asNote = false) const;
 
   static AddQualifierToAccessTopLevelName *create(ConstraintSystem &cs,
                                                   ConstraintLocator *locator);
@@ -1712,7 +1717,7 @@ public:
     return "allow non-class type to convert to 'AnyObject'";
   }
 
-  bool diagnose(bool asNote = false) const;
+  bool diagnose(const Solution &solution, bool asNote = false) const;
 
   static AllowNonClassTypeToConvertToAnyObject *
   create(ConstraintSystem &cs, Type type, ConstraintLocator *locator);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -773,7 +773,7 @@ class ArgumentFailureTracker : public MatchCallArgumentListener {
   SmallVectorImpl<ParamBinding> &Bindings;
   ConstraintLocatorBuilder Locator;
 
-  unsigned NumSynthesizedArgs = 0;
+  SmallVector<std::pair<unsigned, AnyFunctionType::Param>, 4> MissingArguments;
   SmallVector<std::pair<unsigned, AnyFunctionType::Param>, 4> ExtraArguments;
 
 public:
@@ -786,15 +786,12 @@ public:
         Locator(locator) {}
 
   ~ArgumentFailureTracker() override {
-    if (NumSynthesizedArgs > 0) {
-      ArrayRef<AnyFunctionType::Param> argRef(Arguments);
-
-      auto *fix =
-          AddMissingArguments::create(CS, argRef.take_back(NumSynthesizedArgs),
-                                      CS.getConstraintLocator(Locator));
+    if (!MissingArguments.empty()) {
+      auto *fix = AddMissingArguments::create(CS, MissingArguments,
+                                              CS.getConstraintLocator(Locator));
 
       // Not having an argument is the same impact as having a type mismatch.
-      (void)CS.recordFix(fix, /*impact=*/NumSynthesizedArgs * 2);
+      (void)CS.recordFix(fix, /*impact=*/MissingArguments.size() * 2);
     }
   }
 
@@ -814,8 +811,10 @@ public:
         CS.createTypeVariable(argLoc, TVO_CanBindToInOut | TVO_CanBindToLValue |
                                       TVO_CanBindToNoEscape | TVO_CanBindToHole);
 
-    Arguments.push_back(param.withType(argType));
-    ++NumSynthesizedArgs;
+    auto synthesizedArg = param.withType(argType);
+
+    MissingArguments.push_back(std::make_pair(paramIdx, synthesizedArg));
+    Arguments.push_back(synthesizedArg);
 
     return newArgIdx;
   }
@@ -846,7 +845,7 @@ public:
       // record a fix for this, increase the score so there is a way
       // to identify that there is something going on besides just missing
       // arguments.
-      if (NumSynthesizedArgs || !ExtraArguments.empty()) {
+      if (!MissingArguments.empty() || !ExtraArguments.empty()) {
         CS.increaseScore(SK_Fix);
         return false;
       }
@@ -915,7 +914,7 @@ public:
     // If there are not only labeling problems but also some of the
     // arguments are missing, let's account of that in the impact.
     auto impact = 1 + numOutOfOrder + numExtraneous * 2 + numRenames * 3 +
-                  NumSynthesizedArgs * 2;
+                  MissingArguments.size() * 2;
     return CS.recordFix(fix, impact);
   }
 
@@ -1008,15 +1007,19 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
       argsWithLabels.pop_back();
       // Let's make sure that labels associated with tuple elements
       // line up with what is expected by argument list.
-      for (const auto &arg : argTuple->getElements()) {
-        argsWithLabels.push_back(
-            AnyFunctionType::Param(arg.getType(), arg.getName()));
+      SmallVector<std::pair<unsigned, AnyFunctionType::Param>, 4>
+          synthesizedArgs;
+      for (unsigned i = 0, n = argTuple->getNumElements(); i != n; ++i) {
+        const auto &elt = argTuple->getElement(i);
+        AnyFunctionType::Param argument(elt.getType(), elt.getName());
+        synthesizedArgs.push_back(std::make_pair(i, argument));
+        argsWithLabels.push_back(argument);
       }
 
       (void)cs.recordFix(
-          AddMissingArguments::create(cs, argsWithLabels,
+          AddMissingArguments::create(cs, synthesizedArgs,
                                       cs.getConstraintLocator(locator)),
-          /*impact=*/argsWithLabels.size() * 2);
+          /*impact=*/synthesizedArgs.size() * 2);
     }
   }
 
@@ -1476,12 +1479,17 @@ static bool fixMissingArguments(ConstraintSystem &cs, Expr *anchor,
   for (unsigned i = args.size(), n = params.size(); i != n; ++i) {
     auto *argLoc = cs.getConstraintLocator(
         anchor, LocatorPathElt::SynthesizedArgument(i));
-    args.push_back(params[i].withType(cs.createTypeVariable(argLoc,
-                                                      TVO_CanBindToNoEscape)));
+    args.push_back(params[i].withType(
+        cs.createTypeVariable(argLoc, TVO_CanBindToNoEscape)));
   }
 
-  ArrayRef<AnyFunctionType::Param> argsRef(args);
-  auto *fix = AddMissingArguments::create(cs, argsRef.take_back(numMissing),
+  SmallVector<std::pair<unsigned, AnyFunctionType::Param>, 4> synthesizedArgs;
+  synthesizedArgs.reserve(numMissing);
+  for (unsigned i = args.size() - numMissing, n = args.size(); i != n; ++i) {
+    synthesizedArgs.push_back(std::make_pair(i, args[i]));
+  }
+
+  auto *fix = AddMissingArguments::create(cs, synthesizedArgs,
                                           cs.getConstraintLocator(locator));
 
   if (cs.recordFix(fix))
@@ -3564,9 +3572,9 @@ bool ConstraintSystem::repairFailures(
     // But if `T.Element` didn't get resolved to `Void` we'd like
     // to diagnose this as a missing argument which can't be ignored.
     if (arg != getTypeVariables().end()) {
-      conversionsOrFixes.push_back(
-          AddMissingArguments::create(*this, {FunctionType::Param(*arg)},
-                                      getConstraintLocator(anchor, path)));
+      conversionsOrFixes.push_back(AddMissingArguments::create(
+          *this, {std::make_pair(0, AnyFunctionType::Param(*arg))},
+          getConstraintLocator(anchor, path)));
       break;
     }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -975,8 +975,6 @@ public:
   ConstraintLocator *getCalleeLocator(ConstraintLocator *locator,
                                       bool lookThroughApply = true) const;
 
-  Type getType(const Expr *E) const;
-
   void setExprTypes(Expr *expr) const;
 
   /// Retrieve the type of the given node, as recorded in this solution.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -975,14 +975,13 @@ public:
   ConstraintLocator *getCalleeLocator(ConstraintLocator *locator,
                                       bool lookThroughApply = true) const;
 
+  ConstraintLocator *
+  getConstraintLocator(Expr *anchor, ArrayRef<LocatorPathElt> path = {}) const;
+
   void setExprTypes(Expr *expr) const;
 
   /// Retrieve the type of the given node, as recorded in this solution.
-  Type getType(TypedNode node) const {
-    auto known = nodeTypes.find(node);
-    assert(known != nodeTypes.end());
-    return known->second;
-  }
+  Type getType(TypedNode node) const;
 
   /// Resolve type variables present in the raw type, using generic parameter
   /// types where possible.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -984,6 +984,17 @@ public:
     return known->second;
   }
 
+  /// Resolve type variables present in the raw type, using generic parameter
+  /// types where possible.
+  Type resolveInterfaceType(Type type) const;
+
+  /// For a given locator describing a function argument conversion, or a
+  /// constraint within an argument conversion, returns information about the
+  /// application of the argument to its parameter. If the locator is not
+  /// for an argument conversion, returns \c None.
+  Optional<FunctionArgApplyInfo>
+  getFunctionArgApplyInfo(ConstraintLocator *) const;
+
   SWIFT_DEBUG_DUMP;
 
   /// Dump this solution.
@@ -2102,16 +2113,6 @@ public:
     auto *calleeLoc = getCalleeLocator(loc, /*lookThroughApply*/ false);
     return findSelectedOverloadFor(calleeLoc);
   }
-
-  /// Resolve type variables present in the raw type, using generic parameter
-  /// types where possible.
-  Type resolveInterfaceType(Type type) const;
-
-  /// For a given locator describing a function argument conversion, or a
-  /// constraint within an argument conversion, returns information about the
-  /// application of the argument to its parameter. If the locator is not
-  /// for an argument conversion, returns \c None.
-  Optional<FunctionArgApplyInfo> getFunctionArgApplyInfo(ConstraintLocator *);
 
 private:
   unsigned assignTypeVariableID() {
@@ -4806,6 +4807,8 @@ bool isAutoClosureArgument(Expr *argExpr);
 /// parameter being applied, meaning that it's dropped from the type of the
 /// reference.
 bool hasAppliedSelf(ConstraintSystem &cs, const OverloadChoice &choice);
+bool hasAppliedSelf(const OverloadChoice &choice,
+                    llvm::function_ref<Type(Type)> getFixedType);
 
 /// Check whether type conforms to a given known protocol.
 bool conformsToKnownProtocol(ConstraintSystem &cs, Type type,


### PR DESCRIPTION
Make diagnostics stateless by providing them with a solution
instead of applying a solution back to constraint system and
using constraint system. Latter doesn't work well when there
is an ambiguity and multiple solutions are available instead of one.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
