### PR TITLE
Fix EscapeAnalysis verification assert at unreachable blocks

### DIFF
--- a/include/swift/SILOptimizer/Utils/BasicBlockOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/BasicBlockOptUtils.h
@@ -33,6 +33,24 @@ class BasicBlockCloner;
 class SILLoop;
 class SILLoopInfo;
 
+/// Compute the set of reachable blocks.
+class ReachableBlocks {
+  SmallPtrSet<SILBasicBlock *, 32> visited;
+
+public:
+  /// Invoke \p visitor for each reachable block in \p f in worklist order (at
+  /// least one predecessor has been visited--defs are always visited before
+  /// uses except for phi-type block args). The \p visitor takes a block
+  /// argument, which is already marked visited, and must return true to
+  /// continue visiting blocks.
+  ///
+  /// Returns true if all reachable blocks were visited.
+  bool visit(SILFunction *f, function_ref<bool(SILBasicBlock *)> visitor);
+
+  /// Return true if \p bb has been visited.
+  bool isVisited(SILBasicBlock *bb) const { return visited.count(bb); }
+};
+
 /// Remove all instructions in the body of \p bb in safe manner by using
 /// undef.
 void clearBlockBody(SILBasicBlock *bb);

--- a/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
@@ -17,6 +17,30 @@
 
 using namespace swift;
 
+/// Invoke \p visitor for each reachable block in \p f in worklist order (at
+/// least one predecessor has been visited).
+bool ReachableBlocks::visit(SILFunction *f,
+                            function_ref<bool(SILBasicBlock *)> visitor) {
+  assert(visited.empty() && "blocks already visited");
+
+  // Walk over the CFG, starting at the entry block, until all reachable blocks
+  // are visited.
+  SILBasicBlock *entryBB = f->getEntryBlock();
+  SmallVector<SILBasicBlock *, 8> worklist = {entryBB};
+  visited.insert(entryBB);
+  while (!worklist.empty()) {
+    SILBasicBlock *bb = worklist.pop_back_val();
+    if (!visitor(bb))
+      return false;
+
+    for (auto &succ : bb->getSuccessors()) {
+      if (visited.insert(succ).second)
+        worklist.push_back(succ);
+    }
+  }
+  return true;
+}
+
 /// Remove all instructions in the body of \p bb in safe manner by using
 /// undef.
 void swift::clearBlockBody(SILBasicBlock *bb) {
@@ -42,25 +66,16 @@ void swift::removeDeadBlock(SILBasicBlock *bb) {
 }
 
 bool swift::removeUnreachableBlocks(SILFunction &f) {
-  // All reachable blocks, but does not include the entry block.
-  llvm::SmallPtrSet<SILBasicBlock *, 8> visited;
+  ReachableBlocks reachable;
+  // Visit all the blocks without doing any extra work.
+  reachable.visit(&f, [](SILBasicBlock *) { return true; });
 
-  // Walk over the CFG, starting at the entry block, until all reachable blocks are visited.
-  llvm::SmallVector<SILBasicBlock *, 8> worklist(1, f.getEntryBlock());
-  while (!worklist.empty()) {
-    SILBasicBlock *bb = worklist.pop_back_val();
-    for (auto &Succ : bb->getSuccessors()) {
-      if (visited.insert(Succ).second)
-        worklist.push_back(Succ);
-    }
-  }
-
-  // Remove the blocks we never reached. Exclude the entry block from the iteration because it's
-  // not included in the Visited set.
+  // Remove the blocks we never reached. Assume the entry block is visited.
+  // Reachable's visited set contains dangling pointers during this loop.
   bool changed = false;
   for (auto ii = std::next(f.begin()), end = f.end(); ii != end;) {
     auto *bb = &*ii++;
-    if (!visited.count(bb)) {
+    if (!reachable.isVisited(bb)) {
       removeDeadBlock(bb);
       changed = true;
     }

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -1909,3 +1909,32 @@ bb0(%0 : $*SomeData):
   %5 = tuple ()
   return %5 : $()
 }
+
+// -----------------------------------------------------------------------------
+// Unreachable blocks are not mapped to the connection graph. Test
+// that verification does not assert with "Missing escape connection
+// graph mapping". <rdar://problem/60373501> EscapeAnalysis crashes
+// with CFG with unreachable
+sil_global hidden @globalInt: $Int
+
+// CHECK-LABEL: CG of testUnreachable
+// CHECK-LABEL: End
+sil hidden [noinline] @testUnreachable : $@convention(thin) () -> () {
+bb0:
+  %g1 = global_addr @globalInt : $*Int
+  %a1 = begin_access [read] [dynamic] [no_nested_conflict] %g1 : $*Int // users: %18, %17
+  %v1 = load %a1 : $*Int
+  end_access %a1 : $*Int
+  br bb4
+
+bb2:
+  %g2 = global_addr @globalInt : $*Int
+  %a2 = begin_access [read] [dynamic] [no_nested_conflict] %g2 : $*Int // users: %18, %17
+  %v2 = load %a2 : $*Int
+  end_access %a2 : $*Int
+  br bb4
+
+bb4:
+  %z = tuple ()
+  return %z : $()
+}


### PR DESCRIPTION
If EscapeAnalysis verification runs on unreachable code, it asserts
with "Missing escape connection graph mapping" because the connection
graph builder only runs on reachable blocks.

Add a ReachableBlocks utility and use it during verification.

Fixes <rdar://problem/60373501> EscapeAnalysis crashes with CFG with
unreachable blocks
