### PR TITLE
[stdlib][gardening] Silence a warning about unused value

### DIFF
--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -3235,7 +3235,6 @@ internal struct InstantiateKeyPathBuffer: KeyPathPatternVisitor {
   mutating func pushDest<T>(_ value: T) {
     _internalInvariant(_isPOD(T.self))
     let size = MemoryLayout<T>.size
-    let alignment = MemoryLayout<T>.alignment
     let (baseAddress, misalign) = adjustDestForAlignment(of: T.self)
     withUnsafeBytes(of: value) {
       _memcpy(dest: baseAddress, src: $0.baseAddress.unsafelyUnwrapped,


### PR DESCRIPTION
<!-- What's in this pull request? -->
It's only one of two warnings at the moment popping up when I compile the stdlib. Also easily addressed, so it's a perfect time to do some Saturday morning gardening.
