### PR TITLE
[ConstraintSystem] Make relabeling logic consistent

### DIFF
--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -465,12 +465,12 @@ protected:
 /// Call to `foo` is going to be diagnosed as missing `q:`
 /// and having extraneous `a:` labels, with appropriate fix-its added.
 class LabelingFailure final : public FailureDiagnostic {
-  ArrayRef<Identifier> CorrectLabels;
+  RelabelingMapping Mapping;
 
 public:
   LabelingFailure(const Solution &solution, ConstraintLocator *locator,
-                  ArrayRef<Identifier> labels)
-      : FailureDiagnostic(solution, locator), CorrectLabels(labels) {}
+                  const RelabelingMapping &mapping)
+      : FailureDiagnostic(solution, locator), Mapping(mapping) {}
 
   bool diagnoseAsError() override;
   bool diagnoseAsNote() override;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3493,6 +3493,20 @@ void constraints::simplifyLocator(Expr *&anchor,
   }
 }
 
+Expr *constraints::getArgumentListExprFor(ConstraintSystem &cs,
+                                          ConstraintLocator *locator) {
+  auto path = locator->getPath();
+  auto iter = path.begin();
+  if (!locator->findFirst<LocatorPathElt::ApplyArgument>(iter))
+    return nullptr;
+
+  // Form a new locator that ends at the ApplyArgument element, then simplify
+  // to get the argument list.
+  auto newPath = ArrayRef<LocatorPathElt>(path.begin(), iter + 1);
+  auto argListLoc = cs.getConstraintLocator(locator->getAnchor(), newPath);
+  return simplifyLocatorToAnchor(argListLoc);
+}
+
 Expr *constraints::simplifyLocatorToAnchor(ConstraintLocator *locator) {
   if (!locator)
     return nullptr;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4700,10 +4700,10 @@ struct CallArgumentMatchResult {
 
   bool needsRelabeling() const;
 
-  SmallVector<Identifier, 8>
-  buildRelabelingLabels(unsigned numArgs,
-                        ArrayRef<AnyFunctionType::Param> params,
-                        const ParameterListInfo &paramsInfo) const;
+  RelabelingMapping
+  buildRelabelingMapping(ArrayRef<AnyFunctionType::Param> args,
+                         ArrayRef<AnyFunctionType::Param> params,
+                         const ParameterListInfo &paramsInfo) const;
 };
 
 /// Class used as the base for listeners to the \c matchCallArguments process.
@@ -4766,7 +4766,7 @@ public:
   ///
   /// \returns true to indicate that this should cause a failure, false
   /// otherwise.
-  virtual bool relabelArguments(ArrayRef<Identifier> newNames);
+  virtual bool relabelArguments(const RelabelingMapping &mapping);
 
   /// Indicates that the trailing closure argument at the given \c argIdx
   /// cannot be passed to the last parameter at \c paramIdx.
@@ -4856,6 +4856,12 @@ ConstraintLocator *simplifyLocator(ConstraintSystem &cs,
 void simplifyLocator(Expr *&anchor,
                      ArrayRef<LocatorPathElt> &path,
                      SourceRange &range);
+
+/// For a given locator describing an argument application, or a constraint
+/// within an argument application, returns the argument list for that
+/// application. If the locator is not for an argument application, or
+/// the argument list cannot be found, returns \c nullptr.
+Expr *getArgumentListExprFor(ConstraintSystem &cs, ConstraintLocator *locator);
 
 /// Simplify the given locator down to a specific anchor expression,
 /// if possible.

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -33,6 +33,9 @@ namespace swift {
   class TopLevelCodeDecl;
   class TypeChecker;
   class ValueDecl;
+  namespace constraints {
+  struct RelabelingMapping;
+  }
 
 /// Emit diagnostics for syntactic restrictions on a given expression.
 void performSyntacticExprDiagnostics(const Expr *E, const DeclContext *DC,
@@ -63,9 +66,12 @@ void fixItAccess(InFlightDiagnostic &diag,
 /// error diagnostic.
 ///
 /// \returns true if the issue was diagnosed
-bool diagnoseArgumentLabelError(ASTContext &ctx,
-                                Expr *expr,
-                                ArrayRef<Identifier> newNames,
+bool diagnoseArgumentLabelError(ASTContext &ctx, Expr *expr,
+                                ArrayRef<Identifier> newNames, bool isSubscript,
+                                InFlightDiagnostic *existingDiag = nullptr);
+
+bool diagnoseArgumentLabelError(ASTContext &ctx, Expr *expr,
+                                const constraints::RelabelingMapping &mapping,
                                 bool isSubscript,
                                 InFlightDiagnostic *existingDiag = nullptr);
 

--- a/test/Constraints/keyword_arguments.swift
+++ b/test/Constraints/keyword_arguments.swift
@@ -264,8 +264,8 @@ struct Variadics7 {
     // typo B
     f(bravox: 0) // expected-error {{incorrect argument label in call (have 'bravox:', expected 'bravo:')}}
     f(alpha: 0, bravox: 3) // expected-error {{incorrect argument label in call (have 'alpha:bravox:', expected 'alpha:bravo:')}}
-    f(alpha: 0, 1, bravox: 3) // expected-error {{incorrect argument label in call (have 'alpha:_:bravox:', expected 'alpha:_:bravo:')}}
-    f(alpha: 0, 1, 2, bravox: 3) // expected-error {{incorrect argument label in call (have 'alpha:_:_:bravox:', expected 'alpha:_:_:bravo:')}}
+    f(alpha: 0, 1, bravox: 3) // expected-error {{incorrect argument labels in call (have 'alpha:_:bravox:', expected 'alpha:bravo:')}}
+    f(alpha: 0, 1, 2, bravox: 3) // expected-error {{incorrect argument labels in call (have 'alpha:_:_:bravox:', expected 'alpha:bravo:')}}
 
     // OoO + typo A B
     f(bravox: 0, alphax: 1) // expected-error {{incorrect argument labels in call (have 'bravox:alphax:', expected 'alpha:bravo:')}}
@@ -305,13 +305,13 @@ struct Variadics8 {
     // typo B
     f(bravox: 3, charlie: 4) // expected-error {{incorrect argument label in call (have 'bravox:charlie:', expected 'bravo:charlie:')}}
     f(alpha: 0, bravox: 3, charlie: 4) // expected-error {{incorrect argument label in call (have 'alpha:bravox:charlie:', expected 'alpha:bravo:charlie:')}}
-    f(alpha: 0, 1, bravox: 3, charlie: 4) // expected-error {{incorrect argument label in call (have 'alpha:_:bravox:charlie:', expected 'alpha:_:bravo:charlie:')}}
-    f(alpha: 0, 1, 2, bravox: 3, charlie: 4) // expected-error {{incorrect argument label in call (have 'alpha:_:_:bravox:charlie:', expected 'alpha:_:_:bravo:charlie:')}}
+    f(alpha: 0, 1, bravox: 3, charlie: 4) // expected-error {{incorrect argument labels in call (have 'alpha:_:bravox:charlie:', expected 'alpha:bravo:charlie:')}}
+    f(alpha: 0, 1, 2, bravox: 3, charlie: 4) // expected-error {{incorrect argument labels in call (have 'alpha:_:_:bravox:charlie:', expected 'alpha:bravo:charlie:')}}
     // typo C
     f(bravo: 3, charliex: 4) // expected-error {{incorrect argument label in call (have 'bravo:charliex:', expected 'bravo:charlie:')}}
     f(alpha: 0, bravo: 3, charliex: 4) // expected-error {{incorrect argument label in call (have 'alpha:bravo:charliex:', expected 'alpha:bravo:charlie:')}}
-    f(alpha: 0, 1, bravo: 3, charliex: 4) // expected-error {{incorrect argument label in call (have 'alpha:_:bravo:charliex:', expected 'alpha:_:bravo:charlie:')}}
-    f(alpha: 0, 1, 2, bravo: 3, charliex: 4) // expected-error {{incorrect argument label in call (have 'alpha:_:_:bravo:charliex:', expected 'alpha:_:_:bravo:charlie:')}}
+    f(alpha: 0, 1, bravo: 3, charliex: 4) // expected-error {{incorrect argument labels in call (have 'alpha:_:bravo:charliex:', expected 'alpha:bravo:charlie:')}}
+    f(alpha: 0, 1, 2, bravo: 3, charliex: 4) // expected-error {{incorrect argument labels in call (have 'alpha:_:_:bravo:charliex:', expected 'alpha:bravo:charlie:')}}
 
     // OoO ACB + typo B
     f(alpha: 0, charlie: 3, bravox: 4) // expected-error {{incorrect argument labels in call (have 'alpha:charlie:bravox:', expected 'alpha:bravo:charlie:')}}

--- a/test/Constraints/keyword_arguments.swift
+++ b/test/Constraints/keyword_arguments.swift
@@ -139,7 +139,7 @@ variadics1(x: 1, y: 2, 1, 2)
 variadics1(x: 1, y: 2, 1, 2, 3)
 
 // Using various (out-of-order)
-variadics1(1, 2, 3, 4, 5, x: 6, y: 7) // expected-error {{incorrect argument labels in call (have '_:_:_:_:_:x:y:', expected 'x:y:_:')}} {{12-12=x: }} {{15-15=y: }} {{27-30=}} {{33-36=}}
+variadics1(1, 2, 3, 4, 5, x: 6, y: 7) // expected-error {{incorrect argument labels in call (have '_:x:y:', expected 'x:y:_:')}} {{12-12=x: }} {{27-28=y}} {{33-36=}}
 
 func variadics2(x: Int, y: Int = 2, z: Int...) { } // expected-note {{'variadics2(x:y:z:)' declared here}}
 
@@ -264,8 +264,8 @@ struct Variadics7 {
     // typo B
     f(bravox: 0) // expected-error {{incorrect argument label in call (have 'bravox:', expected 'bravo:')}}
     f(alpha: 0, bravox: 3) // expected-error {{incorrect argument label in call (have 'alpha:bravox:', expected 'alpha:bravo:')}}
-    f(alpha: 0, 1, bravox: 3) // expected-error {{incorrect argument labels in call (have 'alpha:_:bravox:', expected 'alpha:bravo:')}}
-    f(alpha: 0, 1, 2, bravox: 3) // expected-error {{incorrect argument labels in call (have 'alpha:_:_:bravox:', expected 'alpha:bravo:')}}
+    f(alpha: 0, 1, bravox: 3) // expected-error {{incorrect argument label in call (have 'alpha:bravox:', expected 'alpha:bravo:')}}
+    f(alpha: 0, 1, 2, bravox: 3) // expected-error {{incorrect argument label in call (have 'alpha:bravox:', expected 'alpha:bravo:')}}
 
     // OoO + typo A B
     f(bravox: 0, alphax: 1) // expected-error {{incorrect argument labels in call (have 'bravox:alphax:', expected 'alpha:bravo:')}}
@@ -291,8 +291,8 @@ struct Variadics8 {
     f(alpha: 0, 1, 2, charlie: 3, bravo: 4) // expected-error {{argument 'bravo' must precede argument 'charlie'}}
     // OoO CAB
     f(charlie: 0, alpha: 1, bravo: 4) // expected-error {{incorrect argument labels in call (have 'charlie:alpha:bravo:', expected 'alpha:bravo:charlie:')}}
-    f(charlie: 0, alpha: 1, 2, bravo: 4) // expected-error {{incorrect argument labels in call (have 'charlie:alpha:_:bravo:', expected 'alpha:bravo:charlie:')}}
-    f(charlie: 0, alpha: 1, 2, 3, bravo: 4) // expected-error {{incorrect argument labels in call (have 'charlie:alpha:_:_:bravo:', expected 'alpha:bravo:charlie:')}}
+    f(charlie: 0, alpha: 1, 2, bravo: 4) // expected-error {{incorrect argument labels in call (have 'charlie:alpha:bravo:', expected 'alpha:bravo:charlie:')}}
+    f(charlie: 0, alpha: 1, 2, 3, bravo: 4) // expected-error {{incorrect argument labels in call (have 'charlie:alpha:bravo:', expected 'alpha:bravo:charlie:')}}
     // OoO BAC
     f(bravo: 0, alpha: 1, charlie: 4) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
     f(bravo: 0, alpha: 1, 2, charlie: 4) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
@@ -305,28 +305,28 @@ struct Variadics8 {
     // typo B
     f(bravox: 3, charlie: 4) // expected-error {{incorrect argument label in call (have 'bravox:charlie:', expected 'bravo:charlie:')}}
     f(alpha: 0, bravox: 3, charlie: 4) // expected-error {{incorrect argument label in call (have 'alpha:bravox:charlie:', expected 'alpha:bravo:charlie:')}}
-    f(alpha: 0, 1, bravox: 3, charlie: 4) // expected-error {{incorrect argument labels in call (have 'alpha:_:bravox:charlie:', expected 'alpha:bravo:charlie:')}}
-    f(alpha: 0, 1, 2, bravox: 3, charlie: 4) // expected-error {{incorrect argument labels in call (have 'alpha:_:_:bravox:charlie:', expected 'alpha:bravo:charlie:')}}
+    f(alpha: 0, 1, bravox: 3, charlie: 4) // expected-error {{incorrect argument label in call (have 'alpha:bravox:charlie:', expected 'alpha:bravo:charlie:')}}
+    f(alpha: 0, 1, 2, bravox: 3, charlie: 4) // expected-error {{incorrect argument label in call (have 'alpha:bravox:charlie:', expected 'alpha:bravo:charlie:')}}
     // typo C
     f(bravo: 3, charliex: 4) // expected-error {{incorrect argument label in call (have 'bravo:charliex:', expected 'bravo:charlie:')}}
     f(alpha: 0, bravo: 3, charliex: 4) // expected-error {{incorrect argument label in call (have 'alpha:bravo:charliex:', expected 'alpha:bravo:charlie:')}}
-    f(alpha: 0, 1, bravo: 3, charliex: 4) // expected-error {{incorrect argument labels in call (have 'alpha:_:bravo:charliex:', expected 'alpha:bravo:charlie:')}}
-    f(alpha: 0, 1, 2, bravo: 3, charliex: 4) // expected-error {{incorrect argument labels in call (have 'alpha:_:_:bravo:charliex:', expected 'alpha:bravo:charlie:')}}
+    f(alpha: 0, 1, bravo: 3, charliex: 4) // expected-error {{incorrect argument label in call (have 'alpha:bravo:charliex:', expected 'alpha:bravo:charlie:')}}
+    f(alpha: 0, 1, 2, bravo: 3, charliex: 4) // expected-error {{incorrect argument label in call (have 'alpha:bravo:charliex:', expected 'alpha:bravo:charlie:')}}
 
     // OoO ACB + typo B
     f(alpha: 0, charlie: 3, bravox: 4) // expected-error {{incorrect argument labels in call (have 'alpha:charlie:bravox:', expected 'alpha:bravo:charlie:')}}
-    f(alpha: 0, 1, charlie: 3, bravox: 4) // expected-error {{incorrect argument labels in call (have 'alpha:_:charlie:bravox:', expected 'alpha:bravo:charlie:')}}
-    f(alpha: 0, 1, 2, charlie: 3, bravox: 4) // expected-error {{incorrect argument labels in call (have 'alpha:_:_:charlie:bravox:', expected 'alpha:bravo:charlie:')}}
+    f(alpha: 0, 1, charlie: 3, bravox: 4) // expected-error {{incorrect argument labels in call (have 'alpha:charlie:bravox:', expected 'alpha:bravo:charlie:')}}
+    f(alpha: 0, 1, 2, charlie: 3, bravox: 4) // expected-error {{incorrect argument labels in call (have 'alpha:charlie:bravox:', expected 'alpha:bravo:charlie:')}}
     // OoO ACB + typo C
-    f(charliex: 3, bravo: 4) // expected-error {{incorrect argument labels in call (have 'charliex:bravo:', expected 'alpha:bravo:charlie:')}}
+    f(charliex: 3, bravo: 4) // expected-error {{incorrect argument labels in call (have 'charliex:bravo:', expected 'bravo:charlie:')}}
     f(alpha: 0, charliex: 3, bravo: 4) // expected-error {{incorrect argument labels in call (have 'alpha:charliex:bravo:', expected 'alpha:bravo:charlie:')}}
-    f(alpha: 0, 1, charliex: 3, bravo: 4) // expected-error {{incorrect argument labels in call (have 'alpha:_:charliex:bravo:', expected 'alpha:bravo:charlie:')}}
-    f(alpha: 0, 1, 2, charliex: 3, bravo: 4) // expected-error {{incorrect argument labels in call (have 'alpha:_:_:charliex:bravo:', expected 'alpha:bravo:charlie:')}}
+    f(alpha: 0, 1, charliex: 3, bravo: 4) // expected-error {{incorrect argument labels in call (have 'alpha:charliex:bravo:', expected 'alpha:bravo:charlie:')}}
+    f(alpha: 0, 1, 2, charliex: 3, bravo: 4) // expected-error {{incorrect argument labels in call (have 'alpha:charliex:bravo:', expected 'alpha:bravo:charlie:')}}
 
     // OoO BAC + typo B
     f(bravox: 0, alpha: 1, charlie: 4) // expected-error {{incorrect argument labels in call (have 'bravox:alpha:charlie:', expected 'alpha:bravo:charlie:')}}
-    f(bravox: 0, alpha: 1, 2, charlie: 4) // expected-error {{incorrect argument labels in call (have 'bravox:alpha:_:charlie:', expected 'alpha:bravo:charlie:')}}
-    f(bravox: 0, alpha: 1, 2, 3, charlie: 4) // expected-error {{incorrect argument labels in call (have 'bravox:alpha:_:_:charlie:', expected 'alpha:bravo:charlie:')}}
+    f(bravox: 0, alpha: 1, 2, charlie: 4) // expected-error {{incorrect argument labels in call (have 'bravox:alpha:charlie:', expected 'alpha:bravo:charlie:')}}
+    f(bravox: 0, alpha: 1, 2, 3, charlie: 4) // expected-error {{incorrect argument labels in call (have 'bravox:alpha:charlie:', expected 'alpha:bravo:charlie:')}}
     // OoO BAC + typo C
     f(bravo: 0, alpha: 1, charliex: 4) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
     f(bravo: 0, alpha: 1, 2, charliex: 4) // expected-error {{argument 'alpha' must precede argument 'bravo'}}
@@ -361,16 +361,16 @@ struct PositionsAroundDefaultsAndVariadics {
 
     f1(c: "3", [4])
 
-    f1(b: "2", [3]) // expected-error {{incorrect argument labels in call (have 'b:_:', expected '_:_:c:_:')}}
+    f1(b: "2", [3]) // expected-error {{incorrect argument labels in call (have 'b:_:', expected '_:c:')}}
     // expected-error@-1 {{cannot convert value of type '[Int]' to expected argument type 'Bool'}}
     
-    f1(b: "2", 1) // expected-error {{incorrect argument labels in call (have 'b:_:', expected '_:_:c:_:')}}
+    f1(b: "2", 1) // expected-error {{incorrect argument labels in call (have 'b:_:', expected '_:c:')}}
     // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
 
-    f1(b: "2", [3], 1) // expected-error {{incorrect argument labels in call (have 'b:_:_:', expected '_:_:c:_:')}}
+    f1(b: "2", [3], 1) // expected-error {{incorrect argument labels in call (have 'b:_:_:', expected '_:_:c:')}}
     // expected-error@-1 {{cannot convert value of type '[Int]' to expected argument type 'Bool'}}
 
-    f1(b: "2", 1, [3]) // expected-error {{incorrect argument labels in call (have 'b:_:_:', expected '_:_:c:_:')}}
+    f1(b: "2", 1, [3]) // expected-error {{incorrect argument labels in call (have 'b:_:_:', expected '_:_:c:')}}
     // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
     // expected-error@-2 {{cannot convert value of type '[Int]' to expected argument type 'Int'}}
   }
@@ -420,11 +420,11 @@ struct PositionsAroundDefaultsAndVariadics {
 
     f2(c: "3", 21) // expected-error {{cannot convert value of type 'Int' to expected argument type '[Int]'}}
     
-    f2(c: "3", 21, [4]) // expected-error {{incorrect argument labels in call (have 'c:_:_:', expected '_:_:c:_:')}}
+    f2(c: "3", 21, [4]) // expected-error {{incorrect argument labels in call (have 'c:_:_:', expected '_:c:_:')}}
     // expected-error@-1 {{cannot convert value of type 'Int' to expected argument type '[Int]'}}
     // expected-error@-2 {{cannot convert value of type '[Int]' to expected argument type 'Bool'}}
 
-    f2(c: "3", [4], 21) // expected-error {{incorrect argument labels in call (have 'c:_:_:', expected '_:_:c:_:')}}
+    f2(c: "3", [4], 21) // expected-error {{incorrect argument labels in call (have 'c:_:_:', expected '_:c:_:')}}
     // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
 
     f2([4]) // expected-error {{cannot convert value of type '[Int]' to expected argument type 'Bool'}}


### PR DESCRIPTION
# Summary

It introduce `CallArgumentMatchResult` and `RelabelingMapping` type.
Using them make behavior of `matchCallArgument`, calculating impact of relabeling fix and relabeling diagnostic consistent.

@xedin please review this.

# Motivation

`matchCallArgument`, `ArgumentFailureTracker::relabelArguments`, `diagnoseArgumentLabelError` have similar duplicated logics for each purpose.

Current such design makes improvement this are difficult.

Some information at `matchCallArgument` is not passed to other stages.

So some problem is happen in corner case.

I also heard this idea here.

https://forums.swift.org/t/question-about-overlapped-multiple-fixits-from-diagnostics/34488/2

It's good if I could follow the intention what @xedin tell me `TODO` here.

## Examples

## Diagnostics of relabeling does not consider default parameter.

```swift
func f(aa: Int, bb: Int, cc: Int = 0) {}
f(bbx: 0)
// incorrect argument labels in call (have 'bbx:', expected 'aa:bb:cc:')
```

Expecting of label `cc:` isn't necessary.

## Diagnostics of relabeling does not consider variadics parameter.

```swift
func f(aa: Int..., bb: Int, cc: Int) {}
f(aa: 1, 2, 3, bbx: 4, cc: 5)
// incorrect argument label in call (have 'aa:_:_:bbx:cc:', expected 'aa:_:_:bb:cc:')
```

Each entry of variadics change into unlabeled individual arguments on label.

## Calculating impact factor of relabeling fix does not consider parameter claiming.

```swift
func f(aa: Int, bb: Int) {}
f(aa: 1, aa: 2)
// incorrect argument label in call (have 'aa:aa:', expected 'aa:bb:')
// Score: 2 0 0 0 0 0 0 0 0 0 0 0
```

Score is `1(Relabeling) + 1(OoO)`.
But second `aa` argument shouldn't be considered as out of order from parameter `aa:`.
Because parameter `aa:` is claimed by first `aa` argument.

---

I think these problems are coming from these duplicated logics.

# Design

To resolve these issue fundamentally,
It introduce two types which is `CallArgumentMatchResult` and `RelabelingMapping`.

They are both just value type holding information.

It split `matchCallArgument` into two overloads.

First one build `CallArgumentMatchResult` and have no side effect.
So it doesn't take `MatchCallArgumentListener`.
Second one keeps compatibility.
It call first one and use result.
It invoke `MatchCallArgumentListener` based on result.

I think that this refactoring makes it more readable in particular about tracking side effect and branching flow.

`CallArgumentMatchResult::buildRelabelingMapping` build `RelabelingMapping`.

`RelabelingMapping` holds mapping information between arguments and parameters, judged label mismatch category.

It changes `RelabelArguments` and `LabelingFailure` to take `RelabelingMapping` instead of `ArrayRef<Identifier>`.

It split `diagnoseArgumentLabelError` into two overloads.
First one takes `RelabelingMapping` and make diagnostics and fix-its from it.
Second one keeps compatibility.
It build `RelabelingMapping` using original logic and calls first one.

`LabelingFailure` calls first one of `diagnoseArgumentLabelError` with own `RelabelingMapping`.

Because `RelabelingMapping` is just a value and built from `CallArgumentMatchResult`,
they can remove duplicated logics and use shared consistent result.

# Achievement and change of test result

Diff of `ArgumentFailureTracker::relabelArguments` and `diagnoseArgumentLabelError` seems to be good for me.
Each original logics of label iteration and matching are removed.
They are just only convert passed argument into their purpose now.

##  label of variadics

```
-variadics1(1, 2, 3, 4, 5, x: 6, y: 7) // expected-error {{incorrect argument labels in call (have '_:_:_:_:_:x:y:', expected 'x:y:_:')}} {{12-12=x: }} {{15-15=y: }} {{27-30=}} {{33-36=}}
+variadics1(1, 2, 3, 4, 5, x: 6, y: 7) // expected-error {{incorrect argument labels in call (have '_:x:y:', expected 'x:y:_:')}} {{12-12=x: }} {{27-28=y}} {{33-36=}}
```

Diagnose and fix-it now knows variadics.
After fix it, code is going to be `variadics1(x: 1, 2, 3, 4, 5, y: 6, 7)`.

Following is same.

```
-    f(alpha: 0, 1, bravox: 3) // expected-error {{incorrect argument label in call (have 'alpha:_:bravox:', expected 'alpha:_:bravo:')}}
+    f(alpha: 0, 1, bravox: 3) // expected-error {{incorrect argument label in call (have 'alpha:bravox:', expected 'alpha:bravo:')}}
```

## default parameter

```
func f1(_ a: Bool = false, _ b: Int = 0, c: String = "", _ d: [Int] = []) {}

-    f1(b: "2", [3]) // expected-error {{incorrect argument labels in call (have 'b:_:', expected '_:_:c:_:')}}
+    f1(b: "2", [3]) // expected-error {{incorrect argument labels in call (have 'b:_:', expected '_:c:')}}
```

Diagnose and fix-it knows that `_ a:` and `_ d:` aren't needed as default value.

# Trouble at coding

I am in some trouble at coding.

## `getArgumentListExprFor`

`RelabelArguments` also created at `matchFunctionTypes`.
To keep same behavior, I need helper function `FailureDiagnostics::getArgumentListExprFor`.
So I publish this at `constraints::getArgumentListExprFor`.
I worried about this design.

## `#include`

I put `RelabelingArgument` at `CSFix.h`.
So I need `#include "ConstraintSystem.h"` at `MiscDiagnostics.cpp`.
First time I wrote `#include "CSFix.h`.
But after merged this,
https://github.com/apple/swift/pull/30411
including order was twisted and I changed.

I moved original mapping logic of `diagnoseArgumentLabelError` to `RelabelingMapping::build`.
It calls `getOriginalArgumentList`.
So I need `#include "swift/Sema/IDETypeChecking.h"` at `CSFix.cpp`.

I feel these `#include` addition is not good.
Please advice me.

# Future direction

If this PR is acceptable, I will more refactor on changes.

## Refactor `matchCallArgument`

I currently prioritized compatibility and ease of reviewing.
So code has duplicated variables to track intermediate state.
For example, local variable `parameterBindings` could be removed as using `result`.

## Improve data structure of `CallArgumentMatchResult`

It can be changed to more efficient.

## Change source of calling label mismatch notifications of `MatchCallArgumentListener`

Their source is `CallArgumentMatchResult`.
It does same as original code.

I think using `RelabelingMapping` is better.
It is consistent with following stages.

Doing it reduce `matchCallArgument` codes and `CallArgumentMatchResult`'s fields.
