### PR TITLE
Vim: Use 4 spaces instead of 2

### DIFF
--- a/utils/vim/ftplugin/swift.vim
+++ b/utils/vim/ftplugin/swift.vim
@@ -8,6 +8,6 @@
 
 setlocal comments=s1:/*,mb:*,ex:*/,:///,://
 setlocal expandtab
-setlocal ts=2
-setlocal sw=2
+setlocal ts=4
+setlocal sw=4
 setlocal smartindent


### PR DESCRIPTION
By default, Xcode uses 4 spaces, instead of 2. Having ts and sw 2 here
makes formatting incompatible with existing files created with Xcode. To
ensure that files created with Vim and Xcode look the same, 4 sounds
ideal.