### PR TITLE
[Diagnostics] Serialize educational note paths in .dia files

### DIFF
--- a/test/diagnostics/serialized-edu-notes.swift
+++ b/test/diagnostics/serialized-edu-notes.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: not %target-swift-frontend -enable-educational-notes -diagnostic-documentation-path /educational/notes/path/prefix -serialize-diagnostics-path %t/diagnostics.dia -typecheck %s
+// RUN: llvm-bcanalyzer -dump %t/diagnostics.dia | %FileCheck %s
+
+
+// A diagnostic with an educational note
+extension (Int, Int) {}
+// CHECK: <Diag
+// CHECK: <DiagInfo
+// CHECK: 'non-nominal type '(Int, Int)' cannot be extended'
+// CHECK: <EduNotePath
+// CHECK: '{{[/\\]+}}educational{{[/\\]+}}notes{{[/\\]+}}path{{[/\\]+}}prefix{{[/\\]+}}nominal-types.md'
+// CHECK: </Diag>
+
+// A diagnostic without an educational note
+let x: Int = "hello, world!"
+// CHECK: <Diag
+// CHECK: <DiagInfo
+// CHECK: 'cannot convert value of type 'String' to specified type 'Int''
+// CHECK-NOT: <EduNotePath
+// CHECK: </Diag>


### PR DESCRIPTION
Add a new optional record type which may appear in diag blocks and contains the path to the educational note.

Open questions:
- Instead of adding swift-specific record IDs starting at 32, should I try upstreaming a new record ID to clang? My thinking is that clang would have no use for it and might not want to accept swift-specific changes
- Does Xcode ignore records with unknown IDs? The Clang `SerializedDiagnosticReader` does and I'm hoping that's what Xcode uses. I'm going to attempt to test this manually, but it would be great if someone with source access could confirm. (Edit: after testing, it doesn't look like there are any compatibility issues)
- Does this require a format version bump? It looks like it wasn't bumped when remarks were introduced.