### PR TITLE
[doc] Replace square brackets with parens for hyperlinking.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ debugging. Depending on your machine, a clean build can take a few minutes to
 several hours. Naturally, incremental builds are much faster.
 
 Once you are able to build things successfully and have a compile-test-debug
-loop going, check out the [development tips][docs/DevelopmentTips.md] for
+loop going, check out the [development tips](docs/DevelopmentTips.md) for
 better productivity while working on the compiler.
 
 ### System Requirements


### PR DESCRIPTION
Thanks @benrimmington for pointing this out in #30418.