### PR TITLE
TBDGen: don't emit $ld$previous$ symbols for added members to a moved decl

### DIFF
--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -277,12 +277,24 @@ getLinkerPlatformName(OriginallyDefinedInAttr::ActiveVersion Ver) {
   return getLinkerPlatformName((uint8_t)getLinkerPlatformId(Ver));
 }
 
+/// Find the most relevant introducing version of the decl stack we have visted
+/// so far.
+static Optional<llvm::VersionTuple>
+getInnermostIntroVersion(ArrayRef<Decl*> DeclStack, PlatformKind Platform) {
+  for (auto It = DeclStack.rbegin(); It != DeclStack.rend(); ++ It) {
+    if (auto Result = (*It)->getIntroducedOSVersion(Platform))
+      return Result;
+  }
+  return None;
+}
+
 void TBDGenVisitor::addLinkerDirectiveSymbolsLdPrevious(StringRef name,
                                                 llvm::MachO::SymbolKind kind) {
   if (kind != llvm::MachO::SymbolKind::GlobalSymbol)
     return;
-  if (!TopLevelDecl)
+  if(DeclStack.empty())
     return;
+  auto TopLevelDecl = DeclStack.front();
   auto MovedVers = getAllMovedPlatformVersions(TopLevelDecl);
   if (MovedVers.empty())
     return;
@@ -290,9 +302,13 @@ void TBDGenVisitor::addLinkerDirectiveSymbolsLdPrevious(StringRef name,
   assert(previousInstallNameMap);
   auto &Ctx = TopLevelDecl->getASTContext();
   for (auto &Ver: MovedVers) {
-    auto IntroVer = TopLevelDecl->getIntroducedOSVersion(Ver.Platform);
+    auto IntroVer = getInnermostIntroVersion(DeclStack, Ver.Platform);
     assert(IntroVer && "cannot find OS intro version");
     if (!IntroVer.hasValue())
+      continue;
+    // This decl is available after the top-level symbol has been moved here,
+    // so we don't need the linker directives.
+    if (*IntroVer >= Ver.Version)
       continue;
     auto PlatformNumber = getLinkerPlatformId(Ver);
     auto It = previousInstallNameMap->find(Ver.ModuleName);
@@ -330,8 +346,9 @@ void TBDGenVisitor::addLinkerDirectiveSymbolsLdHide(StringRef name,
                                                     llvm::MachO::SymbolKind kind) {
   if (kind != llvm::MachO::SymbolKind::GlobalSymbol)
     return;
-  if (!TopLevelDecl)
+  if (DeclStack.empty())
     return;
+  auto TopLevelDecl = DeclStack.front();
   auto MovedVers = getAllMovedPlatformVersions(TopLevelDecl);
   if (MovedVers.empty())
     return;
@@ -346,11 +363,12 @@ void TBDGenVisitor::addLinkerDirectiveSymbolsLdHide(StringRef name,
   unsigned Minor[2];
   Major[1] = MovedVer.getMajor();
   Minor[1] = MovedVer.getMinor().hasValue() ? *MovedVer.getMinor(): 0;
-  auto IntroVer = TopLevelDecl->getIntroducedOSVersion(Platform);
+  auto IntroVer = getInnermostIntroVersion(DeclStack, Platform);
   assert(IntroVer && "cannot find the start point of availability");
   if (!IntroVer.hasValue())
     return;
-  assert(*IntroVer < MovedVer);
+  // This decl is available after the top-level symbol has been moved here,
+  // so we don't need the linker directives.
   if (*IntroVer >= MovedVer)
     return;
   Major[0] = IntroVer->getMajor();
@@ -911,6 +929,12 @@ void TBDGenVisitor::addFirstFileSymbols() {
   }
 }
 
+void TBDGenVisitor::visit(Decl *D) {
+  DeclStack.push_back(D);
+  SWIFT_DEFER { DeclStack.pop_back(); };
+  ASTVisitor::visit(D);
+}
+
 /// The kind of version being parsed, used for diagnostics.
 /// Note: Must match the order in DiagnosticsFrontend.def
 enum DylibVersionKind_t: unsigned {
@@ -1018,8 +1042,6 @@ GenerateTBDRequest::evaluate(Evaluator &evaluator,
     for (auto d : decls) {
       if (opts.LinkerDirectivesOnly && !hasLinkerDirective(d))
         continue;
-      visitor.TopLevelDecl = d;
-      SWIFT_DEFER { visitor.TopLevelDecl = nullptr; };
       visitor.visit(d);
     }
   };

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -69,9 +69,9 @@ public:
   const UniversalLinkageInfo &UniversalLinkInfo;
   ModuleDecl *SwiftModule;
   const TBDGenOptions &Opts;
-  Decl* TopLevelDecl = nullptr;
 
 private:
+  std::vector<Decl*> DeclStack;
   std::unique_ptr<std::map<std::string, InstallNameStore>>
     previousInstallNameMap;
   std::unique_ptr<std::map<std::string, InstallNameStore>>
@@ -108,7 +108,7 @@ public:
         DataLayout(dataLayout), UniversalLinkInfo(universalLinkInfo),
         SwiftModule(swiftModule), Opts(opts),
         previousInstallNameMap(parsePreviousModuleInstallNameMap())  {}
-
+  ~TBDGenVisitor() { assert(DeclStack.empty()); }
   void addMainIfNecessary(FileUnit *file) {
     // HACK: 'main' is a special symbol that's always emitted in SILGen if
     //       the file has an entry point. Since it doesn't show up in the
@@ -152,6 +152,8 @@ public:
   void visitEnumElementDecl(EnumElementDecl *EED);
 
   void visitDecl(Decl *D) {}
+
+  void visit(Decl *D);
 };
 } // end namespace tbdgen
 } // end namespace swift

--- a/test/TBD/Inputs/linker-directive.swift
+++ b/test/TBD/Inputs/linker-directive.swift
@@ -6,4 +6,6 @@ public func toast() {}
 @_originallyDefinedIn(module: "ToasterKit", macOS 10.15, iOS 13)
 public struct Vehicle {
   public func move() {}
+  @available(macOS 10.15, iOS 13, *)
+  public func originallyDefinedInCurrentModule() {}
 }

--- a/test/TBD/linker-directives-ld-previous-macos.swift
+++ b/test/TBD/linker-directives-ld-previous-macos.swift
@@ -4,11 +4,14 @@
 
 // RUN: %target-swift-frontend -typecheck %S/Inputs/linker-directive.swift -tbd-is-installapi -emit-tbd -emit-tbd-path %t/linker_directives.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json
 // RUN: %FileCheck %s < %t/linker_directives.tbd
+// RUN: %FileCheck -check-prefix=CHECK-NO-NEW-SYMBOL %s < %t/linker_directives.tbd
 // RUN: %target-swift-frontend -typecheck %S/Inputs/linker-directive.swift -emit-tbd -emit-tbd-path %t/linker_directives.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json
 // RUN: %FileCheck %s < %t/linker_directives.tbd
+// RUN: %FileCheck -check-prefix=CHECK-NO-NEW-SYMBOL %s < %t/linker_directives.tbd
 
 // RUN: %target-swift-frontend -target-variant x86_64-apple-ios13.0-macabi -typecheck %S/Inputs/linker-directive.swift -emit-tbd -emit-tbd-path %t/linker_directives.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json
 // RUN: %FileCheck -check-prefix=CHECK-ZIPPERED %s < %t/linker_directives.tbd
+// RUN: %FileCheck -check-prefix=CHECK-NO-NEW-SYMBOL %s < %t/linker_directives.tbd
 
 // CHECK: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit5toastyyF$
 // CHECK: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit7VehicleV4moveyyF$
@@ -18,3 +21,5 @@
 
 // CHECK-ZIPPERED: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$13.0$_$s10ToasterKit5toastyyF$
 // CHECK-ZIPPERED: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit5toastyyF$
+
+// CHECK-NO-NEW-SYMBOL-NOT: $_$s10ToasterKit7VehicleV32originallyDefinedInCurrentModuleyyF


### PR DESCRIPTION
When a top-level decl is marked with @_originallyDefinedIn, some of its members
may also be newly added after the top-level decl has been moved to the current module.
For these members, we don't need emit $ld$previous$ symbols for them.

rdar://60478650