### PR TITLE
Do a little extra validation of RawRepresentable.RawValue

### DIFF
--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -466,7 +466,22 @@ bool DerivedConformance::canDeriveRawRepresentable(DeclContext *DC,
   if (TypeChecker::conformsToProtocol(rawType, equatableProto, DC, None)
           .isInvalid())
     return false;
-  
+
+  auto &C = type->getASTContext();
+  auto rawValueDecls = enumDecl->lookupDirect(DeclName(C.Id_RawValue));
+  if (rawValueDecls.size() > 1)
+    return false;
+
+  // Check that the RawValue matches the expected raw type.
+  if (!rawValueDecls.empty()) {
+    if (auto alias = dyn_cast<TypeDecl>(rawValueDecls.front())) {
+      auto ty = alias->getDeclaredInterfaceType();
+      if (!DC->mapTypeIntoContext(ty)->isEqual(rawType)) {
+        return false;
+      }
+    }
+  }
+
   // There must be enum elements.
   if (enumDecl->getAllElements().empty())
     return false;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -981,6 +981,10 @@ EnumRawValuesRequest::evaluate(Evaluator &eval, EnumDecl *ED,
     return true;
   }
 
+  if (!computeAutomaticEnumValueKind(ED)) {
+    return true;
+  }
+
   if (ED->getGenericEnvironmentOfContext() != nullptr)
     rawTy = ED->mapTypeIntoContext(rawTy);
   if (rawTy->hasError())

--- a/test/Sema/enum_raw_representable.swift
+++ b/test/Sema/enum_raw_representable.swift
@@ -229,3 +229,47 @@ enum NotEquatableRawType3: NotEquatableString {
   var rawValue: Int { 0 }
   // expected-note@-1 {{candidate has non-matching type 'Int'}}
 }
+
+enum MismatchedRawValues {
+  enum ExistentialBound: Any? {
+    // expected-error@-1 {{raw type 'Any?' is not expressible}}
+    // expected-error@-2 {{'MismatchedRawValues.ExistentialBound' declares raw type 'Any?'}}
+    // expected-error@-3 {{RawRepresentable conformance cannot be synthesized }}
+    case test = nil
+  }
+
+  public enum StringViaStaticString: StaticString {
+    // expected-error@-1 {{'MismatchedRawValues.StringViaStaticString' declares raw type 'StaticString', but does not conform to RawRepresentable}}
+    // expected-error@-2 {{RawRepresentable conformance cannot be synthesized because}}
+    public typealias RawValue = String
+
+    case TRUE = "TRUE"
+    case FALSE = "FALSE"
+  }
+
+  public enum IntViaString: String {
+    // expected-error@-1 {{'MismatchedRawValues.IntViaString' declares raw type 'String', but does not conform to RawRepresentable}}
+    public typealias RawValue = Int
+
+    case TRUE = "TRUE"
+    case FALSE = "FALSE"
+  }
+
+  public enum ViaNested: String {
+    // expected-error@-1 {{'MismatchedRawValues.ViaNested' declares raw type 'String', but does not conform to RawRepresentable}}
+    struct RawValue: Equatable {
+      let x: String
+    }
+
+    case TRUE = "TRUE"
+    case FALSE = "FALSE"
+  }
+
+  public enum ViaGenericBound<RawValue: Equatable>: String {
+    // expected-error@-1 {{'MismatchedRawValues.ViaGenericBound<RawValue>' declares raw type 'String'}}
+    typealias RawValue = RawValue
+    case TRUE = "TRUE"
+    case FALSE = "FALSE"
+  }
+}
+


### PR DESCRIPTION
* In the DeclChecker, duplicate the check that we have a reasonable
RawValue type so we do not attempt to form an invalid key. The interface
to the autoincrementer has this as invariant, but it was not previously
checked as a precondition.

* In the deriver, try to check for the case where the user has written
a mismatched explicit declaration of RawValue, or a type sharing that
name, and check type equality with the declared raw type to make this
pass resilient to mismatches as well.

Resolves rdar://57072148, rdar://59703784