### PR TITLE
[opt] remove trivially dead instructions in mandatory combine

### DIFF
--- a/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
@@ -156,6 +156,7 @@ void MandatoryCombiner::addReachableCodeToWorklist(SILFunction &function) {
       ++iterator;
 
       if (isInstructionTriviallyDead(instruction)) {
+        instModCallbacks.deleteInst(instruction);
         continue;
       }
 

--- a/test/AutoDiff/SIL/differentiability_witness_function_inst.sil
+++ b/test/AutoDiff/SIL/differentiability_witness_function_inst.sil
@@ -13,7 +13,7 @@
 
 // IRGen test.
 
-// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s --check-prefix=IRGEN --check-prefix %target-cpu
+// RUN: %target-swift-frontend -emit-ir -Xllvm -sil-disable-pass=MandatoryCombine %s | %FileCheck %s --check-prefix=IRGEN --check-prefix %target-cpu
 // NOTE: `%target-cpu`-specific FileCheck lines exist because lowered function types in LLVM IR differ between architectures.
 
 // NOTE(SR-12090): `shell` is required only to run `sed` as a SR-12090 workaround.

--- a/test/ClangImporter/macro_literals.swift
+++ b/test/ClangImporter/macro_literals.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-debuginfo -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-debuginfo -Xllvm -sil-disable-pass=MandatoryCombine -emit-sil %s | %FileCheck %s
 
 import macros
 

--- a/test/Constraints/keypath_dynamic_member_lookup.swift
+++ b/test/Constraints/keypath_dynamic_member_lookup.swift
@@ -39,17 +39,20 @@ var bottomRight = Point(x: 10, y: 10)
 var lens = Lens(Rectangle(topLeft: topLeft,
                           bottomRight: bottomRight))
 
+// A dummy user of variables.
+func user<T>(_ _: T) {}
+
 // CHECK: function_ref @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs15WritableKeyPathCyxqd__G_tcluig
 // CHECK-NEXT: apply %45<Rectangle, Point>({{.*}})
 // CHECK: function_ref @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs7KeyPathCyxqd__G_tcluig
 // CHECK-NEXT: apply %54<Point, Int>({{.*}})
-_ = lens.topLeft.x
+user(lens.topLeft.x)
 
-// CHECK: function_ref @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs15WritableKeyPathCyxqd__G_tcluig
-// CHECK-NEXT: apply %69<Rectangle, Point>({{.*}})
-// CHECK: function_ref @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs15WritableKeyPathCyxqd__G_tcluig
-// CHECK-NEXT: apply %76<Point, Int>({{.*}})
-_ = lens.topLeft.y
+// CHECK: [[LOOKUP_REF1:%.*]] = function_ref @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs15WritableKeyPathCyxqd__G_tcluig
+// CHECK-NEXT: apply [[LOOKUP_REF1]]<Rectangle, Point>({{.*}})
+// CHECK: [[LOOKUP_REF2:%.*]] = function_ref @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs15WritableKeyPathCyxqd__G_tcluig
+// CHECK-NEXT: apply [[LOOKUP_REF2]]<Point, Int>({{.*}})
+user(lens.topLeft.y)
 
 lens.topLeft = Lens(Point(x: 1, y: 2)) // Ok
 lens.bottomRight.y = Lens(12)          // Ok
@@ -238,7 +241,7 @@ func test_recursive_dynamic_lookup(_ lens: Lens<Lens<Point>>) {
   // CHECK: [[FIRST_OBJ:%.*]] = struct_extract {{.*}} : $Lens<Lens<Point>>, #Lens.obj
   // CHECK-NEXT: [[SECOND_OBJ:%.*]] = struct_extract [[FIRST_OBJ]] : $Lens<Point>, #Lens.obj
   // CHECK-NEXT: struct_extract [[SECOND_OBJ]] : $Point, #Point.y
-  _ = lens.obj.obj.y
+  user(lens.obj.obj.y)
   // CHECK: keypath $KeyPath<Point, Int>, (root $Point; stored_property #Point.x : $Int)
   // CHECK-NEXT: keypath $KeyPath<Lens<Point>, Lens<Int>>, (root $Lens<Point>; gettable_property $Lens<Int>,  id @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs7KeyPathCyxqd__G_tcluig : {{.*}})
   // CHECK-NEXT: keypath $KeyPath<Lens<Lens<Point>>, Lens<Lens<Int>>>, (root $Lens<Lens<Point>>; gettable_property $Lens<Lens<Int>>,  id @$s29keypath_dynamic_member_lookup4LensV0B6MemberACyqd__Gs7KeyPathCyxqd__G_tcluig : {{.*}})

--- a/test/IRGen/access_markers.sil
+++ b/test/IRGen/access_markers.sil
@@ -33,6 +33,9 @@ bb0(%0 : $A):
   // CHECK-NEXT: getelementptr inbounds %Ts5Int64V, %Ts5Int64V* [[PROPERTY]], i32 0, i32 0
   // CHECK-NEXT: load i64, i64*
   %4 = load %3 : $*Int64
+  // Use %4 so it's not optimized away.
+  // CHECK-NEXT: store
+  store %4 to undef : $*Int64
 
   // CHECK-NEXT: call void @swift_endAccess([[BUFFER]]* [[SCRATCH1]])
   // CHECK-NEXT: [[T0:%.*]] = bitcast [[BUFFER]]* [[SCRATCH1]] to i8*
@@ -48,6 +51,9 @@ bb0(%0 : $A):
   // CHECK-NEXT: getelementptr inbounds %Ts5Int64V, %Ts5Int64V* [[PROPERTY]], i32 0, i32 0
   // CHECK-NEXT: load i64, i64*
   %7 = load %6 : $*Int64
+  // Use %7 so it's not optimized away.
+  // CHECK-NEXT: store
+  store %7 to undef : $*Int64
 
   // CHECK-NEXT: call void @swift_endAccess([[BUFFER]]* [[SCRATCH2]])
   // CHECK-NEXT: [[T0:%.*]] = bitcast [[BUFFER]]* [[SCRATCH2]] to i8*

--- a/test/IRGen/dynamic_self.sil
+++ b/test/IRGen/dynamic_self.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=MandatoryCombine -emit-ir %s | %FileCheck %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -254,6 +254,8 @@ entry(%u : $*Singleton):
   switch_enum_addr %u : $*Singleton, case #Singleton.value!enumelt: dest
 dest:
   %u2 = unchecked_take_enum_data_addr %u : $*Singleton, #Singleton.value!enumelt
+  // Use u2 so it's not optimized away.
+  copy_addr %u2 to undef : $*(Builtin.Int64, Builtin.Int64)
   %x = tuple ()
   return %x : $()
 }
@@ -979,6 +981,7 @@ entry(%u : $*SinglePayloadSpareBit):
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T4enum21SinglePayloadSpareBitO* %0 to i63*
 x_dest:
   %u2 = unchecked_take_enum_data_addr %u : $*SinglePayloadSpareBit, #SinglePayloadSpareBit.x!enumelt
+  copy_addr %u2 to undef : $*Builtin.Int63
   %a = function_ref @a : $@convention(thin) () -> ()
   apply %a() : $@convention(thin) () -> ()
   br end
@@ -1489,14 +1492,20 @@ entry(%u : $*MultiPayloadNoSpareBits):
 
 x_dest:
   %x = unchecked_take_enum_data_addr %u : $*MultiPayloadNoSpareBits, #MultiPayloadNoSpareBits.x!enumelt
+  // Dummy use of %x so it's not optimized away.
+  copy_addr %x to undef : $*Builtin.Int64
   br end
 
 y_dest:
   %y = unchecked_take_enum_data_addr %u : $*MultiPayloadNoSpareBits, #MultiPayloadNoSpareBits.y!enumelt
+  // Dummy use of %y so it's not optimized away.
+  copy_addr %y to undef : $*Builtin.Int32
   br end
 
 z_dest:
   %z = unchecked_take_enum_data_addr %u : $*MultiPayloadNoSpareBits, #MultiPayloadNoSpareBits.z!enumelt
+  // Dummy use of %z so it's not optimized away.
+  copy_addr %z to undef : $*Builtin.Int63
   br end
 
 a_dest:
@@ -1742,14 +1751,20 @@ entry(%u : $*MultiPayloadOneSpareBit):
 
 x_dest:
   %x = unchecked_take_enum_data_addr %u : $*MultiPayloadOneSpareBit, #MultiPayloadOneSpareBit.x!enumelt
+  // Dummy use of %x so it's not optimized away.
+  copy_addr %x to undef : $*Builtin.Int62
   br end
 
 y_dest:
   %y = unchecked_take_enum_data_addr %u : $*MultiPayloadOneSpareBit, #MultiPayloadOneSpareBit.y!enumelt
+  // Dummy use of %y so it's not optimized away.
+  copy_addr %y to undef : $*Builtin.Int63
   br end
 
 z_dest:
   %z = unchecked_take_enum_data_addr %u : $*MultiPayloadOneSpareBit, #MultiPayloadOneSpareBit.z!enumelt
+  // Dummy use of %z so it's not optimized away.
+  copy_addr %z to undef : $*Builtin.Int61
   br end
 
 a_dest:
@@ -2441,6 +2456,8 @@ entry(%0 : $*DynamicSingleton<T>):
 
 dest:
   %1 = unchecked_take_enum_data_addr %0 : $*DynamicSingleton<T>, #DynamicSingleton.value!enumelt
+  // Dummy use of %1 so it's not optimized away.
+  copy_addr %1 to undef : $*T
   %v = tuple ()
   return %v : $()
 }
@@ -2521,6 +2538,8 @@ entry(%x : $Int32):
   // CHECK-64: [[INT_SHR:%.*]] = lshr i64 [[INT_SHL]], 32
   // CHECK-64: [[INT:%.*]] = trunc i64 [[INT_SHR]] to i32
   %e = unchecked_enum_data %d : $Optional<(Optional<()>, Int32)>, #Optional.some!enumelt
+  // Use %e so it's not optimized away.
+  store %e to undef : $*(Optional<()>, Int32)
   return %d : $Optional<(Optional<()>, Int32)>
 }
 

--- a/test/IRGen/enum_dynamic_multi_payload.sil
+++ b/test/IRGen/enum_dynamic_multi_payload.sil
@@ -285,8 +285,12 @@ sil @dynamic_project : $@convention(thin) <T> () -> @out EitherOr<T, Builtin.Int
 entry(%e : $*EitherOr<T, Builtin.Int64>):
   // CHECK: bitcast [[EITHER_OR]]* %0 to %swift.opaque*
   %l = unchecked_take_enum_data_addr %e : $*EitherOr<T, Builtin.Int64>, #EitherOr.Left!enumelt
+  // Dummy use of %l so that it's not optimized away.
+  copy_addr %l to undef : $*T
   // CHECK: bitcast [[EITHER_OR]]* %0 to i64*
   %r = unchecked_take_enum_data_addr %e : $*EitherOr<T, Builtin.Int64>, #EitherOr.Right!enumelt
+  // Dummy use of %r so that it's not optimized away.
+  copy_addr %r to undef : $*Builtin.Int64
 
   return undef : $()
 }

--- a/test/IRGen/enum_future.sil
+++ b/test/IRGen/enum_future.sil
@@ -258,6 +258,7 @@ entry(%u : $*Singleton):
   switch_enum_addr %u : $*Singleton, case #Singleton.value!enumelt: dest
 dest:
   %u2 = unchecked_take_enum_data_addr %u : $*Singleton, #Singleton.value!enumelt
+  copy_addr %u2 to undef : $*(Builtin.Int64, Builtin.Int64)
   %x = tuple ()
   return %x : $()
 }
@@ -983,6 +984,7 @@ entry(%u : $*SinglePayloadSpareBit):
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T11enum_future21SinglePayloadSpareBitO* %0 to i63*
 x_dest:
   %u2 = unchecked_take_enum_data_addr %u : $*SinglePayloadSpareBit, #SinglePayloadSpareBit.x!enumelt
+  copy_addr %u2 to undef : $*Builtin.Int63
   %a = function_ref @a : $@convention(thin) () -> ()
   apply %a() : $@convention(thin) () -> ()
   br end
@@ -1493,14 +1495,20 @@ entry(%u : $*MultiPayloadNoSpareBits):
 
 x_dest:
   %x = unchecked_take_enum_data_addr %u : $*MultiPayloadNoSpareBits, #MultiPayloadNoSpareBits.x!enumelt
+  // Use %x so it's not optimized away.
+  copy_addr %x to undef : $*Builtin.Int64
   br end
 
 y_dest:
   %y = unchecked_take_enum_data_addr %u : $*MultiPayloadNoSpareBits, #MultiPayloadNoSpareBits.y!enumelt
+  // Use %y so it's not optimized away.
+  copy_addr %y to undef : $*Builtin.Int32
   br end
 
 z_dest:
   %z = unchecked_take_enum_data_addr %u : $*MultiPayloadNoSpareBits, #MultiPayloadNoSpareBits.z!enumelt
+  // Use %z so it's not optimized away.
+  copy_addr %z to undef : $*Builtin.Int63
   br end
 
 a_dest:
@@ -1746,14 +1754,20 @@ entry(%u : $*MultiPayloadOneSpareBit):
 
 x_dest:
   %x = unchecked_take_enum_data_addr %u : $*MultiPayloadOneSpareBit, #MultiPayloadOneSpareBit.x!enumelt
+  // Use %x so it's not optimized away.
+  copy_addr %x to undef : $*Builtin.Int62
   br end
 
 y_dest:
   %y = unchecked_take_enum_data_addr %u : $*MultiPayloadOneSpareBit, #MultiPayloadOneSpareBit.y!enumelt
+  // Use %y so it's not optimized away.
+  copy_addr %y to undef : $*Builtin.Int63
   br end
 
 z_dest:
   %z = unchecked_take_enum_data_addr %u : $*MultiPayloadOneSpareBit, #MultiPayloadOneSpareBit.z!enumelt
+  // Use %z so it's not optimized away.
+  copy_addr %z to undef : $*Builtin.Int61
   br end
 
 a_dest:
@@ -2445,6 +2459,8 @@ entry(%0 : $*DynamicSingleton<T>):
 
 dest:
   %1 = unchecked_take_enum_data_addr %0 : $*DynamicSingleton<T>, #DynamicSingleton.value!enumelt
+  // Use %1 so it's not optimized away.
+  copy_addr %1 to undef : $*T
   %v = tuple ()
   return %v : $()
 }
@@ -2525,6 +2541,8 @@ entry(%x : $Int32):
   // CHECK-64: [[INT_SHR:%.*]] = lshr i64 [[INT_SHL]], 32
   // CHECK-64: [[INT:%.*]] = trunc i64 [[INT_SHR]] to i32
   %e = unchecked_enum_data %d : $Optional<(Optional<()>, Int32)>, #Optional.some!enumelt
+  // Use %e so it's not optimized away.
+  store %e to undef : $*(Optional<()>, Int32)
   return %d : $Optional<(Optional<()>, Int32)>
 }
 

--- a/test/IRGen/existentials.sil
+++ b/test/IRGen/existentials.sil
@@ -73,12 +73,16 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
   // CHECK: [[SRC_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 1
   // CHECK: [[DEST_WITNESS:%.*]] = load i8**, i8*** [[SRC_WITNESS_ADDR]]
   %b = load_weak [take] %w : $*@sil_weak CP?
+  // Use %b so it isn't removed.
+  store_weak %b to undef : $*@sil_weak CP?
 
   // CHECK: [[SRC_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 0
   // CHECK: [[DEST_REF:%.*]] = call %swift.refcounted* @swift_weakLoadStrong(%swift.weak* [[SRC_REF_ADDR]])
   // CHECK: [[SRC_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 1
   // CHECK: [[DEST_WITNESS:%.*]] = load i8**, i8*** [[SRC_WITNESS_ADDR]]
   %c = load_weak        %w : $*@sil_weak CP?
+  // Use %c so it isn't removed.
+  store_weak %c to undef : $*@sil_weak CP?
 
   // CHECK: call { %swift.weak, i8** }* @"$s12existentials2CP_pSgXwWOb"({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr [take] %w to [initialization] %v : $*@sil_weak CP?

--- a/test/IRGen/existentials_objc.sil
+++ b/test/IRGen/existentials_objc.sil
@@ -127,12 +127,16 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
   // CHECK: [[SRC_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 1
   // CHECK: [[DEST_WITNESS:%.*]] = load i8**, i8*** [[SRC_WITNESS_ADDR]]
   %b = load_weak [take] %w : $*@sil_weak CP?
+  // Use the value so it's not optimized away.
+  store_weak %b to undef : $*@sil_weak CP?
 
   // CHECK: [[SRC_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 0
   // CHECK: [[DEST_REF:%.*]] = call %objc_object* @swift_unknownObjectWeakLoadStrong(%swift.weak* [[SRC_REF_ADDR]])
   // CHECK: [[SRC_WITNESS_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 1
   // CHECK: [[DEST_WITNESS:%.*]] = load i8**, i8*** [[SRC_WITNESS_ADDR]]
   %c = load_weak        %w : $*@sil_weak CP?
+  // Use the value so it's not optimized away.
+  store_weak %c to undef : $*@sil_weak CP?
 
   // CHECK: call { %swift.weak, i8** }* @"$s17existentials_objc2CP_pSgXwWOb"({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr [take] %w to [initialization] %v : $*@sil_weak CP?

--- a/test/IRGen/existentials_opaque_boxed.sil
+++ b/test/IRGen/existentials_opaque_boxed.sil
@@ -200,6 +200,8 @@ entry:
 sil @test_open_existential_addr_immutable :$@convention(thin) (@in Existential) -> () {
 bb0(%0 : $*Existential):
   %1 = open_existential_addr immutable_access %0 : $*Existential to $*@opened("01234567-89ab-cdef-0123-000000000000") Existential
+  // Use %1 so it's not optimized away.
+  copy_addr %1 to undef : $*@opened("01234567-89ab-cdef-0123-000000000000") Existential
 	%t = tuple()
   return %t : $()
 }
@@ -247,6 +249,8 @@ bb0(%0 : $*Existential):
 sil @test_open_existential_addr_mutable :$@convention(thin) (@in Existential) -> () {
 bb0(%0 : $*Existential):
   %1 = open_existential_addr mutable_access %0 : $*Existential to $*@opened("01234567-89ab-cdef-0123-000000000001") Existential
+  // Use %1 so it's not optimized away.
+  copy_addr %1 to undef : $*@opened("01234567-89ab-cdef-0123-000000000001") Existential
 	%t = tuple()
   return %t : $()
 }

--- a/test/IRGen/fixed_layout_class.swift
+++ b/test/IRGen/fixed_layout_class.swift
@@ -10,23 +10,25 @@
 // This tests @_fixed_layout classes in resilient modules.
 import fixed_layout_class
 
+func blackHole<T>(_ _ : T) { }
+
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s16class_resilience20useRootClassPropertyyy013fixed_layout_A0026OutsideParentWithResilientF0CF"(%T18fixed_layout_class34OutsideParentWithResilientPropertyC* %0)
 public func useRootClassProperty(_ o: OutsideParentWithResilientProperty) {
   // CHECK: getelementptr inbounds %T18fixed_layout_class34OutsideParentWithResilientPropertyC, %T18fixed_layout_class34OutsideParentWithResilientPropertyC* %0, i32 0, i32 1
-  _ = o.p
+  blackHole(o.p)
   // CHECK: load [[INT]], [[INT]]* @"$s18fixed_layout_class34OutsideParentWithResilientPropertyC1s16resilient_struct4SizeVvpWvd"
-  _ = o.s
+  blackHole(o.s)
   // CHECK: load [[INT]], [[INT]]* @"$s18fixed_layout_class34OutsideParentWithResilientPropertyC5colors5Int32VvpWvd"
-  _ = o.color
+  blackHole(o.color)
   // CHECK: ret void
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s16class_resilience19useSubclassPropertyyy013fixed_layout_A012OutsideChildCF"(%T18fixed_layout_class12OutsideChildC* %0)
 public func useSubclassProperty(_ o: OutsideChild) {
-  // CHECK: getelementptr inbounds %T18fixed_layout_class13OutsideParentC, %T18fixed_layout_class13OutsideParentC* %4, i32 0, i32 1
-  _ = o.property
+  // CHECK: getelementptr inbounds %T18fixed_layout_class13OutsideParentC, %T18fixed_layout_class13OutsideParentC* %6, i32 0, i32 1
+  blackHole(o.property)
   // CHECK: getelementptr inbounds %T18fixed_layout_class12OutsideChildC, %T18fixed_layout_class12OutsideChildC* %0, i32 0, i32 2
-  _ = o.childProperty
+  blackHole(o.childProperty)
   // CHECK: ret void
 }
 
@@ -47,7 +49,7 @@ public func useGenericRootClassProperty<A>(_ o: GenericOutsideParent<A>) {
   // CHECK: [[FIELD_OFFSET_ADDR:%.*]] = getelementptr inbounds i8, i8* [[METADATA_ADDR]], [[INT]] [[FIELD_OFFSET_OFFSET]]
   // CHECK: [[FIELD_OFFSET_PTR:%.*]] = bitcast i8* [[FIELD_OFFSET_ADDR]] to [[INT]]*
   // CHECK: [[FIELD_OFFSET:%.*]] = load [[INT]], [[INT]]* [[FIELD_OFFSET_PTR]]
-  _ = o.property
+  blackHole(o.property)
 
   // CHECK: ret void
 }
@@ -55,7 +57,7 @@ public func useGenericRootClassProperty<A>(_ o: GenericOutsideParent<A>) {
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s16class_resilience27useGenericRootClassPropertyyy013fixed_layout_A00D13OutsideParentCySiGF"(%T18fixed_layout_class20GenericOutsideParentCySiG* %0)
 public func useGenericRootClassProperty(_ o: GenericOutsideParent<Int>) {
   // CHECK: getelementptr inbounds %T18fixed_layout_class20GenericOutsideParentCySiG, %T18fixed_layout_class20GenericOutsideParentCySiG* %0, i32 0, i32 1
-  _ = o.property
+  blackHole(o.property)
 
   // CHECK: ret void
 }
@@ -78,7 +80,7 @@ public func useGenericSubclassProperty<A>(_ o: GenericOutsideChild<A>) {
   // CHECK: [[FIELD_OFFSET_ADDR:%.*]] = getelementptr inbounds i8, i8* [[METADATA_ADDR]], [[INT]] [[FIELD_OFFSET_OFFSET]]
   // CHECK: [[FIELD_OFFSET_PTR:%.*]] = bitcast i8* [[FIELD_OFFSET_ADDR]] to [[INT]]*
   // CHECK: [[FIELD_OFFSET:%.*]] = load [[INT]], [[INT]]* [[FIELD_OFFSET_PTR]]
-  _ = o.property
+  blackHole(o.property)
 
   // CHECK: [[METADATA_ADDR:%.*]] = getelementptr inbounds %T18fixed_layout_class19GenericOutsideChildC, %T18fixed_layout_class19GenericOutsideChildC* %0, i32 0, i32 0, i32 0
   // CHECK: [[METADATA:%.*]] = load %swift.type*, %swift.type** [[METADATA_ADDR]]
@@ -90,7 +92,7 @@ public func useGenericSubclassProperty<A>(_ o: GenericOutsideChild<A>) {
   // CHECK: [[FIELD_OFFSET_ADDR:%.*]] = getelementptr inbounds i8, i8* [[METADATA_ADDR]], [[INT]] [[FIELD_OFFSET_OFFSET]]
   // CHECK: [[FIELD_OFFSET_PTR:%.*]] = bitcast i8* [[FIELD_OFFSET_ADDR]] to [[INT]]*
   // CHECK: [[FIELD_OFFSET:%.*]] = load [[INT]], [[INT]]* [[FIELD_OFFSET_PTR]]
-  _ = o.childProperty
+  blackHole(o.childProperty)
 
   // CHECK: ret void
 }
@@ -99,10 +101,10 @@ public func useGenericSubclassProperty<A>(_ o: GenericOutsideChild<A>) {
 public func useGenericSubclassProperty(_ o: GenericOutsideChild<Int>) {
   // CHECK: [[UPCAST:%.*]] = bitcast %T18fixed_layout_class19GenericOutsideChildCySiG* %0 to %T18fixed_layout_class20GenericOutsideParentCySiG*
   // CHECK: getelementptr inbounds %T18fixed_layout_class20GenericOutsideParentCySiG, %T18fixed_layout_class20GenericOutsideParentCySiG* [[UPCAST]], i32 0, i32 1
-  _ = o.property
+  blackHole(o.property)
 
   // CHECK: getelementptr inbounds %T18fixed_layout_class19GenericOutsideChildCySiG, %T18fixed_layout_class19GenericOutsideChildCySiG* %0, i32 0, i32 2
-  _ = o.childProperty
+  blackHole(o.childProperty)
 
   // CHECK: ret void
 }
@@ -112,7 +114,7 @@ public func callVirtualMethod(_ o: OutsideParent) {
   // Note: virtual method calls still use dispatch thunks
 
   // CHECK: call swiftcc void @"$s18fixed_layout_class13OutsideParentC6methodyyFTj"
-  _ = o.method()
+  blackHole(o.method())
 
   // CHECK: ret void
 }

--- a/test/IRGen/foreign_types.sil
+++ b/test/IRGen/foreign_types.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-generic-metadata-prespecialization -I %S/Inputs/abi %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=MandatoryCombine -disable-generic-metadata-prespecialization -I %S/Inputs/abi %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize
 
 sil_stage canonical
 import c_layout

--- a/test/IRGen/foreign_types_future.sil
+++ b/test/IRGen/foreign_types_future.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -I %S/Inputs/abi %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=MandatoryCombine -prespecialize-generic-metadata -target %module-target-future -I %S/Inputs/abi %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize
 
 // REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios

--- a/test/IRGen/global_resilience.sil
+++ b/test/IRGen/global_resilience.sil
@@ -66,6 +66,8 @@ bb0:
   // CHECK: [[VALUE:%.*]] = load i32, i32* getelementptr inbounds (%T17global_resilience20SmallResilientStructV, %T17global_resilience20SmallResilientStructV* bitcast ([[BUFFER]]* @smallGlobal to %T17global_resilience20SmallResilientStructV*), i32 0, i32 0, i32 0)
   %x_addr = struct_element_addr %addr : $*SmallResilientStruct, #SmallResilientStruct.x
   %x = load %x_addr : $*Int32
+  // Dummy use so that x isn't optimized away.
+  store %x to undef : $*Int32
 
   %tuple = tuple ()
 
@@ -82,6 +84,8 @@ bb0:
 
   // CHECK: [[VALUE:%.*]] = load %T17global_resilience20LargeResilientStructV*, %T17global_resilience20LargeResilientStructV** bitcast ([[BUFFER]]* @largeGlobal to %T17global_resilience20LargeResilientStructV**)
   %addr = global_addr @largeGlobal : $*LargeResilientStruct
+  // Dummy use so that addr isn't optimized away.
+  copy_addr %addr to undef : $*LargeResilientStruct
 
   %tuple = tuple ()
 
@@ -99,6 +103,8 @@ bb0:
   // CHECK:      load i64, i64* getelementptr inbounds (%T17global_resilience20LargeResilientStructV, %T17global_resilience20LargeResilientStructV* @fixedGlobal, i32 0, i32 1, i32 0)
   %x_addr = struct_element_addr %addr : $*LargeResilientStruct, #LargeResilientStruct.x
   %x = load %x_addr : $*Int64
+  // Dummy use so that x isn't optimized away.
+  store %x to undef : $*Int64
 
   %tuple = tuple ()
 
@@ -116,6 +122,8 @@ bb0:
 
   // CHECK: call %swift.opaque* @__swift_project_value_buffer(%swift.type* [[METADATA]], %swift.opaque* bitcast ([{{.*}} x i8]* @otherGlobal to %swift.opaque*))
   %addr = global_addr @otherGlobal : $*Size
+  // Dummy use so that addr isn't optimized away.
+  copy_addr %addr to undef : $*Size
 
   %tuple = tuple ()
 

--- a/test/IRGen/indexing.sil
+++ b/test/IRGen/indexing.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=MandatoryCombine %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/invariant_load.sil
+++ b/test/IRGen/invariant_load.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=MandatoryCombine -emit-ir %s | %FileCheck %s
 
 // REQUIRES: rdar60068448
 // FIXME Reenable the !invariant.load metadata after debugging miscompiles...

--- a/test/IRGen/metatype.sil
+++ b/test/IRGen/metatype.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend -sdk %S/Inputs -I %t -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=MandatoryCombine -sdk %S/Inputs -I %t -emit-ir %s | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/mixed_mode_class_with_unimportable_fields.sil
+++ b/test/IRGen/mixed_mode_class_with_unimportable_fields.sil
@@ -55,6 +55,8 @@ entry:
   // CHECK-V5-32: call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[METADATA]], [[WORD]] 40, [[WORD]] 7)
   // CHECK-V5-64: call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[METADATA]], [[WORD]] 56, [[WORD]] 7)
   %y = alloc_ref $SubButtHolder
+  // Use %y so it's not removed.
+  store %y to undef : $*SubButtHolder
   // CHECK-V4: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$s4main03SubB10ButtHolderCMa"([[WORD]] 0)
   // CHECK-V4: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
   // CHECK-V4: call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[METADATA]], [[WORD]] %{{.*}}, [[WORD]] %{{.*}})
@@ -64,5 +66,7 @@ entry:
   // CHECK-V5-32: call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[METADATA]], [[WORD]] 48, [[WORD]] 7)
   // CHECK-V5-64: call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[METADATA]], [[WORD]] 64, [[WORD]] 7)
   %z = alloc_ref $SubSubButtHolder
+  // Use %z so it's not removed.
+  store %z to undef : $*SubSubButtHolder
   return %x : $ButtHolder
 }

--- a/test/IRGen/objc_block_storage.sil
+++ b/test/IRGen/objc_block_storage.sil
@@ -92,6 +92,8 @@ entry(%0 : $*@block_storage Builtin.RawPointer):
 sil @invoke_trivial : $@convention(c) (@inout_aliasable @block_storage Builtin.RawPointer) -> () {
 entry(%0 : $*@block_storage Builtin.RawPointer):
   %c = project_block_storage %0 : $*@block_storage Builtin.RawPointer
+  // Use %c so it's not optimized away.
+  copy_addr %c to undef : $*Builtin.RawPointer
   return undef : $()
 }
 

--- a/test/IRGen/partial_apply_forwarder.sil
+++ b/test/IRGen/partial_apply_forwarder.sil
@@ -140,15 +140,6 @@ bb0(%0 : $*τ_0_1, %2: $EmptyType):
   return %9 : $@callee_owned () -> ()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @bind_polymorphic_param_from_forwarder_parameter(%swift.opaque* noalias nocapture %0, %swift.type* %"\CF\84_0_1")
-// CHECK: entry:
-// CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$s23partial_apply_forwarder12BaseProducerVMa"([[INT]] 255, %swift.type* %"\CF\84_0_1")
-// CHECK:   [[BPTY:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
-// CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$s23partial_apply_forwarder7WeakBoxCMa"([[INT]] 0, %swift.type* [[BPTY]]
-// CHECK:   [[WBTY:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
-// CHECK:   call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[WBTY]]
-// CHECK:   ret void
-
 // CHECK-LABEL: define internal swiftcc void @"$s7takingQTA.1"(%T23partial_apply_forwarder7WeakBoxC* %0, %swift.refcounted* swiftself %1)
 // CHECK: entry:
 // CHECK:   [[TYADDR:%.*]] = getelementptr inbounds %T23partial_apply_forwarder7WeakBoxC, %T23partial_apply_forwarder7WeakBoxC* %0

--- a/test/IRGen/ptrauth-foreign.sil
+++ b/test/IRGen/ptrauth-foreign.sil
@@ -1,4 +1,4 @@
-// RUN: %swift -module-name test -import-objc-header %S/Inputs/ptrauth-foreign.h %s -parse-stdlib -parse-as-library -emit-ir -target arm64e-apple-ios12.0  | %FileCheck %s --check-prefix=CHECK
+// RUN: %swift -module-name test -import-objc-header %S/Inputs/ptrauth-foreign.h %s -parse-stdlib -parse-as-library -emit-ir -target arm64e-apple-ios12.0 -Xllvm -sil-disable-pass=MandatoryCombine  | %FileCheck %s --check-prefix=CHECK
 
 // REQUIRES: CPU=arm64e
 // REQUIRES: OS=ios

--- a/test/IRGen/select_enum.sil
+++ b/test/IRGen/select_enum.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -gnone -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=MandatoryCombine -gnone -emit-ir %s | %FileCheck %s
 
 import Builtin
 

--- a/test/IRGen/struct_resilience.swift
+++ b/test/IRGen/struct_resilience.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/../Inputs/resilient_enum.swift
-// RUN: %target-swift-frontend -module-name struct_resilience -I %t -emit-ir -enable-library-evolution %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=MandatoryCombine -module-name struct_resilience -I %t -emit-ir -enable-library-evolution %s | %FileCheck %s
 // RUN: %target-swift-frontend -module-name struct_resilience -I %t -emit-ir -enable-library-evolution -O %s
 
 import resilient_struct

--- a/test/IRGen/super.sil
+++ b/test/IRGen/super.sil
@@ -222,6 +222,8 @@ sil_vtable Derived {
 sil @test_super_method_of_generic_base : $@convention(method) (@guaranteed Derived) -> () {
 bb0(%0 : $Derived):
   %4 = super_method %0 : $Derived, #Base.Method : <T where T : Proto> (Base<T>) -> () -> () , $@convention(method) <τ_0_0 where τ_0_0 : Proto> (@guaranteed Base<τ_0_0>) -> ()
+  // Use of %4 so it's not removed.
+  store %4 to undef : $*@convention(method) <τ_0_0 where τ_0_0 : Proto> (@guaranteed Base<τ_0_0>) -> ()
   %7 = tuple ()
   return %7 : $()
 }

--- a/test/IRGen/upcast.sil
+++ b/test/IRGen/upcast.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=MandatoryCombine %s -emit-ir | %FileCheck %s
 
 // Make sure that we are able to lower upcast addresses.
 

--- a/test/SIL/Serialization/Inputs/def_public_non_abi.sil
+++ b/test/SIL/Serialization/Inputs/def_public_non_abi.sil
@@ -5,6 +5,7 @@ sil non_abi [serialized] @other_public_non_abi_function : $@convention(thin) () 
 
 sil non_abi [serialized] @public_non_abi_function : $@convention(thin) () -> () {
   %fn = function_ref @other_public_non_abi_function : $@convention(thin) () -> ()
+  apply %fn() : $@convention(thin) () -> ()
   %0 = tuple ()
   return %0 : $()
 }

--- a/test/SIL/Serialization/globals.sil
+++ b/test/SIL/Serialization/globals.sil
@@ -21,6 +21,8 @@ sil_global [serialized] @serialized_global : $Int
 sil [serialized] @uses_public_global : $@convention(thin) () -> () {
 bb0:
   %1 = global_addr @public_global_used : $*Int
+  // Use %1 so that it's not optimized away.
+  copy_addr %1 to undef : $*Int
   %2 = tuple ()
   return %2 : $()
 }

--- a/test/SIL/Serialization/public_non_abi.sil
+++ b/test/SIL/Serialization/public_non_abi.sil
@@ -15,6 +15,7 @@ import Swift
 sil @top_level_code : $@convention(thin) () -> () {
 bb0:
   %0 = function_ref @public_non_abi_function : $@convention(thin) () -> ()
+  apply %0() : $@convention(thin) () -> ()
   %1 = tuple ()
   return %1 : $()
 }

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -808,7 +808,6 @@ func retain(ptr: Builtin.NativeObject) {
 // CANONICAL-NEXT:   debug_value
 // CANONICAL-NEXT:   strong_release [[P]]
 // CANONICAL-NEXT:   tuple
-// CANONICAL-NEXT:   tuple
 // CANONICAL-NEXT:   return
 // CANONICAL: } // end sil function '$s8builtins7release{{[_0-9a-zA-Z]*}}F'
 

--- a/test/SILOptimizer/definite_init_value_types.swift
+++ b/test/SILOptimizer/definite_init_value_types.swift
@@ -35,7 +35,6 @@ enum ValueEnum {
   // CHECK:        [[BOOL:%.*]] = struct_extract %0 : $Bool, #Bool._value
   // CHECK-NEXT:   cond_br [[BOOL]], bb1, bb2
   // CHECK:      bb1:
-  // CHECK-NEXT:   [[METATYPE:%.*]] = metatype $@thin ValueEnum.Type
   // CHECK-NEXT:   [[NEW_SELF:%.*]] = enum $ValueEnum, #ValueEnum.b!enumelt
   // CHECK-NEXT:   [[SELF_ACCESS:%.*]] = begin_access [modify] [static] [[SELF_BOX]]
   // CHECK-NEXT:   [[NEW_STATE:%.*]] = integer_literal $Builtin.Int1, -1
@@ -46,7 +45,6 @@ enum ValueEnum {
   // CHECK:      bb2:
   // CHECK-NEXT:   br bb3
   // CHECK:      bb3:
-  // CHECK-NEXT:   [[METATYPE:%.*]] = metatype $@thin ValueEnum.Type
   // CHECK-NEXT:   [[NEW_SELF:%.*]] = enum $ValueEnum, #ValueEnum.c!enumelt
   // CHECK-NEXT:   [[SELF_ACCESS:%.*]] = begin_access [modify] [static] [[SELF_BOX]]
   // CHECK-NEXT:   [[STATE_VALUE:%.*]] = load [[STATE]]

--- a/test/SILOptimizer/generic_inline_self.swift
+++ b/test/SILOptimizer/generic_inline_self.swift
@@ -53,8 +53,6 @@ class C : P {
 // CHECK-NEXT:    [[STATIC_METATYPE:%.*]] = upcast [[METATYPE]] : $@thick @dynamic_self C.Type to $@thick C.Type
 // CHECK-NEXT:    [[FN:%.*]] = class_method [[STATIC_METATYPE]] : $@thick C.Type, #C.init!allocator : (C.Type) -> () -> C, $@convention(method) (@thick C.Type) -> @owned C
 // CHECK-NEXT:    [[RESULT2:%.*]] = apply [[FN]]([[STATIC_METATYPE]]) : $@convention(method) (@thick C.Type) -> @owned C
-// CHECK-NEXT:    tuple ()
-// CHECK-NEXT:    tuple ()
 // CHECK-NEXT:    return %5 : $C
   func returnsNewInstanceTransparentProtocol() -> Self {
     return makeInstanceTransparentProtocol(type(of: self))

--- a/test/SILOptimizer/mandatory_inlining.swift
+++ b/test/SILOptimizer/mandatory_inlining.swift
@@ -153,12 +153,15 @@ func class_constrained_generic<T : C>(_ o: T) -> AnyClass? {
   return T.self
 }
 
+@inline(never)
+func blackHole<T>(_ _ : T) { }
+
 // CHECK-LABEL: sil hidden @$s18mandatory_inlining6invokeyyAA1CCF : $@convention(thin) (@guaranteed C) -> () {
 func invoke(_ c: C) {
   // CHECK-NOT: function_ref @$s18mandatory_inlining25class_constrained_generic{{[_0-9a-zA-Z]*}}F
   // CHECK-NOT: apply
   // CHECK: init_existential_metatype
-  _ = class_constrained_generic(c)
+  blackHole(class_constrained_generic(c))
   // CHECK: return
 }
 

--- a/test/Serialization/basic_sil.swift
+++ b/test/Serialization/basic_sil.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-module -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -Xfrontend -enable-objc-interop -o %t/def_basic.swiftmodule %S/Inputs/def_basic.sil
+// RUN: %target-build-swift -Xllvm -sil-disable-pass=MandatoryCombine -emit-module -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -Xfrontend -enable-objc-interop -o %t/def_basic.swiftmodule %S/Inputs/def_basic.sil
 // RUN: llvm-bcanalyzer %t/def_basic.swiftmodule | %FileCheck %s
 // RUN: %target-build-swift -emit-sil -I %t %s -o %t/basic_sil.sil
 // RUN: %target-sil-opt -I %t %t/basic_sil.sil -performance-linker | %FileCheck %S/Inputs/def_basic.sil

--- a/test/Serialization/basic_sil_objc.swift
+++ b/test/Serialization/basic_sil_objc.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Xfrontend %clang-importer-sdk -I %S/../Inputs/clang-importer-sdk/swift-modules -emit-module -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -o %t/def_basic_objc.swiftmodule %S/Inputs/def_basic_objc.sil
+// RUN: %target-build-swift -Xllvm -sil-disable-pass=MandatoryCombine -Xfrontend %clang-importer-sdk -I %S/../Inputs/clang-importer-sdk/swift-modules -emit-module -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -o %t/def_basic_objc.swiftmodule %S/Inputs/def_basic_objc.sil
 // RUN: llvm-bcanalyzer %t/def_basic_objc.swiftmodule | %FileCheck %s
 
 // RUN: %target-build-swift -Xfrontend %clang-importer-sdk -emit-sil -I %t %s -o %t/basic_sil_objc.sil

--- a/test/Serialization/sil_partial_apply_ownership.sil
+++ b/test/Serialization/sil_partial_apply_ownership.sil
@@ -47,7 +47,6 @@ sil @use : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> ()
 
 // CHECK-LABEL: sil @partial_apply_convert
 // CHECK:   convert_escape_to_noescape %{{.*}} : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
-// CHECK:   convert_escape_to_noescape [not_guaranteed] %
 sil @partial_apply_convert : $@convention(thin) () -> () {
 entry:
   %f = function_ref @subject : $@convention(thin) (Builtin.Int64) -> ()


### PR DESCRIPTION
<!-- What's in this pull request? -->
Except for all the test changes, this patch should be very simple. When mandatory combine iterates over all instructions it already checks if they're trivially dead. Now, if they are trivially dead, they will be erased. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
