### PR TITLE
Updated a comment on LookUpConformance to reflect current implementation

### DIFF
--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1054,8 +1054,7 @@ public:
                      SourceLoc ComplainLoc = SourceLoc());
 
   /// Functor class suitable for use as a \c LookupConformanceFn to look up a
-  /// conformance through a particular declaration context using the given
-  /// type checker.
+  /// conformance through a particular declaration context.
   class LookUpConformance {
     DeclContext *dc;
 


### PR DESCRIPTION
LookUpConformance does not depend on a type checker instance anymore.
