### PR TITLE
IRGen: Unique method descriptors in objc method lists

### DIFF
--- a/lib/IRGen/GenObjC.h
+++ b/lib/IRGen/GenObjC.h
@@ -155,7 +155,8 @@ namespace irgen {
   /// constructor, or destructor implementation.
   void emitObjCMethodDescriptor(IRGenModule &IGM,
                                 ConstantArrayBuilder &descriptors,
-                                AbstractFunctionDecl *method);
+                                AbstractFunctionDecl *method,
+                                llvm::StringSet<> &uniqueSelectors);
 
   /// Build an Objective-C method descriptor for the ivar initializer
   /// or destroyer of a class (-.cxx_construct or -.cxx_destruct).
@@ -163,7 +164,8 @@ namespace irgen {
                                          ConstantArrayBuilder &descriptors,
                                          ClassDecl *cd,
                                          llvm::Function *impl,
-                                         bool isDestroyer);
+                                         bool isDestroyer,
+                                         llvm::StringSet<> &uniqueSelectors);
 
   /// Get the type encoding for an ObjC property.
   void getObjCEncodingForPropertyType(IRGenModule &IGM, VarDecl *property,

--- a/test/IRGen/objc_protocol_instance_methods.swift
+++ b/test/IRGen/objc_protocol_instance_methods.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir %s | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+
+// Make sure we don't emit duplicate method descriptors
+
+// CHECK-NOT: _PROTOCOL_INSTANCE_METHODS_NSObject{{.*}}"\01L_selector_data(conformsToProtocol:)"{{.*}}"\01L_selector_data(conformsToProtocol:)"
+
+import Foundation
+
+@objc protocol P: NSObjectProtocol {}
+class C: NSObject, P {}


### PR DESCRIPTION
Before this patch we used to get duplicate entries because we would
define implicit function delcarations, e.g for

(func_decl "perform(_:)" interface type='<Self where Self : NSObjectProtocol> (Self) -> (Selector?) -> Unmanaged<AnyObject>?' access=public @objc
  (parameter "self")
  (parameter_list
    (parameter "aSelector" type='Selector?' interface type='Selector?')))

we will define:

(func_decl implicit "performSelector(_:)" access=public @objc
  (parameter "self")
  (parameter_list
    (parameter "aSelector" type='Selector?' interface type='Selector?')))

rdar://60461850