### PR TITLE
[test] Update uses of llvm-objdump to --long options

### DIFF
--- a/test/ClangImporter/pch-bridging-header.swift
+++ b/test/ClangImporter/pch-bridging-header.swift
@@ -13,7 +13,7 @@
 // Test the driver-automated version works by default
 // RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -typecheck -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header.h
 // RUN: ls %t/tmp/*.pch >/dev/null 2>&1
-// RUN: llvm-objdump -raw-clang-ast %t/tmp/*.pch | llvm-bcanalyzer -dump | %FileCheck %s
+// RUN: llvm-objdump --raw-clang-ast %t/tmp/*.pch | llvm-bcanalyzer -dump | %FileCheck %s
 // CHECK: ORIGINAL_FILE{{.*}}Inputs/sdk-bridging-header.h
 
 // Test the driver-automated version deletes its PCH file when done
@@ -39,7 +39,7 @@
 // Test the driver-automated version using persistent PCH
 // RUN: %target-swiftc_driver -typecheck -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header.h -pch-output-dir %t/pch3
 // RUN: ls %t/pch3/*.pch >/dev/null 2>&1
-// RUN: llvm-objdump -raw-clang-ast %t/pch3/*.pch | llvm-bcanalyzer -dump | %FileCheck %s -check-prefix=PERSISTENT
+// RUN: llvm-objdump --raw-clang-ast %t/pch3/*.pch | llvm-bcanalyzer -dump | %FileCheck %s -check-prefix=PERSISTENT
 // PERSISTENT: ORIGINAL_FILE{{.*}}Inputs/sdk-bridging-header.h
 
 // Test that -pch-disable-validation works in that it won't implicitely create a PCH

--- a/test/Frontend/embed-bitcode-tvos.ll
+++ b/test/Frontend/embed-bitcode-tvos.ll
@@ -1,7 +1,7 @@
 ; REQUIRES: CODEGENERATOR=AArch64
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: %swift -target arm64-apple-tvos9 -c -module-name someModule -embed-bitcode -disable-llvm-optzns -o %t2.o %t.bc -dump-clang-diagnostics 2> %t.diags.txt
-; RUN: llvm-objdump -macho -private-headers %t2.o | %FileCheck %s
+; RUN: llvm-objdump --macho --private-headers %t2.o | %FileCheck %s
 ; RUN: %FileCheck -check-prefix CHECK-IMPORTER %s < %t.diags.txt
 
 target triple = "arm64-apple-tvos9.0"

--- a/test/Frontend/embed-bitcode.ll
+++ b/test/Frontend/embed-bitcode.ll
@@ -6,18 +6,18 @@
 ; serialized in the object file.
 
 ; RUN: %swiftc_driver_plain -frontend -target x86_64-apple-darwin10 -c -module-name someModule -embed-bitcode -disable-llvm-optzns -Xllvm -time-passes -o %t2.o %t.bc -dump-clang-diagnostics 2> %t.diags.txt
-; RUN: llvm-objdump -macho -section="__LLVM,__bitcode" %t2.o | %FileCheck %s
-; RUN: llvm-objdump -macho -section="__LLVM,__swift_cmdline" %t2.o | %FileCheck -check-prefix=CHECK-CMD %s
+; RUN: llvm-objdump --macho --section="__LLVM,__bitcode" %t2.o | %FileCheck %s
+; RUN: llvm-objdump --macho --section="__LLVM,__swift_cmdline" %t2.o | %FileCheck -check-prefix=CHECK-CMD %s
 ; RUN: %FileCheck -check-prefix CHECK-COMPILER %s < %t.diags.txt
 
 ; RUN: %swiftc_driver_plain -frontend -O -target x86_64-apple-darwin10 -c -module-name someModule -embed-bitcode -disable-llvm-optzns -Xllvm -time-passes -o %t2-opt.o %t.bc -dump-clang-diagnostics -Xllvm -debug-pass=Structure 2> %t.diags-opt.txt
-; RUN: llvm-objdump -macho -section="__LLVM,__bitcode" %t2-opt.o | %FileCheck %s
-; RUN: llvm-objdump -macho -section="__LLVM,__swift_cmdline" %t2-opt.o | %FileCheck -check-prefix=CHECK-CMD-OPT %s
+; RUN: llvm-objdump --macho --section="__LLVM,__bitcode" %t2-opt.o | %FileCheck %s
+; RUN: llvm-objdump --macho --section="__LLVM,__swift_cmdline" %t2-opt.o | %FileCheck -check-prefix=CHECK-CMD-OPT %s
 ; RUN: %FileCheck -check-prefix CHECK-COMPILER-OPT %s < %t.diags-opt.txt
 
 ; RUN: %swiftc_driver_plain -frontend -target x86_64-apple-darwin10 -c -module-name someModule -embed-bitcode-marker  -o %t3.o %t.bc
-; RUN: llvm-objdump -macho -section="__LLVM,__bitcode" %t3.o | %FileCheck -check-prefix=MARKER %s
-; RUN: llvm-objdump -macho -section="__LLVM,__swift_cmdline" %t3.o | %FileCheck -check-prefix=MARKER-CMD %s
+; RUN: llvm-objdump --macho --section="__LLVM,__bitcode" %t3.o | %FileCheck -check-prefix=MARKER %s
+; RUN: llvm-objdump --macho --section="__LLVM,__swift_cmdline" %t3.o | %FileCheck -check-prefix=MARKER-CMD %s
 
 target triple = "x86_64-apple-darwin10"
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"

--- a/test/Frontend/embed-bitcode.swift
+++ b/test/Frontend/embed-bitcode.swift
@@ -1,7 +1,7 @@
 // REQUIRES: CPU=x86_64
 // RUN: %target-swift-frontend -c -module-name someModule -embed-bitcode-marker  -o %t.o %s
-// RUN: llvm-objdump -macho -section="__LLVM,__bitcode" %t.o | %FileCheck -check-prefix=MARKER %s
-// RUN: llvm-objdump -macho -section="__LLVM,__swift_cmdline" %t.o | %FileCheck -check-prefix=MARKER-CMD %s
+// RUN: llvm-objdump --macho --section="__LLVM,__bitcode" %t.o | %FileCheck -check-prefix=MARKER %s
+// RUN: llvm-objdump --macho --section="__LLVM,__swift_cmdline" %t.o | %FileCheck -check-prefix=MARKER-CMD %s
 
 // This file tests Mach-O file output, but Linux variants do not produce Mach-O
 // files.


### PR DESCRIPTION
Adapt to llvm upstream commit 5c3ec7dc41f3e15c39a193b45f3cf23255de00a2
to fix the master-next tests.