### PR TITLE
[CSBindings] Refactor a check to produce follow-up direct supertype b…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1032,15 +1032,6 @@ bool TypeVarBindingProducer::computeNext() {
       }
     }
 
-    if (binding.Kind != BindingKind::Supertypes)
-      continue;
-
-    for (auto supertype : enumerateDirectSupertypes(type)) {
-      // If we're not allowed to try this binding, skip it.
-      if (auto simplifiedSuper = CS.checkTypeOfBinding(TypeVar, supertype))
-        addNewBinding(binding.withType(*simplifiedSuper));
-    }
-
     auto srcLocator = binding.getLocator();
     if (srcLocator &&
         srcLocator->isLastElement<LocatorPathElt::ApplyArgToParam>() &&
@@ -1058,6 +1049,14 @@ bool TypeVarBindingProducer::computeNext() {
       auto newType = CS.openUnboundGenericType(UGT, dstLocator)
                          ->reconstituteSugar(/*recursive=*/false);
       addNewBinding(binding.withType(newType));
+    }
+
+    if (binding.Kind == BindingKind::Supertypes) {
+      for (auto supertype : enumerateDirectSupertypes(type)) {
+        // If we're not allowed to try this binding, skip it.
+        if (auto simplifiedSuper = CS.checkTypeOfBinding(TypeVar, supertype))
+          addNewBinding(binding.withType(*simplifiedSuper));
+      }
     }
   }
 

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -374,3 +374,12 @@ func bridgeTupleToAnyObject() {
 func rdar54274245(_ arr: [Any]?) {
   _ = (arr ?? []) as [NSObject]
 }
+
+// rdar://problem/60501780 - failed to infer NSString as a value type of a dictionary
+func rdar60501780() {
+  func foo(_: [String: NSObject]) {}
+
+  func bar(_ v: String) {
+    foo(["": "", "": v as NSString])
+  }
+}


### PR DESCRIPTION
…indings

This is a follow-up to https://github.com/apple/swift/pull/30113
which cased a regression because it was placed under a check which
allows direct supertypes to be inferred if previous (failing) binding
has a supertype as well which has nothing to do with collection
inference.

Let's combine supertype check and inference logic to avoid such
confusion in the future.

Resolves: rdar://problem/60501780

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
