### PR TITLE
IRGen: Use clang's objc encoding for types when there is a ClangNode

### DIFF
--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -1116,6 +1116,29 @@ static llvm::Constant *getObjCEncodingForMethodType(IRGenModule &IGM,
                                  ptrSize * 2, useExtendedEncoding);
 }
 
+static llvm::Constant *
+getObjectEncodingFromClangNode(IRGenModule &IGM, Decl *d,
+                               bool useExtendedEncoding) {
+  // Use the clang node's encoding if there is a clang node.
+  if (d->getClangNode()) {
+    auto clangDecl = d->getClangNode().castAsDecl();
+    auto &clangASTContext = IGM.getClangASTContext();
+    std::string typeStr;
+    if (auto objcMethodDecl = dyn_cast<clang::ObjCMethodDecl>(clangDecl)) {
+      typeStr = clangASTContext.getObjCEncodingForMethodDecl(
+          objcMethodDecl, useExtendedEncoding /*extended*/);
+    }
+    if (auto objcPropertyDecl = dyn_cast<clang::ObjCPropertyDecl>(clangDecl)) {
+      typeStr = clangASTContext.getObjCEncodingForPropertyDecl(objcPropertyDecl,
+                                                               nullptr);
+    }
+    if (!typeStr.empty()) {
+      return IGM.getAddrOfGlobalString(typeStr.c_str());
+    }
+  }
+  return nullptr;
+}
+
 /// Emit the components of an Objective-C method descriptor: its selector,
 /// type encoding, and IMP pointer.
 ObjCMethodDescriptor
@@ -1128,11 +1151,18 @@ irgen::emitObjCMethodDescriptorParts(IRGenModule &IGM,
   /// The first element is the selector.
   descriptor.selectorRef = IGM.getAddrOfObjCMethodName(selector.str());
   
-  /// The second element is the method signature. A method signature is made of
-  /// the return type @encoding and every parameter type @encoding, glued with
-  /// numbers that used to represent stack offsets for each of these elements.
-  CanSILFunctionType methodType = getObjCMethodType(IGM, method);
-  descriptor.typeEncoding = getObjCEncodingForMethodType(IGM, methodType, /*extended*/false);
+  if (auto e =
+          getObjectEncodingFromClangNode(IGM, method, false /*extended*/)) {
+    descriptor.typeEncoding = e;
+  } else {
+    /// The second element is the method signature. A method signature is made
+    /// of the return type @encoding and every parameter type @encoding, glued
+    /// with numbers that used to represent stack offsets for each of these
+    /// elements.
+    CanSILFunctionType methodType = getObjCMethodType(IGM, method);
+    descriptor.typeEncoding =
+        getObjCEncodingForMethodType(IGM, methodType, /*extended*/ false);
+  }
   
   /// The third element is the method implementation pointer.
   if (!concrete) {
@@ -1191,10 +1221,17 @@ irgen::emitObjCGetterDescriptorParts(IRGenModule &IGM,
   Selector getterSel(subscript, Selector::ForGetter);
   ObjCMethodDescriptor descriptor{};
   descriptor.selectorRef = IGM.getAddrOfObjCMethodName(getterSel.str());
-  auto methodTy = getObjCMethodType(IGM,
-                              subscript->getOpaqueAccessor(AccessorKind::Get));
-  descriptor.typeEncoding = getObjCEncodingForMethodType(IGM, methodTy,
-                                                         /*extended*/false);
+
+  if (auto e =
+          getObjectEncodingFromClangNode(IGM, subscript, false /*extended*/)) {
+    descriptor.typeEncoding = e;
+  } else {
+    auto methodTy =
+        getObjCMethodType(IGM, subscript->getOpaqueAccessor(AccessorKind::Get));
+    descriptor.typeEncoding = getObjCEncodingForMethodType(IGM, methodTy,
+                                                           /*extended*/ false);
+  }
+
   descriptor.silFunction = nullptr;
   descriptor.impl = getObjCGetterPointer(IGM, subscript,
                                          descriptor.silFunction);
@@ -1266,8 +1303,13 @@ irgen::emitObjCSetterDescriptorParts(IRGenModule &IGM,
   descriptor.selectorRef = IGM.getAddrOfObjCMethodName(setterSel.str());
   auto methodTy = getObjCMethodType(IGM,
                               subscript->getOpaqueAccessor(AccessorKind::Set));
-  descriptor.typeEncoding = getObjCEncodingForMethodType(IGM, methodTy,
-                                                         /*extended*/false);
+  if (auto e =
+          getObjectEncodingFromClangNode(IGM, subscript, false /*extended*/)) {
+    descriptor.typeEncoding = e;
+  } else {
+    descriptor.typeEncoding = getObjCEncodingForMethodType(IGM, methodTy,
+                                                           /*extended*/ false);
+  }
   descriptor.silFunction = nullptr;
   descriptor.impl = getObjCSetterPointer(IGM, subscript,
                                          descriptor.silFunction);
@@ -1359,9 +1401,15 @@ void irgen::emitObjCIVarInitDestroyDescriptor(IRGenModule &IGM,
   buildMethodDescriptor(IGM, descriptors, descriptor);
 }
 
+
 llvm::Constant *
 irgen::getMethodTypeExtendedEncoding(IRGenModule &IGM,
                                      AbstractFunctionDecl *method) {
+  // Use the clang node's encoding if there is a clang node.
+  if (auto e = getObjectEncodingFromClangNode(IGM, method, true /*extended*/)) {
+    return e;
+  }
+
   CanSILFunctionType methodType = getObjCMethodType(IGM, method);
   return getObjCEncodingForMethodType(IGM, methodType, true/*Extended*/);
 }

--- a/test/IRGen/Inputs/usr/include/Gizmo.h
+++ b/test/IRGen/Inputs/usr/include/Gizmo.h
@@ -159,3 +159,7 @@ struct StructOfNSStrings useStructOfNSStringsInObjC(struct StructOfNSStrings);
 __attribute__((swift_name("OuterType.InnerType")))
 @interface OuterTypeInnerType : NSObject<NSRuncing>
 @end
+
+@protocol P
+- (oneway void)stuff;
+@end

--- a/test/IRGen/objc_type_encoding.swift
+++ b/test/IRGen/objc_type_encoding.swift
@@ -166,6 +166,7 @@ import gizmo
   func subclassComposition(_: MyCustomObject & NSRuncing & NSFunging)
 }
 
+
 // CHECK-macosx: [[ENC1:@.*]] = private unnamed_addr constant [35 x i8] c"v24@0:8@\22<NSFunging><NSRuncing>\2216\00"
 // CHECK-macosx: [[ENC2:@.*]] = private unnamed_addr constant [46 x i8] c"v32@0:8@\22Gizmo\2216@?<v@?@\22NSView\22@\22NSSpoon\22>24\00"
 // CHECK-macosx: [[ENC3:@.*]] = private unnamed_addr constant [53 x i8] c"v24@0:8@\22_TtC18objc_type_encoding14MyCustomObject\2216\00"
@@ -181,3 +182,10 @@ import gizmo
 // CHECK-tvos: [[ENC3:@.*]] = private unnamed_addr constant [53 x i8] c"v24@0:8@\22_TtC18objc_type_encoding14MyCustomObject\2216\00"
 // CHECK-tvos: [[ENC4:@.*]] = private unnamed_addr constant [75 x i8] c"v24@0:8@\22_TtC18objc_type_encoding14MyCustomObject<NSFunging><NSRuncing>\2216\00"
 // CHECK-tvos: @_PROTOCOL_METHOD_TYPES__TtP18objc_type_encoding10MyProtocol_ = private constant [4 x i8*] [i8* getelementptr inbounds ([35 x i8], [35 x i8]* [[ENC1]], i64 0, i64 0), i8* getelementptr inbounds ([46 x i8], [46 x i8]* [[ENC2]], i64 0, i64 0), i8* getelementptr inbounds ([53 x i8], [53 x i8]* [[ENC3]], i64 0, i64 0), i8* getelementptr inbounds ([75 x i8], [75 x i8]* [[ENC4]], i64 0, i64 0)]
+
+class C: P {
+  func stuff() {}
+}
+
+// CHECK-macosx: [[ENC5:@.*]] = private unnamed_addr constant [9 x i8] c"Vv16@0:8\00"
+// CHECK-macosx: @_PROTOCOL_INSTANCE_METHODS_P = {{.*}}@"\01L_selector_data(stuff)"{{.*}}[[ENC5]]{{.*}}, section "__DATA, __objc_const", align 8


### PR DESCRIPTION
We do this because the swift code does not support all attributes and
does not support generics.

rdar://60474785