### PR TITLE
[NFC] Break TypeChecker Down Into a Namespace

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -105,7 +105,6 @@ namespace swift {
   class SourceManager;
   class ValueDecl;
   class DiagnosticEngine;
-  class TypeChecker;
   class TypeCheckerDebugConsumer;
   struct RawComment;
   class DocComment;
@@ -441,9 +440,6 @@ public:
 
   /// Set a new stats reporter.
   void setStatsReporter(UnifiedStatsReporter *stats);
-
-private:
-  friend class TypeChecker;
 
 public:
   /// getIdentifier - Return the uniqued and AST-Context-owned version of the

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -332,6 +332,32 @@ private:
   llvm::BumpPtrAllocator &
   getAllocator(AllocationArena arena = AllocationArena::Permanent) const;
 
+private:
+  bool SemanticQueriesEnabled = false;
+
+public:
+  /// Returns \c true if legacy semantic AST queries are enabled.
+  ///
+  /// The request evaluator generally subsumes the use of this bit. However,
+  /// there are clients - mostly SourceKit - that rely on the fact that this bit
+  /// being \c false causes some property wrapper requests to return null
+  /// sentinel values. These clients should be migrated off of this interface
+  /// to syntactic requests as soon as possible.
+  ///
+  /// rdar://60516325
+  bool areLegacySemanticQueriesEnabled() const {
+    return SemanticQueriesEnabled;
+  }
+
+  /// Enable "semantic queries".
+  ///
+  /// Setting this bit tells property wrapper requests to return a semantic
+  /// value.  It does not otherwise affect compiler behavior and should be
+  /// removed as soon as possible.
+  void setLegacySemanticQueriesEnabled() {
+    SemanticQueriesEnabled = true;
+  }
+
 public:
   /// Allocate - Allocate memory from the ASTContext bump pointer.
   void *Allocate(unsigned long bytes, unsigned alignment,

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -445,15 +445,7 @@ public:
 private:
   friend class TypeChecker;
 
-  void installGlobalTypeChecker(TypeChecker *TC);
 public:
-  /// Returns if semantic AST queries are enabled. This generally means module
-  /// loading and name lookup can take place.
-  bool areSemanticQueriesEnabled() const;
-
-  /// Retrieve the global \c TypeChecker instance associated with this context.
-  TypeChecker *getLegacyGlobalTypeChecker() const;
-
   /// getIdentifier - Return the uniqued and AST-Context-owned version of the
   /// specified string.
   Identifier getIdentifier(StringRef Str) const;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3597,7 +3597,6 @@ class EnumDecl final : public NominalTypeDecl {
 
   friend class EnumRawValuesRequest;
   friend class EnumRawTypeRequest;
-  friend class TypeChecker;
 
 public:
   EnumDecl(SourceLoc EnumLoc, Identifier Name, SourceLoc NameLoc,
@@ -3883,7 +3882,6 @@ class ClassDecl final : public NominalTypeDecl {
   friend class EmittedMembersRequest;
   friend class HasMissingDesignatedInitializersRequest;
   friend class InheritsSuperclassInitializersRequest;
-  friend class TypeChecker;
 
 public:
   ClassDecl(SourceLoc ClassLoc, Identifier Name, SourceLoc NameLoc,
@@ -4258,7 +4256,6 @@ class ProtocolDecl final : public NominalTypeDecl {
   friend class ProtocolRequiresClassRequest;
   friend class ExistentialConformsToSelfRequest;
   friend class ExistentialTypeSupportedRequest;
-  friend class TypeChecker;
 
 public:
   ProtocolDecl(DeclContext *DC, SourceLoc ProtocolLoc, SourceLoc NameLoc,

--- a/include/swift/AST/LookupKinds.h
+++ b/include/swift/AST/LookupKinds.h
@@ -62,12 +62,15 @@ enum NLOptions : unsigned {
   /// Include synonyms declared with @_implements()
   NL_IncludeAttributeImplements = 0x100,
 
+  /// Synthesize property wrappers and include them in the lookup results.
+  NL_IncludePropertyWrappers = 0x200,
+
   /// This lookup is known to not add any additional dependencies to the
   /// primary source file.
   ///
   /// \see NL_KnownDependencyMask
   NL_KnownNoDependency =
-      NL_KnownNonCascadingDependency|NL_KnownCascadingDependency,
+      NL_KnownNonCascadingDependency | NL_KnownCascadingDependency,
 
   /// A mask of all options controlling how a lookup should be recorded as a
   /// dependency.
@@ -83,10 +86,12 @@ enum NLOptions : unsigned {
   ///
   /// FIXME: Eventually, add NL_ProtocolMembers to this, once all of the
   /// callers can handle it.
-  NL_QualifiedDefault = NL_RemoveNonVisible | NL_RemoveOverridden,
+  NL_QualifiedDefault =
+      NL_RemoveNonVisible | NL_RemoveOverridden | NL_IncludePropertyWrappers,
 
   /// The default set of options used for unqualified name lookup.
-  NL_UnqualifiedDefault = NL_RemoveNonVisible | NL_RemoveOverridden
+  NL_UnqualifiedDefault =
+      NL_RemoveNonVisible | NL_RemoveOverridden | NL_IncludePropertyWrappers,
 };
 
 static inline NLOptions operator|(NLOptions lhs, NLOptions rhs) {

--- a/include/swift/AST/LookupKinds.h
+++ b/include/swift/AST/LookupKinds.h
@@ -62,15 +62,12 @@ enum NLOptions : unsigned {
   /// Include synonyms declared with @_implements()
   NL_IncludeAttributeImplements = 0x100,
 
-  /// Synthesize property wrappers and include them in the lookup results.
-  NL_IncludePropertyWrappers = 0x200,
-
   /// This lookup is known to not add any additional dependencies to the
   /// primary source file.
   ///
   /// \see NL_KnownDependencyMask
   NL_KnownNoDependency =
-      NL_KnownNonCascadingDependency | NL_KnownCascadingDependency,
+      NL_KnownNonCascadingDependency|NL_KnownCascadingDependency,
 
   /// A mask of all options controlling how a lookup should be recorded as a
   /// dependency.
@@ -86,12 +83,10 @@ enum NLOptions : unsigned {
   ///
   /// FIXME: Eventually, add NL_ProtocolMembers to this, once all of the
   /// callers can handle it.
-  NL_QualifiedDefault =
-      NL_RemoveNonVisible | NL_RemoveOverridden | NL_IncludePropertyWrappers,
+  NL_QualifiedDefault = NL_RemoveNonVisible | NL_RemoveOverridden,
 
   /// The default set of options used for unqualified name lookup.
-  NL_UnqualifiedDefault =
-      NL_RemoveNonVisible | NL_RemoveOverridden | NL_IncludePropertyWrappers,
+  NL_UnqualifiedDefault = NL_RemoveNonVisible | NL_RemoveOverridden
 };
 
 static inline NLOptions operator|(NLOptions lhs, NLOptions rhs) {

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -267,6 +267,14 @@ public:
   /// A set of synthesized declarations that need to be type checked.
   llvm::SmallVector<Decl *, 8> SynthesizedDecls;
 
+  /// The list of functions defined in this file whose bodies have yet to be
+  /// typechecked. They must be held in this list instead of eagerly validated
+  /// because their bodies may force us to perform semantic checks of arbitrary
+  /// complexity, and we currently cannot handle those checks in isolation. E.g.
+  /// we cannot, in general, perform witness matching on singular requirements
+  /// unless the entire conformance has been evaluated.
+  std::vector<AbstractFunctionDecl *> DelayedFunctions;
+
   /// We might perform type checking on the same source file more than once,
   /// if its the main file or a REPL instance, so keep track of the last
   /// checked synthesized declaration to avoid duplicating work.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -498,7 +498,6 @@ public:
 };
 
 void simple_display(llvm::raw_ostream &out, const KnownProtocolKind);
-class TypeChecker;
 
 // Find the type in the cache or look it up
 class DefaultTypeRequest

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -43,7 +43,6 @@ namespace swift {
   class SubscriptDecl;
   class TopLevelCodeDecl;
   class Type;
-  class TypeChecker;
   class ValueDecl;
   struct PrintOptions;
 

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -66,7 +66,6 @@ namespace swift {
   class SyntaxParsingCache;
   class Token;
   class TopLevelContext;
-  class TypeChecker;
   class TypeCheckerOptions;
   struct TypeLoc;
   class UnifiedStatsReporter;

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -140,12 +140,6 @@ namespace swift {
   /// lib/Sema/PCMacro.cpp for a description of the calls inserted.
   void performPCMacro(SourceFile &SF);
 
-  /// Creates a type checker instance on the given AST context, if it
-  /// doesn't already have one.
-  ///
-  /// \returns a reference to the type checker instance.
-  void createTypeChecker(ASTContext &Ctx);
-
   /// Bind all 'extension' visible from \p SF to the extended nominal.
   void bindExtensions(SourceFile &SF);
 

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -145,7 +145,7 @@ namespace swift {
   /// doesn't already have one.
   ///
   /// \returns a reference to the type checker instance.
-  TypeChecker &createTypeChecker(ASTContext &Ctx);
+  void createTypeChecker(ASTContext &Ctx);
 
   /// Bind all 'extension' visible from \p SF to the extended nominal.
   void bindExtensions(SourceFile &SF);

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -155,9 +155,6 @@ struct ASTContext::Implementation {
   /// The set of cleanups to be called when the ASTContext is destroyed.
   std::vector<std::function<void(void)>> Cleanups;
 
-  /// A global type checker instance..
-  TypeChecker *Checker = nullptr;
-
   // FIXME: This is a StringMap rather than a StringSet because StringSet
   // doesn't allow passing in a pre-existing allocator.
   llvm::StringMap<Identifier::Aligner, llvm::BumpPtrAllocator&>
@@ -630,19 +627,6 @@ void ASTContext::setStatsReporter(UnifiedStatsReporter *stats) {
 
 RC<syntax::SyntaxArena> ASTContext::getSyntaxArena() const {
   return getImpl().TheSyntaxArena;
-}
-
-bool ASTContext::areSemanticQueriesEnabled() const {
-  return getLegacyGlobalTypeChecker() != nullptr;
-}
-
-TypeChecker *ASTContext::getLegacyGlobalTypeChecker() const {
-  return getImpl().Checker;
-}
-
-void ASTContext::installGlobalTypeChecker(TypeChecker *TC) {
-  assert(!getImpl().Checker);
-  getImpl().Checker = TC;
 }
 
 /// getIdentifier - Return the uniqued and AST-Context-owned version of the

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2998,6 +2998,8 @@ bool ValueDecl::isRecursiveValidation() const {
 Type ValueDecl::getInterfaceType() const {
   auto &ctx = getASTContext();
 
+  assert(ctx.areLegacySemanticQueriesEnabled());
+
   if (auto type =
           evaluateOrDefault(ctx.evaluator,
                             InterfaceTypeRequest{const_cast<ValueDecl *>(this)},

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5813,6 +5813,10 @@ StaticSpellingKind AbstractStorageDecl::getCorrectStaticSpelling() const {
 
 llvm::TinyPtrVector<CustomAttr *> VarDecl::getAttachedPropertyWrappers() const {
   auto &ctx = getASTContext();
+  if (!ctx.areLegacySemanticQueriesEnabled()) {
+    return { };
+  }
+
   auto mutableThis = const_cast<VarDecl *>(this);
   return evaluateOrDefault(ctx.evaluator,
                            AttachedPropertyWrappersRequest{mutableThis},
@@ -6782,7 +6786,7 @@ ObjCSelector
 AbstractFunctionDecl::getObjCSelector(DeclName preferredName,
                                       bool skipIsObjCResolution) const {
   // FIXME: Forces computation of the Objective-C selector.
-  if (!skipIsObjCResolution)
+  if (getASTContext().areLegacySemanticQueriesEnabled() && !skipIsObjCResolution)
     (void)isObjC();
 
   // If there is an @objc attribute with a name, use that name.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2998,8 +2998,6 @@ bool ValueDecl::isRecursiveValidation() const {
 Type ValueDecl::getInterfaceType() const {
   auto &ctx = getASTContext();
 
-  assert(ctx.areSemanticQueriesEnabled());
-
   if (auto type =
           evaluateOrDefault(ctx.evaluator,
                             InterfaceTypeRequest{const_cast<ValueDecl *>(this)},
@@ -5813,10 +5811,6 @@ StaticSpellingKind AbstractStorageDecl::getCorrectStaticSpelling() const {
 
 llvm::TinyPtrVector<CustomAttr *> VarDecl::getAttachedPropertyWrappers() const {
   auto &ctx = getASTContext();
-  if (!ctx.areSemanticQueriesEnabled()) {
-    return { };
-  }
-
   auto mutableThis = const_cast<VarDecl *>(this);
   return evaluateOrDefault(ctx.evaluator,
                            AttachedPropertyWrappersRequest{mutableThis},
@@ -6786,7 +6780,7 @@ ObjCSelector
 AbstractFunctionDecl::getObjCSelector(DeclName preferredName,
                                       bool skipIsObjCResolution) const {
   // FIXME: Forces computation of the Objective-C selector.
-  if (getASTContext().areSemanticQueriesEnabled() && !skipIsObjCResolution)
+  if (!skipIsObjCResolution)
     (void)isObjC();
 
   // If there is an @objc attribute with a name, use that name.

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1612,8 +1612,8 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
 
   // Visit all of the nominal types we know about, discovering any others
   // we need along the way.
-  auto &ctx = DC->getASTContext();
   bool wantProtocolMembers = (options & NL_ProtocolMembers);
+  const bool includesPropertyWrappers = (options & NL_IncludePropertyWrappers);
   while (!stack.empty()) {
     auto current = stack.back();
     stack.pop_back();
@@ -1622,7 +1622,7 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
       tracker->addUsedMember({current, member.getBaseName()},isLookupCascading);
 
     // Make sure we've resolved property wrappers, if we need them.
-    if (ctx.areSemanticQueriesEnabled()) {
+    if (includesPropertyWrappers) {
       installPropertyWrapperMembersIfNeeded(current, member);
     }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1612,8 +1612,8 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
 
   // Visit all of the nominal types we know about, discovering any others
   // we need along the way.
+  auto &ctx = DC->getASTContext();
   bool wantProtocolMembers = (options & NL_ProtocolMembers);
-  const bool includesPropertyWrappers = (options & NL_IncludePropertyWrappers);
   while (!stack.empty()) {
     auto current = stack.back();
     stack.pop_back();
@@ -1622,7 +1622,7 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
       tracker->addUsedMember({current, member.getBaseName()},isLookupCascading);
 
     // Make sure we've resolved property wrappers, if we need them.
-    if (includesPropertyWrappers) {
+    if (ctx.areLegacySemanticQueriesEnabled()) {
       installPropertyWrapperMembersIfNeeded(current, member);
     }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -239,7 +239,7 @@ bool CompilerInstance::setUpASTContextIfNeeded() {
   if (setUpModuleLoaders())
     return true;
 
-  createTypeChecker(*Context);
+  Context->setLegacySemanticQueriesEnabled();
   return false;
 }
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1638,7 +1638,7 @@ public:
         Importer(static_cast<ClangImporter *>(CurrDeclContext->getASTContext().
           getClangModuleLoader())),
         CompletionContext(CompletionContext) {
-    (void)swift::createTypeChecker(Ctx);
+    Ctx.setLegacySemanticQueriesEnabled();
 
     // Determine if we are doing code completion inside a static method.
     if (CurrDeclContext) {
@@ -4186,7 +4186,7 @@ public:
                            SourceLoc introducerLoc)
       : Sink(Sink), Ctx(Ctx), CurrDeclContext(CurrDeclContext),
         ParsedKeywords(ParsedKeywords), introducerLoc(introducerLoc) {
-    (void)createTypeChecker(Ctx);
+    Ctx.setLegacySemanticQueriesEnabled();
 
     hasFuncIntroducer = isKeywordSpecified("func");
     hasVarIntroducer = isKeywordSpecified("var") ||

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4405,7 +4405,6 @@ getMemberDecls(InterestedMemberKind Kind) {
 ResolvedMemberResult
 swift::resolveValueMember(DeclContext &DC, Type BaseTy, DeclName Name) {
   ResolvedMemberResult Result;
-  assert(DC.getASTContext().areSemanticQueriesEnabled());
   ConstraintSystem CS(&DC, None);
 
   // Look up all members of BaseTy with the given Name.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4405,6 +4405,7 @@ getMemberDecls(InterestedMemberKind Kind) {
 ResolvedMemberResult
 swift::resolveValueMember(DeclContext &DC, Type BaseTy, DeclName Name) {
   ResolvedMemberResult Result;
+  assert(DC.getASTContext().areLegacySemanticQueriesEnabled());
   ConstraintSystem CS(&DC, None);
 
   // Look up all members of BaseTy with the given Name.

--- a/lib/Sema/CodeSynthesis.h
+++ b/lib/Sema/CodeSynthesis.h
@@ -33,14 +33,11 @@ class ConstructorDecl;
 class FuncDecl;
 class GenericParamList;
 class NominalTypeDecl;
+class ObjCReason;
 class ParamDecl;
 class Type;
 class ValueDecl;
 class VarDecl;
-
-class TypeChecker;
-
-class ObjCReason;
 
 enum class SelfAccessorKind {
   /// We're building a derived accessor on top of whatever this

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2229,8 +2229,15 @@ private:
   /// constraint system for further exploration.
   void applySolution(const Solution &solution);
 
-  // FIXME: Allows the type checker to apply solutions.
-  friend class swift::TypeChecker;
+  // FIXME: Perhaps these belong on ConstraintSystem itself.
+  friend Optional<BraceStmt *>
+  swift::TypeChecker::applyFunctionBuilderBodyTransform(FuncDecl *func,
+                                                        Type builderType);
+  friend Optional<SolutionApplicationTarget>
+  swift::TypeChecker::typeCheckExpression(SolutionApplicationTarget &target,
+                                          bool &unresolvedTypeExprs,
+                                          TypeCheckExprOptions options,
+                                          ExprTypeCheckListener *listener);
 
   /// Emit the fixes computed as part of the solution, returning true if we were
   /// able to emit an error message, or false if none of the fixits worked out.

--- a/lib/Sema/DebuggerTestingTransform.cpp
+++ b/lib/Sema/DebuggerTestingTransform.cpp
@@ -243,7 +243,7 @@ private:
     // TODO: typeCheckExpression() seems to assign types to everything here,
     // but may not be sufficient in some cases.
     Expr *FinalExpr = ClosureCall;
-    (void)swift::createTypeChecker(Ctx);
+    Ctx.setLegacySemanticQueriesEnabled();
     if (!TypeChecker::typeCheckExpression(FinalExpr, getCurrentDeclContext()))
       llvm::report_fatal_error("Could not type-check instrumentation");
 

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -27,7 +27,6 @@ class AccessorDecl;
 class NominalTypeDecl;
 class PatternBindingDecl;
 class Type;
-class TypeChecker;
 class ValueDecl;
 class VarDecl;
 

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -56,7 +56,7 @@ static bool isExtensionAppliedInternal(const DeclContext *DC, Type BaseTy,
   if (!ED->isConstrainedExtension())
     return true;
 
-  (void)swift::createTypeChecker(DC->getASTContext());
+  DC->getASTContext().setLegacySemanticQueriesEnabled();
   GenericSignature genericSig = ED->getGenericSignature();
   SubstitutionMap substMap = BaseTy->getContextSubstitutionMap(
       DC->getParentModule(), ED->getExtendedNominal());

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -31,7 +31,6 @@ namespace swift {
   class InFlightDiagnostic;
   class Stmt;
   class TopLevelCodeDecl;
-  class TypeChecker;
   class ValueDecl;
 
 /// Emit diagnostics for syntactic restrictions on a given expression.

--- a/lib/Sema/TypeCheckAccess.h
+++ b/lib/Sema/TypeCheckAccess.h
@@ -20,7 +20,6 @@
 namespace swift {
 
 class Decl;
-class TypeChecker;
 
 /// Performs access-related checks for \p D.
 ///

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1166,10 +1166,15 @@ namespace {
 class DeclChecker : public DeclVisitor<DeclChecker> {
 public:
   ASTContext &Ctx;
+  SourceFile *SF;
 
-  explicit DeclChecker(ASTContext &ctx) : Ctx(ctx) {}
+  explicit DeclChecker(ASTContext &ctx, SourceFile *SF) : Ctx(ctx), SF(SF) {}
 
   ASTContext &getASTContext() const { return Ctx; }
+  void addDelayedFunction(AbstractFunctionDecl *AFD) {
+    if (!SF) return;
+    SF->DelayedFunctions.push_back(AFD);
+  }
 
   void visit(Decl *decl) {
     if (auto *Stats = getASTContext().Stats)
@@ -1385,7 +1390,7 @@ public:
     TypeChecker::checkDeclAttributes(PBD);
 
     bool isInSILMode = false;
-    if (auto sourceFile = DC->getParentSourceFile())
+    if (auto sourceFile = SF)
       isInSILMode = sourceFile->Kind == SourceFileKind::SIL;
     bool isTypeContext = DC->isTypeContext();
 
@@ -1443,7 +1448,7 @@ public:
         // protocol.
         if (var->isStatic() && !isa<ProtocolDecl>(DC)) {
           // ...but don't enforce this for SIL or module interface files.
-          switch (DC->getParentSourceFile()->Kind) {
+          switch (SF->Kind) {
           case SourceFileKind::Interface:
           case SourceFileKind::SIL:
             return;
@@ -1461,7 +1466,7 @@ public:
 
         // Global variables require an initializer in normal source files.
         if (DC->isModuleScopeContext()) {
-          switch (DC->getParentSourceFile()->Kind) {
+          switch (SF->Kind) {
           case SourceFileKind::Main:
           case SourceFileKind::REPL:
           case SourceFileKind::Interface:
@@ -1994,7 +1999,6 @@ public:
     // Check for circular inheritance within the protocol.
     (void)PD->hasCircularInheritedProtocols();
 
-    auto *SF = PD->getParentSourceFile();
     if (SF) {
       if (auto *tracker = SF->getReferencedNameTracker()) {
         bool isNonPrivate = (PD->getFormalAccess() > AccessLevel::FilePrivate);
@@ -2150,9 +2154,7 @@ public:
     } else if (shouldSkipBodyTypechecking(FD)) {
       FD->setBodySkipped(FD->getBodySourceRange());
     } else {
-      // FIXME: Remove TypeChecker dependency.
-      auto &TC = *Ctx.getLegacyGlobalTypeChecker();
-      TC.definedFunctions.push_back(FD);
+      addDelayedFunction(FD);
     }
 
     checkExplicitAvailability(FD);
@@ -2484,9 +2486,7 @@ public:
     } else if (shouldSkipBodyTypechecking(CD)) {
       CD->setBodySkipped(CD->getBodySourceRange());
     } else {
-      // FIXME: Remove TypeChecker dependency.
-      auto &TC = *Ctx.getLegacyGlobalTypeChecker();
-      TC.definedFunctions.push_back(CD);
+      addDelayedFunction(CD);
     }
 
     checkDefaultArguments(CD->getParameters());
@@ -2501,14 +2501,13 @@ public:
     } else if (shouldSkipBodyTypechecking(DD)) {
       DD->setBodySkipped(DD->getBodySourceRange());
     } else {
-      // FIXME: Remove TypeChecker dependency.
-      auto &TC = *Ctx.getLegacyGlobalTypeChecker();
-      TC.definedFunctions.push_back(DD);
+      addDelayedFunction(DD);
     }
   }
 };
 } // end anonymous namespace
 
 void TypeChecker::typeCheckDecl(Decl *D) {
-  DeclChecker(D->getASTContext()).visit(D);
+  auto *SF = D->getDeclContext()->getParentSourceFile();
+  DeclChecker(D->getASTContext(), SF).visit(D);
 }

--- a/lib/Sema/TypeCheckObjC.h
+++ b/lib/Sema/TypeCheckObjC.h
@@ -25,7 +25,6 @@ namespace swift {
 class AbstractFunctionDecl;
 class ASTContext;
 class SubscriptDecl;
-class TypeChecker;
 class ValueDecl;
 class VarDecl;
 class InFlightDiagnostic;

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -498,6 +498,9 @@ AttachedPropertyWrapperTypeRequest::evaluate(Evaluator &evaluator,
     return Type();
 
   ASTContext &ctx = var->getASTContext();
+  if (!ctx.areLegacySemanticQueriesEnabled())
+    return nullptr;
+
   auto resolution =
       TypeResolution::forContextual(var->getDeclContext());
   TypeResolutionOptions options(TypeResolverContext::PatternBindingDecl);
@@ -530,6 +533,10 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
   if (!binding)
     return Type();
 
+  ASTContext &ctx = var->getASTContext();
+  if (!ctx.areLegacySemanticQueriesEnabled())
+    return Type();
+
   // If there's an initializer of some sort, checking it will determine the
   // property wrapper type.
   unsigned index = binding->getPatternEntryIndexForVarDecl(var);
@@ -539,7 +546,6 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
     if (!binding->isInitializerChecked(index))
       TypeChecker::typeCheckPatternBinding(binding, index);
 
-    auto &ctx = var->getASTContext();
     Type type = ctx.getSideCachedPropertyWrapperBackingPropertyType(var);
     assert(type || ctx.Diags.hadAnyError());
     return type;

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -498,9 +498,6 @@ AttachedPropertyWrapperTypeRequest::evaluate(Evaluator &evaluator,
     return Type();
 
   ASTContext &ctx = var->getASTContext();
-  if (!ctx.areSemanticQueriesEnabled())
-    return nullptr;
-
   auto resolution =
       TypeResolution::forContextual(var->getDeclContext());
   TypeResolutionOptions options(TypeResolverContext::PatternBindingDecl);
@@ -533,10 +530,6 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
   if (!binding)
     return Type();
 
-  ASTContext &ctx = var->getASTContext();
-  if (!ctx.areSemanticQueriesEnabled())
-    return Type();
-
   // If there's an initializer of some sort, checking it will determine the
   // property wrapper type.
   unsigned index = binding->getPatternEntryIndexForVarDecl(var);
@@ -546,6 +539,7 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
     if (!binding->isInitializerChecked(index))
       TypeChecker::typeCheckPatternBinding(binding, index);
 
+    auto &ctx = var->getASTContext();
     Type type = ctx.getSideCachedPropertyWrapperBackingPropertyType(var);
     assert(type || ctx.Diags.hadAnyError());
     return type;

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -39,7 +39,6 @@ class DeclContext;
 class FuncDecl;
 class NormalProtocolConformance;
 class ProtocolDecl;
-class TypeChecker;
 class TypeRepr;
 class ValueDecl;
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -528,6 +528,7 @@ bool swift::performTypeLocChecking(ASTContext &Ctx, TypeLoc &T,
   Optional<DiagnosticSuppression> suppression;
   if (!ProduceDiagnostics)
     suppression.emplace(Ctx.Diags);
+  assert(Ctx.areLegacySemanticQueriesEnabled());
   return TypeChecker::validateType(Ctx, T, resolution, options);
 }
 
@@ -634,7 +635,7 @@ swift::getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
                                    ConcreteDeclRef &referencedDecl) {
   auto &ctx = DC->getASTContext();
   DiagnosticSuppression suppression(ctx.Diags);
-  Ctx.setLegacySemanticQueriesEnabled();
+  ctx.setLegacySemanticQueriesEnabled();
   return TypeChecker::getTypeOfCompletionOperator(DC, LHS, opName, refKind,
                                                   referencedDecl);
 }
@@ -642,7 +643,7 @@ swift::getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
 bool swift::typeCheckExpression(DeclContext *DC, Expr *&parsedExpr) {
   auto &ctx = DC->getASTContext();
   DiagnosticSuppression suppression(ctx.Diags);
-  Ctx.setLegacySemanticQueriesEnabled();
+  ctx.setLegacySemanticQueriesEnabled();
   auto resultTy = TypeChecker::typeCheckExpression(parsedExpr, DC, TypeLoc(),
                                                    CTP_Unused);
   return !resultTy;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -337,7 +337,7 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
   BufferIndirectlyCausingDiagnosticRAII cpr(*SF);
 
   // Make sure we have a type checker.
-  createTypeChecker(Ctx);
+  Ctx.setLegacySemanticQueriesEnabled();
 
   // Make sure that name binding has been completed before doing any type
   // checking.
@@ -564,7 +564,7 @@ void swift::typeCheckPatternBinding(PatternBindingDecl *PBD,
 
   auto &Ctx = PBD->getASTContext();
   DiagnosticSuppression suppression(Ctx.Diags);
-  (void)createTypeChecker(Ctx);
+  Ctx.setLegacySemanticQueriesEnabled();
   (void)evaluateOrDefault(
       Ctx.evaluator, PatternBindingEntryRequest{PBD, bindingIndex}, nullptr);
   TypeChecker::typeCheckPatternBinding(PBD, bindingIndex);
@@ -619,7 +619,7 @@ Optional<Type> swift::getTypeOfCompletionContextExpr(
                         Expr *&parsedExpr,
                         ConcreteDeclRef &referencedDecl) {
   DiagnosticSuppression suppression(Ctx.Diags);
-  (void)createTypeChecker(Ctx);
+  Ctx.setLegacySemanticQueriesEnabled();
 
   // Try to solve for the actual type of the expression.
   return ::getTypeOfCompletionContextExpr(DC, kind, parsedExpr,
@@ -634,7 +634,7 @@ swift::getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
                                    ConcreteDeclRef &referencedDecl) {
   auto &ctx = DC->getASTContext();
   DiagnosticSuppression suppression(ctx.Diags);
-  (void)createTypeChecker(ctx);
+  Ctx.setLegacySemanticQueriesEnabled();
   return TypeChecker::getTypeOfCompletionOperator(DC, LHS, opName, refKind,
                                                   referencedDecl);
 }
@@ -642,7 +642,7 @@ swift::getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
 bool swift::typeCheckExpression(DeclContext *DC, Expr *&parsedExpr) {
   auto &ctx = DC->getASTContext();
   DiagnosticSuppression suppression(ctx.Diags);
-  (void)createTypeChecker(ctx);
+  Ctx.setLegacySemanticQueriesEnabled();
   auto resultTy = TypeChecker::typeCheckExpression(parsedExpr, DC, TypeLoc(),
                                                    CTP_Unused);
   return !resultTy;
@@ -653,19 +653,17 @@ bool swift::typeCheckAbstractFunctionBodyUntil(AbstractFunctionDecl *AFD,
   auto &Ctx = AFD->getASTContext();
   DiagnosticSuppression suppression(Ctx.Diags);
 
-  (void)createTypeChecker(Ctx);
+  Ctx.setLegacySemanticQueriesEnabled();
   return !TypeChecker::typeCheckAbstractFunctionBodyUntil(AFD, EndTypeCheckLoc);
 }
 
 bool swift::typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD) {
   auto &Ctx = static_cast<Decl *>(TLCD)->getASTContext();
   DiagnosticSuppression suppression(Ctx.Diags);
-  (void)createTypeChecker(Ctx);
+  Ctx.setLegacySemanticQueriesEnabled();
   TypeChecker::typeCheckTopLevelCodeDecl(TLCD);
   return true;
 }
-
-void swift::createTypeChecker(ASTContext &Ctx) {}
 
 void TypeChecker::checkForForbiddenPrefix(ASTContext &C, DeclBaseName Name) {
   if (C.TypeCheckerOpts.DebugForbidTypecheckPrefix.empty())

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -405,10 +405,6 @@ enum class CheckedCastContextKind {
 /// The Swift type checker, which takes a parsed AST and performs name binding,
 /// type checking, and semantic analysis to produce a type-annotated AST.
 class TypeChecker final {
-public:
-  /// The list of function definitions we've encountered.
-  std::vector<AbstractFunctionDecl *> definedFunctions;
-
 private:
   TypeChecker() = default;
   ~TypeChecker() = default;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -412,13 +412,6 @@ private:
   friend class ASTContext;
 
 public:
-  /// Create a new type checker instance for the given ASTContext, if it
-  /// doesn't already have one.
-  ///
-  /// \returns a reference to the type checker.
-  static TypeChecker &createForContext(ASTContext &ctx);
-
-public:
   TypeChecker(const TypeChecker&) = delete;
   TypeChecker& operator=(const TypeChecker&) = delete;
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -38,7 +38,6 @@ namespace swift {
 class GenericSignatureBuilder;
 class NominalTypeDecl;
 class NormalProtocolConformance;
-class TypeChecker;
 class TypeResolution;
 class TypeResolutionOptions;
 class TypoCorrectionResults;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -401,8 +401,6 @@ enum class CheckedCastContextKind {
   EnumElementPattern,
 };
 
-/// The Swift type checker, which takes a parsed AST and performs name binding,
-/// type checking, and semantic analysis to produce a type-annotated AST.
 namespace TypeChecker {
 Type getArraySliceType(SourceLoc loc, Type elementType);
 Type getDictionaryType(SourceLoc loc, Type keyType, Type valueType);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -403,666 +403,628 @@ enum class CheckedCastContextKind {
 
 /// The Swift type checker, which takes a parsed AST and performs name binding,
 /// type checking, and semantic analysis to produce a type-annotated AST.
-class TypeChecker final {
-private:
-  TypeChecker() = default;
-  ~TypeChecker() = default;
+namespace TypeChecker {
+Type getArraySliceType(SourceLoc loc, Type elementType);
+Type getDictionaryType(SourceLoc loc, Type keyType, Type valueType);
+Type getOptionalType(SourceLoc loc, Type elementType);
+Type getStringType(ASTContext &ctx);
+Type getSubstringType(ASTContext &ctx);
+Type getIntType(ASTContext &ctx);
+Type getInt8Type(ASTContext &ctx);
+Type getUInt8Type(ASTContext &ctx);
 
-  friend class ASTContext;
-
-public:
-  TypeChecker(const TypeChecker&) = delete;
-  TypeChecker& operator=(const TypeChecker&) = delete;
-
-  static Type getArraySliceType(SourceLoc loc, Type elementType);
-  static Type getDictionaryType(SourceLoc loc, Type keyType, Type valueType);
-  static Type getOptionalType(SourceLoc loc, Type elementType);
-  static Type getStringType(ASTContext &ctx);
-  static Type getSubstringType(ASTContext &ctx);
-  static Type getIntType(ASTContext &ctx);
-  static Type getInt8Type(ASTContext &ctx);
-  static Type getUInt8Type(ASTContext &ctx);
-
-  /// Try to resolve an IdentTypeRepr, returning either the referenced
-  /// Type or an ErrorType in case of error.
-  static Type resolveIdentifierType(TypeResolution resolution,
-                                    IdentTypeRepr *IdType,
-                                    TypeResolutionOptions options);
-
-  /// Bind an UnresolvedDeclRefExpr by performing name lookup and
-  /// returning the resultant expression.  Context is the DeclContext used
-  /// for the lookup.
-  static Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
-                                  DeclContext *Context);
-
-  /// Validate the given type.
-  ///
-  /// Type validation performs name binding, checking of generic arguments,
-  /// and so on to determine whether the given type is well-formed and can
-  /// be used as a type.
-  ///
-  /// \param Loc The type (with source location information) to validate.
-  /// If the type has already been validated, returns immediately.
-  ///
-  /// \param resolution The type resolution being performed.
-  ///
-  /// \param options Options that alter type resolution.
-  ///
-  /// \returns true if type validation failed, or false otherwise.
-  static bool validateType(ASTContext &Ctx, TypeLoc &Loc,
-                           TypeResolution resolution,
+/// Try to resolve an IdentTypeRepr, returning either the referenced
+/// Type or an ErrorType in case of error.
+Type resolveIdentifierType(TypeResolution resolution, IdentTypeRepr *IdType,
                            TypeResolutionOptions options);
 
-  /// Check for unsupported protocol types in the given declaration.
-  static void checkUnsupportedProtocolType(Decl *decl);
+/// Bind an UnresolvedDeclRefExpr by performing name lookup and
+/// returning the resultant expression.  Context is the DeclContext used
+/// for the lookup.
+Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *Context);
 
-  /// Check for unsupported protocol types in the given statement.
-  static void checkUnsupportedProtocolType(ASTContext &ctx, Stmt *stmt);
+/// Validate the given type.
+///
+/// Type validation performs name binding, checking of generic arguments,
+/// and so on to determine whether the given type is well-formed and can
+/// be used as a type.
+///
+/// \param Loc The type (with source location information) to validate.
+/// If the type has already been validated, returns immediately.
+///
+/// \param resolution The type resolution being performed.
+///
+/// \param options Options that alter type resolution.
+///
+/// \returns true if type validation failed, or false otherwise.
+bool validateType(ASTContext &Ctx, TypeLoc &Loc, TypeResolution resolution,
+                  TypeResolutionOptions options);
 
-  /// Check for unsupported protocol types in the given generic requirement
-  /// list.
-  static void checkUnsupportedProtocolType(ASTContext &ctx,
-                                           TrailingWhereClause *whereClause);
+/// Check for unsupported protocol types in the given declaration.
+void checkUnsupportedProtocolType(Decl *decl);
 
-  /// Check for unsupported protocol types in the given generic requirement
-  /// list.
-  static void checkUnsupportedProtocolType(ASTContext &ctx,
-                                           GenericParamList *genericParams);
+/// Check for unsupported protocol types in the given statement.
+void checkUnsupportedProtocolType(ASTContext &ctx, Stmt *stmt);
 
-  /// Resolve a reference to the given type declaration within a particular
-  /// context.
-  ///
-  /// This routine aids unqualified name lookup for types by performing the
-  /// resolution necessary to rectify the declaration found by name lookup with
-  /// the declaration context from which name lookup started.
-  ///
-  /// \param typeDecl The type declaration found by name lookup.
-  /// \param isSpecialized Whether the type will have generic arguments applied.
-  /// \param resolution The resolution to perform.
-  ///
-  /// \returns the resolved type.
-  static Type resolveTypeInContext(TypeDecl *typeDecl,
-                                   DeclContext *foundDC,
-                                   TypeResolution resolution,
-                                   TypeResolutionOptions options,
-                                   bool isSpecialized);
+/// Check for unsupported protocol types in the given generic requirement
+/// list.
+void checkUnsupportedProtocolType(ASTContext &ctx,
+                                  TrailingWhereClause *whereClause);
 
-  /// Apply generic arguments to the given type.
-  ///
-  /// This function requires a valid unbound generic type with the correct
-  /// number of generic arguments given, whereas applyGenericArguments emits
-  /// diagnostics in those cases.
-  ///
-  /// \param unboundType The unbound generic type to which to apply arguments.
-  /// \param decl The declaration of the type.
-  /// \param loc The source location for diagnostic reporting.
-  /// \param resolution The type resolution.
-  /// \param genericArgs The list of generic arguments to apply to the type.
-  ///
-  /// \returns A BoundGenericType bound to the given arguments, or null on
-  /// error.
-  ///
-  /// \see applyGenericArguments
-  static Type applyUnboundGenericArguments(UnboundGenericType *unboundType,
-                                           GenericTypeDecl *decl,
-                                           SourceLoc loc,
-                                           TypeResolution resolution,
-                                           ArrayRef<Type> genericArgs);
+/// Check for unsupported protocol types in the given generic requirement
+/// list.
+void checkUnsupportedProtocolType(ASTContext &ctx,
+                                  GenericParamList *genericParams);
 
-  /// Substitute the given base type into the type of the given nested type,
-  /// producing the effective type that the nested type will have.
-  ///
-  /// \param module The module in which the substitution will be performed.
-  /// \param member The member whose type projection is being computed.
-  /// \param baseTy The base type that will be substituted for the 'Self' of the
-  /// member.
-  /// \param useArchetypes Whether to use context archetypes for outer generic
-  /// parameters if the class is nested inside a generic function.
-  static Type substMemberTypeWithBase(ModuleDecl *module, TypeDecl *member,
-                                      Type baseTy, bool useArchetypes = true);
+/// Resolve a reference to the given type declaration within a particular
+/// context.
+///
+/// This routine aids unqualified name lookup for types by performing the
+/// resolution necessary to rectify the declaration found by name lookup with
+/// the declaration context from which name lookup started.
+///
+/// \param typeDecl The type declaration found by name lookup.
+/// \param isSpecialized Whether the type will have generic arguments applied.
+/// \param resolution The resolution to perform.
+///
+/// \returns the resolved type.
+Type resolveTypeInContext(TypeDecl *typeDecl, DeclContext *foundDC,
+                          TypeResolution resolution,
+                          TypeResolutionOptions options, bool isSpecialized);
 
-  /// Determine whether this is a "pass-through" typealias, which has the
-  /// same type parameters as the nominal type it references and specializes
-  /// the underlying nominal type with exactly those type parameters.
-  /// For example, the following typealias \c GX is a pass-through typealias:
-  ///
-  /// \code
-  /// struct X<T, U> { }
-  /// typealias GX<A, B> = X<A, B>
-  /// \endcode
-  ///
-  /// whereas \c GX2 and \c GX3 are not pass-through because \c GX2 has
-  /// different type parameters and \c GX3 doesn't pass its type parameters
-  /// directly through.
-  ///
-  /// \code
-  /// typealias GX2<A> = X<A, A>
-  /// typealias GX3<A, B> = X<B, A>
-  /// \endcode
-  static bool isPassThroughTypealias(TypeAliasDecl *typealias,
-                                     Type underlyingType,
-                                     NominalTypeDecl *nominal);
-  
-  /// Determine whether one type is a subtype of another.
-  ///
-  /// \param t1 The potential subtype.
-  /// \param t2 The potential supertype.
-  /// \param dc The context of the check.
-  ///
-  /// \returns true if \c t1 is a subtype of \c t2.
-  static bool isSubtypeOf(Type t1, Type t2, DeclContext *dc);
-  
-  /// Determine whether one type is implicitly convertible to another.
-  ///
-  /// \param t1 The potential source type of the conversion.
-  ///
-  /// \param t2 The potential destination type of the conversion.
-  ///
-  /// \param dc The context of the conversion.
-  ///
-  /// \param unwrappedIUO If non-null, will be set to indicate whether the
-  /// conversion force-unwrapped an implicitly-unwrapped optional.
-  ///
-  /// \returns true if \c t1 can be implicitly converted to \c t2.
-  static bool isConvertibleTo(Type t1, Type t2, DeclContext *dc,
-                              bool *unwrappedIUO = nullptr);
+/// Apply generic arguments to the given type.
+///
+/// This function requires a valid unbound generic type with the correct
+/// number of generic arguments given, whereas applyGenericArguments emits
+/// diagnostics in those cases.
+///
+/// \param unboundType The unbound generic type to which to apply arguments.
+/// \param decl The declaration of the type.
+/// \param loc The source location for diagnostic reporting.
+/// \param resolution The type resolution.
+/// \param genericArgs The list of generic arguments to apply to the type.
+///
+/// \returns A BoundGenericType bound to the given arguments, or null on
+/// error.
+///
+/// \see applyGenericArguments
+Type applyUnboundGenericArguments(UnboundGenericType *unboundType,
+                                  GenericTypeDecl *decl, SourceLoc loc,
+                                  TypeResolution resolution,
+                                  ArrayRef<Type> genericArgs);
 
-  /// Determine whether one type is explicitly convertible to another,
-  /// i.e. using an 'as' expression.
-  ///
-  /// \param t1 The potential source type of the conversion.
-  ///
-  /// \param t2 The potential destination type of the conversion.
-  ///
-  /// \param dc The context of the conversion.
-  ///
-  /// \returns true if \c t1 can be explicitly converted to \c t2.
-  static bool isExplicitlyConvertibleTo(Type t1, Type t2, DeclContext *dc);
+/// Substitute the given base type into the type of the given nested type,
+/// producing the effective type that the nested type will have.
+///
+/// \param module The module in which the substitution will be performed.
+/// \param member The member whose type projection is being computed.
+/// \param baseTy The base type that will be substituted for the 'Self' of the
+/// member.
+/// \param useArchetypes Whether to use context archetypes for outer generic
+/// parameters if the class is nested inside a generic function.
+Type substMemberTypeWithBase(ModuleDecl *module, TypeDecl *member, Type baseTy,
+                             bool useArchetypes = true);
 
-  /// Determine whether one type is bridged to another type.
-  ///
-  /// \param t1 The potential source type of the conversion.
-  ///
-  /// \param t2 The potential destination type of the conversion.
-  ///
-  /// \param dc The context of the conversion.
-  ///
-  /// \param unwrappedIUO If non-null, will be set to indicate whether the
-  /// conversion force-unwrapped an implicitly-unwrapped optional.
-  ///
-  /// \returns true if \c t1 can be explicitly converted to \c t2.
-  static bool isObjCBridgedTo(Type t1, Type t2, DeclContext *dc,
-                              bool *unwrappedIUO = nullptr);
+/// Determine whether this is a "pass-through" typealias, which has the
+/// same type parameters as the nominal type it references and specializes
+/// the underlying nominal type with exactly those type parameters.
+/// For example, the following typealias \c GX is a pass-through typealias:
+///
+/// \code
+/// struct X<T, U> { }
+/// typealias GX<A, B> = X<A, B>
+/// \endcode
+///
+/// whereas \c GX2 and \c GX3 are not pass-through because \c GX2 has
+/// different type parameters and \c GX3 doesn't pass its type parameters
+/// directly through.
+///
+/// \code
+/// typealias GX2<A> = X<A, A>
+/// typealias GX3<A, B> = X<B, A>
+/// \endcode
+bool isPassThroughTypealias(TypeAliasDecl *typealias, Type underlyingType,
+                            NominalTypeDecl *nominal);
 
-  /// Return true if performing a checked cast from one type to another
-  /// with the "as!" operator could possibly succeed.
-  ///
-  /// \param t1 The potential source type of the cast.
-  ///
-  /// \param t2 The potential destination type of the cast.
-  ///
-  /// \param dc The context of the cast.
-  ///
-  /// \returns true if a checked cast from \c t1 to \c t2 may succeed, and
-  /// false if it will certainly fail, e.g. because the types are unrelated.
-  static bool checkedCastMaySucceed(Type t1, Type t2, DeclContext *dc);
+/// Determine whether one type is a subtype of another.
+///
+/// \param t1 The potential subtype.
+/// \param t2 The potential supertype.
+/// \param dc The context of the check.
+///
+/// \returns true if \c t1 is a subtype of \c t2.
+bool isSubtypeOf(Type t1, Type t2, DeclContext *dc);
 
-  /// Determine whether a constraint of the given kind can be satisfied
-  /// by the two types.
-  ///
-  /// \param t1 The first type of the constraint.
-  ///
-  /// \param t2 The second type of the constraint.
-  ///
-  /// \param openArchetypes If true, archetypes are replaced with type
-  /// variables, and the result can be interpreted as whether or not the
-  /// two types can possibly equal at runtime.
-  ///
-  /// \param dc The context of the conversion.
-  ///
-  /// \param unwrappedIUO   If non-null, will be set to \c true if the coercion
-  /// or bridge operation force-unwraps an implicitly-unwrapped optional.
-  ///
-  /// \returns true if \c t1 and \c t2 satisfy the constraint.
-  static bool typesSatisfyConstraint(Type t1, Type t2,
-                                     bool openArchetypes,
-                                     constraints::ConstraintKind kind,
-                                     DeclContext *dc,
-                                     bool *unwrappedIUO = nullptr);
+/// Determine whether one type is implicitly convertible to another.
+///
+/// \param t1 The potential source type of the conversion.
+///
+/// \param t2 The potential destination type of the conversion.
+///
+/// \param dc The context of the conversion.
+///
+/// \param unwrappedIUO If non-null, will be set to indicate whether the
+/// conversion force-unwrapped an implicitly-unwrapped optional.
+///
+/// \returns true if \c t1 can be implicitly converted to \c t2.
+bool isConvertibleTo(Type t1, Type t2, DeclContext *dc,
+                     bool *unwrappedIUO = nullptr);
 
-  /// If the inputs to an apply expression use a consistent "sugar" type
-  /// (that is, a typealias or shorthand syntax) equivalent to the result type
-  /// of the function, set the result type of the expression to that sugar type.
-  static Expr *substituteInputSugarTypeForResult(ApplyExpr *E);
+/// Determine whether one type is explicitly convertible to another,
+/// i.e. using an 'as' expression.
+///
+/// \param t1 The potential source type of the conversion.
+///
+/// \param t2 The potential destination type of the conversion.
+///
+/// \param dc The context of the conversion.
+///
+/// \returns true if \c t1 can be explicitly converted to \c t2.
+bool isExplicitlyConvertibleTo(Type t1, Type t2, DeclContext *dc);
 
-  static bool typeCheckAbstractFunctionBodyUntil(AbstractFunctionDecl *AFD,
-                                                 SourceLoc EndTypeCheckLoc);
-  static bool typeCheckAbstractFunctionBody(AbstractFunctionDecl *AFD);
+/// Determine whether one type is bridged to another type.
+///
+/// \param t1 The potential source type of the conversion.
+///
+/// \param t2 The potential destination type of the conversion.
+///
+/// \param dc The context of the conversion.
+///
+/// \param unwrappedIUO If non-null, will be set to indicate whether the
+/// conversion force-unwrapped an implicitly-unwrapped optional.
+///
+/// \returns true if \c t1 can be explicitly converted to \c t2.
+bool isObjCBridgedTo(Type t1, Type t2, DeclContext *dc,
+                     bool *unwrappedIUO = nullptr);
 
-  /// Try to apply the function builder transform of the given builder type
-  /// to the body of the function.
-  ///
-  /// \returns \c None if the builder transformation cannot be applied at all,
-  /// e.g., because of a \c return statement. Otherwise, returns either the
-  /// fully type-checked body of the function (on success) or a \c nullptr
-  /// value if an error occurred while type checking the transformed body.
-  static Optional<BraceStmt *> applyFunctionBuilderBodyTransform(
-      FuncDecl *func, Type builderType);
+/// Return true if performing a checked cast from one type to another
+/// with the "as!" operator could possibly succeed.
+///
+/// \param t1 The potential source type of the cast.
+///
+/// \param t2 The potential destination type of the cast.
+///
+/// \param dc The context of the cast.
+///
+/// \returns true if a checked cast from \c t1 to \c t2 may succeed, and
+/// false if it will certainly fail, e.g. because the types are unrelated.
+bool checkedCastMaySucceed(Type t1, Type t2, DeclContext *dc);
 
-  static bool typeCheckClosureBody(ClosureExpr *closure);
+/// Determine whether a constraint of the given kind can be satisfied
+/// by the two types.
+///
+/// \param t1 The first type of the constraint.
+///
+/// \param t2 The second type of the constraint.
+///
+/// \param openArchetypes If true, archetypes are replaced with type
+/// variables, and the result can be interpreted as whether or not the
+/// two types can possibly equal at runtime.
+///
+/// \param dc The context of the conversion.
+///
+/// \param unwrappedIUO   If non-null, will be set to \c true if the coercion
+/// or bridge operation force-unwraps an implicitly-unwrapped optional.
+///
+/// \returns true if \c t1 and \c t2 satisfy the constraint.
+bool typesSatisfyConstraint(Type t1, Type t2, bool openArchetypes,
+                            constraints::ConstraintKind kind, DeclContext *dc,
+                            bool *unwrappedIUO = nullptr);
 
-  static bool typeCheckTapBody(TapExpr *expr, DeclContext *DC);
+/// If the inputs to an apply expression use a consistent "sugar" type
+/// (that is, a typealias or shorthand syntax) equivalent to the result type
+/// of the function, set the result type of the expression to that sugar type.
+Expr *substituteInputSugarTypeForResult(ApplyExpr *E);
 
-  static Type typeCheckParameterDefault(Expr *&defaultValue, DeclContext *DC,
-                                        Type paramType, bool isAutoClosure);
+bool typeCheckAbstractFunctionBodyUntil(AbstractFunctionDecl *AFD,
+                                        SourceLoc EndTypeCheckLoc);
+bool typeCheckAbstractFunctionBody(AbstractFunctionDecl *AFD);
 
-  static void typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD);
+/// Try to apply the function builder transform of the given builder type
+/// to the body of the function.
+///
+/// \returns \c None if the builder transformation cannot be applied at all,
+/// e.g., because of a \c return statement. Otherwise, returns either the
+/// fully type-checked body of the function (on success) or a \c nullptr
+/// value if an error occurred while type checking the transformed body.
+Optional<BraceStmt *> applyFunctionBuilderBodyTransform(FuncDecl *func,
+                                                        Type builderType);
 
-  static void processREPLTopLevel(SourceFile &SF);
+bool typeCheckClosureBody(ClosureExpr *closure);
 
-  static void typeCheckDecl(Decl *D);
+bool typeCheckTapBody(TapExpr *expr, DeclContext *DC);
 
-  static void addImplicitDynamicAttribute(Decl *D);
-  static void checkDeclAttributes(Decl *D);
-  static void checkParameterAttributes(ParameterList *params);
+Type typeCheckParameterDefault(Expr *&defaultValue, DeclContext *DC,
+                               Type paramType, bool isAutoClosure);
 
-  static Type checkReferenceOwnershipAttr(VarDecl *D, Type interfaceType,
-                                          ReferenceOwnershipAttr *attr);
+void typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD);
 
-  /// Infer default value witnesses for all requirements in the given protocol.
-  static void inferDefaultWitnesses(ProtocolDecl *proto);
+void processREPLTopLevel(SourceFile &SF);
 
-  /// For a generic requirement in a protocol, make sure that the requirement
-  /// set didn't add any requirements to Self or its associated types.
-  static void checkProtocolSelfRequirements(ValueDecl *decl);
+void typeCheckDecl(Decl *D);
 
-  /// All generic parameters of a generic function must be referenced in the
-  /// declaration's type, otherwise we have no way to infer them.
-  static void checkReferencedGenericParams(GenericContext *dc);
+void addImplicitDynamicAttribute(Decl *D);
+void checkDeclAttributes(Decl *D);
+void checkParameterAttributes(ParameterList *params);
 
-  /// Construct a new generic environment for the given declaration context.
-  ///
-  /// \param paramSource The source of generic info: either a generic parameter
-  /// list or a generic context with a \c where clause dependent on outer
-  /// generic parameters.
-  ///
-  /// \param dc The declaration context in which to perform the validation.
-  ///
-  /// \param outerSignature The generic signature of the outer
-  /// context, if not available as part of the \c dc argument (used
-  /// for SIL parsing).
-  ///
-  /// \param allowConcreteGenericParams Whether or not to allow
-  /// same-type constraints between generic parameters and concrete types.
-  ///
-  /// \param additionalRequirements Additional requirements to add
-  /// directly to the GSB.
-  ///
-  /// \param inferenceSources Additional types to infer requirements from.
-  ///
-  /// \returns the resulting generic signature.
-  static GenericSignature checkGenericSignature(
-                        GenericParamSource paramSource,
-                        DeclContext *dc,
-                        GenericSignature outerSignature,
-                        bool allowConcreteGenericParams,
-                        SmallVector<Requirement, 2> additionalRequirements = {},
-                        SmallVector<TypeLoc, 2> inferenceSources = {});
+Type checkReferenceOwnershipAttr(VarDecl *D, Type interfaceType,
+                                 ReferenceOwnershipAttr *attr);
 
-  /// Create a text string that describes the bindings of generic parameters
-  /// that are relevant to the given set of types, e.g.,
-  /// "[with T = Bar, U = Wibble]".
-  ///
-  /// \param types The types that will be scanned for generic type parameters,
-  /// which will be used in the resulting type.
-  ///
-  /// \param genericParams The generic parameters to use to resugar any
-  /// generic parameters that occur within the types.
-  ///
-  /// \param substitutions The generic parameter -> generic argument
-  /// substitutions that will have been applied to these types.
-  /// These are used to produce the "parameter = argument" bindings in the test.
-  static std::string
-  gatherGenericParamBindingsText(ArrayRef<Type> types,
-                              TypeArrayView<GenericTypeParamType> genericParams,
-                              TypeSubstitutionFn substitutions);
+/// Infer default value witnesses for all requirements in the given protocol.
+void inferDefaultWitnesses(ProtocolDecl *proto);
 
-  /// Check the given set of generic arguments against the requirements in a
-  /// generic signature.
-  ///
-  /// \param dc The context in which the generic arguments should be checked.
-  /// \param loc The location at which any diagnostics should be emitted.
-  /// \param noteLoc The location at which any notes will be printed.
-  /// \param owner The type that owns the generic signature.
-  /// \param genericParams The generic parameters being substituted.
-  /// \param requirements The requirements against which the generic arguments
-  /// should be checked.
-  /// \param substitutions Substitutions from interface types of the signature.
-  /// \param conformanceOptions The flags to use when checking conformance
-  /// requirement.
-  /// \param listener The generic check listener used to pick requirements and
-  /// notify callers about diagnosed errors.
-  static RequirementCheckResult checkGenericArguments(
-      DeclContext *dc, SourceLoc loc, SourceLoc noteLoc, Type owner,
-      TypeArrayView<GenericTypeParamType> genericParams,
-      ArrayRef<Requirement> requirements,
-      TypeSubstitutionFn substitutions,
-      LookupConformanceFn conformances,
-      ConformanceCheckOptions conformanceOptions,
-      GenericRequirementsCheckListener *listener = nullptr,
-      SubstOptions options = None);
+/// For a generic requirement in a protocol, make sure that the requirement
+/// set didn't add any requirements to Self or its associated types.
+void checkProtocolSelfRequirements(ValueDecl *decl);
 
-  /// Add any implicitly-defined constructors required for the given
-  /// struct or class.
-  static void addImplicitConstructors(NominalTypeDecl *typeDecl);
+/// All generic parameters of a generic function must be referenced in the
+/// declaration's type, otherwise we have no way to infer them.
+void checkReferencedGenericParams(GenericContext *dc);
+
+/// Construct a new generic environment for the given declaration context.
+///
+/// \param paramSource The source of generic info: either a generic parameter
+/// list or a generic context with a \c where clause dependent on outer
+/// generic parameters.
+///
+/// \param dc The declaration context in which to perform the validation.
+///
+/// \param outerSignature The generic signature of the outer
+/// context, if not available as part of the \c dc argument (used
+/// for SIL parsing).
+///
+/// \param allowConcreteGenericParams Whether or not to allow
+/// same-type constraints between generic parameters and concrete types.
+///
+/// \param additionalRequirements Additional requirements to add
+/// directly to the GSB.
+///
+/// \param inferenceSources Additional types to infer requirements from.
+///
+/// \returns the resulting generic signature.
+GenericSignature
+checkGenericSignature(GenericParamSource paramSource, DeclContext *dc,
+                      GenericSignature outerSignature,
+                      bool allowConcreteGenericParams,
+                      SmallVector<Requirement, 2> additionalRequirements = {},
+                      SmallVector<TypeLoc, 2> inferenceSources = {});
+
+/// Create a text string that describes the bindings of generic parameters
+/// that are relevant to the given set of types, e.g.,
+/// "[with T = Bar, U = Wibble]".
+///
+/// \param types The types that will be scanned for generic type parameters,
+/// which will be used in the resulting type.
+///
+/// \param genericParams The generic parameters to use to resugar any
+/// generic parameters that occur within the types.
+///
+/// \param substitutions The generic parameter -> generic argument
+/// substitutions that will have been applied to these types.
+/// These are used to produce the "parameter = argument" bindings in the test.
+std::string gatherGenericParamBindingsText(
+    ArrayRef<Type> types, TypeArrayView<GenericTypeParamType> genericParams,
+    TypeSubstitutionFn substitutions);
+
+/// Check the given set of generic arguments against the requirements in a
+/// generic signature.
+///
+/// \param dc The context in which the generic arguments should be checked.
+/// \param loc The location at which any diagnostics should be emitted.
+/// \param noteLoc The location at which any notes will be printed.
+/// \param owner The type that owns the generic signature.
+/// \param genericParams The generic parameters being substituted.
+/// \param requirements The requirements against which the generic arguments
+/// should be checked.
+/// \param substitutions Substitutions from interface types of the signature.
+/// \param conformanceOptions The flags to use when checking conformance
+/// requirement.
+/// \param listener The generic check listener used to pick requirements and
+/// notify callers about diagnosed errors.
+RequirementCheckResult checkGenericArguments(
+    DeclContext *dc, SourceLoc loc, SourceLoc noteLoc, Type owner,
+    TypeArrayView<GenericTypeParamType> genericParams,
+    ArrayRef<Requirement> requirements, TypeSubstitutionFn substitutions,
+    LookupConformanceFn conformances,
+    ConformanceCheckOptions conformanceOptions,
+    GenericRequirementsCheckListener *listener = nullptr,
+    SubstOptions options = None);
+
+/// Add any implicitly-defined constructors required for the given
+/// struct or class.
+void addImplicitConstructors(NominalTypeDecl *typeDecl);
+
+/// Fold the given sequence expression into an (unchecked) expression
+/// tree.
+Expr *foldSequence(SequenceExpr *expr, DeclContext *dc);
+
+/// Given an pre-folded expression, find LHS from the expression if a binary
+/// operator \c name appended to the expression.
+Expr *findLHS(DeclContext *DC, Expr *E, Identifier name);
+
+/// Type check the given expression.
+///
+/// \param expr The expression to type-check, which will be modified in
+/// place.
+///
+/// \param convertTypePurpose When convertType is specified, this indicates
+/// what the conversion is doing.  This allows diagnostics generation to
+/// produce more specific and helpful error messages when the conversion fails
+/// to be possible.
+///
+/// \param convertType The type that the expression is being converted to,
+/// or null if the expression is standalone. The location information is
+/// only used for diagnostics should the conversion fail; it is safe to pass
+/// a TypeLoc without location information.
+///
+/// \param options Options that control how type checking is performed.
+///
+/// \param listener If non-null, a listener that will be notified of important
+/// events in the type checking of this expression, and which can introduce
+/// additional constraints.
+///
+/// \returns The type of the top-level expression, or Type() if an
+///          error occurred.
+Type typeCheckExpression(Expr *&expr, DeclContext *dc,
+                         TypeLoc convertType = TypeLoc(),
+                         ContextualTypePurpose convertTypePurpose = CTP_Unused,
+                         TypeCheckExprOptions options = TypeCheckExprOptions(),
+                         ExprTypeCheckListener *listener = nullptr);
+
+Optional<constraints::SolutionApplicationTarget>
+typeCheckExpression(constraints::SolutionApplicationTarget &target,
+                    bool &unresolvedTypeExprs,
+                    TypeCheckExprOptions options = TypeCheckExprOptions(),
+                    ExprTypeCheckListener *listener = nullptr);
+
+/// Type check the given expression and return its type without
+/// applying the solution.
+///
+/// \param expr The expression to type-check.
+///
+/// \param referencedDecl Will be set to the declaration that is referenced by
+/// the expression.
+///
+/// \param allowFreeTypeVariables Whether free type variables are allowed in
+/// the solution, and what to do with them.
+///
+/// \param listener If non-null, a listener that will be notified of important
+/// events in the type checking of this expression, and which can introduce
+/// additional constraints.
+///
+/// \returns the type of \p expr on success, Type() otherwise.
+/// FIXME: expr may still be modified...
+Type getTypeOfExpressionWithoutApplying(
+    Expr *&expr, DeclContext *dc, ConcreteDeclRef &referencedDecl,
+    FreeTypeVariableBinding allowFreeTypeVariables =
+        FreeTypeVariableBinding::Disallow,
+    ExprTypeCheckListener *listener = nullptr);
+
+/// Return the type of operator function for specified LHS, or a null
+/// \c Type on error.
+FunctionType *getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
+                                          Identifier opName,
+                                          DeclRefKind refKind,
+                                          ConcreteDeclRef &refdDecl);
+
+/// Check the key-path expression.
+///
+/// Returns the type of the last component of the key-path.
+Optional<Type> checkObjCKeyPathExpr(DeclContext *dc, KeyPathExpr *expr,
+                                    bool requireResultType = false);
+
+/// Type check whether the given type declaration includes members of
+/// unsupported recursive value types.
+///
+/// \param decl The declaration to be type-checked. This process will not
+/// modify the declaration.
+void checkDeclCircularity(NominalTypeDecl *decl);
+
+/// Type check whether the given switch statement exhaustively covers
+/// its domain.
+///
+/// \param stmt The switch statement to be type-checked.  No modification of
+/// the statement occurs.
+/// \param DC The decl context containing \p stmt.
+/// \param limitChecking The checking process relies on the switch statement
+/// being well-formed.  If it is not, pass true to this flag to run a limited
+/// form of analysis.
+void checkSwitchExhaustiveness(const SwitchStmt *stmt, const DeclContext *DC,
+                               bool limitChecking);
+
+/// Type check the given expression as a condition, which converts
+/// it to a logic value.
+///
+/// \param expr The expression to type-check, which will be modified in place
+/// to return a logic value (builtin i1).
+///
+/// \returns true if an error occurred, false otherwise.
+bool typeCheckCondition(Expr *&expr, DeclContext *dc);
+
+/// Type check the given 'if' or 'while' statement condition, which
+/// either converts an expression to a logic value or bind variables to the
+/// contents of an Optional.
+///
+/// \param cond The condition to type-check, which will be modified in place.
+///
+/// \returns true if an error occurred, false otherwise.
+bool typeCheckStmtCondition(StmtCondition &cond, DeclContext *dc,
+                            Diag<> diagnosticForAlwaysTrue);
+
+/// Determine the semantics of a checked cast operation.
+///
+/// \param fromType       The source type of the cast.
+/// \param toType         The destination type of the cast.
+/// \param dc             The context of the cast.
+/// \param diagLoc        The location at which to report diagnostics.
+/// \param fromExpr       The expression describing the input operand.
+/// \param diagToRange    The source range of the destination type.
+///
+/// \returns a CheckedCastKind indicating the semantics of the cast. If the
+/// cast is invalid, Unresolved is returned. If the cast represents an implicit
+/// conversion, Coercion is returned.
+CheckedCastKind typeCheckCheckedCast(Type fromType, Type toType,
+                                     CheckedCastContextKind ctxKind,
+                                     DeclContext *dc, SourceLoc diagLoc,
+                                     Expr *fromExpr, SourceRange diagToRange);
+
+/// Find the Objective-C class that bridges between a value of the given
+/// dynamic type and the given value type.
+///
+/// \param dc The declaration context from which we will look for
+/// bridging.
+///
+/// \param dynamicType A dynamic type from which we are bridging. Class and
+/// Objective-C protocol types can be used for bridging.
+///
+/// \param valueType The value type being queried, e.g., String.
+///
+/// \returns the Objective-C class type that represents the value
+/// type as an Objective-C class, e.g., \c NSString represents \c
+/// String, or a null type if there is no such type or if the
+/// dynamic type isn't something we can start from.
+Type getDynamicBridgedThroughObjCClass(DeclContext *dc, Type dynamicType,
+                                       Type valueType);
+
+/// Resolve ambiguous pattern/expr productions inside a pattern using
+/// name lookup information. Must be done before type-checking the pattern.
+Pattern *resolvePattern(Pattern *P, DeclContext *dc, bool isStmtCondition);
+
+/// Type check the given pattern.
+///
+/// \returns the type of the pattern, which may be an error type if an
+/// unrecoverable error occurred. If the options permit it, the type may
+/// involve \c UnresolvedType (for patterns with no type information) and
+/// unbound generic types.
+Type typeCheckPattern(ContextualPattern pattern);
+
+bool typeCheckCatchPattern(CatchStmt *S, DeclContext *dc);
+
+/// Coerce a pattern to the given type.
+///
+/// \param pattern The contextual pattern.
+/// \param type the type to coerce the pattern to.
+/// \param options Options that control the coercion.
+///
+/// \returns the coerced pattern, or nullptr if the coercion failed.
+Pattern *coercePatternToType(ContextualPattern pattern, Type type,
+                             TypeResolutionOptions options);
+bool typeCheckExprPattern(ExprPattern *EP, DeclContext *DC, Type type);
+
+/// Coerce the specified parameter list of a ClosureExpr to the specified
+/// contextual type.
+void coerceParameterListToType(ParameterList *P, ClosureExpr *CE,
+                               AnyFunctionType *FN);
+
+/// Type-check an initialized variable pattern declaration.
+bool typeCheckBinding(Pattern *&P, Expr *&Init, DeclContext *DC,
+                      Type patternType);
+bool typeCheckPatternBinding(PatternBindingDecl *PBD, unsigned patternNumber,
+                             Type patternType = Type());
+
+/// Type-check a for-each loop's pattern binding and sequence together.
+///
+/// \returns true if a failure occurred.
+bool typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt);
+
+/// Compute the set of captures for the given function or closure.
+void computeCaptures(AnyFunctionRef AFR);
+
+/// Check for invalid captures from stored property initializers.
+void checkPatternBindingCaptures(IterableDeclContext *DC);
+
+/// Change the context of closures in the given initializer
+/// expression to the given context.
+///
+/// \returns true if any closures were found
+bool contextualizeInitializer(Initializer *DC, Expr *init);
+void contextualizeTopLevelCode(TopLevelCodeDecl *TLCD);
+
+/// Retrieve the default type for the given protocol.
+///
+/// Some protocols, particularly those that correspond to literals, have
+/// default types associated with them. This routine retrieves that default
+/// type.
+///
+/// \returns the default type, or null if there is no default type for
+/// this protocol.
+Type getDefaultType(ProtocolDecl *protocol, DeclContext *dc);
+
+/// Coerce the given expression to materializable type, if it
+/// isn't already.
+Expr *coerceToRValue(
+    ASTContext &Context, Expr *expr,
+    llvm::function_ref<Type(Expr *)> getType =
+        [](Expr *expr) { return expr->getType(); },
+    llvm::function_ref<void(Expr *, Type)> setType =
+        [](Expr *expr, Type type) { expr->setType(type); });
+
+/// Add implicit load expression to given AST, this is sometimes
+/// more complicated than simplify wrapping given root in newly created
+/// `LoadExpr`, because `ForceValueExpr` and `ParenExpr` supposed to appear
+/// only at certain positions in AST.
+Expr *addImplicitLoadExpr(
+    ASTContext &Context, Expr *expr,
+    std::function<Type(Expr *)> getType = [](Expr *E) { return E->getType(); },
+    std::function<void(Expr *, Type)> setType =
+        [](Expr *E, Type type) { E->setType(type); });
+
+/// Determine whether the given type contains the given protocol.
+///
+/// \param DC The context in which to check conformance. This affects, for
+/// example, extension visibility.
+///
+/// \param options Options that control the conformance check.
+///
+/// \returns the conformance, if \c T conforms to the protocol \c Proto, or
+/// an empty optional.
+ProtocolConformanceRef containsProtocol(Type T, ProtocolDecl *Proto,
+                                        DeclContext *DC,
+                                        ConformanceCheckOptions options);
+
+/// Determine whether the given type conforms to the given protocol.
+///
+/// Unlike subTypeOfProtocol(), this will return false for existentials of
+/// non-self conforming protocols.
+///
+/// \param DC The context in which to check conformance. This affects, for
+/// example, extension visibility.
+///
+/// \param options Options that control the conformance check.
+///
+/// \param ComplainLoc If valid, then this function will emit diagnostics if
+/// T does not conform to the given protocol. The primary diagnostic will
+/// be placed at this location, with notes for each of the protocol
+/// requirements not satisfied.
+///
+/// \returns The protocol conformance, if \c T conforms to the
+/// protocol \c Proto, or \c None.
+ProtocolConformanceRef conformsToProtocol(Type T, ProtocolDecl *Proto,
+                                          DeclContext *DC,
+                                          ConformanceCheckOptions options,
+                                          SourceLoc ComplainLoc = SourceLoc());
+
+/// Functor class suitable for use as a \c LookupConformanceFn to look up a
+/// conformance through a particular declaration context.
+class LookUpConformance {
+  DeclContext *dc;
 
 public:
-  /// Fold the given sequence expression into an (unchecked) expression
-  /// tree.
-  static Expr *foldSequence(SequenceExpr *expr, DeclContext *dc);
+  explicit LookUpConformance(DeclContext *dc) : dc(dc) {}
 
-private:
-  /// Given an pre-folded expression, find LHS from the expression if a binary
-  /// operator \c name appended to the expression.
-  static Expr *findLHS(DeclContext *DC, Expr *E, Identifier name);
-
-public:
-  /// Type check the given expression.
-  ///
-  /// \param expr The expression to type-check, which will be modified in
-  /// place.
-  ///
-  /// \param convertTypePurpose When convertType is specified, this indicates
-  /// what the conversion is doing.  This allows diagnostics generation to
-  /// produce more specific and helpful error messages when the conversion fails
-  /// to be possible.
-  ///
-  /// \param convertType The type that the expression is being converted to,
-  /// or null if the expression is standalone. The location information is
-  /// only used for diagnostics should the conversion fail; it is safe to pass
-  /// a TypeLoc without location information.
-  ///
-  /// \param options Options that control how type checking is performed.
-  ///
-  /// \param listener If non-null, a listener that will be notified of important
-  /// events in the type checking of this expression, and which can introduce
-  /// additional constraints.
-  ///
-  /// \returns The type of the top-level expression, or Type() if an
-  ///          error occurred.
-  static Type
-  typeCheckExpression(Expr *&expr, DeclContext *dc,
-                      TypeLoc convertType = TypeLoc(),
-                      ContextualTypePurpose convertTypePurpose = CTP_Unused,
-                      TypeCheckExprOptions options = TypeCheckExprOptions(),
-                      ExprTypeCheckListener *listener = nullptr);
-
-  static Optional<constraints::SolutionApplicationTarget>
-  typeCheckExpression(constraints::SolutionApplicationTarget &target,
-                      bool &unresolvedTypeExprs,
-                      TypeCheckExprOptions options = TypeCheckExprOptions(),
-                      ExprTypeCheckListener *listener = nullptr);
-
-  /// Type check the given expression and return its type without
-  /// applying the solution.
-  ///
-  /// \param expr The expression to type-check.
-  ///
-  /// \param referencedDecl Will be set to the declaration that is referenced by
-  /// the expression.
-  ///
-  /// \param allowFreeTypeVariables Whether free type variables are allowed in
-  /// the solution, and what to do with them.
-  ///
-  /// \param listener If non-null, a listener that will be notified of important
-  /// events in the type checking of this expression, and which can introduce
-  /// additional constraints.
-  ///
-  /// \returns the type of \p expr on success, Type() otherwise.
-  /// FIXME: expr may still be modified...
-  static Type getTypeOfExpressionWithoutApplying(
-      Expr *&expr, DeclContext *dc,
-      ConcreteDeclRef &referencedDecl,
-      FreeTypeVariableBinding allowFreeTypeVariables =
-                              FreeTypeVariableBinding::Disallow,
-      ExprTypeCheckListener *listener = nullptr);
-
-  /// Return the type of operator function for specified LHS, or a null
-  /// \c Type on error.
-  static FunctionType *getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
-                                                   Identifier opName,
-                                                   DeclRefKind refKind,
-                                                   ConcreteDeclRef &refdDecl);
-
-  /// Check the key-path expression.
-  ///
-  /// Returns the type of the last component of the key-path.
-  static Optional<Type> checkObjCKeyPathExpr(DeclContext *dc, KeyPathExpr *expr,
-                                             bool requireResultType = false);
-
-  /// Type check whether the given type declaration includes members of
-  /// unsupported recursive value types.
-  ///
-  /// \param decl The declaration to be type-checked. This process will not
-  /// modify the declaration.
-  static void checkDeclCircularity(NominalTypeDecl *decl);
-
-  /// Type check whether the given switch statement exhaustively covers
-  /// its domain.
-  ///
-  /// \param stmt The switch statement to be type-checked.  No modification of
-  /// the statement occurs.
-  /// \param DC The decl context containing \p stmt.
-  /// \param limitChecking The checking process relies on the switch statement
-  /// being well-formed.  If it is not, pass true to this flag to run a limited
-  /// form of analysis.
-  static void checkSwitchExhaustiveness(const SwitchStmt *stmt,
-                                        const DeclContext *DC,
-                                        bool limitChecking);
-
-  /// Type check the given expression as a condition, which converts
-  /// it to a logic value.
-  ///
-  /// \param expr The expression to type-check, which will be modified in place
-  /// to return a logic value (builtin i1).
-  ///
-  /// \returns true if an error occurred, false otherwise.
-  static bool typeCheckCondition(Expr *&expr, DeclContext *dc);
-
-  /// Type check the given 'if' or 'while' statement condition, which
-  /// either converts an expression to a logic value or bind variables to the
-  /// contents of an Optional.
-  ///
-  /// \param cond The condition to type-check, which will be modified in place.
-  ///
-  /// \returns true if an error occurred, false otherwise.
-  static bool typeCheckStmtCondition(StmtCondition &cond, DeclContext *dc,
-                                     Diag<> diagnosticForAlwaysTrue);
-
-  /// Determine the semantics of a checked cast operation.
-  ///
-  /// \param fromType       The source type of the cast.
-  /// \param toType         The destination type of the cast.
-  /// \param dc             The context of the cast.
-  /// \param diagLoc        The location at which to report diagnostics.
-  /// \param fromExpr       The expression describing the input operand.
-  /// \param diagToRange    The source range of the destination type.
-  ///
-  /// \returns a CheckedCastKind indicating the semantics of the cast. If the
-  /// cast is invalid, Unresolved is returned. If the cast represents an implicit
-  /// conversion, Coercion is returned.
-  static CheckedCastKind typeCheckCheckedCast(Type fromType,
-                                              Type toType,
-                                              CheckedCastContextKind ctxKind,
-                                              DeclContext *dc,
-                                              SourceLoc diagLoc,
-                                              Expr *fromExpr,
-                                              SourceRange diagToRange);
-
-  /// Find the Objective-C class that bridges between a value of the given
-  /// dynamic type and the given value type.
-  ///
-  /// \param dc The declaration context from which we will look for
-  /// bridging.
-  ///
-  /// \param dynamicType A dynamic type from which we are bridging. Class and
-  /// Objective-C protocol types can be used for bridging.
-  ///
-  /// \param valueType The value type being queried, e.g., String.
-  ///
-  /// \returns the Objective-C class type that represents the value
-  /// type as an Objective-C class, e.g., \c NSString represents \c
-  /// String, or a null type if there is no such type or if the
-  /// dynamic type isn't something we can start from.
-  static Type getDynamicBridgedThroughObjCClass(DeclContext *dc,
-                                                Type dynamicType,
-                                                Type valueType);
-
-  /// Resolve ambiguous pattern/expr productions inside a pattern using
-  /// name lookup information. Must be done before type-checking the pattern.
-  static Pattern *resolvePattern(Pattern *P, DeclContext *dc,
-                                 bool isStmtCondition);
-
-  /// Type check the given pattern.
-  ///
-  /// \returns the type of the pattern, which may be an error type if an
-  /// unrecoverable error occurred. If the options permit it, the type may
-  /// involve \c UnresolvedType (for patterns with no type information) and
-  /// unbound generic types.
-  static Type typeCheckPattern(ContextualPattern pattern);
-
-  static bool typeCheckCatchPattern(CatchStmt *S, DeclContext *dc);
-
-  /// Coerce a pattern to the given type.
-  ///
-  /// \param pattern The contextual pattern.
-  /// \param type the type to coerce the pattern to.
-  /// \param options Options that control the coercion.
-  ///
-  /// \returns the coerced pattern, or nullptr if the coercion failed.
-  static Pattern *coercePatternToType(ContextualPattern pattern, Type type,
-                                      TypeResolutionOptions options);
-  static bool typeCheckExprPattern(ExprPattern *EP, DeclContext *DC,
-                                   Type type);
-
-  /// Coerce the specified parameter list of a ClosureExpr to the specified
-  /// contextual type.
-  static void coerceParameterListToType(ParameterList *P, ClosureExpr *CE,
-                                        AnyFunctionType *FN);
-  
-  /// Type-check an initialized variable pattern declaration.
-  static bool typeCheckBinding(Pattern *&P, Expr *&Init, DeclContext *DC,
-                               Type patternType);
-  static bool typeCheckPatternBinding(PatternBindingDecl *PBD,
-                                      unsigned patternNumber,
-                                      Type patternType = Type());
-
-  /// Type-check a for-each loop's pattern binding and sequence together.
-  ///
-  /// \returns true if a failure occurred.
-  static bool typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt);
-
-  /// Compute the set of captures for the given function or closure.
-  static void computeCaptures(AnyFunctionRef AFR);
-
-  /// Check for invalid captures from stored property initializers.
-  static void checkPatternBindingCaptures(IterableDeclContext *DC);
-
-  /// Change the context of closures in the given initializer
-  /// expression to the given context.
-  ///
-  /// \returns true if any closures were found
-  static bool contextualizeInitializer(Initializer *DC, Expr *init);
-  static void contextualizeTopLevelCode(TopLevelCodeDecl *TLCD);
-
-  /// Retrieve the default type for the given protocol.
-  ///
-  /// Some protocols, particularly those that correspond to literals, have
-  /// default types associated with them. This routine retrieves that default
-  /// type.
-  ///
-  /// \returns the default type, or null if there is no default type for
-  /// this protocol.
-  static Type getDefaultType(ProtocolDecl *protocol, DeclContext *dc);
-
-  /// Coerce the given expression to materializable type, if it
-  /// isn't already.
-  static Expr *coerceToRValue(
-      ASTContext &Context, Expr *expr,
-      llvm::function_ref<Type(Expr *)> getType =
-          [](Expr *expr) { return expr->getType(); },
-      llvm::function_ref<void(Expr *, Type)> setType =
-          [](Expr *expr, Type type) { expr->setType(type); });
-
-  /// Add implicit load expression to given AST, this is sometimes
-  /// more complicated than simplify wrapping given root in newly created
-  /// `LoadExpr`, because `ForceValueExpr` and `ParenExpr` supposed to appear
-  /// only at certain positions in AST.
-  static Expr *addImplicitLoadExpr(ASTContext &Context, Expr *expr,
-                                   std::function<Type(Expr *)> getType =
-                                       [](Expr *E) { return E->getType(); },
-                                   std::function<void(Expr *, Type)> setType =
-                                       [](Expr *E, Type type) {
-                                         E->setType(type);
-                                       });
-
-  /// Determine whether the given type contains the given protocol.
-  ///
-  /// \param DC The context in which to check conformance. This affects, for
-  /// example, extension visibility.
-  ///
-  /// \param options Options that control the conformance check.
-  ///
-  /// \returns the conformance, if \c T conforms to the protocol \c Proto, or
-  /// an empty optional.
-  static ProtocolConformanceRef
-  containsProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
-                   ConformanceCheckOptions options);
-
-  /// Determine whether the given type conforms to the given protocol.
-  ///
-  /// Unlike subTypeOfProtocol(), this will return false for existentials of
-  /// non-self conforming protocols.
-  ///
-  /// \param DC The context in which to check conformance. This affects, for
-  /// example, extension visibility.
-  ///
-  /// \param options Options that control the conformance check.
-  ///
-  /// \param ComplainLoc If valid, then this function will emit diagnostics if
-  /// T does not conform to the given protocol. The primary diagnostic will
-  /// be placed at this location, with notes for each of the protocol
-  /// requirements not satisfied.
-  ///
-  /// \returns The protocol conformance, if \c T conforms to the
-  /// protocol \c Proto, or \c None.
-  static ProtocolConformanceRef
-  conformsToProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
-                     ConformanceCheckOptions options,
-                     SourceLoc ComplainLoc = SourceLoc());
-
-  /// Functor class suitable for use as a \c LookupConformanceFn to look up a
-  /// conformance through a particular declaration context.
-  class LookUpConformance {
-    DeclContext *dc;
-
-  public:
-    explicit LookUpConformance(DeclContext *dc) : dc(dc) { }
-
-    ProtocolConformanceRef operator()(CanType dependentType,
-                                      Type conformingReplacementType,
-                                      ProtocolDecl *conformedProtocol) const;
+  ProtocolConformanceRef operator()(CanType dependentType,
+                                    Type conformingReplacementType,
+                                    ProtocolDecl *conformedProtocol) const;
   };
 
   /// Completely check the given conformance.
-  static void checkConformance(NormalProtocolConformance *conformance);
+  void checkConformance(NormalProtocolConformance *conformance);
 
   /// Check all of the conformances in the given context.
-  static void checkConformancesInContext(DeclContext *dc,
-                                         IterableDeclContext *idc);
+  void checkConformancesInContext(DeclContext *dc, IterableDeclContext *idc);
 
   /// Check that the type of the given property conforms to NSCopying.
-  static ProtocolConformanceRef checkConformanceToNSCopying(VarDecl *var);
+  ProtocolConformanceRef checkConformanceToNSCopying(VarDecl *var);
 
   /// Derive an implicit declaration to satisfy a requirement of a derived
   /// protocol conformance.
@@ -1075,15 +1037,15 @@ public:
   /// \returns nullptr if the derivation failed, or the derived declaration
   ///          if it succeeded. If successful, the derived declaration is added
   ///          to TypeDecl's body.
-  static ValueDecl *deriveProtocolRequirement(DeclContext *DC,
-                                              NominalTypeDecl *TypeDecl,
-                                              ValueDecl *Requirement);
+  ValueDecl *deriveProtocolRequirement(DeclContext *DC,
+                                       NominalTypeDecl *TypeDecl,
+                                       ValueDecl *Requirement);
 
   /// Derive an implicit type witness for the given associated type in
   /// the conformance of the given nominal type to some known
   /// protocol.
-  static Type deriveTypeWitness(DeclContext *DC, NominalTypeDecl *nominal,
-                                AssociatedTypeDecl *assocType);
+  Type deriveTypeWitness(DeclContext *DC, NominalTypeDecl *nominal,
+                         AssociatedTypeDecl *assocType);
 
   /// \name Name lookup
   ///
@@ -1098,10 +1060,9 @@ public:
   /// \param name The name of the entity to look for.
   /// \param loc The source location at which name lookup occurs.
   /// \param options Options that control name lookup.
-  static LookupResult lookupUnqualified(DeclContext *dc, DeclNameRef name,
-                                        SourceLoc loc,
-                                        NameLookupOptions options
-                                          = defaultUnqualifiedLookupOptions);
+  LookupResult lookupUnqualified(
+      DeclContext *dc, DeclNameRef name, SourceLoc loc,
+      NameLookupOptions options = defaultUnqualifiedLookupOptions);
 
   /// Perform unqualified type lookup at the given source location
   /// within a particular declaration context.
@@ -1110,10 +1071,9 @@ public:
   /// \param name The name of the entity to look for.
   /// \param loc The source location at which name lookup occurs.
   /// \param options Options that control name lookup.
-  LookupResult
-  static lookupUnqualifiedType(DeclContext *dc, DeclNameRef name, SourceLoc loc,
-                               NameLookupOptions options
-                                 = defaultUnqualifiedLookupOptions);
+  LookupResult lookupUnqualifiedType(
+      DeclContext *dc, DeclNameRef name, SourceLoc loc,
+      NameLookupOptions options = defaultUnqualifiedLookupOptions);
 
   /// Lookup a member in the given type.
   ///
@@ -1123,9 +1083,9 @@ public:
   /// \param options Options that control name lookup.
   ///
   /// \returns The result of name lookup.
-  static LookupResult lookupMember(DeclContext *dc, Type type, DeclNameRef name,
-                                   NameLookupOptions options
-                                     = defaultMemberLookupOptions);
+  LookupResult
+  lookupMember(DeclContext *dc, Type type, DeclNameRef name,
+               NameLookupOptions options = defaultMemberLookupOptions);
 
   /// Look up a member type within the given type.
   ///
@@ -1138,10 +1098,9 @@ public:
   /// \param options Options that control name lookup.
   ///
   /// \returns The result of name lookup.
-  static LookupTypeResult lookupMemberType(DeclContext *dc, Type type,
-                                           DeclNameRef name,
-                                           NameLookupOptions options
-                                             = defaultMemberTypeLookupOptions);
+  LookupTypeResult
+  lookupMemberType(DeclContext *dc, Type type, DeclNameRef name,
+                   NameLookupOptions options = defaultMemberTypeLookupOptions);
 
   /// Look up the constructors of the given type.
   ///
@@ -1150,22 +1109,21 @@ public:
   /// \param options Options that control name lookup.
   ///
   /// \returns the constructors found for this type.
-  static LookupResult lookupConstructors(DeclContext *dc, Type type,
-                                         NameLookupOptions options
-                                           = defaultConstructorLookupOptions);
+  LookupResult lookupConstructors(
+      DeclContext *dc, Type type,
+      NameLookupOptions options = defaultConstructorLookupOptions);
 
   /// Given an expression that's known to be an infix operator,
   /// look up its precedence group.
-  static PrecedenceGroupDecl *
-  lookupPrecedenceGroupForInfixOperator(DeclContext *dc, Expr *op);
+  PrecedenceGroupDecl *lookupPrecedenceGroupForInfixOperator(DeclContext *dc,
+                                                             Expr *op);
 
-  static PrecedenceGroupDecl *lookupPrecedenceGroup(DeclContext *dc,
-                                                    Identifier name,
-                                                    SourceLoc nameLoc);
+  PrecedenceGroupDecl *lookupPrecedenceGroup(DeclContext *dc, Identifier name,
+                                             SourceLoc nameLoc);
 
   /// Check whether the given declaration can be written as a
   /// member of the given base type.
-  static bool isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl);
+  bool isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl);
 
   /// @}
 
@@ -1181,18 +1139,18 @@ public:
   /// A declaration is more specialized than another declaration if its type
   /// is a subtype of the other declaration's type (ignoring the 'self'
   /// parameter of function declarations) and if
-  static Comparison compareDeclarations(DeclContext *dc, ValueDecl *decl1,
-                                        ValueDecl *decl2);
+  Comparison compareDeclarations(DeclContext *dc, ValueDecl *decl1,
+                                 ValueDecl *decl2);
 
   /// Build a type-checked reference to the given value.
-  static Expr *buildCheckedRefExpr(VarDecl *D, DeclContext *UseDC,
-                                   DeclNameLoc nameLoc, bool Implicit);
+  Expr *buildCheckedRefExpr(VarDecl *D, DeclContext *UseDC, DeclNameLoc nameLoc,
+                            bool Implicit);
 
   /// Build a reference to a declaration, where name lookup returned
   /// the given set of declarations.
-  static Expr *buildRefExpr(ArrayRef<ValueDecl *> Decls, DeclContext *UseDC,
-                            DeclNameLoc NameLoc, bool Implicit,
-                            FunctionRefKind functionRefKind);
+  Expr *buildRefExpr(ArrayRef<ValueDecl *> Decls, DeclContext *UseDC,
+                     DeclNameLoc NameLoc, bool Implicit,
+                     FunctionRefKind functionRefKind);
   /// @}
 
   /// Retrieve a specific, known protocol.
@@ -1202,26 +1160,26 @@ public:
   ///
   /// \returns null if the protocol is not available. This represents a
   /// problem with the Standard Library.
-  static ProtocolDecl *getProtocol(ASTContext &ctx, SourceLoc loc,
-                                   KnownProtocolKind kind);
+  ProtocolDecl *getProtocol(ASTContext &ctx, SourceLoc loc,
+                            KnownProtocolKind kind);
 
   /// Retrieve the literal protocol for the given expression.
   ///
   /// \returns the literal protocol, if known and available, or null if the
   /// expression does not have an associated literal protocol.
-  static ProtocolDecl *getLiteralProtocol(ASTContext &ctx, Expr *expr);
+  ProtocolDecl *getLiteralProtocol(ASTContext &ctx, Expr *expr);
 
-  static DeclName getObjectLiteralConstructorName(ASTContext &ctx,
-                                                  ObjectLiteralExpr *expr);
+  DeclName getObjectLiteralConstructorName(ASTContext &ctx,
+                                           ObjectLiteralExpr *expr);
 
-  static Type getObjectLiteralParameterType(ObjectLiteralExpr *expr,
-                                            ConstructorDecl *ctor);
+  Type getObjectLiteralParameterType(ObjectLiteralExpr *expr,
+                                     ConstructorDecl *ctor);
 
   /// Get the module appropriate for looking up standard library types.
   ///
   /// This is "Swift", if that module is imported, or the current module if
   /// we're parsing the standard library.
-  static ModuleDecl *getStdlibModule(const DeclContext *dc);
+  ModuleDecl *getStdlibModule(const DeclContext *dc);
 
   /// \name Resilience diagnostics
 
@@ -1234,27 +1192,24 @@ public:
     PropertyInitializer
   };
 
-  static bool diagnoseInlinableDeclRef(SourceLoc loc, ConcreteDeclRef declRef,
-                                       const DeclContext *DC,
-                                       FragileFunctionKind Kind,
-                                       bool TreatUsableFromInlineAsPublic);
+  bool diagnoseInlinableDeclRef(SourceLoc loc, ConcreteDeclRef declRef,
+                                const DeclContext *DC, FragileFunctionKind Kind,
+                                bool TreatUsableFromInlineAsPublic);
 
-  static Expr *buildDefaultInitializer(Type type);
-  
-private:
-  static bool diagnoseInlinableDeclRefAccess(SourceLoc loc, const ValueDecl *D,
-                                             const DeclContext *DC,
-                                             FragileFunctionKind Kind,
-                                             bool TreatUsableFromInlineAsPublic);
+  Expr *buildDefaultInitializer(Type type);
+
+  bool diagnoseInlinableDeclRefAccess(SourceLoc loc, const ValueDecl *D,
+                                      const DeclContext *DC,
+                                      FragileFunctionKind Kind,
+                                      bool TreatUsableFromInlineAsPublic);
 
   /// Given that a declaration is used from a particular context which
   /// exposes it in the interface of the current module, diagnose if it cannot
   /// reasonably be shared.
-  static bool diagnoseDeclRefExportability(SourceLoc loc, ConcreteDeclRef declRef,
-                                           const DeclContext *DC,
-                                           FragileFunctionKind fragileKind);
+  bool diagnoseDeclRefExportability(SourceLoc loc, ConcreteDeclRef declRef,
+                                    const DeclContext *DC,
+                                    FragileFunctionKind fragileKind);
 
-public:
   /// Given that a type is used from a particular context which
   /// exposes it in the interface of the current module, diagnose if its
   /// generic arguments require the use of conformances that cannot reasonably
@@ -1262,8 +1217,8 @@ public:
   ///
   /// This method \e only checks how generic arguments are used; it is assumed
   /// that the declarations involved have already been checked elsewhere.
-  static void diagnoseGenericTypeExportability(SourceLoc loc, Type type,
-                                               const DeclContext *DC);
+  void diagnoseGenericTypeExportability(SourceLoc loc, Type type,
+                                        const DeclContext *DC);
 
   /// Given that \p DC is within a fragile context for some reason, describe
   /// why.
@@ -1272,7 +1227,7 @@ public:
   /// declarations are permitted.
   ///
   /// \see FragileFunctionKind
-  static std::pair<FragileFunctionKind, bool>
+  std::pair<FragileFunctionKind, bool>
   getFragileFunctionKind(const DeclContext *DC);
 
   /// \name Availability checking
@@ -1285,7 +1240,7 @@ public:
   /// is sufficient to safely conform to the requirement in the context
   /// the provided conformance. On return, requiredAvailability holds th
   /// availability levels required for conformance.
-  static bool
+  bool
   isAvailabilitySafeForConformance(ProtocolDecl *proto, ValueDecl *requirement,
                                    ValueDecl *witness, DeclContext *dc,
                                    AvailabilityContext &requiredAvailability);
@@ -1294,22 +1249,22 @@ public:
   /// that could the passed-in location could be executing upon for
   /// the target platform. If MostRefined != nullptr, set to the most-refined
   /// TRC found while approximating.
-  static AvailabilityContext
-  overApproximateAvailabilityAtLocation(SourceLoc loc, const DeclContext *DC,
-                                        const TypeRefinementContext **MostRefined=nullptr);
+  AvailabilityContext overApproximateAvailabilityAtLocation(
+      SourceLoc loc, const DeclContext *DC,
+      const TypeRefinementContext **MostRefined = nullptr);
 
   /// Walk the AST to build the hierarchy of TypeRefinementContexts
-  static void buildTypeRefinementContextHierarchy(SourceFile &SF);
+  void buildTypeRefinementContextHierarchy(SourceFile &SF);
 
   /// Build the hierarchy of TypeRefinementContexts for the entire
   /// source file, if it has not already been built. Returns the root
   /// TypeRefinementContext for the source file.
-  static TypeRefinementContext *getOrBuildTypeRefinementContext(SourceFile *SF);
+  TypeRefinementContext *getOrBuildTypeRefinementContext(SourceFile *SF);
 
   /// Returns a diagnostic indicating why the declaration cannot be annotated
   /// with an @available() attribute indicating it is potentially unavailable
   /// or None if this is allowed.
-  static Optional<Diag<>>
+  Optional<Diag<>>
   diagnosticIfDeclCannotBePotentiallyUnavailable(const Decl *D);
 
   /// Checks whether a declaration is available when referred to at the given
@@ -1319,15 +1274,15 @@ public:
   /// If the declaration is not available, return false and write the
   /// declaration's availability info to the out parameter
   /// \p OutAvailableRange.
-  static bool isDeclAvailable(const Decl *D, SourceLoc referenceLoc,
-                              const DeclContext *referenceDC,
-                              AvailabilityContext &OutAvailableRange);
+  bool isDeclAvailable(const Decl *D, SourceLoc referenceLoc,
+                       const DeclContext *referenceDC,
+                       AvailabilityContext &OutAvailableRange);
 
   /// Checks whether a declaration should be considered unavailable when
   /// referred to at the given location and, if so, returns the reason why the
   /// declaration is unavailable. Returns None is the declaration is
   /// definitely available.
-  static Optional<UnavailabilityReason>
+  Optional<UnavailabilityReason>
   checkDeclarationAvailability(const Decl *D, SourceLoc referenceLoc,
                                const DeclContext *referenceDC);
 
@@ -1335,68 +1290,69 @@ public:
   ///
   /// An ignored expression is one that is not nested within a larger
   /// expression or statement.
-  static void checkIgnoredExpr(Expr *E);
+  void checkIgnoredExpr(Expr *E);
 
   // Emits a diagnostic, if necessary, for a reference to a declaration
   // that is potentially unavailable at the given source location.
-  static void diagnosePotentialUnavailability(const ValueDecl *D,
-                                              SourceRange ReferenceRange,
-                                              const DeclContext *ReferenceDC,
-                                              const UnavailabilityReason &Reason);
+  void diagnosePotentialUnavailability(const ValueDecl *D,
+                                       SourceRange ReferenceRange,
+                                       const DeclContext *ReferenceDC,
+                                       const UnavailabilityReason &Reason);
 
   // Emits a diagnostic, if necessary, for a reference to a declaration
   // that is potentially unavailable at the given source location, using
   // Name as the diagnostic name.
-  static void diagnosePotentialUnavailability(const Decl *D, DeclName Name,
-                                              SourceRange ReferenceRange,
-                                              const DeclContext *ReferenceDC,
-                                              const UnavailabilityReason &Reason);
+  void diagnosePotentialUnavailability(const Decl *D, DeclName Name,
+                                       SourceRange ReferenceRange,
+                                       const DeclContext *ReferenceDC,
+                                       const UnavailabilityReason &Reason);
 
-  static void diagnosePotentialOpaqueTypeUnavailability(SourceRange ReferenceRange,
-                                           const DeclContext *ReferenceDC,
-                                           const UnavailabilityReason &Reason);
-  
+  void
+  diagnosePotentialOpaqueTypeUnavailability(SourceRange ReferenceRange,
+                                            const DeclContext *ReferenceDC,
+                                            const UnavailabilityReason &Reason);
+
   /// Emits a diagnostic for a reference to a storage accessor that is
   /// potentially unavailable.
-  static void diagnosePotentialAccessorUnavailability(
+  void diagnosePotentialAccessorUnavailability(
       const AccessorDecl *Accessor, SourceRange ReferenceRange,
       const DeclContext *ReferenceDC, const UnavailabilityReason &Reason,
       bool ForInout);
 
   /// Returns the availability attribute indicating deprecation if the
   /// declaration is deprecated or null otherwise.
-  static const AvailableAttr *getDeprecated(const Decl *D);
+  const AvailableAttr *getDeprecated(const Decl *D);
 
   /// Emits a diagnostic for a reference to a declaration that is deprecated.
   /// Callers can provide a lambda that adds additional information (such as a
   /// fixit hint) to the deprecation diagnostic, if it is emitted.
-  static void diagnoseIfDeprecated(SourceRange SourceRange,
-                                   const DeclContext *ReferenceDC,
-                                   const ValueDecl *DeprecatedDecl,
-                                   const ApplyExpr *Call);
+  void diagnoseIfDeprecated(SourceRange SourceRange,
+                            const DeclContext *ReferenceDC,
+                            const ValueDecl *DeprecatedDecl,
+                            const ApplyExpr *Call);
   /// @}
 
   /// If LangOptions::DebugForbidTypecheckPrefix is set and the given decl
   /// name starts with that prefix, an llvm fatal_error is triggered.
   /// This is for testing purposes.
-  static void checkForForbiddenPrefix(ASTContext &C, DeclBaseName Name);
+  void checkForForbiddenPrefix(ASTContext &C, DeclBaseName Name);
 
   /// Check error handling in the given type-checked top-level code.
-  static void checkTopLevelErrorHandling(TopLevelCodeDecl *D);
-  static void checkFunctionErrorHandling(AbstractFunctionDecl *D);
-  static void checkInitializerErrorHandling(Initializer *I, Expr *E);
-  static void checkEnumElementErrorHandling(EnumElementDecl *D, Expr *expr);
-  static void checkPropertyWrapperErrorHandling(PatternBindingDecl *binding,
-                                                Expr *expr);
+  void checkTopLevelErrorHandling(TopLevelCodeDecl *D);
+  void checkFunctionErrorHandling(AbstractFunctionDecl *D);
+  void checkInitializerErrorHandling(Initializer *I, Expr *E);
+  void checkEnumElementErrorHandling(EnumElementDecl *D, Expr *expr);
+  void checkPropertyWrapperErrorHandling(PatternBindingDecl *binding,
+                                         Expr *expr);
 
   /// If an expression references 'self.init' or 'super.init' in an
   /// initializer context, returns the implicit 'self' decl of the constructor.
   /// Otherwise, return nil.
-  static VarDecl *getSelfForInitDelegationInConstructor(DeclContext *DC,
-                                                        UnresolvedDotExpr *UDE);
+  VarDecl *getSelfForInitDelegationInConstructor(DeclContext *DC,
+                                                 UnresolvedDotExpr *UDE);
 
   /// Diagnose assigning variable to itself.
-  static bool diagnoseSelfAssignment(const Expr *E);
+  bool diagnoseSelfAssignment(const Expr *E);
 
   /// Builds a string representing a "default" generic argument list for
   /// \p typeDecl. In general, this means taking the bound of each generic
@@ -1409,22 +1365,20 @@ public:
   ///
   /// Returns true if the arguments list could be constructed, false if for
   /// some reason it could not.
-  static bool getDefaultGenericArgumentsString(
-      SmallVectorImpl<char> &buf,
-      const GenericTypeDecl *typeDecl,
+  bool getDefaultGenericArgumentsString(
+      SmallVectorImpl<char> &buf, const GenericTypeDecl *typeDecl,
       llvm::function_ref<Type(const GenericTypeParamDecl *)> getPreferredType =
           [](const GenericTypeParamDecl *) { return Type(); });
 
   /// Attempt to omit needless words from the name of the given declaration.
-  static Optional<DeclName> omitNeedlessWords(AbstractFunctionDecl *afd);
+  Optional<DeclName> omitNeedlessWords(AbstractFunctionDecl *afd);
 
   /// Attempt to omit needless words from the name of the given declaration.
-  static Optional<Identifier> omitNeedlessWords(VarDecl *var);
+  Optional<Identifier> omitNeedlessWords(VarDecl *var);
 
   /// Calculate edit distance between declaration names.
-  static unsigned getCallEditDistance(DeclNameRef writtenName,
-                                      DeclName correctedName,
-                                      unsigned maxEditDistance);
+  unsigned getCallEditDistance(DeclNameRef writtenName, DeclName correctedName,
+                               unsigned maxEditDistance);
 
   enum : unsigned {
     /// Never consider a candidate that's this distance away or worse.
@@ -1436,18 +1390,16 @@ public:
   };
 
   /// Check for a typo correction.
-  static void performTypoCorrection(DeclContext *DC,
-                                    DeclRefKind refKind,
-                                    Type baseTypeOrNull,
-                                    NameLookupOptions lookupOptions,
-                                    TypoCorrectionResults &corrections,
-                                    GenericSignatureBuilder *gsb = nullptr,
-                                    unsigned maxResults = 4);
+  void performTypoCorrection(DeclContext *DC, DeclRefKind refKind,
+                             Type baseTypeOrNull,
+                             NameLookupOptions lookupOptions,
+                             TypoCorrectionResults &corrections,
+                             GenericSignatureBuilder *gsb = nullptr,
+                             unsigned maxResults = 4);
 
   /// Check if the given decl has a @_semantics attribute that gives it
   /// special case type-checking behavior.
-  static DeclTypeCheckingSemantics
-  getDeclTypeCheckingSemantics(ValueDecl *decl);
+  DeclTypeCheckingSemantics getDeclTypeCheckingSemantics(ValueDecl *decl);
 
   /// Infers the differentiability parameter indices for the given
   /// original or derivative `AbstractFunctionDecl`.
@@ -1459,23 +1411,22 @@ public:
   ///   type that conform to `Differentiable`.
   ///
   /// Used by `@differentiable` and `@derivative` attribute type-checking.
-  static IndexSubset *
+  IndexSubset *
   inferDifferentiabilityParameters(AbstractFunctionDecl *AFD,
                                    GenericEnvironment *derivativeGenEnv);
 
-public:
   /// Require that the library intrinsics for working with Optional<T>
   /// exist.
-  static bool requireOptionalIntrinsics(ASTContext &ctx, SourceLoc loc);
+  bool requireOptionalIntrinsics(ASTContext &ctx, SourceLoc loc);
 
   /// Require that the library intrinsics for working with
   /// UnsafeMutablePointer<T> exist.
-  static bool requirePointerArgumentIntrinsics(ASTContext &ctx, SourceLoc loc);
+  bool requirePointerArgumentIntrinsics(ASTContext &ctx, SourceLoc loc);
 
   /// Require that the library intrinsics for creating
   /// array literals exist.
-  static bool requireArrayLiteralIntrinsics(ASTContext &ctx, SourceLoc loc);
-};
+  bool requireArrayLiteralIntrinsics(ASTContext &ctx, SourceLoc loc);
+  }; // namespace TypeChecker
 
 /// Temporary on-stack storage and unescaping for encoded diagnostic
 /// messages.

--- a/lib/Sema/TypoCorrection.h
+++ b/lib/Sema/TypoCorrection.h
@@ -27,7 +27,6 @@
 namespace swift {
 
 class LookupResult;
-class TypeChecker;
 
 /// A summary of how to fix a typo.  Note that this intentionally doesn't
 /// carry a candidate declaration because we should be able to apply a typo

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -978,7 +978,7 @@ static bool reportModuleDocInfo(CompilerInvocation Invocation,
 
   ASTContext &Ctx = CI.getASTContext();
   registerIDERequestFunctions(Ctx.evaluator);
-  (void)createTypeChecker(Ctx);
+  Ctx.setLegacySemanticQueriesEnabled();
 
   SourceTextInfo IFaceInfo;
   if (getModuleInterfaceInfo(Ctx, ModuleName, IFaceInfo))
@@ -1107,7 +1107,7 @@ static bool reportSourceDocInfo(CompilerInvocation Invocation,
   CI.performSema();
 
   // Setup a typechecker for protocol conformance resolving.
-  (void)createTypeChecker(Ctx);
+  Ctx.setLegacySemanticQueriesEnabled();
 
   SourceTextInfo SourceInfo;
   if (getSourceTextInfo(CI, SourceInfo))
@@ -1458,7 +1458,7 @@ findModuleGroups(StringRef ModuleName, ArrayRef<const char *> Args,
 
   ASTContext &Ctx = CI.getASTContext();
   // Setup a typechecker for protocol conformance resolving.
-  (void)createTypeChecker(Ctx);
+  Ctx.setLegacySemanticQueriesEnabled();
 
   // Load standard library so that Clang importer can use it.
   auto *Stdlib = getModuleByFullName(Ctx, Ctx.StdlibModuleName);

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -200,7 +200,7 @@ static void indexModule(llvm::MemoryBuffer *Input,
   }
 
   // Setup a typechecker for protocol conformance resolving.
-  (void)createTypeChecker(Ctx);
+  Ctx.setLegacySemanticQueriesEnabled();
 
   SKIndexDataConsumer IdxDataConsumer(IdxConsumer);
   index::indexModule(Mod, IdxDataConsumer);
@@ -314,7 +314,7 @@ void SwiftLangSupport::indexSource(StringRef InputFile,
   }
 
   // Setup a typechecker for protocol conformance resolving.
-  (void)createTypeChecker(CI.getASTContext());
+  CI.getASTContext().setLegacySemanticQueriesEnabled();
 
   SKIndexDataConsumer IdxDataConsumer(IdxConsumer);
   index::indexSourceFile(CI.getPrimarySourceFile(), IdxDataConsumer);


### PR DESCRIPTION
Move `definedFunctions` onto SourceFile, then break the now-stateless TypeChecker down into a namespace.

Good riddance.