### PR TITLE
[SR-11540] Fix ambiguos overload apply to argument for contextual closure 

### DIFF
--- a/test/Constraints/diag_ambiguities.swift
+++ b/test/Constraints/diag_ambiguities.swift
@@ -18,8 +18,8 @@ func +++(d: Double, i: Int) {} // expected-note{{found this candidate}}
 1 +++ 2 // expected-error{{ambiguous use of operator '+++'}}
 
 class C {
-  init(_ action: (Int) -> ()) {} // expected-note{{found this candidate}}
-  init(_ action: (Int, Int) -> ()) {} // expected-note{{found this candidate}}
+  init(_ action: (Int) -> ()) {} 
+  init(_ action: (Int, Int) -> ()) {} 
 }
 
 func g(_ x: Int) -> () {} // expected-note{{found this candidate}}
@@ -27,7 +27,7 @@ func g(_ x: Int, _ y: Int) -> () {} // expected-note{{found this candidate}}
 C(g) // expected-error{{ambiguous use of 'g'}}
 
 func h<T>(_ x: T) -> () {}
-C(h) // expected-error{{ambiguous use of 'init(_:)'}}
+_ = C(h) // OK - init(_: (Int) -> ())
 
 func rdar29691909_callee(_ o: AnyObject?) -> Any? { return o } // expected-note {{found this candidate}}
 func rdar29691909_callee(_ o: AnyObject) -> Any { return o } // expected-note {{found this candidate}}

--- a/test/expr/closure/inference.swift
+++ b/test/expr/closure/inference.swift
@@ -38,3 +38,16 @@ var nestedClosuresWithBrokenInference = { f: Int in {} }
     // expected-error@-2 {{consecutive statements on a line must be separated by ';'}} {{44-44=;}}
     // expected-error@-3 {{expected expression}}
     // expected-error@-4 {{use of unresolved identifier 'f'}}
+
+// SR-11540
+
+func SR11540<R>(action: () -> R) -> Void {}
+
+func SR11540<T, R>(action: (T) -> R) -> Void {}
+
+func SR11540_1<T, R>(action: (T) -> R) -> Void {} 
+
+SR11540(action: { return }) // Ok SR11540<R>(action: () -> R) was the selected overload.
+
+// In case that's the only possible overload, it's acceptable
+SR11540_1(action: { return }) // OK


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes SR-11540 by just disfavoring overloads to closures with anonymous var that are function types with more than one argument that matches arguments of no-arg function types.

The first approach was to not accept cases like `func foo(<T, R>(action: (T) -> R) -> Void {})` match `foo(action: { return }`, in a way that:

```swift
func foo<T, R>(action: (T) -> R) -> Void {}
foo(action: { return }) // expected-error {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}}
// expected-error@-1 {{generic parameter 'T' could not be inferred}} expected-error@-1{{generic parameter 'R' could not be inferred}}

// Is expected to be foo(action: { _ in return }) 
```
But since it broke few tests(that was actually accepting this syntax) and I was not sure if this would be a source-compatible change... so opting to just disfavor the overload disambiguate seemed like a better option :) 

cc @xedin @hborla 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-11540.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
