### PR TITLE
[nfc] [fix] update "made change" when we make a change

### DIFF
--- a/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
@@ -199,10 +199,12 @@ bool MandatoryCombiner::doOneIteration(SILFunction &function,
                                                  instructionDescription
 #endif
       );
+      madeChange = true;
     }
 
     for (SILInstruction *instruction : instructionsPendingDeletion) {
       worklist.eraseInstFromFunction(*instruction);
+      madeChange = true;
     }
     instructionsPendingDeletion.clear();
 
@@ -214,6 +216,7 @@ bool MandatoryCombiner::doOneIteration(SILFunction &function,
       LLVM_DEBUG(llvm::dbgs() << "MC: add " << *instruction
                               << " from tracking list to worklist\n");
       worklist.add(instruction);
+      madeChange = true;
     }
     createdInstructions.clear();
   }


### PR DESCRIPTION
<!-- What's in this pull request? -->
AFAICT there is no case where `doOneIteration` is called more than once per pass. In any event, we should report a change was made when we delete, replace, or add instructions. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
