### PR TITLE
[stdlib] NFC: improve doc comment for `ElementaryFunctions`.

### DIFF
--- a/stdlib/public/core/MathFunctions.swift.gyb
+++ b/stdlib/public/core/MathFunctions.swift.gyb
@@ -29,10 +29,6 @@ import SwiftShims
 /// let y = Float.sin(x) // 0.84147096
 /// ```
 ///
-/// Additional operations, such as `atan2(y:x:)`, `hypot(_:_:)` and some
-/// special functions, are provided on the Real protocol, which refines both
-/// ElementaryFunctions and FloatingPoint.
-///
 /// [elfn]: http://en.wikipedia.org/wiki/Elementary_function
 // SWIFT_ENABLE_TENSORFLOW
 // NOTE(TF-796): Make `ElementaryFunctions` available on macOS.


### PR DESCRIPTION
Remove reference to the `Real` protocol, which does not exist on `apple/swift` tensorflow branch.

Note: the current `ElementaryFunctions` protocol definition on `apple/swift` tensorflow branch is ad-hoc. TF-1203 tracks minimizing ad-hoc `ElementaryFunctions` differences with `apple/swift-numerics`.

---

Cherry-picked to `tensorflow-0.8`: https://github.com/apple/swift/pull/30442