### PR TITLE
build: pass `-DBUILD_X10` to build X10

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/tensorflow.py
+++ b/utils/swift_build_support/swift_build_support/products/tensorflow.py
@@ -90,6 +90,9 @@ class TensorFlowSwiftAPIs(product.Product):
                 '-D', 'CMAKE_Swift_FLAGS={}'.format('-L{}'.format(
                     os.path.join(tensorflow_source_dir, 'bazel-bin', 'tensorflow'))
                 ),
+                '-D', 'BUILD_X10={}'.format(
+                    'YES' if self.args.enable_x10 else 'NO'
+                ),
                 '-D', 'X10_INCLUDE_DIR={}'.format(x10_inc),
                 # SWIFT_ENABLE_TENSORFLOW END
                 '-B', self.build_dir,


### PR DESCRIPTION
With work to make X10 an explicit option, stage the new flag to explicitly
enable the X10 support.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
