### PR TITLE
[outputfilemap] Fix another StringRef -> std::string conversion

### DIFF
--- a/lib/Basic/OutputFileMap.cpp
+++ b/lib/Basic/OutputFileMap.cpp
@@ -232,7 +232,7 @@ OutputFileMap::parse(std::unique_ptr<llvm::MemoryBuffer> Buffer,
 
       llvm::SmallString<128> PathStorage;
       OutputMap.insert(std::pair<file_types::ID, std::string>(
-          Kind, resolvePath(Path, PathStorage)));
+          Kind, resolvePath(Path, PathStorage).str()));
 
       // HACK: fake up an SwiftRanges & CompiledSource output filenames
       if (addEntriesForSourceRangeDependencies &&


### PR DESCRIPTION
This fix affects master-next, but it's safe to put on master.
