### PR TITLE
build: disable tests on macOS

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/tensorflow.py
+++ b/utils/swift_build_support/swift_build_support/products/tensorflow.py
@@ -82,6 +82,9 @@ class TensorFlowSwiftAPIs(product.Product):
                 '-D', 'CMAKE_Swift_COMPILER={}'.format(swiftc),
                 # SWIFT_ENABLE_TENSORFLOW
                 target,
+                '-D', 'BUILD_TESTING={}'.format(
+                    'NO' if host_Target.startswith('macosx') else 'YES'
+                ),
                 '-D', 'USE_BUNDLED_CTENSORFLOW=YES',
                 '-D', 'TensorFlow_INCLUDE_DIR={}'.format(tensorflow_source_dir),
                 '-D', 'TensorFlow_LIBRARY={}'.format(

--- a/utils/swift_build_support/swift_build_support/products/tensorflow.py
+++ b/utils/swift_build_support/swift_build_support/products/tensorflow.py
@@ -83,7 +83,7 @@ class TensorFlowSwiftAPIs(product.Product):
                 # SWIFT_ENABLE_TENSORFLOW
                 target,
                 '-D', 'BUILD_TESTING={}'.format(
-                    'NO' if host_Target.startswith('macosx') else 'YES'
+                    'NO' if host_target.startswith('macosx') else 'YES'
                 ),
                 '-D', 'USE_BUNDLED_CTENSORFLOW=YES',
                 '-D', 'TensorFlow_INCLUDE_DIR={}'.format(tensorflow_source_dir),


### PR DESCRIPTION
Darwin does not build and package XCTest, which results in XCTest not being found.
Disable testing on macOS as a workaround.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
