### PR TITLE
[AutoDiff] Fix `inout` parameters + subset parameters thunk crash.

### DIFF
--- a/include/swift/SILOptimizer/Utils/Differentiation/Thunk.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/Thunk.h
@@ -109,9 +109,9 @@ getOrCreateSubsetParametersThunkForDerivativeFunction(
 std::pair<SILFunction *, SubstitutionMap>
 getOrCreateSubsetParametersThunkForLinearMap(
     SILOptFunctionBuilder &fb, SILFunction *assocFn,
-    CanSILFunctionType linearMapType, CanSILFunctionType targetType,
-    AutoDiffDerivativeFunctionKind kind, SILAutoDiffIndices desiredIndices,
-    SILAutoDiffIndices actualIndices);
+    CanSILFunctionType origFnType, CanSILFunctionType linearMapType,
+    CanSILFunctionType targetType, AutoDiffDerivativeFunctionKind kind,
+    SILAutoDiffIndices desiredIndices, SILAutoDiffIndices actualIndices);
 
 } // end namespace autodiff
 

--- a/lib/SILOptimizer/Utils/Differentiation/Thunk.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/Thunk.cpp
@@ -426,9 +426,9 @@ SILFunction *getOrCreateReabstractionThunk(SILOptFunctionBuilder &fb,
 std::pair<SILFunction *, SubstitutionMap>
 getOrCreateSubsetParametersThunkForLinearMap(
     SILOptFunctionBuilder &fb, SILFunction *parentThunk,
-    CanSILFunctionType linearMapType, CanSILFunctionType targetType,
-    AutoDiffDerivativeFunctionKind kind, SILAutoDiffIndices desiredIndices,
-    SILAutoDiffIndices actualIndices) {
+    CanSILFunctionType origFnType, CanSILFunctionType linearMapType,
+    CanSILFunctionType targetType, AutoDiffDerivativeFunctionKind kind,
+    SILAutoDiffIndices desiredIndices, SILAutoDiffIndices actualIndices) {
   LLVM_DEBUG(getADDebugStream()
              << "Getting a subset parameters thunk for " << linearMapType
              << " from " << actualIndices << " to " << desiredIndices << '\n');
@@ -571,28 +571,37 @@ getOrCreateSubsetParametersThunkForLinearMap(
   // - All actual arguments.
   case AutoDiffDerivativeFunctionKind::VJP: {
     auto toIndirectResultsIter = thunk->getIndirectResults().begin();
-    auto useNextResult = [&]() {
+    auto useNextIndirectResult = [&]() {
       arguments.push_back(*toIndirectResultsIter++);
     };
-    // Iterate over actual indices.
+    // Collect pullback arguments.
+    unsigned pullbackResultIndex = 0;
     for (unsigned i : actualIndices.parameters->getIndices()) {
-      auto resultInfo =
-          linearMapType->getResults()[mapOriginalParameterIndex(i)];
-      // Skip direct results. Only indirect results are relevant as arguments.
+      auto origParamInfo = origFnType->getParameters()[i];
+      // Skip original `inout` parameters. All non-indirect-result pullback
+      // arguments (including `inout` arguments) are appended to `arguments`
+      // later.
+      if (origParamInfo.isIndirectMutating())
+        continue;
+      auto resultInfo = linearMapType->getResults()[pullbackResultIndex];
+      assert(pullbackResultIndex < linearMapType->getNumResults());
+      pullbackResultIndex++;
+      // Skip pullback direct results. Only indirect results are relevant as
+      // arguments.
       if (resultInfo.isFormalDirect())
         continue;
-      // If index is desired, use next indirect result.
+      // If index is desired, use next pullback indirect result.
       if (desiredIndices.isWrtParameter(i)) {
-        useNextResult();
+        useNextIndirectResult();
         continue;
       }
-      // Otherwise, construct and use an uninitialized indirect result.
+      // Otherwise, allocate and use an uninitialized pullback indirect result.
       auto *indirectResult = builder.createAllocStack(
           loc, resultInfo.getSILStorageInterfaceType());
       localAllocations.push_back(indirectResult);
       arguments.push_back(indirectResult);
     }
-    // Foward all actual non-indirect-result arguments.
+    // Forward all actual non-indirect-result arguments.
     arguments.append(thunk->getArgumentsWithoutIndirectResults().begin(),
                      thunk->getArgumentsWithoutIndirectResults().end() - 1);
     break;
@@ -619,14 +628,28 @@ getOrCreateSubsetParametersThunkForLinearMap(
   extractAllElements(ai, builder, pullbackDirectResults);
   SmallVector<SILValue, 8> allResults;
   collectAllActualResultsInTypeOrder(ai, pullbackDirectResults, allResults);
+  // Collect pullback `inout` arguments in type order.
+  unsigned inoutArgIdx = 0;
+  SILFunctionConventions origConv(origFnType, thunk->getModule());
+  for (auto paramIdx : actualIndices.parameters->getIndices()) {
+    auto paramInfo = origConv.getParameters()[paramIdx];
+    if (!paramInfo.isIndirectMutating())
+      continue;
+    auto inoutArg = *std::next(ai->getInoutArguments().begin(), inoutArgIdx++);
+    allResults.insert(allResults.begin() + paramIdx, inoutArg);
+  }
+  assert(allResults.size() == actualIndices.parameters->getNumIndices() &&
+         "Number of pullback results should match number of differentiability "
+         "parameters");
 
   SmallVector<SILValue, 8> results;
   for (unsigned i : actualIndices.parameters->getIndices()) {
+    unsigned mappedIndex = mapOriginalParameterIndex(i);
     // If result is desired:
     // - Do nothing if result is indirect.
     //   (It was already forwarded to the `apply` instruction).
     // - Push it to `results` if result is direct.
-    auto result = allResults[mapOriginalParameterIndex(i)];
+    auto result = allResults[mappedIndex];
     if (desiredIndices.isWrtParameter(i)) {
       if (result->getType().isObject())
         results.push_back(result);
@@ -801,16 +824,18 @@ getOrCreateSubsetParametersThunkForDerivativeFunction(
   SubstitutionMap linearMapSubs;
   std::tie(linearMapThunk, linearMapSubs) =
       getOrCreateSubsetParametersThunkForLinearMap(
-          fb, thunk, linearMapType, linearMapTargetType, kind, desiredIndices,
-          actualIndices);
+          fb, thunk, origFnType, linearMapType, linearMapTargetType, kind,
+          desiredIndices, actualIndices);
 
   auto *linearMapThunkFRI = builder.createFunctionRef(loc, linearMapThunk);
   auto *thunkedLinearMap = builder.createPartialApply(
       loc, linearMapThunkFRI, linearMapSubs, {linearMap},
       ParameterConvention::Direct_Guaranteed);
-
-  assert(origFnType->getResults().size() == 1);
-  if (origFnType->getResults().front().isFormalDirect()) {
+  assert(origFnType->getNumResults() +
+             origFnType->getNumIndirectMutatingParameters() ==
+         1);
+  if (origFnType->getNumResults() > 0 &&
+      origFnType->getResults().front().isFormalDirect()) {
     auto result =
         joinElements({originalDirectResult, thunkedLinearMap}, builder, loc);
     builder.createReturn(loc, result);

--- a/test/AutoDiff/downstream/compiler_crashers_fixed/tf1204-pullback-inout-subset-parameters-thunk.swift
+++ b/test/AutoDiff/downstream/compiler_crashers_fixed/tf1204-pullback-inout-subset-parameters-thunk.swift
@@ -1,0 +1,50 @@
+// RUN: %target-swift-emit-sil %s -verify
+// REQUIRES: asserts
+
+// TF-1204: Subset parameters thunk crash for original function with `inout`
+// parameters.
+
+struct Convolution<T>: Differentiable
+where T: Differentiable, T == T.TangentVector {
+  var bias: T
+
+  @differentiable(wrt: self)
+  @differentiable
+  func callAsFunction(_ input: T) -> T {
+    var result = withoutDerivative(at: bias)
+    infer(result: &result, input: input, bias: bias)
+    return result
+  }
+
+  @differentiable
+  func infer(result: inout T, input: T, bias: T) {
+    fatalError()
+  }
+
+  @derivative(of: infer)
+  func _vjpInfer(result: inout T, input: T, bias: T)
+    -> (
+      value: Void, pullback: (inout T) -> (Convolution<T>.TangentVector, T, T)
+    )
+  {
+    fatalError()
+  }
+}
+
+// Original crasher:
+// Assertion failed: (origFnType->getResults().size() == 1), function getOrCreateSubsetParametersThunkForDerivativeFunction, file /Users/swiftninjas/s4tf/swift/lib/SILOptimizer/Utils/Differentiation/Thunk.cpp, line 812.
+// Stack dump:
+// 1.	Swift version 5.2-dev (LLVM b3057cffb6, Swift c8bea53782)
+// 2.	While running pass #135 SILModuleTransform "Differentiation".
+// 3.	While canonicalizing `differentiable_function` SIL node   %22 = differentiable_function [parameters 0 2 3] %18 : $@callee_guaranteed (@inout τ_0_0, @in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @in_guaranteed Convolution<τ_0_0>) -> () // users: %27, %23
+// 4.	While ...in SIL function "@AD__$s4conv11ConvolutionV14callAsFunctionyxxF__vjp_src_0_wrt_1_s14DifferentiableRz13TangentVectorsAAPQzRszl".
+//  for 'callAsFunction(_:)' (at conv.swift:8:5)
+// 0  swift                    0x0000000104c08e75 llvm::sys::PrintStackTrace(llvm::raw_ostream&) + 37
+// 1  swift                    0x0000000104c080b5 llvm::sys::RunSignalHandlers() + 85
+// 2  swift                    0x0000000104c0945c SignalHandler(int) + 268
+// 3  libsystem_platform.dylib 0x00007fff6deebb5d _sigtramp + 29
+// 4  libsystem_platform.dylib 0x0000000000005290 _sigtramp + 18446603338671822672
+// 5  libsystem_c.dylib        0x00007fff6dda56a6 abort + 127
+// 6  libsystem_c.dylib        0x00007fff6dd6e20d basename_r + 0
+// 7  swift                    0x0000000104ec58a3 swift::autodiff::getOrCreateSubsetParametersThunkForDerivativeFunction(swift::SILOptFunctionBuilder&, swift::SILValue, swift::SILValue, swift::AutoDiffDerivativeFunctionKind, swift::SILAutoDiffIndices, swift::SILAutoDiffIndices) (.cold.10) + 35
+// 8  swift                    0x000000010136f079 swift::autodiff::getOrCreateSubsetParametersThunkForDerivativeFunction(swift::SILOptFunctionBuilder&, swift::SILValue, swift::SILValue, swift::AutoDiffDerivativeFunctionKind, swift::SILAutoDiffIndices, swift::SILAutoDiffIndices) + 7545

--- a/test/AutoDiff/downstream/subset_parameters_thunk.swift
+++ b/test/AutoDiff/downstream/subset_parameters_thunk.swift
@@ -1,20 +1,28 @@
+// RUN: %target-run-simple-swift
 // RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var SubsetParameterThunkTests = TestSuite("SubsetParameterThunks")
+
+// MARK: Subset parameter thunk application SIL FileChecks
 
 func foo<T: Numeric>(_ x: T, _ y: T) -> T { x * y }
 
 @derivative(of: foo)
-func foo_vjp<T: Numeric & Differentiable>(_ x: T, _ y: T) -> (value: T, pullback: (T.TangentVector) -> (T.TangentVector, T.TangentVector)) {
+func foo_vjp<T: Numeric & Differentiable>(_ x: T, _ y: T) -> (
+  value: T, pullback: (T.TangentVector) -> (T.TangentVector, T.TangentVector)
+) {
   (foo(x, y), { _ in (.zero, .zero) })
 }
 
-let x = Float(1)
 @differentiable
 func differentiate_foo_wrt_0(_ x: Float) -> Float {
   foo(x, 1)
 }
 
-// Intentional "//" in the label so that this doesn't match a [differentiable] attr pointing at the vjp.
-// CHECK-LABEL: // {{.*}}differentiate_foo_wrt_0{{.*}}__vjp
+// CHECK-LABEL: sil hidden @{{.*}}differentiate_foo_wrt_0{{.*}}__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
 // CHECK: bb0
 // CHECK:   [[FOO_ORIG:%.*]] = function_ref @{{.*}}foo{{.*}} : $@convention(thin) <τ_0_0 where τ_0_0 : Numeric> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> @out τ_0_0
 // CHECK:   [[FOO_FLOAT:%.*]] = partial_apply [callee_guaranteed] [[FOO_ORIG]]<Float>() : $@convention(thin) <τ_0_0 where τ_0_0 : Numeric> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> @out τ_0_0
@@ -28,3 +36,112 @@ func differentiate_foo_wrt_0(_ x: Float) -> Float {
 // CHECK:   [[FOO_VJP_SUBSET_THUNK:%.*]] = thin_to_thick_function [[FOO_VJP_SUBSET_THUNK_THIN]] : $@convention(thin) (@in_guaranteed Float, @in_guaranteed Float) -> (@out Float, @owned @callee_guaranteed (@in_guaranteed Float) -> @out Float) to $@callee_guaranteed (@in_guaranteed Float, @in_guaranteed Float) -> (@out Float, @owned @callee_guaranteed (@in_guaranteed Float) -> @out Float)
 // CHECK:   [[FOO_DIFF:%.*]] = differentiable_function [parameters 0] [[FOO_FLOAT]] : $@callee_guaranteed (@in_guaranteed Float, @in_guaranteed Float) -> @out Float with_derivative {[[FOO_JVP_SUBSET_THUNK]] : $@callee_guaranteed (@in_guaranteed Float, @in_guaranteed Float) -> (@out Float, @owned @callee_guaranteed (@in_guaranteed Float) -> @out Float), [[FOO_VJP_SUBSET_THUNK]] : $@callee_guaranteed (@in_guaranteed Float, @in_guaranteed Float) -> (@out Float, @owned @callee_guaranteed (@in_guaranteed Float) -> @out Float)}
 // CHECK: }
+
+// MARK: `inout` parameters
+
+// TF-1204: Test pullback subset parameter thunks.
+
+func inoutDirect(_ x: Float, _ y: inout Double, _ z: Float) {}
+
+@derivative(of: inoutDirect)
+func vjpInoutDirect(_ x: Float, _ y: inout Double, _ z: Float) -> (
+  value: Void, pullback: (inout Double) -> (Float, Float)
+) {
+  return ((), { dy in
+    dy = 3
+    return (2, 4)
+  })
+}
+
+SubsetParameterThunkTests.test("InoutParametersDirect") {
+  @differentiable(wrt: x)
+  @differentiable(wrt: y)
+  @differentiable(wrt: z)
+  func inoutDirectCaller(_ x: Float, _ y: Double, _ z: Float) -> Double {
+    var result = y
+    inoutDirect(x, &result, z)
+    return result
+  }
+
+  let x: Float = 3
+  let y: Double = 4
+  let z: Float = 5
+  expectEqual((2, 3, 4), gradient(at: x, y, z, in: inoutDirectCaller))
+  expectEqual((3, 4), gradient(at: y, z, in: { y, z in inoutDirectCaller(x, y, z) }))
+  expectEqual((2, 4), gradient(at: x, z, in: { x, z in inoutDirectCaller(x, y, z) }))
+  expectEqual((2, 3), gradient(at: x, y, in: { x, y in inoutDirectCaller(x, y, z) }))
+}
+
+func inoutIndirect<T: Differentiable, U: Differentiable, V: Differentiable>(
+  _ x: T, _ y: inout U, _ z: V
+) {}
+
+@derivative(of: inoutIndirect)
+func vjpInoutIndirect<T: Differentiable, U: Differentiable, V: Differentiable>(
+  _ x: T, _ y: inout U, _ z: V
+) -> (
+  value: Void, pullback: (inout U.TangentVector) -> (T.TangentVector, V.TangentVector)
+) {
+  return ((), { dy in
+    return (.zero, .zero)
+  })
+}
+
+SubsetParameterThunkTests.test("InoutParametersIndirect") {
+  @differentiable(wrt: x)
+  @differentiable(wrt: y)
+  @differentiable(wrt: z)
+  @differentiable
+  func inoutIndirectCaller<T: Differentiable, U: Differentiable, V: Differentiable>(
+    _ x: T, _ y: U, _ z: V
+  ) -> U {
+    var result = y
+    inoutIndirect(x, &result, z)
+    return result
+  }
+
+  let x: Float = 3
+  let y: Double = 4
+  let z: Float = 5
+  expectEqual((0, 1, 0), gradient(at: x, y, z, in: inoutIndirectCaller))
+  expectEqual((1, 0), gradient(at: y, z, in: { y, z in inoutIndirectCaller(x, y, z) }))
+  expectEqual((0, 0), gradient(at: x, z, in: { x, z in inoutIndirectCaller(x, y, z) }))
+  expectEqual((0, 1), gradient(at: x, y, in: { x, y in inoutIndirectCaller(x, y, z) }))
+}
+
+// Check SIL for representative pullback subset parameters thunks.
+
+// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] @AD__$s13TangentVectorQy_AAQzAAQy0_Ieglrr_AbCIeglr_s14DifferentiableRzsAER_sAER0_r1_lTR_src_0_wrt_0_1_pullback_index_subset_thunk : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : Differentiable, τ_0_1 : Differentiable, τ_0_2 : Differentiable> (@inout τ_0_1.TangentVector, @guaranteed @callee_guaranteed (@inout τ_0_1.TangentVector) -> (@out τ_0_0.TangentVector, @out τ_0_2.TangentVector)) -> @out τ_0_0.TangentVector {
+// CHECK: bb0(%0 : $*τ_0_0.TangentVector, %1 : $*τ_0_1.TangentVector, %2 : $@callee_guaranteed (@inout τ_0_1.TangentVector) -> (@out τ_0_0.TangentVector, @out τ_0_2.TangentVector)):
+// CHECK:   %3 = alloc_stack $τ_0_2.TangentVector
+// CHECK:   %4 = apply %2(%0, %3, %1) : $@callee_guaranteed (@inout τ_0_1.TangentVector) -> (@out τ_0_0.TangentVector, @out τ_0_2.TangentVector)
+// CHECK:   destroy_addr %3 : $*τ_0_2.TangentVector
+// CHECK:   dealloc_stack %3 : $*τ_0_2.TangentVector
+// CHECK:   %7 = tuple ()
+// CHECK:   return %7 : $()
+// CHECK: }
+
+// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] @AD__$s13TangentVectorQy_AAQzAAQy0_Ieglrr_ABIegl_s14DifferentiableRzsAER_sAER0_r1_lTR_src_0_wrt_1_pullback_index_subset_thunk : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : Differentiable, τ_0_1 : Differentiable, τ_0_2 : Differentiable> (@inout τ_0_1.TangentVector, @guaranteed @callee_guaranteed (@inout τ_0_1.TangentVector) -> (@out τ_0_0.TangentVector, @out τ_0_2.TangentVector)) -> () {
+// CHECK: bb0(%0 : $*τ_0_1.TangentVector, %1 : $@callee_guaranteed (@inout τ_0_1.TangentVector) -> (@out τ_0_0.TangentVector, @out τ_0_2.TangentVector)):
+// CHECK:   %2 = alloc_stack $τ_0_0.TangentVector
+// CHECK:   %3 = alloc_stack $τ_0_2.TangentVector
+// CHECK:   %4 = apply %1(%2, %3, %0) : $@callee_guaranteed (@inout τ_0_1.TangentVector) -> (@out τ_0_0.TangentVector, @out τ_0_2.TangentVector)
+// CHECK:   destroy_addr %2 : $*τ_0_0.TangentVector
+// CHECK:   destroy_addr %3 : $*τ_0_2.TangentVector
+// CHECK:   dealloc_stack %3 : $*τ_0_2.TangentVector
+// CHECK:   dealloc_stack %2 : $*τ_0_0.TangentVector
+// CHECK:   %9 = tuple ()
+// CHECK:   return %9 : $()
+// CHECK: }
+
+// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] @AD__$sSdSfSdSfIegnrrr_SdS2fIegnrr_TR_src_0_wrt_0_2_pullback_index_subset_thunk : $@convention(thin) (@in_guaranteed Double, @guaranteed @callee_guaranteed (@in_guaranteed Double) -> (@out Float, @out Double, @out Float)) -> (@out Float, @out Float) {
+// CHECK: bb0(%0 : $*Float, %1 : $*Float, %2 : $*Double, %3 : $@callee_guaranteed (@in_guaranteed Double) -> (@out Float, @out Double, @out Float)):
+// CHECK:   %4 = alloc_stack $Double
+// CHECK:   %5 = apply %3(%0, %4, %1, %2) : $@callee_guaranteed (@in_guaranteed Double) -> (@out Float, @out Double, @out Float)
+// CHECK:   destroy_addr %4 : $*Double
+// CHECK:   dealloc_stack %4 : $*Double
+// CHECK:   %8 = tuple ()
+// CHECK:   return %8 : $()
+// CHECK: }
+
+runAllTests()


### PR DESCRIPTION
Update subset parameters thunk logic to handle original `inout` parameters.
Fix pullback thunk `inout` argument forwarding. Improve comments.

Add end-to-end correctness and SIL FileCheck tests.

Resolves TF-1204.

---

Example:

```swift
func inoutDirect(_ x: Float, _ result: inout Double, _ y: Float) {}

// Register derivative wrt all parameters.
@derivative(of: inoutDirect, wrt: (x, result, y))
func vjpFoo(_ x: Float, _ result: inout Double, _ y: Float) -> (
  value: Void, pullback: (inout Double) -> (Float, Float)
) {
  return ((), { dresult in (0, 0) })
}

// Trigger subset parameter thunk for `inoutDirect` wrt `(x, result)`.
@differentiable(wrt: x)
func caller(_ x: Float, _ result: Double, _ y: Float) -> Double {
  var result = result
  inoutDirect(x, &result, y)
  return result
}
```

Before: assertion failure.
```console
Assertion failed: (origFnType->getResults().size() == 1), function getOrCreateSubsetParametersThunkForDerivativeFunction, file /Users/swiftninjas/s4tf/swift/lib/SILOptimizer/Utils/Differentiation/Thunk.cpp, line 812.
Stack dump:
...
1.	Swift version 5.2-dev (LLVM b3057cffb6, Swift c8bea53782)
2.	While running pass #39 SILModuleTransform "Differentiation".
3.	While canonicalizing `differentiable_function` SIL node   %11 = differentiable_function [parameters 0 1] %9 : $@convention(thin) (Float, @inout Double, Float) -> () // users: %13, %12
4.	While ...in SIL function "@AD__$s4main6callerySdSf_SdSftF__vjp_src_0_wrt_0".
 for 'caller(_:_:_:)' (at tf-1024.swift:2:1)
...
7  swift                    0x000000010cb628a3 swift::autodiff::getOrCreateSubsetParametersThunkForDerivativeFunction(swift::SILOptFunctionBuilder&, swift::SILValue, swift::SILValue, swift::AutoDiffDerivativeFunctionKind, swift::SILAutoDiffIndices, swift::SILAutoDiffIndices) (.cold.10) + 35
```

After: no crash.