### PR TITLE
Provide fallback SourceLoc for swiftinterface build errors

### DIFF
--- a/lib/Frontend/ModuleInterfaceBuilder.h
+++ b/lib/Frontend/ModuleInterfaceBuilder.h
@@ -33,7 +33,7 @@ class SearchPathOptions;
 class DependencyTracker;
 
 class ModuleInterfaceBuilder {
-  llvm::vfs::FileSystem &fs;
+  SourceManager &sourceMgr;
   DiagnosticEngine &diags;
   const StringRef interfacePath;
   const StringRef moduleName;
@@ -47,6 +47,19 @@ class ModuleInterfaceBuilder {
   DependencyTracker *const dependencyTracker;
   CompilerInvocation subInvocation;
   SmallVector<StringRef, 3> extraDependencies;
+
+  /// Emit a diagnostic tied to this declaration.
+  template<typename ...ArgTypes>
+  InFlightDiagnostic diagnose(
+      Diag<ArgTypes...> ID,
+      typename detail::PassArgument<ArgTypes>::type... Args) const {
+    SourceLoc loc = diagnosticLoc;
+    if (loc.isInvalid()) {
+      // Diagnose this inside the interface file, if possible.
+      loc = sourceMgr.getLocFromExternalSource(interfacePath, 1, 1);
+    }
+    return diags.diagnose(loc, ID, std::move(Args)...);
+  }
 
   void configureSubInvocationInputsAndOutputs(StringRef OutPath);
 
@@ -86,7 +99,7 @@ public:
                             bool disableInterfaceFileLock = false,
                             SourceLoc diagnosticLoc = SourceLoc(),
                             DependencyTracker *tracker = nullptr)
-    : fs(*sourceMgr.getFileSystem()), diags(diags),
+    : sourceMgr(sourceMgr), diags(diags),
       interfacePath(interfacePath), moduleName(moduleName),
       moduleCachePath(moduleCachePath), prebuiltCachePath(prebuiltCachePath),
       serializeDependencyHashes(serializeDependencyHashes),

--- a/validation-test/ParseableInterface/failing-overlay.swift
+++ b/validation-test/ParseableInterface/failing-overlay.swift
@@ -3,6 +3,4 @@
 
 import ImportsOverlay
 
-// FIXME: It would be better if this had a useful location, like inside the
-// C header that caused the importing of the overlay.
-// CHECK: <unknown>:0: error: failed to build module 'HasOverlay' from its module interface; the compiler that produced it, '(unspecified, file possibly handwritten)', may have used features that aren't supported by this compiler, '{{.*}}Swift version{{.*}}'
+// CHECK: HasOverlay.swiftinterface:1:1: error: failed to build module 'HasOverlay' from its module interface; the compiler that produced it, '(unspecified, file possibly handwritten)', may have used features that aren't supported by this compiler, '{{.*}}Swift version{{.*}}'


### PR DESCRIPTION
When a swiftinterface fails to build for any of various reasons, we try to diagnose the failure at the site of the `import` declaration. But if the import is implicitly added—which happens for many SDK modules, like the standard library and ClangImporter overlays—there is no source location for the import, so the error ends up being diagnosed at `<unknown>:0`. This causes a number of issues; most notably, Xcode doesn’t display the diagnostic as prominently as others.

This change falls back to diagnosing the error at line 1, column 1 of the swiftinterface file itself. This is perhaps not an ideal location, and it won’t help with I/O errors where we can’t open the swiftinterface file (and therefore can’t diagnose an error in it), but it should improve the way we display most module interface building errors.