### PR TITLE
[nfc] [util] add util to check if an instruction dominates all uses of a value

### DIFF
--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -547,6 +547,8 @@ bool tryOptimizeApplyOfPartialApply(
     PartialApplyInst *pai, SILBuilderContext &builderCtxt,
     InstModCallbacks callbacks = InstModCallbacks());
 
+bool dominatesAllUses(SILInstruction *a, SILValue b);
+
 } // end namespace swift
 
 #endif

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1943,3 +1943,15 @@ AbstractFunctionDecl *swift::getBaseMethod(AbstractFunctionDecl *FD) {
   }
   return FD;
 }
+
+/// Checks that "a" dominates all uses of "b".
+/// \param a the instruction who's expected to dominate.
+/// \param b the instruction who's uses are expected to be dominated.
+/// \returns true if all uses of "b" are dominated by "a". Otherwise, false.
+bool swift::dominatesAllUses(SILInstruction *a, SILValue b) {
+  DominanceInfo dominanceInfo(a->getFunction());
+  return std::all_of(b->use_begin(), b->use_end(),
+                     [&a, &dominanceInfo](Operand *use) {
+                       return dominanceInfo.dominates(a, use->getUser());
+                     });
+}


### PR DESCRIPTION
This patch adds a utility function `dominatesAllUses` to check if an instruction dominates all uses of a value. NFC. Used in #30463.

<!-- What's in this pull request? -->

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
