### PR TITLE
Add -sil-inline-never-functions flag.

### DIFF
--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -13,6 +13,12 @@
 #include "swift/SILOptimizer/Utils/PerformanceInlinerUtils.h"
 #include "swift/AST/Module.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
+#include "llvm/Support/CommandLine.h"
+
+llvm::cl::opt<std::string>
+    SILInlineNeverFuns("sil-inline-never-functions", llvm::cl::init(""),
+                       llvm::cl::desc("Never inline functions whose name "
+                                      "includes this string."));
 
 //===----------------------------------------------------------------------===//
 //                               ConstantTracker
@@ -686,6 +692,10 @@ SILFunction *swift::getEligibleFunction(FullApplySite AI,
   if (Callee->getInlineStrategy() == NoInline) {
     return nullptr;
   }
+
+  if (!SILInlineNeverFuns.empty()
+      && Callee->getName().find(SILInlineNeverFuns, 0) != StringRef::npos)
+    return nullptr;
 
   if (!Callee->shouldOptimize()) {
     return nullptr;

--- a/utils/swift-autocomplete.bash
+++ b/utils/swift-autocomplete.bash
@@ -68,6 +68,7 @@ _swift_complete()
       -sil-verify-without-invalidation \
       -sil-inline-test-threshold \
       -sil-inline-test \
+      -sil-inline-never-functions \
       -sroa-args-remove-dead-args-after \
       -ml \
       -sil-print-escapes \


### PR DESCRIPTION
And fix a test case that assumes Array.append is never inlined.

We need to be able to prevent inlining a function and any of its
specializations. There's no way to specify multiple function names on
the command line, so we use the partial match technique.

Part of the series of already-approved pass manager commits from:
https://github.com/apple/swift/pull/22445
