### PR TITLE
More explicit StringRef -> std::string conversions

### DIFF
--- a/include/swift/Basic/PathRemapper.h
+++ b/include/swift/Basic/PathRemapper.h
@@ -39,7 +39,7 @@ public:
   /// Adds a mapping such that any paths starting with `FromPrefix` have that
   /// portion replaced with `ToPrefix`.
   void addMapping(StringRef FromPrefix, StringRef ToPrefix) {
-    PathMappings.emplace_back(FromPrefix, ToPrefix);
+    PathMappings.emplace_back(FromPrefix.str(), ToPrefix.str());
   }
 
   /// Returns a remapped `Path` if it starts with a prefix in the map; otherwise

--- a/lib/Driver/FineGrainedDependencyDriverGraph.cpp
+++ b/lib/Driver/FineGrainedDependencyDriverGraph.cpp
@@ -178,7 +178,7 @@ std::vector<const Job *> ModuleDepGraph::jobsContaining(
 void ModuleDepGraph::registerJob(const Job *job) {
   // No need to create any nodes; that will happen when the swiftdeps file is
   // read. Just record the correspondence.
-  jobsBySwiftDeps.insert(std::make_pair(getSwiftDeps(job), job));
+  jobsBySwiftDeps.insert(std::make_pair(getSwiftDeps(job).str(), job));
 }
 
 std::vector<const Job *> ModuleDepGraph::getAllJobs() const {

--- a/lib/Driver/ParseableOutput.cpp
+++ b/lib/Driver/ParseableOutput.cpp
@@ -136,7 +136,7 @@ public:
     if (PrimaryOutputType != file_types::TY_Nothing) {
       for (llvm::StringRef OutputFileName :
            Cmd.getOutput().getPrimaryOutputFilenames()) {
-        Outputs.push_back(OutputPair(PrimaryOutputType, OutputFileName));
+        Outputs.push_back(OutputPair(PrimaryOutputType, OutputFileName.str()));
       }
     }
     file_types::forAllTypes([&](file_types::ID Ty) {


### PR DESCRIPTION
On the older compiler/stdlib used by our Ubuntu 16.04 bots, the
construction

        std::pair<std::string, X>(StringRef, X)

fails unless you call `.str()`. Newer compilers/stdlib treat this as an
explicit construction, which is what is now needed on master-next, so it
only fails on Ubuntu 16.04.

rdar://60514063
