### PR TITLE
[opt] dead thin to thick in mand combine

### DIFF
--- a/test/SILOptimizer/mandatory_combine_closure_cleanup.sil
+++ b/test/SILOptimizer/mandatory_combine_closure_cleanup.sil
@@ -1,0 +1,32 @@
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -mandatory-combine | %FileCheck %s
+
+import Builtin
+
+func test()
+
+sil [ossa] @closure : $@convention(thin) (Builtin.Int32) -> Builtin.Int32
+
+// CHECK-LABEL: remove_dead_thin_to_thick
+// CHECK: bb0
+// TODO: one of these will be removed by #30429.
+// CHECK-NEXT: tuple
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+// CHECK-LABEL: end sil function 'remove_dead_thin_to_thick'
+sil hidden [ossa] @remove_dead_thin_to_thick : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @closure : $@convention(thin) (Builtin.Int32) -> Builtin.Int32
+  %1 = thin_to_thick_function %0 : $@convention(thin) (Builtin.Int32) -> Builtin.Int32 to $@callee_guaranteed (Builtin.Int32) -> Builtin.Int32
+  debug_value %1 : $@callee_guaranteed (Builtin.Int32) -> Builtin.Int32, let, name "c"
+  
+  %3 = begin_borrow %1 : $@callee_guaranteed (Builtin.Int32) -> Builtin.Int32
+  %4 = copy_value %3 : $@callee_guaranteed (Builtin.Int32) -> Builtin.Int32
+  // This is all we got from the closure so we should be able to remove *everything* in this function.
+  %5 = tuple ()
+  destroy_value %4 : $@callee_guaranteed (Builtin.Int32) -> Builtin.Int32
+  end_borrow %3 : $@callee_guaranteed (Builtin.Int32) -> Builtin.Int32
+  destroy_value %1 : $@callee_guaranteed (Builtin.Int32) -> Builtin.Int32
+  
+  %9 = tuple ()
+  return %9 : $()
+} // end sil function 'remove_dead_thin_to_thick'


### PR DESCRIPTION
This patch supports basic elimination of dead thick to thin function refs in mandatory combine. With #30463 and store elimination [more complex function bodies](https://gist.github.com/zoecarver/c7626b6f3b935a3879e04dec74e3ff93) [1] could also be fully optimized away. This patch is taken from #28536.

[1] this is an example of a function I pulled almost directly from [silgen](https://swift.godbolt.org/z/HnD-CA). I have verified that after applying this patch, #30463, and a store elimination patch all loads, stores, and closures are able to be removed. That being said, it may not be worth the extra Onone compile time.

<!-- What's in this pull request? -->

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
