### PR TITLE
IRGen: Add a flag to disable mangled name type metadata accessors.

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2433,10 +2433,6 @@ struct TargetProtocolConformanceDescriptor final
   using OverloadToken = typename TrailingObjects::template OverloadToken<T>;
 
 public:
-  using WitnessTableAccessorFn
-    = const TargetWitnessTable<Runtime> *(const TargetMetadata<Runtime>*,
-                                          const TargetWitnessTable<Runtime> **);
-
   using GenericRequirementDescriptor =
     TargetGenericRequirementDescriptor<Runtime>;
 

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -280,6 +280,9 @@ public:
   /// Whether to disable shadow copies for local variables on the stack. This is
   /// only used for testing.
   unsigned DisableDebuggerShadowCopies : 1;
+  
+  /// Whether to disable using mangled names for accessing concrete type metadata.
+  unsigned DisableConcreteTypeMetadataMangledNameAccessors : 1;
 
   /// Path to the profdata file to be used for PGO, or the empty string.
   std::string UseProfile = "";
@@ -327,6 +330,7 @@ public:
         UseSwiftCall(false), UseTypeLayoutValueHandling(true), GenerateProfile(false),
         EnableDynamicReplacementChaining(false),
         DisableRoundTripDebugTypes(false), DisableDebuggerShadowCopies(false),
+        DisableConcreteTypeMetadataMangledNameAccessors(false),
         CmdArgs(), SanitizeCoverage(llvm::SanitizerCoverageOptions()),
         TypeInfoFilter(TypeInfoDumpFilter::All) {}
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -510,6 +510,10 @@ def disable_debugger_shadow_copies : Flag<["-"], "disable-debugger-shadow-copies
            "This option is only useful for testing the compiler.">,
   Flags<[FrontendOption, HelpHidden]>;
 
+def disable_concrete_type_metadata_mangled_name_accessors : Flag<["-"], "disable-concrete-type-metadata-mangled-name-accessors">,
+  HelpText<"Disable concrete type metadata access by mangled name">,
+  Flags<[FrontendOption, HelpHidden]>;
+  
 def playground : Flag<["-"], "playground">,
   HelpText<"Apply the playground semantics and transformation">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1261,6 +1261,9 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_disable_debugger_shadow_copies))
     Opts.DisableDebuggerShadowCopies = true;
 
+  if (Args.hasArg(OPT_disable_concrete_type_metadata_mangled_name_accessors))
+    Opts.DisableConcreteTypeMetadataMangledNameAccessors = true;
+
   if (Args.hasArg(OPT_use_jit))
     Opts.UseJIT = true;
   

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -2202,6 +2202,10 @@ irgen::getGenericTypeMetadataAccessFunction(IRGenModule &IGM,
 }
 
 static bool shouldAccessByMangledName(IRGenModule &IGM, CanType type) {
+  // Never access by mangled name if we've been asked not to.
+  if (IGM.getOptions().DisableConcreteTypeMetadataMangledNameAccessors)
+    return false;
+  
   // A nongeneric nominal type with nontrivial metadata has an accessor
   // already we can just call.
   if (auto nom = dyn_cast<NominalType>(type)) {

--- a/test/IRGen/access_type_metadata_by_mangled_name.swift
+++ b/test/IRGen/access_type_metadata_by_mangled_name.swift
@@ -1,4 +1,8 @@
 // RUN: %target-swift-frontend -emit-ir -parse-stdlib %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-endian
+// RUN: %target-swift-frontend -emit-ir -disable-concrete-type-metadata-mangled-name-accessors -parse-stdlib %s | %FileCheck %s --check-prefix=DISABLED
+
+// DISABLED-NOT: __swift_instantiateConcreteTypeFromMangledName
+// DISABLED-NOT: MD" = {{.*}} global
 
 // CHECK: @"$s36access_type_metadata_by_mangled_name3FooCyAA3BarCyAA3ZimCyAA4ZangCGGGMD" = linkonce_odr hidden global { i32, i32 }
 


### PR DESCRIPTION
Useful as a workaround for runtime demangler bugs, or in rare cases where there are
performance problems with the demangler.