### PR TITLE
[Gardening] Standardize edu note markdown headers

### DIFF
--- a/userdocs/diagnostics/associated-type-requirements.md
+++ b/userdocs/diagnostics/associated-type-requirements.md
@@ -1,5 +1,4 @@
-Using Protocols with `Self` or Associated Type Requirements
----
+# Using Protocols with `Self` or Associated Type Requirements
 Protocols in Swift may be used as types, as part of a generic constraint, or as part of an opaque result type.
 ```
 // CustomStringConvertible can be used as a type.

--- a/userdocs/diagnostics/complex-closure-inference.md
+++ b/userdocs/diagnostics/complex-closure-inference.md
@@ -1,5 +1,4 @@
-Inferring Closure Types
----
+# Inferring Closure Types
 If a closure contains a single expression, Swift will consider its body in addition to its signature and the surrounding context when performing type inference. For example, in the following code the type of `doubler` is inferred to be `(Int) -> Int` using only its body:
 ```
 let doubler = {

--- a/userdocs/diagnostics/dynamic-callable-requirements.md
+++ b/userdocs/diagnostics/dynamic-callable-requirements.md
@@ -1,5 +1,4 @@
-@dynamicCallable Implementation Requirements
----
+# @dynamicCallable Implementation Requirements
 If a type is marked with the `@dynamicCallable` attribute, it must provide a valid implementation of `dynamicallyCall(withArguments:)`, `dynamicallyCall(withKeywordArguments:)`, or both. If it fails to do so, an error will be reported at compile-time. Note that an implementation of `dynamicallyCall(withKeywordArguments:)` is required to support calls with keyword arguments.
 
 To be considered valid, an implementation of `dynamicallyCall(withArguments:)` must:

--- a/userdocs/diagnostics/nominal-types.md
+++ b/userdocs/diagnostics/nominal-types.md
@@ -1,5 +1,4 @@
-## Nominal types
-***
+# Nominal types
 In Swift, a type is considered a nominal type if it is named.  In other words, it has been defined by declaring the type somewhere in code. Examples of nominal types include classes, structs and enums, all of which must be declared before using them. Nominal types are an important concept in Swift because they can be extended, explicitly initialized using the `MyType()` syntax, and may conform to protocols.
 
 In contrast, non-nominal types have none of these capabilities. A non-nominal type is any type which is not nominal. They are sometimes called "structural types" because they are usually obtained by composing other types. Examples include function types like `(Int) -> (String)`, tuple types like `(Int, String)`, metatypes like `Int.Type`, and special types like `Any` and `AnyObject`.

--- a/userdocs/diagnostics/property-wrapper-requirements.md
+++ b/userdocs/diagnostics/property-wrapper-requirements.md
@@ -1,5 +1,4 @@
-Property Wrapper Implementation Requirements
----
+# Property Wrapper Implementation Requirements
 If a type is marked with the `@propertyWrapper` attribute, it must meet certain requirements to be a valid property wrapper.
 
 First, all property wrapper types must have a property named `wrappedValue`. This property cannot be static and must have the same access level as the property wrapper type. If the property wrapper provides a `projectedValue` property, it is subject to the same requirements.


### PR DESCRIPTION
Some of these were inconsistent before, now they should all render the same (h1 title followed by body).