### PR TITLE
IRGen: Fix keypath crash whose id's have a generic signature but the pattern has not

### DIFF
--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -879,7 +879,8 @@ emitKeyPathComponent(IRGenModule &IGM,
                     reqt.TypeParameter->getCanonicalType(), reqt.Protocol);
                 externalSubArgs.push_back(IGM.emitWitnessTableRefString(
                     substType, conformance,
-                    genericEnv ? genericEnv->getGenericSignature() : nullptr,
+                    genericEnv ? genericEnv->getGenericSignature()
+                               : componentCanSig,
                     /*shouldSetLowBit*/ true));
               }
             });

--- a/test/Interpreter/errors_imported.swift
+++ b/test/Interpreter/errors_imported.swift
@@ -51,5 +51,21 @@ ErrorHandlingTests.test("blockFailure") {
   }
 }
 
-runAllTests()
+enum MyError : Error {
+  case Ups
+}
 
+extension MyError : LocalizedError {
+  var errorDescription: String? {
+    return NSLocalizedString("something went horribly wrong", comment: "")
+  }
+}
+
+ErrorHandlingTests.test("localizedDescription keypath") {
+  var errors = [Error]()
+  errors.append(MyError.Ups)
+  let str = "Errors: \(errors.map(\.localizedDescription))"
+  expectEqual("Errors: [\"something went horribly wrong\"]", str)
+}
+
+runAllTests()


### PR DESCRIPTION
We used to crash on:

```
keypath $KeyPath<Error, String>, (root $Error; gettable_property $String,
 id @$ss5ErrorP10FoundationE20localizedDescriptionSSvg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned String,
 getter @$ss5ErrorP10FoundationE20localizedDescriptionSSvpsAA_pTK : $@convention(thin) (@in_guaranteed Error) -> @out String,
 external #Error.localizedDescription<τ_0_0>)
```

rdar://60394176