### PR TITLE
ModuleInterface: consider inherited protocols from super class when collecting handled protocols

### DIFF
--- a/test/ModuleInterface/skip-redundant-conformances.swift
+++ b/test/ModuleInterface/skip-redundant-conformances.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -module-name Foo -emit-module-interface-path %t/Foo.swiftinterface %s
+// RUN: %target-swift-frontend -compile-module-from-interface %t/Foo.swiftinterface -o %t/Foo.swiftmodule
+
+public protocol ProtocolA : class {}
+public protocol ProtocolB: ProtocolA {}
+protocol ProtocolC: ProtocolA {}
+
+public class A: ProtocolB {}
+public class B: A, ProtocolC {}


### PR DESCRIPTION
Protocol conformances can be implied by super classes. When collecting the list
of IncludedProtocols, we should traverse the class inheritance chain and collect
all protocols.

Without this change, these implied conformances will be printed again via a synthesized
extension at the end of the Swift interface file, leading to an error of redundant
conformances when building modules.

rdar://58563540