### PR TITLE
Add getArraySemanticsKind API.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/ArraySemantic.h
+++ b/include/swift/SILOptimizer/Analysis/ArraySemantic.h
@@ -45,6 +45,9 @@ enum class ArrayCallKind {
   kArrayUninitializedIntrinsic
 };
 
+/// Return true is the given function is an array semantics call.
+ArrayCallKind getArraySemanticsKind(SILFunction *f);
+
 /// Wrapper around array semantic calls.
 class ArraySemanticsCall {
   ApplyInst *SemanticsCall;


### PR DESCRIPTION
So that it's possible to determine the kind of Array semantic function
from its SILFunction decl only.

