### PR TITLE
[ownership] Rename BorrowScopeIntroducingValue -> BorrowedValue and BorrowScopeOperand -> BorrowingOperand.

### DIFF
--- a/lib/SIL/OwnershipUtils.cpp
+++ b/lib/SIL/OwnershipUtils.cpp
@@ -144,7 +144,7 @@ llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
   return os;
 }
 
-void BorrowScopeOperand::print(llvm::raw_ostream &os) const {
+void BorrowingOperand::print(llvm::raw_ostream &os) const {
   os << "BorrowScopeOperand:\n"
         "Kind: " << kind << "\n"
         "Value: " << op->get()
@@ -152,12 +152,12 @@ void BorrowScopeOperand::print(llvm::raw_ostream &os) const {
 }
 
 llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
-                                     const BorrowScopeOperand &operand) {
+                                     const BorrowingOperand &operand) {
   operand.print(os);
   return os;
 }
 
-void BorrowScopeOperand::visitEndScopeInstructions(
+void BorrowingOperand::visitEndScopeInstructions(
     function_ref<void(Operand *)> func) const {
   switch (kind) {
   case BorrowScopeOperandKind::BeginBorrow:
@@ -189,21 +189,20 @@ void BorrowScopeOperand::visitEndScopeInstructions(
   llvm_unreachable("Covered switch isn't covered");
 }
 
-void BorrowScopeOperand::visitBorrowIntroducingUserResults(
-    function_ref<void(BorrowScopeIntroducingValue)> visitor) {
+void BorrowingOperand::visitBorrowIntroducingUserResults(
+    function_ref<void(BorrowedValue)> visitor) {
   switch (kind) {
   case BorrowScopeOperandKind::BeginApply:
     llvm_unreachable("Never has borrow introducer results!");
   case BorrowScopeOperandKind::BeginBorrow: {
-    auto value =
-        *BorrowScopeIntroducingValue::get(cast<BeginBorrowInst>(op->getUser()));
+    auto value = *BorrowedValue::get(cast<BeginBorrowInst>(op->getUser()));
     return visitor(value);
   }
   case BorrowScopeOperandKind::Branch: {
     auto *bi = cast<BranchInst>(op->getUser());
     for (auto *succBlock : bi->getSuccessorBlocks()) {
-      auto value = *BorrowScopeIntroducingValue::get(
-          succBlock->getArgument(op->getOperandNumber()));
+      auto value =
+          *BorrowedValue::get(succBlock->getArgument(op->getOperandNumber()));
       visitor(value);
     }
     return;
@@ -212,11 +211,11 @@ void BorrowScopeOperand::visitBorrowIntroducingUserResults(
   llvm_unreachable("Covered switch isn't covered?!");
 }
 
-void BorrowScopeOperand::visitConsumingUsesOfBorrowIntroducingUserResults(
+void BorrowingOperand::visitConsumingUsesOfBorrowIntroducingUserResults(
     function_ref<void(Operand *)> func) {
   // First visit all of the results of our user that are borrow introducing
   // values.
-  visitBorrowIntroducingUserResults([&](BorrowScopeIntroducingValue value) {
+  visitBorrowIntroducingUserResults([&](BorrowedValue value) {
     // Visit the scope ending instructions of this value. If any of them are
     // consuming borrow scope operands, visit the consuming uses of the
     // results or successor arguments.
@@ -224,7 +223,7 @@ void BorrowScopeOperand::visitConsumingUsesOfBorrowIntroducingUserResults(
     // This enables one to walk the def-use chain of guaranteed phis for a
     // single guaranteed scope.
     value.visitLocalScopeEndingUses([&](Operand *valueUser) {
-      if (auto subBorrowScopeOp = BorrowScopeOperand::get(valueUser)) {
+      if (auto subBorrowScopeOp = BorrowingOperand::get(valueUser)) {
         if (subBorrowScopeOp->consumesGuaranteedValues()) {
           subBorrowScopeOp->visitUserResultConsumingUses(func);
           return;
@@ -238,7 +237,7 @@ void BorrowScopeOperand::visitConsumingUsesOfBorrowIntroducingUserResults(
   });
 }
 
-void BorrowScopeOperand::visitUserResultConsumingUses(
+void BorrowingOperand::visitUserResultConsumingUses(
     function_ref<void(Operand *)> visitor) {
   auto *ti = dyn_cast<TermInst>(op->getUser());
   if (!ti) {
@@ -266,40 +265,40 @@ void BorrowScopeOperand::visitUserResultConsumingUses(
 //                             Borrow Introducers
 //===----------------------------------------------------------------------===//
 
-void BorrowScopeIntroducingValueKind::print(llvm::raw_ostream &os) const {
+void BorrowedValueKind::print(llvm::raw_ostream &os) const {
   switch (value) {
-  case BorrowScopeIntroducingValueKind::SILFunctionArgument:
+  case BorrowedValueKind::SILFunctionArgument:
     os << "SILFunctionArgument";
     return;
-  case BorrowScopeIntroducingValueKind::BeginBorrow:
+  case BorrowedValueKind::BeginBorrow:
     os << "BeginBorrowInst";
     return;
-  case BorrowScopeIntroducingValueKind::LoadBorrow:
+  case BorrowedValueKind::LoadBorrow:
     os << "LoadBorrowInst";
     return;
-  case BorrowScopeIntroducingValueKind::Phi:
+  case BorrowedValueKind::Phi:
     os << "Phi";
     return;
   }
   llvm_unreachable("Covered switch isn't covered?!");
 }
 
-void BorrowScopeIntroducingValue::print(llvm::raw_ostream &os) const {
+void BorrowedValue::print(llvm::raw_ostream &os) const {
   os << "BorrowScopeIntroducingValue:\n"
     "Kind: " << kind << "\n"
     "Value: " << value;
 }
 
-void BorrowScopeIntroducingValue::getLocalScopeEndingInstructions(
+void BorrowedValue::getLocalScopeEndingInstructions(
     SmallVectorImpl<SILInstruction *> &scopeEndingInsts) const {
   assert(isLocalScope() && "Should only call this given a local scope");
 
   switch (kind) {
-  case BorrowScopeIntroducingValueKind::SILFunctionArgument:
+  case BorrowedValueKind::SILFunctionArgument:
     llvm_unreachable("Should only call this with a local scope");
-  case BorrowScopeIntroducingValueKind::BeginBorrow:
-  case BorrowScopeIntroducingValueKind::LoadBorrow:
-  case BorrowScopeIntroducingValueKind::Phi:
+  case BorrowedValueKind::BeginBorrow:
+  case BorrowedValueKind::LoadBorrow:
+  case BorrowedValueKind::Phi:
     for (auto *use : value->getUses()) {
       if (use->isConsumingUse()) {
 	scopeEndingInsts.push_back(use->getUser());
@@ -310,15 +309,15 @@ void BorrowScopeIntroducingValue::getLocalScopeEndingInstructions(
   llvm_unreachable("Covered switch isn't covered?!");
 }
 
-void BorrowScopeIntroducingValue::visitLocalScopeEndingUses(
+void BorrowedValue::visitLocalScopeEndingUses(
     function_ref<void(Operand *)> visitor) const {
   assert(isLocalScope() && "Should only call this given a local scope");
   switch (kind) {
-  case BorrowScopeIntroducingValueKind::SILFunctionArgument:
+  case BorrowedValueKind::SILFunctionArgument:
     llvm_unreachable("Should only call this with a local scope");
-  case BorrowScopeIntroducingValueKind::LoadBorrow:
-  case BorrowScopeIntroducingValueKind::BeginBorrow:
-  case BorrowScopeIntroducingValueKind::Phi:
+  case BorrowedValueKind::LoadBorrow:
+  case BorrowedValueKind::BeginBorrow:
+  case BorrowedValueKind::Phi:
     for (auto *use : value->getUses()) {
       if (use->isConsumingUse()) {
         visitor(use);
@@ -330,18 +329,18 @@ void BorrowScopeIntroducingValue::visitLocalScopeEndingUses(
 }
 
 llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
-                                     BorrowScopeIntroducingValueKind kind) {
+                                     BorrowedValueKind kind) {
   kind.print(os);
   return os;
 }
 
 llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
-                                     const BorrowScopeIntroducingValue &value) {
+                                     const BorrowedValue &value) {
   value.print(os);
   return os;
 }
 
-bool BorrowScopeIntroducingValue::areUsesWithinScope(
+bool BorrowedValue::areUsesWithinScope(
     ArrayRef<Operand *> uses, SmallVectorImpl<Operand *> &scratchSpace,
     SmallPtrSetImpl<SILBasicBlock *> &visitedBlocks,
     DeadEndBlocks &deadEndBlocks) const {
@@ -368,7 +367,7 @@ bool BorrowScopeIntroducingValue::areUsesWithinScope(
   return checker.validateLifetime(value, scratchSpace, uses);
 }
 
-bool BorrowScopeIntroducingValue::visitLocalScopeTransitiveEndingUses(
+bool BorrowedValue::visitLocalScopeTransitiveEndingUses(
     function_ref<void(Operand *)> visitor) const {
   assert(isLocalScope());
 
@@ -388,7 +387,7 @@ bool BorrowScopeIntroducingValue::visitLocalScopeTransitiveEndingUses(
 
     // See if we have a borrow scope operand. If we do not, then we know we are
     // a final consumer of our borrow scope introducer. Visit it and continue.
-    auto scopeOperand = BorrowScopeOperand::get(op);
+    auto scopeOperand = BorrowingOperand::get(op);
     if (!scopeOperand) {
       visitor(op);
       continue;
@@ -410,7 +409,7 @@ bool BorrowScopeIntroducingValue::visitLocalScopeTransitiveEndingUses(
   return foundError;
 }
 
-bool BorrowScopeIntroducingValue::visitInteriorPointerOperands(
+bool BorrowedValue::visitInteriorPointerOperands(
     function_ref<void(const InteriorPointerOperand &)> func) const {
   SmallVector<Operand *, 32> worklist(value->getUses());
   while (!worklist.empty()) {
@@ -502,8 +501,8 @@ void OwnedValueIntroducerKind::print(llvm::raw_ostream &os) const {
 //                       Introducer Searching Routines
 //===----------------------------------------------------------------------===//
 
-bool swift::getAllBorrowIntroducingValues(
-    SILValue inputValue, SmallVectorImpl<BorrowScopeIntroducingValue> &out) {
+bool swift::getAllBorrowIntroducingValues(SILValue inputValue,
+                                          SmallVectorImpl<BorrowedValue> &out) {
   if (inputValue.getOwnershipKind() != ValueOwnershipKind::Guaranteed)
     return false;
 
@@ -514,7 +513,7 @@ bool swift::getAllBorrowIntroducingValues(
     SILValue value = worklist.pop_back_val();
 
     // First check if v is an introducer. If so, stash it and continue.
-    if (auto scopeIntroducer = BorrowScopeIntroducingValue::get(value)) {
+    if (auto scopeIntroducer = BorrowedValue::get(value)) {
       out.push_back(*scopeIntroducer);
       continue;
     }
@@ -554,7 +553,7 @@ bool swift::getAllBorrowIntroducingValues(
   return true;
 }
 
-Optional<BorrowScopeIntroducingValue>
+Optional<BorrowedValue>
 swift::getSingleBorrowIntroducingValue(SILValue inputValue) {
   if (inputValue.getOwnershipKind() != ValueOwnershipKind::Guaranteed)
     return None;
@@ -563,7 +562,7 @@ swift::getSingleBorrowIntroducingValue(SILValue inputValue) {
   while (true) {
     // First check if our initial value is an introducer. If we have one, just
     // return it.
-    if (auto scopeIntroducer = BorrowScopeIntroducingValue::get(currentValue)) {
+    if (auto scopeIntroducer = BorrowedValue::get(currentValue)) {
       return scopeIntroducer;
     }
 

--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -868,7 +868,7 @@ getEndPointsOfDataDependentChain(SILValue value, SILFunction *fun,
 /// value, if there is exactly one such introducing value. Otherwise, return
 /// None. There can be multiple borrow scopes for a SILValue iff it is derived
 /// from a guaranteed basic block parameter representing a phi node.
-static Optional<BorrowScopeIntroducingValue>
+static Optional<BorrowedValue>
 getUniqueBorrowScopeIntroducingValue(SILValue value) {
   assert(value.getOwnershipKind() == ValueOwnershipKind::Guaranteed &&
          "parameter must be a guarenteed value");
@@ -925,7 +925,7 @@ static void replaceAllUsesAndFixLifetimes(SILValue foldedVal,
   // destroy foldedVal at the end of the borrow scope.
   assert(originalVal.getOwnershipKind() == ValueOwnershipKind::Guaranteed);
 
-  Optional<BorrowScopeIntroducingValue> originalScopeBegin =
+  Optional<BorrowedValue> originalScopeBegin =
       getUniqueBorrowScopeIntroducingValue(originalVal);
   assert(originalScopeBegin &&
          "value without a unique borrow scope should not have been folded");
@@ -976,7 +976,7 @@ static void substituteConstants(FoldState &foldState) {
     // value at the point where the owned value is defined.
     SILInstruction *insertionPoint = definingInst;
     if (constantSILValue.getOwnershipKind() == ValueOwnershipKind::Guaranteed) {
-      Optional<BorrowScopeIntroducingValue> borrowIntroducer =
+      Optional<BorrowedValue> borrowIntroducer =
           getUniqueBorrowScopeIntroducingValue(constantSILValue);
       if (!borrowIntroducer) {
         // This case happens only if constantSILValue is derived from a

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -607,7 +607,7 @@ SILValue AvailableValueAggregator::aggregateValues(SILType LoadTy,
       SILValue borrowedResult = result;
       SILBuilderWithScope builder(&*B.getInsertionPoint(), &insertedInsts);
       result = builder.emitCopyValueOperation(Loc, borrowedResult);
-      SmallVector<BorrowScopeIntroducingValue, 4> introducers;
+      SmallVector<BorrowedValue, 4> introducers;
       bool foundIntroducers =
           getAllBorrowIntroducingValues(borrowedResult, introducers);
       (void)foundIntroducers;
@@ -629,7 +629,7 @@ SILValue AvailableValueAggregator::aggregateValues(SILType LoadTy,
       SILValue borrowedResult = result;
       SILBuilderWithScope builder(&*B.getInsertionPoint(), &insertedInsts);
       result = builder.emitCopyValueOperation(Loc, borrowedResult);
-      SmallVector<BorrowScopeIntroducingValue, 4> introducers;
+      SmallVector<BorrowedValue, 4> introducers;
       bool foundIntroducers =
           getAllBorrowIntroducingValues(borrowedResult, introducers);
       (void)foundIntroducers;

--- a/lib/SILOptimizer/Transforms/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Transforms/SemanticARCOpts.cpp
@@ -1190,7 +1190,7 @@ bool SemanticARCOptVisitor::visitBeginBorrowInst(BeginBorrowInst *bbi) {
 //
 // TODO: This needs a better name.
 bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(CopyValueInst *cvi) {
-  SmallVector<BorrowScopeIntroducingValue, 4> borrowScopeIntroducers;
+  SmallVector<BorrowedValue, 4> borrowScopeIntroducers;
 
   // Find all borrow introducers for our copy operand. If we are unable to find
   // all of the reproducers (due to pattern matching failure), conservatively
@@ -1269,8 +1269,8 @@ bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(CopyValueInst
   // dead end blocks that use the value in a non-consuming way.
   //
   // TODO: There may be some way of sinking this into the loop below.
-  bool haveAnyLocalScopes = llvm::any_of(
-      borrowScopeIntroducers, [](BorrowScopeIntroducingValue borrowScope) {
+  bool haveAnyLocalScopes =
+      llvm::any_of(borrowScopeIntroducers, [](BorrowedValue borrowScope) {
         return borrowScope.isLocalScope();
       });
 
@@ -1302,12 +1302,10 @@ bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(CopyValueInst
       return false;
     SmallVector<Operand *, 8> scratchSpace;
     SmallPtrSet<SILBasicBlock *, 4> visitedBlocks;
-    if (llvm::any_of(borrowScopeIntroducers,
-                     [&](BorrowScopeIntroducingValue borrowScope) {
-                       return !borrowScope.areUsesWithinScope(
-                           destroys, scratchSpace, visitedBlocks,
-                           getDeadEndBlocks());
-                     })) {
+    if (llvm::any_of(borrowScopeIntroducers, [&](BorrowedValue borrowScope) {
+          return !borrowScope.areUsesWithinScope(
+              destroys, scratchSpace, visitedBlocks, getDeadEndBlocks());
+        })) {
       return false;
     }
   }
@@ -1339,7 +1337,7 @@ bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(CopyValueInst
       }
 
       if (llvm::any_of(borrowScopeIntroducers,
-                       [&](BorrowScopeIntroducingValue borrowScope) {
+                       [&](BorrowedValue borrowScope) {
                          return !borrowScope.areUsesWithinScope(
                              phiArgLR.getDestroyingUses(), scratchSpace,
                              visitedBlocks, getDeadEndBlocks());
@@ -1716,7 +1714,7 @@ public:
     // function. To be conservative, assume that all other non-local scopes
     // write to memory.
     if (!value->isLocalScope()) {
-      if (value->kind == BorrowScopeIntroducingValueKind::SILFunctionArgument) {
+      if (value->kind == BorrowedValueKind::SILFunctionArgument) {
         return answer(false);
       }
 
@@ -1727,7 +1725,7 @@ public:
 
     // TODO: This is disabled temporarily for guaranteed phi args just for
     // staging purposes. Thus be conservative and assume true in these cases.
-    if (value->kind == BorrowScopeIntroducingValueKind::Phi) {
+    if (value->kind == BorrowedValueKind::Phi) {
       return answer(true);
     }
 


### PR DESCRIPTION
Andy and I for some time have been discussing the right name for these two
"ownership concepts". What we realized is that the "ing" on
BorrowScopeIntroducingValue is very unfortunate since this value is the result
of a new borrow scope being introduced. So the name should be really:
BorrowScopeIntroducedValue. Given that is sort of unsatisfying, we settled on
the name BorrowedValue.

Once we found the name BorrowedValue, we naturally realized that
BorrowScopeOperand -> BorrowingOperand followed. This is because the operand is
the operand of the instruction that is creating the new borrow scope. So in a
sense the Operand is the "Use" that causes the original value to become
borrowed. So a BorrowingOperand is where the action is and is "active".
