### PR TITLE
[Constraint system] Use the PatternBindingDecl context when possible.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7395,7 +7395,9 @@ static Optional<SolutionApplicationTarget> applySolutionToInitialization(
   TypeResolutionOptions options =
       isa<EditorPlaceholderExpr>(initializer->getSemanticsProvidingExpr())
       ? TypeResolverContext::EditorPlaceholderExpr
-      : TypeResolverContext::InExpression;
+      : target.getInitializationPatternBindingDecl()
+        ? TypeResolverContext::PatternBindingDecl
+        : TypeResolverContext::InExpression;
   options |= TypeResolutionFlags::OverrideType;
 
   // Determine the type of the pattern.
@@ -7411,9 +7413,7 @@ static Optional<SolutionApplicationTarget> applySolutionToInitialization(
   finalPatternType = finalPatternType->reconstituteSugar(/*recursive =*/false);
 
   // Apply the solution to the pattern as well.
-  auto contextualPattern =
-      ContextualPattern::forRawPattern(target.getInitializationPattern(),
-                                       target.getDeclContext());
+  auto contextualPattern = target.getInitializationContextualPattern();
   if (auto coercedPattern = TypeChecker::coercePatternToType(
           contextualPattern, finalPatternType, options)) {
     resultTarget.setPattern(coercedPattern);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2328,6 +2328,10 @@ namespace {
             : ContextualPattern::forRawPattern(pattern, CurDC);
 
         Type type = TypeChecker::typeCheckPattern(contextualPattern);
+
+        // Look through reference storage types.
+        type = type->getReferenceStorageReferent();
+
         Type openedType = CS.openUnboundGenericType(type, locator);
 
         // Determine the subpattern type. It will be convertible to the

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1206,6 +1206,12 @@ class SolutionApplicationTarget {
       /// Whether to bind the variables encountered within the pattern to
       /// fresh type variables via one-way constraints.
       bool bindPatternVarsOneWay;
+
+      /// The pattern binding declaration for an initialization, if any.
+      PatternBindingDecl *patternBinding;
+
+      /// The index into the pattern binding declaration, if any.
+      unsigned patternBindingIndex;
     } expression;
 
     struct {
@@ -1265,6 +1271,13 @@ public:
   /// Form a target for the initialization of a pattern from an expression.
   static SolutionApplicationTarget forInitialization(
       Expr *initializer, DeclContext *dc, Type patternType, Pattern *pattern,
+      bool bindPatternVarsOneWay);
+
+  /// Form a target for the initialization of a pattern binding entry from
+  /// an expression.
+  static SolutionApplicationTarget forInitialization(
+      Expr *initializer, DeclContext *dc, Type patternType,
+      PatternBindingDecl *patternBinding, unsigned patternBindingIndex,
       bool bindPatternVarsOneWay);
 
   Expr *getAsExpr() const {
@@ -1351,6 +1364,9 @@ public:
     return expression.pattern;
   }
 
+  /// For a pattern initialization target, retrieve the contextual pattern.
+  ContextualPattern getInitializationContextualPattern() const;
+
   /// Whether this is an initialization for an Optional.Some pattern.
   bool isOptionalSomePatternInit() const {
     return kind == Kind::expression &&
@@ -1372,6 +1388,18 @@ public:
     assert(kind == Kind::expression);
     assert(expression.contextualPurpose == CTP_Initialization);
     return expression.wrappedVar;
+  }
+
+  PatternBindingDecl *getInitializationPatternBindingDecl() const {
+    assert(kind == Kind::expression);
+    assert(expression.contextualPurpose == CTP_Initialization);
+    return expression.patternBinding;
+  }
+
+  unsigned getInitializationPatternBindingIndex() const {
+    assert(kind == Kind::expression);
+    assert(expression.contextualPurpose == CTP_Initialization);
+    return expression.patternBindingIndex;
   }
 
   /// Whether this context infers an opaque return type.
@@ -3398,7 +3426,9 @@ public:
   ///
   /// \returns a possibly-sanitized initializer, or null if an error occurred.
   Type generateConstraints(Pattern *P, ConstraintLocatorBuilder locator,
-                           bool bindPatternVarsOneWay);
+                           bool bindPatternVarsOneWay,
+                           PatternBindingDecl *patternBinding,
+                           unsigned patternIndex);
 
   /// Generate constraints for a statement condition.
   ///

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2352,11 +2352,16 @@ TypeChecker::getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
   }
 }
 
-bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
-                                   DeclContext *DC,
-                                   Type patternType) {
-  auto target = SolutionApplicationTarget::forInitialization(
-      initializer, DC, patternType, pattern, /*bindPatternVarsOneWay=*/false);
+bool TypeChecker::typeCheckBinding(
+    Pattern *&pattern, Expr *&initializer, DeclContext *DC,
+    Type patternType, PatternBindingDecl *PBD, unsigned patternNumber) {
+  SolutionApplicationTarget target =
+    PBD ? SolutionApplicationTarget::forInitialization(
+            initializer, DC, patternType, PBD, patternNumber,
+            /*bindPatternVarsOneWay=*/false)
+        : SolutionApplicationTarget::forInitialization(
+            initializer, DC, patternType, pattern,
+            /*bindPatternVarsOneWay=*/false);
 
   // Type-check the initializer.
   bool unresolvedTypeExprs = false;
@@ -2425,7 +2430,8 @@ bool TypeChecker::typeCheckPatternBinding(PatternBindingDecl *PBD,
     }
   }
 
-  bool hadError = TypeChecker::typeCheckBinding(pattern, init, DC, patternType);
+  bool hadError = TypeChecker::typeCheckBinding(
+      pattern, init, DC, patternType, PBD, patternNumber);
   if (!init) {
     PBD->setInvalid();
     return true;
@@ -2550,7 +2556,8 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
       // Collect constraints from the element pattern.
       auto pattern = Stmt->getPattern();
       InitType = cs.generateConstraints(
-          pattern, elementLocator, /*bindPatternVarsOneWay=*/false);
+          pattern, elementLocator, /*bindPatternVarsOneWay=*/false,
+          /*patternBinding=*/nullptr, /*patternBindingIndex=*/0);
       if (!InitType)
         return true;
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -916,7 +916,9 @@ void coerceParameterListToType(ParameterList *P, ClosureExpr *CE,
 
 /// Type-check an initialized variable pattern declaration.
 bool typeCheckBinding(Pattern *&P, Expr *&Init, DeclContext *DC,
-                      Type patternType);
+                      Type patternType,
+                      PatternBindingDecl *PBD = nullptr,
+                      unsigned patternNumber = 0);
 bool typeCheckPatternBinding(PatternBindingDecl *PBD, unsigned patternNumber,
                              Type patternType = Type());
 

--- a/test/Constraints/iuo.swift
+++ b/test/Constraints/iuo.swift
@@ -225,3 +225,7 @@ var y: Int = 2
 
 let r = sr6988(x: x, y: y)
 let _: Int = r
+
+// SR-11998 / rdar://problem/58455441
+class C<T> {}
+var sub: C! = C<Int>()


### PR DESCRIPTION
Make sure that we're resolving types and patterns using the
PatternBindingDecl context, both for the type resolver context and the
contextual pattern used for pattern resolution.

Fixes a regression with implicitly-unwrapped options reported as
SR-11998 / rdar://problem/58455441.
