### PR TITLE
create NOTICE as stated in license guidelines

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,13 @@
+Copyright 2014-2020 Apple Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2014-2020 Apple Inc.
+Copyright 2014-2020 Apple Inc. and the Swift project authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
According to [Apache License Document - Applying the license to new software](http://www.apache.org/dev/apply-license.html#new), it's required to put a NOTICE file in the root folder with correct years and owners of the software.

I would recommend `Swift` to follow the best practices and hence made this sample `NOTICE` file. Feel free to change and edit this as appropriate.