### PR TITLE
[Diagnostics] Fix range of fix-its in verify mode

### DIFF
--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -530,7 +530,7 @@ DiagnosticVerifier::verifyFile(unsigned BufferID, bool shouldAutoApplyFixes) {
       // fixit to add them in.
       auto actual = renderFixits(FoundDiagnostic.getFixIts(), InputFile);
       auto replStartLoc = SMLoc::getFromPointer(expected.ExpectedEnd - 8); // {{none}} length
-      auto replEndLoc = SMLoc::getFromPointer(expected.ExpectedEnd - 1);
+      auto replEndLoc = SMLoc::getFromPointer(expected.ExpectedEnd);
 
       llvm::SMFixIt fix(llvm::SMRange(replStartLoc, replEndLoc), actual);
       addError(replStartLoc.getPointer(), "expected no fix-its; actual fix-it seen: " + actual, fix);

--- a/test/FixCode/verify-fixits.swift
+++ b/test/FixCode/verify-fixits.swift
@@ -1,0 +1,9 @@
+// RUN: cp %s %t
+// RUN: not %swift -typecheck -target %target-triple -verify-apply-fixes %t
+// RUN: diff %t %s.result
+
+func f1() {
+  guard true { return } // expected-error {{...}}
+
+  guard true { return } // expected-error {{expected 'else' after 'guard' condition}} {{none}}
+}

--- a/test/FixCode/verify-fixits.swift.result
+++ b/test/FixCode/verify-fixits.swift.result
@@ -1,0 +1,9 @@
+// RUN: cp %s %t
+// RUN: not %swift -typecheck -target %target-triple -verify-apply-fixes %t
+// RUN: diff %t %s.result
+
+func f1() {
+  guard true { return } // expected-error {{expected 'else' after 'guard' condition}}
+
+  guard true { return } // expected-error {{expected 'else' after 'guard' condition}} {{14-14=else }}
+}


### PR DESCRIPTION
This PR fix fix-its range of fix-its range in verify mode.

Current:

```
$ swift -frontend -typecheck -verify a.swift
a.swift:2:89: error: expected no fix-its; actual fix-it seen: {{14-14=else }}
  guard true { return } // unexpected-error {{expected 'else' after 'guard' condition}} {{none}}
                                                                                        ^~~~~~~
                                                                                        {{14-14=else }}
```
A range of fix-its is `{{none}`.

Patched:

```
$ swift -frontend -typecheck -verify a.swift
a.swift:2:89: error: expected no fix-its; actual fix-it seen: {{14-14=else }}
  guard true { return } // unexpected-error {{expected 'else' after 'guard' condition}} {{none}}
                                                                                        ^~~~~~~~
                                                                                        {{14-14=else }}
```

A range of fix-its is `{{none}}`.

This error is small for human.
But it's important when we use `-verify-apply-fixes`.

I also added test case for `-verify-apply-fixes`.
I couldn't find one already exists.

@gregomni @jrose-apple Please review this.
Original code is introduced in https://github.com/apple/swift/pull/674 .