### PR TITLE
Add missing header includes

### DIFF
--- a/include/swift/TBDGen/TBDGen.h
+++ b/include/swift/TBDGen/TBDGen.h
@@ -12,9 +12,11 @@
 #ifndef SWIFT_IRGEN_TBDGEN_H
 #define SWIFT_IRGEN_TBDGEN_H
 
+#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
 #include "swift/Basic/Version.h"
+#include <vector>
 
 namespace llvm {
 class raw_ostream;


### PR DESCRIPTION
Today we get these headers indirectly, but when compiling against `llvm.org/master` the build breaks.