### PR TITLE
Fix Ubuntu 16.04 master-next build

### DIFF
--- a/lib/Driver/ParseableOutput.cpp
+++ b/lib/Driver/ParseableOutput.cpp
@@ -141,7 +141,7 @@ public:
     }
     file_types::forAllTypes([&](file_types::ID Ty) {
       for (auto Output : Cmd.getOutput().getAdditionalOutputsForType(Ty)) {
-        Outputs.push_back(OutputPair(Ty, Output));
+        Outputs.push_back(OutputPair(Ty, Output.str()));
       }
     });
   }

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -528,7 +528,7 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
                                 indexStorePath.str(), &diags, outRecordFile);
       if (failed)
         return false;
-      records.emplace_back(outRecordFile, moduleName.str());
+      records.emplace_back(outRecordFile, moduleName.str().str());
       return true;
     });
     indexModule(module, groupIndexConsumer);


### PR DESCRIPTION
Two more pair of string conversion fixes. With this, I was able to build
swift master-next on Ubuntu 16.04 (didn't try anything downstream of
swift, and not sure if the tests pass).