### PR TITLE
[NFC] Remove the Legacy Semantic Queries Bit

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -332,32 +332,6 @@ private:
   llvm::BumpPtrAllocator &
   getAllocator(AllocationArena arena = AllocationArena::Permanent) const;
 
-private:
-  bool SemanticQueriesEnabled = false;
-
-public:
-  /// Returns \c true if legacy semantic AST queries are enabled.
-  ///
-  /// The request evaluator generally subsumes the use of this bit. However,
-  /// there are clients - mostly SourceKit - that rely on the fact that this bit
-  /// being \c false causes some property wrapper requests to return null
-  /// sentinel values. These clients should be migrated off of this interface
-  /// to syntactic requests as soon as possible.
-  ///
-  /// rdar://60516325
-  bool areLegacySemanticQueriesEnabled() const {
-    return SemanticQueriesEnabled;
-  }
-
-  /// Enable "semantic queries".
-  ///
-  /// Setting this bit tells property wrapper requests to return a semantic
-  /// value.  It does not otherwise affect compiler behavior and should be
-  /// removed as soon as possible.
-  void setLegacySemanticQueriesEnabled() {
-    SemanticQueriesEnabled = true;
-  }
-
 public:
   /// Allocate - Allocate memory from the ASTContext bump pointer.
   void *Allocate(unsigned long bytes, unsigned alignment,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2997,9 +2997,6 @@ bool ValueDecl::isRecursiveValidation() const {
 
 Type ValueDecl::getInterfaceType() const {
   auto &ctx = getASTContext();
-
-  assert(ctx.areLegacySemanticQueriesEnabled());
-
   if (auto type =
           evaluateOrDefault(ctx.evaluator,
                             InterfaceTypeRequest{const_cast<ValueDecl *>(this)},
@@ -5812,13 +5809,8 @@ StaticSpellingKind AbstractStorageDecl::getCorrectStaticSpelling() const {
 }
 
 llvm::TinyPtrVector<CustomAttr *> VarDecl::getAttachedPropertyWrappers() const {
-  auto &ctx = getASTContext();
-  if (!ctx.areLegacySemanticQueriesEnabled()) {
-    return { };
-  }
-
   auto mutableThis = const_cast<VarDecl *>(this);
-  return evaluateOrDefault(ctx.evaluator,
+  return evaluateOrDefault(getASTContext().evaluator,
                            AttachedPropertyWrappersRequest{mutableThis},
                            { });
 }
@@ -6786,7 +6778,7 @@ ObjCSelector
 AbstractFunctionDecl::getObjCSelector(DeclName preferredName,
                                       bool skipIsObjCResolution) const {
   // FIXME: Forces computation of the Objective-C selector.
-  if (getASTContext().areLegacySemanticQueriesEnabled() && !skipIsObjCResolution)
+  if (!skipIsObjCResolution)
     (void)isObjC();
 
   // If there is an @objc attribute with a name, use that name.

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1622,9 +1622,7 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
       tracker->addUsedMember({current, member.getBaseName()},isLookupCascading);
 
     // Make sure we've resolved property wrappers, if we need them.
-    if (ctx.areLegacySemanticQueriesEnabled()) {
-      installPropertyWrapperMembersIfNeeded(current, member);
-    }
+    installPropertyWrapperMembersIfNeeded(current, member);
 
     // Look for results within the current nominal type and its extensions.
     bool currentIsProtocol = isa<ProtocolDecl>(current);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -240,7 +240,6 @@ bool CompilerInstance::setUpASTContextIfNeeded() {
   if (setUpModuleLoaders())
     return true;
 
-  Context->setLegacySemanticQueriesEnabled();
   return false;
 }
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1638,8 +1638,6 @@ public:
         Importer(static_cast<ClangImporter *>(CurrDeclContext->getASTContext().
           getClangModuleLoader())),
         CompletionContext(CompletionContext) {
-    Ctx.setLegacySemanticQueriesEnabled();
-
     // Determine if we are doing code completion inside a static method.
     if (CurrDeclContext) {
       CurrentMethod = CurrDeclContext->getInnermostMethodContext();
@@ -4186,8 +4184,6 @@ public:
                            SourceLoc introducerLoc)
       : Sink(Sink), Ctx(Ctx), CurrDeclContext(CurrDeclContext),
         ParsedKeywords(ParsedKeywords), introducerLoc(introducerLoc) {
-    Ctx.setLegacySemanticQueriesEnabled();
-
     hasFuncIntroducer = isKeywordSpecified("func");
     hasVarIntroducer = isKeywordSpecified("var") ||
                        isKeywordSpecified("let");

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4405,7 +4405,6 @@ getMemberDecls(InterestedMemberKind Kind) {
 ResolvedMemberResult
 swift::resolveValueMember(DeclContext &DC, Type BaseTy, DeclName Name) {
   ResolvedMemberResult Result;
-  assert(DC.getASTContext().areLegacySemanticQueriesEnabled());
   ConstraintSystem CS(&DC, None);
 
   // Look up all members of BaseTy with the given Name.

--- a/lib/Sema/DebuggerTestingTransform.cpp
+++ b/lib/Sema/DebuggerTestingTransform.cpp
@@ -243,7 +243,6 @@ private:
     // TODO: typeCheckExpression() seems to assign types to everything here,
     // but may not be sufficient in some cases.
     Expr *FinalExpr = ClosureCall;
-    Ctx.setLegacySemanticQueriesEnabled();
     if (!TypeChecker::typeCheckExpression(FinalExpr, getCurrentDeclContext()))
       llvm::report_fatal_error("Could not type-check instrumentation");
 

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -56,7 +56,6 @@ static bool isExtensionAppliedInternal(const DeclContext *DC, Type BaseTy,
   if (!ED->isConstrainedExtension())
     return true;
 
-  DC->getASTContext().setLegacySemanticQueriesEnabled();
   GenericSignature genericSig = ED->getGenericSignature();
   SubstitutionMap substMap = BaseTy->getContextSubstitutionMap(
       DC->getParentModule(), ED->getExtendedNominal());

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -497,10 +497,6 @@ AttachedPropertyWrapperTypeRequest::evaluate(Evaluator &evaluator,
   if (!customAttr)
     return Type();
 
-  ASTContext &ctx = var->getASTContext();
-  if (!ctx.areLegacySemanticQueriesEnabled())
-    return nullptr;
-
   auto resolution =
       TypeResolution::forContextual(var->getDeclContext());
   TypeResolutionOptions options(TypeResolverContext::PatternBindingDecl);
@@ -508,8 +504,9 @@ AttachedPropertyWrapperTypeRequest::evaluate(Evaluator &evaluator,
 
   if (TypeChecker::validateType(var->getASTContext(),
                                 customAttr->getTypeLoc(),
-                                resolution, options))
-    return ErrorType::get(ctx);
+                                resolution, options)) {
+    return ErrorType::get(var->getASTContext());
+  }
 
   return customAttr->getTypeLoc().getType();
 }
@@ -533,10 +530,6 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
   if (!binding)
     return Type();
 
-  ASTContext &ctx = var->getASTContext();
-  if (!ctx.areLegacySemanticQueriesEnabled())
-    return Type();
-
   // If there's an initializer of some sort, checking it will determine the
   // property wrapper type.
   unsigned index = binding->getPatternEntryIndexForVarDecl(var);
@@ -546,6 +539,7 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
     if (!binding->isInitializerChecked(index))
       TypeChecker::typeCheckPatternBinding(binding, index);
 
+    ASTContext &ctx = var->getASTContext();
     Type type = ctx.getSideCachedPropertyWrapperBackingPropertyType(var);
     assert(type || ctx.Diags.hadAnyError());
     return type;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -336,9 +336,6 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
 
   BufferIndirectlyCausingDiagnosticRAII cpr(*SF);
 
-  // Make sure we have a type checker.
-  Ctx.setLegacySemanticQueriesEnabled();
-
   // Make sure that name binding has been completed before doing any type
   // checking.
   performNameBinding(*SF);
@@ -528,7 +525,6 @@ bool swift::performTypeLocChecking(ASTContext &Ctx, TypeLoc &T,
   Optional<DiagnosticSuppression> suppression;
   if (!ProduceDiagnostics)
     suppression.emplace(Ctx.Diags);
-  assert(Ctx.areLegacySemanticQueriesEnabled());
   return TypeChecker::validateType(Ctx, T, resolution, options);
 }
 
@@ -565,7 +561,6 @@ void swift::typeCheckPatternBinding(PatternBindingDecl *PBD,
 
   auto &Ctx = PBD->getASTContext();
   DiagnosticSuppression suppression(Ctx.Diags);
-  Ctx.setLegacySemanticQueriesEnabled();
   (void)evaluateOrDefault(
       Ctx.evaluator, PatternBindingEntryRequest{PBD, bindingIndex}, nullptr);
   TypeChecker::typeCheckPatternBinding(PBD, bindingIndex);
@@ -620,7 +615,6 @@ Optional<Type> swift::getTypeOfCompletionContextExpr(
                         Expr *&parsedExpr,
                         ConcreteDeclRef &referencedDecl) {
   DiagnosticSuppression suppression(Ctx.Diags);
-  Ctx.setLegacySemanticQueriesEnabled();
 
   // Try to solve for the actual type of the expression.
   return ::getTypeOfCompletionContextExpr(DC, kind, parsedExpr,
@@ -635,7 +629,6 @@ swift::getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
                                    ConcreteDeclRef &referencedDecl) {
   auto &ctx = DC->getASTContext();
   DiagnosticSuppression suppression(ctx.Diags);
-  ctx.setLegacySemanticQueriesEnabled();
   return TypeChecker::getTypeOfCompletionOperator(DC, LHS, opName, refKind,
                                                   referencedDecl);
 }
@@ -643,7 +636,6 @@ swift::getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
 bool swift::typeCheckExpression(DeclContext *DC, Expr *&parsedExpr) {
   auto &ctx = DC->getASTContext();
   DiagnosticSuppression suppression(ctx.Diags);
-  ctx.setLegacySemanticQueriesEnabled();
   auto resultTy = TypeChecker::typeCheckExpression(parsedExpr, DC, TypeLoc(),
                                                    CTP_Unused);
   return !resultTy;
@@ -653,15 +645,12 @@ bool swift::typeCheckAbstractFunctionBodyUntil(AbstractFunctionDecl *AFD,
                                                SourceLoc EndTypeCheckLoc) {
   auto &Ctx = AFD->getASTContext();
   DiagnosticSuppression suppression(Ctx.Diags);
-
-  Ctx.setLegacySemanticQueriesEnabled();
   return !TypeChecker::typeCheckAbstractFunctionBodyUntil(AFD, EndTypeCheckLoc);
 }
 
 bool swift::typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD) {
   auto &Ctx = static_cast<Decl *>(TLCD)->getASTContext();
   DiagnosticSuppression suppression(Ctx.Diags);
-  Ctx.setLegacySemanticQueriesEnabled();
   TypeChecker::typeCheckTopLevelCodeDecl(TLCD);
   return true;
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -978,7 +978,6 @@ static bool reportModuleDocInfo(CompilerInvocation Invocation,
 
   ASTContext &Ctx = CI.getASTContext();
   registerIDERequestFunctions(Ctx.evaluator);
-  Ctx.setLegacySemanticQueriesEnabled();
 
   SourceTextInfo IFaceInfo;
   if (getModuleInterfaceInfo(Ctx, ModuleName, IFaceInfo))
@@ -1105,9 +1104,6 @@ static bool reportSourceDocInfo(CompilerInvocation Invocation,
   ASTContext &Ctx = CI.getASTContext();
   CloseClangModuleFiles scopedCloseFiles(*Ctx.getClangModuleLoader());
   CI.performSema();
-
-  // Setup a typechecker for protocol conformance resolving.
-  Ctx.setLegacySemanticQueriesEnabled();
 
   SourceTextInfo SourceInfo;
   if (getSourceTextInfo(CI, SourceInfo))
@@ -1456,11 +1452,8 @@ findModuleGroups(StringRef ModuleName, ArrayRef<const char *> Args,
     return;
   }
 
-  ASTContext &Ctx = CI.getASTContext();
-  // Setup a typechecker for protocol conformance resolving.
-  Ctx.setLegacySemanticQueriesEnabled();
-
   // Load standard library so that Clang importer can use it.
+  ASTContext &Ctx = CI.getASTContext();
   auto *Stdlib = getModuleByFullName(Ctx, Ctx.StdlibModuleName);
   if (!Stdlib) {
     Error = "Cannot load stdlib.";

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -199,9 +199,6 @@ static void indexModule(llvm::MemoryBuffer *Input,
     Mod->setHasResolvedImports();
   }
 
-  // Setup a typechecker for protocol conformance resolving.
-  Ctx.setLegacySemanticQueriesEnabled();
-
   SKIndexDataConsumer IdxDataConsumer(IdxConsumer);
   index::indexModule(Mod, IdxDataConsumer);
 }
@@ -312,10 +309,7 @@ void SwiftLangSupport::indexSource(StringRef InputFile,
     IdxConsumer.failed("no primary source file found");
     return;
   }
-
-  // Setup a typechecker for protocol conformance resolving.
-  CI.getASTContext().setLegacySemanticQueriesEnabled();
-
+  
   SKIndexDataConsumer IdxDataConsumer(IdxConsumer);
   index::indexSourceFile(CI.getPrimarySourceFile(), IdxDataConsumer);
 }


### PR DESCRIPTION
Clients that wish to avoid semantic requests should decline to register
those requests.