### PR TITLE
[CodeCompletion] Don't ignore CovariantReturnConversionExpr

### DIFF
--- a/test/IDE/complete_super_self.swift
+++ b/test/IDE/complete_super_self.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=COVARIANT_RETURN_CONV | %FileCheck %s --check-prefix=COVARIANT_RETURN_CONV
+
+class BaseClass {
+  func returnSelf() -> Self {}
+}
+
+class DerivedClass: BaseClass {
+  var value: Int
+  func foo() {}
+}
+
+func test(value: DerivedClass) {
+  value.returnSelf().#^COVARIANT_RETURN_CONV^#
+// COVARIANT_RETURN_CONV: Begin completions, 4 items
+// COVARIANT_RETURN_CONV-DAG: Keyword[self]/CurrNominal:          self[#DerivedClass#];
+// COVARIANT_RETURN_CONV-DAG: Decl[InstanceVar]/CurrNominal:      value[#Int#];
+// COVARIANT_RETURN_CONV-DAG: Decl[InstanceMethod]/CurrNominal:   foo()[#Void#];
+// COVARIANT_RETURN_CONV-DAG: Decl[InstanceMethod]/Super:         returnSelf()[#Self#];
+// COVARIANT_RETURN_CONV: End completions
+}


### PR DESCRIPTION
in typechecked AST. This is needed to correctly get the type of the parsed expression when the expression is a calling to a method in super class returning 'Self'.

rdar://problem/51504896
