### PR TITLE
ModuleInterface: skip override keywords when overriding an invisible decl from super class

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2697,6 +2697,11 @@ public:
     return !isObjC() && isDynamic();
   }
 
+  bool isEffectiveLinkageMoreVisibleThan(ValueDecl *other) const {
+    return (std::min(getEffectiveAccess(), AccessLevel::Public) >
+            std::min(other->getEffectiveAccess(), AccessLevel::Public));
+  }
+
   /// Set whether this type is 'dynamic' or not.
   void setIsDynamic(bool value);
 
@@ -5982,11 +5987,6 @@ public:
   /// For a method of a class, checks whether it will require a new entry in the
   /// vtable.
   bool needsNewVTableEntry() const;
-
-  bool isEffectiveLinkageMoreVisibleThan(ValueDecl *other) const {
-    return (std::min(getEffectiveAccess(), AccessLevel::Public) >
-            std::min(other->getEffectiveAccess(), AccessLevel::Public));
-  }
 
   bool isSynthesized() const {
     return Bits.AbstractFunctionDecl.Synthesized;

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -276,7 +276,10 @@ struct PrintOptions {
   /// Prints type variables and unresolved types in an expanded notation suitable
   /// for debugging.
   bool PrintTypesForDebugging = false;
-  
+
+  /// Whether this print option is for printing .swiftinterface file
+  bool IsForSwiftInterface = false;
+
   /// How to print opaque return types.
   enum class OpaqueReturnTypePrintingMode {
     /// 'some P1 & P2'.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -103,6 +103,7 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(bool preferTypeRepr,
                                                    bool printFullConvention,
                                                    bool printSPIs) {
   PrintOptions result;
+  result.IsForSwiftInterface = true;
   result.PrintLongAttrsOnSeparateLines = true;
   result.TypeDefinitions = true;
   result.PrintIfConfig = false;

--- a/test/ModuleInterface/skip-override-keyword.swift
+++ b/test/ModuleInterface/skip-override-keyword.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -module-name Foo -emit-module-interface-path %t/Foo.swiftinterface %s
+// RUN: %target-swift-frontend -compile-module-from-interface %t/Foo.swiftinterface -o %t/Foo.swiftmodule
+
+public class BaseClass {
+  var property: Int { return 1 }
+  func doSomething() { }
+  subscript(index: Int) -> Int { get { return 0 } set(newValue) {} }
+}
+public class DerivedClass: BaseClass {
+  public override var property : Int { return 0 }
+  public override func doSomething() { }
+  public override subscript(index: Int) -> Int { get {return 0} set(newValue) {} }
+}


### PR DESCRIPTION
When we are printing Swift interface, we have to skip the override keyword
if the overriden decl is invisible from the interface. Otherwise, an error
will occur while building the Swift module because the overriding decl
doesn't override anything.

We couldn't skip every `override` keywords because they change the
ABI if the overriden decl is also publicly visible.

For public-override-internal case, having `override` doesn't have ABI
implication. Thus we can skip them.

rdar://58562780