### PR TITLE
[CSGen] Diagnose `nil` with any number of parentheses

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1152,10 +1152,6 @@ namespace {
       // `_ = nil`, let's diagnose it here because solver can't
       // attempt any types for it.
       auto *parentExpr = CS.getParentExpr(expr);
-      
-      // Loop until you have an expr without parentheses 
-      // so if you have (nil), ((nil)), (((nil))), etc...
-      // you get `nil`
       while (parentExpr && isa<ParenExpr>(parentExpr))
         parentExpr = CS.getParentExpr(parentExpr);
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1152,7 +1152,11 @@ namespace {
       // `_ = nil`, let's diagnose it here because solver can't
       // attempt any types for it.
       auto *parentExpr = CS.getParentExpr(expr);
-      if (parentExpr && isa<ParenExpr>(parentExpr))
+      
+      // Loop until you have an expr without parentheses 
+      // so if you have (nil), ((nil)), (((nil))), etc...
+      // you get `nil`
+      while (parentExpr && isa<ParenExpr>(parentExpr))
         parentExpr = CS.getParentExpr(parentExpr);
 
       if (parentExpr) {

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -439,6 +439,10 @@ func sr_12309() {
   _ = nil? // expected-error {{value of optional type 'Optional<_>' must be unwrapped to a value of type '_'}}
            // expected-note@-1 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
            // expected-note@-2 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
-  _ = (nil) // expected-error {{'nil' requires a contextual type}}
   _ = nil // expected-error {{'nil' requires a contextual type}}
+  _ = (nil) // expected-error {{'nil' requires a contextual type}}
+  _ = ((nil)) // expected-error {{'nil' requires a contextual type}}
+  _ = (((nil))) // expected-error {{'nil' requires a contextual type}}
+  _ = ((((((nil)))))) // expected-error {{'nil' requires a contextual type}}
+  _ = (((((((((nil))))))))) // expected-error {{'nil' requires a contextual type}}
 }

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -436,6 +436,8 @@ func sr_12309() {
 
   _ = S(foo: nil!) // expected-error {{'nil' literal cannot be force unwrapped}}
   _ = nil! // expected-error {{'nil' literal cannot be force unwrapped}}
+  _ = (nil!) // expected-error {{'nil' literal cannot be force unwrapped}}
+  _ = (nil)! // expected-error {{'nil' literal cannot be force unwrapped}}
   _ = nil? // expected-error {{value of optional type 'Optional<_>' must be unwrapped to a value of type '_'}}
            // expected-note@-1 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
            // expected-note@-2 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -438,6 +438,7 @@ func sr_12309() {
   _ = nil! // expected-error {{'nil' literal cannot be force unwrapped}}
   _ = (nil!) // expected-error {{'nil' literal cannot be force unwrapped}}
   _ = (nil)! // expected-error {{'nil' literal cannot be force unwrapped}}
+  _ = ((nil))! // expected-error {{'nil' literal cannot be force unwrapped}}
   _ = nil? // expected-error {{value of optional type 'Optional<_>' must be unwrapped to a value of type '_'}}
            // expected-note@-1 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
            // expected-note@-2 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
This is a followup for #30409 handling the diagnosis of `nil` literal with any number of parentheses.


<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
