### PR TITLE
[DO NOT MERGE] Revert "SILOptimizer: Fix analysis invalidation after devirtualization."

### DIFF
--- a/include/swift/SILOptimizer/Utils/Devirtualize.h
+++ b/include/swift/SILOptimizer/Utils/Devirtualize.h
@@ -65,11 +65,9 @@ SubstitutionMap getWitnessMethodSubstitutions(SILModule &Module, ApplySite AI,
 ///
 /// If this succeeds, the caller must call deleteDevirtualizedApply on
 /// the original apply site.
-///
-/// Return the new apply and true if the CFG was also modified.
-std::pair<ApplySite, bool>
-tryDevirtualizeApply(ApplySite AI, ClassHierarchyAnalysis *CHA,
-                     OptRemark::Emitter *ORE = nullptr);
+ApplySite tryDevirtualizeApply(ApplySite AI,
+                               ClassHierarchyAnalysis *CHA,
+                               OptRemark::Emitter *ORE = nullptr);
 bool canDevirtualizeApply(FullApplySite AI, ClassHierarchyAnalysis *CHA);
 bool canDevirtualizeClassMethod(FullApplySite AI, ClassDecl *CD,
                                 OptRemark::Emitter *ORE = nullptr,
@@ -81,23 +79,21 @@ CanType getSelfInstanceType(CanType ClassOrMetatypeType);
 /// Devirtualize the given apply site, which is known to be devirtualizable.
 ///
 /// The caller must call deleteDevirtualizedApply on the original apply site.
-///
-/// Return the new apply and true if the CFG was also modified.
-std::pair<FullApplySite, bool> devirtualizeClassMethod(FullApplySite AI,
-                                                       SILValue ClassInstance,
-                                                       ClassDecl *CD,
-                                                       OptRemark::Emitter *ORE);
+FullApplySite devirtualizeClassMethod(FullApplySite AI,
+                                      SILValue ClassInstance,
+                                      ClassDecl *CD,
+                                      OptRemark::Emitter *ORE);
 
 /// Attempt to devirtualize the given apply site, which is known to be
 /// of a class method.  If this fails, the returned FullApplySite will be null.
 ///
 /// If this succeeds, the caller must call deleteDevirtualizedApply on
 /// the original apply site.
-///
-/// Return the new apply and true if the CFG was also modified.
-std::pair<FullApplySite, bool>
-tryDevirtualizeClassMethod(FullApplySite AI, SILValue ClassInstance,
-                           ClassDecl *CD, OptRemark::Emitter *ORE,
+FullApplySite
+tryDevirtualizeClassMethod(FullApplySite AI,
+                           SILValue ClassInstance,
+                           ClassDecl *CD,
+                           OptRemark::Emitter *ORE,
                            bool isEffectivelyFinalMethod = false);
 
 /// Attempt to devirtualize the given apply site, which is known to be
@@ -106,9 +102,7 @@ tryDevirtualizeClassMethod(FullApplySite AI, SILValue ClassInstance,
 ///
 /// If this succeeds, the caller must call deleteDevirtualizedApply on
 /// the original apply site.
-///
-/// Return the new apply and true if the CFG was also modified.
-std::pair<ApplySite, bool> tryDevirtualizeWitnessMethod(ApplySite AI, OptRemark::Emitter *ORE);
+ApplySite tryDevirtualizeWitnessMethod(ApplySite AI, OptRemark::Emitter *ORE);
 
 /// Delete a successfully-devirtualized apply site.  This must always be
 /// called after devirtualizing an apply; not only is it not semantically

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -760,7 +760,7 @@ getCalleeFunction(SILFunction *F, FullApplySite AI, bool &IsThick,
 
 static SILInstruction *tryDevirtualizeApplyHelper(FullApplySite InnerAI,
                                                   ClassHierarchyAnalysis *CHA) {
-  auto NewInst = tryDevirtualizeApply(InnerAI, CHA).first;
+  auto NewInst = tryDevirtualizeApply(InnerAI, CHA);
   if (!NewInst)
     return InnerAI.getInstruction();
 

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -229,8 +229,7 @@ static FullApplySite speculateMonomorphicTarget(FullApplySite AI,
 
   // Devirtualize the apply instruction on the identical path.
   auto NewInst =
-      devirtualizeClassMethod(IdenAI, DownCastedClassInstance, CD, nullptr)
-          .first;
+    devirtualizeClassMethod(IdenAI, DownCastedClassInstance, CD, nullptr);
   assert(NewInst && "Expected to be able to devirtualize apply!");
   (void)NewInst;
 
@@ -415,8 +414,7 @@ static bool tryToSpeculateTarget(FullApplySite AI, ClassHierarchyAnalysis *CHA,
     // try to devirtualize it completely.
     ClassHierarchyAnalysis::ClassList Subs;
     if (isDefaultCaseKnown(CHA, AI, CD, Subs)) {
-      auto NewInst =
-          tryDevirtualizeClassMethod(AI, SubTypeValue, CD, &ORE).first;
+      auto NewInst = tryDevirtualizeClassMethod(AI, SubTypeValue, CD, &ORE);
       if (NewInst)
         deleteDevirtualizedApply(AI);
       return bool(NewInst);
@@ -576,8 +574,7 @@ static bool tryToSpeculateTarget(FullApplySite AI, ClassHierarchyAnalysis *CHA,
     ORE.emit(RB);
     return true;
   }
-  auto NewInst =
-      tryDevirtualizeClassMethod(AI, SubTypeValue, CD, nullptr).first;
+  auto NewInst = tryDevirtualizeClassMethod(AI, SubTypeValue, CD, nullptr);
   if (NewInst) {
     ORE.emit(RB);
     deleteDevirtualizedApply(AI);


### PR DESCRIPTION
Reverts apple/swift#30473

Sanity check because I didn't benchmark the original PR.