### PR TITLE
[SourceKit] Save clang module validation time

### DIFF
--- a/test/SourceKit/CodeComplete/complete_build_session.swift
+++ b/test/SourceKit/CodeComplete/complete_build_session.swift
@@ -4,6 +4,8 @@ func test() {
 
 }
 
+// UNSUPPORTED: OS=windows-msvc
+
 // -----------------------------------------------------------------------------
 // Test that modifications for frameworks in '-Fsystem' doesn't affect the result.
 

--- a/test/SourceKit/CodeComplete/complete_build_session.swift
+++ b/test/SourceKit/CodeComplete/complete_build_session.swift
@@ -1,0 +1,86 @@
+import Foo
+
+func test() {
+
+}
+
+// -----------------------------------------------------------------------------
+// Test that modifications for frameworks in '-Fsystem' doesn't affect the result.
+
+// RUN: %empty-directory(%t/ModuleCache)
+// RUN: %empty-directory(%t/System/Frameworks)
+// RUN: cp -R %S/../Inputs/build_session/Frameworks/Foo.framework %t/System/Frameworks/
+// RUN: cp -R %S/../Inputs/build_session/Frameworks/FooHelper.framework %t/System/Frameworks/
+// RUN: %sourcekitd-test \
+// RUN:   -shell -- echo '## ONE' == \
+// RUN:   -req=complete -pos=4:1 %s -- %s -D ONE -Fsystem %t/System/Frameworks -module-cache-path %t/ModuleCache == \
+// RUN:   -shell -- cp -R %S/../Inputs/build_session/Frameworks_modified/Foo.framework %t/System/Frameworks/ == \
+// RUN:   -shell -- cp -R %S/../Inputs/build_session/Frameworks_modified/FooHelper.framework %t/System/Frameworks/ == \
+// RUN:   -shell -- echo '## TWO' == \
+// RUN:   -req=complete -pos=4:1 %s -- %s -D TWO -Fsystem %t/System/Frameworks -module-cache-path %t/ModuleCache \
+// RUN:   | tee %t.response |  %FileCheck %s --check-prefix=CHECK_SYSTEM
+// RUN: sleep 2
+// RUN: %sourcekitd-test \
+// RUN:   -shell -- echo '## THREE' == \
+// RUN:   -req=complete -pos=4:1 %s -- %s -D TWO -Fsystem %t/System/Frameworks -module-cache-path %t/ModuleCache  \
+// RUN:   | %FileCheck %s --check-prefix=CHECK_SYSTEM_2
+
+// CHECK_SYSTEM-LABEL: ## ONE
+// CHECK_SYSTEM-DAG: key.description: "fooFunc(arg: Int32)"
+// CHECK_SYSTEM-DAG: key.description: "fooSubFunc(arg: Int32)"
+// CHECK_SYSTEM-DAG: key.description: "fooHelperFunc(arg: Int32)"
+// CHECK_SYSTEM-DAG: key.description: "fooHelperSubFunc(arg: Int32)"
+
+// CHECK_SYSTEM-LABEL: ## TWO
+// CHECK_SYSTEM-DAG: key.description: "fooFunc(arg: Int32)"
+// CHECK_SYSTEM-DAG: key.description: "fooSubFunc(arg: Int32)"
+// CHECK_SYSTEM-DAG: key.description: "fooHelperFunc(arg: Int32)"
+// CHECK_SYSTEM-DAG: key.description: "fooHelperSubFunc(arg: Int32)"
+
+// CHECK_SYSTEM_2-LABEL: ## THREE
+// CHECK_SYSTEM_2-NOT: fooFunc(
+// CHECK_SYSTEM_2-NOT: fooSubFunc(
+// CHECK_SYSTEM_2-NOT: fooHelperFunc(
+// CHECK_SYSTEM_2-NOT: fooHelperSubFunc(
+// CHECK_SYSTEM_2-DAG: key.description: "fooFunc_mod(arg: Int32)"
+// CHECK_SYSTEM_2-DAG: key.description: "fooSubFunc_mod(arg: Int32)"
+// CHECK_SYSTEM_2-DAG: key.description: "fooHelperFunc_mod(arg: Int32)"
+// CHECK_SYSTEM_2-DAG: key.description: "fooHelperSubFunc_mod(arg: Int32)"
+// CHECK_SYSTEM_2-NOT: fooFunc(
+// CHECK_SYSTEM_2-NOT: fooSubFunc(
+// CHECK_SYSTEM_2-NOT: fooHelperFunc(
+// CHECK_SYSTEM_2-NOT: fooHelperSubFunc(
+
+// -----------------------------------------------------------------------------
+// Test that modifications for frameworks in '-F' are immidiately propagated
+// while modifications for frameworks in '-Fsystem' are not.
+
+// RUN: %empty-directory(%t/ModuleCache)
+// RUN: %empty-directory(%t/Frameworks)
+// RUN: %empty-directory(%t/System/Frameworks)
+// RUN: cp -R %S/../Inputs/build_session/Frameworks/Foo.framework %t/Frameworks/
+// RUN: cp -R %S/../Inputs/build_session/Frameworks/FooHelper.framework %t/System/Frameworks/
+// RUN: %sourcekitd-test \
+// RUN:   -shell -- echo '## ONE' == \
+// RUN:   -req=complete -pos=4:1 %s -- %s -D ONE -F %t/Frameworks -Fsystem %t/System/Frameworks -module-cache-path %t/ModuleCache  == \
+// RUN:   -shell -- cp -R %S/../Inputs/build_session/Frameworks_modified/Foo.framework %t/Frameworks/ == \
+// RUN:   -shell -- cp -R %S/../Inputs/build_session/Frameworks_modified/FooHelper.framework %t/System/Frameworks/ == \
+// RUN:   -shell -- echo '## TWO' == \
+// RUN:   -req=complete -pos=4:1 %s -- %s -D TWO -F %t/Frameworks -Fsystem %t/System/Frameworks -module-cache-path %t/ModuleCache  \
+// RUN:   | %FileCheck %s --check-prefix=CHECK_USER
+
+// CHECK_USER-LABEL: ## ONE
+// CHECK_USER-DAG: key.description: "fooFunc(arg: Int32)"
+// CHECK_USER-DAG: key.description: "fooSubFunc(arg: Int32)"
+// CHECK_USER-DAG: key.description: "fooHelperFunc(arg: Int32)"
+// CHECK_USER-DAG: key.description: "fooHelperSubFunc(arg: Int32)"
+
+// CHECK_USER-LABEL: ## TWO
+// CHECK_USER-NOT: fooFunc(
+// CHECK_USER-NOT: fooSubFunc(
+// CHECK_USER-DAG: key.description: "fooFunc_mod(arg: Int32)"
+// CHECK_USER-DAG: key.description: "fooSubFunc_mod(arg: Int32)"
+// CHECK_USER-DAG: key.description: "fooHelperFunc(arg: Int32)"
+// CHECK_USER-DAG: key.description: "fooHelperSubFunc(arg: Int32)"
+// CHECK_USER-NOT: fooFunc(
+// CHECK_USER-NOT: fooSubFunc(

--- a/test/SourceKit/Inputs/build_session/Frameworks/Foo.framework/Frameworks/FooSub.framework/Headers/FooSub.h
+++ b/test/SourceKit/Inputs/build_session/Frameworks/Foo.framework/Frameworks/FooSub.framework/Headers/FooSub.h
@@ -1,0 +1,6 @@
+#if !defined(__FOOSUB_H__)
+#define __FOOSUB_H__ 1
+
+int fooSubFunc(int arg);
+
+#endif /* ! __FOOSUB_H__ */

--- a/test/SourceKit/Inputs/build_session/Frameworks/Foo.framework/Headers/Foo.h
+++ b/test/SourceKit/Inputs/build_session/Frameworks/Foo.framework/Headers/Foo.h
@@ -1,0 +1,12 @@
+/*  Foo.h
+  Copyright (c) 1815, Napoleon Bonaparte. All rights reserved.
+*/
+#if !defined(__FOO_H__)
+#define __FOO_H__ 1
+
+#import <FooSub/FooSub.h>
+#import <FooHelper/FooHelper.h>
+
+int fooFunc(int arg);
+
+#endif /* ! __FOO_H__ */

--- a/test/SourceKit/Inputs/build_session/Frameworks/Foo.framework/Modules/module.modulemap
+++ b/test/SourceKit/Inputs/build_session/Frameworks/Foo.framework/Modules/module.modulemap
@@ -1,0 +1,9 @@
+framework module Foo {
+  umbrella header "Foo.h"
+  export *
+  framework module FooSub {
+    umbrella header "FooSub.h"
+    export *
+  }
+}
+

--- a/test/SourceKit/Inputs/build_session/Frameworks/FooHelper.framework/Frameworks/FooHelperSub.framework/Headers/FooHelperSub.h
+++ b/test/SourceKit/Inputs/build_session/Frameworks/FooHelper.framework/Frameworks/FooHelperSub.framework/Headers/FooHelperSub.h
@@ -1,0 +1,1 @@
+int fooHelperSubFunc(int arg);

--- a/test/SourceKit/Inputs/build_session/Frameworks/FooHelper.framework/Headers/FooHelper.h
+++ b/test/SourceKit/Inputs/build_session/Frameworks/FooHelper.framework/Headers/FooHelper.h
@@ -1,0 +1,3 @@
+#import <FooHelperSub/FooHelperSub.h>
+
+int fooHelperFunc(int arg);

--- a/test/SourceKit/Inputs/build_session/Frameworks/FooHelper.framework/Headers/FooHelperExplicit.h
+++ b/test/SourceKit/Inputs/build_session/Frameworks/FooHelper.framework/Headers/FooHelperExplicit.h
@@ -1,0 +1,1 @@
+int fooHelperExplicitFunc(int a);

--- a/test/SourceKit/Inputs/build_session/Frameworks/FooHelper.framework/Modules/module.modulemap
+++ b/test/SourceKit/Inputs/build_session/Frameworks/FooHelper.framework/Modules/module.modulemap
@@ -1,0 +1,12 @@
+framework module FooHelper {
+  umbrella header "FooHelper.h"
+
+  framework module FooHelperSub {
+    umbrella header "FooHelperSub.h"
+  }
+
+  explicit module FooHelperExplicit {
+    header "FooHelperExplicit.h"
+  }
+}
+

--- a/test/SourceKit/Inputs/build_session/Frameworks_modified/Foo.framework/Frameworks/FooSub.framework/Headers/FooSub.h
+++ b/test/SourceKit/Inputs/build_session/Frameworks_modified/Foo.framework/Frameworks/FooSub.framework/Headers/FooSub.h
@@ -1,0 +1,6 @@
+#if !defined(__FOOSUB_H__)
+#define __FOOSUB_H__ 1
+
+int fooSubFunc_mod(int arg);
+
+#endif /* ! __FOOSUB_H__ */

--- a/test/SourceKit/Inputs/build_session/Frameworks_modified/Foo.framework/Headers/Foo.h
+++ b/test/SourceKit/Inputs/build_session/Frameworks_modified/Foo.framework/Headers/Foo.h
@@ -1,0 +1,12 @@
+/*  Foo.h
+  Copyright (c) 1815, Napoleon Bonaparte. All rights reserved.
+*/
+#if !defined(__FOO_H__)
+#define __FOO_H__ 1
+
+#import <FooSub/FooSub.h>
+#import <FooHelper/FooHelper.h>
+
+int fooFunc_mod(int arg);
+
+#endif /* ! __FOO_H__ */

--- a/test/SourceKit/Inputs/build_session/Frameworks_modified/Foo.framework/Modules/module.modulemap
+++ b/test/SourceKit/Inputs/build_session/Frameworks_modified/Foo.framework/Modules/module.modulemap
@@ -1,0 +1,9 @@
+framework module Foo {
+  umbrella header "Foo.h"
+  export *
+  framework module FooSub {
+    umbrella header "FooSub.h"
+    export *
+  }
+}
+

--- a/test/SourceKit/Inputs/build_session/Frameworks_modified/FooHelper.framework/Frameworks/FooHelperSub.framework/Headers/FooHelperSub.h
+++ b/test/SourceKit/Inputs/build_session/Frameworks_modified/FooHelper.framework/Frameworks/FooHelperSub.framework/Headers/FooHelperSub.h
@@ -1,0 +1,1 @@
+int fooHelperSubFunc_mod(int arg);

--- a/test/SourceKit/Inputs/build_session/Frameworks_modified/FooHelper.framework/Headers/FooHelper.h
+++ b/test/SourceKit/Inputs/build_session/Frameworks_modified/FooHelper.framework/Headers/FooHelper.h
@@ -1,0 +1,3 @@
+#import <FooHelperSub/FooHelperSub.h>
+
+int fooHelperFunc_mod(int arg);

--- a/test/SourceKit/Inputs/build_session/Frameworks_modified/FooHelper.framework/Headers/FooHelperExplicit.h
+++ b/test/SourceKit/Inputs/build_session/Frameworks_modified/FooHelper.framework/Headers/FooHelperExplicit.h
@@ -1,0 +1,1 @@
+int fooHelperExplicitFunc_mod(int a);

--- a/test/SourceKit/Inputs/build_session/Frameworks_modified/FooHelper.framework/Modules/module.modulemap
+++ b/test/SourceKit/Inputs/build_session/Frameworks_modified/FooHelper.framework/Modules/module.modulemap
@@ -1,0 +1,12 @@
+framework module FooHelper {
+  umbrella header "FooHelper.h"
+
+  framework module FooHelperSub {
+    umbrella header "FooHelperSub.h"
+  }
+
+  explicit module FooHelperExplicit {
+    header "FooHelperExplicit.h"
+  }
+}
+

--- a/test/SourceKit/Sema/sema_build_session.swift
+++ b/test/SourceKit/Sema/sema_build_session.swift
@@ -12,6 +12,8 @@ func test() {
   _ = swiftFunc()
 }
 
+// UNSUPPORTED: OS=windows-msvc
+
 // -----------------------------------------------------------------------------
 // Test that modifications for frameworks in '-Fsystem' doesn't affect the result.
 

--- a/test/SourceKit/Sema/sema_build_session.swift
+++ b/test/SourceKit/Sema/sema_build_session.swift
@@ -1,0 +1,81 @@
+import Foo
+import FooHelper.FooHelperExplicit
+
+func swiftFunc() -> Int { 1 }
+
+func test() {
+  _ = fooFunc(1)
+  _ = fooSubFunc(1)
+  _ = fooHelperFunc(1)
+  _ = fooHelperSubFunc(1)
+  _ = fooHelperExplicitFunc(1)
+  _ = swiftFunc()
+}
+
+// -----------------------------------------------------------------------------
+// Test that modifications for frameworks in '-Fsystem' doesn't affect the result.
+
+// RUN: %empty-directory(%t/ModuleCache)
+// RUN: %empty-directory(%t/System/Frameworks)
+// RUN: cp -R %S/../Inputs/build_session/Frameworks/Foo.framework %t/System/Frameworks/
+// RUN: cp -R %S/../Inputs/build_session/Frameworks/FooHelper.framework %t/System/Frameworks/
+// RUN: %sourcekitd-test \
+// RUN:   -shell -- echo '## ONE' == \
+// RUN:   -req=sema %s -- %s -D ONE -Fsystem %t/System/Frameworks -module-cache-path %t/ModuleCache == \
+// RUN:   -shell -- cp -R %S/../Inputs/build_session/Frameworks_modified/Foo.framework %t/System/Frameworks/ == \
+// RUN:   -shell -- cp -R %S/../Inputs/build_session/Frameworks_modified/FooHelper.framework %t/System/Frameworks/ == \
+// RUN:   -shell -- echo '## TWO' == \
+// RUN:   -req=sema %s -- %s -D TWO -Fsystem %t/System/Frameworks -module-cache-path %t/ModuleCache  \
+// RUN:   | %FileCheck %s --check-prefix=CHECK_SYSTEM
+// RUN: sleep 2
+// RUN: %sourcekitd-test \
+// RUN:   -shell -- echo '## THREE' == \
+// RUN:   -req=sema %s -- %s -D THREE -Fsystem %t/System/Frameworks -module-cache-path %t/ModuleCache  \
+// RUN:   | %FileCheck %s --check-prefix=CHECK_SYSTEM_2
+
+// CHECK_SYSTEM-LABEL: ## ONE
+// CHECK_SYSTEM-NOT: key.description
+
+// CHECK_SYSTEM-LABEL: ## TWO
+// CHECK_SYSTEM-NOT: key.description
+
+// CHECK_SYSTEM_2-LABEL: ## THREE
+// CHECK_SYSTEM_2: key.severity: source.diagnostic.severity.error,
+// CHECK_SYSTEM_2-NEXT: key.description: "use of unresolved identifier 'fooFunc'",
+// CHECK_SYSTEM_2: key.severity: source.diagnostic.severity.error,
+// CHECK_SYSTEM_2-NEXT: key.description: "use of unresolved identifier 'fooSubFunc'",
+// CHECK_SYSTEM_2: key.severity: source.diagnostic.severity.error,
+// CHECK_SYSTEM_2-NEXT: key.description: "use of unresolved identifier 'fooHelperFunc'",
+// CHECK_SYSTEM_2: key.severity: source.diagnostic.severity.error,
+// CHECK_SYSTEM_2-NEXT: key.description: "use of unresolved identifier 'fooHelperSubFunc'",
+// CHECK_SYSTEM_2: key.severity: source.diagnostic.severity.error,
+// CHECK_SYSTEM_2-NEXT: key.description: "use of unresolved identifier 'fooHelperExplicitFunc'",
+
+// -----------------------------------------------------------------------------
+// Test that modifications for frameworks in '-F' are immidiately propagated
+// while modifications for frameworks in '-Fsystem' are not.
+
+// RUN: %empty-directory(%t/ModuleCache)
+// RUN: %empty-directory(%t/Frameworks)
+// RUN: %empty-directory(%t/System/Frameworks)
+// RUN: cp -R %S/../Inputs/build_session/Frameworks/Foo.framework %t/Frameworks/
+// RUN: cp -R %S/../Inputs/build_session/Frameworks/FooHelper.framework %t/System/Frameworks/
+// RUN: %sourcekitd-test \
+// RUN:   -shell -- echo '## ONE' == \
+// RUN:   -req=sema %s -- %s -D ONE -F %t/Frameworks -Fsystem %t/System/Frameworks -module-cache-path %t/ModuleCache  == \
+// RUN:   -shell -- cp -R %S/../Inputs/build_session/Frameworks_modified/Foo.framework %t/Frameworks/ == \
+// RUN:   -shell -- cp -R %S/../Inputs/build_session/Frameworks_modified/FooHelper.framework %t/System/Frameworks/ == \
+// RUN:   -shell -- echo '## TWO' == \
+// RUN:   -req=sema %s -- %s -D TWO -F %t/Frameworks -Fsystem %t/System/Frameworks -module-cache-path %t/ModuleCache  \
+// RUN:   | tee %t.reponse | %FileCheck %s --check-prefix=CHECK_USER
+
+// CHECK_USER-LABEL: ## ONE
+// CHECK_USER-NOT: key.description
+
+// CHECK_USER-LABEL: ## TWO
+// CHECK_USER-NOT: key.severity: 
+// CHECK_USER: key.severity: source.diagnostic.severity.error,
+// CHECK_USER-NEXT: key.description: "use of unresolved identifier 'fooFunc'",
+// CHECK_USER: key.severity: source.diagnostic.severity.error,
+// CHECK_USER-NEXT: key.description: "use of unresolved identifier 'fooSubFunc'",
+// CHECK_USER-NOT: key.severity: 

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -31,6 +31,7 @@
 #include "swift/Sema/IDETypeChecking.h"
 
 #include "llvm/ADT/FoldingSet.h"
+#include "llvm/Support/Chrono.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
@@ -374,7 +375,9 @@ struct SwiftASTManager::Implementation {
       std::shared_ptr<GlobalConfig> Config,
       std::shared_ptr<SwiftStatistics> Stats, StringRef RuntimeResourcePath)
       : EditorDocs(EditorDocs), Config(Config), Stats(Stats),
-        RuntimeResourcePath(RuntimeResourcePath) {}
+        RuntimeResourcePath(RuntimeResourcePath),
+        SessionTimestamp(llvm::sys::toTimeT(std::chrono::system_clock::now())) {
+  }
 
   std::shared_ptr<SwiftEditorDocumentFileMap> EditorDocs;
   std::shared_ptr<GlobalConfig> Config;
@@ -383,6 +386,7 @@ struct SwiftASTManager::Implementation {
   SourceManager SourceMgr;
   Cache<ASTKey, ASTProducerRef> ASTCache{ "sourcekit.swift.ASTCache" };
   llvm::sys::Mutex CacheMtx;
+  std::time_t SessionTimestamp;
 
   WorkQueue ASTBuildQueue{ WorkQueue::Dequeuing::Serial,
                            "sourcekit.swift.ASTBuilding" };
@@ -547,6 +551,18 @@ bool SwiftASTManager::initCompilerInvocation(
   // those with a location in the primary file, and everything else).
   if (Impl.Config->shouldOptimizeForIDE())
     FrontendOpts.IgnoreSwiftSourceInfo = true;
+
+  // To save the time for module validation, consider the lifetime of ASTManager
+  // as a single build session.
+  // NOTE: 'SessionTimestamp - 1' because clang compares it with '<=' that may
+  //       cause unnecessary validations if they happens within one second from
+  //       the SourceKit startup.
+  ImporterOpts.ExtraArgs.push_back("-fbuild-session-timestamp=" +
+                                   std::to_string(Impl.SessionTimestamp - 1));
+  ImporterOpts.ExtraArgs.push_back("-fmodules-validate-once-per-build-session");
+
+  auto &SearchPathOpts = Invocation.getSearchPathOptions();
+  SearchPathOpts.DisableModulesValidateSystemDependencies = true;
 
   // Disable expensive SIL options to reduce time spent in SILGen.
   disableExpensiveSILOptions(Invocation.getSILOptions());

--- a/tools/SourceKit/tools/sourcekitd-test/Options.td
+++ b/tools/SourceKit/tools/sourcekitd-test/Options.td
@@ -149,6 +149,9 @@ def suppress_config_request : Flag<["-"], "suppress-config-request">,
 def module_cache_path: Separate<["-"], "module-cache-path">, HelpText<"module cache path">;
 def module_cache_path_EQ : Joined<["-"], "module-cache-path=">, Alias<module_cache_path>;
 
+def shell: Flag<["-"], "shell">,
+  HelpText<"Run shell command">;
+
 def help : Flag<["-", "--"], "help">,
   HelpText<"Display available options">;
 

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -389,6 +389,10 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
       ModuleCachePath = InputArg->getValue();
       break;
 
+    case OPT_shell:
+      ShellExecution = true;
+      break;
+
     case OPT_UNKNOWN:
       llvm::errs() << "error: unknown argument: "
                    << InputArg->getAsString(ParsedArgs) << '\n'

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -124,6 +124,7 @@ struct TestOptions {
   llvm::StringMap<VFSFile> VFSFiles;
   llvm::Optional<std::string> VFSName;
   llvm::Optional<bool> CancelOnSubsequentRequest;
+  bool ShellExecution = false;
   bool parseArgs(llvm::ArrayRef<const char *> Args);
   void printHelp(bool ShowHidden) const;
 };


### PR DESCRIPTION
Pass `-fbuild-session-timestamp` and `-fmodules-validate-once-per-build-session` to ClangImporter so that the module validation happens only once for the SourceKit lifetime.

rdar://problem/59567281
