### PR TITLE
ModuleInterface: print function-builder custom attribute only on parameters

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -770,6 +770,19 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     }
     break;
   }
+  case DAK_Custom: {
+    if (!Options.IsForSwiftInterface)
+      break;
+    // For Swift interface, we should only print function builder attribute
+    // on parameter decls. Printing the attribute elsewhere isn't ABI relevant.
+    if (auto *VD = dyn_cast<ValueDecl>(D)) {
+      if (VD->getAttachedFunctionBuilder() == this) {
+        if (!isa<ParamDecl>(D))
+          return false;
+      }
+    }
+    break;
+  }
   default:
     break;
   }

--- a/test/ModuleInterface/function_builders.swift
+++ b/test/ModuleInterface/function_builders.swift
@@ -36,11 +36,14 @@ public func tuplify<T>(_ cond: Bool, @TupleBuilder body: (Bool) -> T) {
 }
 
 public struct UsesBuilderProperty {
-  // CHECK: @FunctionBuilders.TupleBuilder public var myVar: (Swift.String, Swift.String) {
+  // CHECK: public var myVar: (Swift.String, Swift.String) {
   // CHECK-NEXT: get
   // CHECK-NEXT: }
   @TupleBuilder public var myVar: (String, String) {
     "hello"
     "goodbye"
   }
+
+  // CHECK: public func myFunc(@FunctionBuilders.TupleBuilder fn: () -> ())
+  public func myFunc(@TupleBuilder fn: () -> ()) {}
 }


### PR DESCRIPTION
Printing this attribute on other definitions isn't necessary.

rdar://58544718
