### PR TITLE
 [ConstraintSystem] Don't allow explicit closure result to be implicitly converted to `Void`

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -37,6 +37,7 @@ class AccessorDecl;
 enum class AccessorKind;
 class ContextualPattern;
 class DefaultArgumentExpr;
+class ClosureExpr;
 class GenericParamList;
 class PrecedenceGroupDecl;
 struct PropertyWrapperBackingPropertyInfo;
@@ -2138,6 +2139,24 @@ private:
 
 public:
   // Cached.
+  bool isCached() const { return true; }
+};
+
+/// Determine whether closure body has any explicit `return`
+/// statements which could produce a non-void result.
+class ClosureHasExplicitResultRequest
+    : public SimpleRequest<ClosureHasExplicitResultRequest, bool(ClosureExpr *),
+                           CacheKind::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  llvm::Expected<bool> evaluate(Evaluator &evaluator,
+                                ClosureExpr *closure) const;
+
+public:
   bool isCached() const { return true; }
 };
 

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -232,3 +232,5 @@ SWIFT_REQUEST(TypeChecker, PatternTypeRequest,
               Cached, HasNearestLocation)
 SWIFT_REQUEST(TypeChecker, ScopedImportLookupRequest,
               ArrayRef<ValueDecl *>(ImportDecl *), Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, ClosureHasExplicitResultRequest,
+              bool(ClosureExpr *), Cached, NoLocationInfo)

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -659,6 +659,7 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
       break;
     }
 
+    case ConstraintLocator::ClosureBody:
     case ConstraintLocator::ClosureResult: {
       diagnostic = diag::cannot_convert_closure_result;
       break;
@@ -1902,6 +1903,7 @@ bool ContextualFailure::diagnoseAsError() {
 
   Diag<Type, Type> diagnostic;
   switch (path.back().getKind()) {
+  case ConstraintLocator::ClosureBody:
   case ConstraintLocator::ClosureResult: {
     auto *closure = cast<ClosureExpr>(getRawAnchor());
     if (closure->hasExplicitResultType() &&
@@ -3786,7 +3788,8 @@ bool MissingArgumentsFailure::diagnoseAsError() {
   if (!(locator->isLastElement<LocatorPathElt::ApplyArgToParam>() ||
         locator->isLastElement<LocatorPathElt::ContextualType>() ||
         locator->isLastElement<LocatorPathElt::ApplyArgument>() ||
-        locator->isLastElement<LocatorPathElt::ClosureResult>()))
+        locator->isLastElement<LocatorPathElt::ClosureResult>() ||
+        locator->isLastElement<LocatorPathElt::ClosureBody>()))
     return false;
 
   // If this is a misplaced `missng argument` situation, it would be
@@ -4045,7 +4048,8 @@ bool MissingArgumentsFailure::diagnoseClosure(ClosureExpr *closure) {
     if (auto objectType = paramType->getOptionalObjectType())
       paramType = objectType;
     funcType = paramType->getAs<FunctionType>();
-  } else if (locator->isLastElement<LocatorPathElt::ClosureResult>()) {
+  } else if (locator->isLastElement<LocatorPathElt::ClosureResult>() ||
+             locator->isLastElement<LocatorPathElt::ClosureBody>()) {
     // Based on the locator we know this this is something like this:
     // `let _: () -> ((Int) -> Void) = { return {} }`.
     funcType = getType(getRawAnchor())

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2197,12 +2197,6 @@ namespace {
           resultTy = CS.createTypeVariable(
               resultLoc,
               closure->hasSingleExpressionBody() ? 0 : TVO_CanBindToHole);
-
-          if (closureHasNoResult(closure)) {
-            // Allow it to default to () if there are no return statements.
-            CS.addConstraint(ConstraintKind::Defaultable, resultTy,
-                             ctx.TheEmptyTupleType, resultLoc);
-          }
         }
       }
 
@@ -2526,13 +2520,6 @@ namespace {
     Type visitCaptureListExpr(CaptureListExpr *expr) {
       // The type of the capture list is just the type of its closure.
       return CS.getType(expr->getClosureBody());
-    }
-
-    bool closureHasNoResult(ClosureExpr *closure) {
-      // Single statement closures always have a result because
-      // `return` is implicit.
-      return closure->hasSingleExpressionBody() ? false
-                                                : !hasExplicitResult(closure);
     }
 
     /// Walk a closure AST to determine if it can throw.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7006,6 +7006,14 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
         ConstraintKind::Conversion, getType(closureBody),
         closureType->getResult(),
         getConstraintLocator(closure, ConstraintLocator::ClosureResult));
+  } else if (!hasExplicitResult(closure)) {
+    // If multi-statement closure doesn't have an explicit result
+    // (no `return` statements) let's default it to `Void`.
+    auto &ctx = getASTContext();
+    addConstraint(
+        ConstraintKind::Defaultable, inferredClosureType->getResult(),
+        ctx.TheEmptyTupleType,
+        getConstraintLocator(closure, ConstraintLocator::ClosureResult));
   }
 
   return true;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3663,6 +3663,7 @@ bool ConstraintSystem::repairFailures(
     break;
   }
 
+  case ConstraintLocator::ClosureBody:
   case ConstraintLocator::ClosureResult: {
     if (repairViaOptionalUnwrap(*this, lhs, rhs, matchKind, conversionsOrFixes,
                                 locator))
@@ -4792,9 +4793,21 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
   // literals and expressions representing an implicit return type of the single
   // expression functions.
   if (auto elt = locator.last()) {
-    if (elt->isClosureResult() || elt->isResultOfSingleExprFunction()) {
-      if (kind >= ConstraintKind::Subtype &&
-          (type1->isUninhabited() || type2->isVoid())) {
+    if (kind >= ConstraintKind::Subtype &&
+        (type1->isUninhabited() || type2->isVoid())) {
+      // A conversion from closure body type to its signature result type.
+      if (auto resultElt = elt->getAs<LocatorPathElt::ClosureBody>()) {
+        // If a single statement closure has explicit `return` let's
+        // forbid conversion to `Void` and report an error instead to
+        // honor user's intent.
+        if (type1->isUninhabited() || !resultElt->hasExplicitReturn()) {
+          increaseScore(SK_FunctionConversion);
+          return getTypeMatchSuccess();
+        }
+      }
+
+      // Single expression function with implicit `return`.
+      if (elt->isResultOfSingleExprFunction()) {
         increaseScore(SK_FunctionConversion);
         return getTypeMatchSuccess();
       }
@@ -6993,6 +7006,8 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
     }
   }
 
+  bool hasReturn = hasExplicitResult(closure);
+
   // If this is a multi-statement closure its body doesn't participate
   // in type-checking.
   if (closure->hasSingleExpressionBody()) {
@@ -7000,13 +7015,11 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
     if (!closureBody)
       return false;
 
-    // Since result of the closure type has to be r-value type, we have
-    // to use equality here.
     addConstraint(
         ConstraintKind::Conversion, getType(closureBody),
         closureType->getResult(),
-        getConstraintLocator(closure, ConstraintLocator::ClosureResult));
-  } else if (!hasExplicitResult(closure)) {
+        getConstraintLocator(closure, LocatorPathElt::ClosureBody(hasReturn)));
+  } else if (!hasReturn) {
     // If multi-statement closure doesn't have an explicit result
     // (no `return` statements) let's default it to `Void`.
     auto &ctx = getASTContext();

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -67,7 +67,8 @@ void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
     case TypeParameterRequirement:
     case ContextualType:
     case SynthesizedArgument:
-    case TernaryBranch: {
+    case TernaryBranch:
+    case ClosureBody: {
       auto numValues = numNumericValuesInPathElement(elt.getKind());
       for (unsigned i = 0; i < numValues; ++i)
         id.AddInteger(elt.getValue(i));
@@ -87,6 +88,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::ApplyFunction:
   case ConstraintLocator::SequenceElementType:
   case ConstraintLocator::ClosureResult:
+  case ConstraintLocator::ClosureBody:
   case ConstraintLocator::ConstructorMember:
   case ConstraintLocator::InstanceType:
   case ConstraintLocator::AutoclosureResult:
@@ -325,6 +327,10 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
     }
     case ClosureResult:
       out << "closure result";
+      break;
+
+    case ClosureBody:
+      out << "type of a closure body";
       break;
 
     case ConstructorMember:

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -71,6 +71,7 @@ public:
     case PatternMatch:
       return 0;
 
+    case ClosureBody:
     case ContextualType:
     case OpenedGeneric:
     case GenericArgument:
@@ -714,6 +715,20 @@ public:
 
   static bool classof(const LocatorPathElt *elt) {
     return elt->getKind() == ConstraintLocator::TypeParameterRequirement;
+  }
+};
+
+class LocatorPathElt::ClosureBody final : public LocatorPathElt {
+  public:
+  ClosureBody(bool hasExplicitReturn = false)
+    : LocatorPathElt(ConstraintLocator::ClosureBody,
+                     hasExplicitReturn) {}
+
+  /// Indicates whether body of the closure has any `return` statements.
+  bool hasExplicitReturn() const { return bool(getValue(0)); }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::ClosureBody;
   }
 };
 

--- a/lib/Sema/ConstraintLocatorPathElts.def
+++ b/lib/Sema/ConstraintLocatorPathElts.def
@@ -54,6 +54,9 @@ SIMPLE_LOCATOR_PATH_ELT(AutoclosureResult)
 /// The result of a closure.
 SIMPLE_LOCATOR_PATH_ELT(ClosureResult)
 
+/// The type of a closure body.
+CUSTOM_LOCATOR_PATH_ELT(ClosureBody)
+
 /// The lookup for a constructor member.
 SIMPLE_LOCATOR_PATH_ELT(ConstructorMember)
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3434,6 +3434,7 @@ void constraints::simplifyLocator(Expr *&anchor,
       }
       break;
 
+    case ConstraintLocator::ClosureBody:
     case ConstraintLocator::ClosureResult:
       if (auto CE = dyn_cast<ClosureExpr>(anchor)) {
         if (CE->hasSingleExpressionBody()) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -24,6 +24,7 @@
 #include "swift/AST/Initializer.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Statistic.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallString.h"
@@ -3853,6 +3854,12 @@ bool constraints::isKnownKeyPathDecl(ASTContext &ctx, ValueDecl *decl) {
   return decl == ctx.getKeyPathDecl() || decl == ctx.getWritableKeyPathDecl() ||
          decl == ctx.getReferenceWritableKeyPathDecl() ||
          decl == ctx.getPartialKeyPathDecl() || decl == ctx.getAnyKeyPathDecl();
+}
+
+bool constraints::hasExplicitResult(ClosureExpr *closure) {
+  auto &ctx = closure->getASTContext();
+  return evaluateOrDefault(ctx.evaluator,
+                           ClosureHasExplicitResultRequest{closure}, false);
 }
 
 static bool isOperator(Expr *expr, StringRef expectedName) {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -5097,6 +5097,11 @@ bool isKnownKeyPathType(Type type);
 /// Determine whether given declaration is one for a key path
 /// `{Writable, ReferenceWritable}KeyPath`.
 bool isKnownKeyPathDecl(ASTContext &ctx, ValueDecl *decl);
+
+/// Determine whether givne closure has any explicit `return`
+/// statements that could produce non-void result.
+bool hasExplicitResult(ClosureExpr *closure);
+
 } // end namespace constraints
 
 template<typename ...Args>

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -823,6 +823,9 @@ ClosureHasExplicitResultRequest::evaluate(Evaluator &evaluator,
     std::pair<bool, Stmt *> walkToStmtPre(Stmt *stmt) override {
       // Record return statements.
       if (auto ret = dyn_cast<ReturnStmt>(stmt)) {
+        if (ret->isImplicit())
+          return {true, stmt};
+
         // If it has a result, remember that we saw one, but keep
         // traversing in case there's a no-result return somewhere.
         if (ret->hasResult()) {

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1005,3 +1005,10 @@ func r60074136() {
   takesClosure { ((Int) -> Void) -> Void in // expected-warning {{unnamed parameters must be written with the empty name '_'}}
   }
 }
+
+func rdar52204414() {
+  let _: () -> Void = { return 42 }
+  // expected-error@-1 {{cannot convert value of type 'Int' to closure result type 'Void'}}
+  let _ = { () -> Void in return 42 }
+  // expected-error@-1 {{declared closure result 'Int' is incompatible with contextual type 'Void'}}
+}

--- a/test/Constraints/sr12277.swift
+++ b/test/Constraints/sr12277.swift
@@ -1,0 +1,45 @@
+// RUN: %target-typecheck-verify-swift
+
+enum Time {
+  case milliseconds(Int)
+}
+
+struct Scheduled<T> {
+  let futureResult: EventLoopFuture<T>
+}
+
+struct EventLoopFuture<T> {
+  func flatMap<V>(_ body: @escaping (T) -> EventLoopFuture<V>) -> EventLoopFuture<V> {
+    fatalError()
+  }
+}
+
+struct EventLoop {
+  func makeSucceededFuture<T>(_ v: T) -> EventLoopFuture<T> {
+    fatalError()
+  }
+
+  func scheduleTask<T>(in t: Time, _ body: @escaping () -> T) -> Scheduled<T> {
+    fatalError()
+  }
+}
+
+struct Thing {}
+
+func bar(eventLoop: EventLoop, process: @escaping (Thing) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {
+  func doIt(thingsLeft: ArraySlice<Thing>) -> EventLoopFuture<Void> {
+    var thingsLeft = thingsLeft
+    guard let first = thingsLeft.popFirst() else {
+      return eventLoop.makeSucceededFuture(())
+    }
+
+    return process(first).flatMap { [thingsLeft] in
+      return eventLoop.scheduleTask(in: .milliseconds(100)) {
+        return doIt(thingsLeft: thingsLeft)
+        // expected-error@-1 {{cannot convert value of type 'EventLoopFuture<Void>' to closure result type 'Void'}}
+      }.futureResult
+    }
+  }
+
+  return doIt(thingsLeft: [][...])
+}


### PR DESCRIPTION
It's allowed to convert a single statement closure from `(...) -> T` to `(...) -> Void`
_only_ if there is no explicit `return` in the body.

Resolves: [SR-12277](https://bugs.swift.org/browse/SR-12277)
Resolves: rdar://problem/52204414

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
