### PR TITLE
[NFC] Don't Mutate Flags; Just Read ASTContext::isAccessControlDisabled

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1371,13 +1371,9 @@ void ClassDecl::recordObjCMethod(AbstractFunctionDecl *method,
 ///
 /// This utility is used by qualified name lookup.
 static void configureLookup(const DeclContext *dc,
-                            NLOptions &options,
+                            NLOptions options,
                             ReferencedNameTracker *&tracker,
                             bool &isLookupCascading) {
-  auto &ctx = dc->getASTContext();
-  if (ctx.isAccessControlDisabled())
-    options |= NL_IgnoreAccessControl;
-
   // Find the dependency tracker we'll need for this lookup.
   tracker = nullptr;
   if (auto containingSourceFile =
@@ -1439,7 +1435,8 @@ static bool isAcceptableLookupResult(const DeclContext *dc,
   }
 
   // Check access.
-  if (!(options & NL_IgnoreAccessControl)) {
+  if (!(options & NL_IgnoreAccessControl) &&
+      !dc->getASTContext().isAccessControlDisabled()) {
     return decl->isAccessibleFrom(dc);
   }
 


### PR DESCRIPTION
Make configureLookup a little easier to reason about by pushing the read
of this flag down into lookup instead of mutating the lookup flags
beforehand.