### PR TITLE
[NFC] Requestify Code Completion's Second Pass

### DIFF
--- a/include/swift/AST/ASTTypeIDZone.def
+++ b/include/swift/AST/ASTTypeIDZone.def
@@ -30,6 +30,8 @@ SWIFT_TYPEID(TypePair)
 SWIFT_TYPEID(TypeWitnessAndDecl)
 SWIFT_TYPEID(Witness)
 SWIFT_TYPEID_NAMED(ClosureExpr *, ClosureExpr)
+SWIFT_TYPEID_NAMED(CodeCompletionCallbacksFactory *,
+                   CodeCompletionCallbacksFactory)
 SWIFT_TYPEID_NAMED(ConstructorDecl *, ConstructorDecl)
 SWIFT_TYPEID_NAMED(CustomAttr *, CustomAttr)
 SWIFT_TYPEID_NAMED(Decl *, Decl)

--- a/include/swift/AST/ASTTypeIDs.h
+++ b/include/swift/AST/ASTTypeIDs.h
@@ -24,6 +24,7 @@ namespace swift {
 class AbstractFunctionDecl;
 class BraceStmt;
 class ClosureExpr;
+class CodeCompletionCallbacksFactory;
 class ConstructorDecl;
 class CustomAttr;
 class Decl;

--- a/include/swift/AST/ParseRequests.h
+++ b/include/swift/AST/ParseRequests.h
@@ -101,6 +101,24 @@ public:
   void cacheResult(ArrayRef<Decl *> decls) const;
 };
 
+void simple_display(llvm::raw_ostream &out,
+                    const CodeCompletionCallbacksFactory *factory);
+
+class CodeCompletionSecondPassRequest
+    : public SimpleRequest<CodeCompletionSecondPassRequest,
+                           bool(SourceFile *, CodeCompletionCallbacksFactory *),
+                           CacheKind::Uncached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  bool evaluate(Evaluator &evaluator, SourceFile *SF,
+                CodeCompletionCallbacksFactory *Factory) const;
+};
+
 /// The zone number for the parser.
 #define SWIFT_TYPEID_ZONE Parse
 #define SWIFT_TYPEID_HEADER "swift/AST/ParseTypeIDZone.def"

--- a/include/swift/AST/ParseTypeIDZone.def
+++ b/include/swift/AST/ParseTypeIDZone.def
@@ -14,6 +14,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+SWIFT_REQUEST(Parse, CodeCompletionSecondPassRequest,
+              bool (SourceFile *, CodeCompletionCallbacksFactory *),
+              Uncached, NoLocationInfo)
 SWIFT_REQUEST(Parse, ParseMembersRequest,
               FingerprintAndMembers(IterableDeclContext *), Cached, NoLocationInfo)
 SWIFT_REQUEST(Parse, ParseAbstractFunctionBodyRequest,

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -181,6 +181,14 @@ void ParseSourceFileRequest::cacheResult(ArrayRef<Decl *> decls) const {
   verify(*SF);
 }
 
+//----------------------------------------------------------------------------//
+// CodeCompletionSecondPassRequest computation.
+//----------------------------------------------------------------------------//
+
+
+void swift::simple_display(llvm::raw_ostream &out,
+                           const CodeCompletionCallbacksFactory *factory) { }
+
 // Define request evaluation functions for each of the type checker requests.
 static AbstractRequestFunction *parseRequestFunctions[] = {
 #define SWIFT_REQUEST(Zone, Name, Sig, Caching, LocOptions)                    \


### PR DESCRIPTION
Code Completion operates on a CompilerInstance that passes a primary
file down for type checking. This means it creates and registers
dependencies in the referenced name trackers. Despite the fact that
those dependencty edges are unused,
because the would-be swiftdeps file is never written to disk,
it is still a dependency source that should participate in the
request-based dependency tracking refactor.