### PR TITLE
Remove [extern_c] attribute from WinSDK module.

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-module WinSDK [system] [extern_c] {
+module WinSDK [system] {
   module WinSock2 {
     header "WinSock2.h"
     header "WS2tcpip.h"


### PR DESCRIPTION
I've verified that all of the header files in this module already contain their own `extern "C"` blocks that are activated if compiling as C++.

The additional `[extern_c]` attribute causes problems for some headers, like `PathCch.h`, that define additional overloads of functions when compiled as C++. The "global" `[extern_c]` essentially switches off name mangling for these overloads, which causes them to conflict with the functions they are overloading.

See here for more context:
https://github.com/apple/swift/pull/30233#issuecomment-601594221

See here for an example of failures caused by the [extern_c]:
https://ci-external.swift.org/job/swift-PR-windows/869/console
(Search for "PathCch.h".)