### PR TITLE
Fix the test for importing C++ access specifiers on Windows

### DIFF
--- a/test/ClangImporter/access-specifiers-module-interface.swift
+++ b/test/ClangImporter/access-specifiers-module-interface.swift
@@ -9,31 +9,31 @@
 // CHECK-NEXT:     init()
 // CHECK-NEXT:   }
 // CHECK-NEXT:   struct PublicEnum : Equatable, RawRepresentable {
-// CHECK-NEXT:     init(_ rawValue: UInt32)
-// CHECK-NEXT:     init(rawValue: UInt32)
-// CHECK-NEXT:     var rawValue: UInt32
-// CHECK-NEXT:     typealias RawValue = UInt32
+// CHECK-NEXT:     init(_ rawValue: [[ENUM_INT:Int32|UInt32]])
+// CHECK-NEXT:     init(rawValue: [[ENUM_INT]])
+// CHECK-NEXT:     var rawValue: [[ENUM_INT]]
+// CHECK-NEXT:     typealias RawValue = [[ENUM_INT]]
 // CHECK-NEXT:   }
-// CHECK-NEXT:   @frozen enum PublicClosedEnum : UInt32 {
-// CHECK-NEXT:     init?(rawValue: UInt32)
-// CHECK-NEXT:     var rawValue: UInt32 { get }
-// CHECK-NEXT:     typealias RawValue = UInt32
+// CHECK-NEXT:   @frozen enum PublicClosedEnum : [[ENUM_INT]] {
+// CHECK-NEXT:     init?(rawValue: [[ENUM_INT]])
+// CHECK-NEXT:     var rawValue: [[ENUM_INT]] { get }
+// CHECK-NEXT:     typealias RawValue = [[ENUM_INT]]
 // CHECK-NEXT:     case value1
 // CHECK-NEXT:     @available(swift, obsoleted: 3, renamed: "value1")
 // CHECK-NEXT:     static var Value1: PublicPrivate.PublicClosedEnum { get }
 // CHECK-NEXT:   }
-// CHECK-NEXT:   enum PublicOpenEnum : UInt32 {
-// CHECK-NEXT:     init?(rawValue: UInt32)
-// CHECK-NEXT:     var rawValue: UInt32 { get }
-// CHECK-NEXT:     typealias RawValue = UInt32
+// CHECK-NEXT:   enum PublicOpenEnum : [[ENUM_INT]] {
+// CHECK-NEXT:     init?(rawValue: [[ENUM_INT]])
+// CHECK-NEXT:     var rawValue: [[ENUM_INT]] { get }
+// CHECK-NEXT:     typealias RawValue = [[ENUM_INT]]
 // CHECK-NEXT:     case value1
 // CHECK-NEXT:     @available(swift, obsoleted: 3, renamed: "value1")
 // CHECK-NEXT:     static var Value1: PublicPrivate.PublicOpenEnum { get }
 // CHECK-NEXT:   }
 // CHECK-NEXT:   struct PublicFlagEnum : OptionSet {
-// CHECK-NEXT:     init(rawValue: UInt32)
-// CHECK-NEXT:     let rawValue: UInt32
-// CHECK-NEXT:     typealias RawValue = UInt32
+// CHECK-NEXT:     init(rawValue: [[ENUM_INT]])
+// CHECK-NEXT:     let rawValue: [[ENUM_INT]]
+// CHECK-NEXT:     typealias RawValue = [[ENUM_INT]]
 // CHECK-NEXT:     typealias Element = PublicPrivate.PublicFlagEnum
 // CHECK-NEXT:     typealias ArrayLiteralElement = PublicPrivate.PublicFlagEnum
 // CHECK-NEXT:   }


### PR DESCRIPTION
PR #30233 added `test/ClangImporter/access-specifiers-module-interface.swift`, which turned out to be broken on Windows. The issue is that C++ enums on Windows have `signed int` as the underlying type, while on macOS and Linux the underlying type is `unsigned int`.
