### PR TITLE
[Property wrappers] Fix handling of @autoclosure in init(wrappedValue:)

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5191,6 +5191,18 @@ public:
   /// a suitable `init(initialValue:)`.
   bool isPropertyMemberwiseInitializedWithWrappedType() const;
 
+  /// Whether the innermost property wrapper's initializer's 'wrappedValue' parameter
+  /// is marked with '@autoclosure' and '@escaping'.
+  bool isInnermostPropertyWrapperInitUsesEscapingAutoClosure() const;
+
+  /// Return the interface type of the value used for the 'wrappedValue:'
+  /// parameter when initializing a property wrapper.
+  ///
+  /// If the property has an attached property wrapper and the 'wrappedValue:'
+  /// parameter is an autoclosure, return a function type returning the stored
+  /// value. Otherwise, return the interface type of the stored value.
+  Type getPropertyWrapperInitValueInterfaceType() const;
+
   /// If this property is the backing storage for a property with an attached
   /// property wrapper, return the original property.
   ///

--- a/include/swift/AST/PropertyWrappers.h
+++ b/include/swift/AST/PropertyWrappers.h
@@ -43,6 +43,10 @@ struct PropertyWrapperTypeInfo {
     HasInitialValueInit
   } wrappedValueInit = NoWrappedValueInit;
 
+  /// Whether the init(wrappedValue:), if it exists, has the wrappedValue
+  /// argument as an escaping autoclosure.
+  bool isWrappedValueInitUsingEscapingAutoClosure = false;
+
   /// The initializer that will be called to default-initialize a
   /// value with an attached property wrapper.
   enum {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6343,6 +6343,8 @@ Expr *swift::findOriginalPropertyWrapperInitialValue(VarDecl *var,
         return { false, E };
 
       if (auto call = dyn_cast<CallExpr>(E)) {
+        ASTContext &ctx = innermostNominal->getASTContext();
+
         // We're looking for an implicit call.
         if (!call->isImplicit())
           return { true, E };
@@ -6352,9 +6354,19 @@ Expr *swift::findOriginalPropertyWrapperInitialValue(VarDecl *var,
         // property.
         if (auto tuple = dyn_cast<TupleExpr>(call->getArg())) {
           if (tuple->getNumElements() > 0) {
-            auto elem = tuple->getElement(0);
-            if (elem->isImplicit() && isa<CallExpr>(elem)) {
-              return { true, E };
+            for (unsigned i : range(tuple->getNumElements())) {
+              if (tuple->getElementName(i) == ctx.Id_wrappedValue ||
+                  tuple->getElementName(i) == ctx.Id_initialValue) {
+                auto elem = tuple->getElement(i)->getSemanticsProvidingExpr();
+
+                // Look through autoclosures.
+                if (auto autoclosure = dyn_cast<AutoClosureExpr>(elem))
+                  elem = autoclosure->getSingleExpressionBody();
+
+                if (elem->isImplicit() && isa<CallExpr>(elem)) {
+                  return { true, E };
+                }
+              }
             }
           }
         }
@@ -6367,7 +6379,6 @@ Expr *swift::findOriginalPropertyWrapperInitialValue(VarDecl *var,
 
         // Find the implicit initialValue/wrappedValue argument.
         if (auto tuple = dyn_cast<TupleExpr>(call->getArg())) {
-          ASTContext &ctx = innermostNominal->getASTContext();
           for (unsigned i : range(tuple->getNumElements())) {
             if (tuple->getElementName(i) == ctx.Id_wrappedValue ||
                 tuple->getElementName(i) == ctx.Id_initialValue) {

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1895,8 +1895,10 @@ static CanAnyFunctionType getStoredPropertyInitializerInterfaceType(
   // wrapper that was initialized with '=', the stored property initializer
   // will be in terms of the original property's type.
   if (auto originalProperty = VD->getOriginalWrappedProperty()) {
-    if (originalProperty->isPropertyMemberwiseInitializedWithWrappedType())
-      resultTy = originalProperty->getValueInterfaceType()->getCanonicalType();
+    if (originalProperty->isPropertyMemberwiseInitializedWithWrappedType()) {
+      resultTy = originalProperty->getPropertyWrapperInitValueInterfaceType()
+                                     ->getCanonicalType();
+    }
   }
 
   auto sig = DC->getGenericSignatureOfContext();
@@ -1915,8 +1917,7 @@ static CanAnyFunctionType getPropertyWrapperBackingInitializerInterfaceType(
 
   auto *DC = VD->getInnermostDeclContext();
   CanType inputType =
-    VD->getParentPattern()->getType()->mapTypeOutOfContext()
-          ->getCanonicalType();
+    VD->getPropertyWrapperInitValueInterfaceType()->getCanonicalType();
 
   auto sig = DC->getGenericSignatureOfContext();
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -930,7 +930,7 @@ static Type getInitializationTypeInContext(
   if (auto singleVar = pattern->getSingleVar()) {
     if (auto originalProperty = singleVar->getOriginalWrappedProperty()) {
       if (originalProperty->isPropertyMemberwiseInitializedWithWrappedType())
-        interfaceType = originalProperty->getValueInterfaceType();
+        interfaceType = originalProperty->getPropertyWrapperInitValueInterfaceType();
     }
   }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2397,9 +2397,32 @@ RValue RValueEmitter::visitCaptureListExpr(CaptureListExpr *E, SGFContext C) {
   return visit(E->getClosureBody(), C);
 }
 
+static OpaqueValueExpr *opaqueValueExprToSubstituteForAutoClosure(
+    const AbstractClosureExpr *e) {
+  // When we find an autoclosure that just calls an opaque closure,
+  // this is a case where we've created the opaque closure as a
+  // stand-in for the autoclosure itself. Such an opaque closure is
+  // created when we have a property wrapper's 'init(wrappedValue:)'
+  // taking an autoclosure argument.
+  if (auto ace = dyn_cast<AutoClosureExpr>(e)) {
+    if (auto ce = dyn_cast<CallExpr>(ace->getSingleExpressionBody())) {
+      if (auto ove = dyn_cast<OpaqueValueExpr>(ce->getFn())) {
+        if (!ace->isImplicit() || !ove->isImplicit() || !ove->isPlaceholder())
+          return nullptr;
+
+        if (ace->getType()->isEqual(ove->getType()))
+          return ove;
+      }
+    }
+  }
+  return nullptr;
+}
 
 RValue RValueEmitter::visitAbstractClosureExpr(AbstractClosureExpr *e,
                                                SGFContext C) {
+  if (auto ove = opaqueValueExprToSubstituteForAutoClosure(e))
+    return visitOpaqueValueExpr(ove, C);
+
   // Emit the closure body.
   SGF.SGM.emitClosure(e);
 

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -750,7 +750,8 @@ void SILGenFunction::emitGeneratorFunction(SILDeclRef function, Expr *value,
                                      ctx.getIdentifier("$input_value"),
                                      dc);
     param->setSpecifier(ParamSpecifier::Owned);
-    param->setInterfaceType(function.getDecl()->getInterfaceType());
+    auto vd = cast<VarDecl>(function.getDecl());
+    param->setInterfaceType(vd->getPropertyWrapperInitValueInterfaceType());
 
     params = ParameterList::create(ctx, SourceLoc(), {param}, SourceLoc());
   }
@@ -800,7 +801,7 @@ void SILGenFunction::emitGeneratorFunction(SILDeclRef function, VarDecl *var) {
   // will be in terms of the original property's type.
   if (auto originalProperty = var->getOriginalWrappedProperty()) {
     if (originalProperty->isPropertyMemberwiseInitializedWithWrappedType()) {
-      interfaceType = originalProperty->getValueInterfaceType();
+      interfaceType = originalProperty->getPropertyWrapperInitValueInterfaceType();
     }
   }
 

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1302,7 +1302,7 @@ namespace {
     {
     }
 
-    bool hasPropertyWrapper() const {
+    bool canRewriteSetAsPropertyWrapperInit() const {
       if (auto *VD = dyn_cast<VarDecl>(Storage)) {
         // If this is not a wrapper property that can be initialized from
         // a value of the wrapped type, we can't perform the initialization.
@@ -1396,9 +1396,8 @@ namespace {
       assert(getAccessorDecl()->isSetter());
       SILDeclRef setter = Accessor;
 
-      if (IsOnSelfParameter &&
+      if (IsOnSelfParameter && canRewriteSetAsPropertyWrapperInit() &&
           !Storage->isStatic() &&
-          hasPropertyWrapper() &&
           isBackingVarVisible(cast<VarDecl>(Storage),
                               SGF.FunctionDC)) {
         // This is wrapped property. Instead of emitting a setter, emit an
@@ -4301,7 +4300,7 @@ static bool trySetterPeephole(SILGenFunction &SGF, SILLocation loc,
   }
 
   auto &setterComponent = static_cast<GetterSetterComponent&>(component);
-  if (setterComponent.hasPropertyWrapper())
+  if (setterComponent.canRewriteSetAsPropertyWrapperInit())
     return false;
   setterComponent.emitAssignWithSetter(SGF, loc, std::move(dest),
                                        std::move(src));

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1321,6 +1321,13 @@ namespace {
           return false;
         }
 
+        // If this property wrapper uses autoclosure in it's initializer,
+        // the argument types of the setter and initializer shall be
+        // different, so we don't rewrite an assignment into an
+        // initialization.
+        if (VD->isInnermostPropertyWrapperInitUsesEscapingAutoClosure())
+          return false;
+
         return true;
       }
 

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -291,6 +291,42 @@ static SubscriptDecl *findEnclosingSelfSubscript(ASTContext &ctx,
   return subscript;
 }
 
+/// Whether the argument with label 'argumentLabel' in the initializer 'init'
+/// is an escaping autoclosure argument.
+static bool isEscapingAutoclosureArgument(const ConstructorDecl *init,
+                                          Identifier argumentLabel) {
+  if (!init)
+    return false;
+
+  Optional<size_t> parameterIndex = None;
+  auto params = init->getParameters();
+  for (size_t i = 0; i < params->size(); i++) {
+    if (params->get(i)->getArgumentName() == argumentLabel) {
+      parameterIndex = i;
+      break;
+    }
+  }
+
+  if (!parameterIndex.hasValue())
+    return false;
+
+  size_t paramIndex = parameterIndex.getValue();
+  if (!params->get(paramIndex)->isAutoClosure())
+    return false;
+
+  if (auto initTy = init->getInterfaceType()->getAs<AnyFunctionType>()) {
+    if (auto funcTy = initTy->getResult()->getAs<FunctionType>()) {
+      if (funcTy->getNumParams() > paramIndex) {
+        Type paramTy = funcTy->getParams()[paramIndex].getPlainType();
+        if (auto paramFuncTy = paramTy->getAs<FunctionType>())
+          return !paramFuncTy->isNoEscape();
+      }
+    }
+  }
+
+  return false;
+}
+
 llvm::Expected<PropertyWrapperTypeInfo>
 PropertyWrapperTypeInfoRequest::evaluate(
     Evaluator &eval, NominalTypeDecl *nominal) const {
@@ -313,12 +349,16 @@ PropertyWrapperTypeInfoRequest::evaluate(
   
   PropertyWrapperTypeInfo result;
   result.valueVar = valueVar;
-  if (findSuitableWrapperInit(ctx, nominal, valueVar,
-                              PropertyWrapperInitKind::WrappedValue))
+  if (auto init = findSuitableWrapperInit(ctx, nominal, valueVar,
+                              PropertyWrapperInitKind::WrappedValue)) {
     result.wrappedValueInit = PropertyWrapperTypeInfo::HasWrappedValueInit;
-  else if (auto init = findSuitableWrapperInit(
+    result.isWrappedValueInitUsingEscapingAutoClosure =
+      isEscapingAutoclosureArgument(init, ctx.Id_wrappedValue);
+  } else if (auto init = findSuitableWrapperInit(
                ctx, nominal, valueVar, PropertyWrapperInitKind::InitialValue)) {
     result.wrappedValueInit = PropertyWrapperTypeInfo::HasInitialValueInit;
+    result.isWrappedValueInitUsingEscapingAutoClosure =
+      isEscapingAutoclosureArgument(init, ctx.Id_initialValue);
 
     if (init->getLoc().isValid()) {
       auto diag = init->diagnose(diag::property_wrapper_init_initialValue);
@@ -632,6 +672,18 @@ Type swift::computeWrappedValueType(VarDecl *var, Type backingStorageType,
   return wrappedValueType;
 }
 
+static bool isOpaquePlaceholderClosure(const Expr *value) {
+  auto ove = dyn_cast<OpaqueValueExpr>(value);
+  if (!ove || !ove->isPlaceholder())
+    return false;
+
+  if (auto valueFnTy = ove->getType()->getAs<FunctionType>()) {
+    return (valueFnTy->getNumParams() == 0);
+  }
+
+  return false;
+}
+
 Expr *swift::buildPropertyWrapperInitialValueCall(
     VarDecl *var, Type backingStorageType, Expr *value,
     bool ignoreAttributeArgs) {
@@ -639,6 +691,13 @@ Expr *swift::buildPropertyWrapperInitialValueCall(
   ASTContext &ctx = var->getASTContext();
   auto wrapperAttrs = var->getAttachedPropertyWrappers();
   Expr *initializer = value;
+  if (var->isInnermostPropertyWrapperInitUsesEscapingAutoClosure() &&
+      isOpaquePlaceholderClosure(value)) {
+    // We can't pass the opaque closure directly as an autoclosure arg.
+    // So we instead pass a CallExpr calling the opaque closure, which
+    // the type checker shall wrap in an AutoClosureExpr.
+    initializer = CallExpr::createImplicit(ctx, value, {}, {});
+  }
   for (unsigned i : llvm::reverse(indices(wrapperAttrs))) {
     Type wrapperType =
       backingStorageType ? computeWrappedValueType(var, backingStorageType, i)

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2485,8 +2485,11 @@ PropertyWrapperBackingPropertyInfoRequest::evaluate(Evaluator &evaluator,
 
   // Form the initialization of the backing property from a value of the
   // original property's type.
+  Type origValueInterfaceType = var->getPropertyWrapperInitValueInterfaceType();
+  Type origValueType =
+    var->getDeclContext()->mapTypeIntoContext(origValueInterfaceType);
   OpaqueValueExpr *origValue =
-      new (ctx) OpaqueValueExpr(var->getSourceRange(), var->getType(),
+      new (ctx) OpaqueValueExpr(var->getSourceRange(), origValueType,
                                 /*isPlaceholder=*/true);
   Expr *initializer = buildPropertyWrapperInitialValueCall(
       var, storageType, origValue,

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -228,10 +228,10 @@ struct UseLazy<T: DefaultInit> {
   @Lazy var bar = T()
   @Lazy var wibble = [1, 2, 3]
 
-  // CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers7UseLazyV3foo3bar6wibbleACyxGSi_xSaySiGtcfC : $@convention(method) <T where T : DefaultInit> (Int, @in T, @owned Array<Int>, @thin UseLazy<T>.Type) -> @out UseLazy<T>
-  // CHECK: function_ref @$s17property_wrappers7UseLazyV3fooSivpfP : $@convention(thin) <τ_0_0 where τ_0_0 : DefaultInit> (Int) -> @owned Lazy<Int>
-  // CHECK: function_ref @$s17property_wrappers7UseLazyV3barxvpfP : $@convention(thin) <τ_0_0 where τ_0_0 : DefaultInit> (@in τ_0_0) -> @out Lazy<τ_0_0>
-  // CHECK: function_ref @$s17property_wrappers7UseLazyV6wibbleSaySiGvpfP : $@convention(thin) <τ_0_0 where τ_0_0 : DefaultInit> (@owned Array<Int>) -> @owned Lazy<Array<Int>>
+  // CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers7UseLazyV3foo3bar6wibbleACyxGSiyXA_xyXASaySiGyXAtcfC : $@convention(method) <T where T : DefaultInit> (@owned @callee_guaranteed () -> Int, @owned @callee_guaranteed () -> @out T, @owned @callee_guaranteed () -> @owned Array<Int>, @thin UseLazy<T>.Type) -> @out UseLazy<T>
+  // CHECK: function_ref @$s17property_wrappers7UseLazyV3fooSivpfP : $@convention(thin) <τ_0_0 where τ_0_0 : DefaultInit> (@owned @callee_guaranteed () -> Int) -> @owned Lazy<Int>
+  // CHECK: function_ref @$s17property_wrappers7UseLazyV3barxvpfP : $@convention(thin) <τ_0_0 where τ_0_0 : DefaultInit> (@owned @callee_guaranteed () -> @out τ_0_0) -> @out Lazy<τ_0_0>
+  // CHECK: function_ref @$s17property_wrappers7UseLazyV6wibbleSaySiGvpfP : $@convention(thin) <τ_0_0 where τ_0_0 : DefaultInit> (@owned @callee_guaranteed () -> @owned Array<Int>) -> @owned Lazy<Array<Int>>
 }
 
 struct X { }
@@ -483,8 +483,7 @@ struct Inner<Value> {
 struct ComposedInit {
   @Outer @Inner var value: Int
 
-  // CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers12ComposedInitV5valueSivpfP : $@convention(thin) (Int) -> Outer<Inner<Int>> {
-  // CHECK: function_ref @$s17property_wrappers12ComposedInitV6_value33_F728088E0028E14D18C6A10CF68512E8LLAA5OuterVyAA5InnerVySiGGvpfiSiycfu_
+  // CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers12ComposedInitV5valueSivpfP : $@convention(thin) (@owned @callee_guaranteed () -> Int) -> Outer<Inner<Int>> {
   // CHECK: function_ref @$s17property_wrappers5InnerV12wrappedValue1dACyxGxyXA_SdtcfcfA0_
   // CHECK: function_ref @$s17property_wrappers5InnerV12wrappedValue1dACyxGxyXA_SdtcfC
   // CHECK: function_ref @$s17property_wrappers5OuterV1a12wrappedValue1sACyxGSi_xSStcfcfA_

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -228,9 +228,9 @@ struct UseLazy<T: DefaultInit> {
   @Lazy var bar = T()
   @Lazy var wibble = [1, 2, 3]
 
-  // CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers7UseLazyV3foo3bar6wibbleACyxGSiyXA_xyXASaySiGyXAtcfC : $@convention(method) <T where T : DefaultInit> (@owned @callee_guaranteed () -> Int, @owned @callee_guaranteed () -> @out T, @owned @callee_guaranteed () -> @owned Array<Int>, @thin UseLazy<T>.Type) -> @out UseLazy<T>
+  // CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers7UseLazyV3foo3bar6wibbleACyxGSiyXA_xyXASaySiGyXAtcfC : $@convention(method) <T where T : DefaultInit> (@owned @callee_guaranteed () -> Int, @owned @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <T>, @owned @callee_guaranteed () -> @owned Array<Int>, @thin UseLazy<T>.Type) -> @out UseLazy<T> {
   // CHECK: function_ref @$s17property_wrappers7UseLazyV3fooSivpfP : $@convention(thin) <τ_0_0 where τ_0_0 : DefaultInit> (@owned @callee_guaranteed () -> Int) -> @owned Lazy<Int>
-  // CHECK: function_ref @$s17property_wrappers7UseLazyV3barxvpfP : $@convention(thin) <τ_0_0 where τ_0_0 : DefaultInit> (@owned @callee_guaranteed () -> @out τ_0_0) -> @out Lazy<τ_0_0>
+  // CHECK: function_ref @$s17property_wrappers7UseLazyV3barxvpfP : $@convention(thin) <τ_0_0 where τ_0_0 : DefaultInit> (@owned @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_0>) -> @out Lazy<τ_0_0>
   // CHECK: function_ref @$s17property_wrappers7UseLazyV6wibbleSaySiGvpfP : $@convention(thin) <τ_0_0 where τ_0_0 : DefaultInit> (@owned @callee_guaranteed () -> @owned Array<Int>) -> @owned Lazy<Array<Int>>
 }
 

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -642,6 +642,38 @@ struct HasStaticWrapper {
   }
 }
 
+@propertyWrapper
+struct ObservedObject<ObjectType : AnyObject > {
+  var wrappedValue: ObjectType
+
+  init(defaulted: Int = 17, wrappedValue: ObjectType) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
+// rdar://problem/58986940 - composition of wrappers with autoclosure
+@propertyWrapper
+struct Once<Value> {
+  enum Storage {
+    case initialValue(() -> Value)
+    case value(Value)
+  }
+
+  var storage: Storage
+
+  init(defaulted: Int = 0, wrappedValue value: @escaping @autoclosure () -> Value) {
+    storage = .initialValue(value)
+  }
+
+  var wrappedValue: Value { fatalError() }
+}
+
+class Model {}
+
+struct TestAutoclosureComposition {
+  @Once @ObservedObject var model = Model()
+}
+
 // CHECK-LABEL: sil_vtable ClassUsingWrapper {
 // CHECK-NEXT:  #ClassUsingWrapper.x!getter: (ClassUsingWrapper) -> () -> Int : @$s17property_wrappers17ClassUsingWrapperC1xSivg   // ClassUsingWrapper.x.getter
 // CHECK-NEXT:  #ClassUsingWrapper.x!setter: (ClassUsingWrapper) -> (Int) -> () : @$s17property_wrappers17ClassUsingWrapperC1xSivs // ClassUsingWrapper.x.setter

--- a/test/SILOptimizer/di_property_wrappers_errors.swift
+++ b/test/SILOptimizer/di_property_wrappers_errors.swift
@@ -68,3 +68,41 @@ struct SR_11477_S {
   @SR_11477_W var foo: Int
   init() {} // expected-error {{return from initializer without initializing all stored properties}} expected-note {{'self.foo' not initialized}}
 }
+
+@propertyWrapper
+struct WrapperWithAutoclosure<V> {
+  var wrappedValue: V
+  init(wrappedValue: @autoclosure @escaping () -> V) {
+    self.wrappedValue = wrappedValue()
+  }
+}
+
+struct UseWrapperWithAutoclosure {
+  @WrapperWithAutoclosure var wrapped: Int
+
+  init() {
+    wrapped = 42 // expected-error{{'self' used before all stored properties are initialized}}
+    // expected-note@-1{{'self.wrapped' not initialized}}
+  } // expected-error{{return from initializer without initializing all stored properties}}
+  // expected-note@-1{{'self.wrapped' not initialized}}
+
+  init(conditional b: Bool) {
+     if b {
+       self._wrapped = WrapperWithAutoclosure(wrappedValue: 32)
+     } else {
+       wrapped = 42 // expected-error{{'self' used before all stored properties are initialized}}
+      // expected-note@-1{{'self.wrapped' not initialized}}
+     }
+  } // expected-error{{return from initializer without initializing all stored properties}}
+  // expected-note@-1{{'self.wrapped' not initialized}}
+
+  init(dynamic b: Bool) {
+    if b {
+      wrapped = 42 // expected-error{{'self' used before all stored properties are initialized}}
+      // expected-note@-1{{'self.wrapped' not initialized}}
+    }
+    wrapped = 27 // expected-error{{'self' used before all stored properties are initialized}}
+    // expected-note@-1{{'self.wrapped' not initialized}}
+  } // expected-error{{return from initializer without initializing all stored properties}}
+  // expected-note@-1{{'self.wrapped' not initialized}}  
+}


### PR DESCRIPTION
*Note*: this pull request picks up https://github.com/apple/swift/pull/26572 and fixes
a few merge conflicts. All thanks go to @roop 

If the ‘wrappedValue:’ parameter is an escaping autoclosure, and a
struct property is marked with that property wrapper, the memberwise
initializer of the struct is now synthesized with an escaping
autoclosure for that property.

Resolves [SR-10950](https://bugs.swift.org/browse/SR-10950).

Given a Lazy property wrapper:
```
@propertyWrapper
enum Lazy<Value> {
  …
  init(wrappedValue: @autoclosure @escaping () -> Value) {
    …
  }
  …
```

and a struct using the property wrapper
```
struct S {
  @Lazy var n: Int = computeInt()
}
```

the memberwise initializer for S is currently synthesized as:
```
init(n: Int = computeInt())
```

This is incorrect because if we create S like `var s1 = S()` or like `var s2 = S(n: computeInt())`, `computeInt()` will get evaluated at the time of creation of S, which
  - is not consistent with the `@autoclosure` specification
  - makes `@Lazy` not really initialize things lazily

To fix this, this PR makes the memberwise initializer get generated as:
```
init(n: @autoclosure @escaping () -> Int = computeInt())
```

### Implementation details:

1. Changed the type of the opaque placeholder (_lib/Sema/TypeCheckStorage.cpp_): PropertyWrapperBackingPropertyInfo.underlyingValue is an opaque expression that serves as a placeholder for what should be used when initializing a struct using a property wrapper. For the above scenario, the type of this expression is changed to **() -> Int** (rather than **Int** previously).
2. Changed the signature of the memberwise initializer (_lib/Sema/CodeSynthesis.cpp_): The argument type is changed to a closure and autoclosure-ness is set.
3. Handled default values provided with an “=“ in the wrapper (_lib/SIL/TypeLowering.cpp_, _lib/SILGen/SILGenConstructor.cpp_, _lib/SILGen/SILGenFunction.cpp_): The type is likewise changed to a closure.
4. Because of (1), the opaque underlyingValue is of a closure type. I should ideally be passing this as the ‘wrappedValue:’ parameter, but we can’t pass a closure to an autoclosure arg. So, instead, I pass an AutoClosureExpr of a CallExpr of a call to this closure. (_lib/Sema/TypeCheckPropertyWrapper.cpp_)
5. Because of (4), I now have an extra CallExpr in the expression tree which causes problems in SILGen. So, while traversing the expression tree, I skip the AutoClosureExpr and CallExpr. (_lib/SILGen/SILGenExpr.cpp_)