### PR TITLE
fix autocomplete crash

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3155,7 +3155,7 @@ public:
 
         // SE-0253: Callable values of user-defined nominal types.
         if (FD->isCallAsFunctionMethod() && !HaveDot &&
-            !ExprType->is<AnyMetatypeType>()) {
+            (!ExprType || !ExprType->is<AnyMetatypeType>())) {
           Type funcType = getTypeOfMember(FD, dynamicLookupInfo)
                               ->castTo<AnyFunctionType>()
                               ->getResult();

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -378,3 +378,14 @@ struct test_54215016 {
 // RDAR_54215016: Begin completions
   }
 }
+
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=CRASH_CALL_AS_FUNCTION -source-filename=%s | %FileCheck %s -check-prefix=CRASH_CALL_AS_FUNCTION
+protocol HasCallAsFunctionRequirement {
+  func callAsFunction()
+}
+struct StructWithCallAsFunction: HasCallAsFunctionRequirement {
+  let f = #^CRASH_CALL_AS_FUNCTION^#
+  func callAsFunction() {}
+}
+// CRASH_CALL_AS_FUNCTION: Begin completion
+// CRASH_CALL_AS_FUNCTION: End completions


### PR DESCRIPTION
A jupyter test case triggers this crash, where a method is called on `ExprType` when it is not null. This PR adds a null check and a test case in the compiler.

This code and crash occurs on master, so I will prepare a PR to master too.

I am not sure exactly what the logic should be when `ExprType` is null. Also there are other places in this function where `ExprType` is used without a null check, and maybe they should get a null check too. We could discuss this on the master PR with someone more knowledgeable about the code.