### PR TITLE
fix autocomplete crash involving callAsFunction

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3147,7 +3147,7 @@ public:
 
         // SE-0253: Callable values of user-defined nominal types.
         if (FD->isCallAsFunctionMethod() && !HaveDot &&
-            !ExprType->is<AnyMetatypeType>()) {
+            (!ExprType || !ExprType->is<AnyMetatypeType>())) {
           Type funcType = getTypeOfMember(FD, dynamicLookupInfo)
                               ->castTo<AnyFunctionType>()
                               ->getResult();

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -378,3 +378,14 @@ struct test_54215016 {
 // RDAR_54215016: Begin completions
   }
 }
+
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=CRASH_CALL_AS_FUNCTION -source-filename=%s | %FileCheck %s -check-prefix=CRASH_CALL_AS_FUNCTION
+protocol HasCallAsFunctionRequirement {
+  func callAsFunction()
+}
+struct StructWithCallAsFunction: HasCallAsFunctionRequirement {
+  let f = #^CRASH_CALL_AS_FUNCTION^#
+  func callAsFunction() {}
+}
+// CRASH_CALL_AS_FUNCTION: Begin completion
+// CRASH_CALL_AS_FUNCTION: End completions


### PR DESCRIPTION
The attached test case causes `ExprType->is<AnyMetatypeType>()` to execute when `ExprType` is null.

I notice that there are other (unchecked?) uses of `ExprType` in this method and in this whole class. I'm not familiar enough with this code to tell if those are a problem, but it might be good to check those too.