### PR TITLE
[NFC] Define LookupOperatorRequest and Friends

### DIFF
--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -168,6 +168,10 @@ public:
   /// Null identifiers come after all other identifiers.
   int compare(Identifier other) const;
 
+  friend llvm::hash_code hash_value(Identifier ident) {
+    return llvm::hash_value(ident.getAsOpaquePointer());
+  }
+
   bool operator==(Identifier RHS) const { return Pointer == RHS.Pointer; }
   bool operator!=(Identifier RHS) const { return !(*this==RHS); }
 

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -71,3 +71,16 @@ SWIFT_REQUEST(NameLookup, UnderlyingTypeDeclsReferencedRequest,
 SWIFT_REQUEST(NameLookup, UnqualifiedLookupRequest,
               LookupResult(UnqualifiedLookupDescriptor), Uncached,
               NoLocationInfo)
+
+SWIFT_REQUEST(NameLookup, LookupPrefixOperatorRequest,
+              PrefixOperatorDecl *(OperatorLookupDescriptor),
+              Uncached, NoLocationInfo)
+SWIFT_REQUEST(NameLookup, LookupInfixOperatorRequest,
+              InfixOperatorDecl *(OperatorLookupDescriptor),
+              Uncached, NoLocationInfo)
+SWIFT_REQUEST(NameLookup, LookupPostfixOperatorRequest,
+              PostfixOperatorDecl *(OperatorLookupDescriptor),
+              Uncached, NoLocationInfo)
+SWIFT_REQUEST(NameLookup, LookupPrecedenceGroupRequest,
+              PrecedenceGroupDecl *(OperatorLookupDescriptor),
+              Uncached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1495,8 +1495,8 @@ struct PrecedenceGroupDescriptor {
 
 void simple_display(llvm::raw_ostream &out, const PrecedenceGroupDescriptor &d);
 
-class LookupPrecedenceGroupRequest
-    : public SimpleRequest<LookupPrecedenceGroupRequest,
+class ValidatePrecedenceGroupRequest
+    : public SimpleRequest<ValidatePrecedenceGroupRequest,
                            PrecedenceGroupDecl *(PrecedenceGroupDescriptor),
                            CacheKind::Cached> {
 public:

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -117,7 +117,7 @@ SWIFT_REQUEST(TypeChecker, IsSetterMutatingRequest, bool(AbstractStorageDecl *),
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, LazyStoragePropertyRequest, VarDecl *(VarDecl *),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, LookupPrecedenceGroupRequest,
+SWIFT_REQUEST(TypeChecker, ValidatePrecedenceGroupRequest,
               PrecedenceGroupDecl *(DeclContext *, Identifier, SourceLoc),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, MangleLocalTypeDeclRequest,

--- a/lib/AST/ModuleNameLookup.cpp
+++ b/lib/AST/ModuleNameLookup.cpp
@@ -249,11 +249,9 @@ llvm::Expected<QualifiedLookupResult> LookupInModuleRequest::evaluate(
     const DeclContext *moduleScopeContext) const {
   assert(moduleScopeContext->isModuleScopeContext());
 
-  auto &ctx = moduleOrFile->getASTContext();
-  FrontendStatsTracer tracer(ctx.Stats, "lookup-in-module");
-
   QualifiedLookupResult decls;
-  LookupByName lookup(ctx, resolutionKind, name, lookupKind);
+  LookupByName lookup(moduleOrFile->getASTContext(), resolutionKind,
+                      name, lookupKind);
   lookup.lookupInModule(decls, moduleOrFile, {}, moduleScopeContext);
   return decls;
 }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1609,7 +1609,6 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
 
   // Visit all of the nominal types we know about, discovering any others
   // we need along the way.
-  auto &ctx = DC->getASTContext();
   bool wantProtocolMembers = (options & NL_ProtocolMembers);
   while (!stack.empty()) {
     auto current = stack.back();

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -12,11 +12,12 @@
 
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/NameLookupRequests.h"
-#include "swift/Subsystems.h"
 #include "swift/AST/ASTContext.h"
-#include "swift/AST/Evaluator.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/Evaluator.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/SourceFile.h"
+#include "swift/Subsystems.h"
 
 using namespace swift;
 
@@ -204,6 +205,22 @@ void swift::simple_display(llvm::raw_ostream &out,
 
 SourceLoc swift::extractNearestSourceLoc(const DirectLookupDescriptor &desc) {
   return extractNearestSourceLoc(desc.DC);
+}
+
+//----------------------------------------------------------------------------//
+// LookupOperatorRequest computation.
+//----------------------------------------------------------------------------//
+
+void swift::simple_display(llvm::raw_ostream &out,
+                           const OperatorLookupDescriptor &desc) {
+  out << "looking up operator ";
+  simple_display(out, desc.name);
+  out << " in ";
+  simple_display(out, desc.SF);
+}
+
+SourceLoc swift::extractNearestSourceLoc(const OperatorLookupDescriptor &desc) {
+  return desc.diagLoc;
 }
 
 // Define request evaluation functions for each of the name lookup requests.

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1017,15 +1017,16 @@ void InterfaceTypeRequest::cacheResult(Type type) const {
 }
 
 //----------------------------------------------------------------------------//
-// LookupPrecedenceGroupRequest computation.
+// ValidatePrecedenceGroupRequest computation.
 //----------------------------------------------------------------------------//
 
-SourceLoc LookupPrecedenceGroupRequest::getNearestLoc() const {
+SourceLoc ValidatePrecedenceGroupRequest::getNearestLoc() const {
   auto &desc = std::get<0>(getStorage());
   return desc.getLoc();
 }
 
-void LookupPrecedenceGroupRequest::diagnoseCycle(DiagnosticEngine &diags) const {
+void ValidatePrecedenceGroupRequest::diagnoseCycle(
+    DiagnosticEngine &diags) const {
   auto &desc = std::get<0>(getStorage());
   if (auto pathDir = desc.pathDirection) {
     diags.diagnose(desc.nameLoc, diag::precedence_group_cycle, (bool)*pathDir);
@@ -1034,7 +1035,8 @@ void LookupPrecedenceGroupRequest::diagnoseCycle(DiagnosticEngine &diags) const 
   }
 }
 
-void LookupPrecedenceGroupRequest::noteCycleStep(DiagnosticEngine &diag) const {
+void ValidatePrecedenceGroupRequest::noteCycleStep(
+    DiagnosticEngine &diag) const {
   auto &desc = std::get<0>(getStorage());
   diag.diagnose(desc.nameLoc,
                  diag::circular_reference_through_precedence_group, desc.ident);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1277,8 +1277,9 @@ void swift::validatePrecedenceGroup(PrecedenceGroupDecl *PGD) {
 
     PrecedenceGroupDescriptor desc{PGD->getDeclContext(), rel.Name, rel.NameLoc,
                                    PrecedenceGroupDescriptor::HigherThan};
-    auto group = evaluateOrDefault(PGD->getASTContext().evaluator,
-                                   LookupPrecedenceGroupRequest{desc}, nullptr);
+    auto group =
+        evaluateOrDefault(PGD->getASTContext().evaluator,
+                          ValidatePrecedenceGroupRequest{desc}, nullptr);
     if (group) {
       rel.Group = group;
       addedHigherThan = true;
@@ -1297,8 +1298,9 @@ void swift::validatePrecedenceGroup(PrecedenceGroupDecl *PGD) {
     auto dc = PGD->getDeclContext();
     PrecedenceGroupDescriptor desc{PGD->getDeclContext(), rel.Name, rel.NameLoc,
                                    PrecedenceGroupDescriptor::LowerThan};
-    auto group = evaluateOrDefault(PGD->getASTContext().evaluator,
-                                   LookupPrecedenceGroupRequest{desc}, nullptr);
+    auto group =
+        evaluateOrDefault(PGD->getASTContext().evaluator,
+                          ValidatePrecedenceGroupRequest{desc}, nullptr);
     bool hadError = false;
     if (group) {
       rel.Group = group;
@@ -1332,7 +1334,7 @@ void swift::validatePrecedenceGroup(PrecedenceGroupDecl *PGD) {
     checkPrecedenceCircularity(Diags, PGD);
 }
 
-llvm::Expected<PrecedenceGroupDecl *> LookupPrecedenceGroupRequest::evaluate(
+llvm::Expected<PrecedenceGroupDecl *> ValidatePrecedenceGroupRequest::evaluate(
     Evaluator &eval, PrecedenceGroupDescriptor descriptor) const {
   if (auto *group = lookupPrecedenceGroup(descriptor)) {
     validatePrecedenceGroup(group);
@@ -1347,7 +1349,7 @@ PrecedenceGroupDecl *TypeChecker::lookupPrecedenceGroup(DeclContext *dc,
                                                         SourceLoc nameLoc) {
   return evaluateOrDefault(
       dc->getASTContext().evaluator,
-      LookupPrecedenceGroupRequest({dc, name, nameLoc, None}), nullptr);
+      ValidatePrecedenceGroupRequest({dc, name, nameLoc, None}), nullptr);
 }
 
 static NominalTypeDecl *resolveSingleNominalTypeDecl(


### PR DESCRIPTION
Turn macro metaprogramming into template metaprogramming by defining a new kind of request that runs operator lookups.

This is the final piece of the puzzle for requestification of the current referenced name tracker system.