### PR TITLE
[AutoDiff upstream] Add differentiability witness SILGen.

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -153,6 +153,25 @@ public:
                                              Type SelfType,
                                              ModuleDecl *Module);
 
+  /// Mangle the derivative function (JVP/VJP) for the given:
+  /// - Mangled original function name.
+  /// - Derivative function kind.
+  /// - Derivative function configuration: parameter/result indices and
+  ///   derivative generic signature.
+  std::string
+  mangleAutoDiffDerivativeFunctionHelper(StringRef name,
+                                         AutoDiffDerivativeFunctionKind kind,
+                                         AutoDiffConfig config);
+
+  /// Mangle the linear map (differential/pullback) for the given:
+  /// - Mangled original function name.
+  /// - Linear map kind.
+  /// - Derivative function configuration: parameter/result indices and
+  ///   derivative generic signature.
+  std::string mangleAutoDiffLinearMapHelper(StringRef name,
+                                            AutoDiffLinearMapKind kind,
+                                            AutoDiffConfig config);
+
   /// Mangle a SIL differentiability witness key:
   /// - Mangled original function name.
   /// - Parameter indices.

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -373,6 +373,57 @@ std::string ASTMangler::mangleReabstractionThunkHelper(
   return finalize();
 }
 
+std::string ASTMangler::mangleAutoDiffDerivativeFunctionHelper(
+    StringRef name, AutoDiffDerivativeFunctionKind kind,
+    AutoDiffConfig config) {
+  // TODO(TF-20): Make the mangling scheme robust. Support demangling.
+  beginManglingWithoutPrefix();
+
+  Buffer << "AD__" << name << '_';
+  switch (kind) {
+  case AutoDiffDerivativeFunctionKind::JVP:
+    Buffer << "_jvp_";
+    break;
+  case AutoDiffDerivativeFunctionKind::VJP:
+    Buffer << "_vjp_";
+    break;
+  }
+  Buffer << config.getSILAutoDiffIndices().mangle();
+  if (config.derivativeGenericSignature) {
+    Buffer << '_';
+    appendGenericSignature(config.derivativeGenericSignature);
+  }
+
+  auto result = Storage.str().str();
+  Storage.clear();
+  return result;
+}
+
+std::string ASTMangler::mangleAutoDiffLinearMapHelper(
+    StringRef name, AutoDiffLinearMapKind kind, AutoDiffConfig config) {
+  // TODO(TF-20): Make the mangling scheme robust. Support demangling.
+  beginManglingWithoutPrefix();
+
+  Buffer << "AD__" << name << '_';
+  switch (kind) {
+  case AutoDiffLinearMapKind::Differential:
+    Buffer << "_differential_";
+    break;
+  case AutoDiffLinearMapKind::Pullback:
+    Buffer << "_pullback_";
+    break;
+  }
+  Buffer << config.getSILAutoDiffIndices().mangle();
+  if (config.derivativeGenericSignature) {
+    Buffer << '_';
+    appendGenericSignature(config.derivativeGenericSignature);
+  }
+
+  auto result = Storage.str().str();
+  Storage.clear();
+  return result;
+}
+
 std::string ASTMangler::mangleSILDifferentiabilityWitnessKey(
     SILDifferentiabilityWitnessKey key) {
   // TODO(TF-20): Make the mangling scheme robust. Support demangling.

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -751,6 +751,132 @@ void SILGenModule::postEmitFunction(SILDeclRef constant,
   LLVM_DEBUG(llvm::dbgs() << "lowered sil:\n";
              F->print(llvm::dbgs()));
   F->verify();
+
+  emitDifferentiabilityWitnessesForFunction(constant, F);
+}
+
+void SILGenModule::emitDifferentiabilityWitnessesForFunction(
+    SILDeclRef constant, SILFunction *F) {
+  // Visit `@differentiable` amd `@derivative` attributes and generate SIL
+  // differentiability witnesses.
+  // Skip if the SILDeclRef is a:
+  // - Default argument generator function.
+  // - Thunk.
+  if (!constant.hasDecl() || !constant.getAbstractFunctionDecl())
+    return;
+  if (constant.kind == SILDeclRef::Kind::DefaultArgGenerator ||
+      constant.isThunk())
+    return;
+  auto *AFD = constant.getAbstractFunctionDecl();
+  auto emitWitnesses = [&](DeclAttributes &Attrs) {
+    for (auto *diffAttr : Attrs.getAttributes<DifferentiableAttr>()) {
+      SILFunction *jvp = nullptr;
+      SILFunction *vjp = nullptr;
+      if (auto *jvpDecl = diffAttr->getJVPFunction())
+        jvp = getFunction(SILDeclRef(jvpDecl), ForDefinition);
+      if (auto *vjpDecl = diffAttr->getVJPFunction())
+        vjp = getFunction(SILDeclRef(vjpDecl), ForDefinition);
+      auto *resultIndices = IndexSubset::get(getASTContext(), 1, {0});
+      assert((!F->getLoweredFunctionType()->getSubstGenericSignature() ||
+              diffAttr->getDerivativeGenericSignature()) &&
+             "Type-checking should resolve derivative generic signatures for "
+             "all original SIL functions with generic signatures");
+      AutoDiffConfig config(diffAttr->getParameterIndices(), resultIndices,
+                            diffAttr->getDerivativeGenericSignature());
+      emitDifferentiabilityWitness(AFD, F, config, jvp, vjp, diffAttr);
+    }
+    for (auto *derivAttr : Attrs.getAttributes<DerivativeAttr>()) {
+      SILFunction *jvp = nullptr;
+      SILFunction *vjp = nullptr;
+      switch (derivAttr->getDerivativeKind()) {
+      case AutoDiffDerivativeFunctionKind::JVP:
+        jvp = F;
+        break;
+      case AutoDiffDerivativeFunctionKind::VJP:
+        vjp = F;
+        break;
+      }
+      auto *origAFD = derivAttr->getOriginalFunction();
+      auto origDeclRef =
+          SILDeclRef(origAFD).asForeign(requiresForeignEntryPoint(origAFD));
+      auto *origFn = getFunction(origDeclRef, NotForDefinition);
+      auto derivativeGenSig = AFD->getGenericSignature();
+      auto *resultIndices = IndexSubset::get(getASTContext(), 1, {0});
+      AutoDiffConfig config(derivAttr->getParameterIndices(), resultIndices,
+                            derivativeGenSig);
+      emitDifferentiabilityWitness(origAFD, origFn, config, jvp, vjp,
+                                   derivAttr);
+    }
+  };
+  if (auto *accessor = dyn_cast<AccessorDecl>(AFD))
+    if (accessor->isGetter())
+      emitWitnesses(accessor->getStorage()->getAttrs());
+  emitWitnesses(AFD->getAttrs());
+}
+
+void SILGenModule::emitDifferentiabilityWitness(
+    AbstractFunctionDecl *originalAFD, SILFunction *originalFunction,
+    const AutoDiffConfig &config, SILFunction *jvp, SILFunction *vjp,
+    const DeclAttribute *attr) {
+  assert(isa<DifferentiableAttr>(attr) || isa<DerivativeAttr>(attr));
+  auto *origFnType = originalAFD->getInterfaceType()->castTo<AnyFunctionType>();
+  auto origSilFnType = originalFunction->getLoweredFunctionType();
+  auto *silParamIndices =
+      autodiff::getLoweredParameterIndices(config.parameterIndices, origFnType);
+  // NOTE(TF-893): Extending capacity is necessary when `origSilFnType` has
+  // parameters corresponding to captured variables. These parameters do not
+  // appear in the type of `origFnType`.
+  // TODO: If posssible, change `autodiff::getLoweredParameterIndices` to
+  // take `CaptureInfo` into account.
+  if (origSilFnType->getNumParameters() > silParamIndices->getCapacity())
+    silParamIndices = silParamIndices->extendingCapacity(
+        getASTContext(), origSilFnType->getNumParameters());
+
+  // Get or create new SIL differentiability witness.
+  // Witness already exists when there are two `@derivative` attributes
+  // (registering JVP and VJP functions) for the same derivative function
+  // configuration.
+  // Witness JVP and VJP are set below.
+  AutoDiffConfig silConfig(silParamIndices, config.resultIndices,
+                           config.derivativeGenericSignature);
+  SILDifferentiabilityWitnessKey key{originalFunction->getName(), silConfig};
+  auto *diffWitness = M.lookUpDifferentiabilityWitness(key);
+  if (!diffWitness) {
+    // Strip external from linkage of original function.
+    // Necessary for Clang-imported functions, which have external linkage.
+    auto linkage = stripExternalFromLinkage(originalFunction->getLinkage());
+    diffWitness = SILDifferentiabilityWitness::createDefinition(
+        M, linkage, originalFunction, silConfig.parameterIndices,
+        silConfig.resultIndices, config.derivativeGenericSignature,
+        /*jvp*/ nullptr, /*vjp*/ nullptr,
+        /*isSerialized*/ hasPublicVisibility(originalFunction->getLinkage()),
+        attr);
+  }
+
+  // Set derivative function in differentiability witness.
+  auto setDerivativeInDifferentiabilityWitness =
+      [&](AutoDiffDerivativeFunctionKind kind, SILFunction *derivative) {
+        auto derivativeThunk = getOrCreateCustomDerivativeThunk(
+            derivative, originalFunction, silConfig, kind);
+        // Check for existing same derivative.
+        // TODO(TF-835): Remove condition below and simplify assertion to
+        // `!diffWitness->getDerivative(kind)` after `@derivative` attribute
+        // type-checking no longer generates implicit `@differentiable`
+        // attributes.
+        auto *existingDerivative = diffWitness->getDerivative(kind);
+        if (existingDerivative && existingDerivative == derivativeThunk)
+          return;
+        assert(!existingDerivative &&
+               "SIL differentiability witness already has a different existing "
+               "derivative");
+        diffWitness->setDerivative(kind, derivativeThunk);
+      };
+  if (jvp)
+    setDerivativeInDifferentiabilityWitness(AutoDiffDerivativeFunctionKind::JVP,
+                                            jvp);
+  if (vjp)
+    setDerivativeInDifferentiabilityWitness(AutoDiffDerivativeFunctionKind::VJP,
+                                            vjp);
 }
 
 void SILGenModule::

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -171,7 +171,59 @@ public:
   /// Determine whether the given class has any instance variables that
   /// need to be destroyed.
   bool hasNonTrivialIVars(ClassDecl *cd);
-  
+
+  /// Given an original function and a user-specified custom derivative
+  /// function, get or create a derivative thunk with the expected derivative
+  /// function type computed from the original function.
+  ///
+  /// To achieve the expected derivative type, the thunk may perform
+  /// self-reordering, reabstraction, or both.
+  ///
+  /// Self-reordering is done for canonicalizing the types of derivative
+  /// functions for instance methods wrt `self`. We want users to define
+  /// derivatives with the following AST function types:
+  ///
+  /// JVP:
+  /// - Takes `Self` as first parameter.
+  /// - Returns differential taking `Self.Tan` as first parameter.
+  ///
+  ///     (Self) -> (T, ...) -> (R, (Self.Tan, T.Tan, ...) -> R.Tan)
+  ///
+  /// VJP:
+  /// - Takes `Self` as first parameter.
+  /// - Returns pullback returning `Self.Tan` as first result.
+  ///
+  ///     (Self) -> (T, ...) -> (R, (R.Tan) -> (Self.Tan, T.Tan, ...))
+  ///
+  /// However, the curried `Self` parameter in the AST JVP/VJP function types
+  /// becomes the *last* parameter in the flattened parameter list of their
+  /// lowered SIL function types.
+  ///
+  /// JVP:
+  /// - Takes `Self` as *last* parameter.
+  /// - Returns differential taking `Self.Tan` as *first* parameter.
+  ///
+  ///     $(T, ..., Self) -> (R, (Self.Tan, T.Tan, ...) -> R.Tan)
+  ///
+  /// VJP:
+  /// - Takes `Self` as *last* parameter.
+  /// - Returns pullback returning `Self.Tan` as *first* result.
+  ///
+  ///     $(T, ..., Self) -> (R, (R.Tan) -> (Self.Tan, T.Tan, ...))
+  ///
+  /// This leads to a parameter ordering inconsistency, and would require the
+  /// differentiation transform to handle "wrt `self` instance method
+  /// derivatives" specially. However, canonicalization during SILGen makes the
+  /// parameter ordering uniform for "instance method derivatives wrt self" and
+  /// simplifies the transform rules.
+  ///
+  /// If `self` must be reordered, reorder it so that it appears as:
+  /// - The last parameter in the returned differential.
+  /// - The last result in the returned pullback.
+  SILFunction *getOrCreateCustomDerivativeThunk(
+      SILFunction *customDerivativeFn, SILFunction *originalFn,
+      const AutoDiffConfig &config, AutoDiffDerivativeFunctionKind kind);
+
   /// Determine whether we need to emit an ivar destroyer for the given class.
   /// An ivar destroyer is needed if a superclass of this class may define a
   /// failing designated initializer.
@@ -341,6 +393,20 @@ public:
                               CanType baseTy,
                               DeclContext *useDC,
                               bool forPropertyDescriptor);
+
+  /// Emit all differentiability witnesses for the given function, visiting its
+  /// `@differentiable` and `@derivative` attributes.
+  void emitDifferentiabilityWitnessesForFunction(SILDeclRef constant,
+                                                 SILFunction *F);
+
+  /// Emit the differentiability witness for the given original function
+  /// declaration and SIL function, autodiff configuration, and JVP and VJP
+  /// functions (null if undefined).
+  void emitDifferentiabilityWitness(AbstractFunctionDecl *originalAFD,
+                                    SILFunction *originalFunction,
+                                    const AutoDiffConfig &config,
+                                    SILFunction *jvp, SILFunction *vjp,
+                                    const DeclAttribute *diffAttr);
 
   /// Known functions for bridging.
   SILDeclRef getStringToNSStringFn();

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1858,6 +1858,23 @@ public:
                                        SILType escapingFnTy);
 
   //===--------------------------------------------------------------------===//
+  // Differentiation thunks
+  //===--------------------------------------------------------------------===//
+
+  /// Get or create a thunk for reabstracting and self-reordering
+  /// differentials/pullbacks returned by user-defined JVP/VJP functions, and
+  /// apply it to the given differential/pullback.
+  ///
+  /// If `reorderSelf` is true, reorder self so that it appears as:
+  /// - The last parameter, for differentials.
+  /// - The last result, for pullbacks.
+  ManagedValue getThunkedAutoDiffLinearMap(ManagedValue linearMap,
+                                           AutoDiffLinearMapKind linearMapKind,
+                                           CanSILFunctionType fromType,
+                                           CanSILFunctionType toType,
+                                           bool reorderSelf);
+
+  //===--------------------------------------------------------------------===//
   // Declarations
   //===--------------------------------------------------------------------===//
   

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -82,9 +82,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "Initialization.h"
+#include "LValue.h"
+#include "RValue.h"
 #include "SILGen.h"
 #include "SILGenFunction.h"
+#include "SILGenFunctionBuilder.h"
 #include "Scope.h"
+#include "swift/AST/ASTMangler.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/ExistentialLayout.h"
@@ -95,9 +100,6 @@
 #include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/TypeLowering.h"
-#include "Initialization.h"
-#include "LValue.h"
-#include "RValue.h"
 #include "llvm/Support/Compiler.h"
 
 using namespace swift;
@@ -1619,6 +1621,10 @@ static ManagedValue applyTrivialConversions(SILGenFunction &SGF,
                                             SILType outerType) {
   auto innerASTTy = innerValue.getType().getASTType();
   auto outerASTTy = outerType.getASTType();
+  if (innerASTTy->hasArchetype())
+    innerASTTy = innerASTTy->mapTypeOutOfContext()->getCanonicalType();
+  if (outerASTTy->hasArchetype())
+    outerASTTy = outerASTTy->mapTypeOutOfContext()->getCanonicalType();
 
   if (innerASTTy == outerASTTy) {
     return innerValue;
@@ -3473,6 +3479,501 @@ SILGenFunction::createWithoutActuallyEscapingClosure(
                            noEscapingFunctionValue.getValue()));
 
   return thunkedFn;
+}
+
+/// Given a value, extracts all elements to `result` from this value if it's a
+/// tuple. Otherwise, add this value directly to `result`.
+static void extractAllElements(SILValue val, SILLocation loc,
+                               SILBuilder &builder,
+                               SmallVectorImpl<SILValue> &result) {
+  auto &fn = builder.getFunction();
+  auto tupleType = val->getType().getAs<TupleType>();
+  if (!tupleType) {
+    result.push_back(val);
+    return;
+  }
+  if (!fn.hasOwnership()) {
+    for (auto i : range(tupleType->getNumElements()))
+      result.push_back(builder.createTupleExtract(loc, val, i));
+    return;
+  }
+  if (tupleType->getNumElements() == 0)
+    return;
+  builder.emitDestructureValueOperation(loc, val, result);
+}
+
+/// Given a range of elements, joins these into a single value. If there's
+/// exactly one element, returns that element. Otherwise, creates a tuple using
+/// a `tuple` instruction.
+static SILValue joinElements(ArrayRef<SILValue> elements, SILBuilder &builder,
+                             SILLocation loc) {
+  if (elements.size() == 1)
+    return elements.front();
+  return builder.createTuple(loc, elements);
+}
+
+/// Adapted from `SILGenModule::getOrCreateReabstractionThunk`.
+ManagedValue SILGenFunction::getThunkedAutoDiffLinearMap(
+    ManagedValue linearMap, AutoDiffLinearMapKind linearMapKind,
+    CanSILFunctionType fromType, CanSILFunctionType toType, bool reorderSelf) {
+  // Compute the thunk type.
+  SubstitutionMap interfaceSubs;
+  GenericEnvironment *genericEnv = nullptr;
+  // Ignore subst types.
+  CanType inputSubstType, outputSubstType;
+  CanType dynamicSelfType;
+  fromType = fromType->getUnsubstitutedType(getModule());
+  toType = toType->getUnsubstitutedType(getModule());
+  auto thunkType =
+      buildThunkType(fromType, toType, inputSubstType, outputSubstType,
+                     genericEnv, interfaceSubs, dynamicSelfType);
+  assert(!dynamicSelfType && "Dynamic self type not handled");
+  auto thunkDeclType =
+      thunkType->getWithExtInfo(thunkType->getExtInfo().withNoEscape(false));
+
+  // Get the thunk name.
+  auto fromInterfaceType = fromType->mapTypeOutOfContext()->getCanonicalType();
+  auto toInterfaceType = toType->mapTypeOutOfContext()->getCanonicalType();
+  Mangle::ASTMangler mangler;
+  std::string name = mangler.mangleReabstractionThunkHelper(
+      thunkType, fromInterfaceType, toInterfaceType, Type(),
+      getModule().getSwiftModule());
+  // TODO(TF-685): Use principled thunk mangling.
+  switch (linearMapKind) {
+  case AutoDiffLinearMapKind::Differential:
+    name += "_differential";
+    break;
+  case AutoDiffLinearMapKind::Pullback:
+    name += "_pullback";
+    break;
+  }
+  name = "AD__" + name;
+  if (reorderSelf)
+    name += "_self_reordering";
+  name += "_thunk";
+
+  // Create the thunk.
+  auto loc = F.getLocation();
+  SILGenFunctionBuilder fb(SGM);
+  auto *thunk = fb.getOrCreateSharedFunction(
+      loc, name, thunkDeclType, IsBare, IsTransparent, IsSerialized,
+      ProfileCounter(), IsReabstractionThunk, IsNotDynamic);
+
+  // Partially-apply the thunk to `linearMap` and return the thunked value.
+  auto getThunkedResult = [&]() {
+    auto linearMapFnType = linearMap.getType().castTo<SILFunctionType>();
+    auto linearMapUnsubstFnType =
+        linearMapFnType->getUnsubstitutedType(getModule());
+    if (linearMapFnType != linearMapUnsubstFnType) {
+      auto unsubstType =
+          SILType::getPrimitiveObjectType(linearMapUnsubstFnType);
+      linearMap = B.createConvertFunction(loc, linearMap, unsubstType,
+                                          /*withoutActuallyEscaping*/ false);
+    }
+    auto thunkedFn = createPartialApplyOfThunk(
+        *this, loc, thunk, interfaceSubs, dynamicSelfType, toType, linearMap);
+    if (!toType->isNoEscape())
+      return thunkedFn;
+    // Handle escaping to noescape conversion.
+    return B.createConvertEscapeToNoEscape(
+        loc, thunkedFn, SILType::getPrimitiveObjectType(toType));
+  };
+
+  if (!thunk->empty())
+    return getThunkedResult();
+  thunk->setGenericEnvironment(genericEnv);
+
+  SILGenFunction thunkSGF(SGM, *thunk, FunctionDC);
+  SmallVector<ManagedValue, 4> params;
+  SmallVector<SILArgument *, 4> thunkIndirectResults;
+  thunkSGF.collectThunkParams(loc, params, &thunkIndirectResults);
+
+  SILFunctionConventions fromConv(fromType, getModule());
+  SILFunctionConventions toConv(toType, getModule());
+  assert(toConv.useLoweredAddresses());
+
+  SmallVector<ManagedValue, 4> thunkArguments;
+  for (auto *indRes : thunkIndirectResults)
+    thunkArguments.push_back(ManagedValue::forLValue(indRes));
+  thunkArguments.append(params.begin(), params.end());
+  SmallVector<SILParameterInfo, 4> toParameters(toConv.getParameters().begin(),
+                                                toConv.getParameters().end());
+  SmallVector<SILResultInfo, 4> toResults(toConv.getResults().begin(),
+                                          toConv.getResults().end());
+  // Handle self reordering.
+  // - For pullbacks: reorder result infos.
+  //   - If self is indirect, reorder indirect results.
+  //   - If self is direct, reorder direct results after `apply` is generated.
+  // - For differentials: reorder parameter infos and arguments.
+  auto numIndirectResults = thunkIndirectResults.size();
+  if (reorderSelf && linearMapKind == AutoDiffLinearMapKind::Pullback &&
+      toResults.size() > 1) {
+    auto toSelfResult = toResults.back();
+    if (toSelfResult.isFormalIndirect() && numIndirectResults > 1) {
+      // Before: [ind_res1, ind_res2, ..., ind_res_self, arg1, arg2, ..., pb]
+      //  After: [ind_res_self, ind_res1, ind_res2, ..., arg1, arg2, ..., pb]
+      std::rotate(thunkArguments.begin(),
+                  thunkArguments.begin() + numIndirectResults - 1,
+                  thunkArguments.begin() + numIndirectResults);
+      // Before: [ind_res1, ind_res2, ..., ind_res_self]
+      //  After: [ind_res_self, ind_res1, ind_res2, ...]
+      std::rotate(thunkIndirectResults.begin(), thunkIndirectResults.end() - 1,
+                  thunkIndirectResults.end());
+    }
+    std::rotate(toResults.begin(), toResults.end() - 1, toResults.end());
+  }
+  if (reorderSelf && linearMapKind == AutoDiffLinearMapKind::Differential &&
+      thunkArguments.size() > 1) {
+    // Before: [ind_res1, ind_res2, ..., arg1, arg2, ..., arg_self, df]
+    //  After: [ind_res1, ind_res2, ..., arg_self, arg1, arg2, ..., df]
+    std::rotate(thunkArguments.begin() + numIndirectResults,
+                thunkArguments.end() - 2, thunkArguments.end() - 1);
+    // Before: [arg1, arg2, ..., arg_self]
+    //  After: [arg_self, arg1, arg2, ...]
+    std::rotate(toParameters.begin(), toParameters.end() - 1,
+                toParameters.end());
+  }
+
+  // Correctness assertions.
+#ifndef NDEBUG
+  assert(toType->getNumParameters() == fromType->getNumParameters());
+  for (unsigned paramIdx : range(toType->getNumParameters())) {
+    auto fromParam = fromConv.getParameters()[paramIdx];
+    auto toParam = toParameters[paramIdx];
+    assert(fromParam.getInterfaceType() == toParam.getInterfaceType());
+  }
+  assert(fromType->getNumResults() == toType->getNumResults());
+  for (unsigned resIdx : range(toType->getNumResults())) {
+    auto fromRes = fromConv.getResults()[resIdx];
+    auto toRes = toResults[resIdx];
+    assert(fromRes.getInterfaceType() == toRes.getInterfaceType());
+  }
+#endif // NDEBUG
+
+  // Gather arguments.
+  SmallVector<SILValue, 4> arguments;
+  auto toArgIter = thunkArguments.begin();
+  auto useNextArgument = [&]() {
+    auto nextArgument = *toArgIter++;
+    arguments.push_back(nextArgument.getValue());
+  };
+
+  SmallVector<AllocStackInst *, 4> localAllocations;
+  auto createAllocStack = [&](SILType type) {
+    auto *alloc = thunkSGF.B.createAllocStack(loc, type);
+    localAllocations.push_back(alloc);
+    return alloc;
+  };
+
+  // Handle indirect results.
+  for (unsigned resIdx : range(toType->getNumResults())) {
+    auto fromRes = fromConv.getResults()[resIdx];
+    auto toRes = toResults[resIdx];
+    // No abstraction mismatch.
+    if (fromRes.isFormalIndirect() == toRes.isFormalIndirect()) {
+      // If result types are indirect, directly pass as next argument.
+      if (toRes.isFormalIndirect())
+        useNextArgument();
+      continue;
+    }
+    // Convert indirect result to direct result.
+    if (fromRes.isFormalIndirect()) {
+      SILType resultTy = fromConv.getSILType(fromRes);
+      assert(resultTy.isAddress());
+      auto *indRes = createAllocStack(resultTy);
+      arguments.push_back(indRes);
+      continue;
+    }
+    // Convert direct result to indirect result.
+    // Increment thunk argument iterator; reabstraction handled later.
+    toArgIter++;
+  }
+
+  // Reabstract parameters.
+  for (unsigned paramIdx : range(toType->getNumParameters())) {
+    auto fromParam = fromConv.getParameters()[paramIdx];
+    auto toParam = toParameters[paramIdx];
+    // No abstraction mismatch. Directly use next argument.
+    if (fromParam.isFormalIndirect() == toParam.isFormalIndirect()) {
+      useNextArgument();
+      continue;
+    }
+    // Convert indirect parameter to direct parameter.
+    if (fromParam.isFormalIndirect()) {
+      auto paramTy = fromConv.getSILType(fromType->getParameters()[paramIdx]);
+      if (!paramTy.hasArchetype())
+        paramTy = thunk->mapTypeIntoContext(paramTy);
+      assert(paramTy.isAddress());
+      auto toArg = (*toArgIter++).getValue();
+      auto *buf = createAllocStack(toArg->getType());
+      thunkSGF.B.createStore(loc, toArg, buf, StoreOwnershipQualifier::Init);
+      arguments.push_back(buf);
+      continue;
+    }
+    // Convert direct parameter to indirect parameter.
+    assert(toParam.isFormalIndirect());
+    auto toArg = (*toArgIter++).getValue();
+    auto load = thunkSGF.emitManagedLoadBorrow(loc, toArg);
+    arguments.push_back(load.getValue());
+  }
+
+  auto *linearMapArg = thunk->getArgumentsWithoutIndirectResults().back();
+  auto *apply = thunkSGF.B.createApply(loc, linearMapArg, SubstitutionMap(),
+                                       arguments, /*isNonThrowing*/ false);
+
+  // Get return elements.
+  SmallVector<SILValue, 4> results;
+  // Extract all direct results.
+  SmallVector<SILValue, 4> directResults;
+  extractAllElements(apply, loc, thunkSGF.B, directResults);
+
+  // Handle self reordering.
+  // For pullbacks: rotate direct results if self is direct.
+  if (reorderSelf && linearMapKind == AutoDiffLinearMapKind::Pullback) {
+    auto fromSelfResult = fromConv.getResults().front();
+    auto toSelfResult = toConv.getResults().back();
+    assert(fromSelfResult.getInterfaceType() ==
+           toSelfResult.getInterfaceType());
+    // Before: [dir_res_self, dir_res1, dir_res2, ...]
+    //  After: [dir_res1, dir_res2, ..., dir_res_self]
+    if (toSelfResult.isFormalDirect() && fromSelfResult.isFormalDirect() &&
+        directResults.size() > 1) {
+      std::rotate(directResults.begin(), directResults.begin() + 1,
+                  directResults.end());
+    }
+  }
+
+  auto fromDirResultsIter = directResults.begin();
+  auto fromIndResultsIter = apply->getIndirectSILResults().begin();
+  auto toIndResultsIter = thunkIndirectResults.begin();
+  // Reabstract results.
+  for (unsigned resIdx : range(toType->getNumResults())) {
+    auto fromRes = fromConv.getResults()[resIdx];
+    auto toRes = toResults[resIdx];
+    // No abstraction mismatch.
+    if (fromRes.isFormalIndirect() == toRes.isFormalIndirect()) {
+      // If result types are direct, add call result as direct thunk result.
+      if (toRes.isFormalDirect())
+        results.push_back(*fromDirResultsIter++);
+      // If result types are indirect, increment indirect result iterators.
+      else {
+        ++fromIndResultsIter;
+        ++toIndResultsIter;
+      }
+      continue;
+    }
+    // Load direct results from indirect results.
+    if (fromRes.isFormalIndirect()) {
+      auto indRes = *fromIndResultsIter++;
+      auto *load = thunkSGF.B.createLoad(loc, indRes,
+                                         LoadOwnershipQualifier::Unqualified);
+      results.push_back(load);
+      continue;
+    }
+    // Store direct results to indirect results.
+    assert(toRes.isFormalIndirect());
+    SILType resultTy = toConv.getSILType(toRes);
+    assert(resultTy.isAddress());
+    auto indRes = *toIndResultsIter++;
+    thunkSGF.emitSemanticStore(loc, *fromDirResultsIter++, indRes,
+                               thunkSGF.getTypeLowering(resultTy),
+                               IsInitialization);
+  }
+  auto retVal = joinElements(results, thunkSGF.B, loc);
+
+  // Emit cleanups.
+  thunkSGF.Cleanups.emitCleanupsForReturn(CleanupLocation::get(loc),
+                                          NotForUnwind);
+
+  // Deallocate local allocations.
+  for (auto *alloc : llvm::reverse(localAllocations))
+    thunkSGF.B.createDeallocStack(loc, alloc);
+
+  // Create return.
+  thunkSGF.B.createReturn(loc, retVal);
+  return getThunkedResult();
+}
+
+// SWIFT_ENABLE_TENSORFLOW
+SILFunction *SILGenModule::getOrCreateCustomDerivativeThunk(
+    SILFunction *customDerivativeFn, SILFunction *originalFn,
+    const AutoDiffConfig &config, AutoDiffDerivativeFunctionKind kind) {
+  auto indices = config.getSILAutoDiffIndices();
+
+  auto customDerivativeFnTy = customDerivativeFn->getLoweredFunctionType();
+  auto *thunkGenericEnv = customDerivativeFnTy->getSubstGenericSignature()
+                              ? customDerivativeFnTy->getSubstGenericSignature()
+                                    ->getGenericEnvironment()
+                              : nullptr;
+
+  auto origFnTy = originalFn->getLoweredFunctionType();
+  CanGenericSignature derivativeCanGenSig;
+  if (auto derivativeGenSig = config.derivativeGenericSignature)
+    derivativeCanGenSig = derivativeGenSig->getCanonicalSignature();
+  auto thunkFnTy = origFnTy->getAutoDiffDerivativeFunctionType(
+      indices.parameters, indices.source, kind, Types,
+      LookUpConformanceInModule(M.getSwiftModule()), derivativeCanGenSig);
+  assert(!thunkFnTy->getExtInfo().hasContext());
+
+  // TODO(TF-685): Use principled thunk mangling.
+  // Do not simply reuse reabstraction thunk mangling.
+  Mangle::ASTMangler mangler;
+  auto name = getASTContext()
+                  .getIdentifier(mangler.mangleAutoDiffDerivativeFunctionHelper(
+                      originalFn->getName(), kind, config))
+                  .str();
+
+  auto loc = customDerivativeFn->getLocation();
+  SILGenFunctionBuilder fb(*this);
+  // This thunk is publicly exposed and cannot be transparent.
+  // Instead, mark it as "always inline" for optimization.
+  auto *thunk = fb.getOrCreateFunction(
+      loc, name, customDerivativeFn->getLinkage(), thunkFnTy, IsBare,
+      IsNotTransparent, customDerivativeFn->isSerialized(),
+      customDerivativeFn->isDynamicallyReplaceable(),
+      customDerivativeFn->getEntryCount(), IsThunk,
+      customDerivativeFn->getClassSubclassScope());
+  thunk->setInlineStrategy(AlwaysInline);
+  if (!thunk->empty())
+    return thunk;
+  thunk->setGenericEnvironment(thunkGenericEnv);
+
+  SILGenFunction thunkSGF(*this, *thunk, customDerivativeFn->getDeclContext());
+  SmallVector<ManagedValue, 4> params;
+  SmallVector<SILArgument *, 4> indirectResults;
+  thunkSGF.collectThunkParams(loc, params, &indirectResults);
+
+  auto *fnRef = thunkSGF.B.createFunctionRef(loc, customDerivativeFn);
+  auto fnRefType =
+      thunkSGF.F.mapTypeIntoContext(fnRef->getType().mapTypeOutOfContext())
+          .castTo<SILFunctionType>()
+          ->getUnsubstitutedType(M);
+
+  // Special support for thunking class initializer derivatives.
+  //
+  // User-defined custom derivatives take a metatype as the last parameter:
+  // - `$(Param0, Param1, ..., @thick Class.Type) -> (...)`
+  // But class initializers take an allocated instance as the last parameter:
+  // - `$(Param0, Param1, ..., @owned Class) -> (...)`
+  //
+  // Adjust forwarded arguments:
+  // - Pop the last `@owned Class` argument.
+  // - Create a `@thick Class.Type` value and pass it as the last argument.
+  auto *origAFD =
+      cast<AbstractFunctionDecl>(originalFn->getDeclContext()->getAsDecl());
+  bool isClassInitializer =
+      isa<ConstructorDecl>(origAFD) &&
+      origAFD->getDeclContext()->getSelfClassDecl() &&
+      SILDeclRef(origAFD, SILDeclRef::Kind::Initializer).mangle() ==
+          originalFn->getName();
+  if (isClassInitializer) {
+    params.pop_back();
+    auto *classDecl = thunkFnTy->getParameters()
+                          .back()
+                          .getInterfaceType()
+                          ->getClassOrBoundGenericClass();
+    assert(classDecl && "Expected last argument to have class type");
+    auto classMetatype = MetatypeType::get(
+        classDecl->getDeclaredInterfaceType(), MetatypeRepresentation::Thick);
+    auto canClassMetatype = classMetatype->getCanonicalType();
+    auto *metatype = thunkSGF.B.createMetatype(
+        loc, SILType::getPrimitiveObjectType(canClassMetatype));
+    params.push_back(ManagedValue::forUnmanaged(metatype));
+  }
+
+  // Collect thunk arguments, converting ownership.
+  SmallVector<SILValue, 8> arguments;
+  for (auto *indRes : indirectResults)
+    arguments.push_back(indRes);
+  forwardFunctionArguments(thunkSGF, loc, fnRefType, params, arguments);
+
+  // Apply function argument.
+  auto apply = thunkSGF.emitApplyWithRethrow(
+      loc, fnRef, /*substFnType*/ fnRef->getType(),
+      thunk->getForwardingSubstitutionMap(), arguments);
+
+  // Self reordering thunk is necessary if wrt at least two parameters,
+  // including self.
+  auto shouldReorderSelf = [&]() {
+    if (!originalFn->hasSelfParam())
+      return false;
+    auto selfParamIndex = origFnTy->getNumParameters() - 1;
+    if (!indices.isWrtParameter(selfParamIndex))
+      return false;
+    return indices.parameters->getNumIndices() > 1;
+  };
+  bool reorderSelf = shouldReorderSelf();
+
+  // If self ordering is not necessary and linear map types are unchanged,
+  // return the `apply` instruction.
+  auto linearMapFnType = cast<SILFunctionType>(
+      thunk
+          ->mapTypeIntoContext(
+              fnRefType->getResults().back().getInterfaceType())
+          ->getCanonicalType());
+  auto targetLinearMapFnType =
+      thunk
+          ->mapTypeIntoContext(
+              thunkFnTy->getResults().back().getSILStorageInterfaceType())
+          .castTo<SILFunctionType>();
+  SILFunctionConventions conv(thunkFnTy, thunkSGF.getModule());
+
+  // Create return instruction in the thunk, first deallocating local
+  // allocations and freeing arguments-to-free.
+  auto createReturn = [&](SILValue retValue) {
+    // Emit cleanups.
+    thunkSGF.Cleanups.emitCleanupsForReturn(CleanupLocation::get(loc),
+                                            NotForUnwind);
+    // Create return.
+    thunkSGF.B.createReturn(loc, retValue);
+  };
+
+  if (!reorderSelf && linearMapFnType == targetLinearMapFnType) {
+    createReturn(apply);
+    return thunk;
+  }
+
+  // Otherwise, apply reabstraction/self reordering thunk to linear map.
+  SmallVector<SILValue, 8> directResults;
+  extractAllElements(apply, loc, thunkSGF.B, directResults);
+  auto linearMap = thunkSGF.emitManagedRValueWithCleanup(directResults.back());
+  assert(linearMap.getType().castTo<SILFunctionType>() == linearMapFnType);
+  auto linearMapKind = kind.getLinearMapKind();
+  linearMap = thunkSGF.getThunkedAutoDiffLinearMap(
+      linearMap, linearMapKind, linearMapFnType, targetLinearMapFnType,
+      reorderSelf);
+
+  SILType linearMapResultType =
+      thunk
+          ->getLoweredType(
+              thunk->mapTypeIntoContext(conv.getSILResultType()).getASTType())
+          .getCategoryType(conv.getSILResultType().getCategory());
+  if (auto tupleType = linearMapResultType.getAs<TupleType>()) {
+    linearMapResultType = SILType::getPrimitiveType(
+        tupleType->getElementTypes().back()->getCanonicalType(),
+        conv.getSILResultType().getCategory());
+  }
+
+  auto targetLinearMapUnsubstFnType =
+      SILType::getPrimitiveObjectType(targetLinearMapFnType);
+  if (linearMap.getType() != targetLinearMapUnsubstFnType) {
+    linearMap = thunkSGF.B.createConvertFunction(
+        loc, linearMap, targetLinearMapUnsubstFnType,
+        /*withoutActuallyEscaping*/ false);
+  }
+
+  // Return original results and thunked differential/pullback.
+  if (directResults.size() > 1) {
+    auto originalDirectResults = ArrayRef<SILValue>(directResults).drop_back(1);
+    auto originalDirectResult =
+        joinElements(originalDirectResults, thunkSGF.B, apply.getLoc());
+    auto thunkResult = joinElements(
+        {originalDirectResult, linearMap.forward(thunkSGF)}, thunkSGF.B, loc);
+    createReturn(thunkResult);
+  } else {
+    createReturn(linearMap.forward(thunkSGF));
+  }
+  return thunk;
 }
 
 ManagedValue Transform::transformFunction(ManagedValue fn,

--- a/test/AutoDiff/SILGen/sil_differentiability_witness_silgen.swift
+++ b/test/AutoDiff/SILGen/sil_differentiability_witness_silgen.swift
@@ -1,0 +1,252 @@
+// RUN: %target-swift-frontend -emit-silgen -enable-experimental-differentiable-programming %s | %target-sil-opt -enable-experimental-differentiable-programming | %FileCheck %s
+// REQUIRES: differentiable_programming
+
+// Test SIL differentiability witness SIL generation.
+
+import _Differentiation
+
+// Dummy `Differentiable`-conforming type.
+public struct DummyTangentVector: Differentiable & AdditiveArithmetic {
+  public static var zero: Self { Self() }
+  public static func + (_: Self, _: Self) -> Self { Self() }
+  public static func - (_: Self, _: Self) -> Self { Self() }
+  public typealias TangentVector = Self
+}
+
+// Test public non-generic function.
+// SIL differentiability witness:
+// - Has public linkage (implicit).
+// - Has no `where` clause.
+
+public func foo(_ x: Float) -> Float { x }
+
+@derivative(of: foo)
+public func foo_jvp(_ x: Float) -> (value: Float, differential: (Float) -> Float) {
+  (x, { $0 })
+}
+
+@derivative(of: foo)
+public func foo_vjp(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  (x, { $0 })
+}
+
+// CHECK-LABEL: // differentiability witness for foo(_:)
+// CHECK-NEXT: sil_differentiability_witness [serialized] [parameters 0] [results 0] @$s36sil_differentiability_witness_silgen3fooyS2fF : $@convention(thin) (Float) -> Float {
+// CHECK-NEXT:   jvp: @AD__$s36sil_differentiability_witness_silgen3fooyS2fF__jvp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK-NEXT:   vjp: @AD__$s36sil_differentiability_witness_silgen3fooyS2fF__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK-NEXT: }
+
+// Test internal non-generic function.
+// SIL differentiability witness:
+// - Has hidden linkage.
+// - Has no `where` clause.
+// - Has only VJP.
+
+func bar<T>(_ x: Float, _ y: T) -> Float { x }
+
+@derivative(of: bar)
+public func bar_jvp<T>(_ x: Float, _ y: T) -> (value: Float, differential: (Float) -> Float) {
+  (x, { $0 })
+}
+
+// CHECK-LABEL: // differentiability witness for bar<A>(_:_:)
+// CHECK-NEXT: sil_differentiability_witness hidden [parameters 0] [results 0] <τ_0_0> @$s36sil_differentiability_witness_silgen3baryS2f_xtlF : $@convention(thin) <T> (Float, @in_guaranteed T) -> Float {
+// CHECK-NEXT:   jvp: @AD__$s36sil_differentiability_witness_silgen3baryS2f_xtlF__jvp_src_0_wrt_0_l : $@convention(thin) <τ_0_0> (Float, @in_guaranteed τ_0_0) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK-NEXT: }
+
+// Test internal generic function.
+// SIL differentiability witness:
+// - Has hidden linkage.
+// - Has `where` clause.
+
+func generic<T>(_ x: T, _ y: Float) -> T { x }
+
+@derivative(of: generic)
+func generic_jvp<T: Differentiable>(_ x: T, _ y: Float) -> (
+  value: T, differential: (T.TangentVector, Float) -> T.TangentVector
+) {
+  (x, { dx, dy in dx })
+}
+
+@derivative(of: generic)
+func generic_vjp<T: Differentiable>(_ x: T, _ y: Float) -> (
+  value: T, pullback: (T.TangentVector) -> (T.TangentVector, Float)
+) {
+  (x, { ($0, .zero) })
+}
+
+// CHECK-LABEL: // differentiability witness for generic<A>(_:_:)
+// CHECK-NEXT: sil_differentiability_witness hidden [parameters 0 1] [results 0] <τ_0_0 where τ_0_0 : Differentiable> @$s36sil_differentiability_witness_silgen7genericyxx_SftlF : $@convention(thin) <T> (@in_guaranteed T, Float) -> @out T {
+// CHECK-NEXT:   jvp: @AD__$s36sil_differentiability_witness_silgen7genericyxx_SftlF__jvp_src_0_wrt_0_1_{{s|16_Differentiation}}14DifferentiableRzl : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0, Float) -> @out τ_0_1 for <τ_0_0.TangentVector, τ_0_0.TangentVector>)
+// CHECK-NEXT:   vjp: @AD__$s36sil_differentiability_witness_silgen7genericyxx_SftlF__vjp_src_0_wrt_0_1_{{s|16_Differentiation}}14DifferentiableRzl : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> (@out τ_0_1, Float) for <τ_0_0.TangentVector, τ_0_0.TangentVector>)
+// CHECK-NEXT: }
+
+public struct Foo: Differentiable {
+  public typealias TangentVector = DummyTangentVector
+  public mutating func move(along _: TangentVector) {}
+
+  @differentiable
+  public var x: Float
+
+// CHECK-LABEL: // differentiability witness for Foo.x.getter
+// CHECK-NEXT: sil_differentiability_witness [serialized] [parameters 0] [results 0] @$s36sil_differentiability_witness_silgen3FooV1xSfvg : $@convention(method) (Foo) -> Float {
+// CHECK-NEXT: }
+
+  @differentiable
+  public init(_ x: Float) {
+    self.x = x
+  }
+
+// CHECK-LABEL: // differentiability witness for Foo.init(_:)
+// CHECK-NEXT: sil_differentiability_witness [serialized] [parameters 0] [results 0] @$s36sil_differentiability_witness_silgen3FooVyACSfcfC : $@convention(method) (Float, @thin Foo.Type) -> Foo {
+// CHECK-NEXT: }
+
+  @differentiable
+  public func method() -> Float {
+    x
+  }
+
+// CHECK-LABEL: // differentiability witness for Foo.method()
+// CHECK-NEXT: sil_differentiability_witness [serialized] [parameters 0] [results 0] @$s36sil_differentiability_witness_silgen3FooV6methodSfyF : $@convention(method) (Foo) -> Float {
+// CHECK-NEXT: }
+
+  @differentiable
+  public var computedProperty: Float {
+    x
+  }
+
+// CHECK-LABEL: // differentiability witness for Foo.computedProperty.getter
+// CHECK-NEXT: sil_differentiability_witness [serialized] [parameters 0] [results 0] @$s36sil_differentiability_witness_silgen3FooV16computedPropertySfvg : $@convention(method) (Foo) -> Float {
+// CHECK-NEXT: }
+
+  @differentiable
+  public subscript() -> Float {
+    x
+  }
+
+// CHECK-LABEL: // differentiability witness for Foo.subscript.getter
+// CHECK-NEXT: sil_differentiability_witness [serialized] [parameters 0] [results 0] @$s36sil_differentiability_witness_silgen3FooVSfycig : $@convention(method) (Foo) -> Float {
+// CHECK-NEXT: }
+}
+
+// Test function that is differentiable wrt subset of its parameters:
+// - wrt x: explicit @differentiable attribute, with no custom derivative specified
+// - wrt y: explicit @differentiable attribute, with custom derivative specified
+// - wrt x, y: custom deriviative specified, with no explicit @differentiable attribute
+// Has a tuple argument to verify that indices are correctly lowered to SIL.
+
+@differentiable(wrt: x)
+public func wrt_subset(_ tup: (Int, Int), _ x: Float, _ y: Float) -> Float {
+  return 0
+}
+
+@derivative(of: wrt_subset, wrt: y)
+public func wrt_subset_jvp_wrt_y(_ tup: (Int, Int), _ x: Float, _ y: Float) -> (value: Float, differential: (Float) -> Float) {
+  return (0, { $0 })
+}
+
+@derivative(of: wrt_subset, wrt: y)
+public func wrt_subset_vjp_wrt_y(_ tup: (Int, Int), _ x: Float, _ y: Float) -> (value: Float, pullback: (Float) -> Float) {
+  return (0, { $0 })
+}
+
+@derivative(of: wrt_subset)
+public func wrt_subset_jvp_wrt_x_y(_ tup: (Int, Int), _ x: Float, _ y: Float) -> (value: Float, differential: (Float, Float) -> Float) {
+  return (0, { $0 + $1 })
+}
+
+@derivative(of: wrt_subset)
+public func wrt_subset_vjp_wrt_x_y(_ tup: (Int, Int), _ x: Float, _ y: Float) -> (value: Float, pullback: (Float) -> (Float, Float)) {
+  return (0, { ($0, $0) })
+}
+
+// CHECK-LABEL: // differentiability witness for wrt_subset(_:_:_:)
+// CHECK-NEXT: sil_differentiability_witness [serialized] [parameters 2] [results 0] @$s36sil_differentiability_witness_silgen10wrt_subsetySfSi_Sit_S2ftF : $@convention(thin) (Int, Int, Float, Float) -> Float {
+// CHECK-NEXT: }
+
+// CHECK-LABEL: // differentiability witness for wrt_subset(_:_:_:)
+// CHECK-NEXT: sil_differentiability_witness [serialized] [parameters 3] [results 0] @$s36sil_differentiability_witness_silgen10wrt_subsetySfSi_Sit_S2ftF : $@convention(thin) (Int, Int, Float, Float) -> Float {
+// CHECK-NEXT:   jvp:
+// CHECK-NEXT:   vjp:
+// CHECK-NEXT: }
+
+// CHECK-LABEL: // differentiability witness for wrt_subset(_:_:_:)
+// CHECK-NEXT: sil_differentiability_witness [serialized] [parameters 2 3] [results 0] @$s36sil_differentiability_witness_silgen10wrt_subsetySfSi_Sit_S2ftF : $@convention(thin) (Int, Int, Float, Float) -> Float {
+// CHECK-NEXT:   jvp:
+// CHECK-NEXT:   vjp:
+// CHECK-NEXT: }
+
+// Test original function with `@differentiable` and `@derivative` attributes.
+
+protocol P1: Differentiable {}
+extension P1 {
+  @differentiable // derivative generic signature: none
+  func foo() -> Float { 1 }
+}
+extension P1 {
+  @derivative(of: foo) // derivative generic signature: `<P1 where Self: P1>`
+  func vjpFoo() -> (value: Float, pullback: (Float) -> (TangentVector)) {
+    fatalError()
+  }
+}
+
+// CHECK-LABEL: // differentiability witness for P1.foo()
+// CHECK-NEXT: sil_differentiability_witness hidden [parameters 0] [results 0] <τ_0_0 where τ_0_0 : P1> @$s36sil_differentiability_witness_silgen2P1PAAE3fooSfyF : $@convention(method) <Self where Self : P1> (@in_guaranteed Self) -> Float {
+// CHECK-NEXT:   vjp: @AD__$s36sil_differentiability_witness_silgen2P1PAAE3fooSfyF__vjp_src_0_wrt_0_36sil_differentiability_witness_silgen2P1Rzl : $@convention(method) <τ_0_0 where τ_0_0 : P1> (@in_guaranteed τ_0_0) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (Float) -> @out τ_0_0 for <τ_0_0.TangentVector>)
+// CHECK-NEXT: }
+
+// Test custom derivatives of functions with generic signatures and `@differentiable` attributes.
+
+@differentiable
+@_silgen_name("genericWithDiffAttr")
+public func genericWithDiffAttr<T: Differentiable>(_ x: T) -> T { fatalError() }
+
+@derivative(of: genericWithDiffAttr)
+public func vjpGenericWithDiffAttr<T: Differentiable>(_ x: T)
+  -> (value: T, pullback: (T.TangentVector) -> T.TangentVector)
+{
+  fatalError()
+}
+
+// CHECK-LABEL: // differentiability witness for genericWithDiffAttr
+// CHECK-NEXT: sil_differentiability_witness [serialized] [parameters 0] [results 0] <τ_0_0 where τ_0_0 : Differentiable> @genericWithDiffAttr : $@convention(thin) <T where T : Differentiable> (@in_guaranteed T) -> @out T {
+// CHECK-NEXT:   vjp
+// CHECK-NEXT: }
+
+// CHECK-NOT: // differentiability witness for genericWithDiffAttr
+
+@differentiable(where T: Differentiable)
+@_silgen_name("genericWithConstrainedDifferentiable")
+public func genericWithConstrainedDifferentiable<T>(_ x: T) -> T { fatalError() }
+
+@derivative(of: genericWithConstrainedDifferentiable)
+public func vjpGenericWithConstrainedDifferentiable<T: Differentiable>(_ x: T)
+  -> (value: T, pullback: (T.TangentVector) -> T.TangentVector)
+{
+  fatalError()
+}
+
+// CHECK-LABEL: // differentiability witness for genericWithConstrainedDifferentiable
+// CHECK-NEXT: sil_differentiability_witness [serialized] [parameters 0] [results 0] <τ_0_0 where τ_0_0 : Differentiable> @genericWithConstrainedDifferentiable : $@convention(thin) <T> (@in_guaranteed T) -> @out T {
+// CHECK-NEXT:   vjp
+// CHECK-NEXT: }
+
+// CHECK-NOT: // differentiability witness for genericWithConstrainedDifferentiable
+
+public extension Differentiable {
+  @differentiable
+  @_silgen_name("protocolExtensionWithDiffAttr")
+  func protocolExtensionWithDiffAttr() -> Self { self }
+
+  @derivative(of: protocolExtensionWithDiffAttr)
+  func protocolExtensionWithDiffAttr() -> (value: Self, pullback: (TangentVector) -> TangentVector) {
+    fatalError("unimplemented")
+  }
+}
+
+// CHECK-LABEL: // differentiability witness for protocolExtensionWithDiffAttr
+// CHECK-NEXT: sil_differentiability_witness [serialized] [parameters 0] [results 0] <τ_0_0 where τ_0_0 : Differentiable> @protocolExtensionWithDiffAttr : $@convention(method) <Self where Self : Differentiable> (@in_guaranteed Self) -> @out Self {
+// CHECK-NEXT:   vjp
+// CHECK-NEXT: }
+
+// CHECK-NOT: // differentiability witness for protocolExtensionWithDiffAttr


### PR DESCRIPTION
In the AST, `@differentiable` and `@derivative` attributes represent function differentiability.
In SIL, [differentiability witnesses](https://github.com/apple/swift/blob/master/docs/SIL.rst#differentiability-witnesses) represent function differentiability.

Generate SIL differentiability witnesses from `@differentiable` and `@derivative` attributes.

---

Add SILGen utilities for:
- Emiting differentiability witnesses.
- Creating derivative function thunks, which are used as entries in differentiability witnesses.

When users register a custom derivative function, it is necessary to create a thunk with the expected derivative type computed from the original function's type. This is important for consistent typing and consistent differentiability witness entry mangling.

---

Example:

```swift
func id<T>(_ x: T) -> T { x }

@derivative(of: id)
func derivative<T: Differentiable>(_ x: __owned T) -> (
  value: T, pullback: (T.TangentVector) -> T.TangentVector
) { fatalError() }

// SIL details:
//
//   Original function type: $@convention(thin) <T> (@in_guaranteed T) -> @out T
//   Actual derivative type: $@convention(thin) <T where T : Differentiable> (@in T) -> (@out T, @owned @callee_guaranteed (@in_guaranteed T.TangentVector) -> @out T.TangentVector)
// Expected derivative type: $@convention(thin) <T where T : Differentiable> (@in_guaranteed T) -> (@out T, @owned @callee_guaranteed (@in_guaranteed T.TangentVector) -> @out T.TangentVector)
//
// In this case, the derivative thunk performs reabstraction.
// For original functions that are methods, derivative thunks also perform parameter reordering.
// See `SILGenModule::getOrCreateCustomDerivativeThunk` documentation for details.
```

SILGen emits:
```sil
// differentiability witness for id<A>(_:)
sil_differentiability_witness hidden [parameters 0] [results 0] <T where T : Differentiable> @$s3foo2idyxxlF : $@convent
ion(thin) <T> (@in_guaranteed T) -> @out T {
  vjp: @AD__$s3foo2idyxxlF__vjp_src_0_wrt_0_s14DifferentiableRzl : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiabl
e> (@in_guaranteed τ_0_0) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector) -> @out τ_0_0.T
angentVector)
}

// derivative thunk for id<A>(_:) [parameters 0] [results 0]
sil hidden [thunk] [always_inline] [ossa] @AD__$s3foo2idyxxlF__vjp_src_0_wrt_0_s14DifferentiableRzl : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector) -> @out τ_0_0.TangentVector) {
// %0                                             // user: %5
// %1                                             // user: %4
bb0(%0 : $*τ_0_0, %1 : $*τ_0_0):
  // function_ref derivative<A>(_:)
  %2 = function_ref @$s3foo10derivativeyx5value_13TangentVectorQzAEc8pullbacktxns14DifferentiableRzlF : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@in τ_0_0) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector) -> @out τ_0_0.TangentVector) // user: %5
  %3 = alloc_stack $τ_0_0                        // users: %6, %5, %4
  copy_addr %1 to [initialization] %3 : $*τ_0_0  // id: %4
  %5 = apply %2<τ_0_0>(%0, %3) : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@in τ_0_0) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector) -> @out τ_0_0.TangentVector) // user: %7
  dealloc_stack %3 : $*τ_0_0                     // id: %6
  return %5 : $@callee_guaranteed (@in_guaranteed τ_0_0.TangentVector) -> @out τ_0_0.TangentVector // id: %7
} // end sil function 'AD__$s3foo2idyxxlF__vjp_src_0_wrt_0_s14DifferentiableRzl'
```

---

Resolves TF-1138.
Incremental improvements are tracked via `TODO` comments.