### PR TITLE
Factor `appendAnyProtocolConformance` out of the conformance mangling.

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -352,6 +352,9 @@ protected:
 
   void appendProtocolConformance(const ProtocolConformance *conformance);
   void appendProtocolConformanceRef(const RootProtocolConformance *conformance);
+  void appendAnyProtocolConformance(CanGenericSignature genericSig,
+                                    CanType conformingType,
+                                    ProtocolConformanceRef conformance);
   void appendConcreteProtocolConformance(
                                         const ProtocolConformance *conformance);
   void appendDependentProtocolConformance(const ConformanceAccessPath &path);

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2757,6 +2757,35 @@ void ASTMangler::appendDependentProtocolConformance(
   }
 }
 
+void ASTMangler::appendAnyProtocolConformance(
+                                           CanGenericSignature genericSig,
+                                           CanType conformingType,
+                                           ProtocolConformanceRef conformance) {
+  if (conformingType->isTypeParameter()) {
+    assert(genericSig && "Need a generic signature to resolve conformance");
+    auto path = genericSig->getConformanceAccessPath(conformingType,
+                                                     conformance.getAbstract());
+    appendDependentProtocolConformance(path);
+  } else if (auto opaqueType = conformingType->getAs<OpaqueTypeArchetypeType>()) {
+    GenericSignature opaqueSignature = opaqueType->getBoundSignature();
+    GenericTypeParamType *opaqueTypeParam = opaqueSignature->getGenericParams().back();
+    ConformanceAccessPath conformanceAccessPath =
+        opaqueSignature->getConformanceAccessPath(opaqueTypeParam,
+                                                  conformance.getAbstract());
+
+    // Append the conformance access path with the signature of the opaque type.
+    {
+      llvm::SaveAndRestore<CanGenericSignature> savedSignature(
+          CurGenericSignature, opaqueSignature.getCanonicalSignature());
+      appendDependentProtocolConformance(conformanceAccessPath);
+    }
+    appendType(conformingType);
+    appendOperator("HO");
+  } else {
+    appendConcreteProtocolConformance(conformance.getConcrete());
+  }
+}
+
 void ASTMangler::appendConcreteProtocolConformance(
                                       const ProtocolConformance *conformance) {
   auto module = conformance->getDeclContext()->getParentModule();
@@ -2797,30 +2826,15 @@ void ASTMangler::appendConcreteProtocolConformance(
       CanType canType = type->getCanonicalType(CurGenericSignature);
       auto proto =
         conditionalReq.getSecondType()->castTo<ProtocolType>()->getDecl();
-      if (canType->isTypeParameter()) {
-        assert(CurGenericSignature &&
-               "Need a generic signature to resolve conformance");
-        auto conformanceAccessPath =
-            CurGenericSignature->getConformanceAccessPath(type, proto);
-        appendDependentProtocolConformance(conformanceAccessPath);
-      } else if (auto opaqueType = canType->getAs<OpaqueTypeArchetypeType>()) {
-        GenericSignature opaqueSignature = opaqueType->getBoundSignature();
-        GenericTypeParamType *opaqueTypeParam = opaqueSignature->getGenericParams().back();
-        ConformanceAccessPath conformanceAccessPath =
-            opaqueSignature->getConformanceAccessPath(opaqueTypeParam, proto);
-
-        // Append the conformance access path with the signature of the opaque type.
-        {
-          llvm::SaveAndRestore<CanGenericSignature> savedSignature(
-              CurGenericSignature, opaqueSignature.getCanonicalSignature());
-          appendDependentProtocolConformance(conformanceAccessPath);
-        }
-        appendType(canType);
-        appendOperator("HO");
+      
+      ProtocolConformanceRef conformance;
+      
+      if (canType->isTypeParameter() || canType->is<OpaqueTypeArchetypeType>()){
+        conformance = ProtocolConformanceRef(proto);
       } else {
-        auto conditionalConf = module->lookupConformance(canType, proto);
-        appendConcreteProtocolConformance(conditionalConf.getConcrete());
+        conformance = module->lookupConformance(canType, proto);
       }
+      appendAnyProtocolConformance(CurGenericSignature, canType, conformance);
       appendListSeparator(firstRequirement);
       break;
     }

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -304,6 +304,9 @@ AvailabilityContext ASTContext::getSwift52Availability() {
 AvailabilityContext ASTContext::getSwift53Availability() {
   auto target = LangOpts.Target;
 
+  if (target.getArchName() == "arm64e")
+    return AvailabilityContext::alwaysAvailable();
+
   if (target.isMacOSX() ) {
     return AvailabilityContext(
         VersionRange::allGTE(llvm::VersionTuple(10, 99, 0)));

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -308,15 +308,7 @@ std::string IRGenMangler::mangleSymbolNameForMangledConformanceAccessorString(
   if (genericSig)
     appendGenericSignature(genericSig);
 
-  if (type)
-    appendType(type);
-
-  if (conformance.isConcrete())
-    appendConcreteProtocolConformance(conformance.getConcrete());
-  else if (conformance.isAbstract())
-    appendProtocolName(conformance.getAbstract());
-  else
-    assert(conformance.isInvalid() && "Unknown protocol conformance");
+  appendAnyProtocolConformance(genericSig, type, conformance);
   return finalize();
 }
 

--- a/test/IRGen/opaque_result_type.swift
+++ b/test/IRGen/opaque_result_type.swift
@@ -34,7 +34,7 @@ extension String: P {
   // -- mangled underlying type
   // CHECK-SAME:         @"symbolic Si"
   // -- conformance to O
-  // CHECK-SAME:         @"get_witness_table S2i18opaque_result_type1OHpyHC
+  // CHECK-SAME:         @"get_witness_table Si18opaque_result_type1OHpyHC
   // CHECK-SAME:  }>
   func poo() -> some O {
     return 0
@@ -65,7 +65,7 @@ public class C: P, Q {
   // -- mangled underlying type
   // CHECK-SAME:         @"symbolic Si"
   // -- conformance to O
-  // CHECK-SAME:         @"get_witness_table S2i18opaque_result_type1OHpyHC
+  // CHECK-SAME:         @"get_witness_table Si18opaque_result_type1OHpyHC
   // CHECK-SAME:  }>
   func poo() -> some O {
     return 0
@@ -79,9 +79,9 @@ public class C: P, Q {
   // -- mangled underlying type
   // CHECK-SAME:         @"symbolic Si"
   // -- conformance to O
-  // CHECK-SAME:         @"get_witness_table S2i18opaque_result_type1OHpyHC
+  // CHECK-SAME:         @"get_witness_table Si18opaque_result_type1OHpyHC
   // -- conformance to O2
-  // CHECK-SAME:         @"get_witness_table S2i18opaque_result_type2O2HpyHC
+  // CHECK-SAME:         @"get_witness_table Si18opaque_result_type2O2HpyHC
   // CHECK-SAME:  }>
   func qoo() -> some O & O2 {
     return 0
@@ -96,7 +96,7 @@ public class C: P, Q {
 // -- mangled underlying type
 // CHECK-SAME:         @"symbolic SS"
 // -- conformance to P
-// CHECK-SAME:         @"get_witness_table S2S18opaque_result_type1PHpyHC
+// CHECK-SAME:         @"get_witness_table SS18opaque_result_type1PHpyHC
 // CHECK-SAME:  }>
 func foo(x: String) -> some P {
   return x
@@ -110,7 +110,7 @@ func foo(x: String) -> some P {
 // -- mangled underlying type
 // CHECK-SAME:         @"symbolic _____ 18opaque_result_type1CC"
 // -- conformance to Q
-// CHECK-SAME:         @"get_witness_table 18opaque_result_type1CCAcA1QHPyHC
+// CHECK-SAME:         @"get_witness_table 18opaque_result_type1CCAA1QHPyHC
 // CHECK-SAME:  }>
 func bar(y: C) -> some Q {
   return y

--- a/test/IRGen/opaque_result_type_metadata_peephole.swift
+++ b/test/IRGen/opaque_result_type_metadata_peephole.swift
@@ -12,9 +12,9 @@ func foo() -> some P {
 // The mangled underlying type in foo2 ought to look through foo()'s opaque type
 // CHECK-LABEL: @"$s36opaque_result_type_metadata_peephole4foo2QryFQOMQ" = {{.*}} constant
 // DEFAULT-SAME:            @"symbolic Si"
-// DEFAULT-SAME:            @"get_witness_table S2i36opaque_result_type_metadata_external1PHpyHC
+// DEFAULT-SAME:            @"get_witness_table Si36opaque_result_type_metadata_external1PHpyHC
 // IMPLICIT-DYNAMIC-SAME:   @"symbolic _____yQo_ 36opaque_result_type_metadata_peephole3fooQryFQO"
-// IMPLICIT-DYNAMIC-SAME:   @"get_witness_table 36opaque_result_type_metadata_peephole3fooQryFQOyQo_0a1_b1_c1_D9_external1P
+// IMPLICIT-DYNAMIC-SAME:   @"get_witness_table x36opaque_result_type_metadata_external1PHD1_0a1_b1_c1_D9_peephole3fooQryFQOyQo_HO
 func foo2() -> some P {
   return foo()
 }


### PR DESCRIPTION
We want to be able to use mangled names to refer to protocol conformances in addition to type
metadata. Provide an ASTMangler method that can render an arbitrary abstract or concrete
`ProtocolConformanceRef`, factoring it out of the code used to emit conditional conformance arguments
in `appendProtocolConformance`.