### PR TITLE
[nfc] add dominance info as member to mandatory combine

### DIFF
--- a/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
@@ -80,6 +80,9 @@ class MandatoryCombiner final
   InstModCallbacks instModCallbacks;
   SmallVectorImpl<SILInstruction *> &createdInstructions;
   SmallVector<SILInstruction *, 16> instructionsPendingDeletion;
+      
+  DominanceAnalysis dominanceAnalysis;
+  std::unique_ptr<DominanceInfo> dominanceInfo;
 
 public:
   MandatoryCombiner(SmallVectorImpl<SILInstruction *> &createdInstructions)
@@ -177,6 +180,8 @@ bool MandatoryCombiner::doOneIteration(SILFunction &function,
   madeChange = false;
 
   addReachableCodeToWorklist(function);
+
+  dominanceInfo = dominanceAnalysis.newFunctionAnalysis(&function);
 
   while (!worklist.isEmpty()) {
     auto *instruction = worklist.pop_back_val();


### PR DESCRIPTION
<!-- What's in this pull request? -->
This change updates mandatory combine to have dominance info and dominance analysis as members. Now, they are only updated once per function per iteration. This could help the performance of #30463 and #30549.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
