### PR TITLE
[stdlib] Avoid malloc_size on OpenBSD.

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -19,6 +19,7 @@
 #ifndef SWIFT_STDLIB_SHIMS_LIBCSHIMS_H
 #define SWIFT_STDLIB_SHIMS_LIBCSHIMS_H
 
+#include "SwiftStdbool.h"
 #include "SwiftStdint.h"
 #include "SwiftStddef.h"
 #include "Visibility.h"
@@ -104,12 +105,14 @@ static inline int _swift_stdlib_memcmp(const void *s1, const void *s2,
 
 // Non-standard extensions
 #if defined(__APPLE__)
+#define HAS_MALLOC_SIZE 1
 static inline __swift_size_t _swift_stdlib_malloc_size(const void *ptr) {
   extern __swift_size_t malloc_size(const void *);
   return malloc_size(ptr);
 }
 #elif defined(__linux__) || defined(__CYGWIN__) || defined(__ANDROID__) \
    || defined(__HAIKU__) || defined(__FreeBSD__) || defined(__wasi__)
+#define HAS_MALLOC_SIZE 1
 static inline __swift_size_t _swift_stdlib_malloc_size(const void *ptr) {
 #if defined(__ANDROID__)
 #if !defined(__ANDROID_API__) || __ANDROID_API__ >= 17
@@ -121,13 +124,22 @@ static inline __swift_size_t _swift_stdlib_malloc_size(const void *ptr) {
   return malloc_usable_size(CONST_CAST(void *, ptr));
 }
 #elif defined(_WIN32)
+#define HAS_MALLOC_SIZE 1
 static inline __swift_size_t _swift_stdlib_malloc_size(const void *ptr) {
   extern __swift_size_t _msize(void *ptr);
   return _msize(CONST_CAST(void *, ptr));
 }
 #else
-#error No malloc_size analog known for this platform/libc.
+#define HAS_MALLOC_SIZE 0
+
+static inline __swift_size_t _swift_stdlib_malloc_size(const void *ptr) {
+  return 0;
+}
 #endif
+
+static inline __swift_bool _swift_stdlib_has_malloc_size() {
+  return HAS_MALLOC_SIZE != 0;
+}
 
 // Math library functions
 static inline SWIFT_ALWAYS_INLINE

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -268,11 +268,15 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
          realMinimumCapacity._builtinWordValue, Element.self)
 
       let storageAddr = UnsafeMutableRawPointer(Builtin.bridgeToRawPointer(_storage))
-      let endAddr = storageAddr + _swift_stdlib_malloc_size(storageAddr)
-      let realCapacity = endAddr.assumingMemoryBound(to: Element.self) - firstElementAddress
-
-      _initStorageHeader(
-        count: uninitializedCount, capacity: realCapacity)
+      if let allocSize = _mallocSize(ofAllocation: storageAddr) {
+        let endAddr = storageAddr + allocSize
+        let realCapacity = endAddr.assumingMemoryBound(to: Element.self) - firstElementAddress
+        _initStorageHeader(
+          count: uninitializedCount, capacity: realCapacity)
+      } else {
+        _initStorageHeader(
+          count: uninitializedCount, capacity: realMinimumCapacity)
+      }
     }
   }
 

--- a/stdlib/public/core/Shims.swift
+++ b/stdlib/public/core/Shims.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -14,9 +14,9 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#if _runtime(_ObjC)
 import SwiftShims
 
+#if _runtime(_ObjC)
 @inlinable
 internal func _makeSwiftNSFastEnumerationState()
    -> _SwiftNSFastEnumerationState {
@@ -36,3 +36,8 @@ internal var _fastEnumerationStorageMutationsTarget: CUnsignedLong = 0
 internal let _fastEnumerationStorageMutationsPtr =
   UnsafeMutablePointer<CUnsignedLong>(Builtin.addressof(&_fastEnumerationStorageMutationsTarget))
 #endif
+
+@usableFromInline @_alwaysEmitIntoClient
+internal func _mallocSize(ofAllocation ptr: UnsafeRawPointer) -> Int? {
+  return _swift_stdlib_has_malloc_size() ? _swift_stdlib_malloc_size(ptr) : nil
+}


### PR DESCRIPTION
malloc introspection is a platform feature that is unavailable on
OpenBSD. There is no workaround for the feature, so simply avoid calling
it in this case. It is assumed on OpenBSD that the tail allocator will
allocate the amount of memory requested of it, and nothing more.