### PR TITLE
[tools] Add include path for iconv on OpenBSD.

### DIFF
--- a/tools/swift-ide-test/CMakeLists.txt
+++ b/tools/swift-ide-test/CMakeLists.txt
@@ -15,6 +15,9 @@ if(LibXml2_FOUND)
   include_directories(SYSTEM ${LIBXML2_INCLUDE_DIR})
   target_link_libraries(swift-ide-test PRIVATE ${LIBXML2_LIBRARIES})
   target_compile_definitions(swift-ide-test PRIVATE SWIFT_HAVE_LIBXML=1)
+  if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "OpenBSD" AND NOT CMAKE_CROSSCOMPILING)
+    include_directories(SYSTEM "/usr/local/include")
+  endif()
 endif()
 
 # Create a symlink for swift-api-dump.py in the bin directory


### PR DESCRIPTION
swift-ide-test depends on libxml2. On OpenBSD, libxml2 is configured to use
iconv out of the box, but unlike other platforms, iconv is not part of
the base installation; it is a separate package, and so resides in
/usr/local/include. This should be added to the search path on this
platform to ensure correct header resolution.