### PR TITLE
SIL: reduced test case for SIL verifier failure

### DIFF
--- a/test/SIL/destroy-dominator.swift
+++ b/test/SIL/destroy-dominator.swift
@@ -1,0 +1,22 @@
+// RUN: %swiftc -sil-verify-all -O -c %s -o /dev/null
+// REQUIRES: asserts
+
+public struct S {
+  let args: [Substring]
+  let arg: Substring
+
+  enum Error: Swift.Error {
+    case Case
+  }
+
+  public init(arg: String) throws {
+    args = arg.split(separator: "\n")
+    guard args.count > 0 else { throw Error.Case }
+
+    let parts = args[0].split(separator: " ")
+    guard parts.count > 2 else { throw Error.Case }
+
+    self.arg = parts[1]
+  }
+}
+


### PR DESCRIPTION
This is a reduced test case from the Foundation test suite which
triggers a SIL verifier error on Windows at least:

```
SIL verification failed: instruction isn't dominated by its operand: properlyDominates(valueI, I)
Verifying instruction:
     %54 = struct_element_addr %53 : $*S, #S.args // users: %130, %116, %55
->   destroy_addr %54 : $*Array<Substring>        // id: %130
```

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
