### PR TITLE
Disable two failing opaque result type tests

### DIFF
--- a/test/IRGen/opaque_result_type.swift
+++ b/test/IRGen/opaque_result_type.swift
@@ -2,6 +2,9 @@
 // RUN: %{python} %utils/chex.py < %s > %t/opaque_result_type.swift
 // RUN: %target-swift-frontend -enable-implicit-dynamic -disable-availability-checking -emit-ir %t/opaque_result_type.swift | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-NODEBUG %t/opaque_result_type.swift
 
+// FIXME: Disabled because compilation is crashing in arm64e
+// REQUIRES: rdar60734429
+
 public protocol O {
   func bar()
 }

--- a/test/Interpreter/opaque_return_type_protocol_ext.swift
+++ b/test/Interpreter/opaque_return_type_protocol_ext.swift
@@ -4,6 +4,9 @@
 
 // REQUIRES: executable_test
 
+// FIXME: Disabled because compilation is crashing in arm64e
+// REQUIRES: rdar60734429
+
 @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
 protocol P {
   associatedtype AT


### PR DESCRIPTION
See e.g. https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-device-non_executable/29. The Interpreter test doesn’t actually crash in any Swift CI configuration, but its compilation step crashes in the same way with arm64e.
