### PR TITLE
[AutoDiff upstream] Add derivative function SILDeclRefs.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -1088,8 +1088,9 @@ Declaration References
 ::
 
   sil-decl-ref ::= '#' sil-identifier ('.' sil-identifier)* sil-decl-subref?
-  sil-decl-subref ::= '!' sil-decl-subref-part ('.' sil-decl-lang)?
+  sil-decl-subref ::= '!' sil-decl-subref-part ('.' sil-decl-lang)? ('.' sil-decl-autodiff)?
   sil-decl-subref ::= '!' sil-decl-lang
+  sil-decl-subref ::= '!' sil-decl-autodiff
   sil-decl-subref-part ::= 'getter'
   sil-decl-subref-part ::= 'setter'
   sil-decl-subref-part ::= 'allocator'
@@ -1102,6 +1103,10 @@ Declaration References
   sil-decl-subref-part ::= 'ivarinitializer'
   sil-decl-subref-part ::= 'defaultarg' '.' [0-9]+
   sil-decl-lang ::= 'foreign'
+  sil-decl-autodiff ::= sil-decl-autodiff-kind '.' sil-decl-autodiff-indices
+  sil-decl-autodiff-kind ::= 'jvp'
+  sil-decl-autodiff-kind ::= 'vjp'
+  sil-decl-autodiff-indices ::= [SU]+
 
 Some SIL instructions need to reference Swift declarations directly. These
 references are introduced with the ``#`` sigil followed by the fully qualified

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -75,6 +75,42 @@ struct AutoDiffDerivativeFunctionKind {
   }
 };
 
+/// A derivative function configuration, uniqued in `ASTContext`.
+/// Identifies a specific derivative function given an original function.
+class AutoDiffDerivativeFunctionIdentifier : public llvm::FoldingSetNode {
+  const AutoDiffDerivativeFunctionKind kind;
+  IndexSubset *const parameterIndices;
+  GenericSignature derivativeGenericSignature;
+
+  AutoDiffDerivativeFunctionIdentifier(
+      AutoDiffDerivativeFunctionKind kind, IndexSubset *parameterIndices,
+      GenericSignature derivativeGenericSignature)
+      : kind(kind), parameterIndices(parameterIndices),
+        derivativeGenericSignature(derivativeGenericSignature) {}
+
+public:
+  AutoDiffDerivativeFunctionKind getKind() const { return kind; }
+  IndexSubset *getParameterIndices() const {
+    return parameterIndices;
+  }
+  GenericSignature getDerivativeGenericSignature() const {
+    return derivativeGenericSignature;
+  }
+
+  static AutoDiffDerivativeFunctionIdentifier *
+  get(AutoDiffDerivativeFunctionKind kind, IndexSubset *parameterIndices,
+      GenericSignature derivativeGenericSignature, ASTContext &C);
+
+  void Profile(llvm::FoldingSetNodeID &ID) {
+    ID.AddInteger(kind);
+    ID.AddPointer(parameterIndices);
+    CanGenericSignature derivativeCanGenSig;
+    if (derivativeGenericSignature)
+      derivativeCanGenSig = derivativeGenericSignature->getCanonicalSignature();
+    ID.AddPointer(derivativeCanGenSig.getPointer());
+  }
+};
+
 /// The kind of a differentiability witness function.
 struct DifferentiabilityWitnessFunctionKind {
   enum innerty : uint8_t {

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -504,6 +504,9 @@ ERROR(expected_sil_colon,none,
       "expected ':' before %0", (StringRef))
 ERROR(expected_sil_tuple_index,none,
       "expected tuple element index", ())
+ERROR(invalid_index_subset,none,
+      "invalid index subset; expected '[SU]+' where 'S' represents set indices "
+      "and 'U' represents unset indices", ())
 
 // SIL Values
 ERROR(sil_value_redefinition,none,

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -19,6 +19,15 @@
 
 using namespace swift;
 
+AutoDiffDerivativeFunctionKind::
+AutoDiffDerivativeFunctionKind(StringRef string) {
+  Optional<innerty> result =
+      llvm::StringSwitch<Optional<innerty>>(string)
+          .Case("jvp", JVP).Case("vjp", VJP);
+  assert(result && "Invalid string");
+  rawValue = *result;
+}
+
 DifferentiabilityWitnessFunctionKind::DifferentiabilityWitnessFunctionKind(
     StringRef string) {
   Optional<innerty> result = llvm::StringSwitch<Optional<innerty>>(string)

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1341,6 +1341,7 @@ static Optional<AccessorKind> getAccessorKind(StringRef ident) {
 
 ///  sil-decl-ref ::= '#' sil-identifier ('.' sil-identifier)* sil-decl-subref?
 ///  sil-decl-subref ::= '!' sil-decl-subref-part ('.' sil-decl-lang)?
+///                      ('.' sil-decl-autodiff)?
 ///  sil-decl-subref ::= '!' sil-decl-lang
 ///  sil-decl-subref-part ::= 'getter'
 ///  sil-decl-subref-part ::= 'setter'
@@ -1350,27 +1351,33 @@ static Optional<AccessorKind> getAccessorKind(StringRef ident) {
 ///  sil-decl-subref-part ::= 'destroyer'
 ///  sil-decl-subref-part ::= 'globalaccessor'
 ///  sil-decl-lang ::= 'foreign'
+///  sil-decl-autodiff ::= sil-decl-autodiff-kind '.' sil-decl-autodiff-indices
+///  sil-decl-autodiff-kind ::= 'jvp'
+///  sil-decl-autodiff-kind ::= 'vjp'
+///  sil-decl-autodiff-indices ::= [SU]+
 bool SILParser::parseSILDeclRef(SILDeclRef &Result,
                                 SmallVectorImpl<ValueDecl *> &values) {
   ValueDecl *VD;
   if (parseSILDottedPath(VD, values))
     return true;
 
-  // Initialize Kind and IsObjC.
+  // Initialize SILDeclRef components.
   SILDeclRef::Kind Kind = SILDeclRef::Kind::Func;
   bool IsObjC = false;
+  AutoDiffDerivativeFunctionIdentifier *DerivativeId = nullptr;
 
   if (!P.consumeIf(tok::sil_exclamation)) {
     // Construct SILDeclRef.
-    Result = SILDeclRef(VD, Kind, IsObjC);
+    Result = SILDeclRef(VD, Kind, IsObjC, DerivativeId);
     return false;
   }
 
-  // Handle sil-constant-kind-and-uncurry-level.
-  // ParseState indicates the value we just handled.
-  // 1 means we just handled Kind.
-  // We accept func|getter|setter|...|foreign when ParseState is 0;
-  // accept foreign when ParseState is 1.
+  // Handle SILDeclRef components. ParseState tracks the last parsed component.
+  //
+  // When ParseState is 0, accept kind (`func|getter|setter|...`) and set
+  // ParseState to 1.
+  //
+  // Always accept `foreign` and derivative function identifier.
   unsigned ParseState = 0;
   Identifier Id;
   do {
@@ -1439,15 +1446,47 @@ bool SILParser::parseSILDeclRef(SILDeclRef &Result,
       } else if (Id.str() == "foreign") {
         IsObjC = true;
         break;
-      } else
+      } else if (Id.str() == "jvp" || Id.str() == "vjp") {
+        IndexSubset *parameterIndices = nullptr;
+        GenericSignature derivativeGenSig;
+        // Parse derivative function kind.
+        AutoDiffDerivativeFunctionKind derivativeKind(Id.str());
+        if (!P.consumeIf(tok::period)) {
+          P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, ".");
+          return true;
+        }
+        // Parse parameter indices.
+        parameterIndices = IndexSubset::getFromString(
+            SILMod.getASTContext(), P.Tok.getText());
+        if (!parameterIndices) {
+          P.diagnose(P.Tok, diag::invalid_index_subset);
+          return true;
+        }
+        P.consumeToken();
+        // Parse derivative generic signature (optional).
+        if (P.Tok.is(tok::oper_binary_unspaced) && P.Tok.getText() == ".<") {
+          P.consumeStartingCharacterOfCurrentToken(tok::period);
+          // Create a new scope to avoid type redefinition errors.
+          Scope genericsScope(&P, ScopeKind::Generics);
+          auto *genericParams = P.maybeParseGenericParams().getPtrOrNull();
+          assert(genericParams);
+          auto *derivativeGenEnv = handleSILGenericParams(genericParams, &P.SF);
+          derivativeGenSig = derivativeGenEnv->getGenericSignature();
+        }
+        DerivativeId = AutoDiffDerivativeFunctionIdentifier::get(
+            derivativeKind, parameterIndices, derivativeGenSig,
+            SILMod.getASTContext());
         break;
+      } else {
+        break;
+      }
     } else
       break;
 
   } while (P.consumeIf(tok::period));
 
   // Construct SILDeclRef.
-  Result = SILDeclRef(VD, Kind, IsObjC);
+  Result = SILDeclRef(VD, Kind, IsObjC, DerivativeId);
   return false;
 }
 

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -114,12 +114,14 @@ bool swift::requiresForeignEntryPoint(ValueDecl *vd) {
 }
 
 SILDeclRef::SILDeclRef(ValueDecl *vd, SILDeclRef::Kind kind,
-                       bool isForeign)
-  : loc(vd), kind(kind), isForeign(isForeign), defaultArgIndex(0)
+                       bool isForeign,
+                       AutoDiffDerivativeFunctionIdentifier *derivativeId)
+  : loc(vd), kind(kind), isForeign(isForeign), defaultArgIndex(0),
+    derivativeFunctionIdentifier(derivativeId)
 {}
 
 SILDeclRef::SILDeclRef(SILDeclRef::Loc baseLoc, bool asForeign) 
-  : defaultArgIndex(0)
+  : defaultArgIndex(0), derivativeFunctionIdentifier(nullptr)
 {
   if (auto *vd = baseLoc.dyn_cast<ValueDecl*>()) {
     if (auto *fd = dyn_cast<FuncDecl>(vd)) {
@@ -845,7 +847,8 @@ SILDeclRef SILDeclRef::getNextOverriddenVTableEntry() const {
 SILDeclRef SILDeclRef::getOverriddenWitnessTableEntry() const {
   auto bestOverridden =
     getOverriddenWitnessTableEntry(cast<AbstractFunctionDecl>(getDecl()));
-  return SILDeclRef(bestOverridden, kind);
+  return SILDeclRef(bestOverridden, kind, isForeign,
+                    derivativeFunctionIdentifier);
 }
 
 AbstractFunctionDecl *SILDeclRef::getOverriddenWitnessTableEntry(

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -3080,6 +3080,45 @@ TypeConverter::getConstantInfo(TypeExpansionContext expansion,
     ::getUncachedSILFunctionTypeForConstant(*this, expansion, constant,
                                             loweredInterfaceType);
 
+  // If the constant refers to a derivative function, get the SIL type of the
+  // original function and use it to compute the derivative SIL type.
+  //
+  // This is necessary because the "lowered AST derivative function type" (BC)
+  // may differ from the "derivative type of the lowered original function type"
+  // (AD):
+  //
+  // +--------------------+       lowering      +--------------------+
+  // | AST orig.  fn type |  -------(A)------>  | SIL orig.  fn type |
+  // +--------------------+                     +--------------------+
+  //         |                                                |
+  //    (B, Sema)   getAutoDiffDerivativeFunctionType     (D, here)
+  //         V                                                V
+  // +--------------------+       lowering      +--------------------+
+  // | AST deriv. fn type |  -------(C)------>  | SIL deriv. fn type |
+  // +--------------------+                     +--------------------+
+  //
+  // (AD) does not always commute with (BC):
+  // - (BC) is the result of computing the AST derivative type (Sema), then
+  //   lowering it via SILGen. This is the default lowering behavior, but may
+  //   break SIL typing invariants because expected lowered derivative types are
+  //   computed from lowered original function types.
+  // - (AD) is the result of lowering the original function type, then computing
+  //   its derivative type. This is the expected lowered derivative type,
+  //   preserving SIL typing invariants.
+  //
+  // Always use (AD) to compute lowered derivative function types.
+  if (auto *derivativeId = constant.derivativeFunctionIdentifier) {
+    // Get lowered original function type.
+    auto origFnConstantInfo = getConstantInfo(
+        TypeExpansionContext::minimal(), constant.asAutoDiffOriginalFunction());
+    // Use it to compute lowered derivative function type.
+    auto *loweredIndices = autodiff::getLoweredParameterIndices(
+        derivativeId->getParameterIndices(), formalInterfaceType);
+    silFnType = origFnConstantInfo.SILFnType->getAutoDiffDerivativeFunctionType(
+        loweredIndices, /*resultIndex*/ 0, derivativeId->getKind(),
+        *this, LookUpConformanceInModule(&M));
+  }
+
   LLVM_DEBUG(llvm::dbgs() << "lowering type for constant ";
              constant.print(llvm::dbgs());
              llvm::dbgs() << "\n  formal type: ";

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -346,6 +346,23 @@ void SILDeclRef::print(raw_ostream &OS) const {
 
   if (isForeign)
     OS << (isDot ? '.' : '!')  << "foreign";
+
+  if (derivativeFunctionIdentifier) {
+    OS << ((isDot || isForeign) ? '.' : '!');
+    switch (derivativeFunctionIdentifier->getKind()) {
+    case AutoDiffDerivativeFunctionKind::JVP:
+      OS << "jvp.";
+      break;
+    case AutoDiffDerivativeFunctionKind::VJP:
+      OS << "vjp.";
+      break;
+    }
+    OS << derivativeFunctionIdentifier->getParameterIndices()->getString();
+    if (auto derivativeGenSig =
+            derivativeFunctionIdentifier->getDerivativeGenericSignature()) {
+      OS << "." << derivativeGenSig;
+    }
+  }
 }
 
 void SILDeclRef::dump() const {

--- a/test/AutoDiff/SIL/Parse/sildeclref_parse.sil
+++ b/test/AutoDiff/SIL/Parse/sildeclref_parse.sil
@@ -1,0 +1,35 @@
+// RUN: %target-sil-opt -enable-experimental-differentiable-programming %s -module-name=sildeclref_parse | %target-sil-opt -enable-experimental-differentiable-programming -module-name=sildeclref_parse | %FileCheck %s
+// REQUIRES: differentiable_programming
+
+// Parse AutoDiff derivative SILDeclRefs via `witness_method` instructions.
+// TODO(TF-1212): Also test `class_method` instructions.
+
+import Swift
+import _Differentiation
+
+protocol Protocol {
+  @differentiable(wrt: (x, y))
+  func f(_ x: Float, _ y: Float) -> Float
+}
+
+// CHECK-LABEL: sil hidden @witness_method
+sil hidden @witness_method : $@convention(thin) <T where T : Protocol> (@in T) -> () {
+bb0(%0 : $*T):
+  // CHECK: witness_method $T, #Protocol.f
+  %1 = witness_method $T, #Protocol.f : <Self where Self : Protocol> (Self) -> (Float, Float) -> Float : $@convention(witness_method: Protocol) <τ_0_0 where τ_0_0 : Protocol> (@in_guaranteed τ_0_0) -> (Float, Float) -> Float
+
+  // CHECK: witness_method $T, #Protocol.f!jvp.SSS
+  %2 = witness_method $T, #Protocol.f!jvp.SSS : <Self where Self : Protocol> (Self) -> (Float, Float) -> Float : $@convention(witness_method: Protocol) <τ_0_0 where τ_0_0 : Protocol> (@in_guaranteed τ_0_0) -> (Float, Float) -> Float
+
+  // CHECK: witness_method $T, #Protocol.f!jvp.UUS
+  %3 = witness_method $T, #Protocol.f!jvp.UUS : <Self where Self : Protocol> (Self) -> (Float, Float) -> Float : $@convention(witness_method: Protocol) <τ_0_0 where τ_0_0 : Protocol> (@in_guaranteed τ_0_0) -> (Float, Float) -> Float
+
+  // CHECK: witness_method $T, #Protocol.f!vjp.SSS
+  %4 = witness_method $T, #Protocol.f!vjp.SSS : <Self where Self : Protocol> (Self) -> (Float, Float) -> Float : $@convention(witness_method: Protocol) <τ_0_0 where τ_0_0 : Protocol> (@in_guaranteed τ_0_0) -> (Float, Float) -> Float
+
+  // CHECK: witness_method $T, #Protocol.f!vjp.UUS
+  %5 = witness_method $T, #Protocol.f!vjp.UUS : <Self where Self : Protocol> (Self) -> (Float, Float) -> Float : $@convention(witness_method: Protocol) <τ_0_0 where τ_0_0 : Protocol> (@in_guaranteed τ_0_0) -> (Float, Float) -> Float
+
+  %6 = tuple ()
+  return %6 : $()
+}


### PR DESCRIPTION
`@differentiable` attribute on protocol requirements and non-final class members
will produce derivative function entries in witness tables and vtables.

This patch adds an optional derivative function configuration
(`AutoDiffDerivativeFunctionIdentifier`) to `SILDeclRef` to represent these
derivative function entries.

Derivative function configurations consist of:
- A derivative function kind (JVP or VJP).
- Differentiability parameter indices.

```
sil-decl-ref ::= '#' sil-identifier ('.' sil-identifier)* sil-decl-subref?
sil-decl-subref ::= '!' sil-decl-subref-part ('.' sil-decl-lang)? ('.' sil-decl-autodiff)?
sil-decl-autodiff ::= sil-decl-autodiff-kind '.' sil-decl-autodiff-indices
ail-decl-autodiff-kind ::= 'jvp' | 'vjp'
sil-decl-autodiff-indices ::= [SU]+
                               ^~ 'S' is set, 'U' is unset
```

Resolves TF-1209.
Enables TF-1212: upstream derivative function entries in witness tables/vtables.

---

Derivative function `SILDeclRef` examples:
```swift
protocol Protocol {
  @differentiable(wrt: (x, y))
  func f(_ x: Float, _ y: Float) -> Float
}

sil hidden @witness_method : $@convention(thin) <T where T : Protocol> (@in T) -> () {
bb0(%0 : $*T):
  // Original function reference.
  %1 = witness_method $T, #Protocol.f : <Self where Self : Protocol> (Self) -> (Float, Float) -> Float : $@convention(witness_method: Protocol) <τ_0_0 where τ_0_0 : Protocol> (@in_guaranteed τ_0_0) -> (Float, Float) -> Float

  // Derivative function references.
  %2 = witness_method $T, #Protocol.f!jvp.SSS : <Self where Self : Protocol> (Self) -> (Float, Float) -> Float : $@convention(witness_method: Protocol) <τ_0_0 where τ_0_0 : Protocol> (@in_guaranteed τ_0_0) -> (Float, Float) -> Float
  %3 = witness_method $T, #Protocol.f!jvp.UUS : <Self where Self : Protocol> (Self) -> (Float, Float) -> Float : $@convention(witness_method: Protocol) <τ_0_0 where τ_0_0 : Protocol> (@in_guaranteed τ_0_0) -> (Float, Float) -> Float
  %4 = witness_method $T, #Protocol.f!vjp.SSS : <Self where Self : Protocol> (Self) -> (Float, Float) -> Float : $@convention(witness_method: Protocol) <τ_0_0 where τ_0_0 : Protocol> (@in_guaranteed τ_0_0) -> (Float, Float) -> Float
  %5 = witness_method $T, #Protocol.f!vjp.UUS : <Self where Self : Protocol> (Self) -> (Float, Float) -> Float : $@convention(witness_method: Protocol) <τ_0_0 where τ_0_0 : Protocol> (@in_guaranteed τ_0_0) -> (Float, Float) -> Float

  %6 = tuple ()
  return %6 : $()
}
```