### PR TITLE
[build-script] Add the installation prefix to the toolchain path

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/pythonkit.py
+++ b/utils/swift_build_support/swift_build_support/products/pythonkit.py
@@ -32,7 +32,7 @@ class PythonKit(product.Product):
     def build(self, host_target):
         toolchain_path = targets.toolchain_path(self.args.install_destdir,
                                                 self.args.install_prefix)
-        swiftc = os.path.join(toolchain_path, 'usr', 'bin', 'swiftc')
+        swiftc = os.path.join(toolchain_path, 'bin', 'swiftc')
 
         # FIXME: this is a workaround for CMake <3.16 which does not correctly
         # generate the build rules if you are not in the build directory.  As a
@@ -52,7 +52,7 @@ class PythonKit(product.Product):
                 self.toolchain.cmake,
                 '-G', 'Ninja',
                 '-D', 'BUILD_SHARED_LIBS=YES',
-                '-D', 'CMAKE_INSTALL_PREFIX={}/usr'.format(
+                '-D', 'CMAKE_INSTALL_PREFIX={}'.format(
                     self.install_toolchain_path()),
                 '-D', 'CMAKE_MAKE_PROGRAM={}'.format(self.toolchain.ninja),
                 '-D', 'CMAKE_Swift_COMPILER={}'.format(swiftc),

--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -32,7 +32,7 @@ class SwiftPM(product.Product):
         script_path = os.path.join(
             self.source_dir, 'Utilities', 'bootstrap')
         toolchain_path = self.install_toolchain_path()
-        swiftc = os.path.join(toolchain_path, "usr", "bin", "swiftc")
+        swiftc = os.path.join(toolchain_path, "bin", "swiftc")
 
         # FIXME: We require llbuild build directory in order to build. Is
         # there a better way to get this?

--- a/utils/swift_build_support/swift_build_support/products/tensorflow.py
+++ b/utils/swift_build_support/swift_build_support/products/tensorflow.py
@@ -32,7 +32,7 @@ class TensorFlowSwiftAPIs(product.Product):
     def build(self, host_target):
         toolchain_path = targets.toolchain_path(self.args.install_destdir,
                                                 self.args.install_prefix)
-        swiftc = os.path.join(toolchain_path, 'usr', 'bin', 'swiftc')
+        swiftc = os.path.join(toolchain_path, 'bin', 'swiftc')
 
         # FIXME: this is a workaround for CMake <3.16 which does not correctly
         # generate the build rules if you are not in the build directory.  As a
@@ -52,7 +52,7 @@ class TensorFlowSwiftAPIs(product.Product):
                 self.toolchain.cmake,
                 '-G', 'Ninja',
                 '-D', 'BUILD_SHARED_LIBS=YES',
-                '-D', 'CMAKE_INSTALL_PREFIX={}/usr'.format(
+                '-D', 'CMAKE_INSTALL_PREFIX={}'.format(
                     self.install_toolchain_path()),
                 '-D', 'CMAKE_MAKE_PROGRAM={}'.format(self.toolchain.ninja),
                 '-D', 'CMAKE_Swift_COMPILER={}'.format(swiftc),

--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -284,5 +284,7 @@ def toolchain_path(install_destdir, install_prefix):
     built_toolchain_path = install_destdir
     if platform.system() == 'Darwin':
         # The prefix is an absolute path, so concatenate without os.path.
-        built_toolchain_path += darwin_toolchain_prefix(install_prefix)
+        built_toolchain_path += darwin_toolchain_prefix(install_prefix) + "/usr"
+    else:
+        built_toolchain_path += install_prefix
     return built_toolchain_path


### PR DESCRIPTION
In several places, it was assumed to be /usr and hard-coded to that. This makes sure the installation prefix actually passed in is used.

I just noticed this when packaging a recent Swift 5.2 snapshot for Android, as [I use `/data/data/com.termux/files/usr` as the install prefix there](https://github.com/buttaface/termux-packages/commit/886cc62e728081b059bec6fa89541475d0d5b735#diff-4d82ce439ff2bae2157f6c5fc393a3c1R16), not the usual `/usr`. There are [three](https://github.com/apple/swift/blob/fcd34575607358797884410254782003135e3441/utils/swift_build_support/swift_build_support/products/indexstoredb.py#L63) [additional](https://github.com/apple/swift/blob/e793fcf05228eec60b26bfd559b07cecf987090b/utils/swift_build_support/swift_build_support/products/skstresstester.py#L53) [instances](https://github.com/apple/swift/blob/e793fcf05228eec60b26bfd559b07cecf987090b/utils/swift_build_support/swift_build_support/products/swiftsyntax.py#L48) where `(install_)toolchain_path()` is passed without the install prefix, so those repos are likely hard-coding `/usr` themselves and will need to be fixed.

If someone gives me the go-ahead on this pull, I will submit pulls for those other repos or contact their developers. @aciidb0mb3r, you added the SwiftPM part of this pull, which is what I actually hit, so let me know what you think. @ahoppen, you added some of these. 