### PR TITLE
[SR-11572] Fix ambiguous function decl involving variadic parameters

### DIFF
--- a/test/decl/func/variadic.swift
+++ b/test/decl/func/variadic.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol SR11572_P {
+    associatedtype T   
+    func SR11572(arg: T)
+}
+ 
+struct SR11572_S: SR11572_P {
+    func SR11572(arg: Void) { }
+}
+
+func SR11572<T: SR11572_P>(some args: T ...) where T.T == Void { }
+
+func SR11572<T: SR11572_P, K: SR11572_P>(some arg1: T, _ arg2: K) { }
+
+func SR11572(another arg1: SR11572_S, _ arg2: SR11572_S) { }
+
+SR11572(some: SR11572_S(), SR11572_S()) // Ok


### PR DESCRIPTION
<!-- What's in this pull request? -->
Tweak the ranking function declaration request to consider that a function declaration with no variadic parameter is more specialized than a function declaration that have any variadic parameter.

cc @xedin @hborla 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-11572.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
