### PR TITLE
Fix out-of-tree builds

### DIFF
--- a/utils/SwiftMathFunctions.py
+++ b/utils/SwiftMathFunctions.py
@@ -3,6 +3,7 @@
 # apple/swift master branch and moved to apple/swift-numerics.
 # TF-1203 tracks eliminating these ad-hoc tensorflow branch changes.
 
+
 class SwiftMathFunction(object):
     def __init__(self, name, kind=None, swiftName=None, args="x", comment=None,
                  platforms=None):

--- a/utils/swift_build_support/swift_build_support/products/tensorflow.py
+++ b/utils/swift_build_support/swift_build_support/products/tensorflow.py
@@ -378,6 +378,20 @@ class TensorFlow(product.Product):
                                      'usr', 'lib', 'swift', 'tensorflow', name))
 
         if self.args.enable_x10:
+            _silenced(os.makedirs)(os.path.join(self.install_toolchain_path(),
+                                                'usr', 'lib', 'swift',
+                                                'tensorflow', 'x10'))
+            for name in (
+                    'device_wrapper.h',
+                    'xla_tensor_wrapper.h',
+                    'xla_tensor_tf_ops.h',
+            ):
+                shutil.copy(os.path.join(self.source_dir, '..',
+                                         'tensorflow-swift-apis', 'Sources',
+                                         'x10', 'swift_bindings', name),
+                            os.path.join(self.install_toolchain_path(),
+                                         'usr', 'lib', 'swift', 'tensorflow',
+                                         'x10', name))
             self._collect_headers()
 
 # SWIFT_ENABLE_TENSORFLOW END


### PR DESCRIPTION
Add relevant x10 headers to the toolchain, they're needed to build outside swift-apis.