### PR TITLE
[AutoDiff upstream] Add derivative function witness/vtable entry SILGen.

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -104,9 +104,8 @@ public:
   void Profile(llvm::FoldingSetNodeID &ID) {
     ID.AddInteger(kind);
     ID.AddPointer(parameterIndices);
-    CanGenericSignature derivativeCanGenSig;
-    if (derivativeGenericSignature)
-      derivativeCanGenSig = derivativeGenericSignature->getCanonicalSignature();
+    auto derivativeCanGenSig =
+        derivativeGenericSignature.getCanonicalSignature();
     ID.AddPointer(derivativeCanGenSig.getPointer());
   }
 };

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -324,6 +324,13 @@ struct SILDeclRef {
     return declRef;
   }
 
+  /// Returns this `SILDeclRef` replacing `loc` with `decl`.
+  SILDeclRef withDecl(ValueDecl *decl) const {
+    SILDeclRef result = *this;
+    result.loc = decl;
+    return result;
+  }
+
   /// True if the decl ref references a thunk from a natively foreign
   /// declaration to Swift calling convention.
   bool isForeignToNativeThunk() const;

--- a/include/swift/SIL/SILWitnessVisitor.h
+++ b/include/swift/SIL/SILWitnessVisitor.h
@@ -122,14 +122,19 @@ public:
 
   void visitAbstractStorageDecl(AbstractStorageDecl *sd) {
     sd->visitOpaqueAccessors([&](AccessorDecl *accessor) {
-      if (SILDeclRef::requiresNewWitnessTableEntry(accessor))
+      if (SILDeclRef::requiresNewWitnessTableEntry(accessor)) {
         asDerived().addMethod(SILDeclRef(accessor, SILDeclRef::Kind::Func));
+        addAutoDiffDerivativeMethodsIfRequired(accessor,
+                                               SILDeclRef::Kind::Func);
+      }
     });
   }
 
   void visitConstructorDecl(ConstructorDecl *cd) {
-    if (SILDeclRef::requiresNewWitnessTableEntry(cd))
+    if (SILDeclRef::requiresNewWitnessTableEntry(cd)) {
       asDerived().addMethod(SILDeclRef(cd, SILDeclRef::Kind::Allocator));
+      addAutoDiffDerivativeMethodsIfRequired(cd, SILDeclRef::Kind::Allocator);
+    }
   }
 
   void visitAccessorDecl(AccessorDecl *func) {
@@ -138,8 +143,10 @@ public:
 
   void visitFuncDecl(FuncDecl *func) {
     assert(!isa<AccessorDecl>(func));
-    if (SILDeclRef::requiresNewWitnessTableEntry(func))
+    if (SILDeclRef::requiresNewWitnessTableEntry(func)) {
       asDerived().addMethod(SILDeclRef(func, SILDeclRef::Kind::Func));
+      addAutoDiffDerivativeMethodsIfRequired(func, SILDeclRef::Kind::Func);
+    }
   }
 
   void visitMissingMemberDecl(MissingMemberDecl *placeholder) {
@@ -165,6 +172,26 @@ public:
 
   void visitPoundDiagnosticDecl(PoundDiagnosticDecl *pdd) {
     // We don't care about diagnostics at this stage.
+  }
+
+private:
+  void addAutoDiffDerivativeMethodsIfRequired(AbstractFunctionDecl *AFD,
+                                              SILDeclRef::Kind kind) {
+    SILDeclRef declRef(AFD, kind);
+    for (auto *diffAttr : AFD->getAttrs().getAttributes<DifferentiableAttr>()) {
+      asDerived().addMethod(declRef.asAutoDiffDerivativeFunction(
+          AutoDiffDerivativeFunctionIdentifier::get(
+              AutoDiffDerivativeFunctionKind::JVP,
+              diffAttr->getParameterIndices(),
+              diffAttr->getDerivativeGenericSignature(),
+              AFD->getASTContext())));
+      asDerived().addMethod(declRef.asAutoDiffDerivativeFunction(
+          AutoDiffDerivativeFunctionIdentifier::get(
+              AutoDiffDerivativeFunctionKind::VJP,
+              diffAttr->getParameterIndices(),
+              diffAttr->getDerivativeGenericSignature(),
+              AFD->getASTContext())));
+    }
   }
 };
 

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -992,8 +992,7 @@ emitKeyPathComponent(IRGenModule &IGM,
         auto methodProto = cast<ProtocolDecl>(dc);
         auto &protoInfo = IGM.getProtocolInfo(methodProto,
                                               ProtocolInfoKind::Full);
-        auto index = protoInfo.getFunctionIndex(
-                             cast<AbstractFunctionDecl>(declRef.getDecl()));
+        auto index = protoInfo.getFunctionIndex(declRef);
         idValue = llvm::ConstantInt::get(IGM.SizeTy, -index.getValue());
         idResolution = KeyPathComponentHeader::Resolved;
       }

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -792,20 +792,19 @@ namespace {
     }
 
     void addMethod(SILDeclRef func) {
-      auto decl = cast<AbstractFunctionDecl>(func.getDecl());
       // If this assert needs to be changed, be sure to also change
       // ProtocolDescriptorBuilder::getRequirementInfo.
-      assert((isa<ConstructorDecl>(decl)
-                ? (func.kind == SILDeclRef::Kind::Allocator)
-                : (func.kind == SILDeclRef::Kind::Func))
-             && "unexpected kind for protocol witness declaration ref");
-      Entries.push_back(WitnessTableEntry::forFunction(decl));
+      assert((isa<ConstructorDecl>(func.getDecl())
+                  ? (func.kind == SILDeclRef::Kind::Allocator)
+                  : (func.kind == SILDeclRef::Kind::Func)) &&
+             "unexpected kind for protocol witness declaration ref");
+      Entries.push_back(WitnessTableEntry::forFunction(func));
     }
 
     void addPlaceholder(MissingMemberDecl *placeholder) {
       for (auto i : range(placeholder->getNumberOfVTableEntries())) {
         (void)i;
-        Entries.push_back(WitnessTableEntry());
+        Entries.push_back(WitnessTableEntry::forPlaceholder());
       }
     }
 
@@ -1318,8 +1317,7 @@ public:
              && "sil witness table does not match protocol");
       assert(entry.getMethodWitness().Requirement == requirement
              && "sil witness table does not match protocol");
-      auto piIndex =
-        PI.getFunctionIndex(cast<AbstractFunctionDecl>(requirement.getDecl()));
+      auto piIndex = PI.getFunctionIndex(requirement);
       assert((size_t)piIndex.getValue() ==
               Table.size() - WitnessTableFirstRequirementOffset &&
              "offset doesn't match ProtocolInfo layout");
@@ -3277,7 +3275,7 @@ FunctionPointer irgen::emitWitnessMethodValue(IRGenFunction &IGF,
 
   // Find the witness we're interested in.
   auto &fnProtoInfo = IGF.IGM.getProtocolInfo(proto, ProtocolInfoKind::Full);
-  auto index = fnProtoInfo.getFunctionIndex(fn);
+  auto index = fnProtoInfo.getFunctionIndex(member);
   llvm::Value *slot;
   llvm::Value *witnessFnPtr =
     emitInvariantLoadOfOpaqueWitness(IGF, wtable,

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -2006,6 +2006,15 @@ getFunctionInterfaceTypeWithCaptures(TypeConverter &TC,
 }
 
 CanAnyFunctionType TypeConverter::makeConstantInterfaceType(SILDeclRef c) {
+  if (auto *derivativeId = c.derivativeFunctionIdentifier) {
+    auto originalFnTy =
+        makeConstantInterfaceType(c.asAutoDiffOriginalFunction());
+    auto *derivativeFnTy = originalFnTy->getAutoDiffDerivativeFunctionType(
+        derivativeId->getParameterIndices(), derivativeId->getKind(),
+        LookUpConformanceInModule(&M));
+    return cast<AnyFunctionType>(derivativeFnTy->getCanonicalType());
+  }
+
   auto *vd = c.loc.dyn_cast<ValueDecl *>();
   switch (c.kind) {
   case SILDeclRef::Kind::Func: {

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -224,6 +224,12 @@ public:
       SILFunction *customDerivativeFn, SILFunction *originalFn,
       const AutoDiffConfig &config, AutoDiffDerivativeFunctionKind kind);
 
+  /// Get or create a derivative function vtable entry thunk for the given
+  /// SILDeclRef and derivative function type.
+  SILFunction *
+  getOrCreateAutoDiffClassMethodThunk(SILDeclRef derivativeFnRef,
+                                      CanSILFunctionType derivativeFnTy);
+
   /// Determine whether we need to emit an ivar destroyer for the given class.
   /// An ivar destroyer is needed if a superclass of this class may define a
   /// failing designated initializer.

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -4454,8 +4454,15 @@ getWitnessFunctionRef(SILGenFunction &SGF,
                       SILLocation loc) {
   switch (witnessKind) {
   case WitnessDispatchKind::Static:
+    if (auto *derivativeId = witness.derivativeFunctionIdentifier) {
+      // TODO(TF-1139, TF-1140): Replace `undef` with `differentiable_function`
+      // and `differentiable_function_extract`.
+      auto derivativeFnSilType = SILType::getPrimitiveObjectType(witnessFTy);
+      return SILUndef::get(derivativeFnSilType, SGF.F);
+    }
     return SGF.emitGlobalFunctionRef(loc, witness);
   case WitnessDispatchKind::Dynamic:
+    assert(!witness.derivativeFunctionIdentifier);
     return SGF.emitDynamicMethodRef(loc, witness, witnessFTy).getValue();
   case WitnessDispatchKind::Witness: {
     auto typeAndConf =

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -186,3 +186,42 @@ getOrCreateReabstractionThunk(CanSILFunctionType thunkType,
       loc, name, thunkDeclType, IsBare, IsTransparent, IsSerializable,
       ProfileCounter(), IsReabstractionThunk, IsNotDynamic);
 }
+
+SILFunction *SILGenModule::getOrCreateAutoDiffClassMethodThunk(
+    SILDeclRef derivativeFnDeclRef, CanSILFunctionType constantTy) {
+  auto *derivativeId = derivativeFnDeclRef.derivativeFunctionIdentifier;
+  assert(derivativeId);
+  auto *derivativeFnDecl = derivativeFnDeclRef.getDecl();
+
+  SILGenFunctionBuilder builder(*this);
+  auto originalFn = derivativeFnDeclRef.asAutoDiffOriginalFunction();
+  // TODO(TF-685): Use principled thunk mangling.
+  // Do not simply reuse reabstraction thunk mangling.
+  auto name = derivativeFnDeclRef.mangle() + "_vtable_entry_thunk";
+  auto *thunk = builder.getOrCreateFunction(
+      derivativeFnDecl, name, originalFn.getLinkage(ForDefinition), constantTy,
+      IsBare, IsTransparent, derivativeFnDeclRef.isSerialized(), IsNotDynamic,
+      ProfileCounter(), IsThunk);
+  if (!thunk->empty())
+    return thunk;
+
+  if (auto genSig = constantTy->getSubstGenericSignature())
+    thunk->setGenericEnvironment(genSig->getGenericEnvironment());
+  SILGenFunction SGF(*this, *thunk, SwiftModule);
+  SmallVector<ManagedValue, 4> params;
+  auto loc = derivativeFnDeclRef.getAsRegularLocation();
+  SGF.collectThunkParams(loc, params);
+
+  // TODO(TF-1139, TF-1140): Replace `undef` with `differentiable_function` and
+  // `differentiable_function_extract`.
+  auto derivativeSilTy = SILType::getPrimitiveObjectType(constantTy);
+  auto derivativeFn = SILUndef::get(derivativeSilTy, *thunk);
+  SmallVector<SILValue, 4> args(thunk->getArguments().begin(),
+                                thunk->getArguments().end());
+  auto apply =
+      SGF.emitApplyWithRethrow(loc, derivativeFn, derivativeSilTy,
+                               SGF.getForwardingSubstitutionMap(), args);
+  SGF.B.createReturn(loc, apply);
+
+  return thunk;
+}

--- a/test/AutoDiff/SIL/Parse/sildeclref_parse.sil
+++ b/test/AutoDiff/SIL/Parse/sildeclref_parse.sil
@@ -1,8 +1,7 @@
 // RUN: %target-sil-opt -enable-experimental-differentiable-programming %s -module-name=sildeclref_parse | %target-sil-opt -enable-experimental-differentiable-programming -module-name=sildeclref_parse | %FileCheck %s
 // REQUIRES: differentiable_programming
 
-// Parse AutoDiff derivative SILDeclRefs via `witness_method` instructions.
-// TODO(TF-1212): Also test `class_method` instructions.
+// Parse AutoDiff derivative SILDeclRefs via `witness_method` and `class_method` instructions.
 
 import Swift
 import _Differentiation
@@ -10,6 +9,11 @@ import _Differentiation
 protocol Protocol {
   @differentiable(wrt: (x, y))
   func f(_ x: Float, _ y: Float) -> Float
+}
+
+class Class<T> {
+  @differentiable(wrt: (x, y) where T: Differentiable)
+  func f(_ x: T, _ y: Float) -> T
 }
 
 // CHECK-LABEL: sil hidden @witness_method
@@ -29,6 +33,22 @@ bb0(%0 : $*T):
 
   // CHECK: witness_method $T, #Protocol.f!vjp.UUS
   %5 = witness_method $T, #Protocol.f!vjp.UUS : <Self where Self : Protocol> (Self) -> (Float, Float) -> Float : $@convention(witness_method: Protocol) <τ_0_0 where τ_0_0 : Protocol> (@in_guaranteed τ_0_0) -> (Float, Float) -> Float
+
+  %6 = tuple ()
+  return %6 : $()
+}
+
+// CHECK-LABEL: sil hidden @class_method
+sil hidden @class_method : $@convention(thin) <T where T : Differentiable> (@guaranteed Class<T>) -> () {
+bb0(%0 : $Class<T>):
+  // CHECK: class_method %0 : $Class<T>, #Class.f
+  %1 = class_method %0 : $Class<T>, #Class.f : <T> (Class<T>) -> (T, Float) -> T, $@convention(method) <τ_0_0> (@in_guaranteed τ_0_0, Float, @guaranteed Class<τ_0_0>) -> @out τ_0_0
+
+  // CHECK: class_method %0 : $Class<T>, #Class.f!jvp.SSU
+  %2 = class_method %0 : $Class<T>, #Class.f!jvp.SSU.<T where T : Differentiable> : <T> (Class<T>) -> (T, Float) -> T, $@convention(method) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, Float, @guaranteed Class<τ_0_0>) -> (@out τ_0_0, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0, Float) -> @out τ_0_1 for <τ_0_0.TangentVector, τ_0_0.TangentVector>)
+
+  // CHECK: class_method %0 : $Class<T>, #Class.f!vjp.SSU
+  %3 = class_method %0 : $Class<T>, #Class.f!vjp.SSU.<T where T : Differentiable> : <T> (Class<T>) -> (T, Float) -> T, $@convention(method) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, Float, @guaranteed Class<τ_0_0>) -> (@out τ_0_0, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> (@out τ_0_1, Float) for <τ_0_0.TangentVector, τ_0_0.TangentVector>)
 
   %6 = tuple ()
   return %6 : $()

--- a/test/AutoDiff/SILGen/vtable.swift
+++ b/test/AutoDiff/SILGen/vtable.swift
@@ -1,0 +1,145 @@
+// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -emit-silgen %s | %FileCheck %s
+
+// Test derivative function vtable entries for `@differentiable` class members:
+// - Methods.
+// - Accessors (from properties and subscripts).
+// - Initializers.
+
+import _Differentiation
+
+// Dummy `Differentiable`-conforming type.
+struct DummyTangentVector: Differentiable & AdditiveArithmetic {
+  // FIXME(TF-648): Dummy to make `Super.TangentVector` be nontrivial.
+  var _nontrivial: [Float] = []
+
+  static var zero: Self { Self() }
+  static func + (_: Self, _: Self) -> Self { Self() }
+  static func - (_: Self, _: Self) -> Self { Self() }
+  typealias TangentVector = Self
+}
+
+class Super: Differentiable {
+  typealias TangentVector = DummyTangentVector
+  func move(along _: TangentVector) {}
+
+  var base: Float
+  // FIXME(TF-648): Dummy to make `Super.TangentVector` be nontrivial.
+  var _nontrivial: [Float] = []
+
+  init(base: Float) {
+    self.base = base
+  }
+
+  @differentiable(wrt: x)
+  func method(_ x: Float, _ y: Float) -> Float {
+    return x
+  }
+
+  @differentiable(wrt: x where T: Differentiable)
+  func genericMethod<T>(_ x: T, _ y: T) -> T {
+    return x
+  }
+
+  @differentiable
+  var property: Float { base }
+
+  @differentiable(wrt: x)
+  subscript(_ x: Float, _ y: Float) -> Float {
+    return x
+  }
+}
+
+class Sub: Super {
+  override init(base: Float) {
+    super.init(base: base)
+  }
+
+  // Override JVP for `method` wrt `x`.
+  @derivative(of: method, wrt: x)
+  @derivative(of: subscript, wrt: x)
+  final func jvpMethod(_ x: Float, _ y: Float) -> (value: Float, differential: (Float) -> Float) {
+    fatalError()
+  }
+  // Override VJP for `method` wrt `x`.
+  @derivative(of: method, wrt: x)
+  @derivative(of: subscript, wrt: x)
+  final func vjpMethod(_ x: Float, _ y: Float) -> (value: Float, pullback: (Float) -> (Float)) {
+    fatalError()
+  }
+
+  // Override derivatives for `method` wrt `x`.
+  // FIXME(TF-1203): This `@differentiable` attribute should not be necessary to
+  // override derivatives. Fix `derivativeFunctionRequiresNewVTableEntry` to
+  // account for derived declaration `@derivative` attributes.
+  @differentiable(wrt: x)
+  // Add new derivatives for `method` wrt `(x, y)`.
+  @differentiable(wrt: (x, y))
+  override func method(_ x: Float, _ y: Float) -> Float {
+    return x
+  }
+
+  // Override derivatives for `property` wrt `self`.
+  @differentiable
+  override var property: Float { base }
+  @derivative(of: property)
+  final func vjpProperty() -> (value: Float, pullback: (Float) -> TangentVector) {
+    fatalError()
+  }
+
+  // Override derivatives for `subscript` wrt `x`.
+  @differentiable(wrt: x)
+  override subscript(_ x: Float, _ y: Float) -> Float {
+    return x
+  }
+}
+
+class SubSub: Sub {}
+
+// CHECK-LABEL: sil_vtable Super {
+// CHECK:   #Super.method: (Super) -> (Float, Float) -> Float : @$s6vtable5SuperC6methodyS2f_SftF
+// CHECK:   #Super.method!jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s6vtable5SuperC6methodyS2f_SftF__jvp_src_0_wrt_0_vtable_entry_thunk
+// CHECK:   #Super.method!vjp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s6vtable5SuperC6methodyS2f_SftF__vjp_src_0_wrt_0_vtable_entry_thunk
+// CHECK:   #Super.genericMethod: <T> (Super) -> (T, T) -> T : @$s6vtable5SuperC13genericMethodyxx_xtlF
+// CHECK:   #Super.genericMethod!jvp.SUU.<T where T : Differentiable>: <T> (Super) -> (T, T) -> T : @AD__$s6vtable5SuperC13genericMethodyxx_xtlF__jvp_src_0_wrt_0_16_Differentiation14DifferentiableRzl_vtable_entry_thunk
+// CHECK:   #Super.genericMethod!vjp.SUU.<T where T : Differentiable>: <T> (Super) -> (T, T) -> T : @AD__$s6vtable5SuperC13genericMethodyxx_xtlF__vjp_src_0_wrt_0_16_Differentiation14DifferentiableRzl_vtable_entry_thunk
+// CHECK:   #Super.property!getter: (Super) -> () -> Float : @$s6vtable5SuperC8propertySfvg
+// CHECK:   #Super.property!getter.jvp.S: (Super) -> () -> Float : @AD__$s6vtable5SuperC8propertySfvg__jvp_src_0_wrt_0_vtable_entry_thunk
+// CHECK:   #Super.property!getter.vjp.S: (Super) -> () -> Float : @AD__$s6vtable5SuperC8propertySfvg__vjp_src_0_wrt_0_vtable_entry_thunk
+// CHECK:   #Super.subscript!getter: (Super) -> (Float, Float) -> Float : @$s6vtable5SuperCyS2f_Sftcig
+// CHECK:   #Super.subscript!getter.jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s6vtable5SuperCyS2f_Sftcig__jvp_src_0_wrt_0_vtable_entry_thunk
+// CHECK:   #Super.subscript!getter.vjp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s6vtable5SuperCyS2f_Sftcig__vjp_src_0_wrt_0_vtable_entry_thunk
+// CHECK: }
+
+// CHECK-LABEL: sil_vtable Sub {
+// CHECK:   #Super.method: (Super) -> (Float, Float) -> Float : @$s6vtable3SubC6methodyS2f_SftF [override]
+// CHECK:   #Super.method!jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s6vtable3SubC6methodyS2f_SftF__jvp_src_0_wrt_0_vtable_entry_thunk [override]
+// CHECK:   #Super.method!vjp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s6vtable3SubC6methodyS2f_SftF__vjp_src_0_wrt_0_vtable_entry_thunk [override]
+// CHECK:   #Super.genericMethod: <T> (Super) -> (T, T) -> T : @$s6vtable5SuperC13genericMethodyxx_xtlF [inherited]
+// CHECK:   #Super.genericMethod!jvp.SUU.<T where T : Differentiable>: <T> (Super) -> (T, T) -> T : @AD__$s6vtable5SuperC13genericMethodyxx_xtlF__jvp_src_0_wrt_0_16_Differentiation14DifferentiableRzl_vtable_entry_thunk [inherited]
+// CHECK:   #Super.genericMethod!vjp.SUU.<T where T : Differentiable>: <T> (Super) -> (T, T) -> T : @AD__$s6vtable5SuperC13genericMethodyxx_xtlF__vjp_src_0_wrt_0_16_Differentiation14DifferentiableRzl_vtable_entry_thunk [inherited]
+// CHECK:   #Super.property!getter: (Super) -> () -> Float : @$s6vtable3SubC8propertySfvg [override]
+// CHECK:   #Super.property!getter.jvp.S: (Super) -> () -> Float : @AD__$s6vtable3SubC8propertySfvg__jvp_src_0_wrt_0_vtable_entry_thunk [override]
+// CHECK:   #Super.property!getter.vjp.S: (Super) -> () -> Float : @AD__$s6vtable3SubC8propertySfvg__vjp_src_0_wrt_0_vtable_entry_thunk [override]
+// CHECK:   #Super.subscript!getter: (Super) -> (Float, Float) -> Float : @$s6vtable3SubCyS2f_Sftcig [override]
+// CHECK:   #Super.subscript!getter.jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s6vtable3SubCyS2f_Sftcig__jvp_src_0_wrt_0_vtable_entry_thunk [override]
+// CHECK:   #Super.subscript!getter.vjp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s6vtable3SubCyS2f_Sftcig__vjp_src_0_wrt_0_vtable_entry_thunk [override]
+// CHECK:   #Sub.method!jvp.SSU: (Sub) -> (Float, Float) -> Float : @AD__$s6vtable3SubC6methodyS2f_SftF__jvp_src_0_wrt_0_1_vtable_entry_thunk
+// CHECK:   #Sub.method!vjp.SSU: (Sub) -> (Float, Float) -> Float : @AD__$s6vtable3SubC6methodyS2f_SftF__vjp_src_0_wrt_0_1_vtable_entry_thunk
+// CHECK: }
+
+// CHECK-LABEL: sil_vtable SubSub {
+// CHECK:   #Super.method: (Super) -> (Float, Float) -> Float : @$s6vtable3SubC6methodyS2f_SftF [inherited]
+// CHECK:   #Super.method!jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s6vtable3SubC6methodyS2f_SftF__jvp_src_0_wrt_0_vtable_entry_thunk [inherited]
+// CHECK:   #Super.method!vjp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s6vtable3SubC6methodyS2f_SftF__vjp_src_0_wrt_0_vtable_entry_thunk [inherited]
+// CHECK:   #Super.genericMethod: <T> (Super) -> (T, T) -> T : @$s6vtable5SuperC13genericMethodyxx_xtlF [inherited]
+// CHECK:   #Super.genericMethod!jvp.SUU.<T where T : Differentiable>: <T> (Super) -> (T, T) -> T : @AD__$s6vtable5SuperC13genericMethodyxx_xtlF__jvp_src_0_wrt_0_16_Differentiation14DifferentiableRzl_vtable_entry_thunk [inherited]
+// CHECK:   #Super.genericMethod!vjp.SUU.<T where T : Differentiable>: <T> (Super) -> (T, T) -> T : @AD__$s6vtable5SuperC13genericMethodyxx_xtlF__vjp_src_0_wrt_0_16_Differentiation14DifferentiableRzl_vtable_entry_thunk [inherited]
+// CHECK:   #Super.property!getter: (Super) -> () -> Float : @$s6vtable3SubC8propertySfvg [inherited]
+// CHECK:   #Super.property!getter.jvp.S: (Super) -> () -> Float : @AD__$s6vtable3SubC8propertySfvg__jvp_src_0_wrt_0_vtable_entry_thunk [inherited]
+// CHECK:   #Super.property!getter.vjp.S: (Super) -> () -> Float : @AD__$s6vtable3SubC8propertySfvg__vjp_src_0_wrt_0_vtable_entry_thunk [inherited]
+// CHECK:   #Super.subscript!getter: (Super) -> (Float, Float) -> Float : @$s6vtable3SubCyS2f_Sftcig [inherited]
+// CHECK:   #Super.subscript!getter.jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s6vtable3SubCyS2f_Sftcig__jvp_src_0_wrt_0_vtable_entry_thunk [inherited]
+// CHECK:   #Super.subscript!getter.vjp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s6vtable3SubCyS2f_Sftcig__vjp_src_0_wrt_0_vtable_entry_thunk [inherited]
+// CHECK:   #Sub.method!jvp.SSU: (Sub) -> (Float, Float) -> Float : @AD__$s6vtable3SubC6methodyS2f_SftF__jvp_src_0_wrt_0_1_vtable_entry_thunk [inherited]
+// CHECK:   #Sub.method!vjp.SSU: (Sub) -> (Float, Float) -> Float : @AD__$s6vtable3SubC6methodyS2f_SftF__vjp_src_0_wrt_0_1_vtable_entry_thunk [inherited]
+// CHECK: }

--- a/test/AutoDiff/SILGen/vtable.swift
+++ b/test/AutoDiff/SILGen/vtable.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -enable-experimental-differentiable-programming -emit-silgen %s | %FileCheck %s
+// REQUIRES: differentiable_programming
 
 // Test derivative function vtable entries for `@differentiable` class members:
 // - Methods.

--- a/test/AutoDiff/SILGen/witness_table.swift
+++ b/test/AutoDiff/SILGen/witness_table.swift
@@ -1,0 +1,84 @@
+// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -emit-silgen %s | %FileCheck %s
+
+// Test derivative function witness table entries for `@differentiable` protocol requirements.
+
+import _Differentiation
+
+protocol Protocol: Differentiable {
+  @differentiable(wrt: (self, x, y))
+  @differentiable(wrt: x)
+  func method(_ x: Float, _ y: Double) -> Float
+
+  @differentiable
+  var property: Float { get set }
+
+  @differentiable(wrt: x)
+  subscript(_ x: Float, _ y: Float) -> Float { get set }
+}
+
+// Dummy `Differentiable`-conforming type.
+struct DummyTangentVector: Differentiable & AdditiveArithmetic {
+  static var zero: Self { Self() }
+  static func + (_: Self, _: Self) -> Self { Self() }
+  static func - (_: Self, _: Self) -> Self { Self() }
+  typealias TangentVector = Self
+}
+
+struct Struct: Protocol {
+  typealias TangentVector = DummyTangentVector
+  mutating func move(along _: TangentVector) {}
+
+  @differentiable(wrt: (self, x, y))
+  @differentiable(wrt: x)
+  func method(_ x: Float, _ y: Double) -> Float {
+    return x
+  }
+
+  // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @AD__${{.*}}method{{.*}}_jvp_SUU : $@convention(witness_method: Protocol) (Float, Double, @in_guaranteed Struct) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+
+  // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @AD__${{.*}}method{{.*}}_vjp_SUU : $@convention(witness_method: Protocol) (Float, Double, @in_guaranteed Struct) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+
+  // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @AD__${{.*}}method{{.*}}_jvp_SSS : $@convention(witness_method: Protocol) (Float, Double, @in_guaranteed Struct) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (Float, Double, @in_guaranteed τ_0_0) -> Float for <DummyTangentVector>) {
+
+  // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @AD__${{.*}}method{{.*}}_vjp_SSS : $@convention(witness_method: Protocol) (Float, Double, @in_guaranteed Struct) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (Float) -> (Float, Double, @out τ_0_0) for <DummyTangentVector>) {
+
+  @differentiable
+  var property: Float {
+    get { 1 }
+    set {}
+  }
+
+  // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @AD__${{.*}}property{{.*}}_jvp_S : $@convention(witness_method: Protocol) (@in_guaranteed Struct) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> Float for <DummyTangentVector>) {
+
+  // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @AD__${{.*}}property{{.*}}_vjp_S : $@convention(witness_method: Protocol) (@in_guaranteed Struct) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (Float) -> @out τ_0_0 for <DummyTangentVector>) {
+
+
+  @differentiable(wrt: x)
+  subscript(_ x: Float, _ y: Float) -> Float {
+    get { x }
+    set {}
+  }
+
+  // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @AD__$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcigTW_jvp_SUU : $@convention(witness_method: Protocol) (Float, Float, @in_guaranteed Struct) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+
+  // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @AD__$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcigTW_vjp_SUU : $@convention(witness_method: Protocol) (Float, Float, @in_guaranteed Struct) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+}
+
+// CHECK-LABEL: sil_witness_table hidden Struct: Protocol module witness_table {
+// CHECK-NEXT:   base_protocol Differentiable: Struct: Differentiable module witness_table
+// CHECK-NEXT:   method #Protocol.method: <Self where Self : Protocol> (Self) -> (Float, Double) -> Float : @$s13witness_table6StructVAA8ProtocolA2aDP6methodyS2f_SdtFTW
+// CHECK-NEXT:   method #Protocol.method!jvp.SUU.<Self where Self : Protocol>: <Self where Self : Protocol> (Self) -> (Float, Double) -> Float : @AD__$s13witness_table6StructVAA8ProtocolA2aDP6methodyS2f_SdtFTW_jvp_SUU
+// CHECK-NEXT:   method #Protocol.method!vjp.SUU.<Self where Self : Protocol>: <Self where Self : Protocol> (Self) -> (Float, Double) -> Float : @AD__$s13witness_table6StructVAA8ProtocolA2aDP6methodyS2f_SdtFTW_vjp_SUU
+// CHECK-NEXT:   method #Protocol.method!jvp.SSS.<Self where Self : Protocol>: <Self where Self : Protocol> (Self) -> (Float, Double) -> Float : @AD__$s13witness_table6StructVAA8ProtocolA2aDP6methodyS2f_SdtFTW_jvp_SSS
+// CHECK-NEXT:   method #Protocol.method!vjp.SSS.<Self where Self : Protocol>: <Self where Self : Protocol> (Self) -> (Float, Double) -> Float : @AD__$s13witness_table6StructVAA8ProtocolA2aDP6methodyS2f_SdtFTW_vjp_SSS
+// CHECK-NEXT:   method #Protocol.property!getter: <Self where Self : Protocol> (Self) -> () -> Float : @$s13witness_table6StructVAA8ProtocolA2aDP8propertySfvgTW
+// CHECK-NEXT:   method #Protocol.property!getter.jvp.S.<Self where Self : Protocol>: <Self where Self : Protocol> (Self) -> () -> Float : @AD__$s13witness_table6StructVAA8ProtocolA2aDP8propertySfvgTW_jvp_S
+// CHECK-NEXT:   method #Protocol.property!getter.vjp.S.<Self where Self : Protocol>: <Self where Self : Protocol> (Self) -> () -> Float : @AD__$s13witness_table6StructVAA8ProtocolA2aDP8propertySfvgTW_vjp_S
+// CHECK-NEXT:   method #Protocol.property!setter: <Self where Self : Protocol> (inout Self) -> (Float) -> () : @$s13witness_table6StructVAA8ProtocolA2aDP8propertySfvsTW
+// CHECK-NEXT:   method #Protocol.property!modify: <Self where Self : Protocol> (inout Self) -> () -> () : @$s13witness_table6StructVAA8ProtocolA2aDP8propertySfvMTW
+// CHECK-NEXT:   method #Protocol.subscript!getter: <Self where Self : Protocol> (Self) -> (Float, Float) -> Float : @$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcigTW
+// CHECK-NEXT:   method #Protocol.subscript!getter.jvp.SUU.<Self where Self : Protocol>: <Self where Self : Protocol> (Self) -> (Float, Float) -> Float : @AD__$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcigTW_jvp_SU
+// CHECK-NEXT:   method #Protocol.subscript!getter.vjp.SUU.<Self where Self : Protocol>: <Self where Self : Protocol> (Self) -> (Float, Float) -> Float : @AD__$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcigTW_vjp_SUU
+// CHECK-NEXT:   method #Protocol.subscript!setter: <Self where Self : Protocol> (inout Self) -> (Float, Float, Float) -> () : @$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcisTW
+// CHECK-NEXT:   method #Protocol.subscript!modify: <Self where Self : Protocol> (inout Self) -> (Float, Float) -> () : @$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftciMTW
+// CHECK: }

--- a/test/AutoDiff/SILGen/witness_table.swift
+++ b/test/AutoDiff/SILGen/witness_table.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -enable-experimental-differentiable-programming -emit-silgen %s | %FileCheck %s
+// REQUIRES: differentiable_programming
 
 // Test derivative function witness table entries for `@differentiable` protocol requirements.
 


### PR DESCRIPTION
`@differentiable` attribute on protocol requirements and non-final class
members now produces derivative function entries in witness tables and vtables.

This enables `witness_method` and `class_method` differentiation.

Existing type-checking rules:

- Witness declarations of `@differentiable` protocol requirements must have a
  `@differentiable` attribute with the same configuration (or a configuration
  with superset parameter indices).
  - Witness table derivative function entries are SILGen'd for `@differentiable`
    witness declarations.

- Class vtable derivative function entries are SILGen'd for non-final
  `@differentiable` class members.
  - These derivative entries can be overridden or inherited, just like other
    vtable entries.

Resolves TF-1212.

---

See `test/AutoDiff/SILGen/{witness_,v}table.swift` for examples.