### PR TITLE
[gardening] Move ErrorBehaviorKind out of the swift::ownership namespace in favor of being a subtype of LinearLifetimeError.

### DIFF
--- a/lib/SIL/LinearLifetimeChecker.cpp
+++ b/lib/SIL/LinearLifetimeChecker.cpp
@@ -31,7 +31,6 @@
 #include "llvm/Support/Debug.h"
 
 using namespace swift;
-using namespace swift::ownership;
 
 //===----------------------------------------------------------------------===//
 //                                Declarations
@@ -82,7 +81,7 @@ struct State {
   SmallSetVector<SILBasicBlock *, 8> successorBlocksThatMustBeVisited;
 
   State(SILValue value, SmallPtrSetImpl<SILBasicBlock *> &visitedBlocks,
-        ErrorBehaviorKind errorBehavior,
+        LinearLifetimeChecker::ErrorBehaviorKind errorBehavior,
         SmallVectorImpl<SILBasicBlock *> *leakingBlocks,
         ArrayRef<Operand *> consumingUses, ArrayRef<Operand *> nonConsumingUses)
       : value(value), beginBlock(value->getParentBlock()), error(errorBehavior),
@@ -91,7 +90,7 @@ struct State {
 
   State(SILBasicBlock *beginBlock,
         SmallPtrSetImpl<SILBasicBlock *> &visitedBlocks,
-        ErrorBehaviorKind errorBehavior,
+        LinearLifetimeChecker::ErrorBehaviorKind errorBehavior,
         SmallVectorImpl<SILBasicBlock *> *leakingBlocks,
         ArrayRef<Operand *> consumingUses, ArrayRef<Operand *> nonConsumingUses)
       : value(), beginBlock(beginBlock), error(errorBehavior),

--- a/lib/SIL/OperandOwnership.cpp
+++ b/lib/SIL/OperandOwnership.cpp
@@ -19,7 +19,6 @@
 #include "swift/SIL/SILVisitor.h"
 
 using namespace swift;
-using namespace swift::ownership;
 
 //===----------------------------------------------------------------------===//
 //                      OperandOwnershipKindClassifier
@@ -37,7 +36,7 @@ private:
   LLVM_ATTRIBUTE_UNUSED SILModule &mod;
 
   const Operand &op;
-  ErrorBehaviorKind errorBehavior;
+  LinearLifetimeChecker::ErrorBehaviorKind errorBehavior;
   bool checkingSubObject;
 
 public:
@@ -48,9 +47,10 @@ public:
   /// should be the subobject and Value should be the parent object. An example
   /// of where one would want to do this is in the case of value projections
   /// like struct_extract.
-  OperandOwnershipKindClassifier(SILModule &mod, const Operand &op,
-                                 ErrorBehaviorKind errorBehavior,
-                                 bool checkingSubObject)
+  OperandOwnershipKindClassifier(
+      SILModule &mod, const Operand &op,
+      LinearLifetimeChecker::ErrorBehaviorKind errorBehavior,
+      bool checkingSubObject)
       : mod(mod), op(op), errorBehavior(errorBehavior),
         checkingSubObject(checkingSubObject) {}
 
@@ -1042,8 +1042,9 @@ OperandOwnershipKindClassifier::visitBuiltinInst(BuiltinInst *bi) {
 
 OperandOwnershipKindMap
 Operand::getOwnershipKindMap(bool isForwardingSubValue) const {
-  OperandOwnershipKindClassifier classifier(getUser()->getModule(), *this,
-                                            ErrorBehaviorKind::ReturnFalse,
-                                            isForwardingSubValue);
+  OperandOwnershipKindClassifier classifier(
+      getUser()->getModule(), *this,
+      LinearLifetimeChecker::ErrorBehaviorKind::ReturnFalse,
+      isForwardingSubValue);
   return classifier.visit(const_cast<SILInstruction *>(getUser()));
 }

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -45,7 +45,6 @@
 #include <algorithm>
 
 using namespace swift;
-using namespace swift::ownership;
 
 // This is an option to put the SILOwnershipVerifier in testing mode. This
 // causes the following:
@@ -89,7 +88,7 @@ class SILValueOwnershipChecker {
   SILValue value;
 
   /// The action that the checker should perform on detecting an error.
-  ErrorBehaviorKind errorBehavior;
+  LinearLifetimeChecker::ErrorBehaviorKind errorBehavior;
 
   /// The list of lifetime ending users that we found. Only valid if check is
   /// successful.
@@ -113,7 +112,7 @@ class SILValueOwnershipChecker {
 public:
   SILValueOwnershipChecker(
       DeadEndBlocks &deadEndBlocks, SILValue value,
-      ErrorBehaviorKind errorBehavior,
+      LinearLifetimeError::ErrorBehaviorKind errorBehavior,
       llvm::SmallPtrSetImpl<SILBasicBlock *> &visitedBlocks)
       : result(), deadEndBlocks(deadEndBlocks), value(value),
         errorBehavior(errorBehavior), visitedBlocks(visitedBlocks) {
@@ -879,11 +878,11 @@ void SILInstruction::verifyOperandOwnership() const {
   if (isa<TermInst>(this))
     return;
 
-  ErrorBehaviorKind errorBehavior;
+  LinearLifetimeChecker::ErrorBehaviorKind errorBehavior;
   if (IsSILOwnershipVerifierTestingEnabled) {
-    errorBehavior = ErrorBehaviorKind::PrintMessageAndReturnFalse;
+    errorBehavior = decltype(errorBehavior)::PrintMessageAndReturnFalse;
   } else {
-    errorBehavior = ErrorBehaviorKind::PrintMessageAndAssert;
+    errorBehavior = decltype(errorBehavior)::PrintMessageAndAssert;
   }
   for (const Operand &op : getAllOperands()) {
     // Skip type dependence operands.
@@ -954,11 +953,11 @@ void SILValue::verifyOwnership(DeadEndBlocks *deadEndBlocks) const {
   if (!f->hasOwnership() || !f->shouldVerifyOwnership())
     return;
 
-  ErrorBehaviorKind errorBehavior;
+  LinearLifetimeChecker::ErrorBehaviorKind errorBehavior;
   if (IsSILOwnershipVerifierTestingEnabled) {
-    errorBehavior = ErrorBehaviorKind::PrintMessageAndReturnFalse;
+    errorBehavior = decltype(errorBehavior)::PrintMessageAndReturnFalse;
   } else {
-    errorBehavior = ErrorBehaviorKind::PrintMessageAndAssert;
+    errorBehavior = decltype(errorBehavior)::PrintMessageAndAssert;
   }
 
   SmallPtrSet<SILBasicBlock *, 32> liveBlocks;

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -73,7 +73,7 @@ static void fixupReferenceCounts(
   DeadEndBlocks deadEndBlocks(pai->getFunction());
   SmallVector<SILBasicBlock *, 4> leakingBlocks;
 
-  auto errorBehavior = ownership::ErrorBehaviorKind::ReturnFalse;
+  auto errorBehavior = LinearLifetimeChecker::ErrorBehaviorKind::ReturnFalse;
 
   // Add a copy of each non-address type capture argument to lifetime extend the
   // captured argument over at least the inlined function and till the end of a

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -1197,7 +1197,7 @@ void AvailableValueAggregator::addHandOffCopyDestroysForPhis(
     //
     // Then perform the linear lifetime check. If we succeed, continue. We have
     // no further work to do.
-    auto errorKind = ownership::ErrorBehaviorKind::ReturnFalse;
+    auto errorKind = LinearLifetimeChecker::ErrorBehaviorKind::ReturnFalse;
     auto *loadOperand = &load->getAllOperands()[0];
     LinearLifetimeChecker checker(visitedBlocks, deadEndBlocks);
     auto error =
@@ -1289,7 +1289,7 @@ void AvailableValueAggregator::addMissingDestroysForCopiedValues(
     //
     // Then perform the linear lifetime check. If we succeed, continue. We have
     // no further work to do.
-    auto errorKind = ownership::ErrorBehaviorKind::ReturnFalse;
+    auto errorKind = LinearLifetimeChecker::ErrorBehaviorKind::ReturnFalse;
     auto *loadOperand = &load->getAllOperands()[0];
     LinearLifetimeChecker checker(visitedBlocks, deadEndBlocks);
     auto error =


### PR DESCRIPTION
This has always been a wart that I have wanted to eliminate. Since I am poking
around this now, might as well take care of it now ; ).
