### PR TITLE
Handle flaky SourceKit/CursorInfo/use-swift-source-info.swift

### DIFF
--- a/test/SourceKit/CursorInfo/use-swift-source-info.swift
+++ b/test/SourceKit/CursorInfo/use-swift-source-info.swift
@@ -3,8 +3,9 @@ func bar() {
   foo()
 }
 
-// FIXME: Rmove XFAIL rdar://problem/60096971
-// XFAIL: *
+// FIXME: Rmove REQUIRES rdar://problem/60096971
+// REQUIRES: rdar60096971
+
 // RUN: %empty-directory(%t)
 // RUN: echo "/// Some doc" >> %t/Foo.swift
 // RUN: echo "public func foo() { }" >> %t/Foo.swift


### PR DESCRIPTION
This test was XFAILed on master-next in https://github.com/apple/swift/pull/30330, but it is now passing again. Change the XFAIL to a failing REQUIRES instead.
