### PR TITLE
[backport: 5.2] Add _mangledTypeName to allow round trips T->mangledName->T

### DIFF
--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -1082,7 +1082,14 @@ struct TypeNamePair {
 ///   -> (UnsafePointer<UInt8>, Int)
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
 TypeNamePair
-swift_getTypeName(const Metadata *type, bool qualified);  
+swift_getTypeName(const Metadata *type, bool qualified);
+
+/// Return the mangled name of a Swift type represented by a metadata object.
+/// func _getMangledTypeName(_ type: Any.Type)
+///   -> (UnsafePointer<UInt8>, Int)
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+TypeNamePair
+swift_getMangledTypeName(const Metadata *type);
 
 } // end namespace swift
 

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -78,6 +78,28 @@ func _typeName(_ type: Any.Type, qualified: Bool = true) -> String {
     UnsafeBufferPointer(start: stringPtr, count: count)).0
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@_silgen_name("swift_getMangledTypeName")
+public func _getMangledTypeName(_ type: Any.Type)
+  -> (UnsafePointer<UInt8>, Int)
+
+/// Returns the mangled name for a given type.
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+public // SPI
+func _mangledTypeName<T>(_ type: T.Type) -> String? {
+  let (stringPtr, count) = _getMangledTypeName(type)
+  guard count > 0 else {
+    return nil
+  }
+
+  let (result, repairsMade) = String._fromUTF8Repairing(
+      UnsafeBufferPointer(start: stringPtr, count: count))
+
+  precondition(!repairsMade, "repairs made to _mangledTypeName, this is not expected since names should always valid UTF-8")
+
+  return result
+}
+
 /// Lookup a class given a name. Until the demangled encoding of type
 /// names is stabilized, this is limited to top-level class names (Foo.bar).
 public // SPI(Foundation)

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -121,15 +121,27 @@ std::string swift::nameForMetadata(const Metadata *type,
   return result;
 }
 
+/// Used as part of cache key for `TypeNameCache`.
+enum class TypeNameKind {
+  NotQualified,
+  Qualified,
+  Mangled,
+};
+
+using TypeNameCacheKey = llvm::PointerIntPair<const Metadata *, 2, TypeNameKind>;
+
+#if SWIFT_CASTING_SUPPORTS_MUTEX
+static StaticReadWriteLock TypeNameCacheLock;
+#endif
+
+/// Cache containing rendered names for Metadata.
+/// Access MUST be protected using `TypeNameCacheLock`.
+static Lazy<llvm::DenseMap<TypeNameCacheKey, std::pair<const char *, size_t>>>
+    TypeNameCache;
+
 TypeNamePair
 swift::swift_getTypeName(const Metadata *type, bool qualified) {
-  using Key = llvm::PointerIntPair<const Metadata *, 1, bool>;
-
-  static StaticReadWriteLock TypeNameCacheLock;
-  static Lazy<llvm::DenseMap<Key, std::pair<const char *, size_t>>>
-    TypeNameCache;
-  
-  Key key(type, qualified);
+  TypeNameCacheKey key = TypeNameCacheKey(type, qualified ? TypeNameKind::Qualified: TypeNameKind::NotQualified);
   auto &cache = TypeNameCache.get();
 
   // Attempt read-only lookup of cache entry.
@@ -164,6 +176,60 @@ swift::swift_getTypeName(const Metadata *type, bool qualified) {
     result[size] = 0;
 
     cache.insert({key, {result, size}});
+    return TypeNamePair{result, size};
+  }
+}
+
+/// Return mangled name for the given type.
+TypeNamePair
+swift::swift_getMangledTypeName(const Metadata *type) {
+  TypeNameCacheKey key(type, TypeNameKind::Mangled);
+  auto &cache = TypeNameCache.get();
+
+  // Attempt read-only lookup of cache entry.
+  {
+#if SWIFT_CASTING_SUPPORTS_MUTEX
+    StaticScopedReadLock guard(TypeNameCacheLock);
+#endif
+
+    auto found = cache.find(key);
+    if (found != cache.end()) {
+      auto result = found->second;
+      return TypeNamePair{result.first, result.second};
+    }
+  }
+
+  // Read-only cache lookup failed, we may need to create it.
+  {
+#if SWIFT_CASTING_SUPPORTS_MUTEX
+    StaticScopedWriteLock guard(TypeNameCacheLock);
+#endif
+
+    // Do lookup again just to make sure it wasn't created by another
+    // thread before we acquired the write lock.
+    auto found = cache.find(key);
+    if (found != cache.end()) {
+      auto result = found->second;
+      return TypeNamePair{result.first, result.second};
+    }
+
+    // Build the mangled name.
+    Demangle::Demangler Dem;
+    auto demangling = _swift_buildDemanglingForMetadata(type, Dem);
+
+    if (demangling == nullptr) {
+      return TypeNamePair{NULL, 0};
+    }
+    auto name = Demangle::mangleNode(demangling);
+
+    // Copy it to memory we can reference forever.
+    auto size = name.size();
+    auto result = (char *)malloc(size + 1);
+    memcpy(result, name.data(), size);
+    result[size] = 0;
+
+    cache.insert({key, {result, size}});
+
     return TypeNamePair{result, size};
   }
 }

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -130,9 +130,7 @@ enum class TypeNameKind {
 
 using TypeNameCacheKey = llvm::PointerIntPair<const Metadata *, 2, TypeNameKind>;
 
-#if SWIFT_CASTING_SUPPORTS_MUTEX
 static StaticReadWriteLock TypeNameCacheLock;
-#endif
 
 /// Cache containing rendered names for Metadata.
 /// Access MUST be protected using `TypeNameCacheLock`.
@@ -188,9 +186,7 @@ swift::swift_getMangledTypeName(const Metadata *type) {
 
   // Attempt read-only lookup of cache entry.
   {
-#if SWIFT_CASTING_SUPPORTS_MUTEX
     StaticScopedReadLock guard(TypeNameCacheLock);
-#endif
 
     auto found = cache.find(key);
     if (found != cache.end()) {
@@ -201,9 +197,7 @@ swift::swift_getMangledTypeName(const Metadata *type) {
 
   // Read-only cache lookup failed, we may need to create it.
   {
-#if SWIFT_CASTING_SUPPORTS_MUTEX
     StaticScopedWriteLock guard(TypeNameCacheLock);
-#endif
 
     // Do lookup again just to make sure it wasn't created by another
     // thread before we acquired the write lock.

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -423,5 +423,33 @@ DemangleToMetadataTests.test("Nested types in same-type-constrained extensions")
   // V !: P3 in InnerTEqualsConformsToP1
 }
 
-runAllTests()
+if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
+  DemangleToMetadataTests.test("Round-trip with _mangledTypeName and _typeByName") {
+    func roundTrip<T>(_ type: T.Type) {
+      let mangledName: String? = _mangledTypeName(type)
+      let recoveredType: Any.Type? = _typeByName(mangledName!)
+      expectEqual(String(reflecting: type), String(reflecting: recoveredType!))
+      expectEqual(type, recoveredType! as! T.Type)
+    }
 
+    roundTrip(Int.self)
+    roundTrip(String.self)
+    roundTrip(ConformsToP2AndP3.self)
+    roundTrip(SG12<ConformsToP1AndP2, ConformsToP1AndP2>.self)
+    roundTrip(SG12<ConformsToP1AndP2, ConformsToP1AndP2>.InnerTEqualsU<ConformsToP3>.self)
+    roundTrip(SG12<ConformsToP1, ConformsToP2>.InnerTEqualsConformsToP1<ConformsToP3>.self)
+    roundTrip(SG12<ConformsToP1, ConformsToP2>.InnerUEqualsConformsToP2<ConformsToP3>.self)
+  }
+
+  DemangleToMetadataTests.test("Check _mangledTypeName, _typeName use appropriate cache keys") {
+    // sanity check that name functions use the right keys to store cached names:
+    for _ in 1...2 {
+      expectEqual("Si", _mangledTypeName(Int.self)!)
+      expectEqual("Swift.Int", _typeName(Int.self, qualified: true))
+      expectEqual("Int", _typeName(Int.self, qualified: false))
+    }
+  }
+}
+
+
+runAllTests()


### PR DESCRIPTION
Backport of `Add _mangledTypeName to allow round trips T->mangledName->T` #30318

The patch also applies cleanly on 5.1, so I'm wondering if we want to backport there as well... 
I think personally I'm happy enough with 5.2 and asking users to upgrade.

cc @jckarter 