### PR TITLE
[AutoDiff upstream] [SIL] Add differentiable function instructions.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5774,6 +5774,67 @@ The rules on generic substitutions are identical to those of ``apply``.
 Differentiable Programming
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+differentiable_function
+```````````````````````
+::
+
+  sil-instruction ::= 'differentiable_function'
+                      sil-differentiable-function-parameter-indices
+                      sil-value ':' sil-type
+                      sil-differentiable-function-derivative-functions-clause?
+
+  sil-differentiable-function-parameter-indices ::=
+      '[' 'parameters' [0-9]+ (' ' [0-9]+)* ']'
+  sil-differentiable-derivative-functions-clause ::=
+      'with_derivative'
+      '{' sil-value ':' sil-type ',' sil-value ':' sil-type '}'
+
+  differentiable_function [parameters 0] %0 : $(T) -> T \
+    with_derivative {%1 : $(T) -> (T, (T) -> T), %2 : $(T) -> (T, (T) -> T)}
+
+Creates a ``@differentiable`` function from an original function operand and
+derivative function operands (optional). There are two derivative function
+kinds: a Jacobian-vector products (JVP) function and a vector-Jacobian products
+(VJP) function.
+
+``[parameters ...]`` specifies parameter indices that the original function is
+differentiable with respect to.
+
+The ``with_derivative`` clause specifies the derivative function operands
+associated with the original function.
+
+The differentiation transformation canonicalizes all `differentiable_function`
+instructions, generating derivative functions if necessary to fill in derivative
+function operands.
+
+In raw SIL, the ``with_derivative`` clause is optional. In canonical SIL, the
+``with_derivative`` clause is mandatory.
+
+
+differentiable_function_extract
+```````````````````````````````
+::
+
+  sil-instruction ::= 'differentiable_function_extract'
+                      '[' sil-differentiable-function-extractee ']'
+                      sil-value ':' sil-type
+                      ('as' sil-type)?
+
+  sil-differentiable-function-extractee ::= 'original' | 'jvp' | 'vjp'
+
+  differentiable_function_extract [original] %0 : $@differentiable (T) -> T
+  differentiable_function_extract [jvp] %0 : $@differentiable (T) -> T
+  differentiable_function_extract [vjp] %0 : $@differentiable (T) -> T
+  differentiable_function_extract [jvp] %0 : $@differentiable (T) -> T \
+    as $(@in_constant T) -> (T, (T.TangentVector) -> T.TangentVector)
+
+Extracts the original function or a derivative function from the given
+``@differentiable`` function. The extractee is one of the following:
+``[original]``, ``[jvp]``, or ``[vjp]``.
+
+In lowered SIL, an explicit extractee type may be provided. This is currently
+used by the LoadableByAddress transformation, which rewrites function types.
+
 differentiability_witness_function
 ``````````````````````````````````
 ::

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -75,6 +75,41 @@ struct AutoDiffDerivativeFunctionKind {
   }
 };
 
+/// A component of a SIL `@differentiable` function-typed value.
+struct NormalDifferentiableFunctionTypeComponent {
+  enum innerty : unsigned { Original = 0, JVP = 1, VJP = 2 } rawValue;
+
+  NormalDifferentiableFunctionTypeComponent() = default;
+  NormalDifferentiableFunctionTypeComponent(innerty rawValue)
+      : rawValue(rawValue) {}
+  NormalDifferentiableFunctionTypeComponent(
+      AutoDiffDerivativeFunctionKind kind);
+  explicit NormalDifferentiableFunctionTypeComponent(unsigned rawValue)
+      : NormalDifferentiableFunctionTypeComponent((innerty)rawValue) {}
+  explicit NormalDifferentiableFunctionTypeComponent(StringRef name);
+  operator innerty() const { return rawValue; }
+
+  /// Returns the derivative function kind, if the component is a derivative
+  /// function.
+  Optional<AutoDiffDerivativeFunctionKind> getAsDerivativeFunctionKind() const;
+};
+
+/// A component of a SIL `@differentiable(linear)` function-typed value.
+struct LinearDifferentiableFunctionTypeComponent {
+  enum innerty : unsigned {
+    Original = 0,
+    Transpose = 1,
+  } rawValue;
+
+  LinearDifferentiableFunctionTypeComponent() = default;
+  LinearDifferentiableFunctionTypeComponent(innerty rawValue)
+      : rawValue(rawValue) {}
+  explicit LinearDifferentiableFunctionTypeComponent(unsigned rawValue)
+      : LinearDifferentiableFunctionTypeComponent((innerty)rawValue) {}
+  explicit LinearDifferentiableFunctionTypeComponent(StringRef name);
+  operator innerty() const { return rawValue; }
+};
+
 /// A derivative function configuration, uniqued in `ASTContext`.
 /// Identifies a specific derivative function given an original function.
 class AutoDiffDerivativeFunctionIdentifier : public llvm::FoldingSetNode {

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1628,6 +1628,17 @@ ERROR(sil_autodiff_expected_parameter_index,PointsToFirstBadToken,
       "expected the index of a parameter to differentiate with respect to", ())
 ERROR(sil_autodiff_expected_result_index,PointsToFirstBadToken,
       "expected the index of a result to differentiate from", ())
+ERROR(sil_inst_autodiff_operand_list_expected_lbrace,PointsToFirstBadToken,
+      "expected '{' to start a derivative function list", ())
+ERROR(sil_inst_autodiff_operand_list_expected_comma,PointsToFirstBadToken,
+      "expected ',' between operands in a derivative function list", ())
+ERROR(sil_inst_autodiff_operand_list_expected_rbrace,PointsToFirstBadToken,
+      "expected '}' to start a derivative function list", ())
+ERROR(sil_inst_autodiff_expected_differentiable_extractee_kind,PointsToFirstBadToken,
+      "expected an extractee kind attribute, which can be one of '[original]', "
+      "'[jvp]', and '[vjp]'", ())
+ERROR(sil_inst_autodiff_expected_function_type_operand,PointsToFirstBadToken,
+      "expected an operand of a function type", ())
 ERROR(sil_inst_autodiff_expected_differentiability_witness_kind,PointsToFirstBadToken,
       "expected a differentiability witness kind, which can be one of '[jvp]', "
       "'[vjp]', or '[transpose]'", ())

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2164,6 +2164,23 @@ public:
   // Differentiable programming instructions
   //===--------------------------------------------------------------------===//
 
+  DifferentiableFunctionInst *createDifferentiableFunction(
+      SILLocation Loc, IndexSubset *ParameterIndices, SILValue OriginalFunction,
+      Optional<std::pair<SILValue, SILValue>> JVPAndVJPFunctions = None) {
+    return insert(DifferentiableFunctionInst::create(
+        getModule(), getSILDebugLocation(Loc), ParameterIndices,
+        OriginalFunction, JVPAndVJPFunctions, hasOwnership()));
+  }
+
+  /// Note: explicit extractee type may be specified only in lowered SIL.
+  DifferentiableFunctionExtractInst *createDifferentiableFunctionExtract(
+      SILLocation Loc, NormalDifferentiableFunctionTypeComponent Extractee,
+      SILValue Function, Optional<SILType> ExtracteeType = None) {
+    return insert(new (getModule()) DifferentiableFunctionExtractInst(
+        getModule(), getSILDebugLocation(Loc), Extractee, Function,
+        ExtracteeType));
+  }
+
   /// Note: explicit function type may be specified only in lowered SIL.
   DifferentiabilityWitnessFunctionInst *createDifferentiabilityWitnessFunction(
       SILLocation Loc, DifferentiabilityWitnessFunctionKind WitnessKind,

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -2828,6 +2828,33 @@ void SILCloner<ImplClass>::visitKeyPathInst(KeyPathInst *Inst) {
 }
 
 template <typename ImplClass>
+void SILCloner<ImplClass>::visitDifferentiableFunctionInst(
+    DifferentiableFunctionInst *Inst) {
+  getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
+  Optional<std::pair<SILValue, SILValue>> derivativeFns = None;
+  if (Inst->hasDerivativeFunctions())
+    derivativeFns = std::make_pair(getOpValue(Inst->getJVPFunction()),
+                                   getOpValue(Inst->getVJPFunction()));
+  recordClonedInstruction(
+      Inst, getBuilder().createDifferentiableFunction(
+                getOpLocation(Inst->getLoc()), Inst->getParameterIndices(),
+                getOpValue(Inst->getOriginalFunction()), derivativeFns));
+}
+
+template <typename ImplClass>
+void SILCloner<ImplClass>::visitDifferentiableFunctionExtractInst(
+    DifferentiableFunctionExtractInst *Inst) {
+  getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
+  Optional<SILType> explicitExtracteeType = None;
+  if (Inst->hasExplicitExtracteeType())
+    explicitExtracteeType = Inst->getType();
+  recordClonedInstruction(
+      Inst, getBuilder().createDifferentiableFunctionExtract(
+                getOpLocation(Inst->getLoc()), Inst->getExtractee(),
+                getOpValue(Inst->getOperand()), explicitExtracteeType));
+}
+
+template <typename ImplClass>
 void SILCloner<ImplClass>::visitDifferentiabilityWitnessFunctionInst(
     DifferentiabilityWitnessFunctionInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -692,6 +692,11 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
                     SingleValueInstruction, None, DoesNotRelease)
 
   // Differentiable programming
+  SINGLE_VALUE_INST(DifferentiableFunctionInst, differentiable_function,
+                    SingleValueInstruction, None, DoesNotRelease)
+  SINGLE_VALUE_INST(DifferentiableFunctionExtractInst,
+                    differentiable_function_extract,
+                    SingleValueInstruction, None, DoesNotRelease)
   SINGLE_VALUE_INST(DifferentiabilityWitnessFunctionInst,
                     differentiability_witness_function,
                     SingleValueInstruction, None, DoesNotRelease)

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -28,6 +28,50 @@ AutoDiffDerivativeFunctionKind::AutoDiffDerivativeFunctionKind(
   rawValue = *result;
 }
 
+NormalDifferentiableFunctionTypeComponent::
+    NormalDifferentiableFunctionTypeComponent(
+        AutoDiffDerivativeFunctionKind kind) {
+  switch (kind) {
+  case AutoDiffDerivativeFunctionKind::JVP:
+    rawValue = JVP;
+    return;
+  case AutoDiffDerivativeFunctionKind::VJP:
+    rawValue = VJP;
+    return;
+  }
+}
+
+NormalDifferentiableFunctionTypeComponent::
+    NormalDifferentiableFunctionTypeComponent(StringRef string) {
+  Optional<innerty> result = llvm::StringSwitch<Optional<innerty>>(string)
+                                 .Case("original", Original)
+                                 .Case("jvp", JVP)
+                                 .Case("vjp", VJP);
+  assert(result && "Invalid string");
+  rawValue = *result;
+}
+
+Optional<AutoDiffDerivativeFunctionKind>
+NormalDifferentiableFunctionTypeComponent::getAsDerivativeFunctionKind() const {
+  switch (rawValue) {
+  case Original:
+    return None;
+  case JVP:
+    return {AutoDiffDerivativeFunctionKind::JVP};
+  case VJP:
+    return {AutoDiffDerivativeFunctionKind::VJP};
+  }
+}
+
+LinearDifferentiableFunctionTypeComponent::
+    LinearDifferentiableFunctionTypeComponent(StringRef string) {
+  Optional<innerty> result = llvm::StringSwitch<Optional<innerty>>(string)
+                                 .Case("original", Original)
+                                 .Case("transpose", Transpose);
+  assert(result && "Invalid string");
+  rawValue = *result;
+}
+
 DifferentiabilityWitnessFunctionKind::DifferentiabilityWitnessFunctionKind(
     StringRef string) {
   Optional<innerty> result = llvm::StringSwitch<Optional<innerty>>(string)

--- a/lib/IRGen/CMakeLists.txt
+++ b/lib/IRGen/CMakeLists.txt
@@ -16,6 +16,7 @@ add_swift_host_library(swiftIRGen STATIC
   GenControl.cpp
   GenCoverage.cpp
   GenDecl.cpp
+  GenDiffFunc.cpp
   GenDiffWitness.cpp
   GenEnum.cpp
   GenExistential.cpp

--- a/lib/IRGen/GenDiffFunc.cpp
+++ b/lib/IRGen/GenDiffFunc.cpp
@@ -1,0 +1,350 @@
+//===- GenDiffFunc.cpp - Swift IR Generation For @differentiable Functions ===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements IR generation for `@differentiable` function types in
+// Swift.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/Decl.h"
+#include "swift/AST/Pattern.h"
+#include "swift/AST/Types.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/SIL/SILType.h"
+#include "llvm/IR/DerivedTypes.h"
+
+#include "Explosion.h"
+#include "GenHeap.h"
+#include "GenRecord.h"
+#include "GenType.h"
+#include "IRGenFunction.h"
+#include "IRGenModule.h"
+#include "IndirectTypeInfo.h"
+#include "NonFixedTypeInfo.h"
+
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"
+
+using namespace swift;
+using namespace irgen;
+
+//----------------------------------------------------------------------------//
+// `@differentiable` (non-linear) function type info
+//----------------------------------------------------------------------------//
+
+namespace {
+class DifferentiableFuncFieldInfo final
+    : public RecordField<DifferentiableFuncFieldInfo> {
+public:
+  DifferentiableFuncFieldInfo(
+      NormalDifferentiableFunctionTypeComponent component, const TypeInfo &type,
+      IndexSubset *parameterIndices)
+      : RecordField(type), component(component),
+        parameterIndices(parameterIndices) {}
+
+  /// The field index.
+  const NormalDifferentiableFunctionTypeComponent component;
+
+  /// The parameter indices.
+  IndexSubset *parameterIndices;
+
+  std::string getFieldName() const {
+    switch (component) {
+    case NormalDifferentiableFunctionTypeComponent::Original:
+      return "original";
+    case NormalDifferentiableFunctionTypeComponent::JVP:
+      return "jvp";
+    case NormalDifferentiableFunctionTypeComponent::VJP:
+      return "vjp";
+    }
+  }
+
+  SILType getType(IRGenModule &IGM, SILType t) const {
+    auto fnTy = t.castTo<SILFunctionType>();
+    auto origFnTy = fnTy->getWithoutDifferentiability();
+    if (component == NormalDifferentiableFunctionTypeComponent::Original)
+      return SILType::getPrimitiveObjectType(origFnTy);
+    auto kind = *component.getAsDerivativeFunctionKind();
+    auto assocTy = origFnTy->getAutoDiffDerivativeFunctionType(
+        parameterIndices, /*resultIndex*/ 0, kind, IGM.getSILTypes(),
+        LookUpConformanceInModule(IGM.getSwiftModule()));
+    return SILType::getPrimitiveObjectType(assocTy);
+  }
+};
+
+class DifferentiableFuncTypeInfo final
+    : public RecordTypeInfo<DifferentiableFuncTypeInfo, LoadableTypeInfo,
+                            DifferentiableFuncFieldInfo> {
+  using super = RecordTypeInfo<DifferentiableFuncTypeInfo, LoadableTypeInfo,
+                               DifferentiableFuncFieldInfo>;
+
+public:
+  DifferentiableFuncTypeInfo(ArrayRef<DifferentiableFuncFieldInfo> fields,
+                             unsigned explosionSize, llvm::Type *ty, Size size,
+                             SpareBitVector &&spareBits, Alignment align,
+                             IsPOD_t isPOD, IsFixedSize_t alwaysFixedSize)
+      : super(fields, explosionSize, ty, size, std::move(spareBits), align,
+              isPOD, alwaysFixedSize) {}
+
+  Address projectFieldAddress(IRGenFunction &IGF, Address addr, SILType T,
+                              const DifferentiableFuncFieldInfo &field) const {
+    return field.projectAddress(IGF, addr, getNonFixedOffsets(IGF, T));
+  }
+
+  void initializeFromParams(IRGenFunction &IGF, Explosion &params, Address src,
+                            SILType T, bool isOutlined) const override {
+    llvm_unreachable("unexploded @differentiable function as argument?");
+  }
+
+  void addToAggLowering(IRGenModule &IGM, SwiftAggLowering &lowering,
+                        Size offset) const override {
+    for (auto &field : getFields()) {
+      auto fieldOffset = offset + field.getFixedByteOffset();
+      cast<LoadableTypeInfo>(field.getTypeInfo())
+          .addToAggLowering(IGM, lowering, fieldOffset);
+    }
+  }
+
+  TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
+                                        SILType T) const override {
+    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+  }
+
+  llvm::NoneType getNonFixedOffsets(IRGenFunction &IGF) const { return None; }
+  llvm::NoneType getNonFixedOffsets(IRGenFunction &IGF, SILType T) const {
+    return None;
+  }
+};
+
+class DifferentiableFuncTypeBuilder
+    : public RecordTypeBuilder<DifferentiableFuncTypeBuilder,
+                               DifferentiableFuncFieldInfo,
+                               NormalDifferentiableFunctionTypeComponent> {
+
+  SILFunctionType *originalType;
+  IndexSubset *parameterIndices;
+
+public:
+  DifferentiableFuncTypeBuilder(IRGenModule &IGM, SILFunctionType *fnTy)
+      : RecordTypeBuilder(IGM),
+        originalType(fnTy->getWithoutDifferentiability()),
+        parameterIndices(fnTy->getDifferentiabilityParameterIndices()) {
+    assert(fnTy->getDifferentiabilityKind() == DifferentiabilityKind::Normal);
+  }
+
+  TypeInfo *createFixed(ArrayRef<DifferentiableFuncFieldInfo> fields,
+                        StructLayout &&layout) {
+    llvm_unreachable("@differentiable functions are always loadable");
+  }
+
+  DifferentiableFuncTypeInfo *
+  createLoadable(ArrayRef<DifferentiableFuncFieldInfo> fields,
+                 StructLayout &&layout, unsigned explosionSize) {
+    return DifferentiableFuncTypeInfo::create(
+        fields, explosionSize, layout.getType(), layout.getSize(),
+        std::move(layout.getSpareBits()), layout.getAlignment(), layout.isPOD(),
+        layout.isAlwaysFixedSize());
+  }
+
+  TypeInfo *createNonFixed(ArrayRef<DifferentiableFuncFieldInfo> fields,
+                           FieldsAreABIAccessible_t fieldsAccessible,
+                           StructLayout &&layout) {
+    llvm_unreachable("@differentiable functions are always loadable");
+  }
+
+  DifferentiableFuncFieldInfo
+  getFieldInfo(unsigned index,
+               NormalDifferentiableFunctionTypeComponent component,
+               const TypeInfo &fieldTI) {
+    return DifferentiableFuncFieldInfo(component, fieldTI, parameterIndices);
+  }
+
+  SILType getType(NormalDifferentiableFunctionTypeComponent component) {
+    if (component == NormalDifferentiableFunctionTypeComponent::Original)
+      return SILType::getPrimitiveObjectType(originalType->getCanonicalType());
+    auto kind = *component.getAsDerivativeFunctionKind();
+    auto assocTy = originalType->getAutoDiffDerivativeFunctionType(
+        parameterIndices, /*resultIndex*/ 0, kind, IGM.getSILTypes(),
+        LookUpConformanceInModule(IGM.getSwiftModule()));
+    return SILType::getPrimitiveObjectType(assocTy);
+  }
+
+  StructLayout performLayout(ArrayRef<const TypeInfo *> fieldTypes) {
+    return StructLayout(IGM, /*decl=*/nullptr, LayoutKind::NonHeapObject,
+                        LayoutStrategy::Universal, fieldTypes);
+  }
+};
+} // end anonymous namespace
+
+//----------------------------------------------------------------------------//
+// `@differentiable(linear)` function type info
+//----------------------------------------------------------------------------//
+
+namespace {
+class LinearFuncFieldInfo final : public RecordField<LinearFuncFieldInfo> {
+public:
+  LinearFuncFieldInfo(LinearDifferentiableFunctionTypeComponent component,
+                      const TypeInfo &type, IndexSubset *parameterIndices)
+      : RecordField(type), component(component),
+        parameterIndices(parameterIndices) {}
+
+  /// The field index.
+  const LinearDifferentiableFunctionTypeComponent component;
+
+  /// The parameter indices.
+  IndexSubset *parameterIndices;
+
+  std::string getFieldName() const {
+    switch (component) {
+    case LinearDifferentiableFunctionTypeComponent::Original:
+      return "original";
+    case LinearDifferentiableFunctionTypeComponent::Transpose:
+      return "transpose";
+    }
+  }
+
+  SILType getType(IRGenModule &IGM, SILType t) const {
+    auto fnTy = t.castTo<SILFunctionType>();
+    auto origFnTy = fnTy->getWithoutDifferentiability();
+    switch (component) {
+    case LinearDifferentiableFunctionTypeComponent::Original:
+      return SILType::getPrimitiveObjectType(origFnTy);
+    case LinearDifferentiableFunctionTypeComponent::Transpose:
+      auto transposeTy = origFnTy->getAutoDiffTransposeFunctionType(
+          parameterIndices, IGM.getSILTypes(),
+          LookUpConformanceInModule(IGM.getSwiftModule()));
+      return SILType::getPrimitiveObjectType(transposeTy);
+    }
+  }
+};
+
+class LinearFuncTypeInfo final
+    : public RecordTypeInfo<LinearFuncTypeInfo, LoadableTypeInfo,
+                            LinearFuncFieldInfo> {
+  using super =
+      RecordTypeInfo<LinearFuncTypeInfo, LoadableTypeInfo, LinearFuncFieldInfo>;
+
+public:
+  LinearFuncTypeInfo(ArrayRef<LinearFuncFieldInfo> fields,
+                     unsigned explosionSize, llvm::Type *ty, Size size,
+                     SpareBitVector &&spareBits, Alignment align, IsPOD_t isPOD,
+                     IsFixedSize_t alwaysFixedSize)
+      : super(fields, explosionSize, ty, size, std::move(spareBits), align,
+              isPOD, alwaysFixedSize) {}
+
+  Address projectFieldAddress(IRGenFunction &IGF, Address addr, SILType T,
+                              const LinearFuncFieldInfo &field) const {
+    return field.projectAddress(IGF, addr, getNonFixedOffsets(IGF, T));
+  }
+
+  void initializeFromParams(IRGenFunction &IGF, Explosion &params, Address src,
+                            SILType T, bool isOutlined) const override {
+    llvm_unreachable("unexploded @differentiable function as argument?");
+  }
+
+  void addToAggLowering(IRGenModule &IGM, SwiftAggLowering &lowering,
+                        Size offset) const override {
+    for (auto &field : getFields()) {
+      auto fieldOffset = offset + field.getFixedByteOffset();
+      cast<LoadableTypeInfo>(field.getTypeInfo())
+          .addToAggLowering(IGM, lowering, fieldOffset);
+    }
+  }
+
+  TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
+                                        SILType T) const override {
+    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+  }
+
+  llvm::NoneType getNonFixedOffsets(IRGenFunction &IGF) const { return None; }
+  llvm::NoneType getNonFixedOffsets(IRGenFunction &IGF, SILType T) const {
+    return None;
+  }
+};
+
+class LinearFuncTypeBuilder
+    : public RecordTypeBuilder<LinearFuncTypeBuilder, LinearFuncFieldInfo,
+                               LinearDifferentiableFunctionTypeComponent> {
+
+  SILFunctionType *originalType;
+  IndexSubset *parameterIndices;
+
+public:
+  LinearFuncTypeBuilder(IRGenModule &IGM, SILFunctionType *fnTy)
+      : RecordTypeBuilder(IGM),
+        originalType(fnTy->getWithoutDifferentiability()),
+        parameterIndices(fnTy->getDifferentiabilityParameterIndices()) {
+    assert(fnTy->getDifferentiabilityKind() == DifferentiabilityKind::Linear);
+  }
+
+  TypeInfo *createFixed(ArrayRef<LinearFuncFieldInfo> fields,
+                        StructLayout &&layout) {
+    llvm_unreachable("@differentiable functions are always loadable");
+  }
+
+  LinearFuncTypeInfo *createLoadable(ArrayRef<LinearFuncFieldInfo> fields,
+                                     StructLayout &&layout,
+                                     unsigned explosionSize) {
+    return LinearFuncTypeInfo::create(
+        fields, explosionSize, layout.getType(), layout.getSize(),
+        std::move(layout.getSpareBits()), layout.getAlignment(), layout.isPOD(),
+        layout.isAlwaysFixedSize());
+  }
+
+  TypeInfo *createNonFixed(ArrayRef<LinearFuncFieldInfo> fields,
+                           FieldsAreABIAccessible_t fieldsAccessible,
+                           StructLayout &&layout) {
+    llvm_unreachable("@differentiable functions are always loadable");
+  }
+
+  LinearFuncFieldInfo
+  getFieldInfo(unsigned index, LinearDifferentiableFunctionTypeComponent field,
+               const TypeInfo &fieldTI) {
+    return LinearFuncFieldInfo(field, fieldTI, parameterIndices);
+  }
+
+  SILType getType(LinearDifferentiableFunctionTypeComponent component) {
+    switch (component) {
+    case LinearDifferentiableFunctionTypeComponent::Original:
+      return SILType::getPrimitiveObjectType(originalType->getCanonicalType());
+    case LinearDifferentiableFunctionTypeComponent::Transpose:
+      auto transposeTy = originalType->getAutoDiffTransposeFunctionType(
+          parameterIndices, IGM.getSILTypes(),
+          LookUpConformanceInModule(IGM.getSwiftModule()));
+      return SILType::getPrimitiveObjectType(transposeTy);
+    }
+  }
+
+  StructLayout performLayout(ArrayRef<const TypeInfo *> fieldTypes) {
+    return StructLayout(IGM, /*decl=*/nullptr, LayoutKind::NonHeapObject,
+                        LayoutStrategy::Universal, fieldTypes);
+  }
+};
+} // end anonymous namespace
+
+//----------------------------------------------------------------------------//
+// Type converter entry points
+//----------------------------------------------------------------------------//
+
+const TypeInfo *
+TypeConverter::convertNormalDifferentiableFunctionType(SILFunctionType *type) {
+  DifferentiableFuncTypeBuilder builder(IGM, type);
+  return builder.layout({NormalDifferentiableFunctionTypeComponent::Original,
+                         NormalDifferentiableFunctionTypeComponent::JVP,
+                         NormalDifferentiableFunctionTypeComponent::VJP});
+}
+
+const TypeInfo *
+TypeConverter::convertLinearDifferentiableFunctionType(SILFunctionType *type) {
+  LinearFuncTypeBuilder builder(IGM, type);
+  return builder.layout({LinearDifferentiableFunctionTypeComponent::Original,
+                         LinearDifferentiableFunctionTypeComponent::Transpose});
+}

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -498,6 +498,16 @@ Address irgen::projectBlockStorageCapture(IRGenFunction &IGF,
 }
 
 const TypeInfo *TypeConverter::convertFunctionType(SILFunctionType *T) {
+  // Handle `@differentiable` and `@differentiable(linear)` functions.
+  switch (T->getDifferentiabilityKind()) {
+  case DifferentiabilityKind::Normal:
+    return convertNormalDifferentiableFunctionType(T);
+  case DifferentiabilityKind::Linear:
+    return convertLinearDifferentiableFunctionType(T);
+  case DifferentiabilityKind::NonDifferentiable:
+    break;
+  }
+
   switch (T->getRepresentation()) {
   case SILFunctionType::Representation::Block:
     return new BlockTypeInfo(CanSILFunctionType(T),

--- a/lib/IRGen/GenType.h
+++ b/lib/IRGen/GenType.h
@@ -145,6 +145,8 @@ private:
   const TypeInfo *convertEnumType(TypeBase *key, CanType type, EnumDecl *D);
   const TypeInfo *convertStructType(TypeBase *key, CanType type, StructDecl *D);
   const TypeInfo *convertFunctionType(SILFunctionType *T);
+  const TypeInfo *convertNormalDifferentiableFunctionType(SILFunctionType *T);
+  const TypeInfo *convertLinearDifferentiableFunctionType(SILFunctionType *T);
   const TypeInfo *convertBlockStorageType(SILBlockStorageType *T);
   const TypeInfo *convertBoxType(SILBoxType *T);
   const TypeInfo *convertArchetypeType(ArchetypeType *T);

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -5022,6 +5022,88 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
                                                  blockType, subMap);
       break;
     }
+    case SILInstructionKind::DifferentiableFunctionInst: {
+      // e.g. differentiable_function [parameters 0 1 2] %0 : $T
+      //
+      // e.g. differentiable_function [parameters 0 1 2] %0 : $T with_derivative
+      //      {%1 : $T, %2 : $T}
+      //       ^~ jvp   ^~ vjp
+      // Parse `[parameters <integer_literal>...]`.
+      SmallVector<unsigned, 8> parameterIndices;
+      if (parseIndexList(P, "parameters", parameterIndices,
+                         diag::sil_autodiff_expected_parameter_index))
+        return true;
+      // Parse the original function value.
+      SILValue original;
+      SourceLoc originalOperandLoc;
+      if (parseTypedValueRef(original, originalOperandLoc, B))
+        return true;
+      auto fnType = original->getType().getAs<SILFunctionType>();
+      if (!fnType) {
+        P.diagnose(originalOperandLoc,
+                   diag::sil_inst_autodiff_expected_function_type_operand);
+        return true;
+      }
+      Optional<std::pair<SILValue, SILValue>> derivativeFunctions = None;
+      // Parse an optional operand list
+      //   `with_derivative { <operand> , <operand> }`.
+      if (P.Tok.is(tok::identifier) && P.Tok.getText() == "with_derivative") {
+        P.consumeToken(tok::identifier);
+        // Parse derivative function values as an operand list.
+        // FIXME(rxwei): Change this to *not* require a type signature once
+        // we can infer derivative function types.
+        derivativeFunctions = std::make_pair(SILValue(), SILValue());
+        if (P.parseToken(
+                tok::l_brace,
+                diag::sil_inst_autodiff_operand_list_expected_lbrace) ||
+            parseTypedValueRef(derivativeFunctions->first, B) ||
+            P.parseToken(tok::comma,
+                         diag::sil_inst_autodiff_operand_list_expected_comma) ||
+            parseTypedValueRef(derivativeFunctions->second, B) ||
+            P.parseToken(tok::r_brace,
+                         diag::sil_inst_autodiff_operand_list_expected_rbrace))
+          return true;
+      }
+      if (parseSILDebugLocation(InstLoc, B))
+        return true;
+      auto *parameterIndicesSubset = IndexSubset::get(
+          P.Context, fnType->getNumParameters(), parameterIndices);
+      ResultVal = B.createDifferentiableFunction(
+          InstLoc, parameterIndicesSubset, original, derivativeFunctions);
+      break;
+    }
+    case SILInstructionKind::DifferentiableFunctionExtractInst: {
+      // Parse the rest of the instruction: an extractee, a differentiable
+      // function operand, an optional explicit extractee type, and a debug
+      // location.
+      NormalDifferentiableFunctionTypeComponent extractee;
+      StringRef extracteeNames[3] = {"original", "jvp", "vjp"};
+      SILValue functionOperand;
+      SourceLoc lastLoc;
+      if (P.parseToken(
+              tok::l_square,
+              diag::sil_inst_autodiff_expected_differentiable_extractee_kind) ||
+          parseSILIdentifierSwitch(
+              extractee, extracteeNames,
+              diag::sil_inst_autodiff_expected_differentiable_extractee_kind) ||
+          P.parseToken(tok::r_square, diag::sil_autodiff_expected_rsquare,
+                       "extractee kind"))
+        return true;
+      if (parseTypedValueRef(functionOperand, B))
+        return true;
+      // Parse an optional explicit extractee type.
+      Optional<SILType> extracteeType = None;
+      if (P.consumeIf(tok::kw_as)) {
+        extracteeType = SILType();
+        if (parseSILType(*extracteeType))
+          return true;
+      }
+      if (parseSILDebugLocation(InstLoc, B))
+        return true;
+      ResultVal = B.createDifferentiableFunctionExtract(
+          InstLoc, extractee, functionOperand, extracteeType);
+      break;
+    }
     case SILInstructionKind::DifferentiabilityWitnessFunctionInst: {
       // e.g. differentiability_witness_function
       //      [jvp] [parameters 0 1] [results 0] <T where T: Differentiable>

--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -455,6 +455,13 @@ void swift::findClosuresForFunctionValue(
         worklistInsert(SVI->getOperand(0));
         continue;
       }
+      // Look through `differentiable_function` operands, which are all
+      // function-typed.
+      if (auto *DFI = dyn_cast<DifferentiableFunctionInst>(I)) {
+        for (auto &fn : DFI->getAllOperands())
+          worklistInsert(fn.get());
+        continue;
+      }
     }
     // Look through Optionals.
     if (V->getType().getOptionalObjectType()) {

--- a/lib/SIL/OperandOwnership.cpp
+++ b/lib/SIL/OperandOwnership.cpp
@@ -348,6 +348,7 @@ FORWARD_ANY_OWNERSHIP_INST(UncheckedEnumData)
 FORWARD_ANY_OWNERSHIP_INST(DestructureStruct)
 FORWARD_ANY_OWNERSHIP_INST(DestructureTuple)
 FORWARD_ANY_OWNERSHIP_INST(InitExistentialRef)
+FORWARD_ANY_OWNERSHIP_INST(DifferentiableFunction)
 #undef FORWARD_ANY_OWNERSHIP_INST
 
 // An instruction that forwards a constant ownership or trivial ownership.
@@ -366,6 +367,8 @@ FORWARD_ANY_OWNERSHIP_INST(InitExistentialRef)
   }
 FORWARD_CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, MustBeLive, TupleExtract)
 FORWARD_CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, MustBeLive, StructExtract)
+FORWARD_CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, MustBeLive,
+                                        DifferentiableFunctionExtract)
 FORWARD_CONSTANT_OR_NONE_OWNERSHIP_INST(Owned, MustBeInvalidated,
                                         MarkUninitialized)
 #undef CONSTANT_OR_NONE_OWNERSHIP_INST

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -607,6 +607,95 @@ TryApplyInst *TryApplyInst::create(
                                      normalBB, errorBB, specializationInfo);
 }
 
+SILType DifferentiableFunctionInst::getDifferentiableFunctionType(
+    SILValue OriginalFunction, IndexSubset *ParameterIndices) {
+  auto fnTy = OriginalFunction->getType().castTo<SILFunctionType>();
+  auto diffTy = fnTy->getWithDifferentiability(DifferentiabilityKind::Normal,
+                                               ParameterIndices);
+  return SILType::getPrimitiveObjectType(diffTy);
+}
+
+ValueOwnershipKind DifferentiableFunctionInst::getMergedOwnershipKind(
+    SILValue OriginalFunction, ArrayRef<SILValue> DerivativeFunctions) {
+  if (DerivativeFunctions.empty())
+    return OriginalFunction.getOwnershipKind();
+  return *mergeSILValueOwnership(
+      {OriginalFunction, DerivativeFunctions[0], DerivativeFunctions[1]});
+}
+
+DifferentiableFunctionInst::DifferentiableFunctionInst(
+    SILDebugLocation Loc, IndexSubset *ParameterIndices,
+    SILValue OriginalFunction, ArrayRef<SILValue> DerivativeFunctions,
+    bool HasOwnership)
+    : InstructionBaseWithTrailingOperands(
+          OriginalFunction, DerivativeFunctions, Loc,
+          getDifferentiableFunctionType(OriginalFunction, ParameterIndices),
+          HasOwnership
+              ? getMergedOwnershipKind(OriginalFunction, DerivativeFunctions)
+              : ValueOwnershipKind(ValueOwnershipKind::None)),
+      ParameterIndices(ParameterIndices),
+      HasDerivativeFunctions(!DerivativeFunctions.empty()) {
+  assert(DerivativeFunctions.empty() || DerivativeFunctions.size() == 2);
+}
+
+DifferentiableFunctionInst *DifferentiableFunctionInst::create(
+    SILModule &Module, SILDebugLocation Loc, IndexSubset *ParameterIndices,
+    SILValue OriginalFunction,
+    Optional<std::pair<SILValue, SILValue>> VJPAndJVPFunctions,
+    bool HasOwnership) {
+  auto derivativeFunctions =
+      VJPAndJVPFunctions.hasValue()
+          ? ArrayRef<SILValue>(
+                reinterpret_cast<SILValue *>(VJPAndJVPFunctions.getPointer()),
+                2)
+          : ArrayRef<SILValue>();
+  size_t size = totalSizeToAlloc<Operand>(1 + derivativeFunctions.size());
+  void *buffer = Module.allocateInst(size, alignof(DifferentiableFunctionInst));
+  return ::new (buffer)
+      DifferentiableFunctionInst(Loc, ParameterIndices, OriginalFunction,
+                                 derivativeFunctions, HasOwnership);
+}
+
+SILType DifferentiableFunctionExtractInst::getExtracteeType(
+    SILValue function, NormalDifferentiableFunctionTypeComponent extractee,
+    SILModule &module) {
+  auto fnTy = function->getType().castTo<SILFunctionType>();
+  assert(fnTy->getDifferentiabilityKind() == DifferentiabilityKind::Normal);
+  auto originalFnTy = fnTy->getWithoutDifferentiability();
+  auto kindOpt = extractee.getAsDerivativeFunctionKind();
+  if (!kindOpt) {
+    assert(extractee == NormalDifferentiableFunctionTypeComponent::Original);
+    return SILType::getPrimitiveObjectType(originalFnTy);
+  }
+  auto resultFnTy = originalFnTy->getAutoDiffDerivativeFunctionType(
+      fnTy->getDifferentiabilityParameterIndices(), /*resultIndex*/ 0, *kindOpt,
+      module.Types, LookUpConformanceInModule(module.getSwiftModule()));
+  return SILType::getPrimitiveObjectType(resultFnTy);
+}
+
+DifferentiableFunctionExtractInst::DifferentiableFunctionExtractInst(
+    SILModule &module, SILDebugLocation debugLoc,
+    NormalDifferentiableFunctionTypeComponent extractee, SILValue function,
+    Optional<SILType> extracteeType)
+    : UnaryInstructionBase(debugLoc, function,
+                           extracteeType
+                               ? *extracteeType
+                               : getExtracteeType(function, extractee, module)),
+      Extractee(extractee), HasExplicitExtracteeType(extracteeType.hasValue()) {
+#ifndef NDEBUG
+  if (extracteeType.hasValue()) {
+    // Note: explicit extractee type is used to avoid inconsistent typing in:
+    // - Canonical SIL, due to generic specialization.
+    // - Lowered SIL, due to LoadableByAddress.
+    // See `TypeSubstCloner::visitDifferentiableFunctionExtractInst` for an
+    // explanation of how explicit extractee type is used.
+    assert((module.getStage() == SILStage::Canonical ||
+            module.getStage() == SILStage::Lowered) &&
+           "Explicit type is valid only in canonical or lowered SIL");
+  }
+#endif
+}
+
 SILType DifferentiabilityWitnessFunctionInst::getDifferentiabilityWitnessType(
     SILModule &module, DifferentiabilityWitnessFunctionKind witnessKind,
     SILDifferentiabilityWitness *witness) {

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2269,6 +2269,41 @@ public:
     }
   }
 
+  void visitDifferentiableFunctionInst(DifferentiableFunctionInst *dfi) {
+    *this << "[parameters";
+    for (auto i : dfi->getParameterIndices()->getIndices())
+      *this << ' ' << i;
+    *this << "] ";
+    *this << getIDAndType(dfi->getOriginalFunction());
+    if (dfi->hasDerivativeFunctions()) {
+      *this << " with_derivative ";
+      *this << '{' << getIDAndType(dfi->getJVPFunction()) << ", "
+            << getIDAndType(dfi->getVJPFunction()) << '}';
+    }
+  }
+
+  void visitDifferentiableFunctionExtractInst(
+      DifferentiableFunctionExtractInst *dfei) {
+    *this << '[';
+    switch (dfei->getExtractee()) {
+    case NormalDifferentiableFunctionTypeComponent::Original:
+      *this << "original";
+      break;
+    case NormalDifferentiableFunctionTypeComponent::JVP:
+      *this << "jvp";
+      break;
+    case NormalDifferentiableFunctionTypeComponent::VJP:
+      *this << "vjp";
+      break;
+    }
+    *this << "] ";
+    *this << getIDAndType(dfei->getOperand());
+    if (dfei->hasExplicitExtracteeType()) {
+      *this << " as ";
+      *this << dfei->getType();
+    }
+  }
+
   void visitDifferentiabilityWitnessFunctionInst(
       DifferentiabilityWitnessFunctionInst *dwfi) {
     auto *witness = dwfi->getWitness();

--- a/lib/SIL/ValueOwnership.cpp
+++ b/lib/SIL/ValueOwnership.cpp
@@ -159,6 +159,7 @@ CONSTANT_OWNERSHIP_INST(Unowned, ValueToBridgeObject)
   }
 CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, StructExtract)
 CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, TupleExtract)
+CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, DifferentiableFunctionExtract)
 // OpenExistentialValue opens the boxed value inside an existential
 // CoW box. The semantics of an existential CoW box implies that we
 // can only consume the projected value inside the box if the box is
@@ -263,6 +264,7 @@ FORWARDING_OWNERSHIP_INST(Enum)
 // frame from usage. In such cases, we have been creating unnecessary ref count
 // traffic in code.
 FORWARDING_OWNERSHIP_INST(InitExistentialRef)
+FORWARDING_OWNERSHIP_INST(DifferentiableFunction)
 #undef FORWARDING_OWNERSHIP_INST
 
 ValueOwnershipKind

--- a/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
@@ -327,6 +327,8 @@ static bool hasOpaqueArchetype(TypeExpansionContext context,
   case SILInstructionKind::CondFailInst:
   case SILInstructionKind::DestructureStructInst:
   case SILInstructionKind::DestructureTupleInst:
+  case SILInstructionKind::DifferentiableFunctionInst:
+  case SILInstructionKind::DifferentiableFunctionExtractInst:
   case SILInstructionKind::DifferentiabilityWitnessFunctionInst:
     // Handle by operand and result check.
     break;

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -875,6 +875,8 @@ InlineCost swift::instructionInlineCost(SILInstruction &I) {
   case SILInstructionKind::SelectValueInst:
   case SILInstructionKind::KeyPathInst:
   case SILInstructionKind::GlobalValueInst:
+  case SILInstructionKind::DifferentiableFunctionInst:
+  case SILInstructionKind::DifferentiableFunctionExtractInst:
   case SILInstructionKind::DifferentiabilityWitnessFunctionInst:
 #define COMMON_ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name)          \
   case SILInstructionKind::Name##ToRefInst:                                    \

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 548; // remove curried SILDeclRefs
+const uint16_t SWIFTMODULE_VERSION_MINOR = 549; // differentiable_function, differentiable_function_extract
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -149,6 +149,8 @@ namespace sil_block {
     SIL_PROPERTY,
     SIL_ONE_OPERAND_EXTRA_ATTR,
     SIL_TWO_OPERANDS_EXTRA_ATTR,
+    SIL_INST_DIFFERENTIABLE_FUNCTION,
+    SIL_INST_DIFFERENTIABLE_FUNCTION_EXTRACT,
 
     // We also share these layouts from the decls block. Their enumerators must
     // not overlap with ours.
@@ -446,6 +448,22 @@ namespace sil_block {
     ValueIDField,          // existential
     BCArray<ValueIDField>  // SILDeclRef
     // may be trailed by an inline protocol conformance
+  >;
+
+  using SILInstDifferentiableFunctionLayout = BCRecordLayout<
+    SIL_INST_DIFFERENTIABLE_FUNCTION,
+    BCVBR<8>,             // number of function parameters
+    BCFixed<1>,           // has derivative functions?
+    BCArray<ValueIDField> // parameter indices and operands
+  >;
+
+  using SILInstDifferentiableFunctionExtractLayout = BCRecordLayout<
+    SIL_INST_DIFFERENTIABLE_FUNCTION_EXTRACT,
+    TypeIDField,
+    SILTypeCategoryField,
+    ValueIDField,
+    BCFixed<2>, // extractee
+    BCFixed<1>  // has explicit extractee type?
   >;
 }
 

--- a/test/AutoDiff/SIL/Serialization/differentiable_function_inst.sil
+++ b/test/AutoDiff/SIL/Serialization/differentiable_function_inst.sil
@@ -1,0 +1,81 @@
+// Round-trip parsing/printing test.
+
+// RUN: %target-sil-opt -enable-experimental-differentiable-programming %s -emit-sorted-sil | %FileCheck %s --check-prefix=CHECK-SIL
+
+// Round-trip serialization-deserialization test.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-sil-opt -enable-experimental-differentiable-programming %s -emit-sib -o %t/tmp.sib -module-name main
+// RUN: %target-sil-opt -enable-experimental-differentiable-programming %t/tmp.sib -o %t/tmp.sil -module-name main
+// NOTE(SR-12090): Workaround because import declarations are not preserved in .sib files.
+// RUN: sed -e 's/import Swift$/import Swift; import _Differentiation/' %t/tmp.sil > %t/tmp_fixed.sil
+// RUN: %target-sil-opt -enable-experimental-differentiable-programming %t/tmp_fixed.sil -module-name main -emit-sorted-sil | %FileCheck %s --check-prefix=CHECK-SIL
+
+// IRGen test.
+
+// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -emit-ir %s | %FileCheck %s --check-prefix=CHECK-IRGEN
+
+// REQUIRES: differentiable_programming
+// NOTE(SR-12090): `shell` is required only to run `sed` as a SR-12090 workaround.
+// REQUIRES: shell
+
+sil_stage raw
+
+import Swift
+import Builtin
+
+import _Differentiation
+
+sil @function : $@convention(thin) (Float) -> Float
+sil @function_vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+
+sil @make_differentiable_function : $@convention(thin) () -> @differentiable @convention(thin) (Float) -> Float {
+bb0:
+  %orig_fn = function_ref @function : $@convention(thin) (Float) -> Float
+  %vjp_fn = function_ref @function_vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+  %diff_fn = differentiable_function [parameters 0] %orig_fn : $@convention(thin) (Float) -> Float with_derivative {undef : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), %vjp_fn : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)}
+  %extracted_vjp = differentiable_function_extract [vjp] %diff_fn : $@differentiable @convention(thin) (Float) -> Float
+  %extracted_original = differentiable_function_extract [original] %diff_fn : $@differentiable @convention(thin) (Float) -> Float
+  return %diff_fn : $@differentiable @convention(thin) (Float) -> Float
+}
+
+// CHECK-SIL-LABEL: @make_differentiable_function : $@convention(thin) () -> @differentiable @convention(thin) (Float) -> Float {
+// CHECK-SIL:   [[ORIG_FN:%.*]] = function_ref @function : $@convention(thin) (Float) -> Float
+// CHECK-SIL:   [[VJP_FN:%.*]] = function_ref @function_vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK-SIL:   [[DIFF_FN:%.*]] = differentiable_function [parameters 0] [[ORIG_FN]] : $@convention(thin) (Float) -> Float with_derivative {undef : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), [[VJP_FN]] : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)}
+// CHECK-SIL:   [[EXTRACTED_VJP_FN:%.*]] = differentiable_function_extract [vjp] [[DIFF_FN]] : $@differentiable @convention(thin) (Float) -> Float
+// CHECK-SIL:   [[EXTRACTED_ORIG_FN:%.*]] = differentiable_function_extract [original] [[DIFF_FN]] : $@differentiable @convention(thin) (Float) -> Float
+// CHECK-SIL:   return [[DIFF_FN]] : $@differentiable @convention(thin) (Float) -> Float
+
+// CHECK-IRGEN-LABEL: define swiftcc { i8*, i8*, i8* } @make_differentiable_function()
+// CHECK-IRGEN-NEXT: entry:
+// CHECK-IRGEN-NEXT:   ret { i8*, i8*, i8* } { i8* bitcast (float (float)* @function to i8*), i8* undef, i8* bitcast ({ float, i8*, %swift.refcounted* } (float)* @function_vjp to i8*) }
+
+sil @examplefunc : $@convention(thin) (Float, Float, Float) -> Float
+sil @examplemethod : $@convention(method) (Float, Float, Float) -> Float
+
+// CHECK-SIL-LABEL: sil @test_roundtrip_parse
+sil @test_roundtrip_parse : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @examplefunc : $@convention(thin) (Float, Float, Float) -> Float
+  %1 = differentiable_function [parameters 0 1 2] %0 : $@convention(thin) (Float, Float, Float) -> Float
+
+  // CHECK-SIL: %2 = differentiable_function_extract [vjp] %1 : $@differentiable @convention(thin) (Float, Float, Float) -> Float
+  %2 = differentiable_function_extract [vjp] %1 : $@differentiable @convention(thin) (Float, Float, Float) -> Float
+  %3 = differentiable_function [parameters 0] %0 : $@convention(thin) (Float, Float, Float) -> Float
+
+  // CHECK-SIL: %4 = differentiable_function_extract [vjp] %3 : $@differentiable @convention(thin) (Float, @noDerivative Float, @noDerivative Float) -> Float
+  %4 = differentiable_function_extract [vjp] %3 : $@differentiable @convention(thin) (Float, @noDerivative Float, @noDerivative Float) -> Float
+  %5 = function_ref @examplemethod : $@convention(method) (Float, Float, Float) -> Float
+  %6 = differentiable_function [parameters 0 1 2] %5 : $@convention(method) (Float, Float, Float) -> Float
+
+  // CHECK-SIL: %7 = differentiable_function_extract [vjp] %6 : $@differentiable @convention(method) (Float, Float, Float) -> Float
+  %7 = differentiable_function_extract [vjp] %6 : $@differentiable @convention(method) (Float, Float, Float) -> Float
+  %8 = differentiable_function [parameters 0] %5 : $@convention(method) (Float, Float, Float) -> Float
+
+  // CHECK-SIL: %9 = differentiable_function_extract [vjp] %8 : $@differentiable @convention(method) (Float, @noDerivative Float, @noDerivative Float) -> Float
+  %9 = differentiable_function_extract [vjp] %8 : $@differentiable @convention(method) (Float, @noDerivative Float, @noDerivative Float) -> Float
+
+  %ret = tuple ()
+  return %ret : $()
+}

--- a/test/AutoDiff/SIL/Serialization/differentiable_function_inst.sil
+++ b/test/AutoDiff/SIL/Serialization/differentiable_function_inst.sil
@@ -47,7 +47,7 @@ bb0:
 // CHECK-SIL:   [[EXTRACTED_ORIG_FN:%.*]] = differentiable_function_extract [original] [[DIFF_FN]] : $@differentiable @convention(thin) (Float) -> Float
 // CHECK-SIL:   return [[DIFF_FN]] : $@differentiable @convention(thin) (Float) -> Float
 
-// CHECK-IRGEN-LABEL: define swiftcc { i8*, i8*, i8* } @make_differentiable_function()
+// CHECK-IRGEN-LABEL: define {{.*}}swiftcc { i8*, i8*, i8* } @make_differentiable_function()
 // CHECK-IRGEN-NEXT: entry:
 // CHECK-IRGEN-NEXT:   ret { i8*, i8*, i8* } { i8* bitcast (float (float)* @function to i8*), i8* undef, i8* bitcast ({ float, i8*, %swift.refcounted* } (float)* @function_vjp to i8*) }
 


### PR DESCRIPTION
Add `differentiable_function` and `differentiable_function_extract`
instructions.

`differentiable_function` creates a `@differentiable` function-typed
value from an original function operand and derivative function operands
(optional).

`differentiable_function_extract` extracts either the original or
derivative function value from a `@differentiable` function.

The differentiation transform canonicalizes `differentiable_function`
instructions, filling in derivative function operands if missing.

Resolves TF-1139 and TF-1140.

Example:

```
sil @function : $@convention(thin) (Float) -> Float
sil @function_vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)

sil @make_differentiable_function : $@convention(thin) () -> @differentiable @convention(thin) (Float) -> Float {
bb0:
  %orig_fn = function_ref @function : $@convention(thin) (Float) -> Float
  %vjp_fn = function_ref @function_vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
  %diff_fn = differentiable_function [parameters 0] %orig_fn : $@convention(thin) (Float) -> Float with_derivative {undef : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), %vjp_fn : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)}
  %extracted_vjp = differentiable_function_extract [vjp] %diff_fn : $@differentiable @convention(thin) (Float) -> Float
  %extracted_original = differentiable_function_extract [original] %diff_fn : $@differentiable @convention(thin) (Float) -> Float
  return %diff_fn : $@differentiable @convention(thin) (Float) -> Float
}
```

---

Also add IRGen for `@differentiable` functions. `@differentiable` and
`@differentiable(linear)` functions are lowered as structs of function
pointers.