### PR TITLE
[AutoDiff][TF-1200] Adding derivatives for stdlib `pow` function.

### DIFF
--- a/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
+++ b/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
@@ -282,14 +282,18 @@ func _${derivative_kind}Erfc(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${
 @derivative(of: pow)
 func _vjpPow(_ x: ${T}, _ y: ${T}) -> (value: ${T}, pullback: (${T}) -> (${T}, ${T})) {
   let value = pow(x, y)
-  return (value, { v in (v * y * pow(x, y - 1), v * value * log(x)) })
+  return (value, { v in (
+    v * y * pow(x, y - 1), v * value * log(x.isLessThanOrEqualTo(0) ? ${T}(1) : x)
+  ) })
 }
 
 @inlinable
 @derivative(of: pow)
 func _jvpPow(_ x: ${T}, _ y: ${T}) -> (value: ${T}, differential: (${T}, ${T}) -> ${T}) {
   let value = pow(x, y)
-  return (value, { (dx, dy) in dx * y * pow(x, y - 1) + dy * value * log(x) })
+  return (value, { (dx, dy) in
+    dx * y * pow(x, y - 1) + dy * value * log(x.isLessThanOrEqualTo(0) ? ${T}(1) : x)
+  })
 }
 %  if T == 'Float80':
 #endif

--- a/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
+++ b/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
@@ -274,7 +274,7 @@ func _${derivative_kind}Erfc(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${
 %end # for derivative_kind in ['jvp', 'vjp']:
 
 // Binary functions
-%for T in ['Float', 'Double', 'Float80']:
+%for T in ['Float', 'Float80']:
 %  if T == 'Float80':
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 %  end

--- a/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
+++ b/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
@@ -298,4 +298,4 @@ func _jvpPow(_ x: ${T}, _ y: ${T}) -> (value: ${T}, differential: (${T}, ${T}) -
 %  if T == 'Float80':
 #endif
 %  end # if T == 'Float80':
-%end # for T in ['Float', 'Double', 'Float80']:
+%end # for T in ['Float', 'Float80']:

--- a/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
+++ b/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
@@ -130,6 +130,7 @@ func _${derivative_kind}Trunc<T: FloatingPoint & Differentiable> (
 }
 %end # for derivative_kind in ['jvp', 'vjp']:
 
+// Unary functions
 %for derivative_kind in ['jvp', 'vjp']:
 %  linear_map_kind = 'differential' if derivative_kind == 'jvp' else 'pullback'
 %  for T in ['Float', 'Double', 'Float80']:
@@ -271,3 +272,26 @@ func _${derivative_kind}Erfc(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${
 %    end # if T == 'Float80':
 %  end # for T in ['Float', 'Double', 'Float80']:
 %end # for derivative_kind in ['jvp', 'vjp']:
+
+// Binary functions
+%for T in ['Float', 'Double', 'Float80']:
+%  if T == 'Float80':
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+%  end
+@inlinable
+@derivative(of: pow)
+func _vjpPow(_ x: ${T}, _ y: ${T}) -> (value: ${T}, pullback: (${T}) -> (${T}, ${T})) {
+  let value = pow(x, y)
+  return (value, { v in (v * y * pow(x, y - 1), v * value * log(x)) })
+}
+
+@inlinable
+@derivative(of: pow)
+func _jvpPow(_ x: ${T}, _ y: ${T}) -> (value: ${T}, differential: (${T}, ${T}) -> ${T}) {
+  let value = pow(x, y)
+  return (value, { (dx, dy) in dx * y * pow(x, y - 1) + dy * value * log(x) })
+}
+%  if T == 'Float80':
+#endif
+%  end # if T == 'Float80':
+%end # for T in ['Float', 'Double', 'Float80']:

--- a/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
+++ b/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
@@ -114,6 +114,15 @@ DerivativeTests.test("${op}_${T}") {
 %end
     }
   }
+
+  // pow
+  let dpow = ${op}(at: 3 as ${T}, 2 as ${T}, in: pow)
+%if op == 'gradient':
+  expectEqualWithTolerance(6, dpow.0)
+  expectEqualWithTolerance(9.887510598012987222, dpow.1)
+%else: # if op == 'derivative'
+  expectEqualWithTolerance(15.887510598012987222, dpow)
+%end
 }
 
 %if T == 'Float80':

--- a/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
+++ b/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
@@ -141,37 +141,62 @@ DerivativeTests.test("${op}_${T}") {
   // pow
   let eps:${T} = 0.01
   let ulps:${T} = eps/eps.ulp
-  for a in -3...3 {
+
+  // Checks for negative base.
+  for a in -3..<0 {
     let x = ${T}(a)
     for b in -3...3 {
       let y = ${T}(b)
-      var expectedValues: (dx: ${T}, dy: ${T})?
-      if x.isZero {
-        if y.isLess(than: 0) {
-          expectedValues = (dx: ${T}.infinity, dy: ${T}.nan)
-        } else if y.isZero {
-          expectedValues = (dx: ${T}.nan, dy: ${T}.zero)
-        } else if !y.isEqual(to: 1) {
-          expectedValues = (dx: ${T}.zero, dy: ${T}.zero)
-        }
-      } else if x.isLess(than: 2) {
-        expectedValues = (dx: y * pow(x, y - 1), ${T}.zero)
-      }
-      if let (expectedDx, expectedDy) = expectedValues {
-        let dpow = ${op}(at: x, y, in: pow)
+      let expectedDx =  y * pow(x, y - 1)
+      let expectedDy = ${T}.zero
+      let dpow = ${op}(at: x, y, in: pow)
 %if op == 'gradient':
-        expectEqualWithTolerance(TestLiteralType(expectedDx), dpow.0)
-        expectEqualWithTolerance(TestLiteralType(expectedDy), dpow.1)
+      expectEqualWithTolerance(TestLiteralType(expectedDx), dpow.0)
+      expectEqualWithTolerance(TestLiteralType(expectedDy), dpow.1)
 %else: # if op == 'derivative'
-        expectEqualWithTolerance(TestLiteralType(expectedDx + expectedDy), dpow)
+      expectEqualWithTolerance(TestLiteralType(expectedDx + expectedDy), dpow)
 %end
-      } else {
+    }
+  }
+
+  // Checks for 0 base.
+  for b in -3...3 {
+    let y = ${T}(b)
+    var expectedValues: (dx: ${T}, dy: ${T})?
+    if y.isLess(than: 0) {
+      expectedValues = (dx: ${T}.infinity, dy: ${T}.nan)
+    } else if y.isZero {
+      expectedValues = (dx: ${T}.nan, dy: ${T}.zero)
+    } else if !y.isEqual(to: 1) {
+      expectedValues = (dx: ${T}.zero, dy: ${T}.zero)
+    }
+    if let (expectedDx, expectedDy) = expectedValues {
+      let dpow = ${op}(at: 0.0, y, in: pow)
 %if op == 'gradient':
-          checkGradient({ pow($0, $1) }, x, y, ulps: ulps)
+      expectEqualWithTolerance(TestLiteralType(expectedDx), dpow.0)
+      expectEqualWithTolerance(TestLiteralType(expectedDy), dpow.1)
 %else: # if op == 'derivative'
-          checkDerivative({ pow($0, $1) }, x, y, ulps: ulps)
+      expectEqualWithTolerance(TestLiteralType(expectedDx + expectedDy), dpow)
 %end
-      }
+    } else {
+%if op == 'gradient':
+      checkGradient({ pow($0, $1) }, 0.0, y, ulps: ulps)
+%else: # if op == 'derivative'
+      checkDerivative({ pow($0, $1) }, 0.0, y, ulps: ulps)
+%end
+    }
+  }
+
+  // Checks for positive base.
+  for a in 1...3 {
+    let x = ${T}(a)
+    for b in -3...3 {
+      let y = ${T}(b)
+%if op == 'gradient':
+      checkGradient({ pow($0, $1) }, x, y, ulps: ulps)
+%else: # if op == 'derivative'
+      checkDerivative({ pow($0, $1) }, x, y, ulps: ulps)
+%end
     }
   }
 }

--- a/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
+++ b/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
@@ -26,7 +26,7 @@ func expectEqualWithTolerance<T>(_ expected: TestLiteralType, _ actual: T,
                                  ulps allowed: T = 3,
                                  file: String = #file, line: UInt = #line)
                                  where T: BinaryFloatingPoint {
-  if actual == T(expected) || actual.isNaN && expected.isNaN {
+  if actual == T(expected) || actual.isNaN && expected.isNaN || actual.isInfinite && expected.isInfinite {
     return
   }
   //  Compute error in ulp, compare to tolerance.
@@ -38,17 +38,40 @@ func expectEqualWithTolerance<T>(_ expected: TestLiteralType, _ actual: T,
              file: file, line: line)
 }
 
+func computeDividedDifference<T: BinaryFloatingPoint> (
+  _ f: (T, T) -> T,
+  _ x: T,
+  _ y: T,
+  eps: T = 0.01
+) -> (dfdx: T, dfdy: T) {
+  let dfdx = (f(x + eps, y) - f(x, y)) / eps
+  let dfdy = (f(x, y + eps) - f(x, y)) / eps
+  return (dfdx, dfdy)
+}
+
 func checkGradient<T: BinaryFloatingPoint & Differentiable>(
   _ f: @differentiable (T, T) -> T,
   _ x: T,
-  _ y: T)
+  _ y: T,
+  ulps: T = 192)
 where T == T.TangentVector {
   let eps = T(0.01)
   let grad = gradient(at: x, y, in: f)
-  let dfdx = (f(x + eps, y) - f(x, y)) / eps
-  let dfdy = (f(x, y + eps) - f(x, y)) / eps
-  expectEqualWithTolerance(TestLiteralType(dfdx), grad.0, ulps: 192)
-  expectEqualWithTolerance(TestLiteralType(dfdy), grad.1, ulps: 192)
+  let (dfdx, dfdy) = computeDividedDifference(f, x, y, eps: eps)
+  expectEqualWithTolerance(TestLiteralType(dfdx), grad.0, ulps: ulps)
+  expectEqualWithTolerance(TestLiteralType(dfdy), grad.1, ulps: ulps)
+}
+
+func checkDerivative<T: BinaryFloatingPoint & Differentiable>(
+  _ f: @differentiable (T, T) -> T,
+  _ x: T,
+  _ y: T,
+  ulps: T = 192)
+where T == T.TangentVector {
+  let eps = T(0.01)
+  let deriv = derivative(at: x, y, in: f)
+  let (dfdx, dfdy) = computeDividedDifference(f, x, y, eps: eps)
+  expectEqualWithTolerance(TestLiteralType(dfdx + dfdy), deriv, ulps: ulps)
 }
 
 %for op in ['derivative', 'gradient']:
@@ -116,13 +139,41 @@ DerivativeTests.test("${op}_${T}") {
   }
 
   // pow
-  let dpow = ${op}(at: 3 as ${T}, 2 as ${T}, in: pow)
+  let eps:${T} = 0.01
+  let ulps:${T} = eps/eps.ulp
+  for a in -3...3 {
+    let x = ${T}(a)
+    for b in -3...3 {
+      let y = ${T}(b)
+      var expectedValues: (dx: ${T}, dy: ${T})?
+      if x.isZero {
+        if y.isLess(than: 0) {
+          expectedValues = (dx: ${T}.infinity, dy: ${T}.nan)
+        } else if y.isZero {
+          expectedValues = (dx: ${T}.nan, dy: ${T}.zero)
+        } else if !y.isEqual(to: 1) {
+          expectedValues = (dx: ${T}.zero, dy: ${T}.zero)
+        }
+      } else if x.isLess(than: 2) {
+        expectedValues = (dx: y * pow(x, y - 1), ${T}.zero)
+      }
+      if let (expectedDx, expectedDy) = expectedValues {
+        let dpow = ${op}(at: x, y, in: pow)
 %if op == 'gradient':
-  expectEqualWithTolerance(6, dpow.0)
-  expectEqualWithTolerance(9.887510598012987222, dpow.1)
+        expectEqualWithTolerance(TestLiteralType(expectedDx), dpow.0)
+        expectEqualWithTolerance(TestLiteralType(expectedDy), dpow.1)
 %else: # if op == 'derivative'
-  expectEqualWithTolerance(15.887510598012987222, dpow)
+        expectEqualWithTolerance(TestLiteralType(expectedDx + expectedDy), dpow)
 %end
+      } else {
+%if op == 'gradient':
+          checkGradient({ pow($0, $1) }, x, y, ulps: ulps)
+%else: # if op == 'derivative'
+          checkDerivative({ pow($0, $1) }, x, y, ulps: ulps)
+%end
+      }
+    }
+  }
 }
 
 %if T == 'Float80':


### PR DESCRIPTION
Adding JVP and VJP function derivatives for `pow` function
defined in stdlib.

Resolves TF-1200.