### PR TITLE
SILOptimizer: a new small optimization pass to remove redundant basic block arguments.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -253,6 +253,8 @@ PASS(PredictableMemoryAccessOptimizations, "predictable-memaccess-opts",
      "Predictable Memory Access Optimizations for Diagnostics")
 PASS(PredictableDeadAllocationElimination, "predictable-deadalloc-elim",
      "Eliminate dead temporary allocations after diagnostics")
+PASS(RedundantPhiElimination, "redundant-phi-elimination",
+     "Redundant Phi Block Argument Elimination")
 PASS(ReleaseDevirtualizer, "release-devirtualizer",
      "SIL release Devirtualization")
 PASS(RetainSinking, "retain-sinking",

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -356,6 +356,9 @@ void addSSAPasses(SILPassPipelinePlan &P, OptimizationLevelKind OpLevel) {
   }
 
   P.addPerformanceConstantPropagation();
+  // Remove redundant arguments right before CSE and DCE, so that CSE and DCE
+  // can cleanup redundant and dead instructions.
+  P.addRedundantPhiElimination();
   P.addCSE();
   P.addDCE();
 

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -24,6 +24,7 @@ silopt_register_sources(
   PerformanceInliner.cpp
   RedundantLoadElimination.cpp
   RedundantOverflowCheckRemoval.cpp
+  RedundantPhiElimination.cpp
   ReleaseDevirtualizer.cpp
   SemanticARCOpts.cpp
   SILCodeMotion.cpp

--- a/lib/SILOptimizer/Transforms/RedundantPhiElimination.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantPhiElimination.cpp
@@ -1,0 +1,201 @@
+//===--- RedundantPhiElimination.cpp - Remove redundant phi arguments -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass eliminates redundant basic block arguments.
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-optimize-block-arguments"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILArgument.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SILOptimizer/Utils/CFGOptUtils.h"
+#include "llvm/Support/Debug.h"
+
+using namespace swift;
+
+namespace {
+
+/// Removes redundant basic block phi-arguments.
+///
+/// RedundantPhiEliminationPass eliminates block arguments which have
+/// the same value as other arguments of the same block. This also works with
+/// cycles, like two equivalent loop induction variables. Such patterns are
+/// generated e.g. when using stdlib's enumerated() on Array.
+///
+/// \code
+///   preheader:
+///     br bb1(%initval, %initval)
+///   header(%phi1, %phi2):
+///     %next1 = builtin "add" (%phi1, %one)
+///     %next2 = builtin "add" (%phi2, %one)
+///     cond_br %loopcond, header(%next1, %next2), exit
+///   exit:
+/// \endcode
+///
+/// is replaced with
+///
+/// \code
+///   preheader:
+///     br bb1(%initval)
+///   header(%phi1):
+///     %next1 = builtin "add" (%phi1, %one)
+///     %next2 = builtin "add" (%phi1, %one) // dead: will be cleaned-up later
+///     cond_br %loopcond, header(%next1), exit
+///   exit:
+/// \endcode
+///
+/// Any remaining dead or "trivially" equivalent instructions will then be
+/// cleaned-up by DCE and CSE, respectively.
+///
+/// RedundantPhiEliminationPass is not part of SimplifyCFG because
+/// * no other SimplifyCFG optimization depends on it.
+/// * compile time: it doesn't need to run every time SimplifyCFG runs.
+///
+class RedundantPhiEliminationPass : public SILFunctionTransform {
+public:
+  RedundantPhiEliminationPass() {}
+
+  void run() override;
+
+private:
+  bool optimizeArgs(SILBasicBlock *block);
+
+  bool valuesAreEqual(SILValue val1, SILValue val2);
+};
+
+void RedundantPhiEliminationPass::run() {
+  SILFunction *F = getFunction();
+  if (!F->shouldOptimize())
+    return;
+
+  LLVM_DEBUG(llvm::dbgs() << "*** RedundantPhiElimination on function: "
+                          << F->getName() << " ***\n");
+
+  bool changed = false;
+  for (SILBasicBlock &block : *getFunction()) {
+    changed |= optimizeArgs(&block);
+  }
+
+  if (changed) {
+    invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+  }
+}
+
+bool RedundantPhiEliminationPass::optimizeArgs(SILBasicBlock *block) {
+  // Avoid running into quadratic behavior for blocks which have many arguments.
+  // This is seldom, anyway.
+  unsigned maxArgumentCombinations = 48;
+
+  bool changed = false;
+  unsigned numArgumentCombinations = 0;
+  for (unsigned arg1Idx = 0; arg1Idx < block->getNumArguments(); ++arg1Idx) {
+    for (unsigned arg2Idx = arg1Idx + 1; arg2Idx < block->getNumArguments();) {
+      if (++numArgumentCombinations > maxArgumentCombinations)
+        return changed;
+
+      SILArgument *arg1 = block->getArgument(arg1Idx);
+      SILArgument *arg2 = block->getArgument(arg2Idx);
+      if (!arg1->isPhiArgument() || !arg2->isPhiArgument())
+        continue;
+
+      if (valuesAreEqual(arg1, arg2)) {
+        arg2->replaceAllUsesWith(arg1);
+        erasePhiArgument(block, arg2Idx);
+        changed = true;
+      } else {
+        ++arg2Idx;
+      }
+    }
+  }
+  return changed;
+}
+
+bool RedundantPhiEliminationPass::valuesAreEqual(SILValue val1, SILValue val2) {
+
+  // Again, avoid running into quadratic behavior in case of cycles or long
+  // chains of instructions. This limit is practically never exceeded.
+  unsigned maxNumberOfChecks = 16;
+
+  SmallVector<std::pair<SILValue, SILValue>, 8> workList;
+  llvm::SmallSet<std::pair<SILValue, SILValue>, 16> handled;
+  
+  workList.push_back({val1, val2});
+  handled.insert({val1, val2});
+
+  while (!workList.empty()) {
+  
+    if (handled.size() > maxNumberOfChecks)
+      return false;
+  
+    auto valuePair = workList.pop_back_val();
+    SILValue val1 = valuePair.first;
+    SILValue val2 = valuePair.second;
+
+    // The trivial case.
+    if (val1 == val2)
+      continue;
+ 
+    if (val1->getKind() != val2->getKind())
+      return false;
+ 
+    if (auto *arg1 = dyn_cast<SILPhiArgument>(val1)) {
+      auto *arg2 = cast<SILPhiArgument>(val2);
+      SILBasicBlock *argBlock = arg1->getParent();
+      if (argBlock != arg2->getParent())
+        return false;
+      if (arg1->getType() != arg2->getType())
+        return false;
+    
+      // All incoming phi values must be equal.
+      for (SILBasicBlock *pred : argBlock->getPredecessorBlocks()) {
+        SILValue incoming1 = arg1->getIncomingPhiValue(pred);
+        SILValue incoming2 = arg2->getIncomingPhiValue(pred);
+        if (!incoming1 || !incoming2)
+          return false;
+
+        if (handled.insert({incoming1, incoming2}).second)
+          workList.push_back({incoming1, incoming2});
+      }
+      continue;
+    }
+    
+    if (auto *inst1 = dyn_cast<SingleValueInstruction>(val1)) {
+      // Bail if the instructions have any side effects.
+      if (inst1->getMemoryBehavior() != SILInstruction::MemoryBehavior::None)
+        return false;
+
+      auto *inst2 = cast<SingleValueInstruction>(val2);
+
+      // Compare the operands by putting them on the worklist.
+      if (!inst1->isIdenticalTo(inst2, [&](SILValue op1, SILValue op2) {
+            if (handled.insert({op1, op2}).second)
+              workList.push_back({op1, op2});
+            return true;
+          })) {
+        return false;
+      }
+      continue;
+    }
+    
+    return false;
+  }
+
+  return true;
+}
+
+} // end anonymous namespace
+
+SILTransform *swift::createRedundantPhiElimination() {
+  return new RedundantPhiEliminationPass();
+}

--- a/test/SILOptimizer/opt_enumerate.swift
+++ b/test/SILOptimizer/opt_enumerate.swift
@@ -24,3 +24,12 @@ public func eliminate_bounds_check(_ array: [Int]) {
   }
 }
 
+// CHECK-LABEL: sil @$s4test27eliminate_two_bounds_checksyySaySiGF
+// CHECK-NOT:  cond_fail {{.*}} "Index out of range"
+// CHECK: // end sil function '$s4test27eliminate_two_bounds_checksyySaySiGF'
+public func eliminate_two_bounds_checks(_ array: [Int]) {
+  for (index, x) in array.enumerated() {
+      take(x, array[index])
+  }
+}
+

--- a/test/SILOptimizer/redundant_phi_elimination.sil
+++ b/test/SILOptimizer/redundant_phi_elimination.sil
@@ -1,0 +1,155 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -redundant-phi-elimination | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+// CHECK-LABEL: sil @test_simple
+// CHECK: bb1:
+// CHECK:   br bb3(%0 : $Builtin.Int64)
+// CHECK: bb2:
+// CHECK:   br bb3(%1 : $Builtin.Int64)
+// CHECK: bb3([[ARG:%[0-9]+]] : $Builtin.Int64):
+// CHECK:   builtin "sadd_with_overflow_Int64"([[ARG]] : $Builtin.Int64, [[ARG]] : $Builtin.Int64,
+// CHECK: } // end sil function 'test_simple'
+sil @test_simple : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int64, 0
+  %1 = integer_literal $Builtin.Int64, 1
+  %2 = integer_literal $Builtin.Int1, -1
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%0 : $Builtin.Int64, %0 : $Builtin.Int64)
+  
+bb2:
+  br bb3(%1 : $Builtin.Int64, %1 : $Builtin.Int64)
+  
+
+bb3(%4 : $Builtin.Int64, %5 : $Builtin.Int64):
+  %6 = builtin "sadd_with_overflow_Int64"(%4 : $Builtin.Int64, %5 : $Builtin.Int64, %2 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %8 = tuple_extract %6 : $(Builtin.Int64, Builtin.Int1), 1
+  cond_fail %8 : $Builtin.Int1, "arithmetic overflow"
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @test_not_equal
+// CHECK: bb1:
+// CHECK:   br bb3(%0 : $Builtin.Int64, %0 : $Builtin.Int64)
+// CHECK: bb2:
+// CHECK:   br bb3(%0 : $Builtin.Int64, %1 : $Builtin.Int64)
+// CHECK: bb3([[ARG1:%[0-9]+]] : $Builtin.Int64, [[ARG2:%[0-9]+]] : $Builtin.Int64):
+// CHECK:   builtin "sadd_with_overflow_Int64"([[ARG1]] : $Builtin.Int64, [[ARG2]] : $Builtin.Int64,
+// CHECK: } // end sil function 'test_not_equal'
+sil @test_not_equal : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int64, 0
+  %1 = integer_literal $Builtin.Int64, 1
+  %2 = integer_literal $Builtin.Int1, -1
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%0 : $Builtin.Int64, %0 : $Builtin.Int64)
+  
+bb2:
+  br bb3(%0 : $Builtin.Int64, %1 : $Builtin.Int64)
+  
+
+bb3(%4 : $Builtin.Int64, %5 : $Builtin.Int64):
+  %6 = builtin "sadd_with_overflow_Int64"(%4 : $Builtin.Int64, %5 : $Builtin.Int64, %2 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %8 = tuple_extract %6 : $(Builtin.Int64, Builtin.Int1), 1
+  cond_fail %8 : $Builtin.Int1, "arithmetic overflow"
+  %r = tuple ()
+  return %r : $()
+}
+
+sil @unknown : $@convention(thin) () -> Builtin.Int64
+
+// CHECK-LABEL: sil @test_side_effects
+// CHECK:   [[A1:%[0-9]+]] = apply
+// CHECK:   [[A2:%[0-9]+]] = apply
+// CHECK:   br bb1([[A1]] : $Builtin.Int64, [[A2]] : $Builtin.Int64)
+// CHECK: bb1([[ARG1:%[0-9]+]] : $Builtin.Int64, [[ARG2:%[0-9]+]] : $Builtin.Int64):
+// CHECK:   builtin "sadd_with_overflow_Int64"([[ARG1]] : $Builtin.Int64, [[ARG2]] : $Builtin.Int64,
+// CHECK: } // end sil function 'test_side_effects'
+sil @test_side_effects : $@convention(thin) () -> () {
+bb0:
+  %f = function_ref @unknown : $@convention(thin) () -> Builtin.Int64
+  %0 = apply %f() : $@convention(thin) () -> Builtin.Int64
+  %1 = apply %f() : $@convention(thin) () -> Builtin.Int64
+  %2 = integer_literal $Builtin.Int1, -1
+  br bb1(%0 : $Builtin.Int64, %1 : $Builtin.Int64)
+  
+bb1(%4 : $Builtin.Int64, %5 : $Builtin.Int64):
+  %6 = builtin "sadd_with_overflow_Int64"(%4 : $Builtin.Int64, %5 : $Builtin.Int64, %2 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %8 = tuple_extract %6 : $(Builtin.Int64, Builtin.Int1), 1
+  cond_fail %8 : $Builtin.Int1, "arithmetic overflow"
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @test_loop
+// CHECK:   br bb1(%0 : $Builtin.Int64)
+// CHECK: bb1([[ARG:%[0-9]+]] : $Builtin.Int64):
+// CHECK:   [[S1:%[0-9]+]] = builtin "sadd_with_overflow_Int64"([[ARG]] : $Builtin.Int64,
+// CHECK:   [[T1:%[0-9]+]] = tuple_extract [[S1]] {{.*}}, 0
+// CHECK:   [[T2:%[0-9]+]] = tuple_extract [[S1]] {{.*}}, 1
+// CHECK:   cond_fail [[T2]]
+// CHECK:   [[S2:%[0-9]+]] = builtin "sadd_with_overflow_Int64"([[ARG]] : $Builtin.Int64,
+// CHECK:   [[T3:%[0-9]+]] = tuple_extract [[S2]] {{.*}}, 1
+// CHECK:   cond_fail [[T3]]
+// CHECK: bb2:
+// CHECK:   br bb1([[T1]] : $Builtin.Int64)
+// CHECK: } // end sil function 'test_loop'
+sil @test_loop : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int64, 0
+  %1 = integer_literal $Builtin.Int64, 1
+  %2 = integer_literal $Builtin.Int1, -1
+  br bb1(%0 : $Builtin.Int64, %0 : $Builtin.Int64)
+  
+
+bb1(%4 : $Builtin.Int64, %5 : $Builtin.Int64):
+  %6 = builtin "sadd_with_overflow_Int64"(%4 : $Builtin.Int64, %1 : $Builtin.Int64, %2 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %7 = tuple_extract %6 : $(Builtin.Int64, Builtin.Int1), 0
+  %8 = tuple_extract %6 : $(Builtin.Int64, Builtin.Int1), 1
+  cond_fail %8 : $Builtin.Int1, "arithmetic overflow"
+  %10 = builtin "sadd_with_overflow_Int64"(%5 : $Builtin.Int64, %1 : $Builtin.Int64, %2 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %11 = tuple_extract %10 : $(Builtin.Int64, Builtin.Int1), 0
+  %12 = tuple_extract %10 : $(Builtin.Int64, Builtin.Int1), 1
+  cond_fail %12 : $Builtin.Int1, "arithmetic overflow"
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1(%7 : $Builtin.Int64, %11 : $Builtin.Int64)
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @test_mismatching_arg
+// CHECK:   br bb1(%0 : $Builtin.Int64, %0 : $Builtin.Int64)
+// CHECK: bb1([[ARG1:%[0-9]+]] : $Builtin.Int64, {{%[0-9]+}} : $Builtin.Int64):
+// CHECK: bb2:
+// CHECK:   br bb1([[ARG1]] : $Builtin.Int64, %1 : $Builtin.Int64)
+// CHECK: } // end sil function 'test_mismatching_arg'
+sil @test_mismatching_arg : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int64, 0
+  %1 = integer_literal $Builtin.Int64, 1
+  br bb1(%0 : $Builtin.Int64, %0 : $Builtin.Int64)
+  
+
+bb1(%4 : $Builtin.Int64, %5 : $Builtin.Int64):
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1(%4 : $Builtin.Int64, %1 : $Builtin.Int64)
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}


### PR DESCRIPTION
The BlockArgumentOptPass eliminates block arguments which have the same value as other arguments of the same block.
This also works with cycles, like two equivalent loop induction variables. Such patterns are generated e.g. when using stdlib's enumerated() on Array.

```
preheader:
  br bb1(%initval, %initval)
header(%phi1, %phi2):
  %next1 = builtin "add" (%phi1, %one)
  %next2 = builtin "add" (%phi2, %one)
  cond_br %loopcond, header(%next1, %next2), exit
exit:
```
is replaced with
```
preheader:
  br bb1(%initval)
header(%phi1):
  %next1 = builtin "add" (%phi1, %one)
  %next2 = builtin "add" (%phi1, %one) // dead: will be cleaned-up later
  cond_br %loopcond, header(%next1), exit
exit:
```

Any remaining dead or "trivially" equivalent instructions will then be cleaned-up by DCE and CSE, respectively.

rdar://problem/33438123
