### PR TITLE
Add direct operator lookup requests

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7063,6 +7063,28 @@ public:
   }
 };
 
+/// The fixity of an OperatorDecl.
+enum class OperatorFixity : uint8_t {
+  Infix,
+  Prefix,
+  Postfix
+};
+
+inline void simple_display(llvm::raw_ostream &out, OperatorFixity fixity) {
+  switch (fixity) {
+  case OperatorFixity::Infix:
+    out << "infix";
+    return;
+  case OperatorFixity::Prefix:
+    out << "prefix";
+    return;
+  case OperatorFixity::Postfix:
+    out << "postfix";
+    return;
+  }
+  llvm_unreachable("Unhandled case in switch");
+}
+
 /// Abstract base class of operator declarations.
 class OperatorDecl : public Decl {
   SourceLoc OperatorLoc, NameLoc;
@@ -7088,6 +7110,21 @@ public:
       : Decl(kind, DC), OperatorLoc(OperatorLoc), NameLoc(NameLoc), name(Name),
         DesignatedNominalTypes(DesignatedNominalTypes) {}
 
+  /// Retrieve the operator's fixity, corresponding to the concrete subclass
+  /// of the OperatorDecl.
+  OperatorFixity getFixity() const {
+    switch (getKind()) {
+#define DECL(Id, Name) case DeclKind::Id: llvm_unreachable("Not an operator!");
+#define OPERATOR_DECL(Id, Name)
+#include "swift/AST/DeclNodes.def"
+    case DeclKind::InfixOperator:
+      return OperatorFixity::Infix;
+    case DeclKind::PrefixOperator:
+      return OperatorFixity::Prefix;
+    case DeclKind::PostfixOperator:
+      return OperatorFixity::Postfix;
+    }
+  }
 
   SourceLoc getOperatorLoc() const { return OperatorLoc; }
   SourceLoc getNameLoc() const { return NameLoc; }

--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -30,6 +30,9 @@ class FileUnit : public DeclContext {
 #pragma clang diagnostic pop
   virtual void anchor();
 
+  friend class DirectOperatorLookupRequest;
+  friend class DirectPrecedenceGroupLookupRequest;
+
   // FIXME: Stick this in a PointerIntPair.
   const FileUnitKind Kind;
 
@@ -107,6 +110,25 @@ public:
                                const ModuleDecl *importedModule,
                                SmallVectorImpl<Identifier> &spiGroups) const {};
 
+protected:
+  /// Look up an operator declaration. Do not call directly, use
+  /// \c DirectOperatorLookupRequest instead.
+  ///
+  /// \param name The operator name ("+", ">>", etc.)
+  ///
+  /// \param fixity One of Prefix, Infix, or Postfix.
+  virtual void
+  lookupOperatorDirect(Identifier name, OperatorFixity fixity,
+                       TinyPtrVector<OperatorDecl *> &results) const {}
+
+  /// Look up a precedence group. Do not call directly, use
+  /// \c DirectPrecedenceGroupLookupRequest instead.
+  ///
+  /// \param name The precedence group name.
+  virtual void lookupPrecedenceGroupDirect(
+      Identifier name, TinyPtrVector<PrecedenceGroupDecl *> &results) const {}
+
+public:
   /// Returns the comment attached to the given declaration.
   ///
   /// This function is an implementation detail for comment serialization.
@@ -340,23 +362,6 @@ public:
 
   virtual StringRef getFilenameForPrivateDecl(const ValueDecl *decl) const {
     return StringRef();
-  }
-
-  /// Look up an operator declaration.
-  ///
-  /// \param name The operator name ("+", ">>", etc.)
-  ///
-  /// \param fixity One of Prefix, Infix, or Postfix.
-  virtual OperatorDecl *lookupOperator(Identifier name,
-                                       OperatorFixity fixity) const {
-    return nullptr;
-  }
-
-  /// Look up a precedence group.
-  ///
-  /// \param name The precedence group name.
-  virtual PrecedenceGroupDecl *lookupPrecedenceGroup(Identifier name) const {
-    return nullptr;
   }
 
   /// Returns the Swift module that overlays a Clang module.

--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -346,8 +346,9 @@ public:
   ///
   /// \param name The operator name ("+", ">>", etc.)
   ///
-  /// \param fixity One of PrefixOperator, InfixOperator, or PostfixOperator.
-  virtual OperatorDecl *lookupOperator(Identifier name, DeclKind fixity) const {
+  /// \param fixity One of Prefix, Infix, or Postfix.
+  virtual OperatorDecl *lookupOperator(Identifier name,
+                                       OperatorFixity fixity) const {
     return nullptr;
   }
 

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -597,6 +597,41 @@ using LookupInfixOperatorRequest = LookupOperatorRequest<InfixOperatorDecl>;
 using LookupPostfixOperatorRequest = LookupOperatorRequest<PostfixOperatorDecl>;
 using LookupPrecedenceGroupRequest = LookupOperatorRequest<PrecedenceGroupDecl>;
 
+/// Looks up an operator in a given file or module without looking through
+/// imports.
+class DirectOperatorLookupRequest
+    : public SimpleRequest<DirectOperatorLookupRequest,
+                           TinyPtrVector<OperatorDecl *>(
+                               OperatorLookupDescriptor, OperatorFixity),
+                           CacheKind::Uncached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  llvm::Expected<TinyPtrVector<OperatorDecl *>>
+  evaluate(Evaluator &evaluator, OperatorLookupDescriptor descriptor,
+           OperatorFixity fixity) const;
+};
+
+/// Looks up an precedencegroup in a given file or module without looking
+/// through imports.
+class DirectPrecedenceGroupLookupRequest
+    : public SimpleRequest<DirectPrecedenceGroupLookupRequest,
+                           TinyPtrVector<PrecedenceGroupDecl *>(
+                               OperatorLookupDescriptor),
+                           CacheKind::Uncached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  llvm::Expected<TinyPtrVector<PrecedenceGroupDecl *>>
+  evaluate(Evaluator &evaluator, OperatorLookupDescriptor descriptor) const;
+};
+
 #define SWIFT_TYPEID_ZONE NameLookup
 #define SWIFT_TYPEID_HEADER "swift/AST/NameLookupTypeIDZone.def"
 #include "swift/Basic/DefineTypeIDZone.h"

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -24,6 +24,13 @@ SWIFT_REQUEST(NameLookup, CustomAttrNominalRequest,
 SWIFT_REQUEST(NameLookup, DirectLookupRequest,
               TinyPtrVector<ValueDecl *>(DirectLookupDescriptor), Uncached,
               NoLocationInfo)
+SWIFT_REQUEST(NameLookup, DirectOperatorLookupRequest,
+              TinyPtrVector<OperatorDecl *>(OperatorLookupDescriptor,
+                                            OperatorFixity),
+              Uncached, NoLocationInfo)
+SWIFT_REQUEST(NameLookup, DirectPrecedenceGroupLookupRequest,
+              TinyPtrVector<PrecedenceGroupDecl *>(OperatorLookupDescriptor),
+              Uncached, NoLocationInfo)
 SWIFT_REQUEST(NameLookup, ExpandASTScopeRequest,
               ast_scope::ASTScopeImpl* (ast_scope::ASTScopeImpl*, ast_scope::ScopeCreator*),
               SeparatelyCached,

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -436,6 +436,16 @@ public:
          ObjCSelector selector,
          SmallVectorImpl<AbstractFunctionDecl *> &results) const override;
 
+protected:
+  virtual void
+  lookupOperatorDirect(Identifier name, OperatorFixity fixity,
+                       TinyPtrVector<OperatorDecl *> &results) const override;
+
+  virtual void lookupPrecedenceGroupDirect(
+      Identifier name,
+      TinyPtrVector<PrecedenceGroupDecl *> &results) const override;
+
+public:
   virtual void getTopLevelDecls(SmallVectorImpl<Decl*> &results) const override;
 
   virtual void

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -328,12 +328,16 @@ public:
   lookupNestedType(Identifier name,
                    const NominalTypeDecl *parent) const override;
 
-  virtual OperatorDecl *lookupOperator(Identifier name,
-                                       OperatorFixity fixity) const override;
+protected:
+  virtual void
+  lookupOperatorDirect(Identifier name, OperatorFixity fixity,
+                       TinyPtrVector<OperatorDecl *> &results) const override;
 
-  virtual PrecedenceGroupDecl *
-  lookupPrecedenceGroup(Identifier name) const override;
+  virtual void lookupPrecedenceGroupDirect(
+      Identifier name,
+      TinyPtrVector<PrecedenceGroupDecl *> &results) const override;
 
+public:
   virtual void lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
                                   VisibleDeclConsumer &consumer,
                                   NLKind lookupKind) const override;

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -329,7 +329,7 @@ public:
                    const NominalTypeDecl *parent) const override;
 
   virtual OperatorDecl *lookupOperator(Identifier name,
-                                       DeclKind fixity) const override;
+                                       OperatorFixity fixity) const override;
 
   virtual PrecedenceGroupDecl *
   lookupPrecedenceGroup(Identifier name) const override;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -948,7 +948,7 @@ namespace {
     template <typename T>
     static PrefixOperatorDecl *lookup(T &container, Identifier name) {
       return cast_or_null<PrefixOperatorDecl>(
-               container.lookupOperator(name, DeclKind::PrefixOperator));
+               container.lookupOperator(name, OperatorFixity::Prefix));
     }
   };
 
@@ -958,7 +958,7 @@ namespace {
     template <typename T>
     static InfixOperatorDecl *lookup(T &container, Identifier name) {
       return cast_or_null<InfixOperatorDecl>(
-               container.lookupOperator(name, DeclKind::InfixOperator));
+               container.lookupOperator(name, OperatorFixity::Infix));
     }
   };
 
@@ -968,7 +968,7 @@ namespace {
     template <typename T>
     static PostfixOperatorDecl *lookup(T &container, Identifier name) {
       return cast_or_null<PostfixOperatorDecl>(
-               container.lookupOperator(name, DeclKind::PostfixOperator));
+               container.lookupOperator(name, OperatorFixity::Postfix));
     }
   };
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1031,9 +1031,8 @@ checkOperatorConflicts(const SourceFile &SF, SourceLoc loc,
       if (loc.isValid()) {
         ASTContext &C = SF.getASTContext();
         C.Diags.diagnose(loc, diag::ambiguous_operator_decls);
-        C.Diags.diagnose(start->first->getLoc(),
-                         diag::found_this_operator_decl);
-        C.Diags.diagnose(i->first->getLoc(), diag::found_this_operator_decl);
+        start->first->diagnose(diag::found_this_operator_decl);
+        i->first->diagnose(diag::found_this_operator_decl);
       }
       return end;
     }
@@ -1053,8 +1052,7 @@ checkOperatorConflicts(const SourceFile &SF, SourceLoc loc,
     ASTContext &C = SF.getASTContext();
     C.Diags.diagnose(loc, diag::ambiguous_precedence_groups);
     for (auto &entry : importedGroups) {
-      C.Diags.diagnose(entry.first->getLoc(),
-                       diag::found_this_precedence_group);
+      entry.first->diagnose(diag::found_this_precedence_group);
     }
   }
   return importedGroups.end();

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -945,39 +945,50 @@ namespace {
   template <>
   struct OperatorLookup<PrefixOperatorDecl> {
     constexpr static auto map_ptr = &SourceFile::PrefixOperators;
-    template <typename T>
-    static PrefixOperatorDecl *lookup(T &container, Identifier name) {
-      return cast_or_null<PrefixOperatorDecl>(
-               container.lookupOperator(name, OperatorFixity::Prefix));
+    static PrefixOperatorDecl *lookup(Evaluator &eval,
+                                      const OperatorLookupDescriptor &desc) {
+      // We can return the first prefix operator. All prefix operators of the
+      // same name are equivalent.
+      DirectOperatorLookupRequest req{desc, OperatorFixity::Prefix};
+      auto results = evaluateOrDefault(eval, req, {});
+      return results.empty() ? nullptr : cast<PrefixOperatorDecl>(results[0]);
     }
   };
 
   template <>
   struct OperatorLookup<InfixOperatorDecl> {
     constexpr static auto map_ptr = &SourceFile::InfixOperators;
-    template <typename T>
-    static InfixOperatorDecl *lookup(T &container, Identifier name) {
-      return cast_or_null<InfixOperatorDecl>(
-               container.lookupOperator(name, OperatorFixity::Infix));
+    static InfixOperatorDecl *lookup(Evaluator &eval,
+                                     const OperatorLookupDescriptor &desc) {
+      // Return the first result if it exists.
+      DirectOperatorLookupRequest req{desc, OperatorFixity::Infix};
+      auto results = evaluateOrDefault(eval, req, {});
+      return results.empty() ? nullptr : cast<InfixOperatorDecl>(results[0]);
     }
   };
 
   template <>
   struct OperatorLookup<PostfixOperatorDecl> {
     constexpr static auto map_ptr = &SourceFile::PostfixOperators;
-    template <typename T>
-    static PostfixOperatorDecl *lookup(T &container, Identifier name) {
-      return cast_or_null<PostfixOperatorDecl>(
-               container.lookupOperator(name, OperatorFixity::Postfix));
+    static PostfixOperatorDecl *lookup(Evaluator &eval,
+                                       const OperatorLookupDescriptor &desc) {
+      // We can return the first postfix operator. All postfix operators of the
+      // same name are equivalent.
+      DirectOperatorLookupRequest req{desc, OperatorFixity::Postfix};
+      auto results = evaluateOrDefault(eval, req, {});
+      return results.empty() ? nullptr : cast<PostfixOperatorDecl>(results[0]);
     }
   };
 
   template <>
   struct OperatorLookup<PrecedenceGroupDecl> {
     constexpr static auto map_ptr = &SourceFile::PrecedenceGroups;
-    template <typename T>
-    static PrecedenceGroupDecl *lookup(T &container, Identifier name) {
-      return container.lookupPrecedenceGroup(name);
+    static PrecedenceGroupDecl *lookup(Evaluator &eval,
+                                       const OperatorLookupDescriptor &desc) {
+      // Return the first result if it exists.
+      auto results =
+          evaluateOrDefault(eval, DirectPrecedenceGroupLookupRequest{desc}, {});
+      return results.empty() ? nullptr : results[0];
     }
   };
 } // end anonymous namespace
@@ -1014,7 +1025,8 @@ void SourceFile::setSyntaxRoot(syntax::SourceFileSyntax &&Root) {
 
 template<typename OP_DECL>
 static Optional<OP_DECL *>
-lookupOperatorDeclForName(ModuleDecl *M, SourceLoc Loc, Identifier Name);
+lookupOperatorDeclForName(ModuleDecl *M, SourceLoc Loc, Identifier Name,
+                          bool isCascading);
 
 template<typename OP_DECL>
 using ImportedOperatorsMap = llvm::SmallDenseMap<OP_DECL*, bool, 16>;
@@ -1063,7 +1075,8 @@ checkOperatorConflicts(const SourceFile &SF, SourceLoc loc,
 template <typename OP_DECL>
 static Optional<OP_DECL *>
 lookupOperatorDeclForName(const FileUnit &File, SourceLoc Loc,
-                          Identifier Name, bool includePrivate) {
+                          Identifier Name, bool includePrivate,
+                          bool isCascading) {
   switch (File.getKind()) {
   case FileUnitKind::Builtin:
     // The Builtin module declares no operators.
@@ -1072,8 +1085,13 @@ lookupOperatorDeclForName(const FileUnit &File, SourceLoc Loc,
     break;
   case FileUnitKind::SerializedAST:
   case FileUnitKind::ClangModule:
-  case FileUnitKind::DWARFModule:
-    return OperatorLookup<OP_DECL>::lookup(cast<LoadedFile>(File), Name);
+  case FileUnitKind::DWARFModule: {
+    auto &eval = File.getASTContext().evaluator;
+    auto desc = OperatorLookupDescriptor::forFile(const_cast<FileUnit *>(&File),
+                                                  Name, isCascading,
+                                                  /*diagLoc*/ SourceLoc());
+    return OperatorLookup<OP_DECL>::lookup(eval, desc);
+  }
   }
 
   auto &SF = cast<SourceFile>(File);
@@ -1102,7 +1120,8 @@ lookupOperatorDeclForName(const FileUnit &File, SourceLoc Loc,
       continue;
 
     Optional<OP_DECL *> maybeOp =
-        lookupOperatorDeclForName<OP_DECL>(imported.module.second, Loc, Name);
+        lookupOperatorDeclForName<OP_DECL>(imported.module.second, Loc, Name,
+                                           isCascading);
     if (!maybeOp)
       return None;
     
@@ -1135,10 +1154,12 @@ lookupOperatorDeclForName(const FileUnit &File, SourceLoc Loc,
 
 template<typename OP_DECL>
 static Optional<OP_DECL *>
-lookupOperatorDeclForName(ModuleDecl *M, SourceLoc Loc, Identifier Name) {
+lookupOperatorDeclForName(ModuleDecl *M, SourceLoc Loc, Identifier Name,
+                          bool isCascading) {
   OP_DECL *result = nullptr;
   for (const FileUnit *File : M->getFiles()) {
-    auto next = lookupOperatorDeclForName<OP_DECL>(*File, Loc, Name, false);
+    auto next = lookupOperatorDeclForName<OP_DECL>(*File, Loc, Name, false,
+                                                   isCascading);
     if (!next.hasValue())
       return next;
 
@@ -1155,9 +1176,10 @@ template <typename OperatorType>
 llvm::Expected<OperatorType *> LookupOperatorRequest<OperatorType>::evaluate(
     Evaluator &evaluator, OperatorLookupDescriptor desc) const {
   auto *file = desc.fileOrModule.get<FileUnit *>();
-  auto result = lookupOperatorDeclForName<OperatorType>(*file, desc.diagLoc,
-                                                        desc.name,
-                                                        /*includePrivate*/ true);
+  auto result =
+      lookupOperatorDeclForName<OperatorType>(*file, desc.diagLoc, desc.name,
+                                              /*includePrivate*/ true,
+                                              desc.isCascading);
   if (!result.hasValue())
     return nullptr;
 
@@ -1167,16 +1189,17 @@ llvm::Expected<OperatorType *> LookupOperatorRequest<OperatorType>::evaluate(
   }
   if (!result.getValue()) {
     result = lookupOperatorDeclForName<OperatorType>(file->getParentModule(),
-                                                     desc.diagLoc, desc.name);
+                                                     desc.diagLoc, desc.name,
+                                                     desc.isCascading);
   }
   return result.hasValue() ? result.getValue() : nullptr;
 }
 
-
 #define LOOKUP_OPERATOR(Kind)                                                  \
   Kind##Decl *ModuleDecl::lookup##Kind(Identifier name, SourceLoc loc) {       \
     auto result =                                                              \
-        lookupOperatorDeclForName<Kind##Decl>(this, loc, name);                \
+        lookupOperatorDeclForName<Kind##Decl>(this, loc, name,                 \
+                                              /*isCascading*/ false);          \
     return result ? *result : nullptr;                                         \
   }                                                                            \
   template llvm::Expected<Kind##Decl *>                                        \
@@ -1188,6 +1211,75 @@ LOOKUP_OPERATOR(InfixOperator)
 LOOKUP_OPERATOR(PostfixOperator)
 LOOKUP_OPERATOR(PrecedenceGroup)
 #undef LOOKUP_OPERATOR
+
+llvm::Expected<TinyPtrVector<OperatorDecl *>>
+DirectOperatorLookupRequest::evaluate(Evaluator &evaluator,
+                                      OperatorLookupDescriptor descriptor,
+                                      OperatorFixity fixity) const {
+  // Query each file.
+  // TODO: Module-level caching.
+  TinyPtrVector<OperatorDecl *> results;
+  for (auto *file : descriptor.getFiles())
+    file->lookupOperatorDirect(descriptor.name, fixity, results);
+
+  return std::move(results);
+}
+
+void SourceFile::lookupOperatorDirect(
+    Identifier name, OperatorFixity fixity,
+    TinyPtrVector<OperatorDecl *> &results) const {
+  OperatorDecl *op = nullptr;
+  switch (fixity) {
+  case OperatorFixity::Infix: {
+    auto result = InfixOperators.find(name);
+    if (result != InfixOperators.end())
+      op = result->second.getPointer();
+    break;
+  }
+  case OperatorFixity::Postfix: {
+    auto result = PostfixOperators.find(name);
+    if (result != PostfixOperators.end())
+      op = result->second.getPointer();
+    break;
+  }
+  case OperatorFixity::Prefix: {
+    auto result = PrefixOperators.find(name);
+    if (result != PrefixOperators.end())
+      op = result->second.getPointer();
+    break;
+  }
+  }
+
+  // We currently can use the operator maps to cache lookup results from other
+  // modules. Make sure we only return results from the source file.
+  if (op && op->getDeclContext()->getParentSourceFile() == this)
+    results.push_back(op);
+}
+
+llvm::Expected<TinyPtrVector<PrecedenceGroupDecl *>>
+DirectPrecedenceGroupLookupRequest::evaluate(
+    Evaluator &evaluator, OperatorLookupDescriptor descriptor) const {
+  // Query each file.
+  // TODO: Module-level caching.
+  TinyPtrVector<PrecedenceGroupDecl *> results;
+  for (auto *file : descriptor.getFiles())
+    file->lookupPrecedenceGroupDirect(descriptor.name, results);
+
+  return std::move(results);
+}
+
+void SourceFile::lookupPrecedenceGroupDirect(
+    Identifier name, TinyPtrVector<PrecedenceGroupDecl *> &results) const {
+  auto result = PrecedenceGroups.find(name);
+  if (result == PrecedenceGroups.end())
+    return;
+
+  // We currently can use the operator maps to cache lookup results from other
+  // modules. Make sure we only return results from the source file.
+  auto *group = result->second.getPointer();
+  if (group->getDeclContext()->getParentSourceFile() == this)
+    results.push_back(group);
+}
 
 void ModuleDecl::getImportedModules(SmallVectorImpl<ImportedModule> &modules,
                                     ModuleDecl::ImportFilter filter) const {

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -211,12 +211,20 @@ SourceLoc swift::extractNearestSourceLoc(const DirectLookupDescriptor &desc) {
 // LookupOperatorRequest computation.
 //----------------------------------------------------------------------------//
 
+ArrayRef<FileUnit *> OperatorLookupDescriptor::getFiles() const {
+  if (auto *module = getModule())
+    return module->getFiles();
+
+  // Return an ArrayRef pointing to the FileUnit in the union.
+  return llvm::makeArrayRef(*fileOrModule.getAddrOfPtr1());
+}
+
 void swift::simple_display(llvm::raw_ostream &out,
                            const OperatorLookupDescriptor &desc) {
   out << "looking up operator ";
   simple_display(out, desc.name);
   out << " in ";
-  simple_display(out, desc.SF);
+  simple_display(out, desc.fileOrModule);
 }
 
 SourceLoc swift::extractNearestSourceLoc(const OperatorLookupDescriptor &desc) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1253,12 +1253,9 @@ static PrecedenceGroupDecl *
 lookupPrecedenceGroup(const PrecedenceGroupDescriptor &descriptor) {
   auto *dc = descriptor.dc;
   if (auto sf = dc->getParentSourceFile()) {
-    OperatorLookupDescriptor desc{
-      sf,
-      descriptor.ident,
-      dc->isCascadingContextForLookup(false),
-      descriptor.nameLoc
-    };
+    auto desc = OperatorLookupDescriptor::forFile(
+        sf, descriptor.ident, dc->isCascadingContextForLookup(false),
+        descriptor.nameLoc);
     return evaluateOrDefault(sf->getASTContext().evaluator,
                              LookupPrecedenceGroupRequest{desc}, nullptr);
   } else {
@@ -1730,12 +1727,9 @@ FunctionOperatorRequest::evaluate(Evaluator &evaluator, FuncDecl *FD) const {
     FD->diagnose(diag::operator_in_local_scope);
   }
 
-  OperatorLookupDescriptor desc{
-    FD->getDeclContext()->getParentSourceFile(),
-    operatorName,
-    FD->isCascadingContextForLookup(false),
-    FD->getLoc()
-  };
+  auto desc = OperatorLookupDescriptor::forFile(
+      FD->getDeclContext()->getParentSourceFile(), operatorName,
+      FD->isCascadingContextForLookup(false), FD->getLoc());
   OperatorDecl *op = nullptr;
   if (FD->isUnaryOperator()) {
     if (FD->getAttrs().hasAttribute<PrefixAttr>()) {

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -130,12 +130,9 @@ Expr *TypeChecker::substituteInputSugarTypeForResult(ApplyExpr *E) {
 static PrecedenceGroupDecl *lookupPrecedenceGroupForOperator(DeclContext *DC,
                                                              Identifier name,
                                                              SourceLoc loc) {
-  OperatorLookupDescriptor desc{
-    DC->getParentSourceFile(),
-    name,
-    DC->isCascadingContextForLookup(true),
-    loc
-  };
+  auto desc = OperatorLookupDescriptor::forFile(
+      DC->getParentSourceFile(), name, DC->isCascadingContextForLookup(true),
+      loc);
   auto &Ctx = DC->getASTContext();
   if (auto op = evaluateOrDefault(Ctx.evaluator,
                                   LookupInfixOperatorRequest{desc},

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1654,7 +1654,7 @@ giveUpFastPath:
           return true;
         if (!fn->getOperatorDecl())
           return true;
-        if (getStableFixity(fn->getOperatorDecl()->getKind()) != rawKind)
+        if (getStableFixity(fn->getOperatorDecl()->getFixity()) != rawKind)
           return true;
         return false;
       });

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -2156,7 +2156,8 @@ TypeDecl *ModuleFile::lookupNestedType(Identifier name,
   return nullptr;
 }
 
-OperatorDecl *ModuleFile::lookupOperator(Identifier name, DeclKind fixity) {
+OperatorDecl *ModuleFile::lookupOperator(Identifier name,
+                                         OperatorFixity fixity) {
   PrettyStackTraceModuleFile stackEntry(*this);
 
   if (!OperatorDecls)

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -731,7 +731,7 @@ public:
   /// Searches the module's operators for one with the given name and fixity.
   ///
   /// If none is found, returns null.
-  OperatorDecl *lookupOperator(Identifier name, DeclKind fixity);
+  OperatorDecl *lookupOperator(Identifier name, OperatorFixity fixity);
 
   /// Searches the module's precedence groups for one with the given
   /// name and fixity.

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -385,19 +385,18 @@ enum class SelfAccessKind : uint8_t {
 };
 using SelfAccessKindField = BCFixed<2>;
   
-/// Translates an operator DeclKind to a Serialization fixity, whose values are
-/// guaranteed to be stable.
-static inline OperatorKind getStableFixity(DeclKind kind) {
-  switch (kind) {
-  case DeclKind::PrefixOperator:
+/// Translates an operator decl fixity to a Serialization fixity, whose values
+/// are guaranteed to be stable.
+static inline OperatorKind getStableFixity(OperatorFixity fixity) {
+  switch (fixity) {
+  case OperatorFixity::Prefix:
     return Prefix;
-  case DeclKind::PostfixOperator:
+  case OperatorFixity::Postfix:
     return Postfix;
-  case DeclKind::InfixOperator:
+  case OperatorFixity::Infix:
     return Infix;
-  default:
-    llvm_unreachable("unknown operator fixity");
   }
+  llvm_unreachable("Unhandled case in switch");
 }
 
 // These IDs must \em not be renumbered or reordered without incrementing

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1730,7 +1730,7 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
       assert(op);
       abbrCode = DeclTypeAbbrCodes[XRefOperatorOrAccessorPathPieceLayout::Code];
       auto emptyID = addDeclBaseNameRef(Identifier());
-      auto fixity = getStableFixity(op->getKind());
+      auto fixity = getStableFixity(op->getFixity());
       XRefOperatorOrAccessorPathPieceLayout::emitRecord(Out, ScratchRecord,
                                                         abbrCode, emptyID,
                                                         fixity);
@@ -1750,7 +1750,7 @@ void Serializer::writeCrossReference(const Decl *D) {
 
     abbrCode = DeclTypeAbbrCodes[XRefOperatorOrAccessorPathPieceLayout::Code];
     auto nameID = addDeclBaseNameRef(op->getName());
-    auto fixity = getStableFixity(op->getKind());
+    auto fixity = getStableFixity(op->getFixity());
     XRefOperatorOrAccessorPathPieceLayout::emitRecord(Out, ScratchRecord,
                                                       abbrCode, nameID,
                                                       fixity);
@@ -4924,7 +4924,7 @@ void Serializer::writeAST(ModuleOrSourceFile DC) {
           .push_back({ extendedNominal, addDeclRef(D) });
       } else if (auto OD = dyn_cast<OperatorDecl>(D)) {
         operatorDecls[OD->getName()]
-          .push_back({ getStableFixity(OD->getKind()), addDeclRef(D) });
+          .push_back({ getStableFixity(OD->getFixity()), addDeclRef(D) });
       } else if (auto PGD = dyn_cast<PrecedenceGroupDecl>(D)) {
         precedenceGroupDecls[PGD->getName()]
           .push_back({ decls_block::PRECEDENCE_GROUP_DECL, addDeclRef(D) });

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1084,14 +1084,17 @@ SerializedASTFile::lookupNestedType(Identifier name,
   return File.lookupNestedType(name, parent);
 }
 
-OperatorDecl *SerializedASTFile::lookupOperator(Identifier name,
-                                                OperatorFixity fixity) const {
-  return File.lookupOperator(name, fixity);
+void SerializedASTFile::lookupOperatorDirect(
+    Identifier name, OperatorFixity fixity,
+    TinyPtrVector<OperatorDecl *> &results) const {
+  if (auto *op = File.lookupOperator(name, fixity))
+    results.push_back(op);
 }
 
-PrecedenceGroupDecl *
-SerializedASTFile::lookupPrecedenceGroup(Identifier name) const {
-  return File.lookupPrecedenceGroup(name);
+void SerializedASTFile::lookupPrecedenceGroupDirect(
+    Identifier name, TinyPtrVector<PrecedenceGroupDecl *> &results) const {
+  if (auto *group = File.lookupPrecedenceGroup(name))
+    results.push_back(group);
 }
 
 void SerializedASTFile::lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1085,7 +1085,7 @@ SerializedASTFile::lookupNestedType(Identifier name,
 }
 
 OperatorDecl *SerializedASTFile::lookupOperator(Identifier name,
-                                                DeclKind fixity) const {
+                                                OperatorFixity fixity) const {
   return File.lookupOperator(name, fixity);
 }
 

--- a/test/decl/operator/Inputs/lookup_moduleA.swift
+++ b/test/decl/operator/Inputs/lookup_moduleA.swift
@@ -1,0 +1,36 @@
+
+// Only declared in module A.
+prefix operator >>>
+public prefix func >>> (rhs: Int) {}
+
+precedencegroup DeclaredInModuleA {}
+
+// Declared in both modules A and B.
+infix operator ???
+precedencegroup DeclaredInModulesAB {}
+
+// Declared in both modules A and B, but with a different
+// precedence group in each.
+infix operator ???? : DeclaredInModuleA
+
+// Declared in both modules A and B, but shadowed by lookup_other.
+precedencegroup DeclaredInModulesABShadowed {}
+
+// Declared in both modules A and B.
+postfix operator <?
+
+// Declared in both modules A and B, and also the stdlib.
+precedencegroup TernaryPrecedence {}
+
+// Also declared in module 'ExportsAC', which shadows this decl.
+precedencegroup ShadowsModuleA {}
+
+// Also declared in modules ExportsAC and C.
+precedencegroup ShadowsModulesAC {}
+
+// Also declared in modules C and ExportsAC.
+infix operator ?????
+
+// Also declared in modules C and ExportsAC, but with a different
+// precedencegroup.
+infix operator ?????? : DeclaredInModuleA

--- a/test/decl/operator/Inputs/lookup_moduleB.swift
+++ b/test/decl/operator/Inputs/lookup_moduleB.swift
@@ -1,0 +1,31 @@
+
+// Both of these decls are also declared in lookup_other, and we should prefer
+// those decls.
+precedencegroup DeclaredAcrossFiles {}
+infix operator &&&
+
+// Also declared in module A.
+infix operator ???
+precedencegroup DeclaredInModulesAB {}
+
+// Also declared in module A, but with a different precedence group.
+infix operator ????
+
+// Declared in both modules A and B, but shadowed by lookup_other.
+precedencegroup DeclaredInModulesABShadowed {}
+
+// Also declared in module A.
+postfix operator <?
+
+// Declared in both modules A and B, and also the stdlib.
+precedencegroup TernaryPrecedence {}
+
+// These are both also declared in module ExportsAC.
+infix operator ???!
+precedencegroup DeclaredInModulesBExportsAC {}
+
+// Also declared in module ExportsAC, but with a different precedence group.
+infix operator ????!
+
+// Also declared in module ExportsAC.
+postfix operator <!

--- a/test/decl/operator/Inputs/lookup_moduleC.swift
+++ b/test/decl/operator/Inputs/lookup_moduleC.swift
@@ -1,0 +1,9 @@
+
+// Also declared in modules ExportsAC and A.
+precedencegroup ShadowsModulesAC {}
+
+// Also declared in modules A and ExportsAC.
+infix operator ?????
+
+// Also declared in modules A and ExportsAC, with a different precedencegroup.
+infix operator ?????? : ShadowsModulesAC

--- a/test/decl/operator/Inputs/lookup_moduleD.swift
+++ b/test/decl/operator/Inputs/lookup_moduleD.swift
@@ -1,0 +1,2 @@
+
+precedencegroup DeclaredInModuleD {}

--- a/test/decl/operator/Inputs/lookup_module_exportsAC.swift
+++ b/test/decl/operator/Inputs/lookup_module_exportsAC.swift
@@ -1,0 +1,26 @@
+
+@_exported import A
+@_exported import C
+
+// Also declared in module A, but this decl shadows it.
+precedencegroup ShadowsModuleA {}
+
+// Also declared in modules A and C, but this decl shadows it.
+precedencegroup ShadowsModulesAC {}
+
+// Also declared in modules A and C, but this decl shadows it.
+infix operator ?????
+
+// Also declared in modules A and C, but with a different precedencegroup.
+// However that shouldn't impact shadowing.
+infix operator ??????
+
+// These are both also declared in module B.
+infix operator ???!
+precedencegroup DeclaredInModulesBExportsAC {}
+
+// Also declared in module B, but with a different precedence group.
+infix operator ????! : ShadowsModuleA
+
+// Also declared in module B.
+postfix operator <!

--- a/test/decl/operator/Inputs/lookup_other.swift
+++ b/test/decl/operator/Inputs/lookup_other.swift
@@ -1,0 +1,13 @@
+
+@_exported import D
+
+// Both of these decls are also declared in module B, but we should prefer
+// these decls.
+precedencegroup DeclaredAcrossFiles {
+  higherThan: AssignmentPrecedence
+  associativity: left
+}
+infix operator &&& : DeclaredAcrossFiles
+
+// Declared in both modules A and B, but shadowed by this decl.
+precedencegroup DeclaredInModulesABShadowed {}

--- a/test/decl/operator/Inputs/lookup_other2.swift
+++ b/test/decl/operator/Inputs/lookup_other2.swift
@@ -1,0 +1,2 @@
+
+@_exported import D

--- a/test/decl/operator/Inputs/lookup_other_compat.swift
+++ b/test/decl/operator/Inputs/lookup_other_compat.swift
@@ -1,0 +1,3 @@
+
+// Also declared in the files being tested.
+precedencegroup RedeclaredInModule {}

--- a/test/decl/operator/Inputs/redeclaration_other_compat.swift
+++ b/test/decl/operator/Inputs/redeclaration_other_compat.swift
@@ -1,0 +1,10 @@
+precedencegroup RedeclaredAcrossFiles {}
+
+infix operator ^^^
+prefix operator >>>
+postfix operator <<<
+
+precedencegroup P1 {}
+infix operator ^^^^ : P1
+
+infix operator &&&

--- a/test/decl/operator/lookup_compatibility.swift
+++ b/test/decl/operator/lookup_compatibility.swift
@@ -1,0 +1,127 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module %S/Inputs/lookup_moduleD.swift -module-name D -o %t -I %t
+// RUN: %target-swift-frontend -emit-module %S/Inputs/lookup_moduleC.swift -module-name C -o %t -I %t
+// RUN: %target-swift-frontend -emit-module %S/Inputs/lookup_moduleB.swift -module-name B -o %t -I %t
+// RUN: %target-swift-frontend -emit-module %S/Inputs/lookup_moduleA.swift -module-name A -o %t -I %t
+// RUN: %target-swift-frontend -emit-module %S/Inputs/lookup_module_exportsAC.swift -module-name ExportsAC -o %t -I %t
+
+// FIXME: Remove -verify-ignore-unknown.
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -primary-file %s %S/Inputs/lookup_other.swift %S/Inputs/lookup_other2.swift %S/Inputs/lookup_other_compat.swift -I %t
+
+import ExportsAC
+import B
+
+infix operator ^^^ : DeclaredAcrossFiles
+func ^^^ (lhs: Int, rhs: Int) -> Int { 0 }
+func &&& (lhs: Int, rhs: Int) -> Int { 0 }
+
+// FIXME(SR-12132): The operator decl >>> is declared in module A, which we
+// should be able to see through ExportsAC.
+prefix func >>> (rhs: Double) {} // expected-error {{operator implementation without matching operator declaration}}
+
+// FIXME(SR-12132): We should also see precedencegroups in module A through
+// ExportsAC.
+infix operator ^^^^ : DeclaredInModuleA // expected-error {{unknown precedence group 'DeclaredInModuleA'}}
+
+// The operator decl for ??? is declared in both modules A and B, but has the
+// same default precedence group in both, so there's no ambiguity.
+func ??? (lhs: Int, rhs: Int) {}
+
+// Same for ???!, declared in modules ExportsAC and B, but has the same
+// precedence group in both.
+func ???! (lhs: Int, rhs: Int) {}
+
+// The operator decl for ???? is declared in both modules A and B, and has a
+// different precedence group in each. This should therefore be ambiguous.
+// However, for compatibility, we don't look through exports in other modules,
+// so we don't see the one in module A.
+func ???? (lhs: Int, rhs: Int) {}
+
+// The operator decl for ????! is declared in both modules ExportsAC and B, and
+// has a different precedence group in each. Therefore ambiguous.
+// FIXME: We shouldn't emit the unknown operator decl error.
+func ????! (lhs: Int, rhs: Int) {} // expected-error {{ambiguous operator declarations found for operator}}
+// expected-error@-1 {{operator implementation without matching operator declaration}}
+
+// Same as ????, the precedencegroup is declared in both modules A and B, but
+// we don't look into module A for compatibility.
+infix operator <?> : DeclaredInModulesAB
+
+// The precedencegroup is declared in both modules ExportsAC and B, therefore
+// ambiguous.
+// FIXME: We shouldn't emit the 'unknown precedence group' error.
+infix operator <!> : DeclaredInModulesBExportsAC // expected-error {{multiple precedence groups found}}
+// expected-error@-1 {{unknown precedence group 'DeclaredInModulesBExportsAC'}}
+
+// This precedencegroup is declared in this module as well as in both modules A
+// and B. The decl in this module should shadow the imported ones, but for
+// compatibility we don't see module A's decl and take module B's decl.
+infix operator <??> : DeclaredInModulesABShadowed
+
+// The operator decl for <? is declared in both modules A and B, but there's no
+// meaningful difference between the declarations, so legal.
+postfix func <? (lhs: Int) {}
+
+// Same thing, <! is declared in both modules ExportsAC and B, but there's no
+// meaningful difference between the declarations, so legal.
+postfix func <! (lhs: Int) {}
+
+// This precedencegroup is declared in both modules A and ExportsAC, but the
+// latter shadows the former.
+infix operator <???> : ShadowsModuleA
+
+// This precedencegroup is declared in modules A, C, and ExportsAC, but the
+// latter shadows both of the former.
+infix operator <????> : ShadowsModulesAC
+
+// This operator decl is declared in modules A, C, and ExportsAC, but the
+// latter shadows both of the former.
+func ????? (lhs: Int, rhs: Int) {}
+
+// This operator decl is declared in modules A, C, and ExportsAC, but the
+// latter shadows both of the former, despite them having different
+// precedencegroups.
+func ?????? (lhs: Int, rhs: Int) {}
+
+// FIXME: Module D is imported through exports in both lookup_other and
+// lookup_other2, but we fail to detect the fact that we're visiting the same
+// thing twice.
+infix operator <> : DeclaredInModuleD // expected-error {{unknown precedence group 'DeclaredInModuleD'}}
+
+// Also declared in lookup_other. To preserve compatibility, we allow an
+// unambiguous lookup that will favor this declaration over lookup_other.
+precedencegroup RedeclaredInModule {} 
+infix operator *** : RedeclaredInModule // Okay.
+
+func testOperatorLookup() {
+  // In lookup_other, DeclaredAcrossFiles is left associative, whereas in
+  // module B it is non-associative. Make sure we use module B's for
+  // compatibility.
+  _ = 5 ^^^ 5 ^^^ 5
+  // expected-error@-1 {{adjacent operators are in unordered precedence groups 'AssignmentPrecedence' and 'DeclaredAcrossFiles'}}
+  // expected-error@-2 {{adjacent operators are in non-associative precedence group 'DeclaredAcrossFiles'}}
+  // expected-error@-3 {{cannot convert value of type '()' to expected argument type 'Int'}}
+
+  // Same for &&&, in lookup_other it is declared as left associative.
+  _ = 5 &&& 5 &&& 5 // expected-error {{adjacent operators are in non-associative precedence group 'DefaultPrecedence'}}
+
+  // The operator >>> is declared in module A, which we should be able to see
+  // through ExportsAC.
+  >>>1
+
+  // We've been evil and overriden TernaryPrecedence in both modules A and B.
+  // FIXME: We shouldn't emit the 'broken stdlib' error.
+  true ? () : () // expected-error {{multiple precedence groups found}}
+  // expected-error@-1 {{broken standard library: missing builtin precedence group 'TernaryPrecedence'}}
+}
+
+precedencegroup CastingPrecedence {
+  lowerThan: AssignmentPrecedence
+}
+
+func testBuiltinPrecedenceGroupOverriding() {
+  // Evil, but allowed.
+  var x = 0
+  x = 0 as Int // expected-error {{cannot convert value of type '()' to type 'Int' in coercion}}
+}

--- a/test/decl/operator/lookup_compatibility.swift
+++ b/test/decl/operator/lookup_compatibility.swift
@@ -5,9 +5,7 @@
 // RUN: %target-swift-frontend -emit-module %S/Inputs/lookup_moduleB.swift -module-name B -o %t -I %t
 // RUN: %target-swift-frontend -emit-module %S/Inputs/lookup_moduleA.swift -module-name A -o %t -I %t
 // RUN: %target-swift-frontend -emit-module %S/Inputs/lookup_module_exportsAC.swift -module-name ExportsAC -o %t -I %t
-
-// FIXME: Remove -verify-ignore-unknown.
-// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -primary-file %s %S/Inputs/lookup_other.swift %S/Inputs/lookup_other2.swift %S/Inputs/lookup_other_compat.swift -I %t
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %s %S/Inputs/lookup_other.swift %S/Inputs/lookup_other2.swift %S/Inputs/lookup_other_compat.swift -I %t
 
 import ExportsAC
 import B

--- a/test/decl/operator/redeclaration_compatibility.swift
+++ b/test/decl/operator/redeclaration_compatibility.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %s %S/Inputs/redeclaration_other_compat.swift
+
+// We currently allow cross-file redeclarations.
+precedencegroup RedeclaredAcrossFiles {}
+
+precedencegroup RedeclaredSameFile {} // expected-note {{previous precedence group declaration here}}
+precedencegroup RedeclaredSameFile {} // expected-error {{precedence group redeclared}}
+
+precedencegroup RedeclaredSameFile2 { // expected-note {{previous precedence group declaration here}}
+  assignment: true
+}
+precedencegroup RedeclaredSameFile2 {} // expected-error {{precedence group redeclared}}
+
+// These are all declared in the other file, and so are allowed for now.
+infix operator ^^^
+prefix operator >>>
+postfix operator <<<
+infix operator ^^^^
+
+// This is declared as an infix operator in the other file, so no problem.
+prefix operator &&&
+postfix operator &&&
+
+infix operator %%% // expected-note {{previous operator declaration here}}
+infix operator %%% // expected-error {{operator redeclared}}
+
+prefix operator %%% // expected-note {{previous operator declaration here}}
+prefix operator %%% // expected-error {{operator redeclared}}
+
+precedencegroup P2 {}
+infix operator *** : P2 // expected-note {{previous operator declaration here}}
+infix operator *** // expected-error {{operator redeclared}}


### PR DESCRIPTION
Introduce `DirectOperatorLookupRequest` & `DirectPrecedenceGroupLookupRequest` that lookup operator and precedence groups within a given file or module without looking through imports.

This is in preparation for a re-write of the existing operator lookup logic (as such I'm trying to touch the old lookup logic as little as possible).