### PR TITLE
Register Conformances as Potential Member Constraints

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3795,10 +3795,7 @@ static void recordConformanceDependency(DeclContext *DC,
       Conformance->getDeclContext()->getParentModule())
     return;
 
-  // FIXME: 'deinit' is being used as a dummy identifier here. Really we
-  // don't care about /any/ of the type's members, only that it conforms to
-  // the protocol.
-  tracker->addUsedMember({Adoptee, DeclBaseName::createDestructor()},
+  tracker->addUsedMember({Adoptee, Identifier()},
                          DC->isCascadingContextForLookup(InExpression));
 }
 

--- a/test/Incremental/single-file/AnyObject.swift
+++ b/test/Incremental/single-file/AnyObject.swift
@@ -15,6 +15,7 @@ import Foundation
 // expected-private-conformance {{Swift.CustomDebugStringConvertible}}
 // expected-private-conformance {{Swift.CVarArg}}
 // expected-private-conformance {{Swift.CustomStringConvertible}}
+// expected-cascading-superclass {{main.LookupFactory}}
 @objc private class LookupFactory: NSObject {
   // expected-provides {{AssignmentPrecedence}}
   // expected-provides {{IntegerLiteralType}}
@@ -29,7 +30,7 @@ import Foundation
 
   // expected-cascading-member {{__C.NSObject.init}}
   // expected-cascading-member {{main.LookupFactory.init}}
-  // expected-cascading-member {{main.LookupFactory.deinit}}
+  // expected-private-member {{main.LookupFactory.deinit}}
   // expected-cascading-member {{main.LookupFactory.someMember}}
   // expected-cascading-member {{main.LookupFactory.someMethod}}
 }

--- a/test/Incremental/single-file/Conformances.swift
+++ b/test/Incremental/single-file/Conformances.swift
@@ -10,7 +10,7 @@ private protocol PrivateProtocol { } // expected-provides {{PrivateProtocol}}
 public struct PublicConformance { } // expected-provides {{PublicConformance}}
 // expected-cascading-member {{main.PublicConformance.init}}
 
-// expected-cascading-member {{main.PublicConformance.deinit}}
+// expected-cascading-conformance {{main.PublicConformance}}
 extension PublicConformance: PublicProtocol { }
 extension PublicConformance: InternalProtocol { }
 extension PublicConformance: FilePrivateProtocol { }
@@ -20,8 +20,7 @@ extension PublicConformance: PrivateProtocol { }
 private struct PrivateConformance { } // expected-provides {{PrivateConformance}}
 // expected-cascading-member {{main.PrivateConformance.init}}
 
-// FIXME: This could be a private dependency...
-// expected-cascading-member {{main.PrivateConformance.deinit}}
+// expected-cascading-conformance {{main.PrivateConformance}}
 extension PrivateConformance: PublicProtocol { } // expected-cascading-conformance {{main.PublicProtocol}}
 extension PrivateConformance: InternalProtocol { } // expected-cascading-conformance {{main.InternalProtocol}}
 extension PrivateConformance: FilePrivateProtocol { } // expected-cascading-conformance {{main.FilePrivateProtocol}}

--- a/test/NameBinding/reference-dependencies-fine.swift
+++ b/test/NameBinding/reference-dependencies-fine.swift
@@ -464,7 +464,6 @@ struct Sentinel2 {}
 
 
 // CHECK-MEMBER-DAG: member interface  4main10IntWrapperV Int false
-// CHECK-MEMBER-DAG: member interface  4main10IntWrapperV deinit false
 // CHECK-POTENTIALMEMBER-DAG: potentialMember interface  SL '' false
 // CHECK-POTENTIALMEMBER-DAG: potentialMember interface  4main18ClassFromOtherFileC '' false
 // CHECK-MEMBER-DAG: member interface  Si max false
@@ -472,13 +471,13 @@ struct Sentinel2 {}
 // CHECK-POTENTIALMEMBER-DAG: potentialMember interface  s33ExpressibleByUnicodeScalarLiteralP '' false
 // CHECK-MEMBER-DAG: member interface  Sx Stride false
 // CHECK-MEMBER-DAG: member interface  Sa reduce false
-// CHECK-MEMBER-DAG: member interface  4main17OtherFileIntArrayV deinit false
+// CHECK-POTENTIALMEMBER-DAG: potentialMember interface 4main17OtherFileIntArrayV '' false
 // CHECK-MEMBER-DAG: member interface  4main18OtherFileOuterTypeV InnerType false
 // CHECK-MEMBER-DAG: member interface  4main18OtherFileOuterTypeV05InnerE0V init false
 // CHECK-MEMBER-DAG: member interface  4main18OtherFileOuterTypeV05InnerE0V sharedConstant false
 // CHECK-MEMBER-DAG: member interface  4main26OtherFileSecretTypeWrapperV0dE0V constant false
-// CHECK-MEMBER-DAG: member interface  4main25OtherFileProtoImplementorV deinit false
-// CHECK-MEMBER-DAG: member interface  4main26OtherFileProtoImplementor2V deinit false
+// CHECK-POTENTIALMEMBER-DAG: potentialMember interface 4main25OtherFileProtoImplementorV '' false
+// CHECK-POTENTIALMEMBER-DAG: potentialMember interface  4main26OtherFileProtoImplementor2V '' false
 // CHECK-MEMBER-DAG: member interface  s15EmptyCollectionV8IteratorV init false
 // CHECK-MEMBER-DAG: member interface  4main13OtherFileEnumO Value false
 // CHECK-MEMBER-DAG: member interface  4main20OtherFileEnumWrapperV Enum false

--- a/test/NameBinding/reference-dependencies-members-fine.swift
+++ b/test/NameBinding/reference-dependencies-members-fine.swift
@@ -52,7 +52,7 @@ protocol SomeProto {}
 // PROVIDES-NOMINAL-DAG:  nominal implementation  4main10OtherClassC '' true
 // PROVIDES-NOMINAL-2-DAG:  nominal interface  4main10OtherClassC '' true
 // PROVIDES-MEMBER-DAG:  potentialMember interface  4main10OtherClassC '' true
-// DEPENDS-MEMBER-DAG:  member interface  4main10OtherClassC deinit false
+// DEPENDS-MEMBER-DAG:  potentialMember interface  4main10OtherClassC '' true
 extension OtherClass : SomeProto {}
 
 // PROVIDES-NOMINAL-DAG:  nominal implementation  4main11OtherStructV '' true

--- a/test/NameBinding/reference-dependencies-members.swift
+++ b/test/NameBinding/reference-dependencies-members.swift
@@ -52,7 +52,7 @@ protocol SomeProto {}
 // DEPENDS-NOMINAL-DAG: 10OtherClassC"
 // DEPENDS-NOMINAL-DAG: 9SomeProtoP"
 // DEPENDS-MEMBER-DAG: - ["{{.+}}9SomeProtoP", ""]
-// DEPENDS-MEMBER-DAG: - ["{{.+}}10OtherClassC", "deinit"]
+// DEPENDS-MEMBER-DAG: - ["{{.+}}10OtherClassC", ""]
 extension OtherClass : SomeProto {}
 
 // PROVIDES-NOMINAL-NEGATIVE-NOT: 11OtherStructV"{{$}}


### PR DESCRIPTION
Unwind a hack whose stated purpose was to register a potential member
edge from an extension to the extended type. In reality, this only
registered a plain member dependency on 'deinit'. This edge is
insufficient in isolation to cause a rebuild of a dependent file in the
case where a type and its extension live in separate files. However, we
appear to have been saved by the redundancy in edge registration because the
lookup for the extended type will register a top-level or nominal
dependency (for an unqualified or qualified reference respectively). The
worry there is if a protocol conformance *should* flip a previously
private nominal dependency edge to a cascading edge. In such a case, the
old code would not have been able to make the cascading edge promotion,
and we would have potentially miscompiled by not rescheduling dependent
jobs.