### PR TITLE
[Property wrappers] Fix property wrapper backing initializer linkage.

### DIFF
--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -293,15 +293,8 @@ SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
     limit = Limit::NeverPublic;
   }
 
-  // The property wrapper backing initializer is never public for resilient
-  // properties.
-  if (kind == SILDeclRef::Kind::PropertyWrapperBackingInitializer) {
-    if (cast<VarDecl>(d)->isResilient())
-      limit = Limit::NeverPublic;
-  }
-
   // Stored property initializers get the linkage of their containing type.
-  if (isStoredPropertyInitializer()) {
+  if (isStoredPropertyInitializer() || isPropertyWrapperBackingInitializer()) {
     // Three cases:
     //
     // 1) Type is formally @_fixed_layout/@frozen. Root initializers can be
@@ -483,7 +476,7 @@ IsSerialized_t SILDeclRef::isSerialized() const {
 
   // Stored property initializers are inlinable if the type is explicitly
   // marked as @frozen.
-  if (isStoredPropertyInitializer()) {
+  if (isStoredPropertyInitializer() || isPropertyWrapperBackingInitializer()) {
     auto *nominal = cast<NominalTypeDecl>(d->getDeclContext());
     auto scope =
       nominal->getFormalAccessScope(/*useDC=*/nullptr,
@@ -1130,8 +1123,7 @@ bool SILDeclRef::canBeDynamicReplacement() const {
 bool SILDeclRef::isDynamicallyReplaceable() const {
   if (kind == SILDeclRef::Kind::DefaultArgGenerator)
     return false;
-  if (isStoredPropertyInitializer() ||
-      kind == SILDeclRef::Kind::PropertyWrapperBackingInitializer)
+  if (isStoredPropertyInitializer() || isPropertyWrapperBackingInitializer())
     return false;
 
   // Class allocators are not dynamic replaceable.

--- a/test/SILGen/dynamically_replaceable.swift
+++ b/test/SILGen/dynamically_replaceable.swift
@@ -414,7 +414,7 @@ struct WrapperWithInitialValue<T> {
   }
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s23dynamically_replaceable10SomeStructV1tSbvpfP
+// CHECK-NOT: sil hidden [ossa] @$s23dynamically_replaceable10SomeStructV1tSbvpfP
 public struct SomeStruct {
   @WrapperWithInitialValue var t = false
 }

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -510,6 +510,8 @@ public protocol TestProtocol {}
 public class TestClass<T> {
   @WrapperWithInitialValue var value: T
 
+  // CHECK-LABEL: sil [ossa] @$s17property_wrappers9TestClassC5valuexvpfP : $@convention(thin) <T> (@in T) -> @out WrapperWithInitialValue<T>
+
   // CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers9TestClassC5value8protocolACyxGx_qd__tcAA0C8ProtocolRd__lufc
   // CHECK: [[BACKING_INIT:%.*]] = function_ref @$s17property_wrappers9TestClassC5valuexvpfP : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out WrapperWithInitialValue<τ_0_0>
   // CHECK-NEXT: partial_apply [callee_guaranteed] [[BACKING_INIT]]<T>()

--- a/test/SILGen/property_wrappers_library_evolution.swift
+++ b/test/SILGen/property_wrappers_library_evolution.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t -enable-library-evolution %S/Inputs/property_wrapper_defs.swift
-// RUN: %target-swift-emit-silgen -primary-file %s -I %t -enable-library-evolution
+// RUN: %target-swift-emit-silgen -primary-file %s -I %t -enable-library-evolution | %FileCheck %s
 import property_wrapper_defs
 
 // rdar://problem/55995892
@@ -8,3 +8,12 @@ import property_wrapper_defs
 
 public enum E { case a }
 struct M { @MyPublished private var e = E.a }
+
+// Ensure that the backing initializer is serialized.
+@frozen
+public struct StructUsesPublishedAsPrivate {
+  public var integer: Int = 17
+
+  // CHECK: sil non_abi [serialized] [ossa] @$s35property_wrappers_library_evolution28StructUsesPublishedAsPrivateV6stringSSvpfP : $@convention(thin) (@owned String) -> @out MyPublished<String>
+  @MyPublished var string: String = "Hello"
+}

--- a/test/decl/var/property_wrappers_library_evolution.swift
+++ b/test/decl/var/property_wrappers_library_evolution.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -typecheck %s -verify -enable-library-evolution
+
+@propertyWrapper
+public struct ResilientWrapper<T> {
+  public var wrappedValue: T
+
+  public init(wrappedValue: T, description: String) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
+func getHello() -> String { return "hello" } // expected-note 2 {{global function 'getHello()' is not '@usableFromInline' or public}}
+
+@frozen
+public struct StructUsesPublishedAsPrivate {
+  public var integer: Int = 17
+
+  @ResilientWrapper(description: getHello()) // expected-error 2 {{global function 'getHello()' is internal and cannot be referenced from a property initializer in a '@frozen' type}}
+  var otherString: String = "World"
+}


### PR DESCRIPTION
Have property wrapper backing initializers determine their linkage in
the same way as stored property initializers, which need to match the linkage
of the enclosing type in cases where one can write an initializer
outside of the source file where that type is declared.

Fixes rdar://problem/59607192.
