### PR TITLE
IRGen: Don't call getConditionalRequirementsIfAvailable()

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2737,12 +2737,8 @@ static void addAbstractConditionalRequirements(
     SpecializedProtocolConformance *specializedConformance,
     llvm::SetVector<GenericRequirement> &requirements) {
   auto subMap = specializedConformance->getSubstitutionMap();
-  auto condRequirements =
-      specializedConformance->getConditionalRequirementsIfAvailable();
-  if (!condRequirements)
-    return;
-
-  for (auto req : *condRequirements) {
+  auto condRequirements = specializedConformance->getConditionalRequirements();
+  for (auto req : condRequirements) {
     if (req.getKind() != RequirementKind::Conformance)
       continue;
     auto *proto =


### PR DESCRIPTION
We should not fail silently here if the conditional requirements
could not be computed due to a cycle.