### PR TITLE
[AutoDiff] Remove `@differentiable(jvp:vjp:)` parsing logic.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1586,14 +1586,10 @@ ERROR(attr_differentiable_expected_parameter_list,PointsToFirstBadToken,
       "expected a list of parameters to differentiate with respect to", ())
 ERROR(attr_differentiable_use_wrt_not_withrespectto,none,
       "use 'wrt:' to specify parameters to differentiate with respect to", ())
-ERROR(attr_differentiable_expected_label,none,"expected 'wrt:' or 'where'", ())
+ERROR(attr_differentiable_expected_label,none,
+      "expected 'wrt:' or 'where' in '@differentiable' attribute", ())
 ERROR(attr_differentiable_unexpected_argument,none,
       "unexpected argument '%0' in '@differentiable' attribute", (StringRef))
-// TODO(TF-893): Remove this error after the 0.8 release.
-ERROR(attr_differentiable_jvp_vjp_deprecated_error,none,
-        "'jvp:' and 'vjp:' arguments in '@differentiable' attribute are "
-        "deprecated; use '@derivative' attribute for derivative registration "
-        "instead", ())
 
 // differentiation `wrt` parameters clause
 ERROR(expected_colon_after_label,PointsToFirstBadToken,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -971,12 +971,6 @@ bool Parser::parseDifferentiableAttributeArguments(
     if (isIdentifier(Tok, "wrt")) {
       return false;
     }
-    // Diagnose deprecated 'jvp' and 'vjp'.
-    if (isIdentifier(Tok, "jvp") || isIdentifier(Tok, "vjp")) {
-      diagnose(Tok.getLoc(),
-               diag::attr_differentiable_jvp_vjp_deprecated_error);
-      return true;
-    }
     diagnose(Tok, diag::attr_differentiable_expected_label);
     return true;
   };
@@ -1016,13 +1010,6 @@ bool Parser::parseDifferentiableAttributeArguments(
       return false;
     if (consumeIfTrailingComma())
       return errorAndSkipUntilConsumeRightParen(*this, AttrName);
-  }
-
-  // Diagnose deprecated 'jvp' and 'vjp'.
-  if (isIdentifier(Tok, "jvp") || isIdentifier(Tok, "vjp")) {
-    diagnose(Tok.getLoc(),
-             diag::attr_differentiable_jvp_vjp_deprecated_error);
-    return errorAndSkipUntilConsumeRightParen(*this, AttrName);
   }
 
   // If parser has not advanced and token is not 'where' or ')', emit error.

--- a/test/AutoDiff/Parse/differentiable_attr_parse.swift
+++ b/test/AutoDiff/Parse/differentiable_attr_parse.swift
@@ -180,56 +180,9 @@ func slope5(_ x: Float) -> Float {
   return 5 * x
 }
 
-// expected-error @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
-@differentiable(jvp: foo)
+// Test removed `jvp:' and 'vjp:' arguments.
+// expected-error @+1 {{expected 'wrt:' or 'where' in '@differentiable' attribute}}
+@differentiable(jvp: foo, vjp: foo)
 func bar(_ x: Float, _: Float) -> Float {
   return 1 + x
-}
-
-// expected-error @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
-@differentiable(vjp: foo)
-func bar(_ x: Float, _: Float) -> Float {
-  return 1 + x
-}
-
-// expected-error @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
-@differentiable(vjp: foo, jvp: foo)
-func bar(_ x: Float, _: Float) -> Float {
-  return 1 + x
-}
-
-// expected-error @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
-@differentiable(wrt: (self, x, y), jvp: foo)
-func bar(_ x: Float, _ y: Float) -> Float {
-  return 1 + x
-}
-
-// expected-error @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
-@differentiable(wrt: (self, x, y), vjp: foo)
-func bar(_ x: Float, _ y: Float) -> Float {
-  return 1 + x
-}
-
-// expected-error @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
-@differentiable(wrt: (self, x, y), jvp: foo, vjp: foo)
-func bar(_ x: Float, _ y: Float) -> Float {
-  return 1 + x
-}
-
-// expected-error @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
-@differentiable(wrt: (x), jvp: foo where T : FloatingPoint)
-func bar<T : Numeric>(_ x: T, _: T) -> T {
-    return 1 + x
-}
-
-// expected-error @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
-@differentiable(wrt: (x), vjp: foo where T : FloatingPoint)
-func bar<T : Numeric>(_ x: T, _: T) -> T {
-    return 1 + x
-}
-
-// expected-error @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
-@differentiable(wrt: (x), jvp: foo, vjp: foo where T : FloatingPoint)
-func bar<T : Numeric>(_ x: T, _: T) -> T {
-    return 1 + x
 }


### PR DESCRIPTION
Remove logic for parsing and diagnosing `jvp:` and `vjp:` arguments for
`@differentiable` attribute. No logic remains for handling those arguments.

Follow-up to TF-1001.