### PR TITLE
[NFC] Preparations to address the «Rename to getName?» TODO on ValueDecl::getFullName

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2496,6 +2496,10 @@ public:
   /// names.
   DeclBaseName getBaseName() const { return Name.getBaseName(); }
 
+  Identifier getBaseIdentifier() const {
+    return getFullName().getBaseIdentifier();
+  }
+
   /// Generates a DeclNameRef referring to this declaration with as much
   /// specificity as possible.
   DeclNameRef createNameRef() const {
@@ -6239,8 +6243,6 @@ public:
                           TypeLoc FnRetType, DeclContext *Parent,
                           ClangNode ClangN = ClangNode());
 
-  Identifier getName() const { return getFullName().getBaseIdentifier(); }
-
   bool isStatic() const;
 
   /// \returns the way 'static'/'class' was spelled in the source.
@@ -6582,8 +6584,6 @@ public:
                   SourceLoc EqualsLoc,
                   LiteralExpr *RawValueExpr,
                   DeclContext *DC);
-
-  Identifier getName() const { return getFullName().getBaseIdentifier(); }
 
   /// Returns the string for the base name, or "_" if this is unnamed.
   StringRef getNameStr() const {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2497,7 +2497,7 @@ public:
   DeclBaseName getBaseName() const { return Name.getBaseName(); }
 
   Identifier getBaseIdentifier() const {
-    return getFullName().getBaseIdentifier();
+    return Name.getBaseIdentifier();
   }
 
   /// Generates a DeclNameRef referring to this declaration with as much
@@ -2828,12 +2828,12 @@ protected:
     ValueDecl(K, context, name, NameLoc), Inherited(inherited) {}
 
 public:
-  Identifier getName() const { return getFullName().getBaseIdentifier(); }
+  Identifier getName() const { return getBaseIdentifier(); }
 
   /// Returns the string for the base name, or "_" if this is unnamed.
   StringRef getNameStr() const {
     assert(!getFullName().isSpecial() && "Cannot get string for special names");
-    return hasName() ? getBaseName().getIdentifier().str() : "_";
+    return hasName() ? getBaseIdentifier().str() : "_";
   }
 
   /// The type of this declaration's values. For the type of the
@@ -4915,12 +4915,12 @@ public:
 
   SourceRange getSourceRange() const;
 
-  Identifier getName() const { return getFullName().getBaseIdentifier(); }
+  Identifier getName() const { return getBaseIdentifier(); }
 
   /// Returns the string for the base name, or "_" if this is unnamed.
   StringRef getNameStr() const {
     assert(!getFullName().isSpecial() && "Cannot get string for special names");
-    return hasName() ? getBaseName().getIdentifier().str() : "_";
+    return hasName() ? getBaseIdentifier().str() : "_";
   }
 
   /// Get the type of the variable within its context. If the context is generic,
@@ -5895,7 +5895,7 @@ public:
   /// Returns the string for the base name, or "_" if this is unnamed.
   StringRef getNameStr() const {
     assert(!getFullName().isSpecial() && "Cannot get string for special names");
-    return hasName() ? getBaseName().getIdentifier().str() : "_";
+    return hasName() ? getBaseIdentifier().str() : "_";
   }
 
   /// Should this declaration be treated as if annotated with transparent
@@ -6588,7 +6588,7 @@ public:
   /// Returns the string for the base name, or "_" if this is unnamed.
   StringRef getNameStr() const {
     assert(!getFullName().isSpecial() && "Cannot get string for special names");
-    return hasName() ? getBaseName().getIdentifier().str() : "_";
+    return hasName() ? getBaseIdentifier().str() : "_";
   }
 
   Type getArgumentInterfaceType() const;

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2613,7 +2613,7 @@ public:
   }
   void visitEnumIsCaseExpr(EnumIsCaseExpr *E) {
     printCommon(E, "enum_is_case_expr") << ' ' <<
-      E->getEnumElement()->getName() << "\n";
+      E->getEnumElement()->getBaseIdentifier() << "\n";
     printRec(E->getSubExpr());
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2876,7 +2876,7 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
         if (!decl->hasName()) {
           Printer << "<anonymous>";
         } else {
-          Printer.printName(decl->getName(),
+          Printer.printName(decl->getBaseIdentifier(),
                             getTypeMemberPrintNameContext(decl));
           if (decl->isOperator())
             Printer << " ";
@@ -2949,7 +2949,8 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
 void PrintAST::printEnumElement(EnumElementDecl *elt) {
   recordDeclLoc(elt,
     [&]{
-      Printer.printName(elt->getName(), getTypeMemberPrintNameContext(elt));
+      Printer.printName(elt->getBaseIdentifier(),
+                        getTypeMemberPrintNameContext(elt));
     });
 
   if (auto *PL = elt->getParameterList()) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -760,7 +760,7 @@ bool Decl::hasUnderscoredNaming() const {
   }
 
   if (!VD->getBaseName().isSpecial() &&
-      VD->getBaseName().getIdentifier().str().startswith("_")) {
+      VD->getBaseIdentifier().str().startswith("_")) {
     return true;
   }
 
@@ -3167,7 +3167,7 @@ bool ValueDecl::shouldHideFromEditor() const {
 
   // '$__' names are reserved by compiler internal.
   if (!getBaseName().isSpecial() &&
-      getBaseName().getIdentifier().str().startswith("$__"))
+      getBaseIdentifier().str().startswith("$__"))
     return true;
 
   return false;
@@ -3586,8 +3586,8 @@ int TypeDecl::compare(const TypeDecl *type1, const TypeDecl *type2) {
       return result;
   }
 
-  if (int result = type1->getBaseName().getIdentifier().str().compare(
-                                  type2->getBaseName().getIdentifier().str()))
+  if (int result = type1->getBaseIdentifier().str().compare(
+                                  type2->getBaseIdentifier().str()))
     return result;
 
   // Error case: two type declarations that cannot be distinguished.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6833,7 +6833,7 @@ AbstractFunctionDecl::getObjCSelector(DeclName preferredName,
     return destructor->getObjCSelector();
   } else if (auto func = dyn_cast<FuncDecl>(this)) {
     // Otherwise cast this to be able to access getName()
-    baseNameStr = func->getName().str();
+    baseNameStr = func->getBaseIdentifier().str();
   } else if (isa<ConstructorDecl>(this)) {
     baseNameStr = "init";
   } else {
@@ -7341,7 +7341,8 @@ SelfAccessKind FuncDecl::getSelfAccessKind() const {
 }
 
 bool FuncDecl::isCallAsFunctionMethod() const {
-  return getName() == getASTContext().Id_callAsFunction && isInstanceMember();
+  return getBaseIdentifier() == getASTContext().Id_callAsFunction &&
+         isInstanceMember();
 }
 
 ConstructorDecl::ConstructorDecl(DeclName Name, SourceLoc ConstructorLoc,
@@ -7838,7 +7839,7 @@ PrecedenceGroupDecl *InfixOperatorDecl::getPrecedenceGroup() const {
 }
 
 bool FuncDecl::isDeferBody() const {
-  return getName() == getASTContext().getIdentifier("$defer");
+  return getBaseIdentifier() == getASTContext().getIdentifier("$defer");
 }
 
 bool FuncDecl::isPotentialIBActionTarget() const {

--- a/lib/AST/FrontendSourceFileDepGraphFactory.cpp
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.cpp
@@ -59,10 +59,6 @@ template <typename DeclT> static std::string getBaseName(const DeclT *decl) {
   return decl->getBaseName().userFacingName().str();
 }
 
-template <typename DeclT> static std::string getName(const DeclT *decl) {
-  return DeclBaseName(decl->getName()).userFacingName().str();
-}
-
 static std::string mangleTypeAsContext(const NominalTypeDecl *NTD) {
   Mangle::ASTMangler Mangler;
   return !NTD ? "" : Mangler.mangleTypeAsContextUSR(NTD);
@@ -188,22 +184,22 @@ std::string
 DependencyKey::computeNameForProvidedEntity<NodeKind::topLevel,
                                             PrecedenceGroupDecl const *>(
     const PrecedenceGroupDecl *D) {
-  return ::getName(D);
+  return D->getName().str().str();
 }
 template <>
 std::string DependencyKey::computeNameForProvidedEntity<
     NodeKind::topLevel, FuncDecl const *>(const FuncDecl *D) {
-  return ::getName(D);
+  return getBaseName(D);
 }
 template <>
 std::string DependencyKey::computeNameForProvidedEntity<
     NodeKind::topLevel, OperatorDecl const *>(const OperatorDecl *D) {
-  return ::getName(D);
+  return D->getName().str().str();
 }
 template <>
 std::string DependencyKey::computeNameForProvidedEntity<
     NodeKind::topLevel, NominalTypeDecl const *>(const NominalTypeDecl *D) {
-  return ::getName(D);
+  return D->getName().str().str();
 }
 template <>
 std::string DependencyKey::computeNameForProvidedEntity<

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -49,7 +49,7 @@ getNameForObjC(const ValueDecl *VD, CustomNamesOnly_t customNamesOnly) {
         return anonTypedef->getIdentifier()->getName();
   }
 
-  return VD->getBaseName().getIdentifier().str();
+  return VD->getBaseIdentifier().str();
 }
 
 std::string swift::objc_translation::

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -90,7 +90,7 @@ printSwiftEnumElemNameInObjC(const EnumElementDecl *EL, llvm::raw_ostream &OS,
   }
   OS << getNameForObjC(EL->getDeclContext()->getSelfEnumDecl());
   if (PreferredName.empty())
-    ElemName = EL->getName().str();
+    ElemName = EL->getBaseIdentifier().str();
   else
     ElemName = PreferredName.str();
 

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -225,7 +225,7 @@ swift::USRGenerationRequest::evaluate(Evaluator &evaluator,
 
     auto ClangMacroInfo = ClangN.getAsMacro();
     bool Ignore = clang::index::generateUSRForMacro(
-        D->getBaseName().getIdentifier().str(),
+        D->getBaseIdentifier().str(),
         ClangMacroInfo->getDefinitionLoc(),
         Importer.getClangASTContext().getSourceManager(), Buffer);
     if (!Ignore)

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2414,7 +2414,7 @@ class DarwinLegacyFilterDeclConsumer : public swift::VisibleDeclConsumer {
     if (clangModule->Name == "MacTypes") {
       if (!VD->hasName() || VD->getBaseName().isSpecial())
         return true;
-      return llvm::StringSwitch<bool>(VD->getBaseName().getIdentifier().str())
+      return llvm::StringSwitch<bool>(VD->getBaseIdentifier().str())
           .Cases("OSErr", "OSStatus", "OptionBits", false)
           .Cases("FourCharCode", "OSType", false)
           .Case("Boolean", false)

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3202,7 +3202,7 @@ namespace {
           // context.
           if (errorWrapper) {
             auto enumeratorValue = cast<ValueDecl>(enumeratorDecl);
-            auto name = enumeratorValue->getBaseName().getIdentifier();
+            auto name = enumeratorValue->getBaseIdentifier();
             auto alias = importEnumCaseAlias(name,
                                              constant,
                                              enumeratorValue,

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -254,7 +254,7 @@ ProvidesEmitter::emitTopLevelNames() const {
   for (const Decl *D : SF->getTopLevelDecls())
     emitTopLevelDecl(D, cpd);
   for (auto *operatorFunction : cpd.memberOperatorDecls)
-    out << "- \"" << escape(operatorFunction->getName()) << "\"\n";
+    out << "- \"" << escape(operatorFunction->getBaseIdentifier()) << "\"\n";
   return cpd;
 }
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2177,7 +2177,7 @@ public:
         VD->shouldHideFromEditor())
       return;
 
-    Identifier Name = VD->getName();
+    const Identifier Name = VD->getName();
     assert(!Name.empty() && "name should not be empty");
 
     CommandWordsPairs Pairs;
@@ -2576,11 +2576,11 @@ public:
 
   void addMethodCall(const FuncDecl *FD, DeclVisibilityKind Reason,
                      DynamicLookupInfo dynamicLookupInfo) {
-    if (FD->getName().empty())
+    if (FD->getBaseIdentifier().empty())
       return;
     foundFunction(FD);
 
-    Identifier Name = FD->getName();
+    const Identifier Name = FD->getBaseIdentifier();
     assert(!Name.empty() && "name should not be empty");
 
     Type FunctionType = getTypeOfMember(FD, dynamicLookupInfo);
@@ -2944,7 +2944,7 @@ public:
     setAssociatedDecl(EED, Builder);
     setClangDeclKeywords(EED, Pairs, Builder);
     addLeadingDot(Builder);
-    addValueBaseName(Builder, EED->getName());
+    addValueBaseName(Builder, EED->getBaseIdentifier());
 
     // Enum element is of function type; (Self.type) -> Self or
     // (Self.Type) -> (Args...) -> Self.

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -2278,7 +2278,7 @@ isApplicable(ResolvedRangeInfo Info, DiagnosticEngine &Diag) {
     }
 
     bool checkName(FuncDecl *FD) {
-      auto Name = FD->getName().str();
+      const auto Name = FD->getBaseIdentifier().str();
       return Name == "~="
       || Name == "=="
       || Name == "__derived_enum_equals"
@@ -2391,7 +2391,8 @@ bool RefactoringActionConvertToSwitchStmt::performChange() {
     bool isFunctionNameAllowed(BinaryExpr *E) {
       auto FunctionBody = dyn_cast<DotSyntaxCallExpr>(E->getFn())->getFn();
       auto FunctionDeclaration = dyn_cast<DeclRefExpr>(FunctionBody)->getDecl();
-      auto FunctionName = dyn_cast<FuncDecl>(FunctionDeclaration)->getName().str();
+      const auto FunctionName = dyn_cast<FuncDecl>(FunctionDeclaration)
+          ->getBaseIdentifier().str();
       return FunctionName == "~="
       || FunctionName == "=="
       || FunctionName == "__derived_enum_equals"

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -1047,7 +1047,7 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
       // as members of the enum case decl. Walk them manually here so that they
       // end up as child nodes of enum case.
       for (auto *EnumElemD : EnumCaseD->getElements()) {
-        if (EnumElemD->getName().empty())
+        if (EnumElemD->getBaseIdentifier().empty())
           continue;
         SyntaxStructureNode SN;
         setDecl(SN, EnumElemD);
@@ -1060,7 +1060,8 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
           SN.NameRange = charSourceRangeFromSourceRange(SM, NameRange);
         } else {
           SN.NameRange = CharSourceRange(EnumElemD->getNameLoc(),
-                                         EnumElemD->getName().getLength());
+                                         EnumElemD->getBaseIdentifier()
+                                           .getLength());
         }
 
         if (auto *E = EnumElemD->getRawValueUnchecked()) {

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -6917,7 +6917,7 @@ const TypeInfo *TypeConverter::convertEnumType(TypeBase *key, CanType type,
       auto bitPattern = strategy->getBitPatternForNoPayloadElement(elt.decl);
       assert(bitPattern.size() == fixedTI->getFixedSize().getValueInBits());
       LLVM_DEBUG(llvm::dbgs() << "  no-payload case "
-                              << elt.decl->getName().str()
+                              << elt.decl->getBaseIdentifier().str()
                               << ":\t";
             displayBitMask(bitPattern));
 

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -693,7 +693,7 @@ private:
     }
 
     if (IGM.IRGen.Opts.EnableReflectionNames) {
-      auto name = value->getBaseName().getIdentifier().str();
+      auto name = value->getBaseIdentifier().str();
       auto fieldName = IGM.getAddrOfFieldName(name);
       B.addRelativeAddress(fieldName);
     } else {

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -489,7 +489,7 @@ private:
       }
 
     if (FD.hasName())
-      return FD.getName().str();
+      return FD.getBaseIdentifier().str();
 
     return StringRef();
   }
@@ -947,8 +947,8 @@ private:
                                   Alignment(1), true, false);
       }
       unsigned Offset = 0;
-      auto MTy = createMemberType(ElemDbgTy, ElemDecl->getName().str(), Offset,
-                                  Scope, File, Flags);
+      auto MTy = createMemberType(ElemDbgTy, ElemDecl->getBaseIdentifier().str(),
+                                  Offset, Scope, File, Flags);
       Elements.push_back(MTy);
     }
     return DBuilder.getOrCreateArray(Elements);

--- a/lib/Index/IndexSymbol.cpp
+++ b/lib/Index/IndexSymbol.cpp
@@ -75,7 +75,7 @@ static bool isUnitTest(const ValueDecl *D) {
     return false;
 
   // 6. ...and starts with "test".
-  if (FD->getName().str().startswith("test"))
+  if (FD->getBaseIdentifier().str().startswith("test"))
     return true;
 
   return false;

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -386,7 +386,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     for (auto *D: TopDecls) {
       if (auto *FD = dyn_cast<FuncDecl>(D)) {
         InsertedFunctions.insert(
-            std::string(FD->getBaseName().getIdentifier()));
+            std::string(FD->getBaseIdentifier()));
       }
     }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3519,7 +3519,7 @@ void Parser::setLocalDiscriminator(ValueDecl *D) {
     if (!getScopeInfo().isInactiveConfigBlock())
       SF.LocalTypeDecls.insert(TD);
 
-  Identifier name = D->getBaseName().getIdentifier();
+  const Identifier name = D->getBaseIdentifier();
   unsigned discriminator = CurLocalContext->claimNextNamedDiscriminator(name);
   D->setLocalDiscriminator(discriminator);
 }

--- a/lib/PrintAsObjC/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.cpp
@@ -395,7 +395,7 @@ private:
       // name.
       os << "  ";
       if (printSwiftEnumElemNameInObjC(Elt, os)) {
-        os << " SWIFT_COMPILE_NAME(\"" << Elt->getName() << "\")";
+        os << " SWIFT_COMPILE_NAME(\"" << Elt->getBaseIdentifier() << "\")";
       }
 
       // Print the raw values, even the ones that we synthesize.

--- a/lib/PrintAsObjC/ModuleContentsWriter.cpp
+++ b/lib/PrintAsObjC/ModuleContentsWriter.cpp
@@ -443,7 +443,7 @@ public:
       bool hasDomainCase = std::any_of(ED->getAllElements().begin(),
                                        ED->getAllElements().end(),
                                        [](const EnumElementDecl *elem) {
-        return elem->getName().str() == "Domain";
+        return elem->getBaseIdentifier().str() == "Domain";
       });
       if (!hasDomainCase) {
         os << "static NSString * _Nonnull const " << getNameForObjC(ED)

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1154,7 +1154,7 @@ static ManagedValue emitBuiltinApplyDerivative(
   auto builtinDecl = cast<FuncDecl>(cast<DeclRefExpr>(
       cast<DotSyntaxBaseIgnoredExpr>(callExpr->getDirectCallee())->getRHS())
           ->getDecl());
-  auto builtinName = builtinDecl->getName().str();
+  const auto builtinName = builtinDecl->getBaseIdentifier().str();
   AutoDiffDerivativeFunctionKind kind;
   unsigned arity;
   bool throws;
@@ -1172,7 +1172,7 @@ static ManagedValue emitBuiltinApplyTranspose(
   auto builtinDecl = cast<FuncDecl>(cast<DeclRefExpr>(
       cast<DotSyntaxBaseIgnoredExpr>(callExpr->getDirectCallee())->getRHS())
           ->getDecl());
-  auto builtinName = builtinDecl->getName().str();
+  const auto builtinName = builtinDecl->getBaseIdentifier().str();
   unsigned arity;
   bool throws;
   auto successfullyParsed = autodiff::getBuiltinApplyTransposeConfig(

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1355,7 +1355,7 @@ SpecializedEmitter::forDecl(SILGenModule &SGM, SILDeclRef function) {
   if (!isa<BuiltinUnit>(decl->getDeclContext()))
     return None;
 
-  auto name = decl->getBaseName().getIdentifier();
+  const auto name = decl->getBaseIdentifier();
   const BuiltinInfo &builtin = SGM.M.getBuiltinInfo(name);
   switch (builtin.ID) {
   // All the non-SIL, non-type-trait builtins should use the

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -253,7 +253,7 @@ void SILGenFunction::emitCaptures(SILLocation loc,
                      isDeferBody
                      ? diag::capture_before_declaration_defer
                      : diag::capture_before_declaration,
-                     vd->getBaseName().getIdentifier());
+                     vd->getBaseIdentifier());
       Diags.diagnose(vd->getLoc(), diag::captured_value_declared_here);
       Diags.diagnose(capture.getLoc(), diag::value_captured_here);
 

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -153,7 +153,7 @@ void ExclusiveBorrowFormalAccess::diagnoseConflict(
   if (!lhsStorage->Indices) {
     assert(isa<VarDecl>(storage));
     SGF.SGM.diagnose(loc, diag::writeback_overlap_property,
-                     storage->getBaseName().getIdentifier())
+                     storage->getBaseIdentifier())
        .highlight(loc.getSourceRange());
     SGF.SGM.diagnose(rhs.loc, diag::writebackoverlap_note)
        .highlight(rhs.loc.getSourceRange());

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -351,7 +351,7 @@ DIMemoryObjectInfo::getPathStringToElement(unsigned Element,
     Result = "self";
   else if (ValueDecl *VD =
                dyn_cast_or_null<ValueDecl>(getLoc().getAsASTNode<Decl>()))
-    Result = std::string(VD->getBaseName().getIdentifier());
+    Result = std::string(VD->getBaseIdentifier());
   else
     Result = "<unknown>";
 

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1203,11 +1203,12 @@ void LifetimeChecker::handleInOutUse(const DIMemoryUse &Use) {
     } else if (FD && FD->isOperator()) {
       diagnose(Module, Use.Inst->getLoc(),
                diag::mutating_method_called_on_immutable_value,
-               FD->getName(), /*operator*/ 1, StringRef(PropertyName));
+               FD->getBaseIdentifier(), /*operator*/ 1,
+               StringRef(PropertyName));
     } else if (FD && isSelfParameter) {
       diagnose(Module, Use.Inst->getLoc(),
                diag::mutating_method_called_on_immutable_value,
-               FD->getName(), /*method*/ 0, StringRef(PropertyName));
+               FD->getBaseIdentifier(), /*method*/ 0, StringRef(PropertyName));
     } else if (isAssignment) {
       diagnose(Module, Use.Inst->getLoc(),
                diag::assignment_to_immutable_value, StringRef(PropertyName));
@@ -1590,7 +1591,7 @@ bool LifetimeChecker::diagnoseMethodCall(const DIMemoryUse &Use,
     if (auto accessor = dyn_cast<AccessorDecl>(Method))
       Name = accessor->getStorage()->getBaseName();
     else
-      Name = Method->getName();
+      Name = Method->getBaseIdentifier();
 
     // If this is a use of self before super.init was called, emit a diagnostic
     // about *that* instead of about individual properties not being

--- a/lib/SILOptimizer/Mandatory/YieldOnceCheck.cpp
+++ b/lib/SILOptimizer/Mandatory/YieldOnceCheck.cpp
@@ -465,7 +465,7 @@ class YieldOnceCheck : public SILFunctionTransform {
           diagnose(astCtx, enumCaseLoc, diag::case_doesnt_yield, OptionSome);
         } else {
           diagnose(astCtx, enumCaseLoc, diag::named_case_doesnt_yield,
-                   enumElemDecl.get()->getName());
+                   enumElemDecl.get()->getBaseIdentifier());
         }
         return;
       }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2844,7 +2844,7 @@ namespace {
           // assigned case comes from Optional<T>
           if (auto EED = dyn_cast<EnumElementDecl>(calledValue)) {
             isOptional = EED->getParentEnum()->isOptionalDecl();
-            memberName = EED->getBaseName().getIdentifier();
+            memberName = EED->getBaseIdentifier();
           }
           
           // Return if the enum case doesn't come from Optional<T>

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7056,7 +7056,7 @@ Expr *ExprRewriter::convertLiteralInPlace(Expr *literal,
 static bool isValidDynamicCallableMethod(FuncDecl *method,
                                          AnyFunctionType *methodType) {
   auto &ctx = method->getASTContext();
-  if (method->getName() != ctx.Id_dynamicallyCall)
+  if (method->getBaseIdentifier() != ctx.Id_dynamicallyCall)
     return false;
   if (methodType->getParams().size() != 1)
     return false;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1461,7 +1461,7 @@ bool AssignmentFailure::diagnoseAsError() {
         std::string message = "key path is read-only";
         if (auto *SE = dyn_cast<SubscriptExpr>(immutableExpr)) {
           if (auto *DRE = dyn_cast<DeclRefExpr>(getKeyPathArgument(SE))) {
-            auto identifier = DRE->getDecl()->getBaseName().getIdentifier();
+            auto identifier = DRE->getDecl()->getBaseIdentifier();
             message =
                 "'" + identifier.str().str() + "' is a read-only key path";
           }
@@ -1574,7 +1574,7 @@ bool AssignmentFailure::diagnoseAsError() {
     // If we're trying to set an unapplied method, say that.
     if (auto *VD = choice->getDecl()) {
       std::string message = "'";
-      message += VD->getBaseName().getIdentifier().str();
+      message += VD->getBaseIdentifier().str();
       message += "'";
 
       auto diagID = DeclDiagnostic;
@@ -1639,7 +1639,7 @@ bool AssignmentFailure::diagnoseAsError() {
 
     if (auto *DRE = dyn_cast<DeclRefExpr>(AE->getFn()->getValueProvidingExpr()))
       name = std::string("'") +
-             DRE->getDecl()->getBaseName().getIdentifier().str().str() + "'";
+             DRE->getDecl()->getBaseIdentifier().str().str() + "'";
 
     emitDiagnostic(Loc, DeclDiagnostic, name + " returns immutable value")
         .highlight(AE->getSourceRange());
@@ -3060,7 +3060,7 @@ bool MissingCallFailure::diagnoseAsError() {
 
   if (auto *DRE = dyn_cast<DeclRefExpr>(baseExpr)) {
     emitDiagnostic(baseExpr->getLoc(), diag::did_not_call_function,
-                   DRE->getDecl()->getBaseName().getIdentifier())
+                   DRE->getDecl()->getBaseIdentifier())
         .fixItInsertAfter(insertLoc, "()");
     return true;
   }
@@ -3075,7 +3075,7 @@ bool MissingCallFailure::diagnoseAsError() {
   if (auto *DSCE = dyn_cast<DotSyntaxCallExpr>(baseExpr)) {
     if (auto *DRE = dyn_cast<DeclRefExpr>(DSCE->getFn())) {
       emitDiagnostic(baseExpr->getLoc(), diag::did_not_call_method,
-                     DRE->getDecl()->getBaseName().getIdentifier())
+                     DRE->getDecl()->getBaseIdentifier())
           .fixItInsertAfter(insertLoc, "()");
       return true;
     }
@@ -3200,7 +3200,7 @@ DeclName MissingMemberFailure::findCorrectEnumCaseName(
   auto candidate =
       corrections.getUniqueCandidateMatching([&](ValueDecl *candidate) {
         return (isa<EnumElementDecl>(candidate) &&
-                candidate->getFullName().getBaseIdentifier().str().equals_lower(
+                candidate->getBaseIdentifier().str().equals_lower(
                     memberName.getBaseIdentifier().str()));
       });
   return (candidate ? candidate->getFullName() : DeclName());

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4819,7 +4819,7 @@ bool ExtraneousReturnFailure::diagnoseAsError() {
     // because certain decls will have empty name (like setters).
     if (FD->getBodyResultTypeLoc().getLoc().isInvalid() &&
         FD->getParameters()->getStartLoc().isValid() &&
-        !FD->getName().empty()) {
+        !FD->getBaseIdentifier().empty()) {
       auto fixItLoc = Lexer::getLocForEndOfToken(
           getASTContext().SourceMgr, FD->getParameters()->getEndLoc());
       emitDiagnostic(anchor->getLoc(), diag::add_return_type_note)
@@ -5725,7 +5725,7 @@ bool ExtraneousCallFailure::diagnoseAsError() {
       if (auto *enumCase = dyn_cast<EnumElementDecl>(decl)) {
         auto diagnostic = emitDiagnostic(
             anchor->getLoc(), diag::unexpected_arguments_in_enum_case,
-            enumCase->getName());
+            enumCase->getBaseIdentifier());
         removeParensFixIt(diagnostic);
         return true;
       }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3870,7 +3870,7 @@ Optional<Identifier> constraints::getOperatorName(Expr *expr) {
   }
 
   if (auto *FD = dyn_cast_or_null<AbstractFunctionDecl>(choice))
-    return FD->getBaseName().getIdentifier();
+    return FD->getBaseIdentifier();
 
   return None;
 }

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -154,10 +154,10 @@ static bool validateCodingKeysEnum(DerivedConformance &derived,
 
   bool propertiesAreValid = true;
   for (auto elt : codingKeysDecl->getAllElements()) {
-    auto it = properties.find(elt->getName());
+    auto it = properties.find(elt->getBaseIdentifier());
     if (it == properties.end()) {
       elt->diagnose(diag::codable_extraneous_codingkey_case_here,
-                    elt->getName());
+                    elt->getBaseIdentifier());
       // TODO: Investigate typo-correction here; perhaps the case name was
       //       misspelled and we can provide a fix-it.
       propertiesAreValid = false;
@@ -493,7 +493,8 @@ static std::tuple<VarDecl *, Type, bool>
 lookupVarDeclForCodingKeysCase(DeclContext *conformanceDC,
                                EnumElementDecl *elt,
                                NominalTypeDecl *targetDecl) {
-  for (auto decl : targetDecl->lookupDirect(DeclName(elt->getName()))) {
+  for (auto decl : targetDecl->lookupDirect(
+                                   DeclName(elt->getBaseIdentifier()))) {
     if (auto *vd = dyn_cast<VarDecl>(decl)) {
       // If we found a property with an attached wrapper, retrieve the
       // backing property.

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -785,8 +785,8 @@ deriveBodyHashable_enum_hasAssociatedValues_hashInto(
                                                        payloadVars);
     auto pat = new (C) EnumElementPattern(TypeLoc::withoutLoc(enumType),
                                           SourceLoc(), DeclNameLoc(),
-                                          DeclNameRef(elt->getName()), elt,
-                                          payloadPattern);
+                                          DeclNameRef(elt->getBaseIdentifier()),
+                                          elt, payloadPattern);
     pat->setImplicit();
 
     auto labelItem = CaseLabelItem(pat);

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -597,7 +597,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
       }
 
       Ctx.Diags.diagnose(DRE->getLoc(), diag::warn_unqualified_access,
-                         VD->getBaseName().getIdentifier(),
+                         VD->getBaseIdentifier(),
                          VD->getDescriptiveKind(),
                          declParent->getDescriptiveKind(),
                          declParent->getFullName());
@@ -656,7 +656,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
       if (TypeChecker::getDeclTypeCheckingSemantics(DRE->getDecl())
             != DeclTypeCheckingSemantics::Normal) {
         Ctx.Diags.diagnose(DRE->getLoc(), diag::unsupported_special_decl_ref,
-                           DRE->getDecl()->getBaseName().getIdentifier());
+                           DRE->getDecl()->getBaseIdentifier());
       }
     }
     
@@ -1504,7 +1504,7 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
           memberLoc = DSCE->getLoc();
           Diags.diagnose(DSCE->getLoc(),
                          diag::method_call_in_closure_without_explicit_self,
-                         MethodExpr->getDecl()->getBaseName().getIdentifier());
+                         MethodExpr->getDecl()->getBaseIdentifier());
         }
 
       if (memberLoc.isValid()) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -161,7 +161,7 @@ public:
       // An indirect case should have a payload.
       if (!caseDecl->hasAssociatedValues())
         diagnose(attr->getLocation(), diag::indirect_case_without_payload,
-                 caseDecl->getName());
+                 caseDecl->getBaseIdentifier());
       // If the enum is already indirect, its cases don't need to be.
       else if (caseDecl->getParentEnum()->getAttrs()
                  .hasAttribute<IndirectAttr>())
@@ -1562,9 +1562,9 @@ void AttributeChecker::checkOperatorAttribute(DeclAttribute *attr) {
   }
 
   // Reject attempts to define builtin operators.
-  if (isBuiltinOperator(FD->getName().str(), attr)) {
+  if (isBuiltinOperator(FD->getBaseIdentifier().str(), attr)) {
     diagnose(D->getStartLoc(), diag::redefining_builtin_operator,
-             attr->getAttrName(), FD->getName().str());
+             attr->getAttrName(), FD->getBaseIdentifier().str());
     attr->setInvalid();
     return;
   }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -479,7 +479,7 @@ void AttributeChecker::visitIBSegueActionAttr(IBSegueActionAttr *attr) {
   // explicit selector.
   if (!FD->getAttrs().hasAttribute<ObjCAttr>() ||
       !FD->getAttrs().getAttribute<ObjCAttr>()->hasName()) {
-    auto newSwiftBaseName = replacingPrefix(FD->getBaseName().getIdentifier());
+    auto newSwiftBaseName = replacingPrefix(FD->getBaseIdentifier());
     auto argumentNames = FD->getFullName().getArgumentNames();
     DeclName newSwiftName(Ctx, newSwiftBaseName, argumentNames);
 

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -291,7 +291,7 @@ public:
           if (DC->isLocalContext()) {
             Context.Diags.diagnose(DRE->getLoc(), diag::capture_across_type_decl,
                                    NTD->getDescriptiveKind(),
-                                   D->getBaseName().getIdentifier());
+                                   D->getBaseIdentifier());
 
             NTD->diagnose(diag::kind_declared_here,
                           DescriptiveDeclKind::Type);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3834,7 +3834,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
         if (auto FD = dyn_cast<FuncDecl>(DRE->getDecl())) {
           if (!FD->getResultInterfaceType()->isVoid()) {
             diags.diagnose(diagLoc, diag::downcast_to_unrelated_fixit,
-                           FD->getName())
+                           FD->getBaseIdentifier())
                 .fixItInsertAfter(fromExpr->getEndLoc(), "()");
           }
         }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -666,7 +666,7 @@ IsStaticRequest::evaluate(Evaluator &evaluator, FuncDecl *decl) const {
   if (!result &&
       decl->isOperator() &&
       dc->isTypeContext()) {
-    auto operatorName = decl->getFullName().getBaseIdentifier();
+    const auto operatorName = decl->getBaseIdentifier();
     if (auto ED = dyn_cast<ExtensionDecl>(dc->getAsDecl())) {
       decl->diagnose(diag::nonstatic_operator_in_extension,
                      operatorName, ED->getExtendedTypeRepr())
@@ -1706,7 +1706,7 @@ OperatorDecl *
 FunctionOperatorRequest::evaluate(Evaluator &evaluator, FuncDecl *FD) const {  
   auto &C = FD->getASTContext();
   auto &diags = C.Diags;
-  auto operatorName = FD->getFullName().getBaseIdentifier();
+  const auto operatorName = FD->getBaseIdentifier();
 
   // Check for static/final/class when we're in a type.
   auto dc = FD->getDeclContext();

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1705,7 +1705,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
           diag::override_with_stored_property_warn :
           diag::override_with_stored_property;
       diags.diagnose(overrideASD, diagID,
-                     overrideASD->getBaseName().getIdentifier());
+                     overrideASD->getBaseIdentifier());
       diags.diagnose(baseASD, diag::property_override_here);
       if (!downgradeToWarning)
         return true;
@@ -1722,7 +1722,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
     if (overrideASD->getWriteImpl() == WriteImplKind::InheritedWithObservers
         && !baseIsSettable) {
       diags.diagnose(overrideASD, diag::observing_readonly_property,
-                     overrideASD->getBaseName().getIdentifier());
+                     overrideASD->getBaseIdentifier());
       diags.diagnose(baseASD, diag::property_override_here);
       return true;
     }
@@ -1732,7 +1732,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
     // setter but override the getter, and that would be surprising at best.
     if (baseIsSettable && !overrideASD->isSettable(override->getDeclContext())) {
       diags.diagnose(overrideASD, diag::override_mutable_with_readonly_property,
-                     overrideASD->getBaseName().getIdentifier());
+                     overrideASD->getBaseIdentifier());
       diags.diagnose(baseASD, diag::property_override_here);
       return true;
     }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1274,7 +1274,7 @@ public:
           Context.SourceMgr.extractText({VD->getNameLoc(), 1}) != "`") {
         auto &DE = getASTContext().Diags;
         DE.diagnose(VD->getNameLoc(), diag::reserved_member_name,
-                    VD->getFullName(), VD->getBaseName().getIdentifier().str());
+                    VD->getFullName(), VD->getBaseIdentifier().str());
         DE.diagnose(VD->getNameLoc(), diag::backticks_to_escape)
             .fixItReplace(VD->getNameLoc(),
                           "`" + VD->getBaseName().userFacingName().str() + "`");

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -178,12 +178,12 @@ TypeChecker::lookupPrecedenceGroupForInfixOperator(DeclContext *DC, Expr *E) {
   }
 
   if (auto *DRE = dyn_cast<DeclRefExpr>(E)) {
-    Identifier name = DRE->getDecl()->getBaseName().getIdentifier();
+    Identifier name = DRE->getDecl()->getBaseIdentifier();
     return lookupPrecedenceGroupForOperator(DC, name, DRE->getLoc());
   }
 
   if (auto *OO = dyn_cast<OverloadedDeclRefExpr>(E)) {
-    Identifier name = OO->getDecls()[0]->getBaseName().getIdentifier();
+    Identifier name = OO->getDecls()[0]->getBaseIdentifier();
     return lookupPrecedenceGroupForOperator(DC, name, OO->getLoc());
   }
 
@@ -204,7 +204,7 @@ TypeChecker::lookupPrecedenceGroupForInfixOperator(DeclContext *DC, Expr *E) {
   }
 
   if (auto *MRE = dyn_cast<MemberRefExpr>(E)) {
-    Identifier name = MRE->getDecl().getDecl()->getBaseName().getIdentifier();
+    Identifier name = MRE->getDecl().getDecl()->getBaseIdentifier();
     return lookupPrecedenceGroupForOperator(DC, name, MRE->getLoc());
   }
 

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1433,7 +1433,7 @@ namespace {
       case PatternKind::OptionalSome: {
         auto *OSP = cast<OptionalSomePattern>(item);
         auto &Ctx = OSP->getElementDecl()->getASTContext();
-        Identifier name = Ctx.getOptionalSomeDecl()->getName();
+        const Identifier name = Ctx.getOptionalSomeDecl()->getBaseIdentifier();
 
         auto subSpace = projectPattern(OSP->getSubPattern());
         // To match patterns like (_, _, ...)?, we must rewrite the underlying


### PR DESCRIPTION
@jckarter pinging you as the one who added the `TODO` in https://github.com/apple/swift/commit/a30e1b44b84051ffea8e375f4b47d8e9646b73db ... 6 years ago.

* Replace `FuncDecl::getName` & `EnumElementDecl::getName` with `ValueDecl::getBaseIdentifier`
* Collapse all indirect accesses equivalent to `ValueDecl::getBaseIdentifier`
### Upcoming
* Rename `getFullName()` to `getName()` on `ValueDecl` & `MissingMemberDecl`