### PR TITLE
shims: repair the build for android

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -282,7 +282,6 @@ float _stdlib_lgammaf(float x) {
   return lgammaf_r(x, &dontCare);
 }
 
-#if defined(__i386__) || defined(__x86_64__)
 static inline SWIFT_ALWAYS_INLINE
 double _stdlib_tan(double x) {
   return __builtin_tan(x);
@@ -385,7 +384,7 @@ double _stdlib_lgamma(double x) {
   return lgamma_r(x, &dontCare);
 }
 
-#if !defined(_WIN32) && !defined(ANDROID)
+#if !(defined(_WIN32) || defined(ANDROID)) && (defined(__i386__) || defined(__x86_64__))
 static inline SWIFT_ALWAYS_INLINE
 long double _stdlib_tanl(long double x) {
   return __builtin_tanl(x);
@@ -482,8 +481,7 @@ long double _stdlib_lgammal(long double x) {
   int dontCare;
   return lgammal_r(x, &dontCare);
 }
-#endif // !defined(_WIN32) && !defined(ANDROID)
-#endif
+#endif // !(defined(_WIN32) || defined(ANDROID)) && (defined(__i386__) || defined(__x86_64__))
 // SWIFT_ENABLE_TENSORFLOW END
 
 #ifdef __cplusplus


### PR DESCRIPTION
The math `long double` variants are only on x86/x86_64 (FP128 is
currently unsupported so ARM64 support is excluded).  However, Windows
and Android are FP64 and should not define the `long double` variants.
The original condition was completely incorrect as the `double` variants
are available everywhere.  This repairs the builds on android ARM64.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
