### PR TITLE
[Serialization] Recover from more failures when reading private declarations

### DIFF
--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -978,13 +978,14 @@ public:
   llvm::Expected<ProtocolConformanceRef>
   readConformanceChecked(llvm::BitstreamCursor &Cursor,
                          GenericEnvironment *genericEnv = nullptr);
-  
+
   /// Read a SILLayout from the given cursor.
   SILLayout *readSILLayout(llvm::BitstreamCursor &Cursor);
 
-  /// Read the given normal conformance from the current module file.
-  NormalProtocolConformance *
-  readNormalConformance(serialization::NormalConformanceID id);
+  /// Read the given normal conformance from the current module file,
+  /// returns the conformance or the first error.
+  llvm::Expected<NormalProtocolConformance *>
+  readNormalConformanceChecked(serialization::NormalConformanceID id);
 
   /// Reads a foreign error conformance from \c DeclTypeCursor, if present.
   Optional<ForeignErrorConvention> maybeReadForeignErrorConvention();


### PR DESCRIPTION
These two commits allow deserialization to recover from some failures reading swiftmodules that use implementation-only imports.

I’m bringing in the first commit from #27130. We saw this path being exercised only in the indexing phase which read private types and their members so it should be pretty safe to merge.

The second commit address a specific issue that we see in a complex case, but it drops too much information for my taste and may cause more problems in the future. I will consider reverting it when we have a better way to prevent such errors, such as always regenerating the swiftmodules from the public textual module interfaces before distribution.

rdar://60291019