### PR TITLE
[opt] [devirt] devirtualize public protocols with single use in WMO

### DIFF
--- a/test/SILOptimizer/devirtualize_existential.swift
+++ b/test/SILOptimizer/devirtualize_existential.swift
@@ -1,19 +1,62 @@
 // RUN: %target-swift-frontend %s -O -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend %s -O -wmo -emit-sil | %FileCheck %s --check-prefix=WMO-CHECK
 
-protocol Pingable {
- func ping(_ x : Int);
+public protocol Pingable {
+  func ping(_ x : Int) -> Int
 }
-class Foo : Pingable {
-  func ping(_ x : Int) { var t : Int }
+
+public class Foo : Pingable {
+  public func ping(_ x : Int) -> Int { x + 1 }
+}
+
+public class Err : Error { }
+
+public protocol Pongable {
+  func pong(_ x : Int) throws -> Int
+}
+
+public class Throwing : Pongable {
+  public func pong(_ x : Int) throws -> Int {
+    if x < 0 {
+      throw Err()
+    }
+    return x + 1
+  }
 }
 
 // Everything gets devirtualized, inlined, and promoted to the stack.
-//CHECK: @$s24devirtualize_existential17interesting_stuffyyF
-//CHECK-NOT: init_existential_addr
-//CHECK-NOT: apply
-//CHECK: return
-public func interesting_stuff() {
- var x : Pingable = Foo()
- x.ping(1)
+// CHECK-LABEL: sil @$s24devirtualize_existential17interesting_stuffSiyF
+// CHECK: bb0
+// CHECK-NEXT: integer_literal
+// CHECK-NEXT: struct
+// CHECK-NEXT: return
+// CHECK-LABEL: end sil function '$s24devirtualize_existential17interesting_stuffSiyF'
+public func interesting_stuff() -> Int {
+ let x : Pingable = Foo()
+ return x.ping(1)
 }
 
+
+// WMO-CHECK-LABEL: sil @$s24devirtualize_existential10ping_entryySiAA8Pingable_pF
+// WMO-CHECK: bb0
+// WMO-CHECK-NEXT: integer_literal
+// WMO-CHECK-NEXT: struct
+// WMO-CHECK-NEXT: return
+// WMO-CHECK-LABEL: end sil function '$s24devirtualize_existential10ping_entryySiAA8Pingable_pF'
+public func ping_entry(_ p: Pingable) -> Int {
+  return p.ping(1)
+}
+
+// WMO-CHECK-LABEL: sil @$s24devirtualize_existential10pong_entryySiAA8Pongable_pF
+// WMO-CHECK: bb0
+// WMO-CHECK-NEXT: integer_literal
+// WMO-CHECK-NEXT: struct
+// WMO-CHECK-NEXT: return
+// WMO-CHECK-LABEL: end sil function '$s24devirtualize_existential10pong_entryySiAA8Pongable_pF'
+public func pong_entry(_ p: Pongable) -> Int {
+  do {
+    return try p.pong(1)
+  } catch _ {
+    return 0
+  }
+}


### PR DESCRIPTION
If a public protocol only has a single conforming type, then devirtualize it in WMO.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
