### PR TITLE
[ConstraintSystem] Diagnose more cases of invalid `nil` use during co…

### DIFF
--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -221,7 +221,7 @@ func process(p: Any?) {
 func compare<T>(_: T, _: T) {} // expected-note {{'compare' declared here}}
 func compare<T>(_: T?, _: T?) {}
 
-_ = nil? as? Int?? // expected-error {{nil literal cannot be the source of a conditional cast}}
+_ = nil? as? Int?? // expected-error {{'nil' requires a contextual type}}
 
 func test_tuple_casts_no_warn() {
   struct Foo {}

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -439,9 +439,10 @@ func sr_12309() {
   _ = (nil!) // expected-error {{'nil' literal cannot be force unwrapped}}
   _ = (nil)! // expected-error {{'nil' literal cannot be force unwrapped}}
   _ = ((nil))! // expected-error {{'nil' literal cannot be force unwrapped}}
-  _ = nil? // expected-error {{value of optional type 'Optional<_>' must be unwrapped to a value of type '_'}}
-           // expected-note@-1 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
-           // expected-note@-2 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+  _ = nil? // expected-error {{'nil' requires a contextual type}}
+  _ = ((nil?)) // expected-error {{'nil' requires a contextual type}}
+  _ = ((nil))? // expected-error {{'nil' requires a contextual type}}
+  _ = ((nil)?) // expected-error {{'nil' requires a contextual type}}
   _ = nil // expected-error {{'nil' requires a contextual type}}
   _ = (nil) // expected-error {{'nil' requires a contextual type}}
   _ = ((nil)) // expected-error {{'nil' requires a contextual type}}


### PR DESCRIPTION
…nstraint generation

Move check for `nil` destination of conditional casts to `visitNilLiteral` and
add support for `nil?` which wasn't previously detected.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
