### PR TITLE
[SR-12382] Improve optional pointer conversion mismatch diagnostics

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -674,6 +674,15 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
       }
       break;
     }
+    
+    case ConstraintLocator::OptionalPayload: {
+      // If we have an inout expression, this comes from an
+      // InoutToPointer argument mismatch failure.
+      if (isa<InOutExpr>(anchor)) {
+        diagnostic = diag::cannot_convert_argument_value;
+      }
+      break;
+    }
 
     case ConstraintLocator::TupleElement: {
       auto *anchor = getRawAnchor();

--- a/test/Constraints/valid_pointer_conversions.swift
+++ b/test/Constraints/valid_pointer_conversions.swift
@@ -31,6 +31,13 @@ func givesPtr(_ str: String) {
   takesDoubleOptionalPtr(i) // expected-error {{cannot convert value of type 'Int' to expected argument type 'UnsafeRawPointer??'}}
   takesMutableDoubleOptionalPtr(arr) // expected-error {{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutableRawPointer??'}}
 
-  // FIXME(SR-12382): Poor diagnostic.
-  takesMutableDoubleOptionalTypedPtr(&i) // expected-error {{type of expression is ambiguous without more context}}
+  takesMutableDoubleOptionalTypedPtr(&i) // expected-error {{cannot convert value of type 'UnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<Double>'}}
+  // expected-note@-1 {{arguments to generic parameter 'Pointee' ('Int' and 'Double') are expected to be equal}}
 }
+
+// SR12382
+func SR12382(_ x: UnsafeMutablePointer<Double>??) {}
+
+var i = 0
+SR12382(&i) // expected-error {{cannot convert value of type 'UnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<Double>'}}
+// expected-note@-1 {{arguments to generic parameter 'Pointee' ('Int' and 'Double') are expected to be equal}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Improves the diagnostic optional inout to generic pointer conversion mismatch.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-12382.

cc @xedin @hamishknight :)
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
