### PR TITLE
[AutoDiff upstream] Fill in derivative witness table/vtable thunks.

### DIFF
--- a/lib/SIL/OwnershipUtils.cpp
+++ b/lib/SIL/OwnershipUtils.cpp
@@ -30,6 +30,7 @@ bool swift::isOwnershipForwardingValueKind(SILNodeKind kind) {
   case SILNodeKind::TupleInst:
   case SILNodeKind::StructInst:
   case SILNodeKind::EnumInst:
+  case SILNodeKind::DifferentiableFunctionInst:
   case SILNodeKind::OpenExistentialRefInst:
   case SILNodeKind::UpcastInst:
   case SILNodeKind::UncheckedRefCastInst:
@@ -46,7 +47,6 @@ bool swift::isOwnershipForwardingValueKind(SILNodeKind kind) {
   case SILNodeKind::DestructureTupleInst:
   case SILNodeKind::MarkDependenceInst:
   case SILNodeKind::InitExistentialRefInst:
-  case SILNodeKind::DifferentiableFunctionInst:
     return true;
   default:
     return false;
@@ -59,9 +59,9 @@ bool swift::isGuaranteedForwardingValueKind(SILNodeKind kind) {
   switch (kind) {
   case SILNodeKind::TupleExtractInst:
   case SILNodeKind::StructExtractInst:
+  case SILNodeKind::DifferentiableFunctionExtractInst:
   case SILNodeKind::OpenExistentialValueInst:
   case SILNodeKind::OpenExistentialBoxValueInst:
-  case SILNodeKind::DifferentiableFunctionExtractInst:
     return true;
   default:
     return isOwnershipForwardingValueKind(kind);

--- a/test/AutoDiff/SILGen/vtable.swift
+++ b/test/AutoDiff/SILGen/vtable.swift
@@ -95,6 +95,19 @@ class Sub: Super {
 
 class SubSub: Sub {}
 
+// Check vtable entry thunks.
+
+// CHECK-LABEL: sil hidden [transparent] [thunk] [ossa] @AD__${{.*}}5SuperC6methody{{.*}}jvp_src_0_wrt_0_vtable_entry_thunk : $@convention(method) (Float, Float, @guaranteed Super) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+// CHECK: bb0(%0 : $Float, %1 : $Float, %2 : @guaranteed $Super):
+// CHECK:   %3 = function_ref @$s6vtable5SuperC6methodyS2f_SftF : $@convention(method) (Float, Float, @guaranteed Super) -> Float
+// CHECK:   %4 = differentiable_function [parameters 0] %3 : $@convention(method) (Float, Float, @guaranteed Super) -> Float
+// CHECK:   %5 = differentiable_function_extract [jvp] %4 : $@differentiable @convention(method) (Float, @noDerivative Float, @noDerivative @guaranteed Super) -> Float
+// CHECK:   %6 = apply %5(%0, %1, %2) : $@convention(method) (Float, Float, @guaranteed Super) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK:   return %6 : $(Float, @callee_guaranteed (Float) -> Float)
+// CHECK: }
+
+// Check vtable entries: new vs `[override]` vs `[inherited]` entries.
+
 // CHECK-LABEL: sil_vtable Super {
 // CHECK:   #Super.method: (Super) -> (Float, Float) -> Float : @$s6vtable5SuperC6methodyS2f_SftF
 // CHECK:   #Super.method!jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s6vtable5SuperC6methodyS2f_SftF__jvp_src_0_wrt_0_vtable_entry_thunk

--- a/test/AutoDiff/SILGen/witness_table.swift
+++ b/test/AutoDiff/SILGen/witness_table.swift
@@ -35,12 +35,32 @@ struct Struct: Protocol {
   }
 
   // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @AD__${{.*}}method{{.*}}_jvp_SUU : $@convention(witness_method: Protocol) (Float, Double, @in_guaranteed Struct) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+  // CHECK: [[ORIG_FN:%.*]] = function_ref {{.*}}method{{.*}} : $@convention(method) (Float, Double, Struct) -> Float
+  // CHECK: [[DIFF_FN:%.*]] = differentiable_function [parameters 0] [[ORIG_FN]]
+  // CHECK: [[JVP_FN:%.*]] = differentiable_function_extract [jvp] [[DIFF_FN]]
+  // CHECK: apply [[JVP_FN]]
+  // CHECK: }
 
   // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @AD__${{.*}}method{{.*}}_vjp_SUU : $@convention(witness_method: Protocol) (Float, Double, @in_guaranteed Struct) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+  // CHECK: [[ORIG_FN:%.*]] = function_ref {{.*}}method{{.*}} : $@convention(method) (Float, Double, Struct) -> Float
+  // CHECK: [[DIFF_FN:%.*]] = differentiable_function [parameters 0] [[ORIG_FN]]
+  // CHECK: [[VJP_FN:%.*]] = differentiable_function_extract [vjp] [[DIFF_FN]]
+  // CHECK: apply [[VJP_FN]]
+  // CHECK: }
 
   // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @AD__${{.*}}method{{.*}}_jvp_SSS : $@convention(witness_method: Protocol) (Float, Double, @in_guaranteed Struct) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (Float, Double, @in_guaranteed τ_0_0) -> Float for <DummyTangentVector>) {
+  // CHECK: [[ORIG_FN:%.*]] = function_ref {{.*}}method{{.*}} : $@convention(method) (Float, Double, Struct) -> Float
+  // CHECK: [[DIFF_FN:%.*]] = differentiable_function [parameters 0 1 2] [[ORIG_FN]]
+  // CHECK: [[JVP_FN:%.*]] = differentiable_function_extract [jvp] [[DIFF_FN]]
+  // CHECK: apply [[JVP_FN]]
+  // CHECK: }
 
   // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @AD__${{.*}}method{{.*}}_vjp_SSS : $@convention(witness_method: Protocol) (Float, Double, @in_guaranteed Struct) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (Float) -> (Float, Double, @out τ_0_0) for <DummyTangentVector>) {
+  // CHECK: [[ORIG_FN:%.*]] = function_ref {{.*}}method{{.*}} : $@convention(method) (Float, Double, Struct) -> Float
+  // CHECK: [[DIFF_FN:%.*]] = differentiable_function [parameters 0 1 2] [[ORIG_FN]]
+  // CHECK: [[VJP_FN:%.*]] = differentiable_function_extract [vjp] [[DIFF_FN]]
+  // CHECK: apply [[VJP_FN]]
+  // CHECK: }
 
   @differentiable
   var property: Float {
@@ -49,9 +69,18 @@ struct Struct: Protocol {
   }
 
   // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @AD__${{.*}}property{{.*}}_jvp_S : $@convention(witness_method: Protocol) (@in_guaranteed Struct) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> Float for <DummyTangentVector>) {
+  // CHECK: [[ORIG_FN:%.*]] = function_ref {{.*}}property{{.*}} : $@convention(method) (Struct) -> Float
+  // CHECK: [[DIFF_FN:%.*]] = differentiable_function [parameters 0] [[ORIG_FN]]
+  // CHECK: [[JVP_FN:%.*]] = differentiable_function_extract [jvp] [[DIFF_FN]]
+  // CHECK: apply [[JVP_FN]]
+  // CHECK: }
 
   // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @AD__${{.*}}property{{.*}}_vjp_S : $@convention(witness_method: Protocol) (@in_guaranteed Struct) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (Float) -> @out τ_0_0 for <DummyTangentVector>) {
-
+  // CHECK: [[ORIG_FN:%.*]] = function_ref {{.*}}property{{.*}} : $@convention(method) (Struct) -> Float
+  // CHECK: [[DIFF_FN:%.*]] = differentiable_function [parameters 0] [[ORIG_FN]]
+  // CHECK: [[VJP_FN:%.*]] = differentiable_function_extract [vjp] [[DIFF_FN]]
+  // CHECK: apply [[VJP_FN]]
+  // CHECK: }
 
   @differentiable(wrt: x)
   subscript(_ x: Float, _ y: Float) -> Float {
@@ -60,8 +89,18 @@ struct Struct: Protocol {
   }
 
   // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @AD__$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcigTW_jvp_SUU : $@convention(witness_method: Protocol) (Float, Float, @in_guaranteed Struct) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+  // CHECK: [[ORIG_FN:%.*]] = function_ref @$s13witness_table6StructVyS2f_Sftcig : $@convention(method) (Float, Float, Struct) -> Float
+  // CHECK: [[DIFF_FN:%.*]] = differentiable_function [parameters 0] [[ORIG_FN]]
+  // CHECK: [[JVP_FN:%.*]] = differentiable_function_extract [jvp] [[DIFF_FN]]
+  // CHECK: apply [[JVP_FN]]
+  // CHECK: }
 
   // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @AD__$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcigTW_vjp_SUU : $@convention(witness_method: Protocol) (Float, Float, @in_guaranteed Struct) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+  // CHECK: [[ORIG_FN:%.*]] = function_ref @$s13witness_table6StructVyS2f_Sftcig : $@convention(method) (Float, Float, Struct) -> Float
+  // CHECK: [[DIFF_FN:%.*]] = differentiable_function [parameters 0] [[ORIG_FN]]
+  // CHECK: [[VJP_FN:%.*]] = differentiable_function_extract [vjp] [[DIFF_FN]]
+  // CHECK: apply [[VJP_FN]]
+  // CHECK: }
 }
 
 // CHECK-LABEL: sil_witness_table hidden Struct: Protocol module witness_table {


### PR DESCRIPTION
Generate `differentiable_function` and `differentiable_function_extract` in
derivative witness table/vtable thunks.

`differentiation_function` is later canonicalized by the differentiation
transform.

Add SIL FileCheck tests.