### PR TITLE
[Index] Add index support for cross import overlays.

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -82,6 +82,9 @@ public:
   /// Emit index data for imported serialized swift system modules.
   bool IndexSystemModules = false;
 
+  /// If indexing system modules, don't index the stdlib.
+  bool IndexIgnoreStdlib = false;
+
   /// The module for which we should verify all of the generic signatures.
   std::string VerifyGenericSignaturesInModule;
 

--- a/include/swift/Index/IndexRecord.h
+++ b/include/swift/Index/IndexRecord.h
@@ -36,6 +36,9 @@ namespace index {
 /// \param indexSystemModules If true, emit index data for imported serialized
 /// swift system modules.
 ///
+/// \param skipStdlib If indexing system modules, don't index the standard
+/// library.
+///
 /// \param isDebugCompilation true for non-optimized compiler invocation.
 ///
 /// \param targetTriple The target for this compilation.
@@ -43,7 +46,8 @@ namespace index {
 /// \param dependencyTracker The set of dependencies seen while building.
 bool indexAndRecord(SourceFile *primarySourceFile, StringRef indexUnitToken,
                     StringRef indexStorePath, bool indexSystemModules,
-                    bool isDebugCompilation, StringRef targetTriple,
+                    bool skipStdlib, bool isDebugCompilation,
+                    StringRef targetTriple,
                     const DependencyTracker &dependencyTracker);
 
 /// Index the given module and store the results to \p indexStorePath.
@@ -64,6 +68,9 @@ bool indexAndRecord(SourceFile *primarySourceFile, StringRef indexUnitToken,
 /// \param indexSystemModules If true, emit index data for imported serialized
 /// swift system modules.
 ///
+/// \param skipStdlib If indexing system modules, don't index the standard
+/// library.
+///
 /// \param isDebugCompilation true for non-optimized compiler invocation.
 ///
 /// \param targetTriple The target for this compilation.
@@ -71,8 +78,8 @@ bool indexAndRecord(SourceFile *primarySourceFile, StringRef indexUnitToken,
 /// \param dependencyTracker The set of dependencies seen while building.
 bool indexAndRecord(ModuleDecl *module, ArrayRef<std::string> indexUnitTokens,
                     StringRef moduleUnitToken, StringRef indexStorePath,
-                    bool indexSystemModules, bool isDebugCompilation,
-                    StringRef targetTriple,
+                    bool indexSystemModules, bool skipStdlib,
+                    bool isDebugCompilation, StringRef targetTriple,
                     const DependencyTracker &dependencyTracker);
 // FIXME: indexUnitTokens could be StringRef, but that creates an impedance
 // mismatch in the caller.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -604,6 +604,10 @@ def external_pass_pipeline_filename : Separate<["-"], "external-pass-pipeline-fi
 def index_system_modules : Flag<["-"], "index-system-modules">,
   HelpText<"Emit index data for imported serialized swift system modules">;
 
+def index_ignore_stdlib :
+  Flag<["-"], "index-ignore-stdlib">,
+  HelpText<"Avoid emitting index data for the standard library.">;
+
 def dump_interface_hash : Flag<["-"], "dump-interface-hash">,
    HelpText<"Parse input file(s) and dump interface token hash(es)">,
    ModeOpt;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2105,10 +2105,15 @@ SourceFile::getModuleShadowedBySeparatelyImportedOverlay(const ModuleDecl *overl
       }
     }
   }
-  auto i = separatelyImportedOverlaysReversed.find(overlay);
-  return i != separatelyImportedOverlaysReversed.end()
-    ? std::get<1>(*i)
-    : nullptr;
+
+  ModuleDecl *underlying = const_cast<ModuleDecl *>(overlay);
+  while (underlying->getNameStr().startswith("_")) {
+    auto next = separatelyImportedOverlaysReversed.find(underlying);
+    if (next == separatelyImportedOverlaysReversed.end())
+      return nullptr;
+    underlying = std::get<1>(*next);
+  }
+  return underlying;
 };
 
 void ModuleDecl::clearLookupCache() {

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -67,6 +67,7 @@ bool ArgsToFrontendOptionsConverter::convert(
     Opts.BridgingHeaderDirForPrint = A->getValue();
   }
   Opts.IndexSystemModules |= Args.hasArg(OPT_index_system_modules);
+  Opts.IndexIgnoreStdlib |= Args.hasArg(OPT_index_ignore_stdlib);
 
   Opts.EmitVerboseSIL |= Args.hasArg(OPT_emit_verbose_sil);
   Opts.EmitSortedSIL |= Args.hasArg(OPT_emit_sorted_sil);

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1729,7 +1729,8 @@ static bool emitIndexDataIfNeeded(SourceFile *PrimarySourceFile,
             PrimarySourceFile->getFilename());
     if (index::indexAndRecord(PrimarySourceFile, PSPs.OutputFilename,
                               opts.IndexStorePath, opts.IndexSystemModules,
-                              isDebugCompilation, Invocation.getTargetTriple(),
+                              opts.IndexIgnoreStdlib, isDebugCompilation,
+                              Invocation.getTargetTriple(),
                               *Instance.getDependencyTracker())) {
       return true;
     }
@@ -1741,7 +1742,7 @@ static bool emitIndexDataIfNeeded(SourceFile *PrimarySourceFile,
 
     if (index::indexAndRecord(Instance.getMainModule(), opts.InputsAndOutputs.copyOutputFilenames(),
                               moduleToken, opts.IndexStorePath,
-                              opts.IndexSystemModules,
+                              opts.IndexSystemModules, opts.IndexIgnoreStdlib,
                               isDebugCompilation, Invocation.getTargetTriple(),
                               *Instance.getDependencyTracker())) {
       return true;

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -781,12 +781,9 @@ void CodeCompletionResultBuilder::setAssociatedDecl(const Decl *D,
     // If this is an underscored cross-import overlay, map it to its underlying
     // module instead.
     if (SF) {
-      while (MD->getNameStr().startswith("_")) {
-        auto *Underlying = SF->getModuleShadowedBySeparatelyImportedOverlay(MD);
-        if (!Underlying)
-          break;
+      auto *Underlying = SF->getModuleShadowedBySeparatelyImportedOverlay(MD);
+      if (Underlying)
         MD = Underlying;
-      }
     }
     CurrentModule = MD;
   }

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -129,7 +129,6 @@ public:
     ImportFilter |= ModuleDecl::ImportFilterKind::Public;
     ImportFilter |= ModuleDecl::ImportFilterKind::Private;
     ImportFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
-    // FIXME: ImportFilterKind::ShadowedBySeparateOverlay?
 
     if (auto *SF = SFOrMod.dyn_cast<SourceFile *>()) {
       SF->getImportedModules(Modules, ImportFilter);
@@ -147,6 +146,7 @@ struct IndexedWitness {
 class IndexSwiftASTWalker : public SourceEntityWalker {
   IndexDataConsumer &IdxConsumer;
   SourceManager &SrcMgr;
+  SourceFile *InitialFile; ///< The SoureFile we started walking from, if any.
   unsigned BufferID;
   bool enableWarnings;
 
@@ -282,8 +282,9 @@ class IndexSwiftASTWalker : public SourceEntityWalker {
 
 public:
   IndexSwiftASTWalker(IndexDataConsumer &IdxConsumer, ASTContext &Ctx,
-                      unsigned BufferID = -1)
-      : IdxConsumer(IdxConsumer), SrcMgr(Ctx.SourceMgr), BufferID(BufferID),
+                      SourceFile *SF = nullptr)
+      : IdxConsumer(IdxConsumer), SrcMgr(Ctx.SourceMgr), InitialFile(SF),
+        BufferID(SF ? SF->getBufferID().getValueOr(-1) : -1),
         enableWarnings(IdxConsumer.enableWarnings()) {}
 
   ~IndexSwiftASTWalker() override {
@@ -755,7 +756,18 @@ bool IndexSwiftASTWalker::visitImports(
       continue;
     bool IsClangModule = *IsClangModuleOpt;
 
-    if (!IdxConsumer.startDependency(Mod->getName().str(), Path, IsClangModule,
+    StringRef ModuleName = Mod->getNameStr();
+
+    // If this module is an underscored cross-import overlay, use the name
+    // of the underlying module instead.
+    if (InitialFile) {
+      ModuleDecl *Underlying =
+        InitialFile->getModuleShadowedBySeparatelyImportedOverlay(Mod);
+      if (Underlying)
+        ModuleName = Underlying->getNameStr();
+    }
+
+    if (!IdxConsumer.startDependency(ModuleName, Path, IsClangModule,
                                      Mod->isSystemModule()))
       return false;
     if (!IsClangModule)
@@ -1584,16 +1596,15 @@ void IndexSwiftASTWalker::collectRecursiveModuleImports(
 
 void index::indexDeclContext(DeclContext *DC, IndexDataConsumer &consumer) {
   assert(DC);
-  unsigned bufferId = DC->getParentSourceFile()->getBufferID().getValue();
-  IndexSwiftASTWalker walker(consumer, DC->getASTContext(), bufferId);
+  SourceFile *SF = DC->getParentSourceFile();
+  IndexSwiftASTWalker walker(consumer, DC->getASTContext(), SF);
   walker.visitDeclContext(DC);
   consumer.finish();
 }
 
 void index::indexSourceFile(SourceFile *SF, IndexDataConsumer &consumer) {
   assert(SF);
-  unsigned bufferID = SF->getBufferID().getValue();
-  IndexSwiftASTWalker walker(consumer, SF->getASTContext(), bufferID);
+  IndexSwiftASTWalker walker(consumer, SF->getASTContext(), SF);
   walker.visitModule(*SF->getParentModule());
   consumer.finish();
 }

--- a/test/Index/Inputs/CrossImport/A.framework/Modules/A.swiftcrossimport/B.swiftoverlay
+++ b/test/Index/Inputs/CrossImport/A.framework/Modules/A.swiftcrossimport/B.swiftoverlay
@@ -1,0 +1,5 @@
+%YAML 1.2
+---
+version: 1
+modules:
+  - name: _ABAdditions

--- a/test/Index/Inputs/CrossImport/A.framework/Modules/A.swiftmodule/module-triple-here.swiftinterface
+++ b/test/Index/Inputs/CrossImport/A.framework/Modules/A.swiftmodule/module-triple-here.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -swift-version 5 -enable-library-evolution -module-name A
+
+public func fromA()

--- a/test/Index/Inputs/CrossImport/B.framework/Modules/B.swiftmodule/module-triple-here.swiftinterface
+++ b/test/Index/Inputs/CrossImport/B.framework/Modules/B.swiftmodule/module-triple-here.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -swift-version 5 -enable-library-evolution -module-name B
+
+public func fromB()

--- a/test/Index/Inputs/CrossImport/C.framework/Modules/C.swiftmodule/module-triple-here.swiftinterface
+++ b/test/Index/Inputs/CrossImport/C.framework/Modules/C.swiftmodule/module-triple-here.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -swift-version 5 -enable-library-evolution -module-name C
+
+public func fromC()

--- a/test/Index/Inputs/CrossImport/_ABAdditions.framework/Modules/_ABAdditions.swiftcrossimport/C.swiftoverlay
+++ b/test/Index/Inputs/CrossImport/_ABAdditions.framework/Modules/_ABAdditions.swiftcrossimport/C.swiftoverlay
@@ -1,0 +1,5 @@
+%YAML 1.2
+---
+version: 1
+modules:
+  - name: __ABAdditionsCAdditions

--- a/test/Index/Inputs/CrossImport/_ABAdditions.framework/Modules/_ABAdditions.swiftmodule/module-triple-here.swiftinterface
+++ b/test/Index/Inputs/CrossImport/_ABAdditions.framework/Modules/_ABAdditions.swiftmodule/module-triple-here.swiftinterface
@@ -1,0 +1,8 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -swift-version 5 -enable-library-evolution -module-name _ABAdditions
+
+@_exported import A
+import B
+
+public func from_ABAdditions()
+public struct From_ABAdditionsType {}

--- a/test/Index/Inputs/CrossImport/__ABAdditionsCAdditions.framework/Modules/__ABAdditionsCAdditions.swiftmodule/module-triple-here.swiftinterface
+++ b/test/Index/Inputs/CrossImport/__ABAdditionsCAdditions.framework/Modules/__ABAdditionsCAdditions.swiftmodule/module-triple-here.swiftinterface
@@ -1,0 +1,7 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -swift-version 5 -enable-library-evolution -module-name __ABAdditionsCAdditions
+
+@_exported import _ABAdditions
+import C
+
+public func from__ABAdditionsCAdditions()

--- a/test/Index/Store/cross-import-overlay.swift
+++ b/test/Index/Store/cross-import-overlay.swift
@@ -1,11 +1,10 @@
 // RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/mcp)
 // RUN: cp -r %S/../Inputs/CrossImport %t/CrossImport
 // RUN: %{python} %S/../../CrossImport/Inputs/rewrite-module-triples.py %t/CrossImport %module-target-triple
 
-// RUN: %target-swift-frontend -c -index-store-path %t/idx -index-system-modules -index-ignore-stdlib -enable-cross-import-overlays %s -Fsystem %t/CrossImport -o %t/file1.o -module-name cross_import_overlay
+// RUN: %target-swift-frontend -c -index-store-path %t/idx -module-cache-path %t/mcp -index-system-modules -index-ignore-stdlib -enable-cross-import-overlays %s -Fsystem %t/CrossImport -o %t/file1.o -module-name cross_import_overlay
 // RUN: c-index-test core -print-unit %t/idx > %t/units
-// RUN: %FileCheck %s --input-file %t/units --check-prefix=UNIT
-// RUN: %FileCheck %s --input-file %t/units --check-prefix=UNIT-NEGATIVE
 
 import A
 import B
@@ -16,59 +15,96 @@ fromB()
 from_ABAdditions()
 from__ABAdditionsCAdditions()
 
-// Check the overlay modules' names match the names of their underlying modules.
+// Check the overlay modules pick up the name of their underlying module.
 //
-// UNIT: module-name: cross_import_overlay
-// UNIT: main-path: {{.*}}/cross-import-overlay.swift
-// UNIT: DEPEND START
-// UNIT: Unit | system | B | {{.*}}/B.swiftmodule/{{.*}}
-// UNIT: Unit | system | C | {{.*}}/C.swiftmodule/{{.*}}
-// UNIT: Unit | system | A | {{.*}}/__ABAdditionsCAdditions.swiftmodule/{{.*}}
-// UNIT: Record | user | {{.*}}/cross-import-overlay.swift | cross-import-overlay.swift-{{.*}}
-// UNIT: DEPEND END
-// UNIT: --------
-// UNIT: module-name: A
-// UNIT: out-file: {{.*}}/_ABAdditions.swiftmodule/{{.*}}
-// UNIT: DEPEND START
-// UNIT: Unit | system | A | {{.*}}/A.swiftmodule/{{.*}}
-// UNIT: Unit | system | B | {{.*}}/B.swiftmodule/{{.*}}
-// UNIT: Record | system | A | {{.*}}/_ABAdditions.swiftmodule/{{.*}}
-// UNIT: DEPEND END
-// UNIT: --------
-// UNIT: module-name: A
-// UNIT: out-file: {{.*}}/__ABAdditionsCAdditions.swiftmodule/{{.*}}
-// UNIT: DEPEND START
-// UNIT: Unit | system | C | {{.*}}/C.swiftmodule/{{.*}}
-// UNIT: Unit | system | A | {{.*}}/_ABAdditions.swiftmodule/{{.*}}
-// UNIT: Record | system | A | {{.*}}/__ABAdditionsCAdditions.swiftmodule/{{.*}}
-// UNIT: DEPEND END
-// UNIT: --------
-// UNIT: module-name: C
-// UNIT: out-file: {{.*}}/C.swiftmodule/{{.*}}
-// UNIT: DEPEND START
-// UNIT: Record | system | C | {{.*}}/C.swiftmodule/{{.*}}
-// UNIT: DEPEND END
-// UNIT: --------
-// UNIT: module-name: B
-// UNIT: out-file: {{.*}}/B.swiftmodule/{{.*}}
-// UNIT: DEPEND START
-// UNIT: Record | system | B | {{.*}}/B.swiftmodule/{{.*}}
-// UNIT: DEPEND END
-// UNIT: --------
-// UNIT: module-name: A
-// UNIT: out-file: {{.*}}/A.swiftmodule/{{.*}}
-// UNIT: DEPEND START
-// UNIT: Record | system | A | {{.*}}/A.swiftmodule/{{.*}}
-// UNIT: DEPEND END
+// FIXME: the units are sorted by their unit name, which for the frameworks in
+// this test end up just being the target triple + a hash of the output file
+// path which changes depending on where this test is run. We should fix this
+// properly, but for now work around it by checking for each unit in a separate
+// pass and do our best to make sure we don't match across unit boundaries.
+//
+// RUN: %FileCheck %s --input-file %t/units --check-prefix=MAIN
+// MAIN:      module-name: cross_import_overlay
+// MAIN:      out-file: {{.*}}/file1.o
+// MAIN-NEXT: target: {{.*}}
+// MAIN-NEXT: is-debug: 1
+// MAIN-NEXT: DEPEND START
+// MAIN-NEXT: Unit | system | Swift | {{.*}}/Swift.swiftmodule
+// MAIN-NEXT: Unit | system | B | {{.*}}/B.swiftmodule/{{.*}}
+// MAIN-NEXT: Unit | system | C | {{.*}}/C.swiftmodule/{{.*}}
+// MAIN-NEXT: Unit | system | A | {{.*}}/__ABAdditionsCAdditions.swiftmodule/{{.*}}
+// MAIN-NEXT: Record | user | {{.*}}/cross-import-overlay.swift
+// MAIN-NEXT: DEPEND END
+//
+// RUN: %FileCheck %s --input-file %t/units --check-prefix=AB_OVERLAY
+// AB_OVERLAY:      module-name: A
+// AB_OVERLAY:      out-file:{{.*}}/_ABAdditions.swiftmodule/{{.*}}
+// AB_OVERLAY-NEXT: target: {{.*}}
+// AB_OVERLAY-NEXT: is-debug: 1
+// AB_OVERLAY-NEXT: DEPEND START
+// AB_OVERLAY-NEXT: Unit | system | A | {{.*}}/A.swiftmodule/{{.*}}
+// AB_OVERLAY-NEXT: Unit | system | B | {{.*}}/B.swiftmodule/{{.*}}
+// AB_OVERLAY-NEXT: Unit | system | Swift | {{.*}}/Swift.swiftmodule
+// AB_OVERLAY-NEXT: Record | system | A | {{.*}}/_ABAdditions.swiftmodule/{{.*}}
+// AB_OVERLAY-NEXT: DEPEND END
+//
+// RUN: %FileCheck %s --input-file %t/units --check-prefix=ABC_OVERLAY
+// ABC_OVERLAY:      module-name: A
+// ABC_OVERLAY:      out-file: {{.*}}/__ABAdditionsCAdditions.swiftmodule/{{.*}}
+// ABC_OVERLAY-NEXT: target: {{.*}}
+// ABC_OVERLAY-NEXT: is-debug: 1
+// ABC_OVERLAY-NEXT: DEPEND START
+// ABC_OVERLAY-NEXT: Unit | system | C | {{.*}}/C.swiftmodule/{{.*}}
+// ABC_OVERLAY-NEXT: Unit | system | Swift | {{.*}}/Swift.swiftmodule
+// ABC_OVERLAY-NEXT: Unit | system | A | {{.*}}/_ABAdditions.swiftmodule/{{.*}}
+// ABC_OVERLAY-NEXT: Record | system | A | {{.*}}/__ABAdditionsCAdditions.swiftmodule/{{.*}}
+// ABC_OVERLAY-NEXT: DEPEND END
+//
+// RUN: %FileCheck %s --input-file %t/units --check-prefix=C_MODULE
+// C_MODULE:      module-name: C
+// C_MODULE:      out-file: {{.*}}/C.swiftmodule/{{.*}}
+// C_MODULE-NEXT: target: {{.*}}
+// C_MODULE-NEXT: is-debug: 1
+// C_MODULE-NEXT: DEPEND START
+// C_MODULE-NEXT: Unit | system | Swift | {{.*}}/Swift.swiftmodule
+// C_MODULE-NEXT: Record | system | C | {{.*}}/C.swiftmodule/{{.*}}
+// C_MODULE-NEXT: DEPEND END
+//
+// RUN: %FileCheck %s --input-file %t/units --check-prefix=B_MODULE
+// B_MODULE:      module-name: B
+// B_MODULE:      out-file: {{.*}}/B.swiftmodule/{{.*}}
+// B_MODULE-NEXT: target: {{.*}}
+// B_MODULE-NEXT: is-debug: 1
+// B_MODULE-NEXT: DEPEND START
+// B_MODULE-NEXT: Unit | system | Swift | {{.*}}/Swift.swiftmodule
+// B_MODULE-NEXT: Record | system | B | {{.*}}/B.swiftmodule/{{.*}}
+// B_MODULE-NEXT: DEPEND END
+//
+// RUN: %FileCheck %s --input-file %t/units --check-prefix=A_MODULE
+// A_MODULE:      module-name: A
+// A_MODULE: out-file: {{.*}}/A.swiftmodule/{{.*}}
+// A_MODULE-NEXT: target: {{.*}}
+// A_MODULE-NEXT: is-debug: 1
+// A_MODULE-NEXT: DEPEND START
+// A_MODULE-NEXT: Unit | system | Swift | {{.*}}/Swift.swiftmodule
+// A_MODULE-NEXT: Record | system | A | {{.*}}/A.swiftmodule/{{.*}}
+// A_MODULE-NEXT: DEPEND END
 
-// Make sure we aren't leaking the underscored overlay names anywhere
-//
-// UNIT-NEGATIVE-NOT: Unit | {{.*}} | _ABAdditions |
-// UNIT-NEGATIVE-NOT: Record | {{.*}} | _ABAdditions |
-// UNIT-NEGATIVE-NOT: Unit | {{.*}} | __ABAdditionsCAdditions |
-// UNIT-NEGATIVE-NOT: Record | {{.*}} | __ABAdditionsCAdditions |
 
-// Make sure we don't regress test performance by indexing the stdlib.
+// Make sure there are three units with module-name 'A' (A, _ABAdditions and
+// __ABAdditionsCAdditions) in case we matched across unit boundaries above
+// due to the nondeterministic ordering.
 //
-// UNIT-NEGATIVE-NOT: Record | system | Swift |
+// RUN: %FileCheck %s --input-file %t/units --check-prefix=UNITS
+// UNITS-COUNT-3: module-name: A
+
+// Make sure we aren't leaking the underscored overlay names anywhere and don't
+// regress test performance by indexing the stdlib.
+//
+// RUN: %FileCheck %s --input-file %t/units --check-prefix=UNITS-NEGATIVE
+// UNITS-NEGATIVE-NOT: Unit | {{.*}} | _ABAdditions
+// UNITS-NEGATIVE-NOT: Record | {{.*}} | _ABAdditions
+// UNITS-NEGATIVE-NOT: Unit | {{.*}} | __ABAdditionsCAdditions
+// UNITS-NEGATIVE-NOT: Record | {{.*}} | __ABAdditionsCAdditions
+// UNITS-NEGATIVE-NOT: Record | system | Swift
 

--- a/test/Index/Store/cross-import-overlay.swift
+++ b/test/Index/Store/cross-import-overlay.swift
@@ -1,0 +1,64 @@
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/../Inputs/CrossImport %t/CrossImport
+// RUN: %{python} %S/../../CrossImport/Inputs/rewrite-module-triples.py %t/CrossImport %module-target-triple
+
+// RUN: %target-swift-frontend -c -index-store-path %t/idx -index-system-modules -enable-cross-import-overlays %s -Fsystem %t/CrossImport -o %t/file1.o -module-name cross_import_overlay
+// RUN: c-index-test core -print-unit %t/idx > %t/units
+// RUN: %FileCheck %s --input-file %t/units --check-prefix=UNIT
+// RUN: %FileCheck %s --input-file %t/units --check-prefix=UNIT-NEGATIVE
+
+import A
+import B
+import C
+
+fromA()
+fromB()
+from_ABAdditions()
+from__ABAdditionsCAdditions()
+
+// UNIT: module-name: cross_import_overlay
+// UNIT: main-path: {{.*}}/cross-import-overlay.swift
+// UNIT: DEPEND START
+// UNIT: Unit | system | B | {{.*}}/B.swiftmodule/{{.*}}
+// UNIT: Unit | system | C | {{.*}}/C.swiftmodule/{{.*}}
+// UNIT: Unit | system | A | {{.*}}/__ABAdditionsCAdditions.swiftmodule/{{.*}}
+// UNIT: Record | user | {{.*}}/cross-import-overlay.swift | cross-import-overlay.swift-{{.*}}
+// UNIT: DEPEND END
+// UNIT: --------
+// UNIT: module-name: A
+// UNIT: out-file: {{.*}}/_ABAdditions.swiftmodule/{{.*}}
+// UNIT: DEPEND START
+// UNIT: Unit | system | A | {{.*}}/A.swiftmodule/{{.*}}
+// UNIT: Unit | system | B | {{.*}}/B.swiftmodule/{{.*}}
+// UNIT: Record | system | A | {{.*}}/_ABAdditions.swiftmodule/{{.*}}
+// UNIT: DEPEND END
+// UNIT: --------
+// UNIT: module-name: A
+// UNIT: out-file: {{.*}}/__ABAdditionsCAdditions.swiftmodule/{{.*}}
+// UNIT: DEPEND START
+// UNIT: Unit | system | C | {{.*}}/C.swiftmodule/{{.*}}
+// UNIT: Unit | system | A | {{.*}}/_ABAdditions.swiftmodule/{{.*}}
+// UNIT: Record | system | A | {{.*}}/__ABAdditionsCAdditions.swiftmodule/{{.*}}
+// UNIT: DEPEND END
+// UNIT: --------
+// UNIT: module-name: C
+// UNIT: out-file: {{.*}}/C.swiftmodule/{{.*}}
+// UNIT: DEPEND START
+// UNIT: Record | system | C | {{.*}}/C.swiftmodule/{{.*}}
+// UNIT: DEPEND END
+// UNIT: --------
+// UNIT: module-name: B
+// UNIT: out-file: {{.*}}/B.swiftmodule/{{.*}}
+// UNIT: DEPEND START
+// UNIT: Record | system | B | {{.*}}/B.swiftmodule/{{.*}}
+// UNIT: DEPEND END
+// UNIT: --------
+// UNIT: module-name: A
+// UNIT: out-file: {{.*}}/A.swiftmodule/{{.*}}
+// UNIT: DEPEND START
+// UNIT: Record | system | A | {{.*}}/A.swiftmodule/{{.*}}
+// UNIT: DEPEND END
+
+// UNIT-NEGATIVE-NOT: Unit | {{.*}} | _ABAdditions |
+// UNIT-NEGATIVE-NOT: Unit | {{.*}} | __ABAdditionsCAdditions |
+

--- a/test/Index/Store/driver-index-with-auxiliary-outputs.swift
+++ b/test/Index/Store/driver-index-with-auxiliary-outputs.swift
@@ -4,7 +4,7 @@
 // make sure the frontend job doesn't try to emit the auxiliary outputs based
 // on the non-indexed files. (This is how Xcode currently constructs -index-file
 // invocations: take a normal build command and add extra arguments to it.)
-// RUN: %target-build-swift -index-file -index-file-path %S/Inputs/SwiftModuleA.swift %S/Inputs/SwiftModuleA.swift %s -index-store-path %t/idx -module-name driver_index -emit-objc-header-path %t/out.h -emit-module-interface-path %t/out.swiftinterface
+// RUN: %target-build-swift -index-file -index-file-path %S/Inputs/SwiftModuleA.swift %S/Inputs/SwiftModuleA.swift %s -index-store-path %t/idx -Xfrontend -index-ignore-stdlib -module-name driver_index -emit-objc-header-path %t/out.h -emit-module-interface-path %t/out.swiftinterface
 
 // RUN: test ! -f %t/out.h
 // RUN: test ! -f %t/out.swiftinterface

--- a/test/Index/index_cross_import.swift
+++ b/test/Index/index_cross_import.swift
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/CrossImport %t/CrossImport
+// RUN: %{python} %S/../CrossImport/Inputs/rewrite-module-triples.py %t/CrossImport %module-target-triple
+
+// RUN: %target-swift-ide-test -print-indexed-symbols -enable-cross-import-overlays -source-filename %s -F %t/CrossImport > %t/out
+// RUN: %FileCheck %s --check-prefix=CHECK-NEGATIVE -input-file=%t/out
+//
+// CHECK-NEGATIVE-NOT: module | user | _ABAdditions
+
+// RUN: %FileCheck %s -input-file=%t/out
+//
+// CHECK: index_cross_import.swift
+// CHECK: ------------
+// CHECK-DAG: module | user | A | {{.*}}/A.swiftmodule/{{.*}}
+// CHECK-DAG: module | user | A | {{.*}}/_ABAdditions.swiftmodule/{{.*}}
+// CHECK-DAG: module | user | A | {{.*}}/__ABAdditionsCAdditions.swiftmodule/{{.*}}
+// CHECK-DAG: module | user | B | {{.*}}/B.swiftmodule/{{.*}}
+// CHECK-DAG: module | user | C | {{.*}}/C.swiftmodule/{{.*}}
+// CHECK: ------------
+
+import A
+// CHECK: [[@LINE-1]]:8 | module/Swift | A | {{.*}} | Ref | rel: 0
+import B
+// CHECK: [[@LINE-1]]:8 | module/Swift | B | {{.*}} | Ref | rel: 0
+import C
+// CHECK: [[@LINE-1]]:8 | module/Swift | C | {{.*}} | Ref | rel: 0
+
+from_ABAdditions()
+// CHECK: [[@LINE-1]]:1 | function/Swift | from_ABAdditions() | {{.*}} | Ref,Call | rel: 0
+from__ABAdditionsCAdditions()
+// CHECK: [[@LINE-1]]:1 | function/Swift | from__ABAdditionsCAdditions() | {{.*}} | Ref,Call | rel: 0

--- a/test/Index/index_swift_only_systemmodule.swift
+++ b/test/Index/index_swift_only_systemmodule.swift
@@ -34,6 +34,7 @@ print(someFunc())
 // RUN: %target-swift-frontend \
 // RUN:     -typecheck \
 // RUN:     -index-system-modules \
+// RUN:     -index-ignore-stdlib \
 // RUN:     -index-store-path %t/idx \
 // RUN:     -sdk %t/SDK \
 // RUN:     -Fsystem %t/SDK/Frameworks \
@@ -66,6 +67,7 @@ print(someFunc())
 // RUN: %target-swift-frontend \
 // RUN:     -typecheck \
 // RUN:     -index-system-modules \
+// RUN:     -index-ignore-stdlib \
 // RUN:     -index-store-path %t/idx \
 // RUN:     -sdk %t/SDK \
 // RUN:     -Fsystem %t/SDK/Frameworks \
@@ -95,6 +97,7 @@ print(someFunc())
 // RUN: %target-swift-frontend \
 // RUN:     -typecheck \
 // RUN:     -index-system-modules \
+// RUN:     -index-ignore-stdlib \
 // RUN:     -index-store-path %t/idx \
 // RUN:     -sdk %t/SDK \
 // RUN:     -Fsystem %t/SDK/Frameworks \
@@ -123,6 +126,7 @@ print(someFunc())
 // RUN: %target-swift-frontend \
 // RUN:     -typecheck \
 // RUN:     -index-system-modules \
+// RUN:     -index-ignore-stdlib \
 // RUN:     -index-store-path %t/idx \
 // RUN:     -sdk %t/SDK \
 // RUN:     -Fsystem %t/SDK/Frameworks \

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -912,12 +912,9 @@ static bool passCursorInfoForDecl(SourceFile* SF,
     if (SF) {
       // In a source file we map the imported overlays to the underlying
       // modules they shadow.
-      while (MD->getNameStr().startswith("_")) {
-        auto *Underlying = SF->getModuleShadowedBySeparatelyImportedOverlay(MD);
-        if (!Underlying)
-          break;
+      auto *Underlying = SF->getModuleShadowedBySeparatelyImportedOverlay(MD);
+      if (Underlying)
         MD = Underlying;
-      }
     } else if (MainModule) {
       // In a module interface we need to map the declared overlays of the main
       // module (which are included in its generated interface) back to the main


### PR DESCRIPTION
Also add a frontend option to skip indexing the stdlib so index tests that pass `-index-system-modules` and aren't interested in the stdlib don't spend a bunch of time indexing it.

Resolves rdar://problem/59445445