### PR TITLE
[AutoDiff upstream] [SIL] Add the 'linear_function' and 'linear_function_extract' instructions

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5811,6 +5811,37 @@ In raw SIL, the ``with_derivative`` clause is optional. In canonical SIL, the
 ``with_derivative`` clause is mandatory.
 
 
+linear_function
+```````````````
+::
+
+  sil-instruction ::= 'linear_function'
+                      sil-linear-function-parameter-indices
+                      sil-value ':' sil-type
+                      sil-linear-function-transpose-function-clause?
+
+  sil-linear-function-parameter-indices ::=
+      '[' 'parameters' [0-9]+ (' ' [0-9]+)* ']'
+  sil-linear-transpose-function-clause ::=
+      with_transpose sil-value ':' sil-type
+
+  linear_function [parameters 0] %0 : $(T) -> T with_transpose %1 : $(T) -> T
+
+Bundles a function with its transpose function into a
+``@differentiable(linear)`` function.
+
+``[parameters ...]`` specifies parameter indices that the original function is
+linear with respect to.
+
+A ``with_transpose`` clause specifies the transpose function associated
+with the original function. When a ``with_transpose`` clause is not specified,
+the mandatory differentiation transform  will add a ``with_transpose`` clause to
+the instruction.
+
+In raw SIL, the ``with_transpose`` clause is optional. In canonical SIL,
+the ``with_transpose`` clause is mandatory.
+
+
 differentiable_function_extract
 ```````````````````````````````
 ::
@@ -5834,6 +5865,25 @@ Extracts the original function or a derivative function from the given
 
 In lowered SIL, an explicit extractee type may be provided. This is currently
 used by the LoadableByAddress transformation, which rewrites function types.
+
+
+linear_function_extract
+```````````````````````
+::
+
+  sil-instruction ::= 'linear_function_extract'
+                      '[' sil-linear-function-extractee ']'
+                      sil-value ':' sil-type
+
+  sil-linear-function-extractee ::= 'original' | 'transpose'
+
+  linear_function_extract [original] %0 : $@differentiable(linear) (T) -> T
+  linear_function_extract [transpose] %0 : $@differentiable(linear) (T) -> T
+
+Extracts the original function or a transpose function from the given
+``@differentiable(linear)`` function. The extractee is one of the following:
+``[original]`` or ``[transpose]``.
+
 
 differentiability_witness_function
 ``````````````````````````````````

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1627,6 +1627,9 @@ ERROR(sil_inst_autodiff_operand_list_expected_rbrace,PointsToFirstBadToken,
 ERROR(sil_inst_autodiff_expected_differentiable_extractee_kind,PointsToFirstBadToken,
       "expected an extractee kind attribute, which can be one of '[original]', "
       "'[jvp]', and '[vjp]'", ())
+ERROR(sil_inst_autodiff_expected_linear_extractee_kind,PointsToFirstBadToken,
+      "expected an extractee kind attribute, which can be one of '[original]' "
+      "and '[transpose]'", ())
 ERROR(sil_inst_autodiff_expected_function_type_operand,PointsToFirstBadToken,
       "expected an operand of a function type", ())
 ERROR(sil_inst_autodiff_expected_differentiability_witness_kind,PointsToFirstBadToken,

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2172,6 +2172,14 @@ public:
         OriginalFunction, JVPAndVJPFunctions, hasOwnership()));
   }
 
+  LinearFunctionInst *createLinearFunction(
+      SILLocation Loc, IndexSubset *ParameterIndices, SILValue OriginalFunction,
+      Optional<SILValue> TransposeFunction = None) {
+    return insert(LinearFunctionInst::create(
+        getModule(), getSILDebugLocation(Loc), ParameterIndices,
+        OriginalFunction, TransposeFunction, hasOwnership()));
+  }
+
   /// Note: explicit extractee type may be specified only in lowered SIL.
   DifferentiableFunctionExtractInst *createDifferentiableFunctionExtract(
       SILLocation Loc, NormalDifferentiableFunctionTypeComponent Extractee,
@@ -2179,6 +2187,13 @@ public:
     return insert(new (getModule()) DifferentiableFunctionExtractInst(
         getModule(), getSILDebugLocation(Loc), Extractee, Function,
         ExtracteeType));
+  }
+
+  LinearFunctionExtractInst *createLinearFunctionExtract(
+      SILLocation Loc, LinearDifferentiableFunctionTypeComponent Extractee,
+      SILValue TheFunction) {
+    return insert(new (getModule()) LinearFunctionExtractInst(
+        getModule(), getSILDebugLocation(Loc), Extractee, TheFunction));
   }
 
   /// Note: explicit function type may be specified only in lowered SIL.

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -2841,6 +2841,18 @@ void SILCloner<ImplClass>::visitDifferentiableFunctionInst(
                 getOpValue(Inst->getOriginalFunction()), derivativeFns));
 }
 
+template<typename ImplClass>
+void SILCloner<ImplClass>::visitLinearFunctionInst(LinearFunctionInst *Inst) {
+  getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
+  auto transpose = Inst->getOptionalTransposeFunction();
+  if (transpose)
+    transpose = getOpValue(*transpose);
+  recordClonedInstruction(
+      Inst, getBuilder().createLinearFunction(
+                getOpLocation(Inst->getLoc()), Inst->getParameterIndices(),
+                getOpValue(Inst->getOriginalFunction()), transpose));
+}
+
 template <typename ImplClass>
 void SILCloner<ImplClass>::visitDifferentiableFunctionExtractInst(
     DifferentiableFunctionExtractInst *Inst) {
@@ -2852,6 +2864,16 @@ void SILCloner<ImplClass>::visitDifferentiableFunctionExtractInst(
       Inst, getBuilder().createDifferentiableFunctionExtract(
                 getOpLocation(Inst->getLoc()), Inst->getExtractee(),
                 getOpValue(Inst->getOperand()), explicitExtracteeType));
+}
+
+template<typename ImplClass>
+void SILCloner<ImplClass>::
+visitLinearFunctionExtractInst(LinearFunctionExtractInst *Inst) {
+  getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
+  recordClonedInstruction(
+      Inst, getBuilder().createLinearFunctionExtract(
+                getOpLocation(Inst->getLoc()), Inst->getExtractee(),
+                getOpValue(Inst->getFunctionOperand())));
 }
 
 template <typename ImplClass>

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -694,8 +694,13 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
   // Differentiable programming
   SINGLE_VALUE_INST(DifferentiableFunctionInst, differentiable_function,
                     SingleValueInstruction, None, DoesNotRelease)
+  SINGLE_VALUE_INST(LinearFunctionInst, linear_function,
+                    SingleValueInstruction, None, DoesNotRelease)
   SINGLE_VALUE_INST(DifferentiableFunctionExtractInst,
                     differentiable_function_extract,
+                    SingleValueInstruction, None, DoesNotRelease)
+  SINGLE_VALUE_INST(LinearFunctionExtractInst,
+                    linear_function_extract,
                     SingleValueInstruction, None, DoesNotRelease)
   SINGLE_VALUE_INST(DifferentiabilityWitnessFunctionInst,
                     differentiability_witness_function,

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -5072,6 +5072,41 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
           InstLoc, parameterIndicesSubset, original, derivativeFunctions);
       break;
     }
+    case SILInstructionKind::LinearFunctionInst: {
+      // e.g. linear_function [parameters 0 1 2] %0 : $T
+      // e.g. linear_function [parameters 0 1 2] %0 : $T with_transpose %1 : $T
+      // Parse `[parameters <integer_literal>...]`.
+      SmallVector<unsigned, 8> parameterIndices;
+      if (parseIndexList(P, "parameters", parameterIndices,
+                         diag::sil_autodiff_expected_parameter_index))
+        return true;
+      // Parse the original function value.
+      SILValue original;
+      SourceLoc originalOperandLoc;
+      if (parseTypedValueRef(original, originalOperandLoc, B))
+        return true;
+      auto fnType = original->getType().getAs<SILFunctionType>();
+      if (!fnType) {
+        P.diagnose(originalOperandLoc,
+                   diag::sil_inst_autodiff_expected_function_type_operand);
+        return true;
+      }
+      // Parse an optional transpose function.
+      Optional<SILValue> transpose = None;
+      if (P.Tok.is(tok::identifier) && P.Tok.getText() == "with_transpose") {
+        P.consumeToken(tok::identifier);
+        transpose = SILValue();
+        if (parseTypedValueRef(*transpose, B))
+          return true;
+      }
+      if (parseSILDebugLocation(InstLoc, B))
+        return true;
+      auto *parameterIndicesSubset = IndexSubset::get(
+          P.Context, fnType->getNumParameters(), parameterIndices);
+      ResultVal = B.createLinearFunction(
+          InstLoc, parameterIndicesSubset, original, transpose);
+      break;
+    }
     case SILInstructionKind::DifferentiableFunctionExtractInst: {
       // Parse the rest of the instruction: an extractee, a differentiable
       // function operand, an optional explicit extractee type, and a debug
@@ -5102,6 +5137,27 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
         return true;
       ResultVal = B.createDifferentiableFunctionExtract(
           InstLoc, extractee, functionOperand, extracteeType);
+      break;
+    }
+    case SILInstructionKind::LinearFunctionExtractInst: {
+      // Parse the rest of the instruction: an extractee, a linear function
+      // operand, and a debug location.
+      LinearDifferentiableFunctionTypeComponent extractee;
+      StringRef extracteeNames[2] = {"original", "transpose"};
+      SILValue functionOperand;
+      SourceLoc lastLoc;
+      if (P.parseToken(tok::l_square,
+              diag::sil_inst_autodiff_expected_linear_extractee_kind) ||
+          parseSILIdentifierSwitch(extractee, extracteeNames,
+              diag::sil_inst_autodiff_expected_linear_extractee_kind) ||
+          P.parseToken(tok::r_square, diag::sil_autodiff_expected_rsquare,
+                       "extractee kind"))
+        return true;
+      if (parseTypedValueRef(functionOperand, B) ||
+          parseSILDebugLocation(InstLoc, B))
+        return true;
+      ResultVal = B.createLinearFunctionExtract(
+          InstLoc, extractee, functionOperand);
       break;
     }
     case SILInstructionKind::DifferentiabilityWitnessFunctionInst: {

--- a/lib/SIL/OperandOwnership.cpp
+++ b/lib/SIL/OperandOwnership.cpp
@@ -349,6 +349,7 @@ FORWARD_ANY_OWNERSHIP_INST(DestructureStruct)
 FORWARD_ANY_OWNERSHIP_INST(DestructureTuple)
 FORWARD_ANY_OWNERSHIP_INST(InitExistentialRef)
 FORWARD_ANY_OWNERSHIP_INST(DifferentiableFunction)
+FORWARD_ANY_OWNERSHIP_INST(LinearFunction)
 #undef FORWARD_ANY_OWNERSHIP_INST
 
 // An instruction that forwards a constant ownership or trivial ownership.
@@ -369,6 +370,8 @@ FORWARD_CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, MustBeLive, TupleExtract)
 FORWARD_CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, MustBeLive, StructExtract)
 FORWARD_CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, MustBeLive,
                                         DifferentiableFunctionExtract)
+FORWARD_CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, MustBeLive,
+                                        LinearFunctionExtract)
 FORWARD_CONSTANT_OR_NONE_OWNERSHIP_INST(Owned, MustBeInvalidated,
                                         MarkUninitialized)
 #undef CONSTANT_OR_NONE_OWNERSHIP_INST

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -656,6 +656,45 @@ DifferentiableFunctionInst *DifferentiableFunctionInst::create(
                                  derivativeFunctions, HasOwnership);
 }
 
+SILType LinearFunctionInst::getLinearFunctionType(
+    SILValue OriginalFunction, IndexSubset *ParameterIndices) {
+  auto fnTy = OriginalFunction->getType().castTo<SILFunctionType>();
+  auto diffTy = fnTy->getWithDifferentiability(
+      DifferentiabilityKind::Linear, ParameterIndices);
+  return SILType::getPrimitiveObjectType(diffTy);
+}
+
+LinearFunctionInst::LinearFunctionInst(
+    SILDebugLocation Loc, IndexSubset *ParameterIndices,
+    SILValue OriginalFunction, Optional<SILValue> TransposeFunction,
+    bool HasOwnership)
+    : InstructionBaseWithTrailingOperands(
+          OriginalFunction,
+          TransposeFunction.hasValue()
+              ? ArrayRef<SILValue>(TransposeFunction.getPointer(), 1)
+              : ArrayRef<SILValue>(),
+          Loc, getLinearFunctionType(OriginalFunction, ParameterIndices),
+          HasOwnership ? (
+            TransposeFunction
+                ? *mergeSILValueOwnership(
+                       {OriginalFunction, *TransposeFunction})
+                : *mergeSILValueOwnership({OriginalFunction})
+          ) : ValueOwnershipKind(ValueOwnershipKind::None)),
+      ParameterIndices(ParameterIndices),
+      HasTransposeFunction(TransposeFunction.hasValue()) {
+}
+
+LinearFunctionInst *LinearFunctionInst::create(
+    SILModule &Module, SILDebugLocation Loc, IndexSubset *ParameterIndices,
+    SILValue OriginalFunction, Optional<SILValue> TransposeFunction,
+    bool HasOwnership) {
+  size_t size = totalSizeToAlloc<Operand>(TransposeFunction.hasValue() ? 2 : 1);
+  void *buffer = Module.allocateInst(size, alignof(DifferentiableFunctionInst));
+  return ::new (buffer) LinearFunctionInst(
+      Loc, ParameterIndices, OriginalFunction, TransposeFunction,
+      HasOwnership);
+}
+
 SILType DifferentiableFunctionExtractInst::getExtracteeType(
     SILValue function, NormalDifferentiableFunctionTypeComponent extractee,
     SILModule &module) {
@@ -695,6 +734,31 @@ DifferentiableFunctionExtractInst::DifferentiableFunctionExtractInst(
   }
 #endif
 }
+
+SILType LinearFunctionExtractInst::
+getExtracteeType(
+    SILValue function, LinearDifferentiableFunctionTypeComponent extractee,
+    SILModule &module) {
+  auto fnTy = function->getType().castTo<SILFunctionType>();
+  assert(fnTy->getDifferentiabilityKind() == DifferentiabilityKind::Linear);
+  auto originalFnTy = fnTy->getWithoutDifferentiability();
+  switch (extractee) {
+  case LinearDifferentiableFunctionTypeComponent::Original:
+    return SILType::getPrimitiveObjectType(originalFnTy);
+  case LinearDifferentiableFunctionTypeComponent::Transpose:
+    auto transposeFnTy = originalFnTy->getAutoDiffTransposeFunctionType(
+        fnTy->getDifferentiabilityParameterIndices(), module.Types,
+        LookUpConformanceInModule(module.getSwiftModule()));
+    return SILType::getPrimitiveObjectType(transposeFnTy);
+  }
+}
+
+LinearFunctionExtractInst::LinearFunctionExtractInst(
+    SILModule &module, SILDebugLocation debugLoc,
+    LinearDifferentiableFunctionTypeComponent extractee, SILValue theFunction)
+    : InstructionBase(debugLoc,
+                      getExtracteeType(theFunction, extractee, module)),
+      extractee(extractee), operands(this, theFunction) {}
 
 SILType DifferentiabilityWitnessFunctionInst::getDifferentiabilityWitnessType(
     SILModule &module, DifferentiabilityWitnessFunctionKind witnessKind,

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2282,6 +2282,18 @@ public:
     }
   }
 
+  void visitLinearFunctionInst(LinearFunctionInst *lfi) {
+    *this << "[parameters";
+    for (auto i : lfi->getParameterIndices()->getIndices())
+      *this << ' ' << i;
+    *this << "] ";
+    *this << getIDAndType(lfi->getOriginalFunction());
+    if (lfi->hasTransposeFunction()) {
+      *this << " with_transpose ";
+      *this << getIDAndType(lfi->getTransposeFunction());
+    }
+  }
+
   void visitDifferentiableFunctionExtractInst(
       DifferentiableFunctionExtractInst *dfei) {
     *this << '[';
@@ -2302,6 +2314,20 @@ public:
       *this << " as ";
       *this << dfei->getType();
     }
+  }
+
+  void visitLinearFunctionExtractInst(LinearFunctionExtractInst *lfei) {
+    *this << '[';
+    switch (lfei->getExtractee()) {
+    case LinearDifferentiableFunctionTypeComponent::Original:
+      *this << "original";
+      break;
+    case LinearDifferentiableFunctionTypeComponent::Transpose:
+      *this << "transpose";
+      break;
+    }
+    *this << "] ";
+    *this << getIDAndType(lfei->getFunctionOperand());
   }
 
   void visitDifferentiabilityWitnessFunctionInst(

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -4640,12 +4640,51 @@ public:
 #endif
   }
 
+  void checkLinearFunctionInst(LinearFunctionInst *lfi) {
+    auto origTy =
+        lfi->getOriginalFunction()->getType().getAs<SILFunctionType>();
+    require(origTy, "The original function must have a function type");
+    require(!origTy->isDifferentiable(),
+            "The original function must not be differentiable");
+    // Skip lowered SIL: LoadableByAddress changes parameter/result conventions.
+    // TODO: Check that transpose function type matches excluding
+    // parameter/result conventions in lowered SIL.
+    if (F.getModule().getStage() == SILStage::Lowered)
+      return;
+    if (lfi->hasTransposeFunction()) {
+      auto transpose = lfi->getTransposeFunction();
+      auto transposeType = transpose->getType().getAs<SILFunctionType>();
+      require(transposeType,
+              "The transpose function must have a function type");
+      require(!transposeType->isDifferentiable(),
+              "The transpose function must not be differentiable");
+      auto expectedTransposeType = origTy->getAutoDiffTransposeFunctionType(
+          lfi->getParameterIndices(), TC, LookUpConformanceInModule(M));
+      // TODO: Consider tightening verification. This requires changes to
+      // `SILFunctionType::getAutoDiffTransposeFunctionType`.
+      requireSameType(
+          SILType::getPrimitiveObjectType(
+              transposeType->getUnsubstitutedType(F.getModule())),
+          SILType::getPrimitiveObjectType(
+              expectedTransposeType->getUnsubstitutedType(F.getModule())),
+          "Transpose type does not match expected transpose type");
+    }
+  }
+
   void checkDifferentiableFunctionExtractInst(
       DifferentiableFunctionExtractInst *dfei) {
     auto fnTy = dfei->getOperand()->getType().getAs<SILFunctionType>();
     require(fnTy, "The function operand must have a function type");
     require(fnTy->getDifferentiabilityKind() == DifferentiabilityKind::Normal,
             "The function operand must be a '@differentiable' function");
+  }
+
+  void checkLinearFunctionExtractInst(LinearFunctionExtractInst *lfei) {
+    auto fnTy = lfei->getFunctionOperand()->getType().getAs<SILFunctionType>();
+    require(fnTy, "The function operand must have a function type");
+    require(fnTy->getDifferentiabilityKind() == DifferentiabilityKind::Linear,
+            "The function operand must be a '@differentiable(linear)' "
+            "function");
   }
 
   void checkDifferentiabilityWitnessFunctionInst(

--- a/lib/SIL/ValueOwnership.cpp
+++ b/lib/SIL/ValueOwnership.cpp
@@ -160,6 +160,7 @@ CONSTANT_OWNERSHIP_INST(Unowned, ValueToBridgeObject)
 CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, StructExtract)
 CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, TupleExtract)
 CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, DifferentiableFunctionExtract)
+CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, LinearFunctionExtract)
 // OpenExistentialValue opens the boxed value inside an existential
 // CoW box. The semantics of an existential CoW box implies that we
 // can only consume the projected value inside the box if the box is
@@ -265,6 +266,7 @@ FORWARDING_OWNERSHIP_INST(Enum)
 // traffic in code.
 FORWARDING_OWNERSHIP_INST(InitExistentialRef)
 FORWARDING_OWNERSHIP_INST(DifferentiableFunction)
+FORWARDING_OWNERSHIP_INST(LinearFunction)
 #undef FORWARDING_OWNERSHIP_INST
 
 ValueOwnershipKind

--- a/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
@@ -329,6 +329,8 @@ static bool hasOpaqueArchetype(TypeExpansionContext context,
   case SILInstructionKind::DestructureTupleInst:
   case SILInstructionKind::DifferentiableFunctionInst:
   case SILInstructionKind::DifferentiableFunctionExtractInst:
+  case SILInstructionKind::LinearFunctionInst:
+  case SILInstructionKind::LinearFunctionExtractInst:
   case SILInstructionKind::DifferentiabilityWitnessFunctionInst:
     // Handle by operand and result check.
     break;

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -876,7 +876,9 @@ InlineCost swift::instructionInlineCost(SILInstruction &I) {
   case SILInstructionKind::KeyPathInst:
   case SILInstructionKind::GlobalValueInst:
   case SILInstructionKind::DifferentiableFunctionInst:
+  case SILInstructionKind::LinearFunctionInst:
   case SILInstructionKind::DifferentiableFunctionExtractInst:
+  case SILInstructionKind::LinearFunctionExtractInst:
   case SILInstructionKind::DifferentiabilityWitnessFunctionInst:
 #define COMMON_ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name)          \
   case SILInstructionKind::Name##ToRefInst:                                    \

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1153,11 +1153,22 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
         ListOfValues);
     RawOpCode = (unsigned)SILInstructionKind::DifferentiableFunctionInst;
     break;
+  case SIL_INST_LINEAR_FUNCTION:
+    SILInstLinearFunctionLayout::readRecord(
+        scratch, /*numParams*/ Attr, /*hasTransposeFunction*/ Attr2,
+        ListOfValues);
+    RawOpCode = (unsigned)SILInstructionKind::LinearFunctionInst;
+    break;
   case SIL_INST_DIFFERENTIABLE_FUNCTION_EXTRACT:
     SILInstDifferentiableFunctionExtractLayout::readRecord(
         scratch, TyID, TyCategory, ValID, /*extractee*/ Attr,
         /*hasExplicitExtracteeType*/ Attr2);
     RawOpCode = (unsigned)SILInstructionKind::DifferentiableFunctionExtractInst;
+    break;
+  case SIL_INST_LINEAR_FUNCTION_EXTRACT:
+    SILInstLinearFunctionExtractLayout::readRecord(
+        scratch, TyID, TyCategory, ValID, /*extractee*/ Attr);
+    RawOpCode = (unsigned)SILInstructionKind::LinearFunctionExtractInst;
     break;
   }
 
@@ -2607,6 +2618,31 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
         Loc, paramIndices, operands[0], derivativeFunctions);
     break;
   }
+  case SILInstructionKind::LinearFunctionInst: {
+    bool hasLinearFunction = (bool)Attr2;
+    unsigned numOperands = hasLinearFunction ? 2 : 1;
+    auto numParamIndices = ListOfValues.size() - numOperands * 3;
+    assert(ListOfValues.size() == numParamIndices + numOperands * 3);
+    auto rawParamIndices =
+       map<SmallVector<unsigned, 8>>(ListOfValues.take_front(numParamIndices),
+                                     [](uint64_t i) { return (unsigned)i; });
+    auto numParams = Attr;
+    auto *paramIndices =
+        IndexSubset::get(MF->getContext(), numParams, rawParamIndices);
+    SmallVector<SILValue, 3> operands;
+    for (auto i = numParamIndices;
+         i < numParamIndices + numOperands * 3; i += 3) {
+      auto astTy = MF->getType(ListOfValues[i]);
+      auto silTy = getSILType(astTy, (SILValueCategory)ListOfValues[i+1], Fn);
+      operands.push_back(getLocalValue(ListOfValues[i+2], silTy));
+    }
+    Optional<SILValue> transposeFunction = None;
+    if (hasLinearFunction)
+      transposeFunction = operands[1];
+    ResultVal = Builder.createLinearFunction(
+        Loc, paramIndices, operands[0], transposeFunction);
+    break;
+  }
   case SILInstructionKind::DifferentiableFunctionExtractInst: {
     auto astTy = MF->getType(TyID);
     auto silTy = getSILType(astTy, SILValueCategory::Object, Fn);
@@ -2617,6 +2653,14 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
       explicitExtracteeType = silTy;
     ResultVal = Builder.createDifferentiableFunctionExtract(
         Loc, extractee, val, explicitExtracteeType);
+    break;
+  }
+  case SILInstructionKind::LinearFunctionExtractInst: {
+    auto astTy = MF->getType(TyID);
+    auto silTy = getSILType(astTy, SILValueCategory::Object, Fn);
+    auto val = getLocalValue(ValID, silTy);
+    LinearDifferentiableFunctionTypeComponent extractee(Attr);
+    ResultVal = Builder.createLinearFunctionExtract(Loc, extractee, val);
     break;
   }
   case SILInstructionKind::DifferentiabilityWitnessFunctionInst: {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 549; // differentiable_function, differentiable_function_extract
+const uint16_t SWIFTMODULE_VERSION_MINOR = 550; // linear_function, linear_function_extract
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -150,7 +150,9 @@ namespace sil_block {
     SIL_ONE_OPERAND_EXTRA_ATTR,
     SIL_TWO_OPERANDS_EXTRA_ATTR,
     SIL_INST_DIFFERENTIABLE_FUNCTION,
+    SIL_INST_LINEAR_FUNCTION,
     SIL_INST_DIFFERENTIABLE_FUNCTION_EXTRACT,
+    SIL_INST_LINEAR_FUNCTION_EXTRACT,
 
     // We also share these layouts from the decls block. Their enumerators must
     // not overlap with ours.
@@ -457,6 +459,13 @@ namespace sil_block {
     BCArray<ValueIDField> // parameter indices and operands
   >;
 
+  using SILInstLinearFunctionLayout = BCRecordLayout<
+    SIL_INST_LINEAR_FUNCTION,
+    BCVBR<8>,             // number of function parameters
+    BCFixed<1>,           // has transpose function?
+    BCArray<ValueIDField> // parameter indices and operands
+  >;
+
   using SILInstDifferentiableFunctionExtractLayout = BCRecordLayout<
     SIL_INST_DIFFERENTIABLE_FUNCTION_EXTRACT,
     TypeIDField,
@@ -464,6 +473,14 @@ namespace sil_block {
     ValueIDField,
     BCFixed<2>, // extractee
     BCFixed<1>  // has explicit extractee type?
+  >;
+
+  using SILInstLinearFunctionExtractLayout = BCRecordLayout<
+    SIL_INST_LINEAR_FUNCTION_EXTRACT,
+    TypeIDField,
+    SILTypeCategoryField,
+    ValueIDField,
+    BCFixed<1> // extractee
   >;
 }
 

--- a/test/AutoDiff/SIL/linear_function_inst.sil
+++ b/test/AutoDiff/SIL/linear_function_inst.sil
@@ -1,0 +1,59 @@
+// Round-trip parsing/printing test.
+
+// RUN: %target-sil-opt -enable-experimental-differentiable-programming %s -emit-sorted-sil | %FileCheck %s --check-prefix=CHECK-SIL
+
+// Round-trip serialization-deserialization test.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-sil-opt -enable-experimental-differentiable-programming %s -emit-sib -o %t/tmp.sib -module-name main
+// RUN: %target-sil-opt -enable-experimental-differentiable-programming %t/tmp.sib -o %t/tmp.sil -module-name main
+// NOTE(SR-12090): Workaround because import declarations are not preserved in .sib files.
+// RUN: sed -e 's/import Swift$/import Swift; import _Differentiation/' %t/tmp.sil > %t/tmp_fixed.sil
+// RUN: %target-sil-opt -enable-experimental-differentiable-programming %t/tmp_fixed.sil -module-name main -emit-sorted-sil | %FileCheck %s --check-prefix=CHECK-SIL
+
+
+sil_stage raw
+
+import Swift
+import Builtin
+
+import _Differentiation
+
+sil hidden @foo : $@convention(thin) (Float, Float, Float) -> Float {
+bb0(%0 : $Float, %1 : $Float, %2 : $Float):
+  return %2 : $Float
+}
+
+sil hidden @foo_t_wrt_0 : $@convention(thin) (Float, Float, Float) -> Float {
+bb0(%0 : $Float, %1 : $Float, %2 : $Float):
+  return %2 : $Float
+}
+
+sil hidden @foo_t_wrt_1_2 : $@convention(thin) (Float, Float) -> (Float, Float) {
+bb0(%0 : $Float, %1 : $Float):
+  %2 = tuple (%1 : $Float, %1 : $Float)
+  return %2 : $(Float, Float)
+}
+
+sil @make_diff_func : $@convention(thin) () -> @differentiable(linear) @convention(thin) (Float, @noDerivative Float, @noDerivative Float) -> Float {
+bb0:
+  %orig = function_ref @foo : $@convention(thin) (Float, Float, Float) -> Float
+  %linear_orig = linear_function [parameters 0] %orig : $@convention(thin) (Float, Float, Float) -> Float
+  %trans = function_ref @foo_t_wrt_0 : $@convention(thin) (Float, Float, Float) -> Float
+  %linear_orig_with_trans = linear_function [parameters 0] %orig : $@convention(thin) (Float, Float, Float) -> Float with_transpose %trans : $@convention(thin) (Float, Float, Float) -> Float
+  %extracted_orig = linear_function_extract [original] %linear_orig : $@differentiable(linear) @convention(thin) (Float, @noDerivative Float, @noDerivative Float) -> Float
+  %extracted_trans = linear_function_extract [transpose] %linear_orig : $@differentiable(linear) @convention(thin) (Float, @noDerivative Float, @noDerivative Float) -> Float
+  return %linear_orig_with_trans : $@differentiable(linear) @convention(thin) (Float, @noDerivative Float, @noDerivative Float) -> Float
+}
+
+
+// CHECK-SIL-LABEL: sil @make_diff_func : $@convention(thin) () -> @differentiable(linear) @convention(thin) (Float, @noDerivative Float, @noDerivative Float) -> Float {
+// CHECK-SIL: bb0:
+// CHECK-SIL:   [[ORIG:%.*]] = function_ref @foo : $@convention(thin) (Float, Float, Float) -> Float
+// CHECK-SIL:   [[LIN_ORIG:%.*]] = linear_function [parameters 0] [[ORIG]] : $@convention(thin) (Float, Float, Float) -> Float
+// CHECK-SIL:   [[TRANS:%.*]] = function_ref @foo_t_wrt_0 : $@convention(thin) (Float, Float, Float) -> Float
+// CHECK-SIL:   [[LIN_ORIG_WITH_TRANS:%.*]] = linear_function [parameters 0] [[ORIG]] : $@convention(thin) (Float, Float, Float) -> Float with_transpose [[TRANS]] : $@convention(thin) (Float, Float, Float) -> Float
+// CHECK-SIL:   [[EXTRACTED_ORIG:%.*]] = linear_function_extract [original] [[LIN_ORIG]] : $@differentiable(linear) @convention(thin) (Float, @noDerivative Float, @noDerivative Float) -> Float
+// CHECK-SIL:   [[EXTRACTED_TRANS:%.*]] = linear_function_extract [transpose] [[LIN_ORIG]] : $@differentiable(linear) @convention(thin) (Float, @noDerivative Float, @noDerivative Float) -> Float
+// CHECK-SIL:   return [[LIN_ORIG_WITH_TRANS]] : $@differentiable(linear) @convention(thin) (Float, @noDerivative Float, @noDerivative Float) -> Float
+// CHECK-SIL: }


### PR DESCRIPTION
Add the `linear_function` and `linear_function_extract` SIL instructions.

`linear_function' bundles` a function with its transpose function into a
`@differentiable(linear)` function.

`linear_function_extract` extracts the original function or a transpose function from the given
`@differentiable(linear)` function.

This resolves TF-1143 and TF-1142.

This builds on top of https://github.com/apple/swift/pull/30579.