### PR TITLE
Start lookup *outside* of D when D is, e.g. an ExtensionDecl

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2643,7 +2643,7 @@ void AttributeChecker::visitFrozenAttr(FrozenAttr *attr) {
 }
 
 void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
-  auto dc = D->getInnermostDeclContext();
+  auto dc = D->getDeclContext();
 
   // Figure out which nominal declaration this custom attribute refers to.
   auto nominal = evaluateOrDefault(

--- a/test/NameBinding/custom-attr-on-extension.swift
+++ b/test/NameBinding/custom-attr-on-extension.swift
@@ -1,0 +1,8 @@
+// Trips an assertion if an ASTScope lookup is attempted into the innermost
+// DeclContext of the extension.
+
+struct Ty{}
+
+@foo extension Ty {} // expected-error {{unknown attribute 'foo'}}
+
+// RUN: %target-swift-frontend -typecheck %s -verify

--- a/test/NameBinding/custom-attr-on-extension.swift
+++ b/test/NameBinding/custom-attr-on-extension.swift
@@ -1,3 +1,5 @@
+// RUN: %target-swift-frontend -typecheck %s -verify
+
 // Trips an assertion if an ASTScope lookup is attempted into the innermost
 // DeclContext of the extension.
 
@@ -5,4 +7,3 @@ struct Ty{}
 
 @foo extension Ty {} // expected-error {{unknown attribute 'foo'}}
 
-// RUN: %target-swift-frontend -typecheck %s -verify


### PR DESCRIPTION
The problem is that the wrong DeclContext is being used:

void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
  auto dc = D->getInnermostDeclContext();

When D is an ExtensionDecl, it causes the lookup to start *inside* the extension. Since the source location of the attribute is *outside* the extension, the ASTScope lookup cannot find a DeclContext that matches the request.

Fix by using “getDeclContext” instead of “getInnermostDeclContext”.

Will push, and see if the PR passes all the tests.

rdar://60840456