### PR TITLE
Don't try to look up info for a null TypeRef

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -885,7 +885,11 @@ public:
 
   /// Return a description of the layout of a value with the given type.
   const TypeInfo *getTypeInfo(const TypeRef *TR) {
-    return getBuilder().getTypeConverter().getTypeInfo(TR);
+    if (TR == nullptr) {
+      return nullptr;
+    } else {
+      return getBuilder().getTypeConverter().getTypeInfo(TR);
+    }
   }
 
 private:


### PR DESCRIPTION
This indirectly hardens the `swift_reflection_infoForTypeRef` API
against being invoked with a null TypeRef pointer.  The API already
handles a nullptr being returned from `TypeConverter::getTypeInfo`
by converting it into a standard "UNKNOWN" type info descriptor.

Resolves rdar://60633988
