### PR TITLE
[Sema] NFC: fix typo.

### DIFF
--- a/lib/Sema/CodeSynthesis.h
+++ b/lib/Sema/CodeSynthesis.h
@@ -63,7 +63,8 @@ Expr *buildArgumentForwardingExpr(ArrayRef<ParamDecl*> params,
 /// Returns the protocol requirement with the specified name.
 ValueDecl *getProtocolRequirement(ProtocolDecl *protocol, Identifier name);
 
-// Returns true if given nominal type has a `let` stored with an initial value.
+// Returns true if given nominal type declaration has a `let` stored property
+// with an initial value.
 bool hasLetStoredPropertyWithInitialValue(NominalTypeDecl *nominal);
 
 } // end namespace swift


### PR DESCRIPTION
`let` stored -> `let` stored property