### PR TITLE
[5.2] IRGen: Generate runtime type manglings using ObjC runtime names.

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -39,8 +39,8 @@ protected:
   bool OptimizeProtocolNames = true;
 
   /// If enabled, use Objective-C runtime names when mangling @objc Swift
-  /// protocols.
-  bool UseObjCProtocolNames = false;
+  /// protocols and classes.
+  bool UseObjCRuntimeNames = false;
 
   /// If enabled, non-canonical types are allowed and type alias types get a
   /// special mangling.

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -83,7 +83,7 @@ IRGenMangler::withSymbolicReferences(IRGenModule &IGM,
                                   llvm::function_ref<void ()> body) {
   Mod = IGM.getSwiftModule();
   OptimizeProtocolNames = false;
-  UseObjCProtocolNames = true;
+  UseObjCRuntimeNames = true;
 
   llvm::SaveAndRestore<bool>
     AllowSymbolicReferencesLocally(AllowSymbolicReferences);

--- a/test/IRGen/Inputs/objc_runtime_name_clang_attr.h
+++ b/test/IRGen/Inputs/objc_runtime_name_clang_attr.h
@@ -1,0 +1,11 @@
+@import Foundation;
+
+__attribute__((objc_runtime_name("ObjCRuntimeNameIsDifferent")))
+@interface ObjCRuntimeNamed: NSObject
+
+@end
+
+__attribute__((objc_runtime_name("ObjCProtoRuntimeNameIsDifferent")))
+@protocol ObjCProtoRuntimeNamed
+
+@end

--- a/test/IRGen/objc_runtime_name_clang_attr.swift
+++ b/test/IRGen/objc_runtime_name_clang_attr.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -import-objc-header %S/Inputs/objc_runtime_name_clang_attr.h %s | %FileCheck %s
+// REQUIRES: objc_interop
+
+// Use the runtime name for runtime instantiation
+// CHECK-LABEL: @"$sSo16ObjCRuntimeNamedCSgMD" = {{.*}}@"symbolic So26ObjCRuntimeNameIsDifferentCSg"
+public func getMetadata() -> Any.Type {
+  return ObjCRuntimeNamed?.self
+}
+// CHECK-LABEL: @"$sSo21ObjCProtoRuntimeNamed_pSgMD" = {{.*}}@"symbolic So31ObjCProtoRuntimeNameIsDifferent_pSg"
+public func getMetadata2() -> Any.Type {
+  return ObjCProtoRuntimeNamed?.self
+}
+
+// Use the source name for symbols to avoid breaking ABI.
+// CHECK-LABEL: define{{.*}}3fooyySo16ObjCRuntimeNamedCF
+public func foo(_: ObjCRuntimeNamed) {}
+
+// CHECK-LABEL: define{{.*}}3fooyySo21ObjCProtoRuntimeNamed_pF
+public func foo(_: ObjCProtoRuntimeNamed) {}


### PR DESCRIPTION
In order for the runtime demangler to be able to find ObjC classes and protocols, it needs to
have the runtime name of the declaration be in the mangled name. Only do this for runtime manglings,
to minimize the potential ABI impact for symbol names that already have the source-level names of
ObjC entities baked in. Fixes SR-12169 | rdar://59306590 | rdar://problem/60888835.