### PR TITLE
Revert "[SourceKit] don't install libdispatch and libBlocksRuntime twice, outside of Mac/Windows"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1027,13 +1027,11 @@ if(SWIFT_BUILD_SYNTAXPARSERLIB OR SWIFT_BUILD_SOURCEKIT)
       set(SOURCEKIT_RUNTIME_DIR lib)
     endif()
     add_dependencies(sourcekit-inproc BlocksRuntime dispatch)
-    if("${SWIFT_HOST_VARIANT_SDK}" MATCHES "OSX|WINDOWS")
-      swift_install_in_component(FILES
-                                   $<TARGET_FILE:dispatch>
-                                   $<TARGET_FILE:BlocksRuntime>
-                                 DESTINATION ${SOURCEKIT_RUNTIME_DIR}
-                                 COMPONENT sourcekit-inproc)
-    endif()
+    swift_install_in_component(FILES
+                                 $<TARGET_FILE:dispatch>
+                                 $<TARGET_FILE:BlocksRuntime>
+                               DESTINATION ${SOURCEKIT_RUNTIME_DIR}
+                               COMPONENT sourcekit-inproc)
     if(SWIFT_HOST_VARIANT_SDK STREQUAL WINDOWS)
       swift_install_in_component(FILES
                                    $<TARGET_LINKER_FILE:dispatch>


### PR DESCRIPTION
Reverts apple/swift#30096

This is causing builds on Linux to fail.