### PR TITLE
GSB: Fix maybeResolveEquivalenceClass() with member type of concrete type

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3659,8 +3659,14 @@ ResolvedType GenericSignatureBuilder::maybeResolveEquivalenceClass(
       // Check whether this associated type references a protocol to which
       // the base conforms. If not, it's unresolved.
       if (baseEquivClass->conformsTo.find(assocType->getProtocol())
-            == baseEquivClass->conformsTo.end())
-        return ResolvedType::forUnresolved(baseEquivClass);
+          == baseEquivClass->conformsTo.end()) {
+        if (!baseEquivClass->concreteType ||
+            !lookupConformance(type->getCanonicalType(),
+                               baseEquivClass->concreteType,
+                               assocType->getProtocol())) {
+          return ResolvedType::forUnresolved(baseEquivClass);
+        }
+      }
 
       nestedTypeDecl = assocType;
     } else {

--- a/test/SILGen/fully-concrete-extension-of-generic.swift
+++ b/test/SILGen/fully-concrete-extension-of-generic.swift
@@ -17,3 +17,17 @@ func exerciseInits(which: Bool) -> C<Int> {
     return C(forInt: ())
   }
 }
+
+protocol P {
+  associatedtype T
+}
+
+struct S : P {
+  typealias T = Int
+}
+
+struct G<T : P> {}
+
+extension G where T == S {
+  func foo(_: T.T) {}
+}


### PR DESCRIPTION
Fixes <rdar://problem/55401811>, <https://bugs.swift.org/browse/SR-11475>.