### PR TITLE
[CSApply] Support dynamic member lookup as component of key path dyna…

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1966,14 +1966,19 @@ namespace {
 
       // Looks like there is a chain of implicit `subscript(dynamicMember:)`
       // calls necessary to resolve a member reference.
-      if (overload.choice.getKind() ==
-          OverloadChoiceKind::KeyPathDynamicMemberLookup) {
+      switch (overload.choice.getKind()) {
+      case OverloadChoiceKind::DynamicMemberLookup:
+      case OverloadChoiceKind::KeyPathDynamicMemberLookup: {
         buildKeyPathSubscriptComponent(overload, dotLoc, /*indexExpr=*/nullptr,
                                        ctx.Id_dynamicMember, componentLoc,
                                        components);
         keyPath->resolveComponents(ctx, components);
         cs.cacheExprTypes(keyPath);
         return keyPath;
+      }
+
+      default:
+        break;
       }
 
       // We can't reuse existing expression because type-check

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -764,3 +764,28 @@ func test_infinite_self_recursion() {
   _ = Recurse<Int>().foo
   // expected-error@-1 {{value of type 'Recurse<Int>' has no dynamic member 'foo' using key path from root type 'Recurse<Int>'}}
 }
+
+// rdar://problem/60225883 - crash during solution application (ExprRewritter::buildKeyPathDynamicMemberIndexExpr)
+func test_combination_of_keypath_and_string_lookups() {
+  @dynamicMemberLookup
+  struct Outer {
+    subscript(dynamicMember member: String) -> Outer {
+      Outer()
+    }
+
+    subscript(dynamicMember member: KeyPath<Inner, Inner>) -> Outer {
+      Outer()
+    }
+  }
+
+  @dynamicMemberLookup
+  struct Inner {
+    subscript(dynamicMember member: String) -> Inner {
+      Inner()
+    }
+  }
+
+  func test(outer: Outer) {
+    _ = outer.hello.world // Ok
+  }
+}


### PR DESCRIPTION
…mic member lookup

Previously solution application only supported references to
key path dynamic member lookup as components but it should support both kinds.

Resolves: rdar://problem/60225883
Resolves: [SR-12313](https://bugs.swift.org/browse/SR-12313)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
