### PR TITLE
[AutoDiff] remove deprecated @nondiff

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -55,7 +55,6 @@ TYPE_ATTR(differentiable)
 TYPE_ATTR(noDerivative)
 // SWIFT_ENABLE_TENSORFLOW
 TYPE_ATTR(autodiff)
-TYPE_ATTR(nondiff)
 // SWIFT_ENABLE_TENSORFLOW END
 
 // SIL-specific attributes

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3118,11 +3118,6 @@ ERROR(noderivative_only_on_differentiable_struct_or_class_fields,none,
       "'@noDerivative' is only allowed on stored properties in structure or "
       "class types that declare a conformance to 'Differentiable'", ())
 
-// SWIFT_ENABLE_TENSORFLOW
-// @nonDiff attribute
-WARNING(nondiff_attr_deprecated,none,
-        "'@nondiff' is deprecated; use '@noDerivative' instead", ())
-
 //------------------------------------------------------------------------------
 // MARK: Type Check Expressions
 //------------------------------------------------------------------------------

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -298,10 +298,7 @@ void AttributedTypeRepr::printAttrs(ASTPrinter &Printer,
     Printer.printSimpleAttr("@autoclosure") << " ";
   if (hasAttr(TAK_escaping))
     Printer.printSimpleAttr("@escaping") << " ";
-  // SWIFT_ENABLE_TENSORFLOW
-  // `@nondiff` is deprecated; it is renamed to `@noDerivative`.
-  if (hasAttr(TAK_noDerivative) || hasAttr(TAK_nondiff))
-  // SWIFT_ENABLE_TENSORFLOW END
+  if (hasAttr(TAK_noDerivative))
     Printer.printSimpleAttr("@noDerivative") << " ";
   if (hasAttr(TAK_differentiable)) {
     if (Attrs.isLinear()) {

--- a/test/AutoDiff/downstream/differentiable_func_type_type_checking.swift
+++ b/test/AutoDiff/downstream/differentiable_func_type_type_checking.swift
@@ -81,9 +81,6 @@ func differentiableToLinear(_ f: @escaping @differentiable (Float) -> Float) {
 // Parameter selection (@noDerivative)
 //===----------------------------------------------------------------------===//
 
-// expected-warning @+1 {{'@nondiff' is deprecated; use '@noDerivative' instead}}
-let _: @differentiable (@nondiff Float, Float) -> Float
-
 // expected-error @+1 {{'@noDerivative' may only be used on parameters of '@differentiable' function types}}
 let _: (@noDerivative Float, Float) -> Float
 


### PR DESCRIPTION
Removes deprecated @nondiff. This has been deprecated for a few releases now, so it should be safe to merge. I'll run this through all our external repo tests to make sure there aren't any @nondiff remaining in them.