### PR TITLE
[AutoDiff upstream] @differentiable function type sema

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4016,6 +4016,18 @@ ERROR(opaque_type_in_protocol_requirement,none,
 ERROR(attr_only_on_parameters_of_differentiable,none,
       "'%0' may only be used on parameters of '@differentiable' function "
       "types", (StringRef))
+ERROR(differentiable_function_type_invalid_parameter,none,
+      "parameter type '%0' does not conform to 'Differentiable'"
+      "%select{| and satisfy '%0 == %0.TangentVector'}1, but the enclosing "
+      "function type is '@differentiable%select{|(linear)}1'"
+      "%select{|; did you want to add '@noDerivative' to this parameter?}2",
+      (StringRef, /*tangentVectorEqualsSelf*/ bool,
+       /*hasValidDifferentiabilityParameter*/ bool))
+ERROR(differentiable_function_type_invalid_result,none,
+      "result type '%0' does not conform to 'Differentiable'"
+      "%select{| and satisfy '%0 == %0.TangentVector'}1, but the enclosing "
+      "function type is '@differentiable%select{|(linear)}1'",
+      (StringRef, bool))
 
 // SIL
 ERROR(opened_non_protocol,none,

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -5066,7 +5066,8 @@ TypeBase::getAutoDiffTangentSpace(LookupConformanceFn lookupConformance) {
   // `TangentVector` associated type.
   auto *differentiableProtocol =
       ctx.getProtocol(KnownProtocolKind::Differentiable);
-  assert(differentiableProtocol && "`Differentiable` protocol not found");
+  if (!differentiableProtocol)
+    return cache(None);
   auto associatedTypeLookup =
       differentiableProtocol->lookupDirect(ctx.Id_TangentVector);
   assert(associatedTypeLookup.size() == 1);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1865,6 +1865,11 @@ namespace {
     Type resolveOpaqueReturnType(TypeRepr *repr, StringRef mangledName,
                                  unsigned ordinal,
                                  TypeResolutionOptions options);
+
+    /// Returns true if the given type conforms to `Differentiable` in the
+    /// module of `DC`. If `tangentVectorEqualsSelf` is true, returns true iff
+    /// the given type additionally satisfies `Self == Self.TangentVector`.
+    bool isDifferentiable(Type type, bool tangentVectorEqualsSelf = false);
   };
 } // end anonymous namespace
 
@@ -2256,16 +2261,16 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
         }
       }
 
-      if (attrs.has(TAK_differentiable) &&
-          !Context.LangOpts.EnableExperimentalDifferentiableProgramming) {
-        diagnoseInvalid(repr, attrs.getLoc(TAK_differentiable),
-                        diag::experimental_differentiable_programming_disabled);
-      }
-
       DifferentiabilityKind diffKind = DifferentiabilityKind::NonDifferentiable;
       if (attrs.has(TAK_differentiable)) {
-        diffKind = attrs.linear ? DifferentiabilityKind::Linear
-                                : DifferentiabilityKind::Normal;
+        if (Context.LangOpts.EnableExperimentalDifferentiableProgramming) {
+          diffKind = attrs.linear ? DifferentiabilityKind::Linear
+                                  : DifferentiabilityKind::Normal;
+        } else {
+          diagnoseInvalid(
+              repr, attrs.getLoc(TAK_differentiable),
+              diag::experimental_differentiable_programming_disabled);
+        }
       }
 
       // Resolve the function type directly with these attributes.
@@ -2304,16 +2309,16 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
         }
       }
 
-      if (attrs.has(TAK_differentiable) &&
-          !Context.LangOpts.EnableExperimentalDifferentiableProgramming) {
-        diagnoseInvalid(repr, attrs.getLoc(TAK_differentiable),
-                        diag::experimental_differentiable_programming_disabled);
-      }
-
       DifferentiabilityKind diffKind = DifferentiabilityKind::NonDifferentiable;
       if (attrs.has(TAK_differentiable)) {
-        diffKind = attrs.linear ? DifferentiabilityKind::Linear
-                                : DifferentiabilityKind::Normal;
+        if (Context.LangOpts.EnableExperimentalDifferentiableProgramming) {
+          diffKind = attrs.linear ? DifferentiabilityKind::Linear
+                                  : DifferentiabilityKind::Normal;
+        } else {
+          diagnoseInvalid(
+              repr, attrs.getLoc(TAK_differentiable),
+              diag::experimental_differentiable_programming_disabled);
+        }
       }
 
       ty = resolveASTFunctionType(fnRepr, options, rep, /*noescape=*/false,
@@ -2588,6 +2593,39 @@ bool TypeResolver::resolveASTFunctionTypeParams(
     elements.emplace_back(ty, Identifier(), paramFlags);
   }
 
+  // All non-`@noDerivative` parameters of `@differentiable` and
+  // `@differentiable(linear)` function types must be differentiable.
+  if (diffKind != DifferentiabilityKind::NonDifferentiable &&
+      resolution.getStage() != TypeResolutionStage::Structural) {
+    bool isLinear = diffKind == DifferentiabilityKind::Linear;
+    // Emit `@noDerivative` fixit only if there is at least one valid
+    // differentiability/linearity parameter. Otherwise, adding `@noDerivative`
+    // produces an ill-formed function type.
+    auto hasValidDifferentiabilityParam =
+        llvm::find_if(elements, [&](AnyFunctionType::Param param) {
+          if (param.isNoDerivative())
+            return false;
+          return isDifferentiable(param.getPlainType(),
+                                  /*tangentVectorEqualsSelf*/ isLinear);
+        }) != elements.end();
+    for (unsigned i = 0, end = inputRepr->getNumElements(); i != end; ++i) {
+      auto *eltTypeRepr = inputRepr->getElementType(i);
+      auto param = elements[i];
+      if (param.isNoDerivative())
+        continue;
+      auto paramType = param.getPlainType();
+      if (isDifferentiable(paramType, /*tangentVectorEqualsSelf*/ isLinear))
+        continue;
+      auto paramTypeString = paramType->getString();
+      auto diagnostic =
+          diagnose(eltTypeRepr->getLoc(),
+                   diag::differentiable_function_type_invalid_parameter,
+                   paramTypeString, isLinear, hasValidDifferentiabilityParam);
+      if (hasValidDifferentiabilityParam)
+        diagnostic.fixItInsert(eltTypeRepr->getLoc(), "@noDerivative ");
+    }
+  }
+
   return false;
 }
 
@@ -2720,8 +2758,35 @@ Type TypeResolver::resolveASTFunctionType(
   case AnyFunctionType::Representation::Swift:
     break;
   }
-  
+
+  // `@differentiable` and `@differentiable(linear)` function types must return
+  // a differentiable type.
+  if (extInfo.isDifferentiable() &&
+      resolution.getStage() != TypeResolutionStage::Structural) {
+    bool isLinear = diffKind == DifferentiabilityKind::Linear;
+    if (!isDifferentiable(outputTy, /*tangentVectorEqualsSelf*/ isLinear)) {
+      diagnose(repr->getResultTypeRepr()->getLoc(),
+               diag::differentiable_function_type_invalid_result,
+               outputTy->getString(), isLinear)
+          .highlight(repr->getResultTypeRepr()->getSourceRange());
+    }
+  }
+
   return fnTy;
+}
+
+bool TypeResolver::isDifferentiable(Type type, bool tangentVectorEqualsSelf) {
+  if (resolution.getStage() != TypeResolutionStage::Contextual)
+    type = DC->mapTypeIntoContext(type);
+  auto tanSpace = type->getAutoDiffTangentSpace(
+      LookUpConformanceInModule(DC->getParentModule()));
+  if (!tanSpace)
+    return false;
+  // If no `Self == Self.TangentVector` requirement, return true.
+  if (!tangentVectorEqualsSelf)
+    return true;
+  // Otherwise, return true if `Self == Self.TangentVector`.
+  return type->getCanonicalType() == tanSpace->getCanonicalType();
 }
 
 Type TypeResolver::resolveSILBoxType(SILBoxTypeRepr *repr,

--- a/test/AutoDiff/ModuleInterface/differentiation.swift
+++ b/test/AutoDiff/ModuleInterface/differentiation.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t.swiftinterface -enable-library-evolution -enable-experimental-differentiable-programming %s
 // RUN: %FileCheck %s < %t.swiftinterface
 
+import _Differentiation
+
 public func a(f: @differentiable (Float) -> Float) {}
 // CHECK: public func a(f: @differentiable (Swift.Float) -> Swift.Float)
 

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -396,7 +396,7 @@ extension TF_521: Differentiable where T: Differentiable {
   // expected-note @+1 {{possibly intended match 'TF_521<T>.TangentVector' does not conform to 'AdditiveArithmetic'}}
   typealias TangentVector = TF_521
 }
-
+// expected-error @+1 {{result type 'TF_521<Float>' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
 let _: @differentiable(Float, Float) -> TF_521<Float> = { r, i in
   TF_521(real: r, imaginary: i)
 }

--- a/test/AutoDiff/Sema/differentiable_func_type.swift
+++ b/test/AutoDiff/Sema/differentiable_func_type.swift
@@ -1,21 +1,76 @@
 // RUN: %target-swift-frontend -enable-experimental-differentiable-programming -typecheck -verify %s
 
+import _Differentiation
+
+//===----------------------------------------------------------------------===//
+// Basic @differentiable function types.
+//===----------------------------------------------------------------------===//
+
 // expected-error @+1 {{@differentiable attribute only applies to function types}}
 let _: @differentiable Float
 
 let _: @differentiable (Float) -> Float
+let _: @differentiable (Float) throws -> Float
+
+//===----------------------------------------------------------------------===//
+// Type differentiability
+//===----------------------------------------------------------------------===//
+
+struct NonDiffType { var x: Int }
+
+// FIXME: Properly type-check parameters and the result's differentiability
+// expected-error @+1 {{parameter type 'NonDiffType' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
+let _: @differentiable (NonDiffType) -> Float
+
+// Emit `@noDerivative` fixit iff there is at least one valid differentiability parameter.
+// expected-error @+1 {{parameter type 'NonDiffType' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'; did you want to add '@noDerivative' to this parameter?}} {{32-32=@noDerivative }}
+let _: @differentiable (Float, NonDiffType) -> Float
+
+// expected-error @+1 {{result type 'NonDiffType' does not conform to 'Differentiable' and satisfy 'NonDiffType == NonDiffType.TangentVector', but the enclosing function type is '@differentiable(linear)'}}
+let _: @differentiable(linear) (Float) -> NonDiffType
+
+// Emit `@noDerivative` fixit iff there is at least one valid linearity parameter.
+// expected-error @+1 {{parameter type 'NonDiffType' does not conform to 'Differentiable' and satisfy 'NonDiffType == NonDiffType.TangentVector', but the enclosing function type is '@differentiable(linear)'; did you want to add '@noDerivative' to this parameter?}} {{40-40=@noDerivative }}
+let _: @differentiable(linear) (Float, NonDiffType) -> Float
+
+// expected-error @+1 {{result type 'NonDiffType' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
+let _: @differentiable (Float) -> NonDiffType
+
+// expected-error @+1 {{result type 'NonDiffType' does not conform to 'Differentiable' and satisfy 'NonDiffType == NonDiffType.TangentVector', but the enclosing function type is '@differentiable(linear)'}}
+let _: @differentiable(linear) (Float) -> NonDiffType
+
+let _: @differentiable(linear) (Float) -> Float
+
+// expected-error @+1 {{result type '@differentiable (U) -> Float' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
+func test1<T: Differentiable, U: Differentiable>(_: @differentiable (T) -> @differentiable (U) -> Float) {}
+// expected-error @+1 {{result type '(U) -> Float' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
+func test2<T: Differentiable, U: Differentiable>(_: @differentiable (T) -> (U) -> Float) {}
+// expected-error @+2 {{result type 'Int' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
+// expected-error @+1 {{result type '@differentiable (U) -> Int' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
+func test3<T: Differentiable, U: Differentiable>(_: @differentiable (T) -> @differentiable (U) -> Int) {}
+// expected-error @+1 {{result type '(U) -> Int' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
+func test4<T: Differentiable, U: Differentiable>(_: @differentiable (T) -> (U) -> Int) {}
+
+//===----------------------------------------------------------------------===//
+// Parameter selection (@noDerivative)
+//===----------------------------------------------------------------------===//
 
 // expected-error @+1 {{'@noDerivative' may only be used on parameters of '@differentiable' function types}}
 let _: @noDerivative Float
+
+// expected-error @+1 {{'@noDerivative' may only be used on parameters of '@differentiable' function types}}
+let _: (@noDerivative Float) -> Float
+
+// expected-error @+1 {{'@noDerivative' may only be used on parameters of '@differentiable' function types}}
+let _: (@noDerivative Float, Float) -> Float
+
+let _: @differentiable (Float, @noDerivative Float) -> Float // okay
 
 // expected-error @+1 {{'@noDerivative' may only be used on parameters of '@differentiable' function types}}
 let _: (Float) -> @noDerivative Float
 
 // expected-error @+1 {{'@noDerivative' may only be used on parameters of '@differentiable' function types}}
 let _: @differentiable (Float) -> @noDerivative Float
-
-// expected-error @+1 {{'@noDerivative' may only be used on parameters of '@differentiable' function types}}
-let _: (@noDerivative Float) -> Float
 
 // expected-error @+2 {{'@noDerivative' may only be used on parameters of '@differentiable' function types}}
 // expected-error @+1 {{'@noDerivative' must not be used on variadic parameters}}
@@ -25,3 +80,95 @@ let _: @differentiable (@noDerivative Float, Float) -> Float
 
 // expected-error @+1 {{'@noDerivative' must not be used on variadic parameters}}
 let _: @differentiable (Float, @noDerivative Float...) -> Float
+
+//===----------------------------------------------------------------------===//
+// Inferred conformances
+//===----------------------------------------------------------------------===//
+
+let diffFunc: @differentiable (Float) -> Float
+let linearFunc: @differentiable(linear) (Float) -> Float
+func inferredConformances<T, U>(_: @differentiable (T) -> U) {}
+func inferredConformancesLinear<T, U>(_: @differentiable(linear) (T) -> U) {}
+inferredConformances(diffFunc)
+inferredConformancesLinear(linearFunc)
+
+func inferredConformancesResult<T, U>() -> @differentiable (T) -> U {}
+func inferredConformancesResultLinear<T, U>() -> @differentiable(linear) (T) -> U {}
+
+let diffFuncWithNondiff: @differentiable (Float, @noDerivative Int) -> Float
+let linearFuncWithNondiff: @differentiable(linear) (Float, @noDerivative Int) -> Float
+func inferredConformances<T, U, V>(_: @differentiable (T, @noDerivative U) -> V) {}
+func inferredConformancesLinear<T, U, V>(_: @differentiable(linear) (T, @noDerivative U) -> V) {}
+inferredConformances(diffFuncWithNondiff)
+inferredConformancesLinear(linearFuncWithNondiff)
+
+struct Vector<T> {
+  var x, y: T
+}
+extension Vector: Equatable where T: Equatable {}
+extension Vector: AdditiveArithmetic where T: AdditiveArithmetic {
+  static var zero: Self { fatalError() }
+  static func + (lhs: Self, rhs: Self) -> Self { fatalError() }
+  static func - (lhs: Self, rhs: Self) -> Self { fatalError() }
+}
+extension Vector: Differentiable where T: Differentiable {
+  struct TangentVector: Equatable, AdditiveArithmetic, Differentiable {
+    var x, y: T.TangentVector
+    static var zero: Self { fatalError() }
+    static func + (lhs: Self, rhs: Self) -> Self { fatalError() }
+    static func - (lhs: Self, rhs: Self) -> Self { fatalError() }
+    typealias TangentVector = Self
+  }
+  mutating func move(along direction: TangentVector) { fatalError() }
+}
+
+func inferredConformancesGeneric<T, U>(_: @differentiable (Vector<T>) -> Vector<U>) {}
+
+// expected-error @+4 {{generic signature requires types 'Vector<T>' and 'Vector<T>.TangentVector' to be the same}}
+// expected-error @+3 {{generic signature requires types 'Vector<U>' and 'Vector<U>.TangentVector' to be the same}}
+// expected-error @+2 {{parameter type 'Vector<T>' does not conform to 'Differentiable' and satisfy 'Vector<T> == Vector<T>.TangentVector', but the enclosing function type is '@differentiable(linear)'}}
+// expected-error @+1 {{result type 'Vector<U>' does not conform to 'Differentiable' and satisfy 'Vector<U> == Vector<U>.TangentVector', but the enclosing function type is '@differentiable(linear)'}}
+func inferredConformancesGenericLinear<T, U>(_: @differentiable(linear) (Vector<T>) -> Vector<U>) {}
+
+func nondiff(x: Vector<Int>) -> Vector<Int> {}
+// expected-error @+1 {{global function 'inferredConformancesGeneric' requires that 'Int' conform to 'Differentiable}}
+inferredConformancesGeneric(nondiff)
+// expected-error @+1 {{global function 'inferredConformancesGenericLinear' requires that 'Int' conform to 'Differentiable}}
+inferredConformancesGenericLinear(nondiff)
+
+func diff(x: Vector<Float>) -> Vector<Float> {}
+inferredConformancesGeneric(diff) // okay!
+
+func inferredConformancesGenericResult<T, U>() -> @differentiable (Vector<T>) -> Vector<U> {}
+// expected-error @+4 {{generic signature requires types 'Vector<T>' and 'Vector<T>.TangentVector' to be the same}}
+// expected-error @+3 {{generic signature requires types 'Vector<U>' and 'Vector<U>.TangentVector' to be the same}}
+// expected-error @+2 {{parameter type 'Vector<T>' does not conform to 'Differentiable' and satisfy 'Vector<T> == Vector<T>.TangentVector', but the enclosing function type is '@differentiable(linear)'}}
+// expected-error @+1 {{result type 'Vector<U>' does not conform to 'Differentiable' and satisfy 'Vector<U> == Vector<U>.TangentVector', but the enclosing function type is '@differentiable(linear)'}}
+func inferredConformancesGenericResultLinear<T, U>() -> @differentiable(linear) (Vector<T>) -> Vector<U> {}
+
+struct Linear<T> {
+  var x, y: T
+}
+extension Linear: Equatable where T: Equatable {}
+extension Linear: AdditiveArithmetic where T: AdditiveArithmetic {}
+extension Linear: Differentiable where T: Differentiable, T == T.TangentVector {
+  typealias TangentVector = Self
+}
+
+// expected-note @+1 2 {{where 'T' = 'Int'}}
+func inferredConformancesGeneric<T, U>(_: @differentiable (Linear<T>) -> Linear<U>) {}
+
+// expected-note @+1 2 {{where 'T' = 'Int'}}
+func inferredConformancesGenericLinear<T, U>(_: @differentiable(linear) (Linear<T>) -> Linear<U>) {}
+
+func nondiff(x: Linear<Int>) -> Linear<Int> {}
+// expected-error @+1 {{global function 'inferredConformancesGeneric' requires that 'Int' conform to 'Differentiable}}
+inferredConformancesGeneric(nondiff)
+// expected-error @+1 {{global function 'inferredConformancesGenericLinear' requires that 'Int' conform to 'Differentiable}}
+inferredConformancesGenericLinear(nondiff)
+
+func diff(x: Linear<Float>) -> Linear<Float> {}
+inferredConformancesGeneric(diff) // okay!
+
+func inferredConformancesGenericResult<T, U>() -> @differentiable (Linear<T>) -> Linear<U> {}
+func inferredConformancesGenericResultLinear<T, U>() -> @differentiable(linear) (Linear<T>) -> Linear<U> {}

--- a/test/AutoDiff/Sema/missing_differentiable_protocol.swift
+++ b/test/AutoDiff/Sema/missing_differentiable_protocol.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -typecheck -verify %s
+
+// Tests that Sema fails gracefully when the `Differentiable` protocol is missing.
+
+// expected-error @+2 {{parameter type 'Float' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
+// expected-error @+1 {{result type 'Float' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
+let _: @differentiable (Float) -> Float
+
+// expected-error @+2 {{parameter type 'T' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
+// expected-error @+1 {{result type 'T' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
+func hasDifferentiableFunctionArg<T>(_ f: @differentiable (T) -> T) {}

--- a/test/AutoDiff/Serialization/differentiable_function.swift
+++ b/test/AutoDiff/Serialization/differentiable_function.swift
@@ -5,6 +5,8 @@
 
 // BCANALYZER-NOT: UnknownCode
 
+import _Differentiation
+
 func a(_ f: @differentiable (Float) -> Float) {}
 // CHECK: func a(_ f: @differentiable (Float) -> Float)
 


### PR DESCRIPTION
Type checking for the `@differentiable` function type:
* Check that parameters and results conform to `Differentiable`.
* Add implicit conformances of parameters and results to `Differentiable` when they are generic parameters.
* Import most of the [differentiable_func_type_type_checking.swift](https://github.com/apple/swift/blob/44f4449ac7edeb3f782df8bf5d08474142a80f3a/test/AutoDiff/downstream/differentiable_func_type_type_checking.swift) test from the `tensorflow` branch. (There are a few function conversion tests that I haven't imported because they depend on the function conversion pipeline.)

Note: I needed to make a small logic change for this to work properly in `master`. In the `tensorflow` branch, we assume that the `Differentiable` protocol is always available. In the `master` branch, it is only available if you `import _Differentiation`. So I changed all the places where we assert/segfault when the `Differentiable` protocol is missing to fail gracefully with a diagnostic. And I added a test for this.

This resolves TF-823 and TF-1219.