### PR TITLE
PrintAsObjC: use header path relative to usr/include when importing non-framework headers

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -332,8 +332,42 @@ static void writeImports(raw_ostream &out,
       allPaths.append(module->getTopLevelModuleName());
       llvm::sys::path::append(allPaths, Buffer.str());
     } else {
-      // Otherwise, import the header directly.
-      allPaths.append(header.NameAsWritten);
+      auto DirPath = header.Entry->getDir()->getName();
+      auto I = llvm::sys::path::begin(DirPath),
+           E = llvm::sys::path::end(DirPath);
+      llvm::SmallVector<StringRef, 4> Comps;
+      // Check if the path of the header contains `/usr/include/` in it.
+      // If so, we print the header include path starting from the next component.
+      // e.g. for .../usr/include/dispatch/dispatch.h, we print
+      // #include "dispatch/dispatch.h" because we could assume /usr/include/ is
+      // in the header search paths.
+      while (true) {
+        StringRef Parts[2] = {*I, StringRef()};
+        ++ I;
+        if (I == E)
+          break;
+        Parts[1] = *I;
+        if (Parts[0] == "usr" && Parts[1] == "include") {
+          ++ I;
+          for (;I != E; ++ I) {
+            Comps.push_back(*I);
+          }
+          break;
+        }
+      };
+      if (!Comps.empty()) {
+        // The header is in a deeper location inside /usr/include/, add the
+        // additional path components before adding the header name.
+        allPaths.append(Comps.front());
+        for (auto c: llvm::makeArrayRef(Comps).slice(1)) {
+          llvm::sys::path::append(allPaths, c);
+        }
+        llvm::sys::path::append(allPaths,
+                                llvm::sys::path::filename(header.NameAsWritten));
+      } else {
+        // Otherwise, import the header directly.
+        allPaths.append(header.NameAsWritten);
+      }
     }
     headerImports.insert(allPaths.str().substr(startIdx));
   };

--- a/test/Inputs/clang-importer-sdk/usr/include/CTypesCore/module.modulemap
+++ b/test/Inputs/clang-importer-sdk/usr/include/CTypesCore/module.modulemap
@@ -1,0 +1,4 @@
+module CTypesCore [system] [extern_c] {
+  umbrella header "values.h"
+  export *
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/CTypesCore/values.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/CTypesCore/values.h
@@ -1,0 +1,3 @@
+typedef int DWORD_CORE;
+
+#define MY_INT 123

--- a/test/PrintAsObjC/imports.swift
+++ b/test/PrintAsObjC/imports.swift
@@ -13,6 +13,7 @@
 // CHECK-NEXT: @import Base.ExplicitSub;
 // CHECK-NEXT: @import Base.ExplicitSub.ExSub;
 // CHECK-NEXT: @import Base.ImplicitSub.ExSub;
+// CHECK-NEXT: @import CTypesCore;
 // CHECK-NEXT: @import Foundation;
 // CHECK-NEXT: @import MostlyPrivate1;
 // CHECK-NEXT: @import MostlyPrivate1_Private;
@@ -24,6 +25,7 @@
 // CHECK-NEXT: #import <Base.ExplicitSub.h>
 // CHECK-NEXT: #import <Base.ExplicitSub.ExSub.h>
 // CHECK-NEXT: #import <Base.ImplicitSub.ExSub.h>
+// CHECK-NEXT: #import <CTypesCore/values.h>
 // CHECK-NEXT: #import <Foundation.h>
 // CHECK-NEXT: #import <MostlyPrivate1/MostlyPrivate1.h>
 // CHECK-NEXT: #import <MostlyPrivate1_Private/MostlyPrivate1_Private.h>
@@ -38,6 +40,7 @@
 
 // NEGATIVE-NOT: secretMethod
 
+import CTypesCore
 import ctypes.bits
 import Foundation
 
@@ -58,6 +61,7 @@ import MostlyPrivate2_Private
 
 @objc class Test {
   @objc let word: DWORD = 0
+  @objc let word_core: DWORD_CORE = 0
   @objc let number: TimeInterval = 0.0
 
   @objc let baseI: BaseI = 0


### PR DESCRIPTION
We could assume usr/include belongs to header search paths. If a header
is located in a deeper location inside this directory, we need to print
the additional path components.

rdar://60857172
