### PR TITLE
[CodeCompletion] Don't run second pass for decls in closures

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2838,6 +2838,15 @@ ParserResult<Expr> Parser::parseExprClosure() {
   ParserStatus Status;
   Status |= parseBraceItems(bodyElements, BraceItemListKind::Brace);
 
+  if (SourceMgr.rangeContainsCodeCompletionLoc({leftBrace, PreviousLoc})) {
+    // Ignore 'CodeCompletionDelayedDeclState' inside closures.
+    // Completions inside functions body inside closures at top level should
+    // be considered top-level completions.
+    if (State->hasCodeCompletionDelayedDeclState())
+      (void)State->takeCodeCompletionDelayedDeclState();
+    Status.setHasCodeCompletion();
+  }
+
   // Parse the closing '}'.
   SourceLoc rightBrace;
   bool missingRBrace = parseMatchingToken(tok::r_brace, rightBrace,

--- a/test/SourceKit/CodeComplete/complete_sequence_func_in_closure.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_func_in_closure.swift
@@ -1,0 +1,55 @@
+struct MyValue {
+  var value = 1
+}
+func foo(fn: () -> Void) {}
+_ = foo {
+  func innerFunc(value: MyValue) {
+    value. // HERE
+  }
+}
+
+struct MyStruct {
+  var x = { () -> Int in
+    class InnerC {
+      init(value: MyValue) {
+        value. // HERE
+      }
+    }
+  }()
+}
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=track-compiles == \
+// RUN:   -req=complete -pos=7:11 -repeat-request=2 %s -- %s -parse-as-library == \
+// RUN:   -req=complete -pos=15:15 -repeat-request=2 %s -- %s -parse-as-library \
+// RUN:   > %t.response.library
+// RUN: %FileCheck --check-prefix=RESULT %s < %t.response.library
+// RUN: %FileCheck --check-prefix=LIB_TRACE %s < %t.response.library
+
+// RESULT-LABEL: key.results: [
+// RESULT: key.description: "value"
+// RESULT-LABEL: key.results: [
+// RESULT: key.description: "value"
+// RESULT-LABEL: key.results: [
+// RESULT: key.description: "value"
+// RESULT-LABEL: key.results: [
+// RESULT: key.description: "value"
+
+// LIB_TRACE-NOT:  key.description: "completion reusing previous ASTContext (benign diagnostic)"
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=track-compiles == \
+// RUN:   -req=complete -pos=7:11 -repeat-request=2 %s -- %s == \
+// RUN:   -req=complete -pos=15:15 -repeat-request=2 %s -- %s \
+// RUN:   > %t.response.script
+// RUN: %FileCheck --check-prefix=RESULT %s < %t.response.script
+// RUN: %FileCheck --check-prefix=SCRIPT_TRACE %s < %t.response.script
+
+// SCRIPT_TRACE-LABEL: key.notification: source.notification.compile-did-finish,
+// SCRIPT_TRACE-NOT: key.description: "completion reusing previous ASTContext (benign diagnostic)"
+// SCRIPT_TRACE-LABEL: key.notification: source.notification.compile-did-finish,
+// SCRIPT_TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
+// SCRIPT_TRACE-LABEL: key.notification: source.notification.compile-did-finish,
+// SCRIPT_TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
+// SCRIPT_TRACE-LABEL: key.notification: source.notification.compile-did-finish,
+// SCRIPT_TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"


### PR DESCRIPTION
For instance:
```swift
let globalVar = {
    func something(arg: Int) -> Int {
        #^HERE^#
    }
    return something(12)
}()
```
We want to consider this as a top-level completion, not a function body completion.

rdar://problem/60838686