### PR TITLE
IRGen: Correctly unique selectors for setter/getters

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1551,12 +1551,12 @@ namespace {
 
       switch (accessor->getAccessorKind()) {
       case AccessorKind::Get:
-        return emitObjCGetterDescriptor(IGM, descriptors,
-                                        accessor->getStorage());
+        return emitObjCGetterDescriptor(
+            IGM, descriptors, accessor->getStorage(), uniqueSelectors);
 
       case AccessorKind::Set:
-        return emitObjCSetterDescriptor(IGM, descriptors,
-                                        accessor->getStorage());
+        return emitObjCSetterDescriptor(
+            IGM, descriptors, accessor->getStorage(), uniqueSelectors);
 
 #define OBJC_ACCESSOR(ID, KEYWORD)
 #define ACCESSOR(ID) \

--- a/lib/IRGen/GenObjC.h
+++ b/lib/IRGen/GenObjC.h
@@ -186,12 +186,14 @@ namespace irgen {
   /// Build an Objective-C method descriptor for the given getter method.
   void emitObjCGetterDescriptor(IRGenModule &IGM,
                                 ConstantArrayBuilder &descriptors,
-                                AbstractStorageDecl *storage);
+                                AbstractStorageDecl *storage,
+                                llvm::StringSet<> &uniqueSelectors);
 
   /// Build an Objective-C method descriptor for the given setter method.
   void emitObjCSetterDescriptor(IRGenModule &IGM,
                                 ConstantArrayBuilder &descriptors,
-                                AbstractStorageDecl *storage);
+                                AbstractStorageDecl *storage,
+                                llvm::StringSet<> &uniqueSelectors);
 
   /// True if the FuncDecl requires an ObjC method descriptor.
   bool requiresObjCMethodDescriptor(FuncDecl *method);

--- a/test/IRGen/Inputs/usr/include/Gizmo.h
+++ b/test/IRGen/Inputs/usr/include/Gizmo.h
@@ -162,6 +162,14 @@ __attribute__((swift_name("OuterType.InnerType")))
 
 @protocol P
 - (oneway void)stuff;
++ (void) classStuff;
 @property (nonatomic, readonly, getter=isValid) signed char valid;
 @property (nonatomic) NSString *name;
+@property (class, nonatomic, readonly) NSString *className;
+
+@optional
+- (oneway void)optionalStuff;
++ (void) optionalClassStuff;
+@property (nonatomic, readonly) NSString *optionalName;
+@property (class, nonatomic, readonly) NSString *optionalClassName;
 @end

--- a/test/IRGen/Inputs/usr/include/Gizmo.h
+++ b/test/IRGen/Inputs/usr/include/Gizmo.h
@@ -160,6 +160,9 @@ __attribute__((swift_name("OuterType.InnerType")))
 @interface OuterTypeInnerType : NSObject<NSRuncing>
 @end
 
+typedef signed char BOOL;
 @protocol P
 - (oneway void)stuff;
+@property (nonatomic, readonly, getter=isValid) BOOL valid;
+@property (nonatomic) NSString *name;
 @end

--- a/test/IRGen/Inputs/usr/include/Gizmo.h
+++ b/test/IRGen/Inputs/usr/include/Gizmo.h
@@ -160,9 +160,8 @@ __attribute__((swift_name("OuterType.InnerType")))
 @interface OuterTypeInnerType : NSObject<NSRuncing>
 @end
 
-typedef signed char BOOL;
 @protocol P
 - (oneway void)stuff;
-@property (nonatomic, readonly, getter=isValid) BOOL valid;
+@property (nonatomic, readonly, getter=isValid) signed char valid;
 @property (nonatomic) NSString *name;
 @end

--- a/test/IRGen/objc_type_encoding.swift
+++ b/test/IRGen/objc_type_encoding.swift
@@ -166,6 +166,23 @@ import gizmo
   func subclassComposition(_: MyCustomObject & NSRuncing & NSFunging)
 }
 
+class C: P {
+  func stuff() {}
+
+  var isValid: Bool { return false }
+  var name: String? {
+    get {
+      return ""
+    }
+    set {}
+  }
+}
+
+// Make sure that the protocol method list's number of entries and the
+// protocols's method extended type encoding list agree in the presence of
+// properties.
+
+// CHECK-macosx: @_PROTOCOL_P = private constant {{.*}} { i32, i32, [4 x { i8*, i8*, i8* }] }* @_PROTOCOL_INSTANCE_METHODS_P,  {{.*}} [4 x i8*]* @_PROTOCOL_METHOD_TYPES_P
 
 // CHECK-macosx: [[ENC1:@.*]] = private unnamed_addr constant [35 x i8] c"v24@0:8@\22<NSFunging><NSRuncing>\2216\00"
 // CHECK-macosx: [[ENC2:@.*]] = private unnamed_addr constant [46 x i8] c"v32@0:8@\22Gizmo\2216@?<v@?@\22NSView\22@\22NSSpoon\22>24\00"
@@ -183,9 +200,6 @@ import gizmo
 // CHECK-tvos: [[ENC4:@.*]] = private unnamed_addr constant [75 x i8] c"v24@0:8@\22_TtC18objc_type_encoding14MyCustomObject<NSFunging><NSRuncing>\2216\00"
 // CHECK-tvos: @_PROTOCOL_METHOD_TYPES__TtP18objc_type_encoding10MyProtocol_ = private constant [4 x i8*] [i8* getelementptr inbounds ([35 x i8], [35 x i8]* [[ENC1]], i64 0, i64 0), i8* getelementptr inbounds ([46 x i8], [46 x i8]* [[ENC2]], i64 0, i64 0), i8* getelementptr inbounds ([53 x i8], [53 x i8]* [[ENC3]], i64 0, i64 0), i8* getelementptr inbounds ([75 x i8], [75 x i8]* [[ENC4]], i64 0, i64 0)]
 
-class C: P {
-  func stuff() {}
-}
 
 // CHECK-macosx: [[ENC5:@.*]] = private unnamed_addr constant [9 x i8] c"Vv16@0:8\00"
 // CHECK-macosx: @_PROTOCOL_INSTANCE_METHODS_P = {{.*}}@"\01L_selector_data(stuff)"{{.*}}[[ENC5]]{{.*}}, section "__DATA, __objc_const", align 8

--- a/test/IRGen/objc_type_encoding.swift
+++ b/test/IRGen/objc_type_encoding.swift
@@ -168,6 +168,7 @@ import gizmo
 
 class C: P {
   func stuff() {}
+  static func classStuff() {}
 
   var valid: Int8 { return 0 }
   var name: String? {
@@ -176,13 +177,53 @@ class C: P {
     }
     set {}
   }
+  static var className : String {
+    return ""
+  }
 }
 
+@objc protocol Q {
+  func stuff()
+  static func classStuff()
+  var valid: Int8 { get }
+  var name: String? {
+    get set
+  }
+  static var className : String {
+    get
+  }
+  @objc optional static func optionalClassStuff()
+  @objc optional var optionalValid: Int8 { get }
+  @objc optional var optionalName: String? {
+    get
+  }
+  @objc optional static var optionalClassName : String {
+    get
+  }
+}
+
+class K: Q {
+  func stuff() {}
+  static func classStuff() {}
+  var valid: Int8 { return 0 }
+  var name: String? {
+    get {
+      return ""
+    }
+    set {}
+  }
+  static var className : String {
+    return ""
+  }
+}
 // Make sure that the protocol method list's number of entries and the
 // protocols's method extended type encoding list agree in the presence of
 // properties.
+// 4 (_PROTOCOL_INSTANCE_METHODS_P) + 2 (_PROTOCOL_CLASS_METHODS_P) + 2(_PROTOCOL_INSTANCE_METHODS_OPT_P) + 2 (_PROTOCOL_CLASS_METHODS_OPT_P) == 10 (_PROTOCOL_METHOD_TYPES_P)
 
-// CHECK-macosx: @_PROTOCOL_P = private constant {{.*}} { i32, i32, [4 x { i8*, i8*, i8* }] }* @_PROTOCOL_INSTANCE_METHODS_P,  {{.*}} [4 x i8*]* @_PROTOCOL_METHOD_TYPES_P
+// CHECK-macosx: @_PROTOCOL_P = private constant {{.*}} [4 x { i8*, i8*, i8* }] }* @_PROTOCOL_INSTANCE_METHODS_P, { i32, i32, [2 x { i8*, i8*, i8* }] }* @_PROTOCOL_CLASS_METHODS_P, { i32, i32, [2 x { i8*, i8*, i8* }] }* @_PROTOCOL_INSTANCE_METHODS_OPT_P, { i32, i32, [2 x { i8*, i8*, i8* }] }* @_PROTOCOL_CLASS_METHODS_OPT_P, { i32, i32, [3 x { i8*, i8* }] }* @_PROTOCOL_PROPERTIES_P, i32 96, i32 0, [10 x i8*]* @_PROTOCOL_METHOD_TYPES_P
+
+// CHECK-macosx: @_PROTOCOL__TtP18objc_type_encoding1Q_ = {{.*}} { i32, i32, [4 x { i8*, i8*, i8* }] }* @_PROTOCOL_INSTANCE_METHODS__TtP18objc_type_encoding1Q_, { i32, i32, [2 x { i8*, i8*, i8* }] }* @_PROTOCOL_CLASS_METHODS__TtP18objc_type_encoding1Q_, { i32, i32, [2 x { i8*, i8*, i8* }] }* @_PROTOCOL_INSTANCE_METHODS_OPT__TtP18objc_type_encoding1Q_, { i32, i32, [2 x { i8*, i8*, i8* }] }* @_PROTOCOL_CLASS_METHODS_OPT__TtP18objc_type_encoding1Q_, { i32, i32, [4 x { i8*, i8* }] }* @_PROTOCOL_PROPERTIES__TtP18objc_type_encoding1Q_, i32 96, i32 1, [10 x i8*]* @_PROTOCOL_METHOD_TYPES__TtP18objc_type_encoding1Q_
 
 // CHECK-macosx: [[ENC1:@.*]] = private unnamed_addr constant [35 x i8] c"v24@0:8@\22<NSFunging><NSRuncing>\2216\00"
 // CHECK-macosx: [[ENC2:@.*]] = private unnamed_addr constant [46 x i8] c"v32@0:8@\22Gizmo\2216@?<v@?@\22NSView\22@\22NSSpoon\22>24\00"

--- a/test/IRGen/objc_type_encoding.swift
+++ b/test/IRGen/objc_type_encoding.swift
@@ -169,7 +169,7 @@ import gizmo
 class C: P {
   func stuff() {}
 
-  var isValid: Bool { return false }
+  var valid: Int8 { return 0 }
   var name: String? {
     get {
       return ""


### PR DESCRIPTION
We were still emitting duplicate setters/getters in the method list but
not in the method type encoding list.
The two need to be in-sync.

rdar://60888524
