### PR TITLE
[Diagnostics] Support diagnosing references to operators without argument application

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -520,10 +520,11 @@ bool MissingConformanceFailure::diagnoseAsAmbiguousOperatorRef() {
   // about missing conformance just in case.
   auto operatorID = name.getIdentifier();
 
-  auto *applyExpr = cast<ApplyExpr>(findParentExpr(anchor));
-  if (auto *binaryOp = dyn_cast<BinaryExpr>(applyExpr)) {
-    auto lhsType = getType(binaryOp->getArg()->getElement(0));
-    auto rhsType = getType(binaryOp->getArg()->getElement(1));
+  auto *fnType = getType(anchor)->getAs<AnyFunctionType>();
+  auto params = fnType->getParams();
+  if (params.size() == 2) {
+    auto lhsType = params[0].getPlainType();
+    auto rhsType = params[1].getPlainType();
 
     if (lhsType->isEqual(rhsType)) {
       emitDiagnostic(anchor->getLoc(), diag::cannot_apply_binop_to_same_args,
@@ -534,7 +535,7 @@ bool MissingConformanceFailure::diagnoseAsAmbiguousOperatorRef() {
     }
   } else {
     emitDiagnostic(anchor->getLoc(), diag::cannot_apply_unop_to_arg,
-                   operatorID.str(), getType(applyExpr->getArg()));
+                   operatorID.str(), params[0].getPlainType());
   }
 
   diagnoseAsNote();

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -265,3 +265,10 @@ func rdar_60185506() {
     let _ = (x?.foo ?? 0) <= 0.5 // Ok
   }
 }
+
+// rdar://problem/60727310
+func rdar60727310() {
+  func myAssertion<T>(_ a: T, _ op: ((T,T)->Bool), _ b: T) {}
+  var e: Error? = nil
+  myAssertion(e, ==, nil) // expected-error {{binary operator '==' cannot be applied to two 'Error?' operands}}
+}


### PR DESCRIPTION
in `MissingConformanceFailure::diagnoseAsAmbiguousOperatorRef`

When there's an ambiguous operator reference that manifests as a missing conformance failure, such as:
```swift
func myAssertion<T>(_ a: T, _ op: ((T,T)->Bool), _ b: T) {}
var e: Error? = nil
myAssertion(e, ==, nil)
```
This previously would crash because the code assumed the parent of the operator ref was an `ApplyExpr`. 

This will also print a note pointing to the candidate with the conformance requirement.

Resolves: rdar://problem/60727310