### PR TITLE
[test] Add indentation regression test.

### DIFF
--- a/test/swift-indent/basic.swift
+++ b/test/swift-indent/basic.swift
@@ -326,6 +326,15 @@ var array: [String] = {
             "two"]
 }()
 #endif
+#if os(iOS)
+var source: String? {
+    if true {
+        if otherCondition {
+            return "true"
+        }
+    }
+}
+#endif
 
 
 // Comments should not affect switch case indentations.


### PR DESCRIPTION
swift-5.2-branch doesn't indent the contents of var decl accessor blocks if the var decl is a direct child of an ifconfig decl on swift-5.2-branch:
```
#if os(iOS)
var source: String? {
    if true {
    if otherCondition {
    return "true"
    }
    }
}
#endif
```
It works correctly on master after the recent indentation overhaul, but we didn't have a test covering that specific case, so adding it here.

Resolves rdar://problem/60292681