### PR TITLE
[ConstraintSystem] Don't check `-disable-availability-checking`

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4369,9 +4369,6 @@ bool ConstraintSystem::isDeclUnavailable(const Decl *D,
                                          ConstraintLocator *locator) const {
   auto &ctx = getASTContext();
 
-  if (ctx.LangOpts.DisableAvailabilityChecking)
-    return false;
-
   // First check whether this declaration is universally unavailable.
   if (D->getAttrs().isUnavailable(ctx))
     return true;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4381,8 +4381,8 @@ bool ConstraintSystem::isDeclUnavailable(const Decl *D,
   }
 
   // If not, let's check contextual unavailability.
-  AvailabilityContext result = AvailabilityContext::alwaysAvailable();
-  return !TypeChecker::isDeclAvailable(D, loc, DC, result);
+  auto result = TypeChecker::checkDeclarationAvailability(D, loc, DC);
+  return result.hasValue();
 }
 
 /// If we aren't certain that we've emitted a diagnostic, emit a fallback

--- a/test/Constraints/rdar60898369.swift
+++ b/test/Constraints/rdar60898369.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -swift-version 5
+
+struct S {
+  @available(swift, obsoleted: 4.2)
+  init(foo: Int) throws {}
+
+  @available(swift, introduced: 4.2)
+  init?(foo: Int) throws {}
+}
+
+_ = try S(foo: 42)


### PR DESCRIPTION
Checking for `-disable-availability-checking` in
`ConstraintSystem::isDeclUnavailable` caused a regression with
obsolete/introduced checking. Let's rely on
`DeclAttributes::isUnavailable` and `TypeChecker::isDeclAvailable`
to do the right thing instead.

Resolves: rdar://problem/60898369

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
