### PR TITLE
[Property wrappers] Allow default initialization to infer a type.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2186,6 +2186,9 @@ public:
   /// Can the pattern at index i be default initialized?
   bool isDefaultInitializable(unsigned i) const;
 
+  /// Can the property wrapper be used to provide default initialization?
+  bool isDefaultInitializableViaPropertyWrapper(unsigned i) const;
+
   /// Does this pattern have a user-provided initializer expression?
   bool isExplicitlyInitialized(unsigned i) const;
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5119,15 +5119,17 @@ public:
   void setTopLevelGlobal(bool b) { Bits.VarDecl.IsTopLevelGlobal = b; }
   
   /// Retrieve the custom attributes that attach property wrappers to this
-  /// property. The returned list contains all of the attached property wrapper attributes in source order,
-  /// which means the outermost wrapper attribute is provided first.
+  /// property. The returned list contains all of the attached property wrapper
+  /// attributes in source order, which means the outermost wrapper attribute
+  /// is provided first.
   llvm::TinyPtrVector<CustomAttr *> getAttachedPropertyWrappers() const;
 
   /// Whether this property has any attached property wrappers.
   bool hasAttachedPropertyWrapper() const;
   
-  /// Whether all of the attached property wrappers have an init(initialValue:) initializer.
-  bool allAttachedPropertyWrappersHaveInitialValueInit() const;
+  /// Whether all of the attached property wrappers have an init(wrappedValue:)
+  /// initializer.
+  bool allAttachedPropertyWrappersHaveWrappedValueInit() const;
   
   /// Retrieve the type of the attached property wrapper as a contextual
   /// type.
@@ -5191,7 +5193,7 @@ public:
   /// \end
   ///
   /// Or when there is no initializer but each composed property wrapper has
-  /// a suitable `init(initialValue:)`.
+  /// a suitable `init(wrappedValue:)`.
   bool isPropertyMemberwiseInitializedWithWrappedType() const;
 
   /// Whether the innermost property wrapper's initializer's 'wrappedValue' parameter

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1878,11 +1878,11 @@ bool PatternBindingDecl::isDefaultInitializable(unsigned i) const {
   if (isDefaultInitializableViaPropertyWrapper(i))
     return true;
 
-  // If one of the attached wrappers is missing an initialValue
+  // If one of the attached wrappers is missing a wrappedValue
   // initializer, cannot default-initialize.
   if (auto singleVar = getSingleVar()) {
     if (auto wrapperInfo = singleVar->getAttachedPropertyWrapperTypeInfo(0)) {
-      if (!singleVar->allAttachedPropertyWrappersHaveInitialValueInit())
+      if (!singleVar->allAttachedPropertyWrappersHaveWrappedValueInit())
         return false;
     }
   }
@@ -5833,7 +5833,7 @@ bool VarDecl::hasAttachedPropertyWrapper() const {
 
 /// Whether all of the attached property wrappers have an init(wrappedValue:)
 /// initializer.
-bool VarDecl::allAttachedPropertyWrappersHaveInitialValueInit() const {
+bool VarDecl::allAttachedPropertyWrappersHaveWrappedValueInit() const {
   for (unsigned i : indices(getAttachedPropertyWrappers())) {
     if (!getAttachedPropertyWrapperTypeInfo(i).wrappedValueInit)
       return false;
@@ -5938,7 +5938,7 @@ bool VarDecl::isPropertyMemberwiseInitializedWithWrappedType() const {
 
   // If all property wrappers have a wrappedValue initializer, the property
   // wrapper will be initialized that way.
-  return allAttachedPropertyWrappersHaveInitialValueInit();
+  return allAttachedPropertyWrappersHaveWrappedValueInit();
 }
 
 bool VarDecl::isInnermostPropertyWrapperInitUsesEscapingAutoClosure() const {

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -516,8 +516,10 @@ PatternBindingDecl *ContextualPattern::getPatternBindingDecl() const {
 }
 
 bool ContextualPattern::allowsInference() const {
-  if (auto pbd = getPatternBindingDecl())
-    return pbd->isInitialized(index);
+  if (auto pbd = getPatternBindingDecl()) {
+    return pbd->isInitialized(index) ||
+        pbd->isDefaultInitializableViaPropertyWrapper(index);
+  }
 
   return true;
 }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4182,7 +4182,7 @@ void SolutionApplicationTarget::maybeApplyPropertyWrapper() {
   if (Expr *initializer = expression.expression) {
     // Form init(wrappedValue:) call(s).
     Expr *wrappedInitializer =
-        buildPropertyWrapperInitialValueCall(
+        buildPropertyWrapperWrappedValueCall(
             singleVar, Type(), initializer, /*ignoreAttributeArgs=*/false);
     if (!wrappedInitializer)
       return;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4188,11 +4188,20 @@ void SolutionApplicationTarget::maybeApplyPropertyWrapper() {
       return;
 
     backingInitializer = wrappedInitializer;
-  } else if (auto outermostArg = outermostWrapperAttr->getArg()) {
+  } else {
     Type outermostWrapperType =
         singleVar->getAttachedPropertyWrapperType(0);
     if (!outermostWrapperType)
       return;
+
+    // Retrieve the outermost wrapper argument. If there isn't one, we're
+    // performing default initialization.
+    auto outermostArg = outermostWrapperAttr->getArg();
+    if (!outermostArg) {
+      SourceLoc fakeParenLoc = outermostWrapperAttr->getRange().End;
+      outermostArg = TupleExpr::createEmpty(
+          ctx, fakeParenLoc, fakeParenLoc, /*Implicit=*/true);
+    }
 
     auto typeExpr = TypeExpr::createImplicitHack(
         outermostWrapperAttr->getTypeLoc().getLoc(),
@@ -4203,8 +4212,6 @@ void SolutionApplicationTarget::maybeApplyPropertyWrapper() {
         outermostWrapperAttr->getArgumentLabelLocs(),
         /*hasTrailingClosure=*/false,
         /*implicit=*/false);
-  } else {
-    llvm_unreachable("No initializer anywhere?");
   }
   wrapperAttrs[0]->setSemanticInit(backingInitializer);
 

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -28,7 +28,8 @@ using namespace swift;
 
 /// The kind of property initializer to look for
 enum class PropertyWrapperInitKind {
-  /// An initial-value initializer (i.e. `init(initialValue:)`)
+  /// An initial-value initializer (i.e. `init(initialValue:)`), which is
+  /// deprecated.
   InitialValue,
   /// An wrapped-value initializer (i.e. `init(wrappedValue:)`)
   WrappedValue,
@@ -684,7 +685,7 @@ static bool isOpaquePlaceholderClosure(const Expr *value) {
   return false;
 }
 
-Expr *swift::buildPropertyWrapperInitialValueCall(
+Expr *swift::buildPropertyWrapperWrappedValueCall(
     VarDecl *var, Type backingStorageType, Expr *value,
     bool ignoreAttributeArgs) {
   // From the innermost wrapper type out, form init(wrapperValue:) calls.

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2463,7 +2463,7 @@ PropertyWrapperBackingPropertyInfoRequest::evaluate(Evaluator &evaluator,
   }
   
   // Get the property wrapper information.
-  if (!var->allAttachedPropertyWrappersHaveInitialValueInit() &&
+  if (!var->allAttachedPropertyWrappersHaveWrappedValueInit() &&
       !originalInitialValue) {
     return PropertyWrapperBackingPropertyInfo(
         backingVar, storageVar, nullptr, nullptr, nullptr);
@@ -2477,7 +2477,7 @@ PropertyWrapperBackingPropertyInfoRequest::evaluate(Evaluator &evaluator,
   OpaqueValueExpr *origValue =
       new (ctx) OpaqueValueExpr(var->getSourceRange(), origValueType,
                                 /*isPlaceholder=*/true);
-  Expr *initializer = buildPropertyWrapperInitialValueCall(
+  Expr *initializer = buildPropertyWrapperWrappedValueCall(
       var, storageType, origValue,
       /*ignoreAttributeArgs=*/!originalInitialValue);
   typeCheckSynthesizedWrapperInitializer(

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -199,23 +199,9 @@ PatternBindingEntryRequest::evaluate(Evaluator &eval,
     }
   }
 
-  // Check the pattern. We treat type-checking a PatternBindingDecl like
-  // type-checking an expression because that's how the initial binding is
-  // checked, and they have the same effect on the file's dependencies.
-  //
-  // In particular, it's /not/ correct to check the PBD's DeclContext because
-  // top-level variables in a script file are accessible from other files,
-  // even though the PBD is inside a TopLevelCodeDecl.
+  // Check the pattern.
   auto contextualPattern =
       ContextualPattern::forPatternBindingDecl(binding, entryNumber);
-  TypeResolutionOptions options(TypeResolverContext::PatternBindingDecl);
-
-  if (binding->isInitialized(entryNumber)) {
-    // If we have an initializer, we can also have unknown types.
-    options |= TypeResolutionFlags::AllowUnspecifiedTypes;
-    options |= TypeResolutionFlags::AllowUnboundGenerics;
-  }
-
   Type patternType = TypeChecker::typeCheckPattern(contextualPattern);
   if (patternType->hasError()) {
     swift::setBoundVarsTypeError(pattern, Context);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1486,7 +1486,7 @@ Type computeWrappedValueType(VarDecl *var, Type backingStorageType,
   
 /// Build a call to the init(wrappedValue:) initializers of the property
 /// wrappers, filling in the given \c value as the original value.
-Expr *buildPropertyWrapperInitialValueCall(VarDecl *var,
+Expr *buildPropertyWrapperWrappedValueCall(VarDecl *var,
                                            Type backingStorageType,
                                            Expr *value,
                                            bool ignoreAttributeArgs);

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1877,7 +1877,7 @@ open class OpenPropertyWrapperWithPublicInit {
   public init(wrappedValue: String) { // Okay
     self.wrappedValue = wrappedValue
   }
-  
+
   open var wrappedValue: String = "Hello, world"
 }
 
@@ -1895,3 +1895,28 @@ func sr_11654_generic_func<T>(_ argument: T?) -> T? {
 
 let sr_11654_c = SR_11654_C()
 _ = sr_11654_generic_func(sr_11654_c.property) // Okay
+
+// rdar://problem/59471019 - property wrapper initializer requires empty parens
+// for default init
+@propertyWrapper
+struct DefaultableIntWrapper {
+  var wrappedValue: Int
+
+  init() {
+    self.wrappedValue = 0
+  }
+}
+
+struct TestDefaultableIntWrapper {
+  @DefaultableIntWrapper var x
+  @DefaultableIntWrapper() var y
+  @DefaultableIntWrapper var z: Int
+
+  mutating func test() {
+    x = y
+    y = z
+  }
+}
+
+
+


### PR DESCRIPTION
Property wrappers are allowed to infer the type of a variable, but this
only worked when the property wrapper was provided with an explicit
initialization, e.g.,

    @WrapsAnInt() var x   // infers type Int from WrapsAnInt.wrappedValue

However, when default initialization is supported by the property wrapper,
dropping the parentheses would produce an error about the missing type
annotation

    @WrapsAnInt var x

Make this second case behave like the first, so that default initialization
works consistently with the explicitly-specified version.
Fixes rdar://problem/59471019.