### PR TITLE
Mark the XCTest overlay as obsolete & stop running its test

### DIFF
--- a/stdlib/public/Darwin/XCTest/XCTest.swift
+++ b/stdlib/public/Darwin/XCTest/XCTest.swift
@@ -2,13 +2,24 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
+// The actual XCTest overlay is not maintained in this repository -- it is
+// distributed in Xcode (libXCTestSwiftSupport.dylib), along with
+// XCTest.framework itself.
+//
+// The codebase here builds the obsolete /usr/lib/swift/libswiftXCTest.dylib
+// that currently ships in the OS. There is no expectation that that library is
+// usable for anything; it only exists to maintain a superficial level of binary
+// compatibility with existing apps that happen to link to it by mistake.
+//
+// rdar://problem/55270944
 
 @_exported import XCTest // Clang module
 

--- a/stdlib/public/Darwin/XCTest/XCTestCaseAdditions.mm
+++ b/stdlib/public/Darwin/XCTest/XCTestCaseAdditions.mm
@@ -2,13 +2,24 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
+// The actual XCTest overlay is not maintained in this repository -- it is
+// distributed in Xcode (libXCTestSwiftSupport.dylib), along with
+// XCTest.framework itself.
+//
+// The codebase here builds the obsolete /usr/lib/swift/libswiftXCTest.dylib
+// that currently ships in the OS. There is no expectation that that library is
+// usable for anything; it only exists to maintain a superficial level of binary
+// compatibility with existing apps that happen to link to it by mistake.
+//
+// rdar://problem/55270944
 
 #import <XCTest/XCTest.h>
 #include "swift/Runtime/Metadata.h"

--- a/validation-test/stdlib/XCTest.swift
+++ b/validation-test/stdlib/XCTest.swift
@@ -1,7 +1,20 @@
 // RUN: rm -rf %t ; mkdir -p %t
-// RUN: %target-build-swift %s -o %t/a.out -swift-version 4 && %target-run %t/a.out
+// RUN: %target-build-swift %s -o %t/a.out -swift-version 4
 
-// REQUIRES: executable_test
+// The actual XCTest overlay is not maintained in this repository -- it is
+// distributed in Xcode (libXCTestSwiftSupport.dylib), along with
+// XCTest.framework itself.
+//
+// The codebase here builds the obsolete /usr/lib/swift/libswiftXCTest.dylib
+// that currently ships in the OS. There is no expectation that that library is
+// usable for anything; it only exists to maintain a superficial level of binary
+// compatibility with existing apps that happen to link to it by mistake.
+//
+// Accordingly, this test is now a build-only test. The code here is only
+// compiled, it is never run.
+//
+// rdar://problem/55270944
+
 // REQUIRES: objc_interop
 
 // FIXME: Add a feature for "platforms that support XCTest".


### PR DESCRIPTION
The actual XCTest overlay is not maintained in this repository -- it is distributed in Xcode (libXCTestSwiftSupport.dylib), along with XCTest.framework itself.

The codebase here builds the obsolete /usr/lib/swift/libswiftXCTest.dylib that currently ships in the OSes. There is no expectation that that library is usable for anything; it only exists to maintain a superficial level of binary compatibility with existing apps that happen to link to it by mistake.

Add notes explaining this to the XCTest sources and stop running the XCTest test in the validation suite. (It is causing spurious build timeouts on ci.swift.org due to what looks like a bad interaction between StdlibUnittest and XCTest.)

Fixes rdar://59486106