### PR TITLE
[NFC] A Handful of Sweeping Evaluator Cleanups

### DIFF
--- a/include/swift/AST/AccessRequests.h
+++ b/include/swift/AST/AccessRequests.h
@@ -41,8 +41,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<AccessLevel> evaluate(Evaluator &evaluator,
-                                       ValueDecl *decl) const;
+  AccessLevel evaluate(Evaluator &evaluator, ValueDecl *decl) const;
 
 public:
   // Separate caching.
@@ -65,8 +64,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<AccessLevel>
-  evaluate(Evaluator &evaluator, AbstractStorageDecl *decl) const;
+  AccessLevel evaluate(Evaluator &evaluator, AbstractStorageDecl *decl) const;
 
 public:
   // Separate caching.
@@ -88,8 +86,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<DefaultAndMax>
-  evaluate(Evaluator &evaluator, ExtensionDecl *decl) const;
+  DefaultAndMax evaluate(Evaluator &evaluator, ExtensionDecl *decl) const;
 
 public:
   // Separate caching.

--- a/include/swift/AST/Evaluator.h
+++ b/include/swift/AST/Evaluator.h
@@ -54,7 +54,7 @@ using AbstractRequestFunction = void(void);
 /// Form the specific request function for the given request type.
 template<typename Request>
 using RequestFunction =
-  llvm::Expected<typename Request::OutputType>(const Request &, Evaluator &);
+  typename Request::OutputType(const Request &, Evaluator &);
 
 /// Pretty stack trace handler for an arbitrary request.
 template<typename Request>

--- a/include/swift/AST/IRGenRequests.h
+++ b/include/swift/AST/IRGenRequests.h
@@ -124,7 +124,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<std::unique_ptr<llvm::Module>>
+  std::unique_ptr<llvm::Module>
   evaluate(Evaluator &evaluator, IRGenDescriptor desc) const;
 
 public:
@@ -142,7 +142,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<std::unique_ptr<llvm::Module>>
+  std::unique_ptr<llvm::Module>
   evaluate(Evaluator &evaluator, IRGenDescriptor desc) const;
 
 public:

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -153,7 +153,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<ClassDecl *>
+  ClassDecl *
   evaluate(Evaluator &evaluator, NominalTypeDecl *subject) const;
 
 public:
@@ -197,7 +197,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool>
+  bool
   evaluate(Evaluator &evaluator, ClassDecl *subject) const;
 
 public:
@@ -219,7 +219,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<NominalTypeDecl *>
+  NominalTypeDecl *
   evaluate(Evaluator &evaluator, ExtensionDecl *ext) const;
 
 public:
@@ -283,7 +283,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<NominalTypeDecl *>
+  NominalTypeDecl *
   evaluate(Evaluator &evaluator, CustomAttr *attr, DeclContext *dc) const;
 
 public:
@@ -303,7 +303,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<DestructorDecl *>
+  DestructorDecl *
   evaluate(Evaluator &evaluator, ClassDecl *classDecl) const;
 
 public:
@@ -324,7 +324,7 @@ private:
   friend SimpleRequest;
   
   // Evaluation.
-  llvm::Expected<GenericParamList *>
+  GenericParamList *
   evaluate(Evaluator &evaluator, GenericContext *value) const;
   
 public:
@@ -347,7 +347,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<ast_scope::ASTScopeImpl *>
+  ast_scope::ASTScopeImpl *
   evaluate(Evaluator &evaluator, ast_scope::ASTScopeImpl *,
            ast_scope::ScopeCreator *) const;
 
@@ -407,8 +407,8 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<LookupResult> evaluate(Evaluator &evaluator,
-                                        UnqualifiedLookupDescriptor desc) const;
+  LookupResult evaluate(Evaluator &evaluator,
+                        UnqualifiedLookupDescriptor desc) const;
 };
 
 using QualifiedLookupResult = SmallVector<ValueDecl *, 4>;
@@ -427,7 +427,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<QualifiedLookupResult>
+  QualifiedLookupResult
   evaluate(Evaluator &evaluator, const DeclContext *moduleOrFile, DeclName name,
            NLKind lookupKind, namelookup::ResolutionKind resolutionKind,
            const DeclContext *moduleScopeContext) const;
@@ -445,10 +445,10 @@ public:
 private:
   friend SimpleRequest;
 
-  llvm::Expected<QualifiedLookupResult> evaluate(Evaluator &evaluator,
-                                                 const DeclContext *dc,
-                                                 DeclNameRef name,
-                                                 NLOptions options) const;
+  QualifiedLookupResult evaluate(Evaluator &evaluator,
+                                 const DeclContext *dc,
+                                 DeclNameRef name,
+                                 NLOptions options) const;
 };
 
 class ModuleQualifiedLookupRequest
@@ -464,10 +464,10 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<QualifiedLookupResult> evaluate(Evaluator &evaluator,
-                                                 const DeclContext *DC,
-                                                 ModuleDecl *mod, DeclNameRef name,
-                                                 NLOptions opts) const;
+  QualifiedLookupResult evaluate(Evaluator &evaluator,
+                                 const DeclContext *DC,
+                                 ModuleDecl *mod, DeclNameRef name,
+                                 NLOptions opts) const;
 };
 
 class QualifiedLookupRequest
@@ -483,7 +483,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<QualifiedLookupResult>
+  QualifiedLookupResult
   evaluate(Evaluator &evaluator, const DeclContext *DC,
            SmallVector<NominalTypeDecl *, 4> decls,
            DeclNameRef name,
@@ -534,7 +534,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<TinyPtrVector<ValueDecl *>>
+  TinyPtrVector<ValueDecl *>
   evaluate(Evaluator &evaluator, DirectLookupDescriptor desc) const;
 };
 
@@ -609,8 +609,8 @@ private:
                        CacheKind::Uncached>;
 
   // Evaluation.
-  llvm::Expected<OperatorType *> evaluate(Evaluator &evaluator,
-                                          OperatorLookupDescriptor desc) const;
+  OperatorType *
+  evaluate(Evaluator &evaluator, OperatorLookupDescriptor desc) const;
 };
 
 using LookupPrefixOperatorRequest = LookupOperatorRequest<PrefixOperatorDecl>;
@@ -631,7 +631,7 @@ public:
 private:
   friend SimpleRequest;
 
-  llvm::Expected<TinyPtrVector<OperatorDecl *>>
+  TinyPtrVector<OperatorDecl *>
   evaluate(Evaluator &evaluator, OperatorLookupDescriptor descriptor,
            OperatorFixity fixity) const;
 };
@@ -649,7 +649,7 @@ public:
 private:
   friend SimpleRequest;
 
-  llvm::Expected<TinyPtrVector<PrecedenceGroupDecl *>>
+  TinyPtrVector<PrecedenceGroupDecl *>
   evaluate(Evaluator &evaluator, OperatorLookupDescriptor descriptor) const;
 };
 
@@ -694,7 +694,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<ProtocolConformanceRef> evaluate(
+  ProtocolConformanceRef evaluate(
       Evaluator &evaluator, LookupConformanceDescriptor desc) const;
 };
 

--- a/include/swift/AST/SILGenRequests.h
+++ b/include/swift/AST/SILGenRequests.h
@@ -89,7 +89,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<std::unique_ptr<SILModule>>
+  std::unique_ptr<SILModule>
   evaluate(Evaluator &evaluator, SILGenDescriptor desc) const;
 
 public:
@@ -107,7 +107,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<std::unique_ptr<SILModule>>
+  std::unique_ptr<SILModule>
   evaluate(Evaluator &evaluator, SILGenDescriptor desc) const;
 
 public:

--- a/include/swift/AST/SILOptimizerRequests.h
+++ b/include/swift/AST/SILOptimizerRequests.h
@@ -50,7 +50,7 @@ llvm::hash_code hash_value(const SILPipelineExecutionDescriptor &desc);
 /// Executes a SIL pipeline plan on a SIL module.
 class ExecuteSILPipelineRequest
     : public SimpleRequest<ExecuteSILPipelineRequest,
-                           bool(SILPipelineExecutionDescriptor),
+                           evaluator::SideEffect(SILPipelineExecutionDescriptor),
                            CacheKind::Uncached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -59,8 +59,8 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator,
-                                SILPipelineExecutionDescriptor desc) const;
+  llvm::Expected<evaluator::SideEffect>
+  evaluate(Evaluator &evaluator, SILPipelineExecutionDescriptor desc) const;
 };
 
 void simple_display(llvm::raw_ostream &out,

--- a/include/swift/AST/SILOptimizerRequests.h
+++ b/include/swift/AST/SILOptimizerRequests.h
@@ -59,7 +59,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<evaluator::SideEffect>
+  evaluator::SideEffect
   evaluate(Evaluator &evaluator, SILPipelineExecutionDescriptor desc) const;
 };
 

--- a/include/swift/AST/SILOptimizerTypeIDZone.def
+++ b/include/swift/AST/SILOptimizerTypeIDZone.def
@@ -15,4 +15,5 @@
 //===----------------------------------------------------------------------===//
 
 SWIFT_REQUEST(SILOptimizer, ExecuteSILPipelineRequest,
-              bool(SILPipelineExecutionDescriptor), Uncached, NoLocationInfo)
+              evaluator::SideEffect(SILPipelineExecutionDescriptor),
+              Uncached, NoLocationInfo)

--- a/include/swift/AST/SimpleRequest.h
+++ b/include/swift/AST/SimpleRequest.h
@@ -148,9 +148,9 @@ SourceLoc extractNearestSourceLoc(const std::tuple<First, Rest...> &value) {
 ///
 /// The \c Derived class needs to implement several operations. The most
 /// important one takes an evaluator and the input values, then computes the
-/// final result, optionally bubbling up errors from recursive evaulations:
+/// final result:
 /// \code
-///   llvm::Expected<Output> evaluate(Evaluator &evaluator, Inputs...) const;
+///   Output evaluate(Evaluator &evaluator, Inputs...) const;
 /// \endcode
 ///
 /// Cycle diagnostics can be handled in one of two ways. Either the \c Derived
@@ -194,7 +194,7 @@ class SimpleRequest<Derived, Output(Inputs...), Caching> {
   }
 
   template<size_t ...Indices>
-  llvm::Expected<Output>
+  Output
   callDerived(Evaluator &evaluator, std::index_sequence<Indices...>) const {
     static_assert(sizeof...(Indices) > 0, "Subclass must define evaluate()");
     return asDerived().evaluate(evaluator, std::get<Indices>(storage)...);
@@ -214,7 +214,7 @@ public:
     : storage(inputs...) { }
 
   /// Request evaluation function that will be registered with the evaluator.
-  static llvm::Expected<OutputType>
+  static OutputType
   evaluateRequest(const Derived &request, Evaluator &evaluator) {
     return request.callDerived(evaluator,
                                std::index_sequence_for<Inputs...>());

--- a/include/swift/AST/TBDGenRequests.h
+++ b/include/swift/AST/TBDGenRequests.h
@@ -92,8 +92,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<TBDFileAndSymbols> evaluate(Evaluator &evaluator,
-                                             TBDGenDescriptor desc) const;
+  TBDFileAndSymbols evaluate(Evaluator &evaluator, TBDGenDescriptor desc) const;
 };
 
 /// Report that a request of the given kind is being evaluated, so it

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -74,7 +74,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<Type>
+  Type
   evaluate(Evaluator &evaluator,
            llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
            unsigned index,
@@ -102,7 +102,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<Type>
+  Type
   evaluate(Evaluator &evaluator, NominalTypeDecl *classDecl,
            TypeResolutionStage stage) const;
 
@@ -128,7 +128,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<Type>
+  Type
   evaluate(Evaluator &evaluator, EnumDecl *enumDecl,
            TypeResolutionStage stage) const;
 
@@ -155,7 +155,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<llvm::TinyPtrVector<ValueDecl *>>
+  llvm::TinyPtrVector<ValueDecl *>
   evaluate(Evaluator &evaluator, ValueDecl *decl) const;
 
 public:
@@ -177,7 +177,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator, ValueDecl *decl) const;
+  bool evaluate(Evaluator &evaluator, ValueDecl *decl) const;
 
 public:
   // Separate caching.
@@ -200,8 +200,8 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<CtorInitializerKind>
-      evaluate(Evaluator &evaluator, ConstructorDecl *decl) const;
+  CtorInitializerKind
+  evaluate(Evaluator &evaluator, ConstructorDecl *decl) const;
 
 public:
   // Caching.
@@ -220,7 +220,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator, ProtocolDecl *decl) const;
+  bool evaluate(Evaluator &evaluator, ProtocolDecl *decl) const;
 
 public:
   // Cycle handling.
@@ -246,7 +246,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator, ProtocolDecl *decl) const;
+  bool evaluate(Evaluator &evaluator, ProtocolDecl *decl) const;
 
 public:
   // Cycle handling.
@@ -272,7 +272,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator, ProtocolDecl *decl) const;
+  bool evaluate(Evaluator &evaluator, ProtocolDecl *decl) const;
 
 public:
   // Cycle handling.
@@ -297,7 +297,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator, ValueDecl *decl) const;
+  bool evaluate(Evaluator &evaluator, ValueDecl *decl) const;
 
 public:
   // Separate caching.
@@ -318,7 +318,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator, ValueDecl *decl) const;
+  bool evaluate(Evaluator &evaluator, ValueDecl *decl) const;
 
 public:
   // Separate caching.
@@ -339,8 +339,8 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<ArrayRef<Requirement>> evaluate(Evaluator &evaluator,
-                                                 ProtocolDecl *proto) const;
+  ArrayRef<Requirement>
+  evaluate(Evaluator &evaluator, ProtocolDecl *proto) const;
 
 public:
   // Separate caching.
@@ -361,7 +361,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<Type> evaluate(Evaluator &evaluator, AssociatedTypeDecl *decl) const;
+  Type evaluate(Evaluator &evaluator, AssociatedTypeDecl *decl) const;
 
 public:
   // Caching.
@@ -440,10 +440,10 @@ private:
   RequirementRepr &getRequirement() const;
 
   // Evaluation.
-  llvm::Expected<Requirement> evaluate(Evaluator &evaluator,
-                                       WhereClauseOwner,
-                                       unsigned index,
-                                       TypeResolutionStage stage) const;
+  Requirement evaluate(Evaluator &evaluator,
+                       WhereClauseOwner,
+                       unsigned index,
+                       TypeResolutionStage stage) const;
 
 public:
   // Source location
@@ -471,7 +471,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<std::string> evaluate(Evaluator &eval, const ValueDecl *d) const;
+  std::string evaluate(Evaluator &eval, const ValueDecl *d) const;
 
 public:
   // Caching
@@ -491,7 +491,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<std::string> evaluate(Evaluator &eval, const TypeDecl *d) const;
+  std::string evaluate(Evaluator &eval, const TypeDecl *d) const;
 
 public:
   // Caching
@@ -512,8 +512,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<Type> evaluate(Evaluator &eval, KnownProtocolKind,
-                                const DeclContext *) const;
+  Type evaluate(Evaluator &eval, KnownProtocolKind, const DeclContext *) const;
 
 public:
   // Caching
@@ -534,8 +533,8 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<PropertyWrapperTypeInfo>
-      evaluate(Evaluator &eval, NominalTypeDecl *nominal) const;
+  PropertyWrapperTypeInfo
+  evaluate(Evaluator &eval, NominalTypeDecl *nominal) const;
 
 public:
   // Caching
@@ -555,7 +554,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<llvm::TinyPtrVector<CustomAttr *>>
+  llvm::TinyPtrVector<CustomAttr *>
   evaluate(Evaluator &evaluator, VarDecl *) const;
 
 public:
@@ -576,7 +575,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<Type>
+  Type
   evaluate(Evaluator &evaluator, VarDecl *var, unsigned i) const;
 
 public:
@@ -597,7 +596,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<Type>
+  Type
   evaluate(Evaluator &evaluator, VarDecl *var) const;
 
 public:
@@ -617,7 +616,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<Optional<PropertyWrapperMutability>>
+  Optional<PropertyWrapperMutability>
   evaluate(Evaluator &evaluator, VarDecl *var) const;
 
 public:
@@ -638,7 +637,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<PropertyWrapperBackingPropertyInfo>
+  PropertyWrapperBackingPropertyInfo
   evaluate(Evaluator &evaluator, VarDecl *var) const;
 
 public:
@@ -658,7 +657,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<Type> evaluate(Evaluator &eval, TypeAliasDecl *d) const;
+  Type evaluate(Evaluator &eval, TypeAliasDecl *d) const;
 
 public:
   // Caching.
@@ -677,8 +676,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<ResilienceExpansion> evaluate(Evaluator &eval,
-                                               DeclContext *context) const;
+  ResilienceExpansion evaluate(Evaluator &eval, DeclContext *context) const;
 
 public:
   // Caching.
@@ -701,7 +699,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<CustomAttr *>
+  CustomAttr *
   evaluate(Evaluator &evaluator, ValueDecl *decl) const;
 
 public:
@@ -721,7 +719,7 @@ public:
 private:
   friend SimpleRequest;
 
-  llvm::Expected<Type>
+  Type
   evaluate(Evaluator &evaluator, ValueDecl *decl) const;
 
 public:
@@ -741,7 +739,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<SelfAccessKind>
+  SelfAccessKind
   evaluate(Evaluator &evaluator, FuncDecl *func) const;
 
 public:
@@ -763,7 +761,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool>
+  bool
   evaluate(Evaluator &evaluator, AbstractStorageDecl *func) const;
 
 public:
@@ -785,7 +783,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool>
+  bool
   evaluate(Evaluator &evaluator, AbstractStorageDecl *func) const;
 
 public:
@@ -807,7 +805,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<OpaqueReadOwnership>
+  OpaqueReadOwnership
   evaluate(Evaluator &evaluator, AbstractStorageDecl *storage) const;
 
 public:
@@ -829,7 +827,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<VarDecl *>
+  VarDecl *
   evaluate(Evaluator &evaluator, VarDecl *lazyVar) const;
 
 public:
@@ -852,7 +850,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool>
+  bool
   evaluate(Evaluator &evaluator, AbstractFunctionDecl *func,
            SourceLoc endTypeCheckLoc) const;
 
@@ -875,7 +873,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<ArrayRef<VarDecl *>>
+  ArrayRef<VarDecl *>
   evaluate(Evaluator &evaluator, NominalTypeDecl *decl) const;
 
 public:
@@ -899,7 +897,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<ArrayRef<Decl *>>
+  ArrayRef<Decl *>
   evaluate(Evaluator &evaluator, NominalTypeDecl *decl) const;
 
 public:
@@ -917,7 +915,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<StorageImplInfo>
+  StorageImplInfo
   evaluate(Evaluator &evaluator, AbstractStorageDecl *decl) const;
 
 public:
@@ -938,7 +936,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool>
+  bool
   evaluate(Evaluator &evaluator, VarDecl *decl) const;
 
 public:
@@ -959,7 +957,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool>
+  bool
   evaluate(Evaluator &evaluator, AbstractStorageDecl *decl) const;
 
 public:
@@ -980,7 +978,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool>
+  bool
   evaluate(Evaluator &evaluator, AccessorDecl *decl) const;
 
 public:
@@ -1002,7 +1000,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<AccessorDecl *>
+  AccessorDecl *
   evaluate(Evaluator &evaluator, AbstractStorageDecl *decl,
            AccessorKind kind) const;
 
@@ -1024,7 +1022,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<DeclRange>
+  DeclRange
   evaluate(Evaluator &evaluator, ClassDecl *classDecl) const;
 
 public:
@@ -1045,7 +1043,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool>
+  bool
   evaluate(Evaluator &evaluator, ValueDecl *value) const;
 
 public:
@@ -1066,8 +1064,9 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<AncestryFlags>
+  AncestryFlags
   evaluate(Evaluator &evaluator, ClassDecl *value) const;
+
 public:
   // Caching.
   bool isCached() const { return true; }
@@ -1088,7 +1087,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<GenericSignature>
+  GenericSignature
   evaluate(Evaluator &evaluator,
            GenericSignatureImpl *baseSignature,
            SmallVector<GenericTypeParamType *, 2> addedParameters,
@@ -1120,7 +1119,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<GenericSignature>
+  GenericSignature
   evaluate(Evaluator &evaluator,
            ModuleDecl *module,
            GenericSignatureImpl *baseSignature,
@@ -1155,7 +1154,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<Type> evaluate(Evaluator &eval, ExtensionDecl *) const;
+  Type evaluate(Evaluator &eval, ExtensionDecl *) const;
 public:
   // Caching.
   bool isCached() const { return true; }
@@ -1172,7 +1171,7 @@ private:
   friend SimpleRequest;
   
   // Evaluation.
-  llvm::Expected<OperatorDecl *>
+  OperatorDecl *
   evaluate(Evaluator &evaluator, FuncDecl *value) const;
   
 public:
@@ -1191,7 +1190,7 @@ private:
   friend SimpleRequest;
   
   // Evaluation.
-  llvm::Expected<GenericSignature>
+  GenericSignature
   evaluate(Evaluator &evaluator, GenericContext *value) const;
   
 public:
@@ -1213,8 +1212,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<Type> evaluate(Evaluator &evaluator,
-                                TypeAliasDecl *decl) const;
+  Type evaluate(Evaluator &evaluator, TypeAliasDecl *decl) const;
 
 public:
   // Caching.
@@ -1236,7 +1234,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<PrecedenceGroupDecl *>
+  PrecedenceGroupDecl *
   evaluate(Evaluator &evaluator, InfixOperatorDecl *PGD) const;
 
 public:
@@ -1256,7 +1254,7 @@ private:
   friend SimpleRequest;
   
   // Evaluation.
-  llvm::Expected<evaluator::SideEffect>
+  evaluator::SideEffect
   evaluate(Evaluator &evaluator, EnumDecl *ED, TypeResolutionStage stage) const;
   
 public:
@@ -1281,7 +1279,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator, ValueDecl *decl) const;
+  bool evaluate(Evaluator &evaluator, ValueDecl *decl) const;
 
 public:
   // Caching.
@@ -1299,7 +1297,7 @@ public:
 private:
   friend SimpleRequest;
 
-  llvm::Expected<OpaqueTypeDecl *>
+  OpaqueTypeDecl *
   evaluate(Evaluator &evaluator, ValueDecl *VD) const;
 
 public:
@@ -1319,7 +1317,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool>
+  bool
   evaluate(Evaluator &evaluator, FuncDecl *value) const;
 
 public:
@@ -1343,8 +1341,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator,
-                                AbstractFunctionDecl *decl) const;
+  bool evaluate(Evaluator &evaluator, AbstractFunctionDecl *decl) const;
 
 public:
   // Separate caching.
@@ -1365,7 +1362,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<ParamSpecifier>
+  ParamSpecifier
   evaluate(Evaluator &evaluator, ParamDecl *decl) const;
 
 public:
@@ -1389,7 +1386,7 @@ private:
   TypeLoc &getResultTypeLoc() const;
 
   // Evaluation.
-  llvm::Expected<Type> evaluate(Evaluator &evaluator, ValueDecl *decl) const;
+  Type evaluate(Evaluator &evaluator, ValueDecl *decl) const;
 
 public:
   // Separate caching.
@@ -1410,7 +1407,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<const PatternBindingEntry *>
+  const PatternBindingEntry *
   evaluate(Evaluator &evaluator, PatternBindingDecl *PBD, unsigned i) const;
 
 public:
@@ -1430,8 +1427,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<NamedPattern *> evaluate(Evaluator &evaluator,
-                                          VarDecl *VD) const;
+  NamedPattern * evaluate(Evaluator &evaluator, VarDecl *VD) const;
 
 public:
   // Separate caching.
@@ -1451,7 +1447,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<Type>
+  Type
   evaluate(Evaluator &evaluator, ValueDecl *decl) const;
 
 public:
@@ -1506,7 +1502,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<PrecedenceGroupDecl *>
+  PrecedenceGroupDecl *
   evaluate(Evaluator &evaluator, PrecedenceGroupDescriptor descriptor) const;
 
 public:
@@ -1533,8 +1529,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator,
-                                NominalTypeDecl *decl) const;
+  bool evaluate(Evaluator &evaluator, NominalTypeDecl *decl) const;
 
 public:
   // Caching.
@@ -1554,8 +1549,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator,
-                                NominalTypeDecl *decl) const;
+  bool evaluate(Evaluator &evaluator, NominalTypeDecl *decl) const;
 
 public:
   // Caching.
@@ -1573,7 +1567,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator, StructDecl *decl) const;
+  bool evaluate(Evaluator &evaluator, StructDecl *decl) const;
 
 public:
   // Caching.
@@ -1592,8 +1586,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<ConstructorDecl *> evaluate(Evaluator &evaluator,
-                                             NominalTypeDecl *decl) const;
+  ConstructorDecl *evaluate(Evaluator &evaluator, NominalTypeDecl *decl) const;
 
 public:
   // Caching.
@@ -1617,8 +1610,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<ConstructorDecl *> evaluate(Evaluator &evaluator,
-                                             NominalTypeDecl *decl) const;
+  ConstructorDecl *evaluate(Evaluator &evaluator, NominalTypeDecl *decl) const;
 
 public:
   // Caching.
@@ -1637,7 +1629,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator,
+  bool evaluate(Evaluator &evaluator,
                                 NominalTypeDecl *decl) const;
 
 public:
@@ -1657,8 +1649,8 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<ConstructorDecl *> evaluate(Evaluator &evaluator,
-                                             NominalTypeDecl *decl) const;
+  ConstructorDecl * evaluate(Evaluator &evaluator,
+                             NominalTypeDecl *decl) const;
 
 public:
   // Caching.
@@ -1676,9 +1668,9 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator, DeclContext *DC,
-                                ValueDecl *VD1, ValueDecl *VD2,
-                                bool dynamic) const;
+  bool evaluate(Evaluator &evaluator, DeclContext *DC,
+                ValueDecl *VD1, ValueDecl *VD2,
+                bool dynamic) const;
 
 public:
   // Caching.
@@ -1697,7 +1689,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator, ClassDecl *decl) const;
+  bool evaluate(Evaluator &evaluator, ClassDecl *decl) const;
 
 public:
   // Separate caching.
@@ -1718,7 +1710,8 @@ enum class ImplicitMemberAction : uint8_t {
 
 class ResolveImplicitMemberRequest
     : public SimpleRequest<ResolveImplicitMemberRequest,
-                           evaluator::SideEffect(NominalTypeDecl *, ImplicitMemberAction),
+                           evaluator::SideEffect(NominalTypeDecl *,
+                                                 ImplicitMemberAction),
                            CacheKind::Uncached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -1727,7 +1720,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<evaluator::SideEffect>
+  evaluator::SideEffect
   evaluate(Evaluator &evaluator, NominalTypeDecl *NTD,
            ImplicitMemberAction action) const;
 
@@ -1748,7 +1741,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<TypeWitnessAndDecl>
+  TypeWitnessAndDecl
   evaluate(Evaluator &evaluator, NormalProtocolConformance *conformance,
            AssociatedTypeDecl *ATD) const;
 
@@ -1770,9 +1763,9 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<Witness> evaluate(Evaluator &evaluator,
-                                   NormalProtocolConformance *conformance,
-                                   ValueDecl *VD) const;
+  Witness evaluate(Evaluator &evaluator,
+                   NormalProtocolConformance *conformance,
+                   ValueDecl *VD) const;
 
 public:
   // Separate caching.
@@ -1803,7 +1796,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<FunctionBuilderBodyPreCheck>
+  FunctionBuilderBodyPreCheck
   evaluate(Evaluator &evaluator, AnyFunctionRef fn) const;
 
 public:
@@ -1823,7 +1816,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator, ClassDecl *decl) const;
+  bool evaluate(Evaluator &evaluator, ClassDecl *decl) const;
 
 public:
   // Cycle handling.
@@ -1846,7 +1839,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator, ProtocolDecl *decl) const;
+  bool evaluate(Evaluator &evaluator, ProtocolDecl *decl) const;
 
 public:
   // Cycle handling.
@@ -1868,7 +1861,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator, EnumDecl *decl) const;
+  bool evaluate(Evaluator &evaluator, EnumDecl *decl) const;
 
 public:
   // Cycle handling.
@@ -1891,7 +1884,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<Initializer *> evaluate(Evaluator &evaluator,
+  Initializer * evaluate(Evaluator &evaluator,
                                          ParamDecl *param) const;
 
 public:
@@ -1913,7 +1906,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<Expr *> evaluate(Evaluator &evaluator, ParamDecl *param) const;
+  Expr *evaluate(Evaluator &evaluator, ParamDecl *param) const;
 
 public:
   // Separate caching.
@@ -1935,8 +1928,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<Expr *> evaluate(Evaluator &evaluator,
-                                  DefaultArgumentExpr *defaultExpr) const;
+  Expr * evaluate(Evaluator &evaluator, DefaultArgumentExpr *defaultExpr) const;
 
 public:
   // Separate caching.
@@ -1957,8 +1949,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator, CanType ty,
-                                DeclContext *dc) const;
+  bool evaluate(Evaluator &evaluator, CanType ty, DeclContext *dc) const;
 
 public:
   // Cached.
@@ -1975,8 +1966,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<ValueDecl *> evaluate(Evaluator &evaluator,
-                                       ValueDecl *VD) const;
+  ValueDecl * evaluate(Evaluator &evaluator, ValueDecl *VD) const;
 
 public:
   // Caching.
@@ -1994,7 +1984,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<evaluator::SideEffect>
+  evaluator::SideEffect
   evaluate(Evaluator &evaluator, SourceFile *SF) const;
 
 public:
@@ -2016,7 +2006,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator, CanType ty) const;
+  bool evaluate(Evaluator &evaluator, CanType ty) const;
 
 public:
   bool isCached() const {
@@ -2039,7 +2029,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator, CanType ty) const;
+  bool evaluate(Evaluator &evaluator, CanType ty) const;
 
 public:
   bool isCached() const {
@@ -2065,8 +2055,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<Type> evaluate(
-      Evaluator &evaluator, ContextualPattern pattern) const;
+  Type evaluate(Evaluator &evaluator, ContextualPattern pattern) const;
 
 public:
   bool isCached() const { return true; }
@@ -2088,7 +2077,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<llvm::ArrayRef<Identifier>>
+  llvm::ArrayRef<Identifier>
   evaluate(Evaluator &evaluator, const Decl *decl) const;
 
 public:
@@ -2115,8 +2104,8 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<IndexSubset *> evaluate(Evaluator &evaluator,
-                                         DifferentiableAttr *attr) const;
+  IndexSubset * evaluate(Evaluator &evaluator,
+                         DifferentiableAttr *attr) const;
 
 public:
   // Separate caching.
@@ -2137,8 +2126,8 @@ private:
   friend SimpleRequest;
 
   // Evaluation
-  llvm::Expected<bool> evaluate(Evaluator &evaluator, TypeEraserAttr *attr,
-                                ProtocolDecl *protocol) const;
+  bool evaluate(Evaluator &evaluator, TypeEraserAttr *attr,
+                ProtocolDecl *protocol) const;
 
 public:
   bool isCached() const { return true; }
@@ -2162,8 +2151,8 @@ public:
 private:
   friend SimpleRequest;
 
-  llvm::Expected<ArrayRef<ValueDecl *>> evaluate(Evaluator &evaluator,
-                                                 ImportDecl *import) const;
+  ArrayRef<ValueDecl *>
+  evaluate(Evaluator &evaluator, ImportDecl *import) const;
 
 public:
   // Cached.
@@ -2181,8 +2170,7 @@ public:
 private:
   friend SimpleRequest;
 
-  llvm::Expected<bool> evaluate(Evaluator &evaluator,
-                                ClosureExpr *closure) const;
+  bool evaluate(Evaluator &evaluator, ClosureExpr *closure) const;
 
 public:
   bool isCached() const { return true; }
@@ -2217,7 +2205,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<ProtocolConformanceLookupResult>
+  ProtocolConformanceLookupResult
   evaluate(Evaluator &evaluator, const DeclContext *DC) const;
 };
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1247,7 +1247,7 @@ public:
 /// Computes the raw values for an enum type.
 class EnumRawValuesRequest :
     public SimpleRequest<EnumRawValuesRequest,
-                         bool (EnumDecl *, TypeResolutionStage),
+                         evaluator::SideEffect (EnumDecl *, TypeResolutionStage),
                          CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -1256,7 +1256,7 @@ private:
   friend SimpleRequest;
   
   // Evaluation.
-  llvm::Expected<bool>
+  llvm::Expected<evaluator::SideEffect>
   evaluate(Evaluator &evaluator, EnumDecl *ED, TypeResolutionStage stage) const;
   
 public:
@@ -1266,8 +1266,8 @@ public:
                            
   // Separate caching.
   bool isCached() const;
-  Optional<bool> getCachedResult() const;
-  void cacheResult(bool value) const;
+  Optional<evaluator::SideEffect> getCachedResult() const;
+  void cacheResult(evaluator::SideEffect value) const;
 };
 
 /// Determines if an override is ABI compatible with its base method.
@@ -1718,7 +1718,7 @@ enum class ImplicitMemberAction : uint8_t {
 
 class ResolveImplicitMemberRequest
     : public SimpleRequest<ResolveImplicitMemberRequest,
-                           bool(NominalTypeDecl *, ImplicitMemberAction),
+                           evaluator::SideEffect(NominalTypeDecl *, ImplicitMemberAction),
                            CacheKind::Uncached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -1727,8 +1727,9 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator, NominalTypeDecl *NTD,
-                                ImplicitMemberAction action) const;
+  llvm::Expected<evaluator::SideEffect>
+  evaluate(Evaluator &evaluator, NominalTypeDecl *NTD,
+           ImplicitMemberAction action) const;
 
 public:
   // Separate caching.
@@ -1984,7 +1985,8 @@ public:
 
 class TypeCheckSourceFileRequest :
     public SimpleRequest<TypeCheckSourceFileRequest,
-                         bool (SourceFile *), CacheKind::SeparatelyCached> {
+                         evaluator::SideEffect (SourceFile *),
+                         CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -1992,13 +1994,14 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator, SourceFile *SF) const;
+  llvm::Expected<evaluator::SideEffect>
+  evaluate(Evaluator &evaluator, SourceFile *SF) const;
 
 public:
   // Separate caching.
   bool isCached() const { return true; }
-  Optional<bool> getCachedResult() const;
-  void cacheResult(bool result) const;
+  Optional<evaluator::SideEffect> getCachedResult() const;
+  void cacheResult(evaluator::SideEffect) const;
 };
 
 /// Computes whether the specified type or a super-class/super-protocol has the

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -55,8 +55,8 @@ SWIFT_REQUEST(TypeChecker, DynamicallyReplacedDeclRequest,
 SWIFT_REQUEST(TypeChecker, EmittedMembersRequest, DeclRange(ClassDecl *),
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, EnumRawValuesRequest,
-              bool (EnumDecl *, TypeResolutionStage), SeparatelyCached,
-              NoLocationInfo)
+              evaluator::SideEffect (EnumDecl *, TypeResolutionStage),
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, EnumRawTypeRequest,
               Type(EnumDecl *, TypeResolutionStage), SeparatelyCached,
               NoLocationInfo)
@@ -182,7 +182,8 @@ SWIFT_REQUEST(TypeChecker, SynthesizeAccessorRequest,
               AccessorDecl *(AbstractStorageDecl *, AccessorKind),
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, TypeCheckFunctionBodyUntilRequest,
-              bool(AbstractFunctionDecl *, SourceLoc), Cached, NoLocationInfo)
+              bool(AbstractFunctionDecl *, SourceLoc),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, UnderlyingTypeRequest, Type(TypeAliasDecl *),
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, USRGenerationRequest, std::string(const ValueDecl *),
@@ -207,8 +208,8 @@ SWIFT_REQUEST(TypeChecker, PreCheckFunctionBuilderRequest,
               FunctionBuilderClosurePreCheck(AnyFunctionRef),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResolveImplicitMemberRequest,
-              bool(NominalTypeDecl *, ImplicitMemberAction), Uncached,
-              NoLocationInfo)
+              evaluator::SideEffect(NominalTypeDecl *, ImplicitMemberAction),
+              Uncached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SPIGroupsRequest,
               llvm::ArrayRef<Identifier>(Decl *),
               Cached, NoLocationInfo)

--- a/include/swift/Basic/CTypeIDZone.def
+++ b/include/swift/Basic/CTypeIDZone.def
@@ -35,6 +35,7 @@ SWIFT_TYPEID_NAMED(void, Void)
 SWIFT_TYPEID_NAMED(std::string, String)
 
 // C++ standard library types.
+SWIFT_TYPEID_NAMED(evaluator::SideEffect, SideEffect)
 SWIFT_TYPEID_TEMPLATE1_NAMED(std::vector, Vector, typename T, T)
 SWIFT_TYPEID_TEMPLATE1_NAMED(std::unique_ptr, UniquePtr, typename T, T)
 

--- a/include/swift/Basic/TypeID.h
+++ b/include/swift/Basic/TypeID.h
@@ -66,6 +66,29 @@ constexpr uint64_t formTypeID(uint8_t zone, uint8_t type) {
   return (uint64_t(zone) << 8) | uint64_t(type);
 }
 
+namespace evaluator {
+/// The return type of requests that execute side effects.
+///
+/// In general, it is not appropriate to use the request evaluator framework to
+/// execute a request for the sake of its side effects. However, there are
+/// operations we would currently like to be requests because it makes modelling
+/// some aspect of their implementation particularly nice. For example, an
+/// operation that emits diagnostics to run some checking code in a primary
+/// file may be desirable to requestify because it should be run only once per
+/// declaration, but it has no coherent return value. Another category of
+/// side-effecting requests are those that adapt existing parts of the compiler that
+/// do not yet behave in a "functional" manner to have a functional interface. Consider
+/// the request to run the SIL Optimizer. In theory, it should be a request that takes in
+/// a SILModule and returns a SILModule. In practice, it is a request that executes
+/// effects against a SILModule.
+///
+/// To make these requests stand out - partially in the hope we can return and
+/// refactor them to behave in a more well-structured manner, partially because
+/// they cannot return \c void or we will get template substitution failures - we
+/// annotate them as computing an \c evaluator::SideEffect.
+using SideEffect = std::tuple<>;
+}
+
 // Define the C type zone (zone 0).
 #define SWIFT_TYPEID_ZONE C
 #define SWIFT_TYPEID_HEADER "swift/Basic/CTypeIDZone.def"

--- a/include/swift/IDE/IDERequests.h
+++ b/include/swift/IDE/IDERequests.h
@@ -69,8 +69,8 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<ide::ResolvedCursorInfo> evaluate(Evaluator &evaluator,
-    CursorInfoOwner CI) const;
+  ide::ResolvedCursorInfo evaluate(Evaluator &evaluator,
+                                   CursorInfoOwner CI) const;
 
 public:
   // Caching
@@ -130,8 +130,8 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<ide::ResolvedRangeInfo> evaluate(Evaluator &evaluator,
-    RangeInfoOwner CI) const;
+  ide::ResolvedRangeInfo evaluate(Evaluator &evaluator,
+                                  RangeInfoOwner CI) const;
 
 public:
   // Caching
@@ -158,8 +158,8 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<ArrayRef<ValueDecl*>> evaluate(Evaluator &evaluator,
-    ValueDecl* VD) const;
+  ArrayRef<ValueDecl*> evaluate(Evaluator &evaluator,
+                                ValueDecl* VD) const;
 
 public:
   // Caching
@@ -219,8 +219,8 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<ArrayRef<ValueDecl*>> evaluate(Evaluator &evaluator,
-    OverridenDeclsOwner Owner) const;
+  ArrayRef<ValueDecl*> evaluate(Evaluator &evaluator,
+                                OverridenDeclsOwner Owner) const;
 
 public:
   // Caching
@@ -271,8 +271,8 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<ProtocolDecl*> evaluate(Evaluator &evaluator,
-    ProtocolNameOwner Input) const;
+  ProtocolDecl *evaluate(Evaluator &evaluator,
+                         ProtocolNameOwner Input) const;
 
 public:
   // Caching

--- a/include/swift/Sema/IDETypeCheckingRequests.h
+++ b/include/swift/Sema/IDETypeCheckingRequests.h
@@ -72,8 +72,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator,
-                                DeclApplicabilityOwner Owner) const;
+  bool evaluate(Evaluator &evaluator, DeclApplicabilityOwner Owner) const;
 
 public:
   // Caching
@@ -170,8 +169,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator,
-                                TypeRelationCheckInput Owner) const;
+  bool evaluate(Evaluator &evaluator, TypeRelationCheckInput Owner) const;
 
 public:
   // Caching
@@ -194,7 +192,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<TypePair> evaluate(Evaluator &evaluator, SubscriptDecl* SD) const;
+  TypePair evaluate(Evaluator &evaluator, SubscriptDecl* SD) const;
 
 public:
   // Caching
@@ -214,7 +212,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<Type> evaluate(Evaluator &evaluator, SubscriptDecl* SD) const {
+  Type evaluate(Evaluator &evaluator, SubscriptDecl* SD) const {
     return evaluateOrDefault(SD->getASTContext().evaluator,
       RootAndResultTypeOfKeypathDynamicMemberRequest{SD}, TypePair()).
         FirstTy;

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1121,7 +1121,7 @@ ASTScopeImpl::expandAndBeCurrentDetectingRecursion(ScopeCreator &scopeCreator) {
                            ExpandASTScopeRequest{this, &scopeCreator}, nullptr);
 }
 
-llvm::Expected<ASTScopeImpl *>
+ASTScopeImpl *
 ExpandASTScopeRequest::evaluate(Evaluator &evaluator, ASTScopeImpl *parent,
                                 ScopeCreator *scopeCreator) const {
   auto *insertionPoint = parent->expandAndBeCurrent(*scopeCreator);

--- a/lib/AST/AccessRequests.cpp
+++ b/lib/AST/AccessRequests.cpp
@@ -36,7 +36,7 @@ namespace swift {
 //----------------------------------------------------------------------------//
 // AccessLevel computation
 //----------------------------------------------------------------------------//
-llvm::Expected<AccessLevel>
+AccessLevel
 AccessLevelRequest::evaluate(Evaluator &evaluator, ValueDecl *D) const {
   assert(!D->hasAccess());
 
@@ -168,7 +168,7 @@ static bool isStoredWithPrivateSetter(VarDecl *VD) {
   return true;
 }
 
-llvm::Expected<AccessLevel>
+AccessLevel
 SetterAccessLevelRequest::evaluate(Evaluator &evaluator,
                                    AbstractStorageDecl *ASD) const {
   assert(!ASD->Accessors.getInt().hasValue());
@@ -205,7 +205,7 @@ void SetterAccessLevelRequest::cacheResult(AccessLevel value) const {
 // DefaultAccessLevel computation
 //----------------------------------------------------------------------------//
 
-llvm::Expected<std::pair<AccessLevel, AccessLevel>>
+std::pair<AccessLevel, AccessLevel>
 DefaultAndMaxAccessLevelRequest::evaluate(Evaluator &evaluator,
                                           ExtensionDecl *ED) const {
   auto &Ctx = ED->getASTContext();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4125,7 +4125,7 @@ void NominalTypeDecl::synthesizeSemanticMembersIfNeeded(DeclName member) {
 
   if (auto actionToTake = action) {
     (void)evaluateOrDefault(Context.evaluator,
-        ResolveImplicitMemberRequest{this, actionToTake.getValue()}, false);
+        ResolveImplicitMemberRequest{this, actionToTake.getValue()}, {});
   }
 }
 
@@ -7486,7 +7486,7 @@ LiteralExpr *EnumElementDecl::getRawValueExpr() const {
   (void)evaluateOrDefault(
       getASTContext().evaluator,
       EnumRawValuesRequest{getParentEnum(), TypeResolutionStage::Interface},
-      true);
+      {});
   return RawValueExpr;
 }
 
@@ -7496,7 +7496,7 @@ LiteralExpr *EnumElementDecl::getStructuralRawValueExpr() const {
   (void)evaluateOrDefault(
       getASTContext().evaluator,
       EnumRawValuesRequest{getParentEnum(), TypeResolutionStage::Structural},
-      true);
+      {});
   return RawValueExpr;
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1394,7 +1394,7 @@ createExtensionGenericParams(ASTContext &ctx,
   return toParams;
 }
 
-llvm::Expected<GenericParamList *>
+GenericParamList *
 GenericParamListRequest::evaluate(Evaluator &evaluator, GenericContext *value) const {
   if (auto *ext = dyn_cast<ExtensionDecl>(value)) {
     // Create the generic parameter list for the extension by cloning the
@@ -4203,7 +4203,7 @@ synthesizeEmptyFunctionBody(AbstractFunctionDecl *afd, void *context) {
            /*isTypeChecked=*/true };
 }
 
-llvm::Expected<DestructorDecl *>
+DestructorDecl *
 GetDestructorRequest::evaluate(Evaluator &evaluator, ClassDecl *CD) const {
   auto &ctx = CD->getASTContext();
   auto *DD = new (ctx) DestructorDecl(CD->getLoc(), CD);
@@ -4268,8 +4268,9 @@ AncestryOptions ClassDecl::checkAncestry() const {
                            AncestryFlags()));
 }
         
-llvm::Expected<AncestryFlags>
-ClassAncestryFlagsRequest::evaluate(Evaluator &evaluator, ClassDecl *value) const {
+AncestryFlags
+ClassAncestryFlagsRequest::evaluate(Evaluator &evaluator,
+                                    ClassDecl *value) const {
   llvm::SmallPtrSet<const ClassDecl *, 8> visited;
 
   AncestryOptions result;

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -323,7 +323,7 @@ ResilienceExpansion DeclContext::getResilienceExpansion() const {
                            ResilienceExpansion::Minimal);
 }
 
-llvm::Expected<ResilienceExpansion>
+ResilienceExpansion
 swift::ResilienceExpansionRequest::evaluate(Evaluator &evaluator,
                                             DeclContext *context) const {
   for (const auto *dc = context->getLocalContext(); dc && dc->isLocalContext();

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -7348,7 +7348,7 @@ static bool isCanonicalRequest(GenericSignature baseSignature,
   return true;
 }
 
-llvm::Expected<GenericSignature>
+GenericSignature
 AbstractGenericSignatureRequest::evaluate(
          Evaluator &evaluator,
          GenericSignatureImpl *baseSignature,
@@ -7406,7 +7406,7 @@ AbstractGenericSignatureRequest::evaluate(
           canBaseSignature.getPointer(), std::move(canAddedParameters),
           std::move(canAddedRequirements)});
     if (!canSignatureResult || !*canSignatureResult)
-      return canSignatureResult;
+      return GenericSignature();
 
     // Substitute in the original generic parameters to form a more-sugared
     // result closer to what the original request wanted. Note that this
@@ -7461,7 +7461,7 @@ AbstractGenericSignatureRequest::evaluate(
       SourceLoc(), /*allowConcreteGenericParams=*/true);
 }
 
-llvm::Expected<GenericSignature>
+GenericSignature
 InferredGenericSignatureRequest::evaluate(
         Evaluator &evaluator, ModuleDecl *parentModule,
         GenericSignatureImpl *parentSig,

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -827,7 +827,7 @@ ProtocolConformanceRef ModuleDecl::lookupConformance(Type type,
       ProtocolConformanceRef::forInvalid());
 }
 
-llvm::Expected<ProtocolConformanceRef>
+ProtocolConformanceRef
 LookupConformanceInModuleRequest::evaluate(
     Evaluator &evaluator, LookupConformanceDescriptor desc) const {
   auto *mod = desc.Mod;
@@ -1185,7 +1185,7 @@ lookupOperatorDeclForName(ModuleDecl *M, SourceLoc Loc, Identifier Name,
 }
 
 template <typename OperatorType>
-llvm::Expected<OperatorType *> LookupOperatorRequest<OperatorType>::evaluate(
+OperatorType *LookupOperatorRequest<OperatorType>::evaluate(
     Evaluator &evaluator, OperatorLookupDescriptor desc) const {
   auto *file = desc.fileOrModule.get<FileUnit *>();
   auto result =
@@ -1214,7 +1214,7 @@ llvm::Expected<OperatorType *> LookupOperatorRequest<OperatorType>::evaluate(
                                               /*isCascading*/ false);          \
     return result ? *result : nullptr;                                         \
   }                                                                            \
-  template llvm::Expected<Kind##Decl *>                                        \
+  template Kind##Decl *                                                        \
   LookupOperatorRequest<Kind##Decl>::evaluate(Evaluator &e,                    \
                                               OperatorLookupDescriptor d) const;
 
@@ -1224,7 +1224,7 @@ LOOKUP_OPERATOR(PostfixOperator)
 LOOKUP_OPERATOR(PrecedenceGroup)
 #undef LOOKUP_OPERATOR
 
-llvm::Expected<TinyPtrVector<OperatorDecl *>>
+TinyPtrVector<OperatorDecl *>
 DirectOperatorLookupRequest::evaluate(Evaluator &evaluator,
                                       OperatorLookupDescriptor descriptor,
                                       OperatorFixity fixity) const {
@@ -1234,7 +1234,7 @@ DirectOperatorLookupRequest::evaluate(Evaluator &evaluator,
   for (auto *file : descriptor.getFiles())
     file->lookupOperatorDirect(descriptor.name, fixity, results);
 
-  return std::move(results);
+  return results;
 }
 
 void SourceFile::lookupOperatorDirect(
@@ -1268,7 +1268,7 @@ void SourceFile::lookupOperatorDirect(
     results.push_back(op);
 }
 
-llvm::Expected<TinyPtrVector<PrecedenceGroupDecl *>>
+TinyPtrVector<PrecedenceGroupDecl *>
 DirectPrecedenceGroupLookupRequest::evaluate(
     Evaluator &evaluator, OperatorLookupDescriptor descriptor) const {
   // Query each file.
@@ -1277,7 +1277,7 @@ DirectPrecedenceGroupLookupRequest::evaluate(
   for (auto *file : descriptor.getFiles())
     file->lookupPrecedenceGroupDirect(descriptor.name, results);
 
-  return std::move(results);
+  return results;
 }
 
 void SourceFile::lookupPrecedenceGroupDirect(
@@ -2049,7 +2049,7 @@ ArrayRef<Identifier> Decl::getSPIGroups() const {
                            ArrayRef<Identifier>());
 }
 
-llvm::Expected<llvm::ArrayRef<Identifier>>
+llvm::ArrayRef<Identifier>
 SPIGroupsRequest::evaluate(Evaluator &evaluator, const Decl *decl) const {
   // Applies only to public ValueDecls and ExtensionDecls.
   if (auto vd = dyn_cast<ValueDecl>(decl))

--- a/lib/AST/ModuleNameLookup.cpp
+++ b/lib/AST/ModuleNameLookup.cpp
@@ -243,7 +243,8 @@ void ModuleNameLookup<LookupStrategy>::lookupInModule(
               decls.end());
 }
 
-llvm::Expected<QualifiedLookupResult> LookupInModuleRequest::evaluate(
+QualifiedLookupResult
+LookupInModuleRequest::evaluate(
     Evaluator &evaluator, const DeclContext *moduleOrFile, DeclName name,
     NLKind lookupKind, ResolutionKind resolutionKind,
     const DeclContext *moduleScopeContext) const {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1242,7 +1242,7 @@ NominalTypeDecl::lookupDirect(DeclName name,
                            DirectLookupRequest({this, name, flags}), {});
 }
 
-llvm::Expected<TinyPtrVector<ValueDecl *>>
+TinyPtrVector<ValueDecl *>
 DirectLookupRequest::evaluate(Evaluator &evaluator,
                               DirectLookupDescriptor desc) const {
   const auto &name = desc.Name;
@@ -1570,7 +1570,7 @@ bool DeclContext::lookupQualified(ArrayRef<NominalTypeDecl *> typeDecls,
   return !decls.empty();
 }
 
-llvm::Expected<QualifiedLookupResult>
+QualifiedLookupResult
 QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
                                  SmallVector<NominalTypeDecl *, 4> typeDecls,
                                  DeclNameRef member, NLOptions options) const {
@@ -1709,7 +1709,7 @@ bool DeclContext::lookupQualified(ModuleDecl *module, DeclNameRef member,
   return !decls.empty();
 }
 
-llvm::Expected<QualifiedLookupResult>
+QualifiedLookupResult
 ModuleQualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
                                        ModuleDecl *module, DeclNameRef member,
                                        NLOptions options) const {
@@ -1762,7 +1762,7 @@ ModuleQualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
   return decls;
 }
 
-llvm::Expected<QualifiedLookupResult>
+QualifiedLookupResult
 AnyObjectLookupRequest::evaluate(Evaluator &evaluator, const DeclContext *dc,
                                  DeclNameRef member, NLOptions options) const {
   using namespace namelookup;
@@ -2188,7 +2188,7 @@ DirectlyReferencedTypeDecls UnderlyingTypeDeclsReferencedRequest::evaluate(
 }
 
 /// Evaluate a superclass declaration request.
-llvm::Expected<ClassDecl *>
+ClassDecl *
 SuperclassDeclRequest::evaluate(Evaluator &evaluator,
                                 NominalTypeDecl *subject) const {
   auto &Ctx = subject->getASTContext();
@@ -2252,7 +2252,7 @@ InheritedProtocolsRequest::evaluate(Evaluator &evaluator,
   return PD->getASTContext().AllocateCopy(result);
 }
 
-llvm::Expected<NominalTypeDecl *>
+NominalTypeDecl *
 ExtendedNominalRequest::evaluate(Evaluator &evaluator,
                                  ExtensionDecl *ext) const {
   auto typeRepr = ext->getExtendedTypeRepr();
@@ -2289,7 +2289,7 @@ static bool declsAreAssociatedTypes(ArrayRef<TypeDecl *> decls) {
   return true;
 }
 
-llvm::Expected<NominalTypeDecl *>
+NominalTypeDecl *
 CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
                                    CustomAttr *attr, DeclContext *dc) const {
   // Find the types referenced by the custom attribute.

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -101,7 +101,7 @@ void HasMissingDesignatedInitializersRequest::cacheResult(bool result) const {
   classDecl->setHasMissingDesignatedInitializers(result);
 }
 
-llvm::Expected<bool>
+bool
 HasMissingDesignatedInitializersRequest::evaluate(Evaluator &evaluator,
                                            ClassDecl *subject) const {
   // Short-circuit and check for the attribute here.

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -863,14 +863,14 @@ bool EnumRawValuesRequest::isCached() const {
   return std::get<1>(getStorage()) == TypeResolutionStage::Interface;
 }
 
-Optional<bool> EnumRawValuesRequest::getCachedResult() const {
+Optional<evaluator::SideEffect> EnumRawValuesRequest::getCachedResult() const {
   auto *ED = std::get<0>(getStorage());
   if (ED->LazySemanticInfo.hasCheckedRawValues())
-    return true;
+    return std::make_tuple<>();
   return None;
 }
 
-void EnumRawValuesRequest::cacheResult(bool) const {
+void EnumRawValuesRequest::cacheResult(evaluator::SideEffect) const {
   auto *ED = std::get<0>(getStorage());
   auto flags = ED->LazySemanticInfo.RawTypeAndFlags.getInt() |
       EnumDecl::HasFixedRawValues |
@@ -1268,15 +1268,16 @@ void DifferentiableAttributeTypeCheckRequest::cacheResult(
 // TypeCheckSourceFileRequest computation.
 //----------------------------------------------------------------------------//
 
-Optional<bool> TypeCheckSourceFileRequest::getCachedResult() const {
+Optional<evaluator::SideEffect>
+TypeCheckSourceFileRequest::getCachedResult() const {
   auto *SF = std::get<0>(getStorage());
   if (SF->ASTStage == SourceFile::TypeChecked)
-    return true;
+    return std::make_tuple<>();
 
   return None;
 }
 
-void TypeCheckSourceFileRequest::cacheResult(bool result) const {
+void TypeCheckSourceFileRequest::cacheResult(evaluator::SideEffect) const {
   auto *SF = std::get<0>(getStorage());
 
   // Verify that we've checked types correctly.

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -166,7 +166,7 @@ static bool shouldUseObjCUSR(const Decl *D) {
   return false;
 }
 
-llvm::Expected<std::string>
+std::string
 swift::USRGenerationRequest::evaluate(Evaluator &evaluator,
                                       const ValueDecl *D) const {
   if (auto *VD = dyn_cast<VarDecl>(D))
@@ -254,7 +254,7 @@ swift::USRGenerationRequest::evaluate(Evaluator &evaluator,
   return NewMangler.mangleDeclAsUSR(D, getUSRSpacePrefix());
 }
 
-llvm::Expected<std::string>
+std::string
 swift::MangleLocalTypeDeclRequest::evaluate(Evaluator &evaluator,
                                             const TypeDecl *D) const {
   if (isa<ModuleDecl>(D))

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -1274,7 +1274,7 @@ bool ASTScopeDeclConsumerForUnqualifiedLookup::lookInMembers(
   return factory.isFirstResultEnough();
 }
 
-llvm::Expected<LookupResult>
+LookupResult
 UnqualifiedLookupRequest::evaluate(Evaluator &evaluator,
                                    UnqualifiedLookupDescriptor desc) const {
   SmallVector<LookupResultEntry, 4> results;

--- a/lib/IDE/IDERequests.cpp
+++ b/lib/IDE/IDERequests.cpp
@@ -303,7 +303,7 @@ bool CursorInfoResolver::rangeContainsLoc(CharSourceRange Range) const {
   return Range.contains(LocToResolve);
 }
 
-llvm::Expected<ide::ResolvedCursorInfo>
+ide::ResolvedCursorInfo
 CursorInfoRequest::evaluate(Evaluator &eval, CursorInfoOwner CI) const {
   if (!CI.isValid())
     return ResolvedCursorInfo();
@@ -1066,7 +1066,7 @@ RangeInfoOwner::RangeInfoOwner(SourceFile *File, unsigned Offset,
   EndLoc = SM.getLocForOffset(BufferId, Offset + Length);
 }
 
-llvm::Expected<ide::ResolvedRangeInfo>
+ide::ResolvedRangeInfo
 RangeInfoRequest::evaluate(Evaluator &eval, RangeInfoOwner CI) const {
   if (!CI.isValid())
     return ResolvedRangeInfo();
@@ -1092,7 +1092,7 @@ static Type getContextFreeInterfaceType(ValueDecl *VD) {
   return VD->getInterfaceType();
 }
 
-llvm::Expected<ArrayRef<ValueDecl*>>
+ArrayRef<ValueDecl *>
 ProvideDefaultImplForRequest::evaluate(Evaluator &eval, ValueDecl* VD) const {
   // Skip decls that don't have valid names.
   if (!VD->getFullName())
@@ -1126,7 +1126,7 @@ ProvideDefaultImplForRequest::evaluate(Evaluator &eval, ValueDecl* VD) const {
 //----------------------------------------------------------------------------//
 // CollectOverriddenDeclsRequest
 //----------------------------------------------------------------------------//
-llvm::Expected<ArrayRef<ValueDecl*>>
+ArrayRef<ValueDecl *>
 CollectOverriddenDeclsRequest::evaluate(Evaluator &evaluator,
                                         OverridenDeclsOwner Owner) const {
   std::vector<ValueDecl*> results;
@@ -1155,7 +1155,7 @@ CollectOverriddenDeclsRequest::evaluate(Evaluator &evaluator,
 //----------------------------------------------------------------------------//
 // ResolveProtocolNameRequest
 //----------------------------------------------------------------------------//
-llvm::Expected<ProtocolDecl*>
+ProtocolDecl *
 ResolveProtocolNameRequest::evaluate(Evaluator &evaluator,
                                      ProtocolNameOwner Input) const {
   auto &ctx = Input.DC->getASTContext();

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1366,7 +1366,7 @@ std::unique_ptr<llvm::Module> swift::performIRGeneration(
       M->getASTContext().evaluator(IRGenWholeModuleRequest{desc}));
 }
 
-llvm::Expected<std::unique_ptr<llvm::Module>>
+std::unique_ptr<llvm::Module>
 IRGenWholeModuleRequest::evaluate(Evaluator &evaluator,
                                   IRGenDescriptor desc) const {
   auto *M = desc.Ctx.get<ModuleDecl *>();
@@ -1401,7 +1401,7 @@ performIRGeneration(const IRGenOptions &Opts, SourceFile &SF,
       SF.getASTContext().evaluator(IRGenSourceFileRequest{desc}));
 }
 
-llvm::Expected<std::unique_ptr<llvm::Module>>
+std::unique_ptr<llvm::Module>
 IRGenSourceFileRequest::evaluate(Evaluator &evaluator,
                                  IRGenDescriptor desc) const {
   auto *SF = desc.Ctx.get<SourceFile *>();

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1850,7 +1850,7 @@ public:
 };
 } // end anonymous namespace
 
-llvm::Expected<std::unique_ptr<SILModule>>
+std::unique_ptr<SILModule>
 SILGenSourceFileRequest::evaluate(Evaluator &evaluator,
                                   SILGenDescriptor desc) const {
   auto *unit = desc.context.get<FileUnit *>();
@@ -1866,10 +1866,10 @@ SILGenSourceFileRequest::evaluate(Evaluator &evaluator,
       M->getSILLoader()->getAllForModule(mod->getName(), file);
   }
 
-  return std::move(M);
+  return M;
 }
 
-llvm::Expected<std::unique_ptr<SILModule>>
+std::unique_ptr<SILModule>
 SILGenWholeModuleRequest::evaluate(Evaluator &evaluator,
                                    SILGenDescriptor desc) const {
   auto *mod = desc.context.get<ModuleDecl *>();
@@ -1894,7 +1894,7 @@ SILGenWholeModuleRequest::evaluate(Evaluator &evaluator,
   if (hasSIB)
     M->getSILLoader()->getAllForModule(mod->getName(), nullptr);
 
-  return std::move(M);
+  return M;
 }
 
 std::unique_ptr<SILModule>

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -276,8 +276,7 @@ public:
 
 } // end anonymous namespace
 
-llvm::Expected<evaluator::SideEffect>
-ExecuteSILPipelineRequest::evaluate(
+evaluator::SideEffect ExecuteSILPipelineRequest::evaluate(
     Evaluator &evaluator, SILPipelineExecutionDescriptor desc) const {
   SILPassManager PM(desc.SM, desc.IsMandatory, desc.IRMod);
   PM.executePassPipelinePlan(desc.Plan);

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -276,11 +276,12 @@ public:
 
 } // end anonymous namespace
 
-llvm::Expected<bool> ExecuteSILPipelineRequest::evaluate(
+llvm::Expected<evaluator::SideEffect>
+ExecuteSILPipelineRequest::evaluate(
     Evaluator &evaluator, SILPipelineExecutionDescriptor desc) const {
   SILPassManager PM(desc.SM, desc.IsMandatory, desc.IRMod);
   PM.executePassPipelinePlan(desc.Plan);
-  return false;
+  return std::make_tuple<>();
 }
 
 void swift::executePassPipelinePlan(SILModule *SM,

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1548,7 +1548,7 @@ public:
 
 }
 
-llvm::Expected<FunctionBuilderBodyPreCheck>
+FunctionBuilderBodyPreCheck
 PreCheckFunctionBuilderRequest::evaluate(Evaluator &eval,
                                          AnyFunctionRef fn) const {
   return PreCheckFunctionBuilderApplication(fn, false).run();

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -385,7 +385,7 @@ static bool isDeclAsSpecializedAs(DeclContext *dc, ValueDecl *decl1,
                            false);
 }
 
-llvm::Expected<bool> CompareDeclSpecializationRequest::evaluate(
+bool CompareDeclSpecializationRequest::evaluate(
     Evaluator &eval, DeclContext *dc, ValueDecl *decl1, ValueDecl *decl2,
     bool isDynamicOverloadComparison) const {
   auto &C = decl1->getASTContext();

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -795,7 +795,7 @@ static void diagnoseMissingRequiredInitializer(
                      diag::required_initializer_here);
 }
 
-llvm::Expected<bool> AreAllStoredPropertiesDefaultInitableRequest::evaluate(
+bool AreAllStoredPropertiesDefaultInitableRequest::evaluate(
     Evaluator &evaluator, NominalTypeDecl *decl) const {
   assert(!decl->hasClangNode());
 
@@ -849,7 +849,7 @@ static bool areAllStoredPropertiesDefaultInitializable(Evaluator &eval,
       eval, AreAllStoredPropertiesDefaultInitableRequest{decl}, false);
 }
 
-llvm::Expected<bool>
+bool
 HasUserDefinedDesignatedInitRequest::evaluate(Evaluator &evaluator,
                                               NominalTypeDecl *decl) const {
   assert(!decl->hasClangNode());
@@ -1015,7 +1015,7 @@ static void addImplicitInheritedConstructorsToClass(ClassDecl *decl) {
   }
 }
 
-llvm::Expected<bool>
+bool
 InheritsSuperclassInitializersRequest::evaluate(Evaluator &eval,
                                                 ClassDecl *decl) const {
   // Check if we parsed the @_inheritsConvenienceInitializers attribute.
@@ -1085,7 +1085,7 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
   (void)decl->getDefaultInitializer();
 }
 
-llvm::Expected<evaluator::SideEffect>
+evaluator::SideEffect
 ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
                                        NominalTypeDecl *target,
                                        ImplicitMemberAction action) const {
@@ -1165,7 +1165,7 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
   return std::make_tuple<>();
 }
 
-llvm::Expected<bool>
+bool
 HasMemberwiseInitRequest::evaluate(Evaluator &evaluator,
                                    StructDecl *decl) const {
   if (!shouldAttemptInitializerSynthesis(decl))
@@ -1190,7 +1190,7 @@ HasMemberwiseInitRequest::evaluate(Evaluator &evaluator,
   return false;
 }
 
-llvm::Expected<ConstructorDecl *>
+ConstructorDecl *
 SynthesizeMemberwiseInitRequest::evaluate(Evaluator &evaluator,
                                           NominalTypeDecl *decl) const {
   // Create the implicit memberwise constructor.
@@ -1201,7 +1201,7 @@ SynthesizeMemberwiseInitRequest::evaluate(Evaluator &evaluator,
   return ctor;
 }
 
-llvm::Expected<ConstructorDecl *>
+ConstructorDecl *
 ResolveEffectiveMemberwiseInitRequest::evaluate(Evaluator &evaluator,
                                                 NominalTypeDecl *decl) const {
   // Compute the access level for the memberwise initializer. The minimum of:
@@ -1288,7 +1288,7 @@ ResolveEffectiveMemberwiseInitRequest::evaluate(Evaluator &evaluator,
   return memberwiseInitDecl;
 }
 
-llvm::Expected<bool>
+bool
 HasDefaultInitRequest::evaluate(Evaluator &evaluator,
                                 NominalTypeDecl *decl) const {
   assert(isa<StructDecl>(decl) || isa<ClassDecl>(decl));
@@ -1328,7 +1328,7 @@ synthesizeSingleReturnFunctionBody(AbstractFunctionDecl *afd, void *) {
            /*isTypeChecked=*/true };
 }
 
-llvm::Expected<ConstructorDecl *>
+ConstructorDecl *
 SynthesizeDefaultInitRequest::evaluate(Evaluator &evaluator,
                                        NominalTypeDecl *decl) const {
   auto &ctx = decl->getASTContext();

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1085,7 +1085,7 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
   (void)decl->getDefaultInitializer();
 }
 
-llvm::Expected<bool>
+llvm::Expected<evaluator::SideEffect>
 ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
                                        NominalTypeDecl *target,
                                        ImplicitMemberAction action) const {
@@ -1162,7 +1162,7 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
   }
     break;
   }
-  return true;
+  return std::make_tuple<>();
 }
 
 llvm::Expected<bool>

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -84,7 +84,7 @@ static bool isMemberDeclAppliedInternal(const DeclContext *DC, Type BaseTy,
                                          /*isExtension=*/false);
 }
 
-llvm::Expected<bool>
+bool
 IsDeclApplicableRequest::evaluate(Evaluator &evaluator,
                                   DeclApplicabilityOwner Owner) const {
   if (auto *VD = dyn_cast<ValueDecl>(Owner.ExtensionOrMember)) {
@@ -96,7 +96,7 @@ IsDeclApplicableRequest::evaluate(Evaluator &evaluator,
   }
 }
 
-llvm::Expected<bool>
+bool
 TypeRelationCheckRequest::evaluate(Evaluator &evaluator,
                                    TypeRelationCheckInput Owner) const {
   Optional<constraints::ConstraintKind> CKind;
@@ -112,7 +112,7 @@ TypeRelationCheckRequest::evaluate(Evaluator &evaluator,
                                              *CKind, Owner.DC);
 }
 
-llvm::Expected<TypePair>
+TypePair
 RootAndResultTypeOfKeypathDynamicMemberRequest::evaluate(Evaluator &evaluator,
                                               SubscriptDecl *subscript) const {
   if (!isValidKeyPathDynamicMemberLookup(subscript))

--- a/lib/Sema/NameBinding.cpp
+++ b/lib/Sema/NameBinding.cpp
@@ -713,7 +713,7 @@ static const char *getImportKindString(ImportKind kind) {
   llvm_unreachable("Unhandled ImportKind in switch.");
 }
 
-llvm::Expected<ArrayRef<ValueDecl *>>
+ArrayRef<ValueDecl *>
 ScopedImportLookupRequest::evaluate(Evaluator &evaluator,
                                     ImportDecl *import) const {
   using namespace namelookup;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2395,7 +2395,7 @@ void AttributeChecker::visitDynamicReplacementAttr(DynamicReplacementAttr *attr)
   }
 }
 
-llvm::Expected<bool>
+bool
 TypeEraserHasViableInitRequest::evaluate(Evaluator &evaluator,
                                          TypeEraserAttr *attr,
                                          ProtocolDecl *protocol) const {
@@ -3097,7 +3097,7 @@ void TypeChecker::addImplicitDynamicAttribute(Decl *D) {
   }
 }
 
-llvm::Expected<ValueDecl *>
+ValueDecl *
 DynamicallyReplacedDeclRequest::evaluate(Evaluator &evaluator,
                                          ValueDecl *VD) const {
   // Dynamic replacements must be explicit.
@@ -3831,7 +3831,7 @@ bool checkIfDifferentiableProgrammingEnabled(
   return false;
 }
 
-llvm::Expected<IndexSubset *> DifferentiableAttributeTypeCheckRequest::evaluate(
+IndexSubset *DifferentiableAttributeTypeCheckRequest::evaluate(
     Evaluator &evaluator, DifferentiableAttr *attr) const {
   // Skip type-checking for implicit `@differentiable` attributes. We currently
   // assume that all implicit `@differentiable` attributes are valid.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -4197,7 +4197,7 @@ ForcedCheckedCastExpr *swift::findForcedDowncast(ASTContext &ctx, Expr *expr) {
   return nullptr;
 }
 
-llvm::Expected<bool>
+bool
 IsCallableNominalTypeRequest::evaluate(Evaluator &evaluator, CanType ty,
                                        DeclContext *dc) const {
   auto options = defaultMemberLookupOptions;
@@ -4269,7 +4269,7 @@ static bool checkForDynamicAttribute(CanType ty,
   return false;
 }
 
-llvm::Expected<bool>
+bool
 HasDynamicMemberLookupAttributeRequest::evaluate(Evaluator &evaluator,
                                                  CanType ty) const {
   return checkForDynamicAttribute<DynamicMemberLookupAttr>(ty, [](Type type) {
@@ -4277,7 +4277,7 @@ HasDynamicMemberLookupAttributeRequest::evaluate(Evaluator &evaluator,
   });
 }
 
-llvm::Expected<bool>
+bool
 HasDynamicCallableAttributeRequest::evaluate(Evaluator &evaluator,
                                              CanType ty) const {
   return checkForDynamicAttribute<DynamicCallableAttr>(ty, [](Type type) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -973,22 +973,22 @@ swift::computeAutomaticEnumValueKind(EnumDecl *ED) {
   }
 }
 
-llvm::Expected<bool>
+llvm::Expected<evaluator::SideEffect>
 EnumRawValuesRequest::evaluate(Evaluator &eval, EnumDecl *ED,
                                TypeResolutionStage stage) const {
   Type rawTy = ED->getRawType();
   if (!rawTy) {
-    return true;
+    return std::make_tuple<>();
   }
 
   if (!computeAutomaticEnumValueKind(ED)) {
-    return true;
+    return std::make_tuple<>();
   }
 
   if (ED->getGenericEnvironmentOfContext() != nullptr)
     rawTy = ED->mapTypeIntoContext(rawTy);
   if (rawTy->hasError())
-    return true;
+    return std::make_tuple<>();
 
   // Check the raw values of the cases.
   LiteralExpr *prevValue = nullptr;
@@ -1017,7 +1017,7 @@ EnumRawValuesRequest::evaluate(Evaluator &eval, EnumDecl *ED,
         valueKind = computeAutomaticEnumValueKind(ED);
         if (!valueKind) {
           elt->setInvalid();
-          return true;
+          return std::make_tuple<>();
         }
       }
       
@@ -1107,7 +1107,7 @@ EnumRawValuesRequest::evaluate(Evaluator &eval, EnumDecl *ED,
                        diag::enum_raw_value_incrementing_from_zero);
     }
   }
-  return true;
+  return std::make_tuple<>();
 }
 
 const ConstructorDecl *

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -231,7 +231,7 @@ static bool canSkipCircularityCheck(NominalTypeDecl *decl) {
   return decl->hasClangNode() || decl->wasDeserialized();
 }
 
-llvm::Expected<bool>
+bool
 HasCircularInheritanceRequest::evaluate(Evaluator &evaluator,
                                         ClassDecl *decl) const {
   if (canSkipCircularityCheck(decl) || !decl->hasSuperclass())
@@ -246,10 +246,10 @@ HasCircularInheritanceRequest::evaluate(Evaluator &evaluator,
     llvm::handleAllErrors(result.takeError(), [](const Error &E) {});
     return true;
   }
-  return result;
+  return result.get();
 }
 
-llvm::Expected<bool>
+bool
 HasCircularInheritedProtocolsRequest::evaluate(Evaluator &evaluator,
                                                ProtocolDecl *decl) const {
   if (canSkipCircularityCheck(decl))
@@ -277,7 +277,7 @@ HasCircularInheritedProtocolsRequest::evaluate(Evaluator &evaluator,
   return false;
 }
 
-llvm::Expected<bool>
+bool
 HasCircularRawValueRequest::evaluate(Evaluator &evaluator,
                                      EnumDecl *decl) const {
   if (canSkipCircularityCheck(decl) || !decl->hasRawType())
@@ -294,7 +294,7 @@ HasCircularRawValueRequest::evaluate(Evaluator &evaluator,
     llvm::handleAllErrors(result.takeError(), [](const Error &E) {});
     return true;
   }
-  return result;
+  return result.get();
 }
 
 namespace {
@@ -399,7 +399,7 @@ static bool doesAccessorNeedDynamicAttribute(AccessorDecl *accessor) {
   llvm_unreachable("covered switch");
 }
 
-llvm::Expected<CtorInitializerKind>
+CtorInitializerKind
 InitKindRequest::evaluate(Evaluator &evaluator, ConstructorDecl *decl) const {
   auto &diags = decl->getASTContext().Diags;
 
@@ -470,7 +470,7 @@ InitKindRequest::evaluate(Evaluator &evaluator, ConstructorDecl *decl) const {
   return CtorInitializerKind::Designated;
 }
 
-llvm::Expected<bool>
+bool
 ProtocolRequiresClassRequest::evaluate(Evaluator &evaluator,
                                        ProtocolDecl *decl) const {
   // Quick check: @objc protocols require a class.
@@ -503,7 +503,7 @@ ProtocolRequiresClassRequest::evaluate(Evaluator &evaluator,
   return false;
 }
 
-llvm::Expected<bool>
+bool
 ExistentialConformsToSelfRequest::evaluate(Evaluator &evaluator,
                                            ProtocolDecl *decl) const {
   // If it's not @objc, it conforms to itself only if it has a self-conformance
@@ -531,7 +531,7 @@ ExistentialConformsToSelfRequest::evaluate(Evaluator &evaluator,
   return true;
 }
 
-llvm::Expected<bool>
+bool
 ExistentialTypeSupportedRequest::evaluate(Evaluator &evaluator,
                                           ProtocolDecl *decl) const {
   // ObjC protocols can always be existential.
@@ -559,7 +559,7 @@ ExistentialTypeSupportedRequest::evaluate(Evaluator &evaluator,
   return true;
 }
 
-llvm::Expected<bool>
+bool
 IsFinalRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
   if (isa<ClassDecl>(decl))
     return decl->getAttrs().hasAttribute<FinalAttr>();
@@ -655,7 +655,7 @@ IsFinalRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
   return false;
 }
 
-llvm::Expected<bool>
+bool
 IsStaticRequest::evaluate(Evaluator &evaluator, FuncDecl *decl) const {
   if (auto *accessor = dyn_cast<AccessorDecl>(decl))
     return accessor->getStorage()->isStatic();
@@ -685,7 +685,7 @@ IsStaticRequest::evaluate(Evaluator &evaluator, FuncDecl *decl) const {
   return result;
 }
 
-llvm::Expected<bool>
+bool
 IsDynamicRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
   // If we can't infer dynamic here, don't.
   if (!DeclAttribute::canAttributeAppearOnDecl(DAK_Dynamic, decl))
@@ -745,7 +745,7 @@ IsDynamicRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
   return false;
 }
 
-llvm::Expected<ArrayRef<Requirement>>
+ArrayRef<Requirement>
 RequirementSignatureRequest::evaluate(Evaluator &evaluator,
                                       ProtocolDecl *proto) const {
   ASTContext &ctx = proto->getASTContext();
@@ -794,7 +794,7 @@ RequirementSignatureRequest::evaluate(Evaluator &evaluator,
   return reqSignature->getRequirements();
 }
 
-llvm::Expected<Type>
+Type
 DefaultDefinitionTypeRequest::evaluate(Evaluator &evaluator,
                                        AssociatedTypeDecl *assocType) const {
   if (assocType->Resolver) {
@@ -813,7 +813,7 @@ DefaultDefinitionTypeRequest::evaluate(Evaluator &evaluator,
   return Type();
 }
 
-llvm::Expected<bool>
+bool
 NeedsNewVTableEntryRequest::evaluate(Evaluator &evaluator,
                                      AbstractFunctionDecl *decl) const {
   auto *dc = decl->getDeclContext();
@@ -973,7 +973,7 @@ swift::computeAutomaticEnumValueKind(EnumDecl *ED) {
   }
 }
 
-llvm::Expected<evaluator::SideEffect>
+evaluator::SideEffect
 EnumRawValuesRequest::evaluate(Evaluator &eval, EnumDecl *ED,
                                TypeResolutionStage stage) const {
   Type rawTy = ED->getRawType();
@@ -1336,7 +1336,7 @@ void swift::validatePrecedenceGroup(PrecedenceGroupDecl *PGD) {
     checkPrecedenceCircularity(Diags, PGD);
 }
 
-llvm::Expected<PrecedenceGroupDecl *> ValidatePrecedenceGroupRequest::evaluate(
+PrecedenceGroupDecl * ValidatePrecedenceGroupRequest::evaluate(
     Evaluator &eval, PrecedenceGroupDescriptor descriptor) const {
   if (auto *group = lookupPrecedenceGroup(descriptor)) {
     validatePrecedenceGroup(group);
@@ -1398,7 +1398,7 @@ bool swift::checkDesignatedTypes(OperatorDecl *OD,
 /// This establishes key invariants, such as an InfixOperatorDecl's
 /// reference to its precedence group and the transitive validity of that
 /// group.
-llvm::Expected<PrecedenceGroupDecl *>
+PrecedenceGroupDecl *
 OperatorPrecedenceGroupRequest::evaluate(Evaluator &evaluator,
                                          InfixOperatorDecl *IOD) const {
   auto enableOperatorDesignatedTypes =
@@ -1464,7 +1464,7 @@ OperatorPrecedenceGroupRequest::evaluate(Evaluator &evaluator,
   return group;
 }
 
-llvm::Expected<SelfAccessKind>
+SelfAccessKind
 SelfAccessKindRequest::evaluate(Evaluator &evaluator, FuncDecl *FD) const {
   if (FD->getAttrs().getAttribute<MutatingAttr>(true)) {
     if (!FD->isInstanceMember() || !FD->getDeclContext()->hasValueSemantics()) {
@@ -1597,7 +1597,7 @@ static ParamDecl *getOriginalParamFromAccessor(AbstractStorageDecl *storage,
   return subscriptParams->get(index - startIndex);
 }
 
-llvm::Expected<bool>
+bool
 IsImplicitlyUnwrappedOptionalRequest::evaluate(Evaluator &evaluator,
                                                ValueDecl *decl) const {
   TypeRepr *TyR = nullptr;
@@ -1670,7 +1670,7 @@ IsImplicitlyUnwrappedOptionalRequest::evaluate(Evaluator &evaluator,
 }
 
 /// Validate the underlying type of the given typealias.
-llvm::Expected<Type>
+Type
 UnderlyingTypeRequest::evaluate(Evaluator &evaluator,
                                 TypeAliasDecl *typeAlias) const {
   TypeResolutionOptions options((typeAlias->getGenericParams()
@@ -1702,7 +1702,7 @@ UnderlyingTypeRequest::evaluate(Evaluator &evaluator,
 
 /// Bind the given function declaration, which declares an operator, to the
 /// corresponding operator declaration.
-llvm::Expected<OperatorDecl *>
+OperatorDecl *
 FunctionOperatorRequest::evaluate(Evaluator &evaluator, FuncDecl *FD) const {  
   auto &C = FD->getASTContext();
   auto &diags = C.Diags;
@@ -1893,7 +1893,7 @@ static Type buildAddressorResultType(AccessorDecl *addressor,
   return valueType->wrapInPointer(pointerKind);
 }
 
-llvm::Expected<Type>
+Type
 ResultTypeRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
   auto &ctx = decl->getASTContext();
 
@@ -1946,7 +1946,7 @@ ResultTypeRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
       resultTyRepr, TypeResolverContext::FunctionResult);
 }
 
-llvm::Expected<ParamSpecifier>
+ParamSpecifier
 ParamSpecifierRequest::evaluate(Evaluator &evaluator,
                                 ParamDecl *param) const {
   auto *dc = param->getDeclContext();
@@ -2071,7 +2071,7 @@ static Type validateParameterType(ParamDecl *decl) {
   return TL.getType();
 }
 
-llvm::Expected<Type>
+Type
 InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
   auto &Context = D->getASTContext();
 
@@ -2278,7 +2278,7 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
   }
 }
 
-llvm::Expected<NamedPattern *>
+NamedPattern *
 NamingPatternRequest::evaluate(Evaluator &evaluator, VarDecl *VD) const {
   auto &Context = VD->getASTContext();
   auto *PBD = VD->getParentPatternBinding();
@@ -2336,7 +2336,7 @@ NamingPatternRequest::evaluate(Evaluator &evaluator, VarDecl *VD) const {
   return namingPattern;
 }
 
-llvm::Expected<DeclRange>
+DeclRange
 EmittedMembersRequest::evaluate(Evaluator &evaluator,
                                 ClassDecl *CD) const {
   if (!CD->getParentSourceFile())
@@ -2437,7 +2437,7 @@ static bool isNonGenericTypeAliasType(Type type) {
   return false;
 }
 
-llvm::Expected<Type>
+Type
 ExtendedTypeRequest::evaluate(Evaluator &eval, ExtensionDecl *ext) const {
   auto error = [&ext]() {
     ext->setInvalid();

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -1283,8 +1283,7 @@ static void markAsObjC(ValueDecl *D, ObjCReason reason,
                        Optional<ForeignErrorConvention> errorConvention);
 
 
-llvm::Expected<bool>
-IsObjCRequest::evaluate(Evaluator &evaluator, ValueDecl *VD) const {
+bool IsObjCRequest::evaluate(Evaluator &evaluator, ValueDecl *VD) const {
   auto dc = VD->getDeclContext();
   Optional<ObjCReason> isObjC;
   if (dc->getSelfClassDecl() && !isa<TypeDecl>(VD)) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1967,7 +1967,7 @@ computeOverriddenAssociatedTypes(AssociatedTypeDecl *assocType) {
   return overriddenAssocTypes;
 }
 
-llvm::Expected<llvm::TinyPtrVector<ValueDecl *>>
+llvm::TinyPtrVector<ValueDecl *>
 OverriddenDeclsRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
   // Value to return in error cases
   auto noResults = llvm::TinyPtrVector<ValueDecl *>();
@@ -2082,9 +2082,8 @@ OverriddenDeclsRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
                                          OverrideCheckingAttempt::PerfectMatch);
 }
 
-llvm::Expected<bool>
-IsABICompatibleOverrideRequest::evaluate(Evaluator &evaluator,
-                                         ValueDecl *decl) const {
+bool IsABICompatibleOverrideRequest::evaluate(Evaluator &evaluator,
+                                              ValueDecl *decl) const {
   auto base = decl->getOverriddenDecl();
   if (!base)
     return false;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -336,7 +336,7 @@ static void checkInheritanceClause(
 static void installCodingKeysIfNecessary(NominalTypeDecl *NTD) {
   auto req =
     ResolveImplicitMemberRequest{NTD, ImplicitMemberAction::ResolveCodingKeys};
-  (void)evaluateOrDefault(NTD->getASTContext().evaluator, req, false);
+  (void)evaluateOrDefault(NTD->getASTContext().evaluator, req, {});
 }
 
 // Check for static properties that produce empty option sets

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -723,9 +723,8 @@ static void checkDefaultArguments(ParameterList *params) {
     (void)param->getTypeCheckedDefaultExpr();
 }
 
-llvm::Expected<Expr *>
-DefaultArgumentExprRequest::evaluate(Evaluator &evaluator,
-                                     ParamDecl *param) const {
+Expr *DefaultArgumentExprRequest::evaluate(Evaluator &evaluator,
+                                           ParamDecl *param) const {
   if (param->getDefaultArgumentKind() == DefaultArgumentKind::Inherited) {
     // Inherited default arguments don't have expressions, but we need to
     // perform a couple of semantic checks to make sure they're valid.
@@ -757,7 +756,7 @@ DefaultArgumentExprRequest::evaluate(Evaluator &evaluator,
   return initExpr;
 }
 
-llvm::Expected<Initializer *>
+Initializer *
 DefaultArgumentInitContextRequest::evaluate(Evaluator &eval,
                                             ParamDecl *param) const {
   auto &ctx = param->getASTContext();

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -684,7 +684,7 @@ static std::pair<const char *, bool> lookupDefaultTypeInfoForKnownProtocol(
   }
 }
 
-llvm::Expected<Type>
+Type
 swift::DefaultTypeRequest::evaluate(Evaluator &evaluator,
                                     KnownProtocolKind knownProtocolKind,
                                     const DeclContext *dc) const {
@@ -782,7 +782,7 @@ static Expr *synthesizeCallerSideDefault(const ParamDecl *param,
   llvm_unreachable("Unhandled case in switch");
 }
 
-llvm::Expected<Expr *> CallerSideDefaultArgExprRequest::evaluate(
+Expr *CallerSideDefaultArgExprRequest::evaluate(
     Evaluator &evaluator, DefaultArgumentExpr *defaultExpr) const {
   auto *param = defaultExpr->getParamDecl();
   auto paramTy = defaultExpr->getType();
@@ -810,9 +810,8 @@ llvm::Expected<Expr *> CallerSideDefaultArgExprRequest::evaluate(
   return initExpr;
 }
 
-llvm::Expected<bool>
-ClosureHasExplicitResultRequest::evaluate(Evaluator &evaluator,
-                                          ClosureExpr *closure) const {
+bool ClosureHasExplicitResultRequest::evaluate(Evaluator &evaluator,
+                                               ClosureExpr *closure) const {
   // A walker that looks for 'return' statements that aren't
   // nested within closures or nested declarations.
   class FindReturns : public ASTWalker {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -83,7 +83,7 @@ TypeChecker::gatherGenericParamBindingsText(
 
 /// Get the opaque type representing the return type of a declaration, or
 /// create it if it does not yet exist.
-llvm::Expected<OpaqueTypeDecl *>
+OpaqueTypeDecl *
 OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
                                   ValueDecl *originatingDecl) const {
   auto *repr = originatingDecl->getOpaqueResultTypeRepr();
@@ -577,7 +577,7 @@ static unsigned getExtendedTypeGenericDepth(ExtensionDecl *ext) {
   return sig->getGenericParams().back()->getDepth();
 }
 
-llvm::Expected<GenericSignature>
+GenericSignature
 GenericSignatureRequest::evaluate(Evaluator &evaluator,
                                   GenericContext *GC) const {
   // The signature of a Protocol is trivial (Self: TheProtocol) so let's compute
@@ -919,7 +919,7 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
   return RequirementCheckResult::SubstitutionFailure;
 }
 
-llvm::Expected<Requirement>
+Requirement
 RequirementRequest::evaluate(Evaluator &evaluator,
                              WhereClauseOwner owner,
                              unsigned index,
@@ -974,9 +974,8 @@ RequirementRequest::evaluate(Evaluator &evaluator,
   llvm_unreachable("unhandled kind");
 }
 
-llvm::Expected<Type>
-StructuralTypeRequest::evaluate(Evaluator &evaluator,
-                                TypeAliasDecl *typeAlias) const {  
+Type StructuralTypeRequest::evaluate(Evaluator &evaluator,
+                                     TypeAliasDecl *typeAlias) const {  
   TypeResolutionOptions options((typeAlias->getGenericParams()
                                      ? TypeResolverContext::GenericTypeAliasDecl
                                      : TypeResolverContext::TypeAliasDecl));

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -723,8 +723,8 @@ static TypeResolutionOptions applyContextualPatternOptions(
   return options;
 }
 
-llvm::Expected<Type> PatternTypeRequest::evaluate(
-    Evaluator &evaluator, ContextualPattern pattern) const {
+Type PatternTypeRequest::evaluate(Evaluator &evaluator,
+                                  ContextualPattern pattern) const {
   Pattern *P = pattern.getPattern();
   DeclContext *dc = pattern.getDeclContext();
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5066,7 +5066,7 @@ diagnoseMissingAppendInterpolationMethod(NominalTypeDecl *typeDecl) {
   }
 }
 
-llvm::Expected<SmallVector<ProtocolConformance *, 2>>
+SmallVector<ProtocolConformance *, 2>
 LookupAllConformancesInContextRequest::evaluate(
     Evaluator &eval, const DeclContext *DC) const {
   return DC->getLocalConformances(ConformanceLookupKind::All);
@@ -5511,7 +5511,7 @@ swift::findWitnessedObjCRequirements(const ValueDecl *witness,
   return result;
 }
 
-llvm::Expected<TypeWitnessAndDecl>
+TypeWitnessAndDecl
 TypeWitnessRequest::evaluate(Evaluator &eval,
                              NormalProtocolConformance *conformance,
                              AssociatedTypeDecl *requirement) const {
@@ -5529,7 +5529,7 @@ TypeWitnessRequest::evaluate(Evaluator &eval,
   return known->second;
 }
 
-llvm::Expected<Witness>
+Witness
 ValueWitnessRequest::evaluate(Evaluator &eval,
                               NormalProtocolConformance *conformance,
                               ValueDecl *requirement) const {

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -24,7 +24,7 @@
 
 using namespace swift;
 
-llvm::Expected<Type>
+Type
 InheritedTypeRequest::evaluate(
     Evaluator &evaluator, llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
     unsigned index,
@@ -62,7 +62,7 @@ InheritedTypeRequest::evaluate(
       evaluator(InheritedTypeRequest{decl, index,
                                      TypeResolutionStage::Interface});
     if (!result)
-      return result;
+      return Type();
 
     return dc->mapTypeIntoContext(*result);
   }
@@ -79,7 +79,7 @@ InheritedTypeRequest::evaluate(
   return inheritedType ? inheritedType : ErrorType::get(dc->getASTContext());
 }
 
-llvm::Expected<Type>
+Type
 SuperclassTypeRequest::evaluate(Evaluator &evaluator,
                                 NominalTypeDecl *nominalDecl,
                                 TypeResolutionStage stage) const {
@@ -129,7 +129,7 @@ SuperclassTypeRequest::evaluate(Evaluator &evaluator,
   return Type();
 }
 
-llvm::Expected<Type>
+Type
 EnumRawTypeRequest::evaluate(Evaluator &evaluator, EnumDecl *enumDecl,
                              TypeResolutionStage stage) const {
   for (unsigned int idx : indices(enumDecl->getInherited())) {
@@ -158,7 +158,7 @@ EnumRawTypeRequest::evaluate(Evaluator &evaluator, EnumDecl *enumDecl,
   return Type();
 }
 
-llvm::Expected<CustomAttr *>
+CustomAttr *
 AttachedFunctionBuilderRequest::evaluate(Evaluator &evaluator,
                                          ValueDecl *decl) const {
   ASTContext &ctx = decl->getASTContext();
@@ -182,9 +182,8 @@ AttachedFunctionBuilderRequest::evaluate(Evaluator &evaluator,
   return nullptr;
 }
 
-llvm::Expected<Type>
-FunctionBuilderTypeRequest::evaluate(Evaluator &evaluator,
-                                     ValueDecl *decl) const {
+Type FunctionBuilderTypeRequest::evaluate(Evaluator &evaluator,
+                                          ValueDecl *decl) const {
   // Look for a function-builder custom attribute.
   auto attr = decl->getAttachedFunctionBuilder();
   if (!attr) return Type();

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1895,7 +1895,7 @@ static void checkClassConstructorBody(ClassDecl *classDecl,
   }
 }
 
-llvm::Expected<bool>
+bool
 TypeCheckFunctionBodyUntilRequest::evaluate(Evaluator &evaluator,
                                             AbstractFunctionDecl *AFD,
                                             SourceLoc endTypeCheckLoc) const {

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -115,7 +115,7 @@ static void computeLoweredStoredProperties(NominalTypeDecl *decl) {
   }
 }
 
-llvm::Expected<ArrayRef<VarDecl *>>
+ArrayRef<VarDecl *>
 StoredPropertiesRequest::evaluate(Evaluator &evaluator,
                                   NominalTypeDecl *decl) const {
   if (!hasStoredProperties(decl))
@@ -137,7 +137,7 @@ StoredPropertiesRequest::evaluate(Evaluator &evaluator,
   return decl->getASTContext().AllocateCopy(results);
 }
 
-llvm::Expected<ArrayRef<Decl *>>
+ArrayRef<Decl *>
 StoredPropertiesAndMissingMembersRequest::evaluate(Evaluator &evaluator,
                                                    NominalTypeDecl *decl) const {
   if (!hasStoredProperties(decl))
@@ -164,7 +164,7 @@ StoredPropertiesAndMissingMembersRequest::evaluate(Evaluator &evaluator,
 }
 
 /// Validate the \c entryNumber'th entry in \c binding.
-llvm::Expected<const PatternBindingEntry *>
+const PatternBindingEntry *
 PatternBindingEntryRequest::evaluate(Evaluator &eval,
                                      PatternBindingDecl *binding,
                                      unsigned entryNumber) const {
@@ -288,7 +288,7 @@ PatternBindingEntryRequest::evaluate(Evaluator &eval,
   return &pbe;
 }
 
-llvm::Expected<bool>
+bool
 IsGetterMutatingRequest::evaluate(Evaluator &evaluator,
                                   AbstractStorageDecl *storage) const {
   auto storageDC = storage->getDeclContext();
@@ -342,7 +342,7 @@ IsGetterMutatingRequest::evaluate(Evaluator &evaluator,
   llvm_unreachable("bad impl kind");
 }
 
-llvm::Expected<bool>
+bool
 IsSetterMutatingRequest::evaluate(Evaluator &evaluator,
                                   AbstractStorageDecl *storage) const {
   // By default, the setter is mutating if we have an instance member of a
@@ -415,7 +415,7 @@ IsSetterMutatingRequest::evaluate(Evaluator &evaluator,
   llvm_unreachable("bad storage kind");
 }
 
-llvm::Expected<OpaqueReadOwnership>
+OpaqueReadOwnership
 OpaqueReadOwnershipRequest::evaluate(Evaluator &evaluator,
                                      AbstractStorageDecl *storage) const {
   return (storage->getAttrs().hasAttribute<BorrowedAttr>()
@@ -1878,7 +1878,7 @@ createModifyCoroutinePrototype(AbstractStorageDecl *storage,
   return createCoroutineAccessorPrototype(storage, AccessorKind::Modify, ctx);
 }
 
-llvm::Expected<AccessorDecl *>
+AccessorDecl *
 SynthesizeAccessorRequest::evaluate(Evaluator &evaluator,
                                     AbstractStorageDecl *storage,
                                     AccessorKind kind) const {
@@ -1906,7 +1906,7 @@ SynthesizeAccessorRequest::evaluate(Evaluator &evaluator,
   llvm_unreachable("Unhandled AccessorKind in switch");
 }
 
-llvm::Expected<bool>
+bool
 RequiresOpaqueAccessorsRequest::evaluate(Evaluator &evaluator,
                                          VarDecl *var) const {
   // Nameless vars from interface files should not have any accessors.
@@ -1953,7 +1953,7 @@ RequiresOpaqueAccessorsRequest::evaluate(Evaluator &evaluator,
   return true;
 }
 
-llvm::Expected<bool>
+bool
 RequiresOpaqueModifyCoroutineRequest::evaluate(Evaluator &evaluator,
                                                AbstractStorageDecl *storage) const {
   // Only for mutable storage.
@@ -1997,7 +1997,7 @@ RequiresOpaqueModifyCoroutineRequest::evaluate(Evaluator &evaluator,
 /// If the storage is for a global stored property or a stored property of a
 /// resilient type, we are synthesizing accessors to present a resilient
 /// interface to the storage and they should not be transparent.
-llvm::Expected<bool>
+bool
 IsAccessorTransparentRequest::evaluate(Evaluator &evaluator,
                                        AccessorDecl *accessor) const {
   auto *storage = accessor->getStorage();
@@ -2114,7 +2114,7 @@ IsAccessorTransparentRequest::evaluate(Evaluator &evaluator,
   return true;
 }
 
-llvm::Expected<VarDecl *>
+VarDecl *
 LazyStoragePropertyRequest::evaluate(Evaluator &evaluator,
                                      VarDecl *VD) const {
   assert(isa<SourceFile>(VD->getDeclContext()->getModuleScopeContext()));
@@ -2288,7 +2288,7 @@ getSetterMutatingness(VarDecl *var, DeclContext *dc) {
     : PropertyWrapperMutability::Nonmutating;
 }
 
-llvm::Expected<Optional<PropertyWrapperMutability>>
+Optional<PropertyWrapperMutability>
 PropertyWrapperMutabilityRequest::evaluate(Evaluator &,
                                            VarDecl *var) const {
   VarDecl *originalVar = var;
@@ -2362,7 +2362,7 @@ PropertyWrapperMutabilityRequest::evaluate(Evaluator &,
   return result;
 }
 
-llvm::Expected<PropertyWrapperBackingPropertyInfo>
+PropertyWrapperBackingPropertyInfo
 PropertyWrapperBackingPropertyInfoRequest::evaluate(Evaluator &evaluator,
                                                     VarDecl *var) const {
   // Determine the type of the backing property.
@@ -2750,7 +2750,7 @@ static StorageImplInfo classifyWithHasStorageAttr(VarDecl *var) {
   return StorageImplInfo(ReadImplKind::Stored, writeImpl, readWriteImpl);
 }
 
-llvm::Expected<StorageImplInfo>
+StorageImplInfo
 StorageImplInfoRequest::evaluate(Evaluator &evaluator,
                                  AbstractStorageDecl *storage) const {
   if (auto *param = dyn_cast<ParamDecl>(storage)) {

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -319,7 +319,7 @@ void swift::performTypeChecking(SourceFile &SF) {
                                  TypeCheckSourceFileRequest{&SF}, {});
 }
 
-llvm::Expected<evaluator::SideEffect>
+evaluator::SideEffect
 TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
   assert(SF && "Source file cannot be null!");
   assert(SF->ASTStage != SourceFile::TypeChecked &&

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -316,10 +316,10 @@ static void typeCheckDelayedFunctions(SourceFile &SF) {
 
 void swift::performTypeChecking(SourceFile &SF) {
   return (void)evaluateOrDefault(SF.getASTContext().evaluator,
-                                 TypeCheckSourceFileRequest{&SF}, false);
+                                 TypeCheckSourceFileRequest{&SF}, {});
 }
 
-llvm::Expected<bool>
+llvm::Expected<evaluator::SideEffect>
 TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
   assert(SF && "Source file cannot be null!");
   assert(SF->ASTStage != SourceFile::TypeChecked &&
@@ -388,7 +388,7 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
     performWholeModuleTypeChecking(*SF);
   }
 
-  return true;
+  return std::make_tuple<>();
 }
 
 void swift::performWholeModuleTypeChecking(SourceFile &SF) {

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -986,7 +986,7 @@ static bool hasLinkerDirective(Decl *D) {
   return !getAllMovedPlatformVersions(D).empty();
 }
 
-llvm::Expected<TBDFileAndSymbols>
+TBDFileAndSymbols
 GenerateTBDRequest::evaluate(Evaluator &evaluator,
                              TBDGenDescriptor desc) const {
   auto *M = desc.getParentModule();

--- a/unittests/AST/ArithmeticEvaluator.cpp
+++ b/unittests/AST/ArithmeticEvaluator.cpp
@@ -81,6 +81,12 @@ void simple_display(llvm::raw_ostream &out, ArithmeticExpr *expr) {
   }
 }
 
+/// Helper to short-circuit errors to NaN.
+template<typename Request>
+static double evalOrNaN(Evaluator &evaluator, const Request &request) {
+  return evaluateOrDefault(evaluator, request, NAN);
+}
+
 /// Rule to evaluate the value of the expression.
 template<typename Derived, CacheKind Caching>
 struct EvaluationRule
@@ -89,8 +95,9 @@ struct EvaluationRule
   using SimpleRequest<Derived, double(ArithmeticExpr *), Caching>
       ::SimpleRequest;
 
-  llvm::Expected<double>
-  evaluate(Evaluator &evaluator, ArithmeticExpr *expr) const {
+  static bool brokeCycle;
+
+  double evaluate(Evaluator &evaluator, ArithmeticExpr *expr) const {
     switch (expr->kind) {
     case ArithmeticExpr::Kind::Literal:
       return static_cast<Literal *>(expr)->value;
@@ -99,19 +106,23 @@ struct EvaluationRule
       auto binary = static_cast<Binary *>(expr);
 
       // Evaluate the left- and right-hand sides.
-      auto lhsValue = evaluator(Derived{binary->lhs});
-      if (!lhsValue)
+      auto lhsValue = evalOrNaN(evaluator, Derived{binary->lhs});
+      if (lhsValue != lhsValue) {
+        brokeCycle = true;
         return lhsValue;
-      auto rhsValue = evaluator(Derived{binary->rhs});
-      if (!rhsValue)
+      }
+      auto rhsValue = evalOrNaN(evaluator, Derived{binary->rhs});
+      if (rhsValue != rhsValue) {
+        brokeCycle = true;
         return rhsValue;
+      }
 
       switch (binary->operatorKind) {
       case Binary::OperatorKind::Sum:
-        return *lhsValue + *rhsValue;
+        return lhsValue + rhsValue;
 
       case Binary::OperatorKind::Product:
-        return *lhsValue * *rhsValue;
+        return lhsValue * rhsValue;
       }
     }
     }
@@ -119,6 +130,9 @@ struct EvaluationRule
 
   SourceLoc getNearestLoc() const { return SourceLoc(); }
 };
+
+template<typename Derived, CacheKind Caching>
+bool EvaluationRule<Derived, Caching>::brokeCycle = false;
 
 struct InternallyCachedEvaluationRule :
 EvaluationRule<InternallyCachedEvaluationRule, CacheKind::Cached>
@@ -191,12 +205,6 @@ static AbstractRequestFunction *arithmeticRequestFunctions[] = {
 #include "ArithmeticEvaluatorTypeIDZone.def"
 #undef SWIFT_REQUEST
 };
-
-/// Helper to short-circuit errors to NaN.
-template<typename Request>
-static double evalOrNaN(Evaluator &evaluator, const Request &request) {
-  return evaluateOrDefault(evaluator, request, NAN);
-}
 
 
 TEST(ArithmeticEvaluator, Simple) {
@@ -342,15 +350,42 @@ TEST(ArithmeticEvaluator, Cycle) {
                                      arithmeticRequestFunctions);
 
   // Evaluate when there is a cycle.
-  bool cycleDetected = false;
-  auto result = evaluator(UncachedEvaluationRule(sum));
-  if (auto err = result.takeError()) {
-    llvm::handleAllErrors(std::move(err),
-      [&](const CyclicalRequestError<UncachedEvaluationRule> &E) {
-        cycleDetected = true;
-      });
-  }
-  EXPECT_TRUE(cycleDetected);
+  UncachedEvaluationRule::brokeCycle = false;
+  EXPECT_TRUE(std::isnan(evalOrNaN(evaluator,
+                                   UncachedEvaluationRule(product))));
+  EXPECT_TRUE(UncachedEvaluationRule::brokeCycle);
+
+  // Cycle-breaking result is cached.
+  EXPECT_TRUE(std::isnan(evalOrNaN(evaluator,
+                                   UncachedEvaluationRule(product))));
+  UncachedEvaluationRule::brokeCycle = false;
+  EXPECT_FALSE(UncachedEvaluationRule::brokeCycle);
+
+  // Evaluate when there is a cycle.
+  evaluator.clearCache();
+  InternallyCachedEvaluationRule::brokeCycle = false;
+  EXPECT_TRUE(std::isnan(evalOrNaN(evaluator,
+                                   InternallyCachedEvaluationRule(product))));
+  EXPECT_TRUE(InternallyCachedEvaluationRule::brokeCycle);
+
+  // Cycle-breaking result is cached.
+  InternallyCachedEvaluationRule::brokeCycle = false;
+  EXPECT_TRUE(std::isnan(evalOrNaN(evaluator,
+                                   InternallyCachedEvaluationRule(product))));
+  EXPECT_FALSE(InternallyCachedEvaluationRule::brokeCycle);
+
+  // Evaluate when there is a cycle.
+  evaluator.clearCache();
+  ExternallyCachedEvaluationRule::brokeCycle = false;
+  EXPECT_TRUE(std::isnan(evalOrNaN(evaluator,
+                                   ExternallyCachedEvaluationRule(product))));
+  EXPECT_TRUE(ExternallyCachedEvaluationRule::brokeCycle);
+
+  // Cycle-breaking result is cached.
+  ExternallyCachedEvaluationRule::brokeCycle = false;
+  EXPECT_TRUE(std::isnan(evalOrNaN(evaluator,
+                                   ExternallyCachedEvaluationRule(product))));
+  EXPECT_FALSE(ExternallyCachedEvaluationRule::brokeCycle);
 
   // Dependency printing.
   std::string productDependencies;


### PR DESCRIPTION
These commits contain:

- Make the few places we have requests that just execute side effects painfully clear with the new `evaluator::SideEffect` return type - an alias to `std::tuple<>`
- Strip the evaluation points of `llvm::Expected`. Request evaluation itself may still fail with an error - that is a valuable behavior to preserve because it means we can still perform rich error reporting and handling during request evaluation. But the evaluation functions themselves have no need to return error values as they should be pure functions of their input state. The evaluator framework itself handles the actual cycle detection and request cancellation portions just fine.

A few requests that were taking advantage of being able to cancel cycles by bubbling errors back up were reverted to their behavior before #18454.