### PR TITLE
Add a test documenting the current state of C++ exception handling

### DIFF
--- a/test/ClangImporter/Inputs/custom-modules/CxxExceptions.h
+++ b/test/ClangImporter/Inputs/custom-modules/CxxExceptions.h
@@ -1,0 +1,20 @@
+class MyException {
+public:
+  virtual ~MyException() {}
+};
+
+// Calls f and catches any exceptions thrown by f.
+// Returns whether an exception was caught.
+inline bool callAndCatchExceptions(void (*f)()) {
+  try {
+    f();
+  } catch (...) {
+    return true;
+  }
+
+  return false;
+}
+
+inline void throwException() {
+  throw MyException();
+}

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -41,6 +41,11 @@ module CoreCooling {
   export *
 }
 
+module CxxExceptions {
+  header "CxxExceptions.h"
+  link "stdc++"
+}
+
 module CXXInterop {
   header "cxx_interop.h"
 }

--- a/test/ClangImporter/cxx-exceptions-executable.swift
+++ b/test/ClangImporter/cxx-exceptions-executable.swift
@@ -15,7 +15,8 @@ CxxExceptionsTestSuite.test("UncaughtException") {
 }
 
 // Exceptions can be thrown and caught within C++ code if they don't cross any
-// interop boundaries.
+// interop boundaries. In addition, ClangImporter correctly codegens throw and
+// try-catch in a C++ inline function.
 CxxExceptionsTestSuite.test("ExceptionCaughtWithinCpp") {
   expectTrue(callAndCatchExceptions(throwException))
 }

--- a/test/ClangImporter/cxx-exceptions-executable.swift
+++ b/test/ClangImporter/cxx-exceptions-executable.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -I %S/Inputs/custom-modules/ -o %t/cxx_exceptions -Xfrontend -enable-cxx-interop
+// RUN: %target-codesign %t/cxx_exceptions
+// RUN: %target-run %t/cxx_exceptions
+
+import CxxExceptions
+import StdlibUnittest
+
+var CxxExceptionsTestSuite = TestSuite("CxxExceptions")
+
+// Uncaught C++ exceptions terminate the program.
+CxxExceptionsTestSuite.test("UncaughtException") {
+  expectCrashLater(withMessage: "terminate called")
+  throwException()
+}
+
+// Exceptions can be thrown and caught within C++ code if they don't cross any
+// interop boundaries.
+CxxExceptionsTestSuite.test("ExceptionCaughtWithinCpp") {
+  expectTrue(callAndCatchExceptions(throwException))
+}
+
+// Exceptions cannot be thrown across interop boundaries. If while unwinding the
+// stack we reach a Swift stack frame, the program terminates.
+// FIXME: This test documents the current behavior, which is wrong. Currently,
+// exceptions will propagate through Swift code. This is bad, because Swift
+// stack frames will be unwound without doing any potentially necessary
+// cleanups.
+// I'm documenting the wrong behavior instead of making this an XFAIL because I
+// want to show exactly how this fails today.
+CxxExceptionsTestSuite.test("DontUnwindAcrossSwiftStackFrame") {
+  func callThrowException() {
+    throwException()
+  }
+  
+  expectTrue(callAndCatchExceptions(callThrowException))
+}
+
+runAllTests()


### PR DESCRIPTION
Swift currently allows C++ exceptions to propagate across Swift stack frames, which is wrong; this test documents that, but also the current behaviors that are fine.

See also the discussion here:
https://forums.swift.org/t/handling-c-exceptions/34823

I'm not sure whether this test will on all platforms, particularly Windows. I may restrict it to certain platforms if build bots show it doesn't work everywhere.