### PR TITLE
[Reflection Tests] Mark 7 tests as unsupported on iOS 32bits

### DIFF
--- a/test/Reflection/box_descriptors.sil
+++ b/test/Reflection/box_descriptors.sil
@@ -5,6 +5,8 @@
 // SR-10758
 // UNSUPPORTED: linux
 
+// UNSUPPORTED: CPU=i386 && OS=ios // rdar://problem/60966825
+
 sil_stage canonical
 
 import Builtin

--- a/test/Reflection/capture_descriptors.sil
+++ b/test/Reflection/capture_descriptors.sil
@@ -4,6 +4,8 @@
 // RUN: %target-build-swift %s -emit-module -emit-library -module-name capture_descriptors -o %t/capture_descriptors%{target-shared-library-suffix} -L%t/../../.. -lBlocksRuntime
 // RUN: %target-swift-reflection-dump -binary-filename %t/capture_descriptors%{target-shared-library-suffix} | %FileCheck %s
 
+// UNSUPPORTED: CPU=i386 && OS=ios // rdar://problem/60966825
+
 sil_stage canonical
 
 import Builtin

--- a/test/Reflection/typeref_decoding.swift
+++ b/test/Reflection/typeref_decoding.swift
@@ -7,6 +7,8 @@
 // RUN: %target-swift-reflection-dump -binary-filename %t/%target-library-name(TypesToReflect) | %FileCheck %s
 // RUN: %target-swift-reflection-dump -binary-filename %t/TypesToReflect | %FileCheck %s
 
+// UNSUPPORTED: CPU=i386 && OS=ios // rdar://problem/60966825
+
 // CHECK: FIELDS:
 // CHECK: =======
 // CHECK: TypesToReflect.Box

--- a/test/Reflection/typeref_decoding_imported.swift
+++ b/test/Reflection/typeref_decoding_imported.swift
@@ -1,6 +1,7 @@
 // XFAIL: OS=windows-msvc
 
 // UNSUPPORTED: CPU=arm64e
+// UNSUPPORTED: CPU=i386 && OS=ios // rdar://problem/60966825
 
 // RUN: %empty-directory(%t)
 

--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -6,6 +6,8 @@
 // Disable asan builds until we build swift-reflection-dump and the reflection library with the same compile: rdar://problem/30406870
 // REQUIRES: no_asan
 
+// UNSUPPORTED: CPU=i386 && OS=ios // rdar://problem/60966825
+
 // CHECK: FIELDS:
 // CHECK: =======
 // CHECK: TypesToReflect.OC

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -1,5 +1,6 @@
 // REQUIRES: no_asan
 // XFAIL: OS=windows-msvc
+// UNSUPPORTED: CPU=i386 && OS=ios // rdar://problem/60966825
 // RUN: %empty-directory(%t)
 
 // UNSUPPORTED: CPU=arm64e

--- a/test/Reflection/typeref_lowering_imported.swift
+++ b/test/Reflection/typeref_lowering_imported.swift
@@ -12,6 +12,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: CPU=x86_64
+// UNSUPPORTED: CPU=i386 && OS=ios // rdar://problem/60966825
 
 12TypeLowering9HasCTypesV
 // CHECK:     (struct TypeLowering.HasCTypes)


### PR DESCRIPTION
These tests fail on some machines only, it may depend on the OS or Xcode version. Marking them as unsupported should unblock https://ci.swift.org/job/oss-swift_tools-R_stdlib-RD_test-simulator/

rdar://problem/60966825
