### PR TITLE
[AutoDiff upstream] Add `@differentiable` function reabstraction.

### DIFF
--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1082,7 +1082,8 @@ public:
     // type.
 
     // The entire original context could be a generic parameter.
-    if (origType.isTypeParameter()) {
+    if (origType.isTypeParameter() ||
+        origType.isOpaqueFunctionOrOpaqueDerivativeFunction()) {
       return addSubstitution(origType.getLayoutConstraint(), substType,
                              nullptr, {});
     }
@@ -1252,6 +1253,10 @@ public:
          && !origType.requiresClass())
         || substTL.isAddressOnly()) {
       return true;
+
+    // Functions are always returned directly.
+    } else if (origType.isOpaqueFunctionOrOpaqueDerivativeFunction()) {
+      return false;
 
     // If the substitution didn't change the type, then a negative
     // response to the above is determinative as well.

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -268,7 +268,8 @@ namespace {
 
     RetTy visitAbstractTypeParamType(CanType type,
                                      AbstractionPattern origType) {
-      if (origType.isTypeParameterOrOpaqueArchetype()) {
+      if (origType.isTypeParameterOrOpaqueArchetype() ||
+          origType.isOpaqueFunctionOrOpaqueDerivativeFunction()) {
         if (origType.requiresClass()) {
           return asImpl().handleReference(type);
         } else {

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3272,6 +3272,11 @@ static ManagedValue createPartialApplyOfThunk(SILGenFunction &SGF,
                              toType->getCalleeConvention());
 }
 
+static ManagedValue createDifferentiableFunctionThunk(
+    SILGenFunction &SGF, SILLocation loc, ManagedValue fn,
+    AbstractionPattern inputOrigType, CanAnyFunctionType inputSubstType,
+    AbstractionPattern outputOrigType, CanAnyFunctionType outputSubstType);
+
 /// Create a reabstraction thunk.
 static ManagedValue createThunk(SILGenFunction &SGF,
                                 SILLocation loc,
@@ -3297,6 +3302,14 @@ static ManagedValue createThunk(SILGenFunction &SGF,
   
   auto expectedType = substExpectedType
     ->getUnsubstitutedType(SGF.SGM.M);
+
+  assert(sourceType->isDifferentiable() == expectedType->isDifferentiable() &&
+         "thunks can't change differentiability");
+  if (sourceType->isDifferentiable()) {
+    return createDifferentiableFunctionThunk(SGF, loc, fn, inputOrigType,
+                                             inputSubstType, outputOrigType,
+                                             outputSubstType);
+  }
 
   // We can't do bridging here.
   assert(expectedType->getLanguage() ==
@@ -3355,6 +3368,104 @@ static ManagedValue createThunk(SILGenFunction &SGF,
   assert(substExpectedType->isNoEscape());
   return SGF.B.createConvertEscapeToNoEscape(
       loc, thunkedFn, SILType::getPrimitiveObjectType(substExpectedType));
+}
+
+/// Create a reabstraction thunk for a @differentiable function.
+static ManagedValue createDifferentiableFunctionThunk(
+    SILGenFunction &SGF, SILLocation loc, ManagedValue fn,
+    AbstractionPattern inputOrigType, CanAnyFunctionType inputSubstType,
+    AbstractionPattern outputOrigType, CanAnyFunctionType outputSubstType) {
+  // Applies a thunk to all the components by extracting them, applying thunks
+  // to all of them, and then putting them back together.
+  auto sourceType = fn.getType().castTo<SILFunctionType>();
+
+  auto withoutDifferentiablePattern =
+      [](AbstractionPattern pattern) -> AbstractionPattern {
+    auto patternType = pattern.getAs<AnyFunctionType>();
+    // If pattern does not store an `AnyFunctionType`, return original pattern.
+    // This logic handles opaque abstraction patterns.
+    if (!patternType)
+      return pattern;
+    pattern.rewriteType(
+        pattern.getGenericSignature(),
+        patternType->getWithoutDifferentiability()->getCanonicalType());
+    return pattern;
+  };
+
+  auto inputOrigTypeNotDiff = withoutDifferentiablePattern(inputOrigType);
+  CanAnyFunctionType inputSubstTypeNotDiff(
+      inputSubstType->getWithoutDifferentiability());
+  auto outputOrigTypeNotDiff = withoutDifferentiablePattern(outputOrigType);
+  CanAnyFunctionType outputSubstTypeNotDiff(
+      outputSubstType->getWithoutDifferentiability());
+  auto &expectedTLNotDiff =
+      SGF.getTypeLowering(outputOrigTypeNotDiff, outputSubstTypeNotDiff);
+  // `differentiable_function_extract` takes `@guaranteed` values.
+  auto borrowedFnValue = fn.borrow(SGF, loc);
+  SILValue original = SGF.B.createDifferentiableFunctionExtractOriginal(
+      loc, borrowedFnValue.getValue());
+  original = SGF.B.emitCopyValueOperation(loc, original);
+  auto managedOriginal = SGF.emitManagedRValueWithCleanup(original);
+
+  ManagedValue originalThunk = createThunk(
+      SGF, loc, managedOriginal, inputOrigTypeNotDiff, inputSubstTypeNotDiff,
+      outputOrigTypeNotDiff, outputSubstTypeNotDiff, expectedTLNotDiff);
+
+  auto numUncurriedParams = inputSubstType->getNumParams();
+  if (auto *resultFnType =
+          inputSubstType->getResult()->getAs<AnyFunctionType>()) {
+    numUncurriedParams += resultFnType->getNumParams();
+  }
+  llvm::SmallBitVector parameterBits(numUncurriedParams);
+  for (auto i : range(inputSubstType->getNumParams()))
+    if (!inputSubstType->getParams()[i].isNoDerivative())
+      parameterBits.set(i);
+  auto *parameterIndices = IndexSubset::get(SGF.getASTContext(), parameterBits);
+
+  auto getDerivativeFnTy =
+      [&](CanAnyFunctionType fnTy,
+          AutoDiffDerivativeFunctionKind kind) -> CanAnyFunctionType {
+    auto assocTy = fnTy->getAutoDiffDerivativeFunctionType(
+        parameterIndices, kind,
+        LookUpConformanceInModule(SGF.SGM.M.getSwiftModule()));
+    return cast<AnyFunctionType>(assocTy->getCanonicalType());
+  };
+  auto getDerivativeFnPattern =
+      [&](AbstractionPattern pattern,
+          AutoDiffDerivativeFunctionKind kind) -> AbstractionPattern {
+    return pattern.getAutoDiffDerivativeFunctionType(
+        parameterIndices, kind,
+        LookUpConformanceInModule(SGF.SGM.M.getSwiftModule()));
+  };
+  auto createDerivativeFnThunk =
+      [&](AutoDiffDerivativeFunctionKind kind) -> ManagedValue {
+    auto derivativeFnInputOrigType =
+        getDerivativeFnPattern(inputOrigTypeNotDiff, kind);
+    auto derivativeFnInputSubstType =
+        getDerivativeFnTy(inputSubstTypeNotDiff, kind);
+    auto derivativeFnOutputOrigType =
+        getDerivativeFnPattern(outputOrigTypeNotDiff, kind);
+    auto derivativeFnOutputSubstType =
+        getDerivativeFnTy(outputSubstTypeNotDiff, kind);
+    auto &derivativeFnExpectedTL = SGF.getTypeLowering(
+        derivativeFnOutputOrigType, derivativeFnOutputSubstType);
+    SILValue derivativeFn = SGF.B.createDifferentiableFunctionExtract(
+        loc, kind, borrowedFnValue.getValue());
+    derivativeFn = SGF.B.emitCopyValueOperation(loc, derivativeFn);
+    auto managedDerivativeFn = SGF.emitManagedRValueWithCleanup(derivativeFn);
+    return createThunk(SGF, loc, managedDerivativeFn, derivativeFnInputOrigType,
+                       derivativeFnInputSubstType, derivativeFnOutputOrigType,
+                       derivativeFnOutputSubstType, derivativeFnExpectedTL);
+  };
+
+  auto jvpThunk = createDerivativeFnThunk(AutoDiffDerivativeFunctionKind::JVP);
+  auto vjpThunk = createDerivativeFnThunk(AutoDiffDerivativeFunctionKind::VJP);
+
+  SILValue convertedBundle = SGF.B.createDifferentiableFunction(
+      loc, sourceType->getDifferentiabilityParameterIndices(),
+      originalThunk.forward(SGF),
+      std::make_pair(jvpThunk.forward(SGF), vjpThunk.forward(SGF)));
+  return SGF.emitManagedRValueWithCleanup(convertedBundle);
 }
 
 static CanSILFunctionType buildWithoutActuallyEscapingThunkType(

--- a/test/AutoDiff/SILGen/reabstraction.swift
+++ b/test/AutoDiff/SILGen/reabstraction.swift
@@ -1,0 +1,82 @@
+// RUN: %target-swift-frontend -emit-silgen -enable-experimental-differentiable-programming %s | %FileCheck %s
+
+import _Differentiation
+
+@_silgen_name("triggerReabstraction1")
+func triggerReabstraction1<T: Differentiable>(_ f: @escaping @differentiable (T) -> T) {}
+
+@_silgen_name("triggerReabstraction2")
+func triggerReabstraction2<T>(_ t: T) {}
+
+@_silgen_name("differentiable1")
+func differentiable1(_ x: Float) -> Float { x }
+
+@_silgen_name("differentiable2")
+func differentiable2<T: Differentiable>(_ t: T) -> T { t }
+
+@_silgen_name("makeSignatureAbstract")
+func makeSignatureAbstract() {
+  triggerReabstraction1(differentiable1)
+}
+
+// CHECK-LABEL: sil{{.*}}@makeSignatureAbstract
+// CHECK:   [[BEFORE:%.*]] = differentiable_function [parameters 0]
+// CHECK:   [[BEFORE_BORROWED:%.*]] = begin_borrow [[BEFORE]]
+// CHECK:   [[ORIG_0:%.*]] = differentiable_function_extract [original] [[BEFORE_BORROWED]]
+// CHECK:   [[ORIG_1:%.*]] = copy_value [[ORIG_0]]
+// CHECK:   [[ORIG_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> Float) -> @out Float
+// CHECK:   [[ORIG_2:%.*]] = partial_apply [callee_guaranteed] [[ORIG_THUNK]]([[ORIG_1]])
+// CHECK:   [[ORIG_3:%.*]] = convert_function [[ORIG_2]]
+// CHECK:   [[JVP_0:%.*]] = differentiable_function_extract [jvp] [[BEFORE_BORROWED]]
+// CHECK:   [[JVP_1:%.*]] = copy_value [[JVP_0]]
+// CHECK:   [[JVP_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)) -> (@out Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <Float, Float>)
+// CHECK:   [[JVP_2:%.*]] = partial_apply [callee_guaranteed] [[JVP_THUNK]]([[JVP_1]])
+// CHECK:   [[JVP_3:%.*]] = convert_function [[JVP_2]]
+// CHECK:   [[VJP_0:%.*]] = differentiable_function_extract [vjp] [[BEFORE_BORROWED]]
+// CHECK:   [[VJP_1:%.*]] = copy_value [[VJP_0]]
+// CHECK:   [[VJP_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)) -> (@out Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <Float, Float>)
+// CHECK:   [[VJP_2:%.*]] = partial_apply [callee_guaranteed] [[VJP_THUNK]]([[VJP_1]])
+// CHECK:   [[VJP_3:%.*]] = convert_function [[VJP_2]]
+// CHECK:   [[AFTER:%.*]] = differentiable_function [parameters 0] [[ORIG_3]] {{.*}} with_derivative {[[JVP_3]] {{.*}}, [[VJP_3]] {{.*}}}
+// CHECK:   [[TRIGGER:%.*]] = function_ref @triggerReabstraction1
+// CHECK:   apply [[TRIGGER]]<Float>([[AFTER]])
+
+@_silgen_name("makeOpaque")
+func makeOpaque() {
+  let f: @differentiable (Float) -> Float = differentiable1
+  triggerReabstraction2(f)
+}
+
+// CHECK-LABEL: sil{{.*}}@makeOpaque
+// CHECK:   [[STACK_ADDR:%.*]] = alloc_stack $@differentiable @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <Float, Float>
+// CHECK:   [[ORIG_0:%.*]] = differentiable_function_extract [original] [[BEFORE:%.*]] : $@differentiable @callee_guaranteed (Float) -> Float
+// CHECK:   [[ORIG_1:%.*]] = copy_value [[ORIG_0]]
+// CHECK:   [[ORIG_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> Float) -> @out Float
+// CHECK:   [[ORIG_2:%.*]] = partial_apply [callee_guaranteed] [[ORIG_THUNK]]([[ORIG_1]])
+// CHECK:   [[ORIG_3:%.*]] = convert_function [[ORIG_2]]
+// CHECK:   [[JVP_0:%.*]] = differentiable_function_extract [jvp] [[BEFORE]]
+// CHECK:   [[JVP_1:%.*]] = copy_value [[JVP_0]]
+// CHECK:   [[JVP_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)) -> (@out Float, @out @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <Float, Float>)
+// CHECK:   [[JVP_2:%.*]] = partial_apply [callee_guaranteed] [[JVP_THUNK]]([[JVP_1]])
+// CHECK:   [[JVP_3:%.*]] = convert_function [[JVP_2]]
+// CHECK:   [[VJP_0:%.*]] = differentiable_function_extract [vjp] [[BEFORE]]
+// CHECK:   [[VJP_1:%.*]] = copy_value [[VJP_0]]
+// CHECK:   [[VJP_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)) -> (@out Float, @out @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <Float, Float>)
+// CHECK:   [[VJP_2:%.*]] = partial_apply [callee_guaranteed] [[VJP_THUNK]]([[VJP_1]])
+// CHECK:   [[VJP_3:%.*]] = convert_function [[VJP_2]]
+// CHECK:   [[AFTER:%.*]] = differentiable_function [parameters 0] [[ORIG_3]] {{.*}} with_derivative {[[JVP_3]] {{.*}}, [[VJP_3]] {{.*}}}
+// CHECK:   store [[AFTER]] to [init] [[STACK_ADDR]]
+// CHECK:   [[TRIGGER:%.*]] = function_ref @triggerReabstraction2
+// CHECK:   apply [[TRIGGER]]<@differentiable (Float) -> Float>([[STACK_ADDR]])
+
+@_silgen_name("makeSignatureDirect")
+func makeSignatureDirect() {
+  let _: @differentiable (Float) -> Float = differentiable2
+}
+
+// CHECK-LABEL: sil{{.*}}@makeSignatureDirect
+// CHECK:  [[ORIG_0:%.*]] = function_ref @differentiable2
+// CHECK:  [[ORIG_1:%.*]] = partial_apply [callee_guaranteed] [[ORIG_0]]<Float>()
+// CHECK:  [[THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float
+// CHECK:  [[ORIG_2:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[ORIG_1]])
+// CHECK:  differentiable_function [parameters 0] [[ORIG_2]]


### PR DESCRIPTION
Add SILGen logic for reabstracting `@differentiable` functions.

This is simply the work that @dan-zheng already did in 94efee120bae44b028327e769c7c66a812abb255, plus a new SILGen FileCheck test that tests reabstraction in isolation from all the other parts.

The simple example mentioned in 94efee120bae44b028327e769c7c66a812abb255 still fails in IRGen, but I'm pretty sure that is a separate issue in IRGen unrelated to reabstraction.

Resolves TF-1223.