### PR TITLE
Backport: Update cmake version to 3.16.5

### DIFF
--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -243,7 +243,7 @@ class CMake(object):
         cwd = os.getcwd()
         os.chdir(cmake_build_dir)
         shell.call_without_sleeping([cmake_bootstrap], echo=True)
-        shell.call_without_sleeping(['make', '-j%s' % self.args.build_jobs],
+        shell.call_without_sleeping(['make', '-DCMAKE_USE_OPENSSL=OFF', '-j%s' % self.args.build_jobs],
                                     echo=True)
         os.chdir(cwd)
         return os.path.join(cmake_build_dir, 'bin', 'cmake')

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -242,8 +242,8 @@ class CMake(object):
 
         cwd = os.getcwd()
         os.chdir(cmake_build_dir)
-        shell.call_without_sleeping([cmake_bootstrap], echo=True)
-        shell.call_without_sleeping(['make', '-DCMAKE_USE_OPENSSL=OFF', '-j%s' % self.args.build_jobs],
+        shell.call_without_sleeping([cmake_bootstrap, '--', '-DCMAKE_USE_OPENSSL=OFF'], echo=True)
+        shell.call_without_sleeping(['make','-j%s' % self.args.build_jobs],
                                     echo=True)
         os.chdir(cwd)
         return os.path.join(cmake_build_dir, 'bin', 'cmake')

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -242,7 +242,8 @@ class CMake(object):
 
         cwd = os.getcwd()
         os.chdir(cmake_build_dir)
-        shell.call_without_sleeping([cmake_bootstrap, '--', '-DCMAKE_USE_OPENSSL=OFF'], echo=True)
+        shell.call_without_sleeping([cmake_bootstrap, '--',
+                                    '-DCMAKE_USE_OPENSSL=OFF'], echo=True)
         shell.call_without_sleeping(['make','-j%s' % self.args.build_jobs],
                                     echo=True)
         os.chdir(cwd)

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -244,7 +244,7 @@ class CMake(object):
         os.chdir(cmake_build_dir)
         shell.call_without_sleeping([cmake_bootstrap, '--',
                                     '-DCMAKE_USE_OPENSSL=OFF'], echo=True)
-        shell.call_without_sleeping(['make','-j%s' % self.args.build_jobs],
+        shell.call_without_sleeping(['make', '-j%s' % self.args.build_jobs],
                                     echo=True)
         os.chdir(cwd)
         return os.path.join(cmake_build_dir, 'bin', 'cmake')

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -65,7 +65,7 @@
                 "swift-xcode-playground-support": "master",
                 "ninja": "release",
                 "icu": "release-65-1",
-                "cmake": "v3.15.1",
+                "cmake": "v3.16.5",
                 "indexstore-db": "master",
                 "sourcekit-lsp": "master",
                 "swift-format": "master"
@@ -91,7 +91,7 @@
                 "swift-xcode-playground-support": "master",
                 "ninja": "release",
                 "icu": "release-65-1",
-                "cmake": "v3.15.1",
+                "cmake": "v3.16.5",
                 "indexstore-db": "master",
                 "sourcekit-lsp": "master",
                 "swift-format": "master"
@@ -263,7 +263,7 @@
                 "swift-xcode-playground-support": "swift-5.2-branch",
                 "ninja": "release",
                 "icu": "release-65-1",
-                "cmake": "v3.15.1",
+                "cmake": "v3.16.5",
                 "indexstore-db": "swift-5.2-branch",
                 "sourcekit-lsp": "swift-5.2-branch",
                 "swift-format": "master"


### PR DESCRIPTION
3.15.1 contains a bug that causes libraries that use the CMake Swift module to be built with -Onone, even in release mode.