### PR TITLE
[PrintAsObjC] Revert emission of header #imports

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -332,42 +332,8 @@ static void writeImports(raw_ostream &out,
       allPaths.append(module->getTopLevelModuleName());
       llvm::sys::path::append(allPaths, Buffer.str());
     } else {
-      auto DirPath = header.Entry->getDir()->getName();
-      auto I = llvm::sys::path::begin(DirPath),
-           E = llvm::sys::path::end(DirPath);
-      llvm::SmallVector<StringRef, 4> Comps;
-      // Check if the path of the header contains `/usr/include/` in it.
-      // If so, we print the header include path starting from the next component.
-      // e.g. for .../usr/include/dispatch/dispatch.h, we print
-      // #include "dispatch/dispatch.h" because we could assume /usr/include/ is
-      // in the header search paths.
-      while (true) {
-        StringRef Parts[2] = {*I, StringRef()};
-        ++ I;
-        if (I == E)
-          break;
-        Parts[1] = *I;
-        if (Parts[0] == "usr" && Parts[1] == "include") {
-          ++ I;
-          for (;I != E; ++ I) {
-            Comps.push_back(*I);
-          }
-          break;
-        }
-      };
-      if (!Comps.empty()) {
-        // The header is in a deeper location inside /usr/include/, add the
-        // additional path components before adding the header name.
-        allPaths.append(Comps.front());
-        for (auto c: llvm::makeArrayRef(Comps).slice(1)) {
-          llvm::sys::path::append(allPaths, c);
-        }
-        llvm::sys::path::append(allPaths,
-                                llvm::sys::path::filename(header.NameAsWritten));
-      } else {
-        // Otherwise, import the header directly.
-        allPaths.append(header.NameAsWritten);
-      }
+      // Otherwise, import the header directly.
+      allPaths.append(header.NameAsWritten);
     }
     headerImports.insert(allPaths.str().substr(startIdx));
   };

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -325,12 +325,9 @@ static void writeImports(raw_ostream &out,
                               const clang::Module *module) {
     auto startIdx = allPaths.size();
     if (module->IsFramework) {
-      SmallString<64> Buffer(header.NameAsWritten);
-      llvm::sys::path::replace_path_prefix(Buffer, "Headers/", StringRef());
-      llvm::sys::path::replace_path_prefix(Buffer, "PrivateHeaders/", StringRef());
       // For framworks, the header import should start from the framework name.
       allPaths.append(module->getTopLevelModuleName());
-      llvm::sys::path::append(allPaths, Buffer.str());
+      llvm::sys::path::append(allPaths, header.NameAsWritten);
     } else {
       // Otherwise, import the header directly.
       allPaths.append(header.NameAsWritten);

--- a/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
@@ -238,7 +238,7 @@ public func _convertNSErrorToError(_ error: NSError?) -> Error {
 }
 
 public func _convertErrorToNSError(_ x: Error) -> NSError {
-  return unsafeDowncast(_bridgeErrorToNSError(x), to: NSError.self)
+  return x as NSError
 }
 
 extension _SwiftNewtypeWrapper where Self.RawValue == Error {

--- a/test/Inputs/clang-importer-sdk/usr/include/CTypesCore/module.modulemap
+++ b/test/Inputs/clang-importer-sdk/usr/include/CTypesCore/module.modulemap
@@ -1,4 +1,0 @@
-module CTypesCore [system] [extern_c] {
-  umbrella header "values.h"
-  export *
-}

--- a/test/Inputs/clang-importer-sdk/usr/include/CTypesCore/values.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/CTypesCore/values.h
@@ -1,3 +1,0 @@
-typedef int DWORD_CORE;
-
-#define MY_INT 123

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -17,7 +17,7 @@
 // RUN: %FileCheck %s < %t/classes.h
 // RUN: %FileCheck --check-prefix=NEGATIVE %s < %t/classes.h
 // RUN: %check-in-clang -I %S/Inputs/custom-modules/ %t/classes.h
-// RUN: %check-in-clang -I %S/Inputs/custom-modules/ -fno-modules -Qunused-arguments %t/classes.h
+// RUN: not %check-in-clang -I %S/Inputs/custom-modules/ -fno-modules -Qunused-arguments %t/classes.h
 // RUN: %check-in-clang -I %S/Inputs/custom-modules/ -fno-modules -Qunused-arguments %t/classes.h -include CoreFoundation.h -include objc_generics.h -include SingleGenericClass.h -include CompatibilityAlias.h
 
 // CHECK-NOT: AppKit;

--- a/test/PrintAsObjC/empty.swift
+++ b/test/PrintAsObjC/empty.swift
@@ -38,7 +38,6 @@
 // CHECK-NEXT: #if __has_warning
 // CHECK-NEXT: #pragma clang diagnostic
 // CHECK-NEXT: #endif
-// CHECK-NEXT: #else
 // CHECK-NEXT: #endif
 
 

--- a/test/PrintAsObjC/imports.swift
+++ b/test/PrintAsObjC/imports.swift
@@ -20,16 +20,6 @@
 // CHECK-NEXT: @import ObjectiveC;
 // CHECK-NEXT: @import ctypes.bits;
 
-// CHECK-NEXT: #else
-// CHECK-NEXT: #import <Base.ExplicitSub.h>
-// CHECK-NEXT: #import <Base.ExplicitSub.ExSub.h>
-// CHECK-NEXT: #import <Base.ImplicitSub.ExSub.h>
-// CHECK-NEXT: #import <Foundation.h>
-// CHECK-NEXT: #import <MostlyPrivate1/MostlyPrivate1.h>
-// CHECK-NEXT: #import <MostlyPrivate1_Private/MostlyPrivate1_Private.h>
-// CHECK-NEXT: #import <MostlyPrivate2_Private/MostlyPrivate2_Private.h>
-// CHECK-NEXT: #import <ctypes/bits.h>
-
 // NEGATIVE-NOT: ctypes;
 // NEGATIVE-NOT: ImSub;
 // NEGATIVE-NOT: ImplicitSub;

--- a/test/PrintAsObjC/imports.swift
+++ b/test/PrintAsObjC/imports.swift
@@ -13,7 +13,6 @@
 // CHECK-NEXT: @import Base.ExplicitSub;
 // CHECK-NEXT: @import Base.ExplicitSub.ExSub;
 // CHECK-NEXT: @import Base.ImplicitSub.ExSub;
-// CHECK-NEXT: @import CTypesCore;
 // CHECK-NEXT: @import Foundation;
 // CHECK-NEXT: @import MostlyPrivate1;
 // CHECK-NEXT: @import MostlyPrivate1_Private;
@@ -25,7 +24,6 @@
 // CHECK-NEXT: #import <Base.ExplicitSub.h>
 // CHECK-NEXT: #import <Base.ExplicitSub.ExSub.h>
 // CHECK-NEXT: #import <Base.ImplicitSub.ExSub.h>
-// CHECK-NEXT: #import <CTypesCore/values.h>
 // CHECK-NEXT: #import <Foundation.h>
 // CHECK-NEXT: #import <MostlyPrivate1/MostlyPrivate1.h>
 // CHECK-NEXT: #import <MostlyPrivate1_Private/MostlyPrivate1_Private.h>
@@ -40,7 +38,6 @@
 
 // NEGATIVE-NOT: secretMethod
 
-import CTypesCore
 import ctypes.bits
 import Foundation
 
@@ -61,7 +58,6 @@ import MostlyPrivate2_Private
 
 @objc class Test {
   @objc let word: DWORD = 0
-  @objc let word_core: DWORD_CORE = 0
   @objc let number: TimeInterval = 0.0
 
   @objc let baseI: BaseI = 0

--- a/test/PrintAsObjC/mixed-framework-fwd.swift
+++ b/test/PrintAsObjC/mixed-framework-fwd.swift
@@ -22,8 +22,6 @@
 // CHECK-NEXT: #pragma clang diagnostic
 // CHECK-NEXT: #endif
 // CHECK-NEXT: @import Foundation;
-// CHECK-NEXT: #else
-// CHECK-NEXT: #import <Foundation.h>
 // CHECK-NEXT: #endif
 
 // NO-IMPORT-NOT: #import

--- a/test/PrintAsObjC/mixed-framework.swift
+++ b/test/PrintAsObjC/mixed-framework.swift
@@ -17,8 +17,6 @@
 // CHECK-NEXT: #pragma clang diagnostic ignored "-Watimport-in-framework-header"
 // CHECK-NEXT: #endif
 // CHECK-NEXT: @import Foundation;
-// CHECK-NEXT: #else
-// CHECK-NEXT: #import <Foundation.h>
 // CHECK-NEXT: #endif
 
 // FRAMEWORK-LABEL: #import <Mixed/Mixed.h>


### PR DESCRIPTION
Revert the various commits implementing the emission of #imports in the generated header. We want this functionality, but getting it *exactly* right has proven quite challenging. Get back to a known "working" state while we figure out the details.