### PR TITLE
[Gardening] Change Xcode link

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Please make sure you use Python 2.x. Python 3.x is not supported currently.
 
 #### macOS
 
-To build for macOS, you need [Xcode 11.4](https://developer.apple.com/xcode/downloads/).
+To build for macOS, you need [Xcode 11.4](https://apps.apple.com/us/app/xcode/id497799835?mt=12).
 The required version of Xcode changes frequently, and is often a beta release.
 Check this document or the host information on <https://ci.swift.org> for the
 current required version.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Please make sure you use Python 2.x. Python 3.x is not supported currently.
 
 #### macOS
 
-To build for macOS, you need [Xcode 11.4](https://apps.apple.com/us/app/xcode/id497799835?mt=12).
+To build for macOS, you need [Xcode 11.4](https://developer.apple.com/xcode/resources/).
 The required version of Xcode changes frequently, and is often a beta release.
 Check this document or the host information on <https://ci.swift.org> for the
 current required version.


### PR DESCRIPTION
Xcode 11.4 GM (11E146) is not on Apple's [beta software downloads](https://developer.apple.com/download/), so I added a direct link to its Mac App Store download page.