### PR TITLE
[WIP] Sema: Resolve type witnesses for conditional conformances early

### DIFF
--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -425,6 +425,10 @@ static bool isInterestingTypealias(Type type) {
 /// Decide whether to show the desugared type or not.  We filter out some
 /// cases to avoid too much noise.
 static bool shouldShowAKA(Type type, StringRef typeName) {
+  // (aka '<<error type>>') does not contribute to a message whatsoever.
+  if (type->is<ErrorType>())
+    return false;
+
   // Canonical types are already desugared.
   if (type->isCanonical())
     return false;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1736,6 +1736,11 @@ public:
     // Check for circular inheritance of the raw type.
     (void)ED->hasCircularRawValue();
 
+    // Resolve all the type witnesses we need now to correctly diagnose
+    // references to default type witnesses with unsatisfied requirements
+    // once we start realizing types in members.
+    TypeChecker::resolveTypeWitnessesForConditionalConformances(ED);
+
     for (Decl *member : ED->getMembers())
       visit(member);
 
@@ -1774,6 +1779,11 @@ public:
     checkUnsupportedNestedType(SD);
 
     checkGenericParams(SD);
+
+    // Resolve all the type witnesses we need now to correctly diagnose
+    // references to default type witnesses with unsatisfied requirements
+    // once we start realizing types in members.
+    TypeChecker::resolveTypeWitnessesForConditionalConformances(SD);
 
     // Force lowering of stored properties.
     (void) SD->getStoredProperties();
@@ -1904,6 +1914,11 @@ public:
 
     // Check for circular inheritance.
     (void)CD->hasCircularInheritance();
+
+    // Resolve all the type witnesses we need now to correctly diagnose
+    // references to default type witnesses with unsatisfied requirements
+    // once we start realizing types in members.
+    TypeChecker::resolveTypeWitnessesForConditionalConformances(CD);
 
     // Force lowering of stored properties.
     (void) CD->getStoredProperties();

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2061,6 +2061,7 @@ public:
         GenericSignature::get({PD->getProtocolSelfType()},
                               PD->getRequirementSignature());
 
+      llvm::errs() << "\n";
       llvm::errs() << "Protocol requirement signature:\n";
       PD->dumpRef(llvm::errs());
       llvm::errs() << "\n";

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -469,12 +469,13 @@ GenericSignature TypeChecker::checkGenericSignature(
   // Debugging of the generic signature builder and generic signature
   // generation.
   if (dc->getASTContext().TypeCheckerOpts.DebugGenericSignatures) {
+    llvm::errs() << "\n";
     if (auto *VD = dyn_cast_or_null<ValueDecl>(dc->getAsDecl())) {
       VD->dumpRef(llvm::errs());
+      llvm::errs() << "\n";
     } else {
       dc->printContext(llvm::errs());
     }
-    llvm::errs() << "\n";
     llvm::errs() << "Generic signature: ";
     sig->print(llvm::errs());
     llvm::errs() << "\n";
@@ -591,8 +592,8 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
     // Debugging of the generic signature builder and generic signature
     // generation.
     if (GC->getASTContext().TypeCheckerOpts.DebugGenericSignatures) {
-      PD->printContext(llvm::errs());
       llvm::errs() << "\n";
+      PD->printContext(llvm::errs());
       llvm::errs() << "Generic signature: ";
       sig->print(llvm::errs());
       llvm::errs() << "\n";

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5115,12 +5115,15 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
   // Check all conformances.
   groupChecker.checkAllConformances();
 
-  if (Context.TypeCheckerOpts.DebugGenericSignatures) {
+  if (Context.TypeCheckerOpts.DebugGenericSignatures &&
+      !conformances.empty()) {
     // Now that they're filled out, print out information about the conformances
     // here, when requested.
+    llvm::errs() << "\n";
+    dc->printContext(llvm::errs());
     for (auto conformance : conformances) {
-      dc->printContext(llvm::errs());
       conformance->dump(llvm::errs());
+      llvm::errs() << "\n";
     }
   }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3795,6 +3795,20 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
       if (typeAliasDecl->getDeclaredInterfaceType()->is<UnboundGenericType>())
         continue;
 
+    // A candidate is nonviable if its context has requirements not
+    // satisfied by those of the confomance context.
+    {
+      const auto candidateCtxSig = candidate.Member->getDeclContext()
+          ->getGenericSignatureOfContext();
+      const auto conformanceCtxSig = DC->getGenericSignatureOfContext();
+
+      if(candidateCtxSig && conformanceCtxSig &&
+         !candidateCtxSig->requirementsNotSatisfiedBy(
+             conformanceCtxSig).empty()) {
+        continue;
+      }
+    }
+
     // Check this type against the protocol requirements.
     if (auto checkResult =
             checkTypeWitness(DC, Proto, assocType, candidate.MemberType)) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -976,6 +976,9 @@ public:
   /// Check all of the conformances in the given context.
   void checkConformancesInContext(DeclContext *dc, IterableDeclContext *idc);
 
+  void resolveTypeWitnessesForConditionalConformances(
+      const NominalTypeDecl *nominal);
+
   /// Check that the type of the given property conforms to NSCopying.
   ProtocolConformanceRef checkConformanceToNSCopying(VarDecl *var);
 

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -433,7 +433,7 @@ func sr_10992_bar(_ fn: (SR_10992_P) -> Void) {
 
 // SR-7516
 
-protocol SR_7516_P1 { associatedtype X = Void } // expected-note {{protocol requires nested type 'X'; do you want to add it?}}
+protocol SR_7516_P1 { associatedtype X = Void } // expected-note 4{{protocol requires nested type 'X'; do you want to add it?}}
 protocol SR_7516_P2 { associatedtype X = Bool }
 protocol SR_7516_P3 { associatedtype X = Void }
 protocol SR_7516_P4 { associatedtype X } // expected-note {{protocol requires nested type 'X'; do you want to add it?}}
@@ -514,3 +514,19 @@ extension SR_7516_S5: SR_7516_P1 {
 // DEFAULT_TYPE_WITNESS-NEXT: internal typealias X = Void
 }
 extension SR_7516_S5: SR_7516_P4 where T: Equatable {}
+
+struct SR_7516_S6<T> {}
+extension SR_7516_S6: SR_7516_P2 where T == Void {}
+extension SR_7516_S6: SR_7516_P1 where T == Never { // expected-error {{type 'SR_7516_S6<T>' does not conform to protocol 'SR_7516_P1'}}
+}
+
+struct SR_7516_S7<T> {}
+extension SR_7516_S7: SR_7516_P1 where T == Void {} // expected-error {{type 'SR_7516_S7<T>' does not conform to protocol 'SR_7516_P1'}}
+extension SR_7516_S7: SR_7516_P2 where T == Never {
+  typealias X = Bool
+}
+
+struct SR_7516_S8<T>: SR_7516_P1 {} // expected-error {{type 'SR_7516_S8<T>' does not conform to protocol 'SR_7516_P1'}}
+extension SR_7516_S8: SR_7516_P2 where T == Never {
+  typealias X = Bool
+}


### PR DESCRIPTION
Resolves SR-7516.

Allows for correctly diagnosing references to default type witnesses with
unsatisfied requirements once we start realizing types in members.

This change also establishes a definite type witness resolution order when associated type collisions occur in the presence of multiple conformances with differing conditional requirements. Previously, depending on validation order, a default type witness for a conditional conformance could satisfy a type requirement for a regular conformance, leading to miscompiles like the following:

```swift
 protocol A { associatedtype X }
 protocol B { associatedtype X = Bool }

 struct Foo<T>: A {} // no objections, A.X := Bool
 extension Foo: B where T == Int {}
```

Given the conditional requirements of a conformance are satisfied by those
of another conformance, default type witnesses for the former, more general
conformance, can now satisfy type requirements for the latter – but not vice versa – in
case of associated type collisions.
For example, both conformances in the snippets below will associate `X` with a single type witness
synthesized for the more general conformance to `B`.

```swift
 struct Foo<T>: B {
   internal typealias X = Bool // synthesized!
 }
 extension Foo: A where T == Int {}
```

```swift
 struct Foo<T> {}
 extension Foo: B where T: Equatable {
   internal typealias X = Bool // synthesized!
 }
 extension Foo: A where T == Int {}
```