### PR TITLE
[Diagnostics] Diagnose key path referring to init method

### DIFF
--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1519,24 +1519,26 @@ public:
   bool diagnoseAsError() override;
 };
 
-/// Diagnose an attempt to reference a method as a key path component
+/// Diagnose an attempt to reference a method or initializer as a key path component
 /// e.g.
 ///
 /// ```swift
 /// struct S {
+///   init() { }
 ///   func foo() -> Int { return 42 }
 ///   static func bar() -> Int { return 0 }
 /// }
 ///
 /// _ = \S.foo
 /// _ = \S.Type.bar
+/// _ = \S.init
 /// ```
 class InvalidMethodRefInKeyPath final : public InvalidMemberRefInKeyPath {
 public:
   InvalidMethodRefInKeyPath(const Solution &solution, ValueDecl *method,
                             ConstraintLocator *locator)
       : InvalidMemberRefInKeyPath(solution, method, locator) {
-    assert(isa<FuncDecl>(method));
+    assert(isa<FuncDecl>(method) || isa<ConstructorDecl>(method));
   }
 
   bool diagnoseAsError() override;

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -747,7 +747,8 @@ bool AllowInvalidRefInKeyPath::diagnose(const Solution &solution,
     return failure.diagnose(asNote);
   }
 
-  case RefKind::Method: {
+  case RefKind::Method:
+  case RefKind::Initializer: {
     InvalidMethodRefInKeyPath failure(solution, Member, getLocator());
     return failure.diagnose(asNote);
   }
@@ -763,6 +764,11 @@ AllowInvalidRefInKeyPath::forRef(ConstraintSystem &cs, ValueDecl *member,
   if (isa<FuncDecl>(member))
     return AllowInvalidRefInKeyPath::create(cs, RefKind::Method, member,
                                             locator);
+
+  // Referencing initializers in key path is not currently allowed.
+  if (isa<ConstructorDecl>(member))
+    return AllowInvalidRefInKeyPath::create(cs, RefKind::Initializer,
+                                            member, locator);
 
   // Referencing static members in key path is not currently allowed.
   if (member->isStatic())

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -1278,6 +1278,9 @@ class AllowInvalidRefInKeyPath final : public ConstraintFix {
     // Allow a reference to a method (instance or static) as
     // a key path component.
     Method,
+    // Allow a reference to a initializer instance as a key path
+    // component.
+    Initializer,
   } Kind;
 
   ValueDecl *Member;
@@ -1297,6 +1300,8 @@ public:
              "path component";
     case RefKind::Method:
       return "allow reference to a method as a key path component";
+    case RefKind::Initializer:
+      return "allow reference to an init method as a key path component";
     }
     llvm_unreachable("covered switch");
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6305,6 +6305,9 @@ static ConstraintFix *validateInitializerRef(ConstraintSystem &cs,
     // which means MetatypeType has to be added after finding a type variable.
     if (locatorEndsWith(baseLocator, ConstraintLocator::MemberRefBase))
       baseType = MetatypeType::get(baseType);
+  } else if (auto *keyPathExpr = dyn_cast<KeyPathExpr>(anchor)) {
+    // Key path can't refer to initializers e.g. `\Type.init`
+    return AllowInvalidRefInKeyPath::forRef(cs, init, locator);
   }
 
   if (!baseType)

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -40,11 +40,8 @@ let some = Some(keyPath: \Demo.here)
 func testFunc() {
   let _: (S) -> Int = \.i
   _ = ([S]()).map(\.i)
-
-  // FIXME: A terrible error, but the same as the pre-existing key path
-  // error in the similar situation: 'let _ = \S.init'.
-  _ = ([S]()).map(\.init)
-  // expected-error@-1 {{type of expression is ambiguous without more context}}
+  _ = \S.init // expected-error {{key path cannot refer to initializer 'init()'}}
+  _ = ([S]()).map(\.init) // expected-error {{key path cannot refer to initializer 'init()'}}
 
   let kp = \S.i
   let _: KeyPath<S, Int> = kp // works, because type defaults to KeyPath nominal


### PR DESCRIPTION
Addresses a diagnostic FIXME where key paths can't refer to init methods.

cc @xedin @hborla :)