### PR TITLE
Fixed incorrect comment in SwiftReflectionTest

### DIFF
--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -107,7 +107,7 @@ internal func getSectionInfo(_ name: String,
 
 /// Get the Swift Reflection section locations for a loaded image.
 ///
-/// An image of interest must have the following sections in the __DATA
+/// An image of interest must have the following sections in the __TEXT
 /// segment:
 /// - __swift5_fieldmd
 /// - __swift5_assocty


### PR DESCRIPTION
This code directly references several sections in the __TEXT segment but the comment refers to __DATA.

This patch is purely a fix to make the comment reflect what the code does (see the previous function to confirm that the sections are pulled out of __TEXt.