### PR TITLE
Reword the missing nullary call error message

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1038,8 +1038,14 @@ NOTE(note_init_parameter,none,
 
 
 ERROR(missing_nullary_call,none,
-     "function produces expected type %0; did you mean to call it with '()'?",
-     (Type))
+     "cannot convert value of type %0 to expected type %1; did you mean to call"
+     " it with '()'%select{| using its default arguments}2?",
+     (Type, Type, bool))
+ERROR(missing_nullary_call_decl,none,
+     "cannot convert value of type %0 (reference to %1 %2) to expected type %3;"
+     " did you mean to call it with '()'"
+     "%select{| using its default arguments}4?",
+     (Type, DescriptiveDeclKind, DeclName, Type, bool))
 ERROR(optional_not_unwrapped,none,
       "value of optional type %0 must be unwrapped to a value of type %1",
      (Type, Type))

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -24,27 +24,27 @@ func f7(_ a: A, _: Int) -> Int { }
 func forgotCall() {
   // Simple cases
   var x: Int
-  x = f1 // expected-error{{function produces expected type 'Int'; did you mean to call it with '()'?}}{{9-9=()}}
+  x = f1 // expected-error{{cannot convert value of type '() -> Int' (reference to global function 'f1') to expected type 'Int'; did you mean to call it with '()'?}}{{9-9=()}}
   x = f2 // expected-error{{cannot assign value of type '(Int) -> Int' to type 'Int'}}
   x = f3 // expected-error{{cannot assign value of type '(Int...) -> Int' to type 'Int'}}
 
   // With a supertype conversion
   var a = A()
-  a = f4 // expected-error{{function produces expected type 'B'; did you mean to call it with '()'?}}{{9-9=()}}
+  a = f4 // expected-error{{cannot convert value of type '() -> B' (reference to global function 'f4') to expected type 'B'; did you mean to call it with '()'?}}{{9-9=()}}
 
   // As a call
-  f5(f4) // expected-error{{function produces expected type 'B'; did you mean to call it with '()'?}}{{8-8=()}}
-  f6(f4, f2) // expected-error{{function produces expected type 'B'; did you mean to call it with '()'?}}{{8-8=()}}
-  // expected-error@-1 {{function produces expected type 'Int'; did you mean to call it with '()'?}} {{12-12=()}}
+  f5(f4) // expected-error{{cannot convert value of type '() -> B' (reference to global function 'f4') to expected type 'B'; did you mean to call it with '()'?}}{{8-8=()}}
+  f6(f4, f2) // expected-error{{cannot convert value of type '(Int) -> Int' (reference to global function 'f2') to expected type 'Int'; did you mean to call it with '()' using its default arguments?}}{{12-12=()}}
+  // expected-error@-1 {{cannot convert value of type '() -> B' (reference to global function 'f4') to expected type 'B'; did you mean to call it with '()'?}} {{8-8=()}}
 
   // With overloading: only one succeeds.
-  a = createB // expected-error{{function produces expected type 'B'; did you mean to call it with '()'?}}
+  a = createB // expected-error{{cannot convert value of type '() -> B' to expected type 'B'; did you mean to call it with '()'?}}
 
-  let _: A = createB // expected-error{{function produces expected type 'B'; did you mean to call it with '()'?}} {{21-21=()}}
-  let _: B = createB // expected-error{{function produces expected type 'B'; did you mean to call it with '()'?}} {{21-21=()}}
+  let _: A = createB // expected-error{{cannot convert value of type '() -> B' to expected type 'B'; did you mean to call it with '()'?}} {{21-21=()}}
+  let _: B = createB // expected-error{{cannot convert value of type '() -> B' to expected type 'B'; did you mean to call it with '()'?}} {{21-21=()}}
 
   // With overloading, pick the fewest number of fixes.
-  var b = f7(f4, f1) // expected-error{{function produces expected type 'B'; did you mean to call it with '()'?}}
+  var b = f7(f4, f1) // expected-error{{cannot convert value of type '() -> B' (reference to global function 'f4') to expected type 'B'; did you mean to call it with '()'?}}
   b.iAmAB()
 }
 
@@ -339,7 +339,7 @@ func test_explicit_call_with_overloads() {
   }
 
   foo(S().foo)
-  // expected-error@-1 {{function produces expected type 'Int'; did you mean to call it with '()'?}} {{14-14=()}}
+  // expected-error@-1 {{cannot convert value of type '(Int, String) -> Int' to expected type 'Int'; did you mean to call it with '()' using its default arguments?}} {{14-14=()}}
 }
 
 // SR-11476
@@ -354,7 +354,7 @@ func testKeyPathSubscriptArgFixes(_ fn: @escaping () -> Int) {
   // expected-note@-2{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}{{12-12=!}}
 
   _ = \S.[nil] // expected-error {{'nil' is not compatible with expected argument type 'Int'}}
-  _ = \S.[fn] // expected-error {{function produces expected type 'Int'; did you mean to call it with '()'?}} {{13-13=()}}
+  _ = \S.[fn] // expected-error {{cannot convert value of type '() -> Int' (reference to parameter 'fn') to expected type 'Int'; did you mean to call it with '()'?}} {{13-13=()}}
 }
 
 func sr12426(a: Any, _ str: String?) {

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -1305,32 +1305,32 @@ class SR_10995 {
 
 class SR_9267 {}
 extension SR_9267 {
-  var foo: String = { // expected-error {{extensions must not contain stored properties}} // expected-error {{function produces expected type 'String'; did you mean to call it with '()'?}} // expected-note {{Remove '=' to make 'foo' a computed property}}{{19-21=}}
+  var foo: String = { // expected-error {{extensions must not contain stored properties}} // expected-error {{cannot convert value of type '() -> String' to expected type 'String'; did you mean to call it with '()'?}} // expected-note {{Remove '=' to make 'foo' a computed property}}{{19-21=}}
     return "Hello"
   }
 }
 
 enum SR_9267_E {
-  var SR_9267_prop: String = { // expected-error {{enums must not contain stored properties}} // expected-error {{function produces expected type 'String'; did you mean to call it with '()'?}} // expected-note {{Remove '=' to make 'SR_9267_prop' a computed property}}{{28-30=}}
+  var SR_9267_prop: String = { // expected-error {{enums must not contain stored properties}} // expected-error {{cannot convert value of type '() -> String' to expected type 'String'; did you mean to call it with '()'?}} // expected-note {{Remove '=' to make 'SR_9267_prop' a computed property}}{{28-30=}}
     return "Hello"
   }
 }
 
-var SR_9267_prop_1: Int = { // expected-error {{function produces expected type 'Int'; did you mean to call it with '()'?}} // expected-note {{Remove '=' to make 'SR_9267_prop_1' a computed property}}{{25-27=}}
+var SR_9267_prop_1: Int = { // expected-error {{cannot convert value of type '() -> Int' to expected type 'Int'; did you mean to call it with '()'?}} // expected-note {{Remove '=' to make 'SR_9267_prop_1' a computed property}}{{25-27=}}
   return 0
 }
 
 class SR_9267_C {
-  var SR_9267_prop_2: String = { // expected-error {{function produces expected type 'String'; did you mean to call it with '()'?}} // expected-note {{Remove '=' to make 'SR_9267_prop_2' a computed property}}{{30-32=}}
+  var SR_9267_prop_2: String = { // expected-error {{cannot convert value of type '() -> String' to expected type 'String'; did you mean to call it with '()'?}} // expected-note {{Remove '=' to make 'SR_9267_prop_2' a computed property}}{{30-32=}}
     return "Hello"
   }
 }
 
 class SR_9267_C2 {
-  let SR_9267_prop_3: Int = { return 0 } // expected-error {{function produces expected type 'Int'; did you mean to call it with '()'?}} // expected-note {{Remove '=' to make 'SR_9267_prop_3' a computed property}}{{3-6=var}}{{27-29=}}
+  let SR_9267_prop_3: Int = { return 0 } // expected-error {{cannot convert value of type '() -> Int' to expected type 'Int'; did you mean to call it with '()'?}} // expected-note {{Remove '=' to make 'SR_9267_prop_3' a computed property}}{{3-6=var}}{{27-29=}}
 }
 
 class LazyPropInClass {
-  lazy var foo: Int = { return 0 } // expected-error {{function produces expected type 'Int'; did you mean to call it with '()'?}}
+  lazy var foo: Int = { return 0 } // expected-error {{cannot convert value of type '() -> Int' to expected type 'Int'; did you mean to call it with '()'?}}
   // expected-note@-1 {{Remove '=' to make 'foo' a computed property}}{{21-23=}}{{3-8=}}
 }

--- a/test/diagnostics/pretty-printed-diagnostics.swift
+++ b/test/diagnostics/pretty-printed-diagnostics.swift
@@ -120,7 +120,7 @@ foo(b:
 // CHECK: [[#LINE-1]] | extension A {
 // CHECK: [[#LINE]]   |   let x: Int = { 42 }()
 // CHECK:             |                ~~~~~~++
-// CHECK:             |                ^ error: function produces expected type 'Int'; did you mean to call it with '()'?
+// CHECK:             |                ^ error: cannot convert value of type '() -> Int' to expected type 'Int'; did you mean to call it with '()'? [insert '()']
 // CHECK:             |                ^ note: Remove '=' to make 'x' a computed property [remove '= ' and replace 'let' with 'var']
 // CHECK: [[#LINE+1]] | }
 

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -21,7 +21,7 @@ var closure5 : (Double) -> Int = {
 
 var closure6 = $0  // expected-error {{anonymous closure argument not contained in a closure}}
 
-var closure7 : Int = { 4 }  // expected-error {{function produces expected type 'Int'; did you mean to call it with '()'?}} {{27-27=()}} // expected-note {{Remove '=' to make 'closure7' a computed property}}{{20-22=}}
+var closure7 : Int = { 4 }  // expected-error {{cannot convert value of type '() -> Int' to expected type 'Int'; did you mean to call it with '()'?}} {{27-27=()}} // expected-note {{Remove '=' to make 'closure7' a computed property}}{{20-22=}}
 
 var capturedVariable = 1
 var closure8 = { [capturedVariable] in

--- a/test/type/types.swift
+++ b/test/type/types.swift
@@ -16,7 +16,7 @@ var d2 : () -> Int = { 4 }
 
 var d3 : () -> Float = { 4 }
 
-var d4 : () -> Int = { d2 }  // expected-error{{function produces expected type 'Int'; did you mean to call it with '()'?}} {{26-26=()}}
+var d4 : () -> Int = { d2 }  // expected-error{{cannot convert value of type '() -> Int' (reference to var 'd2') to expected type 'Int'; did you mean to call it with '()'?}} {{26-26=()}}
 
 if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
   var e0 : [Int]


### PR DESCRIPTION
`function produces expected type 'Int'; did you mean to call it with '()'?` changes to
 `expected an expression of type 'Int', but expression has function type '()->Int'; did you mean to call the function with '()'??`
OR
`expected an expression of type 'Int', but 'foo' is a function returning 'Int'; did you mean to call it with '()'?`
If we have a DeclRefExpr.

I've seen a decent amount of confusion in the past around what the 'expected type' in the current message refers to. The new one is longer, but IMO more clear.