### PR TITLE
[Sema] Diagnose missing 'nil' in failable initializer return

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3518,6 +3518,11 @@ NOTE(make_init_failable,none,
 ERROR(return_init_non_nil,none,
       "'nil' is the only return value permitted in an initializer",
       ())
+ERROR(nil_missing_in_failable_init,none,
+      "'nil' is missing in the failable initializer return", ())
+NOTE(add_nil_failable_init,none,
+      "add 'nil' to the failable initializer return", ())
+
 
 WARNING(if_always_true,none,
         "'if' condition is always true", ())

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -449,6 +449,8 @@ public:
     Type ResultTy = TheFunc->getBodyResultType();
     if (!ResultTy || ResultTy->hasError())
       return nullptr;
+    
+    Expr *E = RS->getResult();
 
     if (!RS->hasResult()) {
 

--- a/test/decl/init/failable.swift
+++ b/test/decl/init/failable.swift
@@ -282,3 +282,14 @@ struct InitiateFailureS {
     return nil // ok
   }
 }
+
+class SR12421 {
+    let label: String
+    init?(label: String?) { 
+        guard let actualLabel = label else {
+            return // expected-error{{'nil' is missing in the failable initializer return}}
+                   // expected-note{{add 'nil' to the failable initializer return}}
+        }
+        self.label = actualLabel
+    }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
If you create a failable initializer and accidentally add a simple `return` rather than `return nil`, will show an error and provide a fix to add `nil` to the `return` statement.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-12421](https://bugs.swift.org/browse/SR-12421).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
