### PR TITLE
NFC: Remove `SWIFT_ENABLE_TENSORFLOW` comment.

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3905,7 +3905,6 @@ ManagedValue SILGenFunction::getThunkedAutoDiffLinearMap(
   return getThunkedResult();
 }
 
-// SWIFT_ENABLE_TENSORFLOW
 SILFunction *SILGenModule::getOrCreateCustomDerivativeThunk(
     SILFunction *customDerivativeFn, SILFunction *originalFn,
     const AutoDiffConfig &config, AutoDiffDerivativeFunctionKind kind) {


### PR DESCRIPTION
Remove accidentally upstreamed marker comment.