### PR TITLE
[AutoDiff upstream] Add differential operators and some utilities.

### DIFF
--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -500,11 +500,23 @@ Type ASTBuilder::createImplFunctionType(
     break;
   }
 
+  DifferentiabilityKind diffKind;
+  switch (flags.getDifferentiabilityKind()) {
+  case ImplFunctionDifferentiabilityKind::NonDifferentiable:
+    diffKind = DifferentiabilityKind::NonDifferentiable;
+    break;
+  case ImplFunctionDifferentiabilityKind::Normal:
+    diffKind = DifferentiabilityKind::Normal;
+    break;
+  case ImplFunctionDifferentiabilityKind::Linear:
+    diffKind = DifferentiabilityKind::Linear;
+    break;
+  }
+
   // TODO: [store-sil-clang-function-type]
-  auto einfo = SILFunctionType::ExtInfo(
-      representation, flags.isPseudogeneric(), !flags.isEscaping(),
-      DifferentiabilityKind::NonDifferentiable,
-      /*clangFunctionType*/ nullptr);
+  auto einfo = SILFunctionType::ExtInfo(representation, flags.isPseudogeneric(),
+                                        !flags.isEscaping(), diffKind,
+                                        /*clangFunctionType*/ nullptr);
 
   llvm::SmallVector<SILParameterInfo, 8> funcParams;
   llvm::SmallVector<SILYieldInfo, 8> funcYields;

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1106,14 +1106,9 @@ static ManagedValue emitBuiltinAutoDiffApplyTransposeFunction(
     origFnArgVals.push_back(arg.getValue());
 
   // Get the transpose function.
-  // TODO(TF-1142): Create a linear_function_extract instead of an undef.
-  auto fnTy = origFnVal->getType().castTo<SILFunctionType>();
-  auto transposeFnType =
-      fnTy->getWithoutDifferentiability()->getAutoDiffTransposeFunctionType(
-      fnTy->getDifferentiabilityParameterIndices(), SGF.SGM.M.Types,
-      LookUpConformanceInModule(SGF.SGM.M.getSwiftModule()));
-  SILValue transposeFn =
-      SILUndef::get(SILType::getPrimitiveObjectType(transposeFnType), SGF.F);
+  SILValue transposeFn = SGF.B.createLinearFunctionExtract(
+      loc, LinearDifferentiableFunctionTypeComponent::Transpose, origFnVal);
+  auto transposeFnType = transposeFn->getType().castTo<SILFunctionType>();
   auto transposeFnUnsubstType =
       transposeFnType->getUnsubstitutedType(SGF.getModule());
   if (transposeFnType != transposeFnUnsubstType) {
@@ -1204,18 +1199,15 @@ static ManagedValue emitBuiltinLinearFunction(
   assert(args.size() == 2);
   auto origFn = args.front();
   auto origType = origFn.getType().castTo<SILFunctionType>();
-  // TODO(TF-1142): Create a linear_function instead of an undef.
-  auto linearFnTy = origType->getWithDifferentiability(
-      DifferentiabilityKind::Linear,
+  auto linearFn = SGF.B.createLinearFunction(
+      loc,
       IndexSubset::getDefault(
-          SGF.getASTContext(), origType->getNumParameters(),
-          /*includeAll*/ true));
-  SILValue linearFn = SILUndef::get(
-      SILType::getPrimitiveObjectType(linearFnTy), SGF.F);
+          SGF.getASTContext(),
+          origType->getNumParameters(),
+          /*includeAll*/ true),
+      origFn.forward(SGF), args[1].forward(SGF));
   return SGF.emitManagedRValueWithCleanup(linearFn);
 }
-
-
 
 /// Emit SIL for the named builtin: globalStringTablePointer. Unlike the default
 /// ownership convention for named builtins, which is to take (non-trivial)

--- a/lib/SILOptimizer/Transforms/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Transforms/SemanticARCOpts.cpp
@@ -776,6 +776,10 @@ struct SemanticARCOptVisitor
   FORWARDING_INST(OpenExistentialBoxValue)
   FORWARDING_INST(MarkDependence)
   FORWARDING_INST(InitExistentialRef)
+  FORWARDING_INST(DifferentiableFunction)
+  FORWARDING_INST(LinearFunction)
+  FORWARDING_INST(DifferentiableFunctionExtract)
+  FORWARDING_INST(LinearFunctionExtract)
 #undef FORWARDING_INST
 
 #define FORWARDING_TERM(NAME)                                                  \

--- a/stdlib/public/Differentiation/CMakeLists.txt
+++ b/stdlib/public/Differentiation/CMakeLists.txt
@@ -12,7 +12,12 @@
 
 add_swift_target_library(swift_Differentiation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   Differentiable.swift
+  DifferentialOperators.swift
+  DifferentiationUtilities.swift
 
-  SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+  SWIFT_COMPILE_FLAGS
+    ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+    -parse-stdlib
+    -Xfrontend -enable-experimental-differentiable-programming
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   INSTALL_IN_COMPONENT stdlib)

--- a/stdlib/public/Differentiation/Differentiable.swift
+++ b/stdlib/public/Differentiation/Differentiable.swift
@@ -20,6 +20,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Swift
+
 /// A type that mathematically represents a differentiable manifold whose
 /// tangent spaces are finite-dimensional.
 public protocol Differentiable {

--- a/stdlib/public/Differentiation/DifferentialOperators.swift
+++ b/stdlib/public/Differentiation/DifferentialOperators.swift
@@ -1,0 +1,359 @@
+//===--- DifferentialOperators.swift --------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// APIs for computing derivatives of functions.
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+// Transpose
+
+@inlinable
+public func transpose<T, R>(
+  of body: @escaping @differentiable(linear) (T) -> R
+) -> @differentiable(linear) (R) -> T {
+  let original = body as (T) -> R
+  let transpose = { x in Builtin.applyTranspose_arity1(body, x) }
+  return Builtin.linearFunction_arity1(transpose, original)
+}
+
+// Value with differential
+
+@inlinable
+public func valueWithDifferential<T, R>(
+  at x: T, in f: @differentiable (T) -> R
+) -> (value: R, differential: (T.TangentVector) -> R.TangentVector) {
+  return Builtin.applyDerivative_jvp(f, x)
+}
+
+@inlinable
+public func valueWithDifferential<T, U, R>(
+  at x: T, _ y: U, in f: @differentiable (T, U) -> R
+) -> (value: R,
+      differential: (T.TangentVector, U.TangentVector) -> R.TangentVector) {
+  return Builtin.applyDerivative_jvp_arity2(f, x, y)
+}
+
+@inlinable
+public func valueWithDifferential<T, U, V, R>(
+  at x: T, _ y: U, _ z: V, in f: @differentiable (T, U, V) -> R
+) -> (value: R,
+      differential: (T.TangentVector, U.TangentVector, V.TangentVector)
+        -> (R.TangentVector)) {
+  return Builtin.applyDerivative_jvp_arity3(f, x, y, z)
+}
+
+// Value with pullback
+
+@inlinable
+public func valueWithPullback<T, R>(
+  at x: T, in f: @differentiable (T) -> R
+) -> (value: R, pullback: (R.TangentVector) -> T.TangentVector) {
+  return Builtin.applyDerivative_vjp(f, x)
+}
+
+@inlinable
+public func valueWithPullback<T, U, R>(
+  at x: T, _ y: U, in f: @differentiable (T, U) -> R
+) -> (value: R,
+      pullback: (R.TangentVector) -> (T.TangentVector, U.TangentVector)) {
+  return Builtin.applyDerivative_vjp_arity2(f, x, y)
+}
+
+@inlinable
+public func valueWithPullback<T, U, V, R>(
+  at x: T, _ y: U, _ z: V, in f: @differentiable (T, U, V) -> R
+) -> (value: R,
+      pullback: (R.TangentVector)
+        -> (T.TangentVector, U.TangentVector, V.TangentVector)) {
+  return Builtin.applyDerivative_vjp_arity3(f, x, y, z)
+}
+
+// Differential
+
+@inlinable
+public func differential<T, R>(
+  at x: T, in f: @differentiable (T) -> R
+) -> (T.TangentVector) -> R.TangentVector {
+  return valueWithDifferential(at: x, in: f).1
+}
+
+@inlinable
+public func differential<T, U, R>(
+  at x: T, _ y: U, in f: @differentiable (T, U) -> R
+) -> (T.TangentVector, U.TangentVector) -> R.TangentVector {
+  return valueWithDifferential(at: x, y, in: f).1
+}
+
+@inlinable
+public func differential<T, U, V, R>(
+  at x: T, _ y: U, _ z: V, in f: @differentiable (T, U, V) -> R
+) -> (T.TangentVector, U.TangentVector, V.TangentVector) -> (R.TangentVector) {
+  return valueWithDifferential(at: x, y, z, in: f).1
+}
+
+
+// Pullback
+
+@inlinable
+public func pullback<T, R>(
+  at x: T, in f: @differentiable (T) -> R
+) -> (R.TangentVector) -> T.TangentVector {
+  return Builtin.applyDerivative_vjp(f, x).1
+}
+
+@inlinable
+public func pullback<T, U, R>(
+  at x: T, _ y: U, in f: @differentiable (T, U) -> R
+) -> (R.TangentVector) -> (T.TangentVector, U.TangentVector) {
+  return Builtin.applyDerivative_vjp_arity2(f, x, y).1
+}
+
+@inlinable
+public func pullback<T, U, V, R>(
+  at x: T, _ y: U, _ z: V, in f: @differentiable (T, U, V) -> R
+) -> (R.TangentVector)
+    -> (T.TangentVector, U.TangentVector, V.TangentVector) {
+  return Builtin.applyDerivative_vjp_arity3(f, x, y, z).1
+}
+
+// Derivative
+
+@inlinable
+public func derivative<T: FloatingPoint, R>(
+  at x: T, in f: @differentiable (T) -> R
+) ->  R.TangentVector
+  where T.TangentVector == T {
+  return differential(at: x, in: f)(T(1))
+}
+
+@inlinable
+public func derivative<T: FloatingPoint, U: FloatingPoint, R>(
+  at x: T, _ y: U, in f: @differentiable (T, U) -> R
+) -> R.TangentVector
+  where T.TangentVector == T,
+        U.TangentVector == U {
+  return differential(at: x, y, in: f)(T(1), U(1))
+}
+
+@inlinable
+public func derivative<T: FloatingPoint, U: FloatingPoint, V: FloatingPoint, R>(
+  at x: T, _ y: U, _ z: V, in f: @differentiable (T, U, V) -> R
+) -> R.TangentVector
+  where T.TangentVector == T,
+        U.TangentVector == U,
+        V.TangentVector == V {
+  return differential(at: x, y, z, in: f)(T(1), U(1), V(1))
+}
+
+// Gradient
+
+@inlinable
+public func gradient<T, R>(
+  at x: T, in f: @differentiable (T) -> R
+) -> T.TangentVector
+  where R : FloatingPoint, R.TangentVector == R {
+  return pullback(at: x, in: f)(R(1))
+}
+
+@inlinable
+public func gradient<T, U, R>(
+  at x: T, _ y: U, in f: @differentiable (T, U) -> R
+) -> (T.TangentVector, U.TangentVector)
+  where R : FloatingPoint, R.TangentVector == R {
+  return pullback(at: x, y, in: f)(R(1))
+}
+
+@inlinable
+public func gradient<T, U, V, R>(
+  at x: T, _ y: U, _ z: V, in f: @differentiable (T, U, V) -> R
+) -> (T.TangentVector, U.TangentVector, V.TangentVector)
+  where R : FloatingPoint, R.TangentVector == R {
+  return pullback(at: x, y, z, in: f)(R(1))
+}
+
+// Value with derivative
+
+@inlinable
+public func valueWithDerivative<T: FloatingPoint, R>(
+  at x: T, in f: @escaping @differentiable (T) -> R
+) -> (value: R, derivative: R.TangentVector)
+  where T.TangentVector == T {
+  let (y, differential) = valueWithDifferential(at: x, in: f)
+  return (y, differential(T(1)))
+}
+
+@inlinable
+public func valueWithDerivative<T: FloatingPoint, U: FloatingPoint, R>(
+  at x: T, _ y: U, in f: @escaping @differentiable (T, U) -> R
+) -> (value: R, derivative: R.TangentVector)
+  where T.TangentVector == T,
+        U.TangentVector == U {
+  let (y, differential) = valueWithDifferential(at: x, y, in: f)
+  return (y, differential(T(1), U(1)))
+}
+
+@inlinable
+public func valueWithDerivative<
+  T: FloatingPoint, U: FloatingPoint, V: FloatingPoint, R>(
+  at x: T, _ y: U, _ z: V, in f: @escaping @differentiable (T, U, V) -> R
+) -> (value: R, derivative: R.TangentVector)
+  where T.TangentVector == T,
+        U.TangentVector == U,
+        V.TangentVector == V {
+  let (y, differential) = valueWithDifferential(at: x, y, z, in: f)
+  return (y, differential(T(1), U(1), V(1)))
+}
+
+// Value with gradient
+
+@inlinable
+public func valueWithGradient<T, R>(
+  at x: T, in f: @differentiable (T) -> R
+) -> (value: R, gradient: T.TangentVector)
+  where R : FloatingPoint, R.TangentVector == R {
+  let (y, pullback) = valueWithPullback(at: x, in: f)
+  return (y, pullback(R(1)))
+}
+
+@inlinable
+public func valueWithGradient<T, U, R>(
+  at x: T, _ y: U, in f: @differentiable (T, U) -> R
+) -> (value: R, gradient: (T.TangentVector, U.TangentVector))
+  where R : FloatingPoint, R.TangentVector == R {
+  let (y, pullback) = valueWithPullback(at: x, y, in: f)
+  return (y, pullback(R(1)))
+}
+
+@inlinable
+public func valueWithGradient<T, U, V, R>(
+  at x: T, _ y: U, _ z: V, in f: @differentiable (T, U, V) -> R
+) -> (value: R,
+      gradient: (T.TangentVector, U.TangentVector, V.TangentVector))
+  where R : FloatingPoint, R.TangentVector == R {
+  let (y, pullback) = valueWithPullback(at: x, y, z, in: f)
+  return (y, pullback(R(1)))
+}
+
+// Derivative (curried)
+
+@inlinable 
+public func derivative<T: FloatingPoint, R>(
+  of f: @escaping @differentiable (T) -> R
+) -> (T) -> R.TangentVector
+  where T.TangentVector == T {
+  return { x in derivative(at: x, in: f) }
+}
+
+@inlinable 
+public func derivative<T: FloatingPoint, U: FloatingPoint, R>(
+  of f: @escaping @differentiable (T, U) -> R
+) -> (T, U) -> R.TangentVector
+  where T.TangentVector == T,
+        U.TangentVector == U {
+  return { (x, y) in derivative(at: x, y, in: f) }
+}
+
+@inlinable
+public func derivative<T: FloatingPoint, U: FloatingPoint, V: FloatingPoint, R>(
+  of f: @escaping @differentiable (T, U, V) -> R
+) -> (T, U, V) -> R.TangentVector
+  where T.TangentVector == T,
+        U.TangentVector == U,
+        V.TangentVector == V {
+  return { (x, y, z) in derivative(at: x, y, z, in: f) }
+}
+
+// Gradient (curried)
+
+@inlinable
+public func gradient<T, R>(
+  of f: @escaping @differentiable (T) -> R
+) -> (T) -> T.TangentVector
+  where R : FloatingPoint, R.TangentVector == R {
+  return { x in gradient(at: x, in: f) }
+}
+
+@inlinable
+public func gradient<T, U, R>(
+  of f: @escaping @differentiable (T, U) -> R
+) -> (T, U) -> (T.TangentVector, U.TangentVector)
+  where R : FloatingPoint, R.TangentVector == R {
+  return { x, y in gradient(at: x, y, in: f) }
+}
+
+@inlinable
+public func gradient<T, U, V, R>(
+  of f: @escaping @differentiable (T, U, V) -> R
+) -> (T, U, V) -> (T.TangentVector, U.TangentVector, V.TangentVector)
+  where R : FloatingPoint, R.TangentVector == R {
+  return { x, y, z in gradient(at: x, y, z, in: f) }
+}
+
+// Value with derivative (curried)
+
+@inlinable
+public func valueWithDerivative<T: FloatingPoint, R>(
+  of f: @escaping @differentiable (T) -> R
+) -> (T) -> (value: R, derivative: R.TangentVector)
+  where T.TangentVector == T {
+  return { x in valueWithDerivative(at: x, in: f) }
+}
+
+@inlinable
+public func valueWithDerivative<T: FloatingPoint, U: FloatingPoint, R>(
+  of f: @escaping @differentiable (T, U) -> R
+) -> (T, U) -> (value: R, derivative: R.TangentVector)
+  where T.TangentVector == T,
+        U.TangentVector == U {
+  return { (x, y) in valueWithDerivative(at: x, y, in: f) }
+}
+
+@inlinable
+public func valueWithDerivative<
+  T: FloatingPoint, U: FloatingPoint, V: FloatingPoint, R>(
+  of f: @escaping @differentiable (T, U, V) -> R
+) -> (T, U, V) -> (value: R, derivative: R.TangentVector)
+  where T.TangentVector == T,
+        U.TangentVector == U,
+        V.TangentVector == V {
+  return { (x, y, z) in valueWithDerivative(at: x, y, z, in: f) }
+}
+
+// Value with gradient (curried)
+
+@inlinable
+public func valueWithGradient<T, R>(
+  of f: @escaping @differentiable (T) -> R
+) -> (T) -> (value: R, gradient: T.TangentVector)
+  where R : FloatingPoint, R.TangentVector == R {
+  return { x in valueWithGradient(at: x, in: f) }
+}
+
+@inlinable
+public func valueWithGradient<T, U, R>(
+  of f: @escaping @differentiable (T, U) -> R
+) -> (T, U) -> (value: R, gradient: (T.TangentVector, U.TangentVector))
+  where R : FloatingPoint, R.TangentVector == R {
+  return { x, y in valueWithGradient(at: x, y, in: f) }
+}
+
+@inlinable
+public func valueWithGradient<T, U, V, R>(
+  of f: @escaping @differentiable (T, U, V) -> R
+) -> (T, U, V)
+  -> (value: R,
+      gradient: (T.TangentVector, U.TangentVector, V.TangentVector))
+  where R : FloatingPoint, R.TangentVector == R {
+  return { x, y, z in valueWithGradient(at: x, y, z, in: f) }
+}

--- a/stdlib/public/Differentiation/DifferentiationUtilities.swift
+++ b/stdlib/public/Differentiation/DifferentiationUtilities.swift
@@ -52,6 +52,24 @@ public func differentiableFunction<T, U, R>(
     /*vjp*/ vjp)
 }
 
+/// Create a differentiable function from a vector-Jacobian products function.
+@inlinable
+public func differentiableFunction<T, U, V, R>(
+  from vjp: @escaping (T, U, V)
+           -> (value: R, pullback: (R.TangentVector)
+             -> (T.TangentVector, U.TangentVector, V.TangentVector))
+) -> @differentiable (T, U, V) -> R {
+  Builtin.differentiableFunction_arity3(
+    /*original*/ { vjp($0, $1, $2).value },
+    /*jvp*/ { _, _, _ in
+      fatalError("""
+        Functions formed with `differentiableFunction(from:)` cannot yet \
+        be used with differential-producing differential operators.
+        """)
+    },
+    /*vjp*/ vjp)
+}
+
 /// Returns `x` like an identity function. When used in a context where `x` is
 /// being differentiated with respect to, this function will not produce any 
 /// derivative at `x`.

--- a/stdlib/public/Differentiation/DifferentiationUtilities.swift
+++ b/stdlib/public/Differentiation/DifferentiationUtilities.swift
@@ -1,0 +1,74 @@
+//===--- DifferentiationUtilities.swift -----------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Utilities for creating differentiable functions, debugging, and customizing
+// derivatives.
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+/// Create a differentiable function from a vector-Jacobian products function.
+@inlinable
+public func differentiableFunction<T : Differentiable, R : Differentiable>(
+  from vjp: @escaping (T)
+           -> (value: R, pullback: (R.TangentVector) -> T.TangentVector)
+) -> @differentiable (T) -> R {
+  Builtin.differentiableFunction_arity1(
+    /*original*/ { vjp($0).value },
+    /*jvp*/ { _ in
+      fatalError("""
+        Functions formed with `differentiableFunction(from:)` cannot yet \
+        be used with differential-producing differential operators.
+        """)
+    },
+    /*vjp*/ vjp)
+}
+
+/// Create a differentiable function from a vector-Jacobian products function.
+@inlinable
+public func differentiableFunction<T, U, R>(
+  from vjp: @escaping (T, U)
+           -> (value: R, pullback: (R.TangentVector)
+             -> (T.TangentVector, U.TangentVector))
+) -> @differentiable (T, U) -> R {
+  Builtin.differentiableFunction_arity2(
+    /*original*/ { vjp($0, $1).value },
+    /*jvp*/ { _, _ in
+      fatalError("""
+        Functions formed with `differentiableFunction(from:)` cannot yet \
+        be used with differential-producing differential operators.
+        """)
+    },
+    /*vjp*/ vjp)
+}
+
+/// Returns `x` like an identity function. When used in a context where `x` is
+/// being differentiated with respect to, this function will not produce any 
+/// derivative at `x`.
+@inlinable
+@inline(__always)
+@_semantics("autodiff.nonvarying")
+public func withoutDerivative<T>(at x: T) -> T {
+  x
+}
+
+/// Applies the given closure `body` to `x`. When used in a context where `x` is
+/// being differentiated with respect to, this function will not produce any
+/// derivative at `x`.
+// FIXME: Support throws-rethrows.
+@inlinable
+@inline(__always)
+@_semantics("autodiff.nonvarying")
+public func withoutDerivative<T, R>(at x: T, in body: (T) -> R) -> R {
+  body(x)
+}

--- a/test/AutoDiff/IRGen/differentiable_function_type.swift
+++ b/test/AutoDiff/IRGen/differentiable_function_type.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -emit-ir -g %s
+
+// TF-1225: IRGenDebugInfo crash when reconstructing `@differentiable` and
+// `@differentiable(linear)` function types.
+
+import _Differentiation
+
+@inlinable
+public func transpose<T, R>(
+  of body: @escaping @differentiable(linear) (T) -> R
+) -> @differentiable(linear) (R) -> T {
+  fatalError()
+}
+
+@inlinable
+public func valueWithDifferential<T, R>(
+  at x: T, in f: @differentiable (T) -> R
+) -> (value: R, differential: (T.TangentVector) -> R.TangentVector) {
+  fatalError()
+}

--- a/test/AutoDiff/SILGen/autodiff_builtins.swift
+++ b/test/AutoDiff/SILGen/autodiff_builtins.swift
@@ -85,7 +85,6 @@ func applyDerivative_f1_vjp<T: AdditiveArithmetic & Differentiable>(t0: T) -> (T
 // CHECK: return [[PULLBACK]]
 
 // MARK: - applyTranspose
-// TODO(TF-1142): Add linear_function_extracts to this test when they exist.
 
 @_silgen_name("applyTranspose_f_direct_arity1")
 func applyTranspose_f_direct_arity1(_ x: Float) -> Float {
@@ -93,8 +92,14 @@ func applyTranspose_f_direct_arity1(_ x: Float) -> Float {
 }
 // CHECK-LABEL: sil{{.*}}@applyTranspose_f_direct_arity1
 // CHECK: bb0([[X:%.*]] : $Float):
-// CHECK: [[RESULT:%.*]] = apply undef([[X]])
-// CHECK: return [[RESULT]]
+// CHECK:   [[ORIG:%.*]] = function_ref @f_direct_arity1 : $@convention(thin) (Float) -> Float
+// CHECK:   [[THICK_ORIG:%.*]] = thin_to_thick_function [[ORIG]] : $@convention(thin) (Float) -> Float to $@callee_guaranteed (Float) -> Float
+// CHECK:   [[LINEAR:%.*]] = linear_function [parameters 0] [[THICK_ORIG]] : $@callee_guaranteed (Float) -> Float
+// CHECK:   [[NOESC_LINEAR:%.*]] = convert_escape_to_noescape [not_guaranteed] [[LINEAR]] : $@differentiable(linear) @callee_guaranteed (Float) -> Float to $@differentiable(linear) @noescape @callee_guaranteed (Float) -> Float
+// CHECK:   [[TRANS:%.*]] = linear_function_extract [transpose] [[NOESC_LINEAR]] : $@differentiable(linear) @noescape @callee_guaranteed (Float) -> Float
+// CHECK:   [[RESULT:%.*]] = apply [[TRANS]]([[X]]) : $@noescape @callee_guaranteed (Float) -> Float
+// CHECK:   destroy_value [[LINEAR]] : $@differentiable(linear) @callee_guaranteed (Float) -> Float
+// CHECK:   return [[RESULT]] : $Float
 
 @_silgen_name("applyTranspose_f_direct_arity2")
 func applyTranspose_f_direct_arity2(_ x: Float) -> (Float, Float) {
@@ -102,10 +107,16 @@ func applyTranspose_f_direct_arity2(_ x: Float) -> (Float, Float) {
 }
 // CHECK-LABEL: sil{{.*}}@applyTranspose_f_direct_arity2
 // CHECK: bb0([[X:%.*]] : $Float)
-// CHECK: [[RESULT:%.*]] = apply undef([[X]])
-// CHECK: ([[RESULT_0:%.*]], [[RESULT_1:%.*]]) = destructure_tuple [[RESULT]]
-// CHECK: [[RETUPLED_RESULT:%.*]] = tuple ([[RESULT_0]] : $Float, [[RESULT_1]] : $Float)
-// CHECK: return [[RETUPLED_RESULT]]
+// CHECK:   [[ORIG:%.*]] = function_ref @f_direct_arity2 : $@convention(thin) (Float, Float) -> Float
+// CHECK:   [[THICK_ORIG:%.*]] = thin_to_thick_function [[ORIG]] : $@convention(thin) (Float, Float) -> Float to $@callee_guaranteed (Float, Float) -> Float
+// CHECK:   [[LINEAR:%.*]] = linear_function [parameters 0 1] [[THICK_ORIG]] : $@callee_guaranteed (Float, Float) -> Float
+// CHECK:   [[NOESC_LINEAR:%.*]] = convert_escape_to_noescape [not_guaranteed] [[LINEAR]] : $@differentiable(linear) @callee_guaranteed (Float, Float) -> Float to $@differentiable(linear) @noescape @callee_guaranteed (Float, Float) -> Float
+// CHECK:   [[TRANS:%.*]] = linear_function_extract [transpose] [[NOESC_LINEAR]] : $@differentiable(linear) @noescape @callee_guaranteed (Float, Float) -> Float
+// CHECK:   [[RESULT:%.*]] = apply [[TRANS]]([[X]]) : $@noescape @callee_guaranteed (Float) -> (Float, Float)
+// CHECK:   ([[RES1:%.*]], [[RES2:%.*]]) = destructure_tuple [[RESULT]] : $(Float, Float)
+// CHECK:   destroy_value [[LINEAR]] : $@differentiable(linear) @callee_guaranteed (Float, Float) -> Float
+// CHECK:   [[RESULT:%.*]] = tuple ([[RES1]] : $Float, [[RES2]] : $Float)
+// CHECK:   return [[RESULT]] : $(Float, Float)
 
 @_silgen_name("applyTranspose_f_indirect_arity1")
 func applyTranspose_f_indirect_arity1<T: AdditiveArithmetic & Differentiable>(_ x: T) -> T {
@@ -133,4 +144,10 @@ func linearFunction_f_direct_arity1() -> @differentiable(linear) (Float) -> Floa
   return Builtin.linearFunction_arity1(f_direct_arity1, f_direct_arity1)
 }
 // CHECK-LABEL: sil{{.*}}@linearFunction_f_direct_arity1
-// CHECK: return undef
+// CHECK: bb0:
+// CHECK:   [[ORIG1:%.*]] = function_ref @f_direct_arity1 : $@convention(thin) (Float) -> Float
+// CHECK:   [[THICK_ORIG1:%.*]] = thin_to_thick_function [[ORIG1]] : $@convention(thin) (Float) -> Float to $@callee_guaranteed (Float) -> Float
+// CHECK:   [[ORIG2:%.*]] = function_ref @f_direct_arity1 : $@convention(thin) (Float) -> Float
+// CHECK:   [[THICK_ORIG2:%.*]] = thin_to_thick_function [[ORIG2]] : $@convention(thin) (Float) -> Float to $@callee_guaranteed (Float) -> Float
+// CHECK:   [[LINEAR:%.*]] = linear_function [parameters 0] [[THICK_ORIG1]] : $@callee_guaranteed (Float) -> Float with_transpose [[THICK_ORIG2]] : $@callee_guaranteed (Float) -> Float
+// CHECK:   return [[LINEAR]] : $@differentiable(linear) @callee_guaranteed (Float) -> Float

--- a/test/AutoDiff/stdlib/differential_operators.swift
+++ b/test/AutoDiff/stdlib/differential_operators.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -enable-experimental-differentiable-programming %s -emit-sil
+// RUN: %target-build-swift -enable-experimental-differentiable-programming %s -o %t/differential_operators
+// RUN: %target-run %t/differential_operators
+// REQUIRES: executable_test
+
+import _Differentiation
+
+import StdlibUnittest
+
+var DifferentialOperatorTestSuite = TestSuite("Tuple")
+
+DifferentialOperatorTestSuite.test("foo") {
+  expectEqual(1, 1)
+}
+
+func exampleVJP(_ x: Float) -> (Float, (Float) -> Float) {
+  (x * x, { 2 * $0 })
+}
+
+DifferentialOperatorTestSuite.test("differentiableFunction_callOriginal") {
+  expectEqual(differentiableFunction(from: exampleVJP)(10), 100)
+}
+
+runAllTests()

--- a/test/AutoDiff/stdlib/differential_operators.swift
+++ b/test/AutoDiff/stdlib/differential_operators.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -enable-experimental-differentiable-programming %s -emit-sil
-// RUN: %target-build-swift -enable-experimental-differentiable-programming %s -o %t/differential_operators
+// RUN: %gyb %s -o %t/differential_operators.swift
+// RUN: %target-build-swift -enable-experimental-differentiable-programming %t/differential_operators.swift -o %t/differential_operators
 // RUN: %target-run %t/differential_operators
 // REQUIRES: executable_test
 
@@ -8,18 +8,70 @@ import _Differentiation
 
 import StdlibUnittest
 
-var DifferentialOperatorTestSuite = TestSuite("Tuple")
+var DifferentialOperatorTestSuite = TestSuite("DifferentialOperator")
 
-DifferentialOperatorTestSuite.test("foo") {
-  expectEqual(1, 1)
+% for arity in range(1, 3 + 1):
+
+% params = ', '.join(['_ x%d: Float' % i for i in range(arity)])
+% pb_return_type = '(' + ', '.join(['Float' for _ in range(arity)]) + ')'
+func exampleVJP_${arity}(${params}) -> (Float, (Float) -> ${pb_return_type}) {
+  (
+    ${' + '.join(['x%d * x%d' % (i, i) for i in range(arity)])},
+    { (${', '.join(['2 * x%d * $0' % i for i in range(arity)])}) }
+  )
 }
 
-func exampleVJP(_ x: Float) -> (Float, (Float) -> Float) {
-  (x * x, { 2 * $0 })
+% argValues = [i * 10 for i in range(1, arity + 1)]
+% args = ', '.join([str(v) for v in argValues])
+% expectedValue = sum([v * v for v in argValues])
+% expectedGradientValues = [2 * v for v in argValues]
+% expectedGradients = '(' + ', '.join([str(g) for g in expectedGradientValues]) + ')'
+
+DifferentialOperatorTestSuite.test("differentiableFunction_callOriginal_${arity}") {
+  let f = differentiableFunction(from: exampleVJP_${arity})
+  expectEqual(${expectedValue}, f(${args}))
 }
 
-DifferentialOperatorTestSuite.test("differentiableFunction_callOriginal") {
-  expectEqual(differentiableFunction(from: exampleVJP)(10), 100)
+DifferentialOperatorTestSuite.test("valueWithPullback_${arity}") {
+  let f = differentiableFunction(from: exampleVJP_${arity})
+  let (value, pb) = valueWithPullback(at: ${args}, in: f)
+  expectEqual(${expectedValue}, value)
+  expectEqual(${expectedGradients}, pb(1))
 }
+
+DifferentialOperatorTestSuite.test("pullback_${arity}") {
+  let f = differentiableFunction(from: exampleVJP_${arity})
+  let pb = pullback(at: ${args}, in: f)
+  expectEqual(${expectedGradients}, pb(1))
+}
+
+DifferentialOperatorTestSuite.test("gradient_${arity}") {
+  let f = differentiableFunction(from: exampleVJP_${arity})
+  let grad = gradient(at: ${args}, in: f)
+  expectEqual(${expectedGradients}, grad)
+}
+
+DifferentialOperatorTestSuite.test("valueWithGradient_${arity}") {
+  let f = differentiableFunction(from: exampleVJP_${arity})
+  let (value, grad) = valueWithGradient(at: ${args}, in: f)
+  expectEqual(${expectedValue}, value)
+  expectEqual(${expectedGradients}, grad)
+}
+
+DifferentialOperatorTestSuite.test("gradient_curried_${arity}") {
+  let f = differentiableFunction(from: exampleVJP_${arity})
+  let gradF = gradient(of: f)
+  expectEqual(${expectedGradients}, gradF(${args}))
+}
+
+DifferentialOperatorTestSuite.test("valueWithGradient_curried_${arity}") {
+  let f = differentiableFunction(from: exampleVJP_${arity})
+  let valueWithGradF = valueWithGradient(of: f)
+  let (value, grad) = valueWithGradF(${args})
+  expectEqual(${expectedValue}, value)
+  expectEqual(${expectedGradients}, grad)
+}
+
+% end
 
 runAllTests()

--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -49,7 +49,7 @@ for filename in os.listdir(sdk_overlay_dir):
     else:
         continue
 
-    if module_name == "Swift" or module_name == "SwiftLang":
+    if module_name in ["_Differentiation", "Swift", "SwiftLang"]:
         continue
 
     # swift -build-module-from-parseable-interface


### PR DESCRIPTION
* Add all [differential operators](https://github.com/apple/swift/blob/master/docs/DifferentiableProgramming.md#list-of-differential-operators).
* Add `withoutDerivative(at:)`, used for efficiently stopping the derivative propagation at a value and causing the derivative at the value to be zero.
* Add utility `differentiableFunction(from:)`, used for creating a `@differentiable` function from an original function and a derivative function.

Mostly work done by @marcrasi and @dan-zheng.
Partially resolves TF-843.

TODO:
* Add `AnyDerivative`.
* Add `Array.differentiableMap(_:)` and `differentiableReduce(_:_:)`.