### PR TITLE
Diagnose Escaping self In Initializer through Property Wrapper

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -2529,9 +2529,9 @@ assign_by_wrapper
 ``````````````````
 ::
 
-  sil-instruction ::= 'assign_by_wrapper' sil-operand 'to' sil-operand ',' 'init' sil-operand ',' 'set' sil-operand
+  sil-instruction ::= 'assign_by_wrapper' '[enclosingSelfAccess]'? sil-operand 'to' sil-operand ',' 'init' sil-operand ',' 'set' sil-operand
 
-  assign_by_wrapper %0 : $S to %1 : $*T, init %2 : $F, set %3 : $G
+  assign_by_wrapper [enclosingSelfAccess] %0 : $S to %1 : $*T, init %2 : $F, set %3 : $G
   // $S can be a value or address type
   // $T must be the type of a property wrapper.
   // $F must be a function type, taking $S as a single argument (or multiple arguments in case of a tuple) and returning $T
@@ -2539,6 +2539,9 @@ assign_by_wrapper
 
 Similar to the ``assign`` instruction, but the assignment is done via a
 delegate.
+
+``[enclosingSelfAccess]`` indicates the property wrapper setter allows
+arbitrary access to the class instance containing the wrapped property.
 
 In case of an initialization, the function ``%2`` is called with ``%0`` as
 argument. The result is stored to ``%1``. In case ``%2`` is an address type,

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -858,12 +858,14 @@ public:
   }
 
   AssignByWrapperInst *createAssignByWrapper(SILLocation Loc,
+                                               bool HasEnclosingSelfAccess,
                                                SILValue Src, SILValue Dest,
                                                SILValue Initializer,
                                                SILValue Setter,
                                           AssignOwnershipQualifier Qualifier) {
     return insert(new (getModule())
-                  AssignByWrapperInst(getSILDebugLocation(Loc), Src, Dest,
+                  AssignByWrapperInst(getSILDebugLocation(Loc),
+                                       HasEnclosingSelfAccess, Src, Dest,
                                        Initializer, Setter, Qualifier));
   }
 

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1240,6 +1240,7 @@ void SILCloner<ImplClass>::visitAssignByWrapperInst(AssignByWrapperInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(
       Inst, getBuilder().createAssignByWrapper(getOpLocation(Inst->getLoc()),
+                                      Inst->hasEnclosingSelfAccess(),
                                       getOpValue(Inst->getSrc()),
                                       getOpValue(Inst->getDest()),
                                       getOpValue(Inst->getInitializer()),

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -3931,7 +3931,8 @@ class AssignByWrapperInst
     : public AssignInstBase<SILInstructionKind::AssignByWrapperInst, 4> {
   friend SILBuilder;
 
-  AssignByWrapperInst(SILDebugLocation DebugLoc, SILValue Src, SILValue Dest,
+  AssignByWrapperInst(SILDebugLocation DebugLoc, bool HasEnclosingSelfAccess,
+                       SILValue Src, SILValue Dest,
                        SILValue Initializer, SILValue Setter,
                        AssignOwnershipQualifier Qualifier =
                          AssignOwnershipQualifier::Unknown);
@@ -3940,6 +3941,14 @@ public:
 
   SILValue getInitializer() { return Operands[2].get(); }
   SILValue getSetter() { return  Operands[3].get(); }
+
+  bool hasEnclosingSelfAccess() const {
+    return SILInstruction::Bits.AssignByWrapperInst.HasEnclosingSelfAccess;
+  }
+  void setHasEnclosingSelfAccess(bool hasEnclosingSelfAccess) {
+    SILInstruction::Bits.AssignByWrapperInst.HasEnclosingSelfAccess =
+        hasEnclosingSelfAccess;
+  }
 
   AssignOwnershipQualifier getOwnershipQualifier() const {
     return AssignOwnershipQualifier(

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -286,8 +286,9 @@ protected:
     OwnershipQualifier : NumAssignOwnershipQualifierBits
   );
   SWIFT_INLINE_BITFIELD(AssignByWrapperInst, NonValueInstruction,
-                        NumAssignOwnershipQualifierBits,
-    OwnershipQualifier : NumAssignOwnershipQualifierBits
+                        NumAssignOwnershipQualifierBits + 1,
+    OwnershipQualifier : NumAssignOwnershipQualifierBits,
+    HasEnclosingSelfAccess : 1
   );
 
   SWIFT_INLINE_BITFIELD(UncheckedOwnershipConversionInst,SingleValueInstruction,

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1081,6 +1081,7 @@ AssignInst::AssignInst(SILDebugLocation Loc, SILValue Src, SILValue Dest,
 }
 
 AssignByWrapperInst::AssignByWrapperInst(SILDebugLocation Loc,
+                                           bool HasEnclosingSelfAccess,
                                            SILValue Src, SILValue Dest,
                                            SILValue Initializer,
                                            SILValue Setter,
@@ -1089,6 +1090,8 @@ AssignByWrapperInst::AssignByWrapperInst(SILDebugLocation Loc,
   assert(Initializer->getType().is<SILFunctionType>());
   SILInstruction::Bits.AssignByWrapperInst.OwnershipQualifier =
       unsigned(Qualifier);
+  SILInstruction::Bits.AssignByWrapperInst.HasEnclosingSelfAccess =
+      HasEnclosingSelfAccess;
 }
 
 MarkFunctionEscapeInst *

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1409,6 +1409,8 @@ public:
   }
 
   void visitAssignByWrapperInst(AssignByWrapperInst *AI) {
+    if (AI->hasEnclosingSelfAccess())
+      *this << "[enclosingSelfAccess] ";
     *this << getIDAndType(AI->getSrc()) << " to ";
     printAssignOwnershipQualifier(AI->getOwnershipQualifier());
     *this << getIDAndType(AI->getDest())

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3610,6 +3610,15 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     SILValue Src, DestAddr, InitFn, SetFn;
     SourceLoc DestLoc;
     AssignOwnershipQualifier AssignQualifier;
+    bool HasEnclosingSelfAccess = false;
+
+    if (P.consumeIf(tok::l_square)) {
+      if (parseVerbatim("enclosingSelfAccess") ||
+          P.parseToken(tok::r_square, diag::expected_tok_in_sil_instr, "]"))
+        return true;
+      HasEnclosingSelfAccess = true;
+    }
+
     if (parseTypedValueRef(Src, B) || parseVerbatim("to") ||
         parseAssignOwnershipQualifier(AssignQualifier, *this) ||
         parseTypedValueRef(DestAddr, DestLoc, B) ||
@@ -3626,7 +3635,8 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
       return true;
     }
 
-    ResultVal = B.createAssignByWrapper(InstLoc, Src, DestAddr, InitFn, SetFn,
+    ResultVal = B.createAssignByWrapper(InstLoc, HasEnclosingSelfAccess, Src,
+                                        DestAddr, InitFn, SetFn,
                                         AssignQualifier);
     break;
   }

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1512,7 +1512,13 @@ namespace {
           Mval = Mval.materialize(SGF, loc);
         }
 
-        SGF.B.createAssignByWrapper(loc, Mval.forward(SGF), proj.forward(SGF),
+        auto typeInfo = field->getAttachedPropertyWrapperTypeInfo(0);
+        bool hasEnclosingSelfAccess =
+            typeInfo.enclosingInstanceWrappedSubscript ||
+            typeInfo.enclosingInstanceProjectedSubscript;
+
+        SGF.B.createAssignByWrapper(loc, hasEnclosingSelfAccess,
+                                     Mval.forward(SGF), proj.forward(SGF),
                                      initFn.getValue(), setterFn.getValue(),
                                      AssignOwnershipQualifier::Unknown);
         return;

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1934,6 +1934,10 @@ void LifetimeChecker::updateInstructionForInitState(DIMemoryUse &Use) {
       assert(InitKind == IsInitialization);
       AI->setOwnershipQualifier(AssignOwnershipQualifier::Reinit);
     } else {
+      if (AI->hasEnclosingSelfAccess() && InitKind != IsInitialization &&
+          getSelfInitializedAtInst(AI) != DIKind::Yes) {
+        diagnose(Module, Inst->getLoc(), diag::self_closure_use_uninit);
+      }
       AI->setOwnershipQualifier((InitKind == IsInitialization
                                  ? AssignOwnershipQualifier::Init
                                  : AssignOwnershipQualifier::Reassign));

--- a/test/SIL/Parser/assign_by_wrapper.sil
+++ b/test/SIL/Parser/assign_by_wrapper.sil
@@ -1,0 +1,54 @@
+// RUN: %target-sil-opt %s | %FileCheck %s
+sil_stage raw
+
+import Builtin
+import Swift
+import SwiftShims
+
+@propertyWrapper struct Observable<Value> {
+  @_hasStorage private var stored: Value { get set }
+  init(wrappedValue: Value)
+  @available(*, unavailable, message: "must be in a class")
+  var wrappedValue: Value { get set }
+  static subscript<EnclosingSelf>(_enclosingInstance observed: EnclosingSelf, wrapped wrappedKeyPath: ReferenceWritableKeyPath<EnclosingSelf, Value>, storage storageKeyPath: ReferenceWritableKeyPath<EnclosingSelf, Observable<Value>>) -> Value { get set }
+}
+
+class ValidSR_12430 {
+  init(value: String)
+  var y: String { get set }
+  @_hasStorage final var _y: Observable<String> { get set }
+  @objc deinit
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers13ValidSR_12430C5valueACSS_tcfc
+// CHECK: assign_by_wrapper [enclosingSelfAccess] {{%.*}} : $String to {{%.*}} : $*Observable<String>, init {{%.*}} : $@callee_guaranteed (@owned String) -> @owned Observable<String>, set {{%.*}} : $@callee_guaranteed (@owned String) -> () // id: {{%.*}}
+// CHECK: return
+sil hidden [ossa] @$s17property_wrappers13ValidSR_12430C5valueACSS_tcfc : $@convention(method) (@owned String, @owned ValidSR_12430) -> @owned ValidSR_12430 {
+bb0(%0 : @owned $String, %1 : @owned $ValidSR_12430):
+  debug_value %0 : $String, let, name "value", argno 1 // id: %2
+  debug_value %1 : $ValidSR_12430, let, name "self", argno 2 // id: %3
+  %4 = mark_uninitialized [rootself] %1 : $ValidSR_12430 // users: %22, %21, %5
+  %5 = begin_borrow %4 : $ValidSR_12430           // users: %20, %13, %8
+  %6 = begin_borrow %0 : $String                  // users: %19, %7
+  %7 = copy_value %6 : $String                    // user: %15
+  %8 = ref_element_addr %5 : $ValidSR_12430, #ValidSR_12430._y // user: %9
+  %9 = begin_access [modify] [dynamic] %8 : $*Observable<String> // users: %16, %15
+  %10 = function_ref @$s17property_wrappers13ValidSR_12430C1ySSvpfP : $@convention(thin) (@owned String) -> @owned Observable<String> // user: %11
+  %11 = partial_apply [callee_guaranteed] %10() : $@convention(thin) (@owned String) -> @owned Observable<String> // users: %18, %15
+  %12 = function_ref @$s17property_wrappers13ValidSR_12430C1ySSvs : $@convention(method) (@owned String, @guaranteed ValidSR_12430) -> () // user: %14
+  %13 = copy_value %5 : $ValidSR_12430            // user: %14
+  %14 = partial_apply [callee_guaranteed] %12(%13) : $@convention(method) (@owned String, @guaranteed ValidSR_12430) -> () // users: %17, %15
+  assign_by_wrapper [enclosingSelfAccess] %7 : $String to %9 : $*Observable<String>, init %11 : $@callee_guaranteed (@owned String) -> @owned Observable<String>, set %14 : $@callee_guaranteed (@owned String) -> () // id: %15
+  end_access %9 : $*Observable<String>            // id: %16
+  destroy_value %14 : $@callee_guaranteed (@owned String) -> () // id: %17
+  destroy_value %11 : $@callee_guaranteed (@owned String) -> @owned Observable<String> // id: %18
+  end_borrow %6 : $String                         // id: %19
+  end_borrow %5 : $ValidSR_12430                  // id: %20
+  %21 = copy_value %4 : $ValidSR_12430            // user: %24
+  destroy_value %4 : $ValidSR_12430               // id: %22
+  destroy_value %0 : $String                      // id: %23
+  return %21 : $ValidSR_12430                     // id: %24
+} // end sil function '$s17property_wrappers13ValidSR_12430C5valueACSS_tcfc'
+
+sil [ossa] @$s17property_wrappers13ValidSR_12430C1ySSvpfP : $@convention(thin) (@owned String) -> @owned Observable<String>
+sil [ossa] @$s17property_wrappers13ValidSR_12430C1ySSvs : $@convention(method) (@owned String, @guaranteed ValidSR_12430) -> ()

--- a/test/decl/var/property_wrappers_sil.swift
+++ b/test/decl/var/property_wrappers_sil.swift
@@ -1,0 +1,73 @@
+// RUN: %target-swift-frontend -emit-sil -swift-version 5 -primary-file %s -o /dev/null -verify
+
+// ---------------------------------------------------------------------------
+// Enclosing instance diagnostics
+// ---------------------------------------------------------------------------
+@propertyWrapper
+struct Observable<Value> {
+  private var stored: Value
+
+  init(wrappedValue: Value) {
+    self.stored = wrappedValue
+  }
+
+  @available(*, unavailable, message: "must be in a class")
+  var wrappedValue: Value {
+    get { fatalError("called wrappedValue getter") }
+    set { fatalError("called wrappedValue setter") }
+  }
+
+  static subscript<EnclosingSelf>(
+      _enclosingInstance observed: EnclosingSelf,
+      wrapped wrappedKeyPath: ReferenceWritableKeyPath<EnclosingSelf, Value>,
+      storage storageKeyPath: ReferenceWritableKeyPath<EnclosingSelf, Self>
+    ) -> Value {
+    get {
+      observed[keyPath: storageKeyPath].stored
+    }
+    set {
+      observed[keyPath: storageKeyPath].stored = newValue
+    }
+  }
+}
+
+class Superclass {
+  var x: Int = 0
+}
+
+class SubclassWithEnclosingSelfInInitializer: Superclass {
+
+  init(test1: String) {
+    // Verify the init operand is accepted.
+    self.y = test1
+
+    // Verify the set operand is not accepted.
+    self.z = test1 // expected-error{{'self' captured by a closure before all members were initialized}}
+  }
+
+  init(test2: String) {
+    // Verify the init operand is accepted.
+    self.y = test2
+
+    super.init()
+
+    // Verify the set operand is accepted.
+    self.z = test2
+  }
+
+  init(test3: String) {
+    super.init() // expected-error{{property 'self.y' not initialized at super.init call}}
+
+    // Verify the init operand is not accepted.
+    self.y = test3 
+
+    // Verify the set operand is accepted.
+    self.z = test3
+  }
+
+  @Observable
+  var y: String
+
+  @Observable
+  var z: String = ""
+}


### PR DESCRIPTION
If a property wrapper is implemented using the static subscript to gain access to the enclosing self, an object must be fully initialized before assigning to the property wrapper.

Add an attribute, `[enclosingSelfAccess]`, to the `assign_by_wrapper` instruction so use analysis can determine if `self` is escaping.

Resolves SR-12430.