### PR TITLE
[CS] Adjust applied overload simplification

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1694,7 +1694,14 @@ void ConstraintSystem::addOverloadSet(ArrayRef<Constraint *> choices,
     return;
   }
 
-  addDisjunctionConstraint(choices, locator, ForgetChoice);
+  auto *disjunction =
+      Constraint::createDisjunction(*this, choices, locator, ForgetChoice);
+  addUnsolvedConstraint(disjunction);
+  if (simplifyAppliedOverloads(disjunction, locator)) {
+    retireConstraint(disjunction);
+    if (!failedConstraint)
+      failedConstraint = disjunction;
+  }
 }
 
 /// If we're resolving an overload set with a decl that has special type


### PR DESCRIPTION
Currently `simplifyAppliedOverloads` depends on the order in which constraints are simplified, specifically that a lookup constraint for a function gets simplified before the applicable function constraint. This happens to work out just fine today with the order in which we re-activate constraints, but I'm [planning on changing that order](https://github.com/apple/swift/pull/30487).

This PR changes the logic such that it's no longer affected by the order in which constraints are simplified. We'll now run it when either an applicable function constraint is added, or a new bind overload disjunction is added. This also means we no longer need to run it potentially multiple times when simplifying an applicable fn.
