### PR TITLE
LoopRotate: limit the size of the block to be duplicated.

### DIFF
--- a/test/SILOptimizer/looprotate.sil
+++ b/test/SILOptimizer/looprotate.sil
@@ -8,22 +8,6 @@ sil_stage canonical
 import Builtin
 import Swift
 
-// CHECK-LABEL: looprotate
-// CHECK: bb0(%0 : $Int32, %1 : $Bar):
-// CHECK:  class_method
-// CHECK:  cond_br {{.*}}, bb3({{.*}} : $Builtin.Int32), bb1
-
-// CHECK: bb1:
-// CHECK:  br bb2({{.*}} : $Builtin.Int32, {{.*}} : $Builtin.Int32, {{.*}}: $Int32)
-
-// CHECK: bb2({{.*}}: $Builtin.Int32, {{.*}} : $Builtin.Int32, {{.*}} : $Int32):
-// CHECK:   class_method
-// CHECK:   cond_br {{%.*}}, bb3({{.*}} : $Builtin.Int32), bb2({{.*}} : $Builtin.Int32, {{.*}} : $Builtin.Int32, {{.*}} : $Int32)
-
-// CHECK: bb3({{.*}} : $Builtin.Int32):
-// CHECK:   [[STRUCT:%.*]] = struct $Int32 ({{%.*}} : $Builtin.Int32)
-// CHECK:   return [[STRUCT]] : $Int32
-
 protocol P {
   func boo() -> Int64
 }
@@ -44,6 +28,24 @@ sil_vtable Bar {
   #Bar.foo_objc: @_TFC4main3Bar3foofS0_FT_T_
 }
 
+// CHECK-LABEL: looprotate
+// CHECK: bb0(%0 : $Int32, %1 : $Bar):
+// CHECK:   class_method
+// CHECK:   apply
+// CHECK:   cond_br {{.*}}, bb3({{.*}} : $Builtin.Int32), bb1
+
+// CHECK: bb1:
+// CHECK:   br bb2({{.*}} : $Builtin.Int32, {{.*}} : $Builtin.Int32, {{.*}}: $Int32)
+
+// CHECK: bb2({{.*}}: $Builtin.Int32, {{.*}} : $Builtin.Int32, {{.*}} : $Int32):
+// CHECK:   class_method
+// CHECK:   apply
+// CHECK:   cond_br {{%.*}}, bb3({{.*}} : $Builtin.Int32), bb2({{.*}} : $Builtin.Int32, {{.*}} : $Builtin.Int32, {{.*}} : $Int32)
+
+// CHECK: bb3({{.*}} : $Builtin.Int32):
+// CHECK:   [[STRUCT:%.*]] = struct $Int32 ({{%.*}} : $Builtin.Int32)
+// CHECK:   return [[STRUCT]] : $Int32
+// CHECK: } // end sil function 'looprotate'
 sil @looprotate : $@convention(thin) (Int32, @owned Bar) -> Int32 {
 bb0(%0 : $Int32, %25: $Bar):
   %1 = struct_extract %0 : $Int32, #Int32._value
@@ -55,6 +57,80 @@ bb0(%0 : $Int32, %25: $Bar):
 bb1(%4 : $Builtin.Int32, %5 : $Builtin.Int32, %26: $Bar, %31 : $<τ_0_0> { var τ_0_0 } <Bool>, %32 : $*Bool):
   %24 = class_method %26 : $Bar, #Bar.foo : (Bar) -> () -> (), $@convention(method) (@guaranteed Bar) -> () // user: %6
   %27 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %6 = struct $Int32 (%5 : $Builtin.Int32)
+  %8 = builtin "cmp_eq_Word"(%5 : $Builtin.Int32, %1 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %8, bb3, bb2
+
+bb2:
+  %10 = integer_literal $Builtin.Int32, 1
+  %12 = integer_literal $Builtin.Int1, -1
+  %13 = builtin "sadd_with_overflow_Word"(%5 : $Builtin.Int32, %10 : $Builtin.Int32, %12 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
+  %14 = tuple_extract %13 : $(Builtin.Int32, Builtin.Int1), 0
+  %15 = enum $Optional<Int32>, #Optional.some!enumelt, %6 : $Int32
+  %16 = unchecked_enum_data %15 : $Optional<Int32>, #Optional.some!enumelt
+  %17 = struct_extract %16 : $Int32, #Int32._value
+  %19 = integer_literal $Builtin.Int1, -1
+  %20 = builtin "sadd_with_overflow_Word"(%4 : $Builtin.Int32, %17 : $Builtin.Int32, %19 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
+  %21 = tuple_extract %20 : $(Builtin.Int32, Builtin.Int1), 0
+  br bb1(%21 : $Builtin.Int32, %14 : $Builtin.Int32, %26: $Bar, %31 : $<τ_0_0> { var τ_0_0 } <Bool>, %32 : $*Bool)
+
+bb3:
+  %23 = struct $Int32 (%4 : $Builtin.Int32)
+  return %23 : $Int32
+}
+
+// CHECK-LABEL: dont_duplicate_large_block
+// CHECK: bb0(%0 : $Int32, %1 : $Bar):
+// CHECK-NOT:   class_method
+// CHECK-NOT:   apply
+// CHECK:   br bb1
+
+// CHECK: bb1({{.*}}):
+// CHECK:   class_method
+// CHECK:   apply
+// CHECK:   cond_br
+
+// CHECK: bb2:
+// CHECK:   br bb1
+
+// CHECK: bb3:
+// CHECK:   return
+// CHECK: } // end sil function 'dont_duplicate_large_block'
+sil @dont_duplicate_large_block : $@convention(thin) (Int32, @owned Bar) -> Int32 {
+bb0(%0 : $Int32, %25: $Bar):
+  %1 = struct_extract %0 : $Int32, #Int32._value
+  %2 = integer_literal $Builtin.Int32, 0
+  %30 = alloc_box $<τ_0_0> { var τ_0_0 } <Bool>
+  %30a = project_box %30 : $<τ_0_0> { var τ_0_0 } <Bool>, 0
+  br bb1(%1 : $Builtin.Int32, %2 : $Builtin.Int32, %25: $Bar, %30 : $<τ_0_0> { var τ_0_0 } <Bool>, %30a : $*Bool)
+
+bb1(%4 : $Builtin.Int32, %5 : $Builtin.Int32, %26: $Bar, %31 : $<τ_0_0> { var τ_0_0 } <Bool>, %32 : $*Bool):
+  %24 = class_method %26 : $Bar, #Bar.foo : (Bar) -> () -> (), $@convention(method) (@guaranteed Bar) -> () // user: %6
+  %27 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %28 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %29 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %33 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %34 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %35 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %36 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %37 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %38 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %39 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %40 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %41 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %42 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %43 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %44 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %45 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %46 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %47 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %48 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %49 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %50 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %51 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %52 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %53 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
+  %54 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
   %6 = struct $Int32 (%5 : $Builtin.Int32)
   %8 = builtin "cmp_eq_Word"(%5 : $Builtin.Int32, %1 : $Builtin.Int32) : $Builtin.Int1
   cond_br %8, bb3, bb2


### PR DESCRIPTION
This avoids significant code size regressions if the loop block to be duplicated is very large.

Also remove the ShouldRotate option. It's not needed anymore as disabling the pass can be done by -sil-disable-pass.

rdar://problem/33970453
