### PR TITLE
[String] Concrete String/Substring overloads for ~=

### DIFF
--- a/stdlib/public/core/StringComparable.swift
+++ b/stdlib/public/core/StringComparable.swift
@@ -82,3 +82,25 @@ extension String: Comparable {
 }
 
 extension Substring: Equatable {}
+
+// TODO(SR-12457): Generalize `~=` over `StringProtocol`. Below are
+// concrete overloads to give us most of the benefit without potential harm
+// to expression type checking performance.
+extension String {
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  @_effects(readonly)
+  public static func ~= (lhs: String, rhs: Substring) -> Bool {
+    return lhs == rhs
+  }
+}
+extension Substring {
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  @_effects(readonly)
+  public static func ~= (lhs: Substring, rhs: String) -> Bool {
+    return lhs == rhs
+  }
+}
+
+

--- a/test/stdlib/StringSwitch.swift
+++ b/test/stdlib/StringSwitch.swift
@@ -1,0 +1,82 @@
+// RUN: %target-run-simple-swift
+
+import StdlibUnittest
+
+var StringSwitchTests = TestSuite("StringSwitchTests")
+
+func switchOver(_ s: String) -> Character {
+  let (first, second) = ("first", "second")
+
+  let ret1: Character
+  switch s {
+    case first: ret1 = "A"
+    case second[...]: ret1 = "B"
+    default: ret1 = "X"
+  }
+
+  let ret2: Character
+  switch s[...] {
+    case first: ret2 = "A"
+    case second[...]: ret2 = "B"
+    default: ret2 = "X"
+  }
+
+  expectEqual(ret1, ret2)
+  return ret1
+}
+
+func switchOver<S1: StringProtocol, S2: StringProtocol>(
+  _ s1: S1, _ s2: S2
+) -> Character {
+  let (first, second) = ("first", "second")
+
+  // TODO(SR-12457): Enable
+#if true
+  fatalError()
+#else
+  let ret1: Character
+  switch s1 {
+    case first: ret1 = "A"
+    case second[...]: ret1 = "B"
+    case s2: ret2 = "="
+    default: ret1 = "X"
+  }
+
+  let ret2: Character
+  switch s2 {
+    case first: ret1 = "A"
+    case second[...]: ret1 = "B"
+    case s1: ret2 = "="
+    default: ret2 = "X"
+  }
+
+  expectEqual(ret1, ret2)
+  return ret1
+#endif
+}
+
+StringSwitchTests.test("switch") {
+  let (first, second) = ("first", "second")
+  let same = "same"
+  let (foo, bar) = ("foo", "bar")
+
+  expectEqual("A", switchOver(first))
+  expectEqual("B", switchOver(second))
+  expectEqual("X", switchOver(foo))
+
+  // TODO(SR-12457): Enable
+#if true
+#else
+  expectEqual("A", switchOver(first, first))
+  expectEqual("B", switchOver(second, second))
+  expectEqual("=", switchOver(same, same))
+  expectEqual("X", switchOver(foo, bar))
+  expectEqual("A", switchOver(first[...], first))
+  expectEqual("B", switchOver(second[...], second))
+  expectEqual("=", switchOver(same[...], same))
+  expectEqual("X", switchOver(foo[...], bar))
+#endif
+
+}
+
+runAllTests()


### PR DESCRIPTION
Add concrete overloads for ~= for String/Substring
combinations. SR-12457 tracks making this generic after we understand
the expression type checker impact.

<rdar://problem/34581170>

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
