### PR TITLE
Add OMPArrayShaping to a few switch statements

### DIFF
--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -446,6 +446,7 @@ OmissionTypeName importer::getClangTypeNameForOmission(clang::ASTContext &ctx,
 
     // OpenMP types that don't have Swift equivalents.
     case clang::BuiltinType::OMPArraySection:
+    case clang::BuiltinType::OMPArrayShaping:
       return OmissionTypeName();
 
     // SVE builtin types that don't have Swift equivalents.

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -320,6 +320,7 @@ namespace {
 
       // OpenMP types that don't have Swift equivalents.
       case clang::BuiltinType::OMPArraySection:
+      case clang::BuiltinType::OMPArrayShaping:
         return Type();
 
       // SVE builtin types that don't have Swift equivalents.


### PR DESCRIPTION
This was added to clang in `llvm/llvm-project/master`. Swift builds fail without this corresponding change.