### PR TITLE
[gardening] Move maybeScopeLess from SIL/Verifier/SILVerifier.cpp -> SIL/IR/SILDebugScope.cpp.

### DIFF
--- a/lib/SIL/IR/SILDebugScope.cpp
+++ b/lib/SIL/IR/SILDebugScope.cpp
@@ -55,3 +55,10 @@ SILFunction *SILDebugScope::getParentFunction() const {
     return ParentScope->getParentFunction();
   return Parent.get<SILFunction *>();
 }
+
+/// Determine whether an instruction may not have a SILDebugScope.
+bool swift::maybeScopeless(SILInstruction &I) {
+  if (I.getFunction()->isBare())
+    return true;
+  return !isa<DebugValueInst>(I) && !isa<DebugValueAddrInst>(I);
+}

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -5527,10 +5527,3 @@ void SILModule::verify() const {
     prop.verify(*this);
   }
 }
-
-/// Determine whether an instruction may not have a SILDebugScope.
-bool swift::maybeScopeless(SILInstruction &I) {
-  if (I.getFunction()->isBare())
-    return true;
-  return !isa<DebugValueInst>(I) && !isa<DebugValueAddrInst>(I);
-}


### PR DESCRIPTION
This is defined in SILDebugScope.h, so I don't know why it was put into
SILVerifier.cpp.
