### PR TITLE
[ConstraintSystem] Allow sequence element mismatch fix to produce new…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -184,6 +184,9 @@ ERROR(value_type_comparison_with_nil_illegal,none,
 ERROR(cannot_match_expr_pattern_with_value,none,
       "expression pattern of type %0 cannot match values of type %1",
       (Type, Type))
+ERROR(cannot_match_expr_tuple_pattern_with_nontuple_value,none,
+      "tuple pattern cannot match values of non-tuple type %0",
+      (Type))
 ERROR(cannot_match_unresolved_expr_pattern_with_value,none,
       "pattern cannot match values of type %0",
       (Type))

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3908,6 +3908,15 @@ bool ConstraintSystem::repairFailures(
     if (rhs->isExistentialType())
       break;
 
+    // If the types didn't line up, let's allow right-hand side
+    // of the conversion (or pattern match) to have holes. This
+    // helps when conversion if between a type and a tuple e.g.
+    // `Int` vs. `(_, _)`.
+    rhs.visit([&](Type type) {
+      if (auto *typeVar = type->getAs<TypeVariableType>())
+        recordPotentialHole(typeVar);
+    });
+
     conversionsOrFixes.push_back(CollectionElementContextualMismatch::create(
         *this, lhs, rhs, getConstraintLocator(locator)));
     break;

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -220,3 +220,12 @@ extension Int : P { }
 func testRepeated(ri: RepeatedSequence<Int>) {
   for x in ri { _ = x }
 }
+
+// SR-12398: Poor pattern matching diagnostic: "for-in loop requires '[Int]' to conform to 'Sequence'"
+func sr_12398(arr1: [Int], arr2: [(a: Int, b: String)]) {
+  for (x, y) in arr1 {}
+  // expected-error@-1 {{tuple pattern cannot match values of non-tuple type 'Int'}}
+
+  for (x, y, _) in arr2 {}
+  // expected-error@-1 {{pattern cannot match values of type '(a: Int, b: String)'}}
+}


### PR DESCRIPTION
… holes

Type on the right-hand side of the element conversion/pattern match
should be allowed to have holes to be able to diagnose failures with
structurally incompatible types.

Resolves: rdar://problem/60832876

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
