### PR TITLE
Add dependencies where targets depend on inclusions from unspecified targets.

### DIFF
--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -124,15 +124,17 @@ if(SWIFT_BUILD_ONLY_SYNTAXPARSERLIB)
   else()
     set(clangBasicDep "${LLVM_LIBRARY_OUTPUT_INTDIR}/libclangBasic.a")
   endif()
+  target_link_libraries(swiftAST PUBLIC
+    swiftBasic)
   target_link_libraries(swiftAST PRIVATE
-    swiftBasic
     swiftSyntax
     ${clangBasicDep})
   target_compile_definitions(swiftAST PRIVATE
     SWIFT_BUILD_ONLY_SYNTAXPARSERLIB=1)
 else()
+  target_link_libraries(swiftAST PUBLIC
+    swiftBasic)
   target_link_libraries(swiftAST PRIVATE
-    swiftBasic
     swiftMarkup
     swiftSyntax)
 endif()

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -116,27 +116,24 @@ if(NOT SWIFT_BUILD_ONLY_SYNTAXPARSERLIB)
     clangBasic)
 endif()
 
+target_link_libraries(swiftAST
+  PUBLIC swiftBasic
+  PRIVATE swiftSyntax)
 if(SWIFT_BUILD_ONLY_SYNTAXPARSERLIB)
   # Add clangBasic as a single direct dependency to avoid bringing along some
   # llvm libraries that we don't need.
   if("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "WINDOWS")
-    set(clangBasicDep "${LLVM_LIBRARY_OUTPUT_INTDIR}/clangBasic.lib")
+    target_link_libraries(swiftAST PRIVATE
+      "${LLVM_LIBRARY_OUTPUT_INTDIR}/clangBasic.lib")
   else()
-    set(clangBasicDep "${LLVM_LIBRARY_OUTPUT_INTDIR}/libclangBasic.a")
+    target_link_libraries(swiftAST PRIVATE
+      "${LLVM_LIBRARY_OUTPUT_INTDIR}/libclangBasic.a")
   endif()
-  target_link_libraries(swiftAST PUBLIC
-    swiftBasic)
-  target_link_libraries(swiftAST PRIVATE
-    swiftSyntax
-    ${clangBasicDep})
   target_compile_definitions(swiftAST PRIVATE
     SWIFT_BUILD_ONLY_SYNTAXPARSERLIB=1)
 else()
-  target_link_libraries(swiftAST PUBLIC
-    swiftBasic)
   target_link_libraries(swiftAST PRIVATE
-    swiftMarkup
-    swiftSyntax)
+    swiftMarkup)
 endif()
 
 # intrinsics_gen is the LLVM tablegen target that generates the include files

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -86,8 +86,9 @@ add_swift_host_library(swiftBasic STATIC
 target_include_directories(swiftBasic PRIVATE
   ${UUID_INCLUDE})
 
+target_link_libraries(swiftBasic PUBLIC
+  swiftDemangling)
 target_link_libraries(swiftBasic PRIVATE
-  swiftDemangling
   ${UUID_LIBRARIES})
 
 message(STATUS "Swift version: ${SWIFT_VERSION}")

--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -16,6 +16,7 @@ add_swift_host_library(swiftFrontend STATIC
 add_dependencies(swiftFrontend
   SwiftOptions)
 target_link_libraries(swiftFrontend PRIVATE
+  swiftAST
   swiftSIL
   swiftMigrator
   swiftOption

--- a/lib/LLVMPasses/CMakeLists.txt
+++ b/lib/LLVMPasses/CMakeLists.txt
@@ -9,4 +9,5 @@ add_swift_host_library(swiftLLVMPasses STATIC
   LLVM_LINK_COMPONENTS
   analysis
   )
-
+target_link_libraries(swiftLLVMPasses PRIVATE
+  swiftDemangling)

--- a/lib/ParseSIL/CMakeLists.txt
+++ b/lib/ParseSIL/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_swift_host_library(swiftParseSIL STATIC
   ParseSIL.cpp)
 target_link_libraries(swiftParseSIL PRIVATE
+  swiftDemangling
   swiftSema
   swiftSIL)
 

--- a/lib/RemoteAST/CMakeLists.txt
+++ b/lib/RemoteAST/CMakeLists.txt
@@ -15,6 +15,8 @@ add_swift_host_library(swiftRemoteAST STATIC
   RemoteAST.cpp
   InProcessMemoryReader.cpp
   ${REMOTE_LIB_HEADERS})
+target_link_libraries(swiftRemoteAST PUBLIC
+  swiftDemangling)
 target_link_libraries(swiftRemoteAST PRIVATE
   swiftIRGen
   swiftSema)

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -27,6 +27,8 @@ add_subdirectory(Verifier)
 
 add_swift_host_library(swiftSIL STATIC
   ${SIL_SOURCES})
+target_link_libraries(swiftSIL PUBLIC
+  swiftDemangling)
 target_link_libraries(swiftSIL PRIVATE
   swiftSema
   swiftSerialization)

--- a/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
@@ -14,6 +14,7 @@ add_sourcekit_library(sourcekitdAPI
   ExpressionTypeArray.cpp
 )
 target_link_libraries(sourcekitdAPI PRIVATE
+  swiftBasic
   SourceKitSupport
   SourceKitSwiftLang)
 

--- a/tools/lldb-moduleimport-test/CMakeLists.txt
+++ b/tools/lldb-moduleimport-test/CMakeLists.txt
@@ -4,6 +4,7 @@ add_swift_host_tool(lldb-moduleimport-test
 )
 target_link_libraries(lldb-moduleimport-test
                       PRIVATE
+                        swiftAST
                         swiftASTSectionImporter
                         swiftClangImporter
                         swiftFrontend)

--- a/tools/sil-func-extractor/CMakeLists.txt
+++ b/tools/sil-func-extractor/CMakeLists.txt
@@ -5,6 +5,7 @@ add_swift_host_tool(sil-func-extractor
 target_link_libraries(sil-func-extractor
                       PRIVATE
                         swiftClangImporter
+                        swiftDemangling
                         swiftFrontend
                         swiftSerialization
                         swiftSILGen

--- a/tools/sil-nm/CMakeLists.txt
+++ b/tools/sil-nm/CMakeLists.txt
@@ -5,6 +5,7 @@ add_swift_host_tool(sil-nm
 target_link_libraries(sil-nm
                       PRIVATE
                         swiftClangImporter
+                        swiftDemangling
                         swiftFrontend
                         swiftSerialization
                         swiftSILGen

--- a/tools/sil-opt/CMakeLists.txt
+++ b/tools/sil-opt/CMakeLists.txt
@@ -6,6 +6,7 @@ target_link_libraries(sil-opt
                       PRIVATE
                         swiftFrontend
                         swiftIRGen
+                        swiftSIL
                         swiftSILGen
                         swiftSILOptimizer
                         # Clang libraries included to appease the linker on linux.

--- a/tools/swift-ast-script/CMakeLists.txt
+++ b/tools/swift-ast-script/CMakeLists.txt
@@ -7,4 +7,5 @@ add_swift_host_tool(swift-ast-script
 )
 target_link_libraries(swift-ast-script
                       PRIVATE
+                        swiftAST
                         swiftFrontendTool)

--- a/tools/swift-ide-test/CMakeLists.txt
+++ b/tools/swift-ide-test/CMakeLists.txt
@@ -6,6 +6,7 @@ add_swift_host_tool(swift-ide-test
 )
 target_link_libraries(swift-ide-test
                       PRIVATE
+                        swiftAST
                         swiftDriver
                         swiftFrontend
                         swiftIDE)


### PR DESCRIPTION
A follow-up PR (https://github.com/apple/swift/pull/30733) adds a flag to control an inline namespace that allows
symbols in libDemangling to be distinguished between the runtime and
the compiler. These dependencies ensure that the flag is plumbed
through for inclusions of Demangling headers that aren't already
covered by existing `target_link_libraries`.

cc: @compnerd 