### PR TITLE
Wrap (de)mangling namespaces in an inline namespace.

### DIFF
--- a/include/swift/AST/ASTDemangler.h
+++ b/include/swift/AST/ASTDemangler.h
@@ -26,6 +26,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "swift/AST/Types.h"
 #include "swift/Demangling/Demangler.h"
+#include "swift/Demangling/NamespaceMacros.h"
 #include "swift/Demangling/TypeDecoder.h"
 
 namespace swift {
@@ -33,6 +34,7 @@ namespace swift {
 class TypeDecl;
 
 namespace Demangle {
+SWIFT_BEGIN_INLINE_NAMESPACE
 
 Type getTypeForMangling(ASTContext &ctx,
                         llvm::StringRef mangling);
@@ -178,6 +180,7 @@ private:
                                               Demangle::Node::Kind kind);
 };
 
+SWIFT_END_INLINE_NAMESPACE
 }  // namespace Demangle
 
 }  // namespace swift

--- a/include/swift/Basic/Mangler.h
+++ b/include/swift/Basic/Mangler.h
@@ -14,6 +14,7 @@
 #define SWIFT_BASIC_MANGLER_H
 
 #include "swift/Demangling/ManglingUtils.h"
+#include "swift/Demangling/NamespaceMacros.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/DenseMap.h"
@@ -24,6 +25,7 @@
 
 namespace swift {
 namespace Mangle {
+SWIFT_BEGIN_INLINE_NAMESPACE
 
 void printManglingStats();
 
@@ -204,6 +206,7 @@ protected:
   }
 };
 
+SWIFT_END_INLINE_NAMESPACE
 } // end namespace Mangle
 } // end namespace swift
 

--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include "llvm/ADT/StringRef.h"
 #include "swift/Runtime/Config.h"
+#include "swift/Demangling/NamespaceMacros.h"
 
 namespace llvm {
   class raw_ostream;
@@ -32,6 +33,7 @@ namespace llvm {
 
 namespace swift {
 namespace Demangle {
+SWIFT_BEGIN_INLINE_NAMESPACE
 
 enum class SymbolicReferenceKind : uint8_t;
 
@@ -621,6 +623,7 @@ bool isFunctionAttr(Node::Kind kind);
 /// contain symbolic references.
 llvm::StringRef makeSymbolicMangledNameStringRef(const char *base);
 
+SWIFT_END_INLINE_NAMESPACE
 } // end namespace Demangle
 } // end namespace swift
 

--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -20,6 +20,7 @@
 #define SWIFT_DEMANGLING_DEMANGLER_H
 
 #include "swift/Demangling/Demangle.h"
+#include "swift/Demangling/NamespaceMacros.h"
 
 //#define NODE_FACTORY_DEBUGGING
 
@@ -28,6 +29,7 @@ using llvm::StringRef;
 
 namespace swift {
 namespace Demangle {
+SWIFT_BEGIN_INLINE_NAMESPACE
 
 class CharVector;
   
@@ -622,6 +624,7 @@ public:
 
 NodePointer demangleOldSymbolAsNode(StringRef MangledName,
                                     NodeFactory &Factory);
+SWIFT_END_INLINE_NAMESPACE
 } // end namespace Demangle
 } // end namespace swift
 

--- a/include/swift/Demangling/ManglingUtils.h
+++ b/include/swift/Demangling/ManglingUtils.h
@@ -14,10 +14,12 @@
 #define SWIFT_DEMANGLING_MANGLINGUTILS_H
 
 #include "llvm/ADT/StringRef.h"
+#include "swift/Demangling/NamespaceMacros.h"
 #include "swift/Demangling/Punycode.h"
 
 namespace swift {
 namespace Mangle {
+SWIFT_BEGIN_INLINE_NAMESPACE
 
 using llvm::StringRef;
 
@@ -311,6 +313,7 @@ public:
   }
 };
 
+SWIFT_END_INLINE_NAMESPACE
 } // end namespace Mangle
 } // end namespace swift
 

--- a/include/swift/Demangling/NamespaceMacros.h
+++ b/include/swift/Demangling/NamespaceMacros.h
@@ -1,0 +1,35 @@
+//===--- NamespaceMacros.h - Macros for inline namespaces -------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Macros that conditionally define an inline namespace so that symbols used in
+// multiple places (such as in the compiler and in the runtime library) can be
+// given distinct mangled names in different contexts without affecting client
+// usage in source.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_DEMANGLING_NAMESPACE_MACROS_H
+#define SWIFT_DEMANGLING_NAMESPACE_MACROS_H
+
+#if defined(__cplusplus)
+
+#if defined(SWIFT_INLINE_NAMESPACE)
+#define SWIFT_BEGIN_INLINE_NAMESPACE inline namespace SWIFT_INLINE_NAMESPACE {
+#define SWIFT_END_INLINE_NAMESPACE }
+#else
+#define SWIFT_BEGIN_INLINE_NAMESPACE
+#define SWIFT_END_INLINE_NAMESPACE
+#endif
+
+#endif
+
+#endif // SWIFT_DEMANGLING_NAMESPACE_MACROS_H

--- a/include/swift/Demangling/Punycode.h
+++ b/include/swift/Demangling/Punycode.h
@@ -28,11 +28,13 @@
 #define SWIFT_DEMANGLING_PUNYCODE_H
 
 #include "llvm/ADT/StringRef.h"
+#include "swift/Demangling/NamespaceMacros.h"
 #include <vector>
 #include <cstdint>
 
 namespace swift {
 namespace Punycode {
+SWIFT_BEGIN_INLINE_NAMESPACE
 
 using llvm::StringRef;
 
@@ -58,6 +60,7 @@ bool encodePunycodeUTF8(StringRef InputUTF8, std::string &OutPunycode,
 
 bool decodePunycodeUTF8(StringRef InputPunycode, std::string &OutUTF8);
 
+SWIFT_END_INLINE_NAMESPACE
 } // end namespace Punycode
 } // end namespace swift
 

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -20,6 +20,7 @@
 
 #include "swift/ABI/MetadataValues.h"
 #include "swift/Demangling/Demangler.h"
+#include "swift/Demangling/NamespaceMacros.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Runtime/Unreachable.h"
 #include "swift/Strings.h"
@@ -28,6 +29,7 @@
 
 namespace swift {
 namespace Demangle {
+SWIFT_BEGIN_INLINE_NAMESPACE
 
 enum class ImplMetatypeRepresentation {
   Thin,
@@ -1152,6 +1154,7 @@ decodeMangledType(BuilderType &Builder,
 }
 
 
+SWIFT_END_INLINE_NAMESPACE
 } // end namespace Demangle
 } // end namespace swift
 

--- a/include/swift/SILOptimizer/Utils/SpecializationMangler.h
+++ b/include/swift/SILOptimizer/Utils/SpecializationMangler.h
@@ -14,6 +14,7 @@
 #define SWIFT_SILOPTIMIZER_UTILS_SPECIALIZATIONMANGLER_H
 
 #include "swift/Demangling/Demangler.h"
+#include "swift/Demangling/NamespaceMacros.h"
 #include "swift/Basic/NullablePtr.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/SIL/SILLinkage.h"
@@ -21,6 +22,7 @@
 
 namespace swift {
 namespace Mangle {
+SWIFT_BEGIN_INLINE_NAMESPACE
 
 enum class SpecializationKind : uint8_t {
   Generic,
@@ -169,6 +171,7 @@ private:
   void mangleReturnValue(ReturnValueModifierIntBase RetMod);
 };
 
+SWIFT_END_INLINE_NAMESPACE
 } // end namespace Mangle
 } // end namespace swift
 

--- a/lib/Demangling/CMakeLists.txt
+++ b/lib/Demangling/CMakeLists.txt
@@ -11,3 +11,12 @@ add_swift_host_library(swiftDemangling STATIC
 target_compile_definitions(swiftDemangling PRIVATE
   LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
 
+# NOTE: Runtime libraries that depend on swiftDemangling should define
+# SWIFT_INLINE_NAMESPACE to specify the identifier that will be used for an
+# inline namespace that will be added around the symbols defined by this
+# library. This keeps the demangling symbols in those libraries distinct
+# from those in the compiler, which prevents ODR violations in certain
+# contexts; for example, on platforms that support statically linking the
+# Swift standard library, it allows this to happen safely when the binary
+# also links in compiler libraries that may not match exactly with the
+# runtime version.

--- a/lib/Demangling/Context.cpp
+++ b/lib/Demangling/Context.cpp
@@ -16,9 +16,11 @@
 
 #include "swift/Demangling/Demangler.h"
 #include "swift/Demangling/ManglingMacros.h"
+#include "swift/Demangling/NamespaceMacros.h"
 
 namespace swift {
 namespace Demangle {
+SWIFT_BEGIN_INLINE_NAMESPACE
 
 //////////////////////////////////
 // Context member functions     //
@@ -248,5 +250,6 @@ std::string demangleTypeAsString(const char *MangledName,
                                   Options);
 }
 
+SWIFT_END_INLINE_NAMESPACE
 } // namespace Demangle
 } // namespace swift

--- a/lib/Demangling/RemanglerBase.h
+++ b/lib/Demangling/RemanglerBase.h
@@ -18,6 +18,7 @@
 #define SWIFT_DEMANGLING_BASEREMANGLER_H
 
 #include "swift/Demangling/Demangler.h"
+#include "swift/Demangling/NamespaceMacros.h"
 #include <unordered_map>
 
 using namespace swift::Demangle;
@@ -25,6 +26,7 @@ using llvm::StringRef;
 
 namespace swift {
 namespace Demangle {
+SWIFT_BEGIN_INLINE_NAMESPACE
 
 // An entry in the remangler's substitution map.
 class SubstitutionEntry {
@@ -163,6 +165,7 @@ public:
   }
 };
 
+SWIFT_END_INLINE_NAMESPACE
 } // end namespace Demangle
 } // end namespace swift
 

--- a/lib/SwiftRemoteMirror/CMakeLists.txt
+++ b/lib/SwiftRemoteMirror/CMakeLists.txt
@@ -1,5 +1,8 @@
 add_swift_host_library(swiftRemoteMirror STATIC
   ${SWIFT_SOURCE_DIR}/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp)
+target_link_libraries(swiftRemoteMirror PRIVATE
+  swiftDemangling)
+
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   target_compile_definitions(swiftRemoteMirror PRIVATE _LIB)
 endif()

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -884,6 +884,13 @@ function(_add_swift_target_library_single target name)
   endif()
   _set_target_prefix_and_suffix("${target}" "${libkind}" "${SWIFTLIB_SINGLE_SDK}")
 
+  # Target libraries that include libDemangling must define the name to use for
+  # the inline namespace to distinguish symbols from those built for the
+  # compiler, in order to avoid possible ODR violations if both are statically
+  # linked into the same binary.
+  target_compile_definitions("${target}" PRIVATE
+                             SWIFT_INLINE_NAMESPACE=__runtime)
+
   if("${SWIFTLIB_SINGLE_SDK}" STREQUAL "WINDOWS")
     swift_windows_include_for_arch(${SWIFTLIB_SINGLE_ARCHITECTURE} SWIFTLIB_INCLUDE)
     target_include_directories("${target}" SYSTEM PRIVATE

--- a/unittests/Reflection/CMakeLists.txt
+++ b/unittests/Reflection/CMakeLists.txt
@@ -5,6 +5,8 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
       TypeRef.cpp)
     target_include_directories(SwiftReflectionTests BEFORE PRIVATE
       ${SWIFT_SOURCE_DIR}/stdlib/include)
+    target_compile_definitions(SwiftReflectionTests PRIVATE
+      SWIFT_INLINE_NAMESPACE=__runtime)
     target_link_libraries(SwiftReflectionTests
       PRIVATE
       swiftReflection${SWIFT_PRIMARY_VARIANT_SUFFIX})

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -83,7 +83,8 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
   # with swiftCore_EXPORTS to permit exporting the stdlib interfaces.
   target_compile_definitions(SwiftRuntimeTests
                              PRIVATE
-                               swiftCore_EXPORTS)
+                               swiftCore_EXPORTS
+                               SWIFT_INLINE_NAMESPACE=__runtime)
 
   target_include_directories(SwiftRuntimeTests BEFORE PRIVATE
     ${SWIFT_SOURCE_DIR}/stdlib/include)

--- a/unittests/runtime/LongTests/CMakeLists.txt
+++ b/unittests/runtime/LongTests/CMakeLists.txt
@@ -47,7 +47,8 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
   # interfaces.
   target_compile_definitions(SwiftRuntimeLongTests
                              PRIVATE
-                               swiftCore_EXPORTS)
+                               swiftCore_EXPORTS
+                               SWIFT_INLINE_NAMESPACE=__runtime)
 
   # FIXME: cross-compile for all variants.
   target_link_libraries(SwiftRuntimeLongTests


### PR DESCRIPTION
Since libDemangling is included in the Swift standard library,
ODR violations can occur on platforms that allow statically
linking stdlib if Swift code is linked with other compiler
libraries that also transitively pull in libDemangling, and if
the stdlib version and compiler version do not match exactly
(even down to commit drift between releases). This lets the
runtime conditionally segregate its copies of the libDemangling
symbols from those in the compiler using an inline namespace
without affecting usage throughout source.

cc: @compnerd 