### PR TITLE
[IRGen] Skip witness table query for protocols that do not require one

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1741,7 +1741,12 @@ namespace {
         auto underlyingConformance = conformance
           .subst(O->getUnderlyingInterfaceType(),
                  *O->getUnderlyingTypeSubstitutions());
-        
+
+        // Skip protocols without Witness tables, e.g. @objc protocols.
+        if (!Lowering::TypeConverter::protocolRequiresWitnessTable(
+                underlyingConformance.getRequirement()))
+          continue;
+
         auto witnessTableRef = IGM.emitWitnessTableRefString(
                                           underlyingType, underlyingConformance,
                                           contextSig,

--- a/test/type/opaque_return_type_obc_protocol.swift
+++ b/test/type/opaque_return_type_obc_protocol.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -disable-availability-checking -emit-ir %s
+// REQUIRES: objc_interop
+//
+// Ensures this does not cause a crash, as @objc protocols are a special case
+// because they do not require a witness table
+// rdar://problem/59740179
+import Foundation
+
+@objc
+public protocol MyProtocol {}
+
+extension NSIndexSet: MyProtocol {}
+
+public func toSomeMyProtocol() -> some MyProtocol { 
+    return NSIndexSet(index: 7)
+}


### PR DESCRIPTION
Some protocols, such as protocols marked with 'objc', do not have a Witness Table.
The code before this patch assumes all protocols do have a Witness Table when generating the layout of an OpaqueTypeDescriptor, causing an assert to be triggered for opaque return types that conform to an 'objc' protocol.

Resolves SR-12257 / rdar://problem/59740179