### PR TITLE
[sil] [irgen] make object instruction valid

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -102,7 +102,7 @@ namespace {
     StructLayout *createLayoutWithTailElems(IRGenModule &IGM,
                                             SILType classType,
                                             ArrayRef<SILType> tailTypes) const;
-    
+
     using HeapTypeInfo<ClassTypeInfo>::initialize;
     void initialize(IRGenFunction &IGF, Explosion &e, Address addr,
                     bool isOutlined) const override;
@@ -497,10 +497,11 @@ void ClassTypeInfo::initialize(IRGenFunction &IGF, Explosion &src, Address addr,
     (void)src.claimNext();
     return;
   }
-  
+
   // If both are the same (address) type then just emit a memcpy.
   if (exploded->getType() == addr->getType()) {
-    IGF.emitMemCpy(addr.getAddress(), exploded, getFixedSize(), addr.getAlignment());
+    IGF.emitMemCpy(addr.getAddress(), exploded, getFixedSize(),
+                   addr.getAlignment());
     (void)src.claimNext();
     return;
   }
@@ -508,7 +509,6 @@ void ClassTypeInfo::initialize(IRGenFunction &IGF, Explosion &src, Address addr,
   // Otherwise, bail to the default implementation.
   HeapTypeInfo<ClassTypeInfo>::initialize(IGF, src, addr, isOutlined);
 }
-  
 
 /// Cast the base to i8*, apply the given inbounds offset (in bytes,
 /// as a size_t), and cast to a pointer to the given type.

--- a/lib/IRGen/GenInit.cpp
+++ b/lib/IRGen/GenInit.cpp
@@ -64,7 +64,7 @@ StackAddress FixedTypeInfo::allocateStack(IRGenFunction &IGF, SILType T,
     auto addr = getUndefAddress();
     return { addr };
   }
-
+  
   Address alloca =
     IGF.createAlloca(getStorageType(), getFixedAlignment(), name);
   IGF.Builder.CreateLifetimeStart(alloca, getFixedSize());

--- a/lib/IRGen/GenInit.cpp
+++ b/lib/IRGen/GenInit.cpp
@@ -64,7 +64,7 @@ StackAddress FixedTypeInfo::allocateStack(IRGenFunction &IGF, SILType T,
     auto addr = getUndefAddress();
     return { addr };
   }
-  
+
   Address alloca =
     IGF.createAlloca(getStorageType(), getFixedAlignment(), name);
   IGF.Builder.CreateLifetimeStart(alloca, getFixedSize());

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3452,32 +3452,40 @@ void IRGenSILFunction::visitObjectInst(swift::ObjectInst *i) {
   SILType objType = i->getType().getObjectType();
   // TODO: Currently generic classes aren't allowed but in the future we could
   // support this.
-  assert(!objType.getClassOrBoundGenericClass()->getAsGenericContext() || !objType.getClassOrBoundGenericClass()->getAsGenericContext()->isGeneric() && "Generics are not yet supported");
+  assert(!objType.getClassOrBoundGenericClass()->getAsGenericContext() ||
+         !objType.getClassOrBoundGenericClass()
+                 ->getAsGenericContext()
+                 ->isGeneric() &&
+             "Generics are not yet supported");
 
   const auto &typeInfo = cast<LoadableTypeInfo>(getTypeInfo(objType));
-  llvm::Value *metadata = emitClassHeapMetadataRef(*this, objType.getASTType(),
-                                                   MetadataValueType::TypeMetadata,
-                                                   MetadataState::Complete);
+  llvm::Value *metadata = emitClassHeapMetadataRef(
+      *this, objType.getASTType(), MetadataValueType::TypeMetadata,
+      MetadataState::Complete);
   // TODO: this shouldn't be a stack alloc but, in order to maintain
   // compatibility with alloc_ref we have to be a pointer.
-  Address alloca = createAlloca(typeInfo.getStorageType()->getPointerElementType(),
-                                typeInfo.getFixedAlignment());
+  Address alloca =
+      createAlloca(typeInfo.getStorageType()->getPointerElementType(),
+                   typeInfo.getFixedAlignment());
   auto classAddr = Builder.CreateBitCast(alloca, IGM.RefCountedPtrTy);
-  auto classVal = emitInitStackObjectCall(metadata, classAddr.getAddress(), "reference.new");
+  auto classVal = emitInitStackObjectCall(metadata, classAddr.getAddress(),
+                                          "reference.new");
   classVal = Builder.CreateBitCast(classVal, typeInfo.getStorageType());
   // Match each property in the class decl to elements in the object
   // instruction.
-  auto propsArr = i->getType().getClassOrBoundGenericClass()->getStoredProperties();
-  SmallVector<VarDecl*, 8> props(propsArr.begin(), propsArr.end());
+  auto propsArr =
+      i->getType().getClassOrBoundGenericClass()->getStoredProperties();
+  SmallVector<VarDecl *, 8> props(propsArr.begin(), propsArr.end());
   for (SILValue elt : i->getAllElements()) {
     auto prop = props.pop_back_val();
     auto elementExplosion = getLoweredExplosion(elt);
     auto propType = IGM.getLoweredType(prop->getType());
     const auto &propTypeInfo = cast<LoadableTypeInfo>(getTypeInfo(propType));
-    auto propAddr = projectPhysicalClassMemberAddress(*this, classVal, objType, propType, prop);
+    auto propAddr = projectPhysicalClassMemberAddress(*this, classVal, objType,
+                                                      propType, prop);
     propTypeInfo.initialize(*this, elementExplosion, propAddr, false);
   }
-  
+
   Explosion e;
   e.add(classVal);
   setLoweredExplosion(i, e);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -877,9 +877,7 @@ public:
   void visitDestroyValueInst(DestroyValueInst *i);
   void visitAutoreleaseValueInst(AutoreleaseValueInst *i);
   void visitSetDeallocatingInst(SetDeallocatingInst *i);
-  void visitObjectInst(ObjectInst *i)  {
-    llvm_unreachable("object instruction cannot appear in a function");
-  }
+  void visitObjectInst(ObjectInst *i);
   void visitStructInst(StructInst *i);
   void visitTupleInst(TupleInst *i);
   void visitEnumInst(EnumInst *i);
@@ -3448,6 +3446,13 @@ void IRGenSILFunction::visitDestroyValueInst(swift::DestroyValueInst *i) {
   Explosion in = getLoweredExplosion(i->getOperand());
   cast<LoadableTypeInfo>(getTypeInfo(i->getOperand()->getType()))
       .consume(*this, in, getDefaultAtomicity());
+}
+
+void IRGenSILFunction::visitObjectInst(swift::ObjectInst *i) {
+  Explosion out;
+  for (SILValue elt : i->getAllElements())
+    out.add(getLoweredExplosion(elt).claimAll());
+  setLoweredExplosion(i, out);
 }
 
 void IRGenSILFunction::visitStructInst(swift::StructInst *i) {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1813,7 +1813,7 @@ public:
     auto *classDecl = objectInst->getType().getClassOrBoundGenericClass();
     require(classDecl, "Type of object instruction must be a class");
     require(!classDecl->getAsGenericContext() ||
-            !classDecl->getAsGenericContext()->isGeneric(),
+                !classDecl->getAsGenericContext()->isGeneric(),
             "Generics are not yet supported in object instructions");
   }
 

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1810,7 +1810,7 @@ public:
   }
 
   void checkObjectInst(ObjectInst *) {
-    require(false, "object instruction is only allowed in a static initializer");
+    require(true, "object instruction is only allowed in a static initializer");
   }
 
   void checkIntegerLiteralInst(IntegerLiteralInst *ILI) {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1809,8 +1809,12 @@ public:
     checkGlobalAccessInst(GVI);
   }
 
-  void checkObjectInst(ObjectInst *) {
-    require(true, "object instruction is only allowed in a static initializer");
+  void checkObjectInst(ObjectInst *objectInst) {
+    auto *classDecl = objectInst->getType().getClassOrBoundGenericClass();
+    require(classDecl, "Type of object instruction must be a class");
+    require(!classDecl->getAsGenericContext() ||
+            !classDecl->getAsGenericContext()->isGeneric(),
+            "Generics are not yet supported in object instructions");
   }
 
   void checkIntegerLiteralInst(IntegerLiteralInst *ILI) {

--- a/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
@@ -1038,6 +1038,9 @@ void DSEContext::processLoadInst(SILInstruction *I, DSEKind Kind) {
 
 void DSEContext::processStoreInst(SILInstruction *I, DSEKind Kind) {
   auto *SI = cast<StoreInst>(I);
+  // TODO: for some reason these stores are removed when they shouldn't be.
+  if (isa<ObjectInst>(SI->getSrc()))
+    return;
   processWrite(I, SI->getSrc(), SI->getDest(), Kind);
 }
 

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -911,7 +911,7 @@ InlineCost swift::instructionInlineCost(SILInstruction &I) {
   case SILInstructionKind::MarkUninitializedInst:
     llvm_unreachable("not valid in canonical sil");
   case SILInstructionKind::ObjectInst:
-    llvm_unreachable("not valid in a function");
+    return InlineCost::Free;
   }
 
   llvm_unreachable("Unhandled ValueKind in switch.");

--- a/test/IRGen/object.sil
+++ b/test/IRGen/object.sil
@@ -1,0 +1,105 @@
+// RUN: %swift -disable-legacy-type-info -module-name run %s -emit-ir -o - | %FileCheck %s
+
+// REQUIRES: CODEGENERATOR=X86
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+class Foo {
+  @_hasStorage @_hasInitialValue var x: Int { get set }
+  @objc deinit
+  init()
+}
+
+class Bar {
+  @_hasStorage @_hasInitialValue var x: Int { get set }
+  @_hasStorage @_hasInitialValue var y: Int { get set }
+  @_hasStorage @_hasInitialValue var z: Int { get set }
+  @objc deinit
+  init()
+}
+
+// CHECK-LABEL: define swiftcc i64 @foouser
+// CHECK: entry
+// CHECK: [[ALLOC:%.*]] = alloca %T3run3FooC
+// CHECK: [[META:%.*]] = call swiftcc %swift.metadata_response @"$s3run3FooCMa"
+// CHECK: [[META_E:%.*]] = extractvalue %swift.metadata_response [[META]]
+// CHECK: [[REF:%.*]] = bitcast %T3run3FooC* [[ALLOC]] to %swift.refcounted*
+// CHECK: [[OBJ_R:%.*]] = call %swift.refcounted* @swift_initStackObject({{.*}}[[META_E]], {{.*}}[[REF]])
+// CHECK: [[OBJ:%.*]] = bitcast %swift.refcounted* [[OBJ_R]] to %T3run3FooC*
+
+// CHECK: [[X_PTR:%.*]] = getelementptr inbounds %T3run3FooC, %T3run3FooC* [[OBJ]], i32 0, i32 1
+// CHECK: [[X:%.*]] = getelementptr inbounds %TSi, %TSi* [[X_PTR]], i32 0, i32 0
+// CHECK: store i64 0, i64* [[X]]
+
+// CHECK: [[X_PTR1:%.*]] = getelementptr inbounds %T3run3FooC, %T3run3FooC* [[OBJ]], i32 0, i32 1
+// CHECK: [[X1:%.*]] = getelementptr inbounds %TSi, %TSi* [[X_PTR1]], i32 0, i32 0
+// CHECK: [[X_VAL:%.*]] = load i64, i64* [[X1]]
+// CHECK: [[ADDED:%.*]] = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 [[X_VAL]], i64 1)
+// CHECK: [[SUM:%.*]] = extractvalue { i64, i1 } [[ADDED]], 0
+
+// CHECK: [[X2:%.*]] = getelementptr inbounds %TSi, %TSi* [[X_PTR1]], i32 0, i32 0
+// CHECK: store i64 [[SUM]], i64* [[X2]]
+// CHECK: [[X3:%.*]] = getelementptr inbounds %TSi, %TSi* [[X_PTR1]], i32 0, i32 0
+// CHECK: [[OUT:%.*]] = load i64, i64* [[X3]]
+// CHECK: ret i64 [[OUT]]
+sil @foouser : $@convention(thin) () -> Int {
+bb0:
+  %1 = integer_literal $Builtin.Int64, 0          // user: %2
+  %2 = struct $Int (%1 : $Builtin.Int64)          // user: %3
+  %3 = object $Foo (%2 : $Int)                    // user: %4
+  %4 = ref_element_addr %3 : $Foo, #Foo.x         // users: %17, %5
+  %5 = begin_access [modify] [dynamic] [no_nested_conflict] %4 : $*Int // users: %7, %15, %16
+  %6 = integer_literal $Builtin.Int64, 1          // user: %10
+  %7 = struct_element_addr %5 : $*Int, #Int._value // user: %8
+  %8 = load %7 : $*Builtin.Int64                  // user: %10
+  %9 = integer_literal $Builtin.Int1, -1          // user: %10
+  %10 = builtin "sadd_with_overflow_Int64"(%8 : $Builtin.Int64, %6 : $Builtin.Int64, %9 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1) // users: %12, %11
+  %11 = tuple_extract %10 : $(Builtin.Int64, Builtin.Int1), 0 // user: %14
+  %12 = tuple_extract %10 : $(Builtin.Int64, Builtin.Int1), 1 // user: %13
+  cond_fail %12 : $Builtin.Int1, "arithmetic overflow" // id: %13
+  %14 = struct $Int (%11 : $Builtin.Int64)        // user: %15
+  store %14 to %5 : $*Int                         // id: %15
+  end_access %5 : $*Int                           // id: %16
+  %17 = begin_access [read] [static] [no_nested_conflict] %4 : $*Int // users: %19, %18
+  %18 = load %17 : $*Int                          // user: %20
+  end_access %17 : $*Int                          // id: %19
+  return %18 : $Int                               // id: %20
+} // end sil function 'foouser'
+
+sil_vtable Foo {
+  
+}
+
+// CHECK-LABEL: define swiftcc i64 @baruser
+// CHECK: [[ALLOC:%.*]] = alloca %T3run3BarC
+// CHECK: [[META:%.*]] = call swiftcc %swift.metadata_response @"$s3run3BarCMa"
+// CHECK: [[META_E:%.*]] = extractvalue %swift.metadata_response [[META]]
+// CHECK: [[REF:%.*]] = bitcast %T3run3BarC* [[ALLOC]] to %swift.refcounted*
+// CHECK: [[OBJ_R:%.*]] = call %swift.refcounted* @swift_initStackObject({{.*}}[[META_E]], {{.*}}[[REF]])
+// CHECK: [[OBJ:%.*]] = bitcast %swift.refcounted* [[OBJ_R]] to %T3run3BarC*
+// CHECK: [[X_PTR:%.*]] = getelementptr inbounds %T3run3BarC, %T3run3BarC* [[OBJ]], i32 0, i32 3
+// CHECK: [[X:%.*]] = getelementptr inbounds %TSi, %TSi* [[X_PTR]], i32 0, i32 0
+// CHECK: store i64 0, i64* [[X]]
+// CHECK: [[Y_PTR:%.*]] = getelementptr inbounds %T3run3BarC, %T3run3BarC* [[OBJ]], i32 0, i32 2
+// CHECK: [[Y:%.*]] = getelementptr inbounds %TSi, %TSi* [[Y_PTR]], i32 0, i32 0
+// CHECK: store i64 0, i64* [[Y]]
+// CHECK: [[Z_PTR:%.*]] = getelementptr inbounds %T3run3BarC, %T3run3BarC* [[OBJ]], i32 0, i32 1
+// CHECK: [[Z:%.*]] = getelementptr inbounds %TSi, %TSi* [[Z_PTR]], i32 0, i32 0
+// CHECK: store i64 0, i64* [[Z]]
+sil @baruser : $@convention(thin) () -> Int {
+bb0:
+  %1 = integer_literal $Builtin.Int64, 0
+  %2 = struct $Int (%1 : $Builtin.Int64)
+  %3 = object $Bar (%2 : $Int, %2 : $Int, %2 : $Int)
+
+  return %2 : $Int
+}
+
+
+sil_vtable Bar {
+  
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
This patch allows the object instruction to be used everywhere. 

### Why the change?
Why is this change beneficial? It may appear that it generates the same code as an alloc_ref on the stack. That is mostly true. 

The problem with alloc_ref is that it behaves very differently from most other sil instructions. It pretends to be a value but it is actually a pointer. It makes it hard for both the sil optimizer and the llvm optimizer to reason about what's going on. This change allows objects (classes) to be created in a way that is much more semantically similar to structs, enums, and tuples which will allow our current sil otpimization passes to optimize class objects with little to no changes. 

For example, mem2reg cannot optimize class objects at all. Adding support would mean re-writing almost the entire pass. However, if objects are created using the object instruction, it can be updated to support objects with only two lines changed in general utility files. That's great.

Additionally, it seems to make it easier for llvm to reason about what's going on as well. In another patch I added support for promoting `alloc_ref`s to `object`s. And, after making no other change to the sil optimizer (i.e. the sil optimizer still didn't know that objects existed) the llvm optimizer was able to reason about what was going on much more easily. 

<details><summary>For example</summary>
<p>

```swift
class Foo {
    var x : Int = 0
}

func a( _ f : Foo) {
    f.x += 1
}

func b( _ f : Foo) -> Int {
    return f.x + 2
}

public func foouser(_ check : Bool) -> Int {
    let f = Foo()
    if check {
        a(f)
    }
    return b(f)
}
```

Before this patch:
```llvm-ir
define swiftcc i64 @"$s3run7foouserySiSbF"(i1 %0) #1 {
entry:
  %1 = alloca %T3run3FooC, align 8
  %access-scratch = alloca [24 x i8], align 8
  %access-scratch2 = alloca [24 x i8], align 8
  %2 = tail call swiftcc %swift.metadata_response @"$s3run3FooCMa"(i64 undef) #10
  %3 = extractvalue %swift.metadata_response %2, 0
  %4 = getelementptr inbounds %T3run3FooC, %T3run3FooC* %1, i64 0, i32 0
  %reference.new = call %swift.refcounted* @swift_initStackObject(%swift.type* %3, %swift.refcounted* nonnull %4) #3
  %5 = getelementptr inbounds %swift.refcounted, %swift.refcounted* %reference.new, i64 1
  %._value = bitcast %swift.refcounted* %5 to i64*
  store i64 0, i64* %._value, align 8
  br i1 %0, label %6, label %entry._crit_edge

entry._crit_edge:                                 ; preds = %entry
  %.pre = bitcast %swift.refcounted* %5 to i8*
  br label %14

6:                                                ; preds = %entry
  %7 = getelementptr inbounds [24 x i8], [24 x i8]* %access-scratch2, i64 0, i64 0
  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
  %8 = bitcast %swift.refcounted* %5 to i8*
  call void @swift_beginAccess(i8* nonnull %8, [24 x i8]* nonnull %access-scratch2, i64 1, i8* null) #3
  %9 = load i64, i64* %._value, align 8
  %10 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %9, i64 1)
  %11 = extractvalue { i64, i1 } %10, 1
  br i1 %11, label %22, label %12, !prof !21, !misexpect !22

12:                                               ; preds = %6
  %13 = extractvalue { i64, i1 } %10, 0
  store i64 %13, i64* %._value, align 8
  br label %14

14:                                               ; preds = %entry._crit_edge, %12
  %.pre-phi = phi i8* [ %.pre, %entry._crit_edge ], [ %8, %12 ]
  %15 = getelementptr inbounds [24 x i8], [24 x i8]* %access-scratch, i64 0, i64 0
  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %15)
  call void @swift_beginAccess(i8* nonnull %.pre-phi, [24 x i8]* nonnull %access-scratch, i64 0, i8* null) #3
  %16 = load i64, i64* %._value, align 8
  %17 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %16, i64 2)
  %18 = extractvalue { i64, i1 } %17, 1
  br i1 %18, label %21, label %19, !prof !21, !misexpect !22

19:                                               ; preds = %14
  %20 = extractvalue { i64, i1 } %17, 0
  ret i64 %20

21:                                               ; preds = %14
  call void asm sideeffect "", "n"(i32 0) #3
  call void @llvm.trap()
  unreachable

22:                                               ; preds = %6
  call void asm sideeffect "", "n"(i32 1) #3
  call void @llvm.trap()
  unreachable
}
```

After this patch:
```
define swiftcc i64 @"$s3run7foouserySiSbF"(i1 %0) {
entry:
  %1 = alloca %T3run3FooC, align 8
  %2 = tail call swiftcc %swift.metadata_response @"$s3run3FooCMa"(i64 undef) #4
  %3 = extractvalue %swift.metadata_response %2, 0
  %4 = getelementptr inbounds %T3run3FooC, %T3run3FooC* %1, i64 0, i32 0
  %reference.new = call %swift.refcounted* @swift_initStackObject(%swift.type* %3, %swift.refcounted* nonnull %4) #3
  %5 = getelementptr inbounds %swift.refcounted, %swift.refcounted* %reference.new, i64 1
  %._value = bitcast %swift.refcounted* %5 to i64*
  %spec.store.select = zext i1 %0 to i64
  store i64 %spec.store.select, i64* %._value, align 8
  %6 = select i1 %0, i64 3, i64 2
  ret i64 %6
}
```

</p>
</details>

### Why stack?
I spent a few days trying to get this to work when `visitObjectInst` just emitted an `Explosion`. In the future, I think this is a thing we can (and should) do but, right now it would mean updating almost every use of a class to handle two paths: an `alloc_ref` object and an `object` object. This is because `alloc_ref` pretends to be a value when it's actually a pointer. The simplest solution was to make `object` essentially a stack version of `alloc_ref` and have it pretend to be a pointer as well. 

### Future plans
I have two more patches that I'll put up for review today. One updates `StackPromotion` to promote stack `alloc_ref`s to `object`s and the other adds some basic support for `object` instructions across the sil optimizer. 

Sorry for all the words here :P **TL;DR:** this patch lays the groundwork for extending struct optimizations to classes as well. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
