### PR TITLE
Radar60966825

### DIFF
--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -487,6 +487,7 @@ public:
         *result = (uint64_t)~0ull;
         return true;
       }
+      return false;
     }
     case DLQ_GetObjCReservedLowBits: {
       auto result = static_cast<uint8_t *>(outBuffer);

--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -478,9 +478,15 @@ public:
     case DLQ_GetPtrAuthMask: {
       // We don't try to sign pointers at all in our view of the object
       // mapping.
-      auto result = static_cast<uintptr_t *>(outBuffer);
-      *result = (uintptr_t)~0ull;
-      return true;
+      if (wordSize == 4) {
+        auto result = static_cast<uint32_t *>(outBuffer);
+        *result = (uint32_t)~0ull;
+        return true;
+      } else if (wordSize == 8) {
+        auto result = static_cast<uint64_t *>(outBuffer);
+        *result = (uint64_t)~0ull;
+        return true;
+      }
     }
     case DLQ_GetObjCReservedLowBits: {
       auto result = static_cast<uint8_t *>(outBuffer);


### PR DESCRIPTION
When using a 64-bit swift-reflection-dump to inspect a 32-bit binary, the DataLayoutQuery code was incorrectly overwriting a 32-bit pointer with a 64-bit computed value for the ptrauth mask.

Resolves rdar://60966825
