### PR TITLE
[ConstraintSystem] Don't include self-recursive dynamic member result…

### DIFF
--- a/test/Constraints/subscript.swift
+++ b/test/Constraints/subscript.swift
@@ -203,3 +203,16 @@ func test_generic_subscript_requirements_mismatch_diagnostics() {
 
   s[number: ["hello"]] // expected-error {{subscript 'subscript(number:)' requires that 'String' conform to 'BinaryInteger'}}
 }
+
+// rdar://61084565 - infinite recursion in dynamic member lookup
+func rdar61084565() {
+  @dynamicMemberLookup
+  struct Foo {
+    subscript(dynamicMember _: KeyPath<Foo, Int>) -> Int {
+      return 42
+    }
+  }
+
+  let a = Foo()
+  a[] // expected-error {{value of type 'Foo' has no subscripts}}
+}


### PR DESCRIPTION
…s as "inaccessible"

Solver has to keep track of excluded dynamic member results while
performing lookup because otherwise, in diagnostic modem it might
include such results as inaccessible.

Resolves: rdar://problem/61084565

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
