### PR TITLE
[arc-opts] Teach IsAddressWrittenToDefUseAnalysis how to track "well behaved" writes but don't use it.

### DIFF
--- a/unittests/Basic/MultiMapCacheTest.cpp
+++ b/unittests/Basic/MultiMapCacheTest.cpp
@@ -17,24 +17,49 @@
 
 using namespace swift;
 
-namespace {
-
-/// A multimap cache that caches the initial 4 powers of each key.
-struct PowerMultiMapCache
-    : public MultiMapCache<PowerMultiMapCache, unsigned, unsigned> {
-  bool constructValuesForKey(unsigned key, std::vector<unsigned> &data) {
-    // Construct the first 3 powers of key.
-    data.push_back(key);
-    data.push_back(key * key);
-    data.push_back(key * key * key);
-    return true;
-  }
-};
-
-} // end anonymous namespace
-
 TEST(MultiMapCache, powersTest) {
-  PowerMultiMapCache cache;
+  std::function<bool(unsigned, std::vector<unsigned> &)> cacheCompute =
+      [&](unsigned key, std::vector<unsigned> &outArray) {
+        outArray.push_back(key);
+        outArray.push_back(key * key);
+        outArray.push_back(key * key * key);
+        return true;
+      };
+  MultiMapCache<unsigned, unsigned> cache(cacheCompute);
+
+  EXPECT_TRUE(cache.empty());
+  EXPECT_EQ(cache.size(), 0u);
+  for (unsigned index : range(1, 256)) {
+    auto array = *cache.get(index);
+    for (unsigned power : array) {
+      EXPECT_EQ(power % index, 0);
+    }
+  }
+  EXPECT_FALSE(cache.empty());
+  EXPECT_EQ(cache.size(), 255);
+  for (unsigned index : range(1, 256)) {
+    auto array = *cache.get(index);
+    for (unsigned power : array) {
+      EXPECT_EQ(power % index, 0);
+    }
+  }
+  EXPECT_FALSE(cache.empty());
+  EXPECT_EQ(cache.size(), 255);
+
+  cache.clear();
+  EXPECT_TRUE(cache.empty());
+  EXPECT_EQ(cache.size(), 0);
+}
+
+TEST(MultiMapCache, smallTest) {
+  std::function<bool(unsigned, SmallVectorImpl<unsigned> &)> cacheCompute =
+      [&](unsigned key, SmallVectorImpl<unsigned> &outArray) {
+        outArray.push_back(key);
+        outArray.push_back(key * key);
+        outArray.push_back(key * key * key);
+        return true;
+      };
+  SmallMultiMapCache<unsigned, unsigned> cache(cacheCompute);
 
   EXPECT_TRUE(cache.empty());
   EXPECT_EQ(cache.size(), 0u);


### PR DESCRIPTION
In a future commit, I am going to build on this to promote load [copy] ->
load_borrow from inout arguments where none of the writes overlap the load
[copy]'s result's lifetime. By committing this separately, I am using the
current pass's logic to validate the change.
