### PR TITLE
[TypeChecker] Remove obsolete check for load expr on typeCheckExpr

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2058,13 +2058,8 @@ TypeChecker::typeCheckExpression(
 
   // Tell the constraint system what the contextual type is.  This informs
   // diagnostics and is a hint for various performance optimizations.
-  // FIXME: Look through LoadExpr. This is an egregious hack due to the
-  // way typeCheckExprIndependently works.
-  Expr *contextualTypeExpr = expr;
-  if (auto loadExpr = dyn_cast_or_null<LoadExpr>(contextualTypeExpr))
-    contextualTypeExpr = loadExpr->getSubExpr();
   cs.setContextualType(
-      contextualTypeExpr,
+      expr,
       target.getExprContextualTypeLoc(),
       target.getExprContextualTypePurpose());
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Run into this while debugging another issue, and since `typeCheckChildIndependently` was gone together with CSDiag and local tests are ok without this, this may not be necessary anymore :)

cc @xedin @DougGregor 
