### PR TITLE
Add new error diagnostic for escaping optional closures

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2856,8 +2856,8 @@ ERROR(autoclosure_function_input_nonunit,none,
 ERROR(escaping_non_function_parameter,none,
       "@escaping attribute may only be used in function parameter position", ())
 
-NOTE(escaping_optional_type_argument, none,
-     "closure is already escaping in optional type argument", ())
+ERROR(escaping_optional_type_argument, none,
+      "closure is already escaping in optional type argument", ())
 
 // @_nonEphemeral attribute
 ERROR(non_ephemeral_non_pointer_type,none,
@@ -4047,8 +4047,6 @@ NOTE(overridden_required_initializer_here,none,
 // Functions
 ERROR(attribute_requires_function_type,none,
       "@%0 attribute only applies to function types", (StringRef))
-ERROR(optional_closures_are_already_escaping,none,
-      "Optional closures are already @escaping", ())
 ERROR(unsupported_convention,none,
       "convention '%0' not supported", (StringRef))
 ERROR(unreferenced_generic_parameter,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4047,6 +4047,8 @@ NOTE(overridden_required_initializer_here,none,
 // Functions
 ERROR(attribute_requires_function_type,none,
       "@%0 attribute only applies to function types", (StringRef))
+ERROR(optional_closures_are_already_escaping,none,
+      "Optional closures are already @escaping", ())
 ERROR(unsupported_convention,none,
       "convention '%0' not supported", (StringRef))
 ERROR(unreferenced_generic_parameter,none,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2416,19 +2416,19 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
 
       if (i == TAK_escaping && ty->getOptionalObjectType()) {
         auto diag = diagnoseInvalid(repr, attrs.getLoc(i),
-                                    diag::optional_closures_are_already_escaping);
-        diag.fixItRemove(getTypeAttrRangeWithAt(Context,
-                                              attrs.getLoc(TAK_escaping)));
+                                    diag::escaping_optional_type_argument);
+        diag.fixItRemove(
+            getTypeAttrRangeWithAt(Context, attrs.getLoc(TAK_escaping)));
       } else {
         auto diag = diagnoseInvalid(repr, attrs.getLoc(i),
                                     diag::attribute_requires_function_type,
                                     TypeAttributes::getAttrName(i));
 
-        // If we see @escaping among the attributes on this type, because it isn't
-        // a function type, we'll remove it.
+        // If we see @escaping among the attributes on this type, because it
+        // isn't a function type, we'll remove it.
         if (i == TAK_escaping) {
-          diag.fixItRemove(getTypeAttrRangeWithAt(Context,
-                                                  attrs.getLoc(TAK_escaping)));
+          diag.fixItRemove(
+              getTypeAttrRangeWithAt(Context, attrs.getLoc(TAK_escaping)));
         }
       }
       attrs.clearAttribute(i);

--- a/test/attr/attr_escaping.swift
+++ b/test/attr/attr_escaping.swift
@@ -72,14 +72,14 @@ struct GenericStruct<T> {}
 
 func misuseEscaping(_ a: @escaping Int) {} // expected-error{{@escaping attribute only applies to function types}} {{26-36=}}
 func misuseEscaping(_ a: (@escaping Int)?) {} // expected-error{{@escaping attribute only applies to function types}} {{27-36=}}
-func misuseEscaping(opt a: @escaping ((Int) -> Int)?) {} // expected-error{{Optional closures are already @escaping}} {{28-38=}}
+func misuseEscaping(opt a: @escaping ((Int) -> Int)?) {} // expected-error{{closure is already escaping in optional type argument}} {{28-38=}}
 
 func misuseEscaping(_ a: (@escaping (Int) -> Int)?) {} // expected-error{{@escaping attribute may only be used in function parameter position}} {{27-36=}}
-  // expected-note@-1{{closure is already escaping in optional type argument}}
+  // expected-error@-1{{closure is already escaping in optional type argument}}
 func misuseEscaping(nest a: (((@escaping (Int) -> Int))?)) {} // expected-error{{@escaping attribute may only be used in function parameter position}} {{32-41=}}
-  // expected-note@-1{{closure is already escaping in optional type argument}}
+  // expected-error@-1{{closure is already escaping in optional type argument}}
 func misuseEscaping(iuo a: (@escaping (Int) -> Int)!) {} // expected-error{{@escaping attribute may only be used in function parameter position}} {{29-38=}}
-  // expected-note@-1{{closure is already escaping in optional type argument}}
+  // expected-error@-1{{closure is already escaping in optional type argument}}
 
 func misuseEscaping(_ a: Optional<@escaping (Int) -> Int>, _ b: Int) {} // expected-error{{@escaping attribute may only be used in function parameter position}} {{35-44=}}
 func misuseEscaping(_ a: (@escaping (Int) -> Int, Int)) {} // expected-error{{@escaping attribute may only be used in function parameter position}} {{27-36=}}

--- a/test/attr/attr_escaping.swift
+++ b/test/attr/attr_escaping.swift
@@ -74,12 +74,9 @@ func misuseEscaping(_ a: @escaping Int) {} // expected-error{{@escaping attribut
 func misuseEscaping(_ a: (@escaping Int)?) {} // expected-error{{@escaping attribute only applies to function types}} {{27-36=}}
 func misuseEscaping(opt a: @escaping ((Int) -> Int)?) {} // expected-error{{closure is already escaping in optional type argument}} {{28-38=}}
 
-func misuseEscaping(_ a: (@escaping (Int) -> Int)?) {} // expected-error{{@escaping attribute may only be used in function parameter position}} {{27-36=}}
-  // expected-error@-1{{closure is already escaping in optional type argument}}
-func misuseEscaping(nest a: (((@escaping (Int) -> Int))?)) {} // expected-error{{@escaping attribute may only be used in function parameter position}} {{32-41=}}
-  // expected-error@-1{{closure is already escaping in optional type argument}}
-func misuseEscaping(iuo a: (@escaping (Int) -> Int)!) {} // expected-error{{@escaping attribute may only be used in function parameter position}} {{29-38=}}
-  // expected-error@-1{{closure is already escaping in optional type argument}}
+func misuseEscaping(_ a: (@escaping (Int) -> Int)?) {} // expected-error{{closure is already escaping in optional type argument}} {{27-36=}}
+func misuseEscaping(nest a: (((@escaping (Int) -> Int))?)) {} // expected-error{{closure is already escaping in optional type argument}} {{32-41=}}
+func misuseEscaping(iuo a: (@escaping (Int) -> Int)!) {} // expected-error{{closure is already escaping in optional type argument}} {{29-38=}}
 
 func misuseEscaping(_ a: Optional<@escaping (Int) -> Int>, _ b: Int) {} // expected-error{{@escaping attribute may only be used in function parameter position}} {{35-44=}}
 func misuseEscaping(_ a: (@escaping (Int) -> Int, Int)) {} // expected-error{{@escaping attribute may only be used in function parameter position}} {{27-36=}}

--- a/test/attr/attr_escaping.swift
+++ b/test/attr/attr_escaping.swift
@@ -72,8 +72,7 @@ struct GenericStruct<T> {}
 
 func misuseEscaping(_ a: @escaping Int) {} // expected-error{{@escaping attribute only applies to function types}} {{26-36=}}
 func misuseEscaping(_ a: (@escaping Int)?) {} // expected-error{{@escaping attribute only applies to function types}} {{27-36=}}
-func misuseEscaping(opt a: @escaping ((Int) -> Int)?) {} // expected-error{{@escaping attribute only applies to function types}} {{28-38=}}
-  // expected-note@-1{{closure is already escaping in optional type argument}}
+func misuseEscaping(opt a: @escaping ((Int) -> Int)?) {} // expected-error{{Optional closures are already @escaping}} {{28-38=}}
 
 func misuseEscaping(_ a: (@escaping (Int) -> Int)?) {} // expected-error{{@escaping attribute may only be used in function parameter position}} {{27-36=}}
   // expected-note@-1{{closure is already escaping in optional type argument}}


### PR DESCRIPTION
This PR will add a new specialized error diagnostic when @escaping attribute is applied to an optional closure 

Resolves [SR-4637](https://bugs.swift.org/browse/SR-4637)