### PR TITLE
IRGen: Disable type layout based value witness generation at Onone

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1292,6 +1292,9 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
                                OPT_disable_type_layouts)) {
     Opts.UseTypeLayoutValueHandling
       = A->getOption().matches(OPT_enable_type_layouts);
+  } else if (Opts.OptMode == OptimizationMode::NoOptimization) {
+    // Disable type layouts at Onone except if explictly requested.
+    Opts.UseTypeLayoutValueHandling = false;
   }
 
   Opts.UseSwiftCall = Args.hasArg(OPT_enable_swiftcall);

--- a/test/IRGen/typelayout_based_value_witness.swift
+++ b/test/IRGen/typelayout_based_value_witness.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -enable-type-layout -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK
 // RUN: %target-swift-frontend -enable-type-layout -primary-file %s -O -emit-ir | %FileCheck %s --check-prefix=OPT --check-prefix=OPT-%target-ptrsize
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s --check-prefix=NOTL
 
 public struct B<T> {
   var x: T
@@ -10,6 +11,10 @@ public struct A<T> {
   var a : B<T>
   var b:  B<T>
 }
+
+// NOTL-LABEL: define{{.*}} %swift.opaque* @"$s30typelayout_based_value_witness1AVwCP"(
+// NOTL:   @"$s30typelayout_based_value_witness1BVMa"(
+// NOTL: }
 
 // CHECK-LABEL: define{{.*}} %swift.opaque* @"$s30typelayout_based_value_witness1AVwCP"(
 // CHECK-NOT:   @"$s30typelayout_based_value_witness1BVMa"(


### PR DESCRIPTION
Type layout based witness generation can emit quite complex IR that will
lead to code bloat if the llvm optimizer is not run.

No need to use type layouts at Onone.

rdar://61155295