### PR TITLE
Sema: Property wrapper storage wrappers ($foo) inherit 'final' bit from original property [5.2]

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -578,7 +578,15 @@ IsFinalRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
           VD->getOriginalWrappedProperty(PropertyWrapperSynthesizedPropertyKind::Backing))
         return true;
 
-      if (auto *nominalDecl = VD->getDeclContext()->getSelfClassDecl()) {
+      // Property wrapper storage wrappers are final if the original property
+      // is final.
+      if (auto *original = VD->getOriginalWrappedProperty(
+            PropertyWrapperSynthesizedPropertyKind::StorageWrapper)) {
+        if (original->isFinal())
+          return true;
+      }
+
+      if (VD->getDeclContext()->getSelfClassDecl()) {
         // If this variable is a class member, mark it final if the
         // class is final, or if it was declared with 'let'.
         auto *PBD = VD->getParentPatternBinding();

--- a/test/SILGen/property_wrappers_final.swift
+++ b/test/SILGen/property_wrappers_final.swift
@@ -1,0 +1,56 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+// Test that the storage wrapper for a final property is itself final, and that
+// its accessors do not appear in the vtable.
+
+public class MyClass {
+  public init() { }
+    
+  @PropertyWrapper()
+  public static var staticProperty: Bool
+
+  @PropertyWrapper()
+  public final var instanceProperty: Bool
+
+}
+
+@propertyWrapper
+public struct PropertyWrapper {
+  public init() {}
+
+  public var projectedValue: PropertyWrapper {
+    get {
+      return self
+    }
+    set {
+      self = newValue
+    }
+  }
+
+  public var wrappedValue: Bool {
+    return false
+  }
+}
+
+// CHECK-LABEL: sil [ossa] @$s23property_wrappers_final17useStorageWrapperyyAA7MyClassCF : $@convention(thin) (@guaranteed MyClass) -> () {
+public func useStorageWrapper(_ c: MyClass) {
+  // CHECK: function_ref @$s23property_wrappers_final7MyClassC15$staticPropertyAA0G7WrapperVvgZ
+  _ = MyClass.$staticProperty
+
+  // CHECK: function_ref @$s23property_wrappers_final7MyClassC15$staticPropertyAA0G7WrapperVvsZ
+  MyClass.$staticProperty = PropertyWrapper()
+
+  // CHECK: $s23property_wrappers_final7MyClassC17$instancePropertyAA0G7WrapperVvg
+  _ = c.$instanceProperty
+
+  // CHECK: $s23property_wrappers_final7MyClassC17$instancePropertyAA0G7WrapperVvs
+  c.$instanceProperty = PropertyWrapper()
+
+  // CHECK: return
+}
+
+// CHECK-LABEL: sil_vtable [serialized] MyClass {
+// CHECK-NEXT:    #MyClass.init!allocator.1: (MyClass.Type) -> () -> MyClass : @$s23property_wrappers_final7MyClassCACycfC
+// CHECK-NEXT:    #MyClass.deinit!deallocator.1: @$s23property_wrappers_final7MyClassCfD
+// CHECK-NEXT:  }

--- a/test/multifile/Inputs/sr12429.swift
+++ b/test/multifile/Inputs/sr12429.swift
@@ -1,0 +1,43 @@
+public class MyClass {
+  public init() { }
+
+  @PropertyWrapper(key: "key", defaultValue: false)
+  public static var wrappedProperty: Bool
+
+  public var otherProperty: String? {
+    didSet {
+      fatalError("Set this other property with value: \(String(describing: otherProperty)), even though we called `myClass.property = `")
+    }
+  }
+
+  public var property: String? {
+    didSet {
+      print("Set expected property: \(String(describing: property))")
+    }
+  }
+}
+
+@propertyWrapper
+public struct PropertyWrapper<Value> {
+  public let key: String
+  public let defaultValue: Value
+
+  public var projectedValue: PropertyWrapper<Value> {
+    get {
+      return self
+    }
+    // Having this setter is what causes the mis-compilation
+    set {
+      self = newValue
+    }
+  }
+
+  public var wrappedValue: Value {
+    return defaultValue
+  }
+
+  public init(key: String, defaultValue: Value) {
+    self.key = key
+    self.defaultValue = defaultValue
+  }
+}

--- a/test/multifile/property-wrappers-sr12429.swift
+++ b/test/multifile/property-wrappers-sr12429.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -o %t/main %t/main.swift %S/Inputs/sr12429.swift
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main
+
+// REQUIRES: executable_test
+
+let object = MyClass()
+object.property = "value"


### PR DESCRIPTION
Otherwise, we would generate inconsistent vtable layouts for classes
with static properties that have attached wrappers. The reason is that
we normally force synthesis of the backing storage and storage wrapper
for each instance property wrapper as part of computing the lowered
stored properties.

However, there was no such forcing for static properties. But since a
static stored property (with an attached wrapper or otherwise) must be
'final', the real fix is to just ensure that the 'final' bit propagates
to the storage wrapper as well.

The backing storage property was already always final, so the issue
did not arise there.

Fixes <rdar://problem/59522703>, <https://bugs.swift.org/browse/SR-12429>.