### PR TITLE
Improve CMake Python Detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.12.4)
 
 # TODO: Fix RPATH usage to be CMP0068 compliant
 # Disable Policy CMP0068 for CMake 3.9
@@ -881,7 +881,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   endif()
 endif()
 
-find_package(PythonInterp REQUIRED)
+find_package(Python2 COMPONENTS Interpreter REQUIRED)
 
 #
 # Find optional dependencies.


### PR DESCRIPTION
#30695 updated the expected/required CMake version to 3.16.5. The CMake module [FindPythonInterp](https://cmake.org/cmake/help/v3.16/module/FindPythonInterp.html) was deprecated in CMake 3.12.

Patch 8f96bfc925d7729a92bbb5a33173900afdd20379 replaces the deprecated CMake module with one of the suggested modules [FindPython2](https://cmake.org/cmake/help/v3.16/module/FindPython2.html). This module looks only for version 2 of Python.

The second patch, 23daa99dff1005b41a657f7cd87b5ce493df1650, is aspirational and if a reviewer decides it is out of scope can easily be removed from this merge request.

My goal is to have CMake find Python 2 or 3 and to prefer Python 2 over 3. The thinking here is that in the currently supported build environments it will find Python 2 and work as it currently does. On newer, not yet supported, build environments that only have Python 3 it will still find a Python.

As is builds will still fail on those platforms, because of Python 2/3 syntax incompatibility, but as those incompatibilities are patched eventually Python 3 will just work. In my opinion, this is a good compromise between backwards compatiblity while looking forward to Python 3. At some point in the future when Python 3 is preferred all of the changes in 23daa99dff1005b41a657f7cd87b5ce493df1650 get reduced to `find_package(Python COMPONENTS Interpreter REQUIRED)` :tada:.

Initially my naive patch using the [FindPython](https://cmake.org/cmake/help/v3.16/module/FindPython.html) module broke compatibility with macOS and previous versions of Ubuntu because they can have 2 and 3 installed side by side.