### PR TITLE
Cross import overlay tooling support fixes

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -338,26 +338,41 @@ public:
   void getDeclaredCrossImportBystanders(
       SmallVectorImpl<Identifier> &bystanderNames);
 
-  /// A lazily populated  mapping from each declared cross import overlay this
-  /// module transitively underlies to its bystander and immediate underlying
-  /// module.
-  llvm::SmallDenseMap<ModuleDecl *, std::pair<Identifier, ModuleDecl *>, 1>
-  declaredCrossImportsTransitive;
+private:
+  /// A cache of this module's underlying module and required bystander if it's
+  /// an underscored cross-import overlay.
+  Optional<std::pair<ModuleDecl *, Identifier>> declaringModuleAndBystander;
 
-  /// Determines if the given \p overlay is a declarared cross-import overlay of
-  /// this module, or an of its transitively declared overlay modules.
-  ///
-  /// This is used by tooling to map overlays to their underlying modules, and t
-  bool isUnderlyingModuleOfCrossImportOverlay(const ModuleDecl *overlay);
+  /// If this module is an underscored cross import overlay, gets the underlying
+  /// module that declared it (which may itself be a cross-import overlay),
+  /// along with the name of the required bystander module. Used by tooling to
+  /// present overlays as if they were part of their underlying module.
+  std::pair<ModuleDecl *, Identifier> getDeclaringModuleAndBystander();
 
-  /// If \p overlay is a transitively declared cross-import overlay of this
-  /// module, gets the list of bystander modules that need to be imported
-  /// alongside this module for the overlay to be loaded.
-  void getAllBystandersForCrossImportOverlay(
-      ModuleDecl *overlay, SmallVectorImpl<Identifier> &bystanders);
+public:
 
-  /// Walks and loads the declared cross-import overlays of this module,
-  /// transitively, to find all overlays this module underlies.
+  /// Returns true if this module is an underscored cross import overlay
+  /// declared by \p other, either directly or transitively (via intermediate
+  /// cross-import overlays - for cross-imports involving more than two
+  /// modules).
+  bool isCrossImportOverlayOf(ModuleDecl *other);
+
+  /// If this module is an underscored cross-import overlay, returns the
+  /// non-underscored underlying module that declares it as an overlay, either
+  /// directly or transitively (via intermediate cross-import overlays - for
+  /// cross-imports involving more than two modules).
+  ModuleDecl *getDeclaringModuleIfCrossImportOverlay();
+
+  /// If this module is an underscored cross-import overlay of \p declaring
+  /// either directly or transitively, populates \p bystanderNames with the set
+  /// of bystander modules that must be present alongside \p declaring for
+  /// the overlay to be imported and returns true. Returns false otherwise.
+  bool getRequiredBystandersIfCrossImportOverlay(
+      ModuleDecl *declaring, SmallVectorImpl<Identifier> &bystanderNames);
+
+
+  /// Walks and loads the declared, underscored cross-import overlays of this
+  /// module, transitively, to find all overlays this module underlies.
   ///
   /// This is used by tooling to present these overlays as part of this module.
   void findDeclaredCrossImportOverlaysTransitive(

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -432,12 +432,10 @@ struct PrintOptions {
   /// The information for converting archetypes to specialized types.
   llvm::Optional<TypeTransformContext> TransformContext;
 
-  /// Before printing the name of a ModuleDecl, this callback will be called and
-  /// the name of the ModuleDecl it returns will be printed instead. This is
-  /// currently used to present cross import overlays as if they were their
-  /// underlying module.
-  std::function<const ModuleDecl*(const ModuleDecl *)> mapModuleToUnderlying =
-    [] (const ModuleDecl *D) { return D; };
+  /// Whether cross-import overlay modules are printed with their own name (e.g.
+  /// _MyFrameworkYourFrameworkAdditions) or that of their underlying module
+  /// (e.g.  MyFramework).
+  bool MapCrossImportOverlaysToDeclaringModule = false;
 
   bool PrintAsMember = false;
   
@@ -525,6 +523,7 @@ struct PrintOptions {
     result.PrintDocumentationComments = true;
     result.SkipUnderscoredKeywords = true;
     result.EnumRawValues = EnumRawValueMode::PrintObjCOnly;
+    result.MapCrossImportOverlaysToDeclaringModule = true;
     return result;
   }
 

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -194,16 +194,6 @@ private:
   /// mechanism which is not SourceFile-dependent.)
   SeparatelyImportedOverlayMap separatelyImportedOverlays;
 
-  using SeparatelyImportedOverlayReverseMap =
-    llvm::SmallDenseMap<ModuleDecl *, ModuleDecl *>;
-
-  /// A lazily populated mapping from a separately imported overlay to its
-  /// underlying shadowed module.
-  ///
-  /// This is used by tooling to substitute the name of the underlying module
-  /// wherever the overlay's name would otherwise be reported.
-  SeparatelyImportedOverlayReverseMap separatelyImportedOverlaysReversed;
-
   /// A pointer to PersistentParserState with a function reference to its
   /// deleter to handle the fact that it's forward declared.
   using ParserStatePtr =
@@ -384,7 +374,6 @@ public:
   /// \returns true if the overlay was added; false if it already existed.
   bool addSeparatelyImportedOverlay(ModuleDecl *overlay,
                                     ModuleDecl *declaring) {
-    separatelyImportedOverlaysReversed.clear();
     return std::get<1>(separatelyImportedOverlays[declaring].insert(overlay));
   }
 
@@ -401,12 +390,6 @@ public:
     auto &value = std::get<1>(*i);
     overlays.append(value.begin(), value.end());
   }
-
-  /// Retrieves a module shadowed by the provided separately imported overlay
-  /// \p shadowed. If such a module is returned, it should be presented to users
-  /// as owning the symbols in \p overlay.
-  ModuleDecl *
-  getModuleShadowedBySeparatelyImportedOverlay(const ModuleDecl *overlay);
 
   void cacheVisibleDecls(SmallVectorImpl<ValueDecl *> &&globals) const;
   const SmallVectorImpl<ValueDecl *> &getCachedVisibleDecls() const;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2153,7 +2153,16 @@ void PrintAST::visitImportDecl(ImportDecl *decl) {
   interleave(decl->getFullAccessPath(),
              [&](const ImportDecl::AccessPathElement &Elem) {
                if (!Mods.empty()) {
-                 Printer.printModuleRef(Mods.front(), Elem.Item);
+                 Identifier Name = Elem.Item;
+                 if (Options.MapCrossImportOverlaysToDeclaringModule) {
+                   if (auto *MD = Mods.front().getAsSwiftModule()) {
+                     ModuleDecl *Declaring = const_cast<ModuleDecl*>(MD)
+                       ->getDeclaringModuleIfCrossImportOverlay();
+                     if (Declaring)
+                       Name = Declaring->getName();
+                   }
+                 }
+                 Printer.printModuleRef(Mods.front(), Name);
                  Mods = Mods.slice(1);
                } else {
                  Printer << Elem.Item.str();
@@ -3591,8 +3600,12 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
   template <typename T>
   void printModuleContext(T *Ty) {
     FileUnit *File = cast<FileUnit>(Ty->getDecl()->getModuleScopeContext());
-    const ModuleDecl *Mod =
-        Options.mapModuleToUnderlying(File->getParentModule());
+    ModuleDecl *Mod = File->getParentModule();
+
+    if (Options.MapCrossImportOverlaysToDeclaringModule) {
+      if (ModuleDecl *Declaring = Mod->getDeclaringModuleIfCrossImportOverlay())
+        Mod = Declaring;
+    }
 
     Identifier Name = Mod->getName();
     if (Options.UseExportedModuleNames)

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1776,78 +1776,118 @@ void ModuleDecl::getDeclaredCrossImportBystanders(
     otherModules.push_back(std::get<0>(pair));
 }
 
-using TransitiveOverlays =
-    llvm::SmallDenseMap<ModuleDecl *, std::pair<Identifier, ModuleDecl *>, 1>;
-
-static void populateTransitiveCrossImports(ModuleDecl *base,
-                                           TransitiveOverlays &result) {
-  if (!result.empty() || !base->mightDeclareCrossImportOverlays())
-    return;
-
-  SmallVector<Identifier, 1> bystanders;
-  SmallVector<Identifier, 1> overlays;
+void ModuleDecl::findDeclaredCrossImportOverlaysTransitive(
+    SmallVectorImpl<ModuleDecl *> &overlayModules) {
   SmallVector<ModuleDecl *, 1> worklist;
-  SourceLoc diagLoc; // ignored
+  SmallPtrSet<ModuleDecl *, 1> seen;
+  SourceLoc unused;
 
-  worklist.push_back(base);
+  worklist.push_back(this);
   while (!worklist.empty()) {
     ModuleDecl *current = worklist.back();
     worklist.pop_back();
-    if (!current->mightDeclareCrossImportOverlays())
-      continue;
-    bystanders.clear();
-    current->getDeclaredCrossImportBystanders(bystanders);
-    for (Identifier bystander: bystanders) {
-      overlays.clear();
-      current->findDeclaredCrossImportOverlays(bystander, overlays, diagLoc);
-      for (Identifier overlay: overlays) {
-        if (!overlay.str().startswith("_"))
-          continue;
-        ModuleDecl *overlayMod =
-            base->getASTContext().getModuleByName(overlay.str());
-        if (!overlayMod)
-          continue;
-        if (result.insert({overlayMod, {bystander, current}}).second)
-          worklist.push_back(overlayMod);
+    for (auto &pair: current->declaredCrossImports) {
+      Identifier &bystander = std::get<0>(pair);
+      for (auto *file: std::get<1>(pair)) {
+        auto overlays = file->getOverlayModuleNames(current, unused, bystander);
+        for (Identifier overlay: overlays) {
+          // We don't present non-underscored overlays as part of the underlying
+          // module, so ignore them.
+          if (!overlay.str().startswith("_"))
+            continue;
+          ModuleDecl *overlayMod =
+              getASTContext().getModuleByName(overlay.str());
+          if (!overlayMod)
+            continue;
+          if (seen.insert(overlayMod).second) {
+            overlayModules.push_back(overlayMod);
+            worklist.push_back(overlayMod);
+          }
+        }
       }
     }
   }
 }
 
-bool ModuleDecl::isUnderlyingModuleOfCrossImportOverlay(
-    const ModuleDecl *overlay) {
-  if (!overlay->getNameStr().startswith("_"))
-    return false;
+std::pair<ModuleDecl *, Identifier>
+ModuleDecl::getDeclaringModuleAndBystander() {
+  if (declaringModuleAndBystander)
+    return *declaringModuleAndBystander;
 
-  populateTransitiveCrossImports(this, declaredCrossImportsTransitive);
-  return declaredCrossImportsTransitive.find(overlay) !=
-      declaredCrossImportsTransitive.end();
-}
+  if (!hasUnderscoredNaming())
+    return *(declaringModuleAndBystander = {nullptr, Identifier()});
 
-void ModuleDecl::getAllBystandersForCrossImportOverlay(
-    ModuleDecl *overlay, SmallVectorImpl<Identifier> &bystanders) {
-  if (!overlay->getNameStr().startswith("_"))
-    return;
+  // Search the transitive set of imported @_exported modules to see if any have
+  // this module as their overlay.
+  SmallPtrSet<ModuleDecl *, 16> seen;
+  SmallVector<ModuleDecl::ImportedModule, 16> imported;
+  SmallVector<ModuleDecl::ImportedModule, 16> furtherImported;
+  ModuleDecl *overlayModule = this;
 
-  populateTransitiveCrossImports(this, declaredCrossImportsTransitive);
+  getImportedModules(imported, ModuleDecl::ImportFilterKind::Public);
+  while (!imported.empty()) {
+    ModuleDecl *importedModule = std::get<1>(imported.back());
+    imported.pop_back();
+    if (!seen.insert(importedModule).second)
+      continue;
 
-  auto end = declaredCrossImportsTransitive.end();
-  for (auto i = declaredCrossImportsTransitive.find(overlay);
-       i != end;
-       i = declaredCrossImportsTransitive.find(i->second.second)) {
-    bystanders.push_back(i->second.first);
+    using CrossImportMap =
+        llvm::SmallDenseMap<Identifier, SmallVector<OverlayFile *, 1>>;
+    CrossImportMap &crossImports = importedModule->declaredCrossImports;
+
+    // If any of MD's cross imports declare this module as its overlay, report
+    // MD as the underlying module.
+    auto ret = std::find_if(crossImports.begin(), crossImports.end(),
+                            [&](CrossImportMap::iterator::value_type &pair) {
+      for (OverlayFile *file: std::get<1>(pair)) {
+        ArrayRef<Identifier> overlays = file->getOverlayModuleNames(
+            importedModule, SourceLoc(), std::get<0>(pair));
+        if (std::find(overlays.begin(), overlays.end(),
+                      overlayModule->getName()) != overlays.end())
+          return true;
+      }
+      return false;
+    });
+    if (ret != crossImports.end())
+      return *(declaringModuleAndBystander = {importedModule, ret->first});
+
+    if (!importedModule->hasUnderscoredNaming())
+      continue;
+
+    furtherImported.clear();
+    importedModule->getImportedModules(furtherImported,
+                                       ModuleDecl::ImportFilterKind::Public);
+    imported.append(furtherImported.begin(), furtherImported.end());
   }
+
+  return *(declaringModuleAndBystander = {nullptr, Identifier()});
 }
 
-void ModuleDecl::findDeclaredCrossImportOverlaysTransitive(
-    SmallVectorImpl<ModuleDecl *> &overlayModules) {
-  populateTransitiveCrossImports(this, declaredCrossImportsTransitive);
-  std::transform(declaredCrossImportsTransitive.begin(),
-                 declaredCrossImportsTransitive.end(),
-                 std::back_inserter(overlayModules),
-                 [](TransitiveOverlays::iterator::value_type &i) {
-    return i.first;
-  });
+bool ModuleDecl::isCrossImportOverlayOf(ModuleDecl *other) {
+  ModuleDecl *current = this;
+  while ((current = current->getDeclaringModuleAndBystander().first)) {
+    if (current == other)
+      return true;
+  }
+  return false;
+}
+
+ModuleDecl *ModuleDecl::getDeclaringModuleIfCrossImportOverlay() {
+  ModuleDecl *current = this, *declaring = nullptr;
+  while ((current = current->getDeclaringModuleAndBystander().first))
+    declaring = current;
+  return declaring;
+}
+
+bool ModuleDecl::getRequiredBystandersIfCrossImportOverlay(
+    ModuleDecl *declaring, SmallVectorImpl<Identifier> &bystanderNames) {
+  auto current = std::make_pair(this, Identifier());
+  while ((current = current.first->getDeclaringModuleAndBystander()).first) {
+    bystanderNames.push_back(current.second);
+    if (current.first == declaring)
+      return true;
+  }
+  return false;
 }
 
 namespace {
@@ -2169,32 +2209,6 @@ bool SourceFile::shouldCrossImport() const {
   return Kind != SourceFileKind::SIL && Kind != SourceFileKind::Interface &&
          getASTContext().LangOpts.EnableCrossImportOverlays;
 }
-
-ModuleDecl*
-SourceFile::getModuleShadowedBySeparatelyImportedOverlay(const ModuleDecl *overlay) {
-  if (separatelyImportedOverlaysReversed.empty() &&
-      !separatelyImportedOverlays.empty()) {
-    for (auto &entry: separatelyImportedOverlays) {
-      ModuleDecl *shadowed = entry.first;
-      for (ModuleDecl *overlay: entry.second) {
-        // If for some reason the same overlay shadows more than one module,
-        // pick the one whose name is alphabetically first.
-        ModuleDecl *old = separatelyImportedOverlaysReversed[overlay];
-        if (!old || shadowed->getNameStr() < old->getNameStr())
-          separatelyImportedOverlaysReversed[overlay] = shadowed;
-      }
-    }
-  }
-
-  ModuleDecl *underlying = const_cast<ModuleDecl *>(overlay);
-  while (underlying->getNameStr().startswith("_")) {
-    auto next = separatelyImportedOverlaysReversed.find(underlying);
-    if (next == separatelyImportedOverlaysReversed.end())
-      return nullptr;
-    underlying = std::get<1>(*next);
-  }
-  return underlying;
-};
 
 void ModuleDecl::clearLookupCache() {
   getASTContext().getImportCache().clear();

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -767,8 +767,7 @@ void CodeCompletionResultBuilder::addChunkWithText(
   addChunkWithTextNoCopy(Kind, copyString(*Sink.Allocator, Text));
 }
 
-void CodeCompletionResultBuilder::setAssociatedDecl(const Decl *D,
-                                                    SourceFile *SF) {
+void CodeCompletionResultBuilder::setAssociatedDecl(const Decl *D) {
   assert(Kind == CodeCompletionResult::ResultKind::Declaration);
   AssociatedDecl = D;
   if (auto *ClangD = D->getClangDecl())
@@ -778,13 +777,12 @@ void CodeCompletionResultBuilder::setAssociatedDecl(const Decl *D,
 
   if (!CurrentModule) {
     ModuleDecl *MD = D->getModuleContext();
-    // If this is an underscored cross-import overlay, map it to its underlying
-    // module instead.
-    if (SF) {
-      auto *Underlying = SF->getModuleShadowedBySeparatelyImportedOverlay(MD);
-      if (Underlying)
-        MD = Underlying;
-    }
+
+    // If this is an underscored cross-import overlay, map it to the underlying
+    // module that declares it instead.
+    if (ModuleDecl *Declaring = MD->getDeclaringModuleIfCrossImportOverlay())
+      MD = Declaring;
+
     CurrentModule = MD;
   }
 
@@ -1558,15 +1556,6 @@ private:
     Builder.addDeclDocCommentWords(llvm::makeArrayRef(Pairs));
   }
 
-  /// Sets the given declaration \p D as the associated declaration of the
-  /// completion result being built in \p Builder.
-  void setAssociatedDecl(const Decl *D, CodeCompletionResultBuilder &Builder) {
-    SourceFile *SF = nullptr;
-    if (CurrDeclContext)
-      SF = CurrDeclContext->getParentSourceFile();
-    Builder.setAssociatedDecl(D, SF);
-  }
-
   bool shouldUseFunctionReference(AbstractFunctionDecl *D) {
     if (PreferFunctionReferencesToCalls)
       return true;
@@ -1742,7 +1731,7 @@ public:
                                           SemanticContextKind::None,
                                           expectedTypeContext);
       auto MD = ModuleDecl::create(Ctx.getIdentifier(Pair.first), Ctx);
-      setAssociatedDecl(MD, Builder);
+      Builder.setAssociatedDecl(MD);
       Builder.addTextChunk(MD->getNameStr());
       Builder.addTypeAnnotation("Module");
       if (Pair.second)
@@ -1778,19 +1767,15 @@ public:
       Optional<CodeCompletionResult::NotRecommendedReason> R = None) {
 
     // Don't add underscored cross-import overlay modules.
-    if (CurrDeclContext && MD->getNameStr().startswith("_")) {
-      if (auto SF = CurrDeclContext->getParentSourceFile()) {
-        if (SF->getModuleShadowedBySeparatelyImportedOverlay(MD))
-          return;
-      }
-    }
+    if (MD->getDeclaringModuleIfCrossImportOverlay())
+      return;
 
     CodeCompletionResultBuilder Builder(
         Sink,
         CodeCompletionResult::ResultKind::Declaration,
         SemanticContextKind::None,
         expectedTypeContext);
-    setAssociatedDecl(MD, Builder);
+    Builder.setAssociatedDecl(MD);
     Builder.addTextChunk(MD->getNameStr());
     Builder.addTypeAnnotation("Module");
     if (R)
@@ -2187,7 +2172,7 @@ public:
     CodeCompletionResultBuilder Builder(
         Sink, CodeCompletionResult::ResultKind::Declaration,
         getSemanticContext(VD, Reason, dynamicLookupInfo), expectedTypeContext);
-    setAssociatedDecl(VD, Builder);
+    Builder.setAssociatedDecl(VD);
     addLeadingDot(Builder);
     addValueBaseName(Builder, Name);
     setClangDeclKeywords(VD, Pairs, Builder);
@@ -2437,7 +2422,7 @@ public:
         Sink, CodeCompletionResult::ResultKind::Declaration,
         SemanticContext ? *SemanticContext : getSemanticContextKind(SD),
         expectedTypeContext);
-    setAssociatedDecl(SD, Builder);
+    Builder.setAssociatedDecl(SD);
     setClangDeclKeywords(SD, Pairs, Builder);
     if (!HaveLParen)
       Builder.addLeftBracket();
@@ -2476,7 +2461,7 @@ public:
           SemanticContext ? *SemanticContext : getSemanticContextKind(AFD),
           expectedTypeContext);
       if (AFD) {
-        setAssociatedDecl(AFD, Builder);
+        Builder.setAssociatedDecl(AFD);
         setClangDeclKeywords(AFD, Pairs, Builder);
       }
 
@@ -2613,7 +2598,7 @@ public:
           getSemanticContext(FD, Reason, dynamicLookupInfo),
           expectedTypeContext);
       setClangDeclKeywords(FD, Pairs, Builder);
-      setAssociatedDecl(FD, Builder);
+      Builder.setAssociatedDecl(FD);
       addLeadingDot(Builder);
       addValueBaseName(Builder, Name);
       if (IsDynamicLookup)
@@ -2726,7 +2711,7 @@ public:
           getSemanticContext(CD, Reason, dynamicLookupInfo),
           expectedTypeContext);
       setClangDeclKeywords(CD, Pairs, Builder);
-      setAssociatedDecl(CD, Builder);
+      Builder.setAssociatedDecl(CD);
       if (needInit) {
         assert(addName.empty());
         addLeadingDot(Builder);
@@ -2817,7 +2802,7 @@ public:
     CodeCompletionResultBuilder Builder(
         Sink, CodeCompletionResult::ResultKind::Declaration,
         getSemanticContext(SD, Reason, dynamicLookupInfo), expectedTypeContext);
-    setAssociatedDecl(SD, Builder);
+    Builder.setAssociatedDecl(SD);
     setClangDeclKeywords(SD, Pairs, Builder);
 
     // '\TyName#^TOKEN^#' requires leading dot.
@@ -2852,7 +2837,7 @@ public:
         Sink, CodeCompletionResult::ResultKind::Declaration,
         getSemanticContext(NTD, Reason, dynamicLookupInfo),
         expectedTypeContext);
-    setAssociatedDecl(NTD, Builder);
+    Builder.setAssociatedDecl(NTD);
     setClangDeclKeywords(NTD, Pairs, Builder);
     addLeadingDot(Builder);
     Builder.addTextChunk(NTD->getName().str());
@@ -2868,7 +2853,7 @@ public:
         Sink, CodeCompletionResult::ResultKind::Declaration,
         getSemanticContext(TAD, Reason, dynamicLookupInfo),
         expectedTypeContext);
-    setAssociatedDecl(TAD, Builder);
+    Builder.setAssociatedDecl(TAD);
     setClangDeclKeywords(TAD, Pairs, Builder);
     addLeadingDot(Builder);
     Builder.addTextChunk(TAD->getName().str());
@@ -2898,7 +2883,7 @@ public:
         Sink, CodeCompletionResult::ResultKind::Declaration,
         getSemanticContext(GP, Reason, dynamicLookupInfo), expectedTypeContext);
     setClangDeclKeywords(GP, Pairs, Builder);
-    setAssociatedDecl(GP, Builder);
+    Builder.setAssociatedDecl(GP);
     addLeadingDot(Builder);
     Builder.addTextChunk(GP->getName().str());
     addTypeAnnotation(Builder, GP->getDeclaredInterfaceType());
@@ -2912,7 +2897,7 @@ public:
         Sink, CodeCompletionResult::ResultKind::Declaration,
         getSemanticContext(AT, Reason, dynamicLookupInfo), expectedTypeContext);
     setClangDeclKeywords(AT, Pairs, Builder);
-    setAssociatedDecl(AT, Builder);
+    Builder.setAssociatedDecl(AT);
     addLeadingDot(Builder);
     Builder.addTextChunk(AT->getName().str());
     if (Type T = getAssociatedTypeType(AT))
@@ -2927,7 +2912,7 @@ public:
       semanticContext, {});
 
     builder.addTextChunk(PGD->getName().str());
-    setAssociatedDecl(PGD, builder);
+    builder.setAssociatedDecl(PGD);
   };
 
   void addEnumElementRef(const EnumElementDecl *EED, DeclVisibilityKind Reason,
@@ -2944,7 +2929,7 @@ public:
         HasTypeContext ? SemanticContextKind::ExpressionSpecific
                        : getSemanticContext(EED, Reason, dynamicLookupInfo),
         expectedTypeContext);
-    setAssociatedDecl(EED, Builder);
+    Builder.setAssociatedDecl(EED);
     setClangDeclKeywords(EED, Pairs, Builder);
     addLeadingDot(Builder);
     addValueBaseName(Builder, EED->getBaseIdentifier());
@@ -3026,7 +3011,7 @@ public:
         getSemanticContext(AFD, Reason, dynamicLookupInfo),
         expectedTypeContext);
     setClangDeclKeywords(AFD, Pairs, Builder);
-    setAssociatedDecl(AFD, Builder);
+    Builder.setAssociatedDecl(AFD);
 
     // Base name
     addLeadingDot(Builder);
@@ -3460,7 +3445,7 @@ public:
     // FIXME: handle variable amounts of space.
     if (HaveLeadingSpace)
       builder.setNumBytesToErase(1);
-    setAssociatedDecl(op, builder);
+    builder.setAssociatedDecl(op);
     builder.addTextChunk(op->getName().str());
     assert(resultType);
     addTypeAnnotation(builder, resultType);
@@ -3506,7 +3491,7 @@ public:
     CodeCompletionResultBuilder builder(
         Sink, CodeCompletionResult::ResultKind::Declaration, semanticContext,
         {});
-    setAssociatedDecl(op, builder);
+    builder.setAssociatedDecl(op);
 
     if (HaveLeadingSpace)
       builder.addAnnotatedWhitespace(" ");
@@ -4174,15 +4159,6 @@ class CompletionOverrideLookup : public swift::VisibleDeclConsumer {
   bool hasOverridabilityModifier = false;
   bool hasStaticOrClass = false;
 
-  /// Sets the given declaration \p D as the associated declaration of the
-  /// completion result being built in \p Builder.
-  void setAssociatedDecl(const Decl *D, CodeCompletionResultBuilder &Builder) {
-    SourceFile *SF = nullptr;
-    if (CurrDeclContext)
-      SF = CurrDeclContext->getParentSourceFile();
-    Builder.setAssociatedDecl(D, SF);
-  }
-
 public:
   CompletionOverrideLookup(CodeCompletionResultSink &Sink, ASTContext &Ctx,
                            const DeclContext *CurrDeclContext,
@@ -4409,7 +4385,7 @@ public:
         SemanticContextKind::Super, {});
     Builder.setExpectedTypeRelation(
         CodeCompletionResult::ExpectedTypeRelation::NotApplicable);
-    setAssociatedDecl(FD, Builder);
+    Builder.setAssociatedDecl(FD);
     addValueOverride(FD, Reason, dynamicLookupInfo, Builder, hasFuncIntroducer);
     Builder.addBraceStmtWithCursor();
   }
@@ -4427,7 +4403,7 @@ public:
     CodeCompletionResultBuilder Builder(
         Sink, CodeCompletionResult::ResultKind::Declaration,
         SemanticContextKind::Super, {});
-    setAssociatedDecl(VD, Builder);
+    Builder.setAssociatedDecl(VD);
     addValueOverride(VD, Reason, dynamicLookupInfo, Builder, hasVarIntroducer);
   }
 
@@ -4438,7 +4414,7 @@ public:
         SemanticContextKind::Super, {});
     Builder.setExpectedTypeRelation(
         CodeCompletionResult::ExpectedTypeRelation::NotApplicable);
-    setAssociatedDecl(SD, Builder);
+    Builder.setAssociatedDecl(SD);
     addValueOverride(SD, Reason, dynamicLookupInfo, Builder, false);
     Builder.addBraceStmtWithCursor();
   }
@@ -4450,7 +4426,7 @@ public:
       SemanticContextKind::Super, {});
     Builder.setExpectedTypeRelation(
         CodeCompletionResult::ExpectedTypeRelation::NotApplicable);
-    setAssociatedDecl(ATD, Builder);
+    Builder.setAssociatedDecl(ATD);
     if (!hasTypealiasIntroducer && !hasAccessModifier)
       addAccessControl(ATD, Builder);
     if (!hasTypealiasIntroducer)
@@ -4468,7 +4444,7 @@ public:
         SemanticContextKind::Super, {});
     Builder.setExpectedTypeRelation(
         CodeCompletionResult::ExpectedTypeRelation::NotApplicable);
-    setAssociatedDecl(CD, Builder);
+    Builder.setAssociatedDecl(CD);
 
     if (!hasAccessModifier)
       addAccessControl(CD, Builder);

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -114,7 +114,7 @@ public:
     NumBytesToErase = N;
   }
 
-  void setAssociatedDecl(const Decl *D, SourceFile *SF);
+  void setAssociatedDecl(const Decl *D);
 
   void setLiteralKind(CodeCompletionLiteralKind kind) { LiteralKind = kind; }
   void setKeywordKind(CodeCompletionKeywordKind kind) { KeywordKind = kind; }

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -372,19 +372,6 @@ getModuleInfoFromOpaqueModule(clang::index::writer::OpaqueModule mod,
   return info;
 }
 
-/// Gets the module name of the given module, or its underlying module if it's a
-/// cross import overlay implicitly imported in \p initialFile.
-static StringRef getUnderlyingModuleName(ModuleDecl *module,
-                                         SourceFile *initialFile) {
-  if (initialFile) {
-    ModuleDecl *underlying =
-      initialFile->getModuleShadowedBySeparatelyImportedOverlay(module);
-    if (underlying)
-      module = underlying;
-  }
-  return module->getNameStr();
-}
-
 static bool
 emitDataForSwiftSerializedModule(ModuleDecl *module,
                                  StringRef indexStorePath,
@@ -454,7 +441,8 @@ static void addModuleDependencies(ArrayRef<ModuleDecl::ImportedModule> imports,
 
             // If this is a cross-import overlay, make sure we use the name of
             // the underlying module instead.
-            moduleName = getUnderlyingModuleName(mod, initialFile);
+            if (auto *declaring = mod->getDeclaringModuleIfCrossImportOverlay())
+              moduleName = declaring->getNameStr();
           }
           clang::index::writer::OpaqueModule opaqMod =
               moduleNameScratch.createString(moduleName);
@@ -480,9 +468,12 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
                                  IndexUnitWriter &parentUnitWriter,
                                  SourceFile *initialFile) {
   StringRef filename = module->getModuleFilename();
+  std::string moduleName = module->getNameStr().str();
+
   // If this is a cross-import overlay, make sure we use the name of the
   // underlying module instead.
-  std::string moduleName = getUnderlyingModuleName(module, initialFile).str();
+  if (ModuleDecl *declaring = module->getDeclaringModuleIfCrossImportOverlay())
+    moduleName = declaring->getNameStr().str();
 
   std::string error;
   auto isUptodateOpt = parentUnitWriter.isUnitUpToDateForOutputFile(/*FilePath=*/filename,

--- a/test/IDE/complete_cross_import.swift
+++ b/test/IDE/complete_cross_import.swift
@@ -7,6 +7,10 @@
 // RUN: %FileCheck --input-file %t/results.tmp --check-prefix=IMPORT %s
 // RUN: %FileCheck --input-file %t/results.tmp --check-prefix=IMPORT-NEGATIVE %s
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -enable-cross-import-overlays -I %S/Inputs/CrossImport -code-completion-token=SCOPED > %t/results.tmp
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=SCOPED %s
+// RUN: %FileCheck --input-file %t/results.tmp --check-prefix=SCOPED-NEGATIVE %s
+
 import A
 import B
 
@@ -38,4 +42,18 @@ import #^IMPORT^#
 
 // IMPORT-NEGATIVE-NOT: _ABAdditions
 // IMPORT-NEGATIVE-NOT: __ABAdditionsDAdditions
+
+
+func bar() {
+	A.#^SCOPED^#
+}
+
+// SCOPED-DAG: Decl[FreeFunction]/OtherModule[A]:  from_ABAdditions()[#Void#]; name=from_ABAdditions()
+// SCOPED-DAG: Decl[FreeFunction]/OtherModule[A]:  fromA()[#Void#]; name=fromA()
+
+// SCOPED-NEGATIVE-NOT: name=_ABAdditions
+// SCOPED-NEGATIVE-NOT: name=__ABAdditionsDAdditions
+// SCOPED-NEGATIVE-NOT: name=fromB
+// SCOPED-NEGATIVE-NOT: [_ABAdditions]
+// SCOPED-NEGATIVE-NOT: [__ABAdditionsDAdditions]
 

--- a/test/SourceKit/DocSupport/doc_swift_module_cross_import.swift.Other.response
+++ b/test/SourceKit/DocSupport/doc_swift_module_cross_import.swift.Other.response
@@ -5,7 +5,12 @@ func fromOther()
 
 // MARK: - C Additions
 
+import A
+import B
 import C
+
+// Available when C is imported with Other
+func filtered()
 
 // Available when C is imported with Other
 func from_OtherCAdditions()
@@ -53,18 +58,53 @@ func from_OtherCAdditions()
     key.length: 1
   },
   {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 78,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 85,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 87,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 94,
+    key.length: 1
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 79,
+    key.offset: 97,
     key.length: 43
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 122,
+    key.offset: 140,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 127,
+    key.offset: 145,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 157,
+    key.length: 43
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 200,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 205,
     key.length: 20
   }
 ]
@@ -79,10 +119,28 @@ func from_OtherCAdditions()
   },
   {
     key.kind: source.lang.swift.decl.function.free,
+    key.name: "filtered()",
+    key.usr: "s:16_OtherCAdditions8filteredyyF",
+    key.offset: 140,
+    key.length: 15,
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>filtered</decl.name>()</decl.function.free>",
+    key.attributes: [
+      {
+        key.kind: source.lang.swift.attribute.availability,
+        key.is_unavailable: 1
+      }
+    ],
+    key.is_unavailable: 1,
+    key.required_bystanders: [
+      "C"
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.function.free,
     key.name: "from_OtherCAdditions()",
     key.usr: "s:16_OtherCAdditions05from_aB0yyF",
     key.doc.full_as_xml: "<Function><Name>from_OtherCAdditions()</Name><USR>s:16_OtherCAdditions05from_aB0yyF</USR><Declaration>func from_OtherCAdditions()</Declaration><CommentParts><Abstract><Para>This has some interesting documentation that shouldn’t be separated from the decl when we print the comment detailing its required bystanders in the generated interface of ‘Other’.</Para></Abstract></CommentParts></Function>",
-    key.offset: 122,
+    key.offset: 200,
     key.length: 27,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>from_OtherCAdditions</decl.name>()</decl.function.free>",
     key.required_bystanders: [

--- a/test/SourceKit/Inputs/CrossImport/_OtherCAdditions.swift
+++ b/test/SourceKit/Inputs/CrossImport/_OtherCAdditions.swift
@@ -1,5 +1,10 @@
 @_exported import Other
+@_exported import A
+import B
 import C
+
+@available(*, unavailable)
+public func filtered() {}
 
 /// This has some interesting documentation that shouldn't be separated from
 /// the decl when we print the comment detailing its required bystanders in the

--- a/test/SourceKit/InterfaceGen/gen_swift_module_cross_import.swift
+++ b/test/SourceKit/InterfaceGen/gen_swift_module_cross_import.swift
@@ -15,8 +15,11 @@
 // CHECK: key.name: "From_ABAdditionsType"
 // CHECK: key.modulename: "A"
 
-// Set up a cross-import module with doc comments
+// Set up a cross-import module with doc comments that also uses cross-imports.
+// This lets us check that that imports of overlays are printed as their
+// underlying modules, and that the synthesized comment above each decl
+// originally from an overlay appears before any doc comments.
 //
-// RUN: %target-swift-frontend -emit-module-path %t.mod/_OtherCAdditions.swiftmodule -emit-module-doc-path %t.mod/_OtherCAdditions.swiftdoc -module-cache-path %t.mod/mcp -I %S/../Inputs/CrossImport %S/../Inputs/CrossImport/_OtherCAdditions.swift -parse-as-library
+// RUN: %target-swift-frontend -emit-module-path %t.mod/_OtherCAdditions.swiftmodule -emit-module-doc-path %t.mod/_OtherCAdditions.swiftdoc -module-cache-path %t.mod/mcp -I %S/../Inputs/CrossImport %S/../Inputs/CrossImport/_OtherCAdditions.swift -parse-as-library -enable-cross-import-overlays
 // RUN: %sourcekitd-test -req=interface-gen -module Other -- -target %target-triple -I %S/../Inputs/CrossImport -I %t.mod/ -module-cache-path %t.mod/mcp > %t.response
 // RUN: diff --strip-trailing-cr -u %s.Other.response %t.response

--- a/test/SourceKit/InterfaceGen/gen_swift_module_cross_import.swift.Other.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module_cross_import.swift.Other.response
@@ -5,7 +5,9 @@ public func fromOther()
 
 // MARK: - C Additions
 
+import B
 import C
+import A
 
 // Available when C is imported with Other
 /// This has some interesting documentation that shouldn't be separated from
@@ -61,38 +63,58 @@ public func from_OtherCAdditions()
     key.length: 1
   },
   {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 85,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 92,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 94,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 101,
+    key.length: 1
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 86,
+    key.offset: 104,
     key.length: 43
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 129,
+    key.offset: 147,
     key.length: 77
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 206,
+    key.offset: 224,
     key.length: 80
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 286,
+    key.offset: 304,
     key.length: 36
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 322,
+    key.offset: 340,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 329,
+    key.offset: 347,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 334,
+    key.offset: 352,
     key.length: 20
   }
 ]
@@ -106,6 +128,16 @@ public func from_OtherCAdditions()
   {
     key.kind: source.lang.swift.ref.module,
     key.offset: 83,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.module,
+    key.offset: 92,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.module,
+    key.offset: 101,
     key.length: 1
   }
 ]
@@ -130,15 +162,15 @@ public func from_OtherCAdditions()
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "from_OtherCAdditions()",
-    key.offset: 329,
+    key.offset: 347,
     key.length: 27,
-    key.nameoffset: 334,
+    key.nameoffset: 352,
     key.namelength: 22,
-    key.docoffset: 129,
+    key.docoffset: 147,
     key.doclength: 193,
     key.attributes: [
       {
-        key.offset: 322,
+        key.offset: 340,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -908,21 +908,10 @@ static bool passCursorInfoForDecl(SourceFile* SF,
   } else if (VD->getModuleContext() != MainModule) {
     ModuleDecl *MD = VD->getModuleContext();
     // If the decl is from a cross-import overlay module, report the overlay's
-    // underlying module as the owning module.
-    if (SF) {
-      // In a source file we map the imported overlays to the underlying
-      // modules they shadow.
-      auto *Underlying = SF->getModuleShadowedBySeparatelyImportedOverlay(MD);
-      if (Underlying)
-        MD = Underlying;
-    } else if (MainModule) {
-      // In a module interface we need to map the declared overlays of the main
-      // module (which are included in its generated interface) back to the main
-      // module itself.
-      if (MainModule->isUnderlyingModuleOfCrossImportOverlay(MD))
-        MD = MainModule;
-    }
-    ModuleName = MD->getName().str().str();
+    // declaring module as the owning module.
+    if (ModuleDecl *Declaring = MD->getDeclaringModuleIfCrossImportOverlay())
+      MD = Declaring;
+    ModuleName = MD->getNameStr().str();
   }
   StringRef ModuleInterfaceName;
   if (auto IFaceGenRef = Lang.getIFaceGenContexts().find(ModuleName, Invok))


### PR DESCRIPTION
Removes the existing SourceFile and ModuleDecl APIs to map an overlay module decl back to its underlying module and adds a simpler getUnderlyingModule() API to ModuleDecl. Updates code completion, cursor info, doc info, interface generation and indexing to use it.

Also fixes:
- interface generation always printing the synthesized comment listing the required bystander modules that need to be imported for the symbol to be available even if the decl it's associated with wasn't actually printed (e.g. due to failed availability checks)
- code completion after a qualifying module name to also include symbols from any of its shadowing overlays.

Resolves rdar://problem/59445352
