### PR TITLE
Removing _ExpressibleByTensorFlowOp since #tfop is gone

### DIFF
--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -954,10 +954,6 @@ public protocol _ExpressibleByFileReferenceLiteral {
   init(fileReferenceLiteralResourceName path: String)
 }
 
-// SWIFT_ENABLE_TENSORFLOW
-// This isn't actually used, but needs to exist for #tfop() processing.
-public protocol _ExpressibleByTensorFlowOp {}
-
 /// A container is destructor safe if whether it may store to memory on
 /// destruction only depends on its type parameters destructors.
 /// For example, whether `Array<Element>` may store to memory on destruction


### PR DESCRIPTION
Removing _ExpressibleByTensorFlowOp since #tfop has been removed with: https://github.com/apple/swift/pull/24720

