### PR TITLE
[benchmark] Add custom-collection String(decoding:as:)

### DIFF
--- a/benchmark/single-source/UTF8Decode.swift
+++ b/benchmark/single-source/UTF8Decode.swift
@@ -19,6 +19,30 @@ public let UTF8Decode = [
       runFunction: run_UTF8Decode,
       tags: [.validation, .api, .String]),
     BenchmarkInfo(
+      name: "UTF8Decode_InitFromCustom_contiguous",
+      runFunction: run_UTF8Decode_InitFromCustom_contiguous,
+      tags: [.validation, .api, .String]),
+    BenchmarkInfo(
+      name: "UTF8Decode_InitFromCustom_contiguous_ascii",
+      runFunction: run_UTF8Decode_InitFromCustom_contiguous_ascii,
+      tags: [.validation, .api, .String]),
+    BenchmarkInfo(
+      name: "UTF8Decode_InitFromCustom_contiguous_ascii_as_ascii",
+      runFunction: run_UTF8Decode_InitFromCustom_contiguous_ascii_as_ascii,
+      tags: [.validation, .api, .String]),
+    BenchmarkInfo(
+      name: "UTF8Decode_InitFromCustom_noncontiguous",
+      runFunction: run_UTF8Decode_InitFromCustom_noncontiguous,
+      tags: [.validation, .api, .String]),
+    BenchmarkInfo(
+      name: "UTF8Decode_InitFromCustom_noncontiguous_ascii",
+      runFunction: run_UTF8Decode_InitFromCustom_noncontiguous_ascii,
+      tags: [.validation, .api, .String]),
+    BenchmarkInfo(
+      name: "UTF8Decode_InitFromCustom_noncontiguous_ascii_as_ascii",
+      runFunction: run_UTF8Decode_InitFromCustom_noncontiguous_ascii_as_ascii,
+      tags: [.validation, .api, .String]),
+    BenchmarkInfo(
       name: "UTF8Decode_InitFromData",
       runFunction: run_UTF8Decode_InitFromData,
       tags: [.validation, .api, .String]),
@@ -163,4 +187,80 @@ public func run_UTF8Decode_InitFromBytes_ascii_as_ascii(_ N: Int) {
   }
 }
 
+struct CustomContiguousCollection: Collection {
+  let storage: [UInt8]
+  typealias Index = Int
+  typealias Element = UInt8
+
+  init(_ bytes: [UInt8]) { self.storage = bytes }
+  subscript(position: Int) -> Element { self.storage[position] }
+  var startIndex: Index { 0 }
+  var endIndex: Index { storage.count }
+  func index(after i: Index) -> Index { i+1 }
+
+  func withContiguousStorageIfAvailable<R>(
+    _ body: (UnsafeBufferPointer<UInt8>) throws -> R
+  ) rethrows -> R? {
+    try storage.withContiguousStorageIfAvailable(body)
+  }
+}
+struct CustomNoncontiguousCollection: Collection {
+  let storage: [UInt8]
+  typealias Index = Int
+  typealias Element = UInt8
+
+  init(_ bytes: [UInt8]) { self.storage = bytes }
+  subscript(position: Int) -> Element { self.storage[position] }
+  var startIndex: Index { 0 }
+  var endIndex: Index { storage.count }
+  func index(after i: Index) -> Index { i+1 }
+}
+let allStringsCustomContiguous = CustomContiguousCollection(allStringsBytes)
+let asciiCustomContiguous = CustomContiguousCollection(Array(ascii.utf8))
+let allStringsCustomNoncontiguous = CustomNoncontiguousCollection(allStringsBytes)
+let asciiCustomNoncontiguous = CustomNoncontiguousCollection(Array(ascii.utf8))
+
+@inline(never)
+public func run_UTF8Decode_InitFromCustom_contiguous(_ N: Int) {
+  let input = allStringsCustomContiguous
+  for _ in 0..<200*N {
+    blackHole(String(decoding: input, as: UTF8.self))
+  }
+}
+@inline(never)
+public func run_UTF8Decode_InitFromCustom_contiguous_ascii(_ N: Int) {
+  let input = asciiCustomContiguous
+  for _ in 0..<1_000*N {
+    blackHole(String(decoding: input, as: UTF8.self))
+  }
+}
+@inline(never)
+public func run_UTF8Decode_InitFromCustom_contiguous_ascii_as_ascii(_ N: Int) {
+  let input = asciiCustomContiguous
+  for _ in 0..<1_000*N {
+    blackHole(String(decoding: input, as: Unicode.ASCII.self))
+  }
+}
+
+@inline(never)
+public func run_UTF8Decode_InitFromCustom_noncontiguous(_ N: Int) {
+  let input = allStringsCustomNoncontiguous
+  for _ in 0..<200*N {
+    blackHole(String(decoding: input, as: UTF8.self))
+  }
+}
+@inline(never)
+public func run_UTF8Decode_InitFromCustom_noncontiguous_ascii(_ N: Int) {
+  let input = asciiCustomNoncontiguous
+  for _ in 0..<1_000*N {
+    blackHole(String(decoding: input, as: UTF8.self))
+  }
+}
+@inline(never)
+public func run_UTF8Decode_InitFromCustom_noncontiguous_ascii_as_ascii(_ N: Int) {
+  let input = asciiCustomNoncontiguous
+  for _ in 0..<1_000*N {
+    blackHole(String(decoding: input, as: Unicode.ASCII.self))
+  }
+}
 


### PR DESCRIPTION
Add a custom collection String(decoding:as:) benchmark for contiguous
and non-contiguous collections (overriding
withContiguousStorageIfAvailable)

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
