### PR TITLE
Sema: Infer error convention from @objc protocol requirements.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4326,6 +4326,13 @@ NOTE(objc_ambiguous_inference_candidate,none,
      "%0 (in protocol %1) provides Objective-C name %2",
      (DeclName, DeclName, ObjCSelector))
 
+ERROR(objc_ambiguous_error_convention,none,
+      "%0 overrides or implements protocol requirements for Objective-C "
+      "declarations with incompatible error argument conventions",
+      (DeclName))
+NOTE(objc_ambiguous_error_convention_candidate,none,
+     "%0 provides an error argument here", (DeclName))
+
 ERROR(nonlocal_bridged_to_objc,none,
       "conformance of %0 to %1 can only be written in module %2",
       (Identifier, Identifier, Identifier))

--- a/include/swift/AST/ForeignErrorConvention.h
+++ b/include/swift/AST/ForeignErrorConvention.h
@@ -182,6 +182,16 @@ public:
            getKind() == NonZeroResult);
     return ResultType;
   }
+  
+  bool operator==(ForeignErrorConvention other) const {
+    return info.TheKind == other.info.TheKind
+      && info.ErrorIsOwned == other.info.ErrorIsOwned
+      && info.ErrorParameterIsReplaced == other.info.ErrorParameterIsReplaced
+      && info.ErrorParameterIndex == other.info.ErrorParameterIndex;
+  }
+  bool operator!=(ForeignErrorConvention other) const {
+    return !(*this == other);
+  }
 };
 
 }

--- a/test/SILGen/Inputs/objc_error_convention_from_protocol.h
+++ b/test/SILGen/Inputs/objc_error_convention_from_protocol.h
@@ -1,0 +1,16 @@
+@import Foundation;
+
+@protocol Caller1
+@required
+- (BOOL)call:(void (^_Nonnull)(void))callback error:(NSError**)error;
+@end;
+
+@protocol CallerA
+@required
+- (BOOL)use:(NSInteger)x thenCall:(void (^_Nonnull)(void))callback error:(NSError**)error;
+@end;
+
+@protocol CallerB
+@required
+- (BOOL)use:(NSInteger)x error:(NSError**)error thenCall:(void (^_Nonnull)(void))callback;
+@end;

--- a/test/SILGen/objc_error_convention_from_protocol.swift
+++ b/test/SILGen/objc_error_convention_from_protocol.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen %s -import-objc-header %S/Inputs/objc_error_convention_from_protocol.h | %FileCheck %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+class Caller1Impl: Caller1 {
+  // declared as - (BOOL)call:(void (^_Nonnull)(void))callback error:(NSError**)error;
+  // CHECK-LABEL: sil {{.*}} @$s{{.*}}11Caller1Impl{{.*}}call{{.*}}To :
+  // CHECK-SAME: $@convention(objc_method) (@convention(block) () -> (), Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, Caller1Impl) -> ObjCBool
+  func call(_ callback: @escaping () -> ()) throws { }
+}
+
+class CallerAImpl: CallerA {
+  // declared as - (BOOL)use:(NSInteger)x thenCall:(void (^_Nonnull)(void))callback error:(NSError**)error;
+  // CHECK-LABEL: sil {{.*}} @$s{{.*}}11CallerAImpl{{.*}}use{{.*}}thenCall{{.*}}To :
+  // CHECK-SAME: $@convention(objc_method) (Int, @convention(block) () -> (), Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, CallerAImpl) -> ObjCBool
+  func use(_ x: Int, thenCall callback: @escaping () -> ()) throws { }
+}
+
+class CallerBImpl: CallerB {
+  // declared as - (BOOL)use:(NSInteger)x error:(NSError**)error thenCall:(void (^_Nonnull)(void))callback;
+  // CHECK-LABEL: sil {{.*}} @$s{{.*}}11CallerBImpl{{.*}}use{{.*}}thenCall{{.*}}To :
+  // CHECK-SAME: $@convention(objc_method) (Int, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @convention(block) () -> (), CallerBImpl) -> ObjCBool
+  func use(_ x: Int, thenCall callback: @escaping () -> ()) throws { }
+}
+

--- a/test/decl/protocol/Inputs/objc_error_convention_conflict.h
+++ b/test/decl/protocol/Inputs/objc_error_convention_conflict.h
@@ -1,0 +1,15 @@
+@import Foundation;
+
+@protocol CallerX
+@required
+- (BOOL)use:(NSInteger)x error:(void (^_Nonnull)(void))callback error:(NSError*_Nullable*_Nullable)error;
+@end;
+@protocol CallerY
+@required
+- (BOOL)use:(NSInteger)x error:(NSError*_Nullable*_Nullable)error error:(void (^_Nonnull)(void))callback;
+@end;
+
+@interface CallerBaseY
+- (BOOL)use:(NSInteger)x error:(NSError*_Nullable*_Nullable)error error:(void (^_Nonnull)(void))callback;
+@end
+

--- a/test/decl/protocol/objc_error_convention_conflict.swift
+++ b/test/decl/protocol/objc_error_convention_conflict.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s -import-objc-header %S/Inputs/objc_error_convention_conflict.h
+// REQUIRES: objc_interop
+
+class CallerXYImpl: CallerX, CallerY {
+  func use(_ x: Int, error callback: @escaping () -> ()) throws { } // expected-error {{incompatible error argument conventions}}
+}
+
+class CallerXDerivedY: CallerBaseY, CallerX {
+  override func use(_ x: Int, error callback: @escaping () -> ()) throws { } // expected-error {{incompatible error argument conventions}}
+}


### PR DESCRIPTION
When a Swift declaration witnesses an ObjC protocol requirement, its error convention needs to
match the requirement. Furthermore, if there are different protocol requirements that the
Swift method can witness, with different error conventions, we need to bail out because we
can't simultaneously match all of them. Fixes rdar://problem/59496036 | SR-12201.