### PR TITLE
[WIP][Sema][SR-12390] Tweak a potential binding for non-rooted key path in arg conv

### DIFF
--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -130,3 +130,28 @@ func test_mismatch_with_contextual_optional_result() {
   let _ = A(B(), keyPath: \.arr)
   // expected-error@-1 {{key path value type '[Int]' cannot be converted to contextual type '[Int]?'}}
 }
+
+struct SR12390 {
+  let value: Int
+}
+
+struct SR12390_1 {
+  let value: String
+}
+
+struct SR12390_2 {
+  let outter: SR12390
+}
+
+func funcSR12390(with keyPath: PartialKeyPath<SR12390>) {}
+func funcSR12390_1(with keyPath: PartialKeyPath<SR12390_1>) {}
+func funcSR12390_2(with keyPath: PartialKeyPath<SR12390_2>) {}
+
+func test_arg_conversion_inference() {
+  
+  funcSR12390(with: \.value) // OK
+  funcSR12390_1(with: \.value) // OK
+  funcSR12390_2(with: \.outter.value) // OK
+
+  let _: PartialKeyPath<SR12390> = \.value // OK
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
When we have an arg conv involving an unresolved root key path arg e.g. `\.value` and a partial key path param `PartialKeyPath<Root>`, potential binding is now finding the binding of key path type `$T4 := PartialKeyPath<Root>` which always fails. 
So this is a tweak on potential binding to try (when possible) find a more specific binding for the key path type typeVar and type-check correctly if possible. 

cc @xedin @DougGregor 

Resolves SR-12390.
