### PR TITLE
[AutoDiff] Simplify conditions enabling differentiable programming.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5019,9 +5019,10 @@ NOTE(function_builder_remove_returns, none,
 //------------------------------------------------------------------------------
 // MARK: differentiable programming diagnostics
 //------------------------------------------------------------------------------
-ERROR(experimental_differentiable_programming_disabled, none,
-      "differentiable programming is an experimental feature that is "
-      "currently disabled", ())
+
+ERROR(differentiable_programming_attr_used_without_required_module, none,
+      "'@%0' attribute used without importing module %1",
+      (StringRef, Identifier))
 
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -498,11 +498,6 @@ def disable_bridging_pch : Flag<["-"], "disable-bridging-pch">,
   HelpText<"Disable automatic generation of bridging PCH files">;
 
 // Experimental feature options
-def enable_experimental_differentiable_programming :
-  Flag<["-"], "enable-experimental-differentiable-programming">,
-  Flags<[FrontendOption]>,
-  HelpText<"Enable experimental differentiable programming features">;
-
 def enable_experimental_additive_arithmetic_derivation :
   Flag<["-"], "enable-experimental-additive-arithmetic-derivation">,
   Flags<[FrontendOption]>,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -449,13 +449,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_enable_experimental_additive_arithmetic_derivation))
     Opts.EnableExperimentalAdditiveArithmeticDerivedConformances = true;
 
-  if (Args.hasArg(OPT_enable_experimental_differentiable_programming)) {
-    Opts.EnableExperimentalDifferentiableProgramming = true;
-    // Differentiable programming implies `AdditiveArithmetic` derived
-    // conformances.
-    Opts.EnableExperimentalAdditiveArithmeticDerivedConformances = true;
-  }
-
   Opts.DebuggerSupport |= Args.hasArg(OPT_debugger_support);
   if (Opts.DebuggerSupport)
     Opts.EnableDollarIdentifiers = true;

--- a/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
@@ -56,9 +56,9 @@ static StringRef getMathOperatorName(MathOperator op) {
 bool DerivedConformance::canDeriveAdditiveArithmetic(NominalTypeDecl *nominal,
                                                      DeclContext *DC) {
   // Experimental `AdditiveArithmetic` derivation must be enabled.
-  auto &ctx = nominal->getASTContext();
-  if (!ctx.LangOpts.EnableExperimentalAdditiveArithmeticDerivedConformances)
-    return false;
+  if (auto *SF = DC->getParentSourceFile())
+    if (!areAdditiveArithmeticDerivedConformancesEnabled(*SF))
+      return false;
   // Nominal type must be a struct. (No stored properties is okay.)
   auto *structDecl = dyn_cast<StructDecl>(nominal);
   if (!structDecl)

--- a/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
@@ -57,7 +57,7 @@ bool DerivedConformance::canDeriveAdditiveArithmetic(NominalTypeDecl *nominal,
                                                      DeclContext *DC) {
   // Experimental `AdditiveArithmetic` derivation must be enabled.
   if (auto *SF = DC->getParentSourceFile())
-    if (!areAdditiveArithmeticDerivedConformancesEnabled(*SF))
+    if (!isAdditiveArithmeticConformanceDerivationEnabled(*SF))
       return false;
   // Nominal type must be a struct. (No stored properties is okay.)
   auto *structDecl = dyn_cast<StructDecl>(nominal);

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -109,9 +109,9 @@ static StructDecl *getTangentVectorStructDecl(DeclContext *DC) {
 bool DerivedConformance::canDeriveDifferentiable(NominalTypeDecl *nominal,
                                                  DeclContext *DC) {
   // Experimental differentiable programming must be enabled.
-  auto &ctx = nominal->getASTContext();
-  if (!ctx.LangOpts.EnableExperimentalDifferentiableProgramming)
-    return false;
+  if (auto *SF = DC->getParentSourceFile())
+    if (!isDifferentiableProgrammingEnabled(*SF))
+      return false;
   // Nominal type must be a struct or class. (No stored properties is okay.)
   if (!isa<StructDecl>(nominal) && !isa<ClassDecl>(nominal))
     return false;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -415,6 +415,35 @@ void swift::performWholeModuleTypeChecking(SourceFile &SF) {
 #endif
 }
 
+bool swift::isDifferentiableProgrammingEnabled(SourceFile &SF) {
+  auto &ctx = SF.getASTContext();
+  // Return true if differentiable programming is explicitly enabled.
+  if (ctx.LangOpts.EnableExperimentalDifferentiableProgramming)
+    return true;
+  // Otherwise, return true iff the `_Differentiation` module is imported in
+  // the given source file.
+  bool importsDifferentiationModule = false;
+  for (auto import : namelookup::getAllImports(&SF)) {
+    if (import.second->getName() == ctx.Id_Differentiation) {
+      importsDifferentiationModule = true;
+      break;
+    }
+  }
+  return importsDifferentiationModule;
+}
+
+bool swift::areAdditiveArithmeticDerivedConformancesEnabled(SourceFile &SF) {
+  auto &ctx = SF.getASTContext();
+  // Return true if `AdditiveArithmetic` derived conformances are explicitly
+  // enabled.
+  if (ctx.LangOpts.EnableExperimentalAdditiveArithmeticDerivedConformances)
+    return true;
+  // Otherwise, return true iff differentiable programming is enabled.
+  // Differentiable programming depends on `AdditiveArithmetic` derived
+  // conformances.
+  return isDifferentiableProgrammingEnabled(SF);
+}
+
 void swift::checkInconsistentImplementationOnlyImports(ModuleDecl *MainModule) {
   bool hasAnyImplementationOnlyImports =
       llvm::any_of(MainModule->getFiles(), [](const FileUnit *F) -> bool {

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -432,7 +432,7 @@ bool swift::isDifferentiableProgrammingEnabled(SourceFile &SF) {
   return importsDifferentiationModule;
 }
 
-bool swift::areAdditiveArithmeticDerivedConformancesEnabled(SourceFile &SF) {
+bool swift::isAdditiveArithmeticConformanceDerivationEnabled(SourceFile &SF) {
   auto &ctx = SF.getASTContext();
   // Return true if `AdditiveArithmetic` derived conformances are explicitly
   // enabled.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1520,6 +1520,12 @@ bool isMemberOperator(FuncDecl *decl, Type type);
 /// Complain if @objc or dynamic is used without importing Foundation.
 void diagnoseAttrsRequiringFoundation(SourceFile &SF);
 
+/// Returns `true` iff differentiable programming is enabled.
+bool isDifferentiableProgrammingEnabled(SourceFile &SF);
+
+/// Returns `true` iff `AdditiveArithmetic` derived conformances are enabled.
+bool areAdditiveArithmeticDerivedConformancesEnabled(SourceFile &SF);
+
 /// Diagnose any Objective-C method overrides that aren't reflected
 /// as overrides in Swift.
 bool diagnoseUnintendedObjCMethodOverrides(SourceFile &sf);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1524,7 +1524,7 @@ void diagnoseAttrsRequiringFoundation(SourceFile &SF);
 bool isDifferentiableProgrammingEnabled(SourceFile &SF);
 
 /// Returns `true` iff `AdditiveArithmetic` derived conformances are enabled.
-bool areAdditiveArithmeticDerivedConformancesEnabled(SourceFile &SF);
+bool isAdditiveArithmeticConformanceDerivationEnabled(SourceFile &SF);
 
 /// Diagnose any Objective-C method overrides that aren't reflected
 /// as overrides in Swift.

--- a/stdlib/public/Differentiation/CMakeLists.txt
+++ b/stdlib/public/Differentiation/CMakeLists.txt
@@ -18,6 +18,5 @@ add_swift_target_library(swift_Differentiation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPE
   SWIFT_COMPILE_FLAGS
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -parse-stdlib
-    -Xfrontend -enable-experimental-differentiable-programming
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   INSTALL_IN_COMPONENT stdlib)

--- a/test/AutoDiff/IRGen/differentiable_function.sil
+++ b/test/AutoDiff/IRGen/differentiable_function.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
 sil_stage raw
 

--- a/test/AutoDiff/IRGen/differentiable_function_type.swift
+++ b/test/AutoDiff/IRGen/differentiable_function_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -emit-ir -g %s
+// RUN: %target-swift-frontend -emit-ir -g %s
 
 // TF-1225: IRGenDebugInfo crash when reconstructing `@differentiable` and
 // `@differentiable(linear)` function types.

--- a/test/AutoDiff/ModuleInterface/differentiation.swift
+++ b/test/AutoDiff/ModuleInterface/differentiation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t.swiftinterface -enable-library-evolution -enable-experimental-differentiable-programming %s
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t.swiftinterface -enable-library-evolution %s
 // RUN: %FileCheck %s < %t.swiftinterface
 
 import _Differentiation

--- a/test/AutoDiff/SIL/Parse/sildeclref.sil
+++ b/test/AutoDiff/SIL/Parse/sildeclref.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-experimental-differentiable-programming %s -module-name=sildeclref_parse | %target-sil-opt -enable-experimental-differentiable-programming -module-name=sildeclref_parse | %FileCheck %s
+// RUN: %target-sil-opt %s -module-name=sildeclref_parse | %target-sil-opt -module-name=sildeclref_parse | %FileCheck %s
 
 // Parse AutoDiff derivative SILDeclRefs via `witness_method` and `class_method` instructions.
 

--- a/test/AutoDiff/SIL/Serialization/differentiable_function.swift
+++ b/test/AutoDiff/SIL/Serialization/differentiable_function.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-sil-opt -enable-experimental-differentiable-programming %s -emit-sib -o %t/tmp.sib -module-name main
-// RUN: %target-sil-opt -enable-experimental-differentiable-programming %t/tmp.sib -o %t/tmp.sil -module-name main
+// RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name main
+// RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.sil -module-name main
 // NOTE(SR-12090): Workaround because import declarations are not preserved in .sib files.
 // RUN: sed -e 's/import Swift$/import Swift; import _Differentiation/' %t/tmp.sil > %t/tmp_fixed.sil
-// RUN: %target-sil-opt -enable-experimental-differentiable-programming %t/tmp_fixed.sil -module-name main -emit-sorted-sil | %FileCheck %s
+// RUN: %target-sil-opt %t/tmp_fixed.sil -module-name main -emit-sorted-sil | %FileCheck %s
 
 // NOTE(SR-12090): `shell` is required only to run `sed` as a SR-12090 workaround.
 // REQUIRES: shell

--- a/test/AutoDiff/SIL/differentiable_function_inst.sil
+++ b/test/AutoDiff/SIL/differentiable_function_inst.sil
@@ -1,19 +1,19 @@
 // Round-trip parsing/printing test.
 
-// RUN: %target-sil-opt -enable-experimental-differentiable-programming %s -emit-sorted-sil | %FileCheck %s --check-prefix=CHECK-SIL
+// RUN: %target-sil-opt %s -emit-sorted-sil | %FileCheck %s --check-prefix=CHECK-SIL
 
 // Round-trip serialization-deserialization test.
 
 // RUN: %empty-directory(%t)
-// RUN: %target-sil-opt -enable-experimental-differentiable-programming %s -emit-sib -o %t/tmp.sib -module-name main
-// RUN: %target-sil-opt -enable-experimental-differentiable-programming %t/tmp.sib -o %t/tmp.sil -module-name main
+// RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name main
+// RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.sil -module-name main
 // NOTE(SR-12090): Workaround because import declarations are not preserved in .sib files.
 // RUN: sed -e 's/import Swift$/import Swift; import _Differentiation/' %t/tmp.sil > %t/tmp_fixed.sil
-// RUN: %target-sil-opt -enable-experimental-differentiable-programming %t/tmp_fixed.sil -module-name main -emit-sorted-sil | %FileCheck %s --check-prefix=CHECK-SIL
+// RUN: %target-sil-opt %t/tmp_fixed.sil -module-name main -emit-sorted-sil | %FileCheck %s --check-prefix=CHECK-SIL
 
 // IRGen test.
 
-// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -emit-ir %s | %FileCheck %s --check-prefix=CHECK-IRGEN
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s --check-prefix=CHECK-IRGEN
 
 // NOTE(SR-12090): `shell` is required only to run `sed` as a SR-12090 workaround.
 // REQUIRES: shell

--- a/test/AutoDiff/SIL/linear_function_inst.sil
+++ b/test/AutoDiff/SIL/linear_function_inst.sil
@@ -1,15 +1,15 @@
 // Round-trip parsing/printing test.
 
-// RUN: %target-sil-opt -enable-experimental-differentiable-programming %s -emit-sorted-sil | %FileCheck %s --check-prefix=CHECK-SIL
+// RUN: %target-sil-opt %s -emit-sorted-sil | %FileCheck %s --check-prefix=CHECK-SIL
 
 // Round-trip serialization-deserialization test.
 
 // RUN: %empty-directory(%t)
-// RUN: %target-sil-opt -enable-experimental-differentiable-programming %s -emit-sib -o %t/tmp.sib -module-name main
-// RUN: %target-sil-opt -enable-experimental-differentiable-programming %t/tmp.sib -o %t/tmp.sil -module-name main
+// RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name main
+// RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.sil -module-name main
 // NOTE(SR-12090): Workaround because import declarations are not preserved in .sib files.
 // RUN: sed -e 's/import Swift$/import Swift; import _Differentiation/' %t/tmp.sil > %t/tmp_fixed.sil
-// RUN: %target-sil-opt -enable-experimental-differentiable-programming %t/tmp_fixed.sil -module-name main -emit-sorted-sil | %FileCheck %s --check-prefix=CHECK-SIL
+// RUN: %target-sil-opt %t/tmp_fixed.sil -module-name main -emit-sorted-sil | %FileCheck %s --check-prefix=CHECK-SIL
 
 
 sil_stage raw

--- a/test/AutoDiff/SILGen/autodiff_builtins.swift
+++ b/test/AutoDiff/SILGen/autodiff_builtins.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-stdlib -emit-silgen -enable-experimental-differentiable-programming %s | %FileCheck %s
+// RUN: %target-swift-frontend -parse-stdlib -emit-silgen %s | %FileCheck %s
 
 import _Differentiation
 import Swift

--- a/test/AutoDiff/SILGen/differentiable_function.swift
+++ b/test/AutoDiff/SILGen/differentiable_function.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -enable-experimental-differentiable-programming %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
 
 // Test SILGen for `@differentiable` function typed values.
 

--- a/test/AutoDiff/SILGen/mangling.swift
+++ b/test/AutoDiff/SILGen/mangling.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -module-name mangling -Xllvm -sil-full-demangle %s -emit-silgen | %FileCheck %s
+// RUN: %target-swift-frontend -module-name mangling -Xllvm -sil-full-demangle %s -emit-silgen | %FileCheck %s
 
 // Note: adapted from test/SILGen/mangling.swift.
 

--- a/test/AutoDiff/SILGen/noderivative_attr.swift
+++ b/test/AutoDiff/SILGen/noderivative_attr.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -emit-silgen -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -verify %s | %FileCheck %s
 // REQUIRES: asserts
 
 import _Differentiation

--- a/test/AutoDiff/SILGen/noderivative_attr_cross_file.swift
+++ b/test/AutoDiff/SILGen/noderivative_attr_cross_file.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -emit-silgen %S/Inputs/noderivative_attr_other_file.swift %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %S/Inputs/noderivative_attr_other_file.swift %s | %FileCheck %s
 
 import _Differentiation
 

--- a/test/AutoDiff/SILGen/reabstraction.swift
+++ b/test/AutoDiff/SILGen/reabstraction.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -enable-experimental-differentiable-programming %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
 
 import _Differentiation
 

--- a/test/AutoDiff/SILGen/sil_differentiability_witness.swift
+++ b/test/AutoDiff/SILGen/sil_differentiability_witness.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -enable-experimental-differentiable-programming %s | %target-sil-opt -enable-experimental-differentiable-programming | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s | %target-sil-opt | %FileCheck %s
 
 // Test SIL differentiability witness SIL generation.
 

--- a/test/AutoDiff/SILGen/vtable.swift
+++ b/test/AutoDiff/SILGen/vtable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
 
 // Test derivative function vtable entries for `@differentiable` class members:
 // - Methods.

--- a/test/AutoDiff/SILGen/witness_table.swift
+++ b/test/AutoDiff/SILGen/witness_table.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
 
 // Test derivative function witness table entries for `@differentiable` protocol requirements.
 

--- a/test/AutoDiff/Sema/DerivedConformances/class_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/class_differentiable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -typecheck -verify -primary-file %s %S/Inputs/class_differentiable_other_module.swift
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %s %S/Inputs/class_differentiable_other_module.swift
 
 import _Differentiation
 

--- a/test/AutoDiff/Sema/DerivedConformances/derived_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/derived_differentiable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -print-ast %s | %FileCheck %s --check-prefix=CHECK-AST
+// RUN: %target-swift-frontend -print-ast %s | %FileCheck %s --check-prefix=CHECK-AST
 
 import _Differentiation
 

--- a/test/AutoDiff/Sema/DerivedConformances/struct_additive_arithmetic.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/struct_additive_arithmetic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -typecheck -verify -primary-file %s %S/Inputs/struct_additive_arithmetic_other_module.swift
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %s %S/Inputs/struct_additive_arithmetic_other_module.swift
 
 import _Differentiation
 

--- a/test/AutoDiff/Sema/DerivedConformances/struct_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/struct_differentiable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -typecheck -verify -primary-file %s %S/Inputs/struct_differentiable_other_module.swift
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %s %S/Inputs/struct_differentiable_other_module.swift
 
 import _Differentiation
 

--- a/test/AutoDiff/Sema/DerivedConformances/struct_differentiable_member_types.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/struct_differentiable_member_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-differentiable-programming
+// RUN: %target-typecheck-verify-swift
 
 import _Differentiation
 

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend-typecheck -enable-experimental-differentiable-programming -verify %s
+// RUN: %target-swift-frontend-typecheck -verify %s
 
 import _Differentiation
 

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend-typecheck -enable-experimental-differentiable-programming -verify %s
+// RUN: %target-swift-frontend-typecheck -verify %s
 
 import _Differentiation
 

--- a/test/AutoDiff/Sema/differentiable_features_disabled.swift
+++ b/test/AutoDiff/Sema/differentiable_features_disabled.swift
@@ -1,22 +1,22 @@
 // RUN: %target-swift-frontend -typecheck -verify %s
 
-// expected-error @+1 {{differentiable programming is an experimental feature that is currently disabled}}
+// expected-error @+1 {{'@differentiable' attribute used without importing module '_Differentiation'}}
 let _: @differentiable (Float) -> Float
 
-// expected-error @+2 {{differentiable programming is an experimental feature that is currently disabled}}
-// expected-error @+1 {{differentiable programming is an experimental feature that is currently disabled}}
+// expected-error @+2 {{'@differentiable' attribute used without importing module '_Differentiation'}}
+// expected-error @+1 {{'@noDerivative' attribute used without importing module '_Differentiation'}}
 let _: @differentiable (Float, @noDerivative Float) -> Float
 
-// expected-error @+1 {{differentiable programming is an experimental feature that is currently disabled}}
+// expected-error @+1 {{'@noDerivative' attribute used without importing module '_Differentiation'}}
 let _: (Float, @noDerivative Float) -> Float
 
-// expected-error @+1 {{differentiable programming is an experimental feature that is currently disabled}}
+// expected-error @+1 {{'@noDerivative' attribute used without importing module '_Differentiation'}}
 let _: @noDerivative Float
 
 func id(_ x: Float) -> Float {
   return x
 }
-// expected-error @+1 {{differentiable programming is an experimental feature that is currently disabled}}
+// expected-error @+1 {{@derivative attribute used without importing module '_Differentiation'}}
 @derivative(of: id)
 func jvpId(x: Float) -> (value: Float, differential: (Float) -> (Float)) {
   return (x, { $0 })

--- a/test/AutoDiff/Sema/differentiable_func_type.swift
+++ b/test/AutoDiff/Sema/differentiable_func_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -typecheck -verify %s
+// RUN: %target-swift-frontend -typecheck -verify %s
 
 import _Differentiation
 

--- a/test/AutoDiff/Sema/missing_differentiable_protocol.swift
+++ b/test/AutoDiff/Sema/missing_differentiable_protocol.swift
@@ -1,11 +1,9 @@
-// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -typecheck -verify %s
+// RUN: %target-swift-frontend -typecheck -verify %s
 
-// Tests that Sema fails gracefully when the `Differentiable` protocol is missing.
+// Tests that Sema fails gracefully when the `_Differentiation` module is not imported.
 
-// expected-error @+2 {{parameter type 'Float' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
-// expected-error @+1 {{result type 'Float' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
+// expected-error @+1 {{'@differentiable' attribute used without importing module '_Differentiation'}}
 let _: @differentiable (Float) -> Float
 
-// expected-error @+2 {{parameter type 'T' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
-// expected-error @+1 {{result type 'T' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
+// expected-error @+1 2 {{'@differentiable' attribute used without importing module '_Differentiation'}}
 func hasDifferentiableFunctionArg<T>(_ f: @differentiable (T) -> T) {}

--- a/test/AutoDiff/Sema/transpose_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/transpose_attr_type_checking.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend-typecheck -enable-experimental-differentiable-programming -verify %s
+// RUN: %target-swift-frontend-typecheck -verify %s
 
 import _Differentiation
 

--- a/test/AutoDiff/Serialization/derivative_attr.swift
+++ b/test/AutoDiff/Serialization/derivative_attr.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -enable-experimental-differentiable-programming %s -emit-module -parse-as-library -o %t
+// RUN: %target-swift-frontend %s -emit-module -parse-as-library -o %t
 // RUN: llvm-bcanalyzer %t/derivative_attr.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
-// RUN: %target-sil-opt -enable-experimental-differentiable-programming -disable-sil-linking -enable-sil-verify-all %t/derivative_attr.swiftmodule -o - | %FileCheck %s
+// RUN: %target-sil-opt -disable-sil-linking -enable-sil-verify-all %t/derivative_attr.swiftmodule -o - | %FileCheck %s
 
 // BCANALYZER-NOT: UnknownCode
 

--- a/test/AutoDiff/Serialization/differentiable_attr.swift
+++ b/test/AutoDiff/Serialization/differentiable_attr.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -enable-experimental-differentiable-programming %s -emit-module -parse-as-library -o %t
+// RUN: %target-swift-frontend %s -emit-module -parse-as-library -o %t
 // RUN: llvm-bcanalyzer %t/differentiable_attr.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
-// RUN: %target-sil-opt -enable-experimental-differentiable-programming -disable-sil-linking -enable-sil-verify-all %t/differentiable_attr.swiftmodule -o - | %FileCheck %s
+// RUN: %target-sil-opt -disable-sil-linking -enable-sil-verify-all %t/differentiable_attr.swiftmodule -o - | %FileCheck %s
 
 // BCANALYZER-NOT: UnknownCode
 

--- a/test/AutoDiff/Serialization/differentiable_function.swift
+++ b/test/AutoDiff/Serialization/differentiable_function.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -emit-module -parse-as-library -enable-experimental-differentiable-programming -o %t
+// RUN: %target-swift-frontend %s -emit-module -parse-as-library -o %t
 // RUN: llvm-bcanalyzer %t/differentiable_function.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
-// RUN: %target-sil-opt -disable-sil-linking -enable-sil-verify-all %t/differentiable_function.swiftmodule -enable-experimental-differentiable-programming -o - | %FileCheck %s
+// RUN: %target-sil-opt -disable-sil-linking -enable-sil-verify-all %t/differentiable_function.swiftmodule -o - | %FileCheck %s
 
 // BCANALYZER-NOT: UnknownCode
 

--- a/test/AutoDiff/Serialization/transpose_attr.swift
+++ b/test/AutoDiff/Serialization/transpose_attr.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -enable-experimental-differentiable-programming %s -emit-module -parse-as-library -o %t
+// RUN: %target-swift-frontend %s -emit-module -parse-as-library -o %t
 // RUN: llvm-bcanalyzer %t/transpose_attr.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
-// RUN: %target-sil-opt -enable-experimental-differentiable-programming -disable-sil-linking -enable-sil-verify-all %t/transpose_attr.swiftmodule -o - | %FileCheck %s
+// RUN: %target-sil-opt -disable-sil-linking -enable-sil-verify-all %t/transpose_attr.swiftmodule -o - | %FileCheck %s
 
 // BCANALYZER-NOT: UnknownCode
 

--- a/test/AutoDiff/compiler_crashers_fixed/tf1167-differentiable-attr-override-match.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/tf1167-differentiable-attr-override-match.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -typecheck -verify %s
+// RUN: %target-swift-frontend -typecheck -verify %s
 // REQUIRES: asserts
 
 // TF-1167: `OverrideMatcher::match` crash due to meaningless assertion:

--- a/test/AutoDiff/stdlib/differential_operators.swift
+++ b/test/AutoDiff/stdlib/differential_operators.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %gyb %s -o %t/differential_operators.swift
-// RUN: %target-build-swift -enable-experimental-differentiable-programming %t/differential_operators.swift -o %t/differential_operators
+// RUN: %target-build-swift %t/differential_operators.swift -o %t/differential_operators
 // RUN: %target-run %t/differential_operators
 // REQUIRES: executable_test
 


### PR DESCRIPTION
Previously, two conditions were necessary to enable differentiable programming:
- Specifying the `-enable-experimental-differentiable-programming` frontend flag.
- Importing the `_Differentiation` module.

Importing the `_Differentiation` module is the true condition because it
contains the required compiler-known `Differentiable` protocol. The frontend
flag is redundant and cumbersome.

Now, the frontend flag is removed. Importing `_Differentiation` is the only condition.