### PR TITLE
SILOptimizer: fix a crash in the keypath optimization

### DIFF
--- a/lib/SILOptimizer/Utils/KeyPathProjector.cpp
+++ b/lib/SILOptimizer/Utils/KeyPathProjector.cpp
@@ -225,7 +225,8 @@ public:
       auto &function = builder.getFunction();
       auto substType = component.getComponentType().subst(keyPath->getSubstitutions(),
                                                            None);
-      SILType type = function.getLoweredType(substType);
+      SILType type = function.getLoweredType(
+                         Lowering::AbstractionPattern::getOpaque(), substType);
       auto addr = builder.createAllocStack(loc, type);
       
       assertHasNoContext();
@@ -302,7 +303,8 @@ public:
           auto &function = builder.getFunction();
           auto substType = component.getComponentType().subst(keyPath->getSubstitutions(),
                                                                None);
-          SILType type = function.getLoweredType(substType);
+          SILType type = function.getLoweredType(
+                        Lowering::AbstractionPattern::getOpaque(), substType);
           auto addr = builder.createAllocStack(loc, type);
 
           assertHasNoContext();
@@ -351,7 +353,8 @@ public:
       auto &function = builder.getFunction();
       auto substType = component.getComponentType().subst(keyPath->getSubstitutions(),
                                                            None);
-      SILType optType = function.getLoweredType(substType);
+      SILType optType = function.getLoweredType(
+                         Lowering::AbstractionPattern::getOpaque(), substType);
       SILType objType = optType.getOptionalObjectType().getAddressType();
       
       assert(objType && "optional wrap must return an optional");
@@ -557,7 +560,8 @@ public:
       auto resultCanType = components.back().getComponentType();
       auto &function = builder.getFunction();
       auto substType = resultCanType.subst(keyPath->getSubstitutions(), None);
-      auto optType = function.getLoweredType(substType);
+      auto optType = function.getLoweredType(
+                         Lowering::AbstractionPattern::getOpaque(), substType);
       
       assert(optType.getOptionalObjectType() &&
              "Optional-chained key path should result in an optional");

--- a/test/SILOptimizer/keypath_opt_crash.swift
+++ b/test/SILOptimizer/keypath_opt_crash.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+// Check if the optimizer does not crash.
+
+import Foundation
+
+@dynamicMemberLookup
+public struct S {
+  private let x: NSXPCConnection
+
+  subscript<T>(dynamicMember property: ReferenceWritableKeyPath<NSXPCConnection, T>) -> T {
+    get {
+      x[keyPath: property]
+    }
+    nonmutating set {
+      x[keyPath: property] = newValue
+    }
+  }
+
+}
+
+// CHECK: sil {{.*}}test_set
+public func test_set(s: S) {
+  s.invalidationHandler = {}
+}
+
+// CHECK: sil {{.*}}test_get
+public func test_get(s: S) -> (() -> ())? {
+  return s.invalidationHandler
+}
+
+


### PR DESCRIPTION
Use the correct type lowering.

rdar://problem/61122088

