### PR TITLE
[AutoDiff] Add `@_exported import _Differentiation` test.

### DIFF
--- a/test/AutoDiff/Sema/ExportedDifferentiationModule/Inputs/exports_differentiation.swift
+++ b/test/AutoDiff/Sema/ExportedDifferentiationModule/Inputs/exports_differentiation.swift
@@ -1,0 +1,1 @@
+@_exported import _Differentiation

--- a/test/AutoDiff/Sema/ExportedDifferentiationModule/main.swift
+++ b/test/AutoDiff/Sema/ExportedDifferentiationModule/main.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %S/Inputs/exports_differentiation.swift -o %t/exports_differentiation.swiftmodule
+// RUN: %target-build-swift %s -I %t
+
+// Test whether importing a module with `@_exported import _Differentiation`
+// enables differentiable programming. This behavior is desirable.
+
+import exports_differentiation
+
+@differentiable
+func id<T: Differentiable>(_ x: T) -> T { x }


### PR DESCRIPTION
Verify that importing a module with `@_exported import _Differentiation`
enables differentiable programming. This behavior is desirable.