### PR TITLE
EscapeAnalysis: fix a problem with unchecked_addr_cast

### DIFF
--- a/test/SILOptimizer/Inputs/dse_with_union.h
+++ b/test/SILOptimizer/Inputs/dse_with_union.h
@@ -1,0 +1,8 @@
+struct S {
+   int i;
+};
+
+union U {
+  struct S *p;
+};
+

--- a/test/SILOptimizer/dse_with_union.swift
+++ b/test/SILOptimizer/dse_with_union.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift -O %s -import-objc-header %S/Inputs/dse_with_union.h -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// Check that EscapeAnalysis does not mess up with a union.
+
+@inline(never)
+func printit(_ u: inout U) {
+  print(u.p![0])
+}
+
+@inline(never)
+func testit(s: S) {
+  var vs = s
+  withUnsafeMutablePointer(to: &vs) {
+    // A C union is an opaque type in swift and not considered as a "pointer"
+    // in escape analysis. Converting between pointer and non-pointer resulted
+    // in a wrong connection graph.
+    var u = U(p: $0)
+    printit(&u)
+  }
+}
+
+// CHECK: S(i: 27)
+testit(s: S(i: 27))
+

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -1127,6 +1127,23 @@ bb0(%0 : $*U, %1 : $*T, %2 : $@thick U.Type):
   return %5 : $()
 }
 
+// CHECK-LABEL: CG of test_unchecked_addr_cast
+// CHECK-NEXT:    Arg [ref] %0 Esc: G, Succ: 
+// CHECK-NEXT:    Val %1 Esc: , Succ: (%1.1)
+// CHECK-NEXT:    Con [ref] %1.1 Esc: G, Succ: 
+// CHECK-NEXT:    Val %2 Esc: , Succ: (%2.1)
+// CHECK-NEXT:    Con [ref] %2.1 Esc: G, Succ: %0
+// CHECK-NEXT:  End
+sil @test_unchecked_addr_cast : $@convention(thin) (@guaranteed AnyObject) -> Int {
+bb0(%0 : $AnyObject):
+  %1 = alloc_stack $Int
+  %2 = unchecked_addr_cast %1 : $*Int to $*AnyObject
+  store %0 to %2 : $*AnyObject
+  %4 = load %1 : $*Int
+  dealloc_stack %1 : $*Int
+  return %4 : $Int
+}
+
 sil_global @global_y : $SomeData
 
 // CHECK-LABEL: CG of test_node_merge_during_struct_inst


### PR DESCRIPTION
In case an unchecked_addr_cast is used to convert between pointer and non-pointer, we missed some escaping values.
This can be the case when using C unions.

https://bugs.swift.org/browse/SR-12427
rdar://problem/60983997
