### PR TITLE
[Darwin] Further restrict inference of the simulator environment

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -84,9 +84,6 @@ ERROR(error_unexpected_input_file,none,
 
 ERROR(error_unknown_target,none,
       "unknown target '%0'", (StringRef))
-WARNING(warning_inferred_simulator_target,none,
-      "inferring simulator environment for target '%0'; "
-      "use '-target %1' instead", (StringRef, StringRef))
 
 ERROR(error_framework_bridging_header,none,
       "using bridging headers with framework targets is unsupported", ())

--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -84,6 +84,9 @@ ERROR(error_unexpected_input_file,none,
 
 ERROR(error_unknown_target,none,
       "unknown target '%0'", (StringRef))
+WARNING(warning_inferred_simulator_target,none,
+      "inferring simulator environment for target '%0'; "
+      "use '-target %1' instead", (StringRef, StringRef))
 
 ERROR(error_framework_bridging_header,none,
       "using bridging headers with framework targets is unsupported", ())

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -61,6 +61,10 @@ ERROR(error_unsupported_target_arch, none,
 ERROR(error_unsupported_opt_for_target, none,
       "unsupported option '%0' for target '%1'", (StringRef, StringRef))
 
+WARNING(warning_inferred_simulator_target,none,
+      "inferring simulator environment for target '%0'; "
+      "use '-target %1' instead", (StringRef, StringRef))
+
 ERROR(error_argument_not_allowed_with, none,
       "argument '%0' is not allowed with '%1'", (StringRef, StringRef))
 

--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -46,6 +46,9 @@ namespace swift {
   /// Returns true if the given triple represents a macCatalyst environment.
   bool tripleIsMacCatalystEnvironment(const llvm::Triple &triple);
 
+  /// Determine whether the triple infers the "simulator" environment.
+  bool tripleInfersSimulatorEnvironment(const llvm::Triple &triple);
+
   /// Returns true if the given -target triple and -target-variant triple
   /// can be zippered.
   bool triplesAreValidForZippering(const llvm::Triple &target,

--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -43,9 +43,6 @@ namespace swift {
   /// Returns true if the given triple represents watchOS running in a simulator.
   bool tripleIsWatchSimulator(const llvm::Triple &triple);
 
-  /// Return true if the given triple represents any simulator.
-  bool tripleIsAnySimulator(const llvm::Triple &triple);
-
   /// Returns true if the given triple represents a macCatalyst environment.
   bool tripleIsMacCatalystEnvironment(const llvm::Triple &triple);
 

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -361,7 +361,7 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   // Set the "targetEnvironment" platform condition if targeting a simulator
   // environment. Otherwise _no_ value is present for targetEnvironment; it's
   // an optional disambiguating refinement of the triple.
-  if (swift::tripleIsAnySimulator(Target))
+  if (Target.isSimulatorEnvironment())
     addPlatformConditionValue(PlatformConditionKind::TargetEnvironment,
                               "simulator");
 

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -32,10 +32,6 @@ bool swift::tripleIsWatchSimulator(const llvm::Triple &triple) {
   return (triple.isWatchOS() && triple.isSimulatorEnvironment());
 }
 
-bool swift::tripleIsAnySimulator(const llvm::Triple &triple) {
-  return triple.isSimulatorEnvironment();
-}
-
 bool swift::tripleIsMacCatalystEnvironment(const llvm::Triple &triple) {
   return triple.isiOS() && !triple.isTvOS() &&
       triple.getEnvironment() == llvm::Triple::MacABI;

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -19,40 +19,21 @@
 using namespace swift;
 
 bool swift::tripleIsiOSSimulator(const llvm::Triple &triple) {
-  llvm::Triple::ArchType arch = triple.getArch();
   return (triple.isiOS() &&
           !tripleIsMacCatalystEnvironment(triple) &&
-          // FIXME: transitional, this should eventually stop testing arch, and
-          // switch to only checking the -environment field.
-          (triple.isSimulatorEnvironment() ||
-           arch == llvm::Triple::x86 || arch == llvm::Triple::x86_64));
+          triple.isSimulatorEnvironment());
 }
 
 bool swift::tripleIsAppleTVSimulator(const llvm::Triple &triple) {
-  llvm::Triple::ArchType arch = triple.getArch();
-  return (triple.isTvOS() &&
-          // FIXME: transitional, this should eventually stop testing arch, and
-          // switch to only checking the -environment field.
-          (triple.isSimulatorEnvironment() ||
-           arch == llvm::Triple::x86 || arch == llvm::Triple::x86_64));
+  return (triple.isTvOS() && triple.isSimulatorEnvironment());
 }
 
 bool swift::tripleIsWatchSimulator(const llvm::Triple &triple) {
-  llvm::Triple::ArchType arch = triple.getArch();
-  return (triple.isWatchOS() &&
-          // FIXME: transitional, this should eventually stop testing arch, and
-          // switch to only checking the -environment field.
-          (triple.isSimulatorEnvironment() ||
-           arch == llvm::Triple::x86 || arch == llvm::Triple::x86_64));
+  return (triple.isWatchOS() && triple.isSimulatorEnvironment());
 }
 
 bool swift::tripleIsAnySimulator(const llvm::Triple &triple) {
-  // FIXME: transitional, this should eventually just use the -environment
-  // field.
-  return triple.isSimulatorEnvironment() ||
-    tripleIsiOSSimulator(triple) ||
-    tripleIsWatchSimulator(triple) ||
-    tripleIsAppleTVSimulator(triple);
+  return triple.isSimulatorEnvironment();
 }
 
 bool swift::tripleIsMacCatalystEnvironment(const llvm::Triple &triple) {
@@ -327,14 +308,6 @@ getOSForAppleTargetSpecificModuleTriple(const llvm::Triple &triple) {
 static Optional<StringRef>
 getEnvironmentForAppleTargetSpecificModuleTriple(const llvm::Triple &triple) {
   auto tripleEnvironment = triple.getEnvironmentName();
-
-  // If the environment is empty, infer a "simulator" environment based on the
-  // OS and architecture combination. This feature is deprecated and exists for
-  // backwards compatibility only; build systems should pass the "simulator"
-  // environment explicitly if they know they're building for a simulator.
-  if (tripleEnvironment == "" && swift::tripleIsAnySimulator(triple))
-    return StringRef("simulator");
-
   return llvm::StringSwitch<Optional<StringRef>>(tripleEnvironment)
               .Cases("unknown", "", None)
   // These values are also supported, but are handled by the default case below:

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -37,6 +37,21 @@ bool swift::tripleIsMacCatalystEnvironment(const llvm::Triple &triple) {
       triple.getEnvironment() == llvm::Triple::MacABI;
 }
 
+bool swift::tripleInfersSimulatorEnvironment(const llvm::Triple &triple) {
+  switch (triple.getOS()) {
+  case llvm::Triple::IOS:
+  case llvm::Triple::TvOS:
+  case llvm::Triple::WatchOS:
+    return !triple.isSimulatorEnvironment() &&
+        (triple.getArch() == llvm::Triple::x86 ||
+         triple.getArch() == llvm::Triple::x86_64) &&
+        !tripleIsMacCatalystEnvironment(triple);
+
+  default:
+    return false;
+  }
+}
+
 bool swift::triplesAreValidForZippering(const llvm::Triple &target,
                                         const llvm::Triple &targetVariant) {
   // The arch and vendor must match.

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -42,7 +42,7 @@ bool swift::tripleInfersSimulatorEnvironment(const llvm::Triple &triple) {
   case llvm::Triple::IOS:
   case llvm::Triple::TvOS:
   case llvm::Triple::WatchOS:
-    return !triple.isSimulatorEnvironment() &&
+    return !triple.hasEnvironment() &&
         (triple.getArch() == llvm::Triple::x86 ||
          triple.getArch() == llvm::Triple::x86_64) &&
         !tripleIsMacCatalystEnvironment(triple);

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -465,7 +465,7 @@ toolchains::Darwin::addProfileGenerationArgs(ArgStringList &Arguments,
     }
 
     StringRef Sim;
-    if (tripleIsAnySimulator(Triple)) {
+    if (Triple.isSimulatorEnvironment()) {
       Sim = "sim";
     }
 

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -264,17 +264,35 @@ static void validateArgs(DiagnosticEngine &diags, const ArgList &args,
 std::unique_ptr<ToolChain>
 Driver::buildToolChain(const llvm::opt::InputArgList &ArgList) {
 
-  if (const Arg *A = ArgList.getLastArg(options::OPT_target))
+  if (const Arg *A = ArgList.getLastArg(options::OPT_target)) {
     DefaultTargetTriple = llvm::Triple::normalize(A->getValue());
+  }
 
-  const llvm::Triple target(DefaultTargetTriple);
+  llvm::Triple target(DefaultTargetTriple);
 
   switch (target.getOS()) {
-  case llvm::Triple::Darwin:
-  case llvm::Triple::MacOSX:
   case llvm::Triple::IOS:
   case llvm::Triple::TvOS:
-  case llvm::Triple::WatchOS: {
+  case llvm::Triple::WatchOS:
+    // Backward compatibility hack: infer "simulator" environment for x86
+    // iOS/tvOS/watchOS.
+    if (!target.isSimulatorEnvironment() &&
+        (target.getArch() == llvm::Triple::x86 ||
+         target.getArch() == llvm::Triple::x86_64) &&
+        !tripleIsMacCatalystEnvironment(target)) {
+      // Set the simulator environment.
+      target.setEnvironment(llvm::Triple::EnvironmentType::Simulator);
+
+      auto newTargetTriple = target.normalize();
+      Diags.diagnose(SourceLoc(), diag::warning_inferred_simulator_target,
+                     DefaultTargetTriple, newTargetTriple);
+
+      DefaultTargetTriple = newTargetTriple;
+    }
+    LLVM_FALLTHROUGH;
+
+  case llvm::Triple::Darwin:
+  case llvm::Triple::MacOSX: {
     Optional<llvm::Triple> targetVariant;
     if (const Arg *A = ArgList.getLastArg(options::OPT_target_variant))
       targetVariant = llvm::Triple(llvm::Triple::normalize(A->getValue()));

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -270,27 +270,23 @@ Driver::buildToolChain(const llvm::opt::InputArgList &ArgList) {
 
   llvm::Triple target(DefaultTargetTriple);
 
+  // Backward compatibility hack: infer "simulator" environment for x86
+  // iOS/tvOS/watchOS.
+  if (tripleInfersSimulatorEnvironment(target)) {
+    // Set the simulator environment.
+    target.setEnvironment(llvm::Triple::EnvironmentType::Simulator);
+
+    auto newTargetTriple = target.normalize();
+    Diags.diagnose(SourceLoc(), diag::warning_inferred_simulator_target,
+                   DefaultTargetTriple, newTargetTriple);
+
+    DefaultTargetTriple = newTargetTriple;
+  }
+
   switch (target.getOS()) {
   case llvm::Triple::IOS:
   case llvm::Triple::TvOS:
   case llvm::Triple::WatchOS:
-    // Backward compatibility hack: infer "simulator" environment for x86
-    // iOS/tvOS/watchOS.
-    if (!target.isSimulatorEnvironment() &&
-        (target.getArch() == llvm::Triple::x86 ||
-         target.getArch() == llvm::Triple::x86_64) &&
-        !tripleIsMacCatalystEnvironment(target)) {
-      // Set the simulator environment.
-      target.setEnvironment(llvm::Triple::EnvironmentType::Simulator);
-
-      auto newTargetTriple = target.normalize();
-      Diags.diagnose(SourceLoc(), diag::warning_inferred_simulator_target,
-                     DefaultTargetTriple, newTargetTriple);
-
-      DefaultTargetTriple = newTargetTriple;
-    }
-    LLVM_FALLTHROUGH;
-
   case llvm::Triple::Darwin:
   case llvm::Triple::MacOSX: {
     Optional<llvm::Triple> targetVariant;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -553,9 +553,22 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   llvm::Triple Target = Opts.Target;
   StringRef TargetArg;
+  std::string TargetArgScratch;
+
   if (const Arg *A = Args.getLastArg(OPT_target)) {
     Target = llvm::Triple(A->getValue());
     TargetArg = A->getValue();
+
+    // Backward compatibility hack: infer "simulator" environment for x86
+    // iOS/tvOS/watchOS. The driver takes care of this for the frontend
+    // most of the time, but loading of old .swiftinterface files goes
+    // directly to the frontend.
+    if (tripleInfersSimulatorEnvironment(Target)) {
+      // Set the simulator environment.
+      Target.setEnvironment(llvm::Triple::EnvironmentType::Simulator);
+      TargetArgScratch = Target.str();
+      TargetArg = TargetArgScratch;
+    }
   }
 
   if (const Arg *A = Args.getLastArg(OPT_target_variant)) {

--- a/lib/IRGen/SwiftTargetInfo.cpp
+++ b/lib/IRGen/SwiftTargetInfo.cpp
@@ -69,7 +69,7 @@ static void configureX86_64(IRGenModule &IGM, const llvm::Triple &triple,
             SWIFT_ABI_X86_64_SWIFT_SPARE_BITS_MASK);
   setToMask(target.IsObjCPointerBit, 64, SWIFT_ABI_X86_64_IS_OBJC_BIT);
 
-  if (tripleIsAnySimulator(triple)) {
+  if (triple.isSimulatorEnvironment()) {
     setToMask(target.ObjCPointerReservedBits, 64,
               SWIFT_ABI_X86_64_SIMULATOR_OBJC_RESERVED_BITS_MASK);
   } else {

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1340,6 +1340,9 @@ static bool areCompatibleArchitectures(const llvm::Triple &moduleTarget,
 
 static bool areCompatibleOSs(const llvm::Triple &moduleTarget,
                              const llvm::Triple &ctxTarget) {
+  if (moduleTarget.getEnvironment() != ctxTarget.getEnvironment())
+    return false;
+
   if (moduleTarget.getOS() == ctxTarget.getOS())
     return true;
 

--- a/test/Driver/infer-simulator.swift
+++ b/test/Driver/infer-simulator.swift
@@ -1,0 +1,13 @@
+// Test the inference of the "simulator" environment within the driver.
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios11.0 %s > %t.simple.txt 2>&1
+// RUN: %FileCheck -check-prefix WARN_IOS_SIMULATOR %s < %t.simple.txt
+// WARN_IOS_SIMULATOR:  warning: inferring simulator environment for target 'x86_64-apple-ios11.0'; use '-target x86_64-apple-ios11.0-simulator' instead
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-tvos10.0 %s > %t.simple.txt 2>&1
+// RUN: %FileCheck -check-prefix WARN_TVOS_SIMULATOR %s < %t.simple.txt
+// WARN_TVOS_SIMULATOR: inferring simulator environment for target 'x86_64-apple-tvos10.0'; use '-target x86_64-apple-tvos10.0-simulator' instead
+
+// RUN: %swiftc_driver -driver-print-jobs -target i386-apple-watchos4.0 %s > %t.simple.txt 2>&1
+// RUN: %FileCheck -check-prefix WARN_WATCHOS_SIMULATOR %s < %t.simple.txt
+// WARN_WATCHOS_SIMULATOR: warning: inferring simulator environment for target 'i386-apple-watchos4.0'; use '-target i386-apple-watchos4.0-simulator' instead

--- a/test/Driver/linker-arclite.swift
+++ b/test/Driver/linker-arclite.swift
@@ -9,7 +9,7 @@
 // CHECK-SAME: -o {{[^ ]+}}
 
 
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios8.0 %S/../Inputs/empty.swift | %FileCheck -check-prefix IOS_ARCLITE %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios8.0-simulator %S/../Inputs/empty.swift | %FileCheck -check-prefix IOS_ARCLITE %s
 
 // IOS_ARCLITE: bin/ld{{"? }}
 // IOS_ARCLITE: -force_load {{[^ ]+/lib/arc/libarclite_iphonesimulator.a}}
@@ -18,8 +18,8 @@
 
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.11 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO_ARCLITE %s
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.10 %S/../Inputs/empty.swift | %FileCheck -check-prefix ANY_ARCLITE %s
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios9 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO_ARCLITE %s
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios8 %S/../Inputs/empty.swift | %FileCheck -check-prefix ANY_ARCLITE %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios9-simulator %S/../Inputs/empty.swift | %FileCheck -check-prefix NO_ARCLITE %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios8-simulator %S/../Inputs/empty.swift | %FileCheck -check-prefix ANY_ARCLITE %s
 // RUN: %swiftc_driver -driver-print-jobs -target arm64-apple-tvos9 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO_ARCLITE %s
 // RUN: %swiftc_driver -driver-print-jobs -target armv7k-apple-watchos2 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO_ARCLITE %s
 

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -6,13 +6,13 @@
 
 // RUN: not %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -static-stdlib %s 2>&1 | %FileCheck -check-prefix=SIMPLE_STATIC %s
 
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios7.1 %s 2>&1 > %t.simple.txt
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios7.1-simulator %s 2>&1 > %t.simple.txt
 // RUN: %FileCheck -check-prefix IOS_SIMPLE %s < %t.simple.txt
 
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-tvos9.0 %s 2>&1 > %t.simple.txt
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-tvos9.0-simulator %s 2>&1 > %t.simple.txt
 // RUN: %FileCheck -check-prefix tvOS_SIMPLE %s < %t.simple.txt
 
-// RUN: %swiftc_driver -driver-print-jobs -target i386-apple-watchos2.0 %s 2>&1 > %t.simple.txt
+// RUN: %swiftc_driver -driver-print-jobs -target i386-apple-watchos2.0-simulator %s 2>&1 > %t.simple.txt
 // RUN: %FileCheck -check-prefix watchOS_SIMPLE %s < %t.simple.txt
 
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-linux-gnu -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.linux.txt
@@ -47,7 +47,7 @@
 // RUN: %FileCheck %s < %t.complex.txt
 // RUN: %FileCheck -check-prefix COMPLEX %s < %t.complex.txt
 
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios7.1 -Xlinker -rpath -Xlinker customrpath -L foo %s 2>&1 > %t.simple.txt
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios7.1-simulator -Xlinker -rpath -Xlinker customrpath -L foo %s 2>&1 > %t.simple.txt
 // RUN: %FileCheck -check-prefix IOS-linker-order %s < %t.simple.txt
 
 // RUN: %swiftc_driver -driver-print-jobs -target armv7-unknown-linux-gnueabihf -Xlinker -rpath -Xlinker customrpath -L foo %s 2>&1 > %t.linux.txt

--- a/test/Driver/print_target_info.swift
+++ b/test/Driver/print_target_info.swift
@@ -7,6 +7,8 @@
 // RUN: %swift_driver -print-target-info -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios13-macabi | %FileCheck -check-prefix CHECK-ZIPPERED %s
 // RUN: %target-swift-frontend -print-target-info -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios13-macabi | %FileCheck -check-prefix CHECK-ZIPPERED %s
 
+// RUN: %swift_driver -print-target-info -target x86_64-apple-ios12.0 | %FileCheck -check-prefix CHECK-IOS-SIM %s
+
 // CHECK-IOS:   "target": {
 // CHECK-IOS:     "triple": "arm64-apple-ios12.0",
 // CHECK-IOS:     "unversionedTriple": "arm64-apple-ios",
@@ -50,3 +52,11 @@
 // CHECK-ZIPPERED:   "swiftRuntimeCompatibilityVersion": "5.1"
 // CHECK-ZIPPERED:   "librariesRequireRPath": false
 // CHECK-ZIPPERED: }
+
+// CHECK-IOS-SIM:   "target": {
+// CHECK-IOS-SIM:     "triple": "x86_64-apple-ios12.0-simulator",
+// CHECK-IOS-SIM:     "unversionedTriple": "x86_64-apple-ios-simulator",
+// CHECK-IOS-SIM:     "moduleTriple": "x86_64-apple-ios-simulator",
+// CHECK-IOS-SIM:     "swiftRuntimeCompatibilityVersion": "5.0",
+// CHECK-IOS-SIM:     "librariesRequireRPath": true
+// CHECK-IOS-SIM:   }

--- a/test/Driver/profiling.swift
+++ b/test/Driver/profiling.swift
@@ -1,20 +1,20 @@
 // RUN: %swiftc_driver -driver-print-jobs -profile-generate -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=CHECK -check-prefix=OSX %s
 
-// RUN: %swiftc_driver -driver-print-jobs -profile-generate -target x86_64-apple-ios7.1 -resource-dir %S/Inputs/fake-resource-dir-old/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=IOS %s
+// RUN: %swiftc_driver -driver-print-jobs -profile-generate -target x86_64-apple-ios7.1-simulator -resource-dir %S/Inputs/fake-resource-dir-old/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=IOS %s
 // RUN: %swiftc_driver -driver-print-jobs -profile-generate -target arm64-apple-ios7.1 -resource-dir %S/Inputs/fake-resource-dir-old/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=IOS %s
 
-// RUN: %swiftc_driver -driver-print-jobs -profile-generate -target x86_64-apple-ios7.1 -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=IOSSIM %s
+// RUN: %swiftc_driver -driver-print-jobs -profile-generate -target x86_64-apple-ios7.1-simulator -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=IOSSIM %s
 // RUN: %swiftc_driver -driver-print-jobs -profile-generate -target arm64-apple-ios7.1 -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=IOS %s
 
-// RUN: %swiftc_driver -driver-print-jobs -profile-generate -target x86_64-apple-tvos9.0 -resource-dir %S/Inputs/fake-resource-dir-old/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=tvOS %s
+// RUN: %swiftc_driver -driver-print-jobs -profile-generate -target x86_64-apple-tvos9.0-simulator -resource-dir %S/Inputs/fake-resource-dir-old/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=tvOS %s
 // RUN: %swiftc_driver -driver-print-jobs -profile-generate -target arm64-apple-tvos9.0 -resource-dir %S/Inputs/fake-resource-dir-old/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=tvOS %s
 
-// RUN: %swiftc_driver -driver-print-jobs -profile-generate -target x86_64-apple-tvos9.0 -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=tvOS_SIM %s
+// RUN: %swiftc_driver -driver-print-jobs -profile-generate -target x86_64-apple-tvos9.0-simulator -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=tvOS_SIM %s
 // RUN: %swiftc_driver -driver-print-jobs -profile-generate -target arm64-apple-tvos9.0 -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=tvOS %s
 
-// RUN: %swiftc_driver -driver-print-jobs -profile-generate -target i386-apple-watchos2.0 -resource-dir %S/Inputs/fake-resource-dir-old/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=watchOS %s
+// RUN: %swiftc_driver -driver-print-jobs -profile-generate -target i386-apple-watchos2.0-simulator -resource-dir %S/Inputs/fake-resource-dir-old/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=watchOS %s
 // RUN: %swiftc_driver -driver-print-jobs -profile-generate -target armv7k-apple-watchos2.0 -resource-dir %S/Inputs/fake-resource-dir-old/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=watchOS %s
-// RUN: %swiftc_driver -driver-print-jobs -profile-generate -target i386-apple-watchos2.0 -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=watchOS_SIM %s
+// RUN: %swiftc_driver -driver-print-jobs -profile-generate -target i386-apple-watchos2.0-simulator -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=watchOS_SIM %s
 // RUN: %swiftc_driver -driver-print-jobs -profile-generate -target armv7k-apple-watchos2.0 -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=watchOS %s
 
 // RUN: %swiftc_driver -driver-print-jobs -profile-generate -target x86_64-unknown-linux-gnu %s | %FileCheck -check-prefix=CHECK -check-prefix=LINUX %s

--- a/test/Driver/sanitize_scudo.swift
+++ b/test/Driver/sanitize_scudo.swift
@@ -2,11 +2,11 @@
 // RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target arm64-apple-ios7.1 %s 2>&1 | %FileCheck -check-prefix=SCUDO_IOS %s
 // RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target arm64-apple-tvos9.0 %s 2>&1 | %FileCheck -check-prefix=SCUDO_tvOS %s
 // RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target armv7k-apple-watchos2.0 %s 2>&1 | %FileCheck -check-prefix=SCUDO_watchOS %s
-// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target i386-apple-watchos2.0 %s 2>&1 | %FileCheck -check-prefix=SCUDO_watchOS_SIM %s
+// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target i386-apple-watchos2.0-simulator %s 2>&1 | %FileCheck -check-prefix=SCUDO_watchOS_SIM %s
 // RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target i386-apple-macosx10.9 %s 2>&1 | %FileCheck -check-prefix=SCUDO_OSX_32 %s
-// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target x86_64-apple-ios7.1 %s 2>&1 | %FileCheck -check-prefix=SCUDO_IOSSIM %s
+// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target x86_64-apple-ios7.1-simulator %s 2>&1 | %FileCheck -check-prefix=SCUDO_IOSSIM %s
 // RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target x86_64-apple-macosx10.9 %s 2>&1 | %FileCheck -check-prefix=SCUDO_OSX_64 %s
-// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target x86_64-apple-tvos9.0 %s 2>&1 | %FileCheck -check-prefix=SCUDO_tvOS_SIM %s
+// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target x86_64-apple-tvos9.0-simulator %s 2>&1 | %FileCheck -check-prefix=SCUDO_tvOS_SIM %s
 // RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target x86_64-unknown-windows-msvc %s 2>&1 | %FileCheck -check-prefix=SCUDO_WINDOWS %s
 
 // RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo,address -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=SCUDO_ASAN %s
@@ -24,11 +24,11 @@
 // SCUDO_LINUX-SAME: -fsanitize=scudo
 // SCUDO_OSX_32: unsupported option '-sanitize=scudo' for target 'i386-apple-macosx10.9'
 // SCUDO_OSX_64: unsupported option '-sanitize=scudo' for target 'x86_64-apple-macosx10.9'
-// SCUDO_IOSSIM: unsupported option '-sanitize=scudo' for target 'x86_64-apple-ios7.1'
+// SCUDO_IOSSIM: unsupported option '-sanitize=scudo' for target 'x86_64-apple-ios7.1-simulator'
 // SCUDO_IOS: unsupported option '-sanitize=scudo' for target 'arm64-apple-ios7.1'
-// SCUDO_tvOS_SIM: unsupported option '-sanitize=scudo' for target 'x86_64-apple-tvos9.0'
+// SCUDO_tvOS_SIM: unsupported option '-sanitize=scudo' for target 'x86_64-apple-tvos9.0-simulator'
 // SCUDO_tvOS: unsupported option '-sanitize=scudo' for target 'arm64-apple-tvos9.0'
-// SCUDO_watchOS_SIM: unsupported option '-sanitize=scudo' for target 'i386-apple-watchos2.0'
+// SCUDO_watchOS_SIM: unsupported option '-sanitize=scudo' for target 'i386-apple-watchos2.0-simulator'
 // SCUDO_watchOS: unsupported option '-sanitize=scudo' for target 'armv7k-apple-watchos2.0'
 // SCUDO_WINDOWS: unsupported option '-sanitize=scudo' for target 'x86_64-unknown-windows-msvc'
 

--- a/test/Driver/sanitizers.swift
+++ b/test/Driver/sanitizers.swift
@@ -3,11 +3,11 @@
  */
 // RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_OSX %s
 // RUN: not %swiftc_driver -driver-print-jobs -sanitize=fuzzer -target x86_64-apple-macosx10.9 -resource-dir %S/Inputs/nonexistent-resource-dir %s 2>&1 | %FileCheck -check-prefix=FUZZER_NONEXISTENT %s
-// RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-apple-ios7.1 %s | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_IOSSIM %s
+// RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-apple-ios7.1-simulator %s | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_IOSSIM %s
 // RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target arm64-apple-ios7.1 %s  | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_IOS %s
-// RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-apple-tvos9.0 %s | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_tvOS_SIM %s
+// RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-apple-tvos9.0-simulator %s | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_tvOS_SIM %s
 // RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target arm64-apple-tvos9.0 %s  | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_tvOS %s
-// RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target i386-apple-watchos2.0 %s   | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_watchOS_SIM %s
+// RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target i386-apple-watchos2.0-simulator %s   | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_watchOS_SIM %s
 // RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target armv7k-apple-watchos2.0 %s | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_watchOS %s
 // RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=ASAN_LINUX %s
 // RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-unknown-windows-msvc %s 2>&1 | %FileCheck -check-prefix=ASAN_WINDOWS %s
@@ -17,11 +17,11 @@
  */
 // RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=TSAN -check-prefix=TSAN_OSX %s
 // RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86-apple-macosx10.9 %s 2>&1 | %FileCheck -check-prefix=TSAN_OSX_32 %s
-// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86_64-apple-ios7.1 %s 2>&1 | %FileCheck -check-prefix=TSAN_IOSSIM %s
+// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86_64-apple-ios7.1-simulator %s 2>&1 | %FileCheck -check-prefix=TSAN_IOSSIM %s
 // RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target arm64-apple-ios7.1 %s 2>&1 | %FileCheck -check-prefix=TSAN_IOS %s
-// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86_64-apple-tvos9.0 %s 2>&1 | %FileCheck -check-prefix=TSAN_tvOS_SIM %s
+// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86_64-apple-tvos9.0-simulator %s 2>&1 | %FileCheck -check-prefix=TSAN_tvOS_SIM %s
 // RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target arm64-apple-tvos9.0 %s 2>&1 | %FileCheck -check-prefix=TSAN_tvOS %s
-// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target i386-apple-watchos2.0 %s 2>&1 | %FileCheck -check-prefix=TSAN_watchOS_SIM %s
+// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target i386-apple-watchos2.0-simulator %s 2>&1 | %FileCheck -check-prefix=TSAN_watchOS_SIM %s
 // RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target armv7k-apple-watchos2.0 %s 2>&1  | %FileCheck -check-prefix=TSAN_watchOS %s
 // RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86_64-unknown-windows-msvc %s 2>&1 | %FileCheck -check-prefix=TSAN_WINDOWS %s
 // RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=TSAN_LINUX %s
@@ -30,11 +30,11 @@
  * Undefined Behavior Sanitizer Tests  (ubsan)
  */
 // RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_OSX %s
-// RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target x86_64-apple-ios7.1 %s | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_IOSSIM %s
+// RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target x86_64-apple-ios7.1-simulator %s | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_IOSSIM %s
 // RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target arm64-apple-ios7.1 %s  | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_IOS %s
-// RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target x86_64-apple-tvos9.0 %s | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_tvOS_SIM %s
+// RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target x86_64-apple-tvos9.0-simulator %s | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_tvOS_SIM %s
 // RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target arm64-apple-tvos9.0 %s  | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_tvOS %s
-// RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target i386-apple-watchos2.0 %s   | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_watchOS_SIM %s
+// RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target i386-apple-watchos2.0-simulator %s   | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_watchOS_SIM %s
 // RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target armv7k-apple-watchos2.0 %s | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_watchOS %s
 // RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=UBSAN_LINUX %s
 // RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target x86_64-unknown-windows-msvc %s 2>&1 | %FileCheck -check-prefix=UBSAN_WINDOWS %s
@@ -79,11 +79,11 @@
 
 // TSAN_OSX: lib{{/|\\\\}}swift{{/|\\\\}}clang{{/|\\\\}}lib{{/|\\\\}}darwin{{/|\\\\}}libclang_rt.tsan_osx_dynamic.dylib
 // TSAN_OSX_32: unsupported option '-sanitize=thread' for target 'x86-apple-macosx10.9'
-// TSAN_IOSSIM: unsupported option '-sanitize=thread' for target 'x86_64-apple-ios7.1'
+// TSAN_IOSSIM: unsupported option '-sanitize=thread' for target 'x86_64-apple-ios7.1-simulator'
 // TSAN_IOS: unsupported option '-sanitize=thread' for target 'arm64-apple-ios7.1'
-// TSAN_tvOS_SIM: unsupported option '-sanitize=thread' for target 'x86_64-apple-tvos9.0'
+// TSAN_tvOS_SIM: unsupported option '-sanitize=thread' for target 'x86_64-apple-tvos9.0-simulator'
 // TSAN_tvOS: unsupported option '-sanitize=thread' for target 'arm64-apple-tvos9.0'
-// TSAN_watchOS_SIM: unsupported option '-sanitize=thread' for target 'i386-apple-watchos2.0'
+// TSAN_watchOS_SIM: unsupported option '-sanitize=thread' for target 'i386-apple-watchos2.0-simulator'
 // TSAN_watchOS: unsupported option '-sanitize=thread' for target 'armv7k-apple-watchos2.0'
 // FUZZER_NONEXISTENT: unsupported option '-sanitize=fuzzer' for target 'x86_64-apple-macosx10.9'
 // TSAN_LINUX: -fsanitize=thread -lBlocksRuntime -ldispatch

--- a/test/Parse/ConditionalCompilation/simulatorTargetEnv.swift
+++ b/test/Parse/ConditionalCompilation/simulatorTargetEnv.swift
@@ -1,6 +1,6 @@
-// RUN: %swift -swift-version 4 -typecheck %s -verify -target x86_64-apple-ios7.0 -parse-stdlib
+// RUN: %swift -swift-version 4 -typecheck %s -verify -target x86_64-apple-ios7.0-simulator -parse-stdlib
 // RUN: %swift -swift-version 4 -typecheck %s -verify -target x86_64-unknown-linux-simulator -parse-stdlib
-// RUN: %swift-ide-test -swift-version 4 -test-input-complete -source-filename=%s -target x86_64-apple-ios7.0
+// RUN: %swift-ide-test -swift-version 4 -test-input-complete -source-filename=%s -target x86_64-apple-ios7.0-simulator
 
 #if !targetEnvironment(simulator)
 // This block should not parse.

--- a/test/Serialization/load-target-normalization.swift
+++ b/test/Serialization/load-target-normalization.swift
@@ -109,15 +109,6 @@ import ForeignModule
 // RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target i386-apple-tvos40-simulator 2>&1 | %FileCheck -DNORM=i386-apple-tvos-simulator %s
 // RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target i386-apple-watchos9.1.1-simulator 2>&1 | %FileCheck -DNORM=i386-apple-watchos-simulator %s
 
-// simulator should be inferred when an Intel architecture is used with iOS, tvOS, or watchOS.
-
-// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target x86_64-apple-ios40.0 2>&1 | %FileCheck -DNORM=x86_64-apple-ios-simulator %s
-// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target x86_64-apple-tvos40 2>&1 | %FileCheck -DNORM=x86_64-apple-tvos-simulator %s
-// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target x86_64-apple-watchos9.1.1 2>&1 | %FileCheck -DNORM=x86_64-apple-watchos-simulator %s
-// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target i386-apple-ios40.0 2>&1 | %FileCheck -DNORM=i386-apple-ios-simulator %s
-// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target i386-apple-tvos40 2>&1 | %FileCheck -DNORM=i386-apple-tvos-simulator %s
-// RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target i386-apple-watchos9.1.1 2>&1 | %FileCheck -DNORM=i386-apple-watchos-simulator %s
-
 // Other environments should be passed through.
 
 // RUN: not %target-swift-frontend %s -typecheck -I %t -parse-stdlib -Xcc -arch -Xcc i386 -target i386-apple-ios40.0-in_spaaaaaaace 2>&1 | %FileCheck -DNORM=i386-apple-ios-in_spaaaaaaace %s


### PR DESCRIPTION
The *-simulator target triples have been used mostly consistently in build systems for
several years to indicate simulator targets... except for Swift's own CMake configuration
and `build-script`, which was still not doing it until recently. There are still `.swiftinterface`
files around that depend on the inference.

Rather than outright removing inference of the "simulator" environment, move it into
the driver and warn that it's happening, so other tools can move off it over time. This
ensures that all frontend/linker/etc. jobs see the "simulator" environment, so the hack is
only in a single place.

This is as far as we can go toward completely removing the hack (rdar://problem/35810403),
because of the need to continue supporting existing `.swiftinterface` files.
