### PR TITLE
[5.2][CS] Use getParameterType for KeyPath as function

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6905,7 +6905,11 @@ ConstraintSystem::simplifyKeyPathConstraint(
       if (fnTy->getParams().size() != 1)
         return false;
 
-      boundRoot = fnTy->getParams()[0].getPlainType();
+      // Match up the root and value types to the function's param and return
+      // types. Note that we're using the type of the parameter as referenced
+      // from inside the function body as we'll be transforming the code into:
+      // { root in root[keyPath: kp] }.
+      boundRoot = fnTy->getParams()[0].getParameterType();
       boundValue = fnTy->getResult();
     }
 

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -59,6 +59,24 @@ public extension Array {
         let sortedA = self.sorted(by: { $0[keyPath: keyPath] < $1[keyPath: keyPath] })
         return sortedA
     }
+
+  var i: Int { 0 }
+}
+
+func takesVariadicFnWithGenericRet<T>(_ fn: (S...) -> T) {}
+
+// rdar://problem/59445486
+func testVariadicKeypathAsFunc() {
+  // These are okay, the base type of the KeyPath is inferred to be [S].
+  let _: (S...) -> Int = \.i
+  let _: (S...) -> Int = \Array.i
+  takesVariadicFnWithGenericRet(\.i)
+  takesVariadicFnWithGenericRet(\Array.i)
+
+  // These are not okay, the KeyPath should have a base that matches the
+  // internal parameter type of the function, i.e [S].
+  let _: (S...) -> Int = \S.i // expected-error {{key path value type 'S' cannot be converted to contextual type '[S]'}}
+  takesVariadicFnWithGenericRet(\S.i) // expected-error {{key path value type 'S' cannot be converted to contextual type '[S]'}}
 }
 
 // rdar://problem/54322807

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -968,6 +968,10 @@ keyPath.test("key path literal closures") {
   // Did we compute the indices once per closure construction, or once per
   // closure application?
   expectEqual(2, callsToComputeIndex)
+
+  // rdar://problem/59445486
+  let variadicFn: (String...) -> Int = \.count
+  expectEqual(3, variadicFn("a", "b", "c"))
 }
 
 // SR-6096


### PR DESCRIPTION
Previously we were using `getPlainType` to match the parameter type against the key path's base type. This gave us the external parameter type, which would be the element type for a variadic parameter.  However the code we generate expects the internal parameter type, which is provided by `getParameterType`.

rdar://problem/59445486
rdar://problem/61229440