### PR TITLE
[5.2] IRGen: Deal with broken AST from batch mode

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -904,6 +904,11 @@ static bool isDependentConformance(
 
     auto assocConformance =
       conformance->getAssociatedConformance(req.getFirstType(), assocProtocol);
+
+    // We migh be presented with a broken AST.
+    if (assocConformance.isInvalid())
+      return false;
+
     if (assocConformance.isAbstract() ||
         isDependentConformance(IGM,
                                assocConformance.getConcrete()

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1754,9 +1754,12 @@ const TypeInfo *TypeConverter::convertType(CanType ty) {
   PrettyStackTraceType stackTrace(IGM.Context, "converting", ty);
 
   switch (ty->getKind()) {
-  case TypeKind::Error:
-    llvm_unreachable("found an ErrorType in IR-gen");
-
+  case TypeKind::Error: {
+    // We might see error types if type checking has failed.
+    // Try to do something graceful and return an zero sized type.
+    auto &ctx = ty->getASTContext();
+    return convertTupleType(cast<TupleType>(ctx.TheEmptyTupleType));
+  }
 #define UNCHECKED_TYPE(id, parent) \
   case TypeKind::id: \
     llvm_unreachable("found a " #id "Type in IR-gen");

--- a/test/IRGen/Inputs/batchmode_errors.swift
+++ b/test/IRGen/Inputs/batchmode_errors.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+@objc
+protocol SomeProto {
+  func conform()
+}
+
+class AnotherClass {}
+
+class SomeClass {
+  // Intentionally referencing the wrong class name.
+  var x : AnotherClass2? = nil
+}
+
+protocol P {}
+protocol WithAssoc {
+  associatedtype AssocType : P
+}
+
+struct BuggyConformer : WithAssoc {
+  typealias AssocType = Int
+}

--- a/test/IRGen/batchmode_ast_errors.swift
+++ b/test/IRGen/batchmode_ast_errors.swift
@@ -1,0 +1,18 @@
+// RUN: not %target-swift-frontend -primary-file %s %S/Inputs/batchmode_errors.swift -emit-ir 2>&1 | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+// Verify that we don't crash (in IRGen).
+
+// CHECK-NOT: Stack dump
+
+extension SomeClass : SomeProto {
+  func conform() {}
+}
+
+func genericParam<T: WithAssoc>(_ t: T) {
+}
+
+func testBuggyGenericParam() {
+   genericParam(BuggyConformer())
+}


### PR DESCRIPTION
Also deal with broken conformance in the AST.

Description: IRGen might be handed broken AST nodes if type checking has failed.

The compiler might crash in batch mode if another file (not the current primary file) contained an error during type checking. This is a consequence of making things more lazy and batch mode. IRGen needs to accept invalid AST.

Scope: This affects any project that compiles invalid code.

Origin: This was introduced as part of batch mode and making type checking more lazy.

Risk: Low. We introduce checks for invalid AST nodes in IRGen and terminate early on a path that would otherwise have crashed later.

Reviewed: Slava


rdar://59552858
rdar://57876556

rdar://61219818