### PR TITLE
[AutoDiff] Disable failing test with `-O`.

### DIFF
--- a/test/AutoDiff/compiler_crashers/sr12493-differentiable-function-extract-subst-function-type.swift
+++ b/test/AutoDiff/compiler_crashers/sr12493-differentiable-function-extract-subst-function-type.swift
@@ -1,0 +1,19 @@
+// RUN: not %target-build-swift -O %s
+
+// SR-12493: SIL verification error regarding substituted function types and
+// `differentiable_function_extract` instruction. Occurs only with `-O`.
+
+import _Differentiation
+
+func exampleVJP_1(_ x0: Float) -> (Float, (Float) -> (Float)) {
+  (
+    x0 * x0,
+    { (2 * x0 * $0) }
+  )
+}
+
+func bar() {
+  let f = differentiableFunction(from: exampleVJP_1)
+  let pb = pullback(at: 10, in: f)
+  _ = pb(1)
+}

--- a/test/AutoDiff/stdlib/differential_operators.swift
+++ b/test/AutoDiff/stdlib/differential_operators.swift
@@ -4,6 +4,9 @@
 // RUN: %target-run %t/differential_operators
 // REQUIRES: executable_test
 
+// FIXME(SR-12493): Disable test for `-O` due to SIL verification error.
+// REQUIRES: swift_test_mode_optimize_none
+
 import _Differentiation
 
 import StdlibUnittest


### PR DESCRIPTION
Disable `test/AutoDiff/stdlib/differential_operators.swift`, which currently fails with `-O`.

SR-12493 tracks fixing the issue. Add negative test.