### PR TITLE
[5.2][Serialization] Recover from a missing conforming type in a protocol conformance 

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -562,7 +562,11 @@ ModuleFile::readConformanceChecked(llvm::BitstreamCursor &Cursor,
     ProtocolConformanceXrefLayout::readRecord(scratch, protoID, nominalID,
                                               moduleID);
 
-    auto nominal = cast<NominalTypeDecl>(getDecl(nominalID));
+    auto maybeNominal = getDeclChecked(nominalID);
+    if (!maybeNominal)
+      return maybeNominal.takeError();
+
+    auto nominal = cast<NominalTypeDecl>(maybeNominal.get());
     PrettyStackTraceDecl trace("cross-referencing conformance for", nominal);
     auto proto = cast<ProtocolDecl>(getDecl(protoID));
     PrettyStackTraceDecl traceTo("... to", proto);

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -118,8 +118,17 @@ namespace swift {
     SILVTable *readVTable(serialization::DeclID);
     SILGlobalVariable *getGlobalForReference(StringRef Name);
     SILGlobalVariable *readGlobalVar(StringRef Name);
-    SILWitnessTable *readWitnessTable(serialization::DeclID,
+
+    /// Read and return the witness table identified with \p WId.
+    SILWitnessTable *readWitnessTable(serialization::DeclID WId,
                                       SILWitnessTable *existingWt);
+
+    /// Read the witness table identified with \p WId, return the table or
+    /// the first error if any.
+    llvm::Expected<SILWitnessTable *>
+      readWitnessTableChecked(serialization::DeclID WId,
+                              SILWitnessTable *existingWt);
+
     void readWitnessTableEntries(
            llvm::BitstreamEntry &entry,
            std::vector<SILWitnessTable::Entry> &witnessEntries,

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -708,9 +708,10 @@ void swift::serialization::diagnoseSerializedASTLoadFailure(
     std::copy_if(
         loadedModuleFile->getDependencies().begin(),
         loadedModuleFile->getDependencies().end(), std::back_inserter(missing),
-        [&duplicates](const ModuleFile::Dependency &dependency) -> bool {
+        [&duplicates, &Ctx](const ModuleFile::Dependency &dependency) -> bool {
           if (dependency.isLoaded() || dependency.isHeader() ||
-              dependency.isImplementationOnly()) {
+              (dependency.isImplementationOnly() &&
+               Ctx.LangOpts.DebuggerSupport)) {
             return false;
           }
           return duplicates.insert(dependency.RawPath).second;

--- a/test/Serialization/Recovery/Inputs/custom-modules/Conformance.h
+++ b/test/Serialization/Recovery/Inputs/custom-modules/Conformance.h
@@ -1,0 +1,4 @@
+enum __attribute__((flag_enum,enum_extensibility(open))) CEnum : int {
+  A = 1 << 0,
+  B = 1 << 1,
+};

--- a/test/Serialization/Recovery/Inputs/custom-modules/module.modulemap
+++ b/test/Serialization/Recovery/Inputs/custom-modules/module.modulemap
@@ -13,3 +13,4 @@ module SuperclassObjC { header "SuperclassObjC.h" }
 module Typedefs { header "Typedefs.h" }
 module TypeRemovalObjC { header "TypeRemovalObjC.h" }
 module Types { header "Types.h" }
+module Conformance { header "Conformance.h" }

--- a/test/Serialization/Recovery/missing-clang-module-conformance.swift
+++ b/test/Serialization/Recovery/missing-clang-module-conformance.swift
@@ -1,0 +1,18 @@
+/// Recover from reading witness table involving a synthesized conformance
+/// rdar://problem/58924131
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/custom-modules %t/
+// RUN: %target-swift-frontend -emit-module %s -module-name MyModule -emit-module-path %t/MyModule.swiftmodule -I %t/custom-modules -swift-version 5
+
+/// Delete the clang module
+// RUN: rm -r %t/custom-modules/
+
+// RUN: not %target-sil-opt %t/MyModule.swiftmodule 2>&1 | %FileCheck %s
+
+@_implementationOnly import Conformance
+// CHECK: missing required module 'Conformance'
+
+public func foo<T: OptionSet>(_ t: T) {}
+
+foo(CEnum.A)


### PR DESCRIPTION
Cherry-pick of #29639.

Description: Non-compilation paths used by sil-opt try to read private declarations and fail on types declared behind implementation-only imports.

Scope: This should affect the sil-opt tool and might affect other non-compilation paths like the indexing phase.

Origin: A change in a framework made the compiler synthesized code for a C enum behind an implementation-only import.

Risk: Low, this fix only affects path that would otherwise have failed.

rdar://problem/61209195