### PR TITLE
Add -Rcross-import option

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -41,6 +41,11 @@
 #  define FIXIT(ID, Text, Signature)
 #endif
 
+#ifndef REMARK
+#  define REMARK(ID,Options,Text,Signature)   \
+DIAG(REMARK,ID,Options,Text,Signature)
+#endif
+
 NOTE(decl_declared_here,none,
      "%0 declared here", (DeclName))
 NOTE(kind_declared_here,none,
@@ -864,6 +869,9 @@ WARNING(module_not_compiled_with_library_evolution,none,
         "using it means binary compatibility for %1 can't be guaranteed",
         (Identifier, Identifier))
 
+REMARK(cross_import_added,none,
+       "import of %0 and %1 triggered a cross-import of %2",
+       (Identifier, Identifier, Identifier))
 
 // Operator decls
 ERROR(ambiguous_operator_decls,none,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -112,6 +112,10 @@ namespace swift {
     /// Detect and automatically import modules' cross-import overlays.
     bool EnableCrossImportOverlays = false;
 
+    /// Emit a remark when import resolution implicitly adds a cross-import
+    /// overlay.
+    bool EnableCrossImportRemarks = false;
+
     ///
     /// Support for alternate usage modes
     ///

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -338,6 +338,9 @@ def emit_loaded_module_trace_path : Separate<["-"], "emit-loaded-module-trace-pa
 def emit_loaded_module_trace_path_EQ : Joined<["-"], "emit-loaded-module-trace-path=">,
   Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath]>,
   Alias<emit_loaded_module_trace_path>;
+def emit_cross_import_remarks : Flag<["-"], "Rcross-import">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Emit a remark if a cross-import of a module is triggered.">;
 
 def emit_tbd : Flag<["-"], "emit-tbd">,
   HelpText<"Emit a TBD file">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -553,6 +553,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
                    OPT_disable_cross_import_overlays,
                    Opts.EnableCrossImportOverlays);
 
+  Opts.EnableCrossImportRemarks = Args.hasArg(OPT_emit_cross_import_remarks);
+
   llvm::Triple Target = Opts.Target;
   StringRef TargetArg;
   if (const Arg *A = Args.getLastArg(OPT_target)) {

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -914,6 +914,11 @@ void ImportResolver::findCrossImports(
                          declaringImport.module.second->getName(),
                          bystandingImport.module.second->getName(), name);
 
+    if (ctx.LangOpts.EnableCrossImportRemarks)
+      ctx.Diags.diagnose(I.importLoc, diag::cross_import_added,
+                         declaringImport.module.second->getName(),
+                         bystandingImport.module.second->getName(), name);
+
     LLVM_DEBUG({
       auto &crossImportOptions = unboundImports.back().options;
       llvm::dbgs() << "  ";

--- a/test/CrossImport/remark-option.swift
+++ b/test/CrossImport/remark-option.swift
@@ -1,0 +1,9 @@
+// This file tests that the -Rcross-import option causes an appropriate remark to be emitted
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/lib-templates/* %t/
+// RUN: %target-typecheck-verify-swift -enable-cross-import-overlays -Rcross-import -I %t/include -I %t/lib/swift -F %t/Frameworks
+
+import DeclaringLibrary
+// FIXME: Similarly to horrible.swift, ideally we would emit this remark on DelcaringLibrary
+// decl, since the cross-import overlay actually belongs to the DeclaringLibrary. (SR-12223)
+import BystandingLibrary // expected-remark {{import of 'DeclaringLibrary' and 'BystandingLibrary' triggered a cross-import of '_OverlayLibrary'}}


### PR DESCRIPTION
It is an optional, user-accessible mechanism to have the compiler tell you what it’s cross-importing.

Resolves rdar://problem/60381893
