### PR TITLE
[Runtime] Handle incomplete class metadata in _checkGenericRequirements.

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -796,6 +796,10 @@ SWIFT_CC(swift)
 SWIFT_RUNTIME_STDLIB_INTERNAL
 const Metadata *_swift_class_getSuperclass(const Metadata *theClass);
 
+SWIFT_CC(swift)
+SWIFT_RUNTIME_STDLIB_INTERNAL MetadataResponse
+getSuperclassMetadata(MetadataRequest request, const ClassMetadata *self);
+
 #if !NDEBUG
 /// Verify that the given metadata pointer correctly roundtrips its
 /// mangled name through the demangler.

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2735,19 +2735,14 @@ initGenericObjCClass(ClassMetadata *self, size_t numFields,
 #endif
 
 SWIFT_CC(swift)
-static std::pair<MetadataDependency, const ClassMetadata *>
-getSuperclassMetadata(ClassMetadata *self, bool allowDependency) {
+SWIFT_RUNTIME_STDLIB_INTERNAL MetadataResponse
+getSuperclassMetadata(MetadataRequest request, const ClassMetadata *self) {
   // If there is a mangled superclass name, demangle it to the superclass
   // type.
-  const ClassMetadata *super = nullptr;
   if (auto superclassNameBase = self->getDescription()->SuperclassType.get()) {
     StringRef superclassName =
       Demangle::makeSymbolicMangledNameStringRef(superclassNameBase);
     SubstGenericParametersFromMetadata substitutions(self);
-    MetadataRequest request(allowDependency
-                              ? MetadataState::NonTransitiveComplete
-                              : /*FIXME*/ MetadataState::Abstract,
-                            /*non-blocking*/ allowDependency);
     MetadataResponse response =
       swift_getTypeByMangledName(request, superclassName,
         substitutions.getGenericArgs(),
@@ -2765,22 +2760,42 @@ getSuperclassMetadata(ClassMetadata *self, bool allowDependency) {
                  superclassName.str().c_str());
     }
 
-    // If the request isn't satisfied, we have a new dependency.
-    if (!request.isSatisfiedBy(response.State)) {
-      assert(allowDependency);
-      return {MetadataDependency(superclass, request.getState()),
-              cast<ClassMetadata>(superclass)};
-    }
+    return response;
+  } else {
+    return MetadataResponse();
+  }
+}
 
+SWIFT_CC(swift)
+static std::pair<MetadataDependency, const ClassMetadata *>
+getSuperclassMetadata(ClassMetadata *self, bool allowDependency) {
+  MetadataRequest request(allowDependency ? MetadataState::NonTransitiveComplete
+                                          : /*FIXME*/ MetadataState::Abstract,
+                          /*non-blocking*/ allowDependency);
+  auto response = getSuperclassMetadata(request, self);
+
+  auto *superclass = response.Value;
+  if (!superclass)
+    return {MetadataDependency(), nullptr};
+
+  const ClassMetadata *second;
 #if SWIFT_OBJC_INTEROP
-    if (auto objcWrapper = dyn_cast<ObjCClassWrapperMetadata>(superclass))
-      superclass = objcWrapper->Class;
+  if (auto objcWrapper = dyn_cast<ObjCClassWrapperMetadata>(superclass)) {
+    second = objcWrapper->Class;
+  } else {
+    second = cast<ClassMetadata>(superclass);
+  }
+#else
+  second = cast<ClassMetadata>(superclass);
 #endif
 
-    super = cast<ClassMetadata>(superclass);
+  // If the request isn't satisfied, we have a new dependency.
+  if (!request.isSatisfiedBy(response.State)) {
+    assert(allowDependency);
+    return {MetadataDependency(superclass, request.getState()), second};
   }
 
-  return {MetadataDependency(), super};
+  return {MetadataDependency(), second};
 }
 
 // Suppress diagnostic about the availability of _objc_realizeClassFromSwift.

--- a/test/Runtime/Inputs/SubclassOfNSObject.h
+++ b/test/Runtime/Inputs/SubclassOfNSObject.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface Subclass : NSObject
+
+@end

--- a/test/Runtime/Inputs/SubclassOfNSObject.m
+++ b/test/Runtime/Inputs/SubclassOfNSObject.m
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+
+@interface Subclass : NSObject
+
+@end
+
+@implementation Subclass
+@end

--- a/test/Runtime/Inputs/Superclass.h
+++ b/test/Runtime/Inputs/Superclass.h
@@ -1,0 +1,4 @@
+#import <Foundation/Foundation.h>
+
+@interface Superclass : NSObject
+@end

--- a/test/Runtime/Inputs/Superclass.m
+++ b/test/Runtime/Inputs/Superclass.m
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface Superclass : NSObject
+@end
+
+@implementation Superclass
+@end

--- a/test/Runtime/Inputs/open_subclass_of_Framework.Superclass.swift
+++ b/test/Runtime/Inputs/open_subclass_of_Framework.Superclass.swift
@@ -1,0 +1,4 @@
+import Framework
+
+open class Subclass1 : Superclass {
+}

--- a/test/Runtime/Inputs/print_subclass/main.swift
+++ b/test/Runtime/Inputs/print_subclass/main.swift
@@ -1,0 +1,3 @@
+// CHECK: Subclass
+print(Subclass().self)
+

--- a/test/Runtime/Inputs/public_struct_with_generic_arg_nsobject_constrained.swift
+++ b/test/Runtime/Inputs/public_struct_with_generic_arg_nsobject_constrained.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public struct Gen<Subclass : NSObject> {
+  public init() {
+  }
+}

--- a/test/Runtime/Inputs/public_struct_with_generic_arg_swift_class_constrained.swift
+++ b/test/Runtime/Inputs/public_struct_with_generic_arg_swift_class_constrained.swift
@@ -1,0 +1,9 @@
+open class Superclass {
+  public init() {
+  }
+}
+
+public struct Gen<Subclass : Superclass> {
+  public init() {
+  }
+}

--- a/test/Runtime/superclass_constraint_metadata_objc_superclass.swift
+++ b/test/Runtime/superclass_constraint_metadata_objc_superclass.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-library -enable-library-evolution -module-name Framework -module-link-name Framework %S/Inputs/public_struct_with_generic_arg_nsobject_constrained.swift -o %t/%target-library-name(Framework) -emit-module-path %t/Framework.swiftmodule
+// RUN: %target-codesign %t/libFramework.dylib
+
+// RUN: %target-build-swift %s %S/Inputs/print_subclass/main.swift -module-name main -o %t/main -I %t -L %t
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %S/Inputs/print_subclass/main.swift
+
+// REQUIRES: executable_test
+
+// REQUIRES: OS=macosx
+// Testing runtime changes that aren't in the os stdlib.
+// UNSUPPORTED: use_os_stdlib
+
+import Swift
+import Foundation
+import Framework
+
+// Swift subclass of a Swift class
+
+// subclass isSwiftClassMetadataSubclass metadata completeness : Complete
+// superclass metadata path: loop
+// iteration 1: subclass->Superclass == NSObject
+//              subclass <= NSObject
+//              superclass == NSObject; done
+
+typealias Gen = Framework.Gen<Subclass>
+
+public class Subclass : NSObject {
+  override init() {
+    self.gen = Gen()
+    super.init()
+  }
+
+  var gen: Gen?
+}
+
+@inline(never)
+public func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}

--- a/test/Runtime/superclass_constraint_metadata_objc_superclass_future.swift
+++ b/test/Runtime/superclass_constraint_metadata_objc_superclass_future.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-library -enable-library-evolution -module-name Framework -module-link-name Framework %S/Inputs/public_struct_with_generic_arg_nsobject_constrained.swift -o %t/%target-library-name(Framework) -emit-module-path %t/Framework.swiftmodule -target %module-target-future
+// RUN: %target-codesign %t/libFramework.dylib
+
+// RUN: %target-build-swift %s %S/Inputs/print_subclass/main.swift -module-name main -o %t/main -I %t -L %t -target %module-target-future
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %S/Inputs/print_subclass/main.swift
+
+// REQUIRES: executable_test
+
+// REQUIRES: OS=macosx
+// Testing runtime changes that aren't in the os stdlib.
+// UNSUPPORTED: use_os_stdlib
+
+import Swift
+import Foundation
+import Framework
+
+// Swift subclass of a ObjC class
+
+// subclass isSwiftClassMetadataSubclass metadata completeness : LayoutComplete
+// superclass metadata path: getSuperclassMetadata
+// getSuperclassMetadata result 1: (Complete, NSObject, !ClassMetadata)
+// handleObjc => swift_dynamicCastMetatype
+
+typealias Gen = Framework.Gen<Subclass>
+
+public class Subclass : NSObject {
+  override init() {
+    self.gen = Gen()
+    super.init()
+  }
+
+  var gen: Gen?
+}
+
+@inline(never)
+public func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}

--- a/test/Runtime/superclass_constraint_metadata_objc_superclass_objc_intermediate_swift_subclass.swift
+++ b/test/Runtime/superclass_constraint_metadata_objc_superclass_objc_intermediate_swift_subclass.swift
@@ -1,0 +1,43 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-library -enable-library-evolution -module-name Framework -module-link-name Framework %S/Inputs/public_struct_with_generic_arg_nsobject_constrained.swift -o %t/%target-library-name(Framework) -emit-module-path %t/Framework.swiftmodule
+// RUN: %target-codesign %t/libFramework.dylib
+
+// RUN: %target-clang -fobjc-arc %S/Inputs/Superclass.m -c -o %t/Superclass.o
+// RUN: %target-build-swift %s %t/Superclass.o %S/Inputs/print_subclass/main.swift -import-objc-header %S/Inputs/Superclass.h -module-name main -o %t/main -I %t -L %t
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %S/Inputs/print_subclass/main.swift
+
+// REQUIRES: executable_test
+
+// REQUIRES: OS=macosx
+// Testing runtime changes that aren't in the os stdlib.
+// UNSUPPORTED: use_os_stdlib
+
+import Swift
+import Foundation
+import Framework
+
+// Swift subclass of an ObjC subclass of an ObjC class
+
+// subclass isSwiftClassMetadataSubclass metadata completeness : Complete
+// superclass metadata path: loop
+// iteration 1: subclass->Superclass == NSObject
+//              subclass <= NSObject
+//              superclass == NSObject; done
+
+typealias Gen = Framework.Gen<Subclass>
+
+public class Subclass : Superclass {
+  override init() {
+    self.gen = Gen()
+    super.init()
+  }
+
+  var gen: Gen?
+}
+
+@inline(never)
+public func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}

--- a/test/Runtime/superclass_constraint_metadata_objc_superclass_objc_intermediate_swift_subclass_future.swift
+++ b/test/Runtime/superclass_constraint_metadata_objc_superclass_objc_intermediate_swift_subclass_future.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-library -enable-library-evolution -module-name Framework -module-link-name Framework %S/Inputs/public_struct_with_generic_arg_nsobject_constrained.swift -o %t/%target-library-name(Framework) -emit-module-path %t/Framework.swiftmodule -target %module-target-future
+// RUN: %target-codesign %t/libFramework.dylib
+
+// RUN: %target-clang -fobjc-arc %S/Inputs/Superclass.m -c -o %t/Superclass.o
+// RUN: %target-build-swift %s %t/Superclass.o %S/Inputs/print_subclass/main.swift -import-objc-header %S/Inputs/Superclass.h -module-name main -o %t/main -I %t -L %t -target %module-target-future
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %S/Inputs/print_subclass/main.swift
+
+// REQUIRES: executable_test
+
+// REQUIRES: OS=macosx
+// Testing runtime changes that aren't in the os stdlib.
+// UNSUPPORTED: use_os_stdlib
+
+import Swift
+import Foundation
+import Framework
+
+// Swift subclass of an ObjC subclass of an ObjC class
+
+// subclass isSwiftClassMetadataSubclass metadata completeness : Complete
+// superclass metadata path: getSuperclassMetadata
+// getSuperclassMetadata result 1: (Complete, NSObject, !ClassMetadata)
+// handleObjc => swift_dynamicCastMetatype
+
+typealias Gen = Framework.Gen<Subclass>
+
+public class Subclass : Superclass {
+  override init() {
+    self.gen = Gen()
+    super.init()
+  }
+
+  var gen: Gen?
+}
+
+@inline(never)
+public func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}

--- a/test/Runtime/superclass_constraint_metadata_objc_superclass_objc_subclass.swift
+++ b/test/Runtime/superclass_constraint_metadata_objc_superclass_objc_subclass.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-library -enable-library-evolution -module-name Framework -module-link-name Framework %S/Inputs/public_struct_with_generic_arg_nsobject_constrained.swift -o %t/%target-library-name(Framework) -emit-module-path %t/Framework.swiftmodule
+// RUN: %target-codesign %t/libFramework.dylib
+
+// RUN: %target-clang -fobjc-arc %S/Inputs/SubclassOfNSObject.m -c -o %t/Superclass.o
+// RUN: %target-build-swift %s %t/Superclass.o %S/Inputs/print_subclass/main.swift -import-objc-header %S/Inputs/SubclassOfNSObject.h -module-name main -o %t/main -I %t -L %t
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %S/Inputs/print_subclass/main.swift
+
+// REQUIRES: executable_test
+
+// REQUIRES: OS=macosx
+// Testing runtime changes that aren't in the os stdlib.
+// UNSUPPORTED: use_os_stdlib
+
+import Swift
+import Foundation
+import Framework
+
+// ObjC subclass of an ObjC subclass
+
+// isSubclass is never called: no reference to subclass metadata from subclass
+// metadata; i.e. Subclass has no member of type Gen<Subclass>?
+
+@inline(never)
+public func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}

--- a/test/Runtime/superclass_constraint_metadata_resilient_superclass.swift
+++ b/test/Runtime/superclass_constraint_metadata_resilient_superclass.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-library -enable-library-evolution -module-name Framework -module-link-name Framework %S/Inputs/public_struct_with_generic_arg_swift_class_constrained.swift -o %t/%target-library-name(Framework) -emit-module-path %t/Framework.swiftmodule
+// RUN: %target-codesign %t/libFramework.dylib
+
+// RUN: %target-build-swift %s %S/Inputs/print_subclass/main.swift -module-name main -o %t/main -I %t -L %t
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %S/Inputs/print_subclass/main.swift
+
+// REQUIRES: executable_test
+
+// REQUIRES: OS=macosx
+// Testing runtime changes that aren't in the os stdlib.
+// UNSUPPORTED: use_os_stdlib
+
+import Swift
+import Framework
+
+// Swift subclass of a Swift class
+
+// subclass isSwiftClassMetadataSubclass metadata completeness : Complete
+// superclass metadata path: loop
+// iteration 1: subclass->Superclass == Superclass
+//              subclass <= Superclass
+//              superclass == Superclass; done
+
+typealias Gen = Framework.Gen<Subclass>
+
+public class Subclass : Superclass {
+  override init() {
+    self.gen = Gen()
+    super.init()
+  }
+
+  var gen: Gen?
+}
+
+@inline(never)
+public func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}

--- a/test/Runtime/superclass_constraint_metadata_resilient_superclass2.swift
+++ b/test/Runtime/superclass_constraint_metadata_resilient_superclass2.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-library -enable-library-evolution -module-name Framework -module-link-name Framework %S/Inputs/public_struct_with_generic_arg_swift_class_constrained.swift -o %t/%target-library-name(Framework) -emit-module-path %t/Framework.swiftmodule
+// RUN: %target-codesign %t/libFramework.dylib
+// RUN: %target-build-swift -emit-library -enable-library-evolution -module-name Framework2 -module-link-name Framework2 %S/Inputs/open_subclass_of_Framework.Superclass.swift -o %t/%target-library-name(Framework2) -emit-module-path %t/Framework2.swiftmodule -I %t -L %t
+// RUN: %target-codesign %t/libFramework2.dylib
+
+// RUN: %target-build-swift %s %S/Inputs/print_subclass/main.swift -module-name main -o %t/main -I %t -L %t
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %S/Inputs/print_subclass/main.swift
+
+// REQUIRES: executable_test
+
+// REQUIRES: OS=macosx
+// Testing runtime changes that aren't in the os stdlib.
+// UNSUPPORTED: use_os_stdlib
+
+import Swift
+import Framework
+import Framework2
+
+// Swift subclass of a Swift subclass of a Swift class
+
+// subclass isSwiftClassMetadataSubclass metadata completeness : Complete
+// superclass metadata path: loop
+// iteration 1: subclass->Superclass == Subclass1
+//              subclass <= Subclass1
+// iteration 2: subclass->Superclass == Superclass
+//              subclass <= Superclass
+//              superclass == Superclass; done
+
+typealias Gen = Framework.Gen<Subclass>
+
+public class Subclass : Subclass1 {
+  override init() {
+    self.gen = Gen()
+    super.init()
+  }
+
+  var gen: Gen?
+}
+
+@inline(never)
+public func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+

--- a/test/Runtime/superclass_constraint_metadata_resilient_superclass2_future.swift
+++ b/test/Runtime/superclass_constraint_metadata_resilient_superclass2_future.swift
@@ -1,0 +1,48 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-library -enable-library-evolution -module-name Framework -module-link-name Framework %S/Inputs/public_struct_with_generic_arg_swift_class_constrained.swift -o %t/%target-library-name(Framework) -emit-module-path %t/Framework.swiftmodule -target %module-target-future
+// RUN: %target-codesign %t/libFramework.dylib
+// RUN: %target-build-swift -emit-library -enable-library-evolution -module-name Framework2 -module-link-name Framework2 %S/Inputs/open_subclass_of_Framework.Superclass.swift -o %t/%target-library-name(Framework2) -emit-module-path %t/Framework2.swiftmodule -target %module-target-future -I %t -L %t 
+// RUN: %target-codesign %t/libFramework2.dylib
+
+// RUN: %target-build-swift %s %S/Inputs/print_subclass/main.swift -module-name main -o %t/main -I %t -L %t -target %module-target-future
+
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %S/Inputs/print_subclass/main.swift
+
+// REQUIRES: executable_test
+
+// REQUIRES: OS=macosx
+// Testing runtime changes that aren't in the os stdlib.
+// UNSUPPORTED: use_os_stdlib
+
+import Swift
+import Framework
+import Framework2
+
+// Swift subclass of a Swift class
+
+// subclass isSwiftClassMetadataSubclass metadata completeness : LayoutComplete
+// superclass metadata path: getSuperclassMetadata
+// getSuperclassMetadata result 1: (Complete, Subclass1)
+// superclass metadata path: loop
+// iteration 1: subclass->Superclass == Superclass
+//              subclass <= Superclass
+//              superclass == Superclass; done
+
+typealias Gen = Framework.Gen<Subclass>
+
+public class Subclass : Subclass1 {
+  override init() {
+    self.gen = Gen()
+    super.init()
+  }
+
+  var gen: Gen?
+}
+
+@inline(never)
+public func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+

--- a/test/Runtime/superclass_constraint_metadata_resilient_superclass_future.swift
+++ b/test/Runtime/superclass_constraint_metadata_resilient_superclass_future.swift
@@ -1,0 +1,40 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-library -enable-library-evolution -module-name Framework -module-link-name Framework %S/Inputs/public_struct_with_generic_arg_swift_class_constrained.swift -o %t/%target-library-name(Framework) -emit-module-path %t/Framework.swiftmodule -target %module-target-future
+// RUN: %target-codesign %t/libFramework.dylib
+
+// RUN: %target-build-swift %s %S/Inputs/print_subclass/main.swift -module-name main -o %t/main -I %t -L %t -target %module-target-future
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %S/Inputs/print_subclass/main.swift
+
+// REQUIRES: executable_test
+
+// REQUIRES: OS=macosx
+// Testing runtime changes that aren't in the os stdlib.
+// UNSUPPORTED: use_os_stdlib
+
+import Swift
+import Framework
+
+// Swift subclass of a Swift class
+
+// subclass isSwiftClassMetadataSubclass metadata completeness : LayoutComplete
+// superclass metadata path: getSuperclassMetadata
+// getSuperclassMetadata result 1: (Complete, Superclass)
+// subclass == superclass; done
+
+typealias Gen = Framework.Gen<Subclass>
+
+public class Subclass : Superclass {
+  override init() {
+    self.gen = Gen()
+    super.init()
+  }
+
+  var gen: Gen?
+}
+
+@inline(never)
+public func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}


### PR DESCRIPTION
When constructing the metadata for a type `Gen<T : Super>` where `Super` is a superclass constraint, the generic argument K at which the metadata for `Gen` is being instantiated is verified to be a subclass of `Super` via `_checkGenericRequirements`.

Previously, that check was done using `swift_dynamicCastMetatype`.  That worked for the most part but provided an incorrect answer if the metadata for `K` was not yet complete.  These classes are incomplete more often thanks to `__swift_instantiateConcreteTypeFromMangledNameAbstract`.

That issue occurred concretely in the following case:

  Framework with Library Evolution enabled:

```
    open class Super { ... }
    public struct Gen<T : Super> {
    }
```

  Target in a different resilience domain from that framework:

```
    class Sub : Super {
      var gen: Gen<Sub>?
    }
```

Here, the mechanism for checking whether the generic argument `K` at which the metadata for `Gen` is being instantiated handles the case where `K`'s metadata is incomplete.  At worst, every superclass name from `super(K)` up to `Super` are demangled to instantiate metadata.  A number of faster paths are included as well.

rdar://problem/60790020