### PR TITLE
Fix the getAddressAccess API.

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -78,8 +78,10 @@ SingleValueInstruction *isAccessProjection(SILValue v);
 /// findAccessedStorage() on either \p v or the returned address.
 SILValue getAddressAccess(SILValue v);
 
-/// Convenience for stripAccessMarkers(getAddressAccess(V)).
-SILValue getAccessedAddress(SILValue v);
+/// Convenience for stripAccessMarkers(getAddressAccess(v)).
+inline SILValue getAccessedAddress(SILValue v) {
+  return stripAccessMarkers(getAddressAccess(v));
+}
 
 /// Return true if \p accessedAddress points to a let-variable.
 ///

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -47,7 +47,7 @@ SingleValueInstruction *swift::isAccessProjection(SILValue v) {
 // TODO: When the optimizer stops stripping begin_access markers, then we should
 // be able to assert that the result is a BeginAccessInst and the default case
 // is unreachable.
-SILValue swift::getAccessedAddress(SILValue v) {
+SILValue swift::getAddressAccess(SILValue v) {
   while (true) {
     assert(v->getType().isAddress());
     auto *projection = isAccessProjection(v);


### PR DESCRIPTION
The API was accidentally undefined, presumably because I checked in
the wrong code or there was a bad merge. The API will be used by
upcoming commits.

Meanwhile, getAccessedAddress was not stripping access markers, which
means some analysis may have been too conservative.

This fix could expose issues by making existing analyses more effective.

