### PR TITLE
Fix LICM combined load/store hoisting/sinking optimization.

### DIFF
--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -561,3 +561,233 @@ bb6:                                              // Preds: bb3 bb5
   return %19 : $()                                // id: %20
 } // end sil function 'hoist_loads_and_stores'
 
+// ==================================================================
+// Test combined load/store hoisting/sinking with aliases
+
+struct Index {
+  @_hasStorage var value: Int64 { get set }
+}
+
+// -----------------------------------------------------------------------------
+// Test combined load/store hoisting/sinking with obvious aliasing loads
+
+// CHECK-LABEL: sil shared @testCombinedLdStAliasingLoad : $@convention(method) (Int64) -> Int64 {
+// CHECK: bb0(%0 : $Int64):
+// CHECK: store
+// CHECK-NOT: {{(load|store)}}
+// CHECK: bb1:
+// CHECK-NEXT: load %{{.*}} : $*Builtin.Int64
+// CHECK-NEXT: store %{{.*}} to %{{.*}} : $*Int64
+// CHECK-NEXT: load %{{.*}} : $*Builtin.Int64
+// CHECK-NEXT: cond_br
+// CHECK-NOT: {{(load|store)}}
+// CHECK-LABEL: } // end sil function 'testCombinedLdStAliasingLoad'
+sil shared @testCombinedLdStAliasingLoad : $@convention(method) (Int64) -> Int64 {
+bb0(%0 : $Int64):
+  %zero = integer_literal $Builtin.Int64, 0
+  %intz = struct $Int64(%zero : $Builtin.Int64)
+  %stackAddr = alloc_stack $Index
+  %outerAddr1 = struct_element_addr %stackAddr : $*Index, #Index.value
+  store %intz to %outerAddr1 : $*Int64
+  %innerAddr1 = struct_element_addr %outerAddr1 : $*Int64, #Int64._value
+  %outerAddr2 = struct_element_addr %stackAddr : $*Index, #Index.value
+  %innerAddr2 = struct_element_addr %outerAddr2 : $*Int64, #Int64._value
+  br bb1
+
+bb1:
+  %val = load %innerAddr2 : $*Builtin.Int64
+  %intv = struct $Int64(%zero : $Builtin.Int64)
+  store %intv to %outerAddr2 : $*Int64
+  %val2 = load %innerAddr1 : $*Builtin.Int64
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1
+
+bb3:
+  dealloc_stack %stackAddr : $*Index
+  %result = struct $Int64(%val2 : $Builtin.Int64)
+  return %result : $Int64
+}
+
+// -----------------------------------------------------------------------------
+// Test combined load/store hoisting/sinking with obvious aliasing stores
+
+// CHECK-LABEL: sil shared @testCombinedLdStAliasingStore : $@convention(method) (Int64) -> Int64 {
+// CHECK: bb0(%0 : $Int64):
+// CHECK: store
+// CHECK-NOT: {{(load|store)}}
+// CHECK: bb1:
+// CHECK-NEXT: load %{{.*}} : $*Builtin.Int64
+// CHECK-NEXT: store %{{.*}} to %{{.*}} : $*Int64
+// CHECK-NEXT: store %{{.*}} to %{{.*}} : $*Builtin.Int64
+// CHECK-NEXT: cond_br
+// CHECK-NOT: {{(load|store)}}
+// CHECK: load
+// CHECK-NOT: {{(load|store)}}
+// CHECK-LABEL: } // end sil function 'testCombinedLdStAliasingStore'
+sil shared @testCombinedLdStAliasingStore : $@convention(method) (Int64) -> Int64 {
+bb0(%0 : $Int64):
+  %zero = integer_literal $Builtin.Int64, 0
+  %intz = struct $Int64(%zero : $Builtin.Int64)
+  %stackAddr = alloc_stack $Index
+  %outerAddr1 = struct_element_addr %stackAddr : $*Index, #Index.value
+  store %intz to %outerAddr1 : $*Int64
+  %innerAddr1 = struct_element_addr %outerAddr1 : $*Int64, #Int64._value
+  %outerAddr2 = struct_element_addr %stackAddr : $*Index, #Index.value
+  %innerAddr2 = struct_element_addr %outerAddr2 : $*Int64, #Int64._value
+  br bb1
+
+bb1:
+  %val = load %innerAddr2 : $*Builtin.Int64
+  %intv = struct $Int64(%zero : $Builtin.Int64)
+  store %intv to %outerAddr2 : $*Int64
+  store %val to %innerAddr1 : $*Builtin.Int64
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1
+
+bb3:
+  dealloc_stack %stackAddr : $*Index
+  %final = load %innerAddr2 : $*Builtin.Int64
+  %result = struct $Int64(%final : $Builtin.Int64)
+  return %result : $Int64
+}
+
+// -----------------------------------------------------------------------------
+// Test combined load/store hoisting/sinking with unknown aliasing loads
+
+// CHECK-LABEL: sil shared @testCombinedLdStUnknownLoad : $@convention(method) (Int64, Builtin.RawPointer, Builtin.RawPointer) -> Int64 {
+// CHECK: bb0(%0 : $Int64, %1 : $Builtin.RawPointer, %2 : $Builtin.RawPointer):
+// CHECK-NOT: {{(load|store)}}
+// CHECK: bb1:
+// CHECK-NEXT:  load %{{.*}} : $*Builtin.Int64
+// CHECK-NEXT:  store %{{.*}} to %{{.*}} : $*Int64
+// CHECK-NEXT:  load %{{.*}} : $*Builtin.Int64
+// CHECK-NEXT:  cond_br
+// CHECK-NOT: {{(load|store)}}
+// CHECK-LABEL: } // end sil function 'testCombinedLdStUnknownLoad'
+sil shared @testCombinedLdStUnknownLoad : $@convention(method) (Int64, Builtin.RawPointer, Builtin.RawPointer) -> Int64 {
+bb0(%0 : $Int64, %1 : $Builtin.RawPointer, %2 : $Builtin.RawPointer):
+  %addr1 = pointer_to_address %1 : $Builtin.RawPointer to $*Index
+  %addr2 = pointer_to_address %2 : $Builtin.RawPointer to $*Index
+  %outerAddr1 = struct_element_addr %addr1 : $*Index, #Index.value
+  %outerAddr2 = struct_element_addr %addr2 : $*Index, #Index.value
+  %innerAddr1 = struct_element_addr %outerAddr1 : $*Int64, #Int64._value
+  %innerAddr2 = struct_element_addr %outerAddr2 : $*Int64, #Int64._value
+  br bb1
+
+bb1:
+  %val = load %innerAddr2 : $*Builtin.Int64
+  store %0 to %outerAddr2 : $*Int64
+  %val2 = load %innerAddr1 : $*Builtin.Int64
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1
+
+bb3:
+  %result = struct $Int64(%val2 : $Builtin.Int64)
+  return %result : $Int64
+}
+
+// -----------------------------------------------------------------------------
+// Reduced test case from rdar !!!
+//
+// Test miscompilation of BidirectionalCollection<IndexSet>._distance with
+// combined load/store hoisting/sinking with mutiple loads from
+// aliasing addresses.
+
+// getRange
+sil @getRange : $@convention(thin) () -> Range<Int64>
+
+// CHECK-LABEL: sil shared @testLICMReducedCombinedLdStExtraProjection : $@convention(method) (Int64) -> Int64 {
+// CHECK: bb0(%0 : $Int64):
+// CHECK:   store %0 to %{{.*}} : $*Int64
+// CHECK-NOT: {{(load|store)}}
+// CHECK: bb1(%{{.*}} : $Builtin.Int64):
+// CHECK:   builtin "sadd_with_overflow_Int64"
+// CHECK:   load %{{.*}} : $*Builtin.Int64
+// CHECK:   builtin "sadd_with_overflow_Int64"
+// CHECK:   builtin "cmp_eq_Int64"
+// CHECK-NEXT: cond_br
+// CHECK: bb3:
+// CHECK:   store %{{.*}} to %{{.*}} : $*Int64
+// CHECK: bb4:
+// CHECK:   store %{{.*}} to %{{.*}} : $*Int64
+// CHECK: bb5:
+// CHECK:   function_ref @getRange : $@convention(thin) () -> Range<Int64>
+// CHECK:   apply %{{.*}}() : $@convention(thin) () -> Range<Int64>
+// CHECK:   store %{{.*}} to %{{.*}} : $*Int64
+// CHECK: bb6:
+// CHECK:   load %{{.*}} : $*Builtin.Int64
+// CHECK:   builtin "cmp_eq_Int64"
+// CHECK:   cond_br
+// CHECK-NOT: {{(load|store)}}
+// CHECK-LABEL: } // end sil function 'testLICMReducedCombinedLdStExtraProjection'
+sil shared @testLICMReducedCombinedLdStExtraProjection : $@convention(method) (Int64) -> Int64 {
+// %0                                             // users: %5, %1
+bb0(%0 : $Int64):
+  %1 = struct_extract %0 : $Int64, #Int64._value      // users: %35, %20
+  %2 = integer_literal $Builtin.Int64, 0          // user: %9
+  %3 = alloc_stack $Index              // users: %41, %13, %4
+  %4 = struct_element_addr %3 : $*Index, #Index.value // users: %8, %5
+  store %0 to %4 : $*Int64                          // id: %5
+  %6 = integer_literal $Builtin.Int64, 1          // user: %11
+  %7 = integer_literal $Builtin.Int1, -1          // user: %11
+  %8 = struct_element_addr %4 : $*Int64, #Int64._value // user: %34
+  br bb1(%2 : $Builtin.Int64)                     // id: %9
+
+// %10                                            // user: %11
+bb1(%10 : $Builtin.Int64):                        // Preds: bb8 bb0
+  %11 = builtin "sadd_with_overflow_Int64"(%10 : $Builtin.Int64, %6 : $Builtin.Int64, %7 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1) // user: %12
+  %12 = tuple_extract %11 : $(Builtin.Int64, Builtin.Int1), 0 // users: %38, %37
+  %13 = struct_element_addr %3 : $*Index, #Index.value // users: %32, %27, %24, %14
+  %14 = struct_element_addr %13 : $*Int64, #Int64._value // user: %15
+  %15 = load %14 : $*Builtin.Int64                // user: %18
+  %16 = integer_literal $Builtin.Int64, 1         // user: %18
+  %17 = integer_literal $Builtin.Int1, -1         // user: %18
+  %18 = builtin "sadd_with_overflow_Int64"(%15 : $Builtin.Int64, %16 : $Builtin.Int64, %17 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1) // user: %19
+  %19 = tuple_extract %18 : $(Builtin.Int64, Builtin.Int1), 0 // users: %26, %23, %20
+  %20 = builtin "cmp_eq_Int64"(%19 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1 // user: %21
+  cond_br %20, bb2, bb3                           // id: %21
+
+bb2:                                              // Preds: bb1
+  cond_br undef, bb4, bb5                         // id: %22
+
+bb3:                                              // Preds: bb1
+  %23 = struct $Int64 (%19 : $Builtin.Int64)        // user: %24
+  store %23 to %13 : $*Int64                        // id: %24
+  br bb6                                          // id: %25
+
+bb4:                                              // Preds: bb2
+  %26 = struct $Int64 (%19 : $Builtin.Int64)        // user: %27
+  store %26 to %13 : $*Int64                        // id: %27
+  br bb6                                          // id: %28
+
+bb5:                                              // Preds: bb2
+  // function_ref getRange
+  %29 = function_ref @getRange : $@convention(thin) () -> Range<Int64> // user: %30
+  %30 = apply %29() : $@convention(thin) () -> Range<Int64> // user: %31
+  %31 = struct_extract %30 : $Range<Int64>, #Range.lowerBound // user: %32
+  store %31 to %13 : $*Int64                        // id: %32
+  br bb6                                          // id: %33
+
+bb6:                                              // Preds: bb5 bb4 bb3
+  %34 = load %8 : $*Builtin.Int64                 // user: %35
+  %35 = builtin "cmp_eq_Int64"(%34 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1 // user: %36
+  cond_br %35, bb7, bb8                           // id: %36
+
+bb7:                                              // Preds: bb6
+  br bb9(%12 : $Builtin.Int64)                    // id: %37
+
+bb8:                                              // Preds: bb6
+  br bb1(%12 : $Builtin.Int64)                    // id: %38
+
+// %39                                            // user: %40
+bb9(%39 : $Builtin.Int64):                        // Preds: bb7
+  %40 = struct $Int64 (%39 : $Builtin.Int64)        // user: %42
+  dealloc_stack %3 : $*Index           // id: %41
+  return %40 : $Int64                               // id: %42
+}

--- a/test/SILOptimizer/licm_multiend.sil
+++ b/test/SILOptimizer/licm_multiend.sil
@@ -30,16 +30,16 @@ sil_global @_swiftEmptyArrayStorage : $_SwiftEmptyArrayStorage
 // CHECK: [[LOOPH]]({{.*}} : $Builtin.Int64)
 // CHECK: cond_br {{.*}}, [[LOOPCOND1:bb[0-9]+]], [[LOOPCOND2:bb[0-9]+]]
 // CHECK: [[LOOPCOND1]]:
+// CHECK-NEXT: store
 // CHECK-NEXT: cond_br {{.*}}, [[LOOPEXIT1:bb[0-9]+]], [[LOOPCONT1:bb[0-9]+]]
 // CHECK: [[LOOPEXIT1]]:
-// CHECK-NEXT: store
 // CHECK-NEXT: end_access [[BEGINA]] : $*Int
 // CHECK-NEXT: br [[LOOPAFTEREXIT:bb[0-9]+]]
 // CHECK: [[LOOPCOND2]]:
 // CHECK-NEXT: struct $Int
+// CHECK-NEXT: store
 // CHECK-NEXT: cond_br {{.*}}, [[LOOPEXIT2:bb[0-9]+]], [[LOOPCONT1]]
 // CHECK: [[LOOPEXIT2]]:
-// CHECK-NEXT: store
 // CHECK-NEXT: end_access [[BEGINA]] : $*Int
 // CHECK-NEXT: br [[LOOPAFTEREXIT]]
 // CHECK: [[LOOPCONT1]]:


### PR DESCRIPTION
    This loop optimization hoists and sinks a group of loads and stores to
    the same address.

    Consider this SIL...

    PRELOOP:
      %stackAddr = alloc_stack $Index
      %outerAddr1 = struct_element_addr %stackAddr : $*Index, #Index.value
      %innerAddr1 = struct_element_addr %outerAddr1 : $*Int, #Int._value

      %outerAddr2 = struct_element_addr %stackAddr : $*Index, #Index.value
      %innerAddr2 = struct_element_addr %outerAddr2 : $*Int, #Int._value

    LOOP:
      %_ = load %innerAddr2 : $*Builtin.Int64
      store %_ to %outerAddr2 : $*Int
      %_ = load %innerAddr1 : $*Builtin.Int64

    There are two bugs:

    1) LICM miscompiles code during combined load/store hoisting and sinking.

    When the loop contains an aliasing load from a difference projection
    value, the optimization sinks the store but never replaces the
    load. At runtime, the load reads a stale value.

    FIX: isOnlyLoadedAndStored needs to check for other load instructions
    before hoisting/sinking a seemingly unrelated set of
    loads/stores. Checking side effect instructions is insufficient. The
    same bug could happen with stores, which also do not produce side
    effects.

Fixes <rdar://61246061> LICM miscompile: Combined load/store hoisting/sinking with aliases

    2) The LICM algorithm is not robust with respect to address projection
       because it identifies a projected address by its SILValue. This
       should never be done! It is trivial to represent a project path
       using an IndexTrieNode (there is also an abstraction called
       "ProjectionPath", but it should _never_ actually be stored by an
       analysis because of the time and space complexity of doing so).

    The second bug is not necessary to fix for correctness, so will be
    fixed in a follow-up commit.