### PR TITLE
[C++] Make const member variables read-only

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3918,6 +3918,12 @@ namespace {
                               /*IsCaptureList*/false,
                               Impl.importSourceLoc(decl->getLocation()),
                               name, dc);
+      if (decl->getType().isConstQualified()) {
+        // Note that in C++ there are ways to change the values of const
+        // members, so we don't use WriteImplKind::Immutable storage.
+        assert(result->supportsMutation());
+        result->overwriteSetterAccess(AccessLevel::Private);
+      }
       result->setIsObjC(false);
       result->setIsDynamic(false);
       result->setInterfaceType(type);

--- a/test/Interop/Cxx/class/Inputs/member-variables.h
+++ b/test/Interop/Cxx/class/Inputs/member-variables.h
@@ -1,0 +1,4 @@
+class MyClass {
+public:
+  const int const_member = 23;
+};

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -1,0 +1,3 @@
+module CxxMemberVariables {
+  header "member-variables.h"
+}

--- a/test/Interop/Cxx/class/member-variables-module-interface.swift
+++ b/test/Interop/Cxx/class/member-variables-module-interface.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=CxxMemberVariables -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK:      struct MyClass {
+// CHECK-NEXT:   var const_member: Int32 { get }
+// CHECK-NEXT:   init()
+// CHECK-NEXT: }

--- a/test/Interop/Cxx/class/member-variables-typechecker.swift
+++ b/test/Interop/Cxx/class/member-variables-typechecker.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-cxx-interop
+
+import CxxMemberVariables
+
+var s = MyClass()
+s.const_member = 42 // expected-error {{cannot assign to property: 'const_member' setter is inaccessible}}


### PR DESCRIPTION
This imports const members of C++ structs/classes stored properties with
an inaccessible setter.

Note that in C++ there are ways to change the values of const members,
so we don't use `WriteImplKind::Immutable` storage.

Resolves: [SR-12463](https://bugs.swift.org/browse/SR-12463)