### PR TITLE
[Diagnostics] Improve {{none}} fix-it verifier

### DIFF
--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -642,17 +642,14 @@ DiagnosticVerifier::Result DiagnosticVerifier::verifyFile(unsigned BufferID) {
 
       assert(!FoundDiagnostic.FixIts.empty() &&
              "some fix-its should be produced here");
-
-      const char *noneStartLoc =
-          expected.ExpectedEnd -
-          (fixitExpectationNoneString.size() + 4) /* length of '{{none}}' */;
+      assert(expected.noneMarkerStartLoc && "none marker location is null");
 
       const char *replStartLoc = nullptr, *replEndLoc = nullptr;
       std::string message;
       if (expected.Fixits.empty()) {
         message = "expected no fix-its";
-        replStartLoc = noneStartLoc;
-        replEndLoc = noneStartLoc;
+        replStartLoc = expected.noneMarkerStartLoc;
+        replEndLoc = expected.noneMarkerStartLoc;
       } else {
         message = "unexpected fix-it seen";
         replStartLoc = expected.Fixits.front().StartLoc;
@@ -676,8 +673,8 @@ DiagnosticVerifier::Result DiagnosticVerifier::verifyFile(unsigned BufferID) {
         actualFixits += " ";
       }
 
-      emitFixItsError(noneStartLoc, message, replStartLoc, replEndLoc,
-                      actualFixits);
+      emitFixItsError(expected.noneMarkerStartLoc, message, replStartLoc,
+                      replEndLoc, actualFixits);
     }
 
     // Actually remove the diagnostic from the list, so we don't match it

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -466,7 +466,7 @@ DiagnosticVerifier::Result DiagnosticVerifier::verifyFile(unsigned BufferID) {
         if (Expected.noneMarkerStartLoc) {
           addError(FixItStr.data() - 2,
                    Twine("A second {{") + fixitExpectationNoneString +
-                       "}} is found. it can be put only one.");
+                       "}} was found. It may only appear once in an expectation.");
           break;
         }
 

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -576,7 +576,7 @@ DiagnosticVerifier::Result DiagnosticVerifier::verifyFile(unsigned BufferID) {
       }
     }
 
-    bool isUnexpectedFixitsSeen =
+    const bool isUnexpectedFixitsSeen =
         expected.Fixits.size() < FoundDiagnostic.FixIts.size();
 
     struct ActualFixitsPhrase {

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -34,6 +34,9 @@ struct ExpectedFixIt {
 } // end namespace swift
 
 namespace {
+
+static constexpr StringLiteral fixitExpectationNoneString("none");
+
 struct ExpectedDiagnosticInfo {
   // This specifies the full range of the "expected-foo {{}}" specifier.
   const char *ExpectedStart, *ExpectedEnd = nullptr;
@@ -457,11 +460,11 @@ DiagnosticVerifier::Result DiagnosticVerifier::verifyFile(unsigned BufferID) {
       ExtraChecks = ExtraChecks.substr(EndLoc+2).ltrim();
       
       // Special case for specifying no fixits should appear.
-      if (FixItStr == "none") {
+      if (FixItStr == fixitExpectationNoneString) {
         Expected.noExtraFixitsMayAppear = true;
         continue;
       }
-        
+
       // Parse the pieces of the fix-it.
       size_t MinusLoc = FixItStr.find('-');
       if (MinusLoc == StringRef::npos) {
@@ -595,7 +598,9 @@ DiagnosticVerifier::Result DiagnosticVerifier::verifyFile(unsigned BufferID) {
       assert(!FoundDiagnostic.FixIts.empty() &&
              "some fix-its should be produced here");
 
-      const char *noneStartLoc = expected.ExpectedEnd - 8; // {{none}} length
+      const char *noneStartLoc =
+          expected.ExpectedEnd -
+          (fixitExpectationNoneString.size() + 4) /* length of '{{none}}' */;
 
       std::string actualFixits =
           renderFixits(FoundDiagnostic.FixIts, InputFile);

--- a/test/FixCode/verify-fixits.swift.result
+++ b/test/FixCode/verify-fixits.swift.result
@@ -5,5 +5,63 @@
 func f1() {
   guard true { return } // expected-error {{expected 'else' after 'guard' condition}}
 
-  guard true { return } // expected-error {{expected 'else' after 'guard' condition}} {{14-14=else }}
+  guard true { return } // expected-error {{expected 'else' after 'guard' condition}} {{14-14=else }} {{none}}
+}
+
+func labeledFunc(aa: Int, bb: Int) {}
+
+func test0Fixits() {
+  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}
+
+  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}
+
+  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}
+
+  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{none}}
+
+  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{none}}
+
+  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{none}}
+}
+
+func test1Fixits() {
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}}
+
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}}
+
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}}
+
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}}
+
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}}
+
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}} {{none}}
+
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}} {{none}}
+
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}} {{none}}
+
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}} {{none}}
+
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}} {{none}}
+}
+
+func test2Fixits() {
+  labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}}
+
+  labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}}
+
+  labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{23-26=bb}}
+
+  labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{23-26=bb}}
+
+  labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{23-26=bb}}
+
+  labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{23-26=bb}} {{none}}
+
+  labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{23-26=bb}} {{none}}
+
+  labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{23-26=bb}} {{none}}
+
+  labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{23-26=bb}} {{none}}
 }

--- a/test/Frontend/verify-fixits.swift
+++ b/test/Frontend/verify-fixits.swift
@@ -1,26 +1,24 @@
-// RUN: cp %s %t
-// RUN: not %swift -typecheck -target %target-triple -verify-apply-fixes %t
-// RUN: diff %t %s.result
+// Tests for fix-its on `-verify` mode.
 
-func f1() {
-  guard true { return } // expected-error {{...}}
-
-  guard true { return } // expected-error {{expected 'else' after 'guard' condition}} {{none}}
-}
+// RUN: not %target-typecheck-verify-swift 2>&1 | %FileCheck %s
 
 func labeledFunc(aa: Int, bb: Int) {}
 
 func test0Fixits() {
   undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}
 
+  // CHECK: [[@LINE+1]]:86: error: expected fix-it not seen
   undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{1-1=a}}
 
+  // CHECK: [[@LINE+1]]:86: error: expected fix-it not seen
   undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{1-1=a}} {{2-2=b}}
 
   undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{none}}
 
+  // CHECK: [[@LINE+1]]:86: error: expected fix-it not seen
   undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{1-1=a}} {{none}}
 
+  // CHECK: [[@LINE+1]]:86: error: expected fix-it not seen
   undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{1-1=a}} {{2-2=b}} {{none}}
 }
 
@@ -29,20 +27,27 @@ func test1Fixits() {
 
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}}
 
+  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=xx}}
 
+  // CHECK: [[@LINE+1]]:134: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}} {{15-18=xx}}
 
+  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=xx}} {{15-18=aa}}
 
+  // CHECK: [[@LINE+1]]:121: error: expected no fix-its; actual fix-it seen: {{{{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{none}}
 
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}} {{none}}
 
+  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=xx}} {{none}}
 
+  // CHECK: [[@LINE+1]]:134: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}} {{15-18=xx}} {{none}}
 
+  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=xx}} {{15-18=aa}} {{none}}
 }
 
@@ -51,17 +56,22 @@ func test2Fixits() {
 
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}}
 
+  // CHECK: [[@LINE+1]]:124: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}} {{{{}}23-26=bb}}
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=xx}}
 
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{23-26=bb}}
 
+  // CHECK: [[@LINE+1]]:137: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}} {{{{}}23-26=bb}}
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{23-26=xx}}
 
+  // CHECK: [[@LINE+1]]:124: error: expected no fix-its; actual fix-it seen: {{{{}}15-18=aa}} {{{{}}23-26=bb}}
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{none}}
 
+  // CHECK: [[@LINE+1]]:137: error: unexpected fix-it seen; actual fix-it seen: {{{{}}15-18=aa}} {{{{}}23-26=bb}}
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{none}}
 
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{23-26=bb}} {{none}}
 
+  // CHECK: [[@LINE+1]]:137: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}} {{{{}}23-26=bb}}
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{23-26=xx}} {{none}}
 }

--- a/test/Frontend/verify-fixits.swift
+++ b/test/Frontend/verify-fixits.swift
@@ -4,6 +4,14 @@
 
 func labeledFunc(aa: Int, bb: Int) {}
 
+func testNoneMarkerCheck() {
+  // CHECK: [[@LINE+1]]:95: error: A second {{{{}}none}} is found. it can be put only one.
+  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{none}} {{none}}
+
+  // CHECK: [[@LINE+1]]:134: error: {{{{}}none}} must be at the end.
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}} {{none}} {{23-26=bb}}
+}
+
 func test0Fixits() {
   undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}
 

--- a/test/Frontend/verify-fixits.swift
+++ b/test/Frontend/verify-fixits.swift
@@ -5,7 +5,7 @@
 func labeledFunc(aa: Int, bb: Int) {}
 
 func testNoneMarkerCheck() {
-  // CHECK: [[@LINE+1]]:95: error: A second {{{{}}none}} is found. it can be put only one.
+  // CHECK: [[@LINE+1]]:95: error: A second {{{{}}none}} was found. It may only appear once in an expectation.
   undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{none}} {{none}}
 
   // CHECK: [[@LINE+1]]:134: error: {{{{}}none}} must be at the end.

--- a/test/Frontend/verify-fixits.swift
+++ b/test/Frontend/verify-fixits.swift
@@ -56,22 +56,22 @@ func test2Fixits() {
 
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}}
 
-  // CHECK: [[@LINE+1]]:124: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}} {{{{}}23-26=bb}}
+  // CHECK: [[@LINE+1]]:124: error: expected fix-it not seen; actual fix-its seen: {{{{}}15-18=aa}} {{{{}}23-26=bb}}
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=xx}}
 
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{23-26=bb}}
 
-  // CHECK: [[@LINE+1]]:137: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}} {{{{}}23-26=bb}}
+  // CHECK: [[@LINE+1]]:137: error: expected fix-it not seen; actual fix-its seen: {{{{}}15-18=aa}} {{{{}}23-26=bb}}
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{23-26=xx}}
 
-  // CHECK: [[@LINE+1]]:124: error: expected no fix-its; actual fix-it seen: {{{{}}15-18=aa}} {{{{}}23-26=bb}}
+  // CHECK: [[@LINE+1]]:124: error: expected no fix-its; actual fix-its seen: {{{{}}15-18=aa}} {{{{}}23-26=bb}}
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{none}}
 
-  // CHECK: [[@LINE+1]]:137: error: unexpected fix-it seen; actual fix-it seen: {{{{}}15-18=aa}} {{{{}}23-26=bb}}
+  // CHECK: [[@LINE+1]]:137: error: unexpected fix-it seen; actual fix-its seen: {{{{}}15-18=aa}} {{{{}}23-26=bb}}
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{none}}
 
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{23-26=bb}} {{none}}
 
-  // CHECK: [[@LINE+1]]:137: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}} {{{{}}23-26=bb}}
+  // CHECK: [[@LINE+1]]:137: error: expected fix-it not seen; actual fix-its seen: {{{{}}15-18=aa}} {{{{}}23-26=bb}}
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{23-26=xx}} {{none}}
 }

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -297,7 +297,7 @@ func complexSequence() {
   //     (type_expr typerepr='P1 & P2 throws -> P3 & P1')))
   _ = try P1 & P2 throws -> P3 & P1
   // expected-warning @-1 {{no calls to throwing functions occur within 'try' expression}}
-  // expected-error @-2 {{single argument function types require parentheses}} {{none}} {{11-11=(}} {{18-18=)}}
+  // expected-error @-2 {{single argument function types require parentheses}} {{11-11=(}} {{18-18=)}}
   // expected-error @-3 {{expected member name or constructor call after type name}}
   // expected-note @-4 {{use '.self' to reference the type object}} {{11-11=(}} {{36-36=).self}}
 }

--- a/test/diagnostics/verifier.swift
+++ b/test/diagnostics/verifier.swift
@@ -16,7 +16,7 @@ let y: Int = "hello, world!" // expected-error@:49 {{cannot convert value of typ
 // Wrong fix-it
 let z: Int = "hello, world!" as Any
 // expected-error@-1 {{cannot convert value of type}} {{3-3=foobarbaz}}
-// CHECK: expected fix-it not seen; actual fix-its: {{[{][{]}}36-36= as! Int{{[}][}]}}
+// CHECK: expected fix-it not seen; actual fix-it seen: {{[{][{]}}36-36= as! Int{{[}][}]}}
 
 // Expected no fix-it
 let a: Bool = "hello, world!" as Any


### PR DESCRIPTION
This PR improve {{none}} fix-it verifier.

Currently, it means that no fix-it is expected.

I improve it to mean that no more fix-it is expected when use it with normal fix-it verifier at same time.

For example:

```swift
func labeledFunc(aa: Int, bb: Int) {}

func test() {
  // (1)
  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}}
  
  // (2)
  labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}}
}
```

They means that diagnosed fix-its include `{{15-18=aa}}` at least.
They doesn't care about whether more other fix-its are emitted.
Actually (2) emits second fix-its for label `bbx:`, but it doesn't affect anything.

I introduce new feature for such situation to check strictly fix-its are just equal to expected.
For example:

```swift
func test() {
  // (3)
  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}} {{none}}
  
  // (4)
  labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{none}}
}
```

With above code, (3) is passed verification but (4) is not.

We can check fix-its more strictly.

---

Original code doesn't support using it with normal fix-its.

This is result from Xcode11.4

```swift
a.swift:3:135: error: expected no fix-its; actual fix-it seen: {{13-16=aa}} {{21-24=bb}}
labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{13-16=aa}} {{none}}
                                                                                                                                      ^~~~~~~
                                                                                                                                      {{13-16=aa}} {{21-24=bb}}
```

---


@CodaFi @gregomni @owenv Could you review this?