### PR TITLE
[prespecialized metadata] Note classes are complete.

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1295,6 +1295,14 @@ public:
     assert(isTypeMetadata());
   }
 
+  bool isCanonicalStaticallySpecializedGenericMetadata() const {
+    auto *description = getDescription();
+    if (!description->isGeneric())
+      return false;
+
+    return this->Flags & ClassFlags::IsCanonicalStaticSpecialization;
+  }
+
   static bool classof(const TargetMetadata<Runtime> *metadata) {
     return metadata->getKind() == MetadataKind::Class;
   }

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -265,7 +265,16 @@ enum class ClassFlags : uint32_t {
   UsesSwiftRefcounting = 0x2,
 
   /// Has this class a custom name, specified with the @objc attribute?
-  HasCustomObjCName = 0x4
+  HasCustomObjCName = 0x4,
+
+  /// Whether this metadata is a specialization of a generic metadata pattern
+  /// which was created during compilation.
+  IsStaticSpecialization = 0x8,
+
+  /// Whether this metadata is a specialization of a generic metadata pattern
+  /// which was created during compilation and made to be canonical by
+  /// modifying the metadata accessor.
+  IsCanonicalStaticSpecialization = 0x10,
 };
 inline bool operator&(ClassFlags a, ClassFlags b) {
   return (uint32_t(a) & uint32_t(b)) != 0;

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -5512,6 +5512,8 @@ bool Metadata::isCanonicalStaticallySpecializedGenericMetadata() const {
     return metadata->isCanonicalStaticallySpecializedGenericMetadata();
   if (auto *metadata = dyn_cast<EnumMetadata>(this))
     return metadata->isCanonicalStaticallySpecializedGenericMetadata();
+  if (auto *metadata = dyn_cast<ClassMetadata>(this))
+    return metadata->isCanonicalStaticallySpecializedGenericMetadata();
 
   return false;
 }


### PR DESCRIPTION
In preparation for the prespecialization of metadata for generic classes, make checkMetadataState always return that the state of
prespecialized class metadata is complete, as is done for generic structs and enums already.