### PR TITLE
benchmark: Add SWIFT_BENCHMARK_UNOPTIMIZED_DRIVER option

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -227,6 +227,9 @@ endif()
 set(SWIFT_BENCHMARK_EXTRA_FLAGS "" CACHE STRING
     "Extra options to pass to swiftc when building the benchmarks")
 
+set(SWIFT_BENCHMARK_UNOPTIMIZED_DRIVER NO CACHE BOOL
+    "Build the benchmark driver utilites without optimization (default: no)")
+
 if (SWIFT_BENCHMARK_BUILT_STANDALONE)
   # This option's value must match the value of the same option used when
   # building the swift runtime.

--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -379,10 +379,13 @@ function (swift_benchmark_compile_archopts)
 
   set(common_swift4_options ${common_options} "-swift-version" "4")
 
-  # Always optimize the driver modules.
-  # Note that we compile the driver for Osize also with -Osize
-  # (and not with -O), because of <rdar://problem/19614516>.
-  string(REPLACE "Onone" "O" driver_opt "${optflag}")
+  # Always optimize the driver modules, unless we're building benchmarks for
+  # debugger testing.
+  if(NOT SWIFT_BENCHMARK_UNOPTIMIZED_DRIVER)
+    # Note that we compile the driver for Osize also with -Osize
+    # (and not with -O), because of <rdar://problem/19614516>.
+    string(REPLACE "Onone" "O" driver_opt "${optflag}")
+  endif()
 
   set(common_options_driver
       "-c"


### PR DESCRIPTION
Add an option to allow compiling the benchmark test utilities and driver
at -Onone. This is needed because lldb does not support stepping through
optimized swift code.