### PR TITLE
[benchmark] Disable inlining of wCSIA in benchmark

### DIFF
--- a/benchmark/single-source/UTF8Decode.swift
+++ b/benchmark/single-source/UTF8Decode.swift
@@ -198,6 +198,7 @@ struct CustomContiguousCollection: Collection {
   var endIndex: Index { storage.count }
   func index(after i: Index) -> Index { i+1 }
 
+  @inline(never)
   func withContiguousStorageIfAvailable<R>(
     _ body: (UnsafeBufferPointer<UInt8>) throws -> R
   ) rethrows -> R? {
@@ -214,6 +215,13 @@ struct CustomNoncontiguousCollection: Collection {
   var startIndex: Index { 0 }
   var endIndex: Index { storage.count }
   func index(after i: Index) -> Index { i+1 }
+
+  @inline(never)
+  func withContiguousStorageIfAvailable<R>(
+    _ body: (UnsafeBufferPointer<UInt8>) throws -> R
+  ) rethrows -> R? {
+    nil
+  }
 }
 let allStringsCustomContiguous = CustomContiguousCollection(allStringsBytes)
 let asciiCustomContiguous = CustomContiguousCollection(Array(ascii.utf8))


### PR DESCRIPTION
... which gives us a better feel for when contiguity is unknown at the
call site.

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
