### PR TITLE
SILGen: Use the original function address as the ID for key paths to import-as-member properties.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3352,11 +3352,15 @@ getIdForKeyPathComponentComputedProperty(SILGenModule &SGM,
     // Identify the property using its (unthunked) getter. For a
     // computed property, this should be stable ABI; for a resilient public
     // property, this should also be stable ABI across modules.
+    auto representativeDecl = getRepresentativeAccessorForKeyPath(storage);
+    // If the property came from an import-as-member function defined in C,
+    // use the original C function as the key.
+    bool isForeign = representativeDecl->isImportAsMember();
+    auto getterRef = SILDeclRef(representativeDecl,
+                                SILDeclRef::Kind::Func, isForeign);
     // TODO: If the getter has shared linkage (say it's synthesized for a
     // Clang-imported thing), we'll need some other sort of
     // stable identifier.
-    auto getterRef = SILDeclRef(getRepresentativeAccessorForKeyPath(storage),
-                                SILDeclRef::Kind::Func);
     return SGM.getFunction(getterRef, NotForDefinition);
   }
   case AccessStrategy::DispatchToAccessor: {

--- a/test/SILGen/Inputs/keypaths_import_as_member.h
+++ b/test/SILGen/Inputs/keypaths_import_as_member.h
@@ -1,0 +1,5 @@
+
+typedef struct Butt { } Butt;
+
+extern int ButtSize(const Butt *butt)
+  __attribute__((swift_name("getter:Butt.size(self:)")));

--- a/test/SILGen/keypaths_import_as_member.swift
+++ b/test/SILGen/keypaths_import_as_member.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-emit-silgen %s -import-objc-header %S/Inputs/keypaths_import_as_member.h | %FileCheck %s
+
+// CHECK-LABEL: sil {{.*}} @$s{{.*}}23keyPathToImportedMember
+func keyPathToImportedMember() {
+  // CHECK: keypath $KeyPath<Butt, Int32>, (root $Butt; gettable_property $Int32,  id @ButtSize
+  _ = \Butt.size
+}


### PR DESCRIPTION
If an import-as-member property was used in a key path, we'd try to identify the component by its
foreign-to-native thunk, which isn't normally generated (causing a crash from the missing symbol)
and wouldn't be globally unique even if it were. Fixes rdar://problem/60519829.