### PR TITLE
[Serialization] Lazily Resolve the Eraser Type of @ _typeEraser

### DIFF
--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -105,6 +105,10 @@ public:
   virtual ValueDecl *
   loadDynamicallyReplacedFunctionDecl(const DynamicReplacementAttr *DRA,
                                       uint64_t contextData) = 0;
+
+  /// Returns the type for a given @_typeEraser() attribute.
+  virtual Type loadTypeEraserType(const TypeEraserAttr *TRA,
+                                  uint64_t contextData) = 0;
 };
 
 /// A class that can lazily load conformances from a serialized format.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2260,6 +2260,27 @@ public:
                            evaluator::SideEffect) const;
 };
 
+class ResolveTypeEraserTypeRequest
+    : public SimpleRequest<ResolveTypeEraserTypeRequest,
+                           Type (ProtocolDecl *, TypeEraserAttr *),
+                           RequestFlags::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  Type evaluate(Evaluator &evaluator, ProtocolDecl *PD,
+                TypeEraserAttr *attr) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+  Optional<Type> getCachedResult() const;
+  void cacheResult(Type value) const;
+};
+
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.
 template<>

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -213,6 +213,9 @@ SWIFT_REQUEST(TypeChecker, PreCheckFunctionBuilderRequest,
 SWIFT_REQUEST(TypeChecker, ResolveImplicitMemberRequest,
               evaluator::SideEffect(NominalTypeDecl *, ImplicitMemberAction),
               Uncached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, ResolveTypeEraserTypeRequest,
+              Type(ProtocolDecl *, TypeEraserAttr *),
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SPIGroupsRequest,
               llvm::ArrayRef<Identifier>(Decl *),
               Cached, NoLocationInfo)

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1081,6 +1081,7 @@ bool DeclContext::isClassConstrainedProtocolExtension() const {
 SourceLoc swift::extractNearestSourceLoc(const DeclContext *dc) {
   switch (dc->getContextKind()) {
   case DeclContextKind::Module:
+    return SourceLoc();
   case DeclContextKind::AbstractFunctionDecl:
   case DeclContextKind::EnumElementDecl:
   case DeclContextKind::ExtensionDecl:

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1080,11 +1080,11 @@ bool DeclContext::isClassConstrainedProtocolExtension() const {
 
 SourceLoc swift::extractNearestSourceLoc(const DeclContext *dc) {
   switch (dc->getContextKind()) {
+  case DeclContextKind::Module:
   case DeclContextKind::AbstractFunctionDecl:
   case DeclContextKind::EnumElementDecl:
   case DeclContextKind::ExtensionDecl:
   case DeclContextKind::GenericTypeDecl:
-  case DeclContextKind::Module:
   case DeclContextKind::SubscriptDecl:
   case DeclContextKind::TopLevelCodeDecl:
     return extractNearestSourceLoc(dc->getAsDecl());

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1372,6 +1372,23 @@ void LookupAllConformancesInContextRequest::writeDependencySink(
 }
 
 //----------------------------------------------------------------------------//
+// ResolveTypeEraserTypeRequest computation.
+//----------------------------------------------------------------------------//
+
+Optional<Type> ResolveTypeEraserTypeRequest::getCachedResult() const {
+  auto ty = std::get<1>(getStorage())->TypeEraserLoc.getType();
+  if (ty.isNull()) {
+    return None;
+  }
+  return ty;
+}
+
+void ResolveTypeEraserTypeRequest::cacheResult(Type value) const {
+  assert(value && "Resolved type erasure type to null type!");
+  std::get<1>(getStorage())->TypeEraserLoc.setType(value);
+}
+
+//----------------------------------------------------------------------------//
 // TypeCheckSourceFileRequest computation.
 //----------------------------------------------------------------------------//
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1290,6 +1290,11 @@ public:
     llvm_unreachable("unimplemented for ClangImporter");
   }
 
+  Type loadTypeEraserType(const TypeEraserAttr *TRA,
+                          uint64_t contextData) override {
+    llvm_unreachable("unimplemented for ClangImporter");
+  }
+
   void loadRequirementSignature(const ProtocolDecl *decl, uint64_t contextData,
                                 SmallVectorImpl<Requirement> &reqs) override {
     llvm_unreachable("unimplemented for ClangImporter");

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2209,8 +2209,7 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     if (invalid)
       return false;
 
-    Attributes.add(new (Context)
-        TypeEraserAttr(AtLoc, {Loc, RParenLoc}, ErasedType.get()));
+    Attributes.add(TypeEraserAttr::create(Context, AtLoc, {Loc, RParenLoc}, ErasedType.get()));
     break;
   }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4103,11 +4103,13 @@ Expr *ConstraintSystem::buildTypeErasedExpr(Expr *expr, DeclContext *dc,
   if (protocols.size() != 1)
     return expr;
 
-  auto *attr = protocols.front()->getAttrs().getAttribute<TypeEraserAttr>();
+  auto *PD = protocols.front();
+  auto *attr = PD->getAttrs().getAttribute<TypeEraserAttr>();
   if (!attr)
     return expr;
 
-  auto typeEraser = attr->getTypeEraserLoc().getType();
+  auto typeEraser = attr->getResolvedType(PD);
+  assert(typeEraser && "Failed to resolve eraser type!");
   auto &ctx = dc->getASTContext();
   return CallExpr::createImplicit(ctx,
                                   TypeExpr::createImplicit(typeEraser, ctx),

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4264,10 +4264,8 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
         serialization::decls_block::TypeEraserDeclAttrLayout::readRecord(
             scratch, isImplicit, typeEraserID);
 
-        auto typeEraser = MF.getType(typeEraserID);
         assert(!isImplicit);
-        Attr = new (ctx) TypeEraserAttr(SourceLoc(), SourceRange(),
-                                        TypeLoc::withoutLoc(typeEraser));
+        Attr = TypeEraserAttr::create(ctx, &MF, typeEraserID);
         break;
       }
 
@@ -5910,6 +5908,11 @@ ModuleFile::loadAssociatedTypeDefault(const swift::AssociatedTypeDecl *ATD,
 ValueDecl *ModuleFile::loadDynamicallyReplacedFunctionDecl(
     const DynamicReplacementAttr *DRA, uint64_t contextData) {
   return cast<ValueDecl>(getDecl(contextData));
+}
+
+Type ModuleFile::loadTypeEraserType(const TypeEraserAttr *TRA,
+                                    uint64_t contextData) {
+  return getType(contextData);
 }
 
 void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -882,6 +882,9 @@ public:
   loadDynamicallyReplacedFunctionDecl(const DynamicReplacementAttr *DRA,
                                       uint64_t contextData) override;
 
+  virtual Type loadTypeEraserType(const TypeEraserAttr *TRA,
+                                  uint64_t contextData) override;
+
   virtual void finishNormalConformance(NormalProtocolConformance *conformance,
                                        uint64_t contextData) override;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2367,7 +2367,8 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     case DAK_TypeEraser: {
       auto abbrCode = S.DeclTypeAbbrCodes[TypeEraserDeclAttrLayout::Code];
       auto attr = cast<TypeEraserAttr>(DA);
-      auto typeEraser = attr->getTypeEraserLoc().getType();
+      auto typeEraser = attr->getResolvedType(cast<ProtocolDecl>(D));
+      assert(typeEraser && "Failed to resolve erasure type!");
       TypeEraserDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
                                            attr->isImplicit(),
                                            S.addTypeRef(typeEraser));

--- a/test/Serialization/Inputs/multi-file-type-eraser.swift
+++ b/test/Serialization/Inputs/multi-file-type-eraser.swift
@@ -1,0 +1,10 @@
+@_typeEraser(AnyWindows)
+public protocol Vista {
+    associatedtype Software : Vista
+
+    var dlls: Software { get }
+}
+
+extension Never: Vista {
+  public var dlls: Never { fatalError() }
+}

--- a/test/Serialization/multi-file-type-eraser.swift
+++ b/test/Serialization/multi-file-type-eraser.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -module-name Multi -o %t/multi-file.swiftmodule -primary-file %s %S/Inputs/multi-file-type-eraser.swift
+// RUN: %target-swift-frontend -emit-module -module-name Multi -o %t/multi-file-2.swiftmodule %s -primary-file %S/Inputs/multi-file-type-eraser.swift
+
+// RUN: %target-swift-frontend -emit-module -module-name Multi %t/multi-file.swiftmodule %t/multi-file-2.swiftmodule -o %t -print-stats 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module -module-name Multi %t/multi-file-2.swiftmodule %t/multi-file.swiftmodule -o %t -print-stats 2>&1 | %FileCheck %s
+// Ensure we don't crash during merge-modules - no matter the order of inputs.
+
+// CHECK: Statistics
+// CHECK: 2 Serialization - # of normal protocol conformances completed
+
+public struct AnyWindows : Vista {
+  public init<V: Vista>(erasing vista: V) {
+    fatalError()
+  }
+
+  public var dlls: Never { fatalError() }
+}
+

--- a/test/Serialization/serialize_attr.swift
+++ b/test/Serialization/serialize_attr.swift
@@ -82,15 +82,3 @@ public class CC<T : PP> {
 // CHECK-DAG: sil [serialized] [_specialize exported: false, kind: full, where T == Int, U == Float] [canonical] [ossa] @$s14serialize_attr14specializeThis_1uyx_q_tr0_lF : $@convention(thin) <T, U> (@in_guaranteed T, @in_guaranteed U) -> () {
 
 // CHECK-DAG: sil [serialized] [noinline] [_specialize exported: false, kind: full, where T == RR, U == SS] [canonical] [ossa] @$s14serialize_attr2CCC3foo_1gqd___AA2GGVyxGtqd___AHtAA2QQRd__lF : $@convention(method) <T where T : PP><U where U : QQ> (@in_guaranteed U, GG<T>, @guaranteed CC<T>) -> (@out U, GG<T>) {
-
-
- // @_typeEraser
- // -----------------------------------------------------------------------------
-
-public class AnyP: P {
-  public init<T: P>(erasing: T) {}
-}
-
-// CHECK-DAG: @_typeEraser(AnyP) protocol P
-@_typeEraser(AnyP)
-public protocol P {}


### PR DESCRIPTION
Type erasure requires a circular construction by its very nature:

```
@_typeEraser(AnyProto)
protocol Proto { /**/ }
public struct AnyProto : Proto {}
```

If we eagerly resolve AnyProto, the chain of resolution steps that
deserialization must make goes a little something like this:

```
Lookup(Proto)
    -> Deserialize(@_typeEraser(AnyProto))
    -> Lookup(AnyProto)
    -> DeserializeInheritedStuff(AnyProto)
    -> Lookup(Proto)
```

Now, this cycle could be broken if the order of incremental inputs was
such that we had already cached the lookup of Proto.

Resolve this cycle in any case by suspending the deserialization of the
type eraser until the point it's demanded by adding
ResolveTypeEraserTypeRequest.

rdar://61270195