### PR TITLE
Add OMPIterator to a few switch cases

### DIFF
--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -447,6 +447,7 @@ OmissionTypeName importer::getClangTypeNameForOmission(clang::ASTContext &ctx,
     // OpenMP types that don't have Swift equivalents.
     case clang::BuiltinType::OMPArraySection:
     case clang::BuiltinType::OMPArrayShaping:
+    case clang::BuiltinType::OMPIterator:
       return OmissionTypeName();
 
     // SVE builtin types that don't have Swift equivalents.

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -321,6 +321,7 @@ namespace {
       // OpenMP types that don't have Swift equivalents.
       case clang::BuiltinType::OMPArraySection:
       case clang::BuiltinType::OMPArrayShaping:
+      case clang::BuiltinType::OMPIterator:
         return Type();
 
       // SVE builtin types that don't have Swift equivalents.


### PR DESCRIPTION
OMPIterator was recently added to upstream clang and thus a few
switch statements need to account for this addition.