### PR TITLE
[CSGen] Bring back performance hack for named patterns with an initializer expression

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2342,15 +2342,17 @@ namespace {
 
         Type openedType = CS.openUnboundGenericType(type, locator);
 
+        auto *subPattern = cast<TypedPattern>(pattern)->getSubPattern();
         // Determine the subpattern type. It will be convertible to the
         // ascribed type.
-        Type subPatternType =
-            getTypeForPattern(
-               cast<TypedPattern>(pattern)->getSubPattern(), locator,
-               Type(), bindPatternVarsOneWay);
+        Type subPatternType = getTypeForPattern(
+            subPattern,
+            locator.withPathElement(LocatorPathElt::PatternMatch(subPattern)),
+            Type(), bindPatternVarsOneWay);
+
         CS.addConstraint(
             ConstraintKind::Conversion, subPatternType, openedType,
-          locator.withPathElement(LocatorPathElt::PatternMatch(pattern)));
+            locator.withPathElement(LocatorPathElt::PatternMatch(pattern)));
         return setType(openedType);
       }
 
@@ -2385,11 +2387,11 @@ namespace {
           if (!externalEltTypes.empty())
             externalEltType = externalEltTypes[i].getPlainType();
 
+          auto *eltPattern = tupleElt.getPattern();
           Type eltTy = getTypeForPattern(
-              tupleElt.getPattern(),
-              locator,
-              externalEltType,
-              bindPatternVarsOneWay);
+              eltPattern,
+              locator.withPathElement(LocatorPathElt::PatternMatch(eltPattern)),
+              externalEltType, bindPatternVarsOneWay);
           tupleTypeElts.push_back(TupleTypeElt(eltTy, tupleElt.getLabel()));
         }
 
@@ -2410,9 +2412,11 @@ namespace {
           externalPatternType = objVar;
         }
 
+        auto *subPattern = cast<OptionalSomePattern>(pattern)->getSubPattern();
         // The subpattern must have optional type.
         Type subPatternType = getTypeForPattern(
-            cast<OptionalSomePattern>(pattern)->getSubPattern(), locator,
+            subPattern,
+            locator.withPathElement(LocatorPathElt::PatternMatch(subPattern)),
             externalPatternType, bindPatternVarsOneWay);
 
         return setType(OptionalType::get(subPatternType));

--- a/validation-test/Sema/type_checker_perf/fast/rdar60961087.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar60961087.swift.gyb
@@ -1,0 +1,18 @@
+// RUN: %scale-test --begin 1 --end 10  --step 1 --select NumLeafScopes %s
+// REQUIRES: asserts,no_asan
+
+func test(_ array: [UInt8]) {
+  var bytes = array.makeIterator()
+
+  while let firstByte = bytes.next() {
+    let secondByte = bytes.next() ?? 0
+
+    let encoded = (
+      (firstByte & 0xF8) >> 3,
+      %for i in range(0, N):
+      ((firstByte & 0x07) << 2) | ((secondByte & 0xC0) >> 6),
+      %end
+      (firstByte & 0xF8) >> 3
+    )
+  }
+}


### PR DESCRIPTION
Unfortunately we still need this performance hack because otherwise
e.g. if initializer returns a tuple its type is going to be connected
to a type variable representing a pattern type, which means all of the
tuple element types are going to form a single constraint system component.

Resolves: rdar://problem/60961087

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
