### PR TITLE
swift-api-checker.py: add -swift-only flag when checking ABI stability

### DIFF
--- a/utils/api_checker/swift-api-checker.py
+++ b/utils/api_checker/swift-api-checker.py
@@ -115,7 +115,8 @@ class DumpConfig:
         if self.platform == 'macosx':
             # We need this input search path for CreateML
             self.inputs.extend([self.sdk + '/usr/lib/swift/'])
-        self.frameworks = []
+        # This is where XCTest is
+        self.frameworks = [self.sdk + '/../../Library/Frameworks/']
         if self.platform.startswith('iosmac'):
             # Catalyst modules need this extra framework dir
             iOSSupport = self.sdk + \

--- a/utils/api_checker/swift-api-checker.py
+++ b/utils/api_checker/swift-api-checker.py
@@ -151,7 +151,7 @@ class DumpConfig:
         for path in self.inputs:
             cmd.extend(['-I', path])
         if self.abi:
-            cmd.extend(['-abi'])
+            cmd.extend(['-abi', '-swift-only'])
         cmd.extend(['-' + o for o in opts])
         if self.verbose:
             cmd.extend(['-v'])


### PR DESCRIPTION
 The existing logic of ABI checking only works for Swift symbols. We need to add this flag so the script can work with Swift overlays.
 
rdar://60786484