### PR TITLE
Convert a clang::Module to non-const to account for a clang API change

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3305,7 +3305,7 @@ ClangModuleUnit::ClangModuleUnit(ModuleDecl &M,
     clangModule(clangModule) {
   // Capture the file metadata before it goes away.
   if (clangModule)
-    ASTSourceDescriptor = {*clangModule};
+    ASTSourceDescriptor = {*const_cast<clang::Module *>(clangModule)};
 }
 
 StringRef ClangModuleUnit::getModuleDefiningPath() const {


### PR DESCRIPTION
An upstream clang changed ASTSourceDescriptor to not have a const
Module pointer. const_cast here to make this agree.

`const_cast` obviously isn't ideal, but the inverse direction (changing all the Swift APIs to not be const) used considerably more `const_cast`s anyways. Doing this without `const_cast` would be a much bigger change.