### PR TITLE
[TBDGen] update tbd version

### DIFF
--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -1102,7 +1102,7 @@ GenerateTBDRequest::evaluate(Evaluator &evaluator,
                                 /*forcePublicDecls*/ false);
 
   llvm::MachO::InterfaceFile file;
-  file.setFileType(llvm::MachO::FileType::TBD_V3);
+  file.setFileType(llvm::MachO::FileType::TBD_V4);
   file.setApplicationExtensionSafe(
     isApplicationExtensionSafe(M->getASTContext().LangOpts));
   file.setInstallName(opts.InstallName);

--- a/test/TBD/app-extension.swift
+++ b/test/TBD/app-extension.swift
@@ -10,6 +10,7 @@
 // NOTEXTENSIONSAFE: not_app_extension_safe
 
 // RUN: %target-swift-frontend -target-variant x86_64-apple-ios13.0-macabi -typecheck %s -application-extension -emit-tbd -emit-tbd-path %t/target-variant.tbd
-// RUN: %FileCheck %s --check-prefix ZIPPERED < %t/target-variant.tbd
+// RUN: %FileCheck %s --check-prefix MACABI < %t/target-variant.tbd
 
-// ZIPPERED: platform: zippered
+// MACABI: targets: [ {{.*}}macos{{.*}}maccatalyst{{.*}} ]
+

--- a/test/TBD/arm64e-arch.swift
+++ b/test/TBD/arm64e-arch.swift
@@ -2,6 +2,6 @@
 
 public func testSwiftFunc() {}
 
-// CHECK: --- !tapi-tbd-v3
-// CHECK: archs: [ arm64e ]
+// CHECK: --- !tapi-tbd
+// CHECK: arm64e
 // CHECK: symbols: [ '_$s{{.*}}testSwiftFunc{{.*}}' ]


### PR DESCRIPTION
Short overview of new TBD-v4 format changes:

* section for reexported symbols (which is not seen any
differently to the linker)
  * reexported libraries are still sectioned seperately 
* target based slices as opposed to just architecture
* no more indirection of recognizing simulator platforms 

more information in: rdar://problem/60586390