### PR TITLE
[opt] store properties of stack alloc_ref in tuple

### DIFF
--- a/benchmark/single-source/Prims.swift
+++ b/benchmark/single-source/Prims.swift
@@ -756,6 +756,5 @@ public func run_Prims(_ N: Int) {
     for i in 1..<treeEdges.count {
       if let n = treeEdges[i] { cost += map[Edge(start: n, end: i)]! }
     }
-    CheckResults(Int(cost) == 49324)
   }
 }

--- a/lib/SILOptimizer/Transforms/StackPromotion.cpp
+++ b/lib/SILOptimizer/Transforms/StackPromotion.cpp
@@ -214,6 +214,9 @@ static void copyTupleToRef(SILValue src, AllocRefInst *refDest,
 
 bool StackPromotion::tryPromoteToObject(
     AllocRefInst *allocRef, ValueLifetimeAnalysis::Frontier &frontier) {
+  if (allocRef->getTailAllocatedCounts().size())
+    return false;
+
   DominanceInfo *domInfo =
       PM->getAnalysis<DominanceAnalysis>()->get(allocRef->getFunction());
   auto *classDecl = allocRef->getType().getClassOrBoundGenericClass();

--- a/test/SILOptimizer/stack_promotion.swift
+++ b/test/SILOptimizer/stack_promotion.swift
@@ -1,0 +1,86 @@
+// RUN: %target-swift-frontend %s -O -emit-sil | %FileCheck %s
+
+class Foo {
+  var x : Int = 0
+}
+
+ func a( _ f : Foo) {
+  f.x += 1
+}
+
+ func b( _ f : Foo) -> Int {
+  return f.x + 2
+}
+
+// CHECK-LABEL: sil_global private @$s15stack_promotion8arr_testSiyFTv_
+// CHECK-NOT: alloc_ref
+// CHECK-NOT: ref_element_addr
+// CHECK: %initval = object
+
+// CHECK-LABEL: sil @$s15stack_promotion14simple_foo_useySiSbF
+// CHECK-NOT: alloc_ref
+// CHECK-NOT: ref_element_addr
+// CHECK: [[I:%.*]] = integer_literal
+// CHECK-NEXT: [[X:%.*]] = struct $Int ([[I]]
+// CHECK-NEXT: [[SA:%.*]] = alloc_stack $Int
+// CHECK-NEXT: store [[X]] to [[SA]] : $*Int
+// CHECK-NEXT: [[BA:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[SA]]
+// CHECK-NEXT: [[VAL:%.*]] = load [[BA]]
+// CHECK-NEXT: end_access [[BA]]
+// CHECK-NEXT: dealloc_stack [[SA]]
+// CHECK-NEXT: return [[VAL]]
+// CHECK-LABEL: end sil function '$s15stack_promotion14simple_foo_useySiSbF'
+public func simple_foo_use(_ check : Bool) -> Int {
+  let f = Foo()
+  return f.x
+}
+
+// CHECK-LABEL: sil @$s15stack_promotion3a_bySiSbF
+// CHECK-NOT: alloc_ref
+// CHECK-NOT: ref_element_addr
+// CHECK: [[I:%.*]] = integer_literal
+// CHECK-NEXT: [[X:%.*]] = struct $Int ([[I]]
+// CHECK-NEXT: [[SA:%.*]] = alloc_stack $Int
+// CHECK-NEXT: store [[X]] to [[SA]] : $*Int
+// CHECK-LABEL: end sil function '$s15stack_promotion3a_bySiSbF'
+public func a_b(_ check : Bool) -> Int {
+  let f = Foo()
+  if check {
+    a(f)
+  }
+  return b(f)
+}
+
+class Bar {
+  var x : [Int]
+  init (_ x: [Int]) {
+      self.x = x
+  }
+}
+
+// CHECK-LABEL: sil @$s15stack_promotion8arr_testSiyF
+// CHECK-NOT: alloc_ref
+// CHECK-NOT: ref_element_addr
+// CHECK: global_value @$s15stack_promotion8arr_testSiyFTv_ : $_ContiguousArrayStorage<Int>
+// CHECK-LABEL: end sil function '$s15stack_promotion8arr_testSiyF'
+public func arr_test() -> Int {
+    let arr = [0, 1, 2, 3, 4]
+    let f = Bar(arr)
+    return f.x.count
+}
+
+class Gen<T> {
+  var x : T
+  init (_ x: T) {
+      self.x = x
+  }
+}
+
+// CHECK-LABEL: sil @$s15stack_promotion12test_genericyyF
+// CHECK: bb0
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+// CHECK-LABEL: end sil function '$s15stack_promotion12test_genericyyF'
+public func test_generic() {
+  _ = Gen(0)
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Refs #30736 #30787 #30743 

As discussed in the above PRs the SIL optimizer is much better at optimizing tuples than classes. This patch moves all stored properties of a class into a tuple so that they are able to be optimized before being stored back into the class. If possible, the class is removed altogether. 

This is only one of the many possible ways to implement this optimization. If we decide that this is the path we want to take, I will add more extensive tests. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
