### PR TITLE
[SR-12242] Apply to Arg involving ConstraintLocator::GenericArgument diagnostics improvement

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -667,12 +667,6 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
     }
 
     case ConstraintLocator::GenericArgument: {
-      // In cases like `[[Int]]` vs. `[[String]]`
-      if (auto *assignExpr = dyn_cast<AssignExpr>(anchor)) {
-        diagnostic = getDiagnosticFor(CTP_AssignSource);
-        fromType = getType(assignExpr->getSrc());
-        toType = getType(assignExpr->getDest());
-      }
       break;
     }
 
@@ -704,13 +698,20 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
   }
 
   if (!diagnostic) {
-    // If we couldn't find a specific diagnostic let's fallback to
-    // attempt to handle cases where we have an apply arg to param.
-    auto applyInfo = getFunctionArgApplyInfo(getLocator());
-    if (applyInfo) {
-      diagnostic = diag::cannot_convert_argument_value;
-      fromType = applyInfo->getArgType();
-      toType = applyInfo->getParamType();
+    // In cases like `[[Int]]` vs. `[[String]]`
+    if (auto *assignExpr = dyn_cast<AssignExpr>(anchor)) {
+      diagnostic = getDiagnosticFor(CTP_AssignSource);
+      fromType = getType(assignExpr->getSrc());
+      toType = getType(assignExpr->getDest());
+    } else {
+      // If we couldn't find a specific diagnostic let's fallback to
+      // attempt to handle cases where we have an apply arg to param.
+      auto applyInfo = getFunctionArgApplyInfo(getLocator());
+      if (applyInfo) {
+        diagnostic = diag::cannot_convert_argument_value;
+        fromType = applyInfo->getArgType();
+        toType = applyInfo->getParamType();
+      }
     }
   }
   

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -675,6 +675,9 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
       // InoutToPointer argument mismatch failure.
       if (isa<InOutExpr>(anchor)) {
         diagnostic = diag::cannot_convert_argument_value;
+        auto applyInfo = getFunctionArgApplyInfo(getLocator());
+        if (applyInfo)
+          toType = applyInfo->getParamType();
       }
       break;
     }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -698,7 +698,7 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
   }
 
   if (!diagnostic) {
-    // In cases like `[[Int]]` vs. `[[String]]`
+    // Handle all mismatches involving an `AssignExpr`
     if (auto *assignExpr = dyn_cast<AssignExpr>(anchor)) {
       diagnostic = getDiagnosticFor(CTP_AssignSource);
       fromType = getType(assignExpr->getSrc());

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -672,10 +672,33 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
         diagnostic = getDiagnosticFor(CTP_AssignSource);
         fromType = getType(assignExpr->getSrc());
         toType = getType(assignExpr->getDest());
+      } else {
+        // Handle cases where we have an apply arg to param
+        if (!path.empty() &&
+            path.front().getKind() == ConstraintLocator::ApplyArgument) {
+          auto &cs = getConstraintSystem();
+          auto applyArgPath = path.drop_back();
+
+          if (!applyArgPath.empty()) {
+            auto applyArg =
+                applyArgPath.back().getAs<LocatorPathElt::ApplyArgToParam>();
+            if (!applyArg)
+              break;
+
+            auto calleeLocator = cs.getCalleeLocator(getLocator());
+            auto calleeType =
+                getType(calleeLocator->getAnchor())->getAs<FunctionType>();
+
+            diagnostic = diag::cannot_convert_argument_value;
+            fromType = getType(anchor);
+            toType = calleeType->getParams()[applyArg->getParamIdx()]
+                         .getParameterType();
+          }
+        }
       }
       break;
     }
-    
+
     case ConstraintLocator::OptionalPayload: {
       // If we have an inout expression, this comes from an
       // InoutToPointer argument mismatch failure.

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1415,3 +1415,17 @@ f11(3, f4) // expected-error {{global function 'f11' requires that 'Int' conform
 let f12: (Int) -> Void = { _ in }
 func f12<T : P2>(_ n: T, _ f: @escaping (T) -> T) {}
 f12(3, f4)// expected-error {{extra argument in call}}
+
+// SR-12242
+struct SR_12242_R<Value> {}
+struct SR_12242_T {}
+
+protocol SR_12242_P {}
+
+func fSR_12242() -> SR_12242_R<[SR_12242_T]> {}
+
+func genericFunc<SR_12242_T: SR_12242_P>(_ completion:  @escaping (SR_12242_R<[SR_12242_T]>) -> Void) {
+  let t = fSR_12242()
+  completion(t) // expected-error {{cannot convert value of type 'diagnostics.SR_12242_R<[diagnostics.SR_12242_T]>' to expected argument type 'diagnostics.SR_12242_R<[SR_12242_T]>'}}
+  // expected-note@-1 {{arguments to generic parameter 'Element' ('diagnostics.SR_12242_T' and 'SR_12242_T') are expected to be equal}}
+}

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1443,3 +1443,30 @@ func assignGenericMismatch() {
   // expected-note@-3 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
   // expected-note@-4 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
 }
+
+// [Int] to [String]? argument to param conversion
+let value: [Int] = []
+func gericArgToParamOptional(_ param: [String]?) {}
+
+gericArgToParamOptional(value) // expected-error {{convert value of type '[Int]' to expected argument type '[String]?'}}
+// expected-note@-1 {{arguments to generic parameter 'Element' ('Int' and 'String') are expected to be equal}}
+
+// Inout Expr conversions
+func gericArgToParamInout1(_ x: inout [[Int]]) {}
+func gericArgToParamInout2(_ x: inout [[String]]) {
+  gericArgToParamInout1(&x) // expected-error {{cannot convert value of type '[[String]]' to expected argument type '[[Int]]'}}
+  // expected-note@-1 {{arguments to generic parameter 'Element' ('String' and 'Int') are expected to be equal}}
+}
+
+func gericArgToParamInoutOptional(_ x: inout [[String]]?) {
+  gericArgToParamInout1(&x) // expected-error {{cannot convert value of type '[[String]]?' to expected argument type '[[Int]]'}}
+  // expected-note@-1 {{arguments to generic parameter 'Element' ('String' and 'Int') are expected to be equal}}
+  // expected-error@-2 {{value of optional type '[[String]]?' must be unwrapped to a value of type '[[String]]'}}
+  // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+}
+
+func gericArgToParamInout(_ x: inout [[Int]]) { // expected-note {{change variable type to '[[String]]?' if it doesn't need to be declared as '[[Int]]'}}
+  gericArgToParamInoutOptional(&x) // expected-error {{cannot convert value of type '[[Int]]' to expected argument type '[[String]]?'}}
+  // expected-note@-1 {{arguments to generic parameter 'Element' ('Int' and 'String') are expected to be equal}}
+  // expected-error@-2 {{inout argument could be set to a value with a type other than '[[Int]]'; use a value declared as type '[[String]]?' instead}}
+}

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1429,3 +1429,17 @@ func genericFunc<SR_12242_T: SR_12242_P>(_ completion:  @escaping (SR_12242_R<[S
   completion(t) // expected-error {{cannot convert value of type 'diagnostics.SR_12242_R<[diagnostics.SR_12242_T]>' to expected argument type 'diagnostics.SR_12242_R<[SR_12242_T]>'}}
   // expected-note@-1 {{arguments to generic parameter 'Element' ('diagnostics.SR_12242_T' and 'SR_12242_T') are expected to be equal}}
 }
+
+func assignGenericMismatch() {
+  var a: [Int]?
+  var b: [String]
+
+  a = b // expected-error {{cannot assign value of type '[String]' to type '[Int]?'}}
+  // expected-note@-1 {{arguments to generic parameter 'Element' ('String' and 'Int') are expected to be equal}}
+
+  b = a // expected-error {{cannot assign value of type '[Int]' to type '[String]'}}
+  // expected-note@-1 {{arguments to generic parameter 'Element' ('Int' and 'String') are expected to be equal}}
+  // expected-error@-2 {{value of optional type '[Int]?' must be unwrapped to a value of type '[Int]'}}
+  // expected-note@-3 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+  // expected-note@-4 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+}

--- a/test/Constraints/valid_pointer_conversions.swift
+++ b/test/Constraints/valid_pointer_conversions.swift
@@ -31,7 +31,7 @@ func givesPtr(_ str: String) {
   takesDoubleOptionalPtr(i) // expected-error {{cannot convert value of type 'Int' to expected argument type 'UnsafeRawPointer??'}}
   takesMutableDoubleOptionalPtr(arr) // expected-error {{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutableRawPointer??'}}
 
-  takesMutableDoubleOptionalTypedPtr(&i) // expected-error {{cannot convert value of type 'UnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<Double>'}}
+  takesMutableDoubleOptionalTypedPtr(&i) // expected-error {{cannot convert value of type 'UnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<Double>??'}}
   // expected-note@-1 {{arguments to generic parameter 'Pointee' ('Int' and 'Double') are expected to be equal}}
 }
 
@@ -39,5 +39,5 @@ func givesPtr(_ str: String) {
 func SR12382(_ x: UnsafeMutablePointer<Double>??) {}
 
 var i = 0
-SR12382(&i) // expected-error {{cannot convert value of type 'UnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<Double>'}}
+SR12382(&i) // expected-error {{cannot convert value of type 'UnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<Double>??'}}
 // expected-note@-1 {{arguments to generic parameter 'Pointee' ('Int' and 'Double') are expected to be equal}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Just improving diagnostics for Generic Mismatch involving argument conversion. 

cc @xedin @hborla :)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-12242.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
