### PR TITLE
Improve usability of _mangledTypeName with Any.Type arguments

### DIFF
--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -86,7 +86,7 @@ public func _getMangledTypeName(_ type: Any.Type)
 /// Returns the mangled name for a given type.
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 public // SPI
-func _mangledTypeName<T>(_ type: T.Type) -> String? {
+func _mangledTypeName(_ type: Any.Type) -> String? {
   let (stringPtr, count) = _getMangledTypeName(type)
   guard count > 0 else {
     return nil

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -467,6 +467,11 @@ if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
       expectEqual("Int", _typeName(Int.self, qualified: false))
     }
   }
+
+  DemangleToMetadataTests.test("Check _mangledTypeName with Any.Type") {
+    let type: Any.Type = Int.self
+    expectEqual("Si", _mangledTypeName(type))
+  }
 }
 
 


### PR DESCRIPTION
Minor follow up to https://github.com/apple/swift/pull/30318 which introduced _mangledTypeName.

We realized when using it in a real project that invoking it with an `Any.Type` was not working well since:

```
57: error: cannot convert value of type 'Any.Type' to expected argument type 'T.Type'
```

Since the API works on Any.Types anyway, it makes more sense to allow passing in anything.

Please sanity check @milseman @jckarter 