### PR TITLE
[benchmark] Change selection of non-skipped ParseInt benchmarks

### DIFF
--- a/benchmark/single-source/IntegerParsing.swift
+++ b/benchmark/single-source/IntegerParsing.swift
@@ -119,7 +119,7 @@ public let IntegerParsing = [
   }),
   BenchmarkInfo(name: "ParseInt.Int64.Hex",
     runFunction: run_ParseIntFromInt64Hex,
-    tags: [.validation, .api],
+    tags: [.validation, .api, .skip],
     setUpFunction: {
       blackHole(int64ValuesSum)
       blackHole(int64HexStrings)
@@ -148,7 +148,7 @@ public let IntegerParsing = [
   }),
   BenchmarkInfo(name: "ParseInt.UInt32.Hex",
     runFunction: run_ParseIntFromUInt32Hex,
-    tags: [.validation, .api],
+    tags: [.validation, .api, .skip],
     setUpFunction: {
       blackHole(uint32ValuesSum)
       blackHole(uint32HexStrings)
@@ -163,7 +163,7 @@ public let IntegerParsing = [
   // UInt64
   BenchmarkInfo(name: "ParseInt.UInt64.Decimal",
     runFunction: run_ParseIntFromUInt64Decimal,
-    tags: [.validation, .api, .skip],
+    tags: [.validation, .api],
     setUpFunction: {
       blackHole(uint64ValuesSum)
       blackHole(uint64DecimalStrings)
@@ -177,7 +177,7 @@ public let IntegerParsing = [
   }),
   BenchmarkInfo(name: "ParseInt.UInt64.Hex",
     runFunction: run_ParseIntFromUInt64Hex,
-    tags: [.validation, .api, .skip],
+    tags: [.validation, .api],
     setUpFunction: {
       blackHole(uint64ValuesSum)
       blackHole(uint64HexStrings)


### PR DESCRIPTION
<!-- What's in this pull request? -->
An update to #29988 in which benchmarks are selected as the representative 5. The new list is now:
- Small signed decimal
- **UInt64 decimal**
- **UInt64 hex**
- Small unsigned binary
- Small signed uncommon radix

The original PR (inadvertently) had two large hex tests and no large decimal test as primary.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
