### PR TITLE
[benchmark] Premultiply N for case conversion benchmark

### DIFF
--- a/benchmark/single-source/AngryPhonebook.swift
+++ b/benchmark/single-source/AngryPhonebook.swift
@@ -26,7 +26,7 @@ public let AngryPhonebook = [
   // Small String Workloads
   BenchmarkInfo(
     name: "AngryPhonebook.ASCII.Small",
-    runFunction: { angryPhonebook($0, ascii) },
+    runFunction: { angryPhonebook($0*10, ascii) },
     tags: t,
     setUpFunction: { blackHole(ascii) }),
   BenchmarkInfo(
@@ -48,7 +48,7 @@ public let AngryPhonebook = [
   // Regular String Workloads
   BenchmarkInfo(
     name: "AngryPhonebook.ASCII",
-    runFunction: { angryPhonebook($0, precomposed: longASCII) },
+    runFunction: { angryPhonebook($0*10, precomposed: longASCII) },
     tags: t,
     setUpFunction: { blackHole(longASCII) }),
   BenchmarkInfo(

--- a/benchmark/single-source/AngryPhonebook.swift
+++ b/benchmark/single-source/AngryPhonebook.swift
@@ -25,7 +25,7 @@ public let AngryPhonebook = [
 
   // Small String Workloads
   BenchmarkInfo(
-    name: "AngryPhonebook.ASCII.Small",
+    name: "AngryPhonebook.ASCII2.Small",
     runFunction: { angryPhonebook($0*10, ascii) },
     tags: t,
     setUpFunction: { blackHole(ascii) }),
@@ -47,7 +47,7 @@ public let AngryPhonebook = [
 
   // Regular String Workloads
   BenchmarkInfo(
-    name: "AngryPhonebook.ASCII",
+    name: "AngryPhonebook.ASCII2",
     runFunction: { angryPhonebook($0*10, precomposed: longASCII) },
     tags: t,
     setUpFunction: { blackHole(longASCII) }),


### PR DESCRIPTION
<!-- What's in this pull request? -->
The `AngryPhonebook.ASCII` & `AngryPhonebook.ASCII.Small` test were running in 14 & 20ms, respectively, which I hard multiplied with 10 to get a better range.

From the docs it seems the benchmark suite should scale these up automatically but that doesn't seem to be happening, or at least not accurately, for this case.

This in anticipation of an upcoming performance improvement for ASCII case conversion.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
