### PR TITLE
[AutoDiff upstream] Update LoadableByAddress.

### DIFF
--- a/test/AutoDiff/IRGen/Inputs/loadable_by_address_cross_module.swift
+++ b/test/AutoDiff/IRGen/Inputs/loadable_by_address_cross_module.swift
@@ -1,0 +1,28 @@
+import _Differentiation
+
+public struct LargeLoadableType<T>: AdditiveArithmetic, Differentiable {
+  public var a, b, c, d, e: Float
+
+  public init(a: Float) {
+    self.a = a
+    self.b = 0
+    self.c = 0
+    self.d = 0
+    self.e = 0
+  }
+
+  @differentiable
+  public func externalLBAModifiedFunction(_ x: Float) -> Float {
+    return x * a
+  }
+
+  // TODO(TF-1226): Remove custom derivative when stdlib derivatives are upstreamed.
+  @usableFromInline
+  @derivative(of: externalLBAModifiedFunction)
+  func externalLBAModifiedFunctionVJP(_ x: Float) -> (
+    value: Float, pullback: (Float) -> (Self, Float)
+  ) {
+    let value = externalLBAModifiedFunction(x)
+    return (value, { v in (Self(a: v * x), v * a) })
+  }
+}

--- a/test/AutoDiff/IRGen/loadable_by_address.swift
+++ b/test/AutoDiff/IRGen/loadable_by_address.swift
@@ -1,0 +1,76 @@
+// RUN: %target-swift-frontend -c -enable-large-loadable-types -Xllvm -sil-verify-after-pass=loadable-address %s
+// RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s -check-prefix=CHECK-SIL
+// RUN: %target-swift-frontend -c -Xllvm -sil-print-after=loadable-address %s 2>&1 | %FileCheck %s -check-prefix=CHECK-LBA-SIL
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+// TF-11: Verify that LoadableByAddress works with differentiation-related instructions:
+// - `differentiable_function`
+// - `differentiable_function_extract`
+
+// TODO: Add tests for `@differentiable(linear)` functions.
+
+import _Differentiation
+import StdlibUnittest
+
+var LBATests = TestSuite("LoadableByAddress")
+
+// `Large` is a large loadable type.
+// `Large.TangentVector` is not a large loadable type.
+struct Large : Differentiable {
+  var a: Float
+  var b: Float
+  var c: Float
+  var d: Float
+  @noDerivative let e: Float
+}
+
+@_silgen_name("large2large")
+@differentiable
+func large2large(_ foo: Large) -> Large {
+  foo
+}
+
+// `large2large` old verification error:
+// SIL verification failed: JVP type does not match expected JVP type
+// $@callee_guaranteed (@in_constant Large) -> (Large, @owned @callee_guaranteed (Large.TangentVector) -> Large.TangentVector)
+// $@callee_guaranteed (@in_constant Large) -> (@out Large, @owned @callee_guaranteed (@in_constant Large.TangentVector) -> @out Large.TangentVector)
+
+@_silgen_name("large2small")
+@differentiable
+func large2small(_ foo: Large) -> Float {
+  foo.a
+}
+
+// `large2small` old verification error:
+// SIL verification failed: JVP type does not match expected JVP type
+//   $@callee_guaranteed (@in_constant Large) -> (Float, @owned @callee_guaranteed (Large.TangentVector) -> Float)
+//   $@callee_guaranteed (@in_constant Large) -> (Float, @owned @callee_guaranteed (@in_constant Large.TangentVector) -> Float)
+
+// CHECK-SIL: sil hidden @large2large : $@convention(thin) (Large) -> Large {
+// CHECK-LBA-SIL: sil hidden @large2large : $@convention(thin) (@in_constant Large) -> @out Large {
+
+// CHECK-SIL-LABEL: sil hidden @large2small : $@convention(thin) (Large) -> Float {
+// CHECK-LBA-SIL: sil hidden @large2small : $@convention(thin) (@in_constant Large) -> Float {
+
+// CHECK-SIL: sil hidden @AD__large2large__jvp_src_0_wrt_0 : $@convention(thin) (Large) -> (Large, @owned @callee_guaranteed (Large.TangentVector) -> Large.TangentVector) {
+// CHECK-LBA-SIL: sil hidden @AD__large2large__jvp_src_0_wrt_0 : $@convention(thin) (@in_constant Large) -> (Large, @owned @callee_guaranteed (Large.TangentVector) -> Large.TangentVector) {
+
+// CHECK-SIL: sil hidden @AD__large2large__vjp_src_0_wrt_0 : $@convention(thin) (Large) -> (Large, @owned @callee_guaranteed (Large.TangentVector) -> Large.TangentVector) {
+// CHECK-LBA-SIL: sil hidden @AD__large2large__vjp_src_0_wrt_0 : $@convention(thin) (@in_constant Large) -> (Large, @owned @callee_guaranteed (Large.TangentVector) -> Large.TangentVector) {
+
+// CHECK-SIL: sil hidden @AD__large2small__jvp_src_0_wrt_0 : $@convention(thin) (Large) -> (Float, @owned @callee_guaranteed (Large.TangentVector) -> Float) {
+// CHECK-LBA-SIL: sil hidden @AD__large2small__jvp_src_0_wrt_0 : $@convention(thin) (@in_constant Large) -> (Float, @owned @callee_guaranteed (Large.TangentVector) -> Float) {
+
+// CHECK-SIL: sil hidden @AD__large2small__vjp_src_0_wrt_0 : $@convention(thin) (Large) -> (Float, @owned @callee_guaranteed (Float) -> Large.TangentVector) {
+// CHECK-LBA-SIL: sil hidden @AD__large2small__vjp_src_0_wrt_0 : $@convention(thin) (@in_constant Large) -> (Float, @owned @callee_guaranteed (Float) -> Large.TangentVector) {
+
+LBATests.test("Correctness") {
+  let one = Large.TangentVector(a: 1, b: 1, c: 1, d: 1)
+  expectEqual(one,
+              pullback(at: Large(a: 0, b: 0, c: 0, d: 0, e: 0), in: large2large)(one))
+  expectEqual(Large.TangentVector(a: 1, b: 0, c: 0, d: 0),
+              gradient(at: Large(a: 0, b: 0, c: 0, d: 0, e: 0), in: large2small))
+}
+
+runAllTests()

--- a/test/AutoDiff/IRGen/loadable_by_address.swift
+++ b/test/AutoDiff/IRGen/loadable_by_address.swift
@@ -4,6 +4,9 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// `isLargeLoadableType` depends on the ABI and differs between architectures.
+// REQUIRES: CPU=x86_64
+
 // TF-11: Verify that LoadableByAddress works with differentiation-related instructions:
 // - `differentiable_function`
 // - `differentiable_function_extract`

--- a/test/AutoDiff/IRGen/loadable_by_address_cross_module.swift
+++ b/test/AutoDiff/IRGen/loadable_by_address_cross_module.swift
@@ -1,0 +1,45 @@
+// First, check that LBA actually modifies the function, so that this test is useful.
+
+// RUN: %target-swift-frontend -emit-sil %S/Inputs/loadable_by_address_cross_module.swift | %FileCheck %s -check-prefix=CHECK-MODULE-PRE-LBA
+// RUN: %target-swift-frontend -c -Xllvm -sil-print-after=loadable-address %S/Inputs/loadable_by_address_cross_module.swift 2>&1 | %FileCheck %s -check-prefix=CHECK-MODULE-POST-LBA
+
+// CHECK-MODULE-PRE-LBA: sil {{.*}}LBAModifiedFunction{{.*}} $@convention(method) <T> (Float, LargeLoadableType<T>) -> Float
+// CHECK-MODULE-POST-LBA: sil {{.*}}LBAModifiedFunction{{.*}} $@convention(method) <T> (Float, @in_constant LargeLoadableType<T>) -> Float
+
+// Compile the module.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -working-directory %t -parse-as-library -emit-module -module-name external -emit-module-path %t/external.swiftmodule -emit-library -static %S/Inputs/loadable_by_address_cross_module.swift
+
+// Next, check that differentiability_witness_functions in the client get
+// correctly modified by LBA.
+
+// RUN: %target-swift-frontend -emit-sil -I%t %s
+// RUN: %target-swift-frontend -emit-sil -I%t %s | %FileCheck %s -check-prefix=CHECK-CLIENT-PRE-LBA
+// RUN: %target-swift-frontend -c -I%t %s -Xllvm -sil-print-after=loadable-address 2>&1 | %FileCheck %s -check-prefix=CHECK-CLIENT-POST-LBA
+
+// CHECK-CLIENT-PRE-LBA: differentiability_witness_function [jvp] [parameters 0 1] [results 0] <T> @${{.*}}LBAModifiedFunction{{.*}} : $@convention(method) <τ_0_0> (Float, LargeLoadableType<τ_0_0>) -> Float
+// CHECK-CLIENT-PRE-LBA: differentiability_witness_function [vjp] [parameters 0 1] [results 0] <T> @${{.*}}LBAModifiedFunction{{.*}} : $@convention(method) <τ_0_0> (Float, LargeLoadableType<τ_0_0>) -> Float
+
+// CHECK-CLIENT-POST-LBA: differentiability_witness_function [jvp] [parameters 0 1] [results 0] <T> @$s8external17LargeLoadableTypeV0A19LBAModifiedFunctionyS2fF : $@convention(method) <τ_0_0> (Float, @in_constant LargeLoadableType<τ_0_0>) -> Float as $@convention(method) <τ_0_0> (Float, @in_constant LargeLoadableType<τ_0_0>) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (Float, τ_0_0) -> Float for <LargeLoadableType<τ_0_0>>)
+// CHECK-CLIENT-POST-LBA: differentiability_witness_function [vjp] [parameters 0 1] [results 0] <T> @$s8external17LargeLoadableTypeV0A19LBAModifiedFunctionyS2fF : $@convention(method) <τ_0_0> (Float, @in_constant LargeLoadableType<τ_0_0>) -> Float as $@convention(method) <τ_0_0> (Float, @in_constant LargeLoadableType<τ_0_0>) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (Float) -> (Float, τ_0_0) for <LargeLoadableType<τ_0_0>>)
+
+// Finally, execute the test.
+
+// RUN: %target-build-swift -I%t -L%t %s -o %t/a.out -lm -lexternal
+// RUN: %target-run %t/a.out
+
+// REQUIRES: executable_test
+
+import _Differentiation
+import external
+import StdlibUnittest
+
+var LBATests = TestSuite("LoadableByAddressCrossModule")
+
+LBATests.test("Correctness") {
+  let g = gradient(at: LargeLoadableType<Int>(a: 5), 10) { $0.externalLBAModifiedFunction($1) }
+  expectEqual((LargeLoadableType<Int>(a: 10), 5), g)
+}
+
+runAllTests()


### PR DESCRIPTION
Update LoadableByAddress to handle AutoDiff-related instructions:
- `differentiable_function`
- `differentiable_function_extract`
- `linear_function`
- `linear_function_extract`
- `differentiability_witness_function`

Add tests.