### PR TITLE
Opaque type substitution also needs to take the access of a opaque ty…

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2932,9 +2932,15 @@ substOpaqueTypesWithUnderlyingTypes(Type ty, const DeclContext *inContext,
 static bool canSubstituteTypeInto(Type ty, const DeclContext *dc,
                                   OpaqueSubstitutionKind kind,
                                   bool isContextWholeModule) {
-  auto nominal = ty->getAnyNominal();
-  if (!nominal)
+  ValueDecl *nominal = ty->getAnyNominal();
+  if (!nominal) {
+    // We also need to check that the opaque type descriptor is accessible.
+    if (auto opaqueTy = ty->getAs<OpaqueTypeArchetypeType>())
+      nominal = opaqueTy->getDecl();
+  }
+  if (!nominal) {
     return true;
+  }
 
   switch (kind) {
   case OpaqueSubstitutionKind::DontSubstitute:

--- a/test/IRGen/Inputs/opaque_result_type_private_underlying_3.swift
+++ b/test/IRGen/Inputs/opaque_result_type_private_underlying_3.swift
@@ -1,0 +1,26 @@
+import Repo1
+
+public extension MyThing {
+  enum MyEnum {
+    case mycase
+
+    private struct MyPrivateThing : Q {
+      init() {
+      }
+
+      var thing: some Q {
+        return self
+      }
+    }
+
+    private var data: MyPrivateThing {
+      switch self {
+      case .mycase: return MyPrivateThing()
+      }
+    }
+
+    public var thing: some Q {
+      self.data.thing
+    }
+  }
+}

--- a/test/IRGen/opaque_result_type_private_underlying.swift
+++ b/test/IRGen/opaque_result_type_private_underlying.swift
@@ -5,6 +5,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -disable-availability-checking -enable-library-evolution -emit-module -emit-module-path=%t/Repo1.swiftmodule -module-name=Repo1 %S/Inputs/opaque_result_type_private_underlying_2.swift
 // RUN: %target-swift-frontend -disable-availability-checking -I %t -emit-ir -primary-file %s  -DUSEMODULE | %FileCheck %s --check-prefix=RESILIENT
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -disable-availability-checking -enable-library-evolution -emit-module -emit-module-path=%t/Repo1.swiftmodule -module-name=Repo1 %S/Inputs/opaque_result_type_private_underlying_2.swift
+// RUN: %target-swift-frontend -disable-availability-checking -I %t -emit-ir -primary-file %s -primary-file %S/Inputs/opaque_result_type_private_underlying_3.swift -DUSEMODULE -DUSESECONDFILE | %FileCheck %s --check-prefix=RESILIENT
 
 #if USEMODULE
 import Repo1
@@ -49,3 +52,19 @@ public struct UsePrivate: A {
     return PrivateUnderlying().bindAssoc()
   }
 }
+
+#if USESECONDFILE
+public struct MyThing {
+    public let which: MyEnum
+    public init(_ which: MyEnum) {
+      self.which = which
+    }
+
+    public var body: some Q {
+        self.thing
+    }
+    public var thing: some Q {
+        self.which.thing
+    }
+}
+#endif


### PR DESCRIPTION
…pe decl into account.

Otherwise, we can access an opaque type descriptor that is private to a
translation unit.

rdar://60123853