### PR TITLE
Disabled tests failing from missing objc symbol.

### DIFF
--- a/test/Runtime/superclass_constraint_metadata_resilient_superclass2_future.swift
+++ b/test/Runtime/superclass_constraint_metadata_resilient_superclass2_future.swift
@@ -11,6 +11,7 @@
 // RUN: %target-run %t/main | %FileCheck %S/Inputs/print_subclass/main.swift
 
 // REQUIRES: executable_test
+// REQUIRES: rdar61345988
 
 // REQUIRES: OS=macosx
 // Testing runtime changes that aren't in the os stdlib.

--- a/test/Runtime/superclass_constraint_metadata_resilient_superclass_future.swift
+++ b/test/Runtime/superclass_constraint_metadata_resilient_superclass_future.swift
@@ -8,6 +8,7 @@
 // RUN: %target-run %t/main | %FileCheck %S/Inputs/print_subclass/main.swift
 
 // REQUIRES: executable_test
+// REQUIRES: rdar61345988
 
 // REQUIRES: OS=macosx
 // Testing runtime changes that aren't in the os stdlib.


### PR DESCRIPTION
Two tests are currently failing with

```
dyld: lazy symbol binding failed: Symbol not found: _objc_opt_self
  Expected in: /usr/lib/libobjc.A.dylib

dyld: Symbol not found: _objc_opt_self
  Expected in: /usr/lib/libobjc.A.dylib
```

Here, they are disabled for now.

rdar://problem/61345988