### PR TITLE
In TempRVO, be more explicit on handling non - onstack partial_apply

### DIFF
--- a/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
+++ b/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
@@ -166,8 +166,11 @@ bool TempRValueOptPass::collectLoads(
     }
     return true;
   }
-  case SILInstructionKind::ApplyInst:
   case SILInstructionKind::PartialApplyInst:
+    if (!cast<PartialApplyInst>(user)->isOnStack())
+      return false;
+     LLVM_FALLTHROUGH;
+  case SILInstructionKind::ApplyInst:
   case SILInstructionKind::TryApplyInst: {
     ApplySite apply(user);
 


### PR DESCRIPTION
We should not optimize away the copy_addr of a guaranteed parameter of a
non-onstack partial_apply.
This is not a bug currently, because TempRVO checks if the lifetime end
points of the temp object are destroy_addr's in
TempRValueOptPass::checkTempObjectDestroy.
This change makes it explicit on which partial_apply's are ok to
optimize.

rdar://61349083
