### PR TITLE
[ConstraintSystem] Don't bind result type of an empty closure too early

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2184,7 +2184,6 @@ namespace {
           closure->getExplicitResultTypeLoc().getType()) {
         resultTy = closure->getExplicitResultTypeLoc().getType();
       } else {
-        auto &ctx = CS.getASTContext();
         auto *resultLoc =
             CS.getConstraintLocator(closure, ConstraintLocator::ClosureResult);
 
@@ -2196,11 +2195,7 @@ namespace {
           return Type();
         };
 
-        if (closure->hasEmptyBody()) {
-          // Closures with empty bodies should be inferred to return
-          // ().
-          resultTy = ctx.TheEmptyTupleType;
-        } else if (auto contextualResultTy = getContextualResultType()) {
+        if (auto contextualResultTy = getContextualResultType()) {
           resultTy = contextualResultTy;
         } else {
           // If no return type was specified, create a fresh type

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -793,7 +793,7 @@ func test() -> Int? {
 }
 
 var fn: () -> [Int] = {}
-// expected-error@-1 {{cannot convert value of type '()' to closure result type '[Int]'}}
+// expected-error@-1 {{cannot convert value of type '[Int]' to closure result type '()'}}
 
 fn = {}
 // expected-error@-1 {{cannot assign value of type '() -> ()' to type '() -> [Int]'}}

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -540,3 +540,21 @@ func testWrapperBuilder() {
 
   let _: Int = x // expected-error{{cannot convert value of type 'Wrapper<(Double, String)>' to specified type 'Int'}}
 }
+
+// rdar://problem/61347993 - empty function builder doesn't compile
+func rdar61347993() {
+  struct Result {}
+
+  @_functionBuilder
+  struct Builder {
+    static func buildBlock() -> Result {
+      Result()
+    }
+  }
+
+  func test_builder<T>(@Builder _: () -> T) {}
+  test_builder {} // Ok
+
+  func test_closure(_: () -> Result) {}
+  test_closure {} // expected-error {{cannot convert value of type '()' to closure result type 'Result'}}
+}


### PR DESCRIPTION
Instead of setting empty closure (`{}`) result type to be `Void`
while generating constraints, let's allocate a new type variable
instead and let it be bound to `Void` once the body is opened.

This way we can support an interaction with function builders which
would return a type different from `Void` even when applied to empty closure.

Resolves: rdar://problem/61347993

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
