### PR TITLE
ASTMangler: Fix substitution round-tripping in the DWARF mangler

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -445,6 +445,28 @@ std::string ASTMangler::mangleSILDifferentiabilityWitnessKey(
   return result;
 }
 
+// In order for the remangler to work correctly, it must agree with
+// AST mangler on the substitution scheme. The AST mangler will use a
+// substitution if a mangled type is identical to a previous type.
+//
+// In the DWARF mangling, we don't canonicalize types. Therefore, any
+// two types that differ by sugar must have distinct manglings. If this
+// invariant is not maintained, then demangling and remangling a type
+// will no longer be idempotent.
+//
+// Since we don't have a distinct mangling for sugared generic
+// parameter types, we must desugar them here.
+static Type getTypeForDWARFMangling(Type t) {
+  return t.subst(
+    [](SubstitutableType *t) -> Type {
+      if (isa<GenericTypeParamType>(t))
+        return t->getCanonicalType();
+      return t;
+    },
+    MakeAbstractConformanceForGenericType(),
+    SubstFlags::AllowLoweredTypes);
+}
+
 std::string ASTMangler::mangleTypeForDebugger(Type Ty, const DeclContext *DC) {
   PrettyStackTraceType prettyStackTrace(Ty->getASTContext(),
                                         "mangling type for debugger", Ty);
@@ -452,6 +474,8 @@ std::string ASTMangler::mangleTypeForDebugger(Type Ty, const DeclContext *DC) {
   DWARFMangling = true;
   OptimizeProtocolNames = false;
   beginMangling();
+
+  Ty = getTypeForDWARFMangling(Ty);
 
   if (DC)
     bindGenericParameters(DC);
@@ -552,7 +576,9 @@ std::string ASTMangler::mangleTypeAsContextUSR(const NominalTypeDecl *type) {
 std::string ASTMangler::mangleTypeAsUSR(Type Ty) {
   DWARFMangling = true;
   beginMangling();
-  
+
+  Ty = getTypeForDWARFMangling(Ty);
+
   if (auto *fnType = Ty->getAs<AnyFunctionType>()) {
     appendFunction(fnType, false);
   } else {
@@ -1130,6 +1156,10 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
 
     case TypeKind::GenericTypeParam: {
       auto paramTy = cast<GenericTypeParamType>(tybase);
+      // If this assertion fires, it probably means the type being mangled here
+      // didn't go through getTypeForDWARFMangling().
+      assert(paramTy->getDecl() == nullptr &&
+             "cannot mangle non-canonical generic parameter");
       // A special mangling for the very first generic parameter. This shows up
       // frequently because it corresponds to 'Self' in protocol requirement
       // generic signatures.

--- a/lib/Basic/Mangler.cpp
+++ b/lib/Basic/Mangler.cpp
@@ -130,15 +130,8 @@ std::string Mangler::finalize() {
   Storage.clear();
 
 #ifndef NDEBUG
-/*
-  Verification is temporarily disabled, because of:
-  rdar://problem/59813007
-  rdar://problem/59496022
-  https://bugs.swift.org/browse/SR-12204
-
   if (StringRef(result).startswith(MANGLING_PREFIX_STR))
     verify(result);
-*/
 #endif
 
   return result;

--- a/test/DebugInfo/retroactive_conformance.swift
+++ b/test/DebugInfo/retroactive_conformance.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -g -o - | %FileCheck %s
+
+extension Optional: Comparable where Wrapped: Comparable {
+  public static func v(in r: ClosedRange<Self>) {}
+  public static func < (lhs: Self, rhs: Self) -> Bool { false }
+}
+
+// CHECK: sSNyxSgAASL23retroactive_conformancexSLHD1__HCg_GD


### PR DESCRIPTION
When mangling sugared types for DWARF debug info, we would
occassionally mix generic parameter types from different
generic environments. Since the mangling for a generic
parameter type only recorded the depth and the index, even
for distinct sugared forms, the remangler would produce a
more 'compact' mangling, by folding together generic parameters
that have the same depth/index, but distinct sugarings in the
AST.

Prevent this from happening by desugaring DWARF types the
correct amount, substituting away generic parameters while
preserving everything else.

Also, re-enable the round-trip verification with the remangler.

Fixes <rdar://problem/59496022>, <https://bugs.swift.org/browse/SR-12204>.