### PR TITLE
[Build] Use simulator triples consistently

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -30,6 +30,7 @@ function(_report_sdk prefix)
     message(STATUS "  Deployment version: ${SWIFT_SDK_${prefix}_DEPLOYMENT_VERSION}")
     message(STATUS "  Version min name: ${SWIFT_SDK_${prefix}_VERSION_MIN_NAME}")
     message(STATUS "  Triple name: ${SWIFT_SDK_${prefix}_TRIPLE_NAME}")
+    message(STATUS "  Simulator: ${SWIFT_SDK_${prefix}_IS_SIMULATOR}")
   endif()
   if(SWIFT_SDK_${prefix}_MODULE_ARCHITECTURES)
     message(STATUS "  Module Architectures: ${SWIFT_SDK_${prefix}_MODULE_ARCHITECTURES}")
@@ -112,6 +113,7 @@ endfunction()
 #   SWIFT_SDK_${prefix}_VERSION_MIN_NAME    Version min name for this SDK
 #   SWIFT_SDK_${prefix}_TRIPLE_NAME         Triple name for this SDK
 #   SWIFT_SDK_${prefix}_ARCHITECTURES       Architectures (as a list)
+#   SWIFT_SDK_${prefix}_IS_SIMULATOR        Whether this is a simulator target.
 #   SWIFT_SDK_${prefix}_ARCH_${ARCH}_TRIPLE Triple name
 macro(configure_sdk_darwin
     prefix name deployment_version xcrun_name
@@ -172,6 +174,13 @@ macro(configure_sdk_darwin
     "${SWIFT_SDK_${prefix}_ARCHITECTURES}"        # rhs
     SWIFT_SDK_${prefix}_MODULE_ARCHITECTURES)     # result
 
+  # Determine whether this is a simulator SDK.
+  if ( ${xcrun_name} MATCHES "simulator" )
+    set(SWIFT_SDK_${prefix}_IS_SIMULATOR TRUE)
+  else()
+    set(SWIFT_SDK_${prefix}_IS_SIMULATOR FALSE)
+  endif()
+
   # Configure variables for _all_ architectures even if we aren't "building"
   # them because they aren't supported.
   foreach(arch ${architectures})
@@ -180,6 +189,12 @@ macro(configure_sdk_darwin
 
     set(SWIFT_SDK_${prefix}_ARCH_${arch}_TRIPLE
         "${arch}-apple-${SWIFT_SDK_${prefix}_TRIPLE_NAME}")
+
+    # If this is a simulator target, append -simulator.
+    if (SWIFT_SDK_${prefix}_IS_SIMULATOR)
+      set(SWIFT_SDK_${prefix}_ARCH_${arch}_TRIPLE
+          "${SWIFT_SDK_${prefix}_ARCH_${arch}_TRIPLE}-simulator")
+    endif ()
 
     if(SWIFT_ENABLE_MACCATALYST AND "${prefix}" STREQUAL "OSX")
       # For macCatalyst append the '-macabi' environment to the target triple.

--- a/cmake/modules/macCatalystUtils.cmake
+++ b/cmake/modules/macCatalystUtils.cmake
@@ -35,6 +35,19 @@ function(get_maccatalyst_build_flavor out_var sdk flavor)
   endif()
 endfunction()
 
+# Form a versioned target triple for the given SDK.
+function(get_versioned_target_triple target_out_var sdk arch version)
+  if (SWIFT_SDK_${sdk}_IS_SIMULATOR)
+    # The version goes before the "-simulator".
+    set(target "${SWIFT_SDK_${sdk}_ARCH_${arch}_TRIPLE}")
+    string(REPLACE "-simulator" "" target "${target}")
+    set(target "${target}${version}-simulator")
+  else ()
+    set(target "${SWIFT_SDK_${sdk}_ARCH_${arch}_TRIPLE}${version}")
+  endif()
+
+  set(${target_out_var} "${target}" PARENT_SCOPE)
+endfunction()
 
 # Sets target_out_var to the target triple for the given SDK and maccatalyst flavor.
 # For zippered flavors also sets the target_variant_out_var. For other
@@ -53,7 +66,8 @@ function(get_target_triple target_out_var target_variant_out_var sdk arch)
   set(deployment_version "${TARGET_DEPLOYMENT_VERSION}")
 
   # Default target triple
-  set(target "${SWIFT_SDK_${sdk}_ARCH_${arch}_TRIPLE}${deployment_version}")
+  get_versioned_target_triple(target ${sdk} ${arch} "${deployment_version}")
+
   set(target_variant)
 
   get_maccatalyst_build_flavor(maccatalyst_build_flavor

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -194,7 +194,7 @@ foreach(SDK ${SWIFT_SDKS})
     foreach(BUILD_FLAVOR ${build_flavors})
     # Configure variables for this subdirectory.
     set(VARIANT_SUFFIX "-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-${ARCH}")
-    set(VARIANT_TRIPLE "${SWIFT_SDK_${SDK}_ARCH_${ARCH}_TRIPLE}${SWIFT_SDK_${SDK}_DEPLOYMENT_VERSION}")
+    get_versioned_target_triple(VARIANT_TRIPLE ${SDK} ${ARCH} "${SWIFT_SDK_${SDK}_DEPLOYMENT_VERSION}")
     set(VARIANT_SDK "${SWIFT_SDK_${SDK}_ARCH_${ARCH}_PATH}")
     set(DEFAULT_OSX_VARIANT_SUFFIX "")
 

--- a/test/IRGen/objc_properties_ios.swift
+++ b/test/IRGen/objc_properties_ios.swift
@@ -1,5 +1,5 @@
-// RUN: %swift -target x86_64-apple-ios9 %S/objc_properties.swift -disable-target-os-checking -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-NEW %S/objc_properties.swift
-// RUN: %swift -target x86_64-apple-ios8 %S/objc_properties.swift -disable-target-os-checking -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-OLD %S/objc_properties.swift
+// RUN: %swift -target x86_64-apple-ios9-simulator %S/objc_properties.swift -disable-target-os-checking -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-NEW %S/objc_properties.swift
+// RUN: %swift -target x86_64-apple-ios8-simulator %S/objc_properties.swift -disable-target-os-checking -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-OLD %S/objc_properties.swift
 
 // REQUIRES: OS=ios
 // REQUIRES: CPU=x86_64

--- a/test/TBD/Inputs/install-name-map-toasterkit.json
+++ b/test/TBD/Inputs/install-name-map-toasterkit.json
@@ -7,6 +7,6 @@
   {
     "module": "ToasterKit",
     "install_name": "/System/Previous/iOS/ToasterKit.dylib",
-    "platforms": ["iOS"]
+    "platforms": ["iOS", "iOS_sim"]
   }
 ]

--- a/test/TBD/linker-directives-ld-previous-ios.swift
+++ b/test/TBD/linker-directives-ld-previous-ios.swift
@@ -3,12 +3,18 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -typecheck %S/Inputs/linker-directive.swift -tbd-is-installapi -emit-tbd -emit-tbd-path %t/linker_directives.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json
-// RUN: %FileCheck %s < %t/linker_directives.tbd
+// RUN: %FileCheck --check-prefix=CHECK-objc-simulator-%target-is-simulator %s < %t/linker_directives.tbd
 // RUN: %target-swift-frontend -typecheck %S/Inputs/linker-directive.swift -emit-tbd -emit-tbd-path %t/linker_directives.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json
-// RUN: %FileCheck %s < %t/linker_directives.tbd
+// RUN: %FileCheck --check-prefix=CHECK-objc-simulator-%target-is-simulator %s <  %t/linker_directives.tbd
 
-// CHECK: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$13.0$_$s10ToasterKit5toastyyF$
-// CHECK: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$13.0$_$s10ToasterKit7VehicleV4moveyyF$
-// CHECK: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$13.0$_$s10ToasterKit7VehicleVMa$
-// CHECK: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$13.0$_$s10ToasterKit7VehicleVMn$
-// CHECK: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$13.0$_$s10ToasterKit7VehicleVN$
+// CHECK-objc-simulator-false: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$13.0$_$s10ToasterKit5toastyyF$
+// CHECK-objc-simulator-false: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$13.0$_$s10ToasterKit7VehicleV4moveyyF$
+// CHECK-objc-simulator-false: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$13.0$_$s10ToasterKit7VehicleVMa$
+// CHECK-objc-simulator-false: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$13.0$_$s10ToasterKit7VehicleVMn$
+// CHECK-objc-simulator-false: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$13.0$_$s10ToasterKit7VehicleVN$
+
+// CHECK-objc-simulator-true: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$7$10.2$13.0$_$s10ToasterKit5toastyyF$
+// CHECK-objc-simulator-true: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$7$10.2$13.0$_$s10ToasterKit7VehicleV4moveyyF$
+// CHECK-objc-simulator-true: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$7$10.2$13.0$_$s10ToasterKit7VehicleVMa$
+// CHECK-objc-simulator-true: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$7$10.2$13.0$_$s10ToasterKit7VehicleVMn$
+// CHECK-objc-simulator-true: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$7$10.2$13.0$_$s10ToasterKit7VehicleVN$

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -328,6 +328,9 @@ if run_os == 'ios' and run_vers.endswith('-macabi'):
     run_os = 'maccatalyst'
 if run_vers.endswith('-simulator'):
     run_vers = run_vers[0:-len('-simulator')]
+    run_environment='-simulator'
+else:
+    run_environment=''
 
 run_ptrsize = '64' if ('64' in run_cpu or run_cpu == "s390x") else '32'
 run_ptrauth = 'ptrauth' if run_cpu == 'arm64e' else 'noptrauth'
@@ -635,8 +638,8 @@ if run_vendor == 'apple':
             }
             pre_stable_version = PRE_STABLE_VERSION.get(run_os, '')
 
-        config.pre_stable_abi_triple = '%s-%s-%s%s' % (run_cpu, run_vendor, run_os,
-                                                       pre_stable_version)
+        config.pre_stable_abi_triple = '%s-%s-%s%s%s' % (run_cpu, run_vendor, run_os,
+                                                         pre_stable_version, run_environment)
         STABLE_VERSION = {
             'macosx': '10.14.4',
             'ios': '12.2',
@@ -645,8 +648,8 @@ if run_vendor == 'apple':
             'watchos': '5.2'
         }
         stable_version = STABLE_VERSION.get(run_os, '')
-        config.stable_abi_triple = '%s-%s-%s%s' % (run_cpu, run_vendor, run_os,
-                                                   stable_version)
+        config.stable_abi_triple = '%s-%s-%s%s%s' % (run_cpu, run_vendor, run_os,
+                                                     stable_version, run_environment)
 
         NEXT_STABLE_VERSION = {
             'macosx': '10.15',
@@ -656,8 +659,9 @@ if run_vendor == 'apple':
             'watchos': '6'
         }
         next_stable_version = NEXT_STABLE_VERSION.get(run_os, '')
-        config.next_stable_abi_triple = '%s-%s-%s%s' % (run_cpu, run_vendor, run_os,
-                                                        next_stable_version)
+        config.next_stable_abi_triple = '%s-%s-%s%s%s' % (run_cpu, run_vendor, run_os,
+                                                          next_stable_version, run_environment)
+
 else:
     config.pre_stable_abi_triple = config.variant_triple
     config.stable_abi_triple = config.variant_triple
@@ -1012,7 +1016,8 @@ if run_vendor == 'apple':
         % (config.target_build_swift))
     config.target_add_rpath = r'-Xlinker -rpath -Xlinker \1'
 
-    target_future = format('%s-apple-%s%s' % (run_cpu, run_os, target_future_version))
+    target_future = format('%s-apple-%s%s%s' % (run_cpu, run_os, target_future_version, run_environment))
+
     config.otool_classic = ("%s otool-classic" % (xcrun_prefix))
 
 elif run_os in ['windows-msvc']:

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -326,6 +326,8 @@ lit_config.note('Using resource dir: ' + test_resource_dir)
 if run_os == 'ios' and run_vers.endswith('-macabi'):
     run_vers = run_vers[0:-len('-macabi')]
     run_os = 'maccatalyst'
+if run_vers.endswith('-simulator'):
+    run_vers = run_vers[0:-len('-simulator')]
 
 run_ptrsize = '64' if ('64' in run_cpu or run_cpu == "s390x") else '32'
 run_ptrauth = 'ptrauth' if run_cpu == 'arm64e' else 'noptrauth'

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -489,14 +489,14 @@ function set_build_options_for_host() {
                     cmake_osx_deployment_target="${DARWIN_DEPLOYMENT_VERSION_OSX}"
                     ;;
                 iphonesimulator-i386)
-                    SWIFT_HOST_TRIPLE="i386-apple-ios${DARWIN_DEPLOYMENT_VERSION_IOS}"
+                    SWIFT_HOST_TRIPLE="i386-apple-ios${DARWIN_DEPLOYMENT_VERSION_IOS}-simulator"
                     llvm_target_arch="X86"
 
                     SWIFT_HOST_VARIANT_SDK="IOS_SIMULATOR"
                     cmake_osx_deployment_target=""
                     ;;
                 iphonesimulator-x86_64)
-                    SWIFT_HOST_TRIPLE="x86_64-apple-ios${DARWIN_DEPLOYMENT_VERSION_IOS}"
+                    SWIFT_HOST_TRIPLE="x86_64-apple-ios${DARWIN_DEPLOYMENT_VERSION_IOS}-simulator"
                     llvm_target_arch="X86"
 
                     SWIFT_HOST_VARIANT_SDK="IOS_SIMULATOR"
@@ -531,7 +531,7 @@ function set_build_options_for_host() {
                     cmake_osx_deployment_target=""
                     ;;
                 appletvsimulator-x86_64)
-                    SWIFT_HOST_TRIPLE="x86_64-apple-tvos${DARWIN_DEPLOYMENT_VERSION_TVOS}"
+                    SWIFT_HOST_TRIPLE="x86_64-apple-tvos${DARWIN_DEPLOYMENT_VERSION_TVOS}-simulator"
                     llvm_target_arch="X86"
 
                     SWIFT_HOST_VARIANT_SDK="TVOS_SIMULATOR"
@@ -545,7 +545,7 @@ function set_build_options_for_host() {
                     cmake_osx_deployment_target=""
                     ;;
                 watchsimulator-i386)
-                    SWIFT_HOST_TRIPLE="i386-apple-watchos${DARWIN_DEPLOYMENT_VERSION_WATCHOS}"
+                    SWIFT_HOST_TRIPLE="i386-apple-watchos${DARWIN_DEPLOYMENT_VERSION_WATCHOS}-simulator"
                     llvm_target_arch="X86"
 
                     SWIFT_HOST_VARIANT_SDK="WATCHOS_SIMULATOR"


### PR DESCRIPTION
The build systems that drive Swift compilation have been using the
"simulator" environment as part of the increasingly inaccurately
named "target triple" to specify simulator targets for several
years... except our own hand-rolled build system. Identify
simulator targets and append "-simulator" to their target
triples, and do so throughout our build and test infrastructure.