### PR TITLE
[Diagnostics] In DefineMemberBasedOnUse::diagnoseForAmbiguity, use the base type from each solution

### DIFF
--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -489,10 +489,15 @@ bool DefineMemberBasedOnUse::diagnose(const Solution &solution,
 }
 
 bool
-DefineMemberBasedOnUse::diagnoseForAmbiguity(ArrayRef<Solution> solutions) const {
+DefineMemberBasedOnUse::diagnoseForAmbiguity(ArrayRef<Solution> solutions,
+                                             ArrayRef<ConstraintFix *> fixes) const {
   Type concreteBaseType;
-  for (const auto &solution: solutions) {
-    auto baseType = solution.simplifyType(BaseType);
+  for (unsigned i = 0; i < solutions.size(); ++i) {
+    const auto *fix = fixes[i]->getAs<DefineMemberBasedOnUse>();
+    const auto &solution = solutions[i];
+    assert(llvm::find(solution.Fixes, fix) != solution.Fixes.end());
+
+    auto baseType = solution.simplifyType(fix->BaseType);
     if (!concreteBaseType)
       concreteBaseType = baseType;
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -489,15 +489,13 @@ bool DefineMemberBasedOnUse::diagnose(const Solution &solution,
 }
 
 bool
-DefineMemberBasedOnUse::diagnoseForAmbiguity(ArrayRef<Solution> solutions,
-                                             ArrayRef<ConstraintFix *> fixes) const {
+DefineMemberBasedOnUse::diagnoseForAmbiguity(CommonFixesArray commonFixes) const {
   Type concreteBaseType;
-  for (unsigned i = 0; i < solutions.size(); ++i) {
-    const auto *fix = fixes[i]->getAs<DefineMemberBasedOnUse>();
-    const auto &solution = solutions[i];
-    assert(llvm::find(solution.Fixes, fix) != solution.Fixes.end());
+  for (const auto &solutionAndFix : commonFixes) {
+    const auto *solution = solutionAndFix.first;
+    const auto *fix = solutionAndFix.second->getAs<DefineMemberBasedOnUse>();
 
-    auto baseType = solution.simplifyType(fix->BaseType);
+    auto baseType = solution->simplifyType(fix->BaseType);
     if (!concreteBaseType)
       concreteBaseType = baseType;
 
@@ -508,7 +506,7 @@ DefineMemberBasedOnUse::diagnoseForAmbiguity(ArrayRef<Solution> solutions,
     }
   }
 
-  return diagnose(solutions.front());
+  return diagnose(*commonFixes.front().first);
 }
 
 DefineMemberBasedOnUse *

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -291,8 +291,10 @@ public:
   virtual bool diagnose(const Solution &solution,
                         bool asNote = false) const = 0;
 
-  virtual bool diagnoseForAmbiguity(ArrayRef<Solution> solutions,
-                                    ArrayRef<ConstraintFix *> fixes) const {
+  using CommonFixesArray =
+      ArrayRef<std::pair<const Solution *, const ConstraintFix *>>;
+
+  virtual bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const {
     return false;
   }
 
@@ -850,8 +852,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(ArrayRef<Solution> solutions,
-                            ArrayRef<ConstraintFix *> fixes) const override;
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static DefineMemberBasedOnUse *create(ConstraintSystem &cs, Type baseType,
                                         DeclNameRef member, bool alreadyDiagnosed,
@@ -1125,9 +1126,8 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(ArrayRef<Solution> solutions,
-                            ArrayRef<ConstraintFix *> fixes) const override {
-    return diagnose(solutions.front());
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
   }
 
   static AddMissingArguments *create(ConstraintSystem &cs,
@@ -1170,9 +1170,8 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(ArrayRef<Solution> solutions,
-                            ArrayRef<ConstraintFix *> fixes) const override {
-    return diagnose(solutions.front());
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
   }
 
   /// FIXME(diagnostics): Once `resolveDeclRefExpr` is gone this
@@ -1381,9 +1380,8 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(ArrayRef<Solution> solutions,
-                            ArrayRef<ConstraintFix *> fixes) const override {
-    return diagnose(solutions.front());
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
   }
 
   static DefaultGenericArgument *create(ConstraintSystem &cs,
@@ -1457,9 +1455,8 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(ArrayRef<Solution> solutions,
-                            ArrayRef<ConstraintFix *> fixes) const override {
-    return diagnose(solutions.front());
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
   }
 
   static IgnoreContextualType *create(ConstraintSystem &cs, Type resultTy,

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -291,7 +291,10 @@ public:
   virtual bool diagnose(const Solution &solution,
                         bool asNote = false) const = 0;
 
-  virtual bool diagnoseForAmbiguity(ArrayRef<Solution> solutions) const { return false; }
+  virtual bool diagnoseForAmbiguity(ArrayRef<Solution> solutions,
+                                    ArrayRef<ConstraintFix *> fixes) const {
+    return false;
+  }
 
   void print(llvm::raw_ostream &Out) const;
 
@@ -847,11 +850,16 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(ArrayRef<Solution> solutions) const override;
+  bool diagnoseForAmbiguity(ArrayRef<Solution> solutions,
+                            ArrayRef<ConstraintFix *> fixes) const override;
 
   static DefineMemberBasedOnUse *create(ConstraintSystem &cs, Type baseType,
                                         DeclNameRef member, bool alreadyDiagnosed,
                                         ConstraintLocator *locator);
+
+  static bool classof(const ConstraintFix *fix) {
+    return fix->getKind() == FixKind::DefineMemberBasedOnUse;
+  }
 };
 
 class AllowInvalidMemberRef : public ConstraintFix {
@@ -1117,7 +1125,8 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(ArrayRef<Solution> solutions) const override {
+  bool diagnoseForAmbiguity(ArrayRef<Solution> solutions,
+                            ArrayRef<ConstraintFix *> fixes) const override {
     return diagnose(solutions.front());
   }
 
@@ -1161,7 +1170,8 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(ArrayRef<Solution> solutions) const override {
+  bool diagnoseForAmbiguity(ArrayRef<Solution> solutions,
+                            ArrayRef<ConstraintFix *> fixes) const override {
     return diagnose(solutions.front());
   }
 
@@ -1371,7 +1381,8 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(ArrayRef<Solution> solutions) const override {
+  bool diagnoseForAmbiguity(ArrayRef<Solution> solutions,
+                            ArrayRef<ConstraintFix *> fixes) const override {
     return diagnose(solutions.front());
   }
 
@@ -1446,7 +1457,8 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(ArrayRef<Solution> solutions) const override {
+  bool diagnoseForAmbiguity(ArrayRef<Solution> solutions,
+                            ArrayRef<ConstraintFix *> fixes) const override {
     return diagnose(solutions.front());
   }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2983,8 +2983,9 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
     bool diagnosed = false;
     for (auto fixes: aggregatedFixes) {
       // A common fix must appear in all solutions
-      if (fixes.second.size() < solutions.size()) continue;
-      diagnosed |= fixes.second.front()->diagnoseForAmbiguity(solutions);
+      if (fixes.second.size() != solutions.size()) continue;
+      diagnosed |= fixes.second.front()->diagnoseForAmbiguity(solutions,
+                                                              fixes.second);
     }
     return diagnosed;
   }

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -40,6 +40,14 @@ struct S {
   }
 }
 
+struct School {
+  var name: String
+}
+func testDiagnoseForAmbiguityCrash(schools: [School]) {
+  schools.map({ $0.name }).sorted(by: { $0.nothing < $1.notAThing })
+  // expected-error@-1 {{value of type 'String' has no member 'nothing'}}
+  // expected-error@-2 {{value of type 'String' has no member 'notAThing'}}
+}
 
 class DefaultValue {
   static func foo(_ a: Int) {}


### PR DESCRIPTION
Previously, the code only used the base type from the first solution. This resulted in potentially calling `solution.simplifyType` on a type that involved type variables that didn't appear in that solution.

Resolves: rdar://problem/61005878