### PR TITLE
[DoNotMerge] Test TF-1232 fix.

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -244,8 +244,11 @@ private:
     declaredCrossImports;
 
   std::unique_ptr<SourceLookupCache> Cache;
+
+public:
   SourceLookupCache &getSourceLookupCache() const;
 
+private:
   /// Tracks the file that will generate the module's entry point, either
   /// because it contains a class marked with \@UIApplicationMain
   /// or \@NSApplicationMain, or because it is a script file.

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -210,11 +210,7 @@ private:
 public:
   /// Appends the given declaration to the end of the top-level decls list. Do
   /// not add any additional uses of this function.
-  void addTopLevelDecl(Decl *d) {
-    // Force decl parsing if we haven't already.
-    (void)getTopLevelDecls();
-    Decls->push_back(d);
-  }
+  void addTopLevelDecl(Decl *d);
 
   /// Prepends a declaration to the top-level decls list.
   ///
@@ -393,8 +389,6 @@ public:
 
   void cacheVisibleDecls(SmallVectorImpl<ValueDecl *> &&globals) const;
   const SmallVectorImpl<ValueDecl *> &getCachedVisibleDecls() const;
-
-  void addVisibleDecl(ValueDecl *decl);
 
   virtual void lookupValue(DeclName name, NLKind lookupKind,
                            SmallVectorImpl<ValueDecl*> &result) const override;

--- a/lib/SILOptimizer/Utils/Differentiation/LinearMapInfo.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/LinearMapInfo.cpp
@@ -159,7 +159,7 @@ EnumDecl *LinearMapInfo::createBranchingTraceDecl(
   computeAccessLevel(branchingTraceDecl, original->getEffectiveSymbolLinkage());
   branchingTraceDecl->getInterfaceType();
   assert(branchingTraceDecl->hasInterfaceType());
-  file.addVisibleDecl(branchingTraceDecl);
+  file.addTopLevelDecl(branchingTraceDecl);
   // Add basic block enum cases.
   for (auto *predBB : originalBB->getPredecessorBlocks()) {
     auto bbId = "bb" + std::to_string(predBB->getDebugID());
@@ -233,7 +233,7 @@ LinearMapInfo::createLinearMapStruct(SILBasicBlock *originalBB,
   computeAccessLevel(linearMapStruct, original->getEffectiveSymbolLinkage());
   linearMapStruct->getInterfaceType();
   assert(linearMapStruct->hasInterfaceType());
-  file.addVisibleDecl(linearMapStruct);
+  file.addTopLevelDecl(linearMapStruct);
   return linearMapStruct;
 }
 

--- a/test/AutoDiff/compiler_crashers_fixed/tf1232-autodiff-generated-declaration-mangling.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/tf1232-autodiff-generated-declaration-mangling.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-build-swift -g %s
+// RUN: %target-build-swift -g %s
 // REQUIRES: asserts
 
 // TF-1232: IRGenDebugInfo crash due to lack of proper mangling for


### PR DESCRIPTION
Change `SourceFile::addTopLevelDecl` to update source lookup caches.
If tests pass: make the change robust, respecting access levels.