### PR TITLE
Revert "[build] Don't reset 'swiftlib_link_flags_all' unnecessarily"

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1430,6 +1430,7 @@ function(add_swift_target_library name)
 
       # Add PrivateFrameworks, rdar://28466433
       set(swiftlib_c_compile_flags_all ${SWIFTLIB_C_COMPILE_FLAGS})
+      set(swiftlib_link_flags_all ${SWIFTLIB_LINK_FLAGS})
 
       # Add flags to prepend framework search paths for the parallel framework
       # hierarchy rooted at /System/iOSSupport/...


### PR DESCRIPTION
Reverts apple/swift#30020

We saw an internal CI failure that could be due to this commit. Revert it for now.