### PR TITLE
Add a lit test feature for libc++.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -887,6 +887,8 @@ find_package(PythonInterp REQUIRED)
 # Find optional dependencies.
 #
 
+find_package(LibCXX)
+
 if(LLVM_ENABLE_LIBXML2)
   find_package(LibXml2 REQUIRED)
 else()

--- a/cmake/modules/FindLibCXX.cmake
+++ b/cmake/modules/FindLibCXX.cmake
@@ -1,0 +1,15 @@
+# Find libc++
+
+find_library(LibCXX_LIBRARY NAMES c++)
+find_library(LibCXXABI_LIBRARY NAMES c++abi)
+
+find_path(LibCXX_PREFIX c++/v1/algorithm PATHS ${LibCXX_LIB_PATH}/../include)
+if (LibCXX_PREFIX)
+  set(LibCXX_INCLUDE_DIR ${LibCXX_PREFIX}/c++/v1/)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LibCXX DEFAULT_MSG
+  LibCXX_LIBRARY
+  LibCXXABI_LIBRARY
+  LibCXX_INCLUDE_DIR)

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -465,6 +465,9 @@ use this pattern::
 
 FIXME: full list.
 
+* ``libc++``: present if libc++ was found. This is intended for C++ interop
+  tests.
+
 * ``swift_ast_verifier``: present if the AST verifier is enabled in this build.
 
 * When writing a test specific to x86, if possible, prefer ``REQUIRES:

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -57,6 +57,10 @@ config.darwin_osx_variant_suffix = "@DEFAULT_OSX_VARIANT_SUFFIX@"
 
 # Please remember to handle empty strings and/or unset variables correctly.
 
+
+if "@LibCXX_FOUND@" == "TRUE":
+    config.available_features.add("libc++")
+
 if "@SWIFT_ASAN_BUILD@" == "TRUE":
     config.available_features.add("asan")
 else:


### PR DESCRIPTION
This is necessary, because (at least initially) C++ interop will only work with
libc++ (not with libstdc++).
