### PR TITLE
SIL Optimizer: Fix two compile time issues

### DIFF
--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -255,6 +255,8 @@ public:
   unsigned getIndex() const {
     return Value.getIndex();
   }
+  
+  unsigned getHash() const { return (unsigned)Value.getStorage(); }
 
   /// Determine if I is a value projection instruction whose corresponding
   /// projection equals this projection.
@@ -689,7 +691,7 @@ static inline llvm::hash_code hash_value(const ProjectionPath &P) {
 
 /// Returns the hashcode for the projection path.
 static inline llvm::hash_code hash_value(const Projection &P) {
-  return llvm::hash_combine(static_cast<unsigned>(P.getKind()));
+  return llvm::hash_combine(P.getHash());
 }
 
 class ProjectionTree;

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -915,7 +915,9 @@ bool SILPerformanceInliner::inlineCallsIntoFunction(SILFunction *Caller) {
     return false;
 
   // Second step: do the actual inlining.
-  for (auto AI : AppliesToInline) {
+  // We inline in reverse order, because for very large blocks with many applies
+  // to inline, splitting the block at every apply would be quadratic.
+  for (auto AI : llvm::reverse(AppliesToInline)) {
     SILFunction *Callee = AI.getReferencedFunctionOrNull();
     assert(Callee && "apply_inst does not have a direct callee anymore");
 


### PR DESCRIPTION
* Fix a compile time problem in the inliner

When inlining many functions in a very large basic block, the splitting of the block at the call sites is quadratic, when traversing in forward order.
Traversing backwards, fixes the problem.

* Fix the hash function for Projection

The hash function didn't take the "index" of an projection into account. This lead to quadratic behavior in redundant load elimination and dead store elimination when compiling very large functions with many loads and stores.

rdar://problem/56268570