### PR TITLE
utils/run-test: added lit's --filter option

### DIFF
--- a/utils/run-test
+++ b/utils/run-test
@@ -132,6 +132,9 @@ def main():
                         dest="targets",
                         help="stdlib deployment targets to test. Accept "
                              "multiple (default: " + host_target + ")")
+    parser.add_argument("--filter", type=str, metavar="REGEX",
+                        help="only run tests with paths matching the given "
+                             "regular expression")
     parser.add_argument("--mode",
                         choices=TEST_MODES, default='optimize_none',
                         help="test mode (default: optimize_none)")
@@ -261,6 +264,9 @@ def main():
         test_args += ['--param', 'swift_test_results_dir=%s' % args.result_dir,
                       '--xunit-xml-output=%s' % os.path.join(args.result_dir,
                                                              'lit-tests.xml')]
+
+    if args.filter:
+        test_args += ['--filter', args.filter]
 
     test_cmd = [sys.executable, args.lit] + test_args + paths
 


### PR DESCRIPTION
Added a pass through of lit's `--filter` option to utils/run-test, to allow running a subset of tests, for example `./utils/run-test --filter=irgen` runs tests in `test/IRGen` and any other test with "irgen" in its name.
