### PR TITLE
[CodeCompletion] Disable an SourceKit test case in Windows

### DIFF
--- a/test/SourceKit/CodeComplete/complete_annotateddescription.swift
+++ b/test/SourceKit/CodeComplete/complete_annotateddescription.swift
@@ -10,5 +10,8 @@ func test(value: MyStruct) {
   value 
 }
 
+// FIXME: windows testing failed with newline code mismatch.
+// UNSUPPORTED: OS=windows-msvc
+
 // RUN: %sourcekitd-test -req=complete -pos=10:8 -req-opts=annotateddescription=1 %s -- %s > %t.result
 // RUN: diff -u %s.result %t.result


### PR DESCRIPTION
https://ci-external.swift.org/job/oss-swift-windows-x86_64-vs2019/739/