### PR TITLE
[Index] Don't replace ' ' or '-' in group names when mapping them to a 'module' name

### DIFF
--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -514,8 +514,6 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
       for (char ch : groupName) {
         if (ch == '/')
           buf += '.';
-        else if (ch == ' ' || ch == '-')
-          buf += '_';
         else
           buf += ch;
       }


### PR DESCRIPTION
The fake module names we create when indexing a Swift module that's divided into 'groups' (e.g. the stdlib) don't have to be valid Swift module names, but we were manipulating them to be so. E.g. the stdlib "Lazy Views" group, became "Lazy_Views" in the index data. This name is displayed in some editors verbatim, and is also used as input to some sourcekitd APIs (e.g. editor.open.interface) that only work if the original group name is passed, rather than the processed one.

This patch stops mapping invalid module name characters like ' ' and '-' to '_' so the original group name is stored in the index data.

Note: groups are currently only supported for the stdlib module. There's no test here, because it would require us to either index the stdlib (which takes > 20s for a debug build) or generalize the feature, which would require a much bigger change. I manually checked this doesn't impact Xcode's interface generation feature (except to make it work for symbols from the "Lazy Views" and "Type-erased" groups), and SourceKit-LSP / other editors don't support the interface generation feature as far as I'm aware, so shouldn't be impacted by this.

Resolves rdar://problem/57270811