### PR TITLE
Make -emit-verbose-sil print conformances for existential insts.

### DIFF
--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -131,7 +131,8 @@ public:
                            ProtocolDecl *requirement) const;
 
   SWIFT_DEBUG_DUMP;
-  void dump(llvm::raw_ostream &out, unsigned indent = 0) const;
+  void dump(llvm::raw_ostream &out, unsigned indent = 0,
+            bool details = true) const;
 
   bool operator==(ProtocolConformanceRef other) const {
     return Union == other.Union;

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3286,9 +3286,12 @@ void ProtocolConformanceRef::dump() const {
   llvm::errs() << '\n';
 }
 
-void ProtocolConformanceRef::dump(llvm::raw_ostream &out,
-                                  unsigned indent) const {
+void ProtocolConformanceRef::dump(llvm::raw_ostream &out, unsigned indent,
+                                  bool details) const {
   llvm::SmallPtrSet<const ProtocolConformance *, 8> visited;
+  if (!details && isConcrete())
+    visited.insert(getConcrete());
+
   dumpProtocolConformanceRefRec(*this, out, indent, visited);
 }
 void ProtocolConformance::dump() const {

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -789,6 +789,16 @@ public:
     return true;
   }
 
+  void printConformances(ArrayRef<ProtocolConformanceRef> conformances) {
+    // FIXME: conformances should always be printed and parsed!
+    if (!Ctx.printVerbose()) {
+      return;
+    }
+    *this << " // ";
+    for (ProtocolConformanceRef conformance : conformances)
+      conformance.dump(PrintState.OS, /*indent*/ 0, /*details*/ false);
+  }
+
   void printDebugLocRef(SILLocation Loc, const SourceManager &SM,
                         bool PrintComma = true) {
     auto DL = Loc.decodeDebugLoc(SM);
@@ -1797,6 +1807,7 @@ public:
       *this << getIDAndType(WMI->getTypeDependentOperands()[0].get());
     }
     *this << " : " << WMI->getType();
+    printConformances({WMI->getConformance()});
   }
   void visitOpenExistentialAddrInst(OpenExistentialAddrInst *OI) {
     if (OI->getAccessKind() == OpenedExistentialAccess::Immutable)
@@ -1823,21 +1834,26 @@ public:
   void visitInitExistentialAddrInst(InitExistentialAddrInst *AEI) {
     *this << getIDAndType(AEI->getOperand()) << ", $"
           << AEI->getFormalConcreteType();
+    printConformances(AEI->getConformances());
   }
   void visitInitExistentialValueInst(InitExistentialValueInst *AEI) {
     *this << getIDAndType(AEI->getOperand()) << ", $"
           << AEI->getFormalConcreteType() << ", " << AEI->getType();
+    printConformances(AEI->getConformances());
   }
   void visitInitExistentialRefInst(InitExistentialRefInst *AEI) {
     *this << getIDAndType(AEI->getOperand()) << " : $"
           << AEI->getFormalConcreteType() << ", " << AEI->getType();
+    printConformances(AEI->getConformances());
   }
-  void visitInitExistentialMetatypeInst(InitExistentialMetatypeInst *AEI) {
-    *this << getIDAndType(AEI->getOperand()) << ", " << AEI->getType();
+  void visitInitExistentialMetatypeInst(InitExistentialMetatypeInst *EMI) {
+    *this << getIDAndType(EMI->getOperand()) << ", " << EMI->getType();
+    printConformances(EMI->getConformances());
   }
   void visitAllocExistentialBoxInst(AllocExistentialBoxInst *AEBI) {
     *this << AEBI->getExistentialType() << ", $"
           << AEBI->getFormalConcreteType();
+    printConformances(AEBI->getConformances());
   }
   void visitDeinitExistentialAddrInst(DeinitExistentialAddrInst *DEI) {
     *this << getIDAndType(DEI->getOperand());


### PR DESCRIPTION
It is a correctness bug that textual SIL cannot parse these, but at
least we can somewhat debug the issue now.
