### PR TITLE
[AutoDiff] Add generated implicit declarations to SynthesizedFileUnit.

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -95,6 +95,8 @@ enum class FileUnitKind {
   Builtin,
   /// A serialized Swift AST.
   SerializedAST,
+  /// A synthesized file.
+  Synthesized,
   /// An imported Clang module.
   ClangModule,
   /// A Clang module imported from DWARF.

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -394,8 +394,6 @@ public:
   void cacheVisibleDecls(SmallVectorImpl<ValueDecl *> &&globals) const;
   const SmallVectorImpl<ValueDecl *> &getCachedVisibleDecls() const;
 
-  void addVisibleDecl(ValueDecl *decl);
-
   virtual void lookupValue(DeclName name, NLKind lookupKind,
                            SmallVectorImpl<ValueDecl*> &result) const override;
 

--- a/include/swift/AST/SynthesizedFileUnit.h
+++ b/include/swift/AST/SynthesizedFileUnit.h
@@ -1,0 +1,63 @@
+//===--- SynthesizedFileUnit.h - A synthesized file unit --------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_SYNTHESIZEDFILEUNIT_H
+#define SWIFT_AST_SYNTHESIZEDFILEUNIT_H
+
+#include "swift/AST/FileUnit.h"
+#include "swift/Basic/Debug.h"
+
+namespace swift {
+
+/// A container for synthesized module-level declarations.
+class SynthesizedFileUnit final : public FileUnit {
+  /// Synthesized top level declarations.
+  TinyPtrVector<ValueDecl *> TopLevelDecls;
+
+  /// A unique identifier representing this file; used to mark private decls
+  /// within the file to keep them from conflicting with other files in the
+  /// same module.
+  mutable Identifier PrivateDiscriminator;
+
+public:
+  SynthesizedFileUnit(ModuleDecl &M);
+  ~SynthesizedFileUnit() = default;
+
+  /// Add a synthesized top-level declaration.
+  void addTopLevelDecl(ValueDecl *FD) { TopLevelDecls.push_back(FD); }
+
+  virtual void lookupValue(DeclName name, NLKind lookupKind,
+                           SmallVectorImpl<ValueDecl *> &result) const override;
+
+  void lookupObjCMethods(
+      ObjCSelector selector,
+      SmallVectorImpl<AbstractFunctionDecl *> &results) const override;
+
+  Identifier getDiscriminatorForPrivateValue(const ValueDecl *D) const override;
+
+  void getTopLevelDecls(SmallVectorImpl<Decl*> &results) const override;
+
+  ArrayRef<ValueDecl *> getTopLevelDecls() const {
+    return TopLevelDecls;
+  };
+
+  static bool classof(const FileUnit *file) {
+    return file->getKind() == FileUnitKind::Synthesized;
+  }
+  static bool classof(const DeclContext *DC) {
+    return isa<FileUnit>(DC) && classof(cast<FileUnit>(DC));
+  }
+};
+
+} // namespace swift
+
+#endif // SWIFT_AST_SYNTHESIZEDFILEUNIT_H

--- a/include/swift/AST/SynthesizedFileUnit.h
+++ b/include/swift/AST/SynthesizedFileUnit.h
@@ -33,7 +33,7 @@ public:
   ~SynthesizedFileUnit() = default;
 
   /// Add a synthesized top-level declaration.
-  void addTopLevelDecl(ValueDecl *FD) { TopLevelDecls.push_back(FD); }
+  void addTopLevelDecl(ValueDecl *D) { TopLevelDecls.push_back(D); }
 
   virtual void lookupValue(DeclName name, NLKind lookupKind,
                            SmallVectorImpl<ValueDecl *> &result) const override;

--- a/include/swift/SILOptimizer/Utils/Differentiation/ADContext.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/ADContext.h
@@ -19,6 +19,7 @@
 
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/Expr.h"
+#include "swift/AST/SynthesizedFileUnit.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SILOptimizer/Utils/Differentiation/Common.h"
 #include "swift/SILOptimizer/Utils/Differentiation/DifferentiationInvoker.h"
@@ -65,6 +66,9 @@ private:
 
   /// Shared pass manager.
   SILPassManager &passManager;
+
+  /// A synthesized file unit.
+  SynthesizedFileUnit &synthesizedFile;
 
   /// The worklist (stack) of `differentiable_function` instructions to be
   /// processed.
@@ -120,6 +124,7 @@ public:
   SILModule &getModule() const { return module; }
   ASTContext &getASTContext() const { return module.getASTContext(); }
   SILPassManager &getPassManager() const { return passManager; }
+  SynthesizedFileUnit &getSynthesizedFile() { return synthesizedFile; }
   Lowering::TypeConverter &getTypeConverter() { return module.Types; }
 
   /// Returns true if the `differentiable_function` instruction worklist is

--- a/include/swift/SILOptimizer/Utils/Differentiation/ADContext.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/ADContext.h
@@ -68,7 +68,7 @@ private:
   SILPassManager &passManager;
 
   /// A synthesized file unit.
-  SynthesizedFileUnit &synthesizedFile;
+  SynthesizedFileUnit *synthesizedFile = nullptr;
 
   /// The worklist (stack) of `differentiable_function` instructions to be
   /// processed.
@@ -124,8 +124,11 @@ public:
   SILModule &getModule() const { return module; }
   ASTContext &getASTContext() const { return module.getASTContext(); }
   SILPassManager &getPassManager() const { return passManager; }
-  SynthesizedFileUnit &getSynthesizedFile() { return synthesizedFile; }
   Lowering::TypeConverter &getTypeConverter() { return module.Types; }
+
+  /// Get or create a synthesized file for adding generated linear map structs
+  /// and branching trace enums. Used by `LinearMapInfo`.
+  SynthesizedFileUnit &getOrCreateSynthesizedFile();
 
   /// Returns true if the `differentiable_function` instruction worklist is
   /// empty.

--- a/include/swift/SILOptimizer/Utils/Differentiation/LinearMapInfo.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/LinearMapInfo.h
@@ -18,6 +18,7 @@
 #define SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_LINEARMAPINFO_H
 
 #include "swift/AST/AutoDiff.h"
+#include "swift/AST/SynthesizedFileUnit.h"
 #include "swift/SIL/ApplySite.h"
 #include "swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h"
 #include "llvm/ADT/DenseMap.h"
@@ -85,6 +86,9 @@ private:
   /// Mapping from linear map structs to their branching trace enum fields.
   llvm::DenseMap<StructDecl *, VarDecl *> linearMapStructEnumFields;
 
+  /// A synthesized file unit.
+  SynthesizedFileUnit &synthesizedFile;
+
   /// A type converter, used to compute struct/enum SIL types.
   Lowering::TypeConverter &typeConverter;
 
@@ -97,13 +101,8 @@ private:
   VarDecl *addVarDecl(NominalTypeDecl *nominal, StringRef name, Type type);
 
   /// Retrieves the file unit that contains implicit declarations in the
-  /// current Swift module. If it does not exist, create one.
-  ///
-  // FIXME: Currently it defaults to the file containing `original`, if it can
-  // be determined. Otherwise, it defaults to any file unit in the module. To
-  // handle this more properly, we could revive the DerivedFileUnit class to
-  // contain all synthesized implicit type declarations.
-  SourceFile &getDeclarationFileUnit();
+  /// current Swift module.
+  SynthesizedFileUnit &getSynthesizedFile() { return synthesizedFile; }
 
   /// Computes and sets the access level for the given nominal type, given the
   /// original function linkage.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -639,6 +639,7 @@ static_assert(sizeof(checkSourceLocType(&ID##Decl::getLoc)) == 2, \
     return getSerializedLocs()->Loc;
   }
   case FileUnitKind::Builtin:
+  case FileUnitKind::Synthesized:
   case FileUnitKind::ClangModule:
   case FileUnitKind::DWARFModule:
     return SourceLoc();

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -623,6 +623,9 @@ unsigned DeclContext::printContext(raw_ostream &OS, const unsigned indent,
     case FileUnitKind::Source:
       OS << " file=\"" << cast<SourceFile>(this)->getFilename() << "\"";
       break;
+    case FileUnitKind::Synthesized:
+      OS << " synthesized file";
+      break;
     case FileUnitKind::SerializedAST:
     case FileUnitKind::ClangModule:
     case FileUnitKind::DWARFModule:

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1180,6 +1180,8 @@ lookupOperatorDeclForName(const FileUnit &File, SourceLoc Loc,
     // The Builtin module declares no operators.
     return nullptr;
   case FileUnitKind::Synthesized:
+    // Synthesized files currently declare no operators.
+    return nullptr;
   case FileUnitKind::Source:
     break;
   case FileUnitKind::SerializedAST:
@@ -1527,6 +1529,9 @@ StringRef ModuleDecl::getModuleFilename() const {
       Result = LF->getFilename();
       continue;
     }
+    // Skip synthesized files.
+    if (auto *SFU = dyn_cast<SynthesizedFileUnit>(F))
+      continue;
     return StringRef();
   }
   return Result;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2232,11 +2232,6 @@ SourceFile::getCachedVisibleDecls() const {
   return getCache().AllVisibleValues;
 }
 
-void SourceFile::addVisibleDecl(ValueDecl *decl) {
-  Decls->push_back(decl);
-  getCache().AllVisibleValues.push_back(decl);
-}
-
 static void performAutoImport(
     SourceFile &SF,
     SourceFile::ImplicitModuleImportKind implicitModuleImportKind) {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -38,6 +38,7 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/ReferencedNameTracker.h"
 #include "swift/AST/SourceFile.h"
+#include "swift/AST/SynthesizedFileUnit.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Compiler.h"
 #include "swift/Basic/SourceManager.h"
@@ -218,6 +219,7 @@ public:
 
   SmallVector<ValueDecl *, 0> AllVisibleValues;
 };
+
 SourceLookupCache &SourceFile::getCache() const {
   if (!Cache) {
     const_cast<SourceFile *>(this)->Cache =
@@ -317,6 +319,10 @@ SourceLookupCache::SourceLookupCache(const ModuleDecl &M) {
   FrontendStatsTracer tracer(M.getASTContext().Stats,
                              "module-populate-cache");
   for (const FileUnit *file : M.getFiles()) {
+    if (auto *SFU = dyn_cast<SynthesizedFileUnit>(file)) {
+      addToUnqualifiedLookupCache(SFU->getTopLevelDecls(), false);
+      continue;
+    }
     auto &SF = *cast<SourceFile>(file);
     addToUnqualifiedLookupCache(SF.getTopLevelDecls(), false);
   }
@@ -1173,6 +1179,7 @@ lookupOperatorDeclForName(const FileUnit &File, SourceLoc Loc,
   case FileUnitKind::Builtin:
     // The Builtin module declares no operators.
     return nullptr;
+  case FileUnitKind::Synthesized:
   case FileUnitKind::Source:
     break;
   case FileUnitKind::SerializedAST:
@@ -2658,6 +2665,70 @@ SourceFile::lookupOpaqueResultType(StringRef MangledName) {
 }
 
 //===----------------------------------------------------------------------===//
+// SynthesizedFileUnit Implementation
+//===----------------------------------------------------------------------===//
+
+SynthesizedFileUnit::SynthesizedFileUnit(ModuleDecl &M)
+    : FileUnit(FileUnitKind::Synthesized, M) {
+  M.getASTContext().addDestructorCleanup(*this);
+}
+
+Identifier
+SynthesizedFileUnit::getDiscriminatorForPrivateValue(const ValueDecl *D) const {
+  assert(D->getDeclContext()->getModuleScopeContext() == this);
+
+  // Use cached primitive discriminator if it exists.
+  if (!PrivateDiscriminator.empty())
+    return PrivateDiscriminator;
+
+  assert(1 == count_if(getParentModule()->getFiles(),
+                       [](const FileUnit *FU) -> bool {
+                         return isa<SynthesizedFileUnit>(FU);
+                       }) &&
+         "Cannot promise uniqueness if multiple synthesized file units exist");
+
+  // Use a discriminator invariant across Swift version: a hash of the module
+  // name and a special string.
+  llvm::MD5 hash;
+  hash.update(getParentModule()->getName().str());
+  // TODO: Use a more robust discriminator for synthesized files. Pick something
+  // that cannot conflict with `SourceFile` discriminators.
+  hash.update("SYNTHESIZED FILE");
+  llvm::MD5::MD5Result result;
+  hash.final(result);
+
+  // Use the hash as a hex string, prefixed with an underscore to make sure
+  // it is a valid identifier.
+  // FIXME: There are more compact ways to encode a 16-byte value.
+  SmallString<33> buffer{"_"};
+  SmallString<32> hashString;
+  llvm::MD5::stringifyResult(result, hashString);
+  buffer += hashString;
+  PrivateDiscriminator = getASTContext().getIdentifier(buffer.str().upper());
+  return PrivateDiscriminator;
+}
+
+void SynthesizedFileUnit::lookupValue(
+    DeclName name, NLKind lookupKind,
+    SmallVectorImpl<ValueDecl *> &result) const {
+  for (auto *decl : TopLevelDecls) {
+    if (decl->getFullName().matchesRef(name))
+      result.push_back(decl);
+  }
+}
+
+void SynthesizedFileUnit::lookupObjCMethods(
+    ObjCSelector selector,
+    SmallVectorImpl<AbstractFunctionDecl *> &results) const {
+  // Synthesized files only contain top-level declarations, no `@objc` methods.
+}
+
+void SynthesizedFileUnit::getTopLevelDecls(
+    SmallVectorImpl<swift::Decl *> &results) const {
+  results.append(TopLevelDecls.begin(), TopLevelDecls.end());
+}
+
+//===----------------------------------------------------------------------===//
 // Miscellaneous
 //===----------------------------------------------------------------------===//
 
@@ -2694,6 +2765,9 @@ void swift::simple_display(llvm::raw_ostream &out, const FileUnit *file) {
     return;
   case FileUnitKind::Builtin:
     out << "(Builtin)";
+    return;
+  case FileUnitKind::Synthesized:
+    out << "(synthesized)";
     return;
   case FileUnitKind::DWARFModule:
   case FileUnitKind::ClangModule:

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -415,6 +415,7 @@ public:
 } // end anonymous namespace
 
 namespace {
+
 class PrettySourceFileEmission : public llvm::PrettyStackTraceEntry {
   const SourceFile &SF;
 public:
@@ -424,6 +425,19 @@ public:
     os << "While emitting IR for source file " << SF.getFilename() << '\n';
   }
 };
+
+class PrettySynthesizedFileUnitEmission : public llvm::PrettyStackTraceEntry {
+  const SynthesizedFileUnit &SFU;
+
+public:
+  explicit PrettySynthesizedFileUnitEmission(const SynthesizedFileUnit &SFU)
+      : SFU(SFU) {}
+
+  void print(raw_ostream &os) const override {
+    os << "While emitting IR for synthesized file" << &SFU << "\n";
+  }
+};
+
 } // end anonymous namespace
 
 /// Emit all the top-level code in the source file.
@@ -473,6 +487,13 @@ void IRGenModule::emitSourceFile(SourceFile &SF) {
       }
     }
   }
+}
+
+/// Emit all the top-level code in the synthesized file unit.
+void IRGenModule::emitSynthesizedFileUnit(SynthesizedFileUnit &SFU) {
+  PrettySynthesizedFileUnitEmission StackEntry(SFU);
+  for (auto *decl : SFU.getTopLevelDecls())
+    emitGlobalDecl(decl);
 }
 
 /// Collect elements of an already-existing global list with the given

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1241,7 +1241,7 @@ static void performParallelIRGeneration(
       CurrentIGMPtr IGM = irgen.getGenModule(SF);
       IGM->emitSourceFile(*SF);
     } else if (auto *nextSFU = dyn_cast<SynthesizedFileUnit>(File)) {
-      CurrentIGMPtr IGM = irgen.getGenModule(SF);
+      CurrentIGMPtr IGM = irgen.getGenModule(nextSFU);
       IGM->emitSynthesizedFileUnit(*nextSFU);
     } else {
       File->collectLinkLibraries([&](LinkLibrary LinkLib) {

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -990,6 +990,11 @@ performIRGeneration(const IRGenOptions &Opts, ModuleDecl *M,
       }
     }
 
+    // Emit synthesized file units.
+    for (auto *File : M->getFiles())
+      if (auto *nextSFU = dyn_cast<SynthesizedFileUnit>(File))
+        IGM.emitSynthesizedFileUnit(*nextSFU);
+
     // Okay, emit any definitions that we suddenly need.
     irgen.emitLazyDefinitions();
 
@@ -1235,6 +1240,9 @@ static void performParallelIRGeneration(
     if (auto *SF = dyn_cast<SourceFile>(File)) {
       CurrentIGMPtr IGM = irgen.getGenModule(SF);
       IGM->emitSourceFile(*SF);
+    } else if (auto *nextSFU = dyn_cast<SynthesizedFileUnit>(File)) {
+      CurrentIGMPtr IGM = irgen.getGenModule(SF);
+      IGM->emitSynthesizedFileUnit(*nextSFU);
     } else {
       File->collectLinkLibraries([&](LinkLibrary LinkLib) {
         irgen.getPrimaryIGM()->addLinkLibrary(LinkLib);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -25,6 +25,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/ReferenceCounting.h"
 #include "swift/AST/SourceFile.h"
+#include "swift/AST/SynthesizedFileUnit.h"
 #include "swift/Basic/ClusteredBitVector.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/OptimizationMode.h"
@@ -1289,6 +1290,7 @@ public:
   llvm::LLVMContext &getLLVMContext() const { return LLVMContext; }
 
   void emitSourceFile(SourceFile &SF);
+  void emitSynthesizedFileUnit(SynthesizedFileUnit &SFU);
   void addLinkLibrary(const LinkLibrary &linkLib);
 
   /// Attempt to finalize the module.

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -737,6 +737,7 @@ bool IndexSwiftASTWalker::visitImports(
       switch (File->getKind()) {
       case FileUnitKind::Source:
       case FileUnitKind::Builtin:
+      case FileUnitKind::Synthesized:
         break;
       case FileUnitKind::SerializedAST:
         assert(!IsClangModuleOpt.hasValue() &&
@@ -1514,6 +1515,9 @@ void IndexSwiftASTWalker::getRecursiveModuleImports(
           switch (FU->getKind()) {
           case FileUnitKind::Builtin:
             Info += "builtin";
+            break;
+          case FileUnitKind::Synthesized:
+            Info += "synthesized";
             break;
           case FileUnitKind::Source:
             Info += "source, file=\"";

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -406,6 +406,7 @@ static void addModuleDependencies(ArrayRef<ModuleDecl::ImportedModule> imports,
       switch (FU->getKind()) {
       case FileUnitKind::Source:
       case FileUnitKind::Builtin:
+      case FileUnitKind::Synthesized:
         break;
       case FileUnitKind::SerializedAST:
       case FileUnitKind::DWARFModule:

--- a/lib/SILOptimizer/Utils/Differentiation/ADContext.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/ADContext.cpp
@@ -54,17 +54,19 @@ static FuncDecl *findOperatorDeclInProtocol(DeclName operatorName,
 // ADContext methods
 //===----------------------------------------------------------------------===//
 
-static SynthesizedFileUnit *createNewSynthesizedFileUnit(ModuleDecl *module) {
-  auto &ctx = module->getASTContext();
-  auto *file = new (ctx) SynthesizedFileUnit(*module);
-  module->addFile(*file);
-  return file;
-}
-
 ADContext::ADContext(SILModuleTransform &transform)
     : transform(transform), module(*transform.getModule()),
-      passManager(*transform.getPassManager()),
-      synthesizedFile(*createNewSynthesizedFileUnit(module.getSwiftModule())) {}
+      passManager(*transform.getPassManager()) {}
+
+SynthesizedFileUnit &ADContext::getOrCreateSynthesizedFile() {
+  if (synthesizedFile)
+    return *synthesizedFile;
+  auto *moduleDecl = module.getSwiftModule();
+  auto &ctx = moduleDecl->getASTContext();
+  synthesizedFile = new (ctx) SynthesizedFileUnit(*moduleDecl);
+  moduleDecl->addFile(*synthesizedFile);
+  return *synthesizedFile;
+}
 
 FuncDecl *ADContext::getPlusDecl() const {
   if (!cachedPlusFn) {

--- a/lib/SILOptimizer/Utils/Differentiation/ADContext.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/ADContext.cpp
@@ -54,9 +54,17 @@ static FuncDecl *findOperatorDeclInProtocol(DeclName operatorName,
 // ADContext methods
 //===----------------------------------------------------------------------===//
 
+static SynthesizedFileUnit *createNewSynthesizedFileUnit(ModuleDecl *module) {
+  auto &ctx = module->getASTContext();
+  auto *file = new (ctx) SynthesizedFileUnit(*module);
+  module->addFile(*file);
+  return file;
+}
+
 ADContext::ADContext(SILModuleTransform &transform)
     : transform(transform), module(*transform.getModule()),
-      passManager(*transform.getPassManager()) {}
+      passManager(*transform.getPassManager()),
+      synthesizedFile(*createNewSynthesizedFileUnit(module.getSwiftModule())) {}
 
 FuncDecl *ADContext::getPlusDecl() const {
   if (!cachedPlusFn) {

--- a/lib/SILOptimizer/Utils/Differentiation/LinearMapInfo.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/LinearMapInfo.cpp
@@ -58,7 +58,7 @@ LinearMapInfo::LinearMapInfo(ADContext &context, AutoDiffLinearMapKind kind,
                              const DifferentiableActivityInfo &activityInfo)
     : kind(kind), original(original), derivative(derivative),
       activityInfo(activityInfo), indices(indices),
-      synthesizedFile(context.getSynthesizedFile()),
+      synthesizedFile(context.getOrCreateSynthesizedFile()),
       typeConverter(context.getTypeConverter()) {
   generateDifferentiationDataStructures(context, derivative);
 }

--- a/lib/SILOptimizer/Utils/Differentiation/LinearMapInfo.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/LinearMapInfo.cpp
@@ -156,7 +156,7 @@ LinearMapInfo::createBranchingTraceDecl(SILBasicBlock *originalBB,
   computeAccessLevel(branchingTraceDecl, original->getEffectiveSymbolLinkage());
   branchingTraceDecl->getInterfaceType();
   assert(branchingTraceDecl->hasInterfaceType());
-  file.addVisibleDecl(branchingTraceDecl);
+  file.addTopLevelDecl(branchingTraceDecl);
   // Add basic block enum cases.
   for (auto *predBB : originalBB->getPredecessorBlocks()) {
     auto bbId = "bb" + std::to_string(predBB->getDebugID());
@@ -226,7 +226,7 @@ LinearMapInfo::createLinearMapStruct(SILBasicBlock *originalBB,
   computeAccessLevel(linearMapStruct, original->getEffectiveSymbolLinkage());
   linearMapStruct->getInterfaceType();
   assert(linearMapStruct->hasInterfaceType());
-  file.addVisibleDecl(linearMapStruct);
+  file.addTopLevelDecl(linearMapStruct);
   return linearMapStruct;
 }
 

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -350,6 +350,8 @@ void SymbolGraph::serialize(llvm::json::OStream &OS) {
             llvm_unreachable("Unexpected module kind: DWARFModule");
           case FileUnitKind::Source:
             llvm_unreachable("Unexpected module kind: Source");
+          case FileUnitKind::Synthesized:
+            llvm_unreachable("Unexpected module kind: Synthesized");
             break;
           case FileUnitKind::SerializedAST: {
             auto SerializedAST = cast<SerializedASTFile>(MainFile);

--- a/test/AutoDiff/compiler_crashers_fixed/tf1232-autodiff-generated-declaration-mangling.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/tf1232-autodiff-generated-declaration-mangling.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-build-swift -g %s
+// RUN: %target-build-swift -g %s
 // REQUIRES: asserts
 
 // TF-1232: IRGenDebugInfo crash due to lack of proper mangling for


### PR DESCRIPTION
Add `SynthesizedFileUnit`: a container for synthesized declarations. Currently, it only supports module-level declarations.

Use `SynthesizedFileUnit` in the differentiation transform: add implicit generated declarations generated to a `SynthesizedFileUnit` instead of an ad-hoc pre-existing `SourceFile`.

---

Resolves TF-1232: type reconstruction for AutoDiff-generated declarations.

Previously, type reconstruction failed because retroactively adding declarations to a `SourceFile` did not update name lookup caches.

Unblocks end-to-end differentiation transform testing.