### PR TITLE
[SourceKit] Don't use diagnostics to indicate fast-completion

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -856,6 +856,11 @@ public:
   /// e.g. `x = .foo`.
   bool MayUseImplicitMemberExpr = false;
 
+  /// Flag to indicate that the completion is happening reusing ASTContext
+  /// from the previous completion.
+  /// NOTE: Do not use this to change the behavior. This is only for debugging.
+  bool ReusingASTContext = false;
+
   CodeCompletionContext(CodeCompletionCache &Cache)
       : Cache(Cache) {}
 

--- a/include/swift/IDE/CompletionInstance.h
+++ b/include/swift/IDE/CompletionInstance.h
@@ -54,7 +54,7 @@ class CompletionInstance {
       const swift::CompilerInvocation &Invocation, llvm::hash_code ArgsHash,
       llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
       DiagnosticConsumer *DiagC,
-      llvm::function_ref<void(CompilerInstance &)> Callback);
+      llvm::function_ref<void(CompilerInstance &, bool)> Callback);
 
   /// Calls \p Callback with new \c CompilerInstance for the completion
   /// request. The \c CompilerInstace passed to the callback already performed
@@ -66,7 +66,7 @@ class CompletionInstance {
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
       llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
       std::string &Error, DiagnosticConsumer *DiagC,
-      llvm::function_ref<void(CompilerInstance &)> Callback);
+      llvm::function_ref<void(CompilerInstance &, bool)> Callback);
 
 public:
   /// Calls \p Callback with a \c CompilerInstance which is prepared for the
@@ -84,7 +84,7 @@ public:
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
       llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
       bool EnableASTCaching, std::string &Error, DiagnosticConsumer *DiagC,
-      llvm::function_ref<void(CompilerInstance &)> Callback);
+      llvm::function_ref<void(CompilerInstance &, bool)> Callback);
 };
 
 } // namespace ide

--- a/test/SourceKit/CodeComplete/complete_sequence_accessor.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_accessor.swift
@@ -38,7 +38,6 @@ enum S {
 
 // Enabled.
 // RUN: %sourcekitd-test \
-// RUN:   -req=track-compiles == \
 // RUN:   -req=complete -pos=12:9 %s -- %s -parse-as-library == \
 // RUN:   -req=complete -pos=15:15 %s -- %s -parse-as-library == \
 // RUN:   -req=complete -pos=16:15 %s -- %s -parse-as-library == \
@@ -52,7 +51,6 @@ enum S {
 // RUN:   -req=complete -pos=23:1 %s -- %s -parse-as-library == \
 // RUN:   -req=complete -pos=16:1 %s -- %s -parse-as-library > %t.response
 // RUN: %FileCheck --check-prefix=RESULT  %s < %t.response
-// RUN: %FileCheck --check-prefix=TRACE  %s < %t.response
 
 // globalValImplicit
 // RESULT-LABEL: key.results: [
@@ -61,6 +59,8 @@ enum S {
 // RESULT-DAG: key.name: "a"
 // RESULT-DAG: key.name: "b"
 // RESULT: ]
+// RESULT-NOT: key.reusingastcontext: 1
+
 // globalValGetSet(get)
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.name: "fooMethod()"
@@ -68,6 +68,8 @@ enum S {
 // RESULT-DAG: key.name: "x"
 // RESULT-DAG: key.name: "y"
 // RESULT: ]
+// RESULT: key.reusingastcontext: 1
+
 // globalValGetSet(set)
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.name: "barMethod()"
@@ -75,6 +77,8 @@ enum S {
 // RESULT-DAG: key.name: "a"
 // RESULT-DAG: key.name: "b"
 // RESULT: ]
+// RESULT: key.reusingastcontext: 1
+
 // propertyImplicit
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.name: "fooMethod()"
@@ -82,6 +86,8 @@ enum S {
 // RESULT-DAG: key.name: "x"
 // RESULT-DAG: key.name: "y"
 // RESULT: ]
+// RESULT: key.reusingastcontext: 1
+
 // propertyGetSet(get)
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.name: "barMethod()"
@@ -89,6 +95,8 @@ enum S {
 // RESULT-DAG: key.name: "a"
 // RESULT-DAG: key.name: "b"
 // RESULT: ]
+// RESULT: key.reusingastcontext: 1
+
 // propertyGetSet(set)
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.name: "fooMethod()"
@@ -96,6 +104,8 @@ enum S {
 // RESULT-DAG: key.name: "x"
 // RESULT-DAG: key.name: "y"
 // RESULT: ]
+// RESULT: key.reusingastcontext: 1
+
 // subscript(implicit getter)
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.name: "fooMethod()"
@@ -103,6 +113,8 @@ enum S {
 // RESULT-DAG: key.name: "x"
 // RESULT-DAG: key.name: "y"
 // RESULT: ]
+// RESULT: key.reusingastcontext: 1
+
 // subscript(get)
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.name: "barMethod()"
@@ -110,6 +122,8 @@ enum S {
 // RESULT-DAG: key.name: "a"
 // RESULT-DAG: key.name: "b"
 // RESULT: ]
+// RESULT: key.reusingastcontext: 1
+
 // subscript(set)
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.name: "barMethod()"
@@ -117,6 +131,8 @@ enum S {
 // RESULT-DAG: key.name: "a"
 // RESULT-DAG: key.name: "b"
 // RESULT: ]
+// RESULT: key.reusingastcontext: 1
+
 // accessor top (global var)
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.description: "get"
@@ -125,6 +141,8 @@ enum S {
 // RESULT-DAG: key.description: "didSet"
 // RESULT-DAG: key.description: "Foo"
 // RESULT: ]
+// RESULT: key.reusingastcontext: 1
+
 // accessor top (property)
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.description: "get"
@@ -133,6 +151,8 @@ enum S {
 // RESULT-DAG: key.description: "didSet"
 // RESULT-DAG: key.description: "Foo"
 // RESULT: ]
+// RESULT: key.reusingastcontext: 1
+
 // accessor second (global var)
 // RESULT-LABEL: key.results: [
 // RESULT-NOT: key.description: "Foo"
@@ -141,29 +161,4 @@ enum S {
 // RESULT-DAG: key.description: "willSet"
 // RESULT-DAG: key.description: "didSet"
 // RESULT: ]
-
-
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE-NOT: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE-NOT: key.description: "completion reusing previous ASTContext (benign diagnostic)"
+// RESULT-NOT: key.reusingastcontext: 1

--- a/test/SourceKit/CodeComplete/complete_sequence_crossfile.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_crossfile.swift
@@ -29,15 +29,15 @@ extension Bar {
 
 // BEGIN dummy.swift
 
+// NOTE: Test that switching editing file doesn't trigger fast-completion
+
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=track-compiles == \
 // RUN:   -req=complete -pos=7:11 %t/file1.swift -- %t/file1.swift %t/file2.swift == \
 // RUN:   -req=complete -pos=6:11 %t/file2.swift -- %t/file1.swift %t/file2.swift > %t.response
 // RUN: %FileCheck --check-prefix=RESULT  %s < %t.response
-// RUN: %FileCheck --check-prefix=TRACE  %s < %t.response
 
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.name: "fooMethod()"
@@ -45,11 +45,12 @@ extension Bar {
 // RESULT-DAG: key.name: "x"
 // RESULT-DAG: key.name: "y"
 // RESULT: ]
+// RESULT-NOT: key.reusingastcontext: 1
+
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.name: "barMethod()"
 // RESULT-DAG: key.name: "self"
 // RESULT-DAG: key.name: "a"
 // RESULT-DAG: key.name: "b"
 // RESULT: ]
-
-// TRACE-NOT: key.description: "completion reusing previous ASTContext (benign diagnostic)"
+// RESULT-NOT: key.reusingastcontext: 1

--- a/test/SourceKit/CodeComplete/complete_sequence_edit.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_edit.swift
@@ -44,12 +44,10 @@ func foo(arg: Foo) {
 // RUN: %{python} %utils/split_file.py -o %t %s
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=track-compiles == \
 // RUN:   -req=complete -pos=8:11 -name file.swift -text-input %t/State1.swift -- file.swift == \
 // RUN:   -req=complete -pos=11:13 -name file.swift -text-input %t/State2.swift -- file.swift == \
 // RUN:   -req=complete -pos=12:13 -name file.swift -text-input %t/State3.swift -- file.swift > %t.response
 // RUN: %FileCheck --check-prefix=RESULT  %s < %t.response
-// RUN: %FileCheck --check-prefix=TRACE  %s < %t.response
 
 // RESULT-LABEL: key.results: [
 // RESULT-NOT: key.name: "z"
@@ -58,6 +56,7 @@ func foo(arg: Foo) {
 // RESULT-DAG: key.name: "x"
 // RESULT-DAG: key.name: "y"
 // RESULT: ]
+// RESULT-NOT: key.reusingastcontext: 1
 
 // RESULT-LABEL: key.results: [
 // RESULT-NOT: key.name: "z"
@@ -66,6 +65,7 @@ func foo(arg: Foo) {
 // RESULT-DAG: key.name: "x"
 // RESULT-DAG: key.name: "y"
 // RESULT: ]
+// RESULT: key.reusingastcontext: 1
 
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.name: "fooMethod()"
@@ -74,16 +74,4 @@ func foo(arg: Foo) {
 // RESULT-DAG: key.name: "y"
 // RESULT-DAG: key.name: "z"
 // RESULT: ]
-
-// TRACE:      key.notification: source.notification.compile-did-finish,
-// TRACE-NEXT: key.diagnostics: [
-// TRACE-NEXT: ]
-
-// TRACE:      key.notification: source.notification.compile-did-finish,
-// TRACE-NEXT: key.diagnostics: [
-// TRACE:          key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE:      ]
-
-// TRACE:      key.notification: source.notification.compile-did-finish,
-// TRACE-NEXT: key.diagnostics: [
-// TRACE-NEXT: ]
+// RESULT-NOT: key.reusingastcontext: 1

--- a/test/SourceKit/CodeComplete/complete_sequence_func_in_closure.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_func_in_closure.swift
@@ -19,37 +19,46 @@ struct MyStruct {
 }
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=track-compiles == \
 // RUN:   -req=complete -pos=7:11 -repeat-request=2 %s -- %s -parse-as-library == \
 // RUN:   -req=complete -pos=15:15 -repeat-request=2 %s -- %s -parse-as-library \
 // RUN:   > %t.response.library
-// RUN: %FileCheck --check-prefix=RESULT %s < %t.response.library
-// RUN: %FileCheck --check-prefix=LIB_TRACE %s < %t.response.library
+// RUN: %FileCheck --check-prefix=RESULT_LIBRARY %s < %t.response.library
 
-// RESULT-LABEL: key.results: [
-// RESULT: key.description: "value"
-// RESULT-LABEL: key.results: [
-// RESULT: key.description: "value"
-// RESULT-LABEL: key.results: [
-// RESULT: key.description: "value"
-// RESULT-LABEL: key.results: [
-// RESULT: key.description: "value"
+// RESULT_LIBRARY-LABEL: key.results: [
+// RESULT_LIBRARY: key.description: "value"
+// RESULT_LIBRARY-NOT: key.reusingastcontext: 1
 
-// LIB_TRACE-NOT:  key.description: "completion reusing previous ASTContext (benign diagnostic)"
+// RESULT_LIBRARY-LABEL: key.results: [
+// RESULT_LIBRARY: key.description: "value"
+// RESULT_LIBRARY-NOT: key.reusingastcontext: 1
+
+// RESULT_LIBRARY-LABEL: key.results: [
+// RESULT_LIBRARY: key.description: "value"
+// RESULT_LIBRARY-NOT: key.reusingastcontext: 1
+
+// RESULT_LIBRARY-LABEL: key.results: [
+// RESULT_LIBRARY: key.description: "value"
+// RESULT_LIBRARY-NOT: key.reusingastcontext: 1
+
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=track-compiles == \
 // RUN:   -req=complete -pos=7:11 -repeat-request=2 %s -- %s == \
 // RUN:   -req=complete -pos=15:15 -repeat-request=2 %s -- %s \
 // RUN:   > %t.response.script
-// RUN: %FileCheck --check-prefix=RESULT %s < %t.response.script
-// RUN: %FileCheck --check-prefix=SCRIPT_TRACE %s < %t.response.script
+// RUN: %FileCheck --check-prefix=RESULT_SCRIPT %s < %t.response.script
 
-// SCRIPT_TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// SCRIPT_TRACE-NOT: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// SCRIPT_TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// SCRIPT_TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// SCRIPT_TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// SCRIPT_TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// SCRIPT_TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// SCRIPT_TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
+// RESULT_SCRIPT-LABEL: key.results: [
+// RESULT_SCRIPT: key.description: "value"
+// RESULT_SCRIPT-NOT: key.reusingastcontext: 1
+
+// RESULT_SCRIPT-LABEL: key.results: [
+// RESULT_SCRIPT: key.description: "value"
+// RESULT_SCRIPT: key.reusingastcontext: 1
+
+// RESULT_SCRIPT-LABEL: key.results: [
+// RESULT_SCRIPT: key.description: "value"
+// RESULT_SCRIPT: key.reusingastcontext: 1
+
+// RESULT_SCRIPT-LABEL: key.results: [
+// RESULT_SCRIPT: key.description: "value"
+// RESULT_SCRIPT: key.reusingastcontext: 1

--- a/test/SourceKit/CodeComplete/complete_sequence_nestedtype.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_nestedtype.swift
@@ -15,13 +15,11 @@ struct Outer {
 }
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=track-compiles == \
 // RUN:   -req=complete -pos=8:13 %s -- %s == \
 // RUN:   -req=complete -pos=8:13 %s -- %s == \
 // RUN:   -req=complete -pos=13:11 %s -- %s \
 // RUN:   > %t.response
 // RUN: %FileCheck --check-prefix=RESULT  %s < %t.response
-// RUN: %FileCheck --check-prefix=TRACE  %s < %t.response
 
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.description: "east"
@@ -29,22 +27,20 @@ struct Outer {
 // RESULT-DAG: key.description: "staticMethod()"
 // RESULT-DAG: key.description: "instanceMethod(self: Outer.Inner)"
 // RESULT: ]
+// RESULT-NOT: key.reusingastcontext: 1
+
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.description: "east"
 // RESULT-DAG: key.description: "west"
 // RESULT-DAG: key.description: "staticMethod()"
 // RESULT-DAG: key.description: "instanceMethod(self: Outer.Inner)"
 // RESULT: ]
+// RESULT: key.reusingastcontext: 1
+
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.description: "east"
 // RESULT-DAG: key.description: "west"
 // RESULT-DAG: key.description: "staticMethod()"
 // RESULT-DAG: key.description: "instanceMethod(self: Inner)"
 // RESULT: ]
-
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE-NOT: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
+// RESULT: key.reusingastcontext: 1

--- a/test/SourceKit/CodeComplete/complete_sequence_property_wrapper.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_property_wrapper.swift
@@ -21,16 +21,13 @@ struct MyStruct {
 // RUN:   -req=track-compiles == \
 // RUN:   -req=complete -pos=16:1 -repeat-request=2 %s -- %s > %t.response
 // RUN: %FileCheck --check-prefix=RESULT  %s < %t.response
-// RUN: %FileCheck --check-prefix=TRACE  %s < %t.response
 
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.description: "barParam"
 // RESULT: ]
+// RESULT-NOT: key.reusingastcontext: 1
+
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.description: "barParam"
 // RESULT: ]
-
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE-NOT: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
+// RESULT: key.reusingastcontext: 1

--- a/test/SourceKit/CodeComplete/complete_sequence_toplevel.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_toplevel.swift
@@ -17,12 +17,10 @@ _ = Bar(a: 12, b: 42)
 
 // Enabled.
 // RUN: %sourcekitd-test \
-// RUN:   -req=track-compiles == \
 // RUN:   -req=complete -pos=14:11 %s -- %s == \
 // RUN:   -req=complete -pos=13:15 %s -- %s == \
 // RUN:   -req=complete -pos=16:22 %s -- %s > %t.response
 // RUN: %FileCheck --check-prefix=RESULT %s < %t.response
-// RUN: %FileCheck --check-prefix=TRACE %s < %t.response
 
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.name: "fooMethod()"
@@ -30,20 +28,18 @@ _ = Bar(a: 12, b: 42)
 // RESULT-DAG: key.name: "x"
 // RESULT-DAG: key.name: "y"
 // RESULT: ]
+// RESULT-NOT: key.reusingastcontext: 1
+
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.name: "Foo"
 // RESULT-DAG: key.name: "Bar"
 // RESULT: ]
+// RESULT: key.reusingastcontext: 1
+
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.name: "barMethod()"
 // RESULT-DAG: key.name: "self"
 // RESULT-DAG: key.name: "a"
 // RESULT-DAG: key.name: "b"
 // RESULT: ]
-
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE-NOT: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
+// RESULT: key.reusingastcontext: 1

--- a/test/SourceKit/CodeComplete/complete_sequence_toplevel_edit.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_toplevel_edit.swift
@@ -54,13 +54,11 @@ func dummy(x: ) {
 // RUN: %{python} %utils/split_file.py -o %t %s
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=track-compiles == \
 // RUN:   -req=complete -pos=7:21 -name file.swift -text-input %t/State1.swift -- file.swift == \
 // RUN:   -req=complete -pos=9:25 -name file.swift -text-input %t/State2.swift -- file.swift == \
 // RUN:   -req=complete -pos=10:27 -name file.swift -text-input %t/State3.swift -- file.swift == \
 // RUN:   -req=complete -pos=10:15 -name file.swift -text-input %t/State4.swift -- file.swift > %t.response
 // RUN: %FileCheck --check-prefix=RESULT %s < %t.response
-// RUN: %FileCheck --check-prefix=TRACE %s < %t.response
 
 // RESULT-LABEL: key.results: [
 // RESULT-NOT: key.description: "fooMethod()"
@@ -68,6 +66,7 @@ func dummy(x: ) {
 // RESULT-NOT: key.description: "y"
 // RESULT-DAG: key.description: "(x: Int, y: Int)",
 // RESULT: ]
+// RESULT-NOT: key.reusingastcontext: 1
 
 // RESULT-LABEL: key.results: [
 // RESULT-NOT: key.description: "z"
@@ -76,6 +75,7 @@ func dummy(x: ) {
 // RESULT-DAG: key.description: "x"
 // RESULT-DAG: key.description: "y"
 // RESULT: ]
+// RESULT: key.reusingastcontext: 1
 
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.description: "fooMethod()"
@@ -84,17 +84,10 @@ func dummy(x: ) {
 // RESULT-DAG: key.description: "y"
 // RESULT-DAG: key.description: "z"
 // RESULT: ]
+// RESULT: key.reusingastcontext: 1
 
 // RESULT-LABEL: key.results: [
 // RESULT-NOT: key.description: "globalFoo"
 // RESULT-DAG: key.description: "Foo"
 // RESULT: ]
-
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE-NOT: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
+// RESULT: key.reusingastcontext: 1

--- a/test/SourceKit/CodeComplete/complete_sequence_toplevel_edit_import.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_toplevel_edit_import.swift
@@ -22,43 +22,36 @@ import Bar
 // RUN: %{python} %utils/split_file.py -o %t %s
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=track-compiles == \
 // RUN:   -req=complete -pos=3:1 -name main.swift -text-input %t/State1.swift -- main.swift -F %S/../Inputs/libIDE-mock-sdk == \
 // RUN:   -req=complete -pos=3:1 -name main.swift -text-input %t/State2.swift -- main.swift -F %S/../Inputs/libIDE-mock-sdk == \
 // RUN:   -req=complete -pos=3:1 -name main.swift -text-input %t/State3.swift -- main.swift -F %S/../Inputs/libIDE-mock-sdk == \
 // RUN:   -req=complete -pos=3:1 -name main.swift -text-input %t/State4.swift -- main.swift -F %S/../Inputs/libIDE-mock-sdk > %t.response
 // RUN: %FileCheck --check-prefix=RESULT %s < %t.response
-// RUN: %FileCheck --check-prefix=TRACE %s < %t.response
 
 // RESULT-LABEL: key.results: [
 // RESULT-NOT: key.description: "Bar",
 // RESULT-DAG: key.description: "Foo",
 // RESULT-DAG: key.description: "FooHelper",
 // RESULT: ]
+// RESULT-NOT: key.reusingastcontext: 1
 
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.description: "Foo",
 // RESULT-DAG: key.description: "FooHelper",
 // RESULT-DAG: key.description: "Bar",
 // RESULT: ]
+// RESULT: key.reusingastcontext: 1
 
 // RESULT-LABEL: key.results: [
 // RESULT-NOT: key.description: "Foo",
 // RESULT-NOT: key.description: "FooHelper",
 // RESULT-DAG: key.description: "Bar",
 // RESULT: ]
+// RESULT: key.reusingastcontext: 1
 
 // RESULT-LABEL: key.results: [
 // RESULT-NOT: key.description: "Foo",
 // RESULT-NOT: key.description: "FooHelper",
 // RESULT-NOT: key.description: "Bar",
 // RESULT: ]
-
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE-NOT: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
-// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
-// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"
+// RESULT: key.reusingastcontext: 1

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -145,6 +145,7 @@ public:
   virtual void failed(StringRef ErrDescription) = 0;
 
   virtual void setCompletionKind(UIdent kind) {};
+  virtual void setReusingASTContext(bool) {};
   virtual bool handleResult(const CodeCompletionInfo &Info) = 0;
 };
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -129,11 +129,12 @@ static bool swiftCodeCompleteImpl(
     bool EnableASTCaching, bool annotateDescription, std::string &Error) {
   return Lang.performCompletionLikeOperation(
       UnresolvedInputFile, Offset, Args, FileSystem, EnableASTCaching, Error,
-      [&](CompilerInstance &CI) {
+      [&](CompilerInstance &CI, bool reusingASTContext) {
         // Create a factory for code completion callbacks that will feed the
         // Consumer.
         auto swiftCache = Lang.getCodeCompletionCache(); // Pin the cache.
         ide::CodeCompletionContext CompletionContext(swiftCache->getCache());
+        CompletionContext.ReusingASTContext = reusingASTContext;
         CompletionContext.setAnnotateResult(annotateDescription);
         std::unique_ptr<CodeCompletionCallbacksFactory> callbacksFactory(
             ide::makeCodeCompletionCallbacksFactory(CompletionContext,
@@ -211,6 +212,8 @@ void SwiftLangSupport::codeComplete(
               SKConsumer, Result, CCOpts.annotatedDescription))
         break;
     }
+    
+    SKConsumer.setReusingASTContext(info.completionContext->ReusingASTContext);
   });
 
   std::string Error;

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -35,7 +35,7 @@ static bool swiftConformingMethodListImpl(
     bool EnableASTCaching, std::string &Error) {
   return Lang.performCompletionLikeOperation(
       UnresolvedInputFile, Offset, Args, FileSystem, EnableASTCaching, Error,
-      [&](CompilerInstance &CI) {
+      [&](CompilerInstance &CI, bool reusingASTContext) {
         // Create a factory for code completion callbacks that will feed the
         // Consumer.
         std::unique_ptr<CodeCompletionCallbacksFactory> callbacksFactory(

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -957,7 +957,7 @@ bool SwiftLangSupport::performCompletionLikeOperation(
     ArrayRef<const char *> Args,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
     bool EnableASTCaching, std::string &Error,
-    llvm::function_ref<void(CompilerInstance &)> Callback) {
+    llvm::function_ref<void(CompilerInstance &, bool)> Callback) {
   assert(FileSystem);
 
   // Resolve symlinks for the input file; we resolve them for the input files

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -444,7 +444,7 @@ public:
       ArrayRef<const char *> Args,
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
       bool EnableASTCaching, std::string &Error,
-      llvm::function_ref<void(swift::CompilerInstance &)> Callback);
+      llvm::function_ref<void(swift::CompilerInstance &, bool)> Callback);
 
   //==========================================================================//
   // LangSupport Interface

--- a/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
@@ -33,7 +33,7 @@ static bool swiftTypeContextInfoImpl(
     bool EnableASTCaching, std::string &Error) {
   return Lang.performCompletionLikeOperation(
       UnresolvedInputFile, Offset, Args, FileSystem, EnableASTCaching, Error,
-      [&](CompilerInstance &CI) {
+      [&](CompilerInstance &CI, bool reusingASTContext) {
         // Create a factory for code completion callbacks that will feed the
         // Consumer.
         std::unique_ptr<CodeCompletionCallbacksFactory> callbacksFactory(

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1933,6 +1933,7 @@ public:
   void failed(StringRef ErrDescription) override;
 
   void setCompletionKind(UIdent kind) override;
+  void setReusingASTContext(bool flag) override;
   bool handleResult(const CodeCompletionInfo &Info) override;
 };
 } // end anonymous namespace
@@ -1962,6 +1963,11 @@ void SKCodeCompletionConsumer::failed(StringRef ErrDescription) {
 void SKCodeCompletionConsumer::setCompletionKind(UIdent kind) {
   assert(kind.isValid());
   RespBuilder.getDictionary().set(KeyKind, kind);
+}
+
+void SKCodeCompletionConsumer::setReusingASTContext(bool flag) {
+  if (flag)
+    RespBuilder.getDictionary().setBool(KeyReusingASTContext, flag);
 }
 
 bool SKCodeCompletionConsumer::handleResult(const CodeCompletionInfo &R) {

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -792,7 +792,8 @@ static bool doCodeCompletionImpl(
       Invocation, /*Args=*/{}, llvm::vfs::getRealFileSystem(), CleanFile.get(),
       Offset, /*EnableASTCaching=*/false, Error,
       CodeCompletionDiagnostics ? &PrintDiags : nullptr,
-      [&](CompilerInstance &CI) {
+      [&](CompilerInstance &CI, bool reusingASTContext) {
+        assert(!reusingASTContext && "reusing AST context without enabling it");
         auto SF = CI.getCodeCompletionFile();
         performCodeCompletionSecondPass(*SF.get(), *callbacksFactory);
       });

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -178,6 +178,7 @@ UID_KEYS = [
     KEY('Files', 'key.files'),
     KEY('OptimizeForIDE', 'key.optimize_for_ide'),
     KEY('RequiredBystanders', 'key.required_bystanders'),
+    KEY('ReusingASTContext', 'key.reusingastcontext'),
 ]
 
 


### PR DESCRIPTION
Add `key.reusingastcontext: 1` to the response instead.
Using diagnostics can be a noise to indexing log clients.

rdar://problem/61367416
