### PR TITLE
test: mark stdlib/StringSwitch as executable_test

### DIFF
--- a/test/stdlib/StringSwitch.swift
+++ b/test/stdlib/StringSwitch.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// REQUIRES: executable_test
 
 import StdlibUnittest
 


### PR DESCRIPTION
This is a runtime test, ensure that is marked as an execution test.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
