### PR TITLE
[SourceKit/CodeFormat] Column-align multiple patterns in catch clauses

### DIFF
--- a/test/SourceKit/CodeFormat/indent-trailing/trailing-catch-item-comma.swift
+++ b/test/SourceKit/CodeFormat/indent-trailing/trailing-catch-item-comma.swift
@@ -1,0 +1,7 @@
+do {
+    print("hello")
+} catch MyErr.a(let code),
+        MyErr.b(let code),
+
+// RUN: %sourcekitd-test -req=format -line=5 -length=1 %s | %FileCheck --strict-whitespace %s
+// CHECK: key.sourcetext: "        "

--- a/test/SourceKit/CodeFormat/indent-trailing/trailing-catch-item-no-comma.swift
+++ b/test/SourceKit/CodeFormat/indent-trailing/trailing-catch-item-no-comma.swift
@@ -1,0 +1,7 @@
+do {
+    print("hello")
+} catch MyErr.a(let code),
+        MyErr.b(let code)
+
+// RUN: %sourcekitd-test -req=format -line=5 -length=1 %s | %FileCheck --strict-whitespace %s
+// CHECK: key.sourcetext: ""

--- a/test/swift-indent/basic.swift
+++ b/test/swift-indent/basic.swift
@@ -939,3 +939,36 @@ IncrementedFirst++
     }++
     .baz()
 
+
+// Multiple patterns in catch should align exactly.
+
+do {
+    print("hello")
+} catch MyErr.a(let code, let message),
+        MyErr.b(
+            let code,
+            let message
+        ),
+        MyErr.c(let code, let message) {
+    print("ahhh!")
+}
+
+do {
+    throw MyErr.a
+} catch where foo == 0,
+        where bar == 1 {
+}
+
+do
+{
+    print("hello")
+}
+catch MyErr.a(let code, let message),
+      MyErr.b(
+        let code,
+        let message
+      ),
+      MyErr.c(let code, let message)
+{
+    print("ahhh!")
+}


### PR DESCRIPTION
`catch` clauses now support multiple patterns thanks to https://github.com/apple/swift/pull/27776. Like `case` patterns, these should be column-aligned if split across multiple lines like below:
```
do {
  ...
} catch MyErr.a(let x),
        MyErr.b(let x) {
  print("hello")
}
```

Resolves rdar://problem/61614223