### PR TITLE
Add init_existential_metatype to CSE.

### DIFF
--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -859,6 +859,21 @@ namespace {
       return true;
     }
 
+    bool
+    visitInitExistentialMetatypeInst(const InitExistentialMetatypeInst *RHS) {
+      auto *X = cast<InitExistentialMetatypeInst>(LHS);
+      ArrayRef<ProtocolConformanceRef> lhsConformances = X->getConformances();
+      ArrayRef<ProtocolConformanceRef> rhsConformances = RHS->getConformances();
+      if (lhsConformances.size() != rhsConformances.size())
+        return false;
+
+      for (unsigned i : indices(lhsConformances)) {
+        if (lhsConformances[i] != rhsConformances[i])
+          return false;
+      }
+      return true;
+    }
+
   private:
     const SILInstruction *LHS;
   };

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -241,6 +241,13 @@ public:
     return llvm::hash_combine(X->getKind(), X->getType());
   }
 
+  hash_code visitInitExistentialMetatypeInst(InitExistentialMetatypeInst *X) {
+    return llvm::hash_combine(
+        X->getKind(), X->getType(), X->getOperand(),
+        llvm::hash_combine_range(X->getConformances().begin(),
+                                 X->getConformances().end()));
+  }
+
   hash_code visitObjCProtocolInst(ObjCProtocolInst *X) {
     return llvm::hash_combine(X->getKind(), X->getType(), X->getProtocol());
   }
@@ -1032,6 +1039,7 @@ bool CSE::canHandle(SILInstruction *Inst) {
   case SILInstructionKind::PointerToThinFunctionInst:
   case SILInstructionKind::MarkDependenceInst:
   case SILInstructionKind::OpenExistentialRefInst:
+  case SILInstructionKind::InitExistentialMetatypeInst:
   case SILInstructionKind::WitnessMethodInst:
     // Intentionally we don't handle (prev_)dynamic_function_ref.
     // They change at runtime.

--- a/test/SILOptimizer/Inputs/cse_metatype_conformanceA.swift
+++ b/test/SILOptimizer/Inputs/cse_metatype_conformanceA.swift
@@ -1,0 +1,6 @@
+// Modules B and C will have separate conformance from A to P.
+public struct A {}
+
+public protocol P {
+  static func foo()
+}

--- a/test/SILOptimizer/Inputs/cse_metatype_conformanceB.swift
+++ b/test/SILOptimizer/Inputs/cse_metatype_conformanceB.swift
@@ -1,0 +1,13 @@
+import moda
+
+// module B
+extension A: P {
+  public static func foo() {
+    print("modA\n")
+  }
+} // conformance B
+
+@inlinable
+public func getPFromB() -> P.Type {
+  return A.self
+}

--- a/test/SILOptimizer/Inputs/cse_metatype_conformanceC.swift
+++ b/test/SILOptimizer/Inputs/cse_metatype_conformanceC.swift
@@ -1,0 +1,13 @@
+import moda
+
+// module C
+extension A: P {
+  public static func foo() {
+    print("modC\n")
+  }
+} // conformance C
+
+@inlinable
+public func getPFromC() -> P.Type {
+  return A.self
+}

--- a/test/SILOptimizer/cse.sil
+++ b/test/SILOptimizer/cse.sil
@@ -1294,4 +1294,21 @@ bb0:
   return %35 : $Int64
 }
 
+// Test init_existential_metatype combining.
+protocol SomeP {}
 
+public enum SpecialEnum : SomeP {}
+
+// CHECK-LABEL: sil @testCSEInitExistentialMetatype : $@convention(thin) (@thick SpecialEnum.Type) -> Bool {
+// CHECK:   [[EMT:%.*]] = init_existential_metatype %0 : $@thick SpecialEnum.Type, $@thick Any.Type
+// CHECK-NOT: init_existential_metatype
+// CHECK:   builtin "is_same_metatype"([[EMT]] : $@thick Any.Type, [[EMT]] : $@thick Any.Type) : $Builtin.Int1
+// CHECK-LABEL: }  // end sil function 'testCSEInitExistentialMetatype'
+sil @testCSEInitExistentialMetatype : $@convention(thin) (@thick SpecialEnum.Type) -> Bool {
+bb0(%0 : $@thick SpecialEnum.Type):
+  %1 = init_existential_metatype %0 : $@thick SpecialEnum.Type, $@thick Any.Type
+  %2 = init_existential_metatype %0 : $@thick SpecialEnum.Type, $@thick Any.Type
+  %3 = builtin "is_same_metatype"(%1 : $@thick Any.Type, %2 : $@thick Any.Type) : $Builtin.Int1
+  %4 = struct $Bool (%3 : $Builtin.Int1)
+  return %4 : $Bool
+}

--- a/test/SILOptimizer/cse_metatype_conformance.swift
+++ b/test/SILOptimizer/cse_metatype_conformance.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %S/Inputs/cse_metatype_conformanceA.swift -module-name moda -emit-module -emit-module-path %t/moda.swiftmodule
+// RUN: %target-swift-frontend %S/Inputs/cse_metatype_conformanceB.swift -module-name modb -emit-module -emit-module-path %t/modb.swiftmodule -I %t
+// RUN: %target-swift-frontend %S/Inputs/cse_metatype_conformanceC.swift -module-name modc -emit-module -emit-module-path %t/modc.swiftmodule -I %t
+// RUN: %target-swift-frontend  -I %t -O -emit-sil -sil-verify-all -parse-as-library %s | %FileCheck %s --check-prefix=CHECK
+
+// Test CSE of init_existential_metatype. Combine instructions with
+// conformance from the same module. Don't combine instructions with
+// conformances from different modules.
+
+// swift -frontend -emit-sil ./checkprotocoltype.swift -O -parse-as-library
+import moda
+import modb
+import modc
+
+@inline(never)
+func callFoo(ptype: P.Type) {
+  ptype.foo()
+}
+
+// CHECK-LABEL: sil @$s24cse_metatype_conformance15testConformanceyyF : $@convention(thin) () -> () {
+// CHECK: [[MT:%.*]] = metatype $@thick A.Type
+// CHECK: [[MTB:%.*]] = init_existential_metatype %0 : $@thick A.Type, $@thick P.Type
+// CHECK: [[F:%.*]] = function_ref @$s24cse_metatype_conformance7callFoo5ptypey4moda1P_pXp_tF : $@convention(thin) (@thick P.Type) -> ()
+// CHECK: apply [[F]]([[MTB]]) : $@convention(thin) (@thick P.Type) -> ()
+// CHECK: apply [[F]]([[MTB]]) : $@convention(thin) (@thick P.Type) -> ()
+// CHECK: [[MTC:%.*]] = init_existential_metatype %0 : $@thick A.Type, $@thick P.Type
+// CHECK: apply [[F]]([[MTC]]) : $@convention(thin) (@thick P.Type) -> ()
+// CHECK-LABEL: } // end sil function '$s24cse_metatype_conformance15testConformanceyyF'
+public func testConformance() {
+  let ptb1: P.Type = getPFromB()
+  callFoo(ptype: ptb1)
+  let ptb2: P.Type = getPFromB()
+  callFoo(ptype: ptb2)
+  let ptc: P.Type = getPFromC()
+  callFoo(ptype: ptc)
+}


### PR DESCRIPTION
So String decoding can be optimized.

Part 2/3 of optimizations for #30729