### PR TITLE
[AutoDiff] Minor SILOptimizer changes.

### DIFF
--- a/include/swift/SILOptimizer/Utils/Differentiation/AdjointValue.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/AdjointValue.h
@@ -148,7 +148,7 @@ public:
               std::get<1>(elt).print(s);
             },
             [&s] { s << ", "; });
-      } else if (auto tupleType = getType().getAs<TupleType>()) {
+      } else if (getType().is<TupleType>()) {
         s << "Tuple>(";
         interleave(
             base->value.aggregate,

--- a/lib/SILOptimizer/Utils/Differentiation/LinearMapInfo.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/LinearMapInfo.cpp
@@ -122,9 +122,11 @@ LinearMapInfo::createBranchingTraceDecl(SILBasicBlock *originalBB,
   auto &file = getSynthesizedFile();
   // Create a branching trace enum.
   Mangle::ASTMangler mangler;
+  auto originalFnTy = original->getLoweredFunctionType();
+  auto numResults = originalFnTy->getNumResults() +
+                    originalFnTy->getNumIndirectMutatingParameters();
   auto *resultIndices = IndexSubset::get(
-      original->getASTContext(),
-      original->getLoweredFunctionType()->getNumResults(), indices.source);
+      original->getASTContext(), numResults, indices.source);
   auto *parameterIndices = indices.parameters;
   AutoDiffConfig config(parameterIndices, resultIndices, genericSig);
   auto enumName = mangler.mangleAutoDiffGeneratedDeclaration(
@@ -193,9 +195,11 @@ LinearMapInfo::createLinearMapStruct(SILBasicBlock *originalBB,
   auto &file = getSynthesizedFile();
   // Create a linear map struct.
   Mangle::ASTMangler mangler;
+  auto originalFnTy = original->getLoweredFunctionType();
+  auto numResults = originalFnTy->getNumResults() +
+                    originalFnTy->getNumIndirectMutatingParameters();
   auto *resultIndices = IndexSubset::get(
-      original->getASTContext(),
-      original->getLoweredFunctionType()->getNumResults(), indices.source);
+      original->getASTContext(), numResults, indices.source);
   auto *parameterIndices = indices.parameters;
   AutoDiffConfig config(parameterIndices, resultIndices, genericSig);
   auto structName = mangler.mangleAutoDiffGeneratedDeclaration(


### PR DESCRIPTION
NFC: silence unused variable warnings.

---

Fix LinearMapInfo result indices calculation: result indices capacity should equal original function "semantic result" count (formal results and `inout` parameters), not just the formal result count.

Fixes `inout` parameter differentiation.