### PR TITLE
tests: fix the benchmark test after renaming some benchmarks

### DIFF
--- a/test/benchmark/Benchmark_O.test.md
+++ b/test/benchmark/Benchmark_O.test.md
@@ -103,9 +103,9 @@ ALPHASORT: FatCompactMap
 Substring filters using + and - prefix
 
 ````
-RUN: %Benchmark_O --list -.A +Angry -Small AngryPhonebook.ASCII.Small \
+RUN: %Benchmark_O --list -.A +Angry -Small AngryPhonebook.ASCII2.Small \
 RUN:             | %FileCheck %s --check-prefix FILTERS
-FILTERS: AngryPhonebook.ASCII.Small
+FILTERS: AngryPhonebook.ASCII2.Small
 FILTERS-NOT: AngryPhonebook.Armenian
 FILTERS-NOT: AngryPhonebook.Cyrillic.Small
 FILTERS: AngryPhonebook.Cyrillic


### PR DESCRIPTION
A follow-up fix for https://github.com/apple/swift/pull/30822