### PR TITLE
[metadata prespecialization] Not always on for stdlib.

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1398,11 +1398,6 @@ void IRGenModule::error(SourceLoc loc, const Twine &message) {
 bool IRGenModule::useDllStorage() { return ::useDllStorage(Triple); }
 
 bool IRGenModule::shouldPrespecializeGenericMetadata() {
-  // Prespecialize generic metadata in the standard library always, disregarding
-  // flags.
-  if (isStandardLibrary()) {
-    return true;
-  }
   auto &context = getSwiftModule()->getASTContext();
   auto deploymentAvailability =
       AvailabilityContext::forDeploymentTarget(context);


### PR DESCRIPTION
Prespecializing metadata in the stdlib looks to be exposing a bug in its implementation.  Disabling for now.