### PR TITLE
[clangimporter] Include clang/AST/ASTContext.h to fix master-next build.

### DIFF
--- a/include/swift/ClangImporter/SwiftAbstractBasicReader.h
+++ b/include/swift/ClangImporter/SwiftAbstractBasicReader.h
@@ -19,6 +19,7 @@
 #ifndef SWIFT_CLANGIMPORTER_SWIFTABSTRACTBASICREADER_H
 #define SWIFT_CLANGIMPORTER_SWIFTABSTRACTBASICREADER_H
 
+#include "clang/AST/ASTContext.h"
 #include "clang/AST/AbstractTypeReader.h"
 
 // This include is required to instantiate the template code in


### PR DESCRIPTION
This  patch fixes a build issue on swift:master-next.  Specifically, a translation unit that seems to include code from SwiftAbstractBasicReader.h (which Deserialization.cpp) includes.  The ASTContext used in that unit is incomplete otherwise.

I don't have commit access, and it seems that is required to get the swift-ci to start testing, but I'll try anyways :)
@swift-ci Please smoke test

