### PR TITLE
Make StringRef to std::string conversion explicit.

### DIFF
--- a/include/swift/ClangImporter/SwiftAbstractBasicReader.h
+++ b/include/swift/ClangImporter/SwiftAbstractBasicReader.h
@@ -19,6 +19,7 @@
 #ifndef SWIFT_CLANGIMPORTER_SWIFTABSTRACTBASICREADER_H
 #define SWIFT_CLANGIMPORTER_SWIFTABSTRACTBASICREADER_H
 
+#include "clang/AST/ASTContext.h"
 #include "clang/AST/AbstractTypeReader.h"
 
 // This include is required to instantiate the template code in

--- a/lib/SILOptimizer/Utils/Differentiation/Common.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/Common.cpp
@@ -357,7 +357,7 @@ SILDifferentiabilityWitness *getOrCreateMinimalASTDifferentiabilityWitness(
   if (!minimalConfig)
     return nullptr;
 
-  std::string originalName = original->getName();
+  std::string originalName = original->getName().str();
   // If original function requires a foreign entry point, use the foreign SIL
   // function to get or create the minimal differentiability witness.
   if (requiresForeignEntryPoint(originalAFD)) {


### PR DESCRIPTION
LLVM recently (Jan 28, 2020) removed the implicit StringRef to std::string conversion operator.  This patch makes the conversion explicit.  This was breaking in swift/master-next
See: llvm/llvm-project@adcd026 and llvm/llvm-project@777180a32b

(I do not have commit access so please summon swift-ci for me :)