### PR TITLE
[siloptimizer] Use .str() on StringRef.

### DIFF
--- a/lib/SILOptimizer/Utils/Differentiation/Common.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/Common.cpp
@@ -357,7 +357,7 @@ SILDifferentiabilityWitness *getOrCreateMinimalASTDifferentiabilityWitness(
   if (!minimalConfig)
     return nullptr;
 
-  std::string originalName = original->getName();
+  std::string originalName = original->getName().str();
   // If original function requires a foreign entry point, use the foreign SIL
   // function to get or create the minimal differentiability witness.
   if (requiresForeignEntryPoint(originalAFD)) {


### PR DESCRIPTION
llvm recently removed the conversion operator that would convert
StringRef into str() implictly.  Now we have to be more explicit.
See: https://github.com/llvm/llvm-project/commit/adcd02683856c30ba6f349279509acecd90063df

(Please summon the swift-ci bot, as I do not have commit privs)