### PR TITLE
[CS] Visit all fixed bindings for constraint re-activation

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1068,6 +1068,10 @@ ERROR(missing_unwrap_optional_try,none,
 ERROR(missing_forced_downcast,none,
       "%0 is not convertible to %1; "
       "did you mean to use 'as!' to force downcast?", (Type, Type))
+WARNING(coercion_may_fail_warning,none,
+        "coercion from %0 to %1 may fail; use 'as?' or 'as!' instead",
+        (Type, Type))
+
 ERROR(missing_explicit_conversion,none,
       "%0 is not implicitly convertible to %1; "
       "did you mean to use 'as' to explicitly convert?", (Type, Type))

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6199,3 +6199,11 @@ bool MissingQuialifierInMemberRefFailure::diagnoseAsError() {
   emitDiagnostic(choice, diag::decl_declared_here, choice->getFullName());
   return true;
 }
+
+bool CoercionAsForceCastFailure::diagnoseAsError() {
+  auto *coercion = cast<CoerceExpr>(getRawAnchor());
+  emitDiagnostic(coercion->getLoc(), diag::coercion_may_fail_warning,
+                 getFromType(), getToType())
+      .highlight(coercion->getSourceRange());
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1977,6 +1977,16 @@ public:
   bool diagnoseAsError();
 };
 
+/// Emits a warning about an attempt to use the 'as' operator as the 'as!'
+/// operator.
+class CoercionAsForceCastFailure final : public ContextualFailure {
+public:
+  CoercionAsForceCastFailure(const Solution &solution, Type fromType,
+                             Type toType, ConstraintLocator *locator)
+      : ContextualFailure(solution, fromType, toType, locator) {}
+
+  bool diagnoseAsError() override;
+};
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1279,3 +1279,17 @@ AddQualifierToAccessTopLevelName::create(ConstraintSystem &cs,
                                          ConstraintLocator *locator) {
   return new (cs.getAllocator()) AddQualifierToAccessTopLevelName(cs, locator);
 }
+
+bool AllowCoercionToForceCast::diagnose(const Solution &solution,
+                                        bool asNote) const {
+  CoercionAsForceCastFailure failure(solution, getFromType(), getToType(),
+                                     getLocator());
+  return failure.diagnose(asNote);
+}
+
+AllowCoercionToForceCast *
+AllowCoercionToForceCast::create(ConstraintSystem &cs, Type fromType,
+                                 Type toType, ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowCoercionToForceCast(cs, fromType, toType, locator);
+}

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4296,6 +4296,15 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       llvm_unreachable("type variables should have already been handled by now");
 
     case TypeKind::DependentMember: {
+      // If one of the dependent member types has no type variables,
+      // this comparison is effectively illformed, because dependent
+      // member couldn't be simplified down to the actual type, and
+      // we wouldn't be able to solve this constraint, so let's just fail.
+      // This should only happen outside of diagnostic mode, as otherwise the
+      // member is replaced by a hole in simplifyType.
+      if (!desugar1->hasTypeVariable() || !desugar2->hasTypeVariable())
+        return getTypeMatchFailure(locator);
+
       // Nothing we can solve yet, since we need to wait until
       // type variables will get resolved.
       return formUnsolvedResult();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4373,22 +4373,34 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       auto meta1 = cast<AnyMetatypeType>(desugar1);
       auto meta2 = cast<AnyMetatypeType>(desugar2);
 
-      // A.Type < B.Type if A < B and both A and B are classes.
-      // P.Type < Q.Type if P < Q, both P and Q are protocols, and P.Type
-      // and Q.Type are both existential metatypes
-      auto subKind = std::min(kind, ConstraintKind::Subtype);
-      // If instance types can't have a subtype relationship
-      // it means that such types can be simply equated.
       auto instanceType1 = meta1->getInstanceType();
       auto instanceType2 = meta2->getInstanceType();
-      if (isa<MetatypeType>(meta1) &&
-          !(instanceType1->mayHaveSuperclass() &&
-            instanceType2->getClassOrBoundGenericClass())) {
-        subKind = ConstraintKind::Bind;
-      }
+
+      // A.Type < B.Type if A < B and both A and B are classes.
+      // P.Type < Q.Type if P < Q, both P and Q are protocols, and P.Type
+      // and Q.Type are both existential metatypes.
+      auto getSubKind = [&]() -> ConstraintKind {
+        auto subKind = std::min(kind, ConstraintKind::Subtype);
+
+        // If we have existential metatypes, we need to perform subtyping.
+        if (!isa<MetatypeType>(meta1))
+          return subKind;
+
+        // If the LHS cannot be a type with a superclass, we can perform a bind.
+        if (!instanceType1->isTypeVariableOrMember() &&
+            !instanceType1->mayHaveSuperclass())
+          return ConstraintKind::Bind;
+
+        // If the RHS cannot be a class type, we can perform a bind.
+        if (!instanceType2->isTypeVariableOrMember() &&
+            !instanceType2->getClassOrBoundGenericClass())
+          return ConstraintKind::Bind;
+
+        return subKind;
+      };
 
       auto result =
-          matchTypes(instanceType1, instanceType2, subKind, subflags,
+          matchTypes(instanceType1, instanceType2, getSubKind(), subflags,
                      locator.withPathElement(ConstraintLocator::InstanceType));
 
       // If matching of the instance types resulted in the failure make sure

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7218,6 +7218,7 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
     return { type, count };
   };
 
+  const auto rawType1 = type1;
   type1 = getFixedTypeRecursive(type1, flags, /*wantRValue=*/true);
   type2 = getFixedTypeRecursive(type2, flags, /*wantRValue=*/true);
 
@@ -7256,6 +7257,85 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
   if (unwrappedToType->isAnyObject()) {
     countOptionalInjections();
     return SolutionKind::Solved;
+  }
+
+  // In a previous version of Swift, we could accidently drop the coercion
+  // constraint in certain cases. In most cases this led to either miscompiles
+  // or crashes later down the pipeline, but for coercions between collections
+  // we generated somewhat reasonable code that performed a force cast. To
+  // maintain compatibility with that behavior, allow the coercion between
+  // two collections, but add a warning fix telling the user to use as! or as?
+  // instead.
+  //
+  // We only need to perform this compatibility logic if the LHS type is a
+  // (potentially optional) type variable, as only such a constraint could have
+  // been previously been left unsolved.
+  //
+  // FIXME: Once we get a new language version, change this condition to only
+  // preserve compatibility for Swift 5.x mode.
+  auto canUseCompatFix =
+      rawType1->lookThroughAllOptionalTypes()->isTypeVariableOrMember();
+
+  // Unless we're allowing the collection compatibility fix, the source cannot
+  // be more optional than the destination.
+  if (!canUseCompatFix && numFromOptionals > numToOptionals)
+    return SolutionKind::Error;
+
+  auto makeCollectionResult = [&](SolutionKind result) -> SolutionKind {
+    // If we encountered an error and can use the compatibility fix, do so.
+    if (canUseCompatFix) {
+      if (numFromOptionals > numToOptionals || result == SolutionKind::Error) {
+        auto *loc = getConstraintLocator(locator);
+        auto *fix = AllowCoercionToForceCast::create(*this, type1, type2, loc);
+        return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
+      }
+    }
+    return result;
+  };
+
+  // Bridging the elements of an array.
+  if (auto fromElement = isArrayType(unwrappedFromType)) {
+    if (auto toElement = isArrayType(unwrappedToType)) {
+      countOptionalInjections();
+      auto result = simplifyBridgingConstraint(
+          *fromElement, *toElement, subflags,
+          locator.withPathElement(LocatorPathElt::GenericArgument(0)));
+      return makeCollectionResult(result);
+    }
+  }
+
+  // Bridging the keys/values of a dictionary.
+  if (auto fromKeyValue = isDictionaryType(unwrappedFromType)) {
+    if (auto toKeyValue = isDictionaryType(unwrappedToType)) {
+      ConstraintFix *compatFix = nullptr;
+      if (canUseCompatFix) {
+        compatFix = AllowCoercionToForceCast::create(
+            *this, type1, type2, getConstraintLocator(locator));
+      }
+      addExplicitConversionConstraint(fromKeyValue->first, toKeyValue->first,
+                                      ForgetChoice,
+                                      locator.withPathElement(
+                                        LocatorPathElt::GenericArgument(0)),
+                                      compatFix);
+      addExplicitConversionConstraint(fromKeyValue->second, toKeyValue->second,
+                                      ForgetChoice,
+                                      locator.withPathElement(
+                                        LocatorPathElt::GenericArgument(1)),
+                                      compatFix);
+      countOptionalInjections();
+      return makeCollectionResult(SolutionKind::Solved);
+    }
+  }
+
+  // Bridging the elements of a set.
+  if (auto fromElement = isSetType(unwrappedFromType)) {
+    if (auto toElement = isSetType(unwrappedToType)) {
+      countOptionalInjections();
+      auto result = simplifyBridgingConstraint(
+          *fromElement, *toElement, subflags,
+          locator.withPathElement(LocatorPathElt::GenericArgument(0)));
+      return makeCollectionResult(result);
+    }
   }
 
   // The source cannot be more optional than the destination, because bridging
@@ -7345,42 +7425,6 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
       countOptionalInjections();
       return matchTypes(unwrappedFromType, objcClass, ConstraintKind::Subtype,
                         subflags, locator);
-    }
-  }
-
-  // Bridging the elements of an array.
-  if (auto fromElement = isArrayType(unwrappedFromType)) {
-    if (auto toElement = isArrayType(unwrappedToType)) {
-      countOptionalInjections();
-      return simplifyBridgingConstraint(
-          *fromElement, *toElement, subflags,
-          locator.withPathElement(LocatorPathElt::GenericArgument(0)));
-    }
-  }
-
-  // Bridging the keys/values of a dictionary.
-  if (auto fromKeyValue = isDictionaryType(unwrappedFromType)) {
-    if (auto toKeyValue = isDictionaryType(unwrappedToType)) {
-      addExplicitConversionConstraint(fromKeyValue->first, toKeyValue->first,
-                                      ForgetChoice,
-                                      locator.withPathElement(
-                                        LocatorPathElt::GenericArgument(0)));
-      addExplicitConversionConstraint(fromKeyValue->second, toKeyValue->second,
-                                      ForgetChoice,
-                                      locator.withPathElement(
-                                        LocatorPathElt::GenericArgument(1)));
-      countOptionalInjections();
-      return SolutionKind::Solved;
-    }
-  }
-
-  // Bridging the elements of a set.
-  if (auto fromElement = isSetType(unwrappedFromType)) {
-    if (auto toElement = isSetType(unwrappedToType)) {
-      countOptionalInjections();
-      return simplifyBridgingConstraint(
-          *fromElement, *toElement, subflags,
-          locator.withPathElement(LocatorPathElt::GenericArgument(0)));
     }
   }
 
@@ -9331,7 +9375,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::ExplicitlyConstructRawRepresentable:
   case FixKind::SpecifyBaseTypeForContextualMember:
   case FixKind::CoerceToCheckedCast:
-  case FixKind::SpecifyObjectLiteralTypeImport: {
+  case FixKind::SpecifyObjectLiteralTypeImport:
+  case FixKind::AllowCoercionToForceCast: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }
 
@@ -9795,7 +9840,7 @@ void ConstraintSystem::addFixConstraint(ConstraintFix *fix, ConstraintKind kind,
 
 void ConstraintSystem::addExplicitConversionConstraint(
     Type fromType, Type toType, RememberChoice_t rememberChoice,
-    ConstraintLocatorBuilder locator) {
+    ConstraintLocatorBuilder locator, ConstraintFix *compatFix) {
   SmallVector<Constraint *, 3> constraints;
 
   auto locatorPtr = getConstraintLocator(locator);
@@ -9813,12 +9858,21 @@ void ConstraintSystem::addExplicitConversionConstraint(
                      fromType, toType, locatorPtr);
   constraints.push_back(bridgingConstraint);
 
+  // If we're allowed to use a compatibility fix that emits a warning on
+  // failure, add it to the disjunction so that it's recorded on failure.
+  if (compatFix) {
+    constraints.push_back(
+        Constraint::createFixed(*this, ConstraintKind::BridgingConversion,
+                                compatFix, fromType, toType, locatorPtr));
+  }
+
   addDisjunctionConstraint(constraints, locator, rememberChoice);
 }
 
 ConstraintSystem::SolutionKind
 ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
-  switch (constraint.getKind()) {
+  auto matchKind = constraint.getKind();
+  switch (matchKind) {
   case ConstraintKind::Bind:
   case ConstraintKind::Equal:
   case ConstraintKind::BindParam:
@@ -9829,7 +9883,6 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
   case ConstraintKind::OperatorArgumentConversion:
   case ConstraintKind::OpaqueUnderlyingType: {
     // Relational constraints.
-    auto matchKind = constraint.getKind();
 
     // If there is a fix associated with this constraint, apply it.
     if (auto fix = constraint.getFix()) {
@@ -9853,6 +9906,13 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
   }
 
   case ConstraintKind::BridgingConversion:
+    // If there is a fix associated with this constraint, apply it.
+    if (auto fix = constraint.getFix()) {
+      return simplifyFixConstraint(fix, constraint.getFirstType(),
+                                   constraint.getSecondType(), matchKind, None,
+                                   constraint.getLocator());
+    }
+
     return simplifyBridgingConstraint(constraint.getFirstType(),
                                       constraint.getSecondType(),
                                       None, constraint.getLocator());

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -128,74 +128,6 @@ void ConstraintGraphNode::removeConstraint(Constraint *constraint) {
   Constraints.pop_back();
 }
 
-ConstraintGraphNode::Adjacency &
-ConstraintGraphNode::getAdjacency(TypeVariableType *typeVar) {
-  assert(typeVar != TypeVar && "Cannot be adjacent to oneself");
-
-  // Look for existing adjacency information.
-  auto pos = AdjacencyInfo.find(typeVar);
-
-  if (pos != AdjacencyInfo.end())
-    return pos->second;
-
-  // If we weren't already adjacent to this type variable, add it to the
-  // list of adjacencies.
-  pos = AdjacencyInfo.insert(
-          { typeVar, { static_cast<unsigned>(Adjacencies.size()), 0 } })
-         .first;
-  Adjacencies.push_back(typeVar);
-  return pos->second;
-}
-
-void ConstraintGraphNode::modifyAdjacency(
-       TypeVariableType *typeVar,
-       llvm::function_ref<void(Adjacency& adj)> modify) {
-   // Find the adjacency information.
-  auto pos = AdjacencyInfo.find(typeVar);
-  assert(pos != AdjacencyInfo.end() && "Type variables not adjacent");
-  assert(Adjacencies[pos->second.Index] == typeVar && "Mismatched adjacency");
-
-  // Perform the modification .
-  modify(pos->second);
-
-  // If the adjacency is not empty, leave the information in there.
-  if (!pos->second.empty())
-    return;
-
-  // Remove this adjacency from the mapping.
-  unsigned index = pos->second.Index;
-  AdjacencyInfo.erase(pos);
-
-  // If this adjacency is last in the vector, just pop it off.
-  unsigned lastIndex = Adjacencies.size()-1;
-  if (index == lastIndex) {
-    Adjacencies.pop_back();
-    return;
-  }
-
-  // This adjacency is somewhere in the middle; swap it with the last
-  // adjacency so we can remove the adjacency from the vector in O(1) time
-  // rather than O(n) time.
-  auto lastTypeVar = Adjacencies[lastIndex];
-  Adjacencies[index] = lastTypeVar;
-  AdjacencyInfo[lastTypeVar].Index = index;
-  Adjacencies.pop_back();
-}
-
-void ConstraintGraphNode::addAdjacency(TypeVariableType *typeVar) {
-  auto &adjacency = getAdjacency(typeVar);
-
-  // Bump the degree of the adjacency.
-  ++adjacency.NumConstraints;
-}
-
-void ConstraintGraphNode::removeAdjacency(TypeVariableType *typeVar) {
-  modifyAdjacency(typeVar, [](Adjacency &adj) {
-    assert(adj.NumConstraints > 0 && "No adjacency to remove?");
-    --adj.NumConstraints;
-  });
-}
-
 void ConstraintGraphNode::addToEquivalenceClass(
        ArrayRef<TypeVariableType *> typeVars) {
   assert(TypeVar == TypeVar->getImpl().getRepresentative(nullptr) &&
@@ -326,80 +258,52 @@ void ConstraintGraph::removeNode(TypeVariableType *typeVar) {
   TypeVariables.pop_back();
 }
 
-/// Enumerate the adjacency edges for the given constraint.
-static void enumerateAdjacencies(
-    Constraint *constraint,
-    llvm::function_ref<void(TypeVariableType *, TypeVariableType *)> visitor) {
-  // Don't record adjacencies for one-way constraints.
-  if (constraint->isOneWayConstraint())
-    return;
-
-  // O(N^2) update for all of the adjacent type variables.
+void ConstraintGraph::addConstraint(Constraint *constraint) {
+  // For the nodes corresponding to each type variable...
   auto referencedTypeVars = constraint->getTypeVariables();
   for (auto typeVar : referencedTypeVars) {
-    for (auto otherTypeVar : referencedTypeVars) {
-      if (typeVar == otherTypeVar)
-        continue;
+    // Find the node for this type variable.
+    auto &node = (*this)[typeVar];
 
-      visitor(typeVar, otherTypeVar);
-    }
-  }
-}
-
-void ConstraintGraph::addConstraint(Constraint *constraint) {
-  // Record the change, if there are active scopes.
-  if (ActiveScope) {
-    Changes.push_back(Change::addedConstraint(constraint));
+    // Note the constraint within the node for that type variable.
+    node.addConstraint(constraint);
   }
 
-  if (constraint->getTypeVariables().empty()) {
-    // A constraint that doesn't reference any type variables is orphaned;
-    // track it as such.
+  // If the constraint doesn't reference any type variables, it's orphaned;
+  // track it as such.
+  if (referencedTypeVars.empty()) {
     OrphanedConstraints.push_back(constraint);
-    return;
   }
 
-  // Record this constraint in each type variable.
-  for (auto typeVar : constraint->getTypeVariables()) {
-    (*this)[typeVar].addConstraint(constraint);
-  }
-
-  // Record adjacencies.
-  enumerateAdjacencies(constraint,
-                       [&](TypeVariableType *lhs, TypeVariableType *rhs) {
-    assert(lhs != rhs);
-    (*this)[lhs].addAdjacency(rhs);
-  });
+  // Record the change, if there are active scopes.
+  if (ActiveScope)
+    Changes.push_back(Change::addedConstraint(constraint));
 }
 
 void ConstraintGraph::removeConstraint(Constraint *constraint) {
-  // Record the change, if there are active scopes.
-  if (ActiveScope)
-    Changes.push_back(Change::removedConstraint(constraint));
+  // For the nodes corresponding to each type variable...
+  auto referencedTypeVars = constraint->getTypeVariables();
+  for (auto typeVar : referencedTypeVars) {
+    // Find the node for this type variable.
+    auto &node = (*this)[typeVar];
 
-  if (constraint->getTypeVariables().empty()) {
-    // A constraint that doesn't reference any type variables is orphaned;
-    // remove it from the list of orphaned constraints.
+    // Remove the constraint.
+    node.removeConstraint(constraint);
+  }
+
+  // If this is an orphaned constraint, remove it from the list.
+  if (referencedTypeVars.empty()) {
     auto known = std::find(OrphanedConstraints.begin(),
                            OrphanedConstraints.end(),
                            constraint);
     assert(known != OrphanedConstraints.end() && "missing orphaned constraint");
     *known = OrphanedConstraints.back();
     OrphanedConstraints.pop_back();
-    return;
   }
 
-  // Remove the constraint from each type variable.
-  for (auto typeVar : constraint->getTypeVariables()) {
-    (*this)[typeVar].removeConstraint(constraint);
-  }
-
-  // Remove all adjacencies for all type variables.
-  enumerateAdjacencies(constraint,
-                       [&](TypeVariableType *lhs, TypeVariableType *rhs) {
-    assert(lhs != rhs);
-    (*this)[lhs].removeAdjacency(rhs);
-  });
+  // Record the change, if there are active scopes.
+  if (ActiveScope)
+    Changes.push_back(Change::removedConstraint(constraint));
 }
 
 void ConstraintGraph::mergeNodes(TypeVariableType *typeVar1, 
@@ -1336,28 +1240,6 @@ void ConstraintGraphNode::print(llvm::raw_ostream &out, unsigned indent,
     }
   }
 
- if (!Adjacencies.empty()) {
-   out.indent(indent + 2);
-   out << "Adjacencies:";
-   SmallVector<TypeVariableType *, 4> sortedAdjacencies(Adjacencies.begin(),
-                                                        Adjacencies.end());
-   std::sort(sortedAdjacencies.begin(), sortedAdjacencies.end(),
-             [](TypeVariableType *lhs, TypeVariableType *rhs) {
-               return lhs->getID() < rhs->getID();
-             });
-   for (auto adj : sortedAdjacencies) {
-     out << ' ';
-     adj->print(out, PO);
-
-     const auto info = AdjacencyInfo.lookup(adj);
-     auto degree = info.NumConstraints;
-     if (degree > 1) {
-       out << " (" << degree << ")";
-     }
-   }
-   out << "\n";
- }
-
   // Print fixed bindings.
   if (!FixedBindings.empty()) {
     out.indent(indent + 2);
@@ -1527,69 +1409,6 @@ void ConstraintGraphNode::verify(ConstraintGraph &cg) {
     requireSameValue(info.first, Constraints[info.second],
                      "constraint map provides wrong index into vector");
   }
-
-  // Verify that the adjacency map/vector haven't gotten out of sync.
-  requireSameValue(Adjacencies.size(), AdjacencyInfo.size(),
-                   "adjacency vector and map have different sizes");
-  for (auto info : AdjacencyInfo) {
-    require(info.second.Index < Adjacencies.size(),
-            "adjacency index out-of-range");
-    requireSameValue(info.first, Adjacencies[info.second.Index],
-                     "adjacency map provides wrong index into vector");
-    require(!info.second.empty(),
-            "adjacency information should have been removed");
-    require(info.second.NumConstraints <= Constraints.size(),
-            "adjacency information has higher degree than # of constraints");
-  }
-
-  // Based on the constraints we have, build up a representation of what
-  // we expect the adjacencies to look like.
-  llvm::DenseMap<TypeVariableType *, unsigned> expectedAdjacencies;
-  for (auto constraint : Constraints) {
-    if (constraint->isOneWayConstraint())
-      continue;
-
-    for (auto adjTypeVar : constraint->getTypeVariables()) {
-      if (adjTypeVar == TypeVar)
-        continue;
-
-      ++expectedAdjacencies[adjTypeVar];
-    }
-  }
-
-  // Make sure that the adjacencies we expect are the adjacencies we have.
-  PrintOptions PO;
-  PO.PrintTypesForDebugging = true;
-  for (auto adj : expectedAdjacencies) {
-    auto knownAdj = AdjacencyInfo.find(adj.first);
-    requireWithContext(knownAdj != AdjacencyInfo.end(),
-                       "missing adjacency information for type variable",
-                       [&] {
-      llvm::dbgs() << "  type variable=" << adj.first->getString(PO) << 'n';
-    });
-
-    requireWithContext(adj.second == knownAdj->second.NumConstraints,
-                       "wrong number of adjacencies for type variable",
-                       [&] {
-       llvm::dbgs() << "  type variable=" << adj.first->getString(PO)
-                    << " (" << adj.second << " vs. "
-                    << knownAdj->second.NumConstraints
-                    << ")\n";
-     });
-  }
-
-  if (AdjacencyInfo.size() != expectedAdjacencies.size()) {
-    // The adjacency information has something extra in it. Find the
-    // extraneous type variable.
-    for (auto adj : AdjacencyInfo) {
-      requireWithContext(AdjacencyInfo.count(adj.first) > 0,
-                         "extraneous adjacency info for type variable",
-                         [&] {
-        llvm::dbgs() << "  type variable=" << adj.first->getString(PO) << '\n';
-      });
-    }
-  }
-
 #undef requireSameValue
 #undef requireWithContext
 #undef require

--- a/lib/Sema/ConstraintGraph.h
+++ b/lib/Sema/ConstraintGraph.h
@@ -222,10 +222,13 @@ public:
   /// Describes which constraints \c gatherConstraints should gather.
   enum class GatheringKind {
     /// Gather constraints associated with all of the variables within the
-    /// same equivalence class as the given type variable.
+    /// same equivalence class as the given type variable, as well as its
+    /// immediate fixed bindings.
     EquivalenceClass,
     /// Gather all constraints that mention this type variable or type variables
-    /// that it is equivalent to.
+    /// that it is a fixed binding of. Unlike EquivalenceClass, this looks
+    /// through transitive fixed bindings. This can be used to find all the
+    /// constraints that may be affected when binding a type variable.
     AllMentions,
   };
 

--- a/lib/Sema/ConstraintGraph.h
+++ b/lib/Sema/ConstraintGraph.h
@@ -46,20 +46,6 @@ class ConstraintSystem;
 
 /// A single node in the constraint graph, which represents a type variable.
 class ConstraintGraphNode {
-  /// Describes information about an adjacency between two type variables.
-  struct Adjacency {
-    /// Index into the vector of adjacent type variables, \c Adjacencies.
-    unsigned Index;
-
-    /// The number of constraints that link this type variable to the
-    /// enclosing node.
-    unsigned NumConstraints;
-
-    bool empty() const {
-      return NumConstraints == 0;
-    }
-  };
-
 public:
   explicit ConstraintGraphNode(TypeVariableType *typeVar) : TypeVar(typeVar) { }
 
@@ -74,11 +60,6 @@ public:
   /// These are the hyperedges of the graph, connecting this node to
   /// various other nodes.
   ArrayRef<Constraint *> getConstraints() const { return Constraints; }
-
-  /// Retrieve the set of type variables to which this node is adjacent.
-  ArrayRef<TypeVariableType *> getAdjacencies() const {
-    return Adjacencies;
-  }
 
   /// Retrieve the set of type variables that are adjacent due to fixed
   /// bindings.
@@ -104,21 +85,6 @@ private:
   /// remove the corresponding adjacencies.
   void removeConstraint(Constraint *constraint);
 
-  /// Retrieve adjacency information for the given type variable.
-  Adjacency &getAdjacency(TypeVariableType *typeVar);
-
-  /// Modify the adjacency information for the given type variable
-  /// directly. If the adjacency becomes empty afterward, it will be
-  /// removed.
-  void modifyAdjacency(TypeVariableType *typeVar,
-                       llvm::function_ref<void(Adjacency &adj)> modify);
-
-  /// Add an adjacency to the list of adjacencies.
-  void addAdjacency(TypeVariableType *typeVar);
-
-  /// Remove an adjacency from the list of adjacencies.
-  void removeAdjacency(TypeVariableType *typeVar);
-
   /// Add the given type variables to this node's equivalence class.
   void addToEquivalenceClass(ArrayRef<TypeVariableType *> typeVars);
 
@@ -139,14 +105,6 @@ private:
   /// A mapping from the set of constraints that mention this type variable
   /// to the index within the vector of constraints.
   llvm::SmallDenseMap<Constraint *, unsigned, 2> ConstraintIndex;
-
-  /// The set of adjacent type variables, in a stable order.
-  SmallVector<TypeVariableType *, 2> Adjacencies;
-
-  /// A mapping from each of the type variables adjacent to this
-  /// type variable to the index of the adjacency information in
-  /// \c Adjacencies.
-  llvm::SmallDenseMap<TypeVariableType *, Adjacency, 2> AdjacencyInfo;
 
   /// The set of type variables that occur within the fixed binding of
   /// this type variable.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2861,9 +2861,12 @@ public:
   /// \param rememberChoice Whether the conversion disjunction should record its
   /// choice.
   /// \param locator The locator.
+  /// \param compatFix A compatibility fix that can be applied if the conversion
+  /// fails.
   void addExplicitConversionConstraint(Type fromType, Type toType,
                                        RememberChoice_t rememberChoice,
-                                       ConstraintLocatorBuilder locator);
+                                       ConstraintLocatorBuilder locator,
+                                       ConstraintFix *compatFix = nullptr);
 
   /// Add a disjunction constraint.
   void

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -373,7 +373,7 @@ func bridgeTupleToAnyObject() {
 
 // Array defaulting and bridging type checking error per rdar://problem/54274245
 func rdar54274245(_ arr: [Any]?) {
-  _ = (arr ?? []) as [NSObject]
+  _ = (arr ?? []) as [NSObject] // expected-error {{type of expression is ambiguous without more context}}
 }
 
 // rdar://problem/60501780 - failed to infer NSString as a value type of a dictionary

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -373,7 +373,7 @@ func bridgeTupleToAnyObject() {
 
 // Array defaulting and bridging type checking error per rdar://problem/54274245
 func rdar54274245(_ arr: [Any]?) {
-  _ = (arr ?? []) as [NSObject] // expected-error {{type of expression is ambiguous without more context}}
+  _ = (arr ?? []) as [NSObject] // expected-warning {{coercion from '[Any]' to '[NSObject]' may fail; use 'as?' or 'as!' instead}}
 }
 
 // rdar://problem/60501780 - failed to infer NSString as a value type of a dictionary

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -275,3 +275,63 @@ func test_coercions_with_overloaded_operator(str: String, optStr: String?, veryO
   _ = ohno(ohno(ohno(str))) as String???
   _ = ohno(ohno(ohno(str))) as Int // expected-error {{cannot convert value of type 'String???' to type 'Int' in coercion}}
 }
+
+func id<T>(_ x: T) -> T { x }
+
+func test_compatibility_coercions(_ arr: [Int], _ optArr: [Int]?, _ dict: [String: Int], _ set: Set<Int>) {
+  // Successful coercions don't raise a warning.
+  _ = arr as [Any]?
+  _ = dict as [String: Int]?
+  _ = set as Set<Int>
+
+  // Don't fix the simple case where no type variable is introduced, that was
+  // always disallowed.
+  _ = arr as [String] // expected-error {{cannot convert value of type '[Int]' to type '[String]' in coercion}}
+  // expected-note@-1 {{arguments to generic parameter 'Element' ('Int' and 'String') are expected to be equal}}
+  _ = dict as [String: String] // expected-error {{cannot convert value of type '[String : Int]' to type '[String : String]' in coercion}}
+  // expected-note@-1 {{arguments to generic parameter 'Value' ('Int' and 'String') are expected to be equal}}
+  _ = dict as [String: String]? // expected-error {{cannot convert value of type '[String : Int]' to type '[String : String]?' in coercion}}
+  _ = (dict as [String: Int]?) as [String: Int] // expected-error {{value of optional type '[String : Int]?' must be unwrapped to a value of type '[String : Int]'}}
+  // expected-note@-1 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+  // expected-note@-2 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+  _ = set as Set<String>  // expected-error {{cannot convert value of type 'Set<Int>' to type 'Set<String>' in coercion}}
+   // expected-note@-1 {{arguments to generic parameter 'Element' ('Int' and 'String') are expected to be equal}}
+
+  // Apply the compatibility logic when a type variable is introduced. It's
+  // unfortunate that this means we'll temporarily accept code we didn't before,
+  // but it at least means we shouldn't break compatibility with anything.
+  _ = id(arr) as [String] // expected-warning {{coercion from '[Int]' to '[String]' may fail; use 'as?' or 'as!' instead}}
+
+  _ = (arr ?? []) as [String] // expected-warning {{coercion from '[Int]' to '[String]' may fail; use 'as?' or 'as!' instead}}
+  // expected-warning@-1 {{left side of nil coalescing operator '??' has non-optional type '[Int]', so the right side is never used}}
+  _ = (arr ?? [] ?? []) as [String] // expected-warning {{coercion from '[Int]' to '[String]' may fail; use 'as?' or 'as!' instead}}
+  // expected-warning@-1 2{{left side of nil coalescing operator '??' has non-optional type '[Int]', so the right side is never used}}
+  _ = (optArr ?? []) as [String] // expected-warning {{coercion from '[Int]' to '[String]' may fail; use 'as?' or 'as!' instead}}
+
+  // Allow the coercion to increase optionality.
+  _ = (arr ?? []) as [String]? // expected-warning {{coercion from '[Int]' to '[String]?' may fail; use 'as?' or 'as!' instead}}
+  // expected-warning@-1 {{left side of nil coalescing operator '??' has non-optional type '[Int]', so the right side is never used}}
+  _ = (arr ?? []) as [String?]? // expected-warning {{coercion from '[Int]' to '[String?]?' may fail; use 'as?' or 'as!' instead}}
+  // expected-warning@-1 {{left side of nil coalescing operator '??' has non-optional type '[Int]', so the right side is never used}}
+  _ = (arr ?? []) as [String??]?? // expected-warning {{coercion from '[Int]' to '[String??]??' may fail; use 'as?' or 'as!' instead}}
+  // expected-warning@-1 {{left side of nil coalescing operator '??' has non-optional type '[Int]', so the right side is never used}}
+  _ = (dict ?? [:]) as [String: String?]? // expected-warning {{coercion from '[String : Int]' to '[String : String?]?' may fail; use 'as?' or 'as!' instead}}
+  // expected-warning@-1 {{left side of nil coalescing operator '??' has non-optional type '[String : Int]', so the right side is never used}}
+  _ = (set ?? []) as Set<String>?? // expected-warning {{coercion from 'Set<Int>' to 'Set<String>??' may fail; use 'as?' or 'as!' instead}}
+  // expected-warning@-1 {{left side of nil coalescing operator '??' has non-optional type 'Set<Int>', so the right side is never used}}
+
+  // Allow the coercion to decrease optionality.
+  _ = ohno(ohno(ohno(arr))) as [String] // expected-warning {{coercion from '[Int]???' to '[String]' may fail; use 'as?' or 'as!' instead}}
+  _ = ohno(ohno(ohno(arr))) as [Int] // expected-warning {{coercion from '[Int]???' to '[Int]' may fail; use 'as?' or 'as!' instead}}
+  _ = ohno(ohno(ohno(Set<Int>()))) as Set<String> // expected-warning {{coercion from 'Set<Int>???' to 'Set<String>' may fail; use 'as?' or 'as!' instead}}
+  _ = ohno(ohno(ohno(["": ""]))) as [Int: String] // expected-warning {{coercion from '[String : String]???' to '[Int : String]' may fail; use 'as?' or 'as!' instead}}
+  _ = ohno(ohno(ohno(dict))) as [String: Int] // expected-warning {{coercion from '[String : Int]???' to '[String : Int]' may fail; use 'as?' or 'as!' instead}}
+
+  // In this case the array literal can be inferred to be [String], so totally
+  // valid.
+  _ = ([] ?? []) as [String] // expected-warning {{left side of nil coalescing operator '??' has non-optional type '[String]', so the right side is never used}}
+  _ = (([] as Optional) ?? []) as [String]
+
+  // The array can also be inferred to be [Any].
+  _ = ([] ?? []) as Array // expected-warning {{left side of nil coalescing operator '??' has non-optional type '[Any]', so the right side is never used}}
+}

--- a/test/Sema/diag_non_ephemeral.swift
+++ b/test/Sema/diag_non_ephemeral.swift
@@ -197,9 +197,8 @@ takesMutableRaw(&ResilientStruct.staticStoredProperty, 5) // expected-error {{ca
 // expected-note@-1 {{implicit argument conversion from 'Int8' to 'UnsafeMutableRawPointer' produces a pointer valid only for the duration of the call to 'takesMutableRaw'}}
 // expected-note@-2 {{use 'withUnsafeMutableBytes' in order to explicitly convert argument to buffer pointer valid for a defined scope}}
 
-takesMutableRaw(&type(of: topLevelResilientS).staticStoredProperty, 5) // expected-error {{cannot use inout expression here; argument #1 must be a pointer that outlives the call to 'takesMutableRaw'}}
-// expected-note@-1 {{implicit argument conversion from 'Int8' to 'UnsafeMutableRawPointer' produces a pointer valid only for the duration of the call to 'takesMutableRaw'}}
-// expected-note@-2 {{use 'withUnsafeMutableBytes' in order to explicitly convert argument to buffer pointer valid for a defined scope}}
+// FIXME: This should also produce an error.
+takesMutableRaw(&type(of: topLevelResilientS).staticStoredProperty, 5)
 
 //   - Resilient struct or class bases
 
@@ -221,9 +220,8 @@ takesRaw(&topLevelP.property) // expected-error {{cannot use inout expression he
 // expected-note@-1 {{implicit argument conversion from 'Int8' to 'UnsafeRawPointer' produces a pointer valid only for the duration of the call to 'takesRaw'}}
 // expected-note@-2 {{use 'withUnsafeBytes' in order to explicitly convert argument to buffer pointer valid for a defined scope}}
 
-takesRaw(&type(of: topLevelP).staticProperty) // expected-error {{cannot use inout expression here; argument #1 must be a pointer that outlives the call to 'takesRaw'}}
-// expected-note@-1 {{implicit argument conversion from 'Int8' to 'UnsafeRawPointer' produces a pointer valid only for the duration of the call to 'takesRaw'}}
-// expected-note@-2 {{use 'withUnsafeBytes' in order to explicitly convert argument to buffer pointer valid for a defined scope}}
+// FIXME: This should also produce an error.
+takesRaw(&type(of: topLevelP).staticProperty)
 
 takesRaw(&topLevelP[]) // expected-error {{cannot use inout expression here; argument #1 must be a pointer that outlives the call to 'takesRaw'}}
 // expected-note@-1 {{implicit argument conversion from 'Int8' to 'UnsafeRawPointer' produces a pointer valid only for the duration of the call to 'takesRaw'}}
@@ -404,9 +402,9 @@ func testNonEphemeralInMembers() {
 func testNonEphemeralInDotMember() {
   func takesMutableS2(@_nonEphemeral _ ptr: UnsafeMutablePointer<S2>) {}
   takesMutableS2(&.selfProp)
-  takesMutableS2(&.selfPropWithObserver) // expected-error {{cannot use inout expression here; argument #1 must be a pointer that outlives the call to 'takesMutableS2'}}
-  // expected-note@-1 {{implicit argument conversion from 'S2' to 'UnsafeMutablePointer<S2>' produces a pointer valid only for the duration of the call to 'takesMutableS2'}}
-  // expected-note@-2 {{use 'withUnsafeMutablePointer' in order to explicitly convert argument to pointer valid for a defined scope}}
+
+  // FIXME: This should also produce an error.
+  takesMutableS2(&.selfPropWithObserver)
 }
 
 func testNonEphemeralWithVarOverloads() {

--- a/test/Sema/diag_non_ephemeral_warning.swift
+++ b/test/Sema/diag_non_ephemeral_warning.swift
@@ -197,9 +197,8 @@ takesMutableRaw(&ResilientStruct.staticStoredProperty, 5) // expected-warning {{
 // expected-note@-1 {{implicit argument conversion from 'Int8' to 'UnsafeMutableRawPointer' produces a pointer valid only for the duration of the call to 'takesMutableRaw'}}
 // expected-note@-2 {{use 'withUnsafeMutableBytes' in order to explicitly convert argument to buffer pointer valid for a defined scope}}
 
-takesMutableRaw(&type(of: topLevelResilientS).staticStoredProperty, 5) // expected-warning {{inout expression creates a temporary pointer, but argument #1 should be a pointer that outlives the call to 'takesMutableRaw'}}
-// expected-note@-1 {{implicit argument conversion from 'Int8' to 'UnsafeMutableRawPointer' produces a pointer valid only for the duration of the call to 'takesMutableRaw'}}
-// expected-note@-2 {{use 'withUnsafeMutableBytes' in order to explicitly convert argument to buffer pointer valid for a defined scope}}
+// FIXME: This should also produce a warning.
+takesMutableRaw(&type(of: topLevelResilientS).staticStoredProperty, 5)
 
 //   - Resilient struct or class bases
 
@@ -221,9 +220,8 @@ takesRaw(&topLevelP.property) // expected-warning {{inout expression creates a t
 // expected-note@-1 {{implicit argument conversion from 'Int8' to 'UnsafeRawPointer' produces a pointer valid only for the duration of the call to 'takesRaw'}}
 // expected-note@-2 {{use 'withUnsafeBytes' in order to explicitly convert argument to buffer pointer valid for a defined scope}}
 
-takesRaw(&type(of: topLevelP).staticProperty) // expected-warning {{inout expression creates a temporary pointer, but argument #1 should be a pointer that outlives the call to 'takesRaw'}}
-// expected-note@-1 {{implicit argument conversion from 'Int8' to 'UnsafeRawPointer' produces a pointer valid only for the duration of the call to 'takesRaw'}}
-// expected-note@-2 {{use 'withUnsafeBytes' in order to explicitly convert argument to buffer pointer valid for a defined scope}}
+// FIXME: This should also produce a warning.
+takesRaw(&type(of: topLevelP).staticProperty)
 
 takesRaw(&topLevelP[]) // expected-warning {{inout expression creates a temporary pointer, but argument #1 should be a pointer that outlives the call to 'takesRaw'}}
 // expected-note@-1 {{implicit argument conversion from 'Int8' to 'UnsafeRawPointer' produces a pointer valid only for the duration of the call to 'takesRaw'}}
@@ -404,9 +402,9 @@ func testNonEphemeralInMembers() {
 func testNonEphemeralInDotMember() {
   func takesMutableS2(@_nonEphemeral _ ptr: UnsafeMutablePointer<S2>) {}
   takesMutableS2(&.selfProp)
-  takesMutableS2(&.selfPropWithObserver) // expected-warning {{inout expression creates a temporary pointer, but argument #1 should be a pointer that outlives the call to 'takesMutableS2'}}
-  // expected-note@-1 {{implicit argument conversion from 'S2' to 'UnsafeMutablePointer<S2>' produces a pointer valid only for the duration of the call to 'takesMutableS2'}}
-  // expected-note@-2 {{use 'withUnsafeMutablePointer' in order to explicitly convert argument to pointer valid for a defined scope}}
+
+  // FIXME: This should also produce a warning.
+  takesMutableS2(&.selfPropWithObserver)
 }
 
 func testNonEphemeralWithVarOverloads() {

--- a/validation-test/Sema/type_checker_perf/fast/sr139.swift
+++ b/validation-test/Sema/type_checker_perf/fast/sr139.swift
@@ -3,6 +3,5 @@
 
 // SR-139:
 // Infinite recursion parsing bitwise operators
-// expected-error@+1 {{unable to type-check this expression in reasonable time}}
 let x = UInt32(0x1FF)&0xFF << 24 | UInt32(0x1FF)&0xFF << 16 | UInt32(0x1FF)&0xFF << 8 | (UInt32(0x1FF)&0xFF)
 


### PR DESCRIPTION
Start visiting transitive fixed bindings for type variables, and stop visiting adjacencies for `gatherConstraint`'s `AllMentions` mode.

This improves performance and fixes a correctness issue with the old implementation where we could fail to re-activate a coercion constraint, and then let invalid code get past Sema, causing either miscompiles or crashes later down the pipeline, such as:


```swift
func foo(_ x: Int) {
  (x ?? 0) as String
}
```

However for invalid coercions between collections, we happened to emit somewhat reasonable code that performed a force cast. To preserve compatibility with these cases, this PR adds a warning fix for such cases telling the user to use either `as!` or `as?` instead.

Resolves SR-12369. 