### PR TITLE
[SourceKit/CodeFormat] Column-align enum element decls and the items in their parameter lists.

### DIFF
--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -1499,6 +1499,34 @@ private:
       return IndentContext {ContextLoc, false};
     }
 
+    if (auto *ECD = dyn_cast<EnumCaseDecl>(D)) {
+      SourceLoc CaseLoc = ECD->getLoc();
+
+      if (TrailingTarget)
+        return None;
+
+      ListAligner Aligner(SM, TargetLocation, CaseLoc, CaseLoc);
+      for (auto *Elem: ECD->getElements()) {
+        SourceRange ElemRange = Elem->getSourceRange();
+        Aligner.updateAlignment(ElemRange, Elem);
+      }
+      return Aligner.getContextAndSetAlignment(CtxOverride);
+    }
+
+    if (auto *EED = dyn_cast<EnumElementDecl>(D)) {
+      SourceLoc ContextLoc = EED->getStartLoc();
+      if (auto Ctx = getIndentContextFrom(EED->getParameterList()))
+        return Ctx;
+
+      if (TrailingTarget)
+        return None;
+
+      return IndentContext {
+        ContextLoc,
+        !OutdentChecker::hasOutdent(SM, EED)
+      };
+    }
+
     if (auto *SD = dyn_cast<SubscriptDecl>(D)) {
       SourceLoc ContextLoc = SD->getStartLoc();
 

--- a/test/swift-indent/basic.swift
+++ b/test/swift-indent/basic.swift
@@ -83,6 +83,27 @@ bax(34949494949)
     .baz
 
 
+// Enum element parameters should be aligned, and raw values should be indented.
+
+enum TestEnum {
+    case first(x: Int,
+               y: Int,
+               z: Int),
+         second(
+            x: Int,
+            y: Int
+         )
+    case third
+}
+
+enum RawEnum: String {
+    case aCaseWithAParticularlyLongNameSoTheValueIsWrapped =
+            "a long message here",
+         aNotherCaseWithAParticularlyLongNameSoTheValueIsWrapped =
+            "a long message here"
+}
+
+
 // Condition elements should align with each other.
 //
 guard let x = Optional.some(10), x > 100,


### PR DESCRIPTION
I missed this in the initial indentation rework. It wasn't handling them at all so we ended up with multi-line enum case decls like the below:

```
enum Foo {
    case first,
    second
    case third(a: Int,
    b: Int),
    fourth(a: Int,
    b: Int
}
```
which is a regression compared to the slightly better 5.2 behavior:
```
enum Foo {
  case first,
  second
  case third(a: Int,
    b: Int),
  fourth(a: Int,
    b: Int)
}
```
New behavior is:
```
enum Foo {
  case first,
       second
  case third(a: Int,
             b: Int),
       fourth(a: Int,
              b: Int)
}
```
Resolves rdar://problem/61461022