### PR TITLE
Add Builtin.is_same_metatype to SILCombine.

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
@@ -252,7 +252,11 @@ static SILInstruction *optimizeBuiltinWithSameOperands(SILBuilder &Builder,
     };
     return B.createTuple(I->getLoc(), Ty, Elements);
   }
-      
+
+  // Replace the type check with 'true'.
+  case BuiltinValueKind::IsSameMetatype:
+    return Builder.createIntegerLiteral(I->getLoc(), I->getType(), true);
+
   default:
     break;
   }

--- a/test/SILOptimizer/existential_metatype.swift
+++ b/test/SILOptimizer/existential_metatype.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend %s -O -emit-sil -parse-as-library | %FileCheck %s
+protocol SomeP {}
+
+public enum SpecialEnum : SomeP {}
+
+// CHECK-LABEL: sil shared [noinline] @$s20existential_metatype17checkProtocolType0aE0Sbxm_tAA5SomePRzlFAA11SpecialEnumO_Tg5Tf4d_n : $@convention(thin) () -> Bool {
+// CHECK-NEXT: bb0:
+// CHECK-NEXT:   %0 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %1 = struct $Bool (%0 : $Builtin.Int1)
+// CHECK-NEXT:   return %1 : $Bool
+// CHECK-LABEL: } // end sil function '$s20existential_metatype17checkProtocolType0aE0Sbxm_tAA5SomePRzlFAA11SpecialEnumO_Tg5Tf4d_n'
+@inline(never)
+func checkProtocolType<P : SomeP>(existentialType: P.Type) -> Bool {
+  return existentialType == SpecialEnum.self
+}
+
+public func testProtocolType() -> Bool {
+  return checkProtocolType(existentialType: SpecialEnum.self)
+}

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -3687,3 +3687,22 @@ bb0(%0 : $@callee_guaranteed (@in Int, @in Int) -> @out (), %1 : $*Int):
   return %5 : $@callee_guaranteed () -> @out ()
 
 }
+
+// Test builtin "is_same_metatype" folding.
+protocol SomeP {}
+
+public enum SpecialEnum : SomeP {}
+
+// CHECK-LABEL: sil @testFoldBuiltinIsSameMetatype : $@convention(thin) (@thick SpecialEnum.Type) -> Bool {
+// CHECK-NEXT: bb0(%0 : $@thick SpecialEnum.Type):
+// CHECK-NEXT:   [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   struct $Bool ([[TRUE]] : $Builtin.Int1)
+// CHECK-NEXT:   return
+// CHECK-LABEL: }  // end sil function 'testFoldBuiltinIsSameMetatype'
+sil @testFoldBuiltinIsSameMetatype : $@convention(thin) (@thick SpecialEnum.Type) -> Bool {
+bb0(%0 : $@thick SpecialEnum.Type):
+  %1 = init_existential_metatype %0 : $@thick SpecialEnum.Type, $@thick Any.Type
+  %3 = builtin "is_same_metatype"(%1 : $@thick Any.Type, %1 : $@thick Any.Type) : $Builtin.Int1
+  %4 = struct $Bool (%3 : $Builtin.Int1)
+  return %4 : $Bool
+}


### PR DESCRIPTION
To optimize String decoding.

Part 3/3 of #30729