### PR TITLE
[OSLogOptimization]  `emitCodeForSymbolicValue` should not attempt generating code for closures created by callers of os_log

### DIFF
--- a/test/SILOptimizer/OSLogMandatoryOptTest.swift
+++ b/test/SILOptimizer/OSLogMandatoryOptTest.swift
@@ -597,7 +597,8 @@ protocol Proto {
   var property: String { get set }
 }
 
-// Test capturing of address-only types in autoclosures.
+// Test capturing of address-only types in autoclosures. The following tests check that
+// there are no crashes in these cases.
 
 // CHECK-LABEL: @${{.*}}testInterpolationOfExistentials1pyAA5Proto_p_tF
 func testInterpolationOfExistentials(p: Proto) {
@@ -607,5 +608,30 @@ func testInterpolationOfExistentials(p: Proto) {
 // CHECK-LABEL: @${{.*}}testInterpolationOfGenerics1pyx_tAA5ProtoRzlF
 func testInterpolationOfGenerics<T : Proto>(p: T) {
   _osLogTestHelper("A generic argument's property \(p.property)")
+}
+
+class TestClassSelfTypeCapture {
+  // CHECK-LABEL: @${{.*}}TestClassSelfTypeCaptureC04testdeF0yyF
+  func testSelfTypeCapture() {
+    _osLogTestHelper("Self type of a class \(String(describing: Self.self))")
+  }
+}
+
+struct TestStructSelfTypeCapture {
+  // CHECK-LABEL: @${{.*}}TestStructSelfTypeCaptureV04testdeF0yyF
+  func testSelfTypeCapture() {
+    _osLogTestHelper("Self type of a struct \(String(describing: Self.self))")
+  }
+}
+
+protocol TestProtocolSelfTypeCapture {
+  func testSelfTypeCapture()
+}
+
+extension TestProtocolSelfTypeCapture {
+  // CHECK-LABEL: @${{.*}}TestProtocolSelfTypeCapturePAAE04testdeF0yyF
+  func testSelfTypeCapture() {
+    _osLogTestHelper("Self type of a protocol \(String(describing: Self.self))")
+  }
 }
 


### PR DESCRIPTION
Make `emitCodeForSymbolicValue` generate code for closures iff the closure is not created by the caller function where the code is generated. Otherwise, when the closure is created
by the caller, just reuse it after copying and extending its lifetime.

Before this change new closures were created as long as all captures of the closures were symbolic constants. This patch updates it so that even if all captures are symbolic constants no code is generated for closures that are already available in the caller. This avoids doing
needless work and also fixes the following bug, which arises because the `emitCodeForSymbolicValue` does not handle all possible constants (particularly, metatype constants) that are tracked by the constant evaluator .

<rdar://problem/61465764>