### PR TITLE
[Parse] Don't drop the EnumCaseDecl when it has a trailing comma.

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6605,8 +6605,7 @@ Parser::parseDeclEnumCase(ParseDeclOptions Flags,
     // Handle the likely case someone typed 'case X, case Y'.
     if (Tok.is(tok::kw_case) && CommaLoc.isValid()) {
       diagnose(Tok, diag::expected_identifier_after_case_comma);
-      Status.setIsParseError();
-      return Status;
+      break;
     }
 
     if (Tok.is(tok::identifier)) {
@@ -6651,8 +6650,7 @@ Parser::parseDeclEnumCase(ParseDeclOptions Flags,
         }
       } else if (CommaLoc.isValid()) {
         diagnose(Tok, diag::expected_identifier_after_case_comma);
-        Status.setIsParseError();
-        return Status;
+        break;
       } else {
         diagnose(CaseLoc, diag::expected_identifier_in_decl, "enum 'case'");
       }

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -454,6 +454,13 @@ func keywordInCaseAndLocalArgLabel(_ for: Int, for in: Int, class _: Int) {
   }
 }
 
+enum CasesWithMissingElement {
+  case a(Int, String),
+  // CHECK: <kw>case</kw> a(<type>Int</type>, <type>String</type>)
+  case b(Int, String),
+  // CHECK: <kw>case</kw> b(<type>Int</type>, <type>String</type>)
+}
+
 // CHECK: <kw>class</kw> Ownership {
 class Ownership {
   // CHECK: <attr-builtin>weak</attr-builtin> <kw>var</kw> w

--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -591,3 +591,13 @@ enum SR11261_Newline2 {
 enum SR11261_PatternMatching {
   case let .foo(x, y): // expected-error {{'case' label can only appear inside a 'switch' statement}}
 }
+
+enum CasesWithMissingElement: Int {
+  // expected-error@-1 {{'CasesWithMissingElement' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}}
+
+  case a = "hello", // expected-error{{expected identifier after comma in enum 'case' declaration}}
+  // expected-error@-1 {{cannot convert value of type 'String' to raw type 'Int'}}
+
+  case b = "hello", // expected-error{{expected identifier after comma in enum 'case' declaration}}
+  // expected-error@-1 {{cannot convert value of type 'String' to raw type 'Int'}}
+}

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -717,6 +717,6 @@ outerLoop1: repeat { // expected-note {{did you mean 'outerLoop1'?}} {{14-23=out
 
 // Errors in case syntax
 class
-case, // expected-error {{expected identifier in enum 'case' declaration}} expected-error {{expected identifier after comma in enum 'case' declaration}}
+case, // expected-error {{expected identifier in enum 'case' declaration}} expected-error {{expected identifier after comma in enum 'case' declaration}} expected-error {{enum 'case' is not allowed outside of an enum}}
 case  // expected-error {{expected identifier in enum 'case' declaration}} expected-error {{enum 'case' is not allowed outside of an enum}}
 // NOTE: EOF is important here to properly test a code path that used to crash the parser


### PR DESCRIPTION
This meant we weren't producing sema diagnostics for the case, and it didn’t get full syntactic/semantic highlighting or indentation.
```
enum CasesWithMissingElement {
  // both cases below are dropped from the AST
  case a(Int, String),
  case b(Int, String),
}
```

Resolves rdar://problem/61476844