### PR TITLE
Revert "Ignore transitive ObjC imports when cross-importing"

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -128,9 +128,7 @@ public:
 
   /// Retrieves the Swift wrapper for the given Clang module, creating
   /// it if necessary.
-  virtual ModuleDecl *
-  getWrapperForModule(const clang::Module *mod,
-                      bool returnOverlayIfPossible = false) const = 0;
+  virtual ModuleDecl *getWrapperForModule(const clang::Module *mod) const = 0;
 
   /// Adds a new search path to the Clang CompilerInstance, as if specified with
   /// -I or -F.

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -465,7 +465,7 @@ public:
   /// Retrieve the top-level module. If this module is already top-level, this
   /// returns itself. If this is a submodule such as \c Foo.Bar.Baz, this
   /// returns the module \c Foo.
-  ModuleDecl *getTopLevelModule(bool overlay = false);
+  ModuleDecl *getTopLevelModule();
 
   bool isResilient() const {
     return getResilienceStrategy() != ResilienceStrategy::Default;

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -330,9 +330,7 @@ public:
 
   /// Retrieves the Swift wrapper for the given Clang module, creating
   /// it if necessary.
-  ModuleDecl *
-  getWrapperForModule(const clang::Module *mod,
-                      bool returnOverlayIfPossible = false) const override;
+  ModuleDecl *getWrapperForModule(const clang::Module *mod) const override;
 
   std::string getBridgingHeaderContents(StringRef headerPath, off_t &fileSize,
                                         time_t &fileModTime);

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -514,7 +514,7 @@ SourceLookupCache &ModuleDecl::getSourceLookupCache() const {
   return *Cache;
 }
 
-ModuleDecl *ModuleDecl::getTopLevelModule(bool overlay) {
+ModuleDecl *ModuleDecl::getTopLevelModule() {
   // If this is a Clang module, ask the Clang importer for the top-level module.
   // We need to check isNonSwiftModule() to ensure we don't look through
   // overlays.
@@ -522,8 +522,7 @@ ModuleDecl *ModuleDecl::getTopLevelModule(bool overlay) {
     if (auto *underlying = findUnderlyingClangModule()) {
       auto &ctx = getASTContext();
       auto *clangLoader = ctx.getClangModuleLoader();
-      return clangLoader->getWrapperForModule(underlying->getTopLevelModule(),
-                                              overlay);
+      return clangLoader->getWrapperForModule(underlying->getTopLevelModule());
     }
   }
   // Swift modules don't currently support submodules.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1860,13 +1860,8 @@ ModuleDecl *ClangImporter::getImportedHeaderModule() const {
   return Impl.ImportedHeaderUnit->getParentModule();
 }
 
-ModuleDecl *
-ClangImporter::getWrapperForModule(const clang::Module *mod,
-                                   bool returnOverlayIfPossible) const {
-  auto clangUnit = Impl.getWrapperForModule(mod);
-  if (returnOverlayIfPossible && clangUnit->getOverlayModule())
-    return clangUnit->getOverlayModule();
-  return clangUnit->getParentModule();
+ModuleDecl *ClangImporter::getWrapperForModule(const clang::Module *mod) const {
+  return Impl.getWrapperForModule(mod)->getParentModule();
 }
 
 PlatformAvailability::PlatformAvailability(LangOptions &langOpts)

--- a/test/CrossImport/Inputs/lib-templates/include/core_mi6.h
+++ b/test/CrossImport/Inputs/lib-templates/include/core_mi6.h
@@ -1,1 +1,0 @@
-void fromCoreMI6();

--- a/test/CrossImport/Inputs/lib-templates/include/core_mi6.swiftcrossimport/ThinLibrary.swiftoverlay
+++ b/test/CrossImport/Inputs/lib-templates/include/core_mi6.swiftcrossimport/ThinLibrary.swiftoverlay
@@ -1,5 +1,0 @@
-%YAML 1.2
----
-version: 1
-modules:
-  - name: _NeverImportedOverlay

--- a/test/CrossImport/Inputs/lib-templates/include/module.modulemap
+++ b/test/CrossImport/Inputs/lib-templates/include/module.modulemap
@@ -4,11 +4,3 @@ module ClangLibrary {
     header "clang_library_submodule.h"
   }
 }
-module core_mi6 {
-  header "core_mi6.h"
-  export *
-}
-module UniversalExports {
-  header "universal_exports.h"
-  export *
-}

--- a/test/CrossImport/Inputs/lib-templates/include/universal_exports.h
+++ b/test/CrossImport/Inputs/lib-templates/include/universal_exports.h
@@ -1,2 +1,0 @@
-#import <core_mi6.h>
-void fromUniversalExportsClang();

--- a/test/CrossImport/Inputs/lib-templates/lib/swift/UniversalExports.swiftinterface
+++ b/test/CrossImport/Inputs/lib-templates/lib/swift/UniversalExports.swiftinterface
@@ -2,10 +2,6 @@
 // swift-module-flags: -swift-version 5 -enable-library-evolution -module-name UniversalExports
 
 import Swift
-
-// This is also a clang overlay:
-@_exported import UniversalExports
-
 @_exported import AlwaysImported
 import NeverImported
 import MI6    // @_exported imports NeverImported

--- a/test/CrossImport/transitive.swift
+++ b/test/CrossImport/transitive.swift
@@ -14,12 +14,6 @@ import UniversalExports
 import ThinLibrary
 #endif
 
-// We should have loaded the underlying clang module.
-fromUniversalExportsClang() // no-error
-
-// We should have loaded core_mi6 too.
-fromCoreMI6() // no-error
-
 // We should have loaded _AlwaysImportedOverlay.
 fromAlwaysImportedOverlay() // no-error
 


### PR DESCRIPTION
Reverts apple/swift#30819