### PR TITLE
[AutoDiff] Remove `-lm` from test.

### DIFF
--- a/test/AutoDiff/IRGen/loadable_by_address_cross_module.swift
+++ b/test/AutoDiff/IRGen/loadable_by_address_cross_module.swift
@@ -26,7 +26,7 @@
 
 // Finally, execute the test.
 
-// RUN: %target-build-swift -I%t -L%t %s -o %t/a.out -lm -lexternal
+// RUN: %target-build-swift -I%t -L%t %s -o %t/a.out -lexternal
 // RUN: %target-run %t/a.out
 
 // REQUIRES: executable_test


### PR DESCRIPTION
`-lm` is not supported on Windows.