### PR TITLE
test: repair the AutoDiff test on Windows

### DIFF
--- a/test/AutoDiff/IRGen/loadable_by_address_cross_module.swift
+++ b/test/AutoDiff/IRGen/loadable_by_address_cross_module.swift
@@ -9,7 +9,7 @@
 // Compile the module.
 
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -working-directory %t -parse-as-library -emit-module -module-name external -emit-module-path %t/external.swiftmodule -emit-library -static %S/Inputs/loadable_by_address_cross_module.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(external)) %S/Inputs/loadable_by_address_cross_module.swift -emit-module -emit-module-path %t/external.swiftmodule -module-name external
 
 // Next, check that differentiability_witness_functions in the client get
 // correctly modified by LBA.
@@ -26,8 +26,10 @@
 
 // Finally, execute the test.
 
-// RUN: %target-build-swift -I%t -L%t %s -o %t/a.out -lm -lexternal
-// RUN: %target-run %t/a.out
+// RUN: %target-build-swift -I%t -L%t %s -o %t/a.out %target-rpath(%t) -L%t -lexternal
+// RUN: %target-codesign %t/a.out
+// RUN: %target-codesign %t/%target-library-name(external)
+// RUN: %target-run %t/a.out %t/%target-library-name(external)
 
 // REQUIRES: executable_test
 


### PR DESCRIPTION
`-lm` is not portable, it is only needed on certain platforms (e.g.
Linux, not BSD).  Remove the explicit link.

Avoid using a static library as that is not supported on all platforms
(e.g. Windows).  Use the helper macros to generate the library.

Repairs the Windows tests.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
