### PR TITLE
Fix SynthesizedFileUnit.

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -14,11 +14,13 @@
 #define SWIFT_AST_SOURCEFILE_H
 
 #include "swift/AST/FileUnit.h"
+#include "swift/AST/SynthesizedFileUnit.h"
 #include "swift/Basic/Debug.h"
 
 namespace swift {
 
 class PersistentParserState;
+class SynthesizedFileUnit;
 
 /// A file containing Swift source code.
 ///
@@ -134,6 +136,9 @@ private:
   /// within the file to keep them from conflicting with other files in the
   /// same module.
   mutable Identifier PrivateDiscriminator;
+
+  /// A synthesized file corresponding to this file, created on-demand.
+  SynthesizedFileUnit *SynthesizedFile = nullptr;
 
   /// The root TypeRefinementContext for this SourceFile.
   ///
@@ -451,6 +456,11 @@ public:
   Identifier getDiscriminatorForPrivateValue(const ValueDecl *D) const override;
   Identifier getPrivateDiscriminator() const { return PrivateDiscriminator; }
   Optional<BasicDeclLocs> getBasicLocsForDecl(const Decl *D) const override;
+
+  /// Returns the synthesized file for this source file, if it exists.
+  SynthesizedFileUnit *getSynthesizedFile() const { return SynthesizedFile; };
+
+  SynthesizedFileUnit &getOrCreateSynthesizedFile();
 
   virtual bool walk(ASTWalker &walker) override;
 

--- a/include/swift/AST/SynthesizedFileUnit.h
+++ b/include/swift/AST/SynthesizedFileUnit.h
@@ -18,8 +18,15 @@
 
 namespace swift {
 
-/// A container for synthesized module-level declarations.
+class SourceFile;
+
+/// A container for synthesized declarations, attached to a `SourceFile`.
+///
+/// Currently, only module-level synthesized declarations are supported.
 class SynthesizedFileUnit final : public FileUnit {
+  /// The parent source file.
+  SourceFile &SF;
+
   /// Synthesized top level declarations.
   TinyPtrVector<ValueDecl *> TopLevelDecls;
 
@@ -29,8 +36,11 @@ class SynthesizedFileUnit final : public FileUnit {
   mutable Identifier PrivateDiscriminator;
 
 public:
-  SynthesizedFileUnit(ModuleDecl &M);
+  SynthesizedFileUnit(SourceFile &SF);
   ~SynthesizedFileUnit() = default;
+
+  /// Returns the parent source file.
+  SourceFile &getSourceFile() const { return SF; }
 
   /// Add a synthesized top-level declaration.
   void addTopLevelDecl(ValueDecl *D) { TopLevelDecls.push_back(D); }

--- a/include/swift/SILOptimizer/Utils/Differentiation/ADContext.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/ADContext.h
@@ -67,9 +67,6 @@ private:
   /// Shared pass manager.
   SILPassManager &passManager;
 
-  /// A synthesized file unit.
-  SynthesizedFileUnit *synthesizedFile = nullptr;
-
   /// The worklist (stack) of `differentiable_function` instructions to be
   /// processed.
   llvm::SmallVector<DifferentiableFunctionInst *, 32>
@@ -126,9 +123,10 @@ public:
   SILPassManager &getPassManager() const { return passManager; }
   Lowering::TypeConverter &getTypeConverter() { return module.Types; }
 
-  /// Get or create a synthesized file for adding generated linear map structs
-  /// and branching trace enums. Used by `LinearMapInfo`.
-  SynthesizedFileUnit &getOrCreateSynthesizedFile();
+  /// Get or create the synthesized file for the given `SILFunction`.
+  /// Used by `LinearMapInfo` for adding generated linear map struct and
+  /// branching trace enum declarations.
+  SynthesizedFileUnit &getOrCreateSynthesizedFile(SILFunction *original);
 
   /// Returns true if the `differentiable_function` instruction worklist is
   /// empty.

--- a/lib/SILOptimizer/Utils/Differentiation/LinearMapInfo.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/LinearMapInfo.cpp
@@ -58,7 +58,7 @@ LinearMapInfo::LinearMapInfo(ADContext &context, AutoDiffLinearMapKind kind,
                              const DifferentiableActivityInfo &activityInfo)
     : kind(kind), original(original), derivative(derivative),
       activityInfo(activityInfo), indices(indices),
-      synthesizedFile(context.getOrCreateSynthesizedFile()),
+      synthesizedFile(context.getOrCreateSynthesizedFile(original)),
       typeConverter(context.getTypeConverter()) {
   generateDifferentiationDataStructures(context, derivative);
 }

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -23,6 +23,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/PropertyWrappers.h"
+#include "swift/AST/SynthesizedFileUnit.h"
 #include "swift/AST/TBDGenRequests.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/ClangImporter/ClangImporter.h"
@@ -1153,6 +1154,10 @@ GenerateTBDRequest::evaluate(Evaluator &evaluator,
   if (auto *singleFile = desc.getSingleFile()) {
     assert(M == singleFile->getParentModule() && "mismatched file and module");
     visitFile(singleFile);
+    // Visit synthesized file, if it exists.
+    if (auto *SF = dyn_cast<SourceFile>(singleFile))
+      if (auto *synthesizedFile = SF->getSynthesizedFile())
+        visitFile(synthesizedFile);
   } else {
     llvm::SmallVector<ModuleDecl*, 4> Modules;
     Modules.push_back(M);


### PR DESCRIPTION
`SynthesizedFileUnit` was added to `master` branch and used by the differentiation transform: https://github.com/apple/swift/pull/30863.

However, it wasn't first tested on `tensorflow` branch. Some TBDGen/serialization crashes surfaced when downstreaming the changes: https://gist.github.com/dan-zheng/3c06fa835ed035389c2dd5adeecac4e7
```
Failing Tests (4):
    Swift(linux-x86_64) :: AutoDiff/downstream/loadable_by_address_cross_module.swift
    Swift(linux-x86_64) :: AutoDiff/downstream/e2e_cross_module.swift
    Swift(linux-x86_64) :: AutoDiff/downstream/compiler_crashers_fixed/tf1202-eliminating-differentiability-witness-original-function.swift
    Swift(linux-x86_64) :: AutoDiff/downstream/differentiable_attr_cross_module/main.swift
```

This fixes those issues, resolving TF-1239.

---

Make `SynthesizedFileUnit` attached to a `SourceFile`: this seemed like the
least ad-hoc approach to avoid doing unnecesary work for other `FileUnit`s.