### PR TITLE
test: support long paths in `rewrite-module-triples`

### DIFF
--- a/test/CrossImport/Inputs/rewrite-module-triples.py
+++ b/test/CrossImport/Inputs/rewrite-module-triples.py
@@ -7,6 +7,7 @@ the indicated module triples instead.
 from __future__ import print_function
 
 import os
+import platform
 import shutil
 import sys
 
@@ -36,7 +37,11 @@ def rewrite(parent, names, copy_fn, rm_fn):
 
         for new_name in new_names:
             new_path = os.path.join(parent, new_name)
-            copy_fn(path, new_path)
+            if platform.system() == 'Windows':
+                copy_fn(u'\\'.join([u'\\\\?', os.path.normpath(path)]),
+                        u'\\'.join([u'\\\\?', os.path.normpath(new_path)]))
+            else:
+                copy_fn(path, new_path)
 
         rm_fn(path)
 


### PR DESCRIPTION
The path that the tests are using here are extremely long, and can
easily exceed the 261 character limit on Windows.  Apply some
workarounds to support long paths.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
