### PR TITLE
Fix assert in MemAccessUtils isLetAccess

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -79,9 +79,7 @@ SingleValueInstruction *isAccessProjection(SILValue v);
 SILValue getAddressAccess(SILValue v);
 
 /// Convenience for stripAccessMarkers(getAddressAccess(v)).
-inline SILValue getAccessedAddress(SILValue v) {
-  return stripAccessMarkers(getAddressAccess(v));
-}
+SILValue getAccessedAddress(SILValue v);
 
 /// Return true if \p accessedAddress points to a let-variable.
 ///

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -58,6 +58,15 @@ SILValue swift::getAddressAccess(SILValue v) {
   }
 }
 
+SILValue swift::getAccessedAddress(SILValue v) {
+  while (true) {
+    SILValue v2 = stripAccessMarkers(getAddressAccess(v));
+    if (v2 == v)
+      return v;
+    v = v2;
+  }
+}
+
 bool swift::isLetAddress(SILValue accessedAddress) {
   assert(accessedAddress == getAccessedAddress(accessedAddress)
          && "caller must find the address root");

--- a/test/SILOptimizer/mem-behavior-all.sil
+++ b/test/SILOptimizer/mem-behavior-all.sil
@@ -141,3 +141,30 @@ bb0(%0 : $C):
   %8 = tuple ()
   return %8 : $()
 }
+
+// ===-----------------------------------------------------------------------===
+// Test that isLetAccess does not assert on nested access markers with
+// interprosed projections.
+
+struct Int64Wrapper {
+  var val : Int64
+}
+
+// CHECK-LABEL: @testNestedAccessWithInterposedProjection
+// CHECK: PAIR #2.
+// CHECK:     %1 = begin_access [modify] [static] %0 : $*Int64Wrapper // users: %7, %2
+// CHECK:     %3 = begin_access [read] [static] %2 : $*Int64  // users: %6, %4
+// CHECK:   r=0,w=1,se=1
+// CHECK: PAIR #3.
+sil @testNestedAccessWithInterposedProjection : $@convention(thin) (@inout Int64Wrapper) -> () {
+bb0(%0 : $*Int64Wrapper):
+  %1 = begin_access [modify] [static] %0 : $*Int64Wrapper
+  %2 = struct_element_addr %1 : $*Int64Wrapper, #Int64Wrapper.val
+  %3 = begin_access [read] [static] %2 : $*Int64
+  %4 = struct_element_addr %3 : $*Int64, #Int64._value
+  %5 = load %4 : $*Builtin.Int64
+  end_access %3 : $*Int64
+  end_access %1 : $*Int64Wrapper
+  %8 = tuple ()
+  return %8 : $()
+}


### PR DESCRIPTION
Assertion failed:
(accessedAddress == getAccessedAddress(accessedAddress) &&
"caller must find the address root"), function isLetAddress,
file /swift/lib/SIL/Utils/MemAccessUtils.cpp, line 63.

Teach the getAccessedAddress utility to iterate through nested access
markers with projections interposed.

Fixes <rdar://problem/61464370>
Crash in SILOptimizer/access_marker_verify.swift

