### PR TITLE
[AutoDiff] Gardening.

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -20,7 +20,6 @@
 namespace swift {
 
 class PersistentParserState;
-class SynthesizedFileUnit;
 
 /// A file containing Swift source code.
 ///

--- a/test/AutoDiff/IRGen/Inputs/loadable_by_address_cross_module.swift
+++ b/test/AutoDiff/IRGen/Inputs/loadable_by_address_cross_module.swift
@@ -15,14 +15,4 @@ public struct LargeLoadableType<T>: AdditiveArithmetic, Differentiable {
   public func externalLBAModifiedFunction(_ x: Float) -> Float {
     return x * a
   }
-
-  // TODO(TF-1226): Remove custom derivative when stdlib derivatives are upstreamed.
-  @usableFromInline
-  @derivative(of: externalLBAModifiedFunction)
-  func externalLBAModifiedFunctionVJP(_ x: Float) -> (
-    value: Float, pullback: (Float) -> (Self, Float)
-  ) {
-    let value = externalLBAModifiedFunction(x)
-    return (value, { v in (Self(a: v * x), v * a) })
-  }
 }

--- a/test/AutoDiff/Parse/differentiable_attr_parse.swift
+++ b/test/AutoDiff/Parse/differentiable_attr_parse.swift
@@ -1,7 +1,5 @@
 // RUN: %target-swift-frontend -parse -verify %s
 
-// TODO(TF-1021): Remove "deprecated 'jvp:' and 'vjp:' argument" warnings.
-
 /// Good
 
 struct Foo {


### PR DESCRIPTION
- Remove obsolete TODO comments.
- Remove unnecessary `SynthesizedFileUnit` forward declaration from `SourceFile.h`.