### PR TITLE
[AutoDiff] Enable forward-mode differentiation tests.

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -275,6 +275,34 @@ code for the target that is not the build machine:
 
   Add ``REQUIRES: executable_test`` to the test.
 
+* ``%target-run-simple-swift(`` *compiler arguments* ``)``: like
+  ``%target-run-simple-swift``, but enables specifying compiler arguments when
+  compiling the Swift program.
+
+  Add ``REQUIRES: executable_test`` to the test.
+
+* ``%target-run-simple-swiftgyb``: build a one-file Swift `.gyb` program and
+  run it on the target machine.
+
+  Use this substitution for executable tests that don't require special
+  compiler arguments.
+
+  Add ``REQUIRES: executable_test`` to the test.
+
+* ``%target-run-simple-swiftgyb(`` *compiler arguments* ``)``: like
+  ``%target-run-simple-swiftgyb``, but enables specifying compiler arguments
+  when compiling the Swift program.
+
+  Add ``REQUIRES: executable_test`` to the test.
+
+* ``%target-run-simple-swift``: build a one-file Swift program and run it on
+  the target machine.
+
+  Use this substitution for executable tests that don't require special
+  compiler arguments.
+
+  Add ``REQUIRES: executable_test`` to the test.
+
 * ``%target-run-stdlib-swift``: like ``%target-run-simple-swift`` with
   ``-parse-stdlib -Xfrontend -disable-access-control``.
 

--- a/test/AutoDiff/stdlib/floating_point.swift.gyb
+++ b/test/AutoDiff/stdlib/floating_point.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swiftgyb
+// RUN: %target-run-simple-swiftgyb(-Xfrontend -enable-experimental-forward-mode-differentiation)
 // REQUIRES: executable_test
 
 #if (arch(i386) || arch(x86_64)) && !os(Windows)
@@ -38,33 +38,24 @@ FloatingPointDerivativeTests.test("${Self}.+") {
   expectEqual((1, 1), gradient(at: ${Self}(4), ${Self}(5), in: +))
   expectEqual((10, 10), pullback(at: ${Self}(4), ${Self}(5), in: +)(${Self}(10)))
 
-  // TODO(TF-1237): Upstream forward-mode differentiation.
-  expectCrash {
-    expectEqual(2, derivative(at: ${Self}(4), ${Self}(5), in: +))
-    expectEqual(20, differential(at: ${Self}(4), ${Self}(5), in: +)(${Self}(10), ${Self}(10)))
-  }
+  expectEqual(2, derivative(at: ${Self}(4), ${Self}(5), in: +))
+  expectEqual(20, differential(at: ${Self}(4), ${Self}(5), in: +)(${Self}(10), ${Self}(10)))
 }
 
 FloatingPointDerivativeTests.test("${Self}.-") {
   expectEqual((1, -1), gradient(at: ${Self}(4), ${Self}(5), in: -))
   expectEqual((10, -10), pullback(at: ${Self}(4), ${Self}(5), in: -)(${Self}(10)))
 
-  // TODO(TF-1237): Upstream forward-mode differentiation.
-  expectCrash {
-    expectEqual(0, derivative(at: ${Self}(4), ${Self}(5), in: -))
-    expectEqual(-5, differential(at: ${Self}(4), ${Self}(5), in: -)(${Self}(5), ${Self}(10)))
-  }
+  expectEqual(0, derivative(at: ${Self}(4), ${Self}(5), in: -))
+  expectEqual(-5, differential(at: ${Self}(4), ${Self}(5), in: -)(${Self}(5), ${Self}(10)))
 }
 
 FloatingPointDerivativeTests.test("${Self}.*") {
   expectEqual((5, 4), gradient(at: ${Self}(4), ${Self}(5), in: *))
   expectEqual((50, 40), pullback(at: ${Self}(4), ${Self}(5), in: *)(${Self}(10)))
 
-  // TODO(TF-1237): Upstream forward-mode differentiation.
-  expectCrash {
-    expectEqual(9, derivative(at: ${Self}(4), ${Self}(5), in: *))
-    expectEqual(90, differential(at: ${Self}(4), ${Self}(5), in: *)(${Self}(10), ${Self}(10)))
-  }
+  expectEqual(9, derivative(at: ${Self}(4), ${Self}(5), in: *))
+  expectEqual(90, differential(at: ${Self}(4), ${Self}(5), in: *)(${Self}(10), ${Self}(10)))
 }
 
 FloatingPointDerivativeTests.test("${Self}./") {
@@ -79,11 +70,8 @@ FloatingPointDerivativeTests.test("${Self}./") {
     expectEqualWithTolerance(-1.6, dy)
   }
 
-  // TODO(TF-1237): Upstream forward-mode differentiation.
-  expectCrash {
-    expectEqualWithTolerance(0.04, derivative(at: ${Self}(4), ${Self}(5), in: /))
-    expectEqual(90, differential(at: ${Self}(4), ${Self}(5), in: *)(${Self}(10), ${Self}(10)))
-  }
+  expectEqualWithTolerance(0.04, derivative(at: ${Self}(4), ${Self}(5), in: /))
+  expectEqual(90, differential(at: ${Self}(4), ${Self}(5), in: *)(${Self}(10), ${Self}(10)))
 }
 
 FloatingPointDerivativeTests.test("${Self}.squareRoot") {

--- a/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
+++ b/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swiftgyb
+// RUN: %target-run-simple-swiftgyb(-Xfrontend -enable-experimental-forward-mode-differentiation)
 // REQUIRES: executable_test
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
@@ -55,10 +55,6 @@ where T == T.TangentVector {
 %for T in ['Float', 'Float80']:
 
 DerivativeTests.test("${op}_${T}") {
-%if op == 'derivative':
-  // TODO(TF-1237): Upstream forward-mode differentiation and uncomment the next line.
-  expectCrash {
-%end
   expectEqualWithTolerance(7.3890560989306502274, ${op}(at: 2 as ${T}, in: exp))
   expectEqualWithTolerance(2.772588722239781145, ${op}(at: 2 as ${T}, in: exp2))
   expectEqualWithTolerance(7.3890560989306502274, ${op}(at: 2 as ${T}, in: expm1))
@@ -86,10 +82,6 @@ DerivativeTests.test("${op}_${T}") {
   expectEqualWithTolerance(0, ${op}(at: 2 as ${T}, in: { round($0) }))
   expectEqualWithTolerance(0, ${op}(at: 2 as ${T}, in: { trunc($0) }))
 
-%if op == 'derivative':
-  } // `expectCrash` for forward-mode differentiation
-%end
-
   // Differential operator specific tests.
 
   // fma
@@ -99,10 +91,7 @@ DerivativeTests.test("${op}_${T}") {
   expectEqualWithTolerance(4, dfma.1)
   expectEqualWithTolerance(1, dfma.2)
 %else: # if op == 'derivative'
-  // TODO(TF-1237): Upstream forward-mode differentiation.
-  expectCrash {
-    expectEqualWithTolerance(10, dfma)
-  }
+  expectEqualWithTolerance(10, dfma)
 %end
 
   // remainder, fmod

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -785,6 +785,7 @@ def use_interpreter_for_simple_runs():
     config.target_run_stdlib_swift = make_simple_target_run(stdlib=True)
     config.target_run_simple_swift = make_simple_target_run()
     config.target_run_simple_swift_parameterized = make_simple_target_run(parameterized=True)
+    config.target_run_simple_swiftgyb_parameterized = make_simple_target_run(gyb=True, parameterized=True)
     config.available_features.add('interpret')
 
 target_specific_module_triple = config.variant_triple
@@ -1609,13 +1610,24 @@ if not kIsWindows:
 			.format(all_stdlib_path, libdispatch_path)) + config.target_run
 			
 if not getattr(config, 'target_run_simple_swift', None):
-    config.target_run_simple_swift_parameterized =                               \
-        (SubstituteCaptures('%%empty-directory(%%t) && '
-                            '%s %s %%s \\1 -o %%t/a.out -module-name main  && '
-                            '%s %%t/a.out && '
-                            '%s %%t/a.out' % (config.target_build_swift,
-                                              mcp_opt, config.target_codesign,
-                                              config.target_run)))
+    config.target_run_simple_swift_parameterized = SubstituteCaptures(
+        "%%empty-directory(%%t) && "
+        "%s %s %%s \\1 -o %%t/a.out -module-name main  && "
+        "%s %%t/a.out && "
+        "%s %%t/a.out"
+        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run)
+    )
+    config.target_run_simple_swiftgyb_parameterized = SubstituteCaptures(
+        "%%empty-directory(%%t) && "
+        "%%gyb %%s -o %%t/main.swift && "
+        "%%line-directive %%t/main.swift -- "
+        "%s %s %%t/main.swift \\1 -o %%t/a.out -module-name main  && "
+        "%s %%t/a.out && "
+        "%%line-directive %%t/main.swift -- "
+        "%s %%t/a.out"
+        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run)
+    )
+
     config.target_run_simple_swift = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -o %%t/a.out -module-name main  && '
@@ -1688,8 +1700,11 @@ config.substitutions.append(('%target-swift-frontend\(mock-sdk:([^)]+)\)',
 config.substitutions.append(('%target-swift-frontend', config.target_swift_frontend))
 
 
+config.substitutions.append(('%target-run-simple-swiftgyb\(([^)]+)\)',
+                            config.target_run_simple_swiftgyb_parameterized))
 config.substitutions.append(('%target-run-simple-swiftgyb', config.target_run_simple_swiftgyb))
-config.substitutions.append(('%target-run-simple-swift\(([^)]+)\)', config.target_run_simple_swift_parameterized))
+config.substitutions.append(('%target-run-simple-swift\(([^)]+)\)',
+                            config.target_run_simple_swift_parameterized))
 config.substitutions.append(('%target-run-simple-swift', config.target_run_simple_swift))
 config.substitutions.append(('%target-run-stdlib-swiftgyb', config.target_run_stdlib_swiftgyb))
 config.substitutions.append(('%target-run-stdlib-swift', config.target_run_stdlib_swift))


### PR DESCRIPTION
Resolve TF-1237 TODO comments.

---

Add `lit` substitution `%target-run-simple-swiftgyb(...)` taking compiler arguments.

Use it in tests:
```swift
// RUN: %target-run-simple-swiftgyb(-Xfrontend -enable-experimental-forward-mode-differentiation)
```