### PR TITLE
test: lit still requires python2, explicitly use that

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -340,7 +340,7 @@ _Block_release(void) { }\n")
       endif()
 
       execute_process(COMMAND
-          "${PYTHON_EXECUTABLE}" "-c" "import psutil"
+          $<TARGET_FILE:Python2::Interpreter> "-c" "import psutil"
           RESULT_VARIABLE python_psutil_status
           TIMEOUT 1 # second
           ERROR_QUIET)
@@ -400,7 +400,7 @@ _Block_release(void) { }\n")
             ${command_upload_swift_reflection_test}
             ${command_clean_test_results_dir}
             COMMAND
-              ${PYTHON_EXECUTABLE} "${LIT}"
+              $<TARGET_FILE:Python2::Interpreter> "${LIT}"
               ${LIT_ARGS}
               "--param" "swift_test_subset=${test_subset}"
               "--param" "swift_test_mode=${test_mode}"
@@ -419,7 +419,7 @@ _Block_release(void) { }\n")
             ${command_upload_swift_reflection_test}
             ${command_clean_test_results_dir}
             COMMAND
-              ${PYTHON_EXECUTABLE} "${LIT}"
+              $<TARGET_FILE:Python2::Interpreter> "${LIT}"
               ${LIT_ARGS}
               "--param" "swift_test_subset=${test_subset}"
               "--param" "swift_test_mode=${test_mode}"


### PR DESCRIPTION
This updates the invocation to use `Python2::Interpreter` rather than
relying on the custom `PYTHON_EXECUTABLE`.  This is much easier to
identify where we are falling back to the python2 code paths and where
we can start moving towards Python3.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
