### PR TITLE
[Constraint solver] Migrate for-each statement checking into SolutionApplicationTarget

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4161,8 +4161,8 @@ SolutionApplicationTarget::SolutionApplicationTarget(
   expression.wrappedVar = nullptr;
   expression.isDiscarded = isDiscarded;
   expression.bindPatternVarsOneWay = false;
-  expression.patternBinding = nullptr;
-  expression.patternBindingIndex = 0;
+  expression.initialization.patternBinding = nullptr;
+  expression.initialization.patternBindingIndex = 0;
 }
 
 void SolutionApplicationTarget::maybeApplyPropertyWrapper() {
@@ -4259,18 +4259,35 @@ SolutionApplicationTarget SolutionApplicationTarget::forInitialization(
     auto result = forInitialization(
         initializer, dc, patternType,
         patternBinding->getPattern(patternBindingIndex), bindPatternVarsOneWay);
-    result.expression.patternBinding = patternBinding;
-    result.expression.patternBindingIndex = patternBindingIndex;
+    result.expression.initialization.patternBinding = patternBinding;
+    result.expression.initialization.patternBindingIndex = patternBindingIndex;
     return result;
 }
 
+SolutionApplicationTarget SolutionApplicationTarget::forForEachStmt(
+    ForEachStmt *stmt, ProtocolDecl *sequenceProto, DeclContext *dc,
+    bool bindPatternVarsOneWay) {
+  SolutionApplicationTarget target(
+      stmt->getSequence(), dc, CTP_ForEachStmt,
+      sequenceProto->getDeclaredType(), /*isDiscarded=*/false);
+  target.expression.pattern = stmt->getPattern();
+  target.expression.bindPatternVarsOneWay =
+    bindPatternVarsOneWay || (stmt->getWhere() != nullptr);
+  target.expression.forEachStmt.stmt = stmt;
+  target.expression.forEachStmt.whereExpr = stmt->getWhere();
+  return target;
+}
+
 ContextualPattern
-SolutionApplicationTarget::getInitializationContextualPattern() const {
+SolutionApplicationTarget::getContextualPattern() const {
   assert(kind == Kind::expression);
-  assert(expression.contextualPurpose == CTP_Initialization);
-  if (expression.patternBinding) {
+  assert(expression.contextualPurpose == CTP_Initialization ||
+         expression.contextualPurpose == CTP_ForEachStmt);
+  if (expression.contextualPurpose == CTP_Initialization &&
+      expression.initialization.patternBinding) {
     return ContextualPattern::forPatternBindingDecl(
-        expression.patternBinding, expression.patternBindingIndex);
+        expression.initialization.patternBinding,
+        expression.initialization.patternBindingIndex);
   }
 
   return ContextualPattern::forRawPattern(expression.pattern, expression.dc);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2309,8 +2309,7 @@ private:
   friend Optional<SolutionApplicationTarget>
   swift::TypeChecker::typeCheckExpression(SolutionApplicationTarget &target,
                                           bool &unresolvedTypeExprs,
-                                          TypeCheckExprOptions options,
-                                          ExprTypeCheckListener *listener);
+                                          TypeCheckExprOptions options);
 
   /// Emit the fixes computed as part of the solution, returning true if we were
   /// able to emit an error message, or false if none of the fixits worked out.
@@ -4453,11 +4452,9 @@ private:
   /// Solve the system of constraints generated from provided expression.
   ///
   /// \param target The target to generate constraints from.
-  /// \param listener The callback to check solving progress.
   /// \param allowFreeTypeVariables How to bind free type variables in
   /// the solution.
   SolutionResult solveImpl(SolutionApplicationTarget &target,
-                           ExprTypeCheckListener *listener,
                            FreeTypeVariableBinding allowFreeTypeVariables
                              = FreeTypeVariableBinding::Disallow);
 
@@ -4470,7 +4467,6 @@ public:
   ///
   /// \param target The target that we'll generate constraints from, which
   /// may be updated by the solving process.
-  /// \param listener The callback to check solving progress.
   /// \param allowFreeTypeVariables How to bind free type variables in
   /// the solution.
   ///
@@ -4478,7 +4474,6 @@ public:
   /// error occurred. When \c None, an error has been emitted.
   Optional<std::vector<Solution>> solve(
       SolutionApplicationTarget &target,
-      ExprTypeCheckListener *listener,
       FreeTypeVariableBinding allowFreeTypeVariables
         = FreeTypeVariableBinding::Disallow);
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -258,33 +258,6 @@ enum class FreeTypeVariableBinding {
   UnresolvedType
 };
 
-/// An abstract interface that can interact with the type checker during
-/// the type checking of a particular expression.
-class ExprTypeCheckListener {
-public:
-  virtual ~ExprTypeCheckListener();
-
-  /// Callback invoked once the constraint system has been constructed.
-  ///
-  /// \param cs The constraint system that has been constructed.
-  ///
-  /// \param expr The pre-checked expression from which the constraint system
-  /// was generated.
-  ///
-  /// \returns true if an error occurred that is not itself part of the
-  /// constraint system, or false otherwise.
-  virtual bool builtConstraints(constraints::ConstraintSystem &cs, Expr *expr);
-
-  /// Callback invokes once the chosen solution has been applied to the
-  /// expression.
-  ///
-  /// The callback may further alter the expression, returning either a
-  /// new expression (to replace the result) or a null pointer to indicate
-  /// failure.
-  virtual Expr *appliedSolution(constraints::Solution &solution,
-                                Expr *expr);
-};
-
 /// A conditional conformance that implied some other requirements. That is, \c
 /// ConformingType conforming to \c Protocol may have required additional
 /// requirements to be satisfied.
@@ -757,23 +730,17 @@ Expr *findLHS(DeclContext *DC, Expr *E, Identifier name);
 ///
 /// \param options Options that control how type checking is performed.
 ///
-/// \param listener If non-null, a listener that will be notified of important
-/// events in the type checking of this expression, and which can introduce
-/// additional constraints.
-///
 /// \returns The type of the top-level expression, or Type() if an
 ///          error occurred.
 Type typeCheckExpression(Expr *&expr, DeclContext *dc,
                          TypeLoc convertType = TypeLoc(),
                          ContextualTypePurpose convertTypePurpose = CTP_Unused,
-                         TypeCheckExprOptions options = TypeCheckExprOptions(),
-                         ExprTypeCheckListener *listener = nullptr);
+                         TypeCheckExprOptions options = TypeCheckExprOptions());
 
 Optional<constraints::SolutionApplicationTarget>
 typeCheckExpression(constraints::SolutionApplicationTarget &target,
                     bool &unresolvedTypeExprs,
-                    TypeCheckExprOptions options = TypeCheckExprOptions(),
-                    ExprTypeCheckListener *listener = nullptr);
+                    TypeCheckExprOptions options = TypeCheckExprOptions());
 
 /// Type check the given expression and return its type without
 /// applying the solution.
@@ -786,17 +753,12 @@ typeCheckExpression(constraints::SolutionApplicationTarget &target,
 /// \param allowFreeTypeVariables Whether free type variables are allowed in
 /// the solution, and what to do with them.
 ///
-/// \param listener If non-null, a listener that will be notified of important
-/// events in the type checking of this expression, and which can introduce
-/// additional constraints.
-///
 /// \returns the type of \p expr on success, Type() otherwise.
 /// FIXME: expr may still be modified...
 Type getTypeOfExpressionWithoutApplying(
     Expr *&expr, DeclContext *dc, ConcreteDeclRef &referencedDecl,
     FreeTypeVariableBinding allowFreeTypeVariables =
-        FreeTypeVariableBinding::Disallow,
-    ExprTypeCheckListener *listener = nullptr);
+        FreeTypeVariableBinding::Disallow);
 
 /// Return the type of operator function for specified LHS, or a null
 /// \c Type on error.


### PR DESCRIPTION
Pull the entirety of type checking for for-each statement headers (i.e., not the
body) into the constraint system, using the normal `SolutionApplicationTarget`-based
constraint generation and application facilities. Most of this was already handled
in the constraint solver (although the `where` filtering condition was not), so
this is a smaller change than it looks like.

This was the last client of `ExprTypeCheckListener`, so remove that listener interface.