### PR TITLE
runtime: fix a UBSAN issue

### DIFF
--- a/stdlib/public/runtime/MetadataCache.h
+++ b/stdlib/public/runtime/MetadataCache.h
@@ -471,7 +471,7 @@ public:
 
 private:
   uint32_t computeHash() const {
-    size_t H = 0x56ba80d1 * NumKeyParameters;
+    size_t H = 0x56ba80d1u * NumKeyParameters;
     for (unsigned index = 0; index != NumKeyParameters; ++index) {
       H = (H >> 10) | (H << ((sizeof(size_t) * 8) - 10));
       H ^= (reinterpret_cast<size_t>(Data[index])


### PR DESCRIPTION
This was identified by UBSAN: signed-integer-overflow.  Explicitly mark
the value as unsigned to ensure that the value does not overflow.  There
is a second instance of a raw literal, however, because it is a `*=` the
value is implicitly understood to be unsigned.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
