### PR TITLE
[SourceKit] Avoid one memcpy on potentially big sourcekit response data

### DIFF
--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/CompactArray.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/CompactArray.h
@@ -20,7 +20,7 @@ namespace sourcekitd {
 
 class CompactArrayBuilderImpl {
 public:
-  std::unique_ptr<llvm::MemoryBuffer> createBuffer() const;
+  std::unique_ptr<llvm::MemoryBuffer> createBuffer(CustomBufferKind Kind) const;
   void appendTo(llvm::SmallVectorImpl<char> &Buf) const;
   unsigned copyInto(char *BufPtr) const;
   size_t sizeInBytes() const;

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
@@ -86,7 +86,7 @@ public:
     void setBool(SourceKit::UIdent Key, bool val);
     Array setArray(SourceKit::UIdent Key);
     Dictionary setDictionary(SourceKit::UIdent Key);
-    void setCustomBuffer(SourceKit::UIdent Key, CustomBufferKind Kind,
+    void setCustomBuffer(SourceKit::UIdent Key,
                          std::unique_ptr<llvm::MemoryBuffer> MemBuf);
 
   private:

--- a/tools/SourceKit/tools/sourcekitd/lib/API/CodeCompletionResultsArray.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/CodeCompletionResultsArray.cpp
@@ -75,7 +75,8 @@ void CodeCompletionResultsArrayBuilder::add(
 
 std::unique_ptr<llvm::MemoryBuffer>
 CodeCompletionResultsArrayBuilder::createBuffer() {
-  return Impl.Builder.createBuffer();
+  return Impl.Builder.createBuffer(
+      CustomBufferKind::CodeCompletionResultsArray);
 }
 
 namespace {

--- a/tools/SourceKit/tools/sourcekitd/lib/API/CompactArray.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/CompactArray.cpp
@@ -70,10 +70,13 @@ unsigned CompactArrayBuilderImpl::getOffsetForString(StringRef Str) {
 }
 
 std::unique_ptr<llvm::MemoryBuffer>
-CompactArrayBuilderImpl::createBuffer() const {
+CompactArrayBuilderImpl::createBuffer(CustomBufferKind Kind) const {
+  auto bodySize = sizeInBytes();
   std::unique_ptr<llvm::WritableMemoryBuffer> Buf;
-  Buf = llvm::WritableMemoryBuffer::getNewUninitMemBuffer(sizeInBytes());
-  copyInto(Buf->getBufferStart(), Buf->getBufferSize());
+  Buf = llvm::WritableMemoryBuffer::getNewUninitMemBuffer(
+      sizeof(uint64_t) + bodySize);
+  *reinterpret_cast<uint64_t*>(Buf->getBufferStart()) = (uint64_t)Kind;
+  copyInto(Buf->getBufferStart() + sizeof(uint64_t), bodySize);
   return std::move(Buf);
 }
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/DocStructureArray.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/DocStructureArray.cpp
@@ -244,6 +244,8 @@ std::unique_ptr<llvm::MemoryBuffer> DocStructureArrayBuilder::createBuffer() {
   size_t structureArrayBufferSize = impl.structureArrayBuffer.size();
   size_t structureBufferSize = impl.structureBuilder.sizeInBytes();
 
+  size_t kindSize = sizeof(uint64_t);
+
   // Header:
   // * offset of each section start (5)
   // * offset of top structure array (relative to structure array section) (1)
@@ -251,9 +253,12 @@ std::unique_ptr<llvm::MemoryBuffer> DocStructureArrayBuilder::createBuffer() {
 
   auto result = llvm::WritableMemoryBuffer::getNewUninitMemBuffer(
       inheritedTypesBufferSize + attrsBufferSize + elementsBufferSize +
-      structureArrayBufferSize + structureBufferSize + headerSize);
+      structureArrayBufferSize + structureBufferSize + headerSize + kindSize);
 
-  char *start = result->getBufferStart();
+  *reinterpret_cast<uint64_t *>(result->getBufferStart()) =
+      (uint64_t)CustomBufferKind::DocStructureArray;
+
+  char *start = result->getBufferStart() + kindSize;
   char *headerPtr = start;
   char *ptr = start + headerSize;
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/DocSupportAnnotationArray.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/DocSupportAnnotationArray.cpp
@@ -53,7 +53,7 @@ void DocSupportAnnotationArrayBuilder::add(const DocEntityInfo &Info) {
 
 std::unique_ptr<llvm::MemoryBuffer>
 DocSupportAnnotationArrayBuilder::createBuffer() {
-  return Impl.Builder.createBuffer();
+  return Impl.Builder.createBuffer(CustomBufferKind::DocSupportAnnotationArray);
 }
 
 namespace {

--- a/tools/SourceKit/tools/sourcekitd/lib/API/TokenAnnotationsArray.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/TokenAnnotationsArray.cpp
@@ -55,7 +55,7 @@ bool TokenAnnotationsArrayBuilder::empty() const {
 
 std::unique_ptr<llvm::MemoryBuffer>
 TokenAnnotationsArrayBuilder::createBuffer() {
-  return Impl.Builder.createBuffer();
+  return Impl.Builder.createBuffer(CustomBufferKind::TokenAnnotationsArray);
 }
 
 namespace {

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
@@ -258,19 +258,9 @@ ResponseBuilder::Dictionary::setDictionary(UIdent Key) {
 }
 
 void ResponseBuilder::Dictionary::setCustomBuffer(
-      SourceKit::UIdent Key,
-      CustomBufferKind Kind, std::unique_ptr<llvm::MemoryBuffer> MemBuf) {
-
-  std::unique_ptr<llvm::WritableMemoryBuffer> CustomBuf;
-  CustomBuf = llvm::WritableMemoryBuffer::getNewUninitMemBuffer(
-      sizeof(uint64_t) + MemBuf->getBufferSize());
-  char *BufPtr = CustomBuf->getBufferStart();
-  *reinterpret_cast<uint64_t*>(BufPtr) = (uint64_t)Kind;
-  BufPtr += sizeof(uint64_t);
-  memcpy(BufPtr, MemBuf->getBufferStart(), MemBuf->getBufferSize());
-
-  xpc_object_t xdata = xpc_data_create(CustomBuf->getBufferStart(),
-                                       CustomBuf->getBufferSize());
+    SourceKit::UIdent Key, std::unique_ptr<llvm::MemoryBuffer> Buf) {
+  xpc_object_t xdata = xpc_data_create(Buf->getBufferStart(),
+                                       Buf->getBufferSize());
   xpc_dictionary_set_value(Impl, Key.c_str(), xdata);
   xpc_release(xdata);
 }


### PR DESCRIPTION
A kind indicator is needed before the actual data when custom data are stored as xpc dictionary values. Instead of prepending the kind bit by copying data to another buffer, let the data producers include it in the created data.
