### PR TITLE
[NFC] reduce the diff to master

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5811,31 +5811,6 @@ In raw SIL, the ``with_derivative`` clause is optional. In canonical SIL, the
 ``with_derivative`` clause is mandatory.
 
 
-differentiable_function_extract
-```````````````````````````````
-::
-
-  sil-instruction ::= 'differentiable_function_extract'
-                      '[' sil-differentiable-function-extractee ']'
-                      sil-value ':' sil-type
-                      ('as' sil-type)?
-
-  sil-differentiable-function-extractee ::= 'original' | 'jvp' | 'vjp'
-
-  differentiable_function_extract [original] %0 : $@differentiable (T) -> T
-  differentiable_function_extract [jvp] %0 : $@differentiable (T) -> T
-  differentiable_function_extract [vjp] %0 : $@differentiable (T) -> T
-  differentiable_function_extract [jvp] %0 : $@differentiable (T) -> T \
-    as $(@in_constant T) -> (T, (T.TangentVector) -> T.TangentVector)
-
-Extracts the original function or a derivative function from the given
-``@differentiable`` function. The extractee is one of the following:
-``[original]``, ``[jvp]``, or ``[vjp]``.
-
-In lowered SIL, an explicit extractee type may be provided. This is currently
-used by the LoadableByAddress transformation, which rewrites function types.
-
-
 linear_function
 ```````````````
 ::
@@ -5865,6 +5840,31 @@ the instruction.
 
 In raw SIL, the ``with_transpose`` clause is optional. In canonical SIL,
 the ``with_transpose`` clause is mandatory.
+
+
+differentiable_function_extract
+```````````````````````````````
+::
+
+  sil-instruction ::= 'differentiable_function_extract'
+                      '[' sil-differentiable-function-extractee ']'
+                      sil-value ':' sil-type
+                      ('as' sil-type)?
+
+  sil-differentiable-function-extractee ::= 'original' | 'jvp' | 'vjp'
+
+  differentiable_function_extract [original] %0 : $@differentiable (T) -> T
+  differentiable_function_extract [jvp] %0 : $@differentiable (T) -> T
+  differentiable_function_extract [vjp] %0 : $@differentiable (T) -> T
+  differentiable_function_extract [jvp] %0 : $@differentiable (T) -> T \
+    as $(@in_constant T) -> (T, (T.TangentVector) -> T.TangentVector)
+
+Extracts the original function or a derivative function from the given
+``@differentiable`` function. The extractee is one of the following:
+``[original]``, ``[jvp]``, or ``[vjp]``.
+
+In lowered SIL, an explicit extractee type may be provided. This is currently
+used by the LoadableByAddress transformation, which rewrites function types.
 
 
 linear_function_extract

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -841,7 +841,7 @@ public:
     return TargetFunctionTypeFlags<int_type>((Data & ~EscapingMask) |
                                              (isEscaping ? EscapingMask : 0));
   }
-  
+
   unsigned getNumParameters() const { return Data & NumParametersMask; }
 
   FunctionMetadataConvention getConvention() const {

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -31,8 +31,6 @@
 #include "swift/Basic/InlineBitfield.h"
 #include "llvm/Support/TrailingObjects.h"
 #include <utility>
-// SWIFT_ENABLE_TENSORFLOW
-#include "swift/AST/AutoDiff.h"
 
 namespace llvm {
   struct fltSemantics;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -90,13 +90,6 @@ class ModuleType;
 class ProtocolConformance;
 enum PointerTypeKind : unsigned;
 struct ValueOwnershipKind;
-// SWIFT_ENABLE_TENSORFLOW
-struct SILAutoDiffConfig;
-
-namespace Lowering {
-class TypeConverter;
-} // namespace Lowering
-// SWIFT_ENABLE_TENSORFLOW END
 
 typedef CanTypeWrapper<SILFunctionType> CanSILFunctionType;
 
@@ -296,7 +289,7 @@ class alignas(1 << TypeAlignInBits) TypeBase {
   TypeBase(const TypeBase&) = delete;
   void operator=(const TypeBase&) = delete;
   
-  /// This union contains the ASTContext for canonical types, and is
+  /// This union contains to the ASTContext for canonical types, and is
   /// otherwise lazily populated by ASTContext when the canonical form of a
   /// non-canonical type is requested. The disposition of the union is stored
   /// outside of the union for performance. See Bits.TypeBase.IsCanonical.
@@ -1868,7 +1861,6 @@ public:
 
   /// Create one from what's present in the parameter type
   inline static ParameterTypeFlags
-  // SWIFT_ENABLE_TENSORFLOW
   fromParameterType(Type paramTy, bool isVariadic, bool isAutoClosure,
                     bool isNonEphemeral, ValueOwnership ownership,
                     bool isNoDerivative);
@@ -1913,8 +1905,8 @@ public:
 
   ParameterTypeFlags withAutoClosure(bool isAutoClosure) const {
     return ParameterTypeFlags(isAutoClosure
-                              ? value | ParameterTypeFlags::AutoClosure
-                              : value - ParameterTypeFlags::AutoClosure);
+                                  ? value | ParameterTypeFlags::AutoClosure
+                                  : value - ParameterTypeFlags::AutoClosure);
   }
 
   ParameterTypeFlags withNonEphemeral(bool isNonEphemeral) const {
@@ -2706,7 +2698,7 @@ enum class FunctionTypeRepresentation : uint8_t {
   /// A C function pointer, which is thin and also uses the C calling
   /// convention.
   CFunctionPointer,
-
+  
   /// The value of the greatest AST function representation.
   Last = CFunctionPointer,
 };
@@ -2733,7 +2725,7 @@ enum class SILFunctionTypeRepresentation : uint8_t {
   /// A C function pointer, which is thin and also uses the C calling
   /// convention.
   CFunctionPointer = uint8_t(FunctionTypeRepresentation::CFunctionPointer),
-
+  
   /// The value of the greatest AST function representation.
   LastAST = CFunctionPointer,
 
@@ -2969,15 +2961,12 @@ public:
     //   |    0 .. 3    |    4   |   5  |      6 .. 7     |
     //
     enum : unsigned {
-      RepresentationMask           = 0xF << 0,
-      NoEscapeMask                 = 1 << 4,
-      ThrowsMask                   = 1 << 5,
-      DifferentiabilityMaskOffset  = 6,
-      DifferentiabilityMask        = 0x3 << DifferentiabilityMaskOffset,
-      // SWIFT_ENABLE_TENSORFLOW
-      NumDifferentiabilityMaskBits = 2,
-      // SWIFT_ENABLE_TENSORFLOW END
-      NumMaskBits                  = 8
+      RepresentationMask          = 0xF << 0,
+      NoEscapeMask                = 1 << 4,
+      ThrowsMask                  = 1 << 5,
+      DifferentiabilityMaskOffset = 6,
+      DifferentiabilityMask       = 0x3 << DifferentiabilityMaskOffset,
+      NumMaskBits                 = 8
     };
 
     unsigned Bits; // Naturally sized for speed.
@@ -4172,11 +4161,9 @@ public:
       NoEscapeMask       = 1 << 5,
       DifferentiabilityMaskOffset = 6,
       DifferentiabilityMask       = 0x3 << DifferentiabilityMaskOffset,
-      // SWIFT_ENABLE_TENSORFLOW
-      NumDifferentiabilityMaskBits = 2,
-      // SWIFT_ENABLE_TENSORFLOW END
       NumMaskBits                 = 8
     };
+
     unsigned Bits; // Naturally sized for speed.
 
     class Uncommon {
@@ -4693,6 +4680,20 @@ public:
 
   CanType getSelfInstanceType(SILModule &M) const;
 
+  /// If this is a @convention(witness_method) function with a class
+  /// constrained self parameter, return the class constraint for the
+  /// Self type.
+  ClassDecl *getWitnessMethodClass(SILModule &M) const;
+
+  /// If this is a @convention(witness_method) function, return the conformance
+  /// for which the method is a witness. If it isn't that convention, return
+  /// an invalid conformance.
+  ProtocolConformanceRef getWitnessMethodConformanceOrInvalid() const {
+    return WitnessMethodConformance;
+  }
+
+  const clang::FunctionType *getClangFunctionType() const;
+
   /// Given that `this` is a `@differentiable` or `@differentiable(linear)`
   /// function type, returns an `IndexSubset` corresponding to the
   /// differentiability/linearity parameters (e.g. all parameters except the
@@ -4837,20 +4838,6 @@ public:
       LookupConformanceFn lookupConformance,
       CanGenericSignature transposeFunctionGenericSignature = nullptr);
 
-  /// If this is a @convention(witness_method) function with a class
-  /// constrained self parameter, return the class constraint for the
-  /// Self type.
-  ClassDecl *getWitnessMethodClass(SILModule &M) const;
-
-  /// If this is a @convention(witness_method) function, return the conformance
-  /// for which the method is a witness. If it isn't that convention, return
-  /// an invalid conformance.
-  ProtocolConformanceRef getWitnessMethodConformanceOrInvalid() const {
-    return WitnessMethodConformance;
-  }
-
-  const clang::FunctionType *getClangFunctionType() const;
-
   ExtInfo getExtInfo() const {
     return ExtInfo(Bits.SILFunctionType.ExtInfoBits, getClangFunctionType());
   }
@@ -4884,7 +4871,6 @@ public:
   }
 
   bool isDifferentiable() const { return getExtInfo().isDifferentiable(); }
-
   DifferentiabilityKind getDifferentiabilityKind() const {
     return getExtInfo().getDifferentiabilityKind();
   }

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -415,10 +415,6 @@ public:
 
   void eraseInstructions();
 
-  // SWIFT_ENABLE_TENSORFLOW
-  /// Get estimated code size, for debugging only.
-  unsigned codeSize() const { return InstList.size(); }
-
 private:
   friend class SILArgument;
 

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -318,6 +318,7 @@ struct SILDeclRef {
   /// Returns the entry point for the original function corresponding to an
   /// autodiff derivative function.
   SILDeclRef asAutoDiffOriginalFunction() const {
+    assert(derivativeFunctionIdentifier);
     SILDeclRef declRef = *this;
     declRef.derivativeFunctionIdentifier = nullptr;
     return declRef;

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -542,7 +542,7 @@ public:
   }
 
   /// Returns true if the function has parameters that are consumed by the
-  /// callee.
+  // callee.
   bool hasOwnedParameters() const {
     for (auto &ParamInfo : getLoweredFunctionType()->getParameters()) {
       if (ParamInfo.isConsumed())
@@ -712,6 +712,7 @@ public:
   void clearSpecializeAttrs() { SpecializeAttrSet.clear(); }
 
   void addSpecializeAttr(SILSpecializeAttr *Attr);
+
 
   /// Get this function's optimization mode or OptimizationMode::NotSet if it is
   /// not set for this specific function.
@@ -1099,9 +1100,6 @@ public:
   /// Like ViewCFG, but the graph does not show the contents of basic blocks.
   void viewCFGOnly() const;
 
-  // SWIFT_ENABLE_TENSORFLOW
-  /// Get estimated code size, for debugging only.
-  unsigned codeSize() const;
 };
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,

--- a/include/swift/SIL/SILFunctionBuilder.h
+++ b/include/swift/SIL/SILFunctionBuilder.h
@@ -69,8 +69,6 @@ class SILFunctionBuilder {
                                          IsThunk_t isThunk,
                                          IsDynamicallyReplaceable_t isDynamic);
 
-
-
   /// Return the declaration of a function, or create it if it doesn't exist.
   SILFunction *getOrCreateFunction(
       SILLocation loc, StringRef name, SILLinkage linkage,

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -34,7 +34,6 @@ class DominanceInfo;
 class PostOrderFunctionInfo;
 class ReversePostOrderInfo;
 class Operand;
-class SILDebugLocation;  // SWIFT_ENABLE_TENSORFLOW: FIXME(clattner): upstream.
 class SILInstruction;
 class SILLocation;
 class DeadEndBlocks;
@@ -382,10 +381,6 @@ public:
 
   /// Get a location for this value.
   SILLocation getLoc() const;
-
-  // SWIFT_ENABLE_TENSORFLOW: FIXME(clattner): merge upstream.
-  /// Get a debug location for this value.
-  SILDebugLocation getDebugLocation() const;
 
   /// Convert this SILValue into an opaque pointer like type. For use with
   /// PointerLikeTypeTraits.

--- a/include/swift/SILOptimizer/Analysis/BottomUpIPAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/BottomUpIPAnalysis.h
@@ -43,7 +43,7 @@ protected:
   /// analysis information for a function.
   /// This base class stores the administrative information needed for
   /// invalidation and updating the analysis.
-  /// In the following "this function" refers to the derivative function.
+  /// In the following "this function" refers to the associated function.
   template<typename FunctionInfo> class FunctionInfoBase {
   public:
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -203,7 +203,6 @@ std::string ASTMangler::mangleWitnessThunk(
                                      const ProtocolConformance *Conformance,
                                            const ValueDecl *Requirement) {
   beginMangling();
-
   // Concrete witness thunks get a special mangling.
   if (Conformance) {
     if (!isa<SelfProtocolConformance>(Conformance)) {

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2785,6 +2785,7 @@ void CallEmission::setArgs(Explosion &original, bool isOutlined,
   case SILFunctionTypeRepresentation::Block:
     adjusted.add(getCallee().getBlockObject());
     LLVM_FALLTHROUGH;
+
   case SILFunctionTypeRepresentation::CFunctionPointer:
     externalizeArguments(IGF, getCallee(), original, adjusted,
                          Temporaries, isOutlined);

--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -568,7 +568,7 @@ clang::CanQualType GenClangType::visitSILFunctionType(CanSILFunctionType type) {
   case SILFunctionType::Representation::CFunctionPointer:
     kind = CFunctionPointer;
     break;
-
+  
   case SILFunctionType::Representation::Thick:
   case SILFunctionType::Representation::Thin:
   case SILFunctionType::Representation::Method:

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1746,14 +1746,11 @@ getIRLinkage(const UniversalLinkageInfo &info, SILLinkage linkage,
       info.UseDLLStorage ? llvm::GlobalValue::DLLImportStorageClass
                          : llvm::GlobalValue::DefaultStorageClass;
 
+  // SWIFT_ENABLE_TENSORFLOW: Cases slightly modified to fix TF-587.
   switch (linkage) {
   case SILLinkage::Public:
     return {llvm::GlobalValue::ExternalLinkage, PublicDefinitionVisibility,
             ExportedStorage};
-
-  case SILLinkage::PublicNonABI:
-    return isDefinition ? RESULT(WeakODR, Hidden, Default)
-                        : RESULT(External, Hidden, Default);
 
   case SILLinkage::Shared:
   case SILLinkage::SharedExternal:
@@ -1761,6 +1758,7 @@ getIRLinkage(const UniversalLinkageInfo &info, SILLinkage linkage,
                         : RESULT(External, Hidden, Default);
 
   case SILLinkage::Hidden:
+  case SILLinkage::PublicNonABI:
     return RESULT(External, Hidden, Default);
 
   case SILLinkage::Private: {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1751,13 +1751,16 @@ getIRLinkage(const UniversalLinkageInfo &info, SILLinkage linkage,
     return {llvm::GlobalValue::ExternalLinkage, PublicDefinitionVisibility,
             ExportedStorage};
 
+  case SILLinkage::PublicNonABI:
+    return isDefinition ? RESULT(WeakODR, Hidden, Default)
+                        : RESULT(External, Hidden, Default);
+
   case SILLinkage::Shared:
   case SILLinkage::SharedExternal:
     return isDefinition ? RESULT(LinkOnceODR, Hidden, Default)
                         : RESULT(External, Hidden, Default);
 
   case SILLinkage::Hidden:
-  case SILLinkage::PublicNonABI:
     return RESULT(External, Hidden, Default);
 
   case SILLinkage::Private: {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -592,7 +592,6 @@ public:
   llvm::IntegerType *RelativeAddressTy;
   llvm::PointerType *RelativeAddressPtrTy;
   llvm::IntegerType *Int64Ty;          /// i64
-
   union {
     llvm::IntegerType *SizeTy;         /// usually i32 or i64
     llvm::IntegerType *IntPtrTy;

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -2962,7 +2962,6 @@ namespace {
       case SILFunctionType::Representation::ObjCMethod:
       case SILFunctionType::Representation::CFunctionPointer:
       case SILFunctionType::Representation::Closure:
-
         // A thin function looks like a plain pointer.
         // FIXME: Except for extra inhabitants?
         return emitFromValueWitnessTable(C.TheRawPointerType);

--- a/lib/IRGen/ProtocolInfo.h
+++ b/lib/IRGen/ProtocolInfo.h
@@ -13,8 +13,6 @@
 // This file defines types for representing the abstract layout of a
 // protocol.
 //
-// SWIFT_ENABLE_TENSORFLOW (this whole file has been significantly modified)
-//
 //===----------------------------------------------------------------------===//
 
 #ifndef SWIFT_IRGEN_PROTOCOLINFO_H

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -617,14 +617,6 @@ bool SILFunction::shouldVerifyOwnership() const {
   return !hasSemanticsAttr("verify.ownership.sil.never");
 }
 
-// SWIFT_ENABLE_TENSORFLOW
-unsigned SILFunction::codeSize() const {
-  unsigned size = 0;
-  for (auto &BB : *this)
-    size += BB.codeSize();
-  return size;
-}
-
 static Identifier getIdentifierForObjCSelector(ObjCSelector selector, ASTContext &Ctxt) {
   SmallVector<char, 64> buffer;
   auto str = selector.getString(buffer);

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -15,9 +15,6 @@
 #include "Linker.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/GenericEnvironment.h"
-// SWIFT_ENABLE_TENSORFLOW
-#include "swift/AST/ASTMangler.h"
-// SWIFT_ENABLE_TENSORFLOW_END
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/SIL/FormalLinkage.h"

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -128,33 +128,6 @@ const SILNode *SILNode::getRepresentativeSILNodeSlowPath() const {
   llvm_unreachable("Invalid value for slow path");
 }
 
-// SWIFT_ENABLE_TENSORFLOW.
-// FIXME: Send upstream.  It would be nice for SILArguments to actually get a
-// loc...
-
-/// Infer an instruction whose value is ultimately passed into the specified
-/// SILArgument, allowing us to get sometimes correct location information.
-static SILInstruction *tryToGetArgumentInst(SILArgument *arg,
-                                        SmallPtrSet<SILArgument*, 4> &visited) {
-  // If we've already visited this argument, don't use it, we don't want to
-  // infinitely recurse through loops.
-  if (!visited.insert(arg).second)
-    return nullptr;
-
-  SmallVector<SILValue, 4> inputs;
-  arg->getIncomingPhiValues(inputs);
-  for (auto input : inputs) {
-    if (auto *arg = dyn_cast<SILArgument>(input)) {
-      if (auto inst = tryToGetArgumentInst(arg, visited))
-        return inst;
-    } else if (auto *inst = dyn_cast<SILInstruction>((SILNode*)input)) {
-      return inst;
-    }
-  }
-
-  return nullptr;
-}
-
 /// Get a location for this value.
 SILLocation SILValue::getLoc() const {
   if (auto *instr = Value->getDefiningInstruction())
@@ -163,38 +136,9 @@ SILLocation SILValue::getLoc() const {
   if (auto *arg = dyn_cast<SILArgument>(*this)) {
     if (arg->getDecl())
       return RegularLocation(const_cast<ValueDecl *>(arg->getDecl()));
-
-    // Take one of the incoming operand locations if we have any.
-    SmallPtrSet<SILArgument*, 4> visitedSet;
-    auto inst = tryToGetArgumentInst(arg, visitedSet);
-    if (inst) return inst->getLoc();
   }
-
-  // If this is something that lives in a function, fall back to the function
-  // loc.  Otherwise, e.g. a SILUndef, return a null location.
-  auto fn = Value->getFunction();
-  return fn ? fn->getLocation() : SILLocation((Expr*)nullptr);
-}
-
-/// Get a debug location for this value.
-SILDebugLocation SILValue::getDebugLocation() const {
-  if (auto *instr = Value->getDefiningInstruction())
-    return instr->getDebugLocation();
-
-  if (auto *arg = dyn_cast<SILArgument>(*this)) {
-    if (arg->getDecl()) {
-      auto loc = RegularLocation(const_cast<ValueDecl *>(arg->getDecl()));
-      return SILDebugLocation(loc, nullptr);
-    }
-
-    // Take one of the incoming operand locations if we have any.
-    SmallPtrSet<SILArgument*, 4> visitedSet;
-    auto inst = tryToGetArgumentInst(arg, visitedSet);
-    if (inst) return inst->getDebugLocation();
-  }
-  auto fn = Value->getFunction();
-  auto loc = fn ? fn->getLocation() : SILLocation((Expr*)nullptr);
-  return SILDebugLocation(loc, nullptr);
+  // TODO: bbargs should probably use one of their operand locations.
+  return Value->getFunction()->getLocation();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -230,11 +230,7 @@ namespace {
       switch (type->getRepresentation()) {
       case AnyFunctionType::Representation::Swift:
       case AnyFunctionType::Representation::Block:
-        // SWIFT_ENABLE_TENSORFLOW
-        // TODO: Are there cases where we have to lower this differently when it
-        // is @differentiable?
         return asImpl().handleReference(type);
-
       case AnyFunctionType::Representation::CFunctionPointer:
       case AnyFunctionType::Representation::Thin:
         return asImpl().handleTrivial(type);

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
@@ -362,4 +362,3 @@ void ExistentialSpecializer::specializeExistentialArgsInAppliesWithinFunction(
 SILTransform *swift::createExistentialSpecializer() {
   return new ExistentialSpecializer();
 }
-

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.h
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.h
@@ -103,4 +103,3 @@ public:
 } // end namespace swift
 
 #endif
-

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5440,7 +5440,6 @@ public:
     };
 
     // Bounds check.  FIXME: overflow
-    // SWIFT_ENABLE_TENSORFLOW
     unsigned entriesPerParam =
         diffKind != DifferentiabilityKind::NonDifferentiable ? 3 : 2;
     if (entriesPerParam * numParams + 2 * numResults +

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1606,7 +1606,6 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
         OnStack);
     break;
   }
-
   case SILInstructionKind::DeallocPartialRefInst: {
     auto Ty = MF->getType(TyID);
     auto Ty2 = MF->getType(TyID2);
@@ -2766,15 +2765,15 @@ bool SILDeserializer::hasSILFunction(StringRef Name,
   GenericSignatureID genericSigID;
   unsigned rawLinkage, isTransparent, isSerialized, isThunk,
       isWithoutactuallyEscapingThunk, isGlobal, inlineStrategy,
-      optimizationMode, effect, numSpecAttrs,
-      hasQualifiedOwnership, isWeakImported, LIST_VER_TUPLE_PIECES(available),
+      optimizationMode, effect, numSpecAttrs, hasQualifiedOwnership,
+      isWeakImported, LIST_VER_TUPLE_PIECES(available),
       isDynamic, isExactSelfClass;
   ArrayRef<uint64_t> SemanticsIDs;
   SILFunctionLayout::readRecord(
       scratch, rawLinkage, isTransparent, isSerialized, isThunk,
       isWithoutactuallyEscapingThunk, isGlobal, inlineStrategy,
-      optimizationMode, effect, numSpecAttrs,
-      hasQualifiedOwnership, isWeakImported, LIST_VER_TUPLE_PIECES(available),
+      optimizationMode, effect, numSpecAttrs, hasQualifiedOwnership,
+      isWeakImported, LIST_VER_TUPLE_PIECES(available),
       isDynamic, isExactSelfClass,
       funcTyID, replacedFunctionID, genericSigID,
       clangOwnerID, SemanticsIDs);

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -264,6 +264,7 @@ enum class SILFunctionTypeRepresentation : uint8_t {
   Block,
   Thin,
   CFunctionPointer,
+  
   FirstSIL = 8,
   Method = FirstSIL,
   ObjCMethod,
@@ -933,6 +934,7 @@ namespace decls_block {
     BCFixed<1>,  // noescape?
     BCFixed<1>,   // throws?
     DifferentiabilityKindField // differentiability kind
+
     // trailed by parameters
   >;
 
@@ -1861,6 +1863,7 @@ namespace decls_block {
     BCFixed<1>,  // implicit flag
     TypeIDField // type referenced by this custom attribute
   >;
+
 }
 
 /// Returns the encoding kind for the given decl.

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -293,8 +293,6 @@ namespace sil_block {
                      DeclIDField, // ClangNode owner
                      BCArray<IdentifierIDField> // Semantics Attribute
                      // followed by specialize attributes
-                     // SWIFT_ENABLE_TENSORFLOW
-                     // followed by reverse differentiable attributes
                      // followed by generic param list, if any
                      >;
 
@@ -377,39 +375,6 @@ namespace sil_block {
     ValueIDField,         // callee value
     BCArray<ValueIDField> // a list of arguments
   >;
-
-  // SWIFT_ENABLE_TENSORFLOW
-  using SILInstDifferentiableFunctionLayout = BCRecordLayout<
-    SIL_INST_DIFFERENTIABLE_FUNCTION,
-    BCVBR<8>,             // number of function parameters
-    BCFixed<1>,           // has derivative functions?
-    BCArray<ValueIDField> // parameter indices and operands
-  >;
-
-  using SILInstLinearFunctionLayout = BCRecordLayout<
-    SIL_INST_LINEAR_FUNCTION,
-    BCVBR<8>,             // number of function parameters
-    BCFixed<1>,           // has transpose function?
-    BCArray<ValueIDField> // parameter indices and operands
-  >;
-
-  using SILInstDifferentiableFunctionExtractLayout = BCRecordLayout<
-    SIL_INST_DIFFERENTIABLE_FUNCTION_EXTRACT,
-    TypeIDField,
-    SILTypeCategoryField,
-    ValueIDField,
-    BCFixed<2>, // extractee
-    BCFixed<1>  // has explicit extractee type?
-  >;
-
-  using SILInstLinearFunctionExtractLayout = BCRecordLayout<
-    SIL_INST_LINEAR_FUNCTION_EXTRACT,
-    TypeIDField,
-    SILTypeCategoryField,
-    ValueIDField,
-    BCFixed<1> // extractee
-  >;
-  // SWIFT_ENABLE_TENSORFLOW END
 
   // SIL instructions with one type. (alloc_stack)
   using SILOneTypeLayout = BCRecordLayout<

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -436,8 +436,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
       (unsigned)F.isThunk(), (unsigned)F.isWithoutActuallyEscapingThunk(),
       (unsigned)F.getSpecialPurpose(), (unsigned)F.getInlineStrategy(),
       (unsigned)F.getOptimizationMode(), (unsigned)F.getEffectsKind(),
-      (unsigned)numSpecAttrs,
-      (unsigned)F.hasOwnership(),
+      (unsigned)numSpecAttrs, (unsigned)F.hasOwnership(),
       F.isAlwaysWeakImported(), LIST_VER_TUPLE_PIECES(available),
       (unsigned)F.isDynamicallyReplaceable(),
       (unsigned)F.isExactSelfClass(),
@@ -2323,7 +2322,7 @@ void SILSerializer::writeIndexTables() {
     Offset.emit(ScratchRecord, sil_index_block::SIL_PROPERTY_OFFSETS,
                 PropertyOffset);
   }
-
+  
 }
 
 void SILSerializer::writeSILGlobalVar(const SILGlobalVariable &g) {

--- a/lib/Serialization/SerializedSILLoader.cpp
+++ b/lib/Serialization/SerializedSILLoader.cpp
@@ -202,10 +202,8 @@ void SerializedSILLoader::getAllProperties() {
     Des->getAllProperties();
 }
 
-// SWIFT_ENABLE_TENSORFLOW
 /// Deserialize all DifferentiabilityWitnesses in all SILModules.
 void SerializedSILLoader::getAllDifferentiabilityWitnesses() {
   for (auto &Des : LoadedSILSections)
     Des->getAllDifferentiabilityWitnesses();
 }
-// SWIFT_ENABLE_TENSORFLOW END

--- a/test/IRGen/sil_linkage.sil
+++ b/test/IRGen/sil_linkage.sil
@@ -5,7 +5,7 @@ sil_stage canonical
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @public_fragile_function_test() {{.*}} {
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @public_transparent_fragile_function_test() {{.*}} {
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @public_transparent_function_test() {{.*}} {
-// CHECK: define hidden swiftcc void @public_non_abi_function_test() {{.*}} {
+// CHECK: define weak_odr hidden swiftcc void @public_non_abi_function_test() {{.*}} {
 // CHECK: define hidden swiftcc void @hidden_fragile_function_test() {{.*}} {
 // CHECK: define linkonce_odr hidden swiftcc void @shared_fragile_function_test() {{.*}} {
 // CHECK: define{{( internal)?}} swiftcc void @private_fragile_function_test() {{.*}} {

--- a/test/IRGen/sil_linkage.sil
+++ b/test/IRGen/sil_linkage.sil
@@ -5,7 +5,8 @@ sil_stage canonical
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @public_fragile_function_test() {{.*}} {
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @public_transparent_fragile_function_test() {{.*}} {
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @public_transparent_function_test() {{.*}} {
-// CHECK: define weak_odr hidden swiftcc void @public_non_abi_function_test() {{.*}} {
+// SWIFT_ENABLE_TENSORFLOW: Fix for TF-587.
+// CHECK: define hidden swiftcc void @public_non_abi_function_test() {{.*}} {
 // CHECK: define hidden swiftcc void @hidden_fragile_function_test() {{.*}} {
 // CHECK: define linkonce_odr hidden swiftcc void @shared_fragile_function_test() {{.*}} {
 // CHECK: define{{( internal)?}} swiftcc void @private_fragile_function_test() {{.*}} {


### PR DESCRIPTION
This removes a bunch of small diffs between `tensorflow` and `master` that appear to be unintentional. (Artifacts left over from merges, small code formatting differences, and helper functions left over from deabstraction.)
