### PR TITLE
[Diagnostics] A couple of adjustments to `FailureDiagnostic`

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1277,8 +1277,10 @@ bool RValueTreatedAsLValueFailure::diagnoseAsError() {
             ConstructorDecl::BodyInitKind::Delegating) {
           emitDiagnostic(loc, diag::assignment_let_property_delegating_init,
                       member->getName());
-          if (auto *ref = getResolvedMemberRef(member)) {
-            emitDiagnostic(ref, diag::decl_declared_here, ref->getFullName());
+          if (auto overload = getOverloadChoiceIfAvailable(
+                  getConstraintLocator(member, ConstraintLocator::Member))) {
+            if (auto *ref = overload->choice.getDeclOrNull())
+              emitDiagnostic(ref, diag::decl_declared_here, ref->getFullName());
           }
           return true;
         }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -153,13 +153,6 @@ protected:
     return None;
   }
 
-  ValueDecl *getResolvedMemberRef(UnresolvedDotExpr *member) const {
-    auto *locator = getConstraintLocator(member, ConstraintLocator::Member);
-    if (auto overload = getOverloadChoiceIfAvailable(locator))
-      return overload->choice.getDeclOrNull();
-    return nullptr;
-  }
-
   /// Retrieve overload choice resolved for a given locator
   /// by the constraint solver.
   Optional<SelectedOverload>

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -140,19 +140,6 @@ protected:
     return cs.getASTContext();
   }
 
-  Optional<std::pair<Type, ConversionRestrictionKind>>
-  getRestrictionForType(Type type) const {
-    for (auto &e : S.ConstraintRestrictions) {
-      auto &location = e.first;
-      auto &restriction = e.second;
-
-      if (std::get<0>(location)->isEqual(type))
-        return std::pair<Type, ConversionRestrictionKind>(std::get<1>(location),
-                                                          restriction);
-    }
-    return None;
-  }
-
   /// Retrieve overload choice resolved for a given locator
   /// by the constraint solver.
   Optional<SelectedOverload>

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -45,15 +45,11 @@ class FailureDiagnostic {
   Expr *RawAnchor;
   /// Simplified anchor associated with the given locator.
   Expr *Anchor;
-  /// Indicates whether locator could be simplified
-  /// down to anchor expression.
-  bool HasComplexLocator;
 
 public:
   FailureDiagnostic(const Solution &solution, ConstraintLocator *locator)
-      : S(solution), Locator(locator), RawAnchor(locator->getAnchor()) {
-    std::tie(Anchor, HasComplexLocator) = computeAnchor();
-  }
+      : S(solution), Locator(locator), RawAnchor(locator->getAnchor()),
+        Anchor(computeAnchor()) {}
 
   FailureDiagnostic(const Solution &solution, Expr *anchor)
       : FailureDiagnostic(solution, solution.getConstraintLocator(anchor)) {}
@@ -189,9 +185,6 @@ protected:
     return S.getFunctionArgApplyInfo(locator);
   }
 
-  /// \returns true is locator hasn't been simplified down to expression.
-  bool hasComplexLocator() const { return HasComplexLocator; }
-
   /// \returns A parent expression if sub-expression is contained anywhere
   /// in the root expression or `nullptr` otherwise.
   Expr *findParentExpr(Expr *subExpr) const;
@@ -219,7 +212,7 @@ protected:
 
 private:
   /// Compute anchor expression associated with current diagnostic.
-  std::pair<Expr *, bool> computeAnchor() const;
+  Expr *computeAnchor() const;
 };
 
 /// Base class for all of the diagnostics related to generic requirement

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -160,6 +160,13 @@ protected:
     return S.getOverloadChoiceIfAvailable(locator);
   }
 
+  /// Retrieve overload choice resolved for a callee for the anchor
+  /// of a given locator.
+  Optional<SelectedOverload>
+  getCalleeOverloadChoiceIfAvailable(ConstraintLocator *locator) const {
+    return getOverloadChoiceIfAvailable(S.getCalleeLocator(locator));
+  }
+
   ConstraintLocator *
   getConstraintLocator(Expr *anchor,
                        ConstraintLocator::PathElement element) const {
@@ -191,10 +198,6 @@ protected:
   /// application. If the locator is not for an argument application, or
   /// the argument list cannot be found, returns \c nullptr.
   Expr *getArgumentListExprFor(ConstraintLocator *locator) const;
-
-  /// \returns The overload choice made by the constraint system for the callee
-  /// of a given locator's anchor, or \c None if no such choice can be found.
-  Optional<SelectedOverload> getChoiceFor(ConstraintLocator *) const;
 
   /// \returns A new type with all of the type variables associated with
   /// generic parameters substituted back into being generic parameter type.


### PR DESCRIPTION
- Remove `HasComplexLocator` which is no longer useful
- Rename `getChoiceFor` to `getCalleeOverloadChoiceIfAvailable` to make it consistent
- Remove unsafe `getRestrictionFor` method
- Remove obsolete `getResolvedMemberRef`

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
