### PR TITLE
[AutoDiff upstream] add more differentiation tests

### DIFF
--- a/test/AutoDiff/SILOptimizer/differentiation_control_flow_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_control_flow_diagnostics.swift
@@ -1,0 +1,174 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+import _Differentiation
+
+// Test supported `br`, `cond_br`, and `switch_enum` terminators.
+
+@differentiable
+func branch(_ x: Float) -> Float {
+  if x > 0 {
+    return x
+  } else if x < 10 {
+    return x
+  }
+  return x
+}
+
+enum Enum {
+  case a(Float)
+  case b(Float)
+}
+
+@differentiable
+func enum_nonactive1(_ e: Enum, _ x: Float) -> Float {
+  switch e {
+    case .a: return x
+    case .b: return x
+  }
+}
+
+@differentiable
+func enum_nonactive2(_ e: Enum, _ x: Float) -> Float {
+  switch e {
+    case let .a(a): return x + a
+    case let .b(b): return x + b
+  }
+}
+
+// Test loops.
+
+@differentiable
+func for_loop(_ x: Float) -> Float {
+  var result: Float = x
+  for _ in 0..<3 {
+    result = result * x
+  }
+  return result
+}
+
+@differentiable
+func while_loop(_ x: Float) -> Float {
+  var result = x
+  var i = 1
+  while i < 3 {
+    result = result * x
+    i += 1
+  }
+  return result
+}
+
+@differentiable
+func nested_loop(_ x: Float) -> Float {
+  var outer = x
+  for _ in 1..<3 {
+    outer = outer * x
+
+    var inner = outer
+    var i = 1
+    while i < 3 {
+      inner = inner / x
+      i += 1
+    }
+    outer = inner
+  }
+  return outer
+}
+
+// TF-433: Test throwing functions.
+
+func rethrowing(_ x: () throws -> Void) rethrows -> Void {}
+
+// expected-error @+1 {{function is not differentiable}}
+@differentiable
+// expected-note @+1 {{when differentiating this function definition}}
+func testTryApply(_ x: Float) -> Float {
+  // expected-note @+1 {{cannot differentiate unsupported control flow}}
+  rethrowing({})
+  return x
+}
+
+// expected-error @+1 {{function is not differentiable}}
+@differentiable
+// expected-note @+1 {{when differentiating this function definition}}
+func withoutDerivative<T : Differentiable, R: Differentiable>(
+  at x: T, in body: (T) throws -> R
+) rethrows -> R {
+  // expected-note @+1 {{cannot differentiate unsupported control flow}}
+  try body(x)
+}
+
+// Test unsupported differentiation of active enum values.
+
+// expected-error @+1 {{function is not differentiable}}
+@differentiable
+// expected-note @+1 {{when differentiating this function definition}}
+func enum_active(_ x: Float) -> Float {
+  // expected-note @+1 {{differentiating enum values is not yet supported}}
+  let e: Enum
+  if x > 0 {
+    e = .a(x)
+  } else {
+    e = .b(x)
+  }
+  switch e {
+    case let .a(a): return x + a
+    case let .b(b): return x + b
+  }
+}
+
+enum Tree : Differentiable & AdditiveArithmetic {
+  case leaf(Float)
+  case branch(Float, Float)
+
+  typealias TangentVector = Self
+  typealias AllDifferentiableVariables = Self
+  static var zero: Self { .leaf(0) }
+
+  // expected-error @+1 {{function is not differentiable}}
+  @differentiable
+  // TODO(TF-956): Improve location of active enum non-differentiability errors
+  // so that they are closer to the source of the non-differentiability.
+  // expected-note @+2 {{when differentiating this function definition}}
+  // expected-note @+1 {{differentiating enum values is not yet supported}}
+  static func +(_ lhs: Self, _ rhs: Self) -> Self {
+    switch (lhs, rhs) {
+    case let (.leaf(x), .leaf(y)):
+      return .leaf(x + y)
+    case let (.branch(x1, x2), .branch(y1, y2)):
+      return .branch(x1 + x2, y1 + y2)
+    default:
+      fatalError()
+    }
+  }
+
+  // expected-error @+1 {{function is not differentiable}}
+  @differentiable
+  // TODO(TF-956): Improve location of active enum non-differentiability errors
+  // so that they are closer to the source of the non-differentiability.
+  // expected-note @+2 {{when differentiating this function definition}}
+  // expected-note @+1 {{differentiating enum values is not yet supported}}
+  static func -(_ lhs: Self, _ rhs: Self) -> Self {
+    switch (lhs, rhs) {
+    case let (.leaf(x), .leaf(y)):
+      return .leaf(x - y)
+    case let (.branch(x1, x2), .branch(y1, y2)):
+      return .branch(x1 - x2, y1 - y2)
+    default:
+      fatalError()
+    }
+  }
+}
+
+// expected-error @+1 {{function is not differentiable}}
+@differentiable
+// expected-note @+1 {{when differentiating this function definition}}
+func loop_array(_ array: [Float]) -> Float {
+  var result: Float = 1
+  // TODO(TF-957): Improve non-differentiability errors for for-in loops
+  // (`Collection.makeIterator` and `IteratorProtocol.next`).
+  // expected-note @+1 {{cannot differentiate through a non-differentiable result; do you want to use 'withoutDerivative(at:)'?}}
+  for x in array {
+    result = result * x
+  }
+  return result
+}

--- a/test/AutoDiff/SILOptimizer/differentiation_control_flow_sil.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_control_flow_sil.swift
@@ -1,0 +1,278 @@
+// RUN: %target-swift-frontend -emit-sil -verify -Xllvm -debug-only=differentiation 2>&1 %s | %FileCheck %s -check-prefix=CHECK-DATA-STRUCTURES
+// RUN: %target-swift-frontend -emit-sil -verify -Xllvm -sil-print-after=differentiation -o /dev/null 2>&1 %s | %FileCheck %s -check-prefix=CHECK-SIL
+// REQUIRES: asserts
+
+// TODO: Add FileCheck tests.
+
+import _Differentiation
+
+//===----------------------------------------------------------------------===//
+// Conditionals
+//===----------------------------------------------------------------------===//
+
+@differentiable
+@_silgen_name("cond")
+func cond(_ x: Float) -> Float {
+  if x > 0 {
+    return x + x
+  }
+  return x - x
+}
+
+// CHECK-DATA-STRUCTURES: struct _AD__cond_bb0__PB__src_0_wrt_0 {
+// CHECK-DATA-STRUCTURES: }
+// CHECK-DATA-STRUCTURES: struct _AD__cond_bb1__PB__src_0_wrt_0 {
+// CHECK-DATA-STRUCTURES:   var predecessor: _AD__cond_bb1__Pred__src_0_wrt_0
+// CHECK-DATA-STRUCTURES:   var pullback_0: (Float) -> (Float, Float)
+// CHECK-DATA-STRUCTURES: }
+// CHECK-DATA-STRUCTURES: struct _AD__cond_bb2__PB__src_0_wrt_0 {
+// CHECK-DATA-STRUCTURES:   var predecessor: _AD__cond_bb2__Pred__src_0_wrt_0
+// CHECK-DATA-STRUCTURES:   var pullback_1: (Float) -> (Float, Float)
+// CHECK-DATA-STRUCTURES: }
+// CHECK-DATA-STRUCTURES: struct _AD__cond_bb3__PB__src_0_wrt_0 {
+// CHECK-DATA-STRUCTURES:   var predecessor: _AD__cond_bb3__Pred__src_0_wrt_0
+// CHECK-DATA-STRUCTURES: }
+// CHECK-DATA-STRUCTURES: enum _AD__cond_bb0__Pred__src_0_wrt_0 {
+// CHECK-DATA-STRUCTURES: }
+// CHECK-DATA-STRUCTURES: enum _AD__cond_bb1__Pred__src_0_wrt_0 {
+// CHECK-DATA-STRUCTURES:   case bb0(_AD__cond_bb0__PB__src_0_wrt_0)
+// CHECK-DATA-STRUCTURES: }
+// CHECK-DATA-STRUCTURES: enum _AD__cond_bb2__Pred__src_0_wrt_0 {
+// CHECK-DATA-STRUCTURES:   case bb0(_AD__cond_bb0__PB__src_0_wrt_0)
+// CHECK-DATA-STRUCTURES: }
+// CHECK-DATA-STRUCTURES: enum _AD__cond_bb3__Pred__src_0_wrt_0 {
+// CHECK-DATA-STRUCTURES:   case bb2(_AD__cond_bb2__PB__src_0_wrt_0)
+// CHECK-DATA-STRUCTURES:   case bb1(_AD__cond_bb1__PB__src_0_wrt_0)
+// CHECK-DATA-STRUCTURES: }
+
+// CHECK-SIL-LABEL: sil hidden [ossa] @AD__cond__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+// CHECK-SIL: bb0([[INPUT_ARG:%.*]] : $Float):
+// CHECK-SIL:   [[BB0_PB_STRUCT:%.*]] = struct $_AD__cond_bb0__PB__src_0_wrt_0 ()
+// CHECK-SIL:   cond_br {{%.*}}, bb1, bb2
+
+// CHECK-SIL: bb1:
+// CHECK-SIL:   [[BB1_PRED:%.*]] = enum $_AD__cond_bb1__Pred__src_0_wrt_0, #_AD__cond_bb1__Pred__src_0_wrt_0.bb0!enumelt, [[BB0_PB_STRUCT]]
+// CHECK-SIL:   [[BB1_PB_STRUCT:%.*]] = struct $_AD__cond_bb1__PB__src_0_wrt_0
+// CHECK-SIL:   [[BB3_PRED_PRED1:%.*]] = enum $_AD__cond_bb3__Pred__src_0_wrt_0, #_AD__cond_bb3__Pred__src_0_wrt_0.bb1!enumelt, [[BB1_PB_STRUCT]]
+// CHECK-SIL:   br bb3({{.*}} : $Float, [[BB3_PRED_PRED1]] : $_AD__cond_bb3__Pred__src_0_wrt_0)
+
+// CHECK-SIL: bb2:
+// CHECK-SIL:   [[BB2_PRED:%.*]] = enum $_AD__cond_bb2__Pred__src_0_wrt_0, #_AD__cond_bb2__Pred__src_0_wrt_0.bb0!enumelt, [[BB0_PB_STRUCT]]
+// CHECK-SIL:   [[BB2_PB_STRUCT:%.*]] = struct $_AD__cond_bb2__PB__src_0_wrt_0
+// CHECK-SIL:   [[BB3_PRED_PRED2:%.*]] = enum $_AD__cond_bb3__Pred__src_0_wrt_0, #_AD__cond_bb3__Pred__src_0_wrt_0.bb2!enumelt, [[BB2_PB_STRUCT]]
+// CHECK-SIL:   br bb3({{.*}} : $Float, [[BB3_PRED_PRED2]] : $_AD__cond_bb3__Pred__src_0_wrt_0)
+
+// CHECK-SIL: bb3([[ORIG_RES:%.*]] : $Float, [[BB3_PRED_ARG:%.*]] : @owned $_AD__cond_bb3__Pred__src_0_wrt_0)
+// CHECK-SIL:   [[BB3_PB_STRUCT:%.*]] = struct $_AD__cond_bb3__PB__src_0_wrt_0
+// CHECK-SIL:   [[PULLBACK_REF:%.*]] = function_ref @AD__cond__pullback_src_0_wrt_0
+// CHECK-SIL:   [[PB:%.*]] = partial_apply [callee_guaranteed] [[PULLBACK_REF]]([[BB3_PB_STRUCT]])
+// CHECK-SIL:   [[VJP_RESULT:%.*]] = tuple ([[ORIG_RES]] : $Float, [[PB]] : $@callee_guaranteed (Float) -> Float)
+// CHECK-SIL:   return [[VJP_RESULT]]
+
+
+// CHECK-SIL-LABEL: sil private [ossa] @AD__cond__pullback_src_0_wrt_0 : $@convention(thin) (Float, @owned _AD__cond_bb3__PB__src_0_wrt_0) -> Float {
+// CHECK-SIL: bb0([[SEED:%.*]] : $Float, [[BB3_PB_STRUCT:%.*]] : @owned $_AD__cond_bb3__PB__src_0_wrt_0):
+// CHECK-SIL:   [[BB3_PRED:%.*]] = destructure_struct [[BB3_PB_STRUCT]] : $_AD__cond_bb3__PB__src_0_wrt_0
+// CHECK-SIL:   switch_enum [[BB3_PRED]] : $_AD__cond_bb3__Pred__src_0_wrt_0, case #_AD__cond_bb3__Pred__src_0_wrt_0.bb2!enumelt: bb3, case #_AD__cond_bb3__Pred__src_0_wrt_0.bb1!enumelt: bb1
+
+// CHECK-SIL: bb1([[BB3_PRED1_TRAMP_PB_STRUCT:%.*]] : @owned $_AD__cond_bb1__PB__src_0_wrt_0):
+// CHECK-SIL:   br bb2({{%.*}} : $Float, {{%.*}}: $Float, [[BB3_PRED1_TRAMP_PB_STRUCT]] : $_AD__cond_bb1__PB__src_0_wrt_0)
+
+// CHECK-SIL: bb2({{%.*}} : $Float, {{%.*}} : $Float, [[BB1_PB_STRUCT:%.*]] : @owned $_AD__cond_bb1__PB__src_0_wrt_0):
+// CHECK-SIL:   ([[BB1_PRED:%.*]], [[BB1_PB:%.*]]) = destructure_struct [[BB1_PB_STRUCT]]
+// CHECK-SIL:   [[BB1_ADJVALS:%.*]] = apply [[BB1_PB]]([[SEED]]) : $@callee_guaranteed (Float) -> (Float, Float)
+// CHECK-SIL:   switch_enum [[BB1_PRED]] : $_AD__cond_bb1__Pred__src_0_wrt_0, case #_AD__cond_bb1__Pred__src_0_wrt_0.bb0!enumelt: bb5
+
+// CHECK-SIL: bb3([[BB3_PRED2_TRAMP_PB_STRUCT:%.*]] : @owned $_AD__cond_bb2__PB__src_0_wrt_0):
+// CHECK-SIL:   br bb4({{%.*}} : $Float, {{%.*}}: $Float, [[BB3_PRED2_TRAMP_PB_STRUCT]] : $_AD__cond_bb2__PB__src_0_wrt_0)
+
+// CHECK-SIL: bb4({{%.*}} : $Float, {{%.*}} : $Float, [[BB2_PB_STRUCT:%.*]] : @owned $_AD__cond_bb2__PB__src_0_wrt_0):
+// CHECK-SIL:   ([[BB2_PRED:%.*]], [[BB2_PB:%.*]]) = destructure_struct [[BB2_PB_STRUCT]]
+// CHECK-SIL:   [[BB2_ADJVALS:%.*]] = apply [[BB2_PB]]([[SEED]]) : $@callee_guaranteed (Float) -> (Float, Float)
+// CHECK-SIL:   switch_enum [[BB2_PRED]] : $_AD__cond_bb2__Pred__src_0_wrt_0, case #_AD__cond_bb2__Pred__src_0_wrt_0.bb0!enumelt: bb6
+
+// CHECK-SIL: bb5([[BB1_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0):
+// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB1_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_bb0__PB__src_0_wrt_0)
+
+// CHECK-SIL: bb6([[BB2_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0):
+// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB2_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_bb0__PB__src_0_wrt_0)
+
+// CHECK-SIL: bb7({{%.*}} : $Float, [[BB0_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0):
+// CHECK-SIL:   return {{%.*}} : $Float
+
+@differentiable
+@_silgen_name("nested_cond")
+func nested_cond(_ x: Float, _ y: Float) -> Float {
+  if x > 0 {
+    if y > 10 {
+      return x * y
+    } else {
+      return x + y
+    }
+  }
+  return y - x
+}
+
+@differentiable
+@_silgen_name("nested_cond_generic")
+func nested_cond_generic<T : Differentiable & FloatingPoint>(_ x: T, _ y: T) -> T {
+  if x > 0 {
+    if y > 10 {
+      return y
+    } else {
+      return x
+    }
+  }
+  return y
+}
+
+@differentiable
+@_silgen_name("loop_generic")
+func loop_generic<T : Differentiable & FloatingPoint>(_ x: T) -> T {
+  var result = x
+  for _ in 1..<3 {
+    var y = x
+    for _ in 1..<3 {
+      result = y
+      y = result
+    }
+  }
+  return result
+}
+
+// Test `switch_enum`.
+
+enum Enum {
+  case a(Float)
+  case b(Float, Float)
+}
+@differentiable
+@_silgen_name("enum_notactive")
+func enum_notactive(_ e: Enum, _ x: Float) -> Float {
+  switch e {
+  case let .a(a): return x * a
+  case let .b(b1, b2): return x * b1 * b2
+  }
+}
+
+// CHECK-SIL-LABEL: sil hidden [ossa] @AD__enum_notactive__vjp_src_0_wrt_1 : $@convention(thin) (Enum, Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+// CHECK-SIL: bb0([[ENUM_ARG:%.*]] : $Enum, [[X_ARG:%.*]] : $Float):
+// CHECK-SIL:   [[BB0_PB_STRUCT:%.*]] = struct $_AD__enum_notactive_bb0__PB__src_0_wrt_1 ()
+// CHECK-SIL:   switch_enum [[ENUM_ARG]] : $Enum, case #Enum.a!enumelt: bb1, case #Enum.b!enumelt: bb2
+
+// CHECK-SIL: bb1([[ENUM_A:%.*]] : $Float):
+// CHECK-SIL:   [[BB1_PRED_PRED0:%.*]] = enum $_AD__enum_notactive_bb1__Pred__src_0_wrt_1, #_AD__enum_notactive_bb1__Pred__src_0_wrt_1.bb0!enumelt, [[BB0_PB_STRUCT]] : $_AD__enum_notactive_bb0__PB__src_0_wrt_1
+// CHECK-SIL:   [[BB1_PB_STRUCT:%.*]] = struct $_AD__enum_notactive_bb1__PB__src_0_wrt_1 ({{.*}})
+// CHECK-SIL:   [[BB3_PRED_PRED1:%.*]] = enum $_AD__enum_notactive_bb3__Pred__src_0_wrt_1, #_AD__enum_notactive_bb3__Pred__src_0_wrt_1.bb1!enumelt, [[BB1_PB_STRUCT]] : $_AD__enum_notactive_bb1__PB__src_0_wrt_1
+// CHECK-SIL:   br bb3({{.*}} : $Float, [[BB3_PRED_PRED1]] : $_AD__enum_notactive_bb3__Pred__src_0_wrt_1)
+
+// CHECK-SIL: bb2([[ENUM_B:%.*]] : $(Float, Float)):
+// CHECK-SIL:   [[BB2_PRED_PRED0:%.*]] = enum $_AD__enum_notactive_bb2__Pred__src_0_wrt_1, #_AD__enum_notactive_bb2__Pred__src_0_wrt_1.bb0!enumelt, [[BB0_PB_STRUCT]] : $_AD__enum_notactive_bb0__PB__src_0_wrt_1
+// CHECK-SIL:   [[BB2_PB_STRUCT:%.*]] = struct $_AD__enum_notactive_bb2__PB__src_0_wrt_1 ({{.*}})
+// CHECK-SIL:   [[BB3_PRED_PRED2:%.*]] = enum $_AD__enum_notactive_bb3__Pred__src_0_wrt_1, #_AD__enum_notactive_bb3__Pred__src_0_wrt_1.bb2!enumelt, [[BB2_PB_STRUCT]] : $_AD__enum_notactive_bb2__PB__src_0_wrt_1
+// CHECK-SIL:   br bb3({{.*}} : $Float, [[BB3_PRED_PRED2]] : $_AD__enum_notactive_bb3__Pred__src_0_wrt_1)
+
+// CHECK-SIL: bb3([[ORIG_RES:%.*]] : $Float, [[BB3_PRED_ARG:%.*]] : @owned $_AD__enum_notactive_bb3__Pred__src_0_wrt_1)
+// CHECK-SIL:   [[BB3_PB_STRUCT:%.*]] = struct $_AD__enum_notactive_bb3__PB__src_0_wrt_1
+// CHECK-SIL:   [[PULLBACK_REF:%.*]] = function_ref @AD__enum_notactive__pullback_src_0_wrt_1
+// CHECK-SIL:   [[PB:%.*]] = partial_apply [callee_guaranteed] [[PULLBACK_REF]]([[BB3_PB_STRUCT]])
+// CHECK-SIL:   [[VJP_RESULT:%.*]] = tuple ([[ORIG_RES]] : $Float, [[PB]] : $@callee_guaranteed (Float) -> Float)
+// CHECK-SIL:   return [[VJP_RESULT]]
+// CHECK-SIL: }
+
+// Test `switch_enum_addr`.
+
+// Clone of `enum Optional<Wrapped>`.
+enum AddressOnlyEnum<T> {
+  case some(T)
+  case none
+}
+@differentiable
+@_silgen_name("enum_addr_notactive")
+func enum_addr_notactive<T>(_ e: AddressOnlyEnum<T>, _ x: Float) -> Float {
+  switch e {
+  case .none: break
+  case .some: break
+  }
+  return x
+}
+
+// CHECK-SIL-LABEL: sil hidden [ossa] @AD__enum_addr_notactive__vjp_src_0_wrt_1_l : $@convention(thin) <τ_0_0> (@in_guaranteed AddressOnlyEnum<τ_0_0>, Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+// CHECK-SIL: bb0([[ENUM_ARG:%.*]] : $*AddressOnlyEnum<τ_0_0>, [[X_ARG:%.*]] : $Float):
+// CHECK-SIL:   [[ENUM_ADDR:%.*]] = alloc_stack $AddressOnlyEnum<τ_0_0>
+// CHECK-SIL:   copy_addr [[ENUM_ARG]] to [initialization] [[ENUM_ADDR]] : $*AddressOnlyEnum<τ_0_0>
+// CHECK-SIL:   [[BB0_PB_STRUCT:%.*]] = struct $_AD__enum_addr_notactive_bb0__PB__src_0_wrt_1_l<τ_0_0> ()
+// CHECK-SIL:   switch_enum_addr [[ENUM_ADDR]] : $*AddressOnlyEnum<τ_0_0>, case #AddressOnlyEnum.none!enumelt: bb1, case #AddressOnlyEnum.some!enumelt: bb2
+
+// CHECK-SIL: bb1:
+// CHECK-SIL:   [[BB1_PRED_PRED0:%.*]] = enum $_AD__enum_addr_notactive_bb1__Pred__src_0_wrt_1_l<τ_0_0>, #_AD__enum_addr_notactive_bb1__Pred__src_0_wrt_1_l.bb0!enumelt, [[BB0_PB_STRUCT]] : $_AD__enum_addr_notactive_bb0__PB__src_0_wrt_1_l<τ_0_0>
+// CHECK-SIL:   dealloc_stack [[ENUM_ADDR]] : $*AddressOnlyEnum<τ_0_0>
+// CHECK-SIL:   [[BB1_PB_STRUCT:%.*]] = struct $_AD__enum_addr_notactive_bb1__PB__src_0_wrt_1_l<τ_0_0> ([[BB1_PRED_PRED0]] : $_AD__enum_addr_notactive_bb1__Pred__src_0_wrt_1_l<τ_0_0>)
+// CHECK-SIL:   [[BB3_PRED_PRED1:%.*]] = enum $_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l<τ_0_0>, #_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l.bb1!enumelt, [[BB1_PB_STRUCT]] : $_AD__enum_addr_notactive_bb1__PB__src_0_wrt_1_l<τ_0_0>
+// CHECK-SIL:   br bb3([[BB3_PRED_PRED1]] : $_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l<τ_0_0>)
+
+// CHECK-SIL: bb2:
+// CHECK-SIL:   [[BB2_PRED_PRED0:%.*]] = enum $_AD__enum_addr_notactive_bb2__Pred__src_0_wrt_1_l<τ_0_0>, #_AD__enum_addr_notactive_bb2__Pred__src_0_wrt_1_l.bb0!enumelt, [[BB0_PB_STRUCT]] : $_AD__enum_addr_notactive_bb0__PB__src_0_wrt_1_l<τ_0_0>
+// CHECK-SIL:   [[ENUM_DATA:%.*]] = unchecked_take_enum_data_addr [[ENUM_ADDR]] : $*AddressOnlyEnum<τ_0_0>, #AddressOnlyEnum.some!enumelt
+// CHECK-SIL:   destroy_addr [[ENUM_DATA]] : $*τ_0_0
+// CHECK-SIL:   dealloc_stack [[ENUM_ADDR]] : $*AddressOnlyEnum<τ_0_0>
+// CHECK-SIL:   [[BB2_PB_STRUCT:%.*]] = struct $_AD__enum_addr_notactive_bb2__PB__src_0_wrt_1_l<τ_0_0> ([[BB2_PRED_PRED0]] : $_AD__enum_addr_notactive_bb2__Pred__src_0_wrt_1_l<τ_0_0>)
+// CHECK-SIL:   [[BB3_PRED_PRED2:%.*]] = enum $_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l<τ_0_0>, #_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l.bb2!enumelt, [[BB2_PB_STRUCT]] : $_AD__enum_addr_notactive_bb2__PB__src_0_wrt_1_l<τ_0_0>
+// CHECK-SIL:   br bb3([[BB3_PRED_PRED2]] : $_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l<τ_0_0>)
+
+// CHECK-SIL: bb3([[BB3_PRED_ARG:%.*]] : $_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l<τ_0_0>):
+// CHECK-SIL:   [[BB3_PB_STRUCT:%.*]] = struct $_AD__enum_addr_notactive_bb3__PB__src_0_wrt_1_l<τ_0_0> ([[BB3_PRED_ARG]] : $_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l<τ_0_0>)
+
+// CHECK-SIL:   [[PB_FNREF:%.*]] = function_ref @AD__enum_addr_notactive__pullback_src_0_wrt_1_l : $@convention(thin) <τ_0_0> (Float, @owned _AD__enum_addr_notactive_bb3__PB__src_0_wrt_1_l<τ_0_0>) -> Float
+// CHECK-SIL:   [[PB:%.*]] = partial_apply [callee_guaranteed] [[PB_FNREF]]<τ_0_0>([[BB3_PB_STRUCT]]) : $@convention(thin) <τ_0_0> (Float, @owned _AD__enum_addr_notactive_bb3__PB__src_0_wrt_1_l<τ_0_0>) -> Float
+// CHECK-SIL:   [[VJP_RESULT:%.*]] = tuple ([[X_ARG]] : $Float, [[PB]] : $@callee_guaranteed (Float) -> Float)
+// CHECK-SIL:   return [[VJP_RESULT]] : $(Float, @callee_guaranteed (Float) -> Float)
+// CHECK-SIL: }
+
+// Test control flow + tuple buffer.
+// Verify that pullback buffers are not allocated for address projections.
+
+@differentiable
+@_silgen_name("cond_tuple_var")
+func cond_tuple_var(_ x: Float) -> Float {
+  // expected-warning @+1 {{variable 'y' was never mutated; consider changing to 'let' constant}}
+  var y = (x, x)
+  if x > 0 {
+    return y.0
+  }
+  return y.1
+}
+
+// CHECK-SIL-LABEL: sil private [ossa] @AD__cond_tuple_var__pullback_src_0_wrt_0 : $@convention(thin) (Float, @owned _AD__cond_tuple_var_bb3__PB__src_0_wrt_0) -> Float {
+// CHECK-SIL: bb0([[SEED:%.*]] : $Float, [[BB3_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb3__PB__src_0_wrt_0):
+// CHECK-SIL:   [[BB3_PRED:%.*]] = destructure_struct [[BB3_PB_STRUCT]] : $_AD__cond_tuple_var_bb3__PB__src_0_wrt_0
+// CHECK-SIL:   copy_addr {{%.*}} to {{%.*}} : $*(Float, Float)
+// CHECK-SIL-NOT:   copy_addr {{%.*}} to {{%.*}} : $*Float
+// CHECK-SIL:   switch_enum [[BB3_PRED]] : $_AD__cond_tuple_var_bb3__Pred__src_0_wrt_0, case #_AD__cond_tuple_var_bb3__Pred__src_0_wrt_0.bb2!enumelt: bb3, case #_AD__cond_tuple_var_bb3__Pred__src_0_wrt_0.bb1!enumelt: bb1
+
+// CHECK-SIL: bb1([[BB3_PRED1_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0):
+// CHECK-SIL:   br bb2({{%.*}} : $Float, {{%.*}} : $Float, [[BB3_PRED1_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0)
+
+// CHECK-SIL: bb2({{%.*}} : $Float, {{%.*}} : $Float, [[BB1_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0):
+// CHECK-SIL:   [[BB1_PRED:%.*]] = destructure_struct [[BB1_PB_STRUCT]]
+// CHECK-SIL:   copy_addr {{%.*}} to {{%.*}} : $*(Float, Float)
+// CHECK-SIL-NOT:   copy_addr {{%.*}} to {{%.*}} : $*Float
+// CHECK-SIL:   switch_enum [[BB1_PRED]] : $_AD__cond_tuple_var_bb1__Pred__src_0_wrt_0, case #_AD__cond_tuple_var_bb1__Pred__src_0_wrt_0.bb0!enumelt: bb5
+
+// CHECK-SIL: bb3([[BB3_PRED2_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0):
+// CHECK-SIL:   br bb4({{%.*}} : $Float, {{%.*}} : $Float, [[BB3_PRED2_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0)
+
+// CHECK-SIL: bb4({{%.*}} : $Float, {{%.*}} : $Float, [[BB2_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0):
+// CHECK-SIL:   [[BB2_PRED:%.*]] = destructure_struct [[BB2_PB_STRUCT]]
+// CHECK-SIL:   copy_addr {{%.*}} to {{%.*}} : $*(Float, Float)
+// CHECK-SIL-NOT:   copy_addr {{%.*}} to {{%.*}} : $*Float
+// CHECK-SIL:   switch_enum [[BB2_PRED]] : $_AD__cond_tuple_var_bb2__Pred__src_0_wrt_0, case #_AD__cond_tuple_var_bb2__Pred__src_0_wrt_0.bb0!enumelt: bb6
+
+// CHECK-SIL: bb5([[BB1_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0):
+// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB1_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0)
+
+// CHECK-SIL: bb6([[BB2_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0):
+// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB2_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0)
+
+// CHECK-SIL: bb7({{%.*}} : $Float, [[BB0_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0):
+// CHECK-SIL:   return {{%.*}} : $Float

--- a/test/AutoDiff/validation-test/control_flow.swift
+++ b/test/AutoDiff/validation-test/control_flow.swift
@@ -1,0 +1,714 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import _Differentiation
+import StdlibUnittest
+
+var ControlFlowTests = TestSuite("ControlFlow")
+
+ControlFlowTests.test("Conditionals") {
+  func cond1(_ x: Float) -> Float {
+    if x > 0 {
+      return x * x
+    }
+    return x + x
+  }
+  expectEqual(8, gradient(at: 4, in: cond1))
+  expectEqual(2, gradient(at: -10, in: cond1))
+
+  func cond2(_ x: Float) -> Float {
+    let y: Float
+    if x > 0 {
+      y = x * x
+    } else if x == -1337 {
+      y = 0
+    } else {
+      y = x + x
+    }
+    return y
+  }
+  expectEqual(8, gradient(at: 4, in: cond2))
+  expectEqual(2, gradient(at: -10, in: cond2))
+  expectEqual(0, gradient(at: -1337, in: cond2))
+
+  func cond2_var(_ x: Float) -> Float {
+    var y: Float = x
+    if x > 0 {
+      y = y * x
+    } else if x == -1337 {
+      y = x // Dummy assignment; shouldn't affect computation.
+      y = x // Dummy assignment; shouldn't affect computation.
+      y = 0
+    } else {
+      y = x + y
+    }
+    return y
+  }
+  expectEqual(8, gradient(at: 4, in: cond2_var))
+  expectEqual(2, gradient(at: -10, in: cond2_var))
+  expectEqual(0, gradient(at: -1337, in: cond2_var))
+
+  func cond3(_ x: Float, _ y: Float) -> Float {
+    if x > 0 {
+      return x * y
+    }
+    return y - x
+  }
+  expectEqual((5, 4), gradient(at: 4, 5, in: cond3))
+  expectEqual((-1, 1), gradient(at: -3, -2, in: cond3))
+
+  func cond4_var(_ x: Float) -> Float {
+    var outer = x
+    outerIf: if true {
+      var inner = outer
+      inner = inner * x
+      if false {
+        break outerIf
+      }
+      outer = inner
+    }
+    return outer
+  }
+  expectEqual((9, 6), valueWithGradient(at: 3, in: cond4_var))
+
+  func cond_tuple(_ x: Float) -> Float {
+    // Convoluted function returning `x + x`.
+    let y: (Float, Float) = (x, x)
+    if x > 0 {
+      return y.0 + y.1
+    }
+    return y.0 + y.0 - y.1 + y.0
+  }
+  expectEqual((8, 2), valueWithGradient(at: 4, in: cond_tuple))
+  expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_tuple))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_tuple))
+
+  func cond_tuple2(_ x: Float) -> Float {
+    // Convoluted function returning `x + x`.
+    let y: (Float, Float) = (x, x)
+    let y0 = y.0
+    if x > 0 {
+      let y1 = y.1
+      return y0 + y1
+    }
+    let y0_double = y0 + y.0
+    let y1 = y.1
+    return y0_double - y1 + y.0
+  }
+  expectEqual((8, 2), valueWithGradient(at: 4, in: cond_tuple2))
+  expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_tuple2))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_tuple2))
+
+  func cond_tuple_var(_ x: Float) -> Float {
+    // Convoluted function returning `x + x`.
+    var y: (Float, Float) = (x, x)
+    var z: (Float, Float) = (x + x, x - x)
+    if x > 0 {
+      var w = (x, x)
+      y.0 = w.1
+      y.1 = w.0
+      z.0 = z.0 - y.0
+      z.1 = z.1 + y.0
+    } else {
+      z = (x, x)
+    }
+    return y.0 + y.1 - z.0 + z.1
+  }
+  expectEqual((8, 2), valueWithGradient(at: 4, in: cond_tuple_var))
+  expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_tuple_var))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_tuple_var))
+
+  func cond_nestedtuple_var(_ x: Float) -> Float {
+    // Convoluted function returning `x + x`.
+    var y: (Float, Float) = (x + x, x - x)
+    var z: ((Float, Float), Float) = (y, x)
+    if x > 0 {
+      var w = (x, x)
+      y.0 = w.1
+      y.1 = w.0
+      z.0.0 = z.0.0 - y.0
+      z.0.1 = z.0.1 + y.0
+    } else {
+      z = ((y.0 - x, y.1 + x), x)
+    }
+    return y.0 + y.1 - z.0.0 + z.0.1
+  }
+  expectEqual((8, 2), valueWithGradient(at: 4, in: cond_nestedtuple_var))
+  expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_nestedtuple_var))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_nestedtuple_var))
+
+  struct FloatPair : Differentiable {
+    var first, second: Float
+    init(_ first: Float, _ second: Float) {
+      self.first = first
+      self.second = second
+    }
+  }
+
+  struct Pair<T : Differentiable, U : Differentiable> : Differentiable {
+    var first: T
+    var second: U
+    init(_ first: T, _ second: U) {
+      self.first = first
+      self.second = second
+    }
+  }
+
+  func cond_struct(_ x: Float) -> Float {
+    // Convoluted function returning `x + x`.
+    let y = FloatPair(x, x)
+    if x > 0 {
+      return y.first + y.second
+    }
+    return y.first + y.first - y.second + y.first
+  }
+  expectEqual((8, 2), valueWithGradient(at: 4, in: cond_struct))
+  expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_struct))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_struct))
+
+  func cond_struct2(_ x: Float) -> Float {
+    // Convoluted function returning `x + x`.
+    let y = FloatPair(x, x)
+    let y0 = y.first
+    if x > 0 {
+      let y1 = y.second
+      return y0 + y1
+    }
+    let y0_double = y0 + y.first
+    let y1 = y.second
+    return y0_double - y1 + y.first
+  }
+  expectEqual((8, 2), valueWithGradient(at: 4, in: cond_struct2))
+  expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_struct2))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_struct2))
+
+  func cond_struct_var(_ x: Float) -> Float {
+    // Convoluted function returning `x + x`.
+    var y = FloatPair(x, x)
+    var z = FloatPair(x + x, x - x)
+    if x > 0 {
+      var w = y
+      y.first = w.second
+      y.second = w.first
+      z.first = z.first - y.first
+      z.second = z.second + y.first
+    } else {
+      z = FloatPair(x, x)
+    }
+    return y.first + y.second - z.first + z.second
+  }
+  expectEqual((8, 2), valueWithGradient(at: 4, in: cond_struct_var))
+  expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_struct_var))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_struct_var))
+
+  func cond_nestedstruct_var(_ x: Float) -> Float {
+    // Convoluted function returning `x + x`.
+    var y = FloatPair(x + x, x - x)
+    var z = Pair(y, x)
+    if x > 0 {
+      var w = FloatPair(x, x)
+      y.first = w.second
+      y.second = w.first
+      z.first.first = z.first.first - y.first
+      z.first.second = z.first.second + y.first
+    } else {
+      z = Pair(FloatPair(y.first - x, y.second + x), x)
+    }
+    return y.first + y.second - z.first.first + z.first.second
+  }
+  expectEqual((8, 2), valueWithGradient(at: 4, in: cond_nestedstruct_var))
+  expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_nestedstruct_var))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_nestedstruct_var))
+
+  func guard1(_ x: Float, _ y: Float) -> Float {
+    guard x > 0 else {
+      return x * x
+    }
+    return y * y
+  }
+  expectEqual((0, 10), gradient(at: 4, 5, in: guard1))
+  expectEqual((-6, 0), gradient(at: -3, -2, in: guard1))
+
+  func guard2(_ x: Float, _ y: Float) -> Float {
+    guard x > 0 else {
+      if y > 0 {
+        return x * y
+      } else if x == -1337 {
+        return x * x
+      }
+      return 0
+    }
+    return y * y
+  }
+  expectEqual((0, 10), gradient(at: 4, 5, in: guard2))
+  expectEqual((5, -1337), gradient(at: -1337, 5, in: guard2))
+  expectEqual((-2674, 0), gradient(at: -1337, -5, in: guard2))
+  expectEqual((2, -3), gradient(at: -3, 2, in: guard2))
+
+  func guard2_var(_ x: Float, _ y: Float) -> Float {
+    var z = y
+    guard x > 0 else {
+      if y > 0 {
+        z = z * x
+      } else if x == -1337 {
+        z = x
+        z = z * z
+      } else {
+        z = 0
+      }
+      return z
+    }
+    return z * y
+  }
+  expectEqual((0, 10), gradient(at: 4, 5, in: guard2_var))
+  expectEqual((5, -1337), gradient(at: -1337, 5, in: guard2_var))
+  expectEqual((-2674, 0), gradient(at: -1337, -5, in: guard2_var))
+  expectEqual((2, -3), gradient(at: -3, 2, in: guard2_var))
+
+  func guard3(_ x: Float, _ y: Float) -> Float {
+    guard x > 0 else {
+      fatalError()
+    }
+    return y * y
+  }
+  expectEqual((0, 10), gradient(at: 4, 5, in: guard3))
+  expectCrash {
+    _ = gradient(at: -3, -2, in: guard3)
+  }
+
+  func cond_empty(_ x: Float) -> Float {
+    if x > 0 {
+      // Create empty trampoline blocks.
+    }
+    return x * x
+  }
+  expectEqual(4, gradient(at: 2, in: cond_empty))
+  expectEqual(-6, gradient(at: -3, in: cond_empty))
+
+  func cond_generic<T : Differentiable & FloatingPoint>(
+    _ x: T, _ y: T
+  ) -> T {
+    if x > 0 {
+      return x
+    }
+    return y
+  }
+  expectEqual((1, 0), gradient(at: 4, 5, in: { x, y in cond_generic(x, y) }))
+  expectEqual((0, 1), gradient(at: -4, 5, in: { x, y in cond_generic(x, y) }))
+}
+
+ControlFlowTests.test("NestedConditionals") {
+  func nested1(_ x: Float) -> Float {
+    if x > 0 {
+      if x > 10 {
+        return x * x + x
+      } else {
+        return x * x
+      }
+    }
+    return x * -x
+  }
+  expectEqual(23, gradient(at: 11, in: nested1))
+  expectEqual(8, gradient(at: 4, in: nested1))
+  expectEqual(20, gradient(at: -10, in: nested1))
+
+  func nested2(_ x: Float, _ y: Float) -> Float {
+    if x > 0 {
+      if y > 10 {
+        return x * y
+      } else {
+        return x + y
+      }
+    }
+    return -y
+  }
+  expectEqual((20, 4), gradient(at: 4, 20, in: nested2))
+  expectEqual((1, 1), gradient(at: 4, 5, in: nested2))
+  expectEqual((0, -1), gradient(at: -3, -2, in: nested2))
+
+  func nested3(_ x: Float, _ y: Float) -> Float {
+    if x > 0 {
+      if y > 10 {
+        let z = x * y
+        if z > 100 {
+          return x + z
+        } else if y == 20 {
+          return z + z
+        }
+      } else {
+        return x + y
+      }
+    }
+    return -y
+  }
+  expectEqual((40, 8), gradient(at: 4, 20, in: nested3))
+  expectEqual((0, -1), gradient(at: 4, 21, in: nested3))
+  expectEqual((1, 1), gradient(at: 4, 5, in: nested3))
+  expectEqual((0, -1), gradient(at: -3, -2, in: nested3))
+
+  func nested3_var(_ x: Float, _ y: Float) -> Float {
+    var w = y
+    if x > 0 {
+      if y > 10 {
+        var z = x * w
+        if z > 100 {
+          z = x + z
+          return z
+        } else if y == 20 {
+          z = z + z
+          return z
+        }
+      } else {
+        w = x + w
+        return w
+      }
+    }
+    w = -w
+    return w
+  }
+  expectEqual((40, 8), gradient(at: 4, 20, in: nested3))
+  expectEqual((0, -1), gradient(at: 4, 21, in: nested3))
+  expectEqual((1, 1), gradient(at: 4, 5, in: nested3))
+  expectEqual((0, -1), gradient(at: -3, -2, in: nested3))
+
+  // TF-781: nested if derivative correctness.
+  do {
+    struct TF_781: Differentiable {
+      var w: Float = 3
+
+      @differentiable(wrt: self) // wrt only self is important
+      func callAsFunction(_ input: Float) -> Float {
+        var x = input
+        if true {
+          if true {
+            // Function application below should make `self` have non-zero
+            // derivative.
+            x = x * w
+          }
+        }
+        return x
+      }
+    }
+    let x: Float = 10
+    expectEqual(TF_781.TangentVector(w: x), gradient(at: TF_781()) { $0(x) })
+  }
+
+  // Non-method version of TF-781.
+  do {
+    @differentiable(wrt: x)
+    func TF_781(_ x: Float, _ y: Float) -> Float {
+      var result = y
+      if true {
+        if true {
+          result = result * x
+        }
+      }
+      return result
+    }
+    let x: Float = 10
+    expectEqual(x, gradient(at: 3) { TF_781($0, x) })
+  }
+}
+
+ControlFlowTests.test("Recursion") {
+  func factorial(_ x: Float) -> Float {
+    if x == 1 {
+      return 1
+    }
+    return x * factorial(x - 1)
+  }
+  expectEqual(0, gradient(at: 1, in: factorial))
+  expectEqual(1, gradient(at: 2, in: factorial))
+  expectEqual(5, gradient(at: 3, in: factorial))
+  expectEqual(26, gradient(at: 4, in: factorial))
+  expectEqual(154, gradient(at: 5, in: factorial))
+
+  func factorial_var1(_ x: Float) -> Float {
+    var y: Float = x
+    if x == 1 {
+      y = 1
+    } else {
+      y = x
+      y = y * factorial_var1(y - 1)
+    }
+    return y
+  }
+  expectEqual(0, gradient(at: 1, in: factorial_var1))
+  expectEqual(1, gradient(at: 2, in: factorial_var1))
+  expectEqual(5, gradient(at: 3, in: factorial_var1))
+  expectEqual(26, gradient(at: 4, in: factorial_var1))
+  expectEqual(154, gradient(at: 5, in: factorial_var1))
+
+  func factorial_var2(_ x: Float) -> Float {
+    // Next line is the only difference with `factorial_var1`.
+    var y: Float = 1
+    if x == 1 {
+      y = 1
+    } else {
+      y = x
+      y = y * factorial_var2(y - 1)
+    }
+    return y
+  }
+  expectEqual(0, gradient(at: 1, in: factorial_var2))
+  expectEqual(1, gradient(at: 2, in: factorial_var2))
+  expectEqual(5, gradient(at: 3, in: factorial_var2))
+  expectEqual(26, gradient(at: 4, in: factorial_var2))
+  expectEqual(154, gradient(at: 5, in: factorial_var2))
+
+  func product(_ x: Float, count: Int) -> Float {
+    precondition(count > 0)
+    if count == 1 {
+      return x
+    }
+    return x * product(x, count: count - 1)
+  }
+  expectEqual(300, gradient(at: 10, in: { x in product(x, count: 3) }))
+  expectEqual(-20, gradient(at: -10, in: { x in product(x, count: 2) }))
+  expectEqual(1, gradient(at: 100, in: { x in product(x, count: 1) }))
+}
+
+ControlFlowTests.test("Enums") {
+  enum Enum {
+    case a(Float)
+    case b(Float, Float)
+
+    func enum_notactive1(_ x: Float) -> Float {
+      switch self {
+      case let .a(a): return x * a
+      case let .b(b1, b2): return x * b1 * b2
+      }
+    }
+  }
+
+  func enum_notactive1(_ e: Enum, _ x: Float) -> Float {
+    switch e {
+    case let .a(a): return x * a
+    case let .b(b1, b2): return x * b1 * b2
+    }
+  }
+  expectEqual(10, gradient(at: 2, in: { x in enum_notactive1(.a(10), x) }))
+  expectEqual(10, gradient(at: 2, in: { x in Enum.a(10).enum_notactive1(x) }))
+  expectEqual(20, gradient(at: 2, in: { x in enum_notactive1(.b(4, 5), x) }))
+  expectEqual(20, gradient(at: 2, in: { x in Enum.b(4, 5).enum_notactive1(x) }))
+
+  func enum_notactive2(_ e: Enum, _ x: Float) -> Float {
+    var y = x
+    if x > 0 {
+      var z = y + y
+      switch e {
+      case .a: z = z - y
+      case .b: y = y + x
+      }
+      var w = y
+      if case .a = e {
+        w = w + z
+      }
+      return w
+    } else if case .b = e {
+      return y + y
+    }
+    return x + y
+  }
+  expectEqual((8, 2), valueWithGradient(at: 4, in: { x in enum_notactive2(.a(10), x) }))
+  expectEqual((20, 2), valueWithGradient(at: 10, in: { x in enum_notactive2(.b(4, 5), x) }))
+  expectEqual((-20, 2), valueWithGradient(at: -10, in: { x in enum_notactive2(.a(10), x) }))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: { x in enum_notactive2(.b(4, 5), x) }))
+
+  func optional_notactive1(_ optional: Float?, _ x: Float) -> Float {
+    if let y = optional {
+      return x * y
+    }
+    return x + x
+  }
+  expectEqual(2, gradient(at: 2, in: { x in optional_notactive1(nil, x) }))
+  expectEqual(10, gradient(at: 2, in: { x in optional_notactive1(10, x) }))
+
+  struct Dense : Differentiable {
+    var w1: Float
+    @noDerivative var w2: Float?
+
+    @differentiable
+    func callAsFunction(_ input: Float) -> Float {
+      if let w2 = w2 {
+        return input * w1 * w2
+      }
+      return input * w1
+    }
+  }
+  expectEqual((Dense.TangentVector(w1: 10), 20),
+              gradient(at: Dense(w1: 4, w2: 5), 2) { dense, x in dense(x) })
+  expectEqual((Dense.TangentVector(w1: 2), 4),
+              gradient(at: Dense(w1: 4, w2: nil), 2) { dense, x in dense(x) })
+
+  indirect enum Indirect {
+    case e(Float, Enum)
+    case indirect(Indirect)
+  }
+
+  func enum_indirect_notactive1(_ indirect: Indirect, _ x: Float) -> Float {
+    switch indirect {
+    case let .e(f, e):
+      switch e {
+      case .a: return x * f * enum_notactive1(e, x)
+      case .b: return x * f * enum_notactive1(e, x)
+      }
+    case let .indirect(ind): return enum_indirect_notactive1(ind, x)
+    }
+  }
+  do {
+    let ind: Indirect = .e(10, .a(3))
+    expectEqual(120, gradient(at: 2, in: { x in enum_indirect_notactive1(ind, x) }))
+    expectEqual(120, gradient(at: 2, in: { x in enum_indirect_notactive1(.indirect(ind), x) }))
+  }
+}
+
+ControlFlowTests.test("Loops") {
+  func for_loop(_ x: Float) -> Float {
+    var result = x
+    for _ in 0..<2 {
+      result = result * x
+    }
+    return result
+  }
+  expectEqual((8, 12), valueWithGradient(at: 2, in: for_loop))
+  expectEqual((27, 27), valueWithGradient(at: 3, in: for_loop))
+
+  func for_loop_nonactive_initial_value(_ x: Float) -> Float {
+    var result: Float = 1
+    for _ in 0..<2 {
+      result = result * x
+    }
+    return result
+  }
+  expectEqual((4, 4), valueWithGradient(at: 2, in: for_loop_nonactive_initial_value))
+  expectEqual((9, 6), valueWithGradient(at: 3, in: for_loop_nonactive_initial_value))
+
+  func while_loop(_ x: Float) -> Float {
+    var result = x
+    var i = 0
+    while i < 2 {
+      result = result * x
+      i += 1
+    }
+    return result
+  }
+  expectEqual((8, 12), valueWithGradient(at: 2, in: while_loop))
+  expectEqual((27, 27), valueWithGradient(at: 3, in: while_loop))
+
+  func while_loop_nonactive_initial_value(_ x: Float) -> Float {
+    var result: Float = 1
+    var i = 0
+    while i < 2 {
+      result = result * x
+      i += 1
+    }
+    return result
+  }
+  expectEqual((4, 4), valueWithGradient(at: 2, in: while_loop_nonactive_initial_value))
+  expectEqual((9, 6), valueWithGradient(at: 3, in: while_loop_nonactive_initial_value))
+
+  func repeat_while_loop(_ x: Float) -> Float {
+    var result = x
+    var i = 0
+    repeat {
+      result = result * x
+      i += 1
+    } while i < 2
+    return result
+  }
+  // FIXME(TF-584): Investigate incorrect (too big) gradient values for
+  // repeat-while loops.
+  // expectEqual((8, 12), valueWithGradient(at: 2, in: repeat_while_loop))
+  // expectEqual((27, 27), valueWithGradient(at: 3, in: repeat_while_loop))
+  expectEqual((8, 18), valueWithGradient(at: 2, in: repeat_while_loop))
+  expectEqual((27, 36), valueWithGradient(at: 3, in: repeat_while_loop))
+
+  func repeat_while_loop_nonactive_initial_value(_ x: Float) -> Float {
+    var result: Float = 1
+    var i = 0
+    repeat {
+      result = result * x
+      i += 1
+    } while i < 2
+    return result
+  }
+  // FIXME(TF-584): Investigate incorrect (too big) gradient values for
+  // repeat-while loops.
+  // expectEqual((4, 4), valueWithGradient(at: 2, in: repeat_while_loop_nonactive_initial_value))
+  // expectEqual((9, 6), valueWithGradient(at: 3, in: repeat_while_loop_nonactive_initial_value))
+  expectEqual((4, 5), valueWithGradient(at: 2, in: repeat_while_loop_nonactive_initial_value))
+  expectEqual((9, 7), valueWithGradient(at: 3, in: repeat_while_loop_nonactive_initial_value))
+
+  func loop_continue(_ x: Float) -> Float {
+    var result = x
+    for i in 1..<10 {
+      if i.isMultiple(of: 2) {
+        continue
+      }
+      result = result * x
+    }
+    return result
+  }
+  expectEqual((64, 192), valueWithGradient(at: 2, in: loop_continue))
+  expectEqual((729, 1458), valueWithGradient(at: 3, in: loop_continue))
+
+  func loop_break(_ x: Float) -> Float {
+    var result = x
+    for i in 1..<10 {
+      if i.isMultiple(of: 2) {
+        continue
+      }
+      result = result * x
+    }
+    return result
+  }
+  expectEqual((64, 192), valueWithGradient(at: 2, in: loop_break))
+  expectEqual((729, 1458), valueWithGradient(at: 3, in: loop_break))
+
+  func nested_loop1(_ x: Float) -> Float {
+    var outer = x
+    for _ in 0..<2 {
+      outer = outer * x
+
+      var inner = outer
+      var i = 0
+      while i < 2 {
+        inner = inner + x
+        i += 1
+      }
+      outer = inner
+    }
+    return outer
+  }
+  expectEqual((20, 22), valueWithGradient(at: 2, in: nested_loop1))
+  expectEqual((104, 66), valueWithGradient(at: 4, in: nested_loop1))
+
+  func nested_loop2(_ x: Float, count: Int) -> Float {
+    var outer = x
+    outerLoop: for _ in 0..<count {
+      outer = outer * x
+
+      var inner = outer
+      var i = 0
+      while i < count {
+        inner = inner + x
+        i += 1
+
+        switch Int(inner.truncatingRemainder(dividingBy: 7)) {
+        case 0: break outerLoop
+        case 1: break
+        default: continue
+        }
+      }
+      outer = inner
+    }
+    return outer
+  }
+  expectEqual((6, 5), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 1) }))
+  expectEqual((20, 22), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 2) }))
+  expectEqual((52, 80), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 3) }))
+  expectEqual((24, 28), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 4) }))
+}
+
+runAllTests()

--- a/test/AutoDiff/validation-test/reabstraction.swift
+++ b/test/AutoDiff/validation-test/reabstraction.swift
@@ -1,0 +1,179 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import _Differentiation
+import StdlibUnittest
+
+var ReabstractionE2ETests = TestSuite("ReabstractionE2E")
+
+ReabstractionE2ETests.test("diff param concrete => generic") {
+  func grad<T: Differentiable>(_ f: @differentiable (T) -> Float, at x: T) -> T.TangentVector {
+    gradient(at: x, in: f)
+  }
+  func inner(_ x: Float) -> Float {
+    7 * x * x
+  }
+  expectEqual(Float(7 * 2 * 3), grad(inner, at: 3))
+}
+
+ReabstractionE2ETests.test("nondiff param concrete => generic") {
+  func grad<T: Differentiable>(_ f: @differentiable (Float, @noDerivative T) -> Float, at x: Float, _ y: T) -> Float {
+    gradient(at: x) { f($0, y) }
+  }
+  func inner(_ x: Float, _ y: Float) -> Float {
+    7 * x * x + y
+  }
+  expectEqual(Float(7 * 2 * 3), grad(inner, at: 3, 10))
+}
+
+ReabstractionE2ETests.test("diff param and nondiff param concrete => generic") {
+  func grad<T: Differentiable>(_ f: @differentiable (T, @noDerivative T) -> Float, at x: T, _ y: T) -> T.TangentVector {
+    gradient(at: x) { f($0, y) }
+  }
+  func inner(_ x: Float, _ y: Float) -> Float {
+    7 * x * x + y
+  }
+  expectEqual(Float(7 * 2 * 3), grad(inner, at: 3, 10))
+}
+
+ReabstractionE2ETests.test("result concrete => generic") {
+  func grad<T: Differentiable>(_ f: @differentiable (Float) -> T, at x: Float, seed: T.TangentVector) -> Float {
+    pullback(at: x, in: f)(seed)
+  }
+  func inner(_ x: Float) -> Float {
+    7 * x * x
+  }
+  expectEqual(Float(7 * 2 * 3), grad(inner, at: 3, seed: 1))
+}
+
+protocol HasFloat: Differentiable {
+  @differentiable
+  var float: Float { get }
+
+  @differentiable
+  init(float: Float)
+}
+
+extension Float: HasFloat {
+  @differentiable
+  var float: Float { self }
+
+  @differentiable
+  init(float: Float) { self = float }
+}
+
+ReabstractionE2ETests.test("diff param generic => concrete") {
+  func inner<T: HasFloat>(x: T) -> Float {
+    7 * x.float * x.float
+  }
+  let transformed: @differentiable (Float) -> Float = inner
+  expectEqual(Float(7 * 3 * 3), transformed(3))
+  expectEqual(Float(7 * 2 * 3), gradient(at: 3, in: transformed))
+}
+
+ReabstractionE2ETests.test("nondiff param generic => concrete") {
+  func inner<T: HasFloat>(x: Float, y: T) -> Float {
+    7 * x * x + y.float
+  }
+  let transformed: @differentiable (Float, @noDerivative Float) -> Float = inner
+  expectEqual(Float(7 * 3 * 3 + 10), transformed(3, 10))
+  expectEqual(Float(7 * 2 * 3), gradient(at: 3) { transformed($0, 10) })
+}
+
+ReabstractionE2ETests.test("diff param and nondiff param generic => concrete") {
+  func inner<T: HasFloat>(x: T, y: T) -> Float {
+    7 * x.float * x.float + y.float
+  }
+  let transformed: @differentiable (Float, @noDerivative Float) -> Float = inner
+  expectEqual(Float(7 * 3 * 3 + 10), transformed(3, 10))
+  expectEqual(Float(7 * 2 * 3), gradient(at: 3) { transformed($0, 10) })
+}
+
+ReabstractionE2ETests.test("result generic => concrete") {
+  func inner<T: HasFloat>(x: Float) -> T {
+    T(float: 7 * x * x)
+  }
+  let transformed: @differentiable (Float) -> Float = inner
+  expectEqual(Float(7 * 3 * 3), transformed(3))
+  expectEqual(Float(7 * 2 * 3), gradient(at: 3, in: transformed))
+}
+
+ReabstractionE2ETests.test("diff param concrete => generic => concrete") {
+  typealias FnTy<T: Differentiable> = @differentiable (T) -> Float
+  func id<T: Differentiable>(_ f: @escaping FnTy<T>) -> FnTy<T> { f }
+  func inner(_ x: Float) -> Float {
+    7 * x * x
+  }
+  let transformed = id(inner)
+  expectEqual(Float(7 * 3 * 3), transformed(3))
+  expectEqual(Float(7 * 2 * 3), gradient(at: 3, in: transformed))
+}
+
+ReabstractionE2ETests.test("nondiff param concrete => generic => concrete") {
+  typealias FnTy<T: Differentiable> = @differentiable (Float, @noDerivative T) -> Float
+  func id<T: Differentiable>(_ f: @escaping FnTy<T>) -> FnTy<T> { f }
+  func inner(_ x: Float, _ y: Float) -> Float {
+    7 * x * x + y
+  }
+  let transformed = id(inner)
+  expectEqual(Float(7 * 3 * 3 + 10), transformed(3, 10))
+  expectEqual(Float(7 * 2 * 3), gradient(at: 3) { transformed($0, 10) })
+}
+
+ReabstractionE2ETests.test("diff param and nondiff param concrete => generic => concrete") {
+  typealias FnTy<T: Differentiable> = @differentiable (T, @noDerivative T) -> Float
+  func id<T: Differentiable>(_ f: @escaping FnTy<T>) -> FnTy<T> { f }
+  func inner(_ x: Float, _ y: Float) -> Float {
+    7 * x * x + y
+  }
+  let transformed = id(inner)
+  expectEqual(Float(7 * 3 * 3 + 10), transformed(3, 10))
+  expectEqual(Float(7 * 2 * 3), gradient(at: 3) { transformed($0, 10) })
+}
+
+ReabstractionE2ETests.test("result concrete => generic => concrete") {
+  typealias FnTy<T: Differentiable> = @differentiable (Float) -> T
+  func id<T: Differentiable>(_ f: @escaping FnTy<T>) -> FnTy<T> { f }
+  func inner(_ x: Float) -> Float {
+    7 * x * x
+  }
+  let transformed = id(inner)
+  expectEqual(Float(7 * 3 * 3), transformed(3))
+  expectEqual(Float(7 * 2 * 3), gradient(at: 3, in: transformed))
+}
+
+ReabstractionE2ETests.test("@differentiable function => opaque generic => concrete") {
+  func id<T>(_ t: T) -> T { t }
+  let inner: @differentiable (Float) -> Float = { 7 * $0 * $0 }
+
+  // TODO(TF-1122): Actually using `id` causes a segfault at runtime.
+  // let transformed = id(inner)
+  // expectEqual(Float(7 * 3 * 3), transformed(3))
+  // expectEqual(Float(7 * 2 * 3), gradient(at: 3, in: id(inner)))
+}
+
+ReabstractionE2ETests.test("@differentiable function => opaque Any => concrete") {
+  func id(_ any: Any) -> Any { any }
+  let inner: @differentiable (Float) -> Float = { 7 * $0 * $0 }
+
+  // TODO(TF-1122): Actually using `id` causes a segfault at runtime.
+  // let transformed = id(inner)
+  // let casted = transformed as! @differentiable (Float) -> Float
+  // expectEqual(Float(7 * 3 * 3), casted(3))
+  // expectEqual(Float(7 * 2 * 3), gradient(at: 3, in: casted))
+}
+
+ReabstractionE2ETests.test("access @differentiable function using KeyPath") {
+  struct Container {
+    let f: @differentiable (Float) -> Float
+  }
+  let container = Container(f: { 7 * $0 * $0 })
+  let kp = \Container.f
+
+  // TODO(TF-1122): Actually using `kp` causes a segfault at runtime.
+  // let extracted = container[keyPath: kp]
+  // expectEqual(Float(7 * 3 * 3), extracted(3))
+  // expectEqual(Float(7 * 2 * 3), gradient(at: 3, in: extracted))
+}
+
+runAllTests()


### PR DESCRIPTION
* Two control-flow related SILOptimizer tests.
* One control-flow validation test.
* One reabstraction validation test.

I needed to append `_l` to the names of some of the CHECKs for the control-flow generated types in `differentiation_control_flow_sil.swift`. And I had to add `import _Differentiation`. Other than that, the tests are unmodified from `tensorflow` branch.