### PR TITLE
Sema: Force property wrappers in EmittedMembersRequest::evaluate()

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2457,6 +2457,14 @@ EmittedMembersRequest::evaluate(Evaluator &evaluator,
   forceConformance(Context.getProtocol(KnownProtocolKind::Encodable));
   forceConformance(Context.getProtocol(KnownProtocolKind::Hashable));
 
+  // The projected storage wrapper ($foo) might have dynamically-dispatched
+  // accessors, so force them to be synthesized.
+  for (auto *member : CD->getMembers()) {
+    if (auto *var = dyn_cast<VarDecl>(member))
+      if (var->hasAttachedPropertyWrapper())
+        (void) var->getPropertyWrapperBackingProperty();
+  }
+
   return CD->getMembers();
 }
 

--- a/test/SILGen/Inputs/property_wrappers_multifile_other.swift
+++ b/test/SILGen/Inputs/property_wrappers_multifile_other.swift
@@ -1,0 +1,22 @@
+public class MyClass {
+  public init() { }
+
+  @PropertyWrapper()
+  public var instanceProperty: Bool
+}
+
+@propertyWrapper
+public struct PropertyWrapper {
+  public var projectedValue: PropertyWrapper {
+    get {
+      return self
+    }
+    set {
+      self = newValue
+    }
+  }
+
+  public var wrappedValue: Bool {
+    return false
+  }
+}

--- a/test/SILGen/property_wrappers_multifile.swift
+++ b/test/SILGen/property_wrappers_multifile.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-emit-silgen -primary-file %s %S/Inputs/property_wrappers_multifile_other.swift | %FileCheck %s
+
+public class YourClass : MyClass {}
+
+// CHECK-LABEL: sil_vtable [serialized] YourClass {
+// CHECK-NEXT:    #MyClass.init!allocator: (MyClass.Type) -> () -> MyClass : @$s27property_wrappers_multifile9YourClassCACycfC [override]
+// CHECK-NEXT:    #MyClass.instanceProperty!getter: (MyClass) -> () -> Bool : @$s27property_wrappers_multifile7MyClassC16instancePropertySbvg [inherited]
+// CHECK-NEXT:    #MyClass.$instanceProperty!getter: (MyClass) -> () -> PropertyWrapper : @$s27property_wrappers_multifile7MyClassC17$instancePropertyAA0G7WrapperVvg [inherited]
+// CHECK-NEXT:    #MyClass.$instanceProperty!setter: (MyClass) -> (PropertyWrapper) -> () : @$s27property_wrappers_multifile7MyClassC17$instancePropertyAA0G7WrapperVvs [inherited]
+// CHECK-NEXT:    #MyClass.$instanceProperty!modify: (MyClass) -> () -> () : @$s27property_wrappers_multifile7MyClassC17$instancePropertyAA0G7WrapperVvM [inherited]
+// CHECK-NEXT:    #YourClass.deinit!deallocator: @$s27property_wrappers_multifile9YourClassCfD
+// CHECK-NEXT:  }

--- a/test/multifile/Inputs/rdar61229365.swift
+++ b/test/multifile/Inputs/rdar61229365.swift
@@ -1,0 +1,33 @@
+public class MyClass {
+  public init() { }
+
+  @PropertyWrapper(defaultValue: false)
+  public var wrappedProperty: Bool
+
+  public func check() {
+    let foo = $wrappedProperty
+    $wrappedProperty = foo
+  }
+}
+
+@propertyWrapper
+public struct PropertyWrapper<Value> {
+  public let defaultValue: Value
+
+  public var projectedValue: PropertyWrapper<Value> {
+    get {
+      return self
+    }
+    set {
+      self = newValue
+    }
+  }
+
+  public var wrappedValue: Value {
+    return defaultValue
+  }
+
+  public init(defaultValue: Value) {
+    self.defaultValue = defaultValue
+  }
+}

--- a/test/multifile/Inputs/sr12429.swift
+++ b/test/multifile/Inputs/sr12429.swift
@@ -26,7 +26,6 @@ public struct PropertyWrapper<Value> {
     get {
       return self
     }
-    // Having this setter is what causes the mis-compilation
     set {
       self = newValue
     }

--- a/test/multifile/property-wrappers-rdar61229365.swift
+++ b/test/multifile/property-wrappers-rdar61229365.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -o %t/main %t/main.swift %S/Inputs/rdar61229365.swift
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main
+
+// REQUIRES: executable_test
+
+class YourClass : MyClass {
+  override init() {
+    super.init()
+  }
+}
+
+let object = YourClass()
+object.check()


### PR DESCRIPTION
Fixes <rdar://problem/61229365>.
