### PR TITLE
Add swiftcc attribute for runtime functions called from Swift

### DIFF
--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -205,10 +205,13 @@ void swift_nonatomic_release_n(HeapObject *object, uint32_t n);
 
 // Refcounting observation hooks for memory tools. Don't use these.
 SWIFT_RUNTIME_EXPORT
+SWIFT_CC(swift)
 size_t swift_retainCount(HeapObject *object);
 SWIFT_RUNTIME_EXPORT
+SWIFT_CC(swift)
 size_t swift_unownedRetainCount(HeapObject *object);
 SWIFT_RUNTIME_EXPORT
+SWIFT_CC(swift)
 size_t swift_weakRetainCount(HeapObject *object);
 
 /// Is this pointer a non-null unique reference to an object?

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -281,7 +281,8 @@ getLayoutFunctionForComputedComponent(IRGenModule &IGM,
   auto layoutFn = llvm::Function::Create(fnTy,
     llvm::GlobalValue::PrivateLinkage, "keypath_get_arg_layout", IGM.getModule());
   layoutFn->setAttributes(IGM.constructInitialAttributes());
-    
+  layoutFn->setCallingConv(IGM.SwiftCC);
+
   {
     IRGenFunction IGF(IGM, layoutFn);
     if (IGM.DebugInfo)
@@ -381,6 +382,7 @@ getWitnessTableForComputedComponent(IRGenModule &IGM,
                                                  /*vararg*/ false);
       auto destroyFn = llvm::Function::Create(destroyType,
         llvm::GlobalValue::PrivateLinkage, "keypath_destroy", IGM.getModule());
+      destroyFn->setCallingConv(IGM.SwiftCC);
       destroy = destroyFn;
       destroyFn->setAttributes(IGM.constructInitialAttributes());
       
@@ -430,6 +432,7 @@ getWitnessTableForComputedComponent(IRGenModule &IGM,
                                               /*vararg*/ false);
       auto copyFn = llvm::Function::Create(copyType,
         llvm::GlobalValue::PrivateLinkage, "keypath_copy", IGM.getModule());
+      copyFn->setCallingConv(IGM.SwiftCC);
       copy = copyFn;
       copyFn->setAttributes(IGM.constructInitialAttributes());
       
@@ -545,7 +548,8 @@ getInitializerForComputedComponent(IRGenModule &IGM,
   auto initFn = llvm::Function::Create(fnTy,
     llvm::GlobalValue::PrivateLinkage, "keypath_arg_init", IGM.getModule());
   initFn->setAttributes(IGM.constructInitialAttributes());
-    
+  initFn->setCallingConv(IGM.SwiftCC);
+
   {
     IRGenFunction IGF(IGM, initFn);
     if (IGM.DebugInfo)

--- a/stdlib/public/SwiftShims/HeapObject.h
+++ b/stdlib/public/SwiftShims/HeapObject.h
@@ -81,17 +81,25 @@ struct HeapObject {
 #ifdef __cplusplus
 extern "C" {
 #endif
+#if __has_attribute(swiftcall)
+#define SWIFT_CC_swift __attribute__((swiftcall))
+#else
+#define SWIFT_CC_swift
+#endif
 
 SWIFT_RUNTIME_STDLIB_API
 void _swift_instantiateInertHeapObject(void *address,
                                        const HeapMetadata *metadata);
 
+SWIFT_CC_swift
 SWIFT_RUNTIME_STDLIB_API
 __swift_size_t swift_retainCount(HeapObject *obj);
 
+SWIFT_CC_swift
 SWIFT_RUNTIME_STDLIB_API
 __swift_size_t swift_unownedRetainCount(HeapObject *obj);
 
+SWIFT_CC_swift
 SWIFT_RUNTIME_STDLIB_API
 __swift_size_t swift_weakRetainCount(HeapObject *obj);
 

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -700,7 +700,7 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
 //// define what these will be.
 /// \returns the demangled name. Returns nullptr if the input String is not a
 /// Swift mangled name.
-SWIFT_RUNTIME_EXPORT
+SWIFT_CC(swift)
 char *swift_demangle(const char *mangledName,
                      size_t mangledNameLength,
                      char *outputBuffer,

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -252,6 +252,7 @@ public:
 
 static SimpleGlobalCache<BoxCacheEntry, BoxesTag> Boxes;
 
+SWIFT_CC(swift)
 BoxPair swift::swift_makeBoxUnique(OpaqueValue *buffer, const Metadata *type,
                                     size_t alignMask) {
   auto *inlineBuffer = reinterpret_cast<ValueBuffer*>(buffer);
@@ -277,6 +278,7 @@ BoxPair swift::swift_makeBoxUnique(OpaqueValue *buffer, const Metadata *type,
   }
 }
 
+SWIFT_CC(swift)
 BoxPair swift::swift_allocBox(const Metadata *type) {
   // Get the heap metadata for the box.
   auto metadata = &Boxes.getOrInsert(type).first->Data;
@@ -439,16 +441,19 @@ void swift::swift_nonatomic_release_n(HeapObject *object, uint32_t n) {
     object->refCounts.decrementAndMaybeDeinitNonAtomic(n);
 }
 
+SWIFT_CC(swift)
 size_t swift::swift_retainCount(HeapObject *object) {
   if (isValidPointerForNativeRetain(object))
     return object->refCounts.getCount();
   return 0;
 }
 
+SWIFT_CC(swift)
 size_t swift::swift_unownedRetainCount(HeapObject *object) {
   return object->refCounts.getUnownedCount();
 }
 
+SWIFT_CC(swift)
 size_t swift::swift_weakRetainCount(HeapObject *object) {
   return object->refCounts.getWeakCount();
 }

--- a/stdlib/public/runtime/Numeric.cpp
+++ b/stdlib/public/runtime/Numeric.cpp
@@ -50,10 +50,12 @@ static T convert(IntegerLiteral value) {
   return result;
 }
 
+SWIFT_CC(swift)
 float swift::swift_intToFloat32(IntegerLiteral value) {
   return convert<float>(value);
 }
 
+SWIFT_CC(swift)
 double swift::swift_intToFloat64(IntegerLiteral value) {
   return convert<double>(value);
 }

--- a/stdlib/public/runtime/RuntimeInvocationsTracking.cpp
+++ b/stdlib/public/runtime/RuntimeInvocationsTracking.cpp
@@ -128,7 +128,7 @@ static uint16_t RuntimeFunctionCountersOffsets[] = {
 /// Public APIs
 
 /// Get the runtime object state associated with an object.
-void _swift_getObjectRuntimeFunctionCounters(
+SWIFT_CC(swift) void _swift_getObjectRuntimeFunctionCounters(
     HeapObject *object, RuntimeFunctionCountersState *result) {
   auto &theSentinel = RuntimeObjectStateCache.get();
   StaticScopedReadLock lock(theSentinel.Lock);
@@ -137,7 +137,7 @@ void _swift_getObjectRuntimeFunctionCounters(
 
 /// Set the runtime object state associated with an object from a provided
 /// state.
-void _swift_setObjectRuntimeFunctionCounters(
+SWIFT_CC(swift) void _swift_setObjectRuntimeFunctionCounters(
     HeapObject *object, RuntimeFunctionCountersState *state) {
   auto &theSentinel = RuntimeObjectStateCache.get();
   StaticScopedWriteLock lock(theSentinel.Lock);
@@ -146,14 +146,14 @@ void _swift_setObjectRuntimeFunctionCounters(
 
 /// Get the global runtime state containing the total numbers of invocations for
 /// each runtime function of interest.
-void _swift_getGlobalRuntimeFunctionCounters(
+SWIFT_CC(swift) void _swift_getGlobalRuntimeFunctionCounters(
     RuntimeFunctionCountersState *result) {
   StaticScopedReadLock lock(RuntimeGlobalFunctionCountersState.Lock);
   *result = RuntimeGlobalFunctionCountersState.State;
 }
 
 /// Set the global runtime state of function pointers from a provided state.
-void _swift_setGlobalRuntimeFunctionCounters(
+SWIFT_CC(swift) void _swift_setGlobalRuntimeFunctionCounters(
     RuntimeFunctionCountersState *state) {
   StaticScopedWriteLock lock(RuntimeGlobalFunctionCountersState.Lock);
   RuntimeGlobalFunctionCountersState.State = *state;
@@ -162,19 +162,19 @@ void _swift_setGlobalRuntimeFunctionCounters(
 /// Return the names of the runtime functions being tracked.
 /// Their order is the same as the order of the counters in the
 /// RuntimeObjectState structure. All these strings are null terminated.
-const char **_swift_getRuntimeFunctionNames() {
+SWIFT_CC(swift) const char **_swift_getRuntimeFunctionNames() {
   return RuntimeFunctionNames;
 }
 
 /// Return the offsets of the runtime function counters being tracked.
 /// Their order is the same as the order of the counters in the
 /// RuntimeObjectState structure.
-const uint16_t *_swift_getRuntimeFunctionCountersOffsets() {
+SWIFT_CC(swift) const uint16_t *_swift_getRuntimeFunctionCountersOffsets() {
   return RuntimeFunctionCountersOffsets;
 }
 
 /// Return the number of runtime functions being tracked.
-uint64_t _swift_getNumRuntimeFunctionCounters() {
+SWIFT_CC(swift) uint64_t _swift_getNumRuntimeFunctionCounters() {
   return ID_LastRuntimeFunctionName;
 }
 
@@ -202,7 +202,7 @@ void _swift_dumpObjectsRuntimeFunctionPointers() {
 
 /// Set mode for global runtime function counters.
 /// Return the old value of this flag.
-int _swift_setGlobalRuntimeFunctionCountersMode(int mode) {
+SWIFT_CC(swift) int _swift_setGlobalRuntimeFunctionCountersMode(int mode) {
   int oldMode = UpdateGlobalRuntimeFunctionCounters;
   UpdateGlobalRuntimeFunctionCounters = mode ? 1 : 0;
   return oldMode;
@@ -210,7 +210,7 @@ int _swift_setGlobalRuntimeFunctionCountersMode(int mode) {
 
 /// Set mode for per object runtime function counters.
 /// Return the old value of this flag.
-int _swift_setPerObjectRuntimeFunctionCountersMode(int mode) {
+SWIFT_CC(swift) int _swift_setPerObjectRuntimeFunctionCountersMode(int mode) {
   int oldMode = UpdatePerObjectRuntimeFunctionCounters;
   UpdatePerObjectRuntimeFunctionCounters = mode ? 1 : 0;
   return oldMode;

--- a/stdlib/public/runtime/RuntimeInvocationsTracking.h
+++ b/stdlib/public/runtime/RuntimeInvocationsTracking.h
@@ -61,47 +61,47 @@ using RuntimeFunctionCountersUpdateHandler =
 
 /// Get the runtime object state associated with an object and store it
 /// into the result.
-SWIFT_RUNTIME_EXPORT void
+SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT void
 _swift_getObjectRuntimeFunctionCounters(HeapObject *object,
                                         RuntimeFunctionCountersState *result);
 
 /// Get the global runtime state containing the total numbers of invocations for
 /// each runtime function of interest and store it into the result.
-SWIFT_RUNTIME_EXPORT void _swift_getGlobalRuntimeFunctionCounters(
+SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT void _swift_getGlobalRuntimeFunctionCounters(
     swift::RuntimeFunctionCountersState *result);
 
 /// Return the names of the runtime functions being tracked.
 /// Their order is the same as the order of the counters in the
 /// RuntimeObjectState structure.
-SWIFT_RUNTIME_EXPORT const char **_swift_getRuntimeFunctionNames();
+SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT const char **_swift_getRuntimeFunctionNames();
 
 /// Return the offsets of the runtime function counters being tracked.
 /// Their order is the same as the order of the counters in the
 /// RuntimeFunctionCountersState structure.
-SWIFT_RUNTIME_EXPORT const uint16_t *_swift_getRuntimeFunctionCountersOffsets();
+SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT const uint16_t *_swift_getRuntimeFunctionCountersOffsets();
 
 /// Return the number of runtime functions being tracked.
-SWIFT_RUNTIME_EXPORT uint64_t _swift_getNumRuntimeFunctionCounters();
+SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT uint64_t _swift_getNumRuntimeFunctionCounters();
 
 /// Dump all per-object runtime function pointers.
 SWIFT_RUNTIME_EXPORT void _swift_dumpObjectsRuntimeFunctionPointers();
 
 /// Set mode for global runtime function counters.
 /// Return the old value of this flag.
-SWIFT_RUNTIME_EXPORT int
+SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT int
 _swift_setPerObjectRuntimeFunctionCountersMode(int mode);
 
 /// Set mode for per object runtime function counters.
 /// Return the old value of this flag.
-SWIFT_RUNTIME_EXPORT int _swift_setGlobalRuntimeFunctionCountersMode(int mode);
+SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT int _swift_setGlobalRuntimeFunctionCountersMode(int mode);
 
 /// Set the global runtime state of function pointers from a provided state.
-SWIFT_RUNTIME_EXPORT void _swift_setGlobalRuntimeFunctionCounters(
+SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT void _swift_setGlobalRuntimeFunctionCounters(
     swift::RuntimeFunctionCountersState *state);
 
 /// Set the runtime object state associated with an object from a provided
 /// state.
-SWIFT_RUNTIME_EXPORT void
+SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT void
 _swift_setObjectRuntimeFunctionCounters(HeapObject *object,
                                         RuntimeFunctionCountersState *state);
 


### PR DESCRIPTION
This change marks all functions called using swiftcc as swiftcc attribute.

Resolves SR-15188.

On most of architectures, C calling convention functions can be invoked using swiftcc.
 However on WebAssembly, swiftcc invocation strictly requires callee function is swiftcc to match the number of parameters with arguments.

Reference: https://reviews.llvm.org/D76049

cc: @jckarter 


**EDIT: 2020-04-13 1:37 JST**

Sorry for not explaining enough.

I mean that the all functions I changed are called using swiftcc by binaries built with currently shipped compilers.

For example, 
```swift
@_silgen_name("foo")
func foo()

foo()
```
the code is represented in that LLVM IR

```llvm
define i32 @main(i32, i8**) #0 {
entry:
  %2 = bitcast i8** %1 to i8*
  call swiftcc void @foo()
  ret i32 0
}

declare swiftcc void @foo() #0
```

As well as this example, the caller of functions that are defined with `silgen_name` attribute are called using swiftcc.
So I think we should define those functions with swiftcc attribute.

Especially on WebAssembly, these calling convention mismatches causes runtime error, so I want to correct the mismatches.