### PR TITLE
[Sema] Diagnose use of implementation-only property wrappers

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2651,14 +2651,14 @@ NOTE(construct_raw_representable_from_unwrapped_value,none,
      "construct %0 from unwrapped %1 value", (Type, Type))
 
 ERROR(decl_from_hidden_module,none,
-      "cannot use %0 %1 %select{here|"
+      "cannot use %0 %1 %select{here|as property wrapper here|"
       "in an extension with public or '@usableFromInline' members|"
       "in an extension with conditional conformances}2; "
       "%select{%3 has been imported as implementation-only|"
       "it is an SPI imported from %3}4",
       (DescriptiveDeclKind, DeclName, unsigned, Identifier, unsigned))
 ERROR(conformance_from_implementation_only_module,none,
-      "cannot use conformance of %0 to %1 %select{here|"
+      "cannot use conformance of %0 to %1 %select{here|as property wrapper here|"
       "in an extension with public or '@usableFromInline' members|"
       "in an extension with conditional conformances}2; %3 has been imported "
       "as implementation-only",

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1639,6 +1639,7 @@ class ExportabilityChecker : public DeclVisitor<ExportabilityChecker> {
   // diag::conformance_from_implementation_only_module.
   enum class Reason : unsigned {
     General,
+    PropertyWrapper,
     ExtensionWithPublicMembers,
     ExtensionWithConditionalConformances
   };
@@ -1836,6 +1837,11 @@ public:
       return;
 
     checkType(TP->getTypeLoc(), anyVar, getDiagnoser(anyVar));
+
+    // Check the property wrapper types.
+    for (auto attr : anyVar->getAttachedPropertyWrappers())
+      checkType(attr->getTypeLoc(), anyVar,
+                getDiagnoser(anyVar, Reason::PropertyWrapper));
   }
 
   void visitPatternBindingDecl(PatternBindingDecl *PBD) {

--- a/test/Sema/Inputs/implementation-only-import-in-decls-helper.swift
+++ b/test/Sema/Inputs/implementation-only-import-in-decls-helper.swift
@@ -18,4 +18,12 @@ public struct IntLike: ExpressibleByIntegerLiteral, Equatable {
   public init(integerLiteral: Int) {}
 }
 
+@propertyWrapper
+public struct BadWrapper {
+    public var wrappedValue: Int
+    public init(wrappedValue: Int) {
+        self.wrappedValue = wrappedValue
+    }
+}
+
 precedencegroup BadPrecedence {}

--- a/test/Sema/implementation-only-import-in-decls.swift
+++ b/test/Sema/implementation-only-import-in-decls.swift
@@ -46,6 +46,10 @@ public struct TestInit {
   public init<T>(where _: T) where T: BadProto {} // expected-error {{cannot use protocol 'BadProto' here; 'BADLibrary' has been imported as implementation-only}}
 }
 
+public struct TestPropertyWrapper {
+  @BadWrapper public var BadProperty: Int // expected-error {{cannot use struct 'BadWrapper' as property wrapper here; 'BADLibrary' has been imported as implementation-only}}
+}
+
 public protocol TestInherited: BadProto {} // expected-error {{cannot use protocol 'BadProto' here; 'BADLibrary' has been imported as implementation-only}}
 
 public protocol TestConstraintBase {

--- a/test/Serialization/Recovery/implementation-only-missing.swift
+++ b/test/Serialization/Recovery/implementation-only-missing.swift
@@ -74,8 +74,7 @@ public struct PublicStruct: LibProtocol {
 
   public init() { }
 
-  @IoiPropertyWrapper("some text")
-  public var wrappedVar: String
+  public var nonWrappedVar: String = "some text"
 }
 
 struct StructWithOverride: HiddenProtocolWithOverride {
@@ -87,6 +86,6 @@ struct StructWithOverride: HiddenProtocolWithOverride {
 import public_lib
 
 var s = PublicStruct()
-print(s.wrappedVar)
+print(s.nonWrappedVar)
 
 #endif


### PR DESCRIPTION
We already ban all structs from declaring that comes from implementation-only imports. Until now we missed property wrappers, they were just dropped in deserialization.

Resolves rdar://problem/59403617