### PR TITLE
Platform: alias math constants on Windows

### DIFF
--- a/stdlib/public/Platform/msvcrt.swift
+++ b/stdlib/public/Platform/msvcrt.swift
@@ -84,3 +84,6 @@ public let DBL_MIN = Double.leastNormalMagnitude
 @available(swift, deprecated: 3.0, message: "Please use 'Double.leastNonzeroMagnitude' or '.leastNonzeroMagnitude'.")
 public let DBL_TRUE_MIN = Double.leastNonzeroMagnitude
 
+public let M_LN2 = ucrt.M_LN2
+public let M_LOG10E = ucrt.M_LOG10E
+public let M_2_SQRTPI = ucrt.M_2_SQRTPI


### PR DESCRIPTION
The non-C/C++ standard defined math constants require
`-Xcc -D_USE_MATH_DEFINES` when using the `ucrt` module.  Instead,
provide them through the wrapper `MSVCRT` module as aliases so that the
user does not need to be aware of this in practice.

Repairs the Windows build of `_Differentiation`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
