### PR TITLE
[sil] Add [move] option to copy_value instruction.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -3931,7 +3931,7 @@ copy_value
 
    sil-instruction ::= 'copy_value' sil-operand
 
-   %1 = copy_value %0 : $A
+   %1 = copy_value '[move]'? %0 : $A
 
 Performs a copy of a loadable value as if by the value's type lowering and
 returns the copy. The returned copy semantically is a value that is completely
@@ -3949,6 +3949,11 @@ independent of the operand. In terms of specific types:
 
 In ownership qualified functions, a ``copy_value`` produces a +1 value that must
 be consumed at most once along any path through the program.
+
+With the optional ``[move]`` attribute, instead of the above behavior,
+``copy_value [move]`` is equivilant to creating a call to the static member
+function ``move`` on the operand, destroying the operand, and propigating the
+returned value.
 
 release_value
 `````````````

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1122,12 +1122,17 @@ public:
                       ObjCProtocolInst(getSILDebugLocation(Loc), P, Ty));
   }
 
-  CopyValueInst *createCopyValue(SILLocation Loc, SILValue operand) {
+  CopyValueInst *createCopyValue(SILLocation Loc, SILValue operand,
+                                 bool isMove) {
     assert(!operand->getType().isTrivial(getFunction()) &&
            "Should not be passing trivial values to this api. Use instead "
            "emitCopyValueOperation");
     return insert(new (getModule())
-                      CopyValueInst(getSILDebugLocation(Loc), operand));
+                      CopyValueInst(getSILDebugLocation(Loc), operand, isMove));
+  }
+
+  CopyValueInst *createCopyValue(SILLocation loc, SILValue operand) {
+    return createCopyValue(loc, operand, false);
   }
 
   DestroyValueInst *createDestroyValue(SILLocation Loc, SILValue operand) {

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -6567,10 +6567,18 @@ public:
 class CopyValueInst
     : public UnaryInstructionBase<SILInstructionKind::CopyValueInst,
                                   SingleValueInstruction> {
+
   friend class SILBuilder;
 
-  CopyValueInst(SILDebugLocation DebugLoc, SILValue operand)
-      : UnaryInstructionBase(DebugLoc, operand, operand->getType()) {}
+  CopyValueInst(SILDebugLocation DebugLoc, SILValue operand, bool isMove)
+      : UnaryInstructionBase(DebugLoc, operand, operand->getType()) {
+    SILInstruction::Bits.CopyValueInst.IsMove = unsigned(isMove);
+  }
+
+public:
+  bool isMove() const {
+    return IsTake_t(SILInstruction::Bits.CopyValueInst.IsMove);
+  }
 };
 
 #define UNCHECKED_REF_STORAGE(Name, ...)                                       \

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -248,6 +248,8 @@ protected:
     friend class StoreReferenceInstBase
   );
 
+  SWIFT_INLINE_BITFIELD(CopyValueInst, SingleValueInstruction, 1, IsMove : 1);
+
   SWIFT_INLINE_BITFIELD(BeginAccessInst, SingleValueInstruction,
                         NumSILAccessKindBits+NumSILAccessEnforcementBits
                         + 1 + 1,

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3479,6 +3479,7 @@ void IRGenSILFunction::visitRetainValueAddrInst(swift::RetainValueAddrInst *i) {
 }
 
 void IRGenSILFunction::visitCopyValueInst(swift::CopyValueInst *i) {
+  assert(!i->isMove() && "copy_value with move is not valid in canonical SIL");
   Explosion in = getLoweredExplosion(i->getOperand());
   Explosion out;
   cast<LoadableTypeInfo>(getTypeInfo(i->getOperand()->getType()))

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -2945,7 +2945,6 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     UNARY_INSTRUCTION(CopyBlock)
     UNARY_INSTRUCTION(IsUnique)
     UNARY_INSTRUCTION(DestroyAddr)
-    UNARY_INSTRUCTION(CopyValue)
     UNARY_INSTRUCTION(DestroyValue)
     UNARY_INSTRUCTION(EndBorrow)
     UNARY_INSTRUCTION(DestructureStruct)
@@ -3018,6 +3017,21 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     }
 
     ResultVal = B.createUncheckedOwnershipConversion(InstLoc, Val, RHSKind);
+    break;
+  }
+
+  case SILInstructionKind::CopyValueInst: {
+    bool isMove;
+    SourceLoc valueLoc;
+    SILValue value;
+
+    if (parseSILOptional(isMove, *this, "move") ||
+        parseTypedValueRef(value, valueLoc, B) ||
+        parseSILDebugLocation(InstLoc, B))
+      return true;
+
+    ResultVal = B.createCopyValue(InstLoc, value, isMove);
+
     break;
   }
 

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -260,7 +260,6 @@ CONSTANT_OR_NONE_OWNERSHIP_INST(Owned, MustBeInvalidated,
     return Map::allLive();                                                     \
   }
 ACCEPTS_ANY_OWNERSHIP_INST(BeginBorrow)
-ACCEPTS_ANY_OWNERSHIP_INST(CopyValue)
 ACCEPTS_ANY_OWNERSHIP_INST(DebugValue)
 ACCEPTS_ANY_OWNERSHIP_INST(FixLifetime)
 ACCEPTS_ANY_OWNERSHIP_INST(UncheckedBitwiseCast) // Is this right?
@@ -832,6 +831,23 @@ OperandOwnershipKindClassifier::visitKeyPathInst(KeyPathInst *I) {
   return Map::compatibilityMap(
        ValueOwnershipKind::Owned, UseLifetimeConstraint::MustBeInvalidated);
 }
+
+ OperandOwnershipKindMap
+ OperandOwnershipKindClassifier::visitCopyValueInst(CopyValueInst *copy) {
+  // Accept all value ownership kinds. If move, must be invalidated.
+  Otherwise,
+  // must be live.
+  OperandOwnershipKindMap map;
+  unsigned index = 0;
+  unsigned end = unsigned(ValueOwnershipKind::LastValueOwnershipKind) + 1;
+  while (index != end) {
+    map.add(ValueOwnershipKind(index),
+            copy->isMove() ? UseLifetimeConstraint::MustBeInvalidated
+                           : UseLifetimeConstraint::MustBeLive);
+    ++index;
+  }
+  return map;
+//}
 
 //===----------------------------------------------------------------------===//
 //                            Builtin Use Checker

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1625,6 +1625,8 @@ public:
   }
 
   void visitCopyValueInst(CopyValueInst *I) {
+    if (I->isMove())
+      *this << "[move] ";
     *this << getIDAndType(I->getOperand());
   }
 

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2287,6 +2287,14 @@ public:
     require(!fnConv.useLoweredAddresses() || F.hasOwnership(),
             "copy_value is only valid in functions with qualified "
             "ownership");
+    if (!I->isMove())
+      return;
+
+    DominanceInfo domInfo(I->getFunction());
+    for (auto *use : I->getOperand()->getUses()) {
+      require(domInfo.dominates(use->getUser(), I),
+              "Operand may not be used after being moved from");
+    }
   }
 
   void checkDestroyValueInst(DestroyValueInst *I) {

--- a/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
@@ -159,6 +159,9 @@ bool OwnershipModelEliminatorVisitor::visitCopyValueInst(CopyValueInst *CVI) {
   if (CVI->getType().isAddressOnly(B.getFunction()))
     return false;
 
+  assert(!CVI->isMove() &&
+         "copy_value with move is not valid in canonical SIL");
+
   // Now that we have set the unqualified ownership flag, destroy value
   // operation will delegate to the appropriate strong_release, etc.
   B.emitCopyValueOperation(CVI->getLoc(), CVI->getOperand());

--- a/test/SILOptimizer/copy_value_move.sil
+++ b/test/SILOptimizer/copy_value_move.sil
@@ -1,0 +1,87 @@
+// RUN: %swift %s -emit-sil -module-name run | %FileCheck %s
+
+sil_stage raw
+
+import Builtin
+
+class Obj { }
+
+struct Foo {
+  @_hasStorage @_hasInitialValue var obj: Obj { get set }
+  public static func move(_ f: Foo) -> Foo
+  init()
+}
+
+// static Foo.move(_:)
+sil [ossa] @$s3run3FooV4moveyA2CFZ : $@convention(method) (@guaranteed Foo, @thin Foo.Type) -> @owned Foo
+
+// CHECK-LABEL: sil hidden @simple_test
+// CHECK-NOT: copy_value
+// CHECK: bb0
+// CHECK-NEXT: function_ref
+// CHECK-NEXT: [[FN:%.*]] = function_ref @$s3run3FooV4moveyA2CFZ
+// CHECK-NEXT: metatype
+// CHECK-NEXT: [[RV:%.*]] = apply [[FN]](%0
+// CHECK-NEXT: release_value %0
+// CHECK-NEXT: release_value [[RV]]
+// CHECK-LABEL: end sil function 'simple_test'
+sil hidden [ossa] @simple_test : $@convention(thin) (@owned Foo) -> () {
+bb0(%0 : @owned $Foo):
+  %5 = copy_value [move] %0 : $Foo
+  destroy_value %5 : $Foo
+  %14 = tuple ()
+  return %14 : $()
+}
+
+struct Bar {
+  @_hasStorage @_hasInitialValue var obj: Obj { get set }
+  public static func move(_ f: __owned Bar) -> Bar
+  init()
+}
+
+// static Bar.move(_:)
+sil [ossa] @$s3run3BarV4moveyA2CnFZ : $@convention(method) (@owned Bar, @thin Bar.Type) -> @owned Bar
+
+// CHECK-LABEL: sil hidden @test_owned_move
+// CHECK-NOT: copy_value
+// CHECK: bb0
+// CHECK-NEXT: function_ref
+// CHECK-NEXT: [[FN:%.*]] = function_ref @$s3run3BarV4moveyA2CnFZ
+// CHECK-NEXT: metatype
+// CHECK-NEXT: [[RV:%.*]] = apply [[FN]](%0
+// CHECK-NEXT: release_value [[RV]]
+// CHECK-LABEL: end sil function 'test_owned_move'
+sil hidden [ossa] @test_owned_move : $@convention(thin) (@owned Bar) -> () {
+bb0(%0 : @owned $Bar):
+  %5 = copy_value [move] %0 : $Bar
+  destroy_value %5 : $Bar
+  %14 = tuple ()
+  return %14 : $()
+}
+
+struct Gen<T> {
+  @_hasStorage @_hasInitialValue var obj: Obj { get set }
+  public static func move(_ f: Gen<T>) -> Gen<T>
+  init()
+}
+
+// static Gen.move(_:)
+sil [ossa] @$s3run3GenV4moveyACyxGAEFZ : $@convention(method) <T> (@guaranteed Gen<T>, @thin Gen<T>.Type) -> @owned Gen<T>
+
+// CHECK-LABEL: sil hidden @test_generic
+// CHECK-NOT: copy_value
+// CHECK: bb0
+// CHECK-NEXT: function_ref
+// CHECK-NEXT: [[FN:%.*]] = function_ref @$s3run3GenV4moveyACyxGAEFZ
+// CHECK-NEXT: metatype
+// CHECK-NEXT: [[RV:%.*]] = apply [[FN]]<T>(%0
+// CHECK-NEXT: release_value %0
+// CHECK-NEXT: release_value [[RV]]
+// CHECK-LABEL: end sil function 'test_generic'
+sil hidden [ossa] @test_generic : $@convention(thin) <T> (@owned Gen<T>) -> () {
+bb0(%0 : @owned $Gen<T>):
+  %2 = copy_value [move] %0 : $Gen<T>
+  destroy_value %2 : $Gen<T>
+  %5 = tuple ()
+  return %5 : $()
+}


### PR DESCRIPTION
This patch is the first step towards supporting move only types. It adds support for moving values in sil. 

Updating copy_value is a way to support move-only values, but I'm not sure it's the best way. Another way to add support would be a new `move_value` instruction. Or, we could emit a call to the move function in SILGen and have no move-related instructions. 

For me, this patch is about opening discussion for the implementation of move-only types more than anything else. My tentative plan is to implement an `@_moveonly` attribute next so that we can have an internal prototype (like with `__shared` and `__owned`). However, I think it would be beneficial to lay out a preliminary roadmap first. 

<!-- What's in this pull request? -->

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
