### PR TITLE
Revert "[PrintAsObjC] Don't include the module for empty extensions"

### DIFF
--- a/lib/PrintAsObjC/ModuleContentsWriter.cpp
+++ b/lib/PrintAsObjC/ModuleContentsWriter.cpp
@@ -400,9 +400,6 @@ public:
   }
 
   bool writeExtension(const ExtensionDecl *ED) {
-    if (printer.isEmptyExtensionDecl(ED))
-      return true;
-
     bool allRequirementsSatisfied = true;
 
     const ClassDecl *CD = ED->getSelfClassDecl();

--- a/test/PrintAsObjC/Inputs/custom-modules/MiserablePileOfSecrets.h
+++ b/test/PrintAsObjC/Inputs/custom-modules/MiserablePileOfSecrets.h
@@ -3,6 +3,3 @@
 @interface NSObject (Secrets)
 - (void)secretMethod;
 @end
-
-@interface SecretClass : NSObject
-@end

--- a/test/PrintAsObjC/imports.swift
+++ b/test/PrintAsObjC/imports.swift
@@ -67,7 +67,3 @@ import MostlyPrivate2_Private
 @objc public class TestSubclass: NSObject {
   @_implementationOnly public override func secretMethod() {}
 }
-
-extension SecretClass {
-  private func somethingThatShouldNotBeIncluded() {}
-}


### PR DESCRIPTION
This reverts commit 8f01b2c8f8ccb2b2d5337029df1aa85ed994242c. While it is absolutely reasonable to prune the generated Swift header by not emitting unnecessary module imports,
some Objective-C code has come to rely on these. Fixes rdar://problem/61415191