### PR TITLE
[DiagnosticVerifier] Fix ASAN issue in the verifier

### DIFF
--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -589,10 +589,10 @@ DiagnosticVerifier::Result DiagnosticVerifier::verifyFile(unsigned BufferID) {
         -> ActualFixitsPhrase {
       std::string actualFixitsStr = renderFixits(actualFixits, InputFile);
 
-      auto phrase = Twine("actual fix-it") +
-                    (actualFixits.size() >= 2 ? "s" : "") +
-                    " seen: " + actualFixitsStr;
-      return ActualFixitsPhrase{phrase.str(), actualFixitsStr};
+      return ActualFixitsPhrase{(Twine("actual fix-it") +
+                                 (actualFixits.size() >= 2 ? "s" : "") +
+                                 " seen: " + actualFixitsStr).str(),
+                                actualFixitsStr};
     };
 
     auto emitFixItsError = [&](const char *location, const Twine &message,


### PR DESCRIPTION
Missed this when reviewing #30791 , but ASAN caught it here: https://ci.swift.org//job/oss-swift-incremental-ASAN-RA-osx/4602/consoleFull#-17223166953122a513-f36a-4c87-8ed7-cbc36a1ec144

This would manifest as a stack-use-after-scope because an `llvm::Twine` can't be safely stored.