### PR TITLE
[AutoDiff] Requestify `@derivative` original function resolution.

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2133,7 +2133,8 @@ public:
 /// Resolves the referenced original declaration for a `@derivative` attribute.
 class DerivativeAttrOriginalDeclRequest
     : public SimpleRequest<DerivativeAttrOriginalDeclRequest,
-                           AbstractFunctionDecl *(DerivativeAttr *),
+                           AbstractFunctionDecl *(DerivativeAttr *,
+                                                  AbstractFunctionDecl *),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -2142,8 +2143,8 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  AbstractFunctionDecl *evaluate(Evaluator &evaluator,
-                                 DerivativeAttr *attr) const;
+  AbstractFunctionDecl *evaluate(Evaluator &evaluator, DerivativeAttr *attr,
+                                 AbstractFunctionDecl *derivative) const;
 
 public:
   // Caching.

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -791,7 +791,7 @@ void SILGenModule::emitDifferentiabilityWitnessesForFunction(
         vjp = F;
         break;
       }
-      auto *origAFD = derivAttr->getOriginalFunction(getASTContext());
+      auto *origAFD = derivAttr->getOriginalFunction(AFD);
       auto origDeclRef =
           SILDeclRef(origAFD).asForeign(requiresForeignEntryPoint(origAFD));
       auto *origFn = getFunction(origDeclRef, NotForDefinition);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4390,10 +4390,9 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
           parametersBitVector[i] = parameters[i];
         auto *indices = IndexSubset::get(ctx, parametersBitVector);
 
-        auto *derivativeAttr =
-            DerivativeAttr::create(ctx, isImplicit, SourceLoc(), SourceRange(),
-                                   /*baseType*/ nullptr, origName, indices);
-        derivativeAttr->setOriginalFunctionResolver(&MF, origDeclId);
+        auto *derivativeAttr = DerivativeAttr::create(
+            ctx, isImplicit, SourceLoc(), SourceRange(),
+            /*baseType*/ nullptr, origName, indices, &MF, origDeclId);
         derivativeAttr->setDerivativeKind(*derivativeKind);
         Attr = derivativeAttr;
         break;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2420,14 +2420,10 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     case DAK_Derivative: {
       auto abbrCode = S.DeclTypeAbbrCodes[DerivativeDeclAttrLayout::Code];
       auto *attr = cast<DerivativeAttr>(DA);
-      auto &ctx = S.getASTContext();
-      assert(attr->getOriginalFunction(ctx) &&
-             "`@derivative` attribute should have original declaration set "
-             "during construction or parsing");
       auto origName = attr->getOriginalFunctionName().Name.getBaseName();
       IdentifierID origNameId = S.addDeclBaseNameRef(origName);
-      DeclID origDeclID = S.addDeclRef(attr->getOriginalFunction(ctx));
-      auto derivativeKind =
+      DeclID origDeclID = S.addDeclRef(D);
+      auto rawDerivativeKind =
           getRawStableAutoDiffDerivativeFunctionKind(attr->getDerivativeKind());
       auto *parameterIndices = attr->getParameterIndices();
       assert(parameterIndices && "Parameter indices must be resolved");
@@ -2436,7 +2432,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
         paramIndicesVector.push_back(parameterIndices->contains(i));
       DerivativeDeclAttrLayout::emitRecord(
           S.Out, S.ScratchRecord, abbrCode, attr->isImplicit(), origNameId,
-          origDeclID, derivativeKind, paramIndicesVector);
+          origDeclID, rawDerivativeKind, paramIndicesVector);
       return;
     }
 
@@ -4866,7 +4862,7 @@ static void recordDerivativeFunctionConfig(
          attr->getDerivativeGenericSignature()});
   }
   for (auto *attr : AFD->getAttrs().getAttributes<DerivativeAttr>()) {
-    auto *origAFD = attr->getOriginalFunction(ctx);
+    auto *origAFD = attr->getOriginalFunction(AFD);
     auto mangledName = ctx.getIdentifier(Mangler.mangleDeclAsUSR(origAFD, ""));
     derivativeConfigs[mangledName].insert(
         {ctx.getIdentifier(attr->getParameterIndices()->getString()),

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -666,7 +666,7 @@ void TBDGenVisitor::visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
   for (const auto *derivativeAttr :
        AFD->getAttrs().getAttributes<DerivativeAttr>())
     addDerivativeConfiguration(
-        derivativeAttr->getOriginalFunction(AFD->getASTContext()),
+        derivativeAttr->getOriginalFunction(AFD),
         AutoDiffConfig(derivativeAttr->getParameterIndices(),
                        IndexSubset::get(AFD->getASTContext(), 1, {0}),
                        AFD->getGenericSignature()));

--- a/test/AutoDiff/Serialization/Inputs/derivative_attr_cross_module.swift
+++ b/test/AutoDiff/Serialization/Inputs/derivative_attr_cross_module.swift
@@ -1,0 +1,6 @@
+import _Differentiation
+
+@derivative(of: id)
+func derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}

--- a/test/AutoDiff/Serialization/derivative_attr_cross_module.swift
+++ b/test/AutoDiff/Serialization/derivative_attr_cross_module.swift
@@ -1,0 +1,11 @@
+// REQUIRES: asserts
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -module-name Multi -o %t/multi-file.swiftmodule -primary-file %s %S/Inputs/derivative_attr_cross_module.swift
+// RUN: %target-swift-frontend -emit-module -module-name Multi -o %t/multi-file-2.swiftmodule %s -primary-file %S/Inputs/derivative_attr_cross_module.swift
+
+// Check that merge-modules does not crash regardless of the order of inputs.
+// RUN: %target-swift-frontend -emit-module -module-name Multi %t/multi-file.swiftmodule %t/multi-file-2.swiftmodule -o %t -print-stats 2>&1
+// RUN: %target-swift-frontend -emit-module -module-name Multi %t/multi-file-2.swiftmodule %t/multi-file.swiftmodule -o %t -print-stats 2>&1
+
+func id(_ x: Float) -> Float { x }


### PR DESCRIPTION
Fully requestify `DerivativeAttr` referenced original function resolution.
Remove mutable state: `DerivativeAttr::OriginalFunction`.

Resolves SR-12566.