### PR TITLE
AutoDiff: Android, Windows does not support FP80

### DIFF
--- a/test/AutoDiff/stdlib/floating_point.swift.gyb
+++ b/test/AutoDiff/stdlib/floating_point.swift.gyb
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swiftgyb(-Xfrontend -enable-experimental-forward-mode-differentiation)
 // REQUIRES: executable_test
 
-#if (arch(i386) || arch(x86_64)) && !os(Windows)
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
   typealias TestLiteralType = Float80
 #else
   typealias TestLiteralType = Double
@@ -31,7 +31,7 @@ func expectEqualWithTolerance<T>(_ expected: TestLiteralType, _ actual: T,
 %for Self in ['Float', 'Double', 'Float80']:
 
 %if Self == 'Float80':
-#if !os(Windows) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 %end
 
 FloatingPointDerivativeTests.test("${Self}.+") {

--- a/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
+++ b/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
@@ -11,7 +11,7 @@
 #error("Unsupported platform")
 #endif
 
-#if (arch(i386) || arch(x86_64)) && !os(Windows)
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
   typealias TestLiteralType = Float80
 #else
   typealias TestLiteralType = Double


### PR DESCRIPTION
Correct the condition for FP80.  This should have no real impact on
Android as the tests are not currently executed.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
