### PR TITLE
AutoDiff: disable the test cases for FP80

### DIFF
--- a/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
+++ b/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
@@ -54,6 +54,10 @@ where T == T.TangentVector {
 %for op in ['derivative', 'gradient']:
 %for T in ['Float', 'Float80']:
 
+%if T == 'Float80':
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+%end
+
 DerivativeTests.test("${op}_${T}") {
   expectEqualWithTolerance(7.3890560989306502274, ${op}(at: 2 as ${T}, in: exp))
   expectEqualWithTolerance(2.772588722239781145, ${op}(at: 2 as ${T}, in: exp2))
@@ -111,6 +115,11 @@ DerivativeTests.test("${op}_${T}") {
     }
   }
 }
+
+%if T == 'Float80':
+#endif
+%end
+
 %end # for T in ['Float', 'Float80']:
 %end # for op in ['derivative', 'gradient']:
 


### PR DESCRIPTION
The FP80 tests should not be built on Android or Windows.  This fixes
the Windows run of the test.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
