### PR TITLE
AutoDiff: repair the cross-module-differentiation on Windows

### DIFF
--- a/test/AutoDiff/validation-test/cross_module_differentiation.swift
+++ b/test/AutoDiff/validation-test/cross_module_differentiation.swift
@@ -1,7 +1,9 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -working-directory %t -parse-as-library -emit-module -module-name cross_module_differentiation_other -emit-module-path %t/cross_module_differentiation_other.swiftmodule -emit-library -static %S/Inputs/cross_module_differentiation_other.swift
-// RUN: %target-build-swift -I%t -L%t %s -o %t/a.out -lcross_module_differentiation_other
-// RUN: %target-run %t/a.out
+// RUN: %target-build-swift-dylib(%t/%target-library-name(cross_module_differentiation_other)) %S/Inputs/cross_module_differentiation_other.swift -emit-module -emit-module-path %t/cross_module_differentiation_other.swiftmodule -module-name cross_module_differentiation_other
+// RUN: %target-build-swift -I%t -L%t %s -o %t/a.out -lcross_module_differentiation_other %target-rpath(%t)
+// RUN: %target-codesign %t/a.out
+// RUN: %target-codesign %t/%target-library-name(cross_module_differentiation_other)
+// RUN: %target-run %t/a.out %t/%target-library-name(cross_module_differentiation_other)
 // REQUIRES: executable_test
 
 // TF-1025: Test differentiability witness linkage for `PublicNonABI` original functions.


### PR DESCRIPTION
Make the cross-module differentiation test work on Windows by converting
to a shared library to run the test.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
