### PR TITLE
Convert a clang::Module to non-const to account for a clang API change

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3310,7 +3310,7 @@ ClangModuleUnit::ClangModuleUnit(ModuleDecl &M,
     clangModule(clangModule) {
   // Capture the file metadata before it goes away.
   if (clangModule)
-    ASTSourceDescriptor = {*clangModule};
+    ASTSourceDescriptor = {*const_cast<clang::Module *>(clangModule)};
 }
 
 StringRef ClangModuleUnit::getModuleDefiningPath() const {


### PR DESCRIPTION
An upstream clang changed ASTSourceDescriptor to not have a const
Module pointer. const_cast here to make this agree.

(cherry picked from commit a49bceeedf2875c6542812b0dc03ae7e382246e1)
