### PR TITLE
[build] re-enable setting soname for Android shared libraries

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1324,14 +1324,8 @@ function(add_swift_target_library name)
       list(APPEND swiftlib_link_flags_all "-Wl,-z,defs")
     endif()
     # Setting back linker flags which are not supported when making Android build on macOS cross-compile host.
-    if(SWIFTLIB_SHARED)
-      if(sdk IN_LIST SWIFT_APPLE_PLATFORMS)
-        list(APPEND swiftlib_link_flags_all "-dynamiclib -Wl,-headerpad_max_install_names")
-      elseif(${sdk} STREQUAL ANDROID)
-        list(APPEND swiftlib_link_flags_all "-shared")
-        # TODO: Instead of `lib${name}.so` find variable or target property which already have this value.
-        list(APPEND swiftlib_link_flags_all "-Wl,-soname,lib${name}.so")
-      endif()
+    if(SWIFTLIB_SHARED AND sdk IN_LIST SWIFT_APPLE_PLATFORMS)
+      list(APPEND swiftlib_link_flags_all "-dynamiclib -Wl,-headerpad_max_install_names")
     endif()
 
     set(sdk_supported_archs
@@ -1471,6 +1465,13 @@ function(add_swift_target_library name)
       endif()
 
      list(APPEND swiftlib_c_compile_flags_all "-DSWIFT_TARGET_LIBRARY_NAME=${name}")
+
+      # Setting back linker flags which are not supported when making Android build on macOS cross-compile host.
+      if(SWIFTLIB_SHARED AND ${sdk} STREQUAL ANDROID)
+        list(APPEND swiftlib_link_flags_all "-shared")
+        # TODO: Instead of `lib${name}.so` find variable or target property which already have this value.
+        list(APPEND swiftlib_link_flags_all "-Wl,-soname,lib${name}.so")
+      endif()
 
       # Add this library variant.
       _add_swift_target_library_single(


### PR DESCRIPTION
Tries to do the same as #30020, but given that was reverted for some "internal CI failure" at Apple, #30846, this one only adds back the flags for Android. This way, they can re-enable the remaining dropped Apple and ELF linker flags at their own pace.

@compnerd, this ~should~ fixes the stdlib and other target libraries for Android, let me know.