### PR TITLE
Several compile time fixes related to large string arrays.

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -73,6 +73,9 @@ public:
   /// Controls whether or not paranoid verification checks are run.
   bool VerifyAll = false;
 
+  /// If true, no SIL verification is done at all.
+  bool VerifyNone = false;
+
   /// Are we debugging sil serialization.
   bool DebugSerialization = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -550,6 +550,9 @@ def sil_merge_partial_modules : Flag<["-"], "sil-merge-partial-modules">,
 def sil_verify_all : Flag<["-"], "sil-verify-all">,
   HelpText<"Verify SIL after each transform">;
   
+def sil_verify_none : Flag<["-"], "sil-verify-none">,
+  HelpText<"Completely disable SIL verification">;
+  
 def verify_all_substitution_maps : Flag<["-"], "verify-all-substitution-maps">,
   HelpText<"Verify all SubstitutionMaps on construction">;
 

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -110,6 +110,10 @@ public:
     InstList.splice(end(), Other->InstList);
   }
 
+  void spliceAtBegin(SILBasicBlock *Other) {
+    InstList.splice(begin(), Other->InstList);
+  }
+
   bool empty() const { return InstList.empty(); }
   iterator begin() { return InstList.begin(); }
   iterator end() { return InstList.end(); }
@@ -201,6 +205,8 @@ public:
   SILArgument *getArgument(unsigned i) { return ArgumentList[i]; }
 
   void cloneArgumentList(SILBasicBlock *Other);
+
+  void moveArgumentList(SILBasicBlock *from);
 
   /// Erase a specific argument from the arg list.
   void eraseArgument(int Index);

--- a/include/swift/SIL/SILInstructionWorklist.h
+++ b/include/swift/SIL/SILInstructionWorklist.h
@@ -72,6 +72,9 @@ public:
   /// Returns true if the worklist is empty.
   bool isEmpty() const { return worklist.empty(); }
 
+  /// Returns the number of elements in the worklist.
+  unsigned size() const { return worklist.size(); }
+
   /// Add the specified instruction to the worklist if it isn't already in it.
   void add(SILInstruction *instruction) {
     if (worklist.insert(instruction).second) {

--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -1045,8 +1045,7 @@ private:
   /// If \p ai is an optimizable @_semantics("array.uninitialized") call, return
   /// valid call information.
   ArrayUninitCall
-  canOptimizeArrayUninitializedCall(ApplyInst *ai,
-                                    const ConnectionGraph *conGraph);
+  canOptimizeArrayUninitializedCall(ApplyInst *ai);
 
   /// Return true of this tuple_extract is the result of an optimizable
   /// @_semantics("array.uninitialized") call.

--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -652,6 +652,9 @@ public:
     /// True if this is a summary graph.
     bool isSummaryGraph;
 
+    /// True if the graph could be computed.
+    bool valid = true;
+
     /// Track the currently active intrusive worklist -- one at a time.
     CGNodeWorklist *activeWorklist = nullptr;
 
@@ -859,6 +862,22 @@ public:
     bool forwardTraverseDefer(CGNode *startNode, CGNodeVisitor &&visitor);
 
   public:
+  
+    /// Returns true if the graph could be computed.
+    ///
+    /// For very large functions (> 10000 nodes), graphs are not cumputed to
+    /// avoid quadratic complexity of the node merging algorithm.
+    bool isValid() const {
+      assert((valid || isEmpty()) && "invalid graph must not contain nodes");
+      return valid;
+    }
+    
+    /// Invalides the graph in case it's getting too large.
+    void invalidate() {
+      clear();
+      valid = false;
+    }
+  
     /// Get the content node pointed to by \p ptrVal.
     ///
     /// If \p ptrVal cannot be mapped to a node, return nullptr.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -984,6 +984,7 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   Opts.DisableSILPerfOptimizations |= Args.hasArg(OPT_disable_sil_perf_optzns);
   Opts.CrossModuleOptimization |= Args.hasArg(OPT_CrossModuleOptimization);
   Opts.VerifyAll |= Args.hasArg(OPT_sil_verify_all);
+  Opts.VerifyNone |= Args.hasArg(OPT_sil_verify_none);
   Opts.DebugSerialization |= Args.hasArg(OPT_sil_debug_serialization);
   Opts.EmitVerboseSIL |= Args.hasArg(OPT_emit_verbose_sil);
   Opts.EmitSortedSIL |= Args.hasArg(OPT_emit_sorted_sil);

--- a/lib/SIL/IR/SILBasicBlock.cpp
+++ b/lib/SIL/IR/SILBasicBlock.cpp
@@ -142,6 +142,13 @@ void SILBasicBlock::cloneArgumentList(SILBasicBlock *Other) {
   }
 }
 
+void SILBasicBlock::moveArgumentList(SILBasicBlock *from) {
+  ArgumentList = std::move(from->ArgumentList);
+  for (SILArgument *arg : getArguments()) {
+    arg->parentBlock = this;
+  }
+}
+
 SILFunctionArgument *
 SILBasicBlock::createFunctionArgument(SILType Ty, const ValueDecl *D,
                                       bool disableEntryBlockVerification) {

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -5232,13 +5232,20 @@ public:
 //                     Out of Line Verifier Run Functions
 //===----------------------------------------------------------------------===//
 
+static bool verificationEnabled(const SILModule &M) {
+#ifdef NDEBUG
+  if (!M.getOptions().VerifyAll)
+    return false;
+#endif
+  return !M.getOptions().VerifyNone;
+}
+
 /// verify - Run the SIL verifier to make sure that the SILFunction follows
 /// invariants.
 void SILFunction::verify(bool SingleFunction) const {
-#ifdef NDEBUG
-  if (!getModule().getOptions().VerifyAll)
+  if (!verificationEnabled(getModule()))
     return;
-#endif
+
   // Please put all checks in visitSILFunction in SILVerifier, not here. This
   // ensures that the pretty stack trace in the verifier is included with the
   // back trace when the verifier crashes.
@@ -5246,19 +5253,16 @@ void SILFunction::verify(bool SingleFunction) const {
 }
 
 void SILFunction::verifyCriticalEdges() const {
-#ifdef NDEBUG
-  if (!getModule().getOptions().VerifyAll)
+  if (!verificationEnabled(getModule()))
     return;
-#endif
+
   SILVerifier(*this, /*SingleFunction=*/true).verifyBranches(this);
 }
 
 /// Verify that a property descriptor follows invariants.
 void SILProperty::verify(const SILModule &M) const {
-#ifdef NDEBUG
-  if (!M.getOptions().VerifyAll)
+  if (!verificationEnabled(M))
     return;
-#endif
 
   auto *decl = getDecl();
   auto *dc = decl->getInnermostDeclContext();
@@ -5310,10 +5314,9 @@ void SILProperty::verify(const SILModule &M) const {
 
 /// Verify that a vtable follows invariants.
 void SILVTable::verify(const SILModule &M) const {
-#ifdef NDEBUG
-  if (!M.getOptions().VerifyAll)
+  if (!verificationEnabled(M))
     return;
-#endif
+
   for (auto &entry : getEntries()) {
     // All vtable entries must be decls in a class context.
     assert(entry.Method.hasDecl() && "vtable entry is not a decl");
@@ -5361,10 +5364,9 @@ void SILVTable::verify(const SILModule &M) const {
 
 /// Verify that a witness table follows invariants.
 void SILWitnessTable::verify(const SILModule &M) const {
-#ifdef NDEBUG
-  if (!M.getOptions().VerifyAll)
+  if (!verificationEnabled(M))
     return;
-#endif
+
   if (isDeclaration())
     assert(getEntries().empty() &&
            "A witness table declaration should not have any entries.");
@@ -5414,10 +5416,9 @@ void SILDefaultWitnessTable::verify(const SILModule &M) const {
 
 /// Verify that a global variable follows invariants.
 void SILGlobalVariable::verify() const {
-#ifdef NDEBUG
-  if (!getModule().getOptions().VerifyAll)
+  if (!verificationEnabled(getModule()))
     return;
-#endif
+
   assert(getLoweredType().isObject()
          && "global variable cannot have address type");
 
@@ -5439,10 +5440,9 @@ void SILGlobalVariable::verify() const {
 
 /// Verify the module.
 void SILModule::verify() const {
-#ifdef NDEBUG
-  if (!getOptions().VerifyAll)
+  if (!verificationEnabled(*this))
     return;
-#endif
+
   // Uniquing set to catch symbol name collisions.
   llvm::DenseSet<StringRef> symbolNames;
 

--- a/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
@@ -661,6 +661,16 @@ AliasResult AliasAnalysis::aliasInner(SILValue V1, SILValue V2,
 }
 
 bool AliasAnalysis::canApplyDecrementRefCount(FullApplySite FAS, SILValue Ptr) {
+  // If the connection graph is invalid due to a very large function, we also
+  // skip all other tests, which might take significant time for a very large
+  // function.
+  // This is a workaround for some quadratic complexity in ARCSequenceOpt.
+  // TODO: remove this check once ARCSequenceOpt is retired or the quadratic
+  // behavior is fixed.
+  auto *conGraph = EA->getConnectionGraph(FAS.getFunction());
+  if (!conGraph->isValid())
+    return true;
+
   // Treat applications of no-return functions as decrementing ref counts. This
   // causes the apply to become a sink barrier for ref count increments.
   if (FAS.isCalleeNoReturn())

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -403,6 +403,7 @@ void EscapeAnalysis::ConnectionGraph::clear() {
   UsePoints.clear();
   UsePointTable.clear();
   NodeAllocator.DestroyAll();
+  valid = true;
   assert(ToMerge.empty());
 }
 
@@ -416,6 +417,9 @@ void EscapeAnalysis::ConnectionGraph::clear() {
 // it's interior property.
 EscapeAnalysis::CGNode *
 EscapeAnalysis::ConnectionGraph::getNode(SILValue V) {
+  if (!isValid())
+    return nullptr;
+
   // Early filter obvious non-pointer opcodes.
   if (isa<FunctionRefInst>(V) || isa<DynamicFunctionRefInst>(V) ||
       isa<PreviousDynamicFunctionRefInst>(V))
@@ -1028,6 +1032,9 @@ CGNode *EscapeAnalysis::ConnectionGraph::getReturnNode() {
 
 bool EscapeAnalysis::ConnectionGraph::mergeFrom(ConnectionGraph *SourceGraph,
                                                 CGNodeMap &Mapping) {
+  assert(isValid());
+  assert(SourceGraph->isValid());
+
   // The main point of the merging algorithm is to map each content node in the
   // source graph to a content node in this (destination) graph. This may
   // require creating new nodes or merging existing nodes in this graph.
@@ -1492,6 +1499,11 @@ void EscapeAnalysis::ConnectionGraph::print(llvm::raw_ostream &OS) const {
 #ifndef NDEBUG
   OS << "CG of " << F->getName() << '\n';
 
+  if (!isValid()) {
+    OS << "  invalid\n";
+    return;
+  }
+
   // Assign the same IDs to SILValues as the SILPrinter does.
   llvm::DenseMap<const SILNode *, unsigned> InstToIDMap;
   InstToIDMap[nullptr] = (unsigned)-1;
@@ -1595,6 +1607,7 @@ void EscapeAnalysis::ConnectionGraph::verify() const {
   // Invalidating EscapeAnalysis clears the connection graph.
   if (isEmpty())
     return;
+  assert(isValid());
 
   verifyStructure();
 
@@ -1728,9 +1741,20 @@ void EscapeAnalysis::buildConnectionGraph(FunctionInfo *FInfo,
     // Create edges for the instructions.
     for (auto &i : *bb) {
       analyzeInstruction(&i, FInfo, BottomUpOrder, RecursionDepth);
+      
+      // Bail if the graph gets too big. The node merging algorithm has
+      // quadratic complexity and we want to avoid this.
+      // TODO: fix the quadratic complexity (if possible) and remove this limit.
+      if (ConGraph->Nodes.size() > 10000) {
+        ConGraph->invalidate();
+        return false;
+      }
     }
     return true;
   });
+
+  if (!ConGraph->isValid())
+    return;
 
   // Second step: create defer-edges for block arguments.
   for (SILBasicBlock &BB : *ConGraph->F) {
@@ -2478,6 +2502,16 @@ void EscapeAnalysis::recompute(FunctionInfo *Initial) {
 bool EscapeAnalysis::mergeCalleeGraph(SILInstruction *AS,
                                       ConnectionGraph *CallerGraph,
                                       ConnectionGraph *CalleeGraph) {
+  if (!CallerGraph->isValid())
+    return false;
+    
+  if (!CalleeGraph->isValid()) {
+    setAllEscaping(AS, CallerGraph);
+    // Conservatively assume that setting that setAllEscaping(AS) did change the
+    // graph.
+    return true;
+  }
+                                      
   // This CGNodeMap uses an intrusive worklist to keep track of Mapped nodes
   // from the CalleeGraph. Meanwhile, mergeFrom uses separate intrusive
   // worklists to update nodes in the CallerGraph.
@@ -2536,6 +2570,11 @@ bool EscapeAnalysis::mergeCalleeGraph(SILInstruction *AS,
 
 bool EscapeAnalysis::mergeSummaryGraph(ConnectionGraph *SummaryGraph,
                                         ConnectionGraph *Graph) {
+  if (!Graph->isValid()) {
+    bool changed = SummaryGraph->isValid();
+    SummaryGraph->invalidate();
+    return changed;
+  }
 
   // Make a 1-to-1 mapping of all arguments and the return value. This CGNodeMap
   // node map uses an intrusive worklist to keep track of Mapped nodes from the

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1608,7 +1608,7 @@ void EscapeAnalysis::ConnectionGraph::verify() const {
         continue;
 
       if (auto ai = dyn_cast<ApplyInst>(&i)) {
-        if (EA->canOptimizeArrayUninitializedCall(ai, this).isValid())
+        if (EA->canOptimizeArrayUninitializedCall(ai).isValid())
           continue;
       }
       for (auto result : i.getResults()) {
@@ -1826,8 +1826,7 @@ bool EscapeAnalysis::buildConnectionGraphForDestructor(
 }
 
 EscapeAnalysis::ArrayUninitCall
-EscapeAnalysis::canOptimizeArrayUninitializedCall(
-    ApplyInst *ai, const ConnectionGraph *conGraph) {
+EscapeAnalysis::canOptimizeArrayUninitializedCall(ApplyInst *ai) {
   ArrayUninitCall call;
   // This must be an exact match so we don't accidentally optimize
   // "array.uninitialized_intrinsic".
@@ -1873,8 +1872,7 @@ bool EscapeAnalysis::canOptimizeArrayUninitializedResult(
   if (!ai)
     return false;
 
-  auto *conGraph = getConnectionGraph(ai->getFunction());
-  return canOptimizeArrayUninitializedCall(ai, conGraph).isValid();
+  return canOptimizeArrayUninitializedCall(ai).isValid();
 }
 
 // Handle @_semantics("array.uninitialized")
@@ -1924,7 +1922,7 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
         return;
       case ArrayCallKind::kArrayUninitialized: {
         ArrayUninitCall call = canOptimizeArrayUninitializedCall(
-            cast<ApplyInst>(FAS.getInstruction()), ConGraph);
+            cast<ApplyInst>(FAS.getInstruction()));
         if (call.isValid()) {
           createArrayUninitializedSubgraph(call, ConGraph);
           return;

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -131,7 +131,9 @@ public:
   }
 
   void notifyHasNewUsers(SILValue value) override {
-    Worklist.addUsersToWorklist(value);
+    if (Worklist.size() < 10000) {
+      Worklist.addUsersToWorklist(value);
+    }
     changed = true;
   }
 

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -1153,6 +1153,22 @@ static bool isReachable(SILBasicBlock *Block) {
 static llvm::cl::opt<bool> SimplifyUnconditionalBranches(
     "simplify-cfg-simplify-unconditional-branches", llvm::cl::init(true));
 
+/// Returns true if \p block has less instructions than \p other.
+static bool hasLessInstructions(SILBasicBlock *block, SILBasicBlock *other) {
+  auto blockIter = block->begin();
+  auto blockEnd = block->end();
+  auto otherIter = other->begin();
+  auto otherEnd = other->end();
+  while (true) {
+    if (otherIter == otherEnd)
+      return false;
+    if (blockIter == blockEnd)
+      return true;
+    ++blockIter;
+    ++otherIter;
+  }
+}
+
 /// simplifyBranchBlock - Simplify a basic block that ends with an unconditional
 /// branch.
 bool SimplifyCFG::simplifyBranchBlock(BranchInst *BI) {
@@ -1201,29 +1217,48 @@ bool SimplifyCFG::simplifyBranchBlock(BranchInst *BI) {
       }
     }
 
-    // Zap BI and move all of the instructions from DestBB into this one.
     BI->eraseFromParent();
-    BB->spliceAtEnd(DestBB);
 
-    // Revisit this block now that we've changed it and remove the DestBB.
-    addToWorklist(BB);
+    // Move instruction from the smaller block to the larger block.
+    // The order is essential because if many blocks are merged and this is done
+    // in the wrong order, we end up with quadratic complexity.
+    //
+    SILBasicBlock *remainingBlock = nullptr, *deletedBlock = nullptr;
+    if (BB != Fn.getEntryBlock() && hasLessInstructions(BB, DestBB)) {
+      while (!BB->pred_empty()) {
+        SILBasicBlock *pred = *BB->pred_begin();
+        replaceBranchTarget(pred->getTerminator(), BB, DestBB, true);
+      }
+      DestBB->spliceAtBegin(BB);
+      DestBB->dropAllArguments();
+      DestBB->moveArgumentList(BB);
+      remainingBlock = DestBB;
+      deletedBlock = BB;
+    } else {
+      BB->spliceAtEnd(DestBB);
+      remainingBlock = BB;
+      deletedBlock = DestBB;
+    }
+
+    // Revisit this block now that we've changed it.
+    addToWorklist(remainingBlock);
 
     // This can also expose opportunities in the successors of
     // the merged block.
-    for (auto &Succ : BB->getSuccessors())
+    for (auto &Succ : remainingBlock->getSuccessors())
       addToWorklist(Succ);
 
-    if (LoopHeaders.count(DestBB))
-      LoopHeaders.insert(BB);
+    if (LoopHeaders.count(deletedBlock))
+      LoopHeaders.insert(remainingBlock);
 
-    auto Iter = JumpThreadingCost.find(DestBB);
+    auto Iter = JumpThreadingCost.find(deletedBlock);
     if (Iter != JumpThreadingCost.end()) {
       int costs = Iter->second;
-      JumpThreadingCost[BB] += costs;
+      JumpThreadingCost[remainingBlock] += costs;
     }
 
-    removeFromWorklist(DestBB);
-    DestBB->eraseFromParent();
+    removeFromWorklist(deletedBlock);
+    deletedBlock->eraseFromParent();
     ++NumBlocksMerged;
     return true;
   }
@@ -2544,7 +2579,10 @@ bool SimplifyCFG::simplifyBlocks() {
 
     switch (TI->getTermKind()) {
     case TermKind::BranchInst:
-      Changed |= simplifyBranchBlock(cast<BranchInst>(TI));
+      if (simplifyBranchBlock(cast<BranchInst>(TI))) {
+        Changed = true;
+        continue;
+      }
       break;
     case TermKind::CondBranchInst:
       Changed |= simplifyCondBrBlock(cast<CondBranchInst>(TI));

--- a/test/Inputs/timeout.py
+++ b/test/Inputs/timeout.py
@@ -16,4 +16,4 @@ def watchdog(command, timeout=None):
 
 
 if __name__ == '__main__':
-    watchdog(sys.argv[2:], timeout=sys.argv[1])
+    watchdog(sys.argv[2:], timeout=float(sys.argv[1]))

--- a/test/SILOptimizer/OSLogFullOptTest.swift
+++ b/test/SILOptimizer/OSLogFullOptTest.swift
@@ -21,6 +21,10 @@ func testSimpleInterpolation() {
     // CHECK: tail call swiftcc i1 @"${{.*}}isLoggingEnabled{{.*}}"()
     // CHECK-NEXT: br i1 {{%.*}}, label %[[ENABLED:[0-9]+]], label %[[NOT_ENABLED:[0-9]+]]
 
+    // CHECK: [[NOT_ENABLED]]:
+    // CHECK-NEXT: tail call void @swift_release
+    // CHECK-NEXT: ret void
+
     // CHECK: [[ENABLED]]:
     //
     // Header bytes.
@@ -47,10 +51,6 @@ func testSimpleInterpolation() {
     // CHECK-32-NEXT: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* getelementptr inbounds ([27 x i8], [27 x i8]* @{{.*}}, i32 0, i32 0), i8* {{(nonnull )?}}[[BUFFER]], i32 8)
     // CHECK-NEXT: tail call void @swift_slowDealloc(i8* {{(nonnull )?}}[[BUFFER]]
     // CHECK-NEXT: br label %[[NOT_ENABLED]]
-
-    // CHECK: [[NOT_ENABLED]]:
-    // CHECK-NEXT: tail call void @swift_release
-    // CHECK-NEXT: ret void
 }
 
 // CHECK-LABEL: define hidden swiftcc void @"${{.*}}testInterpolationWithMultipleArguments
@@ -67,6 +67,10 @@ func testInterpolationWithMultipleArguments() {
     // CHECK: entry:
     // CHECK: tail call swiftcc i1 @"${{.*}}isLoggingEnabled{{.*}}"()
     // CHECK-NEXT: br i1 {{%.*}}, label %[[ENABLED:[0-9]+]], label %[[NOT_ENABLED:[0-9]+]]
+
+    // CHECK: [[NOT_ENABLED]]:
+    // CHECK-NEXT: tail call void @swift_release
+    // CHECK-NEXT: ret void
 
     // CHECK: [[ENABLED]]:
     //
@@ -112,10 +116,6 @@ func testInterpolationWithMultipleArguments() {
     // CHECK-NEXT: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* getelementptr inbounds ([106 x i8], [106 x i8]* @{{.*}}, i{{.*}} 0, i{{.*}} 0), i8* {{(nonnull )?}}[[BUFFER]], i32 20)
     // CHECK-NEXT: tail call void @swift_slowDealloc(i8* {{(nonnull )?}}[[BUFFER]]
     // CHECK-NEXT: br label %[[NOT_ENABLED]]
-
-    // CHECK: [[NOT_ENABLED]]:
-    // CHECK-NEXT: tail call void @swift_release
-    // CHECK-NEXT: ret void
 }
 
 // CHECK-LABEL: define hidden swiftcc void @"${{.*}}testNSObjectInterpolation
@@ -133,6 +133,10 @@ func testNSObjectInterpolation(nsArray: NSArray) {
     // CHECK-NEXT: tail call void @swift_release
     // CHECK-NEXT: tail call void @llvm.objc.release
     // CHECK-NEXT: br label %[[EXIT:[0-9]+]]
+
+    // CHECK: [[EXIT]]:
+    // CHECK-NEXT: tail call void @llvm.objc.release(i8* [[NSARRAY_ARG]])
+    // CHECK-NEXT: ret void
 
     // CHECK: [[ENABLED]]:
     //
@@ -163,10 +167,6 @@ func testNSObjectInterpolation(nsArray: NSArray) {
     // CHECK-NEXT: tail call void @swift_slowDealloc(i8* {{(nonnull )?}}[[BUFFER]]
     // CHECK-NEXT: tail call void @swift_release
     // CHECK-NEXT: br label %[[EXIT]]
-
-    // CHECK: [[EXIT]]:
-    // CHECK-NEXT: tail call void @llvm.objc.release(i8* [[NSARRAY_ARG]])
-    // CHECK-NEXT: ret void
 }
 
 // CHECK-LABEL: define hidden swiftcc void @"${{.*}}testFloatInterpolation
@@ -175,6 +175,10 @@ func testFloatInterpolation(doubleValue: Double) {
     // CHECK: entry:
     // CHECK: tail call swiftcc i1 @"${{.*}}isLoggingEnabled{{.*}}"()
     // CHECK-NEXT: br i1 {{%.*}}, label %[[ENABLED:[0-9]+]], label %[[NOT_ENABLED:[0-9]+]]
+
+    // CHECK: [[NOT_ENABLED]]:
+    // CHECK-NEXT: tail call void @swift_release
+    // CHECK-NEXT: ret void
 
     // CHECK: [[ENABLED]]:
     //
@@ -198,10 +202,6 @@ func testFloatInterpolation(doubleValue: Double) {
     // CHECK-NEXT: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* getelementptr inbounds ([17 x i8], [17 x i8]* @{{.*}}, i{{.*}} 0, i{{.*}} 0), i8* {{(nonnull )?}}[[BUFFER]], i32 12)
     // CHECK-NEXT: tail call void @swift_slowDealloc(i8* {{(nonnull )?}}[[BUFFER]]
     // CHECK-NEXT: br label %[[NOT_ENABLED]]
-
-    // CHECK: [[NOT_ENABLED]]:
-    // CHECK-NEXT: tail call void @swift_release
-    // CHECK-NEXT: ret void
 }
 
 // This test checks that the precision and alignment are optimally "stored" into the
@@ -216,6 +216,10 @@ func testDynamicPrecisionAndAlignment() {
     // CHECK: entry:
     // CHECK: tail call swiftcc i1 @"${{.*}}isLoggingEnabled{{.*}}"()
     // CHECK-NEXT: br i1 {{%.*}}, label %[[ENABLED:[0-9]+]], label %[[NOT_ENABLED:[0-9]+]]
+
+    // CHECK: [[NOT_ENABLED]]:
+    // CHECK-NEXT: tail call void @swift_release
+    // CHECK-NEXT: ret void
 
     // CHECK: [[ENABLED]]:
     //
@@ -261,10 +265,6 @@ func testDynamicPrecisionAndAlignment() {
     // CHECK-NEXT: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* getelementptr inbounds ([28 x i8], [28 x i8]* @{{.*}}, i{{.*}} 0, i{{.*}} 0), i8* {{(nonnull )?}}[[BUFFER]], i32 20)
     // CHECK-NEXT: tail call void @swift_slowDealloc(i8* {{(nonnull )?}}[[BUFFER]]
     // CHECK-NEXT: br label %[[NOT_ENABLED]]
-
-    // CHECK: [[NOT_ENABLED]]:
-    // CHECK-NEXT: tail call void @swift_release
-    // CHECK-NEXT: ret void
 }
 
 // TODO: add test for String. It is more complicated due to more complex logic

--- a/test/SILOptimizer/devirt_jump_thread.sil
+++ b/test/SILOptimizer/devirt_jump_thread.sil
@@ -54,17 +54,17 @@ bb0(%0 : $Int32, %1 : $FooClass):
 //
 // CHECK-LABEL: sil @_TF18devirt_jump_thread26jumpthread_checked_cast_brFCS_8FooClassSi
 // CHECK: checked_cast_br
-// CHECK: bb2(%{{.*}} : $FooClass):
+// CHECK: bb1(%{{.*}} : $FooClass):
 // CHECK: function_ref @_TTOS_no2g__TFC18devirt_jump_thread8FooClass3foofS0_FSiSi
 // CHECK-NOT: function_ref @_TTOS_no2g__TFC18devirt_jump_thread8FooClass3foofS0_FSiSi
 // CHECK-NOT: class_method
-// CHECK: br bb1
+// CHECK: br bb2
 // CHECK-NOT: checked_cast_br
 // CHECK: bb3:
 // CHECK-NOT: function_ref
 // CHECK: class_method
 // CHECK-NOT: function_ref
-// CHECK: br bb1
+// CHECK: br bb2
 // CHECK: }
 // devirt_jump_thread.jumpthread_checked_cast_br (devirt_jump_thread.FooClass) -> Swift.Int32
 sil @_TF18devirt_jump_thread26jumpthread_checked_cast_brFCS_8FooClassSi : $@convention(thin) (@guaranteed FooClass) -> Int32 {
@@ -169,13 +169,13 @@ bb12:                                             // Preds: bb3
 // Check that checked_cast_br gets jump threaded
 // CHECK-LABEL: sil @_TF18devirt_jump_thread6doubleFCS_8FooClassSi
 // CHECK: checked_cast_br
-// CHECK: bb2(%{{.*}} : $FooClass):
+// CHECK: bb2
+// CHECK: class_method
+// CHECK: br bb4
+// CHECK: bb3(%{{.*}} : $FooClass):
 // CHECK-NOT: class_method
 // CHECK: br bb1
 // CHECK-NOT: checked_cast_br
-// CHECK: bb3
-// CHECK: class_method
-// CHECK: br bb1
 // CHECK: }
 // devirt_jump_thread.double (devirt_jump_thread.FooClass) -> Swift.Int32
 sil @_TF18devirt_jump_thread6doubleFCS_8FooClassSi : $@convention(thin) (@guaranteed FooClass) -> Int32 {

--- a/test/SILOptimizer/global_init_opt.swift
+++ b/test/SILOptimizer/global_init_opt.swift
@@ -20,7 +20,7 @@ public func cse() -> Int {
 // CHECK-LABEL: sil @$s4test4licmSiyF
 // CHECK: bb0:
 // CHECK:   builtin "once"
-// CHECK: bb1:
+// CHECK: bb1{{.*}}:
 // CHECK-NOT:   builtin "once"
 // CHECK: } // end sil function '$s4test4licmSiyF'
 public func licm() -> Int {

--- a/test/SILOptimizer/merge_exclusivity.swift
+++ b/test/SILOptimizer/merge_exclusivity.swift
@@ -18,21 +18,21 @@ func sum(_ x: UInt64, _ y: UInt64) -> UInt64 {
 // TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$s17merge_exclusivity5checks6UInt64Vvp
 // TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
 // TESTSIL: end_access [[B1]]
-// TESTSIL: bb5
+// TESTSIL: bb4{{.*}}:
 // TESTSIL: [[B2a:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBALVAR]]
 // TESTSIL-NEXT: load [[B2a]]
 // TESTSIL: end_access [[B2a]]
 // TESTSIL: [[B2b:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
 // TESTSIL: store {{.*}} to [[B2b]]
 // TESTSIL: end_access [[B2b]]
-// TESTSIL: bb6
+// TESTSIL: bb5:
 // TESTSIL: [[B3a:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBALVAR]]
 // TESTSIL-NEXT: load [[B3a]]
 // TESTSIL: end_access [[B3a]]
 // TESTSIL: [[B3b:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
 // TESTSIL: store {{.*}} to [[B3b]]
 // TESTSIL: end_access [[B3b]]
-// TESTSIL: bb7
+// TESTSIL: bb6:
 // TESTSIL: [[B4a:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBALVAR]]
 // TESTSIL-NEXT: load [[B4a]]
 // TESTSIL: end_access [[B4a]]

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -420,11 +420,11 @@ bb4(%6 : $Int64):
 // Make sure the cond_br is not simplified as it would create
 // a critical edge.
 // CHECK-LABEL: @elim_trampoline4
-// CHECK: cond_br %0, bb1, bb2
+// CHECK: cond_br %0, bb2, bb1
 // CHECK: bb1:
-// CHECK-NEXT: br bb3
-// CHECK: bb2:
 // CHECK: br bb3
+// CHECK: bb2:
+// CHECK-NEXT: br bb3
 // CHECK: bb3
 // CHECK: return
 // CHECK: }
@@ -611,24 +611,24 @@ bb3:                                              // Preds: bb0
 sil @nop : $@convention(thin) (Bool) -> Bool {
 bb0(%0 : $Bool):
   %1 = struct_extract %0 : $Bool, #Bool._value
-// CHECK: cond_br %1, [[TRUE:[a-zA-Z0-9]+]], [[FALSE:[a-zA-Z0-9]+]]
+// CHECK: cond_br %1, bb2, bb1
   cond_br %1, bb1, bb2
 
-// CHECK: [[TRUE]]:
+// CHECK: bb1:
+// CHECK:   br bb3
+// CHECK: bb2:
+// CHECK:   br bb3
 bb1:
   %3 = integer_literal $Builtin.Int1, 0
   %4 = struct $Bool (%3 : $Builtin.Int1)
-// CHECK: br [[RETURN:[a-zA-Z0-9]+]]
   br bb3(%4 : $Bool)
 
-// CHECK: [[FALSE]]:
 bb2:
   %6 = integer_literal $Builtin.Int1, -1          // user: %7
   %7 = struct $Bool (%6 : $Builtin.Int1)          // user: %8
-// CHECK: br [[RETURN]]
   br bb3(%7 : $Bool)                              // id: %8
 
-// CHECK: [[RETURN]]
+// CHECK: bb3
 bb3(%9 : $Bool):                                  // Preds: bb1 bb2
 // CHECK-NOT: struct_extract
   %10 = struct_extract %9 : $Bool, #Bool._value    // user: %11
@@ -1050,12 +1050,12 @@ bb5(%r : $Builtin.Int32):
 
 // CHECK-LABEL: sil @simplify_loop_header
 // CHECK: bb1(
-// CHECK:  cond_br {{.*}}, bb2, bb3
+// CHECK:  cond_br {{.*}}, bb3, bb2
 // CHECK: bb2:
-// CHECK:  return
-// CHECK: bb3:
 // CHECK:  enum $Optional<Int32>, #Optional.some
 // CHECK:  br bb1(
+// CHECK: bb3:
+// CHECK:  return
 
 sil @simplify_loop_header : $@convention(thin) () -> () {
 bb0:
@@ -1170,6 +1170,10 @@ bb0(%0 : $Base):
 // CHECK: checked_cast_br [exact] %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
   checked_cast_br [exact] %0 : $Base to Base, bb2, bb7
 
+// CHECK: bb1:
+// CHECK: tuple ()
+// CHECK: return
+
 bb1:
   %3 = tuple ()
   return %3 : $()
@@ -1197,10 +1201,6 @@ bb5:
 
 bb6(%17 : $()):
   br bb1
-
-// CHECK: bb4:
-// CHECK: tuple ()
-// CHECK: return
 
 bb7:
 // CHECK: checked_cast_br [exact] %0 : $Base to Derived
@@ -1381,11 +1381,11 @@ bb3:
 }
 
 // CHECK-LABEL: sil @jumpthread_switch_enum3
-// CHECK: switch_enum %0 : $Optional<Int32>, case #Optional.none!enumelt: bb1, case #Optional.some!enumelt: bb2
+// CHECK: switch_enum %0 : $Optional<Int32>, case #Optional.none!enumelt: bb2, case #Optional.some!enumelt: bb1
 // CHECK: bb1:
-// CHECK-NEXT: switch_enum
-// CHECK: bb2:
 // CHECK-NEXT: br bb5
+// CHECK: bb2:
+// CHECK-NEXT: switch_enum
 // CHECK: bb3:
 // CHECK-NEXT: br bb5
 // CHECK: bb4:
@@ -2248,9 +2248,9 @@ sil @f_use : $@convention(thin) (Builtin.Int32) -> ()
 // CHECK: bb1:
 // CHECK:  [[INVADD:%.*]] = builtin "sadd
 // CHECK:  [[EXT:%.*]] = tuple_extract [[INVADD]]
-// CHECK:  switch_enum {{.*}} case #Optional.some!enumelt: bb3
+// CHECK:  switch_enum {{.*}} case #Optional.some!enumelt: bb2
 
-// CHECK: bb3{{.*}}
+// CHECK: bb2{{.*}}
 // CHECK:  br bb4({{.*}} : $Builtin.Int32, %2 : $Builtin.Int32, [[EXT]]
 
 // CHECK: bb4({{.*}} : $Builtin.Int32, [[CUR:%.*]] : $Builtin.Int32, [[NEXT:%.*]] : $Builtin.Int32
@@ -2368,18 +2368,18 @@ sil @f2 : $@convention(thin) (Builtin.Int16) -> ()
 // CHECK: bb0([[ARG:%.*]] : $AnEnum):
 // CHECK:  [[F:%.*]] = function_ref @f : $@convention(thin) (Builtin.Int32) -> ()
 // CHECK:  [[F2:%.*]] = function_ref @f2 : $@convention(thin) (Builtin.Int16) -> ()
-// CHECK:  switch_enum [[ARG]] : $AnEnum, case #AnEnum.B!enumelt: bb1, case #AnEnum.C!enumelt: bb2
+// CHECK:  switch_enum [[ARG]] : $AnEnum, case #AnEnum.B!enumelt: bb2, case #AnEnum.C!enumelt: bb1
 
-// CHECK: bb1([[ARG2:%.*]] : $Builtin.Int32):
-// CHECK:  apply [[F]]([[ARG2]])
-// CHECK:  [[UED:%.*]] = unchecked_enum_data [[ARG]] : $AnEnum, #AnEnum.B!enumelt
-// CHECK:  apply [[F]]([[UED]])
-// CHECK:  br bb3
-
-// CHECK: bb2([[ARG3:%.*]] : $Builtin.Int16):
+// CHECK: bb1([[ARG3:%.*]] : $Builtin.Int16):
 // CHECK:  apply [[F2]]([[ARG3]])
 // CHECK:  [[UED2:%.*]] = unchecked_enum_data [[ARG]] : $AnEnum, #AnEnum.C!enumelt
 // CHECK:  apply [[F2]]([[UED2]])
+// CHECK:  br bb3
+
+// CHECK: bb2([[ARG2:%.*]] : $Builtin.Int32):
+// CHECK:  apply [[F]]([[ARG2]])
+// CHECK:  [[UED:%.*]] = unchecked_enum_data [[ARG]] : $AnEnum, #AnEnum.B!enumelt
+// CHECK:  apply [[F]]([[UED]])
 // CHECK:  br bb3
 
 sil @jump_thread_switch_enum : $@convention(thin) (AnEnum) -> () {
@@ -2436,8 +2436,8 @@ sil @fC : $@convention(thin) () -> ()
 // CHECK-LABEL: sil @dont_jump_thread_switch_enum_to_cond_br
 // CHECK:    [[BFUN:%.*]] = function_ref @fB : $@convention(thin) () -> ()
 // CHECK:    [[FALSE:%.*]] = integer_literal $Builtin.Int1, 0
-// CHECK:    switch_enum [[ENUM:%.*]] : $AnEnum, case #AnEnum.B!enumelt: bb1
-// CHECK:  bb1:
+// CHECK:    switch_enum [[ENUM:%.*]] : $AnEnum, case #AnEnum.B!enumelt: bb2
+// CHECK:  bb2:
 // CHECK:    [[F:%.*]] = select_enum [[ENUM]] : $AnEnum, case #AnEnum.B!enumelt: [[FALSE]]
 // CHECK:    cond_br [[F]], bb3, bb4
 // CHECK:  bb4:
@@ -2898,17 +2898,17 @@ bb6(%44 : $Builtin.Int8):
 
 // CHECK-LABEL: jump_thread_retain_release
 // CHECK: cond_br
-// CHECK:   cond_br %3, bb3, bb4
+// CHECK:   cond_br %3, bb4, bb3
 
 // CHECK: bb3:
-// CHECK:   strong_retain %1 : $foo
-// CHECK:   strong_release %1 : $foo
-// CHECK:   br bb5(%1 : $foo)
-
-// CHECK: bb4:
 // CHECK:   strong_retain %2 : $foo
 // CHECK:   strong_release %2 : $foo
 // CHECK:   br bb5(%2 : $foo)
+
+// CHECK: bb4:
+// CHECK:   strong_retain %1 : $foo
+// CHECK:   strong_release %1 : $foo
+// CHECK:   br bb5(%1 : $foo)
 
 sil @jump_thread_retain_release : $@convention(thin) (Builtin.Int1, foo, foo, Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1, %1 : $foo, %2 : $foo, %3 : $Builtin.Int1):

--- a/test/SILOptimizer/simplify_cfg_address_phi.sil
+++ b/test/SILOptimizer/simplify_cfg_address_phi.sil
@@ -84,19 +84,19 @@ bb5:
 //
 // CHECK-LABEL: sil @testJumpThreadIndex : $@convention(thin) (__ContiguousArrayStorageBase, Builtin.Int64) -> Builtin.Int32 {
 // CHECK: bb0(%0 : $__ContiguousArrayStorageBase, %1 : $Builtin.Int64):
-// CHECK:   cond_br undef, bb1, bb2
+// CHECK:   cond_br undef, bb2, bb1
 // CHECK: bb1:
-// CHECK:   apply
-// CHECK:   strong_retain
-// CHECK:   strong_release
-// CHECK:   [[IDX1:%.*]] = builtin "truncOrBitCast_Int64_Word"(%1 : $Builtin.Int64) : $Builtin.Word
-// CHECK:   br bb3([[IDX1]] : $Builtin.Word)
-// CHECK: bb2:
 // CHECK:   apply
 // CHECK:   strong_retain
 // CHECK:   strong_release
 // CHECK:   [[IDX2:%.*]] = builtin "truncOrBitCast_Int64_Word"(%1 : $Builtin.Int64) : $Builtin.Word
 // CHECK:   br bb3([[IDX2]] : $Builtin.Word)
+// CHECK: bb2:
+// CHECK:   apply
+// CHECK:   strong_retain
+// CHECK:   strong_release
+// CHECK:   [[IDX1:%.*]] = builtin "truncOrBitCast_Int64_Word"(%1 : $Builtin.Int64) : $Builtin.Word
+// CHECK:   br bb3([[IDX1]] : $Builtin.Word)
 // CHECK: bb3([[PHI:%.*]] : $Builtin.Word):
 // CHECK:   [[TAIL:%.*]] = ref_tail_addr %0 : $__ContiguousArrayStorageBase, $Int32
 // CHECK:   [[ELT:%.*]] = index_addr [[TAIL]] : $*Int32, %14 : $Builtin.Word
@@ -190,14 +190,8 @@ sil @doNothing : $@convention(thin) (@inout Int) -> ()
 
 // CHECK-LABEL: sil @testMultiUse : $@convention(method) (Bool, @inout Int) -> () {
 // CHECK: bb0(%0 : $Bool, %1 : $*Int):
-// CHECK:   cond_br %{{.*}}, bb2, bb1
+// CHECK:   cond_br %{{.*}}, bb1, bb2
 // CHECK: bb1:
-// CHECK:   [[ALLOC1:%.*]] = alloc_box ${ var S }, var, name "s"
-// CHECK:   [[PROJ1:%.*]] = project_box [[ALLOC1]] : ${ var S }, 0
-// CHECK:   [[ADR1:%.*]] = struct_element_addr [[PROJ1]] : $*S, #S.x
-// CHECK:   store %{{.*}} to [[ADR1]] : $*Int
-// CHECK:   br bb3([[ALLOC1]] : ${ var S })
-// CHECK: bb2:
 // CHECK:   apply %{{.*}}(%1) : $@convention(thin) (@inout Int) -> ()
 // CHECK:   [[ALLOC2:%.*]] = alloc_box ${ var S }, var, name "s"
 // CHECK:   [[PROJ2:%.*]] = project_box [[ALLOC2]] : ${ var S }, 0
@@ -205,6 +199,12 @@ sil @doNothing : $@convention(thin) (@inout Int) -> ()
 // CHECK:   store %{{.*}} to [[ADR2]] : $*Int
 // CHECK:   apply %{{.*}}([[ADR2]]) : $@convention(thin) (@inout Int) -> ()
 // CHECK:   br bb3([[ALLOC2]] : ${ var S })
+// CHECK: bb2:
+// CHECK:   [[ALLOC1:%.*]] = alloc_box ${ var S }, var, name "s"
+// CHECK:   [[PROJ1:%.*]] = project_box [[ALLOC1]] : ${ var S }, 0
+// CHECK:   [[ADR1:%.*]] = struct_element_addr [[PROJ1]] : $*S, #S.x
+// CHECK:   store %{{.*}} to [[ADR1]] : $*Int
+// CHECK:   br bb3([[ALLOC1]] : ${ var S })
 // CHECK: bb3([[BOXARG:%.*]] : ${ var S }):
 // CHECK:   [[PROJ3:%.*]] = project_box [[BOXARG]] : ${ var S }, 0
 // CHECK:   [[ADR3:%.*]] = struct_element_addr [[PROJ3]] : $*S, #S.x

--- a/test/SILOptimizer/simplify_cfg_opaque.sil
+++ b/test/SILOptimizer/simplify_cfg_opaque.sil
@@ -8,11 +8,13 @@ protocol P {}
 //
 // CHECK-LABEL: sil @testJumpThread : $@convention(thin) (Any, Any) -> () {
 // CHECK: bb0(%0 : $Any, %1 : $Any):
-// CHECK:   cond_br undef, bb1, bb4
+// CHECK:   cond_br undef, bb1, bb2
 // CHECK: bb1:
 // CHECK:   retain_value %0 : $Any
 // CHECK:   release_value %0 : $Any
-// CHECK:   checked_cast_value_br Any in %0 : $Any to P, bb3, bb2
+// CHECK:   checked_cast_value_br Any in %0 : $Any to P
+// CHECK: bb2:
+// CHECK:   checked_cast_value_br Any in %1 : $Any to P
 // CHECK-LABEL: } // end sil function 'testJumpThread'
 sil @testJumpThread : $@convention(thin) (Any, Any) -> () {
 bb0(%0 : $Any, %1 : $Any):

--- a/test/SILOptimizer/unsafebufferpointer.swift
+++ b/test/SILOptimizer/unsafebufferpointer.swift
@@ -50,16 +50,15 @@ public func testCount(_ x: UnsafeBufferPointer<UInt>) -> Int {
 // The only unconditional branch is into the loop.
 // CHECK: br label %[[LOOP:[0-9]+]]
 //
-// For some reason, LLVM lays out the exit before the loop.
-// CHECK: .loopexit: ; preds = %[[LOOP]]
-// CHECK: ret float
-//
 // CHECK: [[LOOP]]:
 // CHECK: phi float [ 0.000000e+00
 // CHECK: load float, float*
 // CHECK: fadd float
 // CHECK: [[CMP:%[0-9]+]] = icmp eq
 // CHECK: br i1 [[CMP]], label %.loopexit, label %[[LOOP]]
+//
+// CHECK: .loopexit: ; preds = %[[LOOP]]
+// CHECK: ret float
 public func testSubscript(_ ubp: UnsafeBufferPointer<Float>) -> Float {
   var sum: Float = 0
   for i in 0 ..< ubp.count {
@@ -73,17 +72,16 @@ public func testSubscript(_ ubp: UnsafeBufferPointer<Float>) -> Float {
 // The only unconditional branch is into the loop.
 // CHECK: br label %[[LOOP:[0-9]+]]
 //
-// For some reason, LLVM lays out the exit before the loop.
-// CHECK: [[RET:.*]]: ; preds = %[[LOOP]], %entry
-// CHECK: ret i64
-//
 // CHECK: [[LOOP]]:
 // CHECK: phi i64 [ 0
 // CHECK: load i8, i8*
 // CHECK: zext i8 %{{.*}} to i64
 // CHECK: add i64
 // CHECK: [[CMP:%[0-9]+]] = icmp eq
-// CHECK: br i1 [[CMP]], label %[[RET]], label %[[LOOP]]
+// CHECK: br i1 [[CMP]], label %[[RET:.*]], label %[[LOOP]]
+//
+// CHECK: [[RET]]: ; preds = %[[LOOP]], %entry
+// CHECK: ret i64
 public func testSubscript(_ ubp: UnsafeRawBufferPointer) -> Int64 {
   var sum: Int64 = 0
   for i in 0 ..< ubp.count {

--- a/test/stdlib/Reflection.swift
+++ b/test/stdlib/Reflection.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -parse-stdlib %s -module-name Reflection -o %t/a.out
 // RUN: %target-codesign %t/a.out
-// RUN: %{python} %S/timeout.py 360 %target-run %t/a.out | %FileCheck %s
+// RUN: %{python} %S/../Inputs/timeout.py 360 %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test
 // FIXME: timeout wrapper is necessary because the ASan test runs for hours
 

--- a/test/stdlib/Reflection_objc.swift
+++ b/test/stdlib/Reflection_objc.swift
@@ -3,7 +3,7 @@
 // RUN: %target-clang %S/Inputs/Mirror/Mirror.mm -c -o %t/Mirror.mm.o -g
 // RUN: %target-build-swift -parse-stdlib %s -module-name Reflection -I %S/Inputs/Mirror/ -Xlinker %t/Mirror.mm.o -o %t/a.out
 // RUN: %target-codesign %t/a.out
-// RUN: %{python} %S/timeout.py 360 %target-run %t/a.out %S/Inputs/shuffle.jpg | %FileCheck %s
+// RUN: %{python} %S/../Inputs/timeout.py 360 %target-run %t/a.out %S/Inputs/shuffle.jpg | %FileCheck %s
 // FIXME: timeout wrapper is necessary because the ASan test runs for hours
 
 // REQUIRES: executable_test

--- a/validation-test/SILOptimizer/large_string_array.swift.gyb
+++ b/validation-test/SILOptimizer/large_string_array.swift.gyb
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: %gyb %s > %t/main.swift
+
+// The compiler should finish in less than 1 minute. To give some slack,
+// specify a timeout of 5 minutes.
+// If the compiler needs more than 5 minutes, there is probably a real problem.
+// So please don't just increase the timeout in case this fails.
+
+// RUN: %{python} %S/../../test/Inputs/timeout.py 300 %target-swift-frontend -O -parse-as-library -sil-verify-none -emit-sil %t/main.swift | %FileCheck %s
+
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+// REQUIRES: long_test
+
+// Check if the optimizer can optimize the whole array into a statically
+// initialized global
+
+// CHECK: sil_global private @globalinit_{{.*}} : $_ContiguousArrayStorage<String> = {
+// CHECK:   %initval = object $_ContiguousArrayStorage<String>
+
+public let str_array: [String] = [
+
+% for i in range(63500):
+  "string in array with index ${i}",
+% end
+
+]
+


### PR DESCRIPTION
Fix several complexity bugs in the optimizer, which showed up when compiling huge string arrays.

The included test contains an array with > 60000 strings. It used to compile in > 1 hour. Now it needs less than 1 minute.

For details see the commit messages.

rdar://problem/56268570