### PR TITLE
AST: making `export: true` in @_specialized attribute a no-operation

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1568,6 +1568,9 @@ ERROR(attr_specialize_unknown_parameter_name,none,
 ERROR(attr_specialize_expected_bool_value,none,
       "expected a boolean true or false value in '_specialize' attribute", ())
 
+WARNING(attr_specialize_export_true_no_op,none,
+        "'exported: true' has no effect in '_specialize' attribute", ())
+
 ERROR(attr_specialize_missing_parameter_label_or_where_clause,none,
       "expected a parameter label or a where clause in '_specialize' attribute", ())
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -626,7 +626,11 @@ bool Parser::parseSpecializeAttributeArguments(
                  ParamLabel);
       }
       if (ParamLabel == "exported") {
+        auto trueLoc = Tok.getLoc();
         bool isTrue = consumeIf(tok::kw_true);
+        if (isTrue) {
+          diagnose(trueLoc, diag::attr_specialize_export_true_no_op);
+        }
         bool isFalse = consumeIf(tok::kw_false);
         if (!isTrue && !isFalse) {
           diagnose(Tok.getLoc(), diag::attr_specialize_expected_bool_value);

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -768,11 +768,6 @@ void EagerSpecializerTransform::run() {
       auto *NewFunc = eagerSpecialize(FuncBuilder, &F, *SA, ReInfoVec.back());
 
       SpecializedFuncs.push_back(NewFunc);
-
-      if (SA->isExported()) {
-        NewFunc->setLinkage(SILLinkage::Public);
-        continue;
-      }
     }
 
     // TODO: Optimize the dispatch code to minimize the amount

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -1,5 +1,4 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -eager-specializer  %s | %FileCheck %s
-// RUN: %target-sil-opt -enable-sil-verify-all -eager-specializer -sil-deadfuncelim  %s | %FileCheck --check-prefix=CHECK-DEADFUNCELIM %s
 // RUN: %target-sil-opt -enable-sil-verify-all -eager-specializer  %s -o %t.sil && %target-swift-frontend -module-name=eager_specialize -emit-ir %t.sil | %FileCheck --check-prefix=CHECK-IRGEN --check-prefix=CHECK-IRGEN-%target-cpu %s
 // RUN: %target-sil-opt -enable-sil-verify-all -eager-specializer -sil-inline-generics=true -inline %s | %FileCheck --check-prefix=CHECK-EAGER-SPECIALIZE-AND-GENERICS-INLINE %s
 
@@ -577,10 +576,6 @@ bb0(%0 : $*T):
   %3 = tuple ()
   return %3 : $()
 } // end sil function '$s16eager_specialize21exportSpecializationsyyxlF'
-
-// Check that a public specialization for Int64 was produced.
-// specialized exportSpecializations<A> (A) -> ()
-// CHECK-DEADFUNCELIM-LABEL: sil @$s16eager_specialize21exportSpecializationsyyxlFs5Int64V_Tg5 : $@convention(thin) (Int64) -> ()
 
 ////////////////////////////////////////////////////////////////////
 // Check the ability to produce explicit partial specializations.

--- a/test/TBD/specialize_verify.swift
+++ b/test/TBD/specialize_verify.swift
@@ -1,0 +1,7 @@
+// REQUIRES: VENDOR=apple
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -O -module-name test -validate-tbd-against-ir=missing %s
+
+@_specialize(exported: true, where T: _Trivial)
+public func foo<T>(_ x : T) -> T {
+  return x
+}

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -128,7 +128,7 @@ public func funcWithTwoGenericParameters<X, Y>(x: X, y: Y) {
 }
 
 @_specialize(where X == Int, Y == Int)
-@_specialize(exported: true, where X == Int, Y == Int)
+@_specialize(exported: true, where X == Int, Y == Int) // expected-warning{{'exported: true' has no effect in '_specialize' attribute}}
 @_specialize(exported: false, where X == Int, Y == Int)
 @_specialize(exported: false where X == Int, Y == Int) // expected-error{{missing ',' in '_specialize' attribute}}
 @_specialize(exported: yes, where X == Int, Y == Int) // expected-error{{expected a boolean true or false value in '_specialize' attribute}}
@@ -143,9 +143,9 @@ public func funcWithTwoGenericParameters<X, Y>(x: X, y: Y) {
 @_specialize(kind: partial, where X == Int, Y == Int)
 @_specialize(kind: , where X == Int, Y == Int)
 
-@_specialize(exported: true, kind: partial, where X == Int, Y == Int)
-@_specialize(exported: true, exported: true, where X == Int, Y == Int) // expected-error{{parameter 'exported' was already defined in '_specialize' attribute}}
-@_specialize(kind: partial, exported: true, where X == Int, Y == Int)
+@_specialize(exported: true, kind: partial, where X == Int, Y == Int) // expected-warning{{'exported: true' has no effect in '_specialize' attribute}}
+@_specialize(exported: true, exported: true, where X == Int, Y == Int) // expected-error{{parameter 'exported' was already defined in '_specialize' attribute}} expected-warning2{{'exported: true' has no effect in '_specialize' attribute}}
+@_specialize(kind: partial, exported: true, where X == Int, Y == Int) // expected-warning{{'exported: true' has no effect in '_specialize' attribute}}
 @_specialize(kind: partial, kind: partial, where X == Int, Y == Int) // expected-error{{parameter 'kind' was already defined in '_specialize' attribute}}
 
 @_specialize(where X == Int, Y == Int, exported: true, kind: partial) // expected-error{{use of undeclared type 'exported'}} expected-error{{use of undeclared type 'kind'}} expected-error{{use of undeclared type 'partial'}} expected-error{{expected type}}
@@ -200,22 +200,22 @@ public func simpleGeneric<T>(t: T) -> T {
 }
 
 
-@_specialize(exported: true, where S: _Trivial(64))
+@_specialize(exported: true, where S: _Trivial(64)) // expected-warning{{'exported: true' has no effect in '_specialize' attribute}}
 // Check that any bitsize size is OK, not only powers of 8.
 @_specialize(where S: _Trivial(60))
-@_specialize(exported: true, where S: _RefCountedObject)
+@_specialize(exported: true, where S: _RefCountedObject) // expected-warning{{'exported: true' has no effect in '_specialize' attribute}}
 @inline(never)
 public func copyValue<S>(_ t: S, s: inout S) -> Int64 where S: P{
   return 1
 }
 
-@_specialize(exported: true, where S: _Trivial)
-@_specialize(exported: true, where S: _Trivial(64))
-@_specialize(exported: true, where S: _Trivial(32))
-@_specialize(exported: true, where S: _RefCountedObject)
-@_specialize(exported: true, where S: _NativeRefCountedObject)
-@_specialize(exported: true, where S: _Class)
-@_specialize(exported: true, where S: _NativeClass)
+@_specialize(exported: true, where S: _Trivial) // expected-warning{{'exported: true' has no effect in '_specialize' attribute}}
+@_specialize(exported: true, where S: _Trivial(64)) // expected-warning{{'exported: true' has no effect in '_specialize' attribute}}
+@_specialize(exported: true, where S: _Trivial(32)) // expected-warning{{'exported: true' has no effect in '_specialize' attribute}}
+@_specialize(exported: true, where S: _RefCountedObject) // expected-warning{{'exported: true' has no effect in '_specialize' attribute}}
+@_specialize(exported: true, where S: _NativeRefCountedObject) // expected-warning{{'exported: true' has no effect in '_specialize' attribute}}
+@_specialize(exported: true, where S: _Class) // expected-warning{{'exported: true' has no effect in '_specialize' attribute}}
+@_specialize(exported: true, where S: _NativeClass) // expected-warning{{'exported: true' has no effect in '_specialize' attribute}}
 @inline(never)
 public func copyValueAndReturn<S>(_ t: S, s: inout S) -> S where S: P{
   return s
@@ -234,7 +234,7 @@ struct OuterStruct<S> {
 }
 
 // Check _TrivialAtMostN constraints.
-@_specialize(exported: true, where S: _TrivialAtMost(64))
+@_specialize(exported: true, where S: _TrivialAtMost(64)) // expected-warning{{'exported: true' has no effect in '_specialize' attribute}}
 @inline(never)
 public func copy2<S>(_ t: S, s: inout S) -> S where S: P{
   return s


### PR DESCRIPTION
The client code doesn't actually call into these specialized functions even
though they have public linkage. This could lead to TBD verification failure
shown in rdar://44777994.

This patch also warns users' codebase when `export: true` is specified.
