### PR TITLE
[IDE][Refactoring] Handle 'callAsFunction' specially in syntactic rename

### DIFF
--- a/include/swift/IDE/Refactoring.h
+++ b/include/swift/IDE/Refactoring.h
@@ -141,8 +141,17 @@ collectAvailableRefactorings(SourceFile *SF, ResolvedCursorInfo CursorInfo,
                              std::vector<RefactoringKind> &Scratch,
                              bool ExcludeRename);
 
+/// Stores information about the reference that rename availability is being
+/// queried on.
+struct RenameRefInfo {
+  SourceFile *SF; ///< The source file containing the reference.
+  SourceLoc Loc; ///< The reference's source location.
+  bool IsArgLabel; ///< Whether Loc is on an arg label, rather than base name.
+};
+
 ArrayRef<RenameAvailabiliyInfo>
 collectRenameAvailabilityInfo(const ValueDecl *VD,
+                              Optional<RenameRefInfo> RefInfo,
                               std::vector<RenameAvailabiliyInfo> &Scratch);
 
 } // namespace ide

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -316,21 +316,35 @@ public:
     // FIXME: handle escaped keyword names `init`
     bool IsSubscript = Old.base() == "subscript" && Config.IsFunctionLike;
     bool IsInit = Old.base() == "init" && Config.IsFunctionLike;
-    bool IsKeywordBase = IsInit || IsSubscript;
+
+    // FIXME: this should only be treated specially for instance methods.
+    bool IsCallAsFunction = Old.base() == "callAsFunction" &&
+        Config.IsFunctionLike;
+
+    bool IsSpecialBase = IsInit || IsSubscript || IsCallAsFunction;
     
-    // Filter out non-semantic keyword basename locations with no labels.
+    // Filter out non-semantic special basename locations with no labels.
     // We've already filtered out those in active code, so these are
-    // any appearance of just 'init' or 'subscript' in strings, comments, and
-    // inactive code.
-    if (IsKeywordBase && (Config.Usage == NameUsage::Unknown &&
-                           Resolved.LabelType == LabelRangeType::None))
+    // any appearance of just 'init', 'subscript', or 'callAsFunction' in
+    // strings, comments, and inactive code.
+    if (IsSpecialBase && (Config.Usage == NameUsage::Unknown &&
+                          Resolved.LabelType == LabelRangeType::None))
       return RegionType::Unmatched;
 
-    if (!Config.IsFunctionLike || !IsKeywordBase) {
+    if (!Config.IsFunctionLike || !IsSpecialBase) {
       if (renameBase(Resolved.Range, RefactoringRangeKind::BaseName))
         return RegionType::Mismatch;
 
-    } else if (IsKeywordBase && Config.Usage == NameUsage::Definition) {
+    } else if (IsInit || IsCallAsFunction) {
+      if (renameBase(Resolved.Range, RefactoringRangeKind::KeywordBaseName)) {
+        // The base name doesn't need to match (but may) for calls, but
+        // it should for definitions and references.
+        if (Config.Usage == NameUsage::Definition ||
+            Config.Usage == NameUsage::Reference) {
+          return RegionType::Mismatch;
+        }
+      }
+    } else if (IsSubscript && Config.Usage == NameUsage::Definition) {
       if (renameBase(Resolved.Range, RefactoringRangeKind::KeywordBaseName))
         return RegionType::Mismatch;
     }
@@ -528,9 +542,11 @@ static const ValueDecl *getRelatedSystemDecl(const ValueDecl *VD) {
   return nullptr;
 }
 
-static Optional<RefactoringKind> getAvailableRenameForDecl(const ValueDecl *VD) {
+static Optional<RefactoringKind>
+getAvailableRenameForDecl(const ValueDecl *VD,
+                          Optional<RenameRefInfo> RefInfo) {
   std::vector<RenameAvailabiliyInfo> Scratch;
-  for (auto &Info : collectRenameAvailabilityInfo(VD, Scratch)) {
+  for (auto &Info : collectRenameAvailabilityInfo(VD, RefInfo, Scratch)) {
     if (Info.AvailableKind == RenameAvailableKind::Available)
       return Info.Kind;
   }
@@ -744,15 +760,21 @@ bool RefactoringActionLocalRename::
 isApplicable(ResolvedCursorInfo CursorInfo, DiagnosticEngine &Diag) {
   if (CursorInfo.Kind != CursorInfoKind::ValueRef)
     return false;
-  auto RenameOp = getAvailableRenameForDecl(CursorInfo.ValueD);
+
+  Optional<RenameRefInfo> RefInfo;
+  if (CursorInfo.IsRef)
+    RefInfo = {CursorInfo.SF, CursorInfo.Loc, CursorInfo.IsKeywordArgument};
+
+  auto RenameOp = getAvailableRenameForDecl(CursorInfo.ValueD, RefInfo);
   return RenameOp.hasValue() &&
     RenameOp.getValue() == RefactoringKind::LocalRename;
 }
 
-static void analyzeRenameScope(ValueDecl *VD, DiagnosticEngine &Diags,
+static void analyzeRenameScope(ValueDecl *VD, Optional<RenameRefInfo> RefInfo,
+                               DiagnosticEngine &Diags,
                                llvm::SmallVectorImpl<DeclContext *> &Scopes) {
   Scopes.clear();
-  if (!getAvailableRenameForDecl(VD).hasValue()) {
+  if (!getAvailableRenameForDecl(VD, RefInfo).hasValue()) {
     Diags.diagnose(SourceLoc(), diag::value_decl_no_loc, VD->getFullName());
     return;
   }
@@ -786,7 +808,12 @@ bool RefactoringActionLocalRename::performChange() {
   if (CursorInfo.isValid() && CursorInfo.ValueD) {
     ValueDecl *VD = CursorInfo.CtorTyRef ? CursorInfo.CtorTyRef : CursorInfo.ValueD;
     llvm::SmallVector<DeclContext *, 8> Scopes;
-    analyzeRenameScope(VD, DiagEngine, Scopes);
+
+    Optional<RenameRefInfo> RefInfo;
+    if (CursorInfo.IsRef)
+      RefInfo = {CursorInfo.SF, CursorInfo.Loc, CursorInfo.IsKeywordArgument};
+
+    analyzeRenameScope(VD, RefInfo, DiagEngine, Scopes);
     if (Scopes.empty())
       return true;
     RenameRangeCollector rangeCollector(VD, PreferredName);
@@ -3623,9 +3650,11 @@ accept(SourceManager &SM, RegionType RegionType,
     Impl.accept(SM, Range);
   }
 }
+
 ArrayRef<RenameAvailabiliyInfo>
 swift::ide::collectRenameAvailabilityInfo(const ValueDecl *VD,
-                                std::vector<RenameAvailabiliyInfo> &Scratch) {
+                                          Optional<RenameRefInfo> RefInfo,
+                                  std::vector<RenameAvailabiliyInfo> &Scratch) {
   RenameAvailableKind AvailKind = RenameAvailableKind::Available;
   if (getRelatedSystemDecl(VD)){
     AvailKind = RenameAvailableKind::Unavailable_system_symbol;
@@ -3650,6 +3679,30 @@ swift::ide::collectRenameAvailabilityInfo(const ValueDecl *VD,
     if (auto CD = dyn_cast<ConstructorDecl>(VD)) {
       if (!CD->getParameters()->size())
         return Scratch;
+
+      if (RefInfo && !RefInfo->IsArgLabel) {
+        NameMatcher Matcher(*(RefInfo->SF));
+        auto Resolved = Matcher.resolve({RefInfo->Loc, /*ResolveArgs*/true});
+        if (Resolved.LabelRanges.empty())
+          return Scratch;
+      }
+    }
+
+    // Disallow renaming 'callAsFunction' method with no arguments.
+    if (auto FD = dyn_cast<FuncDecl>(VD)) {
+      // FIXME: syntactic rename can only decide by checking the spelling, not
+      // whether it's an instance method, so we do the same here for now.
+      if (FD->getBaseIdentifier() == FD->getASTContext().Id_callAsFunction) {
+        if (!FD->getParameters()->size())
+          return Scratch;
+
+        if (RefInfo && !RefInfo->IsArgLabel) {
+          NameMatcher Matcher(*(RefInfo->SF));
+          auto Resolved = Matcher.resolve({RefInfo->Loc, /*ResolveArgs*/true});
+          if (Resolved.LabelRanges.empty())
+            return Scratch;
+        }
+      }
     }
   }
 
@@ -3682,7 +3735,10 @@ collectAvailableRefactorings(SourceFile *SF,
   case CursorInfoKind::ExprStart:
     break;
   case CursorInfoKind::ValueRef: {
-    auto RenameOp = getAvailableRenameForDecl(CursorInfo.ValueD);
+    Optional<RenameRefInfo> RefInfo;
+    if (CursorInfo.IsRef)
+      RefInfo = {CursorInfo.SF, CursorInfo.Loc, CursorInfo.IsKeywordArgument};
+    auto RenameOp = getAvailableRenameForDecl(CursorInfo.ValueD, RefInfo);
     if (RenameOp.hasValue() &&
         RenameOp.getValue() == RefactoringKind::GlobalRename)
       AllKinds.push_back(RenameOp.getValue());
@@ -3919,8 +3975,12 @@ int swift::ide::findLocalRenameRanges(
     return true;
   }
   ValueDecl *VD = CursorInfo.CtorTyRef ? CursorInfo.CtorTyRef : CursorInfo.ValueD;
+  Optional<RenameRefInfo> RefInfo;
+  if (CursorInfo.IsRef)
+    RefInfo = {CursorInfo.SF, CursorInfo.Loc, CursorInfo.IsKeywordArgument};
+
   llvm::SmallVector<DeclContext *, 8> Scopes;
-  analyzeRenameScope(VD, Diags, Scopes);
+  analyzeRenameScope(VD, RefInfo, Diags, Scopes);
   if (Scopes.empty())
     return true;
   RenameRangeCollector RangeCollector(VD, StringRef());

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -86,10 +86,15 @@ private:
   bool shouldIgnore(Decl *D, bool &ShouldVisitChildren);
 
   ValueDecl *extractDecl(Expr *Fn) const {
+    Fn = Fn->getSemanticsProvidingExpr();
     if (auto *DRE = dyn_cast<DeclRefExpr>(Fn))
       return DRE->getDecl();
     if (auto ApplyE = dyn_cast<ApplyExpr>(Fn))
       return extractDecl(ApplyE->getFn());
+    if (auto *ACE = dyn_cast<AutoClosureExpr>(Fn)) {
+      if (auto *Unwrapped = ACE->getUnwrappedCurryThunkExpr())
+        return extractDecl(Unwrapped);
+    }
     return nullptr;
   }
 };

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1345,15 +1345,36 @@ static bool isDynamicCall(Expr *BaseE, ValueDecl *D) {
   return true;
 }
 
-static bool isBeingCalled(Expr *Target, Expr *Parent, Expr *GrandParent) {
-    if (!Target || !Parent || !isa<ApplyExpr>(Parent))
-      return false;
+static Expr *getUnderlyingFunc(Expr *Fn) {
+  Fn = Fn->getSemanticsProvidingExpr();
+  if (auto *DRE = dyn_cast<DeclRefExpr>(Fn))
+    return DRE;
+  if (auto ApplyE = dyn_cast<SelfApplyExpr>(Fn))
+    return getUnderlyingFunc(ApplyE->getFn());
+  if (auto *ACE = dyn_cast<AutoClosureExpr>(Fn)) {
+    if (auto *Unwrapped = ACE->getUnwrappedCurryThunkExpr())
+      return getUnderlyingFunc(Unwrapped);
+  }
+  return Fn;
+}
 
-    if (!isa<SelfApplyExpr>(Parent))
-      return cast<ApplyExpr>(Parent)->getFn() == Target;
+static bool isBeingCalled(Expr *Target, ArrayRef<Expr*> ExprStack) {
+  if (!Target)
+    return false;
+  Target = getUnderlyingFunc(Target);
 
-  return GrandParent && isa<CallExpr>(GrandParent) &&
-    cast<CallExpr>(GrandParent)->getFn() == Parent;
+  for (Expr *E: reverse(ExprStack)) {
+    auto *AE = dyn_cast<ApplyExpr>(E);
+    if (!AE || AE->isImplicit())
+      continue;
+    if (isa<ConstructorRefCallExpr>(AE) && AE->getArg() == Target)
+      return true;
+    if (isa<SelfApplyExpr>(AE))
+      continue;
+    if (getUnderlyingFunc(AE->getFn()) == Target)
+      return true;
+  }
+  return false;
 }
 
 bool IndexSwiftASTWalker::initFuncRefIndexSymbol(ValueDecl *D, SourceLoc Loc,
@@ -1368,8 +1389,7 @@ bool IndexSwiftASTWalker::initFuncRefIndexSymbol(ValueDecl *D, SourceLoc Loc,
 
   Expr *ParentE = getParentExpr();
 
-  if (!isa<AbstractStorageDecl>(D) &&
-      !isBeingCalled(CurrentE, ParentE, getContainingExpr(2)))
+  if (!isa<AbstractStorageDecl>(D) && !isBeingCalled(CurrentE, ExprStack))
     return false;
 
   Info.roles |= (unsigned)SymbolRole::Call;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7087,8 +7087,9 @@ static Expr *buildCallAsFunctionMethodRef(
 
   // Create direct reference to `callAsFunction` method.
   auto *fn = apply->getFn();
+  auto *arg = apply->getArg();
   auto *declRef = rewriter.buildMemberRef(
-      fn, /*dotLoc*/ SourceLoc(), selected, DeclNameLoc(fn->getEndLoc()),
+      fn, /*dotLoc*/ SourceLoc(), selected, DeclNameLoc(arg->getStartLoc()),
       calleeLoc, calleeLoc, /*implicit*/ true,
       /*extraUncurryLevel=*/true, AccessSemantics::Ordinary);
   if (!declRef)

--- a/test/Index/index_callasfunction.swift
+++ b/test/Index/index_callasfunction.swift
@@ -6,7 +6,7 @@ struct Adder {
 // CHECK: [[@LINE-1]]:10 | instance-method/Swift | callAsFunction(_:) | [[callAsFunc1:.*]] | Def
         return base + x
     }
-    func callAsFunction(x: Int, y: Int) -> Int {
+    func callAsFunction(x: Int, y: Int) -> Adder {
 // CHECK: [[@LINE-1]]:10 | instance-method/Swift | callAsFunction(x:y:) | [[callAsFunc2:.*]] | Def
         return base + x + y
     }
@@ -18,11 +18,30 @@ let global = 1
 
 add3(global)
 // CHECK: [[@LINE-1]]:1 | variable/Swift | add3 | [[add3]] | Ref,Read |
-// CHECK: [[@LINE-2]]:1 | instance-method/Swift | callAsFunction(_:) | [[callAsFunc1]] | Ref,Call,RelRec | rel: 1
+// CHECK: [[@LINE-2]]:5 | instance-method/Swift | callAsFunction(_:) | [[callAsFunc1]] | Ref,Call,RelRec | rel: 1
 // CHECK:   RelRec | struct/Swift | Adder |
 // CHECK: [[@LINE-4]]:6 | variable/Swift | global | {{.*}} | Ref,Read |
 
 add3(x: 10, y: 11)
 // CHECK: [[@LINE-1]]:1 | variable/Swift | add3 | [[add3]] | Ref,Read |
-// CHECK: [[@LINE-2]]:1 | instance-method/Swift | callAsFunction(x:y:) | [[callAsFunc2]] | Ref,Call,RelRec | rel: 1
+// CHECK: [[@LINE-2]]:5 | instance-method/Swift | callAsFunction(x:y:) | [[callAsFunc2]] | Ref,Call,RelRec | rel: 1
+// CHECK:   RelRec | struct/Swift | Adder |
+
+func getAdder(_ base: Int) -> Adder { return Adder(base: base) }
+// CHECK: [[@LINE-1]]:6 | function/Swift | getAdder(_:) | [[getAdder:.*]] | Def | rel: 0
+
+getAdder(5)(10)
+// CHECK: [[@LINE-1]]:1 | function/Swift | getAdder(_:) | [[getAdder]] | Ref,Call | rel: 0
+// CHECK: [[@LINE-2]]:12 | instance-method/Swift | callAsFunction(_:) | [[callAsFunc1]] | Ref,Call,RelRec | rel: 1
+// CHECK:   RelRec | struct/Swift | Adder |
+
+getAdder(5)(x: 1, y: 42)
+// CHECK: [[@LINE-1]]:1 | function/Swift | getAdder(_:) | [[getAdder]] | Ref,Call | rel: 0
+// CHECK: [[@LINE-2]]:12 | instance-method/Swift | callAsFunction(x:y:) | [[callAsFunc2]] | Ref,Call,RelRec | rel: 1
+// CHECK:   RelRec | struct/Swift | Adder |
+
+((add3.callAsFunction)(x: 5, y: 10))(x: 1, y: 42)
+// CHECK: [[@LINE-1]]:8 | instance-method/Swift | callAsFunction(x:y:) | [[callAsFunc2]] | Ref,Call,RelRec | rel: 1
+// CHECK:   RelRec | struct/Swift | Adder |
+// CHECK: [[@LINE-3]]:37 | instance-method/Swift | callAsFunction(x:y:) | [[callAsFunc2]] | Ref,Call,RelRec | rel: 1
 // CHECK:   RelRec | struct/Swift | Adder |

--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -16,19 +16,23 @@ let x = 2
 var y = x + 1
 // CHECK: [[@LINE-1]]:5 | variable/Swift | y | s:14swift_ide_test1ySivp | Def | rel: 0
 // CHECK: [[@LINE-2]]:9 | variable/Swift | x | s:14swift_ide_test1xSivp | Ref,Read | rel: 0
-// CHECK: [[@LINE-3]]:11 | static-method/infix-operator/Swift | +(_:_:) | s:Si1poiyS2i_SitFZ | Ref | rel: 0
+// CHECK: [[@LINE-3]]:11 | static-method/infix-operator/Swift | +(_:_:) | s:Si1poiyS2i_SitFZ | Ref,Call,RelRec | rel: 1
+// CHECK-NEXT: RelRec | struct/Swift | Int | s:Si
 
 // Read of x + Write of y
 y = x + 1
 // CHECK: [[@LINE-1]]:1 | variable/Swift | y | s:14swift_ide_test1ySivp | Ref,Writ | rel: 0
 // CHECK: [[@LINE-2]]:5 | variable/Swift | x | s:14swift_ide_test1xSivp | Ref,Read | rel: 0
-// CHECK: [[@LINE-3]]:7 | static-method/infix-operator/Swift | +(_:_:) | s:Si1poiyS2i_SitFZ | Ref | rel: 0
+// CHECK: [[@LINE-3]]:7 | static-method/infix-operator/Swift | +(_:_:) | s:Si1poiyS2i_SitFZ | Ref,Call,RelRec | rel: 1
+// CHECK-NEXT: RelRec | struct/Swift | Int | s:Si
+
 
 // Read of y + Write of y
 y += x
 // CHECK: [[@LINE-1]]:1 | variable/Swift | y | s:14swift_ide_test1ySivp | Ref,Read,Writ | rel: 0
-// CHECK: [[@LINE-2]]:3 | static-method/infix-operator/Swift | +=(_:_:) | s:Si2peoiyySiz_SitFZ | Ref | rel: 0
-// CHECK: [[@LINE-3]]:6 | variable/Swift | x | s:14swift_ide_test1xSivp | Ref,Read | rel: 0
+// CHECK: [[@LINE-2]]:3 | static-method/infix-operator/Swift | +=(_:_:) | s:Si2peoiyySiz_SitFZ | Ref,Call,RelRec | rel: 1
+// CHECK-NEXT: RelRec | struct/Swift | Int | s:Si
+// CHECK: [[@LINE-4]]:6 | variable/Swift | x | s:14swift_ide_test1xSivp | Ref,Read | rel: 0
 
 var z: Int {
 // CHECK: [[@LINE-1]]:5 | variable/Swift | z | s:14swift_ide_test1zSivp | Def | rel: 0
@@ -118,8 +122,9 @@ struct AStruct {
     // CHECK: [[@LINE-6]]:5 | instance-method/acc-set/Swift | setter:x | s:14swift_ide_test7AStructV1xSivs | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
     // CHECK-NEXT: RelCall,RelCont | instance-method/Swift | aMethod() | s:14swift_ide_test7AStructV7aMethodyyF
     // CHECK-NEXT: RelRec | struct/Swift | AStruct | [[AStruct_USR]]
-    // CHECK: [[@LINE-9]]:7 | static-method/infix-operator/Swift | +=(_:_:) | s:Si2peoiyySiz_SitFZ | Ref,RelCont | rel: 1
-    // CHECK-NEXT: RelCont | instance-method/Swift | aMethod() | s:14swift_ide_test7AStructV7aMethodyyF
+    // CHECK: [[@LINE-9]]:7 | static-method/infix-operator/Swift | +=(_:_:) | s:Si2peoiyySiz_SitFZ | Ref,Call,RelRec,RelCall,RelCont | rel: 2
+    // CHECK-NEXT: RelCall,RelCont | instance-method/Swift | aMethod() | s:14swift_ide_test7AStructV7aMethodyyF
+    // CHECK-NEXT: RelRec | struct/Swift | Int | s:Si
   }
 
   // RelationChildOf, RelationAccessorOf

--- a/test/Sema/call_as_function_simple.swift
+++ b/test/Sema/call_as_function_simple.swift
@@ -61,9 +61,17 @@ extension Extended {
   func callAsFunction() -> Extended {
     return self
   }
+
+  func callAsFunction(_: Int) -> Extended {
+    return self
+  }
 }
 var extended = Extended()
 extended()().callAsFunction()()
+
+// Test diagnostic location
+extended()().callAsFunction()(1) // expected-warning@:30 {{result of call to 'callAsFunction' is unused}}
+extended()().callAsFunction(1) // expected-warning@:14 {{result of call to 'callAsFunction' is unused}}
 
 struct TakesTrailingClosure {
   func callAsFunction(_ fn: () -> Void) {

--- a/test/SourceKit/Indexing/index.swift.response
+++ b/test/SourceKit/Indexing/index.swift.response
@@ -808,7 +808,8 @@
                   key.name: "+(_:_:)",
                   key.usr: <usr>,
                   key.line: 86,
-                  key.column: 8
+                  key.column: 8,
+                  key.receiver_usr: "s:Si"
                 }
               ]
             },

--- a/test/SourceKit/Indexing/index_operators.swift.response
+++ b/test/SourceKit/Indexing/index_operators.swift.response
@@ -108,7 +108,8 @@
               key.name: "-(_:_:)",
               key.usr: "s:15index_operators7StructBV1soiyA2C_ACtFZ",
               key.line: 17,
-              key.column: 19
+              key.column: 19,
+              key.receiver_usr: "s:15index_operators7StructBV"
             }
           ]
         },

--- a/test/SourceKit/Refactoring/basic.swift
+++ b/test/SourceKit/Refactoring/basic.swift
@@ -78,6 +78,34 @@ func foo7() -> String {
   foo6()
 }
 
+struct Test {
+  init(x: Int = 42) {}
+  func callAsFunction(x: Int = 42) {}
+}
+
+Test.init
+Test.init()
+Test.init(x:)
+Test.init(x: 3)
+
+let callable = Test();
+callable(x: 89)
+callable.callAsFunction
+callable.callAsFunction()
+callable.callAsFunction(x:)
+callable.callAsFunction(x: 78)
+(callable.callAsFunction)(x: 78)
+(callable.callAsFunction)()
+
+func foo(_ x: Int) -> Test { fatalError() }
+foo(39)(x: 90)
+
+struct TestDefaultedParen {
+  init(_: Int = 42) {}
+}
+
+TestDefaultedParen.init()
+
 // RUN: %sourcekitd-test -req=cursor -pos=3:1 -end-pos=5:13 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK1
 
 // CHECK1: ACTIONS BEGIN
@@ -92,6 +120,25 @@ func foo7() -> String {
 // RUN: %sourcekitd-test -req=cursor -pos=26:20 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
 // RUN: %sourcekitd-test -req=cursor -pos=27:11 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-LOCAL
 
+// RUN: %sourcekitd-test -req=cursor -pos=83:8  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
+// RUN: %sourcekitd-test -req=cursor -pos=86:6  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-NORENAME
+// RUN: %sourcekitd-test -req=cursor -pos=87:6  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-NORENAME
+// RUN: %sourcekitd-test -req=cursor -pos=88:6  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
+// RUN: %sourcekitd-test -req=cursor -pos=89:6  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
+// RUN: %sourcekitd-test -req=cursor -pos=89:11  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
+
+// RUN: %sourcekitd-test -req=cursor -pos=92:10  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
+// RUN: %sourcekitd-test -req=cursor -pos=93:10  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-NORENAME
+// RUN: %sourcekitd-test -req=cursor -pos=94:10  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-NORENAME
+// RUN: %sourcekitd-test -req=cursor -pos=95:10  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
+// RUN: %sourcekitd-test -req=cursor -pos=96:10  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
+// RUN: %sourcekitd-test -req=cursor -pos=96:25  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
+// RUN: %sourcekitd-test -req=cursor -pos=97:11  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
+// RUN: %sourcekitd-test -req=cursor -pos=97:27  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
+// RUN: %sourcekitd-test -req=cursor -pos=98:11  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-NORENAME
+
+// RUN: %sourcekitd-test -req=cursor -pos=107:20  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-NORENAME
+
 // RUN: %sourcekitd-test -req=cursor -pos=35:10 -end-pos=35:16 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-RENAME-EXTRACT
 // RUN: %sourcekitd-test -req=cursor -pos=35:10 -end-pos=35:16 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-RENAME-EXTRACT
 
@@ -105,6 +152,9 @@ func foo7() -> String {
 
 // RUN: %sourcekitd-test -req=cursor -pos=72:5 -end-pos=72:11 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-RENAME-EXTRACT
 // RUN: %sourcekitd-test -req=cursor -pos=78:3 -end-pos=78:9 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-RENAME-EXTRACT
+
+// CHECK-NORENAME-NOT: Global Rename
+// CHECK-NORENAME-NOT: Local Rename
 
 // CHECK2: ACTIONS BEGIN
 // CHECK2-NEXT: source.refactoring.kind.rename.global

--- a/test/SourceKit/Refactoring/find-rename-ranges/keywordbase.expected
+++ b/test/SourceKit/Refactoring/find-rename-ranges/keywordbase.expected
@@ -2,6 +2,7 @@ source.edit.kind.active:
   95:17-95:18 source.refactoring.range.kind.call-argument-label arg-index=0
   95:18-95:20 source.refactoring.range.kind.call-argument-colon arg-index=0
 source.edit.kind.active:
+  96:17-96:21 source.refactoring.range.kind.keyword-basename
   96:22-96:23 source.refactoring.range.kind.call-argument-label arg-index=0
   96:23-96:25 source.refactoring.range.kind.call-argument-colon arg-index=0
 source.edit.kind.unknown:
@@ -16,6 +17,8 @@ source.edit.kind.unknown:
 source.edit.kind.unknown:
 source.edit.kind.unknown:
 source.edit.kind.inactive:
+  103:17-103:21 source.refactoring.range.kind.keyword-basename
   103:22-103:23 source.refactoring.range.kind.call-argument-label arg-index=0
   103:23-103:25 source.refactoring.range.kind.call-argument-colon arg-index=0
 source.edit.kind.unknown:
+  104:17-104:21 source.refactoring.range.kind.keyword-basename

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/call-as-function-base.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/call-as-function-base.swift.expected
@@ -1,0 +1,15 @@
+struct Adder {
+    var base: Int
+
+    func callAsFunction(x: Int, y: Int) -> Int {
+        return base + x + y
+    }
+}
+
+let /*test:def*/<base>add3</base> = Adder(base: 3)
+/*test:ref*/<base>add3</base>(x: 10, y: 11)
+let blah = /*test:ref*/<base>add3</base>.callAsFunction(x:y:)
+
+
+
+

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/call-as-function-paren-arg.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/call-as-function-paren-arg.swift.expected
@@ -1,0 +1,13 @@
+struct Adder {
+    var base: Int
+    func /*test:def*/<keywordBase>callAsFunction</keywordBase>(<arglabel index=0>_</arglabel><param index=0> x</param>: Int) -> Int {
+        return base + x
+    }
+}
+
+let add3 = Adder(base: 3)
+_ = add3/*test:call*/(<callcombo index=0></callcombo>10)
+_ = add3 . /*test:call*/<keywordBase>callAsFunction</keywordBase>(<callcombo index=0></callcombo>10)
+_ = add3 . /*test:ref*/<keywordBase>callAsFunction</keywordBase>(<sel index=0>_</sel>:)
+_ = add3 . /*test:ref*/<keywordBase>callAsFunction</keywordBase>
+

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/call-as-function.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/call-as-function.swift.expected
@@ -1,0 +1,14 @@
+struct Adder {
+    var base: Int
+    func /*test:def*/<keywordBase>callAsFunction</keywordBase>(<arglabel index=0>x</arglabel><param index=0></param>: Int, <arglabel index=1>y</arglabel><param index=1></param>: Int) -> Adder {
+        return self
+    }
+}
+
+let add3 = Adder(base: 3)
+_ = add3/*test:call*/(<callarg index=0>x</callarg><callcolon index=0>: </callcolon>10, <callarg index=1>y</callarg><callcolon index=1>: </callcolon>11)
+_ = add3 . /*test:call*/<keywordBase>callAsFunction</keywordBase>(<callarg index=0>x</callarg><callcolon index=0>: </callcolon>10, <callarg index=1>y</callarg><callcolon index=1>: </callcolon>11)
+_ = add3 . /*test:ref*/<keywordBase>callAsFunction</keywordBase>(<sel index=0>x</sel>:<sel index=1>y</sel>:)
+_ = add3 . /*test:ref*/<keywordBase>callAsFunction</keywordBase>
+_ = (add3 . /*test:call*/<keywordBase>callAsFunction</keywordBase>())/*test:call*/(<callarg index=0>x</callarg><callcolon index=0>: </callcolon>10, <callarg index=1>y</callarg><callcolon index=1>: </callcolon>11)
+

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/functions/init.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/functions/init.swift.expected
@@ -63,7 +63,7 @@ class SomeClass {
 
 let someClass = SomeClass();
 let _ = /*init:call*/SomeClass(<callarg index=0>a</callarg><callcolon index=0>:</callcolon>1, <callarg index=1>b</callarg><callcolon index=1>:</callcolon>1, <callarg index=2>c</callarg><callcolon index=2>:</callcolon>1)
-let _ = SomeClass . /*init*/init(<sel index=0>a</sel>:<sel index=1>b</sel>:<sel index=2>c</sel>:)
+let _ = SomeClass . /*init*/<keywordBase>init</keywordBase>(<sel index=0>a</sel>:<sel index=1>b</sel>:<sel index=2>c</sel>:)
 _ = someClass/*sub:ref*/[1, y: 2]
 someClass/*sub:ref*/[1, y: 2] = 2
 

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/init.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/init.swift.expected
@@ -1,0 +1,12 @@
+struct Test {
+    var base: Int
+    /*test:def*/<keywordBase>init</keywordBase>(<arglabel index=0>base</arglabel><param index=0></param>: Int) {}
+}
+
+_ = /*test:call*/Test(<callarg index=0>base</callarg><callcolon index=0>: </callcolon>3)
+_ = Test . /*test:call*/<keywordBase>init</keywordBase>(<callarg index=0>base</callarg><callcolon index=0>: </callcolon>3)
+_ = Test . /*test:ref*/<keywordBase>init</keywordBase>
+_ = Test . /*test:ref*/<keywordBase>init</keywordBase>(<sel index=0>base</sel>:)
+
+
+

--- a/test/refactoring/SyntacticRename/call-as-function-base.swift
+++ b/test/refactoring/SyntacticRename/call-as-function-base.swift
@@ -1,0 +1,18 @@
+struct Adder {
+    var base: Int
+
+    func callAsFunction(x: Int, y: Int) -> Int {
+        return base + x + y
+    }
+}
+
+let /*test:def*/add3 = Adder(base: 3)
+/*test:ref*/add3(x: 10, y: 11)
+let blah = /*test:ref*/add3.callAsFunction(x:y:)
+
+// RUN: %empty-directory(%t.ranges)
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="test" -old-name "add3" >> %t.ranges/call-as-function-base.swift.expected
+// RUN: diff -u %S/FindRangeOutputs/call-as-function-base.swift.expected %t.ranges/call-as-function-base.swift.expected
+
+
+

--- a/test/refactoring/SyntacticRename/call-as-function-paren-arg.swift
+++ b/test/refactoring/SyntacticRename/call-as-function-paren-arg.swift
@@ -1,0 +1,16 @@
+struct Adder {
+    var base: Int
+    func /*test:def*/callAsFunction(_ x: Int) -> Int {
+        return base + x
+    }
+}
+
+let add3 = Adder(base: 3)
+_ = add3/*test:call*/(10)
+_ = add3 . /*test:call*/callAsFunction(10)
+_ = add3 . /*test:ref*/callAsFunction(_:)
+_ = add3 . /*test:ref*/callAsFunction
+
+// RUN: %empty-directory(%t.ranges)
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="test" -is-function-like -old-name "callAsFunction(_:)" >> %t.ranges/call-as-function-paren-arg.swift.expected
+// RUN: diff -u %S/FindRangeOutputs/call-as-function-paren-arg.swift.expected %t.ranges/call-as-function-paren-arg.swift.expected

--- a/test/refactoring/SyntacticRename/call-as-function.swift
+++ b/test/refactoring/SyntacticRename/call-as-function.swift
@@ -1,0 +1,17 @@
+struct Adder {
+    var base: Int
+    func /*test:def*/callAsFunction(x: Int, y: Int) -> Adder {
+        return self
+    }
+}
+
+let add3 = Adder(base: 3)
+_ = add3/*test:call*/(x: 10, y: 11)
+_ = add3 . /*test:call*/callAsFunction(x: 10, y: 11)
+_ = add3 . /*test:ref*/callAsFunction(x:y:)
+_ = add3 . /*test:ref*/callAsFunction
+_ = (add3 . /*test:call*/callAsFunction())/*test:call*/(x: 10, y: 11)
+
+// RUN: %empty-directory(%t.ranges)
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="test" -is-function-like -old-name "callAsFunction(x:y:)" >> %t.ranges/call-as-function.swift.expected
+// RUN: diff -u %S/FindRangeOutputs/call-as-function.swift.expected %t.ranges/call-as-function.swift.expected

--- a/test/refactoring/SyntacticRename/init.swift
+++ b/test/refactoring/SyntacticRename/init.swift
@@ -1,0 +1,15 @@
+struct Test {
+    var base: Int
+    /*test:def*/init(base: Int) {}
+}
+
+_ = /*test:call*/Test(base: 3)
+_ = Test . /*test:call*/init(base: 3)
+_ = Test . /*test:ref*/init
+_ = Test . /*test:ref*/init(base:)
+
+
+// RUN: %empty-directory(%t.ranges)
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="test" -is-function-like -old-name "init(base:)" >> %t.ranges/init.swift.expected
+// RUN: diff -u %S/FindRangeOutputs/init.swift.expected %t.ranges/init.swift.expected
+

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -641,11 +641,13 @@ static bool passCursorInfoForModule(ModuleEntity Mod,
 
 static void
 collectAvailableRenameInfo(const ValueDecl *VD,
+                           Optional<RenameRefInfo> RefInfo,
                            std::vector<UIdent> &RefactoringIds,
                            DelayedStringRetriever &RefactroingNameOS,
                            DelayedStringRetriever &RefactoringReasonOS) {
   std::vector<ide::RenameAvailabiliyInfo> Scratch;
-  for (auto Info : ide::collectRenameAvailabilityInfo(VD, Scratch)) {
+  for (auto Info : ide::collectRenameAvailabilityInfo(VD, RefInfo,
+                                                      Scratch)){
     RefactoringIds.push_back(SwiftLangSupport::
       getUIDForRefactoringKind(Info.Kind));
     RefactroingNameOS.startPiece();
@@ -837,8 +839,13 @@ static bool passCursorInfoForDecl(SourceFile* SF,
   std::vector<UIdent> RefactoringIds;
   DelayedStringRetriever RefactoringNameOS(SS);
   DelayedStringRetriever RefactoringReasonOS(SS);
+
   if (RetrieveRefactoring) {
-    collectAvailableRenameInfo(VD, RefactoringIds, RefactoringNameOS,
+    Optional<RenameRefInfo> RefInfo;
+    if (TheTok.IsRef)
+      RefInfo = {TheTok.SF, TheTok.Loc, TheTok.IsKeywordArgument};
+    collectAvailableRenameInfo(VD, RefInfo,
+                               RefactoringIds, RefactoringNameOS,
                                RefactoringReasonOS);
     collectAvailableRefactoringsOtherThanRename(SF, TheTok, RefactoringIds,
       RefactoringNameOS, RefactoringReasonOS);


### PR DESCRIPTION
This change makes us treat it exactly as we do `init`. We don't allow renaming the base name (just the labels), and don't fail if the base name doesn't match for calls.

Note: syntactically we can only go by the passed-in symbol name being spelled `callAsFunction` to check if we should treat it as such, so even non-instance methods with the same spelling are treated as having a special base name when they shouldn't at the moment.

This also fixes a bug where `init` references weren't reporting a `keywordBase` range, and cursor info was reporting rename as available on `init` references/calls with no arguments (meaning there was nothing that could be renamed from that occurrence). It also fixes bug where function calls were incorrectly being reported as references in some cases, so rename was missing their argument labels.

Resolves rdar://problem/60340429