### PR TITLE
[Diagnostics] Introduce `getLoc` and `getSourceRange` to failure diagnostic

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3317,8 +3317,8 @@ bool MissingMemberFailure::diagnoseAsError() {
       emitBasicError(baseType);
     }
   } else if (auto moduleTy = baseType->getAs<ModuleType>()) {
-    emitDiagnostic(diag::no_member_of_module, moduleTy->getModule()->getName(),
-                   getName())
+    emitDiagnosticAt(baseExpr->getLoc(), diag::no_member_of_module,
+                     moduleTy->getModule()->getName(), getName())
         .highlight(getSourceRange())
         .highlight(nameLoc.getSourceRange());
     return true;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -82,8 +82,14 @@ Type FailureDiagnostic::getType(const TypeLoc &loc, bool wantRValue) const {
 template <typename... ArgTypes>
 InFlightDiagnostic
 FailureDiagnostic::emitDiagnostic(ArgTypes &&... Args) const {
-  auto &cs = getConstraintSystem();
-  return cs.getASTContext().Diags.diagnose(std::forward<ArgTypes>(Args)...);
+  return emitDiagnosticAt(getLoc(), std::forward<ArgTypes>(Args)...);
+}
+
+template <typename... ArgTypes>
+InFlightDiagnostic
+FailureDiagnostic::emitDiagnosticAt(ArgTypes &&... Args) const {
+  auto &DE = getASTContext().Diags;
+  return DE.diagnose(std::forward<ArgTypes>(Args)...);
 }
 
 Expr *FailureDiagnostic::findParentExpr(Expr *subExpr) const {
@@ -308,7 +314,6 @@ bool RequirementFailure::isStaticOrInstanceMember(const ValueDecl *decl) {
 }
 
 bool RequirementFailure::diagnoseAsError() {
-  auto *anchor = getRawAnchor();
   const auto *reqDC = getRequirementDC();
   auto *genericCtx = getGenericContext();
 
@@ -317,13 +322,12 @@ bool RequirementFailure::diagnoseAsError() {
 
   if (auto *OTD = dyn_cast<OpaqueTypeDecl>(AffectedDecl)) {
     auto *namingDecl = OTD->getNamingDecl();
-    emitDiagnostic(
-        anchor->getLoc(), diag::type_does_not_conform_in_opaque_return,
-        namingDecl->getDescriptiveKind(), namingDecl->getFullName(), lhs, rhs,
-        rhs->isAnyObject());
+    emitDiagnostic(diag::type_does_not_conform_in_opaque_return,
+                   namingDecl->getDescriptiveKind(), namingDecl->getFullName(),
+                   lhs, rhs, rhs->isAnyObject());
 
     if (auto *repr = namingDecl->getOpaqueResultTypeRepr()) {
-      emitDiagnostic(repr->getLoc(), diag::opaque_return_type_declared_here)
+      emitDiagnosticAt(repr->getLoc(), diag::opaque_return_type_declared_here)
           .highlight(repr->getSourceRange());
     }
     return true;
@@ -333,13 +337,11 @@ bool RequirementFailure::diagnoseAsError() {
       (genericCtx->isChildContextOf(reqDC) ||
        isStaticOrInstanceMember(AffectedDecl))) {
     auto *NTD = reqDC->getSelfNominalTypeDecl();
-    emitDiagnostic(anchor->getLoc(), getDiagnosticInRereference(),
-                   AffectedDecl->getDescriptiveKind(),
-                   AffectedDecl->getFullName(), NTD->getDeclaredType(), lhs,
-                   rhs);
+    emitDiagnostic(
+        getDiagnosticInRereference(), AffectedDecl->getDescriptiveKind(),
+        AffectedDecl->getFullName(), NTD->getDeclaredType(), lhs, rhs);
   } else {
-    emitDiagnostic(anchor->getLoc(), getDiagnosticOnDecl(),
-                   AffectedDecl->getDescriptiveKind(),
+    emitDiagnostic(getDiagnosticOnDecl(), AffectedDecl->getDescriptiveKind(),
                    AffectedDecl->getFullName(), lhs, rhs);
   }
 
@@ -351,8 +353,8 @@ bool RequirementFailure::diagnoseAsNote() {
   const auto &req = getRequirement();
   const auto *reqDC = getRequirementDC();
 
-  emitDiagnostic(reqDC->getAsDecl(), getDiagnosticAsNote(), getLHS(), getRHS(),
-                 req.getFirstType(), req.getSecondType(), "");
+  emitDiagnosticAt(reqDC->getAsDecl(), getDiagnosticAsNote(), getLHS(),
+                   getRHS(), req.getFirstType(), req.getSecondType(), "");
   return true;
 }
 
@@ -367,33 +369,33 @@ void RequirementFailure::emitRequirementNote(const Decl *anchor, Type lhs,
       if (TypeChecker::typesSatisfyConstraint(wrappedType, rhs,
                                               /*openArchetypes=*/false,
                                               kind, getDC()))
-        emitDiagnostic(getAnchor()->getLoc(),
-                       diag::wrapped_type_satisfies_requirement, wrappedType);
+        emitDiagnostic(diag::wrapped_type_satisfies_requirement, wrappedType);
     }
   }
 
   if (isConditional()) {
-    emitDiagnostic(anchor, diag::requirement_implied_by_conditional_conformance,
-                   resolveType(Conformance->getType()),
-                   Conformance->getProtocol()->getDeclaredInterfaceType());
+    emitDiagnosticAt(anchor,
+                     diag::requirement_implied_by_conditional_conformance,
+                     resolveType(Conformance->getType()),
+                     Conformance->getProtocol()->getDeclaredInterfaceType());
     return;
   }
 
   if (req.getKind() == RequirementKind::Layout ||
       rhs->isEqual(req.getSecondType())) {
-    emitDiagnostic(anchor, diag::where_requirement_failure_one_subst,
-                   req.getFirstType(), lhs);
+    emitDiagnosticAt(anchor, diag::where_requirement_failure_one_subst,
+                     req.getFirstType(), lhs);
     return;
   }
 
   if (lhs->isEqual(req.getFirstType())) {
-    emitDiagnostic(anchor, diag::where_requirement_failure_one_subst,
-                   req.getSecondType(), rhs);
+    emitDiagnosticAt(anchor, diag::where_requirement_failure_one_subst,
+                     req.getSecondType(), rhs);
     return;
   }
 
-  emitDiagnostic(anchor, diag::where_requirement_failure_both_subst,
-                 req.getFirstType(), lhs, req.getSecondType(), rhs);
+  emitDiagnosticAt(anchor, diag::where_requirement_failure_both_subst,
+                   req.getFirstType(), lhs, req.getSecondType(), rhs);
 }
 
 bool MissingConformanceFailure::diagnoseAsError() {
@@ -430,12 +432,12 @@ bool MissingConformanceFailure::diagnoseAsError() {
     return true;
 
   if (nonConformingType->isObjCExistentialType()) {
-    emitDiagnostic(anchor->getLoc(), diag::protocol_does_not_conform_static,
-                   nonConformingType, protocolType);
+    emitDiagnostic(diag::protocol_does_not_conform_static, nonConformingType,
+                   protocolType);
     return true;
   }
 
-  if (diagnoseTypeCannotConform(anchor, nonConformingType, protocolType))
+  if (diagnoseTypeCannotConform(nonConformingType, protocolType))
     return true;
 
   // If none of the special cases could be diagnosed,
@@ -443,7 +445,7 @@ bool MissingConformanceFailure::diagnoseAsError() {
   return RequirementFailure::diagnoseAsError();
 }
 
-bool MissingConformanceFailure::diagnoseTypeCannotConform(Expr *anchor,
+bool MissingConformanceFailure::diagnoseTypeCannotConform(
     Type nonConformingType, Type protocolType) const {
   if (getRequirement().getKind() == RequirementKind::Layout ||
       !(nonConformingType->is<AnyFunctionType>() ||
@@ -453,15 +455,16 @@ bool MissingConformanceFailure::diagnoseTypeCannotConform(Expr *anchor,
     return false;
   }
 
-  emitDiagnostic(anchor->getLoc(), diag::type_cannot_conform,
+  emitDiagnostic(diag::type_cannot_conform,
                  nonConformingType->isExistentialType(), nonConformingType,
                  protocolType);
 
   if (auto *OTD = dyn_cast<OpaqueTypeDecl>(AffectedDecl)) {
     auto *namingDecl = OTD->getNamingDecl();
     if (auto *repr = namingDecl->getOpaqueResultTypeRepr()) {
-      emitDiagnostic(repr->getLoc(), diag::required_by_opaque_return,
-                     namingDecl->getDescriptiveKind(), namingDecl->getFullName())
+      emitDiagnosticAt(repr->getLoc(), diag::required_by_opaque_return,
+                       namingDecl->getDescriptiveKind(),
+                       namingDecl->getFullName())
           .highlight(repr->getSourceRange());
     }
     return true;
@@ -473,24 +476,25 @@ bool MissingConformanceFailure::diagnoseTypeCannotConform(Expr *anchor,
   auto noteLocation = reqDC->getAsDecl()->getLoc();
 
   if (!noteLocation.isValid())
-    noteLocation = anchor->getLoc();
+    noteLocation = getLoc();
 
   if (isConditional()) {
-    emitDiagnostic(noteLocation, diag::requirement_implied_by_conditional_conformance,
-                   resolveType(Conformance->getType()),
-                   Conformance->getProtocol()->getDeclaredInterfaceType());
+    emitDiagnosticAt(noteLocation,
+                     diag::requirement_implied_by_conditional_conformance,
+                     resolveType(Conformance->getType()),
+                     Conformance->getProtocol()->getDeclaredInterfaceType());
   } else if (genericCtx != reqDC && (genericCtx->isChildContextOf(reqDC) ||
                                      isStaticOrInstanceMember(AffectedDecl))) {
-    emitDiagnostic(noteLocation, diag::required_by_decl_ref,
-                   AffectedDecl->getDescriptiveKind(),
-                   AffectedDecl->getFullName(),
-                   reqDC->getSelfNominalTypeDecl()->getDeclaredType(),
-                   req.getFirstType(), nonConformingType);
+    emitDiagnosticAt(noteLocation, diag::required_by_decl_ref,
+                     AffectedDecl->getDescriptiveKind(),
+                     AffectedDecl->getFullName(),
+                     reqDC->getSelfNominalTypeDecl()->getDeclaredType(),
+                     req.getFirstType(), nonConformingType);
   } else {
-    emitDiagnostic(noteLocation, diag::required_by_decl,
-                   AffectedDecl->getDescriptiveKind(),
-                   AffectedDecl->getFullName(), req.getFirstType(),
-                   nonConformingType);
+    emitDiagnosticAt(noteLocation, diag::required_by_decl,
+                     AffectedDecl->getDescriptiveKind(),
+                     AffectedDecl->getFullName(), req.getFirstType(),
+                     nonConformingType);
   }
 
   return true;
@@ -518,15 +522,15 @@ bool MissingConformanceFailure::diagnoseAsAmbiguousOperatorRef() {
     auto rhsType = params[1].getPlainType();
 
     if (lhsType->isEqual(rhsType)) {
-      emitDiagnostic(anchor->getLoc(), diag::cannot_apply_binop_to_same_args,
-                     operatorID.str(), lhsType);
+      emitDiagnostic(diag::cannot_apply_binop_to_same_args, operatorID.str(),
+                     lhsType);
     } else {
-      emitDiagnostic(anchor->getLoc(), diag::cannot_apply_binop_to_args,
-                     operatorID.str(), lhsType, rhsType);
+      emitDiagnostic(diag::cannot_apply_binop_to_args, operatorID.str(),
+                     lhsType, rhsType);
     }
   } else {
-    emitDiagnostic(anchor->getLoc(), diag::cannot_apply_unop_to_arg,
-                   operatorID.str(), params[0].getPlainType());
+    emitDiagnostic(diag::cannot_apply_unop_to_arg, operatorID.str(),
+                   params[0].getPlainType());
   }
 
   diagnoseAsNote();
@@ -593,12 +597,11 @@ void GenericArgumentsMismatchFailure::emitNoteForMismatch(int position) {
 
   auto noteLocation = param->getLoc();
 
-  if (!noteLocation.isValid()) {
-    noteLocation = getAnchor()->getLoc();
-  }
+  if (!noteLocation.isValid())
+    noteLocation = getLoc();
 
-  emitDiagnostic(noteLocation, diag::generic_argument_mismatch,
-                 param->getName(), lhs, rhs);
+  emitDiagnosticAt(noteLocation, diag::generic_argument_mismatch,
+                   param->getName(), lhs, rhs);
 }
 
 bool GenericArgumentsMismatchFailure::diagnoseAsError() {
@@ -712,7 +715,7 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
   if (!diagnostic)
     return false;
 
-  emitDiagnostic(anchor->getLoc(), *diagnostic, fromType, toType);
+  emitDiagnosticAt(anchor->getLoc(), *diagnostic, fromType, toType);
   emitNotesForMismatches();
   return true;
 }
@@ -758,8 +761,9 @@ bool LabelingFailure::diagnoseAsNote() {
 
   const auto &choice = selectedOverload->choice;
   if (auto *decl = choice.getDeclOrNull()) {
-    emitDiagnostic(decl, diag::candidate_expected_different_labels,
-                   stringifyLabels(argLabels), stringifyLabels(CorrectLabels));
+    emitDiagnosticAt(decl, diag::candidate_expected_different_labels,
+                     stringifyLabels(argLabels),
+                     stringifyLabels(CorrectLabels));
     return true;
   }
 
@@ -767,20 +771,17 @@ bool LabelingFailure::diagnoseAsNote() {
 }
 
 bool NoEscapeFuncToTypeConversionFailure::diagnoseAsError() {
-  auto *anchor = getAnchor();
-
   if (diagnoseParameterUse())
     return true;
 
   if (auto *typeVar = getRawFromType()->getAs<TypeVariableType>()) {
     if (auto *GP = typeVar->getImpl().getGenericParameter()) {
-      emitDiagnostic(anchor->getLoc(), diag::converting_noescape_to_type, GP);
+      emitDiagnostic(diag::converting_noescape_to_type, GP);
       return true;
     }
   }
 
-  emitDiagnostic(anchor->getLoc(), diag::converting_noescape_to_type,
-                 getToType());
+  emitDiagnostic(diag::converting_noescape_to_type, getToType());
   return true;
 }
 
@@ -810,13 +811,12 @@ bool NoEscapeFuncToTypeConversionFailure::diagnoseParameterUse() const {
       auto paramInterfaceTy = argApplyInfo->getParamInterfaceType();
       if (paramInterfaceTy->isTypeParameter()) {
         auto diagnoseGenericParamFailure = [&](GenericTypeParamDecl *decl) {
-          emitDiagnostic(anchor->getLoc(),
-                         diag::converting_noespace_param_to_generic_type,
+          emitDiagnostic(diag::converting_noespace_param_to_generic_type,
                          PD->getName(), paramInterfaceTy);
 
           auto declLoc = decl->getLoc();
           if (declLoc.isValid())
-            emitDiagnostic(decl, diag::generic_parameters_always_escaping);
+            emitDiagnosticAt(decl, diag::generic_parameters_always_escaping);
         };
 
         // If this is a situation when non-escaping parameter is passed
@@ -848,11 +848,10 @@ bool NoEscapeFuncToTypeConversionFailure::diagnoseParameterUse() const {
   if (!PD)
     return false;
 
-  emitDiagnostic(anchor->getLoc(), diagnostic, PD->getName());
+  emitDiagnostic(diagnostic, PD->getName());
 
   // Give a note and fix-it
-  auto note =
-      emitDiagnostic(PD->getLoc(), diag::noescape_parameter, PD->getName());
+  auto note = emitDiagnosticAt(PD, diag::noescape_parameter, PD->getName());
 
   if (!PD->isAutoClosure()) {
     SourceLoc reprLoc;
@@ -874,30 +873,25 @@ Expr *MissingForcedDowncastFailure::getAnchor() const {
 }
 
 bool MissingForcedDowncastFailure::diagnoseAsError() {
-  auto *coerceExpr = cast<CoerceExpr>(getAnchor());
-
   auto fromType = getFromType();
   auto toType = getToType();
 
-  emitDiagnostic(coerceExpr->getLoc(), diag::missing_forced_downcast, fromType,
-                 toType)
-      .highlight(coerceExpr->getSourceRange())
-      .fixItReplace(coerceExpr->getLoc(), "as!");
+  emitDiagnostic(diag::missing_forced_downcast, fromType, toType)
+      .highlight(getSourceRange())
+      .fixItReplace(getLoc(), "as!");
   return true;
 }
 
 bool MissingAddressOfFailure::diagnoseAsError() {
-  auto *anchor = getAnchor();
   auto argTy = getFromType();
   auto paramTy = getToType();
 
   if (paramTy->getAnyPointerElementType()) {
-    emitDiagnostic(anchor->getLoc(), diag::cannot_convert_argument_value, argTy,
-                   paramTy)
-        .fixItInsert(anchor->getStartLoc(), "&");
+    emitDiagnostic(diag::cannot_convert_argument_value, argTy, paramTy)
+        .fixItInsert(getSourceRange().Start, "&");
   } else {
-    emitDiagnostic(anchor->getLoc(), diag::missing_address_of, argTy)
-        .fixItInsert(anchor->getStartLoc(), "&");
+    emitDiagnostic(diag::missing_address_of, argTy)
+        .fixItInsert(getSourceRange().Start, "&");
   }
   return true;
 }
@@ -962,11 +956,12 @@ bool MissingExplicitConversionFailure::diagnoseAsError() {
 
   auto diagID =
       useAs ? diag::missing_explicit_conversion : diag::missing_forced_downcast;
-  auto diag = emitDiagnostic(anchor->getLoc(), diagID, fromType, toType);
+  auto diag = emitDiagnostic(diagID, fromType, toType);
+
   if (!insertBefore.empty()) {
-    diag.fixItInsert(anchor->getStartLoc(), insertBefore);
+    diag.fixItInsert(getSourceRange().Start, insertBefore);
   }
-  diag.fixItInsertAfter(anchor->getEndLoc(), insertAfter);
+  diag.fixItInsertAfter(getSourceRange().End, insertAfter);
   return true;
 }
 
@@ -987,20 +982,20 @@ bool MemberAccessOnOptionalBaseFailure::diagnoseAsError() {
   if (!unwrappedBaseType)
     return false;
 
-  emitDiagnostic(anchor->getLoc(), diag::optional_base_not_unwrapped,
-                 baseType, Member, unwrappedBaseType);
+  emitDiagnostic(diag::optional_base_not_unwrapped, baseType, Member,
+                 unwrappedBaseType);
 
   // FIXME: It would be nice to immediately offer "base?.member ?? defaultValue"
   // for non-optional results where that would be appropriate. For the moment
   // always offering "?" means that if the user chooses chaining, we'll end up
   // in MissingOptionalUnwrapFailure:diagnose() to offer a default value during
   // the next compile.
-  emitDiagnostic(anchor->getLoc(), diag::optional_base_chain, Member)
-      .fixItInsertAfter(anchor->getEndLoc(), "?");
+  emitDiagnostic(diag::optional_base_chain, Member)
+      .fixItInsertAfter(getSourceRange().End, "?");
 
   if (!resultIsOptional) {
-    emitDiagnostic(anchor->getLoc(), diag::unwrap_with_force_value)
-      .fixItInsertAfter(anchor->getEndLoc(), "!");
+    emitDiagnostic(diag::unwrap_with_force_value)
+        .fixItInsertAfter(getSourceRange().End, "!");
   }
 
   return true;
@@ -1021,7 +1016,7 @@ void MissingOptionalUnwrapFailure::offerDefaultValueUnwrapFixIt(
     if (argApplyInfo->getParameterFlags().isInOut())
       return;
 
-  auto diag = emitDiagnostic(expr->getLoc(), diag::unwrap_with_default_value);
+  auto diag = emitDiagnosticAt(expr->getLoc(), diag::unwrap_with_default_value);
 
   // Figure out what we need to parenthesize.
   bool needsParensInside =
@@ -1051,7 +1046,7 @@ void MissingOptionalUnwrapFailure::offerDefaultValueUnwrapFixIt(
 
 // Suggest a force-unwrap.
 void MissingOptionalUnwrapFailure::offerForceUnwrapFixIt(Expr *expr) const {
-  auto diag = emitDiagnostic(expr->getLoc(), diag::unwrap_with_force_value);
+  auto diag = emitDiagnosticAt(expr->getLoc(), diag::unwrap_with_force_value);
 
   // If expr is optional as the result of an optional chain and this last
   // dot isn't a member returning optional, then offer to force the last
@@ -1125,8 +1120,8 @@ bool MissingOptionalUnwrapFailure::diagnoseAsError() {
       return false;
     }
 
-    emitDiagnostic(tryExpr->getTryLoc(), diag::missing_unwrap_optional_try,
-                   getType(anchor))
+    emitDiagnosticAt(tryExpr->getTryLoc(), diag::missing_unwrap_optional_try,
+                     getType(anchor))
         .fixItReplace({tryExpr->getTryLoc(), tryExpr->getQuestionLoc()},
                       "try!");
     return true;
@@ -1143,8 +1138,8 @@ bool MissingOptionalUnwrapFailure::diagnoseAsError() {
   if (!baseType->getOptionalObjectType())
     return false;
 
-  emitDiagnostic(unwrappedExpr->getLoc(), diag::optional_not_unwrapped,
-                 baseType, unwrappedType);
+  emitDiagnosticAt(unwrappedExpr->getLoc(), diag::optional_not_unwrapped,
+                   baseType, unwrappedType);
 
   // If the expression we're unwrapping is the only reference to a
   // local variable whose type isn't explicit in the source, then
@@ -1171,8 +1166,8 @@ bool MissingOptionalUnwrapFailure::diagnoseAsError() {
 
         if (auto declRefExpr = dyn_cast<DeclRefExpr>(initializer)) {
           if (declRefExpr->getDecl()->isImplicitlyUnwrappedOptional()) {
-            emitDiagnostic(declRefExpr->getLoc(), diag::unwrap_iuo_initializer,
-                           baseType);
+            emitDiagnosticAt(declRefExpr->getLoc(),
+                             diag::unwrap_iuo_initializer, baseType);
           }
         }
 
@@ -1180,7 +1175,8 @@ bool MissingOptionalUnwrapFailure::diagnoseAsError() {
         bool voidReturn =
             fnTy->getResult()->isEqual(TupleType::getEmpty(getASTContext()));
 
-        auto diag = emitDiagnostic(varDecl->getLoc(), diag::unwrap_with_guard);
+        auto diag =
+            emitDiagnosticAt(varDecl->getLoc(), diag::unwrap_with_guard);
         diag.fixItInsert(binding->getStartLoc(), "guard ");
         if (voidReturn) {
           diag.fixItInsertAfter(binding->getEndLoc(), " else { return }");
@@ -1278,8 +1274,8 @@ bool RValueTreatedAsLValueFailure::diagnoseAsError() {
           if (cs.isArrayType(argType) &&
               paramType->getAnyPointerElementType(ptr) &&
               (ptr == PTK_UnsafePointer || ptr == PTK_UnsafeRawPointer)) {
-            emitDiagnostic(inoutExpr->getLoc(),
-                           diag::extra_address_of_unsafepointer, paramType)
+            emitDiagnosticAt(inoutExpr->getLoc(),
+                             diag::extra_address_of_unsafepointer, paramType)
                 .highlight(inoutExpr->getSourceRange())
                 .fixItRemove(inoutExpr->getStartLoc());
             return true;
@@ -1305,12 +1301,13 @@ bool RValueTreatedAsLValueFailure::diagnoseAsError() {
         if (baseRef->getDecl() == ctor->getImplicitSelfDecl() &&
             ctor->getDelegatingOrChainedInitKind(nullptr) ==
             ConstructorDecl::BodyInitKind::Delegating) {
-          emitDiagnostic(loc, diag::assignment_let_property_delegating_init,
-                      member->getName());
+          emitDiagnosticAt(loc, diag::assignment_let_property_delegating_init,
+                           member->getName());
           if (auto overload = getOverloadChoiceIfAvailable(
                   getConstraintLocator(member, ConstraintLocator::Member))) {
             if (auto *ref = overload->choice.getDeclOrNull())
-              emitDiagnostic(ref, diag::decl_declared_here, ref->getFullName());
+              emitDiagnosticAt(ref, diag::decl_declared_here,
+                               ref->getFullName());
           }
           return true;
         }
@@ -1346,8 +1343,8 @@ bool RValueTreatedAsLValueFailure::diagnoseAsNote() {
     return false;
 
   auto *decl = overload->choice.getDecl();
-  emitDiagnostic(decl, diag::candidate_is_not_assignable,
-                 decl->getDescriptiveKind(), decl->getFullName());
+  emitDiagnosticAt(decl, diag::candidate_is_not_assignable,
+                   decl->getDescriptiveKind(), decl->getFullName());
   return true;
 }
 
@@ -1447,7 +1444,7 @@ bool TrailingClosureAmbiguityFailure::diagnoseAsNote() {
   // If we got here, then all of the choices have unique labels. Offer them in
   // order.
   for (const auto &choicePair : choicesByLabel) {
-    auto diag = emitDiagnostic(
+    auto diag = emitDiagnosticAt(
         expr->getLoc(), diag::ambiguous_because_of_trailing_closure,
         choicePair.first.empty(), choicePair.second->getFullName());
     swift::fixItEncloseTrailingClosure(getASTContext(), diag, callExpr,
@@ -1494,7 +1491,7 @@ bool AssignmentFailure::diagnoseAsError() {
                 "'" + identifier.str().str() + "' is a read-only key path";
           }
         }
-        emitDiagnostic(Loc, DeclDiagnostic, message)
+        emitDiagnosticAt(Loc, DeclDiagnostic, message)
             .highlight(immutableExpr->getSourceRange());
         return true;
       }
@@ -1527,7 +1524,7 @@ bool AssignmentFailure::diagnoseAsError() {
         message += " is immutable";
       }
 
-      emitDiagnostic(Loc, DeclDiagnostic, message)
+      emitDiagnosticAt(Loc, DeclDiagnostic, message)
           .highlight(immutableExpr->getSourceRange());
 
       // If there is a masked property of the same type, emit a
@@ -1572,8 +1569,8 @@ bool AssignmentFailure::diagnoseAsError() {
           } else {
             fixItText = selfTy->getString() + ".";
           }
-          emitDiagnostic(startLoc, diag::masked_mutable_property,
-                         fixItText, property->getDescriptiveKind(), selfTy)
+          emitDiagnosticAt(startLoc, diag::masked_mutable_property, fixItText,
+                           property->getDescriptiveKind(), selfTy)
               .fixItInsert(startLoc, fixItText);
         }
       }
@@ -1594,7 +1591,7 @@ bool AssignmentFailure::diagnoseAsError() {
       else
         message = "subscript is immutable";
 
-      emitDiagnostic(Loc, DeclDiagnostic, message)
+      emitDiagnosticAt(Loc, DeclDiagnostic, message)
           .highlight(immutableExpr->getSourceRange());
       return true;
     }
@@ -1616,7 +1613,7 @@ bool AssignmentFailure::diagnoseAsError() {
       } else
         message += " is not settable";
 
-      emitDiagnostic(Loc, diagID, message)
+      emitDiagnosticAt(Loc, diagID, message)
           .highlight(immutableExpr->getSourceRange());
       return true;
     }
@@ -1628,13 +1625,13 @@ bool AssignmentFailure::diagnoseAsError() {
   // If a keypath was the problem but wasn't resolved into a vardecl
   // it is ambiguous or unable to be used for setting.
   if (auto *KPE = dyn_cast_or_null<KeyPathExpr>(immutableExpr)) {
-    emitDiagnostic(Loc, DeclDiagnostic, "immutable key path")
+    emitDiagnosticAt(Loc, DeclDiagnostic, "immutable key path")
         .highlight(KPE->getSourceRange());
     return true;
   }
 
   if (auto LE = dyn_cast<LiteralExpr>(immutableExpr)) {
-    emitDiagnostic(Loc, DeclDiagnostic, "literals are not mutable")
+    emitDiagnosticAt(Loc, DeclDiagnostic, "literals are not mutable")
         .highlight(LE->getSourceRange());
     return true;
   }
@@ -1649,7 +1646,7 @@ bool AssignmentFailure::diagnoseAsError() {
         argsTuple->getNumElements() == 1) {
       if (auto LE = dyn_cast<LiteralExpr>(
               argsTuple->getElement(0)->getSemanticsProvidingExpr())) {
-        emitDiagnostic(Loc, DeclDiagnostic, "literals are not mutable")
+        emitDiagnosticAt(Loc, DeclDiagnostic, "literals are not mutable")
             .highlight(LE->getSourceRange());
         return true;
       }
@@ -1669,7 +1666,7 @@ bool AssignmentFailure::diagnoseAsError() {
       name = std::string("'") +
              DRE->getDecl()->getBaseIdentifier().str().str() + "'";
 
-    emitDiagnostic(Loc, DeclDiagnostic, name + " returns immutable value")
+    emitDiagnosticAt(Loc, DeclDiagnostic, name + " returns immutable value")
         .highlight(AE->getSourceRange());
     return true;
   }
@@ -1679,10 +1676,10 @@ bool AssignmentFailure::diagnoseAsError() {
     Type actualType = getType(immutableExpr)->getInOutObjectType();
     if (!neededType->isEqual(actualType)) {
       if (DeclDiagnostic.ID != diag::cannot_pass_rvalue_inout_subelement.ID) {
-        emitDiagnostic(Loc, DeclDiagnostic,
-                       "implicit conversion from '" + actualType->getString() +
-                           "' to '" + neededType->getString() +
-                           "' requires a temporary")
+        emitDiagnosticAt(Loc, DeclDiagnostic,
+                         "implicit conversion from '" +
+                             actualType->getString() + "' to '" +
+                             neededType->getString() + "' requires a temporary")
             .highlight(immutableExpr->getSourceRange());
       }
       return true;
@@ -1690,14 +1687,14 @@ bool AssignmentFailure::diagnoseAsError() {
   }
 
   if (auto IE = dyn_cast<IfExpr>(immutableExpr)) {
-    emitDiagnostic(Loc, DeclDiagnostic,
-                   "result of conditional operator '? :' is never mutable")
+    emitDiagnosticAt(Loc, DeclDiagnostic,
+                     "result of conditional operator '? :' is never mutable")
         .highlight(IE->getQuestionLoc())
         .highlight(IE->getColonLoc());
     return true;
   }
 
-  emitDiagnostic(Loc, TypeDiagnostic, getType(DestExpr))
+  emitDiagnosticAt(Loc, TypeDiagnostic, getType(DestExpr))
       .highlight(immutableExpr->getSourceRange());
   return true;
 }
@@ -1888,8 +1885,8 @@ bool ContextualFailure::diagnoseAsError() {
   if (CTP == CTP_ReturnSingleExpr || CTP == CTP_ReturnStmt) {
     // Special case the "conversion to void".
     if (getToType()->isVoid()) {
-      emitDiagnostic(anchor->getLoc(), diag::cannot_return_value_from_void_func)
-          .highlight(anchor->getSourceRange());
+      emitDiagnostic(diag::cannot_return_value_from_void_func)
+          .highlight(getSourceRange());
       return true;
     }
   }
@@ -1899,9 +1896,9 @@ bool ContextualFailure::diagnoseAsError() {
 
   if (path.empty()) {
     if (auto *KPE = dyn_cast<KeyPathExpr>(anchor)) {
-      emitDiagnostic(KPE->getLoc(),
-                     diag::expr_smart_keypath_value_covert_to_contextual_type,
-                     getFromType(), getToType());
+      emitDiagnosticAt(KPE->getLoc(),
+                       diag::expr_smart_keypath_value_covert_to_contextual_type,
+                       getFromType(), getToType());
       return true;
     }
     
@@ -1909,14 +1906,13 @@ bool ContextualFailure::diagnoseAsError() {
       return true;
 
     if (isa<OptionalTryExpr>(anchor)) {
-      emitDiagnostic(anchor->getLoc(), diag::cannot_convert_initializer_value,
-                     getFromType(), getToType());
+      emitDiagnostic(diag::cannot_convert_initializer_value, getFromType(),
+                     getToType());
       return true;
     }
 
     if (isa<AssignExpr>(anchor)) {
-      emitDiagnostic(anchor->getLoc(), diag::cannot_convert_assign,
-                     getFromType(), getToType());
+      emitDiagnostic(diag::cannot_convert_assign, getFromType(), getToType());
       return true;
     }
 
@@ -1929,10 +1925,9 @@ bool ContextualFailure::diagnoseAsError() {
   // Special case of some common conversions involving Swift.String
   // indexes, catching cases where people attempt to index them with an integer.
   if (isIntegerToStringIndexConversion()) {
-    emitDiagnostic(anchor->getLoc(), diag::string_index_not_integer,
-                   getFromType())
-        .highlight(anchor->getSourceRange());
-    emitDiagnostic(anchor->getLoc(), diag::string_index_not_integer_note);
+    emitDiagnostic(diag::string_index_not_integer, getFromType())
+        .highlight(getSourceRange());
+    emitDiagnostic(diag::string_index_not_integer_note);
     return true;
   }
 
@@ -1947,8 +1942,9 @@ bool ContextualFailure::diagnoseAsError() {
     if (closure->hasExplicitResultType() &&
         closure->getExplicitResultTypeLoc().getTypeRepr()) {
       auto resultRepr = closure->getExplicitResultTypeLoc().getTypeRepr();
-      emitDiagnostic(resultRepr->getStartLoc(),
-                     diag::incorrect_explicit_closure_result, fromType, toType)
+      emitDiagnosticAt(resultRepr->getStartLoc(),
+                       diag::incorrect_explicit_closure_result, fromType,
+                       toType)
           .fixItReplace(resultRepr->getSourceRange(), toType.getString());
       return true;
     }
@@ -2005,16 +2001,15 @@ bool ContextualFailure::diagnoseAsError() {
 
     if (CTP == CTP_ForEachStmt) {
       if (fromType->isAnyExistentialType()) {
-        emitDiagnostic(anchor->getLoc(), diag::type_cannot_conform,
+        emitDiagnostic(diag::type_cannot_conform,
                        /*isExistentialType=*/true, fromType, toType);
         return true;
       }
 
       emitDiagnostic(
-          anchor->getLoc(),
           diag::foreach_sequence_does_not_conform_to_expected_protocol,
           fromType, toType, bool(fromType->getOptionalObjectType()))
-          .highlight(anchor->getSourceRange());
+          .highlight(getSourceRange());
       return true;
     }
 
@@ -2041,8 +2036,7 @@ bool ContextualFailure::diagnoseAsError() {
     auto *choice = overload->choice.getDecl();
     auto fnType = fromType->getAs<FunctionType>();
     if (!fnType) {
-      emitDiagnostic(anchor->getLoc(),
-                     diag::expected_result_in_contextual_member,
+      emitDiagnostic(diag::expected_result_in_contextual_member,
                      choice->getFullName(), fromType, toType);
       return true;
     }
@@ -2068,16 +2062,14 @@ bool ContextualFailure::diagnoseAsError() {
 
     if (numMissingArgs == 0 || numMissingArgs > 1) {
       auto diagnostic = emitDiagnostic(
-          anchor->getLoc(), diag::expected_parens_in_contextual_member,
-          choice->getFullName());
+          diag::expected_parens_in_contextual_member, choice->getFullName());
 
       // If there are no parameters we can suggest a fix-it
       // to form an explicit call.
       if (numMissingArgs == 0)
-        diagnostic.fixItInsertAfter(anchor->getEndLoc(), "()");
+        diagnostic.fixItInsertAfter(getSourceRange().End, "()");
     } else {
-      emitDiagnostic(anchor->getLoc(),
-                     diag::expected_argument_in_contextual_member,
+      emitDiagnostic(diag::expected_argument_in_contextual_member,
                      choice->getFullName(), params.front().getPlainType());
     }
 
@@ -2088,9 +2080,8 @@ bool ContextualFailure::diagnoseAsError() {
     return false;
   }
 
-  auto diag =
-      emitDiagnostic(anchor->getLoc(), diagnostic, fromType, toType);
-  diag.highlight(anchor->getSourceRange());
+  auto diag = emitDiagnostic(diagnostic, fromType, toType);
+  diag.highlight(getSourceRange());
 
   (void)tryFixIts(diag);
   return true;
@@ -2102,7 +2093,7 @@ bool ContextualFailure::diagnoseAsNote() {
     return false;
 
   auto *decl = overload->choice.getDecl();
-  emitDiagnostic(decl, diag::found_candidate_type, getFromType());
+  emitDiagnosticAt(decl, diag::found_candidate_type, getFromType());
   return true;
 }
 
@@ -2178,7 +2169,7 @@ bool ContextualFailure::diagnoseConversionToNil() const {
 
     // Looks like it's something similar to `let _ = nil`.
     if (!parentExpr) {
-      emitDiagnostic(anchor->getLoc(), diag::unresolved_nil_literal);
+      emitDiagnostic(diag::unresolved_nil_literal);
       return true;
     }
 
@@ -2198,7 +2189,7 @@ bool ContextualFailure::diagnoseConversionToNil() const {
         // If there is no enclosing expression it's something like
         // `(nil)` or `(a: nil)` which can't be inferred without a
         // contextual type.
-        emitDiagnostic(anchor->getLoc(), diag::unresolved_nil_literal);
+        emitDiagnostic(diag::unresolved_nil_literal);
         return true;
       }
 
@@ -2227,8 +2218,7 @@ bool ContextualFailure::diagnoseConversionToNil() const {
       CTP = CTP_CoerceOperand;
     } else {
       // Otherwise let's produce a generic `nil` conversion diagnostic.
-      emitDiagnostic(anchor->getLoc(), diag::cannot_use_nil_with_this_type,
-                     getToType());
+      emitDiagnostic(diag::cannot_use_nil_with_this_type, getToType());
       return true;
     }
   }
@@ -2237,7 +2227,7 @@ bool ContextualFailure::diagnoseConversionToNil() const {
     return false;
 
   if (CTP == CTP_ThrowStmt) {
-    emitDiagnostic(anchor->getLoc(), diag::cannot_throw_nil);
+    emitDiagnostic(diag::cannot_throw_nil);
     return true;
   }
 
@@ -2245,15 +2235,15 @@ bool ContextualFailure::diagnoseConversionToNil() const {
   if (!diagnostic)
     return false;
 
-  emitDiagnostic(anchor->getLoc(), *diagnostic, getToType());
+  emitDiagnostic(*diagnostic, getToType());
 
   if (CTP == CTP_Initialization) {
-    auto *patternTR = getContextualTypeLoc(locator->getAnchor()).getTypeRepr();
+    auto *patternTR = getContextualTypeLoc(getRawAnchor()).getTypeRepr();
     if (!patternTR)
       return true;
 
-    auto diag = emitDiagnostic(patternTR->getLoc(), diag::note_make_optional,
-                               OptionalType::get(getToType()));
+    auto diag = emitDiagnosticAt(patternTR->getLoc(), diag::note_make_optional,
+                                 OptionalType::get(getToType()));
     if (patternTR->isSimple()) {
       diag.fixItInsertAfter(patternTR->getEndLoc(), "?");
     } else {
@@ -2312,24 +2302,21 @@ bool ContextualFailure::diagnoseMissingFunctionCall() const {
           getLocator()->getLastElementAs<LocatorPathElt::PatternMatch>()) {
     if (auto enumElementPattern =
             dyn_cast<EnumElementPattern>(match->getPattern())) {
-      emitDiagnostic(enumElementPattern->getNameLoc(),
-                     diag::enum_element_pattern_assoc_values_mismatch,
-                     enumElementPattern->getName());
-      emitDiagnostic(enumElementPattern->getNameLoc(),
-                     diag::enum_element_pattern_assoc_values_remove)
-        .fixItRemove(enumElementPattern->getSubPattern()->getSourceRange());
+      emitDiagnosticAt(enumElementPattern->getNameLoc(),
+                       diag::enum_element_pattern_assoc_values_mismatch,
+                       enumElementPattern->getName());
+      emitDiagnosticAt(enumElementPattern->getNameLoc(),
+                       diag::enum_element_pattern_assoc_values_remove)
+          .fixItRemove(enumElementPattern->getSubPattern()->getSourceRange());
       return true;
     }
   }
 
-  auto *anchor = getAnchor();
-  emitDiagnostic(anchor->getLoc(), diag::missing_nullary_call,
-                 srcFT->getResult())
-      .highlight(anchor->getSourceRange())
-      .fixItInsertAfter(anchor->getEndLoc(), "()");
+  emitDiagnostic(diag::missing_nullary_call, srcFT->getResult())
+      .highlight(getSourceRange())
+      .fixItInsertAfter(getSourceRange().End, "()");
 
-  tryComputedPropertyFixIts(anchor);
-
+  tryComputedPropertyFixIts();
   return true;
 }
 
@@ -2342,9 +2329,8 @@ bool ContextualFailure::diagnoseCoercionToUnrelatedType() const {
 
     auto diagnostic = getDiagnosticFor(CTP_CoerceOperand, toType);
 
-    auto diag =
-        emitDiagnostic(anchor->getLoc(), *diagnostic, fromType, toType);
-    diag.highlight(anchor->getSourceRange());
+    auto diag = emitDiagnostic(*diagnostic, fromType, toType);
+    diag.highlight(getSourceRange());
 
     (void)tryFixIts(diag);
     
@@ -2359,10 +2345,10 @@ bool ContextualFailure::diagnoseConversionToBool() const {
   if (!toType->isBool())
     return false;
 
-  auto *expr = getAnchor();
+  const auto *expr = getAnchor();
   // Check for "=" converting to Bool.  The user probably meant ==.
   if (auto *AE = dyn_cast<AssignExpr>(expr->getValueProvidingExpr())) {
-    emitDiagnostic(AE->getEqualLoc(), diag::use_of_equal_instead_of_equality)
+    emitDiagnosticAt(AE->getEqualLoc(), diag::use_of_equal_instead_of_equality)
         .fixItReplace(AE->getEqualLoc(), "==")
         .highlight(AE->getDest()->getLoc())
         .highlight(AE->getSrc()->getLoc());
@@ -2411,10 +2397,10 @@ bool ContextualFailure::diagnoseConversionToBool() const {
     }
     // FIXME: The outer parentheses may be superfluous too.
 
-    emitDiagnostic(expr->getLoc(), diag::optional_used_as_boolean, fromType,
+    emitDiagnostic(diag::optional_used_as_boolean, fromType,
                    notOperatorLoc.isValid())
-        .fixItInsert(expr->getStartLoc(), prefix)
-        .fixItInsertAfter(expr->getEndLoc(), suffix)
+        .fixItInsert(getSourceRange().Start, prefix)
+        .fixItInsertAfter(getSourceRange().End, suffix)
         .fixItRemove(notOperatorLoc);
     return true;
   }
@@ -2442,10 +2428,10 @@ bool ContextualFailure::diagnoseConversionToBool() const {
     }
     // FIXME: The outer parentheses may be superfluous too.
 
-    emitDiagnostic(expr->getLoc(), diag::integer_used_as_boolean, fromType,
+    emitDiagnostic(diag::integer_used_as_boolean, fromType,
                    notOperatorLoc.isValid())
-        .fixItInsert(expr->getStartLoc(), prefix)
-        .fixItInsertAfter(expr->getEndLoc(), suffix)
+        .fixItInsert(getSourceRange().Start, prefix)
+        .fixItInsertAfter(getSourceRange().End, suffix)
         .fixItRemove(notOperatorLoc);
     return true;
   }
@@ -2477,9 +2463,8 @@ bool ContextualFailure::diagnoseThrowsTypeMismatch() const {
               .getTypeWitnessByName(errorCodeType, getASTContext().Id_ErrorType)
               ->getCanonicalType();
       if (errorType) {
-        auto diagnostic =
-            emitDiagnostic(anchor->getLoc(), diag::cannot_throw_error_code,
-                           errorCodeType, errorType);
+        auto diagnostic = emitDiagnostic(diag::cannot_throw_error_code,
+                                         errorCodeType, errorType);
         if (auto *UDE = dyn_cast<UnresolvedDotExpr>(anchor)) {
           diagnostic.fixItInsert(UDE->getDotLoc(), "(");
           diagnostic.fixItInsertAfter(UDE->getEndLoc(), ")");
@@ -2492,9 +2477,8 @@ bool ContextualFailure::diagnoseThrowsTypeMismatch() const {
   // The conversion destination of throw is always ErrorType (at the moment)
   // if this ever expands, this should be a specific form like () is for
   // return.
-  emitDiagnostic(anchor->getLoc(), diag::cannot_convert_thrown_type,
-                 getFromType())
-      .highlight(anchor->getSourceRange());
+  emitDiagnostic(diag::cannot_convert_thrown_type, getFromType())
+      .highlight(getSourceRange());
   return true;
 }
 
@@ -2507,14 +2491,13 @@ bool ContextualFailure::diagnoseYieldByReferenceMismatch() const {
   auto contextualType = getToType();
 
   if (auto exprLV = exprType->getAs<LValueType>()) {
-    emitDiagnostic(anchor->getLoc(), diag::cannot_yield_wrong_type_by_reference,
+    emitDiagnostic(diag::cannot_yield_wrong_type_by_reference,
                    exprLV->getObjectType(), contextualType);
   } else if (exprType->isEqual(contextualType)) {
-    emitDiagnostic(anchor->getLoc(),
-                   diag::cannot_yield_rvalue_by_reference_same_type, exprType);
+    emitDiagnostic(diag::cannot_yield_rvalue_by_reference_same_type, exprType);
   } else {
-    emitDiagnostic(anchor->getLoc(), diag::cannot_yield_rvalue_by_reference,
-                   exprType, contextualType);
+    emitDiagnostic(diag::cannot_yield_rvalue_by_reference, exprType,
+                   contextualType);
   }
   return true;
 }
@@ -2568,8 +2551,7 @@ bool ContextualFailure::tryRawRepresentableFixIts(
       fixItAfter += "!" + convWrapAfter.str();
 
       diagnostic.flush();
-      emitDiagnostic(expr->getLoc(),
-                     diag::construct_raw_representable_from_unwrapped_value,
+      emitDiagnostic(diag::construct_raw_representable_from_unwrapped_value,
                      toType, fromType)
           .highlight(exprRange)
           .fixItInsert(exprRange.Start, fixItBefore)
@@ -2668,8 +2650,8 @@ bool ContextualFailure::tryIntegerCastFixIts(
     Type innerTy = getType(innerE);
     if (TypeChecker::isConvertibleTo(innerTy, toType, getDC())) {
       // Remove the unnecessary cast.
-      diagnostic.fixItRemoveChars(anchor->getLoc(), innerE->getStartLoc())
-          .fixItRemove(anchor->getEndLoc());
+      diagnostic.fixItRemoveChars(getLoc(), innerE->getStartLoc())
+          .fixItRemove(getSourceRange().End);
       return true;
     }
   }
@@ -2678,7 +2660,7 @@ bool ContextualFailure::tryIntegerCastFixIts(
   std::string convWrapBefore = toType.getString();
   convWrapBefore += "(";
   std::string convWrapAfter = ")";
-  SourceRange exprRange = anchor->getSourceRange();
+  SourceRange exprRange = getSourceRange();
   diagnostic.fixItInsert(exprRange.Start, convWrapBefore);
   diagnostic.fixItInsertAfter(exprRange.End, convWrapAfter);
   return true;
@@ -2744,14 +2726,12 @@ bool ContextualFailure::tryTypeCoercionFixIt(
                                         SourceLoc(), nullptr, SourceRange());
 
   if (Kind != CheckedCastKind::Unresolved) {
-    auto *anchor = getAnchor();
-
     bool canUseAs = Kind == CheckedCastKind::Coercion ||
                     Kind == CheckedCastKind::BridgingCoercion;
     if (bothOptional && canUseAs)
       toType = OptionalType::get(toType);
     diagnostic.fixItInsert(Lexer::getLocForEndOfToken(getASTContext().SourceMgr,
-                                                      anchor->getEndLoc()),
+                                                      getSourceRange().End),
                            diag::insert_type_coercion, canUseAs, toType);
     return true;
   }
@@ -2826,9 +2806,9 @@ bool ContextualFailure::tryProtocolConformanceFixIt(
   // missing protocols.
   //
   // TODO: Maybe also insert the requirement stubs?
-  auto conformanceDiag = emitDiagnostic(
-      getAnchor()->getLoc(), diag::assign_protocol_conformance_fix_it,
-      unwrappedToType, nominal->getDescriptiveKind(), fromType);
+  auto conformanceDiag =
+      emitDiagnostic(diag::assign_protocol_conformance_fix_it, unwrappedToType,
+                     nominal->getDescriptiveKind(), fromType);
   if (nominal->getInherited().size() > 0) {
     auto lastInherited = nominal->getInherited().back().getLoc();
     auto lastInheritedEndLoc =
@@ -2843,8 +2823,8 @@ bool ContextualFailure::tryProtocolConformanceFixIt(
   return true;
 }
 
-void ContextualFailure::tryComputedPropertyFixIts(Expr *expr) const {
-  if (!isa<ClosureExpr>(expr))
+void ContextualFailure::tryComputedPropertyFixIts() const {
+  if (!isa<ClosureExpr>(getAnchor()))
     return;
 
   // It is possible that we're looking at a stored property being
@@ -2877,8 +2857,7 @@ void ContextualFailure::tryComputedPropertyFixIts(Expr *expr) const {
       if (!VD->isStatic() &&
           !VD->getAttrs().getAttribute<DynamicReplacementAttr>() &&
           initExpr && isa<ClosureExpr>(initExpr)) {
-        auto diag = emitDiagnostic(expr->getLoc(),
-                                   diag::extension_stored_property_fixit,
+        auto diag = emitDiagnostic(diag::extension_stored_property_fixit,
                                    VD->getName());
         diag.fixItRemove(PBD->getEqualLoc(i));
 
@@ -2991,7 +2970,7 @@ bool TupleContextualFailure::diagnoseAsError() {
   else
     return false;
 
-  emitDiagnostic(getAnchor()->getLoc(), diagnostic, getFromType(), getToType());
+  emitDiagnostic(diagnostic, getFromType(), getToType());
   return true;
 }
 
@@ -3001,7 +2980,7 @@ bool FunctionTypeMismatch::diagnoseAsError() {
   if (!diagnostic)
     return false;
 
-  emitDiagnostic(getAnchor()->getLoc(), *diagnostic, getFromType(), getToType());
+  emitDiagnostic(*diagnostic, getFromType(), getToType());
   return true;
 }
 
@@ -3012,17 +2991,16 @@ bool AutoClosureForwardingFailure::diagnoseAsError() {
   // We need a raw anchor here because `getAnchor()` is simplified
   // to the argument expression.
   auto *argExpr = getArgumentExpr(getRawAnchor(), last.getArgIdx());
-  emitDiagnostic(argExpr->getLoc(), diag::invalid_autoclosure_forwarding)
+  emitDiagnosticAt(argExpr->getLoc(), diag::invalid_autoclosure_forwarding)
       .highlight(argExpr->getSourceRange())
       .fixItInsertAfter(argExpr->getEndLoc(), "()");
   return true;
 }
 
 bool AutoClosurePointerConversionFailure::diagnoseAsError() {
-  auto *anchor = getAnchor();
   auto diagnostic = diag::invalid_autoclosure_pointer_conversion;
-  emitDiagnostic(anchor->getLoc(), diagnostic, getFromType(), getToType())
-      .highlight(anchor->getSourceRange());
+  emitDiagnostic(diagnostic, getFromType(), getToType())
+      .highlight(getSourceRange());
   return true;
 }
 
@@ -3033,10 +3011,8 @@ bool NonOptionalUnwrapFailure::diagnoseAsError() {
   if (isa<ForceValueExpr>(anchor))
     diagnostic = diag::invalid_force_unwrap;
 
-  emitDiagnostic(anchor->getLoc(), diagnostic, BaseType)
-      .highlight(anchor->getSourceRange())
-      .fixItRemove(anchor->getEndLoc());
-
+  auto range = getSourceRange();
+  emitDiagnostic(diagnostic, BaseType).highlight(range).fixItRemove(range.End);
   return true;
 }
 
@@ -3066,9 +3042,8 @@ bool MissingCallFailure::diagnoseAsError() {
     case ConstraintLocator::ContextualType:
     case ConstraintLocator::ApplyArgToParam: {
       auto fnType = getType(baseExpr)->castTo<FunctionType>();
-      emitDiagnostic(baseExpr->getLoc(), diag::missing_nullary_call,
-                     fnType->getResult())
-          .fixItInsertAfter(baseExpr->getEndLoc(), "()");
+      emitDiagnostic(diag::missing_nullary_call, fnType->getResult())
+          .fixItInsertAfter(getSourceRange().End, "()");
       return true;
     }
 
@@ -3091,14 +3066,14 @@ bool MissingCallFailure::diagnoseAsError() {
   }
 
   if (auto *DRE = dyn_cast<DeclRefExpr>(baseExpr)) {
-    emitDiagnostic(baseExpr->getLoc(), diag::did_not_call_function,
+    emitDiagnostic(diag::did_not_call_function,
                    DRE->getDecl()->getBaseIdentifier())
         .fixItInsertAfter(insertLoc, "()");
     return true;
   }
 
   if (auto *UDE = dyn_cast<UnresolvedDotExpr>(baseExpr)) {
-    emitDiagnostic(baseExpr->getLoc(), diag::did_not_call_method,
+    emitDiagnostic(diag::did_not_call_method,
                    UDE->getName().getBaseIdentifier())
         .fixItInsertAfter(insertLoc, "()");
     return true;
@@ -3106,7 +3081,7 @@ bool MissingCallFailure::diagnoseAsError() {
 
   if (auto *DSCE = dyn_cast<DotSyntaxCallExpr>(baseExpr)) {
     if (auto *DRE = dyn_cast<DeclRefExpr>(DSCE->getFn())) {
-      emitDiagnostic(baseExpr->getLoc(), diag::did_not_call_method,
+      emitDiagnostic(diag::did_not_call_method,
                      DRE->getDecl()->getBaseIdentifier())
           .fixItInsertAfter(insertLoc, "()");
       return true;
@@ -3116,52 +3091,50 @@ bool MissingCallFailure::diagnoseAsError() {
   if (auto *AE = dyn_cast<AssignExpr>(baseExpr)) {
     auto *srcExpr = AE->getSrc();
     if (auto *fnType = getType(srcExpr)->getAs<FunctionType>()) {
-      emitDiagnostic(srcExpr->getLoc(), diag::missing_nullary_call,
-                     fnType->getResult())
+      emitDiagnosticAt(srcExpr->getLoc(), diag::missing_nullary_call,
+                       fnType->getResult())
           .highlight(srcExpr->getSourceRange())
           .fixItInsertAfter(srcExpr->getEndLoc(), "()");
       return true;
     }
   }
 
-  emitDiagnostic(baseExpr->getLoc(), diag::did_not_call_function_value)
+  emitDiagnostic(diag::did_not_call_function_value)
       .fixItInsertAfter(insertLoc, "()");
   return true;
 }
 
 bool ExtraneousPropertyWrapperUnwrapFailure::diagnoseAsError() {
-  auto loc = getAnchor()->getLoc();
   auto newPrefix = usingStorageWrapper() ? "$" : "_";
 
   if (auto *member = getReferencedMember()) {
-    emitDiagnostic(loc, diag::incorrect_property_wrapper_reference_member,
+    emitDiagnostic(diag::incorrect_property_wrapper_reference_member,
                    member->getDescriptiveKind(), member->getFullName(), false,
                    getToType())
-        .fixItInsert(loc, newPrefix);
+        .fixItInsert(getLoc(), newPrefix);
     return true;
   }
 
-  emitDiagnostic(loc, diag::incorrect_property_wrapper_reference,
-                 getPropertyName(), getFromType(), getToType(), false)
-      .fixItInsert(loc, newPrefix);
+  emitDiagnostic(diag::incorrect_property_wrapper_reference, getPropertyName(),
+                 getFromType(), getToType(), false)
+      .fixItInsert(getLoc(), newPrefix);
   return true;
 }
 
 bool MissingPropertyWrapperUnwrapFailure::diagnoseAsError() {
-  auto loc = getAnchor()->getLoc();
   auto endLoc = getAnchor()->getLoc().getAdvancedLoc(1);
 
   if (auto *member = getReferencedMember()) {
-    emitDiagnostic(loc, diag::incorrect_property_wrapper_reference_member,
+    emitDiagnostic(diag::incorrect_property_wrapper_reference_member,
                    member->getDescriptiveKind(), member->getFullName(), true,
                    getToType())
-        .fixItRemoveChars(loc, endLoc);
+        .fixItRemoveChars(getLoc(), endLoc);
     return true;
   }
 
-  emitDiagnostic(loc, diag::incorrect_property_wrapper_reference,
-                 getPropertyName(), getFromType(), getToType(), true)
-      .fixItRemoveChars(loc, endLoc);
+  emitDiagnostic(diag::incorrect_property_wrapper_reference, getPropertyName(),
+                 getFromType(), getToType(), true)
+      .fixItRemoveChars(getLoc(), endLoc);
   return true;
 }
 
@@ -3171,13 +3144,12 @@ bool SubscriptMisuseFailure::diagnoseAsError() {
   auto *memberExpr = cast<UnresolvedDotExpr>(getRawAnchor());
   auto *baseExpr = getAnchor();
 
-  auto memberRange = baseExpr->getSourceRange();
+  auto memberRange = getSourceRange();
   (void)simplifyLocator(getConstraintSystem(), getLocator(), memberRange);
 
   auto nameLoc = DeclNameLoc(memberRange.Start);
 
-  auto diag = emitDiagnostic(baseExpr->getLoc(),
-                             diag::could_not_find_subscript_member_did_you_mean,
+  auto diag = emitDiagnostic(diag::could_not_find_subscript_member_did_you_mean,
                              getType(baseExpr));
 
   diag.highlight(memberRange).highlight(nameLoc.getSourceRange());
@@ -3204,8 +3176,8 @@ bool SubscriptMisuseFailure::diagnoseAsError() {
   diag.flush();
 
   if (auto overload = getOverloadChoiceIfAvailable(getLocator())) {
-    emitDiagnostic(overload->choice.getDecl(), diag::kind_declared_here,
-                   DescriptiveDeclKind::Subscript);
+    emitDiagnosticAt(overload->choice.getDecl(), diag::kind_declared_here,
+                     DescriptiveDeclKind::Subscript);
   }
 
   return true;
@@ -3213,7 +3185,7 @@ bool SubscriptMisuseFailure::diagnoseAsError() {
 
 bool SubscriptMisuseFailure::diagnoseAsNote() {
   if (auto overload = getOverloadChoiceIfAvailable(getLocator())) {
-    emitDiagnostic(overload->choice.getDecl(), diag::found_candidate);
+    emitDiagnosticAt(overload->choice.getDecl(), diag::found_candidate);
     return true;
   }
   return false;
@@ -3274,13 +3246,13 @@ bool MissingMemberFailure::diagnoseAsError() {
       return hasUnresolvedPattern ? nullptr : expr;
     });
     if (hasUnresolvedPattern && !baseType->getAs<EnumType>()) {
-      emitDiagnostic(anchor->getLoc(),
-          diag::cannot_match_unresolved_expr_pattern_with_value, baseType);
+      emitDiagnostic(diag::cannot_match_unresolved_expr_pattern_with_value,
+                     baseType);
       return;
     }
 
-    emitDiagnostic(anchor->getLoc(), diagnostic, baseType, getName())
-        .highlight(baseExpr->getSourceRange())
+    emitDiagnostic(diagnostic, baseType, getName())
+        .highlight(getSourceRange())
         .highlight(nameLoc.getSourceRange());
   };
 
@@ -3291,37 +3263,35 @@ bool MissingMemberFailure::diagnoseAsError() {
   };
 
   if (getName().getBaseName().getKind() == DeclBaseName::Kind::Subscript) {
-    auto loc = anchor->getLoc();
     if (auto *metatype = baseType->getAs<MetatypeType>()) {
-      emitDiagnostic(loc, diag::could_not_find_type_member,
+      emitDiagnostic(diag::could_not_find_type_member,
                      metatype->getInstanceType(), getName())
-        .highlight(baseExpr->getSourceRange());
+          .highlight(getSourceRange());
     } else {
-      emitDiagnostic(loc, diag::could_not_find_value_subscript, baseType)
-        .highlight(baseExpr->getSourceRange());
+      emitDiagnostic(diag::could_not_find_value_subscript, baseType)
+          .highlight(getSourceRange());
     }
   } else if (getName().getBaseName() == "deinit") {
     // Specialised diagnostic if trying to access deinitialisers
-    emitDiagnostic(anchor->getLoc(), diag::destructor_not_accessible)
-        .highlight(baseExpr->getSourceRange());
+    emitDiagnostic(diag::destructor_not_accessible).highlight(getSourceRange());
   } else if (auto metatypeTy = baseType->getAs<MetatypeType>()) {
     auto instanceTy = metatypeTy->getInstanceType();
     tryTypoCorrection(baseType);
 
     if (DeclName rightName =
             findCorrectEnumCaseName(instanceTy, corrections, getName())) {
-      emitDiagnostic(anchor->getLoc(), diag::could_not_find_enum_case,
-                     instanceTy, getName(), rightName)
+      emitDiagnostic(diag::could_not_find_enum_case, instanceTy, getName(),
+                     rightName)
           .fixItReplace(nameLoc.getBaseNameLoc(),
                         rightName.getBaseIdentifier().str());
       return true;
     }
 
     if (auto correction = corrections.claimUniqueCorrection()) {
-      auto diagnostic = emitDiagnostic(
-          anchor->getLoc(), diag::could_not_find_type_member_corrected,
-          instanceTy, getName(), correction->CorrectedName);
-      diagnostic.highlight(baseExpr->getSourceRange())
+      auto diagnostic =
+          emitDiagnostic(diag::could_not_find_type_member_corrected, instanceTy,
+                         getName(), correction->CorrectedName);
+      diagnostic.highlight(getSourceRange())
           .highlight(nameLoc.getSourceRange());
       correction->addFixits(diagnostic);
     } else if (instanceTy->getAnyNominal() &&
@@ -3338,9 +3308,8 @@ bool MissingMemberFailure::diagnoseAsError() {
       // "no such member" one.
       if (result.ViableCandidates.empty() &&
           result.UnviableCandidates.empty()) {
-        emitDiagnostic(anchor->getLoc(), diag::no_accessible_initializers,
-                       instanceTy)
-            .highlight(baseExpr->getSourceRange());
+        emitDiagnostic(diag::no_accessible_initializers, instanceTy)
+            .highlight(getSourceRange());
       } else {
         emitBasicError(baseType);
       }
@@ -3348,9 +3317,9 @@ bool MissingMemberFailure::diagnoseAsError() {
       emitBasicError(baseType);
     }
   } else if (auto moduleTy = baseType->getAs<ModuleType>()) {
-    emitDiagnostic(baseExpr->getLoc(), diag::no_member_of_module,
-                   moduleTy->getModule()->getName(), getName())
-        .highlight(baseExpr->getSourceRange())
+    emitDiagnostic(diag::no_member_of_module, moduleTy->getModule()->getName(),
+                   getName())
+        .highlight(getSourceRange())
         .highlight(nameLoc.getSourceRange());
     return true;
   } else {
@@ -3360,14 +3329,16 @@ bool MissingMemberFailure::diagnoseAsError() {
       auto loc = ED->getNameLoc();
       if (loc.isValid()) {
         emitBasicError(baseType);
-        emitDiagnostic(loc, diag::did_you_mean_raw_type);
+        emitDiagnosticAt(loc, diag::did_you_mean_raw_type);
         return true;
       }
     } else if (baseType->isAny()) {
       emitBasicError(baseType);
-      emitDiagnostic(anchor->getLoc(), diag::any_as_anyobject_fixit)
-          .fixItInsert(baseExpr->getStartLoc(), "(")
-          .fixItInsertAfter(baseExpr->getEndLoc(), " as AnyObject)");
+
+      auto range = getSourceRange();
+      emitDiagnostic(diag::any_as_anyobject_fixit)
+          .fixItInsert(range.Start, "(")
+          .fixItInsertAfter(range.End, " as AnyObject)");
       return true;
     }
     
@@ -3382,30 +3353,26 @@ bool MissingMemberFailure::diagnoseAsError() {
       
       if (auto correction = corrections.claimUniqueCorrection()) {
         auto diagnostic = emitDiagnostic(
-            anchor->getLoc(),
-            diag::could_not_find_value_dynamic_member_corrected,
-            baseExprType, baseType, getName(),
-            correction->CorrectedName);
-        diagnostic.highlight(baseExpr->getSourceRange())
+            diag::could_not_find_value_dynamic_member_corrected, baseExprType,
+            baseType, getName(), correction->CorrectedName);
+        diagnostic.highlight(getSourceRange())
             .highlight(nameLoc.getSourceRange());
         correction->addFixits(diagnostic);
       } else {
-        auto diagnostic = emitDiagnostic(
-            anchor->getLoc(),
-            diag::could_not_find_value_dynamic_member,
-            baseExprType, baseType, getName());
-        diagnostic.highlight(baseExpr->getSourceRange())
+        auto diagnostic =
+            emitDiagnostic(diag::could_not_find_value_dynamic_member,
+                           baseExprType, baseType, getName());
+        diagnostic.highlight(getSourceRange())
             .highlight(nameLoc.getSourceRange());
       }
     } else {
       if (auto correction = corrections.claimUniqueCorrection()) {
-        auto diagnostic = emitDiagnostic(
-            anchor->getLoc(),
-            diag::could_not_find_value_member_corrected,
-            baseType, getName(),
-            correction->CorrectedName);
-        diagnostic.highlight(baseExpr->getSourceRange())
+        auto diagnostic =
+            emitDiagnostic(diag::could_not_find_value_member_corrected,
+                           baseType, getName(), correction->CorrectedName);
+        diagnostic.highlight(getSourceRange())
             .highlight(nameLoc.getSourceRange());
+
         correction->addFixits(diagnostic);
       } else {
         emitBasicError(baseType);
@@ -3429,9 +3396,7 @@ bool MissingMemberFailure::diagnoseForDynamicCallable() const {
 
   auto &ctx = getASTContext();
   if (arguments.front() == ctx.Id_withKeywordArguments) {
-    auto anchor = getAnchor();
-    emitDiagnostic(anchor->getLoc(),
-                   diag::missing_dynamic_callable_kwargs_method, getBaseType());
+    emitDiagnostic(diag::missing_dynamic_callable_kwargs_method, getBaseType());
     return true;
   }
 
@@ -3454,16 +3419,15 @@ bool InvalidMemberRefOnExistential::diagnoseAsError() {
     baseExpr = call->getFn();
   }
 
-  emitDiagnostic(getAnchor()->getLoc(),
-                 diag::could_not_use_member_on_existential, getBaseType(),
+  emitDiagnostic(diag::could_not_use_member_on_existential, getBaseType(),
                  getName())
       .highlight(nameLoc.getSourceRange())
-      .highlight(baseExpr->getSourceRange());
+      .highlight(getSourceRange());
   return true;
 }
 
 bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
-  auto loc = getAnchor()->getLoc();
+  auto loc = getLoc();
   auto &cs = getConstraintSystem();
   auto *DC = getDC();
   auto locator = getLocator();
@@ -3506,7 +3470,7 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
       !BaseType->is<AnyMetatypeType>()) {
     if (auto ctorRef = dyn_cast<UnresolvedDotExpr>(getRawAnchor())) {
       if (isa<SuperRefExpr>(ctorRef->getBase())) {
-        emitDiagnostic(loc, diag::super_initializer_not_in_initializer);
+        emitDiagnostic(diag::super_initializer_not_in_initializer);
         return true;
       }
 
@@ -3535,13 +3499,13 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
             !isCallArgument(initCall) &&
             getContextualTypePurpose(getRootExpr(ctorRef)) == CTP_Unused) {
           auto fixItLoc = ctorRef->getBase()->getSourceRange().End;
-          emitDiagnostic(loc, diag::init_not_instance_member_use_assignment)
+          emitDiagnostic(diag::init_not_instance_member_use_assignment)
               .fixItInsertAfter(fixItLoc, " = ");
           return true;
         }
 
         SourceRange fixItRng = ctorRef->getBase()->getSourceRange();
-        emitDiagnostic(loc, diag::init_not_instance_member)
+        emitDiagnostic(diag::init_not_instance_member)
             .fixItInsert(fixItRng.Start, "type(of: ")
             .fixItInsertAfter(fixItRng.End, ")");
         return true;
@@ -3574,10 +3538,10 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
       
       if (TypeDC->getSelfNominalTypeDecl() == instanceTy->getAnyNominal()) {
         if (propertyInitializer) {
-          emitDiagnostic(loc, diag::instance_member_in_initializer, Name);
+          emitDiagnostic(diag::instance_member_in_initializer, Name);
           return true;
         } else {
-          emitDiagnostic(loc, diag::instance_member_in_default_parameter, Name);
+          emitDiagnostic(diag::instance_member_in_default_parameter, Name);
           return true;
         }
       }
@@ -3595,8 +3559,8 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
       auto arg = callExpr->getArg();
 
       if (fnType->is<ExistentialMetatypeType>()) {
-        emitDiagnostic(arg->getStartLoc(),
-                       diag::missing_init_on_metatype_initialization)
+        emitDiagnosticAt(arg->getStartLoc(),
+                         diag::missing_init_on_metatype_initialization)
             .highlight(fnExpr->getSourceRange());
         return true;
       }
@@ -3611,7 +3575,7 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
     if (memberTypeContext && currentTypeContext &&
         memberTypeContext->getSemanticDepth() <
         currentTypeContext->getSemanticDepth()) {
-      emitDiagnostic(loc, diag::could_not_use_instance_member_on_type,
+      emitDiagnostic(diag::could_not_use_instance_member_on_type,
                      currentTypeContext->getDeclaredInterfaceType(), Name,
                      memberTypeContext->getDeclaredInterfaceType(), true)
           .highlight(baseRange)
@@ -3622,16 +3586,16 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
     if (auto *UDE = dyn_cast<UnresolvedDotExpr>(getRawAnchor())) {
       auto *baseExpr = UDE->getBase();
       if (isa<TypeExpr>(baseExpr)) {
-        emitDiagnostic(loc, diag::instance_member_use_on_type, instanceTy, Name)
-            .highlight(baseExpr->getSourceRange());
+        emitDiagnostic(diag::instance_member_use_on_type, instanceTy, Name)
+            .highlight(getSourceRange());
         return true;
       }
     }
 
     // Just emit a generic "instance member cannot be used" error
-    emitDiagnostic(loc, diag::could_not_use_instance_member_on_type, instanceTy,
+    emitDiagnostic(diag::could_not_use_instance_member_on_type, instanceTy,
                    Name, instanceTy, false)
-        .highlight(getAnchor()->getSourceRange());
+        .highlight(getSourceRange());
     return true;
   } else {
     // If the base of the lookup is a protocol metatype, suggest
@@ -3656,21 +3620,21 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
         // of a protocol -- otherwise a diagnostic talking about
         // static members doesn't make a whole lot of sense
         if (isa<TypeAliasDecl>(Member)) {
-          Diag.emplace(emitDiagnostic(loc, diag::typealias_outside_of_protocol,
-                                      Name));
+          Diag.emplace(
+              emitDiagnostic(diag::typealias_outside_of_protocol, Name));
         } else if (isa<AssociatedTypeDecl>(Member)) {
-          Diag.emplace(emitDiagnostic(loc, diag::assoc_type_outside_of_protocol,
-                                      Name));
+          Diag.emplace(
+              emitDiagnostic(diag::assoc_type_outside_of_protocol, Name));
         } else if (isa<ConstructorDecl>(Member)) {
-          Diag.emplace(emitDiagnostic(loc, diag::construct_protocol_by_name,
-                                      instanceTy));
+          Diag.emplace(
+              emitDiagnostic(diag::construct_protocol_by_name, instanceTy));
         } else {
           Diag.emplace(emitDiagnostic(
-              loc, diag::could_not_use_type_member_on_protocol_metatype, baseTy,
+              diag::could_not_use_type_member_on_protocol_metatype, baseTy,
               Name));
         }
 
-        Diag->highlight(baseRange).highlight(getAnchor()->getSourceRange());
+        Diag->highlight(baseRange).highlight(getSourceRange());
 
         // See through function decl context
         if (auto parent = cs.DC->getInnermostTypeContext()) {
@@ -3678,7 +3642,7 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
           // 'Proto.static', suggest 'Self.static'
           if (auto extensionContext = parent->getExtendedProtocolDecl()) {
             if (extensionContext->getDeclaredType()->isEqual(instanceTy)) {
-              Diag->fixItReplace(getAnchor()->getSourceRange(), "Self");
+              Diag->fixItReplace(getSourceRange(), "Self");
             }
           }
         }
@@ -3696,11 +3660,11 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
     }
 
     if (isa<EnumElementDecl>(Member)) {
-      Diag.emplace(emitDiagnostic(
-          loc, diag::could_not_use_enum_element_on_instance, Name));
+      Diag.emplace(
+          emitDiagnostic(diag::could_not_use_enum_element_on_instance, Name));
     } else {
-      Diag.emplace(emitDiagnostic(
-          loc, diag::could_not_use_type_member_on_instance, baseTy, Name));
+      Diag.emplace(emitDiagnostic(diag::could_not_use_type_member_on_instance,
+                                  baseTy, Name));
     }
 
     Diag->highlight(getAnchor()->getSourceRange());
@@ -3792,39 +3756,40 @@ bool PartialApplicationFailure::diagnoseAsError() {
                         ? diag::partial_application_of_function_invalid_swift4
                         : diag::partial_application_of_function_invalid;
 
-  emitDiagnostic(anchor->getNameLoc(), diagnostic, kind);
+  emitDiagnosticAt(anchor->getNameLoc(), diagnostic, kind);
   return true;
 }
 
 bool InvalidDynamicInitOnMetatypeFailure::diagnoseAsError() {
-  auto *anchor = getRawAnchor();
-  emitDiagnostic(anchor->getLoc(), diag::dynamic_construct_class,
+  emitDiagnostic(diag::dynamic_construct_class,
                  BaseType->getMetatypeInstanceType())
       .highlight(BaseRange);
-  emitDiagnostic(Init, diag::note_nonrequired_initializer, Init->isImplicit(),
-                 Init->getFullName());
+  emitDiagnosticAt(Init, diag::note_nonrequired_initializer, Init->isImplicit(),
+                   Init->getFullName());
   return true;
 }
 
 bool InitOnProtocolMetatypeFailure::diagnoseAsError() {
-  auto *anchor = getRawAnchor();
   if (IsStaticallyDerived) {
-    emitDiagnostic(anchor->getLoc(), diag::construct_protocol_by_name,
+    emitDiagnostic(diag::construct_protocol_by_name,
                    BaseType->getMetatypeInstanceType())
         .highlight(BaseRange);
   } else {
-    emitDiagnostic(anchor->getLoc(), diag::construct_protocol_value, BaseType)
+    emitDiagnostic(diag::construct_protocol_value, BaseType)
         .highlight(BaseRange);
   }
 
   return true;
 }
 
-bool ImplicitInitOnNonConstMetatypeFailure::diagnoseAsError() {
+SourceLoc ImplicitInitOnNonConstMetatypeFailure::getLoc() const {
   auto *apply = cast<ApplyExpr>(getRawAnchor());
-  auto loc = apply->getArg()->getStartLoc();
-  emitDiagnostic(loc, diag::missing_init_on_metatype_initialization)
-      .fixItInsert(loc, ".init");
+  return apply->getArg()->getStartLoc();
+}
+
+bool ImplicitInitOnNonConstMetatypeFailure::diagnoseAsError() {
+  emitDiagnostic(diag::missing_init_on_metatype_initialization)
+      .fixItInsert(getLoc(), ".init");
   return true;
 }
 
@@ -3868,8 +3833,8 @@ bool MissingArgumentsFailure::diagnoseAsError() {
     auto info = *(getFunctionArgApplyInfo(locator));
 
     auto *argExpr = info.getArgExpr();
-    emitDiagnostic(argExpr->getLoc(), diag::cannot_convert_argument_value,
-                   info.getArgType(), info.getParamType());
+    emitDiagnosticAt(argExpr->getLoc(), diag::cannot_convert_argument_value,
+                     info.getArgType(), info.getParamType());
     // TODO: It would be great so somehow point out which arguments are missing.
     return true;
   }
@@ -3881,8 +3846,7 @@ bool MissingArgumentsFailure::diagnoseAsError() {
   // let _: (Int) -> Void = foo
   // ```
   if (locator->isLastElement<LocatorPathElt::ContextualType>()) {
-    emitDiagnostic(anchor->getLoc(), diag::cannot_convert_initializer_value,
-                   getType(anchor),
+    emitDiagnostic(diag::cannot_convert_initializer_value, getType(anchor),
                    resolveType(getContextualType(getAnchor())));
     // TODO: It would be great so somehow point out which arguments are missing.
     return true;
@@ -3916,8 +3880,7 @@ bool MissingArgumentsFailure::diagnoseAsError() {
       },
       [&] { arguments << ", "; });
 
-  auto diag = emitDiagnostic(anchor->getLoc(), diag::missing_arguments_in_call,
-                             arguments.str());
+  auto diag = emitDiagnostic(diag::missing_arguments_in_call, arguments.str());
 
   Expr *fnExpr = nullptr;
   Expr *argExpr = nullptr;
@@ -3947,7 +3910,7 @@ bool MissingArgumentsFailure::diagnoseAsError() {
 
   if (auto selectedOverload = getCalleeOverloadChoiceIfAvailable(locator)) {
     if (auto *decl = selectedOverload->choice.getDeclOrNull()) {
-      emitDiagnostic(decl, diag::decl_declared_here, decl->getFullName());
+      emitDiagnosticAt(decl, diag::decl_declared_here, decl->getFullName());
     }
   }
 
@@ -3959,10 +3922,12 @@ bool MissingArgumentsFailure::diagnoseAsNote() {
   if (auto overload = getCalleeOverloadChoiceIfAvailable(locator)) {
     auto *fn = resolveType(overload->openedType)->getAs<AnyFunctionType>();
     auto loc = overload->choice.getDecl()->getLoc();
+
     if (loc.isInvalid())
-      loc = getAnchor()->getLoc();
-    emitDiagnostic(loc, diag::candidate_partial_match,
-                   fn->getParamListAsString(fn->getParams()));
+      loc = getLoc();
+
+    emitDiagnosticAt(loc, diag::candidate_partial_match,
+                     fn->getParamListAsString(fn->getParams()));
     return true;
   }
 
@@ -4066,21 +4031,21 @@ bool MissingArgumentsFailure::diagnoseSingleMissingArgument() const {
     return false;
 
   if (label.empty()) {
-    emitDiagnostic(insertLoc, diag::missing_argument_positional, position + 1)
+    emitDiagnosticAt(insertLoc, diag::missing_argument_positional, position + 1)
         .fixItInsert(insertLoc, insertText.str());
   } else if (isPropertyWrapperInitialization()) {
     auto *TE = cast<TypeExpr>(fnExpr);
-    emitDiagnostic(TE->getLoc(), diag::property_wrapper_missing_arg_init, label,
-                   resolveType(TE->getInstanceType())->getString());
+    emitDiagnosticAt(TE->getLoc(), diag::property_wrapper_missing_arg_init,
+                     label, resolveType(TE->getInstanceType())->getString());
   } else {
-    emitDiagnostic(insertLoc, diag::missing_argument_named, label)
+    emitDiagnosticAt(insertLoc, diag::missing_argument_named, label)
         .fixItInsert(insertLoc, insertText.str());
   }
 
   if (auto selectedOverload =
           getCalleeOverloadChoiceIfAvailable(getLocator())) {
     if (auto *decl = selectedOverload->choice.getDeclOrNull()) {
-      emitDiagnostic(decl, diag::decl_declared_here, decl->getFullName());
+      emitDiagnosticAt(decl, diag::decl_declared_here, decl->getFullName());
     }
   }
 
@@ -4120,8 +4085,8 @@ bool MissingArgumentsFailure::diagnoseClosure(ClosureExpr *closure) {
   // needs some, produce a fixit to turn "{...}" into "{ _,_ in ...}".
   if (diff == 0) {
     auto diag =
-        emitDiagnostic(closure->getStartLoc(),
-                       diag::closure_argument_list_missing, numSynthesized);
+        emitDiagnosticAt(closure->getStartLoc(),
+                         diag::closure_argument_list_missing, numSynthesized);
 
     std::string fixText; // Let's provide fixits for up to 10 args.
     if (funcType->getNumParams() <= 10) {
@@ -4153,7 +4118,7 @@ bool MissingArgumentsFailure::diagnoseClosure(ClosureExpr *closure) {
       std::all_of(params->begin(), params->end(),
                   [](ParamDecl *param) { return !param->hasName(); });
 
-  auto diag = emitDiagnostic(
+  auto diag = emitDiagnosticAt(
       params->getStartLoc(), diag::closure_argument_list_tuple,
       resolveType(funcType), funcType->getNumParams(), diff, diff == 1);
 
@@ -4208,8 +4173,7 @@ bool MissingArgumentsFailure::diagnoseInvalidTupleDestructuring() const {
 
   auto name = decl->getBaseName();
   auto diagnostic =
-      emitDiagnostic(anchor->getLoc(),
-                     diag::cannot_convert_single_tuple_into_multiple_arguments,
+      emitDiagnostic(diag::cannot_convert_single_tuple_into_multiple_arguments,
                      decl->getDescriptiveKind(), name, name.isSpecial(),
                      SynthesizedArgs.size(), isa<TupleExpr>(argExpr));
 
@@ -4221,7 +4185,7 @@ bool MissingArgumentsFailure::diagnoseInvalidTupleDestructuring() const {
   diagnostic.flush();
 
   // Add a note which points to the overload choice location.
-  emitDiagnostic(decl, diag::decl_declared_here, decl->getFullName());
+  emitDiagnosticAt(decl, diag::decl_declared_here, decl->getFullName());
   return true;
 }
 
@@ -4341,6 +4305,18 @@ void MissingArgumentsFailure::forFixIt(
   out << "<#" << resolvedType << "#>";
 }
 
+SourceLoc ClosureParamDestructuringFailure::getLoc() const {
+  auto *closure = cast<ClosureExpr>(getAnchor());
+  auto paramList = closure->getParameters();
+  return paramList->getStartLoc();
+}
+
+SourceRange ClosureParamDestructuringFailure::getSourceRange() const {
+  auto *closure = cast<ClosureExpr>(getAnchor());
+  auto paramList = closure->getParameters();
+  return paramList->getSourceRange();
+}
+
 bool ClosureParamDestructuringFailure::diagnoseAsError() {
   auto *closure = cast<ClosureExpr>(getAnchor());
   auto params = closure->getParameters();
@@ -4350,15 +4326,13 @@ bool ClosureParamDestructuringFailure::diagnoseAsError() {
   // structure of parameter type itself is unclear.
   for (auto *param : params->getArray()) {
     if (param->isImplicit()) {
-      emitDiagnostic(params->getStartLoc(),
-                     diag::closure_tuple_parameter_destructuring_implicit,
+      emitDiagnostic(diag::closure_tuple_parameter_destructuring_implicit,
                      getParameterType());
       return true;
     }
   }
 
-  auto diag = emitDiagnostic(params->getStartLoc(),
-                             diag::closure_tuple_parameter_destructuring,
+  auto diag = emitDiagnostic(diag::closure_tuple_parameter_destructuring,
                              getParameterType());
 
   auto *closureBody = closure->getBody();
@@ -4468,7 +4442,7 @@ bool ClosureParamDestructuringFailure::diagnoseAsError() {
     }
   }
 
-  diag.fixItReplace(params->getSourceRange(), nameOS.str())
+  diag.fixItReplace(getSourceRange(), nameOS.str())
       .fixItInsert(bodyLoc, OS.str());
   return true;
 }
@@ -4541,20 +4515,22 @@ bool OutOfOrderArgumentFailure::diagnoseAsError() {
   // There are 4 diagnostic messages variations depending on
   // labeled/unlabeled arguments.
   if (first.empty() && second.empty()) {
-    addFixIts(emitDiagnostic(diagLoc,
-                             isa<BinaryExpr>(anchor)
-                                 ? diag::argument_out_of_order_binary_op
-                                 : diag::argument_out_of_order_unnamed_unnamed,
-                             ArgIdx + 1, PrevArgIdx + 1));
+    addFixIts(emitDiagnosticAt(
+        diagLoc,
+        isa<BinaryExpr>(anchor) ? diag::argument_out_of_order_binary_op
+                                : diag::argument_out_of_order_unnamed_unnamed,
+        ArgIdx + 1, PrevArgIdx + 1));
   } else if (first.empty() && !second.empty()) {
-    addFixIts(emitDiagnostic(diagLoc, diag::argument_out_of_order_unnamed_named,
-                             ArgIdx + 1, second));
+    addFixIts(emitDiagnosticAt(diagLoc,
+                               diag::argument_out_of_order_unnamed_named,
+                               ArgIdx + 1, second));
   } else if (!first.empty() && second.empty()) {
-    addFixIts(emitDiagnostic(diagLoc, diag::argument_out_of_order_named_unnamed,
-                             first, PrevArgIdx + 1));
+    addFixIts(emitDiagnosticAt(diagLoc,
+                               diag::argument_out_of_order_named_unnamed, first,
+                               PrevArgIdx + 1));
   } else {
-    addFixIts(emitDiagnostic(diagLoc, diag::argument_out_of_order_named_named,
-                             first, second));
+    addFixIts(emitDiagnosticAt(diagLoc, diag::argument_out_of_order_named_named,
+                               first, second));
   }
   return true;
 }
@@ -4567,7 +4543,7 @@ bool ExtraneousArgumentsFailure::diagnoseAsError() {
     auto fnType = ContextualType;
     auto params = closure->getParameters();
 
-    auto diag = emitDiagnostic(
+    auto diag = emitDiagnosticAt(
         params->getStartLoc(), diag::closure_argument_list_tuple, fnType,
         fnType->getNumParams(), params->size(), (params->size() == 1));
 
@@ -4590,8 +4566,7 @@ bool ExtraneousArgumentsFailure::diagnoseAsError() {
 
   if (isContextualMismatch()) {
     auto *locator = getLocator();
-    emitDiagnostic(anchor->getLoc(),
-                   locator->isLastElement<LocatorPathElt::ContextualType>()
+    emitDiagnostic(locator->isLastElement<LocatorPathElt::ContextualType>()
                        ? diag::cannot_convert_initializer_value
                        : diag::cannot_convert_argument_value,
                    getType(anchor), ContextualType);
@@ -4604,7 +4579,7 @@ bool ExtraneousArgumentsFailure::diagnoseAsError() {
 
   if (ContextualType->getNumParams() == 0) {
     if (auto argExpr = getArgumentListExprFor(getLocator())) {
-      emitDiagnostic(anchor->getLoc(), diag::extra_argument_to_nullary_call)
+      emitDiagnostic(diag::extra_argument_to_nullary_call)
           .highlight(argExpr->getSourceRange())
           .fixItRemove(argExpr->getSourceRange());
       return true;
@@ -4624,11 +4599,11 @@ bool ExtraneousArgumentsFailure::diagnoseAsError() {
       },
       [&] { OS << ", "; });
 
-  emitDiagnostic(anchor->getLoc(), diag::extra_arguments_in_call, OS.str());
+  emitDiagnostic(diag::extra_arguments_in_call, OS.str());
 
   if (auto overload = getCalleeOverloadChoiceIfAvailable(getLocator())) {
     if (auto *decl = overload->choice.getDeclOrNull()) {
-      emitDiagnostic(decl, diag::decl_declared_here, decl->getFullName());
+      emitDiagnosticAt(decl, diag::decl_declared_here, decl->getFullName());
     }
   }
 
@@ -4643,9 +4618,9 @@ bool ExtraneousArgumentsFailure::diagnoseAsNote() {
   auto *decl = overload->choice.getDecl();
   auto *anchor = getAnchor();
   auto numArgs = getTotalNumArguments();
-  emitDiagnostic(decl, diag::candidate_with_extraneous_args, ContextualType,
-                 ContextualType->getNumParams(), numArgs, (numArgs == 1),
-                 isa<ClosureExpr>(anchor));
+  emitDiagnosticAt(decl, diag::candidate_with_extraneous_args, ContextualType,
+                   ContextualType->getNumParams(), numArgs, (numArgs == 1),
+                   isa<ClosureExpr>(anchor));
   return true;
 }
 
@@ -4658,7 +4633,7 @@ bool ExtraneousArgumentsFailure::diagnoseSingleExtraArgument() const {
   if (auto *call = dyn_cast<CallExpr>(getRawAnchor())) {
     auto *TE = dyn_cast<TypeExpr>(call->getFn());
     if (TE && getType(TE)->getMetatypeInstanceType()->isVoid()) {
-      emitDiagnostic(call->getLoc(), diag::extra_argument_to_nullary_call)
+      emitDiagnosticAt(call->getLoc(), diag::extra_argument_to_nullary_call)
           .highlight(call->getArg()->getSourceRange());
       return true;
     }
@@ -4679,7 +4654,7 @@ bool ExtraneousArgumentsFailure::diagnoseSingleExtraArgument() const {
   auto loc = argExpr->getLoc();
   if (tuple && index == tuple->getNumElements() - 1 &&
       tuple->hasTrailingClosure()) {
-    emitDiagnostic(loc, diag::extra_trailing_closure_in_call)
+    emitDiagnosticAt(loc, diag::extra_trailing_closure_in_call)
         .highlight(argExpr->getSourceRange());
   } else if (ContextualType->getNumParams() == 0) {
     auto *PE = dyn_cast<ParenExpr>(arguments);
@@ -4688,17 +4663,17 @@ bool ExtraneousArgumentsFailure::diagnoseSingleExtraArgument() const {
       subExpr = PE->getSubExpr();
 
     if (subExpr && argument.getPlainType()->isVoid()) {
-      emitDiagnostic(loc, diag::extra_argument_to_nullary_call)
+      emitDiagnosticAt(loc, diag::extra_argument_to_nullary_call)
           .fixItRemove(subExpr->getSourceRange());
     } else {
-      emitDiagnostic(loc, diag::extra_argument_to_nullary_call)
+      emitDiagnosticAt(loc, diag::extra_argument_to_nullary_call)
           .highlight(argExpr->getSourceRange());
     }
   } else if (argument.hasLabel()) {
-    emitDiagnostic(loc, diag::extra_argument_named, argument.getLabel())
+    emitDiagnosticAt(loc, diag::extra_argument_named, argument.getLabel())
         .highlight(argExpr->getSourceRange());
   } else {
-    emitDiagnostic(loc, diag::extra_argument_positional)
+    emitDiagnosticAt(loc, diag::extra_argument_positional)
         .highlight(argExpr->getSourceRange());
   }
   return true;
@@ -4743,49 +4718,58 @@ bool InaccessibleMemberFailure::diagnoseAsError() {
   auto loc = nameLoc.isValid() ? nameLoc.getStartLoc() : anchor->getLoc();
   auto accessLevel = Member->getFormalAccessScope().accessLevelForDiagnostics();
   if (auto *CD = dyn_cast<ConstructorDecl>(Member)) {
-    emitDiagnostic(loc, diag::init_candidate_inaccessible,
-                   CD->getResultInterfaceType(), accessLevel)
+    emitDiagnosticAt(loc, diag::init_candidate_inaccessible,
+                     CD->getResultInterfaceType(), accessLevel)
         .highlight(nameLoc.getSourceRange());
   } else {
-    emitDiagnostic(loc, diag::candidate_inaccessible, Member->getBaseName(),
-                   accessLevel)
+    emitDiagnosticAt(loc, diag::candidate_inaccessible, Member->getBaseName(),
+                     accessLevel)
         .highlight(nameLoc.getSourceRange());
   }
 
-  emitDiagnostic(Member, diag::decl_declared_here, Member->getFullName());
+  emitDiagnosticAt(Member, diag::decl_declared_here, Member->getFullName());
   return true;
+}
+
+SourceLoc AnyObjectKeyPathRootFailure::getLoc() const {
+  if (auto KPE = dyn_cast<KeyPathExpr>(getAnchor())) {
+    if (auto rootTyRepr = KPE->getRootType())
+      return rootTyRepr->getLoc();
+  }
+
+  return FailureDiagnostic::getLoc();
+}
+
+SourceRange AnyObjectKeyPathRootFailure::getSourceRange() const {
+  if (auto KPE = dyn_cast<KeyPathExpr>(getAnchor())) {
+    if (auto rootTyRepr = KPE->getRootType())
+      return rootTyRepr->getSourceRange();
+  }
+
+  return FailureDiagnostic::getSourceRange();
 }
 
 bool AnyObjectKeyPathRootFailure::diagnoseAsError() {
   // Diagnose use of AnyObject as root for a keypath
-
-  auto anchor = getAnchor();
-  auto loc = anchor->getLoc();
-  auto range = anchor->getSourceRange();
-
-  if (auto KPE = dyn_cast<KeyPathExpr>(anchor)) {
-    if (auto rootTyRepr = KPE->getRootType()) {
-      loc = rootTyRepr->getLoc();
-      range = rootTyRepr->getSourceRange();
-    }
-  }
-
-  emitDiagnostic(loc, diag::expr_swift_keypath_anyobject_root).highlight(range);
+  emitDiagnostic(diag::expr_swift_keypath_anyobject_root)
+      .highlight(getSourceRange());
   return true;
 }
 
-bool KeyPathSubscriptIndexHashableFailure::diagnoseAsError() {
-  auto *anchor = getRawAnchor();
+SourceLoc KeyPathSubscriptIndexHashableFailure::getLoc() const {
   auto *locator = getLocator();
 
-  auto loc = anchor->getLoc();
   if (locator->isKeyPathSubscriptComponent()) {
-    auto *KPE = cast<KeyPathExpr>(anchor);
+    auto *KPE = cast<KeyPathExpr>(getAnchor());
     if (auto kpElt = locator->findFirst<LocatorPathElt::KeyPathComponent>())
-      loc = KPE->getComponents()[kpElt->getIndex()].getLoc();
+      return KPE->getComponents()[kpElt->getIndex()].getLoc();
   }
 
-  emitDiagnostic(loc, diag::expr_keypath_subscript_index_not_hashable,
+  return FailureDiagnostic::getLoc();
+}
+
+bool KeyPathSubscriptIndexHashableFailure::diagnoseAsError() {
+  emitDiagnostic(diag::expr_keypath_subscript_index_not_hashable,
                  resolveType(NonConformingType));
   return true;
 }
@@ -4804,20 +4788,20 @@ SourceLoc InvalidMemberRefInKeyPath::getLoc() const {
 }
 
 bool InvalidStaticMemberRefInKeyPath::diagnoseAsError() {
-  emitDiagnostic(getLoc(), diag::expr_keypath_static_member, getName(),
+  emitDiagnostic(diag::expr_keypath_static_member, getName(),
                  isForKeyPathDynamicMemberLookup());
   return true;
 }
 
 bool InvalidMemberWithMutatingGetterInKeyPath::diagnoseAsError() {
-  emitDiagnostic(getLoc(), diag::expr_keypath_mutating_getter, getName(),
+  emitDiagnostic(diag::expr_keypath_mutating_getter, getName(),
                  isForKeyPathDynamicMemberLookup());
   return true;
 }
 
 bool InvalidMethodRefInKeyPath::diagnoseAsError() {
-  emitDiagnostic(getLoc(), diag::expr_keypath_not_property, getKind(),
-                 getName(), isForKeyPathDynamicMemberLookup());
+  emitDiagnostic(diag::expr_keypath_not_property, getKind(), getName(),
+                 isForKeyPathDynamicMemberLookup());
   return true;
 }
 
@@ -4833,21 +4817,19 @@ SourceLoc InvalidUseOfAddressOf::getLoc() const {
 bool InvalidUseOfAddressOf::diagnoseAsError() {
   if (auto argApplyInfo = getFunctionArgApplyInfo(getLocator())) {
     if (!argApplyInfo->getParameterFlags().isInOut()) {
-      auto anchor = getAnchor();
-      emitDiagnostic(anchor->getLoc(), diag::extra_address_of, getToType())
-          .highlight(anchor->getSourceRange())
-          .fixItRemove(anchor->getStartLoc());
+      emitDiagnostic(diag::extra_address_of, getToType())
+          .highlight(getSourceRange())
+          .fixItRemove(getSourceRange().Start);
       return true;
     }
   }
 
-  emitDiagnostic(getLoc(), diag::extraneous_address_of);
+  emitDiagnostic(diag::extraneous_address_of);
   return true;
 }
 
 bool ExtraneousReturnFailure::diagnoseAsError() {
-  auto *anchor = getAnchor();
-  emitDiagnostic(anchor->getLoc(), diag::cannot_return_value_from_void_func);
+  emitDiagnostic(diag::cannot_return_value_from_void_func);
   if (auto FD = dyn_cast<FuncDecl>(getDC())) {
     // We only want to emit the note + fix-it if the function does not
     // have an explicit return type. The reason we also need to check
@@ -4860,7 +4842,7 @@ bool ExtraneousReturnFailure::diagnoseAsError() {
         !FD->getBaseIdentifier().empty()) {
       auto fixItLoc = Lexer::getLocForEndOfToken(
           getASTContext().SourceMgr, FD->getParameters()->getEndLoc());
-      emitDiagnostic(anchor->getLoc(), diag::add_return_type_note)
+      emitDiagnostic(diag::add_return_type_note)
           .fixItInsert(fixItLoc, " -> <#Return Type#>");
     }
   }
@@ -4869,7 +4851,6 @@ bool ExtraneousReturnFailure::diagnoseAsError() {
 }
 
 bool CollectionElementContextualFailure::diagnoseAsError() {
-  auto *anchor = getAnchor();
   auto *locator = getLocator();
 
   auto eltType = getFromType();
@@ -4877,8 +4858,7 @@ bool CollectionElementContextualFailure::diagnoseAsError() {
 
   Optional<InFlightDiagnostic> diagnostic;
   if (isa<ArrayExpr>(getRawAnchor())) {
-    diagnostic.emplace(emitDiagnostic(anchor->getLoc(),
-                                      diag::cannot_convert_array_element,
+    diagnostic.emplace(emitDiagnostic(diag::cannot_convert_array_element,
                                       eltType, contextualType));
   }
 
@@ -4886,14 +4866,12 @@ bool CollectionElementContextualFailure::diagnoseAsError() {
     auto eltLoc = locator->castLastElementTo<LocatorPathElt::TupleElement>();
     switch (eltLoc.getIndex()) {
     case 0: // key
-      diagnostic.emplace(emitDiagnostic(anchor->getLoc(),
-                                        diag::cannot_convert_dict_key, eltType,
+      diagnostic.emplace(emitDiagnostic(diag::cannot_convert_dict_key, eltType,
                                         contextualType));
       break;
 
     case 1: // value
-      diagnostic.emplace(emitDiagnostic(anchor->getLoc(),
-                                        diag::cannot_convert_dict_value,
+      diagnostic.emplace(emitDiagnostic(diag::cannot_convert_dict_value,
                                         eltType, contextualType));
       break;
 
@@ -4907,19 +4885,17 @@ bool CollectionElementContextualFailure::diagnoseAsError() {
     // If this is a conversion failure related to binding of `for-each`
     // statement it has to be diagnosed as pattern match if there are
     // holes present in the contextual type.
-    if (cs.getContextualTypePurpose(anchor) ==
+    if (cs.getContextualTypePurpose(getAnchor()) ==
             ContextualTypePurpose::CTP_ForEachStmt &&
         contextualType->hasHole()) {
       diagnostic.emplace(emitDiagnostic(
-          anchor->getLoc(),
           (contextualType->is<TupleType>() && !eltType->is<TupleType>())
               ? diag::cannot_match_expr_tuple_pattern_with_nontuple_value
               : diag::cannot_match_unresolved_expr_pattern_with_value,
           eltType));
     } else {
       diagnostic.emplace(
-          emitDiagnostic(anchor->getLoc(),
-                         contextualType->isExistentialType()
+          emitDiagnostic(contextualType->isExistentialType()
                              ? diag::cannot_convert_sequence_element_protocol
                              : diag::cannot_convert_sequence_element_value,
                          eltType, contextualType));
@@ -4969,14 +4945,14 @@ bool MissingContextualConformanceFailure::diagnoseAsError() {
   auto srcType = getFromType();
   auto dstType = getToType();
 
-  emitDiagnostic(anchor->getLoc(), *diagnostic, srcType, dstType);
+  emitDiagnostic(*diagnostic, srcType, dstType);
 
   if (isa<InOutExpr>(anchor))
     return true;
 
   if (srcType->isAny() && dstType->isAnyObject()) {
-    emitDiagnostic(anchor->getLoc(), diag::any_as_anyobject_fixit)
-        .fixItInsertAfter(anchor->getEndLoc(), " as AnyObject");
+    emitDiagnostic(diag::any_as_anyobject_fixit)
+        .fixItInsertAfter(getSourceRange().End, " as AnyObject");
   }
 
   return true;
@@ -5018,18 +4994,18 @@ bool MissingGenericArgumentsFailure::diagnoseForAnchor(
     return true;
 
   if (auto *SD = dyn_cast<SubscriptDecl>(DC)) {
-    emitDiagnostic(SD, diag::note_call_to_subscript, SD->getFullName());
+    emitDiagnosticAt(SD, diag::note_call_to_subscript, SD->getFullName());
     return true;
   }
 
   if (auto *AFD = dyn_cast<AbstractFunctionDecl>(DC)) {
     if (isa<ConstructorDecl>(AFD)) {
-      emitDiagnostic(AFD, diag::note_call_to_initializer);
+      emitDiagnosticAt(AFD, diag::note_call_to_initializer);
     } else {
-      emitDiagnostic(AFD,
-                     AFD->isOperator() ? diag::note_call_to_operator
-                                       : diag::note_call_to_func,
-                     AFD->getFullName());
+      emitDiagnosticAt(AFD,
+                       AFD->isOperator() ? diag::note_call_to_operator
+                                         : diag::note_call_to_func,
+                       AFD->getFullName());
     }
     return true;
   }
@@ -5060,10 +5036,10 @@ bool MissingGenericArgumentsFailure::diagnoseParameter(
   if (auto *CE = dyn_cast<ExplicitCastExpr>(getRawAnchor())) {
     auto castTo = getType(CE->getCastTypeLoc());
     auto *NTD = castTo->getAnyNominal();
-    emitDiagnostic(loc, diag::unbound_generic_parameter_cast, GP,
-                   NTD ? NTD->getDeclaredType() : castTo);
+    emitDiagnosticAt(loc, diag::unbound_generic_parameter_cast, GP,
+                     NTD ? NTD->getDeclaredType() : castTo);
   } else {
-    emitDiagnostic(loc, diag::unbound_generic_parameter, GP);
+    emitDiagnosticAt(loc, diag::unbound_generic_parameter, GP);
   }
 
   Type baseTyForNote;
@@ -5083,8 +5059,8 @@ bool MissingGenericArgumentsFailure::diagnoseParameter(
     return true;
   }
 
-  emitDiagnostic(GP->getDecl(), diag::archetype_declared_in_type, GP,
-                 baseTyForNote);
+  emitDiagnosticAt(GP->getDecl(), diag::archetype_declared_in_type, GP,
+                   baseTyForNote);
   return true;
 }
 
@@ -5136,7 +5112,7 @@ void MissingGenericArgumentsFailure::emitGenericSignatureNote(
   auto baseType = anchor.get<TypeRepr *>();
   if (TypeChecker::getDefaultGenericArgumentsString(paramsAsString, GTD,
                                                     getPreferredType)) {
-    auto diagnostic = emitDiagnostic(
+    auto diagnostic = emitDiagnosticAt(
         baseType->getLoc(), diag::unbound_generic_parameter_explicit_fix);
 
     if (auto *genericTy = dyn_cast<GenericIdentTypeRepr>(baseType)) {
@@ -5221,17 +5197,21 @@ bool MissingGenericArgumentsFailure::findArgumentLocations(
   return associator.allParamsAssigned();
 }
 
+SourceLoc SkipUnhandledConstructInFunctionBuilderFailure::getLoc() const {
+  if (auto stmt = unhandled.dyn_cast<Stmt *>())
+    return stmt->getStartLoc();
+
+  return unhandled.get<Decl *>()->getLoc();
+}
+
 void SkipUnhandledConstructInFunctionBuilderFailure::diagnosePrimary(
     bool asNote) {
-  if (auto stmt = unhandled.dyn_cast<Stmt *>()) {
-    emitDiagnostic(stmt->getStartLoc(),
-                   asNote? diag::note_function_builder_control_flow
-                         : diag::function_builder_control_flow,
+  if (unhandled.is<Stmt *>()) {
+    emitDiagnostic(asNote ? diag::note_function_builder_control_flow
+                          : diag::function_builder_control_flow,
                    builder->getFullName());
   } else {
-    auto decl = unhandled.get<Decl *>();
-    emitDiagnostic(decl,
-                   asNote ? diag::note_function_builder_decl
+    emitDiagnostic(asNote ? diag::note_function_builder_decl
                           : diag::function_builder_decl,
                    builder->getFullName());
   }
@@ -5239,10 +5219,8 @@ void SkipUnhandledConstructInFunctionBuilderFailure::diagnosePrimary(
 
 bool SkipUnhandledConstructInFunctionBuilderFailure::diagnoseAsError() {
   diagnosePrimary(/*asNote=*/false);
-  emitDiagnostic(builder,
-                 diag::kind_declname_declared_here,
-                 builder->getDescriptiveKind(),
-                 builder->getFullName());
+  emitDiagnosticAt(builder, diag::kind_declname_declared_here,
+                   builder->getDescriptiveKind(), builder->getFullName());
   return true;
 }
 
@@ -5319,13 +5297,12 @@ bool InvalidTupleSplatWithSingleParameterFailure::diagnoseAsError() {
 
   auto diagnostic =
       name.isSpecial()
-          ? emitDiagnostic(argExpr->getLoc(),
-                           diag::single_tuple_parameter_mismatch_special,
-                           choice->getDescriptiveKind(), paramTy, subsStr)
-          : emitDiagnostic(argExpr->getLoc(),
-                           diag::single_tuple_parameter_mismatch_normal,
-                           choice->getDescriptiveKind(), name, paramTy, subsStr);
-
+          ? emitDiagnosticAt(argExpr->getLoc(),
+                             diag::single_tuple_parameter_mismatch_special,
+                             choice->getDescriptiveKind(), paramTy, subsStr)
+          : emitDiagnosticAt(
+                argExpr->getLoc(), diag::single_tuple_parameter_mismatch_normal,
+                choice->getDescriptiveKind(), name, paramTy, subsStr);
 
   auto newLeftParenLoc = argExpr->getStartLoc();
   if (auto *TE = dyn_cast<TupleExpr>(argExpr)) {
@@ -5355,9 +5332,8 @@ bool InvalidTupleSplatWithSingleParameterFailure::diagnoseAsError() {
 }
 
 bool ThrowingFunctionConversionFailure::diagnoseAsError() {
-  auto *anchor = getAnchor();
-  emitDiagnostic(anchor->getLoc(), diag::throws_functiontype_mismatch,
-                 getFromType(), getToType());
+  emitDiagnostic(diag::throws_functiontype_mismatch, getFromType(),
+                 getToType());
   return true;
 }
 
@@ -5369,8 +5345,8 @@ bool InOutConversionFailure::diagnoseAsError() {
   if (!path.empty() &&
       path.back().getKind() == ConstraintLocator::FunctionArgument) {
     if (auto argApplyInfo = getFunctionArgApplyInfo(locator)) {
-      emitDiagnostic(anchor->getLoc(), diag::cannot_convert_argument_value,
-          argApplyInfo->getArgType(), argApplyInfo->getParamType());
+      emitDiagnostic(diag::cannot_convert_argument_value,
+                     argApplyInfo->getArgType(), argApplyInfo->getParamType());
     } else {
       assert(locator->findLast<LocatorPathElt::ContextualType>());
       auto contextualType = getContextualType(anchor);
@@ -5380,15 +5356,14 @@ bool InOutConversionFailure::diagnoseAsError() {
       if (!diagnostic)
         return false;
 
-      emitDiagnostic(anchor->getLoc(), *diagnostic, getType(anchor),
-                     contextualType);
+      emitDiagnostic(*diagnostic, getType(anchor), contextualType);
     }
 
     return true;
   }
 
-  emitDiagnostic(anchor->getLoc(), diag::cannot_pass_rvalue_inout_converted,
-                 getFromType(), getToType());
+  emitDiagnostic(diag::cannot_pass_rvalue_inout_converted, getFromType(),
+                 getToType());
   fixItChangeArgumentType();
   return true;
 }
@@ -5456,8 +5431,8 @@ void InOutConversionFailure::fixItChangeArgumentType() const {
   if (!startLoc.isValid())
     startLoc = endLoc;
 
-  emitDiagnostic(VD->getLoc(), diag::inout_change_var_type_if_possible,
-                 actualType, neededType)
+  emitDiagnosticAt(VD, diag::inout_change_var_type_if_possible, actualType,
+                   neededType)
       .fixItReplaceChars(startLoc, endLoc, scratch);
 }
 
@@ -5484,8 +5459,8 @@ bool ArgumentMismatchFailure::diagnoseAsError() {
   auto paramType = getToType();
 
   if (paramType->isAnyObject()) {
-    emitDiagnostic(getLoc(), diag::cannot_convert_argument_value_anyobject,
-                   argType, paramType);
+    emitDiagnostic(diag::cannot_convert_argument_value_anyobject, argType,
+                   paramType);
     return true;
   }
 
@@ -5496,7 +5471,7 @@ bool ArgumentMismatchFailure::diagnoseAsError() {
   if (paramType->isExistentialType())
     diagnostic = diag::cannot_convert_argument_value_protocol;
 
-  auto diag = emitDiagnostic(getLoc(), diagnostic, argType, paramType);
+  auto diag = emitDiagnostic(diagnostic, argType, paramType);
 
   // If argument is an l-value type and parameter is a pointer type,
   // let's match up its element type to the argument to see whether
@@ -5517,9 +5492,10 @@ bool ArgumentMismatchFailure::diagnoseAsError() {
 bool ArgumentMismatchFailure::diagnoseAsNote() {
   auto *locator = getLocator();
   if (auto *callee = getCallee()) {
-    emitDiagnostic(callee, diag::candidate_has_invalid_argument_at_position,
-                   getToType(), getParamPosition(),
-                   locator->isLastElement<LocatorPathElt::LValueConversion>());
+    emitDiagnosticAt(
+        callee, diag::candidate_has_invalid_argument_at_position, getToType(),
+        getParamPosition(),
+        locator->isLastElement<LocatorPathElt::LValueConversion>());
     return true;
   }
 
@@ -5568,13 +5544,13 @@ bool ArgumentMismatchFailure::diagnoseUseOfReferenceEqualityOperator() const {
     // reference semantics rather than value semantics. The fixit will
     // lop off the extra '=' in the operator.
     if (nonNilType->getOptionalObjectType()) {
-      emitDiagnostic(loc,
-                     diag::value_type_comparison_with_nil_illegal_did_you_mean,
-                     nonNilType)
+      emitDiagnosticAt(
+          loc, diag::value_type_comparison_with_nil_illegal_did_you_mean,
+          nonNilType)
           .fixItReplace(loc, revisedName);
     } else {
-      emitDiagnostic(loc, diag::value_type_comparison_with_nil_illegal,
-                     nonNilType)
+      emitDiagnosticAt(loc, diag::value_type_comparison_with_nil_illegal,
+                       nonNilType)
           .highlight(nonNilExpr->getSourceRange());
     }
 
@@ -5582,8 +5558,8 @@ bool ArgumentMismatchFailure::diagnoseUseOfReferenceEqualityOperator() const {
   }
 
   if (lhsType->is<FunctionType>() || rhsType->is<FunctionType>()) {
-    emitDiagnostic(binaryOp->getLoc(), diag::cannot_reference_compare_types,
-                   name.str(), lhsType, rhsType)
+    emitDiagnosticAt(binaryOp->getLoc(), diag::cannot_reference_compare_types,
+                     name.str(), lhsType, rhsType)
         .highlight(lhs->getSourceRange())
         .highlight(rhs->getSourceRange());
     return true;
@@ -5606,10 +5582,9 @@ bool ArgumentMismatchFailure::diagnosePatternMatchingMismatch() const {
   auto diagnostic =
       lhsType->is<UnresolvedType>()
           ? emitDiagnostic(
-                getLoc(), diag::cannot_match_unresolved_expr_pattern_with_value,
-                rhsType)
-          : emitDiagnostic(getLoc(), diag::cannot_match_expr_pattern_with_value,
-                           lhsType, rhsType);
+                diag::cannot_match_unresolved_expr_pattern_with_value, rhsType)
+          : emitDiagnostic(diag::cannot_match_expr_pattern_with_value, lhsType,
+                           rhsType);
 
   diagnostic.highlight(lhsExpr->getSourceRange());
   diagnostic.highlight(rhsExpr->getSourceRange());
@@ -5653,15 +5628,15 @@ bool ArgumentMismatchFailure::diagnoseArchetypeMismatch() const {
   if (!(paramDecl && argDecl))
     return false;
 
-  emitDiagnostic(
-      getAnchor()->getLoc(), diag::cannot_convert_argument_value_generic, argTy,
-      describeGenericType(argDecl), paramTy, describeGenericType(paramDecl));
+  emitDiagnostic(diag::cannot_convert_argument_value_generic, argTy,
+                 describeGenericType(argDecl), paramTy,
+                 describeGenericType(paramDecl));
 
-  emitDiagnostic(argDecl, diag::descriptive_generic_type_declared_here,
-                 describeGenericType(argDecl, true));
+  emitDiagnosticAt(argDecl, diag::descriptive_generic_type_declared_here,
+                   describeGenericType(argDecl, true));
 
-  emitDiagnostic(paramDecl, diag::descriptive_generic_type_declared_here,
-                 describeGenericType(paramDecl, true));
+  emitDiagnosticAt(paramDecl, diag::descriptive_generic_type_declared_here,
+                   describeGenericType(paramDecl, true));
 
   return true;
 }
@@ -5707,8 +5682,7 @@ bool ArgumentMismatchFailure::diagnosePropertyWrapperMismatch() const {
       argType->is<ErrorType>())
     return true;
 
-  emitDiagnostic(getLoc(), diag::cannot_convert_initializer_value, argType,
-                 paramType);
+  emitDiagnostic(diag::cannot_convert_initializer_value, argType, paramType);
   return true;
 }
 
@@ -5717,8 +5691,8 @@ void ExpandArrayIntoVarargsFailure::tryDropArrayBracketsFixIt(
   // If this is an array literal, offer to remove the brackets and pass the
   // elements directly as variadic arguments.
   if (auto *arrayExpr = dyn_cast<ArrayExpr>(anchor)) {
-    auto diag = emitDiagnostic(arrayExpr->getLoc(),
-                               diag::suggest_pass_elements_directly);
+    auto diag = emitDiagnosticAt(arrayExpr->getLoc(),
+                                 diag::suggest_pass_elements_directly);
     diag.fixItRemove(arrayExpr->getLBracketLoc())
         .fixItRemove(arrayExpr->getRBracketLoc());
     // Handle the case where the array literal has a trailing comma.
@@ -5729,8 +5703,8 @@ void ExpandArrayIntoVarargsFailure::tryDropArrayBracketsFixIt(
 
 bool ExpandArrayIntoVarargsFailure::diagnoseAsError() {
   if (auto anchor = getAnchor()) {
-    emitDiagnostic(anchor->getLoc(), diag::cannot_convert_array_to_variadic,
-                   getFromType(), getToType());
+    emitDiagnostic(diag::cannot_convert_array_to_variadic, getFromType(),
+                   getToType());
     tryDropArrayBracketsFixIt(anchor);
     // TODO: Array splat fix-it once that's supported.
     return true;
@@ -5745,8 +5719,8 @@ bool ExpandArrayIntoVarargsFailure::diagnoseAsNote() {
     return false;
 
   if (auto chosenDecl = overload->choice.getDeclOrNull()) {
-    emitDiagnostic(chosenDecl, diag::candidate_would_match_array_to_variadic,
-                   getToType());
+    emitDiagnosticAt(chosenDecl, diag::candidate_would_match_array_to_variadic,
+                     getToType());
     tryDropArrayBracketsFixIt(anchor);
     return true;
   }
@@ -5776,9 +5750,9 @@ bool ExtraneousCallFailure::diagnoseAsError() {
   if (auto overload = getCalleeOverloadChoiceIfAvailable(locator)) {
     if (auto *decl = overload->choice.getDeclOrNull()) {
       if (auto *enumCase = dyn_cast<EnumElementDecl>(decl)) {
-        auto diagnostic = emitDiagnostic(
-            anchor->getLoc(), diag::unexpected_arguments_in_enum_case,
-            enumCase->getBaseIdentifier());
+        auto diagnostic =
+            emitDiagnostic(diag::unexpected_arguments_in_enum_case,
+                           enumCase->getBaseIdentifier());
         removeParensFixIt(diagnostic);
         return true;
       }
@@ -5790,7 +5764,7 @@ bool ExtraneousCallFailure::diagnoseAsError() {
     auto *call = cast<CallExpr>(getRawAnchor());
 
     if (getType(baseExpr)->isAnyObject()) {
-      emitDiagnostic(anchor->getLoc(), diag::cannot_call_with_params,
+      emitDiagnostic(diag::cannot_call_with_params,
                      UDE->getName().getBaseName().userFacingName(),
                      getType(call->getArg())->getString(),
                      isa<TypeExpr>(baseExpr));
@@ -5798,22 +5772,19 @@ bool ExtraneousCallFailure::diagnoseAsError() {
     }
   }
 
-  auto diagnostic = emitDiagnostic(
-      anchor->getLoc(), diag::cannot_call_non_function_value, getType(anchor));
+  auto diagnostic =
+      emitDiagnostic(diag::cannot_call_non_function_value, getType(anchor));
   removeParensFixIt(diagnostic);
   return true;
 }
 
 bool InvalidUseOfTrailingClosure::diagnoseAsError() {
-  auto *anchor = getAnchor();
-
-  emitDiagnostic(anchor->getLoc(), diag::trailing_closure_bad_param,
-                 getToType())
-      .highlight(anchor->getSourceRange());
+  emitDiagnostic(diag::trailing_closure_bad_param, getToType())
+      .highlight(getSourceRange());
 
   if (auto overload = getCalleeOverloadChoiceIfAvailable(getLocator())) {
     if (auto *decl = overload->choice.getDeclOrNull()) {
-      emitDiagnostic(decl, diag::decl_declared_here, decl->getFullName());
+      emitDiagnosticAt(decl, diag::decl_declared_here, decl->getFullName());
     }
   }
 
@@ -5858,9 +5829,9 @@ void NonEphemeralConversionFailure::emitSuggestionNotes() const {
   // First emit a note about the implicit conversion only lasting for the
   // duration of the call.
   auto *argExpr = getArgExpr();
-  emitDiagnostic(argExpr->getLoc(),
-                 diag::ephemeral_pointer_argument_conversion_note,
-                 getArgType(), getParamType(), getCallee(), getCalleeFullName())
+  emitDiagnosticAt(
+      argExpr->getLoc(), diag::ephemeral_pointer_argument_conversion_note,
+      getArgType(), getParamType(), getCallee(), getCalleeFullName())
       .highlight(argExpr->getSourceRange());
 
   // Then try to find a suitable alternative.
@@ -5873,9 +5844,9 @@ void NonEphemeralConversionFailure::emitSuggestionNotes() const {
 
     // We can suggest using withUnsafe[Mutable][Bytes/BufferPointer].
     if (auto alternative = getAlternativeKind())
-      emitDiagnostic(argExpr->getLoc(),
-                     diag::ephemeral_use_array_with_unsafe_buffer,
-                     *alternative);
+      emitDiagnosticAt(argExpr->getLoc(),
+                       diag::ephemeral_use_array_with_unsafe_buffer,
+                       *alternative);
     break;
   }
   case ConversionRestrictionKind::StringToPointer: {
@@ -5889,8 +5860,8 @@ void NonEphemeralConversionFailure::emitSuggestionNotes() const {
     switch (getPointerKind(getParamType())) {
     case PTK_UnsafePointer:
     case PTK_UnsafeRawPointer:
-      emitDiagnostic(argExpr->getLoc(),
-                     diag::ephemeral_use_string_with_c_string);
+      emitDiagnosticAt(argExpr->getLoc(),
+                       diag::ephemeral_use_string_with_c_string);
       break;
     case PTK_UnsafeMutableRawPointer:
     case PTK_UnsafeMutablePointer:
@@ -5904,8 +5875,8 @@ void NonEphemeralConversionFailure::emitSuggestionNotes() const {
     // For an arbitrary inout-to-pointer, we can suggest
     // withUnsafe[Mutable][Bytes/Pointer].
     if (auto alternative = getAlternativeKind())
-      emitDiagnostic(argExpr->getLoc(), diag::ephemeral_use_with_unsafe_pointer,
-                     *alternative);
+      emitDiagnosticAt(argExpr->getLoc(),
+                       diag::ephemeral_use_with_unsafe_pointer, *alternative);
     break;
   case ConversionRestrictionKind::DeepEquality:
   case ConversionRestrictionKind::Superclass:
@@ -5965,9 +5936,8 @@ bool NonEphemeralConversionFailure::diagnosePointerInit() const {
                     ? diag::cannot_construct_dangling_pointer_warning
                     : diag::cannot_construct_dangling_pointer;
 
-  auto *anchor = getRawAnchor();
-  emitDiagnostic(anchor->getLoc(), diagID, constructedTy, constructorKind)
-      .highlight(anchor->getSourceRange());
+  emitDiagnostic(diagID, constructedTy, constructorKind)
+      .highlight(getSourceRange());
 
   emitSuggestionNotes();
   return true;
@@ -5976,8 +5946,8 @@ bool NonEphemeralConversionFailure::diagnosePointerInit() const {
 bool NonEphemeralConversionFailure::diagnoseAsNote() {
   // We can only emit a useful note if we have a callee.
   if (auto *callee = getCallee()) {
-    emitDiagnostic(callee, diag::candidate_performs_illegal_ephemeral_conv,
-                   getParamPosition());
+    emitDiagnosticAt(callee, diag::candidate_performs_illegal_ephemeral_conv,
+                     getParamPosition());
     return true;
   }
   return false;
@@ -6000,16 +5970,16 @@ bool NonEphemeralConversionFailure::diagnoseAsError() {
                       ? diag::cannot_use_inout_non_ephemeral_warning
                       : diag::cannot_use_inout_non_ephemeral;
 
-    emitDiagnostic(argExpr->getLoc(), diagID, argDesc, getCallee(),
-                   getCalleeFullName())
+    emitDiagnosticAt(argExpr->getLoc(), diagID, argDesc, getCallee(),
+                     getCalleeFullName())
         .highlight(argExpr->getSourceRange());
   } else {
     auto diagID = DowngradeToWarning
                       ? diag::cannot_pass_type_to_non_ephemeral_warning
                       : diag::cannot_pass_type_to_non_ephemeral;
 
-    emitDiagnostic(argExpr->getLoc(), diagID, getArgType(), argDesc,
-                   getCallee(), getCalleeFullName())
+    emitDiagnosticAt(argExpr->getLoc(), diagID, getArgType(), argDesc,
+                     getCallee(), getCalleeFullName())
         .highlight(argExpr->getSourceRange());
   }
   emitSuggestionNotes();
@@ -6049,9 +6019,7 @@ bool AssignmentTypeMismatchFailure::diagnoseMissingConformance() const {
   if (dstMembers.size() == 1)
     dstType = (*dstMembers.begin())->getDeclaredType();
 
-  auto *anchor = getAnchor();
-  emitDiagnostic(anchor->getLoc(), diag::cannot_convert_assign_protocol,
-                 srcType, dstType);
+  emitDiagnostic(diag::cannot_convert_assign_protocol, srcType, dstType);
   return true;
 }
 
@@ -6068,9 +6036,9 @@ bool AssignmentTypeMismatchFailure::diagnoseAsNote() {
   if (auto overload =
           getCalleeOverloadChoiceIfAvailable(getConstraintLocator(anchor))) {
     if (auto *decl = overload->choice.getDeclOrNull()) {
-      emitDiagnostic(decl,
-                     diag::cannot_convert_candidate_result_to_contextual_type,
-                     decl->getFullName(), getFromType(), getToType());
+      emitDiagnosticAt(decl,
+                       diag::cannot_convert_candidate_result_to_contextual_type,
+                       decl->getFullName(), getFromType(), getToType());
       return true;
     }
   }
@@ -6095,18 +6063,15 @@ bool MissingContextualBaseInMemberRefFailure::diagnoseAsError() {
                         ? diag::cannot_infer_base_of_unresolved_member
                         : diag::unresolved_member_no_inference;
 
-  emitDiagnostic(anchor->getLoc(), diagnostic, MemberName)
-      .highlight(anchor->getSourceRange());
+  emitDiagnostic(diagnostic, MemberName).highlight(getSourceRange());
   return true;
 }
 
 bool UnableToInferClosureReturnType::diagnoseAsError() {
   auto *closure = cast<ClosureExpr>(getRawAnchor());
 
-  auto diagnostic =
-      emitDiagnostic(closure->getLoc(),
-                     diag::cannot_infer_closure_result_type,
-                     closure->hasSingleExpressionBody());
+  auto diagnostic = emitDiagnostic(diag::cannot_infer_closure_result_type,
+                                   closure->hasSingleExpressionBody());
 
   // If there is a location for an 'in' token, then the argument list was
   // specified somehow but no return type was.  Insert a "-> ReturnType "
@@ -6159,10 +6124,14 @@ getImportModuleAndDefaultType(const ASTContext &ctx, ObjectLiteralExpr *expr) {
   return std::make_pair("", "");
 }
 
+SourceLoc UnableToInferProtocolLiteralType::getLoc() const {
+  return getRawAnchor()->getLoc();
+}
+
 bool UnableToInferProtocolLiteralType::diagnoseAsError() {
   auto &cs = getConstraintSystem();
   auto &ctx = cs.getASTContext();
-  auto *expr = cast<ObjectLiteralExpr>(getLocator()->getAnchor());
+  auto *expr = cast<ObjectLiteralExpr>(getRawAnchor());
 
   StringRef importModule;
   StringRef importDefaultTypeName;
@@ -6170,11 +6139,10 @@ bool UnableToInferProtocolLiteralType::diagnoseAsError() {
       getImportModuleAndDefaultType(ctx, expr);
 
   auto plainName = expr->getLiteralKindPlainName();
-  emitDiagnostic(expr->getLoc(), diag::object_literal_default_type_missing,
-                 plainName);
+  emitDiagnostic(diag::object_literal_default_type_missing, plainName);
   if (!importModule.empty()) {
-    emitDiagnostic(expr->getLoc(), diag::object_literal_resolve_import,
-                   importModule, importDefaultTypeName, plainName);
+    emitDiagnostic(diag::object_literal_resolve_import, importModule,
+                   importDefaultTypeName, plainName);
   }
 
   return true;
@@ -6199,33 +6167,30 @@ bool MissingQuialifierInMemberRefFailure::diagnoseAsError() {
 
   auto *DC = choice->getDeclContext();
   if (!(DC->isModuleContext() || DC->isModuleScopeContext())) {
-    emitDiagnostic(UDE->getLoc(), diag::member_shadows_function, UDE->getName(),
-                   methodKind, choice->getDescriptiveKind(),
-                   choice->getFullName());
+    emitDiagnostic(diag::member_shadows_function, UDE->getName(), methodKind,
+                   choice->getDescriptiveKind(), choice->getFullName());
     return true;
   }
 
   auto qualifier = DC->getParentModule()->getName();
 
-  emitDiagnostic(UDE->getLoc(), diag::member_shadows_global_function,
-                 UDE->getName(), methodKind, choice->getDescriptiveKind(),
+  emitDiagnostic(diag::member_shadows_global_function, UDE->getName(),
+                 methodKind, choice->getDescriptiveKind(),
                  choice->getFullName(), qualifier);
 
   SmallString<32> namePlusDot = qualifier.str();
   namePlusDot.push_back('.');
 
-  emitDiagnostic(UDE->getLoc(), diag::fix_unqualified_access_top_level_multi,
-                 namePlusDot, choice->getDescriptiveKind(), qualifier)
+  emitDiagnostic(diag::fix_unqualified_access_top_level_multi, namePlusDot,
+                 choice->getDescriptiveKind(), qualifier)
       .fixItInsert(UDE->getStartLoc(), namePlusDot);
 
-  emitDiagnostic(choice, diag::decl_declared_here, choice->getFullName());
+  emitDiagnosticAt(choice, diag::decl_declared_here, choice->getFullName());
   return true;
 }
 
 bool CoercionAsForceCastFailure::diagnoseAsError() {
-  auto *coercion = cast<CoerceExpr>(getRawAnchor());
-  emitDiagnostic(coercion->getLoc(), diag::coercion_may_fail_warning,
-                 getFromType(), getToType())
-      .highlight(coercion->getSourceRange());
+  emitDiagnostic(diag::coercion_may_fail_warning, getFromType(), getToType())
+      .highlight(getSourceRange());
   return true;
 }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5936,8 +5936,9 @@ bool NonEphemeralConversionFailure::diagnosePointerInit() const {
                     ? diag::cannot_construct_dangling_pointer_warning
                     : diag::cannot_construct_dangling_pointer;
 
-  emitDiagnostic(diagID, constructedTy, constructorKind)
-      .highlight(getSourceRange());
+  auto *anchor = getRawAnchor();
+  emitDiagnosticAt(anchor->getLoc(), diagID, constructedTy, constructorKind)
+      .highlight(anchor->getSourceRange());
 
   emitSuggestionNotes();
   return true;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1140,6 +1140,8 @@ protected:
   const ConstructorDecl *Init;
   SourceRange BaseRange;
 
+  Expr *getAnchor() const override { return getRawAnchor(); }
+
   InvalidInitRefFailure(const Solution &solution, Type baseTy,
                         const ConstructorDecl *init, SourceRange baseRange,
                         ConstraintLocator *locator)

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -56,6 +56,8 @@ public:
 
   virtual ~FailureDiagnostic();
 
+  virtual SourceLoc getLoc() const { return getAnchor()->getLoc(); }
+
   /// Try to diagnose a problem given affected expression,
   /// failure location, types and declarations deduced by
   /// constraint system, and other auxiliary information.
@@ -832,7 +834,7 @@ public:
 
 protected:
   /// Compute location of the failure for diagnostic.
-  SourceLoc getLoc() const;
+  SourceLoc getLoc() const override;
 };
 
 /// Diagnose mismatches relating to tuple destructuring.
@@ -1441,7 +1443,7 @@ public:
 
 protected:
   /// Compute location of the failure for diagnostic.
-  SourceLoc getLoc() const;
+  SourceLoc getLoc() const override;
 
   bool isForKeyPathDynamicMemberLookup() const {
     return getLocator()->isForKeyPathDynamicMemberLookup();
@@ -1819,8 +1821,6 @@ protected:
   /// Are currently impossible to fix correctly,
   /// so we have to attend to that in diagnostics.
   bool diagnoseMisplacedMissingArgument() const;
-
-  SourceLoc getLoc() const { return getAnchor()->getLoc(); }
 };
 
 /// Replace a coercion ('as') with a forced checked cast ('as!').

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -81,7 +81,7 @@ public:
 
   Expr *getRawAnchor() const { return RawAnchor; }
 
-  Expr *getAnchor() const { return Anchor; }
+  virtual Expr *getAnchor() const { return Anchor; }
 
   ConstraintLocator *getLocator() const { return Locator; }
 
@@ -779,6 +779,8 @@ public:
                                    Type toType, ConstraintLocator *locator)
       : ContextualFailure(solution, fromType, toType, locator) {}
 
+  Expr *getAnchor() const override;
+
   bool diagnoseAsError() override;
 
 private:
@@ -935,6 +937,8 @@ class MissingCallFailure final : public FailureDiagnostic {
 public:
   MissingCallFailure(const Solution &solution, ConstraintLocator *locator)
       : FailureDiagnostic(solution, locator) {}
+
+  Expr *getAnchor() const override;
 
   bool diagnoseAsError() override;
 };
@@ -1213,6 +1217,8 @@ public:
         SynthesizedArgs(synthesizedArgs.begin(), synthesizedArgs.end()) {
     assert(!SynthesizedArgs.empty() && "No missing arguments?!");
   }
+
+  Expr *getAnchor() const override;
 
   bool diagnoseAsError() override;
 
@@ -1829,6 +1835,8 @@ public:
   MissingForcedDowncastFailure(const Solution &solution, Type fromType,
                                Type toType, ConstraintLocator *locator)
       : ContextualFailure(solution, fromType, toType, locator) {}
+
+  Expr *getAnchor() const override;
 
   bool diagnoseAsError() override;
 };

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -111,7 +111,7 @@ class T {
       // <rdar://problem/17741575>
       let l = self.m2!.prop1
       // expected-error@-1 {{cannot force unwrap value of non-optional type '() -> U?'}} {{22-23=}}
-      // expected-error@-2 {{method 'm2' was used as a property; add () to call it}}  {{23-23=()}}
+      // expected-error@-2 {{method 'm2' was used as a property; add () to call it}}  {{22-22=()}}
     }
 
     func m2() -> U! {


### PR DESCRIPTION
- Some of the diagnostics have special rules about anchor location,
    let's make `getAnchor` virtual and allow sub-class to override
    default implementation.

- Split `emitDiagnostic` into `emitDiagnostic` and `emitDiagnosticAt`,
   where former passes `getLoc` internally.

- Refactor existing diagnostics to use new methods and avoid passing
   location when possible.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
