### PR TITLE
[ASTScope lookup] Tolerate non-empty braces in braces

### DIFF
--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -658,9 +658,10 @@ public:
     ASTScopeAssert(!n.isDecl(DeclKind::Accessor),
                    "Should not see accessors here");
     // Can occur in illegal code
+    // non-empty brace stmt could define a new insertion point
     if (auto *const s = n.dyn_cast<Stmt *>()) {
       if (auto *const bs = dyn_cast<BraceStmt>(s))
-        ASTScopeAssert(bs->empty(), "Might mess up insertion point");
+        return !bs->empty();
     }
     return !n.isDecl(DeclKind::Var);
   }

--- a/test/NameLookup/nonempty-brace-in-brace.swift
+++ b/test/NameLookup/nonempty-brace-in-brace.swift
@@ -1,0 +1,12 @@
+// RUN: not %target-swift-frontend -typecheck %s  2>&1 |  %FileCheck %s --check-prefix=CHECK-NO-ASSERTION
+
+// Used to trip an assertion
+
+public struct Foo {
+    func bar() {
+        var copySelf = self
+        repeat { copySelf
+
+private extension String {}
+
+// CHECK-NO-ASSERTION-NOT: Assertion


### PR DESCRIPTION
ASTScope lookup does not expect to see a non-empty brace statement inside a brace statement, but a case has been found that indeed causes it (with illegal code). Do not fail an assertion in this case.
rdar://61461187