### PR TITLE
[Draft] Extract SDK specific options from add_swift_target_library

### DIFF
--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -10,6 +10,7 @@ list(APPEND CMAKE_MODULE_PATH
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
 include(AddSwiftStdlib)
+include(DarwinSwiftOverlay)
 
 # Create convenience targets for the Swift standard library.
 

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -981,9 +981,6 @@ endfunction()
 # SWIFT_MODULE_DEPENDS
 #   Swift modules this library depends on.
 #
-# SWIFT_MODULE_DEPENDS_OSX
-#   Swift modules this library depends on when built for OS X.
-#
 # SWIFT_MODULE_DEPENDS_MACCATALYST
 #   Zippered Swift modules this library depends on when built for macCatalyst.
 #   For example, Foundation.
@@ -991,27 +988,6 @@ endfunction()
 # SWIFT_MODULE_DEPENDS_MACCATALYST_UNZIPPERED
 #   Unzippered Swift modules this library depends on when built for macCatalyst.
 #   For example, UIKit
-#
-# SWIFT_MODULE_DEPENDS_IOS
-#   Swift modules this library depends on when built for iOS.
-#
-# SWIFT_MODULE_DEPENDS_TVOS
-#   Swift modules this library depends on when built for tvOS.
-#
-# SWIFT_MODULE_DEPENDS_WATCHOS
-#   Swift modules this library depends on when built for watchOS.
-#
-# SWIFT_MODULE_DEPENDS_FREEBSD
-#   Swift modules this library depends on when built for FreeBSD.
-#
-# SWIFT_MODULE_DEPENDS_LINUX
-#   Swift modules this library depends on when built for Linux.
-#
-# SWIFT_MODULE_DEPENDS_CYGWIN
-#   Swift modules this library depends on when built for Cygwin.
-#
-# SWIFT_MODULE_DEPENDS_HAIKU
-#   Swift modules this library depends on when built for Haiku.
 #
 # FRAMEWORK_DEPENDS
 #   System frameworks this library depends on.
@@ -1121,15 +1097,18 @@ function(add_swift_target_library_single_sdk name)
         SWIFT_COMPILE_FLAGS_WATCHOS
         SWIFT_COMPILE_FLAGS_LINUX
         SWIFT_MODULE_DEPENDS
+# TODO: katei
+# Remove from here to
         SWIFT_MODULE_DEPENDS_CYGWIN
         SWIFT_MODULE_DEPENDS_FREEBSD
         SWIFT_MODULE_DEPENDS_HAIKU
-        SWIFT_MODULE_DEPENDS_IOS
         SWIFT_MODULE_DEPENDS_LINUX
+        SWIFT_MODULE_DEPENDS_IOS
         SWIFT_MODULE_DEPENDS_OSX
         SWIFT_MODULE_DEPENDS_TVOS
         SWIFT_MODULE_DEPENDS_WATCHOS
         SWIFT_MODULE_DEPENDS_WINDOWS
+# here
         SWIFT_MODULE_DEPENDS_FROM_SDK
         TARGET_SDKS
         SWIFT_COMPILE_FLAGS_MACCATALYST
@@ -1257,6 +1236,8 @@ function(add_swift_target_library_single_sdk name)
         endif()
       list(APPEND swiftlib_module_depends_flattened
            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_OSX})
+# TODO: katei
+# Remove from here to
     elseif(${SWIFTLIB_SDK} STREQUAL IOS OR ${SWIFTLIB_SDK} STREQUAL IOS_SIMULATOR)
       list(APPEND swiftlib_module_depends_flattened
            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_IOS})
@@ -1281,6 +1262,7 @@ function(add_swift_target_library_single_sdk name)
     elseif(${SWIFTLIB_SDK} STREQUAL WINDOWS)
       list(APPEND swiftlib_module_depends_flattened
            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_WINDOWS})
+# here
     endif()
 
     # Collect architecture agnostic SDK framework dependencies

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1097,18 +1097,6 @@ function(add_swift_target_library_single_sdk name)
         SWIFT_COMPILE_FLAGS_WATCHOS
         SWIFT_COMPILE_FLAGS_LINUX
         SWIFT_MODULE_DEPENDS
-# TODO: katei
-# Remove from here to
-        SWIFT_MODULE_DEPENDS_CYGWIN
-        SWIFT_MODULE_DEPENDS_FREEBSD
-        SWIFT_MODULE_DEPENDS_HAIKU
-        SWIFT_MODULE_DEPENDS_LINUX
-        SWIFT_MODULE_DEPENDS_IOS
-        SWIFT_MODULE_DEPENDS_OSX
-        SWIFT_MODULE_DEPENDS_TVOS
-        SWIFT_MODULE_DEPENDS_WATCHOS
-        SWIFT_MODULE_DEPENDS_WINDOWS
-# here
         SWIFT_MODULE_DEPENDS_FROM_SDK
         TARGET_SDKS
         SWIFT_COMPILE_FLAGS_MACCATALYST
@@ -1230,39 +1218,7 @@ function(add_swift_target_library_single_sdk name)
             ${SWIFTLIB_SWIFT_MODULE_DEPENDS_MACCATALYST})
           list(APPEND swiftlib_module_depends_flattened
             ${SWIFTLIB_SWIFT_MODULE_DEPENDS_MACCATALYST_UNZIPPERED})
-        else()
-          list(APPEND swiftlib_module_depends_flattened
-            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_OSX})
         endif()
-      list(APPEND swiftlib_module_depends_flattened
-           ${SWIFTLIB_SWIFT_MODULE_DEPENDS_OSX})
-# TODO: katei
-# Remove from here to
-    elseif(${SWIFTLIB_SDK} STREQUAL IOS OR ${SWIFTLIB_SDK} STREQUAL IOS_SIMULATOR)
-      list(APPEND swiftlib_module_depends_flattened
-           ${SWIFTLIB_SWIFT_MODULE_DEPENDS_IOS})
-    elseif(${SWIFTLIB_SDK} STREQUAL TVOS OR ${SWIFTLIB_SDK} STREQUAL TVOS_SIMULATOR)
-      list(APPEND swiftlib_module_depends_flattened
-           ${SWIFTLIB_SWIFT_MODULE_DEPENDS_TVOS})
-    elseif(${SWIFTLIB_SDK} STREQUAL WATCHOS OR ${SWIFTLIB_SDK} STREQUAL WATCHOS_SIMULATOR)
-      list(APPEND swiftlib_module_depends_flattened
-           ${SWIFTLIB_SWIFT_MODULE_DEPENDS_WATCHOS})
-    elseif(${SWIFTLIB_SDK} STREQUAL FREEBSD)
-      list(APPEND swiftlib_module_depends_flattened
-           ${SWIFTLIB_SWIFT_MODULE_DEPENDS_FREEBSD})
-    elseif(${SWIFTLIB_SDK} STREQUAL LINUX OR ${SWIFTLIB_SDK} STREQUAL ANDROID)
-      list(APPEND swiftlib_module_depends_flattened
-           ${SWIFTLIB_SWIFT_MODULE_DEPENDS_LINUX})
-    elseif(${SWIFTLIB_SDK} STREQUAL CYGWIN)
-      list(APPEND swiftlib_module_depends_flattened
-           ${SWIFTLIB_SWIFT_MODULE_DEPENDS_CYGWIN})
-    elseif(${SWIFTLIB_SDK} STREQUAL HAIKU)
-      list(APPEND swiftlib_module_depends_flattened
-           ${SWIFTLIB_SWIFT_MODULE_DEPENDS_HAIKU})
-    elseif(${SWIFTLIB_SDK} STREQUAL WINDOWS)
-      list(APPEND swiftlib_module_depends_flattened
-           ${SWIFTLIB_SWIFT_MODULE_DEPENDS_WINDOWS})
-# here
     endif()
 
     # Collect architecture agnostic SDK framework dependencies

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -895,11 +895,48 @@ endfunction()
 
 # Add a new Swift target library.
 #
+# NOTE: This function inherits all options from add_swift_target_library_single_sdk
+# except for SDK.
+# Usage:
+#   add_swift_target_library(name
+#     [TARGET_SDKS sdk1...]
+#     [add_swift_target_library_single_sdk's options ...])
+#
+# TARGET_SDKS
+#   The set of SDKs in which this library is included. If empty, the library
+#   is included in all SDKs.
+function(add_swift_target_library name)
+  set(options)
+  set(single_parameter_options)
+  set(multiple_parameter_options TARGET_SDKS)
+  cmake_parse_arguments(ASTL
+    "${options}"
+    "${single_parameter_options}"
+    "${multiple_parameter_options}"
+    ${ARGN})
+
+  # If target SDKs are not specified, build for all known SDKs.
+  if("${ASTL_TARGET_SDKS}" STREQUAL "")
+    set(ASTL_TARGET_SDKS ${SWIFT_SDKS})
+  endif()
+  list_replace(ASTL_TARGET_SDKS ALL_APPLE_PLATFORMS "${SWIFT_APPLE_PLATFORMS}")
+
+  # If we are building this library for targets, loop through the various
+  # SDKs building the variants of this library.
+  foreach(sdk ${ASTL_TARGET_SDKS})
+    add_swift_target_library_single_sdk(${name}
+      SDK ${sdk}
+      ${ARGN})
+  endforeach()
+endfunction()
+
+# Add a new Swift library for a single SDK.
+#
 # NOTE: This has not had the swift host code debrided from it yet. That will be
 # in a forthcoming commit.
 #
 # Usage:
-#   add_swift_target_library(name
+#   add_swift_target_library_single_sdk(name
 #     [SHARED]
 #     [STATIC]
 #     [DEPENDS dep1 ...]
@@ -909,7 +946,6 @@ endfunction()
 #     [FRAMEWORK_DEPENDS_WEAK dep1 ...]
 #     [LLVM_LINK_COMPONENTS comp1 ...]
 #     [FILE_DEPENDS target1 ...]
-#     [TARGET_SDKS sdk1...]
 #     [C_COMPILE_FLAGS flag1...]
 #     [SWIFT_COMPILE_FLAGS flag1...]
 #     [LINK_FLAGS flag1...]
@@ -989,9 +1025,8 @@ endfunction()
 # FILE_DEPENDS
 #   Additional files this library depends on.
 #
-# TARGET_SDKS
-#   The set of SDKs in which this library is included. If empty, the library
-#   is included in all SDKs.
+# SDK sdk
+#   SDK to build for.
 #
 # C_COMPILE_FLAGS
 #   Extra compiler flags (C, C++, ObjC).
@@ -1042,7 +1077,7 @@ endfunction()
 #
 # source1 ...
 #   Sources to add into this library.
-function(add_swift_target_library name)
+function(add_swift_target_library_single_sdk name)
   set(SWIFTLIB_options
         DONT_EMBED_BITCODE
         HAS_SWIFT_CONTENT
@@ -1055,6 +1090,7 @@ function(add_swift_target_library name)
         STATIC
         INSTALL_WITH_SHARED)
   set(SWIFTLIB_single_parameter_options
+        SDK
         DEPLOYMENT_VERSION_IOS
         DEPLOYMENT_VERSION_OSX
         DEPLOYMENT_VERSION_TVOS
@@ -1128,12 +1164,6 @@ function(add_swift_target_library name)
     set(SWIFTLIB_HAS_SWIFT_CONTENT TRUE)
   endif()
 
-  # If target SDKs are not specified, build for all known SDKs.
-  if("${SWIFTLIB_TARGET_SDKS}" STREQUAL "")
-    set(SWIFTLIB_TARGET_SDKS ${SWIFT_SDKS})
-  endif()
-  list_replace(SWIFTLIB_TARGET_SDKS ALL_APPLE_PLATFORMS "${SWIFT_APPLE_PLATFORMS}")
-
   # All Swift code depends on the standard library, except for the standard
   # library itself.
   if(SWIFTLIB_HAS_SWIFT_CONTENT AND NOT SWIFTLIB_IS_STDLIB_CORE)
@@ -1176,29 +1206,23 @@ function(add_swift_target_library name)
     list(APPEND SWIFTLIB_DEPENDS clang)
   endif()
 
-  # If we are building this library for targets, loop through the various
-  # SDKs building the variants of this library.
-  list_intersect(
-      "${SWIFTLIB_TARGET_SDKS}" "${SWIFT_SDKS}" SWIFTLIB_TARGET_SDKS)
-
-  foreach(sdk ${SWIFTLIB_TARGET_SDKS})
-    if(NOT SWIFT_SDK_${sdk}_ARCHITECTURES)
-      # SWIFT_SDK_${sdk}_ARCHITECTURES is empty, so just continue
-      continue()
+    if(NOT SWIFT_SDK_${SWIFTLIB_SDK}_ARCHITECTURES)
+      # SWIFT_SDK_${SWIFTLIB_SDK}_ARCHITECTURES is empty, so just continue
+      return()
     endif()
 
     # Skip building library for macOS if macCatalyst support is not enabled and the
     # library only builds for macOS when macCatalyst is enabled.
     if(NOT SWIFT_ENABLE_MACCATALYST AND
-        sdk STREQUAL "OSX" AND
+        SWIFTLIB_SDK STREQUAL "OSX" AND
         SWIFTLIB_MACCATALYST_BUILD_FLAVOR STREQUAL "ios-like")
       message(STATUS "Skipping OSX SDK for module ${name}")
-      continue()
+      return()
     endif()
 
     # Determine if/what macCatalyst build flavor we are
     get_maccatalyst_build_flavor(maccatalyst_build_flavor
-      "${sdk}" "${SWIFTLIB_MACCATALYST_BUILD_FLAVOR}")
+      "${SWIFTLIB_SDK}" "${SWIFTLIB_MACCATALYST_BUILD_FLAVOR}")
 
     set(maccatalyst_build_flavors)
     if(NOT DEFINED maccatalyst_build_flavor)
@@ -1221,7 +1245,7 @@ function(add_swift_target_library name)
 
     # Collect architecture agnostic SDK module dependencies
     set(swiftlib_module_depends_flattened ${SWIFTLIB_SWIFT_MODULE_DEPENDS})
-    if(${sdk} STREQUAL OSX)
+    if(${SWIFTLIB_SDK} STREQUAL OSX)
        if(DEFINED maccatalyst_build_flavor AND NOT maccatalyst_build_flavor STREQUAL "macos-like")
           list(APPEND swiftlib_module_depends_flattened
             ${SWIFTLIB_SWIFT_MODULE_DEPENDS_MACCATALYST})
@@ -1233,61 +1257,61 @@ function(add_swift_target_library name)
         endif()
       list(APPEND swiftlib_module_depends_flattened
            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_OSX})
-    elseif(${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR)
+    elseif(${SWIFTLIB_SDK} STREQUAL IOS OR ${SWIFTLIB_SDK} STREQUAL IOS_SIMULATOR)
       list(APPEND swiftlib_module_depends_flattened
            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_IOS})
-    elseif(${sdk} STREQUAL TVOS OR ${sdk} STREQUAL TVOS_SIMULATOR)
+    elseif(${SWIFTLIB_SDK} STREQUAL TVOS OR ${SWIFTLIB_SDK} STREQUAL TVOS_SIMULATOR)
       list(APPEND swiftlib_module_depends_flattened
            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_TVOS})
-    elseif(${sdk} STREQUAL WATCHOS OR ${sdk} STREQUAL WATCHOS_SIMULATOR)
+    elseif(${SWIFTLIB_SDK} STREQUAL WATCHOS OR ${SWIFTLIB_SDK} STREQUAL WATCHOS_SIMULATOR)
       list(APPEND swiftlib_module_depends_flattened
            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_WATCHOS})
-    elseif(${sdk} STREQUAL FREEBSD)
+    elseif(${SWIFTLIB_SDK} STREQUAL FREEBSD)
       list(APPEND swiftlib_module_depends_flattened
            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_FREEBSD})
-    elseif(${sdk} STREQUAL LINUX OR ${sdk} STREQUAL ANDROID)
+    elseif(${SWIFTLIB_SDK} STREQUAL LINUX OR ${SWIFTLIB_SDK} STREQUAL ANDROID)
       list(APPEND swiftlib_module_depends_flattened
            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_LINUX})
-    elseif(${sdk} STREQUAL CYGWIN)
+    elseif(${SWIFTLIB_SDK} STREQUAL CYGWIN)
       list(APPEND swiftlib_module_depends_flattened
            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_CYGWIN})
-    elseif(${sdk} STREQUAL HAIKU)
+    elseif(${SWIFTLIB_SDK} STREQUAL HAIKU)
       list(APPEND swiftlib_module_depends_flattened
            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_HAIKU})
-    elseif(${sdk} STREQUAL WINDOWS)
+    elseif(${SWIFTLIB_SDK} STREQUAL WINDOWS)
       list(APPEND swiftlib_module_depends_flattened
            ${SWIFTLIB_SWIFT_MODULE_DEPENDS_WINDOWS})
     endif()
 
     # Collect architecture agnostic SDK framework dependencies
     set(swiftlib_framework_depends_flattened ${SWIFTLIB_FRAMEWORK_DEPENDS})
-    if(${sdk} STREQUAL OSX)
+    if(${SWIFTLIB_SDK} STREQUAL OSX)
       list(APPEND swiftlib_framework_depends_flattened
            ${SWIFTLIB_FRAMEWORK_DEPENDS_OSX})
-    elseif(${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR OR
-           ${sdk} STREQUAL TVOS OR ${sdk} STREQUAL TVOS_SIMULATOR)
+    elseif(${SWIFTLIB_SDK} STREQUAL IOS OR ${SWIFTLIB_SDK} STREQUAL IOS_SIMULATOR OR
+           ${SWIFTLIB_SDK} STREQUAL TVOS OR ${SWIFTLIB_SDK} STREQUAL TVOS_SIMULATOR)
       list(APPEND swiftlib_framework_depends_flattened
            ${SWIFTLIB_FRAMEWORK_DEPENDS_IOS_TVOS})
     endif()
 
     # Collect architecutre agnostic compiler flags
     set(swiftlib_swift_compile_flags_all ${SWIFTLIB_SWIFT_COMPILE_FLAGS})
-    if(${sdk} STREQUAL OSX)
+    if(${SWIFTLIB_SDK} STREQUAL OSX)
       list(APPEND swiftlib_swift_compile_flags_all
            ${SWIFTLIB_SWIFT_COMPILE_FLAGS_OSX})
-    elseif(${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR)
+    elseif(${SWIFTLIB_SDK} STREQUAL IOS OR ${SWIFTLIB_SDK} STREQUAL IOS_SIMULATOR)
       list(APPEND swiftlib_swift_compile_flags_all
            ${SWIFTLIB_SWIFT_COMPILE_FLAGS_IOS})
-    elseif(${sdk} STREQUAL TVOS OR ${sdk} STREQUAL TVOS_SIMULATOR)
+    elseif(${SWIFTLIB_SDK} STREQUAL TVOS OR ${SWIFTLIB_SDK} STREQUAL TVOS_SIMULATOR)
       list(APPEND swiftlib_swift_compile_flags_all
            ${SWIFTLIB_SWIFT_COMPILE_FLAGS_TVOS})
-    elseif(${sdk} STREQUAL WATCHOS OR ${sdk} STREQUAL WATCHOS_SIMULATOR)
+    elseif(${SWIFTLIB_SDK} STREQUAL WATCHOS OR ${SWIFTLIB_SDK} STREQUAL WATCHOS_SIMULATOR)
       list(APPEND swiftlib_swift_compile_flags_all
            ${SWIFTLIB_SWIFT_COMPILE_FLAGS_WATCHOS})
-    elseif(${sdk} STREQUAL LINUX)
+    elseif(${SWIFTLIB_SDK} STREQUAL LINUX)
       list(APPEND swiftlib_swift_compile_flags_all
            ${SWIFTLIB_SWIFT_COMPILE_FLAGS_LINUX})
-    elseif(${sdk} STREQUAL WINDOWS)
+    elseif(${SWIFTLIB_SDK} STREQUAL WINDOWS)
       # FIXME(SR2005) static and shared are not mutually exclusive; however
       # since we do a single build of the sources, this doesn't work for
       # building both simultaneously.  Effectively, only shared builds are
@@ -1305,7 +1329,7 @@ function(add_swift_target_library name)
 
     # Collect architecture agnostic SDK linker flags
     set(swiftlib_link_flags_all ${SWIFTLIB_LINK_FLAGS})
-    if(${sdk} STREQUAL IOS_SIMULATOR AND ${name} STREQUAL swiftMediaPlayer)
+    if(${SWIFTLIB_SDK} STREQUAL IOS_SIMULATOR AND ${name} STREQUAL swiftMediaPlayer)
       # message("DISABLING AUTOLINK FOR swiftMediaPlayer")
       list(APPEND swiftlib_link_flags_all "-Xlinker" "-ignore_auto_link")
     endif()
@@ -1319,15 +1343,15 @@ function(add_swift_target_library name)
     # back to supported targets and libraries only.  This is needed for ELF
     # targets only; however, RemoteMirror needs to build with undefined
     # symbols.
-    if(${SWIFT_SDK_${sdk}_OBJECT_FORMAT} STREQUAL ELF AND
+    if(${SWIFT_SDK_${SWIFTLIB_SDK}_OBJECT_FORMAT} STREQUAL ELF AND
        NOT ${name} STREQUAL swiftRemoteMirror)
       list(APPEND swiftlib_link_flags_all "-Wl,-z,defs")
     endif()
     # Setting back linker flags which are not supported when making Android build on macOS cross-compile host.
     if(SWIFTLIB_SHARED)
-      if(sdk IN_LIST SWIFT_APPLE_PLATFORMS)
+      if(SWIFTLIB_SDK IN_LIST SWIFT_APPLE_PLATFORMS)
         list(APPEND swiftlib_link_flags_all "-dynamiclib -Wl,-headerpad_max_install_names")
-      elseif(${sdk} STREQUAL ANDROID)
+      elseif(${SWIFTLIB_SDK} STREQUAL ANDROID)
         list(APPEND swiftlib_link_flags_all "-shared")
         # TODO: Instead of `lib${name}.so` find variable or target property which already have this value.
         list(APPEND swiftlib_link_flags_all "-Wl,-soname,lib${name}.so")
@@ -1335,14 +1359,14 @@ function(add_swift_target_library name)
     endif()
 
     set(sdk_supported_archs
-      ${SWIFT_SDK_${sdk}_ARCHITECTURES}
-      ${SWIFT_SDK_${sdk}_MODULE_ARCHITECTURES})
+      ${SWIFT_SDK_${SWIFTLIB_SDK}_ARCHITECTURES}
+      ${SWIFT_SDK_${SWIFTLIB_SDK}_MODULE_ARCHITECTURES})
     list(REMOVE_DUPLICATES sdk_supported_archs)
 
     # For each architecture supported by this SDK
     foreach(arch ${sdk_supported_archs})
       # Configure variables for this subdirectory.
-      set(VARIANT_SUFFIX "-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
+      set(VARIANT_SUFFIX "-${SWIFT_SDK_${SWIFTLIB_SDK}_LIB_SUBDIR}-${arch}")
       set(VARIANT_NAME "${name}${VARIANT_SUFFIX}")
       set(MODULE_VARIANT_SUFFIX "-swiftmodule${VARIANT_SUFFIX}")
       set(MODULE_VARIANT_NAME "${name}${MODULE_VARIANT_SUFFIX}")
@@ -1442,7 +1466,7 @@ function(add_swift_target_library name)
             AND maccatalyst_build_flavor STREQUAL "zippered"))
 
         # The path to find iOS-only frameworks (such as UIKit) under macCatalyst.
-        set(ios_support_frameworks_path "${SWIFT_SDK_${sdk}_PATH}/System/iOSSupport/System/Library/Frameworks/")
+        set(ios_support_frameworks_path "${SWIFT_SDK_${SWIFTLIB_SDK}_PATH}/System/iOSSupport/System/Library/Frameworks/")
 
         list(APPEND swiftlib_swift_compile_flags_all "-Fsystem" "${ios_support_frameworks_path}")
         list(APPEND swiftlib_c_compile_flags_all "-iframework" "${ios_support_frameworks_path}")
@@ -1452,10 +1476,10 @@ function(add_swift_target_library name)
         list(APPEND swiftlib_link_flags_all "-F${ios_support_frameworks_path}")
       endif()
 
-      if(sdk IN_LIST SWIFT_APPLE_PLATFORMS AND SWIFTLIB_IS_SDK_OVERLAY)
-        set(swiftlib_swift_compile_private_frameworks_flag "-Fsystem" "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}/System/Library/PrivateFrameworks/")
+      if(SWIFTLIB_SDK IN_LIST SWIFT_APPLE_PLATFORMS AND SWIFTLIB_IS_SDK_OVERLAY)
+        set(swiftlib_swift_compile_private_frameworks_flag "-Fsystem" "${SWIFT_SDK_${SWIFTLIB_SDK}_ARCH_${arch}_PATH}/System/Library/PrivateFrameworks/")
         foreach(tbd_lib ${SWIFTLIB_SWIFT_MODULE_DEPENDS_FROM_SDK})
-          list(APPEND swiftlib_link_flags_all "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}/usr/lib/swift/libswift${tbd_lib}.tbd")
+          list(APPEND swiftlib_link_flags_all "${SWIFT_SDK_${SWIFTLIB_SDK}_ARCH_${arch}_PATH}/usr/lib/swift/libswift${tbd_lib}.tbd")
         endforeach()
       endif()
 
@@ -1483,7 +1507,7 @@ function(add_swift_target_library name)
         ${SWIFTLIB_SOURCES}
         TARGET_LIBRARY
         MODULE_TARGETS ${module_variant_names}
-        SDK ${sdk}
+        SDK ${SWIFTLIB_SDK}
         ARCHITECTURE ${arch}
         DEPENDS ${SWIFTLIB_DEPENDS}
         LINK_LIBRARIES ${swiftlib_link_libraries}
@@ -1517,7 +1541,7 @@ function(add_swift_target_library name)
       add_dependencies(${VARIANT_NAME} clang)
     endif()
 
-      if(sdk STREQUAL WINDOWS)
+      if(SWIFTLIB_SDK STREQUAL WINDOWS)
         if(SWIFT_COMPILER_IS_MSVC_LIKE)
           if (SWIFT_STDLIB_MSVC_RUNTIME_LIBRARY MATCHES MultiThreadedDebugDLL)
             target_compile_options(${VARIANT_NAME} PRIVATE /MDd /D_DLL /D_DEBUG)
@@ -1536,7 +1560,7 @@ function(add_swift_target_library name)
         foreach(DEP ${SWIFTLIB_LINK_LIBRARIES})
           if (NOT "${DEP}" STREQUAL "icucore")
             add_dependencies(${VARIANT_NAME}
-              "${DEP}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
+              "${DEP}-${SWIFT_SDK_${SWIFTLIB_SDK}_LIB_SUBDIR}")
           endif()
         endforeach()
 
@@ -1545,12 +1569,12 @@ function(add_swift_target_library name)
           foreach(DEP ${SWIFTLIB_LINK_LIBRARIES})
             if (NOT "${DEP}" STREQUAL "icucore")
               add_dependencies("${VARIANT_NAME}-static"
-                "${DEP}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-static")
+                "${DEP}-${SWIFT_SDK_${SWIFTLIB_SDK}_LIB_SUBDIR}-static")
             endif()
           endforeach()
         endif()
 
-        if(arch IN_LIST SWIFT_SDK_${sdk}_ARCHITECTURES)
+        if(arch IN_LIST SWIFT_SDK_${SWIFTLIB_SDK}_ARCHITECTURES)
           # Note this thin library.
           list(APPEND THIN_INPUT_TARGETS ${VARIANT_NAME})
         endif()
@@ -1558,15 +1582,15 @@ function(add_swift_target_library name)
     endforeach()
 
     # Configure module-only targets
-    if(NOT SWIFT_SDK_${sdk}_ARCHITECTURES
-        AND SWIFT_SDK_${sdk}_MODULE_ARCHITECTURES)
-      set(_target "${name}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
+    if(NOT SWIFT_SDK_${SWIFTLIB_SDK}_ARCHITECTURES
+        AND SWIFT_SDK_${SWIFTLIB_SDK}_MODULE_ARCHITECTURES)
+      set(_target "${name}-${SWIFT_SDK_${SWIFTLIB_SDK}_LIB_SUBDIR}")
 
       # Create unified sdk target
       add_custom_target("${_target}")
 
-      foreach(_arch ${SWIFT_SDK_${sdk}_MODULE_ARCHITECTURES})
-        set(_variant_suffix "-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${_arch}")
+      foreach(_arch ${SWIFT_SDK_${SWIFTLIB_SDK}_MODULE_ARCHITECTURES})
+        set(_variant_suffix "-${SWIFT_SDK_${SWIFTLIB_SDK}_LIB_SUBDIR}-${_arch}")
         set(_module_variant_name "${name}-swiftmodule-${_variant_suffix}")
 
         add_dependencies("${_target}" ${_module_variant_name})
@@ -1582,7 +1606,7 @@ function(add_swift_target_library name)
       return()
     endif()
 
-    set(library_subdir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
+    set(library_subdir "${SWIFT_SDK_${SWIFTLIB_SDK}_LIB_SUBDIR}")
     if(maccatalyst_build_flavor STREQUAL "ios-like")
       set(library_subdir "${SWIFT_SDK_MACCATALYST_LIB_SUBDIR}")
     endif()
@@ -1590,7 +1614,7 @@ function(add_swift_target_library name)
     if(NOT SWIFTLIB_OBJECT_LIBRARY)
       # Determine the name of the universal library.
       if(SWIFTLIB_SHARED)
-        if("${sdk}" STREQUAL "WINDOWS")
+        if("${SWIFTLIB_SDK}" STREQUAL "WINDOWS")
           set(UNIVERSAL_LIBRARY_NAME
             "${SWIFTLIB_DIR}/${library_subdir}/${name}.dll")
         else()
@@ -1598,7 +1622,7 @@ function(add_swift_target_library name)
             "${SWIFTLIB_DIR}/${library_subdir}/${CMAKE_SHARED_LIBRARY_PREFIX}${name}${CMAKE_SHARED_LIBRARY_SUFFIX}")
         endif()
       else()
-        if("${sdk}" STREQUAL "WINDOWS")
+        if("${SWIFTLIB_SDK}" STREQUAL "WINDOWS")
           set(UNIVERSAL_LIBRARY_NAME
             "${SWIFTLIB_DIR}/${library_subdir}/${name}.lib")
         else()
@@ -1613,7 +1637,7 @@ function(add_swift_target_library name)
       endif()
       precondition(THIN_INPUT_TARGETS)
       _add_swift_lipo_target(SDK
-                               ${sdk}
+                               ${SWIFTLIB_SDK}
                              TARGET
                                ${lipo_target}
                              OUTPUT
@@ -1628,7 +1652,7 @@ function(add_swift_target_library name)
         CACHE INTERNAL "UNIVERSAL_LIBRARY_NAMES_${library_subdir}")
 
       # Determine the subdirectory where this library will be installed.
-      set(resource_dir_sdk_subdir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
+      set(resource_dir_sdk_subdir "${SWIFT_SDK_${SWIFTLIB_SDK}_LIB_SUBDIR}")
       if(maccatalyst_build_flavor STREQUAL "ios-like")
         set(resource_dir_sdk_subdir "${SWIFT_SDK_MACCATALYST_LIB_SUBDIR}")
       endif()
@@ -1650,12 +1674,12 @@ function(add_swift_target_library name)
       endif()
 
       set(optional_arg)
-      if(sdk IN_LIST SWIFT_APPLE_PLATFORMS)
+      if(SWIFTLIB_SDK IN_LIST SWIFT_APPLE_PLATFORMS)
         # Allow installation of stdlib without building all variants on Darwin.
         set(optional_arg "OPTIONAL")
       endif()
 
-      if(sdk STREQUAL WINDOWS AND CMAKE_SYSTEM_NAME STREQUAL Windows)
+      if(SWIFTLIB_SDK STREQUAL WINDOWS AND CMAKE_SYSTEM_NAME STREQUAL Windows)
         add_dependencies(${SWIFTLIB_INSTALL_IN_COMPONENT} ${name}-windows-${SWIFT_PRIMARY_VARIANT_ARCH})
         swift_install_in_component(TARGETS ${name}-windows-${SWIFT_PRIMARY_VARIANT_ARCH}
                                    RUNTIME
@@ -1678,7 +1702,7 @@ function(add_swift_target_library name)
                                    PERMISSIONS ${file_permissions}
                                    "${optional_arg}")
       endif()
-      if(sdk STREQUAL WINDOWS)
+      if(SWIFTLIB_SDK STREQUAL WINDOWS)
         foreach(arch ${SWIFT_SDK_WINDOWS_ARCHITECTURES})
           if(TARGET ${name}-windows-${arch}_IMPLIB)
             get_target_property(import_library ${name}-windows-${arch}_IMPLIB IMPORTED_LOCATION)
@@ -1696,8 +1720,8 @@ function(add_swift_target_library name)
         is_installing)
 
       # Add the arch-specific library targets to the global exports.
-      foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
-        set(_variant_name "${name}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
+      foreach(arch ${SWIFT_SDK_${SWIFTLIB_SDK}_ARCHITECTURES})
+        set(_variant_name "${name}-${SWIFT_SDK_${SWIFTLIB_SDK}_LIB_SUBDIR}-${arch}")
         if(maccatalyst_build_flavor STREQUAL "ios-like")
           set(_variant_name "${name}-${SWIFT_SDK_MACCATALYST_LIB_SUBDIR}-${arch}")
         endif()
@@ -1716,8 +1740,8 @@ function(add_swift_target_library name)
       endforeach()
 
       # Add the swiftmodule-only targets to the lipo target depdencies.
-      foreach(arch ${SWIFT_SDK_${sdk}_MODULE_ARCHITECTURES})
-        set(_variant_name "${name}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
+      foreach(arch ${SWIFT_SDK_${SWIFTLIB_SDK}_MODULE_ARCHITECTURES})
+        set(_variant_name "${name}-${SWIFT_SDK_${SWIFTLIB_SDK}_LIB_SUBDIR}-${arch}")
         if(maccatalyst_build_flavor STREQUAL "ios-like")
           set(_variant_name "${name}-${SWIFT_SDK_MACCATALYST_LIB_SUBDIR}-${arch}")
         endif()
@@ -1751,7 +1775,7 @@ function(add_swift_target_library name)
         set(UNIVERSAL_LIBRARY_NAME
             "${universal_subdir}/${library_subdir}/${CMAKE_STATIC_LIBRARY_PREFIX}${name}${CMAKE_STATIC_LIBRARY_SUFFIX}")
         _add_swift_lipo_target(SDK
-                                 ${sdk}
+                                 ${SWIFTLIB_SDK}
                                TARGET
                                  ${lipo_target_static}
                                OUTPUT
@@ -1774,8 +1798,8 @@ function(add_swift_target_library name)
             swiftStdlibCollectionUnittest
             swiftStdlibUnicodeUnittest)
 
-      foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
-        set(VARIANT_SUFFIX "-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
+      foreach(arch ${SWIFT_SDK_${SWIFTLIB_SDK}_ARCHITECTURES})
+        set(VARIANT_SUFFIX "-${SWIFT_SDK_${SWIFTLIB_SDK}_LIB_SUBDIR}-${arch}")
         if(TARGET "swift-stdlib${VARIANT_SUFFIX}" AND
            TARGET "swift-test-stdlib${VARIANT_SUFFIX}")
           add_dependencies("swift-stdlib${VARIANT_SUFFIX}"
@@ -1790,7 +1814,6 @@ function(add_swift_target_library name)
       endforeach()
     endif()
   endforeach() # maccatalyst_build_flavors
-  endforeach()
 endfunction()
 
 # Add an executable compiled for a given variant.

--- a/stdlib/cmake/modules/DarwinSwiftOverlay.cmake
+++ b/stdlib/cmake/modules/DarwinSwiftOverlay.cmake
@@ -1,0 +1,27 @@
+function(select_swift_overlay_dependenies result_var_name)
+  set(options)
+  set(single_parameter_options
+        SDK)
+  set(multiple_parameter_options
+        SWIFT_MODULE_DEPENDS_IOS
+        SWIFT_MODULE_DEPENDS_OSX
+        SWIFT_MODULE_DEPENDS_TVOS
+        SWIFT_MODULE_DEPENDS_WATCHOS)
+
+  cmake_parse_arguments(SOD
+                        "${options}"
+                        "${single_parameter_options}"
+                        "${multiple_parameter_options}"
+                        ${ARGN})
+  set(module_depends)
+  if(${SOD_SDK} STREQUAL OSX)
+    list(APPEND module_depends ${SOD_SWIFT_MODULE_DEPENDS_OSX})
+  elseif(${SOD_SDK} STREQUAL IOS OR ${SOD_SDK} STREQUAL IOS_SIMULATOR)
+    list(APPEND module_depends ${SOD_SWIFT_MODULE_DEPENDS_IOS})
+  elseif(${SOD_SDK} STREQUAL TVOS OR ${SOD_SDK} STREQUAL TVOS_SIMULATOR)
+    list(APPEND module_depends ${SOD_SWIFT_MODULE_DEPENDS_TVOS})
+  elseif(${SOD_SDK} STREQUAL WATCHOS OR ${SOD_SDK} STREQUAL WATCHOS_SIMULATOR)
+    list(APPEND module_depends ${SOD_SWIFT_MODULE_DEPENDS_WATCHOS})
+  endif()
+  set("${result_var_name}" "${module_depends}" PARENT_SCOPE)
+endfunction()

--- a/stdlib/private/OSLog/CMakeLists.txt
+++ b/stdlib/private/OSLog/CMakeLists.txt
@@ -1,4 +1,9 @@
-add_swift_target_library(swiftOSLogTestHelper
+foreach(sdk ${SWIFT_SDKS})
+if(NOT ${sdk} IN_LIST SWIFT_APPLE_PLATFORMS)
+  continue()
+endif()
+
+add_swift_target_library_single_sdk(swiftOSLogTestHelper
   IS_SDK_OVERLAY
   SHARED
 
@@ -11,11 +16,9 @@ add_swift_target_library(swiftOSLogTestHelper
   OSLogNSObjectType.swift
   OSLogFloatingPointTypes.swift
 
-  SWIFT_MODULE_DEPENDS_IOS Darwin ObjectiveC
-  SWIFT_MODULE_DEPENDS_OSX Darwin ObjectiveC
-  SWIFT_MODULE_DEPENDS_TVOS Darwin ObjectiveC
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin ObjectiveC
-  TARGET_SDKS ALL_APPLE_PLATFORMS
+  SWIFT_MODULE_DEPENDS Darwin ObjectiveC
+  SDK ${sdk}
   SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   INSTALL_IN_COMPONENT never_install
   DARWIN_INSTALL_NAME_DIR "${SWIFT_DARWIN_STDLIB_PRIVATE_INSTALL_NAME_DIR}")
+endforeach()

--- a/stdlib/private/RuntimeUnittest/CMakeLists.txt
+++ b/stdlib/private/RuntimeUnittest/CMakeLists.txt
@@ -1,19 +1,25 @@
 set(swift_stdlib_unittest_compile_flags)
+foreach(sdk ${SWIFT_SDKS})
 
-add_swift_target_library(swiftRuntimeUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+set(module_depends)
+set(glibc_sdks LINUX FREEBSD CYGWIN HAIKU)
+if(${sdk} IN_LIST glibc_sdks)
+  list(APPEND module_depends Glibc)
+elseif(${sdk} STREQUAL WINDOWS)
+  list(APPEND module_depends MSVCRT)
+endif()
+
+add_swift_target_library_single_sdk(swiftRuntimeUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   # This file should be listed the first.  Module name is inferred from the
   # filename.
   RuntimeUnittest.swift
 
   ExclusivityTests.cpp
 
-  SWIFT_MODULE_DEPENDS StdlibUnittest
-  SWIFT_MODULE_DEPENDS_LINUX Glibc
-  SWIFT_MODULE_DEPENDS_FREEBSD Glibc
-  SWIFT_MODULE_DEPENDS_CYGWIN Glibc
-  SWIFT_MODULE_DEPENDS_HAIKU Glibc
-  SWIFT_MODULE_DEPENDS_WINDOWS MSVCRT
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS StdlibUnittest ${module_depends}
   SWIFT_COMPILE_FLAGS ${swift_stdlib_unittest_compile_flags} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   INSTALL_IN_COMPONENT stdlib-experimental
   DARWIN_INSTALL_NAME_DIR "${SWIFT_DARWIN_STDLIB_PRIVATE_INSTALL_NAME_DIR}")
 
+endforeach()

--- a/stdlib/private/StdlibCollectionUnittest/CMakeLists.txt
+++ b/stdlib/private/StdlibCollectionUnittest/CMakeLists.txt
@@ -1,6 +1,16 @@
 set(swift_stdlib_unittest_compile_flags)
 
-add_swift_target_library(swiftStdlibCollectionUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+foreach(sdk ${SWIFT_SDKS})
+
+set(module_depends)
+set(glibc_sdks LINUX FREEBSD CYGWIN HAIKU)
+if(${sdk} IN_LIST glibc_sdks)
+  list(APPEND module_depends Glibc)
+elseif(${sdk} STREQUAL WINDOWS)
+  list(APPEND module_depends MSVCRT)
+endif()
+
+add_swift_target_library_single_sdk(swiftStdlibCollectionUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   # This file should be listed the first.  Module name is inferred from the
   # filename.
   StdlibCollectionUnittest.swift
@@ -18,13 +28,10 @@ add_swift_target_library(swiftStdlibCollectionUnittest ${SWIFT_STDLIB_LIBRARY_BU
   RangeSelection.swift
   WriteBackMutableSlice.swift
 
-  SWIFT_MODULE_DEPENDS StdlibUnittest
-  SWIFT_MODULE_DEPENDS_LINUX Glibc
-  SWIFT_MODULE_DEPENDS_FREEBSD Glibc
-  SWIFT_MODULE_DEPENDS_CYGWIN Glibc
-  SWIFT_MODULE_DEPENDS_HAIKU Glibc
-  SWIFT_MODULE_DEPENDS_WINDOWS MSVCRT
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS StdlibUnittest ${module_depends}
   SWIFT_COMPILE_FLAGS ${swift_stdlib_unittest_compile_flags} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   INSTALL_IN_COMPONENT stdlib-experimental
   DARWIN_INSTALL_NAME_DIR "${SWIFT_DARWIN_STDLIB_PRIVATE_INSTALL_NAME_DIR}")
 
+endforeach()

--- a/stdlib/private/StdlibUnicodeUnittest/CMakeLists.txt
+++ b/stdlib/private/StdlibUnicodeUnittest/CMakeLists.txt
@@ -1,18 +1,25 @@
 set(swift_stdlib_unittest_compile_flags)
 
-add_swift_target_library(swiftStdlibUnicodeUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+foreach(sdk ${SWIFT_SDKS})
+
+set(module_depends)
+set(glibc_sdks LINUX FREEBSD CYGWIN HAIKU)
+if(${sdk} IN_LIST glibc_sdks)
+  list(APPEND module_depends Glibc)
+elseif(${sdk} STREQUAL WINDOWS)
+  list(APPEND module_depends MSVCRT)
+endif()
+
+add_swift_target_library_single_sdk(swiftStdlibUnicodeUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   # This file should be listed the first.  Module name is inferred from the
   # filename.
   StdlibUnicodeUnittest.swift
   Collation.swift
 
-  SWIFT_MODULE_DEPENDS StdlibUnittest
-  SWIFT_MODULE_DEPENDS_LINUX Glibc
-  SWIFT_MODULE_DEPENDS_FREEBSD Glibc
-  SWIFT_MODULE_DEPENDS_CYGWIN Glibc
-  SWIFT_MODULE_DEPENDS_HAIKU Glibc
-  SWIFT_MODULE_DEPENDS_WINDOWS MSVCRT
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS StdlibUnittest ${module_depends}
   SWIFT_COMPILE_FLAGS ${swift_stdlib_unittest_compile_flags} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   INSTALL_IN_COMPONENT stdlib-experimental
   DARWIN_INSTALL_NAME_DIR "${SWIFT_DARWIN_STDLIB_PRIVATE_INSTALL_NAME_DIR}")
 
+endforeach()

--- a/stdlib/private/StdlibUnittest/CMakeLists.txt
+++ b/stdlib/private/StdlibUnittest/CMakeLists.txt
@@ -10,7 +10,20 @@ if (NOT IS_BUILD_TYPE_OPTIMIZED)
   list(APPEND swift_stdlib_unittest_compile_flags "-DSWIFT_STDLIB_DEBUG")
 endif()
 
-add_swift_target_library(swiftStdlibUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+foreach(sdk ${SWIFT_SDKS})
+
+set(module_depends)
+set(glibc_sdks LINUX FREEBSD CYGWIN HAIKU)
+
+if(${sdk} IN_LIST SWIFT_APPLE_PLATFORMS)
+  list(APPEND module_depends Darwin Foundation)
+elseif(${sdk} IN_LIST glibc_sdks)
+  list(APPEND module_depends Glibc)
+elseif(${sdk} STREQUAL WINDOWS)
+  list(APPEND module_depends MSVCRT WinSDK)
+endif()
+
+add_swift_target_library_single_sdk(swiftStdlibUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   # This file should be listed the first.  Module name is inferred from the
   # filename.
   StdlibUnittest.swift
@@ -31,18 +44,11 @@ add_swift_target_library(swiftStdlibUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES}
   TestHelpers.swift
   TypeIndexed.swift
 
-  SWIFT_MODULE_DEPENDS SwiftPrivate SwiftPrivateThreadExtras SwiftPrivateLibcExtras
-  SWIFT_MODULE_DEPENDS_IOS Darwin Foundation
-  SWIFT_MODULE_DEPENDS_OSX Darwin Foundation
-  SWIFT_MODULE_DEPENDS_TVOS Darwin Foundation
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Foundation
-  SWIFT_MODULE_DEPENDS_LINUX Glibc
-  SWIFT_MODULE_DEPENDS_FREEBSD Glibc
-  SWIFT_MODULE_DEPENDS_CYGWIN Glibc
-  SWIFT_MODULE_DEPENDS_HAIKU Glibc
-  SWIFT_MODULE_DEPENDS_WINDOWS MSVCRT WinSDK
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS SwiftPrivate SwiftPrivateThreadExtras SwiftPrivateLibcExtras ${module_depends}
   SWIFT_COMPILE_FLAGS ${swift_stdlib_unittest_compile_flags} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   INSTALL_IN_COMPONENT stdlib-experimental
   DARWIN_INSTALL_NAME_DIR "${SWIFT_DARWIN_STDLIB_PRIVATE_INSTALL_NAME_DIR}")
 set_source_files_properties(InspectValue.cpp PROPERTIES COMPILE_FLAGS -std=c++14)
 
+endforeach()

--- a/stdlib/private/SwiftPrivate/CMakeLists.txt
+++ b/stdlib/private/SwiftPrivate/CMakeLists.txt
@@ -2,7 +2,15 @@ set(swift_swiftprivate_compile_flags
     "-parse-stdlib"
     "-Xfrontend" "-disable-access-control")
 
-add_swift_target_library(swiftSwiftPrivate ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+foreach(sdk ${SWIFT_SDKS})
+
+set(module_depends)
+
+if(${sdk} STREQUAL WINDOWS)
+  list(APPEND module_depends MSVCRT WinSDK)
+endif()
+
+add_swift_target_library_single_sdk(swiftSwiftPrivate ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   # This file should be listed the first.  Module name is inferred from the
   # filename.
   SwiftPrivate.swift
@@ -15,8 +23,10 @@ add_swift_target_library(swiftSwiftPrivate ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   GYB_SOURCES
     AtomicInt.swift.gyb
 
-  SWIFT_MODULE_DEPENDS_WINDOWS MSVCRT WinSDK
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   SWIFT_COMPILE_FLAGS ${swift_swiftprivate_compile_flags} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   INSTALL_IN_COMPONENT stdlib-experimental
   DARWIN_INSTALL_NAME_DIR "${SWIFT_DARWIN_STDLIB_PRIVATE_INSTALL_NAME_DIR}")
 
+endforeach()

--- a/stdlib/private/SwiftPrivateLibcExtras/CMakeLists.txt
+++ b/stdlib/private/SwiftPrivateLibcExtras/CMakeLists.txt
@@ -1,4 +1,17 @@
-add_swift_target_library(swiftSwiftPrivateLibcExtras ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+foreach(sdk ${SWIFT_SDKS})
+
+set(module_depends)
+set(glibc_sdks LINUX FREEBSD CYGWIN HAIKU)
+
+if(${sdk} IN_LIST SWIFT_APPLE_PLATFORMS)
+  list(APPEND module_depends Darwin Foundation)
+elseif(${sdk} IN_LIST glibc_sdks)
+  list(APPEND module_depends Glibc)
+elseif(${sdk} STREQUAL WINDOWS)
+  list(APPEND module_depends MSVCRT WinSDK)
+endif()
+
+add_swift_target_library_single_sdk(swiftSwiftPrivateLibcExtras ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   # This file should be listed the first.  Module name is inferred from the
   # filename.
   SwiftPrivateLibcExtras.swift
@@ -7,16 +20,10 @@ add_swift_target_library(swiftSwiftPrivateLibcExtras ${SWIFT_STDLIB_LIBRARY_BUIL
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
-  SWIFT_MODULE_DEPENDS SwiftPrivate
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS SwiftPrivate ${module_depends}
   SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
-  SWIFT_MODULE_DEPENDS_OSX Darwin
-  SWIFT_MODULE_DEPENDS_IOS Darwin
-  SWIFT_MODULE_DEPENDS_TVOS Darwin
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin
-  SWIFT_MODULE_DEPENDS_LINUX Glibc
-  SWIFT_MODULE_DEPENDS_FREEBSD Glibc
-  SWIFT_MODULE_DEPENDS_CYGWIN Glibc
-  SWIFT_MODULE_DEPENDS_HAIKU Glibc
-  SWIFT_MODULE_DEPENDS_WINDOWS MSVCRT WinSDK
   INSTALL_IN_COMPONENT stdlib-experimental
   DARWIN_INSTALL_NAME_DIR "${SWIFT_DARWIN_STDLIB_PRIVATE_INSTALL_NAME_DIR}")
+
+endforeach()

--- a/stdlib/private/SwiftPrivateThreadExtras/CMakeLists.txt
+++ b/stdlib/private/SwiftPrivateThreadExtras/CMakeLists.txt
@@ -1,4 +1,17 @@
-add_swift_target_library(swiftSwiftPrivateThreadExtras ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+foreach(sdk ${SWIFT_SDKS})
+
+set(module_depends)
+set(glibc_sdks LINUX FREEBSD CYGWIN HAIKU)
+
+if(${sdk} IN_LIST SWIFT_APPLE_PLATFORMS)
+  list(APPEND module_depends Darwin Foundation)
+elseif(${sdk} IN_LIST glibc_sdks)
+  list(APPEND module_depends Glibc)
+elseif(${sdk} STREQUAL WINDOWS)
+  list(APPEND module_depends MSVCRT WinSDK)
+endif()
+
+add_swift_target_library_single_sdk(swiftSwiftPrivateThreadExtras ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   # This file should be listed the first.  Module name is inferred from the
   # filename.
   SwiftPrivateThreadExtras.swift
@@ -6,17 +19,11 @@ add_swift_target_library(swiftSwiftPrivateThreadExtras ${SWIFT_STDLIB_LIBRARY_BU
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
-  SWIFT_MODULE_DEPENDS_IOS Darwin
-  SWIFT_MODULE_DEPENDS_OSX Darwin
-  SWIFT_MODULE_DEPENDS_TVOS Darwin
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin
-  SWIFT_MODULE_DEPENDS_LINUX Glibc
-  SWIFT_MODULE_DEPENDS_FREEBSD Glibc
-  SWIFT_MODULE_DEPENDS_CYGWIN Glibc
-  SWIFT_MODULE_DEPENDS_HAIKU Glibc
-  SWIFT_MODULE_DEPENDS_WINDOWS MSVCRT WinSDK
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   TARGET_SDKS ALL_APPLE_PLATFORMS CYGWIN FREEBSD HAIKU LINUX WINDOWS ANDROID
   INSTALL_IN_COMPONENT stdlib-experimental
   DARWIN_INSTALL_NAME_DIR "${SWIFT_DARWIN_STDLIB_PRIVATE_INSTALL_NAME_DIR}")
 
+endforeach()

--- a/stdlib/private/SwiftReflectionTest/CMakeLists.txt
+++ b/stdlib/private/SwiftReflectionTest/CMakeLists.txt
@@ -1,23 +1,32 @@
 
 if (SWIFT_INCLUDE_TESTS)
-  add_swift_target_library(swiftSwiftReflectionTest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+  foreach(sdk ${SWIFT_SDKS})
+  
+  set(module_depends)
+  set(glibc_sdks LINUX FREEBSD CYGWIN HAIKU)
+  
+  if(${sdk} IN_LIST SWIFT_APPLE_PLATFORMS)
+    list(APPEND module_depends Darwin Foundation)
+  elseif(${sdk} IN_LIST glibc_sdks)
+    list(APPEND module_depends Glibc)
+  elseif(${sdk} STREQUAL WINDOWS)
+    list(APPEND module_depends MSVCRT WinSDK)
+  endif()
+
+  add_swift_target_library_single_sdk(swiftSwiftReflectionTest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
     SwiftReflectionTest.swift
+    SDK ${sdk}
     SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     SWIFT_COMPILE_FLAGS_LINUX -Xcc -D_GNU_SOURCE
-    SWIFT_MODULE_DEPENDS_OSX Darwin
-    SWIFT_MODULE_DEPENDS_IOS Darwin
-    SWIFT_MODULE_DEPENDS_TVOS Darwin
-    SWIFT_MODULE_DEPENDS_WATCHOS Darwin
-    SWIFT_MODULE_DEPENDS_LINUX Glibc
-    SWIFT_MODULE_DEPENDS_WINDOWS MSVCRT
+    SWIFT_MODULE_DEPENDS ${module_depends}
     INSTALL_IN_COMPONENT stdlib-experimental
     DARWIN_INSTALL_NAME_DIR "${SWIFT_DARWIN_STDLIB_PRIVATE_INSTALL_NAME_DIR}")
 
-  foreach(SDK ${SWIFT_SDKS})
-    foreach(ARCH ${SWIFT_SDK_${SDK}_ARCHITECTURES})
-      set(VARIANT_SUFFIX "-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-${ARCH}")
-      add_dependencies("swiftSwiftReflectionTest${VARIANT_SUFFIX}"
-        "swift-reflection-test${VARIANT_SUFFIX}")
-    endforeach()
+  foreach(ARCH ${SWIFT_SDK_${sdk}_ARCHITECTURES})
+    set(VARIANT_SUFFIX "-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${ARCH}")
+    add_dependencies("swiftSwiftReflectionTest${VARIANT_SUFFIX}"
+      "swift-reflection-test${VARIANT_SUFFIX}")
+  endforeach()
+
   endforeach()
 endif()

--- a/stdlib/public/Darwin/ARKit/CMakeLists.txt
+++ b/stdlib/public/Darwin/ARKit/CMakeLists.txt
@@ -1,18 +1,30 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftARKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+if(NOT (${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR))
+  continue()
+endif()
+
+set(
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch GLKit SceneKit simd Foundation AVFoundation SpriteKit CoreMedia QuartzCore ModelIO CoreFoundation CoreAudio ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftARKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   ARKit.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS IOS IOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch GLKit SceneKit simd Foundation AVFoundation SpriteKit CoreMedia QuartzCore ModelIO CoreFoundation CoreAudio ObjectiveC # auto-updated
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${SWIFT_MODULE_DEPENDS_IOS}
   FRAMEWORK_DEPENDS_WEAK ARKit
   SWIFT_MODULE_DEPENDS_FROM_SDK CoreMIDI
 
   DEPLOYMENT_VERSION_IOS ${SWIFTLIB_DEPLOYMENT_VERSION_ARKIT_IOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/AVFoundation/CMakeLists.txt
+++ b/stdlib/public/Darwin/AVFoundation/CMakeLists.txt
@@ -1,7 +1,23 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftAVFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(target_sdk ${SWIFT_SDKS})
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${target_sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit simd Foundation CoreMedia QuartzCore XPC CoreFoundation CoreAudio ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics Metal Dispatch simd Foundation CoreMedia QuartzCore CoreFoundation CoreAudio ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics Metal Dispatch simd Foundation CoreMedia QuartzCore CoreFoundation CoreAudio ObjectiveC # auto-updated
+)
+
+if(${target_sdk} STREQUAL OSX
+  OR ${target_sdk} STREQUAL IOS OR ${target_sdk} STREQUAL IOS_SIMULATOR
+  OR ${target_sdk} STREQUAL TVOS OR ${target_sdk} STREQUAL TVOS_SIMULATOR)
+else()
+  continue()
+endif()
+
+add_swift_target_library_single_sdk(swiftAVFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   AVCaptureDevice.swift
   AVCapturePhotoOutput.swift
   AVCaptureSynchronizedDataCollection.swift
@@ -14,12 +30,10 @@ add_swift_target_library(swiftAVFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYP
   GYB_SOURCES
     NSValue.swift.gyb
 
-  TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR
+  SDK ${target_sdk}
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}" "-L${sdk}/usr/lib/swift/"
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit simd Foundation CoreMedia QuartzCore XPC CoreFoundation CoreAudio ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics Metal Dispatch simd Foundation CoreMedia QuartzCore CoreFoundation CoreAudio ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics Metal Dispatch simd Foundation CoreMedia QuartzCore CoreFoundation CoreAudio ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS AVFoundation
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_AVFOUNDATION_OSX}
@@ -27,3 +41,5 @@ add_swift_target_library(swiftAVFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYP
   DEPLOYMENT_VERSION_TVOS ${SWIFTLIB_DEPLOYMENT_VERSION_AVFOUNDATION_TVOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/Accelerate/CMakeLists.txt
+++ b/stdlib/public/Darwin/Accelerate/CMakeLists.txt
@@ -1,7 +1,21 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftAccelerate ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Metal Dispatch IOKit Foundation os XPC CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics Metal Dispatch Foundation os CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics Metal Dispatch Foundation os CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics Dispatch os CoreFoundation ObjectiveC # auto-updated
+)
+
+if(NOT ${sdk} IN_LIST SWIFT_APPLE_PLATFORMS)
+  continue()
+endif()
+
+add_swift_target_library_single_sdk(swiftAccelerate ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   Accelerate.swift
   vImage_Error.swift
   vImage_Options.swift
@@ -43,13 +57,9 @@ add_swift_target_library(swiftAccelerate ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR WATCHOS WATCHOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Metal Dispatch IOKit Foundation os XPC CoreFoundation ObjectiveC # auto-updated
-    os
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreFoundation CoreGraphics Dispatch Foundation Metal ObjectiveC os # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreFoundation CoreGraphics Dispatch Foundation Metal ObjectiveC os # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics Dispatch os CoreFoundation ObjectiveC # auto-updated
+  SDK ${sdk}
 
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS Accelerate
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_SIMD_OSX}
@@ -58,3 +68,5 @@ add_swift_target_library(swiftAccelerate ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES
   DEPLOYMENT_VERSION_WATCHOS ${SWIFTLIB_DEPLOYMENT_VERSION_SIMD_WATCHOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/AppKit/CMakeLists.txt
+++ b/stdlib/public/Darwin/AppKit/CMakeLists.txt
@@ -1,7 +1,14 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
+if(NOT OSX IN_LIST SWIFT_SDKS)
+  return()
+endif()
 
-add_swift_target_library(swiftAppKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+set(
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit Foundation CoreData QuartzCore XPC CoreFoundation ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftAppKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   AppKit.swift
   AppKit_FoundationExtensions.swift
   NSError.swift
@@ -13,8 +20,8 @@ add_swift_target_library(swiftAppKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit Foundation CoreData QuartzCore XPC CoreFoundation ObjectiveC # auto-updated
+  SDK OSX
+  SWIFT_MODULE_DEPENDS ${SWIFT_MODULE_DEPENDS_OSX}
   FRAMEWORK_DEPENDS AppKit
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_APPKIT_OSX}

--- a/stdlib/public/Darwin/AssetsLibrary/CMakeLists.txt
+++ b/stdlib/public/Darwin/AssetsLibrary/CMakeLists.txt
@@ -1,17 +1,29 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftAssetsLibrary ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+if(NOT (${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR))
+  continue()
+endif()
+
+set(
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftAssetsLibrary ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   ALAssetsLibrary.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS IOS IOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${SWIFT_MODULE_DEPENDS_IOS}
   FRAMEWORK_DEPENDS AssetsLibrary
 
   DEPLOYMENT_VERSION_IOS ${SWIFTLIB_DEPLOYMENT_VERSION_ASSETSLIBRARY_IOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/CallKit/CMakeLists.txt
+++ b/stdlib/public/Darwin/CallKit/CMakeLists.txt
@@ -1,17 +1,29 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftCallKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+if(NOT (${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR))
+  continue()
+endif()
+
+set(
+  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftCallKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   CXProviderConfiguration.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS IOS IOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${SWIFT_MODULE_DEPENDS_IOS}
   FRAMEWORK_DEPENDS_WEAK CallKit
 
   DEPLOYMENT_VERSION_IOS ${SWIFTLIB_DEPLOYMENT_VERSION_CALLKIT_IOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/CloudKit/CMakeLists.txt
+++ b/stdlib/public/Darwin/CloudKit/CMakeLists.txt
@@ -1,6 +1,20 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
+foreach(sdk ${SWIFT_SDKS})
+
+if(NOT ${sdk} IN_LIST SWIFT_APPLE_PLATFORMS)
+  continue()
+endif()
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch IOKit Foundation CoreLocation XPC CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch Foundation CoreLocation CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch Foundation CoreLocation CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch Foundation CoreLocation CoreFoundation ObjectiveC # auto-updated
+)
+
 add_swift_target_library(swiftCloudKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   NestedNames.swift
   TypealiasStrings.swift
@@ -18,16 +32,9 @@ add_swift_target_library(swiftCloudKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} 
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR WATCHOS WATCHOS_SIMULATOR
+  SDK ${sdk}
 
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch IOKit Foundation CoreLocation XPC CoreFoundation ObjectiveC # auto-updated
-    os XPC
-  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch Foundation CoreLocation CoreFoundation ObjectiveC # auto-updated
-    os
-  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch Foundation CoreLocation CoreFoundation ObjectiveC # auto-updated
-    os
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch Foundation CoreLocation CoreFoundation ObjectiveC # auto-updated
-    os
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS_WEAK CloudKit
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_CLOUDKIT_OSX}
@@ -36,3 +43,5 @@ add_swift_target_library(swiftCloudKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} 
   DEPLOYMENT_VERSION_WATCHOS ${SWIFTLIB_DEPLOYMENT_VERSION_CLOUDKIT_WATCHOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/Compression/CMakeLists.txt
+++ b/stdlib/public/Darwin/Compression/CMakeLists.txt
@@ -1,19 +1,24 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
+foreach(sdk ${SWIFT_SDKS})
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin # auto-updated
+)
+
+list(APPEND module_depends Foundation)
+
 add_swift_target_library(swiftCompression ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   Compression.swift
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}" "-lcompression"
-  SWIFT_MODULE_DEPENDS_OSX Darwin # auto-updated
-    Foundation # Imported in Swift
-  SWIFT_MODULE_DEPENDS_IOS Darwin # auto-updated
-    Foundation # Imported in Swift
-  SWIFT_MODULE_DEPENDS_TVOS Darwin # auto-updated
-    Foundation # Imported in Swift
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin # auto-updated
-    Foundation # Imported in Swift
+  SWIFT_MODULE_DEPENDS ${module_depends}
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_COMPRESSION_OSX}
   DEPLOYMENT_VERSION_IOS ${SWIFTLIB_DEPLOYMENT_VERSION_COMPRESSION_IOS}
@@ -21,3 +26,5 @@ add_swift_target_library(swiftCompression ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPE
   DEPLOYMENT_VERSION_WATCHOS ${SWIFTLIB_DEPLOYMENT_VERSION_COMPRESSION_WATCHOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/Contacts/CMakeLists.txt
+++ b/stdlib/public/Darwin/Contacts/CMakeLists.txt
@@ -1,17 +1,37 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftContacts ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+if(NOT ${sdk} IN_LIST SWIFT_APPLE_PLATFORMS)
+  continue()
+endif()
+
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch IOKit Foundation XPC CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+)
+
+if(${sdk} STREQUAL OSX
+  OR ${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR
+  OR ${sdk} STREQUAL WATCHOS OR ${sdk} STREQUAL WATCHOS_SIMULATOR)
+else()
+  continue()
+endif()
+
+
+add_swift_target_library_single_sdk(swiftContacts ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   CNError.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX IOS IOS_SIMULATOR WATCHOS WATCHOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch IOKit Foundation XPC CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS_WEAK Contacts
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_CONTACTS_OSX}
@@ -19,3 +39,5 @@ add_swift_target_library(swiftContacts ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} 
   DEPLOYMENT_VERSION_WATCHOS ${SWIFTLIB_DEPLOYMENT_VERSION_CONTACTS_WATCHOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/CoreAudio/CMakeLists.txt
+++ b/stdlib/public/Darwin/CoreAudio/CMakeLists.txt
@@ -1,18 +1,29 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftCoreAudio ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
+)
+
+if(NOT ${sdk} IN_LIST SWIFT_APPLE_PLATFORMS)
+  continue()
+endif()
+
+add_swift_target_library_single_sdk(swiftCoreAudio ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   CoreAudio.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR WATCHOS WATCHOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_OSX Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS CoreAudio
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_COREAUDIO_OSX}
@@ -21,3 +32,5 @@ add_swift_target_library(swiftCoreAudio ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES}
   DEPLOYMENT_VERSION_WATCHOS ${SWIFTLIB_DEPLOYMENT_VERSION_COREAUDIO_WATCHOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/CoreData/CMakeLists.txt
+++ b/stdlib/public/Darwin/CoreData/CMakeLists.txt
@@ -1,7 +1,17 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftCoreData ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch IOKit Foundation XPC CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftCoreData ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   CocoaError.swift
   NSManagedObjectContext.swift
   CoreData.mm
@@ -10,10 +20,8 @@ add_swift_target_library(swiftCoreData ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} 
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch IOKit Foundation XPC CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS CoreData
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_COREDATA_OSX}
@@ -22,3 +30,5 @@ add_swift_target_library(swiftCoreData ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} 
   DEPLOYMENT_VERSION_WATCHOS ${SWIFTLIB_DEPLOYMENT_VERSION_COREDATA_WATCHOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/CoreFoundation/CMakeLists.txt
+++ b/stdlib/public/Darwin/CoreFoundation/CMakeLists.txt
@@ -1,17 +1,27 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftCoreFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin Dispatch ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftCoreFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   CoreFoundation.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  SWIFT_MODULE_DEPENDS_OSX Darwin Dispatch ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch ObjectiveC # auto-updated
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS CoreFoundation
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/CoreGraphics/CMakeLists.txt
+++ b/stdlib/public/Darwin/CoreGraphics/CMakeLists.txt
@@ -1,6 +1,17 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
+
+foreach(sdk ${SWIFT_SDKS})
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin Dispatch IOKit CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
+)
+
 add_swift_target_library(swiftCoreGraphics ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   CoreGraphics.swift
   Private.swift
@@ -12,10 +23,7 @@ add_swift_target_library(swiftCoreGraphics ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYP
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  SWIFT_MODULE_DEPENDS_OSX Darwin Dispatch IOKit CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS CoreGraphics
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_COREGRAPHICS_OSX}
@@ -24,3 +32,5 @@ add_swift_target_library(swiftCoreGraphics ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYP
   DEPLOYMENT_VERSION_WATCHOS ${SWIFTLIB_DEPLOYMENT_VERSION_COREGRAPHICS_WATCHOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/CoreImage/CMakeLists.txt
+++ b/stdlib/public/Darwin/CoreImage/CMakeLists.txt
@@ -1,17 +1,31 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftCoreImage ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+if(${sdk} STREQUAL OSX
+  OR ${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR
+  OR ${sdk} STREQUAL TVOS OR ${sdk} STREQUAL TVOS_SIMULATOR)
+else()
+  continue()
+endif()
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Metal Dispatch IOKit Foundation XPC CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics Metal Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics Metal Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftCoreImage ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   CoreImage.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Metal Dispatch IOKit Foundation XPC CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics Metal Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics Metal Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS_OSX QuartzCore
   FRAMEWORK_DEPENDS_IOS_TVOS CoreImage
 
@@ -20,3 +34,5 @@ add_swift_target_library(swiftCoreImage ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES}
   DEPLOYMENT_VERSION_TVOS ${SWIFTLIB_DEPLOYMENT_VERSION_COREIMAGE_TVOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/CoreLocation/CMakeLists.txt
+++ b/stdlib/public/Darwin/CoreLocation/CMakeLists.txt
@@ -1,6 +1,16 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
+foreach(sdk ${SWIFT_SDKS})
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch IOKit Foundation XPC CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+)
+
 add_swift_target_library(swiftCoreLocation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   CLError.swift
 
@@ -11,10 +21,8 @@ add_swift_target_library(swiftCoreLocation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYP
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch IOKit Foundation XPC CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS CoreLocation
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_CORELOCATION_OSX}
@@ -23,3 +31,5 @@ add_swift_target_library(swiftCoreLocation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYP
   DEPLOYMENT_VERSION_WATCHOS ${SWIFTLIB_DEPLOYMENT_VERSION_CORELOCATION_WATCHOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/CoreMedia/CMakeLists.txt
+++ b/stdlib/public/Darwin/CoreMedia/CMakeLists.txt
@@ -1,16 +1,30 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftCoreMedia ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+if(${sdk} STREQUAL OSX
+  OR ${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR
+  OR ${sdk} STREQUAL TVOS OR ${sdk} STREQUAL TVOS_SIMULATOR)
+else()
+  continue()
+endif()
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Metal Dispatch IOKit Foundation XPC CoreFoundation CoreAudio ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics Metal Dispatch Foundation CoreFoundation CoreAudio ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics Metal Dispatch Foundation CoreFoundation CoreAudio ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftCoreMedia ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   CMTime.swift
   CMTimeRange.swift
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Metal Dispatch IOKit Foundation XPC CoreFoundation CoreAudio ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics Metal Dispatch Foundation CoreFoundation CoreAudio ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics Metal Dispatch Foundation CoreFoundation CoreAudio ObjectiveC # auto-updated
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS CoreMedia
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_COREMEDIA_OSX}
@@ -18,3 +32,5 @@ add_swift_target_library(swiftCoreMedia ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES}
   DEPLOYMENT_VERSION_TVOS ${SWIFTLIB_DEPLOYMENT_VERSION_COREMEDIA_TVOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/CryptoTokenKit/CMakeLists.txt
+++ b/stdlib/public/Darwin/CryptoTokenKit/CMakeLists.txt
@@ -1,15 +1,23 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftCryptoTokenKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+if(NOT ${sdk} STREQUAL OSX)
+  continue()
+endif()
+
+set(
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch IOKit Foundation XPC CoreFoundation ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftCryptoTokenKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   TKSmartCard.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch IOKit Foundation XPC CoreFoundation ObjectiveC # auto-updated
+  SDK OSX
+  SWIFT_MODULE_DEPENDS ${SWIFT_MODULE_DEPENDS_OSX}
   FRAMEWORK_DEPENDS CryptoTokenKit
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_CRYPTOTOKENKIT_OSX}

--- a/stdlib/public/Darwin/Dispatch/CMakeLists.txt
+++ b/stdlib/public/Darwin/Dispatch/CMakeLists.txt
@@ -1,7 +1,17 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftDispatch ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftDispatch ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   Dispatch.swift
   Dispatch.mm
   Block.swift
@@ -18,10 +28,8 @@ add_swift_target_library(swiftDispatch ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} 
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  SWIFT_MODULE_DEPENDS_OSX Darwin ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin ObjectiveC # auto-updated
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS_WEAK Combine
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_DISPATCH_OSX}
@@ -30,3 +38,5 @@ add_swift_target_library(swiftDispatch ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} 
   DEPLOYMENT_VERSION_WATCHOS ${SWIFTLIB_DEPLOYMENT_VERSION_DISPATCH_WATCHOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/Foundation/CMakeLists.txt
+++ b/stdlib/public/Darwin/Foundation/CMakeLists.txt
@@ -1,7 +1,19 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch IOKit XPC CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
+)
+
+list(APPEND module_depends CoreGraphics) # imported in Swift
+
+add_swift_target_library_single_sdk(swiftFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   AffineTransform.swift
   Boxing.swift
   BundleLookup.mm
@@ -83,14 +95,8 @@ add_swift_target_library(swiftFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}" "-Xllvm" "-sil-inline-generics" "-Xllvm" "-sil-partial-specialization" "${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
 
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch IOKit XPC CoreFoundation ObjectiveC # auto-updated
-    CoreGraphics # imported in Swift
-  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
-    CoreGraphics # imported in Swift
-  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
-    CoreGraphics # imported in Swift
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
-    CoreGraphics # imported in Swift
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS Foundation
   FRAMEWORK_DEPENDS_WEAK Combine
 
@@ -100,3 +106,5 @@ add_swift_target_library(swiftFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES
   DEPLOYMENT_VERSION_WATCHOS ${SWIFTLIB_DEPLOYMENT_VERSION_FOUNDATION_WATCHOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/GLKit/CMakeLists.txt
+++ b/stdlib/public/Darwin/GLKit/CMakeLists.txt
@@ -1,7 +1,24 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftGLKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+if(${sdk} STREQUAL OSX
+  OR ${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR
+  OR ${sdk} STREQUAL TVOS OR ${sdk} STREQUAL TVOS_SIMULATOR)
+else()
+  continue()
+endif()
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit simd Foundation CoreData QuartzCore AppKit ModelIO XPC CoreFoundation ObjectiveC # auto-updated
+    os
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch simd Foundation QuartzCore ModelIO CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch simd Foundation QuartzCore ModelIO CoreFoundation ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftGLKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
@@ -10,11 +27,8 @@ add_swift_target_library(swiftGLKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit simd Foundation CoreData QuartzCore AppKit ModelIO XPC CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch simd Foundation QuartzCore ModelIO CoreFoundation ObjectiveC # auto-updated
-    os
-  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch simd Foundation QuartzCore ModelIO CoreFoundation ObjectiveC # auto-updated
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS GLKit
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_GLKIT_OSX}
@@ -22,3 +36,5 @@ add_swift_target_library(swiftGLKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_
   DEPLOYMENT_VERSION_TVOS ${SWIFTLIB_DEPLOYMENT_VERSION_GLKIT_TVOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/GameplayKit/CMakeLists.txt
+++ b/stdlib/public/Darwin/GameplayKit/CMakeLists.txt
@@ -1,21 +1,33 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftGameplayKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+if(${sdk} STREQUAL OSX
+  OR ${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR
+  OR ${sdk} STREQUAL TVOS OR ${sdk} STREQUAL TVOS_SIMULATOR)
+else()
+  continue()
+endif()
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit GLKit SceneKit simd Foundation CoreData SpriteKit QuartzCore AppKit ModelIO XPC CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch GLKit SceneKit simd Foundation SpriteKit QuartzCore ModelIO CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch GLKit SceneKit simd Foundation SpriteKit QuartzCore ModelIO CoreFoundation ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftGameplayKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   GameplayKit.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit GLKit SceneKit simd Foundation CoreData SpriteKit QuartzCore AppKit ModelIO XPC CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch GLKit SceneKit simd Foundation SpriteKit QuartzCore ModelIO CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch GLKit SceneKit simd Foundation SpriteKit QuartzCore ModelIO CoreFoundation ObjectiveC # auto-updated
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS_WEAK GameplayKit
-
-  DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_GAMEPLAYKIT_OSX}
-  DEPLOYMENT_VERSION_IOS ${SWIFTLIB_DEPLOYMENT_VERSION_GAMEPLAYKIT_IOS}
-  DEPLOYMENT_VERSION_TVOS ${SWIFTLIB_DEPLOYMENT_VERSION_GAMEPLAYKIT_TVOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/HomeKit/CMakeLists.txt
+++ b/stdlib/public/Darwin/HomeKit/CMakeLists.txt
@@ -1,18 +1,36 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftHomeKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+if(${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR
+  OR ${sdk} STREQUAL TVOS OR ${sdk} STREQUAL TVOS_SIMULATOR
+  OR ${sdk} STREQUAL WATCHOS OR ${sdk} STREQUAL WATCHOS_SIMULATOR)
+else()
+  continue()
+endif()
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch Foundation QuartzCore CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch Foundation QuartzCore CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+    UIKit # required in some configurations but not found by tool
+)
+
+if(${sdk} STREQUAL WATCHOS)
+  list(APPEND module_depends UIKit) # required in some configurations but not found by tool
+endif()
+
+add_swift_target_library_single_sdk(swiftHomeKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   HomeKit.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR WATCHOS WATCHOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch Foundation QuartzCore CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch Foundation QuartzCore CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
-    UIKit # required in some configurations but not found by tool
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS_WEAK HomeKit
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_HOMEKIT_OSX}
@@ -21,3 +39,5 @@ add_swift_target_library(swiftHomeKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} I
   DEPLOYMENT_VERSION_WATCHOS ${SWIFTLIB_DEPLOYMENT_VERSION_HOMEKIT_WATCHOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/IOKit/CMakeLists.txt
+++ b/stdlib/public/Darwin/IOKit/CMakeLists.txt
@@ -1,17 +1,25 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftIOKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+if(OSX IN_LIST SWIFT_SDKS)
+
+set(
+  SWIFT_MODULE_DEPENDS_OSX Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftIOKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   IOReturn.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX
-  SWIFT_MODULE_DEPENDS_OSX Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
+  SDK OSX
+  SWIFT_MODULE_DEPENDS ${SWIFT_MODULE_DEPENDS_OSX}
   FRAMEWORK_DEPENDS IOKit
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_IOKIT_OSX}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endif()

--- a/stdlib/public/Darwin/Intents/CMakeLists.txt
+++ b/stdlib/public/Darwin/Intents/CMakeLists.txt
@@ -1,7 +1,23 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftIntents ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+if(${sdk} STREQUAL OSX
+  OR ${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR
+  OR ${sdk} STREQUAL WATCHOS OR ${sdk} STREQUAL WATCHOS_SIMULATOR)
+else()
+  continue()
+endif()
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch IOKit Foundation CoreLocation XPC CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch Foundation CoreLocation CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch Foundation CoreLocation CoreFoundation ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftIntents ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   INBooleanResolutionResult.swift
   INCallRecord.swift
   INDoubleResolutionResult.swift
@@ -32,13 +48,13 @@ add_swift_target_library(swiftIntents ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} I
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX IOS IOS_SIMULATOR WATCHOS WATCHOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch IOKit Foundation CoreLocation XPC CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch Foundation CoreLocation CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch Foundation CoreLocation CoreFoundation ObjectiveC # auto-updated
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS_WEAK Intents
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_INTENTS_OSX}
   DEPLOYMENT_VERSION_IOS ${SWIFTLIB_DEPLOYMENT_VERSION_INTENTS_IOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/MapKit/CMakeLists.txt
+++ b/stdlib/public/Darwin/MapKit/CMakeLists.txt
@@ -1,18 +1,29 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftMapKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit Foundation CoreData CoreLocation QuartzCore AppKit XPC CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch Foundation CoreLocation QuartzCore CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch Foundation CoreLocation QuartzCore CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics UIKit Dispatch Foundation CoreLocation CoreFoundation ObjectiveC # auto-updated
+)
+
+if(${sdk} STREQUAL WATCHOS)
+  list(APPEND module_depends UIKit) # required in some configurations but not found by tool
+endif()
+
+add_swift_target_library_single_sdk(swiftMapKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
 
   GYB_SOURCES
     NSValue.swift.gyb
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit Foundation CoreData CoreLocation QuartzCore AppKit XPC CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch Foundation CoreLocation QuartzCore CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch Foundation CoreLocation QuartzCore CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics UIKit Dispatch Foundation CoreLocation CoreFoundation ObjectiveC # auto-updated
-    UIKit # required in some configurations but not found by tool
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS MapKit
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_MAPKIT_OSX}
@@ -21,3 +32,5 @@ add_swift_target_library(swiftMapKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS
   DEPLOYMENT_VERSION_WATCHOS ${SWIFTLIB_DEPLOYMENT_VERSION_MAPKIT_WATCHOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/MediaPlayer/CMakeLists.txt
+++ b/stdlib/public/Darwin/MediaPlayer/CMakeLists.txt
@@ -1,7 +1,18 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftMediaPlayer ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(target_sdk ${SWIFT_SDKS})
+
+if(${target_sdk} STREQUAL IOS OR ${target_sdk} STREQUAL IOS_SIMULATOR)
+else()
+  continue()
+endif()
+
+set(
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch simd Foundation AVFoundation CoreMedia QuartzCore CoreFoundation CoreAudio ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftMediaPlayer ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   MPMusicPlayerPlayParameters.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
@@ -10,10 +21,13 @@ add_swift_target_library(swiftMediaPlayer ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPE
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}" "-L${sdk}/usr/lib/swift/"
   TARGET_SDKS IOS IOS_SIMULATOR
 
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch simd Foundation AVFoundation CoreMedia QuartzCore CoreFoundation CoreAudio ObjectiveC # auto-updated
+  SDK ${target_sdk}
+  SWIFT_MODULE_DEPENDS ${SWIFT_MODULE_DEPENDS_IOS}
   SWIFT_MODULE_DEPENDS_FROM_SDK CoreMIDI
   FRAMEWORK_DEPENDS_WEAK MediaPlayer
 
   DEPLOYMENT_VERSION_IOS ${SWIFTLIB_DEPLOYMENT_VERSION_MEDIAPLAYER_IOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/Metal/CMakeLists.txt
+++ b/stdlib/public/Darwin/Metal/CMakeLists.txt
@@ -1,21 +1,33 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftMetal ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+if(${sdk} STREQUAL OSX
+  OR ${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR
+  OR ${sdk} STREQUAL TVOS OR ${sdk} STREQUAL TVOS_SIMULATOR)
+else()
+  continue()
+endif()
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch IOKit Foundation XPC CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+)
+
+list(APPEND module_depends os)
+
+add_swift_target_library_single_sdk(swiftMetal ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
     Metal.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch IOKit Foundation XPC CoreFoundation ObjectiveC # auto-updated
-    os
-  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
-    os
-  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
-    os
-
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS_WEAK Metal
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_METAL_OSX}
@@ -23,3 +35,5 @@ add_swift_target_library(swiftMetal ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_
   DEPLOYMENT_VERSION_TVOS ${SWIFTLIB_DEPLOYMENT_VERSION_METAL_TVOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/MetalKit/CMakeLists.txt
+++ b/stdlib/public/Darwin/MetalKit/CMakeLists.txt
@@ -1,17 +1,31 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftMetalKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+if(${sdk} STREQUAL OSX
+  OR ${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR
+  OR ${sdk} STREQUAL TVOS OR ${sdk} STREQUAL TVOS_SIMULATOR)
+else()
+  continue()
+endif()
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit simd Foundation CoreData QuartzCore AppKit ModelIO XPC CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch simd Foundation QuartzCore ModelIO CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch simd Foundation QuartzCore ModelIO CoreFoundation ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftMetalKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
     MetalKit.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit simd Foundation CoreData QuartzCore AppKit ModelIO XPC CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch simd Foundation QuartzCore ModelIO CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch simd Foundation QuartzCore ModelIO CoreFoundation ObjectiveC # auto-updated
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   
   FRAMEWORK_DEPENDS_WEAK MetalKit
   FRAMEWORK_DEPENDS_WEAK Metal
@@ -21,3 +35,5 @@ add_swift_target_library(swiftMetalKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} 
   DEPLOYMENT_VERSION_TVOS ${SWIFTLIB_DEPLOYMENT_VERSION_METALKIT_TVOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/ModelIO/CMakeLists.txt
+++ b/stdlib/public/Darwin/ModelIO/CMakeLists.txt
@@ -1,18 +1,34 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftModelIO ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+if(${sdk} STREQUAL OSX
+  OR ${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR
+  OR ${sdk} STREQUAL TVOS OR ${sdk} STREQUAL TVOS_SIMULATOR)
+else()
+  continue()
+endif()
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch IOKit simd Foundation XPC CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics Dispatch simd Foundation CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics Dispatch simd Foundation CoreFoundation ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftModelIO ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   ModelIO.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR
+  SDK ${sdk}
 
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch IOKit simd Foundation XPC CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics Dispatch simd Foundation CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics Dispatch simd Foundation CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS_WEAK ModelIO
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/NaturalLanguage/CMakeLists.txt
+++ b/stdlib/public/Darwin/NaturalLanguage/CMakeLists.txt
@@ -1,7 +1,21 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftNaturalLanguage ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+if(NOT ${sdk} IN_LIST SWIFT_APPLE_PLATFORMS)
+  continue()
+endif()
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch IOKit Foundation XPC CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftNaturalLanguage ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   NLLanguageRecognizer.swift
   NLTagger.swift
   NLTokenizer.swift
@@ -10,11 +24,8 @@ add_swift_target_library(swiftNaturalLanguage ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR WATCHOS WATCHOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch IOKit Foundation XPC CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
 
   FRAMEWORK_DEPENDS_WEAK NaturalLanguage
 
@@ -24,3 +35,5 @@ add_swift_target_library(swiftNaturalLanguage ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_
   DEPLOYMENT_VERSION_WATCHOS ${SWIFTLIB_DEPLOYMENT_VERSION_NATURALLANGUAGE_WATCHOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/Network/CMakeLists.txt
+++ b/stdlib/public/Darwin/Network/CMakeLists.txt
@@ -1,7 +1,25 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftNetwork ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+if(${sdk} STREQUAL OSX
+  OR ${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR
+  OR ${sdk} STREQUAL TVOS OR ${sdk} STREQUAL TVOS_SIMULATOR)
+else()
+  continue()
+endif()
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
+)
+
+list(APPEND module_depends Foundation) # Imported in Swift
+
+add_swift_target_library_single_sdk(swiftNetwork ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   Network.swift
   NWConnection.swift
   NWEndpoint.swift
@@ -20,14 +38,8 @@ add_swift_target_library(swiftNetwork ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} I
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
 
-  TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR # WATCHOS WATCHOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_OSX Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
-    Foundation # Imported in Swift
-  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
-    Foundation # Imported in Swift
-  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch CoreFoundation ObjectiveC # auto-updated
-    Foundation # Imported in Swift
-  # SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch Foundation ObjectiveC # auto-updated
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS_WEAK Network
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_NETWORK_OSX}
@@ -36,3 +48,5 @@ add_swift_target_library(swiftNetwork ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} I
   # DEPLOYMENT_VERSION_WATCHOS ${SWIFTLIB_DEPLOYMENT_VERSION_NETWORK_WATCHOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/ObjectiveC/CMakeLists.txt
+++ b/stdlib/public/Darwin/ObjectiveC/CMakeLists.txt
@@ -1,7 +1,17 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftObjectiveC ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftObjectiveC ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   ObjectiveC.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
@@ -10,10 +20,8 @@ add_swift_target_library(swiftObjectiveC ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES
                       "-disable-objc-attr-requires-foundation-module" "${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
 
-  SWIFT_MODULE_DEPENDS_OSX Darwin # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin # auto-updated
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_OBJECTIVEC_OSX}
   DEPLOYMENT_VERSION_IOS ${SWIFTLIB_DEPLOYMENT_VERSION_OBJECTIVEC_IOS}
@@ -21,3 +29,5 @@ add_swift_target_library(swiftObjectiveC ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES
   DEPLOYMENT_VERSION_WATCHOS ${SWIFTLIB_DEPLOYMENT_VERSION_OBJECTIVEC_WATCHOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/OpenCL/CMakeLists.txt
+++ b/stdlib/public/Darwin/OpenCL/CMakeLists.txt
@@ -1,15 +1,23 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftOpenCL ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+if(NOT OSX IN_LIST ${SWIFT_SDKS})
+  return()
+endif()
+
+set(
+  SWIFT_MODULE_DEPENDS_OSX Darwin Dispatch ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftOpenCL ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   OpenCL.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX
-  SWIFT_MODULE_DEPENDS_OSX Darwin Dispatch ObjectiveC # auto-updated
+  SDK OSX
+  SWIFT_MODULE_DEPENDS ${SWIFT_MODULE_DEPENDS_OSX}
   FRAMEWORK_DEPENDS OpenCL
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_OPENCL_OSX}

--- a/stdlib/public/Darwin/Photos/CMakeLists.txt
+++ b/stdlib/public/Darwin/Photos/CMakeLists.txt
@@ -1,7 +1,23 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftPhotos ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(target_sdk ${SWIFT_SDKS})
+
+if(${target_sdk} STREQUAL OSX
+  OR ${target_sdk} STREQUAL IOS OR ${target_sdk} STREQUAL IOS_SIMULATOR
+  OR ${target_sdk} STREQUAL TVOS OR ${target_sdk} STREQUAL TVOS_SIMULATOR)
+else()
+  continue()
+endif()
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${target_sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit simd Foundation AVFoundation CoreMedia CoreLocation QuartzCore XPC CoreFoundation CoreAudio ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal Dispatch simd Foundation AVFoundation CoreMedia CoreLocation QuartzCore CoreFoundation CoreAudio ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreImage CoreGraphics Metal Dispatch simd Foundation AVFoundation CoreMedia CoreLocation QuartzCore CoreFoundation CoreAudio ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftPhotos ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   PHChange.swift
   PHProjectChangeRequest.swift
 
@@ -9,10 +25,8 @@ add_swift_target_library(swiftPhotos ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}" "-L${sdk}/usr/lib/swift/"
-  TARGET_SDKS IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR OSX
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal Dispatch simd Foundation AVFoundation CoreMedia CoreLocation QuartzCore CoreFoundation CoreAudio ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreImage CoreGraphics Metal Dispatch simd Foundation AVFoundation CoreMedia CoreLocation QuartzCore CoreFoundation CoreAudio ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit simd Foundation AVFoundation CoreMedia CoreLocation QuartzCore XPC CoreFoundation CoreAudio ObjectiveC # auto-updated
+  SDK ${target_sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   
   FRAMEWORK_DEPENDS Photos
 
@@ -21,3 +35,5 @@ add_swift_target_library(swiftPhotos ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_PHOTOS_OSX}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/QuartzCore/CMakeLists.txt
+++ b/stdlib/public/Darwin/QuartzCore/CMakeLists.txt
@@ -1,7 +1,23 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftQuartzCore ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+if(${sdk} STREQUAL OSX
+  OR ${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR
+  OR ${sdk} STREQUAL TVOS OR ${sdk} STREQUAL TVOS_SIMULATOR)
+else()
+  continue()
+endif()
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit Foundation XPC CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics Metal Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics Metal Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftQuartzCore ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
@@ -10,10 +26,8 @@ add_swift_target_library(swiftQuartzCore ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit Foundation XPC CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics Metal Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics Metal Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS QuartzCore
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_QUARTZCORE_OSX}
@@ -21,3 +35,5 @@ add_swift_target_library(swiftQuartzCore ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES
   DEPLOYMENT_VERSION_TVOS ${SWIFTLIB_DEPLOYMENT_VERSION_QUARTZCORE_TVOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/SafariServices/CMakeLists.txt
+++ b/stdlib/public/Darwin/SafariServices/CMakeLists.txt
@@ -1,15 +1,23 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftSafariServices ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+if(NOT OSX IN_LIST SWIFT_SDKS)
+  return()
+endif()
+
+set(
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit Foundation CoreData QuartzCore AppKit XPC CoreFoundation ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftSafariServices ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   SafariServices.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit Foundation CoreData QuartzCore AppKit XPC CoreFoundation ObjectiveC # auto-updated
+  SDK OSX
+  SWIFT_MODULE_DEPENDS ${SWIFT_MODULE_DEPENDS_OSX}
   FRAMEWORK_DEPENDS_WEAK SafariServices
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_SAFARISERVICES_OSX}

--- a/stdlib/public/Darwin/SceneKit/CMakeLists.txt
+++ b/stdlib/public/Darwin/SceneKit/CMakeLists.txt
@@ -1,7 +1,21 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftSceneKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit GLKit simd Foundation CoreData QuartzCore AppKit ModelIO XPC CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch GLKit simd Foundation QuartzCore ModelIO CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch GLKit simd Foundation QuartzCore ModelIO CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics Dispatch simd Foundation CoreFoundation ObjectiveC # auto-updated
+)
+
+if(${sdk} STREQUAL WATCHOS)
+  list(APPEND module_depends UIKit) # required in some configurations but not found by tool
+endif()
+
+add_swift_target_library_single_sdk(swiftSceneKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
@@ -10,12 +24,8 @@ add_swift_target_library(swiftSceneKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} 
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR WATCHOS WATCHOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit GLKit simd Foundation CoreData QuartzCore AppKit ModelIO XPC CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch GLKit simd Foundation QuartzCore ModelIO CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch GLKit simd Foundation QuartzCore ModelIO CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics Dispatch simd Foundation CoreFoundation ObjectiveC # auto-updated
-    UIKit # required in some configurations but not found by tool
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS_WEAK SceneKit
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_SCENEKIT_OSX}
@@ -24,3 +34,5 @@ add_swift_target_library(swiftSceneKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} 
   DEPLOYMENT_VERSION_WATCHOS ${SWIFTLIB_DEPLOYMENT_VERSION_SCENEKIT_WATCHOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/SpriteKit/CMakeLists.txt
+++ b/stdlib/public/Darwin/SpriteKit/CMakeLists.txt
@@ -1,7 +1,17 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftSpriteKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit GLKit simd Foundation CoreData QuartzCore AppKit ModelIO XPC CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch GLKit simd Foundation QuartzCore ModelIO CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch GLKit simd Foundation QuartzCore ModelIO CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics UIKit Dispatch simd Foundation CoreFoundation ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftSpriteKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   SpriteKit.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
@@ -11,11 +21,8 @@ add_swift_target_library(swiftSpriteKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES}
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR WATCHOS WATCHOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit GLKit simd Foundation CoreData QuartzCore AppKit ModelIO XPC CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch GLKit simd Foundation QuartzCore ModelIO CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreImage CoreGraphics Metal UIKit Dispatch GLKit simd Foundation QuartzCore ModelIO CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics UIKit Dispatch simd Foundation CoreFoundation ObjectiveC # auto-updated
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS SpriteKit
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_SPRITEKIT_OSX}
@@ -24,3 +31,5 @@ add_swift_target_library(swiftSpriteKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES}
   DEPLOYMENT_VERSION_WATCHOS ${SWIFTLIB_DEPLOYMENT_VERSION_SPRITEKIT_WATCHOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/UIKit/CMakeLists.txt
+++ b/stdlib/public/Darwin/UIKit/CMakeLists.txt
@@ -1,7 +1,23 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftUIKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+if(${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR
+  OR ${sdk} STREQUAL TVOS OR ${sdk} STREQUAL TVOS_SIMULATOR
+  OR ${sdk} STREQUAL WATCHOS OR ${sdk} STREQUAL WATCHOS_SIMULATOR)
+else()
+  continue()
+endif()
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal Dispatch Foundation QuartzCore CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreImage CoreGraphics Metal Dispatch Foundation QuartzCore CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftUIKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   DesignatedInitializers.mm
   UIKit.swift
 
@@ -12,11 +28,8 @@ add_swift_target_library(swiftUIKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR WATCHOS WATCHOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal Dispatch Foundation QuartzCore CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreImage CoreGraphics Metal Dispatch Foundation QuartzCore CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics Dispatch Foundation CoreFoundation ObjectiveC # auto-updated
-  SWIFT_COMPILE_FLAGS_WATCHOS -Xfrontend -disable-autolink-framework -Xfrontend CoreText
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
   FRAMEWORK_DEPENDS UIKit
 
   DEPLOYMENT_VERSION_IOS ${SWIFTLIB_DEPLOYMENT_VERSION_UIKIT_IOS}
@@ -24,3 +37,5 @@ add_swift_target_library(swiftUIKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_
   DEPLOYMENT_VERSION_WATCHOS ${SWIFTLIB_DEPLOYMENT_VERSION_UIKIT_WATCHOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/Vision/CMakeLists.txt
+++ b/stdlib/public/Darwin/Vision/CMakeLists.txt
@@ -1,17 +1,31 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftVision ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(target_sdk ${SWIFT_SDKS})
+
+if(${target_sdk} STREQUAL OSX
+  OR ${target_sdk} STREQUAL IOS OR ${target_sdk} STREQUAL IOS_SIMULATOR
+  OR ${target_sdk} STREQUAL TVOS OR ${target_sdk} STREQUAL TVOS_SIMULATOR)
+else()
+  continue()
+endif()
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${target_sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Metal Dispatch IOKit simd Foundation XPC CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics Metal Dispatch simd Foundation CoreFoundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics Metal Dispatch simd Foundation CoreFoundation ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftVision ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   Vision.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}" "-L${sdk}/usr/lib/swift/"
-  TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_OSX Darwin CoreImage CoreGraphics Metal Dispatch IOKit simd Foundation XPC CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreImage CoreGraphics Metal Dispatch simd Foundation CoreFoundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreImage CoreGraphics Metal Dispatch simd Foundation CoreFoundation ObjectiveC # auto-updated
+  SDK ${target_sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
 
   FRAMEWORK_DEPENDS_WEAK Vision
 
@@ -20,3 +34,5 @@ add_swift_target_library(swiftVision ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS
   DEPLOYMENT_VERSION_TVOS ${SWIFTLIB_DEPLOYMENT_VERSION_VISION_TVOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/WatchKit/CMakeLists.txt
+++ b/stdlib/public/Darwin/WatchKit/CMakeLists.txt
@@ -1,18 +1,31 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftWatchKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(target_sdk ${SWIFT_SDKS})
+
+if(${target_sdk} STREQUAL WATCHOS OR ${target_sdk} STREQUAL WATCHOS_SIMULATOR)
+else()
+  continue()
+endif()
+
+set(
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin HomeKit CoreGraphics UIKit Dispatch SceneKit simd Foundation MapKit CoreLocation CoreFoundation ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftWatchKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   WKInterfaceController.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}" "-L${sdk}/usr/lib/swift/"
-  TARGET_SDKS WATCHOS WATCHOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin HomeKit CoreGraphics UIKit Dispatch SceneKit simd Foundation MapKit CoreLocation CoreFoundation ObjectiveC # auto-updated
+  SDK ${target_sdk}
+  SWIFT_MODULE_DEPENDS ${SWIFT_MODULE_DEPENDS_WATCHOS}
   FRAMEWORK_DEPENDS_WEAK WatchKit
   SWIFT_COMPILE_FLAGS_WATCHOS -Xfrontend -disable-autolink-framework -Xfrontend CoreText
 
   DEPLOYMENT_VERSION_WATCHOS ${SWIFTLIB_DEPLOYMENT_VERSION_WATCHKIT_WATCHOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/XCTest/CMakeLists.txt
+++ b/stdlib/public/Darwin/XCTest/CMakeLists.txt
@@ -3,7 +3,20 @@ include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
 set(DISABLE_APPLICATION_EXTENSION ON)
 
-add_swift_target_library(swiftXCTest ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+set(module_depends)
+if(${sdk} STREQUAL OSX)
+  list(APPEND module_depends AppKit)
+elseif(${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR)
+  list(APPEND module_depends CoreMedia UIKit)
+elseif(${sdk} STREQUAL TVOS OR ${sdk} STREQUAL TVOS_SIMULATOR)
+  list(APPEND module_depends UIKit)
+else()
+  continue()
+endif()
+
+add_swift_target_library_single_sdk(swiftXCTest ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   XCTestCaseAdditions.mm
   XCTest.swift
 
@@ -15,12 +28,10 @@ add_swift_target_library(swiftXCTest ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS
     # rdar://48445154
     -Xfrontend -module-interface-preserve-types-as-written
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR
+  SDK ${sdk}
   SWIFT_MODULE_DEPENDS ObjectiveC Foundation
   FRAMEWORK_DEPENDS Foundation XCTest
-  SWIFT_MODULE_DEPENDS_OSX AppKit
-  SWIFT_MODULE_DEPENDS_IOS CoreMedia UIKit
-  SWIFT_MODULE_DEPENDS_TVOS UIKit
+  SWIFT_MODULE_DEPENDS ${module_depends}
   DONT_EMBED_BITCODE
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_XCTEST_OSX}
@@ -28,3 +39,5 @@ add_swift_target_library(swiftXCTest ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS
   DEPLOYMENT_VERSION_TVOS ${SWIFTLIB_DEPLOYMENT_VERSION_XCTEST_TVOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/XPC/CMakeLists.txt
+++ b/stdlib/public/Darwin/XPC/CMakeLists.txt
@@ -1,15 +1,23 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftXPC ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+if(NOT OSX IN_LIST SWIFT_SDKS)
+  return()
+endif()
+
+set(
+  SWIFT_MODULE_DEPENDS_OSX Darwin Dispatch ObjectiveC # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftXPC ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   XPC.swift
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  TARGET_SDKS OSX
-  SWIFT_MODULE_DEPENDS_OSX Darwin Dispatch ObjectiveC # auto-updated
+  SDK OSX
+  SWIFT_MODULE_DEPENDS ${SWIFT_MODULE_DEPENDS_OSX}
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_XPC_OSX}
   INSTALL_IN_COMPONENT sdk-overlay

--- a/stdlib/public/Darwin/os/CMakeLists.txt
+++ b/stdlib/public/Darwin/os/CMakeLists.txt
@@ -1,7 +1,24 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftos ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+
+foreach(sdk ${SWIFT_SDKS})
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin Dispatch XPC ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin ObjectiveC # auto-updated
+)
+
+if(${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR
+  OR ${sdk} STREQUAL TVOS OR ${sdk} STREQUAL TVOS_SIMULATOR
+  OR ${sdk} STREQUAL WATCHOS OR ${sdk} STREQUAL WATCHOS_SIMULATOR)
+  list(APPEND module_depends Dispatch) # required in some configurations but not found by tool
+endif()
+
+add_swift_target_library_single_sdk(swiftos ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   format.m
   os.m
   os_log.swift
@@ -13,13 +30,8 @@ add_swift_target_library(swiftos ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  SWIFT_MODULE_DEPENDS_OSX Darwin Dispatch ObjectiveC XPC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin ObjectiveC # auto-updated
-    Dispatch # required in some configurations but not found by tool
-  SWIFT_MODULE_DEPENDS_TVOS Darwin ObjectiveC # auto-updated
-    Dispatch # required in some configurations but not found by tool
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin ObjectiveC # auto-updated
-    Dispatch # required in some configurations but not found by tool
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_OS_OSX}
   DEPLOYMENT_VERSION_IOS ${SWIFTLIB_DEPLOYMENT_VERSION_OS_IOS}
@@ -27,3 +39,5 @@ add_swift_target_library(swiftos ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK
   DEPLOYMENT_VERSION_WATCHOS ${SWIFTLIB_DEPLOYMENT_VERSION_OS_WATCHOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()

--- a/stdlib/public/Darwin/simd/CMakeLists.txt
+++ b/stdlib/public/Darwin/simd/CMakeLists.txt
@@ -1,7 +1,17 @@
 cmake_minimum_required(VERSION 3.4.3)
 include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
-add_swift_target_library(swiftsimd ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+foreach(sdk ${SWIFT_SDKS})
+
+select_swift_overlay_dependenies(module_depends
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS_OSX Darwin # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin # auto-updated
+)
+
+add_swift_target_library_single_sdk(swiftsimd ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
@@ -11,10 +21,8 @@ add_swift_target_library(swiftsimd ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_S
 
   SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} -parse-stdlib ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  SWIFT_MODULE_DEPENDS_OSX Darwin # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin # auto-updated
+  SDK ${sdk}
+  SWIFT_MODULE_DEPENDS ${module_depends}
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_SIMD_OSX}
   DEPLOYMENT_VERSION_IOS ${SWIFTLIB_DEPLOYMENT_VERSION_SIMD_IOS}
@@ -22,3 +30,5 @@ add_swift_target_library(swiftsimd ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_S
   DEPLOYMENT_VERSION_WATCHOS ${SWIFTLIB_DEPLOYMENT_VERSION_SIMD_WATCHOS}
   INSTALL_IN_COMPONENT sdk-overlay
 )
+
+endforeach()


### PR DESCRIPTION
<!-- What's in this pull request? -->
This is a continuation of https://github.com/apple/swift/pull/30919

This PR simplifies the SDK specific module dependencies handling.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
