### PR TITLE
[DiagnosticVerifier] Explicitly convert a StringRef into a std::string.

### DIFF
--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -740,7 +740,7 @@ DiagnosticVerifier::Result DiagnosticVerifier::verifyFile(unsigned BufferID) {
       // Verify educational notes
       for (auto &foundName : FoundDiagnostic.EducationalNotes) {
         llvm::erase_if(expectedNotes->Names,
-                       [&](std::string item) { return item == foundName; });
+                       [&](StringRef item) { return item.equals(foundName); });
       }
 
       if (!expectedNotes->Names.empty()) {
@@ -950,7 +950,7 @@ void DiagnosticVerifier::handleDiagnostic(SourceManager &SM,
 
   llvm::SmallVector<std::string, 1> eduNotes;
   for (auto &notePath : Info.EducationalNotePaths) {
-    eduNotes.push_back(llvm::sys::path::stem(notePath));
+    eduNotes.push_back(llvm::sys::path::stem(notePath).str());
   }
 
   llvm::SmallString<128> message;


### PR DESCRIPTION
The newer llvm StringRef library has removed the implicit StringRef to
std::string conversion.  (See: llvm/llvm-project@adcd026)

This patch also uses a StringRef to compare another StringRef
eliminating the need to perform a StringRef to std::string conversion.

I am concerned that StringRef's are being stored in
ExpectedEducationalNotes, but as long as the StringRef does not out live
the definition this is totally cool then. (cc: @owenv)

(I do not have privs so I cannot run the tests).