### PR TITLE
build: prune some unused options for `_add_swift_host_executable_single`

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -843,8 +843,6 @@ function(_add_swift_host_executable_single name)
     ARCHITECTURE
     SDK)
   set(multiple_parameter_options
-    COMPILE_FLAGS
-    DEPENDS
     LLVM_LINK_COMPONENTS)
   cmake_parse_arguments(SWIFTEXE_SINGLE
     "${options}"
@@ -892,10 +890,8 @@ function(_add_swift_host_executable_single name)
       ${SWIFTEXE_SINGLE_EXTERNAL_SOURCES})
 
   add_dependencies_multiple_targets(
-      TARGETS "${name}"
-      DEPENDS
-        ${LLVM_COMMON_DEPENDS}
-        ${SWIFTEXE_SINGLE_DEPENDS})
+      TARGETS ${name}
+      DEPENDS ${LLVM_COMMON_DEPENDS})
   llvm_update_compile_flags("${name}")
 
   if(SWIFTEXE_SINGLE_SDK STREQUAL WINDOWS)


### PR DESCRIPTION
Remove some unused parameters for this function.  This simplification
will make it easier to merge `_add_swift_host_executable_single` into
`add_swift_host_executable`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
