### PR TITLE
build: duplicate and rename the `_add_variant_*` functions

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -72,7 +72,7 @@ function(is_darwin_based_sdk sdk_name out_var)
 endfunction()
 
 # Usage:
-# _add_variant_c_compile_link_flags(
+# _add_host_variant_c_compile_link_flags(
 #   SDK sdk
 #   ARCH arch
 #   BUILD_TYPE build_type
@@ -86,7 +86,7 @@ endfunction()
 #   DEPLOYMENT_VERSION_WATCHOS version
 #
 # )
-function(_add_variant_c_compile_link_flags)
+function(_add_host_variant_c_compile_link_flags)
   set(oneValueArgs SDK ARCH BUILD_TYPE RESULT_VAR_NAME ENABLE_LTO ANALYZE_CODE_COVERAGE
     DEPLOYMENT_VERSION_OSX DEPLOYMENT_VERSION_MACCATALYST DEPLOYMENT_VERSION_IOS DEPLOYMENT_VERSION_TVOS DEPLOYMENT_VERSION_WATCHOS
     MACCATALYST_BUILD_FLAVOR
@@ -189,7 +189,7 @@ function(_add_variant_c_compile_link_flags)
 endfunction()
 
 
-function(_add_variant_c_compile_flags)
+function(_add_host_variant_c_compile_flags)
   set(oneValueArgs SDK ARCH BUILD_TYPE ENABLE_ASSERTIONS ANALYZE_CODE_COVERAGE
     DEPLOYMENT_VERSION_OSX DEPLOYMENT_VERSION_MACCATALYST DEPLOYMENT_VERSION_IOS DEPLOYMENT_VERSION_TVOS DEPLOYMENT_VERSION_WATCHOS
     RESULT_VAR_NAME ENABLE_LTO
@@ -202,7 +202,7 @@ function(_add_variant_c_compile_flags)
 
   set(result ${${CFLAGS_RESULT_VAR_NAME}})
 
-  _add_variant_c_compile_link_flags(
+  _add_host_variant_c_compile_link_flags(
     SDK "${CFLAGS_SDK}"
     ARCH "${CFLAGS_ARCH}"
     BUILD_TYPE "${CFLAGS_BUILD_TYPE}"
@@ -363,7 +363,7 @@ function(_add_variant_c_compile_flags)
   set("${CFLAGS_RESULT_VAR_NAME}" "${result}" PARENT_SCOPE)
 endfunction()
 
-function(_add_variant_link_flags)
+function(_add_host_variant_link_flags)
   set(oneValueArgs SDK ARCH BUILD_TYPE ENABLE_ASSERTIONS ANALYZE_CODE_COVERAGE
   DEPLOYMENT_VERSION_OSX DEPLOYMENT_VERSION_MACCATALYST DEPLOYMENT_VERSION_IOS DEPLOYMENT_VERSION_TVOS DEPLOYMENT_VERSION_WATCHOS
   RESULT_VAR_NAME ENABLE_LTO LTO_OBJECT_NAME LINK_LIBRARIES_VAR_NAME LIBRARY_SEARCH_DIRECTORIES_VAR_NAME
@@ -382,7 +382,7 @@ function(_add_variant_link_flags)
   set(link_libraries ${${LFLAGS_LINK_LIBRARIES_VAR_NAME}})
   set(library_search_directories ${${LFLAGS_LIBRARY_SEARCH_DIRECTORIES_VAR_NAME}})
 
-  _add_variant_c_compile_link_flags(
+  _add_host_variant_c_compile_link_flags(
     SDK "${LFLAGS_SDK}"
     ARCH "${LFLAGS_ARCH}"
     BUILD_TYPE "${LFLAGS_BUILD_TYPE}"
@@ -670,7 +670,7 @@ function(_add_swift_host_library_single target)
       list(APPEND library_search_directories "$ENV{SDKROOT}/usr/lib/swift")
   endif()
 
-  _add_variant_c_compile_flags(
+  _add_host_variant_c_compile_flags(
     SDK "${SWIFT_HOST_VARIANT_SDK}"
     ARCH "${SWIFT_HOST_VARIANT_ARCH}"
     BUILD_TYPE ${CMAKE_BUILD_TYPE}
@@ -685,7 +685,7 @@ function(_add_swift_host_library_single target)
       list(APPEND c_compile_flags -D_WINDLL)
     endif()
   endif()
-  _add_variant_link_flags(
+  _add_host_variant_link_flags(
     SDK "${SWIFT_HOST_VARIANT_SDK}"
     ARCH "${SWIFT_HOST_VARIANT_ARCH}"
     BUILD_TYPE ${CMAKE_BUILD_TYPE}
@@ -867,7 +867,7 @@ function(_add_swift_host_executable_single name)
         "${SWIFTLIB_DIR}/${SWIFT_SDK_${SWIFTEXE_SINGLE_SDK}_LIB_SUBDIR}")
 
   # Add variant-specific flags.
-  _add_variant_c_compile_flags(
+  _add_host_variant_c_compile_flags(
     SDK "${SWIFTEXE_SINGLE_SDK}"
     ARCH "${SWIFTEXE_SINGLE_ARCHITECTURE}"
     BUILD_TYPE "${CMAKE_BUILD_TYPE}"
@@ -875,7 +875,7 @@ function(_add_swift_host_executable_single name)
     ENABLE_LTO "${SWIFT_TOOLS_ENABLE_LTO}"
     ANALYZE_CODE_COVERAGE "${SWIFT_ANALYZE_CODE_COVERAGE}"
     RESULT_VAR_NAME c_compile_flags)
-  _add_variant_link_flags(
+  _add_host_variant_link_flags(
     SDK "${SWIFTEXE_SINGLE_SDK}"
     ARCH "${SWIFTEXE_SINGLE_ARCHITECTURE}"
     BUILD_TYPE "${CMAKE_BUILD_TYPE}"

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -172,7 +172,7 @@ function(_add_extra_swift_flags_for_module module_name result_var_name)
   set("${result_var_name}" ${result_list} PARENT_SCOPE)
 endfunction()
 
-function(_add_variant_swift_compile_flags
+function(_add_target_variant_swift_compile_flags
     sdk arch build_type enable_assertions result_var_name)
   set(result ${${result_var_name}})
 
@@ -352,7 +352,7 @@ function(_compile_swift_files
   set(swift_flags)
   set(swift_module_flags)
 
-  _add_variant_swift_compile_flags(
+  _add_target_variant_swift_compile_flags(
       "${SWIFTFILE_SDK}"
       "${SWIFTFILE_ARCHITECTURE}"
       "${SWIFT_STDLIB_BUILD_TYPE}"

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -50,7 +50,7 @@ function(add_sourcekit_default_compiler_flags target)
   set(build_type "${CMAKE_BUILD_TYPE}")
   set(enable_assertions "${LLVM_ENABLE_ASSERTIONS}")
   set(analyze_code_coverage "${SWIFT_ANALYZE_CODE_COVERAGE}")
-  _add_variant_c_compile_flags(
+  _add_host_variant_c_compile_flags(
     SDK "${sdk}"
     ARCH "${arch}"
     BUILD_TYPE "${build_type}"
@@ -58,7 +58,7 @@ function(add_sourcekit_default_compiler_flags target)
     ANALYZE_CODE_COVERAGE "${analyze_code_coverage}"
     ENABLE_LTO "${SWIFT_TOOLS_ENABLE_LTO}"
     RESULT_VAR_NAME c_compile_flags)
-  _add_variant_link_flags(
+  _add_host_variant_link_flags(
     SDK "${sdk}"
     ARCH "${arch}"
     BUILD_TYPE "${build_type}"


### PR DESCRIPTION
This allows us to start splitting up the swift and C/C++ specific paths.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
