### PR TITLE
[run-test] add `--build-jobs` option

### DIFF
--- a/utils/run-test
+++ b/utils/run-test
@@ -126,6 +126,9 @@ def main():
                         choices=["true", "verbose", "skip"], default='true',
                         help="build test dependencies before running tests "
                              "(default: true)")
+    parser.add_argument("--build-jobs",
+                        type=int,
+                        help="The number of parallel build jobs to use")
     parser.add_argument("--target",
                         type=argparse.types.ShellSplitType(),
                         action=argparse.actions.AppendAction,
@@ -232,7 +235,11 @@ def main():
         cmake_build = ['cmake', '--build', build_dir, '--']
         if args.build == 'verbose':
             cmake_build += ['-v']
-        cmake_build += ['-j%d' % multiprocessing.cpu_count()]
+
+        if args.build_jobs is not None:
+            cmake_build += ['-j%d' % args.build_jobs]
+        else:
+            cmake_build += ['-j%d' % multiprocessing.cpu_count()]
 
         print("--- Building test dependencies %s ---" %
               ', '.join(dependency_targets))


### PR DESCRIPTION
This patch add `--build-jobs` option to `utils/run-test`.

To make it clear that it's not parallel number of test but build,
I choose `--build-jobs` to name.

## Motivation

I want to specify number of tasks which is a little less than machine cores.

In my mac, if I use all cores for build,
web browsing and text input (japanese IME) become unstable.
So I always use `--jobs 32` on `build-script` (machine core is 36).

@compnerd @CodaFi Please review this.

