### PR TITLE
[android] Add check for __aarch64__ besides __arm__ and __arm64__.

### DIFF
--- a/test/Inputs/clang-importer-sdk/usr/include/cfuncs.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/cfuncs.h
@@ -14,7 +14,7 @@ double pow(double x, double y);
 long double powl(long double x, long double y);
 
 void f16ptrfunc(__fp16 *);
-#if defined __arm__ || defined __arm64__
+#if defined __arm__ || defined __arm64__ || defined __aarch64__
 _Float16 f16func(_Float16);
 #endif
 


### PR DESCRIPTION
The spelling __arm64__ seems to be an Apple-only thing, which is not
provided when targetting Android, and probably other AArch64 Linuxes.

This has been tripping the Android CI for some time (example https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/4424/).