### PR TITLE
[validation-test] avoid crash in StringUTF8

### DIFF
--- a/validation-test/stdlib/StringUTF8.swift
+++ b/validation-test/stdlib/StringUTF8.swift
@@ -67,8 +67,11 @@ private func testForeignContiguous(slowString: NSSlowString, string: String) {
       CFStringCreateWithCString(nil, $0, kCFStringEncodingASCII)!
       } as String
     expectTrue(cfString.isFastUTF8)
-    expectEqualSequence(
-      string.utf8, cfString.withFastUTF8IfAvailable(Array.init)!)
+    let cfStringFastUTF8OrNone = cfString.withFastUTF8IfAvailable(Array.init)
+    if let cfStringFastUTF8 = expectNotNil(cfStringFastUTF8OrNone) {
+      expectEqualSequence(
+        string.utf8, cfStringFastUTF8)
+    }
   }
 }
 


### PR DESCRIPTION
To avoid crash, it uses optional binding.

Resolves half: https://bugs.swift.org/browse/SR-12577

Test case fail as usual, but it will be improved so that detailed output can be obtained.

Example:

```
[ RUN      ] StringUTF8Tests.Contiguous Access
stdout>>> abcd
stdout>>> abcdefghijklmnop
stdout>>> check failed at /Users/omochi/work/swift-source/swift/validation-test/stdlib/StringUTF8.swift, line 69
stdout>>> expected: true
stdout>>> check failed at /Users/omochi/work/swift-source/swift/validation-test/stdlib/StringUTF8.swift, line 72
stdout>>> expected optional to be non-nil
stdout>>> abcdéfghijk
stdout>>> á
stdout>>> 👻
stdout>>> Spooky long string. 👻
stdout>>> в чащах юга жил-был цитрус? да, но фальшивый экземпляр
stdout>>> 日
```

@milseman @Catfish-Man Could you review this?