### PR TITLE
[android] Mark large_string_array as unsupported in Android-ARMv7

### DIFF
--- a/test/Inputs/timeout.py
+++ b/test/Inputs/timeout.py
@@ -1,4 +1,6 @@
-#!/uar/bin/env python
+#!/usr/bin/env python
+
+from __future__ import print_function
 
 import subprocess
 import sys
@@ -7,7 +9,12 @@ import threading
 
 def watchdog(command, timeout=None):
     process = subprocess.Popen(command)
-    timer = threading.Timer(timeout, process.kill)
+
+    def process_kill():
+        process.kill()
+        print("Timeout!", file=sys.stderr)
+
+    timer = threading.Timer(timeout, process_kill)
     try:
         timer.start()
         process.communicate()

--- a/validation-test/SILOptimizer/large_string_array.swift.gyb
+++ b/validation-test/SILOptimizer/large_string_array.swift.gyb
@@ -11,6 +11,10 @@
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: long_test
 
+// Android-ARMv7 takes more  than 5 minutes. Mark it as unsupported to avoid
+// wasting 5 minutes until timing out.
+// UNSUPPORTED: CPU=armv7 && OS=linux-androideabi
+
 // Check if the optimizer can optimize the whole array into a statically
 // initialized global
 


### PR DESCRIPTION
Seems that the test takes more than 5 minutes to finish, so the timeout
is triggered. Remove the test from the supported set for Android-ARMv7.
Instead of using XFAIL, use UNSUPPORTED to avoid spending 5 minutes
waiting for the timeout to occur. I don't think a lot of people will be
able to spend time to find out what's happening in a niche platform.

To make more clear what was happening, include a message if the
timeout.py script actually times out. Otherwise the error is a cryptic
"FileCheck error: '-' is empty.". Also fix the shebang and import the
print function from __future__ to avoid using the old print-chevron.

This appeared in https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android/6082/ for Android ARMv7.

I am still trying to get a number in my machine about the amount of time. It has been already 12 minutes with no result, so there's probably a problem somewhere.