### PR TITLE
Platform: add ShellCore to WinSDK modulemap

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -170,6 +170,13 @@ module WinSDK [system] {
     link "ShLwApi.Lib"
   }
 
+  module ShellCore {
+    header "ShellScalingApi.h"
+    export *
+
+    link "shcore.lib"
+  }
+
   module OLE32 {
     header "oaidl.h"
     export *


### PR DESCRIPTION
Add the ShellCore module to the Windows SDK modulemap.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
