### PR TITLE
build: explicitly execute `line-directive-tool` with Python3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -893,6 +893,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 endif()
 
 find_package(Python2 COMPONENTS Interpreter REQUIRED)
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 #
 # Find optional dependencies.

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -693,7 +693,7 @@ function(_compile_swift_files
   add_custom_command_target(
       dependency_target
       COMMAND
-        "${PYTHON_EXECUTABLE}" "${line_directive_tool}" "@${file_path}" --
+        "$<TARGET_FILE:Python3::Interpreter>" "${line_directive_tool}" "@${file_path}" --
         "${swift_compiler_tool}" "${main_command}" ${swift_flags}
         ${output_option} ${embed_bitcode_option} "@${file_path}"
       ${command_touch_standard_outputs}
@@ -731,7 +731,7 @@ function(_compile_swift_files
           "${CMAKE_COMMAND}" "-E" "make_directory" ${module_dir}
           ${specific_module_dir}
         COMMAND
-          "${PYTHON_EXECUTABLE}" "${line_directive_tool}" "@${file_path}" --
+          "$<TARGET_FILE:Python3::Interpreter>" "${line_directive_tool}" "@${file_path}" --
           "${swift_compiler_tool}" "-emit-module" "-o" "${module_file}"
           "-avoid-emit-module-source-info"
           ${swift_flags} ${swift_module_flags} "@${file_path}"
@@ -766,7 +766,7 @@ function(_compile_swift_files
         COMMAND
           "${CMAKE_COMMAND}" "-E" "make_directory" ${maccatalyst_specific_module_dir}
         COMMAND
-          "${PYTHON_EXECUTABLE}" "${line_directive_tool}" "@${file_path}" --
+          "$<TARGET_FILE:Python3::Interpreter>" "${line_directive_tool}" "@${file_path}" --
           "${swift_compiler_tool}" "-emit-module" "-o" "${maccatalyst_module_file}"
           ${maccatalyst_swift_flags} ${maccatalyst_swift_module_flags} "@${file_path}"
         ${command_touch_maccatalyst_module_outputs}
@@ -792,7 +792,7 @@ function(_compile_swift_files
     add_custom_command_target(
         sib_dependency_target
         COMMAND
-          "${PYTHON_EXECUTABLE}" "${line_directive_tool}" "@${file_path}" --
+          "$<TARGET_FILE:Python3::Interpreter>" "${line_directive_tool}" "@${file_path}" --
           "${swift_compiler_tool}" "-emit-sib" "-o" "${sib_file}" ${swift_flags} -Onone
           "@${file_path}"
         ${command_touch_sib_outputs}
@@ -808,7 +808,7 @@ function(_compile_swift_files
     add_custom_command_target(
         sibopt_dependency_target
         COMMAND
-          "${PYTHON_EXECUTABLE}" "${line_directive_tool}" "@${file_path}" --
+          "$<TARGET_FILE:Python3::Interpreter>" "${line_directive_tool}" "@${file_path}" --
           "${swift_compiler_tool}" "-emit-sib" "-o" "${sibopt_file}" ${swift_flags} -O
           "@${file_path}"
         ${command_touch_sibopt_outputs}
@@ -825,7 +825,7 @@ function(_compile_swift_files
     add_custom_command_target(
         sibgen_dependency_target
         COMMAND
-          "${PYTHON_EXECUTABLE}" "${line_directive_tool}" "@${file_path}" --
+          "$<TARGET_FILE:Python3::Interpreter>" "${line_directive_tool}" "@${file_path}" --
           "${swift_compiler_tool}" "-emit-sibgen" "-o" "${sibgen_file}" ${swift_flags}
           "@${file_path}"
         ${command_touch_sibgen_outputs}


### PR DESCRIPTION
The `line-directive-tool` is Python3 compliant.  Use the Python3
interpreter to execute this tool.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
