### PR TITLE
[5.2][Property Wrappers] Improve error recovery in buildStorageReference.

### DIFF
--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -674,7 +674,7 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
     auto *backing = var->getPropertyWrapperBackingProperty();
 
     // Error recovery.
-    if (!backing) {
+    if (!backing || backing->isInvalid()) {
       auto type = storage->getValueInterfaceType();
       if (isLValue)
         type = LValueType::get(type);
@@ -721,7 +721,7 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
     auto *backing = var->getPropertyWrapperBackingProperty();
 
     // Error recovery.
-    if (!backing) {
+    if (!backing || backing->isInvalid()) {
       auto type = storage->getValueInterfaceType();
       if (isLValue)
         type = LValueType::get(type);

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -826,6 +826,26 @@ struct S {
 }
 
 // ---------------------------------------------------------------------------
+// Invalid redeclaration
+// ---------------------------------------------------------------------------
+@propertyWrapper
+struct WrapperWithProjectedValue<T> {
+  var wrappedValue: T
+  var projectedValue: T { return wrappedValue }
+}
+
+class TestInvalidRedeclaration {
+  @WrapperWithProjectedValue var i = 17
+  // expected-note@-1 {{'i' previously declared here}}
+  // expected-note@-2 {{'$i' previously declared here}}
+  // expected-note@-3 {{'_i' previously declared here}}
+  @WrapperWithProjectedValue var i = 39
+  // expected-error@-1 {{invalid redeclaration of 'i'}}
+  // expected-error@-2 {{invalid redeclaration of '$i'}}
+  // expected-error@-3 {{invalid redeclaration of '_i'}}
+}
+
+// ---------------------------------------------------------------------------
 // Closures in initializers
 // ---------------------------------------------------------------------------
 struct UsesExplicitClosures {


### PR DESCRIPTION
Bail out if the backing storage has an error type. This can happen if there's an invalid redeclaration of the property wrapper, for example.

Cherry-picked from https://github.com/apple/swift/pull/30896

Resolves: rdar://problem/61143435