### PR TITLE
[5.2] [Typechecker] Fix _modify for wrapped properties with observers

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4707,6 +4707,13 @@ public:
   /// Does this storage require a 'modify' accessor in its opaque-accessors set?
   bool requiresOpaqueModifyCoroutine() const;
 
+  /// Does this storage have any explicit observers (willSet or didSet) attached
+  /// to it?
+  bool hasObservers() const {
+    return getParsedAccessor(AccessorKind::WillSet) ||
+           getParsedAccessor(AccessorKind::DidSet);
+  }
+
   SourceRange getBracesRange() const {
     if (auto info = Accessors.getPointer())
       return info->getBracesRange();

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1568,8 +1568,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
     // Make sure that the overriding property doesn't have storage.
     if ((overrideASD->hasStorage() ||
          overrideASD->getAttrs().hasAttribute<LazyAttr>()) &&
-        !(overrideASD->getParsedAccessor(AccessorKind::WillSet) ||
-          overrideASD->getParsedAccessor(AccessorKind::DidSet))) {
+        !overrideASD->hasObservers()) {
       bool downgradeToWarning = false;
       if (!ctx.isSwiftVersionAtLeast(5) &&
           overrideASD->getAttrs().hasAttribute<LazyAttr>()) {

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1579,6 +1579,7 @@ synthesizeCoroutineAccessorBody(AccessorDecl *accessor, ASTContext &ctx) {
   assert(accessor->isCoroutine());
 
   auto storage = accessor->getStorage();
+  auto storageReadWriteImpl = storage->getReadWriteImpl();
   auto target = (accessor->hasForcedStaticDispatch()
                    ? TargetImpl::Ordinary
                    : TargetImpl::Implementation);

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -757,6 +757,8 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
   bool isMemberLValue = isLValue;
   auto propertyWrapperMutability =
       [&](Decl *decl) -> Optional<std::pair<bool, bool>> {
+    if (accessor->isCoroutine())
+      return None;
     auto var = dyn_cast<VarDecl>(decl);
     if (!var)
       return None;

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -757,7 +757,7 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
   bool isMemberLValue = isLValue;
   auto propertyWrapperMutability =
       [&](Decl *decl) -> Optional<std::pair<bool, bool>> {
-    if (accessor->isCoroutine())
+    if (target != TargetImpl::Wrapper && target != TargetImpl::WrapperStorage)
       return None;
     auto var = dyn_cast<VarDecl>(decl);
     if (!var)

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2581,11 +2581,19 @@ static void finishPropertyWrapperImplInfo(VarDecl *var,
     }
   }
 
-  if (wrapperSetterIsUsable)
-    info = StorageImplInfo(ReadImplKind::Get, WriteImplKind::Set,
-                           ReadWriteImplKind::Modify);
-  else
+  bool hasObservers = var->getParsedAccessor(AccessorKind::DidSet) ||
+                      var->getParsedAccessor(AccessorKind::WillSet);
+
+  if (wrapperSetterIsUsable) {
+    if (hasObservers) {
+      info = StorageImplInfo::getMutableComputed();
+    } else {
+      info = StorageImplInfo(ReadImplKind::Get, WriteImplKind::Set,
+                             ReadWriteImplKind::Modify);
+    }
+  } else {
     info = StorageImplInfo::getImmutableComputed();
+  }
 }
 
 static void finishNSManagedImplInfo(VarDecl *var,

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1585,7 +1585,7 @@ synthesizeCoroutineAccessorBody(AccessorDecl *accessor, ASTContext &ctx) {
 
   // If this is a variable with an attached property wrapper, then
   // the accessors need to yield the wrappedValue or projectedValue.
-  if (storage->getReadImpl() == ReadImplKind::Read ||
+  if (accessor->getAccessorKind() == AccessorKind::Read ||
       storageReadWriteImpl == ReadWriteImplKind::Modify) {
     if (auto var = dyn_cast<VarDecl>(storage)) {
       if (var->hasAttachedPropertyWrapper()) {
@@ -2582,15 +2582,16 @@ static void finishPropertyWrapperImplInfo(VarDecl *var,
     }
   }
 
-  if (wrapperSetterIsUsable) {
-    if (var->hasObservers()) {
-      info = StorageImplInfo::getMutableComputed();
-      return;
-    }
+  if (!wrapperSetterIsUsable) {
+    info = StorageImplInfo::getImmutableComputed();
+    return;
+  }
+
+  if (var->hasObservers()) {
+    info = StorageImplInfo::getMutableComputed();
+  } else {
     info = StorageImplInfo(ReadImplKind::Get, WriteImplKind::Set,
                            ReadWriteImplKind::Modify);
-  } else {
-    info = StorageImplInfo::getImmutableComputed();
   }
 }
 

--- a/test/SILGen/property_wrapper_observers.swift
+++ b/test/SILGen/property_wrapper_observers.swift
@@ -1,0 +1,71 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+// 1. Make sure the wrapped property setter calls the observers
+// 2. Make sure the synthesized _modify coroutine calls the wrapped property setter
+
+@propertyWrapper 
+struct Foo {
+  private var _storage: [Int] = []
+
+  init(wrappedValue value: [Int]) {
+    self._storage = value
+  }
+
+  var wrappedValue: [Int] {
+    get { _storage }
+    set { _storage = newValue }
+  }
+}
+
+class Bar {
+  @Foo var someArray = [1, 2, 3] {
+    willSet {}
+    didSet {}
+  }
+}
+
+// Bar.someArray.setter
+
+// CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_observers3BarC9someArraySaySiGvs : $@convention(method) (@owned Array<Int>, @guaranteed Bar) -> () {
+// CHECK: bb0([[VALUE:%.*]] : @owned $Array<Int>, [[BAR:%.*]] : @guaranteed $Bar):
+
+// CHECK: [[WILLSET:%.*]] = function_ref @$s26property_wrapper_observers3BarC9someArraySaySiGvw : $@convention(method) (@guaranteed Array<Int>, @guaranteed Bar) -> ()
+// CHECK-NEXT: [[RESULT_WS:%.*]] = apply [[WILLSET]](%{{[0-9]+}}, [[BAR]]) : $@convention(method) (@guaranteed Array<Int>, @guaranteed Bar) -> ()
+
+// CHECK: [[WRAPPED_VALUE_SETTER:%.*]] = function_ref @$s26property_wrapper_observers3FooV12wrappedValueSaySiGvs : $@convention(method) (@owned Array<Int>, @inout Foo) -> ()
+// CHECK-NEXT: [[RESULT_WVS:%.*]] = apply [[WRAPPED_VALUE_SETTER]](%{{[0-9]+}}, %{{[0-9]+}}) : $@convention(method) (@owned Array<Int>, @inout Foo) -> ()
+
+// CHECK: [[DIDSET:%.*]] = function_ref @$s26property_wrapper_observers3BarC9someArraySaySiGvW : $@convention(method) (@guaranteed Bar) -> ()
+// CHECK-NEXT: [[RESULT_DS:%.*]] = apply [[DIDSET]]([[BAR]]) : $@convention(method) (@guaranteed Bar) -> ()
+// CHECK: }
+
+// Bar.someArray.modify
+
+// CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_observers3BarC9someArraySaySiGvM : $@yield_once @convention(method) (@guaranteed Bar) -> @yields @inout Array<Int> {
+// CHECK: bb0([[BAR:%.*]] : @guaranteed $Bar):
+// CHECK-NEXT: debug_value [[BAR]] : $Bar, let, name "self", argno 1
+// CHECK-NEXT: [[ALLOC_STACK:%.*]] = alloc_stack $Array<Int>
+// CHECK-NEXT:  // function_ref Bar.someArray.getter
+// CHECK-NEXT: [[GETTER:%.*]] = function_ref @$s26property_wrapper_observers3BarC9someArraySaySiGvg : $@convention(method) (@guaranteed Bar) -> @owned Array<Int>
+// CHECK-NEXT:  [[RESULT:%.*]] = apply [[GETTER]]([[BAR]]) : $@convention(method) (@guaranteed Bar) -> @owned Array<Int>
+// CHECK-NEXT:  store [[RESULT]] to [init] [[ALLOC_STACK]] : $*Array<Int>
+// CHECK-NEXT:  yield [[ALLOC_STACK]] : $*Array<Int>, resume bb1, unwind bb2
+
+// CHECK: bb1:
+// CHECK-NEXT:  [[VALUE:%.*]] = load [take] [[ALLOC_STACK]] : $*Array<Int>
+// CHECK-NEXT:  // function_ref Bar.someArray.setter
+// CHECK-NEXT:  [[SETTER:%.*]] = function_ref @$s26property_wrapper_observers3BarC9someArraySaySiGvs : $@convention(method) (@owned Array<Int>, @guaranteed Bar) -> ()
+// CHECK-NEXT:  [[RESULT:%.*]] = apply [[SETTER]]([[VALUE]], [[BAR]]) : $@convention(method) (@owned Array<Int>, @guaranteed Bar) -> ()
+// CHECK-NEXT:  dealloc_stack [[ALLOC_STACK]] : $*Array<Int>
+// CHECK-NEXT:  [[TUPLE:%.*]] = tuple ()
+// CHECK-NEXT:  return [[TUPLE]] : $()
+
+// CHECK: bb2:
+// CHECK-NEXT:  [[NEWVALUE:%.*]] = load [copy] [[ALLOC_STACK]] : $*Array<Int>
+// CHECK-NEXT:  // function_ref Bar.someArray.setter
+// CHECK-NEXT:  [[SETTER:%.*]] = function_ref @$s26property_wrapper_observers3BarC9someArraySaySiGvs : $@convention(method) (@owned Array<Int>, @guaranteed Bar) -> ()
+// CHECK-NEXT:  [[RESULT:%.*]] = apply [[SETTER]]([[NEWVALUE]], [[BAR]]) : $@convention(method) (@owned Array<Int>, @guaranteed Bar) -> ()
+// CHECK-NEXT:  destroy_addr [[ALLOC_STACK]] : $*Array<Int>
+// CHECK-NEXT:  dealloc_stack [[ALLOC_STACK]] : $*Array<Int>
+// CHECK-NEXT:  unwind
+// CHECK-END: }

--- a/test/SILGen/property_wrapper_observers.swift
+++ b/test/SILGen/property_wrapper_observers.swift
@@ -35,8 +35,8 @@ class Bar {
 // CHECK: [[WRAPPED_VALUE_SETTER:%.*]] = function_ref @$s26property_wrapper_observers3FooV12wrappedValueSaySiGvs : $@convention(method) (@owned Array<Int>, @inout Foo) -> ()
 // CHECK-NEXT: [[RESULT_WVS:%.*]] = apply [[WRAPPED_VALUE_SETTER]](%{{[0-9]+}}, %{{[0-9]+}}) : $@convention(method) (@owned Array<Int>, @inout Foo) -> ()
 
-// CHECK: [[DIDSET:%.*]] = function_ref @$s26property_wrapper_observers3BarC9someArraySaySiGvW : $@convention(method) (@guaranteed Bar) -> ()
-// CHECK-NEXT: [[RESULT_DS:%.*]] = apply [[DIDSET]]([[BAR]]) : $@convention(method) (@guaranteed Bar) -> ()
+// CHECK: [[DIDSET:%.*]] = function_ref @$s26property_wrapper_observers3BarC9someArraySaySiGvW : $@convention(method) (@guaranteed Array<Int>, @guaranteed Bar) -> ()
+// CHECK-NEXT: [[RESULT_DS:%.*]] = apply [[DIDSET]](%{{[0-9]+}}, [[BAR]]) : $@convention(method) (@guaranteed Array<Int>, @guaranteed Bar) -> ()
 // CHECK: }
 
 // Bar.someArray.modify

--- a/test/Sema/property_wrapper_property_with_observer.swift
+++ b/test/Sema/property_wrapper_property_with_observer.swift
@@ -1,0 +1,34 @@
+// RUN: %target-run-simple-swift
+
+// REQUIRES: executable_test
+
+@propertyWrapper 
+struct Foo {
+  private var _storage: [Int] = []
+
+  init(wrappedValue value: [Int]) {
+    self._storage = value
+  }
+
+  var wrappedValue: [Int] {
+    get { _storage }
+    set { _storage = newValue }
+  }
+}
+
+class Bar {
+  @Foo var someArray = [1, 2, 3] {
+    willSet {
+      print(newValue) 
+    }
+
+    didSet {
+      print(oldValue)
+    }
+  }
+}
+
+let bar = Bar()
+// CHECK: [4, 2, 3]
+// CHECK: [1, 2, 3]
+bar.someArray[0] = 4

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1190,8 +1190,7 @@ static bool inferIsSettableSyntactically(const AbstractStorageDecl *D) {
   }
   if (D->hasParsedAccessors()) {
     return D->getParsedAccessor(AccessorKind::Set) != nullptr ||
-           D->getParsedAccessor(AccessorKind::WillSet) != nullptr ||
-           D->getParsedAccessor(AccessorKind::DidSet) != nullptr;
+           D->hasObservers();
   } else {
     return true;
   }


### PR DESCRIPTION
Cherry-pick of #29931. I had to make a few minor changes because this branch is quite out of date with master.

---

Since we implemented `_modify` synthesis for property wrappers, it seems like we go through the `_modify` even when the wrapped property has explicit observers attached to it, which means the observer is never called. For example:

```swift
@propertyWrapper 
struct Foo {
  private var _storage: [Int] = []

  init(wrappedValue value: [Int]) {
    self._storage = value
  }

  var wrappedValue: [Int] {
    get { _storage }
    set { _storage = newValue }
  }
}

class Bar {
  @Foo var someArray = [1, 2, 3] {
    willSet { print(newValue) }
  }
}

let bar = Bar()
bar.someArray[0] = 4 // This doesn't trigger willSet anymore
```

This used to work fine on Swift 5.1, but not anymore.

So, if the wrapped property has any observers, then fix `_modify` to call setter.

Resolves SR-12178, SR-12089
Resolves rdar://problem/59496047