### PR TITLE
[CodeCompletion][NFC] Fix typo

### DIFF
--- a/include/swift/IDE/CompletionInstance.h
+++ b/include/swift/IDE/CompletionInstance.h
@@ -50,7 +50,7 @@ class CompletionInstance {
   /// Returns \c if the callback was called. Returns \c false if the compiler
   /// argument has changed, primary file is not the same, the \c Offset is not
   /// in function bodies, or the interface hash of the file has changed.
-  bool performCachedOperaitonIfPossible(
+  bool performCachedOperationIfPossible(
       const swift::CompilerInvocation &Invocation, llvm::hash_code ArgsHash,
       llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
       DiagnosticConsumer *DiagC,

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -164,7 +164,7 @@ static DeclContext *getEquivalentDeclContextFromSourceFile(DeclContext *DC,
 
 } // namespace
 
-bool CompletionInstance::performCachedOperaitonIfPossible(
+bool CompletionInstance::performCachedOperationIfPossible(
     const swift::CompilerInvocation &Invocation, llvm::hash_code ArgsHash,
     llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
     DiagnosticConsumer *DiagC,
@@ -454,7 +454,7 @@ bool swift::ide::CompletionInstance::performOperation(
     // the cached completion instance.
     std::lock_guard<std::mutex> lock(mtx);
 
-    if (performCachedOperaitonIfPossible(Invocation, ArgsHash, completionBuffer,
+    if (performCachedOperationIfPossible(Invocation, ArgsHash, completionBuffer,
                                          Offset, DiagC, Callback))
       return true;
 


### PR DESCRIPTION
`Operaiton` → `Operation`