### PR TITLE
[SymbolGraph] Ignore some Self requirements

### DIFF
--- a/lib/SymbolGraphGen/Edge.cpp
+++ b/lib/SymbolGraphGen/Edge.cpp
@@ -21,9 +21,6 @@ using namespace symbolgraphgen;
 void Edge::serialize(llvm::json::OStream &OS) const {
   OS.object([&](){
     OS.attribute("kind", Kind.Name);
-    if (Kind == RelationshipKind::DefaultImplementationOf() && Source.getSynthesizedBaseTypeDecl()) {
-      abort();
-    }
     SmallString<256> SourceUSR, TargetUSR;
 
     Source.getUSR(SourceUSR);
@@ -44,13 +41,22 @@ void Edge::serialize(llvm::json::OStream &OS) const {
       OS.attribute("targetFallback", Scratch.str());
     }
 
-    if (ConformanceExtension &&
-        !ConformanceExtension->getGenericRequirements().empty()) {
-      OS.attributeArray("swiftConstraints", [&](){
-        for (const auto &Req : ConformanceExtension->getGenericRequirements()) {
-          ::serialize(Req, OS);
+    if (ConformanceExtension) {
+      if (const auto *Generics = ConformanceExtension->getAsGenericContext()) {
+        SmallVector<Requirement, 4> FilteredRequirements;
+        filterGenericRequirements(Generics->getGenericRequirements(),
+            ConformanceExtension->getExtendedNominal()
+                ->getDeclContext()->getSelfNominalTypeDecl(),
+                                  FilteredRequirements);
+        if (!FilteredRequirements.empty()) {
+          OS.attributeArray("swiftConstraints", [&](){
+            for (const auto &Req :
+                 ConformanceExtension->getGenericRequirements()) {
+              ::serialize(Req, OS);
+            }
+          });
         }
-      });
+      }
     }
   });
 }

--- a/lib/SymbolGraphGen/JSON.cpp
+++ b/lib/SymbolGraphGen/JSON.cpp
@@ -66,13 +66,21 @@ void swift::symbolgraphgen::serialize(const ExtensionDecl *Extension,
         OS.attribute("extendedModule", ExtendedModule->getNameStr());
       }
     }
-    auto Generics = Extension->getGenericSignature();
-    if (Generics && !Generics->getRequirements().empty()) {
-      OS.attributeArray("constraints", [&](){
-        for (const auto &Requirement : Generics->getRequirements()) {
-          serialize(Requirement, OS);
-        }
-      }); // end constraints:
+    if (const auto Generics = Extension->getAsGenericContext()) {
+      SmallVector<Requirement, 4> FilteredRequirements;
+
+      filterGenericRequirements(Generics->getGenericRequirements(),
+          Extension->getExtendedNominal()
+              ->getDeclContext()->getSelfNominalTypeDecl(),
+                                FilteredRequirements);
+
+      if (!FilteredRequirements.empty()) {
+        OS.attributeArray("constraints", [&](){
+          for (const auto &Requirement : FilteredRequirements) {
+            serialize(Requirement, OS);
+          }
+        }); // end constraints:
+      }
     }
   }); // end swiftExtension:
 }
@@ -81,16 +89,16 @@ void swift::symbolgraphgen::serialize(const Requirement &Req,
                                       llvm::json::OStream &OS) {
   StringRef Kind;
   switch (Req.getKind()) {
-    case swift::RequirementKind::Conformance:
+    case RequirementKind::Conformance:
       Kind = "conformance";
       break;
-    case swift::RequirementKind::Superclass:
+    case RequirementKind::Superclass:
       Kind = "superclass";
       break;
-    case swift::RequirementKind::SameType:
+    case RequirementKind::SameType:
       Kind = "sameType";
       break;
-    case swift::RequirementKind::Layout:
+    case RequirementKind::Layout:
       return;
   }
 
@@ -99,5 +107,42 @@ void swift::symbolgraphgen::serialize(const Requirement &Req,
     OS.attribute("lhs", Req.getFirstType()->getString());
     OS.attribute("rhs", Req.getSecondType()->getString());
   });
+}
 
+void swift::symbolgraphgen::serialize(const swift::GenericTypeParamType *Param,
+                                      llvm::json::OStream &OS) {
+  OS.object([&](){
+    OS.attribute("name", Param->getName().str());
+    OS.attribute("index", Param->getIndex());
+    OS.attribute("depth", Param->getDepth());
+  });
+}
+
+void swift::symbolgraphgen::filterGenericRequirements(
+    ArrayRef<Requirement> Requirements,
+    const NominalTypeDecl *Self,
+    SmallVectorImpl<Requirement> &FilteredRequirements) {
+  for (const auto &Req : Requirements) {
+      if (Req.getKind() == RequirementKind::Layout) {
+        continue;
+      }
+    /*
+     Don't serialize constraints that aren't applicable for display.
+
+     For example:
+
+     extension Equatable {
+       func foo(_ thing: Self) {}
+     }
+
+     `foo` includes a constraint `Self: Equatable` for the compiler's purposes,
+     but that's redundant for the purposes of documentation.
+     This is extending Equatable, after all!
+    */
+    if (Req.getFirstType()->getString() == "Self" &&
+        Req.getSecondType()->getAnyNominal() == Self) {
+      continue;
+    }
+    FilteredRequirements.push_back(Req);
+  }
 }

--- a/lib/SymbolGraphGen/JSON.h
+++ b/lib/SymbolGraphGen/JSON.h
@@ -19,6 +19,7 @@
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/VersionTuple.h"
 #include "swift/AST/GenericSignature.h"
+#include "swift/AST/Type.h"
 
 namespace swift {
 namespace symbolgraphgen {
@@ -40,7 +41,15 @@ void serialize(const llvm::VersionTuple &VT, llvm::json::OStream &OS);
 void serialize(const llvm::Triple &T, llvm::json::OStream &OS);
 void serialize(const ExtensionDecl *Extension, llvm::json::OStream &OS);
 void serialize(const Requirement &Req, llvm::json::OStream &OS);
+void serialize(const swift::GenericTypeParamType *Param,
+               llvm::json::OStream &OS);
 
+
+/// Filter generic requirements that aren't relevant for documentation.
+void
+filterGenericRequirements(ArrayRef<Requirement> Requirements,
+                          const NominalTypeDecl *Self,
+                          SmallVectorImpl<Requirement> &FilteredRequirements);
 } // end namespace symbolgraphgen
 } // end namespace swift
 

--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -236,41 +236,50 @@ void Symbol::serializeFunctionSignature(llvm::json::OStream &OS) const {
   }
 }
 
-void Symbol::serializeGenericParam(const swift::GenericTypeParamType &Param,
-                                   llvm::json::OStream &OS) const {
-  OS.object([&](){
-    OS.attribute("name", Param.getName().str());
-    OS.attribute("index", Param.getIndex());
-    OS.attribute("depth", Param.getDepth());
-  });
-}
-
 void Symbol::serializeSwiftGenericMixin(llvm::json::OStream &OS) const {
   if (const auto *GC = VD->getAsGenericContext()) {
-      if (const auto Generics = GC->getGenericSignature()) {
+    if (const auto Generics = GC->getGenericSignature()) {
+
+      SmallVector<const GenericTypeParamType *, 4> FilteredParams;
+      SmallVector<Requirement, 4> FilteredRequirements;
+      for (const auto Param : Generics->getGenericParams()) {
+        if (const auto *D = Param->getDecl()) {
+          if (D->isImplicit()) {
+            continue;
+          }
+          FilteredParams.push_back(Param);
+        }
+      }
+
+      const auto *Self = dyn_cast<NominalTypeDecl>(VD);
+      if (!Self) {
+        Self = VD->getDeclContext()->getSelfNominalTypeDecl();
+      }
+
+      filterGenericRequirements(Generics->getRequirements(),
+                         Self,
+                         FilteredRequirements);
+
+      if (FilteredParams.empty() && FilteredRequirements.empty()) {
+        return;
+      }
 
       OS.attributeObject("swiftGenerics", [&](){
-        if (!Generics->getGenericParams().empty()) {
+        if (!FilteredParams.empty()) {
           OS.attributeArray("parameters", [&](){
-            for (const auto Param : Generics->getGenericParams()) {
-              if (const auto *D = Param->getDecl()) {
-                if (D->isImplicit()) {
-                  continue;
-                }
-              }
-              serializeGenericParam(*Param, OS);
+            for (const auto *Param : FilteredParams) {
+              ::serialize(Param, OS);
             }
           }); // end parameters:
         }
 
-        if (!Generics->getRequirements().empty()) {
+        if (!FilteredRequirements.empty()) {
           OS.attributeArray("constraints", [&](){
-            for (const auto &Requirement : Generics->getRequirements()) {
-              ::serialize(Requirement, OS);
+            for (const auto &Req : FilteredRequirements) {
+              ::serialize(Req, OS);
             }
           }); // end constraints:
         }
-
       }); // end swiftGenerics:
     }
   }

--- a/test/SymbolGraph/Symbols/Mixins/Generics/Arguments.swift
+++ b/test/SymbolGraph/Symbols/Mixins/Generics/Arguments.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name Arguments -emit-module-path %t/Arguments.swiftmodule
+// RUN: %target-swift-symbolgraph-extract -module-name Arguments -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/Arguments.symbols.json
+
+public struct MyStruct<T> {
+  public var x: T
+  public init(x: T) {
+    self.x = x
+  }
+}
+
+// CHECK: swiftGenerics
+// CHECK-NEXT: "parameters": [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name":  "T"
+// CHECK-NEXT:     "index": 0
+// CHECK-NEXT:     "depth": 0
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]
+// CHECK-NOT: constraints

--- a/test/SymbolGraph/Symbols/Mixins/Generics/ConstraintsOnLocalContext.swift
+++ b/test/SymbolGraph/Symbols/Mixins/Generics/ConstraintsOnLocalContext.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name ConstraintsOnLocalContext -emit-module-path %t/ConstraintsOnLocalContext.swiftmodule
+// RUN: %target-swift-symbolgraph-extract -module-name ConstraintsOnLocalContext -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/ConstraintsOnLocalContext.symbols.json
+
+public func foo<T: Sequence>(x: T) {}
+
+// CHECK: swiftGenerics
+// CHECK-NEXT: "parameters": [
+//               {
+// CHECK:          "name":  "T"
+// CHECK-NEXT:     "index": 0
+// CHECK-NEXT:     "depth": 0
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]
+// CHECK-NEXT: "constraints": [
+//               {
+// CHECK:          "kind": "conformance"
+// CHECK-NEXT:     "lhs": "T"
+// CHECK-NEXT:     "rhs": "Sequence"
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]

--- a/test/SymbolGraph/Symbols/Mixins/Generics/ConstraintsOnOuterContext.swift
+++ b/test/SymbolGraph/Symbols/Mixins/Generics/ConstraintsOnOuterContext.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name ConstraintsOnOuterContext -emit-module-path %t/ConstraintsOnOuterContext.swiftmodule
+// RUN: %target-swift-symbolgraph-extract -module-name ConstraintsOnOuterContext -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/ConstraintsOnOuterContext.symbols.json
+
+public struct MyStruct<S: Sequence> {
+  public var x: S
+  public init(x: S) {
+    self.x = x
+  }
+  public func foo() where S.Element == Int {}
+}
+
+// CHECK-LABEL: "precise": "s:25ConstraintsOnOuterContext8MyStructV3fooyySi7ElementRtzrlF"
+// CHECK: swiftGenerics
+// CHECK: "constraints": [
+//               {
+// CHECK:          "kind": "conformance"
+// CHECK-NEXT:     "lhs": "S"
+// CHECK-NEXT:     "rhs": "Sequence"
+//               },
+//               {
+// CHECK:          "kind": "sameType"
+// CHECK-NEXT:     "lhs": "S.Element"
+// CHECK-NEXT:     "rhs": "Int"
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]

--- a/test/SymbolGraph/Symbols/Mixins/Generics/Self.swift
+++ b/test/SymbolGraph/Symbols/Mixins/Generics/Self.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name Self -emit-module-path %t/Self.swiftmodule
+// RUN: %target-swift-symbolgraph-extract -module-name Self -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/Self.symbols.json
+
+public protocol P {}
+extension P {
+  static func foo(_ thing: Self) {}
+}
+
+public struct MyStruct: Equatable {
+  public static func ==(lhs: MyStruct, rhs: MyStruct) -> Bool {
+    return true
+  }
+}
+
+// We don't want Self: Equatable to show up here for !=
+// CHECK-NOT: swiftGenerics

--- a/test/SymbolGraph/Symbols/Mixins/Generics/WhereClause.swift
+++ b/test/SymbolGraph/Symbols/Mixins/Generics/WhereClause.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name WhereClause -emit-module-path %t/WhereClause.swiftmodule
+// RUN: %target-swift-symbolgraph-extract -module-name WhereClause -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/WhereClause.symbols.json
+
+public func foo<T>(x: T) where T: Sequence {}
+
+// CHECK: swiftGenerics
+// CHECK-NEXT: "parameters": [
+//               {
+// CHECK: "name":  "T"
+// CHECK-NEXT:     "index": 0
+// CHECK-NEXT:     "depth": 0
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]
+// CHECK-NEXT: "constraints": [
+//               {
+// CHECK:          "kind": "conformance"
+// CHECK-NEXT:     "lhs": "T"
+// CHECK-NEXT:     "rhs": "Sequence"
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]


### PR DESCRIPTION
To ease the burden on the client, ignore some generic requirements involving
Self. For example, `Self: P` where we already know that `Self` conforms to `P`.

An example case:

```
public struct S: Equatable {
  public static func ==(lhs: S, rhs: S) -> Bool { ... }
}
```

`!=` is defined in terms of `Self` and the default implementation has a `Self:
Equatable`. For the purposes of documentation, it's not necessary to specify
that again on the page of documentation for `!=`.

rdar://60963924