### PR TITLE
[Property Wrappers] Use the outermost wrapper attribute type as the contextual type for property wrapper initialization

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4219,6 +4219,7 @@ void SolutionApplicationTarget::maybeApplyPropertyWrapper() {
   // the initializer type later.
   expression.wrappedVar = singleVar;
   expression.expression = backingInitializer;
+  expression.convertType = outermostWrapperAttr->getTypeLoc();
 }
 
 SolutionApplicationTarget SolutionApplicationTarget::forInitialization(

--- a/test/Constraints/requirement_failures_in_contextual_type.swift
+++ b/test/Constraints/requirement_failures_in_contextual_type.swift
@@ -19,3 +19,18 @@ let _: A<Int>.C = 0
 // expected-error@-1 {{'A<Int>.C' (aka 'Int') requires the types 'Int' and 'Int32' be equivalent}}
 let _: A<Int>.B.E = 0
 // expected-error@-1 {{'A<Int>.B' requires the types 'Int' and 'Int32' be equivalent}}
+
+
+protocol P {}
+
+@propertyWrapper
+struct Wrapper<T: P> { // expected-note {{where 'T' = 'Int'}}
+  var wrappedValue: T
+}
+
+class C {
+  static let i = 1
+
+  @Wrapper // expected-error{{generic struct 'Wrapper' requires that 'Int' conform to 'P'}}
+  var value = C.i
+}


### PR DESCRIPTION
Otherwise, the locator path for the property wrapper backing initializer call could be rooted in a `contextual type` path element with no contextual type for that expression in the constraint system, which breaks assumptions in diagnostics code.

Resolves: rdar://problem/60504098