### PR TITLE
[Experiment][ConstraintSystem] Introduce `type member` constraint

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2469,8 +2469,9 @@ namespace {
                            diag::interpolation_broken_proto);
         return nullptr;
       }
-      auto interpolationType =
-        simplifyType(DependentMemberType::get(openedType, associatedTypeDecl));
+
+      auto interpolationType = resolveAssociatedType(simplifyType(openedType),
+                                                     associatedTypeDecl, cs.DC);
 
       // Fetch needed witnesses.
       ConcreteDeclRef builderInit = fetchProtocolInitWitness(

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -689,6 +689,7 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) const {
     }
 
     case ConstraintKind::ValueMember:
+    case ConstraintKind::TypeMember:
     case ConstraintKind::UnresolvedValueMember:
     case ConstraintKind::ValueWitness:
       // If our type variable shows up in the base type, there's

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2015,8 +2015,8 @@ ConstraintSystem::matchSuperclassTypes(Type type1, Type type2,
       continue;
     }
 
-    return matchTypes(super1, type2, ConstraintKind::Bind,
-                      subflags, locator);
+    return matchTypes(replaceDependentTypes(super1), type2,
+                      ConstraintKind::Bind, subflags, locator);
   }
 
   return getTypeMatchFailure(locator);
@@ -6931,7 +6931,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyTypeMemberConstraint(
     return SolutionKind::Error;
   }
 
-  addConstraint(ConstraintKind::Bind, memberType, result, locator);
+  addConstraint(ConstraintKind::Bind, memberType, replaceDependentTypes(result),
+                locator);
   return SolutionKind::Solved;
 }
 
@@ -9863,10 +9864,11 @@ void ConstraintSystem::addConstraint(Requirement req,
     return;
   }
 
-  auto firstType = req.getFirstType();
+  auto firstType = replaceDependentTypes(req.getFirstType());
+
   if (kind) {
-    addConstraint(*kind, req.getFirstType(), req.getSecondType(), locator,
-                  isFavored);
+    auto secondType = replaceDependentTypes(req.getSecondType());
+    addConstraint(*kind, firstType, secondType, locator, isFavored);
   }
 
   if (conformsToAnyObject) {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1674,6 +1674,7 @@ void ConstraintSystem::ArgumentInfoCollector::walk(Type argType) {
 
       case ConstraintKind::BindToPointerType:
       case ConstraintKind::ValueMember:
+      case ConstraintKind::TypeMember:
       case ConstraintKind::ValueWitness:
       case ConstraintKind::UnresolvedValueMember:
       case ConstraintKind::Disjunction:

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -791,7 +791,7 @@ Type ConstraintSystem::openType(Type type, OpenedTypeMap &replacements) {
 
         // FIXME: Need a special locator element to represent
         // this associated type.
-        auto *locator = getConstraintLocator(nullptr);
+        auto *locator = getConstraintLocator(DP->getAssocType());
 
         auto *memberType = createTypeVariable(locator, TVO_CanBindToNoEscape);
         addTypeMemberConstraint(openType(DP->getBase(), replacements),
@@ -4522,10 +4522,11 @@ SourceRange constraints::getSourceRange(ASTNode anchor) {
 Type ConstraintSystem::replaceDependentTypes(Type origType) {
   return origType.transform([&](Type type) -> Type {
     if (auto *DMT = type->getAs<DependentMemberType>()) {
-      auto *memberType = createTypeVariable(getConstraintLocator(nullptr),
+      auto *assocType = DMT->getAssocType();
+      auto *memberType = createTypeVariable(getConstraintLocator(assocType),
                                             TVO_CanBindToNoEscape);
-      addTypeMemberConstraint(DMT->getBase(), DMT->getAssocType(), memberType,
-                              getConstraintLocator(nullptr));
+      addTypeMemberConstraint(DMT->getBase(), assocType, memberType,
+                              getConstraintLocator(assocType));
       return memberType;
     }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2431,6 +2431,11 @@ private:
   /// path literal to the constraint system.
   void addKeyPathApplicationRootConstraint(Type root, ConstraintLocatorBuilder locator);
 
+  /// If given type contains any dependent member types, "open" them
+  /// by introducing a new `type member` constraints and replacing
+  /// original types with type variables.
+  Type replaceDependentTypes(Type type);
+
 public:
   /// Lookup for a member with the given name in the given base type.
   ///

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4513,8 +4513,6 @@ private:
   Optional<ConstraintSystem::PotentialBinding>
   getPotentialBindingForRelationalConstraint(
       PotentialBindings &result, Constraint *constraint,
-      bool &hasDependentMemberRelationalConstraints,
-      bool &hasNonDependentMemberRelationalConstraints,
       bool &addOptionalSupertypeBindings) const;
   PotentialBindings getPotentialBindings(TypeVariableType *typeVar) const;
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2897,8 +2897,8 @@ public:
       break;
 
     case SolutionKind::Error:
-      if (shouldAddNewFailingConstraint()) {
-        addNewFailingConstraint(Constraint::createTypeMember(
+      if (shouldRecordFailedConstraint()) {
+        recordFailedConstraint(Constraint::createTypeMember(
             *this, baseTy, memberTy, assocType, getConstraintLocator(locator)));
       }
       break;


### PR DESCRIPTION
Add a new `baseType[.<associated type>] == memberType` constraint
which replaces use of `DependentMemberType` inside of a
constraint system.

The idea here is two fold:

1. Constraint system simplification (`getFixedTypeRecursive`, `simplifyTypeImpl` no longer need
   to attempt substitutions, holes related to type members are recorded in one place etc.);

2. Removal of stateful tracking related to dependent member type inference
    which paves the way for increment binding computation.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
