### PR TITLE
Work Around The Shared Module Cache's Lack of Concurrency Safety

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -61,8 +61,12 @@ WARNING(could_not_rewrite_bridging_header,none,
   "failed to serialize bridging header; "
   "target may not be debuggable outside of its original project", ())
 ERROR(bridging_header_pch_error,Fatal,
-   "failed to emit precompiled header '%0' for bridging header '%1'",
-   (StringRef, StringRef))
+      "failed to emit precompiled header '%0' for bridging header '%1'",
+      (StringRef, StringRef))
+REMARK(rebuilding_bridging_header_pch_remark,none,
+      "retrying build of precompiled header '%0' for bridging header '%1'; "
+      "errors from the prior build are being ignored",
+      (StringRef, StringRef))
 
 ERROR(emit_pcm_error,Fatal,
    "failed to emit precompiled module '%0' for module map '%1'",

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -389,6 +389,18 @@ public:
   SerializationOptions
   computeSerializationOptions(const SupplementaryOutputPaths &outs,
                               bool moduleIsPublic) const;
+
+  /// Construct a cache key for the .swiftmodule being generated. There is a
+  /// balance to be struck here between things that go in the cache key and
+  /// things that go in the "up to date" check of the cache entry. We want to
+  /// avoid fighting over a single cache entry too much when (say) running
+  /// different compiler versions on the same machine or different inputs
+  /// that happen to have the same short module name, so we will disambiguate
+  /// those in the key. But we want to invalidate and rebuild a cache entry
+  /// -- rather than making a new one and potentially filling up the cache
+  /// with dead entries -- when other factors change, such as the contents of
+  /// the .swiftinterface input or its dependencies.
+  std::string getSwiftModuleCacheHash(const std::string interfacePath) const;
 };
 
 /// A class which manages the state and execution of the compiler.


### PR DESCRIPTION
The Clang Module cache is supposed to be concurrency safe by virtue of taking a number of file locks during PCM emission. In practice, the locking done by clang is insufficient. It appears that submodules can be mutated out from under the module loaders when multiple builds are in-flight. This causes spurious failures in downstream build jobs that can usually be solved by nuking the module cache and trying again - hoping against hope that your build system races in your favor.

When asked to emit PCHs, if it fails, give it one more try with a fresh module cache. This cache path is derived from the name of the module and the hash that is computed for the module cache for Swift Interface files for a little extra entropy. This ensures we have a truly fresh module cache.

The downsides to this approach are that we are trading compile time for stability. Rebuilding the module cache is an expensive proposition.

If Clang moves to explicit module builds, we can nuke this infrastructure.

rdar://61486959, and probably many, many more.