### PR TITLE
build: explicitly pass the path to python2,python3

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -481,6 +481,10 @@ function set_build_options_for_host() {
         appletvsimulator-*  | \
         watchos-*           | \
         watchsimulator-*)
+            swift_cmake_options+=(
+              -DPython2_EXECUTABLE=$(xcrun -f python2.7)
+              -DPython3_EXECUTABLE=$(xcrun -f python3)
+            )
             case ${host} in
                 macosx-x86_64)
                     SWIFT_HOST_TRIPLE="x86_64-apple-macosx${DARWIN_DEPLOYMENT_VERSION_OSX}"


### PR DESCRIPTION
Explicitly pass the path to the python interpreter on macOS by using
`xcrun` to find the tools.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
