### PR TITLE
Cherry-Pick #30999 To Master-Next

### DIFF
--- a/test/SIL/Serialization/deserialize_foundation.sil
+++ b/test/SIL/Serialization/deserialize_foundation.sil
@@ -4,4 +4,4 @@
 
 // REQUIRES: objc_interop
 
-// CHECK-NOT: Unknown
+// CHECK-NOT: Unknown{{Code|Block}}


### PR DESCRIPTION
CocoaError.Code.fileReadUnknown conflicts with the CHECK-NOT line here.
We should be checking more specifically for UnknownBlock and UnknownCode
anyways.

rdar://53284293