### PR TITLE
[line-directive] Escape literal '['

### DIFF
--- a/utils/line-directive
+++ b/utils/line-directive
@@ -700,7 +700,7 @@ def run():
             ':(?P<line>[0-9]+):(?P<column>[0-9]+):(?P<tail>.*?)\n?$')
 
         assertion_pattern = re.compile(
-            '^(?P<head>.*( file | at |#[0-9]+: |[[]))' +
+            '^(?P<head>.*( file | at |#[0-9]+: |[\[]))' +
             sources +
             '(?P<middle>, line |:)(?P<line>[0-9]+)(?P<tail>.*?)\n?$')
 


### PR DESCRIPTION
New versions of Python warn if the literal is not escaped. Specifically:

> Support for nested sets and set operations in regular expressions as in Unicode Technical Standard #18 might be added in the future. This would change the syntax. To facilitate this future change a FutureWarning will be raised in ambiguous cases for the time being. That include sets starting with a literal '[' or containing literal character sequences '--', '&&', '~~', and '||'. To avoid a warning, escape them with a backslash. (Contributed by Serhiy Storchaka in bpo-30349.)"

https://docs.python.org/dev/whatsnew/3.7.html