### PR TITLE
test: Add parens to print for Python3 compatibility

### DIFF
--- a/test/Driver/batch_mode_response_files.swift
+++ b/test/Driver/batch_mode_response_files.swift
@@ -2,7 +2,7 @@
 // that they also use response files correctly when their argument lists are
 // too long.
 
-// RUN: %{python} -c 'for i in range(500001): print "-DTEST_" + str(i)' > %t.resp
+// RUN: %{python} -c 'for i in range(500001): print("-DTEST_" + str(i))' > %t.resp
 // RUN: %swiftc_driver -driver-print-jobs -module-name batch -enable-batch-mode -j 1 -c %S/Inputs/main.swift %S/Inputs/lib.swift @%t.resp 2>&1 > %t.jobs.txt
 // RUN: %FileCheck %s < %t.jobs.txt -check-prefix=BATCH
 

--- a/test/Driver/response-file-merge-modules.swift
+++ b/test/Driver/response-file-merge-modules.swift
@@ -1,4 +1,4 @@
-// RUN: %{python} -c 'for i in range(500001): print "-DTEST_" + str(i)' > %t.resp
+// RUN: %{python} -c 'for i in range(500001): print("-DTEST_" + str(i))' > %t.resp
 // RUN: %swiftc_driver -driver-print-jobs -module-name merge -emit-module %S/Inputs/main.swift %S/Inputs/lib.swift @%t.resp 2>&1 > %t.jobs.txt
 // RUN: %FileCheck %s < %t.jobs.txt -check-prefix=MERGE
 

--- a/test/Driver/response-file.swift
+++ b/test/Driver/response-file.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift -typecheck @%t.0.resp %s 2>&1 | %FileCheck %s -check-prefix=SHORT
 // SHORT: warning: result of call to 'abs' is unused
 
-// RUN: %{python} -c 'for a in ["A", "B", "C", "D"]: print "-DTEST1" + a' > %t.1.resp
+// RUN: %{python} -c 'for a in ["A", "B", "C", "D"]: print("-DTEST1" + a)' > %t.1.resp
 // RUN: %target-build-swift -typecheck @%t.1.resp %s 2>&1 | %FileCheck %s -check-prefix=MULTIPLE
 // MULTIPLE: warning: result of call to 'abs' is unused
 
@@ -24,7 +24,7 @@
 // RUN: %target-build-swift -typecheck @%t.4B.resp 2>&1 | %FileCheck %s -check-prefix=RECURSIVE
 // RECURSIVE: warning: result of call to 'abs' is unused
 
-// RUN: %{python} -c 'for i in range(500001): print "-DTEST5_" + str(i)' > %t.5.resp
+// RUN: %{python} -c 'for i in range(500001): print("-DTEST5_" + str(i))' > %t.5.resp
 // RUN: %target-build-swift -typecheck @%t.5.resp %s 2>&1 | %FileCheck %s -check-prefix=LONG
 // LONG: warning: result of call to 'abs' is unused
 // RUN: %empty-directory(%t/tmp)


### PR DESCRIPTION
Missing parens in inline Python calls from tests.

/cc: @compnerd 