### PR TITLE
[SourceKit] Don't use clang build sessions when validation is disabled

### DIFF
--- a/test/SourceKit/Sema/sema_build_session.swift
+++ b/test/SourceKit/Sema/sema_build_session.swift
@@ -15,7 +15,8 @@ func test() {
 // UNSUPPORTED: OS=windows-msvc
 
 // -----------------------------------------------------------------------------
-// Test that modifications for frameworks in '-Fsystem' doesn't affect the result.
+// Test that modifications for frameworks in '-Fsystem' doesn't affect the result
+// within a session, and that they are propagated after restarting SourceKit.
 
 // RUN: %empty-directory(%t/ModuleCache)
 // RUN: %empty-directory(%t/System/Frameworks)
@@ -69,7 +70,7 @@ func test() {
 // RUN:   -shell -- cp -R %S/../Inputs/build_session/Frameworks_modified/FooHelper.framework %t/System/Frameworks/ == \
 // RUN:   -shell -- echo '## TWO' == \
 // RUN:   -req=sema %s -- %s -D TWO -F %t/Frameworks -Fsystem %t/System/Frameworks -module-cache-path %t/ModuleCache  \
-// RUN:   | tee %t.reponse | %FileCheck %s --check-prefix=CHECK_USER
+// RUN:   | %FileCheck %s --check-prefix=CHECK_USER
 
 // CHECK_USER-LABEL: ## ONE
 // CHECK_USER-NOT: key.description
@@ -81,3 +82,35 @@ func test() {
 // CHECK_USER: key.severity: source.diagnostic.severity.error,
 // CHECK_USER-NEXT: key.description: "use of unresolved identifier 'fooSubFunc'",
 // CHECK_USER-NOT: key.severity: 
+
+// -----------------------------------------------------------------------------
+// Test that modifications for frameworks in '-Fsystem' doesn't affect the result
+// across SourceKit sessions *if* '-disable-modules-validate-system-headers' is
+// passed.
+
+// RUN: %empty-directory(%t/ModuleCache)
+// RUN: %empty-directory(%t/System/Frameworks)
+// RUN: cp -R %S/../Inputs/build_session/Frameworks/Foo.framework %t/System/Frameworks/
+// RUN: cp -R %S/../Inputs/build_session/Frameworks/FooHelper.framework %t/System/Frameworks/
+// RUN: %sourcekitd-test \
+// RUN:   -shell -- echo '## ONE' == \
+// RUN:   -req=sema %s -- %s -D ONE -Fsystem %t/System/Frameworks -module-cache-path %t/ModuleCache -Xfrontend -disable-modules-validate-system-headers == \
+// RUN:   -shell -- cp -R %S/../Inputs/build_session/Frameworks_modified/Foo.framework %t/System/Frameworks/ == \
+// RUN:   -shell -- cp -R %S/../Inputs/build_session/Frameworks_modified/FooHelper.framework %t/System/Frameworks/ == \
+// RUN:   -shell -- echo '## TWO' == \
+// RUN:   -req=sema %s -- %s -D TWO -Fsystem %t/System/Frameworks -module-cache-path %t/ModuleCache -Xfrontend -disable-modules-validate-system-headers \
+// RUN:   | %FileCheck %s --check-prefix=CHECK_DISABLED
+// RUN: sleep 2
+// RUN: %sourcekitd-test \
+// RUN:   -shell -- echo '## THREE' == \
+// RUN:   -req=sema %s -- %s -D THREE -Fsystem %t/System/Frameworks -module-cache-path %t/ModuleCache -Xfrontend -disable-modules-validate-system-headers \
+// RUN:   | %FileCheck %s --check-prefix=CHECK_DISABLED_2
+
+// CHECK_DISABLED-LABEL: ## ONE
+// CHECK_DISABLED-NOT: key.description
+
+// CHECK_DISABLED-LABEL: ## TWO
+// CHECK_DISABLED-NOT: key.description
+
+// CHECK_DISABLED_2-LABEL: ## THREE
+// CHECK_DISABLED_2-NOT: key.description


### PR DESCRIPTION
Don't use `-fbuild-session-timestamp` if `-disable-modules-validate-system-headers` is specified.

Since system header validation happens under *OR* condition of `ValidateSystemInputs` and `ModulesValidateOncePerBuildSession`, using build sessions effectively overrides `-disable-modules-validate-system-headers`.

rdar://problem/61075677
