### PR TITLE
build: add some internal advanced variables for Python detection

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -483,7 +483,9 @@ function set_build_options_for_host() {
         watchsimulator-*)
             swift_cmake_options+=(
               -DPython2_EXECUTABLE=$(xcrun -f python2.7)
+              -D_Python2_EXECUTABLE=$(xcrun -f python2.7)
               -DPython3_EXECUTABLE=$(xcrun -f python3)
+              -D_Python3_EXECUTABLE=$(xcrun -f python3)
             )
             case ${host} in
                 macosx-x86_64)


### PR DESCRIPTION
The `FindPython*` modules are more clever and try really hard to find
the interpreter themselves.  Add additional internal variables to force
them to select the version we would like.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
