### PR TITLE
runtime: extend shims to x86

### DIFF
--- a/stdlib/public/runtime/Float16Support.cpp
+++ b/stdlib/public/runtime/Float16Support.cpp
@@ -30,7 +30,7 @@
 // Android NDK <r21 do not provide `__aeabi_d2h` in the compiler runtime,
 // provide shims in that case.
 #if (defined(ANDROID) && defined(__ARM_ARCH_7A__) && defined(__ARM_EABI__)) || \
-  (defined(__x86_64__) && !defined(__APPLE__))
+  ((defined(__i686__) || defined(__x86_64__)) && !defined(__APPLE__))
 
 #include "../SwiftShims/Visibility.h"
 


### PR DESCRIPTION
The android x86 target exposed the fact that the FP16 support routines
were not being emitted for x86, only x86_64.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
