### PR TITLE
[AutoDiff] Add `REQUIRES: CPU=x86_64` to IRGen test.

### DIFF
--- a/test/AutoDiff/IRGen/witness_table_differentiable_requirements.sil
+++ b/test/AutoDiff/IRGen/witness_table_differentiable_requirements.sil
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -parse-sil %s -emit-ir | %FileCheck %s
+// REQUIRES: CPU=x86_64
 
 sil_stage canonical
 


### PR DESCRIPTION
This should address an arm64e test failure:
https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-device-non_executable/54/console

<details>
<p>

```
/Users/buildnode/jenkins/workspace/oss-swift_tools-RA_stdlib-DA_test-device-non_executable/swift/test/AutoDiff/IRGen/witness_table_differentiable_requirements.sil:77:16: error: CHECK-SAME: expected string not found in input
22:30:25 // CHECK-SAME: i8* bitcast (float (float, %T41witness_table_differentiable_requirements25DifferentiableConformanceV*, %swift.type*, i8**)* @"$s41witness_table_differentiable_requirements25DifferentiableConformanceVAA0E11RequirementA2aDP1fyS2fFTW" to i8*),
22:30:25                ^
22:30:25 <stdin>:39:288: note: scanning from here
22:30:25 @"$s41witness_table_differentiable_requirements25DifferentiableConformanceVAA0E11RequirementAAWP" = hidden constant [4 x i8*] [i8* bitcast (%swift.protocol_conformance_descriptor* @"$s41witness_table_differentiable_requirements25DifferentiableConformanceVAA0E11RequirementAAMc" to i8*), i8* bitcast ({ i8*, i32, i64, i64 }* @"$s41witness_table_differentiable_requirements25DifferentiableConformanceVAA0E11RequirementA2aDP1fyS2fFTW.ptrauth" to i8*), i8* bitcast ({ i8*, i32, i64, i64 }* @"AD__$s41witness_table_differentiable_requirements25DifferentiableConformanceVAA0E11RequirementA2aDP1fyS2fFTW_jvp_SU.ptrauth" to i8*), i8* bitcast ({ i8*, i32, i64, i64 }* @"AD__$s41witness_table_differentiable_requirements25DifferentiableConformanceVAA0E11RequirementA2aDP1fyS2fFTW_vjp_SU.ptrauth" to i8*)], align 8
22:30:25        
```

</p>
</details>