### PR TITLE
Fix @available(macCatalyst N, iOS N+M) bug

### DIFF
--- a/test/attr/attr_availability_maccatalyst.swift
+++ b/test/attr/attr_availability_maccatalyst.swift
@@ -48,11 +48,17 @@ deprecatedOnIOSButNotMacCatalyst() // no-warning
 func introducedLaterOnMacCatalyst() {
 }
 
+@available(iOS 57.0, macCatalyst 56.0, *)
+func introducedLaterOnIOS() {
+}
+
 // expected-note@+1 *{{add @available attribute to enclosing global function}}
 func testPoundAvailable() {
 
   if #available(macCatalyst 55.0, *) {
     introducedLaterOnMacCatalyst() // expected-error {{'introducedLaterOnMacCatalyst()' is only available in Mac Catalyst 56.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    introducedLaterOnIOS() // expected-error {{'introducedLaterOnIOS()' is only available in Mac Catalyst 56.0 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
   }
 
@@ -61,10 +67,18 @@ func testPoundAvailable() {
   if #available(iOS 56.0, macCatalyst 55.0, *) {
     introducedLaterOnMacCatalyst() // expected-error {{'introducedLaterOnMacCatalyst()' is only available in Mac Catalyst 56.0 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
+    introducedLaterOnIOS() // expected-error {{'introducedLaterOnIOS()' is only available in Mac Catalyst 56.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
   }
 
   if #available(iOS 55.0, macCatalyst 56.0, *) {
     introducedLaterOnMacCatalyst() // no-warning
+    introducedLaterOnIOS() // no-error
+  }
+
+  if #available(iOS 57.0, macCatalyst 56.0, *) {
+    introducedLaterOnMacCatalyst() // no-warning
+    introducedLaterOnIOS() // no-error
   }
 
   // iOS availability should be inherited when macCatalyst is not present
@@ -72,10 +86,13 @@ func testPoundAvailable() {
   if #available(iOS 55.0, *) {
     introducedLaterOnMacCatalyst() // expected-error {{'introducedLaterOnMacCatalyst()' is only available in Mac Catalyst 56.0 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
+    introducedLaterOnIOS() // expected-error {{'introducedLaterOnIOS()' is only available in Mac Catalyst 56.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
   }
 
   if #available(iOS 56.0, *) {
     introducedLaterOnMacCatalyst() // no-warning
+    introducedLaterOnIOS() // no-error
   }
 
   // macOS availability doesn't count on macCatalyst for Swift.


### PR DESCRIPTION
Previously, availability checking computed a declaration’s availability as the intersection of all `@available` attributes with active platforms. This meant that Swift would not allow you to use an API that was available earlier in a child platform than in its parent until it was also available in the parent platform. That was incorrect.

This PR corrects availability checking to find the most specific `@available` attribute with an `introduced:` version and use that instead.

Fixes rdar://60892534, rdar://61813677.