### PR TITLE
[SymbolGraph] Add internal/externalParam declaration fragment

### DIFF
--- a/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
+++ b/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
@@ -44,6 +44,10 @@ DeclarationFragmentPrinter::getKindSpelling(FragmentKind Kind) const {
       return "typeIdentifier";
     case FragmentKind::GenericParameter:
       return "genericParameter";
+    case FragmentKind::InternalParam:
+      return "internalParam";
+    case FragmentKind::ExternalParam:
+      return "externalParam";
     case FragmentKind::Text:
       return "text";
     case FragmentKind::None:
@@ -100,10 +104,10 @@ DeclarationFragmentPrinter::printNamePre(PrintNameContext Context) {
     break;
   case PrintNameContext::ClassDynamicSelf:
   case PrintNameContext::FunctionParameterExternal:
-    openFragment(FragmentKind::Identifier);
+    openFragment(FragmentKind::ExternalParam);
     break;
   case PrintNameContext::FunctionParameterLocal:
-    openFragment(FragmentKind::Identifier);
+    openFragment(FragmentKind::InternalParam);
     break;
   case PrintNameContext::TupleElement:
   case PrintNameContext::TypeMember:

--- a/lib/SymbolGraphGen/DeclarationFragmentPrinter.h
+++ b/lib/SymbolGraphGen/DeclarationFragmentPrinter.h
@@ -52,6 +52,8 @@ class DeclarationFragmentPrinter : public ASTPrinter {
     Identifier,
     TypeIdentifier,
     GenericParameter,
+    ExternalParam,
+    InternalParam,
     Text,
   };
 

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -46,7 +46,7 @@ PrintOptions SymbolGraph::getDeclarationFragmentsPrintOptions() const {
   PrintOptions Opts;
   Opts.FunctionDefinitions = false;
   Opts.ArgAndParamPrinting =
-    PrintOptions::ArgAndParamPrintingMode::ArgumentOnly;
+    PrintOptions::ArgAndParamPrintingMode::MatchSource;
   Opts.PrintGetSetOnRWProperties = false;
   Opts.PrintPropertyAccessors = false;
   Opts.PrintSubscriptAccessors = false;
@@ -422,6 +422,8 @@ SymbolGraph::serializeSubheadingDeclarationFragments(StringRef Key,
                                                      llvm::json::OStream &OS) {
   DeclarationFragmentPrinter Printer(OS, Key);
   auto Options = getDeclarationFragmentsPrintOptions();
+  Options.ArgAndParamPrinting =
+    PrintOptions::ArgAndParamPrintingMode::ArgumentOnly;
   Options.VarInitializers = false;
   Options.PrintDefaultArgumentValue = false;
   Options.PrintEmptyArgumentNames = false;

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/DeclarationFragments.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/DeclarationFragments.swift
@@ -3,9 +3,9 @@
 // RUN: %target-swift-symbolgraph-extract -module-name DeclarationFragments -I %t -pretty-print -output-dir %t
 // RUN: %FileCheck %s --input-file %t/DeclarationFragments.symbols.json
 
-public func foo<S>(f: @escaping () -> (), x: Int = 2, s: S) {}
+public func foo<S>(f: @escaping () -> (), ext int: Int = 2, s: S) {}
 
-// CHECK: declarationFragments
+// CHECK-LABEL: {{^      }}"declarationFragments": 
 
 // CHECK: "kind": "keyword",
 // CHECK-NEXT: "spelling": "func"
@@ -25,14 +25,20 @@ public func foo<S>(f: @escaping () -> (), x: Int = 2, s: S) {}
 // CHECK: "kind": "text",
 // CHECK-NEXT: "spelling": ">("
 
-// CHECK: "kind": "identifier",
+// CHECK: "kind": "externalParam",
 // CHECK-NEXT: "spelling": "f"
 
 // CHECK: "kind": "text",
 // CHECK-NEXT: "spelling": ": () -> (), "
 
-// CHECK: "kind": "identifier",
-// CHECK-NEXT: "spelling": "x"
+// CHECK:"kind": "externalParam",
+// CHECK-NEXT:"spelling": "ext"
+
+// CHECK: "kind": "text",
+// CHECK-NEXT: "spelling": " "
+
+// CHECK:"kind": "internalParam",
+// CHECK-NEXT:"spelling": "int"
 
 // CHECK: "kind": "text",
 // CHECK-NEXT: "spelling": ": "
@@ -44,7 +50,7 @@ public func foo<S>(f: @escaping () -> (), x: Int = 2, s: S) {}
 // CHECK: "kind": "text",
 // CHECK-NEXT: "spelling": " = 2, "
 
-// CHECK: "kind": "identifier",
+// CHECK: "kind": "externalParam",
 // CHECK-NEXT: "spelling": "s"
 
 // CHECK: "kind": "text",

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/SubheadingDeclarationFragments.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/SubheadingDeclarationFragments.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name SubheadingDeclarationFragments -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name SubheadingDeclarationFragments -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/SubheadingDeclarationFragments.symbols.json
+
+public func foo<S>(f: @escaping () -> (), ext int: Int = 2, s: S) {}
+
+// Subheading fragments should not contain internalParam kinds.
+
+// CHECK-LABEL: subHeading
+//              {
+//                "kind": "externalParam",
+// CHECK:         "spelling": "ext"
+// CHECK-NEXT:  }, 
+// CHECK-NEXT:  { 
+// CHECK-NEXT: "kind": "text"
+// CHECK-NEXT: "spelling": ": "


### PR DESCRIPTION
These were previously mapped to identifier. Some clients may wish to render
these differently in their declaration blocks.

rdar://61782916