### PR TITLE
[Preset] Generate line number debug information only to reduce the sy…

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1357,6 +1357,10 @@ skip-test-swiftsyntax
 skip-test-skstresstester
 skip-test-swiftevolve
 
+extra-cmake-options=
+   -DCMAKE_C_FLAGS="-gline-tables-only"
+   -DCMAKE_CXX_FLAGS="-gline-tables-only"
+
 #===------------------------------------------------------------------------===#
 # LLDB build configurations
 #


### PR DESCRIPTION
…mbols toolchain size


File | Full debug info | Line number debug info | Improvement
-- | -- | -- | --
./usr/bin/swift.dSYM | 2148 | 1024 | -52.3%
./usr/bin/clang-10.dSYM | 1724 | 346 | -79.9%
./usr/bin//clangd.dSYM | 938 | 189 | -79.9%
./usr/bin/dsymutil.dSYM | 644 | 115 | -82.1%

