### PR TITLE
[SIL] [Parser] Add new parers boilerplate visitors.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -507,6 +507,9 @@ ERROR(expected_sil_tuple_index,none,
 ERROR(invalid_index_subset,none,
       "invalid index subset; expected '[SU]+' where 'S' represents set indices "
       "and 'U' represents unset indices", ())
+ERROR(expected_sil_result_id_to_be_integer,none,
+      "expected integer ID after '%' but did not recieve an integer while "
+      "parsing result ID of SILInstruction", ())
 
 // SIL Values
 ERROR(sil_value_redefinition,none,

--- a/include/swift/Parse/ParseSILSupport.h
+++ b/include/swift/Parse/ParseSILSupport.h
@@ -13,11 +13,10 @@
 #ifndef SWIFT_PARSER_PARSESILSUPPORT_H
 #define SWIFT_PARSER_PARSESILSUPPORT_H
 
+#include "swift/SIL/SILParser.h"
 #include "llvm/Support/PrettyStackTrace.h"
 
 namespace swift {
-  class Parser;
-
   /// Interface between the Parse and ParseSIL libraries, to avoid circular
   /// dependencies.
   class SILParserTUStateBase {
@@ -26,16 +25,16 @@ namespace swift {
     SILParserTUStateBase() = default;
     virtual ~SILParserTUStateBase() = default;
   public:
-    virtual bool parseDeclSIL(Parser &P) = 0;
-    virtual bool parseDeclSILStage(Parser &P) = 0;
-    virtual bool parseSILVTable(Parser &P) = 0;
-    virtual bool parseSILGlobal(Parser &P) = 0;
-    virtual bool parseSILWitnessTable(Parser &P) = 0;
-    virtual bool parseSILDefaultWitnessTable(Parser &P) = 0;
-    virtual bool parseSILDifferentiabilityWitness(Parser &P) = 0;
-    virtual bool parseSILCoverageMap(Parser &P) = 0;
-    virtual bool parseSILProperty(Parser &P) = 0;
-    virtual bool parseSILScope(Parser &P) = 0;
+    virtual bool parseDeclSIL(ReadSIL &P) = 0;
+    virtual bool parseDeclSILStage(ReadSIL &P) = 0;
+    virtual bool parseSILVTable(ReadSIL &P) = 0;
+    virtual bool parseSILGlobal(ReadSIL &P) = 0;
+    virtual bool parseSILWitnessTable(ReadSIL &P) = 0;
+    virtual bool parseSILDefaultWitnessTable(ReadSIL &P) = 0;
+    virtual bool parseSILDifferentiabilityWitness(ReadSIL &P) = 0;
+    virtual bool parseSILCoverageMap(ReadSIL &P) = 0;
+    virtual bool parseSILProperty(ReadSIL &P) = 0;
+    virtual bool parseSILScope(ReadSIL &P) = 0;
   };
 } // end namespace swift
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -887,9 +887,6 @@ public:
   /// Parse the top-level Swift decls into the provided vector.
   void parseTopLevel(SmallVectorImpl<Decl *> &decls);
 
-  /// Parse the top-level SIL decls into the SIL module.
-  void parseTopLevelSIL();
-
   /// Flags that control the parsing of declarations.
   enum ParseDeclFlags {
     PD_Default              = 0,

--- a/include/swift/SIL/SILParser.h
+++ b/include/swift/SIL/SILParser.h
@@ -1,0 +1,175 @@
+//===--- SILParser.h - SIL Undef Value Representation -----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_PARSER_H
+#define SWIFT_SIL_PARSER_H
+
+#include "swift/AST/DeclContext.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/Parse/Parser.h"
+#include "swift/SIL/SILInstruction.h"
+
+namespace swift {
+namespace syntax {
+
+//===----------------------------------------------------------------------===//
+// General types for parsing
+//===----------------------------------------------------------------------===//
+
+// These are both StringRefs used to represent operand ids such as %abc or %0.
+using ValueID = StringRef;
+
+struct SILParserOperand {
+  ValueID value;
+  // TODO: the type parsing should follow a similar model, eventually.
+  SILType type;
+
+  SILParserOperand(ValueID val, SILType ty) : value(val), type(ty) {}
+};
+
+// A list of parser operand ids. This is used primarily for keeping track of the
+// result(s) of a sil instruction.
+using SILParserValues = SmallVector<ValueID, 4>;
+
+// Similar to SILParserValues but includes a type for each value.
+struct SILParserOperands : SmallVector<SILParserOperand, 8> {};
+
+// An unsigned integer where each bit position corresponds to a different
+// attribute.
+// TODO: define and implement this.
+using SILParserAttributes = uint32_t;
+
+// A location range that corisponds to the start of an instruction and the end
+// of an instruction. The Reader will exit early if it runs into an error and
+// let the checker diagnose the problem. Knowing where the reader got to (end)
+// will allow for more accurate diagnosis of the error and location printing.
+struct SourceLocRange {
+  SourceLoc begin;
+  SourceLoc end;
+};
+
+// SILParserResult holds all needed information about any instruction that we
+// read/parse. The reader will return this type and the checker and emitter will
+// take this type and use it to check or emit sil instructions.
+struct SILParserResult {
+  SILInstructionKind kind = SILInstructionKind(0);
+  SILParserValues results;
+  SILParserOperands operands;
+  SourceLocRange loc;
+  SILParserAttributes attrs;
+};
+
+// TODO: move this back to ParseSIL.
+struct UnresolvedValueName {
+  StringRef Name;
+  SourceLoc NameLoc;
+
+  bool isUndef() const { return Name == "undef"; }
+};
+
+//===----------------------------------------------------------------------===//
+// SIL Reader definition
+//===----------------------------------------------------------------------===//
+
+// Provides default implementation for each visitor method. This default
+// implementation will be called if one has not been provided by the visitor.
+class ReadSILBase {
+public:
+  // The default implementation of the visitor is to set the parser result to
+  // `0` so that we know that we cannot handle this type of instruction.
+#define FULL_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)                   \
+  void read##ID(SILParserResult &out) { \
+    out.kind = SILInstructionKind(0); \
+  }
+#include "swift/SIL/SILNodes.def"
+};
+
+// The main sil "Parser" class. Reads and visits sil instructions. Reads the sil
+// instructions into a SILParserResult which can be checked and emitted.
+// TODO: Parser should be private inheritance
+class ReadSIL : public ReadSILBase, public Parser {
+  bool readSingleID(SILParserValues &instResults);
+
+public:
+  // Entry point for the visitor. Reads a sil instruction and visits it.
+  SILParserResult read();
+
+  /// Old methods moved to this parser.
+  /// Parse the top-level SIL decls into the SIL module.
+  void parseTopLevelSIL();
+
+  ReadSIL(unsigned bufferID, SourceFile &SF, SILParserTUStateBase *SIL)
+      : Parser(bufferID, SF, SIL,
+               /*SPActions*/ nullptr, /*PersistentState*/ nullptr) {}
+};
+
+//===----------------------------------------------------------------------===//
+// SIL Checker definition
+//===----------------------------------------------------------------------===//
+
+// Provides default implementation for each visitor method. This default
+// implementation will be called if one has not been provided by the visitor.
+class CheckSILBase {
+public:
+  // The default implementation is to return true, or "no errors". This is
+  // nessisary so that we do not fail when bailing to the old implementation (in
+  // SILParser).
+#define FULL_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)                   \
+  bool check##ID(SILParserResult) { return true; }
+#include "swift/SIL/SILNodes.def"
+};
+
+// A visitor for checking sil instructions as parser results. The job of this
+// class is to make sure that errors do not occor when emitting the instruction.
+// The Emitter should be allowed to make any assumptions it needs to about
+// operands, results, types, and the existance of those. This checker should,
+// therefore, check that there are the correct number of operands, results,
+// attributes, types, etc. and that all those things exist and have already been
+// parsed and/or emitted.
+class CheckSIL : public CheckSILBase {
+public:
+  // Entry point for the visitor.
+  bool check(SILParserResult);
+};
+
+//===----------------------------------------------------------------------===//
+// SIL Emitter definition
+//===----------------------------------------------------------------------===//
+
+// Provides default implementation for each visitor method. This default
+// implementation will be called if one has not been provided by the visitor.
+class EmitSILBase {
+public:
+  // The default implementation is to return a nullptr. This is the only time a
+  // nullptr will be returned from this method and signifies to the caller that
+  // it should fallback to the old parser.
+#define FULL_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)                   \
+  SILInstruction *emit##ID(SILBuilder &, SILParserResult) { return nullptr; }
+#include "swift/SIL/SILNodes.def"
+};
+
+// A visitor for emitting sil instructions based on a *valid* SILParserResult.
+class EmitSIL : public EmitSILBase {
+public:
+  // The main entry point for this visitor. It is required that a sil
+  // instruction can be created given the information in SILParserResult.
+  // Therefore, this method should never return nullptr. The only exception is
+  // to signal that an implementation for the given sil instruction has not yet
+  // been created so, the caller should revert to the old parser. "builder" will
+  // be used to create this sil instruction.
+  SILInstruction *emit(SILBuilder &builder, SILParserResult);
+};
+
+} // namespace syntax
+} // namespace swift
+
+#endif

--- a/lib/SIL/Parser/CMakeLists.txt
+++ b/lib/SIL/Parser/CMakeLists.txt
@@ -1,4 +1,7 @@
 sil_register_sources(
+  Check.cpp
+  Parse.cpp
   ParseSIL.cpp
+  Read.cpp
 )
 

--- a/lib/SIL/Parser/Check.cpp
+++ b/lib/SIL/Parser/Check.cpp
@@ -1,0 +1,42 @@
+//===--- Check.cpp - SIL File Parsing logic -------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/SILParser.h"
+
+using namespace swift;
+using namespace swift::syntax;
+
+//===----------------------------------------------------------------------===//
+// CheckSIL implementation
+//===----------------------------------------------------------------------===//
+
+namespace swift {
+
+bool CheckSIL::check(SILParserResult toCheck) {
+  // If the kind is `0` then we don't suppor this instruction yet. Bail but,
+  // don't error because the old parser will handle this case.
+  if (unsigned(toCheck.kind) == 0)
+    return true;
+
+  switch (toCheck.kind) {
+#define INST(CLASS, PARENT)                                                    \
+  case SILInstructionKind::CLASS:                                              \
+    return check##CLASS(toCheck);
+#include "swift/SIL/SILNodes.def"
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// CheckSIL visitors
+//===----------------------------------------------------------------------===//
+
+} // namespace swift

--- a/lib/SIL/Parser/Parse.cpp
+++ b/lib/SIL/Parser/Parse.cpp
@@ -1,0 +1,44 @@
+//===--- Parse.cpp - SIL File Parsing logic -------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/SILParser.h"
+
+using namespace swift;
+using namespace swift::syntax;
+
+//===----------------------------------------------------------------------===//
+// EmitSIL implementation
+//===----------------------------------------------------------------------===//
+
+namespace swift {
+
+SILInstruction *EmitSIL::emit(SILBuilder &builder, SILParserResult instData) {
+  // If we don't know what the kind is that is because this parser doesn't yet
+  // suppor that instruction. Return nullptr so that the old parser knows it
+  // needs to parse this instruction. This is the only time this method should
+  // ever return a null instruction.
+  if (unsigned(instData.kind) == 0)
+    return nullptr;
+  
+  switch (instData.kind) {
+#define INST(CLASS, PARENT)                                                    \
+  case SILInstructionKind::CLASS:                                              \
+    return emit##CLASS(builder, instData);
+#include "swift/SIL/SILNodes.def"
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// EmitSIL visitors
+//===----------------------------------------------------------------------===//
+
+} // namespace swift

--- a/lib/SIL/Parser/Read.cpp
+++ b/lib/SIL/Parser/Read.cpp
@@ -1,0 +1,99 @@
+//===--- Read.cpp - SIL File Parsing logic --------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/SILParser.h"
+
+using namespace swift;
+using namespace swift::syntax;
+
+//===----------------------------------------------------------------------===//
+// ReadSIL implementation
+//===----------------------------------------------------------------------===//
+
+namespace swift {
+
+bool ReadSIL::readSingleID(SILParserValues &instResults) {
+  if (!Tok.getRawText().equals("%")) {
+    return false;
+  }
+  consumeToken();
+  if (Tok.is(tok::identifier)) {
+    instResults.push_back(Tok.getRawText());
+    return true;
+  }
+  return false;
+}
+
+SILParserResult ReadSIL::read() {
+  ParserPosition start = getParserPosition();
+  SILParserResult readingResult;
+  readingResult.loc.begin = Tok.getLoc();
+  readingResult.loc.end = Tok.getLoc();
+
+  // Read the results, if any:
+  // (%x,)? | %x
+  SILParserValues instResults;
+  if (consumeIf(tok::l_paren)) {
+    while (!consumeIf(tok::r_paren)) {
+      readingResult.loc.end = Tok.getLoc();
+
+      if (!readSingleID(instResults)) {
+        return {};
+      }
+
+      if (Tok.is(tok::comma)) {
+        consumeToken();
+      } else if (!Tok.is(tok::r_paren)) {
+        return {};
+      }
+    }
+  } else if (Tok.getRawText().equals("%")) {
+    if (!readSingleID(instResults)) {
+      return {};
+    }
+  }
+
+  // Read the SILInstruction Kind.
+  if (!Tok.is(tok::identifier)) {
+    return {};
+  }
+
+  auto instStr = Tok.getRawText();
+  consumeToken();
+  readingResult.loc.end = Tok.getLoc();
+
+  if (false) {
+  }
+#define FULL_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)                   \
+  else if (instStr == #NAME) {                                                 \
+    readingResult.kind = SILInstructionKind::ID;                               \
+    read##ID(readingResult);                                                   \
+  }
+#include "swift/SIL/SILNodes.def"
+  else
+    llvm_unreachable("Unhandled SILNode");
+  readingResult.results = instResults;
+  
+  // If we couldn't read the instruction, reset the parser position for the old
+  // parser (which we will bail out to).
+  if (unsigned(readingResult.kind) == 0) {
+    backtrackToPosition(start);
+  }
+  
+  return readingResult;
+}
+
+//===----------------------------------------------------------------------===//
+// ReadSIL visitors
+//===----------------------------------------------------------------------===//
+
+} // namespace swift


### PR DESCRIPTION
Adds basic infastructure and visitors that will be used to implement the
new parser.

Adds three classes: ReadSIL, CheckSIL, EmitSIL. These are
used to read information from a source file, check that the information
is valid, and parse the information into sil instructions respectively.

SILParser has been updated to use ReadSIL as the parser and to use all
three classes to parse instructions when possible.

---

This is an unfortunately large patch. The forthcoming patches will hopefully be smaller and more focussed. Some of the implementation decisions were made to allow for incremental development and ease of transition between the two parsers. In order to start writing visitors I still need to implement two things:
* Type parsing needs to be moved into ReadSIL (and eventually refactored, maybe into its own parser). 
* Local values need to be stored in EmitSIL. `{get,set}LocalValue` will be updated to reach into `emitter`. 

---

This PR goes hand in hand with the design proposed in [the forum](https://forums.swift.org/t/changes-to-the-sil-parser). I expect I'll need to update this PR and rewrite much if not most of it. So, please don't hesitate to suggest design changes. 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
