### PR TITLE
[Incremental, IRGen] Create a new LLVMContext when creating IRGenModule

### DIFF
--- a/include/swift/AST/IRGenRequests.h
+++ b/include/swift/AST/IRGenRequests.h
@@ -49,7 +49,6 @@ struct IRGenDescriptor {
   StringRef ModuleName;
   const PrimarySpecificPaths &PSPs;
   StringRef PrivateDiscriminator;
-  llvm::LLVMContext &LLVMContext;
   ArrayRef<std::string> parallelOutputFilenames;
   llvm::GlobalVariable **outModuleHash;
   llvm::StringSet<> *LinkerDirectives;
@@ -73,7 +72,7 @@ public:
   forFile(const IRGenOptions &Opts, SourceFile &SF,
           std::unique_ptr<SILModule> &&SILMod, StringRef ModuleName,
           const PrimarySpecificPaths &PSPs, StringRef PrivateDiscriminator,
-          llvm::LLVMContext &LLVMContext, llvm::GlobalVariable **outModuleHash,
+          llvm::GlobalVariable **outModuleHash,
           llvm::StringSet<> *LinkerDirectives) {
     return IRGenDescriptor{Opts,
                            &SF,
@@ -81,7 +80,6 @@ public:
                            ModuleName,
                            PSPs,
                            PrivateDiscriminator,
-                           LLVMContext,
                            {},
                            outModuleHash,
                            LinkerDirectives};
@@ -91,7 +89,6 @@ public:
   forWholeModule(const IRGenOptions &Opts, swift::ModuleDecl *M,
                  std::unique_ptr<SILModule> &&SILMod, StringRef ModuleName,
                  const PrimarySpecificPaths &PSPs,
-                 llvm::LLVMContext &LLVMContext,
                  ArrayRef<std::string> parallelOutputFilenames,
                  llvm::GlobalVariable **outModuleHash,
                  llvm::StringSet<> *LinkerDirectives) {
@@ -101,7 +98,6 @@ public:
                            ModuleName,
                            PSPs,
                            "",
-                           LLVMContext,
                            parallelOutputFilenames,
                            outModuleHash,
                            LinkerDirectives};

--- a/include/swift/IRGen/IRGenPublic.h
+++ b/include/swift/IRGen/IRGenPublic.h
@@ -31,8 +31,7 @@ class IRGenModule;
 std::pair<IRGenerator *, IRGenModule *>
 createIRGenModule(SILModule *SILMod, StringRef OutputFilename,
                   StringRef MainInputFilenameForDebugInfo,
-                  StringRef PrivateDiscriminator,
-                  llvm::LLVMContext &LLVMContext);
+                  StringRef PrivateDiscriminator);
 
 /// Delete the IRGenModule and IRGenerator obtained by the above call.
 void deleteIRGenModule(std::pair<IRGenerator *, IRGenModule *> &Module);

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -234,7 +234,6 @@ namespace swift {
   performIRGeneration(const IRGenOptions &Opts, ModuleDecl *M,
                       std::unique_ptr<SILModule> SILMod,
                       StringRef ModuleName, const PrimarySpecificPaths &PSPs,
-                      llvm::LLVMContext &LLVMContext,
                       ArrayRef<std::string> parallelOutputFilenames,
                       llvm::GlobalVariable **outModuleHash = nullptr,
                       llvm::StringSet<> *LinkerDirectives = nullptr);
@@ -247,7 +246,6 @@ namespace swift {
                       std::unique_ptr<SILModule> SILMod,
                       StringRef ModuleName, const PrimarySpecificPaths &PSPs,
                       StringRef PrivateDiscriminator,
-                      llvm::LLVMContext &LLVMContext,
                       llvm::GlobalVariable **outModuleHash = nullptr,
                       llvm::StringSet<> *LinkerDirectives = nullptr);
 
@@ -289,9 +287,7 @@ namespace swift {
                    UnifiedStatsReporter *Stats);
 
   /// Dump YAML describing all fixed-size types imported from the given module.
-  bool performDumpTypeInfo(const IRGenOptions &Opts,
-                           SILModule &SILMod,
-                           llvm::LLVMContext &LLVMContext);
+  bool performDumpTypeInfo(const IRGenOptions &Opts, SILModule &SILMod);
 
   /// Creates a TargetMachine from the IRGen opts and AST Context.
   std::unique_ptr<llvm::TargetMachine>

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1384,18 +1384,15 @@ static void generateIR(const IRGenOptions &IRGenOpts,
                        llvm::GlobalVariable *&HashGlobal,
                        ArrayRef<std::string> parallelOutputFilenames,
                        llvm::StringSet<> &LinkerDirectives) {
-  // FIXME: We shouldn't need to use the global context here, but
-  // something is persisting across calls to performIRGeneration.
-  auto &LLVMContext = getGlobalLLVMContext();
   IRModule = MSF.is<SourceFile *>()
                  ? performIRGeneration(IRGenOpts, *MSF.get<SourceFile *>(),
                                        std::move(SM), OutputFilename, PSPs,
                                        MSF.get<SourceFile *>()->getPrivateDiscriminator().str(),
-                                       LLVMContext, &HashGlobal,
+                                       &HashGlobal,
                                        &LinkerDirectives)
                  : performIRGeneration(IRGenOpts, MSF.get<ModuleDecl *>(),
                                        std::move(SM), OutputFilename, PSPs,
-                                       LLVMContext, parallelOutputFilenames,
+                                       parallelOutputFilenames,
                                        &HashGlobal, &LinkerDirectives);
 }
 
@@ -1663,7 +1660,7 @@ static bool performCompileStepsPostSILGen(
     Stats->flushTracesAndProfiles();
 
   if (Action == FrontendOptions::ActionType::DumpTypeInfo)
-    return performDumpTypeInfo(IRGenOpts, *SM, getGlobalLLVMContext());
+    return performDumpTypeInfo(IRGenOpts, *SM);
 
   if (Action == FrontendOptions::ActionType::Immediate)
     return processCommandLineAndRunImmediately(

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1273,15 +1273,14 @@ public:
   /// The \p SF is the source file for which the llvm module is generated when
   /// doing multi-threaded whole-module compilation. Otherwise it is null.
   IRGenModule(IRGenerator &irgen, std::unique_ptr<llvm::TargetMachine> &&target,
-              SourceFile *SF, llvm::LLVMContext &LLVMContext,
+              SourceFile *SF,
               StringRef ModuleName, StringRef OutputFilename,
               StringRef MainInputFilenameForDebugInfo,
               StringRef PrivateDiscriminator);
 
   /// The constructor used when we just need an IRGenModule for type lowering.
-  IRGenModule(IRGenerator &irgen, std::unique_ptr<llvm::TargetMachine> &&target,
-              llvm::LLVMContext &LLVMContext)
-    : IRGenModule(irgen, std::move(target), /*SF=*/nullptr, LLVMContext,
+  IRGenModule(IRGenerator &irgen, std::unique_ptr<llvm::TargetMachine> &&target)
+    : IRGenModule(irgen, std::move(target), /*SF=*/nullptr,
                   "<fake module name>", "<fake output filename>",
                   "<fake main input filename>", "") {}
 

--- a/lib/IRGen/TypeLayoutDumper.cpp
+++ b/lib/IRGen/TypeLayoutDumper.cpp
@@ -152,15 +152,13 @@ void TypeLayoutDumper::write(ArrayRef<ModuleDecl *> AllModules,
   }
 }
 
-bool swift::performDumpTypeInfo(const IRGenOptions &Opts,
-                                SILModule &SILMod,
-                                llvm::LLVMContext &LLVMContext) {
+bool swift::performDumpTypeInfo(const IRGenOptions &Opts, SILModule &SILMod) {
   auto &Ctx = SILMod.getASTContext();
   assert(!Ctx.hadError());
   (void)Ctx;
 
   IRGenerator IRGen(Opts, SILMod);
-  IRGenModule IGM(IRGen, IRGen.createTargetMachine(), LLVMContext);
+  IRGenModule IGM(IRGen, IRGen.createTargetMachine());
 
   // We want to bypass resilience.
   LoweringModeScope scope(IGM, TypeConverter::Mode::CompletelyFragile);

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -891,11 +891,9 @@ private:
     DumpSource += Line;
 
     // IRGen the current line(s).
-    // FIXME: We shouldn't need to use the global context here, but
-    // something is persisting across calls to performIRGeneration.
     auto LineModule = performIRGeneration(
         IRGenOpts, M, std::move(sil), "REPLLine", PrimarySpecificPaths(),
-        getGlobalLLVMContext(), /*parallelOutputFilenames*/{});
+        /*parallelOutputFilenames*/{});
 
     if (CI.getASTContext().hadError())
       return false;

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -63,7 +63,6 @@ struct IRGenContext {
   SILOptions SILOpts;
   Lowering::TypeConverter TC;
   std::unique_ptr<SILModule> SILMod;
-  llvm::LLVMContext LLVMContext;
   irgen::IRGenerator IRGen;
   irgen::IRGenModule IGM;
 
@@ -73,7 +72,7 @@ private:
       TC(*module),
       SILMod(SILModule::createEmptyModule(module, TC, SILOpts)),
       IRGen(IROpts, *SILMod),
-      IGM(IRGen, IRGen.createTargetMachine(), LLVMContext) {}
+      IGM(IRGen, IRGen.createTargetMachine()) {}
 
   static IRGenOptions createIRGenOptions() {
     IRGenOptions IROpts;

--- a/test/multifile/batch-mode-llvmIRHash-consistency.swift
+++ b/test/multifile/batch-mode-llvmIRHash-consistency.swift
@@ -1,0 +1,22 @@
+// Ensure that the LLVMIR hash of the 2nd compilation in batch mode
+// is consistent no matter if the first one generates code or not.
+
+// RUN: %empty-directory(%t)
+// RUN: echo 'public enum E: Error {}' >%t/main.swift
+// RUN: echo >%t/other.swift
+// RUN: touch -t 201901010101 %t/*.swift
+
+// RUN: cd %t; %target-swift-frontend -c -g -enable-batch-mode -module-name main -primary-file ./main.swift -primary-file other.swift
+
+// RUN: cp %t/main{,-old}.o
+// RUN: cp %t/other{,-old}.o
+// RUN: touch %t/*.swift
+
+// RUN: cd %t; %target-swift-frontend -c -g -enable-batch-mode -module-name main -primary-file ./main.swift -primary-file other.swift
+
+// Ensure that code generation was not performed for other.swift
+
+// RUN: ls -t %t | %FileCheck %s
+
+// CHECK: other.swift
+// CHECK: other.o

--- a/tools/sil-llvm-gen/SILLLVMGen.cpp
+++ b/tools/sil-llvm-gen/SILLLVMGen.cpp
@@ -204,6 +204,6 @@ int main(int argc, char **argv) {
       performIRGeneration(Opts, CI.getMainModule(), CI.takeSILModule(),
                           CI.getMainModule()->getName().str(),
                           PSPs,
-                          getGlobalLLVMContext(), ArrayRef<std::string>());
+                          ArrayRef<std::string>());
   return CI.getASTContext().hadError();
 }

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -492,8 +492,7 @@ int main(int argc, char **argv) {
     {
       auto T = irgen::createIRGenModule(
           SILMod, Invocation.getOutputFilenameForAtMostOnePrimary(),
-          Invocation.getMainInputFilenameForDebugInfoForAtMostOnePrimary(),
-          "", getGlobalLLVMContext());
+          Invocation.getMainInputFilenameForDebugInfoForAtMostOnePrimary(), "");
       runCommandLineSelectedPasses(SILMod, T.second);
       irgen::deleteIRGenModule(T);
     }


### PR DESCRIPTION
Speed up incremental, batch mode compilation by restoring the code generation bypass optimization when in batch mode.

The compiler attempts to bypass code generation when the LLVM intermediate representation  (LLVMIR) is the same as it was when code was last generated. To do so, the compiler creates a hash of the LLVMIR before code generation, and arranges for that hash to be stored into the .o file. On a subsequent compilation, it reads the hash out of the .o file, and if it matches the computed hash, it can bypass code generation.

However, when using batch mode, this optimization fails on all but the first primary file in a batch. What happens is that the `heapallocsite` LLVM metadata kind gets added to the `LLVMContext`, which is a static global when the first file is compiled. The presence of this identifier alters the hash. Thus, when the second primary is compiled, the hash is different depending on whether code generation was skipped for the first primary in the batch.

This PR restores the code generation optimization by allocating a new `LLVMContext` for each primary, and indeed, for each creation of an `IRGenModule`, just as `performParallelRGeneration` has been doing. The creation now occurs in the constructor for `IRGenModule`. This new uniformity has enabled the removal of the `LLVMContext` parameter in many functions.

Thanks to @slavapestov  and @CodaFi for pointing me in this direction.
