### PR TITLE
[TypeChecker] `<unknown>` diagnostic location regarding `Codable` derived conformances 

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -711,7 +711,7 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current) const {
             current->diagnose(diag::invalid_redecl_init,
                               current->getFullName(),
                               otherInit->isMemberwiseInitializer());
-        } else {
+        } else if (!current->isImplicit() && !other->isImplicit()) {
           ctx.Diags.diagnoseWithNotes(
             current->diagnose(diag::invalid_redecl,
                               current->getFullName()), [&]() {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -652,7 +652,7 @@ static void checkRedeclaration(ASTContext &ctx, ValueDecl *current) {
             current->diagnose(diag::invalid_redecl_init,
                               current->getFullName(),
                               otherInit->isMemberwiseInitializer());
-        } else {
+        } else if (!current->isImplicit() && !other->isImplicit()) {
           ctx.Diags.diagnoseWithNotes(
             current->diagnose(diag::invalid_redecl,
                               current->getFullName()), [&]() {

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -61,7 +61,7 @@ func customHashable() {
 enum InvalidCustomHashable {
   case A, B
 
-  var hashValue: String { return "" } // expected-note {{previously declared here}}
+  var hashValue: String { return "" }
 }
 func ==(x: InvalidCustomHashable, y: InvalidCustomHashable) -> String {
   return ""

--- a/test/decl/protocol/special/coding/struct_codable_simple.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple.swift
@@ -29,3 +29,21 @@ let _ = SimpleStruct.encode(to:)
 // The synthesized CodingKeys type should not be accessible from outside the
 // struct.
 let _ = SimpleStruct.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}
+
+// rdar://problem/59655704 
+struct SR_12248_1: Codable { // expected-error {{type 'SR_12248_1' does not conform to protocol 'Encodable'}}
+  var x: Int // expected-note {{'x' previously declared here}}
+  var x: Int // expected-error {{invalid redeclaration of 'x'}}
+  // expected-note@-1 {{cannot automatically synthesize 'Encodable' because '<<error type>>' does not conform to 'Encodable'}}
+  // expected-note@-2 {{cannot automatically synthesize 'Encodable' because '<<error type>>' does not conform to 'Encodable'}}
+}
+
+struct SR_12248_2: Decodable { 
+  var x: Int // expected-note {{'x' previously declared here}}
+  var x: Int // expected-error {{invalid redeclaration of 'x'}}
+}
+
+struct SR_12248_3: Encodable { 
+  var x: Int // expected-note {{'x' previously declared here}}
+  var x: Int // expected-error {{invalid redeclaration of 'x'}}
+}

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -837,12 +837,8 @@ struct WrapperWithProjectedValue<T> {
 class TestInvalidRedeclaration {
   @WrapperWithProjectedValue var i = 17
   // expected-note@-1 {{'i' previously declared here}}
-  // expected-note@-2 {{'$i' previously declared here}}
-  // expected-note@-3 {{'_i' previously declared here}}
   @WrapperWithProjectedValue var i = 39
   // expected-error@-1 {{invalid redeclaration of 'i'}}
-  // expected-error@-2 {{invalid redeclaration of '$i'}}
-  // expected-error@-3 {{invalid redeclaration of '_i'}}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixing <unknown> diagnostic location regarding Codable derived conformances.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
rdar://problem/59655704
Resolves SR-12248.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
