### PR TITLE
FunctionSignatureOpts: fix a crash due to a missing argument declaration

### DIFF
--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -179,7 +179,8 @@ void ExistentialSpecializerCloner::cloneArguments(
         NewF.getLoweredType(NewF.mapTypeIntoContext(GenericParam));
     GenericSILType = GenericSILType.getCategoryType(
                                           ArgDesc.Arg->getType().getCategory());
-    auto *NewArg = ClonedEntryBB->createFunctionArgument(GenericSILType);
+    auto *NewArg =
+      ClonedEntryBB->createFunctionArgument(GenericSILType, ArgDesc.Decl);
     NewArg->setOwnershipKind(ValueOwnershipKind(
         NewF, GenericSILType, ArgDesc.Arg->getArgumentConvention()));
     // Determine the Conformances.

--- a/test/SILGen/opaque_result_type.swift
+++ b/test/SILGen/opaque_result_type.swift
@@ -169,7 +169,7 @@ public class D {
 
 // CHECK-LABEL: sil [ossa] @$s18opaque_result_type10tupleAsAnyQryF : $@convention(thin) () -> @out @_opaqueReturnTypeOf("$s18opaque_result_type10tupleAsAnyQryF", 0) 🦸 {
 public func tupleAsAny() -> some Any {
-// CHECK-NEXT: bb0(%0 : $*()):
+// CHECK:      bb0(%0 : $*()):
 // CHECK-NEXT:   %1 = tuple ()
 // CHECK-NEXT:   return %1 : $()
   return ()

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -98,7 +98,7 @@ func forceHasMemberwiseInit() {
 // CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers17HasMemberwiseInitVACyxGycfC : $@convention(method) <T where T : DefaultInit> (@thin HasMemberwiseInit<T>.Type) -> @out HasMemberwiseInit<T> {
 
 // Initialization of x
-// CHECK-NOT: return
+// CHECK-NOT: return %
 // CHECK: function_ref @$s17property_wrappers17HasMemberwiseInitV2_x33_{{.*}}7WrapperVySbGvpfi : $@convention(thin) <τ_0_0 where τ_0_0 : DefaultInit> () -> Wrapper<Bool>
 
 // Initialization of y

--- a/test/SILOptimizer/constant_propagation_stdlib.swift
+++ b/test/SILOptimizer/constant_propagation_stdlib.swift
@@ -11,7 +11,7 @@ public struct MyInt {
 // CHECK-ONONE:         return [[RESULT]]
 // CHECK-ONONE:       } // end sil function '$s27constant_propagation_stdlib15isConcrete_trueyBi1_AA5MyIntVF'
 // CHECK-O-LABEL:     sil @$s27constant_propagation_stdlib15isConcrete_trueyBi1_AA5MyIntVF : $@convention(thin) (MyInt) -> Builtin.Int1 {
-// CHECK-O-NEXT:      bb0(
+// CHECK-O:           bb0(
 // CHECK-O-NEXT:        [[RESULT:%.*]] = integer_literal $Builtin.Int1, -1
 // CHECK-O-NEXT:        return [[RESULT]]
 // CHECK-O-NEXT:      } // end sil function '$s27constant_propagation_stdlib15isConcrete_trueyBi1_AA5MyIntVF'
@@ -84,7 +84,7 @@ public func isConcrete_concrete_caller(_ x: MyInt) -> Builtin.Int1 {
 // CHECK-ONONE:         return [[RESULT]]
 // CHECK-ONONE:       } // end sil function '$s27constant_propagation_stdlib4main1xBi1__Bi1_Bi1_tAA5MyIntV_tF'
 // CHECK-O-LABEL:     sil @$s27constant_propagation_stdlib4main1xBi1__Bi1_Bi1_tAA5MyIntV_tF : $@convention(thin) (MyInt) -> (Builtin.Int1, Builtin.Int1, Builtin.Int1) {
-// CHECK-O-NEXT:      bb0(
+// CHECK-O:           bb0(
 // CHECK-O-NEXT:        [[VALUE:%.*]] = integer_literal $Builtin.Int1, -1
 // CHECK-O-NEXT:        [[RESULT:%.*]] = tuple ([[VALUE]] : $Builtin.Int1, [[VALUE]] : $Builtin.Int1, [[VALUE]] : $Builtin.Int1)
 // CHECK-O-NEXT:        return [[RESULT]]

--- a/test/SILOptimizer/functionsigopts_crash.swift
+++ b/test/SILOptimizer/functionsigopts_crash.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-frontend -module-name main -O -emit-sil -primary-file %s | %FileCheck %s
+
+protocol P {
+  func foo()
+}
+
+public struct Inner {
+  var x: Int
+  var y: Int
+}
+
+public struct S : P {
+  var i: Inner
+
+  func foo() {
+    print(i.x)
+  }
+}
+
+// Check that FSO does not crash due to a missing decl on the function argument.
+
+// Following specializations should be done:
+//   * FSO: existential to protocol constrained generic
+//   * generic specialization <S>
+//   * FSO: argument explosion 
+
+// CHECK-LABEL: sil shared [noinline] @$s4main6testityyAA1P_pFTf4e_nAA1SV_Tg5Tf4x_n : $@convention(thin) (Int) -> () { 
+// CHECK-NEXT: // %0 "p"
+@inline(never)
+func testit(_ p: P) {
+  p.foo()
+}
+
+public func callit(s: S) {
+  testit(s)
+}


### PR DESCRIPTION
The existential -> generic transformation in FSO didn't preserve the argument declaration.
This caused an assert to hit in a later FSO transformation.

Another change in this PR: SILPrinter: print block argument decl names in comments

rdar://problem/61206439
https://bugs.swift.org/browse/SR-12487