### PR TITLE
[SymbolGraph] Use isImplicitlyPrivate for extended types

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
@@ -107,8 +107,9 @@ bool SymbolGraphASTWalker::walkToDeclPre(Decl *D, CharSourceRange Range) {
   // potentially with generic requirements.
   if (const auto *Extension = dyn_cast<ExtensionDecl>(D)) {
     const auto *ExtendedNominal = Extension->getExtendedNominal();
+    auto ExtendedSG = getModuleSymbolGraph(ExtendedNominal);
     // Ignore effecively private decls.
-    if (ExtendedNominal->hasUnderscoredNaming()) {
+    if (ExtendedSG->isImplicitlyPrivate(ExtendedNominal)) {
       return false;
     }
 
@@ -119,8 +120,6 @@ bool SymbolGraphASTWalker::walkToDeclPre(Decl *D, CharSourceRange Range) {
     // If there are some protocol conformances on this extension, we'll
     // grab them for some new conformsTo relationships.
     if (!Extension->getInherited().empty()) {
-      auto ExtendedSG =
-          getModuleSymbolGraph(ExtendedNominal);
 
       // The symbol graph to use to record these relationships.
       SmallVector<const ProtocolDecl *, 4> Protocols;

--- a/test/SymbolGraph/Symbols/SkipsPublicUnderscore.swift
+++ b/test/SymbolGraph/Symbols/SkipsPublicUnderscore.swift
@@ -10,6 +10,7 @@ public protocol PublicProtocol {}
 public protocol _ProtocolShouldntAppear {}
 
 // CHECK-NOT: _ShouldntAppear
+
 public struct _ShouldntAppear: PublicProtocol, _ProtocolShouldntAppear {
   // Although these are public and not underscored,
   // they are inside an underscored type,
@@ -51,3 +52,11 @@ extension _ShouldntAppear {
     public var shouldntAppear: Int
   }
 }
+
+extension _ShouldntAppear.InnerShouldntAppear {
+  public struct ShouldntAppear {}
+}
+
+extension _ShouldntAppear.InnerShouldntAppear: Equatable {}
+
+// CHECK: "relationships": []


### PR DESCRIPTION
This was just using `hasUnderscoredNaming` before but this only checks the
leafmost type. When filtering extended types, it should continue to look up
through nesting types to see if they are also implicitly private.

rdar://61843516