### PR TITLE
[SymbolGraph] Don't use innermost context for swiftExtension

### DIFF
--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -287,7 +287,7 @@ void Symbol::serializeSwiftGenericMixin(llvm::json::OStream &OS) const {
 
 void Symbol::serializeSwiftExtensionMixin(llvm::json::OStream &OS) const {
   if (const auto *Extension
-          = dyn_cast_or_null<ExtensionDecl>(VD->getInnermostDeclContext())) {
+          = dyn_cast_or_null<ExtensionDecl>(VD->getDeclContext())) {
     ::serialize(Extension, OS);
   }
 }

--- a/test/SymbolGraph/Symbols/Mixins/Extension.swift
+++ b/test/SymbolGraph/Symbols/Mixins/Extension.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name Extension -emit-module-path %t/Extension.swiftmodule
+// RUN: %target-swift-symbolgraph-extract -module-name Extension -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/Extension.symbols.json
+
+public struct Outer<T> {
+  public var x: T
+  public init(x: T) {
+    self.x = x
+  } 
+}
+
+extension Outer where T == Int {
+  // This type's swiftExtension mixin should not include generic
+  // constraints regarding U.
+
+  // CHECK: swiftExtension
+  // CHECK: constraints
+  // CHECK: "kind": "sameType"
+  // CHECK: "lhs": "T"
+  // CHECK: "rhs": "Int"
+  public struct Inner<U: Sequence> {
+    public var x: U
+    public init(x: U) {
+      self.x = x
+    } 
+  }
+}


### PR DESCRIPTION
`getInnerMostContext` can return the same value if it is a type, but
`swiftExtension` should always look upward for an extension.

rdar://61746582