### PR TITLE
Don't build swift-syntax-parser-test with install rpath

### DIFF
--- a/tools/swift-syntax-parser-test/CMakeLists.txt
+++ b/tools/swift-syntax-parser-test/CMakeLists.txt
@@ -13,7 +13,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     INSTALL_RPATH @executable_path/../lib)
 elseif(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
   set_target_properties(swift-syntax-parser-test PROPERTIES
-    BUILD_WITH_INSTALL_RPATH YES
     INSTALL_RPATH ${SWIFT_LIBRARY_OUTPUT_INTDIR})
 endif()
 target_compile_options(swift-syntax-parser-test PRIVATE


### PR DESCRIPTION
This causes it not to find `libBlocksRuntime.so` when running the tests

This did not surface on CI, because libBlocksRuntime is installed there.