### PR TITLE
[build] Set language flag for C++ on OpenBSD.

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -29,6 +29,8 @@ set(SWIFT_RUNTIME_CORE_LINK_FLAGS "${SWIFT_RUNTIME_LINK_FLAGS}")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "CYGWIN")
   list(APPEND SWIFT_RUNTIME_CORE_CXX_FLAGS "-mcmodel=large")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+  list(APPEND SWIFT_RUNTIME_CORE_CXX_FLAGS "-xc++")
 endif()
 
 # C++ code in the runtime and standard library should generally avoid


### PR DESCRIPTION
See #12510 and SR-3635 for some context; OpenBSD exhibits the same
problem listed here. Without this, the build fails with an undefined
symbol error for __gnustep_objcxx_personality_v0. Per commentary on the
aforementioned PR, forcing the language to be interpreted as C++ solves
the problem.

There might be something different we can do here to diagnose and fix
this, but this is the simplest solution to get the build working again,
and enabling this for all C++ files should be tautologous and therefore
harmless.