### PR TITLE
AST: Fix accessibility checking in opaque type archetype substitution logic [5.2]

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2828,10 +2828,14 @@ static bool canSubstituteTypeInto(Type ty, const DeclContext *dc,
         nominal->getDeclContext()->getParentSourceFile() ==
         dc->getParentSourceFile())
       return true;
+
     return nominal->getEffectiveAccess() > AccessLevel::FilePrivate;
 
   case OpaqueSubstitutionKind::SubstituteNonResilientModule:
     // Can't access types that are not public from a different module.
+    if (dc->getParentModule() == nominal->getDeclContext()->getParentModule())
+      return true;
+
     return nominal->getEffectiveAccess() > AccessLevel::Internal;
   }
 }

--- a/test/SILGen/Inputs/opaque_result_type_fragile_other.swift
+++ b/test/SILGen/Inputs/opaque_result_type_fragile_other.swift
@@ -1,0 +1,29 @@
+public protocol View {}
+
+struct InternalView : View {}
+struct InternalGenericView<T> : View {}
+
+public struct PublicView : View {}
+public struct PublicGenericView<T> : View {}
+
+extension View {
+  public func passThrough() -> some View {
+    return self
+  }
+
+  public func wrapWithInternalView() -> some View {
+    return InternalView()
+  }
+
+  public func wrapWithInternalGenericView() -> some View {
+    return InternalGenericView<Self>()
+  }
+
+  public func wrapWithPublicView() -> some View {
+    return PublicView()
+  }
+
+  public func wrapWithPublicGenericView() -> some View {
+    return PublicGenericView<Self>()
+  }
+}

--- a/test/SILGen/opaque_result_type_fragile.swift
+++ b/test/SILGen/opaque_result_type_fragile.swift
@@ -1,0 +1,46 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -disable-availability-checking -emit-module %S/Inputs/opaque_result_type_fragile_other.swift -emit-module-path %t/opaque_result_type_fragile_other.swiftmodule
+// RUN: %target-swift-frontend -disable-availability-checking -emit-silgen -I%t %s | %FileCheck %s
+
+import opaque_result_type_fragile_other
+
+struct InternalView: View {}
+public struct PublicView: View {}
+
+public func testInternalView() {
+  let v = InternalView()
+
+  // CHECK: function_ref @$s32opaque_result_type_fragile_other4ViewPAAE11passThroughQryF : $@convention(method) <τ_0_0 where τ_0_0 : View> (@in_guaranteed τ_0_0) -> @out τ_0_0
+  _ = v.passThrough()
+
+  // CHECK: function_ref @$s32opaque_result_type_fragile_other4ViewPAAE016wrapWithInternalF0QryF : $@convention(method) <τ_0_0 where τ_0_0 : View> (@in_guaranteed τ_0_0) -> @out @_opaqueReturnTypeOf("$s32opaque_result_type_fragile_other4ViewPAAE016wrapWithInternalF0QryF", 0) 🦸<τ_0_0>
+  _ = v.wrapWithInternalView()
+
+  // CHECK: function_ref @$s32opaque_result_type_fragile_other4ViewPAAE023wrapWithInternalGenericF0QryF : $@convention(method) <τ_0_0 where τ_0_0 : View> (@in_guaranteed τ_0_0) -> @out @_opaqueReturnTypeOf("$s32opaque_result_type_fragile_other4ViewPAAE023wrapWithInternalGenericF0QryF", 0) 🦸<τ_0_0>
+  _ = v.wrapWithInternalGenericView()
+
+  // CHECK: function_ref @$s32opaque_result_type_fragile_other4ViewPAAE014wrapWithPublicF0QryF : $@convention(method) <τ_0_0 where τ_0_0 : View> (@in_guaranteed τ_0_0) -> @out PublicView
+  _ = v.wrapWithPublicView()
+
+  //CHECK: function_ref @$s32opaque_result_type_fragile_other4ViewPAAE021wrapWithPublicGenericF0QryF : $@convention(method) <τ_0_0 where τ_0_0 : View> (@in_guaranteed τ_0_0) -> @out PublicGenericView<τ_0_0>
+  _ = v.wrapWithPublicGenericView()
+}
+
+public func testPublicView() {
+  let v = PublicView()
+
+  // CHECK: function_ref @$s32opaque_result_type_fragile_other4ViewPAAE11passThroughQryF : $@convention(method) <τ_0_0 where τ_0_0 : View> (@in_guaranteed τ_0_0) -> @out τ_0_0
+  _ = v.passThrough()
+
+  // CHECK: function_ref @$s32opaque_result_type_fragile_other4ViewPAAE016wrapWithInternalF0QryF : $@convention(method) <τ_0_0 where τ_0_0 : View> (@in_guaranteed τ_0_0) -> @out @_opaqueReturnTypeOf("$s32opaque_result_type_fragile_other4ViewPAAE016wrapWithInternalF0QryF", 0) 🦸<τ_0_0>
+  _ = v.wrapWithInternalView()
+
+  // CHECK: function_ref @$s32opaque_result_type_fragile_other4ViewPAAE023wrapWithInternalGenericF0QryF : $@convention(method) <τ_0_0 where τ_0_0 : View> (@in_guaranteed τ_0_0) -> @out @_opaqueReturnTypeOf("$s32opaque_result_type_fragile_other4ViewPAAE023wrapWithInternalGenericF0QryF", 0) 🦸<τ_0_0>
+  _ = v.wrapWithInternalGenericView()
+
+  // CHECK: function_ref @$s32opaque_result_type_fragile_other4ViewPAAE014wrapWithPublicF0QryF : $@convention(method) <τ_0_0 where τ_0_0 : View> (@in_guaranteed τ_0_0) -> @out PublicView
+  _ = v.wrapWithPublicView()
+
+  //CHECK: function_ref @$s32opaque_result_type_fragile_other4ViewPAAE021wrapWithPublicGenericF0QryF : $@convention(method) <τ_0_0 where τ_0_0 : View> (@in_guaranteed τ_0_0) -> @out PublicGenericView<τ_0_0>
+  _ = v.wrapWithPublicGenericView()
+}

--- a/test/SILOptimizer/cast_folding.swift
+++ b/test/SILOptimizer/cast_folding.swift
@@ -1,7 +1,5 @@
-// RUN: %target-swift-frontend -disable-availability-checking -O -emit-sil %s | %FileCheck %s
-// RUN: %target-swift-frontend -disable-availability-checking -Onone -emit-sil %s | %FileCheck %s --check-prefix=MANDATORY
-// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xllvm -sil-disable-pass=PerfInliner -enable-ownership-stripping-after-serialization -disable-availability-checking -O -emit-sil %s | %FileCheck %s
-// RUN: %target-swift-frontend -enable-ownership-stripping-after-serialization -disable-availability-checking -Onone -emit-sil %s | %FileCheck %s --check-prefix=MANDATORY
+// RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xllvm -sil-disable-pass=PerfInliner -enable-ownership-stripping-after-serialization -O -emit-sil %s | %FileCheck %s
 
 // We want to check two things here:
 // - Correctness
@@ -1067,25 +1065,6 @@ public func testCastToPForOptionalSuccess() -> Bool {
 public func testCastToPForOptionalFailure() -> Bool {
   let t: Int = 42
   return testCastToPForOptional(t)
-}
-
-struct Underlying : P {
-}
-
-public func returnOpaque() -> some P {
-  return Underlying()
-}
-
-// MANDATORY-LABEL: sil{{.*}} @$s12cast_folding23testCastOpaqueArchetypeyyF
-// MANDATORY:   [[O:%.*]] = alloc_stack $@_opaqueReturnTypeOf("$s12cast_folding12returnOpaqueQryF", 0)
-// MANDATORY:   [[F:%.*]] = function_ref @$s12cast_folding12returnOpaqueQryF
-// MANDATORY:   apply [[F]]([[O]])
-// MANDATORY:   [[U:%.*]] = alloc_stack $Underlying
-// MANDATORY:   unconditional_checked_cast_addr @_opaqueReturnTypeOf{{.*}}in [[O]] : $*@_opaqueReturnTypeOf{{.*}}to Underlying in [[U]] : $*Underlying
-// MANDATORY:   load [[U]] : $*Underlying
-@inlinable
-public func testCastOpaqueArchetype() {
-  let o = returnOpaque() as! Underlying
 }
 
 print("test0=\(test0())")

--- a/test/SILOptimizer/cast_folding_opaque.swift
+++ b/test/SILOptimizer/cast_folding_opaque.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -enable-library-evolution -disable-availability-checking -O -emit-sil %s
+// RUN: %target-swift-frontend -enable-library-evolution -disable-availability-checking -Onone -emit-sil %s | %FileCheck %s
+
+public protocol P {}
+
+public struct Underlying : P {
+}
+
+public func returnOpaque() -> some P {
+  return Underlying()
+}
+
+// CHECK-LABEL: sil [serialized] @$s19cast_folding_opaque23testCastOpaqueArchetypeAA10UnderlyingVyF
+// CHECK:   [[O:%.*]] = alloc_stack $@_opaqueReturnTypeOf("$s19cast_folding_opaque12returnOpaqueQryF", 0)
+// CHECK:   [[F:%.*]] = function_ref @$s19cast_folding_opaque12returnOpaqueQryF
+// CHECK:   apply [[F]]([[O]])
+// CHECK:   unconditional_checked_cast_addr @_opaqueReturnTypeOf{{.*}}in [[O]] : $*@_opaqueReturnTypeOf{{.*}}to Underlying in %0 : $*Underlying
+@inlinable
+public func testCastOpaqueArchetype() -> Underlying {
+  return returnOpaque() as! Underlying
+}


### PR DESCRIPTION
We were failing to replace opaque types with their underlying type
upon encountering an internal type from the current module. This
could happen when the internal type appeared in generic substitutions,
for example when calling a protocol extension method.

Fixes <rdar://problem/60951353>.