### PR TITLE
[Driver/Frontend] Thread the target SDK version through to the IR.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -75,6 +75,9 @@ namespace swift {
     /// performed.
     llvm::Optional<llvm::Triple> TargetVariant;
 
+    /// The SDK version, if known.
+    Optional<llvm::VersionTuple> SDKVersion;
+
     ///
     /// Language features
     ///

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -78,6 +78,9 @@ namespace swift {
     /// The SDK version, if known.
     Optional<llvm::VersionTuple> SDKVersion;
 
+    /// The target variant SDK version, if known.
+    Optional<llvm::VersionTuple> VariantSDKVersion;
+
     ///
     /// Language features
     ///

--- a/include/swift/Driver/ToolChain.h
+++ b/include/swift/Driver/ToolChain.h
@@ -136,6 +136,13 @@ protected:
           ExtraEnvironment(std::move(extraEnv)) {}
   };
 
+  /// Handle arguments common to all invocations of the frontend (compilation,
+  /// module-merging, LLDB's REPL, etc).
+  virtual void addCommonFrontendArgs(const OutputInfo &OI,
+                                     const CommandOutput &output,
+                                     const llvm::opt::ArgList &inputArgs,
+                                     llvm::opt::ArgStringList &arguments) const;
+
   virtual InvocationInfo constructInvocation(const CompileJobAction &job,
                                              const JobContext &context) const;
   virtual InvocationInfo constructInvocation(const InterpretJobAction &job,

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -702,4 +702,7 @@ def disable_interface_lockfile : Flag<["-"], "disable-interface-lock">,
 def bridging_header_directory_for_print: Separate<["-"], "bridging-header-directory-for-print">, MetaVarName<"<path>">,
     HelpText<"Directory for bridging header to be printed in compatibility header">;
 
+def target_sdk_version : Separate<["-"], "target-sdk-version">,
+  HelpText<"The version of target SDK used for compilation">;
+
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -705,4 +705,7 @@ def bridging_header_directory_for_print: Separate<["-"], "bridging-header-direct
 def target_sdk_version : Separate<["-"], "target-sdk-version">,
   HelpText<"The version of target SDK used for compilation">;
 
+def target_variant_sdk_version : Separate<["-"], "target-variant-sdk-version">,
+  HelpText<"The version of target variant SDK used for compilation">;
+
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -706,6 +706,12 @@ addCommonInvocationArguments(std::vector<std::string> &invocationArgStrs,
   invocationArgStrs.push_back("-target");
   invocationArgStrs.push_back(triple.str());
 
+  if (ctx.LangOpts.SDKVersion) {
+    invocationArgStrs.push_back("-Xclang");
+    invocationArgStrs.push_back(
+        "-target-sdk-version=" + ctx.LangOpts.SDKVersion->getAsString());
+  }
+
   invocationArgStrs.push_back(ImporterImpl::moduleImportBufferName);
 
   if (ctx.LangOpts.EnableAppExtensionRestrictions) {

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -634,6 +634,14 @@ void toolchains::Darwin::addCommonFrontendArgs(
     arguments.push_back("-target-sdk-version");
     arguments.push_back(inputArgs.MakeArgString(sdkVersion->getAsString()));
   }
+
+  if (auto targetVariant = getTargetVariant()) {
+    if (auto variantSDKVersion = getTargetSDKVersion(*targetVariant)) {
+      arguments.push_back("-target-variant-sdk-version");
+      arguments.push_back(
+          inputArgs.MakeArgString(variantSDKVersion->getAsString()));
+    }
+  }
 }
 
 ToolChain::InvocationInfo

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -518,6 +518,26 @@ static Optional<llvm::VersionTuple> remapVersion(
   return None;
 }
 
+Optional<llvm::VersionTuple>
+toolchains::Darwin::getTargetSDKVersion(const llvm::Triple &triple) const {
+  if (!SDKInfo)
+    return None;
+
+  // Retrieve the SDK version.
+  auto SDKVersion = SDKInfo->getVersion();
+
+  // For the Mac Catalyst environment, we have a macOS SDK with a macOS
+  // SDK version. Map that to the corresponding iOS version number to pass
+  // down to the linker.
+  if (tripleIsMacCatalystEnvironment(triple)) {
+    return remapVersion(
+        SDKInfo->getVersionMap().MacOS2iOSMacMapping, SDKVersion)
+          .getValueOr(llvm::VersionTuple(0, 0, 0));
+  }
+
+  return SDKVersion;
+}
+
 void
 toolchains::Darwin::addDeploymentTargetArgs(ArgStringList &Arguments,
                                             const JobContext &context) const {
@@ -584,23 +604,10 @@ toolchains::Darwin::addDeploymentTargetArgs(ArgStringList &Arguments,
 
     // Compute the SDK version.
     unsigned sdkMajor = 0, sdkMinor = 0, sdkMicro = 0;
-    if (SDKInfo) {
-      // Retrieve the SDK version.
-      auto SDKVersion = SDKInfo->getVersion();
-
-      // For the Mac Catalyst environment, we have a macOS SDK with a macOS
-      // SDK version. Map that to the corresponding iOS version number to pass
-      // down to the linker.
-      if (tripleIsMacCatalystEnvironment(triple)) {
-        SDKVersion = remapVersion(
-            SDKInfo->getVersionMap().MacOS2iOSMacMapping, SDKVersion)
-              .getValueOr(llvm::VersionTuple(0, 0, 0));
-      }
-
-      // Extract the version information.
-      sdkMajor = SDKVersion.getMajor();
-      sdkMinor = SDKVersion.getMinor().getValueOr(0);
-      sdkMicro = SDKVersion.getSubminor().getValueOr(0);
+    if (auto sdkVersion = getTargetSDKVersion(triple)) {
+      sdkMajor = sdkVersion->getMajor();
+      sdkMinor = sdkVersion->getMinor().getValueOr(0);
+      sdkMicro = sdkVersion->getSubminor().getValueOr(0);
     }
 
     Arguments.push_back("-platform_version");
@@ -614,6 +621,18 @@ toolchains::Darwin::addDeploymentTargetArgs(ArgStringList &Arguments,
   if (auto targetVariant = getTargetVariant()) {
     assert(triplesAreValidForZippering(getTriple(), *targetVariant));
     addPlatformVersionArg(*targetVariant);
+  }
+}
+
+void toolchains::Darwin::addCommonFrontendArgs(
+    const OutputInfo &OI, const CommandOutput &output,
+    const llvm::opt::ArgList &inputArgs,
+    llvm::opt::ArgStringList &arguments) const {
+  ToolChain::addCommonFrontendArgs(OI, output, inputArgs, arguments);
+
+  if (auto sdkVersion = getTargetSDKVersion(getTriple())) {
+    arguments.push_back("-target-sdk-version");
+    arguments.push_back(inputArgs.MakeArgString(sdkVersion->getAsString()));
   }
 }
 
@@ -860,9 +879,8 @@ toolchains::Darwin::validateArguments(DiagnosticEngine &diags,
 void
 toolchains::Darwin::validateOutputInfo(DiagnosticEngine &diags,
                                        const OutputInfo &outputInfo) const {
-  // If we are linking and have been provided with an SDK, go read the SDK
-  // information.
-  if (outputInfo.shouldLink() && !outputInfo.SDKPath.empty()) {
+  // If we have been provided with an SDK, go read the SDK information.
+  if (!outputInfo.SDKPath.empty()) {
     auto SDKInfoOrErr = clang::driver::parseDarwinSDKInfo(
         *llvm::vfs::getRealFileSystem(), outputInfo.SDKPath);
     if (SDKInfoOrErr) {

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -127,14 +127,10 @@ static bool addOutputsOfType(ArgStringList &Arguments,
   return Added;
 }
 
-/// Handle arguments common to all invocations of the frontend (compilation,
-/// module-merging, LLDB's REPL, etc).
-static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
-                                  const CommandOutput &output,
-                                  const ArgList &inputArgs,
-                                  ArgStringList &arguments) {
-  const llvm::Triple &Triple = TC.getTriple();
-
+void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
+                                      const CommandOutput &output,
+                                      const ArgList &inputArgs,
+                                      ArgStringList &arguments) const {
   // Only pass -target to the REPL or immediate modes if it was explicitly
   // specified on the command line.
   switch (OI.CompilerMode) {
@@ -375,8 +371,7 @@ ToolChain::constructInvocation(const CompileJobAction &job,
   if (context.Args.hasArg(options::OPT_parse_stdlib))
     Arguments.push_back("-disable-objc-attr-requires-foundation-module");
 
-  addCommonFrontendArgs(*this, context.OI, context.Output, context.Args,
-                        Arguments);
+  addCommonFrontendArgs(context.OI, context.Output, context.Args, Arguments);
   addRuntimeLibraryFlags(context.OI, Arguments);
 
   // Pass along an -import-objc-header arg, replacing the argument with the name
@@ -766,8 +761,7 @@ ToolChain::constructInvocation(const InterpretJobAction &job,
   if (context.Args.hasArg(options::OPT_parse_stdlib))
     Arguments.push_back("-disable-objc-attr-requires-foundation-module");
 
-  addCommonFrontendArgs(*this, context.OI, context.Output, context.Args,
-                        Arguments);
+  addCommonFrontendArgs(context.OI, context.Output, context.Args, Arguments);
   addRuntimeLibraryFlags(context.OI, Arguments);
 
   context.Args.AddLastArg(Arguments, options::OPT_import_objc_header);
@@ -986,8 +980,7 @@ ToolChain::constructInvocation(const MergeModuleJobAction &job,
   Arguments.push_back("-disable-diagnostic-passes");
   Arguments.push_back("-disable-sil-perf-optzns");
 
-  addCommonFrontendArgs(*this, context.OI, context.Output, context.Args,
-                        Arguments);
+  addCommonFrontendArgs(context.OI, context.Output, context.Args, Arguments);
   addRuntimeLibraryFlags(context.OI, Arguments);
 
   addOutputsOfType(Arguments, context.Output, context.Args,
@@ -1080,8 +1073,7 @@ ToolChain::constructInvocation(const REPLJobAction &job,
   for (auto &s : getDriver().getSwiftProgramArgs())
     FrontendArgs.push_back(s.c_str());
 
-  addCommonFrontendArgs(*this, context.OI, context.Output, context.Args,
-                        FrontendArgs);
+  addCommonFrontendArgs(context.OI, context.Output, context.Args, FrontendArgs);
   addRuntimeLibraryFlags(context.OI, FrontendArgs);
 
   context.Args.AddLastArg(FrontendArgs, options::OPT_import_objc_header);
@@ -1166,8 +1158,7 @@ ToolChain::constructInvocation(const GeneratePCHJobAction &job,
     Arguments.push_back(s.c_str());
   Arguments.push_back("-frontend");
 
-  addCommonFrontendArgs(*this, context.OI, context.Output, context.Args,
-                        Arguments);
+  addCommonFrontendArgs(context.OI, context.Output, context.Args, Arguments);
   addRuntimeLibraryFlags(context.OI, Arguments);
 
   addOutputsOfType(Arguments, context.Output, context.Args,

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -48,6 +48,11 @@ protected:
   void addDeploymentTargetArgs(llvm::opt::ArgStringList &Arguments,
                                const JobContext &context) const;
 
+  void addCommonFrontendArgs(
+      const OutputInfo &OI, const CommandOutput &output,
+      const llvm::opt::ArgList &inputArgs,
+      llvm::opt::ArgStringList &arguments) const override;
+
   InvocationInfo constructInvocation(const InterpretJobAction &job,
                                      const JobContext &context) const override;
   InvocationInfo constructInvocation(const DynamicLinkJobAction &job,
@@ -65,6 +70,10 @@ protected:
   std::string findProgramRelativeToSwiftImpl(StringRef name) const override;
 
   bool shouldStoreInvocationInDebugInfo() const override;
+
+  /// Retrieve the target SDK version for the given target triple.
+  Optional<llvm::VersionTuple>
+  getTargetSDKVersion(const llvm::Triple &triple) const ;
 
   /// Information about the SDK that the application is being built against.
   /// This information is only used by the linker, so it is only populated

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -594,6 +594,18 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Diags.diagnose(SourceLoc(), diag::error_unsupported_target_os, TargetArgOS);
   }
 
+  // Parse the SDK version.
+  if (Arg *A = Args.getLastArg(options::OPT_target_sdk_version)) {
+    auto vers = version::Version::parseVersionString(
+      A->getValue(), SourceLoc(), &Diags);
+    if (vers.hasValue()) {
+      Opts.SDKVersion = *vers;
+    } else {
+      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                     A->getAsString(Args), A->getValue());
+    }
+  }
+
   return HadError || UnsupportedOS || UnsupportedArch;
 }
 
@@ -1434,6 +1446,7 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Opts.AutolinkRuntimeCompatibilityDynamicReplacementLibraryVersion =
         getRuntimeCompatVersion();
   }
+
   return false;
 }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -606,6 +606,18 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
   }
 
+  // Parse the target variant SDK version.
+  if (Arg *A = Args.getLastArg(options::OPT_target_variant_sdk_version)) {
+    auto vers = version::Version::parseVersionString(
+      A->getValue(), SourceLoc(), &Diags);
+    if (vers.hasValue()) {
+      Opts.VariantSDKVersion = *vers;
+    } else {
+      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                     A->getAsString(Args), A->getValue());
+    }
+  }
+
   return HadError || UnsupportedOS || UnsupportedArch;
 }
 

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -890,6 +890,13 @@ static void initLLVMModule(const IRGenModule &IGM, ModuleDecl &M) {
   
   Module->setTargetTriple(IGM.Triple.str());
 
+  if (IGM.Context.LangOpts.SDKVersion) {
+    if (Module->getSDKVersion().empty())
+      Module->setSDKVersion(*IGM.Context.LangOpts.SDKVersion);
+    else
+      assert(Module->getSDKVersion() == *IGM.Context.LangOpts.SDKVersion);
+  }
+
   // Set the module's string representation.
   Module->setDataLayout(IGM.DataLayout.getStringRepresentation());
 

--- a/test/Driver/frontend.swift
+++ b/test/Driver/frontend.swift
@@ -1,0 +1,4 @@
+// RUN: %swiftc_driver %s -### 2>&1 | %FileCheck %s
+
+// CHECK: swift-frontend
+

--- a/test/Driver/frontend.swift
+++ b/test/Driver/frontend.swift
@@ -1,4 +1,0 @@
-// RUN: %swiftc_driver %s -### 2>&1 | %FileCheck %s
-
-// CHECK: swift-frontend
-

--- a/test/Driver/macabi-environment.swift
+++ b/test/Driver/macabi-environment.swift
@@ -102,14 +102,20 @@
 // SDK version information.
 
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.0-macabi -sdk %S/Inputs/MacOSX10.15.versioned.sdk %s 2>&1 | %FileCheck -check-prefix MACOS_10_15_ZIPPERED %s
+// MACOS_10_15_ZIPPERED: -target-sdk-version 10.15
+// MACOS_10_15_ZIPPERED: -target-variant-sdk-version 13.1
 // MACOS_10_15_ZIPPERED: -platform_version macos 10.14.0 10.15.0
 // MACOS_10_15_ZIPPERED: -platform_version mac-catalyst 13.0.0 13.1.0
 
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.0-macabi -sdk %S/Inputs/MacOSX10.15.4.versioned.sdk %s 2>&1 | %FileCheck -check-prefix MACOS_10_15_4_ZIPPERED %s
+// MACOS_10_15_4_ZIPPERED: -target-sdk-version 10.15.4
+// MACOS_10_15_4_ZIPPERED: -target-variant-sdk-version 13.4
 // MACOS_10_15_4_ZIPPERED: -platform_version macos 10.14.0 10.15.4
 // MACOS_10_15_4_ZIPPERED: -platform_version mac-catalyst 13.0.0 13.4.0
 
 // RUN: %swiftc_driver -driver-print-jobs -target-variant x86_64-apple-macosx10.14 -target x86_64-apple-ios13.0-macabi -sdk %S/Inputs/MacOSX10.15.4.versioned.sdk %s 2>&1 | %FileCheck -check-prefix MACOS_10_15_4_REVERSE_ZIPPERED %s
+// MACOS_10_15_4_REVERSE_ZIPPERED: -target-sdk-version 13.4
+// MACOS_10_15_4_REVERSE_ZIPPERED: -target-variant-sdk-version 10.15.4
 // MACOS_10_15_4_REVERSE_ZIPPERED: -platform_version mac-catalyst 13.0.0 13.4.0
 // MACOS_10_15_4_REVERSE_ZIPPERED: -platform_version macos 10.14.0 10.15.4
 

--- a/test/Driver/options-repl-darwin.swift
+++ b/test/Driver/options-repl-darwin.swift
@@ -28,5 +28,5 @@
 
 // LLDB: lldb{{"?}} "--repl=
 // LLDB-NOT: -module-name
-// LLDB-NOT: -target
+// LLDB-NOT: -target{{ }}
 // LLDB: "

--- a/test/Driver/sdk-version.swift
+++ b/test/Driver/sdk-version.swift
@@ -1,0 +1,8 @@
+// Check reading the SDKSettings.json from an SDK
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -sdk %S/Inputs/MacOSX10.15.versioned.sdk %s 2>&1 | %FileCheck -check-prefix MACOS_10_15 %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -sdk %S/Inputs/MacOSX10.15.4.versioned.sdk %s 2>&1 | %FileCheck -check-prefix MACOS_10_15_4 %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -sdk %S/Inputs/MacOSX10.15.sdk %s 2>&1 | %FileCheck -check-prefix MACOS_UNVERSIONED %s
+
+// MACOS_10_15: -target-sdk-version 10.15
+// MACOS_10_15_4: -target-sdk-version 10.15.4
+// MACOS_UNVERSIONED-NOT: -target-sdk-version

--- a/test/IRGen/macosx-sdk-version.swift
+++ b/test/IRGen/macosx-sdk-version.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend %s -target x86_64-apple-macosx10.14 -target-sdk-version 10.15.4 -emit-ir | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+public func test() { }
+
+// CHECK: "SDK Version", [3 x i32] [i32 10, i32 15, i32 4]


### PR DESCRIPTION
Teach the driver to pass the SDK version it computes (from the SDK
settings JSON in a Darwin-based platform's SDK) down into the frontend.
The frontend then sets that SDK version in the LLVM module, which
eventually makes its way into the Mach-O file.

Last part of rdar://problem/60332732.