### PR TITLE
[build-script-impl] Allow cross-compiling the host toolchain for Android

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -917,7 +917,7 @@ function false_true() {
 CROSS_COMPILE_HOSTS=($CROSS_COMPILE_HOSTS)
 for t in "${CROSS_COMPILE_HOSTS[@]}"; do
     case ${t} in
-        iphone* | appletv* | watch* | linux-armv6 | linux-armv7 )
+        iphone* | appletv* | watch* | linux-armv6 | linux-armv7 | android-* )
             ;;
         *)
             echo "Unknown host to cross-compile for: ${t}"


### PR DESCRIPTION
This was needed in order [to cross-compile the Swift compiler for Android AArch64](https://github.com/termux/termux-packages/blob/master/packages/swift/swift-build-script.patch#L56), which is why it is now available on any Android AArch64 device running 7.0 Nougat or later. Simply install [the Termux app](https://termux.com/) and run `pkg install swift` and you have a working Swift 5.2.1 compiler. I ran the Swift validation suite with this cross-compiled compiler and 90% of the tests passed, with the remaining failing mostly because they were missing host test binaries like `sourcekitd-test`.

@drexin, one last tiny Android patch extracted from my Termux packaging scripts that should be safe to merge.