### PR TITLE
RedundantPhiElimination: exclude allocation instructions.

### DIFF
--- a/lib/SILOptimizer/Transforms/RedundantPhiElimination.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantPhiElimination.cpp
@@ -175,6 +175,12 @@ bool RedundantPhiEliminationPass::valuesAreEqual(SILValue val1, SILValue val2) {
       if (inst1->getMemoryBehavior() != SILInstruction::MemoryBehavior::None)
         return false;
 
+      // Allocation instructions are defined to have no side-effects.
+      // Two allocations (even if the instruction look the same) don't define
+      // the same value.
+      if (isa<AllocationInst>(inst1))
+        return false;
+
       auto *inst2 = cast<SingleValueInstruction>(val2);
 
       // Compare the operands by putting them on the worklist.

--- a/test/SILOptimizer/redundant_phi_elimination.sil
+++ b/test/SILOptimizer/redundant_phi_elimination.sil
@@ -5,6 +5,8 @@ sil_stage canonical
 import Builtin
 import Swift
 
+class X {}
+
 // CHECK-LABEL: sil @test_simple
 // CHECK: bb1:
 // CHECK:   br bb3(%0 : $Builtin.Int64)
@@ -153,3 +155,21 @@ bb3:
   %r = tuple ()
   return %r : $()
 }
+
+// CHECK-LABEL: sil @test_allocation_inst
+// CHECK:   alloc_ref
+// CHECK:   alloc_ref
+// CHECK: bb1([[ARG1:%[0-9]+]] : $X, [[ARG2:%[0-9]+]] : $X):
+// CHECK:   tuple ([[ARG1]] : $X, [[ARG2]] : $X)
+// CHECK: } // end sil function 'test_allocation_inst'
+sil @test_allocation_inst : $@convention(thin) () -> (X, X) {
+bb0:
+  %1 = alloc_ref $X
+  %2 = alloc_ref $X
+  br bb1(%1 : $X, %2 : $X)
+
+bb1(%3 : $X, %4 : $X):
+  %r = tuple (%3 : $X, %4 : $X)
+  return %r : $(X, X)
+}
+


### PR DESCRIPTION
Treating allocation instructions as the same value caused runtime crashes.

https://bugs.swift.org/browse/SR-12606

rdar://problem/61874205