### PR TITLE
test: Explicitly work with binary data in PathSanitizingFileCheck

### DIFF
--- a/utils/PathSanitizingFileCheck
+++ b/utils/PathSanitizingFileCheck
@@ -12,6 +12,7 @@
 from __future__ import print_function
 
 import argparse
+import io
 import re
 import subprocess
 import sys
@@ -66,20 +67,20 @@ constants.""")
 
     if args.enable_windows_compatibility:
         if args.enable_yaml_compatibility:
-            slashes_re = r'(/|\\\\|\\\\\\\\)'
+            slashes_re = b'(/|\\\\\\\\|\\\\\\\\\\\\\\\\)'
         else:
-            slashes_re = r'(/|\\\\)'
+            slashes_re = b'(/|\\\\\\\\)'
     else:
-        slashes_re = r'/'
+        slashes_re = b'/'
 
-    stdin = sys.stdin.read()
+    stdin = io.open(sys.stdin.fileno(), 'rb').read()
 
     for s in args.sanitize_strings:
-        replacement, pattern = s.split('=', 1)
+        replacement, pattern = s.encode(encoding="utf-8").split(b'=', 1)
         # Since we want to use pattern as a regex in some platforms, we need
         # to escape it first, and then replace the escaped slash
         # literal (r'\\/') for our platform-dependent slash regex.
-        stdin = re.sub(re.sub(r'\\/', slashes_re, re.escape(pattern)),
+        stdin = re.sub(re.sub(b'\\\\/', slashes_re, re.escape(pattern)),
                        replacement,
                        stdin)
 


### PR DESCRIPTION
Python 3 uses the concepts of text and (binary) data instead of Unicode strings and 8-bit strings. This change makes it explicit in Python 2 and 3 that this utility works with binary data instead of strings.

@compnerd I am somewhat concerned about the `slashes_re` in the `args.enable_windows_compatibility` conditional block. There are too many slashes in there and my mind boggles. Probably most important, I do not have a Windows machine to test this on.