### PR TITLE
[CxxInterop] Expose C++ static members as Swift static properties

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3954,10 +3954,6 @@ namespace {
     }
 
     Decl *VisitVarDecl(const clang::VarDecl *decl) {
-      // FIXME: Swift does not have static variables in structs/classes yet.
-      if (decl->getDeclContext()->isRecord())
-        return nullptr;
-
       // Variables are imported as... variables.
       Optional<ImportedName> correctSwiftName;
       auto importedName = importFullName(decl, correctSwiftName);

--- a/test/Interop/Cxx/class/access-specifiers-module-interface.swift
+++ b/test/Interop/Cxx/class/access-specifiers-module-interface.swift
@@ -37,6 +37,7 @@
 // CHECK-NEXT:     typealias Element = PublicPrivate.PublicFlagEnum
 // CHECK-NEXT:     typealias ArrayLiteralElement = PublicPrivate.PublicFlagEnum
 // CHECK-NEXT:   }
+// CHECK-NEXT:   static var PublicStaticMemberVar: Int32
 // CHECK-NEXT:   var PublicMemberVar: Int32
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   mutating func publicMemberFunc()

--- a/test/Interop/Cxx/class/access-specifiers-typechecker.swift
+++ b/test/Interop/Cxx/class/access-specifiers-typechecker.swift
@@ -10,9 +10,7 @@ var v = PublicPrivate()
 // Can access all public members and types.
 
 v.PublicMemberVar = 1
-// TODO: Static member variables don't appear to be imported correctly yet. Once
-// they are, verify that PublicStaticMemberVar is accessible.
-// PublicPrivate.PublicStaticMemberVar = 1
+PublicPrivate.PublicStaticMemberVar = 1
 v.publicMemberFunc()
 
 var publicTypedefVar: PublicPrivate.PublicTypedef
@@ -29,8 +27,6 @@ var publicFlagEnumVar: PublicPrivate.PublicFlagEnum
 // Cannot access any private members and types.
 
 v.PrivateMemberVar = 1 // expected-error {{value of type 'PublicPrivate' has no member 'PrivateMemberVar'}}
-// TODO: This gives the expected error, but only because static member variables
-// (private or  public) aren't imported at all. Once that is fixed, remove this
 PublicPrivate.PrivateStaticMemberVar = 1 // expected-error {{'PublicPrivate' has no member 'PrivateStaticMemberVar'}}
 v.privateMemberFunc() // expected-error {{value of type 'PublicPrivate' has no member 'privateMemberFunc'}}
 

--- a/test/Interop/Cxx/extern-var/Inputs/extern-var.cc
+++ b/test/Interop/Cxx/extern-var/Inputs/extern-var.cc
@@ -1,21 +1,13 @@
 int counter = 12;
 
-int getCounterFromCxx() {
-  return counter;
-}
+int getCounterFromCxx() { return counter; }
 
-void setCounterFromCxx(int c) {
-  counter = c;
-}
+void setCounterFromCxx(int c) { counter = c; }
 
 namespace Namespaced {
-  int counter = 12;
+int counter = 12;
 
-  int getCounterFromCxx() {
-    return counter;
-  }
+int getCounterFromCxx() { return counter; }
 
-  void setCounterFromCxx(int c) {
-    counter = c;
-  }
-}
+void setCounterFromCxx(int c) { counter = c; }
+} // namespace Namespaced

--- a/test/Interop/Cxx/extern-var/Inputs/extern-var.h
+++ b/test/Interop/Cxx/extern-var/Inputs/extern-var.h
@@ -4,8 +4,8 @@ int getCounterFromCxx();
 void setCounterFromCxx(int);
 
 namespace Namespaced {
-  extern int counter;
+extern int counter;
 
-  int getCounterFromCxx();
-  void setCounterFromCxx(int);
-}
+int getCounterFromCxx();
+void setCounterFromCxx(int);
+} // namespace Namespaced

--- a/test/Interop/Cxx/extern-var/extern-var-irgen.swift
+++ b/test/Interop/Cxx/extern-var/extern-var-irgen.swift
@@ -7,6 +7,7 @@ public func getCounter() -> CInt {
 }
 
 // CHECK: @{{counter|"\?counter@@3HA"}} = external {{(dso_local )?}}global i32, align 4
+// CHECK: @{{_ZN10Namespaced7counterE|"\?counter@Namespaced@@3HA"}} = external {{(dso_local )?}}global i32, align 4
 
 // CHECK: define {{(protected |dllexport )?}}swiftcc i32 @"$s4main10getCounters5Int32VyF"() #0
 // CHECK: [[LOAD:%.*]] = load i32, i32* getelementptr inbounds (%Ts5Int32V, %Ts5Int32V* bitcast (i32* @{{counter|"\?counter@@3HA"}} to %Ts5Int32V*), i32 0, i32 0), align 4
@@ -24,8 +25,7 @@ public func getNamespacedCounter() -> CInt {
 }
 
 // CHECK: define {{(protected |dllexport )?}}swiftcc i32 @"$s4main20getNamespacedCounters5Int32VyF"() #0
-//FIXME mangle non-top-level var names to prevent name collisions and check:
-// load i32, i32* getelementptr inbounds (%Ts5Int32V, %Ts5Int32V* bitcast (i32* @Namespaced.counter to %Ts5Int32V*), i32 0, i32 0), align 4
+// CHECK: load i32, i32* getelementptr inbounds (%Ts5Int32V, %Ts5Int32V* bitcast (i32* @{{_ZN10Namespaced7counterE|"\?counter@Namespaced@@3HA"}} to %Ts5Int32V*), i32 0, i32 0), align 4
 // CHECK: ret i32 %1
 
 public func setNamespacedCounter(_ c: CInt) {
@@ -33,8 +33,7 @@ public func setNamespacedCounter(_ c: CInt) {
 }
 
 // CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main20setNamespacedCounteryys5Int32VF"(i32 %0) #0
-//FIXME mangle non-top-level var names to prevent name collisions and check:
-// store i32 %0, i32* getelementptr inbounds (%Ts5Int32V, %Ts5Int32V* bitcast (i32* @Namespaced.counter to %Ts5Int32V*), i32 0, i32 0), align 4
+// CHECK: store i32 %0, i32* getelementptr inbounds (%Ts5Int32V, %Ts5Int32V* bitcast (i32* @{{_ZN10Namespaced7counterE|"\?counter@Namespaced@@3HA"}} to %Ts5Int32V*), i32 0, i32 0), align 4
 
 func modifyInout(_ c: inout CInt) {
   c = 42
@@ -46,4 +45,3 @@ public func passingVarAsInout() {
 
 // CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main17passingVarAsInoutyyF"() #0
 // CHECK: call swiftcc void @"$s4main11modifyInoutyys5Int32VzF"(%Ts5Int32V* nocapture dereferenceable(4) bitcast (i32* @{{counter|"\?counter@@3HA"}} to %Ts5Int32V*))
-

--- a/test/Interop/Cxx/extern-var/extern-var-silgen.swift
+++ b/test/Interop/Cxx/extern-var/extern-var-silgen.swift
@@ -7,6 +7,7 @@ func getCounter() -> CInt {
 }
 
 // CHECK: sil_global @counter : $Int32
+// CHECK: sil_global @{{_ZN10Namespaced7counterE|\?counter@Namespaced@@3HA}} : $Int32
 
 // CHECK: sil hidden @$s4main10getCounters5Int32VyF : $@convention(thin) () -> Int32
 // CHECK: [[COUNTER:%.*]] = global_addr @counter : $*Int32
@@ -28,9 +29,8 @@ func getNamespacedCounter() -> CInt {
 }
 
 // sil hidden @$s4main20getNamespacedCounters5Int32VyF : $@convention(thin) () -> Int32
-//FIXME mangle non-top-level var names to prevent name collisions
-// %0 = global_addr @Namespaced.counter : $*Int32
-// CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] %0 : $*Int32
+// CHECK: [[ADDR:%.*]] = global_addr @{{_ZN10Namespaced7counterE|\?counter@Namespaced@@3HA}} : $*Int32
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[ADDR]] : $*Int32
 // CHECK: [[LOAD:%.*]] = load [[ACCESS]] : $*Int32
 // CHECK: return [[LOAD]] : $Int32
 
@@ -39,9 +39,8 @@ func setNamespacedCounter(_ c: CInt) {
 }
 
 // CHECK: sil hidden @$s4main20setNamespacedCounteryys5Int32VF : $@convention(thin) (Int32) -> ()
-//FIXME mangle non-top-level var names to prevent name collisions
-// %1 = global_addr @Namespaced.counter : $*Int32
-// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] %1 : $*Int32
+// CHECK: [[ADDR:%.*]] = global_addr @{{_ZN10Namespaced7counterE|\?counter@Namespaced@@3HA}} : $*Int32
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*Int32
 // CHECK: store %0 to [[ACCESS]] : $*Int32
 
 func modifyInout(_ c: inout CInt) {

--- a/test/Interop/Cxx/extern-var/extern-var.swift
+++ b/test/Interop/Cxx/extern-var/extern-var.swift
@@ -23,26 +23,25 @@ ExternVarTestSuite.test("write-from-cxx") {
   expectEqual(84, getCounterFromCxx())
 }
 
-//FIXME mangle non-top-level var names to prevent name collisions
-// ExternVarTestSuite.test("namespaced-write-from-swift") {
-//   Namespaced.counter = 42
-//   expectEqual(42, Namespaced.counter)
-//   expectEqual(42, amespaced.getCounterFromCxx())
-// }
+ExternVarTestSuite.test("namespaced-write-from-swift") {
+  Namespaced.counter = 42
+  expectEqual(42, Namespaced.counter)
+  expectEqual(42, Namespaced.getCounterFromCxx())
+}
 
-//FIXME mangle non-top-level var names to prevent name collisions
-// ExternVarTestSuite.test("namespaced-write-from-cxx") {
-//   Namespaced.setCounterFromCxx(84)
-//   expectEqual(84, Namespaced.counter)
-//   expectEqual(84, Namespaced.getCounterFromCxx())
-// }
+ExternVarTestSuite.test("namespaced-write-from-cxx") {
+  Namespaced.setCounterFromCxx(84)
+  expectEqual(84, Namespaced.counter)
+  expectEqual(84, Namespaced.getCounterFromCxx())
+}
 
-//FIXME mangle non-top-level var names to prevent name collisions
-// ExternVarTestSuite.test("no-collisions") {
-//   counter = 12
-//   Namespaced.counter = 42
-//   expectEqual(12, counter)
-//   expectEqual(42, Namespaced.counter)
-// }
+// Check that variables with identical names in different namespaces don't
+// collide in any intermediate representation of the compiler.
+ExternVarTestSuite.test("no-collisions") {
+  counter = 12
+  Namespaced.counter = 42
+  expectEqual(12, counter)
+  expectEqual(42, Namespaced.counter)
+}
 
 runAllTests()

--- a/test/Interop/Cxx/static/Inputs/inline-static-member-var.cc
+++ b/test/Interop/Cxx/static/Inputs/inline-static-member-var.cc
@@ -1,0 +1,9 @@
+#include "inline-static-member-var.h"
+
+int *WithInlineStaticMember::getStaticMemberAddress() { return &staticMember; }
+
+int WithInlineStaticMember::getStaticMemberFromCxx() { return staticMember; }
+
+void WithInlineStaticMember::setStaticMemberFromCxx(int newVal) {
+  staticMember = newVal;
+}

--- a/test/Interop/Cxx/static/Inputs/inline-static-member-var.h
+++ b/test/Interop/Cxx/static/Inputs/inline-static-member-var.h
@@ -1,0 +1,12 @@
+inline static int init() { return 42; }
+
+class WithInlineStaticMember {
+  public:
+    inline static int staticMember = 12;
+    //TODO needs C++ stdlib symbols, fix after apple/swift#30914 is merged.
+    // inline static int staticMemberInitializedAtRuntime = init();
+
+    static int getStaticMemberFromCxx();
+    static int *getStaticMemberAddress();
+    static void setStaticMemberFromCxx(int);
+};

--- a/test/Interop/Cxx/static/Inputs/module.modulemap
+++ b/test/Interop/Cxx/static/Inputs/module.modulemap
@@ -1,0 +1,11 @@
+module StaticLocalVar {
+  header "static-local-var.h"
+}
+
+module StaticMemberVar {
+  header "static-member-var.h"
+}
+
+module InlineStaticMemberVar {
+  header "inline-static-member-var.h"
+}

--- a/test/Interop/Cxx/static/Inputs/static-local-var.cc
+++ b/test/Interop/Cxx/static/Inputs/static-local-var.cc
@@ -1,0 +1,5 @@
+#include "static-local-var.h"
+
+int counterWrapper() {
+  return counter();
+}

--- a/test/Interop/Cxx/static/Inputs/static-local-var.h
+++ b/test/Interop/Cxx/static/Inputs/static-local-var.h
@@ -1,0 +1,6 @@
+int counterWrapper();
+
+inline int counter() {
+  static int a = 0;
+  return a++;
+}

--- a/test/Interop/Cxx/static/Inputs/static-member-var.cc
+++ b/test/Interop/Cxx/static/Inputs/static-member-var.cc
@@ -1,0 +1,32 @@
+#include "static-member-var.h"
+
+int WithStaticMember::staticMember = 42;
+
+int *WithStaticMember::getStaticMemberAddress() { return &staticMember; }
+
+int WithStaticMember::getStaticMemberFromCxx() { return staticMember; }
+
+void WithStaticMember::setStaticMemberFromCxx(int newVal) {
+  staticMember = newVal;
+}
+
+int WithIncompleteStaticMember::arrayMember[3] = {18, 19, 20};
+
+WithIncompleteStaticMember WithIncompleteStaticMember::selfMember =
+    WithIncompleteStaticMember();
+
+WithIncompleteStaticMember *
+WithIncompleteStaticMember::getStaticMemberFromCxx() {
+  return &selfMember;
+}
+
+void WithIncompleteStaticMember::setStaticMemberFromCxx(
+    WithIncompleteStaticMember newVal) {
+  selfMember = newVal;
+}
+
+const int WithConstStaticMember::defined;
+const int WithConstStaticMember::definedOutOfLine = 96;
+
+int ClassA::notUniqueName = 144;
+int ClassB::notUniqueName = 169;

--- a/test/Interop/Cxx/static/Inputs/static-member-var.h
+++ b/test/Interop/Cxx/static/Inputs/static-member-var.h
@@ -1,0 +1,39 @@
+class WithStaticMember {
+public:
+  static int staticMember;
+  static int *getStaticMemberAddress();
+  static int getStaticMemberFromCxx();
+  static void setStaticMemberFromCxx(int);
+};
+
+class WithIncompleteStaticMember {
+public:
+  static int arrayMember[];
+  static WithIncompleteStaticMember selfMember;
+  int id = 3;
+
+  static WithIncompleteStaticMember *getStaticMemberFromCxx();
+  static void setStaticMemberFromCxx(WithIncompleteStaticMember);
+};
+
+class WithConstStaticMember {
+public:
+  const static int notDefined = 24;
+  const static int defined = 48;
+  const static int definedOutOfLine;
+};
+
+class WithConstexprStaticMember {
+public:
+  constexpr static int definedInline = 139;
+};
+
+class ClassA {
+public:
+  static int notUniqueName;
+};
+
+class ClassB {
+public:
+  static int notUniqueName;
+};

--- a/test/Interop/Cxx/static/constexpr-static-member-var.swift
+++ b/test/Interop/Cxx/static/constexpr-static-member-var.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang -c %S/Inputs/static-member-var.cc -I %S/Inputs -o %t/static-member-var.o -std=c++17
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-cxx-interop -Xcc -std=c++17
+// RUN: %target-codesign %t/statics
+// RUN: %target-run %t/statics
+//
+// REQUIRES: executable_test
+
+import StaticMemberVar
+import StdlibUnittest
+
+var ConstexprStaticMemberVarTestSuite = TestSuite("ConstexprStaticMemberVarTestSuite")
+
+ConstexprStaticMemberVarTestSuite.test("constexpr-static-member") {
+  expectEqual(139, WithConstexprStaticMember.definedInline)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/static/inline-static-member-var-irgen.swift
+++ b/test/Interop/Cxx/static/inline-static-member-var-irgen.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-emit-ir -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
+
+import InlineStaticMemberVar
+
+public func readStaticMember() -> CInt {
+  return WithInlineStaticMember.staticMember
+}
+
+// CHECK: @{{_ZN22WithInlineStaticMember12staticMemberE|"\?staticMember@WithInlineStaticMember@@2HA"}} = linkonce_odr {{(dso_local )?}}global i32 12, {{(comdat, )?}}align 4
+
+// CHECK: define {{(protected |dllexport )?}}swiftcc i32 @"$s4main16readStaticMembers5Int32VyF"()
+// CHECK: [[VALUE:%.*]] = load i32, i32* getelementptr inbounds (%Ts5Int32V, %Ts5Int32V* bitcast (i32* @{{_ZN22WithInlineStaticMember12staticMemberE|"\?staticMember@WithInlineStaticMember@@2HA"}} to %Ts5Int32V*), i32 0, i32 0), align 4
+// CHECK: ret i32 [[VALUE]]
+
+public func writeStaticMember(_ c: CInt) {
+  WithInlineStaticMember.staticMember = c
+}
+
+// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main17writeStaticMemberyys5Int32VF"(i32 %0)
+// CHECK: store i32 %0, i32* getelementptr inbounds (%Ts5Int32V, %Ts5Int32V* bitcast (i32* @{{_ZN22WithInlineStaticMember12staticMemberE|"\?staticMember@WithInlineStaticMember@@2HA"}} to %Ts5Int32V*), i32 0, i32 0), align 4
+
+func modifyInout(_ c: inout CInt) {
+  c = 42
+}
+
+public func passingVarAsInout() {
+  modifyInout(&WithInlineStaticMember.staticMember)
+}
+
+// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main17passingVarAsInoutyyF"()
+// CHECK: call swiftcc void @"$s4main11modifyInoutyys5Int32VzF"(%Ts5Int32V* nocapture dereferenceable(4) bitcast (i32* @{{_ZN22WithInlineStaticMember12staticMemberE|"\?staticMember@WithInlineStaticMember@@2HA"}} to %Ts5Int32V*))

--- a/test/Interop/Cxx/static/inline-static-member-var-silgen.swift
+++ b/test/Interop/Cxx/static/inline-static-member-var-silgen.swift
@@ -1,0 +1,38 @@
+// RUN: %target-swift-emit-sil -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
+
+import InlineStaticMemberVar
+
+func readStaticMember() -> CInt {
+  return WithInlineStaticMember.staticMember
+}
+
+// CHECK: sil_global @{{_ZN22WithInlineStaticMember12staticMemberE|\?staticMember@WithInlineStaticMember@@2HA}} : $Int32
+
+// CHECK: sil hidden @$s4main16readStaticMembers5Int32VyF : $@convention(thin) () -> Int32
+// CHECK: [[ADDR:%.*]] = global_addr @{{_ZN22WithInlineStaticMember12staticMemberE|\?staticMember@WithInlineStaticMember@@2HA}} : $*Int32
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[ADDR]] : $*Int32
+// CHECK: [[VALUE:%.*]] = load [[ACCESS]] : $*Int32
+// CHECK: return [[VALUE]] : $Int32
+
+func writeStaticMember(_ c: CInt) {
+  WithInlineStaticMember.staticMember = c
+}
+
+// CHECK: sil hidden @$s4main17writeStaticMemberyys5Int32VF : $@convention(thin) (Int32) -> ()
+// CHECK: [[ADDR:%.*]] = global_addr @{{_ZN22WithInlineStaticMember12staticMemberE|\?staticMember@WithInlineStaticMember@@2HA}} : $*Int32
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*Int32
+// CHECK: store %0 to [[ACCESS]] : $*Int32
+
+func modifyInout(_ c: inout CInt) {
+  c = 42
+}
+
+func passingVarAsInout() {
+  modifyInout(&WithInlineStaticMember.staticMember)
+}
+
+// CHECK: sil hidden @$s4main17passingVarAsInoutyyF : $@convention(thin) () -> ()
+// CHECK: [[ADDR:%.*]] = global_addr @{{_ZN22WithInlineStaticMember12staticMemberE|\?staticMember@WithInlineStaticMember@@2HA}} : $*Int32
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*Int32
+// CHECK: [[FUNC:%.*]] = function_ref @$s4main11modifyInoutyys5Int32VzF : $@convention(thin) (@inout Int32) -> ()
+// CHECK: apply [[FUNC]]([[ACCESS]]) : $@convention(thin) (@inout Int32) -> ()

--- a/test/Interop/Cxx/static/inline-static-member-var.swift
+++ b/test/Interop/Cxx/static/inline-static-member-var.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang -c %S/Inputs/inline-static-member-var.cc -I %S/Inputs -o %t/inline-static-member-var.o -std=c++17
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/inline-static-member-var.o -Xfrontend -enable-cxx-interop -Xcc -std=c++17
+// RUN: %target-codesign %t/statics
+// RUN: %target-run %t/statics 2&>1
+//
+// REQUIRES: executable_test
+
+import InlineStaticMemberVar
+import StdlibUnittest
+
+var InlineStaticMemberVarTestSuite = TestSuite("InlineStaticMemberVarTestSuite")
+
+InlineStaticMemberVarTestSuite.test("read-inline-static-member-address") {
+  expectEqual(
+    &WithInlineStaticMember.staticMember,
+    WithInlineStaticMember.getStaticMemberAddress())
+}
+
+InlineStaticMemberVarTestSuite.test("write-inline-static-member-from-cxx") {
+  expectNotEqual(128, WithInlineStaticMember.staticMember)
+  WithInlineStaticMember.setStaticMemberFromCxx(128)
+  expectEqual(128, WithInlineStaticMember.staticMember)
+}
+
+InlineStaticMemberVarTestSuite.test("write-inline-static-member-from-swift") {
+  expectNotEqual(256, WithInlineStaticMember.staticMember)
+  WithInlineStaticMember.staticMember = 256
+  expectEqual(256, WithInlineStaticMember.getStaticMemberFromCxx())
+}
+
+runAllTests()

--- a/test/Interop/Cxx/static/static-local-var.swift
+++ b/test/Interop/Cxx/static/static-local-var.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang -c %S/Inputs/static-local-var.cc -I %S/Inputs -o %t/static-local-var.o
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-local-var.o -Xfrontend -enable-cxx-interop
+// RUN: %target-codesign %t/statics
+// RUN: %target-run %t/statics
+//
+// REQUIRES: executable_test
+
+import StaticLocalVar
+import StdlibUnittest
+
+var StaticLocalVarTestSuite = TestSuite("StaticLocalVarTestSuite")
+
+StaticLocalVarTestSuite.test("static-local-var") {
+  expectEqual(counter(), 0)
+  expectEqual(counter(), 1)
+
+  // Check that the copies of the `counter()` inline function emitted by Swift
+  // and Clang share the same static local variable.
+  expectEqual(counterWrapper(), 2)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/static/static-member-var-irgen.swift
+++ b/test/Interop/Cxx/static/static-member-var-irgen.swift
@@ -1,0 +1,79 @@
+// RUN: %target-swift-emit-ir -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
+
+// CHECK: @{{_ZN16WithStaticMember12staticMemberE|"\?staticMember@WithStaticMember@@2HA"}} = external {{(dso_local )?}}global i32, align 4
+// CHECK: @{{_ZN26WithIncompleteStaticMember10selfMemberE|"\?selfMember@WithIncompleteStaticMember@@2V1@A"}} = {{external|linkonce_odr}} {{(dso_local )?}}global %class.WithIncompleteStaticMember, align 4
+
+//TODO: This test uses only values of static const members, so it does not need
+//to depend on external definitions. However, our code generation pattern loads
+//the value dynamically. Instead, we should inline known constants. That would
+//allow Swift code to even read the value of WithIncompleteStaticMember::notDefined.
+// CHECK: @{{_ZN21WithConstStaticMember7definedE|"\?defined@WithConstStaticMember@@2HB"}} = {{available_externally|linkonce_odr}} {{(dso_local )?}}constant i32 48, {{(comdat, )?}}align 4
+// CHECK: @{{_ZN21WithConstStaticMember16definedOutOfLineE|"\?definedOutOfLine@WithConstStaticMember@@2HB"}} = external {{(dso_local )?}}constant i32, align 4
+
+//TODO: This test uses only values of static const members, so it does not need
+//to depend on external definitions. However, our code generation pattern loads
+//the value dynamically. Instead, we should inline known constants. That would
+//allow Swift code to even read the value of WithIncompleteStaticMember::notDefined.
+// CHECK: @{{_ZN25WithConstexprStaticMember13definedInlineE|"\?definedInline@WithConstexprStaticMember@@2HB"}} = linkonce_odr {{(dso_local )?}}constant i32 139, {{(comdat, )?}}align 4
+
+import StaticMemberVar
+
+public func readStaticMember() -> CInt {
+  return WithStaticMember.staticMember
+}
+
+// CHECK: define {{(protected |dllexport )?}}swiftcc i32 @"$s4main16readStaticMembers5Int32VyF"()
+// CHECK: [[VALUE:%.*]] = load i32, i32* getelementptr inbounds (%Ts5Int32V, %Ts5Int32V* bitcast (i32* @{{_ZN16WithStaticMember12staticMemberE|"\?staticMember@WithStaticMember@@2HA"}} to %Ts5Int32V*), i32 0, i32 0), align 4
+// CHECK: ret i32 [[VALUE]]
+
+public func writeStaticMember() {
+  WithStaticMember.staticMember = -1
+}
+
+// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main17writeStaticMemberyyF"() #0
+// CHECK: store i32 -1, i32* getelementptr inbounds (%Ts5Int32V, %Ts5Int32V* bitcast (i32* @{{_ZN16WithStaticMember12staticMemberE|"\?staticMember@WithStaticMember@@2HA"}} to %Ts5Int32V*), i32 0, i32 0), align 4
+
+public func readSelfMember() -> WithIncompleteStaticMember {
+  return WithIncompleteStaticMember.selfMember
+}
+
+// CHECK: define {{(protected |dllexport )?}}swiftcc i32 @"$s4main14readSelfMemberSo020WithIncompleteStaticD0VyF"() #0
+// CHECK: [[VALUE:%.*]] = load i32, i32* getelementptr inbounds (%TSo26WithIncompleteStaticMemberV, %TSo26WithIncompleteStaticMemberV* bitcast (%class.WithIncompleteStaticMember* @{{_ZN26WithIncompleteStaticMember1|"\?selfMember@WithIncompleteStaticMember@@2V1@A"}}
+// CHECK: ret i32 [[VALUE]]
+
+public func writeSelfMember(_ m: WithIncompleteStaticMember) {
+  WithIncompleteStaticMember.selfMember = m
+}
+
+// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main15writeSelfMemberyySo020WithIncompleteStaticD0VF"(i32 %0) #0
+// CHECK: store i32 %0, i32* getelementptr inbounds (%TSo26WithIncompleteStaticMemberV, %TSo26WithIncompleteStaticMemberV* bitcast (%class.WithIncompleteStaticMember* @{{_ZN26WithIncompleteStaticMember10selfMemberE|"\?selfMember@WithIncompleteStaticMember@@2V1@A"}} to %TSo26WithIncompleteStaticMemberV*), i32 0, i32 0, i32 0), align 4
+
+// TODO: Currently, the generated code would try to load the value from
+// a symbol that is not defined. We should inline the value instead.
+// public func readNotDefinedConstMember() -> CInt {
+//   return WithConstStaticMember.notDefined
+// }
+
+public func readDefinedConstMember() -> CInt {
+  return WithConstStaticMember.defined
+}
+
+// CHECK: define {{(protected |dllexport )?}}swiftcc i32 @"$s4main22readDefinedConstMembers5Int32VyF"() #0
+// CHECK: [[VALUE:%.*]] = load i32, i32* getelementptr inbounds (%Ts5Int32V, %Ts5Int32V* bitcast (i32* @{{_ZN21WithConstStaticMember7definedE|"\?defined@WithConstStaticMember@@2HB"}} to %Ts5Int32V*), i32 0, i32 0), align 4
+// CHECK: ret i32 [[VALUE]]
+
+public func readDefinedOutOfLineConstMember() -> CInt {
+  return WithConstStaticMember.definedOutOfLine
+}
+
+// CHECK: define {{(protected |dllexport )?}}swiftcc i32 @"$s4main31readDefinedOutOfLineConstMembers5Int32VyF"() #0
+// CHECK: [[VALUE:%.*]] = load i32, i32* getelementptr inbounds (%Ts5Int32V, %Ts5Int32V* bitcast (i32* @{{_ZN21WithConstStaticMember16definedOutOfLineE|"\?definedOutOfLine@WithConstStaticMember@@2HB"}} to %Ts5Int32V*), i32 0, i32 0), align 4
+// CHECK: ret i32 [[VALUE]]
+
+public func readConstexprStaticMember() -> CInt {
+  return WithConstexprStaticMember.definedInline
+}
+
+// CHECK: define {{(protected |dllexport )?}}swiftcc i32 @"$s4main25readConstexprStaticMembers5Int32VyF"() #0
+// CHECK: [[VALUE:%.*]] = load i32, i32* getelementptr inbounds (%Ts5Int32V, %Ts5Int32V* bitcast (i32* @{{_ZN25WithConstexprStaticMember13definedInlineE|"\?definedInline@WithConstexprStaticMember@@2HB"}} to %Ts5Int32V*), i32 0, i32 0), align 4
+// CHECK: ret i32 [[VALUE]]

--- a/test/Interop/Cxx/static/static-member-var-silgen.swift
+++ b/test/Interop/Cxx/static/static-member-var-silgen.swift
@@ -1,0 +1,80 @@
+// RUN: %target-swift-emit-sil -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
+
+// CHECK: sil_global @{{_ZN16WithStaticMember12staticMemberE|\?staticMember@WithStaticMember@@2HA}} : $Int32
+// CHECK: sil_global @{{_ZN26WithIncompleteStaticMember10selfMemberE|\?selfMember@WithIncompleteStaticMember@@2V1@A}} : $WithIncompleteStaticMember
+// CHECK: sil_global [let] @{{_ZN21WithConstStaticMember7definedE|\?defined@WithConstStaticMember@@2HB}} : $Int32
+// CHECK: sil_global [let] @{{_ZN21WithConstStaticMember16definedOutOfLineE|\?definedOutOfLine@WithConstStaticMember@@2HB}} : $Int32
+// CHECK: sil_global [let] @{{_ZN25WithConstexprStaticMember13definedInlineE|\?definedInline@WithConstexprStaticMember@@2HB}} : $Int32
+
+import StaticMemberVar
+
+func readStaticMember() -> CInt {
+  return WithStaticMember.staticMember
+}
+
+// CHECK: sil hidden @$s4main16readStaticMembers5Int32VyF : $@convention(thin) () -> Int32
+// CHECK: [[ADDR:%.*]] = global_addr @{{_ZN16WithStaticMember12staticMemberE|\?staticMember@WithStaticMember@@2HA}} : $*Int32
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[ADDR]] : $*Int32
+// CHECK: [[VALUE:%.*]] = load [[ACCESS]] : $*Int32
+// CHECK: return [[VALUE]] : $Int32
+
+func writeStaticMember() {
+  WithStaticMember.staticMember = -1
+}
+
+// CHECK: sil hidden @$s4main17writeStaticMemberyyF : $@convention(thin) () -> ()
+// CHECK: [[ADDR:%.*]] = global_addr @{{_ZN16WithStaticMember12staticMemberE|\?staticMember@WithStaticMember@@2HA}} : $*Int32
+// CHECK: [[INT:%.*]] = struct $Int32 (%2 : $Builtin.Int32)
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*Int32
+// CHECK: store [[INT]] to [[ACCESS]] : $*Int32
+
+func readSelfMember() -> WithIncompleteStaticMember {
+  return WithIncompleteStaticMember.selfMember
+}
+
+// CHECK: sil hidden @$s4main14readSelfMemberSo020WithIncompleteStaticD0VyF : $@convention(thin) () -> WithIncompleteStaticMember
+// CHECK: [[ADDR:%.*]] = global_addr @{{_ZN26WithIncompleteStaticMember10selfMemberE|\?selfMember@WithIncompleteStaticMember@@2V1@A}} : $*WithIncompleteStaticMember
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[ADDR]] : $*WithIncompleteStaticMember
+// CHECK: [[VALUE:%.*]] = load [[ACCESS]] : $*WithIncompleteStaticMember
+// CHECK: return [[VALUE]] : $WithIncompleteStaticMember
+
+func writeSelfMember(_ m: WithIncompleteStaticMember) {
+  WithIncompleteStaticMember.selfMember = m
+}
+
+// CHECK: sil hidden @$s4main15writeSelfMemberyySo020WithIncompleteStaticD0VF : $@convention(thin) (WithIncompleteStaticMember) -> ()
+// CHECK: [[ADDR:%.*]] = global_addr @{{_ZN26WithIncompleteStaticMember10selfMemberE|\?selfMember@WithIncompleteStaticMember@@2V1@A}} : $*WithIncompleteStaticMember
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*WithIncompleteStaticMember
+// CHECK:  store %0 to [[ACCESS]] : $*WithIncompleteStaticMember
+
+//TODO fix undefined reference to `WithConstStaticMember::notDefined`.
+// func readNotDefinedConstMember() -> CInt {
+//   return WithConstStaticMember.notDefined
+// }
+
+func readDefinedConstMember() -> CInt {
+  return WithConstStaticMember.defined
+}
+
+// CHECK: sil hidden @$s4main22readDefinedConstMembers5Int32VyF : $@convention(thin) () -> Int32
+// CHECK: [[ADDR:%.*]] = global_addr @{{_ZN21WithConstStaticMember7definedE|\?defined@WithConstStaticMember@@2HB}} : $*Int32
+// CHECK: [[VALUE:%.*]] = load [[ADDR]] : $*Int32
+// CHECK: return [[VALUE]] : $Int32
+
+func readDefinedOutOfLineConstMember() -> CInt {
+  return WithConstStaticMember.definedOutOfLine
+}
+
+// CHECK: sil hidden @$s4main31readDefinedOutOfLineConstMembers5Int32VyF : $@convention(thin) () -> Int32
+// CHECK: [[ADDR:%.*]] = global_addr @{{_ZN21WithConstStaticMember16definedOutOfLineE|\?definedOutOfLine@WithConstStaticMember@@2HB}} : $*Int32
+// CHECK: [[VALUE:%.*]] = load [[ADDR]] : $*Int32
+// CHECK: return [[VALUE]] : $Int32
+
+func readConstexprStaticMember() -> CInt {
+  return WithConstexprStaticMember.definedInline
+}
+
+// CHECK: sil hidden @$s4main25readConstexprStaticMembers5Int32VyF : $@convention(thin) () -> Int32
+// CHECK: [[ADDR:%.*]] = global_addr @{{_ZN25WithConstexprStaticMember13definedInlineE|\?definedInline@WithConstexprStaticMember@@2HB}} : $*Int32
+// CHECK: [[VALUE:%.*]] = load [[ADDR]] : $*Int32
+// CHECK: return [[VALUE]] : $Int32

--- a/test/Interop/Cxx/static/static-member-var.swift
+++ b/test/Interop/Cxx/static/static-member-var.swift
@@ -1,0 +1,93 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang -c %S/Inputs/static-member-var.cc -I %S/Inputs -o %t/static-member-var.o -std=c++11
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-cxx-interop -Xcc -std=c++11
+// RUN: %target-codesign %t/statics
+// RUN: %target-run %t/statics
+//
+// REQUIRES: executable_test
+
+import StaticMemberVar
+import StdlibUnittest
+
+var StaticMemberVarTestSuite = TestSuite("StaticMemberVarTestSuite")
+
+StaticMemberVarTestSuite.test("read-static-member-address") {
+  expectEqual(
+    &WithStaticMember.staticMember,
+    WithStaticMember.getStaticMemberAddress())
+}
+
+StaticMemberVarTestSuite.test("write-static-member-from-cxx") {
+  expectNotEqual(84, WithStaticMember.staticMember)
+  WithStaticMember.setStaticMemberFromCxx(84)
+  expectEqual(84, WithStaticMember.staticMember)
+}
+
+StaticMemberVarTestSuite.test("write-static-member-from-swift") {
+  expectNotEqual(24, WithStaticMember.staticMember)
+  WithStaticMember.staticMember = 24
+  expectEqual(24, WithStaticMember.getStaticMemberFromCxx())
+}
+
+StaticMemberVarTestSuite.test("incomplete-array-static-member") {
+  //TODO recognize array member variable `arrayMember`.
+  // expectEqual(18, WithIncompleteStaticMember.arrayMember[0])
+  // expectEqual(3, WithIncompleteStaticMember.arrayMember.count)
+}
+
+StaticMemberVarTestSuite.test("incomplete-self-static-member-address") {
+  expectEqual(
+    WithIncompleteStaticMember.getStaticMemberFromCxx()!,
+    &WithIncompleteStaticMember.selfMember)
+}
+
+StaticMemberVarTestSuite.test("write-incomplete-self-static-member-from-cxx") {
+  expectNotEqual(128, WithIncompleteStaticMember.selfMember.id)
+  var newVal = WithIncompleteStaticMember()
+  newVal.id = 128
+  WithIncompleteStaticMember.setStaticMemberFromCxx(newVal)
+  expectEqual(128, WithIncompleteStaticMember.selfMember.id)
+}
+
+StaticMemberVarTestSuite.test("write-incomplete-self-static-member-from-swift") {
+  expectNotEqual(132, WithIncompleteStaticMember.selfMember.id)
+  WithIncompleteStaticMember.selfMember.id = 132
+  expectEqual(132, WithIncompleteStaticMember.getStaticMemberFromCxx()!.pointee.id)
+}
+
+StaticMemberVarTestSuite.test("const-static-member") {
+  //TODO fix undefined reference to `WithConstStaticMember::notDefined`.
+  // expectEqual(24, WithConstStaticMember.notDefined)
+  expectEqual(48, WithConstStaticMember.defined)
+  expectEqual(96, WithConstStaticMember.definedOutOfLine)
+}
+
+StaticMemberVarTestSuite.test("const-static-member") {
+  //TODO fix undefined reference to `WithConstStaticMember::notDefined`.
+  // expectEqual(24, WithConstStaticMember.notDefined)
+  expectEqual(48, WithConstStaticMember.defined)
+  expectEqual(96, WithConstStaticMember.definedOutOfLine)
+}
+
+StaticMemberVarTestSuite.test("const-static-member") {
+  //TODO fix undefined reference to `WithConstStaticMember::notDefined`.
+  // expectEqual(24, WithConstStaticMember.notDefined)
+  expectEqual(48, WithConstStaticMember.defined)
+  expectEqual(96, WithConstStaticMember.definedOutOfLine)
+}
+
+StaticMemberVarTestSuite.test("const-static-member") {
+  //TODO fix undefined reference to `WithConstStaticMember::notDefined`.
+  // expectEqual(WithConstStaticMember.notDefined)
+  expectEqual(48, WithConstStaticMember.defined)
+  expectEqual(96, WithConstStaticMember.definedOutOfLine)
+}
+
+// Check that variables with identical names in different namespaces don't
+// collide in any intermediate representation of the compiler.
+StaticMemberVarTestSuite.test("no-collisions") {
+  expectEqual(144, ClassA.notUniqueName)
+  expectEqual(169, ClassB.notUniqueName)
+}
+
+runAllTests()


### PR DESCRIPTION
This PR does the following:

* Removes early exit for static members in `ImportDecl.cpp`
* Uses Clang mangler to mangle names of all Clang-backed non-top-level VarDecls in `ASTMangler::mangleGlobalVariableFull`
* Uncomments tests in `test/Interop/Cxx/class` now that static members are supported
* Adds tests into `test/Interop/Cxx/static`

Doing some form of mangling (or including the record name in the name in any form) in `ASTMangler` is AFAIK needed to be able to have multiple static members with the same name. Without the mangling the `SILGenGlobalVariable` is not created due to [this line](https://github.com/apple/swift/blob/841eeb05b037001c8ed440b3bb009f782abe8d53/lib/SILGen/SILGenGlobalVariable.cpp#L48). Therefore with this PR we'll see Clang mangled names for static members in SIL output.

Progres on [SR-12464](https://bugs.swift.org/browse/SR-12464) and [SR-12466](https://bugs.swift.org/browse/SR-12466).