### PR TITLE
XFAIL test on os stdlib bots

### DIFF
--- a/test/Interpreter/metadata_access.swift
+++ b/test/Interpreter/metadata_access.swift
@@ -1,6 +1,10 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 // REQUIRES: executable_test
 
+// This does not work on os_stdlib because it misses availability annotation.
+// rdar://61814566
+// XFAIL: use_os_stdlib
+
 import SwiftShims
 
 struct MetadataAccessFunction {


### PR DESCRIPTION
This was introduced by #30024.

Until we have a proper fix.

rdar://61814566