### PR TITLE
[CodeCompletion] Fix a crash in context type analysis for tuple expr

### DIFF
--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -762,7 +762,9 @@ class ExprContextAnalyzer {
       unsigned Position = 0;
       bool HasName;
       if (getPositionInArgs(*DC, Parent, ParsedExpr, Position, HasName)) {
-        recordPossibleType(tupleT->getElementType(Position));
+        // The expected type may have fewer number of elements.
+        if (Position < tupleT->getNumElements())
+          recordPossibleType(tupleT->getElementType(Position));
       }
       break;
     }

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -101,6 +101,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARG_PARAMFLAG_IUO | %FileCheck %s -check-prefix=ARG_PARAMFLAG_IUO
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARG_PARAMFLAG_VARIADIC | %FileCheck %s -check-prefix=ARG_PARAMFLAG_VARIADIC
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TUPLEELEM_1 | %FileCheck %s -check-prefix=TUPLEELEM_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TUPLEELEM_2 | %FileCheck %s -check-prefix=TUPLEELEM_2
 
 var i1 = 1
 var i2 = 2
@@ -815,4 +817,15 @@ func testPamrameterFlags(_: Int, inoutArg: inout Int, autoclosureArg: @autoclosu
 // ARG_PARAMFLAG_VARIADIC: Begin completions, 1 items
 // ARG_PARAMFLAG_VARIADIC-DAG: Pattern/ExprSpecific: {#variadicArg: Int...#}[#Int#];
 // ARG_PARAMFLAG_VARIADIC: End completions
+}
+
+func testTupleElement(arg: (SimpleEnum, SimpleEnum)) {
+  testTupleElement(arg: (.foo, .#^TUPLEELEM_1^#))
+// TUPLEELEM_1: Begin completions, 3 items
+// TUPLEELEM_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     foo[#SimpleEnum#]; name=foo
+// TUPLEELEM_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     bar[#SimpleEnum#]; name=bar
+// TUPLEELEM_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     baz[#SimpleEnum#]; name=baz
+// TUPLEELEM_1: End completions
+  testTupleElement(arg: (.foo, .bar, .#^TUPLEELEM_2^#))
+// TUPLEELEM_2-NOT: Begin completions
 }


### PR DESCRIPTION
When completing inside tuple expressions, the context tuple type may have fewer number of elements. In such cases, we cannot provide the expected type.

rdar://problem/61668779
