### PR TITLE
[stdlib] Add a couple of missing @_nonEphemeral attributes

### DIFF
--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -485,7 +485,7 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
   /// - Warning: Accessing `pointee` as a type that is unrelated to		
   ///   the underlying memory's bound type is undefined.		
   @_transparent		
-  public init<U>(_ from: UnsafeMutablePointer<U>) {		
+  public init<U>(@_nonEphemeral _ from: UnsafeMutablePointer<U>) {		
    self._rawValue = from._rawValue		
   }		
 
@@ -500,7 +500,7 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
   /// - Warning: Accessing `pointee` as a type that is unrelated to		
   ///   the underlying memory's bound type is undefined.		
   @_transparent		
-  public init?<U>(_ from: UnsafeMutablePointer<U>?) {		
+  public init?<U>(@_nonEphemeral _ from: UnsafeMutablePointer<U>?) {
    guard let unwrapped = from else { return nil }		
    self.init(unwrapped)		
   }

--- a/test/stdlib/AutoreleasingUnsafeMutablePointerDiagnostics.swift
+++ b/test/stdlib/AutoreleasingUnsafeMutablePointerDiagnostics.swift
@@ -1,10 +1,31 @@
 // RUN: %target-typecheck-verify-swift -enable-invalid-ephemeralness-as-error
 // REQUIRES: objc_interop
 
-func unsafePointerInitEphemeralConversions() {
-  class C {}
-  var c: C?
+class C {}
 
-  _ = AutoreleasingUnsafeMutablePointer(&c) // expected-error {{initialization of 'AutoreleasingUnsafeMutablePointer<C?>' results in a dangling pointer}}
+func unsafePointerInitEphemeralConversions() {
+  var c = C()
+  var optC: C?
+
+  _ = AutoreleasingUnsafeMutablePointer(&c) // expected-error {{initialization of 'AutoreleasingUnsafeMutablePointer<C>' results in a dangling pointer}}
+  // expected-note@-1 {{implicit argument conversion from 'C' to 'AutoreleasingUnsafeMutablePointer<C>' produces a pointer valid only for the duration of the call to 'init(_:)'}}
+
+  _ = AutoreleasingUnsafeMutablePointer<AnyObject>(&c) // expected-error {{initialization of 'AutoreleasingUnsafeMutablePointer<AnyObject>' results in a dangling pointer}}
+  // expected-note@-1 {{implicit argument conversion from 'C' to 'UnsafeMutablePointer<C>' produces a pointer valid only for the duration of the call to 'init(_:)'}}
+  // expected-note@-2 {{use 'withUnsafeMutablePointer' in order to explicitly convert argument to pointer valid for a defined scope}}
+
+  _ = AutoreleasingUnsafeMutablePointer(&optC) // expected-error {{initialization of 'AutoreleasingUnsafeMutablePointer<C?>' results in a dangling pointer}}
   // expected-note@-1 {{implicit argument conversion from 'C?' to 'AutoreleasingUnsafeMutablePointer<C?>' produces a pointer valid only for the duration of the call to 'init(_:)'}}
+
+  _ = AutoreleasingUnsafeMutablePointer<C>(&optC) // expected-error {{initialization of 'AutoreleasingUnsafeMutablePointer<C>' results in a dangling pointer}}
+  // expected-note@-1 {{implicit argument conversion from 'C?' to 'UnsafeMutablePointer<C?>' produces a pointer valid only for the duration of the call to 'init(_:)'}}
+  // expected-note@-2 {{use 'withUnsafeMutablePointer' in order to explicitly convert argument to pointer valid for a defined scope}}
+
+  _ = AutoreleasingUnsafeMutablePointer<AnyObject>(&optC) // expected-error {{initialization of 'AutoreleasingUnsafeMutablePointer<AnyObject>' results in a dangling pointer}}
+  // expected-note@-1 {{implicit argument conversion from 'C?' to 'UnsafeMutablePointer<C?>' produces a pointer valid only for the duration of the call to 'init(_:)'}}
+  // expected-note@-2 {{use 'withUnsafeMutablePointer' in order to explicitly convert argument to pointer valid for a defined scope}}
+
+  _ = AutoreleasingUnsafeMutablePointer<AnyObject?>(&optC) // expected-error {{initialization of 'AutoreleasingUnsafeMutablePointer<AnyObject?>' results in a dangling pointer}}
+  // expected-note@-1 {{implicit argument conversion from 'C?' to 'UnsafeMutablePointer<C?>' produces a pointer valid only for the duration of the call to 'init(_:)'}}
+  // expected-note@-2 {{use 'withUnsafeMutablePointer' in order to explicitly convert argument to pointer valid for a defined scope}}
 }

--- a/test/stdlib/AutoreleasingUnsafeMutablePointerDiagnostics_warning.swift
+++ b/test/stdlib/AutoreleasingUnsafeMutablePointerDiagnostics_warning.swift
@@ -1,10 +1,31 @@
 // RUN: %target-typecheck-verify-swift
 // REQUIRES: objc_interop
 
-func unsafePointerInitEphemeralConversions() {
-  class C {}
-  var c: C?
+class C {}
 
-  _ = AutoreleasingUnsafeMutablePointer(&c) // expected-warning {{initialization of 'AutoreleasingUnsafeMutablePointer<C?>' results in a dangling pointer}}
+func unsafePointerInitEphemeralConversions() {
+  var c = C()
+  var optC: C?
+
+  _ = AutoreleasingUnsafeMutablePointer(&c) // expected-warning {{initialization of 'AutoreleasingUnsafeMutablePointer<C>' results in a dangling pointer}}
+  // expected-note@-1 {{implicit argument conversion from 'C' to 'AutoreleasingUnsafeMutablePointer<C>' produces a pointer valid only for the duration of the call to 'init(_:)'}}
+
+  _ = AutoreleasingUnsafeMutablePointer<AnyObject>(&c) // expected-warning {{initialization of 'AutoreleasingUnsafeMutablePointer<AnyObject>' results in a dangling pointer}}
+  // expected-note@-1 {{implicit argument conversion from 'C' to 'UnsafeMutablePointer<C>' produces a pointer valid only for the duration of the call to 'init(_:)'}}
+  // expected-note@-2 {{use 'withUnsafeMutablePointer' in order to explicitly convert argument to pointer valid for a defined scope}}
+
+  _ = AutoreleasingUnsafeMutablePointer(&optC) // expected-warning {{initialization of 'AutoreleasingUnsafeMutablePointer<C?>' results in a dangling pointer}}
   // expected-note@-1 {{implicit argument conversion from 'C?' to 'AutoreleasingUnsafeMutablePointer<C?>' produces a pointer valid only for the duration of the call to 'init(_:)'}}
+
+  _ = AutoreleasingUnsafeMutablePointer<C>(&optC) // expected-warning {{initialization of 'AutoreleasingUnsafeMutablePointer<C>' results in a dangling pointer}}
+  // expected-note@-1 {{implicit argument conversion from 'C?' to 'UnsafeMutablePointer<C?>' produces a pointer valid only for the duration of the call to 'init(_:)'}}
+  // expected-note@-2 {{use 'withUnsafeMutablePointer' in order to explicitly convert argument to pointer valid for a defined scope}}
+
+  _ = AutoreleasingUnsafeMutablePointer<AnyObject>(&optC) // expected-warning {{initialization of 'AutoreleasingUnsafeMutablePointer<AnyObject>' results in a dangling pointer}}
+  // expected-note@-1 {{implicit argument conversion from 'C?' to 'UnsafeMutablePointer<C?>' produces a pointer valid only for the duration of the call to 'init(_:)'}}
+  // expected-note@-2 {{use 'withUnsafeMutablePointer' in order to explicitly convert argument to pointer valid for a defined scope}}
+
+  _ = AutoreleasingUnsafeMutablePointer<AnyObject?>(&optC) // expected-warning {{initialization of 'AutoreleasingUnsafeMutablePointer<AnyObject?>' results in a dangling pointer}}
+  // expected-note@-1 {{implicit argument conversion from 'C?' to 'UnsafeMutablePointer<C?>' produces a pointer valid only for the duration of the call to 'init(_:)'}}
+  // expected-note@-2 {{use 'withUnsafeMutablePointer' in order to explicitly convert argument to pointer valid for a defined scope}}
 }


### PR DESCRIPTION
Looks like I missed these when I rebased https://github.com/apple/swift/pull/27695. Make sure these `AutoreleasingUnsafeMutablePointer` initializers emit a warning if a temporary pointer is passed to them. 