### PR TITLE
[5.2][CodeCompletion] Fix a crash in context type analysis for tuple expr

### DIFF
--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -695,7 +695,9 @@ class ExprContextAnalyzer {
       unsigned Position = 0;
       bool HasName;
       if (getPositionInArgs(*DC, Parent, ParsedExpr, Position, HasName)) {
-        recordPossibleType(tupleT->getElementType(Position));
+        // The expected type may have fewer number of elements.
+        if (Position < tupleT->getNumElements())
+          recordPossibleType(tupleT->getElementType(Position));
       }
       break;
     }

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -94,6 +94,9 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARCHETYPE_GENERIC_1 | %FileCheck %s -check-prefix=ARCHETYPE_GENERIC_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PARAM_WITH_ERROR_AUTOCLOSURE| %FileCheck %s -check-prefix=PARAM_WITH_ERROR_AUTOCLOSURE
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TUPLEELEM_1 | %FileCheck %s -check-prefix=TUPLEELEM_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TUPLEELEM_2 | %FileCheck %s -check-prefix=TUPLEELEM_2
+
 var i1 = 1
 var i2 = 2
 var oi1 : Int?
@@ -750,4 +753,15 @@ struct TestHasErrorAutoclosureParam {
 // PARAM_WITH_ERROR_AUTOCLOSURE: Decl[InstanceMethod]/CurrNominal:   ['(']{#value: <<error type>>#}[')'][#Void#];
 // PARAM_WITH_ERROR_AUTOCLOSURE: End completions
   }
+}
+
+func testTupleElement(arg: (SimpleEnum, SimpleEnum)) {
+  testTupleElement(arg: (.foo, .#^TUPLEELEM_1^#))
+// TUPLEELEM_1: Begin completions, 3 items
+// TUPLEELEM_1-DAG: Decl[EnumElement]/ExprSpecific:     foo[#SimpleEnum#]; name=foo
+// TUPLEELEM_1-DAG: Decl[EnumElement]/ExprSpecific:     bar[#SimpleEnum#]; name=bar
+// TUPLEELEM_1-DAG: Decl[EnumElement]/ExprSpecific:     baz[#SimpleEnum#]; name=baz
+// TUPLEELEM_1: End completions
+  testTupleElement(arg: (.foo, .bar, .#^TUPLEELEM_2^#))
+// TUPLEELEM_2-NOT: Begin completions
 }


### PR DESCRIPTION
(Cherry-pick of #31073 to swift-5.2-branch)

When completing inside tuple expressions, the context tuple type may have fewer number of elements. In such cases, we cannot provide the expected type.

rdar://problem/61902917
