### PR TITLE
Fix property wrapper init diagnostics

### DIFF
--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -125,6 +125,8 @@ findSuitableWrapperInit(ASTContext &ctx, NominalTypeDecl *nominal,
     break;
   }
 
+  TypeChecker::addImplicitConstructors(nominal);
+
   nominal->lookupQualified(nominal, DeclNameRef::createConstructor(),
                            NL_QualifiedDefault, decls);
   for (const auto &decl : decls) {

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -158,6 +158,14 @@ findSuitableWrapperInit(ASTContext &ctx, NominalTypeDecl *nominal,
     if (hasExtraneousParam)
       continue;
 
+    if (initKind != PropertyWrapperInitKind::Default) {
+      if (!argumentParam)
+        continue;
+
+      if (argumentParam->isInOut() || argumentParam->isVariadic())
+        continue;
+    }
+
     // Failable initializers cannot be used.
     if (init->isFailable()) {
       nonviable.push_back(
@@ -174,12 +182,6 @@ findSuitableWrapperInit(ASTContext &ctx, NominalTypeDecl *nominal,
 
     // Additional checks for initial-value and wrapped-value initializers
     if (initKind != PropertyWrapperInitKind::Default) {
-      if (!argumentParam)
-        continue;
-
-      if (argumentParam->isInOut() || argumentParam->isVariadic())
-        continue;
-
       auto paramType = argumentParam->getInterfaceType();
       if (paramType->is<ErrorType>())
         continue;

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -345,9 +345,6 @@ PropertyWrapperTypeInfoRequest::evaluate(
   if (!valueVar)
     return PropertyWrapperTypeInfo();
 
-  // FIXME: Remove this one
-  (void)valueVar->getInterfaceType();
-
   TypeChecker::addImplicitConstructors(nominal);
 
   SmallVector<ValueDecl *, 2> decls;

--- a/test/SILGen/Inputs/property_wrappers_multifile_other.swift
+++ b/test/SILGen/Inputs/property_wrappers_multifile_other.swift
@@ -7,6 +7,8 @@ public class MyClass {
 
 @propertyWrapper
 public struct PropertyWrapper {
+  public init() { }
+
   public var projectedValue: PropertyWrapper {
     get {
       return self

--- a/test/SILGen/property_wrappers_final.swift
+++ b/test/SILGen/property_wrappers_final.swift
@@ -17,6 +17,8 @@ public class MyClass {
 
 @propertyWrapper
 public struct PropertyWrapper {
+  public init() { }
+
   public var projectedValue: PropertyWrapper {
     get {
       return self

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1936,7 +1936,7 @@ struct TestDefaultableIntWrapper {
 
 @propertyWrapper
 public struct NonVisibleImplicitInit {
-// expected-error@-1 3{{internal initializer 'init()' cannot have more restrictive access than its enclosing property wrapper type 'NonVisibleImplicitInit' (which is public)}}
+// expected-error@-1 {{internal initializer 'init()' cannot have more restrictive access than its enclosing property wrapper type 'NonVisibleImplicitInit' (which is public)}}
   public var wrappedValue: Bool {
     return false
   }

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1934,5 +1934,10 @@ struct TestDefaultableIntWrapper {
   }
 }
 
-
-
+@propertyWrapper
+public struct NonVisibleImplicitInit {
+// expected-error@-1 3{{internal initializer 'init()' cannot have more restrictive access than its enclosing property wrapper type 'NonVisibleImplicitInit' (which is public)}}
+  public var wrappedValue: Bool {
+    return false
+  }
+}


### PR DESCRIPTION
This is a regression between 5.2 and master. The first commit is the actual bug fix; the other three are small cleanups I noticed.