### PR TITLE
[IRGen] Fix SynthesizedFileUnit.

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -984,11 +984,16 @@ performIRGeneration(const IRGenOptions &Opts, ModuleDecl *M,
 
     if (SF) {
       IGM.emitSourceFile(*SF);
+      // Emit synthesized file unit, if it exists.
+      if (auto *synthesizedFile = SF->getSynthesizedFile())
+        IGM.emitSynthesizedFileUnit(*synthesizedFile);
     } else {
       for (auto *File : M->getFiles()) {
         if (auto *nextSF = dyn_cast<SourceFile>(File)) {
           if (nextSF->ASTStage >= SourceFile::TypeChecked)
             IGM.emitSourceFile(*nextSF);
+        } else if (auto *nextSFU = dyn_cast<SynthesizedFileUnit>(File)) {
+          IGM.emitSynthesizedFileUnit(*nextSFU);
         } else {
           File->collectLinkLibraries([&IGM](LinkLibrary LinkLib) {
             IGM.addLinkLibrary(LinkLib);
@@ -996,11 +1001,6 @@ performIRGeneration(const IRGenOptions &Opts, ModuleDecl *M,
         }
       }
     }
-
-    // Emit synthesized file units.
-    for (auto *File : M->getFiles())
-      if (auto *nextSFU = dyn_cast<SynthesizedFileUnit>(File))
-        IGM.emitSynthesizedFileUnit(*nextSFU);
 
     // Okay, emit any definitions that we suddenly need.
     irgen.emitLazyDefinitions();


### PR DESCRIPTION
`SynthesizedFileUnit`s are attached to a `SourceFile`: https://github.com/apple/swift/pull/30910

Make IRGen consistent with TBDGen: when processing a `SourceFile`, only process
the attached `SynthesizedFile`. This avoids IRGen/TBDGen inconsistencies.

`SynthesizedFileUnit`s are created only by the differentiation transform, so other compilation paths should not be affected.

---

Resolves TF-1249: derivative symbol TBDGen error.

<details>
<p>

Building https://github.com/tensorflow/swift-apis:

```
$ swift build
<unknown>:0: error: symbol '$s10TensorFlow09_AD__$s10a93Flow6l1Loss9predicted8expectedAA0A0VyxGAG_AGtAA0aB13FloatingPointRzlF_bb0__PB__src_0_wrt_0_10a6Flow0amnoP0VMa' (type metadata accessor for TensorFlow._AD__$s10TensorFlow6l1Loss9predicted8expectedAA0A0VyxGAG_AGtAA0aB13FloatingPointRzlF_bb0__PB__src_0_wrt_0_10TensorFlow0aB13FloatingPointRzl) is in generated IR file, but not in TBD file
<unknown>:0: error: symbol '$s10TensorFlow09_AD__$s10a93Flow6l1Loss9predicted8expectedAA0A0VyxGAG_AGtAA0aB13FloatingPointRzlF_bb0__PB__src_0_wrt_0_10a6Flow0amnoP0VMn' (nominal type descriptor for TensorFlow._AD__$s10TensorFlow6l1Loss9predicted8expectedAA0A0VyxGAG_AGtAA0aB13FloatingPointRzlF_bb0__PB__src_0_wrt_0_10TensorFlow0aB13FloatingPointRzl) is in generated IR file, but not in TBD file
<unknown>:0: error: symbol '$s10TensorFlow09_AD__$s10a95Flow6l1Loss9predicted8expectedAA0A0VyxGAG_AGtAA0aB13FloatingPointRzlF_bb0__Pred__src_0_wrt_0_10a6Flow0amnoP0OMa' (type metadata accessor for TensorFlow._AD__$s10TensorFlow6l1Loss9predicted8expectedAA0A0VyxGAG_AGtAA0aB13FloatingPointRzlF_bb0__Pred__src_0_wrt_0_10TensorFlow0aB13FloatingPointRzl) is in generated IR file, but not in TBD file
<unknown>:0: error: symbol '$s10TensorFlow09_AD__$s10a95Flow6l1Loss9predicted8expectedAA0A0VyxGAG_AGtAA0aB13FloatingPointRzlF_bb0__Pred__src_0_wrt_0_10a6Flow0amnoP0OMn' (nominal type descriptor for TensorFlow._AD__$s10TensorFlow6l1Loss9predicted8expectedAA0A0VyxGAG_AGtAA0aB13FloatingPointRzlF_bb0__Pred__src_0_wrt_0_10TensorFlow0aB13FloatingPointRzl) is in generated IR file, but not in TBD file
<unknown>:0: error: please file a radar or open a bug on bugs.swift.org with this code, and add -Xfrontend -validate-tbd-against-ir=none to squash the errors
```

</p>
</details>

I tried to minimize the reproducer to a small test, but wasn't yet successful: https://github.com/dan-zheng/swift-apis/tree/tbdgen-error-minimal

In the meantime, I'd like to land this patch to fix Swift for TensorFlow builds.