### PR TITLE
[SymbolGraph] Don't trim comment segments past the first nonspace offset

### DIFF
--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -175,9 +175,16 @@ void Symbol::serializeDocComment(llvm::json::OStream &OS) const {
 
   OS.attributeObject("docComment", [&](){
     auto LL = Graph->Ctx.getLineList(RC);
-    size_t InitialIndentation = LL.getLines().empty()
+    StringRef FirstNonBlankLine;
+    for (const auto &Line : LL.getLines()) {
+      if (!Line.Text.empty()) {
+        FirstNonBlankLine = Line.Text;
+        break;
+      }
+    }
+    size_t InitialIndentation = FirstNonBlankLine.empty()
       ? 0
-      : markup::measureIndentation(LL.getLines().front().Text);
+      : markup::measureIndentation(FirstNonBlankLine);
     OS.attributeArray("lines", [&](){
       for (const auto &Line : LL.getLines()) {
         // Line object
@@ -185,7 +192,8 @@ void Symbol::serializeDocComment(llvm::json::OStream &OS) const {
           // Trim off any initial indentation from the line's
           // text and start of its source range, if it has one.
           if (Line.Range.isValid()) {
-            serializeRange(InitialIndentation,
+            serializeRange(std::min(InitialIndentation,
+                                    Line.FirstNonspaceOffset),
                            Line.Range, Graph->M.getASTContext().SourceMgr, OS);
           }
           auto TrimmedLine = Line.Text.drop_front(std::min(InitialIndentation,

--- a/test/SymbolGraph/Symbols/Mixins/DocComment/BlockStyle.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DocComment/BlockStyle.swift
@@ -1,0 +1,500 @@
+// Stop!
+// Only add text to the bottom of this file
+// or you are going to have a bad time.
+
+// SINGLESAMELINE-LABEL: "precise": "s:10BlockStyle14SingleSameLineV"
+// SINGLESAMELINE:       "docComment": {
+// SINGLESAMELINE-NEXT:    "lines": [
+// SINGLESAMELINE-NEXT:      {
+// SINGLESAMELINE-NEXT:        "range": {
+// SINGLESAMELINE-NEXT:          "start": {
+// SINGLESAMELINE-NEXT:            "line": 23,
+// SINGLESAMELINE-NEXT:            "character": 4
+// SINGLESAMELINE-NEXT:          },
+// SINGLESAMELINE-NEXT:          "end": {
+// SINGLESAMELINE-NEXT:            "line": 23,
+// SINGLESAMELINE-NEXT:            "character": 21
+// SINGLESAMELINE-NEXT:          }
+// SINGLESAMELINE-NEXT:        },
+// SINGLESAMELINE-NEXT:        "text": "Single Same Line "
+// SINGLESAMELINE-NEXT:      }
+// SINGLESAMELINE-NEXT:    ]
+// SINGLESAMELINE-NEXT:  },
+
+/** Single Same Line */
+public struct SingleSameLine {}
+
+// EMPTY-LABEL: "precise": "s:10BlockStyle5EmptyV"
+// EMPTY:       "docComment": {
+// EMPTY-NEXT:    "lines": []
+// EMPTY-NEXT:  },
+
+/***/
+public struct Empty {}
+
+// EMPTYWITHNEWLINE-LABEL: "precise": "s:10BlockStyle16EmptyWithNewLineV"
+// EMPTHWITHNEWLINE:       "docComment": {
+// EMPTHWITHNEWLINE-NEXT:    "lines": [
+// EMPTHWITHNEWLINE-NEXT:      {
+// EMPTHWITHNEWLINE-NEXT:        "range": {
+// EMPTHWITHNEWLINE-NEXT:          "start": {
+// EMPTHWITHNEWLINE-NEXT:            "line": 54,
+// EMPTHWITHNEWLINE-NEXT:            "character": 1
+// EMPTHWITHNEWLINE-NEXT:          },
+// EMPTHWITHNEWLINE-NEXT:          "end": {
+// EMPTHWITHNEWLINE-NEXT:            "line": 54,
+// EMPTHWITHNEWLINE-NEXT:            "character": 1
+// EMPTHWITHNEWLINE-NEXT:          }
+// EMPTHWITHNEWLINE-NEXT:        },
+// EMPTHWITHNEWLINE-NEXT:        "text": ""
+// EMPTHWITHNEWLINE-NEXT:      }
+// EMPTHWITHNEWLINE-NEXT:    ]
+// EMPTHWITHNEWLINE-NEXT:  },
+
+/**
+ */
+public struct EmptyWithNewLine {}
+
+// SINGLELINE-LABEL: "precise": "s:10BlockStyle10SingleLineV"
+// SINGLELINE:       "docComment": {
+// SINGLELINE-NEXT:    "lines": [
+// SINGLELINE-NEXT:      {
+// SINGLELINE-NEXT:        "range": {
+// SINGLELINE-NEXT:          "start": {
+// SINGLELINE-NEXT:            "line": 90,
+// SINGLELINE-NEXT:            "character": 1
+// SINGLELINE-NEXT:          },
+// SINGLELINE-NEXT:          "end": {
+// SINGLELINE-NEXT:            "line": 90,
+// SINGLELINE-NEXT:            "character": 13
+// SINGLELINE-NEXT:          }
+// SINGLELINE-NEXT:        },
+// SINGLELINE-NEXT:        "text": "Single line."
+// SINGLELINE-NEXT:      },
+// SINGLELINE-NEXT:      {
+// SINGLELINE-NEXT:        "range": {
+// SINGLELINE-NEXT:          "start": {
+// SINGLELINE-NEXT:            "line": 91,
+// SINGLELINE-NEXT:            "character": 1
+// SINGLELINE-NEXT:          },
+// SINGLELINE-NEXT:          "end": {
+// SINGLELINE-NEXT:            "line": 91,
+// SINGLELINE-NEXT:            "character": 1
+// SINGLELINE-NEXT:          }
+// SINGLELINE-NEXT:        },
+// SINGLELINE-NEXT:        "text": ""
+// SINGLELINE-NEXT:      }
+// SINGLELINE-NEXT:    ]
+// SINGLELINE-NEXT:  },
+
+/**
+ Single line.
+ */
+public struct SingleLine {}
+
+// SINGLELINEWITHART-LABEL: "precise": "s:10BlockStyle17SingleLineWithArtV"
+// SINGLELINEWITHART:       "docComment": {
+// SINGLELINEWITHART-NEXT:    "lines": [
+// SINGLELINEWITHART-NEXT:      {
+// SINGLELINEWITHART-NEXT:        "range": {
+// SINGLELINEWITHART-NEXT:          "start": {
+// SINGLELINEWITHART-NEXT:            "line": 127,
+// SINGLELINEWITHART-NEXT:            "character": 3
+// SINGLELINEWITHART-NEXT:          },
+// SINGLELINEWITHART-NEXT:          "end": {
+// SINGLELINEWITHART-NEXT:            "line": 127,
+// SINGLELINEWITHART-NEXT:            "character": 24
+// SINGLELINEWITHART-NEXT:          }
+// SINGLELINEWITHART-NEXT:        },
+// SINGLELINEWITHART-NEXT:        "text": "Single line with art."
+// SINGLELINEWITHART-NEXT:      },
+// SINGLELINEWITHART-NEXT:      {
+// SINGLELINEWITHART-NEXT:        "range": {
+// SINGLELINEWITHART-NEXT:          "start": {
+// SINGLELINEWITHART-NEXT:            "line": 128,
+// SINGLELINEWITHART-NEXT:            "character": 0
+// SINGLELINEWITHART-NEXT:          },
+// SINGLELINEWITHART-NEXT:          "end": {
+// SINGLELINEWITHART-NEXT:            "line": 128,
+// SINGLELINEWITHART-NEXT:            "character": 1
+// SINGLELINEWITHART-NEXT:          }
+// SINGLELINEWITHART-NEXT:        },
+// SINGLELINEWITHART-NEXT:        "text": " "
+// SINGLELINEWITHART-NEXT:      }
+// SINGLELINEWITHART-NEXT:    ]
+// SINGLELINEWITHART-NEXT:  },
+
+/**
+ * Single line with art.
+ */
+public struct SingleLineWithArt {}
+
+// TWOLINES-LABEL: "precise": "s:10BlockStyle8TwoLinesV"
+// TWOLINES:       "docComment": {
+// TWOLINES-NEXT:    "lines": [
+// TWOLINES-NEXT:      {
+// TWOLINES-NEXT:        "range": {
+// TWOLINES-NEXT:          "start": {
+// TWOLINES-NEXT:            "line": 177,
+// TWOLINES-NEXT:            "character": 1
+// TWOLINES-NEXT:          },
+// TWOLINES-NEXT:          "end": {
+// TWOLINES-NEXT:            "line": 177,
+// TWOLINES-NEXT:            "character": 4
+// TWOLINES-NEXT:          }
+// TWOLINES-NEXT:        },
+// TWOLINES-NEXT:        "text": "Two"
+// TWOLINES-NEXT:      },
+// TWOLINES-NEXT:      {
+// TWOLINES-NEXT:        "range": {
+// TWOLINES-NEXT:          "start": {
+// TWOLINES-NEXT:            "line": 178,
+// TWOLINES-NEXT:            "character": 1
+// TWOLINES-NEXT:          },
+// TWOLINES-NEXT:          "end": {
+// TWOLINES-NEXT:            "line": 178,
+// TWOLINES-NEXT:            "character": 7
+// TWOLINES-NEXT:          }
+// TWOLINES-NEXT:        },
+// TWOLINES-NEXT:        "text": "lines."
+// TWOLINES-NEXT:      },
+// TWOLINES-NEXT:      {
+// TWOLINES-NEXT:        "range": {
+// TWOLINES-NEXT:          "start": {
+// TWOLINES-NEXT:            "line": 179,
+// TWOLINES-NEXT:            "character": 1
+// TWOLINES-NEXT:          },
+// TWOLINES-NEXT:          "end": {
+// TWOLINES-NEXT:            "line": 179,
+// TWOLINES-NEXT:            "character": 1
+// TWOLINES-NEXT:          }
+// TWOLINES-NEXT:        },
+// TWOLINES-NEXT:        "text": ""
+// TWOLINES-NEXT:      }
+// TWOLINES-NEXT:    ]
+// TWOLINES-NEXT:  },
+
+/**
+ Two
+ lines.
+ */
+public struct TwoLines {}
+
+// LARGEINDENT-LABEL: "precise": "s:10BlockStyle11LargeIndentV"
+// LARGEINDENT:       "docComment": {
+// LARGEINDENT-NEXT:    "lines": [
+// LARGEINDENT-NEXT:      {
+// LARGEINDENT-NEXT:        "range": {
+// LARGEINDENT-NEXT:          "start": {
+// LARGEINDENT-NEXT:            "line": 215,
+// LARGEINDENT-NEXT:            "character": 5
+// LARGEINDENT-NEXT:          },
+// LARGEINDENT-NEXT:          "end": {
+// LARGEINDENT-NEXT:            "line": 215,
+// LARGEINDENT-NEXT:            "character": 17
+// LARGEINDENT-NEXT:          }
+// LARGEINDENT-NEXT:        },
+// LARGEINDENT-NEXT:        "text": "Large Indent"
+// LARGEINDENT-NEXT:      },
+// LARGEINDENT-NEXT:      {
+// LARGEINDENT-NEXT:        "range": {
+// LARGEINDENT-NEXT:          "start": {
+// LARGEINDENT-NEXT:            "line": 216,
+// LARGEINDENT-NEXT:            "character": 1
+// LARGEINDENT-NEXT:          },
+// LARGEINDENT-NEXT:          "end": {
+// LARGEINDENT-NEXT:            "line": 216,
+// LARGEINDENT-NEXT:            "character": 1
+// LARGEINDENT-NEXT:          }
+// LARGEINDENT-NEXT:        },
+// LARGEINDENT-NEXT:        "text": ""
+// LARGEINDENT-NEXT:      }
+// LARGEINDENT-NEXT:    ]
+// LARGEINDENT-NEXT:  }
+
+/**
+     Large Indent
+ */
+public struct LargeIndent {}
+
+// TWOLINESBETWEENBLANK-LABEL: "precise": "s:10BlockStyle20TwoLinesBetweenBlankV"
+// TWOLINESBETWEENBLANK:       "docComment": {
+// TWOLINESBETWEENBLANK-NEXT:    "lines": [
+// TWOLINESBETWEENBLANK-NEXT:      {
+// TWOLINESBETWEENBLANK-NEXT:        "range": {
+// TWOLINESBETWEENBLANK-NEXT:          "start": {
+// TWOLINESBETWEENBLANK-NEXT:            "line": 278,
+// TWOLINESBETWEENBLANK-NEXT:            "character": 1
+// TWOLINESBETWEENBLANK-NEXT:          },
+// TWOLINESBETWEENBLANK-NEXT:          "end": {
+// TWOLINESBETWEENBLANK-NEXT:            "line": 278,
+// TWOLINESBETWEENBLANK-NEXT:            "character": 10
+// TWOLINESBETWEENBLANK-NEXT:          }
+// TWOLINESBETWEENBLANK-NEXT:        },
+// TWOLINESBETWEENBLANK-NEXT:        "text": "Two lines"
+// TWOLINESBETWEENBLANK-NEXT:      },
+// TWOLINESBETWEENBLANK-NEXT:      {
+// TWOLINESBETWEENBLANK-NEXT:        "range": {
+// TWOLINESBETWEENBLANK-NEXT:          "start": {
+// TWOLINESBETWEENBLANK-NEXT:            "line": 279,
+// TWOLINESBETWEENBLANK-NEXT:            "character": 0
+// TWOLINESBETWEENBLANK-NEXT:          },
+// TWOLINESBETWEENBLANK-NEXT:          "end": {
+// TWOLINESBETWEENBLANK-NEXT:            "line": 279,
+// TWOLINESBETWEENBLANK-NEXT:            "character": 0
+// TWOLINESBETWEENBLANK-NEXT:          }
+// TWOLINESBETWEENBLANK-NEXT:        },
+// TWOLINESBETWEENBLANK-NEXT:        "text": ""
+// TWOLINESBETWEENBLANK-NEXT:      },
+// TWOLINESBETWEENBLANK-NEXT:      {
+// TWOLINESBETWEENBLANK-NEXT:        "range": {
+// TWOLINESBETWEENBLANK-NEXT:          "start": {
+// TWOLINESBETWEENBLANK-NEXT:            "line": 280,
+// TWOLINESBETWEENBLANK-NEXT:            "character": 1
+// TWOLINESBETWEENBLANK-NEXT:          },
+// TWOLINESBETWEENBLANK-NEXT:          "end": {
+// TWOLINESBETWEENBLANK-NEXT:            "line": 280,
+// TWOLINESBETWEENBLANK-NEXT:            "character": 14
+// TWOLINESBETWEENBLANK-NEXT:          }
+// TWOLINESBETWEENBLANK-NEXT:        },
+// TWOLINESBETWEENBLANK-NEXT:        "text": "Between Blank"
+// TWOLINESBETWEENBLANK-NEXT:      },
+// TWOLINESBETWEENBLANK-NEXT:      {
+// TWOLINESBETWEENBLANK-NEXT:        "range": {
+// TWOLINESBETWEENBLANK-NEXT:          "start": {
+// TWOLINESBETWEENBLANK-NEXT:            "line": 281,
+// TWOLINESBETWEENBLANK-NEXT:            "character": 1
+// TWOLINESBETWEENBLANK-NEXT:          },
+// TWOLINESBETWEENBLANK-NEXT:          "end": {
+// TWOLINESBETWEENBLANK-NEXT:            "line": 281,
+// TWOLINESBETWEENBLANK-NEXT:            "character": 1
+// TWOLINESBETWEENBLANK-NEXT:          }
+// TWOLINESBETWEENBLANK-NEXT:        },
+// TWOLINESBETWEENBLANK-NEXT:        "text": ""
+// TWOLINESBETWEENBLANK-NEXT:      }
+// TWOLINESBETWEENBLANK-NEXT:    ]
+// TWOLINESBETWEENBLANK-NEXT:  },
+
+/**
+ Two lines
+
+ Between Blank
+ */
+public struct TwoLinesBetweenBlank {}
+
+// LEADINGBLANK-LABEL: "precise": "s:10BlockStyle12LeadingBlankV"
+// LEADINGBLANK:       "docComment": {
+// LEADINGBLANK-NEXT:    "lines": [
+// LEADINGBLANK-NEXT:      {
+// LEADINGBLANK-NEXT:        "range": {
+// LEADINGBLANK-NEXT:          "start": {
+// LEADINGBLANK-NEXT:            "line": 330,
+// LEADINGBLANK-NEXT:            "character": 0
+// LEADINGBLANK-NEXT:          },
+// LEADINGBLANK-NEXT:          "end": {
+// LEADINGBLANK-NEXT:            "line": 330,
+// LEADINGBLANK-NEXT:            "character": 0
+// LEADINGBLANK-NEXT:          }
+// LEADINGBLANK-NEXT:        },
+// LEADINGBLANK-NEXT:        "text": ""
+// LEADINGBLANK-NEXT:      },
+// LEADINGBLANK-NEXT:      {
+// LEADINGBLANK-NEXT:        "range": {
+// LEADINGBLANK-NEXT:          "start": {
+// LEADINGBLANK-NEXT:            "line": 331,
+// LEADINGBLANK-NEXT:            "character": 1
+// LEADINGBLANK-NEXT:          },
+// LEADINGBLANK-NEXT:          "end": {
+// LEADINGBLANK-NEXT:            "line": 331,
+// LEADINGBLANK-NEXT:            "character": 14
+// LEADINGBLANK-NEXT:          }
+// LEADINGBLANK-NEXT:        },
+// LEADINGBLANK-NEXT:        "text": "Leading Blank"
+// LEADINGBLANK-NEXT:      },
+// LEADINGBLANK-NEXT:      {
+// LEADINGBLANK-NEXT:        "range": {
+// LEADINGBLANK-NEXT:          "start": {
+// LEADINGBLANK-NEXT:            "line": 332,
+// LEADINGBLANK-NEXT:            "character": 1
+// LEADINGBLANK-NEXT:          },
+// LEADINGBLANK-NEXT:          "end": {
+// LEADINGBLANK-NEXT:            "line": 332,
+// LEADINGBLANK-NEXT:            "character": 1
+// LEADINGBLANK-NEXT:          }
+// LEADINGBLANK-NEXT:        },
+// LEADINGBLANK-NEXT:        "text": ""
+// LEADINGBLANK-NEXT:      }
+// LEADINGBLANK-NEXT:    ]
+// LEADINGBLANK-NEXT:  },
+
+/**
+
+ Leading Blank
+ */
+public struct LeadingBlank {}
+
+// TRAILINGBLANK-LABEL: "precise": "s:10BlockStyle13TrailingBlankV"
+// TRAILINGBLANK:       "docComment": {
+// TRAILINGBLANK-NEXT:    "lines": [
+// TRAILINGBLANK-NEXT:      {
+// TRAILINGBLANK-NEXT:        "range": {
+// TRAILINGBLANK-NEXT:          "start": {
+// TRAILINGBLANK-NEXT:            "line": 381,
+// TRAILINGBLANK-NEXT:            "character": 1
+// TRAILINGBLANK-NEXT:          },
+// TRAILINGBLANK-NEXT:          "end": {
+// TRAILINGBLANK-NEXT:            "line": 381,
+// TRAILINGBLANK-NEXT:            "character": 15
+// TRAILINGBLANK-NEXT:          }
+// TRAILINGBLANK-NEXT:        },
+// TRAILINGBLANK-NEXT:        "text": "Trailing Blank"
+// TRAILINGBLANK-NEXT:      },
+// TRAILINGBLANK-NEXT:      {
+// TRAILINGBLANK-NEXT:        "range": {
+// TRAILINGBLANK-NEXT:          "start": {
+// TRAILINGBLANK-NEXT:            "line": 382,
+// TRAILINGBLANK-NEXT:            "character": 0
+// TRAILINGBLANK-NEXT:          },
+// TRAILINGBLANK-NEXT:          "end": {
+// TRAILINGBLANK-NEXT:            "line": 382,
+// TRAILINGBLANK-NEXT:            "character": 0
+// TRAILINGBLANK-NEXT:          }
+// TRAILINGBLANK-NEXT:        },
+// TRAILINGBLANK-NEXT:        "text": ""
+// TRAILINGBLANK-NEXT:      },
+// TRAILINGBLANK-NEXT:      {
+// TRAILINGBLANK-NEXT:        "range": {
+// TRAILINGBLANK-NEXT:          "start": {
+// TRAILINGBLANK-NEXT:            "line": 383,
+// TRAILINGBLANK-NEXT:            "character": 1
+// TRAILINGBLANK-NEXT:          },
+// TRAILINGBLANK-NEXT:          "end": {
+// TRAILINGBLANK-NEXT:            "line": 383,
+// TRAILINGBLANK-NEXT:            "character": 1
+// TRAILINGBLANK-NEXT:          }
+// TRAILINGBLANK-NEXT:        },
+// TRAILINGBLANK-NEXT:        "text": ""
+// TRAILINGBLANK-NEXT:      }
+// TRAILINGBLANK-NEXT:    ]
+// TRAILINGBLANK-NEXT:  },
+
+/**
+ Trailing Blank
+
+ */
+public struct TrailingBlank {}
+
+// BOUNDBLANK-LABEL: "precise": "s:10BlockStyle10BoundBlankV"
+// BOUNDBLANK:       "docComment": {
+// BOUNDBLANK-NEXT:    "lines": [
+// BOUNDBLANK-NEXT:      {
+// BOUNDBLANK-NEXT:        "range": {
+// BOUNDBLANK-NEXT:          "start": {
+// BOUNDBLANK-NEXT:            "line": 445,
+// BOUNDBLANK-NEXT:            "character": 0
+// BOUNDBLANK-NEXT:          },
+// BOUNDBLANK-NEXT:          "end": {
+// BOUNDBLANK-NEXT:            "line": 445,
+// BOUNDBLANK-NEXT:            "character": 0
+// BOUNDBLANK-NEXT:          }
+// BOUNDBLANK-NEXT:        },
+// BOUNDBLANK-NEXT:        "text": ""
+// BOUNDBLANK-NEXT:      },
+// BOUNDBLANK-NEXT:      {
+// BOUNDBLANK-NEXT:        "range": {
+// BOUNDBLANK-NEXT:          "start": {
+// BOUNDBLANK-NEXT:            "line": 446,
+// BOUNDBLANK-NEXT:            "character": 1
+// BOUNDBLANK-NEXT:          },
+// BOUNDBLANK-NEXT:          "end": {
+// BOUNDBLANK-NEXT:            "line": 446,
+// BOUNDBLANK-NEXT:            "character": 12
+// BOUNDBLANK-NEXT:          }
+// BOUNDBLANK-NEXT:        },
+// BOUNDBLANK-NEXT:        "text": "Bound Blank"
+// BOUNDBLANK-NEXT:      },
+// BOUNDBLANK-NEXT:      {
+// BOUNDBLANK-NEXT:        "range": {
+// BOUNDBLANK-NEXT:          "start": {
+// BOUNDBLANK-NEXT:            "line": 447,
+// BOUNDBLANK-NEXT:            "character": 0
+// BOUNDBLANK-NEXT:          },
+// BOUNDBLANK-NEXT:          "end": {
+// BOUNDBLANK-NEXT:            "line": 447,
+// BOUNDBLANK-NEXT:            "character": 0
+// BOUNDBLANK-NEXT:          }
+// BOUNDBLANK-NEXT:        },
+// BOUNDBLANK-NEXT:        "text": ""
+// BOUNDBLANK-NEXT:      },
+// BOUNDBLANK-NEXT:      {
+// BOUNDBLANK-NEXT:        "range": {
+// BOUNDBLANK-NEXT:          "start": {
+// BOUNDBLANK-NEXT:            "line": 448,
+// BOUNDBLANK-NEXT:            "character": 1
+// BOUNDBLANK-NEXT:          },
+// BOUNDBLANK-NEXT:          "end": {
+// BOUNDBLANK-NEXT:            "line": 448,
+// BOUNDBLANK-NEXT:            "character": 1
+// BOUNDBLANK-NEXT:          }
+// BOUNDBLANK-NEXT:        },
+// BOUNDBLANK-NEXT:        "text": ""
+// BOUNDBLANK-NEXT:      }
+// BOUNDBLANK-NEXT:    ]
+// BOUNDBLANK-NEXT:  },
+
+/**
+
+ Bound Blank
+
+ */
+public struct BoundBlank {}
+
+// ALLINDENTED-LABEL: "precise": "s:10BlockStyle11AllIndentedV"
+// ALLINDENTED:       "docComment": {
+// ALLINDENTED-NEXT:    "lines": [
+// ALLINDENTED-NEXT:      {
+// ALLINDENTED-NEXT:        "range": {
+// ALLINDENTED-NEXT:          "start": {
+// ALLINDENTED-NEXT:            "line": 484,
+// ALLINDENTED-NEXT:            "character": 5
+// ALLINDENTED-NEXT:          },
+// ALLINDENTED-NEXT:          "end": {
+// ALLINDENTED-NEXT:            "line": 484,
+// ALLINDENTED-NEXT:            "character": 18
+// ALLINDENTED-NEXT:          }
+// ALLINDENTED-NEXT:        },
+// ALLINDENTED-NEXT:        "text": "All indented."
+// ALLINDENTED-NEXT:      },
+// ALLINDENTED-NEXT:      {
+// ALLINDENTED-NEXT:        "range": {
+// ALLINDENTED-NEXT:          "start": {
+// ALLINDENTED-NEXT:            "line": 485,
+// ALLINDENTED-NEXT:            "character": 5
+// ALLINDENTED-NEXT:          },
+// ALLINDENTED-NEXT:          "end": {
+// ALLINDENTED-NEXT:            "line": 485,
+// ALLINDENTED-NEXT:            "character": 5
+// ALLINDENTED-NEXT:          }
+// ALLINDENTED-NEXT:        },
+// ALLINDENTED-NEXT:        "text": ""
+// ALLINDENTED-NEXT:      }
+// ALLINDENTED-NEXT:    ]
+// ALLINDENTED-NEXT:  },
+
+    /**
+     All indented.
+     */
+     public struct AllIndented {}
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name BlockStyle -emit-module-path %t/BlockStyle.swiftmodule
+// RUN: %target-swift-symbolgraph-extract -module-name BlockStyle -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/BlockStyle.symbols.json --check-prefix=SINGLESAMELINE
+// RUN: %FileCheck %s --input-file %t/BlockStyle.symbols.json --check-prefix=EMPTY
+// RUN: %FileCheck %s --input-file %t/BlockStyle.symbols.json --check-prefix=EMPTYWITHNEWLINE
+// RUN: %FileCheck %s --input-file %t/BlockStyle.symbols.json --check-prefix=SINGLELINE
+// RUN: %FileCheck %s --input-file %t/BlockStyle.symbols.json --check-prefix=SINGLELINEWITHART
+// RUN: %FileCheck %s --input-file %t/BlockStyle.symbols.json --check-prefix=LARGEINDENT
+// RUN: %FileCheck %s --input-file %t/BlockStyle.symbols.json --check-prefix=TWOLINESBETWEENBLANK
+// RUN: %FileCheck %s --input-file %t/BlockStyle.symbols.json --check-prefix=LEADINGBLANK
+// RUN: %FileCheck %s --input-file %t/BlockStyle.symbols.json --check-prefix=TRAILINGBLANK

--- a/test/SymbolGraph/Symbols/Mixins/DocComment/LineStyle.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DocComment/LineStyle.swift
@@ -1,0 +1,312 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name LineStyle -emit-module-path %t/LineStyle.swiftmodule
+// RUN: %target-swift-symbolgraph-extract -module-name LineStyle -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/LineStyle.symbols.json --check-prefix=SINGLELINE
+// RUN: %FileCheck %s --input-file %t/LineStyle.symbols.json --check-prefix=TWOLINES
+// RUN: %FileCheck %s --input-file %t/LineStyle.symbols.json --check-prefix=TWOLINESAROUNDBLANK
+// RUN: %FileCheck %s --input-file %t/LineStyle.symbols.json --check-prefix=EMPTY
+// RUN: %FileCheck %s --input-file %t/LineStyle.symbols.json --check-prefix=MULTIEMPTY
+// RUN: %FileCheck %s --input-file %t/LineStyle.symbols.json --check-prefix=LEADINGBLANK
+// RUN: %FileCheck %s --input-file %t/LineStyle.symbols.json --check-prefix=TRAILINGBLANK
+
+// SINGLELINE-LABEL: "precise": "s:9LineStyle06SingleA0V"
+// SINGLELINE:       "docComment": {
+// SINGLELINE-NEXT:    "lines": [
+// SINGLELINE-NEXT:      {
+// SINGLELINE-NEXT:        "range": {
+// SINGLELINE-NEXT:          "start": {
+// SINGLELINE-NEXT:            "line": 30,
+// SINGLELINE-NEXT:            "character": 4
+// SINGLELINE-NEXT:          },
+// SINGLELINE-NEXT:          "end": {
+// SINGLELINE-NEXT:            "line": 30,
+// SINGLELINE-NEXT:            "character": 16
+// SINGLELINE-NEXT:          }
+// SINGLELINE-NEXT:        },
+// SINGLELINE-NEXT:        "text": "Single line."
+// SINGLELINE-NEXT:      }
+// SINGLELINE-NEXT:    ]
+// SINGLELINE-NEXT:  }
+
+/// Single line.
+public struct SingleLine {}
+
+// TWOLINES-LABEL: "precise": "s:9LineStyle8TwoLinesV"
+// TWOLINES:       "docComment": {
+// TWOLINES-NEXT:    "lines": [
+// TWOLINES-NEXT:      {
+// TWOLINES-NEXT:        "range": {
+// TWOLINES-NEXT:          "start": {
+// TWOLINES-NEXT:            "line": 65,
+// TWOLINES-NEXT:            "character": 4
+// TWOLINES-NEXT:          },
+// TWOLINES-NEXT:          "end": {
+// TWOLINES-NEXT:            "line": 65,
+// TWOLINES-NEXT:            "character": 7
+// TWOLINES-NEXT:          }
+// TWOLINES-NEXT:        },
+// TWOLINES-NEXT:        "text": "Two"
+// TWOLINES-NEXT:      },
+// TWOLINES-NEXT:      {
+// TWOLINES-NEXT:        "range": {
+// TWOLINES-NEXT:          "start": {
+// TWOLINES-NEXT:            "line": 66,
+// TWOLINES-NEXT:            "character": 4
+// TWOLINES-NEXT:          },
+// TWOLINES-NEXT:          "end": {
+// TWOLINES-NEXT:            "line": 66,
+// TWOLINES-NEXT:            "character": 10
+// TWOLINES-NEXT:          }
+// TWOLINES-NEXT:        },
+// TWOLINES-NEXT:        "text": "lines."
+// TWOLINES-NEXT:      }
+// TWOLINES-NEXT:    ]
+// TWOLINES-NEXT:  },
+
+/// Two
+/// lines.
+public struct TwoLines {}
+
+// TWOLINESAROUNDBLANK-LABEL: "precise": "s:9LineStyle19TwoLinesAroundBlankV"
+// TWOLINESAROUNDBLANK:       "docComment": {
+// TWOLINESAROUNDBLANK-NEXT:    "lines": [
+// TWOLINESAROUNDBLANK-NEXT:      {
+// TWOLINESAROUNDBLANK-NEXT:        "range": {
+// TWOLINESAROUNDBLANK-NEXT:          "start": {
+// TWOLINESAROUNDBLANK-NEXT:            "line": 114,
+// TWOLINESAROUNDBLANK-NEXT:            "character": 4
+// TWOLINESAROUNDBLANK-NEXT:          },
+// TWOLINESAROUNDBLANK-NEXT:          "end": {
+// TWOLINESAROUNDBLANK-NEXT:            "line": 114,
+// TWOLINESAROUNDBLANK-NEXT:            "character": 13
+// TWOLINESAROUNDBLANK-NEXT:          }
+// TWOLINESAROUNDBLANK-NEXT:        },
+// TWOLINESAROUNDBLANK-NEXT:        "text": "Two lines"
+// TWOLINESAROUNDBLANK-NEXT:      },
+// TWOLINESAROUNDBLANK-NEXT:      {
+// TWOLINESAROUNDBLANK-NEXT:        "range": {
+// TWOLINESAROUNDBLANK-NEXT:          "start": {
+// TWOLINESAROUNDBLANK-NEXT:            "line": 115,
+// TWOLINESAROUNDBLANK-NEXT:            "character": 3
+// TWOLINESAROUNDBLANK-NEXT:          },
+// TWOLINESAROUNDBLANK-NEXT:          "end": {
+// TWOLINESAROUNDBLANK-NEXT:            "line": 115,
+// TWOLINESAROUNDBLANK-NEXT:            "character": 3
+// TWOLINESAROUNDBLANK-NEXT:          }
+// TWOLINESAROUNDBLANK-NEXT:        },
+// TWOLINESAROUNDBLANK-NEXT:        "text": ""
+// TWOLINESAROUNDBLANK-NEXT:      },
+// TWOLINESAROUNDBLANK-NEXT:      {
+// TWOLINESAROUNDBLANK-NEXT:        "range": {
+// TWOLINESAROUNDBLANK-NEXT:          "start": {
+// TWOLINESAROUNDBLANK-NEXT:            "line": 116,
+// TWOLINESAROUNDBLANK-NEXT:            "character": 4
+// TWOLINESAROUNDBLANK-NEXT:          },
+// TWOLINESAROUNDBLANK-NEXT:          "end": {
+// TWOLINESAROUNDBLANK-NEXT:            "line": 116,
+// TWOLINESAROUNDBLANK-NEXT:            "character": 16
+// TWOLINESAROUNDBLANK-NEXT:          }
+// TWOLINESAROUNDBLANK-NEXT:        },
+// TWOLINESAROUNDBLANK-NEXT:        "text": "Around Blank"
+// TWOLINESAROUNDBLANK-NEXT:      }
+// TWOLINESAROUNDBLANK-NEXT:    ]
+// TWOLINESAROUNDBLANK-NEXT:  }
+
+/// Two lines
+///
+/// Around Blank
+public struct TwoLinesAroundBlank {}
+
+// EMPTY-LABEL: "precise": "s:9LineStyle5EmptyV"
+// EMPTY:       "docComment": {
+// EMPTY-NEXT:    "lines": [
+// EMPTY-NEXT:      {
+// EMPTY-NEXT:        "range": {
+// EMPTY-NEXT:          "start": {
+// EMPTY-NEXT:            "line": 138,
+// EMPTY-NEXT:            "character": 3
+// EMPTY-NEXT:          },
+// EMPTY-NEXT:          "end": {
+// EMPTY-NEXT:            "line": 138,
+// EMPTY-NEXT:            "character": 3
+// EMPTY-NEXT:          }
+// EMPTY-NEXT:        },
+// EMPTY-NEXT:        "text": ""
+// EMPTY-NEXT:      }
+// EMPTY-NEXT:    ]
+// EMPTY-NEXT:  },
+
+///
+public struct Empty {}
+
+// MULTIEMPTY-LABEL: "precise": "s:9LineStyle10MultiEmptyV"
+// MULTIEMPTY:       "docComment": {
+// MULTIEMPTY-NEXT:    "lines": [
+// MULTIEMPTY-NEXT:      {
+// MULTIEMPTY-NEXT:        "range": {
+// MULTIEMPTY-NEXT:          "start": {
+// MULTIEMPTY-NEXT:            "line": 186,
+// MULTIEMPTY-NEXT:            "character": 3
+// MULTIEMPTY-NEXT:          },
+// MULTIEMPTY-NEXT:          "end": {
+// MULTIEMPTY-NEXT:            "line": 186,
+// MULTIEMPTY-NEXT:            "character": 3
+// MULTIEMPTY-NEXT:          }
+// MULTIEMPTY-NEXT:        },
+// MULTIEMPTY-NEXT:        "text": ""
+// MULTIEMPTY-NEXT:      },
+// MULTIEMPTY-NEXT:      {
+// MULTIEMPTY-NEXT:        "range": {
+// MULTIEMPTY-NEXT:          "start": {
+// MULTIEMPTY-NEXT:            "line": 187,
+// MULTIEMPTY-NEXT:            "character": 3
+// MULTIEMPTY-NEXT:          },
+// MULTIEMPTY-NEXT:          "end": {
+// MULTIEMPTY-NEXT:            "line": 187,
+// MULTIEMPTY-NEXT:            "character": 3
+// MULTIEMPTY-NEXT:          }
+// MULTIEMPTY-NEXT:        },
+// MULTIEMPTY-NEXT:        "text": ""
+// MULTIEMPTY-NEXT:      },
+// MULTIEMPTY-NEXT:      {
+// MULTIEMPTY-NEXT:        "range": {
+// MULTIEMPTY-NEXT:          "start": {
+// MULTIEMPTY-NEXT:            "line": 188,
+// MULTIEMPTY-NEXT:            "character": 3
+// MULTIEMPTY-NEXT:          },
+// MULTIEMPTY-NEXT:          "end": {
+// MULTIEMPTY-NEXT:            "line": 188,
+// MULTIEMPTY-NEXT:            "character": 3
+// MULTIEMPTY-NEXT:          }
+// MULTIEMPTY-NEXT:        },
+// MULTIEMPTY-NEXT:        "text": ""
+// MULTIEMPTY-NEXT:      }
+// MULTIEMPTY-NEXT:    ]
+// MULTIEMPTY-NEXT:  },
+
+///
+///
+///
+public struct MultiEmpty {}
+
+// LEADINGBLANK-LABEL: "precise": "s:9LineStyle12LeadingBlankV",
+// LEADINGBLANK:       "docComment": {
+// LEADINGBLANK-NEXT:    "lines": [
+// LEADINGBLANK-NEXT:      {
+// LEADINGBLANK-NEXT:        "range": {
+// LEADINGBLANK-NEXT:          "start": {
+// LEADINGBLANK-NEXT:            "line": 223,
+// LEADINGBLANK-NEXT:            "character": 3
+// LEADINGBLANK-NEXT:          },
+// LEADINGBLANK-NEXT:          "end": {
+// LEADINGBLANK-NEXT:            "line": 223,
+// LEADINGBLANK-NEXT:            "character": 3
+// LEADINGBLANK-NEXT:          }
+// LEADINGBLANK-NEXT:        },
+// LEADINGBLANK-NEXT:        "text": ""
+// LEADINGBLANK-NEXT:      },
+// LEADINGBLANK-NEXT:      {
+// LEADINGBLANK-NEXT:        "range": {
+// LEADINGBLANK-NEXT:          "start": {
+// LEADINGBLANK-NEXT:            "line": 224,
+// LEADINGBLANK-NEXT:            "character": 4
+// LEADINGBLANK-NEXT:          },
+// LEADINGBLANK-NEXT:          "end": {
+// LEADINGBLANK-NEXT:            "line": 224,
+// LEADINGBLANK-NEXT:            "character": 17
+// LEADINGBLANK-NEXT:          }
+// LEADINGBLANK-NEXT:        },
+// LEADINGBLANK-NEXT:        "text": "Leading Blank"
+// LEADINGBLANK-NEXT:      }
+// LEADINGBLANK-NEXT:    ]
+// LEADINGBLANK-NEXT:  }
+
+///
+/// Leading Blank
+public struct LeadingBlank {}
+
+// TRAILINGBLANK-LABEL: "precise": "s:9LineStyle13TrailingBlankV"
+// TRAILINGBLANK:       "docComment": {
+// TRAILINGBLANK-NEXT:    "lines": [
+// TRAILINGBLANK-NEXT:      {
+// TRAILINGBLANK-NEXT:        "range": {
+// TRAILINGBLANK-NEXT:          "start": {
+// TRAILINGBLANK-NEXT:            "line": 259,
+// TRAILINGBLANK-NEXT:            "character": 4
+// TRAILINGBLANK-NEXT:          },
+// TRAILINGBLANK-NEXT:          "end": {
+// TRAILINGBLANK-NEXT:            "line": 259,
+// TRAILINGBLANK-NEXT:            "character": 18
+// TRAILINGBLANK-NEXT:          }
+// TRAILINGBLANK-NEXT:        },
+// TRAILINGBLANK-NEXT:        "text": "Trailing Blank"
+// TRAILINGBLANK-NEXT:      },
+// TRAILINGBLANK-NEXT:      {
+// TRAILINGBLANK-NEXT:        "range": {
+// TRAILINGBLANK-NEXT:          "start": {
+// TRAILINGBLANK-NEXT:            "line": 260,
+// TRAILINGBLANK-NEXT:            "character": 3
+// TRAILINGBLANK-NEXT:          },
+// TRAILINGBLANK-NEXT:          "end": {
+// TRAILINGBLANK-NEXT:            "line": 260,
+// TRAILINGBLANK-NEXT:            "character": 3
+// TRAILINGBLANK-NEXT:          }
+// TRAILINGBLANK-NEXT:        },
+// TRAILINGBLANK-NEXT:        "text": ""
+// TRAILINGBLANK-NEXT:      }
+// TRAILINGBLANK-NEXT:    ]
+// TRAILINGBLANK-NEXT:  },
+
+/// Trailing Blank
+///
+public struct TrailingBlank {} 
+
+// BOUNDBLANK-LABEL: "precise": "s:9LineStyle10BoundBlankV"
+// BOUNDBLANK:       "docComment": {
+// BOUNDBLANK-NEXT:    "lines": [
+// BOUNDBLANK-NEXT:      {
+// BOUNDBLANK-NEXT:        "range": {
+// BOUNDBLANK-NEXT:          "start": {
+// BOUNDBLANK-NEXT:            "line": 308,
+// BOUNDBLANK-NEXT:            "character": 3
+// BOUNDBLANK-NEXT:          },
+// BOUNDBLANK-NEXT:          "end": {
+// BOUNDBLANK-NEXT:            "line": 308,
+// BOUNDBLANK-NEXT:            "character": 3
+// BOUNDBLANK-NEXT:          }
+// BOUNDBLANK-NEXT:        },
+// BOUNDBLANK-NEXT:        "text": ""
+// BOUNDBLANK-NEXT:      },
+// BOUNDBLANK-NEXT:      {
+// BOUNDBLANK-NEXT:        "range": {
+// BOUNDBLANK-NEXT:          "start": {
+// BOUNDBLANK-NEXT:            "line": 309,
+// BOUNDBLANK-NEXT:            "character": 3
+// BOUNDBLANK-NEXT:          },
+// BOUNDBLANK-NEXT:          "end": {
+// BOUNDBLANK-NEXT:            "line": 309,
+// BOUNDBLANK-NEXT:            "character": 15
+// BOUNDBLANK-NEXT:          }
+// BOUNDBLANK-NEXT:        },
+// BOUNDBLANK-NEXT:        "text": " Bound Blank"
+// BOUNDBLANK-NEXT:      },
+// BOUNDBLANK-NEXT:      {
+// BOUNDBLANK-NEXT:        "range": {
+// BOUNDBLANK-NEXT:          "start": {
+// BOUNDBLANK-NEXT:            "line": 310,
+// BOUNDBLANK-NEXT:            "character": 3
+// BOUNDBLANK-NEXT:          },
+// BOUNDBLANK-NEXT:          "end": {
+// BOUNDBLANK-NEXT:            "line": 310,
+// BOUNDBLANK-NEXT:            "character": 3
+// BOUNDBLANK-NEXT:          }
+// BOUNDBLANK-NEXT:        },
+// BOUNDBLANK-NEXT:        "text": ""
+// BOUNDBLANK-NEXT:      }
+// BOUNDBLANK-NEXT:    ]
+// BOUNDBLANK-NEXT:  },
+
+///
+/// Bound Blank
+///
+public struct BoundBlank {}


### PR DESCRIPTION
Otherwise, the `SourceManager` may skip over a blank line, causing
it to have a line number off by one.

Measure initial indentation from the first non-blank line.

rdar://61827368