### PR TITLE
Move interleave(...) to the llvm namespace

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -202,7 +202,7 @@ struct SILAutoDiffIndices {
 
   std::string mangle() const {
     std::string result = "src_" + llvm::utostr(source) + "_wrt_";
-    interleave(
+    llvm::interleave(
         parameters->getIndices(),
         [&](unsigned idx) { result += llvm::utostr(idx); },
         [&] { result += '_'; });

--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -69,6 +69,10 @@ struct function_traits<R (T::*)(Args...) const> {
   using argument_types = std::tuple<Args...>;
 };
 
+} // end namespace swift
+
+namespace llvm {
+
 /// @{
 
 /// An STL-style algorithm similar to std::for_each that applies a second
@@ -103,6 +107,11 @@ inline void interleave(const Container &c, UnaryFunctor each_fn,
 }
 
 /// @}
+
+} // end namespace llvm
+
+namespace swift {
+
 /// @{
 
 /// The equivalent of std::for_each, but for two lists at once.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1477,25 +1477,26 @@ void PrintAST::printSingleDepthOfGenericSignature(
   if (printParams) {
     // Print the generic parameters.
     Printer << "<";
-    interleave(genericParams,
-               [&](GenericTypeParamType *param) {
-                 if (!subMap.empty()) {
-                   if (auto argTy = substParam(param))
-                     printType(argTy);
-                   else
-                     printType(param);
-                 } else if (auto *GP = param->getDecl()) {
-                   Printer.callPrintStructurePre(
-                       PrintStructureKind::GenericParameter, GP);
-                   Printer.printName(GP->getName(),
-                                     PrintNameContext::GenericParameter);
-                   Printer.printStructurePost(
-                       PrintStructureKind::GenericParameter, GP);
-                 } else {
-                   printType(param);
-                 }
-               },
-               [&] { Printer << ", "; });
+    llvm::interleave(
+        genericParams,
+        [&](GenericTypeParamType *param) {
+          if (!subMap.empty()) {
+            if (auto argTy = substParam(param))
+              printType(argTy);
+            else
+              printType(param);
+          } else if (auto *GP = param->getDecl()) {
+            Printer.callPrintStructurePre(PrintStructureKind::GenericParameter,
+                                          GP);
+            Printer.printName(GP->getName(),
+                              PrintNameContext::GenericParameter);
+            Printer.printStructurePost(PrintStructureKind::GenericParameter,
+                                       GP);
+          } else {
+            printType(param);
+          }
+        },
+        [&] { Printer << ", "; });
   }
 
   if (printRequirements || printInherited) {
@@ -3025,7 +3026,7 @@ void PrintAST::visitEnumCaseDecl(EnumCaseDecl *decl) {
   }
   Printer << tok::kw_case << " ";
 
-  interleave(elems.begin(), elems.end(),
+  llvm::interleave(elems.begin(), elems.end(),
     [&](EnumElementDecl *elt) {
       printEnumElement(elt);
     },
@@ -4438,9 +4439,9 @@ public:
       if (!T->getSubstitutions().empty()) {
         Printer << '<';
         auto replacements = T->getSubstitutions().getReplacementTypes();
-        interleave(replacements.begin(), replacements.end(),
-                   [&](Type t) { visit(t); },
-                   [&] { Printer << ", "; });
+        llvm::interleave(
+            replacements.begin(), replacements.end(), [&](Type t) { visit(t); },
+            [&] { Printer << ", "; });
         Printer << '>';
       }
       return;

--- a/lib/AST/ASTScopePrinting.cpp
+++ b/lib/AST/ASTScopePrinting.cpp
@@ -65,9 +65,10 @@ void ASTScopeImpl::dumpOneScopeMapLocation(
   locScope->lookupLocalsOrMembers({this}, gatherer);
   if (!gatherer.getDecls().empty()) {
     llvm::errs() << "Local bindings: ";
-    interleave(gatherer.getDecls().begin(), gatherer.getDecls().end(),
-               [&](ValueDecl *value) { llvm::errs() << value->getFullName(); },
-               [&]() { llvm::errs() << " "; });
+    llvm::interleave(
+        gatherer.getDecls().begin(), gatherer.getDecls().end(),
+        [&](ValueDecl *value) { llvm::errs() << value->getFullName(); },
+        [&]() { llvm::errs() << " "; });
     llvm::errs() << "\n";
   }
 }

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -29,13 +29,13 @@
 using namespace swift;
 
 void ConformanceAccessPath::print(raw_ostream &out) const {
-  interleave(begin(), end(),
-             [&](const Entry &entry) {
-               entry.first.print(out);
-               out << ": " << entry.second->getName();
-             }, [&] {
-               out << " -> ";
-             });
+  llvm::interleave(
+      begin(), end(),
+      [&](const Entry &entry) {
+        entry.first.print(out);
+        out << ": " << entry.second->getName();
+      },
+      [&] { out << " -> "; });
 }
 
 void ConformanceAccessPath::dump() const {

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2139,16 +2139,16 @@ void EquivalenceClass::dump(llvm::raw_ostream &out,
              },
              [&] { out << ", "; });
   out << "\nSame-type constraints:";
-  interleave(sameTypeConstraints,
-             [&](const Constraint<Type> &constraint) {
-               out << "\n  " << constraint.getSubjectDependentType({ })
-                   << " == " << constraint.value;
+  llvm::interleave(
+      sameTypeConstraints,
+      [&](const Constraint<Type> &constraint) {
+        out << "\n  " << constraint.getSubjectDependentType({})
+            << " == " << constraint.value;
 
-               if (constraint.source->isDerivedRequirement())
-                 out << " [derived]";
-             }, [&] {
-               out << ", ";
-             });
+        if (constraint.source->isDerivedRequirement())
+          out << " [derived]";
+      },
+      [&] { out << ", "; });
   if (concreteType)
     out << "\nConcrete type: " << concreteType.getString();
   if (superclass)
@@ -2922,15 +2922,15 @@ void RewritePath::print(llvm::raw_ostream &out) const {
     if (!getPath().empty()) out << " -> ";
   }
 
-  interleave(getPath().begin(), getPath().end(),
-             [&](AssociatedTypeDecl *assocType) {
-               out.changeColor(raw_ostream::BLUE);
-               out << assocType->getProtocol()->getName() << "."
-               << assocType->getName();
-               out.resetColor();
-             }, [&] {
-               out << " -> ";
-             });
+  llvm::interleave(
+      getPath().begin(), getPath().end(),
+      [&](AssociatedTypeDecl *assocType) {
+        out.changeColor(raw_ostream::BLUE);
+        out << assocType->getProtocol()->getName() << "."
+            << assocType->getName();
+        out.resetColor();
+      },
+      [&] { out << " -> "; });
   out << "]";
 }
 

--- a/lib/AST/IndexSubset.cpp
+++ b/lib/AST/IndexSubset.cpp
@@ -80,8 +80,9 @@ IndexSubset *IndexSubset::extendingCapacity(
 
 void IndexSubset::print(llvm::raw_ostream &s) const {
   s << '{';
-  interleave(range(capacity), [this, &s](unsigned i) { s << contains(i); },
-             [&s] { s << ", "; });
+  llvm::interleave(
+      range(capacity), [this, &s](unsigned i) { s << contains(i); },
+      [&s] { s << ", "; });
   s << '}';
 }
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1479,9 +1479,9 @@ void
 ModuleDecl::ReverseFullNameIterator::printForward(raw_ostream &out,
                                                   StringRef delim) const {
   SmallVector<StringRef, 8> elements(*this, {});
-  swift::interleave(llvm::reverse(elements),
-                    [&out](StringRef next) { out << next; },
-                    [&out, delim] { out << delim; });
+  llvm::interleave(
+      llvm::reverse(elements), [&out](StringRef next) { out << next; },
+      [&out, delim] { out << delim; });
 }
 
 void

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -928,9 +928,9 @@ ClangImporter::create(ASTContext &ctx, const ClangImporterOptions &importerOpts,
 
   if (importerOpts.DumpClangDiagnostics) {
     llvm::errs() << "'";
-    interleave(invocationArgStrs,
-               [](StringRef arg) { llvm::errs() << arg; },
-               [] { llvm::errs() << "' '"; });
+    llvm::interleave(
+        invocationArgStrs, [](StringRef arg) { llvm::errs() << arg; },
+        [] { llvm::errs() << "' '"; });
     llvm::errs() << "'\n";
   }
 

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -973,37 +973,32 @@ void SwiftLookupTable::dump(raw_ostream &os) const {
       printStoredContext(entry.Context, os);
       os << ": ";
 
-      interleave(entry.DeclsOrMacros.begin(), entry.DeclsOrMacros.end(),
-                 [this, &os](uint64_t entry) {
-                   printStoredEntry(this, entry, os);
-                 },
-                 [&os] {
-                   os << ", ";
-                 });
+      llvm::interleave(
+          entry.DeclsOrMacros.begin(), entry.DeclsOrMacros.end(),
+          [this, &os](uint64_t entry) { printStoredEntry(this, entry, os); },
+          [&os] { os << ", "; });
       os << "\n";
     }
   }
 
   if (!Categories.empty()) {
     os << "Categories: ";
-    interleave(Categories.begin(), Categories.end(),
-               [&os](clang::ObjCCategoryDecl *category) {
-                 os << category->getClassInterface()->getName()
-                    << "(" << category->getName() << ")";
-               },
-               [&os] {
-                 os << ", ";
-               });
+    llvm::interleave(
+        Categories.begin(), Categories.end(),
+        [&os](clang::ObjCCategoryDecl *category) {
+          os << category->getClassInterface()->getName() << "("
+             << category->getName() << ")";
+        },
+        [&os] { os << ", "; });
     os << "\n";
   } else if (Reader && !Reader->categories().empty()) {
     os << "Categories: ";
-    interleave(Reader->categories().begin(), Reader->categories().end(),
-               [&os](clang::serialization::DeclID declID) {
-                 os << "decl ID #" << declID;
-               },
-               [&os] {
-                 os << ", ";
-               });
+    llvm::interleave(
+        Reader->categories().begin(), Reader->categories().end(),
+        [&os](clang::serialization::DeclID declID) {
+          os << "decl ID #" << declID;
+        },
+        [&os] { os << ", "; });
     os << "\n";
   }
 
@@ -1020,13 +1015,10 @@ void SwiftLookupTable::dump(raw_ostream &os) const {
       os << ": ";
 
       const auto &entries = GlobalsAsMembersIndex.find(context)->second;
-      interleave(entries.begin(), entries.end(),
-                 [this, &os](uint64_t entry) {
-                   printStoredEntry(this, entry, os);
-                 },
-                 [&os] {
-                   os << ", ";
-                 });
+      llvm::interleave(
+          entries.begin(), entries.end(),
+          [this, &os](uint64_t entry) { printStoredEntry(this, entry, os); },
+          [&os] { os << ", "; });
       os << "\n";
     }
   }

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -706,29 +706,29 @@ private:
     bool hasLabels = LabelList && LabelList->getNumChildren() > 0;
 
     Printer << '(';
-    interleave(Parameters->begin(), Parameters->end(),
-               [&](NodePointer Param) {
-                 assert(Param->getKind() == Node::Kind::TupleElement);
+    llvm::interleave(
+        Parameters->begin(), Parameters->end(),
+        [&](NodePointer Param) {
+          assert(Param->getKind() == Node::Kind::TupleElement);
 
-                 if (hasLabels) {
-                   Printer << getLabelFor(Param, ParamIndex) << ':';
-                 } else if (!showTypes) {
-                   if (auto Label = getChildIf(Param,
-                                               Node::Kind::TupleElementName))
-                     Printer << Label->getText() << ":";
-                   else
-                     Printer << "_:";
-                 }
+          if (hasLabels) {
+            Printer << getLabelFor(Param, ParamIndex) << ':';
+          } else if (!showTypes) {
+            if (auto Label = getChildIf(Param, Node::Kind::TupleElementName))
+              Printer << Label->getText() << ":";
+            else
+              Printer << "_:";
+          }
 
-                 if (hasLabels && showTypes)
-                   Printer << ' ';
+          if (hasLabels && showTypes)
+            Printer << ' ';
 
-                 ++ParamIndex;
+          ++ParamIndex;
 
-                 if (showTypes)
-                   print(Param);
-               },
-               [&]() { Printer << (showTypes ? ", " : ""); });
+          if (showTypes)
+            print(Param);
+        },
+        [&]() { Printer << (showTypes ? ", " : ""); });
     Printer << ')';
   }
 

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2844,15 +2844,16 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
       << "\" - \"" << llvm::sys::path::filename(J->getExecutable())
       << "\", inputs: [";
 
-    interleave(InputActions.begin(), InputActions.end(),
-               [](const Action *A) {
-                 auto Input = cast<InputAction>(A);
-                 llvm::outs() << '"' << Input->getInputArg().getValue() << '"';
-               },
-               [] { llvm::outs() << ", "; });
+    llvm::interleave(
+        InputActions.begin(), InputActions.end(),
+        [](const Action *A) {
+          auto Input = cast<InputAction>(A);
+          llvm::outs() << '"' << Input->getInputArg().getValue() << '"';
+        },
+        [] { llvm::outs() << ", "; });
     if (!InputActions.empty() && !J->getInputs().empty())
       llvm::outs() << ", ";
-    interleave(
+    llvm::interleave(
         J->getInputs().begin(), J->getInputs().end(),
         [](const Job *Input) {
           auto FileNames = Input->getOutput().getPrimaryOutputFilenames();
@@ -3305,9 +3306,10 @@ static unsigned printActions(const Action *A,
     os << "\"" << IA->getInputArg().getValue() << "\"";
   } else {
     os << "{";
-    interleave(*cast<JobAction>(A),
-               [&](const Action *Input) { os << printActions(Input, Ids); },
-               [&] { os << ", "; });
+    llvm::interleave(
+        *cast<JobAction>(A),
+        [&](const Action *Input) { os << printActions(Input, Ids); },
+        [&] { os << ", "; });
     os << "}";
   }
 

--- a/lib/Driver/DriverIncrementalRanges.cpp
+++ b/lib/Driver/DriverIncrementalRanges.cpp
@@ -227,9 +227,10 @@ Ranges SourceRangeBasedInfo::computeNonlocalChangedRanges(
 
 static std::string rangeStrings(std::string prefix, const Ranges &ranges) {
   std::string s = prefix;
-  interleave(ranges.begin(), ranges.end(),
-             [&](const SerializableSourceRange &r) { s += r.printString(); },
-             [&] { s += ", "; });
+  llvm::interleave(
+      ranges.begin(), ranges.end(),
+      [&](const SerializableSourceRange &r) { s += r.printString(); },
+      [&] { s += ", "; });
   return s;
 }
 

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -453,10 +453,12 @@ public:
     out << "@available(*, unavailable)\nextension ";
     nominal->getDeclaredType().print(out, printOptions);
     out << " : ";
-    swift::interleave(ConditionalConformanceProtocols,
-                      [&out, &printOptions](const ProtocolType *protoTy) {
-                        protoTy->print(out, printOptions);
-                      }, [&out] { out << ", "; });
+    llvm::interleave(
+        ConditionalConformanceProtocols,
+        [&out, &printOptions](const ProtocolType *protoTy) {
+          protoTy->print(out, printOptions);
+        },
+        [&out] { out << ", "; });
     out << " where "
         << nominal->getGenericSignature()->getGenericParams().front()->getName()
         << " : " << DummyProtocolName << " {}\n";

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1973,7 +1973,7 @@ static void printTargetInfo(const CompilerInvocation &invocation,
 
   auto outputPaths = [&](StringRef name, const std::vector<std::string> &paths){
     out << "    \"" << name << "\": [\n";
-    interleave(paths, [&out](const std::string &path) {
+    llvm::interleave(paths, [&out](const std::string &path) {
       out << "      \"";
       out.write_escaped(path);
       out << "\"";

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1006,7 +1006,7 @@ void IRGenModule::constructInitialFnAttributes(llvm::AttrBuilder &Attrs,
     SmallString<64> allFeatures;
     // Sort so that the target features string is canonical.
     std::sort(Features.begin(), Features.end());
-    interleave(Features, [&](const std::string &s) {
+    llvm::interleave(Features, [&](const std::string &s) {
       allFeatures.append(s);
     }, [&]{
       allFeatures.push_back(',');

--- a/lib/SIL/IR/SILConstants.cpp
+++ b/lib/SIL/IR/SILConstants.cpp
@@ -102,8 +102,9 @@ void SymbolicValue::print(llvm::raw_ostream &os, unsigned indent) const {
     SmallVector<unsigned, 4> accessPath;
     SymbolicValueMemoryObject *memObject = getAddressValue(accessPath);
     os << "address[" << memObject->getType() << "] ";
-    interleave(accessPath.begin(), accessPath.end(),
-               [&](unsigned idx) { os << idx; }, [&]() { os << ", "; });
+    llvm::interleave(
+        accessPath.begin(), accessPath.end(), [&](unsigned idx) { os << idx; },
+        [&]() { os << ", "; });
     os << "\n";
     break;
   }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -632,9 +632,9 @@ public:
           std::sort(UserIDs.begin(), UserIDs.end());
         }
 
-        interleave(UserIDs.begin(), UserIDs.end(),
-                   [&] (ID id) { *this << id; },
-                   [&] { *this << ", "; });
+        llvm::interleave(
+            UserIDs.begin(), UserIDs.end(), [&](ID id) { *this << id; },
+            [&] { *this << ", "; });
       }
       *this << '\n';
     }
@@ -794,8 +794,9 @@ public:
       std::sort(UserIDs.begin(), UserIDs.end());
     }
 
-    interleave(UserIDs.begin(), UserIDs.end(), [&](ID id) { *this << id; },
-               [&] { *this << ", "; });
+    llvm::interleave(
+        UserIDs.begin(), UserIDs.end(), [&](ID id) { *this << id; },
+        [&] { *this << ", "; });
     return true;
   }
 
@@ -1054,15 +1055,16 @@ public:
       *this << "**" << Ctx.getID(result) << "** = ";
     } else {
       *this << '(';
-      interleave(result->getParent()->getResults(),
-                 [&](SILValue value) {
-                   if (value == SILValue(result)) {
-                     *this << "**" << Ctx.getID(result) << "**";
-                     return;
-                   }
-                   *this << Ctx.getID(value);
-                 },
-                 [&] { *this << ", "; });
+      llvm::interleave(
+          result->getParent()->getResults(),
+          [&](SILValue value) {
+            if (value == SILValue(result)) {
+              *this << "**" << Ctx.getID(result) << "**";
+              return;
+            }
+            *this << Ctx.getID(value);
+          },
+          [&] { *this << ", "; });
       *this << ')';
     }
 
@@ -1190,9 +1192,10 @@ public:
     printSubstitutions(AI->getSubstitutionMap(),
                        AI->getOrigCalleeType()->getInvocationGenericSignature());
     *this << '(';
-    interleave(AI->getArguments(),
-               [&](const SILValue &arg) { *this << Ctx.getID(arg); },
-               [&] { *this << ", "; });
+    llvm::interleave(
+        AI->getArguments(),
+        [&](const SILValue &arg) { *this << Ctx.getID(arg); },
+        [&] { *this << ", "; });
     *this << ") : ";
     if (auto callee = AI->getCallee())
       *this << callee->getType();
@@ -1268,7 +1271,7 @@ public:
     printSubstitutions(BI->getSubstitutions());
     *this << "(";
     
-    interleave(BI->getArguments(), [&](SILValue v) {
+    llvm::interleave(BI->getArguments(), [&](SILValue v) {
       *this << getIDAndType(v);
     }, [&]{
       *this << ", ";
@@ -1447,9 +1450,9 @@ public:
   }
 
   void visitMarkFunctionEscapeInst(MarkFunctionEscapeInst *MFE) {
-    interleave(MFE->getElements(),
-               [&](SILValue Var) { *this << getIDAndType(Var); },
-               [&] { *this << ", "; });
+    llvm::interleave(
+        MFE->getElements(), [&](SILValue Var) { *this << getIDAndType(Var); },
+        [&] { *this << ", "; });
   }
 
   void visitDebugValueInst(DebugValueInst *DVI) {
@@ -1665,22 +1668,24 @@ public:
 
   void visitStructInst(StructInst *SI) {
     *this << SI->getType() << " (";
-    interleave(SI->getElements(),
-               [&](const SILValue &V) { *this << getIDAndType(V); },
-               [&] { *this << ", "; });
+    llvm::interleave(
+        SI->getElements(), [&](const SILValue &V) { *this << getIDAndType(V); },
+        [&] { *this << ", "; });
     *this << ')';
   }
 
   void visitObjectInst(ObjectInst *OI) {
     *this << OI->getType() << " (";
-    interleave(OI->getBaseElements(),
-               [&](const SILValue &V) { *this << getIDAndType(V); },
-               [&] { *this << ", "; });
+    llvm::interleave(
+        OI->getBaseElements(),
+        [&](const SILValue &V) { *this << getIDAndType(V); },
+        [&] { *this << ", "; });
     if (!OI->getTailElements().empty()) {
       *this << ", [tail_elems] ";
-      interleave(OI->getTailElements(),
-                 [&](const SILValue &V) { *this << getIDAndType(V); },
-                 [&] { *this << ", "; });
+      llvm::interleave(
+          OI->getTailElements(),
+          [&](const SILValue &V) { *this << getIDAndType(V); },
+          [&] { *this << ", "; });
     }
     *this << ')';
   }
@@ -1700,16 +1705,17 @@ public:
     // If the type is simple, just print the tuple elements.
     if (SimpleType) {
       *this << '(';
-      interleave(TI->getElements(),
-                 [&](const SILValue &V){ *this << getIDAndType(V); },
-                 [&] { *this << ", "; });
+      llvm::interleave(
+          TI->getElements(),
+          [&](const SILValue &V) { *this << getIDAndType(V); },
+          [&] { *this << ", "; });
       *this << ')';
     } else {
       // Otherwise, print the type, then each value.
       *this << TI->getType() << " (";
-      interleave(TI->getElements(),
-                 [&](const SILValue &V) { *this << Ctx.getID(V); },
-                 [&] { *this << ", "; });
+      llvm::interleave(
+          TI->getElements(), [&](const SILValue &V) { *this << Ctx.getID(V); },
+          [&] { *this << ", "; });
       *this << ')';
     }
   }
@@ -2024,9 +2030,9 @@ public:
   void visitYieldInst(YieldInst *YI) {
     auto values = YI->getYieldedValues();
     if (values.size() != 1) *this << '(';
-    interleave(values,
-               [&](SILValue value) { *this << getIDAndType(value); },
-               [&] { *this << ", "; });
+    llvm::interleave(
+        values, [&](SILValue value) { *this << getIDAndType(value); },
+        [&] { *this << ", "; });
     if (values.size() != 1) *this << ')';
     *this << ", resume " << Ctx.getID(YI->getResumeBB())
           << ", unwind " << Ctx.getID(YI->getUnwindBB());
@@ -2119,9 +2125,9 @@ public:
     if (args.empty()) return;
 
     *this << '(';
-    interleave(args,
-               [&](SILValue v) { *this << getIDAndType(v); },
-               [&] { *this << ", "; });
+    llvm::interleave(
+        args, [&](SILValue v) { *this << getIDAndType(v); },
+        [&] { *this << ", "; });
     *this << ')';
   }
   

--- a/lib/SILOptimizer/Utils/Differentiation/JVPEmitter.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/JVPEmitter.cpp
@@ -1228,10 +1228,10 @@ void JVPEmitter::visitApplyInst(ApplyInst *ai) {
   assert(!activeParamIndices.empty() && "Parameter indices cannot be empty");
   assert(!activeResultIndices.empty() && "Result indices cannot be empty");
   LLVM_DEBUG(auto &s = getADDebugStream() << "Active indices: params={";
-             interleave(
+             llvm::interleave(
                  activeParamIndices.begin(), activeParamIndices.end(),
                  [&s](unsigned i) { s << i; }, [&s] { s << ", "; });
-             s << "}, results={"; interleave(
+             s << "}, results={"; llvm::interleave(
                  activeResultIndices.begin(), activeResultIndices.end(),
                  [&s](unsigned i) { s << i; }, [&s] { s << ", "; });
              s << "}\n";);

--- a/lib/SILOptimizer/Utils/Differentiation/VJPEmitter.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/VJPEmitter.cpp
@@ -521,10 +521,10 @@ void VJPEmitter::visitApplyInst(ApplyInst *ai) {
   assert(!activeParamIndices.empty() && "Parameter indices cannot be empty");
   assert(!activeResultIndices.empty() && "Result indices cannot be empty");
   LLVM_DEBUG(auto &s = getADDebugStream() << "Active indices: params={";
-             interleave(
+             llvm::interleave(
                  activeParamIndices.begin(), activeParamIndices.end(),
                  [&s](unsigned i) { s << i; }, [&s] { s << ", "; });
-             s << "}, results={"; interleave(
+             s << "}, results={"; llvm::interleave(
                  activeResultIndices.begin(), activeResultIndices.end(),
                  [&s](unsigned i) { s << i; }, [&s] { s << ", "; });
              s << "}\n";);

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -1326,7 +1326,7 @@ void ConstraintGraph::printConnectedComponents(
 
     // Print all of the one-way components.
     out << " depends on ";
-    interleave(
+    llvm::interleave(
         component.dependsOn,
         [&](unsigned index) { out << index; },
         [&] { out << ", "; }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1715,8 +1715,9 @@ bool TypeChecker::getDefaultGenericArgumentsString(
   // FIXME: We can potentially be in the middle of creating a generic signature
   // if we get here.  Break this cycle.
   if (typeDecl->hasComputedGenericSignature()) {
-    interleave(typeDecl->getInnermostGenericParamTypes(),
-               printGenericParamSummary, [&]{ genericParamText << ", "; });
+    llvm::interleave(typeDecl->getInnermostGenericParamTypes(),
+                     printGenericParamSummary,
+                     [&] { genericParamText << ", "; });
   }
   
   genericParamText << ">";

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2991,15 +2991,14 @@ void Solution::dump(raw_ostream &out) const {
       out.indent(2);
       opened.first->dump(sm, out);
       out << " opens ";
-      interleave(opened.second.begin(), opened.second.end(),
-                 [&](OpenedType opened) {
-                   Type(opened.first).print(out, PO);
-                   out << " -> ";
-                   Type(opened.second).print(out, PO);
-                 },
-                 [&]() {
-                   out << ", ";
-                 });
+      llvm::interleave(
+          opened.second.begin(), opened.second.end(),
+          [&](OpenedType opened) {
+            Type(opened.first).print(out, PO);
+            out << " -> ";
+            Type(opened.second).print(out, PO);
+          },
+          [&]() { out << ", "; });
       out << "\n";
     }
   }
@@ -3188,15 +3187,14 @@ void ConstraintSystem::print(raw_ostream &out) const {
       out.indent(2);
       opened.first->dump(&getASTContext().SourceMgr, out);
       out << " opens ";
-      interleave(opened.second.begin(), opened.second.end(),
-                 [&](OpenedType opened) {
-                   Type(opened.first).print(out, PO);
-                   out << " -> ";
-                   Type(opened.second).print(out, PO);
-                 },
-                 [&]() {
-                   out << ", ";
-                 });
+      llvm::interleave(
+          opened.second.begin(), opened.second.end(),
+          [&](OpenedType opened) {
+            Type(opened.first).print(out, PO);
+            out << " -> ";
+            Type(opened.second).print(out, PO);
+          },
+          [&]() { out << ", "; });
       out << "\n";
     }
   }

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -686,7 +686,7 @@ namespace {
             llvm_unreachable("Attempted to display disjunct to user!");
           } else {
             buffer << "DISJOIN(";
-            interleave(Spaces, [&](const Space &sp) {
+            llvm::interleave(Spaces, [&](const Space &sp) {
               sp.show(buffer, forDisplay);
             }, [&buffer]() { buffer << " |\n"; });
             buffer << ")";

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1090,9 +1090,9 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
     if (!spis.empty()) {
       SmallString<64> out;
       llvm::raw_svector_ostream outStream(out);
-      swift::interleave(spis,
-                        [&outStream](Identifier next) { outStream << next.str(); },
-                        [&outStream] { outStream << StringRef("\0", 1); });
+      llvm::interleave(
+          spis, [&outStream](Identifier next) { outStream << next.str(); },
+          [&outStream] { outStream << StringRef("\0", 1); });
       ImportedModuleSPI.emit(ScratchRecord, out);
     }
   }


### PR DESCRIPTION
This is for fixing the `master-next` build. Making this change on the `master` branch keeps the diff on `master-next` small. See also pull requests https://github.com/apple/swift/pull/31089 and https://github.com/apple/swift/pull/31090.

Unfortunately this leads to quite a bit of reformatting. I've used clang-format in the places where horizontal alignment broke. There are no syntactic changes at the call sites other than adding `llvm::`.