### PR TITLE
[WIP] Sema: F-bounded polymorphism (Part 1)

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2837,6 +2837,19 @@ public:
   /// metatype.
   Type getDeclaredInterfaceType() const;
 
+  /// When the underlying interface type of a \c TypeAliasDecl is not
+  /// available due to an ongoing request, retrieve its structural type.
+  /// Otherwise, return the declared interface type.
+  ///
+  /// \param desugared Whether to pull out the underlying type for an alias
+  /// declaration.
+  Type getAvailableDeclaredInterfaceType(bool desugared = false) const;
+
+  /// The structural type of this declaration's values. Otherwise equivalent
+  /// to \c getDeclaredInterfaceType(), this method forwards the call to
+  /// \c TypeAliasDecl::getStructuralType for a \c TypeAliasDecl.
+  Type getStructuralType(bool desugared) const;
+
   /// Retrieve the set of protocols that this type inherits (i.e,
   /// explicitly conforms to).
   MutableArrayRef<TypeLoc> getInherited() { return Inherited; }
@@ -3027,13 +3040,16 @@ public:
   Type getUnderlyingType() const;
   void setUnderlyingType(Type type);
 
+  bool isComputingUnderlyingType() const;
+
   /// For generic typealiases, return the unbound generic type.
   UnboundGenericType *getUnboundGenericType() const;
 
-  /// Retrieve a sugared interface type containing the structure of the interface
+  /// Retrieve an interface type containing the structure of the interface
   /// type before any semantic validation has occured.
-  Type getStructuralType() const;
-  
+  /// \param desugared Whether to pull out the underlying type.
+  Type getStructuralType(bool desugared = false) const;
+
   bool isCompatibilityAlias() const {
     return Bits.TypeAliasDecl.IsCompatibilityAlias;
   }

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2242,8 +2242,6 @@ ERROR(recursive_decl_reference,none,
       "%0 %1 references itself", (DescriptiveDeclKind, DeclBaseName))
 ERROR(recursive_same_type_constraint,none,
       "same-type constraint %0 == %1 is recursive", (Type, Type))
-ERROR(recursive_superclass_constraint,none,
-      "superclass constraint %0 : %1 is recursive", (Type, Type))
 ERROR(requires_generic_param_same_type_does_not_conform,none,
       "same-type constraint type %0 does not conform to required protocol %1",
       (Type, Identifier))

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -111,7 +111,7 @@ public:
   void diagnoseCycle(DiagnosticEngine &diags) const;
 
   // Separate caching.
-  bool isCached() const;
+  bool isCached() const { return true; }
   Optional<Type> getCachedResult() const;
   void cacheResult(Type value) const;
 };

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -918,8 +918,7 @@ GenericParamList::clone(DeclContext *dc) const {
   for (auto param : getParams()) {
     auto *newParam = new (ctx) GenericTypeParamDecl(
       dc, param->getName(), param->getNameLoc(),
-      GenericTypeParamDecl::InvalidDepth,
-      param->getIndex());
+      param->getDepth(), param->getIndex());
     params.push_back(newParam);
 
     SmallVector<TypeLoc, 2> inherited;

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2581,18 +2581,9 @@ PotentialArchetype *PotentialArchetype::updateNestedTypeForConformance(
     return nullptr;
 
   // Always refer to the archetype anchor.
-  if (assocType)
-    assocType = assocType->getAssociatedTypeAnchor();
-
-  // If we were asked for a complete, well-formed archetype, make sure we
-  // process delayed requirements if anything changed.
-  SWIFT_DEFER {
-    if (kind == ArchetypeResolutionKind::CompleteWellFormed)
-      builder.processDelayedRequirements();
-  };
+  assocType = assocType->getAssociatedTypeAnchor();
 
   Identifier name = assocType->getName();
-  auto *proto = assocType->getProtocol();
 
   // Look for either an unresolved potential archetype (which we can resolve
   // now) or a potential archetype with the appropriate associated type.
@@ -2636,6 +2627,7 @@ PotentialArchetype *PotentialArchetype::updateNestedTypeForConformance(
   if (shouldUpdatePA) {
     // If there's a superclass constraint that conforms to the protocol,
     // add the appropriate same-type relationship.
+    const auto proto = assocType->getProtocol();
     if (proto) {
       if (auto superSource = builder.resolveSuperConformance(this, proto)) {
         maybeAddSameTypeRequirementForNestedType(resultPA, superSource,
@@ -2649,6 +2641,11 @@ PotentialArchetype *PotentialArchetype::updateNestedTypeForConformance(
       concretizeNestedTypeFromConcreteParent(this, resultPA, builder);
     }
   }
+
+  // If we were asked for a complete, well-formed archetype, make sure we
+  // process delayed requirements if anything changed.
+  if (kind == ArchetypeResolutionKind::CompleteWellFormed)
+    builder.processDelayedRequirements();
 
   return resultPA;
 }
@@ -3500,16 +3497,20 @@ GenericSignatureBuilder::lookupConformance(CanType dependentType,
 }
 
 /// Resolve any unresolved dependent member types using the given builder.
-static Type resolveDependentMemberTypes(GenericSignatureBuilder &builder,
-                                        Type type) {
+static Type resolveDependentMemberTypes(
+                                GenericSignatureBuilder &builder,
+                                Type type,
+                                ArchetypeResolutionKind resolutionKind
+                                  = ArchetypeResolutionKind::WellFormed) {
   if (!type->hasTypeParameter()) return type;
 
-  return type.transformRec([&builder](TypeBase *type) -> Optional<Type> {
+  return type.transformRec([&resolutionKind,
+                            &builder](TypeBase *type) -> Optional<Type> {
     if (!type->isTypeParameter())
       return None;
 
     auto resolved = builder.maybeResolveEquivalenceClass(
-        Type(type), ArchetypeResolutionKind::WellFormed, true);
+        Type(type), resolutionKind, true);
 
     if (!resolved)
       return ErrorType::get(Type(type));
@@ -3534,7 +3535,8 @@ static Type resolveDependentMemberTypes(GenericSignatureBuilder &builder,
         equivClass->recursiveConcreteType = false;
       };
 
-      return resolveDependentMemberTypes(builder, equivClass->concreteType);
+      return resolveDependentMemberTypes(builder, equivClass->concreteType,
+                                         resolutionKind);
     }
 
     return equivClass->getAnchor(builder, builder.getGenericParams());
@@ -3697,7 +3699,7 @@ ResolvedType GenericSignatureBuilder::maybeResolveEquivalenceClass(
   // FIXME: Generic typealiases contradict the assumption above.
   // If there is a type parameter somewhere in this type, resolve it.
   if (type->hasTypeParameter()) {
-    Type resolved = resolveDependentMemberTypes(*this, type);
+    Type resolved = resolveDependentMemberTypes(*this, type, resolutionKind);
     if (resolved->hasError() && !type->hasError())
       return ResolvedType::forUnresolved(nullptr);
 
@@ -3725,7 +3727,7 @@ auto GenericSignatureBuilder::resolve(UnresolvedType paOrT,
     return ResolvedType(pa);
 
   // Determine what kind of resolution we want.
-  Type type = paOrT.dyn_cast<Type>();
+  Type type = paOrT.get<Type>();
   ArchetypeResolutionKind resolutionKind =
     ArchetypeResolutionKind::WellFormed;
   if (!source.isExplicit() && source.isRecursive(type, *this))

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -129,10 +129,6 @@ void SuperclassTypeRequest::diagnoseCycle(DiagnosticEngine &diags) const {
                  nominalDecl->getName());
 }
 
-bool SuperclassTypeRequest::isCached() const {
-  return std::get<1>(getStorage()) == TypeResolutionStage::Interface;
-}
-
 Optional<Type> SuperclassTypeRequest::getCachedResult() const {
   auto nominalDecl = std::get<0>(getStorage());
 

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -927,13 +927,7 @@ static void addImplicitInheritedConstructorsToClass(ClassDecl *decl) {
 
   decl->setAddedImplicitInitializers();
 
-  // We can only inherit initializers if we have a superclass.
-  // FIXME: We should be bailing out earlier in the function, but unfortunately
-  // that currently regresses associated type inference for cases like
-  // compiler_crashers_2_fixed/0124-sr5825.swift due to the fact that we no
-  // longer eagerly compute the interface types of the other constructors.
-  auto superclassTy = decl->getSuperclass();
-  if (!superclassTy)
+  if (!decl->getSuperclass())
     return;
 
   // Check whether the user has defined a designated initializer for this class,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -53,11 +53,6 @@ namespace constraints {
   class SolutionResult;
 }
 
-/// A mapping from substitutable types to the protocol-conformance
-/// mappings for those types.
-using ConformanceMap =
-    llvm::DenseMap<SubstitutableType *, SmallVector<ProtocolConformance *, 2>>;
-
 /// Special-case type checking semantics for certain declarations.
 enum class DeclTypeCheckingSemantics {
   /// A normal declaration.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -26,6 +26,7 @@
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/TypeRefinementContext.h"
+#include "swift/AST/TypeResolutionStage.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Basic/OptionSet.h"
 #include "swift/Config.h"
@@ -78,7 +79,6 @@ enum class DeclTypeCheckingSemantics {
 /// An individual result of a name lookup for a type.
 struct LookupTypeResultEntry {
   TypeDecl *Member;
-  Type MemberType;
   /// The associated type that the Member/MemberType were inferred for, but only
   /// if inference happened when creating this entry.
   AssociatedTypeDecl *InferredAssociatedType;
@@ -498,10 +498,10 @@ Type applyUnboundGenericArguments(UnboundGenericType *unboundType,
 /// \param member The member whose type projection is being computed.
 /// \param baseTy The base type that will be substituted for the 'Self' of the
 /// member.
-/// \param useArchetypes Whether to use context archetypes for outer generic
-/// parameters if the class is nested inside a generic function.
+/// \param stage The type resolution stage to use for substitution.
 Type substMemberTypeWithBase(ModuleDecl *module, TypeDecl *member, Type baseTy,
-                             bool useArchetypes = true);
+                             TypeResolutionStage stage =
+                                 TypeResolutionStage::Contextual);
 
 /// Determine whether this is a "pass-through" typealias, which has the
 /// same type parameters as the nominal type it references and specializes

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -49,10 +49,8 @@ typealias OptionalInt = Optional<Int>
 var uniontest1 : (Int) -> Optional<Int> = OptionalInt.element
 var uniontest2 : Optional<Int> = OptionalInt.none
 var uniontest3 = OptionalInt(1)
-
-// FIXME: Stuff that should work, but doesn't yet.
-// var uniontest4 : OptInt = .none
-// var uniontest5 : OptInt = .Some(1)
+var uniontest4 : OptionalInt = .none
+var uniontest5 : OptionalInt = .element(1)
 
 func formattedTest<T : MyFormattedPrintable>(_ a: T) {
   myPrintf("%v", a)
@@ -224,25 +222,6 @@ struct X4 : P, Q {
 struct X5<T, U> where T: P, T: Q, T.AssocP == T.AssocQ { } // expected-note{{requirement specified as 'T.AssocP' == 'T.AssocQ' [with T = X4]}}
 
 var y: X5<X4, Int> // expected-error{{'X5' requires the types 'X4.AssocP' (aka 'Int') and 'X4.AssocQ' (aka 'String') be equivalent}}
-
-// Recursive generic signature validation.
-class Top {}
-class Bottom<T : Bottom<Top>> {}
-// expected-error@-1 {{'Bottom' requires that 'Top' inherit from 'Bottom<Top>'}}
-// expected-note@-2 {{requirement specified as 'T' : 'Bottom<Top>' [with T = Top]}}
-
-class Bottom2<T: Bottom2<Top2>> {}
-class Top2: Bottom2<Top2> {} // OK
-
-class Bottom3<T: Bottom3<Top3, Top3, Top3>,
-              U: Bottom3<Top3, Top3, Top3>,
-              R: Bottom3<Top3, Top3, Top3>> {}
-class Top3: Bottom3<Top3, Top3, Top3> {} // OK
-
-// FIXME: Unlock recursive superclass constraints.
-class ProtoSuperclass<T> {}
-protocol Proto: ProtoSuperclass<Self> {} // expected-error {{superclass constraint 'Self' : 'ProtoSuperclass<Self>' is recursive}}
-func recursiveSuperclassFunc<T: ProtoSuperclass<T>>(t: T) {} // expected-error {{superclass constraint 'T' : 'ProtoSuperclass<T>' is recursive}}
 
 // Invalid inheritance clause
 

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -231,14 +231,18 @@ class Bottom<T : Bottom<Top>> {}
 // expected-error@-1 {{'Bottom' requires that 'Top' inherit from 'Bottom<Top>'}}
 // expected-note@-2 {{requirement specified as 'T' : 'Bottom<Top>' [with T = Top]}}
 
-// FIXME: Superclass validation circularity.
-class Top2: Bottom2<Top2> {}
-// expected-error@-1 {{'Top2' inherits from itself}}
-// expected-error@-2 {{'Bottom2' requires that 'Top2' inherit from 'Bottom2<Top2>'}}
-// expected-note@-3 {{through reference here}}
 class Bottom2<T: Bottom2<Top2>> {}
-// expected-note@-1 2{{requirement specified as 'T' : 'Bottom2<Top2>' [with T = Top2]}}
-// expected-error@-2 {{'Bottom2' requires that 'Top2' inherit from 'Bottom2<Top2>'}}
+class Top2: Bottom2<Top2> {} // OK
+
+class Bottom3<T: Bottom3<Top3, Top3, Top3>,
+              U: Bottom3<Top3, Top3, Top3>,
+              R: Bottom3<Top3, Top3, Top3>> {}
+class Top3: Bottom3<Top3, Top3, Top3> {} // OK
+
+// FIXME: Unlock recursive superclass constraints.
+class ProtoSuperclass<T> {}
+protocol Proto: ProtoSuperclass<Self> {} // expected-error {{superclass constraint 'Self' : 'ProtoSuperclass<Self>' is recursive}}
+func recursiveSuperclassFunc<T: ProtoSuperclass<T>>(t: T) {} // expected-error {{superclass constraint 'T' : 'ProtoSuperclass<T>' is recursive}}
 
 // Invalid inheritance clause
 

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -228,10 +228,17 @@ var y: X5<X4, Int> // expected-error{{'X5' requires the types 'X4.AssocP' (aka '
 // Recursive generic signature validation.
 class Top {}
 class Bottom<T : Bottom<Top>> {}
-// expected-error@-1 {{generic class 'Bottom' references itself}}
-// expected-note@-2 {{type declared here}}
-// expected-error@-3 {{circular reference}}
-// expected-note@-4 {{through reference here}}
+// expected-error@-1 {{'Bottom' requires that 'Top' inherit from 'Bottom<Top>'}}
+// expected-note@-2 {{requirement specified as 'T' : 'Bottom<Top>' [with T = Top]}}
+
+// FIXME: Superclass validation circularity.
+class Top2: Bottom2<Top2> {}
+// expected-error@-1 {{'Top2' inherits from itself}}
+// expected-error@-2 {{'Bottom2' requires that 'Top2' inherit from 'Bottom2<Top2>'}}
+// expected-note@-3 {{through reference here}}
+class Bottom2<T: Bottom2<Top2>> {}
+// expected-note@-1 2{{requirement specified as 'T' : 'Bottom2<Top2>' [with T = Top2]}}
+// expected-error@-2 {{'Bottom2' requires that 'Top2' inherit from 'Bottom2<Top2>'}}
 
 // Invalid inheritance clause
 

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -149,6 +149,12 @@ protocol RecSuperclassReqP4 {
 class InvalidConformanceToP1: GenericClass<Never>, RecSuperclassReqP1 {}
 // expected-error@-1 {{'RecSuperclassReqP1' requires that 'InvalidConformanceToP1' inherit from 'GenericClass<InvalidConformanceToP1>'}}
 // expected-note@-2 {{requirement specified as 'Self' : 'GenericClass<Self>' [with Self = InvalidConformanceToP1]}}
+class InvalidConformanceToP2: GenericClass<InvalidConformanceToP2>,
+                              RecSuperclassReqP2 {
+// expected-error@-2 {{type 'InvalidConformanceToP2' does not conform to protocol 'RecSuperclassReqP2'}}
+  typealias A = InvalidConformanceToP1
+// expected-note@-1 {{possibly intended match 'InvalidConformanceToP2.A' (aka 'InvalidConformanceToP1') does not conform to 'RecSuperclassReqP2'}}
+}
 class InvalidConformanceToP3: GenericClass<Never>, RecSuperclassReqP3 {
 // expected-error@-1 {{'RecSuperclassReqP3' requires that 'InvalidConformanceToP3' inherit from 'GenericClass<InvalidConformanceToP3.A>' (aka 'GenericClass<Bool>')}}
 // expected-note@-2 {{requirement specified as 'Self' : 'GenericClass<Self.A>' [with Self = InvalidConformanceToP3]}}
@@ -156,15 +162,12 @@ class InvalidConformanceToP3: GenericClass<Never>, RecSuperclassReqP3 {
 }
 
 class ConformanceToP1: GenericClass<ConformanceToP1>, RecSuperclassReqP1 {}
+class ConformanceToP2P3: GenericClass<ConformanceToP2P3>,
+                       RecSuperclassReqP2,
+                       RecSuperclassReqP3 {
+  typealias A = ConformanceToP2P3
+}
 
-// FIXME: False-negative.
-class ConformanceToP2: GenericClass<ConformanceToP2>, RecSuperclassReqP2 {
-// expected-error@-1 {{type 'ConformanceToP2' does not conform to protocol 'RecSuperclassReqP2'}}
-  typealias A = ConformanceToP2 // expected-note {{possibly intended match 'ConformanceToP2.A' (aka 'ConformanceToP2') does not inherit from 'GenericClass<τ_0_0.A>'}}
-}
-class ConformanceToP3: GenericClass<ConformanceToP3>, RecSuperclassReqP3 {
-  typealias A = ConformanceToP3
-}
 // FIXME: False-negative. This bug impacts any associated type declarations
 // that have a superclass bound containing dependent member types (see
 // swift::checkTypeWitness).

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -139,8 +139,7 @@ protocol RecSuperclassReqP2: GenericClass<Self> {
   associatedtype A: RecSuperclassReqP2 // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
 }
 protocol RecSuperclassReqP3: GenericClass<Self.A> {
-  // FIXME: Infinite recursion.
-  associatedtype A//: RecSuperclassReqP3
+  associatedtype A: RecSuperclassReqP3
 }
 protocol RecSuperclassReqP4 {
   associatedtype A: GenericClass<A> // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
@@ -156,9 +155,9 @@ class InvalidConformanceToP2: GenericClass<InvalidConformanceToP2>,
 // expected-note@-1 {{possibly intended match 'InvalidConformanceToP2.A' (aka 'InvalidConformanceToP1') does not conform to 'RecSuperclassReqP2'}}
 }
 class InvalidConformanceToP3: GenericClass<Never>, RecSuperclassReqP3 {
-// expected-error@-1 {{'RecSuperclassReqP3' requires that 'InvalidConformanceToP3' inherit from 'GenericClass<InvalidConformanceToP3.A>' (aka 'GenericClass<Bool>')}}
+// expected-error@-1 {{'RecSuperclassReqP3' requires that 'InvalidConformanceToP3' inherit from 'GenericClass<InvalidConformanceToP3.A>' (aka 'GenericClass<InvalidConformanceToP3>')}}
 // expected-note@-2 {{requirement specified as 'Self' : 'GenericClass<Self.A>' [with Self = InvalidConformanceToP3]}}
-  typealias A = Bool
+  typealias A = InvalidConformanceToP3
 }
 
 class ConformanceToP1: GenericClass<ConformanceToP1>, RecSuperclassReqP1 {}

--- a/test/SILGen/generic_signatures.swift
+++ b/test/SILGen/generic_signatures.swift
@@ -140,3 +140,24 @@ extension Class.NestedClass {
   // CHECK-LABEL: sil hidden [ossa] @$s18generic_signatures5ClassC06NestedC0C3foo3argyx_tAA9WhereableRz3FooAA7FooablePQz5AssocAaHPRtzrlF : $@convention(method) <T where T : Fooable, T : Whereable, T.Assoc == T.Foo> (@in_guaranteed T, @guaranteed Class<T>.NestedClass) -> ()
   func foo(arg: T) where T: Whereable, T.Foo == T.Assoc { }
 }
+
+// CHECK_LABEL: sil hidden [ossa] @$s18generic_signatures1SVACyxGycfC : $@convention(method) <A where A : P, A.Assoc == S<A>> (@thin S<A>.Type) -> S<A>
+struct S<A: P> where A.Assoc == S<A> {}
+
+// Recursive superclass constraints
+
+// CHECK_LABEL: sil hidden [ossa] @$s18generic_signatures6BottomCACyxq_q0_Gycfc : $@convention(method) <T, U, R where T : Bottom<Top, Top, Top>, U : Bottom<Top, Top, Top>, R : Bottom<Top, Top, Top>> (@owned Bottom<T, U, R>) -> @owned Bottom<T, U, R>
+class Bottom<T: Bottom<Top, Top, Top>,
+              U: Bottom<Top, Top, Top>,
+              R: Bottom<Top, Top, Top>> {}
+
+class Top: Bottom<Top, Top, Top> {}
+
+class GenericClass<T> {}
+
+// CHECK_LABEL: sil hidden [ossa] @$s18generic_signatures17RecSuperclassReqCCACyxGycfc : $@convention(method) <T where T : GenericClass<T>> (@owned RecSuperclassReqC<T>) -> @owned RecSuperclassReqC<T>
+class RecSuperclassReqC<T: GenericClass<T>> {}
+// CHECK_LABEL: sil hidden [ossa] @$s18generic_signatures17RecSuperclassReqSVACyxGycfC : $@convention(method) <T where T : GenericClass<T>> (@thin RecSuperclassReqS<T>.Type) -> RecSuperclassReqS<T>
+struct RecSuperclassReqS<T: GenericClass<T>> {}
+// CHECK-LABEL: sil hidden [ossa] @$s18generic_signatures17recSuperclassReqFyyxmAA12GenericClassCyxGRbzlF : $@convention(thin) <T where T : GenericClass<T>> (@thick T.Type) -> ()
+func recSuperclassReqF<T: GenericClass<T>>(_: T.Type) {}

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -71,7 +71,6 @@ class OuterClass {
 class OtherGenericClass<T> {
   protocol InnerProtocol : OtherGenericClass { }
   // expected-error@-1{{protocol 'InnerProtocol' cannot be nested inside another declaration}}
-  // expected-error@-2{{superclass constraint 'Self' : 'OtherGenericClass<Self>' is recursive}}
 }
 
 protocol SelfDotTest {

--- a/test/decl/protocol/protocol_with_superclass.swift
+++ b/test/decl/protocol/protocol_with_superclass.swift
@@ -277,10 +277,8 @@ extension HasMutableProperty {
 // Some pathological examples -- just make sure they don't crash.
 
 protocol RecursiveSelf : Generic<Self> {}
-// expected-error@-1 {{superclass constraint 'Self' : 'Generic<Self>' is recursive}}
 
 protocol RecursiveAssociatedType : Generic<Self.X> {
-  // expected-error@-1 {{superclass constraint 'Self' : 'Generic<Self.X>' is recursive}}
   associatedtype X
 }
 

--- a/test/decl/protocol/protocol_with_superclass_where_clause.swift
+++ b/test/decl/protocol/protocol_with_superclass_where_clause.swift
@@ -278,10 +278,8 @@ extension HasMutableProperty {
 // Some pathological examples -- just make sure they don't crash.
 
 protocol RecursiveSelf where Self : Generic<Self> {}
-// expected-error@-1 {{superclass constraint 'Self' : 'Generic<Self>' is recursive}}
 
 protocol RecursiveAssociatedType where Self : Generic<Self.X> {
-  // expected-error@-1 {{superclass constraint 'Self' : 'Generic<Self.X>' is recursive}}
   associatedtype X
 }
 

--- a/validation-test/compiler_crashers_2_fixed/sr-10612.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr-10612.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend -typecheck %s
+// RUN: %target-swift-frontend -typecheck %s
 
 protocol P1: class {
     associatedtype P1P1: P1


### PR DESCRIPTION
This PR lays groundwork toward resolving SR-10239 and supporting F-bounded polymorphism in Swift by breaking relevant cycles and ultimately unlocking recursive superclass requirements.

With this change, 2 cases remain on the follow-up list:
* Witnessing  associated types with rec. superclass bounds — `associatedtype X: Foo<X>`. This is only a small piece of a far more extensive issue: an associated type superclass bound containing any other dependent member will not let you witness the type requirement.
* Recursive generic signature validation involving archetypes that are recursive through their superclass bounds — `class Foo<T: Foo<T>>`.


