### PR TITLE
Remove Swift's copy of llvm::interleave

### DIFF
--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -69,49 +69,6 @@ struct function_traits<R (T::*)(Args...) const> {
   using argument_types = std::tuple<Args...>;
 };
 
-} // end namespace swift
-
-namespace llvm {
-
-/// @{
-
-/// An STL-style algorithm similar to std::for_each that applies a second
-/// functor between every pair of elements.
-///
-/// This provides the control flow logic to, for example, print a
-/// comma-separated list:
-/// \code
-///   interleave(names.begin(), names.end(),
-///              [&](StringRef name) { OS << name; },
-///              [&] { OS << ", "; });
-/// \endcode
-template <typename ForwardIterator, typename UnaryFunctor,
-          typename NullaryFunctor>
-inline void interleave(ForwardIterator begin, ForwardIterator end,
-                       UnaryFunctor each_fn,
-                       NullaryFunctor between_fn) {
-  if (begin == end)
-    return;
-  each_fn(*begin);
-  ++begin;
-  for (; begin != end; ++begin) {
-    between_fn();
-    each_fn(*begin);
-  }
-}
-
-template <typename Container, typename UnaryFunctor, typename NullaryFunctor>
-inline void interleave(const Container &c, UnaryFunctor each_fn,
-                       NullaryFunctor between_fn) {
-  interleave(c.begin(), c.end(), each_fn, between_fn);
-}
-
-/// @}
-
-} // end namespace llvm
-
-namespace swift {
-
 /// @{
 
 /// The equivalent of std::for_each, but for two lists at once.


### PR DESCRIPTION
This is only needed on the master branch, which doesn't have LLVM's
copy, yet.