### PR TITLE
SIL: support type dependent operands in all cast instructions.

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1031,9 +1031,9 @@ public:
   createUncheckedRefCastAddr(SILLocation Loc,
                              SILValue src, CanType sourceFormalType,
                              SILValue dest, CanType targetFormalType) {
-    return insert(new (getModule()) UncheckedRefCastAddrInst(
+    return insert(UncheckedRefCastAddrInst::create(
         getSILDebugLocation(Loc), src, sourceFormalType,
-        dest, targetFormalType));
+        dest, targetFormalType, getFunction(), C.OpenedArchetypes));
   }
 
   UncheckedAddrCastInst *createUncheckedAddrCast(SILLocation Loc, SILValue Op,
@@ -1152,9 +1152,9 @@ public:
   createUnconditionalCheckedCastAddr(SILLocation Loc,
                                      SILValue src, CanType sourceFormalType,
                                      SILValue dest, CanType targetFormalType) {
-    return insert(new (getModule()) UnconditionalCheckedCastAddrInst(
+    return insert(UnconditionalCheckedCastAddrInst::create(
         getSILDebugLocation(Loc), src, sourceFormalType,
-        dest, targetFormalType));
+        dest, targetFormalType, getFunction(), C.OpenedArchetypes));
   }
 
   UnconditionalCheckedCastValueInst *
@@ -1989,9 +1989,10 @@ public:
                               SILBasicBlock *failureBB,
                               ProfileCounter Target1Count = ProfileCounter(),
                               ProfileCounter Target2Count = ProfileCounter()) {
-    return insertTerminator(new (getModule()) CheckedCastAddrBranchInst(
+    return insertTerminator(CheckedCastAddrBranchInst::create(
         getSILDebugLocation(Loc), consumption, src, sourceFormalType, dest,
-        targetFormalType, successBB, failureBB, Target1Count, Target2Count));
+        targetFormalType, successBB, failureBB, Target1Count, Target2Count,
+        getFunction(), C.OpenedArchetypes));
   }
 
   //===--------------------------------------------------------------------===//

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4517,59 +4517,6 @@ class UncheckedRefCastInst final
          SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
 };
 
-/// Converts a heap object reference to a different type without any runtime
-/// checks. This is a variant of UncheckedRefCast that works on address types,
-/// thus encapsulates an implicit load and take of the reference followed by a
-/// store and initialization of a new reference.
-class UncheckedRefCastAddrInst
-    : public InstructionBase<SILInstructionKind::UncheckedRefCastAddrInst,
-                             NonValueInstruction> {
-public:
-  enum {
-    /// the value being stored
-    Src,
-    /// the lvalue being stored to
-    Dest
-  };
-
-private:
-  FixedOperandList<2> Operands;
-  CanType SourceType;
-  CanType TargetType;
-public:
-  UncheckedRefCastAddrInst(SILDebugLocation Loc, SILValue src, CanType srcType,
-                           SILValue dest, CanType targetType);
-
-  SILValue getSrc() const { return Operands[Src].get(); }
-  SILValue getDest() const { return Operands[Dest].get(); }
-
-  SILType getSourceLoweredType() const { return getSrc()->getType(); }
-  CanType getSourceFormalType() const { return SourceType; }
-
-  SILType getTargetLoweredType() const { return getDest()->getType(); }
-  CanType getTargetFormalType() const { return TargetType; }
-
-  ArrayRef<Operand> getAllOperands() const { return Operands.asArray(); }
-  MutableArrayRef<Operand> getAllOperands() { return Operands.asArray(); }
-};
-
-class UncheckedAddrCastInst final
-  : public UnaryInstructionWithTypeDependentOperandsBase<
-                                SILInstructionKind::UncheckedAddrCastInst,
-                                UncheckedAddrCastInst,
-                                ConversionInst>
-{
-  friend SILBuilder;
-
-  UncheckedAddrCastInst(SILDebugLocation DebugLoc, SILValue Operand,
-                        ArrayRef<SILValue> TypeDependentOperands, SILType Ty)
-      : UnaryInstructionWithTypeDependentOperandsBase(DebugLoc, Operand,
-                                               TypeDependentOperands, Ty) {}
-  static UncheckedAddrCastInst *
-  create(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty,
-         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
-};
-
 /// Convert a value's binary representation to a trivial type of the same size.
 class UncheckedTrivialBitCastInst final
   : public UnaryInstructionWithTypeDependentOperandsBase<
@@ -4841,41 +4788,6 @@ public:
 
   CanType getTargetFormalType() const { return DestFormalTy; }
   SILType getTargetLoweredType() const { return getType(); }
-};
-
-/// Perform an unconditional checked cast that aborts if the cast fails.
-/// The result of the checked cast is left in the destination address.
-class UnconditionalCheckedCastAddrInst
-    : public InstructionBase<SILInstructionKind::UnconditionalCheckedCastAddrInst,
-                             NonValueInstruction> {
-  friend SILBuilder;
-
-  enum {
-    /// the value being stored
-    Src,
-    /// the lvalue being stored to
-    Dest
-  };
-  FixedOperandList<2> Operands;
-  CanType SourceType;
-  CanType TargetType;
-
-  UnconditionalCheckedCastAddrInst(SILDebugLocation Loc,
-                                   SILValue src, CanType sourceType,
-                                   SILValue dest, CanType targetType);
-
-public:
-  SILValue getSrc() const { return Operands[Src].get(); }
-  SILValue getDest() const { return Operands[Dest].get(); }
-
-  SILType getSourceLoweredType() const { return getSrc()->getType(); }
-  CanType getSourceFormalType() const { return SourceType; }
-
-  SILType getTargetLoweredType() const { return getDest()->getType(); }
-  CanType getTargetFormalType() const { return TargetType; }
-
-  ArrayRef<Operand> getAllOperands() const { return Operands.asArray(); }
-  MutableArrayRef<Operand> getAllOperands() { return Operands.asArray(); }
 };
 
 /// Perform an unconditional checked cast that aborts if the cast fails.
@@ -7775,54 +7687,24 @@ public:
   MutableArrayRef<Operand> getAllOperands() { return Operands.asArray(); }
 };
 
-/// Perform a checked cast operation and branch on whether the cast succeeds.
-/// The success branch destination block receives the cast result as a BB
-/// argument.
-class CheckedCastBranchInst final:
-  public UnaryInstructionWithTypeDependentOperandsBase<
-                              SILInstructionKind::CheckedCastBranchInst,
-                              CheckedCastBranchInst,
-                              TermInst> {
-  friend SILBuilder;
-
-  SILType DestLoweredTy;
-  CanType DestFormalTy;
-  bool IsExact;
-
+/// The base class for cast instructions which are terminators.
+class CastBranchInstBase : public TermInst {
   std::array<SILSuccessor, 2> DestBBs;
 
-  CheckedCastBranchInst(SILDebugLocation DebugLoc, bool IsExact,
-                        SILValue Operand,
-                        ArrayRef<SILValue> TypeDependentOperands,
-                        SILType DestLoweredTy, CanType DestFormalTy,
-                        SILBasicBlock *SuccessBB, SILBasicBlock *FailureBB,
-                        ProfileCounter Target1Count, ProfileCounter Target2Count)
-      : UnaryInstructionWithTypeDependentOperandsBase(DebugLoc, Operand,
-                                                      TypeDependentOperands),
-        DestLoweredTy(DestLoweredTy),
-        DestFormalTy(DestFormalTy),
-        IsExact(IsExact), DestBBs{{{this, SuccessBB, Target1Count},
-                                   {this, FailureBB, Target2Count}}} {}
-
-  static CheckedCastBranchInst *
-  create(SILDebugLocation DebugLoc, bool IsExact, SILValue Operand,
-         SILType DestLoweredTy, CanType DestFormalTy,
-         SILBasicBlock *SuccessBB, SILBasicBlock *FailureBB,
-         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes,
-         ProfileCounter Target1Count, ProfileCounter Target2Count);
-
 public:
-  bool isExact() const { return IsExact; }
+
+  CastBranchInstBase(SILInstructionKind K, SILDebugLocation DebugLoc,
+                     SILBasicBlock *SuccessBB, SILBasicBlock *FailureBB,
+                     ProfileCounter Target1Count = ProfileCounter(),
+                     ProfileCounter Target2Count = ProfileCounter()) :
+    TermInst(K, DebugLoc),
+    DestBBs{{{this, SuccessBB, Target1Count},
+             {this, FailureBB, Target2Count}}}
+      {}
 
   SuccessorListTy getSuccessors() {
     return DestBBs;
   }
-
-  SILType getSourceLoweredType() const { return getOperand()->getType(); }
-  CanType getSourceFormalType() const { return getSourceLoweredType().getASTType(); }
-
-  SILType getTargetLoweredType() const { return DestLoweredTy; }
-  CanType getTargetFormalType() const { return DestFormalTy; }
 
   SILBasicBlock *getSuccessBB() { return DestBBs[0]; }
   const SILBasicBlock *getSuccessBB() const { return DestBBs[0]; }
@@ -7835,6 +7717,142 @@ public:
   ProfileCounter getFalseBBCount() const { return DestBBs[1].getCount(); }
 };
 
+/// The base class for cast instructions which are terminators and have a
+/// CastConsumptionKind.
+class CastBranchWithConsumptionKindBase : public CastBranchInstBase {
+  CastConsumptionKind ConsumptionKind;
+
+public:
+
+  CastBranchWithConsumptionKindBase(SILInstructionKind K, SILDebugLocation DebugLoc,
+                     CastConsumptionKind consumptionKind,
+                     SILBasicBlock *SuccessBB, SILBasicBlock *FailureBB,
+                     ProfileCounter Target1Count = ProfileCounter(),
+                     ProfileCounter Target2Count = ProfileCounter()) :
+    CastBranchInstBase(K, DebugLoc, SuccessBB, FailureBB,
+                       Target1Count, Target2Count),
+    ConsumptionKind(consumptionKind) {}
+
+  CastConsumptionKind getConsumptionKind() const { return ConsumptionKind; }
+};
+
+/// Helper base class for AddrCastInstBase.
+///
+/// Ideally, the types would just be a member of AddrCastInstBase. But because
+/// of tail-allocated operands, they need to be in a base class of
+/// InstructionBaseWithTrailingOperands.
+template<typename Base>
+class TypesForAddrCasts : public Base {
+  CanType SourceType;
+  CanType TargetType;
+
+public:
+  template <typename... Args>
+  TypesForAddrCasts(SILInstructionKind K, SILDebugLocation debugLoc,
+                    CanType SourceType, CanType TargetType,
+                    Args &&...args)
+      : Base(K, debugLoc, std::forward<Args>(args)...),
+        SourceType(SourceType), TargetType(TargetType) {}
+
+  CanType getSourceFormalType() const { return SourceType; }
+  CanType getTargetFormalType() const { return TargetType; }
+};
+
+/// Base class for cast instructions with address-type operands.
+template<SILInstructionKind Kind,
+         typename Derived,
+         typename Base>
+class AddrCastInstBase
+    : public InstructionBaseWithTrailingOperands<Kind, Derived,
+                                                 TypesForAddrCasts<Base>> {
+protected:
+  friend InstructionBaseWithTrailingOperands<Kind, Derived, Operand>;
+
+  using TrailingObjects =
+      InstructionBaseWithTrailingOperands<Kind, Derived, Operand>;
+
+public:
+  template <typename... Args>
+  AddrCastInstBase(SILDebugLocation debugLoc,
+                                       SILValue src, CanType srcType,
+                                       SILValue dest, CanType targetType,
+                                       ArrayRef<SILValue> typeDependentOperands,
+                                       Args &&...args)
+      : InstructionBaseWithTrailingOperands<Kind, Derived, TypesForAddrCasts<Base>> (
+                                              src, dest, typeDependentOperands,
+                                              debugLoc, srcType, targetType,
+                                              std::forward<Args>(args)...) {}
+
+  unsigned getNumTypeDependentOperands() const {
+    return this->getAllOperands().size() - 2;
+  }
+
+  ArrayRef<Operand> getTypeDependentOperands() const {
+    return this->getAllOperands().slice(2);
+  }
+
+  MutableArrayRef<Operand> getTypeDependentOperands() {
+    return this->getAllOperands().slice(2);
+  }
+
+  enum {
+    /// the value being stored
+    Src,
+    /// the lvalue being stored to
+    Dest
+  };
+
+  SILValue getSrc() const { return this->getAllOperands()[Src].get(); }
+  SILValue getDest() const { return this->getAllOperands()[Dest].get(); }
+
+  SILType getSourceLoweredType() const { return getSrc()->getType(); }
+  SILType getTargetLoweredType() const { return getDest()->getType(); }
+};
+
+/// Perform a checked cast operation and branch on whether the cast succeeds.
+/// The success branch destination block receives the cast result as a BB
+/// argument.
+class CheckedCastBranchInst final:
+  public UnaryInstructionWithTypeDependentOperandsBase<
+                              SILInstructionKind::CheckedCastBranchInst,
+                              CheckedCastBranchInst,
+                              CastBranchInstBase> {
+  friend SILBuilder;
+
+  SILType DestLoweredTy;
+  CanType DestFormalTy;
+  bool IsExact;
+
+  CheckedCastBranchInst(SILDebugLocation DebugLoc, bool IsExact,
+                        SILValue Operand,
+                        ArrayRef<SILValue> TypeDependentOperands,
+                        SILType DestLoweredTy, CanType DestFormalTy,
+                        SILBasicBlock *SuccessBB, SILBasicBlock *FailureBB,
+                        ProfileCounter Target1Count, ProfileCounter Target2Count)
+      : UnaryInstructionWithTypeDependentOperandsBase(DebugLoc, Operand,
+            TypeDependentOperands,
+            SuccessBB, FailureBB, Target1Count, Target2Count),
+        DestLoweredTy(DestLoweredTy),
+        DestFormalTy(DestFormalTy),
+        IsExact(IsExact) {}
+
+  static CheckedCastBranchInst *
+  create(SILDebugLocation DebugLoc, bool IsExact, SILValue Operand,
+         SILType DestLoweredTy, CanType DestFormalTy,
+         SILBasicBlock *SuccessBB, SILBasicBlock *FailureBB,
+         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes,
+         ProfileCounter Target1Count, ProfileCounter Target2Count);
+
+public:
+  bool isExact() const { return IsExact; }
+
+  SILType getSourceLoweredType() const { return getOperand()->getType(); }
+  CanType getSourceFormalType() const { return getSourceLoweredType().getASTType(); }
+
+  SILType getTargetLoweredType() const { return DestLoweredTy; }
+  CanType getTargetFormalType() const { return DestFormalTy; }
+};
+
 /// Perform a checked cast operation and branch on whether the cast succeeds.
 /// The success branch destination block receives the cast result as a BB
 /// argument.
@@ -7842,14 +7860,12 @@ class CheckedCastValueBranchInst final
     : public UnaryInstructionWithTypeDependentOperandsBase<
           SILInstructionKind::CheckedCastValueBranchInst,
           CheckedCastValueBranchInst,
-          TermInst> {
+          CastBranchInstBase> {
   friend SILBuilder;
 
   CanType SourceFormalTy;
   SILType DestLoweredTy;
   CanType DestFormalTy;
-
-  std::array<SILSuccessor, 2> DestBBs;
 
   CheckedCastValueBranchInst(SILDebugLocation DebugLoc,
                              SILValue Operand, CanType SourceFormalTy,
@@ -7857,10 +7873,9 @@ class CheckedCastValueBranchInst final
                              SILType DestLoweredTy, CanType DestFormalTy,
                              SILBasicBlock *SuccessBB, SILBasicBlock *FailureBB)
       : UnaryInstructionWithTypeDependentOperandsBase(DebugLoc, Operand,
-                                                      TypeDependentOperands),
+                                  TypeDependentOperands, SuccessBB, FailureBB),
         SourceFormalTy(SourceFormalTy),
-        DestLoweredTy(DestLoweredTy), DestFormalTy(DestFormalTy),
-        DestBBs{{{this, SuccessBB}, {this, FailureBB}}} {}
+        DestLoweredTy(DestLoweredTy), DestFormalTy(DestFormalTy) {}
 
   static CheckedCastValueBranchInst *
   create(SILDebugLocation DebugLoc,
@@ -7870,84 +7885,90 @@ class CheckedCastValueBranchInst final
          SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
 
 public:
-  SuccessorListTy getSuccessors() { return DestBBs; }
-
   SILType getSourceLoweredType() const { return getOperand()->getType(); }
   CanType getSourceFormalType() const { return SourceFormalTy; }
 
   SILType getTargetLoweredType() const { return DestLoweredTy; }
   CanType getTargetFormalType() const { return DestFormalTy; }
-
-  SILBasicBlock *getSuccessBB() { return DestBBs[0]; }
-  const SILBasicBlock *getSuccessBB() const { return DestBBs[0]; }
-  SILBasicBlock *getFailureBB() { return DestBBs[1]; }
-  const SILBasicBlock *getFailureBB() const { return DestBBs[1]; }
 };
 
 /// Perform a checked cast operation and branch on whether the cast succeeds.
 /// The result of the checked cast is left in the destination address.
-class CheckedCastAddrBranchInst
-    : public InstructionBase<SILInstructionKind::CheckedCastAddrBranchInst,
-                             TermInst> {
+class CheckedCastAddrBranchInst final
+    : public AddrCastInstBase<
+              SILInstructionKind::CheckedCastAddrBranchInst,
+              CheckedCastAddrBranchInst, CastBranchWithConsumptionKindBase> {
   friend SILBuilder;
-
-  CastConsumptionKind ConsumptionKind;
-
-  FixedOperandList<2> Operands;
-  std::array<SILSuccessor, 2> DestBBs;
-
-  CanType SourceType;
-  CanType TargetType;
 
   CheckedCastAddrBranchInst(SILDebugLocation DebugLoc,
                             CastConsumptionKind consumptionKind, SILValue src,
                             CanType srcType, SILValue dest, CanType targetType,
+                            ArrayRef<SILValue> TypeDependentOperands,
                             SILBasicBlock *successBB, SILBasicBlock *failureBB,
                             ProfileCounter Target1Count,
-                            ProfileCounter Target2Count)
-      : InstructionBase(DebugLoc), ConsumptionKind(consumptionKind),
-        Operands{this, src, dest}, DestBBs{{{this, successBB, Target1Count},
-                                            {this, failureBB, Target2Count}}},
-        SourceType(srcType), TargetType(targetType) {
-    assert(ConsumptionKind != CastConsumptionKind::BorrowAlways &&
-           "BorrowAlways is not supported on addresses");
-  }
+                            ProfileCounter Target2Count);
 
+  static CheckedCastAddrBranchInst *
+  create(SILDebugLocation DebugLoc, CastConsumptionKind consumptionKind,
+         SILValue src, CanType srcType, SILValue dest, CanType targetType,
+         SILBasicBlock *successBB, SILBasicBlock *failureBB,
+         ProfileCounter Target1Count, ProfileCounter Target2Count,
+         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
+};
+
+/// Converts a heap object reference to a different type without any runtime
+/// checks. This is a variant of UncheckedRefCast that works on address types,
+/// thus encapsulates an implicit load and take of the reference followed by a
+/// store and initialization of a new reference.
+class UncheckedRefCastAddrInst final
+    : public AddrCastInstBase<
+               SILInstructionKind::UncheckedRefCastAddrInst,
+               UncheckedRefCastAddrInst, NonValueInstruction> {
 public:
-  enum {
-    /// the value being stored
-    Src,
-    /// the lvalue being stored to
-    Dest
-  };
+  UncheckedRefCastAddrInst(SILDebugLocation Loc, SILValue src, CanType srcType,
+                           SILValue dest, CanType targetType,
+                           ArrayRef<SILValue> TypeDependentOperands);
+  
+  static UncheckedRefCastAddrInst *
+  create(SILDebugLocation Loc, SILValue src, CanType srcType,
+         SILValue dest, CanType targetType,
+         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
+};
 
-  CastConsumptionKind getConsumptionKind() const { return ConsumptionKind; }
+class UncheckedAddrCastInst final
+  : public UnaryInstructionWithTypeDependentOperandsBase<
+                                SILInstructionKind::UncheckedAddrCastInst,
+                                UncheckedAddrCastInst,
+                                ConversionInst>
+{
+  friend SILBuilder;
 
-  SILValue getSrc() const { return Operands[Src].get(); }
-  SILValue getDest() const { return Operands[Dest].get(); }
+  UncheckedAddrCastInst(SILDebugLocation DebugLoc, SILValue Operand,
+                        ArrayRef<SILValue> TypeDependentOperands, SILType Ty)
+      : UnaryInstructionWithTypeDependentOperandsBase(DebugLoc, Operand,
+                                               TypeDependentOperands, Ty) {}
+  static UncheckedAddrCastInst *
+  create(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty,
+         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
+};
 
-  SILType getSourceLoweredType() const { return getSrc()->getType(); }
-  CanType getSourceFormalType() const { return SourceType; }
+/// Perform an unconditional checked cast that aborts if the cast fails.
+/// The result of the checked cast is left in the destination address.
+class UnconditionalCheckedCastAddrInst final
+    : public AddrCastInstBase<
+               SILInstructionKind::UnconditionalCheckedCastAddrInst,
+               UnconditionalCheckedCastAddrInst, NonValueInstruction> {
+  friend SILBuilder;
 
-  SILType getTargetLoweredType() const { return getDest()->getType(); }
-  CanType getTargetFormalType() const { return TargetType; }
+  UnconditionalCheckedCastAddrInst(SILDebugLocation Loc,
+                                   SILValue src, CanType sourceType,
+                                   SILValue dest, CanType targetType,
+                                   ArrayRef<SILValue> TypeDependentOperands);
 
-  ArrayRef<Operand> getAllOperands() const { return Operands.asArray(); }
-  MutableArrayRef<Operand> getAllOperands() { return Operands.asArray(); }
-
-  SuccessorListTy getSuccessors() {
-    return DestBBs;
-  }
-
-  SILBasicBlock *getSuccessBB() { return DestBBs[0]; }
-  const SILBasicBlock *getSuccessBB() const { return DestBBs[0]; }
-  SILBasicBlock *getFailureBB() { return DestBBs[1]; }
-  const SILBasicBlock *getFailureBB() const { return DestBBs[1]; }
-
-  /// The number of times the True branch was executed.
-  ProfileCounter getTrueBBCount() const { return DestBBs[0].getCount(); }
-  /// The number of times the False branch was executed.
-  ProfileCounter getFalseBBCount() const { return DestBBs[1].getCount(); }
+  static UnconditionalCheckedCastAddrInst *
+  create(SILDebugLocation DebugLoc, SILValue src, CanType sourceType,
+         SILValue dest, CanType targetType,
+         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
 };
 
 /// A private abstract class to store the destinations of a TryApplyInst.

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1122,19 +1122,86 @@ BindMemoryInst::create(SILDebugLocation Loc, SILValue Base, SILValue Index,
                                        TypeDependentOperands);
 }
 
-UncheckedRefCastAddrInst::UncheckedRefCastAddrInst(SILDebugLocation Loc,
-                                                   SILValue src,
-                                                   CanType srcType,
-                                                   SILValue dest,
-                                                   CanType targetType)
-    : InstructionBase(Loc),
-      Operands(this, src, dest), SourceType(srcType), TargetType(targetType) {}
+UncheckedRefCastAddrInst::
+UncheckedRefCastAddrInst(SILDebugLocation Loc, SILValue src, CanType srcType,
+                         SILValue dest, CanType targetType,
+                         ArrayRef<SILValue> TypeDependentOperands)
+    : AddrCastInstBase(Loc, src, srcType, dest, targetType,
+        TypeDependentOperands) {}
+
+UncheckedRefCastAddrInst *
+UncheckedRefCastAddrInst::create(SILDebugLocation Loc, SILValue src,
+        CanType srcType, SILValue dest, CanType targetType,
+        SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes) {
+  SILModule &Mod = F.getModule();
+  SmallVector<SILValue, 8> TypeDependentOperands;
+  collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, F,
+                               srcType);
+  collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, F,
+                               targetType);
+  unsigned size =
+      totalSizeToAlloc<swift::Operand>(2 + TypeDependentOperands.size());
+  void *Buffer = Mod.allocateInst(size, alignof(UncheckedRefCastAddrInst));
+  return ::new (Buffer) UncheckedRefCastAddrInst(Loc, src, srcType,
+    dest, targetType, TypeDependentOperands);
+}
 
 UnconditionalCheckedCastAddrInst::UnconditionalCheckedCastAddrInst(
     SILDebugLocation Loc, SILValue src, CanType srcType, SILValue dest,
-    CanType targetType)
-    : InstructionBase(Loc),
-      Operands(this, src, dest), SourceType(srcType), TargetType(targetType) {}
+    CanType targetType, ArrayRef<SILValue> TypeDependentOperands)
+    : AddrCastInstBase(Loc, src, srcType, dest, targetType,
+        TypeDependentOperands) {}
+
+UnconditionalCheckedCastAddrInst *
+UnconditionalCheckedCastAddrInst::create(SILDebugLocation Loc, SILValue src,
+        CanType srcType, SILValue dest, CanType targetType,
+        SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes) {
+  SILModule &Mod = F.getModule();
+  SmallVector<SILValue, 8> TypeDependentOperands;
+  collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, F,
+                               srcType);
+  collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, F,
+                               targetType);
+  unsigned size =
+      totalSizeToAlloc<swift::Operand>(2 + TypeDependentOperands.size());
+  void *Buffer = Mod.allocateInst(size, alignof(UnconditionalCheckedCastAddrInst));
+  return ::new (Buffer) UnconditionalCheckedCastAddrInst(Loc, src, srcType,
+    dest, targetType, TypeDependentOperands);
+}
+
+CheckedCastAddrBranchInst::CheckedCastAddrBranchInst(
+  SILDebugLocation DebugLoc, CastConsumptionKind consumptionKind,
+  SILValue src, CanType srcType, SILValue dest, CanType targetType,
+  ArrayRef<SILValue> TypeDependentOperands,
+  SILBasicBlock *successBB, SILBasicBlock *failureBB,
+  ProfileCounter Target1Count, ProfileCounter Target2Count)
+      : AddrCastInstBase(DebugLoc, src, srcType, dest,
+            targetType, TypeDependentOperands, consumptionKind,
+            successBB, failureBB, Target1Count, Target2Count) {
+  assert(consumptionKind != CastConsumptionKind::BorrowAlways &&
+         "BorrowAlways is not supported on addresses");
+}
+
+CheckedCastAddrBranchInst *
+CheckedCastAddrBranchInst::create(SILDebugLocation DebugLoc,
+         CastConsumptionKind consumptionKind,
+         SILValue src, CanType srcType, SILValue dest, CanType targetType,
+         SILBasicBlock *successBB, SILBasicBlock *failureBB,
+         ProfileCounter Target1Count, ProfileCounter Target2Count,
+         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes) {
+  SILModule &Mod = F.getModule();
+  SmallVector<SILValue, 8> TypeDependentOperands;
+  collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, F,
+                               srcType);
+  collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, F,
+                               targetType);
+  unsigned size =
+      totalSizeToAlloc<swift::Operand>(2 + TypeDependentOperands.size());
+  void *Buffer = Mod.allocateInst(size, alignof(CheckedCastAddrBranchInst));
+  return ::new (Buffer) CheckedCastAddrBranchInst(DebugLoc, consumptionKind,
+    src, srcType, dest, targetType, TypeDependentOperands,
+    successBB, failureBB, Target1Count, Target2Count);
+}
 
 StructInst *StructInst::create(SILDebugLocation Loc, SILType Ty,
                                ArrayRef<SILValue> Elements, SILModule &M,

--- a/test/SILOptimizer/dont_remove_dynamic_self_arg.swift
+++ b/test/SILOptimizer/dont_remove_dynamic_self_arg.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -module-name test -emit-sil -O %s | %FileCheck %s
+// Make sure IRGen does not crash
+// RUN: %target-swift-frontend -module-name test -emit-ir -O %s
+
+public class X {}
+
+@inline(never)
+func transform<T>(_ a: Any, c: (Any) -> T?) -> T? {
+  return c(a)
+}
+
+// CHECK-LABEL: sil private @$s4test1XC6testityACSgypFACXDSgypXEfU_ : $@convention(thin) (@in_guaranteed Any, @thick @dynamic_self X.Type) -> @owned Optional<X> {
+// CHECK: bb0(%0 : $*Any, %1 : $@thick @dynamic_self X.Type):
+
+// The checked_cast_addr_br must have %1 as implicit type dependend operand.
+// CHECK:   checked_cast_addr_br take_always Any in %{{[0-9]+}} : $*Any to @dynamic_self X in %{{[0-9]+}} : $*X, bb1, bb2 // type-defs: %1;
+// CHECK: } // end sil function '$s4test1XC6testityACSgypFACXDSgypXEfU_'
+
+extension X {
+  public func testit(_ a: Any) -> X? {
+    guard let xx = transform(a, c: { $0 as? Self }) else {
+      return nil
+    }
+    return xx
+  }
+}
+


### PR DESCRIPTION
We had this for some cast instructions, but not for cast instructions with address-types.
Type dependent operands - like for dynamic self - are important for establishing a def-use relationship between the instruction/argument which defines the type and the instruction which uses the type.
Missing those dependencies can cause instructions or the dynamic-self argument to be removed while the type is still used in a cast instruction.

This change involved some class hierarchy gymnastics in SILInstruction.h.

Fixes a compiler crash.
rdar://problem/61816506
