### PR TITLE
[Sema] Don't require explicit availability on extensions without public members

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2828,6 +2828,23 @@ bool swift::diagnoseDeclAvailability(const ValueDecl *Decl,
   return AW.diagAvailability(const_cast<ValueDecl *>(Decl), R, nullptr, Flags);
 }
 
+/// Should we warn that \p valueDecl needs an explicit availability annotation
+/// in -require-explicit-availaiblity mode?
+static bool declNeedsExplicitAvailability(const ValueDecl *valueDecl) {
+  AccessScope scope =
+    valueDecl->getFormalAccessScope(/*useDC*/nullptr,
+                                  /*treatUsableFromInlineAsPublic*/true);
+  if (!scope.isPublic() ||
+      valueDecl->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>())
+    return false;
+
+  // Warn on decls without an introduction version.
+  auto &ctx = valueDecl->getASTContext();
+  auto safeRangeUnderApprox = AvailabilityInference::availableRange(valueDecl, ctx);
+  return !safeRangeUnderApprox.getOSVersion().hasLowerEndpoint() &&
+         !valueDecl->getAttrs().isUnavailable(ctx);
+}
+
 void swift::checkExplicitAvailability(Decl *decl) {
   // Check only if the command line option was set.
   if (!decl->getASTContext().LangOpts.RequireExplicitAvailability)
@@ -2840,27 +2857,14 @@ void swift::checkExplicitAvailability(Decl *decl) {
 
   ValueDecl *valueDecl = dyn_cast<ValueDecl>(decl);
   if (valueDecl == nullptr) {
-    // decl should be either a ValueDecl or an ExtensionDecl
+    // decl should be either a ValueDecl or an ExtensionDecl.
     auto extension = cast<ExtensionDecl>(decl);
     valueDecl = extension->getExtendedNominal();
     if (!valueDecl)
       return;
   }
 
-  // Skip decls that are not public and not usable from inline.
-  AccessScope scope =
-    valueDecl->getFormalAccessScope(/*useDC*/nullptr,
-                                  /*treatUsableFromInlineAsPublic*/true);
-  if (!scope.isPublic() ||
-      decl->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>())
-    return;
-
-  // Warn on decls without an introduction version.
-  auto &ctx = decl->getASTContext();
-  auto safeRangeUnderApprox = AvailabilityInference::availableRange(decl, ctx);
-  if (!safeRangeUnderApprox.getOSVersion().hasLowerEndpoint() &&
-      !decl->getAttrs().isUnavailable(ctx)) {
-
+  if (declNeedsExplicitAvailability(valueDecl)) {
     auto diag = decl->diagnose(diag::public_decl_needs_availability);
 
     auto suggestPlatform = decl->getASTContext().LangOpts.RequireExplicitAvailabilityTarget;
@@ -2876,6 +2880,7 @@ void swift::checkExplicitAvailability(Decl *decl) {
       {
          llvm::raw_string_ostream Out(AttrText);
 
+         auto &ctx = valueDecl->getASTContext();
          StringRef OriginalIndent = Lexer::getIndentationForLine(
            ctx.SourceMgr, InsertLoc);
          Out << "@available(" << suggestPlatform << ", *)\n"

--- a/test/attr/require_explicit_availability.swift
+++ b/test/attr/require_explicit_availability.swift
@@ -1,3 +1,5 @@
+// Test the -require-explicit-availability flag
+
 // RUN: %swiftc_driver -typecheck -parse-stdlib -target x86_64-apple-macosx10.10 -Xfrontend -verify -require-explicit-availability -require-explicit-availability-target "macOS 10.10"  %s
 // RUN: %swiftc_driver -typecheck -parse-stdlib -target x86_64-apple-macosx10.10 -warnings-as-errors %s
 
@@ -43,8 +45,21 @@ public class C { } // expected-warning {{public declarations should have an avai
 
 public protocol P { } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
 
+private protocol PrivateProto { }
+
 extension S { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
-  func ok() { }
+  public func warnForPublicMembers() { } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{3-3=@available(macOS 10.10, *)\n  }}
+}
+
+extension S {
+  internal func dontWarnWithoutPublicMembers() { }
+  private func dontWarnWithoutPublicMembers1() { }
+}
+
+extension S : P { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+}
+
+extension S : PrivateProto {
 }
 
 open class OpenClass { } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}


### PR DESCRIPTION
The option -require-explicit-availability warns on declarations that don't declare an introduction version. This change stops the warnings on extensions to public types that don't define either public members or conformances.

rdar://problem/61879659