### PR TITLE
[Diagnostics] Refactor `FailureDiagnostic` to operate on `TypedNode`

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3759,7 +3759,12 @@ public:
     assert(hasExplicitResultType() && "No explicit result type");
     return ExplicitResultType;
   }
-  
+
+  TypeRepr *getExplicitResultTypeRepr() const {
+    assert(hasExplicitResultType() && "No explicit result type");
+    return ExplicitResultType.getTypeRepr();
+  }
+
   void setExplicitResultType(SourceLoc arrowLoc, TypeLoc resultType) {
     ArrowLoc = arrowLoc;
     ExplicitResultType = resultType;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -166,10 +166,17 @@ ConstraintLocator *Solution::getCalleeLocator(ConstraintLocator *locator,
 }
 
 ConstraintLocator *
-Solution::getConstraintLocator(Expr *anchor,
+Solution::getConstraintLocator(const Expr *anchor,
                                ArrayRef<LocatorPathElt> path) const {
   auto &cs = getConstraintSystem();
-  return cs.getConstraintLocator(anchor, path);
+  return cs.getConstraintLocator(const_cast<Expr *>(anchor), path);
+}
+
+ConstraintLocator *
+Solution::getConstraintLocator(ConstraintLocator *base,
+                               ArrayRef<LocatorPathElt> path) const {
+  auto &cs = getConstraintSystem();
+  return cs.getConstraintLocator(base, path);
 }
 
 /// Return the implicit access kind for a MemberRefExpr with the

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -50,7 +50,7 @@ bool FailureDiagnostic::diagnoseAsNote() {
   return false;
 }
 
-Expr *FailureDiagnostic::computeAnchor() const {
+Expr *FailureDiagnostic::getAnchor() const {
   auto &cs = getConstraintSystem();
 
   auto *locator = getLocator();

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3909,9 +3909,8 @@ bool MissingArgumentsFailure::diagnoseAsError() {
   unsigned numArguments = 0;
   bool hasTrailingClosure = false;
 
-  auto *rawAnchor = getRawAnchor().get<const Expr *>();
   std::tie(fnExpr, argExpr, numArguments, hasTrailingClosure) =
-      getCallInfo(const_cast<Expr *>(rawAnchor));
+      getCallInfo(getRawAnchor());
 
   // TODO(diagnostics): We should be able to suggest this fix-it
   // unconditionally.
@@ -3987,7 +3986,7 @@ bool MissingArgumentsFailure::diagnoseSingleMissingArgument() const {
   bool hasTrailingClosure = false;
 
   std::tie(fnExpr, argExpr, insertableEndIdx, hasTrailingClosure) =
-      getCallInfo(const_cast<Expr *>(anchor.get<const Expr *>()));
+      getCallInfo(anchor);
 
   if (!argExpr)
     return false;
@@ -4293,17 +4292,17 @@ bool MissingArgumentsFailure::isMisplacedMissingArgument(
 }
 
 std::tuple<Expr *, Expr *, unsigned, bool>
-MissingArgumentsFailure::getCallInfo(Expr *anchor) const {
-  if (auto *call = dyn_cast<CallExpr>(anchor)) {
+MissingArgumentsFailure::getCallInfo(TypedNode anchor) const {
+  if (auto *call = getAsExpr<CallExpr>(anchor)) {
     return std::make_tuple(call->getFn(), call->getArg(),
                            call->getNumArguments(), call->hasTrailingClosure());
-  } else if (auto *UME = dyn_cast<UnresolvedMemberExpr>(anchor)) {
+  } else if (auto *UME = getAsExpr<UnresolvedMemberExpr>(anchor)) {
     return std::make_tuple(UME, UME->getArgument(), UME->getNumArguments(),
                            UME->hasTrailingClosure());
-  } else if (auto *SE = dyn_cast<SubscriptExpr>(anchor)) {
+  } else if (auto *SE = getAsExpr<SubscriptExpr>(anchor)) {
     return std::make_tuple(SE, SE->getIndex(), SE->getNumArguments(),
                            SE->hasTrailingClosure());
-  } else if (auto *OLE = dyn_cast<ObjectLiteralExpr>(anchor)) {
+  } else if (auto *OLE = getAsExpr<ObjectLiteralExpr>(anchor)) {
     return std::make_tuple(OLE, OLE->getArg(), OLE->getNumArguments(),
                            OLE->hasTrailingClosure());
   }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -83,8 +83,7 @@ public:
 
   ConstraintLocator *getLocator() const { return Locator; }
 
-  Type getType(Expr *expr, bool wantRValue = true) const;
-  Type getType(const TypeLoc &loc, bool wantRValue = true) const;
+  Type getType(TypedNode node, bool wantRValue = true) const;
 
   /// Resolve type variables present in the raw type, if any.
   Type resolveType(Type rawType, bool reconstituteSugar = false,

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -118,19 +118,19 @@ protected:
     return S.getConstraintSystem();
   }
 
-  Type getContextualType(Expr *anchor) const {
+  Type getContextualType(TypedNode anchor) const {
     auto &cs = getConstraintSystem();
-    return cs.getContextualType(anchor);
+    return cs.getContextualType(anchor.get<const Expr *>());
   }
 
-  TypeLoc getContextualTypeLoc(Expr *anchor) const {
+  TypeLoc getContextualTypeLoc(TypedNode anchor) const {
     auto &cs = getConstraintSystem();
-    return cs.getContextualTypeLoc(anchor);
+    return cs.getContextualTypeLoc(anchor.get<const Expr *>());
   }
 
-  ContextualTypePurpose getContextualTypePurpose(Expr *anchor) const {
+  ContextualTypePurpose getContextualTypePurpose(TypedNode anchor) const {
     auto &cs = getConstraintSystem();
-    return cs.getContextualTypePurpose(anchor);
+    return cs.getContextualTypePurpose(anchor.get<const Expr *>());
   }
 
   DeclContext *getDC() const {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -204,6 +204,21 @@ protected:
 
   static SourceLoc getLoc(TypedNode node);
   static SourceRange getSourceRange(TypedNode node);
+
+  template <typename T> static const T *castToExpr(TypedNode node) {
+    return cast<T>(node.get<const Expr *>());
+  }
+
+  template <typename T> static T *getAsExpr(TypedNode node) {
+    if (const auto *E = node.dyn_cast<const Expr *>())
+      return dyn_cast<T>(const_cast<Expr *>(E));
+    return nullptr;
+  }
+
+  template <typename T> static bool isExpr(TypedNode node) {
+    auto *E = node.get<const Expr *>();
+    return isa<T>(E);
+  }
 };
 
 /// Base class for all of the diagnostics related to generic requirement

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1278,10 +1278,11 @@ private:
   /// `@Foo(answer: 42) var question = "ultimate question"`
   bool isPropertyWrapperInitialization() const;
 
-  /// Gather informatioin associated with expression that represents
+  /// Gather information associated with expression that represents
   /// a call - function, arguments, # of arguments and whether it has
   /// a trailing closure.
-  std::tuple<Expr *, Expr *, unsigned, bool> getCallInfo(Expr *anchor) const;
+  std::tuple<Expr *, Expr *, unsigned, bool>
+  getCallInfo(TypedNode anchor) const;
 
   /// Transform given argument into format suitable for a fix-it
   /// text e.g. `[<label>:]? <#<type#>`

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -41,15 +41,9 @@ class FailureDiagnostic {
   const Solution &S;
   ConstraintLocator *Locator;
 
-  /// The original anchor before any simplification.
-  Expr *RawAnchor;
-  /// Simplified anchor associated with the given locator.
-  Expr *Anchor;
-
 public:
   FailureDiagnostic(const Solution &solution, ConstraintLocator *locator)
-      : S(solution), Locator(locator), RawAnchor(locator->getAnchor()),
-        Anchor(computeAnchor()) {}
+      : S(solution), Locator(locator) {}
 
   FailureDiagnostic(const Solution &solution, Expr *anchor)
       : FailureDiagnostic(solution, solution.getConstraintLocator(anchor)) {}
@@ -83,9 +77,9 @@ public:
   /// e.g. ambiguity error.
   virtual bool diagnoseAsNote();
 
-  Expr *getRawAnchor() const { return RawAnchor; }
+  Expr *getRawAnchor() const { return Locator->getAnchor(); }
 
-  virtual Expr *getAnchor() const { return Anchor; }
+  virtual Expr *getAnchor() const;
 
   ConstraintLocator *getLocator() const { return Locator; }
 
@@ -201,10 +195,6 @@ protected:
       Type type,
       llvm::function_ref<void(GenericTypeParamType *, Type)> substitution =
           [](GenericTypeParamType *, Type) {});
-
-private:
-  /// Compute anchor expression associated with current diagnostic.
-  Expr *computeAnchor() const;
 };
 
 /// Base class for all of the diagnostics related to generic requirement

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -158,16 +158,23 @@ protected:
   }
 
   ConstraintLocator *
-  getConstraintLocator(Expr *anchor,
+  getConstraintLocator(TypedNode anchor,
                        ConstraintLocator::PathElement element) const {
-    return S.getConstraintLocator(anchor, {element});
+    return S.getConstraintLocator(anchor.get<const Expr *>(), {element});
   }
 
   /// Retrive the constraint locator for the given anchor and
   /// path, uniqued and automatically calculate the summary flags
   ConstraintLocator *getConstraintLocator(
-      Expr *anchor, ArrayRef<ConstraintLocator::PathElement> path = {}) const {
-    return S.getConstraintLocator(anchor, path);
+      TypedNode anchor,
+      ArrayRef<ConstraintLocator::PathElement> path = {}) const {
+    return S.getConstraintLocator(anchor.get<const Expr *>(), path);
+  }
+
+  ConstraintLocator *
+  getConstraintLocator(ConstraintLocator *baseLocator,
+                       ConstraintLocator::PathElement element) const {
+    return S.getConstraintLocator(baseLocator, element);
   }
 
   Optional<FunctionArgApplyInfo>

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -999,7 +999,11 @@ public:
                                       bool lookThroughApply = true) const;
 
   ConstraintLocator *
-  getConstraintLocator(Expr *anchor, ArrayRef<LocatorPathElt> path = {}) const;
+  getConstraintLocator(const Expr *anchor,
+                       ArrayRef<LocatorPathElt> path = {}) const;
+
+  ConstraintLocator *getConstraintLocator(ConstraintLocator *baseLocator,
+                                          ArrayRef<LocatorPathElt> path) const;
 
   void setExprTypes(Expr *expr) const;
 


### PR DESCRIPTION
Switch all of the relevant `FailureDiagnostic` APIs to use `TypedNode` instead of `Expr *`
and refactor diagnostic implementations to avoid relying on anchors being expressions where
possible.

Since `FailureDiagnostic` is the biggest user of `ConstraintLocator` this refactoring enables
to transition locator from being anchored only on expressions.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
