### PR TITLE
[stdlib] Removes redundant buffer zeroing in foreignErrorCorrectedGrapheme func by using `init(unsafeUninitializedCapacity:initializingWith:) 

### DIFF
--- a/stdlib/public/core/UnicodeHelpers.swift
+++ b/stdlib/public/core/UnicodeHelpers.swift
@@ -397,12 +397,13 @@ extension _StringGuts {
     }
 
     // TODO(String performance): Stack buffer if small enough
-    var cus = Array<UInt16>(repeating: 0, count: count)
-    cus.withUnsafeMutableBufferPointer {
+    let cus = Array<UInt16>(unsafeUninitializedCapacity: count) {
+      buffer, initializedCapacity in
       _cocoaStringCopyCharacters(
         from: self._object.cocoaObject,
         range: start..<end,
-        into: $0.baseAddress._unsafelyUnwrappedUnchecked)
+        into: buffer.baseAddress._unsafelyUnwrappedUnchecked)
+      initializedCapacity = count
     }
     return cus.withUnsafeBufferPointer {
       return Character(String._uncheckedFromUTF16($0))


### PR DESCRIPTION
<!-- What's in this pull request? -->
Removes redundant buffer zeroing in foreignErrorCorrectedGrapheme func by using `init(unsafeUninitializedCapacity:initializingWith:) 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
