### PR TITLE
[CS] A couple of fixes for static and dynamic callables

### DIFF
--- a/test/SILGen/call_as_function.swift
+++ b/test/SILGen/call_as_function.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+struct S {
+  func callAsFunction(_ x: Int) -> Int! { nil }
+}
+
+protocol P1 {
+  func callAsFunction()
+}
+
+protocol P2 {
+  func callAsFunction() -> Self
+}
+
+class C {
+  func callAsFunction(_ x: String) -> Self { return self }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s16call_as_function05test_a1_b1_C0yyAA1SV_AA2P1_pAA2P2_pxtAA1CCRbzlF : $@convention(thin) <T where T : C> (S, @in_guaranteed P1, @in_guaranteed P2, @guaranteed T) -> ()
+func test_call_as_function<T : C>(_ s: S, _ p1: P1, _ p2: P2, _ t: T) {
+  // CHECK: function_ref @$s16call_as_function1SV0A10AsFunctionySiSgSiF : $@convention(method) (Int, S) -> Optional<Int>
+  // CHECK: switch_enum %{{.+}} : $Optional<Int>
+  let _: Int = s(0)
+
+  // SR-12590: SILGen crash on existential callAsFunction.
+  // CHECK: witness_method $@opened({{.+}}) P1, #P1.callAsFunction : <Self where Self : P1> (Self) -> () -> ()
+  p1()
+
+  // CHECK: witness_method $@opened({{.+}}) P2, #P2.callAsFunction : <Self where Self : P2> (Self) -> () -> Self
+  _ = p2()
+
+  // CHECK: class_method %{{.+}} : $C, #C.callAsFunction : (C) -> (String) -> @dynamic_self C, $@convention(method) (@guaranteed String, @guaranteed C) -> @owned C
+  // CHECK: unchecked_ref_cast %{{.+}} : $C to $T
+  _ = t("")
+}
+

--- a/test/SILGen/dynamic_callable_attribute.swift
+++ b/test/SILGen/dynamic_callable_attribute.swift
@@ -38,3 +38,35 @@ public struct Callable2 {
 public func keywordCoerceBug(a: Callable2, s: Int) {
   a(s)
 }
+
+@dynamicCallable
+struct S {
+  func dynamicallyCall(withArguments x: [Int]) -> Int! { nil }
+}
+
+@dynamicCallable
+protocol P1 {
+  func dynamicallyCall(withKeywordArguments: [String: Any])
+}
+
+@dynamicCallable
+protocol P2 {
+  func dynamicallyCall(withArguments x: [Int]) -> Self
+}
+
+@dynamicCallable
+class C {
+  func dynamicallyCall(withKeywordArguments x: [String: String]) -> Self { return self }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s26dynamic_callable_attribute05test_A10_callablesyyAA1SV_AA2P1_pAA2P2_pxtAA1CCRbzlF : $@convention(thin) <T where T : C> (S, @in_guaranteed P1, @in_guaranteed P2, @guaranteed T) -> ()
+func test_dynamic_callables<T : C>(_ s: S, _ p1: P1, _ p2: P2, _ t: T) {
+  // SR-12615: Compiler crash on @dynamicCallable IUO.
+  // CHECK: function_ref @$s26dynamic_callable_attribute1SV15dynamicallyCall13withArgumentsSiSgSaySiG_tF : $@convention(method) (@guaranteed Array<Int>, S) -> Optional<Int>
+  // CHECK: switch_enum %{{.+}} : $Optional<Int>
+  let _: Int = s(0)
+
+  // CHECK: class_method %{{.+}} : $C, #C.dynamicallyCall : (C) -> ([String : String]) -> @dynamic_self C, $@convention(method) (@guaranteed Dictionary<String, String>, @guaranteed C) -> @owned C
+  // CHECK: unchecked_ref_cast %{{.+}} : $C to $T
+  _ = t("")
+}

--- a/test/SILGen/dynamic_callable_attribute.swift
+++ b/test/SILGen/dynamic_callable_attribute.swift
@@ -66,6 +66,12 @@ func test_dynamic_callables<T : C>(_ s: S, _ p1: P1, _ p2: P2, _ t: T) {
   // CHECK: switch_enum %{{.+}} : $Optional<Int>
   let _: Int = s(0)
 
+  // CHECK: witness_method $@opened({{.+}}) P1, #P1.dynamicallyCall : <Self where Self : P1> (Self) -> ([String : Any]) -> ()
+  p1(x: 5)
+
+  // CHECK: witness_method $@opened({{.+}}) P2, #P2.dynamicallyCall : <Self where Self : P2> (Self) -> ([Int]) -> Self
+  _ = p2()
+
   // CHECK: class_method %{{.+}} : $C, #C.dynamicallyCall : (C) -> ([String : String]) -> @dynamic_self C, $@convention(method) (@guaranteed Dictionary<String, String>, @guaranteed C) -> @owned C
   // CHECK: unchecked_ref_cast %{{.+}} : $C to $T
   _ = t("")


### PR DESCRIPTION
Continue to `finishApply` for `@dynamicCallable` applications in order to handle cases such as IUO unwraps and covariant return casts, and add a small hack to fix the closing of existentials around an implicit `callAsFunction` or `@dynamicCallable` application.

Resolves SR-12615 & SR-12590