### PR TITLE
[AutoDiff] differentiation benchmarks

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -80,6 +80,7 @@ set(SWIFT_BENCH_MODULES
     single-source/DictionaryRemove
     single-source/DictionarySubscriptDefault
     single-source/DictionarySwap
+    single-source/Differentiation
     single-source/Diffing
     single-source/DiffingMyers
     single-source/DropFirst

--- a/benchmark/single-source/Differentiation.swift
+++ b/benchmark/single-source/Differentiation.swift
@@ -1,0 +1,70 @@
+//===--- Differentiation.swift -------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+
+import _Differentiation
+
+public let Differentiation = [
+  BenchmarkInfo(
+    name: "DifferentiationIdentity",
+    runFunction: run_DifferentiationIdentity,
+    tags: [.regression, .differentiation]
+  ),
+  BenchmarkInfo(
+    name: "DifferentiationSquare",
+    runFunction: run_DifferentiationSquare,
+    tags: [.regression, .differentiation]
+  ),
+  BenchmarkInfo(
+    name: "DifferentiationArraySum",
+    runFunction: run_DifferentiationArraySum,
+    tags: [.regression, .differentiation],
+    setUpFunction: { blackHole(onesArray) }
+  ),
+]
+
+@inline(never)
+public func run_DifferentiationIdentity(N: Int) {
+  func f(_ x: Float) -> Float {
+    x
+  }
+  for _ in 0..<1000*N {
+    blackHole(valueWithGradient(at: 1, in: f))
+  }
+}
+
+@inline(never)
+public func run_DifferentiationSquare(N: Int) {
+  func f(_ x: Float) -> Float {
+    x * x
+  }
+  for _ in 0..<1000*N {
+    blackHole(valueWithGradient(at: 1, in: f))
+  }
+}
+
+let onesArray: [Float] = Array(repeating: 1, count: 50)
+
+@inline(never)
+public func run_DifferentiationArraySum(N: Int) {
+  func sum(_ array: [Float]) -> Float {
+    var result: Float = 0
+    for i in withoutDerivative(at: 0..<array.count) {
+      result += array[i]
+    }
+    return result
+  }
+  for _ in 0..<N {
+    blackHole(valueWithGradient(at: onesArray, in: sum))
+  }
+}

--- a/benchmark/single-source/Differentiation.swift
+++ b/benchmark/single-source/Differentiation.swift
@@ -10,8 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TestsUtils
+#if canImport(_Differentiation)
 
+import TestsUtils
 import _Differentiation
 
 public let Differentiation = [
@@ -68,3 +69,5 @@ public func run_DifferentiationArraySum(N: Int) {
     blackHole(valueWithGradient(at: onesArray, in: sum))
   }
 }
+
+#endif

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -28,7 +28,7 @@ public enum BenchmarkCategory : String {
   case runtime, refcount, metadata
   // Other general areas of compiled code validation.
   case abstraction, safetychecks, exceptions, bridging, concurrency, existential
-  case exclusivity
+  case exclusivity, differentiation
 
   // Algorithms are "micro" that test some well-known algorithm in isolation:
   // sorting, searching, hashing, fibonaci, crypto, etc.

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -68,6 +68,7 @@ import DictionaryOfAnyHashableStrings
 import DictionaryRemove
 import DictionarySubscriptDefault
 import DictionarySwap
+import Differentiation
 import Diffing
 import DiffingMyers
 import DropFirst
@@ -251,6 +252,7 @@ registerBenchmark(DictionaryOfAnyHashableStrings)
 registerBenchmark(DictionaryRemove)
 registerBenchmark(DictionarySubscriptDefault)
 registerBenchmark(DictionarySwap)
+registerBenchmark(Differentiation)
 registerBenchmark(Diffing)
 registerBenchmark(DiffingMyers)
 registerBenchmark(DropFirst)

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -68,7 +68,9 @@ import DictionaryOfAnyHashableStrings
 import DictionaryRemove
 import DictionarySubscriptDefault
 import DictionarySwap
+#if canImport(_Differentiation)
 import Differentiation
+#endif
 import Diffing
 import DiffingMyers
 import DropFirst
@@ -252,7 +254,9 @@ registerBenchmark(DictionaryOfAnyHashableStrings)
 registerBenchmark(DictionaryRemove)
 registerBenchmark(DictionarySubscriptDefault)
 registerBenchmark(DictionarySwap)
+#if canImport(_Differentiation)
 registerBenchmark(Differentiation)
+#endif
 registerBenchmark(Diffing)
 registerBenchmark(DiffingMyers)
 registerBenchmark(DropFirst)

--- a/stdlib/public/Differentiation/CMakeLists.txt
+++ b/stdlib/public/Differentiation/CMakeLists.txt
@@ -36,4 +36,5 @@ add_swift_target_library(swift_Differentiation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPE
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -parse-stdlib
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
+  DARWIN_INSTALL_NAME_DIR "@rpath"
   INSTALL_IN_COMPONENT stdlib)


### PR DESCRIPTION
Adds some differentiation benchmarks.

I have tagged them [`.regression`](https://github.com/apple/swift/blob/62f257d595d79f7535b7a2f887dbb9756af81697/benchmark/utils/TestsUtils.swift#L51) because I don't yet have any specific codegen/optimization operations in mind to test. When we start looking more closely at the performance of differentiation and identifying specific operations that are important for the performance, we can add [`.validation`](https://github.com/apple/swift/blob/62f257d595d79f7535b7a2f887dbb9756af81697/benchmark/utils/TestsUtils.swift#L24) benchmarks.

@eeckstein could you check if I've used the framework correctly? (Or redirect me to someone else who can review this?)