### PR TITLE
Store the type parameters of bound generics in the debug info.

### DIFF
--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -29,7 +29,6 @@ DebugTypeInfo::DebugTypeInfo(swift::Type Ty, llvm::Type *StorageTy, Size size,
                              bool IsMetadata)
     : Type(Ty.getPointer()), StorageType(StorageTy), size(size), align(align),
       DefaultAlignment(HasDefaultAlignment), IsMetadataType(IsMetadata) {
-  assert(StorageType && "StorageType is a nullptr");
   assert(align.getValue() != 0);
 }
 
@@ -53,6 +52,7 @@ DebugTypeInfo DebugTypeInfo::getFromTypeInfo(swift::Type Ty,
     // encounter one.
     size = Size(0);
   }
+  assert(Info.getStorageType() && "StorageType is a nullptr");
   return DebugTypeInfo(Ty.getPointer(), Info.getStorageType(), size,
                        Info.getBestKnownAlignment(), hasDefaultAlignment(Ty),
                        false);
@@ -80,6 +80,7 @@ DebugTypeInfo DebugTypeInfo::getMetadata(swift::Type Ty, llvm::Type *StorageTy,
                                          Size size, Alignment align) {
   DebugTypeInfo DbgTy(Ty.getPointer(), StorageTy, size,
                       align, true, false);
+  assert(StorageTy && "StorageType is a nullptr");
   assert(!DbgTy.isContextArchetype() && "type metadata cannot contain an archetype");
   return DbgTy;
 }
@@ -88,7 +89,14 @@ DebugTypeInfo DebugTypeInfo::getArchetype(swift::Type Ty, llvm::Type *StorageTy,
                                           Size size, Alignment align) {
   DebugTypeInfo DbgTy(Ty.getPointer(), StorageTy, size,
                       align, true, true);
+  assert(StorageTy && "StorageType is a nullptr");
   assert(!DbgTy.isContextArchetype() && "type metadata cannot contain an archetype");
+  return DbgTy;
+}
+
+DebugTypeInfo DebugTypeInfo::getForwardDecl(swift::Type Ty) {
+  DebugTypeInfo DbgTy(Ty.getPointer(), nullptr, {}, Alignment(1), true,
+                      false);
   return DbgTy;
 }
 
@@ -118,6 +126,7 @@ DebugTypeInfo DebugTypeInfo::getObjCClass(ClassDecl *theClass,
                                           Alignment align) {
   DebugTypeInfo DbgTy(theClass->getInterfaceType().getPointer(), StorageType,
                       size, align, true, false);
+  assert(StorageType && "StorageType is a nullptr");
   assert(!DbgTy.isContextArchetype() && "type of objc class cannot be an archetype");
   return DbgTy;
 }

--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -54,7 +54,7 @@ DebugTypeInfo DebugTypeInfo::getFromTypeInfo(swift::Type Ty,
   }
   assert(Info.getStorageType() && "StorageType is a nullptr");
   return DebugTypeInfo(Ty.getPointer(), Info.getStorageType(), size,
-                       Info.getBestKnownAlignment(), hasDefaultAlignment(Ty),
+                       Info.getBestKnownAlignment(), ::hasDefaultAlignment(Ty),
                        false);
 }
 
@@ -112,7 +112,7 @@ DebugTypeInfo DebugTypeInfo::getGlobal(SILGlobalVariable *GV,
     if (DeclType->isEqual(LowTy))
       Type = DeclType.getPointer();
   }
-  DebugTypeInfo DbgTy(Type, StorageTy, size, align, hasDefaultAlignment(Type),
+  DebugTypeInfo DbgTy(Type, StorageTy, size, align, ::hasDefaultAlignment(Type),
                       false);
   assert(StorageTy && "StorageType is a nullptr");
   assert(!DbgTy.isContextArchetype() &&
@@ -167,6 +167,7 @@ LLVM_DUMP_METHOD void DebugTypeInfo::dump() const {
   if (StorageType) {
     llvm::errs() << "StorageType=";
     StorageType->dump();
-  }
+  } else
+    llvm::errs() << "forward-declared\n";
 }
 #endif

--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -63,6 +63,9 @@ public:
   static DebugTypeInfo getArchetype(swift::Type Ty, llvm::Type *StorageTy,
                                     Size size, Alignment align);
 
+  /// Create a forward declaration for a type whose size is unknown.
+  static DebugTypeInfo getForwardDecl(swift::Type Ty);
+
   /// Create a standalone type from a TypeInfo object.
   static DebugTypeInfo getFromTypeInfo(swift::Type Ty, const TypeInfo &Info);
   /// Global variables.
@@ -89,6 +92,7 @@ public:
   }
 
   bool isNull() const { return Type == nullptr; }
+  bool isForwardDecl() const { return StorageType == nullptr; }
   bool operator==(DebugTypeInfo T) const;
   bool operator!=(DebugTypeInfo T) const;
 

--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -36,7 +36,6 @@ class TypeInfo;
 /// This data structure holds everything needed to emit debug info
 /// for a type.
 class DebugTypeInfo {
-public:
   /// The type we need to emit may be different from the type
   /// mentioned in the Decl, for example, stripped of qualifiers.
   TypeBase *Type = nullptr;
@@ -48,7 +47,8 @@ public:
   bool DefaultAlignment = true;
   bool IsMetadataType = false;
 
-  DebugTypeInfo() {}
+public:
+  DebugTypeInfo() = default;
   DebugTypeInfo(swift::Type Ty, llvm::Type *StorageTy, Size SizeInBytes,
                 Alignment AlignInBytes, bool HasDefaultAlignment,
                 bool IsMetadataType);
@@ -91,12 +91,24 @@ public:
     return false;
   }
 
+  llvm::Type *getStorageType() const {
+    assert((StorageType || size.isZero()) &&
+           "only defined types may have a size");
+    return StorageType;
+  }
+  Size getSize() const { return size; }
+  void setSize(Size NewSize) { size = NewSize; }
+  Alignment getAlignment() const { return align; }
   bool isNull() const { return Type == nullptr; }
   bool isForwardDecl() const { return StorageType == nullptr; }
+  bool isMetadataType() const { return IsMetadataType; }
+  bool hasDefaultAlignment() const { return DefaultAlignment; }
+  
   bool operator==(DebugTypeInfo T) const;
   bool operator!=(DebugTypeInfo T) const;
-
-  void dump() const;
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  LLVM_DUMP_METHOD void dump() const;
+#endif
 };
 }
 }

--- a/test/DebugInfo/BoundGenericStruct.swift
+++ b/test/DebugInfo/BoundGenericStruct.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend %s -O -emit-ir -g -o - | %FileCheck %s
+public struct S<T> {
+  let t : T
+}
+
+public let s = S<Int>(t: 0)
+
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "S",
+// CHECK-SAME:             templateParams: ![[PARAMS:[0-9]+]], identifier:
+// CHECK: ![[PARAMS]] = !{![[INTPARAM:[0-9]+]]}
+// CHECK: ![[INTPARAM]] = !DITemplateTypeParameter(type: ![[INT:[0-9]+]])
+// CHECK: ![[INT]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Int",

--- a/test/DebugInfo/enum.swift
+++ b/test/DebugInfo/enum.swift
@@ -59,7 +59,7 @@ public enum Nothing { }
 public func foo(_ empty : Nothing) { }
 // CHECK: !DICompositeType({{.*}}name: "Nothing", {{.*}}elements: ![[EMPTY]]
 
-// CHECK: !DICompositeType({{.*}}name: "Rose", {{.*}}elements: ![[ELTS:[0-9]+]],
+// CHECK: !DICompositeType({{.*}}name: "Rose",
 // CHECK-SAME:             {{.*}}identifier: "$s4enum4RoseOyxG{{z?}}D")
 enum Rose<A> {
 	case MkRose(() -> A, () -> [Rose<A>])
@@ -69,8 +69,8 @@ enum Rose<A> {
 
 func foo<T>(_ x : Rose<T>) -> Rose<T> { return x }
 
-// CHECK: !DICompositeType({{.*}}name: "Tuple", {{.*}}elements: ![[ELTS:[0-9]+]], {{.*}}identifier: "$s4enum5TupleOyxGD")
-// DWARF: !DICompositeType({{.*}}name: "Tuple", {{.*}}elements: ![[ELTS:[0-9]+]],
+// CHECK: !DICompositeType({{.*}}name: "Tuple", {{.*}}identifier: "$s4enum5TupleOyxGD")
+// DWARF: !DICompositeType({{.*}}name: "Tuple",
 // DWARF-SAME:             {{.*}}identifier: "$s4enum5TupleOyxG{{z?}}D")
 public enum Tuple<P> {
 	case C(P, () -> Tuple)


### PR DESCRIPTION
This is needed to anchor any type aliases that appear in bound generic parameters in the debug info so they can be resolved in the typeref-based part of the debugger without needing to query the Swift module.

This fixes the TestSwiftBridgedArray.py test in https://github.com/apple/llvm-project/pull/1090.