### PR TITLE
[stdlib] Removes redundant buffer zeroing in IndexPath initialiser by using `init(unsafeUninitializedCapacity:initializingWith:)

### DIFF
--- a/stdlib/public/Darwin/Foundation/IndexPath.swift
+++ b/stdlib/public/Darwin/Foundation/IndexPath.swift
@@ -624,9 +624,9 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
         } else if count == 2 {
             _indexes = .pair(nsIndexPath.index(atPosition: 0), nsIndexPath.index(atPosition: 1))
         } else {
-            var indexes = Array<Int>(repeating: 0, count: count)
-            indexes.withUnsafeMutableBufferPointer { (buffer: inout UnsafeMutableBufferPointer<Int>) -> Void in
-                nsIndexPath.getIndexes(buffer.baseAddress!, range: NSRange(location: 0, length: count))
+            let indexes = Array<Int>(unsafeUninitializedCapacity: count) { buf, initializedCount in
+                nsIndexPath.getIndexes(buf.baseAddress!, range: NSRange(location: 0, length: count))
+                initializedCount = count
             }
             _indexes = .array(indexes)
         }

--- a/stdlib/public/Darwin/Foundation/IndexPath.swift
+++ b/stdlib/public/Darwin/Foundation/IndexPath.swift
@@ -617,13 +617,14 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
     
     fileprivate init(nsIndexPath: __shared ReferenceType) {
         let count = nsIndexPath.length
-        if count == 0 {
+        switch count {
+        case 0:
             _indexes = []
-        } else if count == 1 {
+        case 1:
             _indexes = .single(nsIndexPath.index(atPosition: 0))
-        } else if count == 2 {
+        case 2:
             _indexes = .pair(nsIndexPath.index(atPosition: 0), nsIndexPath.index(atPosition: 1))
-        } else {
+        default:
             let indexes = Array<Int>(unsafeUninitializedCapacity: count) { buf, initializedCount in
                 nsIndexPath.getIndexes(buf.baseAddress!, range: NSRange(location: 0, length: count))
                 initializedCount = count

--- a/stdlib/public/Darwin/Foundation/IndexPath.swift
+++ b/stdlib/public/Darwin/Foundation/IndexPath.swift
@@ -625,8 +625,8 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
         case 2:
             _indexes = .pair(nsIndexPath.index(atPosition: 0), nsIndexPath.index(atPosition: 1))
         default:
-            let indexes = Array<Int>(unsafeUninitializedCapacity: count) { buf, initializedCount in
-                nsIndexPath.getIndexes(buf.baseAddress!, range: NSRange(location: 0, length: count))
+            let indexes = Array<Int>(unsafeUninitializedCapacity: count) { buffer, initializedCount in
+                nsIndexPath.getIndexes(buffer.baseAddress!, range: NSRange(location: 0, length: count))
                 initializedCount = count
             }
             _indexes = .array(indexes)


### PR DESCRIPTION
<!-- What's in this pull request? -->
Removes redundant buffer zeroing in IndexPath initialiser by using `init(unsafeUninitializedCapacity:initializingWith:)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
