### PR TITLE
Windows: add a WinGDI submodule

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -203,6 +203,13 @@ module WinSDK [system] {
     link "DnsAPI.Lib"
   }
 
+  module WinGDI {
+    header "wingdi.h"
+    export *
+
+    link "Gdi32.Lib"
+  }
+
   module WinReg {
     header "winreg.h"
     export *


### PR DESCRIPTION
Extract the WinGDI into a submodule to handle the Gdi32 autolinking
requirement as well as to isolate the types.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
