### PR TITLE
[stdlib] Fix for objc_copyClassList broken since snapshot 2019-08-27

### DIFF
--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -429,6 +429,9 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
   @inlinable
   public var pointee: Pointee {
     @_transparent get {
+      if Pointee.self == AnyClass.self {
+        return UnsafePointer(self).pointee
+      }
       // The memory addressed by this pointer contains a non-owning reference,
       // therefore we *must not* point an `UnsafePointer<AnyObject>` to
       // it---otherwise we would allow the compiler to assume it has a +1

--- a/test/stdlib/AutoreleasingUnsafeMutablePointer.swift
+++ b/test/stdlib/AutoreleasingUnsafeMutablePointer.swift
@@ -183,4 +183,14 @@ suite.test("subscript and advanced(by:) works") {
   expectEqual(LifetimeTracked.instances, originalInstances)
 }
 
+suite.test("objc_copyClassList() works") {
+    var nc: UInt32 = 0
+    if let classes = objc_copyClassList(&nc) {
+        for i in 0 ..< Int(nc) {
+            _ = NSStringFromClass(classes[i])
+        }
+        free(UnsafeMutableRawPointer(classes))
+    }
+}
+
 runAllTests()


### PR DESCRIPTION
Hi Apple,

Quick fix for AutoreleasingUnsafeMutablePointer when you are using it with an array of AnyClass objects (for example when using `objc_copyClassList()` from Swift).

Since Xcode 11.4/11.4.1, the following code crashes:
```
var nc: UInt32 = 0
if let classes = objc_copyClassList(&nc) {
    for i in 0 ..< Int(nc) {
        _ = "\(classes[i])"
    }
    free(UnsafeMutableRawPointer(classes))
}
```
With an error along the lines of
```
2020-04-18 22:26:49.986732+0200 SwiftTwaceApp[78749:972902] *** NSForwarding: warning: object 0x7fff87ba8ba8 of class 'JSExport' does not implement methodSignatureForSelector: -- trouble ahead
2020-04-18 22:26:49.987066+0200 SwiftTwaceApp[78749:972902] *** NSForwarding: warning: object 0x7fff87ba8ba8 of class 'JSExport' does not implement doesNotRecognizeSelector: -- abort
```

Seems to be an ownership issue related to the refactoring in #26760 that doesn't take into account the array could contain `AnyClass` instances (as conceded in a TODO for the struct.) This patch uses the old implementation for the `.pointee` getter if `Pointee.self == AnyClass.self`. Seems to resolve the problem for the code above for me.

Resolves [SR-12344](https://bugs.swift.org/browse/SR-12344).

