### PR TITLE
 [OSLog Diagnostics] Improve os log diagnostics emitted in the SIL and Sema diagnostic passes.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -585,8 +585,8 @@ ERROR(oslog_constant_eval_trap, none, "%0", (StringRef))
 ERROR(oslog_too_many_instructions, none, "interpolated expression and arguments "
       "are too complex", ())
 
-ERROR(oslog_invalid_log_message, none, "invalid log message; do not define "
-      "extensions to types defined in the os module", ())
+ERROR(oslog_invalid_log_message, none, "invalid log message; extending "
+      "types defined in the os module is not supported", ())
 
 NOTE(oslog_const_evaluable_fun_error, none, "'%0' failed evaluation", (StringRef))
 
@@ -599,8 +599,9 @@ ERROR(oslog_non_constant_interpolation, none, "'OSLogInterpolation' instance "
 ERROR(oslog_property_not_constant, none, "'OSLogInterpolation.%0' is not a "
       "constant", (StringRef))
 
-ERROR(oslog_message_alive_after_opts, none, "os log string interpolation cannot "
-      "be used in this context", ())
+ERROR(oslog_message_alive_after_opts, none, "string interpolation cannot "
+      "be used in this context; if you are calling an os_log function, "
+      "try a different overload", ())
 
 ERROR(oslog_message_explicitly_created, none, "'OSLogMessage' must be "
       " created from a string interpolation or string literal", ())
@@ -609,7 +610,7 @@ WARNING(oslog_call_in_unreachable_code, none, "os log call will never be "
         "executed and may have undiagnosed errors", ())
 
 ERROR(global_string_pointer_on_non_constant, none, "globalStringTablePointer "
-      "builtin must used only on string literals", ())
+      "builtin must be used only on string literals", ())
 
 ERROR(polymorphic_builtin_passed_non_trivial_non_builtin_type, none, "Argument "
       "of type %0 can not be passed as an argument to a Polymorphic "

--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -108,6 +108,10 @@ using namespace Lowering;
 template <typename... T, typename... U>
 static void diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag,
                      U &&... args) {
+  // The lifetime of StringRef arguments will be extended as necessary by this
+  // utility. The copy happens in onTentativeDiagnosticFlush at the bottom of
+  // DiagnosticEngine.cpp, which is called when the destructor of the
+  // InFlightDiagnostic returned by diagnose runs.
   Context.Diags.diagnose(loc, diag, std::forward<U>(args)...);
 }
 
@@ -365,9 +369,8 @@ static bool diagnoseSpecialErrors(SILInstruction *unevaluableInst,
 
   if (unknownReason.getKind() == UnknownReason::Trap) {
     // We have an assertion failure or fatal error.
-    const char *message = unknownReason.getTrapMessage();
     diagnose(ctx, sourceLoc, diag::oslog_constant_eval_trap,
-             StringRef(message));
+             unknownReason.getTrapMessage());
     return true;
   }
   if (unknownReason.getKind() == UnknownReason::TooManyInstructions) {
@@ -1431,19 +1434,28 @@ suppressGlobalStringTablePointerError(SingleValueInstruction *oslogMessage) {
   SmallVector<SILInstruction *, 8> users;
   getTransitiveUsers(oslogMessage, users);
 
+  // Collect all globalStringTablePointer instructions.
+  SmallVector<BuiltinInst *, 4> globalStringTablePointerInsts;
   for (SILInstruction *user : users) {
     BuiltinInst *bi = dyn_cast<BuiltinInst>(user);
-    if (!bi ||
-        bi->getBuiltinInfo().ID != BuiltinValueKind::GlobalStringTablePointer)
-      continue;
-    // Replace this builtin by a string_literal instruction for an empty string.
+    if (bi &&
+        bi->getBuiltinInfo().ID == BuiltinValueKind::GlobalStringTablePointer)
+      globalStringTablePointerInsts.push_back(bi);
+  }
+
+  // Replace the globalStringTablePointer builtins by a string_literal
+  // instruction for an empty string and clean up dead code.
+  InstructionDeleter deleter;
+  for (BuiltinInst *bi : globalStringTablePointerInsts) {
     SILBuilderWithScope builder(bi);
     StringLiteralInst *stringLiteral = builder.createStringLiteral(
         bi->getLoc(), StringRef(""), StringLiteralInst::Encoding::UTF8);
     bi->replaceAllUsesWith(stringLiteral);
-    // Here, the bulitin instruction is dead, so clean it up.
-    eliminateDeadInstruction(bi);
+    // The bulitin instruction is likely dead. But since we are iterating over
+    // many instructions, do the cleanup at the end.
+    deleter.trackIfDead(bi);
   }
+  deleter.cleanUpDeadInstructions();
 }
 
 /// If the SILInstruction is an initialization of OSLogMessage, return the

--- a/lib/Sema/ConstantnessSemaDiagnostics.cpp
+++ b/lib/Sema/ConstantnessSemaDiagnostics.cpp
@@ -162,6 +162,12 @@ static Expr *checkConstantness(Expr *expr) {
     if (!isa<ApplyExpr>(expr))
       return expr;
 
+    if (NominalTypeDecl *nominal =
+        expr->getType()->getNominalOrBoundGenericNominal()) {
+      if (nominal->getName() == nominal->getASTContext().Id_OSLogMessage)
+        return expr;
+    }
+
     ApplyExpr *apply = cast<ApplyExpr>(expr);
     ValueDecl *calledValue = apply->getCalledValue();
     if (!calledValue)

--- a/test/SILOptimizer/OSLogCompilerDiagnosticsTest.swift
+++ b/test/SILOptimizer/OSLogCompilerDiagnosticsTest.swift
@@ -27,7 +27,7 @@ extension OSLogInterpolation {
 
 func testOSLogInterpolationExtension(a: A) {
   _osLogTestHelper("Error at line: \(a: a)")
-    // expected-error @-1 {{invalid log message; do not define extensions to types defined in the os module}}
+    // expected-error @-1 {{invalid log message; extending types defined in the os module is not supported}}
     // expected-note @-2 {{'OSLogInterpolation.appendLiteral(_:)' failed evaluation}}
     // expected-note @-3 {{value mutable by an unevaluated instruction is not a constant}}
 }
@@ -87,6 +87,6 @@ func testUnreachableLogCallComplex(c: Color)  {
   default: // expected-warning {{default will never be executed}}
     _osLogTestHelper("Some call \(c)")
       // expected-warning@-1 {{os log call will never be executed and may have undiagnosed errors}}
-      // expected-error@-2 {{globalStringTablePointer builtin must used only on string literals}}
+      // expected-error@-2 {{globalStringTablePointer builtin must be used only on string literals}}
   }
 }

--- a/test/SILOptimizer/diagnostic_constant_propagation.swift
+++ b/test/SILOptimizer/diagnostic_constant_propagation.swift
@@ -361,7 +361,7 @@ func testBuiltinGlobalStringTablePointerNoError() -> UnsafePointer<CChar> {
 }
 
 func testBuiltinGlobalStringTablePointerError(s: String) -> UnsafePointer<CChar> {
-  return _getGlobalStringTablePointer(s) // expected-error {{globalStringTablePointer builtin must used only on string literals}}
+  return _getGlobalStringTablePointer(s) // expected-error {{globalStringTablePointer builtin must be used only on string literals}}
 }
 
 @_transparent

--- a/test/Sema/diag_constantness_check_os_log.swift
+++ b/test/Sema/diag_constantness_check_os_log.swift
@@ -119,6 +119,17 @@ func testOSLogInterpolationExtension(a: MyStruct) {
   _osLogTestHelper("Error at line: \(a: a)")
 }
 
+func testExplicitOSLogMessageConstruction() {
+  _osLogTestHelper(OSLogMessage(stringLiteral: "world"))
+    // expected-error@-1 {{argument must be a string interpolation}}
+  _osLogTestHelper(
+    OSLogMessage( // expected-error {{argument must be a string interpolation}}
+      stringInterpolation:
+        OSLogInterpolation(
+          literalCapacity: 0,
+          interpolationCount: 0)))
+}
+
 // Test that @_semantics("oslog.log_with_level") permits values of type OSLog and
 // OSLogType to not be constants.
 


### PR DESCRIPTION
These improvements are aimed at covering some rare corner cases. Only the commit f91e526 has the relevant changes. The previous commit belongs to a previous [PR](https://github.com/apple/swift/pull/31126/)