### PR TITLE
ABI-checker: allow users to specify a directory containing baseline files. NFC

### DIFF
--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -244,6 +244,11 @@ BaselineFilePath("baseline-path",
                  llvm::cl::desc("The path to the Json file that we should use as the baseline"),
                  llvm::cl::cat(Category));
 
+static llvm::cl::opt<std::string>
+BaselineDirPath("baseline-dir",
+                 llvm::cl::desc("The path to a directory containing baseline files: macos.json, iphoneos.json, appletvos.json, watchos.json, and iosmac.json"),
+                 llvm::cl::cat(Category));
+
 static llvm::cl::opt<bool>
 UseEmptyBaseline("empty-baseline",
                 llvm::cl::desc("Use empty baseline for diagnostics"),
@@ -2662,6 +2667,58 @@ static ComparisonInputMode checkComparisonInputMode() {
     return ComparisonInputMode::BaselineJson;
 }
 
+static std::string getDefaultBaselineDir(const char *Main) {
+  llvm::SmallString<128> BaselineDir;
+  // The path of the swift-api-digester executable.
+  std::string ExePath = llvm::sys::fs::getMainExecutable(Main,
+    reinterpret_cast<void *>(&anchorForGetMainExecutable));
+  BaselineDir.append(ExePath);
+  llvm::sys::path::remove_filename(BaselineDir); // Remove /swift-api-digester
+  llvm::sys::path::remove_filename(BaselineDir); // Remove /bin
+  llvm::sys::path::append(BaselineDir, "lib", "swift", "FrameworkABIBaseline");
+  return BaselineDir.str();
+}
+
+static std::string getEmptyBaselinePath(const char *Main) {
+  llvm::SmallString<128> BaselinePath(getDefaultBaselineDir(Main));
+  llvm::sys::path::append(BaselinePath, "nil.json");
+  return BaselinePath.str();
+}
+
+static StringRef getBaselineFilename(llvm::Triple Triple) {
+  if (Triple.isMacCatalystEnvironment())
+    return "iosmac.json";
+  else if (Triple.isMacOSX())
+    return "macos.json";
+  else if (Triple.isiOS())
+    return "iphoneos.json";
+  else if (Triple.isTvOS())
+    return "appletvos.json";
+  else if (Triple.isWatchOS())
+    return "watchos.json";
+  else {
+    llvm::errs() << "Unsupported triple target\n";
+    exit(1);
+  }
+}
+
+static std::string getDefaultBaselinePath(const char *Main, StringRef Module,
+                                          llvm::Triple Triple,
+                                          bool ABI) {
+  llvm::SmallString<128> BaselinePath(getDefaultBaselineDir(Main));
+  llvm::sys::path::append(BaselinePath, Module);
+  // Look for ABI or API baseline
+  llvm::sys::path::append(BaselinePath, ABI? "ABI": "API");
+  llvm::sys::path::append(BaselinePath, getBaselineFilename(Triple));
+  return BaselinePath.str();
+}
+
+static std::string getCustomBaselinePath(llvm::Triple Triple) {
+  llvm::SmallString<128> BaselinePath(options::BaselineDirPath);
+  llvm::sys::path::append(BaselinePath, getBaselineFilename(Triple));
+  return BaselinePath.str();
+}
+
 static SDKNodeRoot *getBaselineFromJson(const char *Main, SDKContext &Ctx) {
   SwiftDeclCollector Collector(Ctx);
   // If the baseline path has been given, honor that.
@@ -2677,41 +2734,16 @@ static SDKNodeRoot *getBaselineFromJson(const char *Main, SDKContext &Ctx) {
 
   assert(Modules.size() == 1 &&
          "Cannot find builtin baseline for more than one module");
-  // The path of the swift-api-digester executable.
-  std::string ExePath = llvm::sys::fs::getMainExecutable(Main,
-    reinterpret_cast<void *>(&anchorForGetMainExecutable));
-  llvm::SmallString<128> BaselinePath(ExePath);
-  llvm::sys::path::remove_filename(BaselinePath); // Remove /swift-api-digester
-  llvm::sys::path::remove_filename(BaselinePath); // Remove /bin
-  llvm::sys::path::append(BaselinePath, "lib", "swift", "FrameworkABIBaseline");
-  if (options::UseEmptyBaseline) {
-    // Use the empty baseline for comparison.
-    llvm::sys::path::append(BaselinePath, "nil.json");
+  std::string Path;
+  if (!options::BaselineDirPath.empty()) {
+    Path = getCustomBaselinePath(Invok.getLangOptions().Target);
+  } else if (options::UseEmptyBaseline) {
+    Path = getEmptyBaselinePath(Main);
   } else {
-    llvm::sys::path::append(BaselinePath, Modules.begin()->getKey());
-    // Look for ABI or API baseline
-    if (Ctx.checkingABI())
-      llvm::sys::path::append(BaselinePath, "ABI");
-    else
-      llvm::sys::path::append(BaselinePath, "API");
-    // Look for deployment target specific baseline files.
-    auto Triple = Invok.getLangOptions().Target;
-    if (Triple.isMacCatalystEnvironment())
-      llvm::sys::path::append(BaselinePath, "iosmac.json");
-    else if (Triple.isMacOSX())
-      llvm::sys::path::append(BaselinePath, "macos.json");
-    else if (Triple.isiOS())
-      llvm::sys::path::append(BaselinePath, "iphoneos.json");
-    else if (Triple.isTvOS())
-      llvm::sys::path::append(BaselinePath, "appletvos.json");
-    else if (Triple.isWatchOS())
-      llvm::sys::path::append(BaselinePath, "watchos.json");
-    else {
-      llvm::errs() << "Unsupported triple target\n";
-      exit(1);
-    }
+    Path = getDefaultBaselinePath(Main, Modules.begin()->getKey(),
+                                  Invok.getLangOptions().Target,
+                                  Ctx.checkingABI());
   }
-  StringRef Path = BaselinePath.str();
   if (!fs::exists(Path)) {
     llvm::errs() << "Baseline at " << Path << " does not exist\n";
     exit(1);


### PR DESCRIPTION
The ABI-checker tool could pick up a baseline file to use according to
the given target triple.