### PR TITLE
[LVA] Update ignore instructions RLE and DSE.

### DIFF
--- a/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
@@ -161,6 +161,8 @@ static bool isDeadStoreInertInstruction(SILInstruction *Inst) {
   case SILInstructionKind::DeallocRefInst:
   case SILInstructionKind::CondFailInst:
   case SILInstructionKind::FixLifetimeInst:
+  case SILInstructionKind::EndAccessInst:
+  case SILInstructionKind::SetDeallocatingInst:
     return true;
   default:
     return false;

--- a/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
@@ -160,6 +160,9 @@ static bool isRLEInertInstruction(SILInstruction *Inst) {
   case SILInstructionKind::IsEscapingClosureInst:
   case SILInstructionKind::IsUniqueInst:
   case SILInstructionKind::FixLifetimeInst:
+  case SILInstructionKind::EndAccessInst:
+  case SILInstructionKind::SetDeallocatingInst:
+  case SILInstructionKind::DeallocRefInst:
     return true;
   default:
     return false;

--- a/test/SILOptimizer/dead_store_elim.sil
+++ b/test/SILOptimizer/dead_store_elim.sil
@@ -1501,3 +1501,21 @@ bb0(%0 : $*foo):
   %20 = tuple()
   return %20 : $()
 }
+
+// Check that begin_access, end_access, strong_release, set_deallocating, and dealloc_ref don't prevent optimization.
+// CHECK-LABEL: ignore_read_write
+// CHECK: bb0
+// CHECK-NOT: store
+// CHECK-LABEL: end sil function 'ignore_read_write'
+sil @ignore_read_write : $@convention(thin) () -> Int {
+bb0:
+  %1 = alloc_ref [stack] $foo
+  %2 = integer_literal $Builtin.Int64, 0
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  %4 = ref_element_addr %1 : $foo, #foo.a
+  store %3 to %4 : $*Int
+  set_deallocating %1 : $foo
+  dealloc_ref %1 : $foo
+  dealloc_ref [stack] %1 : $foo
+  return %3 : $Int
+}

--- a/test/SILOptimizer/redundant_load_elim.sil
+++ b/test/SILOptimizer/redundant_load_elim.sil
@@ -1225,3 +1225,22 @@ bb0(%0 : $*Int):
   %3 = tuple()
   return %3 : $()
 }
+
+// Check that begin_access, end_access, strong_release, set_deallocating, and dealloc_ref don't prevent optimization.
+// CHECK-LABEL: ignore_read_write
+// CHECK: bb0
+// CHECK-NOT: load
+// CHECK-LABEL: end sil function 'ignore_read_write'
+sil @ignore_read_write : $@convention(thin) () -> Int32 {
+bb0:
+  %1 = alloc_ref [stack] $AX
+  %2 = integer_literal $Builtin.Int32, 0
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  %4 = ref_element_addr %1 : $AX, #AX.current
+  store %3 to %4 : $*Int32
+  %5 = load %4 : $*Int32
+  set_deallocating %1 : $AX
+  dealloc_ref %1 : $AX
+  dealloc_ref [stack] %1 : $AX
+  return %5 : $Int32
+}


### PR DESCRIPTION
RLE can ignore end_access, set_deallocating, dealloc_ref, begin_access, and strong_release instructions.

DSE can ignore end_access, set_deallocating, begin_access, and sometimes strong_release.

Requires #31132
