### PR TITLE
Avoid unnecessary performTypeChecking() in REPL

### DIFF
--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -238,7 +238,8 @@ doCodeCompletion(SourceFile &SF, StringRef EnteredCode, unsigned *BufferID,
     newSF.addImports(importsWithOptions);
   }
 
-  performTypeChecking(newSF);
+  performImportResolution(newSF);
+  bindExtensions(newSF);
 
   performCodeCompletionSecondPass(newSF, *CompletionCallbacksFactory);
 


### PR DESCRIPTION
Shepherd #28228 for the brave new world where "name binding" is called imported resolution.