### PR TITLE
[opt] Move "LastRelease" outside BB iteration.

### DIFF
--- a/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
@@ -70,13 +70,11 @@ void ReleaseDevirtualizer::run() {
   SILFunction *F = getFunction();
   RCIA = PM->getAnalysis<RCIdentityAnalysis>()->get(F);
 
+  // The last release_value or strong_release instruction before the
+  // deallocation.
+  SILInstruction *LastRelease = nullptr;
   bool Changed = false;
   for (SILBasicBlock &BB : *F) {
-
-    // The last release_value or strong_release instruction before the
-    // deallocation.
-    SILInstruction *LastRelease = nullptr;
-
     for (SILInstruction &I : BB) {
       if (LastRelease) {
         if (auto *DRI = dyn_cast<DeallocRefInst>(&I)) {

--- a/test/SILOptimizer/devirt_release.sil
+++ b/test/SILOptimizer/devirt_release.sil
@@ -93,6 +93,27 @@ bb0:
   return %r : $()
 }
 
+// CHECK-LABEL: sil @devirtualize_release_multiblock
+// CHECK-NOT: strong_release
+// CHECK: [[A:%[0-9]+]] = alloc_ref
+// CHECK-NEXT: set_deallocating [[A]]
+// CHECK: [[D:%[0-9]+]] = function_ref @$s4test1BCfD
+// CHECK-NEXT: apply [[D]]([[A]])
+// CHECK-NEXT: br
+// CHECK: bb1:
+// CHECK-NEXT: dealloc_ref [stack] [[A]]
+// CHECK: return
+sil @devirtualize_release_multiblock : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_ref [stack] $B
+  strong_release %1 : $B
+  br bb1
+
+bb1:
+  dealloc_ref [stack] %1 : $B
+  %r = tuple ()
+  return %r : $()
+}
 
 sil @unknown_func : $@convention(thin) () -> ()
 


### PR DESCRIPTION
This means that "LastRelease" can be tracked through multiple basic blocks increasing the number of releases we can devirtualize. This helps dead store elimination and object elimination. 