### PR TITLE
[opt] Add dead object elimination pass after dead store elimination.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -528,6 +528,8 @@ static void addLowLevelPassPipeline(SILPassPipelinePlan &P) {
   P.addDeadObjectElimination();
   P.addObjectOutliner();
   P.addDeadStoreElimination();
+  P.addDCE();
+  P.addDeadObjectElimination();
 
   // We've done a lot of optimizations on this function, attempt to FSO.
   P.addFunctionSignatureOpts();


### PR DESCRIPTION
After low-level SSA passes, often the only use of an object will be dead stores. At some point after dead store elimination, dead object elimination is useful. The dead code elimination pass is fast and removes some remaining uses of the object after DSE (such as dead access instructions).

Refs #31133 