### PR TITLE
[SIL Diagnostics] Improve diagnostics for capture of inout values in escaping autoclosures.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -108,7 +108,7 @@ ERROR(capture_before_declaration_defer,none,
 NOTE(captured_value_declared_here,none,
      "captured value declared here", ())
 
-#define SELECT_ESCAPING_CLOSURE_KIND "escaping %select{local function|closure}0"
+#define SELECT_ESCAPING_CLOSURE_KIND "escaping %select{local function|closure|autoclosure}0"
 
 // Invalid escaping capture diagnostics.
 ERROR(escaping_inout_capture,none,
@@ -132,6 +132,10 @@ ERROR(escaping_noescape_var_capture,none,
       " captures non-escaping value", (unsigned))
 
 NOTE(value_captured_here,none,"captured here", ())
+
+NOTE(copy_inout_captured_by_autoclosure,none, "pass a copy of %0", (Identifier))
+
+NOTE(copy_self_captured_by_autoclosure,none, "pass a copy of 'self'", ())
 
 #undef SELECT_ESCAPING_CLOSURE_KIND
 

--- a/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
@@ -17,6 +17,7 @@
 
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticsSIL.h"
+#include "swift/AST/Expr.h"
 #include "swift/AST/Types.h"
 #include "swift/SIL/ApplySite.h"
 #include "swift/SIL/InstructionUtils.h"
@@ -332,17 +333,22 @@ static void checkPartialApply(ASTContext &Context, DeclContext *DC,
   // Should match SELECT_ESCAPING_CLOSURE_KIND in DiagnosticsSIL.def.
   enum {
     EscapingLocalFunction,
-    EscapingClosure
+    EscapingClosure,
+    EscapingAutoClosure,
   } functionKind = EscapingClosure;
 
   if (auto *F = PAI->getReferencedFunctionOrNull()) {
     if (auto loc = F->getLocation()) {
-      if (loc.isASTNode<FuncDecl>())
+      if (loc.isASTNode<FuncDecl>()) {
         functionKind = EscapingLocalFunction;
+      } else if (loc.isASTNode<AutoClosureExpr>()) {
+        functionKind = EscapingAutoClosure;
+      }
     }
   }
   // First, diagnose the inout captures, if any.
   for (auto inoutCapture : inoutCaptures) {
+    Optional<Identifier> paramName = None;
     if (isUseOfSelfInInitializer(inoutCapture)) {
       diagnose(Context, PAI->getLoc(), diag::escaping_mutable_self_capture,
                functionKind);
@@ -352,14 +358,23 @@ static void checkPartialApply(ASTContext &Context, DeclContext *DC,
         diagnose(Context, PAI->getLoc(), diag::escaping_mutable_self_capture,
                  functionKind);
       else {
+        paramName = param->getName();
         diagnose(Context, PAI->getLoc(), diag::escaping_inout_capture,
                  functionKind, param->getName());
         diagnose(Context, param->getLoc(), diag::inout_param_defined_here,
                  param->getName());
       }
     }
-
-    diagnoseCaptureLoc(Context, DC, PAI, inoutCapture);
+    if (functionKind != EscapingAutoClosure) {
+      diagnoseCaptureLoc(Context, DC, PAI, inoutCapture);
+      continue;
+    }
+    // For an autoclosure capture, present a way to fix the problem.
+    if (paramName)
+      diagnose(Context, PAI->getLoc(), diag::copy_inout_captured_by_autoclosure,
+               paramName.getValue());
+    else
+      diagnose(Context, PAI->getLoc(), diag::copy_self_captured_by_autoclosure);
   }
 
   // Finally, diagnose captures of values with noescape type.

--- a/test/SILOptimizer/OSLogCompilerDiagnosticsTest.swift
+++ b/test/SILOptimizer/OSLogCompilerDiagnosticsTest.swift
@@ -58,10 +58,10 @@ func testUnreachableLogCall(c: Color)  {
 
 // Passing InOut values to the logger should not crash the compiler.
 func foo(_ mutableValue: inout String) {
+  // expected-note@-1 {{parameter 'mutableValue' is declared 'inout'}}
    _osLogTestHelper("FMFLabelledLocation: initialized with coder \(mutableValue)")
-    // expected-error@-1 {{escaping closure captures 'inout' parameter 'mutableValue'}}
-    // expected-note@-3 {{parameter 'mutableValue' is declared 'inout'}}
-    // expected-note@-3 {{captured here}}
+    // expected-error@-1 {{escaping autoclosure captures 'inout' parameter 'mutableValue'}}
+    // expected-note@-2 {{pass a copy of 'mutableValue'}}
 }
 
 // This is an extension used only for testing a diagnostic that doesn't arise


### PR DESCRIPTION
Currently, when an inout or mutating self is passed to an escaping, autoclosured parameter, the error message looks as follows: 
```
foo(x) 
  error: escaping closure captures 'inout' parameter 'x'
  note: captured here
```
The error message refers to a closure even though there is no closure is in the source code. This PR improves the error message and makes the note more actionable for autoclosures: 
```
foo(x) 
  error: escaping autoclosure captures 'inout' parameter 'x'
  note: pass a copy of 'x'
```

<rdar://problem/60551844>
