### PR TITLE
[SR-12626] Fix crash when non WritableKeyPath to a set subscript assign

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7802,6 +7802,12 @@ ConstraintSystem::simplifyKeyPathApplicationConstraint(
     return SolutionKind::Unsolved;
   };
 
+  // When locator points to a KeyPathDynamicMemberLookup, skip the
+  // key path application.
+  if (locator.getBaseLocator()->isForKeyPathDynamicMemberLookup()) {
+    return SolutionKind::Error;
+  }
+  
   if (auto clas = keyPathTy->getAs<NominalType>()) {
     if (clas->getDecl() == getASTContext().getAnyKeyPathDecl()) {
       // Read-only keypath, whose projected value is upcast to `Any?`.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7802,9 +7802,10 @@ ConstraintSystem::simplifyKeyPathApplicationConstraint(
     return SolutionKind::Unsolved;
   };
 
-  // When locator points to a KeyPathDynamicMemberLookup, skip the
+  // When locator points to a KeyPathDynamicMemberLookup, reject the
   // key path application.
-  if (locator.getBaseLocator()->isForKeyPathDynamicMemberLookup()) {
+  auto last = locator.last();
+  if (last && last->isKeyPathDynamicMember()) {
     return SolutionKind::Error;
   }
   


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes SR-12626 where applying a non-WritableKeyPath to a set subscript crashes the compiler. 
Also, partially fixes the SR-12425, fixing the crash, but diagnostics have to be improved. So just added the test cases 

cc @xedin @hamishknight :)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-12626.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
