### PR TITLE
Devirtualizer: fix a miscompile due to handling of cast instructions.

### DIFF
--- a/test/SILOptimizer/devirtualize_class_method.swift
+++ b/test/SILOptimizer/devirtualize_class_method.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift -O -module-name=test %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+// REQUIRES: executable_test
+
+class Base {
+  required init() { }
+
+  class func instance() -> Base {
+    return self.init()
+  }
+}
+
+class Middle: Base {
+  override class func instance() -> Middle {
+    return self.init()
+  }
+}
+
+class Derived: Middle {
+  required init() {
+    super.init()
+    print("init Derived")
+  }
+}
+
+struct Maker<C: Base> {
+  @inline(never)
+  static func create() -> Base {
+    return C.instance()
+  }
+}
+
+// CHECK: init Derived
+// CHECK: test.Derived
+print(Maker<Derived>.create())
+


### PR DESCRIPTION
getInstanceWithExactDynamicType returns a new instance, and for this the class decl has to be updated.

https://bugs.swift.org/browse/SR-12538
rdar://problem/61911112
