### PR TITLE
[NFC] Fix typo in SerializedModuleLoader.cpp

### DIFF
--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -35,7 +35,7 @@ using swift::version::Version;
 namespace {
 
 /// Apply \c body for each target-specific module file base name to search from
-/// most to least desiable.
+/// most to least desirable.
 void forEachTargetModuleBasename(const ASTContext &Ctx,
                                  llvm::function_ref<void(StringRef)> body) {
   auto normalizedTarget = getTargetSpecificModuleTriple(Ctx.LangOpts.Target);


### PR DESCRIPTION
No functional change, just a typo fixed in a function doc comment.