### PR TITLE
Fix unchecked_take_enum_data_addr has side effects.

### DIFF
--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -132,11 +132,6 @@ bool swift::isInstructionTriviallyDead(SILInstruction *inst) {
   if (isa<DebugValueInst>(inst) || isa<DebugValueAddrInst>(inst))
     return false;
 
-  // These invalidate enums so "write" memory, but that is not an essential
-  // operation so we can remove these if they are trivially dead.
-  if (isa<UncheckedTakeEnumDataAddrInst>(inst))
-    return true;
-
   if (!inst->mayHaveSideEffects())
     return true;
 

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -3706,3 +3706,16 @@ bb0(%0 : $@thick SpecialEnum.Type):
   %4 = struct $Bool (%3 : $Builtin.Int1)
   return %4 : $Bool
 }
+
+// CHECK-LABEL: sil [ossa] @unchecked_take_enum_data_addr_not_dead : $@convention(thin) (@in FakeOptional<B>) -> ()
+// CHECK: bb0(%0 : $*FakeOptional<B>):
+// CHECK-NEXT: unchecked_take_enum_data_addr
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+// CHECK-LABEL end sil function 'unchecked_take_enum_data_addr_not_dead'
+sil [ossa] @unchecked_take_enum_data_addr_not_dead : $@convention(thin) (@in FakeOptional<B>) -> () {
+bb0(%0 : $*FakeOptional<B>):
+  %2 = unchecked_take_enum_data_addr %0 : $*FakeOptional<B>, #FakeOptional.some!enumelt
+  %4 = tuple ()
+  return %4 : $()
+}


### PR DESCRIPTION
Don't always return true (is trivially dead) for unchecked_take_enum_data_addr. It destroys the address operand so, it's not *always* trivially dead.

Fixes issue described in #31077.