### PR TITLE
Allow initializing a wrapped property with a nonmutating setter

### DIFF
--- a/test/SILOptimizer/di_property_wrappers.swift
+++ b/test/SILOptimizer/di_property_wrappers.swift
@@ -501,6 +501,7 @@ public final class Synchronized<Value> {
   }
 }
 
+
 struct SR_12341 {
   @Wrapper var wrapped: Int = 10
   var str: String
@@ -533,6 +534,34 @@ func testSR_12341() {
   _ = SR_12341(condition: true)
 }
 
+@propertyWrapper
+struct NonMutatingSetterWrapper<Value> {
+    var value: Value
+    init(wrappedValue: Value) {
+        value = wrappedValue
+    }
+    var wrappedValue: Value {
+        get { value }
+        nonmutating set {
+            print("  .. nonmutatingSet \(newValue)")
+        }
+    }
+}
+
+struct NonMutatingWrapperTestStruct {
+    @NonMutatingSetterWrapper var SomeProp: Int
+    init(val: Int) {
+        SomeProp = val
+    }
+}
+
+func testNonMutatingSetterStruct() {
+  // CHECK: ## NonMutatingSetterWrapper
+  print("\n## NonMutatingSetterWrapper")
+  let A = NonMutatingWrapperTestStruct(val: 11)
+  // CHECK-NEXT:  .. nonmutatingSet 11
+}
+
 testIntStruct()
 testIntClass()
 testRefStruct()
@@ -543,3 +572,4 @@ testDefaultNilOptIntStruct()
 testComposed()
 testWrapperInitWithDefaultArg()
 testSR_12341()
+testNonMutatingSetterStruct()

--- a/test/SILOptimizer/di_property_wrappers_errors.swift
+++ b/test/SILOptimizer/di_property_wrappers_errors.swift
@@ -23,30 +23,23 @@ struct IntStructWithClassWrapper {
   @ClassWrapper var wrapped: Int
 
   init() {
-    wrapped = 42 // expected-error{{'self' used before all stored properties are initialized}}
-    // expected-note@-1{{'self.wrapped' not initialized}}
-  } // expected-error{{return from initializer without initializing all stored properties}}
-  // expected-note@-1{{'self.wrapped' not initialized}}
+    wrapped = 42 // expected-error{{variable 'self.wrapped' used before being initialized}}
+  }
 
   init(conditional b: Bool) {
      if b {
        self._wrapped = ClassWrapper(wrappedValue: 32)
      } else {
-       wrapped = 42 // expected-error{{'self' used before all stored properties are initialized}}
-      // expected-note@-1{{'self.wrapped' not initialized}}
+       wrapped = 42 // expected-error{{variable 'self.wrapped' used before being initialized}}
      }
-  } // expected-error{{return from initializer without initializing all stored properties}}
-  // expected-note@-1{{'self.wrapped' not initialized}}
+  }
 
   init(dynamic b: Bool) {
     if b {
-      wrapped = 42 // expected-error{{'self' used before all stored properties are initialized}}
-      // expected-note@-1{{'self.wrapped' not initialized}}
+      wrapped = 42 // expected-error{{variable 'self.wrapped' used before being initialized}}
     }
-    wrapped = 27 // expected-error{{'self' used before all stored properties are initialized}}
-    // expected-note@-1{{'self.wrapped' not initialized}}
-  } // expected-error{{return from initializer without initializing all stored properties}}
-  // expected-note@-1{{'self.wrapped' not initialized}}  
+    wrapped = 27 // expected-error{{variable 'self.wrapped' used before being initialized}}
+  }
 }
 
 // SR_11477


### PR DESCRIPTION
This is achieved in 3 steps:
- CSApply detects assignments to property wrappers inside constructors, and produces an `inout` expr instead of a `load`, which it normally would because nonmutating setters take the `self` by-value. This is necessary becasue the assign_by_wrapper instruction expects an address type for its $1 operand. 
- SILGenLValue now emits the assign_by_wrapper pattern for such setters, ignoring the fact that they capture `self` by value. It also introduces an additional load instruction for the setter patrial_apply because the setter signature still expects a value and we now have an address (because of (1)).
- DefiniteInitialization ignores specifically load instructions used to produce a `self` *value* for a setter referenced on assign_by_wrapper  because it will be deleted by lowering anyway.
