### PR TITLE
[PrintAsObjC] Don't print imports for empty extensions

### DIFF
--- a/lib/PrintAsObjC/ModuleContentsWriter.cpp
+++ b/lib/PrintAsObjC/ModuleContentsWriter.cpp
@@ -400,6 +400,9 @@ public:
   }
 
   bool writeExtension(const ExtensionDecl *ED) {
+    if (printer.isEmptyExtensionDecl(ED))
+      return true;
+
     bool allRequirementsSatisfied = true;
 
     const ClassDecl *CD = ED->getSelfClassDecl();

--- a/test/PrintAsObjC/Inputs/custom-modules/MiserablePileOfSecrets.h
+++ b/test/PrintAsObjC/Inputs/custom-modules/MiserablePileOfSecrets.h
@@ -3,3 +3,6 @@
 @interface NSObject (Secrets)
 - (void)secretMethod;
 @end
+
+@interface SecretClass : NSObject
+@end

--- a/test/PrintAsObjC/imports.swift
+++ b/test/PrintAsObjC/imports.swift
@@ -67,3 +67,7 @@ import MostlyPrivate2_Private
 @objc public class TestSubclass: NSObject {
   @_implementationOnly public override func secretMethod() {}
 }
+
+extension SecretClass {
+  private func somethingThatShouldNotBeIncluded() {}
+}


### PR DESCRIPTION
Resubmitting #30306 now that the blockers for #30944 should have been fixed.

---

Fix an issue in generated compatibility headers where an extension that is not printed would still trigger the inclusion of the extended type's origin module. This was mostly noticeable with `@implementationOnly` imports when imported types were extended with only private members.

rdar://problem/57133517