### PR TITLE
[SymbolGraph] Type subheadings: don't print generics/inheritance

### DIFF
--- a/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
+++ b/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/USRGeneration.h"
+#include "swift/Syntax/TokenKinds.h"
 #include "DeclarationFragmentPrinter.h"
 #include "SymbolGraphASTWalker.h"
 
@@ -145,4 +146,40 @@ void DeclarationFragmentPrinter::printText(StringRef Text) {
     openFragment(FragmentKind::Text);
   }
   Spelling.append(Text);
+}
+
+void DeclarationFragmentPrinter::printAbridgedType(const GenericTypeDecl *TD) {
+  // Subheadings for types are abridged, omitting generics and inheritance.
+  openFragment(DeclarationFragmentPrinter::FragmentKind::Keyword);
+  switch (TD->getKind()) {
+    case DeclKind::Struct:
+      printText(getTokenText(tok::kw_struct));
+      break;
+    case DeclKind::Enum:
+      printText(getTokenText(tok::kw_enum));
+      break;
+    case DeclKind::Protocol:
+      printText(getTokenText(tok::kw_protocol));
+      break;
+    case DeclKind::Class:
+      printText(getTokenText(tok::kw_class));
+      break;
+    case DeclKind::TypeAlias:
+      printText(getTokenText(tok::kw_typealias));
+      break;
+    case DeclKind::OpaqueType:
+      llvm_unreachable("OpaqueType should not be in symbol graphs!");
+    default:
+      llvm_unreachable("GenericTypeDecl kind not handled in DeclarationFragmentPrinter!");
+  }
+
+  openFragment(DeclarationFragmentPrinter::FragmentKind::Text);
+  printText(" ");
+
+  openFragment(DeclarationFragmentPrinter::FragmentKind::TypeIdentifier);
+  printText(TD->getNameStr());
+
+  USR.clear();
+  llvm::raw_svector_ostream USROS(USR);
+  ide::printDeclUSR(TD, USROS);
 }

--- a/lib/SymbolGraphGen/DeclarationFragmentPrinter.h
+++ b/lib/SymbolGraphGen/DeclarationFragmentPrinter.h
@@ -22,6 +22,7 @@ namespace swift {
 class Decl;
 class Type;
 class TypeDecl;
+class GenericTypeDecl;
 
 namespace symbolgraphgen {
 
@@ -43,6 +44,7 @@ struct SymbolGraph;
 ///
 /// Will have fragments representing the `func foo()` part.
 class DeclarationFragmentPrinter : public ASTPrinter {
+public:
   enum class FragmentKind {
     None,
     Keyword,
@@ -56,7 +58,7 @@ class DeclarationFragmentPrinter : public ASTPrinter {
     InternalParam,
     Text,
   };
-
+private:
   /// The output stream to print fragment objects to.
   llvm::json::OStream &OS;
 
@@ -92,6 +94,13 @@ public:
     }
   }
 
+  /// Print an abridged form of a nominal type declaration, as:
+  /// keyword text(" ") typeIdentifier.
+  ///
+  /// Subheadings for types don't include the complete declaration line
+  /// including generics and inheritance.
+  void printAbridgedType(const GenericTypeDecl *TD);
+
   void printDeclLoc(const Decl *D) override;
 
   void printDeclNameEndLoc(const Decl *D) override {
@@ -109,6 +118,8 @@ public:
   void printTypeRef(Type T, const TypeDecl *RefTo, Identifier Name,
                     PrintNameContext NameContext) override;
 
+  /// Print plain text to the current fragment, opening a new text fragment
+  /// if there isn't an open fragment.
   void printText(StringRef Text) override;
 
   ~DeclarationFragmentPrinter() {

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -476,17 +476,22 @@ SymbolGraph::serializeSubheadingDeclarationFragments(StringRef Key,
                                                      const Symbol &S,
                                                      llvm::json::OStream &OS) {
   DeclarationFragmentPrinter Printer(OS, Key);
-  auto Options = getDeclarationFragmentsPrintOptions();
-  Options.ArgAndParamPrinting =
-    PrintOptions::ArgAndParamPrintingMode::ArgumentOnly;
-  Options.VarInitializers = false;
-  Options.PrintDefaultArgumentValue = false;
-  Options.PrintEmptyArgumentNames = false;
-  Options.PrintOverrideKeyword = false;
-  if (S.getSynthesizedBaseType()) {
-    Options.setBaseType(S.getSynthesizedBaseType());
+
+  if (const auto *TD = dyn_cast<GenericTypeDecl>(S.getSymbolDecl())) {
+    Printer.printAbridgedType(TD);
+  } else {
+    auto Options = getDeclarationFragmentsPrintOptions();
+    Options.ArgAndParamPrinting =
+      PrintOptions::ArgAndParamPrintingMode::ArgumentOnly;
+    Options.VarInitializers = false;
+    Options.PrintDefaultArgumentValue = false;
+    Options.PrintEmptyArgumentNames = false;
+    Options.PrintOverrideKeyword = false;
+    if (S.getSynthesizedBaseType()) {
+      Options.setBaseType(S.getSynthesizedBaseType());
+    }
+    S.getSymbolDecl()->print(Printer, Options);
   }
-  S.getSymbolDecl()->print(Printer, Options);
 }
 
 void

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/SubheadingDeclarationFragmentsTypes.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/SubheadingDeclarationFragmentsTypes.swift
@@ -1,0 +1,96 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name SubheadingDeclarationFragmentsTypes -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name SubheadingDeclarationFragmentsTypes -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/SubheadingDeclarationFragmentsTypes.symbols.json --check-prefix=STRUCT
+// RUN: %FileCheck %s --input-file %t/SubheadingDeclarationFragmentsTypes.symbols.json --check-prefix=ENUM
+// RUN: %FileCheck %s --input-file %t/SubheadingDeclarationFragmentsTypes.symbols.json --check-prefix=PROTOCOL
+// RUN: %FileCheck %s --input-file %t/SubheadingDeclarationFragmentsTypes.symbols.json --check-prefix=CLASS
+// RUN: %FileCheck %s --input-file %t/SubheadingDeclarationFragmentsTypes.symbols.json --check-prefix=TYPEALIAS
+
+// STRUCT-LABEL: "precise": "s:35SubheadingDeclarationFragmentsTypes6StructV"
+// STRUCT: subHeading
+// STRUCT-NEXT {
+// STRUCT-NEXT   "kind": "keyword",
+// STRUCT-NEXT   "spelling": "struct"
+// STRUCT-NEXT }
+// STRUCT-NEXT {
+// STRUCT-NEXT   "kind": "text",
+// STRUCT-NEXT   "spelling": " "
+// STRUCT-NEXT }
+// STRUCT-NEXT {
+// STRUCT-NEXT   "kind": "typeIdentifier",
+// STRUCT-NEXT   "spelling": "Struct",
+// STRUCT-NEXT   "preciseIdentifier": "s:35SubheadingDeclarationFragmentsTypes6StructV"
+// STRUCT-NEXT }
+public struct Struct<T> where T: Sequence {}
+
+// ENUM-LABEL: "precise": "s:35SubheadingDeclarationFragmentsTypes4EnumO"
+// ENUM: subHeading
+// ENUM-NEXT: {
+// ENUM-NEXT:   "kind": "keyword",
+// ENUM-NEXT:   "spelling": "enum"
+// ENUM-NEXT: }
+// ENUM-NEXT: {
+// ENUM-NEXT:   "kind": "text",
+// ENUM-NEXT:   "spelling": " "
+// ENUM-NEXT: }
+// ENUM-NEXT: {
+// ENUM-NEXT:   "kind": "typeIdentifier",
+// ENUM-NEXT:   "spelling": "Enum",
+// ENUM-NEXT:   "preciseIdentifier": "s:35SubheadingDeclarationFragmentsTypes4EnumO"
+// ENUM-NEXT: }
+public enum Enum<T> where T: Sequence {}
+
+// PROTOCOL-LABEL: "precise": "s:35SubheadingDeclarationFragmentsTypes8ProtocolP"
+// PROTOCOL: subHeading
+// PROTOCOL-NEXT: {
+// PROTOCOL-NEXT:   "kind": "keyword",
+// PROTOCOL-NEXT:   "spelling": "protocol"
+// PROTOCOL-NEXT: }
+// PROTOCOL-NEXT: {
+// PROTOCOL-NEXT:   "kind": "text",
+// PROTOCOL-NEXT:   "spelling": " "
+// PROTOCOL-NEXT: }
+// PROTOCOL-NEXT: {
+// PROTOCOL-NEXT:   "kind": "typeIdentifier",
+// PROTOCOL-NEXT:   "spelling": "Protocol",
+// PROTOCOL-NEXT:   "preciseIdentifier": "s:35SubheadingDeclarationFragmentsTypes8ProtocolP"
+// PROTOCOL-NEXT: }
+public protocol Protocol where T: Sequence {
+  associatedtype T
+}
+
+// CLASS-LABEL: "precise": "s:35SubheadingDeclarationFragmentsTypes5ClassC"
+// CLASS: subHeading
+// CLASS-NEXT {
+// CLASS-NEXT   "kind": "keyword",
+// CLASS-NEXT   "spelling": "class"
+// CLASS-NEXT },
+// CLASS-NEXT {
+// CLASS-NEXT   "kind": "text",
+// CLASS-NEXT   "spelling": " "
+// CLASS-NEXT },
+// CLASS-NEXT {
+// CLASS-NEXT   "kind": "typeIdentifier",
+// CLASS-NEXT   "spelling": "Class",
+// CLASS-NEXT   "preciseIdentifier": "s:35SubheadingDeclarationFragmentsTypes5ClassC"
+// CLASS-NEXT }
+public class Class<T> where T: Sequence {}
+
+// TYPEALIAS-LABEL: "precise": "s:35SubheadingDeclarationFragmentsTypes9TypeAliasa"
+// TYPEALIAS: subHeading
+// TYPEALIAS-NEXT: {
+// TYPEALIAS-NEXT:   "kind": "keyword",
+// TYPEALIAS-NEXT:   "spelling": "typealias"
+// TYPEALIAS-NEXT: },
+// TYPEALIAS-NEXT: {
+// TYPEALIAS-NEXT:   "kind": "text",
+// TYPEALIAS-NEXT:   "spelling": " "
+// TYPEALIAS-NEXT: },
+// TYPEALIAS-NEXT: {
+// TYPEALIAS-NEXT:   "kind": "typeIdentifier",
+// TYPEALIAS-NEXT:   "spelling": "TypeAlias",
+// TYPEALIAS-NEXT:   "preciseIdentifier": "s:35SubheadingDeclarationFragmentsTypes9TypeAliasa"
+// TYPEALIAS-NEXT: }
+public typealias TypeAlias<T> = Struct<T> where T: Collection
+


### PR DESCRIPTION
- **Explanation**: When recording display names for type declarations for display in a subheading, they should not include generics or inheritance since they cannot be overloaded as functions can. Abridge these to only include the keyword and identifier.
- **Scope**: This only affects an internal data format for documentation generation.
- **Radar**: rdar://62040714
- **Risk**: Low
- **Testing**: New unit tests added.
