### PR TITLE
[Frontend] Remove parseAndTypeCheckMainFileUpTo 

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -674,14 +674,10 @@ private:
   void performSemaUpTo(SourceFile::ASTStage_t LimitStage);
   void parseAndCheckTypesUpTo(SourceFile::ASTStage_t LimitStage);
 
-  void parseLibraryFile(unsigned BufferID);
-
   /// Return true if had load error
-  bool parsePartialModulesAndLibraryFiles();
+  bool parsePartialModulesAndInputFiles();
 
   void forEachFileToTypeCheck(llvm::function_ref<void(SourceFile &)> fn);
-
-  void parseAndTypeCheckMainFileUpTo(SourceFile::ASTStage_t LimitStage);
 
   void finishTypeChecking();
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -466,10 +466,6 @@ class CompilerInstance {
   /// If \p BufID is already in the set, do nothing.
   void recordPrimaryInputBuffer(unsigned BufID);
 
-  /// Record in PrimarySourceFiles the fact that \p SF is a primary, and
-  /// call recordPrimaryInputBuffer on \p SF's buffer (if it exists).
-  void recordPrimarySourceFile(SourceFile *SF);
-
   bool isWholeModuleCompilation() { return PrimaryBufferIDs.empty(); }
 
 public:

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -929,10 +929,6 @@ void CompilerInstance::parseAndTypeCheckMainFileUpTo(
   SourceFile &MainFile =
       MainModule->getMainSourceFile(Invocation.getSourceFileKind());
 
-  auto &Diags = MainFile.getASTContext().Diags;
-  auto DidSuppressWarnings = Diags.getSuppressWarnings();
-  Diags.setSuppressWarnings(DidSuppressWarnings || !mainIsPrimary);
-
   // For a primary, perform type checking if needed. Otherwise, just do import
   // resolution.
   if (mainIsPrimary && LimitStage >= SourceFile::TypeChecked) {
@@ -947,8 +943,6 @@ void CompilerInstance::parseAndTypeCheckMainFileUpTo(
     SILParserState SILContext(TheSILModule.get());
     parseSourceFileSIL(MainFile, &SILContext);
   }
-
-  Diags.setSuppressWarnings(DidSuppressWarnings);
 
   if (mainIsPrimary && !Context->hadError() &&
       Invocation.getFrontendOptions().DebuggerTestingTransform) {

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -198,15 +198,6 @@ void CompilerInstance::recordPrimaryInputBuffer(unsigned BufID) {
   PrimaryBufferIDs.insert(BufID);
 }
 
-void CompilerInstance::recordPrimarySourceFile(SourceFile *SF) {
-  assert(MainModule && "main module not created yet");
-  PrimarySourceFiles.push_back(SF);
-  SF->enableInterfaceHash();
-  SF->createReferencedNameTracker();
-  if (SF->getBufferID().hasValue())
-    recordPrimaryInputBuffer(SF->getBufferID().getValue());
-}
-
 bool CompilerInstance::setUpASTContextIfNeeded() {
   if (Invocation.getFrontendOptions().RequestedAction ==
       FrontendOptions::ActionType::CompileModuleFromInterface) {
@@ -966,8 +957,11 @@ SourceFile *CompilerInstance::createSourceFileForMainModule(
                  Invocation.getLangOptions().BuildSyntaxTree, opts);
   MainModule->addFile(*inputFile);
 
-  if (isPrimary)
-    recordPrimarySourceFile(inputFile);
+  if (isPrimary) {
+    PrimarySourceFiles.push_back(inputFile);
+    inputFile->enableInterfaceHash();
+    inputFile->createReferencedNameTracker();
+  }
 
   if (bufferID == SourceMgr.getCodeCompletionBufferID()) {
     assert(!CodeCompletionFile && "Multiple code completion files?");


### PR DESCRIPTION
Now that we no longer interleave parsing and type-checking for SIL, the main file doesn't need to be handled separately. We can now parse it along with the rest of the input files and type-check it along with the rest of the primaries.