### PR TITLE
[SymbolGraph] Filter @_spi declarations

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -513,6 +513,11 @@ bool SymbolGraph::isImplicitlyPrivate(const ValueDecl *VD) const {
     return true;
   }
 
+  // Don't include declarations with the @_spi attribute for now.
+  if (VD->getAttrs().getAttribute(DeclAttrKind::DAK_SPIAccessControl)) {
+    return true;
+  }
+
   // Symbols must meet the minimum access level to be included in the graph.
   if (VD->getFormalAccess() < Walker.Options.MinimumAccessLevel) {
     return true;

--- a/test/SymbolGraph/Symbols/SkipsSPI.swift
+++ b/test/SymbolGraph/Symbols/SkipsSPI.swift
@@ -1,0 +1,59 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name SkipsSPI -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name SkipsSPI -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/SkipsSPI.symbols.json
+
+// CHECK-NOT: ShouldntAppear
+
+@_spi(OtherModule)
+public struct StructShouldntAppear {
+  // This shouldn't appear because the owner is @_spi(OtherModule).
+  public func functionShouldntAppear() {}
+
+  // Although not @_spi(OtherModule), is in @_spi(OtherModule) struct, so shouldn't appear.
+  public struct InnerStructShouldntAppear {}
+}
+
+@_spi(OtherModule)
+public func functionShouldntAppear() {}
+
+@_spi(OtherModule)
+public protocol ProtocolShouldntAppear {}
+
+@_spi(OtherModule)
+public enum EnumShouldntAppear {}
+
+@_spi(OtherModule)
+public class ClassShouldntAppear {}
+
+// This struct should appear
+public struct StructShouldAppear {
+
+  // This shouldn't appear beacause it is @_spi(OtherModule), despite `StructShouldAppear`.
+  @_spi(OtherModule)
+  public func functionShouldntAppear() {}
+
+  // This shouldn't appear beacause it is @_spi(OtherModule), despite `StructShouldAppear`.
+  @_spi(OtherModule)
+  public struct InnerStructShouldntAppear {}
+}
+
+extension StructShouldAppear {
+  // This shouldn't appear because it is @_spi(OtherModule), despite `StructShouldAppear`.
+  @_spi(OtherModule)
+  public func extendedFunctionShouldntAppear() {}
+}
+
+extension StructShouldAppear.InnerStructShouldntAppear {
+
+  // This should not appear because `StructShouldAppear.InnerStructShouldntAppear`
+  // is @_spi(OtherModule).
+  public func extendedFunctionShouldntAppear() {}
+}
+
+extension StructShouldntAppear.InnerStructShouldntAppear {
+  // This should not appear because `StructShouldntAppear.InnerStructShouldntAppear`
+  // is @_spi(OtherModule).
+  @_spi(OtherModule)
+  public func extendedFunctionShouldntAppear() {}
+}


### PR DESCRIPTION
These definitely shouldn't be showing up in symbol graphs with a minimum access
level of `public`, and it's not clear whether another minimum access level
should show these. For now, filter them unconditionally.

rdar://62081711