### PR TITLE
Pass -fPIE in %target_cc_options lit template var on platforms where needed

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1055,7 +1055,8 @@ elif run_os in ['windows-msvc']:
     config.target_add_rpath = r''
 
     config.target_clang =                                                        \
-            ('clang++ -target %s %s -fobjc-runtime=ios-5.0' % (config.variant_triple, clang_mcp_opt))
+            ('clang++ -target %s %s %s -fobjc-runtime=ios-5.0' %                 \
+             (config.variant_triple, clang_mcp_opt, config.target_cc_options))
     config.target_ld =                                                           \
             ('%r -libpath:%s' % (config.link, os.path.join(test_resource_dir,    \
                                                            config.target_sdk_name)))
@@ -1107,14 +1108,14 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
       config.target_shared_library_prefix = 'lib'
       config.target_shared_library_suffix = ".so"
       config.target_sdk_name = "freebsd"
-      config.target_cc_options = "-fPIC"
+      config.target_cc_options = "-fPIE"
     elif run_os == 'openbsd':
       lit_config.note("Testing OpenBSD " + config.variant_triple)
       config.target_object_format = "elf"
       config.target_shared_library_prefix = 'lib'
       config.target_shared_library_suffix = ".so"
       config.target_sdk_name = "openbsd"
-      config.target_cc_options = "-fPIC"
+      config.target_cc_options = "-fPIE"
     elif kIsAndroid:
       lit_config.note("Testing Android " + config.variant_triple)
       config.target_object_format = "elf"
@@ -1124,14 +1125,14 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
       # Needed by several ParseableInterface/swift_build_sdk_interfaces tests on
       # Android
       config.environment['ANDROID_DATA'] = os.environ['ANDROID_DATA']
-      config.target_cc_options = "-fPIC"
+      config.target_cc_options = "-fPIE"
     else:
       lit_config.note("Testing Linux " + config.variant_triple)
       config.target_object_format = "elf"
       config.target_shared_library_prefix = 'lib'
       config.target_shared_library_suffix = ".so"
       config.target_sdk_name = "linux"
-      config.target_cc_options = "-fPIC"
+      config.target_cc_options = "-fPIE"
     config.target_runtime = "native"
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
 
@@ -1189,8 +1190,8 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
         '%s -emit-pcm -target %s' %
         (config.swiftc, config.variant_triple))
     config.target_clang = (
-        "clang++ -target %s %s -fobjc-runtime=ios-5.0" %
-        (config.variant_triple, clang_mcp_opt))
+        "clang++ -target %s %s %s -fobjc-runtime=ios-5.0" %
+        (config.variant_triple, clang_mcp_opt, config.target_cc_options))
     config.target_ld = "ld -L%r" % (make_path(test_resource_dir, config.target_sdk_name))
 elif run_os == 'linux-androideabi' or run_os == 'linux-android':
     # The module triple for Android ARMv7 seems to be canonicalized in LLVM
@@ -1319,7 +1320,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         'clang++',
         '-target', config.variant_triple,
         clang_mcp_opt, android_include_system_paths_opt,
-        '-fobjc-runtime=ios-5.0'])
+        config.target_cc_options, '-fobjc-runtime=ios-5.0'])
     config.target_ld = ' '.join([
         tools_directory,
         '-L%s' % make_path(test_resource_dir, config.target_sdk_name)])

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1028,6 +1028,7 @@ elif run_os in ['windows-msvc']:
     config.target_shared_library_suffix = '.dll'
     config.target_sdk_name = 'windows'
     config.target_runtime = 'native'
+    config.target_cc_options = ""
 
     config.target_build_swift =                                                  \
             ('%r -target %s %s %s %s %s -libc %s' %                              \
@@ -1202,6 +1203,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
     target_specific_module_triple = re.sub(r'androideabi', 'android',
                                            target_specific_module_triple)
     config.variant_triple = re.sub(r'androideabi', 'android', config.variant_triple)
+    config.target_cc_options = "-fPIE"
     def get_architecture_value(**kwargs):
         result = kwargs[run_cpu]
         if result is None:

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1107,12 +1107,14 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
       config.target_shared_library_prefix = 'lib'
       config.target_shared_library_suffix = ".so"
       config.target_sdk_name = "freebsd"
+      config.target_cc_options = "-fPIC"
     elif run_os == 'openbsd':
       lit_config.note("Testing OpenBSD " + config.variant_triple)
       config.target_object_format = "elf"
       config.target_shared_library_prefix = 'lib'
       config.target_shared_library_suffix = ".so"
       config.target_sdk_name = "openbsd"
+      config.target_cc_options = "-fPIC"
     elif kIsAndroid:
       lit_config.note("Testing Android " + config.variant_triple)
       config.target_object_format = "elf"
@@ -1122,12 +1124,14 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
       # Needed by several ParseableInterface/swift_build_sdk_interfaces tests on
       # Android
       config.environment['ANDROID_DATA'] = os.environ['ANDROID_DATA']
+      config.target_cc_options = "-fPIC"
     else:
       lit_config.note("Testing Linux " + config.variant_triple)
       config.target_object_format = "elf"
       config.target_shared_library_prefix = 'lib'
       config.target_shared_library_suffix = ".so"
       config.target_sdk_name = "linux"
+      config.target_cc_options = "-fPIC"
     config.target_runtime = "native"
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1096,12 +1096,14 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
       config.target_shared_library_prefix = 'lib'
       config.target_shared_library_suffix = ".dll"
       config.target_sdk_name = "cygwin"
+      config.target_cc_options = ""
     elif run_os == 'windows-gnu':
       lit_config.note("Testing MinGW " + config.variant_triple)
       config.target_object_format = "coff"
       config.target_shared_library_prefix = 'lib'
       config.target_shared_library_suffix = ".dll"
       config.target_sdk_name = "mingw"
+      config.target_cc_options = ""
     elif run_os == 'freebsd':
       lit_config.note("Testing FreeBSD " + config.variant_triple)
       config.target_object_format = "elf"


### PR DESCRIPTION
Any C/C++ code that is linked into a Swift executable targeting Linux needs to be compiled with `-fPIE` or `-fPIC`. In the common case (linking an executable) we want to pass `-fPIE`. On other platforms, e.g. Windows, it's illegal to pass `-fPIE` or `-fPIC`.

This makes writing executable tests that run on multiple platforms complicated. This PR handles `-fPIE` behind the scenes in `%target_cc_options` and `%target_clang`.

In case we need to build a shared library on Linux in the test, we can still pass `-fPIC` explicitly.