### PR TITLE
Requestify hasImplementationOnlyImports

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -157,10 +157,6 @@ private:
   /// May be -1, to indicate no association with a buffer.
   int BufferID;
 
-  /// Does this source file have any implementation-only imports?
-  /// If not, we can fast-path module checks.
-  bool HasImplementationOnlyImports = false;
-
   /// The parsing options for the file.
   ParsingOptions ParsingOpts;
 
@@ -333,6 +329,9 @@ public:
 
   ~SourceFile();
 
+  /// Retrieve an immutable view of the source file's imports.
+  ArrayRef<ImportedModuleDesc> getImports() const { return *Imports; }
+
   /// Set the imports for this source file. This gets called by import
   /// resolution.
   void setImports(ArrayRef<ImportedModuleDesc> imports);
@@ -350,9 +349,9 @@ public:
   hasTestableOrPrivateImport(AccessLevel accessLevel, const ValueDecl *ofDecl,
                              ImportQueryKind kind = TestableAndPrivate) const;
 
-  bool hasImplementationOnlyImports() const {
-    return HasImplementationOnlyImports;
-  }
+  /// Does this source file have any implementation-only imports?
+  /// If not, we can fast-path module checks.
+  bool hasImplementationOnlyImports() const;
 
   bool isImportedImplementationOnly(const ModuleDecl *module) const;
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2384,6 +2384,23 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Checks whether a file performs an implementation-only import.
+class HasImplementationOnlyImportsRequest
+    : public SimpleRequest<HasImplementationOnlyImportsRequest,
+                           bool(SourceFile *), RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  bool evaluate(Evaluator &evaluator, SourceFile *SF) const;
+
+public:
+  // Cached.
+  bool isCached() const { return true; }
+};
+
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.
 template<>

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -89,6 +89,8 @@ SWIFT_REQUEST(TypeChecker, HasDynamicMemberLookupAttributeRequest,
               bool(CanType), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, HasDynamicCallableAttributeRequest,
               bool(CanType), Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, HasImplementationOnlyImportsRequest,
+              bool(SourceFile *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, InferredGenericSignatureRequest,
               GenericSignature (ModuleDecl *, GenericSignatureImpl *,
                                  GenericParamSource,


### PR DESCRIPTION
Add `HasImplementationOnlyImportsRequest` to compute whether a file has any implementation-only imports.