### PR TITLE
[AutoDiff] fix _Differentiation rpath

### DIFF
--- a/stdlib/public/Differentiation/CMakeLists.txt
+++ b/stdlib/public/Differentiation/CMakeLists.txt
@@ -37,4 +37,5 @@ add_swift_target_library(swift_Differentiation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPE
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -parse-stdlib
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
+  DARWIN_INSTALL_NAME_DIR "@rpath"
   INSTALL_IN_COMPONENT stdlib)


### PR DESCRIPTION
I'm not very confident that this is the right thing to do. @compnerd could you take a look and let me know what you think?

The problem that this is fixing:
```
# In a SwiftPM package with a single main file:
$ cat Sources/testpackage/main.swift
import _Differentiation
print(gradient(at: Float(6), in: { $0 * $0 }))
$ swift run
dyld: Library not loaded: /usr/lib/swift/libswift_Differentiation.dylib
  Referenced from: /Users/marcrasi/testpackage/.build/x86_64-apple-macosx/debug/testpackage
  Reason: image not found
Abort trap: 6
```

Some commands that I ran for debugging:
```
$ otool -L /Users/marcrasi/testpackage/.build/x86_64-apple-macosx/debug/testpackage
/Users/marcrasi/testpackage/.build/x86_64-apple-macosx/debug/testpackage:
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1675.129.0)
	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.100.1)
	/usr/lib/swift/libswift_Differentiation.dylib (compatibility version 1.0.0, current version 0.0.0)
	@rpath/libswiftCore.dylib (compatibility version 1.0.0, current version 0.0.0)
	@rpath/libswiftDarwin.dylib (compatibility version 1.0.0, current version 0.0.0, weak)
	@rpath/libswiftSwiftOnoneSupport.dylib (compatibility version 1.0.0, current version 0.0.0)

$ otool -l /Users/marcrasi/testpackage/.build/x86_64-apple-macosx/debug/testpackage | grep RPATH -A2
          cmd LC_RPATH
      cmdsize 32
         path /usr/lib/swift (offset 12)
--
          cmd LC_RPATH
      cmdsize 32
         path @loader_path (offset 12)
--
          cmd LC_RPATH
      cmdsize 192
         path /Users/marcrasi/swift-base/build/Ninja-ReleaseAssert/toolchain-macosx-x86_64/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx (offset 12)

$ otool -l /Users/marcrasi/swift-base/build/Ninja-ReleaseAssert/toolchain-macosx-x86_64/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/libswift_Differentiation.dylib | grep ID_DYLIB -A2
          cmd LC_ID_DYLIB
      cmdsize 72
         name /usr/lib/swift/libswift_Differentiation.dylib (offset 24)
```

This PR fixes the problem by changing the "install name" of `libswift_Differentiation.dylib` to `@rpath/libswift_Differentiation.dylib` which makes it get found in the toolchain. Here are the same commands after rebuilding the toolchain with this PR:

```
$ swift run
12.0

$ otool -L /Users/marcrasi/testpackage/.build/x86_64-apple-macosx/debug/testpackage
/Users/marcrasi/testpackage/.build/x86_64-apple-macosx/debug/testpackage:
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1675.129.0)
	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.100.1)
	@rpath/libswiftCore.dylib (compatibility version 1.0.0, current version 0.0.0)
	@rpath/libswiftDarwin.dylib (compatibility version 1.0.0, current version 0.0.0, weak)
	@rpath/libswiftSwiftOnoneSupport.dylib (compatibility version 1.0.0, current version 0.0.0)
	@rpath/libswift_Differentiation.dylib (compatibility version 1.0.0, current version 0.0.0)

$ otool -l /Users/marcrasi/swift-base/build/Ninja-ReleaseAssert/toolchain-macosx-x86_64/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/libswift_Differentiation.dylib | grep ID_DYLIB -A2
          cmd LC_ID_DYLIB
      cmdsize 64
         name @rpath/libswift_Differentiation.dylib (offset 24)
```