### PR TITLE
[indexstore-db] Set PR test preset to not sanitize for now

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1754,13 +1754,13 @@ test-indexstore-db-sanitize-all
 mixin-preset=buildbot_indexstoredb_linux,no_sanitize
 test-indexstore-db-sanitize-all
 
-# Default: sanitize-all
+# Default: no sanitizers
 [preset: buildbot_indexstoredb_macos]
-mixin-preset=buildbot_indexstoredb_macos,sanitize
+mixin-preset=buildbot_indexstoredb_macos,no_sanitize
 
-# Default: sanitize-all
+# Default: no sanitizers
 [preset: buildbot_indexstoredb_linux]
-mixin-preset=buildbot_indexstoredb_linux,sanitize
+mixin-preset=buildbot_indexstoredb_linux,no_sanitize
 
 #===------------------------------------------------------------------------===#
 # Test Swift Corelibs XCTest


### PR DESCRIPTION
We should evaluate pulling the necessary fixes into 5.3, but for now
disable sanitizer flags to fix CI.