### PR TITLE
Removes redundant buffer zeroing in UnicodeScalarProperties by using init(unsafeUninitializedCapacity:initializingWith:)

### DIFF
--- a/stdlib/public/core/UnicodeScalarProperties.swift
+++ b/stdlib/public/core/UnicodeScalarProperties.swift
@@ -707,36 +707,11 @@ extension Unicode.Scalar.Properties {
         guard err.isSuccess else {
           fatalError("Unexpected error case-converting Unicode scalar.")
         }
-        return Int(correctSize)
-      }
-    }
-    if _fastPath(count <= 16) {
-      fixedArray.count = count
-      return fixedArray.withUnsafeBufferPointer {
-        String._uncheckedFromUTF16($0)
-      }
-    }
-    // Allocate `count` code units on the heap.
-    let array = Array<UInt16>(unsafeUninitializedCapacity: count) {
-      buf, initializedCount in
-      _scalar.withUTF16CodeUnits { utf16 in
-        var err = __swift_stdlib_U_ZERO_ERROR
-        let correctSize = u_strTo(
-          buf.baseAddress._unsafelyUnwrappedUnchecked,
-          Int32(buf.count),
-          utf16.baseAddress._unsafelyUnwrappedUnchecked,
-          Int32(utf16.count),
-          "",
-          &err)
-        guard err.isSuccess else {
-          fatalError("Unexpected error case-converting Unicode scalar.")
-        }
         _internalInvariant(count == correctSize, "inconsistent ICU behavior")
-        initializedCount = count
       }
     }
     return array.withUnsafeBufferPointer {
-      String._uncheckedFromUTF16($0)
+      return String._uncheckedFromUTF16($0)
     }
   }
 
@@ -1113,27 +1088,29 @@ extension Unicode.Scalar.Properties {
   internal func _scalarName(
     _ choice: __swift_stdlib_UCharNameChoice
   ) -> String? {
-    var err = __swift_stdlib_U_ZERO_ERROR
-    let count = Int(__swift_stdlib_u_charName(icuValue, choice, nil, 0, &err))
+    var error = __swift_stdlib_U_ZERO_ERROR
+    let count = Int(__swift_stdlib_u_charName(icuValue, choice, nil, 0, &error))
     guard count > 0 else { return nil }
 
     // ICU writes a trailing null, so we have to save room for it as well.
-    var array = Array<UInt8>(repeating: 0, count: count + 1)
-    return array.withUnsafeMutableBufferPointer { bufPtr in
-      var err = __swift_stdlib_U_ZERO_ERROR
+    let array = Array<UInt8>(unsafeUninitializedCapacity: count + 1) {
+      buffer, initializedCount in
+      var error = __swift_stdlib_U_ZERO_ERROR
       let correctSize = __swift_stdlib_u_charName(
         icuValue,
         choice,
-        UnsafeMutableRawPointer(bufPtr.baseAddress._unsafelyUnwrappedUnchecked)
+        UnsafeMutableRawPointer(buffer.baseAddress._unsafelyUnwrappedUnchecked)
           .assumingMemoryBound(to: Int8.self),
-        Int32(bufPtr.count),
-        &err)
-      guard err.isSuccess else {
+        Int32(buffer.count),
+        &error)
+      guard error.isSuccess else {
         fatalError("Unexpected error case-converting Unicode scalar.")
       }
       _internalInvariant(count == correctSize, "inconsistent ICU behavior")
-      return String._fromASCII(
-        UnsafeBufferPointer(rebasing: bufPtr[..<count]))
+      initializedCount = count + 1
+    }
+    return array.withUnsafeBufferPointer { buffer in
+      String._fromASCII(UnsafeBufferPointer(rebasing: buffer[..<count]))
     }
   }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Removes redundant buffer zeroing in UnicodeScalarProperties by using init(unsafeUninitializedCapacity:initializingWith:)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
