### PR TITLE
[ConstraintSystem] Switch `ConstraintLocator` to be anchored on `TypedNode`

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -459,8 +459,8 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) const {
   // of the optional type extracted by force unwrap.
   bool isOptionalObject = false;
   if (auto *locator = typeVar->getImpl().getLocator()) {
-    auto *anchor = locator->getAnchor();
-    isOptionalObject = anchor && isa<ForceValueExpr>(anchor);
+    auto anchor = locator->getAnchor();
+    isOptionalObject = isExpr<ForceValueExpr>(anchor);
   }
 
   // Gather the constraints associated with this type variable.
@@ -1104,7 +1104,7 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
         if (cs.recordFix(fix))
           return true;
       } else if (srcLocator->getAnchor() &&
-                 isa<ObjectLiteralExpr>(srcLocator->getAnchor())) {
+                 isExpr<ObjectLiteralExpr>(srcLocator->getAnchor())) {
         auto *fix = SpecifyObjectLiteralTypeImport::create(
             cs, TypeVar->getImpl().getLocator());
         if (cs.recordFix(fix))

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -50,10 +50,10 @@ public:
 
   virtual ~FailureDiagnostic();
 
-  virtual SourceLoc getLoc() const { return getLoc(getAnchor()); }
+  virtual SourceLoc getLoc() const { return constraints::getLoc(getAnchor()); }
 
   virtual SourceRange getSourceRange() const {
-    return getSourceRange(getAnchor());
+    return constraints::getSourceRange(getAnchor());
   }
 
   /// Try to diagnose a problem given affected expression,
@@ -201,24 +201,6 @@ protected:
       Type type,
       llvm::function_ref<void(GenericTypeParamType *, Type)> substitution =
           [](GenericTypeParamType *, Type) {});
-
-  static SourceLoc getLoc(TypedNode node);
-  static SourceRange getSourceRange(TypedNode node);
-
-  template <typename T> static const T *castToExpr(TypedNode node) {
-    return cast<T>(node.get<const Expr *>());
-  }
-
-  template <typename T> static T *getAsExpr(TypedNode node) {
-    if (const auto *E = node.dyn_cast<const Expr *>())
-      return dyn_cast<T>(const_cast<Expr *>(E));
-    return nullptr;
-  }
-
-  template <typename T> static bool isExpr(TypedNode node) {
-    auto *E = node.get<const Expr *>();
-    return isa<T>(E);
-  }
 };
 
 /// Base class for all of the diagnostics related to generic requirement
@@ -1065,7 +1047,7 @@ public:
 
   SourceLoc getLoc() const override {
     // Diagnostic should point to the member instead of its base expression.
-    return FailureDiagnostic::getLoc(getRawAnchor());
+    return constraints::getLoc(getRawAnchor());
   }
 
   bool diagnoseAsError() override;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -45,7 +45,7 @@ public:
   FailureDiagnostic(const Solution &solution, ConstraintLocator *locator)
       : S(solution), Locator(locator) {}
 
-  FailureDiagnostic(const Solution &solution, const Expr *anchor)
+  FailureDiagnostic(const Solution &solution, TypedNode anchor)
       : FailureDiagnostic(solution, solution.getConstraintLocator(anchor)) {}
 
   virtual ~FailureDiagnostic();
@@ -490,7 +490,8 @@ class TrailingClosureAmbiguityFailure final : public FailureDiagnostic {
   ArrayRef<OverloadChoice> Choices;
 
 public:
-  TrailingClosureAmbiguityFailure(ArrayRef<Solution> solutions, Expr *anchor,
+  TrailingClosureAmbiguityFailure(ArrayRef<Solution> solutions,
+                                  TypedNode anchor,
                                   ArrayRef<OverloadChoice> choices)
       : FailureDiagnostic(solutions.front(), anchor), Choices(choices) {}
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -119,17 +119,17 @@ protected:
 
   Type getContextualType(TypedNode anchor) const {
     auto &cs = getConstraintSystem();
-    return cs.getContextualType(anchor.get<const Expr *>());
+    return cs.getContextualType(anchor);
   }
 
   TypeLoc getContextualTypeLoc(TypedNode anchor) const {
     auto &cs = getConstraintSystem();
-    return cs.getContextualTypeLoc(anchor.get<const Expr *>());
+    return cs.getContextualTypeLoc(anchor);
   }
 
   ContextualTypePurpose getContextualTypePurpose(TypedNode anchor) const {
     auto &cs = getConstraintSystem();
-    return cs.getContextualTypePurpose(anchor.get<const Expr *>());
+    return cs.getContextualTypePurpose(anchor);
   }
 
   DeclContext *getDC() const {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -189,8 +189,7 @@ bool MissingConformance::diagnose(const Solution &solution, bool asNote) const {
 
   if (IsContextual) {
     auto &cs = solution.getConstraintSystem();
-    auto context =
-        cs.getContextualTypePurpose(locator->getAnchor().get<const Expr *>());
+    auto context = cs.getContextualTypePurpose(locator->getAnchor());
     MissingContextualConformanceFailure failure(
         solution, context, NonConformingType, ProtocolType, locator);
     return failure.diagnose(asNote);
@@ -265,7 +264,7 @@ getStructuralTypeContext(const Solution &solution, ConstraintLocator *locator) {
            locator->isLastElement<LocatorPathElt::FunctionArgument>());
 
     auto &cs = solution.getConstraintSystem();
-    auto *anchor = locator->getAnchor().get<const Expr *>();
+    auto anchor = locator->getAnchor();
     auto contextualType = cs.getContextualType(anchor);
     auto exprType = cs.getType(anchor);
     return std::make_tuple(cs.getContextualTypePurpose(anchor), exprType,
@@ -314,8 +313,7 @@ bool AllowTupleTypeMismatch::coalesceAndDiagnose(
   Type toType;
 
   if (getFromType()->is<TupleType>() && getToType()->is<TupleType>()) {
-    purpose =
-        cs.getContextualTypePurpose(locator->getAnchor().get<const Expr *>());
+    purpose = cs.getContextualTypePurpose(locator->getAnchor());
     fromType = getFromType();
     toType = getToType();
   } else if (auto contextualTypeInfo =

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -34,7 +34,7 @@ using namespace constraints;
 
 ConstraintFix::~ConstraintFix() {}
 
-Expr *ConstraintFix::getAnchor() const { return getLocator()->getAnchor(); }
+TypedNode ConstraintFix::getAnchor() const { return getLocator()->getAnchor(); }
 
 void ConstraintFix::print(llvm::raw_ostream &Out) const {
   Out << "[fix: ";
@@ -135,10 +135,10 @@ CoerceToCheckedCast *CoerceToCheckedCast::attempt(ConstraintSystem &cs,
   if (fromType->hasTypeVariable() || toType->hasTypeVariable())
     return nullptr;
 
-  auto *expr = locator->getAnchor();
-  if (auto *assignExpr = dyn_cast<AssignExpr>(expr))
-    expr = assignExpr->getSrc();
-  auto *coerceExpr = dyn_cast<CoerceExpr>(expr);
+  auto anchor = locator->getAnchor();
+  if (auto *assignExpr = getAsExpr<AssignExpr>(anchor))
+    anchor = assignExpr->getSrc();
+  auto *coerceExpr = getAsExpr<CoerceExpr>(anchor);
   if (!coerceExpr)
     return nullptr;
 
@@ -189,7 +189,8 @@ bool MissingConformance::diagnose(const Solution &solution, bool asNote) const {
 
   if (IsContextual) {
     auto &cs = solution.getConstraintSystem();
-    auto context = cs.getContextualTypePurpose(locator->getAnchor());
+    auto context =
+        cs.getContextualTypePurpose(locator->getAnchor().get<const Expr *>());
     MissingContextualConformanceFailure failure(
         solution, context, NonConformingType, ProtocolType, locator);
     return failure.diagnose(asNote);
@@ -264,7 +265,7 @@ getStructuralTypeContext(const Solution &solution, ConstraintLocator *locator) {
            locator->isLastElement<LocatorPathElt::FunctionArgument>());
 
     auto &cs = solution.getConstraintSystem();
-    auto *anchor = locator->getAnchor();
+    auto *anchor = locator->getAnchor().get<const Expr *>();
     auto contextualType = cs.getContextualType(anchor);
     auto exprType = cs.getType(anchor);
     return std::make_tuple(cs.getContextualTypePurpose(anchor), exprType,
@@ -273,15 +274,15 @@ getStructuralTypeContext(const Solution &solution, ConstraintLocator *locator) {
     return std::make_tuple(CTP_CallArgument,
                            argApplyInfo->getArgType(),
                            argApplyInfo->getParamType());
-  } else if (auto *coerceExpr = dyn_cast<CoerceExpr>(locator->getAnchor())) {
+  } else if (auto *coerceExpr = getAsExpr<CoerceExpr>(locator->getAnchor())) {
     return std::make_tuple(CTP_CoerceOperand,
                            solution.getType(coerceExpr->getSubExpr()),
                            solution.getType(coerceExpr));
-  } else if (auto *assignExpr = dyn_cast<AssignExpr>(locator->getAnchor())) {
+  } else if (auto *assignExpr = getAsExpr<AssignExpr>(locator->getAnchor())) {
     return std::make_tuple(CTP_AssignSource,
                            solution.getType(assignExpr->getSrc()),
                            solution.getType(assignExpr->getDest()));
-  } else if (auto *call = dyn_cast<CallExpr>(locator->getAnchor())) {
+  } else if (auto *call = getAsExpr<CallExpr>(locator->getAnchor())) {
     assert(isa<TypeExpr>(call->getFn()));
     return std::make_tuple(
         CTP_Initialization,
@@ -313,7 +314,8 @@ bool AllowTupleTypeMismatch::coalesceAndDiagnose(
   Type toType;
 
   if (getFromType()->is<TupleType>() && getToType()->is<TupleType>()) {
-    purpose = cs.getContextualTypePurpose(locator->getAnchor());
+    purpose =
+        cs.getContextualTypePurpose(locator->getAnchor().get<const Expr *>());
     fromType = getFromType();
     toType = getToType();
   } else if (auto contextualTypeInfo =
@@ -500,8 +502,9 @@ DefineMemberBasedOnUse::diagnoseForAmbiguity(CommonFixesArray commonFixes) const
       concreteBaseType = baseType;
 
     if (concreteBaseType->getCanonicalType() != baseType->getCanonicalType()) {
-      getConstraintSystem().getASTContext().Diags.diagnose(getAnchor()->getLoc(),
-          diag::unresolved_member_no_inference, Name);
+      auto &DE = getConstraintSystem().getASTContext().Diags;
+      DE.diagnose(getLoc(getAnchor()), diag::unresolved_member_no_inference,
+                  Name);
       return true;
     }
   }
@@ -655,7 +658,7 @@ bool RemoveExtraneousArguments::diagnose(const Solution &solution,
 
 bool RemoveExtraneousArguments::isMinMaxNameShadowing(
     ConstraintSystem &cs, ConstraintLocatorBuilder locator) {
-  auto *anchor = dyn_cast_or_null<CallExpr>(locator.getAnchor());
+  auto *anchor = getAsExpr<CallExpr>(locator.getAnchor());
   if (!anchor)
     return false;
 
@@ -1001,7 +1004,9 @@ IgnoreContextualType *IgnoreContextualType::create(ConstraintSystem &cs,
 bool IgnoreAssignmentDestinationType::diagnose(const Solution &solution,
                                                bool asNote) const {
   auto &cs = getConstraintSystem();
-  auto *AE = cast<AssignExpr>(getAnchor());
+  auto *AE = getAsExpr<AssignExpr>(getAnchor());
+
+  assert(AE);
 
   // Let's check whether this is a situation of chained assignment where
   // one of the steps in the chain is an assignment to self e.g.

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_SEMA_CSFIX_H
 #define SWIFT_SEMA_CSFIX_H
 
+#include "ConstraintLocator.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/Identifier.h"
@@ -312,7 +313,7 @@ public:
   /// Retrieve anchor expression associated with this fix.
   /// NOTE: such anchor comes directly from locator without
   /// any simplication attempts.
-  Expr *getAnchor() const;
+  TypedNode getAnchor() const;
   ConstraintLocator *getLocator() const { return Locator; }
 
 protected:

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4489,7 +4489,7 @@ bool swift::areGenericRequirementsSatisfied(
 
   ConstraintSystemOptions Options;
   ConstraintSystem CS(const_cast<DeclContext *>(DC), Options);
-  auto Loc = CS.getConstraintLocator(nullptr);
+  auto Loc = CS.getConstraintLocator({});
 
   // For every requirement, add a constraint.
   for (auto Req : sig->getRequirements()) {
@@ -4564,7 +4564,7 @@ swift::resolveValueMember(DeclContext &DC, Type BaseTy, DeclName Name) {
     return Result;
 
   // Try to figure out the best overload.
-  ConstraintLocator *Locator = CS.getConstraintLocator(nullptr);
+  ConstraintLocator *Locator = CS.getConstraintLocator({});
   TypeVariableType *TV = CS.createTypeVariable(Locator,
                                                TVO_CanBindToLValue |
                                                TVO_CanBindToNoEscape);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4550,7 +4550,7 @@ swift::resolveValueMember(DeclContext &DC, Type BaseTy, DeclName Name) {
   // Look up all members of BaseTy with the given Name.
   MemberLookupResult LookupResult = CS.performMemberLookup(
       ConstraintKind::ValueMember, DeclNameRef(Name), BaseTy,
-      FunctionRefKind::SingleApply, CS.getConstraintLocator(nullptr), false);
+      FunctionRefKind::SingleApply, CS.getConstraintLocator({}), false);
 
   // Keep track of all the unviable members.
   for (auto Can : LookupResult.UnviableCandidates)

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -505,7 +505,7 @@ bool CompareDeclSpecializationRequest::evaluate(
   ConstraintSystem cs(dc, ConstraintSystemOptions());
   bool knownNonSubtype = false;
 
-  auto *locator = cs.getConstraintLocator(nullptr);
+  auto *locator = cs.getConstraintLocator({});
   // FIXME: Locator when anchored on a declaration.
   // Get the type of a reference to the second declaration.
 
@@ -769,8 +769,8 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
   bool isVarAndNotProtocol2 = false;
 
   auto getWeight = [&](ConstraintLocator *locator) -> unsigned {
-    if (auto *anchor = locator->getAnchor()) {
-      auto weight = cs.getExprDepth(anchor);
+    if (auto *anchor = locator->getAnchor().dyn_cast<const Expr *>()) {
+      auto weight = cs.getExprDepth(const_cast<Expr *>(anchor));
       if (weight)
         return *weight + 1;
     }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -879,7 +879,7 @@ public:
       return false;
     }
 
-    auto *anchor = Locator.getBaseLocator()->getAnchor();
+    auto anchor = Locator.getBaseLocator()->getAnchor();
     if (!anchor)
       return true;
 
@@ -941,7 +941,7 @@ public:
     // would not require special handling of the closure type.
     Type argType;
     if (auto *closure =
-            dyn_cast<ClosureExpr>(simplifyLocatorToAnchor(argLoc))) {
+            getAsExpr<ClosureExpr>(simplifyLocatorToAnchor(argLoc))) {
       argType = CS.getClosureType(closure);
     } else {
       argType = Arguments[argIdx].getPlainType();
@@ -1065,8 +1065,8 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
   // If this application is part of an operator, then we allow an implicit
   // lvalue to be compatible with inout arguments.  This is used by
   // assignment operators.
-  auto *anchor = locator.getAnchor();
-  assert(anchor && "locator without anchor expression?");
+  auto anchor = locator.getAnchor();
+  assert(bool(anchor) && "locator without anchor?");
 
   auto isSynthesizedArgument = [](const AnyFunctionType::Param &arg) -> bool {
     if (auto *typeVar = arg.getPlainType()->getAs<TypeVariableType>()) {
@@ -1353,14 +1353,14 @@ static bool isSingleTupleParam(ASTContext &ctx,
 }
 
 static ConstraintFix *fixRequirementFailure(ConstraintSystem &cs, Type type1,
-                                            Type type2, Expr *anchor,
+                                            Type type2, TypedNode anchor,
                                             ArrayRef<LocatorPathElt> path);
 
 static ConstraintFix *fixRequirementFailure(ConstraintSystem &cs, Type type1,
                                             Type type2,
                                             ConstraintLocatorBuilder locator) {
   SmallVector<LocatorPathElt, 4> path;
-  if (auto *anchor = locator.getLocatorParts(path)) {
+  if (auto anchor = locator.getLocatorParts(path)) {
     return fixRequirementFailure(cs, type1, type2, anchor, path);
   }
   return nullptr;
@@ -1372,7 +1372,7 @@ assessRequirementFailureImpact(ConstraintSystem &cs, Type requirementType,
   assert(requirementType);
 
   unsigned impact = 1;
-  auto *anchor = locator.getAnchor();
+  auto anchor = locator.getAnchor();
   if (!anchor)
     return impact;
 
@@ -1395,7 +1395,8 @@ assessRequirementFailureImpact(ConstraintSystem &cs, Type requirementType,
   //
   // Don't add this impact with the others, as we want to keep it consistent
   // across requirement failures to present the user with a choice.
-  if (isa<UnresolvedDotExpr>(anchor) || isa<UnresolvedMemberExpr>(anchor)) {
+  if (isExpr<UnresolvedDotExpr>(anchor) ||
+      isExpr<UnresolvedMemberExpr>(anchor)) {
     auto *calleeLoc = cs.getCalleeLocator(cs.getConstraintLocator(locator));
     if (!cs.findSelectedOverloadFor(calleeLoc))
       return 10;
@@ -1423,7 +1424,7 @@ assessRequirementFailureImpact(ConstraintSystem &cs, Type requirementType,
 
   // If this requirement is associated with an overload choice let's
   // tie impact to how many times this requirement type is mentioned.
-  if (auto *ODRE = dyn_cast<OverloadedDeclRefExpr>(anchor)) {
+  if (auto *ODRE = getAsExpr<OverloadedDeclRefExpr>(anchor)) {
     if (auto *typeVar = requirementType->getAs<TypeVariableType>()) {
       unsigned choiceImpact = 0;
       if (auto choice = cs.findSelectedOverloadFor(ODRE)) {
@@ -1443,7 +1444,7 @@ assessRequirementFailureImpact(ConstraintSystem &cs, Type requirementType,
 
 /// Attempt to fix missing arguments by introducing type variables
 /// and inferring their types from parameters.
-static bool fixMissingArguments(ConstraintSystem &cs, Expr *anchor,
+static bool fixMissingArguments(ConstraintSystem &cs, TypedNode anchor,
                                 SmallVectorImpl<AnyFunctionType::Param> &args,
                                 ArrayRef<AnyFunctionType::Param> params,
                                 unsigned numMissing,
@@ -1476,8 +1477,8 @@ static bool fixMissingArguments(ConstraintSystem &cs, Expr *anchor,
       };
 
       // Something like `foo { x in }` or `foo { $0 }`
-      if (isa<ClosureExpr>(anchor)) {
-        anchor->forEachChildExpr([&](Expr *expr) -> Expr * {
+      if (auto *closure = getAsExpr<ClosureExpr>(anchor)) {
+        closure->forEachChildExpr([&](Expr *expr) -> Expr * {
           if (auto *UDE = dyn_cast<UnresolvedDotExpr>(expr)) {
             if (!isParam(UDE->getBase()))
               return expr;
@@ -1812,7 +1813,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
       loc = getConstraintLocator(loc->getAnchor(), path.drop_back());
     }
 
-    auto *anchor = simplifyLocatorToAnchor(loc);
+    auto anchor = simplifyLocatorToAnchor(loc);
     if (!anchor)
       return getTypeMatchFailure(argumentLocator);
 
@@ -2002,9 +2003,9 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
                                [&numMismatches](unsigned) { ++numMismatches; });
 
     if (numMismatches > 0) {
-      auto *anchor = locator.getAnchor();
+      auto anchor = locator.getAnchor();
       // TODO(diagnostics): Only assignments are supported at the moment.
-      if (!(anchor && isa<AssignExpr>(anchor)))
+      if (!isExpr<AssignExpr>(anchor))
         return getTypeMatchFailure(locator);
 
       auto *fix = IgnoreAssignmentDestinationType::create(
@@ -2228,8 +2229,7 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
         if (!type1->isClassExistentialType() && !type1->mayHaveSuperclass()) {
           if (shouldAttemptFixes()) {
             llvm::SmallVector<LocatorPathElt, 4> path;
-            if (auto *anchor = locator.getLocatorParts(path)) {
-
+            if (auto anchor = locator.getLocatorParts(path)) {
               // Let's drop `optional` or `generic argument` bits from
               // locator because that helps to diagnose reference equality
               // operaators ("===" and "!==") since there is always a
@@ -2321,14 +2321,13 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
             return getTypeMatchFailure(locator);
 
         } else { // There are no elements in the path
-          auto *anchor = locator.getAnchor();
-          if (!(anchor &&
-               (isa<AssignExpr>(anchor) || isa<CoerceExpr>(anchor))))
+          auto anchor = locator.getAnchor();
+          if (!(isExpr<AssignExpr>(anchor) || isExpr<CoerceExpr>(anchor)))
             return getTypeMatchFailure(locator);
         }
-        
-        auto *anchor = locator.getAnchor();
-        if (isa<CoerceExpr>(anchor)) {
+
+        auto anchor = locator.getAnchor();
+        if (isExpr<CoerceExpr>(anchor)) {
           auto *fix = ContextualMismatch::create(
               *this, type1, type2, getConstraintLocator(locator));
           if (recordFix(fix))
@@ -2563,7 +2562,7 @@ ConstraintSystem::matchTypesBindTypeVar(
 }
 
 static ConstraintFix *fixRequirementFailure(ConstraintSystem &cs, Type type1,
-                                            Type type2, Expr *anchor,
+                                            Type type2, TypedNode anchor,
                                             ArrayRef<LocatorPathElt> path) {
   // Can't fix not yet properly resolved types.
   if (type1->isTypeVariableOrMember() || type2->isTypeVariableOrMember())
@@ -2605,15 +2604,15 @@ static ConstraintFix *fixPropertyWrapperFailure(
     Optional<Type> toType = None) {
 
   Expr *baseExpr = nullptr;
-  if (auto *anchor = locator->getAnchor()) {
+  if (auto *anchor = getAsExpr(locator->getAnchor())) {
     if (auto *UDE = dyn_cast<UnresolvedDotExpr>(anchor))
       baseExpr = UDE->getBase();
     else if (auto *SE = dyn_cast<SubscriptExpr>(anchor))
       baseExpr = SE->getBase();
     else if (auto *MRE = dyn_cast<MemberRefExpr>(anchor))
       baseExpr = MRE->getBase();
-    else if (auto *anchor = simplifyLocatorToAnchor(locator))
-      baseExpr = anchor;
+    else if (auto anchor = simplifyLocatorToAnchor(locator))
+      baseExpr = getAsExpr(anchor);
   }
 
   if (!baseExpr)
@@ -2887,21 +2886,21 @@ static bool repairOutOfOrderArgumentsInBinaryFunction(
   if (!(fnType && fnType->getNumParams() == 2))
     return false;
 
-  auto *argExpr = simplifyLocatorToAnchor(locator);
+  auto argument = simplifyLocatorToAnchor(locator);
   // Argument could be synthesized.
-  if (!argExpr)
+  if (!argument)
     return false;
 
   auto currArgIdx =
       locator->castLastElementTo<LocatorPathElt::ApplyArgToParam>().getArgIdx();
   auto otherArgIdx = currArgIdx == 0 ? 1 : 0;
 
-  auto argType = cs.getType(argExpr);
+  auto argType = cs.getType(argument);
   auto paramType = fnType->getParams()[otherArgIdx].getOldType();
 
   bool isOperatorRef = overload->choice.getDecl()->isOperator();
 
-  auto matchArgToParam = [&](Type argType, Type paramType, Expr *anchor) {
+  auto matchArgToParam = [&](Type argType, Type paramType, TypedNode anchor) {
     auto *loc = cs.getConstraintLocator(anchor);
     // If argument (and/or parameter) is a generic type let's not even try this
     // fix because it would be impossible to match given types  without delaying
@@ -2917,22 +2916,22 @@ static bool repairOutOfOrderArgumentsInBinaryFunction(
         ConstraintSystem::TypeMatchFlags::TMF_ApplyingFix, loc);
   };
 
-  auto result = matchArgToParam(argType, paramType, argExpr);
+  auto result = matchArgToParam(argType, paramType, argument);
   if (result.isSuccess()) {
     // Let's check whether other argument matches current parameter type,
     // if it does - it's definitely out-of-order arguments issue.
     auto *otherArgLoc = cs.getConstraintLocator(
         parentLoc, LocatorPathElt::ApplyArgToParam(otherArgIdx, otherArgIdx,
                                                    ParameterTypeFlags()));
-    auto *otherArgExpr = simplifyLocatorToAnchor(otherArgLoc);
+    auto otherArg = simplifyLocatorToAnchor(otherArgLoc);
     // Argument could be synthesized.
-    if (!otherArgExpr)
+    if (!otherArg)
       return false;
 
-    argType = cs.getType(otherArgExpr);
+    argType = cs.getType(otherArg);
     paramType = fnType->getParams()[currArgIdx].getOldType();
 
-    result = matchArgToParam(argType, paramType, otherArgExpr);
+    result = matchArgToParam(argType, paramType, otherArg);
     if (result.isSuccess()) {
       conversionsOrFixes.push_back(MoveOutOfOrderArgument::create(
           cs, otherArgIdx, currArgIdx, {{0}, {1}}, parentLoc));
@@ -2951,7 +2950,7 @@ bool ConstraintSystem::repairFailures(
     SmallVectorImpl<RestrictionOrFix> &conversionsOrFixes,
     ConstraintLocatorBuilder locator) {
   SmallVector<LocatorPathElt, 4> path;
-  auto *anchor = locator.getLocatorParts(path);
+  auto anchor = locator.getLocatorParts(path);
 
   // If there is a missing explicit call it could be:
   //
@@ -2969,11 +2968,11 @@ bool ConstraintSystem::repairFailures(
     // default values, let's see whether error is related to missing
     // explicit call.
     if (fnType->getNumParams() > 0) {
-      auto *anchor = simplifyLocatorToAnchor(getConstraintLocator(locator));
-      if (!anchor)
+      auto anchor = simplifyLocatorToAnchor(getConstraintLocator(locator));
+      if (!anchor.is<const Expr *>())
         return false;
 
-      auto overload = findSelectedOverloadFor(anchor);
+      auto overload = findSelectedOverloadFor(getAsExpr(anchor));
       if (!(overload && overload->choice.isDecl()))
         return false;
 
@@ -2992,8 +2991,7 @@ bool ConstraintSystem::repairFailures(
     // If this is situation like `x = { ... }` where closure results in
     // `Void`, let's not suggest to call the closure, because it's most
     // likely not intended.
-    if (anchor && isa<AssignExpr>(anchor)) {
-      auto *assignment = cast<AssignExpr>(anchor);
+    if (auto *assignment = getAsExpr<AssignExpr>(anchor)) {
       if (isa<ClosureExpr>(assignment->getSrc()) && resultType->isVoid())
         return false;
     }
@@ -3037,7 +3035,7 @@ bool ConstraintSystem::repairFailures(
       // position (which doesn't require explicit `&`) decays into
       // a `Bind` of involved object types, same goes for explicit
       // `&` conversion from l-value to inout type.
-      auto kind = (isa<InOutExpr>(anchor) ||
+      auto kind = (isExpr<InOutExpr>(anchor) ||
                    (rhs->is<InOutType>() &&
                     matchKind == ConstraintKind::OperatorArgumentConversion))
                       ? ConstraintKind::Bind
@@ -3076,7 +3074,7 @@ bool ConstraintSystem::repairFailures(
     if (!anchor)
       return false;
 
-    if (auto *coercion = dyn_cast<CoerceExpr>(anchor)) {
+    if (auto *coercion = getAsExpr<CoerceExpr>(anchor)) {
       // Coercion from T.Type to T.Protocol.
       if (hasConversionOrRestriction(
               ConversionRestrictionKind::MetatypeToExistentialMetatype))
@@ -3129,7 +3127,7 @@ bool ConstraintSystem::repairFailures(
     // member lookup to the generic parameter `V` of *KeyPath<R, V>
     // type associated with key path expression, which we need to
     // fix-up here.
-    if (isa<KeyPathExpr>(anchor)) {
+    if (isExpr<KeyPathExpr>(anchor)) {
       auto *fnType = lhs->getAs<FunctionType>();
       if (fnType && fnType->getResult()->isEqual(rhs))
         return true;
@@ -3146,7 +3144,7 @@ bool ConstraintSystem::repairFailures(
       return true;
     }
 
-    if (auto *ODRE = dyn_cast<OverloadedDeclRefExpr>(anchor)) {
+    if (auto *ODRE = getAsExpr<OverloadedDeclRefExpr>(anchor)) {
       if (lhs->is<LValueType>()) {
         conversionsOrFixes.push_back(
             TreatRValueAsLValue::create(*this, getConstraintLocator(locator)));
@@ -3154,7 +3152,7 @@ bool ConstraintSystem::repairFailures(
       }
     }
 
-    if (auto *OEE = dyn_cast<OptionalEvaluationExpr>(anchor)) {
+    if (auto *OEE = getAsExpr<OptionalEvaluationExpr>(anchor)) {
       // If concrete type of the sub-expression can't be converted to the
       // type associated with optional evaluation result it could only be
       // contextual mismatch where type of the top-level expression
@@ -3170,7 +3168,7 @@ bool ConstraintSystem::repairFailures(
       }
     }
 
-    if (auto *AE = dyn_cast<AssignExpr>(anchor)) {
+    if (auto *AE = getAsExpr<AssignExpr>(anchor)) {
       if (repairByInsertingExplicitCall(lhs, rhs))
         return true;
 
@@ -3744,7 +3742,7 @@ bool ConstraintSystem::repairFailures(
     }
 
     if (lhs->is<FunctionType>() && !rhs->is<AnyFunctionType>() &&
-        isa<ClosureExpr>(anchor)) {
+        isExpr<ClosureExpr>(anchor)) {
       auto *fix = ContextualMismatch::create(*this, lhs, rhs,
                                              getConstraintLocator(locator));
       conversionsOrFixes.push_back(fix);
@@ -3782,10 +3780,10 @@ bool ConstraintSystem::repairFailures(
     // as contextual type mismatch.
     if (loc->isLastElement<LocatorPathElt::ContextualType>() ||
         loc->isLastElement<LocatorPathElt::ApplyArgToParam>()) {
-      auto *argExpr = simplifyLocatorToAnchor(loc);
-      if (argExpr && isa<ClosureExpr>(argExpr)) {
+      auto argument = simplifyLocatorToAnchor(loc);
+      if (isExpr<ClosureExpr>(argument)) {
         auto *locator =
-            getConstraintLocator(argExpr, ConstraintLocator::ClosureResult);
+            getConstraintLocator(argument, ConstraintLocator::ClosureResult);
 
         if (repairViaOptionalUnwrap(*this, lhs, rhs, matchKind,
                                     conversionsOrFixes, locator))
@@ -3797,7 +3795,7 @@ bool ConstraintSystem::repairFailures(
       }
     }
     // Handle function result coerce expression wrong type conversion.
-    if (anchor && isa<CoerceExpr>(anchor)) {
+    if (isExpr<CoerceExpr>(anchor)) {
       auto *fix =
           ContextualMismatch::create(*this, lhs, rhs, loc);
       conversionsOrFixes.push_back(fix);
@@ -3865,7 +3863,7 @@ bool ConstraintSystem::repairFailures(
   }
 
   case ConstraintLocator::TupleElement: {
-    if (anchor && (isa<ArrayExpr>(anchor) || isa<DictionaryExpr>(anchor))) {
+    if (isExpr<ArrayExpr>(anchor) || isExpr<DictionaryExpr>(anchor)) {
       // If we could record a generic arguments mismatch instead of this fix,
       // don't record a ContextualMismatch here.
       if (hasConversionOrRestriction(ConversionRestrictionKind::DeepEquality))
@@ -3952,7 +3950,7 @@ bool ConstraintSystem::repairFailures(
     return true;
 
   case ConstraintLocator::RValueAdjustment: {
-    if (!(anchor && isa<UnresolvedMemberExpr>(anchor)))
+    if (!isExpr<UnresolvedMemberExpr>(anchor))
       break;
 
     if (repairViaOptionalUnwrap(*this, lhs, rhs, matchKind, conversionsOrFixes,
@@ -5216,10 +5214,10 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
   // makes it much easier to diagnose problems like that.
   {
     SmallVector<LocatorPathElt, 4> path;
-    auto *anchor = locator.getLocatorParts(path);
+    auto anchor = locator.getLocatorParts(path);
 
     // If this is a `nil` literal, it would be a contextual failure.
-    if (auto *Nil = dyn_cast_or_null<NilLiteralExpr>(anchor)) {
+    if (auto *Nil = getAsExpr<NilLiteralExpr>(anchor)) {
       auto *fixLocator = getConstraintLocator(
           getContextualType(Nil)
               ? locator.withPathElement(LocatorPathElt::ContextualType())
@@ -5238,9 +5236,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     // of the assignment, let's ignore current the types and instead use
     // source/destination types directly to make it possible to diagnose
     // protocol compositions.
-    if (anchor && isa<AssignExpr>(anchor)) {
-      auto *assignment = cast<AssignExpr>(anchor);
-
+    if (auto *assignment = getAsExpr<AssignExpr>(anchor)) {
       // If the locator's last element points to the function result,
       // let's check whether there is a problem with function argument
       // as well, and if so, avoid producing a fix here, because
@@ -5603,7 +5599,7 @@ static bool isForKeyPathSubscript(ConstraintSystem &cs,
   if (!locator || !locator->getAnchor())
     return false;
 
-  if (auto *SE = dyn_cast<SubscriptExpr>(locator->getAnchor())) {
+  if (auto *SE = getAsExpr<SubscriptExpr>(locator->getAnchor())) {
     auto *indexExpr = dyn_cast<TupleExpr>(SE->getIndex());
     return indexExpr && indexExpr->getNumElements() == 1 &&
            indexExpr->getElementName(0) == cs.getASTContext().Id_keyPath;
@@ -5804,13 +5800,13 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
   TypeBase *favoredType = nullptr;
   if (memberName.isSimpleName(DeclBaseName::createConstructor())) {
     SmallVector<LocatorPathElt, 2> parts;
-    if (auto *anchor = memberLocator->getAnchor()) {
+    if (auto anchor = memberLocator->getAnchor()) {
       auto path = memberLocator->getPath();
       if (!path.empty())
         if (path.back().getKind() == ConstraintLocator::ConstructorMember)
           isImplicitInit = true;
 
-      if (auto applyExpr = dyn_cast<ApplyExpr>(anchor)) {
+      if (auto *applyExpr = getAsExpr<ApplyExpr>(anchor)) {
         auto argExpr = applyExpr->getArg();
         favoredType = getFavoredType(argExpr);
 
@@ -5913,7 +5909,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
       // If we're at the root of an unevaluated context, we can
       // reference instance members on the metatype.
       if (memberLocator &&
-          UnevaluatedRootExprs.count(memberLocator->getAnchor())) {
+          UnevaluatedRootExprs.count(getAsExpr(memberLocator->getAnchor()))) {
         hasInstanceMembers = true;
       }
     } else {
@@ -6304,7 +6300,7 @@ static bool isNonFinalClass(Type type) {
 static ConstraintFix *validateInitializerRef(ConstraintSystem &cs,
                                              ConstructorDecl *init,
                                              ConstraintLocator *locator) {
-  auto *anchor = locator->getAnchor();
+  auto anchor = locator->getAnchor();
   if (!anchor)
     return nullptr;
 
@@ -6323,7 +6319,7 @@ static ConstraintFix *validateInitializerRef(ConstraintSystem &cs,
   Type baseType;
 
   // Explicit initializer reference e.g. `T.init(...)` or `T.init`.
-  if (auto *UDE = dyn_cast<UnresolvedDotExpr>(anchor)) {
+  if (auto *UDE = getAsExpr<UnresolvedDotExpr>(anchor)) {
     baseExpr = UDE->getBase();
     baseType = getType(baseExpr);
     if (baseType->is<MetatypeType>()) {
@@ -6337,7 +6333,7 @@ static ConstraintFix *validateInitializerRef(ConstraintSystem &cs,
       }
     }
     // Initializer call e.g. `T(...)`
-  } else if (auto *CE = dyn_cast<CallExpr>(anchor)) {
+  } else if (auto *CE = getAsExpr<CallExpr>(anchor)) {
     baseExpr = CE->getFn();
     baseType = getType(baseExpr);
     // If this is an initializer call without explicit mention
@@ -6361,7 +6357,7 @@ static ConstraintFix *validateInitializerRef(ConstraintSystem &cs,
     }
     // Initializer reference which requires contextual base type e.g.
     // `.init(...)`.
-  } else if (auto *UME = dyn_cast<UnresolvedMemberExpr>(anchor)) {
+  } else if (auto *UME = getAsExpr<UnresolvedMemberExpr>(anchor)) {
     // We need to find type variable which represents contextual base.
     auto *baseLocator = cs.getConstraintLocator(
         UME, locatorEndsWith(locator, ConstraintLocator::ConstructorMember)
@@ -6381,7 +6377,7 @@ static ConstraintFix *validateInitializerRef(ConstraintSystem &cs,
     // which means MetatypeType has to be added after finding a type variable.
     if (locatorEndsWith(baseLocator, ConstraintLocator::MemberRefBase))
       baseType = MetatypeType::get(baseType);
-  } else if (auto *keyPathExpr = dyn_cast<KeyPathExpr>(anchor)) {
+  } else if (auto *keyPathExpr = getAsExpr<KeyPathExpr>(anchor)) {
     // Key path can't refer to initializers e.g. `\Type.init`
     return AllowInvalidRefInKeyPath::forRef(cs, init, locator);
   }
@@ -6707,8 +6703,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
 
       // If the base type is optional because we haven't chosen to force an
       // implicit optional, don't try to fix it. The IUO will be forced instead.
-      if (auto dotExpr =
-              dyn_cast_or_null<UnresolvedDotExpr>(locator->getAnchor())) {
+      if (auto dotExpr = getAsExpr<UnresolvedDotExpr>(locator->getAnchor())) {
         auto baseExpr = dotExpr->getBase();
         if (auto overload = findSelectedOverloadFor(baseExpr))
           if (overload->choice.isImplicitlyUnwrappedValueOrReturnValue())
@@ -7010,7 +7005,7 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
   };
 
   auto *closureLocator = typeVar->getImpl().getLocator();
-  auto *closure = cast<ClosureExpr>(closureLocator->getAnchor());
+  auto *closure = castToExpr<ClosureExpr>(closureLocator->getAnchor());
   auto *inferredClosureType = getClosureType(closure);
 
   auto *paramList = closure->getParameters();
@@ -7543,7 +7538,7 @@ ConstraintSystem::simplifyKeyPathConstraint(
     ConstraintLocatorBuilder locator) {
   auto subflags = getDefaultDecompositionOptions(flags);
   // The constraint ought to have been anchored on a KeyPathExpr.
-  auto keyPath = cast<KeyPathExpr>(locator.getBaseLocator()->getAnchor());
+  auto keyPath = castToExpr<KeyPathExpr>(locator.getBaseLocator()->getAnchor());
 
   keyPathTy = getFixedTypeRecursive(keyPathTy, /*want rvalue*/ true);
   bool definitelyFunctionType = false;
@@ -8164,10 +8159,10 @@ ConstraintSystem::simplifyApplicableFnConstraint(
   TypeMatchOptions subflags = getDefaultDecompositionOptions(flags);
 
   SmallVector<LocatorPathElt, 2> parts;
-  Expr *anchor = locator.getLocatorParts(parts);
-  bool isOperator = (isa<PrefixUnaryExpr>(anchor) ||
-                     isa<PostfixUnaryExpr>(anchor) ||
-                     isa<BinaryExpr>(anchor));
+  auto anchor = locator.getLocatorParts(parts);
+  bool isOperator =
+      (isExpr<PrefixUnaryExpr>(anchor) || isExpr<PostfixUnaryExpr>(anchor) ||
+       isExpr<BinaryExpr>(anchor));
 
   auto hasInOut = [&]() {
     for (auto param : func1->getParams())
@@ -9216,13 +9211,16 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix, unsigned impact) {
 
   if (isAugmentingFix(fix)) {
     Fixes.push_back(fix);
-  } else {
+  } else if (auto *anchor = getAsExpr(fix->getAnchor())) {
     // Only useful to record if no pre-existing fix in the subexpr tree.
     llvm::SmallDenseSet<Expr *> fixExprs;
-    for (auto fix : Fixes)
-      fixExprs.insert(fix->getAnchor());
+    for (auto fix : Fixes) {
+      if (auto *E = getAsExpr(fix->getAnchor()))
+        fixExprs.insert(E);
+    }
+
     bool found = false;
-    fix->getAnchor()->forEachChildExpr([&](Expr *subExpr) -> Expr * {
+    anchor->forEachChildExpr([&](Expr *subExpr) -> Expr * {
       found |= fixExprs.count(subExpr) > 0;
       return subExpr;
     });
@@ -9598,9 +9596,9 @@ ConstraintSystem::addKeyPathApplicationRootConstraint(Type root, ConstraintLocat
   // If this is a subscript with a KeyPath expression, add a constraint that
   // connects the subscript's root type to the root type of the KeyPath.
   SmallVector<LocatorPathElt, 4> path;
-  Expr *anchor = locator.getLocatorParts(path);
-  
-  auto subscript = dyn_cast_or_null<SubscriptExpr>(anchor);
+  auto anchor = locator.getLocatorParts(path);
+
+  auto subscript = getAsExpr<SubscriptExpr>(anchor);
   if (!subscript)
     return;
 
@@ -9623,8 +9621,13 @@ ConstraintSystem::addKeyPathApplicationRootConstraint(Type root, ConstraintLocat
   auto constraints = CG.gatherConstraints(
       typeVar, ConstraintGraph::GatheringKind::EquivalenceClass,
       [&keyPathExpr](Constraint *constraint) -> bool {
-        return constraint->getKind() == ConstraintKind::KeyPath &&
-               constraint->getLocator()->getAnchor() == keyPathExpr;
+        if (constraint->getKind() != ConstraintKind::KeyPath)
+          return false;
+
+        auto *locator = constraint->getLocator();
+        if (auto KPE = getAsExpr<KeyPathExpr>(locator->getAnchor()))
+          return KPE == keyPathExpr;
+        return false;
       });
 
   for (auto constraint : constraints) {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -706,10 +706,10 @@ void ConstraintSystem::Candidate::applySolutions(
 
       auto anchor = choice.getFirst()->getAnchor();
       // Anchor is not available or expression is not an overload set.
-      if (!anchor || !isa<OverloadSetRefExpr>(anchor))
+      if (!anchor || !isExpr<OverloadSetRefExpr>(anchor))
         continue;
 
-      auto OSR = cast<OverloadSetRefExpr>(anchor);
+      auto *OSR = castToExpr<OverloadSetRefExpr>(anchor);
       auto overload = choice.getSecond().choice;
       auto type = overload.getDecl()->getInterfaceType();
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -705,11 +705,11 @@ void ConstraintSystem::Candidate::applySolutions(
         continue;
 
       auto anchor = choice.getFirst()->getAnchor();
+      auto *OSR = getAsExpr<OverloadSetRefExpr>(anchor);
       // Anchor is not available or expression is not an overload set.
-      if (!anchor || !isExpr<OverloadSetRefExpr>(anchor))
+      if (!OSR)
         continue;
 
-      auto *OSR = castToExpr<OverloadSetRefExpr>(anchor);
       auto overload = choice.getSecond().choice;
       auto type = overload.getDecl()->getInterfaceType();
 

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -595,10 +595,8 @@ static void uniqueTypeVariables(SmallVectorImpl<TypeVariableType *> &typeVars) {
 bool Constraint::isExplicitConversion() const {
   assert(Kind == ConstraintKind::Disjunction);
 
-  if (auto *locator = getLocator()) {
-    if (auto anchor = locator->getAnchor())
-      return isa<CoerceExpr>(anchor);
-  }
+  if (auto *locator = getLocator())
+    return isExpr<CoerceExpr>(locator->getAnchor());
 
   return false;
 }

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -194,7 +194,7 @@ bool ConstraintLocator::isResultOfKeyPathDynamicMemberLookup() const {
 }
 
 bool ConstraintLocator::isKeyPathSubscriptComponent() const {
-  auto *anchor = getAnchor().dyn_cast<const Expr *>();
+  auto *anchor = getAsExpr(getAnchor());
   auto *KPE = dyn_cast_or_null<KeyPathExpr>(anchor);
   if (!KPE)
     return false;

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -26,9 +26,9 @@
 using namespace swift;
 using namespace constraints;
 
-void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
+void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, TypedNode anchor,
                                 ArrayRef<PathElement> path) {
-  id.AddPointer(anchor);
+  id.AddPointer(anchor.getOpaqueValue());
   id.AddInteger(path.size());
   for (auto elt : path) {
     id.AddInteger(elt.getKind());
@@ -149,7 +149,7 @@ bool LocatorPathElt::isResultOfSingleExprFunction() const {
 /// Determine whether given locator points to the subscript reference
 /// e.g. `foo[0]` or `\Foo.[0]`
 bool ConstraintLocator::isSubscriptMemberRef() const {
-  auto *anchor = getAnchor();
+  auto anchor = getAnchor();
   auto path = getPath();
 
   if (!anchor || path.empty())
@@ -159,16 +159,16 @@ bool ConstraintLocator::isSubscriptMemberRef() const {
 }
 
 bool ConstraintLocator::isKeyPathType() const {
-  auto *anchor = getAnchor();
+  auto anchor = getAnchor();
   auto path = getPath();
   // The format of locator should be `<keypath expr> -> key path type`
-  if (!anchor || !isa<KeyPathExpr>(anchor) || path.size() != 1)
+  if (!anchor || !isExpr<KeyPathExpr>(anchor) || path.size() != 1)
     return false;
   return path.back().getKind() == ConstraintLocator::KeyPathType;
 }
 
 bool ConstraintLocator::isKeyPathRoot() const {
-  auto *anchor = getAnchor();
+  auto anchor = getAnchor();
   auto path = getPath();
 
   if (!anchor || path.empty())
@@ -178,7 +178,7 @@ bool ConstraintLocator::isKeyPathRoot() const {
 }
 
 bool ConstraintLocator::isKeyPathValue() const {
-  auto *anchor = getAnchor();
+  auto anchor = getAnchor();
   auto path = getPath();
 
   if (!anchor || path.empty())
@@ -194,7 +194,7 @@ bool ConstraintLocator::isResultOfKeyPathDynamicMemberLookup() const {
 }
 
 bool ConstraintLocator::isKeyPathSubscriptComponent() const {
-  auto *anchor = getAnchor();
+  auto *anchor = getAnchor().dyn_cast<const Expr *>();
   auto *KPE = dyn_cast_or_null<KeyPathExpr>(anchor);
   if (!KPE)
     return false;
@@ -270,11 +270,11 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
   
   out << "locator@" << (void*) this << " [";
 
-  if (anchor) {
-    out << Expr::getKindName(anchor->getKind());
+  if (auto *expr = anchor.dyn_cast<const Expr *>()) {
+    out << Expr::getKindName(expr->getKind());
     if (sm) {
       out << '@';
-      anchor->getLoc().print(out, *sm);
+      expr->getLoc().print(out, *sm);
     }
   }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -170,12 +170,12 @@ void ConstraintSystem::assignFixedType(TypeVariableType *typeVar, Type type,
       if (!locator || !locator->getPath().empty())
         continue;
 
-      auto anchor = locator->getAnchor();
-      if (!(anchor && anchor.is<const Expr *>()))
+      auto *anchor = getAsExpr(locator->getAnchor());
+      if (!anchor)
         continue;
 
       literalProtocol =
-          TypeChecker::getLiteralProtocol(getASTContext(), castToExpr(anchor));
+          TypeChecker::getLiteralProtocol(getASTContext(), anchor);
       if (literalProtocol)
         break;
     }
@@ -3175,8 +3175,8 @@ bool ConstraintSystem::diagnoseAmbiguity(ArrayRef<Solution> solutions) {
 
     // If we can't resolve the locator to an anchor expression with no path,
     // we can't diagnose this well.
-    auto anchor = simplifyLocatorToAnchor(overload.locator);
-    if (!(anchor || anchor.is<const Expr *>()))
+    auto *anchor = getAsExpr(simplifyLocatorToAnchor(overload.locator));
+    if (!anchor)
       continue;
 
     auto it = indexMap.find(castToExpr(anchor));
@@ -3521,8 +3521,6 @@ TypedNode constraints::simplifyLocatorToAnchor(ConstraintLocator *locator) {
 }
 
 Expr *constraints::getArgumentExpr(TypedNode node, unsigned index) {
-  assert(node.is<const Expr *>());
-
   auto *expr = castToExpr(node);
   Expr *argExpr = nullptr;
   if (auto *AE = dyn_cast<ApplyExpr>(expr))

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4447,3 +4447,27 @@ void ConstraintSystem::maybeProduceFallbackDiagnostic(
 
   ctx.Diags.diagnose(target.getLoc(), diag::failed_to_produce_diagnostic);
 }
+
+SourceLoc constraints::getLoc(TypedNode anchor) {
+  if (auto *E = anchor.dyn_cast<const Expr *>()) {
+    return E->getLoc();
+  } else if (auto *T = anchor.dyn_cast<const TypeLoc *>()) {
+    return T->getLoc();
+  } else if (auto *V = anchor.dyn_cast<const VarDecl *>()) {
+    return V->getNameLoc();
+  } else {
+    return anchor.get<const Pattern *>()->getLoc();
+  }
+}
+
+SourceRange constraints::getSourceRange(TypedNode anchor) {
+  if (auto *E = anchor.dyn_cast<const Expr *>()) {
+    return E->getSourceRange();
+  } else if (auto *T = anchor.dyn_cast<const TypeLoc *>()) {
+    return T->getSourceRange();
+  } else if (auto *V = anchor.dyn_cast<const VarDecl *>()) {
+    return V->getSourceRange();
+  } else {
+    return anchor.get<const Pattern *>()->getSourceRange();
+  }
+}

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -171,11 +171,11 @@ void ConstraintSystem::assignFixedType(TypeVariableType *typeVar, Type type,
         continue;
 
       auto anchor = locator->getAnchor();
-      if (!anchor)
+      if (!(anchor && anchor.is<const Expr *>()))
         continue;
 
       literalProtocol =
-          TypeChecker::getLiteralProtocol(getASTContext(), anchor);
+          TypeChecker::getLiteralProtocol(getASTContext(), castToExpr(anchor));
       if (literalProtocol)
         break;
     }
@@ -364,15 +364,14 @@ getAlternativeLiteralTypes(KnownProtocolKind kind) {
 }
 
 ConstraintLocator *ConstraintSystem::getConstraintLocator(
-    Expr *anchor, ArrayRef<ConstraintLocator::PathElement> path) {
+    TypedNode anchor, ArrayRef<ConstraintLocator::PathElement> path) {
   auto summaryFlags = ConstraintLocator::getSummaryFlagsForPath(path);
   return getConstraintLocator(anchor, path, summaryFlags);
 }
 
 ConstraintLocator *ConstraintSystem::getConstraintLocator(
-                     Expr *anchor,
-                     ArrayRef<ConstraintLocator::PathElement> path,
-                     unsigned summaryFlags) {
+    TypedNode anchor, ArrayRef<ConstraintLocator::PathElement> path,
+    unsigned summaryFlags) {
   assert(summaryFlags == ConstraintLocator::getSummaryFlagsForPath(path));
 
   // Check whether a locator with this anchor + path already exists.
@@ -399,7 +398,7 @@ ConstraintLocator *ConstraintSystem::getConstraintLocator(
 
   // We have to build a new locator. Extract the paths from the builder.
   SmallVector<LocatorPathElt, 4> path;
-  Expr *anchor = builder.getLocatorParts(path);
+  auto anchor = builder.getLocatorParts(path);
   return getConstraintLocator(anchor, path, builder.getSummaryFlags());
 }
 
@@ -417,7 +416,7 @@ ConstraintLocator *ConstraintSystem::getConstraintLocator(
     const ConstraintLocatorBuilder &builder,
     ArrayRef<ConstraintLocator::PathElement> newElts) {
   SmallVector<ConstraintLocator::PathElement, 4> newPath;
-  auto *anchor = builder.getLocatorParts(newPath);
+  auto anchor = builder.getLocatorParts(newPath);
   newPath.append(newElts.begin(), newElts.end());
   return getConstraintLocator(anchor, newPath);
 }
@@ -428,8 +427,8 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
     llvm::function_ref<Type(Type)> simplifyType,
     llvm::function_ref<Optional<SelectedOverload>(ConstraintLocator *)>
         getOverloadFor) {
-  auto *anchor = locator->getAnchor();
-  assert(anchor && "Expected an anchor!");
+  auto anchor = locator->getAnchor();
+  assert(bool(anchor) && "Expected an anchor!");
 
   auto path = locator->getPath();
   {
@@ -451,7 +450,7 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
   // may have a callee given by a property or subscript component.
   if (auto componentElt =
           locator->getFirstElementAs<LocatorPathElt::KeyPathComponent>()) {
-    auto *kpExpr = cast<KeyPathExpr>(anchor);
+    auto *kpExpr = castToExpr<KeyPathExpr>(anchor);
     auto component = kpExpr->getComponents()[componentElt->getIndex()];
 
     using ComponentKind = KeyPathExpr::Component::Kind;
@@ -481,7 +480,7 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
   // Make sure we handle subscripts before looking at apply exprs. We don't
   // want to return a subscript member locator for an expression such as x[](y),
   // as its callee is not the subscript, but rather the function it returns.
-  if (isa<SubscriptExpr>(anchor))
+  if (isExpr<SubscriptExpr>(anchor))
     return getConstraintLocator(anchor, ConstraintLocator::SubscriptMember);
 
   auto getSpecialFnCalleeLoc = [&](Type fnTy) -> ConstraintLocator * {
@@ -515,7 +514,7 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
   };
 
   if (lookThroughApply) {
-    if (auto *applyExpr = dyn_cast<ApplyExpr>(anchor)) {
+    if (auto *applyExpr = getAsExpr<ApplyExpr>(anchor)) {
       auto *fnExpr = applyExpr->getFn();
 
       // Handle special cases for applies of non-function types.
@@ -525,7 +524,7 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
       // Otherwise fall through and look for locators anchored on the function
       // expr. For CallExprs, this can look through things like parens and
       // optional chaining.
-      if (auto *callExpr = dyn_cast<CallExpr>(anchor)) {
+      if (auto *callExpr = getAsExpr<CallExpr>(anchor)) {
         anchor = callExpr->getDirectCallee();
       } else {
         anchor = fnExpr;
@@ -533,14 +532,14 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
     }
   }
 
-  if (auto *UDE = dyn_cast<UnresolvedDotExpr>(anchor)) {
+  if (auto *UDE = getAsExpr<UnresolvedDotExpr>(anchor)) {
     return getConstraintLocator(
         anchor, TypeChecker::getSelfForInitDelegationInConstructor(DC, UDE)
                     ? ConstraintLocator::ConstructorMember
                     : ConstraintLocator::Member);
   }
 
-  if (auto *UME = dyn_cast<UnresolvedMemberExpr>(anchor)) {
+  if (auto *UME = getAsExpr<UnresolvedMemberExpr>(anchor)) {
     auto *calleeLoc =
         getConstraintLocator(UME, ConstraintLocator::UnresolvedMember);
 
@@ -558,7 +557,7 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
     return calleeLoc;
   }
 
-  if (isa<MemberRefExpr>(anchor))
+  if (isExpr<MemberRefExpr>(anchor))
     return getConstraintLocator(anchor, ConstraintLocator::Member);
 
   return getConstraintLocator(anchor);
@@ -976,7 +975,7 @@ void ConstraintSystem::recordOpenedTypes(
 
   // If the last path element is an archetype or associated type, ignore it.
   SmallVector<LocatorPathElt, 2> pathElts;
-  Expr *anchor = locator.getLocatorParts(pathElts);
+  auto anchor = locator.getLocatorParts(pathElts);
   if (!pathElts.empty() &&
       pathElts.back().getKind() == ConstraintLocator::GenericParameter)
     return;
@@ -1813,7 +1812,7 @@ static std::pair<bool, unsigned>
 isInvalidPartialApplication(ConstraintSystem &cs,
                             const AbstractFunctionDecl *member,
                             ConstraintLocator *locator) {
-  auto *UDE = dyn_cast_or_null<UnresolvedDotExpr>(locator->getAnchor());
+  auto *UDE = getAsExpr<UnresolvedDotExpr>(locator->getAnchor());
   if (UDE == nullptr)
     return {false,0};
 
@@ -2049,7 +2048,7 @@ void ConstraintSystem::bindOverloadType(
 
     // If this is used inside of the keypath expression, we need to make
     // sure that argument is Hashable.
-    if (isa<KeyPathExpr>(locator->getAnchor()))
+    if (isExpr<KeyPathExpr>(locator->getAnchor()))
       verifyThatArgumentIsHashable(0, argType, locator);
 
     // The resolved decl is for subscript(dynamicMember:), however the original
@@ -2171,7 +2170,7 @@ void ConstraintSystem::bindOverloadType(
       addConstraint(ConstraintKind::Equal, memberTy, leafTy, keyPathLoc);
     }
 
-    if (isa<KeyPathExpr>(locator->getAnchor()))
+    if (isExpr<KeyPathExpr>(locator->getAnchor()))
       verifyThatArgumentIsHashable(0, keyPathTy, locator);
 
     // The resolved decl is for subscript(dynamicMember:), however the
@@ -2247,7 +2246,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
           return nullptr;
         }
       };
-      auto anchor = locator ? locator->getAnchor() : nullptr;
+      auto *anchor = locator ? getAsExpr(locator->getAnchor()) : nullptr;
       auto base = getDotBase(anchor);
       std::tie(openedFullType, refType)
         = getTypeOfMemberReference(baseTy, choice.getDecl(), useDC,
@@ -2641,7 +2640,7 @@ static void diagnoseOperatorAmbiguity(ConstraintSystem &cs,
                                       ArrayRef<Solution> solutions,
                                       ConstraintLocator *locator) {
   auto &DE = cs.getASTContext().Diags;
-  auto *anchor = locator->getAnchor();
+  auto *anchor = castToExpr(locator->getAnchor());
 
   auto *applyExpr = dyn_cast_or_null<ApplyExpr>(cs.getParentExpr(anchor));
   if (!applyExpr)
@@ -2809,7 +2808,7 @@ static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
       if (auto *reprGP = repr->getImpl().getGenericParameter())
         GP = reprGP;
 
-      genericParams[repr] = {GP, locator->getAnchor()->getLoc()};
+      genericParams[repr] = {GP, getLoc(locator->getAnchor())};
     }
   }
 
@@ -2976,16 +2975,16 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
       [&](const auto &overloadDiff) {
         return llvm::all_of(aggregatedFixes, [&](const auto &aggregatedFix) {
           auto *locator = aggregatedFix.first.first;
-          auto *anchor = locator->getAnchor();
+          auto anchor = locator->getAnchor();
           // Assignment failures are all about the source expression, because
           // they treat destination as a contextual type.
-          if (auto *assignExpr = dyn_cast<AssignExpr>(anchor))
+          if (auto *assignExpr = getAsExpr<AssignExpr>(anchor))
             anchor = assignExpr->getSrc();
 
-          if (auto *callExpr = dyn_cast<CallExpr>(anchor)) {
+          if (auto *callExpr = getAsExpr<CallExpr>(anchor)) {
             if (!isa<TypeExpr>(callExpr->getDirectCallee()))
               anchor = callExpr->getDirectCallee();
-          } else if (auto *applyExpr = dyn_cast<ApplyExpr>(anchor)) {
+          } else if (auto *applyExpr = getAsExpr<ApplyExpr>(anchor)) {
             anchor = applyExpr->getFn();
           }
 
@@ -3015,8 +3014,8 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
   {
     DiagnosticTransaction transaction(getASTContext().Diags);
 
-    auto *commonAnchor = commonCalleeLocator->getAnchor();
-    if (auto *callExpr = dyn_cast<CallExpr>(commonAnchor))
+    auto commonAnchor = commonCalleeLocator->getAnchor();
+    if (auto *callExpr = getAsExpr<CallExpr>(commonAnchor))
       commonAnchor = callExpr->getDirectCallee();
     auto &DE = getASTContext().Diags;
     auto name = decl->getFullName();
@@ -3024,9 +3023,9 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
     // Emit an error message for the ambiguity.
     if (aggregatedFixes.size() == 1 &&
         aggregatedFixes.front().first.first->isForContextualType()) {
-      auto *anchor = aggregatedFixes.front().first.first->getAnchor();
+      auto anchor = aggregatedFixes.front().first.first->getAnchor();
       auto baseName = name.getBaseName();
-      DE.diagnose(commonAnchor->getLoc(), diag::no_candidates_match_result_type,
+      DE.diagnose(getLoc(commonAnchor), diag::no_candidates_match_result_type,
                   baseName.userFacingName(), getContextualType(anchor));
     } else if (name.isOperator()) {
       diagnoseOperatorAmbiguity(*this, name.getBaseIdentifier(), solutions,
@@ -3038,9 +3037,8 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
             return argInfo.first->getAnchor() == commonAnchor;
           });
 
-      DE.diagnose(commonAnchor->getLoc(),
-                  diag::no_overloads_match_exactly_in_call,
-                  isApplication,
+      DE.diagnose(getLoc(commonAnchor),
+                  diag::no_overloads_match_exactly_in_call, isApplication,
                   decl->getDescriptiveKind(), name.isSpecial(),
                   name.getBaseName());
     }
@@ -3074,7 +3072,7 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
         // Emit a general "found candidate" note
         if (decl->getLoc().isInvalid()) {
           if (candidateTypes.insert(type->getCanonicalType()).second)
-            DE.diagnose(commonAnchor->getLoc(), diag::found_candidate_type, type);
+            DE.diagnose(getLoc(commonAnchor), diag::found_candidate_type, type);
         } else {
           DE.diagnose(decl->getLoc(), diag::found_candidate);
         }
@@ -3177,15 +3175,16 @@ bool ConstraintSystem::diagnoseAmbiguity(ArrayRef<Solution> solutions) {
 
     // If we can't resolve the locator to an anchor expression with no path,
     // we can't diagnose this well.
-    auto *anchor = simplifyLocatorToAnchor(overload.locator);
-    if (!anchor)
+    auto anchor = simplifyLocatorToAnchor(overload.locator);
+    if (!(anchor || anchor.is<const Expr *>()))
       continue;
-    auto it = indexMap.find(anchor);
+
+    auto it = indexMap.find(castToExpr(anchor));
     if (it == indexMap.end())
       continue;
     unsigned index = it->second;
 
-    auto optDepth = getExprDepth(anchor);
+    auto optDepth = getExprDepth(castToExpr(anchor));
     if (!optDepth)
       continue;
     unsigned depth = *optDepth;
@@ -3224,7 +3223,7 @@ bool ConstraintSystem::diagnoseAmbiguity(ArrayRef<Solution> solutions) {
 
     // Emit the ambiguity diagnostic.
     auto &DE = getASTContext().Diags;
-    DE.diagnose(anchor->getLoc(),
+    DE.diagnose(getLoc(anchor),
                 name.isOperator() ? diag::ambiguous_operator_ref
                                   : diag::ambiguous_decl_ref,
                 name);
@@ -3292,7 +3291,7 @@ constraints::simplifyLocator(ConstraintSystem &cs, ConstraintLocator *locator,
   return cs.getConstraintLocator(anchor, path);
 }
 
-void constraints::simplifyLocator(Expr *&anchor,
+void constraints::simplifyLocator(TypedNode &anchor,
                                   ArrayRef<LocatorPathElt> &path,
                                   SourceRange &range) {
   range = SourceRange();
@@ -3301,25 +3300,25 @@ void constraints::simplifyLocator(Expr *&anchor,
     switch (path[0].getKind()) {
     case ConstraintLocator::ApplyArgument: {
       // Extract application argument.
-      if (auto applyExpr = dyn_cast<ApplyExpr>(anchor)) {
+      if (auto applyExpr = getAsExpr<ApplyExpr>(anchor)) {
         anchor = applyExpr->getArg();
         path = path.slice(1);
         continue;
       }
 
-      if (auto subscriptExpr = dyn_cast<SubscriptExpr>(anchor)) {
+      if (auto subscriptExpr = getAsExpr<SubscriptExpr>(anchor)) {
         anchor = subscriptExpr->getIndex();
         path = path.slice(1);
         continue;
       }
 
-      if (auto objectLiteralExpr = dyn_cast<ObjectLiteralExpr>(anchor)) {
+      if (auto objectLiteralExpr = getAsExpr<ObjectLiteralExpr>(anchor)) {
         anchor = objectLiteralExpr->getArg();
         path = path.slice(1);
         continue;
       }
 
-      if (auto *UME = dyn_cast<UnresolvedMemberExpr>(anchor)) {
+      if (auto *UME = getAsExpr<UnresolvedMemberExpr>(anchor)) {
         anchor = UME->getArgument();
         path = path.slice(1);
         continue;
@@ -3334,21 +3333,21 @@ void constraints::simplifyLocator(Expr *&anchor,
 
     case ConstraintLocator::ApplyFunction:
       // Extract application function.
-      if (auto applyExpr = dyn_cast<ApplyExpr>(anchor)) {
+      if (auto applyExpr = getAsExpr<ApplyExpr>(anchor)) {
         anchor = applyExpr->getFn();
         path = path.slice(1);
         continue;
       }
 
       // The subscript itself is the function.
-      if (auto subscriptExpr = dyn_cast<SubscriptExpr>(anchor)) {
+      if (auto subscriptExpr = getAsExpr<SubscriptExpr>(anchor)) {
         anchor = subscriptExpr;
         path = path.slice(1);
         continue;
       }
 
       // The unresolved member itself is the function.
-      if (auto unresolvedMember = dyn_cast<UnresolvedMemberExpr>(anchor)) {
+      if (auto unresolvedMember = getAsExpr<UnresolvedMemberExpr>(anchor)) {
         if (unresolvedMember->getArgument()) {
           anchor = unresolvedMember;
           path = path.slice(1);
@@ -3374,7 +3373,7 @@ void constraints::simplifyLocator(Expr *&anchor,
       // Extract tuple element.
       auto elt = path[0].castTo<LocatorPathElt::AnyTupleElement>();
       unsigned index = elt.getIndex();
-      if (auto tupleExpr = dyn_cast<TupleExpr>(anchor)) {
+      if (auto tupleExpr = getAsExpr<TupleExpr>(anchor)) {
         if (index < tupleExpr->getNumElements()) {
           anchor = tupleExpr->getElement(index);
           path = path.slice(1);
@@ -3382,7 +3381,7 @@ void constraints::simplifyLocator(Expr *&anchor,
         }
       }
 
-      if (auto *CE = dyn_cast<CollectionExpr>(anchor)) {
+      if (auto *CE = getAsExpr<CollectionExpr>(anchor)) {
         if (index < CE->getNumElements()) {
           anchor = CE->getElement(index);
           path = path.slice(1);
@@ -3395,7 +3394,7 @@ void constraints::simplifyLocator(Expr *&anchor,
     case ConstraintLocator::ApplyArgToParam: {
       auto elt = path[0].castTo<LocatorPathElt::ApplyArgToParam>();
       // Extract tuple element.
-      if (auto tupleExpr = dyn_cast<TupleExpr>(anchor)) {
+      if (auto tupleExpr = getAsExpr<TupleExpr>(anchor)) {
         unsigned index = elt.getArgIdx();
         if (index < tupleExpr->getNumElements()) {
           anchor = tupleExpr->getElement(index);
@@ -3405,7 +3404,7 @@ void constraints::simplifyLocator(Expr *&anchor,
       }
 
       // Extract subexpression in parentheses.
-      if (auto parenExpr = dyn_cast<ParenExpr>(anchor)) {
+      if (auto parenExpr = getAsExpr<ParenExpr>(anchor)) {
         // This simplication request could be for a synthesized argument.
         if (elt.getArgIdx() == 0) {
           anchor = parenExpr->getSubExpr();
@@ -3416,7 +3415,7 @@ void constraints::simplifyLocator(Expr *&anchor,
       break;
     }
     case ConstraintLocator::ConstructorMember:
-      if (auto typeExpr = dyn_cast<TypeExpr>(anchor)) {
+      if (auto typeExpr = getAsExpr<TypeExpr>(anchor)) {
         // This is really an implicit 'init' MemberRef, so point at the base,
         // i.e. the TypeExpr.
         range = SourceRange();
@@ -3428,7 +3427,7 @@ void constraints::simplifyLocator(Expr *&anchor,
 
     case ConstraintLocator::Member:
     case ConstraintLocator::MemberRefBase:
-      if (auto UDE = dyn_cast<UnresolvedDotExpr>(anchor)) {
+      if (auto UDE = getAsExpr<UnresolvedDotExpr>(anchor)) {
         range = UDE->getNameLoc().getSourceRange();
         anchor = UDE->getBase();
         path = path.slice(1);
@@ -3437,7 +3436,7 @@ void constraints::simplifyLocator(Expr *&anchor,
       break;
 
     case ConstraintLocator::SubscriptMember:
-      if (isa<SubscriptExpr>(anchor)) {
+      if (isExpr<SubscriptExpr>(anchor)) {
         path = path.slice(1);
         continue;
       }
@@ -3445,7 +3444,7 @@ void constraints::simplifyLocator(Expr *&anchor,
 
     case ConstraintLocator::ClosureBody:
     case ConstraintLocator::ClosureResult:
-      if (auto CE = dyn_cast<ClosureExpr>(anchor)) {
+      if (auto CE = getAsExpr<ClosureExpr>(anchor)) {
         if (CE->hasSingleExpressionBody()) {
           anchor = CE->getSingleExpressionBody();
           path = path.slice(1);
@@ -3468,7 +3467,7 @@ void constraints::simplifyLocator(Expr *&anchor,
           path[1].getKind() != ConstraintLocator::ApplyArgument)
         break;
 
-      if (auto *kpe = dyn_cast<KeyPathExpr>(anchor)) {
+      if (auto *kpe = getAsExpr<KeyPathExpr>(anchor)) {
         auto component = kpe->getComponents()[elt.getIndex()];
         auto indexExpr = component.getIndexExpr();
         assert(indexExpr && "Trying to apply a component without an index?");
@@ -3480,14 +3479,14 @@ void constraints::simplifyLocator(Expr *&anchor,
     }
 
     case ConstraintLocator::Condition: {
-      anchor = cast<IfExpr>(anchor)->getCondExpr();
+      anchor = castToExpr<IfExpr>(anchor)->getCondExpr();
       path = path.slice(1);
       continue;
     }
 
     case ConstraintLocator::TernaryBranch: {
       auto branch = path[0].castTo<LocatorPathElt::TernaryBranch>();
-      auto *ifExpr = cast<IfExpr>(anchor);
+      auto *ifExpr = castToExpr<IfExpr>(anchor);
 
       anchor = branch.forThen() ? ifExpr->getThenExpr() : ifExpr->getElseExpr();
       path = path.slice(1);
@@ -3504,13 +3503,13 @@ void constraints::simplifyLocator(Expr *&anchor,
   }
 }
 
-Expr *constraints::simplifyLocatorToAnchor(ConstraintLocator *locator) {
+TypedNode constraints::simplifyLocatorToAnchor(ConstraintLocator *locator) {
   if (!locator)
     return nullptr;
 
-  auto *anchor = locator->getAnchor();
+  auto anchor = locator->getAnchor();
   if (!anchor)
-    return nullptr;
+    return {};
 
   SourceRange range;
   auto path = locator->getPath();
@@ -3521,7 +3520,10 @@ Expr *constraints::simplifyLocatorToAnchor(ConstraintLocator *locator) {
   return path.empty() ? anchor : nullptr;
 }
 
-Expr *constraints::getArgumentExpr(Expr *expr, unsigned index) {
+Expr *constraints::getArgumentExpr(TypedNode node, unsigned index) {
+  assert(node.is<const Expr *>());
+
+  auto *expr = castToExpr(node);
   Expr *argExpr = nullptr;
   if (auto *AE = dyn_cast<ApplyExpr>(expr))
     argExpr = AE->getArg();
@@ -3660,19 +3662,19 @@ void ConstraintSystem::generateConstraints(
 
 ConstraintLocator *
 ConstraintSystem::getArgumentInfoLocator(ConstraintLocator *locator) {
-  auto *anchor = locator->getAnchor();
+  auto anchor = locator->getAnchor();
   if (!anchor)
     return nullptr;
 
   // Applies and unresolved member exprs can have callee locators that are
   // dependent on the type of their function, which may not have been resolved
   // yet. Therefore we need to handle them specially.
-  if (auto *apply = dyn_cast<ApplyExpr>(anchor)) {
+  if (auto *apply = getAsExpr<ApplyExpr>(anchor)) {
     auto *fnExpr = getArgumentLabelTargetExpr(apply->getFn());
     return getConstraintLocator(fnExpr);
   }
 
-  if (auto *UME = dyn_cast<UnresolvedMemberExpr>(anchor))
+  if (auto *UME = getAsExpr<UnresolvedMemberExpr>(anchor))
     return getConstraintLocator(UME);
 
   auto path = locator->getPath();
@@ -3760,7 +3762,7 @@ Type Solution::resolveInterfaceType(Type type) const {
 
 Optional<FunctionArgApplyInfo>
 Solution::getFunctionArgApplyInfo(ConstraintLocator *locator) const {
-  auto *anchor = locator->getAnchor();
+  auto anchor = locator->getAnchor();
   auto path = locator->getPath();
 
   // Look for the apply-arg-to-param element in the locator's path. We may
@@ -3781,7 +3783,7 @@ Solution::getFunctionArgApplyInfo(ConstraintLocator *locator) const {
   auto argPath = path.drop_back(iter - path.rbegin());
   auto *argLocator = getConstraintLocator(anchor, argPath);
 
-  auto *argExpr = simplifyLocatorToAnchor(argLocator);
+  auto *argExpr = castToExpr(simplifyLocatorToAnchor(argLocator));
 
   // If we were unable to simplify down to the argument expression, we don't
   // know what this is.
@@ -3799,7 +3801,7 @@ Solution::getFunctionArgApplyInfo(ConstraintLocator *locator) const {
   } else {
     // If we didn't resolve an overload for the callee, we should be dealing
     // with a call of an arbitrary function expr.
-    auto *call = cast<CallExpr>(anchor);
+    auto *call = castToExpr<CallExpr>(anchor);
     assert(!shouldHaveDirectCalleeOverload(call) &&
              "Should we have resolved a callee for this?");
     rawFnType = getType(call->getFn());
@@ -3900,7 +3902,7 @@ bool constraints::isOperatorArgument(ConstraintLocator *locator,
   if (!locator->findLast<LocatorPathElt::ApplyArgToParam>())
     return false;
 
-  if (auto *AE = dyn_cast_or_null<ApplyExpr>(locator->getAnchor())) {
+  if (auto *AE = getAsExpr<ApplyExpr>(locator->getAnchor())) {
     if (isa<PrefixUnaryExpr>(AE) || isa<BinaryExpr>(AE) ||
         isa<PostfixUnaryExpr>(AE))
       return expectedOperator.empty() ||
@@ -3912,7 +3914,7 @@ bool constraints::isOperatorArgument(ConstraintLocator *locator,
 
 bool constraints::isArgumentOfPatternMatchingOperator(
     ConstraintLocator *locator) {
-  auto *binaryOp = dyn_cast_or_null<BinaryExpr>(locator->getAnchor());
+  auto *binaryOp = getAsExpr<BinaryExpr>(locator->getAnchor());
   if (!(binaryOp && binaryOp->isImplicit()))
     return false;
   return isPatternMatchingOperator(binaryOp->getFn());
@@ -3953,7 +3955,8 @@ ConstraintSystem::isConversionEphemeral(ConversionRestrictionKind conversion,
 
     SourceRange range;
     auto *argLoc = simplifyLocator(*this, getConstraintLocator(locator), range);
-    auto *subExpr = argLoc->getAnchor()->getSemanticsProvidingExpr();
+    auto *subExpr =
+        castToExpr(argLoc->getAnchor())->getSemanticsProvidingExpr();
 
     // Look through an InOutExpr if we have one. This is usually the case, but
     // might not be if e.g we're applying an 'add missing &' fix.
@@ -4422,8 +4425,8 @@ bool ConstraintSystem::isDeclUnavailable(const Decl *D,
   SourceLoc loc;
 
   if (locator) {
-    if (auto *anchor = locator->getAnchor())
-      loc = anchor->getLoc();
+    if (auto anchor = locator->getAnchor())
+      loc = getLoc(anchor);
   }
 
   // If not, let's check contextual unavailability.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -455,6 +455,27 @@ public:
 
 namespace constraints {
 
+template <typename T = Expr> T *castToExpr(TypedNode node) {
+  return cast<T>(const_cast<Expr *>(node.get<const Expr *>()));
+}
+
+template <typename T = Expr> T *getAsExpr(TypedNode node) {
+  if (const auto *E = node.dyn_cast<const Expr *>())
+    return dyn_cast_or_null<T>(const_cast<Expr *>(E));
+  return nullptr;
+}
+
+template <typename T> bool isExpr(TypedNode node) {
+  if (node.isNull() || !node.is<const Expr *>())
+    return false;
+
+  auto *E = node.get<const Expr *>();
+  return isa<T>(E);
+}
+
+SourceLoc getLoc(TypedNode node);
+SourceRange getSourceRange(TypedNode node);
+
 /// The result of comparing two constraint systems that are a solutions
 /// to the given set of constraints.
 enum class SolutionCompareResult {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -917,7 +917,7 @@ public:
   llvm::MapVector<TypedNode, Type> nodeTypes;
 
   /// Contextual types introduced by this solution.
-  std::vector<std::pair<const Expr *, ContextualTypeInfo>> contextualTypes;
+  std::vector<std::pair<TypedNode, ContextualTypeInfo>> contextualTypes;
 
   /// Maps AST nodes to their solution application targets.
   llvm::MapVector<SolutionApplicationTargetsKey, SolutionApplicationTarget>
@@ -1719,7 +1719,7 @@ private:
 
   /// Contextual type information for expressions that are part of this
   /// constraint system.
-  llvm::MapVector<const Expr *, ContextualTypeInfo> contextualTypes;
+  llvm::MapVector<TypedNode, ContextualTypeInfo> contextualTypes;
 
   /// Information about each case label item tracked by the constraint system.
   llvm::SmallMapVector<const CaseLabelItem *, CaseLabelItemInfo, 4>
@@ -2527,37 +2527,37 @@ public:
     return E;
   }
 
-  void setContextualType(
-      const Expr *expr, TypeLoc T, ContextualTypePurpose purpose) {
-    assert(expr != nullptr && "Expected non-null expression!");
-    assert(contextualTypes.count(expr) == 0 &&
+  void setContextualType(TypedNode node, TypeLoc T,
+                         ContextualTypePurpose purpose) {
+    assert(bool(node) && "Expected non-null expression!");
+    assert(contextualTypes.count(node) == 0 &&
            "Already set this contextual type");
-    contextualTypes[expr] = { T, purpose };
+    contextualTypes[node] = {T, purpose};
   }
 
-  Optional<ContextualTypeInfo> getContextualTypeInfo(const Expr *expr) const {
-    auto known = contextualTypes.find(expr);
+  Optional<ContextualTypeInfo> getContextualTypeInfo(TypedNode node) const {
+    auto known = contextualTypes.find(node);
     if (known == contextualTypes.end())
       return None;
     return known->second;
   }
 
-  Type getContextualType(const Expr *expr) const {
-    auto result = getContextualTypeInfo(expr);
+  Type getContextualType(TypedNode node) const {
+    auto result = getContextualTypeInfo(node);
     if (result)
       return result->typeLoc.getType();
     return Type();
   }
 
-  TypeLoc getContextualTypeLoc(const Expr *expr) const {
-    auto result = getContextualTypeInfo(expr);
+  TypeLoc getContextualTypeLoc(TypedNode node) const {
+    auto result = getContextualTypeInfo(node);
     if (result)
       return result->typeLoc;
     return TypeLoc();
   }
 
-  ContextualTypePurpose getContextualTypePurpose(const Expr *expr) const {
-    auto result = getContextualTypeInfo(expr);
+  ContextualTypePurpose getContextualTypePurpose(TypedNode node) const {
+    auto result = getContextualTypeInfo(node);
     if (result)
       return result->purpose;
     return CTP_Unused;

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -593,7 +593,7 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
   using namespace constraints;
   auto dc = var->getInnermostDeclContext();
   ConstraintSystem cs(dc, None);
-  auto emptyLocator = cs.getConstraintLocator(nullptr);
+  auto emptyLocator = cs.getConstraintLocator({});
   
   auto wrapperAttrs = var->getAttachedPropertyWrappers();
   Type valueMemberType;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -943,8 +943,8 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
     // Open up the witness type.
     witnessType = witness->getInterfaceType();
     // FIXME: witness as a base locator?
-    locator = cs->getConstraintLocator(nullptr);
-    witnessLocator = cs->getConstraintLocator(static_cast<Expr *>(nullptr),
+    locator = cs->getConstraintLocator({});
+    witnessLocator = cs->getConstraintLocator({},
                                               LocatorPathElt::Witness(witness));
     if (witness->getDeclContext()->isTypeContext()) {
       std::tie(openedFullWitnessType, openWitnessType) 


### PR DESCRIPTION
This is a final round of refactoring which aims to enable locators to be anchored on patterns/decls/types etc.

* Use `TypedNode` as `ConstraintLocator` anchor
* Elevate `TypedNode` access helpers up to the namespace
* Refactor `ConstraintSystem::getConstraintLocator` variants to use `TypedNode`
* Refactor `ConstraintSystem::getContextualType` and its variants to use `TypedNode`
* Adjust remaining places in `FailureDiagnostic` to not assume that anchor is `Expr *`

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
