### PR TITLE
AST: Fast path for matching can. signatures in requirementsNotSatisfiedBy

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -366,7 +366,7 @@ public:
   /// \param otherSig Another generic signature whose generic parameters are
   /// equivalent to or a subset of the generic parameters in this signature.
   SmallVector<Requirement, 4> requirementsNotSatisfiedBy(
-                                               GenericSignature otherSig);
+                                  GenericSignature otherSig) const;
 
   /// Return the canonical version of the given type under this generic
   /// signature.

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -592,7 +592,7 @@ bool GenericSignatureImpl::isRequirementSatisfied(Requirement requirement) {
 }
 
 SmallVector<Requirement, 4> GenericSignatureImpl::requirementsNotSatisfiedBy(
-                                                 GenericSignature otherSig) {
+                                            GenericSignature otherSig) const {
   SmallVector<Requirement, 4> result;
 
   // If the signatures match by pointer, all requirements are satisfied.

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -595,15 +595,19 @@ SmallVector<Requirement, 4> GenericSignatureImpl::requirementsNotSatisfiedBy(
                                                  GenericSignature otherSig) {
   SmallVector<Requirement, 4> result;
 
-  // If the signatures are the same, all requirements are satisfied.
+  // If the signatures match by pointer, all requirements are satisfied.
   if (otherSig.getPointer() == this) return result;
 
   // If there is no other signature, no requirements are satisfied.
   if (!otherSig){
-    result.insert(result.end(),
-                  getRequirements().begin(), getRequirements().end());
+    const auto reqs = getRequirements();
+    result.append(reqs.begin(), reqs.end());
     return result;
   }
+
+  // If the canonical signatures are equal, all requirements are satisfied.
+  if (getCanonicalSignature() == otherSig->getCanonicalSignature())
+    return result;
 
   // Find the requirements that aren't satisfied.
   for (const auto &req : getRequirements()) {


### PR DESCRIPTION
Let's indeed isolate this change (suggested in #30700, extracted from #30712).

@CodaFi If you may
