### PR TITLE
Start Killing Off Usages of TypeChecker::validateType

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -497,9 +497,7 @@ public:
   bool isImplicit() const {
     return Bits.Expr.Implicit;
   }
-  void setImplicit(bool Implicit = true) {
-    Bits.Expr.Implicit = Implicit;
-  }
+  void setImplicit(bool Implicit = true);
 
   /// Retrieves the declaration that is being referenced by this
   /// expression, if any.
@@ -1337,11 +1335,10 @@ public:
 ///
 /// The type of this expression is always \c MetaTypeType.
 class TypeExpr : public Expr {
-  TypeLoc Info;
-  TypeExpr(Type Ty);
+  TypeRepr *Repr;
 public:
   // Create a TypeExpr with location information.
-  TypeExpr(TypeLoc Ty);
+  TypeExpr(TypeRepr *Ty);
 
   // The type of a TypeExpr is always a metatype type.  Return the instance
   // type, ErrorType if an error, or null if not set yet.
@@ -1353,9 +1350,7 @@ public:
                        }) const;
 
   // Create an implicit TypeExpr, which has no location information.
-  static TypeExpr *createImplicit(Type Ty, ASTContext &C) {
-    return new (C) TypeExpr(Ty);
-  }
+  static TypeExpr *createImplicit(Type Ty, ASTContext &C);
 
   // Create an implicit TypeExpr, with location information even though it
   // shouldn't have one.  This is presently used to work around other location
@@ -1389,13 +1384,11 @@ public:
                                             SourceRange AngleLocs,
                                             ASTContext &C);
 
-  TypeLoc &getTypeLoc() { return Info; }
-  TypeLoc getTypeLoc() const { return Info; }
-  TypeRepr *getTypeRepr() const { return Info.getTypeRepr(); }
+  TypeRepr *getTypeRepr() const { return Repr; }
   // NOTE: TypeExpr::getType() returns the type of the expr node, which is the
   // metatype of what is stored as an operand type.
   
-  SourceRange getSourceRange() const { return Info.getSourceRange(); }
+  SourceRange getSourceRange() const { return TypeLoc(Repr).getSourceRange(); }
   // TODO: optimize getStartLoc() and getEndLoc() when TypeLoc allows it.
 
   static bool classof(const Expr *E) {

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4490,8 +4490,7 @@ class ExplicitCastExpr : public Expr {
   TypeLoc CastTy;
 
 protected:
-  ExplicitCastExpr(ExprKind kind, Expr *sub, SourceLoc AsLoc, TypeLoc castTy,
-                   Type resultTy)
+  ExplicitCastExpr(ExprKind kind, Expr *sub, SourceLoc AsLoc, TypeLoc castTy)
     : Expr(kind, /*Implicit=*/false), SubExpr(sub), AsLoc(AsLoc), CastTy(castTy)
   {}
 
@@ -4547,8 +4546,8 @@ StringRef getCheckedCastKindName(CheckedCastKind kind);
 class CheckedCastExpr : public ExplicitCastExpr {
 public:
   CheckedCastExpr(ExprKind kind,
-                  Expr *sub, SourceLoc asLoc, TypeLoc castTy, Type resultTy)
-    : ExplicitCastExpr(kind, sub, asLoc, castTy, resultTy)
+                  Expr *sub, SourceLoc asLoc, TypeLoc castTy)
+    : ExplicitCastExpr(kind, sub, asLoc, castTy)
   {
     Bits.CheckedCastExpr.CastKind = unsigned(CheckedCastKind::Unresolved);
   }
@@ -4583,7 +4582,7 @@ public:
   ForcedCheckedCastExpr(Expr *sub, SourceLoc asLoc, SourceLoc exclaimLoc,
                         TypeLoc type)
     : CheckedCastExpr(ExprKind::ForcedCheckedCast,
-                      sub, asLoc, type, type.getType()),
+                      sub, asLoc, type),
       ExclaimLoc(exclaimLoc)
   {
   }
@@ -4612,7 +4611,7 @@ public:
   ConditionalCheckedCastExpr(Expr *sub, SourceLoc asLoc, SourceLoc questionLoc,
                              TypeLoc type)
     : CheckedCastExpr(ExprKind::ConditionalCheckedCast,
-                      sub, asLoc, type, type.getType()),
+                      sub, asLoc, type),
       QuestionLoc(questionLoc)
   { }
   
@@ -4637,8 +4636,7 @@ public:
 class IsExpr : public CheckedCastExpr {
 public:
   IsExpr(Expr *sub, SourceLoc isLoc, TypeLoc type)
-    : CheckedCastExpr(ExprKind::Is,
-                      sub, isLoc, type, Type())
+    : CheckedCastExpr(ExprKind::Is, sub, isLoc, type)
   {}
   
   IsExpr(SourceLoc isLoc, TypeLoc type)
@@ -4661,7 +4659,7 @@ class CoerceExpr : public ExplicitCastExpr {
 
 public:
   CoerceExpr(Expr *sub, SourceLoc asLoc, TypeLoc type)
-    : ExplicitCastExpr(ExprKind::Coerce, sub, asLoc, type, type.getType())
+    : ExplicitCastExpr(ExprKind::Coerce, sub, asLoc, type)
   { }
 
   CoerceExpr(SourceLoc asLoc, TypeLoc type)
@@ -4671,7 +4669,7 @@ public:
 private:
   CoerceExpr(SourceRange initRange, Expr *literal, TypeLoc type)
     : ExplicitCastExpr(ExprKind::Coerce, literal, initRange.Start,
-                       type, type.getType()), InitRangeEnd(initRange.End)
+                       type), InitRangeEnd(initRange.End)
   { setImplicit(); }
 
 public:

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -54,6 +54,8 @@ struct TypeWitnessAndDecl;
 class ValueDecl;
 enum class OpaqueReadOwnership: uint8_t;
 class StorageImplInfo;
+class TypeResolution;
+class TypeRepr;
 
 /// Display a nominal type or extension thereof.
 void simple_display(
@@ -2400,6 +2402,22 @@ public:
   // Cached.
   bool isCached() const { return true; }
 };
+
+class ValidateTypeRequest
+    : public SimpleRequest<ValidateTypeRequest,
+                           Type(TypeResolution *, TypeRepr *),
+                           RequestFlags::Uncached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  Type evaluate(Evaluator &evaluator, TypeResolution *, TypeRepr *) const;
+};
+
+void simple_display(llvm::raw_ostream &out, const TypeResolution *);
 
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2415,6 +2415,10 @@ private:
 
   // Evaluation.
   Type evaluate(Evaluator &evaluator, TypeResolution *, TypeRepr *) const;
+
+public:
+  // Cycle handling.
+  void noteCycleStep(DiagnosticEngine &diags) const;
 };
 
 void simple_display(llvm::raw_ostream &out, const TypeResolution *);

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -258,3 +258,6 @@ SWIFT_REQUEST(TypeChecker, LookupAllConformancesInContextRequest,
               Uncached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SimpleDidSetRequest, 
               bool(AccessorDecl *), Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, ValidateTypeRequest,
+              Type (TypeResolution *, TypeRepr *),
+              Uncached, NoLocationInfo)

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -1202,6 +1202,10 @@ inline bool TypeRepr::isSimple() const {
   llvm_unreachable("bad TypeRepr kind");
 }
 
+inline SourceLoc extractNearestSourceLoc(const TypeRepr *repr) {
+  return repr->getLoc();
+}
+
 } // end namespace swift
 
 namespace llvm {

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -481,8 +481,9 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   Expr *visitDiscardAssignmentExpr(DiscardAssignmentExpr *E) { return E; }
   Expr *visitTypeExpr(TypeExpr *E) {
     if (!E->isImplicit())
-      if (doIt(E->getTypeLoc()))
-        return nullptr;
+      if (auto *typerepr = E->getTypeRepr())
+        if (doIt(typerepr))
+          return nullptr;
 
     return E;
   }

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1514,3 +1514,12 @@ void swift::simple_display(llvm::raw_ostream &out,
                            const TypeResolution *resolution) {
   out << "resolving types";
 }
+
+//----------------------------------------------------------------------------//
+// ValidateTypeRequest computation.
+//----------------------------------------------------------------------------//
+
+void ValidateTypeRequest::noteCycleStep(DiagnosticEngine &diags) const {
+  // Clients of this request are better at noting cycle steps. Just suppress
+  // this note.
+}

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1509,3 +1509,8 @@ void swift::simple_display(llvm::raw_ostream &out,
   out << "implicit import of ";
   simple_display(out, import.Module);
 }
+
+void swift::simple_display(llvm::raw_ostream &out,
+                           const TypeResolution *resolution) {
+  out << "resolving types";
+}

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -375,8 +375,8 @@ static void collectPossibleCalleesByQualifiedLookup(
   // Re-typecheck TypeExpr so it's typechecked without the arguments which may
   // affects the inference of the generic arguments.
   if (TypeExpr *tyExpr = dyn_cast<TypeExpr>(baseExpr)) {
-    tyExpr->setType(nullptr);
-    tyExpr->getTypeLoc().setType(nullptr);
+    if (!tyExpr->isImplicit())
+      tyExpr->setType(nullptr);
   }
 
   auto baseTyOpt = getTypeOfCompletionContextExpr(

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -395,7 +395,7 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
       ParserResult<TypeRepr> ty = parseType();
       if (ty.isNonNull())
         return makeParserResult(
-            new (Context) TypeExpr(TypeLoc(ty.get(), Type())));
+            new (Context) TypeExpr(ty.get()));
       checkForInputIncomplete();
       return nullptr;
     }
@@ -1534,7 +1534,7 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
   case tok::kw_Any: { // Any
     ExprContext.setCreateSyntax(SyntaxKind::TypeExpr);
     auto TyR = parseAnyType();
-    return makeParserResult(new (Context) TypeExpr(TypeLoc(TyR.get())));
+    return makeParserResult(new (Context) TypeExpr(TyR.get()));
   }
 
   case tok::dollarident: // $1

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -73,25 +73,26 @@ class BuilderClosureVisitor
     if (!cs)
       return nullptr;
 
-    // FIXME: Setting a TypeLoc on this expression is necessary in order
+    // FIXME: Setting a base on this expression is necessary in order
     // to get diagnostics if something about this builder call fails,
     // e.g. if there isn't a matching overload for `buildBlock`.
-    // But we can only do this if there isn't a type variable in the type.
-    TypeLoc typeLoc;
-    if (!builderType->hasTypeVariable()) {
-      typeLoc = TypeLoc(new (ctx) FixedTypeRepr(builderType, loc), builderType);
+    TypeExpr *typeExpr;
+    auto simplifiedTy = cs->simplifyType(builderType);
+    if (!simplifiedTy->hasTypeVariable()) {
+      typeExpr = TypeExpr::createImplicitHack(loc, simplifiedTy, ctx);
+    } else {
+      // HACK: If there's not enough information in the constraint system,
+      // create a garbage base type to force it to diagnose
+      // this as an ambiguous expression.
+      typeExpr = TypeExpr::createImplicitHack(loc, ErrorType::get(ctx), ctx);
     }
-
-    auto typeExpr = new (ctx) TypeExpr(typeLoc);
     cs->setType(typeExpr, MetatypeType::get(builderType));
-    cs->setType(&typeExpr->getTypeLoc(), builderType);
 
     SmallVector<SourceLoc, 4> argLabelLocs;
     for (auto i : indices(argLabels)) {
       argLabelLocs.push_back(args[i]->getStartLoc());
     }
 
-    typeExpr->setImplicit();
     auto memberRef = new (ctx) UnresolvedDotExpr(
         typeExpr, loc, DeclNameRef(fnName), DeclNameLoc(loc),
         /*implicit=*/true);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2719,9 +2719,9 @@ namespace {
     }
 
     Expr *visitTypeExpr(TypeExpr *expr) {
-      auto toType = simplifyType(cs.getType(expr->getTypeLoc()));
-      expr->getTypeLoc().setType(toType);
-      cs.setType(expr, MetatypeType::get(toType));
+      auto toType = simplifyType(cs.getType(expr));
+      assert(toType->is<MetatypeType>());
+      cs.setType(expr, toType);
       return expr;
     }
 
@@ -3960,16 +3960,14 @@ namespace {
             if (!TE)
               return subExpr;
 
-            auto type = TE->getInstanceType(
-                [&](const Expr *expr) { return cs.hasType(expr); },
-                [&](const Expr *expr) { return cs.getType(expr); });
+            auto type = cs.getInstanceType(TE);
 
             assert(!type->hasError());
 
             if (!type->isEqual(toType))
               return subExpr;
 
-            return cs.cacheType(new (ctx) TypeExpr(expr->getCastTypeLoc()));
+            return cs.cacheType(TypeExpr::createImplicitHack(expr->getLoc(), toType, ctx));
           });
         }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5164,7 +5164,7 @@ bool MissingGenericArgumentsFailure::findArgumentLocations(
 
   TypeLoc typeLoc;
   if (auto *TE = getAsExpr<TypeExpr>(anchor))
-    typeLoc = TE->getTypeLoc();
+    typeLoc = TE->getTypeRepr();
   else if (auto *ECE = getAsExpr<ExplicitCastExpr>(anchor))
     typeLoc = ECE->getCastTypeLoc();
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1454,8 +1454,8 @@ namespace {
       TypeResolutionOptions options(TypeResolverContext::InExpression);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
       bool hadError = TypeChecker::validateType(
-          CS.getASTContext(), loc, TypeResolution::forContextual(CS.DC),
-          options);
+          CS.getASTContext(), loc,
+          TypeResolution::forContextual(CS.DC, options), options);
       return hadError ? Type() : loc.getType();
     }
 
@@ -1717,10 +1717,9 @@ namespace {
           for (size_t i = 0, size = specializations.size(); i < size; ++i) {
             TypeResolutionOptions options(TypeResolverContext::InExpression);
             options |= TypeResolutionFlags::AllowUnboundGenerics;
-            if (TypeChecker::validateType(CS.getASTContext(),
-                                specializations[i],
-                                TypeResolution::forContextual(CS.DC),
-                                options))
+            if (TypeChecker::validateType(
+                    CS.getASTContext(), specializations[i],
+                    TypeResolution::forContextual(CS.DC, options), options))
               return Type();
 
             CS.addConstraint(ConstraintKind::Bind,
@@ -2652,10 +2651,12 @@ namespace {
           // of is-patterns applied to an irrefutable pattern.
           pattern = pattern->getSemanticsProvidingPattern();
           while (auto isp = dyn_cast<IsPattern>(pattern)) {
-            if (TypeChecker::validateType(CS.getASTContext(),
-                                          isp->getCastTypeLoc(),
-                                          TypeResolution::forContextual(CS.DC),
-                                          TypeResolverContext::InExpression)) {
+            const auto options =
+                TypeResolutionOptions(TypeResolverContext::InExpression);
+            if (TypeChecker::validateType(
+                    CS.getASTContext(), isp->getCastTypeLoc(),
+                    TypeResolution::forContextual(CS.DC, options),
+                    TypeResolverContext::InExpression)) {
               return false;
             }
 
@@ -2975,10 +2976,9 @@ namespace {
       // Validate the resulting type.
       TypeResolutionOptions options(TypeResolverContext::ExplicitCastExpr);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
-      if (TypeChecker::validateType(CS.getASTContext(),
-                                    expr->getCastTypeLoc(),
-                                    TypeResolution::forContextual(CS.DC),
-                                    options))
+      if (TypeChecker::validateType(
+              CS.getASTContext(), expr->getCastTypeLoc(),
+              TypeResolution::forContextual(CS.DC, options), options))
         return nullptr;
 
       // Open the type we're casting to.
@@ -3005,10 +3005,9 @@ namespace {
       // Validate the resulting type.
       TypeResolutionOptions options(TypeResolverContext::ExplicitCastExpr);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
-      if (TypeChecker::validateType(CS.getASTContext(),
-                                    expr->getCastTypeLoc(),
-                                    TypeResolution::forContextual(CS.DC),
-                                    options))
+      if (TypeChecker::validateType(
+              CS.getASTContext(), expr->getCastTypeLoc(),
+              TypeResolution::forContextual(CS.DC, options), options))
         return nullptr;
 
       // Open the type we're casting to.
@@ -3042,10 +3041,9 @@ namespace {
       // Validate the resulting type.
       TypeResolutionOptions options(TypeResolverContext::ExplicitCastExpr);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
-      if (TypeChecker::validateType(ctx,
-                                    expr->getCastTypeLoc(),
-                                    TypeResolution::forContextual(CS.DC),
-                                    options))
+      if (TypeChecker::validateType(
+              ctx, expr->getCastTypeLoc(),
+              TypeResolution::forContextual(CS.DC, options), options))
         return nullptr;
 
       // Open the type we're casting to.
@@ -3073,10 +3071,9 @@ namespace {
       auto &ctx = CS.getASTContext();
       TypeResolutionOptions options(TypeResolverContext::ExplicitCastExpr);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
-      if (TypeChecker::validateType(ctx,
-                                    expr->getCastTypeLoc(),
-                                    TypeResolution::forContextual(CS.DC),
-                                    options))
+      if (TypeChecker::validateType(
+              ctx, expr->getCastTypeLoc(),
+              TypeResolution::forContextual(CS.DC, options), options))
         return nullptr;
 
       // Open up the type we're checking.

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -993,9 +993,8 @@ void ConstraintSystem::shrink(Expr *expr) {
             // instead of cloning representative.
             auto coercionRepr = typeRepr->clone(CS.getASTContext());
             // Let's try to resolve coercion type from cloned representative.
-            auto resolution = TypeResolution::forContextual(CS.DC);
-            auto coercionType =
-              resolution.resolveType(coercionRepr, None);
+            auto resolution = TypeResolution::forContextual(CS.DC, None);
+            auto coercionType = resolution.resolveType(coercionRepr);
 
             // Looks like coercion type is invalid, let's skip this sub-tree.
             if (coercionType->hasError())

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -652,8 +652,8 @@ Type ConstraintSystem::openUnboundGenericType(UnboundGenericType *unbound,
   // handle generic TypeAliases elsewhere, this can just become a
   // call to BoundGenericType::get().
   return TypeChecker::applyUnboundGenericArguments(
-      unbound, unboundDecl,
-      SourceLoc(), TypeResolution::forContextual(DC), arguments);
+      unbound, unboundDecl, SourceLoc(),
+      TypeResolution::forContextual(DC, None), arguments);
 }
 
 static void checkNestedTypeConstraints(ConstraintSystem &cs, Type type,
@@ -1090,11 +1090,12 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
   // Unqualified reference to a type.
   if (auto typeDecl = dyn_cast<TypeDecl>(value)) {
     // Resolve the reference to this type declaration in our current context.
+    const auto options =
+        TypeResolutionOptions(TypeResolverContext::InExpression);
     auto type = TypeChecker::resolveTypeInContext(
-                                      typeDecl, nullptr,
-                                      TypeResolution::forContextual(useDC),
-                                      TypeResolverContext::InExpression,
-                                      /*isSpecialized=*/false);
+        typeDecl, nullptr, TypeResolution::forContextual(useDC, options),
+        options,
+        /*isSpecialized=*/false);
 
     checkNestedTypeConstraints(*this, type, locator);
 

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -470,7 +470,7 @@ static CallExpr *createContainerKeyedByCall(ASTContext &C, DeclContext *DC,
   // CodingKeys.self expr
   auto *codingKeysExpr = TypeExpr::createForDecl(DeclNameLoc(),
                                                  param,
-                                                 param->getDeclContext(),
+                                                 DC,
                                                  /*Implicit=*/true);
   auto *codingKeysMetaTypeExpr = new (C) DotSelfExpr(codingKeysExpr,
                                                      SourceLoc(), SourceLoc());

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2395,8 +2395,8 @@ ResolveTypeEraserTypeRequest::evaluate(Evaluator &evaluator,
                                        ProtocolDecl *PD,
                                        TypeEraserAttr *attr) const {
   if (auto *typeEraserRepr = attr->getParsedTypeEraserTypeRepr()) {
-    auto resolution = TypeResolution::forContextual(PD);
-    return resolution.resolveType(typeEraserRepr, /*options=*/None);
+    auto resolution = TypeResolution::forContextual(PD, None);
+    return resolution.resolveType(typeEraserRepr);
   } else {
     auto *LazyResolver = attr->Resolver;
     assert(LazyResolver && "type eraser was neither parsed nor deserialized?");
@@ -2584,8 +2584,8 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
     TypeResolutionOptions options = None;
     options |= TypeResolutionFlags::AllowUnboundGenerics;
 
-    auto resolution = TypeResolution::forContextual(DC);
-    T = resolution.resolveType(ProtoTypeLoc.getTypeRepr(), options);
+    auto resolution = TypeResolution::forContextual(DC, options);
+    T = resolution.resolveType(ProtoTypeLoc.getTypeRepr());
     ProtoTypeLoc.setType(T);
   }
 
@@ -4258,12 +4258,13 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
         return derivative->getParent() == func->getParent();
       };
 
-  auto resolution = TypeResolution::forContextual(derivative->getDeclContext());
   Type baseType;
   if (auto *baseTypeRepr = attr->getBaseTypeRepr()) {
     TypeResolutionOptions options = None;
     options |= TypeResolutionFlags::AllowModule;
-    baseType = resolution.resolveType(baseTypeRepr, options);
+    auto resolution =
+        TypeResolution::forContextual(derivative->getDeclContext(), options);
+    baseType = resolution.resolveType(baseTypeRepr);
   }
   if (baseType && baseType->hasError())
     return true;
@@ -4786,10 +4787,11 @@ void AttributeChecker::visitTransposeAttr(TransposeAttr *attr) {
   std::function<bool(AbstractFunctionDecl *)> hasValidTypeContext =
       [&](AbstractFunctionDecl *decl) { return true; };
 
-  auto resolution = TypeResolution::forContextual(transpose->getDeclContext());
+  auto resolution =
+      TypeResolution::forContextual(transpose->getDeclContext(), None);
   Type baseType;
   if (attr->getBaseTypeRepr())
-    baseType = resolution.resolveType(attr->getBaseTypeRepr(), None);
+    baseType = resolution.resolveType(attr->getBaseTypeRepr());
   auto lookupOptions =
       (attr->getBaseTypeRepr() ? defaultMemberLookupOptions
                                : defaultUnqualifiedLookupOptions) |

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -133,7 +133,7 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
   TypeLoc constraintTypeLoc(repr->getConstraint());
   // Pass along the error type if resolving the repr failed.
   auto resolution = TypeResolution::forInterface(
-    dc, dc->getGenericSignatureOfContext());
+      dc, dc->getGenericSignatureOfContext(), options);
   bool validationError
     = TypeChecker::validateType(ctx, constraintTypeLoc, resolution, options);
   auto constraintType = constraintTypeLoc.getType();
@@ -656,8 +656,6 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
     // note them as inference sources.
     if (subscr || func) {
       // Gather requirements from the parameter list.
-      auto resolution = TypeResolution::forStructural(GC);
-
       TypeResolutionOptions options =
           (func ? TypeResolverContext::AbstractFunctionDecl
                 : TypeResolverContext::SubscriptDecl);
@@ -674,7 +672,8 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
                                     : TypeResolverContext::FunctionInput);
         paramOptions |= TypeResolutionFlags::Direct;
 
-        auto type = resolution.resolveType(typeRepr, paramOptions);
+        auto type = TypeResolution::forStructural(GC, paramOptions)
+                        .resolveType(typeRepr);
 
         if (auto *specifier = dyn_cast<SpecifierTypeRepr>(typeRepr))
           typeRepr = specifier->getBase();
@@ -693,8 +692,9 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
         }
       }();
       if (resultTypeRepr && !isa<OpaqueReturnTypeRepr>(resultTypeRepr)) {
-        auto resultType = resolution.resolveType(
-            resultTypeRepr, TypeResolverContext::FunctionResult);
+        auto resultType = TypeResolution::forStructural(
+                              GC, TypeResolverContext::FunctionResult)
+                              .resolveType(resultTypeRepr);
 
         inferenceSources.emplace_back(resultTypeRepr, resultType);
       }
@@ -929,11 +929,11 @@ RequirementRequest::evaluate(Evaluator &evaluator,
   Optional<TypeResolution> resolution;
   switch (stage) {
   case TypeResolutionStage::Structural:
-    resolution = TypeResolution::forStructural(owner.dc);
+    resolution = TypeResolution::forStructural(owner.dc, options);
     break;
 
   case TypeResolutionStage::Interface:
-    resolution = TypeResolution::forInterface(owner.dc);
+    resolution = TypeResolution::forInterface(owner.dc, options);
     break;
 
   case TypeResolutionStage::Contextual:
@@ -943,7 +943,7 @@ RequirementRequest::evaluate(Evaluator &evaluator,
   auto resolveType = [&](TypeLoc &typeLoc) -> Type {
     Type result;
     if (auto typeRepr = typeLoc.getTypeRepr())
-      result = resolution->resolveType(typeRepr, options);
+      result = resolution->resolveType(typeRepr);
     else
       result = typeLoc.getType();
 
@@ -994,9 +994,9 @@ Type StructuralTypeRequest::evaluate(Evaluator &evaluator,
     return ErrorType::get(ctx);
   }
 
-  auto resolution = TypeResolution::forStructural(typeAlias);
-  auto type = resolution.resolveType(underlyingTypeRepr, options);
-  
+  auto resolution = TypeResolution::forStructural(typeAlias, options);
+  auto type = resolution.resolveType(underlyingTypeRepr);
+
   auto genericSig = typeAlias->getGenericSignature();
   SubstitutionMap subs;
   if (genericSig)

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -130,14 +130,10 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
   // Try to resolve the constraint repr. It should be some kind of existential
   // type.
   TypeResolutionOptions options(TypeResolverContext::GenericRequirement);
-  TypeLoc constraintTypeLoc(repr->getConstraint());
-  // Pass along the error type if resolving the repr failed.
   auto resolution = TypeResolution::forInterface(
       dc, dc->getGenericSignatureOfContext(), options);
-  bool validationError
-    = TypeChecker::validateType(ctx, constraintTypeLoc, resolution, options);
-  auto constraintType = constraintTypeLoc.getType();
-  if (validationError)
+  auto constraintType = resolution.resolveType(repr->getConstraint());
+  if (constraintType->hasError())
     return nullptr;
   
   // Error out if the constraint type isn't a class or existential type.

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -615,7 +615,9 @@ Pattern *TypeChecker::resolvePattern(Pattern *P, DeclContext *DC,
       Context.Diags.diagnose(TE->getStartLoc(), diag::type_pattern_missing_is)
         .fixItInsert(TE->getStartLoc(), "is ");
       
-      P = new (Context) IsPattern(TE->getStartLoc(), TE->getTypeLoc(),
+      P = new (Context) IsPattern(TE->getStartLoc(),
+                                  TypeLoc(TE->getTypeRepr(),
+                                          TE->getInstanceType()),
                                   /*subpattern*/nullptr,
                                   CheckedCastKind::Unresolved);
     }

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -467,7 +467,7 @@ public:
 
     // See if the repr resolves to a type.
     Type ty = TypeChecker::resolveIdentifierType(
-        TypeResolution::forContextual(DC), repr, options);
+        TypeResolution::forContextual(DC, options), repr, options);
 
     auto *enumDecl = dyn_cast_or_null<EnumDecl>(ty->getAnyNominal());
     if (!enumDecl)
@@ -565,8 +565,8 @@ public:
       auto *prefixRepr = IdentTypeRepr::create(Context, components);
 
       // See first if the entire repr resolves to a type.
-      Type enumTy = TypeChecker::resolveIdentifierType(TypeResolution::forContextual(DC),
-                                                       prefixRepr, options);
+      Type enumTy = TypeChecker::resolveIdentifierType(
+          TypeResolution::forContextual(DC, options), prefixRepr, options);
       if (!dyn_cast_or_null<EnumDecl>(enumTy->getAnyNominal()))
         return nullptr;
 
@@ -761,7 +761,7 @@ Type PatternTypeRequest::evaluate(Evaluator &evaluator,
   // If we see an explicit type annotation, coerce the sub-pattern to
   // that type.
   case PatternKind::Typed: {
-    auto resolution = TypeResolution::forContextual(dc);
+    auto resolution = TypeResolution::forContextual(dc, options);
     TypedPattern *TP = cast<TypedPattern>(P);
     return validateTypedPattern(resolution, TP, options);
   }
@@ -1210,7 +1210,7 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
 
     // Type-check the type parameter.
     TypeResolutionOptions paramOptions(TypeResolverContext::InExpression);
-    TypeResolution resolution = TypeResolution::forContextual(dc);
+    TypeResolution resolution = TypeResolution::forContextual(dc, paramOptions);
     if (validateType(Context, IP->getCastTypeLoc(), resolution, paramOptions))
       return nullptr;
 

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -534,14 +534,13 @@ Type AttachedPropertyWrapperTypeRequest::evaluate(Evaluator &evaluator,
   // If there isn't an attached property wrapper at this index, we're done.
   if (index >= customAttrVal.size())
     return Type();
-                                               
+
   auto customAttr = customAttrVal[index];
   if (!customAttr)
     return Type();
 
   TypeResolutionOptions options(TypeResolverContext::PatternBindingDecl);
   options |= TypeResolutionFlags::AllowUnboundGenerics;
-
   auto resolution =
       TypeResolution::forContextual(var->getDeclContext(), options);
   if (TypeChecker::validateType(var->getASTContext(),

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -539,11 +539,11 @@ Type AttachedPropertyWrapperTypeRequest::evaluate(Evaluator &evaluator,
   if (!customAttr)
     return Type();
 
-  auto resolution =
-      TypeResolution::forContextual(var->getDeclContext());
   TypeResolutionOptions options(TypeResolverContext::PatternBindingDecl);
   options |= TypeResolutionFlags::AllowUnboundGenerics;
 
+  auto resolution =
+      TypeResolution::forContextual(var->getDeclContext(), options);
   if (TypeChecker::validateType(var->getASTContext(),
                                 customAttr->getTypeLoc(),
                                 resolution, options)) {

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -49,11 +49,11 @@ InheritedTypeRequest::evaluate(
   Optional<TypeResolution> resolution;
   switch (stage) {
   case TypeResolutionStage::Structural:
-    resolution = TypeResolution::forStructural(dc);
+    resolution = TypeResolution::forStructural(dc, options);
     break;
 
   case TypeResolutionStage::Interface:
-    resolution = TypeResolution::forInterface(dc);
+    resolution = TypeResolution::forInterface(dc, options);
     break;
 
   case TypeResolutionStage::Contextual: {
@@ -72,7 +72,7 @@ InheritedTypeRequest::evaluate(
 
   Type inheritedType;
   if (typeLoc.getTypeRepr())
-    inheritedType = resolution->resolveType(typeLoc.getTypeRepr(), options);
+    inheritedType = resolution->resolveType(typeLoc.getTypeRepr());
   else
     inheritedType = typeLoc.getType();
 

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -285,6 +285,7 @@ public:
 class TypeResolution {
   DeclContext *dc;
   TypeResolutionStage stage;
+  TypeResolutionOptions options;
 
   union {
     /// The generic environment used to map to archetypes.
@@ -301,8 +302,9 @@ class TypeResolution {
     } complete;
   };
 
-  TypeResolution(DeclContext *dc, TypeResolutionStage stage)
-    : dc(dc), stage(stage) { }
+  TypeResolution(DeclContext *dc, TypeResolutionStage stage,
+                 TypeResolutionOptions options)
+      : dc(dc), stage(stage), options(options) {}
 
   GenericSignatureBuilder *getGenericSignatureBuilder() const;
 
@@ -310,28 +312,37 @@ public:
   /// Form a type resolution for the structure of a type, which does not
   /// attempt to resolve member types of type parameters to a particular
   /// associated type.
-  static TypeResolution forStructural(DeclContext *dc);
-
-  /// Form a type resolution for an interface type, which is a complete
-  /// description of the type using generic parameters.
-  static TypeResolution forInterface(DeclContext *dc);
+  static TypeResolution forStructural(DeclContext *dc,
+                                      TypeResolutionOptions opts);
 
   /// Form a type resolution for an interface type, which is a complete
   /// description of the type using generic parameters.
   static TypeResolution forInterface(DeclContext *dc,
-                                     GenericSignature genericSig);
+                                     TypeResolutionOptions opts);
+
+  /// Form a type resolution for an interface type, which is a complete
+  /// description of the type using generic parameters.
+  static TypeResolution forInterface(DeclContext *dc,
+                                     GenericSignature genericSig,
+                                     TypeResolutionOptions opts);
 
   /// Form a type resolution for a contextual type, which is a complete
   /// description of the type using the archetypes of the given declaration
   /// context.
-  static TypeResolution forContextual(DeclContext *dc);
+  static TypeResolution forContextual(DeclContext *dc,
+                                      TypeResolutionOptions opts);
 
   /// Form a type resolution for a contextual type, which is a complete
   /// description of the type using the archetypes of the given generic
   /// environment.
   static TypeResolution forContextual(DeclContext *dc,
-                                      GenericEnvironment *genericEnv);
+                                      GenericEnvironment *genericEnv,
+                                      TypeResolutionOptions opts);
 
+public:
+  TypeResolution withOptions(TypeResolutionOptions newOpts) const;
+
+public:
   /// Retrieve the ASTContext in which this resolution occurs.
   ASTContext &getASTContext() const;
 
@@ -341,6 +352,9 @@ public:
 
   /// Retrieve the type resolution stage.
   TypeResolutionStage getStage() const { return stage; }
+
+  /// Retrieve the initial resolution options.
+  TypeResolutionOptions getOptions() const { return options; }
 
   /// Retrieves the generic signature for the context, or NULL if there is
   /// no generic signature to resolve types.
@@ -353,10 +367,8 @@ public:
   ///
   /// \param TyR The type representation to check.
   ///
-  /// \param options Options that alter type resolution.
-  ///
   /// \returns a well-formed type or an ErrorType in case of an error.
-  Type resolveType(TypeRepr *TyR, TypeResolutionOptions options);
+  Type resolveType(TypeRepr *TyR);
 
   /// Whether this type resolution uses archetypes (vs. generic parameters).
   bool usesArchetypes() const;

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -166,6 +166,15 @@ public:
   void operator =(const Context &) = delete;
   void operator =(Context &&) = delete;
 
+  bool operator==(const TypeResolutionOptions &rhs) const {
+    return getBaseContext() == rhs.getBaseContext() &&
+           getContext() == rhs.getContext() && getFlags() == rhs.getFlags();
+  }
+
+  bool operator!=(const TypeResolutionOptions &rhs) const {
+    return !(*this == rhs);
+  }
+
   // NOTE: "None" might be more permissive than one wants, therefore no
   // reasonable default context is possible.
   TypeResolutionOptions() = delete;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -527,7 +527,7 @@ bool swift::performTypeLocChecking(ASTContext &Ctx, TypeLoc &T,
   if (isSILType)
     options |= TypeResolutionFlags::SILType;
 
-  auto resolution = TypeResolution::forContextual(DC, GenericEnv);
+  auto resolution = TypeResolution::forContextual(DC, GenericEnv, options);
   Optional<DiagnosticSuppression> suppression;
   if (!ProduceDiagnostics)
     suppression.emplace(Ctx.Diags);

--- a/test/Sema/diag_erroneous_iuo.swift
+++ b/test/Sema/diag_erroneous_iuo.swift
@@ -116,7 +116,7 @@ _ = [Int!]() // expected-error {{'!' is not allowed here; perhaps '?' was intend
 let _: [Int!] = [1] // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{12-13=?}}
 _ = Optional<Int!>(nil) // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{17-18=?}}
 let _: Optional<Int!> = nil // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{20-21=?}}
-_ = Int!?(0) // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{8-9=?}}
+_ = Int!?(0) // expected-error 3 {{'!' is not allowed here; perhaps '?' was intended?}}{{8-9=?}}
 let _: Int!? = 0 // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{11-12=?}}
 _ = (
   Int!, // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{6-7=?}}


### PR DESCRIPTION
- Put a request around type resolution
- Strip calls to TypeChecker::validateType for Decl nodes
- Strip the first expr node of its `TypeLoc`: `TypeExpr`

Drafted so I can run source compat and see if this is too radical.