### PR TITLE
Add syntax highlighting for GitHub

### DIFF
--- a/userdocs/diagnostics/associated-type-requirements.md
+++ b/userdocs/diagnostics/associated-type-requirements.md
@@ -1,6 +1,7 @@
 # Using Protocols with `Self` or Associated Type Requirements
 Protocols in Swift may be used as types, as part of a generic constraint, or as part of an opaque result type.
-```
+
+```swift
 // CustomStringConvertible can be used as a type.
 func foo(bar: CustomStringConvertible) { /* ... */ }
 
@@ -12,7 +13,8 @@ func baz() -> some CustomStringConvertible { /* ... */ }
 ```
 
 While all Swift protocols can be used as generic constraints and as part of opaque result types, not all protocols can be used as types in general. Specifically, if a protocol has a requirement which references `Self` or an associated type, it cannot be used as a type. One such protocol is `Identifiable`, which has the requirement `var id: ID { get }`, where `ID` is an associated type. As a result, the following code is not allowed:
-```
+
+```swift
 func foo(bar: Identifiable) { /* ... */ }
 // error: protocol 'Identifiable' can only be used as a generic constraint because it has Self or associated type requirements
 ```

--- a/userdocs/diagnostics/complex-closure-inference.md
+++ b/userdocs/diagnostics/complex-closure-inference.md
@@ -1,12 +1,15 @@
 # Inferring Closure Types
 If a closure contains a single expression, Swift will consider its body in addition to its signature and the surrounding context when performing type inference. For example, in the following code the type of `doubler` is inferred to be `(Int) -> Int` using only its body:
-```
+
+```swift
 let doubler = {
   $0 * 2
 }
 ```
+
 If a closure body is not a single expression, it will not be considered when inferring the closure type. This is consistent with how type inference works in other parts of the language, where it proceeds one statement at a time. For example, in the following code an error will be reported because the type of `evenDoubler` cannot be inferred from its surrounding context and no signature was provided:
-```
+
+```swift
 // error: unable to infer complex closure return type; add explicit type to disambiguate
 let evenDoubler = { x in
   if x.isMultiple(of: 2) {
@@ -16,14 +19,18 @@ let evenDoubler = { x in
   }
 }
 ```
+
 This can be fixed by providing additional contextual information:
-```
+
+```swift
 let evenDoubler: (Int) -> Int = { x in
  // ...
 }
 ```
+
 Or by giving the closure an explicit signature:
-```
+
+```swift
 let evenDoubler = { (x: Int) -> Int in
  // ...
 }


### PR DESCRIPTION
I came across these docs while researching when a closure's return type can be inferred, and wanted to leave them better than I found them.