### PR TITLE
[5.3] Fix layering of cross-import and clang overlays

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -395,6 +395,8 @@ public:
     overlays.append(value.begin(), value.end());
   }
 
+  SWIFT_DEBUG_DUMPER(dumpSeparatelyImportedOverlays());
+
   void cacheVisibleDecls(SmallVectorImpl<ValueDecl *> &&globals) const;
   const SmallVectorImpl<ValueDecl *> &getCachedVisibleDecls() const;
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1259,6 +1259,10 @@ namespace {
 
     void visitModuleDecl(ModuleDecl *MD) {
       printCommon(MD, "module");
+
+      if (MD->isNonSwiftModule())
+        OS << " non_swift";
+      
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1418,6 +1418,22 @@ SourceFile::getImportedModules(SmallVectorImpl<ModuleDecl::ImportedModule> &modu
   }
 }
 
+void SourceFile::dumpSeparatelyImportedOverlays() const {
+  for (auto &pair : separatelyImportedOverlays) {
+    auto &underlying = std::get<0>(pair);
+    auto &overlays = std::get<1>(pair);
+
+    llvm::errs() << (void*)underlying << " ";
+    underlying->dump(llvm::errs());
+
+    for (auto overlay : overlays) {
+      llvm::errs() << "- ";
+      llvm::errs() << (void*)overlay << " ";
+      overlay->dump(llvm::errs());
+    }
+  }
+}
+
 void ModuleDecl::getImportedModulesForLookup(
     SmallVectorImpl<ImportedModule> &modules) const {
   FORWARD(getImportedModulesForLookup, (modules));

--- a/test/CrossImport/Inputs/lib-templates/Frameworks/ClangFramework.framework/Modules/ClangFramework.swiftcrossimport/BystandingLibrary.swiftoverlay
+++ b/test/CrossImport/Inputs/lib-templates/Frameworks/ClangFramework.framework/Modules/ClangFramework.swiftcrossimport/BystandingLibrary.swiftoverlay
@@ -1,0 +1,5 @@
+%YAML 1.2
+---
+version: 1
+modules:
+  - name: _ClangFramework_BystandingLibrary

--- a/test/CrossImport/Inputs/lib-templates/Frameworks/OverlaidClangFramework.framework/Modules/OverlaidClangFramework.swiftcrossimport/BystandingLibrary.swiftoverlay
+++ b/test/CrossImport/Inputs/lib-templates/Frameworks/OverlaidClangFramework.framework/Modules/OverlaidClangFramework.swiftcrossimport/BystandingLibrary.swiftoverlay
@@ -1,0 +1,5 @@
+%YAML 1.2
+---
+version: 1
+modules:
+  - name: _OverlaidClangFramework_BystandingLibrary

--- a/test/CrossImport/Inputs/lib-templates/Frameworks/SwiftFramework.framework/Modules/SwiftFramework.swiftcrossimport/BystandingLibrary.swiftoverlay
+++ b/test/CrossImport/Inputs/lib-templates/Frameworks/SwiftFramework.framework/Modules/SwiftFramework.swiftcrossimport/BystandingLibrary.swiftoverlay
@@ -1,0 +1,5 @@
+%YAML 1.2
+---
+version: 1
+modules:
+  - name: _SwiftFramework_BystandingLibrary

--- a/test/CrossImport/Inputs/lib-templates/Frameworks/_ClangFramework_BystandingLibrary.framework/Modules/_ClangFramework_BystandingLibrary.swiftmodule/module-triple-here.swiftinterface
+++ b/test/CrossImport/Inputs/lib-templates/Frameworks/_ClangFramework_BystandingLibrary.framework/Modules/_ClangFramework_BystandingLibrary.swiftmodule/module-triple-here.swiftinterface
@@ -1,0 +1,7 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -swift-version 5 -enable-library-evolution -module-name _ClangFramework_BystandingLibrary
+
+import Swift
+@_exported import ClangFramework
+
+public func fromClangFrameworkCrossImport()

--- a/test/CrossImport/Inputs/lib-templates/Frameworks/_OverlaidClangFramework_BystandingLibrary.framework/Modules/_OverlaidClangFramework_BystandingLibrary.swiftmodule/module-triple-here.swiftinterface
+++ b/test/CrossImport/Inputs/lib-templates/Frameworks/_OverlaidClangFramework_BystandingLibrary.framework/Modules/_OverlaidClangFramework_BystandingLibrary.swiftmodule/module-triple-here.swiftinterface
@@ -1,0 +1,7 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -swift-version 5 -enable-library-evolution -module-name _OverlaidClangFramework_BystandingLibrary
+
+import Swift
+@_exported import OverlaidClangFramework
+
+public func fromOverlaidClangFrameworkCrossImport()

--- a/test/CrossImport/Inputs/lib-templates/Frameworks/_SwiftFramework_BystandingLibrary.framework/Modules/_SwiftFramework_BystandingLibrary.swiftmodule/module-triple-here.swiftinterface
+++ b/test/CrossImport/Inputs/lib-templates/Frameworks/_SwiftFramework_BystandingLibrary.framework/Modules/_SwiftFramework_BystandingLibrary.swiftmodule/module-triple-here.swiftinterface
@@ -1,0 +1,7 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -swift-version 5 -enable-library-evolution -module-name _SwiftFramework_BystandingLibrary
+
+import Swift
+@_exported import SwiftFramework
+
+public func fromSwiftFrameworkCrossImport()

--- a/test/CrossImport/Inputs/lib-templates/lib/swift/OverlaidClangFramework.swiftmodule/module-triple-here.swiftinterface
+++ b/test/CrossImport/Inputs/lib-templates/lib/swift/OverlaidClangFramework.swiftmodule/module-triple-here.swiftinterface
@@ -3,3 +3,5 @@
 
 import Swift
 @_exported import OverlaidClangFramework
+
+public func fromOverlaidClangFrameworkOverlay()

--- a/test/CrossImport/common-case.swift
+++ b/test/CrossImport/common-case.swift
@@ -1,0 +1,40 @@
+// This explicitly tests "common" cases with well-constructed cross-import
+// overlays. Some behaviors here are poorly covered by other tests.
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/lib-templates/* %t/
+// RUN: %{python} %S/Inputs/rewrite-module-triples.py %t %module-target-triple
+
+// RUN: %target-typecheck-verify-swift -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks
+
+// Each framework has a cross-import overlay with this library:
+import BystandingLibrary
+
+// 1. A Swift framework
+
+import SwiftFramework
+
+fromSwiftFramework()
+fromSwiftFrameworkCrossImport()
+SwiftFramework.fromSwiftFramework()
+SwiftFramework.fromSwiftFrameworkCrossImport()
+
+// 2. A Clang framework
+
+import ClangFramework
+
+fromClangFramework()
+fromClangFrameworkCrossImport()
+ClangFramework.fromClangFramework()
+ClangFramework.fromClangFrameworkCrossImport()
+
+// 3. A Swift-overlaid Clang framework
+
+import OverlaidClangFramework
+
+fromOverlaidClangFramework()
+fromOverlaidClangFrameworkOverlay()
+fromOverlaidClangFrameworkCrossImport()
+OverlaidClangFramework.fromOverlaidClangFramework()
+OverlaidClangFramework.fromOverlaidClangFrameworkOverlay()
+OverlaidClangFramework.fromOverlaidClangFrameworkCrossImport()


### PR DESCRIPTION
Cherry-picks #31199 to release/5.3 branch:

> If a clang module declares a cross-import overlay, but it also has a traditional overlay, we want the cross-import overlay to be registered with the SourceFile as sitting atop the traditional overlay. Otherwise module-qualified name lookups will bypass the cross-import overlay.
> 
> This PR also includes some NFC dumping improvements.
> 
> Fixes rdar://62139656
