### PR TITLE
AST: Rename getFullName -> getName on ValueDecl & MissingMemberDecl

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2503,8 +2503,7 @@ public:
   bool isOperator() const { return Name.isOperator(); }
 
   /// Retrieve the full name of the declaration.
-  /// TODO: Rename to getName?
-  DeclName getFullName() const { return Name; }
+  DeclName getName() const { return Name; }
   void setName(DeclName name) { Name = name; }
 
   /// Retrieve the base name of the declaration, ignoring any argument
@@ -2518,7 +2517,7 @@ public:
   /// Generates a DeclNameRef referring to this declaration with as much
   /// specificity as possible.
   DeclNameRef createNameRef() const {
-    return DeclNameRef(getFullName());
+    return DeclNameRef(Name);
   }
 
   /// Retrieve the name to use for this declaration when interoperating
@@ -2847,7 +2846,6 @@ public:
 
   /// Returns the string for the base name, or "_" if this is unnamed.
   StringRef getNameStr() const {
-    assert(!getFullName().isSpecial() && "Cannot get string for special names");
     return hasName() ? getBaseIdentifier().str() : "_";
   }
 
@@ -4950,7 +4948,6 @@ public:
 
   /// Returns the string for the base name, or "_" if this is unnamed.
   StringRef getNameStr() const {
-    assert(!getFullName().isSpecial() && "Cannot get string for special names");
     return hasName() ? getBaseIdentifier().str() : "_";
   }
 
@@ -5925,7 +5922,7 @@ public:
 
   /// Returns the string for the base name, or "_" if this is unnamed.
   StringRef getNameStr() const {
-    assert(!getFullName().isSpecial() && "Cannot get string for special names");
+    assert(!getName().isSpecial() && "Cannot get string for special names");
     return hasName() ? getBaseIdentifier().str() : "_";
   }
 
@@ -6625,7 +6622,7 @@ public:
 
   /// Returns the string for the base name, or "_" if this is unnamed.
   StringRef getNameStr() const {
-    assert(!getFullName().isSpecial() && "Cannot get string for special names");
+    assert(!getName().isSpecial() && "Cannot get string for special names");
     return hasName() ? getBaseIdentifier().str() : "_";
   }
 
@@ -7378,7 +7375,7 @@ public:
     return new (ctx) MissingMemberDecl(DC, name, numVTableEntries, hasStorage);
   }
 
-  DeclName getFullName() const {
+  DeclName getName() const {
     return Name;
   }
 

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -419,7 +419,7 @@ public:
     // to avoid circular validation.
     if (isTypeLookup && !isa<TypeDecl>(VD))
       return;
-    if (VD->getFullName().matchesRef(name.getFullName()))
+    if (VD->getName().matchesRef(name.getFullName()))
       results.push_back(LookupResultEntry(VD));
   }
 };

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -619,9 +619,9 @@ namespace {
     }
 
     void printDeclName(const ValueDecl *D) {
-      if (D->getFullName()) {
+      if (D->getName()) {
         PrintWithColorRAII(OS, IdentifierColor)
-          << '\"' << D->getFullName() << '\"';
+          << '\"' << D->getName() << '\"';
       } else {
         PrintWithColorRAII(OS, IdentifierColor)
           << "'anonname=" << (const void*)D << '\'';
@@ -1105,7 +1105,7 @@ namespace {
     void visitAccessorDecl(AccessorDecl *AD) {
       printCommonFD(AD, "accessor_decl");
       OS << " " << getAccessorKindString(AD->getAccessorKind());
-      OS << "_for=" << AD->getStorage()->getFullName();
+      OS << "_for=" << AD->getStorage()->getName();
       printAbstractFunctionDecl(AD);
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
@@ -1268,7 +1268,7 @@ namespace {
     void visitMissingMemberDecl(MissingMemberDecl *MMD) {
       printCommon(MMD, "missing_member_decl ");
       PrintWithColorRAII(OS, IdentifierColor)
-          << '\"' << MMD->getFullName() << '\"';
+          << '\"' << MMD->getName() << '\"';
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
   };
@@ -1367,15 +1367,15 @@ void swift::printContext(raw_ostream &os, DeclContext *dc) {
     break;
 
   case DeclContextKind::AbstractFunctionDecl:
-    printName(os, cast<AbstractFunctionDecl>(dc)->getFullName());
+    printName(os, cast<AbstractFunctionDecl>(dc)->getName());
     break;
 
   case DeclContextKind::SubscriptDecl:
-    printName(os, cast<SubscriptDecl>(dc)->getFullName());
+    printName(os, cast<SubscriptDecl>(dc)->getName());
     break;
 
   case DeclContextKind::EnumElementDecl:
-    printName(os, cast<EnumElementDecl>(dc)->getFullName());
+    printName(os, cast<EnumElementDecl>(dc)->getName());
     break;
   }
 }
@@ -1393,7 +1393,7 @@ void ValueDecl::dumpRef(raw_ostream &os) const {
   os << ".";
 
   // Print name.
-  getFullName().printPretty(os);
+  getName().printPretty(os);
 
   // Print location.
   auto &srcMgr = getASTContext().SourceMgr;
@@ -3171,7 +3171,7 @@ static void dumpProtocolConformanceRec(
         out << '\n';
         out.indent(indent + 2);
         PrintWithColorRAII(out, ParenthesisColor) << '(';
-        out << "value req=" << req->getFullName() << " witness=";
+        out << "value req=" << req->getName() << " witness=";
         if (!witness) {
           out << "(none)";
         } else if (witness.getDecl() == req) {

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3265,7 +3265,7 @@ void PrintAST::visitModuleDecl(ModuleDecl *decl) { }
 
 void PrintAST::visitMissingMemberDecl(MissingMemberDecl *decl) {
   Printer << "/* placeholder for ";
-  recordDeclLoc(decl, [&]{ Printer << decl->getFullName(); });
+  recordDeclLoc(decl, [&]{ Printer << decl->getName(); });
   unsigned numVTableEntries = decl->getNumberOfVTableEntries();
   if (numVTableEntries > 0)
     Printer << " (vtable entries: " << numVTableEntries << ")";

--- a/lib/AST/ASTScopePrinting.cpp
+++ b/lib/AST/ASTScopePrinting.cpp
@@ -67,7 +67,7 @@ void ASTScopeImpl::dumpOneScopeMapLocation(
     llvm::errs() << "Local bindings: ";
     llvm::interleave(
         gatherer.getDecls().begin(), gatherer.getDecls().end(),
-        [&](ValueDecl *value) { llvm::errs() << value->getFullName(); },
+        [&](ValueDecl *value) { llvm::errs() << value->getName(); },
         [&]() { llvm::errs() << " "; });
     llvm::errs() << "\n";
   }
@@ -169,7 +169,7 @@ void GenericParamScope::printSpecifics(llvm::raw_ostream &out) const {
 }
 
 void AbstractFunctionDeclScope::printSpecifics(llvm::raw_ostream &out) const {
-  out << "'" << decl->getFullName() << "'";
+  out << "'" << decl->getName() << "'";
 }
 
 void AbstractPatternEntryScope::printSpecifics(llvm::raw_ostream &out) const {

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2814,8 +2814,8 @@ public:
 
       // All of the parameter names should match.
       if (!isa<DestructorDecl>(AFD)) { // Destructor has no non-self params.
-        auto paramNames = AFD->getFullName().getArgumentNames();
-        bool checkParamNames = (bool)AFD->getFullName();
+        auto paramNames = AFD->getName().getArgumentNames();
+        bool checkParamNames = (bool)AFD->getName();
         auto *firstParams = AFD->getParameters();
 
         if (checkParamNames &&

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2759,7 +2759,7 @@ static Type mapSignatureFunctionType(ASTContext &ctx, Type type,
 OverloadSignature ValueDecl::getOverloadSignature() const {
   OverloadSignature signature;
 
-  signature.Name = getFullName();
+  signature.Name = getName();
   signature.InProtocolExtension
     = static_cast<bool>(getDeclContext()->getExtendedProtocolDecl());
   signature.IsInstanceMember = isInstanceMember();
@@ -6631,8 +6631,8 @@ SourceRange SubscriptDecl::getSignatureSourceRange() const {
 }
 
 DeclName AbstractFunctionDecl::getEffectiveFullName() const {
-  if (getFullName())
-    return getFullName();
+  if (getName())
+    return getName();
 
   if (auto accessor = dyn_cast<AccessorDecl>(this)) {
     auto &ctx = getASTContext();
@@ -6645,7 +6645,7 @@ DeclName AbstractFunctionDecl::getEffectiveFullName() const {
     case AccessorKind::Get:
     case AccessorKind::Read:
     case AccessorKind::Modify:
-      return subscript ? subscript->getFullName()
+      return subscript ? subscript->getName()
                        : DeclName(ctx, storage->getBaseName(),
                                   ArrayRef<Identifier>());
 
@@ -6657,8 +6657,8 @@ DeclName AbstractFunctionDecl::getEffectiveFullName() const {
       argNames.push_back(Identifier());
       // The subscript index parameters.
       if (subscript) {
-        argNames.append(subscript->getFullName().getArgumentNames().begin(),
-                        subscript->getFullName().getArgumentNames().end());
+        argNames.append(subscript->getName().getArgumentNames().begin(),
+                        subscript->getName().getArgumentNames().end());
       }
       return DeclName(ctx, storage->getBaseName(), argNames);
     }
@@ -6818,7 +6818,7 @@ AbstractFunctionDecl::getObjCSelector(DeclName preferredName,
     llvm_unreachable("Unknown subclass of AbstractFunctionDecl");
   }
 
-  auto argNames = getFullName().getArgumentNames();
+  auto argNames = getName().getArgumentNames();
 
   // Use the preferred name if specified
   if (preferredName) {
@@ -6974,7 +6974,7 @@ ParamDecl *AbstractFunctionDecl::getImplicitSelfDecl(bool createIfNeeded) {
 
 void AbstractFunctionDecl::setParameters(ParameterList *BodyParams) {
 #ifndef NDEBUG
-  auto Name = getFullName();
+  const auto Name = getName();
   if (!isa<DestructorDecl>(this))
     assert((!Name || !Name.isSimpleName()) && "Must have a compound name");
   assert(!Name || (Name.getArgumentNames().size() == BodyParams->size()));
@@ -7360,8 +7360,8 @@ ConstructorDecl::ConstructorDecl(DeclName Name, SourceLoc ConstructorLoc,
 
 bool ConstructorDecl::isObjCZeroParameterWithLongSelector() const {
   // The initializer must have a single, non-empty argument name.
-  if (getFullName().getArgumentNames().size() != 1 ||
-      getFullName().getArgumentNames()[0].empty())
+  if (getName().getArgumentNames().size() != 1 ||
+      getName().getArgumentNames()[0].empty())
     return false;
 
   auto *params = getParameters();
@@ -7923,7 +7923,7 @@ struct DeclTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
       return;
     const Decl *D = static_cast<const Decl *>(Entity);
     if (auto const *VD = dyn_cast<const ValueDecl>(D)) {
-      VD->getFullName().print(OS, false);
+      VD->getName().print(OS, false);
     } else {
       OS << "<"
          << Decl::getDescriptiveKindName(D->getDescriptiveKind())

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -581,7 +581,7 @@ void AccessScope::dump() const {
     if (auto *ext = dyn_cast<ExtensionDecl>(decl))
       llvm::errs() << ext->getExtendedNominal()->getName();
     else if (auto *named = dyn_cast<ValueDecl>(decl))
-      llvm::errs() << named->getFullName();
+      llvm::errs() << named->getName();
     else
       llvm::errs() << (const void *)decl;
 
@@ -680,7 +680,7 @@ unsigned DeclContext::printContext(raw_ostream &OS, const unsigned indent,
     break;
   case DeclContextKind::AbstractFunctionDecl: {
     auto *AFD = cast<AbstractFunctionDecl>(this);
-    OS << " name=" << AFD->getFullName();
+    OS << " name=" << AFD->getName();
     if (AFD->hasInterfaceType())
       OS << " : " << AFD->getInterfaceType();
     else

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -527,7 +527,7 @@ static void formatDiagnosticArgument(StringRef Modifier,
 
   case DiagnosticArgumentKind::ValueDecl:
     Out << FormatOpts.OpeningQuotationMark;
-    Arg.getAsValueDecl()->getFullName().printPretty(Out);
+    Arg.getAsValueDecl()->getName().printPretty(Out);
     Out << FormatOpts.ClosingQuotationMark;
     break;
 
@@ -556,7 +556,7 @@ static void formatDiagnosticArgument(StringRef Modifier,
         selfTy->print(OutNaming);
         OutNaming << '.';
       }
-      namingDecl->getFullName().printPretty(OutNaming);
+      namingDecl->getName().printPretty(OutNaming);
 
       auto descriptiveKind = opaqueTypeDecl->getDescriptiveKind();
 

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -417,7 +417,7 @@ const ValueDecl *findDefaultProvidedDeclWithDocComment(const ValueDecl *VD,
 
   SmallVector<ValueDecl *, 2> members;
   protocol->lookupQualified(const_cast<ProtocolDecl *>(protocol),
-                            DeclNameRef(VD->getFullName()),
+                            DeclNameRef(VD->getName()),
                             NLOptions::NL_ProtocolMembers,
                             members);
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2233,7 +2233,7 @@ void InterpolatedStringLiteralExpr::forEachSegment(ASTContext &Ctx,
       if (auto call = dyn_cast<CallExpr>(expr)) {
         DeclName name;
         if (auto fn = call->getCalledValue()) {
-          name = fn->getFullName();
+          name = fn->getName();
         } else if (auto unresolvedDot =
                       dyn_cast<UnresolvedDotExpr>(call->getFn())) {
           name = unresolvedDot->getName().getFullName();

--- a/lib/AST/FrontendSourceFileDepGraphFactory.cpp
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.cpp
@@ -437,7 +437,7 @@ private:
       auto *VD = dyn_cast<ValueDecl>(D);
       if (!VD || excludeIfPrivate(VD))
         continue;
-      if (VD->getFullName().isOperator())
+      if (VD->getName().isOperator())
         memberOperatorDecls.push_back(cast<FuncDecl>(D));
       else if (const auto *const NTD = dyn_cast<NominalTypeDecl>(D))
         findNominalsAndOperatorsIn(NTD);

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3940,7 +3940,7 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
             if (genReq->getGenericParams())
               continue;
 
-          inheritedTypeDecls[typeReq->getFullName()].push_back(typeReq);
+          inheritedTypeDecls[typeReq->getName()].push_back(typeReq);
         }
       }
       return TypeWalker::Action::Continue;
@@ -3967,7 +3967,7 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
       llvm::raw_string_ostream out(result);
       out << start;
       interleave(assocType->getInherited(), [&](TypeLoc inheritedType) {
-        out << assocType->getFullName() << ": ";
+        out << assocType->getName() << ": ";
         if (auto inheritedTypeRepr = inheritedType.getTypeRepr())
           inheritedTypeRepr->print(out);
         else
@@ -3994,7 +3994,7 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
     {
       llvm::raw_string_ostream out(result);
       out << start;
-      out << type->getFullName() << " == ";
+      out << type->getName() << " == ";
       if (auto typealias = dyn_cast<TypeAliasDecl>(type)) {
         if (auto underlyingTypeRepr = typealias->getUnderlyingTypeRepr())
           underlyingTypeRepr->print(out);
@@ -4053,7 +4053,7 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
 
     // Check whether we inherited any types with the same name.
     auto knownInherited =
-      inheritedTypeDecls.find(assocTypeDecl->getFullName());
+      inheritedTypeDecls.find(assocTypeDecl->getName());
     if (knownInherited == inheritedTypeDecls.end()) continue;
 
     bool shouldWarnAboutRedeclaration =
@@ -4074,7 +4074,7 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
           auto fixItWhere = getProtocolWhereLoc();
           Diags.diagnose(assocTypeDecl,
                          diag::inherited_associated_type_redecl,
-                         assocTypeDecl->getFullName(),
+                         assocTypeDecl->getName(),
                          inheritedFromProto->getDeclaredInterfaceType())
             .fixItInsertAfter(
                       fixItWhere.Loc,
@@ -4082,7 +4082,7 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
             .fixItRemove(assocTypeDecl->getSourceRange());
 
           Diags.diagnose(inheritedAssocTypeDecl, diag::decl_declared_here,
-                         inheritedAssocTypeDecl->getFullName());
+                         inheritedAssocTypeDecl->getName());
 
           shouldWarnAboutRedeclaration = false;
         }
@@ -4097,7 +4097,7 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
             inheritedType->getDeclContext()->getSelfNominalTypeDecl();
         Diags.diagnose(assocTypeDecl,
                        diag::associated_type_override_typealias,
-                       assocTypeDecl->getFullName(),
+                       assocTypeDecl->getName(),
                        inheritedOwningDecl->getDescriptiveKind(),
                        inheritedOwningDecl->getDeclaredInterfaceType());
       }
@@ -4157,7 +4157,7 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
                                   getConcreteTypeReq(type, fixItWhere.Item))
                 .fixItRemove(type->getSourceRange());
               Diags.diagnose(inheritedAssocTypeDecl, diag::decl_declared_here,
-                             inheritedAssocTypeDecl->getFullName());
+                             inheritedAssocTypeDecl->getName());
 
               shouldWarnAboutRedeclaration = false;
             }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -143,7 +143,7 @@ class swift::SourceLookupCache {
   public:
     void add(ValueDecl *VD) {
       if (!VD->hasName()) return;
-      VD->getFullName().addToLookupTable(Members, VD);
+      VD->getName().addToLookupTable(Members, VD);
     }
 
     void clear() {
@@ -389,7 +389,7 @@ void SourceLookupCache::lookupVisibleDecls(AccessPathTy AccessPath,
     for (ValueDecl *vd : tlv.second) {
       // Declarations are added under their full and simple names.  Skip the
       // entry for the simple name so that we report each declaration once.
-      if (tlv.first.isSimpleName() && !vd->getFullName().isSimpleName())
+      if (tlv.first.isSimpleName() && !vd->getName().isSimpleName())
         continue;
       Consumer.foundDecl(vd, DeclVisibilityKind::VisibleAtTopLevel);
     }
@@ -2721,7 +2721,7 @@ void SynthesizedFileUnit::lookupValue(
     DeclName name, NLKind lookupKind,
     SmallVectorImpl<ValueDecl *> &result) const {
   for (auto *decl : TopLevelDecls) {
-    if (decl->getFullName().matchesRef(name))
+    if (decl->getName().matchesRef(name))
       result.push_back(decl);
   }
 }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -182,7 +182,7 @@ bool swift::removeOverriddenDecls(SmallVectorImpl<ValueDecl*> &decls) {
       // C.init overrides B.init overrides A.init, but only C.init and
       // A.init are in the chain. Make sure we still remove A.init from the
       // set in this case.
-      if (decl->getFullName().getBaseName() == DeclBaseName::createConstructor()) {
+      if (decl->getBaseName() == DeclBaseName::createConstructor()) {
         /// FIXME: Avoid the possibility of an infinite loop by fixing the root
         ///        cause instead (incomplete circularity detection).
         assert(decl != overrides && "Circular class inheritance?");
@@ -444,7 +444,7 @@ static void recordShadowedDeclsAfterSignatureMatch(
           if (owningStruct1 == owningStruct2 &&
               owningStruct1->getName().is("Data") &&
               isa<FuncDecl>(firstDecl) && isa<FuncDecl>(secondDecl) &&
-              firstDecl->getFullName() == secondDecl->getFullName() &&
+              firstDecl->getName() == secondDecl->getName() &&
               firstDecl->getBaseName().userFacingName() == "withUnsafeBytes") {
             // If the second module is the Foundation module and the first
             // is the NIOFoundationCompat module, the second is shadowed by the
@@ -602,7 +602,7 @@ bool swift::removeShadowedDecls(SmallVectorImpl<ValueDecl*> &decls,
   bool anyCollisions = false;
   for (auto decl : decls) {
     // Record this declaration based on its full name.
-    auto &knownDecls = collidingDeclGroups[decl->getFullName()];
+    auto &knownDecls = collidingDeclGroups[decl->getName()];
     if (!knownDecls.empty())
       anyCollisions = true;
 
@@ -616,7 +616,7 @@ bool swift::removeShadowedDecls(SmallVectorImpl<ValueDecl*> &decls,
   // Walk through the declarations again, marking any declarations that shadow.
   llvm::SmallPtrSet<ValueDecl *, 4> shadowed;
   for (auto decl : decls) {
-    auto known = collidingDeclGroups.find(decl->getFullName());
+    auto known = collidingDeclGroups.find(decl->getName());
     if (known == collidingDeclGroups.end()) {
       // We already handled this group.
       continue;
@@ -1015,7 +1015,7 @@ void MemberLookupTable::addMember(Decl *member) {
 
   // Add this declaration to the lookup set under its compound name and simple
   // name.
-  vd->getFullName().addToLookupTable(Lookup, vd);
+  vd->getName().addToLookupTable(Lookup, vd);
 
   // And if given a synonym, under that name too.
   if (A)
@@ -1213,7 +1213,7 @@ maybeFilterOutAttrImplements(TinyPtrVector<ValueDecl *> decls,
     // Filter-out any decl that doesn't have the name we're looking for
     // (asserting as a consistency-check that such entries all have
     // @_implements attrs for the name!)
-    if (V->getFullName().matchesRef(name)) {
+    if (V->getName().matchesRef(name)) {
       result.push_back(V);
     } else {
       auto A = V->getAttrs().getAttribute<ImplementsAttr>();
@@ -2256,7 +2256,7 @@ CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
                            moduleName.str().str() + ".");
             ctx.Diags.diagnose(assocType, diag::kind_declname_declared_here,
                                assocType->getDescriptiveKind(),
-                               assocType->getFullName());
+                               assocType->getName());
 
             ComponentIdentTypeRepr *components[2] = {
               new (ctx) SimpleIdentTypeRepr(identTypeRepr->getNameLoc(),

--- a/lib/AST/PrettyStackTrace.cpp
+++ b/lib/AST/PrettyStackTrace.cpp
@@ -48,7 +48,7 @@ void swift::printDeclDescription(llvm::raw_ostream &out, const Decl *D,
   bool hasPrintedName = false;
   if (auto *named = dyn_cast<ValueDecl>(D)) {
     if (named->hasName()) {
-      out << '\'' << named->getFullName() << '\'';
+      out << '\'' << named->getName() << '\'';
       hasPrintedName = true;
     } else if (auto *accessor = dyn_cast<AccessorDecl>(named)) {
       auto ASD = accessor->getStorage();
@@ -80,7 +80,7 @@ void swift::printDeclDescription(llvm::raw_ostream &out, const Decl *D,
           break;
         }
 
-        out << " for " << ASD->getFullName();
+        out << " for " << ASD->getName();
         hasPrintedName = true;
         loc = ASD->getStartLoc();
       }

--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -301,7 +301,7 @@ void TypeRefinementContext::print(raw_ostream &OS, SourceManager &SrcMgr,
     Decl *D = Node.getAsDecl();
     OS << " decl=";
     if (auto VD = dyn_cast<ValueDecl>(D)) {
-      OS << VD->getFullName();
+      OS << VD->getName();
     } else if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
       OS << "extension." << ED->getExtendedType().getString();
     }

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -1221,7 +1221,7 @@ bool ASTScopeDeclConsumerForUnqualifiedLookup::consume(
   for (auto *value: values) {
     if (factory.isOriginallyTypeLookup && !isa<TypeDecl>(value))
       continue;
-    if (!value->getFullName().matchesRef(factory.Name.getFullName()))
+    if (!value->getName().matchesRef(factory.Name.getFullName()))
       continue;
 
     // In order to preserve the behavior of the existing context-based lookup,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2980,7 +2980,7 @@ ClangModuleUnit::lookupNestedType(Identifier name,
       if (importedContext != baseType)
         return true;
 
-      assert(decl->getFullName().matchesRef(name) &&
+      assert(decl->getName() == name &&
              "importFullName behaved differently from importDecl");
       results.push_back(decl);
       anyMatching = true;
@@ -3635,7 +3635,7 @@ void ClangImporter::Implementation::lookupValue(
 
     // If the name matched, report this result.
     bool anyMatching = false;
-    if (decl->getFullName().matchesRef(name) &&
+    if (decl->getName().matchesRef(name) &&
         decl->getDeclContext()->isModuleScopeContext()) {
       consumer.foundDecl(decl, DeclVisibilityKind::VisibleAtTopLevel);
       anyMatching = true;
@@ -3644,7 +3644,7 @@ void ClangImporter::Implementation::lookupValue(
     // If there is an alternate declaration and the name matches,
     // report this result.
     for (auto alternate : getAlternateDecls(decl)) {
-      if (alternate->getFullName().matchesRef(name) &&
+      if (alternate->getName().matchesRef(name) &&
           alternate->getDeclContext()->isModuleScopeContext()) {
         consumer.foundDecl(alternate, DeclVisibilityKind::VisibleAtTopLevel);
         anyMatching = true;
@@ -3679,7 +3679,7 @@ void ClangImporter::Implementation::lookupValue(
                                                      nameVersion));
           if (!alternateNamedDecl || alternateNamedDecl == decl)
             return;
-          assert(alternateNamedDecl->getFullName().matchesRef(name) &&
+          assert(alternateNamedDecl->getName().matchesRef(name) &&
                  "importFullName behaved differently from importDecl");
           if (alternateNamedDecl->getDeclContext()->isModuleScopeContext()) {
             consumer.foundDecl(alternateNamedDecl,
@@ -3725,7 +3725,7 @@ void ClangImporter::Implementation::lookupObjCMembers(
       // If the name we found matches, report the declaration.
       // FIXME: If we didn't need to check alternate decls here, we could avoid
       // importing the member at all by checking importedName ahead of time.
-      if (decl->getFullName().matchesRef(name)) {
+      if (decl->getName().matchesRef(name)) {
         consumer.foundDecl(decl, DeclVisibilityKind::DynamicLookup,
                            DynamicLookupInfo::AnyObject);
       }
@@ -3733,7 +3733,7 @@ void ClangImporter::Implementation::lookupObjCMembers(
       // Check for an alternate declaration; if its name matches,
       // report it.
       for (auto alternate : getAlternateDecls(decl)) {
-        if (alternate->getFullName().matchesRef(name)) {
+        if (alternate->getName().matchesRef(name)) {
           consumer.foundDecl(alternate, DeclVisibilityKind::DynamicLookup,
                              DynamicLookupInfo::AnyObject);
         }

--- a/lib/ClangImporter/DWARFImporter.cpp
+++ b/lib/ClangImporter/DWARFImporter.cpp
@@ -160,7 +160,7 @@ void ClangImporter::Implementation::lookupValueDWARF(
     if (!swiftDecl)
       continue;
 
-    if (swiftDecl->getFullName().matchesRef(name) &&
+    if (swiftDecl->getName().matchesRef(name) &&
         swiftDecl->getDeclContext()->isModuleScopeContext()) {
       forceLoadAllMembers(dyn_cast<IterableDeclContext>(swiftDecl));
       results.push_back(swiftDecl);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2189,7 +2189,7 @@ namespace {
           if (fd->isInstanceMember() != decl->isInstanceProperty())
             continue;
 
-          assert(fd->getFullName().getArgumentNames().empty());
+          assert(fd->getName().getArgumentNames().empty());
           foundMethod = true;
         } else {
           auto *var = cast<VarDecl>(result);
@@ -4160,7 +4160,7 @@ namespace {
       for (auto decl : classDecl->lookupDirect(selector, isInstance)) {
         if ((decl->getClangDecl()
              || !decl->getDeclContext()->getParentSourceFile())
-            && importedName.getDeclName() == decl->getFullName()
+            && importedName.getDeclName() == decl->getName()
             && filter(decl)) {
           result = true;
           break;
@@ -4465,7 +4465,7 @@ namespace {
       // We only care about recording methods with no arguments here, because
       // they can shadow imported properties.
       if (!isa<AccessorDecl>(result) &&
-          result->getFullName().getArgumentNames().empty()) {
+          result->getName().getArgumentNames().empty()) {
         recordMemberInContext(dc, result);
       }
 
@@ -6519,7 +6519,7 @@ void SwiftDeclConverter::recordObjCOverride(AbstractFunctionDecl *decl) {
     return;
   // Dig out the Objective-C superclass.
   SmallVector<ValueDecl *, 4> results;
-  superDecl->lookupQualified(superDecl, DeclNameRef(decl->getFullName()),
+  superDecl->lookupQualified(superDecl, DeclNameRef(decl->getName()),
                              NL_QualifiedDefault | NL_KnownNoDependency,
                              results);
   for (auto member : results) {
@@ -6592,7 +6592,7 @@ void SwiftDeclConverter::recordObjCOverride(SubscriptDecl *subscript) {
   // operation.
   SmallVector<ValueDecl *, 2> lookup;
   subscript->getModuleContext()->lookupQualified(
-      superDecl, DeclNameRef(subscript->getFullName()),
+      superDecl, DeclNameRef(subscript->getName()),
       NL_QualifiedDefault | NL_KnownNoDependency, lookup);
 
   for (auto result : lookup) {
@@ -7705,7 +7705,7 @@ void ClangImporter::Implementation::importAttributes(
   // Hack: mark any method named "print" with less than two parameters as
   // warn_unqualified_access.
   if (auto MD = dyn_cast<FuncDecl>(MappedDecl)) {
-    if (isPrintLikeMethod(MD->getFullName(), MD->getDeclContext())) {
+    if (isPrintLikeMethod(MD->getName(), MD->getDeclContext())) {
       // Use a non-implicit attribute so it shows up in the generated
       // interface.
       MD->getAttrs().add(new (C) WarnUnqualifiedAccessAttr(/*implicit*/false));
@@ -7902,7 +7902,7 @@ static void finishTypeWitnesses(
                           NL_OnlyTypes |
                           NL_ProtocolMembers);
 
-    dc->lookupQualified(nominal, DeclNameRef(assocType->getFullName()), options,
+    dc->lookupQualified(nominal, DeclNameRef(assocType->getName()), options,
                         lookupResults);
     for (auto member : lookupResults) {
       auto typeDecl = cast<TypeDecl>(member);

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -368,7 +368,7 @@ void ProvidesEmitter::CollectedDeclarations::findNominalsAndOperators(
       continue;
     }
 
-    if (VD->getFullName().isOperator()) {
+    if (VD->getName().isOperator()) {
       memberOperatorDecls.push_back(cast<FuncDecl>(VD));
       continue;
     }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1722,7 +1722,7 @@ public:
 private:
   void foundFunction(const AbstractFunctionDecl *AFD) {
     FoundFunctionCalls = true;
-    DeclName Name = AFD->getFullName();
+    const DeclName Name = AFD->getName();
     auto ArgNames = Name.getArgumentNames();
     if (ArgNames.empty())
       return;
@@ -3215,7 +3215,7 @@ public:
     addValueBaseName(Builder, AFD->getBaseName());
 
     // Add the argument labels.
-    auto ArgLabels = AFD->getFullName().getArgumentNames();
+    const auto ArgLabels = AFD->getName().getArgumentNames();
     if (!ArgLabels.empty()) {
       if (!HaveLParen)
         Builder.addLeftParen();
@@ -5572,7 +5572,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
     Lookup.setIsStaticMetatype(ParsedExpr->isStaticallyDerivedMetatype());
   }
   if (auto *DRE = dyn_cast_or_null<DeclRefExpr>(ParsedExpr)) {
-    Lookup.setIsSelfRefExpr(DRE->getDecl()->getFullName() == Context.Id_self);
+    Lookup.setIsSelfRefExpr(DRE->getDecl()->getName() == Context.Id_self);
   } else if (ParsedExpr && isa<SuperRefExpr>(ParsedExpr)) {
     Lookup.setIsSuperRefExpr();
   }

--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -336,7 +336,7 @@ void CommentToXMLConverter::visitDocComment(const DocComment *DC) {
   if (VD && VD->hasName()) {
     llvm::SmallString<64> SS;
     llvm::raw_svector_ostream NameOS(SS);
-    NameOS << VD->getFullName();
+    NameOS << VD->getName();
     appendWithXMLEscaping(OS, NameOS.str());
   }
   OS << "</Name>";

--- a/lib/IDE/ConformingMethodList.cpp
+++ b/lib/IDE/ConformingMethodList.cpp
@@ -189,7 +189,7 @@ void PrintingConformingMethodListConsumer::handleResult(
     auto resultTy = funcTy->castTo<FunctionType>()->getResult();
 
     OS << "   - Name: ";
-    VD->getFullName().print(OS);
+    VD->getName().print(OS);
     OS << "\n";
 
     OS << "     TypeName: ";

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -426,7 +426,7 @@ static bool collectPossibleCalleesForApply(
   } else if (auto *DSCE = dyn_cast<DotSyntaxCallExpr>(fnExpr)) {
     if (auto *DRE = dyn_cast<DeclRefExpr>(DSCE->getFn())) {
       collectPossibleCalleesByQualifiedLookup(
-          DC, DSCE->getArg(), DeclNameRef(DRE->getDecl()->getFullName()),
+          DC, DSCE->getArg(), DeclNameRef(DRE->getDecl()->getName()),
           candidates);
     }
   } else if (auto CRCE = dyn_cast<ConstructorRefCallExpr>(fnExpr)) {

--- a/lib/IDE/IDERequests.cpp
+++ b/lib/IDE/IDERequests.cpp
@@ -1095,7 +1095,7 @@ static Type getContextFreeInterfaceType(ValueDecl *VD) {
 ArrayRef<ValueDecl *>
 ProvideDefaultImplForRequest::evaluate(Evaluator &eval, ValueDecl* VD) const {
   // Skip decls that don't have valid names.
-  if (!VD->getFullName())
+  if (!VD->getName())
     return ArrayRef<ValueDecl*>();
 
   // Check if VD is from a protocol extension.
@@ -1107,7 +1107,7 @@ ProvideDefaultImplForRequest::evaluate(Evaluator &eval, ValueDecl* VD) const {
   // the same name with VD.
   ResolvedMemberResult LookupResult =
   resolveValueMember(*P->getInnermostDeclContext(),
-                     P->getDeclaredInterfaceType(), VD->getFullName());
+                     P->getDeclaredInterfaceType(), VD->getName());
 
   auto VDType = getContextFreeInterfaceType(VD);
   for (auto Mem : LookupResult.getMemberDecls(InterestedMemberKind::All)) {

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -559,7 +559,7 @@ collectDefaultImplementationForProtocolMembers(ProtocolDecl *PD,
       if (VD->getBaseName().empty())
         continue;
 
-      for (auto *Default: PD->lookupDirect(VD->getFullName())) {
+      for (auto *Default: PD->lookupDirect(VD->getName())) {
         if (Default->getDeclContext()->getExtendedProtocolDecl() == PD) {
           DefaultMap.insert({Default, VD});
         }

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -775,7 +775,7 @@ static void analyzeRenameScope(ValueDecl *VD, Optional<RenameRefInfo> RefInfo,
                                llvm::SmallVectorImpl<DeclContext *> &Scopes) {
   Scopes.clear();
   if (!getAvailableRenameForDecl(VD, RefInfo).hasValue()) {
-    Diags.diagnose(SourceLoc(), diag::value_decl_no_loc, VD->getFullName());
+    Diags.diagnose(SourceLoc(), diag::value_decl_no_loc, VD->getName());
     return;
   }
 
@@ -888,7 +888,7 @@ ExtractCheckResult checkExtractConditions(ResolvedRangeInfo &RangeInfo,
   if (It != Declared.end()) {
     DiagEngine.diagnose(It->VD->getLoc(),
                         diag::value_decl_referenced_out_of_range,
-                        It->VD->getFullName());
+                        It->VD->getName());
     return ExtractCheckResult();
   }
 
@@ -2560,8 +2560,8 @@ struct ConvertToTernaryExprInfo {
         if (!ThenRef || !ThenRef->getDecl() || !ElseRef || !ElseRef->getDecl())
           return nullptr;
 
-        auto ThenName = ThenRef->getDecl()->getFullName();
-        auto ElseName = ElseRef->getDecl()->getFullName();
+        const auto ThenName = ThenRef->getDecl()->getName();
+        const auto ElseName = ElseRef->getDecl()->getName();
 
         if (ThenName.compare(ElseName) != 0)
           return nullptr;

--- a/lib/IDE/TypeContextInfo.cpp
+++ b/lib/IDE/TypeContextInfo.cpp
@@ -191,7 +191,7 @@ void PrintingTypeContextInfoConsumer::handleResults(
       OS << "   - ";
 
       OS << "Name: ";
-      VD->getFullName().print(OS);
+      VD->getName().print(OS);
       OS << "\n";
 
       StringRef BriefDoc = VD->getBriefComment();

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -41,16 +41,16 @@ static bool
 printArtificialName(const swift::AbstractStorageDecl *ASD, AccessorKind AK, llvm::raw_ostream &OS) {
   switch (AK) {
   case AccessorKind::Get:
-    OS << "getter:" << ASD->getFullName();
+    OS << "getter:" << ASD->getName();
     return false;
   case AccessorKind::Set:
-    OS << "setter:" << ASD->getFullName();
+    OS << "setter:" << ASD->getName();
     return false;
   case AccessorKind::DidSet:
-    OS << "didSet:" << ASD->getFullName();
+    OS << "didSet:" << ASD->getName();
     return false;
   case AccessorKind::WillSet:
-    OS << "willSet:" << ASD->getFullName() ;
+    OS << "willSet:" << ASD->getName() ;
     return false;
 
   case AccessorKind::Address:
@@ -71,7 +71,7 @@ static bool printDisplayName(const swift::ValueDecl *D, llvm::raw_ostream &OS) {
     return printArtificialName(FD->getStorage(), FD->getAccessorKind(), OS);
   }
 
-  OS << D->getFullName();
+  OS << D->getName();
   return false;
 }
 
@@ -381,7 +381,7 @@ private:
       while ((ArgLoc = NameLoc.getArgumentLabelLoc(LabelIndex++)).isValid()) {
         LabelLocs.push_back(ArgLoc);
       }
-      Labels = MemberwiseInit->getFullName().getArgumentNames();
+      Labels = MemberwiseInit->getName().getArgumentNames();
     } else if (auto *CallParent = dyn_cast_or_null<CallExpr>(getParentExpr())) {
       LabelLocs = CallParent->getArgumentLabelLocs();
       Labels = CallParent->getArgumentLabels();

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2282,7 +2282,7 @@ Expr *Parser::parseExprIdentifier() {
       }
     } else {
       for (auto activeVar : DisabledVars) {
-        if (activeVar->getFullName() == name.getFullName()) {
+        if (activeVar->getName() == name.getFullName()) {
           diagnose(loc.getBaseNameLoc(), DisabledVarReason);
           return new (Context) ErrorExpr(loc.getSourceRange());
         }

--- a/lib/Parse/Scope.cpp
+++ b/lib/Parse/Scope.cpp
@@ -114,7 +114,7 @@ void ScopeInfo::addToScope(ValueDecl *D, Parser &TheParser,
 
   // If we have a shadowed variable definition, check to see if we have a
   // redefinition: two definitions in the same scope with the same name.
-  ScopedHTTy::iterator EntryI = HT.begin(CurScope->HTScope, D->getFullName());
+  ScopedHTTy::iterator EntryI = HT.begin(CurScope->HTScope, D->getName());
 
   // A redefinition is a hit in the scoped table at the same depth.
   if (EntryI != HT.end() && EntryI->first == CurScope->getDepth()) {
@@ -141,7 +141,7 @@ void ScopeInfo::addToScope(ValueDecl *D, Parser &TheParser,
   }
 
   HT.insertIntoScope(CurScope->HTScope,
-                     D->getFullName(),
+                     D->getName(),
                      std::make_pair(CurScope->getDepth(), D));
 }
 

--- a/lib/PrintAsObjC/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.cpp
@@ -210,7 +210,7 @@ private:
       if (isa<AccessorDecl>(VD))
         continue;
       if (!AllowDelayed && owningPrinter.delayedMembers.count(VD)) {
-        os << "// '" << VD->getFullName() << "' below\n";
+        os << "// '" << VD->getName() << "' below\n";
         continue;
       }
       if (VD->getAttrs().hasAttribute<OptionalAttr>() !=
@@ -1020,7 +1020,7 @@ private:
     printEncodedString(nominal->getName().str(), /*includeQuotes=*/false);
     os << ".";
     SmallString<32> scratch;
-    printEncodedString(VD->getFullName().getString(scratch),
+    printEncodedString(VD->getName().getString(scratch),
                        /*includeQuotes=*/false);
     os << "' uses '@objc' inference deprecated in Swift 4; add '@objc' to "
        <<   "provide an Objective-C entrypoint\")";

--- a/lib/SIL/IR/SILConstants.cpp
+++ b/lib/SIL/IR/SILConstants.cpp
@@ -861,7 +861,7 @@ static void getWitnessMethodName(WitnessMethodInst *witnessMethodInst,
   assert(witnessMethodInst);
   SILDeclRef witnessMember = witnessMethodInst->getMember();
   if (witnessMember.hasDecl()) {
-    witnessMember.getDecl()->getFullName().getString(methodName);
+    witnessMember.getDecl()->getName().getString(methodName);
   }
 }
 

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -456,7 +456,7 @@ struct DOTGraphTraits<SILFunction *> : public DefaultDOTGraphTraits {
 
       EnumElementDecl *E =
           getCaseValueForBB<SwitchEnumInst, EnumElementDecl *>(SEIB, Succ);
-      OS << E->getFullName();
+      OS << E->getName();
       return OS.str();
     }
 
@@ -466,7 +466,7 @@ struct DOTGraphTraits<SILFunction *> : public DefaultDOTGraphTraits {
 
       EnumElementDecl *E =
           getCaseValueForBB<SwitchEnumAddrInst, EnumElementDecl *>(SEIB, Succ);
-      OS << E->getFullName();
+      OS << E->getName();
       return OS.str();
     }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1305,7 +1305,7 @@ RValue RValueEmitter::visitDerivedToBaseExpr(DerivedToBaseExpr *E,
   if (inExclusiveBorrowSelfSection(SGF.SelfInitDelegationState)) {
     if (auto *dre = dyn_cast<DeclRefExpr>(E->getSubExpr())) {
       if (isa<ParamDecl>(dre->getDecl()) &&
-          dre->getDecl()->getFullName() == SGF.getASTContext().Id_self &&
+          dre->getDecl()->getName() == SGF.getASTContext().Id_self &&
           dre->getDecl()->isImplicit()) {
         return visitDerivedToBaseExprOfSelf(SGF, dre, E, C);
       }
@@ -2373,7 +2373,7 @@ SILValue SILGenFunction::emitMetatypeOfValue(SILLocation loc, Expr *baseExpr) {
     if (inExclusiveBorrowSelfSection(SelfInitDelegationState)) {
       if (auto *dre = dyn_cast<DeclRefExpr>(baseExpr)) {
         if (isa<ParamDecl>(dre->getDecl()) &&
-            dre->getDecl()->getFullName() == getASTContext().Id_self &&
+            dre->getDecl()->getName() == getASTContext().Id_self &&
             dre->getDecl()->isImplicit()) {
           return emitMetatypeOfDelegatingInitExclusivelyBorrowedSelf(
               *this, loc, dre, metaTy);

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -75,7 +75,7 @@ DeclName SILGenModule::getMagicFunctionName(DeclContext *dc) {
   if (auto absFunc = dyn_cast<AbstractFunctionDecl>(dc)) {
     // If this is an accessor, use the name of the storage.
     if (auto accessor = dyn_cast<AccessorDecl>(absFunc))
-      return accessor->getStorage()->getFullName();
+      return accessor->getStorage()->getName();
     if (auto func = dyn_cast<FuncDecl>(absFunc)) {
       // If this is a defer body, use the parent name.
       if (func->isDeferBody()) {
@@ -83,7 +83,7 @@ DeclName SILGenModule::getMagicFunctionName(DeclContext *dc) {
       }
     }
 
-    return absFunc->getFullName();
+    return absFunc->getName();
   }
   if (auto init = dyn_cast<Initializer>(dc)) {
     return getMagicFunctionName(init->getParent());
@@ -105,10 +105,10 @@ DeclName SILGenModule::getMagicFunctionName(DeclContext *dc) {
     return e->getExtendedNominal()->getName();
   }
   if (auto EED = dyn_cast<EnumElementDecl>(dc)) {
-    return EED->getFullName();
+    return EED->getName();
   }
   if (auto SD = dyn_cast<SubscriptDecl>(dc)) {
-    return SD->getFullName();
+    return SD->getName();
   }
   llvm_unreachable("unexpected #function context");
 }

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1043,7 +1043,7 @@ static bool isReadNoneFunction(const Expr *e) {
   // we can "safely" assume it is readnone (btw, yes this is totally gross).
   // This is better to be attribute driven, a la rdar://15587352.
   if (auto *dre = dyn_cast<DeclRefExpr>(e)) {
-    DeclName name = dre->getDecl()->getFullName();
+    const DeclName name = dre->getDecl()->getName();
     return (name.getArgumentNames().size() == 1 &&
             name.getBaseName() == DeclBaseName::createConstructor() &&
             !name.getArgumentNames()[0].empty() &&
@@ -2433,7 +2433,7 @@ static ManagedValue visitRecNonInOutBase(SILGenLValue &SGL, Expr *e,
     // this handles the case in initializers where there is actually a stack
     // allocation for it as well.
     if (isa<ParamDecl>(dre->getDecl()) &&
-        dre->getDecl()->getFullName() == SGF.getASTContext().Id_self &&
+        dre->getDecl()->getName() == SGF.getASTContext().Id_self &&
         dre->getDecl()->isImplicit()) {
       ctx = SGFContext::AllowGuaranteedPlusZero;
       if (SGF.SelfInitDelegationState != SILGenFunction::NormalSelf) {

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -123,7 +123,7 @@ class BuilderClosureVisitor
 
         // Function must have the right argument labels, if provided.
         if (!argLabels.empty()) {
-          auto funcLabels = func->getFullName().getArgumentNames();
+          auto funcLabels = func->getName().getArgumentNames();
           if (argLabels.size() > funcLabels.size() ||
               funcLabels.slice(0, argLabels.size()) != argLabels)
             continue;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1221,7 +1221,7 @@ namespace {
                   Swift3ObjCInferenceWarnings::Minimal) {
             context.Diags.diagnose(
                 memberLoc, diag::expr_dynamic_lookup_swift3_objc_inference,
-                member->getDescriptiveKind(), member->getFullName(),
+                member->getDescriptiveKind(), member->getName(),
                 member->getDeclContext()->getSelfNominalTypeDecl()->getName());
             context.Diags
                 .diagnose(member, diag::make_decl_objc,
@@ -2946,7 +2946,7 @@ namespace {
         bool diagnoseBadInitRef = true;
         auto arg = base->getSemanticsProvidingExpr();
         if (auto dre = dyn_cast<DeclRefExpr>(arg)) {
-          if (dre->getDecl()->getFullName() == cs.getASTContext().Id_self) {
+          if (dre->getDecl()->getName() == cs.getASTContext().Id_self) {
             // We have a reference to 'self'.
             diagnoseBadInitRef = false;
             // Make sure the reference to 'self' occurs within an initializer.
@@ -3525,7 +3525,7 @@ namespace {
             // initializer failable.
             de.diagnose(otherCtorRef->getLoc(),
                         diag::delegate_chain_nonoptional_to_optional,
-                        isChaining, ctor->getFullName());
+                        isChaining, ctor->getName());
             de.diagnose(otherCtorRef->getLoc(), diag::init_force_unwrap)
                 .fixItInsertAfter(expr->getEndLoc(), "!");
             de.diagnose(inCtor->getLoc(), diag::init_propagate_failure)
@@ -4433,9 +4433,9 @@ namespace {
         if (!func->getDeclContext()->isTypeContext()) {
           de.diagnose(E->getLoc(), diag::expr_selector_not_method,
                       func->getDeclContext()->isModuleScopeContext(),
-                      func->getFullName())
+                      func->getName())
               .highlight(subExpr->getSourceRange());
-          de.diagnose(func, diag::decl_declared_here, func->getFullName());
+          de.diagnose(func, diag::decl_declared_here, func->getName());
           return E;
         }
 
@@ -4451,7 +4451,7 @@ namespace {
           de.diagnose(E->getModifierLoc(),
                       diag::expr_selector_expected_property,
                       E->getSelectorKind() == ObjCSelectorExpr::Setter,
-                      foundDecl->getDescriptiveKind(), foundDecl->getFullName())
+                      foundDecl->getDescriptiveKind(), foundDecl->getName())
               .fixItRemoveChars(E->getModifierLoc(),
                                 E->getSubExpr()->getStartLoc());
 
@@ -4468,9 +4468,9 @@ namespace {
         // If this isn't a property on a type, complain.
         if (!var->getDeclContext()->isTypeContext()) {
           de.diagnose(E->getLoc(), diag::expr_selector_not_property,
-                      isa<ParamDecl>(var), var->getFullName())
+                      isa<ParamDecl>(var), var->getName())
               .highlight(subExpr->getSourceRange());
-          de.diagnose(var, diag::decl_declared_here, var->getFullName());
+          de.diagnose(var, diag::decl_declared_here, var->getName());
           return E;
         }
 
@@ -4481,7 +4481,7 @@ namespace {
             var->isSetterAccessibleFrom(cs.DC);
           auto primaryDiag =
               de.diagnose(E->getLoc(), diag::expr_selector_expected_method,
-                          isSettable, var->getFullName());
+                          isSettable, var->getName());
           primaryDiag.highlight(subExpr->getSourceRange());
 
           // The point at which we will insert the modifier.
@@ -4495,10 +4495,10 @@ namespace {
 
             // Add notes for the getter and setter, respectively.
             de.diagnose(modifierLoc, diag::expr_selector_add_modifier, false,
-                        var->getFullName())
+                        var->getName())
                 .fixItInsert(modifierLoc, "getter: ");
             de.diagnose(modifierLoc, diag::expr_selector_add_modifier, true,
-                        var->getFullName())
+                        var->getName())
                 .fixItInsert(modifierLoc, "setter: ");
 
             // Bail out now. We don't know what the user wanted, so
@@ -4521,8 +4521,8 @@ namespace {
           // Make sure we actually have a setter.
           if (!var->isSettable(cs.DC)) {
             de.diagnose(E->getLoc(), diag::expr_selector_property_not_settable,
-                        var->getDescriptiveKind(), var->getFullName());
-            de.diagnose(var, diag::decl_declared_here, var->getFullName());
+                        var->getDescriptiveKind(), var->getName());
+            de.diagnose(var, diag::decl_declared_here, var->getName());
             return E;
           }
 
@@ -4530,8 +4530,8 @@ namespace {
           if (!var->isSetterAccessibleFrom(cs.DC)) {
             de.diagnose(E->getLoc(),
                         diag::expr_selector_property_setter_inaccessible,
-                        var->getDescriptiveKind(), var->getFullName());
-            de.diagnose(var, diag::decl_declared_here, var->getFullName());
+                        var->getDescriptiveKind(), var->getName());
+            de.diagnose(var, diag::decl_declared_here, var->getName());
             return E;
           }
 
@@ -4543,7 +4543,7 @@ namespace {
         de.diagnose(E->getLoc(), diag::expr_selector_no_declaration)
             .highlight(subExpr->getSourceRange());
         de.diagnose(foundDecl, diag::decl_declared_here,
-                    foundDecl->getFullName());
+                    foundDecl->getName());
         return E;
       }
       assert(method && "Didn't find a method?");
@@ -4557,12 +4557,12 @@ namespace {
         // problems.
         if (auto protocolDecl = dyn_cast<ProtocolDecl>(foundDecl->getDeclContext())) {
           de.diagnose(E->getLoc(), diag::expr_selector_cannot_be_used,
-                      foundDecl->getBaseName(), protocolDecl->getFullName());
+                      foundDecl->getBaseName(), protocolDecl->getName());
           return E;
         }
 
         de.diagnose(E->getLoc(), diag::expr_selector_not_objc,
-                    foundDecl->getDescriptiveKind(), foundDecl->getFullName())
+                    foundDecl->getDescriptiveKind(), foundDecl->getName())
             .highlight(subExpr->getSourceRange());
         de.diagnose(foundDecl, diag::make_decl_objc,
                     foundDecl->getDescriptiveKind())
@@ -4575,7 +4575,7 @@ namespace {
             cs.getASTContext().LangOpts.WarnSwift3ObjCInference ==
                 Swift3ObjCInferenceWarnings::Minimal) {
           de.diagnose(E->getLoc(), diag::expr_selector_swift3_objc_inference,
-                      foundDecl->getDescriptiveKind(), foundDecl->getFullName(),
+                      foundDecl->getDescriptiveKind(), foundDecl->getName(),
                       foundDecl->getDeclContext()
                           ->getSelfNominalTypeDecl()
                           ->getName())

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -342,7 +342,7 @@ bool RequirementFailure::diagnoseAsError() {
   if (auto *OTD = dyn_cast<OpaqueTypeDecl>(AffectedDecl)) {
     auto *namingDecl = OTD->getNamingDecl();
     emitDiagnostic(diag::type_does_not_conform_in_opaque_return,
-                   namingDecl->getDescriptiveKind(), namingDecl->getFullName(),
+                   namingDecl->getDescriptiveKind(), namingDecl->getName(),
                    lhs, rhs, rhs->isAnyObject());
 
     if (auto *repr = namingDecl->getOpaqueResultTypeRepr()) {
@@ -358,10 +358,10 @@ bool RequirementFailure::diagnoseAsError() {
     auto *NTD = reqDC->getSelfNominalTypeDecl();
     emitDiagnostic(
         getDiagnosticInRereference(), AffectedDecl->getDescriptiveKind(),
-        AffectedDecl->getFullName(), NTD->getDeclaredType(), lhs, rhs);
+        AffectedDecl->getName(), NTD->getDeclaredType(), lhs, rhs);
   } else {
     emitDiagnostic(getDiagnosticOnDecl(), AffectedDecl->getDescriptiveKind(),
-                   AffectedDecl->getFullName(), lhs, rhs);
+                   AffectedDecl->getName(), lhs, rhs);
   }
 
   emitRequirementNote(reqDC->getAsDecl(), lhs, rhs);
@@ -483,7 +483,7 @@ bool MissingConformanceFailure::diagnoseTypeCannotConform(
     if (auto *repr = namingDecl->getOpaqueResultTypeRepr()) {
       emitDiagnosticAt(repr->getLoc(), diag::required_by_opaque_return,
                        namingDecl->getDescriptiveKind(),
-                       namingDecl->getFullName())
+                       namingDecl->getName())
           .highlight(repr->getSourceRange());
     }
     return true;
@@ -506,13 +506,13 @@ bool MissingConformanceFailure::diagnoseTypeCannotConform(
                                      isStaticOrInstanceMember(AffectedDecl))) {
     emitDiagnosticAt(noteLocation, diag::required_by_decl_ref,
                      AffectedDecl->getDescriptiveKind(),
-                     AffectedDecl->getFullName(),
+                     AffectedDecl->getName(),
                      reqDC->getSelfNominalTypeDecl()->getDeclaredType(),
                      req.getFirstType(), nonConformingType);
   } else {
     emitDiagnosticAt(noteLocation, diag::required_by_decl,
                      AffectedDecl->getDescriptiveKind(),
-                     AffectedDecl->getFullName(), req.getFirstType(),
+                     AffectedDecl->getName(), req.getFirstType(),
                      nonConformingType);
   }
 
@@ -1323,7 +1323,7 @@ bool RValueTreatedAsLValueFailure::diagnoseAsError() {
                   getConstraintLocator(member, ConstraintLocator::Member))) {
             if (auto *ref = overload->choice.getDeclOrNull())
               emitDiagnosticAt(ref, diag::decl_declared_here,
-                               ref->getFullName());
+                               ref->getName());
           }
           return true;
         }
@@ -1360,7 +1360,7 @@ bool RValueTreatedAsLValueFailure::diagnoseAsNote() {
 
   auto *decl = overload->choice.getDecl();
   emitDiagnosticAt(decl, diag::candidate_is_not_assignable,
-                   decl->getDescriptiveKind(), decl->getFullName());
+                   decl->getDescriptiveKind(), decl->getName());
   return true;
 }
 
@@ -1463,7 +1463,7 @@ bool TrailingClosureAmbiguityFailure::diagnoseAsNote() {
   for (const auto &choicePair : choicesByLabel) {
     auto diag = emitDiagnosticAt(
         expr->getLoc(), diag::ambiguous_because_of_trailing_closure,
-        choicePair.first.empty(), choicePair.second->getFullName());
+        choicePair.first.empty(), choicePair.second->getName());
     swift::fixItEncloseTrailingClosure(getASTContext(), diag, callExpr,
                                        choicePair.first);
   }
@@ -2053,7 +2053,7 @@ bool ContextualFailure::diagnoseAsError() {
     auto fnType = fromType->getAs<FunctionType>();
     if (!fnType) {
       emitDiagnostic(diag::expected_result_in_contextual_member,
-                     choice->getFullName(), fromType, toType);
+                     choice->getName(), fromType, toType);
       return true;
     }
 
@@ -2078,7 +2078,7 @@ bool ContextualFailure::diagnoseAsError() {
 
     if (numMissingArgs == 0 || numMissingArgs > 1) {
       auto diagnostic = emitDiagnostic(
-          diag::expected_parens_in_contextual_member, choice->getFullName());
+          diag::expected_parens_in_contextual_member, choice->getName());
 
       // If there are no parameters we can suggest a fix-it
       // to form an explicit call.
@@ -2086,7 +2086,7 @@ bool ContextualFailure::diagnoseAsError() {
         diagnostic.fixItInsertAfter(getSourceRange().End, "()");
     } else {
       emitDiagnostic(diag::expected_argument_in_contextual_member,
-                     choice->getFullName(), params.front().getPlainType());
+                     choice->getName(), params.front().getPlainType());
     }
 
     return true;
@@ -3129,7 +3129,7 @@ bool ExtraneousPropertyWrapperUnwrapFailure::diagnoseAsError() {
 
   if (auto *member = getReferencedMember()) {
     emitDiagnostic(diag::incorrect_property_wrapper_reference_member,
-                   member->getDescriptiveKind(), member->getFullName(), false,
+                   member->getDescriptiveKind(), member->getName(), false,
                    getToType())
         .fixItInsert(getLoc(), newPrefix);
     return true;
@@ -3146,7 +3146,7 @@ bool MissingPropertyWrapperUnwrapFailure::diagnoseAsError() {
 
   if (auto *member = getReferencedMember()) {
     emitDiagnostic(diag::incorrect_property_wrapper_reference_member,
-                   member->getDescriptiveKind(), member->getFullName(), true,
+                   member->getDescriptiveKind(), member->getName(), true,
                    getToType())
         .fixItRemoveChars(getLoc(), endLoc);
     return true;
@@ -3226,7 +3226,7 @@ DeclName MissingMemberFailure::findCorrectEnumCaseName(
                 candidate->getBaseIdentifier().str().equals_lower(
                     memberName.getBaseIdentifier().str()));
       });
-  return (candidate ? candidate->getFullName() : DeclName());
+  return (candidate ? candidate->getName() : DeclName());
 }
 
 bool MissingMemberFailure::diagnoseAsError() {
@@ -3782,7 +3782,7 @@ bool InvalidDynamicInitOnMetatypeFailure::diagnoseAsError() {
                  BaseType->getMetatypeInstanceType())
       .highlight(BaseRange);
   emitDiagnosticAt(Init, diag::note_nonrequired_initializer, Init->isImplicit(),
-                   Init->getFullName());
+                   Init->getName());
   return true;
 }
 
@@ -3931,7 +3931,7 @@ bool MissingArgumentsFailure::diagnoseAsError() {
 
   if (auto selectedOverload = getCalleeOverloadChoiceIfAvailable(locator)) {
     if (auto *decl = selectedOverload->choice.getDeclOrNull()) {
-      emitDiagnosticAt(decl, diag::decl_declared_here, decl->getFullName());
+      emitDiagnosticAt(decl, diag::decl_declared_here, decl->getName());
     }
   }
 
@@ -4067,7 +4067,7 @@ bool MissingArgumentsFailure::diagnoseSingleMissingArgument() const {
   if (auto selectedOverload =
           getCalleeOverloadChoiceIfAvailable(getLocator())) {
     if (auto *decl = selectedOverload->choice.getDeclOrNull()) {
-      emitDiagnosticAt(decl, diag::decl_declared_here, decl->getFullName());
+      emitDiagnosticAt(decl, diag::decl_declared_here, decl->getName());
     }
   }
 
@@ -4207,7 +4207,7 @@ bool MissingArgumentsFailure::diagnoseInvalidTupleDestructuring() const {
   diagnostic.flush();
 
   // Add a note which points to the overload choice location.
-  emitDiagnosticAt(decl, diag::decl_declared_here, decl->getFullName());
+  emitDiagnosticAt(decl, diag::decl_declared_here, decl->getName());
   return true;
 }
 
@@ -4628,7 +4628,7 @@ bool ExtraneousArgumentsFailure::diagnoseAsError() {
 
   if (auto overload = getCalleeOverloadChoiceIfAvailable(getLocator())) {
     if (auto *decl = overload->choice.getDeclOrNull()) {
-      emitDiagnosticAt(decl, diag::decl_declared_here, decl->getFullName());
+      emitDiagnosticAt(decl, diag::decl_declared_here, decl->getName());
     }
   }
 
@@ -4752,7 +4752,7 @@ bool InaccessibleMemberFailure::diagnoseAsError() {
         .highlight(nameLoc.getSourceRange());
   }
 
-  emitDiagnosticAt(Member, diag::decl_declared_here, Member->getFullName());
+  emitDiagnosticAt(Member, diag::decl_declared_here, Member->getName());
   return true;
 }
 
@@ -5023,7 +5023,7 @@ bool MissingGenericArgumentsFailure::diagnoseForAnchor(
     return true;
 
   if (auto *SD = dyn_cast<SubscriptDecl>(DC)) {
-    emitDiagnosticAt(SD, diag::note_call_to_subscript, SD->getFullName());
+    emitDiagnosticAt(SD, diag::note_call_to_subscript, SD->getName());
     return true;
   }
 
@@ -5034,7 +5034,7 @@ bool MissingGenericArgumentsFailure::diagnoseForAnchor(
       emitDiagnosticAt(AFD,
                        AFD->isOperator() ? diag::note_call_to_operator
                                          : diag::note_call_to_func,
-                       AFD->getFullName());
+                       AFD->getName());
     }
     return true;
   }
@@ -5238,18 +5238,18 @@ void SkipUnhandledConstructInFunctionBuilderFailure::diagnosePrimary(
   if (unhandled.is<Stmt *>()) {
     emitDiagnostic(asNote ? diag::note_function_builder_control_flow
                           : diag::function_builder_control_flow,
-                   builder->getFullName());
+                   builder->getName());
   } else {
     emitDiagnostic(asNote ? diag::note_function_builder_decl
                           : diag::function_builder_decl,
-                   builder->getFullName());
+                   builder->getName());
   }
 }
 
 bool SkipUnhandledConstructInFunctionBuilderFailure::diagnoseAsError() {
   diagnosePrimary(/*asNote=*/false);
   emitDiagnosticAt(builder, diag::kind_declname_declared_here,
-                   builder->getDescriptiveKind(), builder->getFullName());
+                   builder->getDescriptiveKind(), builder->getName());
   return true;
 }
 
@@ -5812,7 +5812,7 @@ bool InvalidUseOfTrailingClosure::diagnoseAsError() {
 
   if (auto overload = getCalleeOverloadChoiceIfAvailable(getLocator())) {
     if (auto *decl = overload->choice.getDeclOrNull()) {
-      emitDiagnosticAt(decl, diag::decl_declared_here, decl->getFullName());
+      emitDiagnosticAt(decl, diag::decl_declared_here, decl->getName());
     }
   }
 
@@ -6067,7 +6067,7 @@ bool AssignmentTypeMismatchFailure::diagnoseAsNote() {
     if (auto *decl = overload->choice.getDeclOrNull()) {
       emitDiagnosticAt(decl,
                        diag::cannot_convert_candidate_result_to_contextual_type,
-                       decl->getFullName(), getFromType(), getToType());
+                       decl->getName(), getFromType(), getToType());
       return true;
     }
   }
@@ -6197,7 +6197,7 @@ bool MissingQuialifierInMemberRefFailure::diagnoseAsError() {
   auto *DC = choice->getDeclContext();
   if (!(DC->isModuleContext() || DC->isModuleScopeContext())) {
     emitDiagnostic(diag::member_shadows_function, UDE->getName(), methodKind,
-                   choice->getDescriptiveKind(), choice->getFullName());
+                   choice->getDescriptiveKind(), choice->getName());
     return true;
   }
 
@@ -6205,7 +6205,7 @@ bool MissingQuialifierInMemberRefFailure::diagnoseAsError() {
 
   emitDiagnostic(diag::member_shadows_global_function, UDE->getName(),
                  methodKind, choice->getDescriptiveKind(),
-                 choice->getFullName(), qualifier);
+                 choice->getName(), qualifier);
 
   SmallString<32> namePlusDot = qualifier.str();
   namePlusDot.push_back('.');
@@ -6214,7 +6214,7 @@ bool MissingQuialifierInMemberRefFailure::diagnoseAsError() {
                  choice->getDescriptiveKind(), qualifier)
       .fixItInsert(UDE->getStartLoc(), namePlusDot);
 
-  emitDiagnosticAt(choice, diag::decl_declared_here, choice->getFullName());
+  emitDiagnosticAt(choice, diag::decl_declared_here, choice->getName());
   return true;
 }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1490,7 +1490,7 @@ public:
 
   DescriptiveDeclKind getKind() const { return Member->getDescriptiveKind(); }
 
-  DeclName getName() const { return Member->getFullName(); }
+  DeclName getName() const { return Member->getName(); }
 
   bool diagnoseAsError() override = 0;
 
@@ -1834,7 +1834,7 @@ protected:
   /// \returns The full name of the callee, or a null decl name if there is no
   /// callee.
   DeclName getCalleeFullName() const {
-    return getCallee() ? getCallee()->getFullName() : DeclName();
+    return getCallee() ? getCallee()->getName() : DeclName();
   }
 
   /// Returns the type of the parameter involved in the mismatch, including any

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -663,7 +663,7 @@ bool RemoveExtraneousArguments::isMinMaxNameShadowing(
     if (auto *baseExpr = dyn_cast<DeclRefExpr>(UDE->getBase())) {
       auto *decl = baseExpr->getDecl();
       if (baseExpr->isImplicit() && decl &&
-          decl->getFullName() == cs.getASTContext().Id_self) {
+          decl->getName() == cs.getASTContext().Id_self) {
         auto memberName = UDE->getName();
         return memberName.isSimpleName("min") || memberName.isSimpleName("max");
       }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6391,7 +6391,7 @@ static ConstraintFix *validateInitializerRef(ConstraintSystem &cs,
       auto &ctx = cs.getASTContext();
       if (auto *DRE =
               dyn_cast<DeclRefExpr>(baseExpr->getSemanticsProvidingExpr())) {
-        if (DRE->getDecl()->getFullName() == ctx.Id_self) {
+        if (DRE->getDecl()->getName() == ctx.Id_self) {
           if (getType(DRE)->is<ArchetypeType>())
             applicable = true;
         }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -590,7 +590,7 @@ synthesizeDesignatedInitOverride(AbstractFunctionDecl *fn, void *context) {
   auto ctorArgs = buildArgumentForwardingExpr(bodyParams->getArray(), ctx);
   auto *superclassCallExpr =
     CallExpr::create(ctx, superclassCtorRefExpr, ctorArgs,
-                     superclassCtor->getFullName().getArgumentNames(), { },
+                     superclassCtor->getName().getArgumentNames(), { },
                      /*hasTrailingClosure=*/false, /*implicit=*/true);
 
   if (auto *funcTy = type->getAs<FunctionType>())
@@ -698,7 +698,7 @@ createDesignatedInitOverride(ClassDecl *classDecl,
   // Create the initializer declaration, inheriting the name,
   // failability, and throws from the superclass initializer.
   auto ctor =
-    new (ctx) ConstructorDecl(superclassCtor->getFullName(),
+    new (ctx) ConstructorDecl(superclassCtor->getName(),
                               classDecl->getBraces().Start,
                               superclassCtor->isFailable(),
                               /*FailabilityLoc=*/SourceLoc(),
@@ -809,14 +809,14 @@ static void diagnoseMissingRequiredInitializer(
     // Add a dummy body.
     out << " {\n";
     out << indentation << extraIndentation << "fatalError(\"";
-    superInitializer->getFullName().printPretty(out);
+    superInitializer->getName().printPretty(out);
     out << " has not been implemented\")\n";
     out << indentation << "}\n";
   }
 
   // Complain.
   ctx.Diags.diagnose(insertionLoc, diag::required_initializer_missing,
-                     superInitializer->getFullName(),
+                     superInitializer->getName(),
                      superInitializer->getDeclContext()->getDeclaredInterfaceType())
     .fixItInsert(insertionLoc, initializerText);
 

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -427,7 +427,7 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
   case ConstraintKind::ValueWitness: {
     auto requirement = getRequirement();
     auto selfNominal = requirement->getDeclContext()->getSelfNominalTypeDecl();
-    Out << "[." << selfNominal->getName() << "::" << requirement->getFullName()
+    Out << "[." << selfNominal->getName() << "::" << requirement->getName()
         << ": witness] == ";
     break;
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2516,7 +2516,7 @@ DeclName OverloadChoice::getName() const {
     case OverloadChoiceKind::DeclViaDynamic:
     case OverloadChoiceKind::DeclViaBridge:
     case OverloadChoiceKind::DeclViaUnwrappedOptional:
-      return getDecl()->getFullName();
+      return getDecl()->getName();
 
     case OverloadChoiceKind::KeyPathApplication:
       // TODO: This should probably produce subscript(keyPath:), but we
@@ -2746,7 +2746,7 @@ std::string swift::describeGenericType(ValueDecl *GP, bool includeName) {
   OS << Decl::getDescriptiveKindName(parent->getDescriptiveKind());
   if (auto *decl = dyn_cast<ValueDecl>(parent)) {
     if (decl->hasName())
-      OS << " '" << decl->getFullName() << "'";
+      OS << " '" << decl->getName() << "'";
   }
 
   return OS.str().str();
@@ -3019,7 +3019,7 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
     if (auto *callExpr = dyn_cast<CallExpr>(commonAnchor))
       commonAnchor = callExpr->getDirectCallee();
     auto &DE = getASTContext().Diags;
-    auto name = decl->getFullName();
+    const auto name = decl->getName();
 
     // Emit an error message for the ambiguity.
     if (aggregatedFixes.size() == 1 &&
@@ -3108,7 +3108,7 @@ static DeclName getOverloadChoiceName(ArrayRef<OverloadChoice> choices) {
     if (!choice.isDecl())
       continue;
 
-    DeclName nextName = choice.getDecl()->getFullName();
+    const DeclName nextName = choice.getDecl()->getName();
     if (!name) {
       name = nextName;
       continue;

--- a/lib/Sema/DebuggerTestingTransform.cpp
+++ b/lib/Sema/DebuggerTestingTransform.cpp
@@ -197,7 +197,7 @@ private:
 
     // Create "$Varname".
     llvm::SmallString<256> DstNameBuf;
-    DeclName DstDN = DstDecl->getFullName();
+    const DeclName DstDN = DstDecl->getName();
     StringRef DstName = Ctx.AllocateCopy(DstDN.getString(DstNameBuf));
     assert(!DstName.empty() && "Varname must be non-empty");
     Expr *Varname = new (Ctx) StringLiteralExpr(DstName, SourceRange());

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -927,7 +927,7 @@ deriveBodyDecodable_init(AbstractFunctionDecl *initDecl, void *) {
 
       auto *selfRef = DerivedConformance::createSelfDeclRef(initDecl);
       auto *varExpr = UnresolvedDotExpr::createImplicit(C, selfRef,
-                                                        varDecl->getFullName());
+                                                        varDecl->getName());
       auto *assignExpr = new (C) AssignExpr(varExpr, SourceLoc(), tryExpr,
                                             /*Implicit=*/true);
       statements.push_back(assignExpr);
@@ -1094,7 +1094,7 @@ static bool canSynthesize(DerivedConformance &derived, ValueDecl *requirement) {
       if (TypeChecker::conformsToProtocol(superType, proto, superclassDecl,
                                           None)) {
         // super.init(from:) must be accessible.
-        memberName = cast<ConstructorDecl>(requirement)->getFullName();
+        memberName = cast<ConstructorDecl>(requirement)->getName();
       } else {
         // super.init() must be accessible.
         // Passing an empty params array constructs a compound name with no
@@ -1111,7 +1111,7 @@ static bool canSynthesize(DerivedConformance &derived, ValueDecl *requirement) {
       if (result.empty()) {
         // No super initializer for us to call.
         superclassDecl->diagnose(diag::decodable_no_super_init_here,
-                                 requirement->getFullName(), memberName);
+                                 requirement->getName(), memberName);
         return false;
       } else if (result.size() > 1) {
         // There are multiple results for this lookup. We'll end up producing a
@@ -1125,20 +1125,20 @@ static bool canSynthesize(DerivedConformance &derived, ValueDecl *requirement) {
         if (!initializer->isDesignatedInit()) {
           // We must call a superclass's designated initializer.
           initializer->diagnose(diag::decodable_super_init_not_designated_here,
-                                requirement->getFullName(), memberName);
+                                requirement->getName(), memberName);
           return false;
         } else if (!initializer->isAccessibleFrom(conformanceDC)) {
           // Cannot call an inaccessible method.
           auto accessScope = initializer->getFormalAccessScope(conformanceDC);
           initializer->diagnose(diag::decodable_inaccessible_super_init_here,
-                                requirement->getFullName(), memberName,
+                                requirement->getName(), memberName,
                                 accessScope.accessLevelForDiagnostics());
           return false;
         } else if (initializer->isFailable()) {
           // We can't call super.init() if it's failable, since init(from:)
           // isn't failable.
           initializer->diagnose(diag::decodable_super_init_is_failable_here,
-                                requirement->getFullName(), memberName);
+                                requirement->getName(), memberName);
           return false;
         }
       }
@@ -1196,7 +1196,7 @@ ValueDecl *DerivedConformance::deriveEncodable(ValueDecl *requirement) {
   ConformanceDecl->diagnose(diag::type_does_not_conform,
                             Nominal->getDeclaredType(), getProtocolType());
   requirement->diagnose(diag::no_witnesses, diag::RequirementKind::Func,
-                        requirement->getFullName(), getProtocolType(),
+                        requirement->getName(), getProtocolType(),
                         /*AddFixIt=*/false);
 
   // Check other preconditions for synthesized conformance.
@@ -1232,7 +1232,7 @@ ValueDecl *DerivedConformance::deriveDecodable(ValueDecl *requirement) {
   ConformanceDecl->diagnose(diag::type_does_not_conform,
                             Nominal->getDeclaredType(), getProtocolType());
   requirement->diagnose(diag::no_witnesses, diag::RequirementKind::Constructor,
-                        requirement->getFullName(), getProtocolType(),
+                        requirement->getName(), getProtocolType(),
                         /*AddFixIt=*/false);
 
   // Check other preconditions for synthesized conformance.

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -419,7 +419,7 @@ ValueDecl *DerivedConformance::deriveCodingKey(ValueDecl *requirement) {
 
     return deriveProperty(*this, optionalIntType, Context.Id_intValue, synth);
   } else if (name == DeclBaseName::createConstructor()) {
-    auto argumentNames = requirement->getFullName().getArgumentNames();
+    auto argumentNames = requirement->getName().getArgumentNames();
     if (argumentNames.size() == 1) {
       if (argumentNames[0] == Context.Id_stringValue) {
         // Derive `init?(stringValue:)`

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -179,7 +179,7 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
   // Note: whenever you update this function, also update
   // TypeChecker::deriveProtocolRequirement.
   ASTContext &ctx = nominal->getASTContext();
-  auto name = requirement->getFullName();
+  const auto name = requirement->getName();
 
   // Local function that retrieves the requirement with the same name as
   // the provided requirement, but within the given known protocol.
@@ -415,7 +415,7 @@ bool DerivedConformance::checkAndDiagnoseDisallowedContext(
         isa<ExtensionDecl>(ConformanceDecl)) {
       ConformanceDecl->diagnose(
           diag::cannot_synthesize_init_in_extension_of_nonfinal,
-          getProtocolType(), synthesizing->getFullName());
+          getProtocolType(), synthesizing->getName());
       return true;
     }
   }

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -825,7 +825,7 @@ ScopedImportLookupRequest::evaluate(Evaluator &evaluator,
 
     if (decls.size() == 1)
       ctx.Diags.diagnose(decls.front(), diag::decl_declared_here,
-                         decls.front()->getFullName());
+                         decls.front()->getName());
   }
   return ctx.AllocateCopy(decls);
 }

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -463,7 +463,7 @@ static void lookupDeclsFromProtocolsBeingConformedTo(
           };
           DeclVisibilityKind ReasonForThisDecl = ReasonForThisProtocol;
           if (const auto Witness = NormalConformance->getWitness(VD)) {
-            if (Witness.getDecl()->getFullName() == VD->getFullName()) {
+            if (Witness.getDecl()->getName() == VD->getName()) {
               if (LS.isIncludingDerivedRequirements() &&
                   Reason == DeclVisibilityKind::MemberOfCurrentNominal &&
                   isDerivedRequirement(Witness.getDecl())) {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -378,16 +378,15 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
 
       // NSObject.addObserver(_:forKeyPath:options:context:)
       if (uncurryLevel == 1 && argIndex == 3) {
-        return decl->getFullName().isCompoundName("addObserver",
-                                                  { "", "forKeyPath",
-                                                    "options", "context" });
+        return decl->getName().isCompoundName("addObserver",
+                                              { "", "forKeyPath",
+                                                "options", "context" });
       }
 
       // NSObject.removeObserver(_:forKeyPath:context:)
       if (uncurryLevel == 1 && argIndex == 2) {
-        return decl->getFullName().isCompoundName("removeObserver",
-                                                  { "", "forKeyPath",
-                                                    "context" });
+        return decl->getName().isCompoundName("removeObserver",
+                                              { "", "forKeyPath", "context" });
       }
 
       return false;
@@ -466,7 +465,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
 
       // Point to callee parameter
       Ctx.Diags.diagnose(calleeParam, diag::decl_declared_here,
-                         calleeParam->getFullName());
+                         calleeParam->getName());
     }
 
     Optional<MagicIdentifierLiteralExpr::Kind>
@@ -600,8 +599,8 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
                          VD->getBaseIdentifier(),
                          VD->getDescriptiveKind(),
                          declParent->getDescriptiveKind(),
-                         declParent->getFullName());
-      Ctx.Diags.diagnose(VD, diag::decl_declared_here, VD->getFullName());
+                         declParent->getName());
+      Ctx.Diags.diagnose(VD, diag::decl_declared_here, VD->getName());
 
       if (VD->getDeclContext()->isTypeContext()) {
         Ctx.Diags.diagnose(DRE->getLoc(), diag::fix_unqualified_access_member)
@@ -1984,7 +1983,7 @@ static void diagnoseUnownedImmediateDeallocationImpl(ASTContext &ctx,
   ctx.Diags.diagnose(diagLoc, diag::unowned_assignment_requires_strong)
     .highlight(diagRange);
 
-  ctx.Diags.diagnose(varDecl, diag::decl_declared_here, varDecl->getFullName());
+  ctx.Diags.diagnose(varDecl, diag::decl_declared_here, varDecl->getName());
 }
 
 void swift::diagnoseUnownedImmediateDeallocation(ASTContext &ctx,
@@ -3375,7 +3374,7 @@ class ObjCSelectorWalker : public ASTWalker {
     // Determine the name we would search for. If there are no
     // argument names, our lookup will be based solely on the base
     // name.
-    DeclName lookupName = method->getFullName();
+    DeclName lookupName = method->getName();
     if (lookupName.getArgumentNames().empty())
       lookupName = lookupName.getBaseName();
 
@@ -3460,7 +3459,7 @@ public:
       if (!ctorContextType || !ctorContextType->isEqual(SelectorTy))
         return { true, expr };
 
-      auto argNames = ctor->getFullName().getArgumentNames();
+      auto argNames = ctor->getName().getArgumentNames();
       if (argNames.size() != 1) return { true, expr };
 
       // Is this the init(stringLiteral:) initializer or init(_:) initializer?
@@ -3623,14 +3622,14 @@ public:
           switch (bestAccessor->getAccessorKind()) {
           case AccessorKind::Get:
             out << "getter: ";
-            name = bestAccessor->getStorage()->getFullName();
+            name = bestAccessor->getStorage()->getName();
             break;
 
           case AccessorKind::Set:
           case AccessorKind::WillSet:
           case AccessorKind::DidSet:
             out << "setter: ";
-            name = bestAccessor->getStorage()->getFullName();
+            name = bestAccessor->getStorage()->getName();
             break;
 
           case AccessorKind::Address:
@@ -3640,7 +3639,7 @@ public:
             llvm_unreachable("cannot be @objc");
           }
         } else {
-          name = bestMethod->getFullName();
+          name = bestMethod->getName();
         }
 
         auto typeName = nominal->getName().str();
@@ -3960,7 +3959,7 @@ static void diagnoseUnintendedOptionalBehavior(const Expr *E,
                               : diag::iuo_to_any_coercion_note;
 
           Ctx.Diags.diagnose(decl->getLoc(), noteDiag,
-                             decl->getDescriptiveKind(), decl->getFullName());
+                             decl->getDescriptiveKind(), decl->getName());
         }
       } else {
         Ctx.Diags.diagnose(subExpr->getStartLoc(),
@@ -4223,7 +4222,7 @@ static void diagnoseDeprecatedWritableKeyPath(const Expr *E,
               !storage->isSetterAccessibleFrom(DC)) {
             Ctx.Diags.diagnose(keyPathExpr->getLoc(),
                                swift::diag::expr_deprecated_writable_keypath,
-                               storage->getFullName());
+                               storage->getName());
           }
         }
       }
@@ -4270,8 +4269,8 @@ static void maybeDiagnoseCallToKeyValueObserveMethod(const Expr *E,
         return;
       if (fn->getModuleContext()->getName() != C.Id_Foundation)
         return;
-      if (!fn->getFullName().isCompoundName("observe",
-                                            {"", "options", "changeHandler"}))
+      if (!fn->getName().isCompoundName("observe",
+                                        {"", "options", "changeHandler"}))
         return;
       auto args = cast<TupleExpr>(expr->getArg());
       auto firstArg = dyn_cast<KeyPathExpr>(args->getElement(0));
@@ -4291,7 +4290,7 @@ static void maybeDiagnoseCallToKeyValueObserveMethod(const Expr *E,
       C.Diags
           .diagnose(expr->getLoc(),
                     diag::observe_keypath_property_not_objc_dynamic,
-                    property->getFullName(), fn->getFullName())
+                    property->getName(), fn->getName())
           .highlight(lastComponent.getLoc());
     }
 
@@ -4545,7 +4544,7 @@ Optional<DeclName> TypeChecker::omitNeedlessWords(AbstractFunctionDecl *afd) {
   if (afd->isInvalid() || isa<DestructorDecl>(afd))
     return None;
 
-  DeclName name = afd->getFullName();
+  const DeclName name = afd->getName();
   if (!name)
     return None;
 

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -104,7 +104,7 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
       downgradeToWarning = DowngradeToWarning::Yes;
   }
 
-  auto diagName = D->getFullName();
+  auto diagName = D->getName();
   bool isAccessor = false;
 
   // Swift 4.2 did not check accessor accessiblity.
@@ -116,7 +116,7 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
 
     // For accessors, diagnose with the name of the storage instead of the
     // implicit '_'.
-    diagName = accessor->getStorage()->getFullName();
+    diagName = accessor->getStorage()->getName();
   }
 
   // Swift 5.0 did not check the underlying types of local typealiases.
@@ -161,7 +161,7 @@ static bool diagnoseDeclExportability(SourceLoc loc, const ValueDecl *D,
   // TODO: different diagnostics
   ASTContext &ctx = definingModule->getASTContext();
   ctx.Diags.diagnose(loc, diag::inlinable_decl_ref_from_hidden_module,
-                     D->getDescriptiveKind(), D->getFullName(),
+                     D->getDescriptiveKind(), D->getName(),
                      static_cast<unsigned>(fragileKind.kind),
                      definingModule->getName(),
                      static_cast<unsigned>(!isImplementationOnly));
@@ -191,7 +191,7 @@ diagnoseGenericArgumentsExportability(SourceLoc loc,
     ASTContext &ctx = M->getASTContext();
     ctx.Diags.diagnose(loc, diag::conformance_from_implementation_only_module,
                        rootConf->getType(),
-                       rootConf->getProtocol()->getFullName(), 0, M->getName());
+                       rootConf->getProtocol()->getName(), 0, M->getName());
     hadAnyIssues = true;
   }
   return hadAnyIssues;

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1663,7 +1663,7 @@ class ExportabilityChecker : public DeclVisitor<ExportabilityChecker> {
                                 HiddenImportKind::SPI;
       auto diag = D->diagnose(diag::decl_from_hidden_module,
                               offendingType->getDescriptiveKind(),
-                              offendingType->getFullName(),
+                              offendingType->getName(),
                               static_cast<unsigned>(reason), M->getName(),
                               static_cast<unsigned>(importKind));
       highlightOffendingType(diag, complainRepr);
@@ -1673,7 +1673,7 @@ class ExportabilityChecker : public DeclVisitor<ExportabilityChecker> {
       ModuleDecl *M = offendingConformance->getDeclContext()->getParentModule();
       D->diagnose(diag::conformance_from_implementation_only_module,
                   offendingConformance->getType(),
-                  offendingConformance->getProtocol()->getFullName(),
+                  offendingConformance->getProtocol()->getName(),
                   static_cast<unsigned>(reason), M->getName());
     }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -478,7 +478,7 @@ void AttributeChecker::visitIBSegueActionAttr(IBSegueActionAttr *attr) {
   if (!FD->getAttrs().hasAttribute<ObjCAttr>() ||
       !FD->getAttrs().getAttribute<ObjCAttr>()->hasName()) {
     auto newSwiftBaseName = replacingPrefix(FD->getBaseIdentifier());
-    auto argumentNames = FD->getFullName().getArgumentNames();
+    auto argumentNames = FD->getName().getArgumentNames();
     DeclName newSwiftName(Ctx, newSwiftBaseName, argumentNames);
 
     auto diag = diagnose(FD, diag::fixit_rename_in_swift, newSwiftName);
@@ -2023,7 +2023,7 @@ static void checkSpecializeAttrRequirements(
       if (gpDecl) {
         ctx.Diags.diagnose(attr->getLocation(),
                            diag::specialize_attr_missing_constraint,
-                           gpDecl->getFullName());
+                           gpDecl->getName());
       }
     }
   }
@@ -2067,8 +2067,7 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
   if (!genericSig) {
     // Only generic functions are permitted to have trailing where clauses.
     diagnose(attr->getLocation(),
-             diag::specialize_attr_nongeneric_trailing_where,
-             FD->getFullName())
+             diag::specialize_attr_nongeneric_trailing_where, FD->getName())
         .highlight(trailingWhereClause->getSourceRange());
     return;
   }
@@ -2196,7 +2195,7 @@ void AttributeChecker::visitFixedLayoutAttr(FixedLayoutAttr *attr) {
   if (VD->getFormalAccess() < AccessLevel::Public &&
       !VD->getAttrs().hasAttribute<UsableFromInlineAttr>()) {
     diagnoseAndRemoveAttr(attr, diag::fixed_layout_attr_on_internal_type,
-                          VD->getFullName(), VD->getFormalAccess());
+                          VD->getName(), VD->getFormalAccess());
   }
 }
 
@@ -2214,8 +2213,7 @@ void AttributeChecker::visitUsableFromInlineAttr(UsableFromInlineAttr *attr) {
   if (VD->getFormalAccess() != AccessLevel::Internal) {
     diagnoseAndRemoveAttr(attr,
                           diag::usable_from_inline_attr_with_explicit_access,
-                          VD->getFullName(),
-                          VD->getFormalAccess());
+                          VD->getName(), VD->getFormalAccess());
     return;
   }
 
@@ -2402,7 +2400,7 @@ static FuncDecl *findReplacedAccessor(DeclNameRef replacedVarName,
     for (auto result : results) {
       Diags.diagnose(result,
                      diag::dynamic_replacement_accessor_ambiguous_candidate,
-                     result->getModuleContext()->getFullName());
+                     result->getModuleContext()->getName());
     }
     attr->setInvalid();
     return nullptr;
@@ -2414,7 +2412,7 @@ static FuncDecl *findReplacedAccessor(DeclNameRef replacedVarName,
   if (!origStorage->isDynamic()) {
     Diags.diagnose(attr->getLocation(),
                    diag::dynamic_replacement_accessor_not_dynamic,
-                   origStorage->getFullName());
+                   origStorage->getName());
     attr->setInvalid();
     return nullptr;
   }
@@ -2431,7 +2429,7 @@ static FuncDecl *findReplacedAccessor(DeclNameRef replacedVarName,
     Diags.diagnose(attr->getLocation(),
                    diag::dynamic_replacement_accessor_not_explicit,
                    (unsigned)origAccessor->getAccessorKind(),
-                   origStorage->getFullName());
+                   origStorage->getName());
     attr->setInvalid();
     return nullptr;
   }
@@ -2467,7 +2465,7 @@ findReplacedFunction(DeclNameRef replacedFunctionName,
         if (Diags) {
           Diags->diagnose(attr->getLocation(),
                           diag::dynamic_replacement_function_not_dynamic,
-                          result->getFullName());
+                          result->getName());
           attr->setInvalid();
         }
         return nullptr;
@@ -2492,7 +2490,7 @@ findReplacedFunction(DeclNameRef replacedFunctionName,
     for (auto *result : results) {
       Diags->diagnose(SourceLoc(),
                       diag::dynamic_replacement_found_function_of_type,
-                      result->getFullName(),
+                      result->getName(),
                       result->getInterfaceType()->getCanonicalType());
     }
   }
@@ -2554,13 +2552,13 @@ void AttributeChecker::visitDynamicReplacementAttr(DynamicReplacementAttr *attr)
   if (original->isObjC() && !replacement->isObjC()) {
     diagnose(attr->getLocation(),
              diag::dynamic_replacement_replacement_not_objc_dynamic,
-             replacement->getFullName());
+             replacement->getName());
     attr->setInvalid();
   }
   if (!original->isObjC() && replacement->isObjC()) {
     diagnose(attr->getLocation(),
              diag::dynamic_replacement_replaced_not_objc_dynamic,
-             original->getFullName());
+             original->getName());
     attr->setInvalid();
   }
 
@@ -2806,7 +2804,7 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
     if (!NTD->lookupConformance(DC->getParentModule(), PD, conformances)) {
       diagnose(attr->getLocation(),
                diag::implements_attr_protocol_not_conformed_to,
-               NTD->getFullName(), PD->getFullName())
+               NTD->getName(), PD->getName())
         .highlight(ProtoTypeLoc.getTypeRepr()->getSourceRange());
     }
 
@@ -2835,7 +2833,7 @@ void AttributeChecker::visitFrozenAttr(FrozenAttr *attr) {
   if (VD->getFormalAccess() < AccessLevel::Public &&
       !VD->getAttrs().hasAttribute<UsableFromInlineAttr>()) {
     diagnoseAndRemoveAttr(attr, diag::frozen_attr_on_internal_type,
-                          VD->getFullName(), VD->getFormalAccess());
+                          VD->getName(), VD->getFormalAccess());
   }
 }
 
@@ -2869,7 +2867,7 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
     if (!isa<VarDecl>(D) || isa<ParamDecl>(D)) {
       diagnose(attr->getLocation(),
                diag::property_wrapper_attribute_not_on_property,
-               nominal->getFullName());
+               nominal->getName());
       attr->setInvalid();
       return;
     }
@@ -2907,7 +2905,7 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
       if (shouldDiagnose()) {
         diagnose(attr->getLocation(),
                  diag::function_builder_attribute_on_storage_without_getter,
-                 nominal->getFullName(),
+                 nominal->getName(),
                  isa<SubscriptDecl>(storage) ? 0
                    : storage->getDeclContext()->isTypeContext() ? 1
                    : cast<VarDecl>(storage)->isLet() ? 2 : 3);
@@ -2917,7 +2915,7 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
     } else {
       diagnose(attr->getLocation(),
                diag::function_builder_attribute_not_allowed_here,
-               nominal->getFullName());
+               nominal->getName());
       attr->setInvalid();
       return;
     }
@@ -2946,8 +2944,8 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
   }
 
   diagnose(attr->getLocation(), diag::nominal_type_not_attribute,
-           nominal->getDescriptiveKind(), nominal->getFullName());
-  nominal->diagnose(diag::decl_declared_here, nominal->getFullName());
+           nominal->getDescriptiveKind(), nominal->getName());
+  nominal->diagnose(diag::decl_declared_here, nominal->getName());
   attr->setInvalid();
 }
 
@@ -3456,7 +3454,7 @@ static IndexSubset *computeDifferentiabilityParameters(
     if (!isInstanceMethod) {
       diags
           .diagnose(attrLoc, diag::diff_function_no_parameters,
-                    function->getFullName())
+                    function->getName())
           .highlight(function->getSignatureSourceRange());
       return nullptr;
     }
@@ -3471,7 +3469,7 @@ static IndexSubset *computeDifferentiabilityParameters(
       if (!conformsToDifferentiable(selfType, function)) {
         diags
             .diagnose(attrLoc, diag::diff_function_no_parameters,
-                      function->getFullName())
+                      function->getName())
             .highlight(function->getSignatureSourceRange());
         return nullptr;
       }
@@ -4014,7 +4012,7 @@ bool resolveDifferentiableAttrDerivativeGenericSignature(
           .diagnose(
               attr->getLocation(),
               diag::differentiable_attr_where_clause_for_nongeneric_original,
-              original->getFullName())
+              original->getName())
           .highlight(whereClause->getSourceRange());
       attr->setInvalid();
       return true;
@@ -4234,7 +4232,7 @@ IndexSubset *DifferentiableAttributeTypeCheckRequest::evaluate(
   if (originalResults.empty()) {
     diags
         .diagnose(attr->getLocation(), diag::autodiff_attr_original_void_result,
-                  original->getFullName())
+                  original->getName())
         .highlight(original->getSourceRange());
     attr->setInvalid();
     return nullptr;
@@ -4483,7 +4481,7 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
                      diag::derivative_attr_original_stored_property_unsupported,
                      originalName.Name);
       diags.diagnose(originalAFD->getLoc(), diag::decl_declared_here,
-                     asd->getFullName());
+                     asd->getName());
       return true;
     }
   }
@@ -4514,7 +4512,7 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
         diags.diagnose(
             attr->getLocation(),
             diag::derivative_attr_class_member_dynamic_self_result_unsupported,
-            DeclNameRef(originalAFD->getFullName()));
+            DeclNameRef(originalAFD->getName()));
         return true;
       }
     }
@@ -4557,7 +4555,7 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
   if (originalResults.empty()) {
     diags
         .diagnose(attr->getLocation(), diag::autodiff_attr_original_void_result,
-                  derivative->getFullName())
+                  derivative->getName())
         .highlight(attr->getOriginalFunctionName().Loc.getSourceRange());
     attr->setInvalid();
     return true;
@@ -4611,7 +4609,7 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
     // Emit differential/pullback type mismatch error on attribute.
     diags.diagnose(attr->getLocation(),
                    diag::derivative_attr_result_func_type_mismatch,
-                   funcResultElt.getName(), originalAFD->getFullName());
+                   funcResultElt.getName(), originalAFD->getName());
     // Emit note with expected differential/pullback type on actual type
     // location.
     auto *tupleReturnTypeRepr =
@@ -4626,7 +4624,7 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
     if (originalAFD->getLoc().isValid())
       diags.diagnose(originalAFD->getLoc(),
                      diag::derivative_attr_result_func_original_note,
-                     originalAFD->getFullName());
+                     originalAFD->getName());
     return true;
   }
 
@@ -4637,7 +4635,7 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
   if (derivativeAttrs.size() > 1) {
     diags.diagnose(attr->getLocation(),
                    diag::derivative_attr_original_already_has_derivative,
-                   originalAFD->getFullName());
+                   originalAFD->getName());
     for (auto *duplicateAttr : derivativeAttrs) {
       if (duplicateAttr == attr)
         continue;

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -754,7 +754,7 @@ void TypeChecker::diagnosePotentialUnavailability(
     const ValueDecl *D, SourceRange ReferenceRange,
     const DeclContext *ReferenceDC,
     const UnavailabilityReason &Reason) {
-  diagnosePotentialUnavailability(D, D->getFullName(), ReferenceRange,
+  diagnosePotentialUnavailability(D, D->getName(), ReferenceRange,
                                   ReferenceDC, Reason);
 }
 
@@ -1425,7 +1425,7 @@ void TypeChecker::diagnosePotentialAccessorUnavailability(
   assert(Accessor->isGetterOrSetter());
 
   const AbstractStorageDecl *ASD = Accessor->getStorage();
-  DeclName Name = ASD->getFullName();
+  DeclName Name = ASD->getName();
 
   auto &diag = ForInout ? diag::availability_inout_accessor_only_version_newer
                         : diag::availability_accessor_only_version_newer;
@@ -1942,12 +1942,12 @@ getAccessorKindAndNameForDiagnostics(const ValueDecl *D) {
   static const unsigned NOT_ACCESSOR_INDEX = 2;
 
   if (auto *accessor = dyn_cast<AccessorDecl>(D)) {
-    DeclName Name = accessor->getStorage()->getFullName();
+    DeclName Name = accessor->getStorage()->getName();
     assert(accessor->isGetterOrSetter());
     return {static_cast<unsigned>(accessor->getAccessorKind()), Name};
   }
 
-  return {NOT_ACCESSOR_INDEX, D->getFullName()};
+  return {NOT_ACCESSOR_INDEX, D->getName()};
 }
 
 void TypeChecker::diagnoseIfDeprecated(SourceRange ReferenceRange,
@@ -2078,7 +2078,7 @@ void swift::diagnoseUnavailableOverride(ValueDecl *override,
     }
 
     DeclName newName = parsedName.formDeclName(ctx);
-    size_t numArgs = override->getFullName().getArgumentNames().size();
+    size_t numArgs = override->getName().getArgumentNames().size();
     if (!newName || newName.getArgumentNames().size() != numArgs)
       return;
 

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -296,7 +296,7 @@ public:
             NTD->diagnose(diag::kind_declared_here,
                           DescriptiveDeclKind::Type);
 
-            D->diagnose(diag::decl_declared_here, D->getFullName());
+            D->diagnose(diag::decl_declared_here, D->getName());
             return { false, DRE };
           }
         }

--- a/lib/Sema/TypeCheckCircularity.cpp
+++ b/lib/Sema/TypeCheckCircularity.cpp
@@ -417,7 +417,7 @@ void LLVM_ATTRIBUTE_USED PathElement::dump() const {
 void PathElement::print(llvm::raw_ostream &out) const {
   out << " -> (";
   if (Member) {
-    auto name = Member->getFullName();
+    auto name = Member->getName();
     if (name) {
       out << name;
     } else {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -501,7 +501,7 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
       // module we could offer a fix-it.
       for (auto lookupResult : inaccessibleResults) {
         auto *VD = lookupResult.getValueDecl();
-        VD->diagnose(diag::decl_declared_here, VD->getFullName());
+        VD->diagnose(diag::decl_declared_here, VD->getName());
       }
 
       // Don't try to recover here; we'll get more access-related diagnostics
@@ -618,7 +618,7 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
       if (Lookup.outerResults().empty()) {
         Context.Diags.diagnose(Loc, diag::use_local_before_declaration, Name);
         Context.Diags.diagnose(innerDecl, diag::decl_declared_here,
-                               localDeclAfterUse->getFullName());
+                               localDeclAfterUse->getName());
         Expr *error = new (Context) ErrorExpr(UDRE->getSourceRange());
         return error;
       }
@@ -750,7 +750,7 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
   Context.Diags.diagnose(Loc, diag::ambiguous_decl_ref, Name);
   for (auto Result : Lookup) {
     auto *Decl = Result.getValueDecl();
-    Context.Diags.diagnose(Decl, diag::decl_declared_here, Decl->getFullName());
+    Context.Diags.diagnose(Decl, diag::decl_declared_here, Decl->getName());
   }
   return new (Context) ErrorExpr(UDRE->getSourceRange());
 }
@@ -773,7 +773,7 @@ TypeChecker::getSelfForInitDelegationInConstructor(DeclContext *DC,
     if (nestedArg->isSuperExpr())
       return ctorContext->getImplicitSelfDecl();
     if (auto declRef = dyn_cast<DeclRefExpr>(nestedArg))
-      if (declRef->getDecl()->getFullName() == DC->getASTContext().Id_self)
+      if (declRef->getDecl()->getName() == DC->getASTContext().Id_self)
         return ctorContext->getImplicitSelfDecl();
   }
   return nullptr;

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -99,13 +99,13 @@ static void describeObjCReason(const ValueDecl *VD, ObjCReason Reason) {
 
     auto overridden = VD->getOverriddenDecl();
     overridden->diagnose(diag::objc_overriding_objc_decl,
-                         kind, VD->getOverriddenDecl()->getFullName());
+                         kind, VD->getOverriddenDecl()->getName());
   } else if (Reason == ObjCReason::WitnessToObjC) {
     auto requirement = Reason.getObjCRequirement();
     requirement->diagnose(diag::objc_witness_objc_requirement,
-                VD->getDescriptiveKind(), requirement->getFullName(),
+                VD->getDescriptiveKind(), requirement->getName(),
                 cast<ProtocolDecl>(requirement->getDeclContext())
-                  ->getFullName());
+                  ->getName());
   }
 }
 
@@ -1358,7 +1358,7 @@ bool IsObjCRequest::evaluate(Evaluator &evaluator, ValueDecl *VD) const {
       if (storageObjCAttr && storageObjCAttr->isSwift3Inferred() &&
           shouldDiagnoseObjCReason(*isObjC, ctx)) {
         storage->diagnose(diag::accessor_swift3_objc_inference,
-                 storage->getDescriptiveKind(), storage->getFullName(),
+                 storage->getDescriptiveKind(), storage->getName(),
                  isa<SubscriptDecl>(storage), accessor->isSetter())
           .fixItInsert(storage->getAttributeInsertionLoc(/*forModifier=*/false),
                        "@objc ");
@@ -1504,15 +1504,15 @@ static ObjCSelector inferObjCName(ValueDecl *decl) {
     // note the ambiguity.
     if (*requirementObjCName != *req->getObjCRuntimeName()) {
       decl->diagnose(diag::objc_ambiguous_inference,
-                     decl->getDescriptiveKind(), decl->getFullName(),
+                     decl->getDescriptiveKind(), decl->getName(),
                      *requirementObjCName, *req->getObjCRuntimeName());
 
       // Note the candidates and what Objective-C names they provide.
       auto diagnoseCandidate = [&](ValueDecl *req) {
         auto proto = cast<ProtocolDecl>(req->getDeclContext());
         auto diag = decl->diagnose(diag::objc_ambiguous_inference_candidate,
-                                   req->getFullName(),
-                                   proto->getFullName(),
+                                   req->getName(),
+                                   proto->getName(),
                                    *req->getObjCRuntimeName());
         fixDeclarationObjCName(diag, decl,
                                decl->getObjCRuntimeName(/*skipIsObjC=*/true),
@@ -1591,12 +1591,12 @@ void markAsObjC(ValueDecl *D, ObjCReason reason,
           if (declProvidingInheritedConvention
               && inheritedConvention != reqErrorConvention) {
             method->diagnose(diag::objc_ambiguous_error_convention,
-                             method->getFullName());
+                             method->getName());
             declProvidingInheritedConvention->diagnose(
                              diag::objc_ambiguous_error_convention_candidate,
-                             declProvidingInheritedConvention->getFullName());
+                             declProvidingInheritedConvention->getName());
             reqMethod->diagnose(diag::objc_ambiguous_error_convention_candidate,
-                                reqMethod->getFullName());
+                                reqMethod->getName());
             break;
           }
 
@@ -1729,10 +1729,10 @@ void swift::diagnoseAttrsRequiringFoundation(SourceFile &SF) {
 std::pair<unsigned, DeclName> swift::getObjCMethodDiagInfo(
                                 AbstractFunctionDecl *member) {
   if (isa<ConstructorDecl>(member))
-    return { 0 + member->isImplicit(), member->getFullName() };
+    return { 0 + member->isImplicit(), member->getName() };
 
   if (isa<DestructorDecl>(member))
-    return { 2 + member->isImplicit(), member->getFullName() };
+    return { 2 + member->isImplicit(), member->getName() };
 
   if (auto accessor = dyn_cast<AccessorDecl>(member)) {
     switch (accessor->getAccessorKind()) {
@@ -1744,13 +1744,13 @@ std::pair<unsigned, DeclName> swift::getObjCMethodDiagInfo(
 
     case AccessorKind::Get:
       if (auto var = dyn_cast<VarDecl>(accessor->getStorage()))
-        return { 5, var->getFullName() };
+        return { 5, var->getName() };
 
       return { 6, Identifier() };
 
     case AccessorKind::Set:
       if (auto var = dyn_cast<VarDecl>(accessor->getStorage()))
-        return { 7, var->getFullName() };
+        return { 7, var->getName() };
       return { 8, Identifier() };
     }
 
@@ -1759,13 +1759,13 @@ std::pair<unsigned, DeclName> swift::getObjCMethodDiagInfo(
 
   // Normal method.
   auto func = cast<FuncDecl>(member);
-  return { 4, func->getFullName() };
+  return { 4, func->getName() };
 }
 
 bool swift::fixDeclarationName(InFlightDiagnostic &diag, const ValueDecl *decl,
                                DeclName targetName) {
   if (decl->isImplicit()) return false;
-  if (decl->getFullName() == targetName) return false;
+  if (decl->getName() == targetName) return false;
 
   // Handle properties directly.
   if (auto var = dyn_cast<VarDecl>(decl)) {
@@ -1779,7 +1779,7 @@ bool swift::fixDeclarationName(InFlightDiagnostic &diag, const ValueDecl *decl,
   auto func = dyn_cast<AbstractFunctionDecl>(decl);
   if (!func) return true;
 
-  auto name = func->getFullName();
+  const auto name = func->getName();
 
   // Fix the name of the function itself.
   if (name.getBaseName() != targetName.getBaseName()) {
@@ -1941,7 +1941,7 @@ namespace {
       // The declarations are in different source files (or unknown source
       // files) of the same module. Order based on name.
       // FIXME: This isn't a total ordering.
-      return lhs->getFullName() < rhs->getFullName();
+      return lhs->getName() < rhs->getName();
     }
   };
 } // end anonymous namespace
@@ -2263,7 +2263,7 @@ bool swift::diagnoseObjCUnsatisfiedOptReqConflicts(SourceFile &sf) {
     auto reqDiagInfo = getObjCMethodDiagInfo(unsatisfied.second);
     auto conflictDiagInfo = getObjCMethodDiagInfo(conflicts[0]);
     auto protocolName
-      = cast<ProtocolDecl>(req->getDeclContext())->getFullName();
+      = cast<ProtocolDecl>(req->getDeclContext())->getName();
     Ctx.Diags.diagnose(conflicts[0],
                        diag::objc_optional_requirement_conflict,
                        conflictDiagInfo.first,
@@ -2274,7 +2274,7 @@ bool swift::diagnoseObjCUnsatisfiedOptReqConflicts(SourceFile &sf) {
                        protocolName);
 
     // Fix the name of the witness, if we can.
-    if (req->getFullName() != conflicts[0]->getFullName() &&
+    if (req->getName() != conflicts[0]->getName() &&
         req->getKind() == conflicts[0]->getKind() &&
         isa<AccessorDecl>(req) == isa<AccessorDecl>(conflicts[0])) {
       // They're of the same kind: fix the name.
@@ -2291,10 +2291,10 @@ bool swift::diagnoseObjCUnsatisfiedOptReqConflicts(SourceFile &sf) {
 
       auto diag = Ctx.Diags.diagnose(conflicts[0],
                                      diag::objc_optional_requirement_swift_rename,
-                                     kind, req->getFullName());
+                                     kind, req->getName());
 
       // Fix the Swift name.
-      fixDeclarationName(diag, conflicts[0], req->getFullName());
+      fixDeclarationName(diag, conflicts[0], req->getName());
 
       // Fix the '@objc' attribute, if needed.
       if (!conflicts[0]->canInferObjCFromRequirement(req))
@@ -2317,7 +2317,7 @@ bool swift::diagnoseObjCUnsatisfiedOptReqConflicts(SourceFile &sf) {
     Ctx.Diags.diagnose(getDeclContextLoc(unsatisfied.first),
                        diag::protocol_conformance_here,
                        true,
-                       classDecl->getFullName(),
+                       classDecl->getName(),
                       protocolName);
     Ctx.Diags.diagnose(req, diag::kind_declname_declared_here,
                        DescriptiveDeclKind::Requirement, reqDiagInfo.second);

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -220,8 +220,8 @@ static bool areOverrideCompatibleSimple(ValueDecl *decl,
                                         ValueDecl *parentDecl) {
   // If the number of argument labels does not match, these overrides cannot
   // be compatible.
-  if (decl->getFullName().getArgumentNames().size() !=
-        parentDecl->getFullName().getArgumentNames().size())
+  if (decl->getName().getArgumentNames().size() !=
+        parentDecl->getName().getArgumentNames().size())
     return false;
 
   // If the parent declaration is not in a class (or extension thereof) or
@@ -495,11 +495,11 @@ static void diagnoseGeneralOverrideFailure(ValueDecl *decl,
   switch (attempt) {
   case OverrideCheckingAttempt::PerfectMatch:
     diags.diagnose(decl, diag::override_multiple_decls_base,
-                   decl->getFullName());
+                   decl->getName());
     break;
   case OverrideCheckingAttempt::BaseName:
     diags.diagnose(decl, diag::override_multiple_decls_arg_mismatch,
-                   decl->getFullName());
+                   decl->getName());
     break;
   case OverrideCheckingAttempt::MismatchedOptional:
   case OverrideCheckingAttempt::MismatchedTypes:
@@ -526,9 +526,9 @@ static void diagnoseGeneralOverrideFailure(ValueDecl *decl,
 
     auto diag = diags.diagnose(matchDecl, diag::overridden_near_match_here,
                                matchDecl->getDescriptiveKind(),
-                               matchDecl->getFullName());
+                               matchDecl->getName());
     if (attempt == OverrideCheckingAttempt::BaseName) {
-      fixDeclarationName(diag, decl, matchDecl->getFullName());
+      fixDeclarationName(diag, decl, matchDecl->getName());
     }
   }
 }
@@ -827,7 +827,7 @@ SmallVector<OverrideMatch, 2> OverrideMatcher::match(
   case OverrideCheckingAttempt::PerfectMatch:
   case OverrideCheckingAttempt::MismatchedOptional:
   case OverrideCheckingAttempt::MismatchedTypes:
-    name = decl->getFullName();
+    name = decl->getName();
     break;
   case OverrideCheckingAttempt::BaseName:
   case OverrideCheckingAttempt::BaseNameWithMismatchedOptional:
@@ -1053,12 +1053,12 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
 
   // If the name of our match differs from the name we were looking for,
   // complain.
-  if (decl->getFullName() != baseDecl->getFullName()) {
+  if (decl->getName() != baseDecl->getName()) {
     auto diag = diags.diagnose(decl, diag::override_argument_name_mismatch,
                                isa<ConstructorDecl>(decl),
-                               decl->getFullName(),
-                               baseDecl->getFullName());
-    fixDeclarationName(diag, decl, baseDecl->getFullName());
+                               decl->getName(),
+                               baseDecl->getName());
+    fixDeclarationName(diag, decl, baseDecl->getName());
     emittedMatchError = true;
   }
 
@@ -1139,7 +1139,7 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
       noteFixableMismatchedTypes(decl, baseDecl);
       diags.diagnose(baseDecl, diag::overridden_near_match_here,
                      baseDecl->getDescriptiveKind(),
-                     baseDecl->getFullName());
+                     baseDecl->getName());
       emittedMatchError = true;
 
     } else if (!isa<AccessorDecl>(method) &&
@@ -1171,7 +1171,7 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
       noteFixableMismatchedTypes(decl, baseDecl);
       diags.diagnose(baseDecl, diag::overridden_near_match_here,
                      baseDecl->getDescriptiveKind(),
-                     baseDecl->getFullName());
+                     baseDecl->getName());
       emittedMatchError = true;
 
     } else if (mayHaveMismatchedOptionals) {
@@ -1325,8 +1325,8 @@ bool swift::checkOverrides(ValueDecl *decl) {
     case OverrideCheckingAttempt::BaseName:
       // Don't keep looking if this is already a simple name, or if there
       // are no arguments.
-      if (decl->getFullName() == decl->getBaseName() ||
-          decl->getFullName().getArgumentNames().empty())
+      if (decl->getName() == decl->getBaseName() ||
+          decl->getName().getArgumentNames().empty())
         return false;
       break;
     case OverrideCheckingAttempt::BaseNameWithMismatchedOptional:
@@ -1532,7 +1532,7 @@ namespace  {
       // Complain.
       Diags.diagnose(Override, diag::override_swift3_objc_inference,
                      Override->getDescriptiveKind(),
-                     Override->getFullName(),
+                     Override->getName(),
                      Base->getDeclContext()
                        ->getSelfNominalTypeDecl()
                        ->getName());

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -558,8 +558,8 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current) const {
     const auto *currentOverride = current->getOverriddenDecl();
     const auto *otherOverride = other->getOverriddenDecl();
     if (currentOverride && currentOverride == otherOverride) {
-      current->diagnose(diag::multiple_override, current->getFullName());
-      other->diagnose(diag::multiple_override_prev, other->getFullName());
+      current->diagnose(diag::multiple_override, current->getName());
+      other->diagnose(diag::multiple_override_prev, other->getName());
       current->setInvalid();
       break;
     }
@@ -686,8 +686,8 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current) const {
       // would be in Swift 5 mode, emit a warning instead of an error.
       if (wouldBeSwift5Redeclaration) {
         current->diagnose(diag::invalid_redecl_swift5_warning,
-                          current->getFullName());
-        other->diagnose(diag::invalid_redecl_prev, other->getFullName());
+                          current->getName());
+        other->diagnose(diag::invalid_redecl_prev, other->getName());
       } else {
         const auto *otherInit = dyn_cast<ConstructorDecl>(other);
         // Provide a better description for implicit initializers.
@@ -698,13 +698,13 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current) const {
           // productive diagnostic.
           if (!other->getOverriddenDecl())
             current->diagnose(diag::invalid_redecl_init,
-                              current->getFullName(),
+                              current->getName(),
                               otherInit->isMemberwiseInitializer());
         } else if (!current->isImplicit() && !other->isImplicit()) {
           ctx.Diags.diagnoseWithNotes(
             current->diagnose(diag::invalid_redecl,
-                              current->getFullName()), [&]() {
-            other->diagnose(diag::invalid_redecl_prev, other->getFullName());
+                              current->getName()), [&]() {
+            other->diagnose(diag::invalid_redecl_prev, other->getName());
           });
         }
         current->setInvalid();
@@ -1260,13 +1260,13 @@ public:
       // expressions to mean something builtin to the language.  We *do* allow
       // these if they are escaped with backticks though.
       if (VD->getDeclContext()->isTypeContext() &&
-          (VD->getFullName().isSimpleName(Context.Id_Type) ||
-           VD->getFullName().isSimpleName(Context.Id_Protocol)) &&
+          (VD->getName().isSimpleName(Context.Id_Type) ||
+           VD->getName().isSimpleName(Context.Id_Protocol)) &&
           VD->getNameLoc().isValid() &&
           Context.SourceMgr.extractText({VD->getNameLoc(), 1}) != "`") {
         auto &DE = getASTContext().Diags;
         DE.diagnose(VD->getNameLoc(), diag::reserved_member_name,
-                    VD->getFullName(), VD->getBaseIdentifier().str());
+                    VD->getName(), VD->getBaseIdentifier().str());
         DE.diagnose(VD->getNameLoc(), diag::backticks_to_escape)
             .fixItReplace(VD->getNameLoc(),
                           "`" + VD->getBaseName().userFacingName().str() + "`");
@@ -1687,7 +1687,7 @@ public:
     auto *DC = NTD->getDeclContext();
     auto kind = DC->getFragileFunctionKind();
     if (kind.kind != FragileFunctionKind::None) {
-      NTD->diagnose(diag::local_type_in_inlinable_function, NTD->getFullName(),
+      NTD->diagnose(diag::local_type_in_inlinable_function, NTD->getName(),
                     static_cast<unsigned>(kind.kind));
     }
 
@@ -1716,7 +1716,7 @@ public:
         // A local generic context is a generic function.
         if (auto AFD = dyn_cast<AbstractFunctionDecl>(DC)) {
           NTD->diagnose(diag::unsupported_type_nested_in_generic_function,
-                        NTD->getName(), AFD->getFullName());
+                        NTD->getName(), AFD->getName());
         } else {
           NTD->diagnose(diag::unsupported_type_nested_in_generic_closure,
                         NTD->getName());
@@ -2224,7 +2224,7 @@ public:
         // We did not find 'Self'. Complain.
         FD->diagnose(diag::operator_in_unrelated_type,
                      FD->getDeclContext()->getDeclaredInterfaceType(), isProtocol,
-                     FD->getFullName());
+                     FD->getName());
       }
     }
 
@@ -2357,7 +2357,7 @@ public:
     if (auto trailingWhereClause = ED->getTrailingWhereClause()) {
       if (!ED->getGenericParams() && !ED->isInvalid()) {
         ED->diagnose(diag::extension_nongeneric_trailing_where,
-                     nominal->getFullName())
+                     nominal->getName())
           .highlight(trailingWhereClause->getSourceRange());
       }
     }
@@ -2463,10 +2463,10 @@ public:
       if (CD->isFailable() &&
           CD->getOverriddenDecl() &&
           !CD->getOverriddenDecl()->isFailable()) {
-        CD->diagnose(diag::failable_initializer_override, CD->getFullName());
+        CD->diagnose(diag::failable_initializer_override, CD->getName());
         auto *OD = CD->getOverriddenDecl();
         OD->diagnose(diag::nonfailable_initializer_override_here,
-                     OD->getFullName());
+                     OD->getName());
       }
     }
 
@@ -2503,7 +2503,7 @@ public:
         }
         if (CD->getFormalAccess() < requiredAccess) {
           auto diag = CD->diagnose(diag::required_initializer_not_accessible,
-                                   nominal->getFullName());
+                                   nominal->getName());
           fixItAccess(diag, CD, requiredAccess);
         }
       }

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -309,7 +309,7 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
 
       for (auto result : lookup) {
         diags.diagnose(result.getValueDecl(), diag::decl_declared_here,
-                       result.getValueDecl()->getFullName());
+                       result.getValueDecl()->getName());
       }
       isInvalid = true;
       break;
@@ -329,7 +329,7 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
       // Check that the property is @objc.
       if (!var->isObjC()) {
         diags.diagnose(componentNameLoc, diag::expr_keypath_non_objc_property,
-                       var->getFullName());
+                       var->getName());
         if (var->getLoc().isValid() && var->getDeclContext()->isTypeContext()) {
           diags.diagnose(var, diag::make_decl_objc,
                          var->getDescriptiveKind())
@@ -345,7 +345,7 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
           auto *parent = var->getDeclContext()->getSelfNominalTypeDecl();
           diags.diagnose(componentNameLoc,
                          diag::expr_keypath_swift3_objc_inference,
-                         var->getFullName(),
+                         var->getName(),
                          parent->getName());
           diags.diagnose(var, diag::make_decl_objc, var->getDescriptiveKind())
             .fixItInsert(var->getAttributeInsertionLoc(false),
@@ -373,7 +373,7 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
       // We cannot refer to a generic type.
       if (type->getDeclaredInterfaceType()->hasTypeParameter()) {
         diags.diagnose(componentNameLoc, diag::expr_keypath_generic_type,
-                       type->getFullName());
+                       type->getName());
         isInvalid = true;
         break;
       }
@@ -396,7 +396,7 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
 
     // Declarations that cannot be part of a key-path.
     diags.diagnose(componentNameLoc, diag::expr_keypath_not_property,
-                   found->getDescriptiveKind(), found->getFullName(),
+                   found->getDescriptiveKind(), found->getName(),
                    /*isForDynamicKeyPathMemberLookup=*/false);
     isInvalid = true;
     break;

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -264,7 +264,7 @@ void TypeChecker::checkProtocolSelfRequirements(ValueDecl *decl) {
 
       ctx.Diags.diagnose(decl,
                          diag::requirement_restricts_self,
-                         decl->getDescriptiveKind(), decl->getFullName(),
+                         decl->getDescriptiveKind(), decl->getName(),
                          req.getFirstType().getString(),
                          static_cast<unsigned>(req.getKind()),
                          req.getSecondType().getString());

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -596,7 +596,7 @@ void TypeChecker::performTypoCorrection(DeclContext *DC, DeclRefKind refKind,
     if (!isPlausibleTypo(refKind, corrections.WrittenName, decl))
       return;
 
-    auto candidateName = decl->getFullName();
+    const auto candidateName = decl->getName();
 
     // Don't waste time computing edit distances that are more than
     // the worst in our collection.
@@ -695,7 +695,7 @@ void TypoCorrectionResults::noteAllCandidates() const {
     // diagnostic.
     if (!ClaimedCorrection) {
       SyntacticTypoCorrection correction(WrittenName, Loc,
-                                         candidate->getFullName());
+                                         candidate->getName());
       correction.addFixits(diagnostic);
     }
   }

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -909,7 +909,7 @@ void repairTupleOrAssociatedValuePatternIfApplicable(
 
   if (addDeclNote)
     DE.diagnose(enumCase->getStartLoc(), diag::decl_declared_here,
-                enumCase->getFullName());
+                enumCase->getName());
 }
 
 /// Perform top-down type coercion on the given pattern.

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -79,7 +79,7 @@ static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
                       nominal->getDeclaredType(), name);
     for (auto var : vars) {
       var->diagnose(diag::kind_declname_declared_here,
-                    var->getDescriptiveKind(), var->getFullName());
+                    var->getDescriptiveKind(), var->getName());
     }
     return nullptr;
   }
@@ -89,7 +89,7 @@ static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
   if (isDeclNotAsAccessibleAsParent(var, nominal)) {
     var->diagnose(diag::property_wrapper_type_requirement_not_accessible,
                   var->getFormalAccess(), var->getDescriptiveKind(),
-                  var->getFullName(), nominal->getDeclaredType(),
+                  var->getName(), nominal->getDeclaredType(),
                   nominal->getFormalAccess());
     return nullptr;
   }
@@ -208,21 +208,21 @@ findSuitableWrapperInit(ASTContext &ctx, NominalTypeDecl *nominal,
       switch (reason) {
       case NonViableReason::Failable:
         init->diagnose(diag::property_wrapper_failable_init,
-                       init->getFullName());
+                       init->getName());
         break;
 
       case NonViableReason::Inaccessible:
         init->diagnose(diag::property_wrapper_type_requirement_not_accessible,
                        init->getFormalAccess(), init->getDescriptiveKind(),
-                       init->getFullName(), nominal->getDeclaredType(),
+                       init->getName(), nominal->getDeclaredType(),
                        nominal->getFormalAccess());
         break;
 
       case NonViableReason::ParameterTypeMismatch:
         init->diagnose(diag::property_wrapper_wrong_initial_value_init,
-                       init->getFullName(), paramType,
+                       init->getName(), paramType,
                        valueVar->getValueInterfaceType());
-        valueVar->diagnose(diag::decl_declared_here, valueVar->getFullName());
+        valueVar->diagnose(diag::decl_declared_here, valueVar->getName());
         break;
       }
     }
@@ -272,7 +272,7 @@ static SubscriptDecl *findEnclosingSelfSubscript(ASTContext &ctx,
     for (auto subscript : subscripts) {
       subscript->diagnose(diag::kind_declname_declared_here,
                           subscript->getDescriptiveKind(),
-                          subscript->getFullName());
+                          subscript->getName());
     }
     return nullptr;
 
@@ -284,7 +284,7 @@ static SubscriptDecl *findEnclosingSelfSubscript(ASTContext &ctx,
     subscript->diagnose(diag::property_wrapper_type_requirement_not_accessible,
                         subscript->getFormalAccess(),
                         subscript->getDescriptiveKind(),
-                        subscript->getFullName(), nominal->getDeclaredType(),
+                        subscript->getName(), nominal->getDeclaredType(),
                         nominal->getFormalAccess());
     return nullptr;
   }
@@ -482,7 +482,7 @@ AttachedPropertyWrappersRequest::evaluate(Evaluator &evaluator,
         whichKind = 2 + static_cast<unsigned>(attr->get());
       }
       var->diagnose(diag::property_with_wrapper_conflict_attribute,
-                    var->getFullName(), whichKind);
+                    var->getName(), whichKind);
       continue;
     }
 
@@ -499,7 +499,7 @@ AttachedPropertyWrappersRequest::evaluate(Evaluator &evaluator,
       else
         whichKind = 2;
       var->diagnose(diag::property_with_wrapper_in_bad_context,
-                    var->getFullName(), whichKind)
+                    var->getName(), whichKind)
         .highlight(attr->getRange());
 
       continue;
@@ -509,7 +509,7 @@ AttachedPropertyWrappersRequest::evaluate(Evaluator &evaluator,
     if (isa<ClassDecl>(dc)) {
       if (var->getAttrs().hasAttribute<OverrideAttr>()) {
         var->diagnose(diag::property_with_wrapper_overrides,
-                      var->getFullName())
+                      var->getName())
           .highlight(attr->getRange());
         continue;
       }
@@ -637,7 +637,7 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
     var->setInvalid();
     if (auto nominalWrapper = rawType->getAnyNominal()) {
       nominalWrapper->diagnose(diag::property_wrapper_declared_here,
-                               nominalWrapper->getFullName());
+                               nominalWrapper->getName());
     }
     return Type();
   }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -609,7 +609,7 @@ swift::matchWitness(
   }
 
   SmallVector<OptionalAdjustment, 2> optionalAdjustments;
-  bool anyRenaming = req->getFullName() != witness->getFullName();
+  const bool anyRenaming = req->getName() != witness->getName();
   if (decomposeFunctionType) {
     // Decompose function types into parameters and result type.
     auto reqFnType = reqType->castTo<AnyFunctionType>();
@@ -1020,7 +1020,7 @@ static bool
 witnessHasImplementsAttrForRequiredName(ValueDecl *witness,
                                         ValueDecl *requirement) {
   if (auto A = witness->getAttrs().getAttribute<ImplementsAttr>()) {
-    return A->getMemberName() == requirement->getFullName();
+    return A->getMemberName() == requirement->getName();
   }
   return false;
 }
@@ -1034,7 +1034,7 @@ witnessHasImplementsAttrForExactRequirement(ValueDecl *witness,
     if (Type T = A->getProtocolType().getType()) {
       if (auto ProtoTy = T->getAs<ProtocolType>()) {
         if (ProtoTy->getDecl() == PD) {
-          return A->getMemberName() == requirement->getFullName();
+          return A->getMemberName() == requirement->getName();
         }
       }
     }
@@ -1607,7 +1607,7 @@ static void diagnoseConformanceImpliedByConditionalConformance(
     if (!decl)
       decl = T->getAnyGeneric();
 
-    prefixStream << "extension " << decl->getFullName() << ": " << protoType << " ";
+    prefixStream << "extension " << decl->getName() << ": " << protoType << " ";
     suffixStream << " {\n"
                  << indent << extraIndent << "<#witnesses#>\n"
                  << indent << "}\n\n"
@@ -2206,8 +2206,8 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
   // diagnosis.
   if (match.Kind != MatchKind::RenamedMatch &&
       !match.Witness->getAttrs().hasAttribute<ImplementsAttr>() &&
-      match.Witness->getFullName() &&
-      req->getFullName() != match.Witness->getFullName() &&
+      match.Witness->getName() &&
+      req->getName() != match.Witness->getName() &&
       !isa<EnumElementDecl>(match.Witness))
     return;
 
@@ -2232,10 +2232,10 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
 
   case MatchKind::RenamedMatch: {
     auto diag = diags.diagnose(match.Witness, diag::protocol_witness_renamed,
-                               req->getFullName(), withAssocTypes);
+                               req->getName(), withAssocTypes);
 
     // Fix the name.
-    fixDeclarationName(diag, match.Witness, req->getFullName());
+    fixDeclarationName(diag, match.Witness, req->getName());
 
     // Also fix the Objective-C name, if needed.
     if (!match.Witness->canInferObjCFromRequirement(req))
@@ -2417,8 +2417,8 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
               diag::
                   protocol_witness_missing_differentiable_attr_nonpublic_other_file,
               reqDiffAttrString, witness->getDescriptiveKind(),
-              witness->getFullName(), req->getDescriptiveKind(),
-              req->getFullName(), conformance->getType(),
+              witness->getName(), req->getDescriptiveKind(),
+              req->getName(), conformance->getType(),
               conformance->getProtocol()->getDeclaredInterfaceType())
           .fixItInsert(match.Witness->getStartLoc(), reqDiffAttrString + ' ');
     }
@@ -2564,7 +2564,7 @@ static void emitDeclaredHereIfNeeded(DiagnosticEngine &diags,
     return;
   if (mainDiagLoc == value->getLoc())
     return;
-  diags.diagnose(value, diag::decl_declared_here, value->getFullName());
+  diags.diagnose(value, diag::decl_declared_here, value->getName());
 }
 
 bool ConformanceChecker::checkObjCTypeErasedGenerics(
@@ -2602,7 +2602,7 @@ bool ConformanceChecker::checkObjCTypeErasedGenerics(
   SourceLoc diagLoc = getLocForDiagnosingWitness(Conformance, typeDecl);
   ctx.Diags.diagnose(diagLoc, diag::type_witness_objc_generic_parameter,
                      type, genericParam, !genericParam.isNull(),
-                     assocType->getFullName(), Proto->getFullName());
+                     assocType->getName(), Proto->getName());
   emitDeclaredHereIfNeeded(ctx.Diags, diagLoc, typeDecl);
 
   return true;
@@ -2631,7 +2631,7 @@ public:
     SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, witness);
     ctx.Diags.diagnose(diagLoc, diagID,
                        witness->getDescriptiveKind(),
-                       witness->getFullName(),
+                       witness->getName(),
                        proto->getName());
     emitDeclaredHereIfNeeded(ctx.Diags, diagLoc, witness);
   }
@@ -2717,7 +2717,7 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
         diags.diagnose(getLocForDiagnosingWitness(conformance, typeDecl),
                        diagKind,
                        typeDecl->getDescriptiveKind(),
-                       typeDecl->getFullName(),
+                       typeDecl->getName(),
                        requiredAccess,
                        proto->getName());
         diagnoseWitnessFixAccessLevel(diags, typeDecl, requiredAccess);
@@ -3046,13 +3046,13 @@ diagnoseMissingWitnesses(MissingWitnessDiagnosisKind Kind) {
           // we can directly associate the fixit with the note issued to the
           // requirement.
           Diags.diagnose(VD, diag::no_witnesses, getRequirementKind(VD),
-            VD->getFullName(), RequirementType, true)
+                         VD->getName(), RequirementType, true)
               .fixItInsertAfter(FixitLocation, FixIt);
         } else {
           // Otherwise, we have to issue another note to carry the fixit,
           // because editor may assume the fixit is in the same file with the note.
           Diags.diagnose(VD, diag::no_witnesses, getRequirementKind(VD),
-            VD->getFullName(), RequirementType, false);
+                         VD->getName(), RequirementType, false);
           if (EditorMode) {
             Diags.diagnose(ComplainLoc, diag::missing_witnesses_general)
               .fixItInsertAfter(FixitLocation, FixIt);
@@ -3060,7 +3060,7 @@ diagnoseMissingWitnesses(MissingWitnessDiagnosisKind Kind) {
         }
       } else {
         Diags.diagnose(VD, diag::no_witnesses, getRequirementKind(VD),
-                       VD->getFullName(), RequirementType, true);
+                       VD->getName(), RequirementType, true);
       }
     }
   };
@@ -3156,7 +3156,7 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
           SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, ctor);
           Optional<InFlightDiagnostic> fixItDiag =
               diags.diagnose(diagLoc, diag::witness_initializer_not_required,
-                             requirement->getFullName(), inExtension,
+                             requirement->getName(), inExtension,
                              conformance->getType());
           if (diagLoc != ctor->getLoc() && !ctor->isImplicit()) {
             // If the main diagnostic is emitted on the conformance, we want to
@@ -3164,7 +3164,7 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
             // defined.
             fixItDiag.getValue().flush();
             fixItDiag.emplace(diags.diagnose(ctor, diag::decl_declared_here,
-                                             ctor->getFullName()));
+                                             ctor->getName()));
           }
           if (!inExtension) {
             fixItDiag->fixItInsert(ctor->getAttributeInsertionLoc(true),
@@ -3190,7 +3190,7 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
         auto &diags = proto->getASTContext().Diags;
         SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, witness);
         diags.diagnose(diagLoc, diag::witness_self_non_subtype,
-                       proto->getDeclaredType(), requirement->getFullName(),
+                       proto->getDeclaredType(), requirement->getName(),
                        conformance->getType());
         emitDeclaredHereIfNeeded(diags, diagLoc, witness);
       });
@@ -3209,7 +3209,7 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
             SourceLoc diagLoc = getLocForDiagnosingWitness(conformance,witness);
             diags.diagnose(diagLoc,
                            diag::witness_requires_dynamic_self,
-                           requirement->getFullName(),
+                           requirement->getName(),
                            conformance->getType(),
                            proto->getDeclaredType());
             emitDeclaredHereIfNeeded(diags, diagLoc, witness);
@@ -3226,7 +3226,7 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
           SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, witness);
           diags.diagnose(diagLoc, diag::witness_self_non_subtype,
                          proto->getDeclaredType(),
-                         requirement->getFullName(),
+                         requirement->getName(),
                          conformance->getType());
           emitDeclaredHereIfNeeded(diags, diagLoc, witness);
         });
@@ -3240,10 +3240,10 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
       SourceLoc diagLoc = getLocForDiagnosingWitness(Conformance, witness);
       diags.diagnose(diagLoc, diag::witness_self_same_type,
                      witness->getDescriptiveKind(),
-                     witness->getFullName(),
+                     witness->getName(),
                      Conformance->getType(),
                      requirement->getDescriptiveKind(),
-                     requirement->getFullName(),
+                     requirement->getName(),
                      proto->getDeclaredType());
       emitDeclaredHereIfNeeded(diags, diagLoc, witness);
 
@@ -3279,10 +3279,10 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
             auto &diags = proto->getASTContext().Diags;
             diags.diagnose(conformance->getLoc(),
                            diag::witness_requires_class_implementation,
-                           requirement->getFullName(),
+                           requirement->getName(),
                            conformance->getType());
             diags.diagnose(witness, diag::decl_declared_here,
-                           witness->getFullName());
+                           witness->getName());
           });
       }
     }
@@ -3347,7 +3347,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
 
     // If the name didn't actually line up, complain.
     if (ignoringNames &&
-        requirement->getFullName() != best.Witness->getFullName() &&
+        requirement->getName() != best.Witness->getName() &&
         !witnessHasImplementsAttrForRequiredName(best.Witness, requirement)) {
 
       diagnoseOrDefer(requirement, false,
@@ -3358,20 +3358,20 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
             SourceLoc diagLoc = getLocForDiagnosingWitness(conformance,witness);
             auto diag = diags.diagnose(
                 diagLoc, diag::witness_argument_name_mismatch,
-                witness->getDescriptiveKind(), witness->getFullName(),
-                proto->getDeclaredType(), requirement->getFullName());
+                witness->getDescriptiveKind(), witness->getName(),
+                proto->getDeclaredType(), requirement->getName());
             if (diagLoc == witness->getLoc()) {
-              fixDeclarationName(diag, witness, requirement->getFullName());
+              fixDeclarationName(diag, witness, requirement->getName());
             } else {
               diag.flush();
               diags.diagnose(witness, diag::decl_declared_here,
-                             witness->getFullName());
+                             witness->getName());
             }
           }
 
           diags.diagnose(requirement, diag::kind_declname_declared_here,
                          DescriptiveDeclKind::Requirement,
-                         requirement->getFullName());
+                         requirement->getName());
         });
     }
 
@@ -3419,7 +3419,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
         diags.diagnose(getLocForDiagnosingWitness(conformance, witness),
                        diagKind,
                        getRequirementKind(requirement),
-                       witness->getFullName(),
+                       witness->getName(),
                        isSetter,
                        requiredAccess,
                        protoAccessScope.accessLevelForDiagnostics(),
@@ -3452,8 +3452,8 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
           SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, witness);
           diags.diagnose(
               diagLoc, diag::availability_protocol_requires_version,
-              conformance->getProtocol()->getFullName(),
-              witness->getFullName(),
+              conformance->getProtocol()->getName(),
+              witness->getName(),
               prettyPlatformString(targetPlatform(ctx.LangOpts)),
               check.RequiredAvailability.getOSVersion().getLowerEndpoint());
           emitDeclaredHereIfNeeded(diags, diagLoc, witness);
@@ -3486,19 +3486,19 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
                 hasAnyError(adjustments)
                     ? diag::err_protocol_witness_optionality
                     : diag::warn_protocol_witness_optionality,
-                issues, witness->getFullName(), proto->getFullName());
+                issues, witness->getName(), proto->getName());
             if (diagLoc == witness->getLoc()) {
               addOptionalityFixIts(adjustments, ctx, witness, diag);
             } else {
               diag.flush();
               diags.diagnose(witness, diag::decl_declared_here,
-                             witness->getFullName());
+                             witness->getName());
             }
           }
 
           diags.diagnose(requirement, diag::kind_declname_declared_here,
                          DescriptiveDeclKind::Requirement,
-                         requirement->getFullName());
+                         requirement->getName());
       });
       break;
     }
@@ -3512,7 +3512,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
           SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, witness);
           diags.diagnose(diagLoc,
                          diag::witness_initializer_failability,
-                         ctor->getFullName(),
+                         ctor->getName(),
                          witnessCtor->isImplicitlyUnwrappedOptional())
             .highlight(witnessCtor->getFailabilityLoc());
           emitDeclaredHereIfNeeded(diags, diagLoc, witness);
@@ -3529,12 +3529,12 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
           diags.diagnose(diagLoc,
                          diag::witness_unavailable,
                          witness->getDescriptiveKind(),
-                         witness->getFullName(),
-                         conformance->getProtocol()->getFullName());
+                         witness->getName(),
+                         conformance->getProtocol()->getName());
           emitDeclaredHereIfNeeded(diags, diagLoc, witness);
           diags.diagnose(requirement, diag::kind_declname_declared_here,
                          DescriptiveDeclKind::Requirement,
-                         requirement->getFullName());
+                         requirement->getName());
         });
       break;
     }
@@ -3612,7 +3612,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
       }
       diags.diagnose(requirement, diagnosticMessage,
                      getRequirementKind(requirement),
-                     requirement->getFullName(),
+                     requirement->getName(),
                      reqType);
 
       // Diagnose each of the matches.
@@ -4004,7 +4004,7 @@ void ConformanceChecker::resolveValueWitnesses() {
       // Objective-C checking for @objc requirements.
       auto &C = witness->getASTContext();
       if (requirement->isObjC() &&
-          requirement->getFullName() == witness->getFullName() &&
+          requirement->getName() == witness->getName() &&
           !requirement->getAttrs().isUnavailable(getASTContext())) {
         // The witness must also be @objc.
         if (!witness->isObjC()) {
@@ -4017,7 +4017,7 @@ void ConformanceChecker::resolveValueWitnesses() {
                 diagLoc,
                 isOptional ? diag::witness_non_objc_optional
                            : diag::witness_non_objc,
-                diagInfo.first, diagInfo.second, Proto->getFullName());
+                diagInfo.first, diagInfo.second, Proto->getName());
             if (diagLoc != witness->getLoc()) {
               // If the main diagnostic is emitted on the conformance, we want
               // to attach the fix-it to the note that shows where the
@@ -4037,8 +4037,8 @@ void ConformanceChecker::resolveValueWitnesses() {
                 diagLoc,
                 isOptional ? diag::witness_non_objc_storage_optional
                            : diag::witness_non_objc_storage,
-                /*isSubscript=*/false, witness->getFullName(),
-                Proto->getFullName());
+                /*isSubscript=*/false, witness->getName(),
+                Proto->getName());
             if (diagLoc != witness->getLoc()) {
               // If the main diagnostic is emitted on the conformance, we want
               // to attach the fix-it to the note that shows where the
@@ -4058,8 +4058,8 @@ void ConformanceChecker::resolveValueWitnesses() {
                 diagLoc,
                 isOptional ? diag::witness_non_objc_storage_optional
                            : diag::witness_non_objc_storage,
-                /*isSubscript=*/true, witness->getFullName(),
-                Proto->getFullName());
+                /*isSubscript=*/true, witness->getName(),
+                Proto->getName());
             if (diagLoc != witness->getLoc()) {
               // If the main diagnostic is emitted on the conformance, we want
               // to attach the fix-it to the note that shows where the
@@ -4082,7 +4082,7 @@ void ConformanceChecker::resolveValueWitnesses() {
 
           requirement->diagnose(diag::kind_declname_declared_here,
                                 DescriptiveDeclKind::Requirement,
-                                requirement->getFullName());
+                                requirement->getName());
 
           Conformance->setInvalid();
           return;
@@ -4102,7 +4102,7 @@ void ConformanceChecker::resolveValueWitnesses() {
                   Swift3ObjCInferenceWarnings::Minimal) {
             C.Diags.diagnose(
                 Conformance->getLoc(), diag::witness_swift3_objc_inference,
-                witness->getDescriptiveKind(), witness->getFullName(),
+                witness->getDescriptiveKind(), witness->getName(),
                 Conformance->getProtocol()->getDeclaredInterfaceType());
             witness
                 ->diagnose(diag::make_decl_objc, witness->getDescriptiveKind())
@@ -4592,8 +4592,8 @@ scorePotentiallyMatching(ValueDecl *req, ValueDecl *witness, unsigned limit) {
     return None;
   };
 
-  DeclName reqName = req->getFullName();
-  DeclName witnessName = witness->getFullName();
+  DeclName reqName = req->getName();
+  DeclName witnessName = witness->getName();
 
   // For @objc protocols, apply the omit-needless-words heuristics to
   // both names.
@@ -4774,8 +4774,8 @@ static bool shouldWarnAboutPotentialWitness(
   // unrelated.  Allow about one typo for every four properly-typed
   // characters, which prevents completely-wacky suggestions in many
   // cases.
-  unsigned reqNameLen = getNameLength(req->getFullName());
-  unsigned witnessNameLen = getNameLength(witness->getFullName());
+  const unsigned reqNameLen = getNameLength(req->getName());
+  const unsigned witnessNameLen = getNameLength(witness->getName());
   if (score > (std::min(reqNameLen, witnessNameLen)) / 4)
     return false;
 
@@ -4790,9 +4790,9 @@ static void diagnosePotentialWitness(NormalProtocolConformance *conformance,
 
   // Primary warning.
   witness->diagnose(diag::req_near_match, witness->getDescriptiveKind(),
-                    witness->getFullName(),
+                    witness->getName(),
                     req->getAttrs().hasAttribute<OptionalAttr>(),
-                    req->getFullName(), proto->getFullName());
+                    req->getName(), proto->getName());
 
   // Describe why the witness didn't satisfy the requirement.
   WitnessChecker::RequirementEnvironmentCache oneUseCache;
@@ -4816,7 +4816,7 @@ static void diagnosePotentialWitness(NormalProtocolConformance *conformance,
   // If moving the declaration can help, suggest that.
   if (auto move
         = canSuppressPotentialWitnessWarningWithMovement(req, witness)) {
-    witness->diagnose(diag::req_near_match_move, witness->getFullName(),
+    witness->diagnose(diag::req_near_match_move, witness->getName(),
                       static_cast<unsigned>(*move));
   }
 
@@ -4824,7 +4824,7 @@ static void diagnosePotentialWitness(NormalProtocolConformance *conformance,
   if (access > AccessLevel::FilePrivate &&
       !witness->getAttrs().hasAttribute<AccessControlAttr>()) {
     witness
-        ->diagnose(diag::req_near_match_access, witness->getFullName(), access)
+        ->diagnose(diag::req_near_match_access, witness->getName(), access)
         .fixItInsert(witness->getAttributeInsertionLoc(true), "private ");
   }
 
@@ -4835,7 +4835,7 @@ static void diagnosePotentialWitness(NormalProtocolConformance *conformance,
   }
 
   req->diagnose(diag::kind_declname_declared_here,
-                DescriptiveDeclKind::Requirement, req->getFullName());
+                DescriptiveDeclKind::Requirement, req->getName());
 }
 
 /// Whether the given protocol is "NSCoding".
@@ -5174,14 +5174,14 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
         auto value = dyn_cast<ValueDecl>(decl);
         if (!value) continue;
 
-        if (!diagnosedNames.insert(value->getFullName()).second)
+        if (!diagnosedNames.insert(value->getName()).second)
           continue;
 
         bool valueIsType = isa<TypeDecl>(value);
         const auto flags =
             NominalTypeDecl::LookupDirectFlags::IgnoreNewExtensions;
         for (auto requirement
-                : diag.Protocol->lookupDirect(value->getFullName(), flags)) {
+                : diag.Protocol->lookupDirect(value->getName(), flags)) {
           if (requirement->getDeclContext() != diag.Protocol)
             continue;
 
@@ -5190,8 +5190,8 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
             continue;
 
           value->diagnose(diag::redundant_conformance_witness_ignored,
-                          value->getDescriptiveKind(), value->getFullName(),
-                          diag.Protocol->getFullName());
+                          value->getDescriptiveKind(), value->getName(),
+                          diag.Protocol->getName());
           break;
         }
       }
@@ -5241,7 +5241,7 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
         auto value = dyn_cast<ValueDecl>(member);
         if (!value) continue;
         if (isa<TypeDecl>(value)) continue;
-        if (!value->getFullName()) continue;
+        if (!value->getName()) continue;
 
         // If this declaration overrides another declaration, the signature is
         // fixed; don't complain about near misses.
@@ -5353,7 +5353,7 @@ swift::findWitnessedObjCRequirements(const ValueDecl *witness,
   auto nominal = dc->getSelfNominalTypeDecl();
   if (!nominal) return result;
 
-  DeclName name = witness->getFullName();
+  DeclName name = witness->getName();
   Optional<AccessorKind> accessorKind;
   if (auto *accessor = dyn_cast<AccessorDecl>(witness)) {
     accessorKind = accessor->getAccessorKind();
@@ -5371,7 +5371,7 @@ swift::findWitnessedObjCRequirements(const ValueDecl *witness,
     case AccessorKind::Get:
     case AccessorKind::Set:
       // These are found relative to the main decl.
-      name = accessor->getStorage()->getFullName();
+      name = accessor->getStorage()->getName();
       break;
     }
   }
@@ -5735,7 +5735,7 @@ void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {
     if (assocType->getProtocol() != proto) {
       SmallVector<ValueDecl *, 2> found;
       proto->getModuleContext()->lookupQualified(
-                           proto, DeclNameRef(assocType->getFullName()),
+                           proto, DeclNameRef(assocType->getName()),
                            NL_QualifiedDefault|NL_ProtocolMembers|NL_OnlyTypes,
                            found);
       if (found.size() == 1 && isa<AssociatedTypeDecl>(found[0]))
@@ -5760,10 +5760,10 @@ void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {
       // Diagnose the lack of a conformance. This is potentially an ABI
       // incompatibility.
       proto->diagnose(diag::assoc_type_default_conformance_failed,
-                      defaultAssocType, assocType->getFullName(),
+                      defaultAssocType, assocType->getName(),
                       req.getFirstType(), req.getSecondType());
       defaultedAssocDecl
-          ->diagnose(diag::assoc_type_default_here, assocType->getFullName(),
+          ->diagnose(diag::assoc_type_default_here, assocType->getName(),
                      defaultAssocType)
           .highlight(defaultedAssocDecl->getDefaultDefinitionTypeRepr()
                          ->getSourceRange());

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1678,7 +1678,7 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
         diags.diagnose(failedDefaultedAssocType,
                        diag::default_associated_type_req_fail,
                        failedDefaultedWitness,
-                       failedDefaultedAssocType->getFullName(),
+                       failedDefaultedAssocType->getName(),
                        proto->getDeclaredType(),
                        failedDefaultedResult.getRequirement(),
                        failedDefaultedResult.isConformanceRequirement());
@@ -1714,7 +1714,7 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
         auto proto = conformance->getProtocol();
         auto &diags = proto->getASTContext().Diags;
         diags.diagnose(assocType, diag::bad_associated_type_deduction,
-                       assocType->getFullName(), proto->getFullName());
+                       assocType->getName(), proto->getName());
         for (const auto &failed : failedSet) {
           if (failed.Result.isError())
             continue;
@@ -1769,17 +1769,17 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
         auto &diags = conformance->getDeclContext()->getASTContext().Diags;
         diags.diagnose(typeWitnessConflict->AssocType,
                        diag::ambiguous_associated_type_deduction,
-                       typeWitnessConflict->AssocType->getFullName(),
+                       typeWitnessConflict->AssocType->getName(),
                        typeWitnessConflict->FirstType,
                        typeWitnessConflict->SecondType);
 
         diags.diagnose(typeWitnessConflict->FirstWitness,
                        diag::associated_type_deduction_witness,
-                       typeWitnessConflict->FirstRequirement->getFullName(),
+                       typeWitnessConflict->FirstRequirement->getName(),
                        typeWitnessConflict->FirstType);
         diags.diagnose(typeWitnessConflict->SecondWitness,
                        diag::associated_type_deduction_witness,
-                       typeWitnessConflict->SecondRequirement->getFullName(),
+                       typeWitnessConflict->SecondRequirement->getName(),
                        typeWitnessConflict->SecondType);
       });
 
@@ -1832,7 +1832,7 @@ bool AssociatedTypeInference::diagnoseAmbiguousSolutions(
         NormalProtocolConformance *conformance) {
         auto &diags = assocType->getASTContext().Diags;
         diags.diagnose(assocType, diag::ambiguous_associated_type_deduction,
-                       assocType->getFullName(), firstType, secondType);
+                       assocType->getName(), firstType, secondType);
 
         auto diagnoseWitness = [&](std::pair<ValueDecl *, ValueDecl *> match,
                                    Type type){
@@ -1840,7 +1840,7 @@ bool AssociatedTypeInference::diagnoseAmbiguousSolutions(
           if (match.first && match.second) {
             diags.diagnose(match.second,
                            diag::associated_type_deduction_witness,
-                           match.first->getFullName(), type);
+                           match.first->getName(), type);
 
             return;
           }

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -213,7 +213,7 @@ Type FunctionBuilderTypeRequest::evaluate(Evaluator &evaluator,
     if (!paramFnType) {
       ctx.Diags.diagnose(attr->getLocation(),
                          diag::function_builder_parameter_not_of_function_type,
-                         nominal->getFullName());
+                         nominal->getName());
       mutableAttr->setInvalid();
       return Type();
     }
@@ -222,7 +222,7 @@ Type FunctionBuilderTypeRequest::evaluate(Evaluator &evaluator,
     if (param->isAutoClosure()) {
       ctx.Diags.diagnose(attr->getLocation(),
                          diag::function_builder_parameter_autoclosure,
-                         nominal->getFullName());
+                         nominal->getName());
       mutableAttr->setInvalid();
       return Type();
     }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -167,10 +167,10 @@ namespace {
   };
 
   static DeclName getDescriptiveName(AbstractFunctionDecl *AFD) {
-    DeclName name = AFD->getFullName();
+    DeclName name = AFD->getName();
     if (!name) {
       if (auto *accessor = dyn_cast<AccessorDecl>(AFD)) {
-        name = accessor->getStorage()->getFullName();
+        name = accessor->getStorage()->getName();
       }
     }
     return name;
@@ -495,7 +495,7 @@ public:
                                        diag::return_non_failable_init)
           .highlight(E->getSourceRange());
         getASTContext().Diags.diagnose(ctor->getLoc(), diag::make_init_failable,
-                    ctor->getFullName())
+                    ctor->getName())
           .fixItInsertAfter(ctor->getLoc(), "?");
         RS->setResult(nullptr);
         return RS;
@@ -1533,10 +1533,10 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
       }
 
       auto diagID = diag::expression_unused_result_call;
-      if (callee->getFullName().isOperator())
+      if (callee->getName().isOperator())
         diagID = diag::expression_unused_result_operator;
       
-      DE.diagnose(fn->getLoc(), diagID, callee->getFullName())
+      DE.diagnose(fn->getLoc(), diagID, callee->getName())
         .highlight(SR1).highlight(SR2);
     } else
       DE.diagnose(fn->getLoc(), diag::expression_unused_result_unknown,

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -875,14 +875,14 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
     // Key path referring to the property being accessed.
     Expr *propertyKeyPath = new (ctx) KeyPathDotExpr(SourceLoc());
     propertyKeyPath = UnresolvedDotExpr::createImplicit(ctx, propertyKeyPath,
-        enclosingSelfAccess->accessedProperty->getFullName());
+        enclosingSelfAccess->accessedProperty->getName());
     propertyKeyPath = new (ctx) KeyPathExpr(
         SourceLoc(), nullptr, propertyKeyPath, /*hasLeadingDot=*/true);
 
     // Key path referring to the backing storage property.
     Expr *storageKeyPath = new (ctx) KeyPathDotExpr(SourceLoc());
     storageKeyPath = UnresolvedDotExpr::createImplicit(ctx, storageKeyPath,
-                                                       storage->getFullName());
+                                                       storage->getName());
     storageKeyPath = new (ctx) KeyPathExpr(SourceLoc(), nullptr, storageKeyPath,
                                            /*hasLeadingDot=*/true);
     Expr *args[3] = {selfDRE, propertyKeyPath, storageKeyPath};
@@ -890,7 +890,7 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
     SubscriptDecl *subscriptDecl = enclosingSelfAccess->subscript;
     lookupExpr = SubscriptExpr::create(
         ctx, wrapperMetatype, SourceLoc(), args,
-        subscriptDecl->getFullName().getArgumentNames(), { }, SourceLoc(),
+        subscriptDecl->getName().getArgumentNames(), { }, SourceLoc(),
         nullptr, subscriptDecl, /*Implicit=*/true);
 
     // FIXME: Since we're not resolving overloads or anything, we should be
@@ -1002,7 +1002,7 @@ static Expr *synthesizeCopyWithZoneCall(Expr *Val, VarDecl *VD,
   FuncDecl *copyMethod = nullptr;
   for (auto member : conformance.getRequirement()->getMembers()) {
     if (auto func = dyn_cast<FuncDecl>(member)) {
-      if (func->getFullName() == copyWithZoneName) {
+      if (func->getName() == copyWithZoneName) {
         copyMethod = func;
         break;
       }
@@ -2615,7 +2615,7 @@ PropertyWrapperBackingPropertyInfoRequest::evaluate(Evaluator &evaluator,
       var->setInvalid();
       if (auto nominalWrapper = wrapperType->getAnyNominal()) {
         nominalWrapper->diagnose(diag::property_wrapper_declared_here,
-                                 nominalWrapper->getFullName());
+                                 nominalWrapper->getName());
       }
       return PropertyWrapperBackingPropertyInfo();
     }

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -816,7 +816,7 @@ namespace {
                     Space::forType(TTy->getUnderlyingType(), Identifier()));
               }
             }
-            return Space::forConstructor(tp, eed->getFullName(),
+            return Space::forConstructor(tp, eed->getName(),
                                          constElemSpaces);
           });
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1000,7 +1000,8 @@ static void maybeDiagnoseBadConformanceRef(DeclContext *dc,
           ? diag::unsupported_recursion_in_associated_type_reference
           : diag::broken_associated_type_witness;
 
-  ctx.Diags.diagnose(loc, diagCode, isa<TypeAliasDecl>(typeDecl), typeDecl->getFullName(), parentTy);
+  ctx.Diags.diagnose(loc, diagCode, isa<TypeAliasDecl>(typeDecl),
+                     typeDecl->getName(), parentTy);
 }
 
 /// Returns a valid type or ErrorType in case of an error.
@@ -1217,7 +1218,7 @@ static Type diagnoseUnknownType(TypeResolution resolution,
     if (!memberLookup.empty()) {
       auto member = memberLookup[0].getValueDecl();
       diags.diagnose(comp->getNameLoc(), diag::invalid_member_reference,
-                     member->getDescriptiveKind(), member->getFullName(),
+                     member->getDescriptiveKind(), member->getName(),
                      parentType)
           .highlight(parentRange);
     } else {
@@ -1228,7 +1229,7 @@ static Type diagnoseUnknownType(TypeResolution resolution,
       // expected name lookup to find a module when there's a conflicting type.
       if (auto typeDecl = parentType->getNominalOrBoundGenericNominal()) {
         ctx.Diags.diagnose(typeDecl, diag::decl_declared_here,
-                           typeDecl->getFullName());
+                           typeDecl->getName());
       }
     }
   }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4920,7 +4920,8 @@ public:
     auto nominal = dyn_cast<NominalTypeDecl>(nominalOrError.get());
     if (!nominal) {
       XRefTracePath tinyTrace{*nominalOrError.get()->getModuleContext()};
-      DeclName fullName = cast<ValueDecl>(nominalOrError.get())->getFullName();
+      const DeclName fullName =
+          cast<ValueDecl>(nominalOrError.get())->getName();
       tinyTrace.addValue(fullName.getBaseIdentifier());
       return llvm::make_error<XRefError>("declaration is not a nominal type",
                                          tinyTrace, fullName);

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -2144,7 +2144,7 @@ void ModuleFile::lookupValue(DeclName name,
           continue;
         }
         auto VD = cast<ValueDecl>(declOrError.get());
-        if (name.isSimpleName() || VD->getFullName().matchesRef(name))
+        if (name.isSimpleName() || VD->getName().matchesRef(name))
           results.push_back(VD);
       }
     }
@@ -2587,7 +2587,7 @@ void ModuleFile::lookupClassMember(ModuleDecl::AccessPathTy accessPath,
     } else {
       for (auto item : *iter) {
         auto vd = cast<ValueDecl>(getDecl(item.second));
-        if (!vd->getFullName().matchesRef(name))
+        if (!vd->getName().matchesRef(name))
           continue;
         
         auto dc = vd->getDeclContext();

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3392,8 +3392,8 @@ public:
     unsigned abbrCode = S.DeclTypeAbbrCodes[FuncLayout::Code];
     SmallVector<IdentifierID, 4> nameComponentsAndDependencies;
     nameComponentsAndDependencies.push_back(
-        S.addDeclBaseNameRef(fn->getFullName().getBaseName()));
-    for (auto argName : fn->getFullName().getArgumentNames())
+        S.addDeclBaseNameRef(fn->getBaseName()));
+    for (auto argName : fn->getName().getArgumentNames())
       nameComponentsAndDependencies.push_back(S.addDeclBaseNameRef(argName));
 
     uint8_t rawAccessLevel = getRawStableAccessLevel(fn->getFormalAccess());
@@ -3420,8 +3420,8 @@ public:
                            S.addDeclRef(fn->getOperatorDecl()),
                            S.addDeclRef(fn->getOverriddenDecl()),
                            overriddenDeclAffectsABI(fn->getOverriddenDecl()),
-                           fn->getFullName().getArgumentNames().size() +
-                             fn->getFullName().isCompoundName(),
+                           fn->getName().getArgumentNames().size() +
+                             fn->getName().isCompoundName(),
                            rawAccessLevel,
                            fn->needsNewVTableEntry(),
                            S.addDeclRef(fn->getOpaqueResultTypeDecl()),
@@ -3528,7 +3528,7 @@ public:
     SmallVector<IdentifierID, 4> nameComponentsAndDependencies;
     auto baseName = S.addDeclBaseNameRef(elem->getBaseName());
     nameComponentsAndDependencies.push_back(baseName);
-    for (auto argName : elem->getFullName().getArgumentNames())
+    for (auto argName : elem->getName().getArgumentNames())
       nameComponentsAndDependencies.push_back(S.addDeclBaseNameRef(argName));
 
     Type ty = elem->getInterfaceType();
@@ -3558,7 +3558,7 @@ public:
                                   isRawValueImplicit,
                                   isNegative,
                                   S.addUniquedStringRef(RawValueText),
-                                  elem->getFullName().getArgumentNames().size()+1,
+                                  elem->getName().getArgumentNames().size()+1,
                                   nameComponentsAndDependencies);
     if (auto *PL = elem->getParameterList())
       writeParameterList(PL);
@@ -3573,7 +3573,7 @@ public:
     Accessors accessors = getAccessors(subscript);
 
     SmallVector<IdentifierID, 4> nameComponentsAndDependencies;
-    for (auto argName : subscript->getFullName().getArgumentNames())
+    for (auto argName : subscript->getName().getArgumentNames())
       nameComponentsAndDependencies.push_back(S.addDeclBaseNameRef(argName));
 
     for (auto accessor : accessors.Decls)
@@ -3614,8 +3614,7 @@ public:
                                 rawAccessLevel,
                                 rawSetterAccessLevel,
                                 rawStaticSpelling,
-                                subscript->
-                                  getFullName().getArgumentNames().size(),
+                                subscript->getName().getArgumentNames().size(),
                                 S.addDeclRef(subscript->getOpaqueResultTypeDecl()),
                                 numVTableEntries,
                                 nameComponentsAndDependencies);
@@ -3631,7 +3630,7 @@ public:
     auto contextID = S.addDeclContextRef(ctor->getDeclContext());
 
     SmallVector<IdentifierID, 4> nameComponentsAndDependencies;
-    for (auto argName : ctor->getFullName().getArgumentNames())
+    for (auto argName : ctor->getName().getArgumentNames())
       nameComponentsAndDependencies.push_back(S.addDeclBaseNameRef(argName));
 
     Type ty = ctor->getInterfaceType();
@@ -3662,7 +3661,7 @@ public:
                                   rawAccessLevel,
                                   ctor->needsNewVTableEntry(),
                                   firstTimeRequired,
-                                  ctor->getFullName().getArgumentNames().size(),
+                                  ctor->getName().getArgumentNames().size(),
                                   nameComponentsAndDependencies);
 
     writeGenericParams(ctor->getGenericParams());

--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -445,7 +445,7 @@ Symbol::getPathComponents(SmallVectorImpl<SmallString<32>> &Components) const {
     // Collect the spellings of the fully qualified identifier components.
     while (Decl && !isa<ModuleDecl>(Decl)) {
       SmallString<32> Scratch;
-      Decl->getFullName().getString(Scratch);
+      Decl->getName().getString(Scratch);
       DeclComponents.push_back(Scratch);
       if (const auto *DC = Decl->getDeclContext()) {
         if (const auto *Nominal = DC->getSelfNominalTypeDecl()) {
@@ -464,7 +464,7 @@ Symbol::getPathComponents(SmallVectorImpl<SmallString<32>> &Components) const {
     // existing on another type, such as a default implementation of
     // a protocol. Build a path as if it were defined in the base type.
     SmallString<32> LastPathComponent;
-    VD->getFullName().getString(LastPathComponent);
+    VD->getName().getString(LastPathComponent);
     Components.push_back(LastPathComponent);
     collectPathComponents(BaseTypeDecl, Components);
   } else {

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -99,11 +99,11 @@ SymbolGraph::isRequirementOrDefaultImplementation(const ValueDecl *VD) const {
     return false;
   };
 
-  if (FoundRequirementMemberNamed(VD->getFullName(), Proto)) {
+  if (FoundRequirementMemberNamed(VD->getName(), Proto)) {
     return true;
   }
   for (auto *Inherited : Proto->getInheritedProtocols()) {
-    if (FoundRequirementMemberNamed(VD->getFullName(), Inherited)) {
+    if (FoundRequirementMemberNamed(VD->getName(), Inherited)) {
       return true;
     }
   }
@@ -315,7 +315,7 @@ void SymbolGraph::recordDefaultImplementationRelationships(Symbol S) {
   auto HandleProtocol = [=](const ProtocolDecl *P) {
     for (const auto *Member : P->getMembers()) {
       if (const auto *MemberVD = dyn_cast<ValueDecl>(Member)) {
-        if (MemberVD->getFullName().compare(VD->getFullName()) == 0) {
+        if (MemberVD->getName().compare(VD->getName()) == 0) {
           recordEdge(Symbol(this, VD, nullptr),
                      Symbol(this, MemberVD, nullptr),
                      RelationshipKind::DefaultImplementationOf());

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -108,7 +108,7 @@ void SwiftLangSupport::getConformingMethodList(
 
         // Name.
         memberElem.DeclNameBegin = SS.size();
-        member->getFullName().print(OS);
+        member->getName().print(OS);
         memberElem.DeclNameLength = SS.size() - memberElem.DeclNameBegin;
 
         // Type name.

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -869,7 +869,7 @@ static void addParameters(const AbstractFunctionDecl *FD,
                           SourceManager &SM,
                           unsigned BufferID) {
   ArrayRef<Identifier> ArgNames;
-  DeclName Name = FD->getFullName();
+  DeclName Name = FD->getName();
   if (Name) {
     ArgNames = Name.getArgumentNames();
   }
@@ -882,7 +882,7 @@ static void addParameters(const SubscriptDecl *D,
                           SourceManager &SM,
                           unsigned BufferID) {
   ArrayRef<Identifier> ArgNames;
-  DeclName Name = D->getFullName();
+  DeclName Name = D->getName();
   if (Name) {
     ArgNames = Name.getArgumentNames();
   }

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -921,7 +921,7 @@ public:
       return true;
 
     if (isa<VarDecl>(D) && D->hasName() &&
-        D->getFullName() == D->getASTContext().Id_self)
+        D->getName() == D->getASTContext().Id_self)
       return true;
 
     // Do not annotate references to unavailable decls.

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -811,7 +811,7 @@ bool SwiftLangSupport::printDisplayName(const swift::ValueDecl *D,
   if (!D->hasName())
     return true;
 
-  OS << D->getFullName();
+  OS << D->getName();
   return false;
 }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -478,7 +478,7 @@ void SwiftLangSupport::printFullyAnnotatedSynthesizedDeclaration(
 template <typename FnTy>
 void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
   llvm::SmallDenseMap<DeclName, unsigned, 16> NamesSeen;
-  ++NamesSeen[VD->getFullName()];
+  ++NamesSeen[VD->getName()];
   SmallVector<LookupResultEntry, 8> RelatedDecls;
 
   if (isa<ParamDecl>(VD))
@@ -499,7 +499,7 @@ void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
       continue;
 
     if (RelatedVD != VD) {
-      ++NamesSeen[RelatedVD->getFullName()];
+      ++NamesSeen[RelatedVD->getName()];
       RelatedDecls.push_back(result);
     }
   }
@@ -509,7 +509,7 @@ void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
   for (auto Related : RelatedDecls) {
     ValueDecl *RelatedVD = Related.getValueDecl();
     bool SameBase = Related.getBaseDecl() && Related.getBaseDecl() == OriginalBase;
-    Fn(RelatedVD, SameBase, NamesSeen[RelatedVD->getFullName()] > 1);
+    Fn(RelatedVD, SameBase, NamesSeen[RelatedVD->getName()] > 1);
   }
 }
 
@@ -1052,7 +1052,7 @@ static DeclName getSwiftDeclName(const ValueDecl *VD,
                                  NameTranslatingInfo &Info) {
   auto &Ctx = VD->getDeclContext()->getASTContext();
   assert(SwiftLangSupport::getNameKindForUID(Info.NameKind) == NameKind::Swift);
-  DeclName OrigName = VD->getFullName();
+  const DeclName OrigName = VD->getName();
   DeclBaseName BaseName = Info.BaseName.empty()
                               ? OrigName.getBaseName()
                               : DeclBaseName(

--- a/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
@@ -91,7 +91,7 @@ void SwiftLangSupport::getExpressionContextInfo(
 
         // Name.
         memberElem.DeclNameBegin = SS.size();
-        member->getFullName().print(OS);
+        member->getName().print(OS);
         memberElem.DeclNameLength = SS.size() - memberElem.DeclNameBegin;
 
         // Description.

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -1071,7 +1071,7 @@ static StringRef getPrintedName(SDKContext &Ctx, ValueDecl *VD) {
     llvm::SmallString<32> Result;
     Result.append(getSimpleName(VD));
     Result.append("(");
-    for (auto Arg : VD->getFullName().getArgumentNames()) {
+    for (auto Arg : VD->getName().getArgumentNames()) {
       Result.append(Arg.empty() ? "_" : Arg.str());
       Result.append(":");
     }

--- a/tools/swift-ast-script/ASTScriptEvaluator.cpp
+++ b/tools/swift-ast-script/ASTScriptEvaluator.cpp
@@ -83,7 +83,7 @@ public:
       out << ".(accessor)";
     } else {
       printDeclContext(out, decl->getDeclContext());
-      out << decl->getFullName();
+      out << decl->getName();
     }
   }
 


### PR DESCRIPTION
Follow-up to #30606

Now that `FuncDecl::getName` and `EnumElementDecl::getName` have been replaced with `ValueDecl::getBaseIdentifier`, we can rename `ValueDecl::getFullName` to `getName()` and thereby address the targeted FIXME.