### PR TITLE
Refactor checkGenericArguments() and related code

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -414,7 +414,7 @@ namespace {
 
       return SubstitutionMap::get(sig,
                                   QueryTypeSubstitutionMap{subs},
-                                  TypeChecker::LookUpConformance(cs.DC));
+                                  LookUpConformanceInModule(cs.DC->getParentModule()));
     }
 
   public:

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -90,8 +90,7 @@ Solution::computeSubstitutions(GenericSignature sig,
 
     // FIXME: Retrieve the conformance from the solution itself.
     return TypeChecker::conformsToProtocol(replacement, protoType,
-                                           getConstraintSystem().DC,
-                                           None);
+                                           getConstraintSystem().DC);
   };
 
   return SubstitutionMap::get(sig,
@@ -447,7 +446,7 @@ namespace {
           // the protocol requirement with Self == the concrete type, and SILGen
           // (or later) can devirtualize as appropriate.
           auto conformance =
-            TypeChecker::conformsToProtocol(baseTy, proto, cs.DC, None);
+            TypeChecker::conformsToProtocol(baseTy, proto, cs.DC);
           if (conformance.isConcrete()) {
             if (auto witness = conformance.getConcrete()->getWitnessDecl(decl)) {
               bool isMemberOperator = witness->getDeclContext()->isTypeContext();
@@ -2082,8 +2081,7 @@ namespace {
       auto bridgedToObjectiveCConformance
         = TypeChecker::conformsToProtocol(valueType,
                                           bridgedProto,
-                                          cs.DC,
-                                          None);
+                                          cs.DC);
 
       FuncDecl *fn = nullptr;
 
@@ -2343,7 +2341,7 @@ namespace {
       ProtocolDecl *protocol = TypeChecker::getProtocol(
           ctx, expr->getLoc(), KnownProtocolKind::ExpressibleByStringLiteral);
 
-      if (!TypeChecker::conformsToProtocol(type, protocol, cs.DC, None)) {
+      if (!TypeChecker::conformsToProtocol(type, protocol, cs.DC)) {
         // If the type does not conform to ExpressibleByStringLiteral, it should
         // be ExpressibleByExtendedGraphemeClusterLiteral.
         protocol = TypeChecker::getProtocol(
@@ -2352,7 +2350,7 @@ namespace {
         isStringLiteral = false;
         isGraphemeClusterLiteral = true;
       }
-      if (!TypeChecker::conformsToProtocol(type, protocol, cs.DC, None)) {
+      if (!TypeChecker::conformsToProtocol(type, protocol, cs.DC)) {
         // ... or it should be ExpressibleByUnicodeScalarLiteral.
         protocol = TypeChecker::getProtocol(
             cs.getASTContext(), expr->getLoc(),
@@ -2467,7 +2465,7 @@ namespace {
         assert(proto && "Missing string interpolation protocol?");
 
         auto conformance =
-          TypeChecker::conformsToProtocol(type, proto, cs.DC, None);
+          TypeChecker::conformsToProtocol(type, proto, cs.DC);
         assert(conformance && "string interpolation type conforms to protocol");
 
         DeclName constrName(ctx, DeclBaseName::createConstructor(), argLabels);
@@ -2573,7 +2571,7 @@ namespace {
       auto proto = TypeChecker::getLiteralProtocol(cs.getASTContext(), expr);
       assert(proto && "Missing object literal protocol?");
       auto conformance =
-        TypeChecker::conformsToProtocol(conformingType, proto, cs.DC, None);
+        TypeChecker::conformsToProtocol(conformingType, proto, cs.DC);
       assert(conformance && "object literal type conforms to protocol");
 
       auto constrName = TypeChecker::getObjectLiteralConstructorName(ctx, expr);
@@ -3278,7 +3276,7 @@ namespace {
       assert(arrayProto && "type-checked array literal w/o protocol?!");
 
       auto conformance =
-        TypeChecker::conformsToProtocol(arrayTy, arrayProto, cs.DC, None);
+        TypeChecker::conformsToProtocol(arrayTy, arrayProto, cs.DC);
       assert(conformance && "Type does not conform to protocol?");
 
       DeclName name(ctx, DeclBaseName::createConstructor(),
@@ -3322,8 +3320,7 @@ namespace {
           KnownProtocolKind::ExpressibleByDictionaryLiteral);
 
       auto conformance =
-        TypeChecker::conformsToProtocol(dictionaryTy, dictionaryProto, cs.DC,
-                                        None);
+        TypeChecker::conformsToProtocol(dictionaryTy, dictionaryProto, cs.DC);
       if (conformance.isInvalid())
         return nullptr;
 
@@ -4062,7 +4059,7 @@ namespace {
           // Special handle for literals conditional checked cast when they can
           // be statically coerced to the cast type.
           if (protocol && TypeChecker::conformsToProtocol(
-                              toType, protocol, cs.DC, None)) {
+                              toType, protocol, cs.DC)) {
             ctx.Diags
                 .diagnose(expr->getLoc(),
                           diag::literal_conditional_downcast_to_coercion,
@@ -4939,7 +4936,7 @@ namespace {
         // verified by the solver, we just need to get it again
         // with all of the generic parameters resolved.
         auto hashableConformance =
-          TypeChecker::conformsToProtocol(indexType, hashable, cs.DC, None);
+          TypeChecker::conformsToProtocol(indexType, hashable, cs.DC);
         assert(hashableConformance);
 
         conformances.push_back(hashableConformance);
@@ -5263,7 +5260,7 @@ collectExistentialConformances(Type fromType, Type toType,
   SmallVector<ProtocolConformanceRef, 4> conformances;
   for (auto proto : layout.getProtocols()) {
     conformances.push_back(TypeChecker::containsProtocol(
-        fromType, proto->getDecl(), DC, None));
+        fromType, proto->getDecl(), DC));
   }
 
   return toType->getASTContext().AllocateCopy(conformances);
@@ -6430,7 +6427,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       auto hashable = ctx.getProtocol(KnownProtocolKind::Hashable);
       auto conformance =
         TypeChecker::conformsToProtocol(
-                        cs.getType(expr), hashable, cs.DC, None);
+                        cs.getType(expr), hashable, cs.DC);
       assert(conformance && "must conform to Hashable");
 
       return cs.cacheType(
@@ -6965,7 +6962,7 @@ Expr *ExprRewriter::convertLiteralInPlace(Expr *literal,
   // initialize via the builtin protocol.
   if (builtinProtocol) {
     auto builtinConformance = TypeChecker::conformsToProtocol(
-        type, builtinProtocol, cs.DC, None);
+        type, builtinProtocol, cs.DC);
     if (builtinConformance) {
       // Find the witness that we'll use to initialize the type via a builtin
       // literal.
@@ -6997,7 +6994,7 @@ Expr *ExprRewriter::convertLiteralInPlace(Expr *literal,
 
   // This literal type must conform to the (non-builtin) protocol.
   assert(protocol && "requirements should have stopped recursion");
-  auto conformance = TypeChecker::conformsToProtocol(type, protocol, cs.DC, None);
+  auto conformance = TypeChecker::conformsToProtocol(type, protocol, cs.DC);
   assert(conformance && "must conform to literal protocol");
 
   // Dig out the literal type and perform a builtin literal conversion to it.
@@ -7134,7 +7131,7 @@ ExprRewriter::buildDynamicCallable(ApplyExpr *apply, SelectedOverload selected,
     auto dictLitProto =
         ctx.getProtocol(KnownProtocolKind::ExpressibleByDictionaryLiteral);
     auto conformance =
-        TypeChecker::conformsToProtocol(argumentType, dictLitProto, cs.DC, None);
+        TypeChecker::conformsToProtocol(argumentType, dictLitProto, cs.DC);
     auto keyType = conformance.getTypeWitnessByName(argumentType, ctx.Id_Key);
     auto valueType =
         conformance.getTypeWitnessByName(argumentType, ctx.Id_Value);
@@ -8406,7 +8403,7 @@ ProtocolConformanceRef Solution::resolveConformance(
     // itself rather than another conforms-to-protocol check.
     Type substConformingType = simplifyType(conformingType);
     return TypeChecker::conformsToProtocol(
-        substConformingType, proto, constraintSystem->DC, None);
+        substConformingType, proto, constraintSystem->DC);
   }
 
   return ProtocolConformanceRef::forInvalid();

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -766,9 +766,7 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) const {
 
         do {
           // If the type conforms to this protocol, we're covered.
-          if (TypeChecker::conformsToProtocol(
-                  testType, protocol, DC,
-                   ConformanceCheckFlags::SkipConditionalRequirements)) {
+          if (DC->getParentModule()->lookupConformance(testType, protocol)) {
             coveredLiteralProtocols.insert(protocol);
             break;
           }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2451,7 +2451,7 @@ bool ContextualFailure::diagnoseThrowsTypeMismatch() const {
           Ctx.getProtocol(KnownProtocolKind::ErrorCodeProtocol)) {
     Type errorCodeType = getFromType();
     auto conformance = TypeChecker::conformsToProtocol(
-        errorCodeType, errorCodeProtocol, getDC(), None);
+        errorCodeType, errorCodeProtocol, getDC());
     if (conformance) {
       Type errorType =
           conformance
@@ -2781,8 +2781,7 @@ bool ContextualFailure::tryProtocolConformanceFixIt(
   // Let's build a list of protocols that the context does not conform to.
   SmallVector<std::string, 8> missingProtoTypeStrings;
   for (auto protocol : layout.getProtocols()) {
-    if (!TypeChecker::conformsToProtocol(fromType, protocol->getDecl(), getDC(),
-                                         None)) {
+    if (!TypeChecker::conformsToProtocol(fromType, protocol->getDecl(), getDC())) {
       missingProtoTypeStrings.push_back(protocol->getString());
     }
   }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -551,7 +551,7 @@ namespace {
       if (otherArgTy && otherArgTy->getAnyNominal()) {
         if (otherArgTy->isEqual(paramTy) &&
             TypeChecker::conformsToProtocol(
-                otherArgTy, literalProto, CS.DC, None)) {
+                otherArgTy, literalProto, CS.DC)) {
           return true;
         }
       } else if (Type defaultType =

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -250,9 +250,7 @@ computeSelfTypeRelationship(DeclContext *dc, ValueDecl *decl1,
 
   // If the model type does not conform to the protocol, the bases are
   // unrelated.
-  auto conformance = TypeChecker::conformsToProtocol(
-                         modelTy, proto, dc,
-                          ConformanceCheckFlags::SkipConditionalRequirements);
+  auto conformance = dc->getParentModule()->lookupConformance(modelTy, proto);
   if (conformance.isInvalid())
     return {SelfTypeRelationship::Unrelated, conformance};
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5179,8 +5179,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
   switch (kind) {
   case ConstraintKind::SelfObjectOfProtocol: {
     auto conformance = TypeChecker::containsProtocol(
-        type, protocol, DC,
-         ConformanceCheckFlags::SkipConditionalRequirements);
+        type, protocol, DC, /*skipConditionalRequirements=*/true);
     if (conformance) {
       return recordConformance(conformance);
     }
@@ -5188,9 +5187,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
   case ConstraintKind::ConformsTo:
   case ConstraintKind::LiteralConformsTo: {
     // Check whether this type conforms to the protocol.
-    auto conformance = TypeChecker::conformsToProtocol(
-        type, protocol, DC,
-         ConformanceCheckFlags::SkipConditionalRequirements);
+    auto conformance = DC->getParentModule()->lookupConformance(
+        type, protocol);
     if (conformance) {
       return recordConformance(conformance);
     }
@@ -6869,9 +6867,8 @@ ConstraintSystem::simplifyValueWitnessConstraint(
   // conformance already?
   auto proto = requirement->getDeclContext()->getSelfProtocolDecl();
   assert(proto && "Value witness constraint for a non-requirement");
-  auto conformance = TypeChecker::conformsToProtocol(
-      baseObjectType, proto, useDC,
-       ConformanceCheckFlags::SkipConditionalRequirements);
+  auto conformance = useDC->getParentModule()->lookupConformance(
+      baseObjectType, proto);
   if (!conformance) {
     // The conformance failed, so mark the member type as a "hole". We cannot
     // do anything further here.

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1726,10 +1726,10 @@ void ConstraintSystem::ArgumentInfoCollector::minimizeLiteralProtocols() {
 
     auto first =
         TypeChecker::conformsToProtocol(candidate.second, candidates[result].first,
-                                        CS.DC, None);
+                                        CS.DC);
     auto second =
         TypeChecker::conformsToProtocol(candidates[result].second, candidate.first,
-                                        CS.DC, None);
+                                        CS.DC);
     if (first.isInvalid() == second.isInvalid())
       return;
 
@@ -1955,7 +1955,7 @@ void ConstraintSystem::sortDesignatedTypes(
         ++nextType;
         break;
       } else if (auto *protoDecl = dyn_cast<ProtocolDecl>(nominalTypes[i])) {
-        if (TypeChecker::conformsToProtocol(argType, protoDecl, DC, None)) {
+        if (TypeChecker::conformsToProtocol(argType, protoDecl, DC)) {
           std::swap(nominalTypes[nextType], nominalTypes[i]);
           ++nextType;
           break;

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1130,10 +1130,8 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
       return false;
 
     auto targetType = target->getDeclaredInterfaceType();
-    auto ref = TypeChecker::conformsToProtocol(
-        targetType, protocol, target,
-        ConformanceCheckFlags::SkipConditionalRequirements);
-
+    auto ref = target->getParentModule()->lookupConformance(
+        targetType, protocol);
     if (ref.isInvalid()) {
       return false;
     }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3595,7 +3595,7 @@ bool constraints::conformsToKnownProtocol(ConstraintSystem &cs, Type type,
                                           KnownProtocolKind protocol) {
   if (auto *proto =
           TypeChecker::getProtocol(cs.getASTContext(), SourceLoc(), protocol))
-    return (bool)TypeChecker::conformsToProtocol(type, proto, cs.DC, None);
+    return (bool)TypeChecker::conformsToProtocol(type, proto, cs.DC);
   return false;
 }
 
@@ -3609,7 +3609,7 @@ Type constraints::isRawRepresentable(ConstraintSystem &cs, Type type) {
   if (!rawReprType)
     return Type();
 
-  auto conformance = TypeChecker::conformsToProtocol(type, rawReprType, DC, None);
+  auto conformance = TypeChecker::conformsToProtocol(type, rawReprType, DC);
   if (conformance.isInvalid())
     return Type();
 

--- a/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
@@ -76,7 +76,7 @@ bool DerivedConformance::canDeriveAdditiveArithmetic(NominalTypeDecl *nominal,
     if (v->getInterfaceType()->hasError())
       return false;
     auto varType = DC->mapTypeIntoContext(v->getValueInterfaceType());
-    return (bool)TypeChecker::conformsToProtocol(varType, proto, DC, None);
+    return (bool)TypeChecker::conformsToProtocol(varType, proto, DC);
   });
 }
 

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -54,7 +54,7 @@ getStoredPropertiesForDifferentiation(NominalTypeDecl *nominal, DeclContext *DC,
     if (vd->getInterfaceType()->hasError())
       continue;
     auto varType = DC->mapTypeIntoContext(vd->getValueInterfaceType());
-    if (!TypeChecker::conformsToProtocol(varType, diffableProto, nominal, None))
+    if (!TypeChecker::conformsToProtocol(varType, diffableProto, nominal))
       continue;
     result.push_back(vd);
   }
@@ -80,7 +80,7 @@ static Type getTangentVectorType(VarDecl *decl, DeclContext *DC) {
   auto &C = decl->getASTContext();
   auto *diffableProto = C.getProtocol(KnownProtocolKind::Differentiable);
   auto varType = DC->mapTypeIntoContext(decl->getValueInterfaceType());
-  auto conf = TypeChecker::conformsToProtocol(varType, diffableProto, DC, None);
+  auto conf = TypeChecker::conformsToProtocol(varType, diffableProto, DC);
   if (!conf)
     return nullptr;
   Type tangentType = conf.getTypeWitnessByName(varType, C.Id_TangentVector);
@@ -96,7 +96,7 @@ static StructDecl *getTangentVectorStructDecl(DeclContext *DC) {
   auto *diffableProto = C.getProtocol(KnownProtocolKind::Differentiable);
   assert(diffableProto && "`Differentiable` protocol not found");
   auto conf = TypeChecker::conformsToProtocol(DC->getSelfTypeInContext(),
-                                              diffableProto, DC, None);
+                                              diffableProto, DC);
   assert(conf && "Nominal must conform to `Differentiable`");
   auto assocType =
       conf.getTypeWitnessByName(DC->getSelfTypeInContext(), C.Id_TangentVector);
@@ -139,13 +139,13 @@ bool DerivedConformance::canDeriveDifferentiable(NominalTypeDecl *nominal,
     //   `X == X.TangentVector`.
     if (nominal->isImplicit() && structDecl == nominal->getDeclContext() &&
         TypeChecker::conformsToProtocol(structDecl->getDeclaredInterfaceType(),
-                                        diffableProto, DC, None))
+                                        diffableProto, DC))
       return structDecl;
     // 3. Equal nominal and conform to `AdditiveArithmetic`.
     if (structDecl == nominal) {
       // Check conformance to `AdditiveArithmetic`.
       if (TypeChecker::conformsToProtocol(nominalTypeInContext, addArithProto,
-                                          DC, None))
+                                          DC))
         return structDecl;
     }
     // Otherwise, candidate is invalid.
@@ -177,8 +177,7 @@ bool DerivedConformance::canDeriveDifferentiable(NominalTypeDecl *nominal,
     if (v->getInterfaceType()->hasError())
       return false;
     auto varType = DC->mapTypeIntoContext(v->getValueInterfaceType());
-    return (bool)TypeChecker::conformsToProtocol(varType, diffableProto, DC,
-                                                 None);
+    return (bool)TypeChecker::conformsToProtocol(varType, diffableProto, DC);
   });
 }
 
@@ -501,7 +500,7 @@ static void checkAndDiagnoseImplicitNoDerivative(ASTContext &Context,
     // Check whether to diagnose stored property.
     auto varType = DC->mapTypeIntoContext(vd->getValueInterfaceType());
     bool conformsToDifferentiable =
-        !TypeChecker::conformsToProtocol(varType, diffableProto, nominal, None)
+        !TypeChecker::conformsToProtocol(varType, diffableProto, nominal)
              .isInvalid();
     // If stored property should not be diagnosed, continue.
     if (conformsToDifferentiable && !vd->isLet())
@@ -609,7 +608,7 @@ deriveDifferentiable_TangentVectorStruct(DerivedConformance &derived) {
 
   auto *addArithProto = C.getProtocol(KnownProtocolKind::AdditiveArithmetic);
   auto nominalConformsToAddArith = TypeChecker::conformsToProtocol(
-      parentDC->getSelfTypeInContext(), addArithProto, parentDC, None);
+      parentDC->getSelfTypeInContext(), addArithProto, parentDC);
 
   // Return `Self` if conditions are met.
   if (!hasNoDerivativeStoredProp && !nominal->getSelfClassDecl() &&

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -55,7 +55,7 @@ storedPropertiesNotConformingToProtocol(DeclContext *DC, StructDecl *theStruct,
       nonconformingProperties.push_back(propertyDecl);
 
     if (!TypeChecker::conformsToProtocol(DC->mapTypeIntoContext(type), protocol,
-                                         DC, None)) {
+                                         DC)) {
       nonconformingProperties.push_back(propertyDecl);
     }
   }
@@ -954,7 +954,7 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
   // We can't form a Hashable conformance if Int isn't Hashable or
   // ExpressibleByIntegerLiteral.
   if (TypeChecker::conformsToProtocol(
-          intType, C.getProtocol(KnownProtocolKind::Hashable), parentDC, None)
+          intType, C.getProtocol(KnownProtocolKind::Hashable), parentDC)
           .isInvalid()) {
     derived.ConformanceDecl->diagnose(diag::broken_int_hashable_conformance);
     return nullptr;
@@ -962,7 +962,7 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
 
   ProtocolDecl *intLiteralProto =
       C.getProtocol(KnownProtocolKind::ExpressibleByIntegerLiteral);
-  if (TypeChecker::conformsToProtocol(intType, intLiteralProto, parentDC, None)
+  if (TypeChecker::conformsToProtocol(intType, intLiteralProto, parentDC)
           .isInvalid()) {
     derived.ConformanceDecl->diagnose(
       diag::broken_int_integer_literal_convertible_conformance);

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -406,7 +406,7 @@ deriveRawRepresentable_init(DerivedConformance &derived) {
                                                  KnownProtocolKind::Equatable);
   assert(equatableProto);
   assert(
-      TypeChecker::conformsToProtocol(rawType, equatableProto, enumDecl, None));
+      TypeChecker::conformsToProtocol(rawType, equatableProto, enumDecl));
   (void)equatableProto;
   (void)rawType;
 
@@ -465,7 +465,7 @@ bool DerivedConformance::canDeriveRawRepresentable(DeclContext *DC,
   if (!equatableProto)
     return false;
 
-  if (TypeChecker::conformsToProtocol(rawType, equatableProto, DC, None)
+  if (TypeChecker::conformsToProtocol(rawType, equatableProto, DC)
           .isInvalid())
     return false;
 

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -188,9 +188,8 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
     auto proto = ctx.getProtocol(kind);
     if (!proto) return nullptr;
 
-    auto conformance = TypeChecker::conformsToProtocol(
-        nominal->getDeclaredInterfaceType(), proto, nominal,
-        ConformanceCheckFlags::SkipConditionalRequirements);
+    auto conformance = nominal->getParentModule()->lookupConformance(
+        nominal->getDeclaredInterfaceType(), proto);
     if (conformance) {
       auto DC = conformance.getConcrete()->getDeclContext();
       // Check whether this nominal type derives conformances to the protocol.
@@ -599,7 +598,7 @@ DerivedConformance::associatedValuesNotConformingToProtocol(DeclContext *DC, Enu
     for (auto param : *PL) {
       auto type = param->getInterfaceType();
       if (TypeChecker::conformsToProtocol(DC->mapTypeIntoContext(type),
-                                          protocol, DC, None)
+                                          protocol, DC)
               .isInvalid()) {
         nonconformingAssociatedValues.push_back(param);
       }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2695,8 +2695,7 @@ TypeEraserHasViableInitRequest::evaluate(Evaluator &evaluator,
           genericSignature->getGenericParams(),
           genericSignature->getRequirements(),
           QuerySubstitutionMap{subMap},
-          TypeChecker::LookUpConformance(dc),
-          None);
+          TypeChecker::LookUpConformance(dc));
 
     if (result != RequirementCheckResult::Success) {
       unviable.push_back(
@@ -4383,20 +4382,14 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
         if (!source)
           return false;
         // Check if target's requirements are satisfied by source.
-        // Cancel diagnostics using `DiagnosticTransaction`.
-        // Diagnostics should not be emitted because this function is used to
-        // check candidates; if no candidates match, a separate diagnostic will
-        // be produced.
-        DiagnosticTransaction transaction(Ctx.Diags);
-        SWIFT_DEFER { transaction.abort(); };
+        // Use invalid 'SourceLoc's to suppress diagnostics.
         return TypeChecker::checkGenericArguments(
-                   derivative, originalName.Loc.getBaseNameLoc(),
-                   originalName.Loc.getBaseNameLoc(), Type(),
+                   derivative, SourceLoc(), SourceLoc(), Type(),
                    source->getGenericParams(), target->getRequirements(),
                    [](SubstitutableType *dependentType) {
                      return Type(dependentType);
                    },
-                   lookupConformance, None) == RequirementCheckResult::Success;
+                   lookupConformance) == RequirementCheckResult::Success;
       };
 
   auto isValidOriginal = [&](AbstractFunctionDecl *originalCandidate) {
@@ -4926,20 +4919,17 @@ void AttributeChecker::visitTransposeAttr(TransposeAttr *attr) {
         if (!source)
           return false;
         // Check if target's requirements are satisfied by source.
-        // Cancel diagnostics using `DiagnosticTransaction`.
+        // Use invalid 'SourceLoc's to suppress diagnostics.
         // Diagnostics should not be emitted because this function is used to
         // check candidates; if no candidates match, a separate diagnostic will
         // be produced.
-        DiagnosticTransaction transaction(Ctx.Diags);
-        SWIFT_DEFER { transaction.abort(); };
         return TypeChecker::checkGenericArguments(
-            transpose, originalName.Loc.getBaseNameLoc(),
-            originalName.Loc.getBaseNameLoc(), Type(),
+            transpose, SourceLoc(), SourceLoc(), Type(),
             source->getGenericParams(), target->getRequirements(),
             [](SubstitutableType *dependentType) {
               return Type(dependentType);
             },
-            lookupConformance, None) == RequirementCheckResult::Success;
+            lookupConformance) == RequirementCheckResult::Success;
       };
 
   auto isValidOriginal = [&](AbstractFunctionDecl *originalCandidate) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1117,8 +1117,7 @@ bool swift::isValidDynamicCallableMethod(FuncDecl *decl, DeclContext *DC,
   if (!hasKeywordArguments) {
     auto arrayLitProto =
       ctx.getProtocol(KnownProtocolKind::ExpressibleByArrayLiteral);
-    return (bool)TypeChecker::conformsToProtocol(argType, arrayLitProto, DC,
-                                                 ConformanceCheckOptions());
+    return (bool)TypeChecker::conformsToProtocol(argType, arrayLitProto, DC);
   }
   // If keyword arguments, check that argument type conforms to
   // `ExpressibleByDictionaryLiteral` and that the `Key` associated type
@@ -1127,13 +1126,11 @@ bool swift::isValidDynamicCallableMethod(FuncDecl *decl, DeclContext *DC,
     ctx.getProtocol(KnownProtocolKind::ExpressibleByStringLiteral);
   auto dictLitProto =
     ctx.getProtocol(KnownProtocolKind::ExpressibleByDictionaryLiteral);
-  auto dictConf = TypeChecker::conformsToProtocol(argType, dictLitProto, DC,
-                                                  ConformanceCheckOptions());
+  auto dictConf = TypeChecker::conformsToProtocol(argType, dictLitProto, DC);
   if (dictConf.isInvalid())
     return false;
   auto keyType = dictConf.getTypeWitnessByName(argType, ctx.Id_Key);
-  return (bool)TypeChecker::conformsToProtocol(keyType, stringLitProtocol, DC,
-                                               ConformanceCheckOptions());
+  return (bool)TypeChecker::conformsToProtocol(keyType, stringLitProtocol, DC);
 }
 
 /// Returns true if the given nominal type has a valid implementation of a
@@ -1226,8 +1223,7 @@ bool swift::isValidStringDynamicMemberLookup(SubscriptDecl *decl,
     ctx.getProtocol(KnownProtocolKind::ExpressibleByStringLiteral);
 
   // If this is `subscript(dynamicMember: String*)`
-  return (bool)TypeChecker::conformsToProtocol(paramType, stringLitProto, DC,
-                                               ConformanceCheckOptions());
+  return (bool)TypeChecker::conformsToProtocol(paramType, stringLitProto, DC);
 }
 
 bool swift::isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl,
@@ -1668,7 +1664,7 @@ void AttributeChecker::checkApplicationMainAttribute(DeclAttribute *attr,
 
   if (!ApplicationDelegateProto ||
       !TypeChecker::conformsToProtocol(CD->getDeclaredType(),
-                                       ApplicationDelegateProto, CD, None)) {
+                                       ApplicationDelegateProto, CD)) {
     diagnose(attr->getLocation(),
              diag::attr_ApplicationMain_not_ApplicationDelegate,
              applicationMainKind);
@@ -2632,7 +2628,7 @@ TypeEraserHasViableInitRequest::evaluate(Evaluator &evaluator,
   }
 
   // The type eraser must conform to the annotated protocol
-  if (!TypeChecker::conformsToProtocol(typeEraser, protocol, dc, None)) {
+  if (!TypeChecker::conformsToProtocol(typeEraser, protocol, dc)) {
     diags.diagnose(attr->getLoc(), diag::type_eraser_does_not_conform,
                    typeEraser, protocolType);
     diags.diagnose(nominalTypeDecl->getLoc(), diag::type_eraser_declared_here);
@@ -3353,7 +3349,7 @@ static ProtocolConformanceRef getDifferentiableConformance(Type type,
   auto *differentiableProto =
       ctx.getProtocol(KnownProtocolKind::Differentiable);
   auto conf =
-      TypeChecker::conformsToProtocol(type, differentiableProto, DC, None);
+      TypeChecker::conformsToProtocol(type, differentiableProto, DC);
   if (!conf)
     return ProtocolConformanceRef();
   // Try to get the `TangentVector` type witness, in case the conformance has

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2687,7 +2687,7 @@ TypeEraserHasViableInitRequest::evaluate(Evaluator &evaluator,
 
           return getSubstitution(type);
         },
-        TypeChecker::LookUpConformance(dc));
+        LookUpConformanceInModule(dc->getParentModule()));
 
     // Use invalid 'SourceLoc's to suppress diagnostics.
     auto result = TypeChecker::checkGenericArguments(
@@ -2695,7 +2695,7 @@ TypeEraserHasViableInitRequest::evaluate(Evaluator &evaluator,
           genericSignature->getGenericParams(),
           genericSignature->getRequirements(),
           QuerySubstitutionMap{subMap},
-          TypeChecker::LookUpConformance(dc));
+          LookUpConformanceInModule(dc->getParentModule()));
 
     if (result != RequirementCheckResult::Success) {
       unviable.push_back(

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4380,14 +4380,8 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
         // requirements are not satisfied.
         if (!source)
           return false;
-        // Check if target's requirements are satisfied by source.
-        // Use invalid 'SourceLoc's to suppress diagnostics.
-        return TypeChecker::checkGenericArguments(
-                   derivative, SourceLoc(), SourceLoc(), Type(),
-                   source->getGenericParams(), target->getRequirements(),
-                   [](SubstitutableType *dependentType) {
-                     return Type(dependentType);
-                   }) == RequirementCheckResult::Success;
+
+        return target->requirementsNotSatisfiedBy(source).empty();
       };
 
   auto isValidOriginal = [&](AbstractFunctionDecl *originalCandidate) {
@@ -4914,17 +4908,8 @@ void AttributeChecker::visitTransposeAttr(TransposeAttr *attr) {
         // requirements are not satisfied.
         if (!source)
           return false;
-        // Check if target's requirements are satisfied by source.
-        // Use invalid 'SourceLoc's to suppress diagnostics.
-        // Diagnostics should not be emitted because this function is used to
-        // check candidates; if no candidates match, a separate diagnostic will
-        // be produced.
-        return TypeChecker::checkGenericArguments(
-            transpose, SourceLoc(), SourceLoc(), Type(),
-            source->getGenericParams(), target->getRequirements(),
-            [](SubstitutableType *dependentType) {
-              return Type(dependentType);
-            }) == RequirementCheckResult::Success;
+
+        return target->requirementsNotSatisfiedBy(source).empty();
       };
 
   auto isValidOriginal = [&](AbstractFunctionDecl *originalCandidate) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2691,11 +2691,10 @@ TypeEraserHasViableInitRequest::evaluate(Evaluator &evaluator,
 
     // Use invalid 'SourceLoc's to suppress diagnostics.
     auto result = TypeChecker::checkGenericArguments(
-          protocol, SourceLoc(), SourceLoc(), typeEraser,
+          dc, SourceLoc(), SourceLoc(), typeEraser,
           genericSignature->getGenericParams(),
           genericSignature->getRequirements(),
-          QuerySubstitutionMap{subMap},
-          LookUpConformanceInModule(dc->getParentModule()));
+          QuerySubstitutionMap{subMap});
 
     if (result != RequirementCheckResult::Success) {
       unviable.push_back(
@@ -4388,8 +4387,7 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
                    source->getGenericParams(), target->getRequirements(),
                    [](SubstitutableType *dependentType) {
                      return Type(dependentType);
-                   },
-                   lookupConformance) == RequirementCheckResult::Success;
+                   }) == RequirementCheckResult::Success;
       };
 
   auto isValidOriginal = [&](AbstractFunctionDecl *originalCandidate) {
@@ -4832,8 +4830,6 @@ doTransposeStaticAndInstanceSelfTypesMatch(AnyFunctionType *transposeType,
 
 void AttributeChecker::visitTransposeAttr(TransposeAttr *attr) {
   auto *transpose = cast<FuncDecl>(D);
-  auto lookupConformance =
-      LookUpConformanceInModule(D->getDeclContext()->getParentModule());
   auto originalName = attr->getOriginalFunctionName();
   auto *transposeInterfaceType =
       transpose->getInterfaceType()->castTo<AnyFunctionType>();
@@ -4928,8 +4924,7 @@ void AttributeChecker::visitTransposeAttr(TransposeAttr *attr) {
             source->getGenericParams(), target->getRequirements(),
             [](SubstitutableType *dependentType) {
               return Type(dependentType);
-            },
-            lookupConformance) == RequirementCheckResult::Success;
+            }) == RequirementCheckResult::Success;
       };
 
   auto isValidOriginal = [&](AbstractFunctionDecl *originalCandidate) {

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2666,8 +2666,8 @@ static bool isIntegerOrFloatingPointType(Type ty, DeclContext *DC,
     Context.getProtocol(KnownProtocolKind::ExpressibleByFloatLiteral);
   if (!integerType || !floatingType) return false;
 
-  return TypeChecker::conformsToProtocol(ty, integerType, DC, None) ||
-         TypeChecker::conformsToProtocol(ty, floatingType, DC, None);
+  return TypeChecker::conformsToProtocol(ty, integerType, DC) ||
+         TypeChecker::conformsToProtocol(ty, floatingType, DC);
 }
 
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3752,7 +3752,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
           auto protocolDecl =
               dyn_cast_or_null<ProtocolDecl>(fromType->getAnyNominal());
           if (protocolDecl &&
-              !conformsToProtocol(toType, protocolDecl, dc, None)) {
+              !conformsToProtocol(toType, protocolDecl, dc)) {
             return failed();
           }
         }
@@ -3846,8 +3846,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
     auto nsErrorTy = Context.getNSErrorType();
 
     if (auto errorTypeProto = Context.getProtocol(KnownProtocolKind::Error)) {
-      if (!conformsToProtocol(toType, errorTypeProto, dc, None)
-               .isInvalid()) {
+      if (!conformsToProtocol(toType, errorTypeProto, dc).isInvalid()) {
         if (nsErrorTy) {
           if (isSubtypeOf(fromType, nsErrorTy, dc)
               // Don't mask "always true" warnings if NSError is cast to
@@ -3857,8 +3856,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
         }
       }
 
-      if (!conformsToProtocol(fromType, errorTypeProto, dc, None)
-              .isInvalid()) {
+      if (!conformsToProtocol(fromType, errorTypeProto, dc).isInvalid()) {
         // Cast of an error-conforming type to NSError or NSObject.
         if ((nsObject && toType->isEqual(nsObject)) ||
              (nsErrorTy && toType->isEqual(nsErrorTy)))

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -959,8 +959,7 @@ swift::computeAutomaticEnumValueKind(EnumDecl *ED) {
   // primitive literal protocols.
   auto conformsToProtocol = [&](KnownProtocolKind protoKind) {
     ProtocolDecl *proto = ED->getASTContext().getProtocol(protoKind);
-    return TypeChecker::conformsToProtocol(rawTy, proto, ED->getDeclContext(),
-                                           None);
+    return TypeChecker::conformsToProtocol(rawTy, proto, ED->getDeclContext());
   };
 
   static auto otherLiteralProtocolKinds = {
@@ -2434,10 +2433,8 @@ EmittedMembersRequest::evaluate(Evaluator &evaluator,
   TypeChecker::addImplicitConstructors(CD);
 
   auto forceConformance = [&](ProtocolDecl *protocol) {
-    auto ref = TypeChecker::conformsToProtocol(
-        CD->getDeclaredInterfaceType(), protocol, CD,
-        ConformanceCheckFlags::SkipConditionalRequirements, SourceLoc());
-
+    auto ref = CD->getParentModule()->lookupConformance(
+        CD->getDeclaredInterfaceType(), protocol);
     if (ref.isInvalid()) {
       return;
     }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -355,11 +355,9 @@ static void checkForEmptyOptionSet(const VarDecl *VD) {
   
   // Make sure this type conforms to OptionSet
   auto *optionSetProto = VD->getASTContext().getProtocol(KnownProtocolKind::OptionSet);
-  bool conformsToOptionSet = (bool)TypeChecker::containsProtocol(
+  bool conformsToOptionSet = (bool)TypeChecker::conformsToProtocol(
                                                   DC->getSelfTypeInContext(),
-                                                  optionSetProto,
-                                                  DC,
-                                                  /*Flags*/None);
+                                                  optionSetProto, DC);
   
   if (!conformsToOptionSet)
     return;
@@ -919,7 +917,7 @@ static Optional<std::string> buildDefaultInitializerString(DeclContext *dc,
 #define CHECK_LITERAL_PROTOCOL(Kind, String)                                   \
   if (auto proto = TypeChecker::getProtocol(                                   \
           type->getASTContext(), SourceLoc(), KnownProtocolKind::Kind)) {      \
-    if (TypeChecker::conformsToProtocol(type, proto, dc, None))                \
+    if (TypeChecker::conformsToProtocol(type, proto, dc))                      \
       return std::string(String);                                              \
   }
     CHECK_LITERAL_PROTOCOL(ExpressibleByArrayLiteral, "[]")
@@ -1040,8 +1038,7 @@ static void diagnoseClassWithoutInitializers(ClassDecl *classDecl) {
     auto *decodableProto = C.getProtocol(KnownProtocolKind::Decodable);
     auto superclassType = superclassDecl->getDeclaredInterfaceType();
     auto ref = TypeChecker::conformsToProtocol(
-        superclassType, decodableProto, superclassDecl,
-        ConformanceCheckOptions(), SourceLoc());
+        superclassType, decodableProto, superclassDecl);
     if (ref) {
       // super conforms to Decodable, so we've failed to inherit init(from:).
       // Let's suggest overriding it here.
@@ -1070,8 +1067,7 @@ static void diagnoseClassWithoutInitializers(ClassDecl *classDecl) {
       // we can produce a slightly different diagnostic to suggest doing so.
       auto *encodableProto = C.getProtocol(KnownProtocolKind::Encodable);
       auto ref = TypeChecker::conformsToProtocol(
-          superclassType, encodableProto, superclassDecl,
-          ConformanceCheckOptions(), SourceLoc());
+          superclassType, encodableProto, superclassDecl);
       if (ref) {
         // We only want to produce this version of the diagnostic if the
         // subclass doesn't directly implement encode(to:).

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -754,13 +754,9 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
     ArrayRef<Requirement> requirements,
     TypeSubstitutionFn substitutions,
     LookupConformanceFn conformances,
-    ConformanceCheckOptions conformanceOptions,
     GenericRequirementsCheckListener *listener,
     SubstOptions options) {
   bool valid = true;
-
-  // We handle any conditional requirements ourselves.
-  conformanceOptions |= ConformanceCheckFlags::SkipConditionalRequirements;
 
   struct RequirementSet {
     ArrayRef<Requirement> Requirements;
@@ -819,14 +815,12 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
       case RequirementKind::Conformance: {
         // Protocol conformance requirements.
         auto proto = secondType->castTo<ProtocolType>();
-        // FIXME: This should track whether this should result in a private
-        // or non-private dependency.
-        // FIXME: Do we really need "used" at this point?
         // FIXME: Poor location information. How much better can we do here?
         // FIXME: This call should support listener to be able to properly
         //        diagnose problems with conformances.
         auto conformance = conformsToProtocol(firstType, proto->getDecl(), dc,
-                                              conformanceOptions, loc);
+                                              ConformanceCheckFlags::SkipConditionalRequirements,
+                                              loc);
 
         if (conformance) {
           // Report the conformance.

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -152,9 +152,8 @@ namespace {
 
       // Dig out the protocol conformance.
       auto *foundProto = cast<ProtocolDecl>(foundDC);
-      auto conformance = TypeChecker::conformsToProtocol(conformingType,
-                                                         foundProto, DC,
-                                                         ConformanceCheckFlags::SkipConditionalRequirements);
+      auto conformance = DC->getParentModule()->lookupConformance(
+          conformingType, foundProto);
       if (conformance.isInvalid()) {
         // If there's no conformance, we have an existential
         // and we found a member from one of the protocols, and
@@ -481,8 +480,7 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
       // member entirely.
       auto *protocol = cast<ProtocolDecl>(assocType->getDeclContext());
 
-      auto conformance = conformsToProtocol(type, protocol, dc,
-                                            ConformanceCheckFlags::SkipConditionalRequirements);
+      auto conformance = dc->getParentModule()->lookupConformance(type, protocol);
       if (!conformance) {
         // FIXME: This is an error path. Should we try to recover?
         continue;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1877,12 +1877,11 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
   // Check that T conforms to all inherited protocols.
   for (auto InheritedProto : Proto->getInheritedProtocols()) {
     auto InheritedConformance =
-      TypeChecker::conformsToProtocol(
-                        T, InheritedProto, DC,
-                        ConformanceCheckFlags::SkipConditionalRequirements,
-                        ComplainLoc);
+      DC->getParentModule()->lookupConformance(T, InheritedProto);
     if (InheritedConformance.isInvalid() ||
         !InheritedConformance.isConcrete()) {
+      diagnoseConformanceFailure(T, InheritedProto, DC, ComplainLoc);
+
       // Recursive call already diagnosed this problem, but tack on a note
       // to establish the relationship.
       if (ComplainLoc.isValid()) {
@@ -3321,7 +3320,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
       // a member that could in turn satisfy *this* requirement.
       auto derivableProto = cast<ProtocolDecl>(derivable->getDeclContext());
       auto conformance =
-          TypeChecker::conformsToProtocol(Adoptee, derivableProto, DC, None);
+          TypeChecker::conformsToProtocol(Adoptee, derivableProto, DC);
       if (conformance.isConcrete()) {
         (void)conformance.getConcrete()->getWitnessDecl(derivable);
       }
@@ -3705,11 +3704,11 @@ CheckTypeWitnessResult swift::checkTypeWitness(DeclContext *dc,
       return superclass;
   }
 
+  auto *module = dc->getParentModule();
+
   // Check protocol conformances.
   for (auto reqProto : genericSig->getConformsTo(depTy)) {
-    if (TypeChecker::conformsToProtocol(
-            contextType, reqProto, dc,
-            ConformanceCheckFlags::SkipConditionalRequirements)
+    if (module->lookupConformance(contextType, reqProto)
             .isInvalid())
       return CheckTypeWitnessResult(reqProto->getDeclaredType());
 
@@ -3719,7 +3718,7 @@ CheckTypeWitnessResult swift::checkTypeWitness(DeclContext *dc,
     if (contextType->isSpecialized()) {
       auto *decl = contextType->getAnyNominal();
       auto subMap = contextType->getContextSubstitutionMap(
-          dc->getParentModule(),
+          module,
           decl,
           decl->getGenericEnvironmentOfContext());
       for (auto replacement : subMap.getReplacementTypes()) {
@@ -3731,7 +3730,7 @@ CheckTypeWitnessResult swift::checkTypeWitness(DeclContext *dc,
 
   if (genericSig->requiresClass(depTy) &&
       !contextType->satisfiesClassConstraint())
-    return CheckTypeWitnessResult(proto->getASTContext().getAnyObjectType());
+    return CheckTypeWitnessResult(module->getASTContext().getAnyObjectType());
 
   // Success!
   return CheckTypeWitnessResult();
@@ -4215,7 +4214,7 @@ void ConformanceChecker::checkConformance(MissingWitnessDiagnosisKind Kind) {
   }
 }
 
-static void diagnoseConformanceFailure(Type T,
+void swift::diagnoseConformanceFailure(Type T,
                                        ProtocolDecl *Proto,
                                        DeclContext *DC,
                                        SourceLoc ComplainLoc) {
@@ -4228,7 +4227,7 @@ static void diagnoseConformanceFailure(Type T,
   // If we're checking conformance of an existential type to a protocol,
   // do a little bit of extra work to produce a better diagnostic.
   if (T->isExistentialType() &&
-      TypeChecker::containsProtocol(T, Proto, DC, None)) {
+      TypeChecker::containsProtocol(T, Proto, DC)) {
 
     if (!T->isObjCExistentialType()) {
       diags.diagnose(ComplainLoc, diag::type_cannot_conform, true,
@@ -4267,8 +4266,7 @@ static void diagnoseConformanceFailure(Type T,
       if (!equatableProto)
         return;
 
-      if (TypeChecker::conformsToProtocol(rawType, equatableProto, enumDecl,
-                                          None)
+      if (TypeChecker::conformsToProtocol(rawType, equatableProto, enumDecl)
               .isInvalid()) {
         SourceLoc loc = enumDecl->getInherited()[0].getSourceRange().Start;
         diags.diagnose(loc, diag::enum_raw_type_not_equatable, rawType);
@@ -4360,7 +4358,7 @@ void ConformanceChecker::emitDelayedDiags() {
 
 ProtocolConformanceRef
 TypeChecker::containsProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
-                              ConformanceCheckOptions options) {
+                              bool skipConditionalRequirements) {
   // Existential types don't need to conform, i.e., they only need to
   // contain the protocol.
   if (T->isExistentialType()) {
@@ -4370,7 +4368,9 @@ TypeChecker::containsProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
     // concretely.
     if (auto superclass = layout.getSuperclass()) {
       auto result =
-          TypeChecker::conformsToProtocol(superclass, Proto, DC, options);
+          (skipConditionalRequirements
+           ? DC->getParentModule()->lookupConformance(superclass, Proto)
+           : TypeChecker::conformsToProtocol(superclass, Proto, DC));
       if (result) {
         return result;
       }
@@ -4394,12 +4394,13 @@ TypeChecker::containsProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
   }
 
   // For non-existential types, this is equivalent to checking conformance.
-  return TypeChecker::conformsToProtocol(T, Proto, DC, options);
+  return (skipConditionalRequirements
+          ? DC->getParentModule()->lookupConformance(T, Proto)
+          : TypeChecker::conformsToProtocol(T, Proto, DC));
 }
 
 ProtocolConformanceRef
 TypeChecker::conformsToProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
-                                ConformanceCheckOptions options,
                                 SourceLoc ComplainLoc) {
   // Look up conformance in the module.
   ModuleDecl *M = DC->getParentModule();
@@ -4410,9 +4411,6 @@ TypeChecker::conformsToProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
     }
     return ProtocolConformanceRef::forInvalid();
   }
-
-  if (options.contains(ConformanceCheckFlags::SkipConditionalRequirements))
-    return lookupResult;
 
   auto condReqs = lookupResult.getConditionalRequirementsIfAvailable();
   assert(condReqs &&
@@ -4452,7 +4450,7 @@ TypeChecker::conformsToProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
 /// requirements are successfully resolved.
 ProtocolConformanceRef
 ModuleDecl::conformsToProtocol(Type sourceTy, ProtocolDecl *targetProtocol) {
-  return TypeChecker::conformsToProtocol(sourceTy, targetProtocol, this, None);
+  return TypeChecker::conformsToProtocol(sourceTy, targetProtocol, this);
 }
 
 void TypeChecker::checkConformance(NormalProtocolConformance *conformance) {
@@ -5729,7 +5727,7 @@ void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {
     auto requirementProto =
       req.getSecondType()->castTo<ProtocolType>()->getDecl();
     auto conformance = conformsToProtocol(defaultAssocTypeInContext,
-                                          requirementProto, proto, None);
+                                          requirementProto, proto);
     if (conformance.isInvalid()) {
       // Diagnose the lack of a conformance. This is potentially an ABI
       // incompatibility.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3957,7 +3957,7 @@ void ConformanceChecker::ensureRequirementsAreSatisfied() {
       proto->getRequirementSignature(),
       QuerySubstitutionMap{substitutions},
       TypeChecker::LookUpConformance(DC),
-      None, &listener);
+      &listener);
 
   switch (result) {
   case RequirementCheckResult::Success:
@@ -4435,7 +4435,7 @@ TypeChecker::conformsToProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
         DC, ComplainLoc, noteLoc, T,
         {lookupResult.getRequirement()->getSelfInterfaceType()}, *condReqs,
         [](SubstitutableType *dependentType) { return Type(dependentType); },
-        LookUpConformance(DC), options);
+        LookUpConformance(DC));
     switch (conditionalCheckResult) {
     case RequirementCheckResult::Success:
       break;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3956,7 +3956,6 @@ void ConformanceChecker::ensureRequirementsAreSatisfied() {
       { proto->getSelfInterfaceType() },
       proto->getRequirementSignature(),
       QuerySubstitutionMap{substitutions},
-      LookUpConformanceInModule(DC->getParentModule()),
       &listener);
 
   switch (result) {
@@ -4434,8 +4433,7 @@ TypeChecker::conformsToProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
     auto conditionalCheckResult = checkGenericArguments(
         DC, ComplainLoc, noteLoc, T,
         {lookupResult.getRequirement()->getSelfInterfaceType()}, *condReqs,
-        [](SubstitutableType *dependentType) { return Type(dependentType); },
-        LookUpConformanceInModule(M));
+        [](SubstitutableType *dependentType) { return Type(dependentType); });
     switch (conditionalCheckResult) {
     case RequirementCheckResult::Success:
       break;

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -955,6 +955,11 @@ llvm::TinyPtrVector<ValueDecl *> findWitnessedObjCRequirements(
                                      const ValueDecl *witness,
                                      bool anySingleRequirement = false);
 
+void diagnoseConformanceFailure(Type T,
+                                ProtocolDecl *Proto,
+                                DeclContext *DC,
+                                SourceLoc ComplainLoc);
+
 }
 
 #endif // SWIFT_SEMA_PROTOCOL_H

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1097,7 +1097,7 @@ bool AssociatedTypeInference::checkCurrentTypeWitnesses(
                                        { proto->getSelfInterfaceType() },
                                        sanitizedRequirements,
                                        QuerySubstitutionMap{substitutions},
-                                       TypeChecker::LookUpConformance(dc),
+                                       LookUpConformanceInModule(dc->getParentModule()),
                                        nullptr, options);
   switch (result) {
   case RequirementCheckResult::Failure:

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1097,7 +1097,6 @@ bool AssociatedTypeInference::checkCurrentTypeWitnesses(
                                        { proto->getSelfInterfaceType() },
                                        sanitizedRequirements,
                                        QuerySubstitutionMap{substitutions},
-                                       LookUpConformanceInModule(dc->getParentModule()),
                                        nullptr, options);
   switch (result) {
   case RequirementCheckResult::Failure:
@@ -1145,7 +1144,6 @@ bool AssociatedTypeInference::checkConstrainedExtension(ExtensionDecl *ext) {
                        ext->getGenericSignature()->getGenericParams(),
                        ext->getGenericSignature()->getRequirements(),
                        QueryTypeSubstitutionMap{subs},
-                       LookUpConformanceInModule(ext->getModuleContext()),
                        nullptr, options)) {
   case RequirementCheckResult::Success:
   case RequirementCheckResult::SubstitutionFailure:

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1098,7 +1098,7 @@ bool AssociatedTypeInference::checkCurrentTypeWitnesses(
                                        sanitizedRequirements,
                                        QuerySubstitutionMap{substitutions},
                                        TypeChecker::LookUpConformance(dc),
-                                       None, nullptr, options);
+                                       nullptr, options);
   switch (result) {
   case RequirementCheckResult::Failure:
     ++NumSolutionStatesFailedCheck;
@@ -1146,7 +1146,6 @@ bool AssociatedTypeInference::checkConstrainedExtension(ExtensionDecl *ext) {
                        ext->getGenericSignature()->getRequirements(),
                        QueryTypeSubstitutionMap{subs},
                        LookUpConformanceInModule(ext->getModuleContext()),
-                       None,
                        nullptr, options)) {
   case RequirementCheckResult::Success:
   case RequirementCheckResult::SubstitutionFailure:

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -949,17 +949,17 @@ Type AssociatedTypeInference::substCurrentTypeWitnesses(Type type) {
 
       SWIFT_DEFER { recursionCheck.erase(assocType); };
 
+      auto *module = dc->getParentModule();
+
       // Try to substitute into the base type.
-      Type result = depMemTy->substBaseType(dc->getParentModule(), baseTy);
+      Type result = depMemTy->substBaseType(module, baseTy);
       if (!result->hasError())
         return result;
 
       // If that failed, check whether it's because of the conformance we're
       // evaluating.
       auto localConformance
-        = TypeChecker::conformsToProtocol(
-                          baseTy, assocType->getProtocol(), dc,
-                          ConformanceCheckFlags::SkipConditionalRequirements);
+        = module->lookupConformance(baseTy, assocType->getProtocol());
       if (localConformance.isInvalid() || localConformance.isAbstract() ||
           (localConformance.getConcrete()->getRootConformance() !=
            conformance)) {

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -956,7 +956,7 @@ static ProtocolConformanceRef checkConformanceToNSCopying(VarDecl *var,
   auto proto = ctx.getNSCopyingDecl();
 
   if (proto) {
-    if (auto result = TypeChecker::conformsToProtocol(type, proto, dc, None))
+    if (auto result = TypeChecker::conformsToProtocol(type, proto, dc))
       return result;
   }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -674,8 +674,7 @@ static Type checkContextualRequirements(Type type,
         dc, loc, noteLoc, type,
         genericSig->getGenericParams(),
         genericSig->getRequirements(),
-        QueryTypeSubstitutionMap{subMap},
-        LookUpConformanceInModule(dc->getParentModule()));
+        QueryTypeSubstitutionMap{subMap});
 
   switch (result) {
   case RequirementCheckResult::Failure:
@@ -914,8 +913,7 @@ Type TypeChecker::applyUnboundGenericArguments(
       checkGenericArguments(dc, loc, noteLoc, unboundType,
                             genericSig->getGenericParams(),
                             genericSig->getRequirements(),
-                            QueryTypeSubstitutionMap{subs},
-                            LookUpConformanceInModule(module));
+                            QueryTypeSubstitutionMap{subs});
 
     switch (result) {
     case RequirementCheckResult::Failure:

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -675,8 +675,7 @@ static Type checkContextualRequirements(Type type,
         genericSig->getGenericParams(),
         genericSig->getRequirements(),
         QueryTypeSubstitutionMap{subMap},
-        TypeChecker::LookUpConformance(dc),
-        None);
+        TypeChecker::LookUpConformance(dc));
 
   switch (result) {
   case RequirementCheckResult::Failure:
@@ -914,7 +913,7 @@ Type TypeChecker::applyUnboundGenericArguments(
                             genericSig->getGenericParams(),
                             genericSig->getRequirements(),
                             QueryTypeSubstitutionMap{subs},
-                            LookUpConformance(dc), None);
+                            LookUpConformance(dc));
 
     switch (result) {
     case RequirementCheckResult::Failure:

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -981,9 +981,8 @@ static void maybeDiagnoseBadConformanceRef(DeclContext *dc,
   // If we weren't given a conformance, go look it up.
   ProtocolConformance *conformance = nullptr;
   if (protocol) {
-    auto conformanceRef = TypeChecker::conformsToProtocol(
-        parentTy, protocol, dc,
-         ConformanceCheckFlags::SkipConditionalRequirements);
+    auto conformanceRef = dc->getParentModule()->lookupConformance(
+        parentTy, protocol);
     if (conformanceRef.isConcrete())
       conformance = conformanceRef.getConcrete();
   }
@@ -3054,7 +3053,7 @@ Type TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
     }
 
     witnessMethodConformance = TypeChecker::conformsToProtocol(
-        selfType, protocolType->getDecl(), DC, ConformanceCheckOptions());
+        selfType, protocolType->getDecl(), DC);
     assert(witnessMethodConformance &&
            "found witness_method without matching conformance");
   }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -929,394 +929,394 @@ ProtocolConformanceRef conformsToProtocol(Type T, ProtocolDecl *Proto,
                                           DeclContext *DC,
                                           SourceLoc ComplainLoc = SourceLoc());
 
-  /// Completely check the given conformance.
-  void checkConformance(NormalProtocolConformance *conformance);
+/// Completely check the given conformance.
+void checkConformance(NormalProtocolConformance *conformance);
 
-  /// Check all of the conformances in the given context.
-  void checkConformancesInContext(DeclContext *dc, IterableDeclContext *idc);
+/// Check all of the conformances in the given context.
+void checkConformancesInContext(DeclContext *dc, IterableDeclContext *idc);
 
-  /// Check that the type of the given property conforms to NSCopying.
-  ProtocolConformanceRef checkConformanceToNSCopying(VarDecl *var);
+/// Check that the type of the given property conforms to NSCopying.
+ProtocolConformanceRef checkConformanceToNSCopying(VarDecl *var);
 
-  /// Derive an implicit declaration to satisfy a requirement of a derived
-  /// protocol conformance.
-  ///
-  /// \param DC           The declaration context where the conformance was
-  ///                     defined, either the type itself or an extension
-  /// \param TypeDecl     The type for which the requirement is being derived.
-  /// \param Requirement  The protocol requirement.
-  ///
-  /// \returns nullptr if the derivation failed, or the derived declaration
-  ///          if it succeeded. If successful, the derived declaration is added
-  ///          to TypeDecl's body.
-  ValueDecl *deriveProtocolRequirement(DeclContext *DC,
-                                       NominalTypeDecl *TypeDecl,
-                                       ValueDecl *Requirement);
+/// Derive an implicit declaration to satisfy a requirement of a derived
+/// protocol conformance.
+///
+/// \param DC           The declaration context where the conformance was
+///                     defined, either the type itself or an extension
+/// \param TypeDecl     The type for which the requirement is being derived.
+/// \param Requirement  The protocol requirement.
+///
+/// \returns nullptr if the derivation failed, or the derived declaration
+///          if it succeeded. If successful, the derived declaration is added
+///          to TypeDecl's body.
+ValueDecl *deriveProtocolRequirement(DeclContext *DC,
+                                     NominalTypeDecl *TypeDecl,
+                                     ValueDecl *Requirement);
 
-  /// Derive an implicit type witness for the given associated type in
-  /// the conformance of the given nominal type to some known
-  /// protocol.
-  Type deriveTypeWitness(DeclContext *DC, NominalTypeDecl *nominal,
-                         AssociatedTypeDecl *assocType);
+/// Derive an implicit type witness for the given associated type in
+/// the conformance of the given nominal type to some known
+/// protocol.
+Type deriveTypeWitness(DeclContext *DC, NominalTypeDecl *nominal,
+                       AssociatedTypeDecl *assocType);
 
-  /// \name Name lookup
-  ///
-  /// Routines that perform name lookup.
-  ///
-  /// @{
+/// \name Name lookup
+///
+/// Routines that perform name lookup.
+///
+/// @{
 
-  /// Perform unqualified name lookup at the given source location
-  /// within a particular declaration context.
-  ///
-  /// \param dc The declaration context in which to perform name lookup.
-  /// \param name The name of the entity to look for.
-  /// \param loc The source location at which name lookup occurs.
-  /// \param options Options that control name lookup.
-  LookupResult lookupUnqualified(
-      DeclContext *dc, DeclNameRef name, SourceLoc loc,
-      NameLookupOptions options = defaultUnqualifiedLookupOptions);
+/// Perform unqualified name lookup at the given source location
+/// within a particular declaration context.
+///
+/// \param dc The declaration context in which to perform name lookup.
+/// \param name The name of the entity to look for.
+/// \param loc The source location at which name lookup occurs.
+/// \param options Options that control name lookup.
+LookupResult lookupUnqualified(
+    DeclContext *dc, DeclNameRef name, SourceLoc loc,
+    NameLookupOptions options = defaultUnqualifiedLookupOptions);
 
-  /// Perform unqualified type lookup at the given source location
-  /// within a particular declaration context.
-  ///
-  /// \param dc The declaration context in which to perform name lookup.
-  /// \param name The name of the entity to look for.
-  /// \param loc The source location at which name lookup occurs.
-  /// \param options Options that control name lookup.
-  LookupResult lookupUnqualifiedType(
-      DeclContext *dc, DeclNameRef name, SourceLoc loc,
-      NameLookupOptions options = defaultUnqualifiedLookupOptions);
+/// Perform unqualified type lookup at the given source location
+/// within a particular declaration context.
+///
+/// \param dc The declaration context in which to perform name lookup.
+/// \param name The name of the entity to look for.
+/// \param loc The source location at which name lookup occurs.
+/// \param options Options that control name lookup.
+LookupResult lookupUnqualifiedType(
+    DeclContext *dc, DeclNameRef name, SourceLoc loc,
+    NameLookupOptions options = defaultUnqualifiedLookupOptions);
 
-  /// Lookup a member in the given type.
-  ///
-  /// \param dc The context that needs the member.
-  /// \param type The type in which we will look for a member.
-  /// \param name The name of the member to look for.
-  /// \param options Options that control name lookup.
-  ///
-  /// \returns The result of name lookup.
-  LookupResult
-  lookupMember(DeclContext *dc, Type type, DeclNameRef name,
-               NameLookupOptions options = defaultMemberLookupOptions);
+/// Lookup a member in the given type.
+///
+/// \param dc The context that needs the member.
+/// \param type The type in which we will look for a member.
+/// \param name The name of the member to look for.
+/// \param options Options that control name lookup.
+///
+/// \returns The result of name lookup.
+LookupResult
+lookupMember(DeclContext *dc, Type type, DeclNameRef name,
+             NameLookupOptions options = defaultMemberLookupOptions);
 
-  /// Look up a member type within the given type.
-  ///
-  /// This routine looks for member types with the given name within the
-  /// given type.
-  ///
-  /// \param dc The context that needs the member.
-  /// \param type The type in which we will look for a member type.
-  /// \param name The name of the member to look for.
-  /// \param options Options that control name lookup.
-  ///
-  /// \returns The result of name lookup.
-  LookupTypeResult
-  lookupMemberType(DeclContext *dc, Type type, DeclNameRef name,
-                   NameLookupOptions options = defaultMemberTypeLookupOptions);
+/// Look up a member type within the given type.
+///
+/// This routine looks for member types with the given name within the
+/// given type.
+///
+/// \param dc The context that needs the member.
+/// \param type The type in which we will look for a member type.
+/// \param name The name of the member to look for.
+/// \param options Options that control name lookup.
+///
+/// \returns The result of name lookup.
+LookupTypeResult
+lookupMemberType(DeclContext *dc, Type type, DeclNameRef name,
+                 NameLookupOptions options = defaultMemberTypeLookupOptions);
 
-  /// Look up the constructors of the given type.
-  ///
-  /// \param dc The context that needs the constructor.
-  /// \param type The type for which we will look for constructors.
-  /// \param options Options that control name lookup.
-  ///
-  /// \returns the constructors found for this type.
-  LookupResult lookupConstructors(
-      DeclContext *dc, Type type,
-      NameLookupOptions options = defaultConstructorLookupOptions);
+/// Look up the constructors of the given type.
+///
+/// \param dc The context that needs the constructor.
+/// \param type The type for which we will look for constructors.
+/// \param options Options that control name lookup.
+///
+/// \returns the constructors found for this type.
+LookupResult lookupConstructors(
+    DeclContext *dc, Type type,
+    NameLookupOptions options = defaultConstructorLookupOptions);
 
-  /// Given an expression that's known to be an infix operator,
-  /// look up its precedence group.
-  PrecedenceGroupDecl *lookupPrecedenceGroupForInfixOperator(DeclContext *dc,
-                                                             Expr *op);
+/// Given an expression that's known to be an infix operator,
+/// look up its precedence group.
+PrecedenceGroupDecl *lookupPrecedenceGroupForInfixOperator(DeclContext *dc,
+                                                           Expr *op);
 
-  PrecedenceGroupDecl *lookupPrecedenceGroup(DeclContext *dc, Identifier name,
-                                             SourceLoc nameLoc);
+PrecedenceGroupDecl *lookupPrecedenceGroup(DeclContext *dc, Identifier name,
+                                           SourceLoc nameLoc);
 
-  /// Check whether the given declaration can be written as a
-  /// member of the given base type.
-  bool isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl);
+/// Check whether the given declaration can be written as a
+/// member of the given base type.
+bool isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl);
 
-  /// @}
+/// @}
 
-  /// \name Overload resolution
-  ///
-  /// Routines that perform overload resolution or provide diagnostics related
-  /// to overload resolution.
-  /// @{
+/// \name Overload resolution
+///
+/// Routines that perform overload resolution or provide diagnostics related
+/// to overload resolution.
+/// @{
 
-  /// Compare two declarations to determine whether one is more specialized
-  /// than the other.
-  ///
-  /// A declaration is more specialized than another declaration if its type
-  /// is a subtype of the other declaration's type (ignoring the 'self'
-  /// parameter of function declarations) and if
-  Comparison compareDeclarations(DeclContext *dc, ValueDecl *decl1,
-                                 ValueDecl *decl2);
+/// Compare two declarations to determine whether one is more specialized
+/// than the other.
+///
+/// A declaration is more specialized than another declaration if its type
+/// is a subtype of the other declaration's type (ignoring the 'self'
+/// parameter of function declarations) and if
+Comparison compareDeclarations(DeclContext *dc, ValueDecl *decl1,
+                               ValueDecl *decl2);
 
-  /// Build a type-checked reference to the given value.
-  Expr *buildCheckedRefExpr(VarDecl *D, DeclContext *UseDC, DeclNameLoc nameLoc,
-                            bool Implicit);
+/// Build a type-checked reference to the given value.
+Expr *buildCheckedRefExpr(VarDecl *D, DeclContext *UseDC, DeclNameLoc nameLoc,
+                          bool Implicit);
 
-  /// Build a reference to a declaration, where name lookup returned
-  /// the given set of declarations.
-  Expr *buildRefExpr(ArrayRef<ValueDecl *> Decls, DeclContext *UseDC,
-                     DeclNameLoc NameLoc, bool Implicit,
-                     FunctionRefKind functionRefKind);
-  /// @}
+/// Build a reference to a declaration, where name lookup returned
+/// the given set of declarations.
+Expr *buildRefExpr(ArrayRef<ValueDecl *> Decls, DeclContext *UseDC,
+                   DeclNameLoc NameLoc, bool Implicit,
+                   FunctionRefKind functionRefKind);
+/// @}
 
-  /// Retrieve a specific, known protocol.
-  ///
-  /// \param loc The location at which we need to look for the protocol.
-  /// \param kind The known protocol we're looking for.
-  ///
-  /// \returns null if the protocol is not available. This represents a
-  /// problem with the Standard Library.
-  ProtocolDecl *getProtocol(ASTContext &ctx, SourceLoc loc,
-                            KnownProtocolKind kind);
+/// Retrieve a specific, known protocol.
+///
+/// \param loc The location at which we need to look for the protocol.
+/// \param kind The known protocol we're looking for.
+///
+/// \returns null if the protocol is not available. This represents a
+/// problem with the Standard Library.
+ProtocolDecl *getProtocol(ASTContext &ctx, SourceLoc loc,
+                          KnownProtocolKind kind);
 
-  /// Retrieve the literal protocol for the given expression.
-  ///
-  /// \returns the literal protocol, if known and available, or null if the
-  /// expression does not have an associated literal protocol.
-  ProtocolDecl *getLiteralProtocol(ASTContext &ctx, Expr *expr);
+/// Retrieve the literal protocol for the given expression.
+///
+/// \returns the literal protocol, if known and available, or null if the
+/// expression does not have an associated literal protocol.
+ProtocolDecl *getLiteralProtocol(ASTContext &ctx, Expr *expr);
 
-  DeclName getObjectLiteralConstructorName(ASTContext &ctx,
-                                           ObjectLiteralExpr *expr);
+DeclName getObjectLiteralConstructorName(ASTContext &ctx,
+                                         ObjectLiteralExpr *expr);
 
-  Type getObjectLiteralParameterType(ObjectLiteralExpr *expr,
-                                     ConstructorDecl *ctor);
+Type getObjectLiteralParameterType(ObjectLiteralExpr *expr,
+                                   ConstructorDecl *ctor);
 
-  /// Get the module appropriate for looking up standard library types.
-  ///
-  /// This is "Swift", if that module is imported, or the current module if
-  /// we're parsing the standard library.
-  ModuleDecl *getStdlibModule(const DeclContext *dc);
+/// Get the module appropriate for looking up standard library types.
+///
+/// This is "Swift", if that module is imported, or the current module if
+/// we're parsing the standard library.
+ModuleDecl *getStdlibModule(const DeclContext *dc);
 
-  /// \name Resilience diagnostics
-  bool diagnoseInlinableDeclRef(SourceLoc loc, ConcreteDeclRef declRef,
-                                const DeclContext *DC, FragileFunctionKind Kind);
+/// \name Resilience diagnostics
+bool diagnoseInlinableDeclRef(SourceLoc loc, ConcreteDeclRef declRef,
+                              const DeclContext *DC, FragileFunctionKind Kind);
 
-  Expr *buildDefaultInitializer(Type type);
+Expr *buildDefaultInitializer(Type type);
 
-  bool diagnoseInlinableDeclRefAccess(SourceLoc loc, const ValueDecl *D,
-                                      const DeclContext *DC,
-                                      FragileFunctionKind Kind);
-
-  /// Given that a declaration is used from a particular context which
-  /// exposes it in the interface of the current module, diagnose if it cannot
-  /// reasonably be shared.
-  bool diagnoseDeclRefExportability(SourceLoc loc, ConcreteDeclRef declRef,
+bool diagnoseInlinableDeclRefAccess(SourceLoc loc, const ValueDecl *D,
                                     const DeclContext *DC,
-                                    FragileFunctionKind fragileKind);
+                                    FragileFunctionKind Kind);
 
-  /// Given that a type is used from a particular context which
-  /// exposes it in the interface of the current module, diagnose if its
-  /// generic arguments require the use of conformances that cannot reasonably
-  /// be shared.
-  ///
-  /// This method \e only checks how generic arguments are used; it is assumed
-  /// that the declarations involved have already been checked elsewhere.
-  void diagnoseGenericTypeExportability(SourceLoc loc, Type type,
-                                        const DeclContext *DC);
+/// Given that a declaration is used from a particular context which
+/// exposes it in the interface of the current module, diagnose if it cannot
+/// reasonably be shared.
+bool diagnoseDeclRefExportability(SourceLoc loc, ConcreteDeclRef declRef,
+                                  const DeclContext *DC,
+                                  FragileFunctionKind fragileKind);
 
-  /// \name Availability checking
-  ///
-  /// Routines that perform API availability checking and type checking of
-  /// potentially unavailable API elements
-  /// @{
+/// Given that a type is used from a particular context which
+/// exposes it in the interface of the current module, diagnose if its
+/// generic arguments require the use of conformances that cannot reasonably
+/// be shared.
+///
+/// This method \e only checks how generic arguments are used; it is assumed
+/// that the declarations involved have already been checked elsewhere.
+void diagnoseGenericTypeExportability(SourceLoc loc, Type type,
+                                      const DeclContext *DC);
 
-  /// Returns true if the availability of the witness
-  /// is sufficient to safely conform to the requirement in the context
-  /// the provided conformance. On return, requiredAvailability holds th
-  /// availability levels required for conformance.
-  bool
-  isAvailabilitySafeForConformance(ProtocolDecl *proto, ValueDecl *requirement,
-                                   ValueDecl *witness, DeclContext *dc,
-                                   AvailabilityContext &requiredAvailability);
+/// \name Availability checking
+///
+/// Routines that perform API availability checking and type checking of
+/// potentially unavailable API elements
+/// @{
 
-  /// Returns an over-approximation of the range of operating system versions
-  /// that could the passed-in location could be executing upon for
-  /// the target platform. If MostRefined != nullptr, set to the most-refined
-  /// TRC found while approximating.
-  AvailabilityContext overApproximateAvailabilityAtLocation(
-      SourceLoc loc, const DeclContext *DC,
-      const TypeRefinementContext **MostRefined = nullptr);
+/// Returns true if the availability of the witness
+/// is sufficient to safely conform to the requirement in the context
+/// the provided conformance. On return, requiredAvailability holds th
+/// availability levels required for conformance.
+bool
+isAvailabilitySafeForConformance(ProtocolDecl *proto, ValueDecl *requirement,
+                                 ValueDecl *witness, DeclContext *dc,
+                                 AvailabilityContext &requiredAvailability);
 
-  /// Walk the AST to build the hierarchy of TypeRefinementContexts
-  void buildTypeRefinementContextHierarchy(SourceFile &SF);
+/// Returns an over-approximation of the range of operating system versions
+/// that could the passed-in location could be executing upon for
+/// the target platform. If MostRefined != nullptr, set to the most-refined
+/// TRC found while approximating.
+AvailabilityContext overApproximateAvailabilityAtLocation(
+    SourceLoc loc, const DeclContext *DC,
+    const TypeRefinementContext **MostRefined = nullptr);
 
-  /// Build the hierarchy of TypeRefinementContexts for the entire
-  /// source file, if it has not already been built. Returns the root
-  /// TypeRefinementContext for the source file.
-  TypeRefinementContext *getOrBuildTypeRefinementContext(SourceFile *SF);
+/// Walk the AST to build the hierarchy of TypeRefinementContexts
+void buildTypeRefinementContextHierarchy(SourceFile &SF);
 
-  /// Returns a diagnostic indicating why the declaration cannot be annotated
-  /// with an @available() attribute indicating it is potentially unavailable
-  /// or None if this is allowed.
-  Optional<Diag<>>
-  diagnosticIfDeclCannotBePotentiallyUnavailable(const Decl *D);
+/// Build the hierarchy of TypeRefinementContexts for the entire
+/// source file, if it has not already been built. Returns the root
+/// TypeRefinementContext for the source file.
+TypeRefinementContext *getOrBuildTypeRefinementContext(SourceFile *SF);
 
-  /// Checks whether a declaration is available when referred to at the given
-  /// location (this reference location must be in the passed-in
-  /// reference DeclContext).
-  /// If the declaration is available, return true.
-  /// If the declaration is not available, return false and write the
-  /// declaration's availability info to the out parameter
-  /// \p OutAvailableRange.
-  bool isDeclAvailable(const Decl *D, SourceLoc referenceLoc,
-                       const DeclContext *referenceDC,
-                       AvailabilityContext &OutAvailableRange);
+/// Returns a diagnostic indicating why the declaration cannot be annotated
+/// with an @available() attribute indicating it is potentially unavailable
+/// or None if this is allowed.
+Optional<Diag<>>
+diagnosticIfDeclCannotBePotentiallyUnavailable(const Decl *D);
 
-  /// Checks whether a declaration should be considered unavailable when
-  /// referred to at the given location and, if so, returns the reason why the
-  /// declaration is unavailable. Returns None is the declaration is
-  /// definitely available.
-  Optional<UnavailabilityReason>
-  checkDeclarationAvailability(const Decl *D, SourceLoc referenceLoc,
-                               const DeclContext *referenceDC);
+/// Checks whether a declaration is available when referred to at the given
+/// location (this reference location must be in the passed-in
+/// reference DeclContext).
+/// If the declaration is available, return true.
+/// If the declaration is not available, return false and write the
+/// declaration's availability info to the out parameter
+/// \p OutAvailableRange.
+bool isDeclAvailable(const Decl *D, SourceLoc referenceLoc,
+                     const DeclContext *referenceDC,
+                     AvailabilityContext &OutAvailableRange);
 
-  /// Checks an "ignored" expression to see if it's okay for it to be ignored.
-  ///
-  /// An ignored expression is one that is not nested within a larger
-  /// expression or statement.
-  void checkIgnoredExpr(Expr *E);
+/// Checks whether a declaration should be considered unavailable when
+/// referred to at the given location and, if so, returns the reason why the
+/// declaration is unavailable. Returns None is the declaration is
+/// definitely available.
+Optional<UnavailabilityReason>
+checkDeclarationAvailability(const Decl *D, SourceLoc referenceLoc,
+                             const DeclContext *referenceDC);
 
-  // Emits a diagnostic, if necessary, for a reference to a declaration
-  // that is potentially unavailable at the given source location.
-  void diagnosePotentialUnavailability(const ValueDecl *D,
-                                       SourceRange ReferenceRange,
-                                       const DeclContext *ReferenceDC,
-                                       const UnavailabilityReason &Reason);
+/// Checks an "ignored" expression to see if it's okay for it to be ignored.
+///
+/// An ignored expression is one that is not nested within a larger
+/// expression or statement.
+void checkIgnoredExpr(Expr *E);
 
-  // Emits a diagnostic, if necessary, for a reference to a declaration
-  // that is potentially unavailable at the given source location, using
-  // Name as the diagnostic name.
-  void diagnosePotentialUnavailability(const Decl *D, DeclName Name,
-                                       SourceRange ReferenceRange,
-                                       const DeclContext *ReferenceDC,
-                                       const UnavailabilityReason &Reason);
+// Emits a diagnostic, if necessary, for a reference to a declaration
+// that is potentially unavailable at the given source location.
+void diagnosePotentialUnavailability(const ValueDecl *D,
+                                     SourceRange ReferenceRange,
+                                     const DeclContext *ReferenceDC,
+                                     const UnavailabilityReason &Reason);
 
-  void
-  diagnosePotentialOpaqueTypeUnavailability(SourceRange ReferenceRange,
-                                            const DeclContext *ReferenceDC,
-                                            const UnavailabilityReason &Reason);
+// Emits a diagnostic, if necessary, for a reference to a declaration
+// that is potentially unavailable at the given source location, using
+// Name as the diagnostic name.
+void diagnosePotentialUnavailability(const Decl *D, DeclName Name,
+                                     SourceRange ReferenceRange,
+                                     const DeclContext *ReferenceDC,
+                                     const UnavailabilityReason &Reason);
 
-  /// Emits a diagnostic for a reference to a storage accessor that is
-  /// potentially unavailable.
-  void diagnosePotentialAccessorUnavailability(
-      const AccessorDecl *Accessor, SourceRange ReferenceRange,
-      const DeclContext *ReferenceDC, const UnavailabilityReason &Reason,
-      bool ForInout);
+void
+diagnosePotentialOpaqueTypeUnavailability(SourceRange ReferenceRange,
+                                          const DeclContext *ReferenceDC,
+                                          const UnavailabilityReason &Reason);
 
-  /// Returns the availability attribute indicating deprecation if the
-  /// declaration is deprecated or null otherwise.
-  const AvailableAttr *getDeprecated(const Decl *D);
+/// Emits a diagnostic for a reference to a storage accessor that is
+/// potentially unavailable.
+void diagnosePotentialAccessorUnavailability(
+    const AccessorDecl *Accessor, SourceRange ReferenceRange,
+    const DeclContext *ReferenceDC, const UnavailabilityReason &Reason,
+    bool ForInout);
 
-  /// Emits a diagnostic for a reference to a declaration that is deprecated.
-  /// Callers can provide a lambda that adds additional information (such as a
-  /// fixit hint) to the deprecation diagnostic, if it is emitted.
-  void diagnoseIfDeprecated(SourceRange SourceRange,
-                            const DeclContext *ReferenceDC,
-                            const ValueDecl *DeprecatedDecl,
-                            const ApplyExpr *Call);
-  /// @}
+/// Returns the availability attribute indicating deprecation if the
+/// declaration is deprecated or null otherwise.
+const AvailableAttr *getDeprecated(const Decl *D);
 
-  /// If LangOptions::DebugForbidTypecheckPrefix is set and the given decl
-  /// name starts with that prefix, an llvm fatal_error is triggered.
-  /// This is for testing purposes.
-  void checkForForbiddenPrefix(ASTContext &C, DeclBaseName Name);
+/// Emits a diagnostic for a reference to a declaration that is deprecated.
+/// Callers can provide a lambda that adds additional information (such as a
+/// fixit hint) to the deprecation diagnostic, if it is emitted.
+void diagnoseIfDeprecated(SourceRange SourceRange,
+                          const DeclContext *ReferenceDC,
+                          const ValueDecl *DeprecatedDecl,
+                          const ApplyExpr *Call);
+/// @}
 
-  /// Check error handling in the given type-checked top-level code.
-  void checkTopLevelErrorHandling(TopLevelCodeDecl *D);
-  void checkFunctionErrorHandling(AbstractFunctionDecl *D);
-  void checkInitializerErrorHandling(Initializer *I, Expr *E);
-  void checkEnumElementErrorHandling(EnumElementDecl *D, Expr *expr);
-  void checkPropertyWrapperErrorHandling(PatternBindingDecl *binding,
-                                         Expr *expr);
+/// If LangOptions::DebugForbidTypecheckPrefix is set and the given decl
+/// name starts with that prefix, an llvm fatal_error is triggered.
+/// This is for testing purposes.
+void checkForForbiddenPrefix(ASTContext &C, DeclBaseName Name);
 
-  /// If an expression references 'self.init' or 'super.init' in an
-  /// initializer context, returns the implicit 'self' decl of the constructor.
-  /// Otherwise, return nil.
-  VarDecl *getSelfForInitDelegationInConstructor(DeclContext *DC,
-                                                 UnresolvedDotExpr *UDE);
+/// Check error handling in the given type-checked top-level code.
+void checkTopLevelErrorHandling(TopLevelCodeDecl *D);
+void checkFunctionErrorHandling(AbstractFunctionDecl *D);
+void checkInitializerErrorHandling(Initializer *I, Expr *E);
+void checkEnumElementErrorHandling(EnumElementDecl *D, Expr *expr);
+void checkPropertyWrapperErrorHandling(PatternBindingDecl *binding,
+                                       Expr *expr);
 
-  /// Diagnose assigning variable to itself.
-  bool diagnoseSelfAssignment(const Expr *E);
+/// If an expression references 'self.init' or 'super.init' in an
+/// initializer context, returns the implicit 'self' decl of the constructor.
+/// Otherwise, return nil.
+VarDecl *getSelfForInitDelegationInConstructor(DeclContext *DC,
+                                               UnresolvedDotExpr *UDE);
 
-  /// Builds a string representing a "default" generic argument list for
-  /// \p typeDecl. In general, this means taking the bound of each generic
-  /// parameter. The \p getPreferredType callback can be used to provide a
-  /// different type from the bound.
-  ///
-  /// It may not always be possible to find a single appropriate type for a
-  /// particular parameter (say, if it has two bounds). In this case, an
-  /// Xcode-style placeholder will be used instead.
-  ///
-  /// Returns true if the arguments list could be constructed, false if for
-  /// some reason it could not.
-  bool getDefaultGenericArgumentsString(
-      SmallVectorImpl<char> &buf, const GenericTypeDecl *typeDecl,
-      llvm::function_ref<Type(const GenericTypeParamDecl *)> getPreferredType =
-          [](const GenericTypeParamDecl *) { return Type(); });
+/// Diagnose assigning variable to itself.
+bool diagnoseSelfAssignment(const Expr *E);
 
-  /// Attempt to omit needless words from the name of the given declaration.
-  Optional<DeclName> omitNeedlessWords(AbstractFunctionDecl *afd);
+/// Builds a string representing a "default" generic argument list for
+/// \p typeDecl. In general, this means taking the bound of each generic
+/// parameter. The \p getPreferredType callback can be used to provide a
+/// different type from the bound.
+///
+/// It may not always be possible to find a single appropriate type for a
+/// particular parameter (say, if it has two bounds). In this case, an
+/// Xcode-style placeholder will be used instead.
+///
+/// Returns true if the arguments list could be constructed, false if for
+/// some reason it could not.
+bool getDefaultGenericArgumentsString(
+    SmallVectorImpl<char> &buf, const GenericTypeDecl *typeDecl,
+    llvm::function_ref<Type(const GenericTypeParamDecl *)> getPreferredType =
+        [](const GenericTypeParamDecl *) { return Type(); });
 
-  /// Attempt to omit needless words from the name of the given declaration.
-  Optional<Identifier> omitNeedlessWords(VarDecl *var);
+/// Attempt to omit needless words from the name of the given declaration.
+Optional<DeclName> omitNeedlessWords(AbstractFunctionDecl *afd);
 
-  /// Calculate edit distance between declaration names.
-  unsigned getCallEditDistance(DeclNameRef writtenName, DeclName correctedName,
-                               unsigned maxEditDistance);
+/// Attempt to omit needless words from the name of the given declaration.
+Optional<Identifier> omitNeedlessWords(VarDecl *var);
 
-  enum : unsigned {
-    /// Never consider a candidate that's this distance away or worse.
-    UnreasonableCallEditDistance = 8,
+/// Calculate edit distance between declaration names.
+unsigned getCallEditDistance(DeclNameRef writtenName, DeclName correctedName,
+                             unsigned maxEditDistance);
 
-    /// Don't consider candidates that score worse than the given distance
-    /// from the best candidate.
-    MaxCallEditDistanceFromBestCandidate = 1
-  };
+enum : unsigned {
+  /// Never consider a candidate that's this distance away or worse.
+  UnreasonableCallEditDistance = 8,
 
-  /// Check for a typo correction.
-  void performTypoCorrection(DeclContext *DC, DeclRefKind refKind,
-                             Type baseTypeOrNull,
-                             NameLookupOptions lookupOptions,
-                             TypoCorrectionResults &corrections,
-                             GenericSignatureBuilder *gsb = nullptr,
-                             unsigned maxResults = 4);
+  /// Don't consider candidates that score worse than the given distance
+  /// from the best candidate.
+  MaxCallEditDistanceFromBestCandidate = 1
+};
 
-  /// Check if the given decl has a @_semantics attribute that gives it
-  /// special case type-checking behavior.
-  DeclTypeCheckingSemantics getDeclTypeCheckingSemantics(ValueDecl *decl);
+/// Check for a typo correction.
+void performTypoCorrection(DeclContext *DC, DeclRefKind refKind,
+                           Type baseTypeOrNull,
+                           NameLookupOptions lookupOptions,
+                           TypoCorrectionResults &corrections,
+                           GenericSignatureBuilder *gsb = nullptr,
+                           unsigned maxResults = 4);
 
-  /// Infers the differentiability parameter indices for the given
-  /// original or derivative `AbstractFunctionDecl`.
-  ///
-  /// The differentiability parameters are inferred to be:
-  /// - All parameters of the function that conform to `Differentiable`.
-  /// - If the function result type is a function type (i.e. the function has
-  ///   a curried method type), then also all parameters of the function result
-  ///   type that conform to `Differentiable`.
-  ///
-  /// Used by `@differentiable` and `@derivative` attribute type-checking.
-  IndexSubset *
-  inferDifferentiabilityParameters(AbstractFunctionDecl *AFD,
-                                   GenericEnvironment *derivativeGenEnv);
+/// Check if the given decl has a @_semantics attribute that gives it
+/// special case type-checking behavior.
+DeclTypeCheckingSemantics getDeclTypeCheckingSemantics(ValueDecl *decl);
 
-  /// Require that the library intrinsics for working with Optional<T>
-  /// exist.
-  bool requireOptionalIntrinsics(ASTContext &ctx, SourceLoc loc);
+/// Infers the differentiability parameter indices for the given
+/// original or derivative `AbstractFunctionDecl`.
+///
+/// The differentiability parameters are inferred to be:
+/// - All parameters of the function that conform to `Differentiable`.
+/// - If the function result type is a function type (i.e. the function has
+///   a curried method type), then also all parameters of the function result
+///   type that conform to `Differentiable`.
+///
+/// Used by `@differentiable` and `@derivative` attribute type-checking.
+IndexSubset *
+inferDifferentiabilityParameters(AbstractFunctionDecl *AFD,
+                                 GenericEnvironment *derivativeGenEnv);
 
-  /// Require that the library intrinsics for working with
-  /// UnsafeMutablePointer<T> exist.
-  bool requirePointerArgumentIntrinsics(ASTContext &ctx, SourceLoc loc);
+/// Require that the library intrinsics for working with Optional<T>
+/// exist.
+bool requireOptionalIntrinsics(ASTContext &ctx, SourceLoc loc);
 
-  /// Require that the library intrinsics for creating
-  /// array literals exist.
-  bool requireArrayLiteralIntrinsics(ASTContext &ctx, SourceLoc loc);
-  }; // namespace TypeChecker
+/// Require that the library intrinsics for working with
+/// UnsafeMutablePointer<T> exist.
+bool requirePointerArgumentIntrinsics(ASTContext &ctx, SourceLoc loc);
+
+/// Require that the library intrinsics for creating
+/// array literals exist.
+bool requireArrayLiteralIntrinsics(ASTContext &ctx, SourceLoc loc);
+}; // namespace TypeChecker
 
 /// Temporary on-stack storage and unescaping for encoded diagnostic
 /// messages.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -681,8 +681,6 @@ std::string gatherGenericParamBindingsText(
 /// \param requirements The requirements against which the generic arguments
 /// should be checked.
 /// \param substitutions Substitutions from interface types of the signature.
-/// \param conformanceOptions The flags to use when checking conformance
-/// requirement.
 /// \param listener The generic check listener used to pick requirements and
 /// notify callers about diagnosed errors.
 RequirementCheckResult checkGenericArguments(
@@ -690,7 +688,6 @@ RequirementCheckResult checkGenericArguments(
     TypeArrayView<GenericTypeParamType> genericParams,
     ArrayRef<Requirement> requirements, TypeSubstitutionFn substitutions,
     LookupConformanceFn conformances,
-    ConformanceCheckOptions conformanceOptions,
     GenericRequirementsCheckListener *listener = nullptr,
     SubstOptions options = None);
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -954,19 +954,6 @@ ProtocolConformanceRef conformsToProtocol(Type T, ProtocolDecl *Proto,
                                           ConformanceCheckOptions options,
                                           SourceLoc ComplainLoc = SourceLoc());
 
-/// Functor class suitable for use as a \c LookupConformanceFn to look up a
-/// conformance through a particular declaration context.
-class LookUpConformance {
-  DeclContext *dc;
-
-public:
-  explicit LookUpConformance(DeclContext *dc) : dc(dc) {}
-
-  ProtocolConformanceRef operator()(CanType dependentType,
-                                    Type conformingReplacementType,
-                                    ProtocolDecl *conformedProtocol) const;
-  };
-
   /// Completely check the given conformance.
   void checkConformance(NormalProtocolConformance *conformance);
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -687,7 +687,6 @@ RequirementCheckResult checkGenericArguments(
     DeclContext *dc, SourceLoc loc, SourceLoc noteLoc, Type owner,
     TypeArrayView<GenericTypeParamType> genericParams,
     ArrayRef<Requirement> requirements, TypeSubstitutionFn substitutions,
-    LookupConformanceFn conformances,
     GenericRequirementsCheckListener *listener = nullptr,
     SubstOptions options = None);
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -331,25 +331,6 @@ enum class RequirementCheckResult {
   Success, Failure, SubstitutionFailure
 };
 
-/// Flags that control protocol conformance checking.
-enum class ConformanceCheckFlags {
-  /// Whether to skip the check for any conditional conformances.
-  ///
-  /// When set, the caller takes responsibility for any
-  /// conditional requirements required for the conformance to be
-  /// correctly used. Otherwise (the default), all of the conditional
-  /// requirements will be checked.
-  SkipConditionalRequirements = 0x01,
-};
-
-/// Options that control protocol conformance checking.
-using ConformanceCheckOptions = OptionSet<ConformanceCheckFlags>;
-
-inline ConformanceCheckOptions operator|(ConformanceCheckFlags lhs,
-                                         ConformanceCheckFlags rhs) {
-  return ConformanceCheckOptions(lhs) | rhs;
-}
-
 /// Describes the kind of checked cast operation being performed.
 enum class CheckedCastContextKind {
   /// None: we're just establishing how to perform the checked cast. This
@@ -923,13 +904,11 @@ Expr *addImplicitLoadExpr(
 /// \param DC The context in which to check conformance. This affects, for
 /// example, extension visibility.
 ///
-/// \param options Options that control the conformance check.
-///
 /// \returns the conformance, if \c T conforms to the protocol \c Proto, or
 /// an empty optional.
 ProtocolConformanceRef containsProtocol(Type T, ProtocolDecl *Proto,
                                         DeclContext *DC,
-                                        ConformanceCheckOptions options);
+                                        bool skipConditionalRequirements=false);
 
 /// Determine whether the given type conforms to the given protocol.
 ///
@@ -938,8 +917,6 @@ ProtocolConformanceRef containsProtocol(Type T, ProtocolDecl *Proto,
 ///
 /// \param DC The context in which to check conformance. This affects, for
 /// example, extension visibility.
-///
-/// \param options Options that control the conformance check.
 ///
 /// \param ComplainLoc If valid, then this function will emit diagnostics if
 /// T does not conform to the given protocol. The primary diagnostic will
@@ -950,7 +927,6 @@ ProtocolConformanceRef containsProtocol(Type T, ProtocolDecl *Proto,
 /// protocol \c Proto, or \c None.
 ProtocolConformanceRef conformsToProtocol(Type T, ProtocolDecl *Proto,
                                           DeclContext *DC,
-                                          ConformanceCheckOptions options,
                                           SourceLoc ComplainLoc = SourceLoc());
 
   /// Completely check the given conformance.


### PR DESCRIPTION
Now that `TypeChecker::conformsToProtocol()` no longer uses the DeclContext to record dependencies, we can make a few simplifications:

- Change the callers that don't care about conditional requirements to call `ModuleDecl::lookupConformance()` instead
- Remove `ConformanceCheckFlags` now that the last remaining flag is gone
- Simplify `checkGenericArguments()` a little

The last remaining usage of the DeclContext is a `mapTypeIntoContext()` call in `checkGenericArguments()`.

The next step is to refactor `checkGenericArguments()` and `conformsToProtocol()` to take a module instead of a DeclContext.

After that, I would like to split off the diagnostics and listener logic from `checkGenericArguments()` into a new method, and move the lower-level semantic query from Sema to AST.