### PR TITLE
[NFC] Extract Dependency Registration to DependencyCollector

### DIFF
--- a/include/swift/AST/Evaluator.h
+++ b/include/swift/AST/Evaluator.h
@@ -48,12 +48,6 @@ class DiagnosticEngine;
 class Evaluator;
 class UnifiedStatsReporter;
 
-namespace detail {
-// Remove this when the compiler bumps to C++17.
-template <typename...>
-using void_t = void;
-}
-
 /// An "abstract" request function pointer, which is the storage type
 /// used for each of the
 using AbstractRequestFunction = void(void);
@@ -231,37 +225,7 @@ class Evaluator {
   /// so all clients must cope with cycles.
   llvm::DenseMap<AnyRequest, std::vector<AnyRequest>> dependencies;
 
-  /// A stack of dependency sources in the order they were evaluated.
-  llvm::SmallVector<evaluator::DependencySource, 8> dependencySources;
-
-  /// An RAII type that manages manipulating the evaluator's
-  /// dependency source stack. It is specialized to be zero-cost for
-  /// requests that are not dependency sources.
-  template <typename Request, typename = detail::void_t<>>
-  struct IncrementalDependencyStackRAII {
-    IncrementalDependencyStackRAII(Evaluator &E, const Request &Req) {}
-  };
-
-  template <typename Request>
-  struct IncrementalDependencyStackRAII<
-      Request, typename std::enable_if<Request::isDependencySource>::type> {
-    NullablePtr<Evaluator> Eval;
-    IncrementalDependencyStackRAII(Evaluator &E, const Request &Req) {
-      auto Source = Req.readDependencySource(E);
-      // If there is no source to introduce, bail. This can occur if
-      // a request originates in the context of a module.
-      if (!Source.getPointer()) {
-        return;
-      }
-      E.dependencySources.emplace_back(Source);
-      Eval = &E;
-    }
-
-    ~IncrementalDependencyStackRAII() {
-      if (Eval.isNonNull())
-        Eval.get()->dependencySources.pop_back();
-    }
-  };
+  evaluator::DependencyCollector collector;
 
   /// Retrieve the request function for the given zone and request IDs.
   AbstractRequestFunction *getAbstractRequestFunction(uint8_t zoneID,
@@ -303,7 +267,8 @@ public:
            typename std::enable_if<Request::isEverCached>::type * = nullptr>
   llvm::Expected<typename Request::OutputType>
   operator()(const Request &request) {
-    IncrementalDependencyStackRAII<Request> incDeps{*this, request};
+    evaluator::DependencyCollector::StackRAII<Request> incDeps{collector,
+                                                               request};
     // The request can be cached, but check a predicate to determine
     // whether this particular instance is cached. This allows more
     // fine-grained control over which instances get cache.
@@ -319,7 +284,8 @@ public:
            typename std::enable_if<!Request::isEverCached>::type * = nullptr>
   llvm::Expected<typename Request::OutputType>
   operator()(const Request &request) {
-    IncrementalDependencyStackRAII<Request> incDeps{*this, request};
+    evaluator::DependencyCollector::StackRAII<Request> incDeps{collector,
+                                                               request};
     return getResultUncached(request);
   }
 
@@ -476,47 +442,7 @@ private:
             typename std::enable_if<Request::isDependencySink>::type * = nullptr>
   void reportEvaluatedResult(const Request &r,
                              const typename Request::OutputType &o) {
-    if (auto *tracker = getActiveDependencyTracker())
-      r.writeDependencySink(*this, *tracker, o);
-  }
-
-  /// If there is an active dependency source, returns its
-  /// \c ReferencedNameTracker. Else, returns \c nullptr.
-  ReferencedNameTracker *getActiveDependencyTracker() const {
-    if (auto *source = getActiveDependencySourceOrNull())
-      return source->getRequestBasedReferencedNameTracker();
-    return nullptr;
-  }
-
-public:
-  /// Returns \c true if the scope of the current active source cascades.
-  ///
-  /// If there is no active scope, the result always cascades.
-  bool isActiveSourceCascading() const {
-    return getActiveSourceScope() == evaluator::DependencyScope::Cascading;
-  }
-
-  /// Returns the scope of the current active scope.
-  ///
-  /// If there is no active scope, the result always cascades.
-  evaluator::DependencyScope getActiveSourceScope() const {
-    if (dependencySources.empty()) {
-      return evaluator::DependencyScope::Cascading;
-    }
-    return dependencySources.back().getInt();
-  }
-
-  /// Returns the active dependency's source file, or \c nullptr if no
-  /// dependency source is active.
-  ///
-  /// The use of this accessor is strongly discouraged, as it implies that a
-  /// dependency sink is seeking to filter out names based on the files they
-  /// come from. Existing callers are being migrated to more reasonable ways
-  /// of judging the relevancy of a dependency.
-  SourceFile *getActiveDependencySourceOrNull() const {
-    if (dependencySources.empty())
-      return nullptr;
-    return dependencySources.back().getPointer();
+    r.writeDependencySink(collector, o);
   }
 
 public:

--- a/include/swift/AST/EvaluatorDependencies.h
+++ b/include/swift/AST/EvaluatorDependencies.h
@@ -26,6 +26,11 @@ namespace swift {
 
 namespace evaluator {
 
+namespace detail {
+// Remove this when the compiler bumps to C++17.
+template <typename...> using void_t = void;
+} // namespace detail
+
 /// The "scope" of a dependency edge tracked by the evaluator.
 ///
 /// Dependency scopes come in two flavors: cascading and private. A private
@@ -99,6 +104,123 @@ inline DependencyScope getScopeForAccessLevel(AccessLevel l) {
 // edges in the incremental dependency graph invalidate entire files instead
 // of individual contexts.
 using DependencySource = llvm::PointerIntPair<SourceFile *, 1, DependencyScope>;
+
+/// A \c DependencyCollector is an aggregator of named references discovered in a
+/// particular \c DependencyScope during the course of request evaluation.
+struct DependencyCollector {
+private:
+  /// A stack of dependency sources in the order they were evaluated.
+  llvm::SmallVector<evaluator::DependencySource, 8> dependencySources;
+
+public:
+  DependencyCollector() = default;
+
+public:
+  /// Registers a named reference from the current dependency scope to a member
+  /// defined in the given \p subject type.
+  ///
+  /// Used member constraints are typically the by-product of direct lookups,
+  /// where the name being looked up and the target of the lookup are known
+  /// up front. A used member dependency causes the file to be rebuilt if the
+  /// definition of that member changes in any way - via
+  /// deletion, addition, or mutation of a member with that same name.
+  void addUsedMember(NominalTypeDecl *subject, DeclBaseName name);
+  /// Registers a reference from the current dependency scope to a
+  /// "potential member" of the given \p subject type.
+  ///
+  /// A single potential member dependency can be thought of as many used member
+  /// dependencies - one for each current member of the subject type, but also
+  /// one for every member that will be added or removed from the type in the
+  /// future. As such, these dependencies cause rebuilds when any members are
+  /// added, removed, or changed in the \p subject type. It also indicates a
+  /// dependency on the \p subject type's existence, so deleting the \p subject
+  /// type will also cause a rebuild.
+  ///
+  /// These dependencies are most appropriate for protocol conformances,
+  /// superclass constraints, and other requirements involving entire types.
+  void addPotentialMember(NominalTypeDecl *subject);
+  /// Registers a reference from the current dependency scope to a given
+  /// top-level \p name.
+  ///
+  /// A top level dependency causes a rebuild when another top-level entity with
+  /// that name is added, removed, or modified.
+  void addTopLevelName(DeclBaseName name);
+  /// Registers a reference from the current dependency scope to a given
+  /// dynamic member \p name.
+  ///
+  /// A dynamic lookup dependency is a special kind of member dependency on
+  /// a name that is found by \c AnyObject lookup.
+  void addDynamicLookupName(DeclBaseName name);
+
+public:
+  /// Returns the scope of the current active scope.
+  ///
+  /// If there is no active scope, the result always cascades.
+  evaluator::DependencyScope getActiveSourceScope() const {
+    if (dependencySources.empty()) {
+      return evaluator::DependencyScope::Cascading;
+    }
+    return dependencySources.back().getInt();
+  }
+
+  /// Returns the active dependency's source file, or \c nullptr if no
+  /// dependency source is active.
+  ///
+  /// The use of this accessor is strongly discouraged, as it implies that a
+  /// dependency sink is seeking to filter out names based on the files they
+  /// come from. Existing callers are being migrated to more reasonable ways
+  /// of judging the relevancy of a dependency.
+  SourceFile *getActiveDependencySourceOrNull() const {
+    if (dependencySources.empty())
+      return nullptr;
+    return dependencySources.back().getPointer();
+  }
+
+public:
+  /// An RAII type that manages manipulating the evaluator's
+  /// dependency source stack. It is specialized to be zero-cost for
+  /// requests that are not dependency sources.
+  template <typename Request, typename = detail::void_t<>> struct StackRAII {
+    StackRAII(DependencyCollector &DC, const Request &Req) {}
+  };
+
+  template <typename Request>
+  struct StackRAII<Request,
+                   typename std::enable_if<Request::isDependencySource>::type> {
+    NullablePtr<DependencyCollector> Coll;
+    StackRAII(DependencyCollector &coll, const Request &Req) {
+      auto Source = Req.readDependencySource(coll);
+      // If there is no source to introduce, bail. This can occur if
+      // a request originates in the context of a module.
+      if (!Source.getPointer()) {
+        return;
+      }
+      coll.dependencySources.emplace_back(Source);
+      Coll = &coll;
+    }
+
+    ~StackRAII() {
+      if (Coll.isNonNull())
+        Coll.get()->dependencySources.pop_back();
+    }
+  };
+
+private:
+  /// If there is an active dependency source, returns its
+  /// \c ReferencedNameTracker. Else, returns \c nullptr.
+  ReferencedNameTracker *getActiveDependencyTracker() const {
+    if (auto *source = getActiveDependencySourceOrNull())
+      return source->getRequestBasedReferencedNameTracker();
+    return nullptr;
+  }
+
+  /// Returns \c true if the scope of the current active source cascades.
+  ///
+  /// If there is no active scope, the result always cascades.
+  bool isActiveSourceCascading() const {
+    return getActiveSourceScope() == evaluator::DependencyScope::Cascading;
+  }
+};
 } // end namespace evaluator
 
 } // end namespace swift

--- a/include/swift/AST/IRGenRequests.h
+++ b/include/swift/AST/IRGenRequests.h
@@ -199,7 +199,8 @@ public:
 
 public:
   // Incremental dependencies.
-  evaluator::DependencySource readDependencySource(Evaluator &) const;
+  evaluator::DependencySource
+  readDependencySource(const evaluator::DependencyCollector &) const;
 };
 
 class IRGenWholeModuleRequest

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -188,8 +188,9 @@ public:
 
 public:
   // Incremental dependencies
-  evaluator::DependencySource readDependencySource(Evaluator &e) const;
-  void writeDependencySink(Evaluator &evaluator, ReferencedNameTracker &tracker,
+  evaluator::DependencySource
+  readDependencySource(const evaluator::DependencyCollector &e) const;
+  void writeDependencySink(evaluator::DependencyCollector &tracker,
                            ArrayRef<ProtocolDecl *> result) const;
 };
 
@@ -239,7 +240,7 @@ public:
 
 public:
   // Incremental dependencies
-  void writeDependencySink(Evaluator &evaluator, ReferencedNameTracker &tracker,
+  void writeDependencySink(evaluator::DependencyCollector &tracker,
                            NominalTypeDecl *result) const;
 };
 
@@ -328,7 +329,8 @@ public:
 
 public:
   // Incremental dependencies.
-  evaluator::DependencySource readDependencySource(Evaluator &) const;
+  evaluator::DependencySource
+  readDependencySource(const evaluator::DependencyCollector &) const;
 };
 
 class GenericParamListRequest :
@@ -431,8 +433,9 @@ private:
 
 public:
   // Incremental dependencies
-  evaluator::DependencySource readDependencySource(Evaluator &) const;
-  void writeDependencySink(Evaluator &eval, ReferencedNameTracker &tracker,
+  evaluator::DependencySource
+  readDependencySource(const evaluator::DependencyCollector &) const;
+  void writeDependencySink(evaluator::DependencyCollector &tracker,
                            LookupResult res) const;
 };
 
@@ -477,7 +480,7 @@ private:
 
 public:
   // Incremental dependencies
-  void writeDependencySink(Evaluator &eval, ReferencedNameTracker &tracker,
+  void writeDependencySink(evaluator::DependencyCollector &tracker,
                            QualifiedLookupResult l) const;
 };
 
@@ -502,8 +505,9 @@ private:
 
 public:
   // Incremental dependencies
-  evaluator::DependencySource readDependencySource(Evaluator &) const;
-  void writeDependencySink(Evaluator &eval, ReferencedNameTracker &tracker,
+  evaluator::DependencySource
+  readDependencySource(const evaluator::DependencyCollector &) const;
+  void writeDependencySink(evaluator::DependencyCollector &tracker,
                            QualifiedLookupResult lookupResult) const;
 };
 
@@ -528,7 +532,8 @@ private:
 
 public:
   // Incremental dependencies.
-  evaluator::DependencySource readDependencySource(Evaluator &) const;
+  evaluator::DependencySource
+  readDependencySource(const evaluator::DependencyCollector &) const;
 };
 
 /// The input type for a direct lookup request.
@@ -580,7 +585,7 @@ private:
 
 public:
   // Incremental dependencies
-  void writeDependencySink(Evaluator &evaluator, ReferencedNameTracker &tracker,
+  void writeDependencySink(evaluator::DependencyCollector &tracker,
                            TinyPtrVector<ValueDecl *> result) const;
 };
 
@@ -665,7 +670,7 @@ public:
 
 public:
   // Incremental dependencies
-  void writeDependencySink(Evaluator &evaluator, ReferencedNameTracker &tracker,
+  void writeDependencySink(evaluator::DependencyCollector &tracker,
                            OperatorType *o) const;
 };
 
@@ -755,7 +760,7 @@ private:
 
 public:
   // Incremental dependencies
-  void writeDependencySink(Evaluator &evaluator, ReferencedNameTracker &tracker,
+  void writeDependencySink(evaluator::DependencyCollector &tracker,
                            ProtocolConformanceRef result) const;
 };
 

--- a/include/swift/AST/ParseRequests.h
+++ b/include/swift/AST/ParseRequests.h
@@ -102,7 +102,8 @@ public:
   void cacheResult(ArrayRef<Decl *> decls) const;
 
 public:
-  evaluator::DependencySource readDependencySource(Evaluator &) const;
+  evaluator::DependencySource
+  readDependencySource(const evaluator::DependencyCollector &) const;
 };
 
 void simple_display(llvm::raw_ostream &out,
@@ -123,7 +124,8 @@ private:
                 CodeCompletionCallbacksFactory *Factory) const;
 
 public:
-  evaluator::DependencySource readDependencySource(Evaluator &) const;
+  evaluator::DependencySource
+  readDependencySource(const evaluator::DependencyCollector &) const;
 };
 
 /// The zone number for the parser.

--- a/include/swift/AST/SILGenRequests.h
+++ b/include/swift/AST/SILGenRequests.h
@@ -98,7 +98,8 @@ public:
 
 public:
   // Incremental dependencies.
-  evaluator::DependencySource readDependencySource(Evaluator &) const;
+  evaluator::DependencySource
+  readDependencySource(const evaluator::DependencyCollector &) const;
 };
 
 class SILGenWholeModuleRequest :

--- a/include/swift/AST/SimpleRequest.h
+++ b/include/swift/AST/SimpleRequest.h
@@ -231,7 +231,8 @@ SourceLoc extractNearestSourceLoc(const std::tuple<First, Rest...> &value) {
 /// and specify \c RequestFlags::DependencySource in addition to one of
 /// the 3 caching kinds defined above.
 /// \code
-///   evaluator::DependencySource readDependencySource(Evaluator &) const;
+///   evaluator::DependencySource
+///   readDependencySource(const evaluator::DependencyCollector &) const;
 /// \endcode
 ///
 /// Requests that define dependency sinks should instead override
@@ -240,8 +241,7 @@ SourceLoc extractNearestSourceLoc(const std::tuple<First, Rest...> &value) {
 /// \c RequestFlags::DependencySource should be specified along with
 /// one of the 3 caching kinds defined above.
 /// \code
-///   void writeDependencySink(Evaluator &,
-///                            ReferencedNameTracker &, Output) const;
+///   void writeDependencySink(evaluator::DependencyCollector &, Output) const;
 /// \endcode
 template<typename Derived, typename Signature, RequestFlags Caching>
 class SimpleRequest;

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -121,9 +121,10 @@ public:
 
 public:
   // Incremental dependencies
-  evaluator::DependencySource readDependencySource(Evaluator &e) const;
-  void writeDependencySink(Evaluator &eval,
-                           ReferencedNameTracker &tracker, Type t) const;
+  evaluator::DependencySource
+  readDependencySource(const evaluator::DependencyCollector &e) const;
+  void writeDependencySink(evaluator::DependencyCollector &tracker,
+                           Type t) const;
 };
 
 /// Request the raw type of the given enum.
@@ -890,7 +891,8 @@ public:
 
 public:
   // Incremental dependencies.
-  evaluator::DependencySource readDependencySource(Evaluator &) const;
+  evaluator::DependencySource
+  readDependencySource(const evaluator::DependencyCollector &) const;
 };
 
 /// Request to obtain a list of stored properties in a nominal type.
@@ -2030,7 +2032,8 @@ public:
 
 public:
   // Incremental dependencies.
-  evaluator::DependencySource readDependencySource(Evaluator &) const;
+  evaluator::DependencySource
+  readDependencySource(const evaluator::DependencyCollector &) const;
 };
 
 /// Computes whether the specified type or a super-class/super-protocol has the
@@ -2271,8 +2274,9 @@ private:
 
 public:
   // Incremental dependencies
-  evaluator::DependencySource readDependencySource(Evaluator &eval) const;
-  void writeDependencySink(Evaluator &eval, ReferencedNameTracker &tracker,
+  evaluator::DependencySource
+  readDependencySource(const evaluator::DependencyCollector &eval) const;
+  void writeDependencySink(evaluator::DependencyCollector &tracker,
                            ProtocolConformanceLookupResult r) const;
 };
 
@@ -2298,8 +2302,9 @@ public:
   void cacheResult(evaluator::SideEffect) const;
 
 public:
-  evaluator::DependencySource readDependencySource(Evaluator &eval) const;
-  void writeDependencySink(Evaluator &eval, ReferencedNameTracker &tracker,
+  evaluator::DependencySource
+  readDependencySource(const evaluator::DependencyCollector &eval) const;
+  void writeDependencySink(evaluator::DependencyCollector &tracker,
                            evaluator::SideEffect) const;
 };
 

--- a/lib/AST/Evaluator.cpp
+++ b/lib/AST/Evaluator.cpp
@@ -367,3 +367,25 @@ void Evaluator::printDependenciesGraphviz(llvm::raw_ostream &out) const {
 void Evaluator::dumpDependenciesGraphviz() const {
   printDependenciesGraphviz(llvm::dbgs());
 }
+
+void evaluator::DependencyCollector::addUsedMember(NominalTypeDecl *subject,
+                                                   DeclBaseName name) {
+  if (auto *tracker = getActiveDependencyTracker())
+    tracker->addUsedMember({subject, name}, isActiveSourceCascading());
+}
+
+void evaluator::DependencyCollector::addPotentialMember(
+    NominalTypeDecl *subject) {
+  if (auto *tracker = getActiveDependencyTracker())
+    tracker->addUsedMember({subject, Identifier()}, isActiveSourceCascading());
+}
+
+void evaluator::DependencyCollector::addTopLevelName(DeclBaseName name) {
+  if (auto *tracker = getActiveDependencyTracker())
+    tracker->addTopLevelName(name, isActiveSourceCascading());
+}
+
+void evaluator::DependencyCollector::addDynamicLookupName(DeclBaseName name) {
+  if (auto *tracker = getActiveDependencyTracker())
+    tracker->addDynamicLookupName(name, isActiveSourceCascading());
+}

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1289,8 +1289,7 @@ OperatorType *LookupOperatorRequest<OperatorType>::evaluate(
 
 template <typename OperatorType>
 void LookupOperatorRequest<OperatorType>::writeDependencySink(
-    Evaluator &evaluator, ReferencedNameTracker &reqTracker,
-    OperatorType *o) const {
+    evaluator::DependencyCollector &reqTracker, OperatorType *o) const {
   auto &desc = std::get<0>(this->getStorage());
   auto *FU = desc.fileOrModule.template get<FileUnit *>();
   auto shouldRegisterDependencyEdge = [&FU](OperatorType *o) -> bool {
@@ -1310,22 +1309,19 @@ void LookupOperatorRequest<OperatorType>::writeDependencySink(
     return;
   }
 
-  reqTracker.addTopLevelName(desc.name, desc.isCascading);
+  reqTracker.addTopLevelName(desc.name);
 }
 
 #define LOOKUP_OPERATOR(Kind)                                                  \
   Kind##Decl *ModuleDecl::lookup##Kind(Identifier name, SourceLoc loc) {       \
-    auto result =                                                              \
-        lookupOperatorDeclForName<Kind##Decl>(this, loc, name,                 \
-                                              /*isCascading*/ false);          \
+    auto result = lookupOperatorDeclForName<Kind##Decl>(                       \
+        this, loc, name, /*isCascading*/ false);                               \
     return result ? *result : nullptr;                                         \
   }                                                                            \
-  template Kind##Decl *                                                        \
-  LookupOperatorRequest<Kind##Decl>::evaluate(Evaluator &e,                    \
-                                              OperatorLookupDescriptor) const; \
-  template                                                                     \
-  void LookupOperatorRequest<Kind##Decl>::writeDependencySink(                 \
-           Evaluator &, ReferencedNameTracker &, Kind##Decl *) const;          \
+  template Kind##Decl *LookupOperatorRequest<Kind##Decl>::evaluate(            \
+      Evaluator &e, OperatorLookupDescriptor) const;                           \
+  template void LookupOperatorRequest<Kind##Decl>::writeDependencySink(        \
+      evaluator::DependencyCollector &, Kind##Decl *) const;
 
 LOOKUP_OPERATOR(PrefixOperator)
 LOOKUP_OPERATOR(InfixOperator)

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -157,8 +157,8 @@ void SuperclassTypeRequest::cacheResult(Type value) const {
     protocolDecl->LazySemanticInfo.SuperclassType.setPointerAndInt(value, true);
 }
 
-evaluator::DependencySource
-SuperclassTypeRequest::readDependencySource(Evaluator &e) const {
+evaluator::DependencySource SuperclassTypeRequest::readDependencySource(
+    const evaluator::DependencyCollector &e) const {
   const auto access = std::get<0>(getStorage())->getFormalAccess();
   return {
     e.getActiveDependencySourceOrNull(),
@@ -166,9 +166,8 @@ SuperclassTypeRequest::readDependencySource(Evaluator &e) const {
   };
 }
 
-void SuperclassTypeRequest::writeDependencySink(Evaluator &eval,
-                                                ReferencedNameTracker &tracker,
-                                                Type value) const {
+void SuperclassTypeRequest::writeDependencySink(
+    evaluator::DependencyCollector &tracker, Type value) const {
   if (!value)
     return;
 
@@ -177,7 +176,7 @@ void SuperclassTypeRequest::writeDependencySink(Evaluator &eval,
   ClassDecl *Super = value->getClassOrBoundGenericClass();
   if (!Super)
     return;
-  tracker.addUsedMember({Super, Identifier()}, eval.isActiveSourceCascading());
+  tracker.addPotentialMember(Super);
 }
 
 //----------------------------------------------------------------------------//
@@ -1349,8 +1348,8 @@ void CheckRedeclarationRequest::cacheResult(evaluator::SideEffect) const {
   std::get<0>(getStorage())->setCheckedRedeclaration();
 }
 
-evaluator::DependencySource
-CheckRedeclarationRequest::readDependencySource(Evaluator &eval) const {
+evaluator::DependencySource CheckRedeclarationRequest::readDependencySource(
+    const evaluator::DependencyCollector &eval) const {
   auto *current = std::get<0>(getStorage());
   auto *currentDC = current->getDeclContext();
   return {
@@ -1360,8 +1359,7 @@ CheckRedeclarationRequest::readDependencySource(Evaluator &eval) const {
 }
 
 void CheckRedeclarationRequest::writeDependencySink(
-    Evaluator &eval, ReferencedNameTracker &tracker,
-    evaluator::SideEffect) const {
+    evaluator::DependencyCollector &tracker, evaluator::SideEffect) const {
   auto *current = std::get<0>(getStorage());
   if (!current->hasName())
     return;
@@ -1373,12 +1371,10 @@ void CheckRedeclarationRequest::writeDependencySink(
 
   if (currentDC->isTypeContext()) {
     if (auto nominal = currentDC->getSelfNominalTypeDecl()) {
-      tracker.addUsedMember({nominal, current->getBaseName()},
-                            eval.isActiveSourceCascading());
+      tracker.addUsedMember(nominal, current->getBaseName());
     }
   } else {
-    tracker.addTopLevelName(current->getBaseName(),
-                            eval.isActiveSourceCascading());
+    tracker.addTopLevelName(current->getBaseName());
   }
 }
 
@@ -1388,33 +1384,28 @@ void CheckRedeclarationRequest::writeDependencySink(
 
 evaluator::DependencySource
 LookupAllConformancesInContextRequest::readDependencySource(
-    Evaluator &eval) const {
+    const evaluator::DependencyCollector &collector) const {
   auto *dc = std::get<0>(getStorage());
   AccessLevel defaultAccess;
   if (auto ext = dyn_cast<ExtensionDecl>(dc)) {
     const NominalTypeDecl *nominal = ext->getExtendedNominal();
     if (!nominal) {
-      return {
-        eval.getActiveDependencySourceOrNull(),
-        evaluator::DependencyScope::Cascading
-      };
+      return {collector.getActiveDependencySourceOrNull(),
+              evaluator::DependencyScope::Cascading};
     }
     defaultAccess = nominal->getFormalAccess();
   } else {
     defaultAccess = cast<NominalTypeDecl>(dc)->getFormalAccess();
   }
-  return {
-    eval.getActiveDependencySourceOrNull(),
-    evaluator::getScopeForAccessLevel(defaultAccess)
-  };
+  return {collector.getActiveDependencySourceOrNull(),
+          evaluator::getScopeForAccessLevel(defaultAccess)};
 }
 
 void LookupAllConformancesInContextRequest::writeDependencySink(
-    Evaluator &eval, ReferencedNameTracker &tracker,
+    evaluator::DependencyCollector &tracker,
     ProtocolConformanceLookupResult conformances) const {
   for (auto conformance : conformances) {
-    tracker.addUsedMember({conformance->getProtocol(), Identifier()},
-                          eval.isActiveSourceCascading());
+    tracker.addPotentialMember(conformance->getProtocol());
   }
 }
 
@@ -1439,8 +1430,8 @@ void ResolveTypeEraserTypeRequest::cacheResult(Type value) const {
 // TypeCheckSourceFileRequest computation.
 //----------------------------------------------------------------------------//
 
-evaluator::DependencySource
-TypeCheckSourceFileRequest::readDependencySource(Evaluator &e) const {
+evaluator::DependencySource TypeCheckSourceFileRequest::readDependencySource(
+    const evaluator::DependencyCollector &e) const {
   return {std::get<0>(getStorage()), evaluator::DependencyScope::Cascading};
 }
 
@@ -1491,7 +1482,8 @@ void TypeCheckSourceFileRequest::cacheResult(evaluator::SideEffect) const {
 //----------------------------------------------------------------------------//
 
 evaluator::DependencySource
-TypeCheckFunctionBodyUntilRequest::readDependencySource(Evaluator &e) const {
+TypeCheckFunctionBodyUntilRequest::readDependencySource(
+    const evaluator::DependencyCollector &e) const {
   // We're going under a function body scope, unconditionally flip the scope
   // to private.
   return {

--- a/lib/IRGen/IRGenRequests.cpp
+++ b/lib/IRGen/IRGenRequests.cpp
@@ -52,8 +52,8 @@ SourceLoc swift::extractNearestSourceLoc(const IRGenDescriptor &desc) {
   return SourceLoc();
 }
 
-evaluator::DependencySource
-IRGenSourceFileRequest::readDependencySource(Evaluator &e) const {
+evaluator::DependencySource IRGenSourceFileRequest::readDependencySource(
+    const evaluator::DependencyCollector &e) const {
   auto &desc = std::get<0>(getStorage());
   return {
     desc.Ctx.dyn_cast<SourceFile *>(),

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -167,8 +167,8 @@ ArrayRef<Decl *> ParseSourceFileRequest::evaluate(Evaluator &evaluator,
   return ctx.AllocateCopy(decls);
 }
 
-evaluator::DependencySource
-ParseSourceFileRequest::readDependencySource(Evaluator &e) const {
+evaluator::DependencySource ParseSourceFileRequest::readDependencySource(
+    const evaluator::DependencyCollector &e) const {
   return {std::get<0>(getStorage()), evaluator::DependencyScope::Cascading};
 }
 
@@ -195,7 +195,8 @@ void swift::simple_display(llvm::raw_ostream &out,
                            const CodeCompletionCallbacksFactory *factory) { }
 
 evaluator::DependencySource
-CodeCompletionSecondPassRequest::readDependencySource(Evaluator &e) const {
+CodeCompletionSecondPassRequest::readDependencySource(
+    const evaluator::DependencyCollector &e) const {
   return {std::get<0>(getStorage()), e.getActiveSourceScope()};
 }
 

--- a/lib/SILGen/SILGenRequests.cpp
+++ b/lib/SILGen/SILGenRequests.cpp
@@ -46,8 +46,8 @@ SourceLoc swift::extractNearestSourceLoc(const SILGenDescriptor &desc) {
   return SourceLoc();
 }
 
-evaluator::DependencySource
-SILGenSourceFileRequest::readDependencySource(Evaluator &e) const {
+evaluator::DependencySource SILGenSourceFileRequest::readDependencySource(
+    const evaluator::DependencyCollector &e) const {
   auto &desc = std::get<0>(getStorage());
   auto *unit = desc.context.get<FileUnit *>();
   return {


### PR DESCRIPTION
Define a new type `DependencyCollector` that abstracts over the
incremental dependency gathering logic. This will insulate the
request-based name tracking code from future work on private,
intransitive dependencies.

For now, this is just a thin wrapper over the `ReferencedNameTracker`.