### PR TITLE
[NFC] [arm64e] Turn on IRGen/opaque_result_type.swift test case.

### DIFF
--- a/test/IRGen/opaque_result_type.swift
+++ b/test/IRGen/opaque_result_type.swift
@@ -2,9 +2,6 @@
 // RUN: %{python} %utils/chex.py < %s > %t/opaque_result_type.swift
 // RUN: %target-swift-frontend -enable-implicit-dynamic -disable-availability-checking -emit-ir %t/opaque_result_type.swift | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-NODEBUG %t/opaque_result_type.swift
 
-// FIXME: Disabled because compilation is crashing in arm64e
-// REQUIRES: rdar60734429
-
 public protocol O {
   func bar()
 }


### PR DESCRIPTION
Fixes rdar://problem/60734429.