### PR TITLE
TempRValueOpt: fix a compile time crash in tryOptimizeStoreIntoTemp

### DIFF
--- a/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
+++ b/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
@@ -628,6 +628,16 @@ TempRValueOptPass::tryOptimizeStoreIntoTemp(StoreInst *si) {
     // We pass in SILValue() since we do not have a source address.
     if (!collectLoads(useOper, user, tempObj, SILValue(), loadInsts))
       return {std::next(si->getIterator()), false};
+
+    // Bail if there is any kind of user which is not handled in the code below.
+    switch (user->getKind()) {
+      case SILInstructionKind::CopyAddrInst:
+      case SILInstructionKind::FixLifetimeInst:
+      case SILInstructionKind::MarkDependenceInst:
+        continue;
+      default:
+        return {std::next(si->getIterator()), false};
+    }
   }
 
   // Since store is always a consuming operation, we do not need to worry about

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -1159,3 +1159,22 @@ bb0(%0 : $*Klass):
   %9999 = tuple()
   return %9999 : $()
 }
+
+// Check that we don't crash with this.
+// CHECK-LABEL: sil [ossa] @unhandled_user : $@convention(thin) (@owned Klass) -> @owned Klass {
+// CHECK:   alloc_stack
+// CHECK:   store
+// CHECK:   begin_access
+// CHECK:   load
+// CHECK: } // end sil function 'unhandled_user'
+sil [ossa] @unhandled_user : $@convention(thin) (@owned Klass) -> @owned Klass {
+bb0(%0 : @owned $Klass):
+  %5 = alloc_stack $Klass
+  store %0 to [init] %5 : $*Klass
+  %104 = begin_access [read] [static] %5 : $*Klass
+  %105 = load [take] %104 : $*Klass
+  end_access %104 : $*Klass
+  dealloc_stack %5 : $*Klass
+  return %105 : $Klass
+}
+


### PR DESCRIPTION
Bail if there is any kind of user which is not handled in this transformation.
