### PR TITLE
[5.3][SR-12425] Improving diagnostics for key path application on non-convertible root type

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -580,6 +580,9 @@ ERROR(expr_keypath_subscript_index_not_hashable, none,
 ERROR(expr_smart_keypath_application_type_mismatch,none,
       "key path of type %0 cannot be applied to a base of type %1",
       (Type, Type))
+ERROR(expr_keypath_root_type_mismatch, none,
+      "key path with root type %0 cannot be applied to a base of type %1",
+      (Type, Type))
 ERROR(expr_swift_keypath_anyobject_root,none,
       "the root type of a Swift key path cannot be 'AnyObject'", ())
 WARNING(expr_deprecated_writable_keypath,none,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6224,3 +6224,15 @@ bool CoercionAsForceCastFailure::diagnoseAsError() {
       .highlight(getSourceRange());
   return true;
 }
+
+bool KeyPathRootTypeMismatchFailure::diagnoseAsError() {
+  auto locator = getLocator();
+  assert(locator->isKeyPathRoot() && "Expected a key path root");
+  
+  auto baseType = getFromType();
+  auto rootType = getToType();
+
+  emitDiagnostic(diag::expr_keypath_root_type_mismatch,
+                 rootType, baseType);
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2022,6 +2022,24 @@ public:
 
   bool diagnoseAsError() override;
 };
+
+/// Diagnose a key path root type that cannot be applied to an instance
+/// base that has another type.
+///
+/// \code
+/// func f(_ bar: Bar , keyPath: KeyPath<Foo, Int> ) {
+///   bar[keyPath: keyPath]
+/// }
+/// \endcode
+class KeyPathRootTypeMismatchFailure final : public ContextualFailure {
+public:
+  KeyPathRootTypeMismatchFailure(const Solution &solution, Type lhs, Type rhs,
+                                 ConstraintLocator *locator)
+      : ContextualFailure(solution, lhs, rhs, locator) {}
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1293,3 +1293,17 @@ AllowCoercionToForceCast::create(ConstraintSystem &cs, Type fromType,
   return new (cs.getAllocator())
       AllowCoercionToForceCast(cs, fromType, toType, locator);
 }
+
+bool AllowKeyPathRootTypeMismatch::diagnose(const Solution &solution,
+                                            bool asNote) const {
+  KeyPathRootTypeMismatchFailure failure(solution, getFromType(), getToType(),
+                                         getLocator());
+  return failure.diagnose(asNote);
+}
+
+AllowKeyPathRootTypeMismatch *
+AllowKeyPathRootTypeMismatch::create(ConstraintSystem &cs, Type lhs, Type rhs,
+                                     ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowKeyPathRootTypeMismatch(cs, lhs, rhs, locator);
+}

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -251,6 +251,10 @@ enum class FixKind : uint8_t {
 
   /// A warning fix that allows a coercion to perform a force-cast.
   AllowCoercionToForceCast,
+  
+  /// Allow key path root type mismatch when applying a key path that has a
+  /// root type not convertible to the type of the base instance.
+  AllowKeyPathRootTypeMismatch,
 };
 
 class ConstraintFix {
@@ -1766,6 +1770,32 @@ public:
   static AllowCoercionToForceCast *create(ConstraintSystem &cs, Type fromType,
                                           Type toType,
                                           ConstraintLocator *locator);
+};
+
+/// Attempt to fix a key path application where the key path type cannot be
+/// applied to a base instance of another type.
+///
+/// \code
+/// func f(_ bar: Bar , keyPath: KeyPath<Foo, Int> ) {
+///   bar[keyPath: keyPath]
+/// }
+/// \endcode
+class AllowKeyPathRootTypeMismatch : public ContextualMismatch {
+protected:
+  AllowKeyPathRootTypeMismatch(ConstraintSystem &cs, Type lhs, Type rhs,
+                               ConstraintLocator *locator)
+      : ContextualMismatch(cs, FixKind::AllowKeyPathRootTypeMismatch, lhs, rhs,
+                           locator) {}
+
+public:
+  std::string getName() const override {
+    return "allow key path root type mismatch";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  static AllowKeyPathRootTypeMismatch *
+  create(ConstraintSystem &cs, Type lhs, Type rhs, ConstraintLocator *locator);
 };
 
 } // end namespace constraints

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3577,6 +3577,13 @@ bool ConstraintSystem::repairFailures(
     break;
   }
 
+  case ConstraintLocator::KeyPathRoot: {
+    conversionsOrFixes.push_back(AllowKeyPathRootTypeMismatch::create(
+        *this, lhs, rhs, getConstraintLocator(locator)));
+
+    break;
+  }
+
   case ConstraintLocator::FunctionArgument: {
     auto *argLoc = getConstraintLocator(
         locator.withPathElement(LocatorPathElt::SynthesizedArgument(0)));
@@ -7829,8 +7836,9 @@ ConstraintSystem::simplifyKeyPathApplicationConstraint(
     rootTy = getFixedTypeRecursive(rootTy, flags, /*wantRValue=*/false);
 
     auto matchRoot = [&](ConstraintKind kind) -> bool {
-      auto rootMatches = matchTypes(rootTy, kpRootTy, kind,
-                                    subflags, locator);
+      auto rootMatches =
+          matchTypes(rootTy, kpRootTy, kind, subflags,
+                     locator.withPathElement(LocatorPathElt::KeyPathRoot()));
       switch (rootMatches) {
       case SolutionKind::Error:
         return false;
@@ -9392,6 +9400,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::SpecifyBaseTypeForContextualMember:
   case FixKind::CoerceToCheckedCast:
   case FixKind::SpecifyObjectLiteralTypeImport:
+  case FixKind::AllowKeyPathRootTypeMismatch:
   case FixKind::AllowCoercionToForceCast: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -811,9 +811,16 @@ internal var rightStructInstance: SR12425_R = SR12425_R()
 
 public extension SR12425_R {
   subscript<T>(dynamicMember member: WritableKeyPath<SR12425_S, T>) -> T {
-      // TODO(Diagnostics): bad diagnostic for member assign.
-      // A better diagnostic would be: key path of type WritableKeyPath<SR12425_S, T> cannot be applied to a base of type SR12425_R
-      get { rightStructInstance[keyPath: member] } // expected-error {{cannot convert return expression of type 'Any?' to return type 'T'}}
-      set { rightStructInstance[keyPath: member] = newValue } // expected-error {{type of expression is ambiguous without more context}}
+      get { rightStructInstance[keyPath: member] } // expected-error {{key path with root type 'SR12425_S' cannot be applied to a base of type 'SR12425_R'}}
+      set { rightStructInstance[keyPath: member] = newValue } // expected-error {{key path with root type 'SR12425_S' cannot be applied to a base of type 'SR12425_R'}}
+  }
+}
+
+@dynamicMemberLookup
+public struct SR12425_R1 {}
+
+public extension SR12425_R1 {
+  subscript<T>(dynamicMember member: KeyPath<SR12425_R1, T>) -> T {
+    get { rightStructInstance[keyPath: member] } // expected-error {{key path with root type 'SR12425_R1' cannot be applied to a base of type 'SR12425_R'}}
   }
 }


### PR DESCRIPTION
Cherry-pick #31192 

cc @xedin :)
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-12425.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
