### PR TITLE
[Parse] Don't drop parsed error types in where clause from AST

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4582,8 +4582,7 @@ Parser::parseDeclExtension(ParseDeclOptions Flags, DeclAttributes &Attributes) {
         return whereStatus;
       trailingWhereHadCodeCompletion = true;
     }
-
-    if (whereStatus.isSuccess()) {
+    if (!requirements.empty()) {
       trailingWhereClause = TrailingWhereClause::create(Context, whereLoc,
                                                         requirements);
     }

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -332,13 +332,9 @@ ParserStatus Parser::parseGenericWhereClause(
       } else {
         // Parse the protocol or composition.
         ParserResult<TypeRepr> Protocol = parseType();
-
-        if (Protocol.isNull()) {
-          Status.setIsParseError();
-          if (Protocol.hasCodeCompletion())
-            Status.setHasCodeCompletion();
-          break;
-        }
+        Status |= Protocol;
+        if (Protocol.isNull())
+          Protocol = makeParserResult(new (Context) ErrorTypeRepr(PreviousLoc));
 
         // Add the requirement.
         Requirements.push_back(RequirementRepr::getTypeConstraint(
@@ -356,17 +352,18 @@ ParserStatus Parser::parseGenericWhereClause(
 
       // Parse the second type.
       ParserResult<TypeRepr> SecondType = parseType();
-      if (SecondType.isNull()) {
-        Status.setIsParseError();
-        if (SecondType.hasCodeCompletion())
-          Status.setHasCodeCompletion();
-        break;
-      }
+      Status |= SecondType;
+      if (SecondType.isNull())
+        SecondType = makeParserResult(new (Context) ErrorTypeRepr(PreviousLoc));
 
       // Add the requirement
       Requirements.push_back(RequirementRepr::getSameType(FirstType.get(),
                                                       EqualLoc,
                                                       SecondType.get()));
+    } else if (FirstType.hasCodeCompletion()) {
+      // Recover by adding dummy constraint.
+      Requirements.push_back(RequirementRepr::getTypeConstraint(
+          FirstType.get(), PreviousLoc, new (Context) ErrorTypeRepr(PreviousLoc)));
     } else {
       BodyContext->setTransparent();
       diagnose(Tok, diag::expected_requirement_delim);

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -332,7 +332,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
 
         // If we didn't parse a type, then we already diagnosed that the type
         // was invalid.  Remember that.
-        if (type.isParseError() && !type.hasCodeCompletion())
+        if (type.isNull() && !type.hasCodeCompletion())
           param.isInvalid = true;
       } else if (paramContext != Parser::ParameterContextKind::Closure) {
         diagnose(Tok, diag::expected_parameter_colon);

--- a/test/IDE/complete_where_clause.swift
+++ b/test/IDE/complete_where_clause.swift
@@ -38,6 +38,9 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NOMINAL_TYPEALIAS_NESTED2 | %FileCheck %s -check-prefix=NOMINAL_TYPEALIAS_NESTED2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NOMINAL_TYPEALIAS_NESTED1_EXT | %FileCheck %s -check-prefix=NOMINAL_TYPEALIAS_NESTED1_EXT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NOMINAL_TYPEALIAS_NESTED2_EXT | %FileCheck %s -check-prefix=NOMINAL_TYPEALIAS_NESTED2_EXT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=EXT_ASSOC_MEMBER_1 | %FileCheck %s -check-prefix=EXT_ASSOC_MEMBER
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=EXT_ASSOC_MEMBER_2 | %FileCheck %s -check-prefix=EXT_ASSOC_MEMBER
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=EXT_SECONDTYPE | %FileCheck %s -check-prefix=EXT_SECONDTYPE
 
 class A1<T1, T2, T3> {}
 
@@ -226,3 +229,20 @@ extension TA2.Inner2 where #^NOMINAL_TYPEALIAS_NESTED2_EXT^# {}
 // NOMINAL_TYPEALIAS_NESTED2_EXT-DAG: Decl[TypeAlias]/CurrNominal:        X1[#T#];
 // NOMINAL_TYPEALIAS_NESTED2_EXT-DAG: Decl[TypeAlias]/CurrNominal:        X2[#T.Q#];
 // NOMINAL_TYPEALIAS_NESTED2_EXT: End completions
+
+protocol WithAssoc {
+  associatedtype T: Assoc
+}
+extension WithAssoc where T.#^EXT_ASSOC_MEMBER_1^# 
+// EXT_ASSOC_MEMBER: Begin completions, 2 items
+// EXT_ASSOC_MEMBER-DAG: Decl[AssociatedType]/CurrNominal:   Q;
+// EXT_ASSOC_MEMBER-DAG: Keyword/None:                       Type[#Self.T.Type#];
+// EXT_ASSOC_MEMBER: End completions
+
+extension WithAssoc where Int == T.#^EXT_ASSOC_MEMBER_2^# 
+// Same as EXT_ASSOC_MEMBER
+
+extension WithAssoc where Int == #^EXT_SECONDTYPE^# 
+// EXT_SECONDTYPE: Begin completions
+// EXT_SECONDTYPE-DAG: Decl[AssociatedType]/CurrNominal:   T;
+// EXT_SECONDTYPE: End completions

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -436,7 +436,7 @@ struct ErrorTypeInVarDeclFunctionType1 {
 }
 
 struct ErrorTypeInVarDeclArrayType1 {
-  var v1 : Int[+] // expected-error {{unexpected ']' in type; did you mean to write an array type?}}
+  var v1 : Int[+] // expected-error {{array types are now written with the brackets around the element type}}
   // expected-error @-1 {{expected expression after unary operator}}
   // expected-error @-2 {{expected expression}}
   var v2 : Int
@@ -444,11 +444,14 @@ struct ErrorTypeInVarDeclArrayType1 {
 
 struct ErrorTypeInVarDeclArrayType2 {
   var v1 : Int[+ // expected-error {{unary operator cannot be separated from its operand}}
+                 // expected-error@-1 {{expected ']' in array type}}
+                 // expected-note@-2 {{to match this opening '['}}
   var v2 : Int // expected-error {{expected expression}}
 }
 
 struct ErrorTypeInVarDeclArrayType3 {
-  var v1 : Int[
+  var v1 : Int[ // expected-error {{expected ']' in array type}}
+                // expected-note@-1 {{to match this opening '['}}
   ;  // expected-error {{expected expression}}
   var v2 : Int
 }
@@ -480,8 +483,9 @@ struct ErrorTypeInVarDeclDictionaryType {
 
 struct ErrorInFunctionSignatureResultArrayType1 {
   func foo() -> Int[ { // expected-error {{expected '{' in body of function declaration}}
+                       // expected-note@-1 {{to match this opening '['}}
     return [0]
-  }
+  }  // expected-error {{expected ']' in array type}}
   func bar() -> Int] { // expected-error {{unexpected ']' in type; did you mean to write an array type?}} {{17-17=[}}
     return [0]
   }
@@ -669,10 +673,8 @@ case let (jeb):
 // rdar://19605164
 // expected-error@+2{{use of undeclared type 'S'}}
 struct Foo19605164 {
-func a(s: S[{{g) -> Int {}
-// expected-error@+2 {{expected parameter name followed by ':'}}
-// expected-error@+1 {{expected ',' separator}}
-}}}
+func a(s: S[{{g) -> Int {} // expected-note {{to match this opening '['}}
+}}} // expected-error {{expected ']' in array type}}
 #endif
   
   


### PR DESCRIPTION
Code completion requires the source range of the `where` clause to correctly lookup member of types in where clause.

Resolves #54931
rdar://problem/61911134
