### PR TITLE
Fixes doc comment in UnsafeRawBufferPointer.swift.gyb

### DIFF
--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -79,7 +79,7 @@
 ///     var destBytes = someBytes[0..<n]
 ///
 /// Next, the bytes referenced by `destBytes` are copied into `byteArray`, a
-/// new `[UInt]` array, and then the remainder of `someBytes` is appended to
+/// new `[UInt8]` array, and then the remainder of `someBytes` is appended to
 /// `byteArray`:
 ///
 ///     var byteArray: [UInt8] = Array(destBytes)


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixes doc comment in UnsafeRawBufferPointer.swift.gyb

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
