### PR TITLE
[5.3] WinSDK: add some more constants to the overlay

### DIFF
--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -90,6 +90,18 @@ public let DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2: DPI_AWARENESS_CONTEXT =
 public let DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED: DPI_AWARENESS_CONTEXT =
     DPI_AWARENESS_CONTEXT(bitPattern: -5)!
 
+// winreg.h
+public let HKEY_CLASSES_ROOT: HKEY = HKEY(bitPattern: 0x80000000)!
+public let HKEY_CURRENT_USER: HKEY = HKEY(bitPattern: 0x80000001)!
+public let HKEY_LOCAL_MACHINE: HKEY = HKEY(bitPattern: 0x80000002)!
+public let HKEY_USERS: HKEY = HKEY(bitPattern: 0x80000003)!
+public let HKEY_PERFORMANCE_DATA: HKEY = HKEY(bitPattern: 0x80000004)!
+public let HKEY_PERFORMANCE_TEXT: HKEY = HKEY(bitPattern: 0x80000050)!
+public let HKEY_PERFORMANCE_NLSTEXT: HKEY = HKEY(bitPattern: 0x80000060)!
+public let HKEY_CURRENT_CONFIG: HKEY = HKEY(bitPattern: 0x80000005)!
+public let HKEY_DYN_DATA: HKEY = HKEY(bitPattern: 0x80000006)!
+public let HKEY_CURRENT_USER_LOCAL_SETTINGS: HKEY = HKEY(bitPattern: 0x80000007)!
+
 // Swift Convenience
 public extension FILETIME {
   var time_t: time_t {


### PR DESCRIPTION
The WinReg.h constants for the register hives are not imported through
the clang importer due to the complicated casting.  Duplicate the values
to allow usage in Swift.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
