### PR TITLE
remove last usage of `PYTHON_EXECUTABLE`

### DIFF
--- a/docs/WindowsBuild.md
+++ b/docs/WindowsBuild.md
@@ -107,7 +107,6 @@ cmake -B "S:\b\toolchain" -G Ninja -S S:\toolchain\llvm ^
   -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE="S:/Library/icu-64/usr/include" ^
   -DSWIFT_WINDOWS_x86_64_ICU_I18N="S:/Library/icu-64/usr/lib/icuin64.lib" ^
   -DCMAKE_INSTALL_PREFIX="C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr" ^
-  -DPYTHON_EXECUTABLE=C:\Python27\python.exe ^
   -DSWIFT_BUILD_DYNAMIC_STDLIB=YES ^
   -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
 
@@ -150,7 +149,7 @@ path S:\b\foundation\Foundation;%PATH%
 ## Build swift-corelibs-xctest
 
 ```cmd
-cmake -B S:\b\xctest -G Ninja -S S:\toolchain\swift-corelibs-xctest -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_Swift_COMPILER=S:/b/toolchain/bin/swiftc.exe -Ddispatch_DIR=S:\b\dispatch\cmake\modules -DFoundation_DIR=S:\b\foundation\cmake\modules -DLIT_COMMAND=S:\toolchain\llvm\utils\lit\lit.py -DPYTHON_EXECUTABLE=C:\Python27\python.exe
+cmake -B S:\b\xctest -G Ninja -S S:\toolchain\swift-corelibs-xctest -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_Swift_COMPILER=S:/b/toolchain/bin/swiftc.exe -Ddispatch_DIR=S:\b\dispatch\cmake\modules -DFoundation_DIR=S:\b\foundation\cmake\modules -DLIT_COMMAND=S:\toolchain\llvm\utils\lit\lit.py
 ninja -C S:\b\xctest
 ```
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1032,7 +1032,7 @@ elif run_os in ['windows-msvc']:
         config.environment['PROCESSOR_ARCHITECTURE'] = os.environ['PROCESSOR_ARCHITECTURE']
     if 'PROCESSOR_IDENTIFIER' in os.environ:
         config.environment['PROCESSOR_IDENTIFIER'] = os.environ['PROCESSOR_IDENTIFIER']
-    config.environment['PYTHON_EXECUTABLE'] = sys.executable
+    config.environment['PYTHON'] = sys.executable
     config.target_object_format = 'coff'
     config.target_shared_library_prefix = ''
     config.target_shared_library_suffix = '.dll'

--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -236,7 +236,6 @@ cmake^
     -DSWIFT_ENABLE_SOURCEKIT_TESTS:BOOL=YES^
     -DSWIFT_INSTALL_COMPONENTS="autolink-driver;compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;editor-integration;tools;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers"^
     -DSWIFT_PARALLEL_LINK_JOBS=8^
-    -DPYTHON_EXECUTABLE:PATH=%PYTHON_HOME%\python.exe^
     -DCMAKE_CXX_FLAGS:STRING="/GS- /Oy"^
     -DCMAKE_EXE_LINKER_FLAGS:STRING=/INCREMENTAL:NO^
     -DCMAKE_SHARED_LINKER_FLAGS:STRING=/INCREMENTAL:NO^

--- a/utils/swift_build_support/tests/mock-distcc.cmd
+++ b/utils/swift_build_support/tests/mock-distcc.cmd
@@ -1,3 +1,3 @@
 @ echo off
-IF NOT DEFINED PYTHON_EXECUTABLE SET PYTHON_EXECUTABLE=python
-"%PYTHON_EXECUTABLE%" "%~dp0\mock-distcc" %*
+IF NOT DEFINED PYTHON SET PYTHON=python
+"%PYTHON%" "%~dp0\mock-distcc" %*


### PR DESCRIPTION
With apple/swift-corelibs-xctest#302, the entire Swift toolchain build
should be able to explicitly specify the python executable in use for
each invocation.  This will allow incremental migration to Python3.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
