### PR TITLE
XFAIL test/Interpreter/metadata_access.swift on arm64e

### DIFF
--- a/test/Interpreter/metadata_access.swift
+++ b/test/Interpreter/metadata_access.swift
@@ -5,6 +5,10 @@
 // rdar://61814566
 // XFAIL: use_os_stdlib
 
+// This test uses raw pointers and so fails on arm64e which authenticates some
+// pointers.
+// XFAIL: arm64e
+
 import SwiftShims
 
 struct MetadataAccessFunction {


### PR DESCRIPTION
The test manipulates raw pointers some of which might be signed and therefore it fails on arm64e
