### PR TITLE
[Property Wrappers] Only re-write assign_by_wrapper to assignment if all fields have been initialized.

### DIFF
--- a/test/SILOptimizer/di_property_wrappers.swift
+++ b/test/SILOptimizer/di_property_wrappers.swift
@@ -501,6 +501,37 @@ public final class Synchronized<Value> {
   }
 }
 
+struct SR_12341 {
+  @Wrapper var wrapped: Int = 10
+  var str: String
+
+  init() {
+     wrapped = 42
+     str = ""
+     wrapped = 27
+  }
+
+  init(condition: Bool) {
+    wrapped = 42
+    wrapped = 27
+    str = ""
+  }
+}
+
+func testSR_12341() {
+  // CHECK: ## SR_12341
+  print("\n## SR_12341")
+
+  // CHECK-NEXT:   .. init 10
+  // CHECK-NEXT:   .. init 42
+  // CHECK-NEXT:   .. set 27
+  _ = SR_12341()
+
+  // CHECK-NEXT:   .. init 10
+  // CHECK-NEXT:   .. init 42
+  // CHECK-NEXT:   .. init 27
+  _ = SR_12341(condition: true)
+}
 
 testIntStruct()
 testIntClass()
@@ -511,3 +542,4 @@ testOptIntStruct()
 testDefaultNilOptIntStruct()
 testComposed()
 testWrapperInitWithDefaultArg()
+testSR_12341()


### PR DESCRIPTION
Otherwise, the wrapped property's setter will be called with the potential to access uninitialized memory via observers.

Resolves: rdar://problem/60832285, rdar://problem/58312953
Resolves: [SR-12341](https://bugs.swift.org/browse/SR-12341)
