### PR TITLE
[prespecialized metadata] Allow existentials as generic arguments.

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -770,12 +770,11 @@ bool irgen::isNominalGenericContextTypeMetadataAccessTrivial(
       return genericArgument && genericArgument->isGenericContext() && 
         (protocols.size() > 0);
     };
-    auto isExistential = [&]() { return argument->isExistentialType(); };
     auto metadataAccessIsTrivial = [&]() {
       return irgen::isCompleteTypeMetadataStaticallyAddressable(IGM,
                                                 argument->getCanonicalType());
     };
-    return !isGenericWithoutPrespecializedConformance() && !isExistential() && 
+    return !isGenericWithoutPrespecializedConformance() &&
            metadataAccessIsTrivial() && witnessTablesAreReferenceable();
   });
   return allWitnessTablesAreReferenceable


### PR DESCRIPTION
Previously, metadata prespecialization was not done when generic arguments were existential types.  Here, that restriction is lifted.