### PR TITLE
Strip TypeExpr of its TypeLoc

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1359,9 +1359,10 @@ public:
 
   
   /// Create a TypeExpr for a TypeDecl at the specified location.
-  static TypeExpr *createForDecl(DeclNameLoc Loc, TypeDecl *D,
-                                 DeclContext *DC,
-                                 bool isImplicit);
+  static TypeExpr *createForDecl(DeclNameLoc Loc, TypeDecl *D, DeclContext *DC);
+
+  static TypeExpr *createImplicitForDecl(DeclNameLoc Loc, TypeDecl *D,
+                                         DeclContext *DC, Type ty);
 
   /// Create a TypeExpr for a member TypeDecl of the given parent TypeDecl.
   static TypeExpr *createForMemberDecl(DeclNameLoc ParentNameLoc,

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1331,13 +1331,13 @@ public:
   }
 };
 
-/// A reference to a type in expression context, spelled out as a TypeLoc.
+/// A reference to a type in expression context.
 ///
-/// The type of this expression is always \c MetaTypeType.
+/// The type of this expression is always \c MetatypeType.
 class TypeExpr : public Expr {
   TypeRepr *Repr;
 public:
-  // Create a TypeExpr with location information.
+  /// Create a \c TypeExpr from a parsed \c TypeRepr.
   TypeExpr(TypeRepr *Ty);
 
   /// Retrieves the corresponding instance type of the type referenced by this
@@ -1348,20 +1348,46 @@ public:
   /// resulting instance type is \c ErrorType.
   Type getInstanceType() const;
 
-  // Create an implicit TypeExpr, which has no location information.
+public:
+  /// Create an implicit \c TypeExpr.
+  ///
+  /// The given type is required to be non-null and must be not be
+  /// a \c MetatypeType as this function will wrap the given type in one.
+  ///
+  /// FIXME: This behavior is bizarre.
   static TypeExpr *createImplicit(Type Ty, ASTContext &C);
 
-  // Create an implicit TypeExpr, with location information even though it
-  // shouldn't have one.  This is presently used to work around other location
-  // processing bugs.  If you have an implicit location, use createImplicit.
+  /// Create an implicit \c TypeExpr that has artificial
+  /// location information attached.
+  ///
+  /// The given type is required to be non-null and must be not be
+  /// a \c MetatypeType as this function will wrap the given type in one.
+  ///
+  /// FIXME: This behavior is bizarre.
+  ///
+  /// Due to limitations in the modeling of certain AST elements, implicit
+  /// \c TypeExpr nodes are often the only source of location information the
+  /// expression checker has when it comes time to diagnose an error.
   static TypeExpr *createImplicitHack(SourceLoc Loc, Type Ty, ASTContext &C);
 
-  
-  /// Create a TypeExpr for a TypeDecl at the specified location.
-  static TypeExpr *createForDecl(DeclNameLoc Loc, TypeDecl *D, DeclContext *DC);
-
+  /// Create an implicit \c TypeExpr for a given \c TypeDecl at the specified location.
+  ///
+  /// The given type is required to be non-null and must be not be
+  /// a \c MetatypeType as this function will wrap the given type in one.
+  ///
+  /// FIXME: This behavior is bizarre.
+  ///
+  /// Unlike the non-implicit case, the given location is not required to be
+  /// valid.
   static TypeExpr *createImplicitForDecl(DeclNameLoc Loc, TypeDecl *D,
                                          DeclContext *DC, Type ty);
+
+public:
+  /// Create a \c TypeExpr for a given \c TypeDecl at the specified location.
+  ///
+  /// The given location must be valid. If it is not, you must use
+  /// \c TypeExpr::createImplicitForDecl instead.
+  static TypeExpr *createForDecl(DeclNameLoc Loc, TypeDecl *D, DeclContext *DC);
 
   /// Create a TypeExpr for a member TypeDecl of the given parent TypeDecl.
   static TypeExpr *createForMemberDecl(DeclNameLoc ParentNameLoc,

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -497,9 +497,7 @@ public:
   bool isImplicit() const {
     return Bits.Expr.Implicit;
   }
-  void setImplicit(bool Implicit = true) {
-    Bits.Expr.Implicit = Implicit;
-  }
+  void setImplicit(bool Implicit = true);
 
   /// Retrieves the declaration that is being referenced by this
   /// expression, if any.
@@ -1337,11 +1335,10 @@ public:
 ///
 /// The type of this expression is always \c MetaTypeType.
 class TypeExpr : public Expr {
-  TypeLoc Info;
-  TypeExpr(Type Ty);
+  TypeRepr *Repr;
 public:
   // Create a TypeExpr with location information.
-  TypeExpr(TypeLoc Ty);
+  TypeExpr(TypeRepr *Ty);
 
   // The type of a TypeExpr is always a metatype type.  Return the instance
   // type, ErrorType if an error, or null if not set yet.
@@ -1353,9 +1350,7 @@ public:
                        }) const;
 
   // Create an implicit TypeExpr, which has no location information.
-  static TypeExpr *createImplicit(Type Ty, ASTContext &C) {
-    return new (C) TypeExpr(Ty);
-  }
+  static TypeExpr *createImplicit(Type Ty, ASTContext &C);
 
   // Create an implicit TypeExpr, with location information even though it
   // shouldn't have one.  This is presently used to work around other location
@@ -1389,13 +1384,11 @@ public:
                                             SourceRange AngleLocs,
                                             ASTContext &C);
 
-  TypeLoc &getTypeLoc() { return Info; }
-  TypeLoc getTypeLoc() const { return Info; }
-  TypeRepr *getTypeRepr() const { return Info.getTypeRepr(); }
+  TypeRepr *getTypeRepr() const { return Repr; }
   // NOTE: TypeExpr::getType() returns the type of the expr node, which is the
   // metatype of what is stored as an operand type.
   
-  SourceRange getSourceRange() const { return Info.getSourceRange(); }
+  SourceRange getSourceRange() const { return TypeLoc(Repr).getSourceRange(); }
   // TODO: optimize getStartLoc() and getEndLoc() when TypeLoc allows it.
 
   static bool classof(const Expr *E) {

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4490,8 +4490,7 @@ class ExplicitCastExpr : public Expr {
   TypeLoc CastTy;
 
 protected:
-  ExplicitCastExpr(ExprKind kind, Expr *sub, SourceLoc AsLoc, TypeLoc castTy,
-                   Type resultTy)
+  ExplicitCastExpr(ExprKind kind, Expr *sub, SourceLoc AsLoc, TypeLoc castTy)
     : Expr(kind, /*Implicit=*/false), SubExpr(sub), AsLoc(AsLoc), CastTy(castTy)
   {}
 
@@ -4547,8 +4546,8 @@ StringRef getCheckedCastKindName(CheckedCastKind kind);
 class CheckedCastExpr : public ExplicitCastExpr {
 public:
   CheckedCastExpr(ExprKind kind,
-                  Expr *sub, SourceLoc asLoc, TypeLoc castTy, Type resultTy)
-    : ExplicitCastExpr(kind, sub, asLoc, castTy, resultTy)
+                  Expr *sub, SourceLoc asLoc, TypeLoc castTy)
+    : ExplicitCastExpr(kind, sub, asLoc, castTy)
   {
     Bits.CheckedCastExpr.CastKind = unsigned(CheckedCastKind::Unresolved);
   }
@@ -4583,7 +4582,7 @@ public:
   ForcedCheckedCastExpr(Expr *sub, SourceLoc asLoc, SourceLoc exclaimLoc,
                         TypeLoc type)
     : CheckedCastExpr(ExprKind::ForcedCheckedCast,
-                      sub, asLoc, type, type.getType()),
+                      sub, asLoc, type),
       ExclaimLoc(exclaimLoc)
   {
   }
@@ -4612,7 +4611,7 @@ public:
   ConditionalCheckedCastExpr(Expr *sub, SourceLoc asLoc, SourceLoc questionLoc,
                              TypeLoc type)
     : CheckedCastExpr(ExprKind::ConditionalCheckedCast,
-                      sub, asLoc, type, type.getType()),
+                      sub, asLoc, type),
       QuestionLoc(questionLoc)
   { }
   
@@ -4637,8 +4636,7 @@ public:
 class IsExpr : public CheckedCastExpr {
 public:
   IsExpr(Expr *sub, SourceLoc isLoc, TypeLoc type)
-    : CheckedCastExpr(ExprKind::Is,
-                      sub, isLoc, type, Type())
+    : CheckedCastExpr(ExprKind::Is, sub, isLoc, type)
   {}
   
   IsExpr(SourceLoc isLoc, TypeLoc type)
@@ -4661,7 +4659,7 @@ class CoerceExpr : public ExplicitCastExpr {
 
 public:
   CoerceExpr(Expr *sub, SourceLoc asLoc, TypeLoc type)
-    : ExplicitCastExpr(ExprKind::Coerce, sub, asLoc, type, type.getType())
+    : ExplicitCastExpr(ExprKind::Coerce, sub, asLoc, type)
   { }
 
   CoerceExpr(SourceLoc asLoc, TypeLoc type)
@@ -4671,7 +4669,7 @@ public:
 private:
   CoerceExpr(SourceRange initRange, Expr *literal, TypeLoc type)
     : ExplicitCastExpr(ExprKind::Coerce, literal, initRange.Start,
-                       type, type.getType()), InitRangeEnd(initRange.End)
+                       type), InitRangeEnd(initRange.End)
   { setImplicit(); }
 
 public:

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1340,14 +1340,13 @@ public:
   // Create a TypeExpr with location information.
   TypeExpr(TypeRepr *Ty);
 
-  // The type of a TypeExpr is always a metatype type.  Return the instance
-  // type, ErrorType if an error, or null if not set yet.
-  Type getInstanceType(llvm::function_ref<bool(const Expr *)> hasType =
-                           [](const Expr *E) -> bool { return !!E->getType(); },
-                       llvm::function_ref<Type(const Expr *)> getType =
-                           [](const Expr *E) -> Type {
-                         return E->getType();
-                       }) const;
+  /// Retrieves the corresponding instance type of the type referenced by this
+  /// expression.
+  ///
+  /// If this node has no type, the resulting instance type is also the
+  /// null \c Type(). If the type of this node is not a \c MetatypeType, the
+  /// resulting instance type is \c ErrorType.
+  Type getInstanceType() const;
 
   // Create an implicit TypeExpr, which has no location information.
   static TypeExpr *createImplicit(Type Ty, ASTContext &C);
@@ -1389,7 +1388,7 @@ public:
   // NOTE: TypeExpr::getType() returns the type of the expr node, which is the
   // metatype of what is stored as an operand type.
   
-  SourceRange getSourceRange() const { return TypeLoc(Repr).getSourceRange(); }
+  SourceRange getSourceRange() const;
   // TODO: optimize getStartLoc() and getEndLoc() when TypeLoc allows it.
 
   static bool classof(const Expr *E) {

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -481,8 +481,9 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   Expr *visitDiscardAssignmentExpr(DiscardAssignmentExpr *E) { return E; }
   Expr *visitTypeExpr(TypeExpr *E) {
     if (!E->isImplicit())
-      if (doIt(E->getTypeLoc()))
-        return nullptr;
+      if (auto *typerepr = E->getTypeRepr())
+        if (doIt(typerepr))
+          return nullptr;
 
     return E;
   }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1950,19 +1950,25 @@ Type TypeExpr::getInstanceType(
   return ErrorType::get(getType(this)->getASTContext());
 }
 
-
 TypeExpr *TypeExpr::createForDecl(DeclNameLoc Loc, TypeDecl *Decl,
-                                  DeclContext *DC,
-                                  bool isImplicit) {
+                                  DeclContext *DC) {
   ASTContext &C = Decl->getASTContext();
-  assert(Loc.isValid() || isImplicit);
+  assert(Loc.isValid());
   auto *Repr = new (C) SimpleIdentTypeRepr(Loc, Decl->createNameRef());
   Repr->setValue(Decl, DC);
   auto result = new (C) TypeExpr(Repr);
-  if (isImplicit) {
-    result->setType(DC->mapTypeIntoContext(Decl->getInterfaceType()));
-    result->setImplicit();
-  }
+  return result;
+}
+
+TypeExpr *TypeExpr::createImplicitForDecl(DeclNameLoc Loc, TypeDecl *Decl,
+                                          DeclContext *DC, Type ty) {
+  ASTContext &C = Decl->getASTContext();
+  auto *Repr = new (C) SimpleIdentTypeRepr(Loc, Decl->createNameRef());
+  Repr->setValue(Decl, DC);
+  auto result = new (C) TypeExpr(Repr);
+  assert(ty && !ty->hasTypeParameter());
+  result->setType(ty);
+  result->setImplicit();
   return result;
 }
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -130,6 +130,12 @@ void Expr::setType(Type T) {
   Ty = T;
 }
 
+void Expr::setImplicit(bool Implicit) {
+  assert(!isa<TypeExpr>(this) || getType() &&
+         "Cannot make a TypeExpr implicit without a contextual type.");
+  Bits.Expr.Implicit = Implicit;
+}
+
 template <class T> static SourceRange getSourceRangeImpl(const T *E) {
   static_assert(isOverriddenFromExpr(&T::getSourceRange) ||
                 (isOverriddenFromExpr(&T::getStartLoc) &&
@@ -936,8 +942,9 @@ static void
 computeSingleArgumentType(ASTContext &ctx, Expr *arg, bool implicit,
                           llvm::function_ref<Type(const Expr *)> getType) {
   // Propagate 'implicit' to the argument.
-  if (implicit)
+  if (implicit) {
     arg->setImplicit(true);
+  }
 
   // Handle parenthesized expressions.
   if (auto paren = dyn_cast<ParenExpr>(arg)) {
@@ -1918,17 +1925,15 @@ Expr *AutoClosureExpr::getUnwrappedCurryThunkExpr() const {
 
 FORWARD_SOURCE_LOCS_TO(UnresolvedPatternExpr, subPattern)
 
-TypeExpr::TypeExpr(TypeLoc TyLoc)
-  : Expr(ExprKind::Type, /*implicit*/false), Info(TyLoc) {
-  Type Ty = TyLoc.getType();
-  if (Ty && Ty->hasCanonicalTypeComputed())
-    setType(MetatypeType::get(Ty, Ty->getASTContext()));
-}
+TypeExpr::TypeExpr(TypeRepr *Repr)
+  : Expr(ExprKind::Type, /*implicit*/false), Repr(Repr) {}
 
-TypeExpr::TypeExpr(Type Ty)
-  : Expr(ExprKind::Type, /*implicit*/true), Info(TypeLoc::withoutLoc(Ty)) {
-  if (Ty->hasCanonicalTypeComputed())
-    setType(MetatypeType::get(Ty, Ty->getASTContext()));
+TypeExpr *TypeExpr::createImplicit(Type Ty, ASTContext &C) {
+  assert(Ty);
+  auto *result = new (C) TypeExpr(nullptr);
+  result->setType(MetatypeType::get(Ty, Ty->getASTContext()));
+  result->setImplicit();
+  return result;
 }
 
 // The type of a TypeExpr is always a metatype type.  Return the instance
@@ -1953,9 +1958,11 @@ TypeExpr *TypeExpr::createForDecl(DeclNameLoc Loc, TypeDecl *Decl,
   assert(Loc.isValid() || isImplicit);
   auto *Repr = new (C) SimpleIdentTypeRepr(Loc, Decl->createNameRef());
   Repr->setValue(Decl, DC);
-  auto result = new (C) TypeExpr(TypeLoc(Repr, Type()));
-  if (isImplicit)
+  auto result = new (C) TypeExpr(Repr);
+  if (isImplicit) {
+    result->setType(DC->mapTypeIntoContext(Decl->getInterfaceType()));
     result->setImplicit();
+  }
   return result;
 }
 
@@ -1983,7 +1990,7 @@ TypeExpr *TypeExpr::createForMemberDecl(DeclNameLoc ParentNameLoc,
   Components.push_back(NewComp);
 
   auto *NewTypeRepr = IdentTypeRepr::create(C, Components);
-  return new (C) TypeExpr(TypeLoc(NewTypeRepr, Type()));
+  return new (C) TypeExpr(NewTypeRepr);
 }
 
 TypeExpr *TypeExpr::createForMemberDecl(IdentTypeRepr *ParentTR,
@@ -2004,7 +2011,7 @@ TypeExpr *TypeExpr::createForMemberDecl(IdentTypeRepr *ParentTR,
   Components.push_back(NewComp);
 
   auto *NewTypeRepr = IdentTypeRepr::create(C, Components);
-  return new (C) TypeExpr(TypeLoc(NewTypeRepr, Type()));
+  return new (C) TypeExpr(NewTypeRepr);
 }
 
 TypeExpr *TypeExpr::createForSpecializedDecl(IdentTypeRepr *ParentTR,
@@ -2053,7 +2060,7 @@ TypeExpr *TypeExpr::createForSpecializedDecl(IdentTypeRepr *ParentTR,
     components.push_back(genericComp);
 
     auto *genericRepr = IdentTypeRepr::create(C, components);
-    return new (C) TypeExpr(TypeLoc(genericRepr, Type()));
+    return new (C) TypeExpr(genericRepr);
   }
 
   return nullptr;
@@ -2064,11 +2071,12 @@ TypeExpr *TypeExpr::createForSpecializedDecl(IdentTypeRepr *ParentTR,
 // processing bugs.  If you have an implicit location, use createImplicit.
 TypeExpr *TypeExpr::createImplicitHack(SourceLoc Loc, Type Ty, ASTContext &C) {
   // FIXME: This is horrible.
+  assert(Ty);
   if (Loc.isInvalid()) return createImplicit(Ty, C);
   auto *Repr = new (C) FixedTypeRepr(Ty, Loc);
-  auto *Res = new (C) TypeExpr(TypeLoc(Repr, Ty));
-  Res->setImplicit();
+  auto *Res = new (C) TypeExpr(Repr);
   Res->setType(MetatypeType::get(Ty, C));
+  Res->setImplicit();
   return Res;
 }
 

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -375,8 +375,8 @@ static void collectPossibleCalleesByQualifiedLookup(
   // Re-typecheck TypeExpr so it's typechecked without the arguments which may
   // affects the inference of the generic arguments.
   if (TypeExpr *tyExpr = dyn_cast<TypeExpr>(baseExpr)) {
-    tyExpr->setType(nullptr);
-    tyExpr->getTypeLoc().setType(nullptr);
+    if (!tyExpr->isImplicit())
+      tyExpr->setType(nullptr);
   }
 
   auto baseTyOpt = getTypeOfCompletionContextExpr(

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -395,7 +395,7 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
       ParserResult<TypeRepr> ty = parseType();
       if (ty.isNonNull())
         return makeParserResult(
-            new (Context) TypeExpr(TypeLoc(ty.get(), Type())));
+            new (Context) TypeExpr(ty.get()));
       checkForInputIncomplete();
       return nullptr;
     }
@@ -1534,7 +1534,7 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
   case tok::kw_Any: { // Any
     ExprContext.setCreateSyntax(SyntaxKind::TypeExpr);
     auto TyR = parseAnyType();
-    return makeParserResult(new (Context) TypeExpr(TypeLoc(TyR.get())));
+    return makeParserResult(new (Context) TypeExpr(TyR.get()));
   }
 
   case tok::dollarident: // $1

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2306,7 +2306,7 @@ Expr *Parser::parseExprIdentifier() {
     // global or local declarations here.
     assert(!TD->getDeclContext()->isTypeContext() ||
            isa<GenericTypeParamDecl>(TD));
-    E = TypeExpr::createForDecl(loc, TD, /*DC*/nullptr, /*implicit*/false);
+    E = TypeExpr::createForDecl(loc, TD, /*DC*/ nullptr);
   } else {
     E = new (Context) DeclRefExpr(D, loc, /*Implicit=*/false);
   }

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -73,25 +73,26 @@ class BuilderClosureVisitor
     if (!cs)
       return nullptr;
 
-    // FIXME: Setting a TypeLoc on this expression is necessary in order
+    // FIXME: Setting a base on this expression is necessary in order
     // to get diagnostics if something about this builder call fails,
     // e.g. if there isn't a matching overload for `buildBlock`.
-    // But we can only do this if there isn't a type variable in the type.
-    TypeLoc typeLoc;
-    if (!builderType->hasTypeVariable()) {
-      typeLoc = TypeLoc(new (ctx) FixedTypeRepr(builderType, loc), builderType);
+    TypeExpr *typeExpr;
+    auto simplifiedTy = cs->simplifyType(builderType);
+    if (!simplifiedTy->hasTypeVariable()) {
+      typeExpr = TypeExpr::createImplicitHack(loc, simplifiedTy, ctx);
+    } else {
+      // HACK: If there's not enough information in the constraint system,
+      // create a garbage base type to force it to diagnose
+      // this as an ambiguous expression.
+      typeExpr = TypeExpr::createImplicitHack(loc, ErrorType::get(ctx), ctx);
     }
-
-    auto typeExpr = new (ctx) TypeExpr(typeLoc);
     cs->setType(typeExpr, MetatypeType::get(builderType));
-    cs->setType(&typeExpr->getTypeLoc(), builderType);
 
     SmallVector<SourceLoc, 4> argLabelLocs;
     for (auto i : indices(argLabels)) {
       argLabelLocs.push_back(args[i]->getStartLoc());
     }
 
-    typeExpr->setImplicit();
     auto memberRef = new (ctx) UnresolvedDotExpr(
         typeExpr, loc, DeclNameRef(fnName), DeclNameLoc(loc),
         /*implicit=*/true);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -183,8 +183,13 @@ bool ConstraintSystem::isStaticallyDerivedMetatype(const Expr *E) {
 }
 
 Type ConstraintSystem::getInstanceType(const TypeExpr *E) {
-  return E->getInstanceType([&](const Expr *E) -> bool { return hasType(E); },
-                            [&](const Expr *E) -> Type { return getType(E); });
+  if (!hasType(E))
+    return Type();
+
+  if (auto metaType = getType(E)->getAs<MetatypeType>())
+    return metaType->getInstanceType();
+
+  return ErrorType::get(getType(E)->getASTContext());
 }
 
 Type ConstraintSystem::getResultType(const AbstractClosureExpr *E) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2650,9 +2650,9 @@ namespace {
     }
 
     Expr *visitTypeExpr(TypeExpr *expr) {
-      auto toType = simplifyType(cs.getType(expr->getTypeLoc()));
-      expr->getTypeLoc().setType(toType);
-      cs.setType(expr, MetatypeType::get(toType));
+      auto toType = simplifyType(cs.getType(expr));
+      assert(toType->is<MetatypeType>());
+      cs.setType(expr, toType);
       return expr;
     }
 
@@ -3887,16 +3887,14 @@ namespace {
             if (!TE)
               return subExpr;
 
-            auto type = TE->getInstanceType(
-                [&](const Expr *expr) { return cs.hasType(expr); },
-                [&](const Expr *expr) { return cs.getType(expr); });
+            auto type = cs.getInstanceType(TE);
 
             assert(!type->hasError());
 
             if (!type->isEqual(toType))
               return subExpr;
 
-            return cs.cacheType(new (ctx) TypeExpr(expr->getCastTypeLoc()));
+            return cs.cacheType(TypeExpr::createImplicitHack(expr->getLoc(), toType, ctx));
           });
         }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1043,7 +1043,7 @@ namespace {
       // reference.
       if (auto *TD = dyn_cast<TypeDecl>(member)) {
         Type refType = simplifyType(openedType);
-        auto ref = TypeExpr::createForDecl(memberLoc, TD, cs.DC, /*isImplicit=*/false);
+        auto ref = TypeExpr::createForDecl(memberLoc, TD, cs.DC);
         cs.setType(ref, refType);
         auto *result = new (context) DotSyntaxBaseIgnoredExpr(
             base, dotLoc, ref, refType);

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5163,7 +5163,7 @@ bool MissingGenericArgumentsFailure::findArgumentLocations(
 
   TypeLoc typeLoc;
   if (auto *TE = getAsExpr<TypeExpr>(anchor))
-    typeLoc = TE->getTypeLoc();
+    typeLoc = TE->getTypeRepr();
   else if (auto *ECE = getAsExpr<ExplicitCastExpr>(anchor))
     typeLoc = ECE->getCastTypeLoc();
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1461,20 +1461,19 @@ namespace {
     Type visitTypeExpr(TypeExpr *E) {
       Type type;
       // If this is an implicit TypeExpr, don't validate its contents.
-      auto &typeLoc = E->getTypeLoc();
-      if (typeLoc.wasValidated()) {
-        type = typeLoc.getType();
-      } else if (typeLoc.hasLocation()) {
-        type = resolveTypeReferenceInExpression(typeLoc);
-      } else if (E->isImplicit() && CS.hasType(&typeLoc)) {
-        type = CS.getType(typeLoc);
+      if (E->isImplicit()) {
+        type = CS.getInstanceType(CS.cacheType(E));
+        assert(type && "Implicit type expr must have type set!");
+      } else {
+        auto *repr = E->getTypeRepr();
+        assert(repr && "Explicit node has no type repr!");
+        type = resolveTypeReferenceInExpression(repr);
       }
 
       if (!type || type->hasError()) return Type();
       
       auto locator = CS.getConstraintLocator(E);
       type = CS.openUnboundGenericType(type, locator);
-      CS.setType(E->getTypeLoc(), type);
       return MetatypeType::get(type);
     }
 
@@ -4022,11 +4021,11 @@ namespace {
             // result of the join.
             auto joinMetaTy =
                 CG.resultOfTypeOperation(typeOperation, apply->getArg());
-            auto joinTy = joinMetaTy->castTo<MetatypeType>()->getInstanceType();
+            auto joinTy = joinMetaTy->castTo<MetatypeType>();
 
-            auto *TE = TypeExpr::createImplicit(joinTy, CS.getASTContext());
+            auto *TE = TypeExpr::createImplicit(joinTy->getInstanceType(),
+                                                CS.getASTContext());
             CS.cacheType(TE);
-            CS.setType(TE->getTypeLoc(), joinTy);
 
             auto *DSE = new (CS.getASTContext())
                 DotSelfExpr(TE, SourceLoc(), SourceLoc(), CS.getType(TE));

--- a/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
@@ -93,8 +93,9 @@ deriveBodyMathOperator(AbstractFunctionDecl *funcDecl, MathOperator op) {
   auto *initDRE =
       new (C) DeclRefExpr(memberwiseInitDecl, DeclNameLoc(), /*Implicit*/ true);
   initDRE->setFunctionRefKind(FunctionRefKind::SingleApply);
-  auto *nominalTypeExpr = TypeExpr::createForDecl(DeclNameLoc(), nominal,
-                                                  funcDecl, /*Implicit*/ true);
+  auto *nominalTypeExpr = TypeExpr::createImplicitForDecl(
+      DeclNameLoc(), nominal, funcDecl,
+      funcDecl->mapTypeIntoContext(nominal->getInterfaceType()));
   auto *initExpr = new (C) ConstructorRefCallExpr(initDRE, nominalTypeExpr);
 
   // Get operator protocol requirement.
@@ -223,8 +224,9 @@ deriveBodyPropertyGetter(AbstractFunctionDecl *funcDecl, ProtocolDecl *proto,
       new (C) DeclRefExpr(memberwiseInitDecl, DeclNameLoc(), /*Implicit*/ true);
   initDRE->setFunctionRefKind(FunctionRefKind::SingleApply);
 
-  auto *nominalTypeExpr = TypeExpr::createForDecl(DeclNameLoc(), nominal,
-                                                  funcDecl, /*Implicit*/ true);
+  auto *nominalTypeExpr = TypeExpr::createImplicitForDecl(
+      DeclNameLoc(), nominal, funcDecl,
+      funcDecl->mapTypeIntoContext(nominal->getInterfaceType()));
   auto *initExpr = new (C) ConstructorRefCallExpr(initDRE, nominalTypeExpr);
 
   auto createMemberPropertyExpr = [&](VarDecl *member) -> Expr * {

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -470,7 +470,7 @@ static CallExpr *createContainerKeyedByCall(ASTContext &C, DeclContext *DC,
   // CodingKeys.self expr
   auto *codingKeysExpr = TypeExpr::createForDecl(DeclNameLoc(),
                                                  param,
-                                                 param->getDeclContext(),
+                                                 DC,
                                                  /*Implicit=*/true);
   auto *codingKeysMetaTypeExpr = new (C) DotSelfExpr(codingKeysExpr,
                                                      SourceLoc(), SourceLoc());

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -468,10 +468,9 @@ static CallExpr *createContainerKeyedByCall(ASTContext &C, DeclContext *DC,
                                                         paramList);
 
   // CodingKeys.self expr
-  auto *codingKeysExpr = TypeExpr::createForDecl(DeclNameLoc(),
-                                                 param,
-                                                 DC,
-                                                 /*Implicit=*/true);
+  auto *codingKeysExpr = TypeExpr::createImplicitForDecl(
+      DeclNameLoc(), param, param->getDeclContext(),
+      DC->mapTypeIntoContext(param->getInterfaceType()));
   auto *codingKeysMetaTypeExpr = new (C) DotSelfExpr(codingKeysExpr,
                                                      SourceLoc(), SourceLoc());
 

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -42,8 +42,9 @@ deriveBodyBridgedNSError_enum_nsErrorDomain(AbstractFunctionDecl *domainDecl,
   auto self = domainDecl->getImplicitSelfDecl();
 
   auto selfRef = new (C) DeclRefExpr(self, DeclNameLoc(), /*implicit*/ true);
-  auto stringType = TypeExpr::createForDecl(DeclNameLoc(), C.getStringDecl(),
-                                            domainDecl, /*implicit*/ true);
+  auto stringType = TypeExpr::createImplicitForDecl(
+      DeclNameLoc(), C.getStringDecl(), domainDecl,
+      C.getStringDecl()->getInterfaceType());
   auto initReflectingCall =
     CallExpr::createImplicit(C, stringType,
                              { selfRef }, { C.getIdentifier("reflecting") });

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -550,8 +550,8 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
           if (typeContext->getSelfClassDecl())
             SelfType = DynamicSelfType::get(SelfType, Context);
           SelfType = DC->mapTypeIntoContext(SelfType);
-          return new (Context) TypeExpr(TypeLoc(new (Context)
-                                                FixedTypeRepr(SelfType, Loc)));
+          return new (Context)
+              TypeExpr(new (Context) FixedTypeRepr(SelfType, Loc));
         }
       }
 
@@ -644,9 +644,14 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
                                        D->getInterfaceType());
     }
 
-    return TypeExpr::createForDecl(UDRE->getNameLoc(), D,
-                                   Lookup[0].getDeclContext(),
-                                   UDRE->isImplicit());
+    auto *LookupDC = Lookup[0].getDeclContext();
+    if (UDRE->isImplicit()) {
+      return TypeExpr::createImplicitForDecl(
+          UDRE->getNameLoc(), D, LookupDC,
+          LookupDC->mapTypeIntoContext(D->getInterfaceType()));
+    } else {
+      return TypeExpr::createForDecl(UDRE->getNameLoc(), D, LookupDC);
+    }
   }
 
   if (AllDeclRefs) {
@@ -715,13 +720,15 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
   if (AllMemberRefs) {
     Expr *BaseExpr;
     if (auto PD = dyn_cast<ProtocolDecl>(Base)) {
-      BaseExpr = TypeExpr::createForDecl(UDRE->getNameLoc(),
-                                         PD->getGenericParams()->getParams().front(),
-                                         /*DC*/nullptr,
-                                         /*isImplicit=*/true);
+      auto selfParam = PD->getGenericParams()->getParams().front();
+      BaseExpr = TypeExpr::createImplicitForDecl(
+          UDRE->getNameLoc(), selfParam,
+          /*DC*/ nullptr,
+          DC->mapTypeIntoContext(selfParam->getInterfaceType()));
     } else if (auto NTD = dyn_cast<NominalTypeDecl>(Base)) {
-      BaseExpr = TypeExpr::createForDecl(UDRE->getNameLoc(), NTD, BaseDC,
-                                         /*isImplicit=*/true);
+      BaseExpr = TypeExpr::createImplicitForDecl(
+          UDRE->getNameLoc(), NTD, BaseDC,
+          DC->mapTypeIntoContext(NTD->getInterfaceType()));
     } else {
       BaseExpr = new (Context) DeclRefExpr(Base, UDRE->getNameLoc(),
                                            /*Implicit=*/true);
@@ -1383,7 +1390,7 @@ TypeExpr *PreCheckExpression::simplifyNestedTypeExpr(UnresolvedDotExpr *UDE) {
   if (Name.isSimpleName(getASTContext().Id_Protocol)) {
     auto *NewTypeRepr =
         new (getASTContext()) ProtocolTypeRepr(InnerTypeRepr, NameLoc);
-    return new (getASTContext()) TypeExpr(TypeLoc(NewTypeRepr, Type()));
+    return new (getASTContext()) TypeExpr(NewTypeRepr);
   }
 
   // Fold 'T.Type' into an existential metatype if 'T' is a protocol,
@@ -1391,7 +1398,7 @@ TypeExpr *PreCheckExpression::simplifyNestedTypeExpr(UnresolvedDotExpr *UDE) {
   if (Name.isSimpleName(getASTContext().Id_Type)) {
     auto *NewTypeRepr =
         new (getASTContext()) MetatypeTypeRepr(InnerTypeRepr, NameLoc);
-    return new (getASTContext()) TypeExpr(TypeLoc(NewTypeRepr, Type()));
+    return new (getASTContext()) TypeExpr(NewTypeRepr);
   }
 
   // Fold 'T.U' into a nested type.
@@ -1486,7 +1493,7 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
 
     auto *NewTypeRepr =
         new (getASTContext()) OptionalTypeRepr(InnerTypeRepr, QuestionLoc);
-    return new (getASTContext()) TypeExpr(TypeLoc(NewTypeRepr, Type()));
+    return new (getASTContext()) TypeExpr(NewTypeRepr);
   }
 
   // Fold T! into an IUO type when T is a TypeExpr.
@@ -1502,7 +1509,7 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
     auto *NewTypeRepr = new (getASTContext())
         ImplicitlyUnwrappedOptionalTypeRepr(InnerTypeRepr,
                                             FVE->getExclaimLoc());
-    return new (getASTContext()) TypeExpr(TypeLoc(NewTypeRepr, Type()));
+    return new (getASTContext()) TypeExpr(NewTypeRepr);
   }
 
   // Fold (T) into a type T with parens around it.
@@ -1517,7 +1524,7 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
 
     auto *NewTypeRepr = TupleTypeRepr::create(getASTContext(), InnerTypeRepr,
                                               PE->getSourceRange());
-    return new (getASTContext()) TypeExpr(TypeLoc(NewTypeRepr, Type()));
+    return new (getASTContext()) TypeExpr(NewTypeRepr);
   }
   
   // Fold a tuple expr like (T1,T2) into a tuple type (T1,T2).
@@ -1550,7 +1557,7 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
     }
     auto *NewTypeRepr = TupleTypeRepr::create(
         getASTContext(), Elts, TE->getSourceRange(), SourceLoc(), Elts.size());
-    return new (getASTContext()) TypeExpr(TypeLoc(NewTypeRepr, Type()));
+    return new (getASTContext()) TypeExpr(NewTypeRepr);
   }
   
 
@@ -1566,7 +1573,7 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
     auto *NewTypeRepr = new (getASTContext())
         ArrayTypeRepr(TyExpr->getTypeRepr(),
                       SourceRange(AE->getLBracketLoc(), AE->getRBracketLoc()));
-    return new (getASTContext()) TypeExpr(TypeLoc(NewTypeRepr, Type()));
+    return new (getASTContext()) TypeExpr(NewTypeRepr);
   }
 
   // Fold [K : V] into a dictionary type.
@@ -1607,7 +1614,7 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
         keyTypeRepr, valueTypeRepr,
         /*FIXME:colonLoc=*/SourceLoc(),
         SourceRange(DE->getLBracketLoc(), DE->getRBracketLoc()));
-    return new (getASTContext()) TypeExpr(TypeLoc(NewTypeRepr, Type()));
+    return new (getASTContext()) TypeExpr(NewTypeRepr);
   }
 
   // Reinterpret arrow expr T1 -> T2 as function type.
@@ -1699,7 +1706,7 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
     auto NewTypeRepr = new (ctx)
         FunctionTypeRepr(nullptr, ArgsTypeRepr, AE->getThrowsLoc(),
                          AE->getArrowLoc(), ResultTypeRepr);
-    return new (ctx) TypeExpr(TypeLoc(NewTypeRepr, Type()));
+    return new (ctx) TypeExpr(NewTypeRepr);
   }
   
   // Fold 'P & Q' into a composition type
@@ -1751,7 +1758,7 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
       auto CompRepr = CompositionTypeRepr::create(getASTContext(), Types,
                                                   lhsExpr->getStartLoc(),
                                                   binaryExpr->getSourceRange());
-      return new (getASTContext()) TypeExpr(TypeLoc(CompRepr, Type()));
+      return new (getASTContext()) TypeExpr(CompRepr);
     }
   }
 
@@ -1926,38 +1933,35 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
   if (!protocol)
     return nullptr;
 
-  Type type;
-  if (typeExpr->getTypeLoc().wasValidated()) {
-    type = typeExpr->getTypeLoc().getType();
+  TypeLoc typeLoc;
+  if (auto precheckedTy = typeExpr->getInstanceType()) {
+    typeLoc = TypeLoc(typeExpr->getTypeRepr(), precheckedTy);
   } else {
     TypeResolutionOptions options(TypeResolverContext::InExpression);
     options |= TypeResolutionFlags::AllowUnboundGenerics;
 
-    auto &typeLoc = typeExpr->getTypeLoc();
+    typeLoc = TypeLoc(typeExpr->getTypeRepr(), Type());
     bool hadError = TypeChecker::validateType(
         getASTContext(), typeLoc, TypeResolution::forContextual(DC), options);
 
     if (hadError)
       return nullptr;
-
-    type = typeLoc.getType();
   }
 
-  if (!type || !type->getAnyNominal())
+  if (!typeLoc.getType() || !typeLoc.getType()->getAnyNominal())
     return nullptr;
 
   // Don't bother to convert deprecated selector syntax.
   if (auto selectorTy = getASTContext().getSelectorType()) {
-    if (type->isEqual(selectorTy))
+    if (typeLoc.getType()->isEqual(selectorTy))
       return nullptr;
   }
 
-  auto *NTD = type->getAnyNominal();
+  auto *NTD = typeLoc.getType()->getAnyNominal();
   SmallVector<ProtocolConformance *, 2> conformances;
   return NTD->lookupConformance(DC->getParentModule(), protocol, conformances)
              ? CoerceExpr::forLiteralInit(getASTContext(), argExpr,
-                                          call->getSourceRange(),
-                                          typeExpr->getTypeLoc())
+                                          call->getSourceRange(), typeLoc)
              : nullptr;
 }
 

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -615,7 +615,9 @@ Pattern *TypeChecker::resolvePattern(Pattern *P, DeclContext *DC,
       Context.Diags.diagnose(TE->getStartLoc(), diag::type_pattern_missing_is)
         .fixItInsert(TE->getStartLoc(), "is ");
       
-      P = new (Context) IsPattern(TE->getStartLoc(), TE->getTypeLoc(),
+      P = new (Context) IsPattern(TE->getStartLoc(),
+                                  TypeLoc(TE->getTypeRepr(),
+                                          TE->getInstanceType()),
                                   /*subpattern*/nullptr,
                                   CheckedCastKind::Unresolved);
     }

--- a/test/Sema/diag_erroneous_iuo.swift
+++ b/test/Sema/diag_erroneous_iuo.swift
@@ -116,7 +116,7 @@ _ = [Int!]() // expected-error {{'!' is not allowed here; perhaps '?' was intend
 let _: [Int!] = [1] // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{12-13=?}}
 _ = Optional<Int!>(nil) // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{17-18=?}}
 let _: Optional<Int!> = nil // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{20-21=?}}
-_ = Int!?(0) // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{8-9=?}}
+_ = Int!?(0) // expected-error 3 {{'!' is not allowed here; perhaps '?' was intended?}}{{8-9=?}}
 let _: Int!? = 0 // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{11-12=?}}
 _ = (
   Int!, // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{6-7=?}}


### PR DESCRIPTION
Remove duplication in the modeling of TypeExpr. The type of a TypeExpr
node is always a metatype corresponding to the contextual
type of the type it's referencing. For some reason, the instance type
was also stored in this TypeLoc at random points in semantic analysis.

Under the assumption that this instance type is always going to be the
instance type of the contextual type of the expression, introduce
a number of simplifications:

1) Explicit TypeExpr nodes must be created with a TypeRepr node
2) Implicit TypeExpr nodes must be created with a contextual type
3) The typing rules for implicit TypeExpr simply opens this type

This opens the door for the further removal of `TypeLoc`s from `Expr` nodes by replacing them with the `TypeExpr`s.