### PR TITLE
[NFC] [SIL] [Parser] Move SILParserTUState into SILParserState.h

### DIFF
--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "SILParserFunctionBuilder.h"
+#include "SILParserState.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericEnvironment.h"
@@ -44,40 +45,6 @@ using namespace swift::syntax;
 //===----------------------------------------------------------------------===//
 // SILParserState implementation
 //===----------------------------------------------------------------------===//
-
-namespace {
-class SILParserState : public SILParserStateBase {
-public:
-  explicit SILParserState(SILModule &M) : M(M) {}
-  ~SILParserState();
-
-  SILModule &M;
-
-  /// This is all of the forward referenced functions with
-  /// the location for where the reference is.
-  llvm::DenseMap<Identifier,
-                 Located<SILFunction*>> ForwardRefFns;
-  /// A list of all functions forward-declared by a sil_scope.
-  llvm::DenseSet<SILFunction *> PotentialZombieFns;
-
-  /// A map from textual .sil scope number to SILDebugScopes.
-  llvm::DenseMap<unsigned, SILDebugScope *> ScopeSlots;
-
-  /// Did we parse a sil_stage for this module?
-  bool DidParseSILStage = false;
-
-  bool parseDeclSIL(Parser &P) override;
-  bool parseDeclSILStage(Parser &P) override;
-  bool parseSILVTable(Parser &P) override;
-  bool parseSILGlobal(Parser &P) override;
-  bool parseSILWitnessTable(Parser &P) override;
-  bool parseSILDefaultWitnessTable(Parser &P) override;
-  bool parseSILDifferentiabilityWitness(Parser &P) override;
-  bool parseSILCoverageMap(Parser &P) override;
-  bool parseSILProperty(Parser &P) override;
-  bool parseSILScope(Parser &P) override;
-};
-} // end anonymous namespace
 
 SILParserState::~SILParserState() {
   if (!ForwardRefFns.empty()) {

--- a/lib/SIL/Parser/SILParserState.h
+++ b/lib/SIL/Parser/SILParserState.h
@@ -1,0 +1,61 @@
+//===--- SILParserState.h - SILParserState declaration -------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_SILPARSERSTATE_H
+#define SWIFT_SIL_SILPARSERSTATE_H
+
+#include "swift/Basic/LLVM.h"
+#include "swift/Parse/ParseSILSupport.h"
+
+//===----------------------------------------------------------------------===//
+// SILParserState
+//===----------------------------------------------------------------------===//
+
+namespace swift {
+
+class Parser;
+class SILModule;
+
+class SILParserState : public SILParserStateBase {
+public:
+  explicit SILParserState(SILModule &M) : M(M) {}
+  ~SILParserState();
+
+  SILModule &M;
+
+  /// This is all of the forward referenced functions with
+  /// the location for where the reference is.
+  llvm::DenseMap<Identifier, Located<SILFunction *>> ForwardRefFns;
+  /// A list of all functions forward-declared by a sil_scope.
+  llvm::DenseSet<SILFunction *> PotentialZombieFns;
+
+  /// A map from textual .sil scope number to SILDebugScopes.
+  llvm::DenseMap<unsigned, SILDebugScope *> ScopeSlots;
+
+  /// Did we parse a sil_stage for this module?
+  bool DidParseSILStage = false;
+
+  bool parseDeclSIL(Parser &P) override;
+  bool parseDeclSILStage(Parser &P) override;
+  bool parseSILVTable(Parser &P) override;
+  bool parseSILGlobal(Parser &P) override;
+  bool parseSILWitnessTable(Parser &P) override;
+  bool parseSILDefaultWitnessTable(Parser &P) override;
+  bool parseSILDifferentiabilityWitness(Parser &P) override;
+  bool parseSILCoverageMap(Parser &P) override;
+  bool parseSILProperty(Parser &P) override;
+  bool parseSILScope(Parser &P) override;
+};
+
+} // end namespace swift
+
+#endif // SWIFT_SIL_SILPARSERSTATE_H


### PR DESCRIPTION
Moves the declaration of SILParserTUState into a new private header file: SILParserState.h. This is a simple cut and paste so there should be no functional changes. 