### PR TITLE
Compatibility51: Backport the 5.2 implementation of the conformance cache.

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -154,6 +154,14 @@
 # elif SWIFT_BNI_XCODE_BUILD
 #  define SWIFT_CLASS_IS_SWIFT_MASK 1ULL
 
+// Compatibility hook libraries cannot rely on the "is swift" bit being either
+// value, since they must work with both OS and Xcode versions of the libraries.
+// Generate a reference to a nonexistent symbol so that we get obvious linker
+// errors if we try.
+# elif SWIFT_COMPATIBILITY_LIBRARY
+extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTLY__;
+#  define SWIFT_CLASS_IS_SWIFT_MASK __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTLY__
+
 // Other builds (such as local builds on developers' computers)
 // dynamically choose the bit at runtime based on the current OS
 // version.

--- a/stdlib/toolchain/CMakeLists.txt
+++ b/stdlib/toolchain/CMakeLists.txt
@@ -56,6 +56,10 @@ else()
   add_compile_definitions(LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
 endif()
 
+# Compatibility libraries build in a special alternate universe that can't
+# directly link to most OS runtime libraries, and have to access the
+# runtime being patched only through public ABI.
+list(APPEND CXX_COMPILE_FLAGS "-DSWIFT_COMPATIBILITY_LIBRARY=1")
 
 add_subdirectory(legacy_layouts)
 add_subdirectory(Compatibility50)

--- a/stdlib/toolchain/Compatibility50/Overrides.cpp
+++ b/stdlib/toolchain/Compatibility50/Overrides.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "Overrides.h"
+#include "../Compatibility51/Overrides.h"
 #include "../../public/runtime/CompatibilityOverride.h"
 
 #include <dlfcn.h>
@@ -34,6 +35,11 @@ OverrideSection Swift50Overrides
 __attribute__((used, section("__DATA,__swift_hooks"))) = {
   .version = 0,
   .conformsToProtocol = swift50override_conformsToProtocol,
+  // We use the same hook for conformsToSwiftProtocol as we do for a 5.1
+  // runtime, so reference the override from the Compatibility51 library.
+  // If we're back deploying to Swift 5.0, we also have to support 5.1, so
+  // the Compatibility51 library is always linked when the 50 library is.
+  .conformsToSwiftProtocol = swift51override_conformsToSwiftProtocol,
 };
 
 // Allow this library to get force-loaded by autolinking

--- a/stdlib/toolchain/Compatibility50/Overrides.h
+++ b/stdlib/toolchain/Compatibility50/Overrides.h
@@ -1,8 +1,8 @@
-//===--- Overrides.cpp - Compat overrides for Swift 5.0 runtime ----s------===//
+//===--- Overrides.h --- Compat overrides for Swift 5.0 runtime ----s------===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/toolchain/Compatibility51/CMakeLists.txt
+++ b/stdlib/toolchain/Compatibility51/CMakeLists.txt
@@ -3,6 +3,7 @@ set(library_name "swiftCompatibility51")
 
 add_swift_target_library("${library_name}" STATIC
   Overrides.cpp
+  ProtocolConformance.cpp
 
   TARGET_SDKS ${SWIFT_APPLE_PLATFORMS}
 

--- a/stdlib/toolchain/Compatibility51/Concurrent.h
+++ b/stdlib/toolchain/Compatibility51/Concurrent.h
@@ -1,0 +1,468 @@
+//===--- Concurrent.h - Concurrent Data Structures backport -----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This is a snapshot of the `ConcurrentMap` and `ConcurrentReadableArray`
+// structures from the Swift runtime, adapted to be independent of runtime
+// dependencies on the C++ runtime and LLVM support libraries to make it
+// suitable for use in back-deployment compatibility libraries.
+
+#ifndef SWIFT_OVERRIDE_CONCURRENTUTILS_H
+#define SWIFT_OVERRIDE_CONCURRENTUTILS_H
+#include <iterator>
+#include <algorithm>
+#include <atomic>
+#include <functional>
+#include <pthread.h>
+#include <stdint.h>
+#include "swift/Basic/Defer.h"
+#include "swift/Runtime/Atomic.h"
+
+namespace swift {
+
+namespace overrides {
+
+/// A utility function for ordering two pointers, which is useful
+/// for implementing compareWithKey.
+template <class T>
+static inline int comparePointers(const T *left, const T *right) {
+  return (left == right ? 0 : std::less<const T *>()(left, right) ? -1 : 1);
+}
+
+template <class EntryTy, bool ProvideDestructor>
+class ConcurrentMapBase;
+
+/// The partial specialization of ConcurrentMapBase whose destructor is
+/// trivial.  The other implementation inherits from this, so this is a
+/// base for all ConcurrentMaps.
+template <class EntryTy>
+class ConcurrentMapBase<EntryTy, false> {
+protected:
+  struct Node {
+    std::atomic<Node*> Left;
+    std::atomic<Node*> Right;
+    EntryTy Payload;
+
+    template <class... Args>
+    Node(Args &&... args)
+      : Left(nullptr), Right(nullptr), Payload(std::forward<Args>(args)...) {}
+
+    Node(const Node &) = delete;
+    Node &operator=(const Node &) = delete;
+
+  #ifndef NDEBUG
+    void dump() const {
+      auto L = Left.load(std::memory_order_acquire);
+      auto R = Right.load(std::memory_order_acquire);
+      printf("\"%p\" [ label = \" {<f0> %08lx | {<f1> | <f2>}}\" "
+             "style=\"rounded\" shape=\"record\"];\n",
+             this, (long) Payload.getKeyValueForDump());
+
+      if (L) {
+        L->dump();
+        printf("\"%p\":f1 -> \"%p\":f0;\n", this, L);
+      }
+      if (R) {
+        R->dump();
+        printf("\"%p\":f2 -> \"%p\":f0;\n", this, R);
+      }
+    }
+  #endif
+  };
+
+  std::atomic<Node*> Root;
+
+  constexpr ConcurrentMapBase() : Root(nullptr) {}
+
+  // Implicitly trivial destructor.
+  ~ConcurrentMapBase() = default;
+
+  void destroyNode(Node *node) {
+    assert(node && "destroying null node");
+    // Destroy the node's payload.
+    node->~Node();
+    // Deallocate the node.
+    free(node);
+  }
+};
+
+/// The partial specialization of ConcurrentMapBase which provides a
+/// non-trivial destructor.
+template <class EntryTy>
+class ConcurrentMapBase<EntryTy, true>
+    : protected ConcurrentMapBase<EntryTy, false> {
+protected:
+  using super = ConcurrentMapBase<EntryTy, false>;
+  using Node = typename super::Node;
+
+  constexpr ConcurrentMapBase() {}
+
+  ~ConcurrentMapBase() {
+    destroyTree(this->Root);
+  }
+
+private:
+  void destroyTree(const std::atomic<Node*> &edge) {
+    // This can be a relaxed load because destruction is not allowed to race
+    // with other operations.
+    auto node = edge.load(std::memory_order_relaxed);
+    if (!node) return;
+
+    // Destroy the node's children.
+    destroyTree(node->Left);
+    destroyTree(node->Right);
+
+    // Destroy the node itself.
+    this->destroyNode(node);
+  }
+};
+
+/// A concurrent map that is implemented using a binary tree. It supports
+/// concurrent insertions but does not support removals or rebalancing of
+/// the tree.
+///
+/// The entry type must provide the following operations:
+///
+///   /// For debugging purposes only. Summarize this key as an integer value.
+///   intptr_t getKeyIntValueForDump() const;
+///
+///   /// A ternary comparison.  KeyTy is the type of the key provided
+///   /// to find or getOrInsert.
+///   int compareWithKey(KeyTy key) const;
+///
+///   /// Return the amount of extra trailing space required by an entry,
+///   /// where KeyTy is the type of the first argument to getOrInsert and
+///   /// ArgTys is the type of the remaining arguments.
+///   static size_t getExtraAllocationSize(KeyTy key, ArgTys...)
+///
+///   /// Return the amount of extra trailing space that was requested for
+///   /// this entry.  This method is only used to compute the size of the
+///   /// object during node deallocation; it does not need to return a
+///   /// correct value so long as the allocator's Deallocate implementation
+///   /// ignores this argument.
+///   size_t getExtraAllocationSize() const;
+///
+/// If ProvideDestructor is false, the destructor will be trivial.  This
+/// can be appropriate when the object is declared at global scope.
+template <class EntryTy, bool ProvideDestructor = true>
+class ConcurrentMap
+      : private ConcurrentMapBase<EntryTy, ProvideDestructor> {
+  using super = ConcurrentMapBase<EntryTy, ProvideDestructor>;
+
+  using Node = typename super::Node;
+
+  /// Inherited from base class:
+  ///   std::atomic<Node*> Root;
+  using super::Root;
+
+  /// This member stores the address of the last node that was found by the
+  /// search procedure. We cache the last search to accelerate code that
+  /// searches the same value in a loop.
+  std::atomic<Node*> LastSearch;
+
+public:
+  constexpr ConcurrentMap() : LastSearch(nullptr) {}
+
+  ConcurrentMap(const ConcurrentMap &) = delete;
+  ConcurrentMap &operator=(const ConcurrentMap &) = delete;
+
+  // ConcurrentMap<T, false> must have a trivial destructor.
+  ~ConcurrentMap() = default;
+
+public:
+
+#ifndef NDEBUG
+  void dump() const {
+    auto R = Root.load(std::memory_order_acquire);
+    printf("digraph g {\n"
+           "graph [ rankdir = \"TB\"];\n"
+           "node  [ fontsize = \"16\" ];\n"
+           "edge  [ ];\n");
+    if (R) {
+      R->dump();
+    }
+    printf("\n}\n");
+  }
+#endif
+
+  /// Search for a value by key \p Key.
+  /// \returns a pointer to the value or null if the value is not in the map.
+  template <class KeyTy>
+  EntryTy *find(const KeyTy &key) {
+    // Check if we are looking for the same key that we looked for in the last
+    // time we called this function.
+    if (Node *last = LastSearch.load(std::memory_order_acquire)) {
+      if (last->Payload.compareWithKey(key) == 0)
+        return &last->Payload;
+    }
+
+    // Search the tree, starting from the root.
+    Node *node = Root.load(std::memory_order_acquire);
+    while (node) {
+      int comparisonResult = node->Payload.compareWithKey(key);
+      if (comparisonResult == 0) {
+        LastSearch.store(node, std::memory_order_release);
+        return &node->Payload;
+      } else if (comparisonResult < 0) {
+        node = node->Left.load(std::memory_order_acquire);
+      } else {
+        node = node->Right.load(std::memory_order_acquire);
+      }
+    }
+
+    return nullptr;
+  }
+
+  /// Get or create an entry in the map.
+  ///
+  /// \returns the entry in the map and whether a new node was added (true)
+  ///   or already existed (false)
+  template <class KeyTy, class... ArgTys>
+  std::pair<EntryTy*, bool> getOrInsert(KeyTy key, ArgTys &&... args) {
+    // Check if we are looking for the same key that we looked for the
+    // last time we called this function.
+    if (Node *last = LastSearch.load(std::memory_order_acquire)) {
+      if (last && last->Payload.compareWithKey(key) == 0)
+        return { &last->Payload, false };
+    }
+
+    // The node we allocated.
+    Node *newNode = nullptr;
+
+    // Start from the root.
+    auto edge = &Root;
+
+    while (true) {
+      // Load the edge.
+      Node *node = edge->load(std::memory_order_acquire);
+
+      // If there's a node there, it's either a match or we're going to
+      // one of its children.
+      if (node) {
+      searchFromNode:
+
+        // Compare our key against the node's key.
+        int comparisonResult = node->Payload.compareWithKey(key);
+
+        // If it's equal, we can use this node.
+        if (comparisonResult == 0) {
+          // Destroy the node we allocated before if we're carrying one around.
+          if (newNode) this->destroyNode(newNode);
+
+          // Cache and report that we found an existing node.
+          LastSearch.store(node, std::memory_order_release);
+          return { &node->Payload, false };
+        }
+
+        // Otherwise, select the appropriate child edge and descend.
+        edge = (comparisonResult < 0 ? &node->Left : &node->Right);
+        continue;
+      }
+
+      // Create a new node.
+      if (!newNode) {
+        size_t allocSize =
+          sizeof(Node) + EntryTy::getExtraAllocationSize(key, args...);
+        void *memory;
+        if (posix_memalign(&memory, alignof(Node), allocSize))
+          abort();
+        newNode = ::new (memory) Node(key, std::forward<ArgTys>(args)...);
+      }
+
+      // Try to set the edge to the new node.
+      if (std::atomic_compare_exchange_strong_explicit(edge, &node, newNode,
+                                                  std::memory_order_acq_rel,
+                                                  std::memory_order_acquire)) {
+        // If that succeeded, cache and report that we created a new node.
+        LastSearch.store(newNode, std::memory_order_release);
+        return { &newNode->Payload, true };
+      }
+
+      // Otherwise, we lost the race because some other thread initialized
+      // the edge before us.  node will be set to the current value;
+      // repeat the search from there.
+      assert(node && "spurious failure from compare_exchange_strong?");
+      goto searchFromNode;
+    }
+  }
+};
+
+/// A minimal implementation of a growable array with no runtime dependencies.
+template<class Element>
+class MiniVector {
+  Element *first;
+  size_t size, capacity;
+public:
+  MiniVector() : first(nullptr), size(0), capacity(0) {
+    static_assert(std::is_trivial<Element>::value,
+                  "only implemented for trivial types");
+  }
+  ~MiniVector() { free(first); }
+  
+  MiniVector(const MiniVector &) = delete;
+  
+  Element *begin() { return first; }
+  Element *end() { return first + size; }
+  
+  void push_back(const Element &e) {
+    if (size >= capacity) {
+      capacity = capacity ? capacity*2 : 8;
+      first = (Element*)realloc(first, capacity * sizeof(Element));
+      if (!first)
+        abort();
+    }
+    first[size++] = e;
+  }
+  
+  void clear_and_shrink_to_fit() {
+    free(first);
+    first = nullptr;
+    size = 0;
+    capacity = 0;
+  }
+};
+
+/// An append-only array that can be read without taking locks. Writes
+/// are still locked and serialized, but only with respect to other
+/// writes.
+template <class ElemTy> struct ConcurrentReadableArray {
+private:
+  /// The struct used for the array's storage. The `Elem` member is
+  /// considered to be the first element of a variable-length array,
+  /// whose size is determined by the allocation. The `Capacity` member
+  /// from `ConcurrentReadableArray` indicates how large it can be.
+  struct Storage {
+    std::atomic<size_t> Count;
+    typename std::aligned_storage<sizeof(ElemTy), alignof(ElemTy)>::type Elem;
+
+    static Storage *allocate(size_t capacity) {
+      auto size = sizeof(Storage) + (capacity - 1) * sizeof(Storage().Elem);
+      auto *ptr = reinterpret_cast<Storage *>(malloc(size));
+      if (!ptr) abort();
+      ptr->Count.store(0, std::memory_order_relaxed);
+      return ptr;
+    }
+
+    void deallocate() {
+      for (size_t i = 0; i < Count; i++) {
+        data()[i].~ElemTy();
+      }
+      free(this);
+    }
+
+    ElemTy *data() {
+      return reinterpret_cast<ElemTy *>(&Elem);
+    }
+  };
+  
+  size_t Capacity;
+  std::atomic<size_t> ReaderCount;
+  std::atomic<Storage *> Elements;
+  pthread_mutex_t WriterMutex;
+  MiniVector<Storage *> FreeList;
+  
+  void incrementReaders() {
+    ReaderCount.fetch_add(1, std::memory_order_acquire);
+  }
+  
+  void decrementReaders() {
+    ReaderCount.fetch_sub(1, std::memory_order_release);
+  }
+  
+  void deallocateFreeList() {
+    for (Storage *storage : FreeList)
+      storage->deallocate();
+    FreeList.clear_and_shrink_to_fit();
+  }
+  
+public:
+  struct Snapshot {
+    ConcurrentReadableArray *Array;
+    const ElemTy *Start;
+    size_t Count;
+    
+    Snapshot(ConcurrentReadableArray *array, const ElemTy *start, size_t count)
+      : Array(array), Start(start), Count(count) {}
+    
+    Snapshot(const Snapshot &other)
+      : Array(other.Array), Start(other.Start), Count(other.Count) {
+      Array->incrementReaders();
+    }
+    
+    ~Snapshot() {
+      Array->decrementReaders();
+    }
+    
+    const ElemTy *begin() { return Start; }
+    const ElemTy *end() { return Start + Count; }
+    size_t count() { return Count; }
+  };
+  
+  // This type cannot be safely copied, moved, or deleted.
+  ConcurrentReadableArray(const ConcurrentReadableArray &) = delete;
+  ConcurrentReadableArray(ConcurrentReadableArray &&) = delete;
+  ConcurrentReadableArray &operator=(const ConcurrentReadableArray &) = delete;
+  
+  ConcurrentReadableArray()
+    : Capacity(0), ReaderCount(0), Elements(nullptr) {
+    pthread_mutex_init(&WriterMutex, nullptr);
+  }
+  
+  ~ConcurrentReadableArray() {
+    assert(ReaderCount.load(std::memory_order_acquire) == 0 &&
+           "deallocating ConcurrentReadableArray with outstanding snapshots");
+    deallocateFreeList();
+    pthread_mutex_destroy(&WriterMutex);
+  }
+  
+  void push_back(const ElemTy &elem) {
+    pthread_mutex_lock(&WriterMutex);
+    SWIFT_DEFER { pthread_mutex_unlock(&WriterMutex); };
+    
+    auto *storage = Elements.load(std::memory_order_relaxed);
+    auto count = storage ? storage->Count.load(std::memory_order_relaxed) : 0;
+    if (count >= Capacity) {
+      auto newCapacity = std::max((size_t)16, count * 2);
+      auto *newStorage = Storage::allocate(newCapacity);
+      if (storage) {
+        std::copy(storage->data(), storage->data() + count, newStorage->data());
+        newStorage->Count.store(count, std::memory_order_relaxed);
+        FreeList.push_back(storage);
+      }
+      
+      storage = newStorage;
+      Capacity = newCapacity;
+      Elements.store(storage, std::memory_order_release);
+    }
+    
+    new(&storage->data()[count]) ElemTy(elem);
+    storage->Count.store(count + 1, std::memory_order_release);
+    
+    if (ReaderCount.load(std::memory_order_acquire) == 0)
+      deallocateFreeList();
+  }
+  
+  Snapshot snapshot() {
+    incrementReaders();
+    auto *storage = Elements.load(SWIFT_MEMORY_ORDER_CONSUME);
+    if (storage == nullptr) {
+      return Snapshot(this, nullptr, 0);
+    }
+    
+    auto count = storage->Count.load(std::memory_order_acquire);
+    const auto *ptr = storage->data();
+    return Snapshot(this, ptr, count);
+  }
+};
+
+}} // end namespace swift::overrides
+
+#endif // SWIFT_RUNTIME_CONCURRENTUTILS_H

--- a/stdlib/toolchain/Compatibility51/Overrides.cpp
+++ b/stdlib/toolchain/Compatibility51/Overrides.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "../../public/runtime/CompatibilityOverride.h"
+#include "Overrides.h"
 
 #include <dlfcn.h>
 #include <mach-o/dyld.h>
@@ -32,6 +33,7 @@ struct OverrideSection {
 OverrideSection Swift51Overrides
 __attribute__((used, section("__DATA,__swift51_hooks"))) = {
   .version = 0,
+  .conformsToSwiftProtocol = swift51override_conformsToSwiftProtocol,
 };
 
 // Allow this library to get force-loaded by autolinking

--- a/stdlib/toolchain/Compatibility51/Overrides.h
+++ b/stdlib/toolchain/Compatibility51/Overrides.h
@@ -1,0 +1,33 @@
+//===--- Overrides.h - Compat overrides for Swift 5.0 runtime ------s------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file provides compatibility override hooks for Swift 5.1 runtimes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/LLVM.h"
+#include "swift/Runtime/Metadata.h"
+
+namespace swift {
+
+using ConformsToSwiftProtocol_t =
+  const ProtocolConformanceDescriptor *(const Metadata * const type,
+                                        const ProtocolDescriptor *protocol,
+                                        StringRef moduleName);
+
+const ProtocolConformanceDescriptor *
+swift51override_conformsToSwiftProtocol(const Metadata * const type,
+                                        const ProtocolDescriptor *protocol,
+                                        StringRef moduleName,
+                                        ConformsToSwiftProtocol_t *original);
+
+} // end namespace swift

--- a/stdlib/toolchain/Compatibility51/ProtocolConformance.cpp
+++ b/stdlib/toolchain/Compatibility51/ProtocolConformance.cpp
@@ -1,0 +1,683 @@
+//===--- ProtocolConformance.cpp - Swift conformance checking backport ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Checking and caching of Swift protocol conformances.
+//
+// This is a version of the Swift 5.2 protocol conformance cache implementation
+// adapted for backporting to Swift 5.1 with the following fixes applied:
+//
+// - rdar://problem/59460603, fixing a problem where the conformance cache would
+//   eagerly instantiate metadata for types when not necessary, causing crashes
+//   if instantiating the type relied on weak-linked symbols that aren't
+//   available on the client OS
+//
+//===----------------------------------------------------------------------===//
+
+#include "Concurrent.h"
+#include "Overrides.h"
+#include "swift/Basic/Lazy.h"
+#include "../../public/runtime/Private.h"
+#include <mach-o/dyld.h>
+#include <mach-o/getsect.h>
+#include <objc/runtime.h>
+#include <assert.h>
+#include <dlfcn.h>
+
+using namespace swift;
+using swift::overrides::ConcurrentMap;
+using swift::overrides::ConcurrentReadableArray;
+
+// Look up Swift runtime entry points dynamically. This handles the case
+// where the main executable can't link against libswiftCore.dylib because
+// it will be loaded dynamically from a location that isn't known at build
+// time.
+static const Metadata *getObjCClassMetadata(const ClassMetadata *c) {
+  using FPtr = const Metadata *(*)(const ClassMetadata *);
+  FPtr func = SWIFT_LAZY_CONSTANT(
+    reinterpret_cast<FPtr>(dlsym(RTLD_DEFAULT, "swift_getObjCClassMetadata")));
+
+  return func(c);
+}
+static const ExistentialTypeMetadata *getExistentialTypeMetadata(
+                                     ProtocolClassConstraint classConstraint,
+                                     const Metadata *superclassConstraint,
+                                     size_t numProtocols,
+                                     const ProtocolDescriptorRef *protocols) {
+  auto func = SWIFT_LAZY_CONSTANT(
+    reinterpret_cast<const ExistentialTypeMetadata *(*)(ProtocolClassConstraint classConstraint,
+      const Metadata *superclassConstraint,
+      size_t numProtocols,
+      const ProtocolDescriptorRef *protocols)>(
+                     dlsym(RTLD_DEFAULT, "swift_getExistentialTypeMetadata")));
+  return func(classConstraint, superclassConstraint, numProtocols, protocols);
+}
+static const TypeContextDescriptor *getTypeContextDescriptor(const Metadata *type) {
+  auto func = SWIFT_LAZY_CONSTANT(
+    reinterpret_cast<const TypeContextDescriptor *(*)(const Metadata *)>(
+                     dlsym(RTLD_DEFAULT, "swift_getTypeContextDescriptor")));
+  return func(type);
+}
+
+// Clone of private helper swift::_swift_class_getSuperclass
+// for use in the override implementation.
+//
+// This also gets used from the Compatibility50 library.
+const Metadata *_swiftoverride_class_getSuperclass(
+                                                    const Metadata *theClass) {
+  if (const ClassMetadata *classType = theClass->getClassObject()) {
+    if (classHasSuperclass(classType))
+      return getObjCClassMetadata(classType->Superclass);
+  }
+  
+  if (const ForeignClassMetadata *foreignClassType
+      = dyn_cast<ForeignClassMetadata>(theClass)) {
+    if (const Metadata *superclass = foreignClassType->Superclass)
+      return superclass;
+  }
+  
+  return nullptr;
+}
+
+// Clone of private function getRootSuperclass. This returns the SwiftObject
+// class in the ABI-stable dylib, regardless of what the local runtime build
+// does, since we're always patching an ABI-stable dylib.
+__attribute__((visibility("hidden"), weak))
+const ClassMetadata *swift::getRootSuperclass() {
+  auto theClass = SWIFT_LAZY_CONSTANT(objc_getClass("_TtCs12_SwiftObject"));
+  return (const ClassMetadata *)theClass;
+}
+
+namespace {
+
+StringRef getTypeContextIdentity(const TypeContextDescriptor *type) {
+  // The first component is the user-facing name and (unless overridden)
+  // the ABI name.
+  StringRef component = type->Name.get();
+
+  // If we don't have import info, we're done.
+  if (!type->getTypeContextDescriptorFlags().hasImportInfo()) {
+    return component;
+  }
+  
+  // The identity starts with the user-facing name.
+  const char *startOfIdentity = component.begin();
+  const char *endOfIdentity = component.end();
+
+  enum class TypeImportComponent : char {
+    ABIName = 'N',
+    SymbolNamespace = 'S',
+    RelatedEntityName = 'R',
+  };
+
+  while (true) {
+    // Parse the next component.  If it's empty, we're done.
+    component = StringRef(component.end() + 1);
+    if (component.empty()) break;
+
+    // Update the identity bounds and assert that the identity
+    // components are in the right order.
+    auto kind = TypeImportComponent(component[0]);
+    if (kind == TypeImportComponent::ABIName) {
+      startOfIdentity = component.begin() + 1;
+      endOfIdentity = component.end();
+    } else if (kind == TypeImportComponent::SymbolNamespace) {
+      endOfIdentity = component.end();
+    } else if (kind == TypeImportComponent::RelatedEntityName) {
+      endOfIdentity = component.end();
+    }
+  }
+  
+  return StringRef(startOfIdentity, endOfIdentity - startOfIdentity);
+}
+
+// Reimplementation of the runtime-private function `swift::equalContexts`
+static bool override_equalContexts(const ContextDescriptor *a,
+                                   const ContextDescriptor *b)
+{
+  // Fast path: pointer equality.
+  if (a == b) return true;
+
+  // If either context is null, we're done.
+  if (a == nullptr || b == nullptr)
+    return false;
+
+  // If either descriptor is known to be unique, we're done.
+  if (a->isUnique() || b->isUnique()) return false;
+  
+  // Do the kinds match?
+  if (a->getKind() != b->getKind()) return false;
+  
+  // Do the parents match?
+  if (!override_equalContexts(a->Parent.get(), b->Parent.get()))
+    return false;
+  
+  // Compare kind-specific details.
+  switch (auto kind = a->getKind()) {
+  case ContextDescriptorKind::Module: {
+    // Modules with the same name are equivalent.
+    auto moduleA = cast<ModuleContextDescriptor>(a);
+    auto moduleB = cast<ModuleContextDescriptor>(b);
+    return strcmp(moduleA->Name.get(), moduleB->Name.get()) == 0;
+  }
+  
+  case ContextDescriptorKind::Extension:
+  case ContextDescriptorKind::Anonymous:
+    // These context kinds are always unique.
+    return false;
+  
+  default:
+    // Types in the same context with the same name are equivalent.
+    if (kind >= ContextDescriptorKind::Type_First
+        && kind <= ContextDescriptorKind::Type_Last) {
+      auto typeA = cast<TypeContextDescriptor>(a);
+      auto typeB = cast<TypeContextDescriptor>(b);
+      return getTypeContextIdentity(typeA) == getTypeContextIdentity(typeB);
+    }
+    
+    // Otherwise, this runtime doesn't know anything about this context kind.
+    // Conservatively return false.
+    return false;
+  }
+}
+
+// Reimplementation of the runtime-private function
+// `ProtocolConformanceDescriptor::getCanonicalTypeMetadata`.
+static const Metadata *
+override_getCanonicalTypeMetadata(const ProtocolConformanceDescriptor *conf) {
+  switch (conf->getTypeKind()) {
+  // The class may be ObjC, in which case we need to instantiate its Swift
+  // metadata. The class additionally may be weak-linked, so we have to check
+  // for null.
+  case TypeReferenceKind::IndirectObjCClass:
+    if (auto cls = *conf->getIndirectObjCClass())
+      return getObjCClassMetadata(cls);
+    return nullptr;
+      
+  case TypeReferenceKind::DirectObjCClassName:
+    if (auto cls = reinterpret_cast<const ClassMetadata *>(
+                             objc_lookUpClass(conf->getDirectObjCClassName())))
+      return getObjCClassMetadata(cls);
+    return nullptr;
+
+  case TypeReferenceKind::DirectTypeDescriptor:
+  case TypeReferenceKind::IndirectTypeDescriptor: {
+    if (auto anyType = conf->getTypeDescriptor()) {
+      if (auto type = dyn_cast<TypeContextDescriptor>(anyType)) {
+        if (!type->isGeneric()) {
+          if (auto accessFn = type->getAccessFunction())
+            return accessFn(MetadataState::Abstract).Value;
+        }
+      } else if (auto protocol = dyn_cast<ProtocolDescriptor>(anyType)) {
+        auto protocolRef = ProtocolDescriptorRef::forSwift(protocol);
+        auto constraint =
+          protocol->getProtocolContextDescriptorFlags().getClassConstraint();
+        return getExistentialTypeMetadata(constraint,
+                                          /*superclass bound*/ nullptr,
+                                          /*num protocols*/ 1,
+                                          &protocolRef);
+      }
+    }
+
+    return nullptr;
+  }
+  }
+
+  swift_runtime_unreachable("Unhandled TypeReferenceKind in switch.");
+}
+
+  class ConformanceCandidate {
+    const void *candidate;
+    bool candidateIsMetadata;
+
+  public:
+    ConformanceCandidate() : candidate(0), candidateIsMetadata(false) { }
+
+    ConformanceCandidate(const ProtocolConformanceDescriptor &conformance)
+      : ConformanceCandidate()
+    {
+      if (auto description = conformance.getTypeDescriptor()) {
+        candidate = description;
+        candidateIsMetadata = false;
+        return;
+      }
+
+      if (auto metadata = override_getCanonicalTypeMetadata(&conformance)) {
+        candidate = metadata;
+        candidateIsMetadata = true;
+        return;
+      }
+    }
+
+    /// Retrieve the conforming type as metadata, or NULL if the candidate's
+    /// conforming type is described in another way (e.g., a nominal type
+    /// descriptor).
+    const Metadata *getConformingTypeAsMetadata() const {
+      return candidateIsMetadata ? static_cast<const Metadata *>(candidate)
+                                 : nullptr;
+    }
+
+    const ContextDescriptor *
+    getContextDescriptor(const Metadata *conformingType) const {
+      const auto *description = getTypeContextDescriptor(conformingType);
+      if (description)
+        return description;
+
+      // Handle single-protocol existential types for self-conformance.
+      auto *existentialType = dyn_cast<ExistentialTypeMetadata>(conformingType);
+      if (existentialType == nullptr ||
+          existentialType->getProtocols().size() != 1 ||
+          existentialType->getSuperclassConstraint() != nullptr)
+        return nullptr;
+
+      auto proto = existentialType->getProtocols()[0];
+
+      if (proto.isObjC())
+        return nullptr;
+
+      return proto.getSwiftProtocol();
+    }
+
+    /// Whether the conforming type exactly matches the conformance candidate.
+    bool matches(const Metadata *conformingType) const {
+      // Check whether the types match.
+      if (candidateIsMetadata && conformingType == candidate)
+        return true;
+
+      // Check whether the nominal type descriptors match.
+      if (!candidateIsMetadata) {
+        const auto *description = getContextDescriptor(conformingType);
+        auto candidateDescription =
+          static_cast<const ContextDescriptor *>(candidate);
+        if (description && override_equalContexts(description, candidateDescription))
+          return true;
+      }
+
+      return false;
+    }
+
+    /// Retrieve the type that matches the conformance candidate, which may
+    /// be a superclass of the given type. Returns null if this type does not
+    /// match this conformance.
+    const Metadata *getMatchingType(const Metadata *conformingType) const {
+      while (conformingType) {
+        // Check for a match.
+        if (matches(conformingType))
+          return conformingType;
+
+        // Look for a superclass.
+        conformingType = _swiftoverride_class_getSuperclass(conformingType);
+      }
+
+      return nullptr;
+    }
+  };
+
+  struct ConformanceSection {
+    const ProtocolConformanceRecord *Begin, *End;
+    const ProtocolConformanceRecord *begin() const {
+      return Begin;
+    }
+    const ProtocolConformanceRecord *end() const {
+      return End;
+    }
+  };
+
+  struct ConformanceCacheKey {
+    /// Either a Metadata* or a NominalTypeDescriptor*.
+    const void *Type;
+    const ProtocolDescriptor *Proto;
+
+    ConformanceCacheKey(const void *type, const ProtocolDescriptor *proto)
+        : Type(type), Proto(proto) {
+      assert(type);
+    }
+  };
+
+  struct ConformanceCacheEntry {
+  private:
+    const void *Type;
+    const ProtocolDescriptor *Proto;
+    std::atomic<const ProtocolConformanceDescriptor *> Description;
+    std::atomic<size_t> FailureGeneration;
+
+  public:
+    ConformanceCacheEntry(ConformanceCacheKey key,
+                          const ProtocolConformanceDescriptor *description,
+                          size_t failureGeneration)
+      : Type(key.Type), Proto(key.Proto), Description(description),
+        FailureGeneration(failureGeneration) {
+    }
+
+    int compareWithKey(const ConformanceCacheKey &key) const {
+      if (key.Type != Type) {
+        return (uintptr_t(key.Type) < uintptr_t(Type) ? -1 : 1);
+      } else if (key.Proto != Proto) {
+        return (uintptr_t(key.Proto) < uintptr_t(Proto) ? -1 : 1);
+      } else {
+        return 0;
+      }
+    }
+
+    template <class... Args>
+    static size_t getExtraAllocationSize(Args &&... ignored) {
+      return 0;
+    }
+
+    bool isSuccessful() const {
+      return Description.load(std::memory_order_relaxed) != nullptr;
+    }
+
+    void makeSuccessful(const ProtocolConformanceDescriptor *description) {
+      Description.store(description, std::memory_order_release);
+    }
+
+    void updateFailureGeneration(size_t failureGeneration) {
+      assert(!isSuccessful());
+      FailureGeneration.store(failureGeneration, std::memory_order_relaxed);
+    }
+
+    /// Get the cached conformance descriptor, if successful.
+    const ProtocolConformanceDescriptor *getDescription() const {
+      assert(isSuccessful());
+      return Description.load(std::memory_order_acquire);
+    }
+    
+    /// Get the generation in which this lookup failed.
+    size_t getFailureGeneration() const {
+      assert(!isSuccessful());
+      return FailureGeneration.load(std::memory_order_relaxed);
+    }
+  };
+
+#if __POINTER_WIDTH__ == 64
+using mach_header_platform = mach_header_64;
+#else
+using mach_header_platform = mach_header;
+#endif
+
+// Conformance Cache.
+struct ConformanceState {
+  ConcurrentMap<ConformanceCacheEntry> Cache;
+  ConcurrentReadableArray<ConformanceSection> SectionsToScan;
+  
+  ConformanceState();
+
+  void cacheSuccess(const void *type, const ProtocolDescriptor *proto,
+                    const ProtocolConformanceDescriptor *description) {
+    auto result = Cache.getOrInsert(ConformanceCacheKey(type, proto),
+                                    description, 0);
+
+    // If the entry was already present, we may need to update it.
+    if (!result.second) {
+      result.first->makeSuccessful(description);
+    }
+  }
+
+  void cacheFailure(const void *type, const ProtocolDescriptor *proto,
+                    size_t failureGeneration) {
+    auto result =
+      Cache.getOrInsert(ConformanceCacheKey(type, proto),
+                        (const ProtocolConformanceDescriptor *) nullptr,
+                        failureGeneration);
+
+    // If the entry was already present, we may need to update it.
+    if (!result.second) {
+      result.first->updateFailureGeneration(failureGeneration);
+    }
+  }
+
+  ConformanceCacheEntry *findCached(const void *type,
+                                    const ProtocolDescriptor *proto) {
+    return Cache.find(ConformanceCacheKey(type, proto));
+  }
+};
+
+static Lazy<ConformanceState> Conformances;
+
+// The Swift runtime in the OS installs this callback to populate its original
+// version of the conformance cache, but since we have our own implementation,
+// we must install our own callback to populate our copy as well.
+static void addImageCallback(const mach_header *mh) {
+  // Look for a __swift5_proto section.
+  unsigned long conformancesSize;
+  const uint8_t *conformances =
+  getsectiondata(reinterpret_cast<const mach_header_platform *>(mh),
+                 SEG_TEXT, "__swift5_proto",
+                 &conformancesSize);
+  
+  if (!conformances)
+    return;
+
+  assert(conformancesSize % sizeof(ProtocolConformanceRecord) == 0 &&
+         "conformances section not a multiple of ProtocolConformanceRecord");
+
+  // If we have a section, enqueue the conformances for lookup.
+  auto conformanceBytes = reinterpret_cast<const char *>(conformances);
+  auto recordsBegin
+    = reinterpret_cast<const ProtocolConformanceRecord*>(conformances);
+  auto recordsEnd
+    = reinterpret_cast<const ProtocolConformanceRecord*>
+                                          (conformanceBytes + conformancesSize);
+  
+  // Conformance cache should always be sufficiently initialized by this point.
+  Conformances.unsafeGetAlreadyInitialized()
+    .SectionsToScan
+    .push_back(ConformanceSection{recordsBegin, recordsEnd});
+};
+
+static void addImageCallback(const mach_header *mh, intptr_t vmaddr_slide) {
+  addImageCallback(mh);
+}
+
+static void initializeProtocolConformanceLookup() {
+  // If `objc_addLoadImageFunc` is available on this OS, use it.
+  // We don't use `__builtin_available` because that requires libraries that may
+  // not be linked into the binary carrying this compatibility shim.
+  auto objc_addLoadImageFunc = reinterpret_cast<void(*)(objc_func_loadImage)>(
+                                  dlsym(RTLD_DEFAULT, "objc_addLoadImageFunc"));
+  if (objc_addLoadImageFunc) {
+    objc_addLoadImageFunc(addImageCallback);
+  } else {
+    _dyld_register_func_for_add_image(addImageCallback);
+  }
+}
+
+ConformanceState::ConformanceState() {
+  initializeProtocolConformanceLookup();
+}
+
+struct ConformanceCacheResult {
+  // true if description is an authoritative result as-is.
+  // false if more searching is required (for example, because a cached
+  // failure was returned in failureEntry but it is out-of-date.
+  bool isAuthoritative;
+
+  // The matching conformance descriptor, or null if no cached conformance
+  // was found.
+  const ProtocolConformanceDescriptor *description;
+
+  // If the search fails, this may be the negative cache entry for the
+  // queried type itself. This entry may be null or out-of-date.
+  ConformanceCacheEntry *failureEntry;
+
+  static ConformanceCacheResult
+  cachedSuccess(const ProtocolConformanceDescriptor *description) {
+    return ConformanceCacheResult { true, description, nullptr };
+  }
+
+  static ConformanceCacheResult
+  cachedFailure(ConformanceCacheEntry *entry, bool auth) {
+    return ConformanceCacheResult { auth, nullptr, entry };
+  }
+
+  static ConformanceCacheResult
+  cacheMiss() {
+    return ConformanceCacheResult { false, nullptr, nullptr };
+  }
+};
+
+/// Retrieve the type key from the given metadata, to be used when looking
+/// into the conformance cache.
+static const void *getConformanceCacheTypeKey(const Metadata *type) {
+  if (auto description = getTypeContextDescriptor(type))
+    return description;
+
+  return type;
+}
+
+/// Search for a conformance descriptor in the ConformanceCache.
+static ConformanceCacheResult
+searchInConformanceCache(const Metadata *type,
+                         const ProtocolDescriptor *protocol) {
+  auto &C = Conformances.get();
+  auto origType = type;
+  ConformanceCacheEntry *failureEntry = nullptr;
+
+recur:
+  {
+    // Try the specific type first.
+    if (auto *Value = C.findCached(type, protocol)) {
+      if (Value->isSuccessful()) {
+        // Found a conformance on the type or some superclass. Return it.
+        return ConformanceCacheResult::cachedSuccess(Value->getDescription());
+      }
+
+      // Found a negative cache entry.
+
+      bool isAuthoritative;
+      if (type == origType) {
+        // This negative cache entry is for the original query type.
+        // Remember it so it can be returned later.
+        failureEntry = Value;
+        // An up-to-date entry for the original type is authoritative.
+        isAuthoritative = true;
+      } else {
+        // An up-to-date cached failure for a superclass of the type is not
+        // authoritative: there may be a still-undiscovered conformance
+        // for the original query type.
+        isAuthoritative = false;
+      }
+
+      // Check if the negative cache entry is up-to-date.
+      if (Value->getFailureGeneration() == C.SectionsToScan.snapshot().count()) {
+        // Negative cache entry is up-to-date. Return failure along with
+        // the original query type's own cache entry, if we found one.
+        // (That entry may be out of date but the caller still has use for it.)
+        return ConformanceCacheResult::cachedFailure(failureEntry,
+                                                     isAuthoritative);
+      }
+
+      // Negative cache entry is out-of-date.
+      // Continue searching for a better result.
+    }
+  }
+
+  {
+    // For generic and resilient types, nondependent conformances
+    // are keyed by the nominal type descriptor rather than the
+    // metadata, so try that.
+    auto typeKey = getConformanceCacheTypeKey(type);
+
+    // Hash and lookup the type-protocol pair in the cache.
+    if (auto *Value = C.findCached(typeKey, protocol)) {
+      if (Value->isSuccessful())
+        return ConformanceCacheResult::cachedSuccess(Value->getDescription());
+
+      // We don't try to cache negative responses for generic
+      // patterns.
+    }
+  }
+
+  // If there is a superclass, look there.
+  if (auto superclass = _swiftoverride_class_getSuperclass(type)) {
+    type = superclass;
+    goto recur;
+  }
+
+  // We did not find an up-to-date cache entry.
+  // If we found an out-of-date entry for the original query type then
+  // return it (non-authoritatively). Otherwise return a cache miss.
+  if (failureEntry)
+    return ConformanceCacheResult::cachedFailure(failureEntry, false);
+  else
+    return ConformanceCacheResult::cacheMiss();
+}
+
+} // end anonymous namespace
+
+const ProtocolConformanceDescriptor *
+swift::swift51override_conformsToSwiftProtocol(const Metadata * const type,
+                                           const ProtocolDescriptor *protocol,
+                                           StringRef module,
+                                           ConformsToSwiftProtocol_t *orig) {
+  auto &C = Conformances.get();
+
+  // See if we have a cached conformance. The ConcurrentMap data structure
+  // allows us to insert and search the map concurrently without locking.
+  auto FoundConformance = searchInConformanceCache(type, protocol);
+  // If the result (positive or negative) is authoritative, return it.
+  if (FoundConformance.isAuthoritative)
+    return FoundConformance.description;
+
+  auto failureEntry = FoundConformance.failureEntry;
+
+  // Prepare to scan conformance records.
+  auto snapshot = C.SectionsToScan.snapshot();
+  
+  // Scan only sections that were not scanned yet.
+  // If we found an out-of-date negative cache entry,
+  // we need not to re-scan the sections that it covers.
+  auto startIndex = failureEntry ? failureEntry->getFailureGeneration() : 0;
+  auto endIndex = snapshot.count();
+
+  // If there are no unscanned sections outstanding
+  // then we can cache failure and give up now.
+  if (startIndex == endIndex) {
+    C.cacheFailure(type, protocol, snapshot.count());
+    return nullptr;
+  }
+
+  // Really scan conformance records.
+  for (size_t i = startIndex; i < endIndex; i++) {
+    auto &section = snapshot.Start[i];
+    // Eagerly pull records for nondependent witnesses into our cache.
+    for (const auto &record : section) {
+      auto &descriptor = *record.get();
+
+      // We only care about conformances for this protocol.
+      if (descriptor.getProtocol() != protocol)
+        continue;
+
+      // If there's a matching type, record the positive result.
+      ConformanceCandidate candidate(descriptor);
+      if (candidate.getMatchingType(type)) {
+        const Metadata *matchingType = candidate.getConformingTypeAsMetadata();
+        if (!matchingType)
+          matchingType = type;
+
+        C.cacheSuccess(matchingType, protocol, &descriptor);
+      }
+    }
+  }
+  
+  // Conformance scan is complete.
+
+  // Search the cache once more, and this time update the cache if necessary.
+  FoundConformance = searchInConformanceCache(type, protocol);
+  if (FoundConformance.isAuthoritative) {
+    return FoundConformance.description;
+  } else {
+    C.cacheFailure(type, protocol, snapshot.count());
+    return nullptr;
+  }
+}
+

--- a/validation-test/Evolution/test_backward_deploy_conformance.swift
+++ b/validation-test/Evolution/test_backward_deploy_conformance.swift
@@ -1,14 +1,8 @@
 // RUN: %target-resilience-test --backward-deployment
 // REQUIRES: executable_test
 
-// This is testing a bug fix in the runtime so we don't want to run it on the
-// backward deployment bots.
-
-// UNSUPPORTED: use_os_stdlib
-
 import StdlibUnittest
 import backward_deploy_conformance
-
 
 var BackwardDeployConformanceTest = TestSuite("BackwardDeployConformance")
 


### PR DESCRIPTION
The runtime that shipped with Swift 5.1 and earlier had a bug that interfered with backward
deployment of binaries that dynamically check for protocol conformances on conditionally-available tests. This was fixed in the top-of-tree Swift runtime by https://github.com/apple/swift/pull/29887; however, that doesn't do much good for running binaries on older OSes that don't have that fix. In order for binaries built with a newer Swift compiler to run successfully on older OSes, introduce a compatibility hook that replaces the conformance cache implementation in the original OS runtime with a version based on the current implementation that has the fix for the protocol conformance bug. Fixes rdar://problem/59460603