### PR TITLE
[5.3][IDE][AST] Handle frameworks with traditional overlays where the underlying module declares cross imports in sourcekit

### DIFF
--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -272,6 +272,10 @@ public:
     return false;
   }
 
+  virtual ModuleDecl *getUnderlyingModuleIfOverlay() const {
+    return nullptr;
+  }
+
   /// Returns the associated clang module if one exists.
   virtual const clang::Module *getUnderlyingClangModule() const {
     return nullptr;

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -351,12 +351,16 @@ private:
   /// present overlays as if they were part of their underlying module.
   std::pair<ModuleDecl *, Identifier> getDeclaringModuleAndBystander();
 
+  ///  If this is a traditional (non-cross-import) overlay, get its underlying
+  ///  module if one exists.
+  ModuleDecl *getUnderlyingModuleIfOverlay() const;
+
 public:
 
   /// Returns true if this module is an underscored cross import overlay
-  /// declared by \p other, either directly or transitively (via intermediate
-  /// cross-import overlays - for cross-imports involving more than two
-  /// modules).
+  /// declared by \p other or its underlying clang module, either directly or
+  /// transitively (via intermediate cross-import overlays - for cross-imports
+  /// involving more than two modules).
   bool isCrossImportOverlayOf(ModuleDecl *other);
 
   /// If this module is an underscored cross-import overlay, returns the
@@ -365,16 +369,18 @@ public:
   /// cross-imports involving more than two modules).
   ModuleDecl *getDeclaringModuleIfCrossImportOverlay();
 
-  /// If this module is an underscored cross-import overlay of \p declaring
-  /// either directly or transitively, populates \p bystanderNames with the set
-  /// of bystander modules that must be present alongside \p declaring for
-  /// the overlay to be imported and returns true. Returns false otherwise.
+  /// If this module is an underscored cross-import overlay of \p declaring or
+  /// its underlying clang module, either directly or transitively, populates
+  /// \p bystanderNames with the set of bystander modules that must be present
+  /// alongside \p declaring for the overlay to be imported and returns true.
+  /// Returns false otherwise.
   bool getRequiredBystandersIfCrossImportOverlay(
       ModuleDecl *declaring, SmallVectorImpl<Identifier> &bystanderNames);
 
 
   /// Walks and loads the declared, underscored cross-import overlays of this
-  /// module, transitively, to find all overlays this module underlies.
+  /// module and its underlying clang module, transitively, to find all cross
+  /// import overlays this module underlies.
   ///
   /// This is used by tooling to present these overlays as part of this module.
   void findDeclaredCrossImportOverlaysTransitive(

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -416,6 +416,8 @@ public:
 
   virtual const clang::Module *getUnderlyingClangModule() const override;
 
+  virtual ModuleDecl *getUnderlyingModuleIfOverlay() const override;
+
   virtual bool getAllGenericSignatures(
                    SmallVectorImpl<GenericSignature> &genericSignatures)
                 override;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1716,6 +1716,14 @@ bool ModuleDecl::walk(ASTWalker &Walker) {
   return false;
 }
 
+ModuleDecl *ModuleDecl::getUnderlyingModuleIfOverlay() const {
+  for (auto *FU : getFiles()) {
+    if (auto *Mod = FU->getUnderlyingModuleIfOverlay())
+      return Mod;
+  }
+  return nullptr;
+}
+
 const clang::Module *ModuleDecl::findUnderlyingClangModule() const {
   for (auto *FU : getFiles()) {
     if (auto *Mod = FU->getUnderlyingClangModule())
@@ -1819,6 +1827,9 @@ void ModuleDecl::findDeclaredCrossImportOverlaysTransitive(
   SourceLoc unused;
 
   worklist.push_back(this);
+  if (auto *clangModule = getUnderlyingModuleIfOverlay())
+    worklist.push_back(clangModule);
+
   while (!worklist.empty()) {
     ModuleDecl *current = worklist.back();
     worklist.pop_back();
@@ -1838,10 +1849,34 @@ void ModuleDecl::findDeclaredCrossImportOverlaysTransitive(
           if (seen.insert(overlayMod).second) {
             overlayModules.push_back(overlayMod);
             worklist.push_back(overlayMod);
+            if (auto *clangModule = overlayMod->getUnderlyingModuleIfOverlay())
+              worklist.push_back(clangModule);
           }
         }
       }
     }
+  }
+}
+
+namespace {
+  using CrossImportMap =
+      llvm::SmallDenseMap<Identifier, SmallVector<OverlayFile *, 1>>;
+
+
+  Identifier getBystanderIfDeclaring(ModuleDecl *mod, ModuleDecl *overlay,
+                                     CrossImportMap modCrossImports) {
+    auto ret = std::find_if(modCrossImports.begin(), modCrossImports.end(),
+                            [&](CrossImportMap::iterator::value_type &pair) {
+      for (OverlayFile *file: std::get<1>(pair)) {
+        ArrayRef<Identifier> overlays = file->getOverlayModuleNames(
+            mod, SourceLoc(), std::get<0>(pair));
+        if (std::find(overlays.begin(), overlays.end(),
+                      overlay->getName()) != overlays.end())
+          return true;
+      }
+      return false;
+    });
+    return ret != modCrossImports.end() ? ret->first : Identifier();
   }
 }
 
@@ -1867,25 +1902,19 @@ ModuleDecl::getDeclaringModuleAndBystander() {
     if (!seen.insert(importedModule).second)
       continue;
 
-    using CrossImportMap =
-        llvm::SmallDenseMap<Identifier, SmallVector<OverlayFile *, 1>>;
-    CrossImportMap &crossImports = importedModule->declaredCrossImports;
+    Identifier bystander = getBystanderIfDeclaring(
+        importedModule, overlayModule, importedModule->declaredCrossImports);
+    if (!bystander.empty())
+      return *(declaringModuleAndBystander = {importedModule, bystander});
 
-    // If any of MD's cross imports declare this module as its overlay, report
-    // MD as the underlying module.
-    auto ret = std::find_if(crossImports.begin(), crossImports.end(),
-                            [&](CrossImportMap::iterator::value_type &pair) {
-      for (OverlayFile *file: std::get<1>(pair)) {
-        ArrayRef<Identifier> overlays = file->getOverlayModuleNames(
-            importedModule, SourceLoc(), std::get<0>(pair));
-        if (std::find(overlays.begin(), overlays.end(),
-                      overlayModule->getName()) != overlays.end())
-          return true;
-      }
-      return false;
-    });
-    if (ret != crossImports.end())
-      return *(declaringModuleAndBystander = {importedModule, ret->first});
+    // Also check the imported module's underlying module if it's a traditional
+    // overlay (i.e. not a cross-import overlay).
+    if (auto *clangModule = importedModule->getUnderlyingModuleIfOverlay()) {
+      Identifier bystander = getBystanderIfDeclaring(
+          clangModule, overlayModule, clangModule->declaredCrossImports);
+      if (!bystander.empty())
+        return *(declaringModuleAndBystander = {clangModule, bystander});
+    }
 
     if (!importedModule->hasUnderscoredNaming())
       continue;
@@ -1901,8 +1930,9 @@ ModuleDecl::getDeclaringModuleAndBystander() {
 
 bool ModuleDecl::isCrossImportOverlayOf(ModuleDecl *other) {
   ModuleDecl *current = this;
+  ModuleDecl *otherClang = other->getUnderlyingModuleIfOverlay();
   while ((current = current->getDeclaringModuleAndBystander().first)) {
-    if (current == other)
+    if (current == other || current == otherClang)
       return true;
   }
   return false;
@@ -1917,10 +1947,11 @@ ModuleDecl *ModuleDecl::getDeclaringModuleIfCrossImportOverlay() {
 
 bool ModuleDecl::getRequiredBystandersIfCrossImportOverlay(
     ModuleDecl *declaring, SmallVectorImpl<Identifier> &bystanderNames) {
+  auto *clangModule = declaring->getUnderlyingModuleIfOverlay();
   auto current = std::make_pair(this, Identifier());
   while ((current = current.first->getDeclaringModuleAndBystander()).first) {
     bystanderNames.push_back(current.second);
-    if (current.first == declaring)
+    if (current.first == declaring || current.first == clangModule)
       return true;
   }
   return false;

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1218,6 +1218,10 @@ StringRef SerializedASTFile::getTargetTriple() const {
   return File.getTargetTriple();
 }
 
+ModuleDecl *SerializedASTFile::getUnderlyingModuleIfOverlay() const {
+  return File.getUnderlyingModule();
+}
+
 const clang::Module *SerializedASTFile::getUnderlyingClangModule() const {
   if (auto *UnderlyingModule = File.getUnderlyingModule())
     return UnderlyingModule->findUnderlyingClangModule();

--- a/test/CrossImport/Inputs/rewrite-module-triples.py
+++ b/test/CrossImport/Inputs/rewrite-module-triples.py
@@ -43,7 +43,10 @@ def rewrite(parent, names, copy_fn, rm_fn):
             else:
                 copy_fn(path, new_path)
 
-        rm_fn(path)
+        if platform.system() == 'Windows':
+            rm_fn(u'\\'.join([u'\\\\?', os.path.normpath(path)]))
+        else:
+            rm_fn(path)
 
 
 for parent, dirs, files in os.walk(root_dir, topdown=False):

--- a/test/SourceKit/CursorInfo/cursor_info_cross_import_common_case.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_cross_import_common_case.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/../../CrossImport/Inputs/lib-templates/* %t/
+// RUN: %{python} %S/../../CrossImport/Inputs/rewrite-module-triples.py %t %module-target-triple
+
+import BystandingLibrary
+
+
+import SwiftFramework
+
+fromSwiftFramework()
+fromSwiftFrameworkCrossImport()
+
+
+import ClangFramework
+
+fromClangFramework()
+fromClangFrameworkCrossImport()
+
+
+import OverlaidClangFramework
+
+fromOverlaidClangFramework()
+fromOverlaidClangFrameworkOverlay()
+fromOverlaidClangFrameworkCrossImport()
+
+
+// RUN: %sourcekitd-test -req=cursor -print-raw-response -pos=10:1 %s -- -target %target-triple -Xfrontend -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks %s  | %FileCheck -check-prefix=CHECKSWIFT %s
+// RUN: %sourcekitd-test -req=cursor -print-raw-response -pos=11:1 %s -- -target %target-triple -Xfrontend -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks %s  | %FileCheck -check-prefix=CHECKSWIFT %s
+
+// RUN: %sourcekitd-test -req=cursor -print-raw-response -pos=16:1 %s -- -target %target-triple -Xfrontend -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks  %s | %FileCheck -check-prefix=CHECKCLANG %s
+// RUN: %sourcekitd-test -req=cursor -print-raw-response -pos=17:1 %s -- -target %target-triple -Xfrontend -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks  %s | %FileCheck -check-prefix=CHECKCLANG %s
+
+// RUN: %sourcekitd-test -req=cursor -print-raw-response -pos=22:1 %s -- -target %target-triple -Xfrontend -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks  %s | %FileCheck -check-prefix=CHECKOVERLAID %s
+// RUN: %sourcekitd-test -req=cursor -print-raw-response -pos=23:1 %s -- -target %target-triple -Xfrontend -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks  %s | %FileCheck -check-prefix=CHECKOVERLAID %s
+// RUN: %sourcekitd-test -req=cursor -print-raw-response -pos=24:1 %s -- -target %target-triple -Xfrontend -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks  %s | %FileCheck -check-prefix=CHECKOVERLAID %s
+
+// CHECKSWIFT: key.modulename: "SwiftFramework"
+// CHECKCLANG: key.modulename: "ClangFramework"
+// CHECKOVERLAID: key.modulename: "OverlaidClangFramework"

--- a/test/SourceKit/DocSupport/doc_cross_import_common.swift
+++ b/test/SourceKit/DocSupport/doc_cross_import_common.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/mcp)
+// RUN: cp -r %S/../../CrossImport/Inputs/lib-templates/* %t/
+// RUN: %{python} %S/../../CrossImport/Inputs/rewrite-module-triples.py %t %module-target-triple
+
+
+// RUN: %sourcekitd-test -req=doc-info -module SwiftFramework -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -module-cache-path %t/mcp > %t.response
+// RUN: %diff -u %s.SwiftFramework.response %t.response
+
+// RUN: %sourcekitd-test -req=doc-info -module ClangFramework -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -module-cache-path %t/mcp > %t.response
+// RUN: %diff -u %s.ClangFramework.response %t.response
+
+// RUN: %sourcekitd-test -req=doc-info -module OverlaidClangFramework -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -module-cache-path %t/mcp > %t.response
+// RUN: %diff -u %s.OverlaidClangFramework.response %t.response

--- a/test/SourceKit/DocSupport/doc_cross_import_common.swift.ClangFramework.response
+++ b/test/SourceKit/DocSupport/doc_cross_import_common.swift.ClangFramework.response
@@ -1,0 +1,79 @@
+
+func fromClangFramework()
+
+// MARK: - BystandingLibrary Additions
+
+import SwiftOnoneSupport
+
+// Available when BystandingLibrary is imported with ClangFramework
+func fromClangFrameworkCrossImport()
+
+
+[
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 6,
+    key.length: 18
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 28,
+    key.length: 39
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment.mark,
+    key.offset: 31,
+    key.length: 35
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 68,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 75,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 94,
+    key.length: 68
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 162,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 167,
+    key.length: 29
+  }
+]
+[
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.name: "fromClangFramework()",
+    key.usr: "c:@F@fromClangFramework",
+    key.offset: 1,
+    key.length: 25,
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromClangFramework</decl.name>()</decl.function.free>"
+  },
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.name: "fromClangFrameworkCrossImport()",
+    key.usr: "s:33_ClangFramework_BystandingLibrary04fromaB11CrossImportyyF",
+    key.offset: 162,
+    key.length: 36,
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromClangFrameworkCrossImport</decl.name>()</decl.function.free>",
+    key.required_bystanders: [
+      "BystandingLibrary"
+    ]
+  }
+]

--- a/test/SourceKit/DocSupport/doc_cross_import_common.swift.OverlaidClangFramework.response
+++ b/test/SourceKit/DocSupport/doc_cross_import_common.swift.OverlaidClangFramework.response
@@ -1,0 +1,110 @@
+import OverlaidClangFramework
+import SwiftOnoneSupport
+
+func fromOverlaidClangFramework()
+func fromOverlaidClangFrameworkOverlay()
+
+
+// MARK: - BystandingLibrary Additions
+
+
+// Available when BystandingLibrary is imported with OverlaidClangFramework
+func fromOverlaidClangFrameworkCrossImport()
+
+
+[
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 0,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 7,
+    key.length: 22
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 30,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 37,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 56,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 61,
+    key.length: 26
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 90,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 95,
+    key.length: 33
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 133,
+    key.length: 39
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment.mark,
+    key.offset: 136,
+    key.length: 35
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 174,
+    key.length: 76
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 250,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 255,
+    key.length: 37
+  }
+]
+[
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.name: "fromOverlaidClangFramework()",
+    key.usr: "c:@F@fromOverlaidClangFramework",
+    key.offset: 56,
+    key.length: 33,
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromOverlaidClangFramework</decl.name>()</decl.function.free>"
+  },
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.name: "fromOverlaidClangFrameworkOverlay()",
+    key.usr: "s:22OverlaidClangFramework04fromabC7OverlayyyF",
+    key.offset: 90,
+    key.length: 40,
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromOverlaidClangFrameworkOverlay</decl.name>()</decl.function.free>"
+  },
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.name: "fromOverlaidClangFrameworkCrossImport()",
+    key.usr: "s:41_OverlaidClangFramework_BystandingLibrary04fromabC11CrossImportyyF",
+    key.offset: 250,
+    key.length: 44,
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromOverlaidClangFrameworkCrossImport</decl.name>()</decl.function.free>",
+    key.required_bystanders: [
+      "BystandingLibrary"
+    ]
+  }
+]

--- a/test/SourceKit/DocSupport/doc_cross_import_common.swift.SwiftFramework.response
+++ b/test/SourceKit/DocSupport/doc_cross_import_common.swift.SwiftFramework.response
@@ -1,0 +1,80 @@
+import SwiftOnoneSupport
+
+func fromSwiftFramework()
+
+
+// MARK: - BystandingLibrary Additions
+
+
+// Available when BystandingLibrary is imported with SwiftFramework
+func fromSwiftFrameworkCrossImport()
+
+
+[
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 0,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 7,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 26,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 31,
+    key.length: 18
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 54,
+    key.length: 39
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment.mark,
+    key.offset: 57,
+    key.length: 35
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 95,
+    key.length: 68
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 163,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 168,
+    key.length: 29
+  }
+]
+[
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.name: "fromSwiftFramework()",
+    key.usr: "s:14SwiftFramework04fromaB0yyF",
+    key.offset: 26,
+    key.length: 25,
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromSwiftFramework</decl.name>()</decl.function.free>"
+  },
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.name: "fromSwiftFrameworkCrossImport()",
+    key.usr: "s:33_SwiftFramework_BystandingLibrary04fromaB11CrossImportyyF",
+    key.offset: 163,
+    key.length: 36,
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromSwiftFrameworkCrossImport</decl.name>()</decl.function.free>",
+    key.required_bystanders: [
+      "BystandingLibrary"
+    ]
+  }
+]

--- a/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift
+++ b/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift
@@ -1,0 +1,54 @@
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/mcp)
+// RUN: cp -r %S/../../CrossImport/Inputs/lib-templates/* %t/
+// RUN: %{python} %S/../../CrossImport/Inputs/rewrite-module-triples.py %t %module-target-triple
+
+// 1) Check the interface shows the decls from each of SwiftFramework's cross-import overlays.
+//
+// RUN: %sourcekitd-test -req=interface-gen -module SwiftFramework -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -module-cache-path %t/mcp > %t.response
+// RUN: %diff -u %s.SwiftFramework.response %t.response
+
+// Make sure cursor info within the generated interface of SwiftFramework on one of the
+// decls originally from a cross-import decls shows 'SwiftFramework' as the parent module.
+//
+// RUN: %sourcekitd-test -req=interface-gen-open -module SwiftFramework -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -module-cache-path %t/mcp == -req=cursor -print-raw-response -pos=10:13 -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -Xfrontend -enable-cross-import-overlays > %t.response
+// RUN: %FileCheck --input-file %t.response --check-prefix=CHECKSWIFT %s
+//
+// CHECKSWIFT: key.name: "fromSwiftFrameworkCrossImport()"
+// CHECKSWIFT: key.modulename: "SwiftFramework"
+
+
+// 2) Check the interface shows the decls from each of ClangFramework's cross-import overlays.
+//
+// RUN: %sourcekitd-test -req=interface-gen -module ClangFramework -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -module-cache-path %t/mcp > %t.response
+// RUN: %diff -u %s.ClangFramework.response %t.response
+
+// Make sure cursor info within the generated interface of ClangFramework on one of the
+// decls originally from a cross-import decls shows 'ClangFramework' as the parent module.
+//
+// RUN: %sourcekitd-test -req=interface-gen-open -module ClangFramework -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -module-cache-path %t/mcp == -req=cursor -print-raw-response -pos=9:13 -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -Xfrontend -enable-cross-import-overlays > %t.response
+// RUN: %FileCheck --input-file %t.response --check-prefix=CHECKCLANG %s
+//
+// CHECKCLANG: key.name: "fromClangFrameworkCrossImport()"
+// CHECKCLANG: key.modulename: "ClangFramework"
+
+
+// 2) Check the interface shows the decls from each of OverlaidClangFramework's cross-import overlays.
+//
+// RUN: %sourcekitd-test -req=interface-gen -module OverlaidClangFramework -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -module-cache-path %t/mcp > %t.response
+// RUN: %diff -u %s.OverlaidClangFramework.response %t.response
+
+// Make sure cursor info within the generated interface of OverlaidClangFramework on one of the
+// decls originally from a cross-import decls shows 'OverlaidClangFramework' as the parent module.
+//
+// RUN: %sourcekitd-test -req=interface-gen-open -module OverlaidClangFramework -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -module-cache-path %t/mcp == -req=cursor -print-raw-response -pos=12:13 -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -Xfrontend -enable-cross-import-overlays > %t.response
+// RUN: %FileCheck --input-file %t.response --check-prefix=CHECKOVERLAIDCLANG %s
+//
+// CHECKOVERLAIDCLANG: key.name: "fromOverlaidClangFrameworkCrossImport()"
+// CHECKOVERLAIDCLANG: key.modulename: "OverlaidClangFramework"
+
+
+
+
+

--- a/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift.ClangFramework.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift.ClangFramework.response
@@ -1,0 +1,110 @@
+
+public func fromClangFramework()
+
+// MARK: - BystandingLibrary Additions
+
+import SwiftOnoneSupport
+
+// Available when BystandingLibrary is imported with ClangFramework
+public func fromClangFrameworkCrossImport()
+
+
+[
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 8,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 13,
+    key.length: 18
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 35,
+    key.length: 39
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment.mark,
+    key.offset: 38,
+    key.length: 35
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 75,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 82,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 101,
+    key.length: 68
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 169,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 176,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 181,
+    key.length: 29
+  }
+]
+[
+  {
+    key.kind: source.lang.swift.ref.module,
+    key.offset: 82,
+    key.length: 17,
+    key.is_system: 1
+  }
+]
+[
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "fromClangFramework()",
+    key.offset: 8,
+    key.length: 25,
+    key.nameoffset: 13,
+    key.namelength: 20,
+    key.attributes: [
+      {
+        key.offset: 1,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "fromClangFrameworkCrossImport()",
+    key.offset: 176,
+    key.length: 36,
+    key.nameoffset: 181,
+    key.namelength: 31,
+    key.attributes: [
+      {
+        key.offset: 169,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
+  }
+]

--- a/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift.OverlaidClangFramework.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift.OverlaidClangFramework.response
@@ -1,0 +1,159 @@
+import OverlaidClangFramework
+import SwiftOnoneSupport
+
+public func fromOverlaidClangFramework()
+public func fromOverlaidClangFrameworkOverlay()
+
+
+// MARK: - BystandingLibrary Additions
+
+
+// Available when BystandingLibrary is imported with OverlaidClangFramework
+public func fromOverlaidClangFrameworkCrossImport()
+
+
+[
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 0,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 7,
+    key.length: 22
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 30,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 37,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 56,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 63,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 68,
+    key.length: 26
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 97,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 104,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 109,
+    key.length: 33
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 147,
+    key.length: 39
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment.mark,
+    key.offset: 150,
+    key.length: 35
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 188,
+    key.length: 76
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 264,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 271,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 276,
+    key.length: 37
+  }
+]
+[
+  {
+    key.kind: source.lang.swift.ref.module,
+    key.offset: 7,
+    key.length: 22
+  },
+  {
+    key.kind: source.lang.swift.ref.module,
+    key.offset: 37,
+    key.length: 17,
+    key.is_system: 1
+  }
+]
+[
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "fromOverlaidClangFramework()",
+    key.offset: 63,
+    key.length: 33,
+    key.nameoffset: 68,
+    key.namelength: 28,
+    key.attributes: [
+      {
+        key.offset: 56,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "fromOverlaidClangFrameworkOverlay()",
+    key.offset: 104,
+    key.length: 40,
+    key.nameoffset: 109,
+    key.namelength: 35,
+    key.attributes: [
+      {
+        key.offset: 97,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "fromOverlaidClangFrameworkCrossImport()",
+    key.offset: 271,
+    key.length: 44,
+    key.nameoffset: 276,
+    key.namelength: 39,
+    key.attributes: [
+      {
+        key.offset: 264,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
+  }
+]

--- a/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift.SwiftFramework.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift.SwiftFramework.response
@@ -1,0 +1,111 @@
+import SwiftOnoneSupport
+
+public func fromSwiftFramework()
+
+
+// MARK: - BystandingLibrary Additions
+
+
+// Available when BystandingLibrary is imported with SwiftFramework
+public func fromSwiftFrameworkCrossImport()
+
+
+[
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 0,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 7,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 26,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 33,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 38,
+    key.length: 18
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 61,
+    key.length: 39
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment.mark,
+    key.offset: 64,
+    key.length: 35
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 102,
+    key.length: 68
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 170,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 177,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 182,
+    key.length: 29
+  }
+]
+[
+  {
+    key.kind: source.lang.swift.ref.module,
+    key.offset: 7,
+    key.length: 17,
+    key.is_system: 1
+  }
+]
+[
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "fromSwiftFramework()",
+    key.offset: 33,
+    key.length: 25,
+    key.nameoffset: 38,
+    key.namelength: 20,
+    key.attributes: [
+      {
+        key.offset: 26,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "fromSwiftFrameworkCrossImport()",
+    key.offset: 177,
+    key.length: 36,
+    key.nameoffset: 182,
+    key.namelength: 31,
+    key.attributes: [
+      {
+        key.offset: 170,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
+  }
+]


### PR DESCRIPTION
cherry-pick of https://github.com/apple/swift/pull/31227 for 5.3

We weren't handling this case, so their generated interfaces / doc info wouldn't include symbols from the cross-import overlays, and we wouldn't map the underscored cross-import overlay name back to the declaring framework's name in cusor-info, completion results or when indexing.

Resolves rdar://problem/62138551