### PR TITLE
Sema: Verify the conditional requirements of a type witness candidate decl. context

### DIFF
--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -71,6 +71,7 @@ struct TypeWitnessConflict {
 ///
 /// This class evaluates true if an error occurred.
 class CheckTypeWitnessResult {
+  /// The requirement that the type witness does not satisfy.
   Type Requirement;
 
 public:


### PR DESCRIPTION
This fixes a special case of SR-12663 when the candidate is declared on the conformance adoptee (or an extension of it).
