### PR TITLE
[sil-combine] Refactor rewriteApplyCallee -> cloneFullApplySiteReplacingCallee and move into InstOptUtils.h.

### DIFF
--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -578,6 +578,15 @@ bool tryOptimizeApplyOfPartialApply(
     PartialApplyInst *pai, SILBuilderContext &builderCtxt,
     InstModCallbacks callbacks = InstModCallbacks());
 
+/// Clone this full apply site, replacing the callee with \p newCallee while
+/// doing so.
+///
+/// The current full apply site is used as an insertion point, so the caller
+/// must clean up this full apply site.
+FullApplySite cloneFullApplySiteReplacingCallee(FullApplySite applySite,
+                                                SILValue newCallee,
+                                                SILBuilderContext &builderCtx);
+
 } // end namespace swift
 
 #endif

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -260,8 +260,6 @@ private:
         });
   }
 
-  FullApplySite rewriteApplyCallee(FullApplySite apply, SILValue callee);
-
   // Build concrete existential information using findInitExistential.
   Optional<ConcreteOpenedExistentialInfo>
   buildConcreteOpenedExistentialInfo(Operand &ArgOperand);


### PR DESCRIPTION
I am going to use this in mandatory combine, and it seems like a generally
useful transformation.

I also updated the routine to construct its own SILBuilder that injects a user
passed in SILBuilderContext eliminating the bad pattern of passing in
SILBuilders.

This should be an NFC change.
