### PR TITLE
[metadata prespecialization] Reenable for stdlib.

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1398,13 +1398,18 @@ void IRGenModule::error(SourceLoc loc, const Twine &message) {
 bool IRGenModule::useDllStorage() { return ::useDllStorage(Triple); }
 
 bool IRGenModule::shouldPrespecializeGenericMetadata() {
+  auto canPrespecializeTarget =
+      (Triple.isOSDarwin() || Triple.isTvOS() || Triple.isOSLinux());
+  if (canPrespecializeTarget && isStandardLibrary()) {
+    return true;
+  }
   auto &context = getSwiftModule()->getASTContext();
   auto deploymentAvailability =
       AvailabilityContext::forDeploymentTarget(context);
-  return IRGen.Opts.PrespecializeGenericMetadata && 
-    deploymentAvailability.isContainedIn(
-      context.getPrespecializedGenericMetadataAvailability()) &&
-    (Triple.isOSDarwin() || Triple.isTvOS() || Triple.isOSLinux());
+  return IRGen.Opts.PrespecializeGenericMetadata &&
+         deploymentAvailability.isContainedIn(
+             context.getPrespecializedGenericMetadataAvailability()) &&
+         canPrespecializeTarget;
 }
 
 void IRGenerator::addGenModule(SourceFile *SF, IRGenModule *IGM) {


### PR DESCRIPTION
Whenever building the stdlib for a supported platform, enable metadata prespecialization for it.