### PR TITLE
[CodeCompletion] Don't perform completion at declaration name position

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4331,6 +4331,21 @@ parseIdentifierDeclName(Parser &P, Identifier &Result, SourceLoc &Loc,
     return makeParserError();
   }
 
+  // If there is expected tokens after the code completion token, just eat the
+  // code completion token. We don't need code completion here.
+  // E.g.:
+  //   'func' <completion> ('('|'<')
+  //   'typealias' <completion> ('='|'<')
+  // If there's no expected token after the completion, override completion may
+  // kicks in. So leave the token here.
+  // E.g.
+  //   'func' <completion>
+  //   'init' <completion>
+  if (P.Tok.is(tok::code_complete) && canRecover(P.peekToken())) {
+    P.consumeToken(tok::code_complete);
+    return makeParserCodeCompletionStatus();
+  }
+
   P.diagnose(P.Tok, diag::expected_identifier_in_decl, DeclKindName);
   return makeParserError();
 }
@@ -4882,7 +4897,7 @@ parseDeclTypeAlias(Parser::ParseDeclOptions Flags, DeclAttributes &Attributes) {
       [](const Token &next) { return next.isAny(tok::colon, tok::equal); });
   if (Status.isError()) {
     TmpCtxt->setTransparent();
-    return nullptr;
+    return Status;
   }
     
   DebuggerContextChange DCC(*this, Id, DeclKind::TypeAlias);
@@ -4998,8 +5013,8 @@ ParserResult<TypeDecl> Parser::parseDeclAssociatedType(Parser::ParseDeclOptions 
       *this, Id, IdLoc, "associatedtype",
       [](const Token &next) { return next.isAny(tok::colon, tok::equal); });
   if (Status.isError())
-    return nullptr;
-  
+    return Status;
+
   DebuggerContextChange DCC(*this, Id, DeclKind::AssociatedType);
   
   // Reject generic parameters with a specific error.
@@ -6237,7 +6252,7 @@ ParserResult<FuncDecl> Parser::parseDeclFunc(SourceLoc StaticLoc,
                  startsWithLess(next);
         });
     if (NameStatus.isError())
-      return nullptr;
+      return NameStatus;
   }
 
   DebuggerContextChange DCC(*this, SimpleName, DeclKind::Func);
@@ -6510,7 +6525,7 @@ ParserResult<EnumDecl> Parser::parseDeclEnum(ParseDeclOptions Flags,
         return next.isAny(tok::colon, tok::l_brace) || startsWithLess(next);
       });
   if (Status.isError())
-    return nullptr;
+    return Status;
 
   DebuggerContextChange DCC(*this, EnumName, DeclKind::Enum);
   
@@ -6792,7 +6807,7 @@ ParserResult<StructDecl> Parser::parseDeclStruct(ParseDeclOptions Flags,
         return next.isAny(tok::colon, tok::l_brace) || startsWithLess(next);
       });
   if (Status.isError())
-    return nullptr;
+    return Status;
 
   DebuggerContextChange DCC (*this, StructName, DeclKind::Struct);
   
@@ -6885,7 +6900,7 @@ ParserResult<ClassDecl> Parser::parseDeclClass(ParseDeclOptions Flags,
         return next.isAny(tok::colon, tok::l_brace) || startsWithLess(next);
       });
   if (Status.isError())
-    return nullptr;
+    return Status;
 
   DebuggerContextChange DCC (*this, ClassName, DeclKind::Class);
   
@@ -7005,7 +7020,7 @@ parseDeclProtocol(ParseDeclOptions Flags, DeclAttributes &Attributes) {
       *this, ProtocolName, NameLoc, "protocol",
       [&](const Token &next) { return next.isAny(tok::colon, tok::l_brace); });
   if (Status.isError())
-    return nullptr;
+    return Status;
 
   // Protocols don't support generic parameters, but people often want them and
   // we want to have good error recovery if they try them out.  Parse them and

--- a/test/IDE/complete_declname.swift
+++ b/test/IDE/complete_declname.swift
@@ -18,6 +18,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-keywords=false -code-completion-token=METHODNAME_PROTOCOL | %FileCheck %s --check-prefix=NO_COMPLETIONS
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-keywords=false -code-completion-token=METHODNAME_CONFORMANCE | %FileCheck %s --check-prefix=METHODNAME_CONFORMANCE
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-keywords=false -code-completion-token=TYPEALIASNAME_CONFORMANCE | %FileCheck %s --check-prefix=TYPEALIASNAME_CONFORMANCE
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-keywords=false -code-completion-token=METHODNAME_HASSIG | %FileCheck %s --check-prefix=NO_COMPLETIONS
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-keywords=false -code-completion-token=TYPEALIASNAME_HASSIG | %FileCheck %s --check-prefix=NO_COMPLETIONS
 
 // NO_COMPLETIONS-NOT: Begin completions
 
@@ -59,8 +61,15 @@ struct MyStruct : P {
 // METHODNAME_CONFORMANCE: Begin completions, 1 items
 // METHODNAME_CONFORMANCE-NEXT: Decl[InstanceMethod]/Super: foo() {|}; name=foo()
 // METHODNAME_CONFORMANCE-NEXT: End completions
+
   typealias #^TYPEALIASNAME_CONFORMANCE^#
 // TYPEALIASNAME_CONFORMANCE: Begin completions, 1 items
 // TYPEALIASNAME_CONFORMANCE-NEXT: Decl[AssociatedType]/Super: Assoc = {#(Type)#}; name=Assoc = Type
 // TYPEALIASNAME_CONFORMANCE-NEXT: End completions
+}
+struct MyStruct2: P {
+  func #^METHODNAME_HASSIG^#() (<#parameters#>} {}
+// INVALID
+  typealias #^TYPEALIASNAME_HASSIG^# = <#type#>
+// INVALID
 }


### PR DESCRIPTION
If there's expected signature after the code completion. For example:
```
  func #^HERE^#(arg: Int) {}
```
This is clearly modifying the function name. We should not perform any completion including override completion.

rdar://problem/58378950
