### PR TITLE
SILOptimizer: reorganize the optimization-prepare passpipeline

### DIFF
--- a/include/swift/SILOptimizer/PassManager/PassPipeline.def
+++ b/include/swift/SILOptimizer/PassManager/PassPipeline.def
@@ -24,7 +24,6 @@
 
 PASSPIPELINE(Diagnostic, "Guaranteed Passes")
 PASSPIPELINE(OwnershipEliminator, "Utility pass to just run the ownership eliminator pass")
-PASSPIPELINE(SILOptPrepare, "Passes that prepare SIL for -O")
 PASSPIPELINE(Performance, "Passes run at -O")
 PASSPIPELINE(Onone, "Passes run at -Onone")
 PASSPIPELINE(InstCount, "Utility pipeline to just run the inst count pass")

--- a/include/swift/SILOptimizer/PassManager/Passes.h
+++ b/include/swift/SILOptimizer/PassManager/Passes.h
@@ -33,9 +33,6 @@ namespace swift {
   /// \returns true if the diagnostic passes produced an error
   bool runSILDiagnosticPasses(SILModule &M);
 
-  /// Prepare SIL for the -O pipeline.
-  void runSILOptPreparePasses(SILModule &Module);
-
   /// Run all the SIL performance optimization passes on \p M.
   void runSILOptimizationPasses(SILModule &M);
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1062,8 +1062,6 @@ static void performSILOptimizations(CompilerInvocation &Invocation,
     runSILPassesForOnone(*SM);
     return;
   }
-  runSILOptPreparePasses(*SM);
-
   StringRef CustomPipelinePath =
   Invocation.getSILOptions().ExternalPassPipelineFilename;
   if (!CustomPipelinePath.empty()) {

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -84,13 +84,6 @@ bool swift::runSILOwnershipEliminatorPass(SILModule &Module) {
   return Ctx.hadError();
 }
 
-// Prepare SIL for the -O pipeline.
-void swift::runSILOptPreparePasses(SILModule &Module) {
-  auto &opts = Module.getOptions();
-  auto plan = SILPassPipelinePlan::getSILOptPreparePassPipeline(opts);
-  executePassPipelinePlan(&Module, plan);
-}
-
 void swift::runSILOptimizationPasses(SILModule &Module) {
   auto &opts = Module.getOptions();
 

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -480,7 +480,6 @@ int main(int argc, char **argv) {
   if (OptimizationGroup == OptGroup::Diagnostics) {
     runSILDiagnosticPasses(*CI.getSILModule());
   } else if (OptimizationGroup == OptGroup::Performance) {
-    runSILOptPreparePasses(*CI.getSILModule());
     runSILOptimizationPasses(*CI.getSILModule());
   } else if (OptimizationGroup == OptGroup::Lowering) {
     runSILLoweringPasses(*CI.getSILModule());


### PR DESCRIPTION
Don't create a separate pass manager for those passes, just let them run at the beginning of the performance pipeline.
Regarding generated code this is a NFC.

This change fixes a problem with pass-bisecting (for debugging). Having two instances of the pass manager can cause troubles with bisecting, because -sil-opt-pass-count affects both pass managers at the same time.
