### PR TITLE
Reorganize and consolidate the `SwiftGlibc` module map.

### DIFF
--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -511,8 +511,8 @@ module SwiftGlibc [system] {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/wait.h"
         export *
       }
-    }
 % end
+    }
 % if CMAKE_SDK in ["LINUX", "FREEBSD"]:
     module sysexits {
       header "${GLIBC_INCLUDE_PATH}/sysexits.h"
@@ -534,8 +534,8 @@ module SwiftGlibc [system] {
       header "${GLIBC_INCLUDE_PATH}/utime.h"
       export *
     }
-  }
 % end
+  }
 }
 
 % if CMAKE_SDK != "WASI":

--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -53,32 +53,6 @@ module SwiftGlibc [system] {
       export *
     }
 % end
-% if CMAKE_SDK in ["LINUX", "CYGWIN"]:
-    module pty {
-      header "${GLIBC_INCLUDE_PATH}/pty.h"
-      export *
-    }
-    module utmp {
-      header "${GLIBC_INCLUDE_PATH}/utmp.h"
-      export *
-    }
-% end
-% if CMAKE_SDK == "FREEBSD":
-    module pty {
-      header "${GLIBC_INCLUDE_PATH}/libutil.h"
-      export *
-    }
-    module utmp {
-      header "${GLIBC_INCLUDE_PATH}/utmpx.h"
-      export *
-    }
-% end
-% if CMAKE_SDK == "HAIKU":
-    module pty {
-      header "${GLIBC_INCLUDE_PATH}/../bsd/pty.h"
-      export *
-    }
-% end
 
     module ctype {
       header "${GLIBC_INCLUDE_PATH}/ctype.h"
@@ -184,6 +158,10 @@ module SwiftGlibc [system] {
   // POSIX
   module POSIX {
 % if CMAKE_SDK in ["LINUX", "CYGWIN"]:
+    module utmp {
+      header "${GLIBC_INCLUDE_PATH}/utmp.h"
+      export *
+    }
     module wait {
       header "${GLIBC_INCLUDE_PATH}/wait.h"
       export *
@@ -380,6 +358,24 @@ module SwiftGlibc [system] {
 % if CMAKE_SDK != "WASI":
     module pthread {
       header "${GLIBC_INCLUDE_PATH}/pthread.h"
+      export *
+    }
+% end
+% if CMAKE_SDK in ["LINUX", "CYGWIN"]:
+    module pty {
+      header "${GLIBC_INCLUDE_PATH}/pty.h"
+      export *
+    }
+% end
+% if CMAKE_SDK == "FREEBSD":
+    module pty {
+      header "${GLIBC_INCLUDE_PATH}/libutil.h"
+      export *
+    }
+% end
+% if CMAKE_SDK == "HAIKU":
+    module pty {
+      header "${GLIBC_INCLUDE_PATH}/../bsd/pty.h"
       export *
     }
 % end

--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -191,17 +191,13 @@ module SwiftGlibc [system] {
     }
 % end
 
-% if CMAKE_SDK in ["LINUX", "FREEBSD", "CYGWIN"]:
+% if CMAKE_SDK in ["LINUX", "FREEBSD", "CYGWIN", "HAIKU"]:
     module ftw {
       header "${GLIBC_INCLUDE_PATH}/ftw.h"
       export *
     }
     module glob {
       header "${GLIBC_INCLUDE_PATH}/glob.h"
-      export *
-    }
-    module iconv {
-      header "${GLIBC_INCLUDE_PATH}/iconv.h"
       export *
     }
     module langinfo {
@@ -216,16 +212,8 @@ module SwiftGlibc [system] {
       header "${GLIBC_INCLUDE_PATH}/netdb.h"
       export *
     }
-    module ifaddrs {
-      header "${GLIBC_INCLUDE_PATH}/ifaddrs.h"
-      export *
-    }
     module search {
       header "${GLIBC_INCLUDE_PATH}/search.h"
-      export *
-    }
-    module spawn {
-      header "${GLIBC_INCLUDE_PATH}/spawn.h"
       export *
     }
     module syslog {
@@ -234,6 +222,21 @@ module SwiftGlibc [system] {
     }
     module tar {
       header "${GLIBC_INCLUDE_PATH}/tar.h"
+      export *
+    }
+% end
+
+% if CMAKE_SDK in ["LINUX", "FREEBSD", "CYGWIN"]:
+    module iconv {
+      header "${GLIBC_INCLUDE_PATH}/iconv.h"
+      export *
+    }
+    module ifaddrs {
+      header "${GLIBC_INCLUDE_PATH}/ifaddrs.h"
+      export *
+    }
+    module spawn {
+      header "${GLIBC_INCLUDE_PATH}/spawn.h"
       export *
     }
     module utmpx {
@@ -247,47 +250,16 @@ module SwiftGlibc [system] {
 % end
 
 % if CMAKE_SDK == "HAIKU":
-    module ftw {
-      header "${GLIBC_INCLUDE_PATH}/ftw.h"
-      export *
-    }
-    module glob {
-      header "${GLIBC_INCLUDE_PATH}/glob.h"
-      export *
-    }
     module iconv {
       header "${GLIBC_INCLUDE_PATH}/../iconv.h"
-      export *
-    }
-    module langinfo {
-      header "${GLIBC_INCLUDE_PATH}/langinfo.h"
-      export *
-    }
-    module monetary {
-      header "${GLIBC_INCLUDE_PATH}/monetary.h"
-      export *
-    }
-    module netdb {
-      header "${GLIBC_INCLUDE_PATH}/netdb.h"
       export *
     }
     module ifaddrs {
       header "${GLIBC_INCLUDE_PATH}/../bsd/ifaddrs.h"
       export *
     }
-    module search {
-      header "${GLIBC_INCLUDE_PATH}/search.h"
-      export *
-    }
-    module syslog {
-      header "${GLIBC_INCLUDE_PATH}/syslog.h"
-      export *
-    }
-    module tar {
-      header "${GLIBC_INCLUDE_PATH}/tar.h"
-      export *
-    }
 % end
+
     module arpa {
       module inet {
         header "${GLIBC_INCLUDE_PATH}/arpa/inet.h"


### PR DESCRIPTION
Specifically:
*  Fix conditional blocks for `WASI` containing unbalanced braces.
*  Move submodules `pty` and `utmp` from `C` to `POSIX`. These aren't really POSIX headers either, but they certainly aren't C standard library headers. For `FREEBSD`, delete submodule `utmp` entirely as it was providing the same header (`utmpx.h`) as submodule `utmpx`.
*  Consolidate the submodules that `HAIKU` shares with `LINUX`, `FREEBSD` and `CYGWIN`.

Moving `pty` and `utmp` changes the submodule structure, but this isn't visible anyway to clients of the Swift module `Glibc`, as reexporting `SwiftGlibc` from `Glibc` loses the submodule structure.

I'm not sure how to test the `WASI` build, as glibc.modulemap currently doesn't even get built on `WASI` (which is likely why the unbalanced braces haven't been noticed). However, it does continue to build fine on Linux.

I've structured this PR into several commits; it may be easiest to review the PR by looking at those individual commits.