### PR TITLE
Add forced precomputation and verification of analysis

### DIFF
--- a/include/swift/SILOptimizer/Analysis/Analysis.h
+++ b/include/swift/SILOptimizer/Analysis/Analysis.h
@@ -137,6 +137,8 @@ public:
   /// specific verification will do so.
   virtual void verify(SILFunction *F) const { verify(); }
 
+  virtual void forcePrecompute(SILFunction *F) {}
+
   /// Perform a potentially more expensive verification of the state of this
   /// analysis.
   ///
@@ -232,6 +234,15 @@ public:
     if (!it.second)
       it.second = newFunctionAnalysis(f);
     return it.second.get();
+  }
+
+  virtual void forcePrecompute(SILFunction *f) override {
+    // Check that the analysis can handle this function.
+    verifyFunction(f);
+
+    auto &it = storage.FindAndConstruct(f);
+    if (!it.second)
+      it.second = newFunctionAnalysis(f);
   }
 
   /// Invalidate all information in this analysis.

--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -242,6 +242,13 @@ public:
     }
   }
 
+  /// Precompute all analyses.
+  void forcePrecomputeAnalyses(SILFunction *F) {
+    for (auto *A : Analyses) {
+      A->forcePrecompute(F);
+    }
+  }
+
   /// Verify all analyses, limiting the verification to just this one function
   /// if possible.
   ///

--- a/test/SILOptimizer/sil_combine_concrete_existential.swift
+++ b/test/SILOptimizer/sil_combine_concrete_existential.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -O -emit-sil -sil-verify-all -Xllvm -sil-disable-pass=function-signature-opts %s | %FileCheck %s
+// %target-swift-frontend -O -emit-sil -Xllvm -sil-verify-force-analysis-around-pass=devirtualizer -Xllvm -sil-disable-pass=function-signature-opts %s | %FileCheck %s
 
 //===----------------------------------------------------------------------===//
 // testReturnSelf: Call to a protocol extension method with


### PR DESCRIPTION
This is cherry-pick of #31251  

-sil-verify-all flag will verify analyses before and after a pass to
confirm correct invalidations. But if an analysis was never
constructed or invalidated as per current pass order,
it may never detect insufficient invalidations.

-sil-verify-force-analysis will force construct an analysis so that we
can better check for insufficient invalidations.
It is also terribly slow compared to -sil-verify-all.
