### PR TITLE
Reduce generics in Codable

### DIFF
--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -3635,92 +3635,92 @@ internal final class _KeyedEncodingContainerBox<
 
   override internal func encodeNil<K: CodingKey>(forKey key: K) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encodeNil(forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeNil(forKey: key)
   }
 
   override internal func encode<K: CodingKey>(_ value: Bool, forKey key: K) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encode(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: key)
   }
 
   override internal func encode<K: CodingKey>(_ value: String, forKey key: K) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encode(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: key)
   }
 
   override internal func encode<K: CodingKey>(_ value: Double, forKey key: K) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encode(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: key)
   }
 
   override internal func encode<K: CodingKey>(_ value: Float, forKey key: K) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encode(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: key)
   }
 
   override internal func encode<K: CodingKey>(_ value: Int, forKey key: K) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encode(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: key)
   }
 
   override internal func encode<K: CodingKey>(_ value: Int8, forKey key: K) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encode(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: key)
   }
 
   override internal func encode<K: CodingKey>(_ value: Int16, forKey key: K) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encode(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: key)
   }
 
   override internal func encode<K: CodingKey>(_ value: Int32, forKey key: K) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encode(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: key)
   }
 
   override internal func encode<K: CodingKey>(_ value: Int64, forKey key: K) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encode(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: key)
   }
 
   override internal func encode<K: CodingKey>(_ value: UInt, forKey key: K) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encode(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: key)
   }
 
   override internal func encode<K: CodingKey>(_ value: UInt8, forKey key: K) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encode(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: key)
   }
 
   override internal func encode<K: CodingKey>(_ value: UInt16, forKey key: K) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encode(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: key)
   }
 
   override internal func encode<K: CodingKey>(_ value: UInt32, forKey key: K) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encode(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: key)
   }
 
   override internal func encode<K: CodingKey>(_ value: UInt64, forKey key: K) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encode(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: key)
   }
 
   override internal func encode<T: Encodable, K: CodingKey>(
@@ -3728,8 +3728,8 @@ internal final class _KeyedEncodingContainerBox<
     forKey key: K
   ) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encode(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: key)
   }
 
   override internal func encodeConditional<T: AnyObject & Encodable, K: CodingKey>(
@@ -3737,8 +3737,8 @@ internal final class _KeyedEncodingContainerBox<
     forKey key: K
   ) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encodeConditional(object, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeConditional(object, forKey: key)
   }
 
   override internal func encodeIfPresent<K: CodingKey>(
@@ -3746,8 +3746,8 @@ internal final class _KeyedEncodingContainerBox<
     forKey key: K
   ) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encodeIfPresent(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: key)
   }
 
   override internal func encodeIfPresent<K: CodingKey>(
@@ -3755,8 +3755,8 @@ internal final class _KeyedEncodingContainerBox<
     forKey key: K
   ) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encodeIfPresent(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: key)
   }
 
   override internal func encodeIfPresent<K: CodingKey>(
@@ -3764,8 +3764,8 @@ internal final class _KeyedEncodingContainerBox<
     forKey key: K
   ) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encodeIfPresent(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: key)
   }
 
   override internal func encodeIfPresent<K: CodingKey>(
@@ -3773,8 +3773,8 @@ internal final class _KeyedEncodingContainerBox<
     forKey key: K
   ) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encodeIfPresent(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: key)
   }
 
   override internal func encodeIfPresent<K: CodingKey>(
@@ -3782,8 +3782,8 @@ internal final class _KeyedEncodingContainerBox<
     forKey key: K
   ) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encodeIfPresent(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: key)
   }
 
   override internal func encodeIfPresent<K: CodingKey>(
@@ -3791,8 +3791,8 @@ internal final class _KeyedEncodingContainerBox<
     forKey key: K
   ) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encodeIfPresent(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: key)
   }
 
   override internal func encodeIfPresent<K: CodingKey>(
@@ -3800,8 +3800,8 @@ internal final class _KeyedEncodingContainerBox<
     forKey key: K
   ) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encodeIfPresent(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: key)
   }
 
   override internal func encodeIfPresent<K: CodingKey>(
@@ -3809,8 +3809,8 @@ internal final class _KeyedEncodingContainerBox<
     forKey key: K
   ) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encodeIfPresent(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: key)
   }
 
   override internal func encodeIfPresent<K: CodingKey>(
@@ -3818,8 +3818,8 @@ internal final class _KeyedEncodingContainerBox<
     forKey key: K
   ) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encodeIfPresent(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: key)
   }
 
   override internal func encodeIfPresent<K: CodingKey>(
@@ -3827,8 +3827,8 @@ internal final class _KeyedEncodingContainerBox<
     forKey key: K
   ) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encodeIfPresent(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: key)
   }
 
   override internal func encodeIfPresent<K: CodingKey>(
@@ -3836,8 +3836,8 @@ internal final class _KeyedEncodingContainerBox<
     forKey key: K
   ) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encodeIfPresent(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: key)
   }
 
   override internal func encodeIfPresent<K: CodingKey>(
@@ -3845,8 +3845,8 @@ internal final class _KeyedEncodingContainerBox<
     forKey key: K
   ) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encodeIfPresent(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: key)
   }
 
   override internal func encodeIfPresent<K: CodingKey>(
@@ -3854,8 +3854,8 @@ internal final class _KeyedEncodingContainerBox<
     forKey key: K
   ) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encodeIfPresent(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: key)
   }
 
   override internal func encodeIfPresent<K: CodingKey>(
@@ -3863,8 +3863,8 @@ internal final class _KeyedEncodingContainerBox<
     forKey key: K
   ) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encodeIfPresent(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: key)
   }
 
   override internal func encodeIfPresent<T: Encodable, K: CodingKey>(
@@ -3872,8 +3872,8 @@ internal final class _KeyedEncodingContainerBox<
     forKey key: K
   ) throws {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    try concrete.encodeIfPresent(value, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: key)
   }
 
   override internal func nestedContainer<NestedKey, K: CodingKey>(
@@ -3881,16 +3881,16 @@ internal final class _KeyedEncodingContainerBox<
     forKey key: K
   ) -> KeyedEncodingContainer<NestedKey> {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return concrete.nestedContainer(keyedBy: NestedKey.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return concrete.nestedContainer(keyedBy: NestedKey.self, forKey: key)
   }
 
   override internal func nestedUnkeyedContainer<K: CodingKey>(
     forKey key: K
   ) -> UnkeyedEncodingContainer {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return concrete.nestedUnkeyedContainer(forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return concrete.nestedUnkeyedContainer(forKey: key)
   }
 
   override internal func superEncoder() -> Encoder {
@@ -3899,8 +3899,8 @@ internal final class _KeyedEncodingContainerBox<
 
   override internal func superEncoder<K: CodingKey>(forKey key: K) -> Encoder {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return concrete.superEncoder(forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return concrete.superEncoder(forKey: key)
   }
 }
 
@@ -4178,14 +4178,14 @@ internal final class _KeyedDecodingContainerBox<
 
   override internal func contains<K: CodingKey>(_ key: K) -> Bool {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return concrete.contains(typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return concrete.contains(key)
   }
 
   override internal func decodeNil<K: CodingKey>(forKey key: K) throws -> Bool {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decodeNil(forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeNil(forKey: key)
   }
 
   override internal func decode<K: CodingKey>(
@@ -4193,8 +4193,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> Bool {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decode(Bool.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(Bool.self, forKey: key)
   }
 
   override internal func decode<K: CodingKey>(
@@ -4202,8 +4202,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> String {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decode(String.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(String.self, forKey: key)
   }
 
   override internal func decode<K: CodingKey>(
@@ -4211,8 +4211,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> Double {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decode(Double.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(Double.self, forKey: key)
   }
 
   override internal func decode<K: CodingKey>(
@@ -4220,8 +4220,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> Float {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decode(Float.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(Float.self, forKey: key)
   }
 
   override internal func decode<K: CodingKey>(
@@ -4229,8 +4229,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> Int {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decode(Int.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(Int.self, forKey: key)
   }
 
   override internal func decode<K: CodingKey>(
@@ -4238,8 +4238,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> Int8 {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decode(Int8.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(Int8.self, forKey: key)
   }
 
   override internal func decode<K: CodingKey>(
@@ -4247,8 +4247,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> Int16 {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decode(Int16.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(Int16.self, forKey: key)
   }
 
   override internal func decode<K: CodingKey>(
@@ -4256,8 +4256,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> Int32 {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decode(Int32.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(Int32.self, forKey: key)
   }
 
   override internal func decode<K: CodingKey>(
@@ -4265,8 +4265,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> Int64 {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decode(Int64.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(Int64.self, forKey: key)
   }
 
   override internal func decode<K: CodingKey>(
@@ -4274,8 +4274,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> UInt {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decode(UInt.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(UInt.self, forKey: key)
   }
 
   override internal func decode<K: CodingKey>(
@@ -4283,8 +4283,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> UInt8 {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decode(UInt8.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(UInt8.self, forKey: key)
   }
 
   override internal func decode<K: CodingKey>(
@@ -4292,8 +4292,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> UInt16 {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decode(UInt16.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(UInt16.self, forKey: key)
   }
 
   override internal func decode<K: CodingKey>(
@@ -4301,8 +4301,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> UInt32 {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decode(UInt32.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(UInt32.self, forKey: key)
   }
 
   override internal func decode<K: CodingKey>(
@@ -4310,8 +4310,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> UInt64 {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decode(UInt64.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(UInt64.self, forKey: key)
   }
 
   override internal func decode<T: Decodable, K: CodingKey>(
@@ -4319,8 +4319,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> T {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decode(T.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(T.self, forKey: key)
   }
 
   override internal func decodeIfPresent<K: CodingKey>(
@@ -4328,8 +4328,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> Bool? {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decodeIfPresent(Bool.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(Bool.self, forKey: key)
   }
 
   override internal func decodeIfPresent<K: CodingKey>(
@@ -4337,8 +4337,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> String? {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decodeIfPresent(String.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(String.self, forKey: key)
   }
 
   override internal func decodeIfPresent<K: CodingKey>(
@@ -4346,8 +4346,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> Double? {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decodeIfPresent(Double.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(Double.self, forKey: key)
   }
 
   override internal func decodeIfPresent<K: CodingKey>(
@@ -4355,8 +4355,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> Float? {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decodeIfPresent(Float.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(Float.self, forKey: key)
   }
 
   override internal func decodeIfPresent<K: CodingKey>(
@@ -4364,8 +4364,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> Int? {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decodeIfPresent(Int.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(Int.self, forKey: key)
   }
 
   override internal func decodeIfPresent<K: CodingKey>(
@@ -4373,8 +4373,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> Int8? {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decodeIfPresent(Int8.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(Int8.self, forKey: key)
   }
 
   override internal func decodeIfPresent<K: CodingKey>(
@@ -4382,8 +4382,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> Int16? {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decodeIfPresent(Int16.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(Int16.self, forKey: key)
   }
 
   override internal func decodeIfPresent<K: CodingKey>(
@@ -4391,8 +4391,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> Int32? {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decodeIfPresent(Int32.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(Int32.self, forKey: key)
   }
 
   override internal func decodeIfPresent<K: CodingKey>(
@@ -4400,8 +4400,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> Int64? {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decodeIfPresent(Int64.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(Int64.self, forKey: key)
   }
 
   override internal func decodeIfPresent<K: CodingKey>(
@@ -4409,8 +4409,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> UInt? {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decodeIfPresent(UInt.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(UInt.self, forKey: key)
   }
 
   override internal func decodeIfPresent<K: CodingKey>(
@@ -4418,8 +4418,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> UInt8? {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decodeIfPresent(UInt8.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(UInt8.self, forKey: key)
   }
 
   override internal func decodeIfPresent<K: CodingKey>(
@@ -4427,8 +4427,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> UInt16? {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decodeIfPresent(UInt16.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(UInt16.self, forKey: key)
   }
 
   override internal func decodeIfPresent<K: CodingKey>(
@@ -4436,8 +4436,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> UInt32? {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decodeIfPresent(UInt32.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(UInt32.self, forKey: key)
   }
 
   override internal func decodeIfPresent<K: CodingKey>(
@@ -4445,8 +4445,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> UInt64? {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decodeIfPresent(UInt64.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(UInt64.self, forKey: key)
   }
 
   override internal func decodeIfPresent<T: Decodable, K: CodingKey>(
@@ -4454,8 +4454,8 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> T? {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.decodeIfPresent(T.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(T.self, forKey: key)
   }
 
   override internal func nestedContainer<NestedKey, K: CodingKey>(
@@ -4463,16 +4463,16 @@ internal final class _KeyedDecodingContainerBox<
     forKey key: K
   ) throws -> KeyedDecodingContainer<NestedKey> {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.nestedContainer(keyedBy: NestedKey.self, forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.nestedContainer(keyedBy: NestedKey.self, forKey: key)
   }
 
   override internal func nestedUnkeyedContainer<K: CodingKey>(
     forKey key: K
   ) throws -> UnkeyedDecodingContainer {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.nestedUnkeyedContainer(forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.nestedUnkeyedContainer(forKey: key)
   }
 
   override internal func superDecoder() throws -> Decoder {
@@ -4481,8 +4481,8 @@ internal final class _KeyedDecodingContainerBox<
 
   override internal func superDecoder<K: CodingKey>(forKey key: K) throws -> Decoder {
     assert(K.self == Key.self)
-    let typedKey = unsafeBitCast(key, to: Key.self)
-    return try concrete.superDecoder(forKey: typedKey)
+    let key = unsafeBitCast(key, to: Key.self)
+    return try concrete.superDecoder(forKey: key)
   }
 }
 

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -3462,149 +3462,149 @@ internal class _KeyedEncodingContainerBase {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeNil(forKey key: CodingKey) throws {
+  internal func encodeNil<K: CodingKey>(forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: Bool, forKey key: CodingKey) throws {
+  internal func encode<K: CodingKey>(_ value: Bool, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: String, forKey key: CodingKey) throws {
+  internal func encode<K: CodingKey>(_ value: String, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: Double, forKey key: CodingKey) throws {
+  internal func encode<K: CodingKey>(_ value: Double, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: Float, forKey key: CodingKey) throws {
+  internal func encode<K: CodingKey>(_ value: Float, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: Int, forKey key: CodingKey) throws {
+  internal func encode<K: CodingKey>(_ value: Int, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: Int8, forKey key: CodingKey) throws {
+  internal func encode<K: CodingKey>(_ value: Int8, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: Int16, forKey key: CodingKey) throws {
+  internal func encode<K: CodingKey>(_ value: Int16, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: Int32, forKey key: CodingKey) throws {
+  internal func encode<K: CodingKey>(_ value: Int32, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: Int64, forKey key: CodingKey) throws {
+  internal func encode<K: CodingKey>(_ value: Int64, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: UInt, forKey key: CodingKey) throws {
+  internal func encode<K: CodingKey>(_ value: UInt, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: UInt8, forKey key: CodingKey) throws {
+  internal func encode<K: CodingKey>(_ value: UInt8, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: UInt16, forKey key: CodingKey) throws {
+  internal func encode<K: CodingKey>(_ value: UInt16, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: UInt32, forKey key: CodingKey) throws {
+  internal func encode<K: CodingKey>(_ value: UInt32, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: UInt64, forKey key: CodingKey) throws {
+  internal func encode<K: CodingKey>(_ value: UInt64, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode<T: Encodable>(_ value: T, forKey key: CodingKey) throws {
+  internal func encode<T: Encodable, K: CodingKey>(_ value: T, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeConditional<T: AnyObject & Encodable>(
+  internal func encodeConditional<T: AnyObject & Encodable, K: CodingKey>(
     _ object: T,
-    forKey key: CodingKey
+    forKey key: K
   ) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: Bool?, forKey key: CodingKey) throws {
+  internal func encodeIfPresent<K: CodingKey>(_ value: Bool?, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: String?, forKey key: CodingKey) throws {
+  internal func encodeIfPresent<K: CodingKey>(_ value: String?, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: Double?, forKey key: CodingKey) throws {
+  internal func encodeIfPresent<K: CodingKey>(_ value: Double?, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: Float?, forKey key: CodingKey) throws {
+  internal func encodeIfPresent<K: CodingKey>(_ value: Float?, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: Int?, forKey key: CodingKey) throws {
+  internal func encodeIfPresent<K: CodingKey>(_ value: Int?, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: Int8?, forKey key: CodingKey) throws {
+  internal func encodeIfPresent<K: CodingKey>(_ value: Int8?, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: Int16?, forKey key: CodingKey) throws {
+  internal func encodeIfPresent<K: CodingKey>(_ value: Int16?, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: Int32?, forKey key: CodingKey) throws {
+  internal func encodeIfPresent<K: CodingKey>(_ value: Int32?, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: Int64?, forKey key: CodingKey) throws {
+  internal func encodeIfPresent<K: CodingKey>(_ value: Int64?, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: UInt?, forKey key: CodingKey) throws {
+  internal func encodeIfPresent<K: CodingKey>(_ value: UInt?, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: UInt8?, forKey key: CodingKey) throws {
+  internal func encodeIfPresent<K: CodingKey>(_ value: UInt8?, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: UInt16?, forKey key: CodingKey) throws {
+  internal func encodeIfPresent<K: CodingKey>(_ value: UInt16?, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: UInt32?, forKey key: CodingKey) throws {
+  internal func encodeIfPresent<K: CodingKey>(_ value: UInt32?, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: UInt64?, forKey key: CodingKey) throws {
+  internal func encodeIfPresent<K: CodingKey>(_ value: UInt64?, forKey key: K) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent<T: Encodable>(
+  internal func encodeIfPresent<T: Encodable, K: CodingKey>(
     _ value: T?,
-    forKey key: CodingKey
+    forKey key: K
   ) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func nestedContainer<NestedKey>(
+  internal func nestedContainer<NestedKey, K: CodingKey>(
     keyedBy keyType: NestedKey.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) -> KeyedEncodingContainer<NestedKey> {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func nestedUnkeyedContainer(
-    forKey key: CodingKey
+  internal func nestedUnkeyedContainer<K: CodingKey>(
+    forKey key: K
   ) -> UnkeyedEncodingContainer {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
@@ -3613,7 +3613,7 @@ internal class _KeyedEncodingContainerBase {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func superEncoder(forKey key: CodingKey) -> Encoder {
+  internal func superEncoder<K: CodingKey>(forKey key: K) -> Encoder {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 }
@@ -3633,204 +3633,274 @@ internal final class _KeyedEncodingContainerBox<
     return concrete.codingPath
   }
 
-  override internal func encodeNil(forKey key: CodingKey) throws {
-    try concrete.encodeNil(forKey: key as! Key)
+  override internal func encodeNil<K: CodingKey>(forKey key: K) throws {
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeNil(forKey: typedKey)
   }
 
-  override internal func encode(_ value: Bool, forKey key: CodingKey) throws {
-    try concrete.encode(value, forKey: key as! Key)
+  override internal func encode<K: CodingKey>(_ value: Bool, forKey key: K) throws {
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: typedKey)
   }
 
-  override internal func encode(_ value: String, forKey key: CodingKey) throws {
-    try concrete.encode(value, forKey: key as! Key)
+  override internal func encode<K: CodingKey>(_ value: String, forKey key: K) throws {
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: typedKey)
   }
 
-  override internal func encode(_ value: Double, forKey key: CodingKey) throws {
-    try concrete.encode(value, forKey: key as! Key)
+  override internal func encode<K: CodingKey>(_ value: Double, forKey key: K) throws {
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: typedKey)
   }
 
-  override internal func encode(_ value: Float, forKey key: CodingKey) throws {
-    try concrete.encode(value, forKey: key as! Key)
+  override internal func encode<K: CodingKey>(_ value: Float, forKey key: K) throws {
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: typedKey)
   }
 
-  override internal func encode(_ value: Int, forKey key: CodingKey) throws {
-    try concrete.encode(value, forKey: key as! Key)
+  override internal func encode<K: CodingKey>(_ value: Int, forKey key: K) throws {
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: typedKey)
   }
 
-  override internal func encode(_ value: Int8, forKey key: CodingKey) throws {
-    try concrete.encode(value, forKey: key as! Key)
+  override internal func encode<K: CodingKey>(_ value: Int8, forKey key: K) throws {
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: typedKey)
   }
 
-  override internal func encode(_ value: Int16, forKey key: CodingKey) throws {
-    try concrete.encode(value, forKey: key as! Key)
+  override internal func encode<K: CodingKey>(_ value: Int16, forKey key: K) throws {
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: typedKey)
   }
 
-  override internal func encode(_ value: Int32, forKey key: CodingKey) throws {
-    try concrete.encode(value, forKey: key as! Key)
+  override internal func encode<K: CodingKey>(_ value: Int32, forKey key: K) throws {
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: typedKey)
   }
 
-  override internal func encode(_ value: Int64, forKey key: CodingKey) throws {
-    try concrete.encode(value, forKey: key as! Key)
+  override internal func encode<K: CodingKey>(_ value: Int64, forKey key: K) throws {
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: typedKey)
   }
 
-  override internal func encode(_ value: UInt, forKey key: CodingKey) throws {
-    try concrete.encode(value, forKey: key as! Key)
+  override internal func encode<K: CodingKey>(_ value: UInt, forKey key: K) throws {
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: typedKey)
   }
 
-  override internal func encode(_ value: UInt8, forKey key: CodingKey) throws {
-    try concrete.encode(value, forKey: key as! Key)
+  override internal func encode<K: CodingKey>(_ value: UInt8, forKey key: K) throws {
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: typedKey)
   }
 
-  override internal func encode(_ value: UInt16, forKey key: CodingKey) throws {
-    try concrete.encode(value, forKey: key as! Key)
+  override internal func encode<K: CodingKey>(_ value: UInt16, forKey key: K) throws {
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: typedKey)
   }
 
-  override internal func encode(_ value: UInt32, forKey key: CodingKey) throws {
-    try concrete.encode(value, forKey: key as! Key)
+  override internal func encode<K: CodingKey>(_ value: UInt32, forKey key: K) throws {
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: typedKey)
   }
 
-  override internal func encode(_ value: UInt64, forKey key: CodingKey) throws {
-    try concrete.encode(value, forKey: key as! Key)
+  override internal func encode<K: CodingKey>(_ value: UInt64, forKey key: K) throws {
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: typedKey)
   }
 
-  override internal func encode<T: Encodable>(
+  override internal func encode<T: Encodable, K: CodingKey>(
     _ value: T,
-    forKey key: CodingKey
+    forKey key: K
   ) throws {
-    try concrete.encode(value, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encode(value, forKey: typedKey)
   }
 
-  override internal func encodeConditional<T: AnyObject & Encodable>(
+  override internal func encodeConditional<T: AnyObject & Encodable, K: CodingKey>(
     _ object: T,
-    forKey key: CodingKey
+    forKey key: K
   ) throws {
-    try concrete.encodeConditional(object, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeConditional(object, forKey: typedKey)
   }
 
-  override internal func encodeIfPresent(
+  override internal func encodeIfPresent<K: CodingKey>(
     _ value: Bool?,
-    forKey key: CodingKey
+    forKey key: K
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: typedKey)
   }
 
-  override internal func encodeIfPresent(
+  override internal func encodeIfPresent<K: CodingKey>(
     _ value: String?,
-    forKey key: CodingKey
+    forKey key: K
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: typedKey)
   }
 
-  override internal func encodeIfPresent(
+  override internal func encodeIfPresent<K: CodingKey>(
     _ value: Double?,
-    forKey key: CodingKey
+    forKey key: K
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: typedKey)
   }
 
-  override internal func encodeIfPresent(
+  override internal func encodeIfPresent<K: CodingKey>(
     _ value: Float?,
-    forKey key: CodingKey
+    forKey key: K
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: typedKey)
   }
 
-  override internal func encodeIfPresent(
+  override internal func encodeIfPresent<K: CodingKey>(
     _ value: Int?,
-    forKey key: CodingKey
+    forKey key: K
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: typedKey)
   }
 
-  override internal func encodeIfPresent(
+  override internal func encodeIfPresent<K: CodingKey>(
     _ value: Int8?,
-    forKey key: CodingKey
+    forKey key: K
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: typedKey)
   }
 
-  override internal func encodeIfPresent(
+  override internal func encodeIfPresent<K: CodingKey>(
     _ value: Int16?,
-    forKey key: CodingKey
+    forKey key: K
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: typedKey)
   }
 
-  override internal func encodeIfPresent(
+  override internal func encodeIfPresent<K: CodingKey>(
     _ value: Int32?,
-    forKey key: CodingKey
+    forKey key: K
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: typedKey)
   }
 
-  override internal func encodeIfPresent(
+  override internal func encodeIfPresent<K: CodingKey>(
     _ value: Int64?,
-    forKey key: CodingKey
+    forKey key: K
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: typedKey)
   }
 
-  override internal func encodeIfPresent(
+  override internal func encodeIfPresent<K: CodingKey>(
     _ value: UInt?,
-    forKey key: CodingKey
+    forKey key: K
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: typedKey)
   }
 
-  override internal func encodeIfPresent(
+  override internal func encodeIfPresent<K: CodingKey>(
     _ value: UInt8?,
-    forKey key: CodingKey
+    forKey key: K
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: typedKey)
   }
 
-  override internal func encodeIfPresent(
+  override internal func encodeIfPresent<K: CodingKey>(
     _ value: UInt16?,
-    forKey key: CodingKey
+    forKey key: K
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: typedKey)
   }
 
-  override internal func encodeIfPresent(
+  override internal func encodeIfPresent<K: CodingKey>(
     _ value: UInt32?,
-    forKey key: CodingKey
+    forKey key: K
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: typedKey)
   }
 
-  override internal func encodeIfPresent(
+  override internal func encodeIfPresent<K: CodingKey>(
     _ value: UInt64?,
-    forKey key: CodingKey
+    forKey key: K
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: typedKey)
   }
 
-  override internal func encodeIfPresent<T: Encodable>(
+  override internal func encodeIfPresent<T: Encodable, K: CodingKey>(
     _ value: T?,
-    forKey key: CodingKey
+    forKey key: K
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    try concrete.encodeIfPresent(value, forKey: typedKey)
   }
 
-  override internal func nestedContainer<NestedKey>(
+  override internal func nestedContainer<NestedKey, K: CodingKey>(
     keyedBy keyType: NestedKey.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) -> KeyedEncodingContainer<NestedKey> {
-    return concrete.nestedContainer(keyedBy: NestedKey.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return concrete.nestedContainer(keyedBy: NestedKey.self, forKey: typedKey)
   }
 
-  override internal func nestedUnkeyedContainer(
-    forKey key: CodingKey
+  override internal func nestedUnkeyedContainer<K: CodingKey>(
+    forKey key: K
   ) -> UnkeyedEncodingContainer {
-    return concrete.nestedUnkeyedContainer(forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return concrete.nestedUnkeyedContainer(forKey: typedKey)
   }
 
   override internal func superEncoder() -> Encoder {
     return concrete.superEncoder()
   }
 
-  override internal func superEncoder(forKey key: CodingKey) -> Encoder {
-    return concrete.superEncoder(forKey: key as! Key)
+  override internal func superEncoder<K: CodingKey>(forKey key: K) -> Encoder {
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return concrete.superEncoder(forKey: typedKey)
   }
 }
 
@@ -3847,233 +3917,233 @@ internal class _KeyedDecodingContainerBase {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func contains(_ key: CodingKey) -> Bool {
+  internal func contains<K: CodingKey>(_ key: K) -> Bool {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decodeNil(forKey key: CodingKey) throws -> Bool {
+  internal func decodeNil<K: CodingKey>(forKey key: K) throws -> Bool {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decode(
+  internal func decode<K: CodingKey>(
     _ type: Bool.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Bool {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decode(
+  internal func decode<K: CodingKey>(
     _ type: String.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> String {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decode(
+  internal func decode<K: CodingKey>(
     _ type: Double.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Double {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decode(
+  internal func decode<K: CodingKey>(
     _ type: Float.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Float {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decode(
+  internal func decode<K: CodingKey>(
     _ type: Int.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Int {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decode(
+  internal func decode<K: CodingKey>(
     _ type: Int8.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Int8 {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decode(
+  internal func decode<K: CodingKey>(
     _ type: Int16.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Int16 {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decode(
+  internal func decode<K: CodingKey>(
     _ type: Int32.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Int32 {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decode(
+  internal func decode<K: CodingKey>(
     _ type: Int64.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Int64 {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decode(
+  internal func decode<K: CodingKey>(
     _ type: UInt.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> UInt {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decode(
+  internal func decode<K: CodingKey>(
     _ type: UInt8.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> UInt8 {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decode(
+  internal func decode<K: CodingKey>(
     _ type: UInt16.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> UInt16 {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decode(
+  internal func decode<K: CodingKey>(
     _ type: UInt32.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> UInt32 {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decode(
+  internal func decode<K: CodingKey>(
     _ type: UInt64.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> UInt64 {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decode<T: Decodable>(
+  internal func decode<T: Decodable, K: CodingKey>(
     _ type: T.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> T {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decodeIfPresent(
+  internal func decodeIfPresent<K: CodingKey>(
     _ type: Bool.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Bool? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decodeIfPresent(
+  internal func decodeIfPresent<K: CodingKey>(
     _ type: String.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> String? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decodeIfPresent(
+  internal func decodeIfPresent<K: CodingKey>(
     _ type: Double.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Double? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decodeIfPresent(
+  internal func decodeIfPresent<K: CodingKey>(
     _ type: Float.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Float? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decodeIfPresent(
+  internal func decodeIfPresent<K: CodingKey>(
     _ type: Int.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Int? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decodeIfPresent(
+  internal func decodeIfPresent<K: CodingKey>(
     _ type: Int8.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Int8? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decodeIfPresent(
+  internal func decodeIfPresent<K: CodingKey>(
     _ type: Int16.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Int16? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decodeIfPresent(
+  internal func decodeIfPresent<K: CodingKey>(
     _ type: Int32.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Int32? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decodeIfPresent(
+  internal func decodeIfPresent<K: CodingKey>(
     _ type: Int64.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Int64? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decodeIfPresent(
+  internal func decodeIfPresent<K: CodingKey>(
     _ type: UInt.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> UInt? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decodeIfPresent(
+  internal func decodeIfPresent<K: CodingKey>(
     _ type: UInt8.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> UInt8? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decodeIfPresent(
+  internal func decodeIfPresent<K: CodingKey>(
     _ type: UInt16.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> UInt16? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decodeIfPresent(
+  internal func decodeIfPresent<K: CodingKey>(
     _ type: UInt32.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> UInt32? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decodeIfPresent(
+  internal func decodeIfPresent<K: CodingKey>(
     _ type: UInt64.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> UInt64? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decodeIfPresent<T: Decodable>(
+  internal func decodeIfPresent<T: Decodable, K: CodingKey>(
     _ type: T.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> T? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func nestedContainer<NestedKey>(
+  internal func nestedContainer<NestedKey, K: CodingKey>(
     keyedBy type: NestedKey.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> KeyedDecodingContainer<NestedKey> {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func nestedUnkeyedContainer(
-    forKey key: CodingKey
+  internal func nestedUnkeyedContainer<K: CodingKey>(
+    forKey key: K
   ) throws -> UnkeyedDecodingContainer {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
@@ -4082,7 +4152,7 @@ internal class _KeyedDecodingContainerBase {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func superDecoder(forKey key: CodingKey) throws -> Decoder {
+  internal func superDecoder<K: CodingKey>(forKey key: K) throws -> Decoder {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 }
@@ -4106,243 +4176,313 @@ internal final class _KeyedDecodingContainerBox<
     return concrete.allKeys
   }
 
-  override internal func contains(_ key: CodingKey) -> Bool {
-    return concrete.contains(key as! Key)
+  override internal func contains<K: CodingKey>(_ key: K) -> Bool {
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return concrete.contains(typedKey)
   }
 
-  override internal func decodeNil(forKey key: CodingKey) throws -> Bool {
-    return try concrete.decodeNil(forKey: key as! Key)
+  override internal func decodeNil<K: CodingKey>(forKey key: K) throws -> Bool {
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeNil(forKey: typedKey)
   }
 
-  override internal func decode(
+  override internal func decode<K: CodingKey>(
     _ type: Bool.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Bool {
-    return try concrete.decode(Bool.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(Bool.self, forKey: typedKey)
   }
 
-  override internal func decode(
+  override internal func decode<K: CodingKey>(
     _ type: String.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> String {
-    return try concrete.decode(String.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(String.self, forKey: typedKey)
   }
 
-  override internal func decode(
+  override internal func decode<K: CodingKey>(
     _ type: Double.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Double {
-    return try concrete.decode(Double.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(Double.self, forKey: typedKey)
   }
 
-  override internal func decode(
+  override internal func decode<K: CodingKey>(
     _ type: Float.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Float {
-    return try concrete.decode(Float.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(Float.self, forKey: typedKey)
   }
 
-  override internal func decode(
+  override internal func decode<K: CodingKey>(
     _ type: Int.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Int {
-    return try concrete.decode(Int.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(Int.self, forKey: typedKey)
   }
 
-  override internal func decode(
+  override internal func decode<K: CodingKey>(
     _ type: Int8.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Int8 {
-    return try concrete.decode(Int8.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(Int8.self, forKey: typedKey)
   }
 
-  override internal func decode(
+  override internal func decode<K: CodingKey>(
     _ type: Int16.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Int16 {
-    return try concrete.decode(Int16.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(Int16.self, forKey: typedKey)
   }
 
-  override internal func decode(
+  override internal func decode<K: CodingKey>(
     _ type: Int32.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Int32 {
-    return try concrete.decode(Int32.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(Int32.self, forKey: typedKey)
   }
 
-  override internal func decode(
+  override internal func decode<K: CodingKey>(
     _ type: Int64.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Int64 {
-    return try concrete.decode(Int64.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(Int64.self, forKey: typedKey)
   }
 
-  override internal func decode(
+  override internal func decode<K: CodingKey>(
     _ type: UInt.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> UInt {
-    return try concrete.decode(UInt.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(UInt.self, forKey: typedKey)
   }
 
-  override internal func decode(
+  override internal func decode<K: CodingKey>(
     _ type: UInt8.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> UInt8 {
-    return try concrete.decode(UInt8.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(UInt8.self, forKey: typedKey)
   }
 
-  override internal func decode(
+  override internal func decode<K: CodingKey>(
     _ type: UInt16.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> UInt16 {
-    return try concrete.decode(UInt16.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(UInt16.self, forKey: typedKey)
   }
 
-  override internal func decode(
+  override internal func decode<K: CodingKey>(
     _ type: UInt32.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> UInt32 {
-    return try concrete.decode(UInt32.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(UInt32.self, forKey: typedKey)
   }
 
-  override internal func decode(
+  override internal func decode<K: CodingKey>(
     _ type: UInt64.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> UInt64 {
-    return try concrete.decode(UInt64.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(UInt64.self, forKey: typedKey)
   }
 
-  override internal func decode<T: Decodable>(
+  override internal func decode<T: Decodable, K: CodingKey>(
     _ type: T.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> T {
-    return try concrete.decode(T.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decode(T.self, forKey: typedKey)
   }
 
-  override internal func decodeIfPresent(
+  override internal func decodeIfPresent<K: CodingKey>(
     _ type: Bool.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Bool? {
-    return try concrete.decodeIfPresent(Bool.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(Bool.self, forKey: typedKey)
   }
 
-  override internal func decodeIfPresent(
+  override internal func decodeIfPresent<K: CodingKey>(
     _ type: String.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> String? {
-    return try concrete.decodeIfPresent(String.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(String.self, forKey: typedKey)
   }
 
-  override internal func decodeIfPresent(
+  override internal func decodeIfPresent<K: CodingKey>(
     _ type: Double.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Double? {
-    return try concrete.decodeIfPresent(Double.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(Double.self, forKey: typedKey)
   }
 
-  override internal func decodeIfPresent(
+  override internal func decodeIfPresent<K: CodingKey>(
     _ type: Float.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Float? {
-    return try concrete.decodeIfPresent(Float.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(Float.self, forKey: typedKey)
   }
 
-  override internal func decodeIfPresent(
+  override internal func decodeIfPresent<K: CodingKey>(
     _ type: Int.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Int? {
-    return try concrete.decodeIfPresent(Int.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(Int.self, forKey: typedKey)
   }
 
-  override internal func decodeIfPresent(
+  override internal func decodeIfPresent<K: CodingKey>(
     _ type: Int8.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Int8? {
-    return try concrete.decodeIfPresent(Int8.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(Int8.self, forKey: typedKey)
   }
 
-  override internal func decodeIfPresent(
+  override internal func decodeIfPresent<K: CodingKey>(
     _ type: Int16.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Int16? {
-    return try concrete.decodeIfPresent(Int16.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(Int16.self, forKey: typedKey)
   }
 
-  override internal func decodeIfPresent(
+  override internal func decodeIfPresent<K: CodingKey>(
     _ type: Int32.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Int32? {
-    return try concrete.decodeIfPresent(Int32.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(Int32.self, forKey: typedKey)
   }
 
-  override internal func decodeIfPresent(
+  override internal func decodeIfPresent<K: CodingKey>(
     _ type: Int64.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> Int64? {
-    return try concrete.decodeIfPresent(Int64.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(Int64.self, forKey: typedKey)
   }
 
-  override internal func decodeIfPresent(
+  override internal func decodeIfPresent<K: CodingKey>(
     _ type: UInt.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> UInt? {
-    return try concrete.decodeIfPresent(UInt.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(UInt.self, forKey: typedKey)
   }
 
-  override internal func decodeIfPresent(
+  override internal func decodeIfPresent<K: CodingKey>(
     _ type: UInt8.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> UInt8? {
-    return try concrete.decodeIfPresent(UInt8.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(UInt8.self, forKey: typedKey)
   }
 
-  override internal func decodeIfPresent(
+  override internal func decodeIfPresent<K: CodingKey>(
     _ type: UInt16.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> UInt16? {
-    return try concrete.decodeIfPresent(UInt16.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(UInt16.self, forKey: typedKey)
   }
 
-  override internal func decodeIfPresent(
+  override internal func decodeIfPresent<K: CodingKey>(
     _ type: UInt32.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> UInt32? {
-    return try concrete.decodeIfPresent(UInt32.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(UInt32.self, forKey: typedKey)
   }
 
-  override internal func decodeIfPresent(
+  override internal func decodeIfPresent<K: CodingKey>(
     _ type: UInt64.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> UInt64? {
-    return try concrete.decodeIfPresent(UInt64.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(UInt64.self, forKey: typedKey)
   }
 
-  override internal func decodeIfPresent<T: Decodable>(
+  override internal func decodeIfPresent<T: Decodable, K: CodingKey>(
     _ type: T.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> T? {
-    return try concrete.decodeIfPresent(T.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.decodeIfPresent(T.self, forKey: typedKey)
   }
 
-  override internal func nestedContainer<NestedKey>(
+  override internal func nestedContainer<NestedKey, K: CodingKey>(
     keyedBy type: NestedKey.Type,
-    forKey key: CodingKey
+    forKey key: K
   ) throws -> KeyedDecodingContainer<NestedKey> {
-    return try concrete.nestedContainer(keyedBy: NestedKey.self, forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.nestedContainer(keyedBy: NestedKey.self, forKey: typedKey)
   }
 
-  override internal func nestedUnkeyedContainer(
-    forKey key: CodingKey
+  override internal func nestedUnkeyedContainer<K: CodingKey>(
+    forKey key: K
   ) throws -> UnkeyedDecodingContainer {
-    return try concrete.nestedUnkeyedContainer(forKey: key as! Key)
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.nestedUnkeyedContainer(forKey: typedKey)
   }
 
   override internal func superDecoder() throws -> Decoder {
     return try concrete.superDecoder()
   }
 
-  override internal func superDecoder(forKey key: CodingKey) throws -> Decoder {
-    return try concrete.superDecoder(forKey: key as! Key)
+  override internal func superDecoder<K: CodingKey>(forKey key: K) throws -> Decoder {
+    assert(K.self == Key.self)
+    let typedKey = unsafeBitCast(key, to: Key.self)
+    return try concrete.superDecoder(forKey: typedKey)
   }
 }
 

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -498,9 +498,8 @@ public struct KeyedEncodingContainer<K: CodingKey> :
 {
   public typealias Key = K
 
-  /// The container for the concrete encoder. The type is _*Base so that it's
-  /// generic on the key type.
-  internal var _box: _KeyedEncodingContainerBase<Key>
+  /// The container for the concrete encoder.
+  internal var _box: _KeyedEncodingContainerBase
 
   /// Creates a new instance with the given container.
   ///
@@ -1467,9 +1466,8 @@ public struct KeyedDecodingContainer<K: CodingKey> :
 {
   public typealias Key = K
 
-  /// The container for the concrete decoder. The type is _*Base so that it's
-  /// generic on the key type.
-  internal var _box: _KeyedDecodingContainerBase<Key>
+  /// The container for the concrete decoder.
+  internal var _box: _KeyedDecodingContainerBase
 
   /// Creates a new instance with the given container.
   ///
@@ -1492,7 +1490,7 @@ public struct KeyedDecodingContainer<K: CodingKey> :
   /// which are not convertible to one another. This should report all keys
   /// present which are convertible to the requested type.
   public var allKeys: [Key] {
-    return _box.allKeys
+    return _box.allKeys as! [Key]
   }
 
   /// Returns a Boolean value indicating whether the decoder contains a value
@@ -3454,7 +3452,7 @@ extension DecodingError {
 // Keyed Encoding Container Implementations
 //===----------------------------------------------------------------------===//
 
-internal class _KeyedEncodingContainerBase<Key: CodingKey> {
+internal class _KeyedEncodingContainerBase {
   internal init(){}
 
   deinit {}
@@ -3464,149 +3462,149 @@ internal class _KeyedEncodingContainerBase<Key: CodingKey> {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeNil(forKey key: Key) throws {
+  internal func encodeNil(forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: Bool, forKey key: Key) throws {
+  internal func encode(_ value: Bool, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: String, forKey key: Key) throws {
+  internal func encode(_ value: String, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: Double, forKey key: Key) throws {
+  internal func encode(_ value: Double, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: Float, forKey key: Key) throws {
+  internal func encode(_ value: Float, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: Int, forKey key: Key) throws {
+  internal func encode(_ value: Int, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: Int8, forKey key: Key) throws {
+  internal func encode(_ value: Int8, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: Int16, forKey key: Key) throws {
+  internal func encode(_ value: Int16, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: Int32, forKey key: Key) throws {
+  internal func encode(_ value: Int32, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: Int64, forKey key: Key) throws {
+  internal func encode(_ value: Int64, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: UInt, forKey key: Key) throws {
+  internal func encode(_ value: UInt, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: UInt8, forKey key: Key) throws {
+  internal func encode(_ value: UInt8, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: UInt16, forKey key: Key) throws {
+  internal func encode(_ value: UInt16, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: UInt32, forKey key: Key) throws {
+  internal func encode(_ value: UInt32, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode(_ value: UInt64, forKey key: Key) throws {
+  internal func encode(_ value: UInt64, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encode<T: Encodable>(_ value: T, forKey key: Key) throws {
+  internal func encode<T: Encodable>(_ value: T, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
   internal func encodeConditional<T: AnyObject & Encodable>(
     _ object: T,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: Bool?, forKey key: Key) throws {
+  internal func encodeIfPresent(_ value: Bool?, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: String?, forKey key: Key) throws {
+  internal func encodeIfPresent(_ value: String?, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: Double?, forKey key: Key) throws {
+  internal func encodeIfPresent(_ value: Double?, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: Float?, forKey key: Key) throws {
+  internal func encodeIfPresent(_ value: Float?, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: Int?, forKey key: Key) throws {
+  internal func encodeIfPresent(_ value: Int?, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: Int8?, forKey key: Key) throws {
+  internal func encodeIfPresent(_ value: Int8?, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: Int16?, forKey key: Key) throws {
+  internal func encodeIfPresent(_ value: Int16?, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: Int32?, forKey key: Key) throws {
+  internal func encodeIfPresent(_ value: Int32?, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: Int64?, forKey key: Key) throws {
+  internal func encodeIfPresent(_ value: Int64?, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: UInt?, forKey key: Key) throws {
+  internal func encodeIfPresent(_ value: UInt?, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: UInt8?, forKey key: Key) throws {
+  internal func encodeIfPresent(_ value: UInt8?, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: UInt16?, forKey key: Key) throws {
+  internal func encodeIfPresent(_ value: UInt16?, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: UInt32?, forKey key: Key) throws {
+  internal func encodeIfPresent(_ value: UInt32?, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeIfPresent(_ value: UInt64?, forKey key: Key) throws {
+  internal func encodeIfPresent(_ value: UInt64?, forKey key: CodingKey) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
   internal func encodeIfPresent<T: Encodable>(
     _ value: T?,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
   internal func nestedContainer<NestedKey>(
     keyedBy keyType: NestedKey.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) -> KeyedEncodingContainer<NestedKey> {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
   internal func nestedUnkeyedContainer(
-    forKey key: Key
+    forKey key: CodingKey
   ) -> UnkeyedEncodingContainer {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
@@ -3615,14 +3613,14 @@ internal class _KeyedEncodingContainerBase<Key: CodingKey> {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func superEncoder(forKey key: Key) -> Encoder {
+  internal func superEncoder(forKey key: CodingKey) -> Encoder {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 }
 
 internal final class _KeyedEncodingContainerBox<
   Concrete: KeyedEncodingContainerProtocol
->: _KeyedEncodingContainerBase<Concrete.Key> {
+>: _KeyedEncodingContainerBase {
   typealias Key = Concrete.Key
 
   internal var concrete: Concrete
@@ -3635,208 +3633,208 @@ internal final class _KeyedEncodingContainerBox<
     return concrete.codingPath
   }
 
-  override internal func encodeNil(forKey key: Key) throws {
-    try concrete.encodeNil(forKey: key)
+  override internal func encodeNil(forKey key: CodingKey) throws {
+    try concrete.encodeNil(forKey: key as! Key)
   }
 
-  override internal func encode(_ value: Bool, forKey key: Key) throws {
-    try concrete.encode(value, forKey: key)
+  override internal func encode(_ value: Bool, forKey key: CodingKey) throws {
+    try concrete.encode(value, forKey: key as! Key)
   }
 
-  override internal func encode(_ value: String, forKey key: Key) throws {
-    try concrete.encode(value, forKey: key)
+  override internal func encode(_ value: String, forKey key: CodingKey) throws {
+    try concrete.encode(value, forKey: key as! Key)
   }
 
-  override internal func encode(_ value: Double, forKey key: Key) throws {
-    try concrete.encode(value, forKey: key)
+  override internal func encode(_ value: Double, forKey key: CodingKey) throws {
+    try concrete.encode(value, forKey: key as! Key)
   }
 
-  override internal func encode(_ value: Float, forKey key: Key) throws {
-    try concrete.encode(value, forKey: key)
+  override internal func encode(_ value: Float, forKey key: CodingKey) throws {
+    try concrete.encode(value, forKey: key as! Key)
   }
 
-  override internal func encode(_ value: Int, forKey key: Key) throws {
-    try concrete.encode(value, forKey: key)
+  override internal func encode(_ value: Int, forKey key: CodingKey) throws {
+    try concrete.encode(value, forKey: key as! Key)
   }
 
-  override internal func encode(_ value: Int8, forKey key: Key) throws {
-    try concrete.encode(value, forKey: key)
+  override internal func encode(_ value: Int8, forKey key: CodingKey) throws {
+    try concrete.encode(value, forKey: key as! Key)
   }
 
-  override internal func encode(_ value: Int16, forKey key: Key) throws {
-    try concrete.encode(value, forKey: key)
+  override internal func encode(_ value: Int16, forKey key: CodingKey) throws {
+    try concrete.encode(value, forKey: key as! Key)
   }
 
-  override internal func encode(_ value: Int32, forKey key: Key) throws {
-    try concrete.encode(value, forKey: key)
+  override internal func encode(_ value: Int32, forKey key: CodingKey) throws {
+    try concrete.encode(value, forKey: key as! Key)
   }
 
-  override internal func encode(_ value: Int64, forKey key: Key) throws {
-    try concrete.encode(value, forKey: key)
+  override internal func encode(_ value: Int64, forKey key: CodingKey) throws {
+    try concrete.encode(value, forKey: key as! Key)
   }
 
-  override internal func encode(_ value: UInt, forKey key: Key) throws {
-    try concrete.encode(value, forKey: key)
+  override internal func encode(_ value: UInt, forKey key: CodingKey) throws {
+    try concrete.encode(value, forKey: key as! Key)
   }
 
-  override internal func encode(_ value: UInt8, forKey key: Key) throws {
-    try concrete.encode(value, forKey: key)
+  override internal func encode(_ value: UInt8, forKey key: CodingKey) throws {
+    try concrete.encode(value, forKey: key as! Key)
   }
 
-  override internal func encode(_ value: UInt16, forKey key: Key) throws {
-    try concrete.encode(value, forKey: key)
+  override internal func encode(_ value: UInt16, forKey key: CodingKey) throws {
+    try concrete.encode(value, forKey: key as! Key)
   }
 
-  override internal func encode(_ value: UInt32, forKey key: Key) throws {
-    try concrete.encode(value, forKey: key)
+  override internal func encode(_ value: UInt32, forKey key: CodingKey) throws {
+    try concrete.encode(value, forKey: key as! Key)
   }
 
-  override internal func encode(_ value: UInt64, forKey key: Key) throws {
-    try concrete.encode(value, forKey: key)
+  override internal func encode(_ value: UInt64, forKey key: CodingKey) throws {
+    try concrete.encode(value, forKey: key as! Key)
   }
 
   override internal func encode<T: Encodable>(
     _ value: T,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws {
-    try concrete.encode(value, forKey: key)
+    try concrete.encode(value, forKey: key as! Key)
   }
 
   override internal func encodeConditional<T: AnyObject & Encodable>(
     _ object: T,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws {
-    try concrete.encodeConditional(object, forKey: key)
+    try concrete.encodeConditional(object, forKey: key as! Key)
   }
 
   override internal func encodeIfPresent(
     _ value: Bool?,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key)
+    try concrete.encodeIfPresent(value, forKey: key as! Key)
   }
 
   override internal func encodeIfPresent(
     _ value: String?,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key)
+    try concrete.encodeIfPresent(value, forKey: key as! Key)
   }
 
   override internal func encodeIfPresent(
     _ value: Double?,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key)
+    try concrete.encodeIfPresent(value, forKey: key as! Key)
   }
 
   override internal func encodeIfPresent(
     _ value: Float?,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key)
+    try concrete.encodeIfPresent(value, forKey: key as! Key)
   }
 
   override internal func encodeIfPresent(
     _ value: Int?,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key)
+    try concrete.encodeIfPresent(value, forKey: key as! Key)
   }
 
   override internal func encodeIfPresent(
     _ value: Int8?,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key)
+    try concrete.encodeIfPresent(value, forKey: key as! Key)
   }
 
   override internal func encodeIfPresent(
     _ value: Int16?,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key)
+    try concrete.encodeIfPresent(value, forKey: key as! Key)
   }
 
   override internal func encodeIfPresent(
     _ value: Int32?,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key)
+    try concrete.encodeIfPresent(value, forKey: key as! Key)
   }
 
   override internal func encodeIfPresent(
     _ value: Int64?,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key)
+    try concrete.encodeIfPresent(value, forKey: key as! Key)
   }
 
   override internal func encodeIfPresent(
     _ value: UInt?,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key)
+    try concrete.encodeIfPresent(value, forKey: key as! Key)
   }
 
   override internal func encodeIfPresent(
     _ value: UInt8?,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key)
+    try concrete.encodeIfPresent(value, forKey: key as! Key)
   }
 
   override internal func encodeIfPresent(
     _ value: UInt16?,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key)
+    try concrete.encodeIfPresent(value, forKey: key as! Key)
   }
 
   override internal func encodeIfPresent(
     _ value: UInt32?,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key)
+    try concrete.encodeIfPresent(value, forKey: key as! Key)
   }
 
   override internal func encodeIfPresent(
     _ value: UInt64?,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key)
+    try concrete.encodeIfPresent(value, forKey: key as! Key)
   }
 
   override internal func encodeIfPresent<T: Encodable>(
     _ value: T?,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws {
-    try concrete.encodeIfPresent(value, forKey: key)
+    try concrete.encodeIfPresent(value, forKey: key as! Key)
   }
 
   override internal func nestedContainer<NestedKey>(
     keyedBy keyType: NestedKey.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) -> KeyedEncodingContainer<NestedKey> {
-    return concrete.nestedContainer(keyedBy: NestedKey.self, forKey: key)
+    return concrete.nestedContainer(keyedBy: NestedKey.self, forKey: key as! Key)
   }
 
   override internal func nestedUnkeyedContainer(
-    forKey key: Key
+    forKey key: CodingKey
   ) -> UnkeyedEncodingContainer {
-    return concrete.nestedUnkeyedContainer(forKey: key)
+    return concrete.nestedUnkeyedContainer(forKey: key as! Key)
   }
 
   override internal func superEncoder() -> Encoder {
     return concrete.superEncoder()
   }
 
-  override internal func superEncoder(forKey key: Key) -> Encoder {
-    return concrete.superEncoder(forKey: key)
+  override internal func superEncoder(forKey key: CodingKey) -> Encoder {
+    return concrete.superEncoder(forKey: key as! Key)
   }
 }
 
-internal class _KeyedDecodingContainerBase<Key: CodingKey> {
+internal class _KeyedDecodingContainerBase {
   internal init(){}
 
   deinit {}
@@ -3845,237 +3843,237 @@ internal class _KeyedDecodingContainerBase<Key: CodingKey> {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal var allKeys: [Key] {
+  internal var allKeys: [CodingKey] {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func contains(_ key: Key) -> Bool {
+  internal func contains(_ key: CodingKey) -> Bool {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func decodeNil(forKey key: Key) throws -> Bool {
+  internal func decodeNil(forKey key: CodingKey) throws -> Bool {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decode(
     _ type: Bool.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Bool {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decode(
     _ type: String.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> String {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decode(
     _ type: Double.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Double {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decode(
     _ type: Float.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Float {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decode(
     _ type: Int.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Int {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decode(
     _ type: Int8.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Int8 {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decode(
     _ type: Int16.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Int16 {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decode(
     _ type: Int32.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Int32 {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decode(
     _ type: Int64.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Int64 {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decode(
     _ type: UInt.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UInt {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decode(
     _ type: UInt8.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UInt8 {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decode(
     _ type: UInt16.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UInt16 {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decode(
     _ type: UInt32.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UInt32 {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decode(
     _ type: UInt64.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UInt64 {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decode<T: Decodable>(
     _ type: T.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> T {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decodeIfPresent(
     _ type: Bool.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Bool? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decodeIfPresent(
     _ type: String.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> String? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decodeIfPresent(
     _ type: Double.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Double? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decodeIfPresent(
     _ type: Float.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Float? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decodeIfPresent(
     _ type: Int.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Int? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decodeIfPresent(
     _ type: Int8.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Int8? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decodeIfPresent(
     _ type: Int16.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Int16? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decodeIfPresent(
     _ type: Int32.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Int32? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decodeIfPresent(
     _ type: Int64.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Int64? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decodeIfPresent(
     _ type: UInt.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UInt? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decodeIfPresent(
     _ type: UInt8.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UInt8? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decodeIfPresent(
     _ type: UInt16.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UInt16? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decodeIfPresent(
     _ type: UInt32.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UInt32? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decodeIfPresent(
     _ type: UInt64.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UInt64? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func decodeIfPresent<T: Decodable>(
     _ type: T.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> T? {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func nestedContainer<NestedKey>(
     keyedBy type: NestedKey.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> KeyedDecodingContainer<NestedKey> {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
   internal func nestedUnkeyedContainer(
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UnkeyedDecodingContainer {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
@@ -4084,14 +4082,14 @@ internal class _KeyedDecodingContainerBase<Key: CodingKey> {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 
-  internal func superDecoder(forKey key: Key) throws -> Decoder {
+  internal func superDecoder(forKey key: CodingKey) throws -> Decoder {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
   }
 }
 
 internal final class _KeyedDecodingContainerBox<
   Concrete: KeyedDecodingContainerProtocol
->: _KeyedDecodingContainerBase<Concrete.Key> {
+>: _KeyedDecodingContainerBase {
   typealias Key = Concrete.Key
 
   internal var concrete: Concrete
@@ -4104,247 +4102,247 @@ internal final class _KeyedDecodingContainerBox<
     return concrete.codingPath
   }
 
-  override var allKeys: [Key] {
+  override var allKeys: [CodingKey] {
     return concrete.allKeys
   }
 
-  override internal func contains(_ key: Key) -> Bool {
-    return concrete.contains(key)
+  override internal func contains(_ key: CodingKey) -> Bool {
+    return concrete.contains(key as! Key)
   }
 
-  override internal func decodeNil(forKey key: Key) throws -> Bool {
-    return try concrete.decodeNil(forKey: key)
+  override internal func decodeNil(forKey key: CodingKey) throws -> Bool {
+    return try concrete.decodeNil(forKey: key as! Key)
   }
 
   override internal func decode(
     _ type: Bool.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Bool {
-    return try concrete.decode(Bool.self, forKey: key)
+    return try concrete.decode(Bool.self, forKey: key as! Key)
   }
 
   override internal func decode(
     _ type: String.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> String {
-    return try concrete.decode(String.self, forKey: key)
+    return try concrete.decode(String.self, forKey: key as! Key)
   }
 
   override internal func decode(
     _ type: Double.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Double {
-    return try concrete.decode(Double.self, forKey: key)
+    return try concrete.decode(Double.self, forKey: key as! Key)
   }
 
   override internal func decode(
     _ type: Float.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Float {
-    return try concrete.decode(Float.self, forKey: key)
+    return try concrete.decode(Float.self, forKey: key as! Key)
   }
 
   override internal func decode(
     _ type: Int.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Int {
-    return try concrete.decode(Int.self, forKey: key)
+    return try concrete.decode(Int.self, forKey: key as! Key)
   }
 
   override internal func decode(
     _ type: Int8.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Int8 {
-    return try concrete.decode(Int8.self, forKey: key)
+    return try concrete.decode(Int8.self, forKey: key as! Key)
   }
 
   override internal func decode(
     _ type: Int16.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Int16 {
-    return try concrete.decode(Int16.self, forKey: key)
+    return try concrete.decode(Int16.self, forKey: key as! Key)
   }
 
   override internal func decode(
     _ type: Int32.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Int32 {
-    return try concrete.decode(Int32.self, forKey: key)
+    return try concrete.decode(Int32.self, forKey: key as! Key)
   }
 
   override internal func decode(
     _ type: Int64.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Int64 {
-    return try concrete.decode(Int64.self, forKey: key)
+    return try concrete.decode(Int64.self, forKey: key as! Key)
   }
 
   override internal func decode(
     _ type: UInt.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UInt {
-    return try concrete.decode(UInt.self, forKey: key)
+    return try concrete.decode(UInt.self, forKey: key as! Key)
   }
 
   override internal func decode(
     _ type: UInt8.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UInt8 {
-    return try concrete.decode(UInt8.self, forKey: key)
+    return try concrete.decode(UInt8.self, forKey: key as! Key)
   }
 
   override internal func decode(
     _ type: UInt16.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UInt16 {
-    return try concrete.decode(UInt16.self, forKey: key)
+    return try concrete.decode(UInt16.self, forKey: key as! Key)
   }
 
   override internal func decode(
     _ type: UInt32.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UInt32 {
-    return try concrete.decode(UInt32.self, forKey: key)
+    return try concrete.decode(UInt32.self, forKey: key as! Key)
   }
 
   override internal func decode(
     _ type: UInt64.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UInt64 {
-    return try concrete.decode(UInt64.self, forKey: key)
+    return try concrete.decode(UInt64.self, forKey: key as! Key)
   }
 
   override internal func decode<T: Decodable>(
     _ type: T.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> T {
-    return try concrete.decode(T.self, forKey: key)
+    return try concrete.decode(T.self, forKey: key as! Key)
   }
 
   override internal func decodeIfPresent(
     _ type: Bool.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Bool? {
-    return try concrete.decodeIfPresent(Bool.self, forKey: key)
+    return try concrete.decodeIfPresent(Bool.self, forKey: key as! Key)
   }
 
   override internal func decodeIfPresent(
     _ type: String.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> String? {
-    return try concrete.decodeIfPresent(String.self, forKey: key)
+    return try concrete.decodeIfPresent(String.self, forKey: key as! Key)
   }
 
   override internal func decodeIfPresent(
     _ type: Double.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Double? {
-    return try concrete.decodeIfPresent(Double.self, forKey: key)
+    return try concrete.decodeIfPresent(Double.self, forKey: key as! Key)
   }
 
   override internal func decodeIfPresent(
     _ type: Float.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Float? {
-    return try concrete.decodeIfPresent(Float.self, forKey: key)
+    return try concrete.decodeIfPresent(Float.self, forKey: key as! Key)
   }
 
   override internal func decodeIfPresent(
     _ type: Int.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Int? {
-    return try concrete.decodeIfPresent(Int.self, forKey: key)
+    return try concrete.decodeIfPresent(Int.self, forKey: key as! Key)
   }
 
   override internal func decodeIfPresent(
     _ type: Int8.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Int8? {
-    return try concrete.decodeIfPresent(Int8.self, forKey: key)
+    return try concrete.decodeIfPresent(Int8.self, forKey: key as! Key)
   }
 
   override internal func decodeIfPresent(
     _ type: Int16.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Int16? {
-    return try concrete.decodeIfPresent(Int16.self, forKey: key)
+    return try concrete.decodeIfPresent(Int16.self, forKey: key as! Key)
   }
 
   override internal func decodeIfPresent(
     _ type: Int32.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Int32? {
-    return try concrete.decodeIfPresent(Int32.self, forKey: key)
+    return try concrete.decodeIfPresent(Int32.self, forKey: key as! Key)
   }
 
   override internal func decodeIfPresent(
     _ type: Int64.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> Int64? {
-    return try concrete.decodeIfPresent(Int64.self, forKey: key)
+    return try concrete.decodeIfPresent(Int64.self, forKey: key as! Key)
   }
 
   override internal func decodeIfPresent(
     _ type: UInt.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UInt? {
-    return try concrete.decodeIfPresent(UInt.self, forKey: key)
+    return try concrete.decodeIfPresent(UInt.self, forKey: key as! Key)
   }
 
   override internal func decodeIfPresent(
     _ type: UInt8.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UInt8? {
-    return try concrete.decodeIfPresent(UInt8.self, forKey: key)
+    return try concrete.decodeIfPresent(UInt8.self, forKey: key as! Key)
   }
 
   override internal func decodeIfPresent(
     _ type: UInt16.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UInt16? {
-    return try concrete.decodeIfPresent(UInt16.self, forKey: key)
+    return try concrete.decodeIfPresent(UInt16.self, forKey: key as! Key)
   }
 
   override internal func decodeIfPresent(
     _ type: UInt32.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UInt32? {
-    return try concrete.decodeIfPresent(UInt32.self, forKey: key)
+    return try concrete.decodeIfPresent(UInt32.self, forKey: key as! Key)
   }
 
   override internal func decodeIfPresent(
     _ type: UInt64.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UInt64? {
-    return try concrete.decodeIfPresent(UInt64.self, forKey: key)
+    return try concrete.decodeIfPresent(UInt64.self, forKey: key as! Key)
   }
 
   override internal func decodeIfPresent<T: Decodable>(
     _ type: T.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> T? {
-    return try concrete.decodeIfPresent(T.self, forKey: key)
+    return try concrete.decodeIfPresent(T.self, forKey: key as! Key)
   }
 
   override internal func nestedContainer<NestedKey>(
     keyedBy type: NestedKey.Type,
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> KeyedDecodingContainer<NestedKey> {
-    return try concrete.nestedContainer(keyedBy: NestedKey.self, forKey: key)
+    return try concrete.nestedContainer(keyedBy: NestedKey.self, forKey: key as! Key)
   }
 
   override internal func nestedUnkeyedContainer(
-    forKey key: Key
+    forKey key: CodingKey
   ) throws -> UnkeyedDecodingContainer {
-    return try concrete.nestedUnkeyedContainer(forKey: key)
+    return try concrete.nestedUnkeyedContainer(forKey: key as! Key)
   }
 
   override internal func superDecoder() throws -> Decoder {
     return try concrete.superDecoder()
   }
 
-  override internal func superDecoder(forKey key: Key) throws -> Decoder {
-    return try concrete.superDecoder(forKey: key)
+  override internal func superDecoder(forKey key: CodingKey) throws -> Decoder {
+    return try concrete.superDecoder(forKey: key as! Key)
   }
 }
 


### PR DESCRIPTION
In particular, types generic on the CodingKey produce a lot of runtime metadata.
Reducing the number of such types should help with some of the reported memory
bloat from Codable.

Resolves rdar://62620208