### PR TITLE
For compatibility, avoid the new fast path if the incoming pointer is 0

### DIFF
--- a/stdlib/public/Darwin/Foundation/NSStringAPI.swift
+++ b/stdlib/public/Darwin/Foundation/NSStringAPI.swift
@@ -178,6 +178,10 @@ extension String {
   /// Creates a string by copying the data from a given
   /// C array of UTF8-encoded bytes.
   public init?(utf8String bytes: UnsafePointer<CChar>) {
+    // This isn't declared to accept nil but in practice it appears some people
+    // manage to pass it nil anyway
+    guard UInt(bitPattern: bytes) != 0 else { return nil }
+    
     if let str = String(validatingUTF8: bytes) {
       self = str
       return

--- a/test/stdlib/NSStringAPI.swift
+++ b/test/stdlib/NSStringAPI.swift
@@ -230,6 +230,12 @@ NSStringAPIs.test("init(utf8String:)") {
   up.deallocate()
 }
 
+NSStringAPIs.test("init(utf8String:) compatibility hack") {
+  let ptr = UnsafePointer<CChar>(bitPattern: 0)
+  expectNil(String(utf8String: ptr))
+}
+
+
 NSStringAPIs.test("canBeConvertedToEncoding(_:)") {
   expectTrue("foo".canBeConverted(to: .ascii))
   expectFalse("あいう".canBeConverted(to: .ascii))


### PR DESCRIPTION
Fixes rdar://problem/60882075