### PR TITLE
Update Devirtualizer's analysis invalidation

### DIFF
--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -233,9 +233,9 @@ FullApplySite findApplyFromDevirtualizedResult(SILValue value);
 /// - a type of the return value is a subclass of the expected return type.
 /// - actual return type and expected return type differ in optionality.
 /// - both types are tuple-types and some of the elements need to be casted.
-SILValue castValueToABICompatibleType(SILBuilder *builder, SILLocation Loc,
-                                      SILValue value, SILType srcTy,
-                                      SILType destTy);
+std::pair<SILValue, bool /* changedCFG */>
+castValueToABICompatibleType(SILBuilder *builder, SILLocation Loc,
+                             SILValue value, SILType srcTy, SILType destTy);
 /// Peek through trivial Enum initialization, typically for pointless
 /// Optionals.
 ///

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -2418,9 +2418,9 @@ bool SimplifyCFG::simplifyTryApplyBlock(TryApplyInst *TAI) {
     for (unsigned i = 0; i < numArgs; ++i) {
       auto Arg = TAI->getArgument(i);
       // Cast argument if required.
-      Arg = castValueToABICompatibleType(&Builder, TAI->getLoc(), Arg,
-                                         origConv.getSILArgumentType(i),
-                                         targetConv.getSILArgumentType(i));
+      std::tie(Arg, std::ignore) = castValueToABICompatibleType(
+          &Builder, TAI->getLoc(), Arg, origConv.getSILArgumentType(i),
+          targetConv.getSILArgumentType(i));
       Args.push_back(Arg);
     }
 
@@ -2435,8 +2435,9 @@ bool SimplifyCFG::simplifyTryApplyBlock(TryApplyInst *TAI) {
     auto Loc = TAI->getLoc();
     auto *NormalBB = TAI->getNormalBB();
 
-    auto CastedResult = castValueToABICompatibleType(&Builder, Loc, NewAI,
-                                                     ResultTy, OrigResultTy);
+    SILValue CastedResult;
+    std::tie(CastedResult, std::ignore) = castValueToABICompatibleType(
+        &Builder, Loc, NewAI, ResultTy, OrigResultTy);
 
     Builder.createBranch(Loc, NormalBB, { CastedResult });
     TAI->eraseFromParent();

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -805,10 +805,10 @@ swift::devirtualizeClassMethod(FullApplySite applySite,
     ++paramArgIter;
   }
   ApplySite newAS;
-  bool changed;
-  std::tie(newAS, changed) = replaceApplySite(
+  bool neededCFGChange;
+  std::tie(newAS, neededCFGChange) = replaceApplySite(
       builder, loc, applySite, fri, subs, newArgs, substConv, newArgBorrows);
-  changedCFG |= changed;
+  changedCFG |= neededCFGChange;
   FullApplySite newAI = FullApplySite::isa(newAS.getInstruction());
   assert(newAI);
 
@@ -1036,11 +1036,11 @@ devirtualizeWitnessMethod(ApplySite applySite, SILFunction *f,
   auto *fri = applyBuilder.createFunctionRefFor(loc, f);
 
   ApplySite newApplySite;
-  bool changed = false;
-  std::tie(newApplySite, changed) =
+  bool neededCFGChange = false;
+  std::tie(newApplySite, neededCFGChange) =
       replaceApplySite(applyBuilder, loc, applySite, fri, subMap, arguments,
                        substConv, borrowedArgs);
-  changedCFG |= changed;
+  changedCFG |= neededCFGChange;
 
   if (ore)
     ore->emit([&]() {

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -460,11 +460,11 @@ getSubstitutionsForCallee(SILModule &module, CanSILFunctionType baseCalleeType,
                                              baseCalleeSig);
 }
 
-static ApplyInst *replaceApplyInst(SILBuilder &builder, SILLocation loc,
-                                   ApplyInst *oldAI, SILValue newFn,
-                                   SubstitutionMap newSubs,
-                                   ArrayRef<SILValue> newArgs,
-                                   ArrayRef<SILValue> newArgBorrows) {
+// Return the new apply and true if a cast required CFG modification.
+static std::pair<ApplyInst *, bool /* changedCFG */>
+replaceApplyInst(SILBuilder &builder, SILLocation loc, ApplyInst *oldAI,
+                 SILValue newFn, SubstitutionMap newSubs,
+                 ArrayRef<SILValue> newArgs, ArrayRef<SILValue> newArgBorrows) {
   auto *newAI =
       builder.createApply(loc, newFn, newSubs, newArgs, oldAI->isNonThrowing());
 
@@ -475,15 +475,15 @@ static ApplyInst *replaceApplyInst(SILBuilder &builder, SILLocation loc,
   }
 
   // Check if any casting is required for the return value.
-  SILValue resultValue = castValueToABICompatibleType(
+  auto castRes = castValueToABICompatibleType(
       &builder, loc, newAI, newAI->getType(), oldAI->getType());
 
-  oldAI->replaceAllUsesWith(resultValue);
-  return newAI;
+  oldAI->replaceAllUsesWith(castRes.first);
+  return {newAI, castRes.second};
 }
 
 // Return the new try_apply and true if a cast required CFG modification.
-static std::pair<TryApplyInst *, bool>
+static std::pair<TryApplyInst *, bool /* changedCFG */>
 replaceTryApplyInst(SILBuilder &builder, SILLocation loc, TryApplyInst *oldTAI,
                     SILValue newFn, SubstitutionMap newSubs,
                     ArrayRef<SILValue> newArgs, SILFunctionConventions conv,
@@ -531,8 +531,8 @@ replaceTryApplyInst(SILBuilder &builder, SILLocation loc, TryApplyInst *oldTAI,
     builder.setInsertionPoint(resultBB);
 
     SILValue resultValue = resultBB->getArgument(0);
-    resultValue = castValueToABICompatibleType(&builder, loc, resultValue,
-                                               newResultTy, oldResultTy);
+    std::tie(resultValue, std::ignore) = castValueToABICompatibleType(
+        &builder, loc, resultValue, newResultTy, oldResultTy);
     builder.createBranch(loc, normalBB, {resultValue});
   }
 
@@ -540,11 +540,13 @@ replaceTryApplyInst(SILBuilder &builder, SILLocation loc, TryApplyInst *oldTAI,
   return {newTAI, resultCastRequired};
 }
 
-static BeginApplyInst *
+// Return the new begin_apply and true if a cast required CFG modification.
+static std::pair<BeginApplyInst *, bool /* changedCFG */>
 replaceBeginApplyInst(SILBuilder &builder, SILLocation loc,
                       BeginApplyInst *oldBAI, SILValue newFn,
                       SubstitutionMap newSubs, ArrayRef<SILValue> newArgs,
                       ArrayRef<SILValue> newArgBorrows) {
+  bool changedCFG = false;
   auto *newBAI = builder.createBeginApply(loc, newFn, newSubs, newArgs,
                                           oldBAI->isNonThrowing());
 
@@ -558,13 +560,14 @@ replaceBeginApplyInst(SILBuilder &builder, SILLocation loc,
   for (auto i : indices(oldYields)) {
     auto oldYield = oldYields[i];
     auto newYield = newYields[i];
-    newYield = castValueToABICompatibleType(
+    auto yieldCastRes = castValueToABICompatibleType(
         &builder, loc, newYield, newYield->getType(), oldYield->getType());
-    oldYield->replaceAllUsesWith(newYield);
+    oldYield->replaceAllUsesWith(yieldCastRes.first);
+    changedCFG |= yieldCastRes.second;
   }
 
   if (newArgBorrows.empty())
-    return newBAI;
+    return {newBAI, changedCFG};
 
   SILValue token = newBAI->getTokenResult();
 
@@ -579,10 +582,11 @@ replaceBeginApplyInst(SILBuilder &builder, SILLocation loc,
     }
   }
 
-  return newBAI;
+  return {newBAI, changedCFG};
 }
 
-static PartialApplyInst *
+// Return the new partial_apply and true if a cast required CFG modification.
+static std::pair<PartialApplyInst *, bool /* changedCFG */>
 replacePartialApplyInst(SILBuilder &builder, SILLocation loc,
                         PartialApplyInst *oldPAI, SILValue newFn,
                         SubstitutionMap newSubs, ArrayRef<SILValue> newArgs) {
@@ -592,15 +596,15 @@ replacePartialApplyInst(SILBuilder &builder, SILLocation loc,
       builder.createPartialApply(loc, newFn, newSubs, newArgs, convention);
 
   // Check if any casting is required for the partially-applied function.
-  SILValue resultValue = castValueToABICompatibleType(
+  auto castRes = castValueToABICompatibleType(
       &builder, loc, newPAI, newPAI->getType(), oldPAI->getType());
-  oldPAI->replaceAllUsesWith(resultValue);
+  oldPAI->replaceAllUsesWith(castRes.first);
 
-  return newPAI;
+  return {newPAI, castRes.second};
 }
 
 // Return the new apply and true if the CFG was also modified.
-static std::pair<ApplySite, bool>
+static std::pair<ApplySite, bool /* changedCFG */>
 replaceApplySite(SILBuilder &builder, SILLocation loc, ApplySite oldAS,
                  SILValue newFn, SubstitutionMap newSubs,
                  ArrayRef<SILValue> newArgs, SILFunctionConventions conv,
@@ -608,9 +612,8 @@ replaceApplySite(SILBuilder &builder, SILLocation loc, ApplySite oldAS,
   switch (oldAS.getKind()) {
   case ApplySiteKind::ApplyInst: {
     auto *oldAI = cast<ApplyInst>(oldAS);
-    return {replaceApplyInst(builder, loc, oldAI, newFn, newSubs, newArgs,
-                             newArgBorrows),
-            false};
+    return replaceApplyInst(builder, loc, oldAI, newFn, newSubs, newArgs,
+                            newArgBorrows);
   }
   case ApplySiteKind::TryApplyInst: {
     auto *oldTAI = cast<TryApplyInst>(oldAS);
@@ -619,16 +622,14 @@ replaceApplySite(SILBuilder &builder, SILLocation loc, ApplySite oldAS,
   }
   case ApplySiteKind::BeginApplyInst: {
     auto *oldBAI = dyn_cast<BeginApplyInst>(oldAS);
-    return {replaceBeginApplyInst(builder, loc, oldBAI, newFn, newSubs, newArgs,
-                                  newArgBorrows),
-            false};
+    return replaceBeginApplyInst(builder, loc, oldBAI, newFn, newSubs, newArgs,
+                                 newArgBorrows);
   }
   case ApplySiteKind::PartialApplyInst: {
     assert(newArgBorrows.empty());
     auto *oldPAI = cast<PartialApplyInst>(oldAS);
-    return {
-        replacePartialApplyInst(builder, loc, oldPAI, newFn, newSubs, newArgs),
-        false};
+    return replacePartialApplyInst(builder, loc, oldPAI, newFn, newSubs,
+                                   newArgs);
   }
   }
   llvm_unreachable("covered switch");
@@ -734,10 +735,11 @@ bool swift::canDevirtualizeClassMethod(FullApplySite applySite, ClassDecl *cd,
 /// return the result value of the new ApplyInst if created one or null.
 ///
 /// Return the new apply and true if the CFG was also modified.
-std::pair<FullApplySite, bool>
+std::pair<FullApplySite, bool /* changedCFG */>
 swift::devirtualizeClassMethod(FullApplySite applySite,
                                SILValue classOrMetatype, ClassDecl *cd,
                                OptRemark::Emitter *ore) {
+  bool changedCFG = false;
   LLVM_DEBUG(llvm::dbgs() << "    Trying to devirtualize : "
                           << *applySite.getInstruction());
 
@@ -775,9 +777,11 @@ swift::devirtualizeClassMethod(FullApplySite applySite,
 
   auto indirectResultArgIter = applySite.getIndirectSILResults().begin();
   for (auto resultTy : substConv.getIndirectSILResultTypes()) {
-    newArgs.push_back(castValueToABICompatibleType(
+    auto castRes = castValueToABICompatibleType(
         &builder, loc, *indirectResultArgIter, indirectResultArgIter->getType(),
-        resultTy));
+        resultTy);
+    newArgs.push_back(castRes.first);
+    changedCFG |= castRes.second;
     ++indirectResultArgIter;
   }
 
@@ -793,15 +797,18 @@ swift::devirtualizeClassMethod(FullApplySite applySite,
       arg = borrowBuilder.createBeginBorrow(loc, arg);
       newArgBorrows.push_back(arg);
     }
-    arg = castValueToABICompatibleType(&builder, loc, arg,
+    auto argCastRes = castValueToABICompatibleType(&builder, loc, arg,
                                        paramArgIter->getType(), paramType);
-    newArgs.push_back(arg);
+
+    newArgs.push_back(argCastRes.first);
+    changedCFG |= argCastRes.second;
     ++paramArgIter;
   }
   ApplySite newAS;
-  bool modifiedCFG;
-  std::tie(newAS, modifiedCFG) = replaceApplySite(
+  bool changed;
+  std::tie(newAS, changed) = replaceApplySite(
       builder, loc, applySite, fri, subs, newArgs, substConv, newArgBorrows);
+  changedCFG |= changed;
   FullApplySite newAI = FullApplySite::isa(newAS.getInstruction());
   assert(newAI);
 
@@ -815,7 +822,7 @@ swift::devirtualizeClassMethod(FullApplySite applySite,
     });
   NumClassDevirt++;
 
-  return {newAI, modifiedCFG};
+  return {newAI, changedCFG};
 }
 
 std::pair<FullApplySite, bool> swift::tryDevirtualizeClassMethod(
@@ -971,6 +978,7 @@ static std::pair<ApplySite, bool>
 devirtualizeWitnessMethod(ApplySite applySite, SILFunction *f,
                           ProtocolConformanceRef cRef,
                           OptRemark::Emitter *ore) {
+  bool changedCFG = false;
   // We know the witness thunk and the corresponding set of substitutions
   // required to invoke the protocol method at this point.
   auto &module = applySite.getModule();
@@ -1012,8 +1020,10 @@ devirtualizeWitnessMethod(ApplySite applySite, SILFunction *f,
         arg = borrowBuilder.createBeginBorrow(applySite.getLoc(), arg);
         borrowedArgs.push_back(arg);
       }
-      arg = castValueToABICompatibleType(&argBuilder, applySite.getLoc(), arg,
-                                         arg->getType(), paramType);
+      auto argCastRes = castValueToABICompatibleType(
+          &argBuilder, applySite.getLoc(), arg, arg->getType(), paramType);
+      arg = argCastRes.first;
+      changedCFG |= argCastRes.second;
     }
     arguments.push_back(arg);
   }
@@ -1026,10 +1036,11 @@ devirtualizeWitnessMethod(ApplySite applySite, SILFunction *f,
   auto *fri = applyBuilder.createFunctionRefFor(loc, f);
 
   ApplySite newApplySite;
-  bool modifiedCFG;
-  std::tie(newApplySite, modifiedCFG) =
+  bool changed = false;
+  std::tie(newApplySite, changed) =
       replaceApplySite(applyBuilder, loc, applySite, fri, subMap, arguments,
                        substConv, borrowedArgs);
+  changedCFG |= changed;
 
   if (ore)
     ore->emit([&]() {
@@ -1039,7 +1050,7 @@ devirtualizeWitnessMethod(ApplySite applySite, SILFunction *f,
              << "Devirtualized call to " << NV("Method", f);
     });
   NumWitnessDevirt++;
-  return {newApplySite, modifiedCFG};
+  return {newApplySite, changedCFG};
 }
 
 static bool canDevirtualizeWitnessMethod(ApplySite applySite) {

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -810,14 +810,7 @@ SILLinkage swift::getSpecializedLinkage(SILFunction *f, SILLinkage linkage) {
 /// - a type of the return value is a subclass of the expected return type.
 /// - actual return type and expected return type differ in optionality.
 /// - both types are tuple-types and some of the elements need to be casted.
-///
-/// If CheckOnly flag is set, then this function only checks if the
-/// required casting is possible. If it is not possible, then None
-/// is returned.
-///
-/// If CheckOnly is not set, then a casting code is generated and the final
-/// casted value is returned.
-///
+/// Return the cast value and true if a CFG modification was required
 /// NOTE: We intentionally combine the checking of the cast's handling
 /// possibility and the transformation performing the cast in the same function,
 /// to avoid any divergence between the check and the implementation in the
@@ -825,27 +818,28 @@ SILLinkage swift::getSpecializedLinkage(SILFunction *f, SILLinkage linkage) {
 ///
 /// NOTE: The implementation of this function is very closely related to the
 /// rules checked by SILVerifier::requireABICompatibleFunctionTypes.
-SILValue swift::castValueToABICompatibleType(SILBuilder *builder,
-                                             SILLocation loc, SILValue value,
-                                             SILType srcTy, SILType destTy) {
+std::pair<SILValue, bool /* changedCFG */>
+swift::castValueToABICompatibleType(SILBuilder *builder, SILLocation loc,
+                                    SILValue value, SILType srcTy,
+                                    SILType destTy) {
 
   // No cast is required if types are the same.
   if (srcTy == destTy)
-    return value;
+    return {value, false};
 
   if (srcTy.isAddress() && destTy.isAddress()) {
     // Cast between two addresses and that's it.
-    return builder->createUncheckedAddrCast(loc, value, destTy);
+    return {builder->createUncheckedAddrCast(loc, value, destTy), false};
   }
 
   // If both types are classes and dest is the superclass of src,
   // simply perform an upcast.
   if (destTy.isExactSuperclassOf(srcTy)) {
-    return builder->createUpcast(loc, value, destTy);
+    return {builder->createUpcast(loc, value, destTy), false};
   }
 
   if (srcTy.isHeapObjectReferenceType() && destTy.isHeapObjectReferenceType()) {
-    return builder->createUncheckedRefCast(loc, value, destTy);
+    return {builder->createUncheckedRefCast(loc, value, destTy), false};
   }
 
   if (auto mt1 = srcTy.getAs<AnyMetatypeType>()) {
@@ -855,11 +849,11 @@ SILValue swift::castValueToABICompatibleType(SILBuilder *builder,
         // A is a superclass of builder, then it can be done by means
         // of a simple upcast.
         if (mt2.getInstanceType()->isExactSuperclassOf(mt1.getInstanceType())) {
-          return builder->createUpcast(loc, value, destTy);
+          return {builder->createUpcast(loc, value, destTy), false};
         }
 
         // Cast between two metatypes and that's it.
-        return builder->createUncheckedBitCast(loc, value, destTy);
+        return {builder->createUncheckedBitCast(loc, value, destTy), false};
       }
     }
   }
@@ -874,7 +868,7 @@ SILValue swift::castValueToABICompatibleType(SILBuilder *builder,
     // simply perform an upcast.
     if (optionalDestTy.isExactSuperclassOf(optionalSrcTy)) {
       // Insert upcast.
-      return builder->createUpcast(loc, value, destTy);
+      return {builder->createUpcast(loc, value, destTy), false};
     }
 
     // Unwrap the original optional value.
@@ -896,7 +890,8 @@ SILValue swift::castValueToABICompatibleType(SILBuilder *builder,
     SILValue unwrappedValue =
         builder->createUncheckedEnumData(loc, value, someDecl);
     // Cast the unwrapped value.
-    auto castedUnwrappedValue = castValueToABICompatibleType(
+    SILValue castedUnwrappedValue;
+    std::tie(castedUnwrappedValue, std::ignore) = castValueToABICompatibleType(
         builder, loc, unwrappedValue, optionalSrcTy, optionalDestTy);
     // Wrap into optional.
     auto castedValue =
@@ -909,7 +904,7 @@ SILValue swift::castValueToABICompatibleType(SILBuilder *builder,
     builder->createBranch(loc, contBB, {castedValue});
     builder->setInsertionPoint(contBB->begin());
 
-    return contBB->getArgument(0);
+    return {contBB->getArgument(0), true};
   }
 
   // Src is not optional, but dest is optional.
@@ -931,16 +926,19 @@ SILValue swift::castValueToABICompatibleType(SILBuilder *builder,
   // Extract elements, cast each of them, create a new tuple.
   if (auto srcTupleTy = srcTy.getAs<TupleType>()) {
     SmallVector<SILValue, 8> expectedTuple;
+    bool changedCFG = false;
     for (unsigned i = 0, e = srcTupleTy->getNumElements(); i < e; i++) {
       SILValue element = builder->createTupleExtract(loc, value, i);
       // Cast the value if necessary.
-      element = castValueToABICompatibleType(builder, loc, element,
-                                             srcTy.getTupleElementType(i),
-                                             destTy.getTupleElementType(i));
+      bool changed;
+      std::tie(element, changed) = castValueToABICompatibleType(
+          builder, loc, element, srcTy.getTupleElementType(i),
+          destTy.getTupleElementType(i));
+      changedCFG |= changed;
       expectedTuple.push_back(element);
     }
 
-    return builder->createTuple(loc, destTy, expectedTuple);
+    return {builder->createTuple(loc, destTy, expectedTuple), changedCFG};
   }
 
   // Function types are interchangeable if they're also ABI-compatible.
@@ -954,8 +952,9 @@ SILValue swift::castValueToABICompatibleType(SILBuilder *builder,
                        "not ABI "
                        "compatible");
       // Insert convert_function.
-      return builder->createConvertFunction(loc, value, destTy,
-                                            /*WithoutActuallyEscaping=*/false);
+      return {builder->createConvertFunction(loc, value, destTy,
+                                             /*WithoutActuallyEscaping=*/false),
+              false};
     }
   }
 

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -930,11 +930,11 @@ swift::castValueToABICompatibleType(SILBuilder *builder, SILLocation loc,
     for (unsigned i = 0, e = srcTupleTy->getNumElements(); i < e; i++) {
       SILValue element = builder->createTupleExtract(loc, value, i);
       // Cast the value if necessary.
-      bool changed;
-      std::tie(element, changed) = castValueToABICompatibleType(
+      bool neededCFGChange;
+      std::tie(element, neededCFGChange) = castValueToABICompatibleType(
           builder, loc, element, srcTy.getTupleElementType(i),
           destTy.getTupleElementType(i));
-      changedCFG |= changed;
+      changedCFG |= neededCFGChange;
       expectedTuple.push_back(element);
     }
 

--- a/test/SILOptimizer/sil_combine_concrete_existential.swift
+++ b/test/SILOptimizer/sil_combine_concrete_existential.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -O -emit-sil -sil-verify-all -Xllvm -sil-disable-pass=function-signature-opts %s | %FileCheck %s
-// %target-swift-frontend -O -emit-sil -Xllvm -sil-verify-force-analysis-around-pass=devirtualizer -Xllvm -sil-disable-pass=function-signature-opts %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-sil -Xllvm -sil-verify-force-analysis-around-pass=devirtualizer -Xllvm -sil-disable-pass=function-signature-opts %s | %FileCheck %s
 
 //===----------------------------------------------------------------------===//
 // testReturnSelf: Call to a protocol extension method with


### PR DESCRIPTION
`castValueToABICompatibleType` can change CFG, Devirtualizer uses this api but doesn't check if it modified the cfg. With this, Devirtualizer checks is cfg changed, and invalidates accordingly.
