### PR TITLE
Don't emit an error for code completion

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -196,9 +196,6 @@ ERROR(repl_must_be_initialized,none,
 ERROR(error_doing_code_completion,none,
       "compiler is in code completion mode (benign diagnostic)", ())
 
-WARNING(completion_reusing_astcontext,none,
-        "completion reusing previous ASTContext (benign diagnostic)", ())
-
 ERROR(verify_encountered_fatal,none,
       "fatal error encountered while in -verify mode", ())
 

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -193,9 +193,6 @@ ERROR(repl_must_be_initialized,none,
       "variables currently must have an initial value when entered at the "
       "top level of the REPL", ())
 
-ERROR(error_doing_code_completion,none,
-      "compiler is in code completion mode (benign diagnostic)", ())
-
 ERROR(verify_encountered_fatal,none,
       "fatal error encountered while in -verify mode", ())
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -822,13 +822,6 @@ void CompilerInstance::parseAndCheckTypesUpTo(
   FrontendStatsTracer tracer(getStatsReporter(), "parse-and-check-types");
 
   bool hadLoadError = parsePartialModulesAndInputFiles();
-  if (Invocation.isCodeCompletion()) {
-    // When we are doing code completion, make sure to emit at least one
-    // diagnostic, so that ASTContext is marked as erroneous.  In this case
-    // various parts of the compiler (for example, AST verifier) have less
-    // strict assumptions about the AST.
-    Diagnostics.diagnose(SourceLoc(), diag::error_doing_code_completion);
-  }
   if (hadLoadError)
     return;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -83,8 +83,7 @@ void EditorDiagConsumer::handleDiagnostic(SourceManager &SM,
   }
 
   // Filter out benign diagnostics for editing.
-  if (Info.ID == diag::lex_editor_placeholder.ID ||
-      Info.ID == diag::error_doing_code_completion.ID)
+  if (Info.ID == diag::lex_editor_placeholder.ID)
     return;
 
   bool IsNote = (Info.Kind == DiagnosticKind::Note);


### PR DESCRIPTION
Now that we no longer perform whole-file type checking for code completion, the `ASTVerifier` is no longer expecting a fully semantically valid AST. As such, we no longer need to emit an error to force it to be more lax with its checks.