### PR TITLE
[5.3] Fix ReactiveKit failure seen in source compatibility suite

### DIFF
--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -405,12 +405,8 @@ bool SerializedModuleLoader::maybeDiagnoseTargetMismatch(
       return false;
     StringRef filePath = directoryIterator->path();
     StringRef extension = llvm::sys::path::extension(filePath);
-    auto fileType = file_types::lookupTypeForExtension(extension);
-    // We also check for interfaces here, because the SerializedModuleLoader
-    // is invoked after the ModuleInterfaceLoader; if the ModuleInterfaceLoader
-    // handled interfaces separately, we could get duplicate diagnostics.
-    if (fileType == file_types::TY_SwiftModuleFile
-        || fileType == file_types::TY_SwiftModuleInterfaceFile) {
+    if (file_types::lookupTypeForExtension(extension) ==
+          file_types::TY_SwiftModuleFile) {
       if (!foundArchs.empty())
         foundArchs += ", ";
       foundArchs += llvm::sys::path::stem(filePath).str();
@@ -418,7 +414,7 @@ bool SerializedModuleLoader::maybeDiagnoseTargetMismatch(
   }
 
   if (foundArchs.empty()) {
-    // It is strange that there were no swiftmodules or swiftinterfaces here;
+    // Maybe this swiftmodule directory only contains swiftinterfaces, or
     // maybe something else is going on. Regardless, we shouldn't emit a
     // possibly incorrect diagnostic.
     return false;

--- a/test/ModuleInterface/ModuleCache/force-module-loading-mode-archs.swift
+++ b/test/ModuleInterface/ModuleCache/force-module-loading-mode-archs.swift
@@ -14,7 +14,7 @@
 // RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-parseable not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
 // RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-serialized not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
 // RUN: env SWIFT_FORCE_MODULE_LOADING=only-parseable not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
-// RUN: env SWIFT_FORCE_MODULE_LOADING=only-serialized not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=WRONG-ARCH-2 -DARCH=%module-target-triple -DTARGET_CPU=%target-cpu %s
+// RUN: env SWIFT_FORCE_MODULE_LOADING=only-serialized not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=NO-SUCH-MODULE %s
 // (default)
 // RUN: not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP -I %t %s 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
 
@@ -82,19 +82,19 @@
 
 // 8. Only the interface is present but for the wrong architecture.
 // (Diagnostics for the module only are tested elsewhere.)
+// FIXME: We should improve this to not just say NO-SUCH-MODULE.
 // RUN: rm %t/Lib.swiftmodule/garbage.swiftmodule
-// RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-parseable not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%module-target-triple %s
-// RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-serialized not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%module-target-triple %s
+// RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-parseable not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=NO-SUCH-MODULE %s
+// RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-serialized not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=NO-SUCH-MODULE %s
 // RUN: env SWIFT_FORCE_MODULE_LOADING=only-parseable not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=NO-SUCH-MODULE %s
-// RUN: env SWIFT_FORCE_MODULE_LOADING=only-serialized not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%module-target-triple %s
+// RUN: env SWIFT_FORCE_MODULE_LOADING=only-serialized not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -I %t 2>&1 | %FileCheck -check-prefix=NO-SUCH-MODULE %s
 // (default)
-// RUN: not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP -I %t %s 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%module-target-triple %s
+// RUN: not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP -I %t %s 2>&1 | %FileCheck -check-prefix=NO-SUCH-MODULE %s
 
 import Lib
 // NO-SUCH-MODULE: [[@LINE-1]]:8: error: no such module 'Lib'
 // BAD-MODULE: [[@LINE-2]]:8: error: malformed compiled module: {{.*}}Lib.swiftmodule
 // WRONG-ARCH: [[@LINE-3]]:8: error: could not find module 'Lib' for target '[[ARCH]]'; found: garbage
-// WRONG-ARCH-2: [[@LINE-4]]:8: error: could not find module 'Lib' for target '[[ARCH]]'; found: [[TARGET_CPU]]
 
 struct X {}
 let _: X = Lib.testValue

--- a/test/ModuleInterface/ModuleCache/force-module-loading-mode-framework.swift
+++ b/test/ModuleInterface/ModuleCache/force-module-loading-mode-framework.swift
@@ -14,7 +14,7 @@
 // RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-parseable not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -F %t 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
 // RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-serialized not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -F %t 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
 // RUN: env SWIFT_FORCE_MODULE_LOADING=only-parseable not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -F %t 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
-// RUN: env SWIFT_FORCE_MODULE_LOADING=only-serialized not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -F %t 2>&1 | %FileCheck -check-prefix=WRONG-ARCH-2 -DARCH=%module-target-triple -DTARGET_CPU=%target-cpu %s
+// RUN: env SWIFT_FORCE_MODULE_LOADING=only-serialized not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -F %t 2>&1 | %FileCheck -check-prefix=NO-SUCH-MODULE %s
 // (default)
 // RUN: not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP -F %t %s 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
 
@@ -83,19 +83,19 @@
 
 // 8. Only the interface is present but for the wrong architecture.
 // (Diagnostics for the module only are tested elsewhere.)
+// FIXME: We should improve this to not just say NO-SUCH-MODULE.
 // RUN: rm %t/Lib.framework/Modules/Lib.swiftmodule/garbage.swiftmodule
-// RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-parseable not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -F %t 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%module-target-triple %s
-// RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-serialized not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -F %t 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%module-target-triple %s
+// RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-parseable not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -F %t 2>&1 | %FileCheck -check-prefix=NO-SUCH-MODULE %s
+// RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-serialized not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -F %t 2>&1 | %FileCheck -check-prefix=NO-SUCH-MODULE %s
 // RUN: env SWIFT_FORCE_MODULE_LOADING=only-parseable not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -F %t 2>&1 | %FileCheck -check-prefix=NO-SUCH-MODULE %s
-// RUN: env SWIFT_FORCE_MODULE_LOADING=only-serialized not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -F %t 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%module-target-triple %s
+// RUN: env SWIFT_FORCE_MODULE_LOADING=only-serialized not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP %s -F %t 2>&1 | %FileCheck -check-prefix=NO-SUCH-MODULE %s
 // (default)
-// RUN: not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP -F %t %s 2>&1 | %FileCheck -check-prefix=WRONG-ARCH -DARCH=%module-target-triple %s
+// RUN: not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP -F %t %s 2>&1 | %FileCheck -check-prefix=NO-SUCH-MODULE %s
 
 import Lib
 // NO-SUCH-MODULE: [[@LINE-1]]:8: error: no such module 'Lib'
 // BAD-MODULE: [[@LINE-2]]:8: error: malformed compiled module: {{.*}}Lib.swiftmodule
 // WRONG-ARCH: [[@LINE-3]]:8: error: could not find module 'Lib' for target '[[ARCH]]'; found: garbage
-// WRONG-ARCH-2: [[@LINE-4]]:8: error: could not find module 'Lib' for target '[[ARCH]]'; found: [[TARGET_CPU]]
 
 struct X {}
 let _: X = Lib.testValue

--- a/test/ModuleInterface/arm64e-fallback.swift
+++ b/test/ModuleInterface/arm64e-fallback.swift
@@ -3,4 +3,4 @@
 // REQUIRES: OS=ios
 
 import DummyFramework
-// CHECK: could not find module 'DummyFramework' for target 'arm64e-apple-ios'; found: arm64-apple-ios, arm64
+// CHECK: no such module 'DummyFramework'

--- a/test/ModuleInterface/can-import.swift
+++ b/test/ModuleInterface/can-import.swift
@@ -1,5 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: echo 'public func externalFunc() {}' | %target-swift-frontend -typecheck -emit-module-interface-path %t/Library.swiftinterface -
+// RUN: %empty-directory(%t/LibraryWithoutThisArchitecture.swiftmodule)
+// RUN: echo 'public func externalFunc() {}' | %target-swift-frontend -typecheck -emit-module-interface-path %t/LibraryWithoutThisArchitecture.swiftmodule/arm40000-apple-ios.swiftinterface -
 // RUN: %target-swift-frontend -typecheck %s -I %t
 
 #if canImport(Library)
@@ -11,4 +13,8 @@ externalFunc()
 
 #if canImport(LibraryThatDoesNotExist)
 #error("should not return true for library that does not exist")
+#endif
+
+#if canImport(LibraryWithoutThisArchitecture)
+#error("should not return true (or diagnose a loader failure) for library that does not exist")
 #endif


### PR DESCRIPTION
Cherry-picks #31288 to 5.3.

> One of the commits in #31196 caused a regression when `canImport()` was used to test the importability of a module which has module interfaces for other targets, but not the current one. In practice, this happens with Combine and other iOS 13-introduced modules, because they don't have module interface files for 32-bit ARM.
> 
> The right solution is to refactor diagnosis during module loading so that we can guarantee that `canImport()` won't diagnose anything, but this PR simply adds a similar test case and reverts the commit to fix the broken bot.
>
> Fixes rdar://62335415.