### PR TITLE
SIL: use object libraries instead of globbing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ if(POLICY CMP0067)
   cmake_policy(SET CMP0067 NEW)
 endif()
 
+# Convert relative paths to absolute for subdirectory `target_sources`
+if(POLICY CMP0076)
+  cmake_policy(SET CMP0076 NEW)
+endif()
+
 # Add path for custom CMake modules.
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -1,38 +1,15 @@
-
-set(SIL_SOURCES)
-
-function(_list_transform newvar)
-  set(sources ${ARGN})
-  set(dir ${CMAKE_CURRENT_SOURCE_DIR})
-  set(tmp)
-  foreach (s ${sources})
-    list(APPEND tmp "${dir}/${s}")
-  endforeach()
-  set(${newvar} "${tmp}" PARENT_SCOPE)
-endfunction()
-
-macro(sil_register_sources)
-  precondition(new_transformed_sources
-    NEGATE
-    MESSAGE "Expected this to be empty since we clear after each run")
-  _list_transform(new_transformed_sources ${ARGN})
-  list_union("${SIL_SOURCES}" "${new_transformed_sources}" out)
-  set(SIL_SOURCES "${out}" PARENT_SCOPE)
-  set(new_transformed_sources)
-endmacro()
-
-add_subdirectory(IR)
-add_subdirectory(Utils)
-add_subdirectory(Verifier)
-add_subdirectory(Parser)
-
 add_swift_host_library(swiftSIL STATIC
-  ${SIL_SOURCES})
+  SIL.cpp)
 target_link_libraries(swiftSIL PUBLIC
   swiftDemangling)
 target_link_libraries(swiftSIL PRIVATE
   swiftSema
   swiftSerialization)
+
+add_subdirectory(IR)
+add_subdirectory(Utils)
+add_subdirectory(Verifier)
+add_subdirectory(Parser)
 
 # intrinsics_gen is the LLVM tablegen target that generates the include files
 # where intrinsics and attributes are declared. swiftSIL depends on these

--- a/lib/SIL/IR/CMakeLists.txt
+++ b/lib/SIL/IR/CMakeLists.txt
@@ -1,4 +1,4 @@
-sil_register_sources(
+target_sources(swiftSIL PRIVATE
   AbstractionPattern.cpp
   Bridging.cpp
   Linker.cpp
@@ -31,5 +31,4 @@ sil_register_sources(
   SILValue.cpp
   SILWitnessTable.cpp
   TypeLowering.cpp
-  ValueOwnership.cpp
-)
+  ValueOwnership.cpp)

--- a/lib/SIL/Parser/CMakeLists.txt
+++ b/lib/SIL/Parser/CMakeLists.txt
@@ -1,4 +1,2 @@
-sil_register_sources(
-  ParseSIL.cpp
-)
-
+target_sources(swiftSIL PRIVATE
+  ParseSIL.cpp)

--- a/lib/SIL/SIL.cpp
+++ b/lib/SIL/SIL.cpp
@@ -1,0 +1,15 @@
+//===--- SIL.cpp ---------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// DO NOT MODIFY THIS FILE!
+// The SIL library is split into sub-components, modify the respective
+// sub-component.

--- a/lib/SIL/Utils/CMakeLists.txt
+++ b/lib/SIL/Utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-sil_register_sources(
+target_sources(swiftSIL PRIVATE
   BasicBlockUtils.cpp
   DebugUtils.cpp
   Dominance.cpp
@@ -13,5 +13,4 @@ sil_register_sources(
   SILInstructionWorklist.cpp
   SILOpenedArchetypesTracker.cpp
   SILRemarkStreamer.cpp
-  ValueUtils.cpp
-)
+  ValueUtils.cpp)

--- a/lib/SIL/Verifier/CMakeLists.txt
+++ b/lib/SIL/Verifier/CMakeLists.txt
@@ -1,7 +1,6 @@
-sil_register_sources(
+target_sources(swiftSIL PRIVATE
   LoadBorrowInvalidationChecker.cpp
   LinearLifetimeChecker.cpp
   MemoryLifetime.cpp
   SILOwnershipVerifier.cpp
-  SILVerifier.cpp
-)
+  SILVerifier.cpp)

--- a/lib/SILOptimizer/ARC/CMakeLists.txt
+++ b/lib/SILOptimizer/ARC/CMakeLists.txt
@@ -1,4 +1,4 @@
-silopt_register_sources(
+target_sources(swiftSILOptimizer PRIVATE
   ARCBBState.cpp
   ARCLoopOpts.cpp
   ARCMatchingSet.cpp
@@ -8,5 +8,4 @@ silopt_register_sources(
   GlobalLoopARCSequenceDataflow.cpp
   RCStateTransition.cpp
   RCStateTransitionVisitors.cpp
-  RefCountState.cpp
-)
+  RefCountState.cpp)

--- a/lib/SILOptimizer/Analysis/CMakeLists.txt
+++ b/lib/SILOptimizer/Analysis/CMakeLists.txt
@@ -1,4 +1,4 @@
-silopt_register_sources(
+target_sources(swiftSILOptimizer PRIVATE
   ARCAnalysis.cpp
   AccessSummaryAnalysis.cpp
   AccessedStorageAnalysis.cpp
@@ -25,5 +25,4 @@ silopt_register_sources(
   SideEffectAnalysis.cpp
   SimplifyInstruction.cpp
   TypeExpansionAnalysis.cpp
-  ValueTracking.cpp
-)
+  ValueTracking.cpp)

--- a/lib/SILOptimizer/CMakeLists.txt
+++ b/lib/SILOptimizer/CMakeLists.txt
@@ -1,25 +1,7 @@
-
-set(SILOPTIMIZER_SOURCES)
-
-function(_list_transform newvar)
-  set(sources ${ARGN})
-  set(dir ${CMAKE_CURRENT_SOURCE_DIR})
-  set(tmp)
-  foreach (s ${sources})
-    list(APPEND tmp "${dir}/${s}")
-  endforeach()
-  set(${newvar} "${tmp}" PARENT_SCOPE)
-endfunction()
-
-macro(silopt_register_sources)
-  precondition(new_transformed_sources
-    NEGATE
-    MESSAGE "Expected this to be empty since we clear after each run")
-  _list_transform(new_transformed_sources ${ARGN})
-  list_union("${SILOPTIMIZER_SOURCES}" "${new_transformed_sources}" out)
-  set(SILOPTIMIZER_SOURCES "${out}" PARENT_SCOPE)
-  set(new_transformed_sources)
-endmacro()
+add_swift_host_library(swiftSILOptimizer STATIC
+  SILOptimizer.cpp)
+target_link_libraries(swiftSILOptimizer PRIVATE
+  swiftSIL)
 
 add_subdirectory(ARC)
 add_subdirectory(Analysis)
@@ -33,8 +15,3 @@ add_subdirectory(SILCombiner)
 add_subdirectory(Transforms)
 add_subdirectory(UtilityPasses)
 add_subdirectory(Utils)
-
-add_swift_host_library(swiftSILOptimizer STATIC
-  ${SILOPTIMIZER_SOURCES})
-target_link_libraries(swiftSILOptimizer PRIVATE
-  swiftSIL)

--- a/lib/SILOptimizer/Differentiation/CMakeLists.txt
+++ b/lib/SILOptimizer/Differentiation/CMakeLists.txt
@@ -1,4 +1,4 @@
-silopt_register_sources(
+target_sources(swiftSILOptimizer PRIVATE
   ADContext.cpp
   Common.cpp
   DifferentiationInvoker.cpp
@@ -6,5 +6,4 @@ silopt_register_sources(
   LinearMapInfo.cpp
   PullbackEmitter.cpp
   Thunk.cpp
-  VJPEmitter.cpp
-)
+  VJPEmitter.cpp)

--- a/lib/SILOptimizer/FunctionSignatureTransforms/CMakeLists.txt
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/CMakeLists.txt
@@ -1,8 +1,7 @@
-silopt_register_sources(
+target_sources(swiftSILOptimizer PRIVATE
   FunctionSignatureOpts.cpp
   DeadArgumentTransform.cpp
   ArgumentExplosionTransform.cpp
   OwnedToGuaranteedTransform.cpp
   ExistentialSpecializer.cpp
-  ExistentialTransform.cpp
-)
+  ExistentialTransform.cpp)

--- a/lib/SILOptimizer/IPO/CMakeLists.txt
+++ b/lib/SILOptimizer/IPO/CMakeLists.txt
@@ -1,4 +1,4 @@
-silopt_register_sources(
+target_sources(swiftSILOptimizer PRIVATE
   CapturePromotion.cpp
   CapturePropagation.cpp
   ClosureSpecializer.cpp

--- a/lib/SILOptimizer/LoopTransforms/CMakeLists.txt
+++ b/lib/SILOptimizer/LoopTransforms/CMakeLists.txt
@@ -1,9 +1,8 @@
-silopt_register_sources(
+target_sources(swiftSILOptimizer PRIVATE
   ArrayBoundsCheckOpts.cpp
   ArrayPropertyOpt.cpp
   COWArrayOpt.cpp
   LoopRotate.cpp
   LoopUnroll.cpp
   LICM.cpp
-  ForEachLoopUnroll.cpp
-)
+  ForEachLoopUnroll.cpp)

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -1,4 +1,4 @@
-silopt_register_sources(
+target_sources(swiftSILOptimizer PRIVATE
   AccessEnforcementSelection.cpp
   AccessMarkerElimination.cpp
   AddressLowering.cpp
@@ -22,5 +22,4 @@ silopt_register_sources(
   YieldOnceCheck.cpp
   MandatoryCombine.cpp
   OSLogOptimization.cpp
-  OwnershipModelEliminator.cpp
-)
+  OwnershipModelEliminator.cpp)

--- a/lib/SILOptimizer/PassManager/CMakeLists.txt
+++ b/lib/SILOptimizer/PassManager/CMakeLists.txt
@@ -1,7 +1,6 @@
-silopt_register_sources(
+target_sources(swiftSILOptimizer PRIVATE
   PassManager.cpp
   Passes.cpp
   PassPipeline.cpp
   PrettyStackTrace.cpp
-  SILOptimizerRequests.cpp
-)
+  SILOptimizerRequests.cpp)

--- a/lib/SILOptimizer/SILCombiner/CMakeLists.txt
+++ b/lib/SILOptimizer/SILCombiner/CMakeLists.txt
@@ -1,7 +1,6 @@
-silopt_register_sources(
+target_sources(swiftSILOptimizer PRIVATE
   SILCombine.cpp
   SILCombinerApplyVisitors.cpp
   SILCombinerBuiltinVisitors.cpp
   SILCombinerCastVisitors.cpp
-  SILCombinerMiscVisitors.cpp
-)
+  SILCombinerMiscVisitors.cpp)

--- a/lib/SILOptimizer/SILOptimizer.cpp
+++ b/lib/SILOptimizer/SILOptimizer.cpp
@@ -1,0 +1,15 @@
+//===--- SILOptimizer.cpp -------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// DO NOT MODIFY THIS FILE!
+// The SILOptimizer library is split into sub-components, modify the respective
+// sub-component.

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -1,4 +1,4 @@
-silopt_register_sources(
+target_sources(swiftSILOptimizer PRIVATE
   ARCCodeMotion.cpp
   AccessEnforcementDom.cpp
   AccessEnforcementOpts.cpp
@@ -37,5 +37,4 @@ silopt_register_sources(
   SpeculativeDevirtualizer.cpp
   StackPromotion.cpp
   TempRValueElimination.cpp
-  UnsafeGuaranteedPeephole.cpp
-)
+  UnsafeGuaranteedPeephole.cpp)

--- a/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
+++ b/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
@@ -1,4 +1,4 @@
-silopt_register_sources(
+target_sources(swiftSILOptimizer PRIVATE
   AADumper.cpp
   AccessSummaryDumper.cpp
   AccessedStorageDumper.cpp
@@ -31,5 +31,4 @@ silopt_register_sources(
   SimplifyUnreachableContainingBlocks.cpp
   StripDebugInfo.cpp
   OwnershipDumper.cpp
-  OwnershipVerifierTextualErrorDumper.cpp
-)
+  OwnershipVerifierTextualErrorDumper.cpp)

--- a/lib/SILOptimizer/Utils/CMakeLists.txt
+++ b/lib/SILOptimizer/Utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-silopt_register_sources(
+target_sources(swiftSILOptimizer PRIVATE
   BasicBlockOptUtils.cpp
   CFGOptUtils.cpp
   CanonicalizeInstruction.cpp
@@ -21,5 +21,4 @@ silopt_register_sources(
   SILSSAUpdater.cpp
   SpecializationMangler.cpp
   StackNesting.cpp
-  ValueLifetime.cpp
-)
+  ValueLifetime.cpp)


### PR DESCRIPTION
This simplifies the handling of the subdirectories in the SIL and
SILOptimizer paths.  Create individual libraries as object libraries
which allows the analysis of the source changes to be limited in scope.
Because these are object libraries, this has 0 overhead compared to the
previous implementation.  However, string operations over the filenames
are avoided.  The cost for this is that any new sub-library needs to be
added into the list rather than added with the special local function.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
