### PR TITLE
[5.3][ConstraintSystem] Properly diagnose operator reference ambiguities

### DIFF
--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -279,3 +279,14 @@ func sr12438(_ e: Error) {
   func foo<T>(_ a: T, _ op: ((T, T) -> Bool)) {}
   foo(e, ==) // expected-error {{type of expression is ambiguous without more context}}
 }
+
+// rdar://problem/62054241 - Swift compiler crashes when passing < as the sort function in sorted(by:) and the type of the array is not comparable
+func rdar_62054241() {
+  struct Foo {
+    let a: Int
+  }
+
+  func test(_ arr: [Foo]) -> [Foo] {
+    return arr.sorted(by: <) // expected-error {{no exact matches in reference to operator function '<'}}
+  }
+}


### PR DESCRIPTION
If operator is referenced instead of applied e.g. `arr.sort(by: <)`
ambiguities should be diagnosed as `no exact matches` with attached
notes describing a failure associated with each potential candidate.

Resolves: rdar://problem/62054241
(cherry picked from commit bb414927a0b4d75d2a66ae38ad468f62868a10cf)

Reviewed by: @hborla 
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
