### PR TITLE
Fix analysis invalidation in ClosureLifetimeFixup

### DIFF
--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -1003,7 +1003,7 @@ class ClosureLifetimeFixup : public SILFunctionTransform {
     if (fixupClosureLifetimes(*getFunction(), checkStackNesting, modifiedCFG)) {
       if (checkStackNesting){
         StackNesting sn;
-        modifiedCFG =
+        modifiedCFG |=
             sn.correctStackNesting(getFunction()) == StackNesting::Changes::CFG;
       }
       if (modifiedCFG)

--- a/test/Interpreter/objc_throw_in_noescape_block.swift
+++ b/test/Interpreter/objc_throw_in_noescape_block.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 //
 // RUN: %target-clang -fobjc-arc %S/Inputs/ObjCException.m -c -o %t/ObjCException.o
-// RUN: %target-build-swift -import-objc-header %S/Inputs/ObjCException.h -Xlinker %t/ObjCException.o %s -o %t/a.out
+// RUN: %target-build-swift -Xllvm -sil-verify-force-analysis=true -import-objc-header %S/Inputs/ObjCException.h -Xlinker %t/ObjCException.o %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 


### PR DESCRIPTION
Accumulate modifiedCFG when calling `correctStackNesting`.
Found this bug with `-sil-verify-force-analysis=true` flag
