### PR TITLE
[docs] Note that adding associatedtypes with defaults is allowed in library evolution

### DIFF
--- a/docs/LibraryEvolution.rst
+++ b/docs/LibraryEvolution.rst
@@ -577,6 +577,8 @@ There are very few safe changes to make to protocols and their members:
   themselves).
 - The ``@discardableResult`` and ``@warn_unqualified_access`` attributes may
   be added to or removed from a function requirement.
+- A new `associatedtype` requirement may be added (with the appropriate
+  availability), as long as it has a default implementation.
 - A new non-type requirement may be added (with the appropriate availability),
   as long as it has an unconstrained default implementation. If the requirement
   uses ``Self`` and the protocol has no other requirements using ``Self`` and


### PR DESCRIPTION
It is actually valid to add an `associatedtype` requirement, even one
with constraints, to an existing protocol, provided it has availability
and a default value.