### PR TITLE
[NFC] [arm64e] Mark arm64e fallback test unsupported for Catalyst.

### DIFF
--- a/test/ModuleInterface/arm64e-fallback.swift
+++ b/test/ModuleInterface/arm64e-fallback.swift
@@ -1,6 +1,7 @@
 // RUN: not %target-typecheck-verify-swift -target arm64e-apple-ios13.0 -F %S/Inputs 2>&1 | %FileCheck %s
 
 // REQUIRES: OS=ios
+// UNSUPPORTED: OS=maccatalyst
 
 import DummyFramework
 // CHECK: could not find module 'DummyFramework' for target 'arm64e-apple-ios'; found: arm64-apple-ios, arm64


### PR DESCRIPTION
Fixes rdar://problem/62337141.