### PR TITLE
[TF] Use `@rpath` as install_name directory for standard library dylibs.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1696,7 +1696,16 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DLIBDISPATCH_CMAKE_BUILD_TYPE:STRING="${LIBDISPATCH_BUILD_TYPE}"
 
                     # SWIFT_ENABLE_TENSORFLOW
+                    # CMake options specific to `tensorflow` branch here.
+
+                    # Propagate "SWIFT_ENABLE_TENSORFLOW=TRUE" to CMake.
+                    # This affects lit tests, adding "tensorflow" as an available feature.
                     -DSWIFT_ENABLE_TENSORFLOW:BOOL=TRUE
+
+                    # Always use "@rpath" as the directory of the install_name for standard library dylibs.
+                    # The default value is "/usr/lib/swift", which doesn't work for toolchains that provide
+                    # custom standard library modules or that make changes to libswiftCore.dylib.
+                    -DSWIFT_DARWIN_STDLIB_INSTALL_NAME_DIR:STRING="@rpath"
                     # SWIFT_ENABLE_TENSORFLOW END
                     "${swift_cmake_options[@]}"
                 )


### PR DESCRIPTION
This sets `@rpath` as the directory in `LC_DYLIB_ID` for standard library dylibs.
This is important for toolchains that provide custom standard library modules or
that make changes to `libswiftCore.dylib`.

This patch should not be upstreamed to master, where Swift-in-the-OS is king and
it seems intended for Swift system libraries to be used.

---

This patch was designed to fix `TensorFlow` module usages on macOS (TF-1260):

<details>
<p>

```swift
import TensorFlow
print(Tensor(1))
```
```
$ swiftc tf.swift
$ ./tf
dyld: Symbol not found: _$s11AllKeyPathss0B12PathIterablePTl
  Referenced from: /Library/Developer/Toolchains/swift-tensorflow-DEVELOPMENT-2020-04-23-a.xctoolchain/usr/lib/swift/macosx/libswiftTensorFlow.dylib
  Expected in: /usr/lib/swift/libswiftCore.dylib
 in /Library/Developer/Toolchains/swift-tensorflow-DEVELOPMENT-2020-04-23-a.xctoolchain/usr/lib/swift/macosx/libswiftTensorFlow.dylib
[1]    67267 abort      ./tf
```

</p>
</details>

Fix verification is pending.

The `-DSWIFT_DARWIN_STDLIB_INSTALL_NAME_DIR:STRING="@rpath"` configuration comes from [compnerd/swift-build](https://github.com/compnerd/swift-build/blob/f5869a829fe6bd2519235f496f43d4e5b9488095/cmake/caches/swift-stdlib-darwin-x86_64.cmake#L15-L16).