### PR TITLE
[SymbolGraph] [5.3] Pick best synthesized member when possible

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.h
+++ b/lib/SymbolGraphGen/SymbolGraph.h
@@ -75,6 +75,9 @@ struct SymbolGraph {
   /// Get the base print options for declaration fragments.
   PrintOptions getDeclarationFragmentsPrintOptions() const;
 
+  bool synthesizedMemberIsBestCandidate(const ValueDecl *VD,
+                                        const NominalTypeDecl *Owner) const;
+
   // MARK: - Symbols (Nodes)
 
   /**
@@ -197,7 +200,11 @@ struct SymbolGraph {
   /// Returns `true` if the declaration has a name that makes it
   /// implicitly internal/private, such as underscore prefixes,
   /// and checking every named parent context as well.
-  bool isImplicitlyPrivate(const ValueDecl *VD) const;
+  ///
+  /// \param IgnoreContext If `true`, don't consider
+  /// the context of the symbol to determine whether it is implicitly private.
+  bool isImplicitlyPrivate(const ValueDecl *VD,
+                           bool IgnoreContext = false) const;
 
   /// Returns `true` if the declaration should be included as a node
   /// in the graph.

--- a/test/SymbolGraph/Relationships/Synthesized/PickBestCandidate.swift
+++ b/test/SymbolGraph/Relationships/Synthesized/PickBestCandidate.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name PickBestCandidate -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name PickBestCandidate -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/PickBestCandidate.symbols.json
+
+public protocol P {
+  func foo()
+  func bar()
+}
+
+public protocol Q : P {}
+extension Q {
+  public func foo() {}
+  public func bar() {}
+}
+
+public protocol R : Q {}
+extension R {
+  public func foo() {}
+  public func bar() {}
+}
+
+public struct MyStruct: R {
+  public func bar() {}
+}
+
+// MyStruct gets one and only one synthesized `foo`.
+// MyStruct gets no synthesized `bar`, because it has its own implementation.
+// CHECK-COUNT-1: ::SYNTHESIZED::

--- a/tools/driver/swift_symbolgraph_extract_main.cpp
+++ b/tools/driver/swift_symbolgraph_extract_main.cpp
@@ -239,6 +239,9 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args, const char *Argv
     return EXIT_FAILURE;
   }
 
+  const auto &MainFile = M->getMainFile(FileUnitKind::SerializedAST);
+  llvm::errs() << "Emitting symbol graph for module file: " << MainFile.getModuleDefiningPath() << '\n';
+
   return symbolgraphgen::emitSymbolGraphForModule(M,
     Options);
 }


### PR DESCRIPTION
A type can have multiple overloads available from different protocols from
which it inherits. Ask the type checker to pick the best one where possible.

rdar://60193198