### PR TITLE
[SymbolGraph] Add navigator declaration fragments

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -280,6 +280,9 @@ struct PrintOptions {
   /// Whether this print option is for printing .swiftinterface file
   bool IsForSwiftInterface = false;
 
+  /// Whether to print generic requirements in a where clause.
+  bool PrintGenericRequirements = true;
+
   /// How to print opaque return types.
   enum class OpaqueReturnTypePrintingMode {
     /// 'some P1 & P2'.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1457,6 +1457,7 @@ void PrintAST::printSingleDepthOfGenericSignature(
     llvm::function_ref<bool(const Requirement &)> filter) {
   bool printParams = (flags & PrintParams);
   bool printRequirements = (flags & PrintRequirements);
+  printRequirements &= Options.PrintGenericRequirements;
   bool printInherited = (flags & PrintInherited);
   bool swapSelfAndDependentMemberType =
     (flags & SwapSelfAndDependentMemberType);

--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -126,7 +126,7 @@ void Symbol::serializeNames(llvm::json::OStream &OS) const {
     getPathComponents(PathComponents);
     
     OS.attribute("title", PathComponents.back());
-    // "navigator": null
+    Graph->serializeNavigatorDeclarationFragments("navigator", *this, OS);
     Graph->serializeSubheadingDeclarationFragments("subHeading", *this, OS);
     // "prose": null
   });

--- a/lib/SymbolGraphGen/SymbolGraph.h
+++ b/lib/SymbolGraphGen/SymbolGraph.h
@@ -75,8 +75,14 @@ struct SymbolGraph {
   /// Get the base print options for declaration fragments.
   PrintOptions getDeclarationFragmentsPrintOptions() const;
 
+
+  /// Returns `true` if `VD` is the best known candidate for an
+  /// overload set in `Owner`.
   bool synthesizedMemberIsBestCandidate(const ValueDecl *VD,
                                         const NominalTypeDecl *Owner) const;
+
+  /// Get the print options for subHeading declaration fragments.
+  PrintOptions getSubHeadingDeclarationFragmentsPrintOptions() const;
 
   // MARK: - Symbols (Nodes)
 
@@ -186,13 +192,20 @@ struct SymbolGraph {
   serializeDeclarationFragments(StringRef Key, const Symbol &S,
                                 llvm::json::OStream &OS);
 
-  /// Get the overall declaration fragments for a `ValueDecl` when it is viewed
+  /// Get the declaration fragments for a symbol when viewed in a navigator
+  /// where there is limited horizontal space.
+  void
+  serializeNavigatorDeclarationFragments(StringRef Key,
+                                         const Symbol &S,
+                                         llvm::json::OStream &OS);
+
+  /// Get the declaration fragments for a symbol when it is viewed
   /// as a subheading and/or part of a larger group of symbol listings.
   void
   serializeSubheadingDeclarationFragments(StringRef Key, const Symbol &S,
                                           llvm::json::OStream &OS);
 
-  /// Get the overall declaration for a type declaration.
+  /// Get the overall declaration for a symbol.
   void
   serializeDeclarationFragments(StringRef Key, Type T,
                                 llvm::json::OStream &OS);

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Navigator.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Navigator.swift
@@ -1,0 +1,88 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name Navigator -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name Navigator -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/Navigator.symbols.json --check-prefix=MYSTRUCT
+// RUN: %FileCheck %s --input-file %t/Navigator.symbols.json --check-prefix=FOO
+// RUN: %FileCheck %s --input-file %t/Navigator.symbols.json --check-prefix=BAR
+public struct MyStruct<S> { public var x: S
+  public init(x: S) {
+    self.x = x
+  }
+  public func foo() where S: Sequence {}
+  public func bar<T>(x: T) where T: Sequence {}
+}
+
+// MYSTRUCT-LABEL: "precise": "s:9Navigator8MyStructV"
+// MYSTRUCT:        names
+// MYSTRUCT-NEXT:      "title": "MyStruct",
+// MYSTRUCT-NEXT:      "navigator": [
+// MYSTRUCT-NEXT:          {
+// MYSTRUCT-NEXT:              "kind": "typeIdentifier"
+// MYSTRUCT-NEXT:              "spelling": "MyStruct"
+// MYSTRUCT-NEXT:              "preciseIdentifier": "s:9Navigator8MyStructV"
+// MYSTRUCT-NEXT:          }
+// MYSTRUCT-NEXT:      ]
+
+// FOO-LABEL: "precise": "s:9Navigator8MyStructV3fooyySTRzlF"
+// FOO:        names
+// FOO-NEXT:      "title": "foo()",
+// FOO-NEXT:      "navigator": [
+// FOO-NEXT:          {
+// FOO-NEXT:              "kind": "keyword"
+// FOO-NEXT:              "spelling": "func"
+// FOO-NEXT:          }
+// FOO-NEXT:          {
+// FOO-NEXT:              "kind": "text"
+// FOO-NEXT:              "spelling": " "
+// FOO-NEXT:          }
+// FOO-NEXT:          {
+// FOO-NEXT:              "kind": "identifier"
+// FOO-NEXT:              "spelling": "foo"
+// FOO-NEXT:          }
+// FOO-NEXT:          {
+// FOO-NEXT:              "kind": "text"
+// FOO-NEXT:              "spelling": "()"
+// FOO-NEXT:          }
+// FOO-NEXT:      ]
+
+// BAR-LABEL: "precise": "s:9Navigator8MyStructV3bar1xyqd___tSTRd__lF"
+// BAR:        names
+// BAR-NEXT:      "title": "bar(x:)",
+// BAR-NEXT:      "navigator": [
+// BAR-NEXT:          {
+// BAR-NEXT:            "kind": "keyword",
+// BAR-NEXT:            "spelling": "func"
+// BAR-NEXT:          }
+// BAR-NEXT:          {
+// BAR-NEXT:            "kind": "text",
+// BAR-NEXT:            "spelling": " "
+// BAR-NEXT:          }
+// BAR-NEXT:          {
+// BAR-NEXT:            "kind": "identifier",
+// BAR-NEXT:            "spelling": "bar"
+// BAR-NEXT:          }
+// BAR-NEXT:          {
+// BAR-NEXT:            "kind": "text",
+// BAR-NEXT:            "spelling": "<"
+// BAR-NEXT:          }
+// BAR-NEXT:          {
+// BAR-NEXT:            "kind": "genericParameter",
+// BAR-NEXT:            "spelling": "T"
+// BAR-NEXT:          }
+// BAR-NEXT:          {
+// BAR-NEXT:            "kind": "text",
+// BAR-NEXT:            "spelling": ">("
+// BAR-NEXT:          }
+// BAR-NEXT:          {
+// BAR-NEXT:            "kind": "externalParam",
+// BAR-NEXT:            "spelling": "x"
+// BAR-NEXT:          }
+// BAR-NEXT:          {
+// BAR-NEXT:            "kind": "text",
+// BAR-NEXT:            "spelling": ": T"
+// BAR-NEXT:          }
+// BAR-NEXT:          {
+// BAR-NEXT:            "kind": "text",
+// BAR-NEXT:            "spelling": ")"
+// BAR-NEXT:          }
+// BAR-NEXT:      ]

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/SubheadingDeclarationFragments.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/SubheadingDeclarationFragments.swift
@@ -3,15 +3,74 @@
 // RUN: %target-swift-symbolgraph-extract -module-name SubheadingDeclarationFragments -I %t -pretty-print -output-dir %t
 // RUN: %FileCheck %s --input-file %t/SubheadingDeclarationFragments.symbols.json
 
-public func foo<S>(f: @escaping () -> (), ext int: Int = 2, s: S) {}
+public func foo<S>(f: @escaping () -> (), ext int: Int = 2, s: S) where S: Sequence {}
 
 // Subheading fragments should not contain internalParam kinds.
 
-// CHECK-LABEL: subHeading
-//              {
-//                "kind": "externalParam",
-// CHECK:         "spelling": "ext"
-// CHECK-NEXT:  }, 
-// CHECK-NEXT:  { 
-// CHECK-NEXT: "kind": "text"
-// CHECK-NEXT: "spelling": ": "
+// CHECK-LABEL: "precise": "s:30SubheadingDeclarationFragments3foo1f3ext1syyyc_SixtSTRzlF"
+// CHECK: names
+// CHECK-NEXT: "title": "foo(f:ext:s:)"
+// CHECK:      "subHeading": [
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "kind": "keyword",
+// CHECK-NEXT:      "spelling": "func"
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "kind": "text",
+// CHECK-NEXT:      "spelling": " "
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "kind": "identifier",
+// CHECK-NEXT:      "spelling": "foo"
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "kind": "text",
+// CHECK-NEXT:      "spelling": "<"
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "kind": "genericParameter",
+// CHECK-NEXT:      "spelling": "S"
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "kind": "text",
+// CHECK-NEXT:      "spelling": ">("
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "kind": "externalParam",
+// CHECK-NEXT:      "spelling": "f"
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "kind": "text",
+// CHECK-NEXT:      "spelling": ": () -> (), "
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "kind": "externalParam",
+// CHECK-NEXT:      "spelling": "ext"
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "kind": "text",
+// CHECK-NEXT:      "spelling": ": "
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "kind": "typeIdentifier",
+// CHECK-NEXT:      "spelling": "Int",
+// CHECK-NEXT:      "preciseIdentifier": "s:Si"
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "kind": "text",
+// CHECK-NEXT:      "spelling": ", "
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "kind": "externalParam",
+// CHECK-NEXT:      "spelling": "s"
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "kind": "text",
+// CHECK-NEXT:      "spelling": ": S"
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "kind": "text",
+// CHECK-NEXT:      "spelling": ")"
+// CHECK-NEXT:    }
+// CHECK-NEXT: ]
+


### PR DESCRIPTION
Only print the type name for a type's navigator fragments.

Don't print where clauses for navigator or subHeading fragments.

rdar://62353465