### PR TITLE
sprinkle some `llvm_unreachable` for MSVC (NFC)

### DIFF
--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -519,6 +519,7 @@ public:
     case FullApplySiteKind::BeginApplyInst:
       return cast<BeginApplyInst>(getInstruction())->getInoutArguments();
     }
+    llvm_unreachable("invalid apply kind");
   }
 
   /// Returns true if \p op is the callee operand of this apply site

--- a/include/swift/SIL/SILDifferentiabilityWitness.h
+++ b/include/swift/SIL/SILDifferentiabilityWitness.h
@@ -113,6 +113,7 @@ public:
     case AutoDiffDerivativeFunctionKind::VJP:
       return VJP;
     }
+    llvm_unreachable("invalid derivative type");
   }
   void setJVP(SILFunction *jvp) { JVP = jvp; }
   void setVJP(SILFunction *vjp) { VJP = vjp; }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8107,6 +8107,7 @@ public:
     case AutoDiffDerivativeFunctionKind::VJP:
       return getVJPFunction();
     }
+    llvm_unreachable("invalid derivative kind");
   }
 };
 

--- a/include/swift/SILOptimizer/Utils/Differentiation/ADContext.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/ADContext.h
@@ -374,6 +374,7 @@ ADContext::emitNondifferentiabilityError(SourceLoc loc,
     return diagnose(loc, diag::autodiff_when_differentiating_function_call);
   }
   }
+  llvm_unreachable("invalid invoker");
 }
 
 } // end namespace autodiff

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1462,6 +1462,7 @@ static bool validateTBDIfNeeded(const CompilerInvocation &Invocation,
     case FrontendOptions::TBDValidationMode::All:
       return true;
     }
+    llvm_unreachable("invalid mode");
   }();
 
   TBDGenOptions Opts = Invocation.getTBDGenOptions();

--- a/lib/IRGen/GenDiffFunc.cpp
+++ b/lib/IRGen/GenDiffFunc.cpp
@@ -65,6 +65,7 @@ public:
     case NormalDifferentiableFunctionTypeComponent::VJP:
       return "vjp";
     }
+    llvm_unreachable("invalid component type");
   }
 
   SILType getType(IRGenModule &IGM, SILType t) const {
@@ -209,6 +210,7 @@ public:
     case LinearDifferentiableFunctionTypeComponent::Transpose:
       return "transpose";
     }
+    llvm_unreachable("invalid component type");
   }
 
   SILType getType(IRGenModule &IGM, SILType t) const {
@@ -223,6 +225,7 @@ public:
           LookUpConformanceInModule(IGM.getSwiftModule()));
       return SILType::getPrimitiveObjectType(transposeTy);
     }
+    llvm_unreachable("invalid component type");
   }
 };
 
@@ -321,6 +324,7 @@ public:
           LookUpConformanceInModule(IGM.getSwiftModule()));
       return SILType::getPrimitiveObjectType(transposeTy);
     }
+    llvm_unreachable("invalid component type");
   }
 
   StructLayout performLayout(ArrayRef<const TypeInfo *> fieldTypes) {

--- a/lib/IRGen/GenPointerAuth.cpp
+++ b/lib/IRGen/GenPointerAuth.cpp
@@ -584,6 +584,7 @@ PointerAuthEntity::getTypeDiscriminator(IRGenModule &IGM) const {
       llvm_unreachable("not type discriminated");
     }
     }
+    llvm_unreachable("invalid representation");
   };
 
   auto getCoroutineYieldTypesDiscriminator = [&](CanSILFunctionType fnType) {

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -738,6 +738,7 @@ bool LinkEntity::isContextDescriptor() const {
   case Kind::DifferentiabilityWitness:
     return false;
   }
+  llvm_unreachable("invalid descriptor");
 }
 
 llvm::Type *LinkEntity::getDefaultDeclarationType(IRGenModule &IGM) const {
@@ -1088,6 +1089,7 @@ DeclContext *LinkEntity::getDeclContextForEmission() const {
   case Kind::DifferentiabilityWitness:
     return nullptr;
   }
+  llvm_unreachable("invalid decl kind");
 }
 
 bool LinkEntity::isAlwaysSharedLinkage() const {

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -927,6 +927,7 @@ const {
       
     return AbstractionPattern(getGenericSignature(), memberTy);
   }
+  llvm_unreachable("invalid abstraction pattern kind");
 }
 
 AbstractionPattern AbstractionPattern::getAutoDiffDerivativeFunctionType(

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -751,6 +751,7 @@ getExtracteeType(
         LookUpConformanceInModule(module.getSwiftModule()));
     return SILType::getPrimitiveObjectType(transposeFnTy);
   }
+  llvm_unreachable("invalid extractee");
 }
 
 LinearFunctionExtractInst::LinearFunctionExtractInst(

--- a/lib/SIL/IR/SILProfiler.cpp
+++ b/lib/SIL/IR/SILProfiler.cpp
@@ -121,6 +121,7 @@ static Stmt *getProfilerStmtForCase(CaseStmt *caseStmt) {
   case CaseParentKind::DoCatch:
     return caseStmt->getBody();
   }
+  llvm_unreachable("invalid parent kind");
 }
 
 /// Check that the input AST has at least been type-checked.

--- a/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
+++ b/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
@@ -165,6 +165,7 @@ public:
 
       return MemBehavior::MayWrite;
     }
+    llvm_unreachable("invalid access kind");
   }
 
   MemBehavior visitEndAccessInst(EndAccessInst *endAccess) {

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1027,6 +1027,7 @@ static SILValue createValueFromAddr(SILValue addr, SILBuilder *builder,
     // Just return anything not null for the dry-run.
     return elems[0];
   }
+  llvm_unreachable("invalid kind");
 }
 
 /// Simplify the following two frontend patterns:

--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -1008,6 +1008,7 @@ IEEESemantics getFPSemantics(BuiltinFloatType *fpType) {
   case BuiltinFloatType::PPC128:
     llvm_unreachable("ppc128 is not supported");
   }
+  llvm_unreachable("invalid floating point kind");
 }
 
 /// This function, given the exponent and significand of a binary fraction

--- a/lib/SILOptimizer/Utils/Differentiation/DifferentiationInvoker.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/DifferentiationInvoker.cpp
@@ -35,6 +35,7 @@ SourceLoc DifferentiationInvoker::getLocation() const {
         ->getLocation()
         .getSourceLoc();
   }
+  llvm_unreachable("invalid differentation invoker kind");
 }
 
 void DifferentiationInvoker::print(llvm::raw_ostream &os) const {

--- a/lib/SILOptimizer/Utils/Differentiation/JVPEmitter.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/JVPEmitter.cpp
@@ -221,6 +221,7 @@ SILValue JVPEmitter::materializeTangentDirect(AdjointValue val,
   case AdjointValueKind::Concrete:
     return val.getConcreteValue();
   }
+  llvm_unreachable("invalid value kind");
 }
 
 SILValue JVPEmitter::materializeTangent(AdjointValue val, SILLocation loc) {

--- a/lib/SILOptimizer/Utils/Differentiation/PullbackEmitter.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/PullbackEmitter.cpp
@@ -1787,6 +1787,7 @@ SILValue PullbackEmitter::materializeAdjointDirect(AdjointValue val,
   case AdjointValueKind::Concrete:
     return val.getConcreteValue();
   }
+  llvm_unreachable("invalid value kind");
 }
 
 SILValue PullbackEmitter::materializeAdjoint(AdjointValue val,
@@ -1958,6 +1959,7 @@ AdjointValue PullbackEmitter::accumulateAdjointsDirect(AdjointValue lhs,
     }
     }
   }
+  llvm_unreachable("invalid LHS kind");
 }
 
 SILValue PullbackEmitter::accumulateDirect(SILValue lhs, SILValue rhs,
@@ -2007,6 +2009,7 @@ SILValue PullbackEmitter::accumulateDirect(SILValue lhs, SILValue rhs,
     return builder.createTuple(loc, adjointTy, adjElements);
   }
   }
+  llvm_unreachable("invalid tangent space");
 }
 
 void PullbackEmitter::accumulateIndirect(SILValue resultBufAccess,

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -259,6 +259,7 @@ getLinkerPlatformId(OriginallyDefinedInAttr::ActiveVersion Ver) {
   case swift::PlatformKind::macCatalystApplicationExtension:
     return LinkerPlatformId::macCatalyst;
   }
+  llvm_unreachable("invalid platform kind");
 }
 
 static StringRef


### PR DESCRIPTION
MSVC does not realize that the switch is exhaustive and requires that
the path is explicitly marked as unreachable.  This silences the C4715
warning ("not all control paths return a value").

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
