### PR TITLE
Fixes example snippets in UnsafePointer.swift

### DIFF
--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -108,8 +108,8 @@
 /// `load(fromByteOffset:as:)` method to read values.
 ///
 ///     let rawPointer = UnsafeRawPointer(uint64Pointer)
-///     fullInteger = rawPointer.load(as: UInt64.self)   // OK
-///     firstByte = rawPointer.load(as: UInt8.self)      // OK
+///     let fullInteger = rawPointer.load(as: UInt64.self)   // OK
+///     let firstByte = rawPointer.load(as: UInt8.self)      // OK
 ///
 /// Performing Typed Pointer Arithmetic
 /// ===================================
@@ -260,7 +260,7 @@ public struct UnsafePointer<Pointee>: _Pointer {
   /// pointer to `Int64`, then accesses a property on the signed integer.
   ///
   ///     let uint64Pointer: UnsafePointer<UInt64> = fetchValue()
-  ///     let isNegative = uint64Pointer.withMemoryRebound(to: Int64.self) { ptr in
+  ///     let isNegative = uint64Pointer.withMemoryRebound(to: Int64.self, capacity: 1) { ptr in
   ///         return ptr.pointee < 0
   ///     }
   ///
@@ -430,8 +430,8 @@ public struct UnsafePointer<Pointee>: _Pointer {
 /// to read and write values.
 ///
 ///     let rawPointer = UnsafeMutableRawPointer(uint64Pointer)
-///     fullInteger = rawPointer.load(as: UInt64.self)   // OK
-///     firstByte = rawPointer.load(as: UInt8.self)      // OK
+///     let fullInteger = rawPointer.load(as: UInt64.self)   // OK
+///     let firstByte = rawPointer.load(as: UInt8.self)      // OK
 ///
 /// Performing Typed Pointer Arithmetic
 /// ===================================
@@ -911,7 +911,7 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
   /// pointer to `Int64`, then accesses a property on the signed integer.
   ///
   ///     let uint64Pointer: UnsafeMutablePointer<UInt64> = fetchValue()
-  ///     let isNegative = uint64Pointer.withMemoryRebound(to: Int64.self) { ptr in
+  ///     let isNegative = uint64Pointer.withMemoryRebound(to: Int64.self, capacity: 1) { ptr in
   ///         return ptr.pointee < 0
   ///     }
   ///


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixes example snippets in UnsafePointer.swift

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
