### PR TITLE
[NFC] Get rid of -Wrange-loop-analysis warnings.

### DIFF
--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -712,7 +712,7 @@ public:
         }
       }
     }
-    for (const auto dcAndScope : bogusDCs) {
+    for (const auto &dcAndScope : bogusDCs) {
       llvm::errs() << "ASTScope tree confabulated: " << dcAndScope.getFirst()
                    << ":\n";
       dcAndScope.getFirst()->printContext(llvm::errs());

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -817,7 +817,7 @@ bool isLocWithinAnInactiveClause(const SourceLoc loc, SourceFile *SF) {
         for (const auto &clause : ifc->getClauses()) {
           if (clause.isActive)
             continue;
-          for (const auto n : clause.Elements) {
+          for (const auto &n : clause.Elements) {
             SourceRange sr = n.getSourceRange();
             if (sr.isValid() && SM.rangeContainsTokenLoc(sr, loc)) {
               wasFoundWithinInactiveClause = true;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1828,7 +1828,7 @@ static bool isDefaultInitializable(const TypeRepr *typeRepr, ASTContext &ctx) {
     if (tuple->hasEllipsis())
       return false;
 
-    for (const auto elt : tuple->getElements()) {
+    for (const auto &elt : tuple->getElements()) {
       if (!isDefaultInitializable(elt.Type, ctx))
         return false;
     }

--- a/lib/AST/FrontendSourceFileDepGraphFactory.cpp
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.cpp
@@ -539,7 +539,7 @@ void FrontendSourceFileDepGraphFactory::addAllDefinedDecls() {
 template <NodeKind kind, typename ContentsT>
 void FrontendSourceFileDepGraphFactory::addAllDefinedDeclsOfAGivenType(
     std::vector<ContentsT> &contentsVec) {
-  for (const auto declOrPair : contentsVec) {
+  for (const auto &declOrPair : contentsVec) {
     Optional<std::string> fp = getFingerprintIfAny(declOrPair);
     addADefinedDecl(
         DependencyKey::createForProvidedEntityInterface<kind>(declOrPair),

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -5508,7 +5508,7 @@ GenericSignatureBuilder::finalize(SourceLoc loc,
     for (const auto gp : getGenericParams())
       depth = std::max(depth, gp->getDepth());
 
-    for (const auto pa : Impl->PotentialArchetypes) {
+    for (const auto &pa : Impl->PotentialArchetypes) {
       auto rep = pa->getRepresentative();
 
       if (pa->getRootGenericParamKey().Depth < depth)

--- a/lib/AST/IncrementalRanges.cpp
+++ b/lib/AST/IncrementalRanges.cpp
@@ -261,7 +261,7 @@ std::vector<CharSourceRange> SwiftRangesEmitter::coalesceSortedRanges(
 std::vector<SerializableSourceRange>
 SwiftRangesEmitter::serializeRanges(std::vector<CharSourceRange> ranges) const {
   std::vector<SerializableSourceRange> result;
-  for (const auto r : ranges)
+  for (const auto &r : ranges)
     result.push_back(SerializableSourceRange(r, sourceMgr));
   return result;
 }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2160,7 +2160,7 @@ InheritedProtocolsRequest::evaluate(Evaluator &evaluator,
   SmallPtrSet<const ProtocolDecl *, 2> known;
   known.insert(PD);
   bool anyObject = false;
-  for (const auto found : getDirectlyInheritedNominalTypeDecls(PD, anyObject)) {
+  for (const auto &found : getDirectlyInheritedNominalTypeDecls(PD, anyObject)) {
     if (auto proto = dyn_cast<ProtocolDecl>(found.Item)) {
       if (known.insert(proto).second)
         result.push_back(proto);

--- a/lib/Basic/OutputFileMap.cpp
+++ b/lib/Basic/OutputFileMap.cpp
@@ -116,7 +116,7 @@ static void writeQuotedEscaped(llvm::raw_ostream &os,
 
 void OutputFileMap::write(llvm::raw_ostream &os,
                           ArrayRef<StringRef> inputs) const {
-  for (const auto input : inputs) {
+  for (const auto &input : inputs) {
     writeQuotedEscaped(os, input);
     os << ":";
 

--- a/lib/Driver/Job.cpp
+++ b/lib/Driver/Job.cpp
@@ -327,7 +327,7 @@ CommandOutput::dump() const {
 
 void CommandOutput::writeOutputFileMap(llvm::raw_ostream &out) const {
   SmallVector<StringRef, 4> inputs;
-  for (const CommandInputPair IP : Inputs) {
+  for (const CommandInputPair &IP : Inputs) {
     assert(IP.Base == IP.Primary && !IP.Base.empty() &&
            "output file maps won't work if these differ");
     inputs.push_back(IP.Primary);

--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -247,7 +247,7 @@ struct CommentToXMLConverter {
 
   void printTagFields(ArrayRef<StringRef> Tags) {
     OS << "<Tags>";
-    for (const auto Tag : Tags) {
+    for (const auto &Tag : Tags) {
       if (Tag.empty()) {
         continue;
       }
@@ -821,7 +821,7 @@ void ide::getDocumentationCommentAsDoxygen(const DocComment *DC,
     Converter.visit(N);
   }
 
-  for (const auto PF : DC->getParamFields()) {
+  for (const auto &PF : DC->getParamFields()) {
     Converter.visit(PF);
   }
 

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -596,7 +596,7 @@ getCalleeFunction(SILFunction *F, FullApplySite AI, bool &IsThick,
   FullArgs.clear();
 
   // First grab our basic arguments from our apply.
-  for (const auto Arg : AI.getArguments())
+  for (const auto &Arg : AI.getArguments())
     FullArgs.push_back(Arg);
 
   // Then grab a first approximation of our apply by stripping off all copy

--- a/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
@@ -131,7 +131,7 @@ static bool hasOpaqueArchetypeOperand(TypeExpansionContext context,
 static bool hasOpaqueArchetypeResult(TypeExpansionContext context,
                                      SILInstruction &inst) {
   // Check the results for opaque types.
-  for (const auto res : inst.getResults())
+  for (const auto &res : inst.getResults())
     if (opaqueArchetypeWouldChange(context, res->getType().getASTType()))
       return true;
   return false;

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -134,7 +134,7 @@ struct UnboundImport {
   NullablePtr<ModuleDecl> getTopLevelModule(ModuleDecl *M, SourceFile &SF);
 
   /// Diagnose any errors concerning the \c @_exported, \c @_implementationOnly,
-  /// \c @testable, or \c @_private attributes, including a
+  /// \c \@testable, or \c @_private attributes, including a 
   /// non-implementation-only import of a fragile library from a resilient one.
   void validateOptions(NullablePtr<ModuleDecl> topLevelModule, SourceFile &SF);
 

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -833,7 +833,7 @@ public:
     removeShadowedDecls(Decls, DC);
 
     size_t index = 0;
-    for (const auto DeclAndReason : Results) {
+    for (const auto &DeclAndReason : Results) {
       if (index >= Decls.size())
         break;
       if (DeclAndReason.D != Decls[index])

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -488,7 +488,7 @@ ProtocolRequiresClassRequest::evaluate(Evaluator &evaluator,
 
   // Look through all of the inherited nominals for a superclass or a
   // class-bound protocol.
-  for (const auto found : allInheritedNominals) {
+  for (const auto &found : allInheritedNominals) {
     // Superclass bound.
     if (isa<ClassDecl>(found.Item))
       return true;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1318,7 +1318,7 @@ resolveTopLevelIdentTypeComponent(TypeResolution resolution,
   TypeDecl *currentDecl = nullptr;
   DeclContext *currentDC = nullptr;
   bool isAmbiguous = false;
-  for (const auto entry : globals) {
+  for (const auto &entry : globals) {
     auto *foundDC = entry.getDeclContext();
     auto *typeDecl = cast<TypeDecl>(entry.getValueDecl());
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2145,7 +2145,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
          S.addTypeRef(KPI->getType().getASTType()),
          (unsigned)KPI->getType().getCategory(),
          ListOfValues);
-    for (const auto conf : serializeAfter) {
+    for (const auto &conf : serializeAfter) {
       S.writeConformance(conf, SILAbbrCodes);
     }
     S.writeGenericRequirements(reqts, SILAbbrCodes);
@@ -2400,7 +2400,7 @@ void SILSerializer::writeSILProperty(const SILProperty &prop) {
     prop.isSerialized(),
     componentValues);
   
-  for (const auto conf : serializeAfter) {
+  for (const auto &conf : serializeAfter) {
     S.writeConformance(conf, SILAbbrCodes);
   }
 }

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -446,13 +446,13 @@ void SymbolGraph::serialize(llvm::json::OStream &OS) {
     }
 
     OS.attributeArray("symbols", [&](){
-      for (const auto S: Nodes) {
+      for (const auto &S: Nodes) {
         S.serialize(OS);
       }
     });
 
     OS.attributeArray("relationships", [&](){
-      for (const auto Relationship : Edges) {
+      for (const auto &Relationship : Edges) {
         Relationship.serialize(OS);
       }
     });

--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
@@ -136,7 +136,7 @@ bool SymbolGraphASTWalker::walkToDeclPre(Decl *D, CharSourceRange Range) {
         }
       };
 
-      for (const auto InheritedLoc : Extension->getInherited()) {
+      for (const auto &InheritedLoc : Extension->getInherited()) {
         auto InheritedTy = InheritedLoc.getType();
         if (!InheritedTy) {
           continue;
@@ -146,7 +146,7 @@ bool SymbolGraphASTWalker::walkToDeclPre(Decl *D, CharSourceRange Range) {
 
       while (!UnexpandedCompositions.empty()) {
         const auto *Comp = UnexpandedCompositions.pop_back_val();
-        for (const auto Member : Comp->getMembers()) {
+        for (const auto &Member : Comp->getMembers()) {
           HandleProtocolOrComposition(Member);
         }
       }


### PR DESCRIPTION
Keep seeing annoying warnings like

```
[979/1334][ 73%][66.143s] Building CXX object lib/AST/CMakeFiles/swiftAST.dir/Decl.cpp.o
/Users/varun/foss-swift/swift/lib/AST/Decl.cpp:1831:21: warning: loop variable 'elt' of type 'const swift::TupleTypeReprElement' creates a copy from type 'const swift::TupleTypeReprElement' [-Wrange-loop-analysis]
    for (const auto elt : tuple->getElements()) {
                    ^
/Users/varun/foss-swift/swift/lib/AST/Decl.cpp:1831:10: note: use reference type 'const swift::TupleTypeReprElement &' to prevent copying
    for (const auto elt : tuple->getElements()) {
         ^~~~~~~~~~~~~~~~
                    &
```

Stop it.