### PR TITLE
Sema: Diagnose invalid default type witnesses eagerly when possible

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3244,6 +3244,15 @@ public:
     TrailingWhere = trailingWhereClause;
   }
 
+  /// Check the given type witness against the requirements of \c this
+  /// associated type relative to the requirement signature of the given
+  /// protocol. If a requirement fails, returns its subject.
+  ///
+  /// \param DC The context in which to check conformances.
+  Type requirementNotSatisfiedByTypeWitness(Type Ty,
+                                            ProtocolDecl *PD,
+                                            DeclContext *DC) const;
+
   /// Retrieve the associated type "anchor", which is the associated type
   /// declaration that will be used to describe this associated type in the
   /// ABI.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2020,9 +2020,13 @@ NOTE(ambiguous_witnesses_wrong_name,none,
      "subscript operators}0 with type %2", (RequirementKind, DeclName, Type))
 NOTE(no_witnesses_type,none,
      "protocol requires nested type %0; do you want to add it?", (Identifier))
-NOTE(default_associated_type_req_fail,none,
-     "default type %0 for associated type %1 (from protocol %2) "
-     "does not %select{inherit from|conform to}4 %3",
+ERROR(default_associated_type_req_fail,none,
+      "default type %0 for associated type %1 is required to "
+      "%select{inherit from|conform to}3 %2",
+      (Type, DeclName, Type, bool))
+NOTE(default_associated_type_req_fail_note,none,
+     "default type %0 for associated type %1 (from protocol %2) does not"
+     "%select{inherit from|conform to}4 %3",
      (Type, DeclName, Type, Type, bool))
 ERROR(associated_type_access,none,
       "associated type in "

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2401,6 +2401,26 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Returns the subject of a requirement that is not satisfied by the given
+/// type witness.
+class RequirementNotSatisfiedByTypeWitness
+    : public SimpleRequest<RequirementNotSatisfiedByTypeWitness,
+                           Type(AssociatedTypeDecl *, CanType,
+                                const ProtocolDecl *,
+                                DeclContext *),
+                           RequestFlags::Uncached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  Type evaluate(Evaluator &evaluator, AssociatedTypeDecl *ATD,
+                CanType Witness,
+                const ProtocolDecl *Proto,
+                DeclContext *DC) const;
+};
+
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.
 template<>

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -29,6 +29,10 @@ SWIFT_REQUEST(TypeChecker, AttachedPropertyWrappersRequest,
               NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, CallerSideDefaultArgExprRequest,
               Expr *(DefaultArgumentExpr *), SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, RequirementNotSatisfiedByTypeWitness,
+              Type(AssociatedTypeDecl *, CanType, const ProtocolDecl *,
+                   DeclContext *),
+              Uncached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, CheckRedeclarationRequest,
               evaluator::SideEffect(ValueDecl *),
               Uncached, NoLocationInfo)

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3993,6 +3993,15 @@ Type AssociatedTypeDecl::getDefaultDefinitionType() const {
            Type());
 }
 
+Type AssociatedTypeDecl::requirementNotSatisfiedByTypeWitness(Type Ty,
+                                                              ProtocolDecl *PD,
+                                                              DeclContext *DC) const {
+  return evaluateOrDefault(getASTContext().evaluator,
+    RequirementNotSatisfiedByTypeWitness{const_cast<AssociatedTypeDecl *>(this),
+                                         Ty->getCanonicalType(), PD, DC},
+    Type());
+}
+
 SourceRange AssociatedTypeDecl::getSourceRange() const {
   SourceLoc endLoc;
   if (auto TWC = getTrailingWhereClause()) {

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -90,14 +90,6 @@ public:
   explicit operator bool() const { return !Requirement.isNull(); }
 };
 
-/// Check whether the given type witness can be used for the given
-/// associated type.
-///
-/// \returns an empty result on success, or a description of the error.
-CheckTypeWitnessResult checkTypeWitness(DeclContext *dc, ProtocolDecl *proto,
-                                        AssociatedTypeDecl *assocType,
-                                        Type type);
-
 /// The set of associated types that have been inferred by matching
 /// the given value witness to its corresponding requirement.
 struct InferredAssociatedTypesByWitness {


### PR DESCRIPTION
TL;DR: Basically diagnoses stuff like `associatedtype X: Sequence = Int` the moment we realize the default definition type, which appears to be a bad idea. 

I only realized doing this is source-breaking once I was almost done wrapping up the commit, and the chances are this change is useless as a whole, but I am still curious about the history of the underlying semantic detail. Was it a deliberate, directional effort?:

The status quo is that default type witnesses are only checked against the protocol requirement signature once they are considered as candidates while checking a relevant conformance. This brings a lot of flexibility — declaring something like `associatedtype X: Sequence = Int` is legal even if it makes no sense in the parent module `M`, because someone could import `M` into a module where `Int` *does* retroactively conform to `Sequence`, thus "enabling" the default type witness.

cc @slavapestov

P.S. Please don't trigger CI; I haven't touched the tests.