### PR TITLE
[benchmark] Revert removal of InsertCharacter & IntegerParsing

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -97,6 +97,8 @@ set(SWIFT_BENCH_MODULES
     single-source/Hash
     single-source/Histogram
     single-source/HTTP2StateMachine
+    single-source/InsertCharacter
+    single-source/IntegerParsing
     single-source/Integrate
     single-source/IterateData
     single-source/Join

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -85,6 +85,8 @@ import Hanoi
 import Hash
 import Histogram
 import HTTP2StateMachine
+import InsertCharacter
+import IntegerParsing
 import Integrate
 import IterateData
 import Join
@@ -268,6 +270,8 @@ registerBenchmark(Hanoi)
 registerBenchmark(HashTest)
 registerBenchmark(Histogram)
 registerBenchmark(HTTP2StateMachine)
+registerBenchmark(InsertCharacter)
+registerBenchmark(IntegerParsing)
 registerBenchmark(IntegrateTest)
 registerBenchmark(IterateData)
 registerBenchmark(Join)


### PR DESCRIPTION
<!-- What's in this pull request? -->
Re-add two benchmark files, `InsertCharacter` & `IntegerParsing`, that seem to have gotten accidentally removed in #19954.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
