### PR TITLE
test: repair the `cross_module_derivative_attr` test

### DIFF
--- a/test/AutoDiff/validation-test/cross_module_derivative_attr.swift
+++ b/test/AutoDiff/validation-test/cross_module_derivative_attr.swift
@@ -1,5 +1,9 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -working-directory %t -I%t -parse-as-library -emit-module -module-name module1 -emit-module-path %t/module1.swiftmodule -emit-library -static %S/Inputs/cross_module_derivative_attr/module1/module1.swift %S/Inputs/cross_module_derivative_attr/module1/module1_other_file.swift -Xfrontend -validate-tbd-against-ir=none
-// RUN: %target-build-swift -I%t -L%t %S/Inputs/cross_module_derivative_attr/main/main.swift -o %t/a.out -lm -lmodule1 -Xfrontend -validate-tbd-against-ir=none
-// RUN: %target-run %t/a.out
+// RUN: %target-build-swift-dylib(%t/%target-library-name(module1)) %S/Inputs/cross_module_derivative_attr/module1/module1.swift %S/Inputs/cross_module_derivative_attr/module1/module1_other_file.swift -emit-module -emit-module-path %t/module1.swiftmodule -module-name module1
+// -Xfrontend -validate-tbd-against-ir=none
+// RUN: %target-build-swift -I%t -L%t %S/Inputs/cross_module_derivative_attr/main/main.swift -o %t/a.out -lmodule1 %target-rpath(%t)
+// -Xfrontend -validate-tbd-against-ir=none
+// RUN: %target-codesign %t/a.out
+// RUN: %target-codesign %t/%target-library-name(module1)
+// RUN: %target-run %t/a.out %t/%target-library-name(module1)
 // REQUIRES: executable_test


### PR DESCRIPTION
Convert to dynamic libraries, fix the run lines, remove the workaround
for the TBD validation.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
