### PR TITLE
test: repair the `custom_derivative` test

### DIFF
--- a/test/AutoDiff/validation-test/custom_derivatives.swift
+++ b/test/AutoDiff/validation-test/custom_derivatives.swift
@@ -4,6 +4,8 @@
 import StdlibUnittest
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin.C
+#elseif os(Windows)
+import ucrt
 #else
 import Glibc
 #endif


### PR DESCRIPTION
The test imports the C library for the math library.  Add a case for
Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
