### PR TITLE
Enhance Scudo test to tolerate GWP-Asan.

### DIFF
--- a/test/Sanitizers/scudo.swift
+++ b/test/Sanitizers/scudo.swift
@@ -8,4 +8,4 @@ let allocated = UnsafeMutableRawPointer.allocate(byteCount: 128, alignment: 1)
 allocated.deallocate()
 allocated.deallocate()
 
-// CHECK: ERROR: invalid chunk state
+// CHECK: {{ERROR: invalid chunk state|\*\*\* GWP-ASan detected a memory error \*\*\*}}


### PR DESCRIPTION
When LLVM was updated to a new enough release to have GWP-Asan, we
started getting probabilistic test failures, as the double-free would
sometimes be caught by GWP-Asan (odds are about 1/5000).

We should tolerate either output.

In some sense it's hard to validate that this change actually works, but I feel confident we'll know after a week or so.
