### PR TITLE
Extensible enumerations for non-resilient libraries.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -560,6 +560,10 @@ SIMPLE_DECL_ATTR(noDerivative, NoDerivative,
   ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
   100)
 
+SIMPLE_DECL_ATTR(_open, Open,
+  OnEnum | ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToRemove | APIBreakingToAdd,
+  101)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1474,6 +1474,8 @@ ERROR(indirect_case_in_indirect_enum,none,
       "enum case in 'indirect' enum cannot also be 'indirect'", ())
 WARNING(enum_frozen_nonpublic,none,
         "%0 has no effect on non-public enums", (DeclAttribute))
+WARNING(enum_open_nonpublic,none,
+        "%0 has no effect on non-public enums", (DeclAttribute))
 
 // Variables (var and let).
 ERROR(getset_init,none,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4599,9 +4599,13 @@ bool EnumDecl::hasOnlyCasesWithoutAssociatedValues() const {
 }
 
 bool EnumDecl::isFormallyExhaustive(const DeclContext *useDC) const {
-  // Enums explicitly marked frozen are exhaustive.
-  if (getAttrs().hasAttribute<FrozenAttr>())
+  // Enums explicitly marked frozen are exhaustive. Enums explicitly
+  // marked open are not.
+  if (getAttrs().hasAttribute<FrozenAttr>()) {
     return true;
+  } else if (getAttrs().hasAttribute<OpenAttr>()) {
+    return false;
+  }
 
   // Objective-C enums /not/ marked frozen are /not/ exhaustive.
   // Note: This implicitly holds @objc enums defined in Swift to a higher
@@ -4648,6 +4652,10 @@ bool EnumDecl::isEffectivelyExhaustive(ModuleDecl *M,
   // whether imported or not, to deal with C's loose rules around enums.
   // This covers both frozen and non-frozen @objc enums.
   if (isObjC())
+    return false;
+
+  // Open enums are non-exhaustive.
+  if (getAttrs().hasAttribute<OpenAttr>())
     return false;
 
   // Otherwise, the only non-exhaustive cases are those that don't have a fixed

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -430,6 +430,11 @@ getOrSynthesizeTangentVectorStruct(DerivedConformance &derived, Identifier id) {
   if (nominal->getAttrs().hasAttribute<FrozenAttr>())
     structDecl->getAttrs().add(new (C) FrozenAttr(/*implicit*/ true));
 
+  // If nominal type is `@open`, also mark `TangentVector` struct as
+  // `@open`.
+  if (nominal->getAttrs().hasAttribute<OpenAttr>())
+    structDecl->getAttrs().add(new (C) OpenAttr(/*implicit*/ true));
+
   // If nominal type is `@usableFromInline`, also mark `TangentVector` struct as
   // `@usableFromInline`.
   if (nominal->getAttrs().hasAttribute<UsableFromInlineAttr>())

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -243,6 +243,7 @@ public:
   void visitImplementsAttr(ImplementsAttr *attr);
 
   void visitFrozenAttr(FrozenAttr *attr);
+  void visitOpenAttr(OpenAttr *attr);
 
   void visitCustomAttr(CustomAttr *attr);
   void visitPropertyWrapperAttr(PropertyWrapperAttr *attr);
@@ -2836,6 +2837,19 @@ void AttributeChecker::visitFrozenAttr(FrozenAttr *attr) {
       !VD->getAttrs().hasAttribute<UsableFromInlineAttr>()) {
     diagnoseAndRemoveAttr(attr, diag::frozen_attr_on_internal_type,
                           VD->getFullName(), VD->getFormalAccess());
+  }
+}
+
+void AttributeChecker::visitOpenAttr(OpenAttr *attr) {
+  if (auto *ED = dyn_cast<EnumDecl>(D)) {
+    if (ED->getFormalAccess() < AccessLevel::Public &&
+        !ED->getAttrs().hasAttribute<UsableFromInlineAttr>()) {
+      diagnoseAndRemoveAttr(attr, diag::enum_open_nonpublic, attr);
+      return;
+    }
+  } else {
+    attr->setInvalid();
+    return;
   }
 }
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1478,6 +1478,7 @@ namespace  {
     UNINTERESTING_ATTR(ClangImporterSynthesizedType)
     UNINTERESTING_ATTR(WeakLinked)
     UNINTERESTING_ATTR(Frozen)
+    UNINTERESTING_ATTR(Open)
     UNINTERESTING_ATTR(HasInitialValue)
     UNINTERESTING_ATTR(ImplementationOnly)
     UNINTERESTING_ATTR(Custom)

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -822,7 +822,7 @@ namespace {
 
           if (!E->isFormallyExhaustive(DC)) {
             arr.push_back(Space::forUnknown(/*allowedButNotRequired*/false));
-          } else if (!E->getAttrs().hasAttribute<FrozenAttr>()) {
+          } else if (!E->getAttrs().hasAttribute<FrozenAttr>() || E->getAttrs().hasAttribute<OpenAttr>()) {
             arr.push_back(Space::forUnknown(/*allowedButNotRequired*/true));
           }
 

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -105,6 +105,7 @@ struct MyStruct {}
 // KEYWORD4-NEXT:             Keyword/None:                       frozen[#Enum Attribute#]; name=frozen
 // KEYWORD4-NEXT:             Keyword/None:                       propertyWrapper[#Enum Attribute#]; name=propertyWrapper
 // KEYWORD4-NEXT:             Keyword/None:                       _functionBuilder[#Enum Attribute#]; name=_functionBuilder
+// KEYWORD4-NEXT:             Keyword/None:                       _open[#Enum Attribute#]; name=_open
 // KEYWORD4-NEXT:             End completions
 
 
@@ -248,6 +249,7 @@ struct _S {
 // ON_MEMBER_LAST-DAG: Keyword/None:                       derivative[#Declaration Attribute#]; name=derivative
 // ON_MEMBER_LAST-DAG: Keyword/None:                       transpose[#Declaration Attribute#]; name=transpose
 // ON_MEMBER_LAST-DAG: Keyword/None:                       noDerivative[#Declaration Attribute#]; name=noDerivative
+// ON_MEMBER_LAST-DAG: Keyword/None:                       _open[#Declaration Attribute#]; name=_open
 // ON_MEMBER_LAST-NOT: Keyword
 // ON_MEMBER_LAST: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_MEMBER_LAST-NOT: Decl[PrecedenceGroup]


### PR DESCRIPTION
This is a work-in-progress patch, put up as a motivating part of a Swift forums pitch. It currently has no tests, and has yet to progress through the evolution process. It exists solely as a reference, to allow other developers to play with the functionality.

- - -

Currently there is a feature mismatch between the resilient and
non-resilient dialects of the Swift language. In resilient libraries,
enumerations default to a mode usually called "open" or "extensible". In
this mode, calling code is required to add "@unknown default" clauses
when performing exhaustive switches over enumerations vended by the
library. This allows the library to add clauses to their enumerations
without breaking callers.

For non-resilient libraries, the default enumeration behaviour is to be
"frozen", or non-extensible. In this mode, callers of the library may
assume that no further case will be added to the enumeration without an
appropriate semantic versioning change, and so may exhaustively switch
over the enum without having to handle the possibility of a case they
did not see before.

This establishes two language dialects: one that defaults to frozen, and
one that defaults to extensible. Leaving aside whether this is a
positive state of affairs or not, however, these two dialects are not
equal.

This is because the resilient dialect may opt-in to the behaviour of the
non-resilient one by using the `@frozen` attribute. If a resilient
library applies this attribute to an enumeration they opt into a number
of behaviours, including exposing its size and direct access to the
enum's layout. However, they _also_ transition the exhaustive switching
behaviour: users are no longer required to add `@unknown default` to
their switch statements.

It is not currently possible for the non-resilient dialect to opt into
the extensible behaviour, however. No amount of work for a non-resilient
library can give them the ability to add cases to an enumeration without
incurring a major semantic version bump. There is no `@unfrozen`,
`@wet`, `@moist`, or other attribute that can be applied to an
enumeration to force this behaviour.

This makes the resilient language mode strictly _more_ powerful than the
non-resilient one. It also drastically neuters the power of enumerations
in non-resilient libraries. Common Swift patterns such as using
enumerations for errors, or to provide tagged union arguments to
methods, are not useful to non-resilient Swift libraries unless they are
extremely confident that the enumeration will never change. In essence,
the non-resilient language dialect forces developers to tag all
enumerations as `@frozen`. This is despite the guidance on `@frozen` in
the _resilient_ langauge dialect being to be extremely cautious and
judicious with its application.

To resolve the issue, this patch adds an attribute to enumerations that
allows them to opt-in to the extensible behaviour. This resolves the
feature incompatibility between the two language dialects, and makes it
easier to bring the two dialects together in future.