### PR TITLE
Small fixes to CppInteroperabilityManifesto.md

### DIFF
--- a/docs/CppInteroperabilityManifesto.md
+++ b/docs/CppInteroperabilityManifesto.md
@@ -183,7 +183,7 @@ that pick different sides, forcing the user to choose.
 
 Swift/C++ interoperability builds on top of the Swift/C interoperability, so it
 helps to be familiar with [Swift's strategy for importing C
-modules](HowSwiftImportsCModules.md).
+modules](HowSwiftImportsCAPIs.md).
 
 # Importing C++ APIs into Swift
 
@@ -2406,7 +2406,7 @@ unambiguously to C++.
 // C++ support module in the Swift standard library.
 
 typealias CxxPointer<T> = UnsafeMutablePointer<T>      // T*
-typealias CxxConstPointer<T> = UnsafeMutablePointer<T> // const T*
+typealias CxxConstPointer<T> = UnsafePointer<T>        // const T*
 
 typealias CxxRef<T> = UnsafeMutablePointer<T>          // T&
 typealias CxxConstRef<T> = UnsafePointer<T>            // const T&


### PR DESCRIPTION
*  Fix link to C interop doc
*  Fix the type for `CxxConstPointer<T>` (this should be an `UnsafePointer`, not `UnsafeMutablePointer`, right?)