### PR TITLE
[Windows] Don't prepend lib prefix for static library

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2414,7 +2414,7 @@ static StringRef baseNameForImage(const JobAction *JA, const OutputInfo &OI,
     return llvm::sys::path::stem(BaseInput);
   
   if (isa<StaticLinkJobAction>(JA)) {
-    Buffer = "lib";
+    Buffer = Triple.isOSWindows() ? "" : "lib";
     Buffer.append(BaseName);
     Buffer.append(Triple.isOSWindows() ? ".lib" : ".a");
     return Buffer.str();

--- a/test/Driver/static-archive.swift
+++ b/test/Driver/static-archive.swift
@@ -42,7 +42,7 @@
 // INFERRED_NAME_DARWIN:  -o libARCHIVER.a
 // INFERRED_NAME_LINUX:   libARCHIVER.a
 // INFERRED_NAME_WINDOWS: -lib
-// INFERRED_NAME_WINDOWS: libARCHIVER.lib
+// INFERRED_NAME_WINDOWS: ARCHIVER.lib
 
 // RUN: not %swiftc_driver -driver-print-jobs -module-name ARCHIVER  %s -emit-executable -static 2>&1 | %FileCheck -check-prefix ERROR %s
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Currently swiftc emits static archives with name prefixed with "lib" for Windows target.
But when clang linker received `-lA`, clang doesn't prepend "lib" prefix for actual library filename. https://github.com/llvm/llvm-project/blob/ff5264f0c6f026b25e2d91d0f5d5377a156c1f40/clang/lib/Driver/ToolChains/MSVC.cpp#L474-L481

So this PR removed the "lib" prefix from static archives on Windows.

ref: https://github.com/apple/swift/pull/31146#issuecomment-620028972


<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
