### PR TITLE
[5.3][SourceKit] Fix unreachable hit in DocumentStructureWalker

### DIFF
--- a/test/SourceKit/DocumentStructure/Inputs/main.swift
+++ b/test/SourceKit/DocumentStructure/Inputs/main.swift
@@ -178,3 +178,9 @@ var var_with_didset = 10 {
     var thing: NSObject {get}
 }
 #endif
+
+class A {
+  #if true
+  @IBAction @objc func foo(a: Int) {}
+  #endif
+}

--- a/test/SourceKit/DocumentStructure/structure.swift.empty.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.empty.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 2787,
+  key.length: 2858,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -1687,6 +1687,54 @@
           key.namelength: 5,
           key.bodyoffset: 2773,
           key.bodylength: 3
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.class,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "A",
+      key.offset: 2788,
+      key.length: 69,
+      key.nameoffset: 2794,
+      key.namelength: 1,
+      key.bodyoffset: 2797,
+      key.bodylength: 59,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.accessibility: source.lang.swift.accessibility.internal,
+          key.name: "foo(a:)",
+          key.offset: 2827,
+          key.length: 19,
+          key.selector_name: "fooWithA:",
+          key.nameoffset: 2832,
+          key.namelength: 11,
+          key.bodyoffset: 2845,
+          key.bodylength: 0,
+          key.attributes: [
+            {
+              key.offset: 2821,
+              key.length: 5,
+              key.attribute: source.decl.attribute.objc.name
+            },
+            {
+              key.offset: 2811,
+              key.length: 9,
+              key.attribute: source.decl.attribute.ibaction
+            }
+          ],
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.var.parameter,
+              key.name: "a",
+              key.offset: 2836,
+              key.length: 6,
+              key.typename: "Int",
+              key.nameoffset: 2836,
+              key.namelength: 1
+            }
+          ]
         }
       ]
     }

--- a/test/SourceKit/DocumentStructure/structure.swift.foobar.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.foobar.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 2787,
+  key.length: 2858,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -1687,6 +1687,54 @@
           key.namelength: 5,
           key.bodyoffset: 2773,
           key.bodylength: 3
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.class,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "A",
+      key.offset: 2788,
+      key.length: 69,
+      key.nameoffset: 2794,
+      key.namelength: 1,
+      key.bodyoffset: 2797,
+      key.bodylength: 59,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.accessibility: source.lang.swift.accessibility.internal,
+          key.name: "foo(a:)",
+          key.offset: 2827,
+          key.length: 19,
+          key.selector_name: "fooWithA:",
+          key.nameoffset: 2832,
+          key.namelength: 11,
+          key.bodyoffset: 2845,
+          key.bodylength: 0,
+          key.attributes: [
+            {
+              key.offset: 2821,
+              key.length: 5,
+              key.attribute: source.decl.attribute.objc.name
+            },
+            {
+              key.offset: 2811,
+              key.length: 9,
+              key.attribute: source.decl.attribute.ibaction
+            }
+          ],
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.var.parameter,
+              key.name: "a",
+              key.offset: 2836,
+              key.length: 6,
+              key.typename: "Int",
+              key.nameoffset: 2836,
+              key.namelength: 1
+            }
+          ]
         }
       ]
     }

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 2787,
+  key.length: 2858,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -1687,6 +1687,54 @@
           key.namelength: 5,
           key.bodyoffset: 2773,
           key.bodylength: 3
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.class,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "A",
+      key.offset: 2788,
+      key.length: 69,
+      key.nameoffset: 2794,
+      key.namelength: 1,
+      key.bodyoffset: 2797,
+      key.bodylength: 59,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.accessibility: source.lang.swift.accessibility.internal,
+          key.name: "foo(a:)",
+          key.offset: 2827,
+          key.length: 19,
+          key.selector_name: "fooWithA:",
+          key.nameoffset: 2832,
+          key.namelength: 11,
+          key.bodyoffset: 2845,
+          key.bodylength: 0,
+          key.attributes: [
+            {
+              key.offset: 2821,
+              key.length: 5,
+              key.attribute: source.decl.attribute.objc.name
+            },
+            {
+              key.offset: 2811,
+              key.length: 9,
+              key.attribute: source.decl.attribute.ibaction
+            }
+          ],
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.var.parameter,
+              key.name: "a",
+              key.offset: 2836,
+              key.length: 6,
+              key.typename: "Int",
+              key.nameoffset: 2836,
+              key.namelength: 1
+            }
+          ]
         }
       ]
     }

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1363,8 +1363,10 @@ public:
     // We only vend the selector name for @IBAction and @IBSegueAction methods.
     if (auto FuncD = dyn_cast_or_null<FuncDecl>(D)) {
       if (FuncD->getAttrs().hasAttribute<IBActionAttr>() ||
-          FuncD->getAttrs().hasAttribute<IBSegueActionAttr>())
-        return FuncD->getObjCSelector().getString(Buf);
+          FuncD->getAttrs().hasAttribute<IBSegueActionAttr>()) {
+        return FuncD->getObjCSelector(DeclName(), /*skipIsObjCResolution*/true)
+          .getString(Buf);
+      }
     }
     return StringRef();
   }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/31299 (reviewed by @akyrtzi)

DocumentStructureWalker is calling getObjCSelector which calls isObjc() which eventually triggers name lookup, which is unsupported within ifconfig ranges.

Resolves rdar://problem/61967092
