### PR TITLE
[irgen] For benchmarking purposes, add the ability to force the alignment of all globals to a custom alignment.

### DIFF
--- a/test/IRGen/force_alignment_of_globals.swift
+++ b/test/IRGen/force_alignment_of_globals.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -emit-ir -Xllvm -force-align-globals-to=8 %s | %FileCheck -check-prefix=CHECK-EIGHT %s
+// RUN: %target-swift-frontend -emit-ir -Xllvm -force-align-globals-to=16 %s | %FileCheck -check-prefix=CHECK-SIXTEEN %s
+
+// CHECK-EIGHT: @"$s26force_alignment_of_globals6globalSivp" ={{( dllexport| protected)?}} global %TSi zeroinitializer, align 8
+// CHECK-SIXTEEN: @"$s26force_alignment_of_globals6globalSivp" ={{( dllexport| protected)?}} global %TSi zeroinitializer, align 16
+public var global: Int = 0


### PR DESCRIPTION
I have seen in certain cases benchmarks being noisy b/c the alignment of global
data was shifting in between 8 and 16 byte aligned. This patch provides an
internal LLVM option that enables us to experiment with seeing if aligning data
like this (just for measuring perf), helps to stabilize said benchmarks.
