### PR TITLE
[docs] "Retroactive protocol refinement" in generics manifesto.

### DIFF
--- a/docs/GenericsManifesto.md
+++ b/docs/GenericsManifesto.md
@@ -694,9 +694,9 @@ foo(X())
 
 Under what circumstances should it print "P"? If `foo()` is defined within the same module as the conformance of `X` to `P`? If the call is defined within the same module as the conformance of `X` to `P`? Never? Either of the first two answers requires significant complications in the dynamic casting infrastructure to take into account the module in which a particular dynamic cast occurred (the first option) or where an existential was formed (the second option), while the third answer breaks the link between the static and dynamic type systems--none of which is an acceptable result.
 
-### Conditional conformances via protocol extensions
+### Retroactive protocol refinement
 
-We often get requests to make a protocol conform to another protocol. This is, effectively, the expansion of the notion of "Conditional conformances" to protocol extensions. For example:
+We often get requests to make protocols retroactively refine other protocols. For example:
 
 ```Swift
 protocol P {
@@ -707,8 +707,8 @@ protocol Q {
   func bar()
 }
 
-extension Q : P { // every type that conforms to Q also conforms to P
-  func foo() {    // implement "foo" requirement in terms of "bar"
+extension Q : P { // Make every type that conforms to Q also conforms to P
+  func foo() {    // Implement `P.foo` requirement in terms of `Q.bar`
     bar()
   }
 }


### PR DESCRIPTION
"Retroactive protocol refinement" is an accurate title for the section.

"Conditional conformances via protocol extensions" is not accurate
because the protocol refinements may not be conditional.