### PR TITLE
SILGen: Fix some issues with tuple/metatype/function reabstraction against opaque return types.

### DIFF
--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -378,7 +378,7 @@ AbstractionPattern::getTupleElementType(unsigned index) const {
   case Kind::Discard:
     llvm_unreachable("operation not needed on discarded abstractions yet");
   case Kind::Type:
-    if (isTypeParameter())
+    if (isTypeParameterOrOpaqueArchetype())
       return AbstractionPattern::getOpaque();
     return AbstractionPattern(getGenericSignature(),
                               getCanTupleElementType(getType(), index));

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -1821,7 +1821,7 @@ TypeConverter::computeLoweredRValueType(TypeExpansionContext forExpansion,
     auto origMeta = origType.getAs<MetatypeType>();
     if (!origMeta) {
       // If the metatype matches a dependent type, it must be thick.
-      assert(origType.isTypeParameter());
+      assert(origType.isTypeParameterOrOpaqueArchetype());
       repr = MetatypeRepresentation::Thick;
     } else {
       // Otherwise, we're thin if the metatype is thinnable both

--- a/test/SILGen/opaque_result_type_underlying_type_abstraction.swift
+++ b/test/SILGen/opaque_result_type_underlying_type_abstraction.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-emit-silgen -disable-availability-checking %s | %FileCheck %s
+
+// CHECK-LABEL: sil {{.*}}9withTuple
+// CHECK: bb0(%0 : $*(Int, String)):
+func withTuple() -> some Any {
+  return (1, "hello")
+}
+
+struct S {}
+
+// CHECK-LABEL: sil {{.*}}12withMetatype
+// CHECK: bb0(%0 : $*@thick S.Type):
+func withMetatype() -> some Any {
+  return S.self
+}
+
+// CHECK-LABEL: sil {{.*}}12withFunction
+// CHECK: bb0(%0 : $*@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <()>):
+func withFunction() -> some Any {
+  let f: () -> () = {}
+  return f
+}
+
+// CHECK-LABEL: sil {{.*}}30withTupleOfMetatypeAndFunction
+// CHECK: bb0(%0 : $*(@thick S.Type, @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <()>)):
+func withTupleOfMetatypeAndFunction() -> some Any {
+  let f: () -> () = {}
+  return (S.self, f)
+}


### PR DESCRIPTION
- Getting a tuple element from an opaque return type `AbstractionPattern` should produce another
  opaque abstraction pattern.
- Relax an assertion failure when lowering metatypes against opaque return type abstraction
  patterns.

Fixes rdar://problem/58787252.