### PR TITLE
IRGen: Fix crash with empty-sized field in a class with resilient ancestry [5.3]

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -273,6 +273,13 @@ namespace {
           // context.
           if (superclassType.hasArchetype())
             Options |= ClassMetadataFlags::ClassHasGenericLayout;
+
+          // Since we're not going to visit the superclass, make sure that we still
+          // set ClassHasObjCAncestry correctly.
+          if (superclassType.getASTType()->getReferenceCounting()
+                == ReferenceCounting::ObjC) {
+            Options |= ClassMetadataFlags::ClassHasObjCAncestry;
+          }
         } else {
           // Otherwise, we are allowed to have total knowledge of the superclass
           // fields, so walk them to compute the layout.

--- a/test/IRGen/class_resilience_objc.swift
+++ b/test/IRGen/class_resilience_objc.swift
@@ -1,19 +1,24 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -enable-library-evolution -enable-objc-interop -emit-ir -o - -primary-file %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_objc_class.swiftmodule -module-name=resilient_objc_class %S/../Inputs/resilient_objc_class.swift -I %t
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -enable-library-evolution -emit-ir -o - -primary-file %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
 
-// XFAIL: CPU=armv7k
-// XFAIL: CPU=powerpc64le
-// XFAIL: CPU=s390x
+// REQUIRES: objc_interop
 
 import Foundation
 import resilient_struct
+import resilient_objc_class
 
 // Note that these are all mutable to allow for the runtime to slide them.
 // CHECK: @"$s21class_resilience_objc27ClassWithEmptyThenResilientC9resilient0I7_struct0H3IntVvpWvd" = hidden global [[INT]] 0,
 // CHECK: @"$s21class_resilience_objc27ClassWithResilientThenEmptyC9resilient0I7_struct0F3IntVvpWvd" = hidden global [[INT]] 0,
+// CHECK: @"$s21class_resilience_objc34AnotherClassWithEmptyThenResilientC9resilient0J7_struct0I3IntVvpWvd" = hidden global [[INT]] 0,
+// CHECK: @"$s21class_resilience_objc34AnotherClassWithResilientThenEmptyC9resilient0J7_struct0G3IntVvpWvd" = hidden global [[INT]] 0,
+
 // CHECK: @"$s21class_resilience_objc27ClassWithEmptyThenResilientC5emptyAA0F0VvpWvd" = hidden global [[INT]] 0,
 // CHECK: @"$s21class_resilience_objc27ClassWithResilientThenEmptyC5emptyAA0H0VvpWvd" = hidden global [[INT]] 0,
+// CHECK: @"$s21class_resilience_objc34AnotherClassWithEmptyThenResilientC5emptyAA0G0VvpWvd" = hidden global [[INT]] 0,
+// CHECK: @"$s21class_resilience_objc34AnotherClassWithResilientThenEmptyC5emptyAA0I0VvpWvd" = hidden global [[INT]] 0,
 
 public class FixedLayoutObjCSubclass : NSObject {
   // This field could use constant direct access because NSObject has
@@ -113,6 +118,29 @@ public class ClassWithEmptyThenResilient : DummyClass {
 }
 
 public class ClassWithResilientThenEmpty : DummyClass {
+  public let resilient: ResilientInt
+  public let empty: Empty
+
+  public init(empty: Empty, resilient: ResilientInt) {
+    self.empty = empty
+    self.resilient = resilient
+  }
+}
+
+// Same as the above, but the superclass is resilient, and ultimately inherits
+// from an Objective-C base class.
+
+public class AnotherClassWithEmptyThenResilient : ResilientNSObjectOutsideParent {
+  public let empty: Empty
+  public let resilient: ResilientInt
+
+  public init(empty: Empty, resilient: ResilientInt) {
+    self.empty = empty
+    self.resilient = resilient
+  }
+}
+
+public class AnotherClassWithResilientThenEmpty : ResilientNSObjectOutsideParent {
   public let resilient: ResilientInt
   public let empty: Empty
 

--- a/test/Interpreter/Inputs/ObjCClasses/ObjCClasses.h
+++ b/test/Interpreter/Inputs/ObjCClasses/ObjCClasses.h
@@ -8,6 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 /* This class has instance variables which are not apparent in the
    interface.  Subclasses will need to be slid by the ObjC runtime. */
 @interface HasHiddenIvars : NSObject
+- (instancetype)init;
 @property NSInteger x;
 @property NSInteger y;
 @property NSInteger z;

--- a/test/Interpreter/Inputs/resilient_objc_class.swift
+++ b/test/Interpreter/Inputs/resilient_objc_class.swift
@@ -1,0 +1,3 @@
+import ObjCClasses
+
+open class HasResilientObjCBaseClass : HasHiddenIvars {}

--- a/test/Interpreter/objc_class_resilience.swift
+++ b/test/Interpreter/objc_class_resilience.swift
@@ -1,13 +1,16 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-clang -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o
-// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct)) -enable-library-evolution %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
-// RUN: %target-codesign %t/%target-library-name(resilient_struct)
 
-// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -I %S/Inputs/ObjCClasses/ -Xlinker %t/ObjCClasses.o -o %t/main %target-rpath(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct)) -enable-library-evolution %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_objc_class)) -enable-library-evolution %S/Inputs/resilient_objc_class.swift -emit-module -emit-module-path %t/resilient_objc_class.swiftmodule -module-name resilient_objc_class -I %S/Inputs/ObjCClasses/ -L %t -Xlinker %t/ObjCClasses.o -framework Foundation
+
+// RUN: %target-codesign %t/%target-library-name(resilient_struct) %t/%target-library-name(resilient_objc_class)
+
+// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_objc_class -I %S/Inputs/ObjCClasses/ -o %t/main %target-rpath(%t)
 // RUN: %target-codesign %t/main
 
-// RUN: %target-run %t/main %t/%target-library-name(resilient_struct)
+// RUN: %target-run %t/main %t/%target-library-name(resilient_struct) %t/%target-library-name(resilient_objc_class)
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
@@ -15,6 +18,7 @@
 import StdlibUnittest
 import Foundation
 import resilient_struct
+import resilient_objc_class
 import ObjCClasses
 
 
@@ -94,6 +98,55 @@ class ClassWithResilientThenEmpty : HasHiddenIvars {
 ResilientClassTestSuite.test("ResilientThenEmpty") {
   let c = ClassWithResilientThenEmpty(empty: Empty(),
                                       resilient: ResilientInt(i: 17))
+  c.x = 100
+  c.y = 2000
+  c.z = 30000
+  c.t = 400000
+  expectEqual(c.resilient.i, 17)
+  expectEqual(c.x, 100)
+  expectEqual(c.y, 2000)
+  expectEqual(c.z, 30000)
+  expectEqual(c.t, 400000)
+}
+
+// Same as the above, but the class itself has a resilient base class
+class AnotherClassWithEmptyThenResilient : HasResilientObjCBaseClass {
+  let empty: Empty
+  let resilient: ResilientInt
+
+  init(empty: Empty, resilient: ResilientInt) {
+    self.empty = empty
+    self.resilient = resilient
+  }
+}
+
+ResilientClassTestSuite.test("AnotherEmptyThenResilient") {
+  let c = AnotherClassWithEmptyThenResilient(empty: Empty(),
+                                             resilient: ResilientInt(i: 17))
+  c.x = 100
+  c.y = 2000
+  c.z = 30000
+  c.t = 400000
+  expectEqual(c.resilient.i, 17)
+  expectEqual(c.x, 100)
+  expectEqual(c.y, 2000)
+  expectEqual(c.z, 30000)
+  expectEqual(c.t, 400000)
+}
+
+class AnotherClassWithResilientThenEmpty : HasHiddenIvars {
+  let resilient: ResilientInt
+  let empty: Empty
+
+  init(empty: Empty, resilient: ResilientInt) {
+    self.empty = empty
+    self.resilient = resilient
+  }
+}
+
+ResilientClassTestSuite.test("AnotherResilientThenEmpty") {
+  let c = AnotherClassWithResilientThenEmpty(empty: Empty(),
+                                             resilient: ResilientInt(i: 17))
   c.x = 100
   c.y = 2000
   c.z = 30000


### PR DESCRIPTION
The problem was that HasObjCAncestry was not getting set if
HasResilientAncestry was true, and thus emitFieldOffsetGlobals() was
marking the field offset as const even though the Objective-C
runtime might slide it.

Fixes <rdar://problem/57549481>.