### PR TITLE
[Gardening] Remove Outdated Advice About -### and -incremental

### DIFF
--- a/docs/Driver.md
+++ b/docs/Driver.md
@@ -294,15 +294,6 @@ past that, so:
      All the same options from above apply, but you'll have to manually deal
      with the work the compiler would have done automatically for you.
 
-   - Invoke `swiftc -c` with `-###`. Then run all of the outputted commands
-     that include `-primary-file`, then run the remaining commands in order
-     (they may have dependencies). If none of the commands have `-primary-file`
-     in them, they're not parallelizable, sorry.
-
-     This is the most hacky approach, because (a) it involves looking for an
-     internal flag in a non-stable interface, and (b) you don't get anything
-     incremental out of this. We could stand some improvements here.
-
    Whatever you do, do *not* invoke the frontend directly.
 
 


### PR DESCRIPTION
Using -### is insufficient to discover the entire set of frontend jobs
needed to satisfy a given incremental compilation session because of the
presence of additional waves of recompilation. More concretely, any
additional compilation jobs whose queueing behavior depends on the set
of jobs reported by -### are, by definition, hidden from -###.

Note that it is also *not* possible to run the incremental build to
a fixpoint by iteratively executing said frontend jobs and re-running
the driver with -### because the build record is never updated to
account for the jobs executed by an external system.