### PR TITLE
[tensorflow] disable REPL (both integrated and LLDB)

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -211,6 +211,13 @@ WARNING(warn_drv_darwin_sdk_invalid_settings, none,
     "SDK settings were ignored because 'SDKSettings.json' could not be parsed",
     ())
 
+// SWIFT_ENABLE_TENSORFLOW
+ERROR(error_tensorflow_toolchain_repl_not_supported, none,
+      "The Swift for TensorFlow toolchain does not support the Swift REPL. Colab "
+      "(https://github.com/tensorflow/swift/blob/master/Usage.md#colaboratory) and Swift-Jupyter "
+      "(https://github.com/google/swift-jupyter) are supported alternatives.",
+      ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2302,6 +2302,15 @@ void Driver::buildJobs(ArrayRef<const Action *> TopLevelActions,
     }
   }
 
+  // SWIFT_ENABLE_TENSORFLOW
+  for (const Action *A : TopLevelActions) {
+    if (A->getKind() == Action::Kind::REPLJob) {
+      Diags.diagnose(SourceLoc(),
+                     diag::error_tensorflow_toolchain_repl_not_supported);
+      return;
+    }
+  }
+
   for (const Action *A : TopLevelActions) {
     if (auto *JA = dyn_cast<JobAction>(A)) {
       (void)buildJobsForAction(C, JA, OFM, workingDirectory, /*TopLevel=*/true,


### PR DESCRIPTION
Disables the integrated and LLDB REPLs in the S4TF toolchain.

When a user tries to run the REPL, it does this:
```
$ swift
<unknown>:0: error: The Swift for TensorFlow toolchain does not support the Swift REPL. Colab (https://github.com/tensorflow/swift/blob/master/Usage.md#colaboratory) and Swift-Jupyter (https://github.com/google/swift-jupyter) are supported alternatives.
```

Determined users who need to use the REPL despite the fact that we don't support it can still get the REPLs by invoking `swift -frontend -repl` (for the integrated REPL) or `lldb -r` (for the LLDB REPL).

Justification: The LLDB REPL keeps breaking in our toolchain, and we would rather spend effort maintaining Swift-in-Colab and Swift-Jupyer.

Corresponding documentation update at https://github.com/tensorflow/swift/pull/432.