### PR TITLE
[SR-12689] Diagnose arg mismatch with exact same fixes across multiple solutions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -245,6 +245,10 @@ ERROR(no_candidates_match_result_type,none,
       "no '%0' candidates produce the expected contextual result type %1",
       (StringRef, Type))
 
+ERROR(no_candidates_match_argument_type,none,
+      "no '%0' candidates produce the expected parameter type %1",
+      (StringRef, Type))
+
 ERROR(cannot_infer_closure_type,none,
       "unable to infer closure type in the current context", ())
 ERROR(cannot_infer_closure_result_type,none,

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -1062,7 +1062,9 @@ public:
   bool coalesceAndDiagnose(const Solution &solution,
                            ArrayRef<ConstraintFix *> secondaryFixes,
                            bool asNote = false) const override;
-
+  
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
+  
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 };
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3009,13 +3009,14 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
     }
   }
 
+  // If any of the non-overloaded common fixes appear in all solutions
+  // and can be diagnosed by the diagnoseForAmbiguity implementation,
+  // we diagnose and be done.
   if (diagnosed)
     return true;
 
-  // If all non-overloaded common fixes do not appear in all solutions
-  // nor are diagnosed for ambiguity, let's try to fall back to common
-  // anchor diagnostic.
-
+  // Otherwise let's try to fall back to overload common anchor
+  // diagnostic if possible.
   if (ambiguosOverloads.empty())
     return false;
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -496,10 +496,8 @@ enum Color {
 
   static func rainbow() -> Color {}
   
-  static func overload(a : Int) -> Color {} // expected-note {{incorrect labels for candidate (have: '(_:)', expected: '(a:)')}}
-  // expected-note@-1 {{candidate has partially matching parameter list (a: Int)}}
-  static func overload(b : Int) -> Color {} // expected-note {{incorrect labels for candidate (have: '(_:)', expected: '(b:)')}}
-  // expected-note@-1 {{candidate has partially matching parameter list (b: Int)}}
+  static func overload(a : Int) -> Color {} // expected-note 2 {{incorrect labels for candidate (have: '(_:)', expected: '(a:)')}}
+  static func overload(b : Int) -> Color {} // expected-note 2 {{incorrect labels for candidate (have: '(_:)', expected: '(b:)')}}
   
   static func frob(_ a : Int, b : inout Int) -> Color {}
   static var svar: Color { return .Red }

--- a/test/Constraints/super_constructor.swift
+++ b/test/Constraints/super_constructor.swift
@@ -39,15 +39,15 @@ class B {
   init() {
   }
 
-  init(x:Int) { // expected-note{{candidate has partially matching parameter list (x: Int)}}
+  init(x:Int) { // expected-note{{incorrect labels for candidate (have: '(_:)', expected: '(x:)')}}
   }
 
-  init(a:UnicodeScalar) { // expected-note {{candidate has partially matching parameter list (a: UnicodeScalar)}}
+  init(a:UnicodeScalar) { // expected-note {{incorrect labels for candidate (have: '(_:)', expected: '(a:)')}}
   }
-  init(b:UnicodeScalar) { // expected-note{{candidate has partially matching parameter list (b: UnicodeScalar)}}
+  init(b:UnicodeScalar) { // expected-note{{incorrect labels for candidate (have: '(_:)', expected: '(b:)')}}
   }
 
-  init(z:Float) { // expected-note{{candidate has partially matching parameter list (z: Float)}}
+  init(z:Float) { // expected-note {{incorrect labels for candidate (have: '(_:)', expected: '(z:)')}}
     super.init() // expected-error{{'super' members cannot be referenced in a root class}}
   }
 }

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -126,3 +126,28 @@ func getCounts(_ scheduler: sr5154_Scheduler, _ handler: @escaping ([Count]) -> 
   })
 }
 
+// SR-12689
+func SR12689(_ u: UnsafeBufferPointer<UInt16>) {}
+
+let array : [UInt16] = [1, 2]
+
+array.withUnsafeBufferPointer {
+    SR12689(UnsafeRawPointer($0).bindMemory(to: UInt16.self, capacity: 1)) // expected-error {{no exact matches in call to initializer}}
+    // expected-note@-1 {{found candidate with type '(Builtin.RawPointer) -> UnsafeRawPointer'}}
+    // expected-note@-2 {{found candidate with type '(UnsafeMutableRawPointer) -> UnsafeRawPointer'}}
+    // expected-note@-3 {{found candidate with type '(OpaquePointer) -> UnsafeRawPointer'}}
+    // expected-note@-4 {{found candidate with type '(UnsafeRawPointer) -> UnsafeRawPointer'}}
+    UnsafeRawPointer($0) as UnsafeBufferPointer<UInt16> // expected-error {{no exact matches in call to initializer}}
+    // expected-note@-1 {{found candidate with type '(Builtin.RawPointer) -> UnsafeRawPointer'}}
+    // expected-note@-2 {{found candidate with type '(UnsafeMutableRawPointer) -> UnsafeRawPointer'}}
+    // expected-note@-3 {{found candidate with type '(OpaquePointer) -> UnsafeRawPointer'}}
+    // expected-note@-4 {{found candidate with type '(UnsafeRawPointer) -> UnsafeRawPointer'}}
+}
+
+func SR12689_1(_ u: Int) -> String { "" } // expected-note 2 {{found this candidate}}
+func SR12689_1(_ u: String) -> Double { 0 } // expected-note 2 {{found this candidate}}
+
+func SR12689_2(_ u: Int) {}
+
+SR12689_2(SR12689_1(1 as Double)) // expected-error {{no exact matches in call to global function 'SR12689_1'}}
+SR12689_1(1 as Double) as Int // expected-error {{no exact matches in call to global function 'SR12689_1'}}

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -151,3 +151,10 @@ func SR12689_2(_ u: Int) {}
 
 SR12689_2(SR12689_1(1 as Double)) // expected-error {{no exact matches in call to global function 'SR12689_1'}}
 SR12689_1(1 as Double) as Int // expected-error {{no exact matches in call to global function 'SR12689_1'}}
+
+// Ambiguos OverloadRefExpr
+func SR12689_O(_ p: Int) {} // expected-note {{found candidate with type '(Int) -> ()'}}
+func SR12689_O(_ p: Double) {} // expected-note {{found candidate with type '(Double) -> ()'}}
+
+func SR12689_3(_ param: (String)-> Void) {}
+SR12689_3(SR12689_O) // expected-error {{no 'SR12689_O' candidates produce the expected parameter type '(String) -> Void'}}

--- a/test/expr/postfix/dot/init_ref_delegation.swift
+++ b/test/expr/postfix/dot/init_ref_delegation.swift
@@ -323,12 +323,12 @@ class TestOverloadSets {
     self.init(5, 5) // expected-error{{extra argument in call}}
   }
   
-  convenience init(a : Z0) { // expected-note{{candidate has partially matching parameter list (a: Z0)}}
+  convenience init(a : Z0) { // expected-note{{incorrect labels for candidate (have: '(_:)', expected: '(a:)')}}
     self.init(42 as Int8) // expected-error{{no exact matches in call to initializer}}
   }
   
-  init(value: Int) { /* ... */ } // expected-note{{candidate has partially matching parameter list (value: Int)}}
-  init(value: Double) { /* ... */ } // expected-note{{candidate has partially matching parameter list (value: Double)}}
+  init(value: Int) { /* ... */ } // expected-note{{incorrect labels for candidate (have: '(_:)', expected: '(value:)')}}
+  init(value: Double) { /* ... */ } // expected-note{{incorrect labels for candidate (have: '(_:)', expected: '(value:)')}}
 }
 
 class TestNestedExpr {


### PR DESCRIPTION
<!-- What's in this pull request? -->
In this case, there are multiple solutions that record the same exact argument mismatch fix. 
So this makes sure if all the fixes are the exact same arg and param types across solutions, we just diagnose.

cc @xedin @hborla :)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-12689.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
