### PR TITLE
SR-12247 : Replace the type alias ModuleDecl::ImportedModule with a dedicated struct

### DIFF
--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -134,7 +134,7 @@ bool swift::isDifferentiableProgrammingEnabled(SourceFile &SF) {
   // the given source file.
   bool importsDifferentiationModule = false;
   for (auto import : namelookup::getAllImports(&SF)) {
-    if (import.second->getName() == ctx.Id_Differentiation) {
+    if (import.importedModule->getName() == ctx.Id_Differentiation) {
       importsDifferentiationModule = true;
       break;
     }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1215,7 +1215,7 @@ lookupOperatorDeclForName(const FileUnit &File, SourceLoc Loc,
   ImportedOperatorsMap<OP_DECL> importedOperators;
   for (auto &imported : SourceFile::Impl::getImportsForSourceFile(SF)) {
     // Protect against source files that contrive to import their own modules.
-    if (imported.module.second == ownModule)
+    if (imported.module.importedModule == ownModule)
       continue;
 
     bool isExported =
@@ -1223,9 +1223,8 @@ lookupOperatorDeclForName(const FileUnit &File, SourceLoc Loc,
     if (!includePrivate && !isExported)
       continue;
 
-    Optional<OP_DECL *> maybeOp =
-        lookupOperatorDeclForName<OP_DECL>(imported.module.second, Loc, Name,
-                                           isCascading);
+    Optional<OP_DECL *> maybeOp = lookupOperatorDeclForName<OP_DECL>(
+        imported.module.importedModule, Loc, Name, isCascading);
     if (!maybeOp)
       return None;
     
@@ -1418,7 +1417,7 @@ SourceFile::getImportedModules(SmallVectorImpl<ModuleDecl::ImportedModule> &modu
     else
       requiredFilter |= ModuleDecl::ImportFilterKind::Private;
 
-    if (!separatelyImportedOverlays.lookup(desc.module.second).empty())
+    if (!separatelyImportedOverlays.lookup(desc.module.importedModule).empty())
       requiredFilter |= ModuleDecl::ImportFilterKind::ShadowedBySeparateOverlay;
 
     if (filter.contains(requiredFilter))
@@ -1513,26 +1512,26 @@ ModuleDecl::removeDuplicateImports(SmallVectorImpl<ImportedModule> &imports) {
   std::sort(imports.begin(), imports.end(),
             [](const ImportedModule &lhs, const ImportedModule &rhs) -> bool {
     // Arbitrarily sort by name to get a deterministic order.
-    if (lhs.second != rhs.second) {
+    if (lhs.importedModule != rhs.importedModule) {
       return std::lexicographical_compare(
-          lhs.second->getReverseFullModuleName(), {},
-          rhs.second->getReverseFullModuleName(), {});
+          lhs.importedModule->getReverseFullModuleName(), {},
+          rhs.importedModule->getReverseFullModuleName(), {});
     }
     using AccessPathElem = Located<Identifier>;
-    return std::lexicographical_compare(lhs.first.begin(), lhs.first.end(),
-                                        rhs.first.begin(), rhs.first.end(),
-                                        [](const AccessPathElem &lElem,
-                                           const AccessPathElem &rElem) {
-      return lElem.Item.str() < rElem.Item.str();
-    });
+    return std::lexicographical_compare(
+        lhs.accessPath.begin(), lhs.accessPath.end(), rhs.accessPath.begin(),
+        rhs.accessPath.end(),
+        [](const AccessPathElem &lElem, const AccessPathElem &rElem) {
+          return lElem.Item.str() < rElem.Item.str();
+        });
   });
-  auto last = std::unique(imports.begin(), imports.end(),
-                          [](const ImportedModule &lhs,
-                             const ImportedModule &rhs) -> bool {
-    if (lhs.second != rhs.second)
-      return false;
-    return ModuleDecl::isSameAccessPath(lhs.first, rhs.first);
-  });
+  auto last = std::unique(
+      imports.begin(), imports.end(),
+      [](const ImportedModule &lhs, const ImportedModule &rhs) -> bool {
+        if (lhs.importedModule != rhs.importedModule)
+          return false;
+        return ModuleDecl::isSameAccessPath(lhs.accessPath, rhs.accessPath);
+      });
   imports.erase(last, imports.end());
 }
 
@@ -1693,11 +1692,12 @@ SourceFile::collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const
   topLevel->getImportedModules(stack, topLevelFilter);
 
   // Make sure the top-level module is first; we want pre-order-ish traversal.
-  stack.emplace_back(ModuleDecl::AccessPathTy(),
-                     const_cast<ModuleDecl *>(topLevel));
+  auto topLevelModule =
+      ModuleDecl::ImportedModule{ModuleDecl::AccessPathTy(), topLevel};
+  stack.emplace_back(topLevelModule);
 
   while (!stack.empty()) {
-    auto next = stack.pop_back_val().second;
+    auto next = stack.pop_back_val().importedModule;
 
     if (!visited.insert(next).second)
       continue;
@@ -1905,7 +1905,7 @@ ModuleDecl::getDeclaringModuleAndBystander() {
 
   getImportedModules(imported, ModuleDecl::ImportFilterKind::Public);
   while (!imported.empty()) {
-    ModuleDecl *importedModule = std::get<1>(imported.back());
+    ModuleDecl *importedModule = imported.back().importedModule;
     imported.pop_back();
     if (!seen.insert(importedModule).second)
       continue;
@@ -2124,15 +2124,15 @@ bool SourceFile::hasTestableOrPrivateImport(
         Imports->begin(), Imports->end(),
         [module, queryKind](ImportedModuleDesc desc) -> bool {
           if (queryKind == ImportQueryKind::TestableAndPrivate)
-            return desc.module.second == module &&
+            return desc.module.importedModule == module &&
                    (desc.importOptions.contains(ImportFlags::PrivateImport) ||
                     desc.importOptions.contains(ImportFlags::Testable));
           else if (queryKind == ImportQueryKind::TestableOnly)
-            return desc.module.second == module &&
+            return desc.module.importedModule == module &&
                    desc.importOptions.contains(ImportFlags::Testable);
           else {
             assert(queryKind == ImportQueryKind::PrivateOnly);
-            return desc.module.second == module &&
+            return desc.module.importedModule == module &&
                    desc.importOptions.contains(ImportFlags::PrivateImport);
           }
         });
@@ -2165,7 +2165,7 @@ bool SourceFile::hasTestableOrPrivateImport(
 
   return std::any_of(Imports->begin(), Imports->end(),
                      [module, filename](ImportedModuleDesc desc) -> bool {
-                       return desc.module.second == module &&
+                       return desc.module.importedModule == module &&
                               desc.importOptions.contains(
                                   ImportFlags::PrivateImport) &&
                               desc.filename == filename;
@@ -2188,7 +2188,7 @@ bool SourceFile::isImportedImplementationOnly(const ModuleDecl *module) const {
 
     // If the module is imported this way, it's not imported
     // implementation-only.
-    if (imports.isImportedBy(module, desc.module.second))
+    if (imports.isImportedBy(module, desc.module.importedModule))
       return false;
   }
 
@@ -2200,7 +2200,7 @@ void SourceFile::lookupImportedSPIGroups(const ModuleDecl *importedModule,
                                     SmallVectorImpl<Identifier> &spiGroups) const {
   for (auto &import : *Imports) {
     if (import.importOptions.contains(ImportFlags::SPIAccessControl) &&
-        importedModule == std::get<ModuleDecl*>(import.module)) {
+        importedModule == import.module.importedModule) {
       auto importedSpis = import.spiGroups;
       spiGroups.append(importedSpis.begin(), importedSpis.end());
     }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1702,8 +1702,8 @@ AnyObjectLookupRequest::evaluate(Evaluator &evaluator, const DeclContext *dc,
   // Collect all of the visible declarations.
   SmallVector<ValueDecl *, 4> allDecls;
   for (auto import : namelookup::getAllImports(dc)) {
-    import.second->lookupClassMember(import.first, member.getFullName(),
-                                     allDecls);
+    import.importedModule->lookupClassMember(import.accessPath,
+                                             member.getFullName(), allDecls);
   }
 
   // For each declaration whose context is not something we've
@@ -1745,7 +1745,7 @@ void DeclContext::lookupAllObjCMethods(
        SmallVectorImpl<AbstractFunctionDecl *> &results) const {
   // Collect all of the methods with this selector.
   for (auto import : namelookup::getAllImports(this)) {
-    import.second->lookupObjCMethods(selector, results);
+    import.importedModule->lookupObjCMethods(selector, results);
   }
 
   // Filter out duplicates.

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -47,9 +47,9 @@ version::Version swift::InterfaceFormatVersion({1, 0});
 static void diagnoseScopedImports(DiagnosticEngine &diags,
                                   ArrayRef<ModuleDecl::ImportedModule> imports){
   for (const ModuleDecl::ImportedModule &importPair : imports) {
-    if (importPair.first.empty())
+    if (importPair.accessPath.empty())
       continue;
-    diags.diagnose(importPair.first.front().Loc,
+    diags.diagnose(importPair.accessPath.front().Loc,
                    diag::module_interface_scoped_import_unsupported);
   }
 }
@@ -115,10 +115,11 @@ static void printImports(raw_ostream &out,
   M->getImportedModules(publicImports, ModuleDecl::ImportFilterKind::Public);
   llvm::SmallSet<ModuleDecl::ImportedModule, 8,
                  ModuleDecl::OrderImportedModules> publicImportSet;
+
   publicImportSet.insert(publicImports.begin(), publicImports.end());
 
   for (auto import : allImports) {
-    auto importedModule = import.second;
+    auto importedModule = import.importedModule;
     if (importedModule->isOnoneSupportModule() ||
         importedModule->isBuiltinModule()) {
       continue;
@@ -140,9 +141,9 @@ static void printImports(raw_ostream &out,
 
     // Write the access path we should be honoring but aren't.
     // (See diagnoseScopedImports above.)
-    if (!import.first.empty()) {
+    if (!import.accessPath.empty()) {
       out << "/*";
-      for (const auto &accessPathElem : import.first)
+      for (const auto &accessPathElem : import.accessPath)
         out << "." << accessPathElem.Item;
       out << "*/";
     }

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -422,8 +422,8 @@ static bool emitLoadedModuleTraceIfNeeded(ModuleDecl *mainModule,
   mainModule->getImportedModules(imports, filter);
 
   SmallPtrSet<ModuleDecl *, 8> importedModules;
-  for (std::pair<ModuleDecl::AccessPathTy, ModuleDecl *> &import : imports)
-    importedModules.insert(import.second);
+  for (ModuleDecl::ImportedModule &import : imports)
+    importedModules.insert(import.importedModule);
 
   llvm::DenseMap<StringRef, ModuleDecl *> pathToModuleDecl;
   for (auto &module : ctxt.LoadedModules) {

--- a/lib/FrontendTool/ImportedModules.cpp
+++ b/lib/FrontendTool/ImportedModules.cpp
@@ -89,10 +89,10 @@ bool swift::emitImportedModules(ASTContext &Context, ModuleDecl *mainModule,
           imported, importFilter);
 
       for (auto IM : imported) {
-        if (auto clangModule = IM.second->findUnderlyingClangModule())
+        if (auto clangModule = IM.importedModule->findUnderlyingClangModule())
           Modules.insert(getTopLevelName(clangModule));
         else
-          assert(IM.second->isStdlibModule() &&
+          assert(IM.importedModule->isStdlibModule() &&
                  "unexpected non-stdlib swift module");
       }
     }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1952,7 +1952,7 @@ public:
     CurrDeclContext->getParentSourceFile()->getImportedModules(Imported,
                                                                ImportFilter);
     while (!Imported.empty()) {
-      ModuleDecl *MD = Imported.back().second;
+      ModuleDecl *MD = Imported.back().importedModule;
       Imported.pop_back();
       if (!ImportedModules.insert(MD->getNameStr()).second)
         continue;
@@ -3656,7 +3656,7 @@ public:
   void collectOperators(SmallVectorImpl<OperatorDecl *> &results) {
     assert(CurrDeclContext);
     for (auto import : namelookup::getAllImports(CurrDeclContext))
-      import.second->getOperatorDecls(results);
+      import.importedModule->getOperatorDecls(results);
   }
 
   void addPostfixBang(Type resultType) {
@@ -4297,7 +4297,7 @@ public:
       }
     }
     for (auto Import : namelookup::getAllImports(CurrDeclContext)) {
-      auto Module = Import.second;
+      auto Module = Import.importedModule;
       if (Module == CurrModule)
         continue;
 
@@ -5956,8 +5956,8 @@ void CodeCompletionCallbacksImpl::doneParsing() {
 
     llvm::DenseSet<CodeCompletionCache::Key> ImportsSeen;
     auto handleImport = [&](ModuleDecl::ImportedModule Import) {
-      ModuleDecl *TheModule = Import.second;
-      ModuleDecl::AccessPathTy Path = Import.first;
+      ModuleDecl *TheModule = Import.importedModule;
+      ModuleDecl::AccessPathTy Path = Import.accessPath;
       if (TheModule->getFiles().empty())
         return;
 
@@ -6028,7 +6028,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
       SF->getImportedModules(Imports, ImportFilter);
 
       for (auto Imported : Imports) {
-        for (auto Import : namelookup::getAllImports(Imported.second))
+        for (auto Import : namelookup::getAllImports(Imported.importedModule))
           handleImport(Import);
       }
     }

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -222,7 +222,7 @@ doCodeCompletion(SourceFile &SF, StringRef EnteredCode, unsigned *BufferID,
   lastModule->getImportedModules(imports,
                                  ModuleDecl::ImportFilterKind::Private);
   for (auto &import : imports) {
-    implicitImports.AdditionalModules.emplace_back(import.second,
+    implicitImports.AdditionalModules.emplace_back(import.importedModule,
                                                    /*exported*/ false);
   }
 

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -717,7 +717,7 @@ private:
   }
   
   llvm::DIModule *getOrCreateModule(ModuleDecl::ImportedModule IM) {
-    ModuleDecl *M = IM.second;
+    ModuleDecl *M = IM.importedModule;
     if (Optional<ASTSourceDescriptor> ModuleDesc = getClangModule(*M))
       return getOrCreateModule(*ModuleDesc, ModuleDesc->getModuleOrNull());
     StringRef Path = getFilenameFromDC(M);
@@ -1807,7 +1807,7 @@ void IRGenDebugInfoImpl::finalize() {
   SmallVector<ModuleDecl::ImportedModule, 8> ModuleWideImports;
   IGM.getSwiftModule()->getImportedModules(ModuleWideImports, ImportFilter);
   for (auto M : ModuleWideImports)
-    if (!ImportedModules.count(M.second))
+    if (!ImportedModules.count(M.importedModule))
       DBuilder.createImportedModule(MainFile, getOrCreateModule(M), MainFile,
                                     0);
 
@@ -2054,7 +2054,7 @@ void IRGenDebugInfoImpl::emitImport(ImportDecl *D) {
   auto L = getDebugLoc(*this, D);
   auto *File = getOrCreateFile(L.Filename);
   DBuilder.createImportedModule(File, DIMod, File, L.Line);
-  ImportedModules.insert(Imported.second);
+  ImportedModules.insert(Imported.importedModule);
 }
 
 llvm::DISubprogram *IRGenDebugInfoImpl::emitFunction(SILFunction &SILFn,

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -174,7 +174,7 @@ typeCheckREPLInput(ModuleDecl *MostRecentModule, StringRef Name,
   MostRecentModule->getImportedModules(imports,
                                        ModuleDecl::ImportFilterKind::Private);
   for (auto &import : imports) {
-    implicitImports.AdditionalModules.emplace_back(import.second,
+    implicitImports.AdditionalModules.emplace_back(import.importedModule,
                                                    /*exported*/ true);
   }
 

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -720,7 +720,7 @@ bool IndexSwiftASTWalker::visitImports(
 
   llvm::SmallPtrSet<ModuleDecl *, 8> Reported;
   for (auto Import : Imports) {
-    ModuleDecl *Mod = Import.second;
+    ModuleDecl *Mod = Import.importedModule;
     bool NewReport = Reported.insert(Mod).second;
     if (!NewReport)
       continue;
@@ -1605,7 +1605,7 @@ void IndexSwiftASTWalker::collectRecursiveModuleImports(
   TopMod.getImportedModules(Imports);
 
   for (auto Import : Imports) {
-    collectRecursiveModuleImports(*Import.second, Visited);
+    collectRecursiveModuleImports(*Import.importedModule, Visited);
   }
 }
 

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -396,7 +396,7 @@ static void addModuleDependencies(ArrayRef<ModuleDecl::ImportedModule> imports,
   auto &fileMgr = clangCI.getFileManager();
 
   for (auto &import : imports) {
-    ModuleDecl *mod = import.second;
+    ModuleDecl *mod = import.importedModule;
     if (mod->isOnoneSupportModule())
       continue; // ignore the Onone support library.
     if (mod->isSwiftShimsModule())

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -395,7 +395,8 @@ static void doDynamicLookup(VisibleDeclConsumer &Consumer,
   DynamicLookupConsumer ConsumerWrapper(Consumer, LS, CurrDC);
 
   for (auto Import : namelookup::getAllImports(CurrDC)) {
-    Import.second->lookupClassMembers(Import.first, ConsumerWrapper);
+    Import.importedModule->lookupClassMembers(Import.accessPath,
+                                              ConsumerWrapper);
   }
 }
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -249,7 +249,7 @@ static void bindExtensions(SourceFile &SF) {
   // private extensions.
   for (auto import : namelookup::getAllImports(&SF)) {
     // FIXME: Respect the access path?
-    for (auto file : import.second->getFiles()) {
+    for (auto file : import.importedModule->getFiles()) {
       auto SF = dyn_cast<SourceFile>(file);
       if (!SF)
         continue;

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -108,7 +108,7 @@ public:
   /// Represents another module that has been imported as a dependency.
   class Dependency {
   public:
-    ModuleDecl::ImportedModule Import = {};
+    llvm::Optional<ModuleDecl::ImportedModule> Import = llvm::None;
     const StringRef RawPath;
     const StringRef RawSPIs;
     SmallVector<Identifier, 4> spiGroups;
@@ -146,7 +146,7 @@ public:
     }
 
     bool isLoaded() const {
-      return Import.second != nullptr;
+      return Import.hasValue() && Import->importedModule != nullptr;
     }
 
     bool isExported() const {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -940,15 +940,16 @@ void Serializer::writeHeader(const SerializationOptions &options) {
 static void flattenImportPath(const ModuleDecl::ImportedModule &import,
                               SmallVectorImpl<char> &out) {
   llvm::raw_svector_ostream outStream(out);
-  import.second->getReverseFullModuleName().printForward(outStream,
-                                                         StringRef("\0", 1));
+  import.importedModule->getReverseFullModuleName().printForward(
+      outStream, StringRef("\0", 1));
 
-  if (import.first.empty())
+  if (import.accessPath.empty())
     return;
 
   outStream << '\0';
-  assert(import.first.size() == 1 && "can only handle top-level decl imports");
-  auto accessPathElem = import.first.front();
+  assert(import.accessPath.size() == 1 &&
+         "can only handle top-level decl imports");
+  auto accessPathElem = import.accessPath.front();
   outStream << accessPathElem.Item.str();
 }
 
@@ -1035,7 +1036,8 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
   auto clangImporter =
     static_cast<ClangImporter *>(M->getASTContext().getClangModuleLoader());
   ModuleDecl *bridgingHeaderModule = clangImporter->getImportedHeaderModule();
-  ModuleDecl::ImportedModule bridgingHeaderImport{{}, bridgingHeaderModule};
+  ModuleDecl::ImportedModule bridgingHeaderImport{ModuleDecl::AccessPathTy(),
+                                                  bridgingHeaderModule};
 
   // Make sure the bridging header module is always at the top of the import
   // list, mimicking how it is processed before any module imports when
@@ -1061,8 +1063,8 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
 
   ModuleDecl *theBuiltinModule = M->getASTContext().TheBuiltinModule;
   for (auto import : allImports) {
-    if (import.second == theBuiltinModule ||
-        import.second == bridgingHeaderModule) {
+    if (import.importedModule == theBuiltinModule ||
+        import.importedModule == bridgingHeaderModule) {
       continue;
     }
 
@@ -1081,11 +1083,11 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
       stableImportControl = ImportControl::ImplementationOnly;
 
     SmallVector<Identifier, 4> spis;
-    M->lookupImportedSPIGroups(import.second, spis);
+    M->lookupImportedSPIGroups(import.importedModule, spis);
 
     ImportedModule.emit(ScratchRecord,
                         static_cast<uint8_t>(stableImportControl),
-                        !import.first.empty(), !spis.empty(), importPath);
+                        !import.accessPath.empty(), !spis.empty(), importPath);
 
     if (!spis.empty()) {
       SmallString<64> out;

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -819,12 +819,13 @@ void swift::serialization::diagnoseSerializedASTLoadFailure(
   }
 
   case serialization::Status::CircularDependency: {
-    auto circularDependencyIter =
-        llvm::find_if(loadedModuleFile->getDependencies(),
-                      [](const ModuleFile::Dependency &next) {
-                        return next.isLoaded() &&
-                               !next.Import.second->hasResolvedImports();
-                      });
+    auto circularDependencyIter = llvm::find_if(
+        loadedModuleFile->getDependencies(),
+        [](const ModuleFile::Dependency &next) {
+          return next.isLoaded() &&
+                 !(next.Import.hasValue() &&
+                   next.Import->importedModule->hasResolvedImports());
+        });
     assert(circularDependencyIter !=
                loadedModuleFile->getDependencies().end() &&
            "circular dependency reported, but no module with unresolved "
@@ -1088,7 +1089,7 @@ void SerializedASTFile::collectLinkLibrariesFromImports(
   File.getImportedModules(Imports, ImportFilter);
 
   for (auto Import : Imports)
-    Import.second->collectLinkLibraries(callback);
+    Import.importedModule->collectLinkLibraries(callback);
 }
 
 void SerializedASTFile::collectLinkLibraries(

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -350,9 +350,9 @@ ImportDepth::ImportDepth(ASTContext &context,
   main->getImportedModules(mainImports, importFilter);
   for (auto &import : mainImports) {
     uint8_t depth = 1;
-    if (auxImports.count(import.second->getName().str()))
+    if (auxImports.count(import.importedModule->getName().str()))
       depth = 0;
-    worklist.emplace_back(import.second, depth);
+    worklist.emplace_back(import.importedModule, depth);
   }
 
   // Fill depths with BFS over module imports.
@@ -380,10 +380,11 @@ ImportDepth::ImportDepth(ASTContext &context,
       uint8_t next = std::max(depth, uint8_t(depth + 1)); // unsigned wrap
 
       // Implicitly imported sub-modules get the same depth as their parent.
-      if (const clang::Module *CMI = import.second->findUnderlyingClangModule())
+      if (const clang::Module *CMI =
+              import.importedModule->findUnderlyingClangModule())
         if (CM && CMI->isSubModuleOf(CM))
           next = depth;
-      worklist.emplace_back(import.second, next);
+      worklist.emplace_back(import.importedModule, next);
     }
   }
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -911,7 +911,7 @@ static void collectModuleDependencies(ModuleDecl *TopMod,
   TopMod->getImportedModules(Imports, ImportFilter);
 
   for (auto Import : Imports) {
-    ModuleDecl *Mod = Import.second;
+    ModuleDecl *Mod = Import.importedModule;
     if (Mod->isSystemModule())
       continue;
     // FIXME: Setup dependencies on the included headers.

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2766,22 +2766,22 @@ static int doPrintModuleImports(const CompilerInvocation &InitInvok,
 
     SmallVector<ModuleDecl::ImportedModule, 16> scratch;
     for (auto next : namelookup::getAllImports(M)) {
-      llvm::outs() << next.second->getName();
-      if (next.second->isClangModule())
+      llvm::outs() << next.importedModule->getName();
+      if (next.importedModule->isClangModule())
         llvm::outs() << " (Clang)";
       llvm::outs() << ":\n";
 
       scratch.clear();
-      next.second->getImportedModules(scratch,
-                                      ModuleDecl::ImportFilterKind::Public);
+      next.importedModule->getImportedModules(
+          scratch, ModuleDecl::ImportFilterKind::Public);
       // FIXME: ImportFilterKind::ShadowedBySeparateOverlay?
       for (auto &import : scratch) {
-        llvm::outs() << "\t" << import.second->getName();
-        for (auto accessPathPiece : import.first) {
+        llvm::outs() << "\t" << import.importedModule->getName();
+        for (auto accessPathPiece : import.accessPath) {
           llvm::outs() << "." << accessPathPiece.Item;
         }
 
-        if (import.second->isClangModule())
+        if (import.importedModule->isClangModule())
           llvm::outs() << " (Clang)";
         llvm::outs() << "\n";
       }


### PR DESCRIPTION
<!-- What's in this pull request? -->
This is for SR-12247: Replace the type alias `ModuleDecl::ImportedModule` with a dedicated struct. It creates a new struct ImportedModule to replace the earlier std::pair implementation. It runs through the client code and replaces .first and .second with .accessPathTy and .moduleDecl. 

The two-argument constructor for ModuleDecl::ImportedModule will fail with an assertion if the .moduleDecl pointer is null. The zero-argument constructor puts a nullPtr in .moduleDecl. There are cases in client code, for instance lib/Serialization/ModuleFile.h:113:32: ModuleDecl::ImportedModule Import = {}; where the zero-argument constructor is called. I am not completely sure, but I think the initialization case is the only time the zero-argument constructor is called. It might be possible to replace that with a singleton. The field in the example is replaced completely later. 

It's not possible right now to make the .accessPathTy and .moduleDecl struct elements const because there are some calls where the struct is modified after creation. It might be possible to clear this up--it needs more work. The ImportedModules go through some std:: data structures and some of them expect to be able to mutate them, but may not actually need to. 

@varungandhi-apple added the issue to bugs.swift.org.
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-12247.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
