### PR TITLE
[5.3][AST] Fix assertion hit in AutoClosureExpr::getUnwrappedCurryThunkExpr()

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1897,6 +1897,8 @@ Expr *AutoClosureExpr::getUnwrappedCurryThunkExpr() const {
 
       if (auto *openExistential = dyn_cast<OpenExistentialExpr>(innerBody)) {
         innerBody = openExistential->getSubExpr();
+        if (auto *ICE = dyn_cast<ImplicitConversionExpr>(innerBody))
+          innerBody = ICE->getSyntacticSubExpr();
       }
 
       if (auto *outerCall = dyn_cast<ApplyExpr>(innerBody)) {

--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -520,3 +520,14 @@ func useDefaultInits() {
   // CHECK: [[@LINE-1]]:15 | instance-property/Swift | y | s:14swift_ide_test7BStructV1ySbvp | Ref,RelCont
   // CHECK: [[@LINE-2]]:7 | constructor/Swift | init(x:y:z:) | s:14swift_ide_test7BStructV1x1y1zACSi_SbSStcfc | Ref,Call,RelCall,RelCont | rel: 1
 }
+
+internal protocol FromInt {
+    init(_ uint64: Int)
+}
+extension Int: FromInt { }
+func test<M>(_: M, value: Int?) {
+    if let idType = M.self as? FromInt.Type {
+        _ = value.flatMap(idType.init) as? M
+// CHECK: [[@LINE-1]]:34 | constructor/Swift | init(_:) | s:14swift_ide_test7FromIntPyxSicfc | Ref,RelCont | rel: 1
+    }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/31352 (reviewed by @slavapestov)

For DoubleCurryThunk cases it’s expecting an ApplyExpr directly within the OpenExistentialExpr, but in some cases it contains an ErasureExpr (implicit conversion) that wraps the ApplyExpr. This updates the method to look through implicit conversions.

Resolves rdar://problem/61885996