### PR TITLE
[SR-12672] Tailored diagnostics for missing member involving array literal default to any element

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3412,7 +3412,8 @@ bool MissingMemberFailure::diagnoseForDefaultAnyArrayLiteral() const {
   if (contextualType)
     return false;
   
-  if (isa<UnresolvedMemberExpr>(expr) && isa<ArrayExpr>(parentExpr)) {
+  if (isa<UnresolvedMemberExpr>(expr) &&
+      parentExpr && isa<ArrayExpr>(parentExpr)) {
     if (auto *metatype = baseType->getAs<MetatypeType>()) {
       baseType = metatype->getInstanceType();
     }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1060,9 +1060,9 @@ private:
   /// defines only `dynamicallyCall(withArguments:)` variant.
   bool diagnoseForDynamicCallable() const;
   
-  /// Tailored diagnostics for array literal with unresolved member expression
-  /// that defaults the element to element type. e.g. _ = [.e]
-  bool diagnoseForDefaultAnyArrayLiteral() const;
+  /// Tailored diagnostics for collection literal with unresolved member expression
+  /// that defaults the element type. e.g. _ = [.e]
+  bool diagnoseInLiteralCollectionContext() const;
 
   static DeclName findCorrectEnumCaseName(Type Ty,
                                           TypoCorrectionResults &corrections,

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1059,6 +1059,10 @@ private:
   /// overload to be present, but a class marked as `@dynamicCallable`
   /// defines only `dynamicallyCall(withArguments:)` variant.
   bool diagnoseForDynamicCallable() const;
+  
+  /// Tailored diagnostics for array literal with unresolved member expression
+  /// that defaults the element to element type. e.g. _ = [.e]
+  bool diagnoseForDefaultAnyArrayLiteral() const;
 
   static DeclName findCorrectEnumCaseName(Type Ty,
                                           TypoCorrectionResults &corrections,

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -664,3 +664,7 @@ func test_34770265(_ dict: [Int: Int]) {
   dict.rdar_34770265_val()
   // expected-error@-1 {{referencing instance method 'rdar_34770265_val()' on 'Dictionary' requires the types 'Int' and 'String' be equivalent}}
 }
+
+// SR-12672
+_ = [.e] // expected-error {{reference to member 'e' cannot be resolved without a contextual type}}
+let _ : [Any] = [.e] // expected-error {{type 'Any' has no member 'e'}}

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -668,3 +668,8 @@ func test_34770265(_ dict: [Int: Int]) {
 // SR-12672
 _ = [.e] // expected-error {{reference to member 'e' cannot be resolved without a contextual type}}
 let _ : [Any] = [.e] // expected-error {{type 'Any' has no member 'e'}}
+_ = [1 :.e] // expected-error {{reference to member 'e' cannot be resolved without a contextual type}}
+_ = [.e: 1] // expected-error {{reference to member 'e' cannot be resolved without a contextual type}}
+let _ : [Int: Any] = [1 : .e] // expected-error {{type 'Any' has no member 'e'}}
+let _ : (Int, Any) = (1, .e) // expected-error {{type 'Any' has no member 'e'}}
+_ = (1, .e) // expected-error {{cannot infer contextual base in reference to member 'e'}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Tailored diagnostics for missing member involving array literal default to any element. 
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-12672.

cc @xedin @varungandhi-apple 
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
