### PR TITLE
[tensorflow] disable REPL (both integrated and LLDB)

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -211,6 +211,13 @@ WARNING(warn_drv_darwin_sdk_invalid_settings, none,
     "SDK settings were ignored because 'SDKSettings.json' could not be parsed",
     ())
 
+// SWIFT_ENABLE_TENSORFLOW
+ERROR(error_tensorflow_toolchain_repl_not_supported, none,
+      "The Swift for TensorFlow toolchain does not support the Swift REPL. Colab "
+      "(https://github.com/tensorflow/swift/blob/master/Usage.md#colaboratory) and Swift-Jupyter "
+      "(https://github.com/google/swift-jupyter) are supported alternatives.",
+      ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2302,6 +2302,15 @@ void Driver::buildJobs(ArrayRef<const Action *> TopLevelActions,
     }
   }
 
+  // SWIFT_ENABLE_TENSORFLOW
+  for (const Action *A : TopLevelActions) {
+    if (A->getKind() == Action::Kind::REPLJob) {
+      Diags.diagnose(SourceLoc(),
+                     diag::error_tensorflow_toolchain_repl_not_supported);
+      return;
+    }
+  }
+
   for (const Action *A : TopLevelActions) {
     if (auto *JA = dyn_cast<JobAction>(A)) {
       (void)buildJobsForAction(C, JA, OFM, workingDirectory, /*TopLevel=*/true,

--- a/test/Driver/options-interpreter.swift
+++ b/test/Driver/options-interpreter.swift
@@ -10,7 +10,7 @@
 // ARGS: -- a b c
 
 // RUN: %swift_driver -### -parse-stdlib %s | %FileCheck -check-prefix PARSE_STDLIB %s
-// RUN: %swift_driver -### -parse-stdlib | %FileCheck -check-prefix PARSE_STDLIB %s
+// SWIFT_ENABLE_TENSORFLOW: REPL is disabled in tensorflow branch.
 // PARSE_STDLIB: -parse-stdlib
 
 

--- a/test/Driver/options-repl-darwin.swift
+++ b/test/Driver/options-repl-darwin.swift
@@ -1,3 +1,6 @@
+// SWIFT_ENABLE_TENSORFLOW: REPL is disabled in tensorflow branch.
+// UNSUPPORTED: tensorflow
+
 // REQUIRES: OS=macosx
 
 // Test LLDB detection, first in a clean environment, then in one that looks

--- a/test/Driver/options-repl.swift
+++ b/test/Driver/options-repl.swift
@@ -1,3 +1,6 @@
+// SWIFT_ENABLE_TENSORFLOW: REPL is disabled in tensorflow branch.
+// UNSUPPORTED: tensorflow
+
 // RUN: not %swift -repl %s 2>&1 | %FileCheck -check-prefix=REPL_NO_FILES %s
 // RUN: not %swift_driver -sdk "" -repl %s 2>&1 | %FileCheck -check-prefix=REPL_NO_FILES %s
 // RUN: not %swift_driver -sdk "" -lldb-repl %s 2>&1 | %FileCheck -check-prefix=REPL_NO_FILES %s

--- a/test/Driver/options.swift
+++ b/test/Driver/options.swift
@@ -3,11 +3,11 @@
 // STDLIB_MODULE: error: module name "Swift" is reserved for the standard library{{$}}
 
 // RUN: not %swiftc_driver -crazy-option-that-does-not-exist %s 2>&1 | %FileCheck -check-prefix=INVALID_OPTION %s
-// RUN: not %swift_driver -crazy-option-that-does-not-exist 2>&1 | %FileCheck -check-prefix=INVALID_OPTION %s
+// SWIFT_ENABLE_TENSORFLOW: REPL is disabled in tensorflow branch.
 // INVALID_OPTION: error: unknown argument: '-crazy-option-that-does-not-exist'
 
 // RUN: %swiftc_driver -assert-config Debug -### %s | %FileCheck -check-prefix=ASSERTCONFIG %s
-// RUN: %swift_driver -assert-config Debug -### | %FileCheck -check-prefix=ASSERTCONFIG %s
+// SWIFT_ENABLE_TENSORFLOW: REPL is disabled in tensorflow branch.
 // ASSERTCONFIG: -assert-config Debug
 
 // RUN: %swiftc_driver -assert-config Release -### %s | %FileCheck -check-prefix=ASSERTCONFIG_RELEASE %s
@@ -29,26 +29,7 @@
 // RUN: not %swiftc_driver -import-objc-header fake.h -emit-module-interface-path fake.swiftinterface %s 2>&1 | %FileCheck -check-prefix=BRIDGING_HEADER_SWIFTINTERFACE %s
 // BRIDGING_HEADER_SWIFTINTERFACE: error: using bridging headers with module interfaces is unsupported
 
-// RUN: %swift_driver -### | %FileCheck -check-prefix=DEFAULT_REPL %s
-// DEFAULT_REPL: -repl
-// RUN: not %swiftc_driver 2>&1 | %FileCheck -check-prefix=DEFAULT_EXEC_ERR  %s
-// DEFAULT_EXEC_ERR: error: no input files
-// RUN: %swiftc_driver %s -### 2>&1 | %FileCheck -check-prefix=DEFAULT_EXEC  %s
-// DEFAULT_EXEC: -c
-// DEFAULT_EXEC: {{ld|clang\+\+}}
-
-// RUN: %swift_driver -repl -### 2>&1 | %FileCheck -check-prefix=REPL %s
-// REPL: warning: unnecessary option '-repl'
-
-// RUN: %swift_driver -lldb-repl -### 2>&1 | %FileCheck -check-prefix=LLDB_REPL %s
-// LLDB_REPL-NOT: warning
-// LLDB_REPL: lldb
-// LLDB_REPL-NOT: warning
-
-// RUN: %swift_driver -deprecated-integrated-repl -### 2>&1 | %FileCheck -check-prefix=INTEGRATED_REPL %s
-// INTEGRATED_REPL-NOT: warning
-// INTEGRATED_REPL: -repl
-// INTEGRATED_REPL-NOT: warning
+// SWIFT_ENABLE_TENSORFLOW: REPL is disabled in tensorflow branch.
 
 // RUN: %swift_driver -### %s | %FileCheck -check-prefix=DEFAULT_I %s
 // DEFAULT_I: -interpret

--- a/test/Driver/sdk-apple.swift
+++ b/test/Driver/sdk-apple.swift
@@ -1,3 +1,6 @@
+// SWIFT_ENABLE_TENSORFLOW: REPL is disabled in tensorflow branch.
+// UNSUPPORTED: tensorflow
+
 // XFAIL: freebsd, linux, windows
 
 // Test SDK detection for immediate mode.

--- a/test/Driver/sdk.swift
+++ b/test/Driver/sdk.swift
@@ -4,9 +4,7 @@
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-windows-msvc -g -sdk %S/../Inputs/clang-importer-sdk %s 2>&1 | %FileCheck %s --check-prefix WINDOWS
 // RUN: %swiftc_driver -driver-print-jobs -target wasm32-unknown-wasi         -g -sdk %S/../Inputs/clang-importer-sdk %s 2>&1 | %FileCheck %s --check-prefix WASI
 
-// RUN: env SDKROOT=%S/../Inputs/clang-importer-sdk %swiftc_driver_plain -target x86_64-apple-macosx10.9  -g -driver-print-jobs %s 2>&1 | %FileCheck %s --check-prefix OSX
-// RUN: env SDKROOT=%S/../Inputs/clang-importer-sdk %swiftc_driver_plain -target x86_64-unknown-linux-gnu -g -driver-print-jobs %s 2>&1 | %FileCheck %s --check-prefix LINUX
-// RUN: env SDKROOT=%S/../Inputs/clang-importer-sdk %swiftc_driver_plain -target x86_64-unknown-freebsd   -g -driver-print-jobs %s 2>&1 | %FileCheck %s --check-prefix FREEBSD
+// SWIFT_ENABLE_TENSORFLOW: REPL is disabled in tensorflow branch.
 
 // OSX-NOT: warning: no such SDK:
 // OSX: bin{{/|\\\\}}swift
@@ -53,12 +51,7 @@
 // WASI: -sdk {{.*}}/Inputs/clang-importer-sdk
 // WASI: {{-syslibroot|--sysroot}} {{.*}}/Inputs/clang-importer-sdk
 
-// RUN: %swift_driver -driver-print-jobs -repl -sdk %S/Inputs/nonexistent-sdk 2>&1 | %FileCheck %s --check-prefix=SDKWARNING
-// RUN: %swift_driver -driver-print-jobs -sdk %S/Inputs/nonexistent-sdk 2>&1 | %FileCheck %s --check-prefix=SDKWARNING
-// RUN: env SDKROOT=%S/Inputs/nonexistent-sdk %swift_driver_plain -driver-print-jobs -repl 2>&1 | %FileCheck %s --check-prefix=SDKWARNING
-
-// SDKWARNING: warning: no such SDK: '{{.*}}/Inputs/nonexistent-sdk'
-// SDKWARNING: -sdk {{.*}}/Inputs/nonexistent-sdk
+// SWIFT_ENABLE_TENSORFLOW: REPL is disabled in tensorflow branch.
 
 // RUN: %swiftc_driver -driver-print-jobs -typecheck -sdk %S/../Inputs/clang-importer-sdk -module-cache-path /path/to/cache %s 2>&1 | %FileCheck %s --check-prefix=CACHE-PATH
 

--- a/test/Driver/subcommands.swift
+++ b/test/Driver/subcommands.swift
@@ -1,3 +1,6 @@
+// SWIFT_ENABLE_TENSORFLOW: REPL is disabled in tensorflow branch.
+// UNSUPPORTED: tensorflow
+
 // REQUIRES: shell
 // Check that 'swift' and 'swift repl' invoke the REPL.
 

--- a/test/Driver/working-directory.swift
+++ b/test/Driver/working-directory.swift
@@ -10,10 +10,7 @@
 // -working-directory=
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory=%S/Inputs -c %/S/Inputs/main.swift | %FileCheck %s -check-prefix=INPUT
 
-// In another driver mode.
-// RUN: cd %t && %swift_driver -driver-print-jobs -working-directory %/S/Inputs -F. | %FileCheck %s -check-prefix=REPL
-// RUN: cd %t && %swift_driver -driver-print-jobs -deprecated-integrated-repl -working-directory %/S/Inputs -F. | %FileCheck %s -check-prefix=REPL
-// REPL: -F {{\\?"?}}SOURCE_DIR/test/Driver/Inputs{{(\\\\(\\\\)?)|/}}.
+// SWIFT_ENABLE_TENSORFLOW: REPL is disabled in tensorflow branch.
 
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory=%/S/Inputs -c -module-name m main.swift lib.swift | %FileCheck %s -check-prefix=MULTI_INPUT
 // MULTI_INPUT: SOURCE_DIR/test/Driver/Inputs{{/|\\\\}}main.swift


### PR DESCRIPTION
(This is a repeat of https://github.com/apple/swift/pull/31358, but with tests this time.)

Disables the integrated and LLDB REPLs in the S4TF toolchain.

When a user tries to run the REPL, it does this:
```
$ swift
<unknown>:0: error: The Swift for TensorFlow toolchain does not support the Swift REPL. Colab (https://github.com/tensorflow/swift/blob/master/Usage.md#colaboratory) and Swift-Jupyter (https://github.com/google/swift-jupyter) are supported alternatives.
```

Determined users who need to use the REPL despite the fact that we don't support it can still get the REPLs by invoking `swift -frontend -repl` (for the integrated REPL) or `lldb -r` (for the LLDB REPL).

Justification: The LLDB REPL keeps breaking in our toolchain, and we would rather spend effort maintaining Swift-in-Colab and Swift-Jupyer.

Corresponding documentation update at https://github.com/tensorflow/swift/pull/432.