### PR TITLE
IRGen: Fix alignment of global variable buffer for non-fixed types

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2224,7 +2224,7 @@ Address IRGenModule::getAddrOfSILGlobalVariable(SILGlobalVariable *var,
     inFixedBuffer = true;
     storageType = getFixedBufferTy();
     fixedSize = Size(DataLayout.getTypeAllocSize(storageType));
-    fixedAlignment = Alignment(DataLayout.getABITypeAlignment(storageType));
+    fixedAlignment = getFixedBufferAlignment(*this);
   }
 
   // Check whether we've created the global variable already.

--- a/test/IRGen/global_resilience.sil
+++ b/test/IRGen/global_resilience.sil
@@ -22,7 +22,7 @@ public struct SmallResilientStruct {
   let x: Int32 = 0
 }
 
-// CHECK: @smallGlobal = {{(dllexport )?}}{{(protected )?}}global [[BUFFER:\[(12|24) x i8\]]] zeroinitializer
+// CHECK: @smallGlobal = {{(dllexport )?}}{{(protected )?}}global [[BUFFER:\[(12|24) x i8\]]] zeroinitializer{{.*}}align {{(8|4)}}
 sil_global [let] @smallGlobal : $SmallResilientStruct
 
 //
@@ -77,7 +77,7 @@ bb0:
 sil @testLargeGlobal : $@convention(thin) () -> () {
 bb0:
   // CHECK: [[ALLOC:%.*]] = call noalias i8* @swift_slowAlloc([[INT]] 32, [[INT]] 7)
-  // CHECK: store i8* [[ALLOC]], i8** bitcast ([[BUFFER]]* @largeGlobal to i8**), align 1
+  // CHECK: store i8* [[ALLOC]], i8** bitcast ([[BUFFER]]* @largeGlobal to i8**), align {{(8|4)}}
   alloc_global @largeGlobal
 
   // CHECK: [[VALUE:%.*]] = load %T17global_resilience20LargeResilientStructV*, %T17global_resilience20LargeResilientStructV** bitcast ([[BUFFER]]* @largeGlobal to %T17global_resilience20LargeResilientStructV**)


### PR DESCRIPTION
It needs to have the getFixedBufferAlignment because that is the value we use to determine whether the type will be stored inline in the buffer or outline in an allocated buffer.

rdar://62443743