### PR TITLE
[ownership] Cleanup how we emit filecheck-compatible verification errors for the ownership verifier.

### DIFF
--- a/include/swift/SIL/LinearLifetimeChecker.h
+++ b/include/swift/SIL/LinearLifetimeChecker.h
@@ -48,6 +48,7 @@ class LinearLifetimeChecker {
 public:
   class Error;
   struct ErrorBehaviorKind;
+  class ErrorBuilder;
 
 private:
   friend class SILOwnershipVerifier;
@@ -97,16 +98,16 @@ private:
   /// to leak. Can be used to insert missing destroys.
   Error checkValue(SILValue value, ArrayRef<Operand *> consumingUses,
                    ArrayRef<Operand *> nonConsumingUses,
-                   ErrorBehaviorKind errorBehavior);
+                   ErrorBuilder &errorBuilder);
 
   Error checkValue(SILValue value, ArrayRef<Operand *> consumingUses,
                    ArrayRef<Operand *> nonConsumingUses,
-                   ErrorBehaviorKind errorBehavior,
+                   ErrorBuilder &errorBuilder,
                    function_ref<void(SILBasicBlock *)> leakingBlockCallback);
 
   Error checkValueImpl(
       SILValue value, ArrayRef<Operand *> consumingUses,
-      ArrayRef<Operand *> nonConsumingUses, ErrorBehaviorKind errorBehavior,
+      ArrayRef<Operand *> nonConsumingUses, ErrorBuilder &errorBuilder,
       Optional<function_ref<void(SILBasicBlock *)>> leakingBlockCallback);
 };
 

--- a/lib/SIL/Verifier/LinearLifetimeChecker.cpp
+++ b/lib/SIL/Verifier/LinearLifetimeChecker.cpp
@@ -32,6 +32,8 @@
 
 using namespace swift;
 
+unsigned LinearLifetimeChecker::ErrorBuilder::errorMessageCount = 0;
+
 //===----------------------------------------------------------------------===//
 //                                Declarations
 //===----------------------------------------------------------------------===//
@@ -54,9 +56,12 @@ struct State {
   //    defining block.
   SILInstruction *beginInst;
 
-  /// The result error object that use to signal either that no errors were
-  /// found or if errors are found the specific type of error that was found.
-  LinearLifetimeChecker::Error error;
+  /// A builder object that we use to build a LinearLifetimeChecker::Error
+  /// object that describes exhaustively the set of errors that we encountered.
+  ///
+  /// It also handles any asserts/messages that need to be emitted if we are
+  /// supposed to fail hard.
+  LinearLifetimeChecker::ErrorBuilder errorBuilder;
 
   /// The blocks that we have already visited.
   SmallPtrSetImpl<SILBasicBlock *> &visitedBlocks;
@@ -87,20 +92,20 @@ struct State {
   SmallSetVector<SILBasicBlock *, 8> successorBlocksThatMustBeVisited;
 
   State(SILValue value, SmallPtrSetImpl<SILBasicBlock *> &visitedBlocks,
-        LinearLifetimeChecker::ErrorBehaviorKind errorBehavior,
+        LinearLifetimeChecker::ErrorBuilder errorBuilder,
         Optional<function_ref<void(SILBasicBlock *)>> leakingBlockCallback,
         ArrayRef<Operand *> consumingUses, ArrayRef<Operand *> nonConsumingUses)
       : value(value), beginInst(value->getDefiningInsertionPoint()),
-        error(errorBehavior), visitedBlocks(visitedBlocks),
+        errorBuilder(errorBuilder), visitedBlocks(visitedBlocks),
         leakingBlockCallback(leakingBlockCallback),
         consumingUses(consumingUses), nonConsumingUses(nonConsumingUses) {}
 
   State(SILBasicBlock *beginBlock,
         SmallPtrSetImpl<SILBasicBlock *> &visitedBlocks,
-        LinearLifetimeChecker::ErrorBehaviorKind errorBehavior,
+        LinearLifetimeChecker::ErrorBuilder &errorBuilder,
         Optional<function_ref<void(SILBasicBlock *)>> leakingBlockCallback,
         ArrayRef<Operand *> consumingUses, ArrayRef<Operand *> nonConsumingUses)
-      : value(), beginInst(&*beginBlock->begin()), error(errorBehavior),
+      : value(), beginInst(&*beginBlock->begin()), errorBuilder(errorBuilder),
         visitedBlocks(visitedBlocks),
         leakingBlockCallback(leakingBlockCallback),
         consumingUses(consumingUses), nonConsumingUses(nonConsumingUses) {}
@@ -176,10 +181,9 @@ void State::initializeAllNonConsumingUses(
                        [&use](const SILInstruction &inst) -> bool {
                          return use->getUser() == &inst;
                        }) == userBlock->end()) {
-        error.handleUseAfterFree([&] {
-          llvm::errs() << "Function: '"
-                       << getBeginBlock()->getParent()->getName() << "'\n"
-                       << "Found use before def?!\n"
+
+        errorBuilder.handleUseAfterFree([&] {
+          llvm::errs() << "Found use before def?!\n"
                        << "Value: ";
           if (auto v = value) {
             llvm::errs() << *v;
@@ -264,10 +268,8 @@ void State::initializeConsumingUse(Operand *consumingUse,
   if (blocksWithConsumingUses.insert(userBlock).second)
     return;
 
-  error.handleOverConsume([&] {
-    llvm::errs() << "Function: '" << getBeginBlock()->getParent()->getName()
-                 << "'\n"
-                 << "Found over consume?!\n";
+  errorBuilder.handleOverConsume([&] {
+    llvm::errs() << "Found over consume?!\n";
     if (auto v = value) {
       llvm::errs() << "Value: " << *v;
     } else {
@@ -298,10 +300,8 @@ void State::checkForSameBlockUseAfterFree(Operand *consumingUse,
                    [&nonConsumingUse](const SILInstruction &i) -> bool {
                      return nonConsumingUse->getUser() == &i;
                    }) != userBlock->end()) {
-    error.handleUseAfterFree([&] {
-      llvm::errs() << "Function: '" << getBeginBlock()->getParent()->getName()
-                   << "'\n"
-                   << "Found use after free?!\n"
+    errorBuilder.handleUseAfterFree([&] {
+      llvm::errs() << "Found use after free?!\n"
                    << "Value: ";
       if (auto v = value) {
         llvm::errs() << *v;
@@ -336,10 +336,8 @@ void State::checkPredsForDoubleConsume(Operand *consumingUse,
     }
   }
 
-  error.handleOverConsume([&] {
-    llvm::errs() << "Function: '" << getBeginBlock()->getParent()->getName()
-                 << "'\n"
-                 << "Found over consume?!\n"
+  errorBuilder.handleOverConsume([&] {
+    llvm::errs() << "Found over consume?!\n"
                  << "Value: ";
     if (auto v = value) {
       llvm::errs() << *v;
@@ -368,10 +366,8 @@ void State::checkPredsForDoubleConsume(SILBasicBlock *userBlock) {
     }
   }
 
-  error.handleOverConsume([&] {
-    llvm::errs() << "Function: '" << getBeginBlock()->getParent()->getName()
-                 << "'\n"
-                 << "Found over consume?!\n"
+  errorBuilder.handleOverConsume([&] {
+    llvm::errs() << "Found over consume?!\n"
                  << "Value: ";
     if (auto v = value) {
       llvm::errs() << *v;
@@ -472,19 +468,17 @@ void State::checkDataflowEndState(DeadEndBlocks &deBlocks) {
     }
 
     // If we are supposed to error on leaks, do so now.
-    error.handleLeak([&] {
-      llvm::errs() << "Function: '" << getBeginBlock()->getParent()->getName()
-                   << "'\n"
-                   << "Error! Found a leak due to a consuming post-dominance "
+    errorBuilder.handleLeak([&] {
+      llvm::errs() << "Error! Found a leak due to a consuming post-dominance "
                       "failure!\n";
       if (auto v = value) {
         llvm::errs() << "Value: " << *value;
       } else {
         llvm::errs() << "Value: N/A\n";
       }
-      llvm::errs() << "    Post Dominating Failure Blocks:\n";
+      llvm::errs() << "Post Dominating Failure Blocks:\n";
       for (auto *succBlock : successorBlocksThatMustBeVisited) {
-        llvm::errs() << "        bb" << succBlock->getDebugID();
+        llvm::errs() << "bb" << succBlock->getDebugID();
       }
       llvm::errs() << '\n';
     });
@@ -506,10 +500,8 @@ void State::checkDataflowEndState(DeadEndBlocks &deBlocks) {
       continue;
     }
 
-    error.handleUseAfterFree([&] {
-      llvm::errs() << "Function: '" << getBeginBlock()->getParent()->getName()
-                   << "'\n"
-                   << "Found use after free due to unvisited non lifetime "
+    errorBuilder.handleUseAfterFree([&] {
+      llvm::errs() << "Found use after free due to unvisited non lifetime "
                       "ending uses?!\n"
                    << "Value: ";
       if (auto v = value) {
@@ -518,7 +510,7 @@ void State::checkDataflowEndState(DeadEndBlocks &deBlocks) {
         llvm::errs() << "N/A. \n";
       }
 
-      llvm::errs() << "    Remaining Users:\n";
+      llvm::errs() << "Remaining Users:\n";
       for (auto &pair : blocksWithNonConsumingUses) {
         llvm::errs() << "User:" << *pair.second->getUser() << "Block: bb"
                      << pair.first->getDebugID() << "\n";
@@ -534,12 +526,12 @@ void State::checkDataflowEndState(DeadEndBlocks &deBlocks) {
 
 LinearLifetimeChecker::Error LinearLifetimeChecker::checkValueImpl(
     SILValue value, ArrayRef<Operand *> consumingUses,
-    ArrayRef<Operand *> nonConsumingUses, ErrorBehaviorKind errorBehavior,
+    ArrayRef<Operand *> nonConsumingUses, ErrorBuilder &errorBuilder,
     Optional<function_ref<void(SILBasicBlock *)>> leakingBlockCallback) {
   assert((!consumingUses.empty() || !deadEndBlocks.empty()) &&
          "Must have at least one consuming user?!");
 
-  State state(value, visitedBlocks, errorBehavior, leakingBlockCallback,
+  State state(value, visitedBlocks, errorBuilder, leakingBlockCallback,
               consumingUses, nonConsumingUses);
 
   // First add our non-consuming uses and their blocks to the
@@ -575,12 +567,10 @@ LinearLifetimeChecker::Error LinearLifetimeChecker::checkValueImpl(
           return useParent != value->getParentBlock() &&
                  !deadEndBlocks.isDeadEnd(useParent);
         })) {
-      state.error.handleUseAfterFree([&] {
-        llvm::errs() << "Function: '" << value->getFunction()->getName()
-                     << "'\n"
-                     << "Found use after free due to unvisited non lifetime "
+      state.errorBuilder.handleUseAfterFree([&] {
+        llvm::errs() << "Found use after free due to unvisited non lifetime "
                         "ending uses?!\n"
-                     << "Value: " << *value << "    Remaining Users:\n";
+                     << "Value: " << *value << "Remaining Users:\n";
         for (const auto &use : nonConsumingUses) {
           llvm::errs() << "User: " << *use->getUser();
         }
@@ -588,7 +578,7 @@ LinearLifetimeChecker::Error LinearLifetimeChecker::checkValueImpl(
       });
     }
 
-    return state.error;
+    return std::move(state.errorBuilder).getFinalError();
   }
 
   // Ok, we may have multiple consuming uses. Add the user block of each of our
@@ -623,29 +613,31 @@ LinearLifetimeChecker::Error LinearLifetimeChecker::checkValueImpl(
   // ...and then check that the end state shows that we have a valid linear
   // typed value.
   state.checkDataflowEndState(deadEndBlocks);
-  return state.error;
+  return std::move(state.errorBuilder).getFinalError();
 }
 
 LinearLifetimeChecker::Error LinearLifetimeChecker::checkValue(
     SILValue value, ArrayRef<Operand *> consumingUses,
-    ArrayRef<Operand *> nonConsumingUses, ErrorBehaviorKind errorBehavior) {
-  return checkValueImpl(value, consumingUses, nonConsumingUses, errorBehavior,
+    ArrayRef<Operand *> nonConsumingUses, ErrorBuilder &errorBuilder) {
+  return checkValueImpl(value, consumingUses, nonConsumingUses, errorBuilder,
                         None);
 }
 
 LinearLifetimeChecker::Error LinearLifetimeChecker::checkValue(
     SILValue value, ArrayRef<Operand *> consumingUses,
-    ArrayRef<Operand *> nonConsumingUses, ErrorBehaviorKind errorBehavior,
+    ArrayRef<Operand *> nonConsumingUses, ErrorBuilder &errorBuilder,
     function_ref<void(SILBasicBlock *)> leakingBlocksCallback) {
-  return checkValueImpl(value, consumingUses, nonConsumingUses, errorBehavior,
+  return checkValueImpl(value, consumingUses, nonConsumingUses, errorBuilder,
                         leakingBlocksCallback);
 }
 
 bool LinearLifetimeChecker::completeConsumingUseSet(
     SILValue value, Operand *consumingUse,
     function_ref<void(SILBasicBlock::iterator)> visitor) {
+  ErrorBuilder errorBuilder(*value->getFunction(),
+                            ErrorBehaviorKind::ReturnFalse);
   auto error =
-      checkValue(value, {consumingUse}, {}, ErrorBehaviorKind::ReturnFalse,
+      checkValue(value, {consumingUse}, {}, errorBuilder,
                  [&](SILBasicBlock *block) { return visitor(block->begin()); });
 
   if (!error.getFoundError()) {
@@ -659,7 +651,8 @@ bool LinearLifetimeChecker::completeConsumingUseSet(
 bool LinearLifetimeChecker::validateLifetime(
     SILValue value, ArrayRef<Operand *> consumingUses,
     ArrayRef<Operand *> nonConsumingUses) {
-  return !checkValue(value, consumingUses, nonConsumingUses,
-                     ErrorBehaviorKind::ReturnFalse)
+  ErrorBuilder errorBuilder(*value->getFunction(),
+                            ErrorBehaviorKind::ReturnFalse);
+  return !checkValue(value, consumingUses, nonConsumingUses, errorBuilder)
               .getFoundError();
 }

--- a/lib/SIL/Verifier/LinearLifetimeCheckerPrivate.h
+++ b/lib/SIL/Verifier/LinearLifetimeCheckerPrivate.h
@@ -14,10 +14,11 @@
 #define SWIFT_SIL_LINEARLIFETIMECHECKER_PRIVATE_H
 
 #include "swift/SIL/LinearLifetimeChecker.h"
+#include "llvm/Support/ErrorHandling.h"
 
 namespace swift {
 
-struct LinearLifetimeChecker::ErrorBehaviorKind {
+struct LLVM_LIBRARY_VISIBILITY LinearLifetimeChecker::ErrorBehaviorKind {
   enum inner_t {
     Invalid = 0,
     ReturnFalse = 1,
@@ -53,14 +54,15 @@ struct LinearLifetimeChecker::ErrorBehaviorKind {
   }
 };
 
-class LinearLifetimeChecker::Error {
-  ErrorBehaviorKind errorBehavior;
+class LLVM_LIBRARY_VISIBILITY LinearLifetimeChecker::Error {
+  friend class ErrorBuilder;
+
   bool foundUseAfterFree = false;
   bool foundLeak = false;
   bool foundOverConsume = false;
 
 public:
-  Error(ErrorBehaviorKind errorBehavior) : errorBehavior(errorBehavior) {}
+  Error() {}
 
   bool getFoundError() const {
     return foundUseAfterFree || foundLeak || foundOverConsume;
@@ -71,41 +73,89 @@ public:
   bool getFoundUseAfterFree() const { return foundUseAfterFree; }
 
   bool getFoundOverConsume() const { return foundOverConsume; }
+};
 
-  void handleLeak(llvm::function_ref<void()> &&messagePrinterFunc) {
-    foundLeak = true;
+class LLVM_LIBRARY_VISIBILITY LinearLifetimeChecker::ErrorBuilder {
+  StringRef functionName;
+  ErrorBehaviorKind behavior;
+  Optional<Error> error;
 
-    if (errorBehavior.shouldPrintMessage())
+  // NOTE: This is only here so that we can emit a unique id for all errors to
+  // ease working with FileCheck.
+  static unsigned errorMessageCount;
+
+public:
+  ErrorBuilder(const SILFunction &fn,
+               LinearLifetimeChecker::ErrorBehaviorKind behavior)
+      : functionName(fn.getName()), behavior(behavior), error(Error()) {}
+
+  ErrorBuilder(const SILFunction &fn,
+               LinearLifetimeChecker::ErrorBehaviorKind::inner_t behavior)
+      : functionName(fn.getName()), behavior(behavior), error(Error()) {}
+
+  Error getFinalError() && {
+    auto result = *error;
+    error = None;
+    return result;
+  }
+
+  bool handleLeak(llvm::function_ref<void()> &&messagePrinterFunc) {
+    error->foundLeak = true;
+
+    if (behavior.shouldPrintMessage()) {
+      llvm::errs() << "Error#: " << errorMessageCount
+                   << ". Begin Error in Function: '" << functionName << "'\n";
       messagePrinterFunc();
+      llvm::errs() << "Error#: " << errorMessageCount
+                   << ". End Error in Function: '" << functionName << "'\n";
+      ++errorMessageCount;
+    }
 
-    if (errorBehavior.shouldReturnFalseOnLeak())
-      return;
+    if (behavior.shouldReturnFalseOnLeak()) {
+      return false;
+    }
 
     // We already printed out our error if we needed to, so don't pass it along.
-    handleError([]() {});
+    return handleError([]() {}, true);
   }
 
-  void handleOverConsume(llvm::function_ref<void()> &&messagePrinterFunc) {
-    foundOverConsume = true;
-    handleError(std::move(messagePrinterFunc));
+  bool handleOverConsume(llvm::function_ref<void()> &&messagePrinterFunc) {
+    error->foundOverConsume = true;
+    return handleError(std::move(messagePrinterFunc));
   }
 
-  void handleUseAfterFree(llvm::function_ref<void()> &&messagePrinterFunc) {
-    foundUseAfterFree = true;
-    handleError(std::move(messagePrinterFunc));
+  bool handleUseAfterFree(llvm::function_ref<void()> &&messagePrinterFunc) {
+    error->foundUseAfterFree = true;
+    return handleError(std::move(messagePrinterFunc));
+  }
+
+  bool
+  handleMalformedSIL(llvm::function_ref<void()> &&messagePrinterFunc) const {
+    return handleError(std::move(messagePrinterFunc));
   }
 
 private:
-  void handleError(llvm::function_ref<void()> &&messagePrinterFunc) {
-    if (errorBehavior.shouldPrintMessage())
+  bool handleError(llvm::function_ref<void()> &&messagePrinterFunc,
+                   bool quiet = false) const {
+    if (behavior.shouldPrintMessage()) {
+      if (!quiet) {
+        llvm::errs() << "Error#: " << errorMessageCount
+                     << ". Begin Error in Function: '" << functionName << "'\n";
+      }
       messagePrinterFunc();
-
-    if (errorBehavior.shouldReturnFalse()) {
-      return;
+      if (!quiet) {
+        llvm::errs() << "Error#: " << errorMessageCount
+                     << ". End Error in Function: '" << functionName << "'\n";
+        ++errorMessageCount;
+      }
     }
 
-    assert(errorBehavior.shouldAssert() && "At this point, we should assert");
-    llvm_unreachable("triggering standard assertion failure routine");
+    if (behavior.shouldReturnFalse()) {
+      return false;
+    }
+
+    llvm::errs() << "Found ownership error?!\n";
+    llvm::report_fatal_error("triggering standard assertion failure routine");
   }
 };
 

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -87,8 +87,9 @@ class SILValueOwnershipChecker {
   /// The value whose ownership we will check.
   SILValue value;
 
-  /// The action that the checker should perform on detecting an error.
-  LinearLifetimeChecker::ErrorBehaviorKind errorBehavior;
+  /// The builder that the checker uses to emit error messages, crash if asked
+  /// for, or supply back interesting info to the caller.
+  LinearLifetimeChecker::ErrorBuilder errorBuilder;
 
   /// The list of lifetime ending users that we found. Only valid if check is
   /// successful.
@@ -112,10 +113,10 @@ class SILValueOwnershipChecker {
 public:
   SILValueOwnershipChecker(
       DeadEndBlocks &deadEndBlocks, SILValue value,
-      LinearLifetimeChecker::ErrorBehaviorKind errorBehavior,
+      LinearLifetimeChecker::ErrorBuilder errorBuilder,
       llvm::SmallPtrSetImpl<SILBasicBlock *> &visitedBlocks)
       : result(), deadEndBlocks(deadEndBlocks), value(value),
-        errorBehavior(errorBehavior), visitedBlocks(visitedBlocks) {
+        errorBuilder(errorBuilder), visitedBlocks(visitedBlocks) {
     assert(value && "Can not initialize a checker with an empty SILValue");
   }
 
@@ -125,20 +126,7 @@ public:
 
   bool check();
 
-  /// Depending on our initialization, either return false or call Func and
-  /// throw an error.
-  bool handleError(function_ref<void()> &&messagePrinterFunc) const {
-    if (errorBehavior.shouldPrintMessage()) {
-      messagePrinterFunc();
-    }
-
-    if (errorBehavior.shouldReturnFalse()) {
-      return false;
-    }
-
-    assert(errorBehavior.shouldAssert() && "At this point, we should assert");
-    llvm_unreachable("triggering standard assertion failure routine");
-  }
+  StringRef getFunctionName() const { return value->getFunction()->getName(); }
 
 private:
   bool checkUses();
@@ -190,8 +178,8 @@ bool SILValueOwnershipChecker::check() {
   llvm::copy(implicitRegularUsers, std::back_inserter(allRegularUsers));
 
   LinearLifetimeChecker checker(visitedBlocks, deadEndBlocks);
-  auto linearLifetimeResult = checker.checkValue(
-      value, allLifetimeEndingUsers, allRegularUsers, errorBehavior);
+  auto linearLifetimeResult = checker.checkValue(value, allLifetimeEndingUsers,
+                                                 allRegularUsers, errorBuilder);
   result = !linearLifetimeResult.getFoundError();
 
   return result.getValue();
@@ -216,9 +204,8 @@ bool SILValueOwnershipChecker::isCompatibleDefUse(
   // conflicting answer so the kind map that was returned is the empty
   // map. Put out a more specific error here.
   if (!opOwnershipKindMap.data.any()) {
-    handleError([&]() {
-      llvm::errs() << "Function: '" << user->getFunction()->getName() << "'\n"
-                   << "Ill-formed SIL! Unable to compute ownership kind "
+    errorBuilder.handleMalformedSIL([&]() {
+      llvm::errs() << "Ill-formed SIL! Unable to compute ownership kind "
                       "map for user?!\n"
                    << "For terminator users, check that successors have "
                       "compatible ownership kinds.\n"
@@ -229,9 +216,8 @@ bool SILValueOwnershipChecker::isCompatibleDefUse(
     return false;
   }
 
-  handleError([&]() {
-    llvm::errs() << "Function: '" << user->getFunction()->getName() << "'\n"
-                 << "Have operand with incompatible ownership?!\n"
+  errorBuilder.handleMalformedSIL([&]() {
+    llvm::errs() << "Have operand with incompatible ownership?!\n"
                  << "Value: " << op->get() << "User: " << *user
                  << "Operand Number: " << op->getOperandNumber() << '\n'
                  << "Conv: " << ownershipKind << '\n'
@@ -266,10 +252,8 @@ bool SILValueOwnershipChecker::discoverBorrowOperandImplicitRegularUsers(
         [&](Operand *op) {
           if (auto subSub = BorrowingOperand::get(op)) {
             if (!visitedValue.insert(op).second) {
-              handleError([&] {
+              errorBuilder.handleMalformedSIL([&] {
                 llvm::errs()
-                    << "Function: " << op->getUser()->getFunction()->getName()
-                    << "\n"
                     << "Implicit Regular User Guaranteed Phi Cycle!\n"
                     << "User: " << *op->getUser()
                     << "Initial: " << initialScopedOperand << "\n";
@@ -383,9 +367,8 @@ bool SILValueOwnershipChecker::
     }
 
     // We were unable to recognize this user, so return true that we failed.
-    handleError([&] {
+    errorBuilder.handleMalformedSIL([&] {
       llvm::errs()
-          << "Function: " << op->getUser()->getFunction()->getName() << "\n"
           << "Could not recognize address user of interior pointer operand!\n"
           << "Interior Pointer Operand: "
           << *interiorPointerOperand.operand->getUser()
@@ -428,14 +411,14 @@ bool SILValueOwnershipChecker::gatherNonGuaranteedUsers(
     // First do a quick check if we have a consuming use. If so, stash the value
     // and continue.
     if (op->isConsumingUse()) {
-      LLVM_DEBUG(llvm::dbgs() << "        Lifetime Ending User: " << *user);
+      LLVM_DEBUG(llvm::dbgs() << "Lifetime Ending User: " << *user);
       lifetimeEndingUsers.push_back(op);
       continue;
     }
 
     // Otherwise, we have a non lifetime ending user. Add it to our non lifetime
     // ending user list.
-    LLVM_DEBUG(llvm::dbgs() << "        Regular User: " << *user);
+    LLVM_DEBUG(llvm::dbgs() << "Regular User: " << *user);
     nonLifetimeEndingUsers.push_back(op);
 
     // If we do not have an owned value at this point, continue, we do not have
@@ -528,10 +511,8 @@ bool SILValueOwnershipChecker::gatherUsers(
         // an end_borrow on a forwarded value which is not supported in any
         // case, so emit an error.
         if (op->get() != value) {
-          handleError([&] {
-            llvm::errs() << "Function: " << value->getFunction()->getName()
-                         << "\n"
-                         << "Invalid End Borrow!\n"
+          errorBuilder.handleMalformedSIL([&] {
+            llvm::errs() << "Invalid End Borrow!\n"
                          << "Original Value: " << value
                          << "End Borrow: " << *op->getUser() << "\n";
           });
@@ -541,7 +522,7 @@ bool SILValueOwnershipChecker::gatherUsers(
 
         // Otherwise, track this as a lifetime ending use of our underlying
         // value and continue.
-        LLVM_DEBUG(llvm::dbgs() << "        Lifetime Ending User: " << *user);
+        LLVM_DEBUG(llvm::dbgs() << "Lifetime Ending User: " << *user);
         lifetimeEndingUsers.push_back(op);
         continue;
       }
@@ -565,14 +546,14 @@ bool SILValueOwnershipChecker::gatherUsers(
       }
 
       // Finally add the op to the non lifetime ending user list.
-      LLVM_DEBUG(llvm::dbgs() << "        Regular User: " << *user);
+      LLVM_DEBUG(llvm::dbgs() << "Regular User: " << *user);
       nonLifetimeEndingUsers.push_back(op);
       continue;
     }
 
     // At this point since we have a forwarded subobject, we know this is a non
     // lifetime ending user.
-    LLVM_DEBUG(llvm::dbgs() << "        Regular User: " << *user);
+    LLVM_DEBUG(llvm::dbgs() << "Regular User: " << *user);
     nonLifetimeEndingUsers.push_back(op);
 
     // At this point, we know that we must have a forwarded subobject. Since
@@ -665,9 +646,8 @@ bool SILValueOwnershipChecker::checkFunctionArgWithoutLifetimeEndingUses(
   if (deadEndBlocks.isDeadEnd(arg->getParent()))
     return true;
 
-  return !handleError([&] {
-    llvm::errs() << "Function: '" << arg->getFunction()->getName() << "'\n"
-                 << "    Owned function parameter without life ending uses!\n"
+  return !errorBuilder.handleMalformedSIL([&] {
+    llvm::errs() << "Owned function parameter without life ending uses!\n"
                  << "Value: " << *arg << '\n';
   });
 }
@@ -686,14 +666,13 @@ bool SILValueOwnershipChecker::checkYieldWithoutLifetimeEndingUses(
   if (deadEndBlocks.isDeadEnd(yield->getParent()->getParent()))
     return true;
 
-  return !handleError([&] {
-    llvm::errs() << "Function: '" << yield->getFunction()->getName() << "'\n"
-                 << "    Owned yield without life ending uses!\n"
+  return !errorBuilder.handleMalformedSIL([&] {
+    llvm::errs() << "Owned yield without life ending uses!\n"
                  << "Value: " << *yield << '\n';
   });
 }
 bool SILValueOwnershipChecker::checkValueWithoutLifetimeEndingUses() {
-  LLVM_DEBUG(llvm::dbgs() << "    No lifetime ending users?! Bailing early.\n");
+  LLVM_DEBUG(llvm::dbgs() << "No lifetime ending users?! Bailing early.\n");
   if (auto *arg = dyn_cast<SILFunctionArgument>(value)) {
     if (checkFunctionArgWithoutLifetimeEndingUses(arg)) {
       return true;
@@ -719,18 +698,15 @@ bool SILValueOwnershipChecker::checkValueWithoutLifetimeEndingUses() {
 
   if (auto *parentBlock = value->getParentBlock()) {
     if (deadEndBlocks.isDeadEnd(parentBlock)) {
-      LLVM_DEBUG(llvm::dbgs() << "    Ignoring transitively unreachable value "
+      LLVM_DEBUG(llvm::dbgs() << "Ignoring transitively unreachable value "
                               << "without users!\n"
-                              << "    Function: '"
-                              << value->getFunction()->getName() << "'\n"
                               << "    Value: " << *value << '\n');
       return true;
     }
   }
 
   if (!isValueAddressOrTrivial(value)) {
-    return !handleError([&] {
-      llvm::errs() << "Function: '" << value->getFunction()->getName() << "'\n";
+    return !errorBuilder.handleMalformedSIL([&] {
       if (value.getOwnershipKind() == ValueOwnershipKind::Owned) {
         llvm::errs() << "Error! Found a leaked owned value that was never "
                         "consumed.\n";
@@ -752,12 +728,11 @@ bool SILValueOwnershipChecker::isGuaranteedFunctionArgWithLifetimeEndingUses(
   if (arg->getOwnershipKind() != ValueOwnershipKind::Guaranteed)
     return true;
 
-  return handleError([&] {
-    llvm::errs() << "    Function: '" << arg->getFunction()->getName() << "'\n"
-                 << "    Guaranteed function parameter with life ending uses!\n"
-                 << "    Value: " << *arg;
+  return errorBuilder.handleMalformedSIL([&] {
+    llvm::errs() << "Guaranteed function parameter with life ending uses!\n"
+                 << "Value: " << *arg;
     for (const auto *use : lifetimeEndingUsers) {
-      llvm::errs() << "    Lifetime Ending User: " << *use->getUser();
+      llvm::errs() << "Lifetime Ending User: " << *use->getUser();
     }
     llvm::errs() << '\n';
   });
@@ -766,13 +741,11 @@ bool SILValueOwnershipChecker::isGuaranteedFunctionArgWithLifetimeEndingUses(
 bool SILValueOwnershipChecker::isSubobjectProjectionWithLifetimeEndingUses(
     SILValue value,
     const llvm::SmallVectorImpl<Operand *> &lifetimeEndingUsers) const {
-  return handleError([&] {
-    llvm::errs() << "    Function: '" << value->getFunction()->getName()
-                 << "'\n"
-                 << "    Subobject projection with life ending uses!\n"
-                 << "    Value: " << *value;
+  return errorBuilder.handleMalformedSIL([&] {
+    llvm::errs() << "Subobject projection with life ending uses!\n"
+                 << "Value: " << *value;
     for (const auto *use : lifetimeEndingUsers) {
-      llvm::errs() << "    Lifetime Ending User: " << *use->getUser();
+      llvm::errs() << "Lifetime Ending User: " << *use->getUser();
     }
     llvm::errs() << '\n';
   });
@@ -878,11 +851,13 @@ void SILInstruction::verifyOperandOwnership() const {
   if (isa<TermInst>(this))
     return;
 
-  LinearLifetimeChecker::ErrorBehaviorKind errorBehavior;
+  using BehaviorKind = LinearLifetimeChecker::ErrorBehaviorKind;
+  Optional<LinearLifetimeChecker::ErrorBuilder> errorBuilder;
   if (IsSILOwnershipVerifierTestingEnabled) {
-    errorBehavior = decltype(errorBehavior)::PrintMessageAndReturnFalse;
+    errorBuilder.emplace(*getFunction(),
+                         BehaviorKind::PrintMessageAndReturnFalse);
   } else {
-    errorBehavior = decltype(errorBehavior)::PrintMessageAndAssert;
+    errorBuilder.emplace(*getFunction(), BehaviorKind::PrintMessageAndAssert);
   }
   for (const Operand &op : getAllOperands()) {
     // Skip type dependence operands.
@@ -895,7 +870,7 @@ void SILInstruction::verifyOperandOwnership() const {
     if (operandOwnershipKindMap.canAcceptKind(valueOwnershipKind))
       continue;
 
-    if (errorBehavior.shouldPrintMessage()) {
+    errorBuilder->handleMalformedSIL([&] {
       llvm::errs() << "Found an operand with a value that is not compatible "
                       "with the operand's operand ownership kind map.\n";
       llvm::errs() << "Value: " << opValue;
@@ -903,14 +878,7 @@ void SILInstruction::verifyOperandOwnership() const {
       llvm::errs() << "Instruction:\n";
       printInContext(llvm::errs());
       llvm::errs() << "Operand Ownership Kind Map: " << operandOwnershipKindMap;
-    }
-
-    if (errorBehavior.shouldReturnFalse())
-      continue;
-
-    assert(errorBehavior.shouldAssert() &&
-           "At this point, we are expected to assert");
-    llvm_unreachable("triggering standard assertion failure routine");
+    });
   }
 }
 
@@ -953,22 +921,21 @@ void SILValue::verifyOwnership(DeadEndBlocks *deadEndBlocks) const {
   if (!f->hasOwnership() || !f->shouldVerifyOwnership())
     return;
 
-  LinearLifetimeChecker::ErrorBehaviorKind errorBehavior;
+  using BehaviorKind = LinearLifetimeChecker::ErrorBehaviorKind;
+  Optional<LinearLifetimeChecker::ErrorBuilder> errorBuilder;
   if (IsSILOwnershipVerifierTestingEnabled) {
-    errorBehavior = decltype(errorBehavior)::PrintMessageAndReturnFalse;
+    errorBuilder.emplace(*f, BehaviorKind::PrintMessageAndReturnFalse);
   } else {
-    errorBehavior = decltype(errorBehavior)::PrintMessageAndAssert;
+    errorBuilder.emplace(*f, BehaviorKind::PrintMessageAndAssert);
   }
 
   SmallPtrSet<SILBasicBlock *, 32> liveBlocks;
   if (deadEndBlocks) {
-    SILValueOwnershipChecker(*deadEndBlocks, *this, errorBehavior,
-                             liveBlocks)
+    SILValueOwnershipChecker(*deadEndBlocks, *this, *errorBuilder, liveBlocks)
         .check();
   } else {
     DeadEndBlocks deadEndBlocks(f);
-    SILValueOwnershipChecker(deadEndBlocks, *this, errorBehavior,
-                             liveBlocks)
+    SILValueOwnershipChecker(deadEndBlocks, *this, *errorBuilder, liveBlocks)
         .check();
   }
 }

--- a/test/SIL/ownership-verifier/arguments.sil
+++ b/test/SIL/ownership-verifier/arguments.sil
@@ -21,11 +21,16 @@ struct NativeObjectPair {
 // Tests //
 ///////////
 
-// CHECK-LABEL: Function: 'no_end_borrow_error'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'no_end_borrow_error'
+// CHECK: Guaranteed function parameter with life ending uses!
+// CHECK: Value: %0 = argument of bb0 : $Builtin.NativeObject
+// CHECK: Lifetime Ending User:   br bb1(%0 : $Builtin.NativeObject)
+// CHECK: Error#: 0. End Error in Function: 'no_end_borrow_error'
+//
+// CHECK-LABEL: Error#: 1. Begin Error in Function: 'no_end_borrow_error'
 // CHECK: Non trivial values, non address values, and non guaranteed function args must have at least one lifetime ending use?!
 // CHECK: Value: %2 = argument of bb1 : $Builtin.NativeObject
-//
-// TODO: Better error message here.
+// CHECK: Error#: 1. End Error in Function: 'no_end_borrow_error'
 sil [ossa] @no_end_borrow_error : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   br bb1(%0 : $Builtin.NativeObject)
@@ -35,16 +40,18 @@ bb1(%1 : @guaranteed $Builtin.NativeObject):
   return %9999 : $()
 }
 
-// CHECK-LABEL: Function: 'leak_along_path'
-// CHECK-NEXT: Guaranteed function parameter with life ending uses!
-// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject
-// CHECK-NEXT: Lifetime Ending User:   br bb1(%0 : $Builtin.NativeObject)
+// CHECK-LABEL: Error#: 2. Begin Error in Function: 'leak_along_path'
+// CHECK: Guaranteed function parameter with life ending uses!
+// CHECK: Value: %0 = argument of bb0 : $Builtin.NativeObject
+// CHECK: Lifetime Ending User:   br bb1(%0 : $Builtin.NativeObject)
+// CHECK: Error#: 2. End Error in Function: 'leak_along_path'
 //
-// CHECK-LABEL: Function: 'leak_along_path'
-// CHECK-NEXT: Error! Found a leak due to a consuming post-dominance failure!
-// CHECK-NEXT:     Value: %2 = argument of bb1 : $Builtin.NativeObject
-// CHECK-NEXT:     Post Dominating Failure Blocks:
-// CHECK-NEXT:         bb3
+// CHECK-LABEL: Error#: 3. Begin Error in Function: 'leak_along_path'
+// CHECK: Error! Found a leak due to a consuming post-dominance failure!
+// CHECK: Value: %2 = argument of bb1 : $Builtin.NativeObject
+// CHECK: Post Dominating Failure Blocks:
+// CHECK: bb3
+// CHECK: Error#: 3. End Error in Function: 'leak_along_path'
 sil [ossa] @leak_along_path : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   br bb1(%0 : $Builtin.NativeObject)
@@ -61,12 +68,12 @@ bb3:
   return %9999 : $()
 }
 
-// CHECK-NOT: Guaranteed function parameter with life ending uses!
-// CHECK-LABEL: Function: 'leak_along_path_2'
-// CHECK-NEXT: Error! Found a leak due to a consuming post-dominance failure!
-// CHECK-NEXT:     Value: %3 = argument of bb1 : $Builtin.NativeObject
-// CHECK-NEXT:     Post Dominating Failure Blocks:
-// CHECK-NEXT:         bb3
+// CHECK-LABEL: Error#: 4. Begin Error in Function: 'leak_along_path_2'
+// CHECK: Error! Found a leak due to a consuming post-dominance failure!
+// CHECK: Value: %3 = argument of bb1 : $Builtin.NativeObject
+// CHECK: Post Dominating Failure Blocks:
+// CHECK: bb3
+// CHECK: Error#: 4. End Error in Function: 'leak_along_path_2'
 sil [ossa] @leak_along_path_2 : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -87,21 +94,27 @@ bb3:
 // Make sure that we only flag the subargument leak and not the parent
 // argument. Also check for over consuming due to phi nodes.
 //
-// CHECK-LABEL: Function: 'leak_along_subarg_path'
-// CHECK-NEXT: Guaranteed function parameter with life ending uses!
-// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject
-// CHECK-NEXT: Lifetime Ending User:   br bb1(%0 : $Builtin.NativeObject)
+// CHECK-LABEL: Error#: 5. Begin Error in Function: 'leak_along_subarg_path'
+// CHECK: Guaranteed function parameter with life ending uses!
+// CHECK: Value: %0 = argument of bb0 : $Builtin.NativeObject
+// CHECK: Lifetime Ending User:   br bb1(%0 : $Builtin.NativeObject)
+// CHECK: Error#: 5. End Error in Function: 'leak_along_subarg_path'
 //
-// CHECK-LABEL: Function: 'leak_along_subarg_path'
-// CHECK-NEXT: Found over consume?!
-// CHECK-NEXT: Value: %2 = argument of bb1 : $Builtin.NativeObject
-// CHECK-NEXT: Block: bb2
+// CHECK-LABEL: Error#: 6. Begin Error in Function: 'leak_along_subarg_path'
+// CHECK: Found over consume?!
+// CHECK: Value: %2 = argument of bb1 : $Builtin.NativeObject
+// CHECK: Block: bb2
+// CHECK: Consuming Users:
+// CHECK:   br bb3(%2 : $Builtin.NativeObject)
+// CHECK:   end_borrow %2 : $Builtin.NativeObject
+// CHECK: Error#: 6. End Error in Function: 'leak_along_subarg_path'
 //
-// CHECK-LABEL: Function: 'leak_along_subarg_path'
-// CHECK-NEXT: Error! Found a leak due to a consuming post-dominance failure!
-// CHECK-NEXT:     Value: %5 = argument of bb3 : $Builtin.NativeObject
-// CHECK-NEXT:     Post Dominating Failure Blocks:
-// CHECK-NEXT:         bb5
+// CHECK-LABEL: Error#: 7. Begin Error in Function: 'leak_along_subarg_path'
+// CHECK: Error! Found a leak due to a consuming post-dominance failure!
+// CHECK: Value: %5 = argument of bb3 : $Builtin.NativeObject
+// CHECK: Post Dominating Failure Blocks:
+// CHECK: bb5
+// CHECK: Error#: 7. End Error in Function: 'leak_along_subarg_path'
 sil [ossa] @leak_along_subarg_path : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   br bb1(%0 : $Builtin.NativeObject)
@@ -125,12 +138,12 @@ bb5:
   return %9999 : $()
 }
 
-// CHECK-LABEL: Function: 'leak_along_subarg_path_2'
-// CHECK-NEXT: Error! Found a leak due to a consuming post-dominance failure!
-// CHECK-NEXT: Value: %7 = argument of bb3 : $Builtin.NativeObject      // user: %9
-// CHECK-NEXT:     Post Dominating Failure Blocks:
-// CHECK-NEXT:         bb5
-// CHECK-NOT: Function: 'leak_along_subarg_path_2'
+// CHECK-LABEL: Error#: 8. Begin Error in Function: 'leak_along_subarg_path_2'
+// CHECK: Error! Found a leak due to a consuming post-dominance failure!
+// CHECK: Value: %7 = argument of bb3 : $Builtin.NativeObject
+// CHECK: Post Dominating Failure Blocks:
+// CHECK: bb5
+// CHECK: Error#: 8. End Error in Function: 'leak_along_subarg_path_2'
 sil [ossa] @leak_along_subarg_path_2 : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -213,20 +226,23 @@ bb5:
 
 // Make sure that we only flag the end_borrow "use after free" in bb2.
 //
-// CHECK-LABEL: Function: 'bad_order'
-// CHECK-NEXT: Found use after free?!
-// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
-// CHECK-NEXT: Consuming User:   end_borrow %1 : $Builtin.NativeObject
-// CHECK-NEXT: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject
-// CHECK-NEXT: Block: bb2
+// CHECK-LABEL: Error#: 9. Begin Error in Function: 'bad_order'
+// CHECK: Found use after free?!
+// CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
+// CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
+// CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject
+// CHECK: Block: bb2
+// CHECK: Error#: 9. End Error in Function: 'bad_order'
 //
-// CHECK-LABEL: Function: 'bad_order'
-// CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
-// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
-// CHECK-NEXT:     Remaining Users:
-// CHECK-NEXT: User:  end_borrow %5 : $Builtin.NativeObject
-// CHECK-NEXT: Block: bb2
-// CHECK-NOT: Block: bb1
+// TODO: Should we really flag this twice?
+//
+// CHECK-LABEL: Error#: 10. Begin Error in Function: 'bad_order'
+// CHECK: Found use after free due to unvisited non lifetime ending uses?!
+// CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
+// CHECK: Remaining Users:
+// CHECK: User:  end_borrow %5 : $Builtin.NativeObject
+// CHECK: Block: bb2
+// CHECK: Error#: 10. End Error in Function: 'bad_order'
 sil [ossa] @bad_order : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -254,53 +270,72 @@ bb5:
   br bb4
 }
 
-// CHECK-LABEL: Function: 'bad_order_add_a_level'
-// CHECK-NEXT: Found use after free?!
-// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
-// CHECK-NEXT: Consuming User:   end_borrow %1 : $Builtin.NativeObject
-// CHECK-NEXT: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject
-// CHECK-NEXT: Block: bb2
+// CHECK-LABEL: Error#: 11. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK: Found use after free?!
+// CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
+// CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
+// CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject
+// CHECK: Block: bb2
+// CHECK: Error#: 11. End Error in Function: 'bad_order_add_a_level'
 //
-// CHECK-LABEL: Function: 'bad_order_add_a_level'
-// CHECK-NEXT: Found over consume?!
-// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
-// CHECK-NEXT: User:   end_borrow %1 : $Builtin.NativeObject
-// CHECK-NEXT: Block: bb2
+// CHECK-LABEL: Error#: 12. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK: Found over consume?!
+// CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %19, %14, %6, %3
+// CHECK: User:   end_borrow %1 : $Builtin.NativeObject           // id: %14
+// CHECK: Block: bb2
+// CHECK: Consuming Users:
+// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %6
+// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %14
+// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %19
+// CHECK: Error#: 12. End Error in Function: 'bad_order_add_a_level'
 //
-// CHECK-LABEL: Function: 'bad_order_add_a_level'
-// CHECK-NEXT: Error! Found a leak due to a consuming post-dominance failure!
-// CHECK-NEXT: Value: %1 = begin_borrow %0
-// CHECK-NEXT: Post Dominating Failure Blocks:
-// CHECK-NEXT: bb3
+// CHECK-LABEL: Error#: 13. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK: Error! Found a leak due to a consuming post-dominance failure!
+// CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %19, %14, %6, %3
+// CHECK: Post Dominating Failure Blocks:
+// CHECK: bb3
+// CHECK: Error#: 13. End Error in Function: 'bad_order_add_a_level'
 //
 // This error is a "use after free" error b/c we are accessing the argument
 // /after/ we end the parent borrow. We /could/ improve the error message here.
 //
-// CHECK-LABEL: Function: 'bad_order_add_a_level'
-// CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
-// CHECK-NEXT: Value: %1 = begin_borrow
-// CHECK-NEXT: Remaining Users:
-// CHECK-NEXT: User: end_borrow %5
-// CHECK-NEXT: Block: bb2
+// CHECK-LABEL: Error#: 14. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK: Found use after free due to unvisited non lifetime ending uses?!
+// CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %19, %14, %6, %3
+// CHECK: Remaining Users:
+// CHECK: User:  end_borrow %5 : $Builtin.NativeObject           // id: %7
+// CHECK: Block: bb2
+// CHECK: Error#: 14. End Error in Function: 'bad_order_add_a_level'
 //
-// CHECK-LABEL: Function: 'bad_order_add_a_level'
-// CHECK-NEXT: Found over consume?!
-// CHECK-NEXT: Value: %5 = argument of bb2 : $Builtin.NativeObject
-// CHECK-NEXT: User:   end_borrow %5 : $Builtin.NativeObject
-// CHECK-NEXT: Block: bb2
+// CHECK-LABEL: Error#: 15. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK: Found over consume?!
+// CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %13, %9, %7
+// CHECK: User:   end_borrow %5 : $Builtin.NativeObject           // id: %13
+// CHECK: Block: bb2
+// CHECK: Consuming Users:
+// CHECK:   end_borrow %5 : $Builtin.NativeObject           // id: %7
+// CHECK:   end_borrow %5 : $Builtin.NativeObject           // id: %13
+// CHECK: Error#: 15. End Error in Function: 'bad_order_add_a_level'
 //
-// CHECK-LABEL: Function: 'bad_order_add_a_level'
-// CHECK-NEXT: Error! Found a leak due to a consuming post-dominance failure!
+// CHECK-LABEL: Error#: 16. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK: Error! Found a leak due to a consuming post-dominance failure!
+// CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %13, %9, %7
+// CHECK: Post Dominating Failure Blocks:
+// CHECK: bb3
+// CHECK: Error#: 16. End Error in Function: 'bad_order_add_a_level'
 //
-// CHECK-LABEL: Function: 'bad_order_add_a_level'
-// CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
+// CHECK-LABEL: Error#: 17. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK: Found use after free due to unvisited non lifetime ending uses?!
+// CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %13, %9, %7
+// CHECK: Remaining Users:
+// CHECK: User:  %9 = begin_borrow %5 : $Builtin.NativeObject    // user: %10
+// CHECK: Block: bb3
+// CHECK: Error#: 17. End Error in Function: 'bad_order_add_a_level'
 //
-// CHECK-LABEL: Function: 'bad_order_add_a_level'
-// CHECK-NEXT: Non trivial values, non address values, and non guaranteed function args must have at least one lifetime ending use?!
-// CHECK-NEXT: Value: %11 = argument of bb4 : $Builtin.NativeObject
-
-// NOTE: We use the expected numbered value in the output to make it easier to
-// match the filecheck patterns with the input.
+// CHECK-LABEL: Error#: 18. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK: Non trivial values, non address values, and non guaranteed function args must have at least one lifetime ending use?!
+// CHECK: Value: %11 = argument of bb4 : $Builtin.NativeObject
+// CHECK: Error#: 18. End Error in Function: 'bad_order_add_a_level'
 sil [ossa] @bad_order_add_a_level : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -344,58 +379,86 @@ bb7:
 // improper uses.
 //
 //
-// CHECK-LABEL: Function: 'bad_order_add_a_level_2'
-// CHECK-NEXT: Found use after free?!
-// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
-// CHECK-NEXT: Consuming User:   end_borrow %1 : $Builtin.NativeObject
-// CHECK-NEXT: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject
-// CHECK-NEXT: Block: bb2
+// CHECK-LABEL: Error#: 19. Begin Error in Function: 'bad_order_add_a_level_2'
+// CHECK: Found use after free?!
+// CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %22, %16, %12, %6, %3
+// CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject           // id: %6
+// CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %7
+// CHECK: Block: bb2
+// CHECK: Error#: 19. End Error in Function: 'bad_order_add_a_level_2'
 //
-// CHECK-LABEL: Function: 'bad_order_add_a_level_2'
-// CHECK-NEXT: Found use after free?!
-// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
-// CHECK-NEXT: Consuming User:   end_borrow %1 : $Builtin.NativeObject
-// CHECK-NEXT: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject
-// CHECK-NEXT: Block: bb4
+// CHECK-LABEL: Error#: 20. Begin Error in Function: 'bad_order_add_a_level_2'
+// CHECK: Found use after free?!
+// CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %22, %16, %12, %6, %3
+// CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject           // id: %12
+// CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %13
+// CHECK: Block: bb4
+// CHECK: Error#: 20. End Error in Function: 'bad_order_add_a_level_2'
 //
-// CHECK-LABEL: Function: 'bad_order_add_a_level_2'
-// CHECK-NEXT: Found use after free?!
-// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
-// CHECK-NEXT: Consuming User:   end_borrow %1 : $Builtin.NativeObject
-// CHECK-NEXT: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject
-// CHECK-NEXT: Block: bb5
+// CHECK-LABEL: Error#: 21. Begin Error in Function: 'bad_order_add_a_level_2'
+// CHECK: Found use after free?!
+// CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %22, %16, %12, %6, %3
+// CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject           // id: %16
+// CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %17
+// CHECK: Block: bb5
+// CHECK: Error#: 21. End Error in Function: 'bad_order_add_a_level_2'
 //
-// CHECK-LABEL: Function: 'bad_order_add_a_level_2'
-// CHECK-NEXT: Found over consume?!
-// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
-// CHECK-NEXT: User:   end_borrow %1 : $Builtin.NativeObject
-// CHECK-NEXT: Block: bb2
+// CHECK-LABEL: Error#: 22. Begin Error in Function: 'bad_order_add_a_level_2'
+// CHECK: Found over consume?!
+// CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %22, %16, %12, %6, %3
+// CHECK: User:   end_borrow %1 : $Builtin.NativeObject           // id: %16
+// CHECK: Block: bb2
+// CHECK: Consuming Users:
+// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %6
+// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %12
+// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %16
+// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %22
+// CHECK: Error#: 22. End Error in Function: 'bad_order_add_a_level_2'
 //
 // This comes from the dataflow, but we already actually identified this error.
 //
-// CHECK-LABEL: Function: 'bad_order_add_a_level_2'
-// CHECK-NEXT: Found over consume?!
+// CHECK-LABEL: Error#: 23. Begin Error in Function: 'bad_order_add_a_level_2'
+// CHECK: Found over consume?!
+// CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %22, %16, %12, %6, %3
+// CHECK: Block: bb2
+// CHECK: Consuming Users:
+// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %6
+// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %12
+// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %16
+// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %22
+// CHECK: Error#: 23. End Error in Function: 'bad_order_add_a_level_2'
 //
 // These are handled via other checks.
-// CHECK-LABEL: Function: 'bad_order_add_a_level_2'
-// CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
-// CHECK-LABEL: Function: 'bad_order_add_a_level_2'
-// CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
-// CHECK-LABEL: Function: 'bad_order_add_a_level_2'
-// CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
 //
-// CHECK-LABEL: Function: 'bad_order_add_a_level_2'
+// CHECK-LABEL: Error#: 24. Begin Error in Function: 'bad_order_add_a_level_2'
+// CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
+// CHECK: Error#: 24. End Error in Function: 'bad_order_add_a_level_2'
+//
+// CHECK-LABEL: Error#: 25. Begin Error in Function: 'bad_order_add_a_level_2'
+// CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
+// CHECK: Error#: 25. End Error in Function: 'bad_order_add_a_level_2'
+//
+// CHECK-LABEL: Error#: 26. Begin Error in Function: 'bad_order_add_a_level_2'
+// CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
+// CHECK: Error#: 26. End Error in Function: 'bad_order_add_a_level_2'
+//
+// CHECK-LABEL: Error#: 27. Begin Error in Function: 'bad_order_add_a_level_2'
 // CHECK-NEXT: Found use after free?!
 // CHECK-NEXT: Value: %5 = argument of bb2 : $Builtin.NativeObject
 // CHECK-NEXT: Consuming User:   end_borrow %5 : $Builtin.NativeObject
 // CHECK-NEXT: Non Consuming User:   end_borrow %11 : $Builtin.NativeObject
 // CHECK-NEXT: Block: bb4
-
-// CHECK-LABEL: Function: 'bad_order_add_a_level_2'
+// CHECK: Error#: 27. End Error in Function: 'bad_order_add_a_level_2'
+//
+// CHECK-LABEL: Error#: 28. Begin Error in Function: 'bad_order_add_a_level_2'
 // CHECK-NEXT: Found over consume?!
 // CHECK-NEXT: Value: %5 = argument of bb2 : $Builtin.NativeObject
 // CHECK-NEXT: User:   end_borrow %5 : $Builtin.NativeObject
 // CHECK-NEXT: Block: bb2
+// CHECK: Error#: 28. End Error in Function: 'bad_order_add_a_level_2'
+//
+// NOTE: There are 2-3 errors here we are not pattern matching. We should add
+// patterns for them so we track if they are changed.
 sil [ossa] @bad_order_add_a_level_2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -435,17 +498,18 @@ bb7:
   br bb6
 }
 
-// CHECK-LABEL: Function: 'owned_argument_overuse_br1'
+// CHECK-LABEL: Error#: 31. Begin Error in Function: 'owned_argument_overuse_br1'
 // CHECK-NEXT: Found over consume?!
 // CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject
 // CHECK-NEXT: User:   destroy_value %0 : $Builtin.NativeObject
 // CHECK-NEXT: Block: bb0
-
-// CHECK-LABEL: Function: 'owned_argument_overuse_br1'
+// CHECK: Error#: 31. End Error in Function: 'owned_argument_overuse_br1'
+//
+// CHECK-LABEL: Error#: 32. Begin Error in Function: 'owned_argument_overuse_br1'
 // CHECK-NEXT: Error! Found a leaked owned value that was never consumed.
 // CHECK-NEXT: Value: %3 = argument of bb1 : $Builtin.NativeObject
 // CHECK-NOT: Block
-// CHECK-NOT: Function: 'owned_argument_overuse_br1'
+// CHECK: Error#: 32. End Error in Function: 'owned_argument_overuse_br1'
 sil [ossa] @owned_argument_overuse_br1 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   destroy_value %0 : $Builtin.NativeObject
@@ -456,13 +520,13 @@ bb1(%1 : @owned $Builtin.NativeObject):
   return %9999 : $()
 }
 
-// CHECK-LABEL: Function: 'owned_argument_overuse_br2'
+// CHECK-LABEL: Error#: 33. Begin Error in Function: 'owned_argument_overuse_br2'
 // CHECK-NEXT: Found over consume?!
 // CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject
 // CHECK-NEXT: User:   destroy_value %0 : $Builtin.NativeObject
 // CHECK-NEXT: Block: bb0
 // CHECK-NOT: Block
-// CHECK-NOT: Function: 'owned_argument_overuse_br2'
+// CHECK: Error#: 33. End Error in Function: 'owned_argument_overuse_br2'
 sil [ossa] @owned_argument_overuse_br2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   destroy_value %0 : $Builtin.NativeObject
@@ -481,10 +545,11 @@ bb1(%1 : @owned $Builtin.NativeObject):
 // Make sure that we error due to the struct_extract. We require end_borrows to
 // be on the original borrowed value.
 //
-// CHECK-LABEL: Function: simple_non_postdominating_diamond_with_forwarding_uses
+// CHECK-LABEL: Error#: 34. Begin Error in Function: 'simple_non_postdominating_diamond_with_forwarding_uses'
 // CHECK-NEXT: Invalid End Borrow!
 // CHECK-NEXT: Original Value:   %5 = begin_borrow %1 : $NativeObjectPair        // user: %6
 // CHECK-NEXT: End Borrow:   br bb3(%6 : $Builtin.NativeObject)              // id: %7
+// CHECK: Error#: 34. End Error in Function: 'simple_non_postdominating_diamond_with_forwarding_uses'
 sil [ossa] @simple_non_postdominating_diamond_with_forwarding_uses : $@convention(thin) (@in_guaranteed Builtin.NativeObject, @guaranteed NativeObjectPair) -> () {
 bb0(%0 : $*Builtin.NativeObject, %1 : @guaranteed $NativeObjectPair):
   cond_br undef, bb1, bb2
@@ -511,13 +576,14 @@ bb3(%7 : @guaranteed $Builtin.NativeObject):
 // TODO: If we ever add simple support for this, we should make sure that we
 // error on %0.
 //
-// CHECK-LABEL: Function: simple_loop_carry_borrow_owned_arg
+// CHECK-LABEL: Error#: 35. Begin Error in Function: 'simple_loop_carry_borrow_owned_arg'
 // CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
 // CHECK-NEXT: User:   br bb1(%3 : $Builtin.NativeObject)              // id: %6
 // CHECK-NEXT: Initial: BorrowScopeOperand:
 // CHECK-NEXT: Kind: BeginBorrow
 // CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // users: %7, %1
 // CHECK-NEXT: User:   %1 = begin_borrow %0 : $Builtin.NativeObject    // user: %2
+// CHECK: Error#: 35. End Error in Function: 'simple_loop_carry_borrow_owned_arg'
 sil [ossa] @simple_loop_carry_borrow_owned_arg : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -547,13 +613,14 @@ bb3:
 // terminator? This works for load_borrow, but not for copy_value +
 // begin_borrow.
 //
-// CHECK-LABEL: Function: 'simple_loop_carry_implicitregularusers_do_not_loop_carry'
+// CHECK-LABEL: Error#: 36. Begin Error in Function: 'simple_loop_carry_implicitregularusers_do_not_loop_carry'
 // CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
 // CHECK-NEXT: Value:   %8 = copy_value %4 : $Builtin.NativeObject      // users: %12, %9
 // CHECK-NEXT:     Remaining Users:
 // CHECK-NEXT: User:   %9 = begin_borrow %8 : $Builtin.NativeObject    // user: %12
 // CHECK-NEXT: User:   end_borrow %4 : $Builtin.NativeObject           // id: %13
 // CHECK-NEXT: User:   end_borrow %4 : $Builtin.NativeObject           // id: %10
+// CHECK: Error#: 36. End Error in Function: 'simple_loop_carry_implicitregularusers_do_not_loop_carry'
 sil [ossa] @simple_loop_carry_implicitregularusers_do_not_loop_carry : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1a = begin_borrow %0 : $Builtin.NativeObject
@@ -582,7 +649,7 @@ bb3:
 
 // We should identify bb0a as consuming the value twice.
 //
-// CHECK-LABEL: Function: 'simple_loop_carry_over_consume'
+// CHECK-LABEL: Error#: 37. Begin Error in Function: 'simple_loop_carry_over_consume'
 // CHECK-NEXT: Found over consume?!
 // CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %3, %3
 // CHECK-NEXT: User:   br bb2(%1 : $Builtin.NativeObject, %1 : $Builtin.NativeObject) // id: %3
@@ -590,6 +657,23 @@ bb3:
 // CHECK-NEXT: Consuming Users:
 // CHECK-NEXT:   br bb2(%1 : $Builtin.NativeObject, %1 : $Builtin.NativeObject) // id: %3
 // CHECK-NEXT:   br bb2(%1 : $Builtin.NativeObject, %1 : $Builtin.NativeObject) // id: %3
+// CHECK: Error#: 37. End Error in Function: 'simple_loop_carry_over_consume'
+//
+// CHECK-LABEL: Error#: 38. Begin Error in Function: 'simple_loop_carry_over_consume'
+// CHECK: Found use after free?!
+// CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %11, %10, %8
+// CHECK: Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
+// CHECK: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject           // id: %12
+// CHECK: Block: bb5
+// CHECK: Error#: 38. End Error in Function: 'simple_loop_carry_over_consume'
+//
+// CHECK-LABEL: Error#: 39. Begin Error in Function: 'simple_loop_carry_over_consume'
+// CHECK: Found use after free due to unvisited non lifetime ending uses?!
+// CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %11, %10, %8
+// CHECK: Remaining Users:
+// CHECK: User:  end_borrow %4 : $Builtin.NativeObject           // id: %12
+// CHECK: Block: bb5
+// CHECK: Error#: 39. End Error in Function: 'simple_loop_carry_over_consume'
 sil [ossa] @simple_loop_carry_over_consume : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -616,13 +700,14 @@ bb3:
   return %9999 : $()
 }
 
-// CHECK-LABEL: Function: simple_loop_carry_cycle
+// CHECK-LABEL: Error#: 40. Begin Error in Function: 'simple_loop_carry_cycle'
 // CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
 // CHECK-NEXT: User:   br bb1(%3 : $Builtin.NativeObject)              // id: %6
 // CHECK-NEXT: Initial: BorrowScopeOperand:
 // CHECK-NEXT: Kind: BeginBorrow
 // CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // user: %1
 // CHECK-NEXT: User:   %1 = begin_borrow %0 : $Builtin.NativeObject    // user: %2
+// CHECK: Error#: 40. End Error in Function: 'simple_loop_carry_cycle'
 sil [ossa] @simple_loop_carry_cycle : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -647,19 +732,21 @@ bb3:
 // terminator. So the end_borrow of %2a in bb3 is considered a liveness use of
 // %2 due to it consuming %3 via the loop carry.
 //
-// CHECK-LABEL: Function: 'simple_loop_carry_borrows_do_not_loop_carry'
+// CHECK-LABEL: Error#: 41. Begin Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
 // CHECK-NEXT: Found use after free?!
 // CHECK-NEXT: Value: %5 = argument of bb1 : $Builtin.NativeObject      // users: %11, %10, %8
 // CHECK-NEXT: Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
 // CHECK-NEXT: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject           // id: %12
 // CHECK-NEXT: Block: bb4
+// CHECK: Error#: 41. End Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
 //
-// CHECK-LABEL: Function: 'simple_loop_carry_borrows_do_not_loop_carry'
+// CHECK-LABEL: Error#: 42. Begin Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
 // CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
 // CHECK-NEXT: Value: %5 = argument of bb1 : $Builtin.NativeObject      // users: %11, %10, %8
 // CHECK-NEXT:     Remaining Users:
 // CHECK-NEXT: User:  end_borrow %4 : $Builtin.NativeObject           // id: %12
 // CHECK-NEXT: Block: bb4
+// CHECK: Error#: 42. End Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
 sil [ossa] @simple_loop_carry_borrows_do_not_loop_carry : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -687,21 +774,23 @@ bb3:
 // We could potentially support this in the future if we wanted to have some
 // sort of support for phi node loops.
 //
-// CHECK-LABEL: Function: simple_validate_enclosing_borrow_around_loop
+// CHECK-LABEL: Error#: 43. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop'
 // CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
 // CHECK-NEXT: User:   br bb1(%6 : $Builtin.NativeObject, %5 : $Builtin.NativeObject) // id: %9
 // CHECK-NEXT: Initial: BorrowScopeOperand:
 // CHECK-NEXT: Kind: BeginBorrow
 // CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %12, %3, %2
 // CHECK-NEXT: User:   %2 = begin_borrow %1 : $Builtin.NativeObject    // user: %4
+// CHECK: Error#: 43. End Error in Function: 'simple_validate_enclosing_borrow_around_loop'
 //
-// CHECK-LABEL: Function: simple_validate_enclosing_borrow_around_loop
+// CHECK-LABEL: Error#: 44. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop'
 // CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
 // CHECK-NEXT: User:   br bb1(%6 : $Builtin.NativeObject, %5 : $Builtin.NativeObject) // id: %9
 // CHECK-NEXT: Initial: BorrowScopeOperand:
 // CHECK-NEXT: Kind: BeginBorrow
 // CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %12, %3, %2
 // CHECK-NEXT: User:   %3 = begin_borrow %1 : $Builtin.NativeObject    // user: %4
+// CHECK: Error#: 44. End Error in Function: 'simple_validate_enclosing_borrow_around_loop'
 sil [ossa] @simple_validate_enclosing_borrow_around_loop : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -727,21 +816,24 @@ bb3:
 }
 
 // Make sure we detect this phi cycle.
-// CHECK-LABEL: Function: simple_validate_enclosing_borrow_around_loop_2
+//
+// CHECK-LABEL: Error#: 45. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop_2'
 // CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
 // CHECK-NEXT: User:   br bb1(%5 : $Builtin.NativeObject, %4 : $Builtin.NativeObject) // id: %8
 // CHECK-NEXT: Initial: BorrowScopeOperand:
 // CHECK-NEXT: Kind: BeginBorrow
 // CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // users: %2, %1
 // CHECK-NEXT: User:   %1 = begin_borrow %0 : $Builtin.NativeObject    // user: %3
+// CHECK: Error#: 45. End Error in Function: 'simple_validate_enclosing_borrow_around_loop_2'
 //
-// CHECK-LABEL: Function: simple_validate_enclosing_borrow_around_loop_2
+// CHECK-LABEL: Error#: 46. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop_2'
 // CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
 // CHECK-NEXT: User:   br bb1(%5 : $Builtin.NativeObject, %4 : $Builtin.NativeObject) // id: %8
 // CHECK-NEXT: Initial: BorrowScopeOperand:
 // CHECK-NEXT: Kind: BeginBorrow
 // CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // users: %2, %1
 // CHECK-NEXT: User:   %2 = begin_borrow %0 : $Builtin.NativeObject    // user: %3
+// CHECK: Error#: 46. End Error in Function: 'simple_validate_enclosing_borrow_around_loop_2'
 sil [ossa] @simple_validate_enclosing_borrow_around_loop_2 : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %2 = begin_borrow %0 : $Builtin.NativeObject
@@ -766,21 +858,23 @@ bb3:
 
 // Same as before, but this time with an owned value as a base.
 //
-// CHECK-LABEL: Function: simple_validate_enclosing_borrow_around_loop_3
+// CHECK-LABEL: Error#: 47. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop_3'
 // CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
 // CHECK-NEXT: User:   br bb1(%5 : $Builtin.NativeObject, %4 : $Builtin.NativeObject) // id: %8
 // CHECK-NEXT: Initial: BorrowScopeOperand:
 // CHECK-NEXT: Kind: BeginBorrow
 // CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // users: %11, %2, %1
 // CHECK-NEXT: User:   %2 = begin_borrow %0 : $Builtin.NativeObject    // user: %3
+// CHECK: Error#: 47. End Error in Function: 'simple_validate_enclosing_borrow_around_loop_3'
 //
-// CHECK-LABEL: Function: simple_validate_enclosing_borrow_around_loop_3
+// CHECK-LABEL: Error#: 48. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop_3'
 // CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
 // CHECK-NEXT: User:   br bb1(%5 : $Builtin.NativeObject, %4 : $Builtin.NativeObject) // id: %8
 // CHECK-NEXT: Initial: BorrowScopeOperand:
 // CHECK-NEXT: Kind: BeginBorrow
 // CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // users: %11, %2, %1
 // CHECK-NEXT: User:   %1 = begin_borrow %0 : $Builtin.NativeObject    // user: %3
+// CHECK: Error#: 48. End Error in Function: 'simple_validate_enclosing_borrow_around_loop_3'
 sil [ossa] @simple_validate_enclosing_borrow_around_loop_3 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %2 = begin_borrow %0 : $Builtin.NativeObject
@@ -803,3 +897,7 @@ bb3:
   %9999 = tuple()
   return %9999 : $()
 }
+
+// We are only expecting 48 errors in this file.
+//
+// CHECK-NOT: Error#: 49

--- a/test/SIL/ownership-verifier/leaks.sil
+++ b/test/SIL/ownership-verifier/leaks.sil
@@ -17,9 +17,10 @@ import Builtin
 // Tests //
 ///////////
 
-// CHECK-LABEL: Function: 'owned_never_consumed'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'owned_never_consumed'
 // CHECK: Error! Found a leaked owned value that was never consumed.
 // CHECK: Value:   %1 = copy_value %0 : $Builtin.NativeObject
+// CHECK: Error#: 0. End Error in Function: 'owned_never_consumed'
 sil [ossa] @owned_never_consumed : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = copy_value %0 : $Builtin.NativeObject
@@ -27,11 +28,12 @@ bb0(%0 : @guaranteed $Builtin.NativeObject):
   return %9999 : $()
 }
 
-// CHECK-LABEL: Function: 'owned_leaks_along_one_path'
+// CHECK-LABEL: Error#: 1. Begin Error in Function: 'owned_leaks_along_one_path'
 // CHECK: Error! Found a leak due to a consuming post-dominance failure!
 // CHECK:     Value: %0 = argument of bb0 : $Builtin.NativeObject
 // CHECK:     Post Dominating Failure Blocks:
 // CHECK:         bb1
+// CHECK: Error#: 1. End Error in Function: 'owned_leaks_along_one_path'
 sil [ossa] @owned_leaks_along_one_path : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   cond_br undef, bb1, bb2
@@ -49,9 +51,10 @@ bb3:
 }
 
 // Make sure that we report the leak at the phi.
-// CHECK-LABEL: Function: 'owned_leaks_with_phi'
+// CHECK-LABEL: Error#: 2. Begin Error in Function: 'owned_leaks_with_phi'
 // CHECK: Error! Found a leaked owned value that was never consumed.
 // CHECK: Value: %6 = argument of bb4 : $Builtin.NativeObject
+// CHECK: Error#: 2. End Error in Function: 'owned_leaks_with_phi'
 sil [ossa] @owned_leaks_with_phi : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   br bb1(%0 : $Builtin.NativeObject)

--- a/test/SIL/ownership-verifier/subobject_borrowing.sil
+++ b/test/SIL/ownership-verifier/subobject_borrowing.sil
@@ -1,5 +1,4 @@
 // RUN: %target-sil-opt -sil-ownership-verifier-enable-testing -enable-sil-verify-all=0 -o /dev/null 2>&1  %s | %FileCheck %s
-// RUN: %target-sil-opt -sil-ownership-verifier-enable-testing -enable-sil-verify-all=0 -o /dev/null 2>&1  %s | %FileCheck -check-prefix=NEGATIVE-TEST %s
 // REQUIRES: asserts
 
 sil_stage canonical
@@ -36,7 +35,6 @@ sil @guaranteed_use_of_nativeobject : $@convention(thin) (@guaranteed Builtin.Na
 // begin_borrow subobject tests
 //
 
-// NEGATIVE-TEST-NOT: Function: 'value_subobject_without_corresponding_end_borrow'
 sil [ossa] @value_subobject_without_corresponding_end_borrow : $@convention(thin) (@owned B) -> () {
 bb0(%0 : @owned $B):
   %1 = begin_borrow %0 : $B
@@ -53,12 +51,13 @@ bb0(%0 : @owned $B):
 // We fail here since we have a use of our subobject after the end_borrow which
 // ends the borrow's lifetime.
 //
-// CHECK-LABEL: Function: 'value_subobject_with_use_after_end_borrow'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'value_subobject_with_use_after_end_borrow'
 // CHECK: Found use after free?!
 // CHECK: Value:   %1 = begin_borrow %0 : $B
 // CHECK: Consuming User:   end_borrow %1 : $B
 // CHECK: Non Consuming User:   %4 = struct_extract %2 : $A, #A.ptr
 // CHECK: Block: bb0
+// CHECK: Error#: 0. End Error in Function: 'value_subobject_with_use_after_end_borrow'
 sil [ossa] @value_subobject_with_use_after_end_borrow : $@convention(thin) (@owned B) -> () {
 bb0(%0 : @owned $B):
   %1 = begin_borrow %0 : $B
@@ -74,16 +73,17 @@ bb0(%0 : @owned $B):
 // sure that our special handling code for subobjects here does not stop us from
 // detecting violations of ownership kinds on the subobjects.
 //
-// CHECK-LABEL: Function: 'value_subobject_with_destroy_of_subobject'
+// CHECK-LABEL: Error#: 1. Begin Error in Function: 'value_subobject_with_destroy_of_subobject'
 // CHECK: Have operand with incompatible ownership?!
 // CHECK: Value:   %5 = tuple_extract %4 : $(Builtin.NativeObject, Builtin.NativeObject), 1
 // CHECK: User:   destroy_value %5 : $Builtin.NativeObject
 // CHECK: Conv: guaranteed
-
+// CHECK: Error#: 1. End Error in Function: 'value_subobject_with_destroy_of_subobject'
+//
 // Make sure we only see one failure here. We should process recursively from
 // the borrow root, not from each of the subobjects of the borrow.
-// NEGATIVE-TEST: Function: 'value_subobject_with_destroy_of_subobject'
-// NEGATIVE-TEST-NOT: Function: 'value_subobject_with_destroy_of_subobject'
+// CHECK-NOT: Error#: 2. Begin Error in Function: 'value_subobject_with_destroy_of_subobject'
+//
 sil [ossa] @value_subobject_with_destroy_of_subobject : $@convention(thin) (@owned B) -> () {
 bb0(%0 : @owned $B):
   %1 = begin_borrow %0 : $B
@@ -98,12 +98,13 @@ bb0(%0 : @owned $B):
   return %9999 : $()
 }
 
-// CHECK-LABEL: Function: 'value_different_subobject_kinds_multiple_levels'
+// CHECK-LABEL: Error#: 2. Begin Error in Function: 'value_different_subobject_kinds_multiple_levels'
 // CHECK: Found use after free?!
 // CHECK: Value:   %1 = begin_borrow %0 : $B
 // CHECK: Consuming User:   end_borrow %1 : $B
 // CHECK: Non Consuming User:   %6 = tuple_extract %4 : $(Builtin.NativeObject, Builtin.NativeObject), 1
 // CHECK: Block: bb0
+// CHECK: Error#: 2. End Error in Function: 'value_different_subobject_kinds_multiple_levels'
 sil [ossa] @value_different_subobject_kinds_multiple_levels : $@convention(thin) (@owned B) -> () {
 bb0(%0 : @owned $B):
   %1 = begin_borrow %0 : $B
@@ -121,7 +122,7 @@ bb0(%0 : @owned $B):
 // Function Argument guaranteed tests
 //
 
-// NEGATIVE-TEST-NOT: Function: 'funcarg_subobject_basic_test'
+// CHECK-NOT: Begin Error in Function: 'funcarg_subobject_basic_test'
 sil [ossa] @funcarg_subobject_basic_test : $@convention(thin) (@guaranteed B) -> () {
 bb0(%0 : @guaranteed $B):
   %2 = struct_extract %0 : $B, #B.a1
@@ -136,11 +137,12 @@ bb0(%0 : @guaranteed $B):
 // sure that our special handling code for subobjects here does not stop us from
 // detecting violations of ownership kinds on the subobjects.
 //
-// CHECK-LABEL: Function: 'funcarg_subobject_with_destroy_of_subobject'
+// CHECK-LABEL: Error#: 3. Begin Error in Function: 'funcarg_subobject_with_destroy_of_subobject'
 // CHECK: Have operand with incompatible ownership?!
 // CHECK: Value:   %4 = tuple_extract %3 : $(Builtin.NativeObject, Builtin.NativeObject), 1
 // CHECK: User:   destroy_value %4 : $Builtin.NativeObject
 // CHECK: Conv: guaranteed
+// CHECK: Error#: 3. End Error in Function: 'funcarg_subobject_with_destroy_of_subobject'
 sil [ossa] @funcarg_subobject_with_destroy_of_subobject : $@convention(thin) (@guaranteed B) -> () {
 bb0(%0 : @guaranteed $B):
   %2 = struct_extract %0 : $B, #B.a1


### PR DESCRIPTION
This is doing a few things with a simple change to use a builder:

1. It cleans up how we emit errors so we have a builder object that constructs
errors. The errors then just become dumb POD data that the builder vends to
callers that via the boolean values describe what errors were found.

2. Now that we have one place where we are actually emitting these errors, I
cleaned up how we emit the errors by normalizing the output so function names
are quoted the same.

3. I changed our error emission so that we emit a unique count of the errors as
we emit them. This makes it so that our pattern matching is much more robust
against weird pattern match errors that can be difficult to debug due to the
errors having unrelated test cases/file check patterns bleed
together. Before/end checks eliminate this problem. I updated all of the
relevant test cases.

The reason /why/ I am doing this though is that I am going to be adding support
to the LinearLifetimeChecker for flagging objects that are outside of the
lifetime that we are verifying (meaning either before or after). This is going
to cause me to need to track /all/ non consuming uses when performing linear
lifetime checks and thus most likely emit more errors. I was finding it to be
difficult to update the current tests given the state of the world before this
patch, so I was inspired to clean this up to satisfy practical as well as debt
concerns.
