### PR TITLE
[ConstraintSystem] Switch solver to use `ASTNode` instead of `TypedNode`

### DIFF
--- a/include/swift/AST/ASTNode.h
+++ b/include/swift/AST/ASTNode.h
@@ -30,7 +30,7 @@ namespace swift {
   class Stmt;
   class Decl;
   class Pattern;
-  struct TypeLoc;
+  class TypeLoc;
   class DeclContext;
   class SourceLoc;
   class SourceRange;

--- a/include/swift/AST/ASTNode.h
+++ b/include/swift/AST/ASTNode.h
@@ -29,15 +29,19 @@ namespace swift {
   class Expr;
   class Stmt;
   class Decl;
+  class Pattern;
+  struct TypeLoc;
   class DeclContext;
   class SourceLoc;
   class SourceRange;
   class ASTWalker;
   enum class ExprKind : uint8_t;
   enum class DeclKind : uint8_t;
+  enum class PatternKind : uint8_t;
   enum class StmtKind;
 
-  struct ASTNode : public llvm::PointerUnion<Expr*, Stmt*, Decl*> {
+  struct ASTNode : public llvm::PointerUnion<Expr *, Stmt *, Decl *, Pattern *,
+                                             TypeLoc *> {
     // Inherit the constructors from PointerUnion.
     using PointerUnion::PointerUnion;
 
@@ -61,6 +65,7 @@ namespace swift {
     FUNC(Stmt)
     FUNC(Expr)
     FUNC(Decl)
+    FUNC(Pattern)
 #undef FUNC
     
     SWIFT_DEBUG_DUMP;

--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -30,7 +30,7 @@ namespace swift {
   class TypeDecl;
   class EnumElementDecl;
   class Type;
-  struct TypeLoc;
+  class TypeLoc;
   class Pattern;
   class ExtensionDecl;
   class NominalTypeDecl;

--- a/include/swift/AST/ASTWalker.h
+++ b/include/swift/AST/ASTWalker.h
@@ -25,7 +25,7 @@ class ModuleDecl;
 class Stmt;
 class Pattern;
 class TypeRepr;
-struct TypeLoc;
+class TypeLoc;
 class ParameterList;
 enum class AccessKind: unsigned char;
 

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -475,22 +475,24 @@ public:
   ///
   /// This distinguishes static references to types, like Int, from metatype
   /// values, "someTy: Any.Type".
-  bool isTypeReference(llvm::function_ref<Type(const Expr *)> getType =
-                           [](const Expr *E) -> Type { return E->getType(); },
-                       llvm::function_ref<Decl *(const Expr *)> getDecl =
-                           [](const Expr *E) -> Decl * {
-                         return nullptr;
-                       }) const;
+  bool isTypeReference(
+      llvm::function_ref<Type(Expr *)> getType = [](Expr *E) -> Type {
+        return E->getType();
+      },
+      llvm::function_ref<Decl *(Expr *)> getDecl = [](Expr *E) -> Decl * {
+        return nullptr;
+      }) const;
 
   /// Determine whether this expression refers to a statically-derived metatype.
   ///
   /// This implies `isTypeReference`, but also requires that the referenced type
   /// is not an archetype or dependent type.
   bool isStaticallyDerivedMetatype(
-      llvm::function_ref<Type(const Expr *)> getType =
-          [](const Expr *E) -> Type { return E->getType(); },
-      llvm::function_ref<bool(const Expr *)> isTypeReference =
-          [](const Expr *E) { return E->isTypeReference(); }) const;
+      llvm::function_ref<Type(Expr *)> getType = [](Expr *E) -> Type {
+        return E->getType();
+      },
+      llvm::function_ref<bool(Expr *)> isTypeReference =
+          [](Expr *E) { return E->isTypeReference(); }) const;
 
   /// isImplicit - Determines whether this expression was implicitly-generated,
   /// rather than explicitly written in the AST.
@@ -538,11 +540,12 @@ public:
 
   SWIFT_DEBUG_DUMP;
   void dump(raw_ostream &OS, unsigned Indent = 0) const;
-  void dump(raw_ostream &OS, llvm::function_ref<Type(const Expr *)> getType,
-            llvm::function_ref<Type(const TypeLoc &)> getTypeOfTypeLoc,
-            llvm::function_ref<Type(const KeyPathExpr *E, unsigned index)> getTypeOfKeyPathComponent,
+  void dump(raw_ostream &OS, llvm::function_ref<Type(Expr *)> getType,
+            llvm::function_ref<Type(TypeLoc &)> getTypeOfTypeLoc,
+            llvm::function_ref<Type(KeyPathExpr *E, unsigned index)>
+                getTypeOfKeyPathComponent,
             unsigned Indent = 0) const;
-  
+
   void print(ASTPrinter &Printer, const PrintOptions &Opts) const;
 
   // Only allow allocation of Exprs using the allocator in ASTContext
@@ -1183,9 +1186,9 @@ public:
   ///
   /// Note: prefer to use the second entry point, which separates out
   /// arguments/labels/etc.
-  static ObjectLiteralExpr *
-  create(ASTContext &ctx, SourceLoc poundLoc, LiteralKind kind, Expr *arg,
-         bool implicit, llvm::function_ref<Type(const Expr *)> getType);
+  static ObjectLiteralExpr *create(ASTContext &ctx, SourceLoc poundLoc,
+                                   LiteralKind kind, Expr *arg, bool implicit,
+                                   llvm::function_ref<Type(Expr *)> getType);
 
   /// Create a new object literal expression.
   static ObjectLiteralExpr *create(ASTContext &ctx, SourceLoc poundLoc,
@@ -1778,11 +1781,12 @@ public:
   ///
   /// Note: do not create new callers to this entry point; use the entry point
   /// that takes separate index arguments.
-  static DynamicSubscriptExpr *
-  create(ASTContext &ctx, Expr *base, Expr *index, ConcreteDeclRef decl,
-         bool implicit,
-         llvm::function_ref<Type(const Expr *)> getType =
-             [](const Expr *E) -> Type { return E->getType(); });
+  static DynamicSubscriptExpr *create(
+      ASTContext &ctx, Expr *base, Expr *index, ConcreteDeclRef decl,
+      bool implicit,
+      llvm::function_ref<Type(Expr *)> getType = [](Expr *E) -> Type {
+        return E->getType();
+      });
 
   /// getIndex - Retrieve the index of the subscript expression, i.e., the
   /// "offset" into the base value.
@@ -2355,12 +2359,13 @@ public:
   ///
   /// Note: do not create new callers to this entry point; use the entry point
   /// that takes separate index arguments.
-  static SubscriptExpr *
-  create(ASTContext &ctx, Expr *base, Expr *index,
-         ConcreteDeclRef decl = ConcreteDeclRef(), bool implicit = false,
-         AccessSemantics semantics = AccessSemantics::Ordinary,
-         llvm::function_ref<Type(const Expr *)> getType =
-             [](const Expr *E) -> Type { return E->getType(); });
+  static SubscriptExpr *create(
+      ASTContext &ctx, Expr *base, Expr *index,
+      ConcreteDeclRef decl = ConcreteDeclRef(), bool implicit = false,
+      AccessSemantics semantics = AccessSemantics::Ordinary,
+      llvm::function_ref<Type(Expr *)> getType = [](Expr *E) -> Type {
+        return E->getType();
+      });
 
   /// Create a new subscript.
   static SubscriptExpr *create(ASTContext &ctx, Expr *base,
@@ -3599,10 +3604,8 @@ public:
   enum : unsigned { InvalidDiscriminator = 0xFFFF };
 
   /// Retrieve the result type of this closure.
-  Type getResultType(llvm::function_ref<Type(const Expr *)> getType =
-                         [](const Expr *E) -> Type {
-    return E->getType();
-  }) const;
+  Type getResultType(llvm::function_ref<Type(Expr *)> getType =
+                         [](Expr *E) -> Type { return E->getType(); }) const;
 
   /// Return whether this closure is throwing when fully applied.
   bool isBodyThrowing() const;
@@ -4263,12 +4266,13 @@ public:
   /// Create a new call expression.
   ///
   /// Note: prefer to use the entry points that separate out the arguments.
-  static CallExpr *
-  create(ASTContext &ctx, Expr *fn, Expr *arg, ArrayRef<Identifier> argLabels,
-         ArrayRef<SourceLoc> argLabelLocs, bool hasTrailingClosure,
-         bool implicit, Type type = Type(),
-         llvm::function_ref<Type(const Expr *)> getType =
-             [](const Expr *E) -> Type { return E->getType(); });
+  static CallExpr *create(
+      ASTContext &ctx, Expr *fn, Expr *arg, ArrayRef<Identifier> argLabels,
+      ArrayRef<SourceLoc> argLabelLocs, bool hasTrailingClosure, bool implicit,
+      Type type = Type(),
+      llvm::function_ref<Type(Expr *)> getType = [](Expr *E) -> Type {
+        return E->getType();
+      });
 
   /// Create a new implicit call expression without any source-location
   /// information.
@@ -4277,11 +4281,12 @@ public:
   /// \param args The call arguments, not including a trailing closure (if any).
   /// \param argLabels The argument labels, whose size must equal args.size(),
   /// or which must be empty.
-  static CallExpr *
-  createImplicit(ASTContext &ctx, Expr *fn, ArrayRef<Expr *> args,
-                 ArrayRef<Identifier> argLabels,
-                 llvm::function_ref<Type(const Expr *)> getType =
-                     [](const Expr *E) -> Type { return E->getType(); }) {
+  static CallExpr *createImplicit(
+      ASTContext &ctx, Expr *fn, ArrayRef<Expr *> args,
+      ArrayRef<Identifier> argLabels,
+      llvm::function_ref<Type(Expr *)> getType = [](Expr *E) -> Type {
+        return E->getType();
+      }) {
     return create(ctx, fn, SourceLoc(), args, argLabels, { }, SourceLoc(),
                   /*trailingClosure=*/nullptr, /*implicit=*/true, getType);
   }
@@ -4295,12 +4300,13 @@ public:
   /// \param argLabelLocs The locations of the argument labels, whose size must
   /// equal args.size() or which must be empty.
   /// \param trailingClosure The trailing closure, if any.
-  static CallExpr *
-  create(ASTContext &ctx, Expr *fn, SourceLoc lParenLoc, ArrayRef<Expr *> args,
-         ArrayRef<Identifier> argLabels, ArrayRef<SourceLoc> argLabelLocs,
-         SourceLoc rParenLoc, Expr *trailingClosure, bool implicit,
-         llvm::function_ref<Type(const Expr *)> getType =
-             [](const Expr *E) -> Type { return E->getType(); });
+  static CallExpr *create(
+      ASTContext &ctx, Expr *fn, SourceLoc lParenLoc, ArrayRef<Expr *> args,
+      ArrayRef<Identifier> argLabels, ArrayRef<SourceLoc> argLabelLocs,
+      SourceLoc rParenLoc, Expr *trailingClosure, bool implicit,
+      llvm::function_ref<Type(Expr *)> getType = [](Expr *E) -> Type {
+        return E->getType();
+      });
 
   SourceLoc getStartLoc() const {
     SourceLoc fnLoc = getFn()->getStartLoc();
@@ -5622,18 +5628,15 @@ inline const SourceLoc *CollectionExpr::getTrailingSourceLocs() const {
 ///
 /// \param argLabelLocs The argument label locations, which might be updated by
 /// this function.
-Expr *packSingleArgument(ASTContext &ctx, SourceLoc lParenLoc,
-                         ArrayRef<Expr *> args,
-                         ArrayRef<Identifier> &argLabels,
-                         ArrayRef<SourceLoc> &argLabelLocs,
-                         SourceLoc rParenLoc,
-                         Expr *trailingClosure, bool implicit,
-                         SmallVectorImpl<Identifier> &argLabelsScratch,
-                         SmallVectorImpl<SourceLoc> &argLabelLocsScratch,
-                         llvm::function_ref<Type(const Expr *)> getType =
-                              [](const Expr *E) -> Type {
-                                return E->getType();
-                              });
+Expr *packSingleArgument(
+    ASTContext &ctx, SourceLoc lParenLoc, ArrayRef<Expr *> args,
+    ArrayRef<Identifier> &argLabels, ArrayRef<SourceLoc> &argLabelLocs,
+    SourceLoc rParenLoc, Expr *trailingClosure, bool implicit,
+    SmallVectorImpl<Identifier> &argLabelsScratch,
+    SmallVectorImpl<SourceLoc> &argLabelLocsScratch,
+    llvm::function_ref<Type(Expr *)> getType = [](Expr *E) -> Type {
+      return E->getType();
+    });
 
 void simple_display(llvm::raw_ostream &out, const ClosureExpr *CE);
 void simple_display(llvm::raw_ostream &out, const DefaultArgumentExpr *expr);

--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -223,7 +223,8 @@ public:
   void print(llvm::raw_ostream &OS,
              const PrintOptions &Options = PrintOptions()) const;
   SWIFT_DEBUG_DUMP;
-  
+  void dump(raw_ostream &OS, unsigned Indent = 0) const;
+
   /// walk - This recursively walks the AST rooted at this pattern.
   Pattern *walk(ASTWalker &walker);
   Pattern *walk(ASTWalker &&walker) { return walk(walker); }  

--- a/include/swift/AST/TypeAlignments.h
+++ b/include/swift/AST/TypeAlignments.h
@@ -51,6 +51,7 @@ namespace swift {
   class TypeVariableType;
   class TypeBase;
   class TypeDecl;
+  class TypeLoc;
   class ValueDecl;
 
   /// We frequently use three tag bits on all of these types.
@@ -63,6 +64,7 @@ namespace swift {
   constexpr size_t PatternAlignInBits = 3;
   constexpr size_t SILFunctionAlignInBits = 2;
   constexpr size_t TypeVariableAlignInBits = 4;
+  constexpr size_t TypeLocAlignInBits = 3;
 }
 
 namespace llvm {
@@ -123,6 +125,8 @@ LLVM_DECLARE_TYPE_ALIGNMENT(swift::SILFunction,
                             swift::SILFunctionAlignInBits)
 
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::AttributeBase, swift::AttrAlignInBits)
+
+LLVM_DECLARE_TYPE_ALIGNMENT(swift::TypeLoc, swift::TypeLocAlignInBits)
 
 static_assert(alignof(void*) >= 2, "pointer alignment is too small");
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -48,7 +48,7 @@ class RequirementRepr;
 class SpecializeAttr;
 class TrailingWhereClause;
 class TypeAliasDecl;
-struct TypeLoc;
+class TypeLoc;
 class Witness;
 struct TypeWitnessAndDecl;
 class ValueDecl;

--- a/include/swift/AST/TypeLoc.h
+++ b/include/swift/AST/TypeLoc.h
@@ -19,6 +19,7 @@
 
 #include "swift/Basic/SourceLoc.h"
 #include "swift/AST/Type.h"
+#include "swift/AST/TypeAlignments.h"
 #include "llvm/ADT/PointerIntPair.h"
 
 namespace swift {
@@ -28,8 +29,7 @@ class TypeRepr;
 
 /// TypeLoc - Provides source location information for a parsed type.
 /// A TypeLoc is stored in AST nodes which use an explicitly written type.
-struct TypeLoc {
-private:
+class alignas(1 << TypeLocAlignInBits) TypeLoc {
   Type Ty;
   TypeRepr *TyR = nullptr;
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -54,7 +54,7 @@ namespace swift {
   class ScopeInfo;
   class SourceManager;
   class TupleType;
-  struct TypeLoc;
+  class TypeLoc;
   
   struct EnumElementInfo;
   

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -67,7 +67,7 @@ namespace swift {
   class Token;
   class TopLevelContext;
   class TypeCheckerOptions;
-  struct TypeLoc;
+  class TypeLoc;
   class UnifiedStatsReporter;
 
   namespace Lowering {

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1774,15 +1774,16 @@ namespace {
 class PrintExpr : public ExprVisitor<PrintExpr> {
 public:
   raw_ostream &OS;
-  llvm::function_ref<Type(const Expr *)> GetTypeOfExpr;
-  llvm::function_ref<Type(const TypeLoc &)> GetTypeOfTypeLoc;
-  llvm::function_ref<Type(const KeyPathExpr *E, unsigned index)> GetTypeOfKeyPathComponent;
+  llvm::function_ref<Type(Expr *)> GetTypeOfExpr;
+  llvm::function_ref<Type(TypeLoc &)> GetTypeOfTypeLoc;
+  llvm::function_ref<Type(KeyPathExpr *E, unsigned index)>
+      GetTypeOfKeyPathComponent;
   unsigned Indent;
 
-  PrintExpr(raw_ostream &os,
-            llvm::function_ref<Type(const Expr *)> getTypeOfExpr,
-            llvm::function_ref<Type(const TypeLoc &)> getTypeOfTypeLoc,
-            llvm::function_ref<Type(const KeyPathExpr *E, unsigned index)> getTypeOfKeyPathComponent,
+  PrintExpr(raw_ostream &os, llvm::function_ref<Type(Expr *)> getTypeOfExpr,
+            llvm::function_ref<Type(TypeLoc &)> getTypeOfTypeLoc,
+            llvm::function_ref<Type(KeyPathExpr *E, unsigned index)>
+                getTypeOfKeyPathComponent,
             unsigned indent)
       : OS(os), GetTypeOfExpr(getTypeOfExpr),
         GetTypeOfTypeLoc(getTypeOfTypeLoc),
@@ -2864,21 +2865,19 @@ void Expr::dump() const {
   llvm::errs() << "\n";
 }
 
-void Expr::dump(raw_ostream &OS,
-                 llvm::function_ref<Type(const Expr *)> getTypeOfExpr,
-                 llvm::function_ref<Type(const TypeLoc &)> getTypeOfTypeLoc,
-                 llvm::function_ref<Type(const KeyPathExpr *E, unsigned index)> getTypeOfKeyPathComponent,
-                 unsigned Indent) const {
+void Expr::dump(raw_ostream &OS, llvm::function_ref<Type(Expr *)> getTypeOfExpr,
+                llvm::function_ref<Type(TypeLoc &)> getTypeOfTypeLoc,
+                llvm::function_ref<Type(KeyPathExpr *E, unsigned index)>
+                    getTypeOfKeyPathComponent,
+                unsigned Indent) const {
   PrintExpr(OS, getTypeOfExpr, getTypeOfTypeLoc, getTypeOfKeyPathComponent, Indent)
       .visit(const_cast<Expr *>(this));
 }
 
 void Expr::dump(raw_ostream &OS, unsigned Indent) const {
-  auto getTypeOfExpr = [](const Expr *E) -> Type { return E->getType(); };
-  auto getTypeOfTypeLoc = [](const TypeLoc &TL) -> Type {
-    return TL.getType();
-  };
-  auto getTypeOfKeyPathComponent = [](const KeyPathExpr *E, unsigned index) -> Type {
+  auto getTypeOfExpr = [](Expr *E) -> Type { return E->getType(); };
+  auto getTypeOfTypeLoc = [](TypeLoc &TL) -> Type { return TL.getType(); };
+  auto getTypeOfKeyPathComponent = [](KeyPathExpr *E, unsigned index) -> Type {
     return E->getComponents()[index].getComponentType();
   };
   dump(OS, getTypeOfExpr, getTypeOfTypeLoc, getTypeOfKeyPathComponent, Indent);

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1426,8 +1426,12 @@ void SourceFile::dump(llvm::raw_ostream &OS) const {
 }
 
 void Pattern::dump() const {
-  PrintPattern(llvm::errs()).visit(const_cast<Pattern*>(this));
-  llvm::errs() << '\n';
+  dump(llvm::errs());
+}
+
+void Pattern::dump(raw_ostream &OS, unsigned Indent) const {
+  PrintPattern(OS, Indent).visit(const_cast<Pattern*>(this));
+  OS << '\n';
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -18,6 +18,8 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/Stmt.h"
+#include "swift/AST/Pattern.h"
+#include "swift/AST/TypeLoc.h"
 #include "swift/Basic/SourceLoc.h"
 
 using namespace swift;
@@ -29,6 +31,10 @@ SourceRange ASTNode::getSourceRange() const {
     return S->getSourceRange();
   if (const auto *D = this->dyn_cast<Decl*>())
     return D->getSourceRange();
+  if (const auto *P = this->dyn_cast<Pattern*>())
+    return P->getSourceRange();
+  if (const auto *L = this->dyn_cast<TypeLoc *>())
+    return L->getSourceRange();
   llvm_unreachable("unsupported AST node");
 }
 
@@ -63,6 +69,10 @@ bool ASTNode::isImplicit() const {
     return S->isImplicit();
   if (const auto *D = this->dyn_cast<Decl*>())
     return D->isImplicit();
+  if (const auto *P = this->dyn_cast<Pattern*>())
+    return P->isImplicit();
+  if (const auto *L = this->dyn_cast<TypeLoc*>())
+    return false;
   llvm_unreachable("unsupported AST node");
 }
 
@@ -73,6 +83,8 @@ void ASTNode::walk(ASTWalker &Walker) {
     S->walk(Walker);
   else if (auto *D = this->dyn_cast<Decl*>())
     D->walk(Walker);
+  else if (auto *P = this->dyn_cast<Pattern*>())
+    P->walk(Walker);
   else
     llvm_unreachable("unsupported AST node");
 }
@@ -84,6 +96,8 @@ void ASTNode::dump(raw_ostream &OS, unsigned Indent) const {
     E->dump(OS, Indent);
   else if (auto D = dyn_cast<Decl*>())
     D->dump(OS, Indent);
+  else if (auto P = dyn_cast<Pattern*>())
+    P->dump(OS, Indent);
   else
     OS << "<null>";
 }
@@ -101,4 +115,5 @@ bool ASTNode::is##T(T##Kind Kind) const {                                     \
 FUNC(Stmt)
 FUNC(Expr)
 FUNC(Decl)
+FUNC(Pattern)
 #undef FUNC

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -114,7 +114,7 @@ ConstraintLocator *Solution::getCalleeLocator(ConstraintLocator *locator,
   auto &cs = getConstraintSystem();
   return cs.getCalleeLocator(
       locator, lookThroughApply,
-      [&](const Expr *expr) -> Type { return getType(expr); },
+      [&](Expr *expr) -> Type { return getType(expr); },
       [&](Type type) -> Type { return simplifyType(type)->getRValueType(); },
       [&](ConstraintLocator *locator) -> Optional<SelectedOverload> {
         return getOverloadChoiceIfAvailable(locator);
@@ -122,7 +122,7 @@ ConstraintLocator *Solution::getCalleeLocator(ConstraintLocator *locator,
 }
 
 ConstraintLocator *
-Solution::getConstraintLocator(TypedNode anchor,
+Solution::getConstraintLocator(ASTNode anchor,
                                ArrayRef<LocatorPathElt> path) const {
   auto &cs = getConstraintSystem();
   return cs.getConstraintLocator(anchor, path);
@@ -153,10 +153,10 @@ getImplicitMemberReferenceAccessSemantics(Expr *base, VarDecl *member,
 /// This extends functionality of `Expr::isTypeReference` with
 /// support for `UnresolvedDotExpr` and `UnresolvedMemberExpr`.
 /// This method could be used on not yet fully type-checked AST.
-bool ConstraintSystem::isTypeReference(const Expr *E) {
+bool ConstraintSystem::isTypeReference(Expr *E) {
   return E->isTypeReference(
-      [&](const Expr *E) -> Type { return simplifyType(getType(E)); },
-      [&](const Expr *E) -> Decl * {
+      [&](Expr *E) -> Type { return simplifyType(getType(E)); },
+      [&](Expr *E) -> Decl * {
         if (auto *UDE = dyn_cast<UnresolvedDotExpr>(E)) {
           return findResolvedMemberRef(
               getConstraintLocator(UDE, ConstraintLocator::Member));
@@ -175,13 +175,13 @@ bool ConstraintSystem::isTypeReference(const Expr *E) {
       });
 }
 
-bool ConstraintSystem::isStaticallyDerivedMetatype(const Expr *E) {
+bool ConstraintSystem::isStaticallyDerivedMetatype(Expr *E) {
   return E->isStaticallyDerivedMetatype(
-      [&](const Expr *E) -> Type { return simplifyType(getType(E)); },
-      [&](const Expr *E) -> bool { return isTypeReference(E); });
+      [&](Expr *E) -> Type { return simplifyType(getType(E)); },
+      [&](Expr *E) -> bool { return isTypeReference(E); });
 }
 
-Type ConstraintSystem::getInstanceType(const TypeExpr *E) {
+Type ConstraintSystem::getInstanceType(TypeExpr *E) {
   if (!hasType(E))
     return Type();
 
@@ -192,7 +192,7 @@ Type ConstraintSystem::getInstanceType(const TypeExpr *E) {
 }
 
 Type ConstraintSystem::getResultType(const AbstractClosureExpr *E) {
-  return E->getResultType([&](const Expr *E) -> Type { return getType(E); });
+  return E->getResultType([&](Expr *E) -> Type { return getType(E); });
 }
 
 static bool buildObjCKeyPathString(KeyPathExpr *E,
@@ -882,9 +882,9 @@ namespace {
       // the base is implicit or not. This helps maintain some invariants around
       // source ranges.
       if (selfParamRef->isImplicit()) {
-          selfCall =
-            CallExpr::createImplicit(context, ref, selfOpenedRef, { },
-                                     [&](const Expr *E) { return cs.getType(E); });
+        selfCall =
+            CallExpr::createImplicit(context, ref, selfOpenedRef, {},
+                                     [&](Expr *E) { return cs.getType(E); });
         selfCall->setType(refTy->getResult());
         cs.cacheType(selfCall);
 
@@ -1778,9 +1778,7 @@ namespace {
       if (!index)
         return nullptr;
 
-      auto getType = [&](const Expr *E) -> Type {
-        return cs.getType(E);
-      };
+      auto getType = [&](Expr *E) -> Type { return cs.getType(E); };
 
       // Handle dynamic lookup.
       if (choice.getKind() == OverloadChoiceKind::DeclViaDynamic ||
@@ -1968,7 +1966,7 @@ namespace {
           anchor = SubscriptExpr::create(
               ctx, dotExpr, origComponent.getIndexExpr(), ConcreteDeclRef(),
               /*implicit=*/true, AccessSemantics::Ordinary,
-              [&](const Expr *expr) { return simplifyType(cs.getType(expr)); });
+              [&](Expr *expr) { return simplifyType(cs.getType(expr)); });
         } else {
           return nullptr;
         }
@@ -2742,9 +2740,7 @@ namespace {
       if (!result)
         return nullptr;
 
-      auto getType = [&](const Expr *E) -> Type {
-        return cs.getType(E);
-      };
+      auto getType = [&](Expr *E) -> Type { return cs.getType(E); };
 
       // If there was an argument, apply it.
       if (auto arg = expr->getArgument()) {
@@ -3242,7 +3238,7 @@ namespace {
       // solver was allowed to return free or unresolved types, which can
       // happen while running diagnostics on one of the expressions.
       if (!overload) {
-        const auto *base = expr->getBase();
+        auto *base = expr->getBase();
         auto &de = cs.getASTContext().Diags;
         auto baseType = cs.getType(base);
 
@@ -7237,9 +7233,7 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
             OpaqueValueExpr(apply->getFn()->getSourceRange(), Type());
         cs.setType(escapable, escapableParams[0].getOldType());
 
-        auto getType = [&](const Expr *E) -> Type {
-          return cs.getType(E);
-        };
+        auto getType = [&](Expr *E) -> Type { return cs.getType(E); };
 
         auto callSubExpr = CallExpr::createImplicit(ctx, body,
                                                     {escapable}, {}, getType);
@@ -7294,10 +7288,8 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
         auto opaqueValue =
             new (ctx) OpaqueValueExpr(apply->getSourceRange(), openedTy);
         cs.setType(opaqueValue, openedTy);
-        
-        auto getType = [&](const Expr *E) -> Type {
-          return cs.getType(E);
-        };
+
+        auto getType = [&](Expr *E) -> Type { return cs.getType(E); };
 
         auto callSubExpr = CallExpr::createImplicit(ctx, body, {opaqueValue}, {}, getType);
         cs.cacheSubExprTypes(callSubExpr);
@@ -7809,7 +7801,7 @@ namespace {
     explicit CompareExprSourceLocs(SourceManager &sourceMgr)
       : sourceMgr(sourceMgr) { }
 
-    bool operator()(TypedNode lhs, TypedNode rhs) const {
+    bool operator()(ASTNode lhs, ASTNode rhs) const {
       if (static_cast<bool>(lhs) != static_cast<bool>(rhs)) {
         return static_cast<bool>(lhs);
       }
@@ -7829,15 +7821,14 @@ namespace {
 /// able to emit an error message, or false if none of the fixits worked out.
 bool ConstraintSystem::applySolutionFixes(const Solution &solution) {
   /// Collect the fixes on a per-expression basis.
-  llvm::SmallDenseMap<TypedNode, SmallVector<ConstraintFix *, 4>>
-      fixesPerAnchor;
+  llvm::SmallDenseMap<ASTNode, SmallVector<ConstraintFix *, 4>> fixesPerAnchor;
   for (auto *fix : solution.Fixes) {
     fixesPerAnchor[fix->getAnchor()].push_back(fix);
   }
 
   // Collect all of the expressions that have fixes, and sort them by
   // source ordering.
-  SmallVector<TypedNode, 4> orderedAnchors;
+  SmallVector<ASTNode, 4> orderedAnchors;
   for (const auto &fix : fixesPerAnchor) {
     orderedAnchors.push_back(fix.getFirst());
   }
@@ -8416,7 +8407,7 @@ ProtocolConformanceRef Solution::resolveConformance(
   return ProtocolConformanceRef::forInvalid();
 }
 
-Type Solution::getType(TypedNode node) const {
+Type Solution::getType(ASTNode node) const {
   auto result = nodeTypes.find(node);
   if (result != nodeTypes.end())
     return result->second;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -51,7 +51,7 @@ bool FailureDiagnostic::diagnoseAsNote() {
   return false;
 }
 
-TypedNode FailureDiagnostic::getAnchor() const {
+ASTNode FailureDiagnostic::getAnchor() const {
   auto &cs = getConstraintSystem();
 
   auto *locator = getLocator();
@@ -72,7 +72,7 @@ TypedNode FailureDiagnostic::getAnchor() const {
   return anchor;
 }
 
-Type FailureDiagnostic::getType(TypedNode node, bool wantRValue) const {
+Type FailureDiagnostic::getType(ASTNode node, bool wantRValue) const {
   return resolveType(S.getType(node), /*reconstituteSugar=*/false, wantRValue);
 }
 
@@ -411,7 +411,7 @@ bool MissingConformanceFailure::diagnoseAsError() {
       llvm::SmallPtrSet<Expr *, 4> anchors;
       for (const auto *fix : cs.getFixes()) {
         if (auto anchor = fix->getAnchor()) {
-          if (anchor.is<const Expr *>())
+          if (anchor.is<Expr *>())
             anchors.insert(getAsExpr(anchor));
         }
       }
@@ -860,7 +860,7 @@ bool NoEscapeFuncToTypeConversionFailure::diagnoseParameterUse() const {
   return true;
 }
 
-TypedNode MissingForcedDowncastFailure::getAnchor() const {
+ASTNode MissingForcedDowncastFailure::getAnchor() const {
   auto anchor = FailureDiagnostic::getAnchor();
   if (auto *assignExpr = getAsExpr<AssignExpr>(anchor))
     return assignExpr->getSrc();
@@ -891,7 +891,7 @@ bool MissingAddressOfFailure::diagnoseAsError() {
   return true;
 }
 
-TypedNode MissingExplicitConversionFailure::getAnchor() const {
+ASTNode MissingExplicitConversionFailure::getAnchor() const {
   auto anchor = FailureDiagnostic::getAnchor();
 
   if (auto *assign = getAsExpr<AssignExpr>(anchor))
@@ -1451,8 +1451,7 @@ bool TrailingClosureAmbiguityFailure::diagnoseAsNote() {
   return true;
 }
 
-AssignmentFailure::AssignmentFailure(const Expr *destExpr,
-                                     const Solution &solution,
+AssignmentFailure::AssignmentFailure(Expr *destExpr, const Solution &solution,
                                      SourceLoc diagnosticLoc)
     : FailureDiagnostic(solution, destExpr), DestExpr(destExpr),
       Loc(diagnosticLoc),
@@ -3011,7 +3010,7 @@ bool NonOptionalUnwrapFailure::diagnoseAsError() {
   return true;
 }
 
-TypedNode MissingCallFailure::getAnchor() const {
+ASTNode MissingCallFailure::getAnchor() const {
   auto anchor = FailureDiagnostic::getAnchor();
 
   if (auto *FVE = getAsExpr<ForceValueExpr>(anchor))
@@ -3468,7 +3467,7 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
 
   auto anchor = getAnchor();
 
-  if (!anchor.is<const Expr *>())
+  if (!anchor.is<Expr *>())
     return false;
 
   Expr *expr = findParentExpr(castToExpr(anchor));
@@ -3743,7 +3742,7 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
     }
 
     // Fall back to a fix-it with a full type qualifier
-    const Expr *baseExpr = nullptr;
+    Expr *baseExpr = nullptr;
     if (const auto *SE = getAsExpr<SubscriptExpr>(getRawAnchor()))
       baseExpr = SE->getBase();
     else if (const auto UDE = getAsExpr<UnresolvedDotExpr>(getRawAnchor()))
@@ -3821,7 +3820,7 @@ bool ImplicitInitOnNonConstMetatypeFailure::diagnoseAsError() {
   return true;
 }
 
-TypedNode MissingArgumentsFailure::getAnchor() const {
+ASTNode MissingArgumentsFailure::getAnchor() const {
   auto anchor = FailureDiagnostic::getAnchor();
 
   if (auto *captureList = getAsExpr<CaptureListExpr>(anchor))
@@ -4300,7 +4299,7 @@ bool MissingArgumentsFailure::isMisplacedMissingArgument(
 }
 
 std::tuple<Expr *, Expr *, unsigned, bool>
-MissingArgumentsFailure::getCallInfo(TypedNode anchor) const {
+MissingArgumentsFailure::getCallInfo(ASTNode anchor) const {
   if (auto *call = getAsExpr<CallExpr>(anchor)) {
     return std::make_tuple(call->getFn(), call->getArg(),
                            call->getNumArguments(), call->hasTrailingClosure());
@@ -5056,8 +5055,8 @@ bool MissingGenericArgumentsFailure::diagnoseParameter(
     Anchor anchor, GenericTypeParamType *GP) const {
   auto &cs = getConstraintSystem();
 
-  auto loc = anchor.is<const Expr *>() ? anchor.get<const Expr *>()->getLoc()
-                                       : anchor.get<TypeRepr *>()->getLoc();
+  auto loc = anchor.is<Expr *>() ? anchor.get<Expr *>()->getLoc()
+                                 : anchor.get<TypeRepr *>()->getLoc();
 
   auto *locator = getLocator();
   // Type variables associated with missing generic parameters are
@@ -5111,7 +5110,7 @@ void MissingGenericArgumentsFailure::emitGenericSignatureNote(
     return;
 
   auto *GTD = dyn_cast<GenericTypeDecl>(paramDC);
-  if (!GTD || anchor.is<const Expr *>())
+  if (!GTD || anchor.is<Expr *>())
     return;
 
   auto getParamDecl =

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -34,7 +34,7 @@ using namespace constraints;
 
 ConstraintFix::~ConstraintFix() {}
 
-TypedNode ConstraintFix::getAnchor() const { return getLocator()->getAnchor(); }
+ASTNode ConstraintFix::getAnchor() const { return getLocator()->getAnchor(); }
 
 void ConstraintFix::print(llvm::raw_ostream &Out) const {
   Out << "[fix: ";

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -18,6 +18,7 @@
 #define SWIFT_SEMA_CSFIX_H
 
 #include "ConstraintLocator.h"
+#include "swift/AST/ASTNode.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/Identifier.h"
@@ -313,7 +314,7 @@ public:
   /// Retrieve anchor expression associated with this fix.
   /// NOTE: such anchor comes directly from locator without
   /// any simplication attempts.
-  TypedNode getAnchor() const;
+  ASTNode getAnchor() const;
   ConstraintLocator *getLocator() const { return Locator; }
 
 protected:

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -767,8 +767,8 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
   bool isVarAndNotProtocol2 = false;
 
   auto getWeight = [&](ConstraintLocator *locator) -> unsigned {
-    if (auto *anchor = locator->getAnchor().dyn_cast<const Expr *>()) {
-      auto weight = cs.getExprDepth(const_cast<Expr *>(anchor));
+    if (auto *anchor = locator->getAnchor().dyn_cast<Expr *>()) {
+      auto weight = cs.getExprDepth(anchor);
       if (weight)
         return *weight + 1;
     }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1353,7 +1353,7 @@ static bool isSingleTupleParam(ASTContext &ctx,
 }
 
 static ConstraintFix *fixRequirementFailure(ConstraintSystem &cs, Type type1,
-                                            Type type2, TypedNode anchor,
+                                            Type type2, ASTNode anchor,
                                             ArrayRef<LocatorPathElt> path);
 
 static ConstraintFix *fixRequirementFailure(ConstraintSystem &cs, Type type1,
@@ -1444,7 +1444,7 @@ assessRequirementFailureImpact(ConstraintSystem &cs, Type requirementType,
 
 /// Attempt to fix missing arguments by introducing type variables
 /// and inferring their types from parameters.
-static bool fixMissingArguments(ConstraintSystem &cs, TypedNode anchor,
+static bool fixMissingArguments(ConstraintSystem &cs, ASTNode anchor,
                                 SmallVectorImpl<AnyFunctionType::Param> &args,
                                 ArrayRef<AnyFunctionType::Param> params,
                                 unsigned numMissing,
@@ -2562,7 +2562,7 @@ ConstraintSystem::matchTypesBindTypeVar(
 }
 
 static ConstraintFix *fixRequirementFailure(ConstraintSystem &cs, Type type1,
-                                            Type type2, TypedNode anchor,
+                                            Type type2, ASTNode anchor,
                                             ArrayRef<LocatorPathElt> path) {
   // Can't fix not yet properly resolved types.
   if (type1->isTypeVariableOrMember() || type2->isTypeVariableOrMember())
@@ -2905,7 +2905,7 @@ static bool repairOutOfOrderArgumentsInBinaryFunction(
 
   bool isOperatorRef = overload->choice.getDecl()->isOperator();
 
-  auto matchArgToParam = [&](Type argType, Type paramType, TypedNode anchor) {
+  auto matchArgToParam = [&](Type argType, Type paramType, ASTNode anchor) {
     auto *loc = cs.getConstraintLocator(anchor);
     // If argument (and/or parameter) is a generic type let's not even try this
     // fix because it would be impossible to match given types  without delaying
@@ -2974,7 +2974,7 @@ bool ConstraintSystem::repairFailures(
     // explicit call.
     if (fnType->getNumParams() > 0) {
       auto anchor = simplifyLocatorToAnchor(getConstraintLocator(locator));
-      if (!anchor.is<const Expr *>())
+      if (!anchor.is<Expr *>())
         return false;
 
       auto overload = findSelectedOverloadFor(getAsExpr(anchor));
@@ -6307,7 +6307,7 @@ static ConstraintFix *validateInitializerRef(ConstraintSystem &cs,
   if (!anchor)
     return nullptr;
 
-  auto getType = [&cs](const Expr *expr) -> Type {
+  auto getType = [&cs](Expr *expr) -> Type {
     return cs.simplifyType(cs.getType(expr))->getRValueType();
   };
 
@@ -9219,7 +9219,7 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix, unsigned impact) {
   // Only useful to record if no pre-existing fix is associated with
   // current anchor or, in case of anchor being an expression, any of
   // its sub-expressions.
-  llvm::SmallDenseSet<TypedNode> anchors;
+  llvm::SmallDenseSet<ASTNode> anchors;
   for (const auto *fix : Fixes)
     anchors.insert(fix->getAnchor());
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -522,7 +522,7 @@ ConstraintSystem::SolverScope::~SolverScope() {
   // Remove any node types we registered.
   for (unsigned i :
            reverse(range(numAddedNodeTypes, cs.addedNodeTypes.size()))) {
-    TypedNode node = cs.addedNodeTypes[i].first;
+    auto node = cs.addedNodeTypes[i].first;
     if (Type oldType = cs.addedNodeTypes[i].second)
       cs.NodeTypes[node] = oldType;
     else

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -26,7 +26,7 @@
 using namespace swift;
 using namespace constraints;
 
-void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, TypedNode anchor,
+void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, ASTNode anchor,
                                 ArrayRef<PathElement> path) {
   id.AddPointer(anchor.getOpaqueValue());
   id.AddInteger(path.size());
@@ -247,6 +247,10 @@ bool ConstraintLocator::isForOptionalTry() const {
   return directlyAt<OptionalTryExpr>();
 }
 
+template <typename E> bool ConstraintLocator::directlyAt() const {
+  return isExpr<E>(getAnchor()) && getPath().empty();
+}
+
 GenericTypeParamType *ConstraintLocator::getGenericParameter() const {
   // Check whether we have a path that terminates at a generic parameter.
   return isForGenericParameter() ?
@@ -270,7 +274,7 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
   
   out << "locator@" << (void*) this << " [";
 
-  if (auto *expr = anchor.dyn_cast<const Expr *>()) {
+  if (auto *expr = anchor.dyn_cast<Expr *>()) {
     out << Expr::getKindName(expr->getKind());
     if (sm) {
       out << '@';

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -247,10 +247,6 @@ bool ConstraintLocator::isForOptionalTry() const {
   return directlyAt<OptionalTryExpr>();
 }
 
-template <typename E> bool ConstraintLocator::directlyAt() const {
-  return isExpr<E>(getAnchor()) && getPath().empty();
-}
-
 GenericTypeParamType *ConstraintLocator::getGenericParameter() const {
   // Check whether we have a path that terminates at a generic parameter.
   return isForGenericParameter() ?

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -381,7 +381,11 @@ public:
   bool isForOptionalTry() const;
 
   /// Determine whether this locator points directly to a given expression.
-  template <typename E> bool directlyAt() const;
+  template <typename E> bool directlyAt() const {
+    if (auto *expr = getAnchor().dyn_cast<Expr *>())
+      return isa<E>(expr) && getPath().empty();
+    return false;
+  }
 
   /// Attempts to cast the first path element of the locator to a specific
   /// \c LocatorPathElt subclass, returning \c None if either unsuccessful or

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -35,7 +35,7 @@
 namespace swift {
 
 class Expr;
-struct TypeLoc;
+class TypeLoc;
 class VarDecl;
 class Pattern;
 class SourceManager;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -364,13 +364,13 @@ getAlternativeLiteralTypes(KnownProtocolKind kind) {
 }
 
 ConstraintLocator *ConstraintSystem::getConstraintLocator(
-    TypedNode anchor, ArrayRef<ConstraintLocator::PathElement> path) {
+    ASTNode anchor, ArrayRef<ConstraintLocator::PathElement> path) {
   auto summaryFlags = ConstraintLocator::getSummaryFlagsForPath(path);
   return getConstraintLocator(anchor, path, summaryFlags);
 }
 
 ConstraintLocator *ConstraintSystem::getConstraintLocator(
-    TypedNode anchor, ArrayRef<ConstraintLocator::PathElement> path,
+    ASTNode anchor, ArrayRef<ConstraintLocator::PathElement> path,
     unsigned summaryFlags) {
   assert(summaryFlags == ConstraintLocator::getSummaryFlagsForPath(path));
 
@@ -423,7 +423,7 @@ ConstraintLocator *ConstraintSystem::getConstraintLocator(
 
 ConstraintLocator *ConstraintSystem::getCalleeLocator(
     ConstraintLocator *locator, bool lookThroughApply,
-    llvm::function_ref<Type(const Expr *)> getType,
+    llvm::function_ref<Type(Expr *)> getType,
     llvm::function_ref<Type(Type)> simplifyType,
     llvm::function_ref<Optional<SelectedOverload>(ConstraintLocator *)>
         getOverloadFor) {
@@ -3302,7 +3302,7 @@ constraints::simplifyLocator(ConstraintSystem &cs, ConstraintLocator *locator,
   return cs.getConstraintLocator(anchor, path);
 }
 
-void constraints::simplifyLocator(TypedNode &anchor,
+void constraints::simplifyLocator(ASTNode &anchor,
                                   ArrayRef<LocatorPathElt> &path,
                                   SourceRange &range) {
   range = SourceRange();
@@ -3514,7 +3514,7 @@ void constraints::simplifyLocator(TypedNode &anchor,
   }
 }
 
-TypedNode constraints::simplifyLocatorToAnchor(ConstraintLocator *locator) {
+ASTNode constraints::simplifyLocatorToAnchor(ConstraintLocator *locator) {
   if (!locator)
     return nullptr;
 
@@ -3531,7 +3531,7 @@ TypedNode constraints::simplifyLocatorToAnchor(ConstraintLocator *locator) {
   return path.empty() ? anchor : nullptr;
 }
 
-Expr *constraints::getArgumentExpr(TypedNode node, unsigned index) {
+Expr *constraints::getArgumentExpr(ASTNode node, unsigned index) {
   auto *expr = castToExpr(node);
   Expr *argExpr = nullptr;
   if (auto *AE = dyn_cast<ApplyExpr>(expr))
@@ -4460,26 +4460,20 @@ void ConstraintSystem::maybeProduceFallbackDiagnostic(
   ctx.Diags.diagnose(target.getLoc(), diag::failed_to_produce_diagnostic);
 }
 
-SourceLoc constraints::getLoc(TypedNode anchor) {
-  if (auto *E = anchor.dyn_cast<const Expr *>()) {
+SourceLoc constraints::getLoc(ASTNode anchor) {
+  if (auto *E = anchor.dyn_cast<Expr *>()) {
     return E->getLoc();
-  } else if (auto *T = anchor.dyn_cast<const TypeLoc *>()) {
+  } else if (auto *T = anchor.dyn_cast<TypeLoc *>()) {
     return T->getLoc();
-  } else if (auto *V = anchor.dyn_cast<const VarDecl *>()) {
-    return V->getNameLoc();
+  } else if (auto *V = anchor.dyn_cast<Decl *>()) {
+    if (auto VD = dyn_cast<VarDecl>(V))
+      return VD->getNameLoc();
+    return anchor.getStartLoc();
   } else {
-    return anchor.get<const Pattern *>()->getLoc();
+    return anchor.get<Pattern *>()->getLoc();
   }
 }
 
-SourceRange constraints::getSourceRange(TypedNode anchor) {
-  if (auto *E = anchor.dyn_cast<const Expr *>()) {
-    return E->getSourceRange();
-  } else if (auto *T = anchor.dyn_cast<const TypeLoc *>()) {
-    return T->getSourceRange();
-  } else if (auto *V = anchor.dyn_cast<const VarDecl *>()) {
-    return V->getSourceRange();
-  } else {
-    return anchor.get<const Pattern *>()->getSourceRange();
-  }
+SourceRange constraints::getSourceRange(ASTNode anchor) {
+  return anchor.getSourceRange();
 }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -188,7 +188,7 @@ Expr *ConstraintLocatorBuilder::trySimplifyToExpr() const {
   // Locators are not guaranteed to have an anchor
   // if constraint system is used to verify generic
   // requirements.
-  if (!anchor.is<const Expr *>())
+  if (!anchor.is<Expr *>())
     return nullptr;
 
   ArrayRef<LocatorPathElt> path = pathBuffer;
@@ -3021,18 +3021,17 @@ void ConstraintSystem::dump(Expr *E) const {
 }
 
 void ConstraintSystem::print(raw_ostream &out, Expr *E) const {
-  auto getTypeOfExpr = [&](const Expr *E) -> Type {
+  auto getTypeOfExpr = [&](Expr *E) -> Type {
     if (hasType(E))
       return getType(E);
     return Type();
   };
-  auto getTypeOfTypeLoc = [&](const TypeLoc &TL) -> Type {
+  auto getTypeOfTypeLoc = [&](TypeLoc &TL) -> Type {
     if (hasType(TL))
       return getType(TL);
     return Type();
   };
-  auto getTypeOfKeyPathComponent =
-      [&](const KeyPathExpr *KP, unsigned I) -> Type {
+  auto getTypeOfKeyPathComponent = [&](KeyPathExpr *KP, unsigned I) -> Type {
     if (hasType(KP, I))
       return getType(KP, I);
     return Type();


### PR DESCRIPTION
This is mostly a refactoring to avoid using special typealias `TypedNode` and switch
to use `ASTNode` to represent constraint locator anchor and cache types in the constraint
system. This also allows to drop `const` qualifiers from `{set, get}Type` and align
everything to use `Expr *`.

Note that `{castTo, getAs, is}Expr` accessors still left in place for now, they could be adjusted
separately.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
