### PR TITLE
Move AST transforms out of the Frontend

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -139,9 +139,26 @@ namespace swift {
     /// Allow throwing call expressions without annotation with 'try'.
     bool EnableThrowWithoutTry = false;
 
+    /// If set, inserts instrumentation useful for testing the debugger.
+    bool DebuggerTestingTransform = false;
+
+    /// Indicates whether the AST should be instrumented to simulate a
+    /// debugger's program counter. Similar to the PlaygroundTransform, this
+    /// will instrument the AST with function calls that get called when you
+    /// would see a program counter move in a debugger. To adopt this implement
+    /// the __builtin_pc_before and __builtin_pc_after functions.
+    bool PCMacro = false;
+
     /// Enable features useful for running playgrounds.
     // FIXME: This should probably be limited to the particular SourceFile.
     bool Playground = false;
+
+    /// Indicates whether the playground transformation should be applied.
+    bool PlaygroundTransform = false;
+
+    /// Indicates whether the playground transformation should omit
+    /// instrumentation that has a high runtime performance impact.
+    bool PlaygroundHighPerformance = false;
 
     /// Keep comments during lexing and attach them to declarations.
     bool AttachCommentsToDecls = false;

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -671,7 +671,6 @@ private:
   ImplicitImportInfo getImplicitImportInfo() const;
 
   void performSemaUpTo(SourceFile::ASTStage_t LimitStage);
-  void parseAndCheckTypesUpTo(SourceFile::ASTStage_t LimitStage);
 
   /// Return true if had load error
   bool parsePartialModulesAndInputFiles();

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -154,9 +154,6 @@ public:
   /// the module.
   bool CheckOnoneSupportCompleteness = false;
 
-  /// If set, inserts instrumentation useful for testing the debugger.
-  bool DebuggerTestingTransform = false;
-
   /// If set, dumps wall time taken to check each function body to llvm::errs().
   bool DebugTimeFunctionBodies = false;
 
@@ -222,20 +219,6 @@ public:
   /// Indicates whether or not the Clang importer should print statistics upon
   /// termination.
   bool PrintClangStats = false;
-
-  /// Indicates whether the playground transformation should be applied.
-  bool PlaygroundTransform = false;
-  
-  /// Indicates whether the AST should be instrumented to simulate a debugger's
-  /// program counter. Similar to the PlaygroundTransform, this will instrument
-  /// the AST with function calls that get called when you would see a program
-  /// counter move in a debugger. To adopt this implement the
-  /// __builtin_pc_before and __builtin_pc_after functions.
-  bool PCMacro = false;
-
-  /// Indicates whether the playground transformation should omit
-  /// instrumentation that has a high runtime performance impact.
-  bool PlaygroundHighPerformance = false;
 
   /// Indicates whether standard help should be shown.
   bool PrintHelp = false;

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -103,13 +103,6 @@ bool ArgsToFrontendOptionsConverter::convert(
 
   Opts.CheckOnoneSupportCompleteness = Args.hasArg(OPT_check_onone_completeness);
 
-  Opts.DebuggerTestingTransform = Args.hasArg(OPT_debugger_testing_transform);
-
-  computePlaygroundOptions();
-
-  // This can be enabled independently of the playground transform.
-  Opts.PCMacro |= Args.hasArg(OPT_pc_macro);
-
   Opts.ParseStdlib |= Args.hasArg(OPT_parse_stdlib);
 
   Opts.IgnoreSwiftSourceInfo |= Args.hasArg(OPT_ignore_module_source_info);
@@ -259,15 +252,6 @@ void ArgsToFrontendOptionsConverter::computeTBDOptions() {
                      A->getOption().getPrefixedName(), value);
     }
   }
-}
-
-void ArgsToFrontendOptionsConverter::computePlaygroundOptions() {
-  using namespace options;
-  Opts.PlaygroundTransform |= Args.hasArg(OPT_playground);
-  if (Args.hasArg(OPT_disable_playground_transform))
-    Opts.PlaygroundTransform = false;
-  Opts.PlaygroundHighPerformance |=
-      Args.hasArg(OPT_playground_high_performance);
 }
 
 void ArgsToFrontendOptionsConverter::computeHelpOptions() {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -451,7 +451,19 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.DebuggerSupport |= Args.hasArg(OPT_debugger_support);
   if (Opts.DebuggerSupport)
     Opts.EnableDollarIdentifiers = true;
+
+  Opts.DebuggerTestingTransform = Args.hasArg(OPT_debugger_testing_transform);
+
   Opts.Playground |= Args.hasArg(OPT_playground);
+  Opts.PlaygroundTransform |= Args.hasArg(OPT_playground);
+  if (Args.hasArg(OPT_disable_playground_transform))
+    Opts.PlaygroundTransform = false;
+  Opts.PlaygroundHighPerformance |=
+      Args.hasArg(OPT_playground_high_performance);
+
+  // This can be enabled independently of the playground transform.
+  Opts.PCMacro |= Args.hasArg(OPT_pc_macro);
+
   Opts.InferImportAsMember |= Args.hasArg(OPT_enable_infer_import_as_member);
 
   Opts.EnableThrowWithoutTry |= Args.hasArg(OPT_enable_throw_without_try);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -846,18 +846,6 @@ void CompilerInstance::parseAndCheckTypesUpTo(
       SILParserState SILContext(TheSILModule.get());
       parseSourceFileSIL(SF, &SILContext);
     }
-
-    auto &opts = Invocation.getFrontendOptions();
-    if (!Context->hadError() && opts.DebuggerTestingTransform)
-      performDebuggerTestingTransform(SF);
-
-    if (!Context->hadError() && opts.PCMacro)
-      performPCMacro(SF);
-
-    // Playground transform knows to look out for PCMacro's changes and not
-    // to playground log them.
-    if (!Context->hadError() && opts.PlaygroundTransform)
-      performPlaygroundTransform(SF, opts.PlaygroundHighPerformance);
   });
 
   // If the limiting AST stage is import resolution, we're done.

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -382,6 +382,18 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
     performWholeModuleTypeChecking(*SF);
   }
 
+  // Perform various AST transforms we've been asked to perform.
+  if (!Ctx.hadError() && Ctx.LangOpts.DebuggerTestingTransform)
+    performDebuggerTestingTransform(*SF);
+
+  if (!Ctx.hadError() && Ctx.LangOpts.PCMacro)
+    performPCMacro(*SF);
+
+  // Playground transform knows to look out for PCMacro's changes and not
+  // to playground log them.
+  if (!Ctx.hadError() && Ctx.LangOpts.PlaygroundTransform)
+    performPlaygroundTransform(*SF, Ctx.LangOpts.PlaygroundHighPerformance);
+
   return std::make_tuple<>();
 }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -520,19 +520,21 @@ bool SwiftASTManager::initCompilerInvocation(
   ImporterOpts.DetailedPreprocessingRecord = true;
 
   assert(!Invocation.getModuleName().empty());
-  Invocation.getLangOptions().AttachCommentsToDecls = true;
-  Invocation.getLangOptions().DiagnosticsEditorMode = true;
-  Invocation.getLangOptions().CollectParsedToken = true;
-  auto &FrontendOpts = Invocation.getFrontendOptions();
-  if (FrontendOpts.PlaygroundTransform) {
+
+  auto &LangOpts = Invocation.getLangOptions();
+  LangOpts.AttachCommentsToDecls = true;
+  LangOpts.DiagnosticsEditorMode = true;
+  LangOpts.CollectParsedToken = true;
+  if (LangOpts.PlaygroundTransform) {
     // The playground instrumenter changes the AST in ways that disrupt the
     // SourceKit functionality. Since we don't need the instrumenter, and all we
     // actually need is the playground semantics visible to the user, like
     // silencing the "expression resolves to an unused l-value" error, disable it.
-    FrontendOpts.PlaygroundTransform = false;
+    LangOpts.PlaygroundTransform = false;
   }
 
   // Disable the index-store functionality for the sourcekitd requests.
+  auto &FrontendOpts = Invocation.getFrontendOptions();
   FrontendOpts.IndexStorePath.clear();
   ImporterOpts.IndexStorePath.clear();
 


### PR DESCRIPTION
Move the playground and debugger transform calls out of the Frontend and into `performTypeChecking`, as we'd want them to be applied if `performTypeChecking` was called lazily.