### PR TITLE
[5.3][Foundation] Adjust Foundation shims for compatibility

### DIFF
--- a/stdlib/public/Darwin/Foundation/NSObject.swift
+++ b/stdlib/public/Darwin/Foundation/NSObject.swift
@@ -12,7 +12,7 @@
 
 @_exported import Foundation // Clang module
 import ObjectiveC
-import _SwiftFoundationOverlayShims
+@_implementationOnly import _SwiftFoundationOverlayShims
 
 // This exists to allow for dynamic dispatch on KVO methods added to NSObject.
 // Extending NSObject with these methods would disallow overrides.

--- a/stdlib/public/SwiftShims/FoundationOverlayShims.h
+++ b/stdlib/public/SwiftShims/FoundationOverlayShims.h
@@ -34,6 +34,44 @@
 #import "NSTimeZoneShims.h"
 #import "NSUndoManagerShims.h"
 
+typedef struct {
+    void *_Nonnull memory;
+    size_t capacity;
+    _Bool onStack;
+} _ConditionalAllocationBuffer;
+
+static inline _Bool _resizeConditionalAllocationBuffer(_ConditionalAllocationBuffer *_Nonnull buffer, size_t amt) {
+    size_t amount = malloc_good_size(amt);
+    if (amount <= buffer->capacity) { return true; }
+    void *newMemory;
+    if (buffer->onStack) {
+        newMemory = malloc(amount);
+        if (newMemory == NULL) { return false; }
+        memcpy(newMemory, buffer->memory, buffer->capacity);
+        buffer->onStack = false;
+    } else {
+        newMemory = realloc(buffer->memory, amount);
+        if (newMemory == NULL) { return false; }
+    }
+    if (newMemory == NULL) { return false; }
+    buffer->memory = newMemory;
+    buffer->capacity = amount;
+    return true;
+}
+
+static inline _Bool _withStackOrHeapBuffer(size_t amount, void (__attribute__((noescape)) ^ _Nonnull applier)(_ConditionalAllocationBuffer *_Nonnull)) {
+    _ConditionalAllocationBuffer buffer;
+    buffer.capacity = malloc_good_size(amount);
+    buffer.onStack = (pthread_main_np() != 0 ? buffer.capacity < 2048 : buffer.capacity < 512);
+    buffer.memory = buffer.onStack ? alloca(buffer.capacity) : malloc(buffer.capacity);
+    if (buffer.memory == NULL) { return false; }
+    applier(&buffer);
+    if (!buffer.onStack) {
+        free(buffer.memory);
+    }
+    return true;
+}
+
 @protocol _NSKVOCompatibilityShim <NSObject>
 + (void)_noteProcessHasUsedKVOSwiftOverlay;
 @end


### PR DESCRIPTION
Cherry-picked from #31380.

- Adjust stray public import of `_SwiftFoundationOverlayShims`
- Re-add Foundation shims that were removed in #28918. The current version of the Foundation overlay doesn’t use these, but we should still keep them in case a toolchain snapshot build picks up an overlay module from one of the SDKs in Xcode 11.

rdar://62339802