### PR TITLE
[5.3] [Diagnostics] Update compiler diagnostics to use less jargon.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -795,19 +795,19 @@ ERROR(unspaced_unary_operator,none,
       "unary operators must not be juxtaposed; parenthesize inner expression",
       ())
 
-ERROR(use_unresolved_identifier,none,
-      "use of unresolved %select{identifier|operator}1 %0", (DeclNameRef, bool))
-ERROR(use_unresolved_identifier_corrected,none,
-      "use of unresolved %select{identifier|operator}1 %0; did you mean '%2'?",
+ERROR(cannot_find_in_scope,none,
+      "cannot %select{find|find operator}1 %0 in scope", (DeclNameRef, bool))
+ERROR(cannot_find_in_scope_corrected,none,
+      "cannot %select{find|find operator}1 %0 in scope; did you mean '%2'?",
       (DeclNameRef, bool, StringRef))
 NOTE(confusable_character,none,
       "%select{identifier|operator}0 '%1' contains possibly confused characters; "
       "did you mean to use '%2'?",
       (bool, StringRef, StringRef))
-ERROR(use_undeclared_type,none,
-      "use of undeclared type %0", (DeclNameRef))
-ERROR(use_undeclared_type_did_you_mean,none,
-      "use of undeclared type %0; did you mean to use '%1'?", (DeclNameRef, StringRef))
+ERROR(cannot_find_type_in_scope,none,
+      "cannot find type %0 in scope", (DeclNameRef))
+ERROR(cannot_find_type_in_scope_did_you_mean,none,
+      "cannot find type %0 in scope; did you mean to use '%1'?", (DeclNameRef, StringRef))
 NOTE(note_typo_candidate_implicit_member,none,
      "did you mean the implicitly-synthesized %1 '%0'?", (StringRef, StringRef))
 NOTE(note_remapped_type,none,
@@ -3660,9 +3660,9 @@ ERROR(continue_not_in_this_stmt,none,
       "'continue' cannot be used with %0 statements", (StringRef))
 
 ERROR(unresolved_label,none,
-      "use of unresolved label %0", (Identifier))
+      "cannot find label %0 in scope", (Identifier))
 ERROR(unresolved_label_corrected,none,
-      "use of unresolved label %0; did you mean %1?",
+      "cannot find label %0 in scope; did you mean %1?",
       (Identifier, Identifier))
 
 ERROR(foreach_sequence_does_not_conform_to_expected_protocol,none,

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -575,7 +575,7 @@ public:
         Context, BeforeLoggerRef, ArgsWithSourceRange, ArgLabels);
     Added<ApplyExpr *> AddedBeforeLogger(BeforeLoggerCall);
     if (!doTypeCheck(Context, TypeCheckDC, AddedBeforeLogger)) {
-      // typically due to 'use of unresolved identifier '__builtin_pc_before''
+      // typically due to 'cannot find '__builtin_pc_before' in scope'
       return E; // return E, it will be used in recovering from TC failure
     }
 
@@ -587,7 +587,7 @@ public:
         Context, AfterLoggerRef, ArgsWithSourceRange, ArgLabels);
     Added<ApplyExpr *> AddedAfterLogger(AfterLoggerCall);
     if (!doTypeCheck(Context, TypeCheckDC, AddedAfterLogger)) {
-      // typically due to 'use of unresolved identifier '__builtin_pc_after''
+      // typically due to 'cannot find '__builtin_pc_after' in scope'
       return E; // return E, it will be used in recovering from TC failure
     }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3482,7 +3482,7 @@ static AbstractFunctionDecl *findAbstractFunctionDecl(
 
   // Otherwise, emit the appropriate diagnostic and return nullptr.
   if (results.empty()) {
-    ctx.Diags.diagnose(funcNameLoc, diag::use_unresolved_identifier, funcName,
+    ctx.Diags.diagnose(funcNameLoc, diag::cannot_find_in_scope, funcName,
                        funcName.isOperator());
     return nullptr;
   }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -392,7 +392,7 @@ static bool diagnoseRangeOperatorMisspell(DiagnosticEngine &Diags,
 
   if (!corrected.empty()) {
     Diags
-        .diagnose(UDRE->getLoc(), diag::use_unresolved_identifier_corrected,
+        .diagnose(UDRE->getLoc(), diag::cannot_find_in_scope_corrected,
                   UDRE->getName(), true, corrected)
         .highlight(UDRE->getSourceRange())
         .fixItReplace(UDRE->getSourceRange(), corrected);
@@ -416,7 +416,7 @@ static bool diagnoseIncDecOperator(DiagnosticEngine &Diags,
 
   if (!corrected.empty()) {
     Diags
-        .diagnose(UDRE->getLoc(), diag::use_unresolved_identifier_corrected,
+        .diagnose(UDRE->getLoc(), diag::cannot_find_in_scope_corrected,
                   UDRE->getName(), true, corrected)
         .highlight(UDRE->getSourceRange());
 
@@ -537,7 +537,7 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
 
     auto emitBasicError = [&] {
       Context.Diags
-          .diagnose(Loc, diag::use_unresolved_identifier, Name,
+          .diagnose(Loc, diag::cannot_find_in_scope, Name,
                     Name.isOperator())
           .highlight(UDRE->getSourceRange());
     };
@@ -561,7 +561,7 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
 
       if (auto typo = corrections.claimUniqueCorrection()) {
         auto diag = Context.Diags.diagnose(
-            Loc, diag::use_unresolved_identifier_corrected, Name,
+            Loc, diag::cannot_find_in_scope_corrected, Name,
             Name.isOperator(), typo->CorrectedName.getBaseIdentifier().str());
         diag.highlight(UDRE->getSourceRange());
         typo->addFixits(diag);

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -263,7 +263,7 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
         diags.diagnose(componentNameLoc, diag::could_not_find_type_member,
                        currentType, componentName);
       else
-        diags.diagnose(componentNameLoc, diag::use_unresolved_identifier,
+        diags.diagnose(componentNameLoc, diag::cannot_find_in_scope,
                        componentName, false);
 
       // Note all the correction candidates.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1140,7 +1140,7 @@ static Type diagnoseUnknownType(TypeResolution resolution,
     auto I = Remapped.find(TypeName);
     if (I != Remapped.end()) {
       auto RemappedTy = I->second->getString();
-      diags.diagnose(L, diag::use_undeclared_type_did_you_mean,
+      diags.diagnose(L, diag::cannot_find_type_in_scope_did_you_mean,
                      comp->getNameRef(), RemappedTy)
         .highlight(R)
         .fixItReplace(R, RemappedTy);
@@ -1157,7 +1157,7 @@ static Type diagnoseUnknownType(TypeResolution resolution,
       return I->second;
     }
 
-    diags.diagnose(L, diag::use_undeclared_type,
+    diags.diagnose(L, diag::cannot_find_type_in_scope,
                 comp->getNameRef())
       .highlight(R);
 
@@ -1653,7 +1653,7 @@ Type TypeChecker::resolveIdentifierType(
     if (!options.contains(TypeResolutionFlags::SilenceErrors)) {
       auto moduleName = moduleTy->getModule()->getName();
       diags.diagnose(Components.back()->getNameLoc(),
-                     diag::use_undeclared_type, DeclNameRef(moduleName));
+                     diag::cannot_find_type_in_scope, DeclNameRef(moduleName));
       diags.diagnose(Components.back()->getNameLoc(),
                      diag::note_module_as_type, moduleName);
     }

--- a/test/APINotes/versioned.swift
+++ b/test/APINotes/versioned.swift
@@ -158,7 +158,7 @@ func testRenamedUnknownEnum() {
 }
 
 func testRenamedTrueEnum() {
-  // CHECK-DIAGS: [[@LINE+1]]:7: error: use of unresolved identifier 'TrueEnumValue'
+  // CHECK-DIAGS: [[@LINE+1]]:7: error: cannot find 'TrueEnumValue' in scope
   _ = TrueEnumValue
 
   // CHECK-DIAGS: [[@LINE+1]]:16: error: type 'TrueEnum' has no member 'TrueEnumValue'
@@ -169,7 +169,7 @@ func testRenamedTrueEnum() {
 
   _ = TrueEnum.value // okay
 
-  // CHECK-DIAGS: [[@LINE+1]]:7: error: use of unresolved identifier 'TrueEnumRenamed'
+  // CHECK-DIAGS: [[@LINE+1]]:7: error: cannot find 'TrueEnumRenamed' in scope
   _ = TrueEnumRenamed
 
   // CHECK-DIAGS: [[@LINE+1]]:16: error: type 'TrueEnum' has no member 'TrueEnumRenamed'
@@ -190,7 +190,7 @@ func testRenamedTrueEnum() {
   _ = TrueEnum.renamedSwift4
   // CHECK-DIAGS-4-NOT: :[[@LINE-1]]:16:
 
-  // CHECK-DIAGS: [[@LINE+1]]:7: error: use of unresolved identifier 'TrueEnumAliasRenamed'
+  // CHECK-DIAGS: [[@LINE+1]]:7: error: cannot find 'TrueEnumAliasRenamed' in scope
   _ = TrueEnumAliasRenamed
 
   // CHECK-DIAGS: [[@LINE+1]]:16: error: type 'TrueEnum' has no member 'TrueEnumAliasRenamed'
@@ -213,7 +213,7 @@ func testRenamedTrueEnum() {
 }
 
 func testRenamedOptionyEnum() {
-  // CHECK-DIAGS: [[@LINE+1]]:7: error: use of unresolved identifier 'OptionyEnumValue'
+  // CHECK-DIAGS: [[@LINE+1]]:7: error: cannot find 'OptionyEnumValue' in scope
   _ = OptionyEnumValue
 
   // CHECK-DIAGS: [[@LINE+1]]:19: error: type 'OptionyEnum' has no member 'OptionyEnumValue'
@@ -224,7 +224,7 @@ func testRenamedOptionyEnum() {
 
   _ = OptionyEnum.value // okay
 
-  // CHECK-DIAGS: [[@LINE+1]]:7: error: use of unresolved identifier 'OptionyEnumRenamed'
+  // CHECK-DIAGS: [[@LINE+1]]:7: error: cannot find 'OptionyEnumRenamed' in scope
   _ = OptionyEnumRenamed
 
   // CHECK-DIAGS: [[@LINE+1]]:19: error: type 'OptionyEnum' has no member 'OptionyEnumRenamed'

--- a/test/AutoDiff/Sema/DerivedConformances/class_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/class_differentiable.swift
@@ -490,7 +490,7 @@ where T: Differentiable {}
 
 // TF-265: Test invalid initializer (that uses a non-existent type).
 class InvalidInitializer: Differentiable {
-  init(filterShape: (Int, Int, Int, Int), blah: NonExistentType) {}  // expected-error {{use of undeclared type 'NonExistentType'}}
+  init(filterShape: (Int, Int, Int, Int), blah: NonExistentType) {}  // expected-error {{cannot find type 'NonExistentType' in scope}}
 }
 
 // Test memberwise initializer synthesis.

--- a/test/AutoDiff/Sema/DerivedConformances/struct_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/struct_differentiable.swift
@@ -308,7 +308,7 @@ where T: Differentiable {}
 
 // TF-265: Test invalid initializer (that uses a non-existent type).
 struct InvalidInitializer: Differentiable {
-  init(filterShape: (Int, Int, Int, Int), blah: NonExistentType) {}  // expected-error {{use of undeclared type 'NonExistentType'}}
+  init(filterShape: (Int, Int, Int, Int), blah: NonExistentType) {}  // expected-error {{cannot find type 'NonExistentType' in scope}}
 }
 
 // Test memberwise initializer synthesis.

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -70,7 +70,7 @@ func vjpSubtractWrt1(x: Float, y: Float) -> (value: Float, pullback: (Float) -> 
 
 // Test invalid original function.
 
-// expected-error @+1 {{use of unresolved identifier 'nonexistentFunction'}}
+// expected-error @+1 {{cannot find 'nonexistentFunction' in scope}}
 @derivative(of: nonexistentFunction)
 func vjpOriginalFunctionNotFound(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
   fatalError()
@@ -78,7 +78,7 @@ func vjpOriginalFunctionNotFound(_ x: Float) -> (value: Float, pullback: (Float)
 
 // Test `@derivative` attribute where `value:` result does not conform to `Differentiable`.
 // Invalid original function should be diagnosed first.
-// expected-error @+1 {{use of unresolved identifier 'nonexistentFunction'}}
+// expected-error @+1 {{cannot find 'nonexistentFunction' in scope}}
 @derivative(of: nonexistentFunction)
 func vjpOriginalFunctionNotFound2(_ x: Float) -> (value: Int, pullback: (Float) -> Float) {
   fatalError()

--- a/test/AutoDiff/compiler_crashers_fixed/tf1167-differentiable-attr-override-match.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/tf1167-differentiable-attr-override-match.swift
@@ -10,7 +10,7 @@
 
 public protocol Base {
   associatedtype Input
-  // expected-error @+1 {{use of undeclared type 'Differentiable'}}
+  // expected-error @+1 {{cannot find type 'Differentiable' in scope}}
   associatedtype Output: Differentiable
 
   // expected-error @+1 {{@differentiable attribute used without importing module '_Differentiation'}}

--- a/test/ClangImporter/CoreServices_test.swift
+++ b/test/ClangImporter/CoreServices_test.swift
@@ -7,10 +7,10 @@ import CoreServices
 func test(_ url: CFURL, ident: CSIdentity) {
   _ = CSBackupIsItemExcluded(url, nil) // okay
 
-  _ = nil as TypeThatDoesNotExist? // expected-error {{use of undeclared type 'TypeThatDoesNotExist'}}
+  _ = nil as TypeThatDoesNotExist? // expected-error {{cannot find type 'TypeThatDoesNotExist' in scope}}
   _ = nil as CoreServices.Collection? // okay
 
-  _ = kCollectionNoAttributes // expected-error{{use of unresolved identifier 'kCollectionNoAttributes'}}
+  _ = kCollectionNoAttributes // expected-error{{cannot find 'kCollectionNoAttributes' in scope}}
 
   var name: Unmanaged<CFString>?
   _ = LSCopyDisplayNameForURL(url, &name) as OSStatus // okay
@@ -22,6 +22,6 @@ func test(_ url: CFURL, ident: CSIdentity) {
   _ = CSIdentityCreateCopy(nil, ident) // okay
 
   var vers: UInt32 = 0
-  _ = KCGetKeychainManagerVersion(&vers) as OSStatus// expected-error{{use of unresolved identifier 'KCGetKeychainManagerVersion'}}
+  _ = KCGetKeychainManagerVersion(&vers) as OSStatus// expected-error{{cannot find 'KCGetKeychainManagerVersion' in scope}}
   _ = CoreServices.KCGetKeychainManagerVersion(&vers) as OSStatus// okay
 }

--- a/test/ClangImporter/Darwin_test.swift
+++ b/test/ClangImporter/Darwin_test.swift
@@ -5,7 +5,7 @@
 import Darwin
 import MachO
 
-_ = nil as Fract? // expected-error{{use of undeclared type 'Fract'}}
+_ = nil as Fract? // expected-error{{cannot find type 'Fract' in scope}}
 _ = nil as Darwin.Fract? // okay
 
 _ = 0 as OSErr
@@ -14,8 +14,8 @@ _ = 0 as UniChar
 
 _ = ProcessSerialNumber()
 
-_ = 0 as Byte // expected-error {{use of undeclared type 'Byte'}} {{10-14=UInt8}}
+_ = 0 as Byte // expected-error {{cannot find type 'Byte' in scope}} {{10-14=UInt8}}
 Darwin.fakeAPIUsingByteInDarwin() as Int // expected-error {{cannot convert value of type 'UInt8' to type 'Int' in coercion}}
 
-_ = FALSE // expected-error {{use of unresolved identifier 'FALSE'}}
+_ = FALSE // expected-error {{cannot find 'FALSE' in scope}}
 _ = DYLD_BOOL.FALSE

--- a/test/ClangImporter/MixedSource/Xcc_include.swift
+++ b/test/ClangImporter/MixedSource/Xcc_include.swift
@@ -6,18 +6,18 @@
 // CHECK-INCLUDE-MISSING: error: '{{.*}}this_header_does_not_exist.h' file not found
 
 func test() {
-  // CHECK-INCLUDE-ONLY: error: use of unresolved identifier 'includedConst'
-  // CHECK-INCLUDE-PLUS-BRIDGING-NOT: unresolved identifier 'includedConst'
-  // CHECK-INCLUDE-FRAMEWORK: error: use of unresolved identifier 'includedConst'
+  // CHECK-INCLUDE-ONLY: error: cannot find 'includedConst' in scope
+  // CHECK-INCLUDE-PLUS-BRIDGING-NOT: cannot find 'includedConst' in scope
+  // CHECK-INCLUDE-FRAMEWORK: error: cannot find 'includedConst' in scope
   _ = includedConst
   
-  // CHECK-INCLUDE-ONLY: error: use of unresolved identifier 'errSecSuccess'
-  // CHECK-INCLUDE-PLUS-BRIDGING: error: use of unresolved identifier 'errSecSuccess'
-  // CHECK-INCLUDE-FRAMEWORK: error: use of unresolved identifier 'errSecSuccess'
+  // CHECK-INCLUDE-ONLY: error: cannot find 'errSecSuccess' in scope
+  // CHECK-INCLUDE-PLUS-BRIDGING: error: cannot find 'errSecSuccess' in scope
+  // CHECK-INCLUDE-FRAMEWORK: error: cannot find 'errSecSuccess' in scope
   _ = errSecSuccess
 
 #if FRAMEWORK
-  // CHECK-INCLUDE-FRAMEWORK-NOT: error: unresolved identifier 'Base'
+  // CHECK-INCLUDE-FRAMEWORK-NOT: error: cannot find 'Base' in scope
   _ = Base()
 #endif
 }

--- a/test/ClangImporter/MixedSource/broken-bridging-header.swift
+++ b/test/ClangImporter/MixedSource/broken-bridging-header.swift
@@ -32,4 +32,4 @@ import HasBridgingHeader // expected-error {{failed to import bridging header}} 
 // HEADER-ERROR: error: failed to import bridging header '{{.*}}/error-on-define.h'
 // HEADER-ERROR-NOT: error:
 
-let _ = x // expected-error {{use of unresolved identifier 'x'}}
+let _ = x // expected-error {{cannot find 'x' in scope}}

--- a/test/ClangImporter/MixedSource/broken-modules.swift
+++ b/test/ClangImporter/MixedSource/broken-modules.swift
@@ -37,4 +37,4 @@ import BrokenClangModule
 
 
 _ = BrokenClangModule.x
-// CHECK: broken-modules.swift:[[@LINE-1]]:5: error: use of unresolved identifier 'BrokenClangModule'
+// CHECK: broken-modules.swift:[[@LINE-1]]:5: error: cannot find 'BrokenClangModule' in scope

--- a/test/ClangImporter/MixedSource/can_import_objc_idempotent.swift
+++ b/test/ClangImporter/MixedSource/can_import_objc_idempotent.swift
@@ -18,21 +18,21 @@
 // current module.  Only an 'import Foo' statement should do this.
 
 #if canImport(AppKit)
-  class AppKitView : NSView {} // expected-error {{use of undeclared type 'NSView'}}
+  class AppKitView : NSView {} // expected-error {{cannot find type 'NSView' in scope}}
 #endif
 
 #if canImport(UIKit)
-  class UIKitView : UIView {} // expected-error {{use of undeclared type 'UIView'}}
+  class UIKitView : UIView {} // expected-error {{cannot find type 'UIView' in scope}}
 #endif
 
 #if canImport(CoreGraphics)
   let square = CGRect(x: 100, y: 100, width: 100, height: 100)
-  // expected-error@-1 {{use of unresolved identifier 'CGRect'}}
+  // expected-error@-1 {{cannot find 'CGRect' in scope}}
 
   let (r, s) = square.divided(atDistance: 50, from: .minXEdge)
 #endif
 
 #if canImport(MixedWithHeader)
-let object = NSObject() // expected-error {{use of unresolved identifier 'NSObject'}}
-let someAPI = Derived() // expected-error {{use of unresolved identifier 'Derived'}}
+let object = NSObject() // expected-error {{cannot find 'NSObject' in scope}}
+let someAPI = Derived() // expected-error {{cannot find 'Derived' in scope}}
 #endif

--- a/test/ClangImporter/MixedSource/mixed-target-using-header.swift
+++ b/test/ClangImporter/MixedSource/mixed-target-using-header.swift
@@ -48,7 +48,7 @@ func testStruct(_ p: Point2D) -> Point2D {
 
 #if !SILGEN
 func testSuppressed() {
-  let _: __int128_t? = nil // expected-error{{use of undeclared type '__int128_t'}}
+  let _: __int128_t? = nil // expected-error{{cannot find type '__int128_t' in scope}}
 }
 #endif
 

--- a/test/ClangImporter/attr-swift_name_renaming.swift
+++ b/test/ClangImporter/attr-swift_name_renaming.swift
@@ -20,7 +20,7 @@ func test() {
 
   // Typedef-of-anonymous-type-name renaming
   var p = Point()
-  var p2 = PointType() // FIXME: should provide Fix-It expected-error{{use of unresolved identifier 'PointType'}} {{none}}
+  var p2 = PointType() // FIXME: should provide Fix-It expected-error{{cannot find 'PointType' in scope}} {{none}}
 
   // Field name remapping
   p.x = 7

--- a/test/ClangImporter/attr-swift_private.swift
+++ b/test/ClangImporter/attr-swift_private.swift
@@ -94,9 +94,9 @@ public func testTopLevel() {
   _ = __PrivS1()
 
 #if !IRGEN
-  let _ = PrivFooSub() // expected-error {{use of unresolved identifier}}
-  privTest() // expected-error {{use of unresolved identifier}}
-  PrivS1() // expected-error {{use of unresolved identifier}}
+  let _ = PrivFooSub() // expected-error {{cannot find 'PrivFooSub' in scope}}
+  privTest() // expected-error {{cannot find 'privTest' in scope}}
+  PrivS1() // expected-error {{cannot find 'PrivS1' in scope}}
 #endif
 }
 

--- a/test/ClangImporter/bad-ns-extensible-string-enum.swift
+++ b/test/ClangImporter/bad-ns-extensible-string-enum.swift
@@ -1,3 +1,3 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -enable-objc-interop -import-objc-header %S/Inputs/bad-ns-extensible-string-enum.h -verify
 
-let string = MyString.MyStringOne // expected-error {{use of unresolved identifier 'MyString'}}
+let string = MyString.MyStringOne // expected-error {{cannot find 'MyString' in scope}}

--- a/test/ClangImporter/ctypes_parse.swift
+++ b/test/ClangImporter/ctypes_parse.swift
@@ -113,7 +113,7 @@ func testFuncStructDisambiguation() {
 }
 
 func testVoid() {
-  var x: MyVoid // expected-error{{use of undeclared type 'MyVoid'}}
+  var x: MyVoid // expected-error{{cannot find type 'MyVoid' in scope}}
   returnsMyVoid()
 }
 

--- a/test/ClangImporter/ctypes_parse_objc.swift
+++ b/test/ClangImporter/ctypes_parse_objc.swift
@@ -84,7 +84,7 @@ func testImportCFTypes() {
 }
 
 func testImportSEL() {
-  var t1 : SEL // expected-error {{use of undeclared type 'SEL'}} {{12-15=Selector}}
+  var t1 : SEL // expected-error {{cannot find type 'SEL' in scope}} {{12-15=Selector}}
   var t2 : ctypes.SEL // expected-error {{no type named 'SEL' in module 'ctypes'}}
 }
 

--- a/test/ClangImporter/enum-objc.swift
+++ b/test/ClangImporter/enum-objc.swift
@@ -21,8 +21,8 @@ let _: Int = forwardWithUnderlyingPointer // expected-error {{cannot convert val
 let _: Int = forwardObjCPointer // expected-error {{cannot convert value of type '(OpaquePointer) -> Void' to specified type 'Int'}}
 
 // FIXME: It would be nice to import these as unavailable somehow instead.
-let _: Int = forwardWithUnderlyingValue // expected-error {{use of unresolved identifier 'forwardWithUnderlyingValue'}}
-let _: Int = forwardObjCValue // expected-error {{use of unresolved identifier 'forwardObjCValue'}}
+let _: Int = forwardWithUnderlyingValue // expected-error {{cannot find 'forwardWithUnderlyingValue' in scope}}
+let _: Int = forwardObjCValue // expected-error {{cannot find 'forwardObjCValue' in scope}}
 
 // Note that if /these/ start getting imported as unavailable, the error will
 // also mention that there's a missing argument, since the second argument isn't

--- a/test/ClangImporter/macros.swift
+++ b/test/ClangImporter/macros.swift
@@ -51,11 +51,11 @@ func testTrueFalse() {
   _ = true // should not result in ambiguous use error
   _ = false
 
-  _ = TRUE // expected-error {{use of unresolved identifier 'TRUE'}}
-  _ = FALSE // expected-error {{use of unresolved identifier 'FALSE'}}
+  _ = TRUE // expected-error {{cannot find 'TRUE' in scope}}
+  _ = FALSE // expected-error {{cannot find 'FALSE' in scope}}
 
-  _ = `true` // expected-error {{use of unresolved identifier 'true'}}
-  _ = `false` // expected-error {{use of unresolved identifier 'false'}}
+  _ = `true` // expected-error {{cannot find 'true' in scope}}
+  _ = `false` // expected-error {{cannot find 'false' in scope}}
 }
 
 func testCStrings() -> Bool {
@@ -75,21 +75,21 @@ func testCFString() -> String {
 }
 
 func testInvalidIntegerLiterals() {
-  var l1 = INVALID_INTEGER_LITERAL_1 // expected-error {{use of unresolved identifier 'INVALID_INTEGER_LITERAL_1'}}
+  var l1 = INVALID_INTEGER_LITERAL_1 // expected-error {{cannot find 'INVALID_INTEGER_LITERAL_1' in scope}}
   // FIXME: <rdar://problem/16445608> Swift should set up a DiagnosticConsumer for Clang
-  // var l2 = INVALID_INTEGER_LITERAL_2 // FIXME {{use of unresolved identifier 'INVALID_INTEGER_LITERAL_2'}}
+  // var l2 = INVALID_INTEGER_LITERAL_2 // FIXME {{cannot find 'INVALID_INTEGER_LITERAL_2' in scope}}
 }
 
 func testUsesMacroFromOtherModule() {
   let m1 = USES_MACRO_FROM_OTHER_MODULE_1
   let m2 = macros.USES_MACRO_FROM_OTHER_MODULE_1
-  let m3 = USES_MACRO_FROM_OTHER_MODULE_2 // expected-error {{use of unresolved identifier 'USES_MACRO_FROM_OTHER_MODULE_2'}}
+  let m3 = USES_MACRO_FROM_OTHER_MODULE_2 // expected-error {{cannot find 'USES_MACRO_FROM_OTHER_MODULE_2' in scope}}
   let m4 = macros.USES_MACRO_FROM_OTHER_MODULE_2 // expected-error {{module 'macros' has no member named 'USES_MACRO_FROM_OTHER_MODULE_2'}}
 }
 
 func testSuppressed() {
-  let m1 = NS_BLOCKS_AVAILABLE // expected-error {{use of unresolved identifier 'NS_BLOCKS_AVAILABLE'}}
-  let m2 = CF_USE_OSBYTEORDER_H // expected-error {{use of unresolved identifier 'CF_USE_OSBYTEORDER_H'}}
+  let m1 = NS_BLOCKS_AVAILABLE // expected-error {{cannot find 'NS_BLOCKS_AVAILABLE' in scope}}
+  let m2 = CF_USE_OSBYTEORDER_H // expected-error {{cannot find 'CF_USE_OSBYTEORDER_H' in scope}}
 }
 
 func testNil() {
@@ -99,7 +99,7 @@ func testNil() {
   localNil = NULL_AS_NIL       // expected-error {{'NULL_AS_NIL' is unavailable: use 'nil' instead of this imported macro}}
   localNil = NULL_AS_CLASS_NIL // expected-error {{'NULL_AS_CLASS_NIL' is unavailable: use 'nil' instead of this imported macro}}
 
-  localNil = Nil // expected-error {{use of unresolved identifier 'Nil'}}
+  localNil = Nil // expected-error {{cannot find 'Nil' in scope}}
 }
 
 func testBitwiseOps() {
@@ -109,7 +109,7 @@ func testBitwiseOps() {
   _ = BIT_SHIFT_4 as CUnsignedInt
 
   _ = RSHIFT_ONE as CUnsignedInt
-  _ = RSHIFT_INVALID // expected-error {{use of unresolved identifier 'RSHIFT_INVALID'}}
+  _ = RSHIFT_INVALID // expected-error {{cannot find 'RSHIFT_INVALID' in scope}}
 
   _ = XOR_HIGH as CUnsignedLongLong
 
@@ -117,7 +117,7 @@ func testBitwiseOps() {
   attributes |= ATTR_BOLD
   attributes |= ATTR_ITALIC
   attributes |= ATTR_UNDERLINE
-  attributes |= ATTR_INVALID // expected-error {{use of unresolved identifier 'ATTR_INVALID'}}
+  attributes |= ATTR_INVALID // expected-error {{cannot find 'ATTR_INVALID' in scope}}
 }
 
 func testIntegerArithmetic() {
@@ -145,7 +145,7 @@ func testIntegerArithmetic() {
   _ = DIVIDE_INTEGRAL as CInt
   _ = DIVIDE_NONINTEGRAL as CInt
   _ = DIVIDE_MIXED_TYPES as CLongLong
-  _ = DIVIDE_INVALID // expected-error {{use of unresolved identifier 'DIVIDE_INVALID'}}
+  _ = DIVIDE_INVALID // expected-error {{cannot find 'DIVIDE_INVALID' in scope}}
 }
 
 func testIntegerComparisons() {
@@ -164,20 +164,20 @@ func testLogicalComparisons() {
 }
 
 func testRecursion() {
-  _ = RECURSION // expected-error {{use of unresolved identifier 'RECURSION'}}
-  _ = REF_TO_RECURSION // expected-error {{use of unresolved identifier 'REF_TO_RECURSION'}}
-  _ = RECURSION_IN_EXPR // expected-error {{use of unresolved identifier 'RECURSION_IN_EXPR'}}
-  _ = RECURSION_IN_EXPR2 // expected-error {{use of unresolved identifier 'RECURSION_IN_EXPR2'}}
-  _ = RECURSION_IN_EXPR3 // expected-error {{use of unresolved identifier 'RECURSION_IN_EXPR3'}}
+  _ = RECURSION // expected-error {{cannot find 'RECURSION' in scope}}
+  _ = REF_TO_RECURSION // expected-error {{cannot find 'REF_TO_RECURSION' in scope}}
+  _ = RECURSION_IN_EXPR // expected-error {{cannot find 'RECURSION_IN_EXPR' in scope}}
+  _ = RECURSION_IN_EXPR2 // expected-error {{cannot find 'RECURSION_IN_EXPR2' in scope}}
+  _ = RECURSION_IN_EXPR3 // expected-error {{cannot find 'RECURSION_IN_EXPR3' in scope}}
 }
 
 func testNulls() {
-  let _: Int = UNAVAILABLE_ONE // expected-error {{use of unresolved identifier 'UNAVAILABLE_ONE'}}
-  let _: Int = DEPRECATED_ONE // expected-error {{use of unresolved identifier 'DEPRECATED_ONE'}}
+  let _: Int = UNAVAILABLE_ONE // expected-error {{cannot find 'UNAVAILABLE_ONE' in scope}}
+  let _: Int = DEPRECATED_ONE // expected-error {{cannot find 'DEPRECATED_ONE' in scope}}
   let _: Int = OKAY_TYPED_ONE // expected-error {{cannot convert value of type 'okay_t' (aka 'UInt32') to specified type 'Int'}}
 }
 
 func testHeaderGuard() {
-  _ = IS_HEADER_GUARD // expected-error {{use of unresolved identifier 'IS_HEADER_GUARD'}}
+  _ = IS_HEADER_GUARD // expected-error {{cannot find 'IS_HEADER_GUARD' in scope}}
   _ = LOOKS_LIKE_HEADER_GUARD_BUT_IS_USEFUL_CONSTANT
 }

--- a/test/ClangImporter/nested_protocol_name.swift
+++ b/test/ClangImporter/nested_protocol_name.swift
@@ -29,7 +29,7 @@ class SturdyBranch: Trunk.Branch {
 }
 
 // FIXME: Odd that name lookup can't find this...
-class NormalBranch: Branch { // expected-error {{use of undeclared type 'Branch'}}
+class NormalBranch: Branch { // expected-error {{cannot find type 'Branch' in scope}}
   func flower() {}
 }
 

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -675,8 +675,8 @@ func testBridgeFunctionPointerTypedefs(fptrTypedef: FPTypedef) {
 }
 
 func testNonTrivialStructs() {
-  _ = NonTrivialToCopy() // expected-error {{use of unresolved identifier 'NonTrivialToCopy'}}
-  _ = NonTrivialToCopyWrapper() // expected-error {{use of unresolved identifier 'NonTrivialToCopyWrapper'}}
+  _ = NonTrivialToCopy() // expected-error {{cannot find 'NonTrivialToCopy' in scope}}
+  _ = NonTrivialToCopyWrapper() // expected-error {{cannot find 'NonTrivialToCopyWrapper' in scope}}
   _ = TrivialToCopy() // okay
 }
 

--- a/test/ClangImporter/sdk-bridging-header.swift
+++ b/test/ClangImporter/sdk-bridging-header.swift
@@ -10,7 +10,7 @@
 // CHECK-FATAL: failed to import bridging header
 
 // CHECK-INCLUDE: error: 'this-header-does-not-exist.h' file not found
-// CHECK-INCLUDE: error: use of unresolved identifier 'MyPredicate'
+// CHECK-INCLUDE: error: cannot find 'MyPredicate' in scope
 
 // REQUIRES: objc_interop
 

--- a/test/ClangImporter/sdk.swift
+++ b/test/ClangImporter/sdk.swift
@@ -13,7 +13,7 @@ func available_DateFormatter(_ a: DateFormatter) {}
 // Some traditional Objective-C types should fail with fixits.
 
 func unavailable_id(_ a: id) {} // expected-error {{'id' is unavailable in Swift: 'id' is not available in Swift; use 'Any'}}
-func unavailable_Class(_ a: Class) {} // expected-error {{use of undeclared type 'Class'; did you mean to use 'AnyClass'?}} {{29-34=AnyClass}}
-func unavailable_BOOL(_ a: BOOL) {} // expected-error {{use of undeclared type 'BOOL'; did you mean to use 'ObjCBool'?}} {{28-32=ObjCBool}}
-func unavailable_SEL(_ a: SEL) {} // expected-error {{use of undeclared type 'SEL'; did you mean to use 'Selector'?}} {{27-30=Selector}}
-func unavailable_NSUInteger(_ a: NSUInteger) {} // expected-error {{use of undeclared type 'NSUInteger'; did you mean to use 'Int'?}} {{34-44=Int}} expected-note {{did you mean to use 'UInt'?}} {{34-44=UInt}}
+func unavailable_Class(_ a: Class) {} // expected-error {{cannot find type 'Class' in scope; did you mean to use 'AnyClass'?}} {{29-34=AnyClass}}
+func unavailable_BOOL(_ a: BOOL) {} // expected-error {{cannot find type 'BOOL' in scope; did you mean to use 'ObjCBool'?}} {{28-32=ObjCBool}}
+func unavailable_SEL(_ a: SEL) {} // expected-error {{cannot find type 'SEL' in scope; did you mean to use 'Selector'?}} {{27-30=Selector}}
+func unavailable_NSUInteger(_ a: NSUInteger) {} // expected-error {{cannot find type 'NSUInteger' in scope; did you mean to use 'Int'?}} {{34-44=Int}} expected-note {{did you mean to use 'UInt'?}} {{34-44=UInt}}

--- a/test/ClangImporter/simd.swift
+++ b/test/ClangImporter/simd.swift
@@ -76,16 +76,16 @@ takes_double8(double8_value)
 
 // These shouldn't be imported, since there's no type to map them to.
 
-let char17_value = makes_char17()   // expected-error{{unresolved identifier 'makes_char17'}}
-let uchar21_value = makes_uchar21() // expected-error{{unresolved identifier 'makes_uchar21'}}
-let short5_value = makes_short5()   // expected-error{{unresolved identifier 'makes_short5'}}
-let ushort6_value = makes_ushort6() // expected-error{{unresolved identifier 'makes_ushort6'}}
-let int128_value = makes_int128()   // expected-error{{unresolved identifier 'makes_int128'}}
-let uint20_value = makes_uint20()   // expected-error{{unresolved identifier 'makes_uint20'}}
+let char17_value = makes_char17()   // expected-error{{cannot find 'makes_char17' in scope}}
+let uchar21_value = makes_uchar21() // expected-error{{cannot find 'makes_uchar21' in scope}}
+let short5_value = makes_short5()   // expected-error{{cannot find 'makes_short5' in scope}}
+let ushort6_value = makes_ushort6() // expected-error{{cannot find 'makes_ushort6' in scope}}
+let int128_value = makes_int128()   // expected-error{{cannot find 'makes_int128' in scope}}
+let uint20_value = makes_uint20()   // expected-error{{cannot find 'makes_uint20' in scope}}
 
-takes_char17(char17_value)   // expected-error{{unresolved identifier 'takes_char17'}}
-takes_uchar21(uchar21_value) // expected-error{{unresolved identifier 'takes_uchar21'}}
-takes_short5(short5_value)   // expected-error{{unresolved identifier 'takes_short5'}}
-takes_ushort6(ushort6_value) // expected-error{{unresolved identifier 'takes_ushort6'}}
-takes_int128(int128_value)   // expected-error{{unresolved identifier 'takes_int128'}}
-takes_uint20(uint20_value)   // expected-error{{unresolved identifier 'takes_uint20'}}
+takes_char17(char17_value)   // expected-error{{cannot find 'takes_char17' in scope}}
+takes_uchar21(uchar21_value) // expected-error{{cannot find 'takes_uchar21' in scope}}
+takes_short5(short5_value)   // expected-error{{cannot find 'takes_short5' in scope}}
+takes_ushort6(ushort6_value) // expected-error{{cannot find 'takes_ushort6' in scope}}
+takes_int128(int128_value)   // expected-error{{cannot find 'takes_int128' in scope}}
+takes_uint20(uint20_value)   // expected-error{{cannot find 'takes_uint20' in scope}}

--- a/test/ClangImporter/submodules.swift
+++ b/test/ClangImporter/submodules.swift
@@ -25,5 +25,5 @@ let _: ctypes.Color?
 
 // Error: "bits" should not be a valid name in this scope.
 #if !NO_ERRORS
-let _: bits.DWORD = 0 // expected-error {{use of undeclared type 'bits'}}
+let _: bits.DWORD = 0 // expected-error {{cannot find type 'bits' in scope}}
 #endif

--- a/test/ClangImporter/submodules_scoped.swift
+++ b/test/ClangImporter/submodules_scoped.swift
@@ -18,7 +18,7 @@ let _: ctypes.DWORD = 0
 func markUsed<T>(_ t: T) {}
 
 #if CHECK_SCOPING
-markUsed(MY_INT) // expected-error {{use of unresolved identifier 'MY_INT'}}
+markUsed(MY_INT) // expected-error {{cannot find 'MY_INT' in scope}}
 markUsed(ctypes.MY_INT) // expected-error {{module 'ctypes' has no member named 'MY_INT'}}
 let _: ctypes.Color? = nil // expected-error {{no type named 'Color' in module 'ctypes'}}
 #endif

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -63,7 +63,7 @@ var evenOrOdd : (Int) -> String = {$0 % 2 == 0 ? "even" : "odd"}
 
 // <rdar://problem/15367882>
 func foo() {
-  not_declared({ $0 + 1 }) // expected-error{{use of unresolved identifier 'not_declared'}}
+  not_declared({ $0 + 1 }) // expected-error{{cannot find 'not_declared' in scope}}
 }
 
 // <rdar://problem/15536725>
@@ -588,7 +588,7 @@ extension A_SR_5030 {
 }
 
 // rdar://problem/33296619
-let u = rdar33296619().element //expected-error {{use of unresolved identifier 'rdar33296619'}}
+let u = rdar33296619().element //expected-error {{cannot find 'rdar33296619' in scope}}
 
 [1].forEach { _ in
   _ = "\(u)"
@@ -614,7 +614,7 @@ _ = "".withCString { UnsafeMutableRawPointer(mutating: $0) }
 
 // rdar://problem/34077439 - Crash when pre-checking bails out and
 // leaves us with unfolded SequenceExprs inside closure body.
-_ = { (offset) -> T in // expected-error {{use of undeclared type 'T'}}
+_ = { (offset) -> T in // expected-error {{cannot find type 'T' in scope}}
   return offset ? 0 : 0
 }
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -252,7 +252,7 @@ _ = r21553065Class<r21553065Protocol>()  // expected-error {{'r21553065Class' re
 
 // Type variables not getting erased with nested closures
 struct Toe {
-  let toenail: Nail // expected-error {{use of undeclared type 'Nail'}}
+  let toenail: Nail // expected-error {{cannot find type 'Nail' in scope}}
 
   func clip() {
     // TODO(diagnostics): Solver should stop once it has detected that `toenail` doesn't exist and report that.

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -88,7 +88,7 @@ func testDiags() {
   tuplify(true) { _ in
     17
     for c in name { // expected-error{{closure containing control flow statement cannot be used with function builder 'TupleBuilder'}}
-    // expected-error@-1 {{use of unresolved identifier 'name'}}
+    // expected-error@-1 {{cannot find 'name' in scope}}
     }
   }
 
@@ -418,12 +418,12 @@ func testNonExhaustiveSwitch(e: E) {
 // rdar://problem/59856491
 struct TestConstraintGenerationErrors {
   @TupleBuilder var buildTupleFnBody: String {
-    String(nothing) // expected-error {{use of unresolved identifier 'nothing'}}
+    String(nothing) // expected-error {{cannot find 'nothing' in scope}}
   }
 
   func buildTupleClosure() {
     tuplify(true) { _ in
-      String(nothing) // expected-error {{use of unresolved identifier 'nothing'}}
+      String(nothing) // expected-error {{cannot find 'nothing' in scope}}
     }
   }
 }

--- a/test/Constraints/invalid_constraint_lookup.swift
+++ b/test/Constraints/invalid_constraint_lookup.swift
@@ -4,12 +4,12 @@ protocol P {
   associatedtype A
   func makeIterator() -> Int
 }
-func f<U: P>(_ rhs: U) -> X<U.A> { // expected-error {{use of undeclared type 'X'}}
+func f<U: P>(_ rhs: U) -> X<U.A> { // expected-error {{cannot find type 'X' in scope}}
   let iter = rhs.makeIterator()
 }
 
 struct Zzz<T> {
-  subscript (a: Foo) -> Zzz<T> { // expected-error {{use of undeclared type 'Foo'}}
+  subscript (a: Foo) -> Zzz<T> { // expected-error {{cannot find type 'Foo' in scope}}
   get: // expected-error {{expected '{' to start getter definition}}
   set:
     for i in value {}
@@ -25,6 +25,6 @@ protocol _Collection {
 protocol Collection : _Collection, Sequence {
   subscript(i: Index) -> Iterator.Element {get set }
 }
-func insertionSort<C: Mutable> (_ elements: inout C, i: C.Index) { // expected-error {{use of undeclared type 'Mutable'}} expected-error {{'Index' is not a member type of 'C'}}
+func insertionSort<C: Mutable> (_ elements: inout C, i: C.Index) { // expected-error {{cannot find type 'Mutable' in scope}} expected-error {{'Index' is not a member type of 'C'}}
   var x: C.Iterator.Element = elements[i] // expected-error {{'Iterator' is not a member type of 'C'}}
 }

--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -82,17 +82,17 @@ struct X2d {
 // Invalid declarations
 // FIXME: Suppress the diagnostic for the call below, because the invalid
 // declaration would have matched.
-func f3(_ x: Intthingy) -> Int { } // expected-error{{use of undeclared type 'Intthingy'}}
+func f3(_ x: Intthingy) -> Int { } // expected-error{{cannot find type 'Intthingy' in scope}}
 
 func f3(_ x: Float) -> Float { }
 f3(i) // expected-error{{cannot convert value of type 'Int' to expected argument type 'Float'}}
 
-func f4(_ i: Wonka) { } // expected-error{{use of undeclared type 'Wonka'}}
-func f4(_ j: Wibble) { } // expected-error{{use of undeclared type 'Wibble'}}
+func f4(_ i: Wonka) { } // expected-error{{cannot find type 'Wonka' in scope}}
+func f4(_ j: Wibble) { } // expected-error{{cannot find type 'Wibble' in scope}}
 f4(5)
 
 func f1() {
-  var c : Class // expected-error{{use of undeclared type 'Class'}}
+  var c : Class // expected-error{{cannot find type 'Class' in scope}}
   markUsed(c.x) // make sure error does not cascade here
 }
 

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -21,7 +21,7 @@ default:
 }
 
 switch (1, 2) {
-case (var a, a): // expected-error {{use of unresolved identifier 'a'}}
+case (var a, a): // expected-error {{cannot find 'a' in scope}}
   ()
 }
 
@@ -260,7 +260,7 @@ if case .foo = sr2057 { } // Ok
 // Invalid 'is' pattern
 class SomeClass {}
 if case let doesNotExist as SomeClass:AlsoDoesNotExist {}
-// expected-error@-1 {{use of undeclared type 'AlsoDoesNotExist'}}
+// expected-error@-1 {{cannot find type 'AlsoDoesNotExist' in scope}}
 // expected-error@-2 {{variable binding in a condition requires an initializer}}
 
 // `.foo` and `.bar(...)` pattern syntax should also be able to match

--- a/test/Constraints/rdar46377919.swift
+++ b/test/Constraints/rdar46377919.swift
@@ -3,7 +3,7 @@
 class Foo {
   init(lhs: @autoclosure () -> Int,
        rhs: @autoclosure () -> Undefined) {
-     // expected-error@-1 {{use of undeclared type 'Undefined'}}
+     // expected-error@-1 {{cannot find type 'Undefined' in scope}}
   }
 }
 

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -149,7 +149,7 @@ rdar19137463(1)
 struct Brunch<U : Fooable> where U.Foo == X {}
 
 struct BadFooable : Fooable { // expected-error{{type 'BadFooable' does not conform to protocol 'Fooable'}}
-  typealias Foo = DoesNotExist // expected-error{{use of undeclared type 'DoesNotExist'}}
+  typealias Foo = DoesNotExist // expected-error{{cannot find type 'DoesNotExist' in scope}}
   var foo: Foo { while true {} }
 }
 

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1471,8 +1471,8 @@ let sr4738 = (1, (2, 3))
 [sr4738].map { (x, (y, z)) -> Int in x + y + z }
 // expected-error@-1 {{closure tuple parameter does not support destructuring}} {{20-26=arg1}} {{38-38=let (y, z) = arg1; }}
 // expected-warning@-2 {{unnamed parameters must be written with the empty name '_'}} {{20-20=_: }}
-// expected-error@-3 {{use of undeclared type 'y'}}
-// expected-error@-4 {{use of undeclared type 'z'}}
+// expected-error@-3 {{cannot find type 'y' in scope}}
+// expected-error@-4 {{cannot find type 'z' in scope}}
 
 // rdar://problem/31892961
 let r31892961_1 = [1: 1, 2: 2]
@@ -1482,8 +1482,8 @@ let r31892961_2 = [1, 2, 3]
 let _: [Int] = r31892961_2.enumerated().map { ((index, val)) in
   // expected-error@-1 {{closure tuple parameter does not support destructuring}} {{48-60=arg0}} {{3-3=\n  let (index, val) = arg0\n  }}
   // expected-warning@-2 {{unnamed parameters must be written with the empty name '_'}} {{48-48=_: }}
-  // expected-error@-3 {{use of undeclared type 'index'}}
-  // expected-error@-4 {{use of undeclared type 'val'}}
+  // expected-error@-3 {{cannot find type 'index' in scope}}
+  // expected-error@-4 {{cannot find type 'val' in scope}}
   val + 1
 }
 
@@ -1499,13 +1499,13 @@ let r31892961_5 = (x: 1, (y: 2, (w: 3, z: 4)))
 [r31892961_5].map { (x: Int, (y: Int, (w: Int, z: Int))) in x + y } // expected-note {{'x' declared here}}
 // expected-error@-1 {{closure tuple parameter does not support destructuring}} {{30-56=arg1}} {{61-61=let (y, (w, z)) = arg1; }}
 // expected-warning@-2 {{unnamed parameters must be written with the empty name '_'}} {{30-30=_: }}
-// expected-error@-3{{use of unresolved identifier 'y'; did you mean 'x'?}}
+// expected-error@-3{{cannot find 'y' in scope; did you mean 'x'?}}
 
 let r31892961_6 = (x: 1, (y: 2, z: 4))
 [r31892961_6].map { (x: Int, (y: Int, z: Int)) in x + y } // expected-note {{'x' declared here}}
 // expected-error@-1 {{closure tuple parameter does not support destructuring}} {{30-46=arg1}} {{51-51=let (y, z) = arg1; }}
 // expected-warning@-2 {{unnamed parameters must be written with the empty name '_'}} {{30-30=_: }}
-// expected-error@-3{{use of unresolved identifier 'y'; did you mean 'x'?}}
+// expected-error@-3{{cannot find 'y' in scope; did you mean 'x'?}}
 
 // rdar://problem/32214649 -- these regressed in Swift 4 mode
 // with SE-0110 because of a problem in associated type inference

--- a/test/CrossImport/loading.swift
+++ b/test/CrossImport/loading.swift
@@ -50,7 +50,7 @@ fromAlwaysImportedOverlay() // no-error
 fromAlwaysImportedPlatformOverlay() // no-error
 
 // We should *not* have loaded _NeverImportedOverlay
-fromNeverImportedOverlay() // expected-error {{use of unresolved identifier 'fromNeverImportedOverlay'}}
+fromNeverImportedOverlay() // expected-error {{cannot find 'fromNeverImportedOverlay' in scope}}
 
 // Unlike real cross-import overlays, our test overlay doesn't @_exported import
 // the underlying module, so you can't call underlying declarations at all in
@@ -60,12 +60,12 @@ fromNeverImportedOverlay() // expected-error {{use of unresolved identifier 'fro
 // if we were using a well-formed overlay, the overlay could shadow them if it
 // chose.
 
-fromThinLibrary() // expected-error {{use of unresolved identifier 'fromThinLibrary'}}
-fromFatLibrary() // expected-error {{use of unresolved identifier 'fromFatLibrary'}}
-fromClangLibrary() // expected-error {{use of unresolved identifier 'fromClangLibrary'}}
-fromSwiftFramework() // expected-error {{use of unresolved identifier 'fromSwiftFramework'}}
-fromClangFramework() // expected-error {{use of unresolved identifier 'fromClangFramework'}}
-fromOverlaidClangFramework() // expected-error {{use of unresolved identifier 'fromOverlaidClangFramework'}}
+fromThinLibrary() // expected-error {{cannot find 'fromThinLibrary' in scope}}
+fromFatLibrary() // expected-error {{cannot find 'fromFatLibrary' in scope}}
+fromClangLibrary() // expected-error {{cannot find 'fromClangLibrary' in scope}}
+fromSwiftFramework() // expected-error {{cannot find 'fromSwiftFramework' in scope}}
+fromClangFramework() // expected-error {{cannot find 'fromClangFramework' in scope}}
+fromOverlaidClangFramework() // expected-error {{cannot find 'fromOverlaidClangFramework' in scope}}
 
 //
 // FileCheck output for -emit-dependencies:

--- a/test/CrossImport/negative.swift
+++ b/test/CrossImport/negative.swift
@@ -74,4 +74,4 @@ import struct DeclaringLibrary.DeclaringLibraryTy
 import DeclaringLibrary
 #endif
 
-func fn(_: OverlayLibraryTy) {} // expected-error {{use of undeclared type 'OverlayLibraryTy'}}
+func fn(_: OverlayLibraryTy) {} // expected-error {{cannot find type 'OverlayLibraryTy' in scope}}

--- a/test/CrossImport/scoped.swift
+++ b/test/CrossImport/scoped.swift
@@ -20,4 +20,4 @@ import struct DeclaringLibrary.DeclaringLibraryTy
 
 func fn1(_: OverlayLibraryTy) {} // no-error
 func fn2(_: DeclaringLibraryTy) {} // no-error
-func fn3(_: ShadowTy) {} // expected-error {{use of undeclared type 'ShadowTy'}}
+func fn3(_: ShadowTy) {} // expected-error {{cannot find type 'ShadowTy' in scope}}

--- a/test/CrossImport/transitive.swift
+++ b/test/CrossImport/transitive.swift
@@ -24,4 +24,4 @@ fromCoreMI6() // no-error
 fromAlwaysImportedOverlay() // no-error
 
 // We should *not* have loaded _NeverImportedOverlay
-fromNeverImportedOverlay() // expected-error {{use of unresolved identifier 'fromNeverImportedOverlay'}}
+fromNeverImportedOverlay() // expected-error {{cannot find 'fromNeverImportedOverlay' in scope}}

--- a/test/Driver/swift-version-default.swift
+++ b/test/Driver/swift-version-default.swift
@@ -7,37 +7,37 @@
 // it can't use the %swiftc_driver or %target-build-swift substitutions.
 
 #if swift(>=3)
-asdf // expected-error {{use of unresolved identifier}}
+asdf // expected-error {{cannot find 'asdf' in scope}}
 #else
 jkl
 #endif
 
 #if swift(>=3.1)
-asdf // expected-error {{use of unresolved identifier}}
+asdf // expected-error {{cannot find 'asdf' in scope}}
 #else
 jkl
 #endif
 
 #if swift(>=4)
-aoeu // expected-error {{use of unresolved identifier}}
+aoeu // expected-error {{cannot find 'aoeu' in scope}}
 #else
 htn 
 #endif
 
 #if swift(>=4.1)
-aoeu // expected-error {{use of unresolved identifier}}
+aoeu // expected-error {{cannot find 'aoeu' in scope}}
 #else
 htn 
 #endif
 
 #if swift(>=4.2)
-aoeu // expected-error {{use of unresolved identifier}}
+aoeu // expected-error {{cannot find 'aoeu' in scope}}
 #else
 htn 
 #endif
 
 #if swift(>=5)
-aoeu // expected-error {{use of unresolved identifier}}
+aoeu // expected-error {{cannot find 'aoeu' in scope}}
 #else
 htn 
 #endif
@@ -45,5 +45,5 @@ htn
 #if swift(>=6)
 aoeu
 #else
-htn // expected-error {{use of unresolved identifier}}
+htn // expected-error {{cannot find 'htn' in scope}}
 #endif

--- a/test/Driver/swift-version.swift
+++ b/test/Driver/swift-version.swift
@@ -17,40 +17,40 @@
 
 #if swift(>=3)
 asdf
-// ERROR_4: [[@LINE-1]]:1: error: {{use of unresolved identifier}}
-// ERROR_5: [[@LINE-2]]:1: error: {{use of unresolved identifier}}
+// ERROR_4: [[@LINE-1]]:1: error: {{cannot find 'asdf' in scope}}
+// ERROR_5: [[@LINE-2]]:1: error: {{cannot find 'asdf' in scope}}
 #else
 jkl
 #endif
 
 #if swift(>=3.1)
 asdf
-// ERROR_4: [[@LINE-1]]:1: error: {{use of unresolved identifier}}
-// ERROR_5: [[@LINE-2]]:1: error: {{use of unresolved identifier}}
+// ERROR_4: [[@LINE-1]]:1: error: {{cannot find 'asdf' in scope}}
+// ERROR_5: [[@LINE-2]]:1: error: {{cannot find 'asdf' in scope}}
 #else
 jkl
 #endif
 
 #if swift(>=4)
 asdf 
-// ERROR_4: [[@LINE-1]]:1: error: {{use of unresolved identifier}}
-// ERROR_5: [[@LINE-2]]:1: error: {{use of unresolved identifier}}
+// ERROR_4: [[@LINE-1]]:1: error: {{cannot find 'asdf' in scope}}
+// ERROR_5: [[@LINE-2]]:1: error: {{cannot find 'asdf' in scope}}
 #else
 jkl
 #endif
 
 #if swift(>=4.1)
 asdf
-// ERROR_4: [[@LINE-1]]:1: error: {{use of unresolved identifier}}
-// ERROR_5: [[@LINE-2]]:1: error: {{use of unresolved identifier}}
+// ERROR_4: [[@LINE-1]]:1: error: {{cannot find 'asdf' in scope}}
+// ERROR_5: [[@LINE-2]]:1: error: {{cannot find 'asdf' in scope}}
 #else
 jkl
 #endif
 
 #if swift(>=5)
 asdf
-// ERROR_5: [[@LINE-1]]:1: error: {{use of unresolved identifier}}
+// ERROR_5: [[@LINE-1]]:1: error: {{cannot find 'asdf' in scope}}
 #else
 jkl
-// ERROR_4: [[@LINE-1]]:1: error: {{use of unresolved identifier}}
+// ERROR_4: [[@LINE-1]]:1: error: {{cannot find 'jkl' in scope}}
 #endif

--- a/test/Driver/warnings-control.swift
+++ b/test/Driver/warnings-control.swift
@@ -18,7 +18,7 @@ func bar() {
 	foo()
 // To help anchor the checks, have an error. Put it inside a later function, to help make sure it comes after
 	xyz
-// DEFAULT: error: use of unresolved identifier 'xyz'
-// WERR:    error: use of unresolved identifier 'xyz'
-// NOWARN:  error: use of unresolved identifier 'xyz'
+// DEFAULT: error: cannot find 'xyz' in scope
+// WERR:    error: cannot find 'xyz' in scope
+// NOWARN:  error: cannot find 'xyz' in scope
 }

--- a/test/FixCode/verify-fixits.swift
+++ b/test/FixCode/verify-fixits.swift
@@ -11,17 +11,17 @@ func f1() {
 func labeledFunc(aa: Int, bb: Int) {}
 
 func test0Fixits() {
-  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}}
 
-  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{1-1=a}}
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-1=a}}
 
-  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{1-1=a}} {{2-2=b}}
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-1=a}} {{2-2=b}}
 
-  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{none}}
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{none}}
 
-  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{1-1=a}} {{none}}
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-1=a}} {{none}}
 
-  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{1-1=a}} {{2-2=b}} {{none}}
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-1=a}} {{2-2=b}} {{none}}
 }
 
 func test1Fixits() {

--- a/test/FixCode/verify-fixits.swift.result
+++ b/test/FixCode/verify-fixits.swift.result
@@ -11,17 +11,17 @@ func f1() {
 func labeledFunc(aa: Int, bb: Int) {}
 
 func test0Fixits() {
-  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}}
 
-  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}}
 
-  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}}
 
-  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{none}}
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{none}}
 
-  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{none}}
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{none}}
 
-  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{none}}
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{none}}
 }
 
 func test1Fixits() {

--- a/test/Frontend/invalid-testable-import.swift
+++ b/test/Frontend/invalid-testable-import.swift
@@ -4,4 +4,4 @@
 
 @testable import single_int // CHECK: module 'single_int' was not compiled for testing
 
-x = 8 // CHECK-NOT: unresolved identifier
+x = 8 // CHECK-NOT: cannot find 'x' in scope

--- a/test/Frontend/verify-fixits.swift
+++ b/test/Frontend/verify-fixits.swift
@@ -5,29 +5,29 @@
 func labeledFunc(aa: Int, bb: Int) {}
 
 func testNoneMarkerCheck() {
-  // CHECK: [[@LINE+1]]:95: error: A second {{{{}}none}} was found. It may only appear once in an expectation.
-  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{none}} {{none}}
+  // CHECK: [[@LINE+1]]:87: error: A second {{{{}}none}} was found. It may only appear once in an expectation.
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{none}} {{none}}
 
   // CHECK: [[@LINE+1]]:134: error: {{{{}}none}} must be at the end.
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}} {{none}} {{23-26=bb}}
 }
 
 func test0Fixits() {
-  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}}
 
-  // CHECK: [[@LINE+1]]:86: error: expected fix-it not seen
-  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{1-1=a}}
+  // CHECK: [[@LINE+1]]:78: error: expected fix-it not seen
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-1=a}}
 
-  // CHECK: [[@LINE+1]]:86: error: expected fix-it not seen
-  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{1-1=a}} {{2-2=b}}
+  // CHECK: [[@LINE+1]]:78: error: expected fix-it not seen
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-1=a}} {{2-2=b}}
 
-  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{none}}
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{none}}
 
-  // CHECK: [[@LINE+1]]:86: error: expected fix-it not seen
-  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{1-1=a}} {{none}}
+  // CHECK: [[@LINE+1]]:78: error: expected fix-it not seen
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-1=a}} {{none}}
 
-  // CHECK: [[@LINE+1]]:86: error: expected fix-it not seen
-  undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}} {{1-1=a}} {{2-2=b}} {{none}}
+  // CHECK: [[@LINE+1]]:78: error: expected fix-it not seen
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-1=a}} {{2-2=b}} {{none}}
 }
 
 func test1Fixits() {

--- a/test/Frontend/verify.swift
+++ b/test/Frontend/verify.swift
@@ -2,7 +2,7 @@
 
 // RUN: not %target-typecheck-verify-swift 2>&1 | %FileCheck %s
 
-// CHECK: [[@LINE+1]]:1: error: unexpected error produced: use of unresolved
+// CHECK: [[@LINE+1]]:1: error: unexpected error produced: cannot find 'undefinedFunc' in scope
 undefinedFunc()
 
 // CHECK: [[@LINE+1]]:4: error: expected error not produced

--- a/test/Generics/associated_type_typo.swift
+++ b/test/Generics/associated_type_typo.swift
@@ -36,15 +36,15 @@ func typoAssoc4<T : P2>(_: T) where T.Assocp2.assoc : P3 {}
 
 // <rdar://problem/19620340>
 
-func typoFunc1<T : P1>(x: TypoType) { // expected-error{{use of undeclared type 'TypoType'}}
+func typoFunc1<T : P1>(x: TypoType) { // expected-error{{cannot find type 'TypoType' in scope}}
   let _: (T.Assoc) -> () = { let _ = $0 }
 }
 
-func typoFunc2<T : P1>(x: TypoType, y: T) { // expected-error{{use of undeclared type 'TypoType'}}
+func typoFunc2<T : P1>(x: TypoType, y: T) { // expected-error{{cannot find type 'TypoType' in scope}}
   let _: (T.Assoc) -> () = { let _ = $0 }
 }
 
-func typoFunc3<T : P1>(x: TypoType, y: (T.Assoc) -> ()) { // expected-error{{use of undeclared type 'TypoType'}}
+func typoFunc3<T : P1>(x: TypoType, y: (T.Assoc) -> ()) { // expected-error{{cannot find type 'TypoType' in scope}}
 }
 
 // rdar://problem/29261689

--- a/test/Generics/function_decls.swift
+++ b/test/Generics/function_decls.swift
@@ -11,7 +11,7 @@ func f3<T : () -> ()>(x: Int, y: Int, t: T) { } // expected-error{{expected a cl
 func f4<T>(x: T, y: T) { }
 
 // Non-protocol type constraints.
-func f6<T : Wonka>(x: T) {} // expected-error{{use of undeclared type 'Wonka'}}
+func f6<T : Wonka>(x: T) {} // expected-error{{cannot find type 'Wonka' in scope}}
 
 func f7<T : Int>(x: T) {} // expected-error{{type 'T' constrained to non-protocol, non-class type 'Int'}}
 

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -282,11 +282,11 @@ func beginsWith3<S0: P2, S1: P2>(_ seq1: S0, _ seq2: S1) -> Bool
 //===----------------------------------------------------------------------===//
 // Bogus requirements
 //===----------------------------------------------------------------------===//
-func nonTypeReq<T>(_: T) where T : Wibble {} // expected-error{{use of undeclared type 'Wibble'}}
+func nonTypeReq<T>(_: T) where T : Wibble {} // expected-error{{cannot find type 'Wibble' in scope}}
 func badProtocolReq<T>(_: T) where T : Int {} // expected-error{{type 'T' constrained to non-protocol, non-class type 'Int'}}
 
-func nonTypeSameType<T>(_: T) where T == Wibble {} // expected-error{{use of undeclared type 'Wibble'}}
-func nonTypeSameType2<T>(_: T) where Wibble == T {} // expected-error{{use of undeclared type 'Wibble'}}
+func nonTypeSameType<T>(_: T) where T == Wibble {} // expected-error{{cannot find type 'Wibble' in scope}}
+func nonTypeSameType2<T>(_: T) where Wibble == T {} // expected-error{{cannot find type 'Wibble' in scope}}
 func sameTypeEq<T>(_: T) where T = T {} // expected-error{{use '==' for same-type requirements rather than '='}} {{34-35===}}
 // expected-warning@-1{{redundant same-type constraint 'T' == 'T'}}
 

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -243,4 +243,4 @@ struct UnsolvableInheritance2<T : U.A, U : T.A> {}
 // expected-error@-2 {{'A' is not a member type of 'T'}}
 
 enum X7<T> where X7.X : G { case X } // expected-error{{enum case 'X' is not a member type of 'X7<T>'}}
-// expected-error@-1{{use of undeclared type 'G'}}
+// expected-error@-1{{cannot find type 'G' in scope}}

--- a/test/Generics/invalid.swift
+++ b/test/Generics/invalid.swift
@@ -1,10 +1,10 @@
 // RUN: %target-typecheck-verify-swift
 
-protocol he where A : B { // expected-error {{use of undeclared type 'A'}}
-  // expected-error@-1 {{use of undeclared type 'B'}}
+protocol he where A : B { // expected-error {{cannot find type 'A' in scope}}
+  // expected-error@-1 {{cannot find type 'B' in scope}}
 
-  associatedtype vav where A : B // expected-error{{use of undeclared type 'A'}}
-  // expected-error@-1 {{use of undeclared type 'B'}}
+  associatedtype vav where A : B // expected-error{{cannot find type 'A' in scope}}
+  // expected-error@-1 {{cannot find type 'B' in scope}}
 }
 
 
@@ -89,11 +89,11 @@ class OuterGeneric<T> {
 // Crash with missing types in requirements.
 protocol P1 {
   associatedtype A where A == ThisTypeDoesNotExist
-  // expected-error@-1{{use of undeclared type 'ThisTypeDoesNotExist'}}
+  // expected-error@-1{{cannot find type 'ThisTypeDoesNotExist' in scope}}
   associatedtype B where ThisTypeDoesNotExist == B
-  // expected-error@-1{{use of undeclared type 'ThisTypeDoesNotExist'}}
+  // expected-error@-1{{cannot find type 'ThisTypeDoesNotExist' in scope}}
   associatedtype C where ThisTypeDoesNotExist == ThisTypeDoesNotExist
-  // expected-error@-1 2{{use of undeclared type 'ThisTypeDoesNotExist'}}
+  // expected-error@-1 2{{cannot find type 'ThisTypeDoesNotExist' in scope}}
 }
 
 // Diagnostic referred to the wrong type - <rdar://problem/33604221>

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -341,7 +341,7 @@ protocol P25b {
 
 protocol P25c {
   associatedtype A: P24
-  associatedtype B where A == X<B> // expected-error{{use of undeclared type 'X'}}
+  associatedtype B where A == X<B> // expected-error{{cannot find type 'X' in scope}}
 }
 
 protocol P25d {

--- a/test/IDE/complete_without_typo_correction.swift
+++ b/test/IDE/complete_without_typo_correction.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=HERE -code-completion-diagnostics 2> %t.err.txt
 // RUN: %FileCheck %s -input-file=%t.err.txt
 
-// CHECK: use of unresolved identifier 'foo11'
+// CHECK: cannot find 'foo11' in scope
 // CHECK-NOT: did you mean
 
 func foo12() -> Int { return 0 }

--- a/test/IDE/enable_objc_interop.swift
+++ b/test/IDE/enable_objc_interop.swift
@@ -2,15 +2,15 @@
 
 #if _runtime(_ObjC)
 foo
-// CHECK-objc: unresolved identifier 'foo'
-// CHECK-objc-NOT: unresolved identifier 'bar'
-// CHECK-objc-NOT: unresolved identifier 'baz'
+// CHECK-objc: cannot find 'foo' in scope
+// CHECK-objc-NOT: cannot find 'bar' in scope
+// CHECK-objc-NOT: cannot find 'baz' in scope
 
 #elseif _runtime(_Native)
 bar
-// CHECK-native-NOT: unresolved identifier 'foo'
-// CHECK-native: unresolved identifier 'bar'
-// CHECK-native-NOT: unresolved identifier 'baz'
+// CHECK-native-NOT: cannot find 'foo' in scope
+// CHECK-native: cannot find 'bar' in scope
+// CHECK-native-NOT: cannot find 'baz' in scope
 
 #else
 baz

--- a/test/IDE/print_ast_tc_decls_errors.swift
+++ b/test/IDE/print_ast_tc_decls_errors.swift
@@ -59,11 +59,11 @@ import func     not_existent_module_c.foo // expected-error{{no such module 'not
 //===--- Inheritance list in structs.
 //===---
 
-struct StructWithInheritance1 : FooNonExistentProtocol {} // expected-error {{use of undeclared type 'FooNonExistentProtocol'}}
+struct StructWithInheritance1 : FooNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}}
 // NO-TYPEREPR: {{^}}struct StructWithInheritance1 : <<error type>> {{{$}}
 // TYPEREPR: {{^}}struct StructWithInheritance1 : FooNonExistentProtocol {{{$}}
 
-struct StructWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {} // expected-error {{use of undeclared type 'FooNonExistentProtocol'}} expected-error {{use of undeclared type 'BarNonExistentProtocol'}}
+struct StructWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}} expected-error {{cannot find type 'BarNonExistentProtocol' in scope}}
 // NO-TYPEREPR: {{^}}struct StructWithInheritance2 : <<error type>>, <<error type>> {{{$}}
 // TYPEREPR: {{^}}struct StructWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {{{$}}
 
@@ -71,15 +71,15 @@ struct StructWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {
 //===--- Inheritance list in classes.
 //===---
 
-class ClassWithInheritance1 : FooNonExistentProtocol {} // expected-error {{use of undeclared type 'FooNonExistentProtocol'}}
+class ClassWithInheritance1 : FooNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}}
 // NO-TYREPR: {{^}}class ClassWithInheritance1 : <<error type>> {{{$}}
 // TYREPR: {{^}}class ClassWithInheritance1 : FooNonExistentProtocol {{{$}}
 
-class ClassWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {} // expected-error {{use of undeclared type 'FooNonExistentProtocol'}} expected-error {{use of undeclared type 'BarNonExistentProtocol'}}
+class ClassWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}} expected-error {{cannot find type 'BarNonExistentProtocol' in scope}}
 // NO-TYREPR: {{^}}class ClassWithInheritance2 : <<error type>>, <<error type>> {{{$}}
 // TYREPR: {{^}}class ClassWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {{{$}}
 
-class ClassWithInheritance3 : FooClass, FooNonExistentProtocol {} // expected-error {{use of undeclared type 'FooNonExistentProtocol'}}
+class ClassWithInheritance3 : FooClass, FooNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}}
 // NO-TYREPR: {{^}}class ClassWithInheritance3 : FooClass, <<error type>> {{{$}}
 // TYREPR: {{^}}class ClassWithInheritance3 : FooClass, FooNonExistentProtocol {{{$}}
 
@@ -101,7 +101,7 @@ class ClassWithInheritance8 : FooClass, BarClass, FooProtocol, BarProtocol {} //
 // NO-TYREPR: {{^}}class ClassWithInheritance8 : FooClass, <<error type>>, FooProtocol, BarProtocol {{{$}}
 // TYREPR: {{^}}class ClassWithInheritance8 : FooClass, BarClass, FooProtocol, BarProtocol {{{$}}
 
-class ClassWithInheritance9 : FooClass, BarClass, FooProtocol, BarProtocol, FooNonExistentProtocol {} // expected-error {{multiple inheritance from classes 'FooClass' and 'BarClass'}} expected-error {{use of undeclared type 'FooNonExistentProtocol'}}
+class ClassWithInheritance9 : FooClass, BarClass, FooProtocol, BarProtocol, FooNonExistentProtocol {} // expected-error {{multiple inheritance from classes 'FooClass' and 'BarClass'}} expected-error {{cannot find type 'FooNonExistentProtocol' in scope}}
 // NO-TYREPR: {{^}}class ClassWithInheritance9 : FooClass, <<error type>>, FooProtocol, BarProtocol, <<error type>> {{{$}}
 // TYREPR: {{^}}class ClassWithInheritance9 : FooClass, BarClass, FooProtocol, BarProtocol, FooNonExistentProtocol {{{$}}
 
@@ -109,11 +109,11 @@ class ClassWithInheritance9 : FooClass, BarClass, FooProtocol, BarProtocol, FooN
 //===--- Inheritance list in enums.
 //===---
 
-enum EnumWithInheritance1 : FooNonExistentProtocol {} // expected-error {{use of undeclared type 'FooNonExistentProtocol'}} expected-error {{raw type}} expected-error {{an enum with no cases}}
+enum EnumWithInheritance1 : FooNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}} expected-error {{raw type}} expected-error {{an enum with no cases}}
 // NO-TYREPR: {{^}}enum EnumWithInheritance1 : <<error type>> {{{$}}
 // TYREPR: {{^}}enum EnumWithInheritance1 : FooNonExistentProtocol {{{$}}
 
-enum EnumWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {} // expected-error {{use of undeclared type 'FooNonExistentProtocol'}} expected-error {{use of undeclared type 'BarNonExistentProtocol'}} expected-error {{raw type}} expected-error {{an enum with no cases}}
+enum EnumWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}} expected-error {{cannot find type 'BarNonExistentProtocol' in scope}} expected-error {{raw type}} expected-error {{an enum with no cases}}
 // NO-TYREPR: {{^}}enum EnumWithInheritance2 : <<error type>>, <<error type>> {{{$}}
 // TYREPR: {{^}}enum EnumWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {{{$}}
 
@@ -139,11 +139,11 @@ enum EnumWithInheritance5 : FooClass, BarClass { case X } // expected-error {{ra
 //===--- Inheritance list in protocols.
 //===---
 
-protocol ProtocolWithInheritance1 : FooNonExistentProtocol {} // expected-error {{use of undeclared type 'FooNonExistentProtocol'}}
+protocol ProtocolWithInheritance1 : FooNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}}
 // NO-TYREPR: {{^}}protocol ProtocolWithInheritance1 : <<error type>> {{{$}}
 // TYREPR: {{^}}protocol ProtocolWithInheritance1 : FooNonExistentProtocol {{{$}}
 
-protocol ProtocolWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {} // expected-error {{use of undeclared type 'FooNonExistentProtocol'}} expected-error {{use of undeclared type 'BarNonExistentProtocol'}}
+protocol ProtocolWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}} expected-error {{cannot find type 'BarNonExistentProtocol' in scope}}
 // NO-TYREPR: {{^}}protocol ProtocolWithInheritance2 : <<error type>>, <<error type>> {{{$}}
 // TYREPR: {{^}}protocol ProtocolWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {{{$}}
 
@@ -165,7 +165,7 @@ protocol ProtocolWithInheritance5 : FooClass, BarClass {} // expected-error{{mul
 
 // Normal typealiases.
 
-typealias Typealias1 = FooNonExistentProtocol // expected-error {{use of undeclared type 'FooNonExistentProtocol'}}
+typealias Typealias1 = FooNonExistentProtocol // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}}
 // NO-TYREPR: {{^}}typealias Typealias1 = <<error type>>{{$}}
 // TYREPR: {{^}}typealias Typealias1 = FooNonExistentProtocol{{$}}
 
@@ -183,11 +183,11 @@ protocol AssociatedType1 {
   associatedtype AssociatedTypeDecl2 : BazProtocol = FooClass
 // CHECK: {{^}}  associatedtype AssociatedTypeDecl2 : BazProtocol = FooClass{{$}}
 
-  associatedtype AssociatedTypeDecl3 : FooNonExistentProtocol // expected-error {{use of undeclared type 'FooNonExistentProtocol'}}
+  associatedtype AssociatedTypeDecl3 : FooNonExistentProtocol // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}}
 // NO-TYREPR: {{^}}  associatedtype AssociatedTypeDecl3 : <<error type>>{{$}}
 // TYREPR: {{^}}  associatedtype AssociatedTypeDecl3 : FooNonExistentProtocol{{$}}
 
-  associatedtype AssociatedTypeDecl4 : FooNonExistentProtocol, BarNonExistentProtocol // expected-error {{use of undeclared type 'FooNonExistentProtocol'}} expected-error {{use of undeclared type 'BarNonExistentProtocol'}}
+  associatedtype AssociatedTypeDecl4 : FooNonExistentProtocol, BarNonExistentProtocol // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}} expected-error {{cannot find type 'BarNonExistentProtocol' in scope}}
 // NO-TYREPR: {{^}}  associatedtype AssociatedTypeDecl4 : <<error type>>, <<error type>>{{$}}
 // TYREPR: {{^}}  associatedtype AssociatedTypeDecl4 : FooNonExistentProtocol, BarNonExistentProtocol{{$}}
 

--- a/test/ImportResolution/import-command-line.swift
+++ b/test/ImportResolution/import-command-line.swift
@@ -7,5 +7,5 @@
 // RUN: not %target-swift-frontend -typecheck %s -enable-source-import -I %S/Inputs -sdk "" -import-module NON_EXISTENT 2>&1 | %FileCheck -check-prefix=NON-EXISTENT %s
 // NON-EXISTENT: error: no such module 'NON_EXISTENT'
 
-var a: A? // expected-error {{use of undeclared type 'A'}}
-var qA: abcde.A? // expected-error {{use of undeclared type 'abcde'}}
+var a: A? // expected-error {{cannot find type 'A' in scope}}
+var qA: abcde.A? // expected-error {{cannot find type 'abcde' in scope}}

--- a/test/ImportResolution/import-multiple-command-line.swift
+++ b/test/ImportResolution/import-multiple-command-line.swift
@@ -5,7 +5,7 @@
 
 // NON-IDENT: error: module name "3333" is not a valid identifier
 
-var c: C? // expected-error {{use of undeclared type 'C'}}
-var u: U? // expected-error {{use of undeclared type 'U'}}
-var qA1: abcde.A? // expected-error {{use of undeclared type 'abcde'}}
-var qA2: aeiou.A? // expected-error {{use of undeclared type 'aeiou'}}
+var c: C? // expected-error {{cannot find type 'C' in scope}}
+var u: U? // expected-error {{cannot find type 'U' in scope}}
+var qA1: abcde.A? // expected-error {{cannot find type 'abcde' in scope}}
+var qA2: aeiou.A? // expected-error {{cannot find type 'aeiou' in scope}}

--- a/test/ImportResolution/import-resolution-2.swift
+++ b/test/ImportResolution/import-resolution-2.swift
@@ -21,7 +21,7 @@ var qA1 : aeiou.A
 var qA2 : asdf.A
 var qA3 : abcde.A
 
-var uS : S // expected-error {{use of undeclared type 'S'}}
+var uS : S // expected-error {{cannot find type 'S' in scope}}
 var qS1 : letters.S // expected-error {{no type named 'S' in module 'letters'}}
 var qS2 : asdf.S // expected-error {{no type named 'S' in module 'asdf'}}
 // but...!

--- a/test/ImportResolution/import-specific-decl.swift
+++ b/test/ImportResolution/import-specific-decl.swift
@@ -19,7 +19,7 @@ var b : B = abcde.B()
 var e : E = aeiou.E()
 
 var u : U = aeiou.U()
-var o : O // expected-error {{use of undeclared type 'O'}}
+var o : O // expected-error {{cannot find type 'O' in scope}}
 
 var o2 = aeiou.O() // expected-error {{module 'aeiou' has no member named 'O'}}
 

--- a/test/ImportResolution/scoped_imports.swift
+++ b/test/ImportResolution/scoped_imports.swift
@@ -22,4 +22,4 @@ import func ClangModuleWithOverlay.ClangTypeImportAsMemberStaticMethod
 import func ClangModuleWithOverlay.ClangTypeImportAsMemberInstanceMethod
 import struct ClangModuleWithOverlay.ClangTypeInner
 
-func foo(_ x: ClangType.Inner) {} // expected-error {{use of undeclared type 'ClangType'}}
+func foo(_ x: ClangType.Inner) {} // expected-error {{cannot find type 'ClangType' in scope}}

--- a/test/Index/Store/record-with-compile-error.swift
+++ b/test/Index/Store/record-with-compile-error.swift
@@ -5,5 +5,5 @@
 // CHECK: function/Swift | test1() | [[TEST1_FUNC:.*]] | <no-cgname> | Def
 // CHECK: [[@LINE+1]]:6 | function/Swift | [[TEST1_FUNC]]
 func test1() {
-  unresolved() // expected-error {{use of unresolved identifier}}
+  unresolved() // expected-error {{cannot find 'unresolved' in scope}}
 }

--- a/test/Interpreter/SDK/missing_imports_repl.swift
+++ b/test/Interpreter/SDK/missing_imports_repl.swift
@@ -22,7 +22,7 @@ import SpriteKit.Nonexistent_Submodule
 // CHECK-ERROR: error: no such module
 
 SKScene()
-// CHECK-ERROR: error: use of unresolved identifier 'SKScene'
+// CHECK-ERROR: error: cannot find 'SKScene' in scope
 
 // Use another inline function that references other inline functions.
 MKMapRectIsNull(x)

--- a/test/Interpreter/SDK/submodules_smoke_test.swift
+++ b/test/Interpreter/SDK/submodules_smoke_test.swift
@@ -20,7 +20,7 @@ typealias PanRecognizer = NSPanGestureRecognizer
 typealias PanRecognizer2 = AppKit.NSPanGestureRecognizer
 
 #if !NO_ERROR
-_ = glVertexPointer // expected-error{{use of unresolved identifier 'glVertexPointer'}}
+_ = glVertexPointer // expected-error{{cannot find 'glVertexPointer' in scope}}
 #endif
 
 // FIXME: Remove -verify-ignore-unknown.

--- a/test/Interpreter/repl_autolinking.swift
+++ b/test/Interpreter/repl_autolinking.swift
@@ -40,6 +40,6 @@ funcFromModuleA()
 // is stdout and stderr, mixed together).
 //
 // CHECK-DAG: "<result from ModuleA><result from ModuleB>"
-// CHECK-DAG: error: use of unresolved identifier 'funcFromModuleA'
+// CHECK-DAG: error: cannot find 'funcFromModuleA' in scope
 // CHECK-DAG: "<result from ModuleA>"
 

--- a/test/Interpreter/submodules_smoke_test.swift
+++ b/test/Interpreter/submodules_smoke_test.swift
@@ -6,5 +6,5 @@ import ExplicitSubmodulesOnly.B
 _ = constantB
 
 #if !NO_ERROR
-_ = constantA // expected-error{{use of unresolved identifier 'constantA'}}
+_ = constantA // expected-error{{cannot find 'constantA' in scope}}
 #endif

--- a/test/Migrator/pre_fixit_pass_still_failed.swift
+++ b/test/Migrator/pre_fixit_pass_still_failed.swift
@@ -2,7 +2,7 @@
 
 // We shouldn't be able to successfully use the pre-fix-it passes to
 // fix this file before migration because there is a use of an
-// unresolved identifier 'bar'.
+// cannot find 'bar' in scope.
 
 func foo(s: String) {}
 foo("Hello")

--- a/test/Misc/serialized-diagnostics-batch-mode.swift
+++ b/test/Misc/serialized-diagnostics-batch-mode.swift
@@ -31,10 +31,10 @@
 // NEGATIVE-STDERR-NOT: invalid redeclaration of 'foo()'
 
 func test() {
-  nonexistent() // CHECK-MAIN-DAG: serialized-diagnostics-batch-mode.swift:[[@LINE]]:3: error: use of unresolved identifier 'nonexistent'
-  // CHECK-STDERR-DAG: serialized-diagnostics-batch-mode.swift:[[@LINE-1]]:3: error: use of unresolved identifier 'nonexistent'
+  nonexistent() // CHECK-MAIN-DAG: serialized-diagnostics-batch-mode.swift:[[@LINE]]:3: error: cannot find 'nonexistent' in scope
+  // CHECK-STDERR-DAG: serialized-diagnostics-batch-mode.swift:[[@LINE-1]]:3: error: cannot find 'nonexistent' in scope
 
   // The other file has a similar call.
-  // CHECK-HELPER-DAG: serialized-diagnostics-batch-mode-helper.swift:{{[0-9]+}}:3: error: use of unresolved identifier 'nonexistent'
-  // CHECK-STDERR-DAG: serialized-diagnostics-batch-mode-helper.swift:{{[0-9]+}}:3: error: use of unresolved identifier 'nonexistent'
+  // CHECK-HELPER-DAG: serialized-diagnostics-batch-mode-helper.swift:{{[0-9]+}}:3: error: cannot find 'nonexistent' in scope
+  // CHECK-STDERR-DAG: serialized-diagnostics-batch-mode-helper.swift:{{[0-9]+}}:3: error: cannot find 'nonexistent' in scope
 }

--- a/test/ModuleInterface/ModuleCache/module-cache-diagnostics.swift
+++ b/test/ModuleInterface/ModuleCache/module-cache-diagnostics.swift
@@ -71,7 +71,7 @@
 // RUN: c-index-test -read-diagnostics %t/err.dia 2>&1 | %FileCheck %s -check-prefix=CHECK-ERROR
 //
 //
-// Next test: add an inlinable function body with an unresolved identifier to LeafModule.swiftinterface; check we do not get a rebuild and report the additional error correctly.
+// Next test: add an inlinable function body with an cannot find to LeafModule.swiftinterface; check we do not get a rebuild and report the additional error correctly.
 //
 // RUN: mv %t/LeafModule.swiftinterface.backup %t/LeafModule.swiftinterface
 // RUN: echo "@inlinable func bar() { var x = unresolved }" >>%t/LeafModule.swiftinterface
@@ -81,7 +81,7 @@
 // RUN: not %target-swift-frontend -I %t -module-cache-path %t/modulecache -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s >%t/err-inline.txt 2>&1
 // RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 // RUN: %FileCheck %s -check-prefix=CHECK-ERROR-INLINE <%t/err-inline.txt
-// CHECK-ERROR-INLINE: LeafModule.swiftinterface:6:33: error: use of unresolved identifier 'unresolved'
+// CHECK-ERROR-INLINE: LeafModule.swiftinterface:6:33: error: cannot find 'unresolved' in scope
 // CHECK-ERROR-INLINE: OtherModule.swiftinterface:4:8: error: failed to build module 'LeafModule' from its module interface; it may have been damaged or it may have triggered a bug in the Swift compiler when it was produced
 // CHECK-ERROR-INLINE: module-cache-diagnostics.swift:{{[0-9]+}}:8: error: failed to build module 'OtherModule' from its module interface; it may have been damaged or it may have triggered a bug in the Swift compiler when it was produced
 // CHECK-ERROR-INLINE-NOT: error:

--- a/test/ModuleInterface/ModuleCache/module-cache-errors-in-importing-file.swift
+++ b/test/ModuleInterface/ModuleCache/module-cache-errors-in-importing-file.swift
@@ -16,7 +16,7 @@
 //
 // RUN: %target-swift-frontend -typecheck -verify -I %t -module-cache-path %t/modulecache %s
 
-unresolved // expected-error {{use of unresolved identifier 'unresolved'}}
+unresolved // expected-error {{cannot find 'unresolved' in scope}}
 
 import SomeModule
 

--- a/test/ModuleInterface/swift_build_sdk_interfaces/xfail-logs.test-sh
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/xfail-logs.test-sh
@@ -4,7 +4,7 @@ RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/logs/Bad-Bad-err.txt
 
 CHECK: # (FAIL) {{.+}}{{\\|/}}Bad.swiftinterface
 
-PRINTS-ERROR: unresolved identifier 'garbage'
+PRINTS-ERROR: cannot find 'garbage' in scope
 
 RUN: %empty-directory(%t)
 RUN: echo '["Good"]' > %t/xfails-good.json

--- a/test/ModuleInterface/swift_build_sdk_interfaces/xfails.test-sh
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/xfails.test-sh
@@ -8,8 +8,8 @@ CHECK: # (FAIL) {{.+}}{{\\|/}}Bad.swiftinterface
 CHECK-VERBOSE-DAG: # (FAIL) {{.+}}{{\\|/}}Bad.swiftinterface
 CHECK-VERBOSE-DAG: # (PASS) {{.+}}{{\\|/}}Good.swiftinterface
 
-PRINTS-ERROR: unresolved identifier 'garbage'
-HIDES-ERROR-NOT: unresolved identifier 'garbage'
+PRINTS-ERROR: cannot find 'garbage' in scope
+HIDES-ERROR-NOT: cannot find 'garbage' in scope
 
 RUN: %empty-directory(%t)
 RUN: echo '["Good"]' > %t/xfails-good.json

--- a/test/NameLookup/Inputs/multi-file-3.swift
+++ b/test/NameLookup/Inputs/multi-file-3.swift
@@ -5,7 +5,7 @@ func ~~~(x: Int, y: Int) -> Bool { // expected-error{{operator implementation wi
 }
 
 func test3() {
-  var a = funcOrVar // expected-error{{use of unresolved identifier 'funcOrVar'}}
+  var a = funcOrVar // expected-error{{cannot find 'funcOrVar' in scope}}
 
   var s = SomeStruct(value: 42) // use the SomeStruct from multi-file.swift
 

--- a/test/NameLookup/accessibility.swift
+++ b/test/NameLookup/accessibility.swift
@@ -29,15 +29,15 @@ markUsed(accessibility.b)
 markUsed(accessibility.c) // expected-error {{module 'accessibility' has no member named 'c'}}
 
 markUsed(x)
-markUsed(y) // expected-error {{use of unresolved identifier 'y'}}
-markUsed(z) // expected-error {{use of unresolved identifier 'z'}}
+markUsed(y) // expected-error {{cannot find 'y' in scope}}
+markUsed(z) // expected-error {{cannot find 'z' in scope}}
 // TESTABLE-NOT: :[[@LINE-3]]:{{[^:]+}}:
 // TESTABLE-NOT: :[[@LINE-3]]:{{[^:]+}}:
-// TESTABLE: :[[@LINE-3]]:10: error: use of unresolved identifier 'z'
+// TESTABLE: :[[@LINE-3]]:10: error: cannot find 'z' in scope
 
 markUsed(a)
 markUsed(b)
-markUsed(c) // expected-error {{use of unresolved identifier 'c'}}
+markUsed(c) // expected-error {{cannot find 'c' in scope}}
 
 Foo.x()
 Foo.y() // expected-error {{'y' is inaccessible due to 'internal' protection level}}
@@ -161,9 +161,9 @@ internal struct FooImpl: Fooable, HasDefaultImplementation {} // expected-error 
 public struct PublicFooImpl: Fooable, HasDefaultImplementation {} // expected-error {{type 'PublicFooImpl' does not conform to protocol 'Fooable'}}
 // TESTABLE-NOT: method 'foo()'
 
-internal class TestableSub: InternalBase {} // expected-error {{undeclared type 'InternalBase'}}
-public class TestablePublicSub: InternalBase {} // expected-error {{undeclared type 'InternalBase'}}
-// TESTABLE-NOT: undeclared type 'InternalBase'
+internal class TestableSub: InternalBase {} // expected-error {{cannot find type 'InternalBase' in scope}}
+public class TestablePublicSub: InternalBase {} // expected-error {{cannot find type 'InternalBase' in scope}}
+// TESTABLE-NOT: cannot find type 'InternalBase' in scope
 #endif
 
 // FIXME: Remove -verify-ignore-unknown.

--- a/test/NameLookup/library.swift
+++ b/test/NameLookup/library.swift
@@ -11,7 +11,7 @@ var y : y_ty = 4
 typealias y_ty = (Int)
 
 // Verify that never-defined types are caught.
-var z : z_ty = 42  // expected-error {{use of undeclared type 'z_ty'}}
+var z : z_ty = 42  // expected-error {{cannot find type 'z_ty' in scope}}
 
 // Make sure we type-check all declarations before any initializers
 var a : Int = b

--- a/test/NameLookup/name_lookup.swift
+++ b/test/NameLookup/name_lookup.swift
@@ -600,7 +600,7 @@ struct Company { // expected-note 2{{'Company' declared here}}
 
 func test1() {
   let example: Company? = Company(owner: Person(name: "Owner"))
-  if let person = aCompany.owner, // expected-error {{use of unresolved identifier 'aCompany'; did you mean 'Company'?}}
+  if let person = aCompany.owner, // expected-error {{cannot find 'aCompany' in scope; did you mean 'Company'?}}
      let aCompany = example {
     _ = person
   }
@@ -608,13 +608,13 @@ func test1() {
 
 func test2() {
   let example: Company? = Company(owner: Person(name: "Owner"))
-  guard let person = aCompany.owner, // expected-error {{use of unresolved identifier 'aCompany'; did you mean 'Company'?}}
+  guard let person = aCompany.owner, // expected-error {{cannot find 'aCompany' in scope; did you mean 'Company'?}}
         let aCompany = example else { return }
 }
 
 func test3() {
   var c: String? = "c" // expected-note {{'c' declared here}}
-  if let a = b = c, let b = c { // expected-error {{use of unresolved identifier 'b'; did you mean 'c'?}}
+  if let a = b = c, let b = c { // expected-error {{cannot find 'b' in scope; did you mean 'c'?}}
     _ = b
   }
 }

--- a/test/NameLookup/name_lookup2.swift
+++ b/test/NameLookup/name_lookup2.swift
@@ -20,7 +20,7 @@ var importedunion: unionSearchFlags = .backwards
 
 
 // This shouldn't be imported from data.
-var notimported : MaybeInt // expected-error {{use of undeclared type 'MaybeInt'}}
+var notimported : MaybeInt // expected-error {{cannot find type 'MaybeInt' in scope}}
 
 //===----------------------------------------------------------------------===//
 // Name lookup stress test
@@ -94,7 +94,7 @@ func func2() {
 }
 
 func func3() {
-  undefined_func() // expected-error {{use of unresolved identifier 'undefined_func'}}
+  undefined_func() // expected-error {{cannot find 'undefined_func' in scope}}
 }
 
 //===----------------------------------------------------------------------===//
@@ -165,7 +165,7 @@ func localtest() {
   }
 }
 
-func f0() -> ThisTypeDoesNotExist { return 1 } // expected-error {{use of undeclared type 'ThisTypeDoesNotExist'}}
+func f0() -> ThisTypeDoesNotExist { return 1 } // expected-error {{cannot find type 'ThisTypeDoesNotExist' in scope}}
 
 for _ in [1] { }
 

--- a/test/NameLookup/scope_map_lookup.swift
+++ b/test/NameLookup/scope_map_lookup.swift
@@ -6,7 +6,7 @@
 // FIXME: Semantic analysis should not recommend 'x' or 'y' here, because they
 // are not actually available.
 func functionParamScopes(x: Int, y: Int = x) -> Int {
-  // expected-error@-1 {{use of unresolved identifier 'x'}}
+  // expected-error@-1 {{cannot find 'x' in scope}}
   // expected-note@-2 {{did you mean 'x'?}}
   // expected-note@-2 {{did you mean 'y'?}}
   return x + y

--- a/test/Parse/ConditionalCompilation/basicParseErrors.swift
+++ b/test/Parse/ConditionalCompilation/basicParseErrors.swift
@@ -105,7 +105,7 @@ fn_j() // OK
 // expected-error @-1 {{invalid conditional compilation expression}}
 undefinedFunc() // ignored.
 #else
-undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}
+undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}}
 #endif
 
 #if false
@@ -113,7 +113,7 @@ undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'
 // expected-error @-1 {{invalid conditional compilation expression}}
 undefinedFunc() // ignored.
 #else
-undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}
+undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}}
 #endif
 
 /// Invalid platform condition arguments don't invalidate the whole condition.
@@ -138,7 +138,7 @@ fn_k()
 // expected-note@-6 {{did you mean 'i386'?}} {{26-29=i386}}
 func undefinedFunc() // ignored.
 #endif
-undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}
+undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}}
 
 #if os(simulator) // expected-warning {{unknown operating system for build configuration 'os'}} expected-note {{did you mean 'targetEnvironment'}} {{5-7=targetEnvironment}}
 #endif

--- a/test/Parse/ConditionalCompilation/can_import_idempotent.swift
+++ b/test/Parse/ConditionalCompilation/can_import_idempotent.swift
@@ -4,6 +4,6 @@
 // RUN: %target-swift-frontend -typecheck -verify -I %t %s
 
 #if canImport(DummyModule)
-print(DummyModule.dummyVar) // expected-error {{use of unresolved identifier 'DummyModule'}}
-print(dummyVar) // expected-error {{use of unresolved identifier 'dummyVar'}}
+print(DummyModule.dummyVar) // expected-error {{cannot find 'DummyModule' in scope}}
+print(dummyVar) // expected-error {{cannot find 'dummyVar' in scope}}
 #endif

--- a/test/Parse/ConditionalCompilation/decl_in_true_inactive.swift
+++ b/test/Parse/ConditionalCompilation/decl_in_true_inactive.swift
@@ -16,7 +16,7 @@ func f2() -> Int {
 #elseif BAR
   let val = 3
 #endif
-  return val // expected-error {{use of unresolved identifier 'val'}}
+  return val // expected-error {{cannot find 'val' in scope}}
 }
 
 struct S1 {
@@ -36,7 +36,7 @@ struct S2 {
   let val = 2
 #endif
   var v: Int {
-    return val // expected-error {{use of unresolved identifier 'val'}}
+    return val // expected-error {{cannot find 'val' in scope}}
   }
 }
 
@@ -51,4 +51,4 @@ _ = gVal1
 #elseif BAR
 let inactive = 3
 #endif
-_ = inactive // expected-error {{use of unresolved identifier 'inactive'}}
+_ = inactive // expected-error {{cannot find 'inactive' in scope}}

--- a/test/Parse/ConditionalCompilation/macabiTargetEnv.swift
+++ b/test/Parse/ConditionalCompilation/macabiTargetEnv.swift
@@ -5,7 +5,7 @@
 
 #if targetEnvironment(macabi) // expected-warning {{'macabi' has been renamed to 'macCatalyst'}} {{23-29=macCatalyst}}
 func underMacABI() {
-  foo() // expected-error {{use of unresolved identifier 'foo'}}
+  foo() // expected-error {{cannot find 'foo' in scope}}
 }
 #endif
 
@@ -17,7 +17,7 @@ let i: SomeType = "SomeString" // no-error
 
 #if targetEnvironment(macCatalyst)
 func underTargetEnvironmentMacCatalyst() {
-  foo() // expected-error {{use of unresolved identifier 'foo'}}
+  foo() // expected-error {{cannot find 'foo' in scope}}
 }
 #endif
 

--- a/test/Parse/ConditionalCompilation/sequence.swift
+++ b/test/Parse/ConditionalCompilation/sequence.swift
@@ -3,11 +3,11 @@
 #if false || true && false
 undefinedIf()
 #else
-undefinedElse() // expected-error {{use of unresolved identifier 'undefinedElse'}}
+undefinedElse() // expected-error {{cannot find 'undefinedElse' in scope}}
 #endif
 
 #if false && true || true
-undefinedIf() // expected-error {{use of unresolved identifier 'undefinedIf'}}
+undefinedIf() // expected-error {{cannot find 'undefinedIf' in scope}}
 #else
 undefinedElse()
 #endif
@@ -15,7 +15,7 @@ undefinedElse()
 #if false || true && false || false
 undefinedIf()
 #else
-undefinedElse() // expected-error {{use of unresolved identifier 'undefinedElse'}}
+undefinedElse() // expected-error {{cannot find 'undefinedElse' in scope}}
 #endif
 
 // expected-error @+1 {{invalid conditional compilation expression}}

--- a/test/Parse/ConditionalCompilation/sequence_version.swift
+++ b/test/Parse/ConditionalCompilation/sequence_version.swift
@@ -18,11 +18,11 @@ foo bar
 // There should be no error here.
 foo bar baz
 #else
-undefinedElse() // expected-error {{use of unresolved identifier 'undefinedElse'}}
+undefinedElse() // expected-error {{cannot find 'undefinedElse' in scope}}
 #endif
 
 #if swift(>=99.0) || FOO
-undefinedIf() // expected-error {{use of unresolved identifier 'undefinedIf'}}
+undefinedIf() // expected-error {{cannot find 'undefinedIf' in scope}}
 #else
 undefinedElse()
 #endif
@@ -31,18 +31,18 @@ undefinedElse()
 // There should be no error here.
 foo bar baz
 #else
-undefinedElse() // expected-error {{use of unresolved identifier 'undefinedElse'}}
+undefinedElse() // expected-error {{cannot find 'undefinedElse' in scope}}
 #endif
 
 #if FOO && swift(>=2.2)
-undefinedIf() // expected-error {{use of unresolved identifier 'undefinedIf'}}
+undefinedIf() // expected-error {{cannot find 'undefinedIf' in scope}}
 #else
 // There should be no error here.
 foo bar baz
 #endif
 
 #if swift(>=2.2) && swift(>=1)
-undefinedIf() // expected-error {{use of unresolved identifier 'undefinedIf'}}
+undefinedIf() // expected-error {{cannot find 'undefinedIf' in scope}}
 #else
 // There should be no error here.
 foo bar baz

--- a/test/Parse/closure-debugger.swift
+++ b/test/Parse/closure-debugger.swift
@@ -1,6 +1,6 @@
 // RUN: not %target-swift-frontend %s -typecheck -debugger-support 2>&1 | %FileCheck %s --check-prefix=DEBUG
 // RUN: not %target-swift-frontend %s -typecheck 2>&1 | %FileCheck %s --check-prefix=NODEBUG
 
-// DEBUG: error: use of unresolved identifier '$0'
+// DEBUG: error: cannot find '$0' in scope
 // NODEBUG: error: anonymous closure argument not contained in a closure
 $0

--- a/test/Parse/conflict_markers.swift
+++ b/test/Parse/conflict_markers.swift
@@ -23,13 +23,13 @@ var b : String = "b"
 var a : String = "a"
 var b : String = "B"
 >>>>>>> 18844bc65229786b96b89a9fc7739c0fc897905e:conflict_markers.swift
-print(a + b) // expected-error {{use of unresolved identifier 'a'}} expected-error {{use of unresolved identifier 'b'}}
+print(a + b) // expected-error {{cannot find 'a' in scope}} expected-error {{cannot find 'b' in scope}}
 
 <<<<<<< HEAD:conflict_markers.swift // expected-error {{source control conflict marker in source file}}
 ======= 
 var d : String = "D"
 >>>>>>> 18844bc65229786b96b89a9fc7739c0fc897905e:conflict_markers.swift
-print(d) // expected-error {{use of unresolved identifier 'd'}}
+print(d) // expected-error {{cannot find 'd' in scope}}
 
 <<<<<<<"HEAD:fake_conflict_markers.swift" // No error
 >>>>>>>"18844bc65229786b96b89a9fc7739c0fc897905e:fake_conflict_markers.swift" // No error
@@ -43,7 +43,7 @@ var fake_b : String = "a"
 var fake_c : String = "a"
 >>>>>>>"18844bc65229786b96b89a9fc7739c0fc897905e:fake_conflict_markers.swift"
 >>>>>>> 18844bc65229786b96b89a9fc7739c0fc897905e:conflict_markers.swift
-print(fake_b + fake_c) // expected-error {{use of unresolved identifier 'fake_b'}} expected-error {{use of unresolved identifier 'fake_c'}}
+print(fake_b + fake_c) // expected-error {{cannot find 'fake_b' in scope}} expected-error {{cannot find 'fake_c' in scope}}
 
 // Disambiguating conflict markers from operator applications.
 
@@ -77,12 +77,12 @@ var b : String = "b"
 var a : String = "a"
 var b : String = "B"
 <<<<
-print(a + b) // expected-error {{use of unresolved identifier 'a'}} expected-error {{use of unresolved identifier 'b'}}
+print(a + b) // expected-error {{cannot find 'a' in scope}} expected-error {{cannot find 'b' in scope}}
 
 >>>> ORIGINAL // expected-error {{source control conflict marker in source file}}
 ==== THEIRS
 ==== YOURS
 var d : String = "D"
 <<<<
-print(d) // expected-error {{use of unresolved identifier 'd'}}
+print(d) // expected-error {{cannot find 'd' in scope}}
 

--- a/test/Parse/confusables.swift
+++ b/test/Parse/confusables.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // expected-error @+4 {{type annotation missing in pattern}}
-// expected-error @+3 {{use of unresolved operator '⁚'}}
+// expected-error @+3 {{cannot find operator '⁚' in scope}}
 // expected-error @+2 {{operator with postfix spacing cannot start a subexpression}}
 // expected-error @+1 {{consecutive statements on a line must be separated by ';'}}
 let number⁚ Int // expected-note {{operator '⁚' contains possibly confused characters; did you mean to use ':'?}} {{11-14=:}}
@@ -11,7 +11,7 @@ let number⁚ Int // expected-note {{operator '⁚' contains possibly confused c
 // expected-error @+1 {{consecutive statements on a line must be separated by ';'}}
 5 ‒ 5 // expected-note {{unicode character '‒' looks similar to '-'; did you mean to use '-'?}} {{3-6=-}}
 
-// expected-error @+2 {{use of unresolved identifier 'ꝸꝸꝸ'}}
+// expected-error @+2 {{cannot find 'ꝸꝸꝸ' in scope}}
 // expected-error @+1 {{expected ',' separator}}
 if (true ꝸꝸꝸ false) {} // expected-note {{identifier 'ꝸꝸꝸ' contains possibly confused characters; did you mean to use '&&&'?}} {{10-19=&&&}}
 

--- a/test/Parse/delayed_extension.swift
+++ b/test/Parse/delayed_extension.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -swift-version 4
 
-extension X { } // expected-error {{use of undeclared type 'X'}}
+extension X { } // expected-error {{cannot find type 'X' in scope}}
 _ = 1
-f() // expected-error {{use of unresolved identifier 'f'}}
+f() // expected-error {{cannot find 'f' in scope}}

--- a/test/Parse/foreach.swift
+++ b/test/Parse/foreach.swift
@@ -16,7 +16,7 @@ func for_each(r: Range<Int>, iir: IntRange<Int>) { // expected-note {{'r' declar
     sum = sum + i
   }
   // Check scoping of variable introduced with foreach loop
-  i = 0 // expected-error{{use of unresolved identifier 'i'; did you mean 'r'?}}
+  i = 0 // expected-error{{cannot find 'i' in scope; did you mean 'r'?}}
 
   // For-each loops with two variables and varying degrees of typedness
   for (i, j) in iir {

--- a/test/Parse/identifiers.swift
+++ b/test/Parse/identifiers.swift
@@ -17,7 +17,7 @@ class 你好 {
 你好.שלום.வணக்கம்.Γειά.привет()
 
 // Identifiers cannot start with combining chars.
-_ = .́duh() // expected-error {{use of unresolved operator '.́'}} // expected-error{{use of unresolved identifier 'duh'}}
+_ = .́duh() // expected-error {{cannot find operator '.́' in scope}} // expected-error{{cannot find 'duh' in scope}}
 
 // Combining characters can be used within identifiers.
 func s̈pin̈al_tap̈() {}
@@ -38,12 +38,12 @@ protocol test {
 func _(_ x: Int) {} // expected-error {{keyword '_' cannot be used as an identifier here}} // expected-note {{if this name is unavoidable, use backticks to escape it}} {{6-7=`_`}}
 
 // SIL keywords are tokenized as normal identifiers in non-SIL mode.
-_ = undef // expected-error {{use of unresolved identifier 'undef'}}
-_ = sil // expected-error {{use of unresolved identifier 'sil'}}
-_ = sil_stage // expected-error {{use of unresolved identifier 'sil_stage'}}
-_ = sil_vtable // expected-error {{use of unresolved identifier 'sil_vtable'}}
-_ = sil_global // expected-error {{use of unresolved identifier 'sil_global'}}
-_ = sil_witness_table // expected-error {{use of unresolved identifier 'sil_witness_table'}}
-_ = sil_default_witness_table // expected-error {{use of unresolved identifier 'sil_default_witness_table'}}
-_ = sil_coverage_map // expected-error {{use of unresolved identifier 'sil_coverage_map'}}
-_ = sil_scope // expected-error {{use of unresolved identifier 'sil_scope'}}
+_ = undef // expected-error {{cannot find 'undef' in scope}}
+_ = sil // expected-error {{cannot find 'sil' in scope}}
+_ = sil_stage // expected-error {{cannot find 'sil_stage' in scope}}
+_ = sil_vtable // expected-error {{cannot find 'sil_vtable' in scope}}
+_ = sil_global // expected-error {{cannot find 'sil_global' in scope}}
+_ = sil_witness_table // expected-error {{cannot find 'sil_witness_table' in scope}}
+_ = sil_default_witness_table // expected-error {{cannot find 'sil_default_witness_table' in scope}}
+_ = sil_coverage_map // expected-error {{cannot find 'sil_coverage_map' in scope}}
+_ = sil_scope // expected-error {{cannot find 'sil_scope' in scope}}

--- a/test/Parse/implicit_getter_incomplete.swift
+++ b/test/Parse/implicit_getter_incomplete.swift
@@ -13,6 +13,6 @@ func test1() {
 // Would trigger assertion when AST verifier checks source ranges ("child source range not contained within its parent")
 func test2() { // expected-note {{match}}
   var a : Int { // expected-note {{match}} expected-note {{'a' declared here}}
-    switch i { // expected-error {{use of unresolved identifier 'i'; did you mean 'a'}} expected-error{{'switch' statement body must have at least one 'case'}}
+    switch i { // expected-error {{cannot find 'i' in scope; did you mean 'a'}} expected-error{{'switch' statement body must have at least one 'case'}}
 }
 // expected-error@+1 2 {{expected '}'}}

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -18,22 +18,22 @@ func test2o(__owned let x : Int) {}  // expected-warning {{'let' in this positio
 // expected-error @-1 {{'__owned' before a parameter name is not allowed, place it before the parameter type instead}} {{13-20=}}
 
 func test3() {
-  undeclared_func( // expected-error {{use of unresolved identifier 'undeclared_func'}}
+  undeclared_func( // expected-error {{cannot find 'undeclared_func' in scope}}
 } // expected-error {{expected expression in list of expressions}}
 
 func runAction() {} // expected-note {{'runAction' declared here}}
 
 // rdar://16601779
 func foo() {
-  runAction(SKAction.sequence() // expected-error {{use of unresolved identifier 'SKAction'; did you mean 'runAction'?}} {{13-21=runAction}} expected-error {{expected ',' separator}} {{32-32=,}}
+  runAction(SKAction.sequence() // expected-error {{cannot find 'SKAction' in scope; did you mean 'runAction'?}} {{13-21=runAction}} expected-error {{expected ',' separator}} {{32-32=,}}
     
     skview!
-    // expected-error @-1 {{use of unresolved identifier 'skview'}}
+    // expected-error @-1 {{cannot find 'skview' in scope}}
 }
 
 super.init() // expected-error {{'super' cannot be used outside of class members}}
 
-switch state { // expected-error {{use of unresolved identifier 'state'}}
+switch state { // expected-error {{cannot find 'state' in scope}}
   let duration : Int = 0 // expected-error {{all statements inside a switch must be covered by a 'case' or 'default'}}
   case 1:
     break
@@ -68,7 +68,7 @@ func d(_ b: String -> <T>() -> T) {} // expected-error {{expected type for funct
 
 // <rdar://problem/22143680> QoI: terrible diagnostic when trying to form a generic protocol
 protocol Animal<Food> {  // expected-error {{protocols do not allow generic parameters; use associated types instead}}
-  func feed(_ food: Food) // expected-error {{use of undeclared type 'Food'}}
+  func feed(_ food: Food) // expected-error {{cannot find type 'Food' in scope}}
 }
 
 

--- a/test/Parse/omit_return.swift
+++ b/test/Parse/omit_return.swift
@@ -1710,7 +1710,7 @@ class CImplicitIdentityExpr { func gimme() -> CImplicitIdentityExpr { self } }
 class CImplicitDotSelfExpr { func gimme() -> CImplicitDotSelfExpr { self.self } }
 
 func badIs<T>(_ value: Any, anInstanceOf type: T.Type) -> Bool {
-    value is type // expected-error {{use of undeclared type 'type'}}
+    value is type // expected-error {{cannot find type 'type' in scope}}
 }
 
 

--- a/test/Parse/omit_return_fail.swift
+++ b/test/Parse/omit_return_fail.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend %s -typecheck -verify
 
 func badIs<T>(_ value: Any, anInstanceOf type: T.Type) -> Bool {
-    value is type // expected-error {{use of undeclared type 'type'}}
+    value is type // expected-error {{cannot find type 'type' in scope}}
 }
 
 func foo() -> Int {

--- a/test/Parse/operator_decl_designated_types.swift
+++ b/test/Parse/operator_decl_designated_types.swift
@@ -30,18 +30,18 @@ infix operator **>> : UndeclaredPrecedence
 // expected-error@-1 {{unknown precedence group 'UndeclaredPrecedence'}}
 
 infix operator **+> : MediumPrecedence, UndeclaredProtocol
-// expected-error@-1 {{use of undeclared type 'UndeclaredProtocol'}}
+// expected-error@-1 {{cannot find type 'UndeclaredProtocol' in scope}}
 
 prefix operator *+*> : MediumPrecedence
-// expected-error@-1 {{use of undeclared type 'MediumPrecedence'}}
+// expected-error@-1 {{cannot find type 'MediumPrecedence' in scope}}
 
 postfix operator ++*> : MediumPrecedence
-// expected-error@-1 {{use of undeclared type 'MediumPrecedence'}}
+// expected-error@-1 {{cannot find type 'MediumPrecedence' in scope}}
 
 prefix operator *++> : UndeclaredProtocol
-// expected-error@-1 {{use of undeclared type 'UndeclaredProtocol'}}
+// expected-error@-1 {{cannot find type 'UndeclaredProtocol' in scope}}
 postfix operator +*+> : UndeclaredProtocol
-// expected-error@-1 {{use of undeclared type 'UndeclaredProtocol'}}
+// expected-error@-1 {{cannot find type 'UndeclaredProtocol' in scope}}
 
 struct Struct {}
 class Class {}
@@ -65,9 +65,9 @@ infix operator ^%*%% : Struct, Class
 prefix operator %^*^^ : Struct, Class
 postfix operator ^^*^% : Struct, Class
 prefix operator %%*^^ : LowPrecedence, Class
-// expected-error@-1{{use of undeclared type 'LowPrecedence'}}
+// expected-error@-1{{cannot find type 'LowPrecedence' in scope}}
 postfix operator ^^*%% : MediumPrecedence, Class
-// expected-error@-1{{use of undeclared type 'MediumPrecedence'}}
+// expected-error@-1{{cannot find type 'MediumPrecedence' in scope}}
 
 // expected-error@+1 {{trailing comma in operator declaration}}
 infix operator <*<>*> : AdditionPrecedence,

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -55,7 +55,7 @@ func braceStmt2() {
 
 func braceStmt3() {
   {  // expected-error {{closure expression is unused}} expected-note {{did you mean to use a 'do' statement?}} {{3-3=do }}
-    undefinedIdentifier {} // expected-error {{use of unresolved identifier 'undefinedIdentifier'}}
+    undefinedIdentifier {} // expected-error {{cannot find 'undefinedIdentifier' in scope}}
   }
 }
 
@@ -386,10 +386,10 @@ struct ErrorTypeInVarDecl11 {
 func ErrorTypeInPattern1(_: protocol<) { } // expected-error {{expected identifier for type name}}
 func ErrorTypeInPattern2(_: protocol<F) { } // expected-error {{expected '>' to complete protocol-constrained type}}
                                             // expected-note@-1 {{to match this opening '<'}}
-                                            // expected-error@-2 {{use of undeclared type 'F'}}
+                                            // expected-error@-2 {{cannot find type 'F' in scope}}
 
 func ErrorTypeInPattern3(_: protocol<F,) { } // expected-error {{expected identifier for type name}}
-                                             // expected-error@-1 {{use of undeclared type 'F'}}
+                                             // expected-error@-1 {{cannot find type 'F' in scope}}
 
 struct ErrorTypeInVarDecl12 {
   var v1 : FooProtocol & // expected-error{{expected identifier for type name}}
@@ -514,7 +514,7 @@ struct ErrorInFunctionSignatureResultArrayType5 {
 
 
 struct ErrorInFunctionSignatureResultArrayType11 { // expected-note{{in declaration of 'ErrorInFunctionSignatureResultArrayType11'}}
-  func foo() -> Int[(a){a++}] { // expected-error {{consecutive declarations on a line must be separated by ';'}} {{29-29=;}} expected-error {{expected ']' in array type}} expected-note {{to match this opening '['}} expected-error {{use of unresolved operator '++'; did you mean '+= 1'?}} expected-error {{use of unresolved identifier 'a'}} expected-error {{expected declaration}}
+  func foo() -> Int[(a){a++}] { // expected-error {{consecutive declarations on a line must be separated by ';'}} {{29-29=;}} expected-error {{expected ']' in array type}} expected-note {{to match this opening '['}} expected-error {{cannot find operator '++' in scope; did you mean '+= 1'?}} expected-error {{cannot find 'a' in scope}} expected-error {{expected declaration}}
   }
 }
 
@@ -651,7 +651,7 @@ func foo1(bar!=baz) {} // expected-note {{did you mean 'foo1'?}}
 func foo2(bar! = baz) {}// expected-note {{did you mean 'foo2'?}}
 
 // rdar://19605567
-// expected-error@+1{{use of unresolved identifier 'esp'; did you mean 'test'?}}
+// expected-error@+1{{cannot find 'esp' in scope; did you mean 'test'?}}
 switch esp {
 case let (jeb):
   // expected-error@+5{{top-level statement cannot begin with a closure expression}}
@@ -667,7 +667,7 @@ case let (jeb):
 #if true
 
 // rdar://19605164
-// expected-error@+2{{use of undeclared type 'S'}}
+// expected-error@+2{{cannot find type 'S' in scope}}
 struct Foo19605164 {
 func a(s: S[{{g) -> Int {}
 // expected-error@+2 {{expected parameter name followed by ':'}}
@@ -702,13 +702,13 @@ struct InitializerWithLabels {
 // rdar://20337695
 func f1() {
 
-  // expected-error @+6 {{use of unresolved identifier 'C'}}
+  // expected-error @+6 {{cannot find 'C' in scope}}
   // expected-note @+5 {{did you mean 'n'?}}
   // expected-error @+4 {{unary operator cannot be separated from its operand}} {{11-12=}}
   // expected-error @+3 {{'==' is not a prefix unary operator}}
   // expected-error @+2 {{consecutive statements on a line must be separated by ';'}} {{8-8=;}}
   // expected-error@+1 {{type annotation missing in pattern}}
-  let n == C { get {}  // expected-error {{use of unresolved identifier 'get'}}
+  let n == C { get {}  // expected-error {{cannot find 'get' in scope}}
   }
 }
 
@@ -768,7 +768,7 @@ enum Rank: Int {  // expected-error {{'Rank' declares raw type 'Int', but does n
 // rdar://22240342 - Crash in diagRecursivePropertyAccess
 class r22240342 {
   lazy var xx: Int = {
-    foo {  // expected-error {{use of unresolved identifier 'foo'}}
+    foo {  // expected-error {{cannot find 'foo' in scope}}
       let issueView = 42
       issueView.delegate = 12
       

--- a/test/Parse/subscripting.swift
+++ b/test/Parse/subscripting.swift
@@ -85,7 +85,7 @@ class X6 {
 
 struct Y1 {
   var stored: Int
-  subscript(_: i, j: Int) -> Int { // expected-error {{use of undeclared type 'i'}}
+  subscript(_: i, j: Int) -> Int { // expected-error {{cannot find type 'i' in scope}}
     get {
       return stored + j
     }
@@ -127,10 +127,10 @@ struct A1 {
   subscript (i : Int) // expected-error{{expected '->' for subscript element type}}
      Int {
     get {
-      return stored // expected-error{{use of unresolved identifier}}
+      return stored // expected-error{{cannot find 'stored' in scope}}
     }
     set {
-      stored = newValue// expected-error{{use of unresolved identifier}}
+      stored = newValue// expected-error{{cannot find 'stored' in scope}}
     }
   }
 }
@@ -142,7 +142,7 @@ struct A2 {
       return stored
     }
     set {
-      stored = newValue // expected-error{{use of unresolved identifier}}
+      stored = newValue // expected-error{{cannot find 'stored' in scope}}
     }
   }
 }
@@ -175,7 +175,7 @@ struct A6 {
                                      // expected-error@-1 {{function types cannot have argument labels}}
                                      // expected-note@-2 {{did you mean}}
     get {
-      return i + j // expected-error {{use of unresolved identifier}}
+      return i + j // expected-error {{cannot find 'j' in scope}}
     }
   }
 }

--- a/test/Parse/swift3_warnings_swift4_errors_version_4.swift
+++ b/test/Parse/swift3_warnings_swift4_errors_version_4.swift
@@ -16,7 +16,7 @@ let z: protocol<P1, P2> // expected-error {{'protocol<...>' composition syntax h
 func bar(f: @noescape () -> ()) {} // expected-error {{unknown attribute 'noescape'}}
 
 func baz(f: @autoclosure(escaping) () -> ()) {}
-// expected-error @-1 {{use of undeclared type 'escaping'}}
+// expected-error @-1 {{cannot find type 'escaping' in scope}}
 // expected-error @-2 {{unnamed parameters must be written with the empty name '_'}}
 // expected-error @-3 {{expected ',' separator}}
 

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -317,7 +317,7 @@ func enumElementSyntaxOnTuple() {
 // sr-176
 enum Whatever { case Thing }
 func f0(values: [Whatever]) { // expected-note {{'values' declared here}}
-    switch value { // expected-error {{use of unresolved identifier 'value'; did you mean 'values'?}}
+    switch value { // expected-error {{cannot find 'value' in scope; did you mean 'values'?}}
     case .Thing: // Ok. Don't emit diagnostics about enum case not found in type <<error type>>.
         break
     }

--- a/test/SPI/client_reuse_spi.swift
+++ b/test/SPI/client_reuse_spi.swift
@@ -24,6 +24,6 @@
 var a = foo() // OK
 a.bar() // expected-error{{'bar' is inaccessible due to '@_spi' protection level}}
 
-var b = SecretStruct() // expected-error{{use of unresolved identifier}}
+var b = SecretStruct() // expected-error{{cannot find 'SecretStruct' in scope}}
 
 #endif

--- a/test/SPI/implementation_only_spi_import.swift
+++ b/test/SPI/implementation_only_spi_import.swift
@@ -18,6 +18,6 @@ foo() // OK
 #elseif LIB_C
 
 import B
-foo() // expected-error{{use of unresolved identifier}}
+foo() // expected-error{{cannot find 'foo' in scope}}
 
 #endif

--- a/test/SPI/public_client.swift
+++ b/test/SPI/public_client.swift
@@ -20,12 +20,12 @@ import SPIHelper
 
 // Use the public API
 publicFunc()
-spiFunc() // expected-error {{use of unresolved identifier}}
-internalFunc() // expected-error {{use of unresolved identifier}}
+spiFunc() // expected-error {{cannot find 'spiFunc' in scope}}
+internalFunc() // expected-error {{cannot find 'internalFunc' in scope}}
 
-let c = SPIClass() // expected-error {{use of unresolved identifier}}
-let s = SPIStruct() // expected-error {{use of unresolved identifier}}
-SPIEnum().spiMethod() // expected-error {{use of unresolved identifier}}
+let c = SPIClass() // expected-error {{cannot find 'SPIClass' in scope}}
+let s = SPIStruct() // expected-error {{cannot find 'SPIStruct' in scope}}
+SPIEnum().spiMethod() // expected-error {{cannot find 'SPIEnum' in scope}}
 
 var ps = PublicStruct()
 let _ = PublicStruct(alt_init: 1) // expected-error {{argument passed to call that takes no arguments}}
@@ -33,13 +33,13 @@ ps.spiMethod() // expected-error {{'spiMethod' is inaccessible due to '@_spi' pr
 ps.spiVar = "write" // expected-error {{'spiVar' is inaccessible due to '@_spi' protection level}}
 print(ps.spiVar) // expected-error {{'spiVar' is inaccessible due to '@_spi' protection level}}
 
-otherApiFunc() // expected-error {{use of unresolved identifier}}
+otherApiFunc() // expected-error {{cannot find 'otherApiFunc' in scope}}
 
-public func publicUseOfSPI(param: SPIClass) -> SPIClass {} // expected-error 2{{use of undeclared type}}
-public func publicUseOfSPI2() -> [SPIClass] {} // expected-error {{use of undeclared type}}
+public func publicUseOfSPI(param: SPIClass) -> SPIClass {} // expected-error 2{{cannot find type 'SPIClass' in scope}}
+public func publicUseOfSPI2() -> [SPIClass] {} // expected-error {{cannot find type 'SPIClass' in scope}}
 
 @inlinable
-func inlinable() -> SPIClass { // expected-error {{use of undeclared type}}
-  spiFunc() // expected-error {{use of unresolved identifier}}
-  _ = SPIClass() // expected-error {{use of unresolved identifier}}
+func inlinable() -> SPIClass { // expected-error {{cannot find type 'SPIClass' in scope}}
+  spiFunc() // expected-error {{cannot find 'spiFunc' in scope}}
+  _ = SPIClass() // expected-error {{cannot find 'SPIClass' in scope}}
 }

--- a/test/SPI/spi_client.swift
+++ b/test/SPI/spi_client.swift
@@ -21,7 +21,7 @@
 // Use as SPI
 publicFunc()
 spiFunc()
-internalFunc() // expected-error {{use of unresolved identifier}}
+internalFunc() // expected-error {{cannot find 'internalFunc' in scope}}
 
 let c = SPIClass()
 c.spiMethod()
@@ -47,7 +47,7 @@ ps.spiMethod()
 ps.spiVar = "write"
 print(ps.spiVar)
 
-otherApiFunc() // expected-error {{use of unresolved identifier}}
+otherApiFunc() // expected-error {{cannot find 'otherApiFunc' in scope}}
 
 public func publicUseOfSPI(param: SPIClass) -> SPIClass {} // expected-error 2{{cannot use class 'SPIClass' here; it is an SPI imported from 'SPIHelper'}}
 // expected-error@-1 {{function cannot be declared public because its parameter uses an '@_spi' type}}

--- a/test/Sema/Inputs/circularity_multifile_error_helper.swift
+++ b/test/Sema/Inputs/circularity_multifile_error_helper.swift
@@ -1,5 +1,5 @@
 struct External {
-  var member: Something // expected-error {{use of undeclared type 'Something'}}
+  var member: Something // expected-error {{cannot find type 'Something' in scope}}
 }
 
 struct OtherExternal {}

--- a/test/Sema/accessibility_private.swift
+++ b/test/Sema/accessibility_private.swift
@@ -81,12 +81,12 @@ extension Container.Inner {
     obj.privateExtensionMethod()
 
     // FIXME: Unqualified lookup won't look into Container from here.
-    _ = PrivateInner() // expected-error {{use of unresolved identifier 'PrivateInner'}}
+    _ = PrivateInner() // expected-error {{cannot find 'PrivateInner' in scope}}
     _ = Container.PrivateInner()
   }
 
   // FIXME: Unqualified lookup won't look into Container from here.
-  var inner: PrivateInner? { return nil } // expected-error {{use of undeclared type 'PrivateInner'}}
+  var inner: PrivateInner? { return nil } // expected-error {{cannot find type 'PrivateInner' in scope}}
   var innerQualified: Container.PrivateInner? { return nil } // expected-error {{invalid redeclaration of 'innerQualified'}} expected-error {{property must be declared private because its type uses a private type}}
 }
 

--- a/test/Sema/circular_decl_checking.swift
+++ b/test/Sema/circular_decl_checking.swift
@@ -6,10 +6,10 @@ class HasFunc {
   func HasFunc() -> HasFunc {
     return HasFunc()
   }
-  func SomethingElse(_: SomethingElse) { // expected-error {{use of undeclared type 'SomethingElse'}}
+  func SomethingElse(_: SomethingElse) { // expected-error {{cannot find type 'SomethingElse' in scope}}
     return nil // expected-error {{unexpected non-void return value in void function}}
   }
-  func SomethingElse() -> SomethingElse? { // expected-error {{use of undeclared type 'SomethingElse'}}
+  func SomethingElse() -> SomethingElse? { // expected-error {{cannot find type 'SomethingElse' in scope}}
     return nil
   }
 }
@@ -28,7 +28,7 @@ class HasProp { // expected-note {{'HasProp' declared here}}
     return HasProp() // expected-error {{use of 'HasProp' refers to instance method rather than class 'HasProp' in module 'circular_decl_checking'}}
     // expected-note@-1 {{use 'circular_decl_checking.' to reference the class in module 'circular_decl_checking'}} {{12-12=circular_decl_checking.}}
   }
-  var SomethingElse: SomethingElse? { // expected-error {{use of undeclared type 'SomethingElse'}}
+  var SomethingElse: SomethingElse? { // expected-error {{cannot find type 'SomethingElse' in scope}}
     return nil
   }
 }
@@ -38,10 +38,10 @@ protocol ReferenceSomeProtocol {
   var SomeProtocol: SomeProtocol { get } 
 }
 
-func TopLevelFunc(x: TopLevelFunc) -> TopLevelFunc { return x } // expected-error 2 {{use of undeclared type 'TopLevelFunc'}}'
+func TopLevelFunc(x: TopLevelFunc) -> TopLevelFunc { return x } // expected-error 2 {{cannot find type 'TopLevelFunc' in scope}}'
 func TopLevelGenericFunc<TopLevelGenericFunc : TopLevelGenericFunc>(x: TopLevelGenericFunc) -> TopLevelGenericFunc { return x } // expected-error {{type 'TopLevelGenericFunc' constrained to non-protocol, non-class type 'TopLevelGenericFunc'}}
-func TopLevelGenericFunc2<T : TopLevelGenericFunc2>(x: T) -> T { return x} // expected-error {{use of undeclared type 'TopLevelGenericFunc2'}}
-var TopLevelVar: TopLevelVar? { return nil } // expected-error {{use of undeclared type 'TopLevelVar'}}
+func TopLevelGenericFunc2<T : TopLevelGenericFunc2>(x: T) -> T { return x} // expected-error {{cannot find type 'TopLevelGenericFunc2' in scope}}
+var TopLevelVar: TopLevelVar? { return nil } // expected-error {{cannot find type 'TopLevelVar' in scope}}
 
 
 protocol AProtocol {

--- a/test/Sema/circularity_multifile_error.swift
+++ b/test/Sema/circularity_multifile_error.swift
@@ -3,7 +3,7 @@
 // SR-4594
 
 struct A {
-  var b: AnUndefinedType // expected-error {{use of undeclared type 'AnUndefinedType'}}
+  var b: AnUndefinedType // expected-error {{cannot find type 'AnUndefinedType' in scope}}
 }
 
 struct B {

--- a/test/Sema/diag_constantness_check.swift
+++ b/test/Sema/diag_constantness_check.swift
@@ -292,7 +292,7 @@ func testFunctionWithWrongSemantics(x: Int) {
 // Test that the check is resilient to other type errors.
 func testOtherTypeErrors() {
   constantArgumentFunction(x)
-    // expected-error@-1 {{use of unresolved identifier 'x'}}
+    // expected-error@-1 {{cannot find 'x' in scope}}
   constantArgumentFunction(10 as String)
     // expected-error@-1 {{cannot convert value of type 'Int' to type 'String' in coercion}}
 }

--- a/test/Sema/diag_variable_used_in_initial.swift
+++ b/test/Sema/diag_variable_used_in_initial.swift
@@ -44,7 +44,7 @@ func localContext() {
     }
 
     extension E { // expected-error {{declaration is only valid at file scope}}
-      // expected-error@-1{{use of undeclared type 'E'}}
+      // expected-error@-1{{cannot find type 'E' in scope}}
       class A7 {
         func foo1() {}
         func foo2() {

--- a/test/Sema/editor_placeholders.swift
+++ b/test/Sema/editor_placeholders.swift
@@ -10,7 +10,7 @@ if (true) {
   <#code#> // expected-error {{editor placeholder}}
 }
 
-foo(<#T##x: Undeclared##Undeclared#>) // expected-error {{editor placeholder}} expected-error {{use of undeclared type 'Undeclared'}}
+foo(<#T##x: Undeclared##Undeclared#>) // expected-error {{editor placeholder}} expected-error {{cannot find type 'Undeclared' in scope}}
 
 func f(_ n: Int) {}
 let a1 = <#T#> // expected-error{{editor placeholder in source file}}

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -178,7 +178,7 @@ enum NoCases: Hashable, Comparable {}
 
 // rdar://19773050
 private enum Bar<T> {
-  case E(Unknown<T>)  // expected-error {{use of undeclared type 'Unknown'}}
+  case E(Unknown<T>)  // expected-error {{cannot find type 'Unknown' in scope}}
 
   mutating func value() -> T {
     switch self {

--- a/test/Sema/typo_correction.swift
+++ b/test/Sema/typo_correction.swift
@@ -12,13 +12,13 @@ import NoSuchModule
 func test_short_and_close() {
   let foo = 4 // expected-note {{'foo' declared here}}
   let bab = fob + 1
-  // expected-error@-1 {{use of unresolved identifier 'fob'; did you mean 'foo'?}}
+  // expected-error@-1 {{cannot find 'fob' in scope; did you mean 'foo'?}}
 }
 
 // This is not.
 func test_too_different() {
   let moo = 4
-  let bbb = mbb + 1 // expected-error {{use of unresolved identifier}}
+  let bbb = mbb + 1 // expected-error {{cannot find 'mbb' in scope}}
 }
 
 struct Whatever {}
@@ -29,26 +29,26 @@ func test_very_short() {
   // Note that we don't suggest operators.
   let x = 0 // expected-note {{did you mean 'x'?}}
   let longer = y
-  // expected-error@-1 {{use of unresolved identifier 'y'}}
+  // expected-error@-1 {{cannot find 'y' in scope}}
 }
 
 // It does not trigger in a variable's own initializer.
 func test_own_initializer() {
-  let x = y // expected-error {{use of unresolved identifier 'y'}}
+  let x = y // expected-error {{cannot find 'y' in scope}}
 }
 
 // Report candidates that are the same distance in different ways.
 func test_close_matches() {
   let match1 = 0 // expected-note {{did you mean 'match1'?}}
   let match22 = 0 // expected-note {{did you mean 'match22'?}}
-  let x = match2 // expected-error {{use of unresolved identifier 'match2'}}
+  let x = match2 // expected-error {{cannot find 'match2' in scope}}
 }
 
 // Report not-as-good matches if they're still close enough to the best.
 func test_keep_if_not_too_much_worse() {
   let longmatch1 = 0 // expected-note {{did you mean 'longmatch1'?}}
   let longmatch22 = 0 // expected-note {{did you mean 'longmatch22'?}}
-  let x = longmatch // expected-error {{use of unresolved identifier 'longmatch'}}
+  let x = longmatch // expected-error {{cannot find 'longmatch' in scope}}
 }
 
 // Report not-as-good matches if they're still close enough to the best.
@@ -56,7 +56,7 @@ func test_drop_if_too_different() {
   let longlongmatch1 = 0 // expected-note {{'longlongmatch1' declared here}}
   let longlongmatch2222 = 0
   let x = longlongmatch
-  // expected-error@-1 {{use of unresolved identifier 'longlongmatch'; did you mean 'longlongmatch1'?}}
+  // expected-error@-1 {{cannot find 'longlongmatch' in scope; did you mean 'longlongmatch1'?}}
 }
 
 // Candidates are suppressed if we have too many that are the same distance.
@@ -67,7 +67,7 @@ func test_too_many_same() {
   let match4 = 0
   let match5 = 0
   let match6 = 0
-  let x = match // expected-error {{use of unresolved identifier 'match'}}
+  let x = match // expected-error {{cannot find 'match' in scope}}
 }
 
 // But if some are better than others, just drop the worse tier.
@@ -78,7 +78,7 @@ func test_too_many_but_some_better() {
   let match4 = 0
   let match5 = 0
   let match6 = 0
-  let x = mtch // expected-error {{use of unresolved identifier 'mtch'}}
+  let x = mtch // expected-error {{cannot find 'mtch' in scope}}
 }
 
 // rdar://problem/28387684
@@ -107,7 +107,7 @@ struct Generic<T> { // expected-note {{'T' declared as parameter to type 'Generi
   class Inner {
     func doStuff() {
       match0()
-      // expected-error@-1 {{use of unresolved identifier 'match0'; did you mean 'match1'?}}
+      // expected-error@-1 {{cannot find 'match0' in scope; did you mean 'match1'?}}
     }
   }
 }
@@ -157,17 +157,17 @@ func overloaded(_: Int) {} // expected-note {{'overloaded' declared here}}
 func overloaded(_: Float) {} // expected-note {{'overloaded' declared here}}
 func test_overloaded() {
   overloadd(0)
-  // expected-error@-1 {{use of unresolved identifier 'overloadd'; did you mean 'overloaded'?}}{{3-12=overloaded}}
+  // expected-error@-1 {{cannot find 'overloadd' in scope; did you mean 'overloaded'?}}{{3-12=overloaded}}
 }
 
 // This is one of the backtraces from rdar://36434823 but got fixed along
 // the way.
 class CircularValidationWithTypo {
-  var cdcdcdcd = ababab { // expected-error {{use of unresolved identifier 'ababab'}}
+  var cdcdcdcd = ababab { // expected-error {{cannot find 'ababab' in scope}}
     didSet { }
   }
 
-  var abababab = cdcdcdc { // expected-error {{use of unresolved identifier 'cdcdcdc'}}
+  var abababab = cdcdcdc { // expected-error {{cannot find 'cdcdcdc' in scope}}
     didSet { }
   }
 }
@@ -178,7 +178,7 @@ protocol PP {}
 func boo() {
   extension PP { // expected-error {{declaration is only valid at file scope}}
     func g() {
-      booo() // expected-error {{use of unresolved identifier 'booo'}}
+      booo() // expected-error {{cannot find 'booo' in scope}}
     }
   }
 }
@@ -188,18 +188,18 @@ func boo() {
 func test_underscored_no_match() {
   let _ham = 0
   _ = ham
-  // expected-error@-1 {{use of unresolved identifier 'ham'}}
+  // expected-error@-1 {{cannot find 'ham' in scope}}
 }
 
 func test_underscored_match() {
   let _eggs = 4 // expected-note {{'_eggs' declared here}}
   _ = _fggs + 1
-  // expected-error@-1 {{use of unresolved identifier '_fggs'; did you mean '_eggs'?}}
+  // expected-error@-1 {{cannot find '_fggs' in scope; did you mean '_eggs'?}}
 }
 
 // Don't show values before declaration.
 func testFwdRef() {
-  let _ = forward_refX + 1 // expected-error {{use of unresolved identifier 'forward_refX'}}
+  let _ = forward_refX + 1 // expected-error {{cannot find 'forward_refX' in scope}}
   let forward_ref1 = 4
 }
 
@@ -218,6 +218,6 @@ protocol P2 {
 
 extension P2 {
   func f() { // expected-note {{did you mean 'f'?}}
-    _ = a // expected-error {{use of unresolved identifier 'a'}}
+    _ = a // expected-error {{cannot find 'a' in scope}}
   }
 }

--- a/test/Sema/typo_correction_limit.swift
+++ b/test/Sema/typo_correction_limit.swift
@@ -3,10 +3,10 @@
 // This is close enough to get typo-correction.
 func test_short_and_close() {
   let foo = 4 // expected-note 5 {{'foo' declared here}}
-  let _ = fob + 1 // expected-error {{use of unresolved identifier 'fob'; did you mean 'foo'?}}
-  let _ = fob + 1 // expected-error {{use of unresolved identifier 'fob'; did you mean 'foo'?}}
-  let _ = fob + 1 // expected-error {{use of unresolved identifier 'fob'; did you mean 'foo'?}}
-  let _ = fob + 1 // expected-error {{use of unresolved identifier 'fob'; did you mean 'foo'?}}
-  let _ = fob + 1 // expected-error {{use of unresolved identifier 'fob'; did you mean 'foo'?}}
-  let _ = fob + 1 // expected-error {{use of unresolved identifier 'fob'}}
+  let _ = fob + 1 // expected-error {{cannot find 'fob' in scope; did you mean 'foo'?}}
+  let _ = fob + 1 // expected-error {{cannot find 'fob' in scope; did you mean 'foo'?}}
+  let _ = fob + 1 // expected-error {{cannot find 'fob' in scope; did you mean 'foo'?}}
+  let _ = fob + 1 // expected-error {{cannot find 'fob' in scope; did you mean 'foo'?}}
+  let _ = fob + 1 // expected-error {{cannot find 'fob' in scope; did you mean 'foo'?}}
+  let _ = fob + 1 // expected-error {{cannot find 'fob' in scope}}
 }

--- a/test/Serialization/Inputs/top-level-code-other.swift
+++ b/test/Serialization/Inputs/top-level-code-other.swift
@@ -1,5 +1,5 @@
 func use(_ x: Int) {}
 func test() {
   use(a!)
-  use(b) // expected-error {{use of unresolved identifier 'b'; did you mean 'a'?}}
+  use(b) // expected-error {{cannot find 'b' in scope; did you mean 'a'?}}
 }

--- a/test/Serialization/Recovery/superclass.swift
+++ b/test/Serialization/Recovery/superclass.swift
@@ -16,8 +16,8 @@ func use(_: C3_NestingCRTPish) {}
 func use(_: C4_ExtensionNestingCRTPish) {}
 
 // FIXME: Better to import the class and make it unavailable.
-func use(_: A1_Sub) {} // expected-error {{use of undeclared type 'A1_Sub'}}
-func use(_: A2_Grandchild) {} // expected-error {{use of undeclared type 'A2_Grandchild'}}
+func use(_: A1_Sub) {} // expected-error {{cannot find type 'A1_Sub' in scope}}
+func use(_: A2_Grandchild) {} // expected-error {{cannot find type 'A2_Grandchild' in scope}}
 
 #else // TEST
 

--- a/test/Serialization/Recovery/typedefs-in-enums.swift
+++ b/test/Serialization/Recovery/typedefs-in-enums.swift
@@ -14,11 +14,11 @@ import Lib
 
 func use(_: OkayEnum) {}
 // FIXME: Better to import the enum and make it unavailable.
-func use(_: BadEnum) {} // expected-error {{use of undeclared type 'BadEnum'}}
+func use(_: BadEnum) {} // expected-error {{cannot find type 'BadEnum' in scope}}
 
 func test() {
   _ = producesOkayEnum()
-  _ = producesBadEnum() // expected-error {{use of unresolved identifier 'producesBadEnum'}}
+  _ = producesBadEnum() // expected-error {{cannot find 'producesBadEnum' in scope}}
 
   // Force a lookup of the ==
   _ = Optional(OkayEnum.noPayload).map { $0 == .noPayload }

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -51,16 +51,16 @@ let _: String = useAssoc(AnotherType.self) // expected-error {{cannot convert va
 let _: Bool? = useAssoc(AnotherType.self) // expected-error {{cannot convert value of type 'AnotherType.Assoc?' (aka 'Optional<Int32>') to specified type 'Bool?'}}
 let _: Int32? = useAssoc(AnotherType.self)
 
-let _ = wrapped // expected-error {{use of unresolved identifier 'wrapped'}}
+let _ = wrapped // expected-error {{cannot find 'wrapped' in scope}}
 let _ = unwrapped // okay
 
-_ = usesWrapped(nil) // expected-error {{use of unresolved identifier 'usesWrapped'}}
+_ = usesWrapped(nil) // expected-error {{cannot find 'usesWrapped' in scope}}
 _ = usesUnwrapped(nil) // expected-error {{'nil' is not compatible with expected argument type 'Int32'}}
 
-let _: WrappedAlias = nil // expected-error {{use of undeclared type 'WrappedAlias'}}
+let _: WrappedAlias = nil // expected-error {{cannot find type 'WrappedAlias' in scope}}
 let _: UnwrappedAlias = nil // expected-error {{'nil' cannot initialize specified type 'UnwrappedAlias' (aka 'Int32')}} expected-note {{add '?'}}
 
-let _: ConstrainedWrapped<Int> = nil // expected-error {{use of undeclared type 'ConstrainedWrapped'}}
+let _: ConstrainedWrapped<Int> = nil // expected-error {{cannot find type 'ConstrainedWrapped' in scope}}
 let _: ConstrainedUnwrapped<Int> = nil // expected-error {{type 'Int' does not conform to protocol 'HasAssoc'}}
 
 func testExtensions(wrapped: WrappedInt, unwrapped: UnwrappedInt) {

--- a/test/Serialization/failed-clang-module.swift
+++ b/test/Serialization/failed-clang-module.swift
@@ -16,7 +16,7 @@
 // RUN: %target-swift-frontend -typecheck %s -Xcc -DFAIL -I %t -module-cache-path %t/mcp -show-diagnostics-after-fatal -verify -verify-ignore-unknown
 
 import SwiftModB // expected-error {{missing required module}}
-_ = TyB() // expected-error {{use of unresolved identifier 'TyB'}}
+_ = TyB() // expected-error {{cannot find 'TyB' in scope}}
 
 // -verify-ignore-unknown is for:
 // <unknown>:0: error: unexpected error produced: could not build Objective-C module 'ObjCFail'

--- a/test/Serialization/load-invalid-arch.swift
+++ b/test/Serialization/load-invalid-arch.swift
@@ -24,7 +24,7 @@
 // CHECK-ALL: error: no such module 'new_module'
 // CHECK-ALL-NEXT: import new_module
 // CHECK-ALL-NEXT: 		^
-// CHECK-ALL: error: use of unresolved identifier 'new_module'
+// CHECK-ALL: error: cannot find 'new_module' in scope
 // CHECK-ALL-NEXT: new_module.foo()
 // CHECK-ALL-NEXT: ^~~~~~~~~~
 // CHECK-ALL-NOT: error:

--- a/test/Serialization/load.swift
+++ b/test/Serialization/load.swift
@@ -6,4 +6,4 @@
 // These errors should happen before we've built the module to import.
 import new_module // expected-error{{no such module 'new_module'}}
 
-new_module.getZero() // expected-error {{use of unresolved identifier 'new_module'}}
+new_module.getZero() // expected-error {{cannot find 'new_module' in scope}}

--- a/test/Serialization/search-paths.swift
+++ b/test/Serialization/search-paths.swift
@@ -31,7 +31,7 @@
 
 import has_xref // expected-error {{missing required modules: 'has_alias', 'struct_with_operators'}}
 
-numeric(42) // expected-error {{use of unresolved identifier 'numeric'}}
+numeric(42) // expected-error {{cannot find 'numeric' in scope}}
 
 // CHECK: <INPUT_BLOCK
 // CHECK-NOT: /secret'

--- a/test/SourceKit/CompileNotifications/diagnostics.swift
+++ b/test/SourceKit/CompileNotifications/diagnostics.swift
@@ -38,7 +38,7 @@
 // SEMA-NEXT:     key.column: 5
 // SEMA-NEXT:     key.filepath: "{{.*}}sema-error.swift"
 // SEMA-NEXT:     key.severity: source.diagnostic.severity.error
-// SEMA-NEXT:     key.description: "use of
+// SEMA-NEXT:     key.description: "cannot find '{{.*}}' in scope
 // SEMA-NEXT:     key.ranges: [
 
 // RUN: %sourcekitd-test -req=track-compiles == -req=sema %s -- %s -Xcc -include -Xcc /doesnotexist | %FileCheck %s -check-prefix=CLANG_IMPORTER

--- a/test/SourceKit/Sema/placeholders.swift.placeholders.response
+++ b/test/SourceKit/Sema/placeholders.swift.placeholders.response
@@ -5,7 +5,7 @@
     key.column: 19,
     key.filepath: placeholders.swift,
     key.severity: source.diagnostic.severity.error,
-    key.description: "use of undeclared type '<#OtherClass#>'",
+    key.description: "cannot find type '<#OtherClass#>' in scope",
     key.diagnostic_stage: source.diagnostic.stage.swift.sema,
     key.ranges: [
       {

--- a/test/SourceKit/Sema/sema_build_session.swift
+++ b/test/SourceKit/Sema/sema_build_session.swift
@@ -44,15 +44,15 @@ func test() {
 
 // CHECK_SYSTEM_2-LABEL: ## THREE
 // CHECK_SYSTEM_2: key.severity: source.diagnostic.severity.error,
-// CHECK_SYSTEM_2-NEXT: key.description: "use of unresolved identifier 'fooFunc'",
+// CHECK_SYSTEM_2-NEXT: key.description: "cannot find 'fooFunc' in scope",
 // CHECK_SYSTEM_2: key.severity: source.diagnostic.severity.error,
-// CHECK_SYSTEM_2-NEXT: key.description: "use of unresolved identifier 'fooSubFunc'",
+// CHECK_SYSTEM_2-NEXT: key.description: "cannot find 'fooSubFunc' in scope",
 // CHECK_SYSTEM_2: key.severity: source.diagnostic.severity.error,
-// CHECK_SYSTEM_2-NEXT: key.description: "use of unresolved identifier 'fooHelperFunc'",
+// CHECK_SYSTEM_2-NEXT: key.description: "cannot find 'fooHelperFunc' in scope",
 // CHECK_SYSTEM_2: key.severity: source.diagnostic.severity.error,
-// CHECK_SYSTEM_2-NEXT: key.description: "use of unresolved identifier 'fooHelperSubFunc'",
+// CHECK_SYSTEM_2-NEXT: key.description: "cannot find 'fooHelperSubFunc' in scope",
 // CHECK_SYSTEM_2: key.severity: source.diagnostic.severity.error,
-// CHECK_SYSTEM_2-NEXT: key.description: "use of unresolved identifier 'fooHelperExplicitFunc'",
+// CHECK_SYSTEM_2-NEXT: key.description: "cannot find 'fooHelperExplicitFunc' in scope",
 
 // -----------------------------------------------------------------------------
 // Test that modifications for frameworks in '-F' are immidiately propagated
@@ -78,9 +78,9 @@ func test() {
 // CHECK_USER-LABEL: ## TWO
 // CHECK_USER-NOT: key.severity: 
 // CHECK_USER: key.severity: source.diagnostic.severity.error,
-// CHECK_USER-NEXT: key.description: "use of unresolved identifier 'fooFunc'",
+// CHECK_USER-NEXT: key.description: "cannot find 'fooFunc' in scope",
 // CHECK_USER: key.severity: source.diagnostic.severity.error,
-// CHECK_USER-NEXT: key.description: "use of unresolved identifier 'fooSubFunc'",
+// CHECK_USER-NEXT: key.description: "cannot find 'fooSubFunc' in scope",
 // CHECK_USER-NOT: key.severity: 
 
 // -----------------------------------------------------------------------------

--- a/test/SourceKit/Sema/sema_diag_after_edit_fixit.swift
+++ b/test/SourceKit/Sema/sema_diag_after_edit_fixit.swift
@@ -29,7 +29,7 @@ let a = 0; let b = 0 }; unresolved
 
 // CHECK:      key.line: 2,
 // CHECK-NEXT: key.column: 25,
-// CHECK:      key.description: "use of unresolved identifier 'unresolved'",
+// CHECK:      key.description: "cannot find 'unresolved' in scope",
 // CHECK:      key.ranges:
 // CHECK-NEXT: {
 // CHECK-NEXT:   key.offset: 37,
@@ -50,7 +50,7 @@ let a = 0; let b = 0 }; unresolved
 
 // CHECK:      key.line: 2,
 // CHECK-NEXT: key.column: 21,
-// CHECK:      key.description: "use of unresolved identifier 'unresolved'",
+// CHECK:      key.description: "cannot find 'unresolved' in scope",
 // CHECK:      key.ranges:
 // CHECK-NEXT: {
 // CHECK-NEXT:   key.offset: 33,

--- a/test/SourceKit/Sema/sema_symlink.swift.response
+++ b/test/SourceKit/Sema/sema_symlink.swift.response
@@ -12,7 +12,7 @@
     key.column: 16,
     key.filepath: real.swift,
     key.severity: source.diagnostic.severity.error,
-    key.description: "use of unresolved identifier 'goo'",
+    key.description: "cannot find 'goo' in scope",
     key.diagnostic_stage: source.diagnostic.stage.swift.sema,
     key.ranges: [
       {

--- a/test/SourceKit/SyntaxMapData/diags.swift.response
+++ b/test/SourceKit/SyntaxMapData/diags.swift.response
@@ -20,7 +20,7 @@
     key.column: 8,
     key.filepath: parse_error.swift,
     key.severity: source.diagnostic.severity.error,
-    key.description: "use of undeclared type 'Undeclared'",
+    key.description: "cannot find type 'Undeclared' in scope",
     key.diagnostic_stage: source.diagnostic.stage.swift.sema,
     key.ranges: [
       {
@@ -51,7 +51,7 @@
     key.column: 8,
     key.filepath: parse_error.swift,
     key.severity: source.diagnostic.severity.error,
-    key.description: "use of undeclared type 'Undeclared'",
+    key.description: "cannot find type 'Undeclared' in scope",
     key.diagnostic_stage: source.diagnostic.stage.swift.sema,
     key.ranges: [
       {

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -72,7 +72,7 @@ struct AutoclosureEscapeTest {
 // expected-error @+1 {{attribute can only be applied to types, not declarations}}
 func func10(@autoclosure(escaping _: () -> ()) { } // expected-error{{expected parameter name followed by ':'}}
 
-func func11(_: @autoclosure(escaping) @noescape () -> ()) { } // expected-error{{use of undeclared type 'escaping'}}
+func func11(_: @autoclosure(escaping) @noescape () -> ()) { } // expected-error{{cannot find type 'escaping' in scope}}
 // expected-error @-1 {{attribute can only be applied to types, not declarations}}
 // expected-error @-2 {{expected ',' separator}}
 // expected-error @-3 {{expected parameter name followed by ':'}}
@@ -115,7 +115,7 @@ let _ : AutoclosureFailableOf<Int> = .Success(42)
 let _ : (@autoclosure () -> ()) -> ()
 
 // escaping is the name of param type
-let _ : (@autoclosure(escaping) -> ()) -> ()  // expected-error {{use of undeclared type 'escaping'}}
+let _ : (@autoclosure(escaping) -> ()) -> ()  // expected-error {{cannot find type 'escaping' in scope}}
 
 // Migration
 // expected-error @+1 {{attribute can only be applied to types, not declarations}}

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -1653,9 +1653,9 @@ protocol infer_protocol5 : Protocol_ObjC1, Protocol_Class1 {
 
 class C {
   // Don't crash.
-  @objc func foo(x: Undeclared) {} // expected-error {{use of undeclared type 'Undeclared'}}
-  @IBAction func myAction(sender: Undeclared) {} // expected-error {{use of undeclared type 'Undeclared'}}
-  @IBSegueAction func myAction(coder: Undeclared, sender: Undeclared) -> Undeclared {fatalError()} // expected-error {{use of undeclared type 'Undeclared'}} expected-error {{use of undeclared type 'Undeclared'}} expected-error {{use of undeclared type 'Undeclared'}}
+  @objc func foo(x: Undeclared) {} // expected-error {{cannot find type 'Undeclared' in scope}}
+  @IBAction func myAction(sender: Undeclared) {} // expected-error {{cannot find type 'Undeclared' in scope}}
+  @IBSegueAction func myAction(coder: Undeclared, sender: Undeclared) -> Undeclared {fatalError()} // expected-error {{cannot find type 'Undeclared' in scope}} expected-error {{cannot find type 'Undeclared' in scope}} expected-error {{cannot find type 'Undeclared' in scope}}
 }
 
 //===---

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -26,9 +26,9 @@ class NonSub {}
 @_specialize(where T == Int)
 // CHECK: @_specialize(exported: false, kind: full, where T == S<Int>)
 @_specialize(where T == S<Int>)
-@_specialize(where T == Int, U == Int) // expected-error{{use of undeclared type 'U'}},
+@_specialize(where T == Int, U == Int) // expected-error{{cannot find type 'U' in scope}},
 // expected-error@-1{{Only one concrete type should be used in the same-type requirement in '_specialize' attribute}}
-@_specialize(where T == T1) // expected-error{{use of undeclared type 'T1'}}
+@_specialize(where T == T1) // expected-error{{cannot find type 'T1' in scope}}
 public func oneGenericParam<T>(_ t: T) -> T {
   return t
 }
@@ -51,7 +51,7 @@ class G<T> {
   @_specialize(where T == Int)
   @_specialize(where T == T) // expected-error{{Only concrete type same-type requirements are supported by '_specialize' attribute}}
   @_specialize(where T == S<T>) // expected-error{{Only concrete type same-type requirements are supported by '_specialize' attribute}}
-  @_specialize(where T == Int, U == Int) // expected-error{{use of undeclared type 'U'}}
+  @_specialize(where T == Int, U == Int) // expected-error{{cannot find type 'U' in scope}}
   // expected-error@-1{{Only one concrete type should be used in the same-type requirement in '_specialize' attribute}}
   func noGenericParams() {}
 
@@ -108,13 +108,13 @@ public func funcWithEmptySpecializeAttr<X: P, Y>(x: X, y: Y) {
 }
 
 
-@_specialize(where X:_Trivial(8), Y:_Trivial(32), Z == Int) // expected-error{{use of undeclared type 'Z'}}
+@_specialize(where X:_Trivial(8), Y:_Trivial(32), Z == Int) // expected-error{{cannot find type 'Z' in scope}}
 // expected-error@-1{{Only one concrete type should be used in the same-type requirement in '_specialize' attribute}}
 @_specialize(where X:_Trivial(8), Y:_Trivial(32, 4))
 @_specialize(where X == Int) // expected-error{{too few type parameters are specified in '_specialize' attribute (got 1, but expected 2)}} expected-error{{Missing constraint for 'Y' in '_specialize' attribute}}
 @_specialize(where Y:_Trivial(32)) // expected-error {{too few type parameters are specified in '_specialize' attribute (got 1, but expected 2)}} expected-error{{Missing constraint for 'X' in '_specialize' attribute}}
 @_specialize(where Y: P) // expected-error{{Only same-type and layout requirements are supported by '_specialize' attribute}} expected-error{{too few type parameters are specified in '_specialize' attribute (got 1, but expected 2)}} expected-error{{Missing constraint for 'X' in '_specialize' attribute}}
-@_specialize(where Y: MyClass) // expected-error{{use of undeclared type 'MyClass'}} expected-error{{too few type parameters are specified in '_specialize' attribute (got 1, but expected 2)}} expected-error{{Missing constraint for 'X' in '_specialize' attribute}}
+@_specialize(where Y: MyClass) // expected-error{{cannot find type 'MyClass' in scope}} expected-error{{too few type parameters are specified in '_specialize' attribute (got 1, but expected 2)}} expected-error{{Missing constraint for 'X' in '_specialize' attribute}}
 // expected-error@-1{{Only conformances to protocol types are supported by '_specialize' attribute}}
 @_specialize(where X:_Trivial(8), Y == Int)
 @_specialize(where X == Int, Y == Int)
@@ -122,7 +122,7 @@ public func funcWithEmptySpecializeAttr<X: P, Y>(x: X, y: Y) {
 // expected-warning@-1{{redundant same-type constraint 'X' == 'Int'}}
 // expected-note@-2{{same-type constraint 'X' == 'Int' written here}}
 @_specialize(where Y:_Trivial(32), X == Float)
-@_specialize(where X1 == Int, Y1 == Int) // expected-error{{use of undeclared type 'X1'}} expected-error{{use of undeclared type 'Y1'}} expected-error{{too few type parameters are specified in '_specialize' attribute (got 0, but expected 2)}} expected-error{{Missing constraint for 'X' in '_specialize' attribute}} expected-error{{Missing constraint for 'Y' in '_specialize' attribute}}
+@_specialize(where X1 == Int, Y1 == Int) // expected-error{{cannot find type 'X1' in scope}} expected-error{{cannot find type 'Y1' in scope}} expected-error{{too few type parameters are specified in '_specialize' attribute (got 0, but expected 2)}} expected-error{{Missing constraint for 'X' in '_specialize' attribute}} expected-error{{Missing constraint for 'Y' in '_specialize' attribute}}
 // expected-error@-1 2{{Only one concrete type should be used in the same-type requirement in '_specialize' attribute}}
 public func funcWithTwoGenericParameters<X, Y>(x: X, y: Y) {
 }
@@ -148,7 +148,7 @@ public func funcWithTwoGenericParameters<X, Y>(x: X, y: Y) {
 @_specialize(kind: partial, exported: true, where X == Int, Y == Int) // expected-warning{{'exported: true' has no effect in '_specialize' attribute}}
 @_specialize(kind: partial, kind: partial, where X == Int, Y == Int) // expected-error{{parameter 'kind' was already defined in '_specialize' attribute}}
 
-@_specialize(where X == Int, Y == Int, exported: true, kind: partial) // expected-error{{use of undeclared type 'exported'}} expected-error{{use of undeclared type 'kind'}} expected-error{{use of undeclared type 'partial'}} expected-error{{expected type}}
+@_specialize(where X == Int, Y == Int, exported: true, kind: partial) // expected-error{{cannot find type 'exported' in scope}} expected-error{{cannot find type 'kind' in scope}} expected-error{{cannot find type 'partial' in scope}} expected-error{{expected type}}
 // expected-error@-1 2{{Only conformances to protocol types are supported by '_specialize' attribute}}
 public func anotherFuncWithTwoGenericParameters<X: P, Y>(x: X, y: Y) {
 }

--- a/test/attr/dynamicReplacement.swift
+++ b/test/attr/dynamicReplacement.swift
@@ -50,7 +50,7 @@ extension K {
   func replacement_finalFunction() {}
 }
 
-extension undeclared { // expected-error{{use of undeclared type 'undeclared'}}
+extension undeclared { // expected-error{{cannot find type 'undeclared' in scope}}
   @_dynamicReplacement(for: property)
   var replacement_property: Int { return 2 }
 

--- a/test/attr/open.swift
+++ b/test/attr/open.swift
@@ -35,7 +35,7 @@ class ExternalSuperClassesMayBeOpen : ExternalOpenClass {}
 class NestedClassesOfPublicTypesAreOpen : ExternalStruct.OpenClass {}
 
 // This one is hard to diagnose.
-class NestedClassesOfInternalTypesAreNotOpen : ExternalInternalStruct.OpenClass {} // expected-error {{use of undeclared type 'ExternalInternalStruct'}}
+class NestedClassesOfInternalTypesAreNotOpen : ExternalInternalStruct.OpenClass {} // expected-error {{cannot find type 'ExternalInternalStruct' in scope}}
 
 class NestedPublicClassesOfOpenClassesAreNotOpen : ExternalOpenClass.PublicClass {} // expected-error {{cannot inherit from non-open class 'ExternalOpenClass.PublicClass' outside of its defining module}}
 

--- a/test/attr/typeEraser.swift
+++ b/test/attr/typeEraser.swift
@@ -40,7 +40,7 @@ func notAProtocol() {}
 
 // MARK: - Type eraser must be a concrete nominal type
 
-@_typeEraser(Undeclared) // expected-error {{use of undeclared type 'Undeclared'}}
+@_typeEraser(Undeclared) // expected-error {{cannot find type 'Undeclared' in scope}}
 protocol B1 {}
 
 @_typeEraser((Int, Int)) // expected-error {{type eraser must be a class, struct, or enum}}

--- a/test/decl/circularity.swift
+++ b/test/decl/circularity.swift
@@ -81,7 +81,7 @@ open class G1<A> {
 
 class C3: G1<A>, P {
     // expected-error@-1 {{type 'C3' does not conform to protocol 'P'}}
-    // expected-error@-2 {{use of undeclared type 'A'}}
+    // expected-error@-2 {{cannot find type 'A' in scope}}
     override func run(a: A) {}
     // expected-error@-1 {{method does not override any method from its superclass}}
 }

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -1,25 +1,25 @@
 // RUN: %target-typecheck-verify-swift
 
-extension extension_for_invalid_type_1 { // expected-error {{use of undeclared type 'extension_for_invalid_type_1'}}
+extension extension_for_invalid_type_1 { // expected-error {{cannot find type 'extension_for_invalid_type_1' in scope}}
   func f() { }
 }
-extension extension_for_invalid_type_2 { // expected-error {{use of undeclared type 'extension_for_invalid_type_2'}}
+extension extension_for_invalid_type_2 { // expected-error {{cannot find type 'extension_for_invalid_type_2' in scope}}
   static func f() { }
 }
-extension extension_for_invalid_type_3 { // expected-error {{use of undeclared type 'extension_for_invalid_type_3'}}
+extension extension_for_invalid_type_3 { // expected-error {{cannot find type 'extension_for_invalid_type_3' in scope}}
   init() {}
 }
-extension extension_for_invalid_type_4 { // expected-error {{use of undeclared type 'extension_for_invalid_type_4'}}
+extension extension_for_invalid_type_4 { // expected-error {{cannot find type 'extension_for_invalid_type_4' in scope}}
   deinit {} // expected-error {{deinitializers may only be declared within a class}}
 }
-extension extension_for_invalid_type_5 { // expected-error {{use of undeclared type 'extension_for_invalid_type_5'}}
+extension extension_for_invalid_type_5 { // expected-error {{cannot find type 'extension_for_invalid_type_5' in scope}}
   typealias X = Int
 }
 
 //===--- Test that we only allow extensions at file scope.
 struct Foo { }
 
-extension NestingTest1 { // expected-error {{use of undeclared type 'NestingTest1'}}
+extension NestingTest1 { // expected-error {{cannot find type 'NestingTest1' in scope}}
   extension Foo {} // expected-error {{declaration is only valid at file scope}}
 }
 struct NestingTest2 {

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -174,8 +174,8 @@ extension S5 : P4 {}
 // rdar://problem/21607421
 public typealias Array2 = Array
 extension Array2 where QQQ : VVV {}
-// expected-error@-1 {{use of undeclared type 'QQQ'}}
-// expected-error@-2 {{use of undeclared type 'VVV'}}
+// expected-error@-1 {{cannot find type 'QQQ' in scope}}
+// expected-error@-2 {{cannot find type 'VVV' in scope}}
 
 // https://bugs.swift.org/browse/SR-9009
 func foo() {

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -270,7 +270,7 @@ protocol ExtendedProtocol {
 }
 
 extension ExtendedProtocol where Self : DerivedWithAlias {
-  func f0(x: T) {} // expected-error {{use of undeclared type 'T'}}
+  func f0(x: T) {} // expected-error {{cannot find type 'T' in scope}}
 
   func f1(x: ConcreteAlias) {
     let _: Int = x

--- a/test/decl/func/constructor.swift
+++ b/test/decl/func/constructor.swift
@@ -85,7 +85,7 @@ B() // okay // expected-warning{{unused}}
 C() // expected-error{{missing argument for parameter 'd'}}
 
 struct E {
-  init(x : Wonka) { } // expected-error{{use of undeclared type 'Wonka'}}
+  init(x : Wonka) { } // expected-error{{cannot find type 'Wonka' in scope}}
 }
 
 var e : E
@@ -101,7 +101,7 @@ class ArgParamSep {
 // rdar://14082378
 
 struct NoCrash1a {
-  init(_: NoCrash1b) {} // expected-error {{use of undeclared type 'NoCrash1b'}}
+  init(_: NoCrash1b) {} // expected-error {{cannot find type 'NoCrash1b' in scope}}
 }
 var noCrash1c : NoCrash1a
 

--- a/test/decl/func/default-values.swift
+++ b/test/decl/func/default-values.swift
@@ -20,7 +20,7 @@ func tupleTypes() {
   typealias ta1 = (a : Int = ()) // expected-error{{default argument not permitted in a tuple type}}{{28-32=}}
   // expected-error @-1{{cannot create a single-element tuple with an element label}}{{20-24=}}
   var c1 : (a : Int, b : Int, c : Int = 3, // expected-error{{default argument not permitted in a tuple type}}{{39-42=}}
-            d = 4) = (1, 2, 3, 4) // expected-error{{default argument not permitted in a tuple type}}{{15-18=}} expected-error{{use of undeclared type 'd'}}
+            d = 4) = (1, 2, 3, 4) // expected-error{{default argument not permitted in a tuple type}}{{15-18=}} expected-error{{cannot find type 'd' in scope}}
 }
 
 func returnWithDefault() -> (a: Int, b: Int = 42) { // expected-error{{default argument not permitted in a tuple type}} {{45-49=}}
@@ -61,7 +61,7 @@ vi.g(i: 12)
 vi.g(f:12.5)
 
 // <rdar://problem/14564964> crash on invalid
-func foo(_ x: WonkaWibble = 17) { } // expected-error{{use of undeclared type 'WonkaWibble'}}
+func foo(_ x: WonkaWibble = 17) { } // expected-error{{cannot find type 'WonkaWibble' in scope}}
 
 // Default arguments for initializers.
 class SomeClass2 { 
@@ -73,7 +73,7 @@ class SomeDerivedClass2 : SomeClass2 {
   }
 }
 
-func shouldNotCrash(_ a : UndefinedType, bar b : Bool = true) { // expected-error {{use of undeclared type 'UndefinedType'}}
+func shouldNotCrash(_ a : UndefinedType, bar b : Bool = true) { // expected-error {{cannot find type 'UndefinedType' in scope}}
 }
 
 // <rdar://problem/20749423> Compiler crashed while building simple subclass

--- a/test/decl/func/functions.swift
+++ b/test/decl/func/functions.swift
@@ -78,20 +78,20 @@ func parseError1b(_ a: // expected-error {{expected parameter type following ':'
 
 func parseError2(_ a: Int, b: ) {} // expected-error {{expected parameter type following ':'}} {{30-30= <#type#>}}
 
-func parseError3(_ a: unknown_type, b: ) {} // expected-error {{use of undeclared type 'unknown_type'}}  expected-error {{expected parameter type following ':'}} {{39-39= <#type#>}}
+func parseError3(_ a: unknown_type, b: ) {} // expected-error {{cannot find type 'unknown_type' in scope}}  expected-error {{expected parameter type following ':'}} {{39-39= <#type#>}}
 
 func parseError4(_ a: , b: ) {} // expected-error 2{{expected parameter type following ':'}}
 
-func parseError5(_ a: b: ) {} // expected-error {{use of undeclared type 'b'}}  expected-error {{expected ',' separator}} {{24-24=,}} expected-error {{expected parameter name followed by ':'}}
+func parseError5(_ a: b: ) {} // expected-error {{cannot find type 'b' in scope}}  expected-error {{expected ',' separator}} {{24-24=,}} expected-error {{expected parameter name followed by ':'}}
 
-func parseError6(_ a: unknown_type, b: ) {} // expected-error {{use of undeclared type 'unknown_type'}}  expected-error {{expected parameter type following ':'}} {{39-39= <#type#>}}
+func parseError6(_ a: unknown_type, b: ) {} // expected-error {{cannot find type 'unknown_type' in scope}}  expected-error {{expected parameter type following ':'}} {{39-39= <#type#>}}
 
-func parseError7(_ a: Int, goo b: unknown_type) {} // expected-error {{use of undeclared type 'unknown_type'}}
+func parseError7(_ a: Int, goo b: unknown_type) {} // expected-error {{cannot find type 'unknown_type' in scope}}
 
-public func foo(_ a: Bool = true) -> (b: Bar, c: Bar) {} // expected-error 2{{use of undeclared type 'Bar'}}
+public func foo(_ a: Bool = true) -> (b: Bar, c: Bar) {} // expected-error 2{{cannot find type 'Bar' in scope}}
 
 func parenPatternInArg((a): Int) -> Int { // expected-error {{expected parameter name followed by ':'}}
-  return a  // expected-error {{use of unresolved identifier 'a'}}
+  return a  // expected-error {{cannot find 'a' in scope}}
 }
 parenPatternInArg(0)  // expected-error {{argument passed to call that takes no arguments}}
 
@@ -104,12 +104,12 @@ _ = nullaryClosure(0)
 // parameter labels, and they are thus not in scope in the body of the function.
 // expected-error@+1{{unnamed parameters must be written}} {{27-27=_: }}
 func destructureArgument( (result: Int, error: Bool) ) -> Int {
-  return result  // expected-error {{use of unresolved identifier 'result'}}
+  return result  // expected-error {{cannot find 'result' in scope}}
 }
 
 // The former is the same as this:
 func destructureArgument2(_ a: (result: Int, error: Bool) ) -> Int {
-  return result  // expected-error {{use of unresolved identifier 'result'}}
+  return result  // expected-error {{cannot find 'result' in scope}}
 }
 
 
@@ -168,7 +168,7 @@ func testCurryFixits() {
 
 // Bogus diagnostic talking about a 'var' where there is none
 func invalidInOutParam(x: inout XYZ) {}
-// expected-error@-1{{use of undeclared type 'XYZ'}}
+// expected-error@-1{{cannot find type 'XYZ' in scope}}
 
 // Parens around the 'inout'
 func parentheticalInout(_ x: ((inout Int))) {}

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -212,7 +212,7 @@ postfix func☃⃠(a : Int) -> Int { return a }
 
 _ = n☃⃠ ☃⃠ n   // Ok.
 _ = n ☃⃠ ☃⃠n   // Ok.
-_ = n ☃⃠☃⃠ n   // expected-error {{use of unresolved operator '☃⃠☃⃠'}}
+_ = n ☃⃠☃⃠ n   // expected-error {{cannot find operator '☃⃠☃⃠' in scope}}
 _ = n☃⃠☃⃠n     // expected-error {{ambiguous missing whitespace between unary and binary operators}}
 // expected-note @-1 {{could be binary '☃⃠' and prefix '☃⃠'}} {{12-12= }} {{18-18= }}
 // expected-note @-2 {{could be postfix '☃⃠' and binary '☃⃠'}} {{6-6= }} {{12-12= }}

--- a/test/decl/func/operator_suggestions.swift
+++ b/test/decl/func/operator_suggestions.swift
@@ -1,23 +1,23 @@
 // RUN: %target-typecheck-verify-swift
 
 _ = 1..<1 // OK
-_ = 1…1 // expected-error {{use of unresolved operator '…'; did you mean '...'?}} {{6-9=...}}
-_ = 1….1 // expected-error {{use of unresolved operator '…'; did you mean '...'?}} {{6-9=...}}
-_ = 1.…1 // expected-error {{use of unresolved operator '.…'; did you mean '...'?}} {{6-10=...}}
-_ = 1…<1 // expected-error {{use of unresolved operator '…<'; did you mean '..<'?}} {{6-10=..<}}
-_ = 1..1 // expected-error {{use of unresolved operator '..'; did you mean '...'?}} {{6-8=...}}
-_ = 1....1 // expected-error {{use of unresolved operator '....'; did you mean '...'?}} {{6-10=...}}
-_ = 1...<1 // expected-error {{use of unresolved operator '...<'; did you mean '..<'?}} {{6-10=..<}}
-_ = 1....<1 // expected-error {{use of unresolved operator '....<'; did you mean '..<'?}} {{6-11=..<}}
+_ = 1…1 // expected-error {{cannot find operator '…' in scope; did you mean '...'?}} {{6-9=...}}
+_ = 1….1 // expected-error {{cannot find operator '…' in scope; did you mean '...'?}} {{6-9=...}}
+_ = 1.…1 // expected-error {{cannot find operator '.…' in scope; did you mean '...'?}} {{6-10=...}}
+_ = 1…<1 // expected-error {{cannot find operator '…<' in scope; did you mean '..<'?}} {{6-10=..<}}
+_ = 1..1 // expected-error {{cannot find operator '..' in scope; did you mean '...'?}} {{6-8=...}}
+_ = 1....1 // expected-error {{cannot find operator '....' in scope; did you mean '...'?}} {{6-10=...}}
+_ = 1...<1 // expected-error {{cannot find operator '...<' in scope; did you mean '..<'?}} {{6-10=..<}}
+_ = 1....<1 // expected-error {{cannot find operator '....<' in scope; did you mean '..<'?}} {{6-11=..<}}
 
 var i = 1
-i++ // expected-error {{use of unresolved operator '++'; did you mean '+= 1'?}}
-++i // expected-error {{use of unresolved operator '++'; did you mean '+= 1'?}}
-i-- // expected-error {{use of unresolved operator '--'; did you mean '-= 1'?}}
---i // expected-error {{use of unresolved operator '--'; did you mean '-= 1'?}}
+i++ // expected-error {{cannot find operator '++' in scope; did you mean '+= 1'?}}
+++i // expected-error {{cannot find operator '++' in scope; did you mean '+= 1'?}}
+i-- // expected-error {{cannot find operator '--' in scope; did you mean '-= 1'?}}
+--i // expected-error {{cannot find operator '--' in scope; did you mean '-= 1'?}}
 
 var d = 1.0
-d++ // expected-error {{use of unresolved operator '++'; did you mean '+= 1'?}}
-++d // expected-error {{use of unresolved operator '++'; did you mean '+= 1'?}}
-d-- // expected-error {{use of unresolved operator '--'; did you mean '-= 1'?}}
---d // expected-error {{use of unresolved operator '--'; did you mean '-= 1'?}}
+d++ // expected-error {{cannot find operator '++' in scope; did you mean '+= 1'?}}
+++d // expected-error {{cannot find operator '++' in scope; did you mean '+= 1'?}}
+d-- // expected-error {{cannot find operator '--' in scope; did you mean '-= 1'?}}
+--d // expected-error {{cannot find operator '--' in scope; did you mean '-= 1'?}}

--- a/test/decl/func/rethrows.swift
+++ b/test/decl/func/rethrows.swift
@@ -9,7 +9,7 @@ let r3 : Optional<() rethrows -> ()> = nil // expected-error {{only function dec
 
 func f1(_ f: () throws -> ()) rethrows { try f() }
 func f2(_ f: () -> ()) rethrows { f() } // expected-error {{'rethrows' function must take a throwing function argument}}
-func f3(_ f: UndeclaredFunctionType) rethrows { f() } // expected-error {{use of undeclared type 'UndeclaredFunctionType'}}
+func f3(_ f: UndeclaredFunctionType) rethrows { f() } // expected-error {{cannot find type 'UndeclaredFunctionType' in scope}}
 
 /** Protocol conformance checking ********************************************/
 

--- a/test/decl/func/vararg.swift
+++ b/test/decl/func/vararg.swift
@@ -23,8 +23,8 @@ func inoutVariadic(_ i: inout Int...) {  // expected-error {{'inout' must not be
 }
 
 // rdar://19722429
-func invalidVariadic(_ e: NonExistentType) { // expected-error {{use of undeclared type 'NonExistentType'}}
-  { (e: ExtraCrispy...) in }() // expected-error {{use of undeclared type 'ExtraCrispy'}}
+func invalidVariadic(_ e: NonExistentType) { // expected-error {{cannot find type 'NonExistentType' in scope}}
+  { (e: ExtraCrispy...) in }() // expected-error {{cannot find type 'ExtraCrispy' in scope}}
 }
 
 func twoVariadics(_ a: Int..., b: Int...) { } // expected-error{{only a single variadic parameter '...' is permitted}} {{38-41=}}

--- a/test/decl/inherit/inherit.swift
+++ b/test/decl/inherit/inherit.swift
@@ -57,9 +57,9 @@ class GenericBase<T> {}
 class GenericSub<T> : GenericBase<T> {} // okay
 
 class InheritGenericParam<T> : T {} // expected-error {{inheritance from non-protocol, non-class type 'T'}}
-class InheritBody : T { // expected-error {{use of undeclared type 'T'}}
+class InheritBody : T { // expected-error {{cannot find type 'T' in scope}}
   typealias T = A
 }
-class InheritBodyBad : fn { // expected-error {{use of undeclared type 'fn'}}
+class InheritBodyBad : fn { // expected-error {{cannot find type 'fn' in scope}}
   func fn() {}
 }

--- a/test/decl/inherit/override.swift
+++ b/test/decl/inherit/override.swift
@@ -62,11 +62,11 @@ func callOverridden(_ b: B) {
 
 @objc
 class Base {
-  func meth(_ x: Undeclared) {} // expected-error {{use of undeclared type 'Undeclared'}}
+  func meth(_ x: Undeclared) {} // expected-error {{cannot find type 'Undeclared' in scope}}
 }
 @objc
 class Sub : Base {
-  func meth(_ x: Undeclared) {} // expected-error {{use of undeclared type 'Undeclared'}}
+  func meth(_ x: Undeclared) {} // expected-error {{cannot find type 'Undeclared' in scope}}
 }
 
 // Objective-C method overriding

--- a/test/decl/init/basic_init.swift
+++ b/test/decl/init/basic_init.swift
@@ -1,11 +1,11 @@
 // RUN: %target-typecheck-verify-swift -enable-objc-interop -disable-objc-attr-requires-foundation-module
 
 class Foo {
-  func bar(_: bar) {} // expected-error{{use of undeclared type 'bar'}}
+  func bar(_: bar) {} // expected-error{{cannot find type 'bar' in scope}}
 }
 
 class C {
-	var triangle : triangle  // expected-error{{use of undeclared type 'triangle'}}
+	var triangle : triangle  // expected-error{{cannot find type 'triangle' in scope}}
 
 	init() {}
 }

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -7,7 +7,7 @@ struct OuterGeneric<D> {
   protocol InnerProtocol { // expected-error{{protocol 'InnerProtocol' cannot be nested inside another declaration}}
     associatedtype Rooster
     func flip(_ r: Rooster)
-    func flop(_ t: D) // expected-error{{use of undeclared type 'D'}}
+    func flop(_ t: D) // expected-error{{cannot find type 'D' in scope}}
   }
 }
 
@@ -15,7 +15,7 @@ class OuterGenericClass<T> {
   protocol InnerProtocol { // expected-error{{protocol 'InnerProtocol' cannot be nested inside another declaration}}
     associatedtype Rooster
     func flip(_ r: Rooster)
-    func flop(_ t: T) // expected-error{{use of undeclared type 'T'}}
+    func flop(_ t: T) // expected-error{{cannot find type 'T' in scope}}
   }
 }
 
@@ -24,7 +24,7 @@ protocol OuterProtocol {
   protocol InnerProtocol { // expected-error{{protocol 'InnerProtocol' cannot be nested inside another declaration}}
     associatedtype Rooster
     func flip(_ r: Rooster)
-    func flop(_ h: Hen) // expected-error{{use of undeclared type 'Hen'}}
+    func flop(_ h: Hen) // expected-error{{cannot find type 'Hen' in scope}}
   }
 }
 
@@ -39,11 +39,11 @@ protocol Racoon {
   associatedtype Stripes
   class Claw<T> { // expected-error{{type 'Claw' cannot be nested in protocol 'Racoon'}}
     func mangle(_ s: Stripes) {}
-    // expected-error@-1 {{use of undeclared type 'Stripes'}}
+    // expected-error@-1 {{cannot find type 'Stripes' in scope}}
   }
   struct Fang<T> { // expected-error{{type 'Fang' cannot be nested in protocol 'Racoon'}}
     func gnaw(_ s: Stripes) {}
-    // expected-error@-1 {{use of undeclared type 'Stripes'}}
+    // expected-error@-1 {{cannot find type 'Stripes' in scope}}
   }
   enum Fur { // expected-error{{type 'Fur' cannot be nested in protocol 'Racoon'}}
     case Stripes

--- a/test/decl/protocol/protocol_with_superclass.swift
+++ b/test/decl/protocol/protocol_with_superclass.swift
@@ -98,13 +98,13 @@ class BadConformingClass1 : ProtoRefinesClass {
   // expected-error@-1 {{'ProtoRefinesClass' requires that 'BadConformingClass1' inherit from 'Generic<Int>'}}
   // expected-note@-2 {{requirement specified as 'Self' : 'Generic<Int>' [with Self = BadConformingClass1]}}
   func requirementUsesClassTypes(_: ConcreteAlias, _: GenericAlias) {
-    // expected-error@-1 {{use of undeclared type 'ConcreteAlias'}}
-    // expected-error@-2 {{use of undeclared type 'GenericAlias'}}
+    // expected-error@-1 {{cannot find type 'ConcreteAlias' in scope}}
+    // expected-error@-2 {{cannot find type 'GenericAlias' in scope}}
 
     _ = ConcreteAlias.self
-    // expected-error@-1 {{use of unresolved identifier 'ConcreteAlias'}}
+    // expected-error@-1 {{cannot find 'ConcreteAlias' in scope}}
     _ = GenericAlias.self
-    // expected-error@-1 {{use of unresolved identifier 'GenericAlias'}}
+    // expected-error@-1 {{cannot find 'GenericAlias' in scope}}
   }
 }
 

--- a/test/decl/protocol/protocol_with_superclass_where_clause.swift
+++ b/test/decl/protocol/protocol_with_superclass_where_clause.swift
@@ -99,13 +99,13 @@ class BadConformingClass1 : ProtoRefinesClass {
   // expected-error@-1 {{'ProtoRefinesClass' requires that 'BadConformingClass1' inherit from 'Generic<Int>'}}
   // expected-note@-2 {{requirement specified as 'Self' : 'Generic<Int>' [with Self = BadConformingClass1]}}
   func requirementUsesClassTypes(_: ConcreteAlias, _: GenericAlias) {
-    // expected-error@-1 {{use of undeclared type 'ConcreteAlias'}}
-    // expected-error@-2 {{use of undeclared type 'GenericAlias'}}
+    // expected-error@-1 {{cannot find type 'ConcreteAlias' in scope}}
+    // expected-error@-2 {{cannot find type 'GenericAlias' in scope}}
 
     _ = ConcreteAlias.self
-    // expected-error@-1 {{use of unresolved identifier 'ConcreteAlias'}}
+    // expected-error@-1 {{cannot find 'ConcreteAlias' in scope}}
     _ = GenericAlias.self
-    // expected-error@-1 {{use of unresolved identifier 'GenericAlias'}}
+    // expected-error@-1 {{cannot find 'GenericAlias' in scope}}
   }
 }
 

--- a/test/decl/protocol/req/func.swift
+++ b/test/decl/protocol/req/func.swift
@@ -191,7 +191,7 @@ protocol P6 {
   func bar(x: Int) // expected-note{{protocol requires function 'bar(x:)' with type '(Int) -> ()'}}
 }
 struct X6 : P6 { // expected-error{{type 'X6' does not conform to protocol 'P6'}}
-  func foo(_ x: Missing) { } // expected-error{{use of undeclared type 'Missing'}}
+  func foo(_ x: Missing) { } // expected-error{{cannot find type 'Missing' in scope}}
   func bar() { }
 }
 
@@ -219,7 +219,7 @@ struct X6Ownership : P6Ownership { // expected-error{{type 'X6Ownership' does no
 }
 
 protocol P7 {
-  func foo(_ x: Blarg) // expected-error{{use of undeclared type 'Blarg'}}
+  func foo(_ x: Blarg) // expected-error{{cannot find type 'Blarg' in scope}}
 }
 
 struct X7 : P7 { }

--- a/test/decl/protocol/special/coding/class_codable_codingkeys_typealias.swift
+++ b/test/decl/protocol/special/coding/class_codable_codingkeys_typealias.swift
@@ -30,7 +30,7 @@ let _ = SimpleClass.CodingKeys.self // expected-error {{'CodingKeys' is inaccess
 // nominal type should produce errors.
 struct ClassWithUndecredCodingKeys : Codable { // expected-error {{type 'ClassWithUndecredCodingKeys' does not conform to protocol 'Decodable'}}
   // expected-error@-1 {{type 'ClassWithUndecredCodingKeys' does not conform to protocol 'Encodable'}}
-  private typealias CodingKeys = NonExistentType // expected-error {{use of undeclared type 'NonExistentType'}}
+  private typealias CodingKeys = NonExistentType // expected-error {{cannot find type 'NonExistentType' in scope}}
   // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey}}
   // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey}}
 }

--- a/test/decl/protocol/special/coding/iuo_crash.swift
+++ b/test/decl/protocol/special/coding/iuo_crash.swift
@@ -4,7 +4,7 @@
 // ill-formed types.
 // rdar://problem/60985179
 struct X: Codable {  // expected-error 2{{type 'X' does not conform to protocol}}
-  var c: Undefined! // expected-error{{use of undeclared type 'Undefined'}}
+  var c: Undefined! // expected-error{{cannot find type 'Undefined' in scope}}
   // expected-note @-1{{does not conform to}}
   // expected-note @-2{{does not conform to}}
 }

--- a/test/decl/protocol/special/coding/struct_codable_codingkeys_typealias.swift
+++ b/test/decl/protocol/special/coding/struct_codable_codingkeys_typealias.swift
@@ -30,7 +30,7 @@ let _ = SimpleStruct.CodingKeys.self // expected-error {{'CodingKeys' is inacces
 // nominal type should produce errors.
 struct StructWithUndeclaredCodingKeys : Codable { // expected-error {{type 'StructWithUndeclaredCodingKeys' does not conform to protocol 'Decodable'}}
   // expected-error@-1 {{type 'StructWithUndeclaredCodingKeys' does not conform to protocol 'Encodable'}}
-  private typealias CodingKeys = NonExistentType // expected-error {{use of undeclared type 'NonExistentType'}}
+  private typealias CodingKeys = NonExistentType // expected-error {{cannot find type 'NonExistentType' in scope}}
   // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey}}
   // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey}}
 }

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -103,14 +103,14 @@ struct Y1 {
 }
 
 struct Y2 {
-  subscript(idx: Int) -> TypoType { // expected-error {{use of undeclared type 'TypoType'}}
+  subscript(idx: Int) -> TypoType { // expected-error {{cannot find type 'TypoType' in scope}}
     get { repeat {} while true }
     set {}
   }
 }
 
 class Y3 {
-  subscript(idx: Int) -> TypoType { // expected-error {{use of undeclared type 'TypoType'}}
+  subscript(idx: Int) -> TypoType { // expected-error {{cannot find type 'TypoType' in scope}}
     get { repeat {} while true }
     set {}
   }
@@ -420,13 +420,13 @@ func testSubscript1(_ s2 : SubscriptTest2) {
 
 class Foo {
     subscript(key: String) -> String { // expected-note {{'subscript(_:)' previously declared here}}
-        get { a } // expected-error {{use of unresolved identifier 'a'}}
-        set { b } // expected-error {{use of unresolved identifier 'b'}}
+        get { a } // expected-error {{cannot find 'a' in scope}}
+        set { b } // expected-error {{cannot find 'b' in scope}}
     }
     
     subscript(key: String) -> String { // expected-error {{invalid redeclaration of 'subscript(_:)'}}
-        get { _ = 0; a } // expected-error {{use of unresolved identifier 'a'}}
-        set { b } // expected-error {{use of unresolved identifier 'b'}}
+        get { _ = 0; a } // expected-error {{cannot find 'a' in scope}}
+        set { b } // expected-error {{cannot find 'b' in scope}}
     }
 }
 

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -303,7 +303,7 @@ extension A {}
 
 extension A<T> {}  // expected-error {{generic type 'A' specialized with too few type parameters (got 1, but expected 2)}}
 extension A<Float,Int> {}  // expected-error {{constrained extension must be declared on the unspecialized generic type 'MyType' with constraints specified by a 'where' clause}}
-extension C<T> {}  // expected-error {{use of undeclared type 'T'}}
+extension C<T> {}  // expected-error {{cannot find type 'T' in scope}}
 extension C<Int> {}  // expected-error {{constrained extension must be declared on the unspecialized generic type 'MyType' with constraints specified by a 'where' clause}}
 
 

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -337,9 +337,9 @@ var extraTokensInAccessorBlock7: X { // expected-error{{non-member observing pro
 }
 
 var extraTokensInAccessorBlock8: X {
-  foo // expected-error {{use of unresolved identifier 'foo'}}
-  get {} // expected-error{{use of unresolved identifier 'get'}}
-  set {} // expected-error{{use of unresolved identifier 'set'}}
+  foo // expected-error {{cannot find 'foo' in scope}}
+  get {} // expected-error{{cannot find 'get' in scope}}
+  set {} // expected-error{{cannot find 'set' in scope}}
 }
 
 var extraTokensInAccessorBlock9: Int {

--- a/test/decl/var/static_var.swift
+++ b/test/decl/var/static_var.swift
@@ -264,7 +264,7 @@ public struct Foo { // expected-note {{to match this opening '{'}}}
   public static let S { _ = 0; a // expected-error{{computed property must have an explicit type}} {{22-22=: <# Type #>}}
     // expected-error@-1{{type annotation missing in pattern}}
     // expected-error@-2{{'let' declarations cannot be computed properties}} {{17-20=var}}
-    // expected-error@-3{{use of unresolved identifier 'a'}}
+    // expected-error@-3{{cannot find 'a' in scope}}
 }
 
 // expected-error@+1 {{expected '}' in struct}}

--- a/test/decl/var/variables.swift
+++ b/test/decl/var/variables.swift
@@ -31,7 +31,7 @@ var (paren) = 0
 var paren2: Int = paren
 
 struct Broken {
-  var b : Bool = True // expected-error{{use of unresolved identifier 'True'}}
+  var b : Bool = True // expected-error{{cannot find 'True' in scope}}
 }
 
 // rdar://16252090 - Warning when inferring empty tuple type for declarations

--- a/test/diagnostics/verifier.swift
+++ b/test/diagnostics/verifier.swift
@@ -25,7 +25,7 @@ let a: Bool = "hello, world!" as Any
 
 // Unexpected error
 _ = foo()
-// CHECK: unexpected error produced: use of unresolved identifier 'foo'
+// CHECK: unexpected error produced: cannot find 'foo' in scope
 
 func b() {
   let c = 2

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -442,13 +442,13 @@ class r22344208 {
   }
 }
 
-var f = { (s: Undeclared) -> Int in 0 } // expected-error {{use of undeclared type 'Undeclared'}}
+var f = { (s: Undeclared) -> Int in 0 } // expected-error {{cannot find type 'Undeclared' in scope}}
 
 // <rdar://problem/21375863> Swift compiler crashes when using closure, declared to return illegal type.
 func r21375863() {
   var width = 0
   var height = 0
-  var bufs: [[UInt8]] = (0..<4).map { _ -> [asdf] in  // expected-error {{use of undeclared type 'asdf'}}
+  var bufs: [[UInt8]] = (0..<4).map { _ -> [asdf] in  // expected-error {{cannot find type 'asdf' in scope}}
     [UInt8](repeating: 0, count: width*height)
   }
 }

--- a/test/expr/closure/inference.swift
+++ b/test/expr/closure/inference.swift
@@ -37,7 +37,7 @@ var nestedClosuresWithBrokenInference = { f: Int in {} }
     // expected-error@-1 {{closure expression is unused}} expected-note@-1 {{did you mean to use a 'do' statement?}} {{53-53=do }}
     // expected-error@-2 {{consecutive statements on a line must be separated by ';'}} {{44-44=;}}
     // expected-error@-3 {{expected expression}}
-    // expected-error@-4 {{use of unresolved identifier 'f'}}
+    // expected-error@-4 {{cannot find 'f' in scope}}
 
 // SR-11540
 

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -162,7 +162,7 @@ func errorRecovery() {
 }
 
 func acceptsInt(_ x: Int) {}
-acceptsInt(unknown_var) // expected-error {{use of unresolved identifier 'unknown_var'}}
+acceptsInt(unknown_var) // expected-error {{cannot find 'unknown_var' in scope}}
 
 
 
@@ -173,7 +173,7 @@ var test1d = { { { 42 } } }
 
 func test2(_ a: Int, b: Int) -> (c: Int) { // expected-error{{cannot create a single-element tuple with an element label}} {{34-37=}} expected-note {{did you mean 'a'?}} expected-note {{did you mean 'b'?}}
  _ = a+b
- a+b+c // expected-error{{use of unresolved identifier 'c'}}
+ a+b+c // expected-error{{cannot find 'c' in scope}}
  return a+b
 }
 

--- a/test/expr/postfix/dot/init_ref_delegation.swift
+++ b/test/expr/postfix/dot/init_ref_delegation.swift
@@ -243,7 +243,7 @@ func init_tests() {
   var cs2a = C(x: 0)
   var cs3a = C()
 
-  var y = x.init() // expected-error{{use of unresolved identifier 'x'}}
+  var y = x.init() // expected-error{{cannot find 'x' in scope}}
 }
 
 protocol P {

--- a/test/expr/primary/keypath/keypath-objc.swift
+++ b/test/expr/primary/keypath/keypath-objc.swift
@@ -121,7 +121,7 @@ func testAsStaticString() {
 
 func testSemanticErrors() {
   let _: String = #keyPath(A.blarg) // expected-error{{type 'A' has no member 'blarg'}}
-  let _: String = #keyPath(blarg) // expected-error{{use of unresolved identifier 'blarg'}}
+  let _: String = #keyPath(blarg) // expected-error{{cannot find 'blarg' in scope}}
   let _: String = #keyPath(AnyObject.ambiguous) // expected-error{{ambiguous reference to member 'ambiguous'}}
   let _: String = #keyPath(C.nonObjC) // expected-error{{argument of '#keyPath' refers to non-'@objc' property 'nonObjC'}}
   let _: String = #keyPath(A.propArray.UTF8View) // expected-error{{type 'String' has no member 'UTF8View'}}
@@ -135,7 +135,7 @@ func testParseErrors() {
   let _: String = #keyPath; // expected-error{{expected '(' following '#keyPath'}}
   let _: String = #keyPath(123; // expected-error{{expected property or type name within '#keyPath(...)'}}
   let _: String = #keyPath(a.123; // expected-error{{expected property or type name within '#keyPath(...)'}}
-  let _: String = #keyPath(A(b:c:d:).propSet); // expected-error{{an Objective-C key path cannot reference a declaration with a compound name}} expected-error{{unresolved identifier 'propSet'}}
+  let _: String = #keyPath(A(b:c:d:).propSet); // expected-error{{an Objective-C key path cannot reference a declaration with a compound name}} expected-error{{cannot find 'propSet' in scope}}
   let _: String = #keyPath(A.propString; // expected-error{{expected ')' to complete '#keyPath' expression}}
     // expected-note@-1{{to match this opening '('}}
 }

--- a/test/expr/primary/selector/property.swift
+++ b/test/expr/primary/selector/property.swift
@@ -108,7 +108,7 @@ func testNonObjCMembers(nonObjCInstance: NonObjCClass) {
 
   // Referencing undefined symbols
 
-  let _ = #selector(getter: UndefinedClass.myVariable) // expected-error{{use of unresolved identifier 'UndefinedClass'}}
+  let _ = #selector(getter: UndefinedClass.myVariable) // expected-error{{cannot find 'UndefinedClass' in scope}}
   let _ = #selector(getter: ObjCClass.undefinedProperty) // expected-error{{type 'ObjCClass' has no member 'undefinedProperty'}}
   let _ = #selector(getter: myObjcInstance.undefinedProperty) // expected-error{{value of type 'ObjCClass' has no member 'undefinedProperty'}}
 }

--- a/test/multifile/Inputs/require-layout-error-other.swift
+++ b/test/multifile/Inputs/require-layout-error-other.swift
@@ -1,3 +1,3 @@
 public struct S {
-  var x: DoesNotExist // expected-error {{use of undeclared type 'DoesNotExist'}}
+  var x: DoesNotExist // expected-error {{cannot find type 'DoesNotExist' in scope}}
 }

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -14,14 +14,14 @@ if let x = foo() {
   modify(&x) // expected-error{{cannot pass immutable value as inout argument: 'x' is a 'let' constant}}
 }
 
-use(x) // expected-error{{unresolved identifier 'x'}}
+use(x) // expected-error{{cannot find 'x' in scope}}
 
 if var x = foo() {
   use(x)
   modify(&x)
 }
 
-use(x) // expected-error{{unresolved identifier 'x'}}
+use(x) // expected-error{{cannot find 'x' in scope}}
 
 if let x = nonOptionalStruct() { _ = x} // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalStruct'}}
 if let x = nonOptionalEnum() { _ = x} // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalEnum'}}
@@ -44,17 +44,17 @@ if let x = foo() {
   _ = x
 } else {
   // TODO: more contextual error? "x is only available on the true branch"?
-  use(x) // expected-error{{unresolved identifier 'x'}}
+  use(x) // expected-error{{cannot find 'x' in scope}}
 }
 
 if let x = foo() {
   use(x)
 } else if let y = foo() { // expected-note {{did you mean 'y'?}}
-  use(x) // expected-error{{unresolved identifier 'x'}}
+  use(x) // expected-error{{cannot find 'x' in scope}}
   use(y)
 } else {
-  use(x) // expected-error{{unresolved identifier 'x'}}
-  use(y) // expected-error{{unresolved identifier 'y'}}
+  use(x) // expected-error{{cannot find 'x' in scope}}
+  use(y) // expected-error{{cannot find 'y' in scope}}
 }
 
 var opt: Int? = .none
@@ -96,7 +96,7 @@ if 1 != 2, 4 == 57 {}
 if 1 != 2, 4 == 57, let x = opt {} // expected-warning {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
 
 // Test that these don't cause the parser to crash.
-if true { if a == 0; {} }   // expected-error {{use of unresolved identifier 'a'}} expected-error {{expected '{' after 'if' condition}}
+if true { if a == 0; {} }   // expected-error {{cannot find 'a' in scope}} expected-error {{expected '{' after 'if' condition}}
 if a == 0, where b == 0 {}  // expected-error 4{{}} expected-note {{}} {{25-25=do }}
 
 
@@ -141,7 +141,7 @@ func useInt(_ x: Int) {}
 
 func testWhileScoping(_ a: Int?) {// expected-note {{did you mean 'a'?}}
   while let x = a { }
-  useInt(x) // expected-error{{use of unresolved identifier 'x'}}
+  useInt(x) // expected-error{{cannot find 'x' in scope}}
 }
 
 // Matching a case with a single, labeled associated value.

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -653,65 +653,65 @@ func bad_if() {
 
 // Typo correction for loop labels
 for _ in [1] {
-  break outerloop // expected-error {{use of unresolved label 'outerloop'}}
-  continue outerloop // expected-error {{use of unresolved label 'outerloop'}}
+  break outerloop // expected-error {{cannot find label 'outerloop' in scope}}
+  continue outerloop // expected-error {{cannot find label 'outerloop' in scope}}
 }
 while true {
-  break outerloop // expected-error {{use of unresolved label 'outerloop'}}
-  continue outerloop // expected-error {{use of unresolved label 'outerloop'}}
+  break outerloop // expected-error {{cannot find label 'outerloop' in scope}}
+  continue outerloop // expected-error {{cannot find label 'outerloop' in scope}}
 }
 repeat {
-  break outerloop // expected-error {{use of unresolved label 'outerloop'}}
-  continue outerloop // expected-error {{use of unresolved label 'outerloop'}}
+  break outerloop // expected-error {{cannot find label 'outerloop' in scope}}
+  continue outerloop // expected-error {{cannot find label 'outerloop' in scope}}
 } while true
 
 outerLoop: for _ in [1] { // expected-note {{'outerLoop' declared here}}
-  break outerloop // expected-error {{use of unresolved label 'outerloop'; did you mean 'outerLoop'?}} {{9-18=outerLoop}}
+  break outerloop // expected-error {{cannot find label 'outerloop' in scope; did you mean 'outerLoop'?}} {{9-18=outerLoop}}
 }
 outerLoop: for _ in [1] { // expected-note {{'outerLoop' declared here}}
-  continue outerloop // expected-error {{use of unresolved label 'outerloop'; did you mean 'outerLoop'?}} {{12-21=outerLoop}}
+  continue outerloop // expected-error {{cannot find label 'outerloop' in scope; did you mean 'outerLoop'?}} {{12-21=outerLoop}}
 }
 outerLoop: while true { // expected-note {{'outerLoop' declared here}}
-  break outerloop // expected-error {{use of unresolved label 'outerloop'; did you mean 'outerLoop'?}} {{9-18=outerLoop}}
+  break outerloop // expected-error {{cannot find label 'outerloop' in scope; did you mean 'outerLoop'?}} {{9-18=outerLoop}}
 }
 outerLoop: while true { // expected-note {{'outerLoop' declared here}}
-  continue outerloop // expected-error {{use of unresolved label 'outerloop'; did you mean 'outerLoop'?}} {{12-21=outerLoop}}
+  continue outerloop // expected-error {{cannot find label 'outerloop' in scope; did you mean 'outerLoop'?}} {{12-21=outerLoop}}
 }
 outerLoop: repeat { // expected-note {{'outerLoop' declared here}}
-  break outerloop // expected-error {{use of unresolved label 'outerloop'; did you mean 'outerLoop'?}} {{9-18=outerLoop}}
+  break outerloop // expected-error {{cannot find label 'outerloop' in scope; did you mean 'outerLoop'?}} {{9-18=outerLoop}}
 } while true
 outerLoop: repeat { // expected-note {{'outerLoop' declared here}}
-  continue outerloop // expected-error {{use of unresolved label 'outerloop'; did you mean 'outerLoop'?}} {{12-21=outerLoop}}
+  continue outerloop // expected-error {{cannot find label 'outerloop' in scope; did you mean 'outerLoop'?}} {{12-21=outerLoop}}
 } while true
 
 outerLoop1: for _ in [1] { // expected-note {{did you mean 'outerLoop1'?}} {{11-20=outerLoop1}}
   outerLoop2: for _ in [1] { // expected-note {{did you mean 'outerLoop2'?}} {{11-20=outerLoop2}}
-    break outerloop // expected-error {{use of unresolved label 'outerloop'}}
+    break outerloop // expected-error {{cannot find label 'outerloop' in scope}}
   }
 }
 outerLoop1: for _ in [1] { // expected-note {{did you mean 'outerLoop1'?}} {{14-23=outerLoop1}}
   outerLoop2: for _ in [1] { // expected-note {{did you mean 'outerLoop2'?}} {{14-23=outerLoop2}}
-    continue outerloop // expected-error {{use of unresolved label 'outerloop'}}
+    continue outerloop // expected-error {{cannot find label 'outerloop' in scope}}
   }
 }
 outerLoop1: while true { // expected-note {{did you mean 'outerLoop1'?}} {{11-20=outerLoop1}}
   outerLoop2: while true { // expected-note {{did you mean 'outerLoop2'?}} {{11-20=outerLoop2}}
-    break outerloop // expected-error {{use of unresolved label 'outerloop'}}
+    break outerloop // expected-error {{cannot find label 'outerloop' in scope}}
   }
 }
 outerLoop1: while true { // expected-note {{did you mean 'outerLoop1'?}} {{14-23=outerLoop1}}
   outerLoop2: while true { // expected-note {{did you mean 'outerLoop2'?}} {{14-23=outerLoop2}}
-    continue outerloop // expected-error {{use of unresolved label 'outerloop'}}
+    continue outerloop // expected-error {{cannot find label 'outerloop' in scope}}
   }
 }
 outerLoop1: repeat { // expected-note {{did you mean 'outerLoop1'?}} {{11-20=outerLoop1}}
   outerLoop2: repeat { // expected-note {{did you mean 'outerLoop2'?}} {{11-20=outerLoop2}}
-    break outerloop // expected-error {{use of unresolved label 'outerloop'}}
+    break outerloop // expected-error {{cannot find label 'outerloop' in scope}}
   } while true
 } while true
 outerLoop1: repeat { // expected-note {{did you mean 'outerLoop1'?}} {{14-23=outerLoop1}}
   outerLoop2: repeat { // expected-note {{did you mean 'outerLoop2'?}} {{14-23=outerLoop2}}
-    continue outerloop // expected-error {{use of unresolved label 'outerloop'}}
+    continue outerloop // expected-error {{cannot find label 'outerloop' in scope}}
   } while true
 } while true
 

--- a/test/type/infer/instance_variables.swift
+++ b/test/type/infer/instance_variables.swift
@@ -13,6 +13,6 @@ func testX(_ x: inout X) {
 }
 
 struct Broken {
-  var b = True // expected-error{{use of unresolved identifier 'True'}} 
+  var b = True // expected-error{{cannot find 'True' in scope}} 
 }
 

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -172,7 +172,7 @@ takesP1AndP2([AnyObject & P1 & P2]())
 takesP1AndP2([Swift.AnyObject & P1 & P2]())
 takesP1AndP2([AnyObject & protocol_composition.P1 & P2]())
 takesP1AndP2([AnyObject & P1 & protocol_composition.P2]())
-takesP1AndP2([DoesNotExist & P1 & P2]()) // expected-error {{use of unresolved identifier 'DoesNotExist'}}
+takesP1AndP2([DoesNotExist & P1 & P2]()) // expected-error {{cannot find 'DoesNotExist' in scope}}
 takesP1AndP2([Swift.DoesNotExist & P1 & P2]()) // expected-error {{module 'Swift' has no member named 'DoesNotExist'}}
 
 typealias T08 = P1 & inout P2 // expected-error {{'inout' may only be used on parameters}}

--- a/test/type/protocol_types.swift
+++ b/test/type/protocol_types.swift
@@ -52,7 +52,7 @@ struct NestedCompoAliasTypeWhereRequirement<T> where T: CompoAssocType.Compo {}
 
 struct Struct1<T> { }
 struct Struct2<T : Pub & Bar> { }
-struct Struct3<T : Pub & Bar & P3> { } // expected-error {{use of undeclared type 'P3'}}
+struct Struct3<T : Pub & Bar & P3> { } // expected-error {{cannot find type 'P3' in scope}}
 struct Struct4<T> where T : Pub & Bar {}
 
 struct Struct5<T : protocol<Pub, Bar>> { } // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}}

--- a/test/type/types.swift
+++ b/test/type/types.swift
@@ -3,8 +3,8 @@
 var a : Int
 
 func test() {
-  var y : a   // expected-error {{use of undeclared type 'a'}}
-  var z : y   // expected-error {{use of undeclared type 'y'}}
+  var y : a   // expected-error {{cannot find type 'a' in scope}}
+  var z : y   // expected-error {{cannot find type 'y' in scope}}
   var w : Swift.print   // expected-error {{no type named 'print' in module 'Swift'}}
 }
 
@@ -33,7 +33,7 @@ if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
 var f0 : [Float]
 var f1 : [(Int,Int)]
 
-var g : Swift // expected-error {{use of undeclared type 'Swift'}} expected-note {{cannot use module 'Swift' as a type}}
+var g : Swift // expected-error {{cannot find type 'Swift' in scope}} expected-note {{cannot use module 'Swift' as a type}}
 
 var h0 : Int?
 _ = h0 == nil // no-warning
@@ -196,7 +196,7 @@ func foo3(inout a: Int -> Void) {} // expected-error {{'inout' before a paramete
 func sr5505(arg: Int) -> String {
   return "hello"
 }
-var _: sr5505 = sr5505 // expected-error {{use of undeclared type 'sr5505'}}
+var _: sr5505 = sr5505 // expected-error {{cannot find type 'sr5505' in scope}}
 
 typealias A = (inout Int ..., Int ... = [42, 12]) -> Void // expected-error {{'inout' must not be used on variadic parameters}}
                                                           // expected-error@-1 {{only a single element can be variadic}} {{35-39=}}

--- a/unittests/SourceKit/SwiftLang/EditingTest.cpp
+++ b/unittests/SourceKit/SwiftLang/EditingTest.cpp
@@ -277,7 +277,7 @@ void EditTest::doubleOpenWithDelay(std::chrono::microseconds delay,
   }
 
   ASSERT_EQ(1u, Consumer.Diags.size());
-  EXPECT_STREQ("use of unresolved identifier 'unknown_name'", Consumer.Diags[0].Description.c_str());
+  EXPECT_STREQ("cannot find 'unknown_name' in scope", Consumer.Diags[0].Description.c_str());
 
   close(DocName);
 }

--- a/validation-test/ClangImporter/bridging-header-reentrancy.swift
+++ b/validation-test/ClangImporter/bridging-header-reentrancy.swift
@@ -14,4 +14,4 @@
 mainBridgingHeaderLoaded() // ok, expected
 appBridgingHeaderLoaded() // ok, accidentally loaded
 CNCTest() // error, accidentally shadowed
-// expected-error@-1 {{use of unresolved identifier 'CNCTest'}}
+// expected-error@-1 {{cannot find 'CNCTest' in scope}}

--- a/validation-test/ClangImporter/macros-repeatedly-redefined.swift
+++ b/validation-test/ClangImporter/macros-repeatedly-redefined.swift
@@ -10,4 +10,4 @@ import E
 import F
 
 _ = REDEFINED // no-warning
-_ = x // expected-error {{use of unresolved identifier 'x'}}
+_ = x // expected-error {{cannot find 'x' in scope}}

--- a/validation-test/Sema/SwiftUI/rdar57201781.swift
+++ b/validation-test/Sema/SwiftUI/rdar57201781.swift
@@ -11,7 +11,7 @@ struct ContentView : View {
     VStack { // expected-error{{type of expression is ambiguous without more context}}
       HStack {
         Text("")
-        TextFi // expected-error {{use of unresolved identifier 'TextFi'}}
+        TextFi // expected-error {{cannot find 'TextFi' in scope}}
       }
 
       ForEach(0 ... 4, id: \.self) { i in

--- a/validation-test/compiler_crashers_fixed/00053-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/00053-std-function-func-swift-type-subst.swift
@@ -10,5 +10,5 @@
 
 // Issue found by https://github.com/julasamer (julasamer)
 
-struct c<d, e: b> where d.c == e { // expected-error {{use of undeclared type 'b'}} expected-error {{'c' is not a member type of 'd'}}
+struct c<d, e: b> where d.c == e { // expected-error {{cannot find type 'b' in scope}} expected-error {{'c' is not a member type of 'd'}}
 }


### PR DESCRIPTION
Fixes rdar://problem/62375243.

Cherry-pick https://github.com/apple/swift/pull/31315 onto 5.3