### PR TITLE
Strip Out More TypeLocs

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3781,12 +3781,7 @@ public:
 
   TypeRepr *getExplicitResultTypeRepr() const {
     assert(hasExplicitResultType() && "No explicit result type");
-    return ExplicitResultType.getTypeRepr();
-  }
-
-  void setExplicitResultType(SourceLoc arrowLoc, TypeLoc resultType) {
-    ArrowLoc = arrowLoc;
-    ExplicitResultType = resultType;
+    return ExplicitResultType->getTypeRepr();
   }
 
   /// Determine whether the closure has a single expression for its

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4936,25 +4936,20 @@ public:
 class EditorPlaceholderExpr : public Expr {
   Identifier Placeholder;
   SourceLoc Loc;
-  TypeLoc PlaceholderTy;
+  TypeRepr *PlaceholderTy;
   TypeRepr *ExpansionTyR;
   Expr *SemanticExpr;
 
 public:
   EditorPlaceholderExpr(Identifier Placeholder, SourceLoc Loc,
-                        TypeLoc PlaceholderTy,
-                        TypeRepr *ExpansionTyR)
-    : Expr(ExprKind::EditorPlaceholder, /*Implicit=*/false),
-      Placeholder(Placeholder), Loc(Loc),
-      PlaceholderTy(PlaceholderTy),
-      ExpansionTyR(ExpansionTyR),
-      SemanticExpr(nullptr) {
-  }
+                        TypeRepr *PlaceholderTy, TypeRepr *ExpansionTyR)
+      : Expr(ExprKind::EditorPlaceholder, /*Implicit=*/false),
+        Placeholder(Placeholder), Loc(Loc), PlaceholderTy(PlaceholderTy),
+        ExpansionTyR(ExpansionTyR), SemanticExpr(nullptr) {}
 
   Identifier getPlaceholder() const { return Placeholder; }
   SourceRange getSourceRange() const { return Loc; }
-  TypeLoc &getTypeLoc() { return PlaceholderTy; }
-  TypeLoc getTypeLoc() const { return PlaceholderTy; }
+  TypeRepr *getPlaceholderTypeRepr() const { return PlaceholderTy; }
   SourceLoc getTrailingAngleBracketLoc() const {
     return Loc.getAdvancedLoc(Placeholder.getLength() - 1);
   }

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3769,17 +3769,11 @@ public:
     return ThrowsLoc;
   }
 
-  /// Retrieve the explicit result type location information.
-  TypeExpr *getExplicitResultTypeExpr() const {
+  Type getExplicitResultType() const {
     assert(hasExplicitResultType() && "No explicit result type");
-    return ExplicitResultType;
+    return ExplicitResultType->getInstanceType();
   }
-
-  void setExplicitResultTypeExpr(TypeExpr *NewResultType) {
-    assert(hasExplicitResultType() && "No explicit result type");
-    ExplicitResultType = NewResultType;
-    assert(hasExplicitResultType() && "No explicit result type");
-  }
+  void setExplicitResultType(Type ty);
 
   TypeRepr *getExplicitResultTypeRepr() const {
     assert(hasExplicitResultType() && "No explicit result type");

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3706,7 +3706,7 @@ class ClosureExpr : public AbstractClosureExpr {
   SourceLoc InLoc;
 
   /// The explicitly-specified result type.
-  TypeLoc ExplicitResultType;
+  TypeExpr *ExplicitResultType;
 
   /// The body of the closure, along with a bit indicating whether it
   /// was originally just a single expression.
@@ -3714,7 +3714,7 @@ class ClosureExpr : public AbstractClosureExpr {
 public:
   ClosureExpr(SourceRange bracketRange, VarDecl *capturedSelfDecl,
               ParameterList *params, SourceLoc throwsLoc, SourceLoc arrowLoc,
-              SourceLoc inLoc, TypeLoc explicitResultType,
+              SourceLoc inLoc, TypeExpr *explicitResultType,
               unsigned discriminator, DeclContext *parent)
     : AbstractClosureExpr(ExprKind::Closure, Type(), /*Implicit=*/false,
                           discriminator, parent),
@@ -3774,9 +3774,15 @@ public:
   }
 
   /// Retrieve the explicit result type location information.
-  TypeLoc &getExplicitResultTypeLoc() {
+  TypeExpr *getExplicitResultTypeExpr() const {
     assert(hasExplicitResultType() && "No explicit result type");
     return ExplicitResultType;
+  }
+
+  void setExplicitResultTypeExpr(TypeExpr *NewResultType) {
+    assert(hasExplicitResultType() && "No explicit result type");
+    ExplicitResultType = NewResultType;
+    assert(hasExplicitResultType() && "No explicit result type");
   }
 
   TypeRepr *getExplicitResultTypeRepr() const {

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3386,7 +3386,7 @@ public:
 /// UnresolvedSpecializeExpr - Represents an explicit specialization using
 /// a type parameter list (e.g. "Vector<Int>") that has not been resolved.
 class UnresolvedSpecializeExpr final : public Expr,
-    private llvm::TrailingObjects<UnresolvedSpecializeExpr, TypeLoc> {
+    private llvm::TrailingObjects<UnresolvedSpecializeExpr, TypeRepr *> {
   friend TrailingObjects;
 
   Expr *SubExpr;
@@ -3395,31 +3395,27 @@ class UnresolvedSpecializeExpr final : public Expr,
 
   UnresolvedSpecializeExpr(Expr *SubExpr,
                            SourceLoc LAngleLoc,
-                           ArrayRef<TypeLoc> UnresolvedParams,
+                           ArrayRef<TypeRepr *> UnresolvedParams,
                            SourceLoc RAngleLoc)
     : Expr(ExprKind::UnresolvedSpecialize, /*Implicit=*/false),
       SubExpr(SubExpr), LAngleLoc(LAngleLoc), RAngleLoc(RAngleLoc) {
     Bits.UnresolvedSpecializeExpr.NumUnresolvedParams = UnresolvedParams.size();
     std::uninitialized_copy(UnresolvedParams.begin(), UnresolvedParams.end(),
-                            getTrailingObjects<TypeLoc>());
+                            getTrailingObjects<TypeRepr *>());
   }
 
 public:
   static UnresolvedSpecializeExpr *
   create(ASTContext &ctx, Expr *SubExpr, SourceLoc LAngleLoc,
-         ArrayRef<TypeLoc> UnresolvedParams, SourceLoc RAngleLoc);
+         ArrayRef<TypeRepr *> UnresolvedParams, SourceLoc RAngleLoc);
   
   Expr *getSubExpr() const { return SubExpr; }
   void setSubExpr(Expr *e) { SubExpr = e; }
   
   /// Retrieve the list of type parameters. These parameters have not yet
   /// been bound to archetypes of the entity to be specialized.
-  ArrayRef<TypeLoc> getUnresolvedParams() const {
-    return {getTrailingObjects<TypeLoc>(),
-            Bits.UnresolvedSpecializeExpr.NumUnresolvedParams};
-  }
-  MutableArrayRef<TypeLoc> getUnresolvedParams() {
-    return {getTrailingObjects<TypeLoc>(),
+  ArrayRef<TypeRepr *> getUnresolvedParams() const {
+    return {getTrailingObjects<TypeRepr *>(),
             Bits.UnresolvedSpecializeExpr.NumUnresolvedParams};
   }
   

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1551,7 +1551,7 @@ public:
           ParameterList *&params,
           SourceLoc &throwsLoc,
           SourceLoc &arrowLoc,
-          TypeRepr *&explicitResultType,
+          TypeExpr *&explicitResultType,
           SourceLoc &inLoc);
 
   Expr *parseExprAnonClosureArg();

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2695,7 +2695,7 @@ public:
       }
     }
     OS << '\n';
-    auto *TyR = E->getTypeLoc().getTypeRepr();
+    auto *TyR = E->getPlaceholderTypeRepr();
     auto *ExpTyR = E->getTypeForExpansion();
     if (TyR)
       printRec(TyR);

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -810,9 +810,11 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   Expr *visitClosureExpr(ClosureExpr *expr) {
     visit(expr->getParameters());
 
-    if (expr->hasExplicitResultType())
-      if (doIt(expr->getExplicitResultTypeLoc()))
-        return nullptr;
+    if (expr->hasExplicitResultType()) {
+      Expr *result = doIt(expr->getExplicitResultTypeExpr());
+      if (!result) return nullptr;
+      expr->setExplicitResultTypeExpr(cast<TypeExpr>(result));
+    }
 
     // Handle single-expression closures.
     if (expr->hasSingleExpressionBody()) {

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -811,9 +811,8 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     visit(expr->getParameters());
 
     if (expr->hasExplicitResultType()) {
-      Expr *result = doIt(expr->getExplicitResultTypeExpr());
-      if (!result) return nullptr;
-      expr->setExplicitResultTypeExpr(cast<TypeExpr>(result));
+      if (doIt(expr->getExplicitResultTypeRepr()))
+        return nullptr;
     }
 
     // Handle single-expression closures.

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1191,9 +1191,9 @@ ErasureExpr *ErasureExpr::create(ASTContext &ctx, Expr *subExpr, Type type,
 
 UnresolvedSpecializeExpr *UnresolvedSpecializeExpr::create(ASTContext &ctx,
                                              Expr *SubExpr, SourceLoc LAngleLoc,
-                                             ArrayRef<TypeLoc> UnresolvedParams,
+                                             ArrayRef<TypeRepr *> UnresolvedParams,
                                              SourceLoc RAngleLoc) {
-  auto size = totalSizeToAlloc<TypeLoc>(UnresolvedParams.size());
+  auto size = totalSizeToAlloc<TypeRepr *>(UnresolvedParams.size());
   auto mem = ctx.Allocate(size, alignof(UnresolvedSpecializeExpr));
   return ::new(mem) UnresolvedSpecializeExpr(SubExpr, LAngleLoc,
                                              UnresolvedParams, RAngleLoc);

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1861,6 +1861,11 @@ bool ClosureExpr::capturesSelfEnablingImplictSelf() const {
   return false;
 }
 
+void ClosureExpr::setExplicitResultType(Type ty) {
+  assert(ty && !ty->hasTypeVariable());
+  ExplicitResultType->setType(MetatypeType::get(ty));
+}
+
 FORWARD_SOURCE_LOCS_TO(AutoClosureExpr, Body)
 
 void AutoClosureExpr::setBody(Expr *E) {

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -211,7 +211,7 @@ Type swift::ide::getReturnTypeFromContext(const DeclContext *DC) {
       return ACE->getResultType();
     if (auto CE = dyn_cast<ClosureExpr>(ACE)) {
       if (CE->hasExplicitResultType()) {
-        if (auto ty = CE->getExplicitResultTypeExpr()->getInstanceType()) {
+        if (auto ty = CE->getExplicitResultType()) {
           return ty;
         }
 

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -29,6 +29,7 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/IDE/CodeCompletion.h"
 #include "swift/Sema/IDETypeChecking.h"
+#include "swift/Subsystems.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
 
@@ -209,10 +210,23 @@ Type swift::ide::getReturnTypeFromContext(const DeclContext *DC) {
     if (ACE->getType() && !ACE->getType()->hasError())
       return ACE->getResultType();
     if (auto CE = dyn_cast<ClosureExpr>(ACE)) {
-      if (CE->hasExplicitResultType())
-        return const_cast<ClosureExpr *>(CE)
-            ->getExplicitResultTypeLoc()
-            .getType();
+      if (CE->hasExplicitResultType()) {
+        if (auto ty = CE->getExplicitResultTypeExpr()->getInstanceType()) {
+          return ty;
+        }
+
+        auto typeLoc = TypeLoc{CE->getExplicitResultTypeRepr()};
+        if (swift::performTypeLocChecking(DC->getASTContext(),
+                                          typeLoc,
+                                          /*isSILMode*/ false,
+                                          /*isSILType*/ false,
+                                          DC->getGenericEnvironmentOfContext(),
+                                          const_cast<DeclContext *>(DC),
+                                          /*diagnostics*/ false)) {
+          return Type();
+        }
+        return typeLoc.getType();
+      }
     }
   }
   return Type();

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -2295,9 +2295,8 @@ private:
 
       SourceLoc ContextLoc = getContextLocForArgs(SM, USE);
       ListAligner Aligner(SM, TargetLocation, ContextLoc, L, R);
-      for (auto &Arg: USE->getUnresolvedParams()) {
-        if (auto *T = Arg.getTypeRepr())
-          Aligner.updateAlignment(T->getSourceRange(), T);
+      for (auto *T : USE->getUnresolvedParams()) {
+        Aligner.updateAlignment(T->getSourceRange(), T);
       }
       return Aligner.getContextAndSetAlignment(CtxOverride);
     }

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -663,7 +663,7 @@ std::pair<bool, Expr *> ModelASTWalker::walkToExprPre(Expr *E) {
     SN.BodyRange = innerCharSourceRangeFromSourceRange(SM, E->getSourceRange());
     if (Closure->hasExplicitResultType())
       SN.TypeRange = charSourceRangeFromSourceRange(SM,
-                          Closure->getExplicitResultTypeExpr()->getSourceRange());
+                          Closure->getExplicitResultTypeRepr()->getSourceRange());
 
     pushStructureNode(SN, Closure);
 

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -663,7 +663,7 @@ std::pair<bool, Expr *> ModelASTWalker::walkToExprPre(Expr *E) {
     SN.BodyRange = innerCharSourceRangeFromSourceRange(SM, E->getSourceRange());
     if (Closure->hasExplicitResultType())
       SN.TypeRange = charSourceRangeFromSourceRange(SM,
-                          Closure->getExplicitResultTypeLoc().getSourceRange());
+                          Closure->getExplicitResultTypeExpr()->getSourceRange());
 
     pushStructureNode(SN, Closure);
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2422,7 +2422,7 @@ parseClosureSignatureIfPresent(SourceRange &bracketRange,
                                VarDecl *&capturedSelfDecl,
                                ParameterList *&params, SourceLoc &throwsLoc,
                                SourceLoc &arrowLoc,
-                               TypeRepr *&explicitResultType, SourceLoc &inLoc){
+                               TypeExpr *&explicitResultType, SourceLoc &inLoc){
   // Clear out result parameters.
   bracketRange = SourceRange();
   capturedSelfDecl = nullptr;
@@ -2686,12 +2686,14 @@ parseClosureSignatureIfPresent(SourceRange &bracketRange,
       arrowLoc = consumeToken();
 
       // Parse the type.
-      explicitResultType =
+      auto *explicitResultTypeRepr =
           parseType(diag::expected_closure_result_type).getPtrOrNull();
-      if (!explicitResultType) {
+      if (!explicitResultTypeRepr) {
         // If we couldn't parse the result type, clear out the arrow location.
         arrowLoc = SourceLoc();
         invalid = true;
+      } else {
+        explicitResultType = new (Context) TypeExpr(explicitResultTypeRepr);
       }
     }
   }
@@ -2791,7 +2793,7 @@ ParserResult<Expr> Parser::parseExprClosure() {
   ParameterList *params = nullptr;
   SourceLoc throwsLoc;
   SourceLoc arrowLoc;
-  TypeRepr *explicitResultType;
+  TypeExpr *explicitResultType;
   SourceLoc inLoc;
   parseClosureSignatureIfPresent(bracketRange, captureList,
                                  capturedSelfDecl, params, throwsLoc,

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1161,13 +1161,10 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
         if (argStat.isError())
           diagnose(LAngleLoc, diag::while_parsing_as_left_angle_bracket);
 
-        SmallVector<TypeLoc, 8> locArgs;
-        for (auto ty : args)
-          locArgs.push_back(ty);
         SyntaxContext->createNodeInPlace(SyntaxKind::SpecializeExpr);
         Result = makeParserResult(
             Result, UnresolvedSpecializeExpr::create(
-                        Context, Result.get(), LAngleLoc, locArgs, RAngleLoc));
+                        Context, Result.get(), LAngleLoc, args, RAngleLoc));
       }
 
       continue;
@@ -2312,10 +2309,7 @@ Expr *Parser::parseExprIdentifier() {
   }
   
   if (hasGenericArgumentList) {
-    SmallVector<TypeLoc, 8> locArgs;
-    for (auto ty : args)
-      locArgs.push_back(ty);
-    E = UnresolvedSpecializeExpr::create(Context, E, LAngleLoc, locArgs,
+    E = UnresolvedSpecializeExpr::create(Context, E, LAngleLoc, args,
                                          RAngleLoc);
   }
   return E;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7696,6 +7696,10 @@ namespace {
         auto *params = closure->getParameters();
         TypeChecker::coerceParameterListToType(params, closure, fnType);
 
+        if (closure->hasExplicitResultType()) {
+          closure->setExplicitResultType(fnType->getResult());
+        }
+
         if (auto transform =
                        Rewriter.getAppliedBuilderTransform(closure)) {
           // Apply the function builder to the closure. We want to be in the

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1691,8 +1691,7 @@ namespace {
         if (BoundGenericType *bgt
               = meta->getInstanceType()->getAs<BoundGenericType>()) {
           ArrayRef<Type> typeVars = bgt->getGenericArgs();
-          MutableArrayRef<TypeLoc> specializations =
-              expr->getUnresolvedParams();
+          auto specializations = expr->getUnresolvedParams();
 
           // If we have too many generic arguments, complain.
           if (specializations.size() > typeVars.size()) {
@@ -1715,14 +1714,15 @@ namespace {
           for (size_t i = 0, size = specializations.size(); i < size; ++i) {
             TypeResolutionOptions options(TypeResolverContext::InExpression);
             options |= TypeResolutionFlags::AllowUnboundGenerics;
+            auto tyLoc = TypeLoc{specializations[i]};
             if (TypeChecker::validateType(CS.getASTContext(),
-                                specializations[i],
+                                tyLoc,
                                 TypeResolution::forContextual(CS.DC),
                                 options))
               return Type();
 
             CS.addConstraint(ConstraintKind::Bind,
-                             typeVars[i], specializations[i].getType(),
+                             typeVars[i], tyLoc.getType(),
                              locator);
           }
           

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2182,8 +2182,7 @@ namespace {
           return Type();
         }
 
-        auto *resultExpr = closure->getExplicitResultTypeExpr();
-        if (auto declaredTy = resultExpr->getInstanceType()) {
+        if (auto declaredTy = closure->getExplicitResultType()) {
           return declaredTy;
         }
 
@@ -2216,11 +2215,6 @@ namespace {
               resultLoc,
               closure->hasSingleExpressionBody() ? 0 : TVO_CanBindToHole);
         }
-      }
-
-      if (closure->hasExplicitResultType()) {
-        CS.setType(closure->getExplicitResultTypeExpr(),
-                   MetatypeType::get(resultTy));
       }
 
       return FunctionType::get(closureParams, resultTy, extInfo);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7078,14 +7078,11 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
         closureType->getResult(),
         getConstraintLocator(closure, LocatorPathElt::ClosureBody(hasReturn)));
   } else if (!hasReturn) {
-    bool hasExplicitResult = closure->hasExplicitResultType() &&
-                             closure->getExplicitResultTypeLoc().getType();
-
     // If this closure has an empty body and no explicit result type
     // let's bind result type to `Void` since that's the only type empty body
     // can produce. Otherwise, if (multi-statement) closure doesn't have
     // an explicit result (no `return` statements) let's default it to `Void`.
-    auto constraintKind = (closure->hasEmptyBody() && !hasExplicitResult)
+    auto constraintKind = (closure->hasEmptyBody() && !closure->hasExplicitResultType())
                               ? ConstraintKind::Bind
                               : ConstraintKind::Defaultable;
     addConstraint(

--- a/lib/Sema/DebuggerTestingTransform.cpp
+++ b/lib/Sema/DebuggerTestingTransform.cpp
@@ -226,7 +226,7 @@ private:
     auto *Params = ParameterList::createEmpty(Ctx);
     auto *Closure = new (Ctx)
         ClosureExpr(SourceRange(), nullptr, Params, SourceLoc(), SourceLoc(),
-                    SourceLoc(), TypeLoc(), DF.getNextDiscriminator(),
+                    SourceLoc(), nullptr, DF.getNextDiscriminator(),
                     getCurrentDeclContext());
     Closure->setImplicit(true);
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -537,13 +537,6 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
             isa<SubscriptExpr>(ParentExpr)) {
           return;
         }
-
-        if (auto *CE = dyn_cast<ClosureExpr>(ParentExpr)) {
-          if (CE->hasExplicitResultType() &&
-              CE->getExplicitResultTypeExpr() == E) {
-            return;
-          }
-        }
       }
 
       // Is this a protocol metatype?

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -537,6 +537,13 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
             isa<SubscriptExpr>(ParentExpr)) {
           return;
         }
+
+        if (auto *CE = dyn_cast<ClosureExpr>(ParentExpr)) {
+          if (CE->hasExplicitResultType() &&
+              CE->getExplicitResultTypeExpr() == E) {
+            return;
+          }
+        }
       }
 
       // Is this a protocol metatype?

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1320,15 +1320,6 @@ bool PreCheckExpression::walkToClosureExprPre(ClosureExpr *closure) {
     hadParameterError |= param->isInvalid();
   }
 
-  // Validate the result type, if present.
-  if (closure->hasExplicitResultType() &&
-      TypeChecker::validateType(getASTContext(),
-                                closure->getExplicitResultTypeLoc(),
-                                TypeResolution::forContextual(closure),
-                                TypeResolverContext::InExpression)) {
-    return false;
-  }
-
   if (hadParameterError)
     return false;
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1096,16 +1096,6 @@ namespace {
         return finish(true, TypeChecker::resolveDeclRefExpr(unresolved, DC));
       }
 
-      if (auto PlaceholderE = dyn_cast<EditorPlaceholderExpr>(expr)) {
-        if (!PlaceholderE->getTypeLoc().isNull()) {
-          if (!TypeChecker::validateType(
-                  getASTContext(), PlaceholderE->getTypeLoc(),
-                  TypeResolution::forContextual(DC), None))
-            expr->setType(PlaceholderE->getTypeLoc().getType());
-        }
-        return finish(true, expr);
-      }
-
       // Let's try to figure out if `InOutExpr` is out of place early
       // otherwise there is a risk of producing solutions which can't
       // be later applied to AST and would result in the crash in some

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1427,19 +1427,14 @@ TypeExpr *PreCheckExpression::simplifyNestedTypeExpr(UnresolvedDotExpr *UDE) {
 
 TypeExpr *PreCheckExpression::simplifyUnresolvedSpecializeExpr(
     UnresolvedSpecializeExpr *us) {
-  SmallVector<TypeRepr *, 4> genericArgs;
-  for (auto &type : us->getUnresolvedParams()) {
-    genericArgs.push_back(type.getTypeRepr());
-  }
-
-  auto angleRange = SourceRange(us->getLAngleLoc(), us->getRAngleLoc());
-
   // If this is a reference type a specialized type, form a TypeExpr.
-
   // The base should be a TypeExpr that we already resolved.
   if (auto *te = dyn_cast<TypeExpr>(us->getSubExpr())) {
     if (auto *ITR = dyn_cast_or_null<IdentTypeRepr>(te->getTypeRepr())) {
-      return TypeExpr::createForSpecializedDecl(ITR, genericArgs, angleRange,
+      return TypeExpr::createForSpecializedDecl(ITR,
+                                                us->getUnresolvedParams(),
+                                                SourceRange(us->getLAngleLoc(),
+                                                            us->getRAngleLoc()),
                                                 getASTContext());
     }
   }

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -211,13 +211,11 @@ struct ExprToIdentTypeRepr : public ASTVisitor<ExprToIdentTypeRepr, bool>
     assert(!components.empty() && "no components before generic args?!");
     
     // Track the AST location of the generic arguments.
-    SmallVector<TypeRepr*, 4> argTypeReprs;
-    for (auto &arg : use->getUnresolvedParams())
-      argTypeReprs.push_back(arg.getTypeRepr());
     auto origComponent = components.back();
     components.back() =
       GenericIdentTypeRepr::create(C, origComponent->getNameLoc(),
-                                   origComponent->getNameRef(), argTypeReprs,
+                                   origComponent->getNameRef(),
+                                   use->getUnresolvedParams(),
                                    SourceRange(use->getLAngleLoc(),
                                                use->getRAngleLoc()));
 

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -257,7 +257,7 @@ void REPLChecker::generatePrintOfExpression(StringRef NameStr, Expr *E) {
 
   ClosureExpr *CE =
       new (Context) ClosureExpr(SourceRange(), nullptr, params, SourceLoc(),
-                                SourceLoc(), SourceLoc(), TypeLoc(),
+                                SourceLoc(), SourceLoc(), nullptr,
                                 discriminator, newTopLevel);
 
   SmallVector<AnyFunctionType::Param, 1> args;

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -446,9 +446,9 @@ var f = { (s: Undeclared) -> Int in 0 } // expected-error {{cannot find type 'Un
 
 // <rdar://problem/21375863> Swift compiler crashes when using closure, declared to return illegal type.
 func r21375863() {
-  var width = 0
-  var height = 0
-  var bufs: [[UInt8]] = (0..<4).map { _ -> [asdf] in  // expected-error {{cannot find type 'asdf' in scope}}
+  var width = 0 // expected-warning {{variable 'width' was never mutated}}
+  var height = 0 // expected-warning {{variable 'height' was never mutated}}
+  var bufs: [[UInt8]] = (0..<4).map { _ -> [asdf] in  // expected-error {{cannot find type 'asdf' in scope}} expected-warning {{variable 'bufs' was never used}}
     [UInt8](repeating: 0, count: width*height)
   }
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1562,7 +1562,7 @@ private:
     PlaceholderFinder Finder(E->getStartLoc(), Found);
     E->walk(Finder);
     if (Found) {
-      if (auto TR = Found->getTypeLoc().getTypeRepr()) {
+      if (auto TR = Found->getPlaceholderTypeRepr()) {
         TR->walk(ClosureWalker);
         return ClosureWalker.FoundFunctionTypeRepr;
       }


### PR DESCRIPTION
Remove TypeLoc from 

* ClosureExpr
* UnresolvedSpecializeExpr
* EditorPlaceholderExpr

Type checking for closures is now somewhat simpler.