### PR TITLE
[Darwin] Import all overlay shims with @_implementationOnly

### DIFF
--- a/stdlib/public/Darwin/Dispatch/Block.swift
+++ b/stdlib/public/Darwin/Dispatch/Block.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import _SwiftDispatchOverlayShims
+@_implementationOnly import _SwiftDispatchOverlayShims
 
 public struct DispatchWorkItemFlags : OptionSet, RawRepresentable {
 	public let rawValue: UInt

--- a/stdlib/public/Darwin/Dispatch/Data.swift
+++ b/stdlib/public/Darwin/Dispatch/Data.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import _SwiftDispatchOverlayShims
+@_implementationOnly import _SwiftDispatchOverlayShims
 
 public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	public typealias Iterator = DispatchDataIterator

--- a/stdlib/public/Darwin/Dispatch/Dispatch.swift
+++ b/stdlib/public/Darwin/Dispatch/Dispatch.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import Dispatch
-import _SwiftDispatchOverlayShims
+@_implementationOnly import _SwiftDispatchOverlayShims
 
 /// dispatch_assert
 

--- a/stdlib/public/Darwin/Dispatch/Queue.swift
+++ b/stdlib/public/Darwin/Dispatch/Queue.swift
@@ -12,7 +12,7 @@
 
 // dispatch/queue.h
 
-import _SwiftDispatchOverlayShims
+@_implementationOnly import _SwiftDispatchOverlayShims
 
 public final class DispatchSpecificKey<T> {
 	public init() {}

--- a/stdlib/public/Darwin/Dispatch/Source.swift
+++ b/stdlib/public/Darwin/Dispatch/Source.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 // import Foundation
-import _SwiftDispatchOverlayShims
+@_implementationOnly import _SwiftDispatchOverlayShims
 
 extension DispatchSourceProtocol {
 	public typealias DispatchSourceHandler = @convention(block) () -> Void

--- a/stdlib/public/Darwin/Dispatch/Time.swift
+++ b/stdlib/public/Darwin/Dispatch/Time.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import _SwiftDispatchOverlayShims
+@_implementationOnly import _SwiftDispatchOverlayShims
 
 public struct DispatchTime : Comparable {
 	private static let timebaseInfo: mach_timebase_info_data_t = {

--- a/stdlib/public/Darwin/Network/NWConnection.swift
+++ b/stdlib/public/Darwin/Network/NWConnection.swift
@@ -12,7 +12,7 @@
 
 import Dispatch
 import Foundation
-import _SwiftNetworkOverlayShims
+@_implementationOnly import _SwiftNetworkOverlayShims
 
 /// An NWConnection is an object that represents a bi-directional data pipe between
 /// a local endpoint and a remote endpoint.

--- a/stdlib/public/Darwin/Network/NWEndpoint.swift
+++ b/stdlib/public/Darwin/Network/NWEndpoint.swift
@@ -12,7 +12,7 @@
 
 import Darwin
 import Foundation
-import _SwiftNetworkOverlayShims
+@_implementationOnly import _SwiftNetworkOverlayShims
 
 internal extension sockaddr_in {
 	init(_ address:in_addr, _ port: in_port_t) {

--- a/stdlib/public/Darwin/Network/NWError.swift
+++ b/stdlib/public/Darwin/Network/NWError.swift
@@ -12,7 +12,7 @@
 
 import Darwin
 import Security
-import _SwiftNetworkOverlayShims
+@_implementationOnly import _SwiftNetworkOverlayShims
 
 /// NWError is a type to deliver error codes relevant to NWConnection and NWListener objects.
 /// Generic connectivity errors will be delivered in the posix domain, resolution errors will

--- a/stdlib/public/Darwin/Network/NWPath.swift
+++ b/stdlib/public/Darwin/Network/NWPath.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import _SwiftNetworkOverlayShims
+@_implementationOnly import _SwiftNetworkOverlayShims
 
 /// An NWInterface object represents an instance of a network interface of a specific
 /// type, such as a Wi-Fi or Cellular interface.

--- a/stdlib/public/Darwin/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/Darwin/ObjectiveC/ObjectiveC.swift
@@ -12,7 +12,7 @@
 
 @_exported
 import ObjectiveC
-import _SwiftObjectiveCOverlayShims
+@_implementationOnly import _SwiftObjectiveCOverlayShims
 
 //===----------------------------------------------------------------------===//
 // Objective-C Primitive Types

--- a/stdlib/public/Darwin/SafariServices/SafariServices.swift
+++ b/stdlib/public/Darwin/SafariServices/SafariServices.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import SafariServices // Clang module
-import _SwiftSafariServicesOverlayShims
+@_implementationOnly import _SwiftSafariServicesOverlayShims
 
 #if os(macOS)
 

--- a/stdlib/public/Darwin/UIKit/UIKit.swift
+++ b/stdlib/public/Darwin/UIKit/UIKit.swift
@@ -14,7 +14,7 @@ import Foundation
 @_exported import UIKit
 
 #if os(iOS) || os(tvOS)
-import _SwiftUIKitOverlayShims
+@_implementationOnly import _SwiftUIKitOverlayShims
 #endif
 
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/Darwin/XCTest/XCTest.swift
+++ b/stdlib/public/Darwin/XCTest/XCTest.swift
@@ -24,7 +24,7 @@
 @_exported import XCTest // Clang module
 
 import CoreGraphics
-import _SwiftXCTestOverlayShims
+@_implementationOnly import _SwiftXCTestOverlayShims
 
 // --- XCTest API Swiftification ---
 

--- a/stdlib/public/Darwin/XPC/XPC.swift
+++ b/stdlib/public/Darwin/XPC/XPC.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import XPC
-import _SwiftXPCOverlayShims
+@_implementationOnly import _SwiftXPCOverlayShims
 
 //===----------------------------------------------------------------------===//
 // XPC Types

--- a/stdlib/public/Darwin/os/os_log.swift
+++ b/stdlib/public/Darwin/os/os_log.swift
@@ -12,7 +12,7 @@
 
 @_exported import os
 @_exported import os.log
-import _SwiftOSOverlayShims
+@_implementationOnly import _SwiftOSOverlayShims
 
 @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
 public func os_log(

--- a/stdlib/public/Darwin/os/os_signpost.swift
+++ b/stdlib/public/Darwin/os/os_signpost.swift
@@ -12,7 +12,7 @@
 
 @_exported import os
 @_exported import os.signpost
-import _SwiftOSOverlayShims
+@_implementationOnly import _SwiftOSOverlayShims
 import os.log
 
 @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)


### PR DESCRIPTION
This removes these imports from the generated Swift modules, and also makes sure shims aren't used in any inlinable code.

C.f. https://github.com/apple/swift/pull/28918

rdar://62626788