### PR TITLE
cross-module-optimiations: Fix an compiler crash and a wrong linkage

### DIFF
--- a/test/SILOptimizer/Inputs/cross-module.swift
+++ b/test/SILOptimizer/Inputs/cross-module.swift
@@ -162,6 +162,25 @@ public class FooClass: PrivateProto {
   }
 }
 
+final class Internalclass {
+  public var publicint: Int = 27
+}
+
+final public class Outercl {
+  var ic: Internalclass = Internalclass()
+}
+
+@inline(never)
+public func classWithPublicProperty<T>(_ t: T) -> Int {
+  return createInternal().ic.publicint
+}
+
+@inline(never)
+func createInternal() -> Outercl {
+  return Outercl()
+}
+
+
 @inline(never)
 @_semantics("optimize.sil.specialize.generic.never")
 fileprivate func callProtocolFoo<T: PrivateProto>(_ t: T) {

--- a/test/SILOptimizer/cross-module-optimization.swift
+++ b/test/SILOptimizer/cross-module-optimization.swift
@@ -118,6 +118,9 @@ func testMisc() {
   // CHECK-OUTPUT: 42
   // CHECK-SIL-DAG: sil shared {{.*}} @$s4Test13callUnrelatedyxxlFSi_Tg5
   print(callUnrelated(42))
+
+  // CHECK-OUTPUT: 27
+  print(classWithPublicProperty(33))
 }
 
 testNestedTypes()


### PR DESCRIPTION
In case a property is more visible than its container, an assert was triggering in ValueDecl::isUsableFromInline().

rdar://problem/62403317
