### PR TITLE
[TF] Change PythonKit deployment target to macOS 10.10.

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/pythonkit.py
+++ b/utils/swift_build_support/swift_build_support/products/pythonkit.py
@@ -48,9 +48,12 @@ class PythonKit(product.Product):
             pass
 
         # SWIFT_ENABLE_TENSORFLOW
+        # NOTE(TF-1252): macOS deployment target must be below 10.13 to avoid
+        # libswiftCore.dylib dynamic linker issues on 10.14+ while `tensorflow`
+        # branch contains changes to libswiftCore.dylib.
         target = ''
         if host_target.startswith('macosx'):
-            target = '-DCMAKE_Swift_COMPILER_TARGET=x86_64-apple-macosx10.13'
+            target = '-DCMAKE_Swift_COMPILER_TARGET=x86_64-apple-macosx10.10'
         # SWIFT_ENABLE_TENSORFLOW END
 
         with shell.pushd(self.build_dir):


### PR DESCRIPTION
Change PythonKit deployment target from macOS 10.13 to macOS 10.10.

This is necessary to work around TF-1252 for Swift libraries that import `PythonKit`, like `TensorFlow`. It should allow us to make `TensorFlow` have a lower deployment target to work around TF-1252.

Robust fix for the underlying issue (TF-1268): remove core standard library changes from `tensorflow` branch. This will take more time.