### PR TITLE
[CxxInterop] Add C++ demangled name for globals/static member variables to SIL

### DIFF
--- a/test/Interop/Cxx/extern-var/extern-var-silgen.swift
+++ b/test/Interop/Cxx/extern-var/extern-var-silgen.swift
@@ -6,7 +6,9 @@ func getCounter() -> CInt {
   return counter
 }
 
+// CHECK: // clang name: counter
 // CHECK: sil_global @counter : $Int32
+// CHECK: // clang name: Namespaced::counter
 // CHECK: sil_global @{{_ZN10Namespaced7counterE|\?counter@Namespaced@@3HA}} : $Int32
 
 // CHECK: sil hidden @$s4main10getCounters5Int32VyF : $@convention(thin) () -> Int32

--- a/test/Interop/Cxx/static/inline-static-member-var-silgen.swift
+++ b/test/Interop/Cxx/static/inline-static-member-var-silgen.swift
@@ -6,6 +6,7 @@ func readStaticMember() -> CInt {
   return WithInlineStaticMember.staticMember
 }
 
+// CHECK: // clang name: WithInlineStaticMember::staticMember
 // CHECK: sil_global @{{_ZN22WithInlineStaticMember12staticMemberE|\?staticMember@WithInlineStaticMember@@2HA}} : $Int32
 
 // CHECK: sil hidden @$s4main16readStaticMembers5Int32VyF : $@convention(thin) () -> Int32

--- a/test/Interop/Cxx/static/static-member-func-silgen.swift
+++ b/test/Interop/Cxx/static/static-member-func-silgen.swift
@@ -11,6 +11,7 @@ func callStaticMemberFunc() -> CInt {
 // CHECK: [[VALUE:%.*]] = apply [[FUNC]]() : $@convention(c) () -> Int32
 // CHECK: return [[VALUE]] : $Int32
 
+// CHECK: // clang name: WithStaticMemberFunc::staticMemberFunc
 // CHECK: sil [clang WithStaticMemberFunc.staticMemberFunc] @{{_ZN20WithStaticMemberFunc16staticMemberFuncEv|\?staticMemberFunc@WithStaticMemberFunc@@SAHXZ}} : $@convention(c) () -> Int32
 
 func callStaticMemberFuncAddr() -> CInt {
@@ -21,4 +22,5 @@ func callStaticMemberFuncAddr() -> CInt {
 // CHECK: [[FUNC:%.*]] = function_ref @{{_ZN20WithStaticMemberFunc26getStaticMemberFuncAddressEv|\?getStaticMemberFuncAddress@WithStaticMemberFunc@@SAP6AHXZXZ}} : $@convention(c) () -> Optional<@convention(c) () -> Int32>
 // CHECK: [[VALUE:%.*]] = apply [[FUNC]]() : $@convention(c) () -> Optional<@convention(c) () -> Int32>
 
+// CHECK: // clang name: WithStaticMemberFunc::getStaticMemberFuncAddress
 // CHECK: sil [clang WithStaticMemberFunc.getStaticMemberFuncAddress] @{{_ZN20WithStaticMemberFunc26getStaticMemberFuncAddressEv|\?getStaticMemberFuncAddress@WithStaticMemberFunc@@SAP6AHXZXZ}} : $@convention(c) () -> Optional<@convention(c) () -> Int32>

--- a/test/Interop/Cxx/static/static-member-var-silgen.swift
+++ b/test/Interop/Cxx/static/static-member-var-silgen.swift
@@ -1,9 +1,14 @@
 // RUN: %target-swift-emit-sil -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
 
+// CHECK: // clang name: WithStaticMember::staticMember
 // CHECK: sil_global @{{_ZN16WithStaticMember12staticMemberE|\?staticMember@WithStaticMember@@2HA}} : $Int32
+// CHECK: // clang name: WithIncompleteStaticMember::selfMember
 // CHECK: sil_global @{{_ZN26WithIncompleteStaticMember10selfMemberE|\?selfMember@WithIncompleteStaticMember@@2V1@A}} : $WithIncompleteStaticMember
+// CHECK: // clang name: WithConstStaticMember::defined
 // CHECK: sil_global [let] @{{_ZN21WithConstStaticMember7definedE|\?defined@WithConstStaticMember@@2HB}} : $Int32
+// CHECK: // clang name: WithConstStaticMember::definedOutOfLine
 // CHECK: sil_global [let] @{{_ZN21WithConstStaticMember16definedOutOfLineE|\?definedOutOfLine@WithConstStaticMember@@2HB}} : $Int32
+// CHECK: // clang name: WithConstexprStaticMember::definedInline
 // CHECK: sil_global [let] @{{_ZN25WithConstexprStaticMember13definedInlineE|\?definedInline@WithConstexprStaticMember@@2HB}} : $Int32
 
 import StaticMemberVar

--- a/test/Interop/Cxx/static/static-var-silgen.swift
+++ b/test/Interop/Cxx/static/static-var-silgen.swift
@@ -8,15 +8,25 @@ func initStaticVars() -> CInt {
     + staticConstexprNonTrivial.val
 }
 
+// CHECK: // clang name: staticVar
 // CHECK: sil_global @staticVar : $Int32
+// CHECK: // clang name: staticVarInit
 // CHECK: sil_global @staticVarInit : $Int32
+// CHECK: // clang name: staticVarInlineInit
 // CHECK: sil_global @staticVarInlineInit : $Int32
+// CHECK: // clang name: staticConst
 // CHECK: sil_global [let] @staticConst : $Int32
+// CHECK: // clang name: staticConstInit
 // CHECK: sil_global [let] @staticConstInit : $Int32
+// CHECK: // clang name: staticConstInlineInit
 // CHECK: sil_global [let] @staticConstInlineInit : $Int32
+// CHECK: // clang name: staticConstexpr
 // CHECK: sil_global [let] @staticConstexpr : $Int32
+// CHECK: // clang name: staticNonTrivial
 // CHECK: sil_global @staticNonTrivial : $NonTrivial
+// CHECK: // clang name: staticConstNonTrivial
 // CHECK: sil_global [let] @staticConstNonTrivial : $NonTrivial
+// CHECK: // clang name: staticConstexprNonTrivial
 // CHECK: sil_global [let] @staticConstexprNonTrivial : $NonTrivial
 
 func readStaticVar() -> CInt {


### PR DESCRIPTION
This PR adds to the SIL output C++ demangled name for static member variables and global variables similarly to how it's already done for C++ functions.