### PR TITLE
[NFC] Add a regression test for SR-12432

### DIFF
--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -49,6 +49,13 @@ func testFunc() {
   let _: (S) -> Int = f // expected-error {{cannot convert value of type 'KeyPath<S, Int>' to specified type '(S) -> Int'}}
 }
 
+struct SR_12432 {
+  static func takesKeyPath(_: KeyPath<SR_12432.S, String>) -> String { "" }
+
+  struct S {
+    let text: String = takesKeyPath(\.text) // okay
+  }
+}
 
 // SR-11234
 public extension Array {


### PR DESCRIPTION
This key path bug was fixed somewhat recently - this PR just adds a regression test. 

Resolves: rdar://problem/59590959
Resolves: [SR-12432](https://bugs.swift.org/browse/SR-12432)