### PR TITLE
[5.3][CSApply] Fix a case where CSApply produced an invalid DeclRefExpr

### DIFF
--- a/test/Constraints/Inputs/imported_type.h
+++ b/test/Constraints/Inputs/imported_type.h
@@ -1,0 +1,4 @@
+#import <Foundation/Foundation.h>
+
+@interface Data
+@end

--- a/test/Constraints/invalid_decl_ref.swift
+++ b/test/Constraints/invalid_decl_ref.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -module-name SomeModule -typecheck -verify -dump-ast -import-objc-header %S/Inputs/imported_type.h %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+// CHECK: declref_expr type='module<SomeModule>'
+// CHECK-NEXT: type_expr type='Data.Type'
+let type = SomeModule.Data.self


### PR DESCRIPTION
Cherry-picked from https://github.com/apple/swift/pull/31398
Reviewed by @xedin 

---
When re-writing an UnresolvedDotExpr to a resolved member reference, check if the member is a type reference and build a TypeExpr before checking if the base is a module and building a simple DeclRefExpr. Otherwise, CSApply could produce invalid DeclRefExprs for a type reference, which will crash later on in SILGen.

Resolves: rdar://problem/61450069