### PR TITLE
[5.3] [Typechecker] Allow property observers on lazy variables

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2943,8 +2943,6 @@ ERROR(lazy_requires_single_var,none,
 
 ERROR(lazy_must_be_property,none,
       "lazy is only valid for members of a struct or class", ())
-ERROR(lazy_not_observable,none,
-      "lazy properties must not have observers", ())
 ERROR(lazy_not_strong,none,
       "lazy properties cannot be %0", (ReferenceOwnership))
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1494,6 +1494,7 @@ static std::pair<BraceStmt *, bool>
 synthesizeObservedSetterBody(AccessorDecl *Set, TargetImpl target,
                              ASTContext &Ctx) {
   auto VD = cast<VarDecl>(Set->getStorage());
+  bool isLazy = !VD->isStatic() && VD->getAttrs().hasAttribute<LazyAttr>();
 
   SourceLoc Loc = VD->getLoc();
 
@@ -1559,10 +1560,9 @@ synthesizeObservedSetterBody(AccessorDecl *Set, TargetImpl target,
     // parameter or it's provided explicitly in the parameter list.
     if (!didSet->isSimpleDidSet()) {
       Expr *OldValueExpr =
-          buildStorageReference(Set, VD, target,
+          buildStorageReference(Set, VD, isLazy ? TargetImpl::Ordinary : target,
                                 /*isUsedForGetAccess=*/true,
-                                /*isUsedForSetAccess=*/true,
-                                Ctx);
+                                /*isUsedForSetAccess=*/true, Ctx);
 
       // Error recovery.
       if (OldValueExpr == nullptr) {
@@ -1590,8 +1590,9 @@ synthesizeObservedSetterBody(AccessorDecl *Set, TargetImpl target,
   // Create an assignment into the storage or call to superclass setter.
   auto *ValueDRE = new (Ctx) DeclRefExpr(ValueDecl, DeclNameLoc(), true);
   ValueDRE->setType(ValueDecl->getType());
-  createPropertyStoreOrCallSuperclassSetter(Set, ValueDRE, VD, target,
-                                            SetterBody, Ctx);
+  createPropertyStoreOrCallSuperclassSetter(
+      Set, ValueDRE, isLazy ? VD->getLazyStorageProperty() : VD, target,
+      SetterBody, Ctx);
 
   if (auto didSet = VD->getParsedAccessor(AccessorKind::DidSet))
     callObserver(didSet, OldValue);
@@ -1619,6 +1620,9 @@ synthesizeSetterBody(AccessorDecl *setter, ASTContext &ctx) {
   if (auto var = dyn_cast<VarDecl>(storage)) {
     if (var->getAttrs().hasAttribute<LazyAttr>()) {
       // Lazy property setters write to the underlying storage.
+      if (var->hasObservers()) {
+        return synthesizeObservedSetterBody(setter, TargetImpl::Storage, ctx);
+      }
       auto *storage = var->getLazyStorageProperty();
       return synthesizeTrivialSetterBodyWithStorage(setter, TargetImpl::Storage,
                                                     storage, ctx);
@@ -2791,11 +2795,10 @@ static void finishLazyVariableImplInfo(VarDecl *var,
   }
 
   // Lazy properties must be written as stored properties in the source.
-  if (!info.isSimpleStored()) {
-    diagnoseAndRemoveAttr(var, attr,
-                          info.hasStorage()
-                          ? diag::lazy_not_observable
-                          : diag::lazy_not_on_computed);
+  if (info.getReadImpl() != ReadImplKind::Stored &&
+      (info.getWriteImpl() != WriteImplKind::Stored &&
+       info.getWriteImpl() != WriteImplKind::StoredWithObservers)) {
+    diagnoseAndRemoveAttr(var, attr, diag::lazy_not_on_computed);
     invalid = true;
   }
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1492,9 +1492,8 @@ static Expr *maybeWrapInOutExpr(Expr *expr, ASTContext &ctx) {
 /// setter which calls them.
 static std::pair<BraceStmt *, bool>
 synthesizeObservedSetterBody(AccessorDecl *Set, TargetImpl target,
-                             ASTContext &Ctx) {
+                             ASTContext &Ctx, bool isLazy = false) {
   auto VD = cast<VarDecl>(Set->getStorage());
-  bool isLazy = !VD->isStatic() && VD->getAttrs().hasAttribute<LazyAttr>();
 
   SourceLoc Loc = VD->getLoc();
 
@@ -1621,7 +1620,8 @@ synthesizeSetterBody(AccessorDecl *setter, ASTContext &ctx) {
     if (var->getAttrs().hasAttribute<LazyAttr>()) {
       // Lazy property setters write to the underlying storage.
       if (var->hasObservers()) {
-        return synthesizeObservedSetterBody(setter, TargetImpl::Storage, ctx);
+        return synthesizeObservedSetterBody(setter, TargetImpl::Storage, ctx,
+                                            /*isLazy=*/true);
       }
       auto *storage = var->getLazyStorageProperty();
       return synthesizeTrivialSetterBodyWithStorage(setter, TargetImpl::Storage,

--- a/test/SILGen/lazy_property_with_observers.swift
+++ b/test/SILGen/lazy_property_with_observers.swift
@@ -24,6 +24,15 @@ class Foo {
   }
 }
 
+struct Foo1 {
+  lazy var bar = 1 {
+    didSet(oldValue) {}
+  }
+}
+
+var foo1 = Foo1()
+foo1.bar = 2
+
 // Setter which calls willSet and didSet (which fetches the oldValue) //
 
 // CHECK-LABEL: sil hidden [ossa] @$s28lazy_property_with_observers3FooC3barSivs : $@convention(method) (Int, @guaranteed Foo) -> () {
@@ -122,6 +131,32 @@ class Foo {
 // CHECK-NEXT:  [[BEGIN_ACCESS:%.*]] = begin_access [modify] [dynamic] [[REF_ELEM]] : $*Optional<Int>
 // CHECK-NEXT:  assign [[ENUM]] to [[BEGIN_ACCESS]] : $*Optional<Int>
 // CHECK-NEXT:  end_access [[BEGIN_ACCESS]] : $*Optional<Int>
+// CHECK-NEXT:  [[TUPLE:%.*]] = tuple ()
+// CHECK-NEXT:  return [[TUPLE]] : $()
+// CHECK-END: }
+
+// Setter which calls a didSet (which fetches the oldValue) and uses a mutating getter
+
+// CHECK-LABEL: sil hidden [ossa] @$s28lazy_property_with_observers4Foo1V3barSivs : $@convention(method) (Int, @inout Foo1) -> () {
+// CHECK: bb0([[VALUE:%.*]] : $Int, [[FOO1:%.*]] : $*Foo1):
+// CHECK-NEXT:  debug_value [[VALUE]] : $Int, let, name "value", argno 1
+// CHECK-NEXT:  debug_value_addr [[FOO1]] : $*Foo1, var, name "self", argno 2
+// CHECK-NEXT:  [[BEGIN_ACCESS:%.*]] = begin_access [modify] [unknown] %1 : $*Foo1
+// CHECK-NEXT: // function_ref Foo1.bar.getter
+// CHECK-NEXT:  [[GETTER:%.*]] = function_ref @$s28lazy_property_with_observers4Foo1V3barSivg : $@convention(method) (@inout Foo1) -> Int
+// CHECK-NEXT:  [[OLDVALUE:%.*]] = apply [[GETTER]]([[BEGIN_ACCESS]]) : $@convention(method) (@inout Foo1) -> Int
+// CHECK-NEXT:  debug_value [[OLDVALUE]] : $Int, let, name "tmp"
+// CHECK-NEXT:  end_access [[BEGIN_ACCESS]] : $*Foo1
+// CHECK-NEXT:  [[ENUM:%.*]] = enum $Optional<Int>, #Optional.some!enumelt, [[VALUE]] : $Int
+// CHECK-NEXT:  [[BEGIN_ACCESS:%.*]] = begin_access [modify] [unknown] [[FOO1]] : $*Foo1
+// CHECK-NEXT:  [[REF_ELEM:%.*]] = struct_element_addr [[BEGIN_ACCESS]] : $*Foo1, #Foo1.$__lazy_storage_$_bar
+// CHECK-NEXT:  assign [[ENUM]] to [[REF_ELEM]] : $*Optional<Int>
+// CHECK-NEXT:  end_access [[BEGIN_ACCESS]] : $*Foo1
+// CHECK-NEXT:  [[BEGIN_ACCESS:%.*]] = begin_access [modify] [unknown] [[FOO1]] : $*Foo1
+// CHECK-NEXT:  // function_ref Foo1.bar.didset
+// CHECK-NEXT:  [[DIDSET:%.*]] = function_ref @$s28lazy_property_with_observers4Foo1V3barSivW : $@convention(method) (Int, @inout Foo1) -> ()
+// CHECK-NEXT:  [[DIDSET_RESULT:%.*]] = apply [[DIDSET]]([[OLDVALUE]], [[BEGIN_ACCESS]]) : $@convention(method) (Int, @inout Foo1) -> ()
+// CHECK-NEXT:  end_access [[BEGIN_ACCESS]] : $*Foo1
 // CHECK-NEXT:  [[TUPLE:%.*]] = tuple ()
 // CHECK-NEXT:  return [[TUPLE]] : $()
 // CHECK-END: }

--- a/test/SILGen/lazy_property_with_observers.swift
+++ b/test/SILGen/lazy_property_with_observers.swift
@@ -2,22 +2,34 @@
 
 class Foo {
   lazy var bar: Int = 0 {
-    didSet { print(oldValue) }
-    willSet { print(newValue) }
+    didSet(oldValue) {}
+    willSet {}
   }
 
   lazy var baz: Int = 0 {
-    didSet { }
-    willSet { print(newValue) }
+    didSet {}
+    willSet {}
+  }
+
+  lazy var observable1: Int = 0 {
+    didSet(oldValue) {}
+  }
+
+  lazy var observable2: Int = 0 {
+    didSet {}
+  }
+
+  lazy var observable3: Int = 0 {
+    willSet {}
   }
 }
 
-// Foo.bar.setter
+// Setter which calls willSet and didSet (which fetches the oldValue) //
 
 // CHECK-LABEL: sil hidden [ossa] @$s28lazy_property_with_observers3FooC3barSivs : $@convention(method) (Int, @guaranteed Foo) -> () {
 // CHECK: bb0([[VALUE:%.*]] : $Int, [[FOO:%.*]] : @guaranteed $Foo):
-// CHECK-NEXT:  debug_value [[VALUE]] : $Int, let, name "value", argno 1 // id: %2
-// CHECK-NEXT:  debug_value [[FOO]] : $Foo, let, name "self", argno 2 // id: %3
+// CHECK-NEXT:  debug_value [[VALUE]] : $Int, let, name "value", argno 1
+// CHECK-NEXT:  debug_value [[FOO]] : $Foo, let, name "self", argno 2 
 // CHECK-NEXT:  [[GETTER:%.*]] = class_method [[FOO]] : $Foo, #Foo.bar!getter : (Foo) -> () -> Int, $@convention(method) (@guaranteed Foo) -> Int
 // CHECK-NEXT:  [[OLDVALUE:%.*]] = apply [[GETTER]]([[FOO]]) : $@convention(method) (@guaranteed Foo) -> Int
 // CHECK-NEXT:  debug_value [[OLDVALUE]] : $Int, let, name "tmp"
@@ -36,7 +48,7 @@ class Foo {
 // CHECK-NEXT:  return [[TUPLE]] : $()
 // CHECK-END: }
 
-// Foo.baz.setter
+// Setter which calls willSet and simple didSet (which doesn't fetch the oldValue) //
 
 // CHECK-LABEL: sil hidden [ossa] @$s28lazy_property_with_observers3FooC3bazSivs : $@convention(method) (Int, @guaranteed Foo) -> () {
 // CHECK: bb0([[VALUE:%.*]] : $Int, [[FOO:%.*]] : @guaranteed $Foo):
@@ -53,6 +65,63 @@ class Foo {
 // CHECK-NEXT:  // function_ref Foo.baz.didset
 // CHECK-NEXT:  [[DIDSET:%.*]] = function_ref @$s28lazy_property_with_observers3FooC3bazSivW : $@convention(method) (@guaranteed Foo) -> ()
 // CHECK-NEXT:  [[DIDSET_RESULT:%.*]] = apply [[DIDSET]]([[FOO]]) : $@convention(method) (@guaranteed Foo) -> ()
+// CHECK-NEXT:  [[TUPLE:%.*]] = tuple ()
+// CHECK-NEXT:  return [[TUPLE]] : $()
+// CHECK-END: }
+
+// Setter which calls didSet (which fetches oldValue) only //
+
+// CHECK-LABEL: sil hidden [ossa] @$s28lazy_property_with_observers3FooC11observable1Sivs : $@convention(method) (Int, @guaranteed Foo) -> () {
+// CHECK: bb0([[VALUE:%.*]] : $Int, [[FOO:%.*]] : @guaranteed $Foo):
+// CHECK-NEXT:  debug_value [[VALUE]] : $Int, let, name "value", argno 1
+// CHECK-NEXT:  debug_value [[FOO]] : $Foo, let, name "self", argno 2 
+// CHECK-NEXT:  [[GETTER:%.*]] = class_method [[FOO]] : $Foo, #Foo.observable1!getter : (Foo) -> () -> Int, $@convention(method) (@guaranteed Foo) -> Int
+// CHECK-NEXT:  [[OLDVALUE:%.*]] = apply [[GETTER]]([[FOO]]) : $@convention(method) (@guaranteed Foo) -> Int
+// CHECK-NEXT:  debug_value [[OLDVALUE]] : $Int, let, name "tmp"
+// CHECK-NEXT:  [[ENUM:%.*]] = enum $Optional<Int>, #Optional.some!enumelt, [[VALUE]] : $Int
+// CHECK-NEXT:  [[REF_ELEM:%.*]] = ref_element_addr [[FOO]] : $Foo, #Foo.$__lazy_storage_$_observable1
+// CHECK-NEXT:  [[BEGIN_ACCESS:%.*]] = begin_access [modify] [dynamic] [[REF_ELEM]] : $*Optional<Int>
+// CHECK-NEXT:  assign [[ENUM]] to [[BEGIN_ACCESS]] : $*Optional<Int>
+// CHECK-NEXT:  end_access [[BEGIN_ACCESS]] : $*Optional<Int>
+// CHECK-NEXT:  // function_ref Foo.observable1.didset
+// CHECK-NEXT:  [[DIDSET:%.*]] = function_ref @$s28lazy_property_with_observers3FooC11observable1SivW : $@convention(method) (Int, @guaranteed Foo) -> ()
+// CHECK-NEXT:  [[DIDSET_RESULT:%.*]] = apply [[DIDSET]]([[OLDVALUE]], [[FOO]]) : $@convention(method) (Int, @guaranteed Foo) -> ()
+// CHECK-NEXT:  [[TUPLE:%.*]] = tuple ()
+// CHECK-NEXT:  return [[TUPLE]] : $()
+// CHECK-END: }
+
+// Setter which calls simple didSet (which doesn't fetch the oldValue) only //
+
+// CHECK-LABEL: sil hidden [ossa] @$s28lazy_property_with_observers3FooC11observable2Sivs : $@convention(method) (Int, @guaranteed Foo) -> () {
+// CHECK: bb0([[VALUE:%.*]] : $Int, [[FOO:%.*]] : @guaranteed $Foo):
+// CHECK-NEXT:  debug_value [[VALUE]] : $Int, let, name "value", argno 1
+// CHECK-NEXT:  debug_value [[FOO]] : $Foo, let, name "self", argno 2
+// CHECK-NEXT:  [[ENUM:%.*]] = enum $Optional<Int>, #Optional.some!enumelt, [[VALUE]] : $Int
+// CHECK-NEXT:  [[REF_ELEM:%.*]] = ref_element_addr [[FOO]] : $Foo, #Foo.$__lazy_storage_$_observable2
+// CHECK-NEXT:  [[BEGIN_ACCESS:%.*]] = begin_access [modify] [dynamic] [[REF_ELEM]] : $*Optional<Int>
+// CHECK-NEXT:  assign [[ENUM]] to [[BEGIN_ACCESS]] : $*Optional<Int>
+// CHECK-NEXT:  end_access [[BEGIN_ACCESS]] : $*Optional<Int>
+// CHECK-NEXT:  // function_ref Foo.observable2.didset
+// CHECK-NEXT:  [[DIDSET:%.*]] = function_ref @$s28lazy_property_with_observers3FooC11observable2SivW : $@convention(method) (@guaranteed Foo) -> ()
+// CHECK-NEXT:  [[DIDSET_RESULT:%.*]] = apply [[DIDSET]]([[FOO]]) : $@convention(method) (@guaranteed Foo) -> ()
+// CHECK-NEXT:  [[TUPLE:%.*]] = tuple ()
+// CHECK-NEXT:  return [[TUPLE]] : $()
+// CHECK-END: }
+
+// Setter which calls willSet only //
+
+// CHECK-LABEL: sil hidden [ossa] @$s28lazy_property_with_observers3FooC11observable3Sivs : $@convention(method) (Int, @guaranteed Foo) -> () {
+// CHECK: bb0([[VALUE:%.*]] : $Int, [[FOO:%.*]] : @guaranteed $Foo):
+// CHECK-NEXT:  debug_value [[VALUE]] : $Int, let, name "value", argno 1
+// CHECK-NEXT:  debug_value [[FOO]] : $Foo, let, name "self", argno 2
+// CHECK-NEXT:  // function_ref Foo.observable3.willset
+// CHECK-NEXT:  [[WILLSET:%.*]] = function_ref @$s28lazy_property_with_observers3FooC11observable3Sivw : $@convention(method) (Int, @guaranteed Foo) -> ()
+// CHECK-NEXT:  [[WILLSET_RESULT:%.*]] = apply [[WILLSET]]([[VALUE]], [[FOO]]) : $@convention(method) (Int, @guaranteed Foo) -> ()
+// CHECK-NEXT:  [[ENUM:%.*]] = enum $Optional<Int>, #Optional.some!enumelt, [[VALUE]] : $Int
+// CHECK-NEXT:  [[REF_ELEM:%.*]] = ref_element_addr [[FOO]] : $Foo, #Foo.$__lazy_storage_$_observable3
+// CHECK-NEXT:  [[BEGIN_ACCESS:%.*]] = begin_access [modify] [dynamic] [[REF_ELEM]] : $*Optional<Int>
+// CHECK-NEXT:  assign [[ENUM]] to [[BEGIN_ACCESS]] : $*Optional<Int>
+// CHECK-NEXT:  end_access [[BEGIN_ACCESS]] : $*Optional<Int>
 // CHECK-NEXT:  [[TUPLE:%.*]] = tuple ()
 // CHECK-NEXT:  return [[TUPLE]] : $()
 // CHECK-END: }

--- a/test/SILGen/lazy_property_with_observers.swift
+++ b/test/SILGen/lazy_property_with_observers.swift
@@ -1,0 +1,58 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+class Foo {
+  lazy var bar: Int = 0 {
+    didSet { print(oldValue) }
+    willSet { print(newValue) }
+  }
+
+  lazy var baz: Int = 0 {
+    didSet { }
+    willSet { print(newValue) }
+  }
+}
+
+// Foo.bar.setter
+
+// CHECK-LABEL: sil hidden [ossa] @$s28lazy_property_with_observers3FooC3barSivs : $@convention(method) (Int, @guaranteed Foo) -> () {
+// CHECK: bb0([[VALUE:%.*]] : $Int, [[FOO:%.*]] : @guaranteed $Foo):
+// CHECK-NEXT:  debug_value [[VALUE]] : $Int, let, name "value", argno 1 // id: %2
+// CHECK-NEXT:  debug_value [[FOO]] : $Foo, let, name "self", argno 2 // id: %3
+// CHECK-NEXT:  [[GETTER:%.*]] = class_method [[FOO]] : $Foo, #Foo.bar!getter : (Foo) -> () -> Int, $@convention(method) (@guaranteed Foo) -> Int
+// CHECK-NEXT:  [[OLDVALUE:%.*]] = apply [[GETTER]]([[FOO]]) : $@convention(method) (@guaranteed Foo) -> Int
+// CHECK-NEXT:  debug_value [[OLDVALUE]] : $Int, let, name "tmp"
+// CHECK-NEXT:  // function_ref Foo.bar.willset
+// CHECK-NEXT:  [[WILLSET:%.*]] = function_ref @$s28lazy_property_with_observers3FooC3barSivw : $@convention(method) (Int, @guaranteed Foo) -> ()
+// CHECK-NEXT:  [[WILLSET_RESULT:%.*]] = apply [[WILLSET]]([[VALUE]], [[FOO]]) : $@convention(method) (Int, @guaranteed Foo) -> ()
+// CHECK-NEXT:  [[ENUM:%.*]] = enum $Optional<Int>, #Optional.some!enumelt, [[VALUE]] : $Int
+// CHECK-NEXT:  [[REF_ELEM:%.*]] = ref_element_addr [[FOO]] : $Foo, #Foo.$__lazy_storage_$_bar
+// CHECK-NEXT:  [[BEGIN_ACCESS:%.*]] = begin_access [modify] [dynamic] [[REF_ELEM]] : $*Optional<Int>
+// CHECK-NEXT:  assign [[ENUM]] to [[BEGIN_ACCESS]] : $*Optional<Int>
+// CHECK-NEXT:  end_access [[BEGIN_ACCESS]] : $*Optional<Int>
+// CHECK-NEXT:  // function_ref Foo.bar.didset
+// CHECK-NEXT:  [[DIDSET:%.*]] = function_ref @$s28lazy_property_with_observers3FooC3barSivW : $@convention(method) (Int, @guaranteed Foo) -> ()
+// CHECK-NEXT:  [[DIDSET_RESULT:%.*]] = apply [[DIDSET]]([[OLDVALUE]], [[FOO]]) : $@convention(method) (Int, @guaranteed Foo) -> ()
+// CHECK-NEXT:  [[TUPLE:%.*]] = tuple ()
+// CHECK-NEXT:  return [[TUPLE]] : $()
+// CHECK-END: }
+
+// Foo.baz.setter
+
+// CHECK-LABEL: sil hidden [ossa] @$s28lazy_property_with_observers3FooC3bazSivs : $@convention(method) (Int, @guaranteed Foo) -> () {
+// CHECK: bb0([[VALUE:%.*]] : $Int, [[FOO:%.*]] : @guaranteed $Foo):
+// CHECK-NEXT:  debug_value [[VALUE]] : $Int, let, name "value", argno 1
+// CHECK-NEXT:  debug_value [[FOO]] : $Foo, let, name "self", argno 2
+// CHECK-NEXT:  // function_ref Foo.baz.willset
+// CHECK-NEXT:  [[WILLSET:%.*]] = function_ref @$s28lazy_property_with_observers3FooC3bazSivw : $@convention(method) (Int, @guaranteed Foo) -> ()
+// CHECK-NEXT:  [[WILLSET_RESULT:%.*]] = apply [[WILLSET]]([[VALUE]], [[FOO]]) : $@convention(method) (Int, @guaranteed Foo) -> ()
+// CHECK-NEXT:  [[ENUM:%.*]] = enum $Optional<Int>, #Optional.some!enumelt, [[VALUE]] : $Int
+// CHECK-NEXT:  [[REF_ELEM:%.*]] = ref_element_addr [[FOO]] : $Foo, #Foo.$__lazy_storage_$_baz
+// CHECK-NEXT:  [[BEGIN_ACCESS:%.*]] = begin_access [modify] [dynamic] [[REF_ELEM]] : $*Optional<Int>
+// CHECK-NEXT:  assign [[ENUM]] to [[BEGIN_ACCESS]] : $*Optional<Int>
+// CHECK-NEXT:  end_access [[BEGIN_ACCESS]] : $*Optional<Int>
+// CHECK-NEXT:  // function_ref Foo.baz.didset
+// CHECK-NEXT:  [[DIDSET:%.*]] = function_ref @$s28lazy_property_with_observers3FooC3bazSivW : $@convention(method) (@guaranteed Foo) -> ()
+// CHECK-NEXT:  [[DIDSET_RESULT:%.*]] = apply [[DIDSET]]([[FOO]]) : $@convention(method) (@guaranteed Foo) -> ()
+// CHECK-NEXT:  [[TUPLE:%.*]] = tuple ()
+// CHECK-NEXT:  return [[TUPLE]] : $()
+// CHECK-END: }

--- a/test/decl/var/lazy_properties.swift
+++ b/test/decl/var/lazy_properties.swift
@@ -41,9 +41,9 @@ class TestClass {
 
   lazy var k : Int = { () -> Int in return 0 }()+1  // multi-stmt closure
 
-  lazy var l : Int = 42 {  // expected-error {{lazy properties must not have observers}} {{3-8=}}
-    didSet {
-    }
+  lazy var l : Int = 42 {  // Okay
+    didSet {}
+    willSet {}
   }
 
   init() {

--- a/test/decl/var/lazy_properties.swift
+++ b/test/decl/var/lazy_properties.swift
@@ -46,6 +46,14 @@ class TestClass {
     willSet {}
   }
 
+  lazy var m : Int = 42 { // Okay
+    didSet {}
+  }
+
+  lazy var n : Int = 42 {
+    willSet {} // Okay
+  }
+
   init() {
     lazy var localvar = 42  // expected-error {{lazy is only valid for members of a struct or class}} {{5-10=}}
     localvar += 1


### PR DESCRIPTION
Cherry pick of #31097.

**Explanation**: Lifts an existing restriction and allows `lazy` stored properties to have observers i.e. `didSet`/`willSet` as well, just like regular stored properties.

**Scope**: Affects use of lazy properties

**SR Issue**: SR-7083

**Risk**: Low. This allows code that previously did not compile to now compile and work successfully.

**Testing**: Added typechecker and SILGen tests which pass on Swift CI.

