### PR TITLE
[build] set CMAKE_OSX_ARCHITECTURES in swift_cmake_options

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -621,6 +621,9 @@ function set_build_options_for_host() {
                 -DSWIFT_DARWIN_DEPLOYMENT_VERSION_TVOS="${DARWIN_DEPLOYMENT_VERSION_TVOS}"
                 -DSWIFT_DARWIN_DEPLOYMENT_VERSION_WATCHOS="${DARWIN_DEPLOYMENT_VERSION_WATCHOS}"
                 -DCMAKE_OSX_SYSROOT:PATH="${cmake_os_sysroot}"
+                # This is needed to make sure to avoid using the wrong architecture
+                # in the compiler checks CMake performs
+                -DCMAKE_OSX_ARCHITECTURES="${architecture}"
             )
             ;;
     esac


### PR DESCRIPTION
This augments #31023 to make sure CMake invokes the compiler checks
correctly -- this is needed to avoid errors in certain
configurations.

Addresses rdar://62339814