### PR TITLE
[5.3][ConstraintSystem] Don't attempt property wrapper fixes for key path …

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2603,6 +2603,11 @@ static ConstraintFix *fixPropertyWrapperFailure(
     ConstraintSystem &cs, Type baseTy, ConstraintLocator *locator,
     llvm::function_ref<bool(SelectedOverload, VarDecl *, Type)> attemptFix,
     Optional<Type> toType = None) {
+  // Don't attempt this fix if this is a key path dynamic member
+  // lookup which produced no results. Unwrapping or wrapping
+  // the base type is not going to produce desired results.
+  if (locator->isForKeyPathDynamicMemberLookup())
+    return nullptr;
 
   Expr *baseExpr = nullptr;
   if (auto *anchor = locator->getAnchor()) {

--- a/test/Constraints/sr12520.swift
+++ b/test/Constraints/sr12520.swift
@@ -1,0 +1,38 @@
+// RUN: %target-typecheck-verify-swift
+
+@propertyWrapper
+@dynamicMemberLookup
+struct Binding<Value> {
+  var wrappedValue: Value
+
+  subscript<Subject>(dynamicMember keyPath: WritableKeyPath<Value, Subject>) -> Binding<Subject> {
+    get { fatalError() }
+  }
+}
+
+@propertyWrapper
+struct Wrapper<Value> {
+  var wrappedValue: Value
+  var projectedValue: Binding<Value>
+}
+
+@dynamicMemberLookup class Foo {
+  struct State {
+    let value: Bool
+  }
+
+  let currentState: State = State(value: false)
+
+  subscript<U>(dynamicMember keyPath: KeyPath<State, U>) -> U {
+    return currentState[keyPath: keyPath]
+  }
+}
+
+struct Test {
+  @Wrapper var foo: Foo
+
+  func test() {
+    if foo.bar { // expected-error {{value of type 'Foo' has no dynamic member 'bar' using key path from root type 'Foo.State'}}
+    }
+  }
+}


### PR DESCRIPTION
…dynamic member lookup

If this is an attempt to fetch members through key path dynamic member lookup
let's not try to apply any property wrapper related fixes because modifying
base type would not change the result.

Reviewed By: @hborla 

Resolves: [SR-12520](https://bugs.swift.org/browse/SR-12520)
Resolves: rdar://problem/61911108
(cherry picked from commit 6bdd534a9cdf31318d8166b7b6e8e99d24485756)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
