### PR TITLE
[NFC] Remove Needless Double-Import of Decls

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3157,13 +3157,8 @@ void ClangModuleUnit::lookupObjCMethods(
       (void)owner.importDecl(objcMethod->findPropertyDecl(true),
                              owner.CurrentVersion);
 
-    // Import it.
-    // FIXME: Retrying a failed import works around recursion bugs in the Clang
-    // importer.
     auto imported =
         owner.importDecl(objcMethod, owner.CurrentVersion);
-    if (!imported)
-      imported = owner.importDecl(objcMethod, owner.CurrentVersion);
     if (!imported) continue;
 
     if (auto func = dyn_cast<AbstractFunctionDecl>(imported))


### PR DESCRIPTION
Requestification addressed the bulk of the issues with the re-entrant
Clang Importer. Flush a hack that depended on that old state of affairs.

rdar://60111478