### PR TITLE
[5.3] [metadata prespecialization] Zero trailing flags field.

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -3373,6 +3373,7 @@ public:
   /// class metadata.
   ///
   /// See also: [pre-5.2-extra-data-zeroing]
+  /// See also: [pre-5.3-extra-data-zeroing]
   const GenericMetadataPartialPattern *getExtraDataPattern() const {
     assert(asSelf()->hasExtraDataPattern());
     return this->template getTrailingObjects<GenericMetadataPartialPattern>();

--- a/lib/IRGen/ConstantBuilder.h
+++ b/lib/IRGen/ConstantBuilder.h
@@ -77,6 +77,8 @@ public:
     addInt(IGM().Int32Ty, value);
   }
 
+  void addInt64(uint64_t value) { addInt(IGM().Int64Ty, value); }
+
   void addRelativeAddressOrNull(llvm::Constant *target) {
     if (target) {
       addRelativeAddress(target);

--- a/lib/IRGen/ConstantBuilder.h
+++ b/lib/IRGen/ConstantBuilder.h
@@ -79,6 +79,8 @@ public:
 
   void addInt64(uint64_t value) { addInt(IGM().Int64Ty, value); }
 
+  void addSize(Size size) { addInt(IGM().SizeTy, size.getValue()); }
+
   void addRelativeAddressOrNull(llvm::Constant *target) {
     if (target) {
       addRelativeAddress(target);

--- a/lib/IRGen/EnumMetadataVisitor.h
+++ b/lib/IRGen/EnumMetadataVisitor.h
@@ -94,12 +94,13 @@ public:
   void addGenericWitnessTable(GenericRequirement requirement) { addPointer(); }
   void addPayloadSize() { addPointer(); }
   void noteStartOfTypeSpecificMembers() {}
-  void addTrailingFlags() { addPointer(); }
+  void addTrailingFlags() { addInt64(); }
 
 private:
   void addPointer() {
     NextOffset += super::IGM.getPointerSize();
   }
+  void addInt64() { NextOffset += Size(8); }
 };
 
 } // end namespace irgen

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3731,7 +3731,7 @@ namespace {
     GenericMetadataPatternFlags getPatternFlags() {
       auto flags = super::getPatternFlags();
 
-      if (IGM.shouldPrespecializeGenericMetadata()) {
+      if (hasTrailingFlags()) {
         flags.setHasTrailingFlags(true);
       }
 
@@ -3744,7 +3744,11 @@ namespace {
                                                      HasDependentVWT);
     }
 
-    bool hasExtraDataPattern() {
+    bool hasTrailingFlags() {
+      return IGM.shouldPrespecializeGenericMetadata();
+    }
+
+    bool hasKnownFieldOffsets() {
       auto &ti = IGM.getTypeInfo(getLoweredType());
       if (!isa<FixedTypeInfo>(ti))
         return false;
@@ -3755,19 +3759,31 @@ namespace {
       return true;
     }
 
-    /// Fill in a constant field offset vector if possible.
+    bool hasExtraDataPattern() {
+      return hasKnownFieldOffsets() || hasTrailingFlags();
+    }
+
+    /// If present, the extra data pattern consists of one or both of the
+    /// following:
+    ///
+    /// - the field offset vector
+    /// - the trailing flags
     PartialPattern buildExtraDataPattern() {
       ConstantInitBuilder builder(IGM);
-      auto init = builder.beginArray(IGM.Int32Ty);
+      auto init = builder.beginStruct();
 
       struct Scanner : StructMetadataScanner<Scanner> {
+        GenericStructMetadataBuilder &Outer;
         SILType Type;
-        ConstantArrayBuilder &B;
-        Scanner(IRGenModule &IGM, StructDecl *target, SILType type,
-                ConstantArrayBuilder &B)
-          : StructMetadataScanner(IGM, target), Type(type), B(B) {}
+        ConstantStructBuilder &B;
+        Scanner(GenericStructMetadataBuilder &outer, IRGenModule &IGM, StructDecl *target, SILType type,
+                ConstantStructBuilder &B)
+            : StructMetadataScanner(IGM, target), Outer(outer), Type(type), B(B) {}
 
         void addFieldOffset(VarDecl *field) {
+          if (!Outer.hasKnownFieldOffsets()) {
+            return;
+          }
           auto offset = emitPhysicalStructMemberFixedOffset(IGM, Type, field);
           if (offset) {
             B.add(offset);
@@ -3783,21 +3799,27 @@ namespace {
         void noteEndOfFieldOffsets() {
           B.addAlignmentPadding(IGM.getPointerAlignment());
         }
+
+        void addTrailingFlags() { B.addInt64(0); }
       };
-      Scanner(IGM, Target, getLoweredType(), init).layout();
-      Size vectorSize = init.getNextOffsetFromGlobal();
+      Scanner(*this, IGM, Target, getLoweredType(), init).layout();
+      Size structSize = init.getNextOffsetFromGlobal();
 
       auto global = init.finishAndCreateGlobal("", IGM.getPointerAlignment(),
                                                /*constant*/ true);
 
       auto &layout = IGM.getMetadataLayout(Target);
-      return { global,
-               layout.getFieldOffsetVectorOffset().getStatic()
-                 - IGM.getOffsetOfStructTypeSpecificMetadataMembers(),
-               vectorSize };
-    }
 
-    void addTrailingFlags() { this->B.addInt(IGM.Int64Ty, 0); }
+      bool offsetUpToTrailingFlags = hasTrailingFlags() && !hasKnownFieldOffsets(); 
+      Size zeroingStart = IGM.getOffsetOfStructTypeSpecificMetadataMembers();
+      Offset zeroingEnd = offsetUpToTrailingFlags 
+                            ? layout.getTrailingFlagsOffset()
+                            : layout.getFieldOffsetVectorOffset();
+      return { global,
+               zeroingEnd.getStatic()
+                 - zeroingStart,
+               structSize };
+    }
 
     bool hasCompletionFunction() {
       return !isa<FixedTypeInfo>(IGM.getTypeInfo(getLoweredType()));
@@ -4172,24 +4194,58 @@ namespace {
         descriptor = emitPointerAuthSign(IGF, descriptor, authInfo);
       }
 
-      auto metadata =
+      return
         IGF.Builder.CreateCall(IGM.getAllocateGenericValueMetadataFn(),
                                {descriptor, arguments, templatePointer,
                                 extraSizeV});
+    }
 
-      // Initialize the payload-size field if we have a constant value for it.
-      // This is so small that we just do it inline instead of bothering
-      // with a pattern.
+    bool hasTrailingFlags() {
+      return IGM.shouldPrespecializeGenericMetadata();
+    }
+
+    bool hasKnownPayloadSize() {
+      auto &layout = IGM.getMetadataLayout(Target);
+      return layout.hasPayloadSizeOffset() && (bool)getConstantPayloadSize(IGM, Target);
+    }
+
+    bool hasExtraDataPattern() {
+      return hasKnownPayloadSize() || hasTrailingFlags();
+    }
+
+    /// If present, the extra data pattern consists of one or both of the
+    /// following:
+    ///
+    /// - the payload-size
+    /// - the trailing flags
+    PartialPattern buildExtraDataPattern() {
+      ConstantInitBuilder builder(IGM);
+      auto init = builder.beginStruct();
+
+      auto &layout = IGM.getMetadataLayout(Target);
+
       if (layout.hasPayloadSizeOffset()) {
         if (auto size = getConstantPayloadSize(IGM, Target)) {
-          auto offset = layout.getPayloadSizeOffset();
-          auto slot = IGF.emitAddressAtOffset(metadata, offset, IGM.SizeTy,
-                                              IGM.getPointerAlignment());
-          IGF.Builder.CreateStore(IGM.getSize(*size), slot);
+          init.addSize(*size);
         }
       }
+      if (hasTrailingFlags()) {
+        init.addInt64(0);
+      }
+      Size structSize = init.getNextOffsetFromGlobal();
 
-      return metadata;
+      auto global = init.finishAndCreateGlobal("", IGM.getPointerAlignment(),
+                                               /*constant*/ true);
+
+      bool offsetUpToTrailingFlags = hasTrailingFlags() && !hasKnownPayloadSize(); 
+      Size zeroingStart = IGM.getOffsetOfEnumTypeSpecificMetadataMembers();
+      Offset zeroingEnd = offsetUpToTrailingFlags 
+                            ? layout.getTrailingFlagsOffset()
+                            : layout.getPayloadSizeOffset();
+      return { global,
+               zeroingEnd.getStatic()
+                 - zeroingStart,
+               structSize };
     }
 
     llvm::Constant *emitNominalTypeDescriptor() {
@@ -4199,7 +4255,7 @@ namespace {
     GenericMetadataPatternFlags getPatternFlags() {
       auto flags = super::getPatternFlags();
 
-      if (IGM.shouldPrespecializeGenericMetadata()) {
+      if (hasTrailingFlags()) {
         flags.setHasTrailingFlags(true);
       }
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2317,6 +2317,7 @@ namespace {
       asImpl().layoutHeader();
 
       // See also: [pre-5.2-extra-data-zeroing]
+      // See also: [pre-5.3-extra-data-zeroing]
       if (asImpl().hasExtraDataPattern()) {
         asImpl().addExtraDataPattern();
       }

--- a/lib/IRGen/MetadataLayout.cpp
+++ b/lib/IRGen/MetadataLayout.cpp
@@ -543,6 +543,11 @@ EnumMetadataLayout::EnumMetadataLayout(IRGenModule &IGM, EnumDecl *decl)
       super::noteStartOfGenericRequirements();
     }
 
+    void addTrailingFlags() {
+      Layout.TrailingFlagsOffset = getNextOffset();
+      super::addTrailingFlags();
+    }
+
     void layout() {
       super::layout();
       Layout.TheSize = getMetadataSize();
@@ -556,6 +561,11 @@ Offset
 EnumMetadataLayout::getPayloadSizeOffset() const {
   assert(PayloadSizeOffset.isStatic());
   return Offset(PayloadSizeOffset.getStaticOffset());
+}
+
+Offset EnumMetadataLayout::getTrailingFlagsOffset() const {
+  assert(TrailingFlagsOffset.isStatic());
+  return Offset(TrailingFlagsOffset.getStaticOffset());
 }
 
 /********************************** STRUCTS ***********************************/
@@ -594,6 +604,11 @@ StructMetadataLayout::StructMetadataLayout(IRGenModule &IGM, StructDecl *decl)
       super::noteEndOfFieldOffsets();
     }
 
+    void addTrailingFlags() {
+      Layout.TrailingFlagsOffset = getNextOffset();
+      super::addTrailingFlags();
+    }
+
     void layout() {
       super::layout();
       Layout.TheSize = getMetadataSize();
@@ -620,6 +635,11 @@ StructMetadataLayout::getFieldOffsetVectorOffset() const {
   return Offset(FieldOffsetVector.getStaticOffset());
 }
 
+Offset 
+StructMetadataLayout::getTrailingFlagsOffset() const {
+  assert(TrailingFlagsOffset.isStatic());
+  return Offset(TrailingFlagsOffset.getStaticOffset());
+}
 /****************************** FOREIGN CLASSES *******************************/
 ForeignClassMetadataLayout::ForeignClassMetadataLayout(IRGenModule &IGM,
                                                        ClassDecl *theClass)

--- a/lib/IRGen/MetadataLayout.h
+++ b/lib/IRGen/MetadataLayout.h
@@ -284,6 +284,7 @@ public:
 class EnumMetadataLayout : public NominalMetadataLayout {
   /// The offset of the payload size field, if there is one.
   StoredOffset PayloadSizeOffset;
+  StoredOffset TrailingFlagsOffset;
 
   // TODO: presumably it would be useful to store *something* here
   // for resilience.
@@ -301,6 +302,7 @@ public:
   }
 
   Offset getPayloadSizeOffset() const;
+  Offset getTrailingFlagsOffset() const;
 
   static bool classof(const MetadataLayout *layout) {
     return layout->getKind() == Kind::Enum;
@@ -310,6 +312,7 @@ public:
 /// Layout for struct type metadata.
 class StructMetadataLayout : public NominalMetadataLayout {
   llvm::DenseMap<VarDecl*, StoredOffset> FieldOffsets;
+  StoredOffset TrailingFlagsOffset;
 
   /// The start of the field-offset vector.
   StoredOffset FieldOffsetVector;
@@ -338,6 +341,7 @@ public:
   Size getStaticFieldOffset(VarDecl *field) const;
 
   Offset getFieldOffsetVectorOffset() const;
+  Offset getTrailingFlagsOffset() const;
 
   static bool classof(const MetadataLayout *layout) {
     return layout->getKind() == Kind::Struct;

--- a/lib/IRGen/StructMetadataVisitor.h
+++ b/lib/IRGen/StructMetadataVisitor.h
@@ -104,13 +104,14 @@ public:
     NextOffset = NextOffset.roundUpToAlignment(super::IGM.getPointerAlignment());
   }
 
-  void addTrailingFlags() { addPointer(); }
+  void addTrailingFlags() { addInt64(); }
 
 private:
   void addPointer() {
     NextOffset += super::IGM.getPointerSize();
   }
   void addInt32() { NextOffset += Size(4); }
+  void addInt64() { NextOffset += Size(8); }
 };
 
 } // end namespace irgen

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -663,6 +663,11 @@ swift::swift_allocateGenericValueMetadata(const ValueTypeDescriptor *description
 
   auto bytes = (char*) cache.getAllocator().Allocate(totalSize, alignof(void*));
 
+#ifndef NDEBUG
+  // Fill the metadata record with garbage.
+  memset(bytes, 0xAA, totalSize);
+#endif
+
   auto addressPoint = bytes + sizeof(ValueMetadata::HeaderType);
   auto metadata = reinterpret_cast<ValueMetadata *>(addressPoint);
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -617,7 +617,10 @@ initializeValueMetadataFromPattern(ValueMetadata *metadata,
     auto extraDataPattern = pattern->getExtraDataPattern();
 
     // Zero memory up to the offset.
-    memset(metadataExtraData, 0, size_t(extraDataPattern->OffsetInWords));
+    // [pre-5.3-extra-data-zeroing] Before Swift 5.3, the runtime did not
+    // correctly zero the zero-prefix of the extra-data pattern.
+    memset(metadataExtraData, 0,
+           size_t(extraDataPattern->OffsetInWords) * sizeof(void *));
 
     // Copy the pattern into the rest of the extra data.
     copyMetadataPattern(metadataExtraData, extraDataPattern);

--- a/test/IRGen/enum_future.sil
+++ b/test/IRGen/enum_future.sil
@@ -2660,7 +2660,7 @@ entry(%x : $*MyOptional):
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal %swift.type* @"$s11enum_future16DynamicSingletonOMi"(%swift.type_descriptor* %0, i8** %1, i8* %2) {{.*}} {
 // CHECK:   [[T0:%.*]] = bitcast i8** %1 to %swift.type**
 // CHECK:   [[T:%T]] = load %swift.type*, %swift.type** [[T0]],
-// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata(%swift.type_descriptor* %0, i8** %1, i8* %2, [[WORD]] {{4|8|16}})
+// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata(%swift.type_descriptor* %0, i8** %1, i8* %2, [[WORD]] {{4|8|12|16}})
 // CHECK-NEXT: ret %swift.type* [[METADATA]]
 
 // CHECK-LABEL: define{{( protected)?}} internal swiftcc %swift.metadata_response @"$s11enum_future16DynamicSingletonOMr"

--- a/test/IRGen/enum_value_semantics_future.sil
+++ b/test/IRGen/enum_value_semantics_future.sil
@@ -160,6 +160,8 @@ enum GenericFixedLayout<T> {
 // CHECK-SAME:   {{.*}}* @"$s27enum_value_semantics_future23SinglePayloadNontrivialOMn"
 // CHECK-SAME: }>
 
+// CHECK: @"$s27enum_value_semantics_future18GenericFixedLayoutOWV" = internal constant %swift.enum_vwtable
+// CHECK: [[EXTRA_DATA_PATTERN:@[0-9]+]] = internal constant { i64 } zeroinitializer
 
 // CHECK-LABEL: @"$s27enum_value_semantics_future18GenericFixedLayoutOMn" = hidden constant
 // CHECK-SAME:    [16 x i8*]* @"$s27enum_value_semantics_future18GenericFixedLayoutOMI"
@@ -167,13 +169,15 @@ enum GenericFixedLayout<T> {
 
 // CHECK-LABEL: @"$s27enum_value_semantics_future18GenericFixedLayoutOMP" = internal constant <{ {{.*}} }> <{
 //   Instantiation function.
-// CHECK-SAME:    i32 trunc (i64 sub (i64 ptrtoint (%swift.type* (%swift.type_descriptor*, i8**, i8*)* @"$s27enum_value_semantics_future18GenericFixedLayoutOMi" to i64), i64 ptrtoint (<{ i32, i32, i32, i32 }>* @"$s27enum_value_semantics_future18GenericFixedLayoutOMP" to i64)) to i32),
+// CHECK-SAME:    i32 trunc (i64 sub (i64 ptrtoint (%swift.type* (%swift.type_descriptor*, i8**, i8*)* @"$s27enum_value_semantics_future18GenericFixedLayoutOMi" to i64), i64 ptrtoint (<{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s27enum_value_semantics_future18GenericFixedLayoutOMP" to i64)) to i32),
 //   Completion function.
 // CHECK-SAME:    i32 0,
-//   Pattern flags.  0x4020_0002 == (MetadataKind::Enum << 21 | HasTrailingFlags).
-// CHECK-SAME:    i32 1075838978,
+//   Pattern flags.  0x4020_0003 == (MetadataKind::Enum << 21 | HasTrailingFlags | HasExtraDataPattern).
+// CHECK-SAME:    i32 1075838979,
 //   Value witness table.
-// CHECK-SAME:    i32 trunc (i64 sub (i64 ptrtoint (%swift.enum_vwtable* @"$s27enum_value_semantics_future18GenericFixedLayoutOWV" to i64), i64 ptrtoint (i32* getelementptr inbounds (<{ i32, i32, i32, i32 }>, <{ i32, i32, i32, i32 }>* @"$s27enum_value_semantics_future18GenericFixedLayoutOMP", i32 0, i32 3) to i64)) to i32)
+// CHECK-SAME:    i32 trunc (i64 sub (i64 ptrtoint (%swift.enum_vwtable* @"$s27enum_value_semantics_future18GenericFixedLayoutOWV" to i64), i64 ptrtoint (i32* getelementptr inbounds (<{ i32, i32, i32, i32, i32, i16, i16 }>, <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s27enum_value_semantics_future18GenericFixedLayoutOMP", i32 0, i32 3) to i64)) to i32)
+//   Extra data pattern.
+// CHECK-SAME: i32 trunc (i64 sub (i64 ptrtoint ({ i64 }* [[EXTRA_DATA_PATTERN]] to i64), i64 ptrtoint (i32* getelementptr inbounds (<{ i32, i32, i32, i32, i32, i16, i16 }>, <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s27enum_value_semantics_future18GenericFixedLayoutOMP", i32 0, i32 4) to i64)) to i32)
 // CHECK-SAME:  }>
 
 sil @single_payload_nontrivial_copy_destroy : $(@owned SinglePayloadNontrivial) -> () {

--- a/test/IRGen/generic_structs.sil
+++ b/test/IRGen/generic_structs.sil
@@ -8,7 +8,7 @@ import Builtin
 
 // -- Generic structs with fixed layout should have no completion function
 //    and emit the field offset vector as part of the pattern.
-// CHECK:       [[PATTERN:@.*]] = internal constant [4 x i32] [i32 0, i32 1, i32 8, i32 0]
+// CHECK:       [[PATTERN:@.*]] = internal constant { i32, i32, i32, [4 x i8] } { i32 0, i32 1, i32 8, [4 x i8] zeroinitializer }, align 8
 // CHECK-LABEL: @"$s15generic_structs18FixedLayoutGenericVMP" = internal constant <{ {{.*}} }> <{
 // -- instantiation function
 // CHECK-SAME:   %swift.type* (%swift.type_descriptor*, i8**, i8*)* @"$s15generic_structs18FixedLayoutGenericVMi"
@@ -19,7 +19,7 @@ import Builtin
 // -- vwtable pointer
 // CHECK-SAME:   @"$s15generic_structs18FixedLayoutGenericVWV"
 // -- extra data pattern
-// CHECK-SAME: [4 x i32]* [[PATTERN]]
+// CHECK-SAME: { i32, i32, i32, [4 x i8] }* [[PATTERN]]
 // CHECK-SAME: i16 1,
 // CHECK-SAME: i16 2 }>
 

--- a/test/IRGen/generic_structs_future.sil
+++ b/test/IRGen/generic_structs_future.sil
@@ -9,7 +9,7 @@ import Builtin
 
 // -- Generic structs with fixed layout should have no completion function
 //    and emit the field offset vector as part of the pattern.
-// CHECK:       [[PATTERN:@.*]] = internal constant [4 x i32] [i32 0, i32 1, i32 8, i32 0]
+// CHECK:       [[PATTERN:@.*]] = internal constant { i32, i32, i32, [4 x i8], i64 } { i32 0, i32 1, i32 8, [4 x i8] zeroinitializer, i64 0 }, align 8
 // CHECK-LABEL: @"$s22generic_structs_future18FixedLayoutGenericVMP" = internal constant <{ {{.*}} }> <{
 // -- instantiation function
 // CHECK-SAME:   %swift.type* (%swift.type_descriptor*, i8**, i8*)* @"$s22generic_structs_future18FixedLayoutGenericVMi"
@@ -20,9 +20,9 @@ import Builtin
 // -- vwtable pointer
 // CHECK-SAME:   @"$s22generic_structs_future18FixedLayoutGenericVWV"
 // -- extra data pattern
-// CHECK-SAME: [4 x i32]* [[PATTERN]]
+// CHECK-SAME: { i32, i32, i32, [4 x i8], i64 }* [[PATTERN]]
 // CHECK-SAME: i16 1,
-// CHECK-SAME: i16 2 }>
+// CHECK-SAME: i16 3 }>
 
 // -- Generic structs with dynamic layout contain the vwtable pattern as part
 //    of the metadata pattern, and no independent vwtable symbol

--- a/test/IRGen/prespecialized-metadata/Inputs/enum-extra-data-fields.swift
+++ b/test/IRGen/prespecialized-metadata/Inputs/enum-extra-data-fields.swift
@@ -1,0 +1,18 @@
+public struct First<T> {
+  public let value: Int32
+}
+
+public struct Second {
+  public let value: Int64
+}
+
+@frozen
+public enum FixedPayloadSize<T> {
+  case first(First<T>)
+  case second(Second)
+}
+
+public enum DynamicPayloadSize<T> {
+  case first(First<T>)
+  case second(Second)
+}

--- a/test/IRGen/prespecialized-metadata/Inputs/extraDataFields.cpp
+++ b/test/IRGen/prespecialized-metadata/Inputs/extraDataFields.cpp
@@ -1,0 +1,64 @@
+#include "extraDataFields.h"
+#include <swift/Runtime/Metadata.h>
+
+using namespace swift;
+
+namespace llvm {
+  int DisableABIBreakingChecks;
+  int EnableABIBreakingChecks;
+}
+
+void *completeMetadata(void *uncastMetadata) {
+  auto *metadata = static_cast<Metadata *>(uncastMetadata);
+
+  auto request =
+        MetadataRequest(MetadataState::Complete, /*isNonBlocking*/ false);
+  auto response = swift_checkMetadataState(request, metadata);
+  return (void *)response.Value;
+}
+
+int64_t *trailingFlagsForStructMetadata(void *uncastMetadata) {
+  auto *metadata = static_cast<StructMetadata *>(uncastMetadata);
+  auto *description = metadata->getDescription();
+  if (!description->isGeneric())
+    return nullptr;
+
+  auto *trailingFlags = metadata->getTrailingFlags();
+  if (trailingFlags == nullptr)
+    return nullptr;
+
+  auto *retval = (int64_t *)malloc(sizeof(int64_t));
+  *retval = trailingFlags->getOpaqueValue();
+  return retval;
+}
+
+const uint32_t *fieldOffsetsForStructMetadata(void *uncastMetadata) {
+  auto *metadata = static_cast<StructMetadata *>(uncastMetadata);
+  return metadata->getFieldOffsets();
+}
+
+int64_t *trailingFlagsForEnumMetadata(void *uncastMetadata) {
+  auto *metadata = static_cast<EnumMetadata *>(uncastMetadata);
+  auto *description = metadata->getDescription();
+  if (!description->isGeneric())
+    return nullptr;
+
+  auto *trailingFlags = metadata->getTrailingFlags();
+  if (trailingFlags == nullptr)
+    return nullptr;
+
+  auto *retval = (int64_t *)malloc(sizeof(int64_t));
+  *retval = trailingFlags->getOpaqueValue();
+  return retval;
+}
+
+size_t *payloadSizeForEnumMetadata(void *uncastMetadata) {
+  auto *metadata = static_cast<EnumMetadata *>(uncastMetadata);
+  if (!metadata->hasPayloadSize())
+    return nullptr;
+
+  auto *retval = (size_t *)malloc(sizeof(size_t));
+  *retval = metadata->getPayloadSize();
+  return retval;
+}
+

--- a/test/IRGen/prespecialized-metadata/Inputs/extraDataFields.h
+++ b/test/IRGen/prespecialized-metadata/Inputs/extraDataFields.h
@@ -1,0 +1,32 @@
+#ifdef __cplusplus
+#include <cstdint>
+#include <cstddef>
+#else
+#include <stdint.h>
+#include <stddef.h>
+#endif
+
+#ifdef __cplusplus
+extern "C"
+#endif
+void *completeMetadata(void *metadata);
+
+#ifdef __cplusplus
+extern "C"
+#endif
+int64_t *trailingFlagsForStructMetadata(void *metadata);
+
+#ifdef __cplusplus
+extern "C"
+#endif
+const uint32_t *fieldOffsetsForStructMetadata(void *metadata);
+
+#ifdef __cplusplus
+extern "C"
+#endif
+int64_t *trailingFlagsForEnumMetadata(void *metadata);
+
+#ifdef __cplusplus
+extern "C"
+#endif
+size_t *payloadSizeForEnumMetadata(void *metadata);

--- a/test/IRGen/prespecialized-metadata/Inputs/isPrespecialized.cpp
+++ b/test/IRGen/prespecialized-metadata/Inputs/isPrespecialized.cpp
@@ -1,0 +1,38 @@
+#include "isPrespecialized.h"
+#include <swift/Runtime/Metadata.h>
+
+using namespace swift;
+
+namespace llvm {
+  int DisableABIBreakingChecks;
+  int EnableABIBreakingChecks;
+}
+
+bool isCanonicalStaticallySpecializedGenericMetadata(Metadata *self) {
+  if (auto *metadata = dyn_cast<StructMetadata>(self)) {
+    return metadata->isCanonicalStaticallySpecializedGenericMetadata();
+  }
+  if (auto *metadata = dyn_cast<EnumMetadata>(self))
+    return metadata->isCanonicalStaticallySpecializedGenericMetadata();
+  if (auto *metadata = dyn_cast<ClassMetadata>(self))
+    return metadata->isCanonicalStaticallySpecializedGenericMetadata();
+
+  return false;
+}
+
+int isCanonicalStaticallySpecializedGenericMetadata(void *ptr) {
+  auto metadata = static_cast<Metadata *>(ptr);
+  auto isCanonical =
+      isCanonicalStaticallySpecializedGenericMetadata(metadata);
+  return isCanonical;
+}
+
+void allocateDirtyAndFreeChunk(void) {
+  uintptr_t ChunkSize = 16 * 1024;
+
+  char *allocation = new char[ChunkSize];
+
+  memset(allocation, 255, ChunkSize);
+
+  delete[] allocation;
+}

--- a/test/IRGen/prespecialized-metadata/Inputs/isPrespecialized.h
+++ b/test/IRGen/prespecialized-metadata/Inputs/isPrespecialized.h
@@ -1,0 +1,9 @@
+#ifdef __cplusplus
+extern "C"
+#endif
+int isCanonicalStaticallySpecializedGenericMetadata(void *metadata);
+
+#ifdef __cplusplus
+extern "C"
+#endif
+void allocateDirtyAndFreeChunk(void);

--- a/test/IRGen/prespecialized-metadata/Inputs/struct-extra-data-fields.swift
+++ b/test/IRGen/prespecialized-metadata/Inputs/struct-extra-data-fields.swift
@@ -1,0 +1,9 @@
+public struct FixedFieldOffsets<Tag> {
+  public let first: Int64
+  public let second: Int64
+}
+
+public struct DynamicFieldOffsets<Value> {
+  public let first: Value
+  public let second: Value
+}

--- a/test/IRGen/prespecialized-metadata/enum-extradata-no_payload_size-no_trailing_flags.swift
+++ b/test/IRGen/prespecialized-metadata/enum-extradata-no_payload_size-no_trailing_flags.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+//     CHECK: @"$s4main6EitherOMP" = internal constant <{ 
+// Ensure that there is no reference to an anonymous global from within
+// s4main4PairVMP.  It would be better to use CHECK-NOT-SAME, if such a thing
+// existed.
+// CHECK-NOT: {{@[0-9]+}}
+// CHECK-LABEL: @"symbolic _____ 4main6EitherO"
+
+enum Either<First, Second, Third> {
+  case first(Int)
+  case second(String)
+}
+
+

--- a/test/IRGen/prespecialized-metadata/enum-extradata-no_payload_size-trailing_flags.swift
+++ b/test/IRGen/prespecialized-metadata/enum-extradata-no_payload_size-trailing_flags.swift
@@ -1,0 +1,93 @@
+// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: [[EXTRA_DATA_PATTERN:@[0-9]+]] = internal constant { i64 } zeroinitializer, align [[ALIGNMENT]]
+
+//      CHECK: @"$s4main6EitherOMP" = internal constant <{ 
+//           :   i32, 
+//           :   i32, 
+//           :   i32, 
+//           :   i32, 
+//           :   i32, 
+//           :   i16, 
+//           :   i16 
+//           : }> <{
+//           :   i32 trunc (
+//           :     i64 sub (
+//           :       i64 ptrtoint (
+//           :         %swift.type* (
+//           :           %swift.type_descriptor*, 
+//           :           i8**, 
+//           :           i8*
+//           :         )* @"$s4main6EitherOMi" to i64
+//           :       ), 
+//           :       i64 ptrtoint (
+//           :         <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main6EitherOMP" to i64
+//           :       )
+//           :     ) to i32
+//           :   ), 
+//           :   i32 trunc (
+//           :     i64 sub (
+//           :       i64 ptrtoint (
+//           :         %swift.metadata_response (
+//           :           %swift.type*, 
+//           :           i8*, 
+//           :           i8**
+//           :         )* @"$s4main6EitherOMr" to i64
+//           :       ), 
+//           :       i64 ptrtoint (
+//           :         i32* getelementptr inbounds (
+//           :           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
+//           :           <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main6EitherOMP", 
+//           :           i32 0, 
+//           :           i32 1
+//           :         ) to i64
+//           :       )
+//           :     ) to i32
+//           :   ), 
+//           :   i32 1075838979, 
+//           :   i32 trunc (
+//           :     i64 sub (
+//           :       i64 ptrtoint (
+//           :         %swift.enum_vwtable* @"$s4main6EitherOWV" to i64
+//           :       ), 
+//           :       i64 ptrtoint (
+//           :         i32* getelementptr inbounds (
+//           :           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
+//           :           <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main6EitherOMP", 
+//           :           i32 0, 
+//           :           i32 3
+//           :         ) to i64
+//           :       )
+//           :     ) to i32
+//           :   ), 
+//           :   i32 trunc (
+// CHECK-SAME:     [[INT]] sub (
+// CHECK-SAME:       [[INT]] ptrtoint (
+// CHECK-SAME:         { 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }* [[EXTRA_DATA_PATTERN]] to [[INT]]
+// CHECK-SAME:       ), 
+// CHECK-SAME:       [[INT]] ptrtoint (
+// CHECK-SAME:         i32* getelementptr inbounds (
+// CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
+// CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main6EitherOMP", 
+// CHECK-SAME:           i32 0, 
+// CHECK-SAME:           i32 4
+// CHECK-SAME:         ) to [[INT]]
+// CHECK-SAME:       )
+// CHECK-SAME:     )
+//           :   ), 
+//           :   i16 4, 
+//           :   i16 1 
+//           : }>, align 8
+
+enum Either<First, Second, Third> {
+  case first(Int)
+  case second(String)
+}
+

--- a/test/IRGen/prespecialized-metadata/enum-extradata-payload_size-no_trailing_flags.swift
+++ b/test/IRGen/prespecialized-metadata/enum-extradata-payload_size-no_trailing_flags.swift
@@ -1,0 +1,88 @@
+// RUN: %target-swift-frontend -enable-library-evolution -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+
+//      CHECK: [[EXTRA_DATA_PATTERN:@[0-9]+]] = internal constant { [[INT]] } { 
+// The payload size is 8: the larger payload is the size of an Int64.
+// CHECK-SAME:   [[INT]] 8
+// CHECK-SAME: }, align [[ALIGNMENT]]
+
+
+//      CHECK: @"$s4main6EitherOMP" = internal constant <{ 
+//           :   i32, 
+//           :   i32, 
+//           :   i32, 
+//           :   i32, 
+//           :   i32, 
+//           :   i16, 
+//           :   i16 
+//           : }> <{ 
+//           :   i32 trunc (
+//           :     i64 sub (
+//           :       i64 ptrtoint (
+//           :         %swift.type* (
+//           :           %swift.type_descriptor*, 
+//           :           i8**, 
+//           :           i8*
+//           :         )* @"$s4main6EitherOMi" to i64
+//           :       ), 
+//           :       i64 ptrtoint (
+//           :         <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main6EitherOMP" to i64
+//           :       )
+//           :     ) to i32
+//           :   ), 
+//           :   i32 0, 
+//           :   i32 1075838979, 
+//           :   i32 trunc (
+//           :     i64 sub (
+//           :       i64 ptrtoint (
+//           :         %swift.enum_vwtable* @"$s4main6EitherOWV" to i64
+//           :       ), 
+//           :       i64 ptrtoint (
+//           :         i32* getelementptr inbounds (
+//           :           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
+//           :           <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main6EitherOMP", 
+//           :           i32 0, 
+//           :           i32 3
+//           :         ) to i64
+//           :       )
+//           :     ) to i32
+//           :   ), 
+//           :   i32 trunc (
+// CHECK-SAME:     [[INT]] sub (
+// CHECK-SAME:       [[INT]] ptrtoint (
+// CHECK-SAME:         { [[INT]] }* [[EXTRA_DATA_PATTERN]] to [[INT]]
+// CHECK-SAME:       ), 
+// CHECK-SAME:       [[INT]] ptrtoint (
+// CHECK-SAME:         i32* getelementptr inbounds (
+// CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
+// CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main6EitherOMP", 
+// CHECK-SAME:           i32 0, 
+// CHECK-SAME:           i32 4
+// CHECK-SAME:         ) to [[INT]]
+// CHECK-SAME:       )
+// CHECK-SAME:     )
+//           :   ), 
+//           :   i16 1, 
+//           :   i16 2 
+//           : }>, 
+//           : align 8
+
+public struct First<T> {
+  public let value: Int32
+}
+
+public struct Second {
+  public let value: Int64
+}
+
+@frozen
+public enum Either<T> {
+  case first(First<T>)
+  case second(Second)
+}
+

--- a/test/IRGen/prespecialized-metadata/enum-extradata-payload_size-trailing_flags.swift
+++ b/test/IRGen/prespecialized-metadata/enum-extradata-payload_size-trailing_flags.swift
@@ -1,0 +1,88 @@
+// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -enable-library-evolution -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+
+//      CHECK: [[EXTRA_DATA_PATTERN:@[0-9]+]] = internal constant { [[INT]], i64 } { 
+// The payload size is 8: the larger payload is the size of an Int64.
+// CHECK-SAME:   [[INT]] 8, 
+// CHECK-SAME:   i64 0 
+// CHECK-SAME: }, align [[ALIGNMENT]]
+
+
+//      CHECK: @"$s4main6EitherOMP" = internal constant <{ 
+//           :   i32, 
+//           :   i32, 
+//           :   i32, 
+//           :   i32, 
+//           :   i32, 
+//           :   i16, 
+//           :   i16 
+//           : }> <{ 
+//           :   i32 trunc (
+//           :     i64 sub (
+//           :       i64 ptrtoint (
+//           :         %swift.type* (
+//           :           %swift.type_descriptor*, 
+//           :           i8**, 
+//           :           i8*
+//           :         )* @"$s4main6EitherOMi" to i64
+//           :       ), 
+//           :       i64 ptrtoint (
+//           :         <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main6EitherOMP" to i64
+//           :       )
+//           :     ) to i32
+//           :   ), 
+//           :   i32 0, 
+//           :   i32 1075838979, 
+//           :   i32 trunc (
+//           :     i64 sub (
+//           :       i64 ptrtoint (
+//           :         %swift.enum_vwtable* @"$s4main6EitherOWV" to i64
+//           :       ), 
+//           :       i64 ptrtoint (
+//           :         i32* getelementptr inbounds (
+//           :           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
+//           :           <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main6EitherOMP", 
+//           :           i32 0, 
+//           :           i32 3
+//           :         ) to i64
+//           :       )
+//           :     ) to i32
+//           :   ), 
+//           :   i32 trunc (
+// CHECK-SAME:     [[INT]] sub (
+// CHECK-SAME:       [[INT]] ptrtoint (
+// CHECK-SAME:         { [[INT]], i64 }* [[EXTRA_DATA_PATTERN]] to [[INT]]
+// CHECK-SAME:       ), 
+// CHECK-SAME:       [[INT]] ptrtoint (
+// CHECK-SAME:         i32* getelementptr inbounds (
+// CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
+// CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main6EitherOMP", 
+// CHECK-SAME:           i32 0, 
+// CHECK-SAME:           i32 4
+// CHECK-SAME:         ) to [[INT]]
+// CHECK-SAME:       )
+// CHECK-SAME:     )
+//           :   ), 
+//           :   i16 1, 
+//           :   i16 2 
+//           : }>, 
+//           : align 8
+
+public struct First<T> {
+  public let value: Int32
+}
+
+public struct Second {
+  public let value: Int64
+}
+
+@frozen
+public enum Either<T> {
+  case first(First<T>)
+  case second(Second)
+}

--- a/test/IRGen/prespecialized-metadata/enum-extradata-run.swift
+++ b/test/IRGen/prespecialized-metadata/enum-extradata-run.swift
@@ -1,0 +1,101 @@
+// RUN: %empty-directory(%t)
+// RUN: %clang -c -v %target-cc-options -g -O0 -isysroot %sdk %S/Inputs/extraDataFields.cpp -o %t/extraDataFields.o -I %clang-include-dir -I %swift_src_root/include/ -I %swift_src_root/../llvm-project/llvm/include -I %clang-include-dir/../../llvm-macosx-x86_64/include -L %clang-include-dir/../lib/swift/macosx
+
+// RUN: %target-build-swift -c %S/Inputs/enum-extra-data-fields.swift -emit-library -emit-module -enable-library-evolution -module-name ExtraDataFieldsNoTrailingFlags -target %module-target-future -Xfrontend -disable-generic-metadata-prespecialization -emit-module-path %t/ExtraDataFieldsNoTrailingFlags.swiftmodule -o %t/libExtraDataFieldsNoTrailingFlags.dylib
+// RUN: %target-build-swift -c %S/Inputs/enum-extra-data-fields.swift -emit-library -emit-module -enable-library-evolution -module-name ExtraDataFieldsTrailingFlags -target %module-target-future -Xfrontend -prespecialize-generic-metadata -emit-module-path %t/ExtraDataFieldsTrailingFlags.swiftmodule -o %t/libExtraDataFieldsTrailingFlags.dylib
+// RUN: %target-build-swift -v %mcp_opt %s %t/extraDataFields.o -import-objc-header %S/Inputs/extraDataFields.h -Xfrontend -disable-generic-metadata-prespecialization -target %module-target-future -lc++ -L %clang-include-dir/../lib/swift/macosx -sdk %sdk -o %t/main -I %t -L %t -lExtraDataFieldsTrailingFlags -lExtraDataFieldsNoTrailingFlags -module-name main
+
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: OS=macosx
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+
+func ptr<T>(to ty: T.Type) -> UnsafeMutableRawPointer {
+    UnsafeMutableRawPointer(mutating: unsafePointerToMetadata(of: ty))!
+}
+
+func unsafePointerToMetadata<T>(of ty: T.Type) -> UnsafePointer<T.Type> {
+  unsafeBitCast(ty, to: UnsafePointer<T.Type>.self)
+}
+
+import ExtraDataFieldsNoTrailingFlags
+
+
+let one = completeMetadata(
+  ptr(
+    to: ExtraDataFieldsNoTrailingFlags.FixedPayloadSize<Void>.self
+  )
+)
+
+// CHECK: nil
+print(
+  trailingFlagsForEnumMetadata(
+    one
+  )
+)
+
+let onePayloadSize = payloadSizeForEnumMetadata(one)
+
+// CHECK-NEXT: 8
+print(onePayloadSize!.pointee)
+
+let two = completeMetadata(
+  ptr(
+    to: ExtraDataFieldsNoTrailingFlags.DynamicPayloadSize<Int32>.self
+  )
+)
+
+// CHECK-NEXT: nil
+print(
+  trailingFlagsForEnumMetadata(
+    two
+  )
+)
+
+let twoPayloadSize = payloadSizeForEnumMetadata(two)
+
+// CHECK-NEXT: nil
+print(twoPayloadSize)
+
+
+import ExtraDataFieldsTrailingFlags
+
+
+let three = completeMetadata(
+  ptr(
+    to: ExtraDataFieldsTrailingFlags.FixedPayloadSize<Void>.self
+  )
+)
+
+// CHECK-NEXT: 0
+print(
+  trailingFlagsForEnumMetadata(
+    three
+  )!.pointee
+)
+
+let threePayloadSize = payloadSizeForEnumMetadata(three)
+
+// CHECK-NEXT: 8
+print(threePayloadSize!.pointee)
+
+let four = completeMetadata(
+  ptr(
+    to: ExtraDataFieldsTrailingFlags.DynamicPayloadSize<Int32>.self
+  )
+)
+
+// CHECK-NEXT: 0
+print(
+  trailingFlagsForEnumMetadata(
+    four
+  )!.pointee
+)
+
+let fourPayloadSize = payloadSizeForEnumMetadata(four)
+
+// CHECK-NEXT: nil
+print(fourPayloadSize)
+

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-payload_size.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-payload_size.swift
@@ -1,0 +1,117 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -enable-library-evolution -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$s4main5ValueOySiGWV" = linkonce_odr hidden constant %swift.enum_vwtable
+// CHECK: @"$s4main5ValueOySiGMf" = linkonce_odr hidden constant <{ 
+// CHECK-SAME:   i8**, 
+// CHECK-SAME:   [[INT]], 
+// CHECK-SAME:   %swift.type_descriptor*, 
+// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   i64 
+// CHECK-SAME: }> <{ 
+// CHECK-SAME: i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOySiGWV", i32 0, i32 0), 
+// CHECK-SAME: [[INT]] 513, 
+// CHECK-SAME:   %swift.type_descriptor* bitcast (
+// CHECK-SAME:     {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
+// CHECK-SAME:   ), 
+// CHECK-SAME:   %swift.type* @"$sSiN", 
+// Payload size.
+// CHECK-SAME:   [[INT]] 8,
+// Trailing flags.
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+
+public struct First<Tag> {
+  public let value: Int64
+}
+
+public struct Second {
+  public let value: Int64
+}
+
+@frozen
+public enum Value<Tag> {
+  case first(First<Tag>)
+  case second(Second)
+
+  static func only(_ int: Int) -> Self {
+    return .second(Second(value: Int64(int)))
+  }
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+//      CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+//      CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5ValueOySiGMf" to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     )
+// CHECK-SAME:   )
+//      CHECK: }
+func doit() {
+  consume( Value<Int>.only(13) )
+}
+doit()
+
+//      CHECK: ; Function Attrs: noinline nounwind readnone
+//      CHECK: define{{( protected)?}} swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {
+//      CHECK: entry:
+//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+//      CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+//      CHECK: [[TYPE_COMPARISON_LABEL]]:
+//      CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE]]
+//      CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+//      CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+//      CHECK: [[EXIT_PRESPECIALIZED]]:
+//      CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           [[INT]],
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5ValueOySiGMf" to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
+//      CHECK: [[EXIT_NORMAL]]:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   i8* %2, 
+// CHECK-SAME:   i8* undef, 
+// CHECK-SAME:   i8* undef, 
+// CHECK-SAME:   %swift.type_descriptor* bitcast (
+// CHECK-SAME:     {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
+// CHECK-SAME:   )
+// CHECK-SAME: ) #{{[0-9]+}}
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+

--- a/test/IRGen/prespecialized-metadata/enum-trailing-flags-run.swift
+++ b/test/IRGen/prespecialized-metadata/enum-trailing-flags-run.swift
@@ -1,0 +1,80 @@
+// RUN: %empty-directory(%t)
+// RUN: %clang -c -v %target-cc-options -g -O0 -isysroot %sdk %S/Inputs/isPrespecialized.cpp -o %t/isPrespecialized.o -I %clang-include-dir -I %swift_src_root/include/ -I %swift_src_root/../llvm-project/llvm/include -I %clang-include-dir/../../llvm-macosx-x86_64/include -L %clang-include-dir/../lib/swift/macosx
+
+// RUN: %target-build-swift -v %mcp_opt %s %t/isPrespecialized.o -import-objc-header %S/Inputs/isPrespecialized.h -Xfrontend -prespecialize-generic-metadata -target %module-target-future -lc++ -L %clang-include-dir/../lib/swift/macosx -sdk %sdk -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main
+
+
+// REQUIRES: OS=macosx
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+
+func ptr<T>(to ty: T.Type) -> UnsafeMutableRawPointer {
+    UnsafeMutableRawPointer(mutating: unsafePointerToMetadata(of: ty))!
+}
+
+func unsafePointerToMetadata<T>(of ty: T.Type) -> UnsafePointer<T.Type> {
+  unsafeBitCast(ty, to: UnsafePointer<T.Type>.self)
+}
+
+protocol Natural {}
+
+enum Zero : Natural {}
+
+enum Successor<N : Natural> : Natural {}
+
+extension Natural {
+    static func withSuccessor<
+        Invocation : WithSuccessorInvocation
+    >
+    (
+        invoke invocation: Invocation
+    )
+        -> Invocation.Return
+    {
+        invocation.invoke(Successor<Self>.self)
+    }
+
+    static func withSuccessor<
+        Invocation : WithSuccessorInvocation
+    >
+    (
+        offsetBy count: UInt,
+        invoke invocation: Invocation
+    )
+        -> Invocation.Return
+    {
+        if isCanonicalStaticallySpecializedGenericMetadata(ptr(to: Self.self)) != 0 {
+            fatalError()
+        }
+        switch count {
+        case 0:
+            return invocation.invoke(Self.self)
+        case 1:
+            return withSuccessor(invoke: invocation)
+        default:
+            return Successor<Self>.withSuccessor(
+                offsetBy: count - 1,
+                invoke: invocation
+            )
+        }
+    }
+}
+
+protocol WithSuccessorInvocation {
+    associatedtype Return
+    func invoke<N : Natural>( _ t: N.Type) -> Return
+}
+
+struct PointerInvocation : WithSuccessorInvocation {
+    typealias Return = UnsafeMutableRawPointer
+    func invoke<N : Natural>(_ t: N.Type) -> Return {
+        ptr(to: t)
+    }
+}
+
+allocateDirtyAndFreeChunk()
+
+_ = Zero.withSuccessor(offsetBy: 10000, invoke: PointerInvocation())
+

--- a/test/IRGen/prespecialized-metadata/struct-extradata-field_offsets-no_trailing_flags.swift
+++ b/test/IRGen/prespecialized-metadata/struct-extradata-field_offsets-no_trailing_flags.swift
@@ -1,0 +1,89 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+//      CHECK: [[EXTRA_DATA_PATTERN:@[0-9]+]]  = internal constant { 
+// CHECK-SAME:     i32
+// CHECK-SAME:   , i32
+// CHECK-SAME:   , i32
+//           :   , [4 x i8] 
+// CHECK-SAME: } { 
+// CHECK-SAME:   i32 0, 
+// CHECK-SAME:   i32 8, 
+// CHECK-SAME:   i32 16
+//           :   , [4 x i8] zeroinitializer 
+// CHECK-SAME: }, align [[ALIGNMENT]]
+//      CHECK: @"$s4main4PairVMP" = internal constant <{ 
+//           :   i32, 
+//           :   i32, 
+//           :   i32, 
+//           :   i32, 
+//           :   i32, 
+//           :   i16, 
+//           :   i16 
+//           : }> <{ 
+//           :   i32 trunc (
+//           :     i64 sub (
+//           :       i64 ptrtoint (
+//           :         %swift.type* (
+//           :           %swift.type_descriptor*, 
+//           :           i8**, 
+//           :           i8*
+//           :         )* @"$s4main4PairVMi" to i64
+//           :       ), 
+//           :       i64 ptrtoint (
+//           :         <{ i32, i32, i32, i32, i32, i16, i16 }>* 
+//           :         @"$s4main4PairVMP" to i64
+//           :       )
+//           :     ) to i32
+//           :   ), 
+//           :   i32 0, 
+//           :   i32 1073741827, 
+//           :   i32 trunc (
+//           :     i64 sub (
+//           :       i64 ptrtoint (
+//           :         %swift.vwtable* @"$s4main4PairVWV" to i64
+//           :       ), 
+//           :       i64 ptrtoint (
+//           :         i32* getelementptr inbounds (
+//           :           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
+//           :           <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main4PairVMP", 
+//           :           i32 0, 
+//           :           i32 3
+//           :         ) to i64
+//           :       )
+//           :     ) to i32
+//           :   ), 
+//           :   i32 trunc (
+// CHECK-SAME:     [[INT]] sub (
+// CHECK-SAME:       [[INT]] ptrtoint (
+// CHECK-SAME:         { i32
+// CHECK-SAME:         , i32
+// CHECK-SAME:         , i32
+//           :         , [4 x i8] 
+// CHECK-SAME:         }* [[EXTRA_DATA_PATTERN]] to [[INT]]
+// CHECK-SAME:       ), 
+// CHECK-SAME:       [[INT]] ptrtoint (
+// CHECK-SAME:         i32* getelementptr inbounds (
+// CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
+// CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main4PairVMP", 
+// CHECK-SAME:           i32 0, 
+// CHECK-SAME:           i32 4
+// CHECK-SAME:         ) to [[INT]]
+// CHECK-SAME:       )
+// CHECK-SAME:     )
+//           :   ), 
+//           :   i16 3, 
+//           :   i16 3 
+//           : }>, align 8
+
+struct Pair<First, Second, Third> {
+    let first: Int64
+    let second: Int64
+    let third: Int64
+}
+
+

--- a/test/IRGen/prespecialized-metadata/struct-extradata-field_offsets-trailing_flags.swift
+++ b/test/IRGen/prespecialized-metadata/struct-extradata-field_offsets-trailing_flags.swift
@@ -1,0 +1,92 @@
+// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+//      CHECK: [[EXTRA_DATA_PATTERN:@[0-9]+]]  = internal constant { 
+// CHECK-SAME:   i32, 
+// CHECK-SAME:   i32, 
+// CHECK-SAME:   i32,
+//           :   , [4 x i8], 
+// CHECK-SAME:   i64 
+// CHECK-SAME: } { 
+// CHECK-SAME:   i32 0, 
+// CHECK-SAME:   i32 8, 
+// CHECK-SAME:   i32 16, 
+//           :   [4 x i8] zeroinitializer, 
+// CHECK-SAME:   i64 0 
+// CHECK-SAME: }, align [[ALIGNMENT]]
+//      CHECK: @"$s4main4PairVMP" = internal constant <{ 
+//           :   i32, 
+//           :   i32, 
+//           :   i32, 
+//           :   i32, 
+//           :   i32, 
+//           :   i16, 
+//           :   i16 
+//           : }> <{ 
+//           :   i32 trunc (
+//           :     i64 sub (
+//           :       i64 ptrtoint (
+//           :         %swift.type* (
+//           :           %swift.type_descriptor*, 
+//           :           i8**, 
+//           :           i8*
+//           :         )* @"$s4main4PairVMi" to i64
+//           :       ), 
+//           :       i64 ptrtoint (
+//           :         <{ i32, i32, i32, i32, i32, i16, i16 }>* 
+//           :         @"$s4main4PairVMP" to i64
+//           :       )
+//           :     ) to i32
+//           :   ), 
+//           :   i32 0, 
+//           :   i32 1073741827, 
+//           :   i32 trunc (
+//           :     i64 sub (
+//           :       i64 ptrtoint (
+//           :         %swift.vwtable* @"$s4main4PairVWV" to i64
+//           :       ), 
+//           :       i64 ptrtoint (
+//           :         i32* getelementptr inbounds (
+//           :           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
+//           :           <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main4PairVMP", 
+//           :           i32 0, 
+//           :           i32 3
+//           :         ) to i64
+//           :       )
+//           :     ) to i32
+//           :   ), 
+//           :   i32 trunc (
+// CHECK-SAME:     [[INT]] sub (
+// CHECK-SAME:       [[INT]] ptrtoint (
+// CHECK-SAME:         { 
+// CHECK-SAME:           i32, 
+// CHECK-SAME:           i32, 
+// CHECK-SAME:           i32, 
+//           :           [4 x i8], 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }* [[EXTRA_DATA_PATTERN]] to [[INT]]
+// CHECK-SAME:       ), 
+// CHECK-SAME:       [[INT]] ptrtoint (
+// CHECK-SAME:         i32* getelementptr inbounds (
+// CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
+// CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main4PairVMP", 
+// CHECK-SAME:           i32 0, 
+// CHECK-SAME:           i32 4
+// CHECK-SAME:         ) to [[INT]]
+// CHECK-SAME:       )
+// CHECK-SAME:     )
+//           :   ), 
+//           :   i16 3, 
+//           :   i16 3 
+//           : }>, align 8
+
+struct Pair<First, Second, Third> {
+    let first: Int64
+    let second: Int64
+    let third: Int64
+}
+

--- a/test/IRGen/prespecialized-metadata/struct-extradata-no_field_offsets-no_trailing_flags.swift
+++ b/test/IRGen/prespecialized-metadata/struct-extradata-no_field_offsets-no_trailing_flags.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+//     CHECK: @"$s4main4PairVMP" = internal constant <{ 
+// Ensure that there is no reference to an anonymous global from within
+// s4main4PairVMP.  It would be better to use CHECK-NOT-SAME, if such a thing
+// existed.
+// CHECK-NOT: {{@[0-9]+}}
+// CHECK-LABEL: @"symbolic _____ 4main4PairV"
+
+struct Pair<First, Second, Third> {
+    let first: First               
+    let second: Second
+    let third: Third               
+}                                  
+
+
+

--- a/test/IRGen/prespecialized-metadata/struct-extradata-no_field_offsets-trailing_flags.swift
+++ b/test/IRGen/prespecialized-metadata/struct-extradata-no_field_offsets-trailing_flags.swift
@@ -1,0 +1,93 @@
+// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: [[EXTRA_DATA_PATTERN:@[0-9]+]] = internal constant { i64 } zeroinitializer, align [[ALIGNMENT]]
+
+//      CHECK: @"$s4main4PairVMP" = internal constant <{ 
+//           :   i32, 
+//           :   i32, 
+//           :   i32, 
+//           :   i32, 
+//           :   i32, 
+//           :   i16, 
+//           :   i16 
+//           : }> <{ 
+//           :   i32 trunc (
+//           :     i64 sub (
+//           :       i64 ptrtoint (
+//           :         %swift.type* (
+//           :           %swift.type_descriptor*, 
+//           :           i8**, 
+//           :           i8*
+//           :         )* @"$s4main4PairVMi" to i64
+//           :       ), 
+//           :       i64 ptrtoint (
+//           :         <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main4PairVMP" to i64
+//           :       )
+//           :     ) to i32
+//           :   ), 
+//           :   i32 trunc (
+//           :     i64 sub (
+//           :       i64 ptrtoint (
+//           :         %swift.metadata_response (
+//           :           %swift.type*, 
+//           :           i8*, 
+//           :           i8**
+//           :         )* @"$s4main4PairVMr" to i64
+//           :       ), 
+//           :       i64 ptrtoint (
+//           :         i32* getelementptr inbounds (
+//           :           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
+//           :           <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main4PairVMP", 
+//           :           i32 0, 
+//           :           i32 1
+//           :         ) to i64
+//           :       )
+//           :     ) to i32
+//           :   ), 
+//           :   i32 1073741827, 
+//           :   i32 trunc (
+//           :     i64 sub (
+//           :       i64 ptrtoint (
+//           :         %swift.vwtable* @"$s4main4PairVWV" to i64
+//           :       ), 
+//           :       i64 ptrtoint (
+//           :         i32* getelementptr inbounds (
+//           :           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
+//           :           <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main4PairVMP", 
+//           :           i32 0, 
+//           :           i32 3
+//           :         ) to i64
+//           :       )
+//           :     ) to i32
+//           :   ), 
+//           :   i32 trunc (
+// CHECK-SAME:     [[INT]] sub (
+// CHECK-SAME:       [[INT]] ptrtoint (
+// CHECK-SAME:         { 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }* [[EXTRA_DATA_PATTERN]] to [[INT]]
+// CHECK-SAME:       ), 
+// CHECK-SAME:       [[INT]] ptrtoint (
+// CHECK-SAME:         i32* getelementptr inbounds (
+// CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
+// CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main4PairVMP", 
+// CHECK-SAME:           i32 0, 
+// CHECK-SAME:           i32 4
+// CHECK-SAME:         ) to [[INT]]
+// CHECK-SAME:       )
+// CHECK-SAME:     )
+//           :   ), 
+//           :   i16 5, 
+//           :   i16 1 
+//           : }>, align 8
+
+struct Pair<First, Second, Third> {
+    let first: First
+    let second: Second
+    let third: Third
+}

--- a/test/IRGen/prespecialized-metadata/struct-extradata-run.swift
+++ b/test/IRGen/prespecialized-metadata/struct-extradata-run.swift
@@ -1,0 +1,117 @@
+// RUN: %empty-directory(%t)
+// RUN: %clang -c -v %target-cc-options -g -O0 -isysroot %sdk %S/Inputs/extraDataFields.cpp -o %t/extraDataFields.o -I %clang-include-dir -I %swift_src_root/include/ -I %swift_src_root/../llvm-project/llvm/include -I %clang-include-dir/../../llvm-macosx-x86_64/include -L %clang-include-dir/../lib/swift/macosx
+
+// RUN: %target-build-swift -c %S/Inputs/struct-extra-data-fields.swift -emit-library -emit-module -module-name ExtraDataFieldsNoTrailingFlags -target %module-target-future -Xfrontend -disable-generic-metadata-prespecialization -emit-module-path %t/ExtraDataFieldsNoTrailingFlags.swiftmodule -o %t/libExtraDataFieldsNoTrailingFlags.dylib
+// RUN: %target-build-swift -c %S/Inputs/struct-extra-data-fields.swift -emit-library -emit-module -module-name ExtraDataFieldsTrailingFlags -target %module-target-future -Xfrontend -prespecialize-generic-metadata -emit-module-path %t/ExtraDataFieldsTrailingFlags.swiftmodule -o %t/libExtraDataFieldsTrailingFlags.dylib
+// RUN: %target-build-swift -v %mcp_opt %s %t/extraDataFields.o -import-objc-header %S/Inputs/extraDataFields.h -Xfrontend -disable-generic-metadata-prespecialization -target %module-target-future -lc++ -L %clang-include-dir/../lib/swift/macosx -sdk %sdk -o %t/main -I %t -L %t -lExtraDataFieldsTrailingFlags -lExtraDataFieldsNoTrailingFlags -module-name main
+
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: OS=macosx
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+
+func ptr<T>(to ty: T.Type) -> UnsafeMutableRawPointer {
+    UnsafeMutableRawPointer(mutating: unsafePointerToMetadata(of: ty))!
+}
+
+func unsafePointerToMetadata<T>(of ty: T.Type) -> UnsafePointer<T.Type> {
+  unsafeBitCast(ty, to: UnsafePointer<T.Type>.self)
+}
+
+import ExtraDataFieldsNoTrailingFlags
+
+
+let one = completeMetadata(
+  ptr(
+    to: ExtraDataFieldsNoTrailingFlags.FixedFieldOffsets<Void>.self
+  )
+)
+
+// CHECK: nil
+print(
+  trailingFlagsForStructMetadata(
+    one
+  )
+)
+
+guard let oneOffsets = fieldOffsetsForStructMetadata(one) else {
+  fatalError("no field offsets")
+}
+
+// CHECK-NEXT: 0
+print(oneOffsets.advanced(by: 0).pointee)
+// CHECK-NEXT: 8
+print(oneOffsets.advanced(by: 1).pointee)
+
+let two = completeMetadata(
+  ptr(
+    to: ExtraDataFieldsNoTrailingFlags.DynamicFieldOffsets<Int32>.self
+  )
+)
+
+// CHECK-NEXT: nil
+print(
+  trailingFlagsForStructMetadata(
+    two
+  )
+)
+
+guard let twoOffsets = fieldOffsetsForStructMetadata(two) else {
+  fatalError("no field offsets")
+}
+
+// CHECK-NEXT: 0
+print(twoOffsets.advanced(by: 0).pointee)
+// CHECK-NEXT: 4
+print(twoOffsets.advanced(by: 1).pointee)
+
+
+import ExtraDataFieldsTrailingFlags
+
+
+let three = completeMetadata(
+  ptr(
+    to: ExtraDataFieldsTrailingFlags.FixedFieldOffsets<Void>.self
+  )
+)
+
+// CHECK-NEXT: 0
+print(
+  trailingFlagsForStructMetadata(
+    three
+  )!.pointee
+)
+
+guard let threeOffsets = fieldOffsetsForStructMetadata(three) else {
+  fatalError("no field offsets")
+}
+
+// CHECK-NEXT: 0
+print(threeOffsets.advanced(by: 0).pointee)
+// CHECK-NEXT: 8
+print(threeOffsets.advanced(by: 1).pointee)
+
+let four = completeMetadata(
+  ptr(
+    to: ExtraDataFieldsTrailingFlags.DynamicFieldOffsets<Int32>.self
+  )
+)
+
+// CHECK-NEXT: 0
+print(
+  trailingFlagsForStructMetadata(
+    four
+  )!.pointee
+)
+
+guard let fourOffsets = fieldOffsetsForStructMetadata(four) else {
+  fatalError("no field offsets")
+}
+
+// CHECK-NEXT: 0
+print(fourOffsets.advanced(by: 0).pointee)
+// CHECK-NEXT: 4
+print(fourOffsets.advanced(by: 1).pointee)
+

--- a/test/IRGen/prespecialized-metadata/struct-trailing-flags-run.swift
+++ b/test/IRGen/prespecialized-metadata/struct-trailing-flags-run.swift
@@ -1,0 +1,80 @@
+// RUN: %empty-directory(%t)
+// RUN: %clang -c -v %target-cc-options -g -O0 -isysroot %sdk %S/Inputs/isPrespecialized.cpp -o %t/isPrespecialized.o -I %clang-include-dir -I %swift_src_root/include/ -I %swift_src_root/../llvm-project/llvm/include -I %clang-include-dir/../../llvm-macosx-x86_64/include -L %clang-include-dir/../lib/swift/macosx
+
+// RUN: %target-build-swift -v %mcp_opt %s %t/isPrespecialized.o -import-objc-header %S/Inputs/isPrespecialized.h -Xfrontend -prespecialize-generic-metadata -target %module-target-future -lc++ -L %clang-include-dir/../lib/swift/macosx -sdk %sdk -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main
+
+
+
+// REQUIRES: OS=macosx
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+
+func ptr<T>(to ty: T.Type) -> UnsafeMutableRawPointer {
+    UnsafeMutableRawPointer(mutating: unsafePointerToMetadata(of: ty))!
+}
+
+func unsafePointerToMetadata<T>(of ty: T.Type) -> UnsafePointer<T.Type> {
+  unsafeBitCast(ty, to: UnsafePointer<T.Type>.self)
+}
+
+protocol Natural {}
+
+struct Zero : Natural {}
+
+struct Successor<N : Natural> : Natural {}
+
+extension Natural {
+    static func withSuccessor<
+        Invocation : WithSuccessorInvocation
+    >
+    (
+        invoke invocation: Invocation
+    )
+        -> Invocation.Return
+    {
+        invocation.invoke(Successor<Self>.self)
+    }
+
+    static func withSuccessor<
+        Invocation : WithSuccessorInvocation
+    >
+    (
+        offsetBy count: UInt,
+        invoke invocation: Invocation
+    )
+        -> Invocation.Return
+    {
+        if isCanonicalStaticallySpecializedGenericMetadata(ptr(to: Self.self)) != 0 {
+            fatalError()
+        }
+        switch count {
+        case 0:
+            return invocation.invoke(Self.self)
+        case 1:
+            return withSuccessor(invoke: invocation)
+        default:
+            return Successor<Self>.withSuccessor(
+                offsetBy: count - 1,
+                invoke: invocation
+            )
+        }
+    }
+}
+
+protocol WithSuccessorInvocation {
+    associatedtype Return
+    func invoke<N : Natural>( _ t: N.Type) -> Return
+}
+
+struct PointerInvocation : WithSuccessorInvocation {
+    typealias Return = UnsafeMutableRawPointer
+    func invoke<N : Natural>(_ t: N.Type) -> Return {
+        ptr(to: t)
+    }
+}
+
+allocateDirtyAndFreeChunk()
+
+_ = Zero.withSuccessor(offsetBy: 10000, invoke: PointerInvocation())


### PR DESCRIPTION
The important changes here are 

> [metadata prespecialization] Zero trailing flags.
> 
> Previously, the trailing flags field of runtime instantiated generic metadata for types which had prespecialization enabled were not zeroed.  Consequently, the field always contained garbage.  Often, metadata was instantiated on new (and so, zeroed) pages, so the garbage happened to be zero as is appropriate.  However, when the metadata was instantiated on pages which had previously been dirtied, the garbage value would sometimes indicate that the metadata was canonical statically specialized.  When that occurred, swift_checkMetadataState would incorrectly return a metadata state of complete, despite the fact that the metadata might not in fact be complete.  As a result, the runtime was trafficking in incomplete metadata as if it were complete, resulting in various crashes that would arise from for example missing a witness table or a value witness table.
> 
> Here the problem is corrected.  The trailing flags field of structs and enums that have the field is set to 0.  For structs, this is accomplished by modifying the extra data pattern to exist not only when there is fixed type info for the type but also when the type is being prespecialized.  For enums, this is achieved by modifying the metadata allocation function to do the zeroing.
> 
> rdar://problem/61465515

and

> [IRGen] Corrected size of trailing flags field.
> 
> The struct and enum metadata scanners were both adding a pointer for the trailing flags field.  That was only correct for 64-bit platforms.  Instead, add an Int64.

Together, those two commits unlock reenabling metadata prespecialization for the stdlib.

Additionally, improved the debuggability of bad metadata records by first memsetting them to 0xAA on allocation in debug builds and secondly asserting that newly created records are not prespecialized.  Mike Ash pointed out that the memsetting could be done in release builds as well by so long as the work if the MallocScribble environment variable is set; that change will be done in a follow-on commit.