### PR TITLE
[opt] Update alloc_refs on the stack to have stack memory kind.

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -582,9 +582,7 @@ public:
   // Visitors for specific identified access kinds. These default to calling out
   // to visitIdentified.
 
-  Result visitClassAccess(RefElementAddrInst *field) {
-    return asImpl().visitBase(field, AccessedStorage::Class);
-  }
+  Result visitClassAccess(RefElementAddrInst *field);
   Result visitArgumentAccess(SILFunctionArgument *arg) {
     return asImpl().visitBase(arg, AccessedStorage::Argument);
   }

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -588,6 +588,10 @@ static void addClosureSpecializePassPipeline(SILPassPipelinePlan &P) {
 static void addLowLevelPassPipeline(SILPassPipelinePlan &P) {
   P.startPipeline("LowLevel,Function", true /*isFunctionPassPipeline*/);
 
+  P.addAccessEnforcementOpts();
+  P.addAccessEnforcementWMO();
+  P.addAccessMarkerElimination();
+
   // Should be after FunctionSignatureOpts and before the last inliner.
   P.addReleaseDevirtualizer();
 

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -590,7 +590,7 @@ static void addLowLevelPassPipeline(SILPassPipelinePlan &P) {
 
   P.addAccessEnforcementOpts();
   P.addAccessEnforcementWMO();
-  P.addAccessMarkerElimination();
+  // P.addAccessMarkerElimination();
 
   // Should be after FunctionSignatureOpts and before the last inliner.
   P.addReleaseDevirtualizer();

--- a/test/SILOptimizer/access_enforcement_opts.sil
+++ b/test/SILOptimizer/access_enforcement_opts.sil
@@ -1737,3 +1737,136 @@ bb0(%0 : ${ var Int64 }):
   end_access %access : $*Int64
   return %val : $Int64
 }
+
+// CHECK-LABEL: sil @promote_local_class_to_static
+// CHECK: begin_access [modify] [static] [no_nested_conflict]
+// CHECK: begin_access [read] [static] [no_nested_conflict]
+// CHECK-LABEL: end sil function 'promote_local_class_to_static'
+sil @promote_local_class_to_static : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int32, 0
+  %1 = struct $Int32 (%0 : $Builtin.Int32)
+  %4 = alloc_ref [stack] $RefElemClass
+  
+  %8 = ref_element_addr %4 : $RefElemClass, #RefElemClass.y
+  %9 = begin_access [modify] [dynamic] [no_nested_conflict] %8 : $*Int32
+  store %1 to %9 : $*Int32
+  end_access %9 : $*Int32
+  
+  %17 = begin_access [read] [dynamic] [no_nested_conflict] %8 : $*Int32
+  %18 = struct_element_addr %17 : $*Int32, #Int32._value
+  %19 = load %18 : $*Builtin.Int32
+  end_access %17 : $*Int32
+
+  set_deallocating %4 : $RefElemClass
+  dealloc_ref %4 : $RefElemClass
+  dealloc_ref [stack] %4 : $RefElemClass
+  
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+class Class1 {
+  @_hasStorage @_hasInitialValue var x: Int32 { get set }
+  deinit
+  init()
+}
+
+struct Struct1 {
+  @_hasStorage @_hasInitialValue var c: Class1 { get set }
+  init(c: Class1 = Class1())
+  init()
+}
+
+class Class2 {
+  @_hasStorage @_hasInitialValue var s: Struct1 { get set }
+  deinit
+  init()
+}
+
+// CHECK-LABEL: sil @promote_local_class_in_struct_in_class_to_static
+// CHECK: begin_access [modify] [static] [no_nested_conflict]
+// CHECK: begin_access [read] [static] [no_nested_conflict]
+// CHECK-LABEL: end sil function 'promote_local_class_in_struct_in_class_to_static'
+sil @promote_local_class_in_struct_in_class_to_static : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int32, 0
+  %1 = struct $Int32 (%0 : $Builtin.Int32)
+  %4 = alloc_ref [stack] $Class2
+  
+  %5 = ref_element_addr %4 : $Class2, #Class2.s
+  %6 = struct_element_addr %5 : $*Struct1, #Struct1.c
+  %7 = load %6 : $*Class1
+  %8 = ref_element_addr %7 : $Class1, #Class1.x
+  %9 = begin_access [modify] [dynamic] [no_nested_conflict] %8 : $*Int32
+  store %1 to %9 : $*Int32
+  end_access %9 : $*Int32
+  
+  %17 = begin_access [read] [dynamic] [no_nested_conflict] %8 : $*Int32
+  %18 = struct_element_addr %17 : $*Int32, #Int32._value
+  %19 = load %18 : $*Builtin.Int32
+  end_access %17 : $*Int32
+
+  set_deallocating %4 : $Class2
+  dealloc_ref %4 : $Class2
+  dealloc_ref [stack] %4 : $Class2
+  
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @promote_local_class_in_struct_to_static
+// CHECK: begin_access [modify] [static] [no_nested_conflict]
+// CHECK: begin_access [read] [static] [no_nested_conflict]
+// CHECK-LABEL: end sil function 'promote_local_class_in_struct_to_static'
+sil @promote_local_class_in_struct_to_static : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int32, 0
+  %1 = struct $Int32 (%0 : $Builtin.Int32)
+  %4 = alloc_stack $Struct1
+  
+  %6 = struct_element_addr %4 : $*Struct1, #Struct1.c
+  %7 = load %6 : $*Class1
+  %8 = ref_element_addr %7 : $Class1, #Class1.x
+  %9 = begin_access [modify] [dynamic] [no_nested_conflict] %8 : $*Int32
+  store %1 to %9 : $*Int32
+  end_access %9 : $*Int32
+  
+  %17 = begin_access [read] [dynamic] [no_nested_conflict] %8 : $*Int32
+  %18 = struct_element_addr %17 : $*Int32, #Int32._value
+  %19 = load %18 : $*Builtin.Int32
+  end_access %17 : $*Int32
+
+  dealloc_stack %4 : $*Struct1
+  
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @promote_local_class_in_tuple_to_static
+// CHECK: begin_access [modify] [static] [no_nested_conflict]
+// CHECK: begin_access [read] [static] [no_nested_conflict]
+// CHECK-LABEL: end sil function 'promote_local_class_in_tuple_to_static'
+sil @promote_local_class_in_tuple_to_static : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int32, 0
+  %1 = struct $Int32 (%0 : $Builtin.Int32)
+  %4 = alloc_stack $(Class1, Int)
+  
+  %6 = tuple_element_addr %4 : $*(Class1, Int), 0
+  %7 = load %6 : $*Class1
+  %8 = ref_element_addr %7 : $Class1, #Class1.x
+  %9 = begin_access [modify] [dynamic] [no_nested_conflict] %8 : $*Int32
+  store %1 to %9 : $*Int32
+  end_access %9 : $*Int32
+  
+  %17 = begin_access [read] [dynamic] [no_nested_conflict] %8 : $*Int32
+  %18 = struct_element_addr %17 : $*Int32, #Int32._value
+  %19 = load %18 : $*Builtin.Int32
+  end_access %17 : $*Int32
+
+  dealloc_stack %4 : $*(Class1, Int)
+  
+  %9999 = tuple ()
+  return %9999 : $()
+}


### PR DESCRIPTION
Update MemAccessUtils to classify class allocs on the stack as "AccessedStorage::Kind::Stack" instead of "::Class". This allows class element access markers to be promoted to have static access enforcement.

Right now we're really bad at optimizing classes. I've made a few patches recently to address some of the issues I've seen in the optimizer around class optimization. They're mostly similar patches (or at least addressing similar problems) and over time they seem to have gotten more and more general. I think this may finally be the _right_ patch.

Fixing this edge case around access enforcement is (hopefully, we'll see what the benchmarks say) a big performance improvement for a relatively small patch. And, more importantly, this feels like the "correct" way to address the problem (rather than storing class members in tuples =P). 