### PR TITLE
[Frontend] Avoid passing CompilerInvocation + CompilerInstance

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -494,7 +494,6 @@ public:
 
   bool hasASTContext() const { return Context != nullptr; }
 
-  SILOptions &getSILOptions() { return Invocation.getSILOptions(); }
   const SILOptions &getSILOptions() const { return Invocation.getSILOptions(); }
 
   Lowering::TypeConverter &getSILTypes();

--- a/include/swift/Migrator/Migrator.h
+++ b/include/swift/Migrator/Migrator.h
@@ -28,8 +28,7 @@ namespace migrator {
 /// If needed, run the migrator on the compiler invocation's input file and emit
 /// a "replacement map" describing the requested changes to the source file.
 /// \return true on error.
-bool updateCodeAndEmitRemapIfNeeded(CompilerInstance *Instance,
-                                    const CompilerInvocation &Invocation);
+bool updateCodeAndEmitRemapIfNeeded(CompilerInstance *Instance);
 
 /// Specify options when running syntactic migration pass.
 struct SyntacticPassOptions {

--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -26,8 +26,8 @@
 using namespace swift;
 using namespace swift::migrator;
 
-bool migrator::updateCodeAndEmitRemapIfNeeded(
-    CompilerInstance *Instance, const CompilerInvocation &Invocation) {
+bool migrator::updateCodeAndEmitRemapIfNeeded(CompilerInstance *Instance) {
+  const auto &Invocation = Instance->getInvocation();
   if (!Invocation.getMigratorOptions().shouldRunMigrator())
     return false;
 


### PR DESCRIPTION
Instead of passing both a `CompilerInvocation` and `CompilerInstance` throughout FrontendTool, just pass the `CompilerInstance` and use it to get the invocation.