### PR TITLE
[5.3][Property Wrappers] For now, don't allow wrappedValue and projectedValue to have dynamic Self type.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4904,6 +4904,9 @@ ERROR(property_wrapper_type_requirement_not_accessible,none,
 ERROR(property_wrapper_ambiguous_enclosing_self_subscript, none,
       "property wrapper type %0 has multiple enclosing-self subscripts %1",
       (Type, DeclName))
+ERROR(property_wrapper_dynamic_self_type, none,
+      "property wrapper %select{wrapped value|projected value}0 cannot have "
+      "dynamic Self type", (bool))
 
 ERROR(property_wrapper_attribute_not_on_property, none,
       "property wrapper attribute %0 can only be applied to a property",

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2862,7 +2862,7 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
 
   // If the nominal type is a property wrapper type, we can be delegating
   // through a property.
-  if (nominal->getPropertyWrapperTypeInfo()) {
+  if (nominal->getAttrs().hasAttribute<PropertyWrapperAttr>()) {
     // property wrappers can only be applied to variables
     if (!isa<VarDecl>(D) || isa<ParamDecl>(D)) {
       diagnose(attr->getLocation(),

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -406,25 +406,21 @@ PropertyWrapperTypeInfoRequest::evaluate(
     }
   }
 
-  auto diagnoseInvalidDynamicSelf = [&]() -> bool {
-    bool invalidDynamicSelf = false;
-    if (result.projectedValueVar &&
-        result.projectedValueVar->getValueInterfaceType()->is<DynamicSelfType>()) {
-      result.projectedValueVar->diagnose(
-          diag::property_wrapper_dynamic_self_type, /*projectedValue=*/true);
-      invalidDynamicSelf = true;
-    }
+  bool hasInvalidDynamicSelf = false;
+  if (result.projectedValueVar &&
+      result.projectedValueVar->getValueInterfaceType()->hasDynamicSelfType()) {
+    result.projectedValueVar->diagnose(
+        diag::property_wrapper_dynamic_self_type, /*projectedValue=*/true);
+    hasInvalidDynamicSelf = true;
+  }
 
-    if (result.valueVar->getValueInterfaceType()->is<DynamicSelfType>()) {
-      result.valueVar->diagnose(
-          diag::property_wrapper_dynamic_self_type, /*projectedValue=*/false);
-      invalidDynamicSelf = true;
-    }
+  if (result.valueVar->getValueInterfaceType()->hasDynamicSelfType()) {
+    result.valueVar->diagnose(
+        diag::property_wrapper_dynamic_self_type, /*projectedValue=*/false);
+    hasInvalidDynamicSelf = true;
+  }
 
-    return invalidDynamicSelf;
-  };
-
-  if (diagnoseInvalidDynamicSelf())
+  if (hasInvalidDynamicSelf)
     return PropertyWrapperTypeInfo();
 
   return result;

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -406,6 +406,27 @@ PropertyWrapperTypeInfoRequest::evaluate(
     }
   }
 
+  auto diagnoseInvalidDynamicSelf = [&]() -> bool {
+    bool invalidDynamicSelf = false;
+    if (result.projectedValueVar &&
+        result.projectedValueVar->getValueInterfaceType()->is<DynamicSelfType>()) {
+      result.projectedValueVar->diagnose(
+          diag::property_wrapper_dynamic_self_type, /*projectedValue=*/true);
+      invalidDynamicSelf = true;
+    }
+
+    if (result.valueVar->getValueInterfaceType()->is<DynamicSelfType>()) {
+      result.valueVar->diagnose(
+          diag::property_wrapper_dynamic_self_type, /*projectedValue=*/false);
+      invalidDynamicSelf = true;
+    }
+
+    return invalidDynamicSelf;
+  };
+
+  if (diagnoseInvalidDynamicSelf())
+    return PropertyWrapperTypeInfo();
+
   return result;
 }
 

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -818,11 +818,26 @@ struct TestProjectionValuePropertyAttr {
 @propertyWrapper
 struct BrokenLazy { }
 // expected-error@-1{{property wrapper type 'BrokenLazy' does not contain a non-static property named 'wrappedValue'}}
-// expected-note@-2{{'BrokenLazy' declared here}}
 
 struct S {
-  @BrokenLazy // expected-error{{struct 'BrokenLazy' cannot be used as an attribute}}
+  @BrokenLazy
   var wrappedValue: Int
+}
+
+@propertyWrapper
+struct DynamicSelfStruct {
+  var wrappedValue: Self { self } // okay
+  var projectedValue: Self { self } // okay
+}
+
+@propertyWrapper
+class DynamicSelf {
+  var wrappedValue: Self { self } // expected-error {{property wrapper wrapped value cannot have dynamic Self type}}
+  var projectedValue: Self { self } // expected-error {{property wrapper projected value cannot have dynamic Self type}}
+}
+
+struct UseDynamicSelfWrapper {
+  @DynamicSelf() var value
 }
 
 // ---------------------------------------------------------------------------

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -833,7 +833,7 @@ struct DynamicSelfStruct {
 @propertyWrapper
 class DynamicSelf {
   var wrappedValue: Self { self } // expected-error {{property wrapper wrapped value cannot have dynamic Self type}}
-  var projectedValue: Self { self } // expected-error {{property wrapper projected value cannot have dynamic Self type}}
+  var projectedValue: Self? { self } // expected-error {{property wrapper projected value cannot have dynamic Self type}}
 }
 
 struct UseDynamicSelfWrapper {


### PR DESCRIPTION
Cherry-picked from https://github.com/apple/swift/pull/31344 and it's follow-up https://github.com/apple/swift/pull/31443

---
Currently, when wrappedValue or projectedValue have dynamic Self type, the synthesized properties when using the wrapper will also get a dynamic Self type, but in a new context. This bug could manifest as really misleading diagnostics, or a crash. For now, we will disallow this, but we can re-visit implementing correct support for this in the future.

Resolves: rdar://problem/53258469
