### PR TITLE
Windows: add `combase` to the `WinSDK.core` module

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -27,6 +27,11 @@ module WinSDK [system] {
       export *
     }
 
+    module com {
+      header "combaseapi.h"
+      export *
+    }
+
     module compress {
       header "compressapi.h"
       export *


### PR DESCRIPTION
Ensure that this header properly gets modularized into its own module.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
