### PR TITLE
[IDE][SourceKit] Support escaped identifiers for the syntactic rename and related idents requests.

### DIFF
--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -131,6 +131,8 @@ static std::vector<CharSourceRange> getLabelRanges(const ParameterList* List,
     } else {
       NameLoc = ParamLoc;
       NameLength = Param->getNameStr().size();
+      if (SM.extractText({NameLoc, 1}) == "`")
+        NameLength += 2;
       LabelRanges.push_back(CharSourceRange(NameLoc, NameLength));
     }
   }

--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -531,3 +531,10 @@ func test<M>(_: M, value: Int?) {
 // CHECK: [[@LINE-1]]:34 | constructor/Swift | init(_:) | s:14swift_ide_test7FromIntPyxSicfc | Ref,RelCont | rel: 1
     }
 }
+
+func `escapedName`(`x`: Int) {}
+// CHECK: [[@LINE-1]]:6 | function/Swift | escapedName(x:) | {{.*}} | Def | rel: 0
+`escapedName`(`x`: 2)
+// CHECK: [[@LINE-1]]:1 | function/Swift | escapedName(x:) | {{.*}} | Ref,Call | rel: 0
+`escapedName`(`x`:)
+// CHECK: [[@LINE-1]]:1 | function/Swift | escapedName(x:) | {{.*}} | Ref | rel: 0

--- a/test/SourceKit/NameTranslation/swiftnames.swift
+++ b/test/SourceKit/NameTranslation/swiftnames.swift
@@ -8,7 +8,7 @@ class C1 : NSObject {
 }
 func takeC1(a : Int, b: Int, c :Int) -> C1 {
   let C1Ins = C1(a: a, b: b)
-  C1Ins.foo(a: a, b: b, c: c)
+  C1Ins.`foo`(`a`: a, `b`: b, c: c)
   C1Ins.foo1(a: a, b, c: c)
   C1Ins.foo2(a, b, c: c)
   C1Ins.foo3()
@@ -57,11 +57,16 @@ class C3: NSObject {
 
 // REQUIRES: objc_interop
 // RUN: %sourcekitd-test -req=translate -swift-name "foo(a:b:c:)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK1 %s
+// RUN: %sourcekitd-test -req=translate -swift-name '`foo`(`a`:b:c:)' -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK1 %s
+// RUN: %sourcekitd-test -req=translate -swift-name '`foo(`a:b:c:)' -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK1 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "foo(a:b:c:)" -pos=11:11 %s -print-raw-response -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK_RAW1 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "bar(x:y:)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECKFEWER1 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "bar(::)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECKMISSING1 %s
+// RUN: %sourcekitd-test -req=translate -swift-name 'bar(`:`:)' -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECKMISSING1 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "(x:y:z:)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECKMISSING2 %s
+// RUN: %sourcekitd-test -req=translate -swift-name '`(x:y:z:)' -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECKMISSING2 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "foo(a1:b1:c1:)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK2 %s
+// RUN: %sourcekitd-test -req=translate -swift-name '`foo`(a1:`b1`:c1:)' -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK2 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "foo(_:b1:c1:)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK3 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "foo1(_:_:c2:)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK4 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "foo1(_:_:_:)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK5 %s

--- a/test/SourceKit/Refactoring/basic.swift
+++ b/test/SourceKit/Refactoring/basic.swift
@@ -113,6 +113,9 @@ struct HasInitWithDefaultArgs {
 HasInitWithDefaultArgs(z: 45)
 HasInitWithDefaultArgs(y: 45, z: 89)
 
+func `hasBackticks`(`x`: Int) {}
+`hasBackticks`(`x`:2)
+
 // RUN: %sourcekitd-test -req=cursor -pos=3:1 -end-pos=5:13 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK1
 
 // CHECK1: ACTIONS BEGIN
@@ -150,6 +153,13 @@ HasInitWithDefaultArgs(y: 45, z: 89)
 // RUN: %sourcekitd-test -req=cursor -pos=114:24  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
 // RUN: %sourcekitd-test -req=cursor -pos=114:31  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
 // RUN: %sourcekitd-test -req=cursor -pos=114:31  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
+
+// RUN: %sourcekitd-test -req=cursor -pos=116:6  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
+// RUN: %sourcekitd-test -req=cursor -pos=116:7  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
+// RUN: %sourcekitd-test -req=cursor -pos=117:1  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
+// RUN: %sourcekitd-test -req=cursor -pos=117:2  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
+// RUN: %sourcekitd-test -req=cursor -pos=117:16  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
+// RUN: %sourcekitd-test -req=cursor -pos=117:17  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
 
 // RUN: %sourcekitd-test -req=cursor -pos=35:10 -end-pos=35:16 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-RENAME-EXTRACT
 // RUN: %sourcekitd-test -req=cursor -pos=35:10 -end-pos=35:16 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-RENAME-EXTRACT

--- a/test/SourceKit/RelatedIdents/related_idents.swift
+++ b/test/SourceKit/RelatedIdents/related_idents.swift
@@ -69,6 +69,12 @@ struct Projection<T> {
   var item: T
 }
 
+func `escapedName`(`x`: Int) {}
+`escapedName`(`x`: 2)
+`escapedName`(`x`:)
+escapedName(`x`: 2)
+escapedName(`x`:)
+
 // RUN: %sourcekitd-test -req=related-idents -pos=6:17 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK1 %s
 // CHECK1: START RANGES
 // CHECK1-NEXT: 1:7 - 2
@@ -146,3 +152,16 @@ struct Projection<T> {
 // CHECK10-NEXT: 63:10 - 3
 // CHECK10-NEXT: 64:10 - 3
 // CHECK10-NEXT: END RANGES
+
+// RUN: %sourcekitd-test -req=related-idents -pos=72:6 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK11 %s
+// RUN: %sourcekitd-test -req=related-idents -pos=73:1 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK11 %s
+// RUN: %sourcekitd-test -req=related-idents -pos=73:2 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK11 %s
+// RUN: %sourcekitd-test -req=related-idents -pos=74:1 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK11 %s
+// RUN: %sourcekitd-test -req=related-idents -pos=74:2 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK11 %s
+// CHECK11:      START RANGES
+// CHECK11-NEXT: 72:6 - 13
+// CHECK11-NEXT: 73:1 - 13
+// CHECK11-NEXT: 74:1 - 13
+// CHECK11-NEXT: 75:1 - 11
+// CHECK11-NEXT: 76:1 - 11
+

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/backticks-noncollapsible-separate-arglabel.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/backticks-noncollapsible-separate-arglabel.swift.expected
@@ -1,0 +1,5 @@
+struct Foo {
+    /*test:def*/<keywordBase>subscript</keywordBase>(<arglabel index=0>`x`</arglabel> <noncollapsibleparam index=0>y</noncollapsibleparam>: Int) -> Int { fatalError() }
+}
+Foo()/*test:ref*/[<callarg index=0>`x`</callarg><callcolon index=0>: </callcolon>10]
+

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/backticks-noncollapsible.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/backticks-noncollapsible.swift.expected
@@ -1,0 +1,5 @@
+struct Foo {
+    /*test:def*/<keywordBase>subscript</keywordBase>(<arglabel index=0></arglabel><noncollapsibleparam index=0>`x`</noncollapsibleparam>: Int) -> Int { fatalError() }
+}
+Foo()/*test:ref*/[<callcombo index=0></callcombo>10]
+

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/backticks-separate-arglabel.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/backticks-separate-arglabel.swift.expected
@@ -1,0 +1,4 @@
+func /*test:def*/<base>`foo`</base>(<arglabel index=0>`x`</arglabel><param index=0> `y`</param>: Int) {}
+/*test:call*/<base>`foo`</base>(<callarg index=0>`x`</callarg><callcolon index=0>: </callcolon>2)
+_ = /*test:ref*/<base>`foo`</base>(<sel index=0>`x`</sel>:)
+

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/backticks.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/backticks.swift.expected
@@ -1,0 +1,4 @@
+func /*test:def*/<base>`foo`</base>(<arglabel index=0>`x`</arglabel><param index=0></param>: Int) {}
+/*test:call*/<base>`foo`</base>(<callarg index=0>`x`</callarg><callcolon index=0>: </callcolon>2)
+_ = /*test:ref*/<base>`foo`</base>(<sel index=0>`x`</sel>:)
+

--- a/test/refactoring/SyntacticRename/backticks-noncollapsible-separate-arglabel.swift
+++ b/test/refactoring/SyntacticRename/backticks-noncollapsible-separate-arglabel.swift
@@ -1,0 +1,8 @@
+struct Foo {
+    /*test:def*/subscript(`x` y: Int) -> Int { fatalError() }
+}
+Foo()/*test:ref*/[`x`: 10]
+
+// RUN: %empty-directory(%t.ranges)
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="test" -is-function-like -old-name "subscript(x:)" >> %t.ranges/backticks-noncollapsible-separate-arglabel.swift.expected
+// RUN: diff -u %S/FindRangeOutputs/backticks-noncollapsible-separate-arglabel.swift.expected %t.ranges/backticks-noncollapsible-separate-arglabel.swift.expected

--- a/test/refactoring/SyntacticRename/backticks-noncollapsible.swift
+++ b/test/refactoring/SyntacticRename/backticks-noncollapsible.swift
@@ -1,0 +1,8 @@
+struct Foo {
+    /*test:def*/subscript(`x`: Int) -> Int { fatalError() }
+}
+Foo()/*test:ref*/[10]
+
+// RUN: %empty-directory(%t.ranges)
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="test" -is-function-like -old-name "subscript(_:)" >> %t.ranges/backticks-noncollapsible.swift.expected
+// RUN: diff -u %S/FindRangeOutputs/backticks-noncollapsible.swift.expected %t.ranges/backticks-noncollapsible.swift.expected

--- a/test/refactoring/SyntacticRename/backticks-separate-arglabel.swift
+++ b/test/refactoring/SyntacticRename/backticks-separate-arglabel.swift
@@ -1,0 +1,7 @@
+func /*test:def*/`foo`(`x` `y`: Int) {}
+/*test:call*/`foo`(`x`: 2)
+_ = /*test:ref*/`foo`(`x`:)
+
+// RUN: %empty-directory(%t.ranges)
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="test" -is-function-like -old-name "foo(x:)" >> %t.ranges/backticks-separate-arglabel.swift.expected
+// RUN: diff -u %S/FindRangeOutputs/backticks-separate-arglabel.swift.expected %t.ranges/backticks-separate-arglabel.swift.expected

--- a/test/refactoring/SyntacticRename/backticks.swift
+++ b/test/refactoring/SyntacticRename/backticks.swift
@@ -1,0 +1,7 @@
+func /*test:def*/`foo`(`x`: Int) {}
+/*test:call*/`foo`(`x`: 2)
+_ = /*test:ref*/`foo`(`x`:)
+
+// RUN: %empty-directory(%t.ranges)
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="test" -is-function-like -old-name "foo(x:)" >> %t.ranges/backticks.swift.expected
+// RUN: diff -u %S/FindRangeOutputs/backticks.swift.expected %t.ranges/backticks.swift.expected

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1152,7 +1152,11 @@ static void handleSemanticRequest(
     else
       return Rec(createErrorRequestInvalid("'key.namekind' is unrecognizable"));
     if (auto Base = Req.getString(KeyBaseName)) {
-      Input.BaseName = Base.getValue();
+      if (Input.NameKind == UIDKindNameSwift) {
+        Input.BaseName = Base.getValue().trim('`');
+      } else {
+        Input.BaseName = Base.getValue();
+      }
     }
     llvm::SmallVector<const char*, 4> ArgParts;
     llvm::SmallVector<const char*, 4> Selectors;
@@ -1164,7 +1168,7 @@ static void handleSemanticRequest(
     }
     std::transform(ArgParts.begin(), ArgParts.end(),
                    std::back_inserter(Input.ArgNames),
-                   [](const char *C) { return StringRef(C); });
+                   [](const char *C) { return StringRef(C).trim('`'); });
     std::transform(Selectors.begin(), Selectors.end(),
                    std::back_inserter(Input.ArgNames),
                    [](const char *C) { return StringRef(C); });


### PR DESCRIPTION
Both would previously not account for the extra two backticks in their name, e.g. giving `` [`fo]o` `` rather than `` [`foo`] ``.

This updates their ranges to include the backticks, and for syntactic rename, to account for them when comparing base names and argument labels with expected values. It also updates Swift -> ObjC name translation to account for them too.

Resolves rdar://problem/46409010
Resolves rdar://problem/48256383