### PR TITLE
Sema: Fix crash with stored property that has on-demand 'modify' accessor

### DIFF
--- a/test/SILGen/observers_with_on_demand_modify_accessor.swift
+++ b/test/SILGen/observers_with_on_demand_modify_accessor.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-emit-silgen %s -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// REQUIRES: objc_interop
+
+public protocol Proto {
+  var property: Int { get set }
+}
+
+public class ClassWithDynamicObservedProperty : Proto {
+  @objc public dynamic var property: Int = 0 {
+    didSet {}
+  }
+}
+
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s40observers_with_on_demand_modify_accessor32ClassWithDynamicObservedPropertyC8propertySivM : $@yield_once @convention(method) (@guaranteed ClassWithDynamicObservedProperty) -> @yields @inout Int {
+// CHECK: objc_method %0 : $ClassWithDynamicObservedProperty, #ClassWithDynamicObservedProperty.property!getter.foreign
+// CHECK: objc_method %0 : $ClassWithDynamicObservedProperty, #ClassWithDynamicObservedProperty.property!setter.foreign
+// CHECK: return


### PR DESCRIPTION
If a stored property has observers, the 'modify' coroutine body takes a
special form which directly yields the underlying storage and calls the
'didSet' and/or 'willSet' accessors.

However, if a property is 'dynamic', the 'modify' coroutine is synthesized
on-demand and it's SIL is serialized. It cannot reference the 'didSet'
or 'willSet' accessors, since they are private. Furthermore, an on-demand
accessor must also work if the property is overridden in a subclass.

So in this case, fall back to the more general 'modify' synthesis code,
which just calls the getter followed by the setter.

Fixes <rdar://problem/62339808>.