### PR TITLE
Sema: Apply substitutions when checking type witnesses against associ…

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3683,23 +3683,30 @@ ResolveWitnessResult ConformanceChecker::resolveWitnessViaDefault(
 
 # pragma mark Type witness resolution
 
-CheckTypeWitnessResult swift::checkTypeWitness(DeclContext *dc,
-                                               ProtocolDecl *proto,
+CheckTypeWitnessResult swift::checkTypeWitness(Type type,
                                                AssociatedTypeDecl *assocType,
-                                               Type type) {
-  auto genericSig = proto->getGenericSignature();
-  auto *depTy = DependentMemberType::get(proto->getSelfInterfaceType(),
-                                         assocType);
-
+                                               NormalProtocolConformance *Conf) {
   if (type->hasError())
-    return ErrorType::get(proto->getASTContext());
+    return ErrorType::get(assocType->getASTContext());
+
+  const auto proto = Conf->getProtocol();
+  const auto dc = Conf->getDeclContext();
+  const auto genericSig = proto->getGenericSignature();
+  const auto depTy = DependentMemberType::get(proto->getSelfInterfaceType(),
+                                              assocType);
 
   Type contextType = type->hasTypeParameter() ? dc->mapTypeIntoContext(type)
                                               : type;
 
-  // FIXME: This is incorrect; depTy is written in terms of the protocol's
-  // associated types, and we need to substitute in known type witnesses.
   if (auto superclass = genericSig->getSuperclassBound(depTy)) {
+    // If the superclass has a type parameter, substitute in known type
+    // witnesses.
+    if (superclass->hasTypeParameter()) {
+      const auto subMap = SubstitutionMap::getProtocolSubstitutions(
+          proto, Conf->getType(), ProtocolConformanceRef(Conf));
+
+      superclass = superclass.subst(subMap);
+    }
     if (!superclass->isExactSuperclassOf(contextType))
       return superclass;
   }
@@ -3796,7 +3803,7 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
 
     // Check this type against the protocol requirements.
     if (auto checkResult =
-            checkTypeWitness(DC, Proto, assocType, candidate.MemberType)) {
+            checkTypeWitness(candidate.MemberType, assocType, Conformance)) {
       nonViable.push_back({candidate.Member, checkResult});
     } else {
       viable.push_back(candidate);

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -91,12 +91,12 @@ public:
 };
 
 /// Check whether the given type witness can be used for the given
-/// associated type.
+/// associated type in the given conformance.
 ///
 /// \returns an empty result on success, or a description of the error.
-CheckTypeWitnessResult checkTypeWitness(DeclContext *dc, ProtocolDecl *proto,
+CheckTypeWitnessResult checkTypeWitness(Type type,
                                         AssociatedTypeDecl *assocType,
-                                        Type type);
+                                        NormalProtocolConformance *Conf);
 
 /// The set of associated types that have been inferred by matching
 /// the given value witness to its corresponding requirement.

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -380,7 +380,7 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
         // Check that the type witness meets the
         // requirements on the associated type.
         if (auto failed =
-                checkTypeWitness(dc, proto, result.first, result.second)) {
+                checkTypeWitness(result.second, result.first, conformance)) {
           witnessResult.NonViable.push_back(
                           std::make_tuple(result.first,result.second,failed));
           LLVM_DEBUG(llvm::dbgs() << "-- doesn't fulfill requirements\n");
@@ -854,7 +854,7 @@ Type AssociatedTypeInference::computeDefaultTypeWitness(
   if (defaultType->hasError())
     return Type();
 
-  if (auto failed = checkTypeWitness(dc, proto, assocType, defaultType)) {
+  if (auto failed = checkTypeWitness(defaultType, assocType, conformance)) {
     // Record the failure, if we haven't seen one already.
     if (!failedDefaultedAssocType && !failed.isError()) {
       failedDefaultedAssocType = defaultedAssocType;
@@ -886,7 +886,7 @@ Type AssociatedTypeInference::computeDerivedTypeWitness(
     return Type();
 
   // Make sure that the derived type is sane.
-  if (checkTypeWitness(dc, proto, assocType, derivedType)) {
+  if (checkTypeWitness(derivedType, assocType, conformance)) {
     /// FIXME: Diagnose based on this.
     failedDerivedAssocType = assocType;
     failedDerivedWitness = derivedType;

--- a/test/decl/protocol/conforms/associated_type.swift
+++ b/test/decl/protocol/conforms/associated_type.swift
@@ -70,3 +70,56 @@ struct X2a : P2 {
 struct X2b : P2 { // expected-error{{type 'X2b' does not conform to protocol 'P2'}}
   func f(_: @escaping (Int) -> Int) { } // expected-note{{candidate has non-matching type '(@escaping (Int) -> Int) -> ()'}}
 }
+
+// SR-12707
+
+class SR_12707_C<T> {}
+
+// Regular type witnesses
+protocol SR_12707_P1 {
+  associatedtype A
+  associatedtype B: SR_12707_C<(A, Self)> // expected-note {{'B' declared here}}
+}
+struct SR_12707_Conform_P1: SR_12707_P1 {
+  typealias A = Never
+  typealias B = SR_12707_C<(A, SR_12707_Conform_P1)>
+}
+
+// Type witness in protocol extension
+protocol SR_12707_P2: SR_12707_P1 {}
+extension SR_12707_P2 {
+  typealias B = SR_12707_C<(A, Self)> // expected-warning {{typealias overriding associated type 'B' from protocol 'SR_12707_P1' is better expressed as same-type constraint on the protocol}}
+}
+struct SR_12707_Conform_P2: SR_12707_P2 {
+  typealias A = Never
+}
+
+// Default type witness
+protocol SR_12707_P3 {
+  associatedtype A
+  associatedtype B: SR_12707_C<(A, Self)> = SR_12707_C<(A, Self)>
+}
+struct SR_12707_Conform_P3: SR_12707_P3 {
+  typealias A = Never
+}
+
+// FIXME: Type witness resolution success is order-dependent.
+protocol SR_12707_FIXME_P1 {
+  associatedtype A
+}
+protocol SR_12707_FIXME_P2: SR_12707_FIXME_P1 {
+  associatedtype B: SR_12707_C<(A, Self)> = SR_12707_C<(A, Self)> // expected-note {{default type 'associated_type.SR_12707_C<(associated_type.SR_12707_FIXME_Conform_P2.A, associated_type.SR_12707_FIXME_Conform_P2)>' (aka 'SR_12707_C<(Never, SR_12707_FIXME_Conform_P2)>') for associated type 'B' (from protocol 'SR_12707_FIXME_P2') does not inherit from 'associated_type.SR_12707_C<(associated_type.SR_12707_FIXME_Conform_P2.A, associated_type.SR_12707_FIXME_Conform_P2)>'}}
+}
+struct SR_12707_FIXME_Conform_P2: SR_12707_FIXME_P2 { // expected-error {{type 'SR_12707_FIXME_Conform_P2' does not conform to protocol 'SR_12707_FIXME_P2'}}
+  typealias A = Never
+}
+
+// FIXME: Type witness resolution success is order-dependent.
+protocol SR_12707_FIXME_P3 {
+  associatedtype A: SR_12707_C<B> // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
+  associatedtype B
+}
+struct SR_12707_FIXME_Conform_P3: SR_12707_FIXME_P3 { // expected-error {{type 'SR_12707_FIXME_Conform_P3' does not conform to protocol 'SR_12707_FIXME_P3'}}
+  typealias A = SR_12707_C<B> // expected-note {{possibly intended match 'SR_12707_FIXME_Conform_P3.A' (aka 'SR_12707_C<Never>') does not inherit from 'SR_12707_C<SR_12707_FIXME_Conform_P3.B>'}}
+  typealias B = Never
+}

--- a/test/decl/protocol/req/associated_type_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference.swift
@@ -562,3 +562,29 @@ extension S31: P34 {} // expected-error {{type 'S31<T>' does not conform to prot
 extension S31 where T: P32 {
   func boo() -> Void {} // expected-note {{candidate has non-matching type '<T> () -> Void' [with A = S31<T>.A]}}
 }
+
+// SR-12707
+
+class SR_12707_C<T> {}
+
+// Inference in the adoptee
+protocol SR_12707_P1 {
+  associatedtype A
+  associatedtype B: SR_12707_C<(A, Self)>
+
+  func foo(arg: B)
+}
+struct SR_12707_Conform_P1: SR_12707_P1 {
+  typealias A = Never
+
+  func foo(arg: SR_12707_C<(A, SR_12707_Conform_P1)>) {}
+}
+
+// Inference in protocol extension
+protocol SR_12707_P2: SR_12707_P1 {}
+extension SR_12707_P2 {
+  func foo(arg: SR_12707_C<(A, Self)>) {}
+}
+struct SR_12707_Conform_P2: SR_12707_P2 {
+  typealias A = Never
+}


### PR DESCRIPTION
…atedtype superclass bounds

This is for starters. The functional change is small; the remaining part are tests and refactoring.

Resolves SR-12707 in one direction (the initial goal is to handle substitutions, what makes the bug order-dependent *now* is an orthogonal issue).