### PR TITLE
[Property Wrappers] Fix disallowing dynamic Self for property wrapper wrappedValue/projectedValue to also cover optional.

### DIFF
--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -406,25 +406,21 @@ PropertyWrapperTypeInfoRequest::evaluate(
     }
   }
 
-  auto diagnoseInvalidDynamicSelf = [&]() -> bool {
-    bool invalidDynamicSelf = false;
-    if (result.projectedValueVar &&
-        result.projectedValueVar->getValueInterfaceType()->is<DynamicSelfType>()) {
-      result.projectedValueVar->diagnose(
-          diag::property_wrapper_dynamic_self_type, /*projectedValue=*/true);
-      invalidDynamicSelf = true;
-    }
+  bool hasInvalidDynamicSelf = false;
+  if (result.projectedValueVar &&
+      result.projectedValueVar->getValueInterfaceType()->hasDynamicSelfType()) {
+    result.projectedValueVar->diagnose(
+        diag::property_wrapper_dynamic_self_type, /*projectedValue=*/true);
+    hasInvalidDynamicSelf = true;
+  }
 
-    if (result.valueVar->getValueInterfaceType()->is<DynamicSelfType>()) {
-      result.valueVar->diagnose(
-          diag::property_wrapper_dynamic_self_type, /*projectedValue=*/false);
-      invalidDynamicSelf = true;
-    }
+  if (result.valueVar->getValueInterfaceType()->hasDynamicSelfType()) {
+    result.valueVar->diagnose(
+        diag::property_wrapper_dynamic_self_type, /*projectedValue=*/false);
+    hasInvalidDynamicSelf = true;
+  }
 
-    return invalidDynamicSelf;
-  };
-
-  if (diagnoseInvalidDynamicSelf())
+  if (hasInvalidDynamicSelf)
     return PropertyWrapperTypeInfo();
 
   return result;

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -833,7 +833,7 @@ struct DynamicSelfStruct {
 @propertyWrapper
 class DynamicSelf {
   var wrappedValue: Self { self } // expected-error {{property wrapper wrapped value cannot have dynamic Self type}}
-  var projectedValue: Self { self } // expected-error {{property wrapper projected value cannot have dynamic Self type}}
+  var projectedValue: Self? { self } // expected-error {{property wrapper projected value cannot have dynamic Self type}}
 }
 
 struct UseDynamicSelfWrapper {


### PR DESCRIPTION
This is a follow up to https://github.com/apple/swift/pull/31344 to also cover `Self?`.

I left the error message the same because any use of dynamic self other than `Self` and `Self?` will be diagnosed with `Covariant 'Self' can only appear at the top level of property type`.