### PR TITLE
[NFC] Internalize TypeResolutionOptions in TypeResolution

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1454,7 +1454,7 @@ namespace {
       options |= TypeResolutionFlags::AllowUnboundGenerics;
       bool hadError = TypeChecker::validateType(
           CS.getASTContext(), loc,
-          TypeResolution::forContextual(CS.DC, options), options);
+          TypeResolution::forContextual(CS.DC, options));
       return hadError ? Type() : loc.getType();
     }
 
@@ -1717,7 +1717,7 @@ namespace {
             auto tyLoc = TypeLoc{specializations[i]};
             if (TypeChecker::validateType(
                     CS.getASTContext(), tyLoc,
-                    TypeResolution::forContextual(CS.DC, options), options))
+                    TypeResolution::forContextual(CS.DC, options)))
               return Type();
 
             CS.addConstraint(ConstraintKind::Bind,
@@ -2662,8 +2662,7 @@ namespace {
             if (TypeChecker::validateType(
                     CS.getASTContext(), isp->getCastTypeLoc(),
                     TypeResolution::forContextual(
-                        CS.DC, TypeResolverContext::InExpression),
-                    TypeResolverContext::InExpression)) {
+                        CS.DC, TypeResolverContext::InExpression))) {
               return false;
             }
 
@@ -2988,7 +2987,7 @@ namespace {
       options |= TypeResolutionFlags::AllowUnboundGenerics;
       if (TypeChecker::validateType(
               CS.getASTContext(), expr->getCastTypeLoc(),
-              TypeResolution::forContextual(CS.DC, options), options))
+              TypeResolution::forContextual(CS.DC, options)))
         return nullptr;
 
       // Open the type we're casting to.
@@ -3017,7 +3016,7 @@ namespace {
       options |= TypeResolutionFlags::AllowUnboundGenerics;
       if (TypeChecker::validateType(
               CS.getASTContext(), expr->getCastTypeLoc(),
-              TypeResolution::forContextual(CS.DC, options), options))
+              TypeResolution::forContextual(CS.DC, options)))
         return nullptr;
 
       // Open the type we're casting to.
@@ -3053,7 +3052,7 @@ namespace {
       options |= TypeResolutionFlags::AllowUnboundGenerics;
       if (TypeChecker::validateType(
               ctx, expr->getCastTypeLoc(),
-              TypeResolution::forContextual(CS.DC, options), options))
+              TypeResolution::forContextual(CS.DC, options)))
         return nullptr;
 
       // Open the type we're casting to.
@@ -3083,7 +3082,7 @@ namespace {
       options |= TypeResolutionFlags::AllowUnboundGenerics;
       if (TypeChecker::validateType(
               ctx, expr->getCastTypeLoc(),
-              TypeResolution::forContextual(CS.DC, options), options))
+              TypeResolution::forContextual(CS.DC, options)))
         return nullptr;
 
       // Open up the type we're checking.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1453,8 +1453,8 @@ namespace {
       TypeResolutionOptions options(TypeResolverContext::InExpression);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
       bool hadError = TypeChecker::validateType(
-          CS.getASTContext(), loc, TypeResolution::forContextual(CS.DC),
-          options);
+          CS.getASTContext(), loc,
+          TypeResolution::forContextual(CS.DC, options), options);
       return hadError ? Type() : loc.getType();
     }
 
@@ -1715,10 +1715,9 @@ namespace {
             TypeResolutionOptions options(TypeResolverContext::InExpression);
             options |= TypeResolutionFlags::AllowUnboundGenerics;
             auto tyLoc = TypeLoc{specializations[i]};
-            if (TypeChecker::validateType(CS.getASTContext(),
-                                tyLoc,
-                                TypeResolution::forContextual(CS.DC),
-                                options))
+            if (TypeChecker::validateType(
+                    CS.getASTContext(), tyLoc,
+                    TypeResolution::forContextual(CS.DC, options), options))
               return Type();
 
             CS.addConstraint(ConstraintKind::Bind,
@@ -2660,10 +2659,11 @@ namespace {
           // of is-patterns applied to an irrefutable pattern.
           pattern = pattern->getSemanticsProvidingPattern();
           while (auto isp = dyn_cast<IsPattern>(pattern)) {
-            if (TypeChecker::validateType(CS.getASTContext(),
-                                          isp->getCastTypeLoc(),
-                                          TypeResolution::forContextual(CS.DC),
-                                          TypeResolverContext::InExpression)) {
+            if (TypeChecker::validateType(
+                    CS.getASTContext(), isp->getCastTypeLoc(),
+                    TypeResolution::forContextual(
+                        CS.DC, TypeResolverContext::InExpression),
+                    TypeResolverContext::InExpression)) {
               return false;
             }
 
@@ -2986,10 +2986,9 @@ namespace {
       // Validate the resulting type.
       TypeResolutionOptions options(TypeResolverContext::ExplicitCastExpr);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
-      if (TypeChecker::validateType(CS.getASTContext(),
-                                    expr->getCastTypeLoc(),
-                                    TypeResolution::forContextual(CS.DC),
-                                    options))
+      if (TypeChecker::validateType(
+              CS.getASTContext(), expr->getCastTypeLoc(),
+              TypeResolution::forContextual(CS.DC, options), options))
         return nullptr;
 
       // Open the type we're casting to.
@@ -3016,10 +3015,9 @@ namespace {
       // Validate the resulting type.
       TypeResolutionOptions options(TypeResolverContext::ExplicitCastExpr);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
-      if (TypeChecker::validateType(CS.getASTContext(),
-                                    expr->getCastTypeLoc(),
-                                    TypeResolution::forContextual(CS.DC),
-                                    options))
+      if (TypeChecker::validateType(
+              CS.getASTContext(), expr->getCastTypeLoc(),
+              TypeResolution::forContextual(CS.DC, options), options))
         return nullptr;
 
       // Open the type we're casting to.
@@ -3053,10 +3051,9 @@ namespace {
       // Validate the resulting type.
       TypeResolutionOptions options(TypeResolverContext::ExplicitCastExpr);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
-      if (TypeChecker::validateType(ctx,
-                                    expr->getCastTypeLoc(),
-                                    TypeResolution::forContextual(CS.DC),
-                                    options))
+      if (TypeChecker::validateType(
+              ctx, expr->getCastTypeLoc(),
+              TypeResolution::forContextual(CS.DC, options), options))
         return nullptr;
 
       // Open the type we're casting to.
@@ -3084,10 +3081,9 @@ namespace {
       auto &ctx = CS.getASTContext();
       TypeResolutionOptions options(TypeResolverContext::ExplicitCastExpr);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
-      if (TypeChecker::validateType(ctx,
-                                    expr->getCastTypeLoc(),
-                                    TypeResolution::forContextual(CS.DC),
-                                    options))
+      if (TypeChecker::validateType(
+              ctx, expr->getCastTypeLoc(),
+              TypeResolution::forContextual(CS.DC, options), options))
         return nullptr;
 
       // Open up the type we're checking.

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -994,8 +994,7 @@ void ConstraintSystem::shrink(Expr *expr) {
             auto coercionRepr = typeRepr->clone(CS.getASTContext());
             // Let's try to resolve coercion type from cloned representative.
             auto resolution = TypeResolution::forContextual(CS.DC, None);
-            auto coercionType =
-              resolution.resolveType(coercionRepr, None);
+            auto coercionType = resolution.resolveType(coercionRepr);
 
             // Looks like coercion type is invalid, let's skip this sub-tree.
             if (coercionType->hasError())

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -993,7 +993,7 @@ void ConstraintSystem::shrink(Expr *expr) {
             // instead of cloning representative.
             auto coercionRepr = typeRepr->clone(CS.getASTContext());
             // Let's try to resolve coercion type from cloned representative.
-            auto resolution = TypeResolution::forContextual(CS.DC);
+            auto resolution = TypeResolution::forContextual(CS.DC, None);
             auto coercionType =
               resolution.resolveType(coercionRepr, None);
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -651,8 +651,8 @@ Type ConstraintSystem::openUnboundGenericType(UnboundGenericType *unbound,
   // handle generic TypeAliases elsewhere, this can just become a
   // call to BoundGenericType::get().
   return TypeChecker::applyUnboundGenericArguments(
-      unbound, unboundDecl,
-      SourceLoc(), TypeResolution::forContextual(DC), arguments);
+      unbound, unboundDecl, SourceLoc(),
+      TypeResolution::forContextual(DC, None), arguments);
 }
 
 static void checkNestedTypeConstraints(ConstraintSystem &cs, Type type,
@@ -1090,10 +1090,10 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
   if (auto typeDecl = dyn_cast<TypeDecl>(value)) {
     // Resolve the reference to this type declaration in our current context.
     auto type = TypeChecker::resolveTypeInContext(
-                                      typeDecl, nullptr,
-                                      TypeResolution::forContextual(useDC),
-                                      TypeResolverContext::InExpression,
-                                      /*isSpecialized=*/false);
+        typeDecl, nullptr,
+        TypeResolution::forContextual(useDC, TypeResolverContext::InExpression),
+        TypeResolverContext::InExpression,
+        /*isSpecialized=*/false);
 
     checkNestedTypeConstraints(*this, type, locator);
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1092,7 +1092,6 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
     auto type = TypeChecker::resolveTypeInContext(
         typeDecl, nullptr,
         TypeResolution::forContextual(useDC, TypeResolverContext::InExpression),
-        TypeResolverContext::InExpression,
         /*isSpecialized=*/false);
 
     checkNestedTypeConstraints(*this, type, locator);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2620,7 +2620,7 @@ ResolveTypeEraserTypeRequest::evaluate(Evaluator &evaluator,
                                        TypeEraserAttr *attr) const {
   if (auto *typeEraserRepr = attr->getParsedTypeEraserTypeRepr()) {
     auto resolution = TypeResolution::forContextual(PD, None);
-    return resolution.resolveType(typeEraserRepr, /*options=*/None);
+    return resolution.resolveType(typeEraserRepr);
   } else {
     auto *LazyResolver = attr->Resolver;
     assert(LazyResolver && "type eraser was neither parsed nor deserialized?");
@@ -2807,7 +2807,7 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
     options |= TypeResolutionFlags::AllowUnboundGenerics;
 
     auto resolution = TypeResolution::forContextual(DC, options);
-    T = resolution.resolveType(ProtoTypeLoc.getTypeRepr(), options);
+    T = resolution.resolveType(ProtoTypeLoc.getTypeRepr());
     ProtoTypeLoc.setType(T);
   }
 
@@ -4473,7 +4473,7 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
     options |= TypeResolutionFlags::AllowModule;
     auto resolution =
         TypeResolution::forContextual(derivative->getDeclContext(), options);
-    baseType = resolution.resolveType(baseTypeRepr, options);
+    baseType = resolution.resolveType(baseTypeRepr);
   }
   if (baseType && baseType->hasError())
     return true;
@@ -4985,7 +4985,7 @@ void AttributeChecker::visitTransposeAttr(TransposeAttr *attr) {
       TypeResolution::forContextual(transpose->getDeclContext(), None);
   Type baseType;
   if (attr->getBaseTypeRepr())
-    baseType = resolution.resolveType(attr->getBaseTypeRepr(), None);
+    baseType = resolution.resolveType(attr->getBaseTypeRepr());
   auto lookupOptions =
       (attr->getBaseTypeRepr() ? defaultMemberLookupOptions
                                : defaultUnqualifiedLookupOptions) |

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2619,7 +2619,7 @@ ResolveTypeEraserTypeRequest::evaluate(Evaluator &evaluator,
                                        ProtocolDecl *PD,
                                        TypeEraserAttr *attr) const {
   if (auto *typeEraserRepr = attr->getParsedTypeEraserTypeRepr()) {
-    auto resolution = TypeResolution::forContextual(PD);
+    auto resolution = TypeResolution::forContextual(PD, None);
     return resolution.resolveType(typeEraserRepr, /*options=*/None);
   } else {
     auto *LazyResolver = attr->Resolver;
@@ -2806,7 +2806,7 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
     TypeResolutionOptions options = None;
     options |= TypeResolutionFlags::AllowUnboundGenerics;
 
-    auto resolution = TypeResolution::forContextual(DC);
+    auto resolution = TypeResolution::forContextual(DC, options);
     T = resolution.resolveType(ProtoTypeLoc.getTypeRepr(), options);
     ProtoTypeLoc.setType(T);
   }
@@ -4467,11 +4467,12 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
         return derivative->getParent() == func->getParent();
       };
 
-  auto resolution = TypeResolution::forContextual(derivative->getDeclContext());
   Type baseType;
   if (auto *baseTypeRepr = attr->getBaseTypeRepr()) {
     TypeResolutionOptions options = None;
     options |= TypeResolutionFlags::AllowModule;
+    auto resolution =
+        TypeResolution::forContextual(derivative->getDeclContext(), options);
     baseType = resolution.resolveType(baseTypeRepr, options);
   }
   if (baseType && baseType->hasError())
@@ -4980,7 +4981,8 @@ void AttributeChecker::visitTransposeAttr(TransposeAttr *attr) {
   std::function<bool(AbstractFunctionDecl *)> hasValidTypeContext =
       [&](AbstractFunctionDecl *decl) { return true; };
 
-  auto resolution = TypeResolution::forContextual(transpose->getDeclContext());
+  auto resolution =
+      TypeResolution::forContextual(transpose->getDeclContext(), None);
   Type baseType;
   if (attr->getBaseTypeRepr())
     baseType = resolution.resolveType(attr->getBaseTypeRepr(), None);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1391,7 +1391,7 @@ TypeExpr *PreCheckExpression::simplifyNestedTypeExpr(UnresolvedDotExpr *UDE) {
     options |= TypeResolutionFlags::AllowUnboundGenerics;
     options |= TypeResolutionFlags::AllowUnavailable;
     auto resolution = TypeResolution::forContextual(DC, options);
-    auto BaseTy = resolution.resolveType(InnerTypeRepr, options);
+    auto BaseTy = resolution.resolveType(InnerTypeRepr);
 
     if (BaseTy && BaseTy->mayHaveMembers()) {
       auto lookupOptions = defaultMemberLookupOptions;
@@ -1918,8 +1918,7 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
 
     typeLoc = TypeLoc(typeExpr->getTypeRepr(), Type());
     bool hadError = TypeChecker::validateType(
-        getASTContext(), typeLoc, TypeResolution::forContextual(DC, options),
-        options);
+        getASTContext(), typeLoc, TypeResolution::forContextual(DC, options));
 
     if (hadError)
       return nullptr;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1390,7 +1390,7 @@ TypeExpr *PreCheckExpression::simplifyNestedTypeExpr(UnresolvedDotExpr *UDE) {
     TypeResolutionOptions options(TypeResolverContext::InExpression);
     options |= TypeResolutionFlags::AllowUnboundGenerics;
     options |= TypeResolutionFlags::AllowUnavailable;
-    auto resolution = TypeResolution::forContextual(DC);
+    auto resolution = TypeResolution::forContextual(DC, options);
     auto BaseTy = resolution.resolveType(InnerTypeRepr, options);
 
     if (BaseTy && BaseTy->mayHaveMembers()) {
@@ -1918,7 +1918,8 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
 
     typeLoc = TypeLoc(typeExpr->getTypeRepr(), Type());
     bool hadError = TypeChecker::validateType(
-        getASTContext(), typeLoc, TypeResolution::forContextual(DC), options);
+        getASTContext(), typeLoc, TypeResolution::forContextual(DC, options),
+        options);
 
     if (hadError)
       return nullptr;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -817,7 +817,7 @@ DefaultDefinitionTypeRequest::evaluate(Evaluator &evaluator,
   if (defaultDefinition) {
     auto resolution =
         TypeResolution::forInterface(assocType->getDeclContext(), None);
-    return resolution.resolveType(defaultDefinition, None);
+    return resolution.resolveType(defaultDefinition);
   }
 
   return Type();
@@ -1436,7 +1436,7 @@ static NominalTypeDecl *resolveSingleNominalTypeDecl(
   TypeResolutionOptions options = TypeResolverContext::TypeAliasDecl;
   options |= flags;
   if (TypeChecker::validateType(
-          Ctx, typeLoc, TypeResolution::forInterface(DC, options), options))
+          Ctx, typeLoc, TypeResolution::forInterface(DC, options)))
     return nullptr;
 
   return typeLoc.getType()->getAnyNominal();
@@ -1771,7 +1771,7 @@ UnderlyingTypeRequest::evaluate(Evaluator &evaluator,
   auto underlyingLoc = TypeLoc(typeAlias->getUnderlyingTypeRepr());
   if (TypeChecker::validateType(
           typeAlias->getASTContext(), underlyingLoc,
-          TypeResolution::forInterface(typeAlias, options), options)) {
+          TypeResolution::forInterface(typeAlias, options))) {
     typeAlias->setInvalid();
     return ErrorType::get(typeAlias->getASTContext());
   }
@@ -2021,8 +2021,7 @@ ResultTypeRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
   auto *dc = decl->getInnermostDeclContext();
   auto resolution =
       TypeResolution::forInterface(dc, TypeResolverContext::FunctionResult);
-  return resolution.resolveType(
-      resultTyRepr, TypeResolverContext::FunctionResult);
+  return resolution.resolveType(resultTyRepr);
 }
 
 ParamSpecifier
@@ -2125,7 +2124,7 @@ static Type validateParameterType(ParamDecl *decl) {
 
   auto &ctx = dc->getASTContext();
   auto resolution = TypeResolution::forInterface(dc, options);
-  if (TypeChecker::validateType(ctx, TL, resolution, options)) {
+  if (TypeChecker::validateType(ctx, TL, resolution)) {
     decl->setInvalid();
     return ErrorType::get(ctx);
   }
@@ -2545,7 +2544,7 @@ ExtendedTypeRequest::evaluate(Evaluator &eval, ExtensionDecl *ext) const {
   TypeResolutionOptions options(TypeResolverContext::ExtensionBinding);
   options |= TypeResolutionFlags::AllowUnboundGenerics;
   auto tr = TypeResolution::forStructural(ext->getDeclContext(), options);
-  auto extendedType = tr.resolveType(extendedRepr, options);
+  auto extendedType = tr.resolveType(extendedRepr);
 
   if (extendedType->hasError())
     return error();

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -136,7 +136,7 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
   auto resolution = TypeResolution::forInterface(
       dc, dc->getGenericSignatureOfContext(), options);
   bool validationError
-    = TypeChecker::validateType(ctx, constraintTypeLoc, resolution, options);
+    = TypeChecker::validateType(ctx, constraintTypeLoc, resolution);
   auto constraintType = constraintTypeLoc.getType();
   if (validationError)
     return nullptr;
@@ -674,8 +674,7 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
                                     : TypeResolverContext::FunctionInput);
         paramOptions |= TypeResolutionFlags::Direct;
 
-        auto type = resolution.withOptions(paramOptions)
-                        .resolveType(typeRepr, paramOptions);
+        auto type = resolution.withOptions(paramOptions).resolveType(typeRepr);
 
         if (auto *specifier = dyn_cast<SpecifierTypeRepr>(typeRepr))
           typeRepr = specifier->getBase();
@@ -696,8 +695,7 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
       if (resultTypeRepr && !isa<OpaqueReturnTypeRepr>(resultTypeRepr)) {
         auto resultType =
             resolution.withOptions(TypeResolverContext::FunctionResult)
-                .resolveType(resultTypeRepr,
-                             TypeResolverContext::FunctionResult);
+                .resolveType(resultTypeRepr);
 
         inferenceSources.emplace_back(resultTypeRepr, resultType);
       }
@@ -940,7 +938,7 @@ RequirementRequest::evaluate(Evaluator &evaluator,
   auto resolveType = [&](TypeLoc &typeLoc) -> Type {
     Type result;
     if (auto typeRepr = typeLoc.getTypeRepr())
-      result = resolution->resolveType(typeRepr, options);
+      result = resolution->resolveType(typeRepr);
     else
       result = typeLoc.getType();
 
@@ -992,8 +990,8 @@ Type StructuralTypeRequest::evaluate(Evaluator &evaluator,
   }
 
   auto resolution = TypeResolution::forStructural(typeAlias, options);
-  auto type = resolution.resolveType(underlyingTypeRepr, options);
-  
+  auto type = resolution.resolveType(underlyingTypeRepr);
+
   auto genericSig = typeAlias->getGenericSignature();
   SubstitutionMap subs;
   if (genericSig)

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -465,7 +465,7 @@ public:
 
     // See if the repr resolves to a type.
     Type ty = TypeChecker::resolveIdentifierType(
-        TypeResolution::forContextual(DC), repr, options);
+        TypeResolution::forContextual(DC, options), repr, options);
 
     auto *enumDecl = dyn_cast_or_null<EnumDecl>(ty->getAnyNominal());
     if (!enumDecl)
@@ -563,8 +563,8 @@ public:
       auto *prefixRepr = IdentTypeRepr::create(Context, components);
 
       // See first if the entire repr resolves to a type.
-      Type enumTy = TypeChecker::resolveIdentifierType(TypeResolution::forContextual(DC),
-                                                       prefixRepr, options);
+      Type enumTy = TypeChecker::resolveIdentifierType(
+          TypeResolution::forContextual(DC, options), prefixRepr, options);
       if (!dyn_cast_or_null<EnumDecl>(enumTy->getAnyNominal()))
         return nullptr;
 
@@ -761,7 +761,7 @@ Type PatternTypeRequest::evaluate(Evaluator &evaluator,
   // If we see an explicit type annotation, coerce the sub-pattern to
   // that type.
   case PatternKind::Typed: {
-    auto resolution = TypeResolution::forContextual(dc);
+    auto resolution = TypeResolution::forContextual(dc, options);
     TypedPattern *TP = cast<TypedPattern>(P);
     return validateTypedPattern(resolution, TP, options);
   }
@@ -1210,7 +1210,7 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
 
     // Type-check the type parameter.
     TypeResolutionOptions paramOptions(TypeResolverContext::InExpression);
-    TypeResolution resolution = TypeResolution::forContextual(dc);
+    TypeResolution resolution = TypeResolution::forContextual(dc, paramOptions);
     if (validateType(Context, IP->getCastTypeLoc(), resolution, paramOptions))
       return nullptr;
 

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -465,7 +465,7 @@ public:
 
     // See if the repr resolves to a type.
     Type ty = TypeChecker::resolveIdentifierType(
-        TypeResolution::forContextual(DC, options), repr, options);
+        TypeResolution::forContextual(DC, options), repr);
 
     auto *enumDecl = dyn_cast_or_null<EnumDecl>(ty->getAnyNominal());
     if (!enumDecl)
@@ -564,7 +564,7 @@ public:
 
       // See first if the entire repr resolves to a type.
       Type enumTy = TypeChecker::resolveIdentifierType(
-          TypeResolution::forContextual(DC, options), prefixRepr, options);
+          TypeResolution::forContextual(DC, options), prefixRepr);
       if (!dyn_cast_or_null<EnumDecl>(enumTy->getAnyNominal()))
         return nullptr;
 
@@ -694,7 +694,7 @@ static Type validateTypedPattern(TypeResolution resolution,
       hadError = true;
     }
   } else {
-    hadError = TypeChecker::validateType(Context, TL, resolution, options);
+    hadError = TypeChecker::validateType(Context, TL, resolution);
   }
 
   if (hadError) {
@@ -1211,7 +1211,7 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
     // Type-check the type parameter.
     TypeResolutionOptions paramOptions(TypeResolverContext::InExpression);
     TypeResolution resolution = TypeResolution::forContextual(dc, paramOptions);
-    if (validateType(Context, IP->getCastTypeLoc(), resolution, paramOptions))
+    if (validateType(Context, IP->getCastTypeLoc(), resolution))
       return nullptr;
 
     auto castType = IP->getCastTypeLoc().getType();

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -567,7 +567,7 @@ Type AttachedPropertyWrapperTypeRequest::evaluate(Evaluator &evaluator,
       TypeResolution::forContextual(var->getDeclContext(), options);
   if (TypeChecker::validateType(var->getASTContext(),
                                 customAttr->getTypeLoc(),
-                                resolution, options)) {
+                                resolution)) {
     return ErrorType::get(var->getASTContext());
   }
 

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -560,11 +560,11 @@ Type AttachedPropertyWrapperTypeRequest::evaluate(Evaluator &evaluator,
   if (!customAttr)
     return Type();
 
-  auto resolution =
-      TypeResolution::forContextual(var->getDeclContext());
   TypeResolutionOptions options(TypeResolverContext::PatternBindingDecl);
   options |= TypeResolutionFlags::AllowUnboundGenerics;
 
+  auto resolution =
+      TypeResolution::forContextual(var->getDeclContext(), options);
   if (TypeChecker::validateType(var->getASTContext(),
                                 customAttr->getTypeLoc(),
                                 resolution, options)) {

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -72,7 +72,7 @@ InheritedTypeRequest::evaluate(
 
   Type inheritedType;
   if (typeLoc.getTypeRepr())
-    inheritedType = resolution->resolveType(typeLoc.getTypeRepr(), options);
+    inheritedType = resolution->resolveType(typeLoc.getTypeRepr());
   else
     inheritedType = typeLoc.getType();
 

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -49,11 +49,11 @@ InheritedTypeRequest::evaluate(
   Optional<TypeResolution> resolution;
   switch (stage) {
   case TypeResolutionStage::Structural:
-    resolution = TypeResolution::forStructural(dc);
+    resolution = TypeResolution::forStructural(dc, options);
     break;
 
   case TypeResolutionStage::Interface:
-    resolution = TypeResolution::forInterface(dc);
+    resolution = TypeResolution::forInterface(dc, options);
     break;
 
   case TypeResolutionStage::Contextual: {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -442,10 +442,7 @@ TypeChecker::getDynamicBridgedThroughObjCClass(DeclContext *dc,
 
 Type TypeChecker::resolveTypeInContext(TypeDecl *typeDecl, DeclContext *foundDC,
                                        TypeResolution resolution,
-                                       TypeResolutionOptions options,
                                        bool isSpecialized) {
-  assert(resolution.getOptions() == options);
-
   auto fromDC = resolution.getDeclContext();
   ASTContext &ctx = fromDC->getASTContext();
 
@@ -712,16 +709,14 @@ static void diagnoseUnboundGenericType(Type ty, SourceLoc loc);
 /// \param resolution The type resolution to perform.
 /// \param comp The arguments to apply with the angle bracket range for
 /// diagnostics.
-/// \param options The type resolution context.
 ///
 /// \returns A BoundGenericType bound to the given arguments, or null on
 /// error.
 ///
 /// \see applyUnboundGenericArguments
-static Type applyGenericArguments(Type type,
-                                  TypeResolution resolution,
-                                  ComponentIdentTypeRepr *comp,
-                                  TypeResolutionOptions options) {
+static Type applyGenericArguments(Type type, TypeResolution resolution,
+                                  ComponentIdentTypeRepr *comp) {
+  const auto options = resolution.getOptions();
   auto dc = resolution.getDeclContext();
   auto loc = comp->getNameLoc().getBaseNameLoc();
 
@@ -794,7 +789,7 @@ static Type applyGenericArguments(Type type,
     if (auto nominal = dyn_cast<NominalTypeDecl>(decl)) {
       if (nominal->isOptionalDecl()) {
         // Validate the generic argument.
-        Type objectType = resolution.resolveType(genericArgs[0], options);
+        Type objectType = resolution.resolveType(genericArgs[0]);
         if (!objectType || objectType->hasError())
           return nullptr;
 
@@ -812,13 +807,13 @@ static Type applyGenericArguments(Type type,
   }
 
   // Resolve the types of the generic arguments.
-  options = adjustOptionsForGenericArgs(options);
-  auto genericResolution = resolution.withOptions(options);
+  auto genericResolution =
+      resolution.withOptions(adjustOptionsForGenericArgs(options));
 
   SmallVector<Type, 2> args;
   for (auto tyR : genericArgs) {
     // Propagate failure.
-    Type substTy = genericResolution.resolveType(tyR, options);
+    Type substTy = genericResolution.resolveType(tyR);
     if (!substTy || substTy->hasError())
       return ErrorType::get(ctx);
 
@@ -829,8 +824,9 @@ static Type applyGenericArguments(Type type,
       unboundType, genericDecl, loc,
       resolution, args);
 
-  if (!options.contains(TypeResolutionFlags::AllowUnavailable)) {
-    if (options.isAnyExpr() || dc->getParent()->isLocalContext())
+  const auto genericOptions = genericResolution.getOptions();
+  if (!genericOptions.contains(TypeResolutionFlags::AllowUnavailable)) {
+    if (genericOptions.isAnyExpr() || dc->getParent()->isLocalContext())
       if (dc->getResilienceExpansion() == ResilienceExpansion::Minimal)
         TypeChecker::diagnoseGenericTypeExportability(loc, result, dc);
   }
@@ -1017,15 +1013,13 @@ static void maybeDiagnoseBadConformanceRef(DeclContext *dc,
 }
 
 /// Returns a valid type or ErrorType in case of an error.
-static Type resolveTypeDecl(TypeDecl *typeDecl,
-                            DeclContext *foundDC, TypeResolution resolution,
-                            ComponentIdentTypeRepr *comp,
-                            TypeResolutionOptions options) {
+static Type resolveTypeDecl(TypeDecl *typeDecl, DeclContext *foundDC,
+                            TypeResolution resolution,
+                            ComponentIdentTypeRepr *comp) {
   // Resolve the type declaration to a specific type. How this occurs
   // depends on the current context and where the type was found.
   Type type = TypeChecker::resolveTypeInContext(
-      typeDecl, foundDC, resolution, options,
-      isa<GenericIdentTypeRepr>(comp));
+      typeDecl, foundDC, resolution, isa<GenericIdentTypeRepr>(comp));
 
   if (type->hasError() && foundDC &&
       (isa<AssociatedTypeDecl>(typeDecl) || isa<TypeAliasDecl>(typeDecl))) {
@@ -1036,7 +1030,7 @@ static Type resolveTypeDecl(TypeDecl *typeDecl,
                                    typeDecl);
   }
 
-  return applyGenericArguments(type, resolution, comp, options);
+  return applyGenericArguments(type, resolution, comp);
 }
 
 static std::string getDeclNameFromContext(DeclContext *dc,
@@ -1080,7 +1074,6 @@ static Type diagnoseUnknownType(TypeResolution resolution,
                                 Type parentType,
                                 SourceRange parentRange,
                                 ComponentIdentTypeRepr *comp,
-                                TypeResolutionOptions options,
                                 NameLookupOptions lookupOptions) {
   auto dc = resolution.getDeclContext();
   ASTContext &ctx = dc->getASTContext();
@@ -1298,21 +1291,20 @@ static SelfTypeKind getSelfTypeKind(DeclContext *dc,
 ///
 /// \returns Either the resolved type or a null type, the latter of
 /// which indicates that some dependencies were unsatisfied.
-static Type
-resolveTopLevelIdentTypeComponent(TypeResolution resolution,
-                                  ComponentIdentTypeRepr *comp,
-                                  TypeResolutionOptions options) {
-  // Short-circuiting.
+static Type resolveTopLevelIdentTypeComponent(TypeResolution resolution,
+                                              ComponentIdentTypeRepr *comp) {
+  const auto options = resolution.getOptions();
   ASTContext &ctx = resolution.getASTContext();
   auto &diags = ctx.Diags;
+
+  // Short-circuiting.
   if (comp->isInvalid()) return ErrorType::get(ctx);
 
   // If the component has already been bound to a declaration, handle
   // that now.
   if (auto *typeDecl = comp->getBoundDecl()) {
     // Resolve the type declaration within this context.
-    return resolveTypeDecl(typeDecl, comp->getDeclContext(), resolution,
-                           comp, options);
+    return resolveTypeDecl(typeDecl, comp->getDeclContext(), resolution, comp);
   }
 
   // Resolve the first component, which is the only one that requires
@@ -1335,8 +1327,7 @@ resolveTopLevelIdentTypeComponent(TypeResolution resolution,
     auto *foundDC = entry.getDeclContext();
     auto *typeDecl = cast<TypeDecl>(entry.getValueDecl());
 
-    Type type = resolveTypeDecl(typeDecl, foundDC, resolution,
-                                comp, options);
+    Type type = resolveTypeDecl(typeDecl, foundDC, resolution, comp);
     if (type->is<ErrorType>())
       return type;
 
@@ -1403,7 +1394,7 @@ resolveTopLevelIdentTypeComponent(TypeResolution resolution,
       return ErrorType::get(ctx);
 
     return diagnoseUnknownType(resolution, nullptr, SourceRange(), comp,
-                               options, lookupOptions);
+                               lookupOptions);
   }
 
   comp->setValue(currentDecl, currentDC);
@@ -1431,12 +1422,11 @@ static void diagnoseAmbiguousMemberType(Type baseTy, SourceRange baseRange,
 /// Resolve the given identifier type representation as a qualified
 /// lookup within the given parent type, returning the type it
 /// references.
-static Type resolveNestedIdentTypeComponent(
-              TypeResolution resolution,
-              Type parentTy,
-              SourceRange parentRange,
-              ComponentIdentTypeRepr *comp,
-              TypeResolutionOptions options) {
+static Type resolveNestedIdentTypeComponent(TypeResolution resolution,
+                                            Type parentTy,
+                                            SourceRange parentRange,
+                                            ComponentIdentTypeRepr *comp) {
+  const auto options = resolution.getOptions();
   auto DC = resolution.getDeclContext();
   auto &ctx = DC->getASTContext();
   auto &diags = ctx.Diags;
@@ -1481,7 +1471,7 @@ static Type resolveNestedIdentTypeComponent(
     }
 
     // If there are generic arguments, apply them now.
-    return applyGenericArguments(memberType, resolution, comp, options);
+    return applyGenericArguments(memberType, resolution, comp);
   };
 
   // Short-circuiting.
@@ -1498,7 +1488,7 @@ static Type resolveNestedIdentTypeComponent(
       // type later on.
       if (!memberType->is<DependentMemberType>() ||
           memberType->castTo<DependentMemberType>()->getAssocType()) {
-        return applyGenericArguments(memberType, resolution, comp, options);
+        return applyGenericArguments(memberType, resolution, comp);
       }
 
       return memberType;
@@ -1553,8 +1543,8 @@ static Type resolveNestedIdentTypeComponent(
     if (options.contains(TypeResolutionFlags::SilenceErrors))
       return ErrorType::get(ctx);
 
-    memberType = diagnoseUnknownType(resolution, parentTy, parentRange,
-                                     comp, options, lookupOptions);
+    memberType = diagnoseUnknownType(resolution, parentTy, parentRange, comp,
+                                     lookupOptions);
     member = comp->getBoundDecl();
     if (!member)
       return ErrorType::get(ctx);
@@ -1568,31 +1558,29 @@ static Type resolveNestedIdentTypeComponent(
   return maybeDiagnoseBadMemberType(member, memberType, inferredAssocType);
 }
 
-static Type resolveIdentTypeComponent(
-              TypeResolution resolution,
-              ArrayRef<ComponentIdentTypeRepr *> components,
-              TypeResolutionOptions options) {
+static Type
+resolveIdentTypeComponent(TypeResolution resolution,
+                          ArrayRef<ComponentIdentTypeRepr *> components) {
   auto comp = components.back();
 
   // The first component uses unqualified lookup.
   auto parentComps = components.slice(0, components.size()-1);
   if (parentComps.empty()) {
-    return resolveTopLevelIdentTypeComponent(resolution, comp, options);
+    return resolveTopLevelIdentTypeComponent(resolution, comp);
   }
 
   // All remaining components use qualified lookup.
 
   // Resolve the parent type.
-  Type parentTy = resolveIdentTypeComponent(resolution, parentComps, options);
+  Type parentTy = resolveIdentTypeComponent(resolution, parentComps);
   if (!parentTy || parentTy->hasError()) return parentTy;
   
   SourceRange parentRange(parentComps.front()->getStartLoc(),
                           parentComps.back()->getEndLoc());
 
   // Resolve the nested type.
-  return resolveNestedIdentTypeComponent(resolution, parentTy,
-                                         parentRange, comp,
-                                         options);
+  return resolveNestedIdentTypeComponent(resolution, parentTy, parentRange,
+                                         comp);
 }
 
 static bool diagnoseAvailability(IdentTypeRepr *IdType,
@@ -1643,19 +1631,16 @@ static Type applyNonEscapingFromContext(DeclContext *DC,
 }
 
 /// Returns a valid type or ErrorType in case of an error.
-Type TypeChecker::resolveIdentifierType(
-       TypeResolution resolution,
-       IdentTypeRepr *IdType,
-       TypeResolutionOptions options) {
-  assert(resolution.getOptions() == options);
-
+Type TypeChecker::resolveIdentifierType(TypeResolution resolution,
+                                        IdentTypeRepr *IdType) {
+  const auto options = resolution.getOptions();
   auto DC = resolution.getDeclContext();
   ASTContext &ctx = DC->getASTContext();
   auto &diags = ctx.Diags;
   auto ComponentRange = IdType->getComponentRange();
   auto Components = llvm::makeArrayRef(ComponentRange.begin(),
                                        ComponentRange.end());
-  Type result = resolveIdentTypeComponent(resolution, Components, options);
+  Type result = resolveIdentTypeComponent(resolution, Components);
   if (!result) return nullptr;
 
   if (auto moduleTy = result->getAs<ModuleType>()) {
@@ -1756,10 +1741,7 @@ static bool validateAutoClosureAttributeUse(DiagnosticEngine &Diags,
 }
 
 bool TypeChecker::validateType(ASTContext &Context, TypeLoc &Loc,
-                               TypeResolution resolution,
-                               TypeResolutionOptions options) {
-  assert(resolution.getOptions() == options);
-
+                               TypeResolution resolution) {
   // If we've already validated this type, don't do so again.
   if (Loc.wasValidated())
     return Loc.isError();
@@ -1767,7 +1749,7 @@ bool TypeChecker::validateType(ASTContext &Context, TypeLoc &Loc,
   if (auto *Stats = Context.Stats)
     Stats->getFrontendCounters().NumTypesValidated++;
 
-  Type type = resolution.resolveType(Loc.getTypeRepr(), options);
+  Type type = resolution.resolveType(Loc.getTypeRepr());
   Loc.setType(type);
 
   return type->hasError();
@@ -1888,9 +1870,7 @@ namespace {
   };
 } // end anonymous namespace
 
-Type TypeResolution::resolveType(TypeRepr *TyR,
-                              TypeResolutionOptions options) {
-  assert(getOptions() == options);
+Type TypeResolution::resolveType(TypeRepr *TyR) {
   auto &ctx = getASTContext();
   FrontendStatsTracer StatsTracer(ctx.Stats,
                                   "resolve-type", TyR);
@@ -1898,7 +1878,7 @@ Type TypeResolution::resolveType(TypeRepr *TyR,
 
   TypeResolver typeResolver(*this);
 
-  auto result = typeResolver.resolveType(TyR, options);
+  auto result = typeResolver.resolveType(TyR, getOptions());
 
   if (result) {
     // If we resolved down to an error, make sure to mark the typeRepr as invalid
@@ -1963,8 +1943,8 @@ Type TypeResolver::resolveType(TypeRepr *repr, TypeResolutionOptions options) {
   case TypeReprKind::SimpleIdent:
   case TypeReprKind::GenericIdent:
   case TypeReprKind::CompoundIdent:
-    return TypeChecker::resolveIdentifierType(
-        resolution.withOptions(options), cast<IdentTypeRepr>(repr), options);
+    return TypeChecker::resolveIdentifierType(resolution.withOptions(options),
+                                              cast<IdentTypeRepr>(repr));
 
   case TypeReprKind::Function: {
     if (!(options & TypeResolutionFlags::SILType)) {
@@ -3886,7 +3866,7 @@ Type swift::resolveCustomAttrType(CustomAttr *attr, DeclContext *dc,
 
   ASTContext &ctx = dc->getASTContext();
   auto resolution = TypeResolution::forContextual(dc, options);
-  if (TypeChecker::validateType(ctx, attr->getTypeLoc(), resolution, options))
+  if (TypeChecker::validateType(ctx, attr->getTypeLoc(), resolution))
     return Type();
 
   // We always require the type to resolve to a nominal type.

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -366,10 +366,8 @@ public:
   ///
   /// \param TyR The type representation to check.
   ///
-  /// \param options Options that alter type resolution.
-  ///
   /// \returns a well-formed type or an ErrorType in case of an error.
-  Type resolveType(TypeRepr *TyR, TypeResolutionOptions options);
+  Type resolveType(TypeRepr *TyR);
 
   /// Whether this type resolution uses archetypes (vs. generic parameters).
   bool usesArchetypes() const;

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -230,6 +230,15 @@ public:
     return !static_cast<bool>(unsigned(set) & ~unsigned(flags));
   }
 
+  friend bool operator==(TypeResolutionOptions lhs, TypeResolutionOptions rhs) {
+    return lhs.base == rhs.base && lhs.context == rhs.context &&
+           lhs.flags == rhs.flags;
+  }
+
+  friend bool operator!=(TypeResolutionOptions lhs, TypeResolutionOptions rhs) {
+    return !(lhs == rhs);
+  }
+
   /// Produce type resolution options with additional flags.
   friend TypeResolutionOptions operator|(TypeResolutionOptions lhs,
                                          TypeResolutionFlags rhs) {
@@ -276,6 +285,7 @@ public:
 class TypeResolution {
   DeclContext *dc;
   TypeResolutionStage stage;
+  TypeResolutionOptions options;
 
   union {
     /// The generic environment used to map to archetypes.
@@ -292,8 +302,9 @@ class TypeResolution {
     } complete;
   };
 
-  TypeResolution(DeclContext *dc, TypeResolutionStage stage)
-    : dc(dc), stage(stage) { }
+  TypeResolution(DeclContext *dc, TypeResolutionStage stage,
+                 TypeResolutionOptions options)
+      : dc(dc), stage(stage), options(options) {}
 
   GenericSignatureBuilder *getGenericSignatureBuilder() const;
 
@@ -301,28 +312,37 @@ public:
   /// Form a type resolution for the structure of a type, which does not
   /// attempt to resolve member types of type parameters to a particular
   /// associated type.
-  static TypeResolution forStructural(DeclContext *dc);
-
-  /// Form a type resolution for an interface type, which is a complete
-  /// description of the type using generic parameters.
-  static TypeResolution forInterface(DeclContext *dc);
+  static TypeResolution forStructural(DeclContext *dc,
+                                      TypeResolutionOptions opts);
 
   /// Form a type resolution for an interface type, which is a complete
   /// description of the type using generic parameters.
   static TypeResolution forInterface(DeclContext *dc,
-                                     GenericSignature genericSig);
+                                     TypeResolutionOptions opts);
+
+  /// Form a type resolution for an interface type, which is a complete
+  /// description of the type using generic parameters.
+  static TypeResolution forInterface(DeclContext *dc,
+                                     GenericSignature genericSig,
+                                     TypeResolutionOptions opts);
 
   /// Form a type resolution for a contextual type, which is a complete
   /// description of the type using the archetypes of the given declaration
   /// context.
-  static TypeResolution forContextual(DeclContext *dc);
+  static TypeResolution forContextual(DeclContext *dc,
+                                      TypeResolutionOptions opts);
 
   /// Form a type resolution for a contextual type, which is a complete
   /// description of the type using the archetypes of the given generic
   /// environment.
   static TypeResolution forContextual(DeclContext *dc,
-                                      GenericEnvironment *genericEnv);
+                                      GenericEnvironment *genericEnv,
+                                      TypeResolutionOptions opts);
 
+public:
+  TypeResolution withOptions(TypeResolutionOptions opts) const;
+
+public:
   /// Retrieve the ASTContext in which this resolution occurs.
   ASTContext &getASTContext() const;
 
@@ -332,6 +352,8 @@ public:
 
   /// Retrieve the type resolution stage.
   TypeResolutionStage getStage() const { return stage; }
+
+  TypeResolutionOptions getOptions() const { return options; }
 
   /// Retrieves the generic signature for the context, or NULL if there is
   /// no generic signature to resolve types.

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -542,7 +542,7 @@ bool swift::performTypeLocChecking(ASTContext &Ctx, TypeLoc &T,
   Optional<DiagnosticSuppression> suppression;
   if (!ProduceDiagnostics)
     suppression.emplace(Ctx.Diags);
-  return TypeChecker::validateType(Ctx, T, resolution, options);
+  return TypeChecker::validateType(Ctx, T, resolution);
 }
 
 /// Expose TypeChecker's handling of GenericParamList to SIL parsing.

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -538,7 +538,7 @@ bool swift::performTypeLocChecking(ASTContext &Ctx, TypeLoc &T,
   if (isSILType)
     options |= TypeResolutionFlags::SILType;
 
-  auto resolution = TypeResolution::forContextual(DC, GenericEnv);
+  auto resolution = TypeResolution::forContextual(DC, GenericEnv, options);
   Optional<DiagnosticSuppression> suppression;
   if (!ProduceDiagnostics)
     suppression.emplace(Ctx.Diags);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -360,8 +360,7 @@ Type getUInt8Type(ASTContext &ctx);
 
 /// Try to resolve an IdentTypeRepr, returning either the referenced
 /// Type or an ErrorType in case of error.
-Type resolveIdentifierType(TypeResolution resolution, IdentTypeRepr *IdType,
-                           TypeResolutionOptions options);
+Type resolveIdentifierType(TypeResolution resolution, IdentTypeRepr *IdType);
 
 /// Bind an UnresolvedDeclRefExpr by performing name lookup and
 /// returning the resultant expression.  Context is the DeclContext used
@@ -379,11 +378,8 @@ Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *Context);
 ///
 /// \param resolution The type resolution being performed.
 ///
-/// \param options Options that alter type resolution.
-///
 /// \returns true if type validation failed, or false otherwise.
-bool validateType(ASTContext &Ctx, TypeLoc &Loc, TypeResolution resolution,
-                  TypeResolutionOptions options);
+bool validateType(ASTContext &Ctx, TypeLoc &Loc, TypeResolution resolution);
 
 /// Check for unsupported protocol types in the given declaration.
 void checkUnsupportedProtocolType(Decl *decl);
@@ -414,8 +410,7 @@ void checkUnsupportedProtocolType(ASTContext &ctx,
 ///
 /// \returns the resolved type.
 Type resolveTypeInContext(TypeDecl *typeDecl, DeclContext *foundDC,
-                          TypeResolution resolution,
-                          TypeResolutionOptions options, bool isSpecialized);
+                          TypeResolution resolution, bool isSpecialized);
 
 /// Apply generic arguments to the given type.
 ///


### PR DESCRIPTION
Ultimately this refactoring is needed to support replacing `TypeChecker::validateType` with a request. This lays the groundwork for that by internalizing TypeResolutionOptions. This makes TypeCheckType a little more comprehensible by making it obvious when it mutates options versus when it just forwards them. It also ensures that a `TypeResolution` object is all one needs to be able to invoke, well, Type Resolution.

Most of this patch is just transposing arguments.