### PR TITLE
[NFC] Remove TypeLoc from typeCheckExpression

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4253,7 +4253,7 @@ namespace {
                                                 { Identifier() });
 
       auto resultTy = TypeChecker::typeCheckExpression(
-          callExpr, cs.DC, TypeLoc::withoutLoc(valueType), CTP_CannotFail);
+          callExpr, cs.DC, valueType, CTP_CannotFail);
       assert(resultTy && "Conversion cannot fail!");
       (void)resultTy;
 
@@ -8059,7 +8059,7 @@ static Optional<SolutionApplicationTarget> applySolutionToForEachStmt(
     Expr *convertElementExpr = elementExpr;
     if (TypeChecker::typeCheckExpression(
             convertElementExpr, dc,
-            TypeLoc::withoutLoc(optPatternType),
+            optPatternType,
             CTP_CoerceOperand).isNull()) {
       return None;
     }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1982,7 +1982,7 @@ bool GenericRequirementsCheckListener::diagnoseUnsatisfiedRequirement(
 
 #pragma mark High-level entry points
 Type TypeChecker::typeCheckExpression(Expr *&expr, DeclContext *dc,
-                                      TypeLoc convertType,
+                                      Type convertType,
                                       ContextualTypePurpose convertTypePurpose,
                                       TypeCheckExprOptions options) {
   SolutionApplicationTarget target(
@@ -2106,7 +2106,7 @@ Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
                                             bool isAutoClosure) {
   assert(paramType && !paramType->hasError());
   return typeCheckExpression(
-      defaultValue, DC, TypeLoc::withoutLoc(paramType),
+      defaultValue, DC, paramType,
       isAutoClosure ? CTP_AutoclosureDefaultParameter : CTP_DefaultParameter);
 }
 
@@ -2481,7 +2481,7 @@ bool TypeChecker::typeCheckCondition(Expr *&expr, DeclContext *dc) {
     return true;
 
   auto resultTy = TypeChecker::typeCheckExpression(
-      expr, dc, TypeLoc::withoutLoc(boolDecl->getDeclaredType()),
+      expr, dc, boolDecl->getDeclaredType(),
       CTP_Condition);
   return !resultTy;
 }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1056,7 +1056,7 @@ EnumRawValuesRequest::evaluate(Evaluator &eval, EnumDecl *ED,
     {
       Expr *exprToCheck = prevValue;
       if (TypeChecker::typeCheckExpression(exprToCheck, ED,
-                                           TypeLoc::withoutLoc(rawTy),
+                                           rawTy,
                                            CTP_EnumCaseRawValue)) {
         TypeChecker::checkEnumElementErrorHandling(elt, exprToCheck);
       }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -524,7 +524,7 @@ public:
     }
 
     auto exprTy = TypeChecker::typeCheckExpression(E, DC,
-                                                   TypeLoc::withoutLoc(ResultTy),
+                                                   ResultTy,
                                                    ctp, options);
     RS->setResult(E);
 
@@ -585,7 +585,7 @@ public:
       }
 
       TypeChecker::typeCheckExpression(exprToCheck, DC,
-                                       TypeLoc::withoutLoc(contextType),
+                                       contextType,
                                        contextTypePurpose);
 
       // Propagate the change into the inout expression we stripped before.
@@ -608,7 +608,7 @@ public:
     Type exnType = getASTContext().getErrorDecl()->getDeclaredType();
     if (!exnType) return TS;
 
-    TypeChecker::typeCheckExpression(E, DC, TypeLoc::withoutLoc(exnType),
+    TypeChecker::typeCheckExpression(E, DC, exnType,
                                      CTP_ThrowStmt);
     TS->setSubExpr(E);
     
@@ -1592,7 +1592,7 @@ Stmt *StmtChecker::visitBraceStmt(BraceStmt *BS) {
       }
 
       auto resultTy =
-          TypeChecker::typeCheckExpression(SubExpr, DC, TypeLoc(),
+          TypeChecker::typeCheckExpression(SubExpr, DC, Type(),
                                            CTP_Unused, options);
 
       // If a closure expression is unused, the user might have intended
@@ -1673,7 +1673,7 @@ static Expr* constructCallToSuperInit(ConstructorDecl *ctor,
 
   DiagnosticSuppression suppression(ctor->getASTContext().Diags);
   auto resultTy =
-      TypeChecker::typeCheckExpression(r, ctor, TypeLoc(), CTP_Unused,
+      TypeChecker::typeCheckExpression(r, ctor, Type(), CTP_Unused,
                                        TypeCheckExprFlags::IsDiscarded);
   if (!resultTy)
     return nullptr;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -653,7 +653,7 @@ swift::getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
 bool swift::typeCheckExpression(DeclContext *DC, Expr *&parsedExpr) {
   auto &ctx = DC->getASTContext();
   DiagnosticSuppression suppression(ctx.Diags);
-  auto resultTy = TypeChecker::typeCheckExpression(parsedExpr, DC, TypeLoc(),
+  auto resultTy = TypeChecker::typeCheckExpression(parsedExpr, DC, Type(),
                                                    CTP_Unused);
   return !resultTy;
 }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -694,16 +694,14 @@ Expr *findLHS(DeclContext *DC, Expr *E, Identifier name);
 /// to be possible.
 ///
 /// \param convertType The type that the expression is being converted to,
-/// or null if the expression is standalone. The location information is
-/// only used for diagnostics should the conversion fail; it is safe to pass
-/// a TypeLoc without location information.
+/// or null if the expression is standalone.
 ///
 /// \param options Options that control how type checking is performed.
 ///
 /// \returns The type of the top-level expression, or Type() if an
 ///          error occurred.
 Type typeCheckExpression(Expr *&expr, DeclContext *dc,
-                         TypeLoc convertType = TypeLoc(),
+                         Type convertType = Type(),
                          ContextualTypePurpose convertTypePurpose = CTP_Unused,
                          TypeCheckExprOptions options = TypeCheckExprOptions());
 


### PR DESCRIPTION
Turns out, no callers were taking advantage of the location information in the TypeLoc.

Noticed this while I was cleaning up TypeCheckType.