### PR TITLE
[Serialization] Remove duplicated IsSIB bit

### DIFF
--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -306,16 +306,15 @@ class SerializedASTFile final : public LoadedFile {
 
   ModuleFile &File;
 
-  bool IsSIB;
-
-  SerializedASTFile(ModuleDecl &M, ModuleFile &file, bool isSIB = false)
-    : LoadedFile(FileUnitKind::SerializedAST, M), File(file), IsSIB(isSIB) {}
+  SerializedASTFile(ModuleDecl &M, ModuleFile &file)
+    : LoadedFile(FileUnitKind::SerializedAST, M), File(file) {}
 
   void
   collectLinkLibrariesFromImports(ModuleDecl::LinkLibraryCallback callback) const;
 
 public:
-  bool isSIB() const { return IsSIB; }
+  /// Whether this represents a '.sib' file.
+  bool isSIB() const;
 
   /// Returns the language version that was used to compile the contents of this
   /// file.

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -677,8 +677,7 @@ FileUnit *SerializedModuleLoaderBase::loadAST(
     M.setResilienceStrategy(extendedInfo.getResilienceStrategy());
 
     // We've loaded the file. Now try to bring it into the AST.
-    auto fileUnit = new (Ctx) SerializedASTFile(M, *loadedModuleFile,
-                                                extendedInfo.isSIB());
+    auto fileUnit = new (Ctx) SerializedASTFile(M, *loadedModuleFile);
     M.addFile(*fileUnit);
     if (extendedInfo.isTestable())
       M.setTestingEnabled();
@@ -1098,6 +1097,10 @@ void SerializedASTFile::collectLinkLibraries(
   } else {
     File.collectLinkLibraries(callback);
   }
+}
+
+bool SerializedASTFile::isSIB() const {
+  return File.IsSIB;
 }
 
 bool SerializedASTFile::isSystemModule() const {


### PR DESCRIPTION
Store the bit on the `ModuleFile`, and query it from the `SerializedASTFile`.