### PR TITLE
Revert "Merge llvm:master; fix SmallVectorBase in the swift runtime."

### DIFF
--- a/stdlib/public/runtime/LLVMSupport.cpp
+++ b/stdlib/public/runtime/LLVMSupport.cpp
@@ -37,30 +37,21 @@ report_bad_alloc_error(const char *Reason, bool GenCrashDiag) {}
 // TODO: This is a hack. This implementaiton is copied from LLVM and has to stay
 // in sync with it.
 
-// Note: Moving this function into the header may cause performance regression.
-template <class Size_T>
+/// grow_pod - This is an implementation of the grow() method which only works
+/// on POD-like datatypes and is out of line to reduce code duplication.
 void
 #if !defined(_WIN32)
 __attribute__((__weak__, __visibility__("hidden")))
 #endif
-SmallVectorBase<Size_T>::grow_pod(void *FirstEl, size_t MinCapacity,
-                                       size_t TSize) {
-  // Ensure we can fit the new capacity.
-  // This is only going to be applicable when the capacity is 32 bit.
-  if (MinCapacity > SizeTypeMax())
+llvm::SmallVectorBase::grow_pod(void *FirstEl, size_t MinCapacity,
+                                size_t TSize) {
+  // Ensure we can fit the new capacity in 32 bits.
+  if (MinCapacity > UINT32_MAX)
     report_bad_alloc_error("SmallVector capacity overflow during allocation");
 
-  // Ensure we can meet the guarantee of space for at least one more element.
-  // The above check alone will not catch the case where grow is called with a
-  // default MinCapacity of 0, but the current capacity cannot be increased.
-  // This is only going to be applicable when the capacity is 32 bit.
-  if (capacity() == SizeTypeMax())
-    report_bad_alloc_error("SmallVector capacity unable to grow");
-
-  // In theory 2*capacity can overflow if the capacity is 64 bit, but the
-  // original capacity would never be large enough for this to be a problem.
   size_t NewCapacity = 2 * capacity() + 1; // Always grow.
-  NewCapacity = std::min(std::max(NewCapacity, MinCapacity), SizeTypeMax());
+  NewCapacity =
+    std::min(std::max(NewCapacity, MinCapacity), size_t(UINT32_MAX));
 
   void *NewElts;
   if (BeginX == FirstEl) {
@@ -76,9 +67,6 @@ SmallVectorBase<Size_T>::grow_pod(void *FirstEl, size_t MinCapacity,
   this->BeginX = NewElts;
   this->Capacity = NewCapacity;
 }
-
-template class llvm::SmallVectorBase<uint32_t>;
-template class llvm::SmallVectorBase<uint64_t>;
 
 } // end namespace llvm
 #endif // defined(swiftCore_EXPORTS)


### PR DESCRIPTION
Reverts apple/swift#31454