### PR TITLE
Register operator dependencies on direct lookup requests

### DIFF
--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -649,16 +649,15 @@ template <typename OperatorType>
 class LookupOperatorRequest
     : public SimpleRequest<LookupOperatorRequest<OperatorType>,
                            OperatorType *(OperatorLookupDescriptor),
-                           RequestFlags::Cached|RequestFlags::DependencySink> {
+                           RequestFlags::Cached> {
   using SimpleRequest<LookupOperatorRequest<OperatorType>,
                       OperatorType *(OperatorLookupDescriptor),
-                      RequestFlags::Cached |
-                          RequestFlags::DependencySink>::SimpleRequest;
+                      RequestFlags::Cached>::SimpleRequest;
 
 private:
   friend SimpleRequest<LookupOperatorRequest<OperatorType>,
                        OperatorType *(OperatorLookupDescriptor),
-                       RequestFlags::Cached|RequestFlags::DependencySink>;
+                       RequestFlags::Cached>;
 
   // Evaluation.
   OperatorType *evaluate(Evaluator &evaluator,
@@ -667,11 +666,6 @@ private:
 public:
   // Cached.
   bool isCached() const { return true; }
-
-public:
-  // Incremental dependencies
-  void writeDependencySink(evaluator::DependencyCollector &tracker,
-                           OperatorType *o) const;
 };
 
 using LookupPrefixOperatorRequest = LookupOperatorRequest<PrefixOperatorDecl>;
@@ -685,7 +679,8 @@ class DirectOperatorLookupRequest
     : public SimpleRequest<DirectOperatorLookupRequest,
                            TinyPtrVector<OperatorDecl *>(
                                OperatorLookupDescriptor, OperatorFixity),
-                           RequestFlags::Uncached> {
+                           RequestFlags::Uncached |
+                               RequestFlags::DependencySink> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -695,6 +690,11 @@ private:
   TinyPtrVector<OperatorDecl *>
   evaluate(Evaluator &evaluator, OperatorLookupDescriptor descriptor,
            OperatorFixity fixity) const;
+
+public:
+  // Incremental dependencies.
+  void writeDependencySink(evaluator::DependencyCollector &tracker,
+                           TinyPtrVector<OperatorDecl *> ops) const;
 };
 
 /// Looks up an precedencegroup in a given file or module without looking
@@ -703,7 +703,8 @@ class DirectPrecedenceGroupLookupRequest
     : public SimpleRequest<DirectPrecedenceGroupLookupRequest,
                            TinyPtrVector<PrecedenceGroupDecl *>(
                                OperatorLookupDescriptor),
-                           RequestFlags::Uncached> {
+                           RequestFlags::Uncached |
+                               RequestFlags::DependencySink> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -712,6 +713,11 @@ private:
 
   TinyPtrVector<PrecedenceGroupDecl *>
   evaluate(Evaluator &evaluator, OperatorLookupDescriptor descriptor) const;
+
+public:
+  // Incremental dependencies.
+  void writeDependencySink(evaluator::DependencyCollector &tracker,
+                           TinyPtrVector<PrecedenceGroupDecl *> groups) const;
 };
 
 class LookupConformanceDescriptor final {


### PR DESCRIPTION
Make sure a dependency gets registered when a direct lookup for an operator or precedence group decl is fired off. This is necessary in order to ensure that operator redeclaration checking records the right dependencies (and any future logic that might want to perform direct operator lookups).

In doing so, this PR also removes the compatibility logic for the old referenced name tracker that would skip recording dependencies in certain cases. This should be safe as the new logic will record strictly more dependencies than the old logic.

