### PR TITLE
Define ResolveTypeRequest

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -152,6 +152,9 @@ WARNING(warn_property_wrapper_module_scope,none,
         "wrapper %0; please qualify the reference with %1",
         (DeclNameRef, Identifier))
 
+NOTE(circular_type_resolution_note,none,
+     "while resolving type %0", (TypeRepr *))
+
 //------------------------------------------------------------------------------
 // MARK: Cross-import overlay loading diagnostics
 //------------------------------------------------------------------------------

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -50,6 +50,7 @@ class TrailingWhereClause;
 class TypeAliasDecl;
 class TypeLoc;
 class Witness;
+class TypeResolution;
 struct TypeWitnessAndDecl;
 class ValueDecl;
 enum class OpaqueReadOwnership: uint8_t;
@@ -2405,6 +2406,28 @@ public:
   // Cached.
   bool isCached() const { return true; }
 };
+
+class ResolveTypeRequest
+    : public SimpleRequest<ResolveTypeRequest,
+                           Type(TypeResolution *, TypeRepr *),
+                           RequestFlags::Uncached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+public:
+  // Cycle handling.
+  void noteCycleStep(DiagnosticEngine &diags) const;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  Type evaluate(Evaluator &evaluator, TypeResolution *resolution,
+                TypeRepr *repr) const;
+};
+
+void simple_display(llvm::raw_ostream &out, const TypeResolution *resolution);
+SourceLoc extractNearestSourceLoc(const TypeRepr *repr);
 
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -226,6 +226,8 @@ SWIFT_REQUEST(TypeChecker, ResolveImplicitMemberRequest,
 SWIFT_REQUEST(TypeChecker, ResolveTypeEraserTypeRequest,
               Type(ProtocolDecl *, TypeEraserAttr *),
               SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, ResolveTypeRequest,
+              Type (TypeResolution *, TypeRepr *), Uncached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SPIGroupsRequest,
               llvm::ArrayRef<Identifier>(Decl *),
               Cached, NoLocationInfo)

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1501,3 +1501,23 @@ void swift::simple_display(llvm::raw_ostream &out,
   out << "implicit import of ";
   simple_display(out, import.Module);
 }
+
+//----------------------------------------------------------------------------//
+// ResolveTypeRequest computation.
+//----------------------------------------------------------------------------//
+
+void ResolveTypeRequest::noteCycleStep(DiagnosticEngine &diags) const {
+  auto *repr = std::get<1>(getStorage());
+  diags.diagnose(repr->getLoc(), diag::circular_type_resolution_note, repr);
+}
+
+void swift::simple_display(llvm::raw_ostream &out,
+                           const TypeResolution *resolution) {
+  out << "while resolving type ";
+}
+
+SourceLoc swift::extractNearestSourceLoc(const TypeRepr *repr) {
+  if (!repr)
+    return SourceLoc();
+  return repr->getLoc();
+}

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1453,8 +1453,7 @@ namespace {
       TypeResolutionOptions options(TypeResolverContext::InExpression);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
       bool hadError = TypeChecker::validateType(
-          CS.getASTContext(), loc,
-          TypeResolution::forContextual(CS.DC, options));
+          loc, TypeResolution::forContextual(CS.DC, options));
       return hadError ? Type() : loc.getType();
     }
 
@@ -1716,8 +1715,7 @@ namespace {
             options |= TypeResolutionFlags::AllowUnboundGenerics;
             auto tyLoc = TypeLoc{specializations[i]};
             if (TypeChecker::validateType(
-                    CS.getASTContext(), tyLoc,
-                    TypeResolution::forContextual(CS.DC, options)))
+                    tyLoc, TypeResolution::forContextual(CS.DC, options)))
               return Type();
 
             CS.addConstraint(ConstraintKind::Bind,
@@ -2660,7 +2658,7 @@ namespace {
           pattern = pattern->getSemanticsProvidingPattern();
           while (auto isp = dyn_cast<IsPattern>(pattern)) {
             if (TypeChecker::validateType(
-                    CS.getASTContext(), isp->getCastTypeLoc(),
+                    isp->getCastTypeLoc(),
                     TypeResolution::forContextual(
                         CS.DC, TypeResolverContext::InExpression))) {
               return false;
@@ -2986,7 +2984,7 @@ namespace {
       TypeResolutionOptions options(TypeResolverContext::ExplicitCastExpr);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
       if (TypeChecker::validateType(
-              CS.getASTContext(), expr->getCastTypeLoc(),
+              expr->getCastTypeLoc(),
               TypeResolution::forContextual(CS.DC, options)))
         return nullptr;
 
@@ -3015,7 +3013,7 @@ namespace {
       TypeResolutionOptions options(TypeResolverContext::ExplicitCastExpr);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
       if (TypeChecker::validateType(
-              CS.getASTContext(), expr->getCastTypeLoc(),
+              expr->getCastTypeLoc(),
               TypeResolution::forContextual(CS.DC, options)))
         return nullptr;
 
@@ -3042,7 +3040,6 @@ namespace {
     }
 
     Type visitConditionalCheckedCastExpr(ConditionalCheckedCastExpr *expr) {
-      auto &ctx = CS.getASTContext();
       auto fromExpr = expr->getSubExpr();
       if (!fromExpr) // Either wasn't constructed correctly or wasn't folded.
         return nullptr;
@@ -3051,7 +3048,7 @@ namespace {
       TypeResolutionOptions options(TypeResolverContext::ExplicitCastExpr);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
       if (TypeChecker::validateType(
-              ctx, expr->getCastTypeLoc(),
+              expr->getCastTypeLoc(),
               TypeResolution::forContextual(CS.DC, options)))
         return nullptr;
 
@@ -3081,7 +3078,7 @@ namespace {
       TypeResolutionOptions options(TypeResolverContext::ExplicitCastExpr);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
       if (TypeChecker::validateType(
-              ctx, expr->getCastTypeLoc(),
+              expr->getCastTypeLoc(),
               TypeResolution::forContextual(CS.DC, options)))
         return nullptr;
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1918,7 +1918,7 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
 
     typeLoc = TypeLoc(typeExpr->getTypeRepr(), Type());
     bool hadError = TypeChecker::validateType(
-        getASTContext(), typeLoc, TypeResolution::forContextual(DC, options));
+        typeLoc, TypeResolution::forContextual(DC, options));
 
     if (hadError)
       return nullptr;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1916,12 +1916,11 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
     TypeResolutionOptions options(TypeResolverContext::InExpression);
     options |= TypeResolutionFlags::AllowUnboundGenerics;
 
-    typeLoc = TypeLoc(typeExpr->getTypeRepr(), Type());
-    bool hadError = TypeChecker::validateType(
-        typeLoc, TypeResolution::forContextual(DC, options));
-
-    if (hadError)
+    auto result = TypeResolution::forContextual(DC, options)
+                      .resolveType(typeExpr->getTypeRepr());
+    if (result->hasError())
       return nullptr;
+    typeLoc = TypeLoc{typeExpr->getTypeRepr(), result};
   }
 
   if (!typeLoc.getType() || !typeLoc.getType()->getAnyNominal())

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1435,8 +1435,8 @@ static NominalTypeDecl *resolveSingleNominalTypeDecl(
 
   TypeResolutionOptions options = TypeResolverContext::TypeAliasDecl;
   options |= flags;
-  if (TypeChecker::validateType(
-          Ctx, typeLoc, TypeResolution::forInterface(DC, options)))
+  if (TypeChecker::validateType(typeLoc,
+                                TypeResolution::forInterface(DC, options)))
     return nullptr;
 
   return typeLoc.getType()->getAnyNominal();
@@ -1770,8 +1770,7 @@ UnderlyingTypeRequest::evaluate(Evaluator &evaluator,
 
   auto underlyingLoc = TypeLoc(typeAlias->getUnderlyingTypeRepr());
   if (TypeChecker::validateType(
-          typeAlias->getASTContext(), underlyingLoc,
-          TypeResolution::forInterface(typeAlias, options))) {
+          underlyingLoc, TypeResolution::forInterface(typeAlias, options))) {
     typeAlias->setInvalid();
     return ErrorType::get(typeAlias->getASTContext());
   }
@@ -2124,7 +2123,7 @@ static Type validateParameterType(ParamDecl *decl) {
 
   auto &ctx = dc->getASTContext();
   auto resolution = TypeResolution::forInterface(dc, options);
-  if (TypeChecker::validateType(ctx, TL, resolution)) {
+  if (TypeChecker::validateType(TL, resolution)) {
     decl->setInvalid();
     return ErrorType::get(ctx);
   }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1431,15 +1431,13 @@ static NominalTypeDecl *resolveSingleNominalTypeDecl(
     TypeResolutionFlags flags = TypeResolutionFlags(0)) {
   auto *TyR = new (Ctx) SimpleIdentTypeRepr(DeclNameLoc(loc),
                                             DeclNameRef(ident));
-  TypeLoc typeLoc = TypeLoc(TyR);
 
   TypeResolutionOptions options = TypeResolverContext::TypeAliasDecl;
   options |= flags;
-  if (TypeChecker::validateType(typeLoc,
-                                TypeResolution::forInterface(DC, options)))
+  auto result = TypeResolution::forInterface(DC, options).resolveType(TyR);
+  if (result->hasError())
     return nullptr;
-
-  return typeLoc.getType()->getAnyNominal();
+  return result->getAnyNominal();
 }
 
 bool swift::checkDesignatedTypes(OperatorDecl *OD,
@@ -1768,13 +1766,13 @@ UnderlyingTypeRequest::evaluate(Evaluator &evaluator,
     return ErrorType::get(typeAlias->getASTContext());
   }
 
-  auto underlyingLoc = TypeLoc(typeAlias->getUnderlyingTypeRepr());
-  if (TypeChecker::validateType(
-          underlyingLoc, TypeResolution::forInterface(typeAlias, options))) {
+  auto result = TypeResolution::forInterface(typeAlias, options)
+                    .resolveType(underlyingRepr);
+  if (result->hasError()) {
     typeAlias->setInvalid();
     return ErrorType::get(typeAlias->getASTContext());
   }
-  return underlyingLoc.getType();
+  return result;
 }
 
 /// Bind the given function declaration, which declares an operator, to the
@@ -2119,16 +2117,14 @@ static Type validateParameterType(ParamDecl *decl) {
                        TypeResolverContext::FunctionInput);
   options |= TypeResolutionFlags::Direct;
 
-  auto TL = TypeLoc(decl->getTypeRepr());
-
   auto &ctx = dc->getASTContext();
-  auto resolution = TypeResolution::forInterface(dc, options);
-  if (TypeChecker::validateType(TL, resolution)) {
+  auto Ty = TypeResolution::forInterface(dc, options)
+                .resolveType(decl->getTypeRepr());
+  if (Ty->hasError()) {
     decl->setInvalid();
     return ErrorType::get(ctx);
   }
 
-  Type Ty = TL.getType();
   if (decl->isVariadic()) {
     Ty = TypeChecker::getArraySliceType(decl->getStartLoc(), Ty);
     if (Ty.isNull()) {
@@ -2145,7 +2141,7 @@ static Type validateParameterType(ParamDecl *decl) {
 
     return Ty;
   }
-  return TL.getType();
+  return Ty;
 }
 
 Type

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -135,8 +135,8 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
   // Pass along the error type if resolving the repr failed.
   auto resolution = TypeResolution::forInterface(
       dc, dc->getGenericSignatureOfContext(), options);
-  bool validationError
-    = TypeChecker::validateType(ctx, constraintTypeLoc, resolution);
+  bool validationError =
+      TypeChecker::validateType(constraintTypeLoc, resolution);
   auto constraintType = constraintTypeLoc.getType();
   if (validationError)
     return nullptr;

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -131,14 +131,11 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
   // Try to resolve the constraint repr. It should be some kind of existential
   // type.
   TypeResolutionOptions options(TypeResolverContext::GenericRequirement);
-  TypeLoc constraintTypeLoc(repr->getConstraint());
   // Pass along the error type if resolving the repr failed.
-  auto resolution = TypeResolution::forInterface(
-      dc, dc->getGenericSignatureOfContext(), options);
-  bool validationError =
-      TypeChecker::validateType(constraintTypeLoc, resolution);
-  auto constraintType = constraintTypeLoc.getType();
-  if (validationError)
+  auto constraintType = TypeResolution::forInterface(
+                            dc, dc->getGenericSignatureOfContext(), options)
+                            .resolveType(repr->getConstraint());
+  if (constraintType->hasError())
     return nullptr;
   
   // Error out if the constraint type isn't a class or existential type.

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -694,7 +694,7 @@ static Type validateTypedPattern(TypeResolution resolution,
       hadError = true;
     }
   } else {
-    hadError = TypeChecker::validateType(Context, TL, resolution);
+    hadError = TypeChecker::validateType(TL, resolution);
   }
 
   if (hadError) {
@@ -1211,7 +1211,7 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
     // Type-check the type parameter.
     TypeResolutionOptions paramOptions(TypeResolverContext::InExpression);
     TypeResolution resolution = TypeResolution::forContextual(dc, paramOptions);
-    if (validateType(Context, IP->getCastTypeLoc(), resolution))
+    if (validateType(IP->getCastTypeLoc(), resolution))
       return nullptr;
 
     auto castType = IP->getCastTypeLoc().getType();

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -561,9 +561,7 @@ Type AttachedPropertyWrapperTypeRequest::evaluate(Evaluator &evaluator,
 
   auto resolution =
       TypeResolution::forContextual(var->getDeclContext(), options);
-  if (TypeChecker::validateType(var->getASTContext(),
-                                customAttr->getTypeLoc(),
-                                resolution)) {
+  if (TypeChecker::validateType(customAttr->getTypeLoc(), resolution)) {
     return ErrorType::get(var->getASTContext());
   }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -21,7 +21,6 @@
 #include "TypeCheckType.h"
 #include "TypoCorrection.h"
 
-#include "swift/Strings.h"
 #include "swift/AST/ASTDemangler.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
@@ -35,12 +34,14 @@
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SourceFile.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeLoc.h"
 #include "swift/AST/TypeResolutionStage.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/Basic/StringExtras.h"
 #include "swift/ClangImporter/ClangImporter.h"
+#include "swift/Strings.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallString.h"
@@ -1748,7 +1749,7 @@ bool TypeChecker::validateType(TypeLoc &Loc, TypeResolution resolution) {
   if (auto *Stats = resolution.getASTContext().Stats)
     Stats->getFrontendCounters().NumTypesValidated++;
 
-  Type type = resolution.resolveType(Loc.getTypeRepr());
+  auto type = resolution.resolveType(Loc.getTypeRepr());
   Loc.setType(type);
 
   return type->hasError();
@@ -1871,33 +1872,38 @@ namespace {
 
 Type TypeResolution::resolveType(TypeRepr *TyR) {
   auto &ctx = getASTContext();
-  FrontendStatsTracer StatsTracer(ctx.Stats,
-                                  "resolve-type", TyR);
-  PrettyStackTraceTypeRepr stackTrace(ctx, "resolving", TyR);
+  auto Ty =
+      evaluateOrDefault(ctx.evaluator, ResolveTypeRequest{this, TyR}, Type());
+  if (!Ty)
+    return ErrorType::get(ctx);
+  return Ty;
+}
 
-  TypeResolver typeResolver(*this);
+Type ResolveTypeRequest::evaluate(Evaluator &evaluator,
+                                  TypeResolution *resolution,
+                                  TypeRepr *TyR) const {
+  const auto options = resolution->getOptions();
+  auto &ctx = resolution->getASTContext();
+  auto result =
+      TypeResolver(*resolution).resolveType(TyR, resolution->getOptions());
 
-  auto result = typeResolver.resolveType(TyR, getOptions());
-
-  if (result) {
-    // If we resolved down to an error, make sure to mark the typeRepr as invalid
-    // so we don't produce a redundant diagnostic.
-    if (result->hasError()) {
-      TyR->setInvalid();
-      return result;
-    }
-
-    auto loc = TyR->getLoc();
-
-    if (options.contains(TypeResolutionFlags::SILType)
-        && !result->isLegalSILType()) {
-      ctx.Diags.diagnose(loc, diag::illegal_sil_type, result);
-      return ErrorType::get(ctx);
-    }
-
-    if (validateAutoClosureAttributeUse(ctx.Diags, TyR, result, options))
-      return ErrorType::get(ctx);
+  // If we resolved down to an error, make sure to mark the typeRepr as invalid
+  // so we don't produce a redundant diagnostic.
+  if (result->hasError()) {
+    TyR->setInvalid();
+    return result;
   }
+
+  auto loc = TyR->getLoc();
+
+  if (options.contains(TypeResolutionFlags::SILType)
+      && !result->isLegalSILType()) {
+    ctx.Diags.diagnose(loc, diag::illegal_sil_type, result);
+    return ErrorType::get(ctx);
+  }
+
+  if (validateAutoClosureAttributeUse(ctx.Diags, TyR, result, options))
+    return ErrorType::get(ctx);
 
   return result;
 }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1740,13 +1740,12 @@ static bool validateAutoClosureAttributeUse(DiagnosticEngine &Diags,
   return !isValid;
 }
 
-bool TypeChecker::validateType(ASTContext &Context, TypeLoc &Loc,
-                               TypeResolution resolution) {
+bool TypeChecker::validateType(TypeLoc &Loc, TypeResolution resolution) {
   // If we've already validated this type, don't do so again.
   if (Loc.wasValidated())
     return Loc.isError();
 
-  if (auto *Stats = Context.Stats)
+  if (auto *Stats = resolution.getASTContext().Stats)
     Stats->getFrontendCounters().NumTypesValidated++;
 
   Type type = resolution.resolveType(Loc.getTypeRepr());
@@ -3866,7 +3865,7 @@ Type swift::resolveCustomAttrType(CustomAttr *attr, DeclContext *dc,
 
   ASTContext &ctx = dc->getASTContext();
   auto resolution = TypeResolution::forContextual(dc, options);
-  if (TypeChecker::validateType(ctx, attr->getTypeLoc(), resolution))
+  if (TypeChecker::validateType(attr->getTypeLoc(), resolution))
     return Type();
 
   // We always require the type to resolve to a nominal type.

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -542,7 +542,7 @@ bool swift::performTypeLocChecking(ASTContext &Ctx, TypeLoc &T,
   Optional<DiagnosticSuppression> suppression;
   if (!ProduceDiagnostics)
     suppression.emplace(Ctx.Diags);
-  return TypeChecker::validateType(Ctx, T, resolution);
+  return TypeChecker::validateType(T, resolution);
 }
 
 /// Expose TypeChecker's handling of GenericParamList to SIL parsing.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -379,7 +379,7 @@ Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *Context);
 /// \param resolution The type resolution being performed.
 ///
 /// \returns true if type validation failed, or false otherwise.
-bool validateType(ASTContext &Ctx, TypeLoc &Loc, TypeResolution resolution);
+bool validateType(TypeLoc &Loc, TypeResolution resolution);
 
 /// Check for unsupported protocol types in the given declaration.
 void checkUnsupportedProtocolType(Decl *decl);

--- a/test/CircularReferences/global_typealias.swift
+++ b/test/CircularReferences/global_typealias.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-typealias A = B // expected-error {{type alias 'A' references itself}} expected-note {{through reference here}}
-typealias C = D // expected-note {{through reference here}} expected-note {{through reference here}}
-typealias D = (A, Int) // expected-note {{through reference here}} expected-note {{through reference here}}
-typealias B = C // expected-note {{through reference here}} expected-note {{through reference here}}
+typealias A = B // expected-error {{type alias 'A' references itself}} expected-note {{while resolving type 'B'}} expected-note {{through reference here}}
+typealias C = D // expected-note {{through reference here}} expected-note {{while resolving type 'D'}} expected-note {{through reference here}}
+typealias D = (A, Int) // expected-note {{through reference here}} expected-note {{while resolving type '(A, Int)'}} expected-note {{through reference here}}
+typealias B = C // expected-note {{through reference here}} expected-note {{while resolving type 'C'}} expected-note {{through reference here}}

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -231,7 +231,8 @@ class Bottom<T : Bottom<Top>> {}
 // expected-error@-1 {{generic class 'Bottom' references itself}}
 // expected-note@-2 {{type declared here}}
 // expected-error@-3 {{circular reference}}
-// expected-note@-4 {{through reference here}}
+// expected-note@-4 {{while resolving type 'Bottom<Top>'}}
+// expected-note@-5 {{through reference here}}
 
 // Invalid inheritance clause
 

--- a/test/Sema/circular_decl_checking.swift
+++ b/test/Sema/circular_decl_checking.swift
@@ -66,7 +66,7 @@ class X {
 // <rdar://problem/17144076> recursive typealias causes a segfault in the type checker
 struct SomeStruct<A> {
   typealias A = A // this is OK now -- the underlying type is the generic parameter 'A'
-  typealias B = B // expected-error {{type alias 'B' references itself}}
+  typealias B = B // expected-error {{type alias 'B' references itself}} expected-note {{while resolving type 'B'}}
 }
 
 // <rdar://problem/27680407> Infinite recursion when using fully-qualified associatedtype name that has not been defined with typealias

--- a/test/Sema/diag_typealias.swift
+++ b/test/Sema/diag_typealias.swift
@@ -2,4 +2,4 @@
 
 struct S {}
 
-typealias S = S // expected-error {{type alias 'S' references itself}} expected-note {{through reference here}}
+typealias S = S // expected-error {{type alias 'S' references itself}} expected-note {{while resolving type 'S'}} expected-note {{through reference here}}

--- a/test/decl/circularity.swift
+++ b/test/decl/circularity.swift
@@ -71,7 +71,8 @@ class C1 {
 class C2: C1, P {
     override func run(a: A) {}
     // expected-error@-1 {{circular reference}}
-    // expected-note@-2 2{{through reference here}}
+    // expected-note@-2 {{while resolving type 'A'}}
+    // expected-note@-3 2{{through reference here}}
 }
 
 // Another crash to the above
@@ -98,7 +99,8 @@ class C4 {
 
 class D4 : C4, P1 { // expected-note 2 {{through reference here}}
   required init(x: X) { // expected-error {{circular reference}}
-    // expected-note@-1 2{{through reference here}}
+    // expected-note@-1 {{while resolving type 'X'}}
+    // expected-note@-2 2{{through reference here}}
     super.init(x: x)
   }
 }

--- a/test/decl/init/basic_init.swift
+++ b/test/decl/init/basic_init.swift
@@ -10,7 +10,7 @@ class C {
 	init() {}
 }
 
-typealias t = t // expected-error {{type alias 't' references itself}} expected-note {{through reference here}}
+typealias t = t // expected-error {{type alias 't' references itself}} expected-note {{while resolving type 't'}} expected-note {{through reference here}}
 
 extension Foo {
   convenience init() {} // expected-error{{invalid redeclaration of synthesized 'init()'}}

--- a/test/decl/protocol/req/recursion.swift
+++ b/test/decl/protocol/req/recursion.swift
@@ -46,6 +46,7 @@ public protocol P {
 public struct S<A: P> where A.T == S<A> { // expected-error {{circular reference}}
 // expected-note@-1 {{type declared here}}
 // expected-error@-2 {{generic struct 'S' references itself}}
+// expected-note@-3 {{while resolving type 'S<A>'}}
   func f(a: A.T) {
     g(a: id(t: a))
     // expected-error@-1 {{cannot convert value of type 'A.T' to expected argument type 'S<A>'}}
@@ -74,6 +75,7 @@ protocol PI {
 struct SI<A: PI> : I where A : I, A.T == SI<A> { // expected-error {{circular reference}}
 // expected-note@-1 {{type declared here}}
 // expected-error@-2 {{generic struct 'SI' references itself}}
+// expected-note@-3 {{while resolving type 'SI<A>'}}
   func ggg<T : I>(t: T.Type) -> T {
     return T()
   }

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -144,13 +144,13 @@ protocol P3 {
 
 // Test for not crashing on recursive aliases
 protocol Circular {
-  typealias Y = Self.Y // expected-error {{type alias 'Y' references itself}}
+  typealias Y = Self.Y // expected-error {{type alias 'Y' references itself}} expected-note {{while resolving type 'Self.Y'}}
 
-  typealias Y2 = Y2 // expected-error {{type alias 'Y2' references itself}}
+  typealias Y2 = Y2 // expected-error {{type alias 'Y2' references itself}} expected-note {{while resolving type 'Y2'}}
 
-  typealias Y3 = Y4 // expected-error {{type alias 'Y3' references itself}}
+  typealias Y3 = Y4 // expected-error {{type alias 'Y3' references itself}} expected-note {{while resolving type 'Y4'}}
 
-  typealias Y4 = Y3 // expected-note {{through reference here}}
+  typealias Y4 = Y3 // expected-note {{through reference here}} expected-note {{while resolving type 'Y3'}}
 }
 
 // Qualified and unqualified references to protocol typealiases from concrete type


### PR DESCRIPTION
Now that the foundations are merged, requestify type resolution. I'll eventually use this to migrate all the callers of `TypeChecker::validateType` once their TypeLocs have been stripped.