### PR TITLE
build: shuffle library order

### DIFF
--- a/unittests/Driver/CMakeLists.txt
+++ b/unittests/Driver/CMakeLists.txt
@@ -5,9 +5,7 @@ add_swift_unittest(SwiftDriverTests
   UnitTestSourceFileDepGraphFactory.cpp
 )
 
-target_link_libraries(SwiftDriverTests
-   PRIVATE
-   swiftDriver
-   swiftClangImporter
+target_link_libraries(SwiftDriverTests PRIVATE
    swiftAST
-)
+   swiftClangImporter
+   swiftDriver)


### PR DESCRIPTION
ELF is sensitive to library ordering.  Ensure that `swiftClangImporter`
comes after `swiftAST` as `swiftAST` has grown a dependency on
`swiftClangImporter`.  Adding this properly using
`target_link_libraries` will cause a cyclic dependency so add this
reordering here.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
