### PR TITLE
[5.3] Allow initializing a wrapped property with a nonmutating setter

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6925,9 +6925,37 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
   llvm_unreachable("Unhandled coercion");
 }
 
+/// Detect if the expression is an assignment to a `self` wrapped property that
+/// has a nonmutating setter, inside a constructor.
+///
+/// We use this to decide when to produce an inout_expr instead of a load_expr
+/// for the sake of emitting a reference required by the assign_by_wrapper
+/// instruction.
+static bool isNonMutatingSetterPWAssignInsideInit(Expr *baseExpr,
+                                                  ValueDecl *member,
+                                                  DeclContext *UseDC) {
+  // Setter is mutating
+  if (cast<AbstractStorageDecl>(member)->isSetterMutating())
+    return false;
+  // Member is not a wrapped property
+  auto *VD = dyn_cast<VarDecl>(member);
+  if (!(VD && VD->hasAttachedPropertyWrapper()))
+    return false;
+  // This is not an expression inside a constructor
+  auto *CD = dyn_cast<ConstructorDecl>(UseDC);
+  if (!CD)
+    return false;
+  // This is not an assignment on self
+  if (!baseExpr->isSelfExprOf(CD))
+    return false;
+
+  return true;
+}
+
 /// Adjust the given type to become the self type when referring to
 /// the given member.
-static Type adjustSelfTypeForMember(Type baseTy, ValueDecl *member,
+static Type adjustSelfTypeForMember(Expr *baseExpr,
+                                    Type baseTy, ValueDecl *member,
                                     AccessSemantics semantics,
                                     DeclContext *UseDC) {
   auto baseObjectTy = baseTy->getWithoutSpecifierType();
@@ -6951,10 +6979,15 @@ static Type adjustSelfTypeForMember(Type baseTy, ValueDecl *member,
   bool isSettableFromHere =
       SD->isSettable(UseDC) && SD->isSetterAccessibleFrom(UseDC);
 
-  // If neither the property's getter nor its setter are mutating, the base
-  // can be an rvalue.
-  if (!SD->isGetterMutating()
-      && (!isSettableFromHere || !SD->isSetterMutating()))
+  // If neither the property's getter nor its setter are mutating, and
+  // this is not a nonmutating property wrapper setter,
+  // the base can be an rvalue.
+  // With the exception of assignments to a wrapped property inside a
+  // constructor, where we need to produce a reference to be used on
+  // the assign_by_wrapper instruction. 
+  if (!SD->isGetterMutating() && 
+      (!isSettableFromHere || !SD->isSetterMutating()) &&
+      !isNonMutatingSetterPWAssignInsideInit(baseExpr, member, UseDC))
     return baseObjectTy;
 
   // If we're calling an accessor, keep the base as an inout type, because the
@@ -6984,7 +7017,7 @@ ExprRewriter::coerceObjectArgumentToType(Expr *expr,
                                          Type baseTy, ValueDecl *member,
                                          AccessSemantics semantics,
                                          ConstraintLocatorBuilder locator) {
-  Type toType = adjustSelfTypeForMember(baseTy, member, semantics, dc);
+  Type toType = adjustSelfTypeForMember(expr, baseTy, member, semantics, dc);
 
   // If our expression already has the right type, we're done.
   Type fromType = cs.getType(expr);

--- a/test/SILOptimizer/di_property_wrappers.swift
+++ b/test/SILOptimizer/di_property_wrappers.swift
@@ -501,6 +501,7 @@ public final class Synchronized<Value> {
   }
 }
 
+
 struct SR_12341 {
   @Wrapper var wrapped: Int = 10
   var str: String
@@ -533,6 +534,34 @@ func testSR_12341() {
   _ = SR_12341(condition: true)
 }
 
+@propertyWrapper
+struct NonMutatingSetterWrapper<Value> {
+    var value: Value
+    init(wrappedValue: Value) {
+        value = wrappedValue
+    }
+    var wrappedValue: Value {
+        get { value }
+        nonmutating set {
+            print("  .. nonmutatingSet \(newValue)")
+        }
+    }
+}
+
+struct NonMutatingWrapperTestStruct {
+    @NonMutatingSetterWrapper var SomeProp: Int
+    init(val: Int) {
+        SomeProp = val
+    }
+}
+
+func testNonMutatingSetterStruct() {
+  // CHECK: ## NonMutatingSetterWrapper
+  print("\n## NonMutatingSetterWrapper")
+  let A = NonMutatingWrapperTestStruct(val: 11)
+  // CHECK-NEXT:  .. nonmutatingSet 11
+}
+
 testIntStruct()
 testIntClass()
 testRefStruct()
@@ -543,3 +572,4 @@ testDefaultNilOptIntStruct()
 testComposed()
 testWrapperInitWithDefaultArg()
 testSR_12341()
+testNonMutatingSetterStruct()

--- a/test/SILOptimizer/di_property_wrappers_errors.swift
+++ b/test/SILOptimizer/di_property_wrappers_errors.swift
@@ -23,30 +23,23 @@ struct IntStructWithClassWrapper {
   @ClassWrapper var wrapped: Int
 
   init() {
-    wrapped = 42 // expected-error{{'self' used before all stored properties are initialized}}
-    // expected-note@-1{{'self.wrapped' not initialized}}
-  } // expected-error{{return from initializer without initializing all stored properties}}
-  // expected-note@-1{{'self.wrapped' not initialized}}
+    wrapped = 42 // expected-error{{variable 'self.wrapped' used before being initialized}}
+  }
 
   init(conditional b: Bool) {
      if b {
        self._wrapped = ClassWrapper(wrappedValue: 32)
      } else {
-       wrapped = 42 // expected-error{{'self' used before all stored properties are initialized}}
-      // expected-note@-1{{'self.wrapped' not initialized}}
+       wrapped = 42 // expected-error{{variable 'self.wrapped' used before being initialized}}
      }
-  } // expected-error{{return from initializer without initializing all stored properties}}
-  // expected-note@-1{{'self.wrapped' not initialized}}
+  }
 
   init(dynamic b: Bool) {
     if b {
-      wrapped = 42 // expected-error{{'self' used before all stored properties are initialized}}
-      // expected-note@-1{{'self.wrapped' not initialized}}
+      wrapped = 42 // expected-error{{variable 'self.wrapped' used before being initialized}}
     }
-    wrapped = 27 // expected-error{{'self' used before all stored properties are initialized}}
-    // expected-note@-1{{'self.wrapped' not initialized}}
-  } // expected-error{{return from initializer without initializing all stored properties}}
-  // expected-note@-1{{'self.wrapped' not initialized}}  
+    wrapped = 27 // expected-error{{variable 'self.wrapped' used before being initialized}}
+  }
 }
 
 // SR_11477


### PR DESCRIPTION
Cherry-pick #31161 into release/5.3, originally reviewed by @slavapestov

The title is achieved in 3 steps:

- CSApply detects assignments to property wrappers inside constructors, and produces an inout expr instead of a load, which it normally would because nonmutating setters take the self by-value. This is necessary because the assign_by_wrapper instruction expects an address type for its $1 operand.
- SILGenLValue now emits the assign_by_wrapper pattern for such setters, ignoring the fact that they capture `self` by value. It also introduces an additional load instruction for the setter patrial_apply because the setter signature still expects a value and we now have an address (because of (1)).
- DefiniteInitialization ignores specifically load instructions used to produce a `self` value for a setter referenced on assign_by_wrapper because it will be deleted by lowering anyway.