### PR TITLE
Replace "unchecked" arithmetic with "wrapping" in optimization guide.

### DIFF
--- a/docs/OptimizationTips.rst
+++ b/docs/OptimizationTips.rst
@@ -283,18 +283,19 @@ through the usage of ``inout`` parameters:
   var a = [1, 2, 3]
   append_one_in_place(&a)
 
-Unchecked operations
+Wrapping operations
 ====================
 
 Swift eliminates integer overflow bugs by checking for overflow when performing
-normal arithmetic. These checks are not appropriate in high performance code
-where one knows that no memory safety issues can result.
+normal arithmetic. These checks may not be appropriate in high performance code
+if one either knows that overflow cannot occur, or that the result of
+allowing the operation to wrap around is correct.
 
-Advice: Use unchecked integer arithmetic when you can prove that overflow cannot occur
+Advice: Use wrapping integer arithmetic when you can prove that overflow cannot occur
 ---------------------------------------------------------------------------------------
 
-In performance-critical code you can elide overflow checks if you know it is
-safe.
+In performance-critical code you can use wrapping arithmetic to avoid overflow
+checks if you know it is safe.
 
 ::
 
@@ -302,10 +303,16 @@ safe.
   b: [Int]
   c: [Int]
 
-  // Precondition: for all a[i], b[i]: a[i] + b[i] does not overflow!
+  // Precondition: for all a[i], b[i]: a[i] + b[i] either does not overflow,
+  // or the result of wrapping is desired.
   for i in 0 ... n {
     c[i] = a[i] &+ b[i]
   }
+
+It's important to note that the behavior of the ``&+``, ``&-``, and ``&*``
+operators is fully-defined; the result simply wraps around if it would overflow.
+Thus, ``Int.max + 1`` is guaranteed to be ``Int.min`` (unlike in C, where
+``INT_MAX + 1`` is undefined behavior).
 
 Generics
 ========

--- a/docs/OptimizationTips.rst
+++ b/docs/OptimizationTips.rst
@@ -311,7 +311,7 @@ checks if you know it is safe.
 
 It's important to note that the behavior of the ``&+``, ``&-``, and ``&*``
 operators is fully-defined; the result simply wraps around if it would overflow.
-Thus, ``Int.max + 1`` is guaranteed to be ``Int.min`` (unlike in C, where
+Thus, ``Int.max &+ 1`` is guaranteed to be ``Int.min`` (unlike in C, where
 ``INT_MAX + 1`` is undefined behavior).
 
 Generics


### PR DESCRIPTION
Previously, this section talked about "unchecked" arithmetic operations; that's not what &+ and friends are. They are wrapping operations with fully-defined behavior (unlike nsw llvm ops, which are actually "unchecked").
