### PR TITLE
[NFC] Add GuaranteedArguments case to EscapeState.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -256,7 +256,6 @@ private:
   };
 
 public:
-  
   /// Indicates to what a value escapes. Note: the order of values is important.
   enum class EscapeState : char {
 
@@ -264,19 +263,21 @@ public:
     /// The value points to a locally allocated object who's lifetime ends in
     /// the same function.
     None,
-    
+
+    /// The node's value escapes through a guaranteed function argument.
+    GuaranteedArguments,
+
     /// The node's value escapes through the return value.
     /// The value points to a locally allocated object which escapes via the
     /// return instruction.
     Return,
 
-    /// The node's value escapes through a function argument.
-    Arguments,
+    /// The node's value escapes through a non-guaranteed function argument.
+    AnyArguments,
 
     /// The node's value escapes to any global or unidentified memory.
     Global
   };
-
 
   /// A node in the connection graph.
   /// A node basically represents a "pointer" or the "memory content" where a
@@ -552,7 +553,8 @@ public:
         case EscapeState::None:
         case EscapeState::Return:
           return false;
-        case EscapeState::Arguments:
+        case EscapeState::AnyArguments:
+        case EscapeState::GuaranteedArguments:
           return !nodeValue || !isExclusiveArgument(nodeValue);
         case EscapeState::Global:
           return true;


### PR DESCRIPTION
Removes "EscapeState::Arguments" in favor of "EscapeState::GuaranteedArguments" and "EscapeState::AnyArguments". If the escaping SILFunctionArgument has an Indirect_In_Guaranteed or a Direct_Guaranteed calling convention then, GuaranteedArguments will be selected.

In some cases (such as stack promotion) it's OK if the value escapes the function as long as it's not destroyed. In those cases, knowing if the escaping argument is guaranteed can be very beneficial. 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
