### PR TITLE
build: clean up the mac catalyst flag handling in the host

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -89,9 +89,6 @@ function(_add_host_variant_c_compile_link_flags)
     ""
     ${ARGN})
 
-  get_maccatalyst_build_flavor(maccatalyst_build_flavor
-    "${SWFIT_HOST_VARIANT_SDK}" "")
-
   set(result ${${CFLAGS_RESULT_VAR_NAME}})
 
   is_darwin_based_sdk("${SWIFT_HOST_VARIANT_SDK}" IS_DARWIN)
@@ -102,12 +99,9 @@ function(_add_host_variant_c_compile_link_flags)
   # MSVC, clang-cl, gcc don't understand -target.
   if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT SWIFT_COMPILER_IS_MSVC_LIKE)
     get_target_triple(target target_variant "${SWIFT_HOST_VARIANT_SDK}" "${SWIFT_HOST_VARIANT_ARCH}"
-      MACCATALYST_BUILD_FLAVOR "${maccatalyst_build_flavor}"
+      MACCATALYST_BUILD_FLAVOR ""
       DEPLOYMENT_VERSION "${DEPLOYMENT_VERSION}")
     list(APPEND result "-target" "${target}")
-    if(target_variant)
-      list(APPEND result "-target-variant" "${target_variant}")
-    endif()
   endif()
 
   set(_sysroot
@@ -133,21 +127,8 @@ function(_add_host_variant_c_compile_link_flags)
     # side effects are introduced should a new search path be added.
     list(APPEND result
       "-arch" "${SWIFT_HOST_VARIANT_ARCH}"
-      "-F${SWIFT_SDK_${SWIFT_HOST_VARIANT_ARCH}_PATH}/../../../Developer/Library/Frameworks")
-
-    set(add_explicit_version TRUE)
-
-    # iOS-like and zippered libraries get their deployment version from the
-    # target triple
-    if(maccatalyst_build_flavor STREQUAL "ios-like" OR
-        maccatalyst_build_flavor STREQUAL "zippered")
-      set(add_explicit_version FALSE)
-    endif()
-
-    if(add_explicit_version)
-      list(APPEND result
-        "-m${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_VERSION_MIN_NAME}-version-min=${DEPLOYMENT_VERSION}")
-     endif()
+      "-F${SWIFT_SDK_${SWIFT_HOST_VARIANT_ARCH}_PATH}/../../../Developer/Library/Frameworks"
+      "-m${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_VERSION_MIN_NAME}-version-min=${DEPLOYMENT_VERSION}")
   endif()
 
   if(CFLAGS_ANALYZE_CODE_COVERAGE)
@@ -432,9 +413,6 @@ function(_add_host_variant_link_flags target)
         "SHELL:-Xlinker -dead_strip")
     endif()
   endif()
-
-  get_maccatalyst_build_flavor(maccatalyst_build_flavor
-    "${SWIFT_HOST_VARIANT_SDK}" "")
 endfunction()
 
 # Add a single variant of a new Swift library.


### PR DESCRIPTION
The toolchain does not actually use any catalyst flavor, which resulted
in these paths actually being dead.  Cull them except for the one path
which simply computes the target triple.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
