### PR TITLE
build: default the lld/gold enabling as per reality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,12 +147,22 @@ set(CLANG_COMPILER_VERSION "" CACHE STRING
     "The internal version of the Clang compiler")
 
 # Indicate whether Swift should attempt to use the lld linker.
-set(SWIFT_ENABLE_LLD_LINKER TRUE CACHE BOOL
+if(CMAKE_SYSTEM_NAME STREQUAL Windows AND NOT CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)
+  set(SWIFT_ENABLE_LLD_LINKER_default TRUE)
+else()
+  set(SWIFT_ENABLE_LLD_LINKER_default FALSE)
+endif()
+set(SWIFT_ENABLE_LLD_LINKER ${SWIFT_ENABLE_LLD_LINKER_default} CACHE BOOL
     "Enable using the lld linker when available")
 
 # Indicate whether Swift should attempt to use the gold linker.
 # This is not used on Darwin.
-set(SWIFT_ENABLE_GOLD_LINKER TRUE CACHE BOOL
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin OR CMAKE_SYSTEM_NAME STREQUAL Windows)
+  set(SWIFT_ENABLE_GOLD_LINKER_default FALSE)
+else()
+  set(SWIFT_ENABLE_GOLD_LINKER_default TRUE)
+endif()
+set(SWIFT_ENABLE_GOLD_LINKER ${SWIFT_ENABLE_GOLD_LINKER_default} CACHE BOOL
     "Enable using the gold linker when available")
 
 set(SWIFT_TOOLS_ENABLE_LTO OFF CACHE STRING "Build Swift tools with LTO. One

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -403,18 +403,12 @@ function(_add_host_variant_link_flags target)
   endif()
 
   if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
-    # FIXME: On Apple platforms, find_program needs to look for "ld64.lld"
-    find_program(LDLLD_PATH "ld.lld")
-    if((SWIFT_ENABLE_LLD_LINKER AND LDLLD_PATH AND NOT APPLE) OR
-       (SWIFT_HOST_VARIANT_SDK STREQUAL WINDOWS AND NOT CMAKE_SYSTEM_NAME STREQUAL WINDOWS))
-      target_link_options(${target} PRIVATE -fuse-ld=lld)
-    elseif(SWIFT_ENABLE_GOLD_LINKER AND
-           "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_OBJECT_FORMAT}" STREQUAL "ELF")
-      if(CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)
-        target_link_options(${target} PRIVATE -fuse-ld=gold.exe)
-      else()
-        target_link_options(${target} PRIVATE -fuse-ld=gold)
-      endif()
+    if(SWIFT_ENABLE_LLD_LINKER)
+      target_link_options(${target} PRIVATE
+        -fuse-ld=lld$<$<STREQUAL:${CMAKE_HOST_SYSTEM_NAME},Windows>:.exe>)
+    elseif(SWIFT_ENABLE_GOLD_LINKER)
+      target_link_options(${target} PRIVATE
+        -fuse-ld=gold$<$<STREQUAL:${CMAKE_HOST_SYSTEM_NAME},Windows>:.exe>)
     endif()
   endif()
 


### PR DESCRIPTION
Rather than defaulting both of these to true, enable gold by default
only on ELFish targets, and enable LLD by default for Windows on
non-Windows hosts.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
