### PR TITLE
[Test] Generalize api-digester tests to all platforms.

### DIFF
--- a/test/api-digester/apinotes-diags.swift
+++ b/test/api-digester/apinotes-diags.swift
@@ -1,4 +1,3 @@
-// REQUIRES: OS=macosx
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)

--- a/test/api-digester/apinotes-diags.swift
+++ b/test/api-digester/apinotes-diags.swift
@@ -1,3 +1,5 @@
+// REQUIRES: VENDOR=apple
+
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)

--- a/test/api-digester/apinotes-migrator-gen.swift
+++ b/test/api-digester/apinotes-migrator-gen.swift
@@ -1,4 +1,3 @@
-// REQUIRES: OS=macosx
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)

--- a/test/api-digester/apinotes-migrator-gen.swift
+++ b/test/api-digester/apinotes-migrator-gen.swift
@@ -1,3 +1,5 @@
+// REQUIRES: VENDOR=apple
+
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)

--- a/test/api-digester/clang-module-dump.swift
+++ b/test/api-digester/clang-module-dump.swift
@@ -1,4 +1,3 @@
-// REQUIRES: OS=macosx
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)

--- a/test/api-digester/clang-module-dump.swift
+++ b/test/api-digester/clang-module-dump.swift
@@ -1,3 +1,5 @@
+// REQUIRES: VENDOR=apple
+
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)

--- a/test/api-digester/compare-clang-dump.swift
+++ b/test/api-digester/compare-clang-dump.swift
@@ -1,3 +1,5 @@
+// REQUIRES: VENDOR=apple
+
 // RUN: %empty-directory(%t.module-cache)
 // RUN: %api-digester -dump-sdk -module Foo -o %t.dump1.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %S/Inputs/Foo -avoid-location
 // RUN: %api-digester -dump-sdk -module Foo -o %t.dump2.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %S/Inputs/Foo-new-version -avoid-location

--- a/test/api-digester/compare-dump-abi-parsable-interface.swift
+++ b/test/api-digester/compare-dump-abi-parsable-interface.swift
@@ -1,3 +1,5 @@
+// REQUIRES: VENDOR=apple
+
 // RUN: %empty-directory(%t.mod1)
 // RUN: %empty-directory(%t.mod2)
 // RUN: %empty-directory(%t.sdk)

--- a/test/api-digester/compare-dump-abi.swift
+++ b/test/api-digester/compare-dump-abi.swift
@@ -1,3 +1,5 @@
+// REQUIRES: VENDOR=apple
+
 // RUN: %empty-directory(%t.mod1)
 // RUN: %empty-directory(%t.mod2)
 // RUN: %empty-directory(%t.sdk)

--- a/test/api-digester/compare-dump-abi.swift
+++ b/test/api-digester/compare-dump-abi.swift
@@ -4,8 +4,8 @@
 // RUN: %empty-directory(%t.module-cache)
 // RUN: %empty-directory(%t.baseline/ABI)
 
-// RUN: %swift -emit-module -o %t.mod1/cake.swiftmodule %S/Inputs/cake_baseline/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -emit-module-source-info -emit-module-source-info-path %t.mod1/cake.swiftsourceinfo 2> %t.compiler-diags
-// RUN: %swift -emit-module -o %t.mod2/cake.swiftmodule %S/Inputs/cake_current/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource -emit-module-source-info -emit-module-source-info-path %t.mod2/cake.swiftsourceinfo
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t.mod1/cake.swiftmodule %S/Inputs/cake_baseline/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -emit-module-source-info -emit-module-source-info-path %t.mod1/cake.swiftsourceinfo 2> %t.compiler-diags
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t.mod2/cake.swiftmodule %S/Inputs/cake_current/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource -emit-module-source-info -emit-module-source-info-path %t.mod2/cake.swiftsourceinfo
 // RUN: %api-digester -dump-sdk -module cake -output-dir %t.baseline -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod1 -I %S/Inputs/APINotesLeft -abi
 // RUN: %api-digester -diagnose-sdk -print-module -baseline-dir %t.baseline -module cake -I %t.mod2 -I %S/Inputs/APINotesLeft -module-cache-path %t.module-cache %clang-importer-sdk-nosource -abi -o %t.result
 // RUN: %clang -E -P -w -x c %S/Outputs/Cake-abi.txt -o - | sed '/^\s*$/d' > %t.abi.expected

--- a/test/api-digester/compare-dump-binary-vs-interface.swift
+++ b/test/api-digester/compare-dump-binary-vs-interface.swift
@@ -1,3 +1,5 @@
+// REQUIRES: VENDOR=apple
+
 // RUN: %empty-directory(%t.mod1)
 // RUN: %empty-directory(%t.mod2)
 // RUN: %empty-directory(%t.sdk)

--- a/test/api-digester/compare-dump-parsable-interface.swift
+++ b/test/api-digester/compare-dump-parsable-interface.swift
@@ -1,3 +1,5 @@
+// REQUIRES: VENDOR=apple
+
 // RUN: %empty-directory(%t.mod1)
 // RUN: %empty-directory(%t.mod2)
 // RUN: %empty-directory(%t.sdk)

--- a/test/api-digester/compare-dump.swift
+++ b/test/api-digester/compare-dump.swift
@@ -1,3 +1,5 @@
+// REQUIRES: VENDOR=apple
+
 // RUN: %empty-directory(%t.mod1)
 // RUN: %empty-directory(%t.mod2)
 // RUN: %empty-directory(%t.sdk)

--- a/test/api-digester/compare-dump.swift
+++ b/test/api-digester/compare-dump.swift
@@ -2,8 +2,8 @@
 // RUN: %empty-directory(%t.mod2)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
-// RUN: %swift -emit-module -o %t.mod1/cake.swiftmodule %S/Inputs/cake_baseline/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -module-name cake
-// RUN: %swift -emit-module -o %t.mod2/cake.swiftmodule %S/Inputs/cake_current/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource -module-name cake
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t.mod1/cake.swiftmodule %S/Inputs/cake_baseline/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -module-name cake
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t.mod2/cake.swiftmodule %S/Inputs/cake_current/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource -module-name cake
 // RUN: %api-digester -dump-sdk -module cake -o %t.dump1.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod1 -I %S/Inputs/APINotesLeft
 // RUN: %api-digester -dump-sdk -module cake -o %t.dump2.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod2 -I %S/Inputs/APINotesRight
 // RUN: %api-digester -diagnose-sdk -print-module --input-paths %t.dump1.json -input-paths %t.dump2.json -o %t.result
@@ -13,15 +13,15 @@
 // RUN: diff -u %t.expected %t.result.tmp
 
 // Compare color against an empty baseline
-// RUN: %swift -emit-module -o %t.mod1/color.swiftmodule %S/Inputs/cake_baseline/color.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -module-name color
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t.mod1/color.swiftmodule %S/Inputs/cake_baseline/color.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -module-name color
 // RUN: %api-digester -diagnose-sdk -o %t.result -empty-baseline -I %S/Inputs/APINotesLeft -I %t.mod1 %clang-importer-sdk-nosource -module color -abi
 // RUN: %clang -E -P -x c %S/Outputs/color_vs_empty.txt -o - | sed '/^\s*$/d' > %t.expected
 // RUN: %clang -E -P -x c %t.result -o - | sed '/^\s*$/d' > %t.result.tmp
 // RUN: diff -u %t.expected %t.result.tmp
 
 // Run another module API checking without -enable-library-evolution
-// RUN: %swift -emit-module -o %t.mod1/color.swiftmodule %S/Inputs/cake_baseline/color.swift -parse-as-library -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -module-name color
-// RUN: %swift -emit-module -o %t.mod2/color.swiftmodule %S/Inputs/cake_current/color.swift -parse-as-library -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource -module-name color
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t.mod1/color.swiftmodule %S/Inputs/cake_baseline/color.swift -parse-as-library -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -module-name color
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t.mod2/color.swiftmodule %S/Inputs/cake_current/color.swift -parse-as-library -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource -module-name color
 // RUN: %api-digester -dump-sdk -module color -o - -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod1 -I %S/Inputs/APINotesLeft > %t.dump1.json
 // RUN: %api-digester -dump-sdk -module color -o - -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod2 -I %S/Inputs/APINotesLeft > %t.dump2.json
 // RUN: %api-digester -diagnose-sdk -print-module --input-paths %t.dump1.json -input-paths %t.dump2.json -o %t.result

--- a/test/api-digester/compare-two-sdks.swift
+++ b/test/api-digester/compare-two-sdks.swift
@@ -5,7 +5,7 @@
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
 
-// RUN: %api-digester -diagnose-sdk -print-module -module-list-file %S/Inputs/mock-sdk-modules.txt -sdk %S/Inputs/mock-sdk.sdk -bsdk %S/Inputs/mock-sdk-baseline.sdk -module-cache-path %t.module-cache -o %t.result -abort-on-module-fail -target x86_64-apple-macos10.14
+// RUN: %api-digester -diagnose-sdk -print-module -module-list-file %S/Inputs/mock-sdk-modules.txt -sdk %S/Inputs/mock-sdk.sdk -bsdk %S/Inputs/mock-sdk-baseline.sdk -module-cache-path %t.module-cache -o %t.result -abort-on-module-fail
 
 // RUN: %clang -E -P -x c %S/Outputs/mock-sdk-api.txt -o - | sed '/^\s*$/d' > %t.expected
 // RUN: %clang -E -P -x c %t.result -o - | sed '/^\s*$/d' > %t.result.tmp

--- a/test/api-digester/dump-empty-baseline.swift
+++ b/test/api-digester/dump-empty-baseline.swift
@@ -1,4 +1,3 @@
-// REQUIRES: OS=macosx
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)

--- a/test/api-digester/dump-module.swift
+++ b/test/api-digester/dump-module.swift
@@ -1,7 +1,8 @@
+// REQUIRES: macosx
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
-// RUN: %swift -emit-module -o %t.mod/cake.swiftmodule %S/Inputs/cake.swift -parse-as-library -I %S/Inputs/ClangCake %clang-importer-sdk-nosource
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t.mod/cake.swiftmodule %S/Inputs/cake.swift -parse-as-library -I %S/Inputs/ClangCake %clang-importer-sdk-nosource
 // RUN: %api-digester -dump-sdk -module cake -o %t.dump.json -module-cache-path %t.module-cache -swift-only -I %t.mod -I %S/Inputs/ClangCake %clang-importer-sdk-nosource -avoid-tool-args
 // RUN: diff -u %S/Outputs/cake.json %t.dump.json
 // RUN: %api-digester -dump-sdk -module cake -o %t.dump.json -module-cache-path %t.module-cache -swift-only -I %t.mod -abi -I %S/Inputs/ClangCake %clang-importer-sdk-nosource -avoid-tool-args

--- a/test/api-digester/internal-extension.swift
+++ b/test/api-digester/internal-extension.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
-// RUN: %swift -emit-module -o %t.mod/cake.swiftmodule %S/Inputs/cake.swift -parse-as-library -I %S/Inputs/ClangCake %clang-importer-sdk-nosource
-// RUN: %swift -emit-module -o %t.mod/main.swiftmodule %s -parse-as-library -I %t.mod -I %S/Inputs/ClangCake %clang-importer-sdk-nosource
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t.mod/cake.swiftmodule %S/Inputs/cake.swift -parse-as-library -I %S/Inputs/ClangCake %clang-importer-sdk-nosource
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t.mod/main.swiftmodule %s -parse-as-library -I %t.mod -I %S/Inputs/ClangCake %clang-importer-sdk-nosource
 // RUN: %api-digester -dump-sdk -module main -o %t.dump.json -module-cache-path %t.module-cache -swift-only -I %t.mod -I %S/Inputs/ClangCake %clang-importer-sdk-nosource
 // RUN: %FileCheck %s < %t.dump.json
 

--- a/test/api-digester/internal-extension.swift
+++ b/test/api-digester/internal-extension.swift
@@ -1,3 +1,5 @@
+// REQUIRES: VENDOR=apple
+
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)

--- a/test/api-digester/lit.local.cfg
+++ b/test/api-digester/lit.local.cfg
@@ -1,5 +1,0 @@
-if 'OS=macosx' not in config.available_features:
-    config.unsupported = True
-
-else:
-    config.substitutions.append(('%api-digester', config.swift_api_digester))

--- a/test/api-digester/macro-gen-json.swift
+++ b/test/api-digester/macro-gen-json.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
-// RUN: %swift -emit-module -o %t.mod/macrogenleft.swiftmodule %S/Inputs/macro-gen-left.swift -parse-as-library
-// RUN: %swift -emit-module -o %t.mod/macrogenright.swiftmodule %S/Inputs/macro-gen-right.swift -parse-as-library
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t.mod/macrogenleft.swiftmodule %S/Inputs/macro-gen-left.swift -parse-as-library
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t.mod/macrogenright.swiftmodule %S/Inputs/macro-gen-right.swift -parse-as-library
 // RUN: %api-digester -dump-sdk -module macrogenleft -o %t.dump1.json -module-cache-path %t.module-cache -sdk %t.sdk -I %t.mod -migrator
 // RUN: %api-digester -dump-sdk -module macrogenright -o %t.dump2.json -module-cache-path %t.module-cache -sdk %t.sdk -I %t.mod -migrator
 // RUN: %api-digester -generate-migration-script --input-paths %t.dump1.json -input-paths %t.dump2.json -o %t.result -json

--- a/test/api-digester/macro-gen.swift
+++ b/test/api-digester/macro-gen.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
-// RUN: %swift -emit-module -o %t.mod/macrogenleft.swiftmodule %S/Inputs/macro-gen-left.swift -parse-as-library
-// RUN: %swift -emit-module -o %t.mod/macrogenright.swiftmodule %S/Inputs/macro-gen-right.swift -parse-as-library
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t.mod/macrogenleft.swiftmodule %S/Inputs/macro-gen-left.swift -parse-as-library
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t.mod/macrogenright.swiftmodule %S/Inputs/macro-gen-right.swift -parse-as-library
 // RUN: %api-digester -dump-sdk -module macrogenleft -o %t.dump1.json -module-cache-path %t.module-cache -sdk %t.sdk -swift-version 4 -I %t.mod -migrator
 // RUN: %api-digester -dump-sdk -module macrogenright -o %t.dump2.json -module-cache-path %t.module-cache -sdk %t.sdk -swift-version 5 -I %t.mod -migrator
 // RUN: %api-digester -generate-migration-script --input-paths %t.dump1.json -input-paths %t.dump2.json -o %t.result

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1345,6 +1345,10 @@ else:
     lit_config.fatal("Don't know how to define target_run and "
                      "target_build_swift for platform " + config.variant_triple)
 
+config.swift_api_digester = (
+    '%s -target %s' % (config.swift_api_digester, config.variant_triple))
+config.substitutions.append(('%api-digester', config.swift_api_digester))
+
 # Enable typo-correction for testing purposes.
 config.target_swift_frontend += " -typo-correction-limit 10 "
 subst_target_swift_frontend_mock_sdk += " -typo-correction-limit 10 "


### PR DESCRIPTION
The API digester tests were being run only for macOS, mainly
because they were not using %target-swift consistently. Lift
the unnecessary restriction so we run these tests more widely.
