### PR TITLE
Append newline to printout of "Defaulted constraints"

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3921,6 +3921,7 @@ void ConstraintSystem::print(raw_ostream &out) const {
     }, [&] {
       out << ", ";
     });
+    out << "\n";
   }
 
   if (failedConstraint) {


### PR DESCRIPTION
Currently, when dumping `ConstraintSystem`, the "Defaulted constraints" section doesn't end with a newline. If this is the last section, it doesn't play nice with `lldb`'s command line.