### PR TITLE
Sema: Make -debug-generic-signatures output legible

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2057,6 +2057,7 @@ public:
         GenericSignature::get({PD->getProtocolSelfType()},
                               PD->getRequirementSignature());
 
+      llvm::errs() << "\n";
       llvm::errs() << "Protocol requirement signature:\n";
       PD->dumpRef(llvm::errs());
       llvm::errs() << "\n";

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -467,12 +467,13 @@ GenericSignature TypeChecker::checkGenericSignature(
   // Debugging of the generic signature builder and generic signature
   // generation.
   if (dc->getASTContext().TypeCheckerOpts.DebugGenericSignatures) {
+    llvm::errs() << "\n";
     if (auto *VD = dyn_cast_or_null<ValueDecl>(dc->getAsDecl())) {
       VD->dumpRef(llvm::errs());
+      llvm::errs() << "\n";
     } else {
       dc->printContext(llvm::errs());
     }
-    llvm::errs() << "\n";
     llvm::errs() << "Generic signature: ";
     sig->print(llvm::errs());
     llvm::errs() << "\n";
@@ -589,8 +590,8 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
     // Debugging of the generic signature builder and generic signature
     // generation.
     if (GC->getASTContext().TypeCheckerOpts.DebugGenericSignatures) {
-      PD->printContext(llvm::errs());
       llvm::errs() << "\n";
+      PD->printContext(llvm::errs());
       llvm::errs() << "Generic signature: ";
       sig->print(llvm::errs());
       llvm::errs() << "\n";

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5087,12 +5087,15 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
   // Check all conformances.
   groupChecker.checkAllConformances();
 
-  if (Context.TypeCheckerOpts.DebugGenericSignatures) {
+  if (Context.TypeCheckerOpts.DebugGenericSignatures &&
+      !conformances.empty()) {
     // Now that they're filled out, print out information about the conformances
     // here, when requested.
+    llvm::errs() << "\n";
+    dc->printContext(llvm::errs());
     for (auto conformance : conformances) {
-      dc->printContext(llvm::errs());
       conformance->dump(llvm::errs());
+      llvm::errs() << "\n";
     }
   }
 


### PR DESCRIPTION
Fixes missing/extra newlines and duplication so that the output is properly split into blocks.
