### PR TITLE
IRGen: Sign the class stub initialization callback pointer on arm64e [5.3]

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1164,6 +1164,9 @@ namespace SpecialPointerAuthDiscriminators {
   /// they're important enough to be worth writing in one place.
   const uint16_t OpaqueReadResumeFunction = 56769;
   const uint16_t OpaqueModifyResumeFunction = 3909;
+
+  /// Resilient class stub initializer callback
+  const uint16_t ResilientClassStubInitCallback = 0xC671;
 }
 
 /// The number of arguments that will be passed directly to a generic

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -122,6 +122,9 @@ struct PointerAuthOptions : clang::PointerAuthOptions {
 
   /// Resumption functions from yield-many coroutines.
   PointerAuthSchema YieldManyResumeFunctions;
+
+  /// Resilient class stub initializer callbacks.
+  PointerAuthSchema ResilientClassStubInitCallbacks;
 };
 
 /// The set of options supported by IR generation.

--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -168,14 +168,6 @@ namespace irgen {
                                     llvm::Value *selfValue,
                                     llvm::Value *metadataValue);
 
-  /// We emit Objective-C class stubs for non-generic classes with resilient
-  /// ancestry. This lets us attach categories to the class even though it
-  /// does not have statically-emitted metadata.
-  bool hasObjCResilientClassStub(IRGenModule &IGM, ClassDecl *D);
-
-  /// Emit a resilient class stub.
-  void emitObjCResilientClassStub(IRGenModule &IGM, ClassDecl *D);
-
   /// Emit the constant fragile offset of the given property inside an instance
   /// of the class.
   llvm::Constant *tryEmitConstantClassFragilePhysicalMemberOffset(

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1672,7 +1672,7 @@ namespace {
                      / IGM.getPointerSize());
       } else {
         ExtraClassDescriptorFlags flags;
-        if (hasObjCResilientClassStub(IGM, getType()))
+        if (IGM.hasObjCResilientClassStub(getType()))
           flags.setObjCResilientClassStub(true);
         B.addInt32(flags.getOpaqueValue());
       }
@@ -1694,7 +1694,7 @@ namespace {
             ClassMetadataStrategy::Resilient)
         return;
 
-      if (!hasObjCResilientClassStub(IGM, getType()))
+      if (!IGM.hasObjCResilientClassStub(getType()))
         return;
 
       B.addRelativeAddress(
@@ -3390,8 +3390,8 @@ void irgen::emitClassMetadata(IRGenModule &IGM, ClassDecl *classDecl,
       // Even non-@objc classes can have Objective-C categories attached, so
       // we always emit a resilient class stub as long as -enable-objc-interop
       // is set.
-      if (hasObjCResilientClassStub(IGM, classDecl)) {
-        emitObjCResilientClassStub(IGM, classDecl);
+      if (IGM.hasObjCResilientClassStub(classDecl)) {
+        IGM.emitObjCResilientClassStub(classDecl);
 
         if (classDecl->isObjC()) {
           auto *stub = IGM.getAddrOfObjCResilientClassStub(

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -729,6 +729,10 @@ static void setPointerAuthOptions(PointerAuthOptions &opts,
       PointerAuthSchema(codeKey, /*address*/ true, Discrimination::Type);
   opts.YieldOnceResumeFunctions =
       PointerAuthSchema(codeKey, /*address*/ true, Discrimination::Type);
+
+  opts.ResilientClassStubInitCallbacks =
+      PointerAuthSchema(codeKey, /*address*/ true, Discrimination::Constant,
+      SpecialPointerAuthDiscriminators::ResilientClassStubInitCallback);
 }
 
 std::unique_ptr<llvm::TargetMachine>

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1563,6 +1563,14 @@ public:
 
   void emitOpaqueTypeDescriptorAccessor(OpaqueTypeDecl *);
 
+  /// We emit Objective-C class stubs for non-generic classes with resilient
+  /// ancestry. This lets us attach categories to the class even though it
+  /// does not have statically-emitted metadata.
+  bool hasObjCResilientClassStub(ClassDecl *D);
+
+  /// Emit a resilient class stub.
+  void emitObjCResilientClassStub(ClassDecl *D);
+
 private:
   llvm::Constant *
   getAddrOfSharedContextDescriptor(LinkEntity entity,

--- a/test/IRGen/class_update_callback_with_stub.swift
+++ b/test/IRGen/class_update_callback_with_stub.swift
@@ -63,21 +63,21 @@ import resilient_objc_class
 // CHECK-SAME:    internal global %objc_full_class_stub {
 // CHECK-SAME:    [[INT]] 0,
 // CHECK-SAME:    [[INT]] 1,
-// CHECK-SAME:    %objc_class* (%objc_class*, i8*)* @"$s31class_update_callback_with_stub17ResilientSubclassCMU"
+// CHECK-SAME:    %objc_class* (%objc_class*, i8*)* {{.*}}@"$s31class_update_callback_with_stub17ResilientSubclassCMU{{(\.ptrauth)?}}"
 // CHECK-SAME:  }
 
 // CHECK-LABEL: @"$s31class_update_callback_with_stub25ResilientNSObjectSubclassCMt" =
 // CHECK-SAME:    internal global %objc_full_class_stub {
 // CHECK-SAME:    [[INT]] 0,
 // CHECK-SAME:    [[INT]] 1,
-// CHECK-SAME:    %objc_class* (%objc_class*, i8*)* @"$s31class_update_callback_with_stub25ResilientNSObjectSubclassCMU"
+// CHECK-SAME:    %objc_class* (%objc_class*, i8*)* {{.*}}@"$s31class_update_callback_with_stub25ResilientNSObjectSubclassCMU{{(\.ptrauth)?}}"
 // CHECK-SAME:  }
 
 // CHECK-LABEL: @"$s31class_update_callback_with_stub27FixedLayoutNSObjectSubclassCMt" =
 // CHECK-SAME:    internal global %objc_full_class_stub {
 // CHECK-SAME:    [[INT]] 0,
 // CHECK-SAME:    [[INT]] 1,
-// CHECK-SAME:    %objc_class* (%objc_class*, i8*)* @"$s31class_update_callback_with_stub27FixedLayoutNSObjectSubclassCMU"
+// CHECK-SAME:    %objc_class* (%objc_class*, i8*)* {{.*}}@"$s31class_update_callback_with_stub27FixedLayoutNSObjectSubclassCMU{{(\.ptrauth)?}}"
 // CHECK-SAME:  }
 
 

--- a/validation-test/Runtime/class_stubs.m
+++ b/validation-test/Runtime/class_stubs.m
@@ -5,7 +5,7 @@
 // RUN: %target-build-swift -emit-library -emit-module -o %t/libfirst.dylib -emit-objc-header-path %t/first.h %S/Inputs/class-stubs-from-objc/first.swift -Xlinker -install_name -Xlinker @executable_path/libfirst.dylib -enable-library-evolution
 // RUN: %target-build-swift -emit-library -o %t/libsecond.dylib -emit-objc-header-path %t/second.h -I %t %S/Inputs/class-stubs-from-objc/second.swift -Xlinker -install_name -Xlinker @executable_path/libsecond.dylib -lfirst -L %t -target %target-next-stable-abi-triple
 // RUN: cp %S/Inputs/class-stubs-from-objc/module.map %t/
-// RUN: xcrun -sdk %sdk %clang %s -I %t -L %t -fmodules -fobjc-arc -o %t/main -lfirst -lsecond -Wl,-U,_objc_loadClassref -target %target-next-stable-abi-triple
+// RUN: xcrun -sdk %sdk %clang %s -I %t -L %t -fmodules -fobjc-arc -o %t/main -lfirst -lsecond -target %target-next-stable-abi-triple
 // RUN: %target-codesign %t/main %t/libfirst.dylib %t/libsecond.dylib
 // RUN: %target-run %t/main %t/libfirst.dylib %t/libsecond.dylib
 
@@ -31,7 +31,7 @@
 
 int main(int argc, const char * const argv[]) {
   // Only test the new behavior on a new enough libobjc.
-  if (!dlsym(RTLD_NEXT, "_objc_loadClassref")) {
+  if (!dlsym(RTLD_NEXT, "objc_loadClassref")) {
     fprintf(stderr, "skipping evolution tests; OS too old\n");
     return EXIT_SUCCESS;
   }

--- a/validation-test/Runtime/class_stubs_weak.m
+++ b/validation-test/Runtime/class_stubs_weak.m
@@ -7,7 +7,7 @@
 // RUN: cp %S/Inputs/class-stubs-weak/module.map %t/
 
 // Note: This is the just-built Clang, not the system Clang.
-// RUN: xcrun -sdk %sdk %clang %s -I %t -L %t -fmodules -fobjc-arc -o %t/main -lfirst -lsecond -Wl,-U,_objc_loadClassref -target %target-triple
+// RUN: xcrun -sdk %sdk %clang %s -I %t -L %t -fmodules -fobjc-arc -o %t/main -lfirst -lsecond -target %target-triple
 
 // Now rebuild the library, omitting the weak-exported class
 // RUN: %target-build-swift -emit-library -o %t/libsecond.dylib -I %t %S/Inputs/class-stubs-weak/second.swift -Xlinker -install_name -Xlinker @executable_path/libsecond.dylib -lfirst -L %t -target %target-next-stable-abi-triple
@@ -18,6 +18,8 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 // REQUIRES: swift_stable_abi
+
+// REQUIRES: rdar62692550
 
 #import <dlfcn.h>
 #import <stdio.h>
@@ -37,7 +39,7 @@
 
 int main(int argc, const char * const argv[]) {
   // Only test the new behavior on a new enough libobjc.
-  if (!dlsym(RTLD_NEXT, "_objc_loadClassref")) {
+  if (!dlsym(RTLD_NEXT, "objc_loadClassref")) {
     fprintf(stderr, "skipping evolution tests; OS too old\n");
     return EXIT_SUCCESS;
   }


### PR DESCRIPTION
The Objective-C runtime expects a signed pointer here. The existing test
would have caught this, except it was always disabled because the
symbol name passed to the dlsym() check should not have had the leading
'_'.

Fixes <rdar://problem/57679510>.