### PR TITLE
[5.3] Propagate Failures Explicitly in Opaque Type Resolution

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2658,8 +2658,10 @@ Type TypeResolver::resolveOpaqueReturnType(TypeRepr *repr,
   if (auto generic = dyn_cast<GenericIdentTypeRepr>(repr)) {
     for (auto argRepr : generic->getGenericArgs()) {
       auto argTy = resolveType(argRepr, options);
-      if (!argTy)
-        return Type();
+      // If we cannot resolve the generic parameter, propagate the error out.
+      if (!argTy || argTy->hasError()) {
+        return ErrorType::get(Context);
+      }
       TypeArgsBuf.push_back(argTy);
     }
   }
@@ -2667,8 +2669,10 @@ Type TypeResolver::resolveOpaqueReturnType(TypeRepr *repr,
   // Use type reconstruction to summon the opaque type decl.
   Demangler demangle;
   auto definingDeclNode = demangle.demangleSymbol(mangledName);
-  if (!definingDeclNode)
-    return Type();
+  if (!definingDeclNode) {
+    diagnose(repr->getLoc(), diag::no_opaque_return_type_of);
+    return ErrorType::get(Context);
+  }
   if (definingDeclNode->getKind() == Node::Kind::Global)
     definingDeclNode = definingDeclNode->getChild(0);
   ASTBuilder builder(Context);
@@ -2678,8 +2682,9 @@ Type TypeResolver::resolveOpaqueReturnType(TypeRepr *repr,
   
   auto TypeArgs = ArrayRef<Type>(TypeArgsBuf);
   auto ty = builder.resolveOpaqueType(opaqueNode, TypeArgs, ordinal);
-  if (!ty) {
+  if (!ty || ty->hasError()) {
     diagnose(repr->getLoc(), diag::no_opaque_return_type_of);
+    return ErrorType::get(Context);
   }
   return ty;
 }

--- a/test/ModuleInterface/invalid-opaque-result-types.swift
+++ b/test/ModuleInterface/invalid-opaque-result-types.swift
@@ -1,0 +1,23 @@
+// Test that we emit a diagnostic (and don't crash) when we cannot resolve
+// an opaque result type reference.
+//
+// First, emit an empty module interface:
+//
+// RUN: %empty-directory(%t)
+// RUN: echo "" | %target-swift-frontend -typecheck -emit-module-interface-path %t/InvalidOpaqueResultType.swiftinterface -enable-library-evolution -swift-version 5 -module-name InvalidOpaqueResultType -
+//
+// Then, blit some invalid opaque result types into the interface
+//
+// Test that we reject broken type parameters
+// RUN: echo "public typealias SomeGenericBalderdash = @_opaqueReturnTypeOf(\"$somesuchnonsense\", 0) 🦸<InvalidParameter>" >> %t/InvalidOpaqueResultType.swiftinterface
+// Test that we reject types we cannot demangle
+// RUN: echo "public typealias SomesuchNonsense = @_opaqueReturnTypeOf(\"$somesuchnonsense\", 0) 🦸" >> %t/InvalidOpaqueResultType.swiftinterface
+//
+// The stage is set:
+//
+// RUN: not %target-swift-frontend -typecheck %s -I %t 2>&1 | %FileCheck %s
+
+// CHECK: cannot find type 'InvalidParameter' in scope
+// CHECK: unable to resolve type for _opaqueReturnTypeOf attribute
+// CHECK: failed to build module 'InvalidOpaqueResultType' from its module interface
+import InvalidOpaqueResultType


### PR DESCRIPTION
Cherry-picked from #31484 

This code should not yield the null Type() on failure. Instead, diagnose
the failure and yield an ErrorType. This matches what clients of this
function expect to signal failure.

Include a regression test that exercises a common failure mode if we
don't do this: module interface loading crashes.

rdar://62745419