### PR TITLE
Diags: Use the declared type for diagnosing inheritance from final class

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2536,7 +2536,7 @@ NOTE(superclass_here,none,"superclass is declared here", ())
 ERROR(superclass_of_open_not_open,none,
   "superclass %0 of open class must be open", (Type))
 ERROR(inheritance_from_final_class,none,
-      "inheritance from a final class %0", (Identifier))
+      "inheritance from a final class %0", (Type))
 ERROR(inheritance_from_unspecialized_objc_generic_class,none,
       "inheritance from a generic Objective-C class %0 must bind "
       "type parameters of %0 to specific concrete types", (Identifier))

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1943,7 +1943,8 @@ public:
       bool isInvalidSuperclass = false;
 
       if (Super->isFinal()) {
-        CD->diagnose(diag::inheritance_from_final_class, Super->getName());
+        CD->diagnose(diag::inheritance_from_final_class,
+                     Super->getDeclaredType());
         // FIXME: should this really be skipping the rest of decl-checking?
         return;
       }

--- a/test/attr/attr_final.swift
+++ b/test/attr/attr_final.swift
@@ -81,3 +81,8 @@ class Sub2 : Super2 { //// expected-error{{inheritance from a final class 'Super
 
   final override init() {} // expected-error {{'final' modifier cannot be applied to this declaration}} {{3-9=}}
 }
+
+struct Box<T> {
+  final class Super3 {}
+}
+class Sub3: Box<Int>.Super3 {} // expected-error{{inheritance from a final class 'Box.Super3'}}


### PR DESCRIPTION
Otherwise we do not reflect the lexical scope of nested superclass declarations.