### PR TITLE
[Diags] Don't error twice for incomplete computed properties in extensions

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5448,16 +5448,6 @@ ParserStatus Parser::parseGetSet(ParseDeclOptions Flags,
     if (parsingLimitedSyntax)
       return makeParserSuccess();
 
-    // In an extension, add a getter to prevent an "extensions must not contain
-    // stored properties" error.
-    if (Flags.contains(PD_InExtension)) {
-      auto getter = createAccessorFunc(
-          Tok.getLoc(), /*ValueNamePattern*/ nullptr, GenericParams, Indices,
-          StaticLoc, Flags, AccessorKind::Get, storage, this,
-          /*AccessorKeywordLoc*/ SourceLoc());
-      accessors.add(getter);
-    }
-
     diagnose(accessors.RBLoc, diag::computed_property_no_accessors,
              /*subscript*/ Indices != nullptr);
     return makeParserError();

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5448,6 +5448,16 @@ ParserStatus Parser::parseGetSet(ParseDeclOptions Flags,
     if (parsingLimitedSyntax)
       return makeParserSuccess();
 
+    // In an extension, add a getter to prevent an "extensions must not contain
+    // stored properties" error.
+    if (Flags.contains(PD_InExtension)) {
+      auto getter = createAccessorFunc(
+          Tok.getLoc(), /*ValueNamePattern*/ nullptr, GenericParams, Indices,
+          StaticLoc, Flags, AccessorKind::Get, storage, this,
+          /*AccessorKeywordLoc*/ SourceLoc());
+      accessors.add(getter);
+    }
+
     diagnose(accessors.RBLoc, diag::computed_property_no_accessors,
              /*subscript*/ Indices != nullptr);
     return makeParserError();

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3064,6 +3064,13 @@ StorageImplInfoRequest::evaluate(Evaluator &evaluator,
       readImpl = ReadImplKind::Stored;
     }
 
+  // Extensions can't have stored properties. If there are braces, assume
+  // this is an incomplete computed property. This avoids an "extensions
+  // must not contain stored properties" error later on.
+  } else if (isa<ExtensionDecl>(storage->getDeclContext()) &&
+             storage->getBracesRange().isValid()) {
+    readImpl = ReadImplKind::Get;
+
   // Otherwise, it's stored.
   } else {
     readImpl = ReadImplKind::Stored;

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -380,6 +380,12 @@ var x12: X {
 
 var x13: X {} // expected-error {{computed property must have accessors specified}}
 
+struct X14 {}
+extension X14 {
+  var x14: X {
+  } // expected-error {{computed property must have accessors specified}}
+}
+
 // Type checking problems
 struct Y { }
 var y: Y


### PR DESCRIPTION
If you have an empty computed property in an extension:

```swift
struct S {}

extension S {
    var foo: Int {
    }
}
```

Then Swift will give 2 conflicting errors: one that calls it a computed
property and another that calls it a stored property.

```
5:5: error: computed property must have accessors specified
    }
    ^
4:9: error: extensions must not contain stored properties
    var foo: Int {
        ^
```

This removes the unhelpful second diagnostic by changing
`StorageImplInfoRequest::evaluate` to use `ReadImplKind::Get` for
 properties with braces inside extensions.

This happens to me frequently. I'll decide to add a computed property,
write its declaration, then pause to decide how to implement it. The
presence of a 2nd error is both distracting and confusing.