### PR TITLE
NFC: fix stdlib compilation warning.

### DIFF
--- a/stdlib/public/Darwin/Foundation/Data.swift
+++ b/stdlib/public/Darwin/Foundation/Data.swift
@@ -1416,7 +1416,6 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
 
         @inlinable
-        @usableFromInline
         @_alwaysEmitIntoClient
         internal mutating func _truncateOrZeroExtend(toCount newCount: Int) {
             switch self {


### PR DESCRIPTION
Remove extraneous `@usableFromInline` attribute.
Silences warning:

```
swift/stdlib/public/Darwin/Foundation/Data.swift:1419:9: warning: '@inlinable' declaration is already '@usableFromInline'
        @usableFromInline
        ^~~~~~~~~~~~~~~~~
```