### PR TITLE
Fixes example snippets in StringUTF8View.swift

### DIFF
--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -78,7 +78,7 @@ extension String {
   ///
   ///     print(strncmp(s1, s2, 14))
   ///     // Prints "0"
-  ///     print(String(s1.utf8.prefix(14)))
+  ///     print(String(s1.utf8.prefix(14))!)
   ///     // Prints "They call me '"
   ///
   /// Extending the compared character count to 15 includes the differing
@@ -86,7 +86,7 @@ extension String {
   ///
   ///     print(strncmp(s1, s2, 15))
   ///     // Prints "-17"
-  ///     print(String(s1.utf8.prefix(15)))
+  ///     print(String(s1.utf8.prefix(15))!)
   ///     // Prints "They call me 'B"
   @frozen
   public struct UTF8View {


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixes example snippets in StringUTF8View.swift

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
