### PR TITLE
AST: Assert we were given a type parameter in GenericSignatureImpl::requiresClass

### DIFF
--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -379,7 +379,8 @@ GenericSignatureImpl::lookupConformance(CanType type,
 }
 
 bool GenericSignatureImpl::requiresClass(Type type) {
-  if (!type->isTypeParameter()) return false;
+  assert(type->isTypeParameter() &&
+         "Only type parameters can have superclass requirements");
 
   auto &builder = *getGenericSignatureBuilder();
   auto equivClass =

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -222,8 +222,7 @@ bool AbstractionPattern::requiresClass() const {
     auto type = getType();
     if (auto archetype = dyn_cast<ArchetypeType>(type))
       return archetype->requiresClass();
-    if (isa<DependentMemberType>(type) ||
-        isa<GenericTypeParamType>(type)) {
+    if (type->isTypeParameter()) {
       if (getKind() == Kind::ClangType) {
         // ObjC generics are always class constrained.
         return true;


### PR DESCRIPTION
Doing the absolute minimum here to ease progression.


