### PR TITLE
Fix variable name in `DifferentialProgramming.md`

### DIFF
--- a/docs/DifferentiableProgramming.md
+++ b/docs/DifferentiableProgramming.md
@@ -343,7 +343,7 @@ struct Observation {
 func meanError(for model: PodcastSpeedModel, _ observations: [Observation]) -> Float {
     var error: Float = 0
     for observation in observations {
-        error += abs(model.prediction(for: observation.state) - observation.userSpeed)
+        error += abs(model.prediction(for: observation.podcastState) - observation.userSpeed)
     }
     return error / Float(observations.count)
 }


### PR DESCRIPTION
In Podcast Player example of [`DifferentialProgramming.md`](https://github.com/apple/swift/blob/master/docs/DifferentiableProgramming.md#intelligent-applications), struct `Observation` has variable named `podcastState`, while it has been referenced as `state` in the `meanError` function. 

Changed it to `podcastState`.

Relevant code snippet: 
```swift
struct Observation {
    var podcastState: PodcastState
    var userSpeed: Float
}

func meanError(for model: PodcastSpeedModel, _ observations: [Observation]) -> Float {
    var error: Float = 0
    for observation in observations {
        error += abs(model.prediction(for: observation.state) - observation.userSpeed)
    }
    return error / Float(observations.count)
}
```
