### PR TITLE
[silgen] Instead of creating a single CleanupCloner for an RValue, use a helper routine that stores into an outarray a cloner for each ManagedValue in the RValue.

### DIFF
--- a/lib/SILGen/Cleanup.cpp
+++ b/lib/SILGen/Cleanup.cpp
@@ -349,11 +349,19 @@ CleanupCloner::CleanupCloner(SILGenFunction &SGF, const ManagedValue &mv)
 CleanupCloner::CleanupCloner(SILGenBuilder &builder, const ManagedValue &mv)
     : CleanupCloner(builder.getSILGenFunction(), mv) {}
 
-CleanupCloner::CleanupCloner(SILGenFunction &SGF, const RValue &rv)
-    : SGF(SGF), hasCleanup(rv.isPlusOne(SGF)), isLValue(false) {}
+void CleanupCloner::getClonersForRValue(
+    SILGenBuilder &builder, const RValue &rvalue,
+    SmallVectorImpl<CleanupCloner> &resultingCloners) {
+  return getClonersForRValue(builder.getSILGenFunction(), rvalue,
+                             resultingCloners);
+}
 
-CleanupCloner::CleanupCloner(SILGenBuilder &builder, const RValue &rv)
-    : CleanupCloner(builder.getSILGenFunction(), rv) {}
+void CleanupCloner::getClonersForRValue(
+    SILGenFunction &SGF, const RValue &rvalue,
+    SmallVectorImpl<CleanupCloner> &resultingCloners) {
+  transform(rvalue.values, std::back_inserter(resultingCloners),
+            [&](ManagedValue mv) { return CleanupCloner(SGF, mv); });
+}
 
 ManagedValue CleanupCloner::clone(SILValue value) const {
   if (isLValue) {

--- a/lib/SILGen/Cleanup.h
+++ b/lib/SILGen/Cleanup.h
@@ -282,10 +282,16 @@ class CleanupCloner {
 public:
   CleanupCloner(SILGenFunction &SGF, const ManagedValue &mv);
   CleanupCloner(SILGenBuilder &builder, const ManagedValue &mv);
-  CleanupCloner(SILGenFunction &SGF, const RValue &rv);
-  CleanupCloner(SILGenBuilder &builder, const RValue &rv);
 
   ManagedValue clone(SILValue value) const;
+
+  static void
+  getClonersForRValue(SILGenFunction &SGF, const RValue &rvalue,
+                      SmallVectorImpl<CleanupCloner> &resultingCloners);
+
+  static void
+  getClonersForRValue(SILGenBuilder &builder, const RValue &rvalue,
+                      SmallVectorImpl<CleanupCloner> &resultingCloners);
 };
 
 } // end namespace Lowering

--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -35,6 +35,7 @@ class Initialization;
 class Scope;
 class SILGenFunction;
 class TypeLowering;
+class CleanupCloner;
 
 /// An "exploded" SIL rvalue, in which tuple values are recursively
 /// destructured.
@@ -71,6 +72,7 @@ class TypeLowering;
 class RValue {
   friend class swift::Lowering::Scope;
   friend class swift::Lowering::ArgumentSource;
+  friend class swift::Lowering::CleanupCloner;
 
   std::vector<ManagedValue> values;
   CanType type;

--- a/lib/SILGen/Scope.cpp
+++ b/lib/SILGen/Scope.cpp
@@ -86,12 +86,14 @@ RValue Scope::popPreservingValue(RValue &&rv) {
   // recreate the RValue in the outer scope.
   CanType type = rv.type;
   unsigned numEltsRemaining = rv.elementsToBeAdded;
-  CleanupCloner cloner(SGF, rv);
-  llvm::SmallVector<SILValue, 4> values;
+  SmallVector<CleanupCloner, 4> cloners;
+  CleanupCloner::getClonersForRValue(SGF, rv, cloners);
+
+  SmallVector<SILValue, 4> values;
   std::move(rv).forwardAll(SGF, values);
 
   // Lifetime any address only values that we may have.
-  llvm::SmallVector<SILValue, 4> lifetimeExtendingBoxes;
+  SmallVector<SILValue, 4> lifetimeExtendingBoxes;
   lifetimeExtendAddressOnlyRValueSubValues(SGF, loc, values,
                                            lifetimeExtendingBoxes);
 
@@ -111,9 +113,9 @@ RValue Scope::popPreservingValue(RValue &&rv) {
   // Reconstruct the managed values from the underlying sil values in the outer
   // scope. Since the RValue wants a std::vector value, we use that instead.
   std::vector<ManagedValue> managedValues;
-  std::transform(
-      values.begin(), values.end(), std::back_inserter(managedValues),
-      [&cloner](SILValue v) -> ManagedValue { return cloner.clone(v); });
+  for (unsigned i : indices(values)) {
+    managedValues.push_back(cloners[i].clone(values[i]));
+  }
 
   // And then assemble the managed values into a rvalue.
   return RValue(SGF, std::move(managedValues), type, numEltsRemaining);


### PR DESCRIPTION
This simplifies CleanupCloner so that it only needs to model the cleanup of a
single managed value. It also eliminates a tie in between RValue and
CleanupCloner which is not needed.
