### PR TITLE
[Gardening] Enable Swift highlighting in SILProgrammersManual

### DIFF
--- a/docs/SILProgrammersManual.md
+++ b/docs/SILProgrammersManual.md
@@ -44,7 +44,7 @@ positions in several different contexts:
 
 Consider the example:
 
-```
+```swift
 func example<T>(i: Int, t: T) -> (Int, T) {
   let foo = { return ($0, t) }
   return foo(i)


### PR DESCRIPTION
Currently, when viewing a rendered result of `SILProgrammersManual.md`, the Swift code snippet is not highlighted.