### PR TITLE
Update build-windows.bat

### DIFF
--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -50,6 +50,15 @@ subst T: %full_build_root% %exitOnError%
 set build_root=T:
 set install_directory=%build_root%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr
 
+md %build_root%\tmp
+set TMPDIR=%build_root%\tmp
+
+md %build_root%\tmp\org.llvm.clang
+set CUSTOM_CLANG_MODULE_CACHE=%build_root%\tmp\org.llvm.clang.9999
+
+md %build_root%\tmp\org.swift.package-manager
+set SWIFTPM_MODULECACHE_OVERRIDE=%build_root%\tmp\org.swift.package-manager
+
 call :clone_repositories %exitOnError%
 call :download_icu %exitOnError%
 :: TODO: Disabled until we need LLBuild/SwiftPM in this build script.


### PR DESCRIPTION
Try to redirect the module caches to the build root

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
