### PR TITLE
test: loosen the test expectation

### DIFF
--- a/test/Driver/profiling.swift
+++ b/test/Driver/profiling.swift
@@ -66,4 +66,4 @@
 
 // RUN: %swiftc_driver -driver-print-jobs -profile-use=/dev/null %s | %FileCheck -check-prefix=USE_DEVNULL %s
 // USE_DEVNULL: swift
-// USE_DEVNULL: -profile-use={{/dev/null|(.*local\\\\temp\\\\.*profiling-[^ ]*.o)}}
+// USE_DEVNULL: -profile-use={{/dev/null|(.*profiling-[^ ]*.o)}}


### PR DESCRIPTION
The test expects the output location to be temp directory layout which
may not be the case.  Loosen the test to enable moving the temporary
directory.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
