### PR TITLE
[AutoDiff] Fix `@differentiable` attribute derivative configurations.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7106,6 +7106,10 @@ void AbstractFunctionDecl::prepareDerivativeFunctionConfigurations() {
 ArrayRef<AutoDiffConfig>
 AbstractFunctionDecl::getDerivativeFunctionConfigurations() {
   prepareDerivativeFunctionConfigurations();
+  // Check `@differentiable` attributes.
+  for (auto *diffAttr : getAttrs().getAttributes<DifferentiableAttr>())
+    (void)diffAttr->getParameterIndices();
+  // Load derivative configurations from imported modules.
   auto &ctx = getASTContext();
   if (ctx.getCurrentGeneration() > DerivativeFunctionConfigGeneration) {
     unsigned previousGeneration = DerivativeFunctionConfigGeneration;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7106,7 +7106,8 @@ void AbstractFunctionDecl::prepareDerivativeFunctionConfigurations() {
 ArrayRef<AutoDiffConfig>
 AbstractFunctionDecl::getDerivativeFunctionConfigurations() {
   prepareDerivativeFunctionConfigurations();
-  // Check `@differentiable` attributes.
+  // Resolve derivative function configurations from `@differentiable`
+  // attributes by type-checking them.
   for (auto *diffAttr : getAttrs().getAttributes<DifferentiableAttr>())
     (void)diffAttr->getParameterIndices();
   // Load derivative configurations from imported modules.

--- a/test/AutoDiff/SILOptimizer/Inputs/differentiation_diagnostics_other_file.swift
+++ b/test/AutoDiff/SILOptimizer/Inputs/differentiation_diagnostics_other_file.swift
@@ -1,0 +1,19 @@
+import _Differentiation
+
+protocol Protocol: Differentiable {
+  // Test cross-file `@differentiable` attribute.
+  @differentiable(wrt: self)
+  func identityDifferentiableAttr() -> Self
+}
+
+extension Protocol {
+  func identityDerivativeAttr() -> Self { self }
+
+  // Test cross-file `@derivative` attribute.
+  @derivative(of: identityDerivativeAttr)
+  func vjpIdentityDerivativeAttr() -> (
+    value: Self, pullback: (TangentVector) -> TangentVector
+  ) {
+    fatalError()
+  }
+}

--- a/test/AutoDiff/SILOptimizer/differentiation_diagnostics_cross_file.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_diagnostics_cross_file.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -emit-sil -verify -primary-file %s %S/Inputs/differentiation_diagnostics_other_file.swift -module-name main -o /dev/null
+
+// Test differentiation transform cross-file diagnostics.
+
+import _Differentiation
+
+// TF-1271: Test `@differentiable` original function in other file.
+@differentiable
+func crossFileDifferentiableAttr<T: Protocol>(
+  _ input: T
+) -> T {
+  return input.identityDifferentiableAttr()
+}
+
+// TF-1272: Test original function with registered derivatives in other files.
+// FIXME(TF-1272): Find a way to type-check `@derivative` attributes in other
+// files.
+@differentiable
+func crossFileDerivativeAttr<T: Protocol>(
+  _ input: T
+) -> T {
+  // expected-error @+2 {{expression is not differentiable}}
+  // expected-note @+1 {{cannot differentiate functions that have not been marked '@differentiable' and that are defined in other files}}
+  return input.identityDerivativeAttr()
+}


### PR DESCRIPTION
In `AbstractFunctionDecl::getDerivativeFunctionConfigurations`, type-check `@differentiable` attributes.

This is important to populate derivative configurations for original functions in other files. Otherwise, they will incorrectly be diagnosed with:
```
cannot differentiate functions that have not been marked '@differentiable' and that are defined in other files
```

---

Resolves TF-1271.

Exposes TF-1272: fix derivative configurations for cross-file `@derivative` attributes. This is a more difficult issue.