### PR TITLE
[build] NFC: document tensorflow branch CMake options.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,8 +77,10 @@ option(SWIFT_BUILD_STDLIB_EXTRA_TOOLCHAIN_CONTENT
     "If not building stdlib, controls whether to build 'stdlib/toolchain' content"
     TRUE)
 
+# `SWIFT_ENABLE_TENSOFRFLOW` affects lit tests, adding "tensorflow" as an
+# available feature.
 option(SWIFT_ENABLE_TENSORFLOW
-    "Enable TensorFlow in the compiler and build the Swift TensorFlow library"
+    "Enable TensorFlow in the compiler"
     FALSE)
 
 # In many cases, the CMake build system needs to determine whether to include

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1698,8 +1698,8 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DSWIFT_TOOLS_ENABLE_LTO:STRING="${SWIFT_TOOLS_ENABLE_LTO}"
                     -DSWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER:BOOL=$(true_false "${BUILD_RUNTIME_WITH_HOST_COMPILER}")
                     -DLIBDISPATCH_CMAKE_BUILD_TYPE:STRING="${LIBDISPATCH_BUILD_TYPE}"
-
                     # SWIFT_ENABLE_TENSORFLOW
+                    # CMake options specific to `tensorflow` branch here.
                     -DSWIFT_ENABLE_TENSORFLOW:BOOL=TRUE
                     # SWIFT_ENABLE_TENSORFLOW END
                     "${swift_cmake_options[@]}"


### PR DESCRIPTION
Document `SWIFT_ENABLE_TENSORFLOW` CMake option.
Explain that it affects the `tensorflow` lit testing available feature.

Factored out from https://github.com/apple/swift/pull/31301.