### PR TITLE
[AutoDiff] Require same access level for original/derivative functions.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3064,8 +3064,8 @@ ERROR(derivative_attr_access_level_mismatch,none,
        /*derivative*/ DeclName, /*derivative*/ AccessLevel))
 NOTE(derivative_attr_fix_access,none,
      "mark the derivative function as "
-     "'%select{private|fileprivate|internal|public|open}0' to match the "
-     "original function", (AccessLevel))
+     "'%select{private|fileprivate|internal|@usableFromInline|@usableFromInline}0' "
+     "to match the original function", (AccessLevel))
 
 // @transpose
 ERROR(transpose_attr_invalid_linearity_parameter_or_result,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3054,6 +3054,22 @@ ERROR(derivative_attr_original_already_has_derivative,none,
       "a derivative already exists for %0", (DeclName))
 NOTE(derivative_attr_duplicate_note,none,
      "other attribute declared here", ())
+ERROR(derivative_attr_access_level_lower_than_original,none,
+      "derivative functions for "
+      "%select{private|fileprivate|internal|public or '@usableFromInline'|open}1 "
+      "original function %0 must also be "
+      "%select{private|fileprivate|internal|public or '@usableFromInline'|open}1, "
+      "but %2 is %select{private|fileprivate|internal|public|open}3",
+      (/*original*/ DeclName, /*original*/ AccessLevel,
+       /*derivative*/ DeclName, /*derivative*/ AccessLevel))
+ERROR(derivative_attr_access_level_higher_than_original,none,
+      "the original function of "
+      "%select{a private|a fileprivate|an internal|a public or '@usableFromInline'|an open}3 "
+      "derivative function must also be "
+      "%select{private|fileprivate|internal|public or '@usableFromInline'|open}3, "
+      "but %0 is %select{private|fileprivate|internal|public|open}1",
+      (/*original*/ DeclName, /*original*/ AccessLevel,
+       /*derivative*/ DeclName, /*derivative*/ AccessLevel))
 
 // @transpose
 ERROR(transpose_attr_invalid_linearity_parameter_or_result,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3054,22 +3054,18 @@ ERROR(derivative_attr_original_already_has_derivative,none,
       "a derivative already exists for %0", (DeclName))
 NOTE(derivative_attr_duplicate_note,none,
      "other attribute declared here", ())
-ERROR(derivative_attr_access_level_lower_than_original,none,
-      "derivative functions for "
-      "%select{private|fileprivate|internal|public or '@usableFromInline'|open}1 "
-      "original function %0 must also be "
-      "%select{private|fileprivate|internal|public or '@usableFromInline'|open}1, "
-      "but %2 is %select{private|fileprivate|internal|public|open}3",
+ERROR(derivative_attr_access_level_mismatch,none,
+      "derivative function must have same access level as original function; "
+      "derivative function %2 is "
+      "%select{private|fileprivate|internal|public|open}3, "
+      "but original function %0 is "
+      "%select{private|fileprivate|internal|public|open}1",
       (/*original*/ DeclName, /*original*/ AccessLevel,
        /*derivative*/ DeclName, /*derivative*/ AccessLevel))
-ERROR(derivative_attr_access_level_higher_than_original,none,
-      "the original function of "
-      "%select{a private|a fileprivate|an internal|a public or '@usableFromInline'|an open}3 "
-      "derivative function must also be "
-      "%select{private|fileprivate|internal|public or '@usableFromInline'|open}3, "
-      "but %0 is %select{private|fileprivate|internal|public|open}1",
-      (/*original*/ DeclName, /*original*/ AccessLevel,
-       /*derivative*/ DeclName, /*derivative*/ AccessLevel))
+NOTE(derivative_attr_fix_access,none,
+     "mark the derivative function as "
+     "'%select{private|fileprivate|internal|public|open}0' to match the "
+     "original function", (AccessLevel))
 
 // @transpose
 ERROR(transpose_attr_invalid_linearity_parameter_or_result,none,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4562,7 +4562,17 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
                    derivative->getName(), derivativeAccess);
     auto fixItDiag =
         derivative->diagnose(diag::derivative_attr_fix_access, originalAccess);
-    fixItAccess(fixItDiag, derivative, originalAccess);
+    // If original access is public, suggest adding `@usableFromInline` to
+    // derivative.
+    if (originalAccess == AccessLevel::Public) {
+      fixItDiag.fixItInsert(
+          derivative->getAttributeInsertionLoc(/*forModifier*/ false),
+          "@usableFromInline ");
+    }
+    // Otherwise, suggest changing derivative access level.
+    else {
+      fixItAccess(fixItDiag, derivative, originalAccess);
+    }
     return true;
   }
 

--- a/test/AutoDiff/SILGen/sil_differentiability_witness.swift
+++ b/test/AutoDiff/SILGen/sil_differentiability_witness.swift
@@ -44,7 +44,7 @@ public func foo_vjp(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
 func bar<T>(_ x: Float, _ y: T) -> Float { x }
 
 @derivative(of: bar)
-public func bar_jvp<T>(_ x: Float, _ y: T) -> (value: Float, differential: (Float) -> Float) {
+func bar_jvp<T>(_ x: Float, _ y: T) -> (value: Float, differential: (Float) -> Float) {
   (x, { $0 })
 }
 

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -746,6 +746,7 @@ extension InoutParameters {
 // Test cross-file derivative registration.
 
 extension FloatingPoint where Self: Differentiable {
+  @usableFromInline
   @derivative(of: rounded)
   func vjpRounded() -> (
     value: Self,
@@ -801,4 +802,113 @@ extension HasADefaultDerivative {
   func req(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
     (x, { 10 * $0 })
   }
+}
+
+// MARK: - Original function visibility = derivative function visibility
+
+public func public_original_public_derivative(_ x: Float) -> Float { x }
+@derivative(of: public_original_public_derivative)
+public func _public_original_public_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
+public func public_original_usablefrominline_derivative(_ x: Float) -> Float { x }
+@usableFromInline
+@derivative(of: public_original_usablefrominline_derivative)
+func _public_original_usablefrominline_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
+@usableFromInline
+func usablefrominline_original_public_derivative(_ x: Float) -> Float { x }
+// expected-error @+1 {{derivative functions for public or '@usableFromInline' original function 'usablefrominline_original_public_derivative' must also be public or '@usableFromInline', but '_usablefrominline_original_public_derivative' is public}}
+@derivative(of: usablefrominline_original_public_derivative)
+public func _usablefrominline_original_public_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
+func internal_original_internal_derivative(_ x: Float) -> Float { x }
+@derivative(of: internal_original_internal_derivative)
+func _internal_original_internal_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
+private func private_original_private_derivative(_ x: Float) -> Float { x }
+@derivative(of: private_original_private_derivative)
+private func _private_original_private_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
+fileprivate func fileprivate_original_fileprivate_derivative(_ x: Float) -> Float { x }
+@derivative(of: fileprivate_original_fileprivate_derivative)
+fileprivate func _fileprivate_original_fileprivate_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
+fileprivate func fileprivate_original_private_derivative(_ x: Float) -> Float { x }
+// expected-error @+1 {{derivative functions for fileprivate original function 'fileprivate_original_private_derivative' must also be fileprivate, but '_fileprivate_original_private_derivative' is private}}
+@derivative(of: fileprivate_original_private_derivative)
+private func _fileprivate_original_private_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
+private func private_original_fileprivate_derivative(_ x: Float) -> Float { x }
+// expected-error @+1 {{derivative functions for fileprivate original function 'private_original_fileprivate_derivative' must also be fileprivate, but '_private_original_fileprivate_derivative' is fileprivate}}
+@derivative(of: private_original_fileprivate_derivative)
+fileprivate func _private_original_fileprivate_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
+// MARK: - Original function visibility < derivative function visibility
+
+func internal_original_public_derivative(_ x: Float) -> Float { x }
+// expected-error @+1 {{the original function of a public or '@usableFromInline' derivative function must also be public or '@usableFromInline', but 'internal_original_public_derivative' is internal}}
+@derivative(of: internal_original_public_derivative)
+public func _internal_original_public_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
+private func private_original_usablefrominline_derivative(_ x: Float) -> Float { x }
+// expected-error @+1 {{the original function of a public or '@usableFromInline' derivative function must also be public or '@usableFromInline', but 'private_original_usablefrominline_derivative' is private}}
+@derivative(of: private_original_usablefrominline_derivative)
+@usableFromInline
+func _private_original_usablefrominline_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
+private func private_original_public_derivative(_ x: Float) -> Float { x }
+// expected-error @+1 {{the original function of a public or '@usableFromInline' derivative function must also be public or '@usableFromInline', but 'private_original_public_derivative' is private}}
+@derivative(of: private_original_public_derivative)
+public func _private_original_public_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
+private func private_original_internal_derivative(_ x: Float) -> Float { x }
+// expected-error @+1 {{the original function of an internal derivative function must also be internal, but 'private_original_internal_derivative' is private}}
+@derivative(of: private_original_internal_derivative)
+func _private_original_internal_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
+// MARK: - Original function visibility > derivative function visibility
+
+public func public_original_private_derivative(_ x: Float) -> Float { x }
+// expected-error @+1 {{derivative functions for public or '@usableFromInline' original function 'public_original_private_derivative' must also be public or '@usableFromInline', but '_public_original_private_derivative' is fileprivate}}
+@derivative(of: public_original_private_derivative)
+fileprivate func _public_original_private_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
+public func public_original_internal_derivative(_ x: Float) -> Float { x }
+// expected-error @+1 {{derivative functions for public or '@usableFromInline' original function 'public_original_internal_derivative' must also be public or '@usableFromInline', but '_public_original_internal_derivative' is internal}}
+@derivative(of: public_original_internal_derivative)
+func _public_original_internal_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
+func internal_original_fileprivate_derivative(_ x: Float) -> Float { x }
+// expected-error @+1 {{derivative functions for internal original function 'internal_original_fileprivate_derivative' must also be internal, but '_internal_original_fileprivate_derivative' is fileprivate}}
+@derivative(of: internal_original_fileprivate_derivative)
+fileprivate func _internal_original_fileprivate_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
 }

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -819,14 +819,6 @@ func _public_original_usablefrominline_derivative(_ x: Float) -> (value: Float, 
   fatalError()
 }
 
-@usableFromInline
-func usablefrominline_original_public_derivative(_ x: Float) -> Float { x }
-// expected-error @+1 {{derivative functions for public or '@usableFromInline' original function 'usablefrominline_original_public_derivative' must also be public or '@usableFromInline', but '_usablefrominline_original_public_derivative' is public}}
-@derivative(of: usablefrominline_original_public_derivative)
-public func _usablefrominline_original_public_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
-  fatalError()
-}
-
 func internal_original_internal_derivative(_ x: Float) -> Float { x }
 @derivative(of: internal_original_internal_derivative)
 func _internal_original_internal_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
@@ -846,46 +838,61 @@ fileprivate func _fileprivate_original_fileprivate_derivative(_ x: Float) -> (va
 }
 
 fileprivate func fileprivate_original_private_derivative(_ x: Float) -> Float { x }
-// expected-error @+1 {{derivative functions for fileprivate original function 'fileprivate_original_private_derivative' must also be fileprivate, but '_fileprivate_original_private_derivative' is private}}
+// expected-error @+1 {{derivative function must have same access level as original function; derivative function '_fileprivate_original_private_derivative' is private, but original function 'fileprivate_original_private_derivative' is fileprivate}}
 @derivative(of: fileprivate_original_private_derivative)
+// expected-note @+1 {{mark the derivative function as 'fileprivate' to match the original function}}
 private func _fileprivate_original_private_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
   fatalError()
 }
 
 private func private_original_fileprivate_derivative(_ x: Float) -> Float { x }
-// expected-error @+1 {{derivative functions for fileprivate original function 'private_original_fileprivate_derivative' must also be fileprivate, but '_private_original_fileprivate_derivative' is fileprivate}}
+// expected-error @+1 {{derivative function must have same access level as original function; derivative function '_private_original_fileprivate_derivative' is fileprivate, but original function 'private_original_fileprivate_derivative' is private}}
 @derivative(of: private_original_fileprivate_derivative)
+// expected-note @+1 {{mark the derivative function as 'private' to match the original function}}
 fileprivate func _private_original_fileprivate_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
   fatalError()
 }
 
 // MARK: - Original function visibility < derivative function visibility
 
+@usableFromInline
+func usablefrominline_original_public_derivative(_ x: Float) -> Float { x }
+// expected-error @+1 {{derivative function must have same access level as original function; derivative function '_usablefrominline_original_public_derivative' is public, but original function 'usablefrominline_original_public_derivative' is internal}}
+@derivative(of: usablefrominline_original_public_derivative)
+// expected-note @+1 {{mark the derivative function as 'internal' to match the original function}}
+public func _usablefrominline_original_public_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
 func internal_original_public_derivative(_ x: Float) -> Float { x }
-// expected-error @+1 {{the original function of a public or '@usableFromInline' derivative function must also be public or '@usableFromInline', but 'internal_original_public_derivative' is internal}}
+// expected-error @+1 {{derivative function must have same access level as original function; derivative function '_internal_original_public_derivative' is public, but original function 'internal_original_public_derivative' is internal}}
 @derivative(of: internal_original_public_derivative)
+// expected-note @+1 {{mark the derivative function as 'internal' to match the original function}}
 public func _internal_original_public_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
   fatalError()
 }
 
 private func private_original_usablefrominline_derivative(_ x: Float) -> Float { x }
-// expected-error @+1 {{the original function of a public or '@usableFromInline' derivative function must also be public or '@usableFromInline', but 'private_original_usablefrominline_derivative' is private}}
+// expected-error @+1 {{derivative function must have same access level as original function; derivative function '_private_original_usablefrominline_derivative' is internal, but original function 'private_original_usablefrominline_derivative' is private}}
 @derivative(of: private_original_usablefrominline_derivative)
 @usableFromInline
+// expected-note @+1 {{mark the derivative function as 'private' to match the original function}}
 func _private_original_usablefrominline_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
   fatalError()
 }
 
 private func private_original_public_derivative(_ x: Float) -> Float { x }
-// expected-error @+1 {{the original function of a public or '@usableFromInline' derivative function must also be public or '@usableFromInline', but 'private_original_public_derivative' is private}}
+// expected-error @+1 {{derivative function must have same access level as original function; derivative function '_private_original_public_derivative' is public, but original function 'private_original_public_derivative' is private}}
 @derivative(of: private_original_public_derivative)
+// expected-note @+1 {{mark the derivative function as 'private' to match the original function}}
 public func _private_original_public_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
   fatalError()
 }
 
 private func private_original_internal_derivative(_ x: Float) -> Float { x }
-// expected-error @+1 {{the original function of an internal derivative function must also be internal, but 'private_original_internal_derivative' is private}}
+// expected-error @+1 {{derivative function must have same access level as original function; derivative function '_private_original_internal_derivative' is internal, but original function 'private_original_internal_derivative' is private}}
 @derivative(of: private_original_internal_derivative)
+// expected-note @+1 {{mark the derivative function as 'private' to match the original function}}
 func _private_original_internal_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
   fatalError()
 }
@@ -893,22 +900,25 @@ func _private_original_internal_derivative(_ x: Float) -> (value: Float, pullbac
 // MARK: - Original function visibility > derivative function visibility
 
 public func public_original_private_derivative(_ x: Float) -> Float { x }
-// expected-error @+1 {{derivative functions for public or '@usableFromInline' original function 'public_original_private_derivative' must also be public or '@usableFromInline', but '_public_original_private_derivative' is fileprivate}}
+// expected-error @+1 {{derivative function must have same access level as original function; derivative function '_public_original_private_derivative' is fileprivate, but original function 'public_original_private_derivative' is public}}
 @derivative(of: public_original_private_derivative)
+// expected-note @+1 {{mark the derivative function as 'public' to match the original function}}
 fileprivate func _public_original_private_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
   fatalError()
 }
 
 public func public_original_internal_derivative(_ x: Float) -> Float { x }
-// expected-error @+1 {{derivative functions for public or '@usableFromInline' original function 'public_original_internal_derivative' must also be public or '@usableFromInline', but '_public_original_internal_derivative' is internal}}
+// expected-error @+1 {{derivative function must have same access level as original function; derivative function '_public_original_internal_derivative' is internal, but original function 'public_original_internal_derivative' is public}}
 @derivative(of: public_original_internal_derivative)
+// expected-note @+1 {{mark the derivative function as 'public' to match the original function}}
 func _public_original_internal_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
   fatalError()
 }
 
 func internal_original_fileprivate_derivative(_ x: Float) -> Float { x }
-// expected-error @+1 {{derivative functions for internal original function 'internal_original_fileprivate_derivative' must also be internal, but '_internal_original_fileprivate_derivative' is fileprivate}}
+// expected-error @+1 {{derivative function must have same access level as original function; derivative function '_internal_original_fileprivate_derivative' is fileprivate, but original function 'internal_original_fileprivate_derivative' is internal}}
 @derivative(of: internal_original_fileprivate_derivative)
+// expected-note @+1 {{mark the derivative function as 'internal' to match the original function}}
 fileprivate func _internal_original_fileprivate_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
   fatalError()
 }

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -837,29 +837,13 @@ fileprivate func _fileprivate_original_fileprivate_derivative(_ x: Float) -> (va
   fatalError()
 }
 
-fileprivate func fileprivate_original_private_derivative(_ x: Float) -> Float { x }
-// expected-error @+1 {{derivative function must have same access level as original function; derivative function '_fileprivate_original_private_derivative' is private, but original function 'fileprivate_original_private_derivative' is fileprivate}}
-@derivative(of: fileprivate_original_private_derivative)
-// expected-note @+1 {{mark the derivative function as 'fileprivate' to match the original function}}
-private func _fileprivate_original_private_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
-  fatalError()
-}
-
-private func private_original_fileprivate_derivative(_ x: Float) -> Float { x }
-// expected-error @+1 {{derivative function must have same access level as original function; derivative function '_private_original_fileprivate_derivative' is fileprivate, but original function 'private_original_fileprivate_derivative' is private}}
-@derivative(of: private_original_fileprivate_derivative)
-// expected-note @+1 {{mark the derivative function as 'private' to match the original function}}
-fileprivate func _private_original_fileprivate_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
-  fatalError()
-}
-
 // MARK: - Original function visibility < derivative function visibility
 
 @usableFromInline
 func usablefrominline_original_public_derivative(_ x: Float) -> Float { x }
 // expected-error @+1 {{derivative function must have same access level as original function; derivative function '_usablefrominline_original_public_derivative' is public, but original function 'usablefrominline_original_public_derivative' is internal}}
 @derivative(of: usablefrominline_original_public_derivative)
-// expected-note @+1 {{mark the derivative function as 'internal' to match the original function}}
+// expected-note @+1 {{mark the derivative function as 'internal' to match the original function}} {{1-7=internal}}
 public func _usablefrominline_original_public_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
   fatalError()
 }
@@ -867,7 +851,7 @@ public func _usablefrominline_original_public_derivative(_ x: Float) -> (value: 
 func internal_original_public_derivative(_ x: Float) -> Float { x }
 // expected-error @+1 {{derivative function must have same access level as original function; derivative function '_internal_original_public_derivative' is public, but original function 'internal_original_public_derivative' is internal}}
 @derivative(of: internal_original_public_derivative)
-// expected-note @+1 {{mark the derivative function as 'internal' to match the original function}}
+// expected-note @+1 {{mark the derivative function as 'internal' to match the original function}} {{1-7=internal}}
 public func _internal_original_public_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
   fatalError()
 }
@@ -876,7 +860,7 @@ private func private_original_usablefrominline_derivative(_ x: Float) -> Float {
 // expected-error @+1 {{derivative function must have same access level as original function; derivative function '_private_original_usablefrominline_derivative' is internal, but original function 'private_original_usablefrominline_derivative' is private}}
 @derivative(of: private_original_usablefrominline_derivative)
 @usableFromInline
-// expected-note @+1 {{mark the derivative function as 'private' to match the original function}}
+// expected-note @+1 {{mark the derivative function as 'private' to match the original function}} {{1-1=private }}
 func _private_original_usablefrominline_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
   fatalError()
 }
@@ -884,7 +868,7 @@ func _private_original_usablefrominline_derivative(_ x: Float) -> (value: Float,
 private func private_original_public_derivative(_ x: Float) -> Float { x }
 // expected-error @+1 {{derivative function must have same access level as original function; derivative function '_private_original_public_derivative' is public, but original function 'private_original_public_derivative' is private}}
 @derivative(of: private_original_public_derivative)
-// expected-note @+1 {{mark the derivative function as 'private' to match the original function}}
+// expected-note @+1 {{mark the derivative function as 'private' to match the original function}} {{1-7=private}}
 public func _private_original_public_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
   fatalError()
 }
@@ -897,12 +881,28 @@ func _private_original_internal_derivative(_ x: Float) -> (value: Float, pullbac
   fatalError()
 }
 
+fileprivate func fileprivate_original_private_derivative(_ x: Float) -> Float { x }
+// expected-error @+1 {{derivative function must have same access level as original function; derivative function '_fileprivate_original_private_derivative' is private, but original function 'fileprivate_original_private_derivative' is fileprivate}}
+@derivative(of: fileprivate_original_private_derivative)
+// expected-note @+1 {{mark the derivative function as 'fileprivate' to match the original function}} {{1-8=fileprivate}}
+private func _fileprivate_original_private_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
+private func private_original_fileprivate_derivative(_ x: Float) -> Float { x }
+// expected-error @+1 {{derivative function must have same access level as original function; derivative function '_private_original_fileprivate_derivative' is fileprivate, but original function 'private_original_fileprivate_derivative' is private}}
+@derivative(of: private_original_fileprivate_derivative)
+// expected-note @+1 {{mark the derivative function as 'private' to match the original function}} {{1-12=private}}
+fileprivate func _private_original_fileprivate_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
 // MARK: - Original function visibility > derivative function visibility
 
 public func public_original_private_derivative(_ x: Float) -> Float { x }
 // expected-error @+1 {{derivative function must have same access level as original function; derivative function '_public_original_private_derivative' is fileprivate, but original function 'public_original_private_derivative' is public}}
 @derivative(of: public_original_private_derivative)
-// expected-note @+1 {{mark the derivative function as 'public' to match the original function}}
+// expected-note @+1 {{mark the derivative function as '@usableFromInline' to match the original function}} {{1-1=@usableFromInline }}
 fileprivate func _public_original_private_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
   fatalError()
 }
@@ -910,7 +910,7 @@ fileprivate func _public_original_private_derivative(_ x: Float) -> (value: Floa
 public func public_original_internal_derivative(_ x: Float) -> Float { x }
 // expected-error @+1 {{derivative function must have same access level as original function; derivative function '_public_original_internal_derivative' is internal, but original function 'public_original_internal_derivative' is public}}
 @derivative(of: public_original_internal_derivative)
-// expected-note @+1 {{mark the derivative function as 'public' to match the original function}}
+// expected-note @+1 {{mark the derivative function as '@usableFromInline' to match the original function}} {{1-1=@usableFromInline }}
 func _public_original_internal_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
   fatalError()
 }
@@ -918,7 +918,7 @@ func _public_original_internal_derivative(_ x: Float) -> (value: Float, pullback
 func internal_original_fileprivate_derivative(_ x: Float) -> Float { x }
 // expected-error @+1 {{derivative function must have same access level as original function; derivative function '_internal_original_fileprivate_derivative' is fileprivate, but original function 'internal_original_fileprivate_derivative' is internal}}
 @derivative(of: internal_original_fileprivate_derivative)
-// expected-note @+1 {{mark the derivative function as 'internal' to match the original function}}
+// expected-note @+1 {{mark the derivative function as 'internal' to match the original function}} {{1-12=internal}}
 fileprivate func _internal_original_fileprivate_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
   fatalError()
 }


### PR DESCRIPTION
Require `@derivative` functions and their original functions to have the same access level.
Public original functions may also have internal `@usableFromInline` derivatives, as a special case. Diagnose access level mismatches.

This simplifies derivative registration rules, and may enable simplification of AutoDiff symbol linkage rules.

Resolves TF-1099 and TF-1160.

---

Example:
```swift
import _Differentiation

public func publicOriginal(_ x: Float) -> Float { x }

@derivative(of: publicOriginal)
private func privativeDerivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
  fatalError()
}
```

```console
$ swift example.swift
example.swift:5:17: error: derivative function must have same access level as original function; derivative function 'privativeDerivative' is private, but original function 'publicOriginal' is public
@derivative(of: publicOriginal)
                ^
example.swift:6:14: note: mark the derivative function as 'public' to match the original function
private func privativeDerivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
~~~~~~~      ^
public
```

---

Future direction: anonymous `func` declarations (SR-12003) will enable public derivative functions without exposing them as public API.

```swift
public func bar(_ x: Float) -> Float { x }

@derivative(of: bar)
public func _(_ x: Float) -> (value: Float, differential: (Float) -> Float) {
  (x, { dx in dx })
}
```

---

This additional restriction will break users. Fix all `@derivative` usage errors caught by ["community CI"](https://github.com/tensorflow/swift-apis/blob/master/Dockerfile) before merging.

Done: https://github.com/tensorflow/swift-apis/pull/929