### PR TITLE
AST: Remove TypeAliasType::getGenericSignature

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1772,11 +1772,6 @@ class TypeAliasType final
   }
 
 public:
-  /// Retrieve the generic signature used for substitutions.
-  GenericSignature getGenericSignature() const {
-    return getSubstitutionMap().getGenericSignature();
-  }
-
   static TypeAliasType *get(TypeAliasDecl *typealias, Type parent,
                             SubstitutionMap substitutions, Type underlying);
 

--- a/lib/PrintAsObjC/ModuleContentsWriter.cpp
+++ b/lib/PrintAsObjC/ModuleContentsWriter.cpp
@@ -56,7 +56,7 @@ class ReferencedTypeFinder : public TypeDeclFinder {
   Action visitTypeAliasType(TypeAliasType *aliasTy) override {
     if (aliasTy->getDecl()->hasClangNode() &&
         !aliasTy->getDecl()->isCompatibilityAlias()) {
-      assert(!aliasTy->getGenericSignature());
+      assert(!aliasTy->getDecl()->getGenericSignature());
       Callback(*this, aliasTy->getDecl());
     } else {
       Type(aliasTy->getSinglyDesugaredType()).walk(*this);


### PR DESCRIPTION
The divergence of `TypeAliasType` from `BoundGenericType`, precomputed substitution maps in particular, are currently blocking proper handling of recursive generic signature validation, because a meaningful subst. map must be constructed with a generic signature and therefore cannot be used to represent a structural type.

In an incremental effort to eventually close the gap between these type nodes, start off by removing `TypeAliasType::getGenericSignature` and its sole client.
