### PR TITLE
[CxxInterop] Fix static-var-irgen test for arm/ios

### DIFF
--- a/test/Interop/Cxx/static/static-var-irgen.swift
+++ b/test/Interop/Cxx/static/static-var-irgen.swift
@@ -46,10 +46,10 @@ public func initStaticVars() -> CInt {
 // CHECK: ret i32 16
 
 // CHECK: define internal void @{{__cxx_global_var_init.4|"\?\?__EstaticNonTrivial@@YAXXZ"}}()
-// CHECK: call {{void @_ZN10NonTrivialC[12]Ei\(%class.NonTrivial\* @_ZL16staticNonTrivial, i32 1024\)|%class.NonTrivial\* @"\?\?0NonTrivial@@QEAA@H@Z"\(%class.NonTrivial\* @staticNonTrivial, i32 1024\)}}
+// CHECK: call {{void|%class.NonTrivial\*}} {{@_ZN10NonTrivialC[12]Ei\(%class.NonTrivial\* @_ZL16staticNonTrivial, i32 1024\)|@"\?\?0NonTrivial@@QEAA@H@Z"\(%class.NonTrivial\* @staticNonTrivial, i32 1024\)}}
 
 // CHECK: define internal void @{{__cxx_global_var_init.5|"\?\?__EstaticConstNonTrivial@@YAXXZ"}}()
-// CHECK: call {{void @_ZN10NonTrivialC[12]Ei\(%class.NonTrivial\* @_ZL21staticConstNonTrivial, i32 2048\)|%class.NonTrivial\* @"\?\?0NonTrivial@@QEAA@H@Z"\(%class.NonTrivial\* @staticConstNonTrivial, i32 2048\)}}
+// CHECK: call {{void|%class.NonTrivial\*}} {{@_ZN10NonTrivialC[12]Ei\(%class.NonTrivial\* @_ZL21staticConstNonTrivial, i32 2048\)|@"\?\?0NonTrivial@@QEAA@H@Z"\(%class.NonTrivial\* @staticConstNonTrivial, i32 2048\)}}
 
 public func readStaticVar() -> CInt {
   return staticVar


### PR DESCRIPTION
This PR fixes the build failures reported at https://github.com/apple/swift/pull/31362 (https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-device-non_executable/70/consoleText).