### PR TITLE
[5.3][SourceKit] Report macCatalyst availability as macCatalyst rather than iOS

### DIFF
--- a/test/SourceKit/DocSupport/Inputs/availability_maccatalyst.swift
+++ b/test/SourceKit/DocSupport/Inputs/availability_maccatalyst.swift
@@ -1,0 +1,6 @@
+/// Some doc
+@available(iOS, deprecated)
+public func isAlwaysDeprecated_iOS() {}
+
+@available(macCatalyst, deprecated)
+public func isAlwaysDeprecated_catalyst() {}

--- a/test/SourceKit/DocSupport/Inputs/availability_maccatalyst_is_deprecated.swift
+++ b/test/SourceKit/DocSupport/Inputs/availability_maccatalyst_is_deprecated.swift
@@ -1,0 +1,18 @@
+/// Some doc
+@available(iOS, deprecated)
+public func isAlwaysDeprecated_iOS() {}
+
+@available(macCatalyst, deprecated)
+public func isAlwaysDeprecated_catalyst() {}
+
+@available(iOS, deprecated: 20.0)
+public func deprecatedInFutureVersion_iOS() {}
+
+@available(macCatalyst, deprecated: 20.0)
+public func deprecatedInFutureVersion_catalyst() {}
+
+@available(iOS, deprecated: 1.0)
+public func deprecatedInPastVersion_iOS() {}
+
+@available(macCatalyst, deprecated: 1.0)
+public func deprecatedInPastVersion_catalyst() {}

--- a/test/SourceKit/DocSupport/doc_swift_module_availability_maccatalyst.swift
+++ b/test/SourceKit/DocSupport/doc_swift_module_availability_maccatalyst.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t.mod)
+// RUN: %target-swift-frontend -emit-module -o %t.mod/availability.swiftmodule %S/Inputs/availability_maccatalyst.swift -parse-as-library -emit-module-doc-path %t.mod/availability.swiftdoc
+// RUN: %sourcekitd-test -req=doc-info -module availability -- -target %target-triple -I %t.mod | %FileCheck %s
+
+// CHECK:      key.name: "isAlwaysDeprecated_catalyst()",
+// CHECK:      key.attributes: [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     key.kind: source.lang.swift.attribute.availability,
+// CHECK-NEXT:     key.platform: source.availability.platform.maccatalyst,
+// CHECK-NEXT:     key.is_deprecated: 1
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]
+
+// CHECK:      key.name: "isAlwaysDeprecated_iOS()",
+// CHECK:      key.attributes: [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     key.kind: source.lang.swift.attribute.availability,
+// CHECK-NEXT:     key.platform: source.availability.platform.ios,
+// CHECK-NEXT:     key.is_deprecated: 1
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]

--- a/test/SourceKit/DocSupport/doc_swift_module_availability_maccatalyst_is_deprecated.swift
+++ b/test/SourceKit/DocSupport/doc_swift_module_availability_maccatalyst_is_deprecated.swift
@@ -1,0 +1,6 @@
+// REQUIRES: OS=maccatalyst
+
+// RUN: %empty-directory(%t.mod)
+// RUN: %swift -emit-module -target x86_64-apple-ios13.1-macabi -o %t.mod/availability.swiftmodule %S/Inputs/availability_maccatalyst_is_deprecated.swift -parse-as-library -emit-module-doc-path %t.mod/availability.swiftdoc
+// RUN: %sourcekitd-test -req=doc-info -module availability -- -target x86_64-apple-ios13.1-macabi -I %t.mod > %t.response
+// RUN: %diff -u %s.response %t.response

--- a/test/SourceKit/DocSupport/doc_swift_module_availability_maccatalyst_is_deprecated.swift.response
+++ b/test/SourceKit/DocSupport/doc_swift_module_availability_maccatalyst_is_deprecated.swift.response
@@ -1,0 +1,184 @@
+import SwiftOnoneSupport
+
+func deprecatedInFutureVersion_catalyst()
+
+func deprecatedInFutureVersion_iOS()
+
+func deprecatedInPastVersion_catalyst()
+
+func deprecatedInPastVersion_iOS()
+
+func isAlwaysDeprecated_catalyst()
+
+func isAlwaysDeprecated_iOS()
+
+
+[
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 0,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 7,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 26,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 31,
+    key.length: 34
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 69,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 74,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 107,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 112,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 148,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 153,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 184,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 189,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 220,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 225,
+    key.length: 22
+  }
+]
+[
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.name: "deprecatedInFutureVersion_catalyst()",
+    key.usr: "s:12availability34deprecatedInFutureVersion_catalystyyF",
+    key.offset: 26,
+    key.length: 41,
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>deprecatedInFutureVersion_catalyst</decl.name>()</decl.function.free>",
+    key.attributes: [
+      {
+        key.kind: source.lang.swift.attribute.availability,
+        key.platform: source.availability.platform.maccatalyst,
+        key.deprecated: "20.0"
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.name: "deprecatedInFutureVersion_iOS()",
+    key.usr: "s:12availability29deprecatedInFutureVersion_iOSyyF",
+    key.offset: 69,
+    key.length: 36,
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>deprecatedInFutureVersion_iOS</decl.name>()</decl.function.free>",
+    key.attributes: [
+      {
+        key.kind: source.lang.swift.attribute.availability,
+        key.platform: source.availability.platform.ios,
+        key.deprecated: "20.0"
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.name: "deprecatedInPastVersion_catalyst()",
+    key.usr: "s:12availability32deprecatedInPastVersion_catalystyyF",
+    key.offset: 107,
+    key.length: 39,
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>deprecatedInPastVersion_catalyst</decl.name>()</decl.function.free>",
+    key.attributes: [
+      {
+        key.kind: source.lang.swift.attribute.availability,
+        key.platform: source.availability.platform.maccatalyst,
+        key.deprecated: "1.0"
+      }
+    ],
+    key.is_deprecated: 1
+  },
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.name: "deprecatedInPastVersion_iOS()",
+    key.usr: "s:12availability27deprecatedInPastVersion_iOSyyF",
+    key.offset: 148,
+    key.length: 34,
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>deprecatedInPastVersion_iOS</decl.name>()</decl.function.free>",
+    key.attributes: [
+      {
+        key.kind: source.lang.swift.attribute.availability,
+        key.platform: source.availability.platform.ios,
+        key.deprecated: "1.0"
+      }
+    ],
+    key.is_deprecated: 1
+  },
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.name: "isAlwaysDeprecated_catalyst()",
+    key.usr: "s:12availability27isAlwaysDeprecated_catalystyyF",
+    key.offset: 184,
+    key.length: 34,
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>isAlwaysDeprecated_catalyst</decl.name>()</decl.function.free>",
+    key.attributes: [
+      {
+        key.kind: source.lang.swift.attribute.availability,
+        key.platform: source.availability.platform.maccatalyst,
+        key.is_deprecated: 1
+      }
+    ],
+    key.is_deprecated: 1
+  },
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.name: "isAlwaysDeprecated_iOS()",
+    key.usr: "s:12availability22isAlwaysDeprecated_iOSyyF",
+    key.doc.full_as_xml: "<Function><Name>isAlwaysDeprecated_iOS()</Name><USR>s:12availability22isAlwaysDeprecated_iOSyyF</USR><Declaration>@available(iOS, deprecated)\nfunc isAlwaysDeprecated_iOS()</Declaration><CommentParts><Abstract><Para>Some doc</Para></Abstract></CommentParts></Function>",
+    key.offset: 220,
+    key.length: 29,
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>isAlwaysDeprecated_iOS</decl.name>()</decl.function.free>",
+    key.attributes: [
+      {
+        key.kind: source.lang.swift.attribute.availability,
+        key.platform: source.availability.platform.ios,
+        key.is_deprecated: 1
+      }
+    ],
+    key.is_deprecated: 1
+  }
+]

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -630,7 +630,7 @@ static void reportAttributes(ASTContext &Ctx,
       case PlatformKind::iOS:
         PlatformUID = PlatformIOS; break;
       case PlatformKind::macCatalyst:
-        PlatformUID = PlatformIOS; break;
+        PlatformUID = PlatformMacCatalyst; break;
       case PlatformKind::OSX:
         PlatformUID = PlatformOSX; break;
       case PlatformKind::tvOS:


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/31466 for 5.3.

- **Explanation**:
SourceKit's doc-info request was incorrectly reporting the platform of `@available(macCatalyst, ...)` attributes as `source.availability.platform.ios` rather than `source.availability.platform.maccatalyst`.

- **Scope of issue**: Only impacts sourcekitd's doc-info request. Other sourcekitd requests and the compiler are unaffected.
- **Origination**: Has been an issue since explicit macCatalyst availability attribute support was added.
- **Risk**: Low. It's a single line change and only impacts SourceKit's doc-info request.
- **Testing**: Added a regression test for this case and all existing tests pass.
- **Reviewer**: Rintaro Ishizaki (@rintaro) on the master branch PR

Resolves rdar://problem/60918688