### PR TITLE
[5.3] COWArrayOpts: fix a mis-compile related to owned function arguments

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -99,25 +99,6 @@ static bool isRelease(SILInstruction *Inst, SILValue RetainedValue,
         return true;
       }
 
-  if (auto *AI = dyn_cast<ApplyInst>(Inst)) {
-    if (auto *F = AI->getReferencedFunctionOrNull()) {
-      auto Params = F->getLoweredFunctionType()->getParameters();
-      auto Args = AI->getArguments();
-      for (unsigned ArgIdx = 0, ArgEnd = Params.size(); ArgIdx != ArgEnd;
-           ++ArgIdx) {
-        if (MatchedReleases.count(&AI->getArgumentRef(ArgIdx)))
-          continue;
-        if (!areArraysEqual(RCIA, Args[ArgIdx], RetainedValue, ArrayAddress))
-          continue;
-        ParameterConvention P = Params[ArgIdx].getConvention();
-        if (P == ParameterConvention::Direct_Owned) {
-          LLVM_DEBUG(llvm::dbgs() << "     matching with release " << *Inst);
-          MatchedReleases.insert(&AI->getArgumentRef(ArgIdx));
-          return true;
-        }
-      }
-    }
-  }
   LLVM_DEBUG(llvm::dbgs() << "      not a matching release " << *Inst);
   return false;
 }

--- a/test/SILOptimizer/wrong_cow_arrayopt.swift
+++ b/test/SILOptimizer/wrong_cow_arrayopt.swift
@@ -1,0 +1,23 @@
+// RUN: %target-run-simple-swift(-O) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+
+@inline(never)
+func testit(_ input: [[Int]]) -> [[Int]] {
+  var result : [[Int]] = []
+  for inputElementArray in input {
+    var mutableElementArray = inputElementArray
+    for _ in 0..<2 {
+      // The COW-check for 'mutableElementArray' must not be hoisted out of this loop.
+      for i in 0..<1 {
+        mutableElementArray[i] += 1
+      }
+      result.append(mutableElementArray)
+    }
+  }
+  return result
+}
+
+// CHECK: {{\[\[1\], \[2\]\]}}
+print(testit([[0]]))


### PR DESCRIPTION
COWArrayOpts wrongly assumed that an 'owned' argument is released in the function.

https://bugs.swift.org/browse/SR-12440
rdar://problem/62201043

This is a cherry-pick of https://github.com/apple/swift/pull/31532