### PR TITLE
[5.3][SR-12725] Diagnose unhandled generic argument mismatch involving FunctionArgument

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -679,10 +679,6 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
       break;
     }
 
-    case ConstraintLocator::GenericArgument: {
-      break;
-    }
-
     case ConstraintLocator::OptionalPayload: {
       // If we have an inout expression, this comes from an
       // InoutToPointer argument mismatch failure.
@@ -709,7 +705,7 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
     }
 
     default:
-      return false;
+      break;
     }
   }
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1470,3 +1470,10 @@ func gericArgToParamInout(_ x: inout [[Int]]) { // expected-note {{change variab
   // expected-note@-1 {{arguments to generic parameter 'Element' ('Int' and 'String') are expected to be equal}}
   // expected-error@-2 {{inout argument could be set to a value with a type other than '[[Int]]'; use a value declared as type '[[String]]?' instead}}
 }
+
+// SR-12725
+struct SR12725<E> {} // expected-note {{arguments to generic parameter 'E' ('Int' and 'Double') are expected to be equal}}
+func generic<T>(_ value: inout T, _ closure: (SR12725<T>) -> Void) {}
+
+let arg: Int
+generic(&arg) { (g: SR12725<Double>) -> Void in } // expected-error {{cannot convert value of type '(SR12725<Double>) -> Void' to expected argument type '(SR12725<Int>) -> Void'}}


### PR DESCRIPTION
**Explanation:**  This improves diagnostics related to generic argument mismatch(es) found while converting one function type into another and other cases which aren't handled specifically by providing a fallback diagnostic. 

**Scope:** Diagnostics related to generic argument mismatches.

**SR Issue:** SR-12725

**Risk:** Very Low

**Testing:** Added regression tests.

**Reviewer:** @xedin 
