### PR TITLE
[ownership] In a few FileCheck, RUN: lines move %s before 2>&1.

### DIFF
--- a/test/SIL/ownership-verifier/borrow_scope_introducing_operands_positive.sil
+++ b/test/SIL/ownership-verifier/borrow_scope_introducing_operands_positive.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all=0 -o /dev/null 2>&1 %s
+// RUN: %target-sil-opt -enable-sil-verify-all=0 -o /dev/null %s 2>&1
 
 // REQUIRES: asserts
 

--- a/test/SIL/ownership-verifier/definite_init.sil
+++ b/test/SIL/ownership-verifier/definite_init.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -module-name Swift -enable-sil-verify-all=0 -o /dev/null 2>&1 %s
+// RUN: %target-sil-opt -module-name Swift -enable-sil-verify-all=0 -o /dev/null %s 2>&1
 // REQUIRES: asserts
 
 sil_stage raw

--- a/test/SIL/ownership-verifier/false_positive_leaks.sil
+++ b/test/SIL/ownership-verifier/false_positive_leaks.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -module-name Swift -enable-sil-verify-all=0 -o /dev/null 2>&1  %s
+// RUN: %target-sil-opt -module-name Swift -enable-sil-verify-all=0 -o /dev/null %s 2>&1
 // REQUIRES: asserts
 
 // This file is meant to contain dataflow tests that if they fail are false

--- a/test/SIL/ownership-verifier/objc_use_verifier.sil
+++ b/test/SIL/ownership-verifier/objc_use_verifier.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all=0 -module-name ObjectiveC -o /dev/null 2>&1  %s
+// RUN: %target-sil-opt -enable-sil-verify-all=0 -module-name ObjectiveC -o /dev/null %s 2>&1
 // REQUIRES: asserts
 // REQUIRES: objc_interop
 

--- a/test/SIL/ownership-verifier/opaque_use_verifier.sil
+++ b/test/SIL/ownership-verifier/opaque_use_verifier.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-opaque-values -enable-sil-verify-all=0 -module-name Swift -o /dev/null 2>&1  %s
+// RUN: %target-sil-opt -enable-sil-opaque-values -enable-sil-verify-all=0 -module-name Swift -o /dev/null %s 2>&1
 // REQUIRES: asserts
 
 // This file is meant to contain tests that previously the verifier treated

--- a/test/SIL/ownership-verifier/over_consume_positive.sil
+++ b/test/SIL/ownership-verifier/over_consume_positive.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all=0 -module-name Swift -o /dev/null 2>&1  %s
+// RUN: %target-sil-opt -enable-sil-verify-all=0 -module-name Swift -o /dev/null %s 2>&1
 // REQUIRES: asserts
 
 // This file is meant to contain tests that previously the verifier treated

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all=0 -module-name Swift -o /dev/null 2>&1  %s
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all=0 -module-name Swift -o /dev/null %s 2>&1
 // REQUIRES: asserts
 
 // This file is meant to contain tests that previously the verifier treated


### PR DESCRIPTION
NFC. Just matching other parts of the compiler.

----

As an added benefit it makes munging these a little easier since 2>&1 is by the "| FileCheck" part of the RUN line.