### PR TITLE
Fix default arguments of inlinable local functions

### DIFF
--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -348,6 +348,13 @@ swift::FragileFunctionKindRequest::evaluate(Evaluator &evaluator,
       auto *VD = cast<ValueDecl>(dc->getAsDecl());
       assert(VD->hasParameterList());
 
+      if (VD->getDeclContext()->isLocalContext()) {
+        auto kind = VD->getDeclContext()->getFragileFunctionKind();
+        if (kind.kind != FragileFunctionKind::None)
+          return {FragileFunctionKind::DefaultArgument,
+                  kind.allowUsableFromInline};
+      }
+
       auto effectiveAccess =
         VD->getFormalAccessScope(/*useDC=*/nullptr,
                                  /*treatUsableFromInlineAsPublic=*/true);

--- a/test/SILGen/default_arguments_local.swift
+++ b/test/SILGen/default_arguments_local.swift
@@ -57,3 +57,16 @@ class ArtClass<T> {
     return 0
   }
 }
+
+// Default arguments of local functions inside @inlinable contexts should be serialized.
+// https://bugs.swift.org/browse/SR-12404
+
+// CHECK-LABEL: sil [serialized] [ossa] @$s23default_arguments_local5outeryyF : $@convention(thin) () -> () {
+@inlinable public func outer() {
+  // CHECK-LABEL: sil shared [serialized] [ossa] @$s23default_arguments_local5outeryyF5innerL_1xySi_tFfA_ : $@convention(thin) () -> Int {
+
+  // CHECK-LABEL: sil shared [serializable] [ossa] @$s23default_arguments_local5outeryyF5innerL_1xySi_tF : $@convention(thin) (Int) -> () {
+  func inner(x: Int = 0) {}
+
+  inner()
+}

--- a/test/attr/attr_inlinable.swift
+++ b/test/attr/attr_inlinable.swift
@@ -9,11 +9,11 @@
 // expected-warning@-1 {{'@inlinable' declaration is already '@usableFromInline'}}
 
 private func privateFunction() {}
-// expected-note@-1{{global function 'privateFunction()' is not '@usableFromInline' or public}}
+// expected-note@-1 2{{global function 'privateFunction()' is not '@usableFromInline' or public}}
 fileprivate func fileprivateFunction() {}
 // expected-note@-1{{global function 'fileprivateFunction()' is not '@usableFromInline' or public}}
 func internalFunction() {}
-// expected-note@-1{{global function 'internalFunction()' is not '@usableFromInline' or public}}
+// expected-note@-1 2{{global function 'internalFunction()' is not '@usableFromInline' or public}}
 @usableFromInline func versionedFunction() {}
 public func publicFunction() {}
 
@@ -305,4 +305,17 @@ public struct PrivateInlinableCrash {
   private func formatYesNo(_ value: Bool) -> String {
     value ? "YES" : "NO"
   }
+}
+
+// https://bugs.swift.org/browse/SR-12404
+@inlinable public func inlinableOuterFunction() {
+  func innerFunction1(x: () = privateFunction()) {}
+  // expected-error@-1 {{global function 'privateFunction()' is private and cannot be referenced from a default argument value}}
+
+  func innerFunction2(x: () = internalFunction()) {}
+  // expected-error@-1 {{global function 'internalFunction()' is internal and cannot be referenced from a default argument value}}
+
+  func innerFunction3(x: () = versionedFunction()) {}
+
+  func innerFunction4(x: () = publicFunction()) {}
 }


### PR DESCRIPTION
Fixes two regressions that were introduced in Swift 5.2:

- Default arguments of local functions inside `@inlinable` functions were not serialized, which would cause a SIL verifier failure if the default argument was referenced
- There was no enforcement that these default arguments did not reference non-public symbols, which again could cause crashes.

Fixes rdar://problem/62200974 / https://bugs.swift.org/browse/SR-12404.