### PR TITLE
build: avoid redundant flag specification

### DIFF
--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -61,11 +61,7 @@ endif()
 # on the presence of symbols in libSupport to identify how the code was
 # built and cause link failures for mismatches. Without linking that library,
 # we get link failures regardless, so instead, this just disables the checks.
-if(CMAKE_VERSION VERSION_LESS 3.12)
-  append("-DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
-else()
-  add_compile_definitions(LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
-endif()
+add_compile_definitions($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1>)
 
 set(SWIFT_STDLIB_LIBRARY_BUILD_TYPES)
 if(SWIFT_BUILD_DYNAMIC_STDLIB)

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1147,14 +1147,6 @@ function(_add_swift_target_library_single target name)
     MACCATALYST_BUILD_FLAVOR "${SWIFTLIB_SINGLE_MACCATALYST_BUILD_FLAVOR}"
     )
 
-  if(SWIFTLIB_IS_STDLIB)
-    # We don't ever want to link against the ABI-breakage checking symbols
-    # in the standard library, runtime, or overlays because they only rely
-    # on the header parts of LLVM's ADT.
-    list(APPEND c_compile_flags
-      "-DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1")
-  endif()
-
   if(SWIFTLIB_SINGLE_SDK STREQUAL WINDOWS)
     if(libkind STREQUAL SHARED)
       list(APPEND c_compile_flags -D_WINDLL)

--- a/stdlib/toolchain/CMakeLists.txt
+++ b/stdlib/toolchain/CMakeLists.txt
@@ -44,18 +44,6 @@ if("Thread" IN_LIST SWIFT_RUNTIME_USE_SANITIZERS)
   list(APPEND CXX_LINK_FLAGS "-fsanitize=thread")
 endif()
 
-# Do not enforce checks for LLVM's ABI-breaking build settings.
-# The Swift runtime uses some header-only code from LLVM's ADT classes,
-# but we do not want to link libSupport into the runtime. These checks rely
-# on the presence of symbols in libSupport to identify how the code was
-# built and cause link failures for mismatches. Without linking that library,
-# we get link failures regardless, so instead, this just disables the checks.
-if(CMAKE_VERSION VERSION_LESS 3.12)
-  append("-DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
-else()
-  add_compile_definitions(LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
-endif()
-
 # Compatibility libraries build in a special alternate universe that can't
 # directly link to most OS runtime libraries, and have to access the
 # runtime being patched only through public ABI.


### PR DESCRIPTION
Remove the flag being specified in multiple locations unnecessarily.
The flags flow downwards to all the subdirectories.  Use that to apply
the C/C++ flags from the root of the runtime repository.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
