### PR TITLE
Temporarily disable 3 AutoDiff tests: SR-12732

### DIFF
--- a/test/AutoDiff/stdlib/derivative_customization.swift
+++ b/test/AutoDiff/stdlib/derivative_customization.swift
@@ -1,6 +1,8 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// REQUIRES: SR12732
+
 import DifferentiationUnittest
 import StdlibUnittest
 

--- a/test/AutoDiff/validation-test/custom_derivatives.swift
+++ b/test/AutoDiff/validation-test/custom_derivatives.swift
@@ -1,6 +1,8 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// REQUIRES: SR12732
+
 import StdlibUnittest
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin.C

--- a/test/AutoDiff/validation-test/derivative_registration.swift
+++ b/test/AutoDiff/validation-test/derivative_registration.swift
@@ -1,6 +1,8 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// REQUIRES: SR12732
+
 import StdlibUnittest
 import DifferentiationUnittest
 


### PR DESCRIPTION
https://bugs.swift.org/browse/SR-12732
3 AutoDiff test failures: crashing in SIL verification

Failing Tests (3):
06:26:12     Swift(macosx-x86_64) :: AutoDiff/validation-test/derivative_registration.swift
06:26:12     Swift(macosx-x86_64) :: AutoDiff/validation-test/custom_derivatives.swift
06:26:12     Swift(macosx-x86_64) :: AutoDiff/stdlib/derivative_customization.swift

Possibly from:

commit 738ef730e8c3ed1dbcd00163134b54d953f18714
Author: Dan Zheng <danielzheng@google.com>
Date:   Mon May 4 00:44:48 2020 -0700

    [AutoDiff] Fix `@differentiable` attribute derivative configurations. (#31524)

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
