### PR TITLE
runtime: remove some unnecessary use of `llvm/Support/Compiler.h`

### DIFF
--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -33,7 +33,6 @@ typedef InlineRefCountsPlaceholder InlineRefCounts;
 #include <stdint.h>
 #include <assert.h>
 
-#include "llvm/Support/Compiler.h"
 #include "swift/Basic/type_traits.h"
 #include "swift/Runtime/Atomic.h"
 #include "swift/Runtime/Config.h"
@@ -182,7 +181,7 @@ namespace swift {
 }
 
 // FIXME: HACK: copied from HeapObject.cpp
-extern "C" LLVM_LIBRARY_VISIBILITY LLVM_ATTRIBUTE_NOINLINE LLVM_ATTRIBUTE_USED
+extern "C" SWIFT_LIBRARY_VISIBILITY SWIFT_NOINLINE SWIFT_USED
 void _swift_release_dealloc(swift::HeapObject *object);
 
 namespace swift {
@@ -373,12 +372,12 @@ class RefCountBitsT {
   // to improve performance of debug builds.
   
   private:
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   bool getUseSlowRC() const {
     return bool(getField(UseSlowRC));
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   void setUseSlowRC(bool value) {
     setField(UseSlowRC, value);
   }
@@ -387,7 +386,7 @@ class RefCountBitsT {
   
   enum Immortal_t { Immortal };
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   bool isImmortal(bool checkSlowRCBit) const {
     if (checkSlowRCBit) {
       return (getField(IsImmortal) == Offsets::IsImmortalMask) &&
@@ -397,34 +396,34 @@ class RefCountBitsT {
     }
   }
   
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   bool isOverflowingUnownedRefCount(uint32_t oldValue, uint32_t inc) const {
     auto newValue = getUnownedRefCount();
     return newValue != oldValue + inc ||
       newValue == Offsets::UnownedRefCountMask;
   }
   
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   void setIsImmortal(bool value) {
     assert(value);
     setField(IsImmortal, Offsets::IsImmortalMask);
     setField(UseSlowRC, value);
   }
   
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   bool pureSwiftDeallocation() const {
     return bool(getField(PureSwiftDealloc)) && !bool(getField(UseSlowRC));
   }
   
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   void setPureSwiftDeallocation(bool value) {
     setField(PureSwiftDealloc, value);
   }
   
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   RefCountBitsT() = default;
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   constexpr
   RefCountBitsT(uint32_t strongExtraCount, uint32_t unownedCount)
     : bits((BitsType(strongExtraCount) << Offsets::StrongExtraRefCountShift) |
@@ -432,7 +431,7 @@ class RefCountBitsT {
            (BitsType(unownedCount)     << Offsets::UnownedRefCountShift))
   { }
   
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   constexpr
   RefCountBitsT(Immortal_t immortal)
   : bits((BitsType(2) << Offsets::StrongExtraRefCountShift) |
@@ -440,7 +439,7 @@ class RefCountBitsT {
          (BitsType(1) << Offsets::UseSlowRCShift))
   { }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   RefCountBitsT(HeapObjectSideTableEntry* side)
     : bits((reinterpret_cast<BitsType>(side) >> Offsets::SideTableUnusedLowBits)
            | (BitsType(1) << Offsets::UseSlowRCShift)
@@ -449,7 +448,7 @@ class RefCountBitsT {
     assert(refcountIsInline);
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   RefCountBitsT(const RefCountBitsT<RefCountIsInline> *newbitsPtr) {
     bits = 0;
 
@@ -473,7 +472,7 @@ class RefCountBitsT {
     }
   }
   
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   bool hasSideTable() const {
     bool hasSide = getUseSlowRC() && !isImmortal(false);
 
@@ -484,7 +483,7 @@ class RefCountBitsT {
     return hasSide;
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   HeapObjectSideTableEntry *getSideTable() const {
     assert(hasSideTable());
 
@@ -493,32 +492,32 @@ class RefCountBitsT {
       (uintptr_t(getField(SideTable)) << Offsets::SideTableUnusedLowBits);
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   uint32_t getUnownedRefCount() const {
     assert(!hasSideTable());
     return uint32_t(getField(UnownedRefCount));
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   bool getIsDeiniting() const {
     assert(!hasSideTable());
     return bool(getField(IsDeiniting));
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   uint32_t getStrongExtraRefCount() const {
     assert(!hasSideTable());
     return uint32_t(getField(StrongExtraRefCount));
   }
 
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   void setHasSideTable(bool value) {
     bits = 0;
     setUseSlowRC(value);
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   void setSideTable(HeapObjectSideTableEntry *side) {
     assert(hasSideTable());
     // Stored value is a shifted pointer.
@@ -529,19 +528,19 @@ class RefCountBitsT {
     setField(SideTableMark, 1);
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   void setUnownedRefCount(uint32_t value) {
     assert(!hasSideTable());
     setField(UnownedRefCount, value);
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   void setIsDeiniting(bool value) {
     assert(!hasSideTable());
     setField(IsDeiniting, value);
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   void setStrongExtraRefCount(uint32_t value) {
     assert(!hasSideTable());
     setField(StrongExtraRefCount, value);
@@ -551,7 +550,7 @@ class RefCountBitsT {
   // Returns true if the increment is a fast-path result.
   // Returns false if the increment should fall back to some slow path
   // (for example, because UseSlowRC is set or because the refcount overflowed).
-  LLVM_NODISCARD LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_NODISCARD SWIFT_ALWAYS_INLINE
   bool incrementStrongExtraRefCount(uint32_t inc) {
     // This deliberately overflows into the UseSlowRC field.
     bits += BitsType(inc) << Offsets::StrongExtraRefCountShift;
@@ -562,7 +561,7 @@ class RefCountBitsT {
   // Returns false if the decrement should fall back to some slow path
   // (for example, because UseSlowRC is set
   // or because the refcount is now zero and should deinit).
-  LLVM_NODISCARD LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_NODISCARD SWIFT_ALWAYS_INLINE
   bool decrementStrongExtraRefCount(uint32_t dec) {
 #ifndef NDEBUG
     if (!hasSideTable() && !isImmortal(false)) {
@@ -583,19 +582,19 @@ class RefCountBitsT {
   }
 
   // Returns the old reference count before the increment.
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   uint32_t incrementUnownedRefCount(uint32_t inc) {
     uint32_t old = getUnownedRefCount();
     setUnownedRefCount(old + inc);
     return old;
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   void decrementUnownedRefCount(uint32_t dec) {
     setUnownedRefCount(getUnownedRefCount() - dec);
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   bool isUniquelyReferenced() {
     static_assert(Offsets::UnownedRefCountBitCount +
                   Offsets::IsDeinitingBitCount +
@@ -614,7 +613,7 @@ class RefCountBitsT {
       !getUseSlowRC() && !getIsDeiniting() && getStrongExtraRefCount() == 0;
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   BitsType getBitsValue() {
     return bits;
   }
@@ -636,10 +635,10 @@ class alignas(sizeof(void*) * 2) SideTableRefCountBits : public RefCountBitsT<Re
   uint32_t weakBits;
 
   public:
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   SideTableRefCountBits() = default;
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   constexpr
   SideTableRefCountBits(uint32_t strongExtraCount, uint32_t unownedCount)
     : RefCountBitsT<RefCountNotInline>(strongExtraCount, unownedCount)
@@ -647,34 +646,34 @@ class alignas(sizeof(void*) * 2) SideTableRefCountBits : public RefCountBitsT<Re
     , weakBits(1)
   { }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   SideTableRefCountBits(HeapObjectSideTableEntry* side) = delete;
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   SideTableRefCountBits(InlineRefCountBits newbits)
     : RefCountBitsT<RefCountNotInline>(&newbits), weakBits(1)
   { }
 
   
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   void incrementWeakRefCount() {
     weakBits++;
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   bool decrementWeakRefCount() {
     assert(weakBits > 0);
     weakBits--;
     return weakBits == 0;
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   uint32_t getWeakRefCount() {
     return weakBits;
   }
 
   // Side table ref count never has a side table of its own.
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   bool hasSideTable() {
     return false;
   }
@@ -706,19 +705,19 @@ class RefCounts {
 
   // Out-of-line slow paths.
 
-  LLVM_ATTRIBUTE_NOINLINE
+  SWIFT_NOINLINE
   void incrementSlow(RefCountBits oldbits, uint32_t inc) SWIFT_CC(PreserveMost);
 
-  LLVM_ATTRIBUTE_NOINLINE
+  SWIFT_NOINLINE
   void incrementNonAtomicSlow(RefCountBits oldbits, uint32_t inc);
 
-  LLVM_ATTRIBUTE_NOINLINE
+  SWIFT_NOINLINE
   bool tryIncrementSlow(RefCountBits oldbits);
 
-  LLVM_ATTRIBUTE_NOINLINE
+  SWIFT_NOINLINE
   bool tryIncrementNonAtomicSlow(RefCountBits oldbits);
 
-  LLVM_ATTRIBUTE_NOINLINE
+  SWIFT_NOINLINE
   void incrementUnownedSlow(uint32_t inc);
 
   public:
@@ -882,22 +881,22 @@ class RefCounts {
 
   // Decrement the reference count.
   // Return true if the caller should now deinit the object.
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   bool decrementShouldDeinit(uint32_t dec) {
     return doDecrement<DontPerformDeinit>(dec);
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   bool decrementShouldDeinitNonAtomic(uint32_t dec) {
     return doDecrementNonAtomic<DontPerformDeinit>(dec);
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   void decrementAndMaybeDeinit(uint32_t dec) {
     doDecrement<DoPerformDeinit>(dec);
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   void decrementAndMaybeDeinitNonAtomic(uint32_t dec) {
     doDecrementNonAtomic<DoPerformDeinit>(dec);
   }
@@ -1419,7 +1418,7 @@ class HeapObjectSideTableEntry {
   
   // WEAK
   
-  LLVM_NODISCARD
+  SWIFT_NODISCARD
   HeapObjectSideTableEntry* incrementWeak() {
     // incrementWeak need not be atomic w.r.t. concurrent deinit initiation.
     // The client can't actually get a reference to the object without
@@ -1472,7 +1471,7 @@ class HeapObjectSideTableEntry {
 // This version can actually be non-atomic.
 template <>
 template <PerformDeinit performDeinit>
-LLVM_ATTRIBUTE_ALWAYS_INLINE
+SWIFT_ALWAYS_INLINE
 inline bool RefCounts<InlineRefCountBits>::doDecrementNonAtomic(uint32_t dec) {
   
   // We can get away without atomicity here.

--- a/stdlib/public/SwiftShims/Visibility.h
+++ b/stdlib/public/SwiftShims/Visibility.h
@@ -30,6 +30,10 @@
 #define __has_builtin(builtin) 0
 #endif
 
+#if !defined(__cplusplus) || !defined(__has_cpp_attribute)
+#define __has_cpp_attribute(attribute) 0
+#endif
+
 #if __has_feature(nullability)
 // Provide macros to temporarily suppress warning about the use of
 // _Nullable and _Nonnull.
@@ -60,10 +64,42 @@
 #define SWIFT_READNONE
 #endif
 
+#if __has_attribute(noinline)
+#define SWIFT_NOINLINE __attribute__((__noinline__))
+#elif defined(_MSC_VER)
+#define SWIFT_NOINLINE __declspec(noinline)
+#else
+#define SWIFT_NOINLINE
+#endif
+
 #if __has_attribute(always_inline)
 #define SWIFT_ALWAYS_INLINE __attribute__((always_inline))
+#elif defined(_MSC_VER)
+#define SWIFT_ALWAYS_INLINE __forceinline
 #else
 #define SWIFT_ALWAYS_INLINE
+#endif
+
+#if __cplusplus > 201402l && __has_cpp_attribute(nodiscard)
+#define SWIFT_NODISCARD [[nodiscard]]
+#elif __has_cpp_attribute(clang::warn_unused_result)
+#define SWIFT_NODISCARD [[clang::warn_unused_result]]
+#else
+#define SWIFT_NODISCARD
+#endif
+
+#if __has_attribute(noreturn)
+#define SWIFT_NORETURN __attribute__((__noreturn__))
+#elif defined(_MSC_VER)
+#define SWIFT_NORETURN __declspec(noreturn)
+#else
+#define SWIFT_NORETURN
+#endif
+
+#if __has_attribute(used)
+#define SWIFT_USED __attribute__((__used__))
+#else
+#define SWIFT_USED
 #endif
 
 #if __has_attribute(unavailable)

--- a/stdlib/public/runtime/AnyHashableSupport.cpp
+++ b/stdlib/public/runtime/AnyHashableSupport.cpp
@@ -73,7 +73,7 @@ static ConcurrentMap<HashableConformanceEntry, /*Destructor*/ false>
   HashableConformances;
 
 template<bool KnownToConformToHashable>
-LLVM_ATTRIBUTE_ALWAYS_INLINE
+SWIFT_ALWAYS_INLINE
 static const Metadata *findHashableBaseTypeImpl(const Metadata *type) {
   // Check the cache first.
   if (HashableConformanceEntry *entry =

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -39,7 +39,6 @@
 #include "swift/Runtime/Unreachable.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/PointerIntPair.h"
-#include "llvm/Support/Compiler.h"
 #if SWIFT_OBJC_INTEROP
 #include "swift/Runtime/ObjCBridge.h"
 #include "SwiftObject.h"
@@ -248,8 +247,7 @@ swift::swift_getMangledTypeName(const Metadata *type) {
 // This is noinline to preserve this frame in stack traces.
 // We want "dynamicCastFailure" to appear in crash logs even we crash 
 // during the diagnostic because some Metadata is invalid.
-LLVM_ATTRIBUTE_NORETURN
-LLVM_ATTRIBUTE_NOINLINE
+SWIFT_NORETURN SWIFT_NOINLINE
 void 
 swift::swift_dynamicCastFailure(const void *sourceType, const char *sourceName, 
                                 const void *targetType, const char *targetName, 
@@ -262,7 +260,7 @@ swift::swift_dynamicCastFailure(const void *sourceType, const char *sourceName,
                     message ? message : "");
 }
 
-LLVM_ATTRIBUTE_NORETURN
+SWIFT_NORETURN
 void 
 swift::swift_dynamicCastFailure(const Metadata *sourceType,
                                 const Metadata *targetType, 
@@ -2965,7 +2963,7 @@ findBridgeWitness(const Metadata *T) {
   }
 
   auto w = swift_conformsToObjectiveCBridgeable(T);
-  if (LLVM_LIKELY(w))
+  if (SWIFT_LIKELY(w))
     return reinterpret_cast<const _ObjectiveCBridgeableWitnessTable *>(w);
   // Class and ObjC existential metatypes can be bridged, but metatypes can't
   // directly conform to protocols yet. Use a stand-in conformance for a type

--- a/stdlib/public/runtime/Enum.cpp
+++ b/stdlib/public/runtime/Enum.cpp
@@ -14,8 +14,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/MathExtras.h"
 #include "swift/Runtime/Metadata.h"
 #include "swift/Runtime/Enum.h"
 #include "swift/Runtime/Debug.h"

--- a/stdlib/public/runtime/ErrorObject.h
+++ b/stdlib/public/runtime/ErrorObject.h
@@ -28,8 +28,6 @@
 #include "swift/Runtime/HeapObject.h"
 #include "SwiftHashableSupport.h"
 
-#include "llvm/Support/Compiler.h"
-
 #include <atomic>
 #if SWIFT_OBJC_INTEROP
 # include <CoreFoundation/CoreFoundation.h>
@@ -211,9 +209,9 @@ void swift_willThrow(SWIFT_CONTEXT void *unused,
                      SWIFT_ERROR_RESULT SwiftError **object);
 
 /// Halt in response to an error.
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API LLVM_ATTRIBUTE_NORETURN
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API SWIFT_NORETURN
 void swift_errorInMain(SwiftError *object);
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API LLVM_ATTRIBUTE_NORETURN
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API SWIFT_NORETURN
 void swift_unexpectedError(SwiftError *object,
                            OpaqueValue *filenameStart,
                            long filenameLength,

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -224,7 +224,7 @@ static _Unwind_Reason_Code SwiftUnwindFrame(struct _Unwind_Context *context, voi
 }
 #endif
 
-LLVM_ATTRIBUTE_NOINLINE
+SWIFT_NOINLINE
 void swift::printCurrentBacktrace(unsigned framesToSkip) {
 #if SWIFT_SUPPORTS_BACKTRACE_REPORTING
   constexpr unsigned maxSupportedStackDepth = 128;
@@ -255,7 +255,7 @@ void swift::printCurrentBacktrace(unsigned framesToSkip) {
 // The layout of this struct is CrashReporter ABI, so there are no ABI concerns
 // here.
 extern "C" {
-LLVM_LIBRARY_VISIBILITY
+SWIFT_LIBRARY_VISIBILITY
 struct crashreporter_annotations_t gCRAnnotations
 __attribute__((__section__("__DATA," CRASHREPORTER_ANNOTATIONS_SECTION))) = {
     CRASHREPORTER_ANNOTATIONS_VERSION, 0, 0, 0, 0, 0, 0, 0};
@@ -320,7 +320,7 @@ reportNow(uint32_t flags, const char *message)
 #endif
 }
 
-LLVM_ATTRIBUTE_NOINLINE SWIFT_RUNTIME_EXPORT
+SWIFT_NOINLINE SWIFT_RUNTIME_EXPORT
 void _swift_runtime_on_report(uintptr_t flags, const char *message,
                               RuntimeErrorDetails *details) {
   // Do nothing. This function is meant to be used by the debugger.
@@ -376,7 +376,7 @@ static int swift_vasprintf(char **strp, const char *fmt, va_list ap) {
 }
 
 // Report a fatal error to system console, stderr, and crash logs, then abort.
-LLVM_ATTRIBUTE_NORETURN
+SWIFT_NORETURN
 void
 swift::fatalError(uint32_t flags, const char *format, ...)
 {
@@ -419,8 +419,7 @@ swift::warning(uint32_t flags, const char *format, ...)
 }
 
 // Crash when a deleted method is called by accident.
-SWIFT_RUNTIME_EXPORT
-LLVM_ATTRIBUTE_NORETURN
+SWIFT_RUNTIME_EXPORT SWIFT_NORETURN
 void
 swift_deletedMethodError() {
   swift::fatalError(/* flags = */ 0,

--- a/stdlib/public/runtime/Exclusivity.cpp
+++ b/stdlib/public/runtime/Exclusivity.cpp
@@ -46,7 +46,7 @@ static const char *getAccessName(ExclusivityFlags flags) {
   }
 }
 
-LLVM_ATTRIBUTE_ALWAYS_INLINE
+SWIFT_ALWAYS_INLINE
 static void reportExclusivityConflict(ExclusivityFlags oldAction, void *oldPC,
                                       ExclusivityFlags newFlags, void *newPC,
                                       void *pointer) {
@@ -261,10 +261,10 @@ static SwiftTLSContext &getTLSContext() {
   return *ctx;
 }
 
-#elif SWIFT_TLS_HAS_THREADLOCAL
+#elif __has_feature(cxx_thread_local) || defined(_MSC_VER)
 // Second choice is direct language support for thread-locals.
 
-static LLVM_THREAD_LOCAL SwiftTLSContext TLSContext;
+static thread_local SwiftTLSContext TLSContext;
 
 static SwiftTLSContext &getTLSContext() {
   return TLSContext;

--- a/stdlib/public/runtime/ExistentialContainer.cpp
+++ b/stdlib/public/runtime/ExistentialContainer.cpp
@@ -57,7 +57,7 @@ void OpaqueExistentialContainer::deinit() {
 // *NOTE* This routine performs unused memory reads on purpose to try to catch
 // use-after-frees in conjunction with ASAN or Guard Malloc.
 template <>
-LLVM_ATTRIBUTE_USED
+SWIFT_USED
 void OpaqueExistentialContainer::verify() const {
   // We do not actually care about value. We just want to see if the
   // memory is valid or not. So convert to a uint8_t and try to
@@ -71,7 +71,7 @@ void OpaqueExistentialContainer::verify() const {
 
 /// Dump information about this specific container and its contents.
 template <>
-LLVM_ATTRIBUTE_USED
+SWIFT_USED
 void OpaqueExistentialContainer::dump() const {
   // Quickly verify to make sure we are well formed.
   verify();

--- a/stdlib/public/runtime/ExistentialMetadataImpl.h
+++ b/stdlib/public/runtime/ExistentialMetadataImpl.h
@@ -26,12 +26,12 @@ namespace metadataimpl {
 
 /// A common base class for opaque-existential and class-existential boxes.
 template<typename Impl>
-struct LLVM_LIBRARY_VISIBILITY ExistentialBoxBase {
+struct SWIFT_LIBRARY_VISIBILITY ExistentialBoxBase {
 };
 
 /// A common base class for fixed and non-fixed opaque-existential box
 /// implementations.
-struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBoxBase
+struct SWIFT_LIBRARY_VISIBILITY OpaqueExistentialBoxBase
     : ExistentialBoxBase<OpaqueExistentialBoxBase> {
   template <class Container, class... A>
   static void destroy(Container *value, A... args) {
@@ -290,7 +290,7 @@ struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBoxBase
 /// witness tables.  Note that the WitnessTables field is accessed via
 /// spooky action from Header.
 template <unsigned NumWitnessTables>
-struct LLVM_LIBRARY_VISIBILITY FixedOpaqueExistentialContainer {
+struct SWIFT_LIBRARY_VISIBILITY FixedOpaqueExistentialContainer {
   OpaqueExistentialContainer Header;
   const void *WitnessTables[NumWitnessTables];
 };
@@ -304,7 +304,7 @@ struct FixedOpaqueExistentialContainer<0> {
 /// A box implementation class for an opaque existential type with
 /// a fixed number of witness tables.
 template <unsigned NumWitnessTables>
-struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBox
+struct SWIFT_LIBRARY_VISIBILITY OpaqueExistentialBox
     : OpaqueExistentialBoxBase {
   struct Container : FixedOpaqueExistentialContainer<NumWitnessTables> {
     const Metadata *getType() const {
@@ -346,7 +346,7 @@ struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBox
 
 /// A non-fixed box implementation class for an opaque existential
 /// type with a dynamic number of witness tables.
-struct LLVM_LIBRARY_VISIBILITY NonFixedOpaqueExistentialBox
+struct SWIFT_LIBRARY_VISIBILITY NonFixedOpaqueExistentialBox
     : OpaqueExistentialBoxBase {
   struct Container {
     OpaqueExistentialContainer Header;
@@ -400,7 +400,7 @@ struct LLVM_LIBRARY_VISIBILITY NonFixedOpaqueExistentialBox
 
 /// A common base class for fixed and non-fixed class-existential box
 /// implementations.
-struct LLVM_LIBRARY_VISIBILITY ClassExistentialBoxBase
+struct SWIFT_LIBRARY_VISIBILITY ClassExistentialBoxBase
     : ExistentialBoxBase<ClassExistentialBoxBase> {
   static constexpr unsigned numExtraInhabitants =
     swift_getHeapObjectExtraInhabitantCount();
@@ -468,7 +468,7 @@ struct LLVM_LIBRARY_VISIBILITY ClassExistentialBoxBase
 /// A box implementation class for an existential container with
 /// a class constraint and a fixed number of protocol witness tables.
 template <unsigned NumWitnessTables>
-struct LLVM_LIBRARY_VISIBILITY ClassExistentialBox
+struct SWIFT_LIBRARY_VISIBILITY ClassExistentialBox
     : ClassExistentialBoxBase {
   struct Container {
     ClassExistentialContainer Header;
@@ -495,7 +495,7 @@ struct LLVM_LIBRARY_VISIBILITY ClassExistentialBox
 
 /// A non-fixed box implementation class for a class existential
 /// type with a dynamic number of witness tables.
-struct LLVM_LIBRARY_VISIBILITY NonFixedClassExistentialBox
+struct SWIFT_LIBRARY_VISIBILITY NonFixedClassExistentialBox
     : ClassExistentialBoxBase {
   struct Container {
     ClassExistentialContainer Header;
@@ -532,7 +532,7 @@ struct LLVM_LIBRARY_VISIBILITY NonFixedClassExistentialBox
 
 /// A common base class for fixed and non-fixed existential metatype box
 /// implementations.
-struct LLVM_LIBRARY_VISIBILITY ExistentialMetatypeBoxBase
+struct SWIFT_LIBRARY_VISIBILITY ExistentialMetatypeBoxBase
     : ExistentialBoxBase<ExistentialMetatypeBoxBase> {
   static constexpr unsigned numExtraInhabitants =
     swift_getHeapObjectExtraInhabitantCount();
@@ -591,7 +591,7 @@ struct LLVM_LIBRARY_VISIBILITY ExistentialMetatypeBoxBase
 /// A box implementation class for an existential metatype container
 /// with a fixed number of protocol witness tables.
 template <unsigned NumWitnessTables>
-struct LLVM_LIBRARY_VISIBILITY ExistentialMetatypeBox
+struct SWIFT_LIBRARY_VISIBILITY ExistentialMetatypeBox
     : ExistentialMetatypeBoxBase {
   struct Container {
     ExistentialMetatypeContainer Header;
@@ -618,7 +618,7 @@ struct LLVM_LIBRARY_VISIBILITY ExistentialMetatypeBox
 
 /// A non-fixed box implementation class for an existential metatype
 /// type with a dynamic number of witness tables.
-struct LLVM_LIBRARY_VISIBILITY NonFixedExistentialMetatypeBox
+struct SWIFT_LIBRARY_VISIBILITY NonFixedExistentialMetatypeBox
     : ExistentialMetatypeBoxBase {
   struct Container {
     ExistentialMetatypeContainer Header;

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -20,8 +20,6 @@
 #include "swift/Runtime/Metadata.h"
 #include "swift/Runtime/Once.h"
 #include "swift/ABI/System.h"
-#include "llvm/Support/Compiler.h"
-#include "llvm/Support/MathExtras.h"
 #include "MetadataCache.h"
 #include "Private.h"
 #include "RuntimeInvocationsTracking.h"
@@ -327,7 +325,7 @@ HeapObject *swift::swift_allocEmptyBox() {
 }
 
 // Forward-declare this, but define it after swift_release.
-extern "C" LLVM_LIBRARY_VISIBILITY LLVM_ATTRIBUTE_NOINLINE LLVM_ATTRIBUTE_USED 
+extern "C" SWIFT_LIBRARY_VISIBILITY SWIFT_NOINLINE SWIFT_USED
 void _swift_release_dealloc(HeapObject *object);
 
 static HeapObject *_swift_retain_(HeapObject *object) {

--- a/stdlib/public/runtime/Leaks.h
+++ b/stdlib/public/runtime/Leaks.h
@@ -23,20 +23,19 @@
 
 #include "../SwiftShims/Visibility.h"
 
-#include "llvm/Support/Compiler.h"
 #include "swift/Runtime/Config.h"
 
 namespace swift {
 struct HeapObject;
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT LLVM_ATTRIBUTE_NOINLINE LLVM_ATTRIBUTE_USED
+SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT SWIFT_NOINLINE SWIFT_USED
 void _swift_leaks_startTrackingObjects(const char *);
-SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT LLVM_ATTRIBUTE_NOINLINE LLVM_ATTRIBUTE_USED
+SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT SWIFT_NOINLINE SWIFT_USED
 int _swift_leaks_stopTrackingObjects(const char *);
-SWIFT_RUNTIME_EXPORT LLVM_ATTRIBUTE_NOINLINE LLVM_ATTRIBUTE_USED
+SWIFT_RUNTIME_EXPORT SWIFT_NOINLINE SWIFT_USED
 void _swift_leaks_startTrackingObject(swift::HeapObject *);
-SWIFT_RUNTIME_EXPORT LLVM_ATTRIBUTE_NOINLINE LLVM_ATTRIBUTE_USED
+SWIFT_RUNTIME_EXPORT SWIFT_NOINLINE SWIFT_USED
 void _swift_leaks_stopTrackingObject(swift::HeapObject *);
 
 #define SWIFT_LEAKS_START_TRACKING_OBJECT(obj)                                 \

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -27,8 +27,6 @@
 #include "swift/Runtime/Mutex.h"
 #include "swift/Runtime/Once.h"
 #include "swift/Strings.h"
-#include "llvm/Support/MathExtras.h"
-#include "llvm/Support/PointerLikeTypeTraits.h"
 #include <algorithm>
 #include <cctype>
 #include <cinttypes>
@@ -4143,7 +4141,7 @@ StringRef swift::getStringForMetadataKind(MetadataKind kind) {
 
 #ifndef NDEBUG
 template <>
-LLVM_ATTRIBUTE_USED
+SWIFT_USED
 void Metadata::dump() const {
   printf("TargetMetadata.\n");
   printf("Kind: %s.\n", getStringForMetadataKind(getKind()).data());
@@ -4198,7 +4196,7 @@ void Metadata::dump() const {
 }
 
 template <>
-LLVM_ATTRIBUTE_USED
+SWIFT_USED
 void ContextDescriptor::dump() const {
   printf("TargetTypeContextDescriptor.\n");
   printf("Flags: 0x%x.\n", this->Flags.getIntValue());
@@ -4212,7 +4210,7 @@ void ContextDescriptor::dump() const {
 }
 
 template<>
-LLVM_ATTRIBUTE_USED
+SWIFT_USED
 void EnumDescriptor::dump() const {
   printf("TargetEnumDescriptor.\n");
   printf("Flags: 0x%x.\n", this->Flags.getIntValue());
@@ -4688,7 +4686,7 @@ swift_getAssociatedTypeWitnessSlowImpl(
 #endif
   
   // If the low bit of the witness is clear, it's already a metadata pointer.
-  if (LLVM_LIKELY((uintptr_t(witness) &
+  if (SWIFT_LIKELY((uintptr_t(witness) &
         ProtocolRequirementFlags::AssociatedTypeMangledNameBit) == 0)) {
     // Cached metadata pointers are always complete.
     return MetadataResponse{(const Metadata *)witness, MetadataState::Complete};
@@ -4809,7 +4807,7 @@ swift::swift_getAssociatedTypeWitness(MetadataRequest request,
                                                           extraDiscriminator));
 #endif
 
-  if (LLVM_LIKELY((uintptr_t(witness) &
+  if (SWIFT_LIKELY((uintptr_t(witness) &
         ProtocolRequirementFlags::AssociatedTypeMangledNameBit) == 0)) {
     // Cached metadata pointers are always complete.
     return MetadataResponse{(const Metadata *)witness, MetadataState::Complete};
@@ -4861,7 +4859,7 @@ static const WitnessTable *swift_getAssociatedConformanceWitnessSlowImpl(
 #endif
 
   // Fast path: we've already resolved this to a witness table, so return it.
-  if (LLVM_LIKELY((uintptr_t(witness) &
+  if (SWIFT_LIKELY((uintptr_t(witness) &
          ProtocolRequirementFlags::AssociatedTypeMangledNameBit) == 0)) {
     return static_cast<const WitnessTable *>(witness);
   }
@@ -4937,7 +4935,7 @@ const WitnessTable *swift::swift_getAssociatedConformanceWitness(
 #endif
 
   // Fast path: we've already resolved this to a witness table, so return it.
-  if (LLVM_LIKELY((uintptr_t(witness) &
+  if (SWIFT_LIKELY((uintptr_t(witness) &
          ProtocolRequirementFlags::AssociatedTypeMangledNameBit) == 0)) {
     return static_cast<const WitnessTable *>(witness);
   }
@@ -5314,7 +5312,7 @@ checkTransitiveCompleteness(const Metadata *initialType) {
 }
 
 /// Diagnose a metadata dependency cycle.
-LLVM_ATTRIBUTE_NORETURN
+SWIFT_NORETURN
 static void diagnoseMetadataDependencyCycle(const Metadata *start,
                                             ArrayRef<MetadataDependency> links){
   assert(start == links.back().Value);

--- a/stdlib/public/runtime/MetadataImpl.h
+++ b/stdlib/public/runtime/MetadataImpl.h
@@ -40,7 +40,6 @@
 #ifndef SWIFT_RUNTIME_METADATAIMPL_H
 #define SWIFT_RUNTIME_METADATAIMPL_H
 
-#include "llvm/Support/Compiler.h"
 #include "swift/Runtime/Config.h"
 #include "swift/Runtime/Metadata.h"
 #include "swift/Runtime/HeapObject.h"

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -20,7 +20,6 @@
 #include "swift/Demangling/Demangler.h"
 #include "swift/Runtime/Config.h"
 #include "swift/Runtime/Metadata.h"
-#include "llvm/Support/Compiler.h"
 
 #if defined(__APPLE__) && defined(__MACH__)
 #include <TargetConditionals.h>
@@ -192,10 +191,10 @@ public:
   }
 #endif
 
-  LLVM_LIBRARY_VISIBILITY
+  SWIFT_LIBRARY_VISIBILITY
   const ClassMetadata *_swift_getClass(const void *object);
 
-  LLVM_LIBRARY_VISIBILITY
+  SWIFT_LIBRARY_VISIBILITY
   bool usesNativeSwiftReferenceCounting(const ClassMetadata *theClass);
 
   static inline

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -32,7 +32,7 @@ using namespace swift;
 
 #ifndef NDEBUG
 template <>
-LLVM_ATTRIBUTE_USED
+SWIFT_USED
 void ProtocolDescriptor::dump() const {
   printf("TargetProtocolDescriptor.\n"
          "Name: \"%s\".\n",
@@ -96,7 +96,7 @@ template<> void ProtocolConformanceDescriptor::dump() const {
 
 #ifndef NDEBUG
 template<>
-LLVM_ATTRIBUTE_USED
+SWIFT_USED
 void ProtocolConformanceDescriptor::verify() const {
   auto typeKind = unsigned(getTypeKind());
   assert(((unsigned(TypeReferenceKind::First_Kind) <= typeKind) &&
@@ -302,7 +302,7 @@ struct ConformanceState {
   }
 
 #ifndef NDEBUG
-  void verify() const LLVM_ATTRIBUTE_USED;
+  void verify() const SWIFT_USED;
 #endif
 };
 

--- a/stdlib/public/runtime/ReflectionMirror.mm
+++ b/stdlib/public/runtime/ReflectionMirror.mm
@@ -23,7 +23,6 @@
 #include "swift/Runtime/Portability.h"
 #include "Private.h"
 #include "WeakReference.h"
-#include "llvm/Support/Compiler.h"
 #include <cassert>
 #include <cinttypes>
 #include <cstdio>

--- a/stdlib/public/runtime/SwiftObject.h
+++ b/stdlib/public/runtime/SwiftObject.h
@@ -23,7 +23,6 @@
 #include <utility>
 #include "swift/Runtime/HeapObject.h"
 #if SWIFT_OBJC_INTEROP
-#include "llvm/Support/Compiler.h"
 #include <objc/NSObject.h>
 #endif
 

--- a/stdlib/public/runtime/ThreadLocalStorage.h
+++ b/stdlib/public/runtime/ThreadLocalStorage.h
@@ -13,7 +13,6 @@
 #ifndef SWIFT_RUNTIME_THREADLOCALSTORAGE_H
 #define SWIFT_RUNTIME_THREADLOCALSTORAGE_H
 
-#include "llvm/Support/Compiler.h"
 #include "swift/Runtime/Config.h"
 
 // Depending on the target, we may be able to use dedicated TSD keys or
@@ -24,16 +23,6 @@
 // On Apple platforms, we have dedicated TSD keys.
 #if defined(__APPLE__)
 # define SWIFT_TLS_HAS_RESERVED_PTHREAD_SPECIFIC 1
-#endif
-
-// If we're using Clang, and Clang claims not to support thread_local,
-// it must be because we're on a platform that doesn't support it.
-#if __clang__ && !__has_feature(cxx_thread_local)
-// No thread_local.
-#else
-// Otherwise, we do have thread_local.
-# define SWIFT_TLS_HAS_THREADLOCAL 1
-static_assert(LLVM_ENABLE_THREADS, "LLVM_THREAD_LOCAL will use a global?");
 #endif
 
 #if SWIFT_TLS_HAS_RESERVED_PTHREAD_SPECIFIC
@@ -92,6 +81,9 @@ typedef unsigned long __swift_thread_key_t;
 #  include <io.h>
 #  define WIN32_LEAN_AND_MEAN
 #  include <Windows.h>
+
+#  include <type_traits>
+
 static_assert(std::is_same<__swift_thread_key_t, DWORD>::value,
               "__swift_thread_key_t is not a DWORD");
 

--- a/stdlib/public/runtime/WeakReference.h
+++ b/stdlib/public/runtime/WeakReference.h
@@ -119,20 +119,20 @@ class WeakReferenceBits {
   uintptr_t bits;
 
  public:
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   WeakReferenceBits() { }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   WeakReferenceBits(HeapObjectSideTableEntry *newValue) {
     setNativeOrNull(newValue);
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   bool isNativeOrNull() const {
     return bits == 0  ||  (bits & NativeMarkerMask) == NativeMarkerValue;
   }
     
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   HeapObjectSideTableEntry *getNativeOrNull() const {
     assert(isNativeOrNull());
     if (bits == 0)
@@ -142,7 +142,7 @@ class WeakReferenceBits {
         reinterpret_cast<HeapObjectSideTableEntry *>(bits & ~NativeMarkerMask);
   }
   
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   void setNativeOrNull(HeapObjectSideTableEntry *newValue) {
     assert((uintptr_t(newValue) & NativeMarkerMask) == 0);
     if (newValue)

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -75,7 +75,6 @@ static float swift_strtof_l(const char *nptr, char **endptr, locale_t loc) {
 #include <limits>
 #include <thread>
 #include "llvm/ADT/StringExtras.h"
-#include "llvm/Support/Compiler.h"
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/SwiftDtoa.h"
 #include "swift/Basic/Lazy.h"


### PR DESCRIPTION
Replace many of the LLVM attributes in favour of their Swift namespaced
counterparts.  This has no impact on the code itself, just uses a
separate namespace for the macros that we already have in the Swift
shims rather than dragging in `Support/Compiler.h` from `LLVMSupport`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
