### PR TITLE
[5.3][CodeCompletion] Give up fast-completion if dependent files are modified

### DIFF
--- a/include/swift/IDE/CompletionInstance.h
+++ b/include/swift/IDE/CompletionInstance.h
@@ -44,8 +44,10 @@ class CompletionInstance {
   std::mutex mtx;
 
   std::unique_ptr<CompilerInstance> CachedCI;
+  ModuleDecl *CurrentModule = nullptr;
   llvm::hash_code CachedArgHash;
   llvm::sys::TimePoint<> DependencyCheckedTimestamp;
+  llvm::StringMap<llvm::hash_code> InMemoryDependencyHash;
   unsigned CachedReuseCount = 0;
 
   void cacheCompilerInstance(std::unique_ptr<CompilerInstance> CI,

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -18,19 +18,19 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/SourceFile.h"
-#include "swift/Serialization/SerializedModuleLoader.h"
-#include "swift/ClangImporter/ClangModule.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/PrettyStackTrace.h"
 #include "swift/Basic/SourceManager.h"
+#include "swift/ClangImporter/ClangModule.h"
 #include "swift/Driver/FrontendUtil.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/PersistentParserState.h"
+#include "swift/Serialization/SerializedModuleLoader.h"
 #include "swift/Subsystems.h"
+#include "clang/AST/ASTContext.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/Support/MemoryBuffer.h"
-#include "clang/AST/ASTContext.h"
 
 using namespace swift;
 using namespace ide;
@@ -165,70 +165,111 @@ static DeclContext *getEquivalentDeclContextFromSourceFile(DeclContext *DC,
   return newDC;
 }
 
-/// Check if any dependent files are modified since \p timestamp.
-bool areAnyDependentFilesInvalidated(CompilerInstance &CI,
-                                     llvm::vfs::FileSystem &FS,
-                                     StringRef currentFileName,
-                                     llvm::sys::TimePoint<> timestamp) {
-
-  auto isInvalidated = [&](StringRef filePath) -> bool {
-    auto stat = FS.status(filePath);
-    if (!stat)
-      // Missing.
-      return true;
-
-    auto lastModTime = stat->getLastModificationTime();
-    if (lastModTime > timestamp)
-      // Modified.
-      return true;
-
-    // If the last modification time is zero, this file is probably from a
-    // virtual file system. We need to check the content.
-    if (lastModTime == llvm::sys::TimePoint<>()) {
-      if (&CI.getFileSystem() == &FS)
-        return false;
-
-      auto oldContent = CI.getFileSystem().getBufferForFile(filePath);
-      auto newContent = FS.getBufferForFile(filePath);
-      if (!oldContent || !newContent)
-        // (unreachable?)
-        return true;
-
-      if (oldContent.get()->getBuffer() != newContent.get()->getBuffer())
-        // Different content.
-        return true;
-    }
-
-    return false;
-  };
-
+/// For each dependency file in \p CI, run \p callback until the callback
+/// returns \c true. Returns \c true if any callback call returns \c true, \c
+/// false otherwise.
+static bool
+forEachDependencyUntilTrue(CompilerInstance &CI, ModuleDecl *CurrentModule,
+                           unsigned excludeBufferID,
+                           llvm::function_ref<bool(StringRef)> callback) {
   // Check files in the current module.
-  for (FileUnit *file : CI.getMainModule()->getFiles()) {
+  for (FileUnit *file : CurrentModule->getFiles()) {
     StringRef filename;
-    if (auto SF = dyn_cast<SourceFile>(file))
+    if (auto SF = dyn_cast<SourceFile>(file)) {
+      if (SF->getBufferID() == excludeBufferID)
+        continue;
       filename = SF->getFilename();
-    else if (auto LF = dyn_cast<LoadedFile>(file))
+    } else if (auto LF = dyn_cast<LoadedFile>(file))
       filename = LF->getFilename();
     else
       continue;
 
-    // Ignore the current file and synthesized files.
-    if (filename.empty() || filename.front() == '<' ||
-        filename.equals(currentFileName))
+    // Ignore synthesized files.
+    if (filename.empty() || filename.front() == '<')
       continue;
 
-    if (isInvalidated(filename))
+    if (callback(filename))
       return true;
   }
 
   // Check other non-system depenencies (e.g. modules, headers).
   for (auto &dep : CI.getDependencyTracker()->getDependencies()) {
-    if (isInvalidated(dep))
+    if (callback(dep))
       return true;
   }
 
-  // All loaded module files are not modified since the timestamp.
   return false;
+}
+
+/// Collect hash codes of the dependencies into \c Map.
+static void cacheDependencyHashIfNeeded(CompilerInstance &CI,
+                                        ModuleDecl *CurrentModule,
+                                        unsigned excludeBufferID,
+                                        llvm::StringMap<llvm::hash_code> &Map) {
+  auto &FS = CI.getFileSystem();
+  forEachDependencyUntilTrue(
+      CI, CurrentModule, excludeBufferID, [&](StringRef filename) {
+        if (Map.count(filename))
+          return false;
+
+        auto stat = FS.status(filename);
+        if (!stat)
+          return false;
+
+        // We will check the hash only if the modification time of the dependecy
+        // is zero. See 'areAnyDependentFilesInvalidated() below'.
+        if (stat->getLastModificationTime() != llvm::sys::TimePoint<>())
+          return false;
+
+        auto buf = FS.getBufferForFile(filename);
+        Map[filename] = llvm::hash_value(buf.get()->getBuffer());
+        return false;
+      });
+}
+
+/// Check if any dependent files are modified since \p timestamp.
+static bool areAnyDependentFilesInvalidated(
+    CompilerInstance &CI, ModuleDecl *CurrentModule, llvm::vfs::FileSystem &FS,
+    unsigned excludeBufferID, llvm::sys::TimePoint<> timestamp,
+    llvm::StringMap<llvm::hash_code> &Map) {
+
+  return forEachDependencyUntilTrue(
+      CI, CurrentModule, excludeBufferID, [&](StringRef filePath) {
+        auto stat = FS.status(filePath);
+        if (!stat)
+          // Missing.
+          return true;
+
+        auto lastModTime = stat->getLastModificationTime();
+        if (lastModTime > timestamp)
+          // Modified.
+          return true;
+
+        // If the last modification time is zero, this file is probably from a
+        // virtual file system. We need to check the content.
+        if (lastModTime == llvm::sys::TimePoint<>()) {
+          // Get the hash code of the last content.
+          auto oldHashEntry = Map.find(filePath);
+          if (oldHashEntry == Map.end())
+            // Unreachable? Not virtual in old filesystem, but virtual in new
+            // one.
+            return true;
+          auto oldHash = oldHashEntry->second;
+
+          // Calculate the hash code of the current content.
+          auto newContent = FS.getBufferForFile(filePath);
+          if (!newContent)
+            // Unreachable? stat succeeded, but coundn't get the content.
+            return true;
+
+          auto newHash = llvm::hash_value(newContent.get()->getBuffer());
+
+          if (oldHash != newHash)
+            return true;
+        }
+
+        return false;
+      });
 }
 
 } // namespace
@@ -262,8 +303,9 @@ bool CompletionInstance::performCachedOperationIfPossible(
     return false;
 
   if (shouldCheckDependencies()) {
-    if (areAnyDependentFilesInvalidated(CI, *FileSystem, bufferName,
-                                        DependencyCheckedTimestamp))
+    if (areAnyDependentFilesInvalidated(
+            CI, CurrentModule, *FileSystem, SM.getCodeCompletionBufferID(),
+            DependencyCheckedTimestamp, InMemoryDependencyHash))
       return false;
     DependencyCheckedTimestamp = std::chrono::system_clock::now();
   }
@@ -409,6 +451,7 @@ bool CompletionInstance::performCachedOperationIfPossible(
     performImportResolution(*newSF);
     bindExtensions(*newSF);
 
+    CurrentModule = newM;
     traceDC = newM;
 #ifndef NDEBUG
     const auto *reparsedState = newSF->getDelayedParserState();
@@ -435,6 +478,8 @@ bool CompletionInstance::performCachedOperationIfPossible(
   }
 
   CachedReuseCount += 1;
+  cacheDependencyHashIfNeeded(CI, CurrentModule, SM.getCodeCompletionBufferID(),
+                              InMemoryDependencyHash);
 
   return true;
 }
@@ -503,17 +548,24 @@ bool CompletionInstance::performNewOperation(
 void CompletionInstance::cacheCompilerInstance(
     std::unique_ptr<CompilerInstance> CI, llvm::hash_code ArgsHash) {
   CachedCI = std::move(CI);
+  CurrentModule = CachedCI->getMainModule();
   CachedArgHash = ArgsHash;
   auto now = std::chrono::system_clock::now();
   DependencyCheckedTimestamp = now;
   CachedReuseCount = 0;
+  InMemoryDependencyHash.clear();
+  cacheDependencyHashIfNeeded(
+      *CachedCI, CurrentModule,
+      CachedCI->getASTContext().SourceMgr.getCodeCompletionBufferID(),
+      InMemoryDependencyHash);
 }
 
 bool CompletionInstance::shouldCheckDependencies() const {
   assert(CachedCI);
   using namespace std::chrono;
   auto now = system_clock::now();
-  return DependencyCheckedTimestamp + seconds(DependencyCheckIntervalSecond) < now;
+  return DependencyCheckedTimestamp + seconds(DependencyCheckIntervalSecond) <
+         now;
 }
 
 void CompletionInstance::setDependencyCheckIntervalSecond(unsigned Value) {

--- a/test/SourceKit/CodeComplete/Inputs/checkdeps/ClangFW.framework/Headers/ClangFW.h
+++ b/test/SourceKit/CodeComplete/Inputs/checkdeps/ClangFW.framework/Headers/ClangFW.h
@@ -1,0 +1,2 @@
+
+#import <ClangFW/Funcs.h>

--- a/test/SourceKit/CodeComplete/Inputs/checkdeps/ClangFW.framework/Headers/Funcs.h
+++ b/test/SourceKit/CodeComplete/Inputs/checkdeps/ClangFW.framework/Headers/Funcs.h
@@ -1,0 +1,4 @@
+#ifndef CLANGFW_FUNCS_H
+#define CLANGFW_FUNCS_H
+int clangFWFunc();
+#endif

--- a/test/SourceKit/CodeComplete/Inputs/checkdeps/ClangFW.framework/Modules/module.modulemap
+++ b/test/SourceKit/CodeComplete/Inputs/checkdeps/ClangFW.framework/Modules/module.modulemap
@@ -1,0 +1,4 @@
+framework module ClangFW {
+  umbrella header "ClangFW.h"
+  export *
+}

--- a/test/SourceKit/CodeComplete/Inputs/checkdeps/ClangFW.framework_mod/Headers/Funcs.h
+++ b/test/SourceKit/CodeComplete/Inputs/checkdeps/ClangFW.framework_mod/Headers/Funcs.h
@@ -1,0 +1,5 @@
+#ifndef CLANGFW_FUNCS_H
+#define CLANGFW_FUNCS_H
+int clangFWFunc_mod();
+#endif
+

--- a/test/SourceKit/CodeComplete/Inputs/checkdeps/MyProject/Bridging.h
+++ b/test/SourceKit/CodeComplete/Inputs/checkdeps/MyProject/Bridging.h
@@ -1,0 +1,1 @@
+#import "LocalCFunc.h"

--- a/test/SourceKit/CodeComplete/Inputs/checkdeps/MyProject/Library.swift
+++ b/test/SourceKit/CodeComplete/Inputs/checkdeps/MyProject/Library.swift
@@ -1,1 +1,5 @@
 func localSwiftFunc() -> Int {}
+
+struct MyStruct {
+  func myStructMethod() {}
+}

--- a/test/SourceKit/CodeComplete/Inputs/checkdeps/MyProject/Library.swift
+++ b/test/SourceKit/CodeComplete/Inputs/checkdeps/MyProject/Library.swift
@@ -1,0 +1,1 @@
+func localSwiftFunc() -> Int {}

--- a/test/SourceKit/CodeComplete/Inputs/checkdeps/MyProject/LibraryExt.swift
+++ b/test/SourceKit/CodeComplete/Inputs/checkdeps/MyProject/LibraryExt.swift
@@ -1,0 +1,3 @@
+extension MyStruct {
+  func extensionMethod() {}
+}

--- a/test/SourceKit/CodeComplete/Inputs/checkdeps/MyProject/LocalCFunc.h
+++ b/test/SourceKit/CodeComplete/Inputs/checkdeps/MyProject/LocalCFunc.h
@@ -1,0 +1,6 @@
+#ifndef MYPROJECT_LOCALCFUNC_H
+#define MYPROJECT_LOCALCFUNC_H
+
+int localClangFunc();
+
+#endif

--- a/test/SourceKit/CodeComplete/Inputs/checkdeps/MyProject_mod/Library.swift
+++ b/test/SourceKit/CodeComplete/Inputs/checkdeps/MyProject_mod/Library.swift
@@ -1,1 +1,5 @@
 func localSwiftFunc_mod() -> Int {}
+
+struct MyStruct {
+  func myStructMethod_mod() {}
+}

--- a/test/SourceKit/CodeComplete/Inputs/checkdeps/MyProject_mod/Library.swift
+++ b/test/SourceKit/CodeComplete/Inputs/checkdeps/MyProject_mod/Library.swift
@@ -1,0 +1,1 @@
+func localSwiftFunc_mod() -> Int {}

--- a/test/SourceKit/CodeComplete/Inputs/checkdeps/MyProject_mod/LocalCFunc.h
+++ b/test/SourceKit/CodeComplete/Inputs/checkdeps/MyProject_mod/LocalCFunc.h
@@ -1,0 +1,7 @@
+#ifndef MYPROJECT_LOCALCFUNC_H
+#define MYPROJECT_LOCALCFUNC_H
+
+int localClangFunc_mod();
+
+#endif
+

--- a/test/SourceKit/CodeComplete/Inputs/checkdeps/SwiftFW_src/Funcs.swift
+++ b/test/SourceKit/CodeComplete/Inputs/checkdeps/SwiftFW_src/Funcs.swift
@@ -1,0 +1,2 @@
+public func swiftFWFunc() -> Int { return 1 }
+

--- a/test/SourceKit/CodeComplete/Inputs/checkdeps/SwiftFW_src_mod/Funcs.swift
+++ b/test/SourceKit/CodeComplete/Inputs/checkdeps/SwiftFW_src_mod/Funcs.swift
@@ -1,0 +1,1 @@
+public func swiftFWFunc_mod() -> Int { return 1 }

--- a/test/SourceKit/CodeComplete/Inputs/checkdeps/test.swift
+++ b/test/SourceKit/CodeComplete/Inputs/checkdeps/test.swift
@@ -1,0 +1,5 @@
+import Foundation
+import ClangFW // < 500 headers framework
+func foo() {
+  /* HERE */
+}

--- a/test/SourceKit/CodeComplete/complete_checkdeps_bridged.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_bridged.swift
@@ -5,6 +5,8 @@ func foo() {
   /*HERE*/
 }
 
+// REQUIRES: shell
+
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_bridged.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_bridged.swift
@@ -1,0 +1,72 @@
+import ClangFW
+import SwiftFW
+
+func foo() {
+  /*HERE*/
+}
+
+// RUN: %empty-directory(%t/Frameworks)
+// RUN: %empty-directory(%t/MyProject)
+
+// RUN: COMPILER_ARGS=( \
+// RUN:   -target %target-triple \
+// RUN:   -module-name MyProject \
+// RUN:   -F %t/Frameworks \
+// RUN:   -I %t/MyProject \
+// RUN:   -import-objc-header %t/MyProject/Bridging.h \
+// RUN:   %t/MyProject/Library.swift \
+// RUN:   %s \
+// RUN: )
+// RUN: INPUT_DIR=%S/Inputs/checkdeps
+// RUN: DEPCHECK_INTERVAL=1
+// RUN: SLEEP_TIME=2
+
+// RUN: cp -R $INPUT_DIR/MyProject %t/
+// RUN: cp -R $INPUT_DIR/ClangFW.framework %t/Frameworks/
+// RUN: %empty-directory(%t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule)
+// RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=global-config -completion-check-dependency-interval ${DEPCHECK_INTERVAL} == \
+
+// RUN:   -shell -- echo "### Initial" == \
+// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+
+// RUN:   -shell -- echo '### Modify bridging header library file' == \
+// RUN:   -shell -- cp -R $INPUT_DIR/MyProject_mod/LocalCFunc.h %t/MyProject/ == \
+// RUN:   -shell -- sleep $SLEEP_TIME == \
+// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+
+// RUN:   -shell -- echo '### Fast completion' == \
+// RUN:   -shell -- sleep $SLEEP_TIME == \
+// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} \
+
+// RUN:   | %FileCheck %s
+
+
+// CHECK-LABEL: ### Initial
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "clangFWFunc()"
+// CHECK-DAG: key.description: "swiftFWFunc()"
+// CHECK-DAG: key.description: "localClangFunc()"
+// CHECK-DAG: key.description: "localSwiftFunc()"
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext: 1
+
+// CHECK-LABEL: ### Modify bridging header library file
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "clangFWFunc()"
+// CHECK-DAG: key.description: "swiftFWFunc()"
+// CHECK-DAG: key.description: "localClangFunc_mod()"
+// CHECK-DAG: key.description: "localSwiftFunc()"
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext: 1
+
+// CHECK-LABEL: ### Fast completion
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "clangFWFunc()"
+// CHECK-DAG: key.description: "swiftFWFunc()"
+// CHECK-DAG: key.description: "localClangFunc_mod()"
+// CHECK-DAG: key.description: "localSwiftFunc()"
+// CHECK: ]
+// CHECK: key.reusingastcontext: 1

--- a/test/SourceKit/CodeComplete/complete_checkdeps_clangmodule.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_clangmodule.swift
@@ -5,6 +5,8 @@ func foo() {
   /*HERE*/
 }
 
+// REQUIRES: shell
+
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_clangmodule.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_clangmodule.swift
@@ -1,0 +1,72 @@
+import ClangFW
+import SwiftFW
+
+func foo() {
+  /*HERE*/
+}
+
+// RUN: %empty-directory(%t/Frameworks)
+// RUN: %empty-directory(%t/MyProject)
+
+// RUN: COMPILER_ARGS=( \
+// RUN:   -target %target-triple \
+// RUN:   -module-name MyProject \
+// RUN:   -F %t/Frameworks \
+// RUN:   -I %t/MyProject \
+// RUN:   -import-objc-header %t/MyProject/Bridging.h \
+// RUN:   %t/MyProject/Library.swift \
+// RUN:   %s \
+// RUN: )
+// RUN: INPUT_DIR=%S/Inputs/checkdeps
+// RUN: DEPCHECK_INTERVAL=1
+// RUN: SLEEP_TIME=2
+
+// RUN: cp -R $INPUT_DIR/MyProject %t/
+// RUN: cp -R $INPUT_DIR/ClangFW.framework %t/Frameworks/
+// RUN: %empty-directory(%t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule)
+// RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=global-config -completion-check-dependency-interval ${DEPCHECK_INTERVAL} == \
+
+// RUN:   -shell -- echo "### Initial" == \
+// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+
+// RUN:   -shell -- echo '### Modify framework (c)' == \
+// RUN:   -shell -- cp -R $INPUT_DIR/ClangFW.framework_mod/* %t/Frameworks/ClangFW.framework/ == \
+// RUN:   -shell -- sleep $SLEEP_TIME == \
+// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+
+// RUN:   -shell -- echo '### Fast completion' == \
+// RUN:   -shell -- sleep $SLEEP_TIME == \
+// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} \
+
+// RUN:   | %FileCheck %s
+
+
+// CHECK-LABEL: ### Initial
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "clangFWFunc()"
+// CHECK-DAG: key.description: "swiftFWFunc()"
+// CHECK-DAG: key.description: "localClangFunc()"
+// CHECK-DAG: key.description: "localSwiftFunc()"
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext: 1
+
+// CHECK-LABEL: ### Modify framework (c)
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "clangFWFunc_mod()"
+// CHECK-DAG: key.description: "swiftFWFunc()"
+// CHECK-DAG: key.description: "localClangFunc()"
+// CHECK-DAG: key.description: "localSwiftFunc()"
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext: 1
+
+// CHECK-LABEL: ### Fast completion
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "clangFWFunc_mod()"
+// CHECK-DAG: key.description: "swiftFWFunc()"
+// CHECK-DAG: key.description: "localClangFunc()"
+// CHECK-DAG: key.description: "localSwiftFunc()"
+// CHECK: ]
+// CHECK: key.reusingastcontext: 1

--- a/test/SourceKit/CodeComplete/complete_checkdeps_otherfile.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_otherfile.swift
@@ -1,0 +1,71 @@
+import ClangFW
+import SwiftFW
+
+func foo() {
+  /*HERE*/
+}
+
+// RUN: %empty-directory(%t/Frameworks)
+// RUN: %empty-directory(%t/MyProject)
+
+// RUN: COMPILER_ARGS=( \
+// RUN:   -target %target-triple \
+// RUN:   -module-name MyProject \
+// RUN:   -F %t/Frameworks \
+// RUN:   -I %t/MyProject \
+// RUN:   -import-objc-header %t/MyProject/Bridging.h \
+// RUN:   %t/MyProject/Library.swift \
+// RUN:   %s \
+// RUN: )
+// RUN: INPUT_DIR=%S/Inputs/checkdeps
+// RUN: DEPCHECK_INTERVAL=1
+// RUN: SLEEP_TIME=2
+
+// RUN: cp -R $INPUT_DIR/MyProject %t/
+// RUN: cp -R $INPUT_DIR/ClangFW.framework %t/Frameworks/
+// RUN: %empty-directory(%t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule)
+// RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=global-config -completion-check-dependency-interval ${DEPCHECK_INTERVAL} == \
+
+// RUN:   -shell -- echo "### Initial" == \
+// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+
+// RUN:   -shell -- echo "### Modify local library file" == \
+// RUN:   -shell -- cp -R $INPUT_DIR/MyProject_mod/Library.swift %t/MyProject/ == \
+// RUN:   -shell -- sleep $SLEEP_TIME == \
+// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+
+// RUN:   -shell -- echo '### Fast completion' == \
+// RUN:   -shell -- sleep $SLEEP_TIME == \
+// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} \
+
+// RUN:   | %FileCheck %s
+
+// CHECK-LABEL: ### Initial
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "clangFWFunc()"
+// CHECK-DAG: key.description: "swiftFWFunc()"
+// CHECK-DAG: key.description: "localClangFunc()"
+// CHECK-DAG: key.description: "localSwiftFunc()"
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext: 1
+
+// CHECK-LABEL: ### Modify local library file
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "clangFWFunc()"
+// CHECK-DAG: key.description: "swiftFWFunc()"
+// CHECK-DAG: key.description: "localClangFunc()"
+// CHECK-DAG: key.description: "localSwiftFunc_mod()"
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext: 1
+
+// CHECK-LABEL: ### Fast completion
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "clangFWFunc()"
+// CHECK-DAG: key.description: "swiftFWFunc()"
+// CHECK-DAG: key.description: "localClangFunc()"
+// CHECK-DAG: key.description: "localSwiftFunc_mod()"
+// CHECK: ]
+// CHECK: key.reusingastcontext: 1

--- a/test/SourceKit/CodeComplete/complete_checkdeps_otherfile.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_otherfile.swift
@@ -5,6 +5,8 @@ func foo() {
   /*HERE*/
 }
 
+// REQUIRES: shell
+
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_swiftmodule.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_swiftmodule.swift
@@ -1,0 +1,71 @@
+import ClangFW
+import SwiftFW
+
+func foo() {
+  /*HERE*/
+}
+
+// RUN: %empty-directory(%t/Frameworks)
+// RUN: %empty-directory(%t/MyProject)
+
+// RUN: COMPILER_ARGS=( \
+// RUN:   -target %target-triple \
+// RUN:   -module-name MyProject \
+// RUN:   -F %t/Frameworks \
+// RUN:   -I %t/MyProject \
+// RUN:   -import-objc-header %t/MyProject/Bridging.h \
+// RUN:   %t/MyProject/Library.swift \
+// RUN:   %s \
+// RUN: )
+// RUN: INPUT_DIR=%S/Inputs/checkdeps
+// RUN: DEPCHECK_INTERVAL=1
+// RUN: SLEEP_TIME=2
+
+// RUN: cp -R $INPUT_DIR/MyProject %t/
+// RUN: cp -R $INPUT_DIR/ClangFW.framework %t/Frameworks/
+// RUN: %empty-directory(%t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule)
+// RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=global-config -completion-check-dependency-interval ${DEPCHECK_INTERVAL} == \
+
+// RUN:   -shell -- echo "### Initial" == \
+// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+
+// RUN:   -shell -- echo '### Modify framework (s)' == \
+// RUN:   -shell --  %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src_mod/Funcs.swift == \
+// RUN:   -shell -- sleep $SLEEP_TIME == \
+// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+
+// RUN:   -shell -- echo '### Fast completion' == \
+// RUN:   -shell -- sleep $SLEEP_TIME == \
+// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} \
+
+// RUN:   | %FileCheck %s
+
+// CHECK-LABEL: ### Initial
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "clangFWFunc()"
+// CHECK-DAG: key.description: "swiftFWFunc()"
+// CHECK-DAG: key.description: "localClangFunc()"
+// CHECK-DAG: key.description: "localSwiftFunc()"
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext: 1
+
+// CHECK-LABEL: ### Modify framework (s)
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "clangFWFunc()"
+// CHECK-DAG: key.description: "swiftFWFunc_mod()"
+// CHECK-DAG: key.description: "localClangFunc()"
+// CHECK-DAG: key.description: "localSwiftFunc()"
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext: 1
+
+// CHECK-LABEL: ### Fast completion
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "clangFWFunc()"
+// CHECK-DAG: key.description: "swiftFWFunc_mod()"
+// CHECK-DAG: key.description: "localClangFunc()"
+// CHECK-DAG: key.description: "localSwiftFunc()"
+// CHECK: ]
+// CHECK: key.reusingastcontext: 1

--- a/test/SourceKit/CodeComplete/complete_checkdeps_swiftmodule.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_swiftmodule.swift
@@ -5,6 +5,8 @@ func foo() {
   /*HERE*/
 }
 
+// REQUIRES: shell
+
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_vfs.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_vfs.swift
@@ -2,6 +2,8 @@ func foo(value: MyStruct) {
   value./*HERE*/
 }
 
+// REQUIRES: shell
+
 // RUN: DEPCHECK_INTERVAL=1
 // RUN: SLEEP_TIME=2
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_vfs.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_vfs.swift
@@ -1,0 +1,45 @@
+func foo(value: MyStruct) {
+  value./*HERE*/
+}
+
+// RUN: DEPCHECK_INTERVAL=1
+// RUN: SLEEP_TIME=2
+
+// RUN: %empty-directory(%t)
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=global-config -completion-check-dependency-interval ${DEPCHECK_INTERVAL} == \
+
+// RUN:   -shell -- echo "### Initial" == \
+// RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/Library.swift == \
+
+// RUN:   -shell -- echo "### Modify" == \
+// RUN:   -shell -- sleep ${SLEEP_TIME} == \
+// RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/Library.swift == \
+
+// RUN:   -shell -- echo "### Keep" == \
+// RUN:   -shell -- sleep ${SLEEP_TIME} == \
+// RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/Library.swift \
+
+// RUN:   |  %FileCheck %s
+
+// CHECK-LABEL: ### Initial
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "myStructMethod()"
+// CHECK-DAG: key.description: "self"
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext: 1
+
+// CHECK-LABEL: ### Modify
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "myStructMethod_mod()"
+// CHECK-DAG: key.description: "self"
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext: 1
+
+// CHECK-LABEL: ### Keep
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "myStructMethod_mod()"
+// CHECK-DAG: key.description: "self"
+// CHECK: ]
+// CHECK: key.reusingastcontext: 1

--- a/test/SourceKit/CodeComplete/complete_checkdeps_vfs.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_vfs.swift
@@ -8,26 +8,29 @@ func foo(value: MyStruct) {
 // RUN: SLEEP_TIME=2
 
 // RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/VFS)
+// RUN: cp %S/Inputs/checkdeps/MyProject/LibraryExt.swift %t/VFS/
 
 // RUN: %sourcekitd-test \
 // RUN:   -req=global-config -completion-check-dependency-interval ${DEPCHECK_INTERVAL} == \
 
 // RUN:   -shell -- echo "### Initial" == \
-// RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/Library.swift == \
+// RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift == \
 
 // RUN:   -shell -- echo "### Modify" == \
 // RUN:   -shell -- sleep ${SLEEP_TIME} == \
-// RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/Library.swift == \
+// RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift == \
 
 // RUN:   -shell -- echo "### Keep" == \
 // RUN:   -shell -- sleep ${SLEEP_TIME} == \
-// RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/Library.swift \
+// RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift \
 
 // RUN:   |  %FileCheck %s
 
 // CHECK-LABEL: ### Initial
 // CHECK: key.results: [
 // CHECK-DAG: key.description: "myStructMethod()"
+// CHECK-DAG: key.description: "extensionMethod()"
 // CHECK-DAG: key.description: "self"
 // CHECK: ]
 // CHECK-NOT: key.reusingastcontext: 1
@@ -35,6 +38,7 @@ func foo(value: MyStruct) {
 // CHECK-LABEL: ### Modify
 // CHECK: key.results: [
 // CHECK-DAG: key.description: "myStructMethod_mod()"
+// CHECK-DAG: key.description: "extensionMethod()"
 // CHECK-DAG: key.description: "self"
 // CHECK: ]
 // CHECK-NOT: key.reusingastcontext: 1
@@ -42,6 +46,7 @@ func foo(value: MyStruct) {
 // CHECK-LABEL: ### Keep
 // CHECK: key.results: [
 // CHECK-DAG: key.description: "myStructMethod_mod()"
+// CHECK-DAG: key.description: "extensionMethod()"
 // CHECK-DAG: key.description: "self"
 // CHECK: ]
 // CHECK: key.reusingastcontext: 1

--- a/test/SourceKit/CodeComplete/complete_checkdeps_vfs_open.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_vfs_open.swift
@@ -2,6 +2,8 @@ func foo(value: MyStruct) {
   value./*HERE*/
 }
 
+// REQUIRES: shell
+
 // RUN: DEPCHECK_INTERVAL=1
 // RUN: SLEEP_TIME=2
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_vfs_open.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_vfs_open.swift
@@ -1,0 +1,46 @@
+func foo(value: MyStruct) {
+  value./*HERE*/
+}
+
+// RUN: DEPCHECK_INTERVAL=1
+// RUN: SLEEP_TIME=2
+
+// RUN: %empty-directory(%t)
+// RUN: %sourcekitd-test \
+// RUN:   -req=global-config -completion-check-dependency-interval ${DEPCHECK_INTERVAL} == \
+
+// RUN:   -shell -- echo "### Initial" == \
+// RUN:   -req=complete.open -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/Library.swift == \
+// RUN:   -req=complete.close -pos=2:9 -name %t/VFS/Main.swift %s == \
+
+// RUN:   -shell -- echo "### Modify" == \
+// RUN:   -shell -- sleep ${SLEEP_TIME} == \
+// RUN:   -req=complete.open -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/Library.swift == \
+// RUN:   -req=complete.close -pos=2:9 -name %t/VFS/Main.swift %s == \
+
+// RUN:   -shell -- echo "### Keep" == \
+// RUN:   -req=complete.open -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/Library.swift == \
+// RUN:   -req=complete.close -pos=2:9 -name %t/VFS/Main.swift %s \
+
+// RUN:   | %FileCheck %s
+
+// CHECK-LABEL: ### Initial
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "myStructMethod()"
+// CHECK-DAG: key.description: "self"
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext: 1
+
+// CHECK-LABEL: ### Modify
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "myStructMethod_mod()"
+// CHECK-DAG: key.description: "self"
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext: 1
+
+// CHECK-LABEL: ### Keep
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "myStructMethod_mod()"
+// CHECK-DAG: key.description: "self"
+// CHECK: ]
+// CHECK: key.reusingastcontext: 1

--- a/test/SourceKit/CodeComplete/complete_checkdeps_vfs_open.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_vfs_open.swift
@@ -8,27 +8,31 @@ func foo(value: MyStruct) {
 // RUN: SLEEP_TIME=2
 
 // RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/VFS)
+// RUN: cp %S/Inputs/checkdeps/MyProject/LibraryExt.swift %t/VFS/
+
 // RUN: %sourcekitd-test \
 // RUN:   -req=global-config -completion-check-dependency-interval ${DEPCHECK_INTERVAL} == \
 
 // RUN:   -shell -- echo "### Initial" == \
-// RUN:   -req=complete.open -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/Library.swift == \
+// RUN:   -req=complete.open -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift == \
 // RUN:   -req=complete.close -pos=2:9 -name %t/VFS/Main.swift %s == \
 
 // RUN:   -shell -- echo "### Modify" == \
 // RUN:   -shell -- sleep ${SLEEP_TIME} == \
-// RUN:   -req=complete.open -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/Library.swift == \
+// RUN:   -req=complete.open -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift == \
 // RUN:   -req=complete.close -pos=2:9 -name %t/VFS/Main.swift %s == \
 
 // RUN:   -shell -- echo "### Keep" == \
-// RUN:   -req=complete.open -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/Library.swift == \
+// RUN:   -req=complete.open -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift == \
 // RUN:   -req=complete.close -pos=2:9 -name %t/VFS/Main.swift %s \
 
-// RUN:   | %FileCheck %s
+// RUN:   | tee %t/trace | %FileCheck %s
 
 // CHECK-LABEL: ### Initial
 // CHECK: key.results: [
 // CHECK-DAG: key.description: "myStructMethod()"
+// CHECK-DAG: key.description: "extensionMethod()"
 // CHECK-DAG: key.description: "self"
 // CHECK: ]
 // CHECK-NOT: key.reusingastcontext: 1
@@ -36,6 +40,7 @@ func foo(value: MyStruct) {
 // CHECK-LABEL: ### Modify
 // CHECK: key.results: [
 // CHECK-DAG: key.description: "myStructMethod_mod()"
+// CHECK-DAG: key.description: "extensionMethod()"
 // CHECK-DAG: key.description: "self"
 // CHECK: ]
 // CHECK-NOT: key.reusingastcontext: 1
@@ -43,6 +48,7 @@ func foo(value: MyStruct) {
 // CHECK-LABEL: ### Keep
 // CHECK: key.results: [
 // CHECK-DAG: key.description: "myStructMethod_mod()"
+// CHECK-DAG: key.description: "extensionMethod()"
 // CHECK-DAG: key.description: "self"
 // CHECK: ]
 // CHECK: key.reusingastcontext: 1

--- a/tools/SourceKit/include/SourceKit/Core/Context.h
+++ b/tools/SourceKit/include/SourceKit/Core/Context.h
@@ -36,6 +36,9 @@ public:
     ///
     /// At the time of writing this just means ignoring .swiftsourceinfo files.
     bool OptimizeForIDE = false;
+
+    /// Interval second for checking dependencies in fast code completion.
+    unsigned CompletionCheckDependencyInterval = 5;
   };
 
 private:
@@ -43,8 +46,10 @@ private:
   mutable llvm::sys::Mutex Mtx;
 
 public:
-  Settings update(Optional<bool> OptimizeForIDE);
+  Settings update(Optional<bool> OptimizeForIDE,
+                  Optional<unsigned> CompletionCheckDependencyInterval);
   bool shouldOptimizeForIDE() const;
+  unsigned getCompletionCheckDependencyInterval() const;
 };
 
 class Context {

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -146,7 +146,7 @@ public:
   virtual void failed(StringRef ErrDescription) = 0;
 
   virtual void setCompletionKind(UIdent kind) {};
-  virtual void setReusingASTContext(bool) {};
+  virtual void setReusingASTContext(bool) = 0;
   virtual bool handleResult(const CodeCompletionInfo &Info) = 0;
 };
 

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -37,6 +37,7 @@ class SourceFileSyntax;
 } // namespace swift
 
 namespace SourceKit {
+class GlobalConfig;
 
 struct EntityInfo {
   UIdent Kind;
@@ -650,6 +651,8 @@ public:
   const static std::string SynthesizedUSRSeparator;
 
   virtual ~LangSupport() { }
+
+  virtual void globalConfigurationUpdated(std::shared_ptr<GlobalConfig> Config) {};
 
   virtual void indexSource(StringRef Filename,
                            IndexingConsumer &Consumer,

--- a/tools/SourceKit/lib/Core/Context.cpp
+++ b/tools/SourceKit/lib/Core/Context.cpp
@@ -17,16 +17,23 @@
 using namespace SourceKit;
 
 GlobalConfig::Settings
-GlobalConfig::update(Optional<bool> OptimizeForIDE) {
+GlobalConfig::update(Optional<bool> OptimizeForIDE,
+                     Optional<unsigned> CompletionCheckDependencyInterval) {
   llvm::sys::ScopedLock L(Mtx);
   if (OptimizeForIDE.hasValue())
     State.OptimizeForIDE = *OptimizeForIDE;
+  if (CompletionCheckDependencyInterval.hasValue())
+    State.CompletionCheckDependencyInterval = *CompletionCheckDependencyInterval;
   return State;
 };
 
 bool GlobalConfig::shouldOptimizeForIDE() const {
   llvm::sys::ScopedLock L(Mtx);
   return State.OptimizeForIDE;
+}
+unsigned GlobalConfig::getCompletionCheckDependencyInterval() const {
+  llvm::sys::ScopedLock L(Mtx);
+  return State.CompletionCheckDependencyInterval;
 }
 
 SourceKit::Context::Context(StringRef RuntimeLibPath,

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -1221,6 +1221,7 @@ void SwiftLangSupport::codeCompleteOpen(
         completionKind = completionCtx.CodeCompletionKind;
         typeContextKind = completionCtx.typeContextKind;
         mayUseImplicitMemberExpr = completionCtx.MayUseImplicitMemberExpr;
+        consumer.setReusingASTContext(completionCtx.ReusingASTContext);
         completions =
             extendCompletions(results, sink, info, nameToPopularity, CCOpts);
       });

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -450,6 +450,8 @@ public:
   // LangSupport Interface
   //==========================================================================//
 
+  void globalConfigurationUpdated(std::shared_ptr<GlobalConfig> Config) override;
+
   void indexSource(StringRef Filename, IndexingConsumer &Consumer,
                    ArrayRef<const char *> Args) override;
 

--- a/tools/SourceKit/tools/sourcekitd-test/Options.td
+++ b/tools/SourceKit/tools/sourcekitd-test/Options.td
@@ -143,6 +143,11 @@ def vfs_name : Separate<["-"], "vfs-name">,
 def optimize_for_ide : Joined<["-"], "for-ide=">,
   HelpText<"Value for the OptimizeForIde global configuration setting">;
 
+def completion_check_dependency_interval : Separate<["-"], "completion-check-dependency-interval">,
+  HelpText<"Inteval seconds for checking dependencies in fast completion">;
+def completion_check_dependency_interval_EQ : Joined<["-"], "completion-check-dependency-interval=">,
+  Alias<completion_check_dependency_interval>;
+
 def suppress_config_request : Flag<["-"], "suppress-config-request">,
   HelpText<"Suppress the default global configuration request, that is otherwise sent before any other request (except for the global-config request itself)">;
 

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -381,6 +381,19 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
       break;
     }
 
+    case OPT_completion_check_dependency_interval: {
+      int64_t Value;
+      if (StringRef(InputArg->getValue()).getAsInteger(10, Value)) {
+        llvm::errs() << "error: expected number for inteval\n";
+        return true;
+      } else if (Value < 0) {
+        llvm::errs() << "error: completion-check-dependency-interval must be > 0\n";
+        return true;
+      }
+      CompletionCheckDependencyInterval = Value;
+      break;
+    }
+
     case OPT_suppress_config_request:
       SuppressDefaultConfigRequest = true;
       break;

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -114,6 +114,7 @@ struct TestOptions {
   bool timeRequest = false;
   llvm::Optional<bool> OptimizeForIde;
   bool SuppressDefaultConfigRequest = false;
+  llvm::Optional<unsigned> CompletionCheckDependencyInterval;
   unsigned repeatRequest = 1;
   struct VFSFile {
     std::string path;

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -548,7 +548,14 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
   case SourceKitRequest::GlobalConfiguration:
     sourcekitd_request_dictionary_set_uid(Req, KeyRequest, RequestGlobalConfiguration);
     if (Opts.OptimizeForIde.hasValue())
-      sourcekitd_request_dictionary_set_int64(Req, KeyOptimizeForIDE, static_cast<int64_t>(Opts.OptimizeForIde.getValue()));
+      sourcekitd_request_dictionary_set_int64(
+          Req, KeyOptimizeForIDE,
+          static_cast<int64_t>(Opts.OptimizeForIde.getValue()));
+    if (Opts.CompletionCheckDependencyInterval.hasValue())
+      sourcekitd_request_dictionary_set_int64(
+          Req, KeyCompletionCheckDependencyInterval,
+          static_cast<int64_t>(
+              Opts.CompletionCheckDependencyInterval.getValue()));
     break;
 
   case SourceKitRequest::ProtocolVersion:

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -2034,6 +2034,7 @@ public:
   void startGroup(UIdent kind, StringRef name) override;
   void endGroup() override;
   void setNextRequestStart(unsigned offset) override;
+  void setReusingASTContext(bool flag) override;
 };
 } // end anonymous namespace
 
@@ -2230,6 +2231,10 @@ void SKGroupedCodeCompletionConsumer::endGroup() {
 void SKGroupedCodeCompletionConsumer::setNextRequestStart(unsigned offset) {
   assert(!Response.isNull());
   Response.set(KeyNextRequestStart, offset);
+}
+void SKGroupedCodeCompletionConsumer::setReusingASTContext(bool flag) {
+  if (flag)
+    RespBuilder.getDictionary().setBool(KeyReusingASTContext, flag);
 }
 
 //===----------------------------------------------------------------------===//

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -438,9 +438,21 @@ void handleRequestImpl(sourcekitd_object_t ReqObj, ResponseReceiver Rec) {
     if (!Req.getInt64(KeyOptimizeForIDE, EditorMode, true)) {
       OptimizeForIDE = EditorMode;
     }
+    Optional<unsigned> CompletionCheckDependencyInterval;
+    int64_t IntervalValue = 0;
+    if (!Req.getInt64(KeyCompletionCheckDependencyInterval,
+                      IntervalValue, /*isOptional=*/true))
+      CompletionCheckDependencyInterval = IntervalValue;
 
-    GlobalConfig::Settings UpdatedConfig = Config->update(OptimizeForIDE);
+    GlobalConfig::Settings UpdatedConfig = Config->update(
+        OptimizeForIDE, CompletionCheckDependencyInterval);
+
+    getGlobalContext().getSwiftLangSupport().globalConfigurationUpdated(Config);
+
     dict.set(KeyOptimizeForIDE, UpdatedConfig.OptimizeForIDE);
+    dict.set(KeyCompletionCheckDependencyInterval,
+             UpdatedConfig.CompletionCheckDependencyInterval);
+
     return Rec(RB.createResponse());
   }
   if (ReqUID == RequestProtocolVersion) {

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -179,6 +179,8 @@ UID_KEYS = [
     KEY('OptimizeForIDE', 'key.optimize_for_ide'),
     KEY('RequiredBystanders', 'key.required_bystanders'),
     KEY('ReusingASTContext', 'key.reusingastcontext'),
+    KEY('CompletionCheckDependencyInterval',
+        'key.completion_check_dependency_interval'),
 ]
 
 


### PR DESCRIPTION
- **Explanation**:  Fix a regression caused by fast-completion mode. Fast completion mode could not detect the modification in dependent files such as imported module file, header files in clang modules. Fix the problem by adding some logic to check if the decencies are modified
- **Scope**: Code completion inside function bodies or single file scripts
- **Risk**: Low-Mid. Increase chances to invalidate fast-completion. But the changes are closed in code completion, it should not affect other parts.
- **Issue**: rdar://problem/62336432
- **Testing**: Added regression test cases to check modifications are correctly propagated.
- **Reviewer**: Ben Langmuir (@benlangmuir )
