### PR TITLE
build: remove `ANALYZE_CODE_COVERAGE` from `_add_host_variant_c_compi…

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -78,11 +78,10 @@ endfunction()
 
 # Usage:
 # _add_host_variant_c_compile_link_flags(
-#   ANALYZE_CODE_COVERAGE analyze_code_coverage
 #   RESULT_VAR_NAME result_var_name
 # )
 function(_add_host_variant_c_compile_link_flags)
-  set(oneValueArgs RESULT_VAR_NAME ANALYZE_CODE_COVERAGE)
+  set(oneValueArgs RESULT_VAR_NAME)
   cmake_parse_arguments(CFLAGS
     ""
     "${oneValueArgs}"
@@ -150,11 +149,6 @@ function(_add_host_variant_c_compile_link_flags)
      endif()
   endif()
 
-  if(CFLAGS_ANALYZE_CODE_COVERAGE)
-    list(APPEND result "-fprofile-instr-generate"
-                       "-fcoverage-mapping")
-  endif()
-
   _compute_lto_flag("${SWIFT_TOOLS_ENABLE_LTO}" _lto_flag_out)
   if (_lto_flag_out)
     list(APPEND result "${_lto_flag_out}")
@@ -165,9 +159,7 @@ endfunction()
 
 
 function(_add_host_variant_c_compile_flags target)
-  _add_host_variant_c_compile_link_flags(
-    ANALYZE_CODE_COVERAGE FALSE
-    RESULT_VAR_NAME result)
+  _add_host_variant_c_compile_link_flags(RESULT_VAR_NAME result)
   target_compile_options(${target} PRIVATE
     ${result})
 
@@ -332,9 +324,7 @@ function(_add_host_variant_c_compile_flags target)
 endfunction()
 
 function(_add_host_variant_link_flags target)
-  _add_host_variant_c_compile_link_flags(
-    ANALYZE_CODE_COVERAGE ${SWIFT_ANALYZE_CODE_COVERAGE}
-    RESULT_VAR_NAME result)
+  _add_host_variant_c_compile_link_flags(RESULT_VAR_NAME result)
   target_link_options(${target} PRIVATE
     ${result})
 


### PR DESCRIPTION
…le_link_flags`

This flag does not make sense here as this function is called from
`_add_host_variant_link_flags` and `_add_host_variant_c_compile_flags`.
The latter will add the flags appropriately.  The former is always
invoked *after* `_add_host_variant_c_compile_flags`.  This effectively
was duplicating the flags.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
