### PR TITLE
DependencyScanner: honor additional compiler flags in interfaces files when collecting imports

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -121,6 +121,7 @@ namespace swift {
   class UnifiedStatsReporter;
   class IndexSubset;
   struct SILAutoDiffDerivativeFunctionKey;
+  struct SubASTContextDelegate;
 
   enum class KnownProtocolKind : uint8_t;
 
@@ -719,7 +720,8 @@ public:
   Optional<ModuleDependencies> getModuleDependencies(
       StringRef moduleName,
       bool isUnderlyingClangModule,
-      ModuleDependenciesCache &cache);
+      ModuleDependenciesCache &cache,
+      SubASTContextDelegate &delegate);
 
   /// Load extensions to the given nominal type from the external
   /// module loaders.

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -25,6 +25,7 @@
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/TinyPtrVector.h"
+#include "swift/AST/ModuleDependencies.h"
 
 namespace llvm {
 class FileCollector;
@@ -82,6 +83,15 @@ public:
   /// Return the underlying clang::DependencyCollector that this
   /// class wraps.
   std::shared_ptr<clang::DependencyCollector> getClangCollector();
+};
+
+/// Abstract interface to run an action in a sub ASTContext.
+struct SubASTContextDelegate {
+  virtual bool runInSubContext(ASTContext &ctx, StringRef interfacePath,
+    llvm::function_ref<bool(ASTContext&)> action) {
+    llvm_unreachable("function should be overriden");
+  }
+  virtual ~SubASTContextDelegate() = default;
 };
 
 /// Abstract interface that loads named modules into the AST.
@@ -186,7 +196,7 @@ public:
   /// if no such module exists.
   virtual Optional<ModuleDependencies> getModuleDependencies(
       StringRef moduleName,
-      ModuleDependenciesCache &cache) = 0;
+      ModuleDependenciesCache &cache, SubASTContextDelegate &delegate) = 0;
 };
 
 } // namespace swift

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -370,7 +370,8 @@ public:
   void verifyAllModules() override;
 
   Optional<ModuleDependencies> getModuleDependencies(
-      StringRef moduleName, ModuleDependenciesCache &cache) override;
+      StringRef moduleName, ModuleDependenciesCache &cache,
+      SubASTContextDelegate &delegate) override;
 
   /// Add dependency information for the bridging header.
   ///

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -124,6 +124,7 @@ namespace swift {
 
 class LangOptions;
 class SearchPathOptions;
+class CompilerInvocation;
 
 /// A ModuleLoader that runs a subordinate \c CompilerInvocation and
 /// \c CompilerInstance to convert .swiftinterface files to .swiftmodule
@@ -210,6 +211,10 @@ bool extractSwiftInterfaceVersionAndArgs(SourceManager &SM,
                                          llvm::StringSaver &SubArgSaver,
                                          SmallVectorImpl<const char *> &SubArgs,
                                          SourceLoc diagnosticLoc = SourceLoc());
+
+void inheritOptionsForBuildingInterface(CompilerInvocation &Invok,
+                                        const SearchPathOptions &SearchPathOpts,
+                                        const LangOptions &LangOpts);
 }
 
 #endif

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -110,6 +110,7 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/Frontend/ModuleInterfaceSupport.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
+#include "llvm/Support/StringSaver.h"
 
 namespace clang {
 class CompilerInstance;
@@ -201,6 +202,14 @@ public:
 std::string
 getModuleCachePathFromClang(const clang::CompilerInstance &Instance);
 
+bool extractSwiftInterfaceVersionAndArgs(SourceManager &SM,
+                                         DiagnosticEngine &Diags,
+                                         StringRef InterfacePath,
+                                         version::Version &Vers,
+                                         StringRef &CompilerVersion,
+                                         llvm::StringSaver &SubArgSaver,
+                                         SmallVectorImpl<const char *> &SubArgs,
+                                         SourceLoc diagnosticLoc = SourceLoc());
 }
 
 #endif

--- a/include/swift/Sema/SourceLoader.h
+++ b/include/swift/Sema/SourceLoader.h
@@ -93,7 +93,8 @@ public:
   }
 
   Optional<ModuleDependencies> getModuleDependencies(
-      StringRef moduleName, ModuleDependenciesCache &cache) override {
+      StringRef moduleName, ModuleDependenciesCache &cache,
+      SubASTContextDelegate &delegate) override {
     // FIXME: Implement?
     return None;
   }

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -194,7 +194,8 @@ public:
   virtual void verifyAllModules() override;
 
   virtual Optional<ModuleDependencies> getModuleDependencies(
-      StringRef moduleName, ModuleDependenciesCache &cache) override;
+      StringRef moduleName, ModuleDependenciesCache &cache,
+      SubASTContextDelegate &delegate) override;
 };
 
 /// Imports serialized Swift modules into an ASTContext.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1462,13 +1462,14 @@ void ASTContext::addModuleLoader(std::unique_ptr<ModuleLoader> loader,
 
 Optional<ModuleDependencies> ASTContext::getModuleDependencies(
     StringRef moduleName, bool isUnderlyingClangModule,
-    ModuleDependenciesCache &cache) {
+    ModuleDependenciesCache &cache, SubASTContextDelegate &delegate) {
   for (auto &loader : getImpl().ModuleLoaders) {
     if (isUnderlyingClangModule &&
         loader.get() != getImpl().TheClangModuleLoader)
       continue;
 
-    if (auto dependencies = loader->getModuleDependencies(moduleName, cache))
+    if (auto dependencies = loader->getModuleDependencies(moduleName, cache,
+                                                          delegate))
       return dependencies;
   }
 

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -224,7 +224,8 @@ static void recordModuleDependencies(
 }
 
 Optional<ModuleDependencies> ClangImporter::getModuleDependencies(
-    StringRef moduleName, ModuleDependenciesCache &cache) {
+    StringRef moduleName, ModuleDependenciesCache &cache,
+    SubASTContextDelegate &delegate) {
   // Check whether there is already a cached result.
   if (auto found = cache.findDependencies(
           moduleName, ModuleDependenciesKind::Clang))

--- a/lib/FrontendTool/ScanDependencies.cpp
+++ b/lib/FrontendTool/ScanDependencies.cpp
@@ -76,6 +76,9 @@ struct InterfaceSubASTContextDelegate: SubASTContextDelegate {
       return true;
     }
     CompilerInvocation invok;
+
+    // Inherit options from the parent ASTContext so we have all search paths, etc.
+    inheritOptionsForBuildingInterface(invok, ctx.SearchPathOpts, ctx.LangOpts);
     CompilerInstance inst;
     // Use the additional flags to setup the compiler instance.
     if (invok.parseArgs(SubArgs, ctx.Diags)) {

--- a/test/ScanDependencies/Inputs/CHeaders/G.h
+++ b/test/ScanDependencies/Inputs/CHeaders/G.h
@@ -1,0 +1,1 @@
+void funcG(void);

--- a/test/ScanDependencies/Inputs/CHeaders/module.modulemap
+++ b/test/ScanDependencies/Inputs/CHeaders/module.modulemap
@@ -22,3 +22,8 @@ module F {
   header "F.h"
   export *
 }
+
+module G {
+  header "G.h"
+  export *
+}

--- a/test/ScanDependencies/Inputs/Swift/G.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/G.swiftinterface
@@ -1,0 +1,9 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name G -swift-version 5
+
+#if swift(>=5.0)
+
+@_exported import G
+public func overlayFuncG() { }
+
+#endif

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/clang-module-cache
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
 
 // Check the contents of the JSON output
 // RUN: %FileCheck %s < %t/deps.json
@@ -20,6 +20,7 @@
 
 import C
 import E
+import G
 
 // CHECK: "mainModuleName": "deps"
 
@@ -34,6 +35,9 @@ import E
 // CHECK-NEXT: }
 // CHECK-NEXT: {
 // CHECK-NEXT: "swift": "E"
+// CHECK-NEXT: }
+// CHECK-NEXT: {
+// CHECK-NEXT: "swift": "G"
 // CHECK-NEXT: }
 // CHECK-NEXT: {
 // CHECK-NEXT: "swift": "Swift"
@@ -90,6 +94,16 @@ import E
 // CHECK: "moduleInterfacePath"
 // CHECK-SAME: E.swiftinterface
 
+/// --------Swift module G
+// CHECK-LABEL: "modulePath": "G.swiftmodule"
+// CHECK: "directDependencies"
+// CHECK-NEXT: {
+// CHECK-NEXT: "clang": "G"
+// CHECK-NEXT: },
+// CHECK-NEXT: {
+// CHECK-NEXT: "swift": "G"
+// CHECK-NEXT: }
+
 /// --------Swift module Swift
 // CHECK-LABEL: "modulePath": "Swift.swiftmodule",
 
@@ -124,6 +138,7 @@ import E
 // Check make-style dependencies
 // CHECK-MAKE-DEPS: module_deps.swift
 // CHECK-MAKE-DEPS-SAME: A.swiftinterface
+// CHECK-MAKE-DEPS-SAME: G.swiftinterface
 // CHECK-MAKE-DEPS-SAME: Swift.swiftmodule
 // CHECK-MAKE-DEPS-SAME: B.h
 // CHECK-MAKE-DEPS-SAME: F.h


### PR DESCRIPTION
Additional flags in interface files may change parsing behavior like #if
statements. We should use a fresh ASTContext with these additional
flags when parsing interface files to collect imports.

rdar://62612027