### PR TITLE
Improved the description of loadable and address-only types

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -718,18 +718,23 @@ generic constraints:
   * @weak types
   * Types that can't satisfy the requirements for being loadable because they
     care about the exact location of their value in memory and need to run some
-    user-written code when they are copied or moved. For example:
+    user-written code when they are copied or moved. Most commonly, types "care"
+    about the addresses of values because addresses of values are registered in
+    some global data structure, or because values may contain pointers into
+    themselves.  For example:
 
     * Addresses of values of Swift ``@weak`` types are registered in a global
       table. That table needs to be adjusted when a ``@weak`` value is copied
       or moved to a new address.
 
-    * A non-COW collection type with a heap allocation needs to allocate memory
-      and copy the collection elements when the collection is copied.
+    * A non-COW collection type with a heap allocation (like ``std::vector`` in
+      C++) needs to allocate memory and copy the collection elements when the
+      collection is copied.
 
-    * A non-COW string type with an SSO buffer (like ``std::string`` in C++)
-      can contain a pointer into the value itself. That pointer needs to be
-      recomputed when the string is copied or moved.
+    * A non-COW string type that implements a small string optimization (like
+      many implementations of ``std::string`` in C++) can contain a pointer
+      into the value itself. That pointer needs to be recomputed when the
+      string is copied or moved.
 
   Values of address-only type ("address-only values") must reside in
   memory and can only be referenced in SIL by address. Addresses of

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -686,6 +686,16 @@ generic constraints:
   * Class protocol types
   * Archetypes constrained by a class protocol
 
+  Values of loadable types are loaded and stored by loading and storing
+  individual components of their representation. As a consequence:
+
+    * values of loadable types can be loaded into SIL SSA values and stored
+      from SSA values into memory without running any user-written code,
+      although compiler-generated reference counting operations can happen.
+
+    * values of loadable types can be take-initialized (moved between
+      memory locations) with a bitwise copy.
+
   A *loadable aggregate type* is a tuple or struct type that is loadable.
 
   A *trivial type* is a loadable type with trivial value semantics.
@@ -706,6 +716,20 @@ generic constraints:
   * Runtime-sized types
   * Non-class protocol types
   * @weak types
+  * Types that can't satisfy the requirements for being loadable because they
+    care about the exact location of their value in memory and need to run some
+    user-written code when they are copied or moved. For example:
+
+    * Addresses of values of Swift ``@weak`` types are registered in a global
+      table. That table needs to be adjusted when a ``@weak`` value is copied
+      or moved to a new address.
+
+    * A non-COW collection type with a heap allocation needs to allocate memory
+      and copy the collection elements when the collection is copied.
+
+    * A non-COW string type with an SSO buffer (like ``std::string`` in C++)
+      can contain a pointer into the value itself. That pointer needs to be
+      recomputed when the string is copied or moved.
 
   Values of address-only type ("address-only values") must reside in
   memory and can only be referenced in SIL by address. Addresses of


### PR DESCRIPTION
Added a missing requirement that loadable types must be loaded and stored in terms of their parts. Added some examples of loadable and address-only types that are not expressible in Swift today but help illustrate the concepts.
