### PR TITLE
[5.3, NFC] Diags: Audit diags using DeclName for names of nominals and vars 

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -529,16 +529,16 @@ ERROR(expression_unused_keypath_result,none,
       "result of key path is unused", ())
 ERROR(expr_keypath_non_objc_property,none,
       "argument of '#keyPath' refers to non-'@objc' property %0",
-      (DeclName))
+      (Identifier))
 WARNING(expr_keypath_swift3_objc_inference,none,
         "argument of '#keyPath' refers to property %0 in %1 that depends on "
         "'@objc' inference deprecated in Swift 4",
-        (DeclName, Identifier))
+        (Identifier, Identifier))
 ERROR(expr_keypath_type_of_property,none,
       "cannot refer to type member %0 within instance of type %1",
       (DeclNameRef, Type))
 ERROR(expr_keypath_generic_type,none,
-      "key path cannot refer to generic type %0", (DeclName))
+      "key path cannot refer to generic type %0", (Identifier))
 ERROR(expr_keypath_not_property,none,
       "%select{key path|dynamic key path member lookup}2 cannot refer to %0 %1",
       (DescriptiveDeclKind, DeclName, bool))
@@ -620,7 +620,7 @@ ERROR(expr_selector_property_setter_inaccessible,none,
       "setter of %0 %1 is inaccessible", (DescriptiveDeclKind, DeclName))
 ERROR(expr_selector_cannot_be_used,none,
       "cannot use %0 as a selector because protocol %1 is not exposed to Objective-C",
-      (DeclBaseName, DeclName))
+      (DeclBaseName, Identifier))
 ERROR(expr_selector_not_objc,none,
       "argument of '#selector' refers to %0 %1 that is not exposed to "
       "Objective-C",
@@ -778,10 +778,10 @@ ERROR(use_nonmatching_operator,none,
       (DeclNameRef, unsigned))
 ERROR(unsupported_recursion_in_associated_type_reference,none,
       "unsupported recursion for reference to %select{associated type|type alias}0 %1 of type %2",
-      (bool, DeclName, Type))
+      (bool, Identifier, Type))
 ERROR(broken_associated_type_witness,none,
       "reference to invalid %select{associated type|type alias}0 %1 of type %2",
-      (bool, DeclName, Type))
+      (bool, Identifier, Type))
 
 ERROR(unspaced_binary_operator_fixit,none,
       "missing whitespace between %0 and %1 operators",
@@ -1241,7 +1241,7 @@ ERROR(attribute_requires_single_argument,none,
       "'%0' requires a function with one argument", (StringRef))
 
 ERROR(nominal_type_not_attribute,none,
-      "%0 %1 cannot be used as an attribute", (DescriptiveDeclKind, DeclName))
+      "%0 %1 cannot be used as an attribute", (DescriptiveDeclKind, Identifier))
 
 ERROR(mutating_invalid_global_scope,none, "%0 is only valid on methods",
       (SelfAccessKind))
@@ -1734,9 +1734,10 @@ NOTE(extension_stored_property_fixit,none,
      "Remove '=' to make %0 a computed property", (Identifier))
 ERROR(extension_nongeneric_trailing_where,none,
       "trailing 'where' clause for extension of non-generic type %0",
-      (DeclName))
+      (Identifier))
 ERROR(extension_protocol_inheritance,none,
-      "extension of protocol %0 cannot have an inheritance clause", (DeclName))
+      "extension of protocol %0 cannot have an inheritance clause",
+      (Identifier))
 ERROR(objc_generic_extension_using_type_parameter,none,
       "extension of a generic Objective-C class cannot access the class's "
       "generic parameters at runtime", ())
@@ -1933,33 +1934,33 @@ ERROR(witness_not_accessible_proto,none,
       "%select{%error|fileprivate|internal|public|%error}3 because it matches a "
       "requirement in %select{private|fileprivate|internal|public|%error}4 protocol "
       "%5",
-      (RequirementKind, DeclName, bool, AccessLevel, AccessLevel, DeclName))
+      (RequirementKind, DeclName, bool, AccessLevel, AccessLevel, Identifier))
 ERROR(witness_not_accessible_type,none,
       "%select{initializer %1|method %1|%select{|setter for }2property %1"
       "|subscript%select{| setter}2}0 must be as accessible as its enclosing "
       "type because it matches a requirement in protocol %5",
-      (RequirementKind, DeclName, bool, AccessLevel, AccessLevel, DeclName))
+      (RequirementKind, DeclName, bool, AccessLevel, AccessLevel, Identifier))
 ERROR(type_witness_not_accessible_proto,none,
       "%0 %1 must be declared %select{%error|fileprivate|internal|public|%error}2 "
       "because it matches a requirement in "
       "%select{%error|fileprivate|internal|public|%error}2 protocol %3",
-      (DescriptiveDeclKind, DeclName, AccessLevel, DeclName))
+      (DescriptiveDeclKind, Identifier, AccessLevel, Identifier))
 ERROR(type_witness_not_accessible_type,none,
       "%0 %1 must be as accessible as its enclosing type because it "
       "matches a requirement in protocol %3",
-      (DescriptiveDeclKind, DeclName, AccessLevel, DeclName))
+      (DescriptiveDeclKind, Identifier, AccessLevel, Identifier))
 ERROR(witness_not_usable_from_inline,none,
       "%0 %1 must be declared '@usableFromInline' "
       "because it matches a requirement in protocol %2",
-      (DescriptiveDeclKind, DeclName, DeclName))
+      (DescriptiveDeclKind, DeclName, Identifier))
 WARNING(witness_not_usable_from_inline_warn,none,
         "%0 %1 should be declared '@usableFromInline' "
         "because it matches a requirement in protocol %2",
-        (DescriptiveDeclKind, DeclName, DeclName))
+        (DescriptiveDeclKind, DeclName, Identifier))
 ERROR(type_witness_objc_generic_parameter,none,
       "type %0 involving Objective-C type parameter%select{| %1}2 cannot be "
       "used for associated type %3 of protocol %4",
-      (Type, Type, bool, DeclName, DeclName))
+      (Type, Type, bool, Identifier, Identifier))
 NOTE(witness_fix_access,none,
      "mark the %0 as '%select{%error|fileprivate|internal|public|%error}1' to "
      "satisfy the requirement", (DescriptiveDeclKind, AccessLevel))
@@ -1969,9 +1970,9 @@ NOTE(witness_move_to_another_extension,none,
      "satisfy the requirement", (DescriptiveDeclKind, AccessLevel))
 WARNING(assoc_type_default_conformance_failed,none,
         "default type %0 for associated type %1 does not satisfy constraint "
-        "%2: %3", (Type, DeclName, Type, Type))
+        "%2: %3", (Type, Identifier, Type, Type))
 NOTE(assoc_type_default_here,none,
-     "associated type %0 has default type %1 written here", (DeclName, Type))
+     "associated type %0 has default type %1 written here", (Identifier, Type))
 
 ERROR(protocol_access,none,
       "%select{protocol must be declared %select{"
@@ -2023,7 +2024,7 @@ NOTE(no_witnesses_type,none,
 NOTE(default_associated_type_req_fail,none,
      "default type %0 for associated type %1 (from protocol %2) "
      "does not %select{inherit from|conform to}4 %3",
-     (Type, DeclName, Type, Type, bool))
+     (Type, Identifier, Type, Type, bool))
 ERROR(associated_type_access,none,
       "associated type in "
       "%select{a private|a fileprivate|an internal|a public|%error}0 protocol "
@@ -2050,23 +2051,23 @@ WARNING(associated_type_not_usable_from_inline_warn,none,
 
 NOTE(bad_associated_type_deduction,none,
      "unable to infer associated type %0 for protocol %1",
-     (DeclName, DeclName))
+     (Identifier, Identifier))
 NOTE(associated_type_deduction_witness_failed,none,
      "candidate would match and infer %0 = %1 if %1 "
      "%select{inherited from|conformed to}3 %2",
-     (DeclName, Type, Type, bool))
+     (Identifier, Type, Type, bool))
 NOTE(associated_type_witness_conform_impossible,none,
      "candidate can not infer %0 = %1 because %1 "
      "is not a nominal type and so can't conform to %2",
-     (DeclName, Type, Type))
+     (Identifier, Type, Type))
 NOTE(associated_type_witness_inherit_impossible,none,
      "candidate can not infer %0 = %1 because %1 "
      "is not a class type and so can't inherit from %2",
-     (DeclName, Type, Type))
+     (Identifier, Type, Type))
 
 NOTE(ambiguous_associated_type_deduction,none,
      "ambiguous inference of associated type %0: %1 vs. %2",
-     (DeclName, Type, Type))
+     (Identifier, Type, Type))
 NOTE(associated_type_deduction_witness,none,
      "matching requirement %0 to this declaration inferred associated type to "
      "%1",
@@ -2097,12 +2098,12 @@ ERROR(err_protocol_witness_optionality,none,
       "%select{type|result|parameter|parameters|"
       "result and parameters}0 of %1 %select{has|has|has|have|have|}0"
       " different optionality than required by protocol %2",
-      (unsigned, DeclName, DeclName))
+      (unsigned, DeclName, Identifier))
 WARNING(warn_protocol_witness_optionality,none,
       "%select{type|result|parameter|parameters|"
       "result and parameters}0 of %1 %select{has|has|has|have|have|}0"
       " different optionality than expected by protocol %2",
-      (unsigned, DeclName, DeclName))
+      (unsigned, DeclName, Identifier))
 
 NOTE(protocol_witness_static_conflict,none,
      "candidate operates on %select{a type|an instance}0, not "
@@ -2136,42 +2137,42 @@ NOTE(protocol_witness_circularity,none,
 
 NOTE(protocol_conformance_here,none,
      "%select{|class }0%1 declares conformance to protocol %2 here",
-     (bool, DeclName, DeclName))
+     (bool, Identifier, Identifier))
 NOTE(declared_protocol_conformance_here,none,
      "%select{%0 inherits conformance to protocol %2 from superclass|"
      "%0 declares conformance to protocol %2|"
      "%0 implicitly conforms to protocol %2 (via conformance to %3)|"
      "%0 implicitly conforms to protocol %2}1 here",
-     (Type, unsigned, DeclName, DeclName))
+     (Type, unsigned, Identifier, Identifier))
 
 ERROR(witness_unavailable,none,
         "unavailable %0 %1 was used to satisfy a requirement of protocol %2",
-        (DescriptiveDeclKind, DeclName, DeclName))
+        (DescriptiveDeclKind, DeclName, Identifier))
 
 ERROR(redundant_conformance,none,
-      "redundant conformance of %0 to protocol %1", (Type, DeclName))
+      "redundant conformance of %0 to protocol %1", (Type, Identifier))
 ERROR(redundant_conformance_conditional,none,
       "conflicting conformance of %0 to protocol %1; there cannot be more "
       "than one conformance, even with different conditional bounds",
-      (Type, DeclName))
+      (Type, Identifier))
 WARNING(redundant_conformance_adhoc,none,
         "conformance of %0 to protocol %1 was already stated in "
         "%select{the protocol's|the type's}2 module %3",
-        (Type, DeclName, bool, Identifier))
+        (Type, Identifier, bool, Identifier))
 WARNING(redundant_conformance_adhoc_conditional,none,
         "conformance of %0 to protocol %1 conflicts with that stated in "
         "%select{the protocol's|the type's}2 module %3 and will be ignored; "
         "there cannot be more than one conformance, even with different conditional bounds",
-        (Type, DeclName, bool, Identifier))
+        (Type, Identifier, bool, Identifier))
 NOTE(redundant_conformance_witness_ignored,none,
      "%0 %1 will not be used to satisfy the conformance to %2",
-     (DescriptiveDeclKind, DeclName, DeclName))
+     (DescriptiveDeclKind, DeclName, Identifier))
 
 // "Near matches"
 WARNING(req_near_match,none,
         "%0 %1 nearly matches %select{defaulted|optional}2 requirement %3 "
         "of protocol %4",
-        (DescriptiveDeclKind, DeclName, bool, DeclName, DeclName))
+        (DescriptiveDeclKind, DeclName, bool, DeclName, Identifier))
 NOTE(optional_req_nonobjc_near_match_add_objc,none,
      "add '@objc' to provide an Objective-C entrypoint", ())
 NOTE(req_near_match_move,none,
@@ -2303,17 +2304,19 @@ NOTE(previous_same_type_constraint, none,
 
 WARNING(inherited_associated_type_redecl,none,
         "redeclaration of associated type %0 from protocol %1 is better "
-        "expressed as a 'where' clause on the protocol", (DeclName, Type))
+        "expressed as a 'where' clause on the protocol",
+        (Identifier, Type))
 WARNING(typealias_override_associated_type,none,
         "typealias overriding associated type %0 from protocol %1 is better "
-        "expressed as same-type constraint on the protocol", (DeclName, Type))
+        "expressed as same-type constraint on the protocol",
+        (Identifier, Type))
 WARNING(associated_type_override_typealias,none,
         "associated type %0 is redundant with type %0 declared in inherited "
-        "%1 %2", (DeclName, DescriptiveDeclKind, Type))
+        "%1 %2", (Identifier, DescriptiveDeclKind, Type))
 
 ERROR(associated_type_objc,none,
       "associated type %0 cannot be declared inside '@objc' protocol %1",
-      (DeclName, DeclName))
+      (Identifier, Identifier))
 
 ERROR(generic_param_access,none,
       "%0 %select{must be declared %select{"
@@ -2655,11 +2658,11 @@ ERROR(conformance_from_implementation_only_module,none,
       "in an extension with public or '@usableFromInline' members|"
       "in an extension with conditional conformances}2; %3 has been imported "
       "as implementation-only",
-      (Type, DeclName, unsigned, Identifier))
+      (Type, Identifier, unsigned, Identifier))
 ERROR(assoc_conformance_from_implementation_only_module,none,
       "cannot use conformance of %0 to %1 in associated type %3 (inferred as "
       "%4); %2 has been imported as implementation-only",
-      (Type, DeclName, Identifier, Type, Type))
+      (Type, Identifier, Identifier, Type, Type))
 ERROR(unexportable_clang_function_type,none,
       "cannot export the underlying C type of the function type %0; "
       "it may use anonymous types or types defined outside of a module",
@@ -2952,14 +2955,14 @@ ERROR(attr_for_debugger_support_only,none,
 
 // @_implements
 ERROR(implements_attr_protocol_lacks_member,none,
-      "protocol %0 has no member %1", (DeclName, DeclName))
+      "protocol %0 has no member %1", (Identifier, DeclName))
 
 ERROR(implements_attr_non_protocol_type,none,
       "non-protocol type in @_implements attribute", ())
 
 ERROR(implements_attr_protocol_not_conformed_to,none,
       "containing type %0 does not conform to protocol %1",
-      (DeclName, DeclName))
+      (Identifier, Identifier))
 
 // @differentiable
 ERROR(differentiable_attr_no_vjp_or_jvp_when_linear,none,
@@ -4041,7 +4044,7 @@ NOTE(required_initializer_here,none,
 ERROR(required_initializer_not_accessible,none,
       "'required' initializer must be accessible wherever class %0 can be "
       "subclassed",
-      (DeclName))
+      (Identifier))
 ERROR(required_initializer_missing_keyword,none,
       "'required' modifier must be present on all overrides of a required "
       "initializer", ())
@@ -4281,7 +4284,7 @@ NOTE(objc_overriding_objc_decl,none,
      "here", (unsigned, DeclName))
 NOTE(objc_witness_objc_requirement,none,
      "satisfying requirement for %0 %1 in protocol %2",
-     (DescriptiveDeclKind, DeclName, DeclName))
+     (DescriptiveDeclKind, DeclName, Identifier))
 WARNING(witness_swift3_objc_inference,none,
         "use of %0 %1 to satisfy a requirement of protocol %2 depends on "
         "'@objc' inference deprecated in Swift 4",
@@ -4348,7 +4351,7 @@ ERROR(objc_ambiguous_inference,none,
       (DescriptiveDeclKind, DeclName, ObjCSelector, ObjCSelector))
 NOTE(objc_ambiguous_inference_candidate,none,
      "%0 (in protocol %1) provides Objective-C name %2",
-     (DeclName, DeclName, ObjCSelector))
+     (DeclName, Identifier, ObjCSelector))
 
 ERROR(objc_ambiguous_error_convention,none,
       "%0 overrides or implements protocol requirements for Objective-C "
@@ -4401,7 +4404,7 @@ ERROR(objc_optional_requirement_conflict,none,
       "Objective-C method %4 provided by " OBJC_DIAG_SELECT
       " conflicts with optional requirement " OBJC_DIAG_SELECT_2
       " in protocol %5",
-      (unsigned, DeclName, unsigned, DeclName, ObjCSelector, DeclName))
+      (unsigned, DeclName, unsigned, DeclName, ObjCSelector, Identifier))
 
 NOTE(objc_optional_requirement_swift_rename,none,
      "rename %select{method|initializer|property|subscript}0 to match "
@@ -4410,22 +4413,22 @@ NOTE(objc_optional_requirement_swift_rename,none,
 ERROR(witness_non_objc,none,
       "non-'@objc' " OBJC_DIAG_SELECT " does not satisfy requirement "
       "of '@objc' protocol %2",
-      (unsigned, DeclName, DeclName))
+      (unsigned, DeclName, Identifier))
 
 WARNING(witness_non_objc_optional,none,
         "non-'@objc' " OBJC_DIAG_SELECT " does not satisfy optional "
         "requirement of '@objc' protocol %2",
-        (unsigned, DeclName, DeclName))
+        (unsigned, DeclName, Identifier))
 
 ERROR(witness_non_objc_storage,none,
       "non-'@objc' %select{property %1|subscript}0 does not satisfy "
       "requirement of '@objc' protocol %2",
-      (bool, DeclName, DeclName))
+      (bool, DeclName, Identifier))
 
 WARNING(witness_non_objc_storage_optional,none,
       "non-'@objc' %select{property %1|subscript}0 does not satisfy "
       "optional requirement of '@objc' protocol %2",
-      (bool, DeclName, DeclName))
+      (bool, DeclName, Identifier))
 
 ERROR(nonobjc_not_allowed,none,
       "declaration is %" OBJC_ATTR_SELECT "0, and cannot be marked @nonobjc",
@@ -4473,7 +4476,7 @@ ERROR(dynamic_replacement_accessor_not_found, none,
 ERROR(dynamic_replacement_accessor_ambiguous, none,
       "replaced accessor for %0 occurs in multiple places", (DeclNameRef))
 NOTE(dynamic_replacement_accessor_ambiguous_candidate, none,
-      "candidate accessor found in module %0", (DeclName))
+      "candidate accessor found in module %0", (Identifier))
 ERROR(dynamic_replacement_function_of_type_not_found, none,
       "replaced function %0 of type %1 could not be found", (DeclNameRef, Type))
 NOTE(dynamic_replacement_found_function_of_type, none,
@@ -4624,7 +4627,7 @@ ERROR(availability_stored_property_no_potential,
 
 ERROR(availability_protocol_requires_version,
       none, "protocol %0 requires %1 to be available in %2 %3 and newer",
-      (DeclName, DeclName, StringRef, llvm::VersionTuple))
+      (Identifier, DeclName, StringRef, llvm::VersionTuple))
 
 NOTE(availability_protocol_requirement_here, none,
      "protocol requirement here", ())
@@ -4689,7 +4692,7 @@ ERROR(usable_from_inline_attr_in_protocol,none,
 
 ERROR(local_type_in_inlinable_function,
       none, "type %0 cannot be nested inside " FRAGILE_FUNC_KIND "1",
-      (DeclName, unsigned))
+      (Identifier, unsigned))
 
 ERROR(resilience_decl_unavailable,
       none, DECL_OR_ACCESSOR "4 %1 is %select{private|fileprivate|internal|'@_spi'|'@_spi'}2 and "
@@ -4905,9 +4908,9 @@ ERROR(property_wrapper_ambiguous_enclosing_self_subscript, none,
 
 ERROR(property_wrapper_attribute_not_on_property, none,
       "property wrapper attribute %0 can only be applied to a property",
-      (DeclName))
+      (Identifier))
 NOTE(property_wrapper_declared_here,none,
-     "property wrapper type %0 declared here", (DeclName))
+     "property wrapper type %0 declared here", (Identifier))
 
 ERROR(property_wrapper_mutating_get_composed_to_get_only,none,
       "property wrapper %0 with a mutating getter cannot be composed inside "
@@ -4927,16 +4930,16 @@ ERROR(property_wrapper_computed, none,
 ERROR(property_with_wrapper_conflict_attribute,none,
       "property %0 with a wrapper cannot also be "
       "%select{lazy|@NSCopying|@NSManaged|weak|unowned|unmanaged}1",
-      (DeclName, int))
+      (Identifier, int))
 ERROR(property_wrapper_not_single_var, none,
       "property wrapper can only apply to a single variable", ())
 ERROR(property_with_wrapper_in_bad_context,none,
       "%select{|non-static |non-static }1property %0 declared inside "
       "%select{a protocol|an extension|an enum}1 cannot have a wrapper",
-      (DeclName, int))
+      (Identifier, int))
 ERROR(property_with_wrapper_overrides,none,
       "property %0 with attached wrapper cannot override another property",
-      (DeclName))
+      (Identifier))
 
 NOTE(property_wrapper_direct_init,none,
      "initialize the property wrapper type directly with "
@@ -4990,7 +4993,7 @@ NOTE(note_function_builder_control_flow, none,
       "builder %0", (DeclName))
 ERROR(function_builder_attribute_not_allowed_here, none,
       "function builder attribute %0 can only be applied to a parameter, "
-      "function, or computed property", (DeclName))
+      "function, or computed property", (Identifier))
 ERROR(function_builder_attribute_on_storage_without_getter, none,
       "function builder attribute %0 can only be applied to a "
       "%select{subscript|property|constant|variable}1 if it defines a getter",
@@ -4998,11 +5001,11 @@ ERROR(function_builder_attribute_on_storage_without_getter, none,
 ERROR(function_builder_parameter_not_of_function_type, none,
       "function builder attribute %0 can only be applied to a parameter of "
       "function type",
-      (DeclName))
+      (Identifier))
 ERROR(function_builder_parameter_autoclosure, none,
       "function builder attribute %0 cannot be applied to an autoclosure "
       "parameter",
-      (DeclName))
+      (Identifier))
 ERROR(function_builder_multiple, none,
       "only one function builder attribute can be attached to a "
       "%select{declaration|parameter}0", (bool))

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3907,7 +3907,7 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
 
   // Collect all of the inherited associated types and typealiases in the
   // inherited protocols (recursively).
-  llvm::MapVector<DeclName, TinyPtrVector<TypeDecl *>> inheritedTypeDecls;
+  llvm::MapVector<Identifier, TinyPtrVector<TypeDecl *>> inheritedTypeDecls;
   {
     proto->walkInheritedProtocols(
         [&](ProtocolDecl *inheritedProto) -> TypeWalker::Action {
@@ -4092,8 +4092,8 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
   // Check all remaining inherited type declarations to determine if
   // this protocol has a non-associated-type type with the same name.
   inheritedTypeDecls.remove_if(
-    [&](const std::pair<DeclName, TinyPtrVector<TypeDecl *>> &inherited) {
-      auto name = inherited.first;
+    [&](const std::pair<Identifier, TinyPtrVector<TypeDecl *>> &inherited) {
+      const auto name = inherited.first;
       for (auto found : proto->lookupDirect(name)) {
         // We only want concrete type declarations.
         auto type = dyn_cast<TypeDecl>(found);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2793,7 +2793,7 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
     if (!R) {
       diagnose(attr->getLocation(),
                diag::implements_attr_protocol_lacks_member,
-               PD->getBaseName(), attr->getMemberName())
+               PD->getName(), attr->getMemberName())
         .highlight(attr->getMemberNameLoc().getSourceRange());
     }
 


### PR DESCRIPTION
Cherry-pick #31503 to ease rebranching.

* **Expanation**: Replaces DeclName with Identifier without having to audit emission spots, so there is zero **Risk**.
* **Reviewer**: Pavel Yaskevich (@xedin)