### PR TITLE
SIL.rst: use terms 'object type' and 'address type'

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -338,11 +338,12 @@ differences.
 Legal SIL Types
 ```````````````
 
-The type of a value in SIL shall be:
+The type of a value in SIL is either:
 
-- a loadable legal SIL type, ``$T``,
+- an *object type* ``$T``, where ``T`` is a legal loadable type, or
 
-- the address of a legal SIL type, ``$*T``, or
+- an *address type* ``$*T``, where ``T`` is a legal SIL type (loadable or
+  address-only).
 
 A type ``T`` is a *legal SIL type* if:
 


### PR DESCRIPTION
Use the terms used in compiler source when introducing these concepts in the documentation.
