### PR TITLE
build: remove explicit link against `atomic`

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -348,13 +348,11 @@ function(_add_host_variant_link_flags target)
       ${CMAKE_BINARY_DIR}/winsdk_lib_${SWIFT_HOST_VARIANT_ARCH}_symlinks)
   elseif(SWIFT_HOST_VARIANT_SDK STREQUAL HAIKU)
     target_link_libraries(${target} PRIVATE
-      atomic
       bsd)
     target_link_options(${target} PRIVATE
       "SHELL:-Xlinker -Bsymbolic")
   elseif(SWIFT_HOST_VARIANT_SDK STREQUAL ANDROID)
     target_link_libraries(${target} PRIVATE
-      atomic
       dl
       log
       # We need to add the math library, which is linked implicitly by libc++


### PR DESCRIPTION
This is no longer required after the fix for the over-aligned type for
the atomic type.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
