### PR TITLE
runtime: replace `LLVM_ATTRIBUTE_ALWAYS_INLINE` with `SWIFT_INLINE` (…

### DIFF
--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -373,21 +373,17 @@ class RefCountBitsT {
   // to improve performance of debug builds.
   
   private:
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
-  bool getUseSlowRC() const {
-    return bool(getField(UseSlowRC));
-  }
+    SWIFT_ALWAYS_INLINE
+    bool getUseSlowRC() const { return bool(getField(UseSlowRC)); }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
-  void setUseSlowRC(bool value) {
-    setField(UseSlowRC, value);
-  }
+    SWIFT_ALWAYS_INLINE
+    void setUseSlowRC(bool value) { setField(UseSlowRC, value); }
 
   public:
   
   enum Immortal_t { Immortal };
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   bool isImmortal(bool checkSlowRCBit) const {
     if (checkSlowRCBit) {
       return (getField(IsImmortal) == Offsets::IsImmortalMask) &&
@@ -396,43 +392,43 @@ class RefCountBitsT {
       return (getField(IsImmortal) == Offsets::IsImmortalMask);
     }
   }
-  
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+
+  SWIFT_ALWAYS_INLINE
   bool isOverflowingUnownedRefCount(uint32_t oldValue, uint32_t inc) const {
     auto newValue = getUnownedRefCount();
     return newValue != oldValue + inc ||
       newValue == Offsets::UnownedRefCountMask;
   }
-  
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+
+  SWIFT_ALWAYS_INLINE
   void setIsImmortal(bool value) {
     assert(value);
     setField(IsImmortal, Offsets::IsImmortalMask);
     setField(UseSlowRC, value);
   }
-  
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+
+  SWIFT_ALWAYS_INLINE
   bool pureSwiftDeallocation() const {
     return bool(getField(PureSwiftDealloc)) && !bool(getField(UseSlowRC));
   }
-  
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+
+  SWIFT_ALWAYS_INLINE
   void setPureSwiftDeallocation(bool value) {
     setField(PureSwiftDealloc, value);
   }
-  
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+
+  SWIFT_ALWAYS_INLINE
   RefCountBitsT() = default;
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   constexpr
   RefCountBitsT(uint32_t strongExtraCount, uint32_t unownedCount)
     : bits((BitsType(strongExtraCount) << Offsets::StrongExtraRefCountShift) |
            (BitsType(1)                << Offsets::PureSwiftDeallocShift) |
            (BitsType(unownedCount)     << Offsets::UnownedRefCountShift))
   { }
-  
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+
+  SWIFT_ALWAYS_INLINE
   constexpr
   RefCountBitsT(Immortal_t immortal)
   : bits((BitsType(2) << Offsets::StrongExtraRefCountShift) |
@@ -440,7 +436,7 @@ class RefCountBitsT {
          (BitsType(1) << Offsets::UseSlowRCShift))
   { }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   RefCountBitsT(HeapObjectSideTableEntry* side)
     : bits((reinterpret_cast<BitsType>(side) >> Offsets::SideTableUnusedLowBits)
            | (BitsType(1) << Offsets::UseSlowRCShift)
@@ -449,7 +445,7 @@ class RefCountBitsT {
     assert(refcountIsInline);
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   RefCountBitsT(const RefCountBitsT<RefCountIsInline> *newbitsPtr) {
     bits = 0;
 
@@ -472,8 +468,8 @@ class RefCountBitsT {
       copyFieldFrom(newbits, UseSlowRC);
     }
   }
-  
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+
+  SWIFT_ALWAYS_INLINE
   bool hasSideTable() const {
     bool hasSide = getUseSlowRC() && !isImmortal(false);
 
@@ -484,7 +480,7 @@ class RefCountBitsT {
     return hasSide;
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   HeapObjectSideTableEntry *getSideTable() const {
     assert(hasSideTable());
 
@@ -493,32 +489,31 @@ class RefCountBitsT {
       (uintptr_t(getField(SideTable)) << Offsets::SideTableUnusedLowBits);
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   uint32_t getUnownedRefCount() const {
     assert(!hasSideTable());
     return uint32_t(getField(UnownedRefCount));
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   bool getIsDeiniting() const {
     assert(!hasSideTable());
     return bool(getField(IsDeiniting));
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   uint32_t getStrongExtraRefCount() const {
     assert(!hasSideTable());
     return uint32_t(getField(StrongExtraRefCount));
   }
 
-
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   void setHasSideTable(bool value) {
     bits = 0;
     setUseSlowRC(value);
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   void setSideTable(HeapObjectSideTableEntry *side) {
     assert(hasSideTable());
     // Stored value is a shifted pointer.
@@ -529,19 +524,19 @@ class RefCountBitsT {
     setField(SideTableMark, 1);
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   void setUnownedRefCount(uint32_t value) {
     assert(!hasSideTable());
     setField(UnownedRefCount, value);
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   void setIsDeiniting(bool value) {
     assert(!hasSideTable());
     setField(IsDeiniting, value);
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   void setStrongExtraRefCount(uint32_t value) {
     assert(!hasSideTable());
     setField(StrongExtraRefCount, value);
@@ -551,8 +546,8 @@ class RefCountBitsT {
   // Returns true if the increment is a fast-path result.
   // Returns false if the increment should fall back to some slow path
   // (for example, because UseSlowRC is set or because the refcount overflowed).
-  LLVM_NODISCARD LLVM_ATTRIBUTE_ALWAYS_INLINE
-  bool incrementStrongExtraRefCount(uint32_t inc) {
+  LLVM_NODISCARD SWIFT_ALWAYS_INLINE bool
+  incrementStrongExtraRefCount(uint32_t inc) {
     // This deliberately overflows into the UseSlowRC field.
     bits += BitsType(inc) << Offsets::StrongExtraRefCountShift;
     return (SignedBitsType(bits) >= 0);
@@ -562,8 +557,8 @@ class RefCountBitsT {
   // Returns false if the decrement should fall back to some slow path
   // (for example, because UseSlowRC is set
   // or because the refcount is now zero and should deinit).
-  LLVM_NODISCARD LLVM_ATTRIBUTE_ALWAYS_INLINE
-  bool decrementStrongExtraRefCount(uint32_t dec) {
+  LLVM_NODISCARD SWIFT_ALWAYS_INLINE bool
+  decrementStrongExtraRefCount(uint32_t dec) {
 #ifndef NDEBUG
     if (!hasSideTable() && !isImmortal(false)) {
       // Can't check these assertions with side table present.
@@ -583,19 +578,19 @@ class RefCountBitsT {
   }
 
   // Returns the old reference count before the increment.
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   uint32_t incrementUnownedRefCount(uint32_t inc) {
     uint32_t old = getUnownedRefCount();
     setUnownedRefCount(old + inc);
     return old;
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   void decrementUnownedRefCount(uint32_t dec) {
     setUnownedRefCount(getUnownedRefCount() - dec);
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   bool isUniquelyReferenced() {
     static_assert(Offsets::UnownedRefCountBitCount +
                   Offsets::IsDeinitingBitCount +
@@ -614,7 +609,7 @@ class RefCountBitsT {
       !getUseSlowRC() && !getIsDeiniting() && getStrongExtraRefCount() == 0;
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   BitsType getBitsValue() {
     return bits;
   }
@@ -636,45 +631,41 @@ class alignas(sizeof(void*) * 2) SideTableRefCountBits : public RefCountBitsT<Re
   uint32_t weakBits;
 
   public:
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
-  SideTableRefCountBits() = default;
+    SWIFT_ALWAYS_INLINE
+    SideTableRefCountBits() = default;
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
-  constexpr
-  SideTableRefCountBits(uint32_t strongExtraCount, uint32_t unownedCount)
-    : RefCountBitsT<RefCountNotInline>(strongExtraCount, unownedCount)
-    // weak refcount starts at 1 on behalf of the unowned count
-    , weakBits(1)
-  { }
+    SWIFT_ALWAYS_INLINE
+    constexpr SideTableRefCountBits(uint32_t strongExtraCount,
+                                    uint32_t unownedCount)
+        : RefCountBitsT<RefCountNotInline>(strongExtraCount, unownedCount)
+          // weak refcount starts at 1 on behalf of the unowned count
+          ,
+          weakBits(1) {}
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
-  SideTableRefCountBits(HeapObjectSideTableEntry* side) = delete;
+    SWIFT_ALWAYS_INLINE
+    SideTableRefCountBits(HeapObjectSideTableEntry *side) = delete;
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
-  SideTableRefCountBits(InlineRefCountBits newbits)
-    : RefCountBitsT<RefCountNotInline>(&newbits), weakBits(1)
-  { }
+    SWIFT_ALWAYS_INLINE
+    SideTableRefCountBits(InlineRefCountBits newbits)
+        : RefCountBitsT<RefCountNotInline>(&newbits), weakBits(1) {}
 
-  
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
-  void incrementWeakRefCount() {
-    weakBits++;
+    SWIFT_ALWAYS_INLINE
+    void incrementWeakRefCount() { weakBits++; }
+
+    SWIFT_ALWAYS_INLINE
+    bool decrementWeakRefCount() {
+      assert(weakBits > 0);
+      weakBits--;
+      return weakBits == 0;
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
-  bool decrementWeakRefCount() {
-    assert(weakBits > 0);
-    weakBits--;
-    return weakBits == 0;
-  }
-
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   uint32_t getWeakRefCount() {
     return weakBits;
   }
 
   // Side table ref count never has a side table of its own.
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   bool hasSideTable() {
     return false;
   }
@@ -882,22 +873,22 @@ class RefCounts {
 
   // Decrement the reference count.
   // Return true if the caller should now deinit the object.
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   bool decrementShouldDeinit(uint32_t dec) {
     return doDecrement<DontPerformDeinit>(dec);
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   bool decrementShouldDeinitNonAtomic(uint32_t dec) {
     return doDecrementNonAtomic<DontPerformDeinit>(dec);
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   void decrementAndMaybeDeinit(uint32_t dec) {
     doDecrement<DoPerformDeinit>(dec);
   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  SWIFT_ALWAYS_INLINE
   void decrementAndMaybeDeinitNonAtomic(uint32_t dec) {
     doDecrementNonAtomic<DoPerformDeinit>(dec);
   }
@@ -1472,9 +1463,9 @@ class HeapObjectSideTableEntry {
 // This version can actually be non-atomic.
 template <>
 template <PerformDeinit performDeinit>
-LLVM_ATTRIBUTE_ALWAYS_INLINE
-inline bool RefCounts<InlineRefCountBits>::doDecrementNonAtomic(uint32_t dec) {
-  
+SWIFT_ALWAYS_INLINE inline bool
+RefCounts<InlineRefCountBits>::doDecrementNonAtomic(uint32_t dec) {
+
   // We can get away without atomicity here.
   // The caller claims that there are no other threads with strong references 
   // to this object.

--- a/stdlib/public/runtime/AnyHashableSupport.cpp
+++ b/stdlib/public/runtime/AnyHashableSupport.cpp
@@ -10,15 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/Runtime/Config.h"
+#include "../SwiftShims/Visibility.h"
+#include "Private.h"
+#include "SwiftHashableSupport.h"
+#include "SwiftValue.h"
 #include "swift/Basic/Lazy.h"
+#include "swift/Runtime/Casting.h"
 #include "swift/Runtime/Concurrent.h"
+#include "swift/Runtime/Config.h"
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/HeapObject.h"
-#include "swift/Runtime/Casting.h"
-#include "Private.h"
-#include "SwiftValue.h"
-#include "SwiftHashableSupport.h"
 
 using namespace swift;
 using namespace swift::hashable_support;
@@ -72,9 +73,9 @@ struct HashableConformanceEntry {
 static ConcurrentMap<HashableConformanceEntry, /*Destructor*/ false>
   HashableConformances;
 
-template<bool KnownToConformToHashable>
-LLVM_ATTRIBUTE_ALWAYS_INLINE
-static const Metadata *findHashableBaseTypeImpl(const Metadata *type) {
+template <bool KnownToConformToHashable>
+SWIFT_ALWAYS_INLINE static const Metadata *
+findHashableBaseTypeImpl(const Metadata *type) {
   // Check the cache first.
   if (HashableConformanceEntry *entry =
           HashableConformances.find(HashableConformanceKey{type})) {

--- a/stdlib/public/runtime/Exclusivity.cpp
+++ b/stdlib/public/runtime/Exclusivity.cpp
@@ -14,12 +14,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+// NOTE: This should really be applied in the CMakeLists.txt.  However, we do
+// not have a way to currently specify that at the target specific level yet.
+#if defined(_WIN32)
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
+#define VCEXTRALEAN
+#endif
+
+#include "swift/Runtime/Exclusivity.h"
+#include "../SwiftShims/Visibility.h"
+#include "ThreadLocalStorage.h"
 #include "swift/Basic/Lazy.h"
 #include "swift/Runtime/Config.h"
 #include "swift/Runtime/Debug.h"
-#include "swift/Runtime/Exclusivity.h"
 #include "swift/Runtime/Metadata.h"
-#include "ThreadLocalStorage.h"
 #include <memory>
 #include <stdio.h>
 
@@ -46,7 +55,7 @@ static const char *getAccessName(ExclusivityFlags flags) {
   }
 }
 
-LLVM_ATTRIBUTE_ALWAYS_INLINE
+SWIFT_ALWAYS_INLINE
 static void reportExclusivityConflict(ExclusivityFlags oldAction, void *oldPC,
                                       ExclusivityFlags newFlags, void *newPC,
                                       void *pointer) {

--- a/stdlib/public/runtime/WeakReference.h
+++ b/stdlib/public/runtime/WeakReference.h
@@ -17,10 +17,11 @@
 #ifndef SWIFT_RUNTIME_WEAKREFERENCE_H
 #define SWIFT_RUNTIME_WEAKREFERENCE_H
 
+#include "../../../stdlib/public/SwiftShims/Target.h"
+#include "../SwiftShims/Visibility.h"
 #include "swift/Runtime/Config.h"
 #include "swift/Runtime/HeapObject.h"
 #include "swift/Runtime/Metadata.h"
-#include "../../../stdlib/public/SwiftShims/Target.h"
 
 #if SWIFT_OBJC_INTEROP
 #include "swift/Runtime/ObjCBridge.h"
@@ -119,37 +120,36 @@ class WeakReferenceBits {
   uintptr_t bits;
 
  public:
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
-  WeakReferenceBits() { }
+   SWIFT_ALWAYS_INLINE
+   WeakReferenceBits() {}
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
-  WeakReferenceBits(HeapObjectSideTableEntry *newValue) {
-    setNativeOrNull(newValue);
-  }
+   SWIFT_ALWAYS_INLINE
+   WeakReferenceBits(HeapObjectSideTableEntry *newValue) {
+     setNativeOrNull(newValue);
+   }
 
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
-  bool isNativeOrNull() const {
-    return bits == 0  ||  (bits & NativeMarkerMask) == NativeMarkerValue;
-  }
-    
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
-  HeapObjectSideTableEntry *getNativeOrNull() const {
-    assert(isNativeOrNull());
-    if (bits == 0)
-      return nullptr;
-    else
-      return
-        reinterpret_cast<HeapObjectSideTableEntry *>(bits & ~NativeMarkerMask);
-  }
-  
-  LLVM_ATTRIBUTE_ALWAYS_INLINE
-  void setNativeOrNull(HeapObjectSideTableEntry *newValue) {
-    assert((uintptr_t(newValue) & NativeMarkerMask) == 0);
-    if (newValue)
-      bits = uintptr_t(newValue) | NativeMarkerValue;
-    else
-      bits = 0;
-  }
+   SWIFT_ALWAYS_INLINE
+   bool isNativeOrNull() const {
+     return bits == 0 || (bits & NativeMarkerMask) == NativeMarkerValue;
+   }
+
+   SWIFT_ALWAYS_INLINE
+   HeapObjectSideTableEntry *getNativeOrNull() const {
+     assert(isNativeOrNull());
+     if (bits == 0)
+       return nullptr;
+     return reinterpret_cast<HeapObjectSideTableEntry *>(bits &
+                                                         ~NativeMarkerMask);
+   }
+
+   SWIFT_ALWAYS_INLINE
+   void setNativeOrNull(HeapObjectSideTableEntry *newValue) {
+     assert((uintptr_t(newValue) & NativeMarkerMask) == 0);
+     if (newValue)
+       bits = uintptr_t(newValue) | NativeMarkerValue;
+     else
+       bits = 0;
+   }
 };
 
 


### PR DESCRIPTION
…NFC)

This replaces the `LLVM_ATTRIBUTE_ALWAYS_INLINE` with `SWIFT_INLINE`
which is equivalent but namespaced to Swift instead.  This reduces the
unnecessary reliance on LLVMSupport.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
