### PR TITLE
Runtime: simplify `SWIFT_LIBRARY_VISIBILITY`

### DIFF
--- a/stdlib/public/SwiftShims/Visibility.h
+++ b/stdlib/public/SwiftShims/Visibility.h
@@ -116,19 +116,6 @@
 #endif
 
 
-#ifndef SWIFT_GNUC_PREREQ
-# if defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__)
-#  define SWIFT_GNUC_PREREQ(maj, min, patch) \
-    ((__GNUC__ << 20) + (__GNUC_MINOR__ << 10) + __GNUC_PATCHLEVEL__ >= \
-     ((maj) << 20) + ((min) << 10) + (patch))
-# elif defined(__GNUC__) && defined(__GNUC_MINOR__)
-#  define SWIFT_GNUC_PREREQ(maj, min, patch) \
-    ((__GNUC__ << 20) + (__GNUC_MINOR__ << 10) >= ((maj) << 20) + ((min) << 10))
-# else
-#  define SWIFT_GNUC_PREREQ(maj, min, patch) 0
-# endif
-#endif
-
 /// Attributes for runtime-stdlib interfaces.
 /// Use these for C implementations that are imported into Swift via SwiftShims
 /// and for C implementations of Swift @_silgen_name declarations
@@ -151,9 +138,8 @@
 
 // Match the definition of LLVM_LIBRARY_VISIBILITY from LLVM's
 // Compiler.h. That header requires C++ and this needs to work in C.
-#if (__has_attribute(visibility) || SWIFT_GNUC_PREREQ(4, 0, 0)) &&              \
-    !defined(__MINGW32__) && !defined(__CYGWIN__) && !defined(_WIN32)
-#define SWIFT_LIBRARY_VISIBILITY __attribute__ ((visibility("hidden")))
+#if __has_attribute(visibility) && (defined(__ELF__) || defined(__MACH__))
+#define SWIFT_LIBRARY_VISIBILITY __attribute__ ((__visibility__("hidden")))
 #else
 #define SWIFT_LIBRARY_VISIBILITY
 #endif


### PR DESCRIPTION
This removes the GNUC version check as the runtime does require ABI
support which is not present in GCC.  Remove the unnecessary check and
simplify the condition by checking the file format that the visibility
attribute is being applied to and limit it to the ones supporting it.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
