### PR TITLE
[5.3][CodeCompletion] Make getEquivalentDeclContextFromSourceFile safer

### DIFF
--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -100,7 +100,7 @@ static DeclContext *getEquivalentDeclContextFromSourceFile(DeclContext *DC,
     if (!D)
       return nullptr;
     auto *parentDC = newDC->getParent();
-    unsigned N;
+    unsigned N = ~0U;
 
     if (auto accessor = dyn_cast<AccessorDecl>(D)) {
       // The AST for accessors is like:
@@ -140,7 +140,7 @@ static DeclContext *getEquivalentDeclContextFromSourceFile(DeclContext *DC,
   newDC = SF;
   do {
     auto N = IndexStack.pop_back_val();
-    Decl *D;
+    Decl *D = nullptr;
     if (auto parentSF = dyn_cast<SourceFile>(newDC))
       D = getElementAt(parentSF->getTopLevelDecls(), N);
     else if (auto parentIDC = dyn_cast<IterableDeclContext>(newDC->getAsDecl()))
@@ -148,14 +148,14 @@ static DeclContext *getEquivalentDeclContextFromSourceFile(DeclContext *DC,
     else
       llvm_unreachable("invalid DC kind for finding equivalent DC (query)");
 
-    if (auto storage = dyn_cast<AbstractStorageDecl>(D)) {
+    if (auto storage = dyn_cast_or_null<AbstractStorageDecl>(D)) {
       if (IndexStack.empty())
         return nullptr;
       auto accessorN = IndexStack.pop_back_val();
       D = getElementAt(storage->getAllAccessors(), accessorN);
     }
 
-    newDC = dyn_cast<DeclContext>(D);
+    newDC = dyn_cast_or_null<DeclContext>(D);
     if (!newDC)
       return nullptr;
   } while (!IndexStack.empty());
@@ -354,7 +354,7 @@ bool CompletionInstance::performCachedOperationIfPossible(
 
     DeclContext *DC =
         getEquivalentDeclContextFromSourceFile(newInfo.ParentContext, oldSF);
-    if (!DC)
+    if (!DC || !isa<AbstractFunctionDecl>(DC))
       return false;
 
     // OK, we can perform fast completion for this. Update the orignal delayed


### PR DESCRIPTION
Cherry-pick of #31561 into `release/5.3`

* **Explanation**: Fix a crash by adding null pointer guards in fast-completion.
* **Scope**: Code completions inside function bodies
* **Risk**: Very low. Just adding pointer checks.
* **Issue**: rdar://problem/62893219
* **Testing**: Since we haven't been able to reproduce the crash, no test cases are added. It passes existing test suite
* **Reviewer**: Ben Langmuir (@benlangmuir )