### PR TITLE
[CSGen] Allow typed pattern to propagate its type to sub-pattern

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2277,10 +2277,13 @@ namespace {
             getTypeForPattern(
               cast<VarPattern>(pattern)->getSubPattern(), locator,
               externalPatternType, bindPatternVarsOneWay));
+
       case PatternKind::Any: {
         return setType(
-            CS.createTypeVariable(CS.getConstraintLocator(locator),
-                                  TVO_CanBindToNoEscape));
+            externalPatternType
+                ? externalPatternType
+                : CS.createTypeVariable(CS.getConstraintLocator(locator),
+                                        TVO_CanBindToNoEscape));
       }
 
       case PatternKind::Named: {
@@ -2382,7 +2385,7 @@ namespace {
         Type subPatternType = getTypeForPattern(
             subPattern,
             locator.withPathElement(LocatorPathElt::PatternMatch(subPattern)),
-            Type(), bindPatternVarsOneWay);
+            openedType, bindPatternVarsOneWay);
 
         CS.addConstraint(
             ConstraintKind::Conversion, subPatternType, openedType,


### PR DESCRIPTION
Currently we always generate a new type variable for any pattern
(represented as `_` in the source), but in cases where it's a
sub-pattern of a typed pattern e.g. `let _: Foo = ...` it makes
more sense to pass a type to it directly otherwise type variable
allocated for any pattern gets disconnected from the rest of
the constraint system.
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
