### PR TITLE
[5.3] Fix module triples for “ios-like” Mac Catalyst modules

### DIFF
--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -362,13 +362,13 @@ function(_compile_swift_files
       )
 
   # Determine the subdirectory where the binary should be placed.
-  compute_library_subdir(library_subdir
-      "${SWIFTFILE_SDK}" "${SWIFTFILE_ARCHITECTURE}")
-
+  set(library_subdir_sdk "${SWIFTFILE_SDK}")
   if(maccatalyst_build_flavor STREQUAL "ios-like")
-  	compute_library_subdir(library_subdir
-      "MACCATALYST" "${SWIFTFILE_ARCHITECTURE}")
+    set(library_subdir_sdk "MACCATALYST")
   endif()
+
+  compute_library_subdir(library_subdir
+    "${library_subdir_sdk}" "${SWIFTFILE_ARCHITECTURE}")
 
   # If we have a custom module cache path, use it.
   if (SWIFT_MODULE_CACHE_PATH)
@@ -464,7 +464,7 @@ function(_compile_swift_files
     list(APPEND swift_flags "-parse-as-library")
 
     set(module_base "${module_dir}/${SWIFTFILE_MODULE_NAME}")
-    set(module_triple ${SWIFT_SDK_${SWIFTFILE_SDK}_ARCH_${SWIFTFILE_ARCHITECTURE}_MODULE})
+    set(module_triple ${SWIFT_SDK_${library_subdir_sdk}_ARCH_${SWIFTFILE_ARCHITECTURE}_MODULE})
     if(SWIFTFILE_SDK IN_LIST SWIFT_APPLE_PLATFORMS OR
        SWIFTFILE_SDK STREQUAL "MACCATALYST")
       set(specific_module_dir "${module_base}.swiftmodule")


### PR DESCRIPTION
Cherry-picks #31394 to 5.3 branch:

> The “ios-like” build flavor is used to build modules that do not exist on macOS for Mac Catalyst. Even though they are built for the “OSX” SDK, they need to have a “MACCATALYST”-style module triple; unfortunately, the transition to naming swiftmodules by module triple in #31170 did not handle this edge case correctly.
>
> This commit handles that by piggybacking on a similar special case used to change the lib/swift subdirectory.

Fixes rdar://62902611.
