### PR TITLE
[utils/build-parser-lib] Fixes for building the parser library

### DIFF
--- a/utils/build-parser-lib
+++ b/utils/build-parser-lib
@@ -234,7 +234,7 @@ class Builder(object):
             "-DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=FALSE",
             "-DSWIFT_BUILD_STATIC_SDK_OVERLAY=FALSE",
         ]
-        cmake_args += ["-DLLVM_ENABLE_LIBXML2=FALSE"]
+        cmake_args += ["-DLLVM_ENABLE_LIBXML2=FALSE", "-DLLVM_ENABLE_LIBEDIT=FALSE"]
         # We are not using cmark but initialize the CMARK variables to something so
         # that configure can succeed.
         cmake_args += [
@@ -246,7 +246,7 @@ class Builder(object):
             "-DCLANG_INCLUDE_TESTS=FALSE",
             "-DSWIFT_INCLUDE_TESTS=FALSE",
         ]
-        cmake_args += [os.path.join(SWIFT_SOURCE_ROOT, "llvm")]
+        cmake_args += [os.path.join(SWIFT_SOURCE_ROOT, "llvm-project", "llvm")]
         self.call(cmake_args)
 
     def build_target(self, build_dir, target, env=None):
@@ -448,6 +448,17 @@ def main():
 
     if not args.install_destdir:
         args.install_destdir = os.path.join(args.build_dir, "install")
+
+    swift_src_path = os.path.join(SWIFT_SOURCE_ROOT, "swift")
+    swift_src_in_llvm_project_path = \
+        os.path.join(SWIFT_SOURCE_ROOT, "llvm-project", "swift")
+    # Need to symlink 'swift' into 'llvm-project' since we will be doing
+    # a unified configure with 'swift' as an external project.
+    if not os.path.exists(swift_src_in_llvm_project_path):
+        print("Symlinking '%s' to '%s'" %
+              (swift_src_path, swift_src_in_llvm_project_path), file=sys.stderr)
+        shell.symlink(swift_src_path, swift_src_in_llvm_project_path,
+                      dry_run=args.dry_run, echo=args.verbose)
 
     architectures = args.architectures.split(" ")
     architectures = [arch for arch in architectures if arch != ""]

--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -195,6 +195,15 @@ def copytree(src, dest, dry_run=None, echo=True):
     shutil.copytree(src, dest)
 
 
+def symlink(source, dest, dry_run=None, echo=True):
+    dry_run = _coerce_dry_run(dry_run)
+    if dry_run or echo:
+        _echo_command(dry_run, ['ln', '-s', source, dest])
+    if dry_run:
+        return
+    os.symlink(source, dest)
+
+
 # Initialized later
 lock = None
 


### PR DESCRIPTION
* Need to symlink 'swift' into 'llvm-project' since we are doing a unified configure with 'swift' as an external project.
* Need to set "-DLLVM_ENABLE_LIBEDIT=FALSE" to get iOS builds working again