### PR TITLE
Remove XFAIL on class_resilience_objc.swift test

### DIFF
--- a/test/IRGen/class_resilience_objc.swift
+++ b/test/IRGen/class_resilience_objc.swift
@@ -7,7 +7,6 @@
 //   The test is cloned as class_resilience_objc_armv7k.swift for them.
 // XFAIL: CPU=armv7k
 // XFAIL: CPU=arm64_32
-// XFAIL: CPU=arm64e
 // REQUIRES: objc_interop
 
 import Foundation


### PR DESCRIPTION
Apparently this test passes now