### PR TITLE
runtime: replace `LLVM_LIBRARY_VISIBILITY` with `SWIFT_LIBRARY_VISIBI…

### DIFF
--- a/stdlib/private/StdlibUnittest/InspectValue.cpp
+++ b/stdlib/private/StdlibUnittest/InspectValue.cpp
@@ -15,11 +15,9 @@
 
 using namespace swift;
 
-SWIFT_CC(swift) LLVM_LIBRARY_VISIBILITY extern "C"
-const char *getMetadataKindOf(
-    OpaqueValue *value,
-    const Metadata *type
-) {
+SWIFT_CC(swift)
+SWIFT_LIBRARY_VISIBILITY extern "C" const
+    char *getMetadataKindOf(OpaqueValue *value, const Metadata *type) {
   switch (type->getKind()) {
 #define METADATAKIND(NAME, VALUE) \
   case MetadataKind::NAME: return #NAME;
@@ -28,4 +26,3 @@ const char *getMetadataKindOf(
   default: return "none of your business";
   }
 }
-

--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -182,7 +182,7 @@ namespace swift {
 }
 
 // FIXME: HACK: copied from HeapObject.cpp
-extern "C" LLVM_LIBRARY_VISIBILITY LLVM_ATTRIBUTE_NOINLINE LLVM_ATTRIBUTE_USED
+extern "C" SWIFT_LIBRARY_VISIBILITY LLVM_ATTRIBUTE_NOINLINE LLVM_ATTRIBUTE_USED
 void _swift_release_dealloc(swift::HeapObject *object);
 
 namespace swift {

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -255,7 +255,7 @@ void swift::printCurrentBacktrace(unsigned framesToSkip) {
 // The layout of this struct is CrashReporter ABI, so there are no ABI concerns
 // here.
 extern "C" {
-LLVM_LIBRARY_VISIBILITY
+SWIFT_LIBRARY_VISIBILITY
 struct crashreporter_annotations_t gCRAnnotations
 __attribute__((__section__("__DATA," CRASHREPORTER_ANNOTATIONS_SECTION))) = {
     CRASHREPORTER_ANNOTATIONS_VERSION, 0, 0, 0, 0, 0, 0, 0};

--- a/stdlib/public/runtime/ExistentialMetadataImpl.h
+++ b/stdlib/public/runtime/ExistentialMetadataImpl.h
@@ -25,13 +25,11 @@ namespace swift {
 namespace metadataimpl {
 
 /// A common base class for opaque-existential and class-existential boxes.
-template<typename Impl>
-struct LLVM_LIBRARY_VISIBILITY ExistentialBoxBase {
-};
+template <typename Impl> struct SWIFT_LIBRARY_VISIBILITY ExistentialBoxBase {};
 
 /// A common base class for fixed and non-fixed opaque-existential box
 /// implementations.
-struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBoxBase
+struct SWIFT_LIBRARY_VISIBILITY OpaqueExistentialBoxBase
     : ExistentialBoxBase<OpaqueExistentialBoxBase> {
   template <class Container, class... A>
   static void destroy(Container *value, A... args) {
@@ -290,7 +288,7 @@ struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBoxBase
 /// witness tables.  Note that the WitnessTables field is accessed via
 /// spooky action from Header.
 template <unsigned NumWitnessTables>
-struct LLVM_LIBRARY_VISIBILITY FixedOpaqueExistentialContainer {
+struct SWIFT_LIBRARY_VISIBILITY FixedOpaqueExistentialContainer {
   OpaqueExistentialContainer Header;
   const void *WitnessTables[NumWitnessTables];
 };
@@ -304,7 +302,7 @@ struct FixedOpaqueExistentialContainer<0> {
 /// A box implementation class for an opaque existential type with
 /// a fixed number of witness tables.
 template <unsigned NumWitnessTables>
-struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBox
+struct SWIFT_LIBRARY_VISIBILITY OpaqueExistentialBox
     : OpaqueExistentialBoxBase {
   struct Container : FixedOpaqueExistentialContainer<NumWitnessTables> {
     const Metadata *getType() const {
@@ -346,7 +344,7 @@ struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBox
 
 /// A non-fixed box implementation class for an opaque existential
 /// type with a dynamic number of witness tables.
-struct LLVM_LIBRARY_VISIBILITY NonFixedOpaqueExistentialBox
+struct SWIFT_LIBRARY_VISIBILITY NonFixedOpaqueExistentialBox
     : OpaqueExistentialBoxBase {
   struct Container {
     OpaqueExistentialContainer Header;
@@ -400,7 +398,7 @@ struct LLVM_LIBRARY_VISIBILITY NonFixedOpaqueExistentialBox
 
 /// A common base class for fixed and non-fixed class-existential box
 /// implementations.
-struct LLVM_LIBRARY_VISIBILITY ClassExistentialBoxBase
+struct SWIFT_LIBRARY_VISIBILITY ClassExistentialBoxBase
     : ExistentialBoxBase<ClassExistentialBoxBase> {
   static constexpr unsigned numExtraInhabitants =
     swift_getHeapObjectExtraInhabitantCount();
@@ -462,14 +460,12 @@ struct LLVM_LIBRARY_VISIBILITY ClassExistentialBoxBase
     return swift_getHeapObjectExtraInhabitantIndex(
                                   (HeapObject* const *) src->getValueSlot()) + 1;
   }
-  
 };
 
 /// A box implementation class for an existential container with
 /// a class constraint and a fixed number of protocol witness tables.
 template <unsigned NumWitnessTables>
-struct LLVM_LIBRARY_VISIBILITY ClassExistentialBox
-    : ClassExistentialBoxBase {
+struct SWIFT_LIBRARY_VISIBILITY ClassExistentialBox : ClassExistentialBoxBase {
   struct Container {
     ClassExistentialContainer Header;
     const void *TypeInfo[NumWitnessTables];
@@ -495,7 +491,7 @@ struct LLVM_LIBRARY_VISIBILITY ClassExistentialBox
 
 /// A non-fixed box implementation class for a class existential
 /// type with a dynamic number of witness tables.
-struct LLVM_LIBRARY_VISIBILITY NonFixedClassExistentialBox
+struct SWIFT_LIBRARY_VISIBILITY NonFixedClassExistentialBox
     : ClassExistentialBoxBase {
   struct Container {
     ClassExistentialContainer Header;
@@ -532,7 +528,7 @@ struct LLVM_LIBRARY_VISIBILITY NonFixedClassExistentialBox
 
 /// A common base class for fixed and non-fixed existential metatype box
 /// implementations.
-struct LLVM_LIBRARY_VISIBILITY ExistentialMetatypeBoxBase
+struct SWIFT_LIBRARY_VISIBILITY ExistentialMetatypeBoxBase
     : ExistentialBoxBase<ExistentialMetatypeBoxBase> {
   static constexpr unsigned numExtraInhabitants =
     swift_getHeapObjectExtraInhabitantCount();
@@ -591,7 +587,7 @@ struct LLVM_LIBRARY_VISIBILITY ExistentialMetatypeBoxBase
 /// A box implementation class for an existential metatype container
 /// with a fixed number of protocol witness tables.
 template <unsigned NumWitnessTables>
-struct LLVM_LIBRARY_VISIBILITY ExistentialMetatypeBox
+struct SWIFT_LIBRARY_VISIBILITY ExistentialMetatypeBox
     : ExistentialMetatypeBoxBase {
   struct Container {
     ExistentialMetatypeContainer Header;
@@ -618,7 +614,7 @@ struct LLVM_LIBRARY_VISIBILITY ExistentialMetatypeBox
 
 /// A non-fixed box implementation class for an existential metatype
 /// type with a dynamic number of witness tables.
-struct LLVM_LIBRARY_VISIBILITY NonFixedExistentialMetatypeBox
+struct SWIFT_LIBRARY_VISIBILITY NonFixedExistentialMetatypeBox
     : ExistentialMetatypeBoxBase {
   struct Container {
     ExistentialMetatypeContainer Header;

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -327,7 +327,7 @@ HeapObject *swift::swift_allocEmptyBox() {
 }
 
 // Forward-declare this, but define it after swift_release.
-extern "C" LLVM_LIBRARY_VISIBILITY LLVM_ATTRIBUTE_NOINLINE LLVM_ATTRIBUTE_USED 
+extern "C" SWIFT_LIBRARY_VISIBILITY LLVM_ATTRIBUTE_NOINLINE LLVM_ATTRIBUTE_USED
 void _swift_release_dealloc(HeapObject *object);
 
 static HeapObject *_swift_retain_(HeapObject *object) {

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -192,10 +192,10 @@ public:
   }
 #endif
 
-  LLVM_LIBRARY_VISIBILITY
+  SWIFT_LIBRARY_VISIBILITY
   const ClassMetadata *_swift_getClass(const void *object);
 
-  LLVM_LIBRARY_VISIBILITY
+  SWIFT_LIBRARY_VISIBILITY
   bool usesNativeSwiftReferenceCounting(const ClassMetadata *theClass);
 
   static inline


### PR DESCRIPTION
…LITY` (NFC)

This replaces `LLVM_LIBRARY_VISIBILITY` with `SWIFT_LIBRARY_VISIBILTIY`
througout the runtime.  The purpose of this attribution is unclear -
building with `-fvisibility=hidden` would accomplish this.  This is an
entirely mechanical change replacing the macro with the Swift namespaced
variant instead.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
