### PR TITLE
[docs] Fix link in UnsupportedOptimizationAttributes.rst.

### DIFF
--- a/docs/proposals/UnsupportedOptimizationAttributes.rst
+++ b/docs/proposals/UnsupportedOptimizationAttributes.rst
@@ -16,7 +16,7 @@ requiring manual intervention of the source maintainer.
 -----------------
 
 Force inlining (at least at -O for now). See the discussion in
-:ref:`transparent-attribute`.
+docs/TransparentAttr.md.
 
 @_specialize directs the compiler to specialize generics
 --------------------------------------------------------


### PR DESCRIPTION
`docs/TransparentAttr.rst` was recently rewritten as `docs/TransparentAttr.md`: https://github.com/apple/swift/commit/00b46f3653057a5ddd633fb1a8b6af8e12bbccb6
Update old link to `docs/TransparentAttr.rst`.

Fixes Sphinx doc generation:
```
Warning, treated as error:
swift/docs/proposals/UnsupportedOptimizationAttributes.rst:18:undefined label: transparent-attribute (if the link has no caption the label must precede a section header)
```