### PR TITLE
[ownership] Change the ownership verifier textual error dumper to emit error counts on a per function instead of global basis.

### DIFF
--- a/test/SIL/ownership-verifier/arguments.sil
+++ b/test/SIL/ownership-verifier/arguments.sil
@@ -31,6 +31,8 @@ struct NativeObjectPair {
 // CHECK: Non trivial values, non address values, and non guaranteed function args must have at least one lifetime ending use?!
 // CHECK: Value: %2 = argument of bb1 : $Builtin.NativeObject
 // CHECK: Error#: 1. End Error in Function: 'no_end_borrow_error'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'no_end_borrow_error'
 sil [ossa] @no_end_borrow_error : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   br bb1(%0 : $Builtin.NativeObject)
@@ -40,18 +42,20 @@ bb1(%1 : @guaranteed $Builtin.NativeObject):
   return %9999 : $()
 }
 
-// CHECK-LABEL: Error#: 2. Begin Error in Function: 'leak_along_path'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'leak_along_path'
 // CHECK: Guaranteed function parameter with life ending uses!
 // CHECK: Value: %0 = argument of bb0 : $Builtin.NativeObject
 // CHECK: Lifetime Ending User:   br bb1(%0 : $Builtin.NativeObject)
-// CHECK: Error#: 2. End Error in Function: 'leak_along_path'
+// CHECK: Error#: 0. End Error in Function: 'leak_along_path'
 //
-// CHECK-LABEL: Error#: 3. Begin Error in Function: 'leak_along_path'
+// CHECK-LABEL: Error#: 1. Begin Error in Function: 'leak_along_path'
 // CHECK: Error! Found a leak due to a consuming post-dominance failure!
 // CHECK: Value: %2 = argument of bb1 : $Builtin.NativeObject
 // CHECK: Post Dominating Failure Blocks:
 // CHECK: bb3
-// CHECK: Error#: 3. End Error in Function: 'leak_along_path'
+// CHECK: Error#: 1. End Error in Function: 'leak_along_path'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'leak_along_path'
 sil [ossa] @leak_along_path : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   br bb1(%0 : $Builtin.NativeObject)
@@ -68,12 +72,14 @@ bb3:
   return %9999 : $()
 }
 
-// CHECK-LABEL: Error#: 4. Begin Error in Function: 'leak_along_path_2'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'leak_along_path_2'
 // CHECK: Error! Found a leak due to a consuming post-dominance failure!
 // CHECK: Value: %3 = argument of bb1 : $Builtin.NativeObject
 // CHECK: Post Dominating Failure Blocks:
 // CHECK: bb3
-// CHECK: Error#: 4. End Error in Function: 'leak_along_path_2'
+// CHECK: Error#: 0. End Error in Function: 'leak_along_path_2'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'leak_along_path_2'
 sil [ossa] @leak_along_path_2 : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -94,27 +100,29 @@ bb3:
 // Make sure that we only flag the subargument leak and not the parent
 // argument. Also check for over consuming due to phi nodes.
 //
-// CHECK-LABEL: Error#: 5. Begin Error in Function: 'leak_along_subarg_path'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'leak_along_subarg_path'
 // CHECK: Guaranteed function parameter with life ending uses!
 // CHECK: Value: %0 = argument of bb0 : $Builtin.NativeObject
 // CHECK: Lifetime Ending User:   br bb1(%0 : $Builtin.NativeObject)
-// CHECK: Error#: 5. End Error in Function: 'leak_along_subarg_path'
+// CHECK: Error#: 0. End Error in Function: 'leak_along_subarg_path'
 //
-// CHECK-LABEL: Error#: 6. Begin Error in Function: 'leak_along_subarg_path'
+// CHECK-LABEL: Error#: 1. Begin Error in Function: 'leak_along_subarg_path'
 // CHECK: Found over consume?!
 // CHECK: Value: %2 = argument of bb1 : $Builtin.NativeObject
 // CHECK: Block: bb2
 // CHECK: Consuming Users:
 // CHECK:   br bb3(%2 : $Builtin.NativeObject)
 // CHECK:   end_borrow %2 : $Builtin.NativeObject
-// CHECK: Error#: 6. End Error in Function: 'leak_along_subarg_path'
+// CHECK: Error#: 1. End Error in Function: 'leak_along_subarg_path'
 //
-// CHECK-LABEL: Error#: 7. Begin Error in Function: 'leak_along_subarg_path'
+// CHECK-LABEL: Error#: 2. Begin Error in Function: 'leak_along_subarg_path'
 // CHECK: Error! Found a leak due to a consuming post-dominance failure!
 // CHECK: Value: %5 = argument of bb3 : $Builtin.NativeObject
 // CHECK: Post Dominating Failure Blocks:
 // CHECK: bb5
-// CHECK: Error#: 7. End Error in Function: 'leak_along_subarg_path'
+// CHECK: Error#: 2. End Error in Function: 'leak_along_subarg_path'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'leak_along_subarg_path'
 sil [ossa] @leak_along_subarg_path : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   br bb1(%0 : $Builtin.NativeObject)
@@ -138,12 +146,14 @@ bb5:
   return %9999 : $()
 }
 
-// CHECK-LABEL: Error#: 8. Begin Error in Function: 'leak_along_subarg_path_2'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'leak_along_subarg_path_2'
 // CHECK: Error! Found a leak due to a consuming post-dominance failure!
 // CHECK: Value: %7 = argument of bb3 : $Builtin.NativeObject
 // CHECK: Post Dominating Failure Blocks:
 // CHECK: bb5
-// CHECK: Error#: 8. End Error in Function: 'leak_along_subarg_path_2'
+// CHECK: Error#: 0. End Error in Function: 'leak_along_subarg_path_2'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'leak_along_subarg_path_2'
 sil [ossa] @leak_along_subarg_path_2 : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -226,23 +236,25 @@ bb5:
 
 // Make sure that we only flag the end_borrow "use after free" in bb2.
 //
-// CHECK-LABEL: Error#: 9. Begin Error in Function: 'bad_order'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'bad_order'
 // CHECK: Found use after free?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
 // CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject
 // CHECK: Block: bb2
-// CHECK: Error#: 9. End Error in Function: 'bad_order'
+// CHECK: Error#: 0. End Error in Function: 'bad_order'
 //
 // TODO: Should we really flag this twice?
 //
-// CHECK-LABEL: Error#: 10. Begin Error in Function: 'bad_order'
+// CHECK-LABEL: Error#: 1. Begin Error in Function: 'bad_order'
 // CHECK: Found use after free due to unvisited non lifetime ending uses?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
 // CHECK: Remaining Users:
 // CHECK: User:  end_borrow %5 : $Builtin.NativeObject
 // CHECK: Block: bb2
-// CHECK: Error#: 10. End Error in Function: 'bad_order'
+// CHECK: Error#: 1. End Error in Function: 'bad_order'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'bad_order'
 sil [ossa] @bad_order : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -270,15 +282,15 @@ bb5:
   br bb4
 }
 
-// CHECK-LABEL: Error#: 11. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'bad_order_add_a_level'
 // CHECK: Found use after free?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
 // CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject
 // CHECK: Block: bb2
-// CHECK: Error#: 11. End Error in Function: 'bad_order_add_a_level'
+// CHECK: Error#: 0. End Error in Function: 'bad_order_add_a_level'
 //
-// CHECK-LABEL: Error#: 12. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK-LABEL: Error#: 1. Begin Error in Function: 'bad_order_add_a_level'
 // CHECK: Found over consume?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %19, %14, %6, %3
 // CHECK: User:   end_borrow %1 : $Builtin.NativeObject           // id: %14
@@ -287,27 +299,27 @@ bb5:
 // CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %6
 // CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %14
 // CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %19
-// CHECK: Error#: 12. End Error in Function: 'bad_order_add_a_level'
+// CHECK: Error#: 1. End Error in Function: 'bad_order_add_a_level'
 //
-// CHECK-LABEL: Error#: 13. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK-LABEL: Error#: 2. Begin Error in Function: 'bad_order_add_a_level'
 // CHECK: Error! Found a leak due to a consuming post-dominance failure!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %19, %14, %6, %3
 // CHECK: Post Dominating Failure Blocks:
 // CHECK: bb3
-// CHECK: Error#: 13. End Error in Function: 'bad_order_add_a_level'
+// CHECK: Error#: 2. End Error in Function: 'bad_order_add_a_level'
 //
 // This error is a "use after free" error b/c we are accessing the argument
 // /after/ we end the parent borrow. We /could/ improve the error message here.
 //
-// CHECK-LABEL: Error#: 14. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK-LABEL: Error#: 3. Begin Error in Function: 'bad_order_add_a_level'
 // CHECK: Found use after free due to unvisited non lifetime ending uses?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %19, %14, %6, %3
 // CHECK: Remaining Users:
 // CHECK: User:  end_borrow %5 : $Builtin.NativeObject           // id: %7
 // CHECK: Block: bb2
-// CHECK: Error#: 14. End Error in Function: 'bad_order_add_a_level'
+// CHECK: Error#: 3. End Error in Function: 'bad_order_add_a_level'
 //
-// CHECK-LABEL: Error#: 15. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK-LABEL: Error#: 4. Begin Error in Function: 'bad_order_add_a_level'
 // CHECK: Found over consume?!
 // CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %13, %9, %7
 // CHECK: User:   end_borrow %5 : $Builtin.NativeObject           // id: %13
@@ -315,27 +327,29 @@ bb5:
 // CHECK: Consuming Users:
 // CHECK:   end_borrow %5 : $Builtin.NativeObject           // id: %7
 // CHECK:   end_borrow %5 : $Builtin.NativeObject           // id: %13
-// CHECK: Error#: 15. End Error in Function: 'bad_order_add_a_level'
+// CHECK: Error#: 4. End Error in Function: 'bad_order_add_a_level'
 //
-// CHECK-LABEL: Error#: 16. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK-LABEL: Error#: 5. Begin Error in Function: 'bad_order_add_a_level'
 // CHECK: Error! Found a leak due to a consuming post-dominance failure!
 // CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %13, %9, %7
 // CHECK: Post Dominating Failure Blocks:
 // CHECK: bb3
-// CHECK: Error#: 16. End Error in Function: 'bad_order_add_a_level'
+// CHECK: Error#: 5. End Error in Function: 'bad_order_add_a_level'
 //
-// CHECK-LABEL: Error#: 17. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK-LABEL: Error#: 6. Begin Error in Function: 'bad_order_add_a_level'
 // CHECK: Found use after free due to unvisited non lifetime ending uses?!
 // CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %13, %9, %7
 // CHECK: Remaining Users:
 // CHECK: User:  %9 = begin_borrow %5 : $Builtin.NativeObject    // user: %10
 // CHECK: Block: bb3
-// CHECK: Error#: 17. End Error in Function: 'bad_order_add_a_level'
+// CHECK: Error#: 6. End Error in Function: 'bad_order_add_a_level'
 //
-// CHECK-LABEL: Error#: 18. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK-LABEL: Error#: 7. Begin Error in Function: 'bad_order_add_a_level'
 // CHECK: Non trivial values, non address values, and non guaranteed function args must have at least one lifetime ending use?!
 // CHECK: Value: %11 = argument of bb4 : $Builtin.NativeObject
-// CHECK: Error#: 18. End Error in Function: 'bad_order_add_a_level'
+// CHECK: Error#: 7. End Error in Function: 'bad_order_add_a_level'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'bad_order_add_a_level'
 sil [ossa] @bad_order_add_a_level : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -379,31 +393,31 @@ bb7:
 // improper uses.
 //
 //
-// CHECK-LABEL: Error#: 19. Begin Error in Function: 'bad_order_add_a_level_2'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'bad_order_add_a_level_2'
 // CHECK: Found use after free?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %22, %16, %12, %6, %3
 // CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject           // id: %6
 // CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %7
 // CHECK: Block: bb2
-// CHECK: Error#: 19. End Error in Function: 'bad_order_add_a_level_2'
+// CHECK: Error#: 0. End Error in Function: 'bad_order_add_a_level_2'
 //
-// CHECK-LABEL: Error#: 20. Begin Error in Function: 'bad_order_add_a_level_2'
+// CHECK-LABEL: Error#: 1. Begin Error in Function: 'bad_order_add_a_level_2'
 // CHECK: Found use after free?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %22, %16, %12, %6, %3
 // CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject           // id: %12
 // CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %13
 // CHECK: Block: bb4
-// CHECK: Error#: 20. End Error in Function: 'bad_order_add_a_level_2'
+// CHECK: Error#: 1. End Error in Function: 'bad_order_add_a_level_2'
 //
-// CHECK-LABEL: Error#: 21. Begin Error in Function: 'bad_order_add_a_level_2'
+// CHECK-LABEL: Error#: 2. Begin Error in Function: 'bad_order_add_a_level_2'
 // CHECK: Found use after free?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %22, %16, %12, %6, %3
 // CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject           // id: %16
 // CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %17
 // CHECK: Block: bb5
-// CHECK: Error#: 21. End Error in Function: 'bad_order_add_a_level_2'
+// CHECK: Error#: 2. End Error in Function: 'bad_order_add_a_level_2'
 //
-// CHECK-LABEL: Error#: 22. Begin Error in Function: 'bad_order_add_a_level_2'
+// CHECK-LABEL: Error#: 3. Begin Error in Function: 'bad_order_add_a_level_2'
 // CHECK: Found over consume?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %22, %16, %12, %6, %3
 // CHECK: User:   end_borrow %1 : $Builtin.NativeObject           // id: %16
@@ -413,11 +427,11 @@ bb7:
 // CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %12
 // CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %16
 // CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %22
-// CHECK: Error#: 22. End Error in Function: 'bad_order_add_a_level_2'
+// CHECK: Error#: 3. End Error in Function: 'bad_order_add_a_level_2'
 //
 // This comes from the dataflow, but we already actually identified this error.
 //
-// CHECK-LABEL: Error#: 23. Begin Error in Function: 'bad_order_add_a_level_2'
+// CHECK-LABEL: Error#: 4. Begin Error in Function: 'bad_order_add_a_level_2'
 // CHECK: Found over consume?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %22, %16, %12, %6, %3
 // CHECK: Block: bb2
@@ -426,36 +440,36 @@ bb7:
 // CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %12
 // CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %16
 // CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %22
-// CHECK: Error#: 23. End Error in Function: 'bad_order_add_a_level_2'
+// CHECK: Error#: 4. End Error in Function: 'bad_order_add_a_level_2'
 //
 // These are handled via other checks.
 //
-// CHECK-LABEL: Error#: 24. Begin Error in Function: 'bad_order_add_a_level_2'
+// CHECK-LABEL: Error#: 5. Begin Error in Function: 'bad_order_add_a_level_2'
 // CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
-// CHECK: Error#: 24. End Error in Function: 'bad_order_add_a_level_2'
+// CHECK: Error#: 5. End Error in Function: 'bad_order_add_a_level_2'
 //
-// CHECK-LABEL: Error#: 25. Begin Error in Function: 'bad_order_add_a_level_2'
+// CHECK-LABEL: Error#: 6. Begin Error in Function: 'bad_order_add_a_level_2'
 // CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
-// CHECK: Error#: 25. End Error in Function: 'bad_order_add_a_level_2'
+// CHECK: Error#: 6. End Error in Function: 'bad_order_add_a_level_2'
 //
-// CHECK-LABEL: Error#: 26. Begin Error in Function: 'bad_order_add_a_level_2'
+// CHECK-LABEL: Error#: 7. Begin Error in Function: 'bad_order_add_a_level_2'
 // CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
-// CHECK: Error#: 26. End Error in Function: 'bad_order_add_a_level_2'
+// CHECK: Error#: 7. End Error in Function: 'bad_order_add_a_level_2'
 //
-// CHECK-LABEL: Error#: 27. Begin Error in Function: 'bad_order_add_a_level_2'
+// CHECK-LABEL: Error#: 8. Begin Error in Function: 'bad_order_add_a_level_2'
 // CHECK-NEXT: Found use after free?!
 // CHECK-NEXT: Value: %5 = argument of bb2 : $Builtin.NativeObject
 // CHECK-NEXT: Consuming User:   end_borrow %5 : $Builtin.NativeObject
 // CHECK-NEXT: Non Consuming User:   end_borrow %11 : $Builtin.NativeObject
 // CHECK-NEXT: Block: bb4
-// CHECK: Error#: 27. End Error in Function: 'bad_order_add_a_level_2'
+// CHECK: Error#: 8. End Error in Function: 'bad_order_add_a_level_2'
 //
-// CHECK-LABEL: Error#: 28. Begin Error in Function: 'bad_order_add_a_level_2'
+// CHECK-LABEL: Error#: 9. Begin Error in Function: 'bad_order_add_a_level_2'
 // CHECK-NEXT: Found over consume?!
 // CHECK-NEXT: Value: %5 = argument of bb2 : $Builtin.NativeObject
 // CHECK-NEXT: User:   end_borrow %5 : $Builtin.NativeObject
 // CHECK-NEXT: Block: bb2
-// CHECK: Error#: 28. End Error in Function: 'bad_order_add_a_level_2'
+// CHECK: Error#: 9. End Error in Function: 'bad_order_add_a_level_2'
 //
 // NOTE: There are 2-3 errors here we are not pattern matching. We should add
 // patterns for them so we track if they are changed.
@@ -498,18 +512,20 @@ bb7:
   br bb6
 }
 
-// CHECK-LABEL: Error#: 31. Begin Error in Function: 'owned_argument_overuse_br1'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'owned_argument_overuse_br1'
 // CHECK-NEXT: Found over consume?!
 // CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject
 // CHECK-NEXT: User:   destroy_value %0 : $Builtin.NativeObject
 // CHECK-NEXT: Block: bb0
-// CHECK: Error#: 31. End Error in Function: 'owned_argument_overuse_br1'
+// CHECK: Error#: 0. End Error in Function: 'owned_argument_overuse_br1'
 //
-// CHECK-LABEL: Error#: 32. Begin Error in Function: 'owned_argument_overuse_br1'
+// CHECK-LABEL: Error#: 1. Begin Error in Function: 'owned_argument_overuse_br1'
 // CHECK-NEXT: Error! Found a leaked owned value that was never consumed.
 // CHECK-NEXT: Value: %3 = argument of bb1 : $Builtin.NativeObject
 // CHECK-NOT: Block
-// CHECK: Error#: 32. End Error in Function: 'owned_argument_overuse_br1'
+// CHECK: Error#: 1. End Error in Function: 'owned_argument_overuse_br1'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'owned_argument_overuse_br1'
 sil [ossa] @owned_argument_overuse_br1 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   destroy_value %0 : $Builtin.NativeObject
@@ -520,13 +536,15 @@ bb1(%1 : @owned $Builtin.NativeObject):
   return %9999 : $()
 }
 
-// CHECK-LABEL: Error#: 33. Begin Error in Function: 'owned_argument_overuse_br2'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'owned_argument_overuse_br2'
 // CHECK-NEXT: Found over consume?!
 // CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject
 // CHECK-NEXT: User:   destroy_value %0 : $Builtin.NativeObject
 // CHECK-NEXT: Block: bb0
 // CHECK-NOT: Block
-// CHECK: Error#: 33. End Error in Function: 'owned_argument_overuse_br2'
+// CHECK: Error#: 0. End Error in Function: 'owned_argument_overuse_br2'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'owned_argument_overuse_br2'
 sil [ossa] @owned_argument_overuse_br2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   destroy_value %0 : $Builtin.NativeObject
@@ -545,11 +563,13 @@ bb1(%1 : @owned $Builtin.NativeObject):
 // Make sure that we error due to the struct_extract. We require end_borrows to
 // be on the original borrowed value.
 //
-// CHECK-LABEL: Error#: 34. Begin Error in Function: 'simple_non_postdominating_diamond_with_forwarding_uses'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_non_postdominating_diamond_with_forwarding_uses'
 // CHECK-NEXT: Invalid End Borrow!
 // CHECK-NEXT: Original Value:   %5 = begin_borrow %1 : $NativeObjectPair        // user: %6
 // CHECK-NEXT: End Borrow:   br bb3(%6 : $Builtin.NativeObject)              // id: %7
-// CHECK: Error#: 34. End Error in Function: 'simple_non_postdominating_diamond_with_forwarding_uses'
+// CHECK: Error#: 0. End Error in Function: 'simple_non_postdominating_diamond_with_forwarding_uses'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_non_postdominating_diamond_with_forwarding_uses'
 sil [ossa] @simple_non_postdominating_diamond_with_forwarding_uses : $@convention(thin) (@in_guaranteed Builtin.NativeObject, @guaranteed NativeObjectPair) -> () {
 bb0(%0 : $*Builtin.NativeObject, %1 : @guaranteed $NativeObjectPair):
   cond_br undef, bb1, bb2
@@ -576,14 +596,16 @@ bb3(%7 : @guaranteed $Builtin.NativeObject):
 // TODO: If we ever add simple support for this, we should make sure that we
 // error on %0.
 //
-// CHECK-LABEL: Error#: 35. Begin Error in Function: 'simple_loop_carry_borrow_owned_arg'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_loop_carry_borrow_owned_arg'
 // CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
 // CHECK-NEXT: User:   br bb1(%3 : $Builtin.NativeObject)              // id: %6
 // CHECK-NEXT: Initial: BorrowScopeOperand:
 // CHECK-NEXT: Kind: BeginBorrow
 // CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // users: %7, %1
 // CHECK-NEXT: User:   %1 = begin_borrow %0 : $Builtin.NativeObject    // user: %2
-// CHECK: Error#: 35. End Error in Function: 'simple_loop_carry_borrow_owned_arg'
+// CHECK: Error#: 0. End Error in Function: 'simple_loop_carry_borrow_owned_arg'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_loop_carry_borrow_owned_arg'
 sil [ossa] @simple_loop_carry_borrow_owned_arg : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -613,14 +635,16 @@ bb3:
 // terminator? This works for load_borrow, but not for copy_value +
 // begin_borrow.
 //
-// CHECK-LABEL: Error#: 36. Begin Error in Function: 'simple_loop_carry_implicitregularusers_do_not_loop_carry'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_loop_carry_implicitregularusers_do_not_loop_carry'
 // CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
 // CHECK-NEXT: Value:   %8 = copy_value %4 : $Builtin.NativeObject      // users: %12, %9
 // CHECK-NEXT:     Remaining Users:
 // CHECK-NEXT: User:   %9 = begin_borrow %8 : $Builtin.NativeObject    // user: %12
 // CHECK-NEXT: User:   end_borrow %4 : $Builtin.NativeObject           // id: %13
 // CHECK-NEXT: User:   end_borrow %4 : $Builtin.NativeObject           // id: %10
-// CHECK: Error#: 36. End Error in Function: 'simple_loop_carry_implicitregularusers_do_not_loop_carry'
+// CHECK: Error#: 0. End Error in Function: 'simple_loop_carry_implicitregularusers_do_not_loop_carry'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_loop_carry_implicitregularusers_do_not_loop_carry'
 sil [ossa] @simple_loop_carry_implicitregularusers_do_not_loop_carry : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1a = begin_borrow %0 : $Builtin.NativeObject
@@ -649,7 +673,7 @@ bb3:
 
 // We should identify bb0a as consuming the value twice.
 //
-// CHECK-LABEL: Error#: 37. Begin Error in Function: 'simple_loop_carry_over_consume'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_loop_carry_over_consume'
 // CHECK-NEXT: Found over consume?!
 // CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %3, %3
 // CHECK-NEXT: User:   br bb2(%1 : $Builtin.NativeObject, %1 : $Builtin.NativeObject) // id: %3
@@ -657,23 +681,25 @@ bb3:
 // CHECK-NEXT: Consuming Users:
 // CHECK-NEXT:   br bb2(%1 : $Builtin.NativeObject, %1 : $Builtin.NativeObject) // id: %3
 // CHECK-NEXT:   br bb2(%1 : $Builtin.NativeObject, %1 : $Builtin.NativeObject) // id: %3
-// CHECK: Error#: 37. End Error in Function: 'simple_loop_carry_over_consume'
+// CHECK: Error#: 0. End Error in Function: 'simple_loop_carry_over_consume'
 //
-// CHECK-LABEL: Error#: 38. Begin Error in Function: 'simple_loop_carry_over_consume'
+// CHECK-LABEL: Error#: 1. Begin Error in Function: 'simple_loop_carry_over_consume'
 // CHECK: Found use after free?!
 // CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %11, %10, %8
 // CHECK: Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
 // CHECK: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject           // id: %12
 // CHECK: Block: bb5
-// CHECK: Error#: 38. End Error in Function: 'simple_loop_carry_over_consume'
+// CHECK: Error#: 1. End Error in Function: 'simple_loop_carry_over_consume'
 //
-// CHECK-LABEL: Error#: 39. Begin Error in Function: 'simple_loop_carry_over_consume'
+// CHECK-LABEL: Error#: 2. Begin Error in Function: 'simple_loop_carry_over_consume'
 // CHECK: Found use after free due to unvisited non lifetime ending uses?!
 // CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %11, %10, %8
 // CHECK: Remaining Users:
 // CHECK: User:  end_borrow %4 : $Builtin.NativeObject           // id: %12
 // CHECK: Block: bb5
-// CHECK: Error#: 39. End Error in Function: 'simple_loop_carry_over_consume'
+// CHECK: Error#: 2. End Error in Function: 'simple_loop_carry_over_consume'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_loop_carry_over_consume'
 sil [ossa] @simple_loop_carry_over_consume : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -700,14 +726,16 @@ bb3:
   return %9999 : $()
 }
 
-// CHECK-LABEL: Error#: 40. Begin Error in Function: 'simple_loop_carry_cycle'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_loop_carry_cycle'
 // CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
 // CHECK-NEXT: User:   br bb1(%3 : $Builtin.NativeObject)              // id: %6
 // CHECK-NEXT: Initial: BorrowScopeOperand:
 // CHECK-NEXT: Kind: BeginBorrow
 // CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // user: %1
 // CHECK-NEXT: User:   %1 = begin_borrow %0 : $Builtin.NativeObject    // user: %2
-// CHECK: Error#: 40. End Error in Function: 'simple_loop_carry_cycle'
+// CHECK: Error#: 0. End Error in Function: 'simple_loop_carry_cycle'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_loop_carry_cycle'
 sil [ossa] @simple_loop_carry_cycle : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -732,21 +760,23 @@ bb3:
 // terminator. So the end_borrow of %2a in bb3 is considered a liveness use of
 // %2 due to it consuming %3 via the loop carry.
 //
-// CHECK-LABEL: Error#: 41. Begin Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
 // CHECK-NEXT: Found use after free?!
 // CHECK-NEXT: Value: %5 = argument of bb1 : $Builtin.NativeObject      // users: %11, %10, %8
 // CHECK-NEXT: Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
 // CHECK-NEXT: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject           // id: %12
 // CHECK-NEXT: Block: bb4
-// CHECK: Error#: 41. End Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
+// CHECK: Error#: 0. End Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
 //
-// CHECK-LABEL: Error#: 42. Begin Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
+// CHECK-LABEL: Error#: 1. Begin Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
 // CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
 // CHECK-NEXT: Value: %5 = argument of bb1 : $Builtin.NativeObject      // users: %11, %10, %8
 // CHECK-NEXT:     Remaining Users:
 // CHECK-NEXT: User:  end_borrow %4 : $Builtin.NativeObject           // id: %12
 // CHECK-NEXT: Block: bb4
-// CHECK: Error#: 42. End Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
+// CHECK: Error#: 1. End Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
 sil [ossa] @simple_loop_carry_borrows_do_not_loop_carry : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -774,23 +804,25 @@ bb3:
 // We could potentially support this in the future if we wanted to have some
 // sort of support for phi node loops.
 //
-// CHECK-LABEL: Error#: 43. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop'
 // CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
 // CHECK-NEXT: User:   br bb1(%6 : $Builtin.NativeObject, %5 : $Builtin.NativeObject) // id: %9
 // CHECK-NEXT: Initial: BorrowScopeOperand:
 // CHECK-NEXT: Kind: BeginBorrow
 // CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %12, %3, %2
 // CHECK-NEXT: User:   %2 = begin_borrow %1 : $Builtin.NativeObject    // user: %4
-// CHECK: Error#: 43. End Error in Function: 'simple_validate_enclosing_borrow_around_loop'
+// CHECK: Error#: 0. End Error in Function: 'simple_validate_enclosing_borrow_around_loop'
 //
-// CHECK-LABEL: Error#: 44. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop'
+// CHECK-LABEL: Error#: 1. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop'
 // CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
 // CHECK-NEXT: User:   br bb1(%6 : $Builtin.NativeObject, %5 : $Builtin.NativeObject) // id: %9
 // CHECK-NEXT: Initial: BorrowScopeOperand:
 // CHECK-NEXT: Kind: BeginBorrow
 // CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %12, %3, %2
 // CHECK-NEXT: User:   %3 = begin_borrow %1 : $Builtin.NativeObject    // user: %4
-// CHECK: Error#: 44. End Error in Function: 'simple_validate_enclosing_borrow_around_loop'
+// CHECK: Error#: 1. End Error in Function: 'simple_validate_enclosing_borrow_around_loop'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_validate_enclosing_borrow_around_loop'
 sil [ossa] @simple_validate_enclosing_borrow_around_loop : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -817,23 +849,25 @@ bb3:
 
 // Make sure we detect this phi cycle.
 //
-// CHECK-LABEL: Error#: 45. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop_2'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop_2'
 // CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
 // CHECK-NEXT: User:   br bb1(%5 : $Builtin.NativeObject, %4 : $Builtin.NativeObject) // id: %8
 // CHECK-NEXT: Initial: BorrowScopeOperand:
 // CHECK-NEXT: Kind: BeginBorrow
 // CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // users: %2, %1
 // CHECK-NEXT: User:   %1 = begin_borrow %0 : $Builtin.NativeObject    // user: %3
-// CHECK: Error#: 45. End Error in Function: 'simple_validate_enclosing_borrow_around_loop_2'
+// CHECK: Error#: 0. End Error in Function: 'simple_validate_enclosing_borrow_around_loop_2'
 //
-// CHECK-LABEL: Error#: 46. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop_2'
+// CHECK-LABEL: Error#: 1. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop_2'
 // CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
 // CHECK-NEXT: User:   br bb1(%5 : $Builtin.NativeObject, %4 : $Builtin.NativeObject) // id: %8
 // CHECK-NEXT: Initial: BorrowScopeOperand:
 // CHECK-NEXT: Kind: BeginBorrow
 // CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // users: %2, %1
 // CHECK-NEXT: User:   %2 = begin_borrow %0 : $Builtin.NativeObject    // user: %3
-// CHECK: Error#: 46. End Error in Function: 'simple_validate_enclosing_borrow_around_loop_2'
+// CHECK: Error#: 1. End Error in Function: 'simple_validate_enclosing_borrow_around_loop_2'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_validate_enclosing_borrow_around_loop_2'
 sil [ossa] @simple_validate_enclosing_borrow_around_loop_2 : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %2 = begin_borrow %0 : $Builtin.NativeObject
@@ -858,23 +892,25 @@ bb3:
 
 // Same as before, but this time with an owned value as a base.
 //
-// CHECK-LABEL: Error#: 47. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop_3'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop_3'
 // CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
 // CHECK-NEXT: User:   br bb1(%5 : $Builtin.NativeObject, %4 : $Builtin.NativeObject) // id: %8
 // CHECK-NEXT: Initial: BorrowScopeOperand:
 // CHECK-NEXT: Kind: BeginBorrow
 // CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // users: %11, %2, %1
 // CHECK-NEXT: User:   %2 = begin_borrow %0 : $Builtin.NativeObject    // user: %3
-// CHECK: Error#: 47. End Error in Function: 'simple_validate_enclosing_borrow_around_loop_3'
+// CHECK: Error#: 0. End Error in Function: 'simple_validate_enclosing_borrow_around_loop_3'
 //
-// CHECK-LABEL: Error#: 48. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop_3'
+// CHECK-LABEL: Error#: 1. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop_3'
 // CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
 // CHECK-NEXT: User:   br bb1(%5 : $Builtin.NativeObject, %4 : $Builtin.NativeObject) // id: %8
 // CHECK-NEXT: Initial: BorrowScopeOperand:
 // CHECK-NEXT: Kind: BeginBorrow
 // CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // users: %11, %2, %1
 // CHECK-NEXT: User:   %1 = begin_borrow %0 : $Builtin.NativeObject    // user: %3
-// CHECK: Error#: 48. End Error in Function: 'simple_validate_enclosing_borrow_around_loop_3'
+// CHECK: Error#: 1. End Error in Function: 'simple_validate_enclosing_borrow_around_loop_3'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_validate_enclosing_borrow_around_loop_3'
 sil [ossa] @simple_validate_enclosing_borrow_around_loop_3 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %2 = begin_borrow %0 : $Builtin.NativeObject
@@ -897,7 +933,3 @@ bb3:
   %9999 = tuple()
   return %9999 : $()
 }
-
-// We are only expecting 48 errors in this file.
-//
-// CHECK-NOT: Error#: 49

--- a/test/SIL/ownership-verifier/leaks.sil
+++ b/test/SIL/ownership-verifier/leaks.sil
@@ -21,6 +21,8 @@ import Builtin
 // CHECK: Error! Found a leaked owned value that was never consumed.
 // CHECK: Value:   %1 = copy_value %0 : $Builtin.NativeObject
 // CHECK: Error#: 0. End Error in Function: 'owned_never_consumed'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]+}}. End Error in Function: 'owned_never_consumed'
 sil [ossa] @owned_never_consumed : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = copy_value %0 : $Builtin.NativeObject
@@ -28,12 +30,14 @@ bb0(%0 : @guaranteed $Builtin.NativeObject):
   return %9999 : $()
 }
 
-// CHECK-LABEL: Error#: 1. Begin Error in Function: 'owned_leaks_along_one_path'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'owned_leaks_along_one_path'
 // CHECK: Error! Found a leak due to a consuming post-dominance failure!
 // CHECK:     Value: %0 = argument of bb0 : $Builtin.NativeObject
 // CHECK:     Post Dominating Failure Blocks:
 // CHECK:         bb1
-// CHECK: Error#: 1. End Error in Function: 'owned_leaks_along_one_path'
+// CHECK: Error#: 0. End Error in Function: 'owned_leaks_along_one_path'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]+}}. End Error in Function: 'owned_leaks_along_one_path'
 sil [ossa] @owned_leaks_along_one_path : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   cond_br undef, bb1, bb2
@@ -51,10 +55,12 @@ bb3:
 }
 
 // Make sure that we report the leak at the phi.
-// CHECK-LABEL: Error#: 2. Begin Error in Function: 'owned_leaks_with_phi'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'owned_leaks_with_phi'
 // CHECK: Error! Found a leaked owned value that was never consumed.
 // CHECK: Value: %6 = argument of bb4 : $Builtin.NativeObject
-// CHECK: Error#: 2. End Error in Function: 'owned_leaks_with_phi'
+// CHECK: Error#: 0. End Error in Function: 'owned_leaks_with_phi'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]+}}. End Error in Function: 'owned_leaks_with_phi'
 sil [ossa] @owned_leaks_with_phi : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   br bb1(%0 : $Builtin.NativeObject)

--- a/test/SIL/ownership-verifier/subobject_borrowing.sil
+++ b/test/SIL/ownership-verifier/subobject_borrowing.sil
@@ -73,17 +73,14 @@ bb0(%0 : @owned $B):
 // sure that our special handling code for subobjects here does not stop us from
 // detecting violations of ownership kinds on the subobjects.
 //
-// CHECK-LABEL: Error#: 1. Begin Error in Function: 'value_subobject_with_destroy_of_subobject'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'value_subobject_with_destroy_of_subobject'
 // CHECK: Have operand with incompatible ownership?!
 // CHECK: Value:   %5 = tuple_extract %4 : $(Builtin.NativeObject, Builtin.NativeObject), 1
 // CHECK: User:   destroy_value %5 : $Builtin.NativeObject
 // CHECK: Conv: guaranteed
-// CHECK: Error#: 1. End Error in Function: 'value_subobject_with_destroy_of_subobject'
+// CHECK: Error#: 0. End Error in Function: 'value_subobject_with_destroy_of_subobject'
 //
-// Make sure we only see one failure here. We should process recursively from
-// the borrow root, not from each of the subobjects of the borrow.
-// CHECK-NOT: Error#: 2. Begin Error in Function: 'value_subobject_with_destroy_of_subobject'
-//
+// CHECK-NOT: Error#: {{[0-9][0-9]+}}. Begin Error in Function: 'value_subobject_with_destroy_of_subobject'
 sil [ossa] @value_subobject_with_destroy_of_subobject : $@convention(thin) (@owned B) -> () {
 bb0(%0 : @owned $B):
   %1 = begin_borrow %0 : $B
@@ -98,13 +95,15 @@ bb0(%0 : @owned $B):
   return %9999 : $()
 }
 
-// CHECK-LABEL: Error#: 2. Begin Error in Function: 'value_different_subobject_kinds_multiple_levels'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'value_different_subobject_kinds_multiple_levels'
 // CHECK: Found use after free?!
 // CHECK: Value:   %1 = begin_borrow %0 : $B
 // CHECK: Consuming User:   end_borrow %1 : $B
 // CHECK: Non Consuming User:   %6 = tuple_extract %4 : $(Builtin.NativeObject, Builtin.NativeObject), 1
 // CHECK: Block: bb0
-// CHECK: Error#: 2. End Error in Function: 'value_different_subobject_kinds_multiple_levels'
+// CHECK: Error#: 0. End Error in Function: 'value_different_subobject_kinds_multiple_levels'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]+}}. End Error in Function: 'value_different_subobject_kinds_multiple_levels'
 sil [ossa] @value_different_subobject_kinds_multiple_levels : $@convention(thin) (@owned B) -> () {
 bb0(%0 : @owned $B):
   %1 = begin_borrow %0 : $B
@@ -137,12 +136,14 @@ bb0(%0 : @guaranteed $B):
 // sure that our special handling code for subobjects here does not stop us from
 // detecting violations of ownership kinds on the subobjects.
 //
-// CHECK-LABEL: Error#: 3. Begin Error in Function: 'funcarg_subobject_with_destroy_of_subobject'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'funcarg_subobject_with_destroy_of_subobject'
 // CHECK: Have operand with incompatible ownership?!
 // CHECK: Value:   %4 = tuple_extract %3 : $(Builtin.NativeObject, Builtin.NativeObject), 1
 // CHECK: User:   destroy_value %4 : $Builtin.NativeObject
 // CHECK: Conv: guaranteed
-// CHECK: Error#: 3. End Error in Function: 'funcarg_subobject_with_destroy_of_subobject'
+// CHECK: Error#: 0. End Error in Function: 'funcarg_subobject_with_destroy_of_subobject'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]+}}. End Error in Function: 'funcarg_subobject_with_destroy_of_subobject'
 sil [ossa] @funcarg_subobject_with_destroy_of_subobject : $@convention(thin) (@guaranteed B) -> () {
 bb0(%0 : @guaranteed $B):
   %2 = struct_extract %0 : $B, #B.a1


### PR DESCRIPTION
This will just make them easier to update over time since adding a new function
doesn't require one to renumber the /entire/ file... *face-palm*.

Originally the reason why I added this is b/c I need to ensure that we handle
all errors exactly once so making sure we control the exact amount of emitted
errors is important. I can still do this with the new approach by just doing
per-function max error counts. Thus I also in this commit added FileCheck
patterns that implemented this scheme so now we have everything.
