### PR TITLE
For the TensorFlow toolchain, keep using @rpath for libraries

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -81,9 +81,9 @@ bool swift::triplesAreValidForZippering(const llvm::Triple &target,
 
 bool swift::tripleRequiresRPathForSwiftInOS(const llvm::Triple &triple) {
   if (triple.isMacOSX()) {
-    // macOS 10.14.4 contains a copy of Swift, but the linker will still use an
-    // rpath-based install name until 10.15.
-    return triple.isMacOSXVersionLT(10, 15);
+    // SWIFT_ENABLE_TENSORFLOW
+    // For TensorFlow, use the toolchain libs, not system ones
+    return false;
   }
 
   if (triple.isiOS()) {

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -84,6 +84,7 @@ bool swift::tripleRequiresRPathForSwiftInOS(const llvm::Triple &triple) {
     // SWIFT_ENABLE_TENSORFLOW
     // For TensorFlow, use the toolchain libs, not system ones
     return false;
+    // SWIFT_ENABLE_TENSORFLOW END
   }
 
   if (triple.isiOS()) {

--- a/stdlib/linker-support/magic-symbols-for-install-name.c
+++ b/stdlib/linker-support/magic-symbols-for-install-name.c
@@ -83,6 +83,9 @@
   // treat macOS 10.14 as an "older OS."
 #if __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_14
   RPATH_INSTALL_NAME_DIRECTIVE(10, 14)
+  // SWIFT_ENABLE_TENSORFLOW
+  // For TensorFlow, keep using @rpath instead of system paths
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 15)
 #endif
 
 #else

--- a/stdlib/linker-support/magic-symbols-for-install-name.c
+++ b/stdlib/linker-support/magic-symbols-for-install-name.c
@@ -86,6 +86,7 @@
   // SWIFT_ENABLE_TENSORFLOW
   // For TensorFlow, keep using @rpath instead of system paths
   RPATH_INSTALL_NAME_DIRECTIVE(10, 15)
+  // SWIFT_ENABLE_TENSORFLOW END
 #endif
 
 #else

--- a/test/Driver/linker-rpath.swift
+++ b/test/Driver/linker-rpath.swift
@@ -10,7 +10,7 @@
 // RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.14 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.14.3 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.14.4 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.15 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.15 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 
 // RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target arm64-apple-ios12 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target arm64-apple-ios12.1 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s

--- a/test/Driver/linker-rpath.swift
+++ b/test/Driver/linker-rpath.swift
@@ -5,12 +5,12 @@
 // SWIFT_ENABLE_TENSORFLOW
 // All "-no-toolchain-stdlib-rpath" additions are SWIFT_ENABLE_TENSORFLOW.
 
-// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.14 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.14.3 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.14.4 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.15 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.14 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.14.3 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.14.4 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.15 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
 
 // RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target arm64-apple-ios12 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target arm64-apple-ios12.1 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s


### PR DESCRIPTION
For the TensorFlow toolchain, keep using @rpath for libraries instead of system libs for MacOSX 10.15