### PR TITLE
[5.3][IDE] Loosen assertion check in IDE/SyntaxModelWalker

### DIFF
--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -1214,7 +1214,13 @@ bool ModelASTWalker::handleSpecialDeclAttribute(const DeclAttribute *D,
         if (!passNode({SyntaxNodeKind::AttributeBuiltin, Next.Range}))
           return false;
       } else {
-          assert(0 && "Attribute's TokenNodes already consumed?");
+        // Only mispelled attributes, corrected in the AST but not
+        // recognised or present in TokenNodes should get us here.
+        // E.g. @availability(...) comes through as if @available(...) was
+        // specified, but there's no TokenNode because we don't highlight them
+        // (to indicate they're invalid).
+        assert(Next.Range.getStart() == D->getRange().Start &&
+               "Attribute's TokenNodes already consumed?");
       }
     } else {
         assert(0 && "No TokenNodes?");

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -554,3 +554,8 @@ struct FreeWhere<T> {
   // CHECK: <kw>typealias</kw> Alias = <type>Int</type> <kw>where</kw> <type>T</type> == <type>Int</type>
   typealias Alias = Int where T == Int
 }
+
+// Renamed attribute ('fixed' to @available by the parser after emitting an error, so not treated as a custom attribute)
+// CHECK: @availability(<kw>macOS</kw> <float>10.11</float>, *)
+@availability(macOS 10.11, *)
+class HasMisspelledAttr {}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/31465 for 5.3

- **Explanation**
We were asserting that the range of each attribute recorded in the AST started at the same location as the fist unconsumed SyntaxNode in the file. This should be true in most cases, but isn't for mispelled attributes that are corrected in the AST, as they are not recognised and not present in the list of SyntaxNodes. E.g. `@availability(...)` comes through as if `@available(...)` was specified, but there's no SyntaxNode for it because we don't syntax highlight invalid attributes (to indicate they're invalid).
- **Scope of issue**: Sourcekitd hits an assertion while any file containing a misspelled attribute that the compiler corrects is open (of which there are currently 10).
- **Origination**: When the assertion was added.
- **Risk**: Low. This is purely a refinement of the assertion condition, only impacts SourceKit, and only when built with assertions enabled.
- **Testing**: Added a regression test for this case and all existing tests pass.
- **Reviewers**: Rintaro Ishizaki (@rintaro) on the master branch PR.

Resolves rdar://problem/62201594
Resolves https://bugs.swift.org/browse/SR-12500