### PR TITLE
[5.3][IDE][DocSupport] Fix DocInfo missing decls when generated for clang submodules.

### DIFF
--- a/include/swift/IDE/ModuleInterfacePrinting.h
+++ b/include/swift/IDE/ModuleInterfacePrinting.h
@@ -54,18 +54,10 @@ bool printTypeInterface(ModuleDecl *M, Type Ty, ASTPrinter &Printer,
 bool printTypeInterface(ModuleDecl *M, StringRef TypeUSR, ASTPrinter &Printer,
                         std::string &TypeName, std::string &Error);
 
-void printModuleInterface(ModuleDecl *M, Optional<StringRef> Group,
+void printModuleInterface(ModuleDecl *M, ArrayRef<StringRef> GroupNames,
                           ModuleTraversalOptions TraversalOptions,
                           ASTPrinter &Printer, const PrintOptions &Options,
                           const bool PrintSynthesizedExtensions);
-
-// FIXME: this API should go away when Swift can represent Clang submodules as
-// 'swift::ModuleDecl *' objects.
-void printSubmoduleInterface(ModuleDecl *M, ArrayRef<StringRef> FullModuleName,
-                             ArrayRef<StringRef> GroupNames,
-                             ModuleTraversalOptions TraversalOptions,
-                             ASTPrinter &Printer, const PrintOptions &Options,
-                             const bool PrintSynthesizedExtensions);
 
 /// Print the interface for a header that has been imported via the implicit
 /// objc header importing feature.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2398,7 +2398,7 @@ public:
   FilteringDeclaredDeclConsumer(swift::VisibleDeclConsumer &consumer,
                                 const ClangModuleUnit *CMU)
       : NextConsumer(consumer), ModuleFilter(CMU) {
-    assert(CMU);
+    assert(CMU && CMU->isTopLevel() && "Only top-level modules supported");
   }
 
   void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason,

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -189,17 +189,6 @@ printTypeInterface(ModuleDecl *M, StringRef TypeUSR, ASTPrinter &Printer,
                             Printer, TypeName, Error);
 }
 
-void swift::ide::printModuleInterface(ModuleDecl *M, Optional<StringRef> Group,
-                                      ModuleTraversalOptions TraversalOptions,
-                                      ASTPrinter &Printer,
-                                      const PrintOptions &Options,
-                                      const bool PrintSynthesizedExtensions) {
-  printSubmoduleInterface(M, M->getName().str(),
-                          Group.hasValue() ? Group.getValue() : ArrayRef<StringRef>(),
-                          TraversalOptions, Printer, Options,
-                          PrintSynthesizedExtensions);
-}
-
 static void adjustPrintOptions(PrintOptions &AdjustedOptions) {
   // Don't print empty curly braces while printing the module interface.
   AdjustedOptions.FunctionDefinitions = false;
@@ -230,7 +219,7 @@ static bool extensionHasClangNode(ExtensionDecl *ext) {
 
 Optional<StringRef>
 swift::ide::findGroupNameForUSR(ModuleDecl *M, StringRef USR) {
-  for (auto File : M->getFiles()) {
+  for (auto File : M->getTopLevelModule()->getFiles()) {
     if (auto Name = File->getGroupNameByUSR(USR)) {
       return Name;
     }
@@ -539,15 +528,22 @@ static void printCrossImportOverlays(ModuleDecl *Declaring, ASTContext &Ctx,
   }
 }
 
-void swift::ide::printSubmoduleInterface(
-       ModuleDecl *M,
-       ArrayRef<StringRef> FullModuleName,
+void swift::ide::printModuleInterface(
+       ModuleDecl *TargetMod,
        ArrayRef<StringRef> GroupNames,
        ModuleTraversalOptions TraversalOptions,
        ASTPrinter &Printer,
        const PrintOptions &Options,
        const bool PrintSynthesizedExtensions) {
-  auto &SwiftContext = M->getASTContext();
+
+  // Clang submodules aren't handled well by `getDisplayDecls()` (no decls are
+  // returned), so map them to their top-level module and filter out the extra
+  // results below.
+  const clang::Module *TargetClangMod = TargetMod->findUnderlyingClangModule();
+  ModuleDecl *TopLevelMod = TargetMod->getTopLevelModule();
+  bool IsSubmodule = TargetMod != TopLevelMod;
+
+  auto &SwiftContext = TopLevelMod->getASTContext();
   auto &Importer =
       static_cast<ClangImporter &>(*SwiftContext.getClangModuleLoader());
 
@@ -555,9 +551,8 @@ void swift::ide::printSubmoduleInterface(
   adjustPrintOptions(AdjustedOptions);
 
   SmallVector<Decl *, 1> Decls;
-  M->getDisplayDecls(Decls);
+  TopLevelMod->getDisplayDecls(Decls);
 
-  const clang::Module *InterestingClangModule = nullptr;
   SmallVector<ImportDecl *, 1> ImportDecls;
   llvm::DenseSet<const clang::Module *> ClangModulesForImports;
   SmallVector<Decl *, 1> SwiftDecls;
@@ -565,27 +560,13 @@ void swift::ide::printSubmoduleInterface(
                  SmallVector<std::pair<Decl *, clang::SourceLocation>, 1>>
     ClangDecls;
 
-  // Drop top-level module name.
-  FullModuleName = FullModuleName.slice(1);
-
-  InterestingClangModule = M->findUnderlyingClangModule();
-  if (InterestingClangModule) {
-    for (StringRef Name : FullModuleName) {
-      InterestingClangModule = InterestingClangModule->findSubmodule(Name);
-      if (!InterestingClangModule)
-        return;
-    }
-  } else {
-    assert(FullModuleName.empty());
-  }
-
   // If we're printing recursively, find all of the submodules to print.
-  if (InterestingClangModule) {
+  if (TargetClangMod) {
     if (TraversalOptions) {
       SmallVector<const clang::Module *, 8> Worklist;
       SmallPtrSet<const clang::Module *, 8> Visited;
-      Worklist.push_back(InterestingClangModule);
-      Visited.insert(InterestingClangModule);
+      Worklist.push_back(TargetClangMod);
+      Visited.insert(TargetClangMod);
       while (!Worklist.empty()) {
         const clang::Module *CM = Worklist.pop_back_val();
         if (!(TraversalOptions & ModuleTraversal::VisitHidden) &&
@@ -604,17 +585,17 @@ void swift::ide::printSubmoduleInterface(
         }
       }
     } else {
-      ClangDecls.insert({ InterestingClangModule, {} });
+      ClangDecls.insert({ TargetClangMod, {} });
     }
   }
 
-  // Collect those submodules that are actually imported but have no import decls
-  // in the module.
+  // Collect those submodules that are actually imported but have no import
+  // decls in the module.
   llvm::SmallPtrSet<const clang::Module *, 16> NoImportSubModules;
-  if (InterestingClangModule) {
+  if (TargetClangMod) {
     // Assume all submodules are missing.
-    for (auto It =InterestingClangModule->submodule_begin();
-         It != InterestingClangModule->submodule_end(); It++) {
+    for (auto It = TargetClangMod->submodule_begin();
+         It != TargetClangMod->submodule_end(); It++) {
       NoImportSubModules.insert(*It);
     }
   }
@@ -631,18 +612,18 @@ void swift::ide::printSubmoduleInterface(
     }
 
     auto ShouldPrintImport = [&](ImportDecl *ImportD) -> bool {
-      if (!InterestingClangModule)
+      if (!TargetClangMod)
         return true;
-      auto ClangMod = ImportD->getClangModule();
-      if (!ClangMod)
+      auto ImportedMod = ImportD->getClangModule();
+      if (!ImportedMod)
         return true;
-      if (!ClangMod->isSubModule())
+      if (!ImportedMod->isSubModule())
         return true;
-      if (ClangMod == InterestingClangModule)
+      if (ImportedMod == TargetClangMod)
         return false;
       // FIXME: const-ness on the clang API.
-      return ClangMod->isSubModuleOf(
-                          const_cast<clang::Module*>(InterestingClangModule));
+      return ImportedMod->isSubModuleOf(
+        const_cast<clang::Module*>(TargetClangMod));
     };
 
     if (auto ID = dyn_cast<ImportDecl>(D)) {
@@ -690,14 +671,16 @@ void swift::ide::printSubmoduleInterface(
       }
     }
 
-    if (FullModuleName.empty()) {
+    if (!IsSubmodule) {
       // If group name is given and the decl does not belong to the group, skip it.
       if (!GroupNames.empty()){
-        if (auto Target = D->getGroupName()) {
+        if (auto TargetGroup = D->getGroupName()) {
           if (std::find(GroupNames.begin(), GroupNames.end(),
-                        Target.getValue()) != GroupNames.end()) {
-            FileRangedDecls.insert(std::make_pair(D->getSourceFileName().getValue(),
-              std::vector<Decl*>())).first->getValue().push_back(D);
+                        TargetGroup.getValue()) != GroupNames.end()) {
+            FileRangedDecls.insert({
+              D->getSourceFileName().getValue(),
+              std::vector<Decl*>()
+            }).first->getValue().push_back(D);
           }
         }
         continue;
@@ -725,8 +708,9 @@ void swift::ide::printSubmoduleInterface(
   }
 
   // Create the missing import decls and add to the collector.
-  for (auto *SM : NoImportSubModules) {
-    ImportDecls.push_back(createImportDecl(M->getASTContext(), M, SM, {}));
+  for (auto *SubMod : NoImportSubModules) {
+    ImportDecls.push_back(createImportDecl(TopLevelMod->getASTContext(),
+                                           TopLevelMod, SubMod, {}));
   }
 
   // Sort imported clang declarations in source order *within a submodule*.
@@ -760,7 +744,7 @@ void swift::ide::printSubmoduleInterface(
   };
 
   // Imports from the stdlib are internal details that don't need to be exposed.
-  if (!M->isStdlibModule()) {
+  if (!TargetMod->isStdlibModule()) {
     for (auto *D : ImportDecls)
       PrintDecl(D);
     Printer << "\n";
@@ -785,8 +769,7 @@ void swift::ide::printSubmoduleInterface(
     }
   }
 
-  if (!(TraversalOptions & ModuleTraversal::SkipOverlay) ||
-      !InterestingClangModule) {
+  if (!(TraversalOptions & ModuleTraversal::SkipOverlay) || !TargetClangMod) {
     for (auto *D : SwiftDecls) {
       if (PrintDecl(D))
         Printer << "\n";
@@ -796,8 +779,8 @@ void swift::ide::printSubmoduleInterface(
     // also print the decls from any underscored Swift cross-import overlays it
     // is the underlying module of, transitively.
     if (GroupNames.empty()) {
-      printCrossImportOverlays(M, SwiftContext, *PrinterToUse, AdjustedOptions,
-                               PrintSynthesizedExtensions);
+      printCrossImportOverlays(TargetMod, SwiftContext, *PrinterToUse,
+                               AdjustedOptions, PrintSynthesizedExtensions);
     }
   }
 }

--- a/test/SourceKit/DocSupport/doc_clang_module.swift
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift
@@ -9,3 +9,7 @@
 // RUN: %sourcekitd-test -req=doc-info -module Foo -- -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:         -target %target-triple %clang-importer-sdk-nosource -I %t | %sed_clean > %t.response
 // RUN: %diff -u %s.response %t.response
+
+// RUN: %sourcekitd-test -req=doc-info -module Foo.FooSub -- -F %S/../Inputs/libIDE-mock-sdk \
+// RUN:         -target %target-triple %clang-importer-sdk-nosource -I %t | %sed_clean > %t.response
+// RUN: %diff -u %s.sub.response %t.response

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.sub.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.sub.response
@@ -1,0 +1,402 @@
+import FooHelper
+
+func fooSubFunc1(_ a: Int32) -> Int32
+struct FooSubEnum1 : Equatable, RawRepresentable {
+
+    init(_ rawValue: UInt32)
+
+    init(rawValue rawValue: UInt32)
+
+    var rawValue: UInt32
+
+    static func != (_ lhs: FooSubEnum1, _ rhs: FooSubEnum1) -> Bool
+}
+var FooSubEnum1X: FooSubEnum1 { get }
+var FooSubEnum1Y: FooSubEnum1 { get }
+var FooSubUnnamedEnumeratorA1: Int { get }
+
+[
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 0,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 7,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 18,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 23,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 35,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 37,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int32",
+    key.usr: "s:s5Int32V",
+    key.offset: 40,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int32",
+    key.usr: "s:s5Int32V",
+    key.offset: 50,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 56,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 63,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.ref.protocol,
+    key.name: "Equatable",
+    key.usr: "s:SQ",
+    key.offset: 77,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.ref.protocol,
+    key.name: "RawRepresentable",
+    key.usr: "s:SY",
+    key.offset: 88,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 112,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 117,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 119,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "UInt32",
+    key.usr: "s:s6UInt32V",
+    key.offset: 129,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 142,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 147,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 156,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "UInt32",
+    key.usr: "s:s6UInt32V",
+    key.offset: 166,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 179,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 183,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "UInt32",
+    key.usr: "s:s6UInt32V",
+    key.offset: 193,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 205,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 212,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 221,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 223,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "FooSubEnum1",
+    key.usr: "c:@E@FooSubEnum1",
+    key.offset: 228,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 241,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 243,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "FooSubEnum1",
+    key.usr: "c:@E@FooSubEnum1",
+    key.offset: 248,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Bool",
+    key.usr: "s:Sb",
+    key.offset: 264,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 271,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 275,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "FooSubEnum1",
+    key.usr: "c:@E@FooSubEnum1",
+    key.offset: 289,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 303,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 309,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 313,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "FooSubEnum1",
+    key.usr: "c:@E@FooSubEnum1",
+    key.offset: 327,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 341,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 347,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 351,
+    key.length: 25
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int",
+    key.usr: "s:Si",
+    key.offset: 378,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 384,
+    key.length: 3
+  }
+]
+[
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.name: "fooSubFunc1(_:)",
+    key.usr: "c:@F@fooSubFunc1",
+    key.offset: 18,
+    key.length: 37,
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooSubFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
+    key.entities: [
+      {
+        key.kind: source.lang.swift.decl.var.local,
+        key.keyword: "_",
+        key.name: "a",
+        key.offset: 40,
+        key.length: 5
+      }
+    ],
+    key.modulename: "Foo.FooSub"
+  },
+  {
+    key.kind: source.lang.swift.decl.struct,
+    key.name: "FooSubEnum1",
+    key.usr: "c:@E@FooSubEnum1",
+    key.offset: 56,
+    key.length: 214,
+    key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooSubEnum1</decl.name> : <ref.protocol usr=\"s:SQ\">Equatable</ref.protocol>, <ref.protocol usr=\"s:SY\">RawRepresentable</ref.protocol></decl.struct>",
+    key.conforms: [
+      {
+        key.kind: source.lang.swift.ref.protocol,
+        key.name: "Equatable",
+        key.usr: "s:SQ"
+      },
+      {
+        key.kind: source.lang.swift.ref.protocol,
+        key.name: "RawRepresentable",
+        key.usr: "s:SY"
+      }
+    ],
+    key.entities: [
+      {
+        key.kind: source.lang.swift.decl.function.constructor,
+        key.name: "init(_:)",
+        key.usr: "s:So11FooSubEnum1VyABs6UInt32Vcfc",
+        key.offset: 112,
+        key.length: 24,
+        key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>rawValue</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
+        key.entities: [
+          {
+            key.kind: source.lang.swift.decl.var.local,
+            key.keyword: "_",
+            key.name: "rawValue",
+            key.offset: 129,
+            key.length: 6
+          }
+        ]
+      },
+      {
+        key.kind: source.lang.swift.decl.function.constructor,
+        key.name: "init(rawValue:)",
+        key.usr: "s:So11FooSubEnum1V8rawValueABs6UInt32V_tcfc",
+        key.offset: 142,
+        key.length: 31,
+        key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>rawValue</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
+        key.entities: [
+          {
+            key.kind: source.lang.swift.decl.var.local,
+            key.keyword: "rawValue",
+            key.name: "rawValue",
+            key.offset: 166,
+            key.length: 6
+          }
+        ]
+      },
+      {
+        key.kind: source.lang.swift.decl.var.instance,
+        key.name: "rawValue",
+        key.usr: "s:So11FooSubEnum1V8rawValues6UInt32Vvp",
+        key.offset: 179,
+        key.length: 20,
+        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>rawValue</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.type></decl.var.instance>"
+      },
+      {
+        key.kind: source.lang.swift.decl.function.operator.infix,
+        key.name: "!=(_:_:)",
+        key.usr: "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@FooSubEnum1",
+        key.original_usr: "s:SQsE2neoiySbx_xtFZ",
+        key.offset: 205,
+        key.length: 63,
+        key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
+        key.entities: [
+          {
+            key.kind: source.lang.swift.decl.var.local,
+            key.keyword: "_",
+            key.name: "lhs",
+            key.offset: 228,
+            key.length: 11
+          },
+          {
+            key.kind: source.lang.swift.decl.var.local,
+            key.keyword: "_",
+            key.name: "rhs",
+            key.offset: 248,
+            key.length: 11
+          }
+        ]
+      }
+    ],
+    key.modulename: "Foo.FooSub"
+  },
+  {
+    key.kind: source.lang.swift.decl.var.global,
+    key.name: "FooSubEnum1X",
+    key.usr: "c:@E@FooSubEnum1@FooSubEnum1X",
+    key.offset: 271,
+    key.length: 37,
+    key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubEnum1X</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>",
+    key.modulename: "Foo.FooSub"
+  },
+  {
+    key.kind: source.lang.swift.decl.var.global,
+    key.name: "FooSubEnum1Y",
+    key.usr: "c:@E@FooSubEnum1@FooSubEnum1Y",
+    key.offset: 309,
+    key.length: 37,
+    key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubEnum1Y</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>",
+    key.modulename: "Foo.FooSub"
+  },
+  {
+    key.kind: source.lang.swift.decl.var.global,
+    key.name: "FooSubUnnamedEnumeratorA1",
+    key.usr: "c:@Ea@FooSubUnnamedEnumeratorA1@FooSubUnnamedEnumeratorA1",
+    key.offset: 347,
+    key.length: 42,
+    key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubUnnamedEnumeratorA1</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>",
+    key.modulename: "Foo.FooSub"
+  }
+]

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.sub.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.sub.response
@@ -1,6 +1,4 @@
-import Foo
 import FooHelper
-import SwiftOnoneSupport
 
 
 public func fooSubFunc1(_ a: Int32) -> Int32
@@ -27,226 +25,206 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 7,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 11,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 18,
     key.length: 9
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 28,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 35,
-    key.length: 17
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 55,
+    key.offset: 19,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 62,
+    key.offset: 26,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 67,
+    key.offset: 31,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 79,
+    key.offset: 43,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 81,
+    key.offset: 45,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 84,
+    key.offset: 48,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 94,
+    key.offset: 58,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 101,
+    key.offset: 65,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 108,
+    key.offset: 72,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 115,
+    key.offset: 79,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 129,
+    key.offset: 93,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 140,
+    key.offset: 104,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 164,
+    key.offset: 128,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 171,
+    key.offset: 135,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 176,
+    key.offset: 140,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 178,
+    key.offset: 142,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 188,
+    key.offset: 152,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 201,
+    key.offset: 165,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 208,
+    key.offset: 172,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 213,
+    key.offset: 177,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 223,
+    key.offset: 187,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 236,
+    key.offset: 200,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 243,
+    key.offset: 207,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 247,
+    key.offset: 211,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 257,
+    key.offset: 221,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 266,
+    key.offset: 230,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 273,
+    key.offset: 237,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 277,
+    key.offset: 241,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 291,
+    key.offset: 255,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 305,
+    key.offset: 269,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 311,
+    key.offset: 275,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 318,
+    key.offset: 282,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 322,
+    key.offset: 286,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 336,
+    key.offset: 300,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 350,
+    key.offset: 314,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 357,
+    key.offset: 321,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 364,
+    key.offset: 328,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 368,
+    key.offset: 332,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 395,
+    key.offset: 359,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 401,
+    key.offset: 365,
     key.length: 3
   }
 ]
@@ -254,74 +232,63 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.ref.module,
     key.offset: 7,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.ref.module,
-    key.offset: 18,
     key.length: 9
   },
   {
-    key.kind: source.lang.swift.ref.module,
-    key.offset: 35,
-    key.length: 17,
-    key.is_system: 1
-  },
-  {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 84,
+    key.offset: 48,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 94,
+    key.offset: 58,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 129,
+    key.offset: 93,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 140,
+    key.offset: 104,
     key.length: 16,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 188,
+    key.offset: 152,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 223,
+    key.offset: 187,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 257,
+    key.offset: 221,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 291,
+    key.offset: 255,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 336,
+    key.offset: 300,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 395,
+    key.offset: 359,
     key.length: 3,
     key.is_system: 1
   }
@@ -331,14 +298,14 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooSubFunc1(_:)",
-    key.offset: 62,
+    key.offset: 26,
     key.length: 37,
     key.typename: "Int32",
-    key.nameoffset: 67,
+    key.nameoffset: 31,
     key.namelength: 23,
     key.attributes: [
       {
-        key.offset: 55,
+        key.offset: 19,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -347,7 +314,7 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 79,
+        key.offset: 43,
         key.length: 10,
         key.typename: "Int32",
         key.nameoffset: 0,
@@ -359,11 +326,11 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubEnum1",
-    key.offset: 108,
+    key.offset: 72,
     key.length: 157,
-    key.nameoffset: 115,
+    key.nameoffset: 79,
     key.namelength: 11,
-    key.bodyoffset: 158,
+    key.bodyoffset: 122,
     key.bodylength: 106,
     key.inheritedtypes: [
       {
@@ -375,7 +342,7 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     ],
     key.attributes: [
       {
-        key.offset: 101,
+        key.offset: 65,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -383,12 +350,12 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 129,
+        key.offset: 93,
         key.length: 9
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 140,
+        key.offset: 104,
         key.length: 16
       }
     ],
@@ -397,13 +364,13 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(_:)",
-        key.offset: 171,
+        key.offset: 135,
         key.length: 24,
-        key.nameoffset: 171,
+        key.nameoffset: 135,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 164,
+            key.offset: 128,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -412,7 +379,7 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 176,
+            key.offset: 140,
             key.length: 18,
             key.typename: "UInt32",
             key.nameoffset: 0,
@@ -424,13 +391,13 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 208,
+        key.offset: 172,
         key.length: 22,
-        key.nameoffset: 208,
+        key.nameoffset: 172,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 201,
+            key.offset: 165,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -439,10 +406,10 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 213,
+            key.offset: 177,
             key.length: 16,
             key.typename: "UInt32",
-            key.nameoffset: 213,
+            key.nameoffset: 177,
             key.namelength: 8
           }
         ]
@@ -452,14 +419,14 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "rawValue",
-        key.offset: 243,
+        key.offset: 207,
         key.length: 20,
         key.typename: "UInt32",
-        key.nameoffset: 247,
+        key.nameoffset: 211,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 236,
+            key.offset: 200,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -471,16 +438,16 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubEnum1X",
-    key.offset: 273,
+    key.offset: 237,
     key.length: 37,
     key.typename: "FooSubEnum1",
-    key.nameoffset: 277,
+    key.nameoffset: 241,
     key.namelength: 12,
-    key.bodyoffset: 304,
+    key.bodyoffset: 268,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 266,
+        key.offset: 230,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -490,16 +457,16 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubEnum1Y",
-    key.offset: 318,
+    key.offset: 282,
     key.length: 37,
     key.typename: "FooSubEnum1",
-    key.nameoffset: 322,
+    key.nameoffset: 286,
     key.namelength: 12,
-    key.bodyoffset: 349,
+    key.bodyoffset: 313,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 311,
+        key.offset: 275,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -509,16 +476,16 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubUnnamedEnumeratorA1",
-    key.offset: 364,
+    key.offset: 328,
     key.length: 42,
     key.typename: "Int",
-    key.nameoffset: 368,
+    key.nameoffset: 332,
     key.namelength: 25,
-    key.bodyoffset: 400,
+    key.bodyoffset: 364,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 357,
+        key.offset: 321,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -983,8 +983,9 @@ static bool getModuleInterfaceInfo(ASTContext &Ctx, StringRef ModuleName,
   SmallString<128> Text;
   llvm::raw_svector_ostream OS(Text);
   AnnotatingPrinter Printer(OS);
-  printModuleInterface(M, None, TraversalOptions, Printer, Options,
-                       true);
+
+  printModuleInterface(M, None, TraversalOptions, Printer, Options, true);
+
   Info.Text = std::string(OS.str());
   Info.TopEntities = std::move(Printer.TopEntities);
   Info.References = std::move(Printer.References);

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2174,34 +2174,13 @@ static int doPrintModules(const CompilerInvocation &InitInvok,
       continue;
     }
 
-    // Split the module path.
-    std::vector<StringRef> ModuleName;
-    while (!ModuleToPrint.empty()) {
-      StringRef SubModuleName;
-      std::tie(SubModuleName, ModuleToPrint) = ModuleToPrint.split('.');
-      ModuleName.push_back(SubModuleName);
-    }
-    assert(!ModuleName.empty());
-
-    // FIXME: If ModuleToPrint is a submodule, get its top-level module, which
-    // will be the DeclContext for all of its Decls since we don't have first-
-    // class submodules.
-    if (ModuleName.size() > 1) {
-      M = getModuleByFullName(Context, ModuleName[0]);
-      if (!M) {
-        llvm::errs() << "error: could not find module '" << ModuleName[0]
-                     << "'\n";
-        ExitCode = 1;
-        continue;
-      }
-    }
     std::vector<StringRef> GroupNames;
     for (StringRef G : GroupsToPrint) {
       GroupNames.push_back(G);
     }
 
-    printSubmoduleInterface(M, ModuleName, GroupNames, TraversalOptions,
-                            *Printer, Options, SynthesizeExtensions);
+    printModuleInterface(M, GroupNames, TraversalOptions, *Printer, Options,
+                         SynthesizeExtensions);
   }
 
   return ExitCode;


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/31589 for 5.3.

- **Explantion**
    Our handling of clang submodules was different between sourcekitd's DocInfo and InterfaceGen requests. For InterfaceGen submodules were mapped back to their top-level clang modules (or their Swift overlay if it had one) before being passed into `printSubmoduleInterface`, along with the dot separated name of the submodule.

    For DocInfo, they were not, and only the rightmost component of their name was passed. The call to retrieve the decls from a ModuleDecl doesn't work if the ModuleDecl wraps a clang submodule, so we were missing these decls.

    InterfaceGen for submodules also shouldn't have been mapping back to the overlays of their top-level clang modules, but instead just the top-level clang modules themselves, as that meant we ended up printing import decls from the Swift overlay in the submodule interfaces.
- **Scope of issue**: User-facing generated interfaces would include imports that weren't present in the original module for clang submodule interfaces, and DocInfo for clang submodules would be missing most decls they contained.
- **Origination**: Unclear. I suspect this has been an issue for a long time.
- **Risk**: Low. This only impacts sourcekitd (not the compiler) and only the DocInfo and InterfaceGen requests.
- **Testing**: Added a regression test for these cases and all existing tests pass. Also verified interface generation for clang submodules works in Xcode after these changes.
- **Reviewer**: Argyrios Kyrtzidis (@akyrtzi) on the master branch PR.

Resolves rdar://problem/57338105