### PR TITLE
Frontend: Emit reference dependencies at the end of the frontend pipeline

### DIFF
--- a/test/Incremental/PrivateDependencies/reference-dependencies-dynamic-lookup-fine.swift
+++ b/test/Incremental/PrivateDependencies/reference-dependencies-dynamic-lookup-fine.swift
@@ -29,10 +29,12 @@ import Foundation
   // CHECK-DAG:  dynamicLookup implementation  '' bar true
   // CHECK-DAG:  dynamicLookup interface  '' bar true
 
+  // DUPLICATE-NOT:  dynamicLookup implementation  '' bar true
   // DUPLICATE:  dynamicLookup implementation  '' bar true
-  // DUPLICATE:  dynamicLookup implementation  '' bar true
+  // DUPLICATE-NOT:  dynamicLookup implementation  '' bar true
+  // DUPLICATE-NOT:  dynamicLookup interface  '' bar true
   // DUPLICATE:  dynamicLookup interface  '' bar true
-  // DUPLICATE:  dynamicLookup interface  '' bar true
+  // DUPLICATE-NOT:  dynamicLookup interface  '' bar true
   func bar(_ x: Int, y: Int) {}
   func bar(_ str: String) {}
     


### PR DESCRIPTION
As part of eliminating cascading dependencies, we need to make sure to
capture any dependencies discovered during SILGen and IRGen.

This is a little bit tricky because we exit early in various places in
the pipeline, so we want to do it after performCompileStepsPostSema()
returns, but we can't do it too late, because the ASTContext might
already have been deallocated.

So emit the dependencies manually before freeing the ASTContext if we
decide to do that, or just do it before returning from performCompile()
using a SWIFT_DEFER otherwise.

This should have no observable effect until we start recording dependencies
for lookups done on behalf of declarations in secondary files.