### PR TITLE
Sema: Only run extension binding once

### DIFF
--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -140,7 +140,7 @@ namespace swift {
   void performPCMacro(SourceFile &SF);
 
   /// Bind all 'extension' visible from \p SF to the extended nominal.
-  void bindExtensions(SourceFile &SF);
+  void bindExtensions(ModuleDecl &mod);
 
   /// Once import resolution is complete, this walks the AST to resolve types
   /// and diagnose problems therein.

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -806,12 +806,13 @@ void CompilerInstance::performSemaUpTo(SourceFile::ASTStage_t LimitStage) {
   }) && "some files have not yet had their imports resolved");
   MainModule->setHasResolvedImports();
 
-  forEachFileToTypeCheck([&](SourceFile &SF) {
-    if (LimitStage == SourceFile::ImportsResolved) {
-      bindExtensions(SF);
-      return;
-    }
+  bindExtensions(*MainModule);
 
+  // If the limiting AST stage is import resolution, we're done.
+  if (LimitStage == SourceFile::ImportsResolved)
+    return;
+
+  forEachFileToTypeCheck([&](SourceFile &SF) {
     performTypeChecking(SF);
 
     // Parse the SIL decls if needed.
@@ -821,11 +822,6 @@ void CompilerInstance::performSemaUpTo(SourceFile::ASTStage_t LimitStage) {
       parseSourceFileSIL(SF, &SILContext);
     }
   });
-
-  // If the limiting AST stage is import resolution, we're done.
-  if (LimitStage <= SourceFile::ImportsResolved) {
-    return;
-  }
 
   finishTypeChecking();
 }

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -446,7 +446,7 @@ bool CompletionInstance::performCachedOperationIfPossible(
     // Re-process the whole file (parsing will be lazily triggered). Still
     // re-use imported modules.
     performImportResolution(*newSF);
-    bindExtensions(*newSF);
+    bindExtensions(*newM);
 
     CurrentModule = newM;
     traceDC = newM;

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -239,7 +239,7 @@ doCodeCompletion(SourceFile &SF, StringRef EnteredCode, unsigned *BufferID,
   newModule->addFile(newSF);
 
   performImportResolution(newSF);
-  bindExtensions(newSF);
+  bindExtensions(*newModule);
 
   performCodeCompletionSecondPass(newSF, *CompletionCallbacksFactory);
 

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -184,6 +184,8 @@ typeCheckREPLInput(ModuleDecl *MostRecentModule, StringRef Name,
   auto &REPLInputFile =
       *new (Ctx) SourceFile(*REPLModule, SourceFileKind::REPL, BufferID);
   REPLModule->addFile(REPLInputFile);
+  performImportResolution(REPLInputFile);
+  bindExtensions(*REPLModule);
   performTypeChecking(REPLInputFile);
   return REPLModule;
 }

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -131,6 +131,7 @@ ModuleDecl *SourceLoader::loadModule(SourceLoc importLoc,
   importMod->addFile(*importFile);
   performImportResolution(*importFile);
   importMod->setHasResolvedImports();
+  bindExtensions(*importMod);
   return importMod;
 }
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -326,10 +326,6 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
 
   BufferIndirectlyCausingDiagnosticRAII cpr(*SF);
 
-  // Make sure that import resolution has been completed before doing any type
-  // checking.
-  performImportResolution(*SF);
-
   // Could build scope maps here because the AST is stable now.
 
   {

--- a/test/Incremental/PrivateDependencies/reference-dependencies-dynamic-lookup-fine.swift
+++ b/test/Incremental/PrivateDependencies/reference-dependencies-dynamic-lookup-fine.swift
@@ -29,10 +29,12 @@ import Foundation
   // CHECK-DAG:  dynamicLookup implementation  '' bar true
   // CHECK-DAG:  dynamicLookup interface  '' bar true
 
+  // DUPLICATE-NOT:  dynamicLookup implementation  '' bar true
   // DUPLICATE:  dynamicLookup implementation  '' bar true
-  // DUPLICATE:  dynamicLookup implementation  '' bar true
+  // DUPLICATE-NOT:  dynamicLookup implementation  '' bar true
+  // DUPLICATE-NOT:  dynamicLookup interface  '' bar true
   // DUPLICATE:  dynamicLookup interface  '' bar true
-  // DUPLICATE:  dynamicLookup interface  '' bar true
+  // DUPLICATE-NOT:  dynamicLookup interface  '' bar true
   func bar(_ x: Int, y: Int) {}
   func bar(_ str: String) {}
     


### PR DESCRIPTION
There's no need to walk all imports of all source files, and bind the
extensions defined therein. The only time that a non-main module
contains source files is when using -enable-source-import, and we
can just explicitly call bindExtensions() in the right place.