### PR TITLE
[SymbolGraph] Use `identifier` for type name fragments

### DIFF
--- a/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
+++ b/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
@@ -148,38 +148,36 @@ void DeclarationFragmentPrinter::printText(StringRef Text) {
   Spelling.append(Text);
 }
 
-void DeclarationFragmentPrinter::printAbridgedType(const GenericTypeDecl *TD) {
-  // Subheadings for types are abridged, omitting generics and inheritance.
-  openFragment(DeclarationFragmentPrinter::FragmentKind::Keyword);
-  switch (TD->getKind()) {
-    case DeclKind::Struct:
-      printText(getTokenText(tok::kw_struct));
-      break;
-    case DeclKind::Enum:
-      printText(getTokenText(tok::kw_enum));
-      break;
-    case DeclKind::Protocol:
-      printText(getTokenText(tok::kw_protocol));
-      break;
-    case DeclKind::Class:
-      printText(getTokenText(tok::kw_class));
-      break;
-    case DeclKind::TypeAlias:
-      printText(getTokenText(tok::kw_typealias));
-      break;
-    case DeclKind::OpaqueType:
-      llvm_unreachable("OpaqueType should not be in symbol graphs!");
-    default:
-      llvm_unreachable("GenericTypeDecl kind not handled in DeclarationFragmentPrinter!");
+void DeclarationFragmentPrinter::printAbridgedType(const GenericTypeDecl *TD,
+                                                   bool PrintKeyword) {
+  if (PrintKeyword) {
+    openFragment(DeclarationFragmentPrinter::FragmentKind::Keyword);
+    switch (TD->getKind()) {
+      case DeclKind::Struct:
+        printText(getTokenText(tok::kw_struct));
+        break;
+      case DeclKind::Enum:
+        printText(getTokenText(tok::kw_enum));
+        break;
+      case DeclKind::Protocol:
+        printText(getTokenText(tok::kw_protocol));
+        break;
+      case DeclKind::Class:
+        printText(getTokenText(tok::kw_class));
+        break;
+      case DeclKind::TypeAlias:
+        printText(getTokenText(tok::kw_typealias));
+        break;
+      case DeclKind::OpaqueType:
+        llvm_unreachable("OpaqueType should not be in symbol graphs!");
+      default:
+        llvm_unreachable("GenericTypeDecl kind not handled in DeclarationFragmentPrinter!");
+    }
+
+    openFragment(DeclarationFragmentPrinter::FragmentKind::Text);
+    printText(" ");
   }
 
-  openFragment(DeclarationFragmentPrinter::FragmentKind::Text);
-  printText(" ");
-
-  openFragment(DeclarationFragmentPrinter::FragmentKind::TypeIdentifier);
+  openFragment(DeclarationFragmentPrinter::FragmentKind::Identifier);
   printText(TD->getNameStr());
-
-  USR.clear();
-  llvm::raw_svector_ostream USROS(USR);
-  ide::printDeclUSR(TD, USROS);
 }

--- a/lib/SymbolGraphGen/DeclarationFragmentPrinter.h
+++ b/lib/SymbolGraphGen/DeclarationFragmentPrinter.h
@@ -99,7 +99,10 @@ public:
   ///
   /// Subheadings for types don't include the complete declaration line
   /// including generics and inheritance.
-  void printAbridgedType(const GenericTypeDecl *TD);
+  ///
+  /// \param TD The type declaration to print.
+  /// \param PrintKeyword Print the corresponding keyword introducer if `true`.
+  void printAbridgedType(const GenericTypeDecl *TD, bool PrintKeyword);
 
   void printDeclLoc(const Decl *D) override;
 

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -522,15 +522,14 @@ SymbolGraph::serializeNavigatorDeclarationFragments(StringRef Key,
   DeclarationFragmentPrinter Printer(OS, Key);
 
   if (const auto *TD = dyn_cast<GenericTypeDecl>(S.getSymbolDecl())) {
-    Printer.printTypeRef(TD->getInterfaceType(), TD, TD->getName(),
-                         PrintNameContext::Normal);
-    return;
+    Printer.printAbridgedType(TD, /*PrintKeyword=*/false);
+  } else {
+    auto Options = getSubHeadingDeclarationFragmentsPrintOptions();
+    if (S.getSynthesizedBaseType()) {
+      Options.setBaseType(S.getSynthesizedBaseType());
+    }
+    S.getSymbolDecl()->print(Printer, Options);
   }
-  auto Options = getSubHeadingDeclarationFragmentsPrintOptions();
-  if (S.getSynthesizedBaseType()) {
-    Options.setBaseType(S.getSynthesizedBaseType());
-  }
-  S.getSymbolDecl()->print(Printer, Options);
 }
 
 void
@@ -540,7 +539,7 @@ SymbolGraph::serializeSubheadingDeclarationFragments(StringRef Key,
   DeclarationFragmentPrinter Printer(OS, Key);
 
   if (const auto *TD = dyn_cast<GenericTypeDecl>(S.getSymbolDecl())) {
-    Printer.printAbridgedType(TD);
+    Printer.printAbridgedType(TD, /*PrintKeyword=*/true);
   } else {
     auto Options = getSubHeadingDeclarationFragmentsPrintOptions();
     if (S.getSynthesizedBaseType()) {

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Navigator.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Navigator.swift
@@ -17,9 +17,8 @@ public struct MyStruct<S> { public var x: S
 // MYSTRUCT-NEXT:      "title": "MyStruct",
 // MYSTRUCT-NEXT:      "navigator": [
 // MYSTRUCT-NEXT:          {
-// MYSTRUCT-NEXT:              "kind": "typeIdentifier"
+// MYSTRUCT-NEXT:              "kind": "identifier"
 // MYSTRUCT-NEXT:              "spelling": "MyStruct"
-// MYSTRUCT-NEXT:              "preciseIdentifier": "s:9Navigator8MyStructV"
 // MYSTRUCT-NEXT:          }
 // MYSTRUCT-NEXT:      ]
 

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/SubheadingDeclarationFragmentsTypes.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/SubheadingDeclarationFragmentsTypes.swift
@@ -18,9 +18,8 @@
 // STRUCT-NEXT   "spelling": " "
 // STRUCT-NEXT }
 // STRUCT-NEXT {
-// STRUCT-NEXT   "kind": "typeIdentifier",
-// STRUCT-NEXT   "spelling": "Struct",
-// STRUCT-NEXT   "preciseIdentifier": "s:35SubheadingDeclarationFragmentsTypes6StructV"
+// STRUCT-NEXT   "kind": "identifier",
+// STRUCT-NEXT   "spelling": "Struct"
 // STRUCT-NEXT }
 public struct Struct<T> where T: Sequence {}
 
@@ -35,9 +34,8 @@ public struct Struct<T> where T: Sequence {}
 // ENUM-NEXT:   "spelling": " "
 // ENUM-NEXT: }
 // ENUM-NEXT: {
-// ENUM-NEXT:   "kind": "typeIdentifier",
-// ENUM-NEXT:   "spelling": "Enum",
-// ENUM-NEXT:   "preciseIdentifier": "s:35SubheadingDeclarationFragmentsTypes4EnumO"
+// ENUM-NEXT:   "kind": "identifier",
+// ENUM-NEXT:   "spelling": "Enum"
 // ENUM-NEXT: }
 public enum Enum<T> where T: Sequence {}
 
@@ -52,9 +50,8 @@ public enum Enum<T> where T: Sequence {}
 // PROTOCOL-NEXT:   "spelling": " "
 // PROTOCOL-NEXT: }
 // PROTOCOL-NEXT: {
-// PROTOCOL-NEXT:   "kind": "typeIdentifier",
-// PROTOCOL-NEXT:   "spelling": "Protocol",
-// PROTOCOL-NEXT:   "preciseIdentifier": "s:35SubheadingDeclarationFragmentsTypes8ProtocolP"
+// PROTOCOL-NEXT:   "kind": "identifier",
+// PROTOCOL-NEXT:   "spelling": "Protocol"
 // PROTOCOL-NEXT: }
 public protocol Protocol where T: Sequence {
   associatedtype T
@@ -71,9 +68,8 @@ public protocol Protocol where T: Sequence {
 // CLASS-NEXT   "spelling": " "
 // CLASS-NEXT },
 // CLASS-NEXT {
-// CLASS-NEXT   "kind": "typeIdentifier",
-// CLASS-NEXT   "spelling": "Class",
-// CLASS-NEXT   "preciseIdentifier": "s:35SubheadingDeclarationFragmentsTypes5ClassC"
+// CLASS-NEXT   "kind": "identifier",
+// CLASS-NEXT   "spelling": "Class"
 // CLASS-NEXT }
 public class Class<T> where T: Sequence {}
 
@@ -88,9 +84,8 @@ public class Class<T> where T: Sequence {}
 // TYPEALIAS-NEXT:   "spelling": " "
 // TYPEALIAS-NEXT: },
 // TYPEALIAS-NEXT: {
-// TYPEALIAS-NEXT:   "kind": "typeIdentifier",
-// TYPEALIAS-NEXT:   "spelling": "TypeAlias",
-// TYPEALIAS-NEXT:   "preciseIdentifier": "s:35SubheadingDeclarationFragmentsTypes9TypeAliasa"
+// TYPEALIAS-NEXT:   "kind": "identifier",
+// TYPEALIAS-NEXT:   "spelling": "TypeAlias"
 // TYPEALIAS-NEXT: }
 public typealias TypeAlias<T> = Struct<T> where T: Collection
 


### PR DESCRIPTION
In the cases where we specialize the presentation of type declarations in a
subheading or navigator setting, make sure to use the `identifier` fragment
kind instead of `typeIdentifier` to keep it consistent with the normal or
"full" setting.

rdar://62953144