### PR TITLE
[5.3] Revert "[CS] Account for type variables when matching metatypes"

### DIFF
--- a/test/Constraints/rdar62842651.swift
+++ b/test/Constraints/rdar62842651.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
+
+class A {}
+class B: A {}
+
+func test<T>(_ type: T.Type) -> T? {
+  fatalError()
+}
+
+// CHECK: [[RESULT:%.*]] = function_ref @$s12rdar628426514testyxSgxmlF
+// CHECK-NEXT: apply [[RESULT]]<B>({{.*}})
+let _: A? = test(B.self)


### PR DESCRIPTION
5.3 cherry-pick of https://github.com/apple/swift/pull/31569.

---

- Explanation: Reverts a commit that regressed type inference.

- Scope: Fixes a regression. 

- Resolves: rdar://62953678

- Risk: Very low. The commit is small and hasn't been part of a release.

- Testing: Added a regression test

- Reviewer: @xedin