### PR TITLE
Requestify SIL parsing

### DIFF
--- a/include/swift/AST/SILGenRequests.h
+++ b/include/swift/AST/SILGenRequests.h
@@ -41,7 +41,7 @@ void reportEvaluatedRequest(UnifiedStatsReporter &stats,
                             const Request &request);
 
 struct SILGenDescriptor {
-  llvm::PointerUnion<ModuleDecl *, FileUnit *> context;
+  llvm::PointerUnion<FileUnit *, ModuleDecl *> context;
   Lowering::TypeConverter &conv;
   const SILOptions &opts;
 
@@ -73,6 +73,17 @@ public:
                                          const SILOptions &opts) {
     return SILGenDescriptor{mod, conv, opts};
   }
+
+  /// For a single file input, returns a single element array containing that
+  /// file. Otherwise returns an array of each file in the module.
+  ArrayRef<FileUnit *> getFiles() const;
+
+  /// If the module or file contains SIL that needs parsing, returns the file
+  /// to be parsed, or \c nullptr if parsing isn't required.
+  SourceFile *getSourceFileToParse() const;
+
+  /// Whether the SIL is being emitted for a whole module.
+  bool isWholeModule() const;
 };
 
 void simple_display(llvm::raw_ostream &out, const SILGenDescriptor &d);
@@ -118,6 +129,22 @@ private:
 
 public:
   bool isCached() const { return true; }
+};
+
+/// Parses a .sil file into a SILModule.
+class ParseSILModuleRequest
+    : public SimpleRequest<ParseSILModuleRequest,
+                           std::unique_ptr<SILModule>(SILGenDescriptor),
+                           RequestFlags::Uncached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  std::unique_ptr<SILModule>
+  evaluate(Evaluator &evaluator, SILGenDescriptor desc) const;
 };
 
 /// The zone number for SILGen.

--- a/include/swift/AST/SILGenTypeIDZone.def
+++ b/include/swift/AST/SILGenTypeIDZone.def
@@ -20,3 +20,6 @@ SWIFT_REQUEST(SILGen, SILGenSourceFileRequest,
 SWIFT_REQUEST(SILGen, SILGenWholeModuleRequest,
               std::unique_ptr<SILModule>(SILGenDescriptor),
               Uncached, NoLocationInfo)
+SWIFT_REQUEST(SILGen, ParseSILModuleRequest,
+              std::unique_ptr<SILModule>(SILGenDescriptor),
+              Uncached, NoLocationInfo)

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -425,7 +425,6 @@ class CompilerInstance {
   DiagnosticEngine Diagnostics{SourceMgr};
   std::unique_ptr<ASTContext> Context;
   std::unique_ptr<Lowering::TypeConverter> TheSILTypes;
-  std::unique_ptr<SILModule> TheSILModule;
   std::unique_ptr<DiagnosticVerifier> DiagVerifier;
 
   /// Null if no tracker.
@@ -498,8 +497,6 @@ public:
 
   Lowering::TypeConverter &getSILTypes();
 
-  void createSILModule();
-
   void addDiagnosticConsumer(DiagnosticConsumer *DC) {
     Diagnostics.addConsumer(*DC);
   }
@@ -516,16 +513,6 @@ public:
   const DependencyTracker *getDependencyTracker() const { return DepTracker.get(); }
 
   UnifiedStatsReporter *getStatsReporter() const { return Stats.get(); }
-
-  SILModule *getSILModule() {
-    return TheSILModule.get();
-  }
-
-  std::unique_ptr<SILModule> takeSILModule();
-
-  bool hasSILModule() {
-    return static_cast<bool>(TheSILModule);
-  }
 
   ModuleDecl *getMainModule() const;
 
@@ -658,9 +645,6 @@ private:
 
 public:
   void freeASTContext();
-
-  /// Frees up the SILModule that this instance is holding on to.
-  void freeSILModule();
 
 private:
   /// Load stdlib & return true if should continue, i.e. no error

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -888,7 +888,8 @@ public:
   void parseTopLevel(SmallVectorImpl<Decl *> &decls);
 
   /// Parse the top-level SIL decls into the SIL module.
-  void parseTopLevelSIL();
+  /// \returns \c true if there was a parsing error.
+  bool parseTopLevelSIL();
 
   /// Flags that control the parsing of declarations.
   enum ParseDeclFlags {

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -102,9 +102,6 @@ namespace swift {
 
   /// @}
 
-  /// Parse a source file's SIL declarations into a given SIL module.
-  void parseSourceFileSIL(SourceFile &SF, SILParserState *sil);
-
   /// Finish the code completion.
   void performCodeCompletionSecondPass(SourceFile &SF,
                                        CodeCompletionCallbacksFactory &Factory);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -186,14 +186,6 @@ Lowering::TypeConverter &CompilerInstance::getSILTypes() {
   return *tc;
 }
 
-void CompilerInstance::createSILModule() {
-  assert(MainModule && "main module not created yet");
-  // Assume WMO if a -primary-file option was not provided.
-  TheSILModule = SILModule::createEmptyModule(
-      getMainModule(), getSILTypes(), Invocation.getSILOptions(),
-      Invocation.getFrontendOptions().InputsAndOutputs.isWholeModule());
-}
-
 void CompilerInstance::recordPrimaryInputBuffer(unsigned BufID) {
   PrimaryBufferIDs.insert(BufID);
 }
@@ -679,10 +671,6 @@ CompilerInstance::openModuleDoc(const InputFile &input) {
   return None;
 }
 
-std::unique_ptr<SILModule> CompilerInstance::takeSILModule() {
-  return std::move(TheSILModule);
-}
-
 /// Implicitly import the SwiftOnoneSupport module in non-optimized
 /// builds. This allows for use of popular specialized functions
 /// from the standard library, which makes the non-optimized builds
@@ -759,14 +747,6 @@ void CompilerInstance::performSemaUpTo(SourceFile::ASTStage_t LimitStage) {
 
   ModuleDecl *mainModule = getMainModule();
   Context->LoadedModules[mainModule->getName()] = mainModule;
-
-  if (Invocation.getInputKind() == InputFileKind::SIL) {
-    assert(!InputSourceCodeBufferIDs.empty());
-    assert(InputSourceCodeBufferIDs.size() == 1);
-    assert(MainBufferID != NO_SUCH_BUFFER);
-    assert(isPrimaryInput(MainBufferID) || isWholeModuleCompilation());
-    createSILModule();
-  }
 
   if (Invocation.getImplicitStdlibKind() == ImplicitStdlibKind::Stdlib) {
     if (!loadStdlib())
@@ -988,8 +968,6 @@ void CompilerInstance::freeASTContext() {
   PrimaryBufferIDs.clear();
   PrimarySourceFiles.clear();
 }
-
-void CompilerInstance::freeSILModule() { TheSILModule.reset(); }
 
 /// Perform "stable" optimizations that are invariant across compiler versions.
 static bool performMandatorySILPasses(CompilerInvocation &Invocation,

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -814,13 +814,6 @@ void CompilerInstance::performSemaUpTo(SourceFile::ASTStage_t LimitStage) {
 
   forEachFileToTypeCheck([&](SourceFile &SF) {
     performTypeChecking(SF);
-
-    // Parse the SIL decls if needed.
-    // TODO: Requestify SIL parsing.
-    if (TheSILModule) {
-      SILParserState SILContext(TheSILModule.get());
-      parseSourceFileSIL(SF, &SILContext);
-    }
   });
 
   finishTypeChecking();

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1066,17 +1066,11 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
 static bool performCompileStepsPostSema(CompilerInstance &Instance,
                                         int &ReturnValue,
                                         FrontendObserver *observer) {
-  auto mod = Instance.getMainModule();
-  if (auto SM = Instance.takeSILModule()) {
-    const PrimarySpecificPaths PSPs =
-        Instance.getPrimarySpecificPathsForAtMostOnePrimary();
-    return performCompileStepsPostSILGen(Instance, std::move(SM), mod, PSPs,
-                                         ReturnValue, observer);
-  }
-
   const auto &Invocation = Instance.getInvocation();
   const SILOptions &SILOpts = Invocation.getSILOptions();
   const FrontendOptions &opts = Invocation.getFrontendOptions();
+
+  auto *mod = Instance.getMainModule();
   if (!opts.InputsAndOutputs.hasPrimaryInputs()) {
     // If there are no primary inputs the compiler is in WMO mode and builds one
     // SILModule for the entire module.

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -121,7 +121,14 @@ ParseSILModuleRequest::evaluate(Evaluator &evaluator,
   SILParserState parserState(silMod.get());
   Parser parser(*bufferID, *SF, parserState.Impl.get());
   PrettyStackTraceParser StackTrace(parser);
-  parser.parseTopLevelSIL();
+
+  auto hadError = parser.parseTopLevelSIL();
+  if (hadError) {
+    // The rest of the SIL pipeline expects well-formed SIL, so if we encounter
+    // a parsing error, just return an empty SIL module.
+    return SILModule::createEmptyModule(mod, desc.conv, desc.opts,
+                                        desc.isWholeModule());
+  }
   return silMod;
 }
 

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/SILGenRequests.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Defer.h"
@@ -105,17 +106,23 @@ SILParserState::SILParserState(SILModule *M)
 
 SILParserState::~SILParserState() = default;
 
-void swift::parseSourceFileSIL(SourceFile &SF, SILParserState *sil) {
-  auto bufferID = SF.getBufferID();
+std::unique_ptr<SILModule>
+ParseSILModuleRequest::evaluate(Evaluator &evaluator,
+                                SILGenDescriptor desc) const {
+  auto *SF = desc.getSourceFileToParse();
+  assert(SF);
+
+  auto bufferID = SF->getBufferID();
   assert(bufferID);
 
-  FrontendStatsTracer tracer(SF.getASTContext().Stats,
-                             "Parsing SIL");
-  Parser parser(*bufferID, SF, sil->Impl.get(),
-                /*persistentParserState*/ nullptr,
-                /*syntaxTreeCreator*/ nullptr);
+  auto *mod = SF->getParentModule();
+  auto silMod = SILModule::createEmptyModule(mod, desc.conv, desc.opts,
+                                             desc.isWholeModule());
+  SILParserState parserState(silMod.get());
+  Parser parser(*bufferID, *SF, parserState.Impl.get());
   PrettyStackTraceParser StackTrace(parser);
   parser.parseTopLevelSIL();
+  return silMod;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1860,6 +1860,11 @@ public:
 std::unique_ptr<SILModule>
 SILGenSourceFileRequest::evaluate(Evaluator &evaluator,
                                   SILGenDescriptor desc) const {
+  // If we have a .sil file to parse, defer to the parsing request.
+  if (desc.getSourceFileToParse()) {
+    return llvm::cantFail(evaluator(ParseSILModuleRequest{desc}));
+  }
+
   auto *unit = desc.context.get<FileUnit *>();
   auto *mod = unit->getParentModule();
   auto M = std::unique_ptr<SILModule>(
@@ -1879,6 +1884,11 @@ SILGenSourceFileRequest::evaluate(Evaluator &evaluator,
 std::unique_ptr<SILModule>
 SILGenWholeModuleRequest::evaluate(Evaluator &evaluator,
                                    SILGenDescriptor desc) const {
+  // If we have a .sil file to parse, defer to the parsing request.
+  if (desc.getSourceFileToParse()) {
+    return llvm::cantFail(evaluator(ParseSILModuleRequest{desc}));
+  }
+
   auto *mod = desc.context.get<ModuleDecl *>();
   auto M = std::unique_ptr<SILModule>(
       new SILModule(mod, desc.conv, desc.opts, mod, /*wholeModule*/ true));

--- a/lib/SILGen/SILGenRequests.cpp
+++ b/lib/SILGen/SILGenRequests.cpp
@@ -56,6 +56,49 @@ evaluator::DependencySource SILGenSourceFileRequest::readDependencySource(
   };
 }
 
+ArrayRef<FileUnit *> SILGenDescriptor::getFiles() const {
+  if (auto *mod = context.dyn_cast<ModuleDecl *>())
+    return mod->getFiles();
+
+  // For a single file, we can form an ArrayRef that points at its storage in
+  // the union.
+  return llvm::makeArrayRef(*context.getAddrOfPtr1());
+}
+
+bool SILGenDescriptor::isWholeModule() const {
+  return context.is<ModuleDecl *>();
+}
+
+SourceFile *SILGenDescriptor::getSourceFileToParse() const {
+#ifndef NDEBUG
+  auto sfCount = llvm::count_if(getFiles(), [](FileUnit *file) {
+    return isa<SourceFile>(file);
+  });
+  auto silFileCount = llvm::count_if(getFiles(), [](FileUnit *file) {
+    auto *SF = dyn_cast<SourceFile>(file);
+    return SF && SF->Kind == SourceFileKind::SIL;
+  });
+  assert(silFileCount == 0 || (silFileCount == 1 && sfCount == 1) &&
+         "Cannot currently mix a .sil file with other SourceFiles");
+#endif
+
+  for (auto *file : getFiles()) {
+    // Skip other kinds of files.
+    auto *SF = dyn_cast<SourceFile>(file);
+    if (!SF)
+      continue;
+
+    // Given the above precondition that a .sil file isn't mixed with other
+    // SourceFiles, we can return a SIL file if we have it, or return nullptr.
+    if (SF->Kind == SourceFileKind::SIL) {
+      return SF;
+    } else {
+      return nullptr;
+    }
+  }
+  return nullptr;
+}
+
 // Define request evaluation functions for each of the SILGen requests.
 static AbstractRequestFunction *silGenRequestFunctions[] = {
 #define SWIFT_REQUEST(Zone, Name, Sig, Caching, LocOptions)                    \

--- a/tools/sil-llvm-gen/SILLLVMGen.cpp
+++ b/tools/sil-llvm-gen/SILLLVMGen.cpp
@@ -184,26 +184,28 @@ int main(int argc, char **argv) {
   if (CI.getASTContext().hadError())
     return 1;
 
-  // Load the SIL if we have a module. We have to do this after SILParse
-  // creating the unfortunate double if statement.
-  if (Invocation.hasSerializedAST()) {
-    assert(!CI.hasSILModule() &&
-           "performSema() should not create a SILModule.");
-    CI.createSILModule();
-    std::unique_ptr<SerializedSILLoader> SL = SerializedSILLoader::create(
-        CI.getASTContext(), CI.getSILModule(), nullptr);
+  auto *mod = CI.getMainModule();
+  assert(mod->getFiles().size() == 1);
 
-    if (extendedInfo.isSIB())
-      SL->getAllForModule(CI.getMainModule()->getName(), nullptr);
-    else
-      SL->getAll();
+  std::unique_ptr<SILModule> SILMod;
+  if (PerformWMO) {
+    SILMod = performSILGeneration(mod, CI.getSILTypes(), CI.getSILOptions());
+  } else {
+    SILMod = performSILGeneration(*mod->getFiles()[0], CI.getSILTypes(),
+                                  CI.getSILOptions());
+  }
+
+  // Load the SIL if we have a non-SIB serialized module. SILGen handles SIB for
+  // us.
+  if (Invocation.hasSerializedAST() && !extendedInfo.isSIB()) {
+    auto SL = SerializedSILLoader::create(
+        CI.getASTContext(), SILMod.get(), nullptr);
+    SL->getAll();
   }
 
   const PrimarySpecificPaths PSPs(OutputFilename, InputFilename);
-  auto Mod =
-      performIRGeneration(Opts, CI.getMainModule(), CI.takeSILModule(),
-                          CI.getMainModule()->getName().str(),
-                          PSPs,
-                          ArrayRef<std::string>());
+  auto Mod = performIRGeneration(Opts, CI.getMainModule(), std::move(SILMod),
+                                 CI.getMainModule()->getName().str(), PSPs,
+                                 ArrayRef<std::string>());
   return CI.getASTContext().hadError();
 }


### PR DESCRIPTION
Introduce `ParseSILModuleRequest` to replace `parseSourceFileSIL`, and call it from SIL generation instead of inside `performSemaUpTo`. This then allows us to remove the `SILModule` stored in the Frontend.