### PR TITLE
runtime: add and switch to `SWIFT_USED` (NFC)

### DIFF
--- a/stdlib/public/SwiftShims/HeapObject.h
+++ b/stdlib/public/SwiftShims/HeapObject.h
@@ -65,7 +65,7 @@ struct HeapObject {
   { }
 
 #ifndef NDEBUG
-  void dump() const LLVM_ATTRIBUTE_USED;
+  void dump() const SWIFT_USED;
 #endif
 
 #endif // __swift__

--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -182,7 +182,7 @@ namespace swift {
 }
 
 // FIXME: HACK: copied from HeapObject.cpp
-extern "C" SWIFT_LIBRARY_VISIBILITY SWIFT_NOINLINE LLVM_ATTRIBUTE_USED void
+extern "C" SWIFT_LIBRARY_VISIBILITY SWIFT_NOINLINE SWIFT_USED void
 _swift_release_dealloc(swift::HeapObject *object);
 
 namespace swift {

--- a/stdlib/public/SwiftShims/Visibility.h
+++ b/stdlib/public/SwiftShims/Visibility.h
@@ -72,6 +72,12 @@
 #define SWIFT_NOINLINE
 #endif
 
+#if __has_attribute(used)
+#define SWIFT_USED __attribute__((__used__))
+#else
+#define SWIFT_USED
+#endif
+
 #if __has_attribute(unavailable)
 #define SWIFT_ATTRIBUTE_UNAVAILABLE __attribute__((__unavailable__))
 #else

--- a/stdlib/public/runtime/ExistentialContainer.cpp
+++ b/stdlib/public/runtime/ExistentialContainer.cpp
@@ -56,9 +56,7 @@ void OpaqueExistentialContainer::deinit() {
 
 // *NOTE* This routine performs unused memory reads on purpose to try to catch
 // use-after-frees in conjunction with ASAN or Guard Malloc.
-template <>
-LLVM_ATTRIBUTE_USED
-void OpaqueExistentialContainer::verify() const {
+template <> SWIFT_USED void OpaqueExistentialContainer::verify() const {
   // We do not actually care about value. We just want to see if the
   // memory is valid or not. So convert to a uint8_t and try to
   // memcpy into firstByte. We use volatile to just ensure that this
@@ -70,9 +68,7 @@ void OpaqueExistentialContainer::verify() const {
 }
 
 /// Dump information about this specific container and its contents.
-template <>
-LLVM_ATTRIBUTE_USED
-void OpaqueExistentialContainer::dump() const {
+template <> SWIFT_USED void OpaqueExistentialContainer::dump() const {
   // Quickly verify to make sure we are well formed.
   verify();
 

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -327,7 +327,7 @@ HeapObject *swift::swift_allocEmptyBox() {
 }
 
 // Forward-declare this, but define it after swift_release.
-extern "C" SWIFT_LIBRARY_VISIBILITY SWIFT_NOINLINE LLVM_ATTRIBUTE_USED void
+extern "C" SWIFT_LIBRARY_VISIBILITY SWIFT_NOINLINE SWIFT_USED void
 _swift_release_dealloc(HeapObject *object);
 
 static HeapObject *_swift_retain_(HeapObject *object) {

--- a/stdlib/public/runtime/Leaks.h
+++ b/stdlib/public/runtime/Leaks.h
@@ -31,17 +31,17 @@ struct HeapObject;
 }
 
 SWIFT_CC(swift)
-SWIFT_RUNTIME_EXPORT SWIFT_NOINLINE LLVM_ATTRIBUTE_USED
-void _swift_leaks_startTrackingObjects(const char *);
+SWIFT_RUNTIME_EXPORT SWIFT_NOINLINE SWIFT_USED void
+_swift_leaks_startTrackingObjects(const char *);
 
 SWIFT_CC(swift)
-SWIFT_RUNTIME_EXPORT SWIFT_NOINLINE LLVM_ATTRIBUTE_USED
-int _swift_leaks_stopTrackingObjects(const char *);
+SWIFT_RUNTIME_EXPORT SWIFT_NOINLINE SWIFT_USED int
+_swift_leaks_stopTrackingObjects(const char *);
 
-SWIFT_RUNTIME_EXPORT SWIFT_NOINLINE LLVM_ATTRIBUTE_USED void
+SWIFT_RUNTIME_EXPORT SWIFT_NOINLINE SWIFT_USED void
 _swift_leaks_startTrackingObject(swift::HeapObject *);
 
-SWIFT_RUNTIME_EXPORT SWIFT_NOINLINE LLVM_ATTRIBUTE_USED void
+SWIFT_RUNTIME_EXPORT SWIFT_NOINLINE SWIFT_USED void
 _swift_leaks_stopTrackingObject(swift::HeapObject *);
 
 #define SWIFT_LEAKS_START_TRACKING_OBJECT(obj)                                 \

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -4142,9 +4142,7 @@ StringRef swift::getStringForMetadataKind(MetadataKind kind) {
 /***************************************************************************/
 
 #ifndef NDEBUG
-template <>
-LLVM_ATTRIBUTE_USED
-void Metadata::dump() const {
+template <> SWIFT_USED void Metadata::dump() const {
   printf("TargetMetadata.\n");
   printf("Kind: %s.\n", getStringForMetadataKind(getKind()).data());
   printf("Value Witnesses: %p.\n", getValueWitnesses());
@@ -4197,9 +4195,7 @@ void Metadata::dump() const {
 #endif
 }
 
-template <>
-LLVM_ATTRIBUTE_USED
-void ContextDescriptor::dump() const {
+template <> SWIFT_USED void ContextDescriptor::dump() const {
   printf("TargetTypeContextDescriptor.\n");
   printf("Flags: 0x%x.\n", this->Flags.getIntValue());
   printf("Parent: %p.\n", this->Parent.get());
@@ -4211,9 +4207,7 @@ void ContextDescriptor::dump() const {
   }
 }
 
-template<>
-LLVM_ATTRIBUTE_USED
-void EnumDescriptor::dump() const {
+template <> SWIFT_USED void EnumDescriptor::dump() const {
   printf("TargetEnumDescriptor.\n");
   printf("Flags: 0x%x.\n", this->Flags.getIntValue());
   printf("Parent: %p.\n", this->Parent.get());

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -31,9 +31,7 @@
 using namespace swift;
 
 #ifndef NDEBUG
-template <>
-LLVM_ATTRIBUTE_USED
-void ProtocolDescriptor::dump() const {
+template <> SWIFT_USED void ProtocolDescriptor::dump() const {
   printf("TargetProtocolDescriptor.\n"
          "Name: \"%s\".\n",
          Name.get());
@@ -95,9 +93,7 @@ template<> void ProtocolConformanceDescriptor::dump() const {
 #endif
 
 #ifndef NDEBUG
-template<>
-LLVM_ATTRIBUTE_USED
-void ProtocolConformanceDescriptor::verify() const {
+template <> SWIFT_USED void ProtocolConformanceDescriptor::verify() const {
   auto typeKind = unsigned(getTypeKind());
   assert(((unsigned(TypeReferenceKind::First_Kind) <= typeKind) &&
           (unsigned(TypeReferenceKind::Last_Kind) >= typeKind)) &&
@@ -302,7 +298,7 @@ struct ConformanceState {
   }
 
 #ifndef NDEBUG
-  void verify() const LLVM_ATTRIBUTE_USED;
+  void verify() const SWIFT_USED;
 #endif
 };
 


### PR DESCRIPTION
This further trims dependencies to LLVMSupport by introducing the
equivalent `SWIFT_USED` macro.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
