### PR TITLE
[ownership] Track /all/ non consuming uses and emit errors for all of them instead of relying on just the last one in a block.

### DIFF
--- a/include/swift/Basic/FrozenMultiMap.h
+++ b/include/swift/Basic/FrozenMultiMap.h
@@ -231,6 +231,8 @@ public:
 
   /// Return a range of (key, ArrayRef<Value>) pairs. The keys are guaranteed to
   /// be in key sorted order and the ArrayRef<Value> are in insertion order.
+  ///
+  /// The range skips all erased (key, ArrayRef<Value>) entries.
   RangeType getRange() const {
     assert(isFrozen() &&
            "Can not create range until data structure is frozen?!");

--- a/test/SIL/ownership-verifier/arguments.sil
+++ b/test/SIL/ownership-verifier/arguments.sil
@@ -244,16 +244,6 @@ bb5:
 // CHECK: Block: bb2
 // CHECK: Error#: 0. End Error in Function: 'bad_order'
 //
-// TODO: Should we really flag this twice?
-//
-// CHECK-LABEL: Error#: 1. Begin Error in Function: 'bad_order'
-// CHECK: Found use after free due to unvisited non lifetime ending uses?!
-// CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
-// CHECK: Remaining Users:
-// CHECK: User:  end_borrow %5 : $Builtin.NativeObject
-// CHECK: Block: bb2
-// CHECK: Error#: 1. End Error in Function: 'bad_order'
-//
 // CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'bad_order'
 sil [ossa] @bad_order : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
@@ -301,6 +291,15 @@ bb5:
 // CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %19
 // CHECK: Error#: 1. End Error in Function: 'bad_order_add_a_level'
 //
+// This block is reported as leaking block since given our partial-cfg:
+//
+//                /---> BB3
+// BB1 -> BB2 ------> BB5
+//
+// we create the borrow at BB1 and end its lifetime at BB2 and BB5. This causes
+// us to walk up, identify they double consume at BB2 from BB5. Since we skipped
+// BB3 that is identified as a leaking block appropriately.
+//
 // CHECK-LABEL: Error#: 2. Begin Error in Function: 'bad_order_add_a_level'
 // CHECK: Error! Found a leak due to a consuming post-dominance failure!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %19, %14, %6, %3
@@ -308,18 +307,7 @@ bb5:
 // CHECK: bb3
 // CHECK: Error#: 2. End Error in Function: 'bad_order_add_a_level'
 //
-// This error is a "use after free" error b/c we are accessing the argument
-// /after/ we end the parent borrow. We /could/ improve the error message here.
-//
 // CHECK-LABEL: Error#: 3. Begin Error in Function: 'bad_order_add_a_level'
-// CHECK: Found use after free due to unvisited non lifetime ending uses?!
-// CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %19, %14, %6, %3
-// CHECK: Remaining Users:
-// CHECK: User:  end_borrow %5 : $Builtin.NativeObject           // id: %7
-// CHECK: Block: bb2
-// CHECK: Error#: 3. End Error in Function: 'bad_order_add_a_level'
-//
-// CHECK-LABEL: Error#: 4. Begin Error in Function: 'bad_order_add_a_level'
 // CHECK: Found over consume?!
 // CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %13, %9, %7
 // CHECK: User:   end_borrow %5 : $Builtin.NativeObject           // id: %13
@@ -327,27 +315,31 @@ bb5:
 // CHECK: Consuming Users:
 // CHECK:   end_borrow %5 : $Builtin.NativeObject           // id: %7
 // CHECK:   end_borrow %5 : $Builtin.NativeObject           // id: %13
-// CHECK: Error#: 4. End Error in Function: 'bad_order_add_a_level'
+// CHECK: Error#: 3. End Error in Function: 'bad_order_add_a_level'
 //
-// CHECK-LABEL: Error#: 5. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK-LABEL: Error#: 4. Begin Error in Function: 'bad_order_add_a_level'
 // CHECK: Error! Found a leak due to a consuming post-dominance failure!
 // CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %13, %9, %7
 // CHECK: Post Dominating Failure Blocks:
 // CHECK: bb3
+// CHECK: Error#: 4. End Error in Function: 'bad_order_add_a_level'
+//
+// We found a use that we didn't visit. For our purposes, we consider this to be
+// an outside lifetime use rather than use after freer to unite it with errors
+// from uses that are not reachable from the definition of the value.
+//
+// CHECK-LABEL: Error#: 5. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK: Found outside of lifetime uses!
+// CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %13, %9, %7
+// CHECK: User List:
+// CHECK: User:  %9 = begin_borrow %5 : $Builtin.NativeObject    // user: %10
+// CHECK: Block: bb3
 // CHECK: Error#: 5. End Error in Function: 'bad_order_add_a_level'
 //
 // CHECK-LABEL: Error#: 6. Begin Error in Function: 'bad_order_add_a_level'
-// CHECK: Found use after free due to unvisited non lifetime ending uses?!
-// CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %13, %9, %7
-// CHECK: Remaining Users:
-// CHECK: User:  %9 = begin_borrow %5 : $Builtin.NativeObject    // user: %10
-// CHECK: Block: bb3
-// CHECK: Error#: 6. End Error in Function: 'bad_order_add_a_level'
-//
-// CHECK-LABEL: Error#: 7. Begin Error in Function: 'bad_order_add_a_level'
 // CHECK: Non trivial values, non address values, and non guaranteed function args must have at least one lifetime ending use?!
 // CHECK: Value: %11 = argument of bb4 : $Builtin.NativeObject
-// CHECK: Error#: 7. End Error in Function: 'bad_order_add_a_level'
+// CHECK: Error#: 6. End Error in Function: 'bad_order_add_a_level'
 //
 // CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'bad_order_add_a_level'
 sil [ossa] @bad_order_add_a_level : $@convention(thin) (@owned Builtin.NativeObject) -> () {
@@ -442,34 +434,20 @@ bb7:
 // CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %22
 // CHECK: Error#: 4. End Error in Function: 'bad_order_add_a_level_2'
 //
-// These are handled via other checks.
-//
 // CHECK-LABEL: Error#: 5. Begin Error in Function: 'bad_order_add_a_level_2'
-// CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
-// CHECK: Error#: 5. End Error in Function: 'bad_order_add_a_level_2'
-//
-// CHECK-LABEL: Error#: 6. Begin Error in Function: 'bad_order_add_a_level_2'
-// CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
-// CHECK: Error#: 6. End Error in Function: 'bad_order_add_a_level_2'
-//
-// CHECK-LABEL: Error#: 7. Begin Error in Function: 'bad_order_add_a_level_2'
-// CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
-// CHECK: Error#: 7. End Error in Function: 'bad_order_add_a_level_2'
-//
-// CHECK-LABEL: Error#: 8. Begin Error in Function: 'bad_order_add_a_level_2'
 // CHECK-NEXT: Found use after free?!
 // CHECK-NEXT: Value: %5 = argument of bb2 : $Builtin.NativeObject
 // CHECK-NEXT: Consuming User:   end_borrow %5 : $Builtin.NativeObject
 // CHECK-NEXT: Non Consuming User:   end_borrow %11 : $Builtin.NativeObject
 // CHECK-NEXT: Block: bb4
-// CHECK: Error#: 8. End Error in Function: 'bad_order_add_a_level_2'
+// CHECK: Error#: 5. End Error in Function: 'bad_order_add_a_level_2'
 //
-// CHECK-LABEL: Error#: 9. Begin Error in Function: 'bad_order_add_a_level_2'
+// CHECK-LABEL: Error#: 6. Begin Error in Function: 'bad_order_add_a_level_2'
 // CHECK-NEXT: Found over consume?!
 // CHECK-NEXT: Value: %5 = argument of bb2 : $Builtin.NativeObject
 // CHECK-NEXT: User:   end_borrow %5 : $Builtin.NativeObject
 // CHECK-NEXT: Block: bb2
-// CHECK: Error#: 9. End Error in Function: 'bad_order_add_a_level_2'
+// CHECK: Error#: 6. End Error in Function: 'bad_order_add_a_level_2'
 //
 // NOTE: There are 2-3 errors here we are not pattern matching. We should add
 // patterns for them so we track if they are changed.
@@ -683,19 +661,29 @@ bb3:
 // CHECK-NEXT:   br bb2(%1 : $Builtin.NativeObject, %1 : $Builtin.NativeObject) // id: %3
 // CHECK: Error#: 0. End Error in Function: 'simple_loop_carry_over_consume'
 //
+// This error is a little non-sensical since we have malformed SIL here. The
+// end_borrow is considered to be a read only use of itself since we borrow %5
+// and then pass %8 (the result of the borrow) around the loop. This then
+// becomes %5 and then our end_borrow is treated as the end of the lfietime of
+// the end_borrow and thus a liveness requiring use of the thing that %8 was
+// borrowed from, %5.
+//
 // CHECK-LABEL: Error#: 1. Begin Error in Function: 'simple_loop_carry_over_consume'
 // CHECK: Found use after free?!
 // CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %11, %10, %8
 // CHECK: Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
-// CHECK: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject           // id: %12
+// CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
 // CHECK: Block: bb5
 // CHECK: Error#: 1. End Error in Function: 'simple_loop_carry_over_consume'
 //
+// %5 is passed around the loop as an incoming value to %4. So we get a certain
+// amount of circularity here. The important thing is we flag it.
+//
 // CHECK-LABEL: Error#: 2. Begin Error in Function: 'simple_loop_carry_over_consume'
-// CHECK: Found use after free due to unvisited non lifetime ending uses?!
+// CHECK: Found use after free?!
 // CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %11, %10, %8
-// CHECK: Remaining Users:
-// CHECK: User:  end_borrow %4 : $Builtin.NativeObject           // id: %12
+// CHECK: Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
+// CHECK: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject           // id: %12
 // CHECK: Block: bb5
 // CHECK: Error#: 2. End Error in Function: 'simple_loop_carry_over_consume'
 //
@@ -756,24 +744,26 @@ bb3:
   return %9999 : $()
 }
 
-// This first test fails since the %2a is considered dead at bb2a's
-// terminator. So the end_borrow of %2a in bb3 is considered a liveness use of
-// %2 due to it consuming %3 via the loop carry.
+// This is slightly non-sensical since we are feeding the verifier broken SIL.
 //
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
 // CHECK-NEXT: Found use after free?!
 // CHECK-NEXT: Value: %5 = argument of bb1 : $Builtin.NativeObject      // users: %11, %10, %8
 // CHECK-NEXT: Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
-// CHECK-NEXT: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject           // id: %12
+// CHECK-NEXT: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
 // CHECK-NEXT: Block: bb4
 // CHECK: Error#: 0. End Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
 //
+// This test fails since the %2a is considered dead at bb2a's terminator. So the
+// end_borrow of %2a in bb3 is considered a liveness use of %2 due to it
+// consuming %3 via the loop carry.
+//
 // CHECK-LABEL: Error#: 1. Begin Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
-// CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
-// CHECK-NEXT: Value: %5 = argument of bb1 : $Builtin.NativeObject      // users: %11, %10, %8
-// CHECK-NEXT:     Remaining Users:
-// CHECK-NEXT: User:  end_borrow %4 : $Builtin.NativeObject           // id: %12
-// CHECK-NEXT: Block: bb4
+// CHECK: Found use after free?!
+// CHECK: Value: %5 = argument of bb1 : $Builtin.NativeObject      // users: %11, %10, %8
+// CHECK: Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
+// CHECK: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject           // id: %12
+// CHECK: Block: bb4
 // CHECK: Error#: 1. End Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
 //
 // CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'

--- a/test/SIL/ownership-verifier/borrow_scope_introducing_operands.sil
+++ b/test/SIL/ownership-verifier/borrow_scope_introducing_operands.sil
@@ -19,12 +19,13 @@ bb2:
   unwind
 }
 
-// CHECK-LABEL: Function: 'destroy_value_before_end_borrow'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'destroy_value_before_end_borrow'
 // CHECK: Found use after free?!
 // CHECK: Value: %0 = argument of bb0 : $Builtin.NativeObject
 // CHECK: Consuming User:   destroy_value %0 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   end_borrow %1 : $Builtin.NativeObject
 // CHECK: Block: bb0
+// CHECK: Error#: 0. End Error in Function: 'destroy_value_before_end_borrow'
 sil [ossa] @destroy_value_before_end_borrow : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -34,12 +35,15 @@ bb0(%0 : @owned $Builtin.NativeObject):
   return %9999 : $()
 }
 
-// CHECK-LABEL: Function: 'destroy_value_before_end_borrow_coroutine'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'destroy_value_before_end_borrow_coroutine'
 // CHECK: Found use after free?!
 // CHECK: Value: %0 = argument of bb0 : $Builtin.NativeObject
 // CHECK: Consuming User:   destroy_value %0 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   end_apply %2
 // CHECK: Block: bb0
+// CHECK: Error#: 0. End Error in Function: 'destroy_value_before_end_borrow_coroutine'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'destroy_value_before_end_borrow_coroutine'
 sil [ossa] @destroy_value_before_end_borrow_coroutine : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %coro = function_ref @coroutine_callee : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
@@ -50,12 +54,15 @@ bb0(%0 : @owned $Builtin.NativeObject):
   return %r : $()
 }
 
-// CHECK-LABEL: Function: 'destroy_value_before_end_borrow_coroutine_2'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'destroy_value_before_end_borrow_coroutine_2'
 // CHECK: Found use after free?!
 // CHECK: Value: %0 = argument of bb0 : $Builtin.NativeObject
 // CHECK: Consuming User:   destroy_value %0 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   abort_apply %2
 // CHECK: Block: bb0
+// CHECK: Error#: 0. End Error in Function: 'destroy_value_before_end_borrow_coroutine_2'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'destroy_value_before_end_borrow_coroutine_2'
 sil [ossa] @destroy_value_before_end_borrow_coroutine_2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %coro = function_ref @coroutine_callee : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
@@ -66,20 +73,15 @@ bb0(%0 : @owned $Builtin.NativeObject):
   return %r : $()
 }
 
-// CHECK-LABEL: Function: 'destroy_value_before_end_borrow_coroutine_3'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'destroy_value_before_end_borrow_coroutine_3'
 // CHECK: Found use after free?!
 // CHECK: Value: %0 = argument of bb0 : $Builtin.NativeObject
 // CHECK: Consuming User:   destroy_value %0 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   abort_apply %2
 // CHECK: Block: bb1
-
-// CHECK-LABEL: Function: 'destroy_value_before_end_borrow_coroutine_3'
-// CHECK: Found use after free due to unvisited non lifetime ending uses?!
-// CHECK: Value: %0 = argument of bb0 : $Builtin.NativeObject
-// CHECK:     Remaining Users:
-// CHECK: User:  abort_apply %2
-// CHECK: Block: bb1
-
+// CHECK: Error#: 0. End Error in Function: 'destroy_value_before_end_borrow_coroutine_3'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'destroy_value_before_end_borrow_coroutine_3'
 sil [ossa] @destroy_value_before_end_borrow_coroutine_3 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %coro = function_ref @coroutine_callee : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
@@ -101,12 +103,15 @@ bb3:
   return %r : $()
 }
 
-// CHECK-LABEL: Function: 'parent_borrow_scope_end_before_end_borrow_coroutine'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'parent_borrow_scope_end_before_end_borrow_coroutine'
 // CHECK: Found use after free?!
 // CHECK: Value: %1 = begin_borrow %0 : $Builtin.NativeObject
 // CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   end_apply %3
 // CHECK: Block: bb0
+// CHECK: Error#: 0. End Error in Function: 'parent_borrow_scope_end_before_end_borrow_coroutine'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'parent_borrow_scope_end_before_end_borrow_coroutine'
 sil [ossa] @parent_borrow_scope_end_before_end_borrow_coroutine : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -119,12 +124,15 @@ bb0(%0 : @owned $Builtin.NativeObject):
   return %r : $()
 }
 
-// CHECK-LABEL: Function: 'parent_borrow_scope_end_before_end_borrow_coroutine_2'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'parent_borrow_scope_end_before_end_borrow_coroutine_2'
 // CHECK: Found use after free?!
 // CHECK: Value: %1 = begin_borrow %0 : $Builtin.NativeObject
 // CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   abort_apply %3
 // CHECK: Block: bb0
+// CHECK: Error#: 0. End Error in Function: 'parent_borrow_scope_end_before_end_borrow_coroutine_2'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'parent_borrow_scope_end_before_end_borrow_coroutine_2'
 sil [ossa] @parent_borrow_scope_end_before_end_borrow_coroutine_2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -137,20 +145,15 @@ bb0(%0 : @owned $Builtin.NativeObject):
   return %r : $()
 }
 
-// CHECK-LABEL: Function: 'parent_borrow_scope_end_before_end_borrow_coroutine_3'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'parent_borrow_scope_end_before_end_borrow_coroutine_3'
 // CHECK: Found use after free?!
 // CHECK: Value: %1 = begin_borrow %0 : $Builtin.NativeObject
 // CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   abort_apply %3
 // CHECK: Block: bb1
-
-// CHECK-LABEL: Function: 'parent_borrow_scope_end_before_end_borrow_coroutine_3'
-// CHECK: Found use after free due to unvisited non lifetime ending uses?!
-// CHECK: Value: %1 = begin_borrow %0 : $Builtin.NativeObject
-// CHECK:     Remaining Users:
-// CHECK: User:  abort_apply %3
-// CHECK: Block: bb1
-
+// CHECK: Error#: 0. End Error in Function: 'parent_borrow_scope_end_before_end_borrow_coroutine_3'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'parent_borrow_scope_end_before_end_borrow_coroutine_3'
 sil [ossa] @parent_borrow_scope_end_before_end_borrow_coroutine_3 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject


### PR DESCRIPTION
Beyond allowing us to emit better errors, this will allow me to (in a subsequent
commit) count the amount of uses that are "outside" of the linear lifetime. I
can then compare that against a passed in set of "non consuming uses". If the
count of the number of uses "outside" of the linear lifetime equals the count of
the passed in set of "non consuming uses", then I know that /all/ non consuming
uses that I am testing against are not co-incident with the linear lifetime,
meaning that they can not effect (in a local, direct sense) the linear lifetime.

I am going to use that information to determine when it is safe to convert an
inout form a load [copy] to a load_borrow in the face of local mutations. I can
pass the set of local mutations as non-consuming uses to a linear lifetime
consisting of the load [copy]/destroy_values and thus prove that no writes occur
in between the load [copy]/destroy_value meaning it is safe to conver them to
borrow form.

NOTE: The aforementioned optimization is an extension of an optimization already
in tree that just bails if we have any writes to an inout locally, which is so
unfortunate.
