### PR TITLE
[5.3][Diagnostics] Diagnose passing r-value without `&` to `inout` paramet…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3111,9 +3111,15 @@ bool ConstraintSystem::repairFailures(
       // position (which doesn't require explicit `&`) decays into
       // a `Bind` of involved object types, same goes for explicit
       // `&` conversion from l-value to inout type.
+      //
+      // In case of regular argument conversion although explicit `&`
+      // is required we still want to diagnose the problem as one
+      // about mutability instead of suggesting to add `&` which wouldn't
+      // be correct.
       auto kind = (isa<InOutExpr>(anchor) ||
                    (rhs->is<InOutType>() &&
-                    matchKind == ConstraintKind::OperatorArgumentConversion))
+                    (matchKind == ConstraintKind::ArgumentConversion ||
+                     matchKind == ConstraintKind::OperatorArgumentConversion)))
                       ? ConstraintKind::Bind
                       : matchKind;
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1477,3 +1477,9 @@ func generic<T>(_ value: inout T, _ closure: (SR12725<T>) -> Void) {}
 
 let arg: Int
 generic(&arg) { (g: SR12725<Double>) -> Void in } // expected-error {{cannot convert value of type '(SR12725<Double>) -> Void' to expected argument type '(SR12725<Int>) -> Void'}}
+
+// rdar://problem/62428353 - bad error message for passing `T` where `inout T` was expected
+func rdar62428353<T>(_ t: inout T) {
+  let v = t // expected-note {{change 'let' to 'var' to make it mutable}} {{3-6=var}}
+  rdar62428353(v) // expected-error {{cannot pass immutable value as inout argument: 'v' is a 'let' constant}}
+}


### PR DESCRIPTION
…er as mutability problem

Cherry-pick of https://github.com/apple/swift/pull/31600

---
- Explanation: If argument is immutable, with or without explicit `&`, let's
diagnose that as mutability problem because suggesting
to add `&` to immutable declaration is not the best possible fix.

- Scope: Diagnostic improvement

- Resolves: rdar://problem/62428353

- Risk: Very low

- Testing: Added a regression test

- Reviewer: @hborla 

Resolves: rdar://problem/62428353
(cherry picked from commit 595b198f8e54719ea7fb6ccfa64c10d10f2cb13f)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
