### PR TITLE
[5.3][ConstraintSystem] Always verify computed/resolved pattern types befo…

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2254,6 +2254,8 @@ namespace {
 
       switch (pattern->getKind()) {
       case PatternKind::Paren: {
+        auto *paren = cast<ParenPattern>(pattern);
+
         // Parentheses don't affect the canonical type, but record them as
         // type sugar.
         if (externalPatternType &&
@@ -2262,13 +2264,14 @@ namespace {
               ->getUnderlyingType();
         }
 
-        return setType(
-            ParenType::get(
-              CS.getASTContext(),
-              getTypeForPattern(
-                cast<ParenPattern>(pattern)->getSubPattern(), locator,
-                externalPatternType,
-                bindPatternVarsOneWay)));
+        auto underlyingType =
+            getTypeForPattern(paren->getSubPattern(), locator,
+                              externalPatternType, bindPatternVarsOneWay);
+
+        if (!underlyingType)
+          return Type();
+
+        return setType(ParenType::get(CS.getASTContext(), underlyingType));
       }
       case PatternKind::Var:
         // Var doesn't affect the type.
@@ -2370,10 +2373,14 @@ namespace {
 
         Type type = TypeChecker::typeCheckPattern(contextualPattern);
 
+        if (!type)
+          return Type();
+
         // Look through reference storage types.
         type = type->getReferenceStorageReferent();
 
         Type openedType = CS.openUnboundGenericType(type, locator);
+        assert(openedType);
 
         auto *subPattern = cast<TypedPattern>(pattern)->getSubPattern();
         // Determine the subpattern type. It will be convertible to the
@@ -2382,6 +2389,9 @@ namespace {
             subPattern,
             locator.withPathElement(LocatorPathElt::PatternMatch(subPattern)),
             Type(), bindPatternVarsOneWay);
+
+        if (!subPatternType)
+          return Type();
 
         CS.addConstraint(
             ConstraintKind::Conversion, subPatternType, openedType,
@@ -2425,6 +2435,10 @@ namespace {
               eltPattern,
               locator.withPathElement(LocatorPathElt::PatternMatch(eltPattern)),
               externalEltType, bindPatternVarsOneWay);
+
+          if (!eltTy)
+            return Type();
+
           tupleTypeElts.push_back(TupleTypeElt(eltTy, tupleElt.getLabel()));
         }
 
@@ -2452,6 +2466,9 @@ namespace {
             locator.withPathElement(LocatorPathElt::PatternMatch(subPattern)),
             externalPatternType, bindPatternVarsOneWay);
 
+        if (!subPatternType)
+          return Type();
+
         return setType(OptionalType::get(subPatternType));
       }
 
@@ -2460,15 +2477,24 @@ namespace {
 
         Type castType =
             resolveTypeReferenceInExpression(isPattern->getCastTypeLoc());
+
+        if (!castType)
+          return Type();
+
         castType = CS.openUnboundGenericType(
             castType,
             locator.withPathElement(LocatorPathElt::PatternMatch(pattern)));
+
+        assert(castType);
 
         auto *subPattern = isPattern->getSubPattern();
         Type subPatternType = getTypeForPattern(
             subPattern,
             locator.withPathElement(LocatorPathElt::PatternMatch(subPattern)),
             castType, bindPatternVarsOneWay);
+
+        if (!subPatternType)
+          return Type();
 
         // Make sure we can cast from the subpattern type to the type we're
         // checking; if it's impossible, fail.
@@ -2502,10 +2528,15 @@ namespace {
           Type parentType =
             resolveTypeReferenceInExpression(enumPattern->getParentType());
 
+          if (!parentType)
+            return Type();
+
           parentType = CS.openUnboundGenericType(
               parentType, CS.getConstraintLocator(
                               locator, {LocatorPathElt::PatternMatch(pattern),
                                         ConstraintLocator::ParentType}));
+
+          assert(parentType);
 
           // Perform member lookup into the parent's metatype.
           Type parentMetaType = MetatypeType::get(parentType);
@@ -2539,6 +2570,10 @@ namespace {
           // types.
           Type subPatternType = getTypeForPattern(
               subPattern, locator, Type(), bindPatternVarsOneWay);
+
+          if (!subPatternType)
+            return Type();
+
           SmallVector<AnyFunctionType::Param, 4> params;
           AnyFunctionType::decomposeInput(subPatternType, params);
 


### PR DESCRIPTION
…re use

Cherry-pick of https://github.com/apple/swift/pull/31604

---
- Explanation: While trying to infer type for pattern always take result of
`getTypeForPattern` and `resolveTypeInExpressionContext` with
a grain of salt because both of these methods produce empty type
if type as-written or one of the sub-pattern types is incorrect.

- Scope: Type-checker stability improvements in constraint generation of patterns

- Resolves: rdar://problem/60534522

- Risk: Low

- Testing: Unfortunately I couldn't find a test-case for this. These changes introduce multiple
null checks.

- Reviewer: @DougGregor 

Resolves: rdar://problem/60534522
(cherry picked from commit f22ca7216b486157171913c66a199182d58676bf)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
