### PR TITLE
Add a test that imported C++ classes can conform to protocols

### DIFF
--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -9,3 +9,7 @@ module MemoryLayout {
 module MemberVariables {
   header "member-variables.h"
 }
+
+module ProtocolConformance {
+  header "protocol-conformance.h"
+}

--- a/test/Interop/Cxx/class/Inputs/protocol-conformance.h
+++ b/test/Interop/Cxx/class/Inputs/protocol-conformance.h
@@ -1,0 +1,7 @@
+struct ConformsToProtocol {
+  int return42() { return 42; }
+};
+
+struct DoesNotConformToProtocol {
+  int returnFortyTwo() { return 42; }
+};

--- a/test/Interop/Cxx/class/protocol-conformance-silgen.swift
+++ b/test/Interop/Cxx/class/protocol-conformance-silgen.swift
@@ -1,0 +1,15 @@
+// Tests that a C++ class can conform to a Swift protocol.
+
+// RUN: %target-swift-emit-silgen -I %S/Inputs -enable-cxx-interop %s
+
+import ProtocolConformance
+
+protocol HasReturn42 {
+  mutating func return42() -> CInt
+}
+
+// FIXME:
+// https://bugs.swift.org/browse/SR-12750
+// SILGen currently hits an assertion failure in getParameterTypes() when the
+// following protocol conformance is declared.
+// extension ConformsToProtocol : HasReturn42 {}

--- a/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
+++ b/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
@@ -1,0 +1,13 @@
+// Tests that a C++ class can conform to a Swift protocol.
+
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-cxx-interop
+
+import ProtocolConformance
+
+protocol HasReturn42 {
+  mutating func return42() -> CInt // expected-note {{requires function 'return42()'}}
+}
+
+extension ConformsToProtocol : HasReturn42 {}
+
+extension DoesNotConformToProtocol : HasReturn42 {} // expected-error {{'DoesNotConformToProtocol' does not conform to protocol}}


### PR DESCRIPTION
Currently, trying to do this causes an assertion failure in SILGen, so the corresponding line in the SILGen test is commented out.

See https://bugs.swift.org/browse/SR-12750