### PR TITLE
Synthesize memberwise initializers despite AccessSpecDecl

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -45,6 +45,7 @@
 #include "swift/Config.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
+#include "clang/AST/DeclCXX.h"
 #include "clang/Basic/CharInfo.h"
 #include "swift/Basic/Statistic.h"
 #include "clang/Basic/TargetInfo.h"
@@ -3311,6 +3312,12 @@ namespace {
       // it is nested in a struct.
 
       for (auto m : decl->decls()) {
+        if (isa<clang::AccessSpecDecl>(m)) {
+          // The presence of AccessSpecDecls themselves does not influence
+          // whether we can generate a member-wise initializer.
+          continue;
+        }
+
         auto nd = dyn_cast<clang::NamedDecl>(m);
         if (!nd) {
           // We couldn't import the member, so we can't reference it in Swift.

--- a/test/Interop/Cxx/class/Inputs/memberwise-initializer.h
+++ b/test/Interop/Cxx/class/Inputs/memberwise-initializer.h
@@ -1,0 +1,44 @@
+#ifndef TEST_INTEROP_CXX_CLASS_INPUTS_MEMBERWISE_INITIALIZER_H
+#define TEST_INTEROP_CXX_CLASS_INPUTS_MEMBERWISE_INITIALIZER_H
+
+struct StructPrivateOnly {
+private:
+  int varPrivate;
+};
+
+struct StructPublicOnly {
+  int varPublic;
+};
+
+struct StructEmptyPrivateSection {
+  int varPublic;
+private:
+};
+
+struct StructPublicAndPrivate {
+  int varPublic;
+private:
+  int varPrivate;
+};
+
+class ClassPrivateOnly {
+  int varPrivate;
+};
+
+class ClassPublicOnly {
+public:
+  int varPublic;
+};
+
+class ClassEmptyPublicSection {
+  int varPrivate;
+public:
+};
+
+class ClassPrivateAndPublic {
+  int varPrivate;
+public:
+  int varPublic;
+};
+
+#endif

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -2,6 +2,10 @@ module AccessSpecifiers {
   header "access-specifiers.h"
 }
 
+module MemberwiseInitializer {
+  header "memberwise-initializer.h"
+}
+
 module MemoryLayout {
   header "memory-layout.h"
 }

--- a/test/Interop/Cxx/class/member-variables-module-interface.swift
+++ b/test/Interop/Cxx/class/member-variables-module-interface.swift
@@ -3,4 +3,5 @@
 // CHECK:      struct MyClass {
 // CHECK-NEXT:   var const_member: Int32 { get }
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   init(const_member: Int32)
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/memberwise-initializer-module-interface.swift
+++ b/test/Interop/Cxx/class/memberwise-initializer-module-interface.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=MemberwiseInitializer -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK:      struct StructPrivateOnly {
+// CHECK-NEXT:   init()
+// CHECK-NEXT: }
+// CHECK-NEXT: struct StructPublicOnly {
+// CHECK-NEXT:   var varPublic: Int32
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   init(varPublic: Int32)
+// CHECK-NEXT: }
+// CHECK-NEXT: struct StructEmptyPrivateSection {
+// CHECK-NEXT:   var varPublic: Int32
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   init(varPublic: Int32)
+// CHECK-NEXT: }
+// CHECK-NEXT: struct StructPublicAndPrivate {
+// CHECK-NEXT:   var varPublic: Int32
+// CHECK-NEXT:   init()
+// CHECK-NEXT: }
+// CHECK-NEXT: struct ClassPrivateOnly {
+// CHECK-NEXT:   init()
+// CHECK-NEXT: }
+// CHECK-NEXT: struct ClassPublicOnly {
+// CHECK-NEXT:   var varPublic: Int32
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   init(varPublic: Int32)
+// CHECK-NEXT: }
+// CHECK-NEXT: struct ClassEmptyPublicSection {
+// CHECK-NEXT:   init()
+// CHECK-NEXT: }
+// CHECK-NEXT: struct ClassPrivateAndPublic {
+// CHECK-NEXT:   var varPublic: Int32
+// CHECK-NEXT:   init()
+// CHECK-NEXT: }

--- a/test/Interop/Cxx/class/memberwise-initializer-typechecker.swift
+++ b/test/Interop/Cxx/class/memberwise-initializer-typechecker.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-cxx-interop
+
+import MemberwiseInitializer
+
+let structPrivateOnly = StructPrivateOnly(varPrivate: 42)  // expected-error {{argument passed to call that takes no arguments}}
+let structPublicOnly = StructPublicOnly(varPublic: 42)
+let structEmptyPrivateSetion = StructEmptyPrivateSection(varPublic: 42)
+let structPublicAndPrivate1 = StructPublicAndPrivate(varPublic: 42)  // expected-error {{argument passed to call that takes no arguments}}
+let structPublicAndPrivate2 = StructPublicAndPrivate(varPublic: 42, varPrivate: 23)  // expected-error {{argument passed to call that takes no arguments}}
+
+let classPrivateOnly = ClassPrivateOnly(varPrivate: 42) // expected-error {{argument passed to call that takes no arguments}}
+let classPublicOnly = ClassPublicOnly(varPublic: 42)
+let classEmptyPublicSetion = ClassEmptyPublicSection(varPrivate: 42) // expected-error {{argument passed to call that takes no arguments}}
+let classPublicAndPrivate1 = ClassPrivateAndPublic(varPublic: 23)  // expected-error {{argument passed to call that takes no arguments}}
+let classPublicAndPrivate2 = ClassPrivateAndPublic(varPrivate: 42, varPublic: 23)  // expected-error {{argument passed to call that takes no arguments}}


### PR DESCRIPTION
Previously the mere presence of `public:` or `private:` inhibited the
synthesis of memberwise initializers.

Resolves SR-12729.