### PR TITLE
[Runtime] Add an alignment parameter to MetadataAllocator::Deallocate to match LLVM

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -5504,7 +5504,8 @@ void *MetadataAllocator::Allocate(size_t size, size_t alignment) {
   }
 }
 
-void MetadataAllocator::Deallocate(const void *allocation, size_t size) {
+void MetadataAllocator::Deallocate(const void *allocation, size_t size,
+                                   size_t alignment) {
   __asan_poison_memory_region(allocation, size);
 
   if (size > PoolRange::MaxPoolAllocationSize) {

--- a/stdlib/public/runtime/MetadataCache.h
+++ b/stdlib/public/runtime/MetadataCache.h
@@ -33,7 +33,7 @@ public:
   LLVM_ATTRIBUTE_RETURNS_NONNULL void *Allocate(size_t size, size_t alignment);
   using AllocatorBase<MetadataAllocator>::Allocate;
 
-  void Deallocate(const void *Ptr, size_t size);
+  void Deallocate(const void *Ptr, size_t size, size_t alignment);
   using AllocatorBase<MetadataAllocator>::Deallocate;
 
   void PrintStats() const {}


### PR DESCRIPTION
rdar://problem/62975124