### PR TITLE
Remove all uses of -force-single-frontend-invocation

### DIFF
--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -189,7 +189,7 @@ function (add_swift_benchmark_library objfile_out sibfile_out swiftmodule_out)
     DEPENDS ${stdlib_dependencies} ${sources} ${BENCHLIB_DEPENDS}
     COMMAND "${SWIFT_EXEC}"
       ${BENCHLIB_LIBRARY_FLAGS}
-      "-force-single-frontend-invocation"
+      "-whole-module-optimization"
       "-parse-as-library"
       "-module-name" "${module_name}"
       "-emit-module" "-emit-module-path" "${swiftmodule}"
@@ -209,7 +209,7 @@ function (add_swift_benchmark_library objfile_out sibfile_out swiftmodule_out)
       ${stdlib_dependencies} ${sources} ${BENCHLIB_DEPENDS}
       COMMAND "${SWIFT_EXEC}"
         ${BENCHLIB_LIBRARY_FLAGS}
-        "-force-single-frontend-invocation"
+        "-whole-module-optimization"
         "-parse-as-library"
         "-module-name" "${module_name}"
         "-emit-sib"
@@ -574,7 +574,7 @@ function (swift_benchmark_compile_archopts)
         ${SWIFT_BENCH_SIBFILES} "${source}"
       COMMAND "${SWIFT_EXEC}"
       ${common_swift4_options}
-      "-force-single-frontend-invocation"
+      "-whole-module-optimization"
       "-emit-module" "-module-name" "${module_name}"
       "-I" "${objdir}"
       "-o" "${objdir}/${module_name}.o"

--- a/docs/CompilerPerformance.md
+++ b/docs/CompilerPerformance.md
@@ -100,8 +100,7 @@ running in, and often to perform separate analysis for each mode. The
 significant modes are:
 
   - **Primary-file** vs. **whole-module**: this varies depending on whether the
-    driver is run with the flag `-wmo`, `-whole-module-optimization` or
-    `-force-single-frontend-invocation` (all these options are synonymous).
+    driver is run with the flag `-wmo` (a.k.a. `-whole-module-optimization`).
 
     - **Batch** vs. **single-file** primary-file mode. This distinction refines
     the behaviour of primary-file mode, with the new batch mode added in the

--- a/lib/Driver/FrontendUtil.cpp
+++ b/lib/Driver/FrontendUtil.cpp
@@ -32,10 +32,10 @@ bool swift::driver::getSingleFrontendInvocationFromDriverArguments(
 
   // When creating a CompilerInvocation, ensure that the driver creates a single
   // frontend command.
-  Args.push_back("-force-single-frontend-invocation");
+  Args.push_back("-whole-module-optimization");
 
   // Explictly disable batch mode to avoid a spurious warning when combining
-  // -enable-batch-mode with -force-single-frontend-invocation.  This is an
+  // -enable-batch-mode with -whole-module-optimization.  This is an
   // implementation detail.
   Args.push_back("-disable-batch-mode");
 

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -90,7 +90,7 @@ function(handle_swift_sources
 
     # FIXME: We shouldn't /have/ to build things in a single process.
     # <rdar://problem/15972329>
-    list(APPEND swift_compile_flags "-force-single-frontend-invocation")
+    list(APPEND swift_compile_flags "-whole-module-optimization")
 
     _compile_swift_files(
         dependency_target

--- a/test/Driver/actions-dsym.swift
+++ b/test/Driver/actions-dsym.swift
@@ -107,7 +107,7 @@
 // LINK-DEBUG-SWIFTMODULES: 7: link, {1, 2, 3, 4, 5, 6}, image
 
 // RUN: touch %t/a.o %t/b.o
-// RUN: %swiftc_driver -driver-print-actions -target x86_64-apple-macosx10.9 -g %S/Inputs/main.swift %S/../Inputs/empty.swift %s -module-name actions -force-single-frontend-invocation 2>&1 | %FileCheck %s -check-prefix=WHOLE-MODULE
+// RUN: %swiftc_driver -driver-print-actions -target x86_64-apple-macosx10.9 -g %S/Inputs/main.swift %S/../Inputs/empty.swift %s -module-name actions -whole-module-optimization 2>&1 | %FileCheck %s -check-prefix=WHOLE-MODULE
 // WHOLE-MODULE: 0: input, "{{.*}}Inputs/main.swift", swift
 // WHOLE-MODULE: 1: input, "{{.*}}Inputs/empty.swift", swift
 // WHOLE-MODULE: 2: input, "{{.*}}actions-dsym.swift", swift

--- a/test/Driver/actions.swift
+++ b/test/Driver/actions.swift
@@ -193,7 +193,7 @@
 // COMPILE-PLUS-OBJECT-MACHO: 3: link, {0, 2}, image
 
 
-// RUN: %swiftc_driver -driver-print-actions %S/Inputs/main.swift %S/../Inputs/empty.swift %s -module-name actions -force-single-frontend-invocation 2>&1 | %FileCheck %s -check-prefix=WHOLE-MODULE -check-prefix WHOLE-MODULE-%target-object-format
+// RUN: %swiftc_driver -driver-print-actions %S/Inputs/main.swift %S/../Inputs/empty.swift %s -module-name actions -whole-module-optimization 2>&1 | %FileCheck %s -check-prefix=WHOLE-MODULE -check-prefix WHOLE-MODULE-%target-object-format
 // WHOLE-MODULE: 0: input, "{{.*}}Inputs/main.swift", swift
 // WHOLE-MODULE: 1: input, "{{.*}}Inputs/empty.swift", swift
 // WHOLE-MODULE: 2: input, "{{.*}}actions.swift", swift

--- a/test/Driver/embed-bitcode.swift
+++ b/test/Driver/embed-bitcode.swift
@@ -44,7 +44,7 @@
 // CHECK-MODULE-NOT: -fake-llvm-option
 // CHECK-MODULE-NOT: -emit-module-path
 
-// RUN: %target-swiftc_driver -embed-bitcode -force-single-frontend-invocation %s 2>&1 -### | %FileCheck %s -check-prefix=CHECK-SINGLE
+// RUN: %target-swiftc_driver -embed-bitcode -whole-module-optimization %s 2>&1 -### | %FileCheck %s -check-prefix=CHECK-SINGLE
 // CHECK-SINGLE: -frontend
 // CHECK-SINGLE: -emit-bc
 // CHECK-SINGLE: -frontend
@@ -52,7 +52,7 @@
 // CHECK-SINGLE: -embed-bitcode
 // CHECK-SINGLE: -disable-llvm-optzns
 
-// RUN: %target-swiftc_driver -embed-bitcode -force-single-frontend-invocation -O %s 2>&1 -### | %FileCheck %s -check-prefix=CHECK-SINGLE-OPT
+// RUN: %target-swiftc_driver -embed-bitcode -whole-module-optimization -O %s 2>&1 -### | %FileCheck %s -check-prefix=CHECK-SINGLE-OPT
 // CHECK-SINGLE-OPT: -frontend
 // CHECK-SINGLE-OPT-SAME: -emit-bc
 // CHECK-SINGLE-OPT-SAME: -O{{[" ]}}
@@ -62,7 +62,7 @@
 // CHECK-SINGLE-OPT-SAME: -O{{[" ]}}
 // CHECK-SINGLE-OPT-SAME: -disable-llvm-optzns
 
-// RUN: %target-swiftc_driver -embed-bitcode -force-single-frontend-invocation -Osize %s 2>&1 -### | %FileCheck %s -check-prefix=CHECK-SINGLE-OPT-SIZE
+// RUN: %target-swiftc_driver -embed-bitcode -whole-module-optimization -Osize %s 2>&1 -### | %FileCheck %s -check-prefix=CHECK-SINGLE-OPT-SIZE
 // CHECK-SINGLE-OPT-SIZE: -frontend
 // CHECK-SINGLE-OPT-SIZE-SAME: -emit-bc
 // CHECK-SINGLE-OPT-SIZE-SAME: -Osize
@@ -72,7 +72,7 @@
 // CHECK-SINGLE-OPT-SIZE-SAME: -Osize
 // CHECK-SINGLE-OPT-SIZE-SAME: -disable-llvm-optzns
 
-// RUN: %target-swiftc_driver -embed-bitcode -target-cpu abc -force-single-frontend-invocation %s 2>&1 -### | %FileCheck %s -check-prefix=CHECK-SINGLE-MISC
+// RUN: %target-swiftc_driver -embed-bitcode -target-cpu abc -whole-module-optimization %s 2>&1 -### | %FileCheck %s -check-prefix=CHECK-SINGLE-MISC
 // CHECK-SINGLE-MISC: -frontend
 // CHECK-SINGLE-MISC-SAME: -emit-bc
 // CHECK-SINGLE-MISC-SAME: -target-cpu abc
@@ -82,7 +82,7 @@
 // CHECK-SINGLE-MISC-SAME: -target-cpu abc
 // CHECK-SINGLE-MISC-SAME: -disable-llvm-optzns
 
-// RUN: %target-swiftc_driver -embed-bitcode -c -parse-as-library -emit-module -force-single-frontend-invocation %s -parse-stdlib -module-name Swift 2>&1 -### | %FileCheck %s -check-prefix=CHECK-LIB-WMO
+// RUN: %target-swiftc_driver -embed-bitcode -c -parse-as-library -emit-module -whole-module-optimization %s -parse-stdlib -module-name Swift 2>&1 -### | %FileCheck %s -check-prefix=CHECK-LIB-WMO
 // CHECK-LIB-WMO: -frontend
 // CHECK-LIB-WMO: -emit-bc
 // CHECK-LIB-WMO: -parse-stdlib

--- a/test/Driver/emit-interface.swift
+++ b/test/Driver/emit-interface.swift
@@ -6,7 +6,7 @@
 // CHECK-SAME: -emit-module-interface-path {{.+[/\\]}}foo.swiftinterface
 // CHECK: {{(bin/)?}}ld
 
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -emit-module-interface -o %t/foo -force-single-frontend-invocation 2>&1 | %FileCheck -check-prefix=CHECK-WHOLE-MODULE %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -emit-module-interface -o %t/foo -whole-module-optimization 2>&1 | %FileCheck -check-prefix=CHECK-WHOLE-MODULE %s
 
 // CHECK-WHOLE-MODULE: swift{{c?(\.exe)?"?}} -frontend
 // CHECK-WHOLE-MODULE-SAME: emit-interface.swift
@@ -14,14 +14,14 @@
 // CHECK-WHOLE-MODULE-NOT: -merge-modules
 // CHECK-WHOLE-MODULE: {{(bin/)?}}ld
 
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -emit-module-interface-path %t/unrelated.swiftinterface -o %t/foo -force-single-frontend-invocation 2>&1 | %FileCheck -check-prefix=CHECK-EXPLICIT-PATH %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -emit-module-interface-path %t/unrelated.swiftinterface -o %t/foo -whole-module-optimization 2>&1 | %FileCheck -check-prefix=CHECK-EXPLICIT-PATH %s
 
 // CHECK-EXPLICIT-PATH: swift{{c?(\.exe)?"?}} -frontend
 // CHECK-EXPLICIT-PATH-SAME: emit-interface.swift
 // CHECK-EXPLICIT-PATH-SAME: -emit-module-interface-path {{.+[/\\]}}unrelated.swiftinterface
 
 // Ensure that we emit arguments when we force filelists as well
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -emit-module-interface -o %t/foo -module-name foo -force-single-frontend-invocation -driver-filelist-threshold=0 2>&1 | %FileCheck -check-prefix=CHECK-FILELIST %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -emit-module-interface -o %t/foo -module-name foo -whole-module-optimization -driver-filelist-threshold=0 2>&1 | %FileCheck -check-prefix=CHECK-FILELIST %s
 
 // CHECK-FILELIST: swift{{c?(\.exe)?"?}} -frontend
 // CHECK-FILELIST-SAME: -supplementary-output-file-map

--- a/test/Driver/emit-objc-header-single-vs-multi-file.swift
+++ b/test/Driver/emit-objc-header-single-vs-multi-file.swift
@@ -5,7 +5,7 @@
 // FIXME: END -enable-source-import hackaround
 
 // RUN: %target-swiftc_driver %clang-importer-sdk-nosource -emit-module -o %t.1.swiftmodule -emit-objc-header -emit-objc-header-path %t.1.h -module-name ThisModule %s %S/Inputs/main.swift %S/Inputs/lib.swift -I %t
-// RUN: %target-swiftc_driver %clang-importer-sdk-nosource -emit-module -o %t.2.swiftmodule -emit-objc-header -emit-objc-header-path %t.2.h -module-name ThisModule %s %S/Inputs/main.swift %S/Inputs/lib.swift -force-single-frontend-invocation -I %t
+// RUN: %target-swiftc_driver %clang-importer-sdk-nosource -emit-module -o %t.2.swiftmodule -emit-objc-header -emit-objc-header-path %t.2.h -module-name ThisModule %s %S/Inputs/main.swift %S/Inputs/lib.swift -whole-module-optimization -I %t
 // RUN: diff %t.1.h %t.2.h
 
 // REQUIRES: objc_interop

--- a/test/Driver/emit-objc-header.swift
+++ b/test/Driver/emit-objc-header.swift
@@ -6,7 +6,7 @@
 // CHECK-SAME: -emit-objc-header-path {{.+}}/foo.h
 // CHECK: {{(bin/)?}}ld
 
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -emit-objc-header-path %t/foo.h -force-single-frontend-invocation 2>&1 | %FileCheck -check-prefix=CHECK-WHOLE-MODULE %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -emit-objc-header-path %t/foo.h -whole-module-optimization 2>&1 | %FileCheck -check-prefix=CHECK-WHOLE-MODULE %s
 
 // CHECK-WHOLE-MODULE: swift{{c?(\.exe)?"?}} -frontend
 // CHECK-WHOLE-MODULE-SAME: emit-objc-header.swift

--- a/test/Driver/filelists.swift
+++ b/test/Driver/filelists.swift
@@ -25,7 +25,7 @@
 
 
 
-// RUN: %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -c %t/a.swift %t/b.swift %t/c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -force-single-frontend-invocation 2>&1 | %FileCheck -check-prefix=CHECK-WMO %s
+// RUN: %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -c %t/a.swift %t/b.swift %t/c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -whole-module-optimization 2>&1 | %FileCheck -check-prefix=CHECK-WMO %s
 
 // CHECK-WMO-NOT: Handled
 // CHECK-WMO: Handled all
@@ -38,10 +38,10 @@
 // RUN: %empty-directory(%t/bin)
 // RUN: ln -s %S/Inputs/filelists/fake-ld.py %t/bin/ld
 
-// RUN: (cd %t && %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -output-file-map=%S/Inputs/filelists/output.json -force-single-frontend-invocation -num-threads 1 2>&1 | %FileCheck -check-prefix=CHECK-WMO-THREADED %s)
-// RUN: (cd %t && %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -output-file-map=%S/Inputs/filelists/output.json -force-single-frontend-invocation -num-threads 1 -embed-bitcode 2>&1 | %FileCheck -check-prefix=CHECK-WMO-THREADED %s)
+// RUN: (cd %t && %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -output-file-map=%S/Inputs/filelists/output.json -whole-module-optimization -num-threads 1 2>&1 | %FileCheck -check-prefix=CHECK-WMO-THREADED %s)
+// RUN: (cd %t && %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -output-file-map=%S/Inputs/filelists/output.json -whole-module-optimization -num-threads 1 -embed-bitcode 2>&1 | %FileCheck -check-prefix=CHECK-WMO-THREADED %s)
 // RUN: %empty-directory(%t/tmp)
-// RUN: (cd %t && env TMPDIR="%t/tmp/" %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -output-file-map=%S/Inputs/filelists/output.json -force-single-frontend-invocation -num-threads 1 -save-temps 2>&1 | %FileCheck -check-prefix=CHECK-WMO-THREADED %s)
+// RUN: (cd %t && env TMPDIR="%t/tmp/" %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -output-file-map=%S/Inputs/filelists/output.json -whole-module-optimization -num-threads 1 -save-temps 2>&1 | %FileCheck -check-prefix=CHECK-WMO-THREADED %s)
 // RUN: ls %t/tmp/sources-* %t/tmp/outputs-*
 
 // CHECK-WMO-THREADED-NOT: Handled
@@ -56,17 +56,17 @@
 // CHECK-WMO-THREADED-NOT: Handled
 
 // RUN: mkdir -p %t/tmp-fail/
-// RUN: (cd %t && env TMPDIR="%t/tmp-fail/" not %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/fail.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -output-file-map=%S/Inputs/filelists/output.json -force-single-frontend-invocation -num-threads 1)
+// RUN: (cd %t && env TMPDIR="%t/tmp-fail/" not %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/fail.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -output-file-map=%S/Inputs/filelists/output.json -whole-module-optimization -num-threads 1)
 // RUN: not ls %t/tmp-fail/sources-*
 // RUN: not ls %t/tmp-fail/outputs-*
 
 // RUN: mkdir -p %t/tmp-crash/
-// RUN: (cd %t && env TMPDIR="%t/tmp-crash/" not %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/crash.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -output-file-map=%S/Inputs/filelists/output.json -force-single-frontend-invocation -num-threads 1)
+// RUN: (cd %t && env TMPDIR="%t/tmp-crash/" not %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/crash.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -output-file-map=%S/Inputs/filelists/output.json -whole-module-optimization -num-threads 1)
 // RUN: ls %t/tmp-crash/sources-* %t/tmp-crash/outputs-*
 
 
 // RUN: (cd %t && env PATH="%t/bin/:$PATH" %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -emit-library ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -output-file-map=%S/Inputs/filelists/output.json 2>&1 | %FileCheck -check-prefix=CHECK-LINK %s)
-// RUN: (cd %t && env PATH="%t/bin/:$PATH" %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -emit-library ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -output-file-map=%S/Inputs/filelists/output.json -force-single-frontend-invocation -num-threads 1 2>&1 | %FileCheck -check-prefix=CHECK-LINK %s)
+// RUN: (cd %t && env PATH="%t/bin/:$PATH" %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -emit-library ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -output-file-map=%S/Inputs/filelists/output.json -whole-module-optimization -num-threads 1 2>&1 | %FileCheck -check-prefix=CHECK-LINK %s)
 
 // CHECK-LINK: Handled link
 

--- a/test/Driver/no-inputs.swift
+++ b/test/Driver/no-inputs.swift
@@ -1,5 +1,5 @@
 // RUN: %swiftc_driver_plain -v 2>&1 | %FileCheck %s
-// RUN: %swiftc_driver_plain -v -force-single-frontend-invocation 2>&1 | %FileCheck %s
+// RUN: %swiftc_driver_plain -v -whole-module-optimization 2>&1 | %FileCheck %s
 // RUN: not %swiftc_driver_plain -emit-executable 2>&1 | %FileCheck --check-prefix=CHECK-ERROR %s
 
 // CHECK-NOT: error: no input files

--- a/test/Interpreter/struct_extra_inhabitants.swift
+++ b/test/Interpreter/struct_extra_inhabitants.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // -- build resilient library
-// RUN: %target-build-swift -force-single-frontend-invocation -enable-library-evolution -module-name ExtraInhabitantResilientTypes -emit-module-path %t/ExtraInhabitantResilientTypes.swiftmodule -parse-as-library -c -o %t/ExtraInhabitantResilientTypes.o %S/Inputs/struct_extra_inhabitants_ExtraInhabitantResilientTypes.swift
+// RUN: %target-build-swift -whole-module-optimization -enable-library-evolution -module-name ExtraInhabitantResilientTypes -emit-module-path %t/ExtraInhabitantResilientTypes.swiftmodule -parse-as-library -c -o %t/ExtraInhabitantResilientTypes.o %S/Inputs/struct_extra_inhabitants_ExtraInhabitantResilientTypes.swift
 
 // -- run tests
 // RUN: %target-build-swift -parse-stdlib -Xfrontend -verify-type-layout -Xfrontend PairWithPointerFirst -Xfrontend -verify-type-layout -Xfrontend PairWithPointerSecond -Xfrontend -verify-type-layout -Xfrontend PairWithPointerSecondAndPhantomParam_Int -Xfrontend -verify-type-layout -Xfrontend GenericPairWithPointerFirst_Int -Xfrontend -verify-type-layout -Xfrontend GenericPairWithPointerFirst_AnyObject -Xfrontend -verify-type-layout -Xfrontend GenericPairWithPointerSecond_Int -Xfrontend -verify-type-layout -Xfrontend GenericPairWithPointerSecond_AnyObject -Xfrontend -verify-type-layout -Xfrontend StringAlike32 -Xfrontend -verify-type-layout -Xfrontend StringAlike64 -I %t -o %t/a.out.tests %s %t/ExtraInhabitantResilientTypes.o

--- a/test/Interpreter/testability.swift
+++ b/test/Interpreter/testability.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-library -c %S/Inputs/testability_helper.swift -enable-testing -force-single-frontend-invocation -o %t/testability_helper.o -emit-module
+// RUN: %target-build-swift -emit-library -c %S/Inputs/testability_helper.swift -enable-testing -whole-module-optimization -o %t/testability_helper.o -emit-module
 
 // RUN: %target-build-swift %s -I %t -Xlinker %t/testability_helper.o -o %t/main
 // RUN: %target-codesign %t/main

--- a/test/Interpreter/testable_key_path.swift
+++ b/test/Interpreter/testable_key_path.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -force-single-frontend-invocation -c -o %t/Module.o -enable-testing -parse-as-library -emit-module -emit-module-path %t/Module.swiftmodule -module-name Module %S/Inputs/testable_key_path_2.swift
+// RUN: %target-build-swift -whole-module-optimization -c -o %t/Module.o -enable-testing -parse-as-library -emit-module -emit-module-path %t/Module.swiftmodule -module-name Module %S/Inputs/testable_key_path_2.swift
 // RUN: %target-build-swift -o %t/a.out -I %t %s %t/Module.o
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/ModuleInterface/enums-layout.swift
+++ b/test/ModuleInterface/enums-layout.swift
@@ -5,7 +5,7 @@
 
 // Try again using a single-frontend build.
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -force-single-frontend-invocation -emit-module-interface-path %t/Lib.swiftinterface -emit-module -o %t/unused.swiftmodule -enable-library-evolution -Xfrontend -enable-objc-interop -Xfrontend -disable-objc-attr-requires-foundation-module -swift-version 5 %S/Inputs/enums-layout-helper.swift -module-name Lib
+// RUN: %target-build-swift -whole-module-optimization -emit-module-interface-path %t/Lib.swiftinterface -emit-module -o %t/unused.swiftmodule -enable-library-evolution -Xfrontend -enable-objc-interop -Xfrontend -disable-objc-attr-requires-foundation-module -swift-version 5 %S/Inputs/enums-layout-helper.swift -module-name Lib
 // RUN: %FileCheck -check-prefix CHECK -check-prefix CHECK-SINGLE-FRONTEND %S/Inputs/enums-layout-helper.swift < %t/Lib.swiftinterface
 // RUN: %target-swift-frontend -enable-objc-interop -O -emit-ir -primary-file %s -I %t -Xllvm -swiftmergefunc-threshold=0 | %FileCheck %s
 

--- a/test/ModuleInterface/option-preservation.swift
+++ b/test/ModuleInterface/option-preservation.swift
@@ -11,7 +11,7 @@
 
 // Make sure flags show up when filelists are enabled
 
-// RUN: %target-build-swift %s -driver-filelist-threshold=0 -emit-module-interface -o %t/foo -module-name foo -module-link-name fooCore -force-single-frontend-invocation -Ounchecked -enforce-exclusivity=unchecked -autolink-force-load 2>&1
+// RUN: %target-build-swift %s -driver-filelist-threshold=0 -emit-module-interface -o %t/foo -module-name foo -module-link-name fooCore -whole-module-optimization -Ounchecked -enforce-exclusivity=unchecked -autolink-force-load 2>&1
 // RUN: %FileCheck %s < %t/foo.swiftinterface --check-prefix CHECK-FILELIST-INTERFACE
 
 // CHECK-FILELIST-INTERFACE: swift-module-flags:

--- a/test/PCMacro/defer.swift
+++ b/test/PCMacro/defer.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PCMacro/didset.swift
+++ b/test/PCMacro/didset.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PCMacro/else.swift
+++ b/test/PCMacro/else.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PCMacro/elseif.swift
+++ b/test/PCMacro/elseif.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 /*// RUN: %target-codesign %t/main*/
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PCMacro/for.swift
+++ b/test/PCMacro/for.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PCMacro/func_decls.swift
+++ b/test/PCMacro/func_decls.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PCMacro/func_throw_notype.swift
+++ b/test/PCMacro/func_throw_notype.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 /*// RUN: %target-codesign %t/main*/
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PCMacro/getset.swift
+++ b/test/PCMacro/getset.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 /*// RUN: %target-codesign %t/main*/
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PCMacro/if.swift
+++ b/test/PCMacro/if.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PCMacro/init.swift
+++ b/test/PCMacro/init.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 /*// RUN: %target-codesign %t/main*/
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PCMacro/module_file_id.swift
+++ b/test/PCMacro/module_file_id.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/test -I=%t %t/PlaygroundSupport.o %S/Inputs/PlaygroundModuleAndFileIDs.swift %t/main.swift 
 // RUN: %target-codesign %t/test
 // RUN: %target-run %t/test | %FileCheck %s

--- a/test/PCMacro/mutation.swift
+++ b/test/PCMacro/mutation.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PCMacro/nested_function.swift
+++ b/test/PCMacro/nested_function.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PCMacro/operators.swift
+++ b/test/PCMacro/operators.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PCMacro/pc_and_log.swift
+++ b/test/PCMacro/pc_and_log.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/../PlaygroundTransform/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/../PlaygroundTransform/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground-high-performance -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PCMacro/plus_equals.swift
+++ b/test/PCMacro/plus_equals.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PCMacro/switch.swift
+++ b/test/PCMacro/switch.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/array.swift
+++ b/test/PlaygroundTransform/array.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/array_did_set.swift
+++ b/test/PlaygroundTransform/array_did_set.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/array_in_struct.swift
+++ b/test/PlaygroundTransform/array_in_struct.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
 // RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main2 -I=%t %t/PlaygroundSupport.o %t/main.swift 

--- a/test/PlaygroundTransform/bare_value.swift
+++ b/test/PlaygroundTransform/bare_value.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/control-flow.swift
+++ b/test/PlaygroundTransform/control-flow.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/declarations.swift
+++ b/test/PlaygroundTransform/declarations.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/defer.swift
+++ b/test/PlaygroundTransform/defer.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/disable_transform_only.swift
+++ b/test/PlaygroundTransform/disable_transform_only.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -disable-playground-transform -I=%t %t/PlaygroundSupport.o -o %t/main %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s -allow-empty

--- a/test/PlaygroundTransform/do-catch.swift
+++ b/test/PlaygroundTransform/do-catch.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/do.swift
+++ b/test/PlaygroundTransform/do.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/empty-tuple.swift
+++ b/test/PlaygroundTransform/empty-tuple.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/generics.swift
+++ b/test/PlaygroundTransform/generics.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/high_performance.swift
+++ b/test/PlaygroundTransform/high_performance.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -playground-high-performance -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/implicit_return_func_binaryoperation_args.swift
+++ b/test/PlaygroundTransform/implicit_return_func_binaryoperation_args.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/implicit_return_func_is.swift
+++ b/test/PlaygroundTransform/implicit_return_func_is.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/implicit_return_func_stringliteral.swift
+++ b/test/PlaygroundTransform/implicit_return_func_stringliteral.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/implicit_return_init_nil.swift
+++ b/test/PlaygroundTransform/implicit_return_init_nil.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/implicit_return_subscript_chain.swift
+++ b/test/PlaygroundTransform/implicit_return_subscript_chain.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/implicit_return_var_intliteral.swift
+++ b/test/PlaygroundTransform/implicit_return_var_intliteral.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/init.swift
+++ b/test/PlaygroundTransform/init.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/iuo.swift
+++ b/test/PlaygroundTransform/iuo.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/module_file_id.swift
+++ b/test/PlaygroundTransform/module_file_id.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -o %t/test -I=%t %t/PlaygroundSupport.o %S/Inputs/PlaygroundModuleAndFileIDs.swift %t/main.swift
 // RUN: %target-codesign %t/test
 // RUN: %target-run %t/test | %FileCheck %s

--- a/test/PlaygroundTransform/mutation.swift
+++ b/test/PlaygroundTransform/mutation.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/nested_function.swift
+++ b/test/PlaygroundTransform/nested_function.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift && %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 // RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main2 -I=%t %t/PlaygroundSupport.o %t/main.swift && %target-codesign %t/main2

--- a/test/PlaygroundTransform/plus_equals.swift
+++ b/test/PlaygroundTransform/plus_equals.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/print.swift
+++ b/test/PlaygroundTransform/print.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PrintAsObjC/arc-conventions.swift
+++ b/test/PrintAsObjC/arc-conventions.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -c %s -parse-as-library -force-single-frontend-invocation -o %t/swift.o -emit-objc-header-path %t/swift.h
+// RUN: %target-build-swift -c %s -parse-as-library -whole-module-optimization -o %t/swift.o -emit-objc-header-path %t/swift.h
 
 // RUN: %clang -c %target-cc-options -isysroot %sdk -Weverything -Werror -Wno-unused-macros -Wno-incomplete-module -fobjc-arc -fmodules %S/Inputs/arc-conventions.m -o %t/main.o -I %t
 // RUN: %target-build-swift %t/swift.o %t/main.o -o %t/main

--- a/test/Runtime/synthesized_decl_uniqueness.swift
+++ b/test/Runtime/synthesized_decl_uniqueness.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -parse-as-library -force-single-frontend-invocation %S/Inputs/synthesized_decl_uniqueness.swift -emit-object -o %t/A.o -module-name A -emit-module-path %t/A.swiftmodule
-// RUN: %target-build-swift -parse-as-library -force-single-frontend-invocation %S/Inputs/synthesized_decl_uniqueness.swift -emit-object -o %t/B.o -module-name B -emit-module-path %t/B.swiftmodule
+// RUN: %target-build-swift -parse-as-library -whole-module-optimization %S/Inputs/synthesized_decl_uniqueness.swift -emit-object -o %t/A.o -module-name A -emit-module-path %t/A.swiftmodule
+// RUN: %target-build-swift -parse-as-library -whole-module-optimization %S/Inputs/synthesized_decl_uniqueness.swift -emit-object -o %t/B.o -module-name B -emit-module-path %t/B.swiftmodule
 // RUN: %target-build-swift -I %t %s %t/A.o %t/B.o -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out

--- a/test/Serialization/basic_sil.swift
+++ b/test/Serialization/basic_sil.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-module -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -Xfrontend -enable-objc-interop -o %t/def_basic.swiftmodule %S/Inputs/def_basic.sil
+// RUN: %target-build-swift -emit-module -Xfrontend -disable-diagnostic-passes -whole-module-optimization -Xfrontend -enable-objc-interop -o %t/def_basic.swiftmodule %S/Inputs/def_basic.sil
 // RUN: llvm-bcanalyzer %t/def_basic.swiftmodule | %FileCheck %s
 // RUN: %target-build-swift -emit-sil -I %t %s -o %t/basic_sil.sil
 // RUN: %target-sil-opt -I %t %t/basic_sil.sil -performance-linker | %FileCheck %S/Inputs/def_basic.sil

--- a/test/Serialization/basic_sil_objc.swift
+++ b/test/Serialization/basic_sil_objc.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Xfrontend %clang-importer-sdk -I %S/../Inputs/clang-importer-sdk/swift-modules -emit-module -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -o %t/def_basic_objc.swiftmodule %S/Inputs/def_basic_objc.sil
+// RUN: %target-build-swift -Xfrontend %clang-importer-sdk -I %S/../Inputs/clang-importer-sdk/swift-modules -emit-module -Xfrontend -disable-diagnostic-passes -whole-module-optimization -o %t/def_basic_objc.swiftmodule %S/Inputs/def_basic_objc.sil
 // RUN: llvm-bcanalyzer %t/def_basic_objc.swiftmodule | %FileCheck %s
 
 // RUN: %target-build-swift -Xfrontend %clang-importer-sdk -emit-sil -I %t %s -o %t/basic_sil_objc.sil

--- a/test/Serialization/sil_box_types.sil
+++ b/test/Serialization/sil_box_types.sil
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-module -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -o %t/sil_box_types.swiftmodule %s
+// RUN: %target-build-swift -emit-module -Xfrontend -disable-diagnostic-passes -whole-module-optimization -o %t/sil_box_types.swiftmodule %s
 // RUN: %target-build-swift -emit-sil -I %t %s | %FileCheck %s
 
 import Builtin

--- a/test/Serialization/sil_partial_apply_ownership.sil
+++ b/test/Serialization/sil_partial_apply_ownership.sil
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-module -Xllvm -verify-skip-convert-escape-to-noescape-attributes -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -o %t/sil_partial_apply_ownership.swiftmodule %s
+// RUN: %target-build-swift -emit-module -Xllvm -verify-skip-convert-escape-to-noescape-attributes -Xfrontend -disable-diagnostic-passes -whole-module-optimization -o %t/sil_partial_apply_ownership.swiftmodule %s
 // RUN: %target-build-swift -Xllvm -verify-skip-convert-escape-to-noescape-attributes -emit-sil -I %t %s | %FileCheck %s
 
 import Builtin

--- a/test/Serialization/xref-private-type.swift
+++ b/test/Serialization/xref-private-type.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -swift-version 4 -O  -force-single-frontend-invocation -emit-module-path %t/LibCore.swiftmodule %S/Inputs/xref-private-type/LibCore.swift
-// RUN: %target-build-swift -swift-version 4 -O -I %t  -force-single-frontend-invocation -emit-module-path %t/Lib.swiftmodule %S/Inputs/xref-private-type/Lib.swift 
+// RUN: %target-build-swift -swift-version 4 -O  -whole-module-optimization -emit-module-path %t/LibCore.swiftmodule %S/Inputs/xref-private-type/LibCore.swift
+// RUN: %target-build-swift -swift-version 4 -O -I %t  -whole-module-optimization -emit-module-path %t/Lib.swiftmodule %S/Inputs/xref-private-type/Lib.swift 
 // RUN: %target-build-swift -swift-version 4 -O -I %t -emit-sil %s | %FileCheck %s
 
 import Lib

--- a/test/reproducible-builds/swiftc-emit-tbd.swift
+++ b/test/reproducible-builds/swiftc-emit-tbd.swift
@@ -1,6 +1,6 @@
 // REQUIRES: VENDOR=apple 
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -O -g -module-name foo %s -emit-tbd-path %t/run-1.tbd -force-single-frontend-invocation
-// RUN: %target-build-swift -O -g -module-name foo %s -emit-tbd-path %t/run-2.tbd -force-single-frontend-invocation
+// RUN: %target-build-swift -O -g -module-name foo %s -emit-tbd-path %t/run-1.tbd -whole-module-optimization
+// RUN: %target-build-swift -O -g -module-name foo %s -emit-tbd-path %t/run-2.tbd -whole-module-optimization
 // RUN: diff -u %t/run-1.tbd %t/run-2.tbd
 print("foo")

--- a/test/stdlib/KeyPathMultiModule.swift
+++ b/test/stdlib/KeyPathMultiModule.swift
@@ -1,6 +1,6 @@
 // -- Test with resilience enabled
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -force-single-frontend-invocation -enable-library-evolution -module-name KeyPathMultiModule_b -c -o %t/KeyPathMultiModule_b.o -emit-module-path %t/KeyPathMultiModule_b.swiftmodule -parse-as-library %S/Inputs/KeyPathMultiModule_b.swift
+// RUN: %target-build-swift -whole-module-optimization -enable-library-evolution -module-name KeyPathMultiModule_b -c -o %t/KeyPathMultiModule_b.o -emit-module-path %t/KeyPathMultiModule_b.swiftmodule -parse-as-library %S/Inputs/KeyPathMultiModule_b.swift
 // RUN: %target-build-swift -g %t/KeyPathMultiModule_b.o -I %t %s -o %t/a.out.resilient
 // RUN: %target-codesign %t/a.out.resilient
 // RUN: %target-run %t/a.out.resilient
@@ -8,7 +8,7 @@
 // -- Test again with resilience disabled, which changes the circumstances under
 //    which we emit and use property descriptors
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -force-single-frontend-invocation -module-name KeyPathMultiModule_b -c -o %t/KeyPathMultiModule_b.o -emit-module-path %t/KeyPathMultiModule_b.swiftmodule -parse-as-library %S/Inputs/KeyPathMultiModule_b.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name KeyPathMultiModule_b -c -o %t/KeyPathMultiModule_b.o -emit-module-path %t/KeyPathMultiModule_b.swiftmodule -parse-as-library %S/Inputs/KeyPathMultiModule_b.swift
 // RUN: %target-build-swift %t/KeyPathMultiModule_b.o -I %t %s -o %t/a.out.fragile
 // RUN: %target-codesign %t/a.out.fragile
 // RUN: %target-run %t/a.out.fragile

--- a/test/stdlib/Print.swift
+++ b/test/stdlib/Print.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -c -force-single-frontend-invocation -parse-as-library -emit-module -emit-module-path %t/PrintTestTypes.swiftmodule -o %t/PrintTestTypes.o %S/Inputs/PrintTestTypes.swift
+// RUN: %target-build-swift -c -whole-module-optimization -parse-as-library -emit-module -emit-module-path %t/PrintTestTypes.swiftmodule -o %t/PrintTestTypes.o %S/Inputs/PrintTestTypes.swift
 // RUN: %target-build-swift %s -Xlinker %t/PrintTestTypes.o -I %t -L %t -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main

--- a/test/stdlib/PrintArray.swift
+++ b/test/stdlib/PrintArray.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -c -force-single-frontend-invocation -parse-as-library -emit-module -emit-module-path %t/PrintTestTypes.swiftmodule -o %t/PrintTestTypes.o %S/Inputs/PrintTestTypes.swift
+// RUN: %target-build-swift -c -whole-module-optimization -parse-as-library -emit-module -emit-module-path %t/PrintTestTypes.swiftmodule -o %t/PrintTestTypes.o %S/Inputs/PrintTestTypes.swift
 // RUN: %target-build-swift %s -Xlinker %t/PrintTestTypes.o -I %t -L %t -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main

--- a/test/stdlib/PrintClass.swift
+++ b/test/stdlib/PrintClass.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -c -force-single-frontend-invocation -parse-as-library -emit-module -emit-module-path %t/PrintTestTypes.swiftmodule -o %t/PrintTestTypes.o %S/Inputs/PrintTestTypes.swift
+// RUN: %target-build-swift -c -whole-module-optimization -parse-as-library -emit-module -emit-module-path %t/PrintTestTypes.swiftmodule -o %t/PrintTestTypes.o %S/Inputs/PrintTestTypes.swift
 // RUN: %target-build-swift %s -Xlinker %t/PrintTestTypes.o -I %t -L %t -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main

--- a/test/stdlib/PrintString.swift
+++ b/test/stdlib/PrintString.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -c -force-single-frontend-invocation -parse-as-library -emit-module -emit-module-path %t/PrintTestTypes.swiftmodule -o %t/PrintTestTypes.o %S/Inputs/PrintTestTypes.swift
+// RUN: %target-build-swift -c -whole-module-optimization -parse-as-library -emit-module -emit-module-path %t/PrintTestTypes.swiftmodule -o %t/PrintTestTypes.o %S/Inputs/PrintTestTypes.swift
 // RUN: %target-build-swift -swift-version 5 %s -Xlinker %t/PrintTestTypes.o -I %t -L %t -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main

--- a/test/stdlib/PrintStruct.swift
+++ b/test/stdlib/PrintStruct.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -c -force-single-frontend-invocation -parse-as-library -emit-module -emit-module-path %t/PrintTestTypes.swiftmodule -o %t/PrintTestTypes.o %S/Inputs/PrintTestTypes.swift
+// RUN: %target-build-swift -c -whole-module-optimization -parse-as-library -emit-module -emit-module-path %t/PrintTestTypes.swiftmodule -o %t/PrintTestTypes.o %S/Inputs/PrintTestTypes.swift
 // RUN: %target-build-swift %s -Xlinker %t/PrintTestTypes.o -I %t -L %t -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main

--- a/test/stdlib/PrintTuple.swift
+++ b/test/stdlib/PrintTuple.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -c -force-single-frontend-invocation -parse-as-library -emit-module -emit-module-path %t/PrintTestTypes.swiftmodule -o %t/PrintTestTypes.o %S/Inputs/PrintTestTypes.swift
+// RUN: %target-build-swift -c -whole-module-optimization -parse-as-library -emit-module -emit-module-path %t/PrintTestTypes.swiftmodule -o %t/PrintTestTypes.o %S/Inputs/PrintTestTypes.swift
 // RUN: %target-build-swift %s -Xlinker %t/PrintTestTypes.o -I %t -L %t -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main

--- a/test/stdlib/RuntimeRetroactiveConformance.swift
+++ b/test/stdlib/RuntimeRetroactiveConformance.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -c -force-single-frontend-invocation -parse-as-library -emit-module -emit-module-path %t/A.swiftmodule -o %t/A.o -module-name A %S/Inputs/RuntimeRetroactiveConformance/A.swift 
-// RUN: %target-build-swift -c -force-single-frontend-invocation -parse-as-library -emit-module -emit-module-path %t/B.swiftmodule -o %t/B.o -module-name B %S/Inputs/RuntimeRetroactiveConformance/B.swift 
+// RUN: %target-build-swift -c -whole-module-optimization -parse-as-library -emit-module -emit-module-path %t/A.swiftmodule -o %t/A.o -module-name A %S/Inputs/RuntimeRetroactiveConformance/A.swift 
+// RUN: %target-build-swift -c -whole-module-optimization -parse-as-library -emit-module -emit-module-path %t/B.swiftmodule -o %t/B.o -module-name B %S/Inputs/RuntimeRetroactiveConformance/B.swift 
 // RUN: %target-build-swift %s %t/A.o %t/B.o -I %t -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out

--- a/utils/swift-project-settings.el
+++ b/utils/swift-project-settings.el
@@ -363,7 +363,7 @@ everything in the Swift project" )
 
 (defconst swift-project-single-frontend-swiftc-args
   (append swift-project-common-swiftc-args
-           (list "-force-single-frontend-invocation" "-parse-as-library"))
+           (list "-whole-module-optimization" "-parse-as-library"))
   "The arguments we'll pass to swiftc for syntax-checking
 libraries that require a single frontend invocation" )
 

--- a/validation-test/Driver/many-inputs.swift
+++ b/validation-test/Driver/many-inputs.swift
@@ -5,10 +5,10 @@
 // at one point.
 // RUN: for i in {1..1100}; do echo "public func foo$i() {}" > %t/$i.swift; echo "CHECK: foo$i" >> %t/check.txt; done
 
-// RUN: (cd %t && %target-build-swift -force-single-frontend-invocation -emit-library ./*.swift -o ./libWMO)
+// RUN: (cd %t && %target-build-swift -whole-module-optimization -emit-library ./*.swift -o ./libWMO)
 // RUN: nm %t/libWMO | %FileCheck %t/check.txt
 
-// RUN: (cd %t && %target-build-swift -force-single-frontend-invocation -num-threads 1 -emit-library ./*.swift -o ./libWMOThreaded)
+// RUN: (cd %t && %target-build-swift -whole-module-optimization -num-threads 1 -emit-library ./*.swift -o ./libWMOThreaded)
 // RUN: nm %t/libWMOThreaded | %FileCheck %t/check.txt
 
 // This is very slow due to process overhead. It's also doing one file at a time

--- a/validation-test/Serialization/Foundation-determinism-wmo.swift
+++ b/validation-test/Serialization/Foundation-determinism-wmo.swift
@@ -1,5 +1,5 @@
-// RUN: %target-build-swift -module-name Foundation -parse-as-library %S/../../stdlib/public/Darwin/Foundation/*.swift `dirname %t`/../../../stdlib/public/Darwin/Foundation/8/*.swift -emit-module-path %t.1.swiftmodule -force-single-frontend-invocation
-// RUN: %target-build-swift -module-name Foundation -parse-as-library %S/../../stdlib/public/Darwin/Foundation/*.swift `dirname %t`/../../../stdlib/public/Darwin/Foundation/8/*.swift -emit-module-path %t.2.swiftmodule -force-single-frontend-invocation
+// RUN: %target-build-swift -module-name Foundation -parse-as-library %S/../../stdlib/public/Darwin/Foundation/*.swift `dirname %t`/../../../stdlib/public/Darwin/Foundation/8/*.swift -emit-module-path %t.1.swiftmodule -whole-module-optimization
+// RUN: %target-build-swift -module-name Foundation -parse-as-library %S/../../stdlib/public/Darwin/Foundation/*.swift `dirname %t`/../../../stdlib/public/Darwin/Foundation/8/*.swift -emit-module-path %t.2.swiftmodule -whole-module-optimization
 // RUN: diff <(llvm-bcanalyzer -dump %t.1.swiftmodule | sed -e 's/\.[0-9]\.swiftmodule/\.x\.swiftmodule/g') <(llvm-bcanalyzer -dump %t.2.swiftmodule | sed -e 's/\.[0-9]\.swiftmodule/\.x\.swiftmodule/g')
 
 // REQUIRES: sr4342

--- a/validation-test/execution/testability.swift
+++ b/validation-test/execution/testability.swift
@@ -8,7 +8,7 @@
 // RUN: grep RUN: %S/../../test/Interpreter/testability.swift | sed -e 's|%%S|%%S/../../test/Interpreter|g' -e 's|%%s|%%S/../../test/Interpreter/testability.swift|g' -e 's|%%target-build-swift|%%target-build-swift -O|' > %t/VERIFY-orig.txt
 // RUN: diff %t/VERIFY.txt %t/VERIFY-orig.txt
 
-// RUN: %target-build-swift -O -emit-library -c %S/../../test/Interpreter/Inputs/testability_helper.swift -enable-testing -force-single-frontend-invocation -o %t/testability_helper.o -emit-module
+// RUN: %target-build-swift -O -emit-library -c %S/../../test/Interpreter/Inputs/testability_helper.swift -enable-testing -whole-module-optimization -o %t/testability_helper.o -emit-module
 
 // RUN: %target-build-swift -O %S/../../test/Interpreter/testability.swift -I %t -Xlinker %t/testability_helper.o -o %t/main
 // RUN: %target-codesign %t/main

--- a/validation-test/stdlib/CommandLine.swift
+++ b/validation-test/stdlib/CommandLine.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 //
 //
-// RUN: %target-build-swift %S/Inputs/CommandLineStressTest/CommandLineStressTest.swift -parse-as-library -force-single-frontend-invocation -module-name CommandLineStressTestSwift -emit-object -o %t/CommandLineStressTestSwift.o
+// RUN: %target-build-swift %S/Inputs/CommandLineStressTest/CommandLineStressTest.swift -parse-as-library -whole-module-optimization -module-name CommandLineStressTestSwift -emit-object -o %t/CommandLineStressTestSwift.o
 // RUN: %clang -arch %target-cpu -c -o %t/CommandLineStressTest.o -x c %S/Inputs/CommandLineStressTest/CommandLineStressTest.c
 // RUN: %target-build-swift %t/CommandLineStressTest.o %t/CommandLineStressTestSwift.o -o %t/CommandLineStressTest
 // RUN: %target-codesign %t/CommandLineStressTest

--- a/validation-test/stdlib/MicroStdlib/MicroStdlib.swift
+++ b/validation-test/stdlib/MicroStdlib/MicroStdlib.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -c -force-single-frontend-invocation -parse-as-library -parse-stdlib -Xllvm -basic-dynamic-replacement -module-name Swift -emit-module -emit-module-path %t/Swift.swiftmodule -o %t/Swift.o %S/Inputs/Swift.swift
+// RUN: %target-build-swift -c -whole-module-optimization -parse-as-library -parse-stdlib -Xllvm -basic-dynamic-replacement -module-name Swift -emit-module -emit-module-path %t/Swift.swiftmodule -o %t/Swift.o %S/Inputs/Swift.swift
 // RUN: ls %t/Swift.swiftmodule
 // RUN: ls %t/Swift.swiftdoc
 // RUN: ls %t/Swift.o


### PR DESCRIPTION
The `-force-single-frontend-invocation` flag predates WMO and is now an alias for `-whole-module-optimization`. We should use the latter and let the former fade into history.