### PR TITLE
runtime: add and switch to `SWIFT_NORETURN` (NFC)

### DIFF
--- a/stdlib/public/SwiftShims/Visibility.h
+++ b/stdlib/public/SwiftShims/Visibility.h
@@ -72,6 +72,12 @@
 #define SWIFT_NOINLINE
 #endif
 
+#if __has_attribute(noreturn)
+#define SWIFT_NORETURN __attribute__((__noreturn__))
+#else
+#define SWIFT_NORETURN
+#endif
+
 #if __has_attribute(used)
 #define SWIFT_USED __attribute__((__used__))
 #else

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -248,7 +248,7 @@ swift::swift_getMangledTypeName(const Metadata *type) {
 // This is noinline to preserve this frame in stack traces.
 // We want "dynamicCastFailure" to appear in crash logs even we crash 
 // during the diagnostic because some Metadata is invalid.
-LLVM_ATTRIBUTE_NORETURN SWIFT_NOINLINE void
+SWIFT_NORETURN SWIFT_NOINLINE void
 swift::swift_dynamicCastFailure(const void *sourceType, const char *sourceName,
                                 const void *targetType, const char *targetName,
                                 const char *message) {
@@ -260,11 +260,9 @@ swift::swift_dynamicCastFailure(const void *sourceType, const char *sourceName,
                     message ? message : "");
 }
 
-LLVM_ATTRIBUTE_NORETURN
-void 
-swift::swift_dynamicCastFailure(const Metadata *sourceType,
-                                const Metadata *targetType, 
-                                const char *message) {
+SWIFT_NORETURN void swift::swift_dynamicCastFailure(const Metadata *sourceType,
+                                                    const Metadata *targetType,
+                                                    const char *message) {
   std::string sourceName = nameForMetadata(sourceType);
   std::string targetName = nameForMetadata(targetType);
 

--- a/stdlib/public/runtime/ErrorObject.h
+++ b/stdlib/public/runtime/ErrorObject.h
@@ -206,19 +206,20 @@ SWIFT_RUNTIME_STDLIB_API
 void swift_errorRelease(SwiftError *object);
 
 /// Breakpoint hook for debuggers.
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
-void swift_willThrow(SWIFT_CONTEXT void *unused,
-                     SWIFT_ERROR_RESULT SwiftError **object);
+SWIFT_CC(swift)
+SWIFT_RUNTIME_STDLIB_API void
+swift_willThrow(SWIFT_CONTEXT void *unused,
+                SWIFT_ERROR_RESULT SwiftError **object);
 
 /// Halt in response to an error.
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API LLVM_ATTRIBUTE_NORETURN
-void swift_errorInMain(SwiftError *object);
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API LLVM_ATTRIBUTE_NORETURN
-void swift_unexpectedError(SwiftError *object,
-                           OpaqueValue *filenameStart,
-                           long filenameLength,
-                           bool isAscii,
-                           unsigned long line);
+SWIFT_CC(swift)
+SWIFT_RUNTIME_STDLIB_API SWIFT_NORETURN void
+swift_errorInMain(SwiftError *object);
+
+SWIFT_CC(swift)
+SWIFT_RUNTIME_STDLIB_API SWIFT_NORETURN void
+swift_unexpectedError(SwiftError *object, OpaqueValue *filenameStart,
+                      long filenameLength, bool isAscii, unsigned long line);
 
 #if SWIFT_OBJC_INTEROP
 

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -376,10 +376,7 @@ static int swift_vasprintf(char **strp, const char *fmt, va_list ap) {
 }
 
 // Report a fatal error to system console, stderr, and crash logs, then abort.
-LLVM_ATTRIBUTE_NORETURN
-void
-swift::fatalError(uint32_t flags, const char *format, ...)
-{
+SWIFT_NORETURN void swift::fatalError(uint32_t flags, const char *format, ...) {
   va_list args;
   va_start(args, format);
 
@@ -419,14 +416,10 @@ swift::warning(uint32_t flags, const char *format, ...)
 }
 
 // Crash when a deleted method is called by accident.
-SWIFT_RUNTIME_EXPORT
-LLVM_ATTRIBUTE_NORETURN
-void
-swift_deletedMethodError() {
+SWIFT_RUNTIME_EXPORT SWIFT_NORETURN void swift_deletedMethodError() {
   swift::fatalError(/* flags = */ 0,
                     "Fatal error: Call of deleted method\n");
 }
-
 
 // Crash due to a retain count overflow.
 // FIXME: can't pass the object's address from InlineRefCounts without hacks

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -5312,9 +5312,9 @@ checkTransitiveCompleteness(const Metadata *initialType) {
 }
 
 /// Diagnose a metadata dependency cycle.
-LLVM_ATTRIBUTE_NORETURN
-static void diagnoseMetadataDependencyCycle(const Metadata *start,
-                                            ArrayRef<MetadataDependency> links){
+SWIFT_NORETURN static void
+diagnoseMetadataDependencyCycle(const Metadata *start,
+                                ArrayRef<MetadataDependency> links) {
   assert(start == links.back().Value);
 
   std::string diagnostic =


### PR DESCRIPTION
Remove the use of the `LLVM_ATTRIBUTE_NORETURN` to trim dependencies on
LLVMSupport.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
