### PR TITLE
[Function builders] Clean up locators in the builder transform.

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -551,8 +551,7 @@ protected:
       return nullptr;
     }
 
-    // FIXME: Need a locator for the "if" statement.
-    Type resultType = cs->addJoinConstraint(nullptr,
+    Type resultType = cs->addJoinConstraint(cs->getConstraintLocator(ifStmt),
         {
           { cs->getType(thenExpr), cs->getConstraintLocator(thenExpr) },
           { cs->getType(elseExpr), cs->getConstraintLocator(elseExpr) }
@@ -709,8 +708,8 @@ protected:
     }
 
     // Form the type of the switch itself.
-    // FIXME: Need a locator for the "switch" statement.
-    Type resultType = cs->addJoinConstraint(nullptr, injectedCaseTerms);
+    Type resultType = cs->addJoinConstraint(
+        cs->getConstraintLocator(switchStmt), injectedCaseTerms);
     if (!resultType) {
       hadError = true;
       return nullptr;
@@ -810,7 +809,8 @@ protected:
     }
     cs->addConstraint(
         ConstraintKind::Equal, cs->getType(arrayInitExpr), arrayType,
-        cs->getConstraintLocator(arrayInitExpr));
+        cs->getConstraintLocator(
+          arrayInitExpr, LocatorPathElt::ContextualType()));
 
     // Form a call to Array.append(_:) to add the result of executing each
     // iteration of the loop body to the array formed above.
@@ -1477,32 +1477,10 @@ Optional<BraceStmt *> TypeChecker::applyFunctionBuilderBodyTransform(
   // Build a constraint system in which we can check the body of the function.
   ConstraintSystem cs(func, options);
 
-  // Find an expression... any expression... to use for a locator.
-  // FIXME: This is a hack because we don't have the notion of locators that
-  // refer to statements.
-  Expr *fakeAnchor = nullptr;
-  {
-    class FindExprWalker : public ASTWalker {
-      Expr *&fakeAnchor;
-
-    public:
-      explicit FindExprWalker(Expr *&fakeAnchor) : fakeAnchor(fakeAnchor) { }
-
-      std::pair<bool, Expr *> walkToExprPre(Expr *E) {
-        if (!fakeAnchor)
-          fakeAnchor = E;
-
-        return { false, nullptr };
-      }
-    } walker(fakeAnchor);
-
-    func->getBody()->walk(walker);
-  }
-
   if (auto result = cs.matchFunctionBuilder(
           func, builderType, resultContextType, resultConstraintKind,
-          /*calleeLocator=*/cs.getConstraintLocator(fakeAnchor),
-          /*FIXME:*/cs.getConstraintLocator(fakeAnchor))) {
+          cs.getConstraintLocator(func->getBody()),
+          cs.getConstraintLocator(func->getBody()))) {
     if (result->isFailure())
       return nullptr;
   }


### PR DESCRIPTION
Now that statements can be locators, we can clean up several FIXMEs.
Also, add an appropriate ContextualType locator noticed by Pavel.
