### PR TITLE
sprinkle `llvm_unreachable` for covered switches (NFC)

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7187,6 +7187,7 @@ public:
     case DeclKind::PostfixOperator:
       return OperatorFixity::Postfix;
     }
+    llvm_unreachable("inavlid decl kind");
   }
 
   SourceLoc getOperatorLoc() const { return OperatorLoc; }

--- a/include/swift/AST/EvaluatorDependencies.h
+++ b/include/swift/AST/EvaluatorDependencies.h
@@ -94,6 +94,7 @@ inline DependencyScope getScopeForAccessLevel(AccessLevel l) {
   case AccessLevel::Open:
     return DependencyScope::Cascading;
   }
+  llvm_unreachable("invalid access level kind");
 }
 
 // A \c DependencySource is currently defined to be a parent source file and
@@ -258,6 +259,7 @@ private:
     case Mode::ExperimentalPrivateDependencies:
       return false;
     }
+    llvm_unreachable("invalid mode");
   }
 };
 } // end namespace evaluator

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -1015,6 +1015,7 @@ public:
       return SourceRange(getLoc(), getLoc());
     }
     }
+    llvm_unreachable("invalid parent kind");
   }
 
   bool isDefault() { return getCaseLabelItems()[0].isDefault(); }

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -452,6 +452,7 @@ getParameterDifferentiability(ImplParameterDifferentiability diffKind) {
   case ImplParameterDifferentiability::NotDifferentiable:
     return SILParameterDifferentiability::NotDifferentiable;
   }
+  llvm_unreachable("unknown differentiability kind");
 }
 
 static ResultConvention getResultConvention(ImplResultConvention conv) {

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -62,6 +62,7 @@ NormalDifferentiableFunctionTypeComponent::getAsDerivativeFunctionKind() const {
   case VJP:
     return {AutoDiffDerivativeFunctionKind::VJP};
   }
+  llvm_unreachable("invalid derivative kind");
 }
 
 LinearDifferentiableFunctionTypeComponent::
@@ -93,6 +94,7 @@ DifferentiabilityWitnessFunctionKind::getAsDerivativeFunctionKind() const {
   case Transpose:
     return None;
   }
+  llvm_unreachable("invalid derivative kind");
 }
 
 void SILAutoDiffIndices::print(llvm::raw_ostream &s) const {
@@ -375,6 +377,7 @@ Type TangentSpace::getType() const {
   case Kind::Tuple:
     return value.tupleType;
   }
+  llvm_unreachable("invalid tangent space kind");
 }
 
 CanType TangentSpace::getCanonicalType() const {

--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -155,6 +155,7 @@ const clang::Type *ClangTypeConverter::getFunctionType(
   case AnyFunctionType::Representation::Thin:
     llvm_unreachable("Expected a C-compatible representation.");
   }
+  llvm_unreachable("invalid representation");
 }
 
 clang::QualType ClangTypeConverter::convertMemberType(NominalTypeDecl *DC,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -645,6 +645,7 @@ static_assert(sizeof(checkSourceLocType(&ID##Decl::getLoc)) == 2, \
   case FileUnitKind::DWARFModule:
     return SourceLoc();
   }
+  llvm_unreachable("invalid file kind");
 }
 
 Expr *AbstractFunctionDecl::getSingleExpressionBody() const {
@@ -6297,6 +6298,7 @@ bool ParamDecl::hasCallerSideDefaultExpr() const {
   case DefaultArgumentKind::EmptyDictionary:
     return true;
   }
+  llvm_unreachable("invalid default argument kind");
 }
 
 Expr *ParamDecl::getTypeCheckedDefaultExpr() const {

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -106,6 +106,7 @@ ModuleDependenciesCache::getDependenciesMap(ModuleDependenciesKind kind) {
   case ModuleDependenciesKind::Clang:
     return ClangModuleDependencies;
   }
+  llvm_unreachable("invalid dependency kind");
 }
 
 const llvm::StringMap<ModuleDependencies> &
@@ -117,6 +118,7 @@ ModuleDependenciesCache::getDependenciesMap(ModuleDependenciesKind kind) const {
   case ModuleDependenciesKind::Clang:
     return ClangModuleDependencies;
   }
+  llvm_unreachable("invalid dependency kind");
 }
 
 bool ModuleDependenciesCache::hasDependencies(

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2969,6 +2969,7 @@ static bool canSubstituteTypeInto(Type ty, const DeclContext *dc,
 
     return typeDecl->getEffectiveAccess() > AccessLevel::Internal;
   }
+  llvm_unreachable("invalid subsitution kind");
 }
 
 Type ReplaceOpaqueTypesWithUnderlyingTypes::

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -1079,6 +1079,7 @@ namespace driver {
                      forRanges, "file is up-to-date and output exists");
         return false;
       }
+      llvm_unreachable("invalid job condition");
     }
 
     bool isCascadingJobAccordingToCondition(
@@ -1092,6 +1093,7 @@ namespace driver {
       case Job::Condition::CheckDependencies:
         return false;
       }
+      llvm_unreachable("invalid job condition");
     }
 
     void forEachOutOfDateExternalDependency(

--- a/lib/Frontend/DependencyVerifier.cpp
+++ b/lib/Frontend/DependencyVerifier.cpp
@@ -239,6 +239,7 @@ public:
     case Expectation::Scope::Cascading:
       return "cascading";
     }
+    llvm_unreachable("invalid expectation scope");
   }
 
   StringRef renderAsFixit(ASTContext &Ctx) const {

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -875,6 +875,7 @@ class OutdentChecker: protected RangeWalker {
       return !SM.isBeforeInBuffer(L, CheckRange.Start) &&
         (R.isInvalid() || !SM.isBeforeInBuffer(CheckRange.End, R));
     }
+    llvm_unreachable("invalid range kind");
   }
 
 public:

--- a/lib/IRGen/ProtocolInfo.h
+++ b/lib/IRGen/ProtocolInfo.h
@@ -194,6 +194,7 @@ public:
              left.AssociatedConformanceEntry.Protocol ==
                  right.AssociatedConformanceEntry.Protocol;
     }
+    llvm_unreachable("invalid witness kind");
   }
 };
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1855,6 +1855,7 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
         return makeParserError();
       }
       }
+      llvm_unreachable("invalid next segment kind");
     }).isError() || SuppressLaterDiags) {
       return false;
     }

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1007,6 +1007,7 @@ private:
       // Execute the expression.
       return rewriteExpr(capturedExpr);
     }
+    llvm_unreachable("invalid function builder target");
   }
 
   /// Declare the given temporary variable, adding the appropriate

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8544,4 +8544,5 @@ SolutionApplicationTarget SolutionApplicationTarget::walk(ASTWalker &walker) {
 
     return *this;
   }
+  llvm_unreachable("invalid target kind");
 }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5880,6 +5880,7 @@ void NonEphemeralConversionFailure::emitSuggestionNotes() const {
     case PTK_AutoreleasingUnsafeMutablePointer:
       return None;
     }
+    llvm_unreachable("invalid pointer kind");
   };
 
   // First emit a note about the implicit conversion only lasting for the

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4077,6 +4077,7 @@ ConstraintSystem::isConversionEphemeral(ConversionRestrictionKind conversion,
     // parameter.
     return ConversionEphemeralness::NonEphemeral;
   }
+  llvm_unreachable("invalid conversion restriction kind");
 }
 
 Expr *ConstraintSystem::buildAutoClosureExpr(Expr *expr,
@@ -4381,6 +4382,7 @@ bool SolutionApplicationTarget::contextualTypeIsOnlyAHint() const {
   case CTP_CannotFail:
     return false;
   }
+  llvm_unreachable("invalid contextual type");
 }
 
 /// Given a specific expression and the remnants of the failed constraint

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1351,6 +1351,7 @@ public:
     case Kind::caseLabelItem:
       return nullptr;
     }
+    llvm_unreachable("invalid expression type");
   }
 
   DeclContext *getDeclContext() const {
@@ -1367,6 +1368,7 @@ public:
     case Kind::caseLabelItem:
       return caseLabelItem.dc;
     }
+    llvm_unreachable("invalid decl context type");
   }
 
   ContextualTypePurpose getExprContextualTypePurpose() const {
@@ -1520,6 +1522,7 @@ public:
     case Kind::function:
       return function.function;
     }
+    llvm_unreachable("invalid function kind");
   }
 
   Optional<StmtCondition> getAsStmtCondition() const {
@@ -1532,6 +1535,7 @@ public:
     case Kind::stmtCondition:
       return stmtCondition.stmtCondition;
     }
+    llvm_unreachable("invalid statement kind");
   }
 
   Optional<CaseLabelItem *> getAsCaseLabelItem() const {
@@ -1544,6 +1548,7 @@ public:
     case Kind::caseLabelItem:
       return caseLabelItem.caseLabelItem;
     }
+    llvm_unreachable("invalid case label type");
   }
 
   BraceStmt *getFunctionBody() const {
@@ -1572,6 +1577,7 @@ public:
     case Kind::caseLabelItem:
       return caseLabelItem.caseLabelItem->getSourceRange();
     }
+    llvm_unreachable("invalid target type");
   }
 
   /// Retrieve the source location for the target.
@@ -1589,6 +1595,7 @@ public:
     case Kind::caseLabelItem:
       return caseLabelItem.caseLabelItem->getStartLoc();
     }
+    llvm_unreachable("invalid target type");
   }
 
   /// Walk the contents of the application target.

--- a/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
@@ -51,6 +51,7 @@ static StringRef getMathOperatorName(MathOperator op) {
   case Subtract:
     return "-";
   }
+  llvm_unreachable("invalid math operator kind");
 }
 
 bool DerivedConformance::canDeriveAdditiveArithmetic(NominalTypeDecl *nominal,

--- a/lib/Sema/SolutionResult.h
+++ b/lib/Sema/SolutionResult.h
@@ -135,6 +135,7 @@ public:
     case TooComplex:
       return true;
     }
+    llvm_unreachable("invalid diagnostic kind");
   }
 
   /// Note that the failure has been diagnosed.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3450,6 +3450,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
     case CheckedCastKind::Unresolved:
       return failed();
     }
+    llvm_unreachable("invalid cast type");
   };
 
   // Check for casts between specific concrete types that cannot succeed.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2351,6 +2351,7 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
     return resultTy;
   }
   }
+  llvm_unreachable("invalid decl kind");
 }
 
 NamedPattern *

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5556,6 +5556,7 @@ ValueDecl *TypeChecker::deriveProtocolRequirement(DeclContext *DC,
       llvm_unreachable(
           "When possible, OptionSet is derived via memberwise init synthesis");
   }
+  llvm_unreachable("unknown derivable protocol kind");
 }
 
 Type TypeChecker::deriveTypeWitness(DeclContext *DC,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -694,6 +694,7 @@ static Type checkContextualRequirements(Type type,
   case RequirementCheckResult::Success:
     return type;
   }
+  llvm_unreachable("invalid requirement check type");
 }
 
 static void diagnoseUnboundGenericType(Type ty, SourceLoc loc);

--- a/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
+++ b/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
@@ -54,6 +54,7 @@ DeclarationFragmentPrinter::getKindSpelling(FragmentKind Kind) const {
     case FragmentKind::None:
       llvm_unreachable("Fragment kind of 'None' has no spelling");
   }
+  llvm_unreachable("invalid fragment kind");
 }
 
 void DeclarationFragmentPrinter::closeFragment() {

--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -371,6 +371,7 @@ Symbol::getDomain(PlatformAgnosticAvailabilityKind AgnosticKind,
     case swift::PlatformKind::none:
       return None;
   }
+  llvm_unreachable("invalid platform kind");
 }
 
 void Symbol::serializeAvailabilityMixin(llvm::json::OStream &OS) const {


### PR DESCRIPTION
Annotate the covered switches with `llvm_unreachable` to avoid the MSVC
warning which does not recognise the covered switches.  This allows us
to avoid a spew of warnings.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
