### PR TITLE
runtime: remove dependency on `LLVM_ENABLE_THREADS`

### DIFF
--- a/stdlib/public/runtime/Exclusivity.cpp
+++ b/stdlib/public/runtime/Exclusivity.cpp
@@ -270,10 +270,10 @@ static SwiftTLSContext &getTLSContext() {
   return *ctx;
 }
 
-#elif SWIFT_TLS_HAS_THREADLOCAL
+#elif __has_feature(cxx_thread_local)
 // Second choice is direct language support for thread-locals.
 
-static LLVM_THREAD_LOCAL SwiftTLSContext TLSContext;
+static thread_local SwiftTLSContext TLSContext;
 
 static SwiftTLSContext &getTLSContext() {
   return TLSContext;

--- a/stdlib/public/runtime/ThreadLocalStorage.h
+++ b/stdlib/public/runtime/ThreadLocalStorage.h
@@ -26,16 +26,6 @@
 # define SWIFT_TLS_HAS_RESERVED_PTHREAD_SPECIFIC 1
 #endif
 
-// If we're using Clang, and Clang claims not to support thread_local,
-// it must be because we're on a platform that doesn't support it.
-#if __clang__ && !__has_feature(cxx_thread_local)
-// No thread_local.
-#else
-// Otherwise, we do have thread_local.
-# define SWIFT_TLS_HAS_THREADLOCAL 1
-static_assert(LLVM_ENABLE_THREADS, "LLVM_THREAD_LOCAL will use a global?");
-#endif
-
 #if SWIFT_TLS_HAS_RESERVED_PTHREAD_SPECIFIC
 // Use reserved TSD keys.
 # if __has_include(<pthread/tsd_private.h>)
@@ -92,6 +82,9 @@ typedef unsigned long __swift_thread_key_t;
 #  include <io.h>
 #  define WIN32_LEAN_AND_MEAN
 #  include <Windows.h>
+
+#include <type_traits>
+
 static_assert(std::is_same<__swift_thread_key_t, DWORD>::value,
               "__swift_thread_key_t is not a DWORD");
 


### PR DESCRIPTION
This removes the LLVMSupport usage for thread local.  This effectively
is a no-op as the runtime requires that it is built with clang, which
provides the C++11 `thread_local` support on all the targets.  In the
case that the target does not support `thread_local`, clang would
fallback to `__declspec(thread)` on MSVC and `__thread` on other modes.
However, because the runtime is always built in C++14 mode, the
`thread_local` support should be assumed to be present.  Remove the
unnecessary condition and inline the single use of the macro for
`thread_local`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
