### PR TITLE
Patch a Source of Iterator Invalidation

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2697,7 +2697,7 @@ SourceFile::getConfiguredReferencedNameTracker() const {
 }
 
 ArrayRef<OpaqueTypeDecl *> SourceFile::getOpaqueReturnTypeDecls() {
-  for (auto *vd : UnvalidatedDeclsWithOpaqueReturnTypes) {
+  for (auto *vd : UnvalidatedDeclsWithOpaqueReturnTypes.takeVector()) {
     if (auto opaqueDecl = vd->getOpaqueResultTypeDecl()) {
       auto inserted = ValidatedOpaqueReturnTypes.insert(
                 {opaqueDecl->getOpaqueReturnTypeIdentifier().str(),
@@ -2708,7 +2708,6 @@ ArrayRef<OpaqueTypeDecl *> SourceFile::getOpaqueReturnTypeDecls() {
     }
   }
 
-  UnvalidatedDeclsWithOpaqueReturnTypes.clear();
   return OpaqueReturnTypes;
 }
 


### PR DESCRIPTION
Cherry-picked from #31639 

- Explanation: 

getOpaqueResultTypeDecl() can wind up invoking lazy function body
parsing when it runs availability checking. If any of those function
bodies have opaque result types, they will be inserted. If that
insertion happens to resize the SetVector, iterators will be invalidated
and a non-deterministic crash results.

Instead, use SetVector::takeVector() for the iteration so we have
a temporary copy whose iterators cannot be invalidated in this
situation. This also elegantly handles clearing out the vector for us.

- Scope: Iterator invalidation could occur at any point in the compiler pipeline now that lazy parsing is enabled. The crashes would most likely manifest deep in code generation where the opaque result type decls themselves are needed most.

- Resolves rdar://62976771

- Risk: Low

- Testing: MovieSwiftUI semi-reliably reproduces this crash. Verifying the source compatibility suite and ASAN bots pass after this change suffices. 

Reviewer: @DougGregor