### PR TITLE
Suggest `numericCast` instead of integer initializer call as a fix-it for integer conversions.

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2627,7 +2627,8 @@ bool ContextualFailure::tryIntegerCastFixIts(
   auto fromType = getFromType();
   auto toType = getToType();
 
-  if (!isIntegerType(fromType) || !isIntegerType(toType))
+  if (!isExpressibleByIntegerLiteralType(fromType) ||
+      !isExpressibleByIntegerLiteralType(toType))
     return false;
 
   auto getInnerCastedExpr = [&](const Expr *expr) -> Expr * {
@@ -2657,8 +2658,11 @@ bool ContextualFailure::tryIntegerCastFixIts(
     }
   }
 
-  // Add a wrapping integer cast.
-  std::string convWrapBefore = toType.getString();
+  // Add a wrapping integer cast using numeric cast or Integer initializer.
+  bool isBinaryIntToIntConversion =
+      isBinaryIntegerType(fromType) && isBinaryIntegerType(toType);
+  std::string convWrapBefore =
+      isBinaryIntToIntConversion ? "numericCast" : toType.getString();
   convWrapBefore += "(";
   std::string convWrapAfter = ")";
   SourceRange exprRange = getSourceRange();

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -656,10 +656,16 @@ private:
   /// property
   void tryComputedPropertyFixIts() const;
 
-  bool isIntegerType(Type type) const {
+  bool isExpressibleByIntegerLiteralType(Type type) const {
     return conformsToKnownProtocol(
         getConstraintSystem(), type,
         KnownProtocolKind::ExpressibleByIntegerLiteral);
+  }
+
+  bool isBinaryIntegerType(Type type) const {
+    return conformsToKnownProtocol(
+        getConstraintSystem(), type,
+        KnownProtocolKind::BinaryInteger);
   }
 
   /// Return true if the conversion from fromType to toType is

--- a/test/Sema/numeric_cast_fix.swift
+++ b/test/Sema/numeric_cast_fix.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %s
+
+
+let x: [Int] = [1, 2, 3, 4]
+let y: UInt = 4
+
+_ = x.filter { ($0 + y)  > 42 } // expected-error {{cannot convert value of type 'UInt' to expected argument type 'Int'}} {{22-22=numericCast(}} {{23-23=)}}


### PR DESCRIPTION
Only do so for binary integer to integer conversions.
`numericCast` is effectively the same thing but is more explicit about what's going on.

Resolves rdar://56043942

