### PR TITLE
[NFC] AST: Relocate some conformance lookup client methods from DeclContext to IterableDeclContext

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -51,6 +51,7 @@ namespace swift {
   class Expr;
   class GenericParamList;
   class LazyMemberLoader;
+  class GenericContext;
   class GenericSignature;
   class GenericTypeParamDecl;
   class GenericTypeParamType;
@@ -817,6 +818,9 @@ public:
 
   /// Return 'this' as a \c Decl.
   const Decl *getDecl() const;
+
+  /// Return 'this' as a \c GenericContext.
+  const GenericContext *getAsGenericContext() const;
 
   /// Get the DeclID this Decl was deserialized from.
   serialization::DeclID getDeclID() const {

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -567,22 +567,6 @@ public:
   LLVM_READONLY
   ASTContext &getASTContext() const;
 
-  /// Retrieve the set of protocols whose conformances will be
-  /// associated with this declaration context.
-  ///
-  /// This function differs from \c getLocalConformances() in that it
-  /// returns protocol declarations, not protocol conformances, and
-  /// therefore does not require the protocol conformances to be
-  /// formed.
-  ///
-  /// \param lookupKind The kind of lookup to perform.
-  ///
-  /// FIXME: This likely makes more sense on IterableDeclContext or
-  /// something similar.
-  SmallVector<ProtocolDecl *, 2>
-  getLocalProtocols(ConformanceLookupKind lookupKind
-                      = ConformanceLookupKind::All) const;
-
   /// Retrieve the set of protocol conformances associated with this
   /// declaration context.
   ///
@@ -593,14 +577,6 @@ public:
   SmallVector<ProtocolConformance *, 2>
   getLocalConformances(ConformanceLookupKind lookupKind
                          = ConformanceLookupKind::All) const;
-
-  /// Retrieve diagnostics discovered while expanding conformances for this
-  /// declaration context. This operation then removes those diagnostics from
-  /// consideration, so subsequent calls to this function with the same
-  /// declaration context that have not had any new extensions bound
-  /// will see an empty array.
-  SmallVector<ConformanceDiagnostic, 4>
-  takeConformanceDiagnostics() const;
 
   /// Retrieves a list of separately imported overlays which are shadowing
   /// \p declaring. If any \p overlays are returned, qualified lookups into
@@ -815,6 +791,26 @@ public:
   /// Determine whether this was deserialized (and thus SerialID is
   /// valid).
   bool wasDeserialized() const;
+
+  /// Retrieve the set of protocols whose conformances will be
+  /// associated with this declaration context.
+  ///
+  /// This function differs from \c getLocalConformances() in that it
+  /// returns protocol declarations, not protocol conformances, and
+  /// therefore does not require the protocol conformances to be
+  /// formed.
+  ///
+  /// \param lookupKind The kind of lookup to perform.
+  SmallVector<ProtocolDecl *, 2>
+  getLocalProtocols(ConformanceLookupKind lookupKind
+                      = ConformanceLookupKind::All) const;
+
+  /// Retrieve diagnostics discovered while expanding conformances for this
+  /// declaration context. This operation then removes those diagnostics from
+  /// consideration, so subsequent calls to this function with the same
+  /// declaration context that have not had any new extensions bound
+  /// will see an empty array.
+  SmallVector<ConformanceDiagnostic, 4> takeConformanceDiagnostics() const;
 
   /// Return 'this' as a \c Decl.
   const Decl *getDecl() const;

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -567,17 +567,6 @@ public:
   LLVM_READONLY
   ASTContext &getASTContext() const;
 
-  /// Retrieve the set of protocol conformances associated with this
-  /// declaration context.
-  ///
-  /// \param lookupKind The kind of lookup to perform.
-  ///
-  /// FIXME: This likely makes more sense on IterableDeclContext or
-  /// something similar.
-  SmallVector<ProtocolConformance *, 2>
-  getLocalConformances(ConformanceLookupKind lookupKind
-                         = ConformanceLookupKind::All) const;
-
   /// Retrieves a list of separately imported overlays which are shadowing
   /// \p declaring. If any \p overlays are returned, qualified lookups into
   /// \p declaring should be performed into \p overlays instead; since they
@@ -804,6 +793,14 @@ public:
   SmallVector<ProtocolDecl *, 2>
   getLocalProtocols(ConformanceLookupKind lookupKind
                       = ConformanceLookupKind::All) const;
+
+  /// Retrieve the set of protocol conformances associated with this
+  /// declaration context.
+  ///
+  /// \param lookupKind The kind of lookup to perform.
+  SmallVector<ProtocolConformance *, 2>
+  getLocalConformances(ConformanceLookupKind lookupKind
+                         = ConformanceLookupKind::All) const;
 
   /// Retrieve diagnostics discovered while expanding conformances for this
   /// declaration context. This operation then removes those diagnostics from

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2259,7 +2259,8 @@ void simple_display(llvm::raw_ostream &out, ConformanceLookupKind kind);
 /// must also be reported so it can be checked as well.
 class LookupAllConformancesInContextRequest
     : public SimpleRequest<LookupAllConformancesInContextRequest,
-                           ProtocolConformanceLookupResult(const DeclContext *),
+                           ProtocolConformanceLookupResult(
+                               const IterableDeclContext *),
                            RequestFlags::Uncached |
                                RequestFlags::DependencySink |
                                RequestFlags::DependencySource> {
@@ -2271,7 +2272,7 @@ private:
 
   // Evaluation.
   ProtocolConformanceLookupResult
-  evaluate(Evaluator &evaluator, const DeclContext *DC) const;
+  evaluate(Evaluator &evaluator, const IterableDeclContext *IDC) const;
 
 public:
   // Incremental dependencies

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -256,7 +256,7 @@ SWIFT_REQUEST(TypeChecker, ScopedImportLookupRequest,
 SWIFT_REQUEST(TypeChecker, ClosureHasExplicitResultRequest,
               bool(ClosureExpr *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, LookupAllConformancesInContextRequest,
-              ProtocolConformanceLookupResult(const DeclContext *),
+              ProtocolConformanceLookupResult(const IterableDeclContext *),
               Uncached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SimpleDidSetRequest, 
               bool(AccessorDecl *), Cached, NoLocationInfo)

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1343,11 +1343,13 @@ IterableDeclContext::getLocalProtocols(ConformanceLookupKind lookupKind) const {
 }
 
 SmallVector<ProtocolConformance *, 2>
-DeclContext::getLocalConformances(ConformanceLookupKind lookupKind) const {
+IterableDeclContext::getLocalConformances(ConformanceLookupKind lookupKind)
+    const {
   SmallVector<ProtocolConformance *, 2> result;
 
   // Dig out the nominal type.
-  NominalTypeDecl *nominal = getSelfNominalTypeDecl();
+  const auto dc = getAsGenericContext();
+  const auto nominal = dc->getSelfNominalTypeDecl();
   if (!nominal) {
     return result;
   }
@@ -1366,7 +1368,7 @@ DeclContext::getLocalConformances(ConformanceLookupKind lookupKind) const {
   nominal->prepareConformanceTable();
   nominal->ConformanceTable->lookupConformances(
     nominal,
-    const_cast<DeclContext *>(this),
+    const_cast<GenericContext *>(dc),
     lookupKind,
     nullptr,
     &result,

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1385,20 +1385,16 @@ void CheckRedeclarationRequest::writeDependencySink(
 evaluator::DependencySource
 LookupAllConformancesInContextRequest::readDependencySource(
     const evaluator::DependencyCollector &collector) const {
-  auto *dc = std::get<0>(getStorage());
-  AccessLevel defaultAccess;
-  if (auto ext = dyn_cast<ExtensionDecl>(dc)) {
-    const NominalTypeDecl *nominal = ext->getExtendedNominal();
-    if (!nominal) {
-      return {collector.getActiveDependencySourceOrNull(),
-              evaluator::DependencyScope::Cascading};
-    }
-    defaultAccess = nominal->getFormalAccess();
-  } else {
-    defaultAccess = cast<NominalTypeDecl>(dc)->getFormalAccess();
+  const auto *nominal = std::get<0>(getStorage())
+                            ->getAsGenericContext()
+                            ->getSelfNominalTypeDecl();
+  if (!nominal) {
+    return {collector.getActiveDependencySourceOrNull(),
+            evaluator::DependencyScope::Cascading};
   }
+
   return {collector.getActiveDependencySourceOrNull(),
-          evaluator::getScopeForAccessLevel(defaultAccess)};
+          evaluator::getScopeForAccessLevel(nominal->getFormalAccess())};
 }
 
 void LookupAllConformancesInContextRequest::writeDependencySink(

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -2730,7 +2730,8 @@ bool RefactoringActionConvertToTernaryExpr::performChange() {
 /// these stubs should be filled.
 class FillProtocolStubContext {
 
-  std::vector<ValueDecl*> getUnsatisfiedRequirements(const DeclContext *DC);
+  std::vector<ValueDecl*>
+  getUnsatisfiedRequirements(const IterableDeclContext *IDC);
 
   /// Context in which the content should be filled; this could be either a
   /// nominal type declaraion or an extension declaration.
@@ -2801,12 +2802,12 @@ getContextFromCursorInfo(ResolvedCursorInfo CursorInfo) {
 }
 
 std::vector<ValueDecl*> FillProtocolStubContext::
-getUnsatisfiedRequirements(const DeclContext *DC) {
+getUnsatisfiedRequirements(const IterableDeclContext *IDC) {
   // The results to return.
   std::vector<ValueDecl*> NonWitnessedReqs;
 
   // For each conformance of the extended nominal.
-  for(ProtocolConformance *Con : DC->getLocalConformances()) {
+  for(ProtocolConformance *Con : IDC->getLocalConformances()) {
 
     // Collect non-witnessed requirements.
     Con->forEachNonWitnessedRequirement(

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1116,9 +1116,9 @@ namespace {
 
     /// Gather protocol records for all of the explicitly-specified Objective-C
     /// protocol conformances.
-    void visitConformances(DeclContext *dc) {
+    void visitConformances(const IterableDeclContext *idc) {
       llvm::SmallSetVector<ProtocolDecl *, 2> protocols;
-      for (auto conformance : dc->getLocalConformances(
+      for (auto conformance : idc->getLocalConformances(
                                 ConformanceLookupKind::OnlyExplicit)) {
         ProtocolDecl *proto = conformance->getProtocol();
         getObjCProtocols(proto, protocols);

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -913,9 +913,9 @@ IRGenModule::getConstantReferenceForProtocolDescriptor(ProtocolDecl *proto) {
                                      LinkEntity::forProtocolDescriptor(proto));
 }
 
-void IRGenModule::addLazyConformances(DeclContext *dc) {
+void IRGenModule::addLazyConformances(const IterableDeclContext *idc) {
   for (const ProtocolConformance *conf :
-         dc->getLocalConformances(ConformanceLookupKind::All)) {
+         idc->getLocalConformances(ConformanceLookupKind::All)) {
     IRGen.addLazyWitnessTable(conf);
   }
 }

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1586,8 +1586,9 @@ private:
   void addRuntimeResolvableType(GenericTypeDecl *nominal);
   void maybeEmitOpaqueTypeDecl(OpaqueTypeDecl *opaque);
 
-  /// Add all conformances of the given \c DeclContext LazyWitnessTables.
-  void addLazyConformances(DeclContext *dc);
+  /// Add all conformances of the given \c IterableDeclContext
+  /// LazyWitnessTables.
+  void addLazyConformances(const IterableDeclContext *idc);
 
 //--- Global context emission --------------------------------------------------
 public:

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -777,11 +777,12 @@ bool IndexSwiftASTWalker::visitImports(
 }
 
 bool IndexSwiftASTWalker::handleWitnesses(Decl *D, SmallVectorImpl<IndexedWitness> &explicitWitnesses) {
-  auto DC = dyn_cast<DeclContext>(D);
-  if (!DC)
+  const auto *const IDC = dyn_cast<IterableDeclContext>(D);
+  if (!IDC)
     return true;
 
-  for (auto *conf : DC->getLocalConformances()) {
+  const auto DC = IDC->getAsGenericContext();
+  for (auto *conf : IDC->getLocalConformances()) {
     if (conf->isInvalid())
       continue;
 

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -48,7 +48,7 @@ void swift::simple_display(llvm::raw_ostream &out,
 FingerprintAndMembers
 ParseMembersRequest::evaluate(Evaluator &evaluator,
                               IterableDeclContext *idc) const {
-  SourceFile &sf = *idc->getDecl()->getDeclContext()->getParentSourceFile();
+  SourceFile &sf = *idc->getAsGenericContext()->getParentSourceFile();
   unsigned bufferID = *sf.getBufferID();
 
   // Lexer diaganostics have been emitted during skipping, so we disable lexer's

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -1026,11 +1026,11 @@ getHashValueRequirement(ASTContext &C) {
 }
 
 static ProtocolConformance *
-getHashableConformance(Decl *parentDecl) {
+getHashableConformance(const Decl *parentDecl) {
   ASTContext &C = parentDecl->getASTContext();
-  auto DC = cast<DeclContext>(parentDecl);
+  const auto IDC = cast<IterableDeclContext>(parentDecl);
   auto hashableProto = C.getProtocol(KnownProtocolKind::Hashable);
-  for (auto conformance: DC->getLocalConformances()) {
+  for (auto conformance: IDC->getLocalConformances()) {
     if (conformance->getProtocol() == hashableProto) {
       return conformance;
     }

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -539,7 +539,7 @@ static void
 // wrappers.
 static void
 synthesizePropertyWrapperStorageWrapperProperties(IterableDeclContext *IDC) {
-  auto SF = IDC->getDecl()->getDeclContext()->getParentSourceFile();
+  auto SF = IDC->getAsGenericContext()->getParentSourceFile();
   if (!SF || SF->Kind == SourceFileKind::Interface)
     return;
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5023,8 +5023,8 @@ diagnoseMissingAppendInterpolationMethod(NominalTypeDecl *typeDecl) {
 
 SmallVector<ProtocolConformance *, 2>
 LookupAllConformancesInContextRequest::evaluate(
-    Evaluator &eval, const DeclContext *DC) const {
-  return DC->getLocalConformances(ConformanceLookupKind::All);
+    Evaluator &eval, const IterableDeclContext *IDC) const {
+  return IDC->getLocalConformances(ConformanceLookupKind::All);
 }
 
 void TypeChecker::checkConformancesInContext(DeclContext *dc,
@@ -5050,7 +5050,7 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
   // Check each of the conformances associated with this context.
   auto conformances =
       evaluateOrDefault(dc->getASTContext().evaluator,
-                        LookupAllConformancesInContextRequest{dc}, {});
+                        LookupAllConformancesInContextRequest{idc}, {});
 
   // The conformance checker bundle that checks all conformances in the context.
   auto &Context = dc->getASTContext();

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5103,7 +5103,7 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
                     groupChecker.getUnsatisfiedRequirements().end());
 
   // Diagnose any conflicts attributed to this declaration context.
-  for (const auto &diag : dc->takeConformanceDiagnostics()) {
+  for (const auto &diag : idc->takeConformanceDiagnostics()) {
     // Figure out the declaration of the existing conformance.
     Decl *existingDecl = dyn_cast<NominalTypeDecl>(diag.ExistingDC);
     if (!existingDecl)

--- a/lib/SymbolGraphGen/Edge.cpp
+++ b/lib/SymbolGraphGen/Edge.cpp
@@ -42,20 +42,19 @@ void Edge::serialize(llvm::json::OStream &OS) const {
     }
 
     if (ConformanceExtension) {
-      if (const auto *Generics = ConformanceExtension->getAsGenericContext()) {
-        SmallVector<Requirement, 4> FilteredRequirements;
-        filterGenericRequirements(Generics->getGenericRequirements(),
-            ConformanceExtension->getExtendedNominal()
-                ->getDeclContext()->getSelfNominalTypeDecl(),
-                                  FilteredRequirements);
-        if (!FilteredRequirements.empty()) {
-          OS.attributeArray("swiftConstraints", [&](){
-            for (const auto &Req :
-                 ConformanceExtension->getGenericRequirements()) {
-              ::serialize(Req, OS);
-            }
-          });
-        }
+      SmallVector<Requirement, 4> FilteredRequirements;
+      filterGenericRequirements(
+          ConformanceExtension->getGenericRequirements(),
+          ConformanceExtension->getExtendedNominal()
+              ->getDeclContext()->getSelfNominalTypeDecl(),
+                                FilteredRequirements);
+      if (!FilteredRequirements.empty()) {
+        OS.attributeArray("swiftConstraints", [&](){
+          for (const auto &Req :
+               ConformanceExtension->getGenericRequirements()) {
+            ::serialize(Req, OS);
+          }
+        });
       }
     }
   });

--- a/lib/SymbolGraphGen/JSON.cpp
+++ b/lib/SymbolGraphGen/JSON.cpp
@@ -66,21 +66,20 @@ void swift::symbolgraphgen::serialize(const ExtensionDecl *Extension,
         OS.attribute("extendedModule", ExtendedModule->getNameStr());
       }
     }
-    if (const auto Generics = Extension->getAsGenericContext()) {
-      SmallVector<Requirement, 4> FilteredRequirements;
 
-      filterGenericRequirements(Generics->getGenericRequirements(),
-          Extension->getExtendedNominal()
-              ->getDeclContext()->getSelfNominalTypeDecl(),
-                                FilteredRequirements);
+    SmallVector<Requirement, 4> FilteredRequirements;
 
-      if (!FilteredRequirements.empty()) {
-        OS.attributeArray("constraints", [&](){
-          for (const auto &Requirement : FilteredRequirements) {
-            serialize(Requirement, OS);
-          }
-        }); // end constraints:
-      }
+    filterGenericRequirements(Extension->getGenericRequirements(),
+        Extension->getExtendedNominal()
+            ->getDeclContext()->getSelfNominalTypeDecl(),
+                              FilteredRequirements);
+
+    if (!FilteredRequirements.empty()) {
+      OS.attributeArray("constraints", [&](){
+        for (const auto &Requirement : FilteredRequirements) {
+          serialize(Requirement, OS);
+        }
+      }); // end constraints:
     }
   }); // end swiftExtension:
 }

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -444,8 +444,8 @@ void TBDGenVisitor::addBaseConformanceDescriptor(
   addSymbol(entity);
 }
 
-void TBDGenVisitor::addConformances(DeclContext *DC) {
-  for (auto conformance : DC->getLocalConformances(
+void TBDGenVisitor::addConformances(const IterableDeclContext *IDC) {
+  for (auto conformance : IDC->getLocalConformances(
                             ConformanceLookupKind::NonInherited)) {
     auto protocol = conformance->getProtocol();
     auto needsWTable =
@@ -462,8 +462,9 @@ void TBDGenVisitor::addConformances(DeclContext *DC) {
     // We cannot emit the witness table symbol if the protocol is imported from
     // another module and it's resilient, because initialization of that protocol
     // is necessary in this case
-    if (!rootConformance->getProtocol()->isResilient(DC->getParentModule(),
-                                                     ResilienceExpansion::Maximal))
+    if (!rootConformance->getProtocol()->isResilient(
+            IDC->getAsGenericContext()->getParentModule(),
+            ResilienceExpansion::Maximal))
       addSymbol(LinkEntity::forProtocolWitnessTable(rootConformance));
     addSymbol(LinkEntity::forProtocolConformanceDescriptor(rootConformance));
 

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -95,7 +95,7 @@ private:
 
   void addSymbol(LinkEntity entity);
 
-  void addConformances(DeclContext *DC);
+  void addConformances(const IterableDeclContext *IDC);
 
   void addDispatchThunk(SILDeclRef declRef);
 


### PR DESCRIPTION
Reduce the set of declaration nodes we can call these methods on by moving `getLocalProtocols`, `getLocalConformances` and `takeConformanceDiagnostics` to `IterableDeclContext`, and adding `IterableDeclContext::getAsGenericContext()` to make up for the casting complications.