### PR TITLE
[build-script] On non-Darwin build lld by default.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -125,6 +125,7 @@ KNOWN_SETTINGS=(
     skip-build-benchmarks                         ""                "set to skip building Swift Benchmark Suite"
     skip-build-clang-tools-extra                  ""                "set to skip building clang-tools-extra as part of llvm"
     skip-build-compiler-rt                        ""                "set to skip building Compiler-RT"
+    skip-build-lld                                ""                "set to skip building lld as part of llvm (linux only)"
     skip-build-cygwin                             ""                "set to skip building Swift stdlibs for Cygwin"
     skip-build-external-benchmarks                "1"               "set to skip building the external Swift Benchmark Suite. (skipped by default)"
     skip-build-freebsd                            ""                "set to skip building Swift stdlibs for FreeBSD"
@@ -1490,6 +1491,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -DNDEBUG"
                     -DCMAKE_BUILD_TYPE:STRING="${LLVM_BUILD_TYPE}"
                     -DLLVM_TOOL_SWIFT_BUILD:BOOL=NO
+                    -DLLVM_TOOL_LLD_BUILD:BOOL=TRUE
                     -DLLVM_INCLUDE_DOCS:BOOL=TRUE
                     -DLLVM_ENABLE_LTO:STRING="${LLVM_ENABLE_LTO}"
                     -DCOMPILER_RT_INTERCEPT_LIBDISPATCH=ON
@@ -1506,12 +1508,20 @@ for host in "${ALL_HOSTS[@]}"; do
                     llvm_enable_projects+=("clang-tools-extra")
                 fi
 
-                cmake_options+=(
-                    -DLLVM_ENABLE_PROJECTS="$(join ";" ${llvm_enable_projects[@]})"
-                )
+                # On non-Darwin platforms, build lld so we can always have a
+                # linker that is compatible with the swift we are using to
+                # compile the stdlib.
+                #
+                # This makes it easier to build target stdlibs on systems that
+                # have old toolchains without more modern linker features.
+                if [[ "$(uname -s)" != "Darwin" ]] ; then
+                    if [[ ! "${SKIP_BUILD_LLD}" ]]; then
+                        llvm_enable_projects+=("lld")
+                    fi
+                fi
 
                 cmake_options+=(
-                  -DLLVM_TOOL_LLD_BUILD:BOOL=TRUE
+                    -DLLVM_ENABLE_PROJECTS="$(join ";" ${llvm_enable_projects[@]})"
                 )
 
                 if [[ "${BUILD_TOOLCHAIN_ONLY}" ]]; then


### PR DESCRIPTION
This will let us use lld to link the stdlib. This will allow us to
avoid problems due to old compilers being used on certain older distributions
that we support.

If anyone wants to not build lld, they can just pass to build-script-impl
--skip-build-lld
