### PR TITLE
Set dynamic library install_name directory to @rpath on macOS. (#31592)

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -89,9 +89,10 @@ bool swift::triplesAreValidForZippering(const llvm::Triple &target,
 
 bool swift::tripleRequiresRPathForSwiftInOS(const llvm::Triple &triple) {
   if (triple.isMacOSX()) {
-    // macOS 10.14.4 contains a copy of Swift, but the linker will still use an
-    // rpath-based install name until 10.15.
-    return triple.isMacOSXVersionLT(10, 15);
+    // SWIFT_ENABLE_TENSORFLOW
+    // For TensorFlow, use the toolchain libs, not system ones
+    return false;
+    // SWIFT_ENABLE_TENSORFLOW END
   }
 
   if (triple.isiOS()) {

--- a/stdlib/linker-support/magic-symbols-for-install-name.c
+++ b/stdlib/linker-support/magic-symbols-for-install-name.c
@@ -83,6 +83,10 @@
   // treat macOS 10.14 as an "older OS."
 #if __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_14
   RPATH_INSTALL_NAME_DIRECTIVE(10, 14)
+  // SWIFT_ENABLE_TENSORFLOW
+  // For TensorFlow, keep using @rpath instead of system paths
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 15)
+  // SWIFT_ENABLE_TENSORFLOW END
 #endif
 
 #else

--- a/test/Driver/linker-rpath.swift
+++ b/test/Driver/linker-rpath.swift
@@ -5,11 +5,11 @@
 // SWIFT_ENABLE_TENSORFLOW
 // All "-no-toolchain-stdlib-rpath" additions are SWIFT_ENABLE_TENSORFLOW.
 
-// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.14 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.14.3 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.14.4 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.14 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.14.3 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.14.4 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.15 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
 
 // RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target arm64-apple-ios12 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/31592.
Resolves TF-1260 (macOS `swiftc` dynamic linker issue) for `tensorflow-0.9`.

> Use `@rpath` instead of system library path as the dynamic library `install_name`
> directory on macOS.
> 
> This is an ad-hoc patch for tensorflow branch that fixes `swiftc` binary linker
> issues on macOS 10.15, until changes to `libswiftCore.dylib` are removed (TF-1268).
> This patch should not be upstreamed to master.
> 
> Resolves TF-1260.