### PR TITLE
Update checkout for swift-syntax to release tag.

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -343,7 +343,7 @@
                 "llbuild": "swift-DEVELOPMENT-SNAPSHOT-2020-04-13-a",
                 "swift-tools-support-core": "0.0.1",
                 "swiftpm": "swift-DEVELOPMENT-SNAPSHOT-2020-04-13-a",
-                "swift-syntax": "1e524b3edc47e8ff66890d914b8bcd024e061631",
+                "swift-syntax": "swift-DEVELOPMENT-SNAPSHOT-2020-04-13-a",
                 "swift-stress-tester": "swift-DEVELOPMENT-SNAPSHOT-2020-04-13-a",
                 "swift-corelibs-xctest": "swift-DEVELOPMENT-SNAPSHOT-2020-04-13-a",
                 "swift-corelibs-foundation": "swift-DEVELOPMENT-SNAPSHOT-2020-04-13-a",


### PR DESCRIPTION
`tensorflow-0.9` cherry-pick of https://github.com/apple/swift/pull/31494.
Fixes macOS toolchain builds.