### PR TITLE
[stdlib] Remove unneeded `numericCast`s

### DIFF
--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -607,12 +607,14 @@ internal func += <Element, C: Collection>(
 ) where C.Element == Element {
 
   let oldCount = lhs.count
-  let newCount = oldCount + numericCast(rhs.count)
+  let newCount = oldCount + rhs.count
 
   let buf: UnsafeMutableBufferPointer<Element>
   
   if _fastPath(newCount <= lhs.capacity) {
-    buf = UnsafeMutableBufferPointer(start: lhs.firstElementAddress + oldCount, count: numericCast(rhs.count))
+    buf = UnsafeMutableBufferPointer(
+      start: lhs.firstElementAddress + oldCount,
+      count: rhs.count)
     lhs.count = newCount
   }
   else {
@@ -624,7 +626,9 @@ internal func += <Element, C: Collection>(
       from: lhs.firstElementAddress, count: oldCount)
     lhs.count = 0
     (lhs, newLHS) = (newLHS, lhs)
-    buf = UnsafeMutableBufferPointer(start: lhs.firstElementAddress + oldCount, count: numericCast(rhs.count))
+    buf = UnsafeMutableBufferPointer(
+      start: lhs.firstElementAddress + oldCount,
+      count: rhs.count)
   }
 
   var (remainders,writtenUpTo) = buf.initialize(from: rhs)
@@ -716,7 +720,7 @@ internal func _copyCollectionToContiguousArray<
   C: Collection
 >(_ source: C) -> ContiguousArray<C.Element>
 {
-  let count: Int = numericCast(source.count)
+  let count = source.count
   if count == 0 {
     return ContiguousArray()
   }
@@ -725,7 +729,9 @@ internal func _copyCollectionToContiguousArray<
     _uninitializedCount: count,
     minimumCapacity: 0)
 
-  let p = UnsafeMutableBufferPointer(start: result.firstElementAddress, count: count)
+  let p = UnsafeMutableBufferPointer(
+    start: result.firstElementAddress,
+    count: count)
   var (itr, end) = source._copyContents(initializing: p)
 
   _debugPrecondition(itr.next() == nil,

--- a/stdlib/public/core/ExistentialCollection.swift
+++ b/stdlib/public/core/ExistentialCollection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -743,7 +743,7 @@ internal final class _CollectionBox<S: Collection>: _AnyCollectionBox<S.Element>
   internal override func _index(
     _ i: _AnyIndexBox, offsetBy n: Int
   ) -> _AnyIndexBox {
-    return _IndexBox(_base: _base.index(_unbox(i), offsetBy: numericCast(n)))
+    return _IndexBox(_base: _base.index(_unbox(i), offsetBy: n))
   }
 
   @inlinable
@@ -752,10 +752,7 @@ internal final class _CollectionBox<S: Collection>: _AnyCollectionBox<S.Element>
     offsetBy n: Int,
     limitedBy limit: _AnyIndexBox
   ) -> _AnyIndexBox? {
-    return _base.index(
-        _unbox(i),
-        offsetBy: numericCast(n),
-        limitedBy: _unbox(limit))
+    return _base.index(_unbox(i), offsetBy: n, limitedBy: _unbox(limit))
       .map { _IndexBox(_base: $0) }
   }
 
@@ -764,7 +761,7 @@ internal final class _CollectionBox<S: Collection>: _AnyCollectionBox<S.Element>
     _ i: inout _AnyIndexBox, offsetBy n: Int
   ) {
     if let box = i as? _IndexBox<S.Index> {
-      return _base.formIndex(&box._base, offsetBy: numericCast(n))
+      return _base.formIndex(&box._base, offsetBy: n)
     }
     fatalError("Index type mismatch!")
   }
@@ -774,10 +771,7 @@ internal final class _CollectionBox<S: Collection>: _AnyCollectionBox<S.Element>
     _ i: inout _AnyIndexBox, offsetBy n: Int, limitedBy limit: _AnyIndexBox
   ) -> Bool {
     if let box = i as? _IndexBox<S.Index> {
-      return _base.formIndex(
-        &box._base,
-        offsetBy: numericCast(n),
-        limitedBy: _unbox(limit))
+      return _base.formIndex(&box._base, offsetBy: n, limitedBy: _unbox(limit))
     }
     fatalError("Index type mismatch!")
   }
@@ -787,12 +781,12 @@ internal final class _CollectionBox<S: Collection>: _AnyCollectionBox<S.Element>
     from start: _AnyIndexBox,
     to end: _AnyIndexBox
   ) -> Int {
-    return numericCast(_base.distance(from: _unbox(start), to: _unbox(end)))
+    return _base.distance(from: _unbox(start), to: _unbox(end))
   }
 
   @inlinable
   internal override var _count: Int {
-    return numericCast(_base.count)
+    return _base.count
   }
 
   @usableFromInline
@@ -949,7 +943,7 @@ internal final class _BidirectionalCollectionBox<S: BidirectionalCollection>
   internal override func _index(
     _ i: _AnyIndexBox, offsetBy n: Int
   ) -> _AnyIndexBox {
-    return _IndexBox(_base: _base.index(_unbox(i), offsetBy: numericCast(n)))
+    return _IndexBox(_base: _base.index(_unbox(i), offsetBy: n))
   }
 
   @inlinable
@@ -958,11 +952,7 @@ internal final class _BidirectionalCollectionBox<S: BidirectionalCollection>
     offsetBy n: Int,
     limitedBy limit: _AnyIndexBox
   ) -> _AnyIndexBox? {
-    return _base.index(
-        _unbox(i),
-        offsetBy: numericCast(n),
-        limitedBy: _unbox(limit)
-      )
+    return _base.index(_unbox(i), offsetBy: n, limitedBy: _unbox(limit))
       .map { _IndexBox(_base: $0) }
   }
 
@@ -971,7 +961,7 @@ internal final class _BidirectionalCollectionBox<S: BidirectionalCollection>
     _ i: inout _AnyIndexBox, offsetBy n: Int
   ) {
     if let box = i as? _IndexBox<S.Index> {
-      return _base.formIndex(&box._base, offsetBy: numericCast(n))
+      return _base.formIndex(&box._base, offsetBy: n)
     }
     fatalError("Index type mismatch!")
   }
@@ -981,10 +971,7 @@ internal final class _BidirectionalCollectionBox<S: BidirectionalCollection>
     _ i: inout _AnyIndexBox, offsetBy n: Int, limitedBy limit: _AnyIndexBox
   ) -> Bool {
     if let box = i as? _IndexBox<S.Index> {
-      return _base.formIndex(
-        &box._base,
-        offsetBy: numericCast(n),
-        limitedBy: _unbox(limit))
+      return _base.formIndex(&box._base, offsetBy: n, limitedBy: _unbox(limit))
     }
     fatalError("Index type mismatch!")
   }
@@ -994,12 +981,12 @@ internal final class _BidirectionalCollectionBox<S: BidirectionalCollection>
     from start: _AnyIndexBox,
     to end: _AnyIndexBox
   ) -> Int {
-    return numericCast(_base.distance(from: _unbox(start), to: _unbox(end)))
+    return _base.distance(from: _unbox(start), to: _unbox(end))
   }
 
   @inlinable
   internal override var _count: Int {
-    return numericCast(_base.count)
+    return _base.count
   }
 
   @inlinable
@@ -1168,7 +1155,7 @@ internal final class _RandomAccessCollectionBox<S: RandomAccessCollection>
   internal override func _index(
     _ i: _AnyIndexBox, offsetBy n: Int
   ) -> _AnyIndexBox {
-    return _IndexBox(_base: _base.index(_unbox(i), offsetBy: numericCast(n)))
+    return _IndexBox(_base: _base.index(_unbox(i), offsetBy: n))
   }
 
   @inlinable
@@ -1177,11 +1164,7 @@ internal final class _RandomAccessCollectionBox<S: RandomAccessCollection>
     offsetBy n: Int,
     limitedBy limit: _AnyIndexBox
   ) -> _AnyIndexBox? {
-    return _base.index(
-        _unbox(i),
-        offsetBy: numericCast(n),
-        limitedBy: _unbox(limit)
-      )
+    return _base.index(_unbox(i), offsetBy: n, limitedBy: _unbox(limit))
       .map { _IndexBox(_base: $0) }
   }
 
@@ -1190,7 +1173,7 @@ internal final class _RandomAccessCollectionBox<S: RandomAccessCollection>
     _ i: inout _AnyIndexBox, offsetBy n: Int
   ) {
     if let box = i as? _IndexBox<S.Index> {
-      return _base.formIndex(&box._base, offsetBy: numericCast(n))
+      return _base.formIndex(&box._base, offsetBy: n)
     }
     fatalError("Index type mismatch!")
   }
@@ -1200,10 +1183,7 @@ internal final class _RandomAccessCollectionBox<S: RandomAccessCollection>
     _ i: inout _AnyIndexBox, offsetBy n: Int, limitedBy limit: _AnyIndexBox
   ) -> Bool {
     if let box = i as? _IndexBox<S.Index> {
-      return _base.formIndex(
-        &box._base,
-        offsetBy: numericCast(n),
-        limitedBy: _unbox(limit))
+      return _base.formIndex(&box._base, offsetBy: n, limitedBy: _unbox(limit))
     }
     fatalError("Index type mismatch!")
   }
@@ -1213,12 +1193,12 @@ internal final class _RandomAccessCollectionBox<S: RandomAccessCollection>
     from start: _AnyIndexBox,
     to end: _AnyIndexBox
   ) -> Int {
-    return numericCast(_base.distance(from: _unbox(start), to: _unbox(end)))
+    return _base.distance(from: _unbox(start), to: _unbox(end))
   }
 
   @inlinable
   internal override var _count: Int {
-    return numericCast(_base.count)
+    return _base.count
   }
 
   @inlinable

--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -231,7 +231,7 @@ extension LazyFilterCollection: Collection {
     // _base at least once, to trigger a _precondition in forward only
     // collections.
     _ensureBidirectional(step: step)
-    for _ in 0 ..< abs(numericCast(n)) {
+    for _ in 0 ..< abs(n) {
       _advanceIndex(&i, step: step)
     }
     return i
@@ -252,7 +252,7 @@ extension LazyFilterCollection: Collection {
     // invoked on the _base at least once, to trigger a _precondition in
     // forward only collections.
     _ensureBidirectional(step: step)
-    for _ in 0 ..< abs(numericCast(n)) {
+    for _ in 0 ..< abs(n) {
       if i == limit {
         return nil
       }

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -449,8 +449,7 @@ extension RangeReplaceableCollection {
   public mutating func append<S: Sequence>(contentsOf newElements: __owned S)
     where S.Element == Element {
 
-    let approximateCapacity = self.count +
-      numericCast(newElements.underestimatedCount)
+    let approximateCapacity = self.count + newElements.underestimatedCount
     self.reserveCapacity(approximateCapacity)
     for element in newElements {
       append(element)
@@ -800,7 +799,7 @@ extension RangeReplaceableCollection
 
   @inlinable
   public mutating func _customRemoveLast(_ n: Int) -> Bool {
-    self = self[startIndex..<index(endIndex, offsetBy: numericCast(-n))]
+    self = self[startIndex..<index(endIndex, offsetBy: -n)]
     return true
   }
 }
@@ -998,7 +997,7 @@ extension RangeReplaceableCollection {
   >(lhs: Other, rhs: Self) -> Self
   where Element == Other.Element {
     var result = Self()
-    result.reserveCapacity(rhs.count + numericCast(lhs.underestimatedCount))
+    result.reserveCapacity(rhs.count + lhs.underestimatedCount)
     result.append(contentsOf: lhs)
     result.append(contentsOf: rhs)
     return result

--- a/stdlib/public/core/Slice.swift
+++ b/stdlib/public/core/Slice.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -337,7 +337,7 @@ extension Slice: RangeReplaceableCollection
     let newSliceCount =
       _base.distance(from: _startIndex, to: subRange.lowerBound)
       + _base.distance(from: subRange.upperBound, to: _endIndex)
-      + (numericCast(newElements.count) as Int)
+      + newElements.count
     _base.replaceSubrange(subRange, with: newElements)
     _startIndex = _base.index(_base.startIndex, offsetBy: sliceOffset)
     _endIndex = _base.index(_startIndex, offsetBy: newSliceCount)
@@ -400,7 +400,7 @@ extension Slice
       let newSliceCount =
         _base.distance(from: _startIndex, to: subRange.lowerBound)
         + _base.distance(from: subRange.upperBound, to: _endIndex)
-        + (numericCast(newElements.count) as Int)
+        + newElements.count
       _base.replaceSubrange(subRange, with: newElements)
       _startIndex = _base.startIndex
       _endIndex = _base.index(_startIndex, offsetBy: newSliceCount)
@@ -409,7 +409,7 @@ extension Slice
       let lastValidIndex = _base.index(before: subRange.lowerBound)
       let newEndIndexOffset =
         _base.distance(from: subRange.upperBound, to: _endIndex)
-        + (numericCast(newElements.count) as Int) + 1
+        + newElements.count + 1
       _base.replaceSubrange(subRange, with: newElements)
       if shouldUpdateStartIndex {
         _startIndex = _base.index(after: lastValidIndex)
@@ -443,7 +443,7 @@ extension Slice
   where S: Collection, S.Element == Base.Element {
     // FIXME: swift-3-indexing-model: range check.
     if i == _base.startIndex {
-      let newSliceCount = count + numericCast(newElements.count)
+      let newSliceCount = count + newElements.count
       _base.insert(contentsOf: newElements, at: i)
       _startIndex = _base.startIndex
       _endIndex = _base.index(_startIndex, offsetBy: newSliceCount)
@@ -452,7 +452,7 @@ extension Slice
       let lastValidIndex = _base.index(before: i)
       let newEndIndexOffset =
         _base.distance(from: i, to: _endIndex)
-        + numericCast(newElements.count) + 1
+        + newElements.count + 1
       _base.insert(contentsOf: newElements, at: i)
       if shouldUpdateStartIndex {
         _startIndex = _base.index(after: lastValidIndex)

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -116,8 +116,7 @@ internal struct _SliceBuffer<Element>
   /// the given collection.
   ///
   /// - Precondition: This buffer is backed by a uniquely-referenced
-  ///   `_ContiguousArrayBuffer` and
-  ///   `insertCount <= numericCast(newValues.count)`.
+  ///   `_ContiguousArrayBuffer` and `insertCount <= newValues.count`.
   @inlinable
   internal mutating func replaceSubrange<C>(
     _ subrange: Range<Int>,
@@ -126,7 +125,7 @@ internal struct _SliceBuffer<Element>
   ) where C: Collection, C.Element == Element {
 
     _invariantCheck()
-    _internalInvariant(insertCount <= numericCast(newValues.count))
+    _internalInvariant(insertCount <= newValues.count)
 
     _internalInvariant(_hasNativeBuffer)
     _internalInvariant(isUniquelyReferenced())


### PR DESCRIPTION
Follow-up to: [SE-0191](https://github.com/apple/swift-evolution/blob/master/proposals/0191-eliminate-indexdistance.md)