### PR TITLE
[5.3][ConstraintSystem] Look through key path dynamic lookup nodes while s…

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3508,6 +3508,12 @@ void constraints::simplifyLocator(Expr *&anchor,
       continue;
     }
 
+    case ConstraintLocator::KeyPathDynamicMember: {
+      // Key path dynamic member lookup should be completely transparent.
+      path = path.slice(1);
+      continue;
+    }
+
     default:
       // FIXME: Lots of other cases to handle.
       break;

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1483,3 +1483,24 @@ func rdar62428353<T>(_ t: inout T) {
   let v = t // expected-note {{change 'let' to 'var' to make it mutable}} {{3-6=var}}
   rdar62428353(v) // expected-error {{cannot pass immutable value as inout argument: 'v' is a 'let' constant}}
 }
+
+func rdar62989214() {
+  struct Flag {
+    var isTrue: Bool
+  }
+
+  @propertyWrapper @dynamicMemberLookup
+  struct Wrapper<Value> {
+    var wrappedValue: Value
+
+    subscript<Subject>(
+      dynamicMember keyPath: WritableKeyPath<Value, Subject>
+    ) -> Wrapper<Subject> {
+      get { fatalError() }
+    }
+  }
+
+  func test(arr: Wrapper<[Flag]>, flag: Flag) {
+    arr[flag].isTrue // expected-error {{cannot convert value of type 'Flag' to expected argument type 'Int'}}
+  }
+}


### PR DESCRIPTION
…implifying locators

Cherry-pick of https://github.com/apple/swift/pull/31654

---

- Explanation: Key path dynamic member lookup should be completely transparent
for simplification purposes, it's just a means to get to the current
overload choice.

- Scope: Diagnostics related to key path dynamic member lookup

- Resolves: rdar://problem/62989214

- Risk: Very low

- Testing: Added a regression test

- Reviewer: @hborla 

Resolves: rdar://problem/62989214
(cherry picked from commit b99ccd38ad37099233d97d5a0c344ec2aadbc38f)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
