### PR TITLE
Correctly print an AbstractionPattern with C++ method types

### DIFF
--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -765,22 +765,13 @@ void AbstractionPattern::print(raw_ostream &out) const {
   case Kind::CurriedCFunctionAsMethodType:
   case Kind::PartialCurriedCFunctionAsMethodType:
   case Kind::CFunctionAsMethodType:
-  case Kind::CXXMethodType:
-  case Kind::CurriedCXXMethodType:
-  case Kind::PartialCurriedCXXMethodType:
     out << (getKind() == Kind::ClangType
               ? "AP::ClangType(" :
             getKind() == Kind::CurriedCFunctionAsMethodType
               ? "AP::CurriedCFunctionAsMethodType(" :
-            getKind() == Kind::CFunctionAsMethodType
-              ? "AP::CFunctionAsMethodType(" :
-            getKind() == Kind::CXXMethodType
-              ? "AP::CXXMethodType(" :
-            getKind() == Kind::CurriedCXXMethodType
-              ? "AP::CurriedCXXMethodType(" :
-            getKind() == Kind::PartialCurriedCXXMethodType
-              ? "AP::PartialCurriedCXXMethodType("
-              : "AP::PartialCurriedCFunctionAsMethodType(");
+            getKind() == Kind::PartialCurriedCFunctionAsMethodType
+              ? "AP::PartialCurriedCFunctionAsMethodType("
+              : "AP::CFunctionAsMethodType(");
     if (auto sig = getGenericSignature()) {
       sig->print(out);
     }
@@ -798,6 +789,23 @@ void AbstractionPattern::print(raw_ostream &out) const {
         out << "static";
       }
     }
+    out << ")";
+    return;
+  case Kind::CXXMethodType:
+  case Kind::CurriedCXXMethodType:
+  case Kind::PartialCurriedCXXMethodType:
+    out << (getKind() == Kind::CXXMethodType
+              ? "AP::CXXMethodType(" :
+            getKind() == Kind::CurriedCXXMethodType
+              ? "AP::CurriedCXXMethodType("
+              : "AP::PartialCurriedCXXMethodType");
+    if (auto sig = getGenericSignature()) {
+      sig->print(out);
+    }
+    getType().dump(out);
+    out << ", ";
+    getCXXMethod()->dump();
+    assert(!hasImportAsMemberStatus());
     out << ")";
     return;
   case Kind::CurriedObjCMethodType:


### PR DESCRIPTION
Printing an AbstractionPattern with a CXXMethodType would previously fail because the code would try to get a Clang type instead. I could add an if statement but instead, I split off the cases related to C++ method type into a new block, as that seems to follow the pattern in AbstractionPattern::print().
