### PR TITLE
Synthesize memberwise initializers despite member functions

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3349,7 +3349,7 @@ namespace {
         auto member = Impl.importDecl(nd, getActiveSwiftVersion());
         if (!member) {
           if (!isa<clang::TypeDecl>(nd) && !isa<clang::FunctionDecl>(nd)) {
-            // We don't know what this field is.
+            // We don't know what this member is.
             // Assume it may be important in C.
             hasUnreferenceableStorage = true;
             hasMemberwiseInitializer = false;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3348,7 +3348,7 @@ namespace {
 
         auto member = Impl.importDecl(nd, getActiveSwiftVersion());
         if (!member) {
-          if (!isa<clang::TypeDecl>(nd)) {
+          if (!isa<clang::TypeDecl>(nd) && !isa<clang::FunctionDecl>(nd)) {
             // We don't know what this field is.
             // Assume it may be important in C.
             hasUnreferenceableStorage = true;

--- a/test/Interop/Cxx/class/Inputs/memberwise-initializer.h
+++ b/test/Interop/Cxx/class/Inputs/memberwise-initializer.h
@@ -21,6 +21,11 @@ private:
   int varPrivate;
 };
 
+struct StructWithUnimportedMemberFunction {
+  int varPublic;
+  int StructWithUnimportedMemberFunction::* unimportedMemberFunction();
+};
+
 class ClassPrivateOnly {
   int varPrivate;
 };
@@ -39,6 +44,12 @@ class ClassPrivateAndPublic {
   int varPrivate;
 public:
   int varPublic;
+};
+
+struct ClassWithUnimportedMemberFunction {
+public:
+  int varPublic;
+  int ClassWithUnimportedMemberFunction::* unimportedMemberFunction();
 };
 
 #endif

--- a/test/Interop/Cxx/class/memberwise-initializer-module-interface.swift
+++ b/test/Interop/Cxx/class/memberwise-initializer-module-interface.swift
@@ -17,6 +17,11 @@
 // CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT:   init()
 // CHECK-NEXT: }
+// CHECK-NEXT: struct StructWithUnimportedMemberFunction {
+// CHECK-NEXT:   var varPublic: Int32
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   init(varPublic: Int32)
+// CHECK-NEXT: }
 // CHECK-NEXT: struct ClassPrivateOnly {
 // CHECK-NEXT:   init()
 // CHECK-NEXT: }
@@ -31,4 +36,9 @@
 // CHECK-NEXT: struct ClassPrivateAndPublic {
 // CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT:   init()
+// CHECK-NEXT: }
+// CHECK-NEXT: struct ClassWithUnimportedMemberFunction {
+// CHECK-NEXT:   var varPublic: Int32
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   init(varPublic: Int32)
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/memberwise-initializer-typechecker.swift
+++ b/test/Interop/Cxx/class/memberwise-initializer-typechecker.swift
@@ -7,9 +7,11 @@ let structPublicOnly = StructPublicOnly(varPublic: 42)
 let structEmptyPrivateSetion = StructEmptyPrivateSection(varPublic: 42)
 let structPublicAndPrivate1 = StructPublicAndPrivate(varPublic: 42)  // expected-error {{argument passed to call that takes no arguments}}
 let structPublicAndPrivate2 = StructPublicAndPrivate(varPublic: 42, varPrivate: 23)  // expected-error {{argument passed to call that takes no arguments}}
+let structWithUnimportedMemberFunction = StructWithUnimportedMemberFunction(varPublic: 42)
 
 let classPrivateOnly = ClassPrivateOnly(varPrivate: 42) // expected-error {{argument passed to call that takes no arguments}}
 let classPublicOnly = ClassPublicOnly(varPublic: 42)
 let classEmptyPublicSetion = ClassEmptyPublicSection(varPrivate: 42) // expected-error {{argument passed to call that takes no arguments}}
 let classPublicAndPrivate1 = ClassPrivateAndPublic(varPublic: 23)  // expected-error {{argument passed to call that takes no arguments}}
 let classPublicAndPrivate2 = ClassPrivateAndPublic(varPrivate: 42, varPublic: 23)  // expected-error {{argument passed to call that takes no arguments}}
+let classWithUnimportedMemberFunction = ClassWithUnimportedMemberFunction(varPublic: 42)


### PR DESCRIPTION
Previously unimportable member functions inhibited the synthesis of
memberwise initializers.

Resolves SR-12730.