### PR TITLE
Disable test on non-x86_64

### DIFF
--- a/test/SILOptimizer/optimize_keypath_objc.swift
+++ b/test/SILOptimizer/optimize_keypath_objc.swift
@@ -4,6 +4,9 @@
 
 // REQUIRES: objc_interop
 
+// This test currently fails iphonesimulator-i386.
+// REQUIRES: CPU=x86_64
+
 import Foundation
 
 class Foo: NSObject {


### PR DESCRIPTION
It currently fails on i386 simulator bots.

rdar://63019134