### PR TITLE
[5.3] Add fix on Keypath -> Function with multiple arguments type mismatch

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -585,6 +585,8 @@ ERROR(expr_keypath_root_type_mismatch, none,
       (Type, Type))
 ERROR(expr_swift_keypath_anyobject_root,none,
       "the root type of a Swift key path cannot be 'AnyObject'", ())
+ERROR(expr_keypath_multiparam_func_conversion, none,
+      "cannot convert key path into a multi-argument function type %0", (Type))
 WARNING(expr_deprecated_writable_keypath,none,
         "forming a writable keypath to property %0 that is read-only in this context "
         "is deprecated and will be removed in a future release",(DeclName))

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6266,3 +6266,10 @@ bool KeyPathRootTypeMismatchFailure::diagnoseAsError() {
                  rootType, baseType);
   return true;
 }
+
+bool MultiArgFuncKeyPathFailure::diagnoseAsError() {
+  // Diagnose use a keypath where a function with multiple arguments is expected
+  emitDiagnostic(diag::expr_keypath_multiparam_func_conversion,
+                 resolveType(functionType));
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2044,6 +2044,22 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose an attempt to use a KeyPath where a multi-argument function is expected
+///
+/// ```swift
+/// [Item].sorted(\Item.name)
+/// ```
+class MultiArgFuncKeyPathFailure final : public FailureDiagnostic {
+  Type functionType;
+public:
+  MultiArgFuncKeyPathFailure(const Solution &solution, Type functionType,
+                             ConstraintLocator *locator)
+  : FailureDiagnostic(solution, locator),
+  functionType(functionType) {}
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -722,6 +722,19 @@ AllowAnyObjectKeyPathRoot::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) AllowAnyObjectKeyPathRoot(cs, locator);
 }
 
+bool AllowMultiArgFuncKeyPathMismatch::diagnose(const Solution &solution,
+                                                bool asNote) const {
+  MultiArgFuncKeyPathFailure failure(solution, functionType, getLocator());
+  return failure.diagnose(asNote);
+}
+
+AllowMultiArgFuncKeyPathMismatch *
+AllowMultiArgFuncKeyPathMismatch::create(ConstraintSystem &cs, Type fnType,
+                                         ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+  AllowMultiArgFuncKeyPathMismatch(cs, fnType, locator);
+}
+
 bool TreatKeyPathSubscriptIndexAsHashable::diagnose(const Solution &solution,
                                                     bool asNote) const {
   KeyPathSubscriptIndexHashableFailure failure(solution, NonConformingType,

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -255,6 +255,9 @@ enum class FixKind : uint8_t {
   /// Allow key path root type mismatch when applying a key path that has a
   /// root type not convertible to the type of the base instance.
   AllowKeyPathRootTypeMismatch,
+
+  /// Allow key path to be bound to a function type with more than 1 argument
+  AllowMultiArgFuncKeyPathMismatch
 };
 
 class ConstraintFix {
@@ -1262,6 +1265,26 @@ public:
 
   static AllowAnyObjectKeyPathRoot *create(ConstraintSystem &cs,
                                            ConstraintLocator *locator);
+};
+
+class AllowMultiArgFuncKeyPathMismatch final : public ConstraintFix {
+  Type functionType;
+
+  AllowMultiArgFuncKeyPathMismatch(ConstraintSystem &cs, Type fnType,
+                                   ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::AllowMultiArgFuncKeyPathMismatch, locator),
+        functionType(fnType) {}
+
+public:
+  std::string getName() const override {
+    return "allow conversion of a keypath type to a multi-argument function";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  static AllowMultiArgFuncKeyPathMismatch *create(ConstraintSystem &cs,
+                                                  Type fnType,
+                                                  ConstraintLocator *locator);
 };
 
 class TreatKeyPathSubscriptIndexAsHashable final : public ConstraintFix {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "CSFix.h"
+#include "CSDiagnostics.h"
 #include "ConstraintSystem.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericEnvironment.h"
@@ -7615,10 +7616,10 @@ ConstraintSystem::simplifyKeyPathConstraint(
   auto subflags = getDefaultDecompositionOptions(flags);
   // The constraint ought to have been anchored on a KeyPathExpr.
   auto keyPath = cast<KeyPathExpr>(locator.getBaseLocator()->getAnchor());
-
   keyPathTy = getFixedTypeRecursive(keyPathTy, /*want rvalue*/ true);
   bool definitelyFunctionType = false;
   bool definitelyKeyPathType = false;
+  bool resolveAsMultiArgFuncFix = false;
 
   auto tryMatchRootAndValueFromType = [&](Type type,
                                           bool allowPartial = true) -> bool {
@@ -7643,10 +7644,18 @@ ConstraintSystem::simplifyKeyPathConstraint(
     }
 
     if (auto fnTy = type->getAs<FunctionType>()) {
-      definitelyFunctionType = true;
+      if (fnTy->getParams().size() != 1) {
+        if (!shouldAttemptFixes())
+          return false;
 
-      if (fnTy->getParams().size() != 1)
-        return false;
+        resolveAsMultiArgFuncFix = true;
+        auto *fix = AllowMultiArgFuncKeyPathMismatch::create(
+            *this, fnTy, locator.getBaseLocator());
+        // Pretend the keypath type got resolved and move on.
+        return !recordFix(fix);
+      }
+
+      definitelyFunctionType = true;
 
       // Match up the root and value types to the function's param and return
       // types. Note that we're using the type of the parameter as referenced
@@ -7680,6 +7689,10 @@ ConstraintSystem::simplifyKeyPathConstraint(
     if (!tryMatchRootAndValueFromType(contextualTy))
       return SolutionKind::Error;
   }
+
+  // If we fix this keypath as `AllowMultiArgFuncKeyPathMismatch`, just proceed
+  if (resolveAsMultiArgFuncFix)
+    return SolutionKind::Solved;
 
   // See if we resolved overloads for all the components involved.
   enum {
@@ -7845,7 +7858,7 @@ ConstraintSystem::simplifyKeyPathConstraint(
   } else if (!anyComponentsUnresolved ||
              (definitelyKeyPathType && capability == ReadOnly)) {
     auto resolvedKPTy =
-        BoundGenericType::get(kpDecl, nullptr, {rootTy, valueTy});
+      BoundGenericType::get(kpDecl, nullptr, {rootTy, valueTy});
     return matchTypes(keyPathTy, resolvedKPTy, ConstraintKind::Bind, subflags,
                       loc);
   } else {
@@ -9562,6 +9575,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowClosureParameterDestructuring:
   case FixKind::AllowInaccessibleMember:
   case FixKind::AllowAnyObjectKeyPathRoot:
+  case FixKind::AllowMultiArgFuncKeyPathMismatch:
   case FixKind::TreatKeyPathSubscriptIndexAsHashable:
   case FixKind::AllowInvalidRefInKeyPath:
   case FixKind::DefaultGenericArgument:

--- a/test/Constraints/keypath_closure_conv_mismatch.swift
+++ b/test/Constraints/keypath_closure_conv_mismatch.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %s
+
+// rdar://problem/57930643
+struct School {
+  var name: String
+}
+func testKeyPathClosureLiteralError() -> [School] {
+  let slist = [School(name:"AHS"), School(name:"BHS")]
+  return slist.sorted(by: \School.name) // expected-error {{cannot convert key path into a multi-argument function type '(School, School) throws -> Bool'}}
+}

--- a/test/Constraints/keypath_closure_conv_mismatch_generic.swift
+++ b/test/Constraints/keypath_closure_conv_mismatch_generic.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %s
+
+// rdar://problem/57930643
+struct School {
+  var name: String
+}
+func test<A, B>(_: (A, B) -> Bool) {} // expected-note {{in call to function 'test'}}
+test(\School.name) // expected-error {{generic parameter 'A' could not be inferred}} // expected-error {{generic parameter 'B' could not be inferred}} // expected-error {{cannot convert key path into a multi-argument function type '(A, B) -> Bool'}}
+

--- a/test/Constraints/keypath_closure_conv_mismatch_norettype.swift
+++ b/test/Constraints/keypath_closure_conv_mismatch_norettype.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %s
+
+// rdar://problem/57930643
+struct School {
+  var name: String
+}
+func testKeyPathClosureLiteralError() {
+  let slist = [School(name:"AHS"), School(name:"BHS")]
+  _ = slist.sorted(by: \School.name) // expected-error {{cannot convert key path into a multi-argument function type '(School, School) throws -> Bool'}}
+}


### PR DESCRIPTION
Cherry-pick #31563, originally reviewed by @xedin.

When simplifying a keypath constraint with a function type binding, single-parameter functions have the parameter type and the return type matched against the keypath root and value; whereas multiple-parameter functions cause an ambiguous failure (in `simplifyKeyPathConstraint`).

Resolves rdar://problem/57930643
