### PR TITLE
[5.3] Allow SPI access within the same module in checkAccess

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3500,7 +3500,10 @@ static bool checkAccess(const DeclContext *useDC, const ValueDecl *VD,
   case AccessLevel::Public:
   case AccessLevel::Open: {
     if (useDC && VD->isSPI()) {
-      auto *useSF = dyn_cast<SourceFile>(useDC->getModuleScopeContext());
+      auto useModuleScopeContext = useDC->getModuleScopeContext();
+      if (useModuleScopeContext == sourceDC->getModuleScopeContext()) return true;
+
+      auto *useSF = dyn_cast<SourceFile>(useModuleScopeContext);
       return !useSF || useSF->isImportedAsSPI(VD);
     }
     return true;

--- a/test/SPI/equatable_and_conformances.swift
+++ b/test/SPI/equatable_and_conformances.swift
@@ -1,0 +1,37 @@
+// Test how SPI affects access control in protocol conformance lookup.
+
+// RUN: %target-build-swift %s -swift-version 5
+
+// rdar://61043406
+
+@_spi(Private)
+public struct SPIEquatable : Equatable {
+  public static func ==(lhs: SPIEquatable, rhs: SPIEquatable) -> Bool {
+    return true
+  }
+}
+
+// rdar://61987739
+
+@_spi(Private)
+public struct SPIStruct {}
+
+public protocol PublicProto {
+  func thingOne()
+
+  @_spi(Private)
+  func thingTwo(_ data: SPIStruct)
+}
+
+extension PublicProto {
+  @_spi(Private)
+  public func thingTwo(_ data: SPIStruct) {
+    // default implementation
+  }
+}
+
+fileprivate struct FilePrivateStruct: PublicProto {
+  func thingOne() {
+    // OK
+  }
+}


### PR DESCRIPTION
Cherry-pick of #31591.

---

* Explanation:
    SPI decls were not considered to be accessible from the same module when searched with `checkAccess`. This affected the search for protocol conformances leading the compiler to complain wrongly about conformances or to synthesize `==` for an SPI type when there was already an implementation. The later caused an assert in SILGen.
* Scope: This code path affects only the users of the `@_spi` attribute.
* Risk: Low
* Testing: Added a new test with reducers of the two failures we observed.
* Resolves rdar://61043406&61987739
* Reviewed by @brentdax 