### PR TITLE
[Proof of concept] Support the use of optional labels for the first trailing closure

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -544,8 +544,8 @@ public:
 
   /// Given that this is a packed argument expression of the sort that
   /// would be produced from packSingleArgument, return the index of the
-  /// unlabeled trailing closure, if there is one.
-  Optional<unsigned> getUnlabeledTrailingClosureIndexOfPackedArgument() const;
+  /// first trailing closure, if there is one.
+  Optional<unsigned> getFirstTrailingClosureIndexOfPackedArgument() const;
 
   /// Produce a mapping from each subexpression to its parent
   /// expression, with the provided expression serving as the root of
@@ -1234,9 +1234,9 @@ public:
     return Bits.ObjectLiteralExpr.HasTrailingClosure;
   }
 
-  /// Return the index of the unlabeled trailing closure argument.
-  Optional<unsigned> getUnlabeledTrailingClosureIndex() const {
-    return getArg()->getUnlabeledTrailingClosureIndexOfPackedArgument();
+  /// Return the index of the first trailing closure argument.
+  Optional<unsigned> getFirstTrailingClosureIndex() const {
+    return getArg()->getFirstTrailingClosureIndexOfPackedArgument();
   }
 
   SourceLoc getSourceLoc() const { return PoundLoc; }
@@ -1825,9 +1825,9 @@ public:
     return Bits.DynamicSubscriptExpr.HasTrailingClosure;
   }
 
-  /// Return the index of the unlabeled trailing closure argument.
-  Optional<unsigned> getUnlabeledTrailingClosureIndex() const {
-    return Index->getUnlabeledTrailingClosureIndexOfPackedArgument();
+  /// Return the index of the first trailing closure argument.
+  Optional<unsigned> getFirstTrailingClosureIndex() const {
+    return Index->getFirstTrailingClosureIndexOfPackedArgument();
   }
 
   SourceLoc getLoc() const { return Index->getStartLoc(); }
@@ -1899,9 +1899,9 @@ public:
     return Bits.UnresolvedMemberExpr.HasTrailingClosure;
   }
 
-  /// Return the index of the unlabeled trailing closure argument.
-  Optional<unsigned> getUnlabeledTrailingClosureIndex() const {
-    return getArgument()->getUnlabeledTrailingClosureIndexOfPackedArgument();
+  /// Return the index of the first trailing closure argument.
+  Optional<unsigned> getFirstTrailingClosureIndex() const {
+    return getArgument()->getFirstTrailingClosureIndexOfPackedArgument();
   }
 
   SourceLoc getLoc() const { return NameLoc.getBaseNameLoc(); }
@@ -2086,7 +2086,7 @@ public:
   bool hasTrailingClosure() const { return Bits.ParenExpr.HasTrailingClosure; }
 
   Optional<unsigned>
-  getUnlabeledTrailingClosureIndexOfPackedArgument() const {
+  getFirstTrailingClosureIndexOfPackedArgument() const {
     return hasTrailingClosure() ? Optional<unsigned>(0) : None;
   }
 
@@ -2185,7 +2185,7 @@ public:
   }
 
   Optional<unsigned>
-  getUnlabeledTrailingClosureIndexOfPackedArgument() const {
+  getFirstTrailingClosureIndexOfPackedArgument() const {
     return FirstTrailingArgumentAt;
   }
 
@@ -2474,9 +2474,9 @@ public:
     return Bits.SubscriptExpr.HasTrailingClosure;
   }
 
-  /// Return the index of the unlabeled trailing closure argument.
-  Optional<unsigned> getUnlabeledTrailingClosureIndex() const {
-    return getIndex()->getUnlabeledTrailingClosureIndexOfPackedArgument();
+  /// Return the index of the first trailing closure argument.
+  Optional<unsigned> getFirstTrailingClosureIndex() const {
+    return getIndex()->getFirstTrailingClosureIndexOfPackedArgument();
   }
 
   /// Determine whether this subscript reference should bypass the
@@ -4324,8 +4324,8 @@ public:
   /// Whether this application was written using a trailing closure.
   bool hasTrailingClosure() const;
 
-  /// Return the index of the unlabeled trailing closure argument.
-  Optional<unsigned> getUnlabeledTrailingClosureIndex() const;
+  /// Return the index of the first trailing closure argument.
+  Optional<unsigned> getFirstTrailingClosureIndex() const;
 
   static bool classof(const Expr *E) {
     return E->getKind() >= ExprKind::First_ApplyExpr &&
@@ -4413,9 +4413,9 @@ public:
   /// Whether this call with written with a single trailing closure.
   bool hasTrailingClosure() const { return Bits.CallExpr.HasTrailingClosure; }
 
-  /// Return the index of the unlabeled trailing closure argument.
-  Optional<unsigned> getUnlabeledTrailingClosureIndex() const {
-    return getArg()->getUnlabeledTrailingClosureIndexOfPackedArgument();
+  /// Return the index of the first trailing closure argument.
+  Optional<unsigned> getFirstTrailingClosureIndex() const {
+    return getArg()->getFirstTrailingClosureIndexOfPackedArgument();
   }
 
   using TrailingCallArguments::getArgumentLabels;

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1069,24 +1069,24 @@ Expr *swift::packSingleArgument(ASTContext &ctx, SourceLoc lParenLoc,
     argLabelLocs = argLabelLocsScratch;
   }
 
-  Optional<unsigned> unlabeledTrailingClosureIndex;
-  if (!trailingClosures.empty() && trailingClosures[0].Label.empty())
-    unlabeledTrailingClosureIndex = args.size() - trailingClosures.size();
+  Optional<unsigned> firstTrailingClosureIndex;
+  if (!trailingClosures.empty())
+    firstTrailingClosureIndex = args.size() - trailingClosures.size();
 
   auto arg = TupleExpr::create(ctx, lParenLoc, rParenLoc, args, argLabels,
                                argLabelLocs,
-                               unlabeledTrailingClosureIndex,
+                               firstTrailingClosureIndex,
                                /*Implicit=*/false);
   computeSingleArgumentType(ctx, arg, implicit, getType);
   return arg;
 }
 
 Optional<unsigned>
-Expr::getUnlabeledTrailingClosureIndexOfPackedArgument() const {
+Expr::getFirstTrailingClosureIndexOfPackedArgument() const {
   if (auto PE = dyn_cast<ParenExpr>(this))
-    return PE->getUnlabeledTrailingClosureIndexOfPackedArgument();
+    return PE->getFirstTrailingClosureIndexOfPackedArgument();
   if (auto TE = dyn_cast<TupleExpr>(this))
-    return TE->getUnlabeledTrailingClosureIndexOfPackedArgument();
+    return TE->getFirstTrailingClosureIndexOfPackedArgument();
   return None;
 }
 
@@ -1675,9 +1675,9 @@ bool ApplyExpr::hasTrailingClosure() const {
   return false;
 }
 
-Optional<unsigned> ApplyExpr::getUnlabeledTrailingClosureIndex() const {
+Optional<unsigned> ApplyExpr::getFirstTrailingClosureIndex() const {
   if (auto call = dyn_cast<CallExpr>(this))
-    return call->getUnlabeledTrailingClosureIndex();
+    return call->getFirstTrailingClosureIndex();
 
   return None;
 }
@@ -1731,7 +1731,7 @@ CallExpr *CallExpr::create(ASTContext &ctx, Expr *fn, SourceLoc lParenLoc,
   SmallVector<Identifier, 4> argLabelsScratch;
   SmallVector<SourceLoc, 4> argLabelLocsScratch;
   Expr *arg = packSingleArgument(ctx, lParenLoc, args, argLabels, argLabelLocs,
-                                 rParenLoc,  trailingClosures, implicit,
+                                 rParenLoc, trailingClosures, implicit,
                                  argLabelsScratch, argLabelLocsScratch,
                                  getType);
 

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -887,7 +887,7 @@ std::vector<CallArgInfo> swift::ide::
 getCallArgInfo(SourceManager &SM, Expr *Arg, LabelRangeEndAt EndKind) {
   std::vector<CallArgInfo> InfoVec;
   if (auto *TE = dyn_cast<TupleExpr>(Arg)) {
-    auto FirstTrailing = TE->getUnlabeledTrailingClosureIndexOfPackedArgument();
+    auto FirstTrailing = TE->getFirstTrailingClosureIndexOfPackedArgument();
     for (size_t ElemIndex: range(TE->getNumElements())) {
       Expr *Elem = TE->getElement(ElemIndex);
       if (isa<DefaultArgumentExpr>(Elem))

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5515,7 +5515,7 @@ Expr *ExprRewriter::coerceCallArguments(Expr *arg, AnyFunctionType *funcType,
   SmallVector<ParamBinding, 4> parameterBindings;
   bool failed = constraints::matchCallArguments(args, params,
                                                 paramInfo,
-                       arg->getUnlabeledTrailingClosureIndexOfPackedArgument(),
+                           arg->getFirstTrailingClosureIndexOfPackedArgument(),
                                                 /*allowFixes=*/false, listener,
                                                 parameterBindings);
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -994,7 +994,7 @@ namespace {
     Type addSubscriptConstraints(
         Expr *anchor, Type baseTy, Expr *index,
         ValueDecl *declOrNull, ArrayRef<Identifier> argLabels,
-        Optional<unsigned> unlabeledTrailingClosure,
+        Optional<unsigned> firstTrailingClosure,
         ConstraintLocator *locator = nullptr,
         SmallVectorImpl<TypeVariableType *> *addedTypeVars = nullptr) {
       // Locators used in this expression.
@@ -1012,7 +1012,7 @@ namespace {
                                 ConstraintLocator::FunctionResult);
 
       associateArgumentLabels(memberLocator,
-                              {argLabels, unlabeledTrailingClosure});
+                              {argLabels, firstTrailingClosure});
 
       Type outputTy;
 
@@ -1306,7 +1306,7 @@ namespace {
       auto *exprLoc = CS.getConstraintLocator(expr);
       associateArgumentLabels(
           exprLoc, {expr->getArgumentLabels(),
-                    expr->getUnlabeledTrailingClosureIndex()});
+                    expr->getFirstTrailingClosureIndex()});
 
       // If the expression has already been assigned a type; just use that type.
       if (expr->getType())
@@ -1591,7 +1591,7 @@ namespace {
         associateArgumentLabels(
             CS.getConstraintLocator(expr),
             {expr->getArgumentLabels(),
-             expr->getUnlabeledTrailingClosureIndex()});
+             expr->getFirstTrailingClosureIndex()});
         return baseTy;
       }
 
@@ -1833,7 +1833,7 @@ namespace {
       return addSubscriptConstraints(expr, CS.getType(base),
                                      expr->getIndex(),
                                      decl, expr->getArgumentLabels(),
-                                     expr->getUnlabeledTrailingClosureIndex());
+                                     expr->getFirstTrailingClosureIndex());
     }
     
     Type visitArrayExpr(ArrayExpr *expr) {
@@ -2125,7 +2125,7 @@ namespace {
       return addSubscriptConstraints(expr, CS.getType(expr->getBase()),
                                      expr->getIndex(), /*decl*/ nullptr,
                                      expr->getArgumentLabels(),
-                                     expr->getUnlabeledTrailingClosureIndex());
+                                     expr->getFirstTrailingClosureIndex());
     }
 
     Type visitTupleElementExpr(TupleElementExpr *expr) {
@@ -2909,7 +2909,7 @@ namespace {
       associateArgumentLabels(
           CS.getConstraintLocator(expr),
           {expr->getArgumentLabels(scratch),
-           expr->getUnlabeledTrailingClosureIndex()},
+           expr->getFirstTrailingClosureIndex()},
           /*labelsArePermanent=*/isa<CallExpr>(expr));
 
       if (auto *UDE = dyn_cast<UnresolvedDotExpr>(fnExpr)) {
@@ -3458,12 +3458,12 @@ namespace {
         // re-type-check the constraints during failure diagnosis.
         case KeyPathExpr::Component::Kind::Subscript: {
           auto index = component.getIndexExpr();
-          auto unlabeledTrailingClosureIndex =
-            index->getUnlabeledTrailingClosureIndexOfPackedArgument();
+          auto firstTrailingClosureIndex =
+            index->getFirstTrailingClosureIndexOfPackedArgument();
           base = addSubscriptConstraints(E, base, index,
                                          /*decl*/ nullptr,
                                          component.getSubscriptLabels(),
-                                         unlabeledTrailingClosureIndex,
+                                         firstTrailingClosureIndex,
                                          memberLocator,
                                          &componentTypeVars);
           break;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2183,7 +2183,7 @@ public:
 
   struct ArgumentInfo {
     ArrayRef<Identifier> Labels;
-    Optional<unsigned> UnlabeledTrailingClosureIndex;
+    Optional<unsigned> FirstTrailingClosureIndex;
   };
 
   /// A mapping from the constraint locators for references to various
@@ -4900,7 +4900,7 @@ public:
 /// \param args The arguments.
 /// \param params The parameters.
 /// \param paramInfo Declaration-level information about the parameters.
-/// \param unlabeledTrailingClosureIndex The index of an unlabeled trailing closure,
+/// \param firstTrailingClosureIndex The index of the first trailing closure,
 ///   if any.
 /// \param allowFixes Whether to allow fixes when matching arguments.
 ///
@@ -4913,7 +4913,7 @@ public:
 bool matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
                         ArrayRef<AnyFunctionType::Param> params,
                         const ParameterListInfo &paramInfo,
-                        Optional<unsigned> unlabeledTrailingClosureIndex,
+                        Optional<unsigned> firstTrailingClosureIndex,
                         bool allowFixes,
                         MatchCallArgumentListener &listener,
                         SmallVectorImpl<ParamBinding> &parameterBindings);

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -394,7 +394,7 @@ EXPR_NODES = [
              Child('Pattern', kind='Pattern'),
          ]),
 
-    # trailing-closure-element -> identifier ':' closure-expression
+    # trailing-closure-element -> identifier ':' closure-expr
     Node('MultipleTrailingClosureElement', kind='Syntax',
          children=[
              Child('Label', kind='Token',
@@ -409,8 +409,9 @@ EXPR_NODES = [
     Node('MultipleTrailingClosureElementList', kind='SyntaxCollection',
          element='MultipleTrailingClosureElement'),
 
-    # call-expr -> expr '(' call-argument-list ')' closure-expr?
-    #            | expr closure-expr
+    # call-expr -> expr '(' call-argument-list ')' closure-expr? multiple-trailing-closure-element-list
+    #            | expr closure-expr multiple-trailing-closure-element-list
+    #            | expr trailing-closure-element multiple-trailing-closure-element-list
     Node('FunctionCallExpr', kind='Expr',
          children=[
              Child('CalledExpression', kind='Expr'),
@@ -424,11 +425,11 @@ EXPR_NODES = [
                    is_optional=True),
              Child('AdditionalTrailingClosures',
                    kind='MultipleTrailingClosureElementList',
-                   collection_element_name='AdditionalTralingClosure',
+                   collection_element_name='AdditionalTrailingClosure',
                    is_optional=True),
          ]),
 
-    # subscript-expr -> expr '[' call-argument-list ']' closure-expr?
+    # subscript-expr -> expr '[' call-argument-list ']' closure-expr? multiple-trailing-closure-element-list
     Node('SubscriptExpr', kind='Expr',
          children=[
              Child('CalledExpression', kind='Expr'),
@@ -440,7 +441,7 @@ EXPR_NODES = [
                    is_optional=True),
              Child('AdditionalTrailingClosures',
                    kind='MultipleTrailingClosureElementList',
-                   collection_element_name='AdditionalTralingClosure',
+                   collection_element_name='AdditionalTrailingClosure',
                    is_optional=True),
          ]),
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Most of the changes are minor refactorings that could benefit the codebase regardless of the feature in question being implemented (such as typo corrections, minor renamings for clarity); I will extract those out for actual review.

Missing are any diagnostics improvements, IDE integration, or even tests. This PR is not intended for merging as-is. However, it does build, and the resultant compiler will accept the following:

```swift
if let x = [1, 2, 3].first where: { $0 > 2 } {
  print(x)
}
```

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
