### PR TITLE
[AutoDiff] NFC: gardening.

### DIFF
--- a/include/swift/SILOptimizer/Differentiation/Common.h
+++ b/include/swift/SILOptimizer/Differentiation/Common.h
@@ -211,19 +211,16 @@ inline void createEntryArguments(SILFunction *f) {
     decl->setSpecifier(ParamDecl::Specifier::Default);
     entry->createFunctionArgument(type, decl);
   };
-  // f->getLoweredFunctionType()->remap
   for (auto indResTy :
        conv.getIndirectSILResultTypes(f->getTypeExpansionContext())) {
     if (indResTy.hasArchetype())
       indResTy = indResTy.mapTypeOutOfContext();
     createFunctionArgument(f->mapTypeIntoContext(indResTy).getAddressType());
-    // createFunctionArgument(indResTy.getAddressType());
   }
   for (auto paramTy : conv.getParameterSILTypes(f->getTypeExpansionContext())) {
     if (paramTy.hasArchetype())
       paramTy = paramTy.mapTypeOutOfContext();
     createFunctionArgument(f->mapTypeIntoContext(paramTy));
-    // createFunctionArgument(paramTy);
   }
 }
 

--- a/include/swift/SILOptimizer/Differentiation/PullbackEmitter.h
+++ b/include/swift/SILOptimizer/Differentiation/PullbackEmitter.h
@@ -18,10 +18,10 @@
 #ifndef SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_PULLBACKEMITTER_H
 #define SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_PULLBACKEMITTER_H
 
+#include "swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h"
 #include "swift/SILOptimizer/Differentiation/AdjointValue.h"
 #include "swift/SILOptimizer/Differentiation/DifferentiationInvoker.h"
 #include "swift/SILOptimizer/Differentiation/LinearMapInfo.h"
-#include "swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h"
 
 #include "swift/SIL/TypeSubstCloner.h"
 #include "llvm/ADT/DenseMap.h"

--- a/include/swift/SILOptimizer/Differentiation/VJPEmitter.h
+++ b/include/swift/SILOptimizer/Differentiation/VJPEmitter.h
@@ -18,9 +18,9 @@
 #ifndef SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_VJPEMITTER_H
 #define SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_VJPEMITTER_H
 
+#include "swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h"
 #include "swift/SILOptimizer/Differentiation/DifferentiationInvoker.h"
 #include "swift/SILOptimizer/Differentiation/LinearMapInfo.h"
-#include "swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h"
 
 #include "swift/SIL/TypeSubstCloner.h"
 #include "llvm/ADT/DenseMap.h"

--- a/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
+++ b/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
@@ -126,8 +126,8 @@ LinearMapInfo::createBranchingTraceDecl(SILBasicBlock *originalBB,
   auto originalFnTy = original->getLoweredFunctionType();
   auto numResults = originalFnTy->getNumResults() +
                     originalFnTy->getNumIndirectMutatingParameters();
-  auto *resultIndices = IndexSubset::get(
-      original->getASTContext(), numResults, indices.source);
+  auto *resultIndices =
+      IndexSubset::get(original->getASTContext(), numResults, indices.source);
   auto *parameterIndices = indices.parameters;
   AutoDiffConfig config(parameterIndices, resultIndices, genericSig);
   auto enumName = mangler.mangleAutoDiffGeneratedDeclaration(
@@ -199,8 +199,8 @@ LinearMapInfo::createLinearMapStruct(SILBasicBlock *originalBB,
   auto originalFnTy = original->getLoweredFunctionType();
   auto numResults = originalFnTy->getNumResults() +
                     originalFnTy->getNumIndirectMutatingParameters();
-  auto *resultIndices = IndexSubset::get(
-      original->getASTContext(), numResults, indices.source);
+  auto *resultIndices =
+      IndexSubset::get(original->getASTContext(), numResults, indices.source);
   auto *parameterIndices = indices.parameters;
   AutoDiffConfig config(parameterIndices, resultIndices, genericSig);
   auto structName = mangler.mangleAutoDiffGeneratedDeclaration(

--- a/lib/SILOptimizer/Differentiation/PullbackEmitter.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackEmitter.cpp
@@ -151,8 +151,8 @@ void PullbackEmitter::cleanUpTemporariesForBlock(SILBasicBlock *bb,
 const Lowering::TypeLowering &PullbackEmitter::getTypeLowering(Type type) {
   auto pbGenSig =
       getPullback().getLoweredFunctionType()->getSubstGenericSignature();
-  Lowering::AbstractionPattern pattern(
-      pbGenSig, type->getCanonicalType(pbGenSig));
+  Lowering::AbstractionPattern pattern(pbGenSig,
+                                       type->getCanonicalType(pbGenSig));
   return getPullback().getTypeLowering(pattern, type);
 }
 
@@ -2083,8 +2083,8 @@ void PullbackEmitter::accumulateIndirect(SILValue lhsDestAccess,
   auto type = lhsDestAccess->getType();
   auto astType = type.getASTType();
   auto *swiftMod = getModule().getSwiftModule();
-  auto tangentSpace = astType->getAutoDiffTangentSpace(
-      LookUpConformanceInModule(swiftMod));
+  auto tangentSpace =
+      astType->getAutoDiffTangentSpace(LookUpConformanceInModule(swiftMod));
   assert(tangentSpace && "No tangent space for this type");
   switch (tangentSpace->getKind()) {
   case TangentSpace::Kind::TangentVector: {

--- a/lib/SILOptimizer/Differentiation/VJPEmitter.cpp
+++ b/lib/SILOptimizer/Differentiation/VJPEmitter.cpp
@@ -174,7 +174,8 @@ SILFunction *VJPEmitter::createEmptyPullback() {
     SILParameterInfo inoutParamTanParam(
         origResult.getInterfaceType()
             ->getAutoDiffTangentSpace(lookupConformance)
-            ->getType()->getCanonicalType(witnessCanGenSig),
+            ->getType()
+            ->getCanonicalType(witnessCanGenSig),
         inoutParamTanConvention);
     pbParams.push_back(inoutParamTanParam);
   } else {
@@ -184,7 +185,8 @@ SILFunction *VJPEmitter::createEmptyPullback() {
     pbParams.push_back(getTangentParameterInfoForOriginalResult(
         origResult.getInterfaceType()
             ->getAutoDiffTangentSpace(lookupConformance)
-            ->getType()->getCanonicalType(witnessCanGenSig),
+            ->getType()
+            ->getCanonicalType(witnessCanGenSig),
         origResult.getConvention()));
   }
 
@@ -192,7 +194,8 @@ SILFunction *VJPEmitter::createEmptyPullback() {
   // returned pullback's closure context.
   auto *origExit = &*original->findReturnBB();
   auto *pbStruct = pullbackInfo.getLinearMapStruct(origExit);
-  auto pbStructType = pbStruct->getDeclaredInterfaceType()->getCanonicalType(witnessCanGenSig);
+  auto pbStructType =
+      pbStruct->getDeclaredInterfaceType()->getCanonicalType(witnessCanGenSig);
   pbParams.push_back({pbStructType, ParameterConvention::Direct_Owned});
 
   // Add pullback results for the requested wrt parameters.
@@ -205,7 +208,8 @@ SILFunction *VJPEmitter::createEmptyPullback() {
     adjResults.push_back(getTangentResultInfoForOriginalParameter(
         origParam.getInterfaceType()
             ->getAutoDiffTangentSpace(lookupConformance)
-            ->getType()->getCanonicalType(witnessCanGenSig),
+            ->getType()
+            ->getCanonicalType(witnessCanGenSig),
         origParam.getConvention()));
   }
 
@@ -275,8 +279,8 @@ void VJPEmitter::visitSILInstruction(SILInstruction *inst) {
 
 SILType VJPEmitter::getLoweredType(Type type) {
   auto vjpGenSig = vjp->getLoweredFunctionType()->getSubstGenericSignature();
-  Lowering::AbstractionPattern pattern(
-      vjpGenSig, type->getCanonicalType(vjpGenSig));
+  Lowering::AbstractionPattern pattern(vjpGenSig,
+                                       type->getCanonicalType(vjpGenSig));
   return vjp->getLoweredType(pattern, type);
 }
 
@@ -490,9 +494,8 @@ void VJPEmitter::visitSwitchEnumInstBase(SwitchEnumInstBase *sei) {
                                   newDefaultBB, caseBBs);
     break;
   case SILInstructionKind::SwitchEnumAddrInst:
-    getBuilder().createSwitchEnumAddr(sei->getLoc(),
-                                      getOpValue(sei->getOperand()),
-                                      newDefaultBB, caseBBs);
+    getBuilder().createSwitchEnumAddr(
+        sei->getLoc(), getOpValue(sei->getOperand()), newDefaultBB, caseBBs);
     break;
   default:
     llvm_unreachable("Expected `switch_enum` or `switch_enum_addr`");


### PR DESCRIPTION
Run `clang-format` on all differentiation SILOptimizer files.
Remove dead commented code.