### PR TITLE
[AutoDiff] Fix derivative function configurations for accessors.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7111,10 +7111,19 @@ void AbstractFunctionDecl::prepareDerivativeFunctionConfigurations() {
 ArrayRef<AutoDiffConfig>
 AbstractFunctionDecl::getDerivativeFunctionConfigurations() {
   prepareDerivativeFunctionConfigurations();
+
   // Resolve derivative function configurations from `@differentiable`
   // attributes by type-checking them.
   for (auto *diffAttr : getAttrs().getAttributes<DifferentiableAttr>())
     (void)diffAttr->getParameterIndices();
+  // For accessors: resolve derivative function configurations from storage
+  // `@differentiable` attributes by type-checking them.
+  if (auto *accessor = dyn_cast<AccessorDecl>(this)) {
+    auto *storage = accessor->getStorage();
+    for (auto *diffAttr : storage->getAttrs().getAttributes<DifferentiableAttr>())
+      (void)diffAttr->getParameterIndices();
+  }
+
   // Load derivative configurations from imported modules.
   auto &ctx = getASTContext();
   if (ctx.getCurrentGeneration() > DerivativeFunctionConfigGeneration) {

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -656,9 +656,9 @@ emitDerivativeFunctionReference(
     auto loc = witnessMethod->getLoc();
     auto requirementDeclRef = witnessMethod->getMember();
     auto *requirementDecl = requirementDeclRef.getAbstractFunctionDecl();
-    // If requirement declaration does not have any `@differentiable`
-    // attributes, produce an error.
-    if (!requirementDecl->getAttrs().hasAttribute<DifferentiableAttr>()) {
+    // If requirement declaration does not have any derivative function
+    // configurations, produce an error.
+    if (requirementDecl->getDerivativeFunctionConfigurations().empty()) {
       context.emitNondifferentiabilityError(
           original, invoker, diag::autodiff_protocol_member_not_differentiable);
       return None;
@@ -701,9 +701,9 @@ emitDerivativeFunctionReference(
     auto loc = classMethod->getLoc();
     auto methodDeclRef = classMethod->getMember();
     auto *methodDecl = methodDeclRef.getAbstractFunctionDecl();
-    // If method declaration does not have any `@differentiable` attributes,
-    // produce an error.
-    if (!methodDecl->getAttrs().hasAttribute<DifferentiableAttr>()) {
+    // If method declaration does not have any derivative function
+    // configurations, produce an error.
+    if (methodDecl->getDerivativeFunctionConfigurations().empty()) {
       context.emitNondifferentiabilityError(
           original, invoker, diag::autodiff_class_member_not_differentiable);
       return None;

--- a/test/AutoDiff/SILOptimizer/Inputs/differentiation_diagnostics_other_file.swift
+++ b/test/AutoDiff/SILOptimizer/Inputs/differentiation_diagnostics_other_file.swift
@@ -4,6 +4,14 @@ protocol Protocol: Differentiable {
   // Test cross-file `@differentiable` attribute.
   @differentiable(wrt: self)
   func identityDifferentiableAttr() -> Self
+
+  // Test `@differentiable` propagation from storage declaration to accessors.
+  @differentiable
+  var property: Float { get set }
+
+  // Test `@differentiable` propagation from storage declaration to accessors.
+  @differentiable
+  subscript() -> Float { get set }
 }
 
 extension Protocol {
@@ -15,5 +23,21 @@ extension Protocol {
     value: Self, pullback: (TangentVector) -> TangentVector
   ) {
     fatalError()
+  }
+}
+
+class Class: Differentiable {
+  // Test `@differentiable` propagation from storage declaration to accessors.
+  @differentiable
+  var property: Float {
+    get { 1 }
+    set {}
+  }
+
+  // Test `@differentiable` propagation from storage declaration to accessors.
+  @differentiable
+  subscript() -> Float {
+    get { 1 }
+    set {}
   }
 }

--- a/test/AutoDiff/SILOptimizer/differentiation_diagnostics_cross_file.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_diagnostics_cross_file.swift
@@ -23,3 +23,37 @@ func crossFileDerivativeAttr<T: Protocol>(
   // expected-note @+1 {{cannot differentiate functions that have not been marked '@differentiable' and that are defined in other files}}
   return input.identityDerivativeAttr()
 }
+
+// TF-1234: Test `@differentiable` propagation from protocol requirement storage
+// declarations to their accessors in other file.
+
+@differentiable
+func protocolRequirementGetters<T: Protocol>(_ x: T) -> Float {
+  x.property + x[]
+}
+
+// TODO(TF-1184): Make `@differentiable` on storage declarations propagate to
+// the setter in addition to the getter.
+@differentiable
+func protocolRequirementSetters<T: Protocol>(_ x: inout T, _ newValue: Float) {
+  // expected-error @+2 {{expression is not differentiable}}
+  // expected-note @+1 {{member is not differentiable because the corresponding protocol requirement is not '@differentiable'}}
+  x.property = newValue
+  // expected-error @+2 {{expression is not differentiable}}
+  // expected-note @+1 {{member is not differentiable because the corresponding protocol requirement is not '@differentiable'}}
+  x[] = newValue
+}
+
+// TF-1234: Test `@differentiable` propagation from class member storage
+// declarations to their accessors in other file.
+
+@differentiable
+func classRequirementGetters(_ x: Class) -> Float {
+  x.property + x[]
+}
+
+@differentiable
+func classRequirementSetters(_ x: inout Class, _ newValue: Float) {
+  x.property = newValue
+  x[] = newValue
+}


### PR DESCRIPTION
For accessors: make `AbstractFunctionDecl::getDerivativeFunctionConfigurations`
resolve configurations from parent storage declaration `@differentiable`
attributes.

Fixes "no `@differentiable` attribute" non-differentiability error for accessors
whose parent storage declaration `@differentiable` attributes have not been
type-checked (e.g. because the storage declarations are in another file).

Add protocol requirement and class member storage declaration tests.

Resolves TF-1234.