### PR TITLE
[AutoDiff] Remove `raw_ostream &` argument from `IndexSubset::dump`.

### DIFF
--- a/include/swift/AST/IndexSubset.h
+++ b/include/swift/AST/IndexSubset.h
@@ -207,7 +207,7 @@ public:
   }
 
   void print(llvm::raw_ostream &s = llvm::outs()) const;
-  SWIFT_DEBUG_DUMPER(dump(llvm::raw_ostream &s = llvm::errs()));
+  SWIFT_DEBUG_DUMPER(dump());
 
   int findNext(int startIndex) const;
   int findFirst() const { return findNext(-1); }

--- a/lib/AST/IndexSubset.cpp
+++ b/lib/AST/IndexSubset.cpp
@@ -86,7 +86,8 @@ void IndexSubset::print(llvm::raw_ostream &s) const {
   s << '}';
 }
 
-void IndexSubset::dump(llvm::raw_ostream &s) const {
+void IndexSubset::dump() const {
+  auto &s = llvm::errs();
   s << "(index_subset capacity=" << capacity << " indices=(";
   interleave(getIndices(), [&s](unsigned i) { s << i; },
              [&s] { s << ", "; });


### PR DESCRIPTION
Remove `llvm::raw_ostream &` argument so that `IndexSubset::dump` can be called in lldb without issue.

---

Before:
```console
(lldb) p fnTy->getDifferentiabilityParameterIndices()->dump()
error: too few arguments to function call, expected 1, have 0
'dump' declared here
(lldb) p fnTy->getDifferentiabilityParameterIndices()->dump(llvm::errs())
error: no member named 'errs' in namespace 'llvm'
```

After: `IndexSubset::dump` works in lldb.