### PR TITLE
[WebAssembly] Use absolute pointers

### DIFF
--- a/include/swift/Basic/RelativePointer.h
+++ b/include/swift/Basic/RelativePointer.h
@@ -146,6 +146,12 @@ static inline uintptr_t applyRelativeOffset(BasePtrTy *basePtr, Offset offset) {
                 std::is_signed<Offset>::value,
                 "offset type should be signed integer");
 
+#if defined(__WASM__)
+  // WebAssembly target uses only absolute pointers.
+  // See https://forums.swift.org/t/wasm-support/16087/17 for more details.
+  return (uintptr_t)(intptr_t)offset;
+#endif
+
   auto base = reinterpret_cast<uintptr_t>(basePtr);
   // We want to do wrapping arithmetic, but with a sign-extended
   // offset. To do this in C, we need to do signed promotion to get
@@ -164,6 +170,14 @@ static inline Offset measureRelativeOffset(A *referent, B *base) {
   static_assert(std::is_integral<Offset>::value &&
                 std::is_signed<Offset>::value,
                 "offset type should be signed integer");
+
+#if defined(__WASM__)
+  // WebAssembly target uses only absolute pointers.
+  auto offset = (Offset)(uintptr_t)referent;
+  assert((intptr_t)offset == (intptr_t)(uintptr_t)referent
+         && "pointer too large to fit in offset type");
+  return offset;
+#endif
 
   auto distance = (uintptr_t)referent - (uintptr_t)base;
   // Truncate as unsigned, then wrap around to signed.


### PR DESCRIPTION
<!-- What's in this pull request? -->
WebAssembly target uses absolute pointers, as explained by @kateinoigakukun on [Swift Forums](https://forums.swift.org/t/wasm-support/16087/16):

>It's due to the design of WebAssembly and LLVM support.
If LLVM supports substruction relocation type on WebAssembly like R_X86_64_PC32 or X86_64_RELOC_SUBTRACTOR, this issue can be solved easily.
>
>But LLVM doesn't support this relocation type because of the design of WebAssembly.
>
>First, R_X86_64_PC32 and X86_64_RELOC_SUBTRACTOR are mainly used to generate PIC but WebAssembly doesn't require PIC because it doesn't support dynamic linking. In addition, the memory space also begins at 0, so it's unnecessary to relocate at load time. All absolute addresses can be embedded in wasm binary file directly.

As confirmed by @jckarter:

>I agree using an absolute pointer in place of relative is the way to go.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Related to SR-9307.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
