### PR TITLE
[TF] Add "-DLLVM_ENABLE_Z3_SOLVER=NO" to tensorflow presets.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2466,6 +2466,9 @@ swift-primary-variant-arch=x86_64
 pythonkit
 install-pythonkit
 
+# Do not link libz3.
+llvm-cmake-options=-DLLVM_ENABLE_Z3_SOLVER=NO
+
 [preset: tensorflow_osx]
 mixin-preset=tensorflow_osx_base
 test
@@ -2527,6 +2530,9 @@ install-pythonkit
 
 # The swift-package-tests fail when run with python3.
 test-installable-package=
+
+# Do not link libz3.
+llvm-cmake-options=-DLLVM_ENABLE_Z3_SOLVER=NO
 
 [preset: tensorflow_linux,no_test]
 mixin-preset=


### PR DESCRIPTION
This prevents libz3.dylib dynamic linker errors that occur when:
- Toolchain build machine has z3 installed.
- Target machine does not have z3 installed.

Example fixed error:

```console
$ swift build
dyld: Library not loaded: /usr/local/opt/z3/lib/libz3.dylib
  Referenced from: /Library/Developer/Toolchains/swift-latest/usr/bin/swift
  Reason: image not found
```