### PR TITLE
[Runtime] Define WASI MutexPThread macros as 0

### DIFF
--- a/include/swift/Runtime/MutexPThread.h
+++ b/include/swift/Runtime/MutexPThread.h
@@ -26,12 +26,12 @@ typedef pthread_cond_t ConditionHandle;
 typedef pthread_mutex_t MutexHandle;
 typedef pthread_rwlock_t ReadWriteLockHandle;
 
-#if defined(__CYGWIN__) || defined(__ANDROID__) || defined(__HAIKU__)
+#if defined(__CYGWIN__) || defined(__ANDROID__) || defined(__HAIKU__) || defined(__wasi__)
 // At the moment CYGWIN pthreads implementation doesn't support the use of
 // constexpr for static allocation versions. The way they define things
 // results in a reinterpret_cast which violates constexpr. Similarly, Android's
 // pthread implementation makes use of volatile attributes that prevent it from
-// being marked as constexpr.
+// being marked as constexpr. WASI currently doesn't support threading/locking at all.
 #define SWIFT_CONDITION_SUPPORTS_CONSTEXPR 0
 #define SWIFT_MUTEX_SUPPORTS_CONSTEXPR 0
 #define SWIFT_READWRITELOCK_SUPPORTS_CONSTEXPR 0


### PR DESCRIPTION
WebAssembly/WASI target doesn't compile with MutexPThread `constexpr` macros defined as `1` due lack of support for threading/locking, previously reported in SR-12097.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Related to SR-9307.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
