### PR TITLE
[AutoDiff] Add SR-12744 negative test.

### DIFF
--- a/test/AutoDiff/compiler_crashers/sr12744-unhandled-pullback-indirect-result.swift
+++ b/test/AutoDiff/compiler_crashers/sr12744-unhandled-pullback-indirect-result.swift
@@ -1,0 +1,19 @@
+// RUN: not --crash %target-swift-frontend -emit-sil -verify %s
+// REQUIRES: asserts
+
+// SR-12744: Pullback generation crash for unhandled indirect result.
+// May be due to inconsistent derivative function type calculation logic in
+// `VJPEmitter::createEmptyPullback`.
+
+import _Differentiation
+
+class Class: Differentiable {
+  @differentiable(wrt: (self, x))
+  @differentiable(wrt: x)
+  func f(_ x: Float) -> Float { x }
+}
+
+func test<C: Class>(_ c: C, _ x: Float) {
+  _ = gradient(at: c, x) { c, x in c.f(x) }
+  _ = gradient(at: x) { x in c.f(x) }
+}


### PR DESCRIPTION
Add negative test for SR-12744: pullback generation crash for unhandled indirect result.
May be related to https://github.com/apple/swift/pull/31496, which updated derivative typing rules.