### PR TITLE
Ignore conflicting debug variables for same function argument.

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1116,17 +1116,9 @@ public:
 
       if (VarInfo)
         if (unsigned ArgNo = VarInfo->ArgNo) {
-          // It is a function argument.
-          if (ArgNo < DebugVars.size() && !DebugVars[ArgNo].empty() && !VarInfo->Name.empty()) {
-            require(
-                DebugVars[ArgNo] == VarInfo->Name,
-                "Scope contains conflicting debug variables for one function "
-                "argument");
-          } else {
-            // Reserve enough space.
-            while (DebugVars.size() <= ArgNo) {
-              DebugVars.push_back(StringRef());
-            }
+          // Reserve enough space.
+          while (DebugVars.size() <= ArgNo) {
+            DebugVars.push_back(StringRef());
           }
           DebugVars[ArgNo] = VarInfo->Name;
       }

--- a/test/SIL/conflicting_debugs.sil
+++ b/test/SIL/conflicting_debugs.sil
@@ -1,0 +1,15 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s
+
+sil_stage canonical
+
+import Builtin
+
+// Make sure we can read in two debug_values with the same argument number but
+// different names.
+sil @test : $@convention(thin) (Builtin.Int32) -> Builtin.Int32 {
+// %0 "y"
+bb0(%0 : $Builtin.Int32):
+  debug_value %0 : $Builtin.Int32, let, name "y", argno 1
+  debug_value %0 : $Builtin.Int32, let, name "x", argno 1
+  return %0 : $Builtin.Int32
+}


### PR DESCRIPTION
It's possible to have two debug variables for the same function argument when [one function is inlined into the other](https://swift.godbolt.org/z/5uuWRp) so, we shouldn't crash. 

I'm not entirely sure this is the right fix. Maybe, instead, we should update the linliner to remove argument debug variables.

This is not only nice for debugging but also necessary for round-trip sil testing (read and dump sil between all passes). 