### PR TITLE
Enable LLVM's HotColdSplitting pass

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -202,6 +202,7 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
     PMBuilder.SLPVectorize = true;
     PMBuilder.LoopVectorize = true;
     PMBuilder.MergeFunctions = true;
+    PMBuilder.SplitColdCode = true;
   } else {
     PMBuilder.OptLevel = 0;
     if (!Opts.DisableLLVMOptzns)

--- a/test/DebugInfo/doubleinlines.swift
+++ b/test/DebugInfo/doubleinlines.swift
@@ -11,10 +11,12 @@ func callCondFail(arg: Builtin.Int1, msg: Builtin.RawPointer) {
 }
 
 // CHECK: define hidden swiftcc void @"$s13DoubleInlines12callCondFail3arg3msgyBi1__BptF"{{.*}} !dbg ![[FUNCSCOPE:.*]] {
-// CHECK: tail call void asm sideeffect "", "n"(i32 0) #3, !dbg ![[SCOPEONE:.*]]
+// CHECK: call void @"$s13DoubleInlines12callCondFail3arg3msgyBi1__BptF.cold.1"()
+// CHECK: define internal void @"$s13DoubleInlines12callCondFail3arg3msgyBi1__BptF.cold.1"()
+// CHECK: tail call void asm sideeffect "", "n"(i32 0) {{.*}}, !dbg ![[SCOPEONE:.*]]
 // CHECK: ![[FUNCSCOPEOTHER:.*]] = distinct !DISubprogram(name: "condFail",{{.*}}
-// CHECK: ![[SCOPEFIVE:.*]] = distinct !DILexicalBlock(scope: ![[FUNCSCOPE]], file: ![[FILE:.*]], line: 9)
-// CHECK: ![[SCOPESIX:.*]] = distinct !DILexicalBlock(scope: ![[FUNCSCOPEOTHER]], file: ![[FILE]], line: 5)
-// CHECK: ![[SCOPEONE]] = !DILocation(line: 0, scope: ![[SCOPETWO:.*]], inlinedAt: ![[SCOPETHREE:.*]])
-// CHECK: ![[SCOPETHREE]] = !DILocation(line: 6, scope: ![[SCOPEFOUR:.*]])
+// CHECK: ![[SCOPESIX:.*]] = distinct !DILexicalBlock(scope: ![[FUNCSCOPEOTHER]], file: ![[FILE:.*]], line: 5)
+// CHECK: ![[SCOPEFIVE:.*]] = distinct !DILexicalBlock(scope: ![[FUNCSCOPE]], file: ![[FILE]], line: 9)
+// CHECK: ![[SCOPETHREE:.*]] = !DILocation(line: 6, scope: ![[SCOPEFOUR:[0-9]+]])
 // CHECK: ![[SCOPEFOUR]] = distinct !DILexicalBlock(scope: ![[SCOPEFIVE]], file: ![[FILE]], line: 10)
+// CHECK: ![[SCOPEONE]] = !DILocation(line: 0, scope: ![[SCOPETWO:.*]])

--- a/test/DebugInfo/trap.swift
+++ b/test/DebugInfo/trap.swift
@@ -10,9 +10,9 @@ func f(_ x : Int64) -> Int64 {
     Builtin.int_trap()
   }
   if x > 42 {
-    // CHECK-DAG: ![[LOC2:.*]] = !DILocation(line: [[@LINE+1]],
+    // CHECK-DAG: call void @llvm.trap(), !dbg ![[LOC2:.*]]
+    // CHECK-DAG: ![[LOC2]] = !DILocation(line: [[@LINE+1]],
     Builtin.int_trap()
-    // CHECK-DAG: call void @llvm.trap(), !dbg ![[LOC2]]
   }
   return x
 }

--- a/test/IRGen/condfail_message.swift
+++ b/test/IRGen/condfail_message.swift
@@ -1,16 +1,24 @@
-// RUN: %target-swift-frontend -primary-file %s -g -emit-ir | %FileCheck %s
-// RUN: %target-swift-frontend -primary-file %s -g -O -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -g -emit-ir | %FileCheck %s --check-prefix CHECK-NOOPT
+// RUN: %target-swift-frontend -primary-file %s -g -O -emit-ir | %FileCheck %s --check-prefix CHECK-OPT
 // REQUIRES: optimized_stdlib
 
 // CHECK-LABEL: define hidden swiftcc i8 @"$s16condfail_message6testitys4Int8VADF"(i8 %0)
-// CHECK: call void @llvm.trap(), !dbg [[LOC:![0-9]+]]
+// CHECK-OPT: call void @"$s16condfail_message6testitys4Int8VADF.cold.1"()
+// CHECK-OPT: define internal void @"$s16condfail_message6testitys4Int8VADF.cold.1"()
+// CHECK-NOOPT: call void @llvm.trap(), !dbg [[LOC:![0-9]+]]
+// CHECK-OPT: call void @llvm.trap(), !dbg [[LOC:![0-9]+]]
 
 func testit(_ a: Int8) -> Int8 {
   return a + 1
 }
 
-// CHECK: [[CALLER_LOC:![0-9]+]] = !DILocation(line: 9, column: 12, scope: !{{.*}})
-// CHECK: [[LOC]] = !DILocation(line: 0, scope: [[FAILURE_FUNC:![0-9]+]], inlinedAt: [[CALLER_LOC]])
-// CHECK: [[FAILURE_FUNC]] = distinct !DISubprogram(name: "Swift runtime failure: arithmetic overflow", scope: {{.*}}, file: {{.*}}, type: [[FUNC_TYPE:![0-9]+]], flags: DIFlagArtificial, spFlags: DISPFlagDefinition, {{.*}})
-// CHECK: [[FUNC_TYPE]] = !DISubroutineType(types: null)
+// CHECK-NOOPT: [[CALLER_LOC:![0-9]+]] = !DILocation(line: 12, column: 12, scope: !{{.*}})
+// CHECK-NOOPT: [[LOC:![0-9]+]] = !DILocation(line: 0, scope: [[FAILURE_FUNC:![0-9]+]], inlinedAt: [[CALLER_LOC]])
+// CHECK-NOOPT: [[FAILURE_FUNC]] = distinct !DISubprogram(name: "Swift runtime failure: arithmetic overflow", scope: {{.*}}, file: {{.*}}, type: [[FUNC_TYPE:![0-9]+]], flags: DIFlagArtificial, spFlags: DISPFlagDefinition, {{.*}})
+// CHECK-NOOPT: [[FUNC_TYPE]] = !DISubroutineType(types: null)
+
+// CHECK-OPT: [[CALLER_LOC:![0-9]+]] = !DILocation(line: 12, column: 12, scope: !{{.*}})
+// CHECK-OPT: [[FAILURE_FUNC:![0-9]+]] = distinct !DISubprogram(name: "$s16condfail_message6testitys4Int8VADF.cold.1", linkageName: "$s16condfail_message6testitys4Int8VADF.cold.1", scope: null, file: {{.*}}, type: [[FUNC_TYPE:![0-9]+]], spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: {{.*}}, retainedNodes: {{.*}})
+// CHECK-OPT: [[FUNC_TYPE]] = !DISubroutineType(types: {{.*}})
+// CHECK-OPT: [[LOC]] = !DILocation(line: 0, scope: [[FAILURE_FUNC:![0-9]+]])
  


### PR DESCRIPTION
This pass can extract cold paths that end in traps. This along with the
MergeFunctions pass has potential for code size reduction as well

rdar://52147720
