### PR TITLE
[Parser/libSyntax] Avoid doing lookup for a previous parsed node when we are in backtracking mode

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -494,13 +494,7 @@ public:
     ~BacktrackingScope();
     bool willBacktrack() const { return Backtrack; }
 
-    void cancelBacktrack() {
-      Backtrack = false;
-      SynContext->setTransparent();
-      SynContext.reset();
-      DT.commit();
-      TempReceiver.shouldTransfer = true;
-    }
+    void cancelBacktrack();
   };
 
   /// RAII object that, when it is destructed, restores the parser and lexer to

--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -326,6 +326,9 @@ public:
     IsBacktracking = true;
   }
 
+  /// Cancels backtracking state from the top of the context stack until `this` context.
+  void cancelBacktrack();
+
   bool isBacktracking() const { return IsBacktracking; }
 
   void setShouldDefer(bool Value = true) { ShouldDefer = Value; }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5531,7 +5531,14 @@ ParserStatus Parser::parseGetSet(ParseDeclOptions Flags,
       parseImplicitGetter();
       return makeParserSuccess();
     }
-    IsFirstAccessor = false;
+    if (IsFirstAccessor) {
+      // Continue parsing without backtracking so we can re-use previously
+      // parsed nodes for incremental re-parsing, but avoid destructing
+      // `backtrack` because its syntax context isn't at the top of the stack at
+      // this point.
+      backtrack->cancelBacktrack();
+      IsFirstAccessor = false;
+    }
 
     // For now, immediately reject illegal accessors in protocols just to
     // avoid having to deal with them everywhere.

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -222,6 +222,19 @@ swift::Parser::BacktrackingScope::~BacktrackingScope() {
   }
 }
 
+void swift::Parser::BacktrackingScope::cancelBacktrack() {
+  if (!Backtrack)
+    return;
+
+  Backtrack = false;
+  SynContext->cancelBacktrack();
+  SynContext->setTransparent();
+  if (SynContext->isTopOfContextStack())
+    SynContext.reset();
+  DT.commit();
+  TempReceiver.shouldTransfer = true;
+}
+
 /// Tokenizes a string literal, taking into account string interpolation.
 static void getStringPartTokens(const Token &Tok, const LangOptions &LangOpts,
                                 const SourceManager &SM,

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -50,6 +50,24 @@ size_t SyntaxParsingContext::lookupNode(size_t LexerOffset, SourceLoc Loc) {
   if (!Enabled)
     return 0;
 
+  // Avoid doing lookup for a previous parsed node when we are in backtracking
+  // mode. This is because if the parser library client give us a node pointer
+  // and we discard it due to backtracking then we are violating this invariant:
+  //
+  //   The parser guarantees that any \c swiftparse_client_node_t, given to the
+  //   parser by \c swiftparse_node_handler_t or \c swiftparse_node_lookup_t,
+  //   will be returned back to the client.
+  //
+  // which will end up likely creating a memory leak for the client because
+  // the semantics is that the parser accepts ownership of the object that the
+  // node pointer represents.
+  //
+  // Note that the fact that backtracking mode is disabling incremental parse
+  // node re-use is another reason that we should keep backtracking state as
+  // minimal as possible.
+  if (isBacktracking())
+    return 0;
+
   assert(getStorage().size() == Offset &&
          "Cannot do lookup if nodes have already been gathered");
   assert(Mode == AccumulationMode::CreateSyntax &&

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -46,6 +46,17 @@ SyntaxParsingContext::SyntaxParsingContext(SyntaxParsingContext *&CtxtHolder,
   getStorage().reserve(128);
 }
 
+void SyntaxParsingContext::cancelBacktrack() {
+  SyntaxParsingContext *curr = CtxtHolder;
+  while (true) {
+    curr->IsBacktracking = false;
+    if (curr == this) {
+      break;
+    }
+    curr = curr->getParent();
+  }
+}
+
 size_t SyntaxParsingContext::lookupNode(size_t LexerOffset, SourceLoc Loc) {
   if (!Enabled)
     return 0;

--- a/test/incrParse/add-close-brace-to-property.swift
+++ b/test/incrParse/add-close-brace-to-property.swift
@@ -1,0 +1,9 @@
+// RUN: %empty-directory(%t)
+// RUN: %validate-incrparse %s --test-case REPLACE
+
+
+var value: Int {
+    get { fatalError() }
+<<REPLACE<|||}>>>
+
+let x = 10

--- a/test/incrParse/reuse.swift
+++ b/test/incrParse/reuse.swift
@@ -1,10 +1,18 @@
 // RUN: %empty-directory(%t)
+// RUN: %validate-incrparse %s --test-case MODIFY_ACCESSOR
 // RUN: %validate-incrparse %s --test-case ADD_PROPERTY
 // RUN: %validate-incrparse %s --test-case WRAP_IN_CLASS
 // RUN: %validate-incrparse %s --test-case UNWRAP_CLASS
 // RUN: %validate-incrparse %s --test-case NEXT_TOKEN_CALCULATION
 
 func start() {}
+
+<reparse MODIFY_ACCESSOR>var someprop: Int {</reparse MODIFY_ACCESSOR>
+  <reparse MODIFY_ACCESSOR>get {</reparse MODIFY_ACCESSOR>
+    return 0
+  <reparse MODIFY_ACCESSOR>}</reparse MODIFY_ACCESSOR>
+  <reparse MODIFY_ACCESSOR>set { print(<<MODIFY_ACCESSOR<|||0>>>) }</reparse MODIFY_ACCESSOR>
+<reparse MODIFY_ACCESSOR>}</reparse MODIFY_ACCESSOR>
 
 <reparse ADD_PROPERTY>struct Foo {</reparse ADD_PROPERTY>
   let a: Int


### PR DESCRIPTION
This both addresses a crash during incremental re-parse (rdar://57679731) and generally avoids violating invariants for interacting with the parser library.

Also for accessor parsing only backtrack until the accessor introducer. Previously it was backtracking for the duration of the whole property body.