### PR TITLE
[stdlib] ManagedBuffer independent of malloc_size.

### DIFF
--- a/include/swift/AST/PlatformKinds.def
+++ b/include/swift/AST/PlatformKinds.def
@@ -32,5 +32,6 @@ AVAILABILITY_PLATFORM(watchOSApplicationExtension, "application extensions for w
 AVAILABILITY_PLATFORM(macOSApplicationExtension, "application extensions for macOS")
 AVAILABILITY_PLATFORM(macCatalyst, "Mac Catalyst")
 AVAILABILITY_PLATFORM(macCatalystApplicationExtension, "application extensions for Mac Catalyst")
+AVAILABILITY_PLATFORM(OpenBSD, "OpenBSD")
 
 #undef AVAILABILITY_PLATFORM

--- a/lib/AST/PlatformKind.cpp
+++ b/lib/AST/PlatformKind.cpp
@@ -87,6 +87,8 @@ static bool isPlatformActiveForTarget(PlatformKind Platform,
     case PlatformKind::watchOS:
     case PlatformKind::watchOSApplicationExtension:
       return Target.isWatchOS();
+    case PlatformKind::OpenBSD:
+      return Target.isOSOpenBSD();
     case PlatformKind::none:
       llvm_unreachable("handled above");
   }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1930,6 +1930,10 @@ PlatformAvailability::PlatformAvailability(const LangOptions &langOpts)
         "APIs deprecated as of macOS 10.9 and earlier are unavailable in Swift";
     break;
 
+  case PlatformKind::OpenBSD:
+    deprecatedAsUnavailableMessage = "";
+    break;
+
   case PlatformKind::none:
     break;
   }
@@ -1961,6 +1965,9 @@ bool PlatformAvailability::isPlatformRelevant(StringRef name) const {
     return name == "watchos";
   case PlatformKind::watchOSApplicationExtension:
     return name == "watchos" || name == "watchos_app_extension";
+
+  case PlatformKind::OpenBSD:
+    return name == "openbsd";
 
   case PlatformKind::none:
     return false;
@@ -2000,6 +2007,10 @@ bool PlatformAvailability::treatDeprecatedAsUnavailable(
   case PlatformKind::watchOS:
   case PlatformKind::watchOSApplicationExtension:
     // No deprecation filter on watchOS
+    return false;
+
+  case PlatformKind::OpenBSD:
+    // No deprecation filter on OpenBSD
     return false;
   }
 

--- a/lib/PrintAsObjC/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.cpp
@@ -852,6 +852,9 @@ private:
       case PlatformKind::watchOSApplicationExtension:
         plat = "watchos_app_extension";
         break;
+      case PlatformKind::OpenBSD:
+        plat = "openbsd";
+        break;
       case PlatformKind::none:
         llvm_unreachable("handled above");
       }

--- a/lib/SymbolGraphGen/AvailabilityMixin.cpp
+++ b/lib/SymbolGraphGen/AvailabilityMixin.cpp
@@ -56,6 +56,8 @@ StringRef getDomain(const AvailableAttr &AvAttr) {
       return { "tvOSAppExtension" };
     case swift::PlatformKind::watchOSApplicationExtension:
       return { "watchOSAppExtension" };
+    case swift::PlatformKind::OpenBSD:
+      return { "OpenBSD" };
     case swift::PlatformKind::none:
       return { "*" };
   }

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -249,6 +249,8 @@ getLinkerPlatformId(OriginallyDefinedInAttr::ActiveVersion Ver) {
   switch(Ver.Platform) {
   case swift::PlatformKind::none:
     llvm_unreachable("cannot find platform kind");
+  case swift::PlatformKind::OpenBSD:
+    llvm_unreachable("not used for this platform");
   case swift::PlatformKind::iOS:
   case swift::PlatformKind::iOSApplicationExtension:
     return Ver.IsSimulator ? LinkerPlatformId::iOS_sim:

--- a/stdlib/public/core/BridgingBuffer.swift
+++ b/stdlib/public/core/BridgingBuffer.swift
@@ -25,6 +25,7 @@ internal final class __BridgingBufferStorage
 internal typealias _BridgingBuffer
   = ManagedBufferPointer<_BridgingBufferHeader, AnyObject>
 
+@available(OpenBSD, unavailable, message: "malloc_size is unavailable.")
 extension ManagedBufferPointer
 where Header == _BridgingBufferHeader, Element == AnyObject {
   internal init(_ count: Int) {

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -83,6 +83,7 @@ extension ManagedBuffer {
   /// idea to store this information in the "header" area when
   /// an instance is created.
   @inlinable
+  @available(OpenBSD, unavailable, message: "malloc_size is unavailable.")
   public final var capacity: Int {
     let storageAddr = UnsafeMutableRawPointer(Builtin.bridgeToRawPointer(self))
     let endAddr = storageAddr + _swift_stdlib_malloc_size(storageAddr)
@@ -197,6 +198,7 @@ public struct ManagedBufferPointer<Header, Element> {
   ///   properties.  The `deinit` of `bufferClass` must destroy its
   ///   stored `Header` and any constructed `Element`s.
   @inlinable
+  @available(OpenBSD, unavailable, message: "malloc_size is unavailable.")
   public init(
     bufferClass: AnyClass,
     minimumCapacity: Int,
@@ -329,6 +331,7 @@ extension ManagedBufferPointer {
   /// idea to store this information in the "header" area when
   /// an instance is created.
   @inlinable
+  @available(OpenBSD, unavailable, message: "malloc_size is unavailable.")
   public var capacity: Int {
     return (
       _capacityInBytes &- ManagedBufferPointer._elementOffset
@@ -431,6 +434,7 @@ extension ManagedBufferPointer {
 
   /// The actual number of bytes allocated for this object.
   @inlinable
+  @available(OpenBSD, unavailable, message: "malloc_size is unavailable.")
   internal var _capacityInBytes: Int {
     return _swift_stdlib_malloc_size(_address)
   }

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -39,6 +39,7 @@ struct MyStruct {}
 // AVAILABILITY1-NEXT: Keyword/None:                       macOSApplicationExtension[#Platform#]; name=macOSApplicationExtension{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       macCatalyst[#Platform#]; name=macCatalyst
 // AVAILABILITY1-NEXT: Keyword/None:                       macCatalystApplicationExtension[#Platform#]; name=macCatalystApplicationExtension
+// AVAILABILITY1-NEXT: Keyword/None:                       OpenBSD[#Platform#]; name=OpenBSD{{$}}
 // AVAILABILITY1-NEXT: End completions
 
 @available(*, #^AVAILABILITY2^#)

--- a/test/Interpreter/generic_ref_counts.swift
+++ b/test/Interpreter/generic_ref_counts.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 // REQUIRES: executable_test
+// XFAIL: OS=openbsd
 
 import Swift
 

--- a/test/stdlib/ManagedBuffer.swift
+++ b/test/stdlib/ManagedBuffer.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
+// XFAIL: OS=openbsd
 
 import StdlibUnittest
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -674,6 +674,7 @@ static void reportAttributes(ASTContext &Ctx,
   static UIdent PlatformOSXAppExt("source.availability.platform.osx_app_extension");
   static UIdent PlatformtvOSAppExt("source.availability.platform.tvos_app_extension");
   static UIdent PlatformWatchOSAppExt("source.availability.platform.watchos_app_extension");
+  static UIdent PlatformOpenBSD("source.availability.platform.openbsd");
   std::vector<const DeclAttribute*> Scratch;
 
   for (auto Attr : getDeclAttributes(D, Scratch)) {
@@ -702,6 +703,8 @@ static void reportAttributes(ASTContext &Ctx,
         PlatformUID = PlatformtvOSAppExt; break;
       case PlatformKind::watchOSApplicationExtension:
         PlatformUID = PlatformWatchOSAppExt; break;
+      case PlatformKind::OpenBSD:
+        PlatformUID = PlatformOpenBSD; break;
       }
 
       AvailableAttrInfo Info;


### PR DESCRIPTION
ManagedBuffer and ManagedBufferPointer no longer requires having a
functional malloc_size implementation to work. When malloc_size is
unavailable, we store the capacity in the tail allocation used by either
class.

Adding extra stored properties is not feasible, since there are
preconditions and invariants that check for these. This would also mean
that platforms which do have malloc_size would be wasting an unnecessary
stored property per class.

Wrapping the header object is not feasible, since there are certain
assumptions that the header object (and thus not the wrapper) and the
tail-allocated memory are adjacent.

Creating a static dictionary to track allocations and their sizes would
be possible, but this seems too brittle; any allocation tracking would
have to be static since ManagedBuffer and ManagedBufferPointer are
implemented with extensions, restricting us to only computed properties.

Thus, we are left with having to use the dynamic allocation in
ManagedBuffer and ManagedBufferPointer itself. This leaves us with one
gap: the single-argument initializer in ManagedBufferPointer,
`init(unsafeBufferObject:)`. This is fine when called from
`init(bufferClass:minimumCapacity:makingHeaderWith:)`, but if only
initialized with the single-argument initializer, the base capacity
implementation will not be correct. This may be okay, since generally
clients subclassing ManagedBufferPointer should override `capacity` for
their own tracking; indeed, this is what the unit test actually does.
Furthermore, it is the caller's responsibility to supply enough memory
to store the allocated elements in any case; the way the initializer is
written currently, we have no other way of knowing the size of the
allocation from the caller without malloc_size.