### PR TITLE
[overlay] Remove unnecessary Optional unwrapping

### DIFF
--- a/stdlib/public/Darwin/Foundation/NSStringAPI.swift
+++ b/stdlib/public/Darwin/Foundation/NSStringAPI.swift
@@ -1257,7 +1257,7 @@ extension StringProtocol where Index == String.Index {
       in: _toRelativeNSRange(range),
       scheme: NSLinguisticTagScheme(rawValue: tagScheme._ephemeralString),
       options: opts,
-      orthography: orthography != nil ? orthography! : nil
+      orthography: orthography
     ) {
       var stop_ = false
       body($0!.rawValue, self._toRange($1), self._toRange($2), &stop_)


### PR DESCRIPTION
Now we pass `NSOrthography?` directly to a function that takes `NSOrthography?` without doing any additional work.

If indeed this breaks nothing, I'll sync it to [Foundation](https://github.com/apple/swift-corelibs-foundation) by making another PR.