### PR TITLE
[stdlib] Remove more unneeded `numericCast`s

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -941,7 +941,7 @@ public func checkOneLevelOfRandomAccessCollection<
     instances,
     distances: distances,
     of: collection,
-    distanceOracle: { (x:Int, y:Int) in numericCast(y - x) },
+    distanceOracle: { (x:Int, y:Int) in y - x },
     advanceOracle: { x, y in nextN(distances[y], instances[x]) },
     startIndex: collection.startIndex,
     endIndex: next5(partWay1), message(),
@@ -1709,7 +1709,7 @@ public func checkOneLevelOfRandomAccessCollection<
     instances,
     distances: distances,
     of: collection,
-    distanceOracle: { (x:Int, y:Int) in numericCast(y - x) },
+    distanceOracle: { (x:Int, y:Int) in y - x },
     advanceOracle: { x, y in nextN(distances[y], instances[x]) },
     startIndex: collection.startIndex,
     endIndex: next5(partWay1), message(),
@@ -1888,7 +1888,7 @@ public func checkRangeReplaceable<C, N>(
         let growth = newCount - oldCount
 
         let expectedCount = source.count + growth
-        let actualCount = numericCast(a.count) as Int
+        let actualCount = a.count
         if actualCount != expectedCount {
           reportFailure(
             &a, "\(actualCount) != expected count \(expectedCount)")

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -25,8 +25,8 @@ public struct SubscriptRangeTest {
 
   public func bounds<C : Collection>(in c: C) -> Range<C.Index> {
     let i = c.startIndex
-    return c.index(i, offsetBy: numericCast(bounds.lowerBound)) ..<
-           c.index(i, offsetBy: numericCast(bounds.upperBound))
+    return c.index(i, offsetBy: bounds.lowerBound) ..<
+           c.index(i, offsetBy: bounds.upperBound)
   }
 
   public init(
@@ -390,7 +390,7 @@ let findLastTests = [
 
 extension Collection {
   public func nthIndex(_ offset: Int) -> Index {
-    return self.index(self.startIndex, offsetBy: numericCast(offset))
+    return self.index(self.startIndex, offsetBy: offset)
   }
 }
 
@@ -639,14 +639,14 @@ extension TestSuite {
         let c = makeWrappedCollection([ 1010, 2020, 3030 ].map(OpaqueValue.init))
         let index = c.endIndex
         expectCrashLater()
-        _blackHole(c.index(index, offsetBy: numericCast(outOfBoundsIndexOffset)))
+        _blackHole(c.index(index, offsetBy: outOfBoundsIndexOffset))
       }
 
       self.test("\(testNamePrefix).Index/OutOfBounds/Right/Empty") {
         let c = makeWrappedCollection([])
         let index = c.endIndex
         expectCrashLater()
-        _blackHole(c.index(index, offsetBy: numericCast(outOfBoundsIndexOffset)))
+        _blackHole(c.index(index, offsetBy: outOfBoundsIndexOffset))
       }
     }
 
@@ -659,7 +659,7 @@ extension TestSuite {
         let c = makeWrappedCollection([ 1010, 2020, 3030 ].map(OpaqueValue.init))
         var index = c.endIndex
         expectCrashLater()
-        index = c.index(index, offsetBy: numericCast(outOfBoundsSubscriptOffset))
+        index = c.index(index, offsetBy: outOfBoundsSubscriptOffset)
         _blackHole(c[index])
       }
 
@@ -667,7 +667,7 @@ extension TestSuite {
         let c = makeWrappedCollection([])
         var index = c.endIndex
         expectCrashLater()
-        index = c.index(index, offsetBy: numericCast(outOfBoundsSubscriptOffset))
+        index = c.index(index, offsetBy: outOfBoundsSubscriptOffset)
         _blackHole(c[index])
       }
 
@@ -684,10 +684,10 @@ extension TestSuite {
         print("\(elements)/sliceFromLeft=\(sliceFromLeft)/sliceFromRight=\(sliceFromRight)")
         let base = makeWrappedCollection(elements)
         let sliceStartIndex =
-          base.index(base.startIndex, offsetBy: numericCast(sliceFromLeft))
+          base.index(base.startIndex, offsetBy: sliceFromLeft)
         let sliceEndIndex = base.index(
           base.startIndex,
-          offsetBy: numericCast(elements.count - sliceFromRight))
+          offsetBy: elements.count - sliceFromRight)
         var slice = base[sliceStartIndex..<sliceEndIndex]
         expectType(C.SubSequence.self, &slice)
 
@@ -711,12 +711,12 @@ extension TestSuite {
           if sliceFromLeft == 0 { return }
           index = base.index(
             base.startIndex,
-            offsetBy: numericCast(sliceFromLeft - 1))
+            offsetBy: sliceFromLeft - 1)
         case .outOfRangeToTheRight:
           if sliceFromRight == 0 { return }
           index = base.index(
             base.startIndex,
-            offsetBy: numericCast(elements.count - sliceFromRight))
+            offsetBy: elements.count - sliceFromRight)
         case .baseEndIndex:
           index = base.endIndex
         case .sliceEndIndex:
@@ -758,7 +758,7 @@ extension TestSuite {
         let c = makeWrappedCollection([ 1010, 2020, 3030 ].map(OpaqueValue.init))
         var index = c.endIndex
         expectCrashLater()
-        index = c.index(index, offsetBy: numericCast(outOfBoundsSubscriptOffset))
+        index = c.index(index, offsetBy: outOfBoundsSubscriptOffset)
         _blackHole(c[index..<index])
       }
 
@@ -766,7 +766,7 @@ extension TestSuite {
         let c = makeWrappedCollection([])
         var index = c.endIndex
         expectCrashLater()
-        index = c.index(index, offsetBy: numericCast(outOfBoundsSubscriptOffset))
+        index = c.index(index, offsetBy: outOfBoundsSubscriptOffset)
         _blackHole(c[index..<index])
       }
 
@@ -786,10 +786,10 @@ extension TestSuite {
           + "/sliceFromRight=\(sliceFromRight)")
         let base = makeWrappedCollection(elements)
         let sliceStartIndex =
-          base.index(base.startIndex, offsetBy: numericCast(sliceFromLeft))
+          base.index(base.startIndex, offsetBy: sliceFromLeft)
         let sliceEndIndex = base.index(
           base.startIndex,
-          offsetBy: numericCast(elements.count - sliceFromRight))
+          offsetBy: elements.count - sliceFromRight)
         var slice = base[sliceStartIndex..<sliceEndIndex]
         expectType(C.SubSequence.self, &slice)
 
@@ -823,28 +823,28 @@ extension TestSuite {
           if sliceFromLeft == 0 { return }
           let index = base.index(
             base.startIndex,
-            offsetBy: numericCast(sliceFromLeft - 1))
+            offsetBy: sliceFromLeft - 1)
           bounds = index..<index
           break
         case .outOfRangeToTheLeftNonEmpty:
           if sliceFromLeft == 0 { return }
           let index = base.index(
             base.startIndex,
-            offsetBy: numericCast(sliceFromLeft - 1))
+            offsetBy: sliceFromLeft - 1)
           bounds = index..<sliceStartIndex
           break
         case .outOfRangeToTheRightEmpty:
           if sliceFromRight == 0 { return }
           let index = base.index(
             base.startIndex,
-            offsetBy: numericCast(elements.count - sliceFromRight + 1))
+            offsetBy: elements.count - sliceFromRight + 1)
           bounds = index..<index
           break
         case .outOfRangeToTheRightNonEmpty:
           if sliceFromRight == 0 { return }
           let index = base.index(
             base.startIndex,
-            offsetBy: numericCast(elements.count - sliceFromRight + 1))
+            offsetBy: elements.count - sliceFromRight + 1)
           bounds = sliceEndIndex..<index
           break
         case .outOfRangeBothSides:
@@ -853,11 +853,11 @@ extension TestSuite {
           bounds =
             base.index(
               base.startIndex,
-              offsetBy: numericCast(sliceFromLeft - 1))
+              offsetBy: sliceFromLeft - 1)
             ..<
             base.index(
               base.startIndex,
-              offsetBy: numericCast(elements.count - sliceFromRight + 1))
+              offsetBy: elements.count - sliceFromRight + 1)
           break
         case .baseEndIndex:
           if sliceFromRight == 0 { return }
@@ -892,7 +892,7 @@ extension TestSuite {
     self.test("\(testNamePrefix).count/semantics") {
       for test in subscriptRangeTests {
         let c = makeWrappedCollection(test.collection)
-        expectEqual(test.count, numericCast(c.count) as Int)
+        expectEqual(test.count, c.count)
       }
     }
 
@@ -908,7 +908,7 @@ extension TestSuite {
           Optional<CollectionWithEquatableElement.Index>.self,
           &result)
         let zeroBasedIndex = result.map {
-          numericCast(c.distance(from: c.startIndex, to: $0)) as Int
+          c.distance(from: c.startIndex, to: $0)
         }
         expectEqual(
           test.expected,
@@ -929,7 +929,7 @@ extension TestSuite {
             extractValueFromEquatable(candidate).value == test.element.value
         }
         let zeroBasedIndex = result.map {
-          numericCast(c.distance(from: c.startIndex, to: $0)) as Int
+          c.distance(from: c.startIndex, to: $0)
         }
         expectEqual(
           test.expected,
@@ -1058,7 +1058,7 @@ extension TestSuite {
       for test in prefixThroughTests {
         let c = makeWrappedCollection(test.collection.map(OpaqueValue.init))
         let index = c.index(
-          c.startIndex, offsetBy: numericCast(test.position))
+          c.startIndex, offsetBy: test.position)
         let result = c.prefix(through: index)
         expectEqualSequence(
           test.expected, result.map(extractValue).map { $0.value },
@@ -1073,7 +1073,7 @@ extension TestSuite {
     self.test("\(testNamePrefix).prefix(upTo:)/semantics") {
       for test in prefixUpToTests {
         let c = makeWrappedCollection(test.collection.map(OpaqueValue.init))
-        let index = c.index(c.startIndex, offsetBy: numericCast(test.end))
+        let index = c.index(c.startIndex, offsetBy: test.end)
         let result = c.prefix(upTo: index)
         expectEqualSequence(
           test.expected, result.map(extractValue).map { $0.value },
@@ -1088,7 +1088,7 @@ extension TestSuite {
     self.test("\(testNamePrefix).suffix(from:)/semantics") {
       for test in suffixFromTests {
         let c = makeWrappedCollection(test.collection.map(OpaqueValue.init))
-        let index = c.index(c.startIndex, offsetBy: numericCast(test.start))
+        let index = c.index(c.startIndex, offsetBy: test.start)
         let result = c.suffix(from: index)
 
         expectEqualSequence(
@@ -1149,7 +1149,7 @@ extension TestSuite {
           into: slice,
           in: slice.index(
             slice.startIndex,
-            offsetBy: numericCast(test.numberToRemove)) ..< slice.endIndex
+            offsetBy: test.numberToRemove) ..< slice.endIndex
         )
         slice.removeFirst(test.numberToRemove)
         expectEqualSequence(
@@ -1387,7 +1387,7 @@ extension TestSuite {
           Optional<CollectionWithEquatableElement.Index>.self,
           &result)
         let zeroBasedIndex = result.map {
-          numericCast(c.distance(from: c.startIndex, to: $0)) as Int
+          c.distance(from: c.startIndex, to: $0)
         }
         expectEqual(
           test.expected,
@@ -1416,7 +1416,7 @@ extension TestSuite {
             extractValueFromEquatable(candidate).value == test.element.value
         })
         let zeroBasedIndex = result.map {
-          numericCast(c.distance(from: c.startIndex, to: $0)) as Int
+          c.distance(from: c.startIndex, to: $0)
         }
         expectEqual(
           test.expected,
@@ -1441,7 +1441,7 @@ extension TestSuite {
             into: slice,
           in: slice.startIndex
             ..< slice.index(
-              slice.endIndex, offsetBy: numericCast(-test.numberToRemove))
+              slice.endIndex, offsetBy: -test.numberToRemove)
         )
         let removedElement = slice.removeLast()
         expectEqual(
@@ -1486,7 +1486,7 @@ extension TestSuite {
           into: slice,
           in: slice.startIndex
             ..< slice.index(
-                  slice.endIndex, offsetBy: numericCast(-test.numberToRemove))
+                  slice.endIndex, offsetBy: -test.numberToRemove)
         )
         slice.removeLast(test.numberToRemove)
         expectEqualSequence(
@@ -1547,7 +1547,7 @@ extension TestSuite {
           into: slice,
           in: slice.startIndex
               ..< slice.index(
-                    slice.endIndex, offsetBy: numericCast(-test.numberToRemove))
+                    slice.endIndex, offsetBy: -test.numberToRemove)
         )
         let removedElement = slice.popLast()!
         expectEqual(
@@ -1591,7 +1591,7 @@ extension TestSuite {
         let index = c.startIndex
         expectCrashLater()
         _blackHole(
-          c.index(index, offsetBy: numericCast(-outOfBoundsIndexOffset)))
+          c.index(index, offsetBy: -outOfBoundsIndexOffset))
       }
 
       self.test("\(testNamePrefix).Index/OutOfBounds/Left/Empty") {
@@ -1599,7 +1599,7 @@ extension TestSuite {
         let index = c.startIndex
         expectCrashLater()
         _blackHole(
-          c.index(index, offsetBy: numericCast(-outOfBoundsIndexOffset)))
+          c.index(index, offsetBy: -outOfBoundsIndexOffset))
       }
     }
 
@@ -1616,7 +1616,7 @@ extension TestSuite {
         var index = c.startIndex
         expectCrashLater()
         index = c.index(
-          index, offsetBy: numericCast(-outOfBoundsSubscriptOffset))
+          index, offsetBy: -outOfBoundsSubscriptOffset)
         _blackHole(c[index])
       }
 
@@ -1627,7 +1627,7 @@ extension TestSuite {
         var index = c.startIndex
         expectCrashLater()
         index = c.index(
-          index, offsetBy: numericCast(-outOfBoundsSubscriptOffset))
+          index, offsetBy: -outOfBoundsSubscriptOffset)
         _blackHole(c[index])
       }
     }
@@ -1645,7 +1645,7 @@ extension TestSuite {
         var index = c.startIndex
         expectCrashLater()
         index = c.index(
-          index, offsetBy: numericCast(-outOfBoundsSubscriptOffset))
+          index, offsetBy: -outOfBoundsSubscriptOffset)
         _blackHole(c[index..<index])
       }
 
@@ -1656,7 +1656,7 @@ extension TestSuite {
         var index = c.startIndex
         expectCrashLater()
         index = c.index(
-          index, offsetBy: numericCast(-outOfBoundsSubscriptOffset))
+          index, offsetBy: -outOfBoundsSubscriptOffset)
         _blackHole(c[index..<index])
       }
     }
@@ -1884,7 +1884,7 @@ extension TestSuite {
       let d = c.distance(
         from: c.nthIndex(test.startOffset), to: c.nthIndex(test.endOffset))
       expectEqual(
-        numericCast(test.expectedDistance),
+        test.expectedDistance,
         d, stackTrace: SourceLocStack().with(test.loc))
     }
 
@@ -1901,7 +1901,7 @@ extension TestSuite {
       }
       let new = c.index(
         c.nthIndex(test.startOffset),
-        offsetBy: numericCast(test.distance))
+        offsetBy: test.distance)
 
       // Since the `nthIndex(offset:)` method performs the same operation
       // (i.e. advances `c.startIndex` by `test.distance`, it would be
@@ -1924,7 +1924,7 @@ extension TestSuite {
       if test.expectedOffset! >= max {
         expectCrashLater()
       }
-      c.formIndex(&new, offsetBy: numericCast(test.distance))
+      c.formIndex(&new, offsetBy: test.distance)
       expectEqual(test.expectedOffset!, extractValue(c[new]).value,
         stackTrace: SourceLocStack().with(test.loc))
     }
@@ -1940,7 +1940,7 @@ extension TestSuite {
       if test.expectedOffset! < 0 || !collectionIsBidirectional {
         expectCrashLater()
       }
-      let new = c.index(start, offsetBy: numericCast(test.distance))
+      let new = c.index(start, offsetBy: test.distance)
       expectEqual(test.expectedOffset!, extractValue(c[new]).value,
         stackTrace: SourceLocStack().with(test.loc))
     }
@@ -1955,7 +1955,7 @@ extension TestSuite {
       if test.expectedOffset! < 0 || !collectionIsBidirectional {
         expectCrashLater()
       }
-      c.formIndex(&new, offsetBy: numericCast(test.distance))
+      c.formIndex(&new, offsetBy: test.distance)
       expectEqual(test.expectedOffset!, extractValue(c[new]).value,
         stackTrace: SourceLocStack().with(test.loc))
     }
@@ -1968,7 +1968,7 @@ extension TestSuite {
         let limit = c.nthIndex(test.limit.unsafelyUnwrapped)
         let new = c.index(
           c.nthIndex(test.startOffset),
-          offsetBy: numericCast(test.distance),
+          offsetBy: test.distance,
           limitedBy: limit)
         if let expectedOffset = test.expectedOffset {
           expectEqual(c.nthIndex(expectedOffset), new!,
@@ -1986,7 +1986,7 @@ extension TestSuite {
         let c = toCollection(0..<20)
         let limit = c.nthIndex(test.limit.unsafelyUnwrapped)
         var new = c.nthIndex(test.startOffset)
-        let exact = c.formIndex(&new, offsetBy: numericCast(test.distance), limitedBy: limit)
+        let exact = c.formIndex(&new, offsetBy: test.distance, limitedBy: limit)
         if let expectedOffset = test.expectedOffset {
           expectEqual(c.nthIndex(expectedOffset), new,
             stackTrace: SourceLocStack().with(test.loc))
@@ -2009,7 +2009,7 @@ extension TestSuite {
       if collectionIsBidirectional {
         let new = c.index(
           c.nthIndex(test.startOffset),
-          offsetBy: numericCast(test.distance),
+          offsetBy: test.distance,
           limitedBy: limit)
         if let expectedOffset = test.expectedOffset {
           expectEqual(c.nthIndex(expectedOffset), new!,
@@ -2021,7 +2021,7 @@ extension TestSuite {
         expectCrashLater()
         _ = c.index(
           c.nthIndex(test.startOffset),
-          offsetBy: numericCast(test.distance),
+          offsetBy: test.distance,
           limitedBy: limit)
       }
     }
@@ -2037,7 +2037,7 @@ extension TestSuite {
       if collectionIsBidirectional {
         let exact = c.formIndex(
           &new,
-          offsetBy: numericCast(test.distance),
+          offsetBy: test.distance,
           limitedBy: limit)
         if let expectedOffset = test.expectedOffset {
           expectEqual(c.nthIndex(expectedOffset), new,
@@ -2049,7 +2049,7 @@ extension TestSuite {
         }
       } else {
         expectCrashLater()
-        _ = c.formIndex(&new, offsetBy: numericCast(test.distance), limitedBy: limit)
+        _ = c.formIndex(&new, offsetBy: test.distance, limitedBy: limit)
       }
     }
 
@@ -2133,7 +2133,7 @@ extension TestSuite {
       let d = c.distance(
         from: c.nthIndex(test.startOffset), to: c.nthIndex(test.endOffset))
       expectEqual(
-        numericCast(test.expectedDistance),
+        test.expectedDistance,
         d, stackTrace: SourceLocStack().with(test.loc))
     }
 
@@ -2150,7 +2150,7 @@ extension TestSuite {
       }
       let new = c.index(
         c.nthIndex(test.startOffset),
-        offsetBy: numericCast(test.distance))
+        offsetBy: test.distance)
 
       // Since the `nthIndex(offset:)` method performs the same operation
       // (i.e. advances `c.startIndex` by `test.distance`, it would be
@@ -2173,7 +2173,7 @@ extension TestSuite {
       if test.expectedOffset! >= max {
         expectCrashLater()
       }
-      c.formIndex(&new, offsetBy: numericCast(test.distance))
+      c.formIndex(&new, offsetBy: test.distance)
       expectEqual(test.expectedOffset!, extractValue(c[new]).value,
         stackTrace: SourceLocStack().with(test.loc))
     }
@@ -2189,7 +2189,7 @@ extension TestSuite {
       if test.expectedOffset! < 0 || !collectionIsBidirectional {
         expectCrashLater()
       }
-      let new = c.index(start, offsetBy: numericCast(test.distance))
+      let new = c.index(start, offsetBy: test.distance)
       expectEqual(test.expectedOffset!, extractValue(c[new]).value,
         stackTrace: SourceLocStack().with(test.loc))
     }
@@ -2204,7 +2204,7 @@ extension TestSuite {
       if test.expectedOffset! < 0 || !collectionIsBidirectional {
         expectCrashLater()
       }
-      c.formIndex(&new, offsetBy: numericCast(test.distance))
+      c.formIndex(&new, offsetBy: test.distance)
       expectEqual(test.expectedOffset!, extractValue(c[new]).value,
         stackTrace: SourceLocStack().with(test.loc))
     }
@@ -2217,7 +2217,7 @@ extension TestSuite {
         let limit = c.nthIndex(test.limit.unsafelyUnwrapped)
         let new = c.index(
           c.nthIndex(test.startOffset),
-          offsetBy: numericCast(test.distance),
+          offsetBy: test.distance,
           limitedBy: limit)
         if let expectedOffset = test.expectedOffset {
           expectEqual(c.nthIndex(expectedOffset), new!,
@@ -2235,7 +2235,7 @@ extension TestSuite {
         let c = toCollection(0..<20)
         let limit = c.nthIndex(test.limit.unsafelyUnwrapped)
         var new = c.nthIndex(test.startOffset)
-        let exact = c.formIndex(&new, offsetBy: numericCast(test.distance), limitedBy: limit)
+        let exact = c.formIndex(&new, offsetBy: test.distance, limitedBy: limit)
         if let expectedOffset = test.expectedOffset {
           expectEqual(c.nthIndex(expectedOffset), new,
             stackTrace: SourceLocStack().with(test.loc))
@@ -2258,7 +2258,7 @@ extension TestSuite {
       if collectionIsBidirectional {
         let new = c.index(
           c.nthIndex(test.startOffset),
-          offsetBy: numericCast(test.distance),
+          offsetBy: test.distance,
           limitedBy: limit)
         if let expectedOffset = test.expectedOffset {
           expectEqual(c.nthIndex(expectedOffset), new!,
@@ -2270,7 +2270,7 @@ extension TestSuite {
         expectCrashLater()
         _ = c.index(
           c.nthIndex(test.startOffset),
-          offsetBy: numericCast(test.distance),
+          offsetBy: test.distance,
           limitedBy: limit)
       }
     }
@@ -2286,7 +2286,7 @@ extension TestSuite {
       if collectionIsBidirectional {
         let exact = c.formIndex(
           &new,
-          offsetBy: numericCast(test.distance),
+          offsetBy: test.distance,
           limitedBy: limit)
         if let expectedOffset = test.expectedOffset {
           expectEqual(c.nthIndex(expectedOffset), new,
@@ -2298,7 +2298,7 @@ extension TestSuite {
         }
       } else {
         expectCrashLater()
-        _ = c.formIndex(&new, offsetBy: numericCast(test.distance), limitedBy: limit)
+        _ = c.formIndex(&new, offsetBy: test.distance, limitedBy: limit)
       }
     }
 
@@ -2382,7 +2382,7 @@ extension TestSuite {
       let d = c.distance(
         from: c.nthIndex(test.startOffset), to: c.nthIndex(test.endOffset))
       expectEqual(
-        numericCast(test.expectedDistance),
+        test.expectedDistance,
         d, stackTrace: SourceLocStack().with(test.loc))
     }
 
@@ -2399,7 +2399,7 @@ extension TestSuite {
       }
       let new = c.index(
         c.nthIndex(test.startOffset),
-        offsetBy: numericCast(test.distance))
+        offsetBy: test.distance)
 
       // Since the `nthIndex(offset:)` method performs the same operation
       // (i.e. advances `c.startIndex` by `test.distance`, it would be
@@ -2422,7 +2422,7 @@ extension TestSuite {
       if test.expectedOffset! >= max {
         expectCrashLater()
       }
-      c.formIndex(&new, offsetBy: numericCast(test.distance))
+      c.formIndex(&new, offsetBy: test.distance)
       expectEqual(test.expectedOffset!, extractValue(c[new]).value,
         stackTrace: SourceLocStack().with(test.loc))
     }
@@ -2438,7 +2438,7 @@ extension TestSuite {
       if test.expectedOffset! < 0 || !collectionIsBidirectional {
         expectCrashLater()
       }
-      let new = c.index(start, offsetBy: numericCast(test.distance))
+      let new = c.index(start, offsetBy: test.distance)
       expectEqual(test.expectedOffset!, extractValue(c[new]).value,
         stackTrace: SourceLocStack().with(test.loc))
     }
@@ -2453,7 +2453,7 @@ extension TestSuite {
       if test.expectedOffset! < 0 || !collectionIsBidirectional {
         expectCrashLater()
       }
-      c.formIndex(&new, offsetBy: numericCast(test.distance))
+      c.formIndex(&new, offsetBy: test.distance)
       expectEqual(test.expectedOffset!, extractValue(c[new]).value,
         stackTrace: SourceLocStack().with(test.loc))
     }
@@ -2466,7 +2466,7 @@ extension TestSuite {
         let limit = c.nthIndex(test.limit.unsafelyUnwrapped)
         let new = c.index(
           c.nthIndex(test.startOffset),
-          offsetBy: numericCast(test.distance),
+          offsetBy: test.distance,
           limitedBy: limit)
         if let expectedOffset = test.expectedOffset {
           expectEqual(c.nthIndex(expectedOffset), new!,
@@ -2484,7 +2484,7 @@ extension TestSuite {
         let c = toCollection(0..<20)
         let limit = c.nthIndex(test.limit.unsafelyUnwrapped)
         var new = c.nthIndex(test.startOffset)
-        let exact = c.formIndex(&new, offsetBy: numericCast(test.distance), limitedBy: limit)
+        let exact = c.formIndex(&new, offsetBy: test.distance, limitedBy: limit)
         if let expectedOffset = test.expectedOffset {
           expectEqual(c.nthIndex(expectedOffset), new,
             stackTrace: SourceLocStack().with(test.loc))
@@ -2507,7 +2507,7 @@ extension TestSuite {
       if collectionIsBidirectional {
         let new = c.index(
           c.nthIndex(test.startOffset),
-          offsetBy: numericCast(test.distance),
+          offsetBy: test.distance,
           limitedBy: limit)
         if let expectedOffset = test.expectedOffset {
           expectEqual(c.nthIndex(expectedOffset), new!,
@@ -2519,7 +2519,7 @@ extension TestSuite {
         expectCrashLater()
         _ = c.index(
           c.nthIndex(test.startOffset),
-          offsetBy: numericCast(test.distance),
+          offsetBy: test.distance,
           limitedBy: limit)
       }
     }
@@ -2535,7 +2535,7 @@ extension TestSuite {
       if collectionIsBidirectional {
         let exact = c.formIndex(
           &new,
-          offsetBy: numericCast(test.distance),
+          offsetBy: test.distance,
           limitedBy: limit)
         if let expectedOffset = test.expectedOffset {
           expectEqual(c.nthIndex(expectedOffset), new,
@@ -2547,7 +2547,7 @@ extension TestSuite {
         }
       } else {
         expectCrashLater()
-        _ = c.formIndex(&new, offsetBy: numericCast(test.distance), limitedBy: limit)
+        _ = c.formIndex(&new, offsetBy: test.distance, limitedBy: limit)
       }
     }
 

--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -167,7 +167,7 @@ if resiliencyChecks.subscriptOnOutOfBoundsIndicesBehavior != .none {
     var c = makeWrappedCollection([ 1010, 2020, 3030 ].map(OpaqueValue.init))
     var index = c.endIndex
     expectCrashLater()
-    index = c.index(index, offsetBy: numericCast(outOfBoundsSubscriptOffset))
+    index = c.index(index, offsetBy: outOfBoundsSubscriptOffset)
     c[index] = wrapValue(OpaqueValue(9999))
   }
 
@@ -175,7 +175,7 @@ if resiliencyChecks.subscriptOnOutOfBoundsIndicesBehavior != .none {
     var c = makeWrappedCollection([])
     var index = c.endIndex
     expectCrashLater()
-    index = c.index(index, offsetBy: numericCast(outOfBoundsSubscriptOffset))
+    index = c.index(index, offsetBy: outOfBoundsSubscriptOffset)
     c[index] = wrapValue(OpaqueValue(9999))
   }
 
@@ -192,10 +192,10 @@ if resiliencyChecks.subscriptOnOutOfBoundsIndicesBehavior != .none {
     print("\(elements)/sliceFromLeft=\(sliceFromLeft)/sliceFromRight=\(sliceFromRight)")
     let base = makeWrappedCollection(elements)
     let sliceStartIndex =
-      base.index(base.startIndex, offsetBy: numericCast(sliceFromLeft))
+      base.index(base.startIndex, offsetBy: sliceFromLeft)
     let sliceEndIndex = base.index(
       base.startIndex,
-      offsetBy: numericCast(elements.count - sliceFromRight))
+      offsetBy: elements.count - sliceFromRight)
     var slice = base[sliceStartIndex..<sliceEndIndex]
     expectType(C.SubSequence.self, &slice)
 
@@ -224,12 +224,12 @@ if resiliencyChecks.subscriptOnOutOfBoundsIndicesBehavior != .none {
       if sliceFromLeft == 0 { return }
       index = base.index(
         base.startIndex,
-        offsetBy: numericCast(sliceFromLeft - 1))
+        offsetBy: sliceFromLeft - 1)
     case .outOfRangeToTheRight:
       if sliceFromRight == 0 { return }
       index = base.index(
         base.startIndex,
-        offsetBy: numericCast(elements.count - sliceFromRight))
+        offsetBy: elements.count - sliceFromRight)
     case .baseEndIndex:
       index = base.endIndex
     case .sliceEndIndex:
@@ -342,10 +342,10 @@ if resiliencyChecks.subscriptRangeOnOutOfBoundsRangesBehavior != .none {
     print("\(elements)/sliceFromLeft=\(sliceFromLeft)/sliceFromRight=\(sliceFromRight)")
     let base = makeWrappedCollection(elements)
     let sliceStartIndex =
-      base.index(base.startIndex, offsetBy: numericCast(sliceFromLeft))
+      base.index(base.startIndex, offsetBy: sliceFromLeft)
     let sliceEndIndex = base.index(
       base.startIndex,
-      offsetBy: numericCast(elements.count - sliceFromRight))
+      offsetBy: elements.count - sliceFromRight)
     var slice = base[sliceStartIndex..<sliceEndIndex]
     expectType(C.SubSequence.self, &slice)
 
@@ -385,28 +385,28 @@ if resiliencyChecks.subscriptRangeOnOutOfBoundsRangesBehavior != .none {
       if sliceFromLeft == 0 { return }
       let index = base.index(
         base.startIndex,
-        offsetBy: numericCast(sliceFromLeft - 1))
+        offsetBy: sliceFromLeft - 1)
       bounds = index..<index
       break
     case .outOfRangeToTheLeftNonEmpty:
       if sliceFromLeft == 0 { return }
       let index = base.index(
         base.startIndex,
-        offsetBy: numericCast(sliceFromLeft - 1))
+        offsetBy: sliceFromLeft - 1)
       bounds = index..<sliceStartIndex
       break
     case .outOfRangeToTheRightEmpty:
       if sliceFromRight == 0 { return }
       let index = base.index(
         base.startIndex,
-        offsetBy: numericCast(elements.count - sliceFromRight + 1))
+        offsetBy: elements.count - sliceFromRight + 1)
       bounds = index..<index
       break
     case .outOfRangeToTheRightNonEmpty:
       if sliceFromRight == 0 { return }
       let index = base.index(
         base.startIndex,
-        offsetBy: numericCast(elements.count - sliceFromRight + 1))
+        offsetBy: elements.count - sliceFromRight + 1)
       bounds = sliceEndIndex..<index
       break
     case .outOfRangeBothSides:
@@ -415,11 +415,11 @@ if resiliencyChecks.subscriptRangeOnOutOfBoundsRangesBehavior != .none {
       bounds =
         base.index(
           base.startIndex,
-          offsetBy: numericCast(sliceFromLeft - 1))
+          offsetBy: sliceFromLeft - 1)
         ..<
         base.index(
           base.startIndex,
-          offsetBy: numericCast(elements.count - sliceFromRight + 1))
+          offsetBy: elements.count - sliceFromRight + 1)
       break
     case .baseEndIndex:
       if sliceFromRight == 0 { return }
@@ -427,8 +427,8 @@ if resiliencyChecks.subscriptRangeOnOutOfBoundsRangesBehavior != .none {
       break
     }
 
-    let count: Int = numericCast(
-      base.distance(from: bounds.lowerBound, to: bounds.upperBound))
+    let count: Int =
+      base.distance(from: bounds.lowerBound, to: bounds.upperBound)
     let newValues = makeWrappedCollection(Array(elements[0..<count]))
     let newSlice = newValues[...]
 
@@ -918,7 +918,7 @@ if resiliencyChecks.subscriptOnOutOfBoundsIndicesBehavior != .none {
     var c = makeWrappedCollection([ 1010, 2020, 3030 ].map(OpaqueValue.init))
     var index = c.startIndex
     expectCrashLater()
-    index = c.index(index, offsetBy: numericCast(-outOfBoundsSubscriptOffset))
+    index = c.index(index, offsetBy: -outOfBoundsSubscriptOffset)
     c[index] = wrapValue(OpaqueValue(9999))
   }
 
@@ -926,7 +926,7 @@ if resiliencyChecks.subscriptOnOutOfBoundsIndicesBehavior != .none {
     var c = makeWrappedCollection([])
     var index = c.startIndex
     expectCrashLater()
-    index = c.index(index, offsetBy: numericCast(-outOfBoundsSubscriptOffset))
+    index = c.index(index, offsetBy: -outOfBoundsSubscriptOffset)
     c[index] = wrapValue(OpaqueValue(9999))
   }
 }

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -971,7 +971,7 @@ self.test("\(testNamePrefix).reserveCapacity()/semantics") {
 
   for test in tests {
     var c = makeWrappedCollection(test.collection)
-    c.reserveCapacity(numericCast(test.requestedCapacity))
+    c.reserveCapacity(test.requestedCapacity)
     expectEqualSequence(
       test.collection.map { $0.value },
       c.map { extractValue($0).value },

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -106,7 +106,7 @@ extension TestSuite {
         var c = makeWrappedCollection(test.collection.map(OpaqueValue.init))
         let survivingIndices = _allIndices(
           into: c,
-          in: c.index(c.startIndex, offsetBy: numericCast(test.numberToRemove)) ..<
+          in: c.index(c.startIndex, offsetBy: test.numberToRemove) ..<
             c.endIndex
         )
         c.removeFirst(test.numberToRemove)
@@ -251,7 +251,7 @@ extension TestSuite {
         let survivingIndices = _allIndices(
           into: c,
           in: c.startIndex ..<
-            c.index(c.endIndex, offsetBy: numericCast(-test.numberToRemove))
+            c.index(c.endIndex, offsetBy: -test.numberToRemove)
         )
         c.removeLast(test.numberToRemove)
         expectEqualSequence(

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceInstance.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceInstance.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -77,7 +77,7 @@ public func checkSequence<
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   sameValue: (Expected.Element, Expected.Element) -> Bool
 ) where S.Element == Expected.Element {
-  let expectedCount: Int = numericCast(expected.count)
+  let expectedCount: Int = expected.count
   checkIterator(
     expected, sequence.makeIterator(), message(),
   stackTrace: stackTrace.pushIf(showFrame, file: file, line: line),
@@ -170,7 +170,7 @@ public func checkSequence<
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   sameValue: (Element, Element) -> Bool
 ) where S.Element == Element {
-  let expectedCount: Int = numericCast(expected.count)
+  let expectedCount: Int = expected.count
   checkIterator(
     expected, sequence.makeIterator(), message(),
     stackTrace: stackTrace.pushIf(showFrame, file: file, line: line),

--- a/stdlib/private/StdlibCollectionUnittest/RangeSelection.swift
+++ b/stdlib/private/StdlibCollectionUnittest/RangeSelection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -49,8 +49,8 @@ public enum RangeSelection {
       case .full:
         return c.startIndex..<c.endIndex
       case let .offsets(lowerBound, upperBound):
-        let start = c.index(c.startIndex, offsetBy: numericCast(lowerBound))
-        let end = c.index(c.startIndex, offsetBy: numericCast(upperBound))
+        let start = c.index(c.startIndex, offsetBy: lowerBound)
+        let end = c.index(c.startIndex, offsetBy: upperBound)
         return start..<end
     }
   }
@@ -78,8 +78,8 @@ public enum RangeSelection {
         let beforeEnd = c.index(c.startIndex, offsetBy: c.count - 1)
         return c.startIndex...beforeEnd
       case let .offsets(lowerBound, upperBound):
-        let start = c.index(c.startIndex, offsetBy: numericCast(lowerBound))
-        let end = c.index(c.startIndex, offsetBy: numericCast(upperBound))
+        let start = c.index(c.startIndex, offsetBy: lowerBound)
+        let end = c.index(c.startIndex, offsetBy: upperBound)
         return start...end
     }
   }

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -2831,7 +2831,7 @@ public func checkLosslessStringConvertible<Instance>(
 }
 
 public func nthIndex<C: Collection>(_ x: C, _ n: Int) -> C.Index {
-  return x.index(x.startIndex, offsetBy: numericCast(n))
+  return x.index(x.startIndex, offsetBy: n)
 }
 
 public func nth<C: Collection>(_ x: C, _ n: Int) -> C.Element {

--- a/test/Prototypes/Algorithms.swift
+++ b/test/Prototypes/Algorithms.swift
@@ -263,11 +263,11 @@ extension MutableCollection where Self: RandomAccessCollection {
     // If the difference moving forward and backward are relative primes,
     // the entire rotation will be completed in one cycle. Otherwise, repeat
     // cycle, moving the start point forward with each cycle.
-    let cycles = _gcd(numericCast(plus), -numericCast(minus))
+    let cycles = _gcd(plus, -minus)
 
     for cycle in 1...cycles {
       _rotateCycle(
-        start: index(startIndex, offsetBy: numericCast(cycle)),
+        start: index(startIndex, offsetBy: cycle),
         sourceOffsetForIndex: { $0 < pivot ? plus : minus })
     }
     return pivot
@@ -412,13 +412,13 @@ extension Concatenation : RandomAccessCollection
     case let .first(i):
       let d: Int = _base1.distance(from: i, to: _base1.endIndex)
       if n < d {
-        return Index(first: _base1.index(i, offsetBy: numericCast(n)))
+        return Index(first: _base1.index(i, offsetBy: n))
       } else {
         return Index(
-          second: _base2.index(_base2.startIndex, offsetBy: numericCast(n - d)))
+          second: _base2.index(_base2.startIndex, offsetBy: n - d))
       }
     case let .second(i):
-      return Index(second: _base2.index(i, offsetBy: numericCast(n)))
+      return Index(second: _base2.index(i, offsetBy: n))
     }
   }
 
@@ -427,14 +427,14 @@ extension Concatenation : RandomAccessCollection
   ) -> Index {
     switch i._position {
     case let .first(i):
-      return Index(first: _base1.index(i, offsetBy: -numericCast(n)))
+      return Index(first: _base1.index(i, offsetBy: -n))
     case let .second(i):
       let d: Int = _base2.distance(from: _base2.startIndex, to: i)
       if n <= d {
-        return Index(second: _base2.index(i, offsetBy: -numericCast(n)))
+        return Index(second: _base2.index(i, offsetBy: -n))
       } else {
         return Index(
-          first: _base1.index(_base1.endIndex, offsetBy: -numericCast(n - d)))
+          first: _base1.index(_base1.endIndex, offsetBy: -(n - d)))
       }
     }
   }

--- a/test/Prototypes/PatternMatching.swift
+++ b/test/Prototypes/PatternMatching.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -299,7 +299,7 @@ extension StaticString {
 extension Collection where Iterator.Element == UTF8.CodeUnit {
   var u8str : String {
     var a = Array<UTF8.CodeUnit>()
-    a.reserveCapacity(numericCast(count) + 1)
+    a.reserveCapacity(count + 1)
     a.append(contentsOf: self)
     a.append(0)
     return String(reflecting: String(cString: a))

--- a/validation-test/stdlib/Slice/Inputs/Template.swift.gyb
+++ b/validation-test/stdlib/Slice/Inputs/Template.swift.gyb
@@ -100,10 +100,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = ${test.base}(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -115,10 +115,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = ${test.base}(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -130,10 +130,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = ${test.base}(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableBidirectionalCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableBidirectionalCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableBidirectionalCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableBidirectionalCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableBidirectionalCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableBidirectionalCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableBidirectionalCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableBidirectionalCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRandomAccessCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRandomAccessCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRandomAccessCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRandomAccessCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRandomAccessCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRandomAccessCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRandomAccessCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRandomAccessCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableBidirectionalCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableBidirectionalCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableRandomAccessCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableRandomAccessCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = DefaultedRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = DefaultedRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = DefaultedRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableBidirectionalCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableBidirectionalCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableBidirectionalCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableBidirectionalCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableBidirectionalCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableBidirectionalCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableBidirectionalCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableBidirectionalCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRandomAccessCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRandomAccessCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRandomAccessCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRandomAccessCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRandomAccessCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRandomAccessCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRandomAccessCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRandomAccessCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalMutableRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableBidirectionalCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableBidirectionalCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableBidirectionalCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableBidirectionalCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableBidirectionalCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableBidirectionalCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalRangeReplaceableBidirectionalCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalRangeReplaceableCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableRandomAccessCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableRandomAccessCollection_FullWidth.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableRandomAccessCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableRandomAccessCollection_WithPrefix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableRandomAccessCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRangeReplaceableRandomAccessCollection_WithSuffix.swift
@@ -27,10 +27,10 @@ func makeCollection(elements: [OpaqueValue<Int>])
   let base = MinimalRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -42,10 +42,10 @@ func makeCollectionOfEquatable(elements: [MinimalEquatableValue])
   let base = MinimalRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 
@@ -57,10 +57,10 @@ func makeCollectionOfComparable(elements: [MinimalComparableValue])
   let base = MinimalRangeReplaceableRandomAccessCollection(elements: baseElements)
   let startIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count))
+    offsetBy: prefix.count)
   let endIndex = base.index(
     base.startIndex,
-    offsetBy: numericCast(prefix.count + elements.count))
+    offsetBy: prefix.count + elements.count)
   return Slice(base: base, bounds: startIndex..<endIndex)
 }
 

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -25,11 +25,11 @@ import ucrt
 extension Collection {
   internal func index(_nth n: Int) -> Index {
     precondition(n >= 0)
-    return index(startIndex, offsetBy: numericCast(n))
+    return index(startIndex, offsetBy: n)
   }
   internal func index(_nthLast n: Int) -> Index {
     precondition(n >= 0)
-    return index(endIndex, offsetBy: -numericCast(n))
+    return index(endIndex, offsetBy: -n)
   }
 }
 


### PR DESCRIPTION
The second commit is automatically generated from:
validation-test/stdlib/Slice/Inputs/Template.swift.gyb

Follow-up to: apple/swift#31653