### PR TITLE
ClangImporter: pass _WASI_EMULATED_MMAN when triple is WASI

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -600,6 +600,10 @@ importer::getNormalInvocationArguments(
       });
     }
 
+    if (triple.isOSWASI()) {
+      invocationArgStrs.insert(invocationArgStrs.end(), {"-D_WASI_EMULATED_MMAN"});
+    }
+
     if (triple.isOSWindows()) {
       switch (triple.getArch()) {
       default: llvm_unreachable("unsupported Windows architecture");


### PR DESCRIPTION
Defining `_WASI_EMULATED_MMAN` is [required when compiling with WASI libc](https://github.com/WebAssembly/wasi-libc/blob/575e1579a4ebaa6dccb884ca657188a92982af23/libc-top-half/musl/include/sys/mman.h#L2).

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Related to SR-9307.

(cc @compnerd)
