### PR TITLE
Use correct associated context for SIL parsing

### DIFF
--- a/include/swift/AST/SILGenRequests.h
+++ b/include/swift/AST/SILGenRequests.h
@@ -81,9 +81,6 @@ public:
   /// If the module or file contains SIL that needs parsing, returns the file
   /// to be parsed, or \c nullptr if parsing isn't required.
   SourceFile *getSourceFileToParse() const;
-
-  /// Whether the SIL is being emitted for a whole module.
-  bool isWholeModule() const;
 };
 
 void simple_display(llvm::raw_ostream &out, const SILGenDescriptor &d);

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -262,10 +262,6 @@ private:
   /// The indexed profile data to be used for PGO, or nullptr.
   std::unique_ptr<llvm::IndexedInstrProfReader> PGOReader;
 
-  /// True if this SILModule really contains the whole module, i.e.
-  /// optimizations can assume that they see the whole module.
-  bool wholeModule;
-
   /// The options passed into this SILModule.
   const SILOptions &Options;
 
@@ -281,8 +277,7 @@ private:
   llvm::SetVector<DeleteNotificationHandler*> NotificationHandlers;
 
   SILModule(ModuleDecl *M, Lowering::TypeConverter &TC,
-            const SILOptions &Options, const DeclContext *associatedDC,
-            bool wholeModule);
+            const SILOptions &Options, const DeclContext *associatedDC);
 
   SILModule(const SILModule&) = delete;
   void operator=(const SILModule&) = delete;
@@ -357,8 +352,7 @@ public:
   /// later parse SIL bodies directly into, without converting from an AST.
   static std::unique_ptr<SILModule>
   createEmptyModule(ModuleDecl *M, Lowering::TypeConverter &TC,
-                    const SILOptions &Options,
-                    bool WholeModule = false);
+                    const SILOptions &Options);
 
   /// Get the Swift module associated with this SIL module.
   ModuleDecl *getSwiftModule() const { return TheSwiftModule; }
@@ -382,7 +376,7 @@ public:
   /// Returns true if this SILModule really contains the whole module, i.e.
   /// optimizations can assume that they see the whole module.
   bool isWholeModule() const {
-    return wholeModule;
+    return isa<ModuleDecl>(AssociatedDeclContext);
   }
 
   bool isStdlibModule() const;

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -280,8 +280,6 @@ private:
   /// invalidation message is sent.
   llvm::SetVector<DeleteNotificationHandler*> NotificationHandlers;
 
-  // Intentionally marked private so that we need to use 'constructSIL()'
-  // to construct a SILModule.
   SILModule(ModuleDecl *M, Lowering::TypeConverter &TC,
             const SILOptions &Options, const DeclContext *associatedDC,
             bool wholeModule);
@@ -354,17 +352,6 @@ public:
 
   /// Erase a global SIL variable from the module.
   void eraseGlobalVariable(SILGlobalVariable *G);
-
-  /// Construct a SIL module from an AST module.
-  ///
-  /// The module will be constructed in the Raw stage. The provided AST module
-  /// should contain source files.
-  ///
-  /// If a source file is provided, SIL will only be emitted for decls in that
-  /// source file.
-  static std::unique_ptr<SILModule>
-  constructSIL(ModuleDecl *M, Lowering::TypeConverter &TC,
-               const SILOptions &Options, FileUnit *sf = nullptr);
 
   /// Create and return an empty SIL module that we can
   /// later parse SIL bodies directly into, without converting from an AST.

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -366,15 +366,15 @@ public:
   ASTContext &getASTContext() const;
   SourceManager &getSourceManager() const { return getASTContext().SourceMgr; }
 
-  /// Get the Swift DeclContext associated with this SIL module.
+  /// Get the Swift DeclContext associated with this SIL module. This is never
+  /// null.
   ///
   /// All AST declarations within this context are assumed to have been fully
   /// processed as part of generating this module. This allows certain passes
   /// to make additional assumptions about these declarations.
   ///
   /// If this is the same as TheSwiftModule, the entire module is being
-  /// compiled as a single unit. If this is null, no context-based assumptions
-  /// can be made.
+  /// compiled as a single unit.
   const DeclContext *getAssociatedContext() const {
     return AssociatedDeclContext;
   }

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1203,14 +1203,9 @@ static bool isFirstObjectFileInModule(IRGenModule &IGM) {
   if (IGM.getSILModule().isWholeModule())
     return IGM.IRGen.getPrimaryIGM() == &IGM;
 
-  const DeclContext *DC = IGM.getSILModule().getAssociatedContext();
-  if (!DC)
-    return false;
-
-  assert(!isa<ModuleDecl>(DC) && "that would be a whole module build");
-  assert(isa<FileUnit>(DC) && "compiling something smaller than a file?");
-  ModuleDecl *containingModule = cast<FileUnit>(DC)->getParentModule();
-  return containingModule->getFiles().front() == DC;
+  auto *file = cast<FileUnit>(IGM.getSILModule().getAssociatedContext());
+  auto *containingModule = file->getParentModule();
+  return containingModule->getFiles().front() == file;
 }
 
 void IRGenModule::emitAutolinkInfo() {

--- a/lib/SIL/IR/SIL.cpp
+++ b/lib/SIL/IR/SIL.cpp
@@ -127,12 +127,6 @@ bool SILModule::isTypeMetadataAccessible(CanType type) {
     // Private declarations are inaccessible from different files unless
     // this is WMO and we're in the same module.
     case FormalLinkage::Private: {
-      // The only time we don't have an associated DC is in the
-      // integrated REPL, where we also don't have a concept of other
-      // source files within the current module.
-      if (!AssociatedDeclContext)
-        return (decl->getModuleContext() != getSwiftModule());
-
       // The associated DC should be either a SourceFile or, in WMO mode,
       // a ModuleDecl.  In the WMO modes, IRGen will ensure that private
       // declarations are usable throughout the module.  Therefore, in

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -93,12 +93,11 @@ class SILModule::SerializationCallback final
 };
 
 SILModule::SILModule(ModuleDecl *SwiftModule, TypeConverter &TC,
-                     const SILOptions &Options, const DeclContext *associatedDC,
-                     bool wholeModule)
+                     const SILOptions &Options, const DeclContext *associatedDC)
     : TheSwiftModule(SwiftModule),
       AssociatedDeclContext(associatedDC),
-      Stage(SILStage::Raw), wholeModule(wholeModule), Options(Options),
-      serialized(false), SerializeSILAction(), Types(TC) {
+      Stage(SILStage::Raw), Options(Options), serialized(false),
+      SerializeSILAction(), Types(TC) {
   assert(AssociatedDeclContext);
 
   // We always add the base SILModule serialization callback.
@@ -125,10 +124,9 @@ SILModule::~SILModule() {
 }
 
 std::unique_ptr<SILModule>
-SILModule::createEmptyModule(ModuleDecl *M, TypeConverter &TC, const SILOptions &Options,
-                             bool WholeModule) {
-  return std::unique_ptr<SILModule>(
-      new SILModule(M, TC, Options, M, WholeModule));
+SILModule::createEmptyModule(ModuleDecl *M, TypeConverter &TC,
+                             const SILOptions &Options) {
+  return std::unique_ptr<SILModule>(new SILModule(M, TC, Options, M));
 }
 
 ASTContext &SILModule::getASTContext() const {

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -99,6 +99,8 @@ SILModule::SILModule(ModuleDecl *SwiftModule, TypeConverter &TC,
       AssociatedDeclContext(associatedDC),
       Stage(SILStage::Raw), wholeModule(wholeModule), Options(Options),
       serialized(false), SerializeSILAction(), Types(TC) {
+  assert(AssociatedDeclContext);
+
   // We always add the base SILModule serialization callback.
   std::unique_ptr<DeserializationNotificationHandler> callback(
       new SILModule::SerializationCallback());

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -115,8 +115,8 @@ ParseSILModuleRequest::evaluate(Evaluator &evaluator,
   auto bufferID = SF->getBufferID();
   assert(bufferID);
 
-  auto *mod = SF->getParentModule();
-  auto silMod = SILModule::createEmptyModule(mod, desc.conv, desc.opts);
+  auto silMod = SILModule::createEmptyModule(desc.context, desc.conv,
+                                             desc.opts);
   SILParserState parserState(silMod.get());
   Parser parser(*bufferID, *SF, parserState.Impl.get());
   PrettyStackTraceParser StackTrace(parser);
@@ -125,7 +125,7 @@ ParseSILModuleRequest::evaluate(Evaluator &evaluator,
   if (hadError) {
     // The rest of the SIL pipeline expects well-formed SIL, so if we encounter
     // a parsing error, just return an empty SIL module.
-    return SILModule::createEmptyModule(mod, desc.conv, desc.opts);
+    return SILModule::createEmptyModule(desc.context, desc.conv, desc.opts);
   }
   return silMod;
 }

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -116,8 +116,7 @@ ParseSILModuleRequest::evaluate(Evaluator &evaluator,
   assert(bufferID);
 
   auto *mod = SF->getParentModule();
-  auto silMod = SILModule::createEmptyModule(mod, desc.conv, desc.opts,
-                                             desc.isWholeModule());
+  auto silMod = SILModule::createEmptyModule(mod, desc.conv, desc.opts);
   SILParserState parserState(silMod.get());
   Parser parser(*bufferID, *SF, parserState.Impl.get());
   PrettyStackTraceParser StackTrace(parser);
@@ -126,8 +125,7 @@ ParseSILModuleRequest::evaluate(Evaluator &evaluator,
   if (hadError) {
     // The rest of the SIL pipeline expects well-formed SIL, so if we encounter
     // a parsing error, just return an empty SIL module.
-    return SILModule::createEmptyModule(mod, desc.conv, desc.opts,
-                                        desc.isWholeModule());
+    return SILModule::createEmptyModule(mod, desc.conv, desc.opts);
   }
   return silMod;
 }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1868,7 +1868,7 @@ SILGenSourceFileRequest::evaluate(Evaluator &evaluator,
   auto *unit = desc.context.get<FileUnit *>();
   auto *mod = unit->getParentModule();
   auto M = std::unique_ptr<SILModule>(
-      new SILModule(mod, desc.conv, desc.opts, unit, /*wholeModule*/ false));
+      new SILModule(mod, desc.conv, desc.opts, unit));
   SILGenModuleRAII scope(*M, mod);
 
   if (auto *file = dyn_cast<SourceFile>(unit)) {
@@ -1891,7 +1891,7 @@ SILGenWholeModuleRequest::evaluate(Evaluator &evaluator,
 
   auto *mod = desc.context.get<ModuleDecl *>();
   auto M = std::unique_ptr<SILModule>(
-      new SILModule(mod, desc.conv, desc.opts, mod, /*wholeModule*/ true));
+      new SILModule(mod, desc.conv, desc.opts, mod));
   SILGenModuleRAII scope(*M, mod);
 
   for (auto file : mod->getFiles()) {

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1867,8 +1867,7 @@ SILGenSourceFileRequest::evaluate(Evaluator &evaluator,
 
   auto *unit = desc.context.get<FileUnit *>();
   auto *mod = unit->getParentModule();
-  auto M = std::unique_ptr<SILModule>(
-      new SILModule(mod, desc.conv, desc.opts, unit));
+  auto M = SILModule::createEmptyModule(desc.context, desc.conv, desc.opts);
   SILGenModuleRAII scope(*M, mod);
 
   if (auto *file = dyn_cast<SourceFile>(unit)) {
@@ -1890,8 +1889,7 @@ SILGenWholeModuleRequest::evaluate(Evaluator &evaluator,
   }
 
   auto *mod = desc.context.get<ModuleDecl *>();
-  auto M = std::unique_ptr<SILModule>(
-      new SILModule(mod, desc.conv, desc.opts, mod));
+  auto M = SILModule::createEmptyModule(desc.context, desc.conv, desc.opts);
   SILGenModuleRAII scope(*M, mod);
 
   for (auto file : mod->getFiles()) {

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4099,8 +4099,6 @@ static bool isVerbatimNullableTypeInC(SILModule &M, Type ty) {
 
   // Other types like UnsafePointer can also be nullable.
   const DeclContext *DC = M.getAssociatedContext();
-  if (!DC)
-    DC = M.getSwiftModule();
   ty = OptionalType::get(ty);
   return ty->isTriviallyRepresentableIn(ForeignLanguage::C, DC);
 }

--- a/lib/SILGen/SILGenRequests.cpp
+++ b/lib/SILGen/SILGenRequests.cpp
@@ -65,10 +65,6 @@ ArrayRef<FileUnit *> SILGenDescriptor::getFiles() const {
   return llvm::makeArrayRef(*context.getAddrOfPtr1());
 }
 
-bool SILGenDescriptor::isWholeModule() const {
-  return context.is<ModuleDecl *>();
-}
-
 SourceFile *SILGenDescriptor::getSourceFileToParse() const {
 #ifndef NDEBUG
   auto sfCount = llvm::count_if(getFiles(), [](FileUnit *file) {

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -285,8 +285,6 @@ static bool isDefaultCaseKnown(ClassHierarchyAnalysis *CHA,
   auto *Method = CMI->getMember().getAbstractFunctionDecl();
   assert(Method && "not a function");
 
-  const DeclContext *DC = AI.getModule().getAssociatedContext();
-
   if (CD->isFinal())
     return true;
 
@@ -295,13 +293,8 @@ static bool isDefaultCaseKnown(ClassHierarchyAnalysis *CHA,
   if (CD->checkAncestry(AncestryFlags::ObjC))
     return false;
 
-  // Without an associated context we cannot perform any
-  // access-based optimizations.
-  if (!DC)
-    return false;
-
   // Only handle classes defined within the SILModule's associated context.
-  if (!CD->isChildContextOf(DC))
+  if (!CD->isChildContextOf(AI.getModule().getAssociatedContext()))
     return false;
 
   if (!CD->hasAccess())

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -89,13 +89,6 @@ static bool isEffectivelyFinalMethod(FullApplySite applySite, CanType classType,
   if (cd && cd->isFinal())
     return true;
 
-  const DeclContext *dc = applySite.getModule().getAssociatedContext();
-
-  // Without an associated context we cannot perform any
-  // access-based optimizations.
-  if (!dc)
-    return false;
-
   auto *cmi = cast<MethodInst>(applySite.getCallee());
 
   if (!calleesAreStaticallyKnowable(applySite.getModule(), cmi->getMember()))
@@ -149,18 +142,11 @@ static bool isEffectivelyFinalMethod(FullApplySite applySite, CanType classType,
 ///   it is a whole-module compilation.
 static bool isKnownFinalClass(ClassDecl *cd, SILModule &module,
                               ClassHierarchyAnalysis *cha) {
-  const DeclContext *dc = module.getAssociatedContext();
-
   if (cd->isFinal())
     return true;
 
-  // Without an associated context we cannot perform any
-  // access-based optimizations.
-  if (!dc)
-    return false;
-
   // Only handle classes defined within the SILModule's associated context.
-  if (!cd->isChildContextOf(dc))
+  if (!cd->isChildContextOf(module.getAssociatedContext()))
     return false;
 
   if (!cd->hasAccess())

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1815,12 +1815,8 @@ bool swift::calleesAreStaticallyKnowable(SILModule &module, SILDeclRef decl) {
 /// knowable based on the Decl and the compilation mode?
 bool swift::calleesAreStaticallyKnowable(SILModule &module,
                                          AbstractFunctionDecl *afd) {
-  const DeclContext *assocDC = module.getAssociatedContext();
-  if (!assocDC)
-    return false;
-
   // Only handle members defined within the SILModule's associated context.
-  if (!afd->isChildContextOf(assocDC))
+  if (!afd->isChildContextOf(module.getAssociatedContext()))
     return false;
 
   if (afd->isDynamic()) {
@@ -1859,12 +1855,8 @@ bool swift::calleesAreStaticallyKnowable(SILModule &module,
 // FIXME: Merge this with calleesAreStaticallyKnowable above
 bool swift::calleesAreStaticallyKnowable(SILModule &module,
                                          EnumElementDecl *eed) {
-  const DeclContext *assocDC = module.getAssociatedContext();
-  if (!assocDC)
-    return false;
-
   // Only handle members defined within the SILModule's associated context.
-  if (!eed->isChildContextOf(assocDC))
+  if (!eed->isChildContextOf(module.getAssociatedContext()))
     return false;
 
   if (eed->isDynamic()) {

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2645,9 +2645,6 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
   // Go through all SILVTables in SILMod and write them if we should
   // serialize everything.
   // FIXME: Resilience: could write out vtable for fragile classes.
-  const DeclContext *assocDC = SILMod->getAssociatedContext();
-  assert(assocDC && "cannot serialize SIL without an associated DeclContext");
-  (void)assocDC;
   for (const SILVTable &vt : SILMod->getVTables()) {
     if ((ShouldSerializeAll || vt.isSerialized()) &&
         SILMod->shouldSerializeEntitiesAssociatedWithDeclContext(vt.getClass()))

--- a/test/IRGen/multi_file_resilience.swift
+++ b/test/IRGen/multi_file_resilience.swift
@@ -7,6 +7,11 @@
 
 // RUN: %target-swift-frontend -module-name main -I %t -emit-ir -primary-file %s %S/Inputs/OtherModule.swift | %FileCheck %s -DINT=i%target-ptrsize
 
+// Check that we correctly handle resilience when parsing as SIL + SIB.
+// RUN: %target-swift-frontend -emit-sib -module-name main %S/Inputs/OtherModule.swift -I %t -o %t/other.sib
+// RUN: %target-swift-frontend -emit-silgen -module-name main -primary-file %s %S/Inputs/OtherModule.swift -I %t -o %t/main.sil
+// RUN: %target-swift-frontend -emit-ir -module-name main -primary-file %t/main.sil %t/other.sib -I %t | %FileCheck %s -DINT=i%target-ptrsize
+
 // This is a single-module version of the test case in
 // multi_module_resilience.
 // rdar://39763787


### PR DESCRIPTION
Adjust `SILModule::createEmptyModule` to accept a `FileUnit` or `ModuleDecl`, and pass the corresponding context for SIL generation and parsing. This change means that SIL parsing will now correctly use a `SourceFile` associated context when in single-file mode.

In addition, tighten up some invariants around `SILModule` construction.