### PR TITLE
Driver: link only static libraries for WebAssembly

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1466,9 +1466,14 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
       break;
 
     case options::OPT_emit_library:
-      OI.LinkAction = Args.hasArg(options::OPT_static) ?
-                      LinkKind::StaticLibrary :
-                      LinkKind::DynamicLibrary;
+      // WebAssembly only supports static libraries
+      if (TC.getTriple().isOSBinFormatWasm()) {
+        OI.LinkAction = LinkKind::StaticLibrary;
+      } else {
+        OI.LinkAction = Args.hasArg(options::OPT_static) ?
+                        LinkKind::StaticLibrary :
+                        LinkKind::DynamicLibrary;
+      }
       OI.CompilerOutputType = file_types::TY_Object;
       break;
 


### PR DESCRIPTION
WebAssembly doesn't support dynamic linking currently (at least not without direct support from a WebAssembly host, [which is not standardized at all](https://webassembly.org/docs/dynamic-linking/)). Thus, the Swift driver shouldn't attempt to link dynamic libraries when `-emit-library` is passed.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Related to SR-9307.

(cc @compnerd)
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
