### PR TITLE
ClangImporter: support __isoc_va_list for WASI/musl

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -787,7 +787,7 @@ namespace {
         }
 
         static const llvm::StringLiteral vaListNames[] = {
-          "va_list", "__gnuc_va_list", "__va_list"
+          "va_list", "__gnuc_va_list", "__isoc_va_list", "__va_list"
         };
 
         ImportHint hint = ImportHint::None;

--- a/lib/ClangImporter/MappedTypes.def
+++ b/lib/ClangImporter/MappedTypes.def
@@ -128,6 +128,7 @@ MAP_STDLIB_TYPE("u_int64_t", UnsignedInt, 64, "UInt64", false, DoNothing)
 // There's an explicit workaround in ImportType.cpp's VisitDecayedType for that.
 MAP_STDLIB_TYPE("va_list", VaList, 0, "CVaListPointer", false, DoNothing)
 MAP_STDLIB_TYPE("__gnuc_va_list", VaList, 0, "CVaListPointer", false, DoNothing)
+MAP_STDLIB_TYPE("__isoc_va_list", VaList, 0, "CVaListPointer", false, DoNothing)
 MAP_STDLIB_TYPE("__va_list", VaList, 0, "CVaListPointer", false, DoNothing)
 
 // libkern/OSTypes.h types.

--- a/test/Interop/C/va_list/Inputs/module.modulemap
+++ b/test/Interop/C/va_list/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module ImportCVAList {
+  header "va_list.h"
+  export *
+}

--- a/test/Interop/C/va_list/Inputs/va_list.h
+++ b/test/Interop/C/va_list/Inputs/va_list.h
@@ -1,0 +1,10 @@
+#include <stdarg.h>
+
+typedef va_list __gnuc_va_list;
+typedef va_list __isoc_va_list;
+typedef va_list __va_list;
+
+va_list va;
+__gnuc_va_list gnu;
+__isoc_va_list isoC;
+__va_list underscore;

--- a/test/Interop/C/va_list/va_list.swift
+++ b/test/Interop/C/va_list/va_list.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=ImportCVAList -I %S/Inputs -source-filename=x | %FileCheck %s
+
+// CHECK: var va: CVaListPointer
+// CHECK: var gnu: CVaListPointer
+// CHECK: var isoC: CVaListPointer
+// CHECK: var underscore: CVaListPointer


### PR DESCRIPTION
`__isoc_va_list` is used in musl and WASI libc, as the latter is based on musl. It would be great to support this variant in ClangImport to improve support for those environments.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Related to SR-9307.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
