### PR TITLE
Runtime: define get_return_address for WebAssembly

### DIFF
--- a/stdlib/public/runtime/Exclusivity.cpp
+++ b/stdlib/public/runtime/Exclusivity.cpp
@@ -38,6 +38,8 @@
 #elif _MSC_VER
 #include <intrin.h>
 #define get_return_address() _ReturnAddress()
+#elif defined(__wasi__)
+#define get_return_address() ((void*) 0)
 #else
 #error missing implementation for get_return_address
 #define get_return_address() ((void*) 0)


### PR DESCRIPTION
<!-- What's in this pull request? -->
WebAssembly/WASI doesn't support stack traces and return addresses. To make it possible to compile exclusivity code for this platform, it seems to make the most sense for the `get_return_address()` to return a zero value. Since it's only used for diagnostics, this shouldn't cause any issues when targeting WASI.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Related to SR-9307.

(cc @compnerd)
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
