### PR TITLE
test: enable WebAssembly/WASI in lit.cfg

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information
@@ -297,6 +297,8 @@ config.swift_refactor = inferSwiftBinary('swift-refactor')
 config.swift_demangle_yamldump = inferSwiftBinary('swift-demangle-yamldump')
 config.benchmark_o = inferSwiftBinary('Benchmark_O')
 config.benchmark_driver = inferSwiftBinary('Benchmark_Driver')
+config.wasmer = inferSwiftBinary('wasmer')
+config.wasm_ld = inferSwiftBinary('wasm-ld')
 
 config.swift_utils = make_path(config.swift_src_root, 'utils')
 config.line_directive = make_path(config.swift_utils, 'line-directive')
@@ -1339,6 +1341,73 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         tools_directory,
         '-L%s' % make_path(test_resource_dir, config.target_sdk_name)])
     # The Swift interpreter is not available when targeting Android.
+    config.available_features.discard('swift_interpreter')
+elif run_os == 'wasi':
+    lit_config.note("Testing WebAssembly/WASI " + config.variant_triple)
+
+    config.target_object_format = "wasm"
+    config.target_shared_library_prefix = 'lib'
+    config.target_shared_library_suffix = ".a"
+    config.target_sdk_name = "wasi"
+    config.target_runtime = "native"
+
+    config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
+
+    config.target_build_swift = ' '.join([
+        config.swiftc,
+        '-target', config.variant_triple,
+        '-Xcc', '--sysroot=%s' % config.variant_sdk,
+        '-Xclang-linker', '--sysroot=%s' % config.variant_sdk,
+        '-toolchain-stdlib-rpath', resource_dir_opt, 
+        mcp_opt, config.swift_test_options,
+        config.swift_driver_test_options, swift_execution_tests_extra_flags])
+    config.target_codesign = "echo"
+    config.target_build_swift_dylib = (
+        "%s -parse-as-library -emit-library -o '\\1'"
+        % (config.target_build_swift))
+    config.target_add_rpath = ''
+    config.target_swift_frontend = ' '.join([
+        config.swift,
+        '-frontend',
+        '-target', config.variant_triple,
+        '-Xcc', '--sysroot=%s' % config.variant_sdk,
+        resource_dir_opt, mcp_opt,
+        config.swift_test_options, config.swift_frontend_test_options])
+    subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
+    subst_target_swift_frontend_mock_sdk_after = ""
+    config.target_run = '%s run --backend cranelift --' % config.wasmer
+    if 'interpret' in lit_config.params:
+        use_interpreter_for_simple_runs()
+    config.target_sil_opt = (
+        '%s -target %s %s %s %s' %
+        (config.sil_opt, config.variant_triple, resource_dir_opt, mcp_opt, config.sil_test_options))
+    config.target_swift_symbolgraph_extract = ' '.join([
+        config.swift_symbolgraph_extract,
+        '-target', config.variant_triple,
+        mcp_opt])
+    config.target_swift_ide_test = (
+        '%s -target %s %s %s %s' %
+        (config.swift_ide_test, config.variant_triple, resource_dir_opt,
+         mcp_opt, ccp_opt))
+    subst_target_swift_ide_test_mock_sdk = config.target_swift_ide_test
+    subst_target_swift_ide_test_mock_sdk_after = ""
+    config.target_swiftc_driver = (
+        "%s -target %s -toolchain-stdlib-rpath %s %s" %
+        (config.swiftc, config.variant_triple, resource_dir_opt, mcp_opt))
+    config.target_swift_modulewrap = (
+        '%s -modulewrap -target %s' %
+        (config.swiftc, config.variant_triple))
+    config.target_swift_emit_pcm = (
+        '%s -emit-pcm -target %s' %
+        (config.swiftc, config.variant_triple))
+    config.target_clang = (
+        "%s -target %s %s -fobjc-runtime=ios-5.0" %
+        (config.clang, config.variant_triple, clang_mcp_opt))
+    config.target_ld = (
+        "%s -L%r" % 
+        (config.wasm_ld, make_path(test_resource_dir, config.target_sdk_name)))
+
+    # The Swift interpreter is not available when targeting WebAssembly/WASI.
     config.available_features.discard('swift_interpreter')
 
 else:


### PR DESCRIPTION
<!-- What's in this pull request? -->
Enable WASI environment and `wasm32` architecture in `lit.cfg`. It uses `wasmer` as the test runner, which can be easily installed on macOS with `brew install wasmer`. After a quick comparison, `wasmer` is the fastest one, we previously tried `wasmtime` before replacing it with `wasmer` in swiftwasm/swift#451, which made CI run faster in our fork PRs.

As there's no official support for the WebAssembly target and no Jenkins nodes set up, this will serve for local testing, but I would hope that we could have a Jenkins node set up at some point.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Related to SR-9307.

(cc @DougGregor @compnerd @kateinoigakukun)
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
