### PR TITLE
[semantic-arcopts] Teach optimizer how to convert load [copy] -> load_borrow from inout parameters that only have writes that do not overlap with the lifetime region of the load [copy]'s result.

### DIFF
--- a/include/swift/SIL/LinearLifetimeChecker.h
+++ b/include/swift/SIL/LinearLifetimeChecker.h
@@ -79,6 +79,14 @@ public:
       SILValue value, Operand *consumingUse,
       function_ref<void(SILBasicBlock::iterator insertPt)> visitor);
 
+  /// Given a linear lifetime defined by \p value and \p consumingUses, return
+  /// true if all uses in \p usesToTest are strictly not contained within the
+  /// region where the Linear Lifetime defined by \p value and \p consumingUses
+  /// is live. Otherwise, returns false.
+  bool usesNotContainedWithinLifetime(SILValue value,
+                                      ArrayRef<Operand *> consumingUses,
+                                      ArrayRef<Operand *> usesToTest);
+
 private:
   /// Returns true if:
   ///
@@ -108,7 +116,9 @@ private:
   Error checkValueImpl(
       SILValue value, ArrayRef<Operand *> consumingUses,
       ArrayRef<Operand *> nonConsumingUses, ErrorBuilder &errorBuilder,
-      Optional<function_ref<void(SILBasicBlock *)>> leakingBlockCallback);
+      Optional<function_ref<void(SILBasicBlock *)>> leakingBlockCallback,
+      Optional<function_ref<void(Operand *)>>
+          nonConsumingUsesOutsideLifetimeCallback);
 };
 
 } // namespace swift

--- a/lib/SIL/Verifier/LinearLifetimeCheckerPrivate.h
+++ b/lib/SIL/Verifier/LinearLifetimeCheckerPrivate.h
@@ -25,6 +25,7 @@ struct LLVM_LIBRARY_VISIBILITY LinearLifetimeChecker::ErrorBehaviorKind {
     PrintMessage = 2,
     Assert = 4,
     ReturnFalseOnLeak = 8,
+    StoreNonConsumingUsesOutsideLifetime = 16,
     PrintMessageAndReturnFalse = PrintMessage | ReturnFalse,
     PrintMessageAndAssert = PrintMessage | Assert,
     ReturnFalseOnLeakAssertOtherwise = ReturnFalseOnLeak | Assert,
@@ -32,6 +33,14 @@ struct LLVM_LIBRARY_VISIBILITY LinearLifetimeChecker::ErrorBehaviorKind {
 
   ErrorBehaviorKind() : Value(Invalid) {}
   ErrorBehaviorKind(inner_t Inner) : Value(Inner) { assert(Value != Invalid); }
+  ErrorBehaviorKind(unsigned Inner) : Value(inner_t(Inner)) {
+    assert(Value != Invalid);
+  }
+
+  bool shouldStoreNonConsumingUsesOutsideLifetime() const {
+    assert(Value != Invalid);
+    return Value & StoreNonConsumingUsesOutsideLifetime;
+  }
 
   bool shouldAssert() const {
     assert(Value != Invalid);
@@ -60,12 +69,14 @@ class LLVM_LIBRARY_VISIBILITY LinearLifetimeChecker::Error {
   bool foundUseAfterFree = false;
   bool foundLeak = false;
   bool foundOverConsume = false;
+  bool foundUseOutsideOfLifetime = false;
 
 public:
   Error() {}
 
   bool getFoundError() const {
-    return foundUseAfterFree || foundLeak || foundOverConsume;
+    return foundUseAfterFree || foundLeak || foundOverConsume ||
+           foundUseOutsideOfLifetime;
   }
 
   bool getFoundLeak() const { return foundLeak; }
@@ -73,6 +84,10 @@ public:
   bool getFoundUseAfterFree() const { return foundUseAfterFree; }
 
   bool getFoundOverConsume() const { return foundOverConsume; }
+
+  bool getFoundUseOutsideOfLifetime() const {
+    return foundUseOutsideOfLifetime;
+  }
 };
 
 class LLVM_LIBRARY_VISIBILITY LinearLifetimeChecker::ErrorBuilder {
@@ -160,6 +175,15 @@ public:
   bool
   handleMalformedSIL(llvm::function_ref<void()> &&messagePrinterFunc) const {
     return handleError(std::move(messagePrinterFunc));
+  }
+
+  /// Handle a case where we either found a use-after-free due to a
+  /// non-consuming use after our lifetime has ended /or/ if we found a use
+  /// before def of a non consuming value.
+  void
+  handleUseOutsideOfLifetime(llvm::function_ref<void()> &&messagePrinterFunc) {
+    error->foundUseOutsideOfLifetime = true;
+    handleError(std::move(messagePrinterFunc));
   }
 
 private:

--- a/test/SIL/ownership-verifier/arguments.sil
+++ b/test/SIL/ownership-verifier/arguments.sil
@@ -237,7 +237,7 @@ bb5:
 // Make sure that we only flag the end_borrow "use after free" in bb2.
 //
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'bad_order'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
 // CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject
@@ -273,7 +273,7 @@ bb5:
 }
 
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'bad_order_add_a_level'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
 // CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject
@@ -329,9 +329,8 @@ bb5:
 // from uses that are not reachable from the definition of the value.
 //
 // CHECK-LABEL: Error#: 5. Begin Error in Function: 'bad_order_add_a_level'
-// CHECK: Found outside of lifetime uses!
+// CHECK: Found outside of lifetime use!
 // CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %13, %9, %7
-// CHECK: User List:
 // CHECK: User:  %9 = begin_borrow %5 : $Builtin.NativeObject    // user: %10
 // CHECK: Block: bb3
 // CHECK: Error#: 5. End Error in Function: 'bad_order_add_a_level'
@@ -386,7 +385,7 @@ bb7:
 //
 //
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'bad_order_add_a_level_2'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %22, %16, %12, %6, %3
 // CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject           // id: %6
 // CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %7
@@ -394,7 +393,7 @@ bb7:
 // CHECK: Error#: 0. End Error in Function: 'bad_order_add_a_level_2'
 //
 // CHECK-LABEL: Error#: 1. Begin Error in Function: 'bad_order_add_a_level_2'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %22, %16, %12, %6, %3
 // CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject           // id: %12
 // CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %13
@@ -402,7 +401,7 @@ bb7:
 // CHECK: Error#: 1. End Error in Function: 'bad_order_add_a_level_2'
 //
 // CHECK-LABEL: Error#: 2. Begin Error in Function: 'bad_order_add_a_level_2'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %22, %16, %12, %6, %3
 // CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject           // id: %16
 // CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %17
@@ -435,7 +434,7 @@ bb7:
 // CHECK: Error#: 4. End Error in Function: 'bad_order_add_a_level_2'
 //
 // CHECK-LABEL: Error#: 5. Begin Error in Function: 'bad_order_add_a_level_2'
-// CHECK-NEXT: Found use after free?!
+// CHECK-NEXT: Found outside of lifetime use?!
 // CHECK-NEXT: Value: %5 = argument of bb2 : $Builtin.NativeObject
 // CHECK-NEXT: Consuming User:   end_borrow %5 : $Builtin.NativeObject
 // CHECK-NEXT: Non Consuming User:   end_borrow %11 : $Builtin.NativeObject
@@ -614,12 +613,9 @@ bb3:
 // begin_borrow.
 //
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_loop_carry_implicitregularusers_do_not_loop_carry'
-// CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
-// CHECK-NEXT: Value:   %8 = copy_value %4 : $Builtin.NativeObject      // users: %12, %9
-// CHECK-NEXT:     Remaining Users:
-// CHECK-NEXT: User:   %9 = begin_borrow %8 : $Builtin.NativeObject    // user: %12
-// CHECK-NEXT: User:   end_borrow %4 : $Builtin.NativeObject           // id: %13
-// CHECK-NEXT: User:   end_borrow %4 : $Builtin.NativeObject           // id: %10
+// CHECK: Found non consuming use outside of the lifetime being verified.
+// CHECK: Value:   %8 = copy_value %4 : $Builtin.NativeObject      // users: %12, %9
+// CHECK: User:   end_borrow %4 : $Builtin.NativeObject           // id: %13
 // CHECK: Error#: 0. End Error in Function: 'simple_loop_carry_implicitregularusers_do_not_loop_carry'
 //
 // CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_loop_carry_implicitregularusers_do_not_loop_carry'
@@ -669,7 +665,7 @@ bb3:
 // borrowed from, %5.
 //
 // CHECK-LABEL: Error#: 1. Begin Error in Function: 'simple_loop_carry_over_consume'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %11, %10, %8
 // CHECK: Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
 // CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
@@ -680,7 +676,7 @@ bb3:
 // amount of circularity here. The important thing is we flag it.
 //
 // CHECK-LABEL: Error#: 2. Begin Error in Function: 'simple_loop_carry_over_consume'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %11, %10, %8
 // CHECK: Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
 // CHECK: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject           // id: %12
@@ -747,7 +743,7 @@ bb3:
 // This is slightly non-sensical since we are feeding the verifier broken SIL.
 //
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
-// CHECK-NEXT: Found use after free?!
+// CHECK-NEXT: Found outside of lifetime use?!
 // CHECK-NEXT: Value: %5 = argument of bb1 : $Builtin.NativeObject      // users: %11, %10, %8
 // CHECK-NEXT: Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
 // CHECK-NEXT: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
@@ -759,7 +755,7 @@ bb3:
 // consuming %3 via the loop carry.
 //
 // CHECK-LABEL: Error#: 1. Begin Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value: %5 = argument of bb1 : $Builtin.NativeObject      // users: %11, %10, %8
 // CHECK: Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
 // CHECK: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject           // id: %12

--- a/test/SIL/ownership-verifier/borrow_scope_introducing_operands.sil
+++ b/test/SIL/ownership-verifier/borrow_scope_introducing_operands.sil
@@ -20,7 +20,7 @@ bb2:
 }
 
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'destroy_value_before_end_borrow'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value: %0 = argument of bb0 : $Builtin.NativeObject
 // CHECK: Consuming User:   destroy_value %0 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   end_borrow %1 : $Builtin.NativeObject
@@ -36,7 +36,7 @@ bb0(%0 : @owned $Builtin.NativeObject):
 }
 
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'destroy_value_before_end_borrow_coroutine'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value: %0 = argument of bb0 : $Builtin.NativeObject
 // CHECK: Consuming User:   destroy_value %0 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   end_apply %2
@@ -55,7 +55,7 @@ bb0(%0 : @owned $Builtin.NativeObject):
 }
 
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'destroy_value_before_end_borrow_coroutine_2'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value: %0 = argument of bb0 : $Builtin.NativeObject
 // CHECK: Consuming User:   destroy_value %0 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   abort_apply %2
@@ -74,7 +74,7 @@ bb0(%0 : @owned $Builtin.NativeObject):
 }
 
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'destroy_value_before_end_borrow_coroutine_3'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value: %0 = argument of bb0 : $Builtin.NativeObject
 // CHECK: Consuming User:   destroy_value %0 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   abort_apply %2
@@ -104,7 +104,7 @@ bb3:
 }
 
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'parent_borrow_scope_end_before_end_borrow_coroutine'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value: %1 = begin_borrow %0 : $Builtin.NativeObject
 // CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   end_apply %3
@@ -125,7 +125,7 @@ bb0(%0 : @owned $Builtin.NativeObject):
 }
 
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'parent_borrow_scope_end_before_end_borrow_coroutine_2'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value: %1 = begin_borrow %0 : $Builtin.NativeObject
 // CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   abort_apply %3
@@ -146,7 +146,7 @@ bb0(%0 : @owned $Builtin.NativeObject):
 }
 
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'parent_borrow_scope_end_before_end_borrow_coroutine_3'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value: %1 = begin_borrow %0 : $Builtin.NativeObject
 // CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   abort_apply %3

--- a/test/SIL/ownership-verifier/interior_pointer.sil
+++ b/test/SIL/ownership-verifier/interior_pointer.sil
@@ -10,7 +10,7 @@ class KlassUser {
 }
 
 // CHECK-LABEL: Function: 'simple_error_ref_element_addr'
-// CHECK-NEXT: Found use after free?!
+// CHECK-NEXT: Found outside of lifetime use?!
 // CHECK-NEXT: Value:   %1 = begin_borrow %0 : $KlassUser               // users: %3, %2
 // CHECK-NEXT: Consuming User:   end_borrow %1 : $KlassUser                      // id: %3
 // CHECK-NEXT: Non Consuming User:   %5 = load [copy] %2 : $*Klass                   // user: %6
@@ -26,7 +26,7 @@ bb0(%0 : @owned $KlassUser):
 }
 
 // CHECK-LABEL: Function: 'simple_error_ref_tail_addr'
-// CHECK-NEXT: Found use after free?!
+// CHECK-NEXT: Found outside of lifetime use?!
 // CHECK-NEXT: Value:   %1 = begin_borrow %0 : $KlassUser               // users: %3, %2
 // CHECK-NEXT: Consuming User:   end_borrow %1 : $KlassUser                      // id: %3
 // CHECK-NEXT: Non Consuming User:   %5 = load [copy] %2 : $*Klass                   // user: %6

--- a/test/SIL/ownership-verifier/over_consume.sil
+++ b/test/SIL/ownership-verifier/over_consume.sil
@@ -128,7 +128,7 @@ bb0(%0 : @guaranteed $Builtin.NativeObject):
 // use after consume.
 //
 // CHECK-LABEL: Function: 'use_after_end_borrow'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
 // CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   %4 = apply %2(%1) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
@@ -148,7 +148,7 @@ bb0(%0 : @owned $Builtin.NativeObject):
 // has finished.
 //
 // CHECK-LABEL: Function: 'destroy_before_end_borrow'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value:   %0 = argument of bb0 : $Builtin.NativeObject
 // CHECK: Consuming User:   destroy_value %0 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   end_borrow %1 : $Builtin.NativeObject
@@ -247,7 +247,7 @@ bb3:
 
 
 // CHECK-LABEL: Function: 'switch_enum_guaranteed_arg_outlives_original_value'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Optional<Builtin.NativeObject>
 // CHECK: Consuming User:   end_borrow %1 : $Optional<Builtin.NativeObject>
 // CHECK: Non Consuming User:   %5 = unchecked_ref_cast %3 : $Builtin.NativeObject to $Builtin.NativeObject
@@ -416,7 +416,7 @@ bb3:
 }
 
 // CHECK-LABEL: Function: 'checked_cast_br_guaranteed_arg_outlives_original_value'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
 // CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   %9 = unchecked_ref_cast %7 : $Builtin.NativeObject to $Builtin.NativeObject
@@ -443,7 +443,7 @@ bb3:
 }
 
 // CHECK-LABEL: Function: 'consume_with_classmethod'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value:   %2 = upcast %0 : $Klass to $SuperKlass
 // CHECK: Consuming User:   store %2 to [init] %1 : $*SuperKlass
 // CHECK: Non Consuming User:   %4 = class_method %2 : $SuperKlass, #SuperKlass.doSomething : (SuperKlass) -> () -> (), $@convention(method) (@guaranteed SuperKlass) -> ()
@@ -467,9 +467,8 @@ entry(%0 : @owned $Builtin.NativeObject):
 }
 
 // CHECK-LABEL: Function: 'use_after_free_consume_in_same_block'
-// CHECK: Found use after free due to unvisited non lifetime ending uses?!
+// CHECK: Found non consuming use outside of the lifetime being verified.
 // CHECK: Value:   %3 = copy_value %2 : $Builtin.NativeObject
-// CHECK:     Remaining Users:
 // CHECK: User:   %10 = apply %7(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
 sil [ossa] @use_after_free_consume_in_same_block : $@convention(thin) (@owned NativeObjectPair) -> @error Error {
 bb0(%0 : @owned $NativeObjectPair):

--- a/test/SIL/ownership-verifier/subobject_borrowing.sil
+++ b/test/SIL/ownership-verifier/subobject_borrowing.sil
@@ -52,7 +52,7 @@ bb0(%0 : @owned $B):
 // ends the borrow's lifetime.
 //
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'value_subobject_with_use_after_end_borrow'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value:   %1 = begin_borrow %0 : $B
 // CHECK: Consuming User:   end_borrow %1 : $B
 // CHECK: Non Consuming User:   %4 = struct_extract %2 : $A, #A.ptr
@@ -96,7 +96,7 @@ bb0(%0 : @owned $B):
 }
 
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'value_different_subobject_kinds_multiple_levels'
-// CHECK: Found use after free?!
+// CHECK: Found outside of lifetime use?!
 // CHECK: Value:   %1 = begin_borrow %0 : $B
 // CHECK: Consuming User:   end_borrow %1 : $B
 // CHECK: Non Consuming User:   %6 = tuple_extract %4 : $(Builtin.NativeObject, Builtin.NativeObject), 1

--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -1132,11 +1132,10 @@ bb0(%0 : $*NativeObjectPair):
   return %9999 : $()
 }
 
-// We should be able to handle this, but we can not until we teach the ARC
-// optimizer to avoid writes not within the load [copy] region.
+// We can handle this since the store is outside of our region.
 //
 // CHECK-LABEL: sil [ossa] @inout_argument_never_written_to_3 : $@convention(thin) (@inout NativeObjectPair, @owned Builtin.NativeObject) -> () {
-// CHECK: load [copy]
+// CHECK: load_borrow
 // CHECK: } // end sil function 'inout_argument_never_written_to_3'
 sil [ossa] @inout_argument_never_written_to_3 : $@convention(thin) (@inout NativeObjectPair, @owned Builtin.NativeObject) -> () {
 bb0(%0 : $*NativeObjectPair, %1 : @owned $Builtin.NativeObject):
@@ -1146,6 +1145,322 @@ bb0(%0 : $*NativeObjectPair, %1 : @owned $Builtin.NativeObject):
   apply %5(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   destroy_value %3 : $Builtin.NativeObject
   store %1 to [assign] %2 : $*Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We cannot handle this since the store is inside of our region.
+//
+// CHECK-LABEL: sil [ossa] @inout_argument_never_written_to_4 : $@convention(thin) (@inout NativeObjectPair, @owned Builtin.NativeObject) -> () {
+// CHECK: load [copy]
+// CHECK: } // end sil function 'inout_argument_never_written_to_4'
+sil [ossa] @inout_argument_never_written_to_4 : $@convention(thin) (@inout NativeObjectPair, @owned Builtin.NativeObject) -> () {
+bb0(%0 : $*NativeObjectPair, %1 : @owned $Builtin.NativeObject):
+  %2 = struct_element_addr %0 : $*NativeObjectPair, #NativeObjectPair.obj1
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  %5 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %5(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  store %1 to [assign] %2 : $*Builtin.NativeObject
+  destroy_value %3 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We cannot handle this since the store is inside of our region.
+//
+// CHECK-LABEL: sil [ossa] @inout_argument_never_written_to_4a : $@convention(thin) (@inout NativeObjectPair, @owned Builtin.NativeObject) -> () {
+// CHECK: load [copy]
+// CHECK: } // end sil function 'inout_argument_never_written_to_4a'
+sil [ossa] @inout_argument_never_written_to_4a : $@convention(thin) (@inout NativeObjectPair, @owned Builtin.NativeObject) -> () {
+bb0(%0 : $*NativeObjectPair, %1 : @owned $Builtin.NativeObject):
+  %2 = struct_element_addr %0 : $*NativeObjectPair, #NativeObjectPair.obj1
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  store %1 to [assign] %2 : $*Builtin.NativeObject
+  %5 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %5(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  destroy_value %3 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We can handle this since the store is outside of our region.
+//
+// CHECK-LABEL: sil [ossa] @inout_argument_never_written_to_5 : $@convention(thin) (@inout NativeObjectPair, @owned Builtin.NativeObject) -> () {
+// CHECK: load_borrow
+// CHECK: } // end sil function 'inout_argument_never_written_to_5'
+sil [ossa] @inout_argument_never_written_to_5 : $@convention(thin) (@inout NativeObjectPair, @owned Builtin.NativeObject) -> () {
+bb0(%0 : $*NativeObjectPair, %1 : @owned $Builtin.NativeObject):
+  %2 = struct_element_addr %0 : $*NativeObjectPair, #NativeObjectPair.obj1
+  store %1 to [assign] %2 : $*Builtin.NativeObject
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  %5 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %5(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  destroy_value %3 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We can handle this since the store is outside of our region.
+//
+// CHECK-LABEL: sil [ossa] @inout_argument_never_written_to_6 : $@convention(thin) (@inout NativeObjectPair, @owned Builtin.NativeObject) -> () {
+// CHECK: load_borrow
+// CHECK: } // end sil function 'inout_argument_never_written_to_6'
+sil [ossa] @inout_argument_never_written_to_6 : $@convention(thin) (@inout NativeObjectPair, @owned Builtin.NativeObject) -> () {
+bb0(%0 : $*NativeObjectPair, %1 : @owned $Builtin.NativeObject):
+  %2 = struct_element_addr %0 : $*NativeObjectPair, #NativeObjectPair.obj1
+  store %1 to [assign] %2 : $*Builtin.NativeObject
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  cond_br undef, bb1, bb2
+
+bb1:
+  %5 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %5(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  destroy_value %3 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We can handle this since the store is outside of our region.
+//
+// CHECK-LABEL: sil [ossa] @inout_argument_never_written_to_6a : $@convention(thin) (@inout NativeObjectPair, @owned Builtin.NativeObject) -> () {
+// CHECK: load_borrow
+// CHECK: } // end sil function 'inout_argument_never_written_to_6a'
+sil [ossa] @inout_argument_never_written_to_6a : $@convention(thin) (@inout NativeObjectPair, @owned Builtin.NativeObject) -> () {
+bb0(%0 : $*NativeObjectPair, %1 : @owned $Builtin.NativeObject):
+  %2 = struct_element_addr %0 : $*NativeObjectPair, #NativeObjectPair.obj1
+  br bb0a
+
+bb0a:
+  store %1 to [assign] %2 : $*Builtin.NativeObject
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  cond_br undef, bb1, bb2
+
+bb1:
+  %5 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %5(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  destroy_value %3 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We can handle this since the store is outside of our region.
+//
+// CHECK-LABEL: sil [ossa] @inout_argument_never_written_to_6b : $@convention(thin) (@inout NativeObjectPair, @owned Builtin.NativeObject) -> () {
+// CHECK: load_borrow
+// CHECK: } // end sil function 'inout_argument_never_written_to_6b'
+sil [ossa] @inout_argument_never_written_to_6b : $@convention(thin) (@inout NativeObjectPair, @owned Builtin.NativeObject) -> () {
+bb0(%0 : $*NativeObjectPair, %1 : @owned $Builtin.NativeObject):
+  %2 = struct_element_addr %0 : $*NativeObjectPair, #NativeObjectPair.obj1
+  store %1 to [assign] %2 : $*Builtin.NativeObject
+  br bb0a
+
+bb0a:
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  cond_br undef, bb1, bb2
+
+bb1:
+  %5 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %5(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  destroy_value %3 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We can handle this since the store is outside of our region.
+//
+// CHECK-LABEL: sil [ossa] @inout_argument_never_written_to_6c : $@convention(thin) (@inout NativeObjectPair, @owned Builtin.NativeObject) -> () {
+// CHECK: load_borrow
+// CHECK: } // end sil function 'inout_argument_never_written_to_6c'
+sil [ossa] @inout_argument_never_written_to_6c : $@convention(thin) (@inout NativeObjectPair, @owned Builtin.NativeObject) -> () {
+bb0(%0 : $*NativeObjectPair, %1 : @owned $Builtin.NativeObject):
+  %2 = struct_element_addr %0 : $*NativeObjectPair, #NativeObjectPair.obj1
+  %1a = copy_value %1 : $Builtin.NativeObject
+  store %1 to [assign] %2 : $*Builtin.NativeObject
+  br bb0a
+
+bb0a:
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  cond_br undef, bb1, bb2
+
+bb1:
+  %5 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %5(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  destroy_value %3 : $Builtin.NativeObject
+  store %1a to [assign] %2 : $*Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// This case, we can not optimize since the write scope is created around our entire load [copy].
+//
+// CHECK-LABEL: sil [ossa] @inout_argument_never_written_to_begin_access_1 : $@convention(thin) (@inout NativeObjectPair, @guaranteed Builtin.NativeObject) -> () {
+// CHECK: load [copy]
+// CHECK: } // end sil function 'inout_argument_never_written_to_begin_access_1'
+sil [ossa] @inout_argument_never_written_to_begin_access_1 : $@convention(thin) (@inout NativeObjectPair, @guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $*NativeObjectPair, %1 : @guaranteed $Builtin.NativeObject):
+  %2 = struct_element_addr %0 : $*NativeObjectPair, #NativeObjectPair.obj1
+  %2a = begin_access [modify] [static] %2 : $*Builtin.NativeObject
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  %5 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %5(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  destroy_value %3 : $Builtin.NativeObject
+  end_access %2a : $*Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @inout_argument_never_written_to_begin_access_1a : $@convention(thin) (@inout NativeObjectPair, @guaranteed Builtin.NativeObject) -> () {
+// CHECK: load [copy]
+// CHECK: } // end sil function 'inout_argument_never_written_to_begin_access_1a'
+sil [ossa] @inout_argument_never_written_to_begin_access_1a : $@convention(thin) (@inout NativeObjectPair, @guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $*NativeObjectPair, %1 : @guaranteed $Builtin.NativeObject):
+  %2 = struct_element_addr %0 : $*NativeObjectPair, #NativeObjectPair.obj1
+  %2a = begin_access [modify] [static] %2 : $*Builtin.NativeObject
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  %5 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %5(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_access %2a : $*Builtin.NativeObject
+  destroy_value %3 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @inout_argument_never_written_to_begin_access_1b : $@convention(thin) (@inout NativeObjectPair, @guaranteed Builtin.NativeObject) -> () {
+// CHECK: load [copy]
+// CHECK: } // end sil function 'inout_argument_never_written_to_begin_access_1b'
+sil [ossa] @inout_argument_never_written_to_begin_access_1b : $@convention(thin) (@inout NativeObjectPair, @guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $*NativeObjectPair, %1 : @guaranteed $Builtin.NativeObject):
+  %2 = struct_element_addr %0 : $*NativeObjectPair, #NativeObjectPair.obj1
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  %2a = begin_access [modify] [static] %2 : $*Builtin.NativeObject
+  %5 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %5(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_access %2a : $*Builtin.NativeObject
+  destroy_value %3 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @inout_argument_never_written_to_begin_access_1c : $@convention(thin) (@inout NativeObjectPair, @guaranteed Builtin.NativeObject) -> () {
+// CHECK: load [copy]
+// CHECK: } // end sil function 'inout_argument_never_written_to_begin_access_1c'
+sil [ossa] @inout_argument_never_written_to_begin_access_1c : $@convention(thin) (@inout NativeObjectPair, @guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $*NativeObjectPair, %1 : @guaranteed $Builtin.NativeObject):
+  %2 = struct_element_addr %0 : $*NativeObjectPair, #NativeObjectPair.obj1
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  %2a = begin_access [modify] [static] %2 : $*Builtin.NativeObject
+  %5 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %5(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  destroy_value %3 : $Builtin.NativeObject
+  end_access %2a : $*Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @inout_argument_never_written_to_begin_access_2a : $@convention(thin) (@inout NativeObjectPair, @guaranteed Builtin.NativeObject) -> () {
+// CHECK: load [copy]
+// CHECK: } // end sil function 'inout_argument_never_written_to_begin_access_2a'
+sil [ossa] @inout_argument_never_written_to_begin_access_2a : $@convention(thin) (@inout NativeObjectPair, @guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $*NativeObjectPair, %1 : @guaranteed $Builtin.NativeObject):
+  %2 = struct_element_addr %0 : $*NativeObjectPair, #NativeObjectPair.obj1
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  cond_br undef, bb1, bb2
+
+bb1:
+  %2a = begin_access [modify] [static] %2 : $*Builtin.NativeObject
+  %5 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %5(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  destroy_value %3 : $Builtin.NativeObject
+  end_access %2a : $*Builtin.NativeObject
+  br bb3
+
+bb2:
+  destroy_value %3 : $Builtin.NativeObject
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @inout_argument_never_written_to_begin_access_2b : $@convention(thin) (@inout NativeObjectPair, @guaranteed Builtin.NativeObject) -> () {
+// CHECK: load [copy]
+// CHECK: } // end sil function 'inout_argument_never_written_to_begin_access_2b'
+sil [ossa] @inout_argument_never_written_to_begin_access_2b : $@convention(thin) (@inout NativeObjectPair, @guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $*NativeObjectPair, %1 : @guaranteed $Builtin.NativeObject):
+  %2 = struct_element_addr %0 : $*NativeObjectPair, #NativeObjectPair.obj1
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  br bb0a
+
+bb0a:
+  %2a = begin_access [modify] [static] %2 : $*Builtin.NativeObject
+  cond_br undef, bb1, bb2
+
+bb1:
+  %5 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %5(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  destroy_value %3 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  destroy_value %3 : $Builtin.NativeObject
+  br bb3
+
+bb3:
+  end_access %2a : $*Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @inout_argument_never_written_to_begin_access_2c : $@convention(thin) (@inout NativeObjectPair, @guaranteed Builtin.NativeObject) -> () {
+// CHECK: load [copy]
+// CHECK: } // end sil function 'inout_argument_never_written_to_begin_access_2c'
+sil [ossa] @inout_argument_never_written_to_begin_access_2c : $@convention(thin) (@inout NativeObjectPair, @guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $*NativeObjectPair, %1 : @guaranteed $Builtin.NativeObject):
+  %2 = struct_element_addr %0 : $*NativeObjectPair, #NativeObjectPair.obj1
+  %2a = begin_access [modify] [static] %2 : $*Builtin.NativeObject
+  br bb0a
+
+bb0a:
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  cond_br undef, bb1, bb2
+
+bb1:
+  %5 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %5(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  destroy_value %3 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  destroy_value %3 : $Builtin.NativeObject
+  br bb3
+
+bb3:
+  end_access %2a : $*Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()
 }


### PR DESCRIPTION
rdar://58667192
