### PR TITLE
[AutoDiff] Fix semantic member accessor pullback ownership errors.

### DIFF
--- a/test/AutoDiff/SILOptimizer/Inputs/nontrivial_loadable_type.swift
+++ b/test/AutoDiff/SILOptimizer/Inputs/nontrivial_loadable_type.swift
@@ -1,0 +1,62 @@
+import _Differentiation
+
+/// A non-trivial, loadable type.
+///
+/// Used to test differentiation transform coverage.
+struct NontrivialLoadable<T> {
+  fileprivate class Box {
+    fileprivate var value: T
+    init(_ value: T) {
+      self.value = value
+    }
+  }
+  private var handle: Box
+
+  init(_ value: T) {
+    self.handle = Box(value)
+  }
+
+  var value: T {
+    get { handle.value }
+    set { handle.value = newValue }
+  }
+}
+
+extension NontrivialLoadable: ExpressibleByFloatLiteral
+where T: ExpressibleByFloatLiteral {
+  init(floatLiteral value: T.FloatLiteralType) {
+    self.handle = Box(T(floatLiteral: value))
+  }
+}
+
+extension NontrivialLoadable: ExpressibleByIntegerLiteral
+where T: ExpressibleByIntegerLiteral {
+  init(integerLiteral value: T.IntegerLiteralType) {
+    self.handle = Box(T(integerLiteral: value))
+  }
+}
+
+extension NontrivialLoadable: Equatable where T: Equatable {
+  static func == (lhs: NontrivialLoadable, rhs: NontrivialLoadable) -> Bool {
+    return lhs.value == rhs.value
+  }
+}
+
+extension NontrivialLoadable: AdditiveArithmetic where T: AdditiveArithmetic {
+  static var zero: NontrivialLoadable { return NontrivialLoadable(T.zero) }
+  static func + (lhs: NontrivialLoadable, rhs: NontrivialLoadable)
+    -> NontrivialLoadable
+  {
+    return NontrivialLoadable(lhs.value + rhs.value)
+  }
+  static func - (lhs: NontrivialLoadable, rhs: NontrivialLoadable)
+    -> NontrivialLoadable
+  {
+    return NontrivialLoadable(lhs.value - rhs.value)
+  }
+}
+
+extension NontrivialLoadable: Differentiable
+where T: Differentiable, T == T.TangentVector {
+  typealias TangentVector = NontrivialLoadable<T.TangentVector>
+}

--- a/test/AutoDiff/SILOptimizer/property_wrappers.swift
+++ b/test/AutoDiff/SILOptimizer/property_wrappers.swift
@@ -1,0 +1,76 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s %S/Inputs/nontrivial_loadable_type.swift
+
+// Test property wrapper differentiation coverage for a variety of property
+// types: trivial, non-trivial loadable, and address-only.
+
+import DifferentiationUnittest
+
+// MARK: Property wrappers
+
+@propertyWrapper
+struct SimpleWrapper<Value> {
+  var wrappedValue: Value // stored property
+}
+
+@propertyWrapper
+struct Wrapper<Value> {
+  private var value: Value
+  var wrappedValue: Value { // computed property
+    get { value }
+    set { value = newValue }
+  }
+
+  init(wrappedValue: Value) {
+    self.value = wrappedValue
+  }
+}
+
+// MARK: Types with wrapped properties
+
+struct Struct: Differentiable {
+  @Wrapper @SimpleWrapper var trivial: Float = 10
+  @Wrapper @SimpleWrapper var tracked: Tracked<Float> = 20
+  @Wrapper @SimpleWrapper var nontrivial: NontrivialLoadable<Float> = 30
+
+  static func testGetters() {
+    let _: @differentiable (Self) -> Float = { $0.trivial }
+    let _: @differentiable (Self) -> Tracked<Float> = { $0.tracked }
+    let _: @differentiable (Self) -> NontrivialLoadable<Float> = { $0.nontrivial }
+  }
+
+  static func testSetters() {
+    let _: @differentiable (inout Self, Float) -> Void =
+      { $0.trivial = $1 }
+    let _: @differentiable (inout Self, Tracked<Float>) -> Void =
+      { $0.tracked = $1 }
+    let _: @differentiable (inout Self, NontrivialLoadable<Float>) -> Void =
+      { $0.nontrivial = $1 }
+  }
+}
+
+struct GenericStruct<T: Differentiable>: Differentiable {
+  @Wrapper @SimpleWrapper var trivial: Float = 10
+  @Wrapper @SimpleWrapper var tracked: Tracked<Float> = 20
+  @Wrapper @SimpleWrapper var nontrivial: NontrivialLoadable<Float> = 30
+  @Wrapper @SimpleWrapper var addressOnly: T
+
+  // SR-12778: Test getter pullback for non-trivial loadable property.
+  static func testGetters() {
+    let _: @differentiable (Self) -> Float = { $0.trivial }
+    let _: @differentiable (Self) -> Tracked<Float> = { $0.tracked }
+    let _: @differentiable (Self) -> NontrivialLoadable<Float> = { $0.nontrivial }
+    let _: @differentiable (Self) -> T = { $0.addressOnly }
+  }
+
+  // SR-12779: Test setter pullback for non-trivial loadable property.
+  static func testSetters() {
+    let _: @differentiable (inout Self, Float) -> Void =
+      { $0.trivial = $1 }
+    let _: @differentiable (inout Self, Tracked<Float>) -> Void =
+      { $0.tracked = $1 }
+    let _: @differentiable (inout Self, NontrivialLoadable<Float>) -> Void =
+      { $0.nontrivial = $1 }
+    let _: @differentiable (inout Self, T) -> Void =
+      { $0.addressOnly = $1 }
+  }
+}


### PR DESCRIPTION
Mirror of `master` branch PR: https://github.com/apple/swift/pull/31700

> Fix ownership errors in semantic member accessor pullbacks:
> - Getter pullbacks: emit copy value operation before storing value.
> - Setter pullbacks: track loaded value as a temporary, to be destroyed.
> 
> Add tests covering trivial, non-trivial, and address-only properties.
> Resolves SR-12778 and SR-12779.

Fixes `AutoDiff/validation-test/property_wrappers.swift` on `tensorflow-stage` branch.