### PR TITLE
[CxxInterop] Import C++ references.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2695,10 +2695,10 @@ enum class FunctionTypeRepresentation : uint8_t {
   /// A "thin" function that needs no context.
   Thin,
   
-  /// A C function pointer, which is thin and also uses the C calling
-  /// convention.
+  /// A C function pointer (or reference), which is thin and also uses the C
+  /// calling convention.
   CFunctionPointer,
-  
+
   /// The value of the greatest AST function representation.
   Last = CFunctionPointer,
 };
@@ -2979,8 +2979,8 @@ public:
       // We preserve a full clang::Type *, not a clang::FunctionType * as:
       // 1. We need to keep sugar in case we need to present an error to the user.
       // 2. The actual type being stored is [ignoring sugar] either a
-      //    clang::PointerType or a clang::BlockPointerType which points to a
-      //    clang::FunctionType.
+      //    clang::PointerType, a clang::BlockPointerType, or a
+      //    clang::ReferenceType which points to a clang::FunctionType.
       const clang::Type *ClangFunctionType;
 
       bool empty() const { return !ClangFunctionType; }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3376,7 +3376,8 @@ void AnyFunctionType::ExtInfo::Uncommon::printClangFunctionType(
 void
 AnyFunctionType::ExtInfo::assertIsFunctionType(const clang::Type *type) {
 #ifndef NDEBUG
-  if (!(type->isFunctionPointerType() || type->isBlockPointerType())) {
+  if (!(type->isFunctionPointerType() || type->isBlockPointerType() ||
+        type->isFunctionReferenceType())) {
     SmallString<256> buf;
     llvm::raw_svector_ostream os(buf);
     os << "Expected a Clang function type wrapped in a pointer type or "

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -159,6 +159,30 @@ namespace {
     explicit operator bool() const { return (bool) AbstractType; }
   };
 
+  static ImportResult importFunctionPointerLikeType(const clang::Type &type,
+                                                    const Type &pointeeType) {
+    auto funcTy = pointeeType->castTo<FunctionType>();
+    return {FunctionType::get(
+                funcTy->getParams(), funcTy->getResult(),
+                funcTy->getExtInfo()
+                    .withRepresentation(
+                        AnyFunctionType::Representation::CFunctionPointer)
+                    .withClangFunctionType(&type)),
+            type.isReferenceType() ? ImportHint::None
+                                    : ImportHint::CFunctionPointer};
+  }
+
+  static ImportResult importOverAlignedFunctionPointerLikeType(
+      const clang::Type &type, ClangImporter::Implementation &Impl) {
+    auto opaquePointer = Impl.SwiftContext.getOpaquePointerDecl();
+    if (!opaquePointer) {
+      return Type();
+    }
+    return {opaquePointer->getDeclaredType(),
+            type.isReferenceType() ? ImportHint::None
+                                    : ImportHint::OtherPointer};
+  }
+
   class SwiftTypeConverter :
     public clang::TypeVisitor<SwiftTypeConverter, ImportResult>
   {
@@ -406,23 +430,11 @@ namespace {
       // alignment is greater than the maximum Swift alignment, import as
       // OpaquePointer.
       if (!pointeeType || Impl.isOverAligned(pointeeQualType)) {
-        auto opaquePointer = Impl.SwiftContext.getOpaquePointerDecl();
-        if (!opaquePointer)
-          return Type();
-        return {opaquePointer->getDeclaredType(),
-                ImportHint::OtherPointer};
+        return importOverAlignedFunctionPointerLikeType(*type, Impl);
       }
-      
+
       if (pointeeQualType->isFunctionType()) {
-        auto funcTy = pointeeType->castTo<FunctionType>();
-        return {
-          FunctionType::get(funcTy->getParams(), funcTy->getResult(),
-            funcTy->getExtInfo()
-              .withRepresentation(
-                AnyFunctionType::Representation::CFunctionPointer)
-              .withClangFunctionType(type)),
-          ImportHint::CFunctionPointer
-        };
+        return importFunctionPointerLikeType(*type, pointeeType);
       }
 
       PointerTypeKind pointerKind;
@@ -472,7 +484,29 @@ namespace {
     }
 
     ImportResult VisitReferenceType(const clang::ReferenceType *type) {
-      return Type();
+      auto pointeeQualType = type->getPointeeType();
+      auto quals = pointeeQualType.getQualifiers();
+      Type pointeeType =
+          Impl.importTypeIgnoreIUO(pointeeQualType, ImportTypeKind::Value,
+                                   AllowNSUIntegerAsInt, Bridgeability::None);
+
+      if (pointeeQualType->isFunctionType()) {
+        return importFunctionPointerLikeType(*type, pointeeType);
+      }
+
+      if (Impl.isOverAligned(pointeeQualType)) {
+        return importOverAlignedFunctionPointerLikeType(*type, Impl);
+      }
+
+      PointerTypeKind pointerKind;
+      if (quals.hasConst()) {
+        pointerKind = PTK_UnsafePointer;
+      } else {
+        pointerKind = PTK_UnsafeMutablePointer;
+      }
+
+      return {pointeeType->wrapInPointer(pointerKind),
+              ImportHint::None};
     }
 
     ImportResult VisitMemberPointer(const clang::MemberPointerType *type) {

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -135,9 +135,10 @@ enum class ImportTypeKind {
 
   /// Import the type of a function parameter.
   ///
-  /// This provides special treatment for C++ references (which become
-  /// [inout] parameters) and C pointers (which become magic [inout]-able types),
-  /// among other things, and enables the conversion of bridged types.
+  /// Special handling:
+  /// * C and C++ pointers become `UnsafePointer?` or `UnsafeMutablePointer?`
+  /// * C++ references become `UnsafePointer` or `UnsafeMutablePointer`
+  /// * Bridging that requires type conversions is allowed.
   /// Parameters are always considered CF-audited.
   Parameter,
 

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -319,6 +319,8 @@ getClangFunctionType(const clang::Type *clangType) {
     clangType = ptrTy->getPointeeType().getTypePtr();
   } else if (auto blockTy = clangType->getAs<clang::BlockPointerType>()) {
     clangType = blockTy->getPointeeType().getTypePtr();
+  } else if (auto refTy = clangType->getAs<clang::ReferenceType>()) {
+    clangType = refTy->getPointeeType().getTypePtr();
   }
   return clangType->castAs<clang::FunctionType>();
 }

--- a/test/Interop/Cxx/reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/reference/Inputs/module.modulemap
@@ -1,0 +1,3 @@
+module Reference {
+  header "reference.h"
+}

--- a/test/Interop/Cxx/reference/Inputs/reference.cpp
+++ b/test/Interop/Cxx/reference/Inputs/reference.cpp
@@ -1,0 +1,19 @@
+#include "reference.h"
+#include <utility>
+
+static int staticInt = 42;
+
+int getStaticInt() { return staticInt; }
+int &getStaticIntRef() { return staticInt; }
+int &&getStaticIntRvalueRef() { return std::move(staticInt); }
+const int &getConstStaticIntRef() { return staticInt; }
+const int &&getConstStaticIntRvalueRef() { return std::move(staticInt); }
+
+void setStaticInt(int i) { staticInt = i; }
+void setStaticIntRef(int &i) { staticInt = i; }
+void setStaticIntRvalueRef(int &&i) { staticInt = i; }
+void setConstStaticIntRef(const int &i) { staticInt = i; }
+void setConstStaticIntRvalueRef(const int &&i) { staticInt = i; }
+
+auto getFuncRef() -> int (&)() { return getStaticInt; }
+auto getFuncRvalueRef() -> int (&&)() { return getStaticInt; }

--- a/test/Interop/Cxx/reference/Inputs/reference.h
+++ b/test/Interop/Cxx/reference/Inputs/reference.h
@@ -1,0 +1,19 @@
+#ifndef TEST_INTEROP_CXX_REFERENCE_INPUTS_REFERENCE_H
+#define TEST_INTEROP_CXX_REFERENCE_INPUTS_REFERENCE_H
+
+int getStaticInt();
+int &getStaticIntRef();
+int &&getStaticIntRvalueRef();
+const int &getConstStaticIntRef();
+const int &&getConstStaticIntRvalueRef();
+
+void setStaticInt(int);
+void setStaticIntRef(int &);
+void setStaticIntRvalueRef(int &&);
+void setConstStaticIntRef(const int &);
+void setConstStaticIntRvalueRef(const int &&);
+
+auto getFuncRef() -> int (&)();
+auto getFuncRvalueRef() -> int (&&)();
+
+#endif // TEST_INTEROP_CXX_REFERENCE_INPUTS_REFERENCE_H

--- a/test/Interop/Cxx/reference/reference-irgen.swift
+++ b/test/Interop/Cxx/reference/reference-irgen.swift
@@ -1,0 +1,71 @@
+// RUN: %target-swift-emit-ir -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
+
+import Reference
+
+public func getCxxRef() -> UnsafeMutablePointer<CInt> {
+  return getStaticIntRef()
+}
+
+// CHECK: define {{(protected |dllexport )?}}swiftcc i8* @"$s4main9getCxxRefSpys5Int32VGyF"()
+// CHECK: call i32* @{{_Z15getStaticIntRefv|"\?getStaticIntRef@@YAAEAHXZ"}}()
+
+public func getConstCxxRef() -> UnsafePointer<CInt> {
+  return getConstStaticIntRef()
+}
+
+// CHECK: define {{(protected |dllexport )?}}swiftcc i8* @"$s4main14getConstCxxRefSPys5Int32VGyF"()
+// CHECK: call i32* @{{_Z20getConstStaticIntRefv|"\?getConstStaticIntRef@@YAAEBHXZ"}}()
+
+public func getCxxRvalueRef() -> UnsafeMutablePointer<CInt> {
+  return getStaticIntRvalueRef()
+}
+
+// CHECK: define {{(protected |dllexport )?}}swiftcc i8* @"$s4main15getCxxRvalueRefSpys5Int32VGyF"()
+// CHECK: call i32* @{{_Z21getStaticIntRvalueRefv|"\?getStaticIntRvalueRef@@YA\$\$QEAHXZ"}}()
+
+public func getConstCxxRvalueRef() -> UnsafePointer<CInt> {
+  return getConstStaticIntRvalueRef()
+}
+
+// CHECK: define {{(protected |dllexport )?}}swiftcc i8* @"$s4main20getConstCxxRvalueRefSPys5Int32VGyF"()
+// CHECK: call i32* @{{_Z26getConstStaticIntRvalueRefv|"\?getConstStaticIntRvalueRef@@YA\$\$QEBHXZ"}}()
+
+public func setCxxRef() {
+  var val: CInt = 21
+  withUnsafeMutablePointer(to: &val) {
+    setStaticIntRef($0)
+  }
+}
+
+// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main9setCxxRefyyF"()
+// CHECK: call void @{{_Z15setStaticIntRefRi|"\?setStaticIntRef@@YAXAEAH@Z"}}(i32* {{nonnull %val|%2}})
+
+public func setCxxConstRef() {
+  var val: CInt = 21
+  withUnsafePointer(to: &val) {
+    setConstStaticIntRef($0)
+  }
+}
+
+// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main14setCxxConstRefyyF"()
+// CHECK: call void @{{_Z20setConstStaticIntRefRKi|"\?setConstStaticIntRef@@YAXAEBH@Z"}}(i32* {{nonnull %val|%2}})
+
+public func setCxxRvalueRef() {
+  var val: CInt = 21
+  withUnsafeMutablePointer(to: &val) {
+    setStaticIntRvalueRef($0)
+  }
+}
+
+// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main15setCxxRvalueRefyyF"()
+// CHECK: call void @{{_Z21setStaticIntRvalueRefOi|"\?setStaticIntRvalueRef@@YAX\$\$QEAH@Z"}}(i32* {{nonnull %val|%2}})
+
+public func setCxxConstRvalueRef() {
+  var val: CInt = 21
+  withUnsafePointer(to: &val) {
+    setConstStaticIntRvalueRef($0)
+  }
+}
+
+// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main20setCxxConstRvalueRefyyF"()
+// CHECK: call void @{{_Z26setConstStaticIntRvalueRefOKi|"\?setConstStaticIntRvalueRef@@YAX\$\$QEBH@Z"}}(i32* {{nonnull %val|%2}})

--- a/test/Interop/Cxx/reference/reference-module-interface.swift
+++ b/test/Interop/Cxx/reference/reference-module-interface.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=Reference -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK: func getStaticInt() -> Int32
+// CHECK: func getStaticIntRef() -> UnsafeMutablePointer<Int32>
+// CHECK: func getStaticIntRvalueRef() -> UnsafeMutablePointer<Int32>
+// CHECK: func getConstStaticIntRef() -> UnsafePointer<Int32>
+// CHECK: func getConstStaticIntRvalueRef() -> UnsafePointer<Int32>
+// CHECK: func setStaticInt(_: Int32)
+// CHECK: func setStaticIntRef(_: UnsafeMutablePointer<Int32>)
+// CHECK: func setStaticIntRvalueRef(_: UnsafeMutablePointer<Int32>)
+// CHECK: func setConstStaticIntRef(_: UnsafePointer<Int32>)
+// CHECK: func setConstStaticIntRvalueRef(_: UnsafePointer<Int32>)
+// CHECK: func getFuncRef() -> @convention(c) () -> Int32
+// CHECK: func getFuncRvalueRef() -> @convention(c) () -> Int32

--- a/test/Interop/Cxx/reference/reference-silgen.swift
+++ b/test/Interop/Cxx/reference/reference-silgen.swift
@@ -1,0 +1,83 @@
+// RUN: %target-swift-emit-sil -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
+
+import Reference
+
+func getCxxRef() -> UnsafeMutablePointer<CInt> {
+  return getStaticIntRef()
+}
+
+// CHECK: sil hidden @$s4main9getCxxRefSpys5Int32VGyF : $@convention(thin) () -> UnsafeMutablePointer<Int32>
+// CHECK: [[REF:%.*]] = function_ref @{{_Z15getStaticIntRefv|\?getStaticIntRef@@YAAEAHXZ}} : $@convention(c) () -> UnsafeMutablePointer<Int32>
+// CHECK: apply [[REF]]() : $@convention(c) () -> UnsafeMutablePointer<Int32>
+
+func getConstCxxRef() -> UnsafePointer<CInt> {
+  return getConstStaticIntRef()
+}
+
+// CHECK: sil hidden @$s4main14getConstCxxRefSPys5Int32VGyF : $@convention(thin) () -> UnsafePointer<Int32>
+// CHECK: [[REF:%.*]] = function_ref @{{_Z20getConstStaticIntRefv|\?getConstStaticIntRef@@YAAEBHXZ}} : $@convention(c) () -> UnsafePointer<Int32>
+// CHECK: apply [[REF]]() : $@convention(c) () -> UnsafePointer<Int32>
+
+func getCxxRvalueRef() -> UnsafeMutablePointer<CInt> {
+  return getStaticIntRvalueRef()
+}
+
+// CHECK: sil hidden @$s4main15getCxxRvalueRefSpys5Int32VGyF : $@convention(thin) () -> UnsafeMutablePointer<Int32>
+// CHECK: [[REF:%.*]] = function_ref @{{_Z21getStaticIntRvalueRefv|\?getStaticIntRvalueRef@@YA\$\$QEAHXZ}} : $@convention(c) () -> UnsafeMutablePointer<Int32>
+// CHECK: apply [[REF]]() : $@convention(c) () -> UnsafeMutablePointer<Int32>
+
+func getConstCxxRvalueRef() -> UnsafePointer<CInt> {
+  return getConstStaticIntRvalueRef()
+}
+
+// CHECK: sil hidden @$s4main20getConstCxxRvalueRefSPys5Int32VGyF : $@convention(thin) () -> UnsafePointer<Int32>
+// CHECK: [[REF:%.*]] = function_ref @{{_Z26getConstStaticIntRvalueRefv|\?getConstStaticIntRvalueRef@@YA\$\$QEBHXZ}} : $@convention(c) () -> UnsafePointer<Int32>
+// CHECK: apply [[REF]]() : $@convention(c) () -> UnsafePointer<Int32>
+
+func setCxxRef() {
+  var val: CInt = 21
+  withUnsafeMutablePointer(to: &val) {
+    setStaticIntRef($0)
+  }
+}
+
+// CHECK: // closure #1 in setCxxRef()
+// CHECK: sil private @$s4main9setCxxRefyyFySpys5Int32VGXEfU_ : $@convention(thin) (UnsafeMutablePointer<Int32>) -> ()
+// CHECK: [[REF:%.*]] = function_ref @{{_Z15setStaticIntRefRi|\?setStaticIntRef@@YAXAEAH@Z}} : $@convention(c) (UnsafeMutablePointer<Int32>) -> ()
+// CHECK: apply [[REF]](%0) : $@convention(c) (UnsafeMutablePointer<Int32>) -> ()
+
+func setCxxConstRef() {
+  var val: CInt = 21
+  withUnsafePointer(to: &val) {
+    setConstStaticIntRef($0)
+  }
+}
+
+// CHECK: // closure #1 in setCxxConstRef()
+// CHECK: sil private @$s4main14setCxxConstRefyyFySPys5Int32VGXEfU_ : $@convention(thin) (UnsafePointer<Int32>) -> ()
+// CHECK: [[REF:%.*]] = function_ref @{{_Z20setConstStaticIntRefRKi|\?setConstStaticIntRef@@YAXAEBH@Z}} : $@convention(c) (UnsafePointer<Int32>) -> ()
+// CHECK: apply [[REF]](%0) : $@convention(c) (UnsafePointer<Int32>) -> ()
+
+func setCxxRvalueRef() {
+  var val: CInt = 21
+  withUnsafeMutablePointer(to: &val) {
+    setStaticIntRvalueRef($0)
+  }
+}
+
+// CHECK: // closure #1 in setCxxRvalueRef()
+// CHECK: sil private @$s4main15setCxxRvalueRefyyFySpys5Int32VGXEfU_ : $@convention(thin) (UnsafeMutablePointer<Int32>) -> ()
+// CHECK: [[REF:%.*]] = function_ref @{{_Z21setStaticIntRvalueRefOi|\?setStaticIntRvalueRef@@YAX\$\$QEAH@Z}} : $@convention(c) (UnsafeMutablePointer<Int32>) -> ()
+// CHECK: apply [[REF]](%0) : $@convention(c) (UnsafeMutablePointer<Int32>) -> ()
+
+func setCxxConstRvalueRef() {
+  var val: CInt = 21
+  withUnsafePointer(to: &val) {
+    setConstStaticIntRvalueRef($0)
+  }
+}
+
+// CHECK: // closure #1 in setCxxConstRvalueRef()
+// CHECK: sil private @$s4main20setCxxConstRvalueRefyyFySPys5Int32VGXEfU_ : $@convention(thin) (UnsafePointer<Int32>) -> ()
+// CHECK: [[REF:%.*]] = function_ref @{{_Z26setConstStaticIntRvalueRefOKi|\?setConstStaticIntRvalueRef@@YAX\$\$QEBH@Z}} : $@convention(c) (UnsafePointer<Int32>) -> ()
+// CHECK: apply [[REF]](%0) : $@convention(c) (UnsafePointer<Int32>) -> ()

--- a/test/Interop/Cxx/reference/reference.swift
+++ b/test/Interop/Cxx/reference/reference.swift
@@ -1,0 +1,92 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang -c %S/Inputs/reference.cpp -I %S/Inputs -o %t/reference.o -std=c++17
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/reference %t/reference.o -Xfrontend -enable-cxx-interop -Xcc -std=c++17
+// RUN: %target-codesign %t/reference
+// RUN: %target-run %t/reference
+//
+// REQUIRES: executable_test
+
+import Reference
+import StdlibUnittest
+
+var ReferenceTestSuite = TestSuite("Reference")
+
+ReferenceTestSuite.test("read-lvalue-reference") {
+  expectNotEqual(13, getStaticInt())
+  setStaticInt(13)
+  expectEqual(13, getStaticIntRef().pointee)
+  expectEqual(13, getConstStaticIntRef().pointee)
+}
+
+ReferenceTestSuite.test("read-rvalue-reference") {
+  expectNotEqual(32, getStaticInt())
+  setStaticInt(32)
+  expectEqual(32, getStaticIntRvalueRef().pointee)
+  expectEqual(32, getConstStaticIntRvalueRef().pointee)
+}
+
+ReferenceTestSuite.test("write-lvalue-reference") {
+  expectNotEqual(14, getStaticInt())
+  getStaticIntRef().pointee = 14
+  expectEqual(14, getStaticInt())
+}
+
+ReferenceTestSuite.test("write-rvalue-reference") {
+  expectNotEqual(41, getStaticInt())
+  getStaticIntRvalueRef().pointee = 41
+  expectEqual(41, getStaticInt())
+}
+
+ReferenceTestSuite.test("pass-lvalue-reference") {
+  expectNotEqual(21, getStaticInt())
+  var val: CInt = 21
+  withUnsafeMutablePointer(to: &val) {
+    setStaticIntRef($0)
+  }
+  expectEqual(21, getStaticInt())
+}
+
+ReferenceTestSuite.test("pass-const-lvalue-reference") {
+  expectNotEqual(22, getStaticInt())
+  var val: CInt = 22
+  withUnsafePointer(to: &val) {
+    setConstStaticIntRef($0)
+  }
+  expectEqual(22, getStaticInt())
+}
+
+ReferenceTestSuite.test("pass-rvalue-reference") {
+  expectNotEqual(52, getStaticInt())
+  var val: CInt = 52
+  withUnsafeMutablePointer(to: &val) {
+    setStaticIntRvalueRef($0)
+  }
+  expectEqual(52, getStaticInt())
+}
+
+ReferenceTestSuite.test("pass-const-rvalue-reference") {
+  expectNotEqual(53, getStaticInt())
+  var val: CInt = 53
+  withUnsafePointer(to: &val) {
+    setConstStaticIntRvalueRef($0)
+  }
+  expectEqual(53, getStaticInt())
+}
+
+ReferenceTestSuite.test("func-reference") {
+  let cxxF: @convention(c) () -> Int32 = getFuncRef()
+
+  expectNotEqual(15, getStaticInt())
+  setStaticInt(15)
+  expectEqual(15, cxxF())
+}
+
+ReferenceTestSuite.test("func-rvalue-reference") {
+  let cxxF: @convention(c) () -> Int32 = getFuncRvalueRef()
+
+  expectNotEqual(61, getStaticInt())
+  setStaticInt(61)
+  expectEqual(61, cxxF())
+}
+
+runAllTests()


### PR DESCRIPTION
This PR enables import of C++ references as `UnsafePointers`. PR follows the implementation of pointers with a difference that for references we don't wrap the `UnsafePointer` in `Optional`.