### PR TITLE
[AutoDiff] make differentiable array ops inlinable

### DIFF
--- a/stdlib/public/Differentiation/ArrayDifferentiation.swift
+++ b/stdlib/public/Differentiation/ArrayDifferentiation.swift
@@ -262,6 +262,7 @@ extension Array where Element: Differentiable {
 //===----------------------------------------------------------------------===//
 
 extension Array where Element: Differentiable {
+  @inlinable
   @differentiable(wrt: (self, initialResult))
   public func differentiableReduce<Result: Differentiable>(
     _ initialResult: Result,
@@ -270,7 +271,7 @@ extension Array where Element: Differentiable {
     reduce(initialResult, nextPartialResult)
   }
 
-  @usableFromInline
+  @inlinable
   @derivative(of: differentiableReduce)
   internal func _vjpDifferentiableReduce<Result: Differentiable>(
     _ initialResult: Result,
@@ -310,6 +311,7 @@ extension Array where Element: Differentiable {
 }
 
 extension Array where Element: Differentiable {
+  @inlinable
   @differentiable(wrt: self)
   public func differentiableMap<Result: Differentiable>(
     _ body: @differentiable (Element) -> Result
@@ -317,7 +319,7 @@ extension Array where Element: Differentiable {
     map(body)
   }
 
-  @usableFromInline
+  @inlinable
   @derivative(of: differentiableMap)
   internal func _vjpDifferentiableMap<Result: Differentiable>(
     _ body: @differentiable (Element) -> Result


### PR DESCRIPTION
A solver in https://github.com/borglab/SwiftFusion that had some `differentiableMap` and `differentiableReduce` in its inner loop was spending ~50% of its time in these two operations. Switching the solver to use `map` and `reduce` changed this to ~0%.

Making `differentiableMap` and `differentiableReduce` `@inlinable` should fix this. (Though I haven't actually built a toolchain to confirm. This isn't urgent enough that I want to spend time building a toolchain to confirm it, so I'll just wait until this makes its way into a toolchain before confirming.)