### PR TITLE
ABIChecker: don't diagnose missing availability attribute for decls where the attribute doesn't apply

### DIFF
--- a/test/api-digester/Inputs/cake_current/cake.swift
+++ b/test/api-digester/Inputs/cake_current/cake.swift
@@ -245,3 +245,5 @@ open class AddingNewDesignatedInit {
 public extension Float {
   func floatHigher() {}
 }
+
+infix operator <==> : AssignmentPrecedence

--- a/test/api-digester/Outputs/Cake-abi.txt
+++ b/test/api-digester/Outputs/Cake-abi.txt
@@ -53,8 +53,6 @@ cake: Accessor GlobalLetChangedToVar.Modify() is a new API without @available at
 cake: Accessor GlobalLetChangedToVar.Set() is a new API without @available attribute
 cake: Accessor fixedLayoutStruct2.BecomeFixedBinaryOrder.Modify() is a new API without @available attribute
 cake: Accessor fixedLayoutStruct2.BecomeFixedBinaryOrder.Set() is a new API without @available attribute
-cake: AssociatedType RequiementChanges.addedTypeWithDefault is a new API without @available attribute
-cake: AssociatedType RequiementChanges.addedTypeWithoutDefault is a new API without @available attribute
 cake: Class C0 is a new API without @available attribute
 cake: Class C5 is now without @objc
 cake: Class C8 is a new API without @available attribute

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -1145,6 +1145,8 @@ public:
     // Decls with @_alwaysEmitIntoClient aren't required to have an
     // @available attribute.
     if (!Ctx.getOpts().SkipOSCheck &&
+        DeclAttribute::canAttributeAppearOnDeclKind(DeclAttrKind::DAK_Available,
+                                                    D->getDeclKind()) &&
         !D->getIntroducingVersion().hasOSAvailability() &&
         !D->hasDeclAttribute(DeclAttrKind::DAK_AlwaysEmitIntoClient)) {
       D->emitDiag(D->getLoc(), diag::new_decl_without_intro);


### PR DESCRIPTION
rdar://62990671