### PR TITLE
Include llvm/Support/Debug.h in AdjointValue.h

### DIFF
--- a/include/swift/SILOptimizer/Differentiation/AdjointValue.h
+++ b/include/swift/SILOptimizer/Differentiation/AdjointValue.h
@@ -21,6 +21,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/SIL/SILValue.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/Debug.h"
 
 namespace swift {
 namespace autodiff {


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/commit/63c0ded8c90f670f886dd213f3148bdb352b60ea from `master-next` to `master`.

---

This is needed to reference `llvm::dbgs()`.