### PR TITLE
Adapt to Tuple-In-OptionalSome Patterns in Space Projection

### DIFF
--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -212,12 +212,6 @@ namespace {
         }
         return Space(T, H, SP);
       }
-      static Space forConstructor(Type T, DeclName H,
-                                  std::forward_list<Space> SP) {
-        // No need to filter SP here; this is only used to copy other
-        // Constructor spaces.
-        return Space(T, H, SP);
-      }
       static Space forBool(bool C) {
         return Space(C);
       }
@@ -1441,7 +1435,7 @@ namespace {
         if (subSpace.getKind() == SpaceKind::Constructor &&
             subSpace.getHead().getBaseIdentifier().empty()) {
           return Space::forConstructor(item->getType(), name,
-                                       std::move(subSpace.getSpaces()));
+                                       {subSpace});
         }
         return Space::forConstructor(item->getType(), name, subSpace);
       }

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -1438,3 +1438,15 @@ enum SR11212Tests {
   }
 
 } // end SR11212Tests
+
+func sr12412() {
+  enum E {
+    case x
+    case y
+  }
+  switch (E.x, true) as Optional<(e: E, b: Bool)> {
+      case nil, (e: .x, b: _)?: break
+      case (e: .y, b: false)?: break
+      case (e: .y, b: true)?: break
+  }
+}


### PR DESCRIPTION
The space engine goes out of its way to rewrite OptionalSome patterns
using the postfix-? sugar into .some(...). Unfortunately, it performed
the following remapping:

```
(x, y, z, ...)? -> .some(x, y, z, ...)
```

This syntactic form used to behave correctly. However, we are no longer
flattening nested tuples so the correct rewrite is:

```
(x, y, z, ...)? -> .some((x, y, z, ...))
```

Correct this space projection rule.

rdar://62200966