### PR TITLE
ModuleInterface: refactor compiler instance configuration to a standalone delegate class. NFC

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -121,7 +121,7 @@ namespace swift {
   class UnifiedStatsReporter;
   class IndexSubset;
   struct SILAutoDiffDerivativeFunctionKey;
-  struct SubASTContextDelegate;
+  struct InterfaceSubContextDelegate;
 
   enum class KnownProtocolKind : uint8_t;
 
@@ -721,7 +721,7 @@ public:
       StringRef moduleName,
       bool isUnderlyingClangModule,
       ModuleDependenciesCache &cache,
-      SubASTContextDelegate &delegate);
+      InterfaceSubContextDelegate &delegate);
 
   /// Load extensions to the given nominal type from the external
   /// module loaders.

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -371,7 +371,7 @@ public:
 
   Optional<ModuleDependencies> getModuleDependencies(
       StringRef moduleName, ModuleDependenciesCache &cache,
-      SubASTContextDelegate &delegate) override;
+      InterfaceSubContextDelegate &delegate) override;
 
   /// Add dependency information for the bridging header.
   ///

--- a/include/swift/Frontend/FrontendInputsAndOutputs.h
+++ b/include/swift/Frontend/FrontendInputsAndOutputs.h
@@ -173,7 +173,7 @@ public:
 
 private:
   friend class ArgsToFrontendOptionsConverter;
-  friend class ModuleInterfaceBuilder;
+  friend struct InterfaceSubContextDelegateImpl;
   void setMainAndSupplementaryOutputs(
       ArrayRef<std::string> outputFiles,
       ArrayRef<SupplementaryOutputPaths> supplementaryOutputs);

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -108,6 +108,7 @@
 #define SWIFT_FRONTEND_MODULEINTERFACELOADER_H
 
 #include "swift/Basic/LLVM.h"
+#include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/ModuleInterfaceSupport.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
 #include "llvm/Support/StringSaver.h"
@@ -203,18 +204,65 @@ public:
 std::string
 getModuleCachePathFromClang(const clang::CompilerInstance &Instance);
 
-bool extractSwiftInterfaceVersionAndArgs(SourceManager &SM,
-                                         DiagnosticEngine &Diags,
-                                         StringRef InterfacePath,
-                                         version::Version &Vers,
-                                         StringRef &CompilerVersion,
-                                         llvm::StringSaver &SubArgSaver,
-                                         SmallVectorImpl<const char *> &SubArgs,
-                                         SourceLoc diagnosticLoc = SourceLoc());
+struct InterfaceSubContextDelegateImpl: InterfaceSubContextDelegate {
+private:
+  SourceManager &SM;
+  DiagnosticEngine &Diags;
+  CompilerInvocation subInvocation;
 
-void inheritOptionsForBuildingInterface(CompilerInvocation &Invok,
-                                        const SearchPathOptions &SearchPathOpts,
-                                        const LangOptions &LangOpts);
+  template<typename ...ArgTypes>
+  InFlightDiagnostic diagnose(StringRef interfacePath,
+                              SourceLoc diagnosticLoc,
+                              Diag<ArgTypes...> ID,
+                        typename detail::PassArgument<ArgTypes>::type... Args) {
+    SourceLoc loc = diagnosticLoc;
+    if (diagnosticLoc.isInvalid()) {
+      // Diagnose this inside the interface file, if possible.
+      loc = SM.getLocFromExternalSource(interfacePath, 1, 1);
+    }
+    return Diags.diagnose(loc, ID, std::move(Args)...);
+  }
+
+  bool extractSwiftInterfaceVersionAndArgs(llvm::StringSaver &SubArgSaver,
+                                           SmallVectorImpl<const char *> &SubArgs,
+                                           std::string &CompilerVersion,
+                                           StringRef interfacePath,
+                                           SourceLoc diagnosticLoc);
+  SubCompilerInstanceInfo createInstance(StringRef moduleName,
+                                         StringRef interfacePath,
+                                         StringRef outputPath,
+                                         SourceLoc diagLoc);
+public:
+  InterfaceSubContextDelegateImpl(SourceManager &SM,
+                                  DiagnosticEngine &Diags,
+                                  const SearchPathOptions &searchPathOpts,
+                                  const LangOptions &langOpts,
+                                  ClangModuleLoader *clangImporter = nullptr,
+                                  StringRef moduleCachePath = StringRef(),
+                                  StringRef prebuiltCachePath = StringRef(),
+                                  bool serializeDependencyHashes = false,
+                                  bool trackSystemDependencies = false,
+                                  bool remarkOnRebuildFromInterface = false,
+                                  bool disableInterfaceFileLock = false);
+  bool runInSubContext(StringRef moduleName,
+                       StringRef interfacePath,
+                       StringRef outputPath,
+                       SourceLoc diagLoc,
+                       llvm::function_ref<bool(ASTContext&)> action) override;
+  bool runInSubCompilerInstance(StringRef moduleName,
+                                StringRef interfacePath,
+                                StringRef outputPath,
+                                SourceLoc diagLoc,
+                                llvm::function_ref<bool(SubCompilerInstanceInfo&)> action) override;
+
+  ~InterfaceSubContextDelegateImpl() = default;
+
+  /// includes a hash of relevant key data.
+  void computeCachedOutputPath(StringRef moduleName,
+                               StringRef UseInterfacePath,
+                               llvm::SmallString<256> &OutPath);
+  std::string getCacheHash(StringRef useInterfacePath);
+};
 }
 
 #endif

--- a/include/swift/Sema/SourceLoader.h
+++ b/include/swift/Sema/SourceLoader.h
@@ -94,7 +94,7 @@ public:
 
   Optional<ModuleDependencies> getModuleDependencies(
       StringRef moduleName, ModuleDependenciesCache &cache,
-      SubASTContextDelegate &delegate) override {
+      InterfaceSubContextDelegate &delegate) override {
     // FIXME: Implement?
     return None;
   }

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -195,7 +195,7 @@ public:
 
   virtual Optional<ModuleDependencies> getModuleDependencies(
       StringRef moduleName, ModuleDependenciesCache &cache,
-      SubASTContextDelegate &delegate) override;
+      InterfaceSubContextDelegate &delegate) override;
 };
 
 /// Imports serialized Swift modules into an ASTContext.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1463,7 +1463,7 @@ void ASTContext::addModuleLoader(std::unique_ptr<ModuleLoader> loader,
 
 Optional<ModuleDependencies> ASTContext::getModuleDependencies(
     StringRef moduleName, bool isUnderlyingClangModule,
-    ModuleDependenciesCache &cache, SubASTContextDelegate &delegate) {
+    ModuleDependenciesCache &cache, InterfaceSubContextDelegate &delegate) {
   for (auto &loader : getImpl().ModuleLoaders) {
     if (isUnderlyingClangModule &&
         loader.get() != getImpl().TheClangModuleLoader)

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -803,7 +803,7 @@ bool ClangImporter::canReadPCH(StringRef PCHFilename) {
   CI.setInvocation(std::move(invocation));
   CI.setTarget(&Impl.Instance->getTarget());
   CI.setDiagnostics(
-      &*CompilerInstance::createDiagnostics(new clang::DiagnosticOptions()));
+      &*clang::CompilerInstance::createDiagnostics(new clang::DiagnosticOptions()));
 
   // Note: Reusing the file manager is safe; this is a component that's already
   // reused when building PCM files for the module cache.

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -225,7 +225,7 @@ static void recordModuleDependencies(
 
 Optional<ModuleDependencies> ClangImporter::getModuleDependencies(
     StringRef moduleName, ModuleDependenciesCache &cache,
-    SubASTContextDelegate &delegate) {
+    InterfaceSubContextDelegate &delegate) {
   // Check whether there is already a cached result.
   if (auto found = cache.findDependencies(
           moduleName, ModuleDependenciesKind::Clang))

--- a/lib/Frontend/ModuleInterfaceBuilder.h
+++ b/lib/Frontend/ModuleInterfaceBuilder.h
@@ -16,6 +16,7 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Frontend/Frontend.h"
+#include "swift/AST/ModuleLoader.h"
 #include "swift/Serialization/SerializationOptions.h"
 #include "llvm/Support/StringSaver.h"
 
@@ -35,17 +36,14 @@ class DependencyTracker;
 class ModuleInterfaceBuilder {
   SourceManager &sourceMgr;
   DiagnosticEngine &diags;
+  InterfaceSubContextDelegate &subASTDelegate;
   const StringRef interfacePath;
   const StringRef moduleName;
   const StringRef moduleCachePath;
   const StringRef prebuiltCachePath;
-  const bool serializeDependencyHashes;
-  const bool trackSystemDependencies;
-  const bool remarkOnRebuildFromInterface;
   const bool disableInterfaceFileLock;
   const SourceLoc diagnosticLoc;
   DependencyTracker *const dependencyTracker;
-  CompilerInvocation subInvocation;
   SmallVector<StringRef, 3> extraDependencies;
 
 public:
@@ -75,12 +73,6 @@ private:
                     ID, std::move(Args)...);
   }
 
-  void configureSubInvocationInputsAndOutputs(StringRef OutPath);
-
-  void configureSubInvocation(const SearchPathOptions &SearchPathOpts,
-                              const LangOptions &LangOpts,
-                              ClangModuleLoader *ClangLoader);
-
   /// Populate the provided \p Deps with \c FileDependency entries for all
   /// dependencies \p SubInstance's DependencyTracker recorded while compiling
   /// the module, excepting .swiftmodules in \p moduleCachePath or
@@ -92,41 +84,24 @@ private:
       SmallVectorImpl<SerializationOptions::FileDependency> &Deps,
       bool IsHashBased);
 
-  bool extractSwiftInterfaceVersionAndArgs(
-      version::Version &Vers, StringRef &CompilerVersion,
-      llvm::StringSaver &SubArgSaver, SmallVectorImpl<const char *> &SubArgs);
-
   bool buildSwiftModuleInternal(StringRef OutPath, bool ShouldSerializeDeps,
                                 std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer);
 public:
   ModuleInterfaceBuilder(SourceManager &sourceMgr, DiagnosticEngine &diags,
-                            const SearchPathOptions &searchPathOpts,
-                            const LangOptions &langOpts,
-                            ClangModuleLoader *clangImporter,
+                            InterfaceSubContextDelegate &subASTDelegate,
                             StringRef interfacePath,
                             StringRef moduleName,
                             StringRef moduleCachePath,
                             StringRef prebuiltCachePath,
-                            bool serializeDependencyHashes = false,
-                            bool trackSystemDependencies = false,
-                            bool remarkOnRebuildFromInterface = false,
                             bool disableInterfaceFileLock = false,
                             SourceLoc diagnosticLoc = SourceLoc(),
                             DependencyTracker *tracker = nullptr)
     : sourceMgr(sourceMgr), diags(diags),
+      subASTDelegate(subASTDelegate),
       interfacePath(interfacePath), moduleName(moduleName),
       moduleCachePath(moduleCachePath), prebuiltCachePath(prebuiltCachePath),
-      serializeDependencyHashes(serializeDependencyHashes),
-      trackSystemDependencies(trackSystemDependencies),
-      remarkOnRebuildFromInterface(remarkOnRebuildFromInterface),
       disableInterfaceFileLock(disableInterfaceFileLock),
-      diagnosticLoc(diagnosticLoc), dependencyTracker(tracker) {
-    configureSubInvocation(searchPathOpts, langOpts, clangImporter);
-  }
-
-  const CompilerInvocation &getSubInvocation() const {
-    return subInvocation;
-  }
+      diagnosticLoc(diagnosticLoc), dependencyTracker(tracker) {}
 
   /// Ensures the requested file name is added as a dependency of the resulting
   /// module.


### PR DESCRIPTION
Module interface builder used to maintain a separate compiler instance for building Swift modules. The configuration of this compiler instance is also useful for dependencies scanner because it needs to emit front-end compiler invocation for building Swift modules explicitly.

This patch refactor the configuration out to a delegate class, and the delegate class is also used by the dependency scanner.