### PR TITLE
Const-Qualify LangOptions and TypeCheckerOptions

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -241,7 +241,7 @@ public:
   const LangOptions &LangOpts;
 
   /// The type checker options.
-  TypeCheckerOptions &TypeCheckerOpts;
+  const TypeCheckerOptions &TypeCheckerOpts;
 
   /// The search path options used by this AST context.
   SearchPathOptions &SearchPathOpts;

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -238,7 +238,7 @@ public:
   UnifiedStatsReporter *Stats = nullptr;
 
   /// The language options used for translation.
-  LangOptions &LangOpts;
+  const LangOptions &LangOpts;
 
   /// The type checker options.
   TypeCheckerOptions &TypeCheckerOpts;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -575,7 +575,7 @@ protected:
     HasAnyUnavailableValues : 1
   );
 
-  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1,
     /// If the module was or is being compiled with `-enable-testing`.
     TestingEnabled : 1,
 
@@ -601,7 +601,10 @@ protected:
 
     /// Whether the module was imported from Clang (or, someday, maybe another
     /// language).
-    IsNonSwiftModule : 1
+    IsNonSwiftModule : 1,
+
+    /// Whether this module is the main module.
+    IsMainModule : 1
   );
 
   SWIFT_INLINE_BITFIELD(PrecedenceGroupDecl, Decl, 1+2,

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -379,5 +379,10 @@ ERROR(expectation_missing_opening_braces,none,
 ERROR(expectation_missing_closing_braces,none,
       "didn't find '}}' to match '{{' in expectation", ())
 
+WARNING(module_incompatible_with_skip_function_bodies,none,
+        "module '%0' cannot be built with "
+        "-experimental-skip-non-inlinable-function-bodies; this option has "
+        "been automatically disabled", (StringRef))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -347,6 +347,13 @@ public:
     return new (ctx) ModuleDecl(name, ctx, importInfo);
   }
 
+  static ModuleDecl *
+  createMainModule(ASTContext &ctx, Identifier name, ImplicitImportInfo iinfo) {
+    auto *Mod = ModuleDecl::create(name, ctx, iinfo);
+    Mod->Bits.ModuleDecl.IsMainModule = true;
+    return Mod;
+  }
+
   using Decl::getASTContext;
 
   /// Retrieves information about which modules are implicitly imported by
@@ -540,6 +547,10 @@ public:
   /// \see #isNonSwiftModule
   void setIsNonSwiftModule(bool flag = true) {
     Bits.ModuleDecl.IsNonSwiftModule = flag;
+  }
+
+  bool isMainModule() const {
+    return Bits.ModuleDecl.IsMainModule;
   }
 
   /// Retrieve the top-level module. If this module is already top-level, this

--- a/include/swift/AST/PlatformKind.h
+++ b/include/swift/AST/PlatformKind.h
@@ -54,11 +54,11 @@ StringRef prettyPlatformString(PlatformKind platform);
 /// If ForTargetVariant is true then for zippered builds the target-variant
 /// triple will be used rather than the target to determine whether the
 /// platform is active.
-bool isPlatformActive(PlatformKind Platform, LangOptions &LangOpts,
+bool isPlatformActive(PlatformKind Platform, const LangOptions &LangOpts,
                       bool ForTargetVariant = false);
 
 /// Returns the target platform for the given language options.
-PlatformKind targetPlatform(LangOptions &LangOpts);
+PlatformKind targetPlatform(const LangOptions &LangOpts);
 
 /// Returns true when availability attributes from the "parent" platform
 /// should also apply to the "child" platform for declarations without

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -475,6 +475,16 @@ ModuleDecl::ModuleDecl(Identifier name, ASTContext &ctx,
   setInterfaceType(ModuleType::get(this));
 
   setAccess(AccessLevel::Public);
+
+  Bits.ModuleDecl.TestingEnabled = 0;
+  Bits.ModuleDecl.FailedToLoad = 0;
+  Bits.ModuleDecl.RawResilienceStrategy = 0;
+  Bits.ModuleDecl.HasResolvedImports = 0;
+  Bits.ModuleDecl.PrivateImportsEnabled = 0;
+  Bits.ModuleDecl.ImplicitDynamicEnabled = 0;
+  Bits.ModuleDecl.IsSystemModule = 0;
+  Bits.ModuleDecl.IsNonSwiftModule = 0;
+  Bits.ModuleDecl.IsMainModule = 0;
 }
 
 ArrayRef<ImplicitImport> ModuleDecl::getImplicitImports() const {

--- a/lib/AST/PlatformKind.cpp
+++ b/lib/AST/PlatformKind.cpp
@@ -92,7 +92,7 @@ static bool isPlatformActiveForTarget(PlatformKind Platform,
   llvm_unreachable("bad PlatformKind");
 }
 
-bool swift::isPlatformActive(PlatformKind Platform, LangOptions &LangOpts,
+bool swift::isPlatformActive(PlatformKind Platform, const LangOptions &LangOpts,
                              bool ForTargetVariant) {
   llvm::Triple TT = LangOpts.Target;
 
@@ -105,7 +105,7 @@ bool swift::isPlatformActive(PlatformKind Platform, LangOptions &LangOpts,
                                    LangOpts.EnableAppExtensionRestrictions);
 }
 
-PlatformKind swift::targetPlatform(LangOptions &LangOpts) {
+PlatformKind swift::targetPlatform(const LangOptions &LangOpts) {
   if (LangOpts.Target.isMacOSX()) {
     return (LangOpts.EnableAppExtensionRestrictions
                 ? PlatformKind::OSXApplicationExtension

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1877,7 +1877,7 @@ ClangImporter::getWrapperForModule(const clang::Module *mod,
   return clangUnit->getParentModule();
 }
 
-PlatformAvailability::PlatformAvailability(LangOptions &langOpts)
+PlatformAvailability::PlatformAvailability(const LangOptions &langOpts)
     : platformKind(targetPlatform(langOpts)) {
   switch (platformKind) {
   case PlatformKind::iOS:

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -255,7 +255,7 @@ public:
   /// API is now unavailable.
   std::string deprecatedAsUnavailableMessage;
 
-  PlatformAvailability(LangOptions &opts);
+  PlatformAvailability(const LangOptions &opts);
 
 private:
   PlatformAvailability(const PlatformAvailability&) = delete;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -629,6 +629,11 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
   }
 
+  if (FrontendOpts.RequestedAction == FrontendOptions::ActionType::EmitSyntax) {
+    Opts.BuildSyntaxTree = true;
+    Opts.VerifySyntaxTree = true;
+  }
+
   return HadError || UnsupportedOS || UnsupportedArch;
 }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -682,6 +682,17 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
   // body skipping.
   Opts.SkipNonInlinableFunctionBodies |= Args.hasArg(OPT_tbd_is_installapi);
 
+  if (Opts.SkipNonInlinableFunctionBodies &&
+      FrontendOpts.ModuleName == SWIFT_ONONE_SUPPORT) {
+    // Disable this optimization if we're compiling SwiftOnoneSupport, because
+    // we _definitely_ need to look inside every declaration to figure out
+    // what gets prespecialized.
+    Opts.SkipNonInlinableFunctionBodies = false;
+    Diags.diagnose(SourceLoc(),
+                   diag::module_incompatible_with_skip_function_bodies,
+                   SWIFT_ONONE_SUPPORT);
+  }
+
   Opts.DisableConstraintSolverPerformanceHacks |=
       Args.hasArg(OPT_disable_constraint_solver_performance_hacks);
 
@@ -908,12 +919,14 @@ void parseExclusivityEnforcementOptions(const llvm::opt::Arg *A,
 
 static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
                          IRGenOptions &IRGenOpts,
-                         FrontendOptions &FEOpts,
+                         const FrontendOptions &FEOpts,
+                         const TypeCheckerOptions &TCOpts,
                          DiagnosticEngine &Diags,
                          const llvm::Triple &Triple,
                          ClangImporterOptions &ClangOpts) {
   using namespace options;
 
+  
   if (const Arg *A = Args.getLastArg(OPT_sil_inline_threshold)) {
     if (StringRef(A->getValue()).getAsInteger(10, Opts.InlineThreshold)) {
       Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
@@ -956,8 +969,9 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_sil_merge_partial_modules))
     Opts.MergePartialModules = true;
 
-  if (Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies))
-    Opts.SkipNonInlinableFunctionBodies = true;
+  // Propagate the typechecker's understanding of
+  // -experimental-skip-non-inlinable-function-bodies to SIL.
+  Opts.SkipNonInlinableFunctionBodies = TCOpts.SkipNonInlinableFunctionBodies;
 
   // Parse the optimization level.
   // Default to Onone settings if no option is passed.
@@ -1629,7 +1643,8 @@ bool CompilerInvocation::parseArgs(
     return true;
   }
 
-  if (ParseSILArgs(SILOpts, ParsedArgs, IRGenOpts, FrontendOpts, Diags,
+  if (ParseSILArgs(SILOpts, ParsedArgs, IRGenOpts, FrontendOpts,
+                   TypeCheckerOpts, Diags,
                    LangOpts.Target, ClangImporterOpts)) {
     return true;
   }

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -717,7 +717,8 @@ ImplicitImportInfo CompilerInstance::getImplicitImportInfo() const {
 ModuleDecl *CompilerInstance::getMainModule() const {
   if (!MainModule) {
     Identifier ID = Context->getIdentifier(Invocation.getModuleName());
-    MainModule = ModuleDecl::create(ID, *Context, getImplicitImportInfo());
+    MainModule = ModuleDecl::createMainModule(*Context, ID,
+                                              getImplicitImportInfo());
     if (Invocation.getFrontendOptions().EnableTesting)
       MainModule->setTestingEnabled();
     if (Invocation.getFrontendOptions().EnablePrivateImports)

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1200,12 +1200,7 @@ static bool performCompile(CompilerInstance &Instance,
                            FrontendObserver *observer) {
   const auto &Invocation = Instance.getInvocation();
   const auto &opts = Invocation.getFrontendOptions();
-  FrontendOptions::ActionType Action = opts.RequestedAction;
-
-  if (Action == FrontendOptions::ActionType::EmitSyntax) {
-    Instance.getASTContext().LangOpts.BuildSyntaxTree = true;
-    Instance.getASTContext().LangOpts.VerifySyntaxTree = true;
-  }
+  const FrontendOptions::ActionType Action = opts.RequestedAction;
 
   // We've been asked to precompile a bridging header or module; we want to
   // avoid touching any other inputs and just parse, emit and exit.

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -317,6 +317,8 @@ bool CompletionInstance::performCachedOperationIfPossible(
 
   LangOptions langOpts = CI.getASTContext().LangOpts;
   langOpts.DisableParserLookup = true;
+  // Ensure all non-function-body tokens are hashed into the interface hash
+  langOpts.EnableTypeFingerprints = false;
   TypeCheckerOptions typeckOpts = CI.getASTContext().TypeCheckerOpts;
   SearchPathOptions searchPathOpts = CI.getASTContext().SearchPathOpts;
   DiagnosticEngine tmpDiags(tmpSM);
@@ -331,8 +333,6 @@ bool CompletionInstance::performCachedOperationIfPossible(
       SourceFile(*tmpM, oldSF->Kind, tmpBufferID, /*KeepParsedTokens=*/false,
                  /*BuildSyntaxTree=*/false, oldSF->getParsingOptions());
   tmpSF->enableInterfaceHash();
-  // Ensure all non-function-body tokens are hashed into the interface hash
-  tmpCtx->LangOpts.EnableTypeFingerprints = false;
 
   // FIXME: Since we don't setup module loaders on the temporary AST context,
   // 'canImport()' conditional compilation directive always fails. That causes

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8321,7 +8321,7 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
     result.setExpr(resultExpr);
 
     auto &ctx = cs.getASTContext();
-    if (ctx.TypeCheckerOpts.DebugConstraintSolver) {
+    if (cs.isDebugMode()) {
       auto &log = ctx.TypeCheckerDebug->getStream();
       log << "---Type-checked expression---\n";
       resultExpr->dump(log);

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -107,7 +107,7 @@ ConstraintSystem::determineBestBindings() {
 
     inferTransitiveSupertypeBindings(cache, bindings);
 
-    if (getASTContext().TypeCheckerOpts.DebugConstraintSolver) {
+    if (isDebugMode()) {
       auto &log = getASTContext().TypeCheckerDebug->getStream();
       bindings.dump(typeVar, log, solverState->depth * 2);
     }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4364,7 +4364,7 @@ bool ConstraintSystem::generateConstraints(
       target = *resultTarget;
     }
 
-    if (getASTContext().TypeCheckerOpts.DebugConstraintSolver) {
+    if (isDebugMode()) {
       auto &log = getASTContext().TypeCheckerDebug->getStream();
       log << "---Initial constraints for the given expression---\n";
       print(log, expr);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8148,7 +8148,7 @@ retry_after_fail:
   // If we have a common result type, bind the expected result type to it.
   if (commonResultType && !commonResultType->is<ErrorType>()) {
     ASTContext &ctx = getASTContext();
-    if (ctx.TypeCheckerOpts.DebugConstraintSolver) {
+    if (isDebugMode()) {
       auto &log = ctx.TypeCheckerDebug->getStream();
       log.indent(solverState ? solverState->depth * 2 : 0)
         << "(common result type for $T" << fnTypeVar->getID() << " is "
@@ -9290,7 +9290,7 @@ static bool isAugmentingFix(ConstraintFix *fix) {
 
 bool ConstraintSystem::recordFix(ConstraintFix *fix, unsigned impact) {
   auto &ctx = getASTContext();
-  if (ctx.TypeCheckerOpts.DebugConstraintSolver) {
+  if (isDebugMode()) {
     auto &log = ctx.TypeCheckerDebug->getStream();
     log.indent(solverState ? solverState->depth * 2 : 0)
       << "(attempting fix ";

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -100,7 +100,7 @@ void SplitterStep::computeFollowupSteps(
     return;
   }
 
-  if (isDebugMode()) {
+  if (CS.isDebugMode()) {
     auto &log = getDebugLogger();
     // Verify that the constraint graph is valid.
     CG.verify();
@@ -238,7 +238,7 @@ bool SplitterStep::mergePartialSolutions() const {
       // Finalize this solution.
       auto solution = CS.finalize();
       solutionMemory += solution.getTotalMemory();
-      if (isDebugMode())
+      if (CS.isDebugMode())
         getDebugLogger() << "(composed solution " << CS.CurrentScore << ")\n";
 
       // Save this solution.
@@ -391,7 +391,7 @@ StepResult ComponentStep::take(bool prevFailed) {
   }
 
   auto solution = CS.finalize();
-  if (isDebugMode())
+  if (CS.isDebugMode())
     getDebugLogger() << "(found solution " << getCurrentScore() << ")\n";
 
   Solutions.push_back(std::move(solution));
@@ -408,7 +408,7 @@ StepResult ComponentStep::finalize(bool isSuccess) {
   // Rewind all modifications done to constraint system.
   ComponentScope.reset();
 
-  if (isDebugMode()) {
+  if (CS.isDebugMode()) {
     auto &log = getDebugLogger();
     log << (isSuccess ? "finished" : "failed") << " component #" << Index
         << ")\n";
@@ -440,7 +440,7 @@ StepResult ComponentStep::finalize(bool isSuccess) {
 
 void TypeVariableStep::setup() {
   ++CS.solverState->NumTypeVariablesBound;
-  if (isDebugMode()) {
+  if (CS.isDebugMode()) {
     PrintOptions PO;
     PO.PrintTypesForDebugging = true;
     auto &log = getDebugLogger();
@@ -478,7 +478,7 @@ StepResult TypeVariableStep::resume(bool prevFailed) {
   // Rewind back all of the changes made to constraint system.
   ActiveChoice.reset();
 
-  if (isDebugMode())
+  if (CS.isDebugMode())
     getDebugLogger() << ")\n";
 
   // Let's check if we should stop right before
@@ -517,7 +517,7 @@ StepResult DisjunctionStep::resume(bool prevFailed) {
   // Rewind back the constraint system information.
   ActiveChoice.reset();
 
-  if (isDebugMode())
+  if (CS.isDebugMode())
     getDebugLogger() << ")\n";
 
   // Attempt next disjunction choice (if any left).
@@ -530,7 +530,7 @@ bool DisjunctionStep::shouldSkip(const DisjunctionChoice &choice) const {
   bool attemptFixes = CS.shouldAttemptFixes();
   // Enable all disabled choices in "diagnostic" mode.
   if (!attemptFixes && choice.isDisabled()) {
-    if (isDebugMode()) {
+    if (CS.isDebugMode()) {
       auto &log = getDebugLogger();
       log << "(skipping ";
       choice.print(log, &ctx.SourceMgr);

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -231,12 +231,6 @@ protected:
     CS.filterSolutions(solutions, minimize);
   }
 
-  /// Check whether constraint solver is running in "debug" mode,
-  /// which should output diagnostic information.
-  bool isDebugMode() const {
-    return CS.getASTContext().TypeCheckerOpts.DebugConstraintSolver;
-  }
-
   llvm::raw_ostream &getDebugLogger(bool indent = true) const {
     auto &log = CS.getASTContext().TypeCheckerDebug->getStream();
     return indent ? log.indent(CS.solverState->depth * 2) : log;
@@ -471,7 +465,7 @@ private:
     if (IsSingle)
       return;
 
-    if (isDebugMode())
+    if (CS.isDebugMode())
       getDebugLogger() << "(solving component #" << Index << '\n';
 
     ComponentScope = std::make_unique<Scope>(*this);
@@ -515,7 +509,7 @@ public:
       if (shouldStopAt(*choice))
         break;
 
-      if (isDebugMode()) {
+      if (CS.isDebugMode()) {
         auto &log = getDebugLogger();
         log << "(attempting ";
         choice->print(log, &CS.getASTContext().SourceMgr);
@@ -530,7 +524,7 @@ public:
         }
       }
 
-      if (isDebugMode())
+      if (CS.isDebugMode())
         getDebugLogger() << ")\n";
 
       // If this binding didn't match, let's check if we've attempted

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -872,7 +872,7 @@ namespace {
         contractedCycle = false;
         for (const auto &edge : cycleEdges) {
           if (unionSets(edge.first, edge.second)) {
-            if (ctx.TypeCheckerOpts.DebugConstraintSolver) {
+            if (cs.isDebugMode()) {
               auto &log = ctx.TypeCheckerDebug->getStream();
               if (cs.solverState)
                 log.indent(cs.solverState->depth * 2);
@@ -1155,7 +1155,7 @@ bool ConstraintGraph::contractEdges() {
           rep2->getImpl().canBindToLValue()) ||
          // Allow l-value contractions when binding parameter types.
          isParamBindingConstraint)) {
-      if (CS.getASTContext().TypeCheckerOpts.DebugConstraintSolver) {
+      if (CS.isDebugMode()) {
         auto &log = CS.getASTContext().TypeCheckerDebug->getStream();
         if (CS.solverState)
           log.indent(CS.solverState->depth * 2);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -74,6 +74,12 @@ ConstraintSystem::ConstraintSystem(DeclContext *dc,
     CG(*new ConstraintGraph(*this))
 {
   assert(DC && "context required");
+  // Respect the global debugging flag, but turn off debugging while
+  // parsing and loading other modules.
+  if (Context.TypeCheckerOpts.DebugConstraintSolver &&
+      DC->getParentModule()->isMainModule()) {
+    Options |= ConstraintSystemFlags::DebugConstraints;
+  }
 }
 
 ConstraintSystem::~ConstraintSystem() {
@@ -2408,7 +2414,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
                      verifyThatArgumentIsHashable);
   }
 
-  if (getASTContext().TypeCheckerOpts.DebugConstraintSolver) {
+  if (isDebugMode()) {
     PrintOptions PO;
     PO.PrintTypesForDebugging = true;
     auto &log = getASTContext().TypeCheckerDebug->getStream();
@@ -2571,7 +2577,7 @@ bool OverloadChoice::isImplicitlyUnwrappedValueOrReturnValue() const {
 
 SolutionResult ConstraintSystem::salvage() {
   auto &ctx = getASTContext();
-  if (ctx.TypeCheckerOpts.DebugConstraintSolver) {
+  if (isDebugMode()) {
     auto &log = ctx.TypeCheckerDebug->getStream();
     log << "---Attempting to salvage and emit diagnostics---\n";
   }
@@ -2619,7 +2625,7 @@ SolutionResult ConstraintSystem::salvage() {
 
     // If there are multiple solutions, try to diagnose an ambiguity.
     if (viable.size() > 1) {
-      if (getASTContext().TypeCheckerOpts.DebugConstraintSolver) {
+      if (isDebugMode()) {
         auto &log = getASTContext().TypeCheckerDebug->getStream();
         log << "---Ambiguity error: " << viable.size()
             << " solutions found---\n";

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -104,10 +104,6 @@ ModuleDecl *SourceLoader::loadModule(SourceLoc importLoc,
     dependencyTracker->addDependency(inputFile->getBufferIdentifier(),
                                      /*isSystem=*/false);
 
-  // Turn off debugging while parsing other modules.
-  llvm::SaveAndRestore<bool>
-      turnOffDebug(Ctx.TypeCheckerOpts.DebugConstraintSolver, false);
-
   unsigned bufferID;
   if (auto BufID =
        Ctx.SourceMgr.getIDForBufferIdentifier(inputFile->getBufferIdentifier()))

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2214,7 +2214,7 @@ getTypeOfCompletionOperatorImpl(DeclContext *DC, Expr *expr,
   if (!expr)
     return nullptr;
 
-  if (Context.TypeCheckerOpts.DebugConstraintSolver) {
+  if (CS.isDebugMode()) {
     auto &log = Context.TypeCheckerDebug->getStream();
     log << "---Initial constraints for the given expression---\n";
     expr->dump(log);
@@ -2228,7 +2228,7 @@ getTypeOfCompletionOperatorImpl(DeclContext *DC, Expr *expr,
     return nullptr;
 
   auto &solution = viable[0];
-  if (Context.TypeCheckerOpts.DebugConstraintSolver) {
+  if (CS.isDebugMode()) {
     auto &log = Context.TypeCheckerDebug->getStream();
     log << "---Solution---\n";
     solution.dump(log);

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -332,13 +332,6 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
     FrontendStatsTracer tracer(Ctx.Stats,
                                "Type checking and Semantic analysis");
 
-    if (Ctx.TypeCheckerOpts.SkipNonInlinableFunctionBodies)
-      // Disable this optimization if we're compiling SwiftOnoneSupport, because
-      // we _definitely_ need to look inside every declaration to figure out
-      // what gets prespecialized.
-      if (SF->getParentModule()->isOnoneSupportModule())
-        Ctx.TypeCheckerOpts.SkipNonInlinableFunctionBodies = false;
-
     if (!Ctx.LangOpts.DisableAvailabilityChecking) {
       // Build the type refinement hierarchy for the primary
       // file before type checking.

--- a/test/Frontend/skip-non-inlinable-function-bodies.swift
+++ b/test/Frontend/skip-non-inlinable-function-bodies.swift
@@ -1,10 +1,13 @@
 // RUN: %empty-directory(%t)
 
-// 1. Make sure you can't -emit-ir or -c when you're skipping non-inlinable function bodies
+// 1a. Make sure you can't -emit-ir or -c when you're skipping non-inlinable function bodies
+// 1b. Also make sure we warn when you try to build SwiftONoneSupport with this option enabled
 
 // RUN: not %target-swift-frontend -emit-ir %s -experimental-skip-non-inlinable-function-bodies %s 2>&1 | %FileCheck %s --check-prefix ERROR
 // RUN: not %target-swift-frontend -c %s -experimental-skip-non-inlinable-function-bodies %s 2>&1 | %FileCheck %s --check-prefix ERROR
+// RUN: %target-swift-frontend -typecheck -experimental-skip-non-inlinable-function-bodies -module-name SwiftOnoneSupport %s 2>&1 | %FileCheck %s --check-prefix WARNING
 // ERROR: -experimental-skip-non-inlinable-function-bodies does not support emitting IR
+// WARNING: module 'SwiftOnoneSupport' cannot be built with -experimental-skip-non-inlinable-function-bodies; this option has been automatically disabled
 
 // 2. Emit the SIL for a module and check it against the expected strings in function bodies.
 //    If we're doing the right skipping, then the strings that are CHECK-NOT'd won't have been typechecked or SILGen'd.


### PR DESCRIPTION
This required moving aside the hacks that necessitated mutating these options outside of the frontend.

For LangOptions, `-experimental-skip-function-bodies` was silently disabling itself if the module under scrutiny was `SwiftOnoneSupport`. Push this computation into the frontend and warn about it.

For TypeCheckerOptions the main offender was the expression checker's debugging flags. For these, add a bit to `ConstraintSystemFlags` and convert the save-and-restore patterns to use that instead. A beneficial behavior where constraint debugging was turned off for loaded modules is being emulated by plumbing the notion of the "main module" into `ModuleDecl` itself.