### PR TITLE
[5.1 Compatibility library] Add missing #include

### DIFF
--- a/stdlib/toolchain/Compatibility51/Concurrent.h
+++ b/stdlib/toolchain/Compatibility51/Concurrent.h
@@ -20,6 +20,7 @@
 #include <iterator>
 #include <algorithm>
 #include <atomic>
+#include <cassert>
 #include <functional>
 #include <pthread.h>
 #include <stdint.h>


### PR DESCRIPTION
Fixes a build failure reported in 63112718