### PR TITLE
[AutoDiff] fix array subscript lookup when there are multiple

### DIFF
--- a/test/AutoDiff/stdlib/array.swift
+++ b/test/AutoDiff/stdlib/array.swift
@@ -8,6 +8,15 @@ var ArrayAutoDiffTests = TestSuite("ArrayAutoDiff")
 
 typealias FloatArrayTan = Array<Float>.TangentVector
 
+extension Array.DifferentiableView {
+  /// A subscript that always fatal errors.
+  ///
+  /// The differentiation transform should never emit calls to this.
+  subscript(alwaysFatalError: Int) -> Element {
+    fatalError("wrong subscript")
+  }
+}
+
 ArrayAutoDiffTests.test("ArrayIdentity") {
   func arrayIdentity(_ x: [Float]) -> [Float] {
     return x


### PR DESCRIPTION
The differentiation transform sometimes tries to call the wrong subscript when there are multiple subscripts.

This concretely causes problems when you `import TensorFlow` because [this subscript](https://github.com/tensorflow/swift-apis/blob/ae03b887c0263cd92cc007873101941634656d0a/Sources/TensorFlow/StdlibExtensions.swift#L209) has different conformances in its generic signature than the correct subscript, so you get an assertion failure while trying to construct a substitution map for it:
```
Assertion failed: (conformances.size() == numConformanceRequirements), function Storage, file /Users/danielzheng/swift-debug/swift/lib/AST/SubstitutionMap.cpp, line 46.
```