### PR TITLE
[AutoDiff] Fix derivative forwarding thunk linkage.

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -839,8 +839,8 @@ void SILGenModule::emitDifferentiabilityWitness(
   SILDifferentiabilityWitnessKey key{originalFunction->getName(), silConfig};
   auto *diffWitness = M.lookUpDifferentiabilityWitness(key);
   if (!diffWitness) {
-    // Strip external from linkage of original function.
-    // Necessary for Clang-imported functions, which have external linkage.
+    // Differentiability witnesses have the same linkage as the original
+    // function, stripping external.
     auto linkage = stripExternalFromLinkage(originalFunction->getLinkage());
     diffWitness = SILDifferentiabilityWitness::createDefinition(
         M, linkage, originalFunction, silConfig.parameterIndices,

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3941,14 +3941,17 @@ SILFunction *SILGenModule::getOrCreateCustomDerivativeThunk(
 
   auto loc = customDerivativeFn->getLocation();
   SILGenFunctionBuilder fb(*this);
-  // This thunk is publicly exposed and cannot be transparent.
-  // Instead, mark it as "always inline" for optimization.
+  // Derivative thunks have the same linkage as the original function, stripping
+  // external.
+  auto linkage = stripExternalFromLinkage(originalFn->getLinkage());
   auto *thunk = fb.getOrCreateFunction(
-      loc, name, customDerivativeFn->getLinkage(), thunkFnTy, IsBare,
-      IsNotTransparent, customDerivativeFn->isSerialized(),
+      loc, name, linkage, thunkFnTy, IsBare, IsNotTransparent,
+      customDerivativeFn->isSerialized(),
       customDerivativeFn->isDynamicallyReplaceable(),
       customDerivativeFn->getEntryCount(), IsThunk,
       customDerivativeFn->getClassSubclassScope());
+  // This thunk may be publicly exposed and cannot be transparent.
+  // Instead, mark it as "always inline" for optimization.
   thunk->setInlineStrategy(AlwaysInline);
   if (!thunk->empty())
     return thunk;

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -837,6 +837,27 @@ fileprivate func _fileprivate_original_fileprivate_derivative(_ x: Float) -> (va
   fatalError()
 }
 
+func internal_original_usablefrominline_derivative(_ x: Float) -> Float { x }
+@usableFromInline
+@derivative(of: internal_original_usablefrominline_derivative)
+func _internal_original_usablefrominline_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
+func internal_original_inlinable_derivative(_ x: Float) -> Float { x }
+@inlinable
+@derivative(of: internal_original_inlinable_derivative)
+func _internal_original_inlinable_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
+func internal_original_alwaysemitintoclient_derivative(_ x: Float) -> Float { x }
+@_alwaysEmitIntoClient
+@derivative(of: internal_original_alwaysemitintoclient_derivative)
+func _internal_original_alwaysemitintoclient_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
 // MARK: - Original function visibility < derivative function visibility
 
 @usableFromInline

--- a/test/AutoDiff/compiler_crashers_fixed/tf1160-derivative-usable-from-inline-mismatch.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/tf1160-derivative-usable-from-inline-mismatch.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -c %s -verify
+// REQUIRES: asserts
+
+// TF-1160: Linker error for `@usableFromInline` derivative function but
+// non-`@usableFromInline` internal original function.
+
+import _Differentiation
+
+func internalOriginal(_ x: Float) -> Float { x }
+
+@usableFromInline
+@derivative(of: internalOriginal)
+func usableFromInlineDerivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  (x, { $0 })
+}
+
+// Original error: type-checking passes but TBDGen is not consistent with IRGen.
+// <unknown>:0: error: symbol 'AD__$s4main16internalOriginalyS2fF__vjp_src_0_wrt_0' (AD__$s4main16internalOriginalyS2fF__vjp_src_0_wrt_0) is in generated IR file, but not in TBD file
+// <unknown>:0: error: please file a radar or open a bug on bugs.swift.org with this code, and add -Xfrontend -validate-tbd-against-ir=none to squash the errors


### PR DESCRIPTION
Make derivative forwarding thunks use original function's linkage instead of the
derivative function's, stripping external.

This is consistent with the linkage of differentiability witnesses.

Clarify AutoDiff linkage-related comments.

Resolves TF-1160: TBDGen error due to incorrect derivative thunk linkage.

---

```swift
import _Differentiation

func internalOriginal(_ x: Float) -> Float { x }

@usableFromInline
@derivative(of: internalOriginal)
func usableFromInlineDerivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
  (x, { $0 })
}
```

Before:
```console
$ swiftc tf-1160.swift
<unknown>:0: error: symbol 'AD__$s4main16internalOriginalyS2fF__vjp_src_0_wrt_0' (AD__$s4main16internalOriginalyS2fF__vjp_src_0_wrt_0) is in generated IR file, but not in TBD file
<unknown>:0: error: please file a radar or open a bug on bugs.swift.org with this code, and add -Xfrontend -validate-tbd-against-ir=none to squash the errors
```

After: no error.