### PR TITLE
Fixes example snippets in FloatingPoint.swift

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -126,7 +126,7 @@
 ///     let temperatureData = ["21.5", "19.25", "27", "no data", "28.25", "no data", "23"]
 ///     let tempsCelsius = temperatureData.map { Double($0) ?? .nan }
 ///     print(tempsCelsius)
-///     // Prints "[21.5, 19.25, 27, .nan, 28.25, .nan, 23.0]"
+///     // Prints "[21.5, 19.25, 27, nan, 28.25, nan, 23.0]"
 ///
 ///
 /// Note that some elements in the `temperatureData ` array are not valid

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -125,7 +125,9 @@
 ///
 ///     let temperatureData = ["21.5", "19.25", "27", "no data", "28.25", "no data", "23"]
 ///     let tempsCelsius = temperatureData.map { Double($0) ?? .nan }
-///     // tempsCelsius == [21.5, 19.25, 27, nan, 28.25, nan, 23.0]
+///     print(tempsCelsius)
+///     // Prints "[21.5, 19.25, 27, .nan, 28.25, .nan, 23.0]"
+///
 ///
 /// Note that some elements in the `temperatureData ` array are not valid
 /// numbers. When these invalid strings are parsed by the `Double` failable
@@ -135,7 +137,8 @@
 /// Next, the observations in Celsius are converted to Fahrenheit:
 ///
 ///     let tempsFahrenheit = tempsCelsius.map { $0 * 1.8 + 32 }
-///     // tempsFahrenheit == [70.7, 66.65, 80.6, nan, 82.85, nan, 73.4]
+///     print(tempsFahrenheit)
+///     // Prints "[70.7, 66.65, 80.6, nan, 82.85, nan, 73.4]"
 ///
 /// The NaN values in the `tempsCelsius` array are propagated through the
 /// conversion and remain NaN in `tempsFahrenheit`.
@@ -1104,7 +1107,8 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
   ///
   ///     var numbers = [2.5, 21.25, 3.0, .nan, -9.5]
   ///     numbers.sort { !$1.isTotallyOrdered(belowOrEqualTo: $0) }
-  ///     // numbers == [-9.5, 2.5, 3.0, 21.25, NaN]
+  ///     print(numbers)
+  ///     // Prints "[-9.5, 2.5, 3.0, 21.25, nan]"
   ///
   /// The `isTotallyOrdered(belowOrEqualTo:)` method implements the total order
   /// relation as defined by the [IEEE 754 specification][spec].


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixes example snippets in FloatingPoint.swift

In terms of Swift [-9.5, 2.5, 3.0, 21.25, .nan] != [-9.5, 2.5, 3.0, 21.25, .nan] because Double.nan != Double.nan
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
