### PR TITLE
[NFC] GenericSignatureImpl: Spell conformsToProtocol & getConformsTo in terms of requirements

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -152,7 +152,7 @@ public:
                       TypeArrayView<GenericTypeParamType> genericParams,
                       ArrayRef<Requirement> requirements);
 public:
-  using ConformsToArray = SmallVector<ProtocolDecl *, 2>;
+  using RequiredProtocols = SmallVector<ProtocolDecl *, 2>;
 
 private:
   // Direct comparison is disabled for generic signatures.  Canonicalize them
@@ -318,12 +318,13 @@ public:
   /// Determine the superclass bound on the given dependent type.
   Type getSuperclassBound(Type type) const;
 
-  /// Determine the set of protocols to which the given dependent type
-  /// must conform.
-  GenericSignature::ConformsToArray getConformsTo(Type type) const;
+  /// Determine the set of protocols to which the given type parameter is
+  /// required to conform.
+  GenericSignature::RequiredProtocols getRequiredProtocols(Type type) const;
 
-  /// Determine whether the given dependent type conforms to this protocol.
-  bool conformsToProtocol(Type type, ProtocolDecl *proto) const;
+  /// Determine whether the given type parameter is required to conform to
+  /// the given protocol.
+  bool requiresProtocol(Type type, ProtocolDecl *proto) const;
 
   /// Determine whether the given dependent type is equal to a concrete type.
   bool isConcreteType(Type type) const;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3723,11 +3723,8 @@ OpaqueTypeArchetypeType::get(OpaqueTypeDecl *Decl,
       superclass = superclass.subst(Substitutions);
     }
   #endif
-  SmallVector<ProtocolDecl*, 4> protos;
-  for (auto proto : signature->getConformsTo(opaqueInterfaceTy)) {
-    protos.push_back(proto);
-  }
-  
+  const auto protos = signature->getRequiredProtocols(opaqueInterfaceTy);
+
   auto mem = ctx.Allocate(
     OpaqueTypeArchetypeType::totalSizeToAlloc<ProtocolDecl *, Type, LayoutConstraint>(
       protos.size(), superclass ? 1 : 0, layout ? 1 : 0),

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2539,8 +2539,9 @@ void ASTMangler::appendGenericSignatureParts(
 DependentMemberType *
 ASTMangler::dropProtocolFromAssociatedType(DependentMemberType *dmt) {
   auto baseTy = dmt->getBase();
-  bool unambiguous = (!dmt->getAssocType() ||
-                      CurGenericSignature->getConformsTo(baseTy).size() <= 1);
+  bool unambiguous =
+      (!dmt->getAssocType() ||
+       CurGenericSignature->getRequiredProtocols(baseTy).size() <= 1);
 
   if (auto *baseDMT = baseTy->getAs<DependentMemberType>())
     baseTy = dropProtocolFromAssociatedType(baseDMT);
@@ -2573,8 +2574,8 @@ void ASTMangler::appendAssociatedTypeName(DependentMemberType *dmt) {
     // If the base type is known to have a single protocol conformance
     // in the current generic context, then we don't need to disambiguate the
     // associated type name by protocol.
-    if (!OptimizeProtocolNames || !CurGenericSignature
-        || CurGenericSignature->getConformsTo(dmt->getBase()).size() > 1) {
+    if (!OptimizeProtocolNames || !CurGenericSignature ||
+        CurGenericSignature->getRequiredProtocols(dmt->getBase()).size() > 1) {
       appendAnyGenericType(assocTy->getProtocol());
     }
     return;

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -368,7 +368,7 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
 
   // If the type doesn't conform to this protocol, the result isn't formed
   // from these requirements.
-  if (!genericSig->conformsToProtocol(type, proto))
+  if (!genericSig->requiresProtocol(type, proto))
     return ProtocolConformanceRef::forInvalid();
 
   auto accessPath =

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2416,7 +2416,7 @@ bool ClangImporter::Implementation::matchesHashableBound(Type type) {
     if (auto *generic = genericTy->getDecl()) {
       auto genericSig =
         generic->getDeclContext()->getGenericSignatureOfContext();
-      if (genericSig && genericSig->getConformsTo(type).empty()) {
+      if (genericSig && genericSig->getRequiredProtocols(type).empty()) {
         type = genericSig->getSuperclassBound(type);
         if (!type)
           return false;

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2344,7 +2344,7 @@ public:
       }
 
       if (t->isTypeParameter()) {
-        auto protos = genericSig->getConformsTo(t);
+        const auto protos = genericSig->getRequiredProtocols(t);
         if (!protos.empty())
           return buildProtocolComposition(protos);
       }
@@ -4729,7 +4729,7 @@ public:
     bool hasExplicitAnyObject = false;
     if (auto superTy = genericSig->getSuperclassBound(ResultT))
       opaqueTypes.push_back(superTy);
-    for (auto proto : genericSig->getConformsTo(ResultT))
+    for (const auto proto : genericSig->getRequiredProtocols(ResultT))
       opaqueTypes.push_back(proto->getDeclaredInterfaceType());
     if (auto layout = genericSig->getLayoutConstraint(ResultT))
       hasExplicitAnyObject = layout->isClass();

--- a/lib/IRGen/Fulfillment.h
+++ b/lib/IRGen/Fulfillment.h
@@ -68,7 +68,7 @@ public:
     virtual bool hasLimitedInterestingConformances(CanType type) const = 0;
 
     /// Return the limited interesting conformances for an interesting type.
-    virtual GenericSignature::ConformsToArray
+    virtual GenericSignature::RequiredProtocols
       getInterestingConformances(CanType type) const = 0;
 
     /// Return the limited interesting conformances for an interesting type.

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -101,8 +101,8 @@ protected:
 
   FulfillmentMap Fulfillments;
 
-  GenericSignature::ConformsToArray getConformsTo(Type t) {
-    return Generics->getConformsTo(t);
+  GenericSignature::RequiredProtocols getRequiredProtocols(Type t) {
+    return Generics->getRequiredProtocols(t);
   }
 
   CanType getSuperclassBound(Type t) {
@@ -166,9 +166,9 @@ private:
     bool hasLimitedInterestingConformances(CanType type) const override {
       return true;
     }
-    GenericSignature::ConformsToArray
+    GenericSignature::RequiredProtocols
     getInterestingConformances(CanType type) const override {
-      return Self.getConformsTo(type);
+      return Self.getRequiredProtocols(type);
     }
     CanType getSuperclassBound(CanType type) const override {
       return Self.getSuperclassBound(type);
@@ -1203,7 +1203,7 @@ public:
           bool hasLimitedInterestingConformances(CanType type) const override {
             return false;
           }
-          GenericSignature::ConformsToArray
+          GenericSignature::RequiredProtocols
           getInterestingConformances(CanType type) const override {
             llvm_unreachable("no limits");
           }

--- a/lib/IRGen/LocalTypeData.cpp
+++ b/lib/IRGen/LocalTypeData.cpp
@@ -497,7 +497,7 @@ void LocalTypeDataCache::addAbstractForTypeMetadata(IRGenFunction &IGF,
     bool hasLimitedInterestingConformances(CanType type) const override {
       return false;
     }
-    GenericSignature::ConformsToArray
+    GenericSignature::RequiredProtocols
     getInterestingConformances(CanType type) const override {
       llvm_unreachable("no limits");
     }

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -741,7 +741,7 @@ bool irgen::isNominalGenericContextTypeMetadataAccessTrivial(
 
   auto allWitnessTablesAreReferenceable = llvm::all_of(environment->getGenericParams(), [&](auto parameter) {
     auto signature = environment->getGenericSignature();
-    auto protocols = signature->getConformsTo(parameter);
+    const auto protocols = signature->getRequiredProtocols(parameter);
     auto argument = ((Type *)parameter)->subst(substitutions);
     auto canonicalType = argument->getCanonicalType();
     auto witnessTablesAreReferenceable = [&]() {

--- a/lib/PrintAsObjC/ModuleContentsWriter.cpp
+++ b/lib/PrintAsObjC/ModuleContentsWriter.cpp
@@ -71,8 +71,7 @@ class ReferencedTypeFinder : public TypeDeclFinder {
     if (sig->getSuperclassBound(paramTy))
       return true;
 
-    auto conformsTo = sig->getConformsTo(paramTy);
-    return !conformsTo.empty();
+    return !sig->getRequiredProtocols(paramTy).empty();
   }
 
   Action visitBoundGenericType(BoundGenericType *boundGeneric) override {

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2923,9 +2923,8 @@ public:
     require(selfRequirement &&
             selfRequirement->getKind() == RequirementKind::Conformance,
             "first non-same-typerequirement should be conformance requirement");
-    auto conformsTo = genericSig->getConformsTo(selfGenericParam);
-    require(std::find(conformsTo.begin(), conformsTo.end(), protocol)
-              != conformsTo.end(),
+    const auto protos = genericSig->getRequiredProtocols(selfGenericParam);
+    require(std::find(protos.begin(), protos.end(), protocol) != protos.end(),
             "requirement Self parameter must conform to called protocol");
 
     auto lookupType = AMI->getLookupType();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2750,7 +2750,7 @@ TypeEraserHasViableInitRequest::evaluate(Evaluator &evaluator,
     ParamDecl *param = *init->getParameters()->begin();
     if (param->getArgumentName() != ctx.Id_erasing ||
         !param->getInterfaceType()->isEqual(genericParamType) ||
-        !genericSignature->conformsToProtocol(genericParamType, protocol))
+        !genericSignature->requiresProtocol(genericParamType, protocol))
       return false;
 
     // Allow other constraints as long as the init can be called with any

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3707,7 +3707,7 @@ CheckTypeWitnessResult swift::checkTypeWitness(DeclContext *dc,
   auto *module = dc->getParentModule();
 
   // Check protocol conformances.
-  for (auto reqProto : genericSig->getConformsTo(depTy)) {
+  for (const auto reqProto : genericSig->getRequiredProtocols(depTy)) {
     if (module->lookupConformance(contextType, reqProto)
             .isInvalid())
       return CheckTypeWitnessResult(reqProto->getDeclaredType());

--- a/tools/swift-ast-script/ASTScriptEvaluator.cpp
+++ b/tools/swift-ast-script/ASTScriptEvaluator.cpp
@@ -60,7 +60,7 @@ public:
       auto paramResultType = paramFnType->getResult();
       if (!paramResultType->isTypeParameter()) continue;
       auto sig = fn->getGenericSignature();
-      if (!sig->conformsToProtocol(paramResultType, ViewProtocol)) continue;
+      if (!sig->requiresProtocol(paramResultType, ViewProtocol)) continue;
 
       // The parameter must not be a @ViewBuilder parameter.
       if (param->getFunctionBuilderType()) continue;


### PR DESCRIPTION
Make it clear that only abstract conformances are of interest to these methods.