### PR TITLE
Check SPI attribute usage in frozen types and on protocol requirements

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1705,6 +1705,10 @@ ERROR(spi_attribute_on_non_public,none,
       "cannot be declared '@_spi' because only public and open "
       "declarations can be '@_spi'",
       (AccessLevel, DescriptiveDeclKind))
+ERROR(spi_attribute_on_protocol_requirement,none,
+      "protocol requirement %0 cannot be declared '@_spi' without "
+      "a default implementation in a protocol extension",
+      (DeclName))
 
 // Opaque return types
 ERROR(opaque_type_invalid_constraint,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1709,6 +1709,9 @@ ERROR(spi_attribute_on_protocol_requirement,none,
       "protocol requirement %0 cannot be declared '@_spi' without "
       "a default implementation in a protocol extension",
       (DeclName))
+ERROR(spi_attribute_on_frozen_stored_properties,none,
+      "stored property %0 cannot be declared '@_spi' in a '@frozen' struct",
+      (DeclName))
 
 // Opaque return types
 ERROR(opaque_type_invalid_constraint,none,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -863,12 +863,51 @@ void AttributeChecker::visitSetterAccessAttr(
 
 void AttributeChecker::visitSPIAccessControlAttr(SPIAccessControlAttr *attr) {
   if (auto VD = dyn_cast<ValueDecl>(D)) {
+    // VD must be public or open to use an @_spi attribute.
     auto declAccess = VD->getFormalAccess();
     if (declAccess < AccessLevel::Public) {
       diagnoseAndRemoveAttr(attr,
                             diag::spi_attribute_on_non_public,
                             declAccess,
                             D->getDescriptiveKind());
+    }
+
+    // If VD is a public protocol requirement it can be SPI only if there's
+    // a default implementation.
+    if (auto protocol = dyn_cast<ProtocolDecl>(D->getDeclContext())) {
+      auto implementations = TypeChecker::lookupMember(
+                                             D->getDeclContext(),
+                                             protocol->getDeclaredType(),
+                                             VD->createNameRef(),
+                                             NameLookupFlags::ProtocolMembers);
+      bool hasDefaultImplementation = llvm::any_of(implementations,
+        [&](const LookupResultEntry &entry) {
+          auto entryDecl = entry.getValueDecl();
+          auto DC = entryDecl->getDeclContext();
+          auto extension = dyn_cast<ExtensionDecl>(DC);
+
+          // The implementation must be defined in the same module in
+          // an unconstrained extension.
+          if (!extension ||
+              extension->getParentModule() != protocol->getParentModule() ||
+              extension->isConstrainedExtension())
+            return false;
+
+          // For computed properties and subscripts, check that the default
+          // implementation defines `set` if the protocol declares it.
+          if (auto protoStorage = dyn_cast<AbstractStorageDecl>(VD))
+            if (auto entryStorage = dyn_cast<AbstractStorageDecl>(entryDecl))
+              if (protoStorage->getAccessor(AccessorKind::Set) &&
+                  !entryStorage->getAccessor(AccessorKind::Set))
+                return false;
+
+          return true;
+        });
+
+      if (!hasDefaultImplementation)
+        diagnoseAndRemoveAttr(attr,
+                              diag::spi_attribute_on_protocol_requirement,
+                              VD->getName());
     }
   }
 }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -909,6 +909,14 @@ void AttributeChecker::visitSPIAccessControlAttr(SPIAccessControlAttr *attr) {
                               diag::spi_attribute_on_protocol_requirement,
                               VD->getName());
     }
+
+    // Forbid stored properties marked SPI in frozen types.
+    if (auto property = dyn_cast<AbstractStorageDecl>(VD))
+      if (auto DC = dyn_cast<NominalTypeDecl>(D->getDeclContext()))
+        if (property->hasStorage() && !DC->isFormallyResilient())
+          diagnoseAndRemoveAttr(attr,
+                                diag::spi_attribute_on_frozen_stored_properties,
+                                VD->getName());
   }
 }
 

--- a/test/SPI/local_spi_decls.swift
+++ b/test/SPI/local_spi_decls.swift
@@ -31,7 +31,9 @@ func inlinable() -> SPIClass { // expected-error {{class 'SPIClass' is '@_spi' a
 @_spi(S) public struct SPIStruct {} // expected-note 2 {{struct 'SPIStruct' is not '@usableFromInline' or public}}
 
 @frozen public struct FrozenStruct {
-  @_spi(S) public var asdf = SPIStruct() // expected-error {{struct 'SPIStruct' is '@_spi' and cannot be referenced from a property initializer in a '@frozen' type}}
+  @_spi(S) public var spiInFrozen = SPIStruct() // expected-error {{struct 'SPIStruct' is '@_spi' and cannot be referenced from a property initializer in a '@frozen' type}}
+  // expected-error @-1 {{stored property 'spiInFrozen' cannot be declared '@_spi' in a '@frozen' struct}}
+
   var asdf = SPIStruct() // expected-error {{struct 'SPIStruct' is '@_spi' and cannot be referenced from a property initializer in a '@frozen' type}}
 }
 

--- a/test/SPI/protocol_requirement.swift
+++ b/test/SPI/protocol_requirement.swift
@@ -1,0 +1,71 @@
+// Test limitations on SPI protocol requirements.
+
+// RUN: %target-typecheck-verify-swift
+
+// Reject SPI protocol requirements without a default implementation.
+public protocol PublicProtoRejected {
+  @_spi(Private) // expected-error{{protocol requirement 'reqWithoutDefault()' cannot be declared '@_spi' without a default implementation in a protocol extension}}
+  func reqWithoutDefault()
+
+  @_spi(Private) // expected-error{{protocol requirement 'property' cannot be declared '@_spi' without a default implementation in a protocol extension}}
+  var property: Int { get set }
+
+  @_spi(Private) // expected-error{{protocol requirement 'propertyWithoutSetter' cannot be declared '@_spi' without a default implementation in a protocol extension}}
+  var propertyWithoutSetter: Int { get set }
+
+  @_spi(Private) // expected-error{{protocol requirement 'subscript(_:)' cannot be declared '@_spi' without a default implementation in a protocol extension}}
+  subscript(index: Int) -> Int { get set }
+
+  @_spi(Private) // expected-error{{protocol requirement 'init()' cannot be declared '@_spi' without a default implementation in a protocol extension}}
+  init()
+
+  @_spi(Private) // expected-error{{'@_spi' attribute cannot be applied to this declaration}}
+  associatedtype T
+}
+
+extension PublicProtoRejected {
+  @_spi(Private)
+  public var propertyWithoutSetter: Int { get { return 42 } }
+}
+
+extension PublicProtoRejected where Self : Equatable {
+  @_spi(Private)
+  public func reqWithoutDefault() {
+    // constrainted implementation
+  }
+}
+
+// Accept SPI protocol requirements with an implementation.
+public protocol PublicProto {
+  @_spi(Private)
+  func reqWithDefaultImplementation()
+
+  @_spi(Private)
+  var property: Int { get set }
+
+  @_spi(Private)
+  subscript(index: Int) -> Int { get set }
+
+  @_spi(Private)
+  init()
+}
+
+extension PublicProto {
+  @_spi(Private)
+  public func reqWithDefaultImplementation() { }
+
+  @_spi(Private)
+  public var property: Int {
+    get { return 42 }
+    set { }
+  }
+
+  @_spi(Private)
+  public subscript(index: Int) -> Int {
+    get { return 42 }
+    set { }
+  }
+
+  @_spi(Private)
+  public init() { }
+}

--- a/test/SPI/resilience.swift
+++ b/test/SPI/resilience.swift
@@ -1,0 +1,29 @@
+// Test limits of SPI members in frozen types.
+
+// RUN: %target-typecheck-verify-swift
+
+@frozen
+public struct FrozenStruct {
+  public var okProperty: Int
+
+  @_spi(S)
+  public var okComputedProperty: Int { get { return 42 } }
+
+  @_spi(S) // expected-error {{stored property 'spiProperty' cannot be declared '@_spi' in a '@frozen' struct}}
+  public var spiProperty: Int
+
+  @_spi(S) // expected-error {{stored property 'spiPropertySet' cannot be declared '@_spi' in a '@frozen' struct}}
+  public var spiPropertySet = 4
+
+  @_spi(S) // expected-error {{stored property 'spiPropertyDoubleErrors' cannot be declared '@_spi' in a '@frozen' struct}}
+  // expected-error @-1 {{internal property cannot be declared '@_spi' because only public and open declarations can be '@_spi'}}
+  var spiPropertyDoubleErrors: Int
+}
+
+public struct UnfrozenStruct {
+  @_spi(S)
+  public var spiProperty: Int
+
+  @_spi(S)
+  public var spiPropertySet = 4
+}


### PR DESCRIPTION
Add two soundness checks on the use of the `@_spi` attribute:
* Report stored properties marked with `@_spi` in frozen structs as an error. A frozen struct with an SPI stored properties would prevent clients to know the correct layout of the struct.
* Check that SPI requirements in public protocols have a default implementation defined in an unconstrained protocol extension in the same module.