### PR TITLE
[presets] Do not copy Swift resource dir into LLDB when building a to…

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1217,6 +1217,8 @@ dash-dash
 lldb-no-debugserver
 lldb-use-system-debugserver
 lldb-build-type=Release
+lldb-extra-cmake-args=
+  -DLLDB_FRAMEWORK_COPY_SWIFT_RESOURCES=OFF
 verbose-build
 build-ninja
 build-swift-stdlib-unittest-extra


### PR DESCRIPTION
…olchain

This is useless and leads in duplicated symbol file in the LLDB
framework.

rdar://61702866
