### PR TITLE
[NFC] AST: Const-qualify GenericSignatureImpl

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -101,7 +101,7 @@ class GenericTypeParamType;
 /// both the generic type parameters and the requirements placed on those
 /// generic parameters.
 class GenericSignature {
-  GenericSignatureImpl *Ptr;
+  const GenericSignatureImpl *Ptr;
 
 public:
   /// Create a new generic signature with the given type parameters and
@@ -118,13 +118,13 @@ public:
                                    ArrayRef<Requirement> requirements);
 
 public:
-  /*implicit*/ GenericSignature(GenericSignatureImpl *P = 0) : Ptr(P) {}
+  /*implicit*/ GenericSignature(const GenericSignatureImpl *P = 0) : Ptr(P) {}
 
-  GenericSignatureImpl *getPointer() const { return Ptr; }
+  const GenericSignatureImpl *getPointer() const { return Ptr; }
 
   bool isNull() const { return Ptr == 0; }
 
-  GenericSignatureImpl *operator->() const { return Ptr; }
+  const GenericSignatureImpl *operator->() const { return Ptr; }
 
   explicit operator bool() const { return Ptr != 0; }
 
@@ -175,7 +175,7 @@ public:
 public:
   CanGenericSignature(std::nullptr_t) : GenericSignature(nullptr) {}
 
-  explicit CanGenericSignature(GenericSignatureImpl *P = 0)
+  explicit CanGenericSignature(const GenericSignatureImpl *P = 0)
       : GenericSignature(P) {
     assert(isActuallyCanonicalOrNull() &&
            "Forming a CanGenericSignature out of a non-canonical signature!");
@@ -204,8 +204,8 @@ class alignas(1 << TypeAlignInBits) GenericSignatureImpl final
   GenericSignatureImpl(const GenericSignatureImpl&) = delete;
   void operator=(const GenericSignatureImpl&) = delete;
 
-  unsigned NumGenericParams;
-  unsigned NumRequirements;
+  const unsigned NumGenericParams;
+  const unsigned NumRequirements;
 
   GenericEnvironment *GenericEnv = nullptr;
 
@@ -220,23 +220,13 @@ class alignas(1 << TypeAlignInBits) GenericSignatureImpl final
     return NumRequirements;
   }
 
-  /// Retrieve a mutable version of the generic parameters.
-  MutableArrayRef<Type> getGenericParamsBuffer() {
-    return {getTrailingObjects<Type>(), NumGenericParams};
-  }
-
-  /// Retrieve a mutable version of the requirements.
-  MutableArrayRef<Requirement> getRequirementsBuffer() {
-    return {getTrailingObjects<Requirement>(), NumRequirements};
-  }
-
   GenericSignatureImpl(TypeArrayView<GenericTypeParamType> params,
                        ArrayRef<Requirement> requirements,
                        bool isKnownCanonical);
 
   // FIXME: Making this a CanGenericSignature reveals callers are violating
   // the interface's invariants.
-  mutable llvm::PointerUnion<GenericSignatureImpl *, ASTContext *>
+  mutable llvm::PointerUnion<const GenericSignatureImpl *, ASTContext *>
     CanonicalSignatureOrASTContext;
 
   void buildConformanceAccessPath(
@@ -244,15 +234,15 @@ class alignas(1 << TypeAlignInBits) GenericSignatureImpl final
       ArrayRef<Requirement> reqs,
       const void /*GenericSignatureBuilder::RequirementSource*/ *source,
       ProtocolDecl *conformingProto, Type rootType,
-      ProtocolDecl *requirementSignatureProto);
+      ProtocolDecl *requirementSignatureProto) const;
 
   friend class ArchetypeType;
 
 public:
   /// Retrieve the generic parameters.
   TypeArrayView<GenericTypeParamType> getGenericParams() const {
-    auto temp = const_cast<GenericSignatureImpl *>(this);
-    return TypeArrayView<GenericTypeParamType>(temp->getGenericParamsBuffer());
+    return TypeArrayView<GenericTypeParamType>(
+        {getTrailingObjects<Type>(), NumGenericParams});
   }
 
   /// Retrieve the innermost generic parameters.
@@ -263,7 +253,7 @@ public:
 
   /// Retrieve the requirements.
   ArrayRef<Requirement> getRequirements() const {
-    return const_cast<GenericSignatureImpl *>(this)->getRequirementsBuffer();
+    return {getTrailingObjects<Requirement>(), NumRequirements};
   }
 
   /// Only allow allocation by doing a placement new.
@@ -299,7 +289,7 @@ public:
   }
 
   /// Return true if these two generic signatures are equal.
-  bool isEqual(GenericSignature Other);
+  bool isEqual(GenericSignature Other) const;
 
   /// Determines whether this GenericSignature is canonical.
   bool isCanonical() const;
@@ -310,55 +300,55 @@ public:
   CanGenericSignature getCanonicalSignature() const;
 
   /// Retrieve the generic signature builder for the given generic signature.
-  GenericSignatureBuilder *getGenericSignatureBuilder();
+  GenericSignatureBuilder *getGenericSignatureBuilder() const;
 
   /// Returns the generic environment that provides fresh contextual types
   /// (archetypes) that correspond to the interface types in this generic
   /// signature.
-  GenericEnvironment *getGenericEnvironment();
+  GenericEnvironment *getGenericEnvironment() const;
 
   /// Uniquing for the ASTContext.
-  void Profile(llvm::FoldingSetNodeID &ID) {
+  void Profile(llvm::FoldingSetNodeID &ID) const {
     Profile(ID, getGenericParams(), getRequirements());
   }
   
   /// Determine whether the given dependent type is required to be a class.
-  bool requiresClass(Type type);
+  bool requiresClass(Type type) const;
 
   /// Determine the superclass bound on the given dependent type.
-  Type getSuperclassBound(Type type);
+  Type getSuperclassBound(Type type) const;
 
   /// Determine the set of protocols to which the given dependent type
   /// must conform.
-  GenericSignature::ConformsToArray getConformsTo(Type type);
+  GenericSignature::ConformsToArray getConformsTo(Type type) const;
 
   /// Determine whether the given dependent type conforms to this protocol.
-  bool conformsToProtocol(Type type, ProtocolDecl *proto);
+  bool conformsToProtocol(Type type, ProtocolDecl *proto) const;
 
   /// Determine whether the given dependent type is equal to a concrete type.
-  bool isConcreteType(Type type);
+  bool isConcreteType(Type type) const;
 
   /// Return the concrete type that the given dependent type is constrained to,
   /// or the null Type if it is not the subject of a concrete same-type
   /// constraint.
-  Type getConcreteType(Type type);
+  Type getConcreteType(Type type) const;
 
   /// Return the layout constraint that the given dependent type is constrained
   /// to, or the null LayoutConstraint if it is not the subject of layout
   /// constraint.
-  LayoutConstraint getLayoutConstraint(Type type);
+  LayoutConstraint getLayoutConstraint(Type type) const;
 
   /// Return whether two type parameters represent the same type under this
   /// generic signature.
   ///
   /// The type parameters must be known to not be concrete within the context.
-  bool areSameTypeParameterInContext(Type type1, Type type2);
+  bool areSameTypeParameterInContext(Type type1, Type type2) const;
 
   /// Determine if \c sig can prove \c requirement, meaning that it can deduce
   /// T: Foo or T == U (etc.) with the information it knows. This includes
   /// checking against global state, if any/all of the types in the requirement
   /// are concrete, not type parameters.
-  bool isRequirementSatisfied(Requirement requirement);
+  bool isRequirementSatisfied(Requirement requirement) const;
 
   /// Return the requirements of this generic signature that are not also
   /// satisfied by \c otherSig.
@@ -370,14 +360,15 @@ public:
 
   /// Return the canonical version of the given type under this generic
   /// signature.
-  CanType getCanonicalTypeInContext(Type type);
-  bool isCanonicalTypeInContext(Type type);
+  CanType getCanonicalTypeInContext(Type type) const;
+  bool isCanonicalTypeInContext(Type type) const;
 
   /// Return the canonical version of the given type under this generic
   /// signature.
   CanType getCanonicalTypeInContext(Type type,
-                                    GenericSignatureBuilder &builder);
-  bool isCanonicalTypeInContext(Type type, GenericSignatureBuilder &builder);
+                                    GenericSignatureBuilder &builder) const;
+  bool isCanonicalTypeInContext(Type type,
+                                GenericSignatureBuilder &builder) const;
 
   /// Retrieve the conformance access path used to extract the conformance of
   /// interface \c type to the given \c protocol.
@@ -392,14 +383,14 @@ public:
   ///
   /// \seealso ConformanceAccessPath
   ConformanceAccessPath getConformanceAccessPath(Type type,
-                                                 ProtocolDecl *protocol);
+                                                 ProtocolDecl *protocol) const;
 
   /// Get the ordinal of a generic parameter in this generic signature.
   ///
   /// For example, if you have a generic signature for a nested context like:
   ///   <t_0_0, t_0_1, t_1_0>
   /// then this will return 0 for t_0_0, 1 for t_0_1, and 2 for t_1_0.
-  unsigned getGenericParamOrdinal(GenericTypeParamType *param);
+  unsigned getGenericParamOrdinal(GenericTypeParamType *param) const;
       
   /// Get a substitution map that maps all of the generic signature's
   /// generic parameters to themselves.
@@ -440,7 +431,7 @@ static inline raw_ostream &operator<<(raw_ostream &OS,
 
 // A GenericSignature casts like a GenericSignatureImpl*.
 template <> struct simplify_type<const ::swift::GenericSignature> {
-  typedef ::swift::GenericSignatureImpl *SimpleType;
+  typedef const ::swift::GenericSignatureImpl *SimpleType;
   static SimpleType getSimplifiedValue(const ::swift::GenericSignature &Val) {
     return Val.getPointer();
   }

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -384,7 +384,7 @@ SourceLoc extractNearestSourceLoc(Type ty);
 class CanType : public Type {
   bool isActuallyCanonicalOrNull() const;
 
-  static bool isReferenceTypeImpl(CanType type, GenericSignatureImpl *sig,
+  static bool isReferenceTypeImpl(CanType type, const GenericSignatureImpl *sig,
                                   bool functionsCount);
   static bool isExistentialTypeImpl(CanType type);
   static bool isAnyExistentialTypeImpl(CanType type);
@@ -436,7 +436,7 @@ public:
   ///   - existentials with class or class protocol bounds
   /// But not:
   ///   - function types
-  bool allowsOwnership(GenericSignatureImpl *sig) const {
+  bool allowsOwnership(const GenericSignatureImpl *sig) const {
     return isReferenceTypeImpl(*this, sig,
                                /*functions count*/ false);
   }

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1114,7 +1114,7 @@ void simple_display(llvm::raw_ostream &out, AncestryFlags value);
 
 class AbstractGenericSignatureRequest :
     public SimpleRequest<AbstractGenericSignatureRequest,
-                         GenericSignature (GenericSignatureImpl *,
+                         GenericSignature (const GenericSignatureImpl *,
                                            SmallVector<GenericTypeParamType *, 2>,
                                            SmallVector<Requirement, 2>),
                          RequestFlags::Cached> {
@@ -1127,7 +1127,7 @@ private:
   // Evaluation.
   GenericSignature
   evaluate(Evaluator &evaluator,
-           GenericSignatureImpl *baseSignature,
+           const GenericSignatureImpl *baseSignature,
            SmallVector<GenericTypeParamType *, 2> addedParameters,
            SmallVector<Requirement, 2> addedRequirements) const;
 
@@ -1144,7 +1144,7 @@ public:
 class InferredGenericSignatureRequest :
     public SimpleRequest<InferredGenericSignatureRequest,
                          GenericSignature (ModuleDecl *,
-                                            GenericSignatureImpl *,
+                                            const GenericSignatureImpl *,
                                             GenericParamSource,
                                             SmallVector<Requirement, 2>,
                                             SmallVector<TypeLoc, 2>,
@@ -1160,7 +1160,7 @@ private:
   GenericSignature
   evaluate(Evaluator &evaluator,
            ModuleDecl *module,
-           GenericSignatureImpl *baseSignature,
+           const GenericSignatureImpl *baseSignature,
            GenericParamSource paramSource,
            SmallVector<Requirement, 2> addedRequirements,
            SmallVector<TypeLoc, 2> inferenceSources,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -16,7 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 SWIFT_REQUEST(TypeChecker, AbstractGenericSignatureRequest,
-              GenericSignature (GenericSignatureImpl *,
+              GenericSignature (const GenericSignatureImpl *,
                                 SmallVector<GenericTypeParamType *, 2>,
                                 SmallVector<Requirement, 2>),
               Cached, NoLocationInfo)
@@ -92,7 +92,7 @@ SWIFT_REQUEST(TypeChecker, HasDynamicCallableAttributeRequest,
 SWIFT_REQUEST(TypeChecker, HasImplementationOnlyImportsRequest,
               bool(SourceFile *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, InferredGenericSignatureRequest,
-              GenericSignature (ModuleDecl *, GenericSignatureImpl *,
+              GenericSignature (ModuleDecl *, const GenericSignatureImpl *,
                                  GenericParamSource,
                                  SmallVector<Requirement, 2>,
                                  SmallVector<TypeLoc, 2>, bool),

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -558,7 +558,7 @@ public:
   
   /// allowsOwnership() - Are variables of this type permitted to have
   /// ownership attributes?
-  bool allowsOwnership(GenericSignatureImpl *sig = nullptr);
+  bool allowsOwnership(const GenericSignatureImpl *sig = nullptr);
 
   /// Determine whether this type involves a type variable.
   bool hasTypeVariable() const {

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -7421,7 +7421,7 @@ static bool isCanonicalRequest(GenericSignature baseSignature,
 GenericSignature
 AbstractGenericSignatureRequest::evaluate(
          Evaluator &evaluator,
-         GenericSignatureImpl *baseSignature,
+         const GenericSignatureImpl *baseSignature,
          SmallVector<GenericTypeParamType *, 2> addedParameters,
          SmallVector<Requirement, 2> addedRequirements) const {
   // If nothing is added to the base signature, just return the base
@@ -7534,7 +7534,7 @@ AbstractGenericSignatureRequest::evaluate(
 GenericSignature
 InferredGenericSignatureRequest::evaluate(
         Evaluator &evaluator, ModuleDecl *parentModule,
-        GenericSignatureImpl *parentSig,
+        const GenericSignatureImpl *parentSig,
         GenericParamSource paramSource,
         SmallVector<Requirement, 2> addedRequirements,
         SmallVector<TypeLoc, 2> inferenceSources,

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -167,7 +167,7 @@ bool TypeBase::isAnyClassReferenceType() {
   return getCanonicalType().isAnyClassReferenceType();
 }
 
-bool CanType::isReferenceTypeImpl(CanType type, GenericSignatureImpl *sig,
+bool CanType::isReferenceTypeImpl(CanType type, const GenericSignatureImpl *sig,
                                   bool functionsCount) {
   switch (type->getKind()) {
 #define SUGARED_TYPE(id, parent) case TypeKind::id:
@@ -253,7 +253,7 @@ bool CanType::isReferenceTypeImpl(CanType type, GenericSignatureImpl *sig,
 ///   - existentials with class or class protocol bounds
 /// But not:
 ///   - function types
-bool TypeBase::allowsOwnership(GenericSignatureImpl *sig) {
+bool TypeBase::allowsOwnership(const GenericSignatureImpl *sig) {
   return getCanonicalType().allowsOwnership(sig);
 }
 


### PR DESCRIPTION
The only remaining mutation spots are `CanonicalSignatureOrASTContext` and `GenericEnv`.

This is supposed to be NFC.