### PR TITLE
[CodeCompletion] Inherit options when parsing new buffer

### DIFF
--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -315,10 +315,10 @@ bool CompletionInstance::performCachedOperationIfPossible(
   auto tmpBufferID = tmpSM.addMemBufferCopy(completionBuffer);
   tmpSM.setCodeCompletionPoint(tmpBufferID, Offset);
 
-  LangOptions langOpts;
+  LangOptions langOpts = CI.getASTContext().LangOpts;
   langOpts.DisableParserLookup = true;
-  TypeCheckerOptions typeckOpts;
-  SearchPathOptions searchPathOpts;
+  TypeCheckerOptions typeckOpts = CI.getASTContext().TypeCheckerOpts;
+  SearchPathOptions searchPathOpts = CI.getASTContext().SearchPathOpts;
   DiagnosticEngine tmpDiags(tmpSM);
   std::unique_ptr<ASTContext> tmpCtx(
       ASTContext::get(langOpts, typeckOpts, searchPathOpts, tmpSM, tmpDiags));
@@ -327,13 +327,20 @@ bool CompletionInstance::performCachedOperationIfPossible(
   registerTypeCheckerRequestFunctions(tmpCtx->evaluator);
   registerSILGenRequestFunctions(tmpCtx->evaluator);
   ModuleDecl *tmpM = ModuleDecl::create(Identifier(), *tmpCtx);
-  SourceFile *tmpSF = new (*tmpCtx) SourceFile(*tmpM, oldSF->Kind, tmpBufferID);
+  SourceFile *tmpSF = new (*tmpCtx)
+      SourceFile(*tmpM, oldSF->Kind, tmpBufferID, /*KeepParsedTokens=*/false,
+                 /*BuildSyntaxTree=*/false, oldSF->getParsingOptions());
   tmpSF->enableInterfaceHash();
   // Ensure all non-function-body tokens are hashed into the interface hash
   tmpCtx->LangOpts.EnableTypeFingerprints = false;
 
-  // Couldn't find any completion token?
+  // FIXME: Since we don't setup module loaders on the temporary AST context,
+  // 'canImport()' conditional compilation directive always fails. That causes
+  // interface hash change and prevents fast-completion.
+
+  // Parse and get the completion context.
   auto *newState = tmpSF->getDelayedParserState();
+  // Couldn't find any completion token?
   if (!newState->hasCodeCompletionDelayedDeclState())
     return false;
 

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -676,6 +676,10 @@ ParserResult<IfConfigDecl> Parser::parseIfConfig(
     SmallVector<ASTNode, 16> Elements;
     llvm::SaveAndRestore<bool> S(InInactiveClauseEnvironment,
                                  InInactiveClauseEnvironment || !isActive);
+    // Disable updating the interface hash inside inactive blocks.
+    llvm::SaveAndRestore<NullablePtr<llvm::MD5>> T(
+        CurrentTokenHash, isActive ? CurrentTokenHash : nullptr);
+
     if (isActive || !isVersionCondition) {
       parseElements(Elements, isActive);
     } else if (SyntaxContext->isEnabled()) {

--- a/test/SourceKit/CodeComplete/complete_sequence_ifconfig.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_ifconfig.swift
@@ -1,0 +1,37 @@
+struct MyStruct { func foo() {} }
+
+#if DEBUG
+import Swift
+#endif
+
+#if arch(x86_64)
+operator ++++++
+#endif
+
+#if !targetEnvironment(simulator)
+precedencegroup MyPrecedence
+#endif
+
+func foo(value: MyStruct) {
+  value.
+}
+
+// Ensure that compilation directives are equally evaluated and doesn't affect the fast completions.
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=complete -pos=16:9 -repeat-request=2 %s -- %s -target %target-triple \
+// RUN:   | %FileCheck %s
+
+// CHECK-LABEL: key.results: [
+// CHECK-NOT: ]
+// CHECK-DAG: key.description: "foo()",
+// CHECK-DAG: key.description: "self",
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext
+
+// CHECK-LABEL: key.results: [
+// CHECK-NOT: ]
+// CHECK-DAG: key.description: "foo()",
+// CHECK-DAG: key.description: "self",
+// CHECK: ],
+// CHECK: key.reusingastcontext: 1


### PR DESCRIPTION
for fast completions. Options may affect the parsing result.
Also, don't collect interface hash tokens inside inactive blocks.
