### PR TITLE
SILGen: Fix source location for the enum payload argument source

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3818,7 +3818,7 @@ RValue CallEmission::applyEnumElementConstructor(SGFContext C) {
                                                   resultFnType.getParams(),
                                                   /*canonicalVararg*/ true);
     auto arg = RValue(SGF, argVals, payloadTy->getCanonicalType());
-    payload = ArgumentSource(element, std::move(arg));
+    payload = ArgumentSource(uncurriedLoc, std::move(arg));
     formalResultType = cast<FunctionType>(formalResultType).getResult();
     origFormalType = origFormalType.getFunctionResultType();
   } else {

--- a/test/SILGen/Inputs/enum_debuginfo_other.swift
+++ b/test/SILGen/Inputs/enum_debuginfo_other.swift
@@ -1,0 +1,3 @@
+public enum MyEnum {
+  case hasPayload(argument: Any)
+}

--- a/test/SILGen/enum_debuginfo.swift
+++ b/test/SILGen/enum_debuginfo.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -emit-silgen %S/Inputs/enum_debuginfo_other.swift -primary-file %s -module-name enum_debuginfo -g -Xllvm -sil-print-debuginfo | %FileCheck %s
+
+public func makeEnum() -> MyEnum {
+  return .hasPayload(argument: 123)
+}
+
+// CHECK-NOT: enum_debuginfo_other.swift


### PR DESCRIPTION
We should use the source location of the call site, and not the enum
element declaration, otherwise we emit incorrect debug info.

Fixes <rdar://problem/63067437>.