### PR TITLE
[Sema] Forbid leaking implementation-only imported types in SPI decls

### DIFF
--- a/test/SPI/implementation_only_spi_import_exposability.swift
+++ b/test/SPI/implementation_only_spi_import_exposability.swift
@@ -1,0 +1,46 @@
+/// @_implementationOnly imported decls (SPI or not) should not be exposed in SPI.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -DLIB %s -module-name Lib -emit-module-path %t/Lib.swiftmodule
+// RUN: %target-typecheck-verify-swift -DCLIENT -I %t
+
+#if LIB
+
+@_spi(A) public func spiFunc() {}
+
+@_spi(A) public struct SPIStruct {
+  public init() {}
+}
+
+@_spi(A) public protocol SPIProtocol {}
+
+public func ioiFunc() {}
+
+public struct IOIStruct {
+  public init() {}
+}
+
+public protocol IOIProtocol {}
+
+#elseif CLIENT
+
+@_spi(A) @_implementationOnly import Lib
+
+@_spi(B) public func leakSPIStruct(_ a: SPIStruct) -> SPIStruct { fatalError() } // expected-error 2 {{cannot use struct 'SPIStruct' here; 'Lib' has been imported as implementation-only}}
+@_spi(B) public func leakIOIStruct(_ a: IOIStruct) -> IOIStruct { fatalError() } // expected-error 2 {{cannot use struct 'IOIStruct' here; 'Lib' has been imported as implementation-only}}
+
+public struct PublicStruct : IOIProtocol, SPIProtocol { // expected-error {{cannot use protocol 'IOIProtocol' here; 'Lib' has been imported as implementation-only}}
+// expected-error @-1 {{cannot use protocol 'SPIProtocol' here; 'Lib' has been imported as implementation-only}}
+  public var spiStruct = SPIStruct() // expected-error {{cannot use struct 'SPIStruct' here; 'Lib' has been imported as implementation-only}}
+  public var ioiStruct = IOIStruct() // expected-error {{cannot use struct 'IOIStruct' here; 'Lib' has been imported as implementation-only}}
+
+  @inlinable
+  public func publicInlinable() {
+    spiFunc() // expected-error {{global function 'spiFunc()' is '@_spi' and cannot be referenced from an '@inlinable' function}}
+    ioiFunc() // expected-error {{global function 'ioiFunc()' cannot be used in an '@inlinable' function because 'Lib' was imported implementation-only}}
+    let s = SPIStruct() // expected-error {{struct 'SPIStruct' is '@_spi' and cannot be referenced from an '@inlinable' function}}
+    let i = IOIStruct() // expected-error {{struct 'IOIStruct' cannot be used in an '@inlinable' function because 'Lib' was imported implementation-only}}
+  }
+}
+
+#endif


### PR DESCRIPTION
The use of `@_spi(Secret) @_implementationOnly import Lib` means that the API and `Secret` SPI of `Lib` is imported for use in local implementation details and the dependency on `Lib` is hidden from all clients. This PR fixes a flaw allowing types imported as implementation-only to be exposed in the SPI of the local module. This could lead to the compiler emitting an invalid *.private.swiftinterface* file that would use types in SPI signatures without the related import hidden from even internal clients.

We are considering changing the meaning of such an import but for now let’s make sure to enforce the expected behavior in a consistent way.