### PR TITLE
[AutoDiff] Fix semantic member accessor linear map structs.

### DIFF
--- a/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
+++ b/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
@@ -408,6 +408,11 @@ void LinearMapInfo::generateDifferentiationDataStructures(
     linearMapStructEnumFields.insert({linearMapStruct, traceEnumField});
   }
 
+  // Do not add linear map fields for semantic member accessors, which have
+  // special-case pullback generation. Linear map structs should be empty.
+  if (isSemanticMemberAccessor(original))
+    return;
+
   // Add linear map fields to the linear map structs.
   for (auto &origBB : *original) {
     for (auto &inst : origBB) {


### PR DESCRIPTION
Ensure that semantic member accessors have empty linear map structs.
Semantic member accessor VJPs do not accumulate any callee pullbacks.

Resolves SR-12800: SIL verification error.

---

```swift
import _Differentiation

@propertyWrapper
struct Wrapper<Value> {
  private var value: Value

  @differentiable(where Value: Differentiable)
  var wrappedValue: Value {
    get { value }
    set { value = newValue }
  }
}
extension Wrapper: Differentiable where Value: Differentiable {}

struct Struct: Differentiable {
  @Wrapper var property: Float

  static func testGetter() {
    // SR-1280: trigger semantic member accessor VJP/pullback generation.
    let _: @differentiable (Struct) -> Float = { $0.property }
  }
}
```

Before:
```console
$ swift test.swift
SIL verification failed: number of struct operands does not match number of stored member variables of struct: opi != opEnd
Verifying instruction:
->   %15 = struct $_AD__$s4test6StructV8propertySfvg_bb0__PB__src_0_wrt_0 () // user: %17
     %17 = partial_apply [callee_guaranteed] %16(%15) : $@convention(method) (Float, @owned _AD__$s4test6StructV8propertySfvg_bb0__PB__src_0_wrt_0) -> Struct.TangentVector // user: %18
In function:
// AD__$s4test6StructV8propertySfvg__vjp_src_0_wrt_0
...
```

After: no verification failure.