### PR TITLE
runtime: explicitly namespace ArrayRef in shared headers

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2000,7 +2000,7 @@ public:
   }
 
   /// Retrieve the set of protocols required by the existential.
-  ArrayRef<ProtocolDescriptorRef> getProtocols() const {
+  llvm::ArrayRef<ProtocolDescriptorRef> getProtocols() const {
     return { this->template getTrailingObjects<ProtocolDescriptorRef>(),
              NumProtocols };
   }
@@ -2013,7 +2013,7 @@ public:
   }
 
   /// Retrieve the set of protocols required by the existential.
-  MutableArrayRef<ProtocolDescriptorRef> getMutableProtocols() {
+  llvm::MutableArrayRef<ProtocolDescriptorRef> getMutableProtocols() {
     return { this->template getTrailingObjects<ProtocolDescriptorRef>(),
              NumProtocols };
   }
@@ -2535,13 +2535,13 @@ public:
   getWitnessTable(const TargetMetadata<Runtime> *type) const;
 
   /// Retrieve the resilient witnesses.
-  ArrayRef<ResilientWitness> getResilientWitnesses() const{
+  llvm::ArrayRef<ResilientWitness> getResilientWitnesses() const {
     if (!Flags.hasResilientWitnesses())
       return { };
 
-    return ArrayRef<ResilientWitness>(
-             this->template getTrailingObjects<ResilientWitness>(),
-             numTrailingObjects(OverloadToken<ResilientWitness>()));
+    return llvm::ArrayRef<ResilientWitness>(
+        this->template getTrailingObjects<ResilientWitness>(),
+        numTrailingObjects(OverloadToken<ResilientWitness>()));
   }
 
   ConstTargetPointer<Runtime, GenericWitnessTable>
@@ -2828,23 +2828,23 @@ class TargetGenericEnvironment
 
 public:
   /// Retrieve the cumulative generic parameter counts at each level of genericity.
-  ArrayRef<uint16_t> getGenericParameterCounts() const {
-    return ArrayRef<uint16_t>(this->template getTrailingObjects<uint16_t>(),
+  llvm::ArrayRef<uint16_t> getGenericParameterCounts() const {
+    return llvm::makeArrayRef(this->template getTrailingObjects<uint16_t>(),
                               Flags.getNumGenericParameterLevels());
   }
 
   /// Retrieve the generic parameters descriptors.
-  ArrayRef<GenericParamDescriptor> getGenericParameters() const {
-    return ArrayRef<GenericParamDescriptor>(
-             this->template getTrailingObjects<GenericParamDescriptor>(),
-             getGenericParameterCounts().back());
+  llvm::ArrayRef<GenericParamDescriptor> getGenericParameters() const {
+    return llvm::makeArrayRef(
+        this->template getTrailingObjects<GenericParamDescriptor>(),
+        getGenericParameterCounts().back());
   }
 
   /// Retrieve the generic requirements.
-  ArrayRef<GenericRequirementDescriptor> getGenericRequirements() const {
-    return ArrayRef<GenericRequirementDescriptor>(
-             this->template getTrailingObjects<GenericRequirementDescriptor>(),
-             Flags.getNumGenericRequirements());
+  llvm::ArrayRef<GenericRequirementDescriptor> getGenericRequirements() const {
+    return llvm::makeArrayRef(
+        this->template getTrailingObjects<GenericRequirementDescriptor>(),
+        Flags.getNumGenericRequirements());
   }
 };
 
@@ -4604,7 +4604,8 @@ class DynamicReplacementScope
                                   DynamicReplacementDescriptor>;
   friend TrailingObjects;
 
-  ArrayRef<DynamicReplacementDescriptor> getReplacementDescriptors() const {
+  llvm::ArrayRef<DynamicReplacementDescriptor>
+  getReplacementDescriptors() const {
     return {this->template getTrailingObjects<DynamicReplacementDescriptor>(),
             numReplacements};
   }

--- a/include/swift/Basic/LLVM.h
+++ b/include/swift/Basic/LLVM.h
@@ -38,8 +38,10 @@ namespace llvm {
   template <typename T, unsigned N> class SmallVector;
   template <unsigned N> class SmallString;
   template <typename T, unsigned N> class SmallSetVector;
+#if !defined(swiftCore_EXPORTS)
   template<typename T> class ArrayRef;
   template<typename T> class MutableArrayRef;
+#endif
   template<typename T> class TinyPtrVector;
   template<typename T> class Optional;
   template <typename ...PTs> class PointerUnion;
@@ -63,9 +65,11 @@ namespace swift {
   using llvm::cast_or_null;
 
   // Containers.
+#if !defined(swiftCore_EXPORTS)
   using llvm::ArrayRef;
-  using llvm::iterator_range;
   using llvm::MutableArrayRef;
+#endif
+  using llvm::iterator_range;
   using llvm::None;
   using llvm::Optional;
   using llvm::PointerUnion;

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -23,6 +23,7 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/Runtime/Unreachable.h"
 #include "swift/Strings.h"
+#include "llvm/ADT/ArrayRef.h"
 #include <vector>
 
 namespace swift {
@@ -876,7 +877,7 @@ class TypeDecoder {
         }
       }
       genericArgsLevels.push_back(genericArgsBuf.size());
-      std::vector<ArrayRef<BuiltType>> genericArgs;
+      std::vector<llvm::ArrayRef<BuiltType>> genericArgs;
       for (unsigned i = 0; i < genericArgsLevels.size() - 1; ++i) {
         auto start = genericArgsLevels[i], end = genericArgsLevels[i+1];
         genericArgs.emplace_back(genericArgsBuf.data() + start,

--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -346,11 +346,11 @@ class OpaqueArchetypeTypeRef final : public TypeRef {
   // Each ArrayRef in ArgumentLists references into the buffer owned by this
   // vector, which must not be modified after construction.
   std::vector<const TypeRef *> AllArgumentsBuf;
-  std::vector<ArrayRef<const TypeRef *>> ArgumentLists;
-  
-  static TypeRefID Profile(StringRef idString,
-                           StringRef description, unsigned ordinal,
-                           ArrayRef<ArrayRef<const TypeRef *>> argumentLists) {
+  std::vector<llvm::ArrayRef<const TypeRef *>> ArgumentLists;
+
+  static TypeRefID
+  Profile(StringRef idString, StringRef description, unsigned ordinal,
+          llvm::ArrayRef<llvm::ArrayRef<const TypeRef *>> argumentLists) {
     TypeRefID ID;
     ID.addString(idString.str());
     ID.addInteger(ordinal);
@@ -362,14 +362,13 @@ class OpaqueArchetypeTypeRef final : public TypeRef {
     
     return ID;
   }
-  
+
 public:
-  OpaqueArchetypeTypeRef(StringRef id,
-                         StringRef description, unsigned ordinal,
-                         ArrayRef<ArrayRef<const TypeRef *>> argumentLists)
-    : TypeRef(TypeRefKind::OpaqueArchetype),
-      ID(id), Description(description), Ordinal(ordinal)
-  {
+  OpaqueArchetypeTypeRef(
+      StringRef id, StringRef description, unsigned ordinal,
+      llvm::ArrayRef<llvm::ArrayRef<const TypeRef *>> argumentLists)
+      : TypeRef(TypeRefKind::OpaqueArchetype), ID(id), Description(description),
+        Ordinal(ordinal) {
     std::vector<unsigned> argumentListLengths;
     
     for (auto argList : argumentLists) {
@@ -379,25 +378,24 @@ public:
     }
     auto *data = AllArgumentsBuf.data();
     for (auto length : argumentListLengths) {
-      ArgumentLists.push_back(ArrayRef<const TypeRef *>(data, length));
+      ArgumentLists.push_back(llvm::ArrayRef<const TypeRef *>(data, length));
       data += length;
     }
     assert(data == AllArgumentsBuf.data() + AllArgumentsBuf.size());
   }
-  
+
   template <typename Allocator>
-  static const OpaqueArchetypeTypeRef *create(Allocator &A,
-                                     StringRef id, StringRef description,
-                                     unsigned ordinal,
-                                     ArrayRef<ArrayRef<const TypeRef *>> arguments) {
+  static const OpaqueArchetypeTypeRef *
+  create(Allocator &A, StringRef id, StringRef description, unsigned ordinal,
+         llvm::ArrayRef<llvm::ArrayRef<const TypeRef *>> arguments) {
     FIND_OR_CREATE_TYPEREF(A, OpaqueArchetypeTypeRef,
                            id, description, ordinal, arguments);
   }
 
-  ArrayRef<ArrayRef<const TypeRef *>> getArgumentLists() const {
+  llvm::ArrayRef<llvm::ArrayRef<const TypeRef *>> getArgumentLists() const {
     return ArgumentLists;
   }
-  
+
   unsigned getOrdinal() const {
     return Ordinal;
   }

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -361,14 +361,14 @@ public:
 
   const BoundGenericTypeRef *
   createBoundGenericType(const Optional<std::string> &mangledName,
-                         ArrayRef<const TypeRef *> args,
+                         llvm::ArrayRef<const TypeRef *> args,
                          const TypeRef *parent) {
     return BoundGenericTypeRef::create(*this, *mangledName, args, parent);
   }
-  
+
   const TypeRef *
   resolveOpaqueType(NodePointer opaqueDescriptor,
-                    ArrayRef<ArrayRef<const TypeRef *>> genericArgs,
+                    llvm::ArrayRef<llvm::ArrayRef<const TypeRef *>> genericArgs,
                     unsigned ordinal) {
     // TODO: Produce a type ref for the opaque type if the underlying type isn't
     // available.
@@ -403,26 +403,25 @@ public:
                                           genericArgs);
   }
 
-  const TupleTypeRef *
-  createTupleType(ArrayRef<const TypeRef *> elements,
-                  std::string &&labels, bool isVariadic) {
+  const TupleTypeRef *createTupleType(llvm::ArrayRef<const TypeRef *> elements,
+                                      std::string &&labels, bool isVariadic) {
     // FIXME: Add uniqueness checks in TupleTypeRef::Profile and
     // unittests/Reflection/TypeRef.cpp if using labels for identity.
     return TupleTypeRef::create(*this, elements, isVariadic);
   }
 
   const FunctionTypeRef *createFunctionType(
-      ArrayRef<remote::FunctionParam<const TypeRef *>> params,
+      llvm::ArrayRef<remote::FunctionParam<const TypeRef *>> params,
       const TypeRef *result, FunctionTypeFlags flags) {
     return FunctionTypeRef::create(*this, params, result, flags);
   }
 
   const FunctionTypeRef *createImplFunctionType(
-    Demangle::ImplParameterConvention calleeConvention,
-    ArrayRef<Demangle::ImplFunctionParam<const TypeRef *>> params,
-    ArrayRef<Demangle::ImplFunctionResult<const TypeRef *>> results,
-    Optional<Demangle::ImplFunctionResult<const TypeRef *>> errorResult,
-    ImplFunctionTypeFlags flags) {
+      Demangle::ImplParameterConvention calleeConvention,
+      llvm::ArrayRef<Demangle::ImplFunctionParam<const TypeRef *>> params,
+      llvm::ArrayRef<Demangle::ImplFunctionResult<const TypeRef *>> results,
+      Optional<Demangle::ImplFunctionResult<const TypeRef *>> errorResult,
+      ImplFunctionTypeFlags flags) {
     // Minimal support for lowered function types. These come up in
     // reflection as capture types. For the reflection library's
     // purposes, the only part that matters is the convention.
@@ -451,9 +450,8 @@ public:
   }
 
   const ProtocolCompositionTypeRef *
-  createProtocolCompositionType(ArrayRef<BuiltProtocolDecl> protocols,
-                                BuiltType superclass,
-                                bool isClassBound) {
+  createProtocolCompositionType(llvm::ArrayRef<BuiltProtocolDecl> protocols,
+                                BuiltType superclass, bool isClassBound) {
     std::vector<const TypeRef *> protocolRefs;
     for (const auto &protocol : protocols) {
       if (!protocol)
@@ -530,7 +528,7 @@ public:
 
   const ObjCClassTypeRef *
   createBoundGenericObjCClassType(const std::string &name,
-                                  ArrayRef<const TypeRef *> args) {
+                                  llvm::ArrayRef<const TypeRef *> args) {
     // Remote reflection just ignores generic arguments for Objective-C
     // lightweight generic types, since they don't affect layout.
     return createObjCClassType(name);

--- a/include/swift/Runtime/Numeric.h
+++ b/include/swift/Runtime/Numeric.h
@@ -44,9 +44,9 @@ public:
   /// Return the chunks of data making up this value, arranged starting from
   /// the least-significant chunk.  The value is sign-extended to fill the
   /// final chunk.
-  ArrayRef<UnsignedChunk> getData() const {
-    return ArrayRef<UnsignedChunk>(Data,
-                      (Flags.getBitWidth() + BitsPerChunk - 1) / BitsPerChunk);
+  llvm::ArrayRef<UnsignedChunk> getData() const {
+    return llvm::makeArrayRef(Data, (Flags.getBitWidth() + BitsPerChunk - 1) /
+                                        BitsPerChunk);
   }
 
   /// The flags for this value.

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -1072,9 +1072,9 @@ public:
         newArgsBuffer.push_back(visit(arg));
       }
     }
-    
-    std::vector<ArrayRef<const TypeRef *>> newArgLists;
-    
+
+    std::vector<llvm::ArrayRef<const TypeRef *>> newArgLists;
+
     return OpaqueArchetypeTypeRef::create(Builder, O->getID(), O->getDescription(),
                                           O->getOrdinal(),
                                           newArgLists);

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -5311,7 +5311,7 @@ checkTransitiveCompleteness(const Metadata *initialType) {
 /// Diagnose a metadata dependency cycle.
 SWIFT_NORETURN static void
 diagnoseMetadataDependencyCycle(const Metadata *start,
-                                ArrayRef<MetadataDependency> links) {
+                                llvm::ArrayRef<MetadataDependency> links) {
   assert(start == links.back().Value);
 
   std::string diagnostic =

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -892,9 +892,9 @@ public:
 
 #pragma mark Metadata lookup via mangled name
 
-Optional<unsigned> swift::_depthIndexToFlatIndex(
-                                              unsigned depth, unsigned index,
-                                              ArrayRef<unsigned> paramCounts) {
+Optional<unsigned>
+swift::_depthIndexToFlatIndex(unsigned depth, unsigned index,
+                              llvm::ArrayRef<unsigned> paramCounts) {
   // Out-of-bounds depth.
   if (depth >= paramCounts.size()) return None;
 
@@ -945,8 +945,8 @@ bool swift::_gatherGenericParameterCounts(
 }
 
 /// Retrieve the generic parameters introduced in this context.
-static ArrayRef<GenericParamDescriptor> getLocalGenericParams(
-    const ContextDescriptor *context) {
+static llvm::ArrayRef<GenericParamDescriptor>
+getLocalGenericParams(const ContextDescriptor *context) {
   if (!context->isGeneric())
     return { };
 
@@ -961,13 +961,13 @@ static ArrayRef<GenericParamDescriptor> getLocalGenericParams(
   return genericContext->getGenericParams().slice(startParamIndex);
 }
 
-static bool _gatherGenericParameters(
-                          const ContextDescriptor *context,
-                          ArrayRef<const Metadata *> genericArgs,
-                          const Metadata *parent,
-                          SmallVectorImpl<unsigned> &genericParamCounts,
-                          SmallVectorImpl<const void *> &allGenericArgsVec,
-                          Demangler &demangler) {
+static bool
+_gatherGenericParameters(const ContextDescriptor *context,
+                         llvm::ArrayRef<const Metadata *> genericArgs,
+                         const Metadata *parent,
+                         llvm::SmallVectorImpl<unsigned> &genericParamCounts,
+                         llvm::SmallVectorImpl<const void *> &allGenericArgsVec,
+                         Demangler &demangler) {
   // Figure out the various levels of generic parameters we have in
   // this type.
   (void)_gatherGenericParameterCounts(context,
@@ -1176,9 +1176,10 @@ public:
 
   Demangle::NodeFactory &getNodeFactory() { return demangler; }
 
-  BuiltType resolveOpaqueType(NodePointer opaqueDecl,
-                              ArrayRef<ArrayRef<BuiltType>> genericArgs,
-                              unsigned ordinal) {
+  BuiltType
+  resolveOpaqueType(NodePointer opaqueDecl,
+                    llvm::ArrayRef<llvm::ArrayRef<BuiltType>> genericArgs,
+                    unsigned ordinal) {
     auto descriptor = _findOpaqueTypeDescriptor(opaqueDecl, demangler);
     if (!descriptor)
       return BuiltType();
@@ -1212,7 +1213,7 @@ public:
         return substitutions.getWitnessTable(type, index);
       }).getMetadata();
   }
-  
+
   BuiltTypeDecl createTypeDecl(NodePointer node,
                                bool &typeAlias) const {
     // Look for a nominal type descriptor based on its mangled name.
@@ -1255,8 +1256,9 @@ public:
 #endif
   }
 
-  BuiltType createBoundGenericObjCClassType(const std::string &mangledName,
-                                            ArrayRef<BuiltType> args) const {
+  BuiltType
+  createBoundGenericObjCClassType(const std::string &mangledName,
+                                  llvm::ArrayRef<BuiltType> args) const {
     // Generic arguments of lightweight Objective-C generic classes are not
     // reified in the metadata.
     return createObjCClassType(mangledName);
@@ -1278,7 +1280,7 @@ public:
   }
 
   BuiltType createBoundGenericType(BuiltTypeDecl anyTypeDecl,
-                                   ArrayRef<BuiltType> genericArgs,
+                                   llvm::ArrayRef<BuiltType> genericArgs,
                                    BuiltType parent) const {
     auto typeDecl = dyn_cast<TypeContextDescriptor>(anyTypeDecl);
     if (!typeDecl) {
@@ -1326,9 +1328,9 @@ public:
     return swift_getExistentialMetatypeMetadata(instance);
   }
 
-  BuiltType createProtocolCompositionType(ArrayRef<BuiltProtocolDecl> protocols,
-                                          BuiltType superclass,
-                                          bool isClassBound) const {
+  BuiltType
+  createProtocolCompositionType(llvm::ArrayRef<BuiltProtocolDecl> protocols,
+                                BuiltType superclass, bool isClassBound) const {
     // Determine whether we have a class bound.
     ProtocolClassConstraint classConstraint = ProtocolClassConstraint::Any;
     if (isClassBound || superclass) {
@@ -1360,9 +1362,9 @@ public:
     return BuiltType();
   }
 
-  BuiltType createFunctionType(
-                           ArrayRef<Demangle::FunctionParam<BuiltType>> params,
-                           BuiltType result, FunctionTypeFlags flags) const {
+  BuiltType
+  createFunctionType(llvm::ArrayRef<Demangle::FunctionParam<BuiltType>> params,
+                     BuiltType result, FunctionTypeFlags flags) const {
     SmallVector<BuiltType, 8> paramTypes;
     SmallVector<uint32_t, 8> paramFlags;
 
@@ -1384,18 +1386,17 @@ public:
   }
 
   BuiltType createImplFunctionType(
-    Demangle::ImplParameterConvention calleeConvention,
-    ArrayRef<Demangle::ImplFunctionParam<BuiltType>> params,
-    ArrayRef<Demangle::ImplFunctionResult<BuiltType>> results,
-    Optional<Demangle::ImplFunctionResult<BuiltType>> errorResult,
-    ImplFunctionTypeFlags flags) {
+      Demangle::ImplParameterConvention calleeConvention,
+      llvm::ArrayRef<Demangle::ImplFunctionParam<BuiltType>> params,
+      llvm::ArrayRef<Demangle::ImplFunctionResult<BuiltType>> results,
+      Optional<Demangle::ImplFunctionResult<BuiltType>> errorResult,
+      ImplFunctionTypeFlags flags) {
     // We can't realize the metadata for a SILFunctionType.
     return BuiltType();
   }
 
-  BuiltType createTupleType(ArrayRef<BuiltType> elements,
-                            std::string labels,
-                            bool variadic) const {
+  BuiltType createTupleType(llvm::ArrayRef<BuiltType> elements,
+                            std::string labels, bool variadic) const {
     // TODO: 'variadic' should no longer exist
     auto flags = TupleTypeFlags().withNumElements(elements.size());
     if (!labels.empty())
@@ -2195,8 +2196,8 @@ class AutomaticDynamicReplacements
                                   AutomaticDynamicReplacementEntry>;
   friend TrailingObjects;
 
-
-  ArrayRef<AutomaticDynamicReplacementEntry> getReplacementEntries() const {
+  llvm::ArrayRef<AutomaticDynamicReplacementEntry>
+  getReplacementEntries() const {
     return {
         this->template getTrailingObjects<AutomaticDynamicReplacementEntry>(),
         numScopes};
@@ -2239,8 +2240,8 @@ class AutomaticDynamicReplacementsSome
                                   DynamicReplacementSomeDescriptor>;
   friend TrailingObjects;
 
-
-  ArrayRef<DynamicReplacementSomeDescriptor> getReplacementEntries() const {
+  llvm::ArrayRef<DynamicReplacementSomeDescriptor>
+  getReplacementEntries() const {
     return {
         this->template getTrailingObjects<DynamicReplacementSomeDescriptor>(),
         numEntries};

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -286,7 +286,7 @@ public:
     /// An element in the descriptor path.
     struct PathElement {
       /// The generic parameters local to this element.
-      ArrayRef<GenericParamDescriptor> localGenericParams;
+      llvm::ArrayRef<GenericParamDescriptor> localGenericParams;
 
       /// The total number of generic parameters.
       unsigned numTotalGenericParams;


### PR DESCRIPTION
There are a set of headers shared between the Swift compiler and the
runtime.  Ensure that we explicitly use `llvm::ArrayRef` rather than
`ArrayRef` which is aliased to `::llvm::ArrayRef`.  Doing so enables us
to replace the `ArrayRef` with an inline namespaced version fixing ODR
violations when the swift runtime is loaded into an address space with
LLVM.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
