### PR TITLE
[AutoDiff] Fix semantic member accessor linear map structs.

### DIFF
--- a/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
+++ b/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
@@ -408,6 +408,11 @@ void LinearMapInfo::generateDifferentiationDataStructures(
     linearMapStructEnumFields.insert({linearMapStruct, traceEnumField});
   }
 
+  // Do not add linear map fields for semantic member accessors, which have
+  // special-case pullback generation. Linear map structs should be empty.
+  if (isSemanticMemberAccessor(original))
+    return;
+
   // Add linear map fields to the linear map structs.
   for (auto &origBB : *original) {
     for (auto &inst : origBB) {


### PR DESCRIPTION
Cherry-pick of `master` branch PR: https://github.com/apple/swift/pull/31745

Ensure that semantic member accessors have empty linear map structs.
Semantic member accessor VJPs do not accumulate any callee pullbacks.

Resolves SR-12800: SIL verification error.

