### PR TITLE
Don't emit debug line numbers for Swift type forward declarations

### DIFF
--- a/test/ClangImporter/objc_ir.swift
+++ b/test/ClangImporter/objc_ir.swift
@@ -361,12 +361,12 @@ func testBlocksWithGenerics(hba: HasBlockArray) -> Any {
 
 // CHECK: ![[SWIFT_NAME_ALIAS_VAR]] = !DILocalVariable(name: "obj", arg: 1, scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: {{[0-9]+}}, type: ![[SWIFT_NAME_ALIAS_TYPE:[0-9]+]])
 // CHECK: ![[LET_SWIFT_NAME_ALIAS_TYPE:[0-9]+]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[SWIFT_NAME_ALIAS_TYPE:[0-9]+]])
-// CHECK: ![[SWIFT_NAME_ALIAS_TYPE]] = !DIDerivedType(tag: DW_TAG_typedef, name: "$sSo14SwiftNameAliasaD", scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: {{[0-9]+}}, baseType: !{{[0-9]+}})
+// CHECK: ![[SWIFT_NAME_ALIAS_TYPE]] = !DIDerivedType(tag: DW_TAG_typedef, name: "$sSo14SwiftNameAliasaD", scope: !{{[0-9]+}}, file: !{{[0-9]+}}, baseType: !{{[0-9]+}})
 
 // CHECK: ![[SWIFT_GENERIC_NAME_ALIAS_VAR]] = !DILocalVariable(name: "generic_obj", arg: 1, scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: {{[0-9]+}}, type: ![[LET_SWIFT_GENERIC_NAME_ALIAS_TYPE:[0-9]+]])
 // CHECK: ![[LET_SWIFT_GENERIC_NAME_ALIAS_TYPE:[0-9]+]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[SWIFT_GENERIC_NAME_ALIAS_TYPE:[0-9]+]])
-// CHECK: ![[SWIFT_GENERIC_NAME_ALIAS_TYPE]] = !DIDerivedType(tag: DW_TAG_typedef, name: "$sSo21SwiftGenericNameAliasaySo8NSNumberCGD", scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: {{[0-9]+}}, baseType: !{{[0-9]+}})
+// CHECK: ![[SWIFT_GENERIC_NAME_ALIAS_TYPE]] = !DIDerivedType(tag: DW_TAG_typedef, name: "$sSo21SwiftGenericNameAliasaySo8NSNumberCGD", scope: !{{[0-9]+}}, file: !{{[0-9]+}}, baseType: !{{[0-9]+}})
 
 // CHECK: ![[SWIFT_CONSTR_GENERIC_NAME_ALIAS_VAR]] = !DILocalVariable(name: "constr_generic_obj", arg: 1, scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: {{[0-9]+}}, type: ![[LET_SWIFT_CONSTR_GENERIC_NAME_ALIAS_TYPE:[0-9]+]])
 // CHECK: ![[LET_SWIFT_CONSTR_GENERIC_NAME_ALIAS_TYPE:[0-9]+]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[SWIFT_CONSTR_GENERIC_NAME_ALIAS_TYPE:[0-9]+]])
-// CHECK: ![[SWIFT_CONSTR_GENERIC_NAME_ALIAS_TYPE]] = !DIDerivedType(tag: DW_TAG_typedef, name: "$sSo27SwiftConstrGenericNameAliasaySo8NSNumberCGD", scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: {{[0-9]+}}, baseType: !{{[0-9]+}})
+// CHECK: ![[SWIFT_CONSTR_GENERIC_NAME_ALIAS_TYPE]] = !DIDerivedType(tag: DW_TAG_typedef, name: "$sSo27SwiftConstrGenericNameAliasaySo8NSNumberCGD", scope: !{{[0-9]+}}, file: !{{[0-9]+}}, baseType: !{{[0-9]+}})

--- a/test/DebugInfo/BoundGenericEnum.swift
+++ b/test/DebugInfo/BoundGenericEnum.swift
@@ -59,14 +59,13 @@ y.g()
 // CASE_0-DAG: !DISubprogram(name: "map", {{.*}}line: 11, type: ![[SBTY:[0-9]+]]
 // CASE_0-DAG: ![[SBTY]] = !DISubroutineType(types: ![[SBTYS:[0-9]+]])
 // CASE_0-DAG: ![[SBTYS]] = !{!{{[0-9]+}}, !{{[0-9]+}}, ![[SELFTY:[0-9]+]]}
-// CASE_0-DAG: ![[SELFTY]] = !DICompositeType(tag: DW_TAG_structure_type, {{.*}}line: 5, {{.*}}elements: ![[UNSIZED_ELTS:[0-9]+]]
+// CASE_0-DAG: ![[SELFTY]] = !DICompositeType(tag: DW_TAG_structure_type, {{.*}}elements: ![[UNSIZED_ELTS:[0-9]+]]
 // CASE_0-DAG: ![[UNSIZED_ELTS]] = !{![[UNSIZED_MEM:[0-9]+]]}
 // CASE_0-DAG: ![[UNSIZED_MEM]] = !DIDerivedType(tag: DW_TAG_member, {{.*}} baseType: ![[UNIQ:[0-9]+]]
 
 // The unique unsized type.
 // CASE_0: ![[UNIQ]] = !DICompositeType(
 // CASE_0-SAME:            tag: DW_TAG_structure_type, name: "Result",
-// CASE_0-SAME:            line: 5,
 // CASE_0-NOT:             size:
 // CASE_0-SAME:            runtimeLang: DW_LANG_Swift,
 // CASE_0-SAME:            identifier: "$s1a6ResultOyxGD")
@@ -75,10 +74,10 @@ y.g()
 // CASE_1-DAG: ![[F:[0-9]+]] = distinct !DISubprogram(name: "f", 
 // CASE_1-DAG: !DILocalVariable(name: "self", arg: 1, scope: ![[F]],{{.*}} line: 31,{{.*}} type: ![[C_CLASS:[0-9]+]]
 // CASE_1-DAG: ![[C_CLASS]] = !DIDerivedType(tag: DW_TAG_const_type,{{.*}} baseType: ![[CLASS:[0-9]+]])
-// CASE_1-DAG: ![[CLASS]] = !DICompositeType(tag: DW_TAG_structure_type,{{.*}} line: 5, size: {{40|72}}
+// CASE_1-DAG: ![[CLASS]] = !DICompositeType(tag: DW_TAG_structure_type,{{.*}} size: {{40|72}}
 
 // (2)
 // CASE_2-DAG: ![[G:[0-9]+]] = distinct !DISubprogram(name: "g", 
 // CASE_2-DAG: !DILocalVariable(name: "self", arg: 1, scope: ![[G]],{{.*}} line: 38,{{.*}} type: ![[C_TUP:[0-9]+]]
 // CASE_2-DAG: ![[C_TUP]] = !DIDerivedType(tag: DW_TAG_const_type,{{.*}} baseType: ![[TUP:[0-9]+]])
-// CASE_2-DAG: ![[TUP]] = !DICompositeType(tag: DW_TAG_structure_type,{{.*}} line: 5, size: {{264|512}},
+// CASE_2-DAG: ![[TUP]] = !DICompositeType(tag: DW_TAG_structure_type,{{.*}} size: {{264|512}},

--- a/test/DebugInfo/apple-types-accel.swift
+++ b/test/DebugInfo/apple-types-accel.swift
@@ -20,7 +20,6 @@
 
 // Verify the IR interface:
 // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "foo"
-// CHECK-SAME:             line: [[@LINE+2]]
 // CHECK-SAME:             identifier: "$s4main3fooCD"
 class foo {
 	var x : Int64 = 1

--- a/test/DebugInfo/attributes.swift
+++ b/test/DebugInfo/attributes.swift
@@ -2,12 +2,12 @@
 
 // REQUIRES: objc_interop
 
-// CHECK-DAG: ![[TY0:.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "ObjCClass",{{.*}} line: [[@LINE+1]],{{.*}} runtimeLang: DW_LANG_Swift,
+// CHECK-DAG: ![[TY0:.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "ObjCClass",{{.*}} runtimeLang: DW_LANG_Swift,
 @objc class ObjCClass {
       @IBAction func click(_: AnyObject?) -> () {}
 }
 
-// CHECK-DAG: ![[TY1:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "SwiftClass",{{.*}} line: [[@LINE+1]],{{.*}} runtimeLang: DW_LANG_Swift
+// CHECK-DAG: ![[TY1:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "SwiftClass",{{.*}} runtimeLang: DW_LANG_Swift
 class SwiftClass {
       @objc func objcmethod() -> () {}
       func swiftmethod() -> () {}

--- a/test/DebugInfo/enum.swift
+++ b/test/DebugInfo/enum.swift
@@ -8,7 +8,6 @@ protocol P {}
 enum Either {
   case First(Int64), Second(P), Neither
 // CHECK: !DICompositeType({{.*}}name: "Either",
-// CHECK-SAME:             line: [[@LINE-3]],
 // CHECK-SAME:             size: {{328|168}},
 }
 // CHECK: ![[EMPTY:.*]] = !{}
@@ -16,7 +15,6 @@ enum Either {
 let E : Either = .Neither;
 
 // CHECK: !DICompositeType({{.*}}name: "Color",
-// CHECK-SAME:             line: [[@LINE+3]]
 // CHECK-SAME:             size: 8,
 // CHECK-SAME:             identifier: "$s4enum5ColorOD"
 enum Color : UInt64 {
@@ -29,7 +27,6 @@ enum Color : UInt64 {
 }
 
 // CHECK: !DICompositeType({{.*}}name: "MaybeIntPair",
-// CHECK-SAME:             line: [[@LINE+3]],
 // CHECK-SAME:             size: 136{{[,)]}}
 // CHECK-SAME:             identifier: "$s4enum12MaybeIntPairOD"
 enum MaybeIntPair {
@@ -51,7 +48,6 @@ enum Maybe<T> {
 let r = Color.Red
 let c = MaybeIntPair.just(74, 75)
 // CHECK: !DICompositeType({{.*}}name: "Maybe",
-// CHECK-SAME:             line: [[@LINE-8]],
 // CHECK-SAME:             identifier: "$s4enum5MaybeOyAA5ColorOGD"
 let movie : Maybe<Color> = .none
 

--- a/test/DebugInfo/parent-scope.swift
+++ b/test/DebugInfo/parent-scope.swift
@@ -19,7 +19,7 @@ public struct Generic<T : P> {
 // But only one concrete type is expected.
 // CHECK: !DISubprogram({{.*}}linkageName: "$s4main8ConcreteV3getSiSgyF",
 // CHECK-SAME:          scope: ![[CONC:[0-9]+]],
-// CHECK: ![[CONC]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Concrete", scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: {{[0-9]+}}, elements: !{{[0-9]+}}, runtimeLang: DW_LANG_Swift, identifier: "$s4main8ConcreteVD")
+// CHECK: ![[CONC]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Concrete", scope: !{{[0-9]+}}, file: !{{[0-9]+}}, elements: !{{[0-9]+}}, runtimeLang: DW_LANG_Swift, identifier: "$s4main8ConcreteVD")
 public struct Concrete {
   public func get() -> Int? {
     return nil

--- a/test/DebugInfo/typealias.swift
+++ b/test/DebugInfo/typealias.swift
@@ -6,10 +6,10 @@ func markUsed<T>(_ t: T) {}
 
 public class DWARF {
 // CHECK-DAG: ![[BASE:.*]] = !DICompositeType({{.*}}identifier: "$ss6UInt32VD"
-// CHECK-DAG: ![[DIEOFFSET:.*]] = !DIDerivedType(tag: DW_TAG_typedef, name: "$s9typealias5DWARFC9DIEOffsetaD",{{.*}} line: [[@LINE+1]], baseType: ![[BASE]])
+// CHECK-DAG: ![[DIEOFFSET:.*]] = !DIDerivedType(tag: DW_TAG_typedef, name: "$s9typealias5DWARFC9DIEOffsetaD",{{.*}} baseType: ![[BASE]])
   typealias DIEOffset = UInt32
   // CHECK-DAG: ![[VOID:.*]] = !DICompositeType({{.*}}identifier: "$sytD"
-  // CHECK-DAG: ![[PRIVATETYPE:.*]] = !DIDerivedType(tag: DW_TAG_typedef, name: "$s9typealias5DWARFC11PrivateType{{.+}}aD",{{.*}} line: [[@LINE+1]], baseType: ![[VOID]])
+  // CHECK-DAG: ![[PRIVATETYPE:.*]] = !DIDerivedType(tag: DW_TAG_typedef, name: "$s9typealias5DWARFC11PrivateType{{.+}}aD",{{.*}} baseType: ![[VOID]])
   fileprivate typealias PrivateType = ()
   fileprivate static func usePrivateType() -> PrivateType { return () }
 }


### PR DESCRIPTION
These line numbers are consumed by LLDB and stored in the Declaration object,
but as far as I can tell no user-facing feature relies on this.

Removing the line number can reduce the churn for incremental builds
significantly, since whitespace changes in one file may trigger a recompilation
of any file that uses a type declared below the whitespace change.

<rdar://problem/63156560>
