### PR TITLE
[5.3][ASTPrinter] Fix issue where printing if-let variables shows their type as optional

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -1149,6 +1149,10 @@ parseOptionalPatternTypeAnnotation(ParserResult<Pattern> result,
 
   // In an if-let, the actual type of the expression is Optional of whatever
   // was written.
+  // FIXME: This is not good, `TypeRepr`s are supposed to represent what the
+  // user actually wrote in source (that's why they don't have any `isImplicit`
+  // bit). This synthesized `OptionalTypeRepr` leads to workarounds in other
+  // parts where we want to reason about the types as perceived by the user.
   if (isOptional)
     repr = new (Context) OptionalTypeRepr(repr, SourceLoc());
 

--- a/test/SourceKit/CursorInfo/sr-12631-if-let-type.swift
+++ b/test/SourceKit/CursorInfo/sr-12631-if-let-type.swift
@@ -1,0 +1,14 @@
+let foo: Int? = 123
+if let bar: Int = foo {
+  _ = bar
+}
+
+// RUN: %sourcekitd-test -req=cursor -pos=2:8 %s -- %s | %FileCheck --check-prefix=CHECK-BAR %s
+// RUN: %sourcekitd-test -req=cursor -pos=3:7 %s -- %s | %FileCheck --check-prefix=CHECK-BAR %s
+// RUN: %sourcekitd-test -req=cursor -pos=1:5 %s -- %s | %FileCheck --check-prefix=CHECK-FOO %s
+
+// CHECK-BAR:      <Declaration>let bar: <Type usr="s:Si">Int</Type></Declaration>
+// CHECK-BAR-NEXT: <decl.var.local><syntaxtype.keyword>let</syntaxtype.keyword> <decl.name>bar</decl.name>: <decl.var.type><ref.struct usr="s:Si">Int</ref.struct></decl.var.type></decl.var.local>
+
+// CHECK-FOO:      <Declaration>let foo: <Type usr="s:Si">Int</Type>?</Declaration>
+// CHECK-FOO-NEXT: <decl.var.global><syntaxtype.keyword>let</syntaxtype.keyword> <decl.name>foo</decl.name>: <decl.var.type><ref.struct usr="s:Si">Int</ref.struct>?</decl.var.type></decl.var.global> 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/31742 for 5.3.

* **Explanation**: Fixes issue with printing the declaration of an `if-let` variable that has an explicit type annotation; its type was shown as optional which was incorrect.

* **Scope of issue**: Only affects printing of variable declarations.

* **Origination**: Issue showed up in 5.2 release.

* **Risk**: Low.

* **Testing**: Added regression tests.

* **Reviewe**r: Nathan Hawes (@nathawes)

Resolves rdar://62894516