### PR TITLE
[5.3][CodeCompletion] Inherit options when parsing new buffer

### DIFF
--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -676,6 +676,10 @@ ParserResult<IfConfigDecl> Parser::parseIfConfig(
     SmallVector<ASTNode, 16> Elements;
     llvm::SaveAndRestore<bool> S(InInactiveClauseEnvironment,
                                  InInactiveClauseEnvironment || !isActive);
+    // Disable updating the interface hash inside inactive blocks.
+    llvm::SaveAndRestore<NullablePtr<llvm::MD5>> T(
+        CurrentTokenHash, isActive ? CurrentTokenHash : nullptr);
+
     if (isActive || !isVersionCondition) {
       parseElements(Elements, isActive);
     } else if (SyntaxContext->isEnabled()) {

--- a/test/SourceKit/CodeComplete/complete_sequence_ifconfig.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_ifconfig.swift
@@ -1,0 +1,37 @@
+struct MyStruct { func foo() {} }
+
+#if DEBUG
+import Swift
+#endif
+
+#if arch(x86_64)
+operator ++++++
+#endif
+
+#if !targetEnvironment(simulator)
+precedencegroup MyPrecedence
+#endif
+
+func foo(value: MyStruct) {
+  value.
+}
+
+// Ensure that compilation directives are equally evaluated and doesn't affect the fast completions.
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=complete -pos=16:9 -repeat-request=2 %s -- %s -target %target-triple \
+// RUN:   | %FileCheck %s
+
+// CHECK-LABEL: key.results: [
+// CHECK-NOT: ]
+// CHECK-DAG: key.description: "foo()",
+// CHECK-DAG: key.description: "self",
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext
+
+// CHECK-LABEL: key.results: [
+// CHECK-NOT: ]
+// CHECK-DAG: key.description: "foo()",
+// CHECK-DAG: key.description: "self",
+// CHECK: ],
+// CHECK: key.reusingastcontext: 1


### PR DESCRIPTION
Cherry-pick of #31741 into `release/5.3`

* **Explanation**: In fast-completion mode, we parse the new buffer to find the context of the completion. Previously, the parsing was performed without any options so `#if` directives could evaluate differently from the original source file. This used to cause giving up performing fast-completion, or perform it in a wrong context.
* **Scope**: Code completion
* **Risk**: Low
* **Issue**: rdar://problem/63063182
* **Testing**: Added regression test cases
* **Reviewer**: Ben Langmuir (@benlangmuir)