### PR TITLE
standard library: remove use of `LLVM.h` in the compatibility

### DIFF
--- a/stdlib/toolchain/Compatibility50/Overrides.h
+++ b/stdlib/toolchain/Compatibility50/Overrides.h
@@ -14,7 +14,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/Basic/LLVM.h"
 #include "swift/Runtime/Metadata.h"
 
 namespace swift {

--- a/stdlib/toolchain/Compatibility51/Overrides.h
+++ b/stdlib/toolchain/Compatibility51/Overrides.h
@@ -14,20 +14,20 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/Basic/LLVM.h"
 #include "swift/Runtime/Metadata.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace swift {
 
 using ConformsToSwiftProtocol_t =
   const ProtocolConformanceDescriptor *(const Metadata * const type,
                                         const ProtocolDescriptor *protocol,
-                                        StringRef moduleName);
+                                        llvm::StringRef moduleName);
 
 const ProtocolConformanceDescriptor *
 swift51override_conformsToSwiftProtocol(const Metadata * const type,
                                         const ProtocolDescriptor *protocol,
-                                        StringRef moduleName,
+                                        llvm::StringRef moduleName,
                                         ConformsToSwiftProtocol_t *original);
 
 } // end namespace swift


### PR DESCRIPTION
Remove the use of the `LLVM.h` forward declarations from the
compatibility shims.  This allows us to fully isolate the target side
from the LLVM namespace ensuring that we prevent ODR violations when
LLVM is linked into the same address space.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
