### PR TITLE
[utils/build-parser-lib] Disable `LLVM_ENABLE_TERMINFO` for building the parser library

### DIFF
--- a/utils/build-parser-lib
+++ b/utils/build-parser-lib
@@ -234,7 +234,11 @@ class Builder(object):
             "-DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=FALSE",
             "-DSWIFT_BUILD_STATIC_SDK_OVERLAY=FALSE",
         ]
-        cmake_args += ["-DLLVM_ENABLE_LIBXML2=FALSE", "-DLLVM_ENABLE_LIBEDIT=FALSE"]
+        cmake_args += [
+            "-DLLVM_ENABLE_LIBXML2=FALSE",
+            "-DLLVM_ENABLE_LIBEDIT=FALSE",
+            "-DLLVM_ENABLE_TERMINFO=FALSE",
+        ]
         # We are not using cmark but initialize the CMARK variables to something so
         # that configure can succeed.
         cmake_args += [


### PR DESCRIPTION
We don't need it and it causes the parser library to reference non-public symbols.