### PR TITLE
runtime: namespace SmallVectorImpl for inline namespace

### DIFF
--- a/include/swift/Basic/LLVM.h
+++ b/include/swift/Basic/LLVM.h
@@ -34,7 +34,9 @@ namespace llvm {
   class Twine;
   template <typename T> class SmallPtrSetImpl;
   template <typename T, unsigned N> class SmallPtrSet;
+#if !defined(swiftCore_EXPORTS)
   template <typename T> class SmallVectorImpl;
+#endif
   template <typename T, unsigned N> class SmallVector;
   template <unsigned N> class SmallString;
   template <typename T, unsigned N> class SmallSetVector;
@@ -79,7 +81,9 @@ namespace swift {
   using llvm::SmallSetVector;
   using llvm::SmallString;
   using llvm::SmallVector;
+#if !defined(swiftCore_EXPORTS)
   using llvm::SmallVectorImpl;
+#endif
   using llvm::StringLiteral;
   using llvm::StringRef;
   using llvm::TinyPtrVector;

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -896,7 +896,7 @@ class TypeDecoder {
 private:
   template <typename T>
   bool decodeImplFunctionPart(Demangle::NodePointer node,
-                              SmallVectorImpl<T> &results) {
+                              llvm::SmallVectorImpl<T> &results) {
     if (node->getNumChildren() != 2)
       return true;
     
@@ -919,7 +919,7 @@ private:
 
   bool decodeImplFunctionParam(
       Demangle::NodePointer node,
-      SmallVectorImpl<ImplFunctionParam<BuiltType>> &results) {
+      llvm::SmallVectorImpl<ImplFunctionParam<BuiltType>> &results) {
     // Children: `convention, differentiability?, type`
     if (node->getNumChildren() != 2 && node->getNumChildren() != 3)
       return true;
@@ -1021,7 +1021,7 @@ private:
 
   bool decodeMangledFunctionInputType(
       Demangle::NodePointer node,
-      SmallVectorImpl<FunctionParam<BuiltType>> &params,
+      llvm::SmallVectorImpl<FunctionParam<BuiltType>> &params,
       bool &hasParamFlags) {
     // Look through a couple of sugar nodes.
     if (node->getKind() == NodeKind::Type ||

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -911,9 +911,9 @@ swift::_depthIndexToFlatIndex(unsigned depth, unsigned index,
 ///
 /// \returns true if the innermost descriptor is generic.
 bool swift::_gatherGenericParameterCounts(
-                                 const ContextDescriptor *descriptor,
-                                 SmallVectorImpl<unsigned> &genericParamCounts,
-                                 Demangler &BorrowFrom) {
+    const ContextDescriptor *descriptor,
+    llvm::SmallVectorImpl<unsigned> &genericParamCounts,
+    Demangler &BorrowFrom) {
   DemanglerForRuntimeTypeResolution<> demangler;
   demangler.providePreallocatedMemory(BorrowFrom);
 
@@ -1974,10 +1974,9 @@ demangleToGenericParamRef(StringRef typeName) {
 }
 
 void swift::gatherWrittenGenericArgs(
-                             const Metadata *metadata,
-                             const TypeContextDescriptor *description,
-                             SmallVectorImpl<const Metadata *> &allGenericArgs,
-                             Demangler &BorrowFrom) {
+    const Metadata *metadata, const TypeContextDescriptor *description,
+    llvm::SmallVectorImpl<const Metadata *> &allGenericArgs,
+    Demangler &BorrowFrom) {
   if (!description)
     return;
   auto generics = description->getGenericContext();

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -387,10 +387,10 @@ public:
   /// Use with \c _getTypeByMangledName to decode potentially-generic types.
   class SWIFT_RUNTIME_LIBRARY_VISIBILITY SubstGenericParametersFromWrittenArgs {
     /// The complete set of generic arguments.
-    const SmallVectorImpl<const Metadata *> &allGenericArgs;
+    const llvm::SmallVectorImpl<const Metadata *> &allGenericArgs;
 
     /// The counts of generic parameters at each level.
-    const SmallVectorImpl<unsigned> &genericParamCounts;
+    const llvm::SmallVectorImpl<unsigned> &genericParamCounts;
 
   public:
     /// Initialize a new function object to handle substitutions. Both
@@ -404,10 +404,10 @@ public:
     /// \param genericParamCounts The count of generic parameters at each
     /// generic level, typically gathered by _gatherGenericParameterCounts.
     explicit SubstGenericParametersFromWrittenArgs(
-        const SmallVectorImpl<const Metadata *> &allGenericArgs,
-        const SmallVectorImpl<unsigned> &genericParamCounts)
-      : allGenericArgs(allGenericArgs), genericParamCounts(genericParamCounts) {
-    }
+        const llvm::SmallVectorImpl<const Metadata *> &allGenericArgs,
+        const llvm::SmallVectorImpl<unsigned> &genericParamCounts)
+        : allGenericArgs(allGenericArgs),
+          genericParamCounts(genericParamCounts) {}
 
     const Metadata *getMetadata(unsigned depth, unsigned index) const;
     const WitnessTable *getWitnessTable(const Metadata *type,

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -793,7 +793,7 @@ static bool isSubclass(const Metadata *subclass, const Metadata *superclass) {
 
 bool swift::_checkGenericRequirements(
                       llvm::ArrayRef<GenericRequirementDescriptor> requirements,
-                      SmallVectorImpl<const void *> &extraArguments,
+                      llvm::SmallVectorImpl<const void *> &extraArguments,
                       SubstGenericParameterFn substGenericParam,
                       SubstDependentWitnessTableFn substWitnessTable) {
   for (const auto &req : requirements) {


### PR DESCRIPTION
This adjusts the use of `SmallVectorImpl` to allow the runtime to use
inline namespaces for its local copy of LLVMSupport.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
