### PR TITLE
[5.3] [Sema] Fix a couple of AnyObject lookup bugs

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4239,8 +4239,8 @@ ERROR(objc_invalid_on_subscript,none,
 ERROR(objc_invalid_on_static_subscript,none,
       "%0 cannot be %" OBJC_ATTR_SELECT "1", (DescriptiveDeclKind, unsigned))
 ERROR(objc_invalid_with_generic_params,none,
-      "method cannot be %" OBJC_ATTR_SELECT "0 because it has generic "
-      "parameters", (unsigned))
+      "%0 cannot be %" OBJC_ATTR_SELECT "1 because it has generic parameters",
+      (DescriptiveDeclKind, unsigned))
 ERROR(objc_convention_invalid,none,
       "%0 is not representable in Objective-C, so it cannot be used"
       " with '@convention(%1)'", (Type, StringRef))

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -216,9 +216,19 @@ getDynamicResultSignature(ValueDecl *decl) {
   }
 
   if (auto asd = dyn_cast<AbstractStorageDecl>(decl)) {
+    auto ty = asd->getInterfaceType();
+
+    // Strip off a generic signature if we have one. This matches the logic
+    // for methods, and ensures that we don't take a protocol's generic
+    // signature into account for a subscript requirement.
+    if (auto *genericFn = ty->getAs<GenericFunctionType>()) {
+      ty = FunctionType::get(genericFn->getParams(), genericFn->getResult(),
+                             genericFn->getExtInfo());
+    }
+
     // Handle properties and subscripts, anchored by the getter's selector.
     return std::make_tuple(asd->isStatic(), asd->getObjCGetterSelector(),
-                           asd->getInterfaceType()->getCanonicalType());
+                           ty->getCanonicalType());
   }
 
   llvm_unreachable("Not a valid @objc member");

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -137,6 +137,9 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
       if (auto *SE = dyn_cast<SubscriptExpr>(E))
         CallArgs.insert(SE->getIndex());
 
+      if (auto *DSE = dyn_cast<DynamicSubscriptExpr>(E))
+        CallArgs.insert(DSE->getIndex());
+
       if (auto *KPE = dyn_cast<KeyPathExpr>(E)) {
         for (auto Comp : KPE->getComponents()) {
           if (auto *Arg = Comp.getIndexExpr())

--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -371,6 +371,10 @@ class C1 {
   @objc subscript(unambiguousSubscript _: String) -> Int { return 0 } // expected-note {{found this candidate}}
 }
 
+class C2 {
+  @objc subscript(singleCandidate _: Int) -> Int { return 0 }
+}
+
 func testAnyObjectAmbiguity(_ x: AnyObject) {
   _ = x.ambiguousProperty // expected-error {{ambiguous use of 'ambiguousProperty'}}
   _ = x.unambiguousProperty
@@ -383,6 +387,9 @@ func testAnyObjectAmbiguity(_ x: AnyObject) {
 
   _ = x.ambiguousMethodParam // expected-error {{ambiguous use of 'ambiguousMethodParam'}}
   _ = x.unambiguousMethodParam
+
+  // SR-12799: Don't emit a "single-element" tuple error.
+  _ = x[singleCandidate: 0]
 
   _ = x[ambiguousSubscript: 0] // expected-error {{ambiguous use of 'subscript(ambiguousSubscript:)'}}
 

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2375,3 +2375,9 @@ class SR_9035_C {}
   func throwingMethod2() throws -> Unmanaged<SR_9035_C> // expected-error {{method cannot be a member of an @objc protocol because its result type cannot be represented in Objective-C}}
   // expected-note@-1 {{inferring '@objc' because the declaration is a member of an '@objc' protocol}}
 }
+
+// SR-12801: Make sure we reject an @objc generic subscript.
+class SR12801 {
+  @objc subscript<T>(foo : [T]) -> Int { return 0 }
+  // expected-error@-1 {{subscript cannot be marked @objc because it has generic parameters}}
+}


### PR DESCRIPTION
5.3 cherry-pick of https://github.com/apple/swift/pull/31753.

---

**Explanation**: Fixes a spurious compiler error, compiler crash, and fixes an ambiguity error with AnyObject subscript lookup.

**Scope**: Fixes 3 bugs that have previously shipped. The most important part of this change is the fix for the AnyObject subscript ambiguity, which can be exacerbated by importing additional modules.

**Radar**: rdar://62906344.

**Risk**: Fairly low.

**Testing**: Added unit tests.

**Reviewer**: @xedin