### PR TITLE
[5.1 Compatibility library] Add missing #include

### DIFF
--- a/stdlib/toolchain/Compatibility51/Concurrent.h
+++ b/stdlib/toolchain/Compatibility51/Concurrent.h
@@ -20,6 +20,7 @@
 #include <iterator>
 #include <algorithm>
 #include <atomic>
+#include <cassert>
 #include <functional>
 #include <pthread.h>
 #include <stdint.h>


### PR DESCRIPTION
(cherry picked from commit 833d2cd9d395f8669e280e731bbf66424753812d)

* Explanation:
The 5.1 compatibility library is failing to build, because it's missing the header `#include <cassert>`.
* Risk: Low
* Resolves rdar://63195373
* Reviewed by @DougGregor 