### PR TITLE
[Dependencies] Fix -emit-fine-grained-dependency-sourcefile-dot-files flag definition

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -193,7 +193,7 @@ HelpText<"Include within-file dependencies.">;
 
 def emit_fine_grained_dependency_sourcefile_dot_files :
 Flag<["-"], "emit-fine-grained-dependency-sourcefile-dot-files">,
-InternalDebugOpt,
+Flags<[FrontendOption, HelpHidden]>,
 HelpText<"Emit dot files for every source file.">;
 
 def driver_mode : Joined<["--"], "driver-mode=">, Flags<[HelpHidden]>,


### PR DESCRIPTION
This flag was marked as an `InternalDebugOpt`, so it was accepted by the driver but rejected by the frontend. Change it to instead be `FrontendOption, HelpHidden`.