### PR TITLE
runtime: remove forward declaration of `llvm::function_ref`

### DIFF
--- a/include/swift/Basic/LLVM.h
+++ b/include/swift/Basic/LLVM.h
@@ -54,7 +54,9 @@ namespace llvm {
   class raw_ostream;
   class APInt;
   class APFloat;
+#if !defined(swiftCore_EXPORTS)
   template <typename Fn> class function_ref;
+#endif
 } // end namespace llvm
 
 
@@ -92,7 +94,9 @@ namespace swift {
   // Other common classes.
   using llvm::APFloat;
   using llvm::APInt;
+#if !defined(swiftCore_EXPORTS)
   using llvm::function_ref;
+#endif
   using llvm::NoneType;
   using llvm::raw_ostream;
 } // end namespace swift


### PR DESCRIPTION
The runtime has an embedded copy of LLVMSupport which provides
`llvm::function_ref` as `__swift::__runtime::llvm::function_ref`.  This
forward declaration can cause the inlined namespaces to be ignored.
Remove the forward declaration for the runtime.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
