### PR TITLE
[SILGen] Merge the two SILGen requests

### DIFF
--- a/include/swift/AST/SILGenRequests.h
+++ b/include/swift/AST/SILGenRequests.h
@@ -87,10 +87,10 @@ void simple_display(llvm::raw_ostream &out, const SILGenDescriptor &d);
 
 SourceLoc extractNearestSourceLoc(const SILGenDescriptor &desc);
 
-class SILGenSourceFileRequest :
-    public SimpleRequest<SILGenSourceFileRequest,
-                         std::unique_ptr<SILModule>(SILGenDescriptor),
-                         RequestFlags::Uncached|RequestFlags::DependencySource> {
+class SILGenerationRequest
+    : public SimpleRequest<
+          SILGenerationRequest, std::unique_ptr<SILModule>(SILGenDescriptor),
+          RequestFlags::Uncached | RequestFlags::DependencySource> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -100,32 +100,11 @@ private:
   // Evaluation.
   std::unique_ptr<SILModule>
   evaluate(Evaluator &evaluator, SILGenDescriptor desc) const;
-
-public:
-  bool isCached() const { return true; }
 
 public:
   // Incremental dependencies.
   evaluator::DependencySource
   readDependencySource(const evaluator::DependencyCollector &) const;
-};
-
-class SILGenWholeModuleRequest :
-    public SimpleRequest<SILGenWholeModuleRequest,
-                         std::unique_ptr<SILModule>(SILGenDescriptor),
-                         RequestFlags::Uncached> {
-public:
-  using SimpleRequest::SimpleRequest;
-
-private:
-  friend SimpleRequest;
-
-  // Evaluation.
-  std::unique_ptr<SILModule>
-  evaluate(Evaluator &evaluator, SILGenDescriptor desc) const;
-
-public:
-  bool isCached() const { return true; }
 };
 
 /// Parses a .sil file into a SILModule.

--- a/include/swift/AST/SILGenTypeIDZone.def
+++ b/include/swift/AST/SILGenTypeIDZone.def
@@ -14,10 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-SWIFT_REQUEST(SILGen, SILGenSourceFileRequest,
-              std::unique_ptr<SILModule>(SILGenDescriptor),
-              Uncached, NoLocationInfo)
-SWIFT_REQUEST(SILGen, SILGenWholeModuleRequest,
+SWIFT_REQUEST(SILGen, SILGenerationRequest,
               std::unique_ptr<SILModule>(SILGenDescriptor),
               Uncached, NoLocationInfo)
 SWIFT_REQUEST(SILGen, ParseSILModuleRequest,

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1837,7 +1837,7 @@ public:
     }
   }
 
-  SILGenModuleRAII(SILModule &M, ModuleDecl *SM) : SGM{M, SM} {}
+  explicit SILGenModuleRAII(SILModule &M) : SGM{M, M.getSwiftModule()} {}
 
   ~SILGenModuleRAII() {
     // Emit any delayed definitions that were forced.
@@ -1860,56 +1860,35 @@ public:
 } // end anonymous namespace
 
 std::unique_ptr<SILModule>
-SILGenSourceFileRequest::evaluate(Evaluator &evaluator,
-                                  SILGenDescriptor desc) const {
+SILGenerationRequest::evaluate(Evaluator &evaluator,
+                               SILGenDescriptor desc) const {
   // If we have a .sil file to parse, defer to the parsing request.
   if (desc.getSourceFileToParse()) {
     return llvm::cantFail(evaluator(ParseSILModuleRequest{desc}));
   }
 
-  auto *unit = desc.context.get<FileUnit *>();
-  auto *mod = unit->getParentModule();
-  auto M = SILModule::createEmptyModule(desc.context, desc.conv, desc.opts);
-  SILGenModuleRAII scope(*M, mod);
+  // Otherwise perform SIL generation of the passed SourceFiles.
+  auto silMod = SILModule::createEmptyModule(desc.context, desc.conv,
+                                             desc.opts);
+  SILGenModuleRAII scope(*silMod);
 
-  if (auto *file = dyn_cast<SourceFile>(unit)) {
-    scope.emitSourceFile(file);
-  } else if (auto *file = dyn_cast<SerializedASTFile>(unit)) {
-    if (file->isSIB())
-      M->getSILLoader()->getAllForModule(mod->getName(), file);
-  }
-
-  return M;
-}
-
-std::unique_ptr<SILModule>
-SILGenWholeModuleRequest::evaluate(Evaluator &evaluator,
-                                   SILGenDescriptor desc) const {
-  // If we have a .sil file to parse, defer to the parsing request.
-  if (desc.getSourceFileToParse()) {
-    return llvm::cantFail(evaluator(ParseSILModuleRequest{desc}));
-  }
-
-  auto *mod = desc.context.get<ModuleDecl *>();
-  auto M = SILModule::createEmptyModule(desc.context, desc.conv, desc.opts);
-  SILGenModuleRAII scope(*M, mod);
-
-  for (auto file : mod->getFiles()) {
+  for (auto file : desc.getFiles()) {
     if (auto *nextSF = dyn_cast<SourceFile>(file))
       scope.emitSourceFile(nextSF);
   }
 
-  // Also make sure to process any intermediate files that may contain SIL
-  bool hasSIB = std::any_of(mod->getFiles().begin(),
-                            mod->getFiles().end(),
-                            [](const FileUnit *File) -> bool {
+  // Also make sure to process any intermediate files that may contain SIL.
+  bool hasSIB = llvm::any_of(desc.getFiles(), [](const FileUnit *File) -> bool {
     auto *SASTF = dyn_cast<SerializedASTFile>(File);
     return SASTF && SASTF->isSIB();
   });
-  if (hasSIB)
-    M->getSILLoader()->getAllForModule(mod->getName(), nullptr);
+  if (hasSIB) {
+    auto primary = desc.context.dyn_cast<FileUnit *>();
+    silMod->getSILLoader()->getAllForModule(silMod->getSwiftModule()->getName(),
+                                            primary);
+  }
 
-  return M;
+  return silMod;
 }
 
 std::unique_ptr<SILModule>
@@ -1917,7 +1896,7 @@ swift::performSILGeneration(ModuleDecl *mod, Lowering::TypeConverter &tc,
                             const SILOptions &options) {
   auto desc = SILGenDescriptor::forWholeModule(mod, tc, options);
   return llvm::cantFail(
-      mod->getASTContext().evaluator(SILGenWholeModuleRequest{desc}));
+      mod->getASTContext().evaluator(SILGenerationRequest{desc}));
 }
 
 std::unique_ptr<SILModule>
@@ -1925,5 +1904,5 @@ swift::performSILGeneration(FileUnit &sf, Lowering::TypeConverter &tc,
                             const SILOptions &options) {
   auto desc = SILGenDescriptor::forFile(sf, tc, options);
   return llvm::cantFail(
-      sf.getASTContext().evaluator(SILGenSourceFileRequest{desc}));
+      sf.getASTContext().evaluator(SILGenerationRequest{desc}));
 }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1817,6 +1817,8 @@ class SILGenModuleRAII {
 
 public:
   void emitSourceFile(SourceFile *sf) {
+    assert(sf->ASTStage == SourceFile::TypeChecked);
+
     SourceFileScope scope(SGM, sf);
     for (Decl *D : sf->getTopLevelDecls()) {
       FrontendStatsTracer StatsTracer(SGM.getASTContext().Stats,
@@ -1893,10 +1895,8 @@ SILGenWholeModuleRequest::evaluate(Evaluator &evaluator,
   SILGenModuleRAII scope(*M, mod);
 
   for (auto file : mod->getFiles()) {
-    auto nextSF = dyn_cast<SourceFile>(file);
-    if (!nextSF || nextSF->ASTStage != SourceFile::TypeChecked)
-      continue;
-    scope.emitSourceFile(nextSF);
+    if (auto *nextSF = dyn_cast<SourceFile>(file))
+      scope.emitSourceFile(nextSF);
   }
 
   // Also make sure to process any intermediate files that may contain SIL

--- a/lib/SILGen/SILGenRequests.cpp
+++ b/lib/SILGen/SILGenRequests.cpp
@@ -46,14 +46,18 @@ SourceLoc swift::extractNearestSourceLoc(const SILGenDescriptor &desc) {
   return SourceLoc();
 }
 
-evaluator::DependencySource SILGenSourceFileRequest::readDependencySource(
+evaluator::DependencySource SILGenerationRequest::readDependencySource(
     const evaluator::DependencyCollector &e) const {
   auto &desc = std::get<0>(getStorage());
+
+  // We don't track dependencies in whole-module mode.
+  if (auto *mod = desc.context.dyn_cast<ModuleDecl *>()) {
+    return {nullptr, e.getActiveSourceScope()};
+  }
+
+  // If we have a single source file, it's the source of dependencies.
   auto *unit = desc.context.get<FileUnit *>();
-  return {
-    dyn_cast_or_null<SourceFile>(unit),
-    evaluator::DependencyScope::Cascading
-  };
+  return {dyn_cast<SourceFile>(unit), evaluator::DependencyScope::Cascading};
 }
 
 ArrayRef<FileUnit *> SILGenDescriptor::getFiles() const {


### PR DESCRIPTION
They both do essentially the same thing, with the single-file request being the single-element case of the whole-module request, with only the call to `getAllForModule` really caring about the difference.