### PR TITLE
ReplaceOpaqueTypesWithUnderlyingTypes: Handle a type being "substituted" with itself.

### DIFF
--- a/test/SILGen/opaque_type_lowering_in_substitution.swift
+++ b/test/SILGen/opaque_type_lowering_in_substitution.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-emit-silgen -disable-availability-checking -verify %s
+protocol P {}
+extension Int: P {}
+
+func foo() -> some P { return 0 }
+func bar<T: P>(_ x: T) -> some P { return x }
+
+struct Bas<T: P> { init(_: T) {} }
+
+func abstraction_level<T>(x: T) -> (T) -> () {
+    return { _ in () }
+}
+
+func test() {
+    abstraction_level(x: Bas(bar(foo())))(Bas(bar(foo())))
+}


### PR DESCRIPTION
SIL type lowering might have already substituted away an opaque type during a SIL substitution.
Fixes rdar://problem/62072397.