### PR TITLE
Revert "[presets] Do not copy Swift resource dir into LLDB when build…

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1217,8 +1217,6 @@ dash-dash
 lldb-no-debugserver
 lldb-use-system-debugserver
 lldb-build-type=Release
-lldb-extra-cmake-args=
-  -DLLDB_FRAMEWORK_COPY_SWIFT_RESOURCES=OFF
 verbose-build
 build-ninja
 build-swift-stdlib-unittest-extra


### PR DESCRIPTION
…ing a toolchain"

This reverts commit a49e872bf81f468cd3760ba5f728ff03d8330dc1.

This had the intended effect, but it also means we cannot run the tests on
the package bots anymore, which is not desirable.
