### PR TITLE
Link Windows runtime dynamically in interop test

### DIFF
--- a/test/Interop/Cxx/reference/reference.swift
+++ b/test/Interop/Cxx/reference/reference.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/reference.cpp -I %S/Inputs -o %t/reference.o -std=c++17
+// RUN: %target-clang -c %S/Inputs/reference.cpp -I %S/Inputs -o %t/reference.o -std=c++17 -D_DLL
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/reference %t/reference.o -Xfrontend -enable-cxx-interop -Xcc -std=c++17
 // RUN: %target-codesign %t/reference
 // RUN: %target-run %t/reference


### PR DESCRIPTION
To make the Windows CI green (https://ci-external.swift.org/job/oss-swift-windows-x86_64/3976).