### PR TITLE
[IRGen] NFC: Add static_assert cross references

### DIFF
--- a/lib/IRGen/ClassMetadataVisitor.h
+++ b/lib/IRGen/ClassMetadataVisitor.h
@@ -49,6 +49,9 @@ protected:
 
 public:
   void layout() {
+    static_assert(MetadataAdjustmentIndex::Class == 2,
+                  "Adjustment index must be synchronized with this layout");
+
     // HeapMetadata header.
     asImpl().addDestructorFunction();
 

--- a/lib/IRGen/EnumMetadataVisitor.h
+++ b/lib/IRGen/EnumMetadataVisitor.h
@@ -44,6 +44,9 @@ protected:
 
 public:
   void layout() {
+    static_assert(MetadataAdjustmentIndex::ValueType == 1,
+                  "Adjustment index must be synchronized with this layout");
+
     // Metadata header.
     super::layout();
 

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -55,6 +55,7 @@
 #include "ConformanceDescription.h"
 #include "GenDecl.h"
 #include "GenEnum.h"
+#include "GenMeta.h"
 #include "GenPointerAuth.h"
 #include "GenIntegerLiteral.h"
 #include "GenType.h"
@@ -338,6 +339,8 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   // A full type metadata record is basically just an adjustment to the
   // address point of a type metadata.  Resilience may cause
   // additional data to be laid out prior to this address point.
+  static_assert(MetadataAdjustmentIndex::ValueType == 1,
+                "Adjustment index must be synchronized with this layout");
   FullTypeMetadataStructTy = createStructType(*this, "swift.full_type", {
     WitnessTablePtrTy,
     TypeMetadataStructTy
@@ -350,6 +353,8 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   // A full heap metadata is basically just an additional small prefix
   // on a full metadata, used for metadata corresponding to heap
   // allocations.
+  static_assert(MetadataAdjustmentIndex::Class == 2,
+                "Adjustment index must be synchronized with this layout");
   FullHeapMetadataStructTy =
                   createStructType(*this, "swift.full_heapmetadata", {
     dtorPtrTy,

--- a/lib/IRGen/NominalMetadataVisitor.h
+++ b/lib/IRGen/NominalMetadataVisitor.h
@@ -20,6 +20,7 @@
 
 #include "GenericRequirement.h"
 #include "GenProto.h"
+#include "GenMeta.h"
 #include "IRGenModule.h"
 #include "MetadataVisitor.h"
 

--- a/lib/IRGen/StructMetadataVisitor.h
+++ b/lib/IRGen/StructMetadataVisitor.h
@@ -43,6 +43,9 @@ protected:
 
 public:
   void layout() {
+    static_assert(MetadataAdjustmentIndex::ValueType == 1,
+                  "Adjustment index must be synchronized with this layout");
+
     // Metadata header.
     super::layout();
 


### PR DESCRIPTION
The metadata visitors note the address start of the metadata, but that is not actually the way the offsets are calculated.