### PR TITLE
SILOptimizer: a bit refactoring and a small bug fix

### DIFF
--- a/include/swift/SILOptimizer/Utils/LoadStoreOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/LoadStoreOptUtils.h
@@ -169,14 +169,16 @@ public:
   }
 
   /// Print the LSBase.
-  virtual void print(llvm::raw_ostream &os, SILModule *Mod,
-                     TypeExpansionContext context) {
+  virtual void print(llvm::raw_ostream &os) {
     os << Base;
-    Path.getValue().print(os, *Mod, context);
+    SILFunction *F = Base->getFunction();
+    if (F) {
+      Path.getValue().print(os, F->getModule(), TypeExpansionContext(*F));
+    }
   }
 
-  virtual void dump(SILModule *Mod, TypeExpansionContext context) {
-    print(llvm::dbgs(), Mod, context);
+  virtual void dump() {
+    print(llvm::dbgs());
   }
 };
 
@@ -260,13 +262,12 @@ public:
     return Path.getValue().createExtract(Base, Inst, true);
   }
 
-  void print(llvm::raw_ostream &os, SILModule *Mod,
-             TypeExpansionContext context) {
+  void print(llvm::raw_ostream &os) {
     if (CoveringValue) {
       os << "Covering Value";
       return;
     }
-    LSBase::print(os, Mod, context);
+    LSBase::print(os);
   }
 
   /// Expand this SILValue to all individual fields it contains.

--- a/lib/SIL/IR/SILBasicBlock.cpp
+++ b/lib/SIL/IR/SILBasicBlock.cpp
@@ -226,7 +226,9 @@ SILPhiArgument *SILBasicBlock::replacePhiArgumentAndReplaceAllUses(
   // any uses.
   SmallVector<Operand *, 16> operands;
   SILValue undef = SILUndef::get(ty, *getParent());
-  for (auto *use : getArgument(i)->getUses()) {
+  SILArgument *arg = getArgument(i);
+  while (!arg->use_empty()) {
+    Operand *use = *arg->use_begin();
     use->set(undef);
     operands.push_back(use);
   }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3532,6 +3532,9 @@ ID SILPrintContext::getID(const SILNode *node) {
     return {ID::SILUndef, 0};
   
   SILBasicBlock *BB = node->getParentBlock();
+  if (!BB) {
+    return { ID::Null, 0 };
+  }
   if (SILFunction *F = BB->getParent()) {
     setContext(F);
     // Lazily initialize the instruction -> ID mapping.

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -835,9 +835,7 @@ static bool getDeadInstsAfterInitializerRemoved(
 bool DeadObjectElimination::processAllocApply(ApplyInst *AI,
                                               DeadEndBlocks &DEBlocks) {
   // Currently only handle array.uninitialized
-  if (ArraySemanticsCall(AI).getKind() != ArrayCallKind::kArrayUninitialized &&
-      ArraySemanticsCall(AI).getKind() !=
-          ArrayCallKind::kArrayUninitializedIntrinsic)
+  if (!isAllocatingApply(AI))
     return false;
 
   llvm::SmallVector<SILInstruction *, 8> instsDeadAfterInitializerRemoved;

--- a/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
@@ -1585,8 +1585,7 @@ bool RLEContext::run() {
 
   LLVM_DEBUG(for (unsigned i = 0; i < LocationVault.size(); ++i) {
     llvm::dbgs() << "LSLocation #" << i;
-    getLocation(i).print(llvm::dbgs(), &Fn->getModule(),
-                         TypeExpansionContext(*Fn));
+    getLocation(i).print(llvm::dbgs());
   });
 
   if (Optimistic)

--- a/lib/SILOptimizer/UtilityPasses/LSLocationPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/LSLocationPrinter.cpp
@@ -171,7 +171,7 @@ public:
 
         llvm::outs() << "#" << Counter++ << II;
         for (auto &Loc : Locs) {
-          Loc.print(llvm::outs(), &Fn.getModule(), TypeExpansionContext(Fn));
+          Loc.print(llvm::outs());
         }
         Locs.clear();
       }
@@ -227,7 +227,7 @@ public:
         LSLocation::reduce(L, &Fn.getModule(), TypeExpansionContext(Fn), SLocs);
         llvm::outs() << "#" << Counter++ << II;
         for (auto &Loc : SLocs) {
-          Loc.print(llvm::outs(), &Fn.getModule(), TypeExpansionContext(Fn));
+          Loc.print(llvm::outs());
         }
         L.reset();
         Locs.clear();


### PR DESCRIPTION
Fix a use-list iteration problem in replacePhiArgumentAndReplaceAllUses().
It didn't work with more than one use. I'm not sure if we could hit this problem in real world right now. I found it during my work on COW representation where I use this function in a new optimization.

Other than that, some small refactoring - NFC.