### PR TITLE
[5.3] ReplaceOpaqueTypesWithUnderlyingTypes: Handle a type being "substituted" with itself.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3043,12 +3043,21 @@ ProtocolConformanceRef ReplaceOpaqueTypesWithUnderlyingTypes::
 operator()(CanType maybeOpaqueType, Type replacementType,
            ProtocolDecl *protocol) const {
   auto abstractRef = ProtocolConformanceRef(protocol);
-
+  
   auto archetypeAndRoot = getArchetypeAndRootOpaqueArchetype(maybeOpaqueType);
   if (!archetypeAndRoot) {
-    assert(maybeOpaqueType->isTypeParameter() ||
-           maybeOpaqueType->is<ArchetypeType>());
-    return abstractRef;
+    if (maybeOpaqueType->isTypeParameter() ||
+        maybeOpaqueType->is<ArchetypeType>())
+      return abstractRef;
+    
+    // SIL type lowering may have already substituted away the opaque type, in
+    // which case we'll end up "substituting" the same type.
+    if (maybeOpaqueType->isEqual(replacementType)) {
+      return inContext->getParentModule()
+                      ->lookupConformance(replacementType, protocol);
+    }
+    
+    llvm_unreachable("origType should have been an opaque type or type parameter");
   }
 
   auto archetype = archetypeAndRoot->first;

--- a/test/SILGen/opaque_type_lowering_in_substitution.swift
+++ b/test/SILGen/opaque_type_lowering_in_substitution.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-emit-silgen -disable-availability-checking -verify %s
+protocol P {}
+extension Int: P {}
+
+func foo() -> some P { return 0 }
+func bar<T: P>(_ x: T) -> some P { return x }
+
+struct Bas<T: P> { init(_: T) {} }
+
+func abstraction_level<T>(x: T) -> (T) -> () {
+    return { _ in () }
+}
+
+func test() {
+    abstraction_level(x: Bas(bar(foo())))(Bas(bar(foo())))
+}


### PR DESCRIPTION
5.3 cherry-pick of #31773

Explanation: Fixes a crash in some situations involving highly composed opaque return types.
Scope: Bug fix
Radar: rdar://62072397
Risk: Low
Testing: Full CI, local testing
Reviewed by: @aschwaighofer 