### PR TITLE
[build] Pass target argument to the linker if needed

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -89,15 +89,6 @@ function(is_darwin_based_sdk sdk_name out_var)
   endif()
 endfunction()
 
-function(does_compiler_support_target_triple out_var)
-  # MSVC, clang-cl, gcc don't understand -target.
-  if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT SWIFT_COMPILER_IS_MSVC_LIKE)
-    set(${out_var} TRUE PARENT_SCOPE)
-  else()
-    set(${out_var} FALSE PARENT_SCOPE)
-  endif()
-endfunction()
-
 # Usage:
 # _add_host_variant_c_compile_link_flags(name)
 function(_add_host_variant_c_compile_link_flags name)
@@ -106,8 +97,8 @@ function(_add_host_variant_c_compile_link_flags name)
     set(DEPLOYMENT_VERSION "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_DEPLOYMENT_VERSION}")
   endif()
 
-  does_compiler_support_target_triple(COMPILER_SUPPORTS_TARGET_TRIPLE)
-  if(COMPILER_SUPPORTS_TARGET_TRIPLE)
+  # MSVC, clang-cl, gcc don't understand -target.
+  if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT SWIFT_COMPILER_IS_MSVC_LIKE)
     get_target_triple(target target_variant "${SWIFT_HOST_VARIANT_SDK}" "${SWIFT_HOST_VARIANT_ARCH}"
       MACCATALYST_BUILD_FLAVOR ""
       DEPLOYMENT_VERSION "${DEPLOYMENT_VERSION}")
@@ -566,8 +557,8 @@ function(add_swift_host_library name)
     endif()
 
     set(DEPLOYMENT_VERSION "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_DEPLOYMENT_VERSION}")
-    does_compiler_support_target_triple(COMPILER_SUPPORTS_TARGET_TRIPLE)
-    if(COMPILER_SUPPORTS_TARGET_TRIPLE)
+    # MSVC, clang-cl, gcc don't understand -target.
+    if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT SWIFT_COMPILER_IS_MSVC_LIKE)
       get_target_triple(target target_variant "${SWIFT_HOST_VARIANT_SDK}" "${SWIFT_HOST_VARIANT_ARCH}"
         MACCATALYST_BUILD_FLAVOR ""
         DEPLOYMENT_VERSION "${DEPLOYMENT_VERSION}")

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -89,6 +89,15 @@ function(is_darwin_based_sdk sdk_name out_var)
   endif()
 endfunction()
 
+function(does_compiler_support_target_triple out_var)
+  # MSVC, clang-cl, gcc don't understand -target.
+  if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT SWIFT_COMPILER_IS_MSVC_LIKE)
+    set(${out_var} TRUE PARENT_SCOPE)
+  else()
+    set(${out_var} FALSE PARENT_SCOPE)
+  endif()
+endfunction()
+
 # Usage:
 # _add_host_variant_c_compile_link_flags(name)
 function(_add_host_variant_c_compile_link_flags name)
@@ -97,8 +106,8 @@ function(_add_host_variant_c_compile_link_flags name)
     set(DEPLOYMENT_VERSION "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_DEPLOYMENT_VERSION}")
   endif()
 
-  # MSVC, clang-cl, gcc don't understand -target.
-  if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT SWIFT_COMPILER_IS_MSVC_LIKE)
+  does_compiler_support_target_triple(COMPILER_SUPPORTS_TARGET_TRIPLE)
+  if(COMPILER_SUPPORTS_TARGET_TRIPLE)
     get_target_triple(target target_variant "${SWIFT_HOST_VARIANT_SDK}" "${SWIFT_HOST_VARIANT_ARCH}"
       MACCATALYST_BUILD_FLAVOR ""
       DEPLOYMENT_VERSION "${DEPLOYMENT_VERSION}")
@@ -554,6 +563,15 @@ function(add_swift_host_library name)
     if(SWIFT_COMPILER_VERSION)
       target_link_options(${name} PRIVATE
         "LINKER:-current_version,${SWIFT_COMPILER_VERSION}")
+    endif()
+
+    set(DEPLOYMENT_VERSION "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_DEPLOYMENT_VERSION}")
+    does_compiler_support_target_triple(COMPILER_SUPPORTS_TARGET_TRIPLE)
+    if(COMPILER_SUPPORTS_TARGET_TRIPLE)
+      get_target_triple(target target_variant "${SWIFT_HOST_VARIANT_SDK}" "${SWIFT_HOST_VARIANT_ARCH}"
+        MACCATALYST_BUILD_FLAVOR ""
+        DEPLOYMENT_VERSION "${DEPLOYMENT_VERSION}")
+      target_link_options(${name} PRIVATE -target;${target})
     endif()
   endif()
 


### PR DESCRIPTION
Following #31125 and #31612, `-target` is not added automatically to
linker flags when that's needed (e.g. when building for Apple SDKs) --
mimic the logic used to add it for compiler flags.

Addresses rdar://63138761