### PR TITLE
standard library: sort headers

### DIFF
--- a/stdlib/toolchain/Compatibility51/ProtocolConformance.cpp
+++ b/stdlib/toolchain/Compatibility51/ProtocolConformance.cpp
@@ -22,15 +22,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "../../public/runtime/Private.h"
 #include "Concurrent.h"
 #include "Overrides.h"
 #include "swift/Basic/Lazy.h"
-#include "../../public/runtime/Private.h"
+#include <assert.h>
+#include <dlfcn.h>
 #include <mach-o/dyld.h>
 #include <mach-o/getsect.h>
 #include <objc/runtime.h>
-#include <assert.h>
-#include <dlfcn.h>
 
 using namespace swift;
 using swift::overrides::ConcurrentMap;


### PR DESCRIPTION
This just is using the standard formatting suggested by clang-format.
This fixes the issue with forward declarations being injected into the
search order.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
