### PR TITLE
SILGen: Remove obsolete hack preventing emission of allocating init for unavailable initializer

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -957,13 +957,6 @@ void SILGenModule::emitConstructor(ConstructorDecl *decl) {
   if (isa<ProtocolDecl>(decl->getDeclContext()))
     return;
 
-  // Always-unavailable imported constructors are factory methods
-  // that have been imported as constructors and then hidden by an
-  // imported init method.
-  if (decl->hasClangNode() &&
-      decl->getAttrs().isUnavailable(decl->getASTContext()))
-    return;
-
   SILDeclRef constant(decl);
   DeclContext *declCtx = decl->getDeclContext();
 

--- a/test/SILGen/Inputs/objc_init_unavailable.h
+++ b/test/SILGen/Inputs/objc_init_unavailable.h
@@ -1,0 +1,6 @@
+@import Foundation;
+
+@interface ClassWithUnavailableInit : NSObject
+
+- (instancetype)initWithBundleID:(NSString *)bundleID __attribute__((availability(macos, unavailable)));
+@end

--- a/test/SILGen/objc_init_unavailable.swift
+++ b/test/SILGen/objc_init_unavailable.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -enable-objc-interop -import-objc-header %S/Inputs/objc_init_unavailable.h %s | %FileCheck %s
+// REQUIRES: objc_interop
+
+@available(macOS, unavailable)
+public func callUnavailableInit(name: String) -> ClassWithUnavailableInit {
+  return ClassWithUnavailableInit(bundleID: name)
+}
+
+// CHECK-LABEL: sil [ossa] @$s21objc_init_unavailable19callUnavailableInit4nameSo09ClassWitheF0CSS_tF : $@convention(thin) (@guaranteed String) -> @owned ClassWithUnavailableInit {
+// CHECK: function_ref @$sSo24ClassWithUnavailableInitC8bundleIDABSgSSSg_tcfC : $@convention(method) (@owned Optional<String>, @thick ClassWithUnavailableInit.Type) -> @owned Optional<ClassWithUnavailableInit>
+// CHECK: return
+
+// CHECK-LABEL: sil shared [serializable] [ossa] @$sSo24ClassWithUnavailableInitC8bundleIDABSgSSSg_tcfC : $@convention(method) (@owned Optional<String>, @thick ClassWithUnavailableInit.Type) -> @owned Optional<ClassWithUnavailableInit> {
+// CHECK: function_ref @$sSo24ClassWithUnavailableInitC8bundleIDABSgSSSg_tcfcTO : $@convention(method) (@owned Optional<String>, @owned ClassWithUnavailableInit) -> @owned Optional<ClassWithUnavailableInit>
+// CHECK: return
+
+// CHECK-LABEL: sil shared [serializable] [thunk] [ossa] @$sSo24ClassWithUnavailableInitC8bundleIDABSgSSSg_tcfcTO : $@convention(method) (@owned Optional<String>, @owned ClassWithUnavailableInit) -> @owned Optional<ClassWithUnavailableInit> {
+// CHECK: objc_method %1 : $ClassWithUnavailableInit, #ClassWithUnavailableInit.init!initializer.foreign : (ClassWithUnavailableInit.Type) -> (String?) -> ClassWithUnavailableInit?, $@convention(objc_method) (Optional<NSString>, @owned ClassWithUnavailableInit) -> @owned Optional<ClassWithUnavailableInit>
+// CHECK: return


### PR DESCRIPTION
Fixes <rdar://problem/63188572>.