### PR TITLE
Simplify lazy function body emission in SILGen

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -531,7 +531,7 @@ static SILFunction *getFunctionToInsertAfter(SILGenModule &SGM,
     // be inserted after.
     auto foundDelayed = SGM.delayedFunctions.find(insertAfter);
     if (foundDelayed != SGM.delayedFunctions.end()) {
-      insertAfter = foundDelayed->second.insertAfter;
+      insertAfter = foundDelayed->second;
     } else {
       break;
     }
@@ -639,14 +639,14 @@ SILFunction *SILGenModule::getFunction(SILDeclRef constant,
     // Move the function to its proper place within the module.
     M.functions.remove(F);
     SILFunction *insertAfter = getFunctionToInsertAfter(*this,
-                                              foundDelayed->second.insertAfter);
+                                              foundDelayed->second);
     if (!insertAfter) {
       M.functions.push_front(F);
     } else {
       M.functions.insertAfter(insertAfter->getIterator(), F);
     }
 
-    forcedFunctions.push_back(*foundDelayed);
+    forcedFunctions.push_back(constant);
     delayedFunctions.erase(foundDelayed);
   } else {
     // We would have registered a delayed function as "last emitted" when we
@@ -663,12 +663,174 @@ bool SILGenModule::hasFunction(SILDeclRef constant) {
 
 void SILGenModule::visitFuncDecl(FuncDecl *fd) { emitFunction(fd); }
 
+static void emitDelayedFunction(SILGenModule &SGM,
+                                SILDeclRef constant,
+                                SILFunction *f) {
+  switch (constant.kind) {
+  case SILDeclRef::Kind::Func: {
+    auto *fd = cast<FuncDecl>(constant.getDecl());
+
+    SGM.preEmitFunction(constant, fd, f, fd);
+    PrettyStackTraceSILFunction X("silgen emitFunction", f);
+    SILGenFunction(SGM, *f, fd).emitFunction(fd);
+    SGM.postEmitFunction(constant, f);
+    break;
+  }
+
+  case SILDeclRef::Kind::Allocator: {
+    auto *decl = cast<ConstructorDecl>(constant.getDecl());
+
+    if (decl->getDeclContext()->getSelfClassDecl() &&
+        (decl->isDesignatedInit() ||
+         decl->isObjC())) {
+      SGM.preEmitFunction(constant, decl, f, decl);
+      PrettyStackTraceSILFunction X("silgen emitConstructor", f);
+      SILGenFunction(SGM, *f, decl).emitClassConstructorAllocator(decl);
+      SGM.postEmitFunction(constant, f);
+    } else {
+      SGM.preEmitFunction(constant, decl, f, decl);
+      PrettyStackTraceSILFunction X("silgen emitConstructor", f);
+      f->createProfiler(decl, constant, ForDefinition);
+      SILGenFunction(SGM, *f, decl).emitValueConstructor(decl);
+      SGM.postEmitFunction(constant, f);
+    }
+    break;
+  }
+
+  case SILDeclRef::Kind::Initializer: {
+    auto *decl = cast<ConstructorDecl>(constant.getDecl());
+    assert(decl->getDeclContext()->getSelfClassDecl());
+
+    SGM.preEmitFunction(constant, decl, f, decl);
+    PrettyStackTraceSILFunction X("silgen constructor initializer", f);
+    f->createProfiler(decl, constant, ForDefinition);
+    SILGenFunction(SGM, *f, decl).emitClassConstructorInitializer(decl);
+    SGM.postEmitFunction(constant, f);
+    break;
+  }
+
+  case SILDeclRef::Kind::DefaultArgGenerator: {
+    auto *decl = constant.getDecl();
+    auto *param = getParameterAt(decl, constant.defaultArgIndex);
+    auto *initDC = param->getDefaultArgumentInitContext();
+
+    switch (param->getDefaultArgumentKind()) {
+    case DefaultArgumentKind::Normal: {
+      auto arg = param->getTypeCheckedDefaultExpr();
+      SGM.preEmitFunction(constant, arg, f, arg);
+      PrettyStackTraceSILFunction X("silgen emitDefaultArgGenerator ", f);
+      SILGenFunction SGF(SGM, *f, initDC);
+      SGF.emitGeneratorFunction(constant, arg);
+      SGM.postEmitFunction(constant, f);
+      break;
+    }
+
+    case DefaultArgumentKind::StoredProperty: {
+      auto arg = param->getStoredProperty();
+      SGM.preEmitFunction(constant, arg, f, arg);
+      PrettyStackTraceSILFunction X("silgen emitDefaultArgGenerator ", f);
+      SILGenFunction SGF(SGM, *f, initDC);
+      SGF.emitGeneratorFunction(constant, arg);
+      SGM.postEmitFunction(constant, f);
+      break;
+    }
+
+    default:
+      llvm_unreachable("Bad default argument kind");
+    }
+
+    break;
+  }
+
+  case SILDeclRef::Kind::StoredPropertyInitializer: {
+    auto *var = cast<VarDecl>(constant.getDecl());
+
+    auto *pbd = var->getParentPatternBinding();
+    unsigned idx = pbd->getPatternEntryIndexForVarDecl(var);
+    auto *init = pbd->getInit(idx);
+    auto *initDC = pbd->getInitContext(idx);
+    auto captureInfo = pbd->getCaptureInfo(idx);
+    assert(!pbd->isInitializerSubsumed(idx));
+
+    // If this is the backing storage for a property with an attached wrapper
+    // that was initialized with `=`, use that expression as the initializer.
+    if (auto originalProperty = var->getOriginalWrappedProperty()) {
+      if (originalProperty
+              ->isPropertyMemberwiseInitializedWithWrappedType()) {
+        auto wrapperInfo =
+            originalProperty->getPropertyWrapperBackingPropertyInfo();
+        assert(wrapperInfo.originalInitialValue);
+        init = wrapperInfo.originalInitialValue;
+      }
+    }
+
+    SGM.preEmitFunction(constant, init, f, init);
+    PrettyStackTraceSILFunction X("silgen emitStoredPropertyInitialization", f);
+    f->createProfiler(init, constant, ForDefinition);
+    SILGenFunction SGF(SGM, *f, initDC);
+
+    // If this is a stored property initializer inside a type at global scope,
+    // it may close over a global variable. If we're emitting top-level code,
+    // then emit a "mark_function_escape" that lists the captured global
+    // variables so that definite initialization can reason about this
+    // escape point.
+    if (!var->getDeclContext()->isLocalContext() &&
+        SGM.TopLevelSGF && SGM.TopLevelSGF->B.hasValidInsertionPoint()) {
+      SGM.emitMarkFunctionEscapeForTopLevelCodeGlobals(var, captureInfo);
+    }
+
+    SGF.emitGeneratorFunction(constant, init, /*EmitProfilerIncrement=*/true);
+    SGM.postEmitFunction(constant, f);
+    break;
+  }
+
+  case SILDeclRef::Kind::PropertyWrapperBackingInitializer: {
+    auto *var = cast<VarDecl>(constant.getDecl());
+
+    SGM.preEmitFunction(constant, var, f, var);
+    PrettyStackTraceSILFunction X(
+        "silgen emitPropertyWrapperBackingInitializer", f);
+    auto wrapperInfo = var->getPropertyWrapperBackingPropertyInfo();
+    assert(wrapperInfo.initializeFromOriginal);
+    f->createProfiler(wrapperInfo.initializeFromOriginal, constant,
+                      ForDefinition);
+    auto varDC = var->getInnermostDeclContext();
+    SILGenFunction SGF(SGM, *f, varDC);
+    SGF.emitGeneratorFunction(constant, wrapperInfo.initializeFromOriginal);
+    SGM.postEmitFunction(constant, f);
+    break;
+  }
+
+  case SILDeclRef::Kind::GlobalAccessor: {
+    auto *global = cast<VarDecl>(constant.getDecl());
+    auto found = SGM.delayedGlobals.find(global);
+    assert(found != SGM.delayedGlobals.end());
+
+    auto *onceToken = found->second.first;
+    auto *onceFunc = found->second.second;
+
+    SGM.preEmitFunction(constant, global, f, global);
+    PrettyStackTraceSILFunction X("silgen emitGlobalAccessor", f);
+    SILGenFunction(SGM, *f, global->getDeclContext())
+      .emitGlobalAccessor(global, onceToken, onceFunc);
+    SGM.postEmitFunction(constant, f);
+    break;
+  }
+
+  case SILDeclRef::Kind::EnumElement:
+  case SILDeclRef::Kind::Destroyer:
+  case SILDeclRef::Kind::Deallocator:
+  case SILDeclRef::Kind::IVarInitializer:
+  case SILDeclRef::Kind::IVarDestroyer:
+    llvm_unreachable("Cannot emit as a delayed function");
+    break;
+  }
+}
+
 /// Emit a function now, if it's externally usable or has been referenced in
 /// the current TU, or remember how to emit it later if not.
-template<typename /*void (SILFunction*)*/ Fn>
 static void emitOrDelayFunction(SILGenModule &SGM,
                                 SILDeclRef constant,
-                                Fn &&emitter,
                                 bool forceEmission = false) {
   auto emitAfter = SGM.lastEmittedFunction;
 
@@ -696,8 +858,7 @@ static void emitOrDelayFunction(SILGenModule &SGM,
 
   // If we don't want to emit now, remember how for later.
   if (!f) {
-    SGM.delayedFunctions.insert({constant, {emitAfter,
-                                            std::forward<Fn>(emitter)}});
+    SGM.delayedFunctions.insert({constant, emitAfter});
     // Even though we didn't emit the function now, update the
     // lastEmittedFunction so that we preserve the original ordering that
     // the symbols would have been emitted in.
@@ -705,7 +866,7 @@ static void emitOrDelayFunction(SILGenModule &SGM,
     return;
   }
 
-  emitter(f);
+  emitDelayedFunction(SGM, constant, f);
 }
 
 void SILGenModule::preEmitFunction(SILDeclRef constant,
@@ -926,20 +1087,10 @@ void SILGenModule::emitFunction(FuncDecl *fd) {
   emitAbstractFuncDecl(fd);
 
   if (fd->hasBody()) {
-    FrontendStatsTracer Tracer(getASTContext().Stats,
-                               "SILGen-funcdecl", fd);
-    PrettyStackTraceDecl stackTrace("emitting SIL for", fd);
-
     SILDeclRef constant(decl);
-
     bool ForCoverageMapping = doesASTRequireProfiling(M, fd);
-
-    emitOrDelayFunction(*this, constant, [this,constant,fd](SILFunction *f){
-      preEmitFunction(constant, fd, f, fd);
-      PrettyStackTraceSILFunction X("silgen emitFunction", f);
-      SILGenFunction(*this, *f, fd).emitFunction(fd);
-      postEmitFunction(constant, f);
-    }, /*forceEmission=*/ForCoverageMapping);
+    emitOrDelayFunction(*this, constant,
+                        /*forceEmission=*/ForCoverageMapping);
   }
 }
 
@@ -967,31 +1118,14 @@ void SILGenModule::emitConstructor(ConstructorDecl *decl) {
     // initializers, have have separate entry points for allocation and
     // initialization.
     if (decl->isDesignatedInit() || decl->isObjC()) {
-      emitOrDelayFunction(
-          *this, constant, [this, constant, decl](SILFunction *f) {
-            preEmitFunction(constant, decl, f, decl);
-            PrettyStackTraceSILFunction X("silgen emitConstructor", f);
-            SILGenFunction(*this, *f, decl).emitClassConstructorAllocator(decl);
-            postEmitFunction(constant, f);
-          });
+      emitOrDelayFunction(*this, constant);
 
-      // Constructors may not have bodies if they've been imported, or if they've
-      // been parsed from a module interface.
       if (decl->hasBody()) {
         SILDeclRef initConstant(decl, SILDeclRef::Kind::Initializer);
-        emitOrDelayFunction(
-            *this, initConstant,
-            [this, initConstant, decl](SILFunction *initF) {
-              preEmitFunction(initConstant, decl, initF, decl);
-              PrettyStackTraceSILFunction X("silgen constructor initializer",
-                                            initF);
-              initF->createProfiler(decl, initConstant, ForDefinition);
-              SILGenFunction(*this, *initF, decl)
-                .emitClassConstructorInitializer(decl);
-              postEmitFunction(initConstant, initF);
-            },
-            /*forceEmission=*/ForCoverageMapping);
+        emitOrDelayFunction(*this, initConstant,
+                            /*forceEmission=*/ForCoverageMapping);
       }
+
       return;
     }
   }
@@ -999,14 +1133,7 @@ void SILGenModule::emitConstructor(ConstructorDecl *decl) {
   // Struct and enum constructors do everything in a single function, as do
   // non-@objc convenience initializers for classes.
   if (decl->hasBody()) {
-    emitOrDelayFunction(
-        *this, constant, [this, constant, decl](SILFunction *f) {
-          preEmitFunction(constant, decl, f, decl);
-          PrettyStackTraceSILFunction X("silgen emitConstructor", f);
-          f->createProfiler(decl, constant, ForDefinition);
-          SILGenFunction(*this, *f, decl).emitValueConstructor(decl);
-          postEmitFunction(constant, f);
-        });
+    emitOrDelayFunction(*this, constant);
   }
 }
 
@@ -1169,37 +1296,14 @@ void SILGenModule::emitDestructor(ClassDecl *cd, DestructorDecl *dd) {
 
 void SILGenModule::emitDefaultArgGenerator(SILDeclRef constant,
                                            ParamDecl *param) {
-  auto initDC = param->getDefaultArgumentInitContext();
-
   switch (param->getDefaultArgumentKind()) {
   case DefaultArgumentKind::None:
     llvm_unreachable("No default argument here?");
 
-  case DefaultArgumentKind::Normal: {
-    auto arg = param->getTypeCheckedDefaultExpr();
-    emitOrDelayFunction(*this, constant,
-        [this,constant,arg,initDC](SILFunction *f) {
-      preEmitFunction(constant, arg, f, arg);
-      PrettyStackTraceSILFunction X("silgen emitDefaultArgGenerator ", f);
-      SILGenFunction SGF(*this, *f, initDC);
-      SGF.emitGeneratorFunction(constant, arg);
-      postEmitFunction(constant, f);
-    });
-    return;
-  }
-
-  case DefaultArgumentKind::StoredProperty: {
-    auto arg = param->getStoredProperty();
-    emitOrDelayFunction(*this, constant,
-        [this,constant,arg,initDC](SILFunction *f) {
-      preEmitFunction(constant, arg, f, arg);
-      PrettyStackTraceSILFunction X("silgen emitDefaultArgGenerator ", f);
-      SILGenFunction SGF(*this, *f, initDC);
-      SGF.emitGeneratorFunction(constant, arg);
-      postEmitFunction(constant, f);
-    });
-    return;
-  }
+  case DefaultArgumentKind::Normal:
+  case DefaultArgumentKind::StoredProperty:
+    emitOrDelayFunction(*this, constant);
+    break;
 
   case DefaultArgumentKind::Inherited:
   case DefaultArgumentKind::Column:
@@ -1211,69 +1315,21 @@ void SILGenModule::emitDefaultArgGenerator(SILDeclRef constant,
   case DefaultArgumentKind::NilLiteral:
   case DefaultArgumentKind::EmptyArray:
   case DefaultArgumentKind::EmptyDictionary:
-    return;
+    break;
   }
 }
 
 void SILGenModule::
 emitStoredPropertyInitialization(PatternBindingDecl *pbd, unsigned i) {
   auto *var = pbd->getAnchoringVarDecl(i);
-  auto *init = pbd->getInit(i);
-  auto *initDC = pbd->getInitContext(i);
-  auto captureInfo = pbd->getCaptureInfo(i);
-  assert(!pbd->isInitializerSubsumed(i));
-
-  // If this is the backing storage for a property with an attached wrapper
-  // that was initialized with `=`, use that expression as the initializer.
-  if (auto originalProperty = var->getOriginalWrappedProperty()) {
-    if (originalProperty
-            ->isPropertyMemberwiseInitializedWithWrappedType()) {
-      auto wrapperInfo =
-          originalProperty->getPropertyWrapperBackingPropertyInfo();
-      assert(wrapperInfo.originalInitialValue);
-      init = wrapperInfo.originalInitialValue;
-    }
-  }
-
   SILDeclRef constant(var, SILDeclRef::Kind::StoredPropertyInitializer);
-  emitOrDelayFunction(*this, constant,
-                      [this,var,captureInfo,constant,init,initDC](SILFunction *f) {
-    preEmitFunction(constant, init, f, init);
-    PrettyStackTraceSILFunction X("silgen emitStoredPropertyInitialization", f);
-    f->createProfiler(init, constant, ForDefinition);
-    SILGenFunction SGF(*this, *f, initDC);
-
-    // If this is a stored property initializer inside a type at global scope,
-    // it may close over a global variable. If we're emitting top-level code,
-    // then emit a "mark_function_escape" that lists the captured global
-    // variables so that definite initialization can reason about this
-    // escape point.
-    if (!var->getDeclContext()->isLocalContext() &&
-        TopLevelSGF && TopLevelSGF->B.hasValidInsertionPoint()) {
-      emitMarkFunctionEscapeForTopLevelCodeGlobals(var, captureInfo);
-    }
-
-    SGF.emitGeneratorFunction(constant, init, /*EmitProfilerIncrement=*/true);
-    postEmitFunction(constant, f);
-  });
+  emitOrDelayFunction(*this, constant);
 }
 
 void SILGenModule::
 emitPropertyWrapperBackingInitializer(VarDecl *var) {
   SILDeclRef constant(var, SILDeclRef::Kind::PropertyWrapperBackingInitializer);
-  emitOrDelayFunction(*this, constant, [this, constant, var](SILFunction *f) {
-    preEmitFunction(constant, var, f, var);
-    PrettyStackTraceSILFunction X(
-        "silgen emitPropertyWrapperBackingInitializer", f);
-    auto wrapperInfo = var->getPropertyWrapperBackingPropertyInfo();
-    assert(wrapperInfo.initializeFromOriginal);
-    f->createProfiler(wrapperInfo.initializeFromOriginal, constant,
-                      ForDefinition);
-    auto varDC = var->getInnermostDeclContext();
-    SILGenFunction SGF(*this, *f, varDC);
-    SGF.emitGeneratorFunction(constant, wrapperInfo.initializeFromOriginal);
-    postEmitFunction(constant, f);
-  });
+  emitOrDelayFunction(*this, constant);
 }
 
 SILFunction *SILGenModule::emitLazyGlobalInitializer(StringRef funcName,
@@ -1306,14 +1362,8 @@ void SILGenModule::emitGlobalAccessor(VarDecl *global,
                                       SILGlobalVariable *onceToken,
                                       SILFunction *onceFunc) {
   SILDeclRef accessor(global, SILDeclRef::Kind::GlobalAccessor);
-  emitOrDelayFunction(*this, accessor,
-                      [this,accessor,global,onceToken,onceFunc](SILFunction *f){
-    preEmitFunction(accessor, global, f, global);
-    PrettyStackTraceSILFunction X("silgen emitGlobalAccessor", f);
-    SILGenFunction(*this, *f, global->getDeclContext())
-      .emitGlobalAccessor(global, onceToken, onceFunc);
-    postEmitFunction(accessor, f);
-  });
+  delayedGlobals[global] = std::make_pair(onceToken, onceFunc);
+  emitOrDelayFunction(*this, accessor);
 }
 
 void SILGenModule::emitDefaultArgGenerators(SILDeclRef::Loc decl,
@@ -1840,7 +1890,8 @@ public:
            || !SGM.pendingConformances.empty()) {
       while (!SGM.forcedFunctions.empty()) {
         auto &front = SGM.forcedFunctions.front();
-        front.second.emitter(SGM.getFunction(front.first, ForDefinition));
+        emitDelayedFunction(SGM, front,
+                            SGM.getEmittedFunction(front, ForDefinition));
         SGM.forcedFunctions.pop_front();
       }
       while (!SGM.pendingConformances.empty()) {

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -60,19 +60,16 @@ public:
   /// Mapping from ProtocolConformances to emitted SILWitnessTables.
   llvm::DenseMap<NormalProtocolConformance*, SILWitnessTable*> emittedWitnessTables;
 
-  struct DelayedFunction {
-    /// Insert the entity after the given function when it's emitted.
-    SILDeclRef insertAfter;
-    /// Code that generates the function.
-    std::function<void (SILFunction *)> emitter;
-  };
-
-  /// Mapping from SILDeclRefs to delayed SILFunction generators for
-  /// non-externally-visible symbols.
-  llvm::DenseMap<SILDeclRef, DelayedFunction> delayedFunctions;
+  /// Mapping from SILDeclRefs to where the given function will be inserted
+  /// when it's emitted. Used for non-externally visible symbols.
+  llvm::DenseMap<SILDeclRef, SILDeclRef> delayedFunctions;
 
   /// Queue of delayed SILFunctions that need to be forced.
-  std::deque<std::pair<SILDeclRef, DelayedFunction>> forcedFunctions;
+  std::deque<SILDeclRef> forcedFunctions;
+
+  /// Mapping global VarDecls to their onceToken and onceFunc, respectively.
+  llvm::DenseMap<VarDecl *, std::pair<SILGlobalVariable *,
+                                      SILFunction *>> delayedGlobals;
 
   /// The most recent declaration we considered for emission.
   SILDeclRef lastEmittedFunction;

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -284,10 +284,6 @@ public:
   /// SILDeclRef(cd, Destructor).
   void emitDestructor(ClassDecl *cd, DestructorDecl *dd);
 
-  /// Generates the enum constructor for the given
-  /// EnumElementDecl under the name SILDeclRef(decl).
-  void emitEnumConstructor(EnumElementDecl *decl);
-
   /// Emits the default argument generator with the given expression.
   void emitDefaultArgGenerator(SILDeclRef constant, ParamDecl *param);
 

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -138,8 +138,6 @@ SILGenFunction::emitGlobalFunctionRef(SILLocation loc, SILDeclRef constant,
       SGM.emitForeignToNativeThunk(constant);
     } else if (constant.isNativeToForeignThunk()) {
       SGM.emitNativeToForeignThunk(constant);
-    } else if (constant.kind == SILDeclRef::Kind::EnumElement) {
-      SGM.emitEnumConstructor(cast<EnumElementDecl>(constant.getDecl()));
     }
   }
 

--- a/test/ClangImporter/attr-swift_private.swift
+++ b/test/ClangImporter/attr-swift_private.swift
@@ -53,15 +53,6 @@ public func testInitializers() {
   _ = Bar(__: 1)
 }
 
-// CHECK-LABEL: define linkonce_odr hidden {{.+}} @"$sSo3BarC8__noArgsABSgyt_tcfcTO"
-// CHECK: @"\01L_selector(initWithNoArgs)"
-// CHECK-LABEL: define linkonce_odr hidden {{.+}} @"$sSo3BarC8__oneArgABSgs5Int32V_tcfcTO"
-// CHECK: @"\01L_selector(initWithOneArg:)"
-// CHECK-LABEL: define linkonce_odr hidden {{.+}} @"$sSo3BarC9__twoArgs5otherABSgs5Int32V_AGtcfcTO"
-// CHECK: @"\01L_selector(initWithTwoArgs:other:)"
-// CHECK-LABEL: define linkonce_odr hidden {{.+}} @"$sSo3BarC2__ABSgs5Int32V_tcfcTO"
-// CHECK: @"\01L_selector(init:)"
-
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @{{.+}}18testFactoryMethods
 public func testFactoryMethods() {
   // CHECK: @"\01L_selector(fooWithOneArg:)"
@@ -135,3 +126,12 @@ func testRawNames() {
   let _ = Foo.__foo // expected-error{{'__foo' has been replaced by 'init(__:)'}}
 }
 #endif
+
+// CHECK-LABEL: define linkonce_odr hidden {{.+}} @"$sSo3BarC8__noArgsABSgyt_tcfcTO"
+// CHECK: @"\01L_selector(initWithNoArgs)"
+// CHECK-LABEL: define linkonce_odr hidden {{.+}} @"$sSo3BarC8__oneArgABSgs5Int32V_tcfcTO"
+// CHECK: @"\01L_selector(initWithOneArg:)"
+// CHECK-LABEL: define linkonce_odr hidden {{.+}} @"$sSo3BarC9__twoArgs5otherABSgs5Int32V_AGtcfcTO"
+// CHECK: @"\01L_selector(initWithTwoArgs:other:)"
+// CHECK-LABEL: define linkonce_odr hidden {{.+}} @"$sSo3BarC2__ABSgs5Int32V_tcfcTO"
+// CHECK: @"\01L_selector(init:)"

--- a/test/ClangImporter/objc_ir.swift
+++ b/test/ClangImporter/objc_ir.swift
@@ -50,10 +50,6 @@ func initCallToAllocInit(i i: CInt) {
 // CHECK-LABEL: linkonce_odr hidden {{.*}} @"$sSo1BC3intABSgs5Int32V_tcfC"
 // CHECK: call [[OPAQUE:%.*]]* @objc_allocWithZone
 
-// CHECK: linkonce_odr hidden {{.*}} @"$sSo1BC3intABSgs5Int32V_tcfcTO"
-// CHECK: load i8*, i8** @"\01L_selector(initWithInt:)"
-// CHECK: call [[OPAQUE:%.*]]* bitcast (void ()* @objc_msgSend
-
 // Indexed subscripting
 // CHECK-LABEL: define hidden swiftcc void @"$s7objc_ir19indexedSubscripting1b3idx1aySo1BC_SiSo1ACtF"
 func indexedSubscripting(b b: B, idx: Int, a: A) {
@@ -356,6 +352,10 @@ func testBlocksWithGenerics(hba: HasBlockArray) -> Any {
   return hba.blockArray
 }
 
+
+// CHECK-LABEL: linkonce_odr hidden {{.*}} @"$sSo1BC3intABSgs5Int32V_tcfcTO"
+// CHECK: load i8*, i8** @"\01L_selector(initWithInt:)"
+// CHECK: call [[OPAQUE:%.*]]* bitcast (void ()* @objc_msgSend
 
 // CHECK: attributes [[NOUNWIND]] = { nounwind }
 

--- a/test/SILGen/objc_currying.swift
+++ b/test/SILGen/objc_currying.swift
@@ -193,6 +193,6 @@ func curry_initializer() -> (Int) -> Gizmo? {
 
 // CHECK-LABEL: sil shared [serializable] [ossa] @$sSo5GizmoC7bellsOnABSgSi_tcfC : $@convention(method) (Int, @thick Gizmo.Type) -> @owned Optional<Gizmo> {
 
-// CHECK-LABEL: sil shared [serializable] [thunk] [ossa] @$sSo5GizmoC7bellsOnABSgSi_tcfcTO : $@convention(method) (Int, @owned Gizmo) -> @owned Optional<Gizmo> {
-
 // CHECK-LABEL: sil private [ossa] @$s13objc_currying17curry_initializerSo5GizmoCSgSicyFAESicfu_ : $@convention(thin) (Int) -> @owned Optional<Gizmo> {
+
+// CHECK-LABEL: sil shared [serializable] [thunk] [ossa] @$sSo5GizmoC7bellsOnABSgSi_tcfcTO : $@convention(method) (Int, @owned Gizmo) -> @owned Optional<Gizmo> {

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -97,9 +97,6 @@ public func arraysOfGenericParam<T: AnyObject>(y: Array<T>) {
   x.propertyArrayOfThings = y
 }
 
-// CHECK-LABEL: sil shared [serializable] [thunk] [ossa] @$sSo12GenericClassC13arrayOfThingsAByxGSgSayxG_tcfcTO
-// CHECK:         objc_method {{%.*}} : $GenericClass<T>, #GenericClass.init!initializer.foreign {{.*}}, $@convention(objc_method) @pseudogeneric <τ_0_0 where τ_0_0 : AnyObject> (NSArray, @owned GenericClass<τ_0_0>) -> @owned Optional<GenericClass<τ_0_0>>
-
 // CHECK-LABEL: sil private [ossa] @$s21objc_imported_generic0C4FuncyyxmRlzClFyycfU_ : $@convention(thin) <V where V : AnyObject> () -> () {
 // CHECK:  [[META:%.*]] = metatype $@thick GenericClass<V>.Type
 // CHECK:  [[INIT:%.*]] = function_ref @$sSo12GenericClassCAByxGycfC : $@convention(method) <τ_0_0 where τ_0_0 : AnyObject> (@thick GenericClass<τ_0_0>.Type) -> @owned GenericClass<τ_0_0>
@@ -117,6 +114,9 @@ func genericFunc<V: AnyObject>(_ v: V.Type) {
 func configureWithoutOptions() {
   _ = GenericClass<NSObject>(options: nil)
 }
+
+// CHECK-LABEL: sil shared [serializable] [thunk] [ossa] @$sSo12GenericClassC13arrayOfThingsAByxGSgSayxG_tcfcTO
+// CHECK:         objc_method {{%.*}} : $GenericClass<T>, #GenericClass.init!initializer.foreign {{.*}}, $@convention(objc_method) @pseudogeneric <τ_0_0 where τ_0_0 : AnyObject> (NSArray, @owned GenericClass<τ_0_0>) -> @owned Optional<GenericClass<τ_0_0>>
 
 // foreign to native thunk for init(options:), uses GenericOption : Hashable
 // conformance


### PR DESCRIPTION
Over time SILGen has grown three mechanisms for lazily emitting function bodies:

- "Delayed functions", which is used for implicit functions defined in the current translation unit, for example, witnesses in derived conformances. These are not emitted as long as the declaration is not visible outside of the translation unit, and not referenced anywhere.

- A more recent "on-demand" mechanism, for lazy emission of declarations from outside the current translation unit, namely imported functions with bodies, and on-demand accessors synthesized to satisfy protocol conformances. This is the most recently added mechanism, meant to replace the old "external declarations" list.

- And yet another spot where we would lazily emit foreign to native thunks, native to foreign thunks, and enum element constructors.

This PR begins converging some of these code paths. The eventual goal is to centralize invariants and make it easier to request-ify SIL generation of individual functions -- today, SIL generation requests are at the level of the entire translation unit.