### PR TITLE
[gardening] Propagate type info to silence static analyzer nullptr error.

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -207,9 +207,9 @@ SILCombiner::optimizeApplyOfConvertFunctionInst(FullApplySite AI,
   // we got this far it is legal to perform the transformation (since
   // otherwise, we would be creating malformed SIL).
   bool setNonThrowing = FRI->getFunctionType()->hasErrorResult();
-  SILInstruction *NAI = Builder.createApply(AI.getLoc(), FRI, SubstitutionMap(),
-                                            Args, setNonThrowing);
-  assert(FullApplySite::isa(NAI).getSubstCalleeType()->getAllResultsSubstType(
+  ApplyInst *NAI = Builder.createApply(AI.getLoc(), FRI, SubstitutionMap(),
+                                       Args, setNonThrowing);
+  assert(FullApplySite(NAI).getSubstCalleeType()->getAllResultsSubstType(
              AI.getModule(), AI.getFunction()->getTypeExpansionContext()) ==
              AI.getSubstCalleeType()->getAllResultsSubstType(
                  AI.getModule(), AI.getFunction()->getTypeExpansionContext()) &&


### PR DESCRIPTION
The static analyzer flags this as a nullptr dereference since FullApplySite::isa
can fail if given a non-ApplySite. Of course though, the SILInstruction is an
apply! We just created it! This commit helps the static analyzer by propagating
this type information by not downcasting our ApplyInst to SILInstruction and
then just use FullApplySite's ApplyInst constructor instead.
