### PR TITLE
[5.3][ConstraintSystem] Detect and diagnose inability to infer type of clo…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -245,6 +245,9 @@ ERROR(no_candidates_match_result_type,none,
       "no '%0' candidates produce the expected contextual result type %1",
       (StringRef, Type))
 
+ERROR(cannot_infer_closure_parameter_type,none,
+      "unable to infer type of a closure parameter %0 in the current context",
+       (StringRef))
 ERROR(cannot_infer_closure_type,none,
       "unable to infer closure type in the current context", ())
 ERROR(cannot_infer_closure_result_type,none,

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1973,6 +1973,15 @@ public:
   bool diagnoseAsError();
 };
 
+class UnableToInferClosureParameterType final : public FailureDiagnostic {
+public:
+  UnableToInferClosureParameterType(const Solution &solution,
+                                    ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator) {}
+
+  bool diagnoseAsError();
+};
+
 class UnableToInferClosureReturnType final : public FailureDiagnostic {
 public:
   UnableToInferClosureReturnType(const Solution &solution,

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -22,6 +22,7 @@
 #include "ConstraintSystem.h"
 #include "OverloadChoice.h"
 #include "swift/AST/Expr.h"
+#include "swift/AST/ParameterList.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/SourceManager.h"
@@ -1224,6 +1225,38 @@ SpecifyBaseTypeForContextualMember *SpecifyBaseTypeForContextualMember::create(
     ConstraintSystem &cs, DeclNameRef member, ConstraintLocator *locator) {
   return new (cs.getAllocator())
       SpecifyBaseTypeForContextualMember(cs, member, locator);
+}
+
+std::string SpecifyClosureParameterType::getName() const {
+  std::string name;
+  llvm::raw_string_ostream OS(name);
+
+  auto *closure = cast<ClosureExpr>(getAnchor());
+  auto paramLoc =
+      getLocator()->castLastElementTo<LocatorPathElt::TupleElement>();
+
+  auto *PD = closure->getParameters()->get(paramLoc.getIndex());
+
+  OS << "specify type for parameter ";
+  if (PD->isAnonClosureParam()) {
+    OS << "$" << paramLoc.getIndex();
+  } else {
+    OS << "'" << PD->getParameterName() << "'";
+  }
+
+  return OS.str();
+}
+
+bool SpecifyClosureParameterType::diagnose(const Solution &solution,
+                                           bool asNote) const {
+  UnableToInferClosureParameterType failure(solution, getLocator());
+  return failure.diagnose(asNote);
+}
+
+SpecifyClosureParameterType *
+SpecifyClosureParameterType::create(ConstraintSystem &cs,
+                                    ConstraintLocator *locator) {
+  return new (cs.getAllocator()) SpecifyClosureParameterType(cs, locator);
 }
 
 bool SpecifyClosureReturnType::diagnose(const Solution &solution,

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -232,6 +232,10 @@ enum class FixKind : uint8_t {
   /// inferred and has to be specified explicitly.
   SpecifyBaseTypeForContextualMember,
 
+  /// Type of the closure parameter used in the body couldn't be inferred
+  /// and has to be specified explicitly.
+  SpecifyClosureParameterType,
+
   /// Closure return type has to be explicitly specified because it can't be
   /// inferred in current context e.g. because it's a multi-statement closure.
   SpecifyClosureReturnType,
@@ -251,7 +255,7 @@ enum class FixKind : uint8_t {
 
   /// A warning fix that allows a coercion to perform a force-cast.
   AllowCoercionToForceCast,
-  
+
   /// Allow key path root type mismatch when applying a key path that has a
   /// root type not convertible to the type of the base instance.
   AllowKeyPathRootTypeMismatch,
@@ -1704,6 +1708,19 @@ public:
 
   static SpecifyBaseTypeForContextualMember *
   create(ConstraintSystem &cs, DeclNameRef member, ConstraintLocator *locator);
+};
+
+class SpecifyClosureParameterType final : public ConstraintFix {
+  SpecifyClosureParameterType(ConstraintSystem &cs, ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::SpecifyClosureParameterType, locator) {}
+
+public:
+  std::string getName() const;
+
+  bool diagnose(const Solution &solution, bool asNote = false) const;
+
+  static SpecifyClosureParameterType *create(ConstraintSystem &cs,
+                                             ConstraintLocator *locator);
 };
 
 class SpecifyClosureReturnType final : public ConstraintFix {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2196,8 +2196,12 @@ namespace {
             auto declaredTy = param->getType();
             externalType = CS.openUnboundGenericType(declaredTy, paramLoc);
           } else {
+            // Let's allow parameters which haven't been explicitly typed
+            // to become holes by default, this helps in situations like
+            // `foo { a in }` where `foo` doesn't exist.
             externalType = CS.createTypeVariable(
-                paramLoc, TVO_CanBindToInOut | TVO_CanBindToNoEscape);
+                paramLoc,
+                TVO_CanBindToInOut | TVO_CanBindToNoEscape | TVO_CanBindToHole);
           }
 
           closureParams.push_back(param->toFunctionParam(externalType));

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9603,6 +9603,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowTupleSplatForSingleParameter:
   case FixKind::AllowInvalidUseOfTrailingClosure:
   case FixKind::AllowNonClassTypeToConvertToAnyObject:
+  case FixKind::SpecifyClosureParameterType:
   case FixKind::SpecifyClosureReturnType:
   case FixKind::AddQualifierToAccessTopLevelName:
     llvm_unreachable("handled elsewhere");

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -1126,6 +1126,10 @@ bool ConstraintGraph::contractEdges() {
     if (isParamBindingConstraint && tyvar1->getImpl().canBindToInOut()) {
       bool isNotContractable = true;
       if (auto bindings = CS.getPotentialBindings(tyvar1)) {
+        // Holes can't be contracted.
+        if (bindings.IsHole)
+          continue;
+
         for (auto &binding : bindings.Bindings) {
           auto type = binding.BindingType;
           isNotContractable = type.findIf([&](Type nestedType) -> bool {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -300,6 +300,10 @@ public:
   /// Determine whether this type variable represents a closure type.
   bool isClosureType() const;
 
+  /// Determine whether this type variable represents one of the
+  /// parameter types associated with a closure.
+  bool isClosureParameterType() const;
+
   /// Determine whether this type variable represents a closure result type.
   bool isClosureResultType() const;
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -90,6 +90,14 @@ bool TypeVariableType::Implementation::isClosureType() const {
   return isa<ClosureExpr>(locator->getAnchor()) && locator->getPath().empty();
 }
 
+bool TypeVariableType::Implementation::isClosureParameterType() const {
+  if (!(locator && locator->getAnchor()))
+    return false;
+
+  return isa<ClosureExpr>(locator->getAnchor()) &&
+         locator->isLastElement<LocatorPathElt::TupleElement>();
+}
+
 bool TypeVariableType::Implementation::isClosureResultType() const {
   if (!(locator && locator->getAnchor()))
     return false;

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -255,8 +255,7 @@ struct Toe {
   let toenail: Nail // expected-error {{cannot find type 'Nail' in scope}}
 
   func clip() {
-    // TODO(diagnostics): Solver should stop once it has detected that `toenail` doesn't exist and report that.
-    toenail.inspect { x in // expected-error {{type of expression is ambiguous without more context}}
+    toenail.inspect { x in
       toenail.inspect { y in }
     }
   }
@@ -297,7 +296,7 @@ func r18800223(_ i : Int) {
 }
 
 // <rdar://problem/21883806> Bogus "'_' can only appear in a pattern or on the left side of an assignment" is back
-_ = { $0 }  // expected-error {{unable to infer closure type in the current context}}
+_ = { $0 }  // expected-error {{unable to infer type of a closure parameter $0 in the current context}}
 
 
 

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -15,15 +15,15 @@ fe(.baz) // expected-error {{reference to member 'baz' cannot be resolved withou
 fe(.nope, .nyet) // expected-error {{type 'Int' has no member 'nope'}}
 // expected-error@-1 {{reference to member 'nyet' cannot be resolved without a contextual type}}
 
-func fg<T>(_ f: (T) -> T) -> Void {} // expected-note {{in call to function 'fg'}}
-fg({x in x}) // expected-error {{generic parameter 'T' could not be inferred}}
+func fg<T>(_ f: (T) -> T) -> Void {}
+fg({x in x}) // expected-error {{unable to infer type of a closure parameter 'x' in the current context}}
 
 
 struct S {
-  func f<T>(_ i: (T) -> T, _ j: Int) -> Void {} // expected-note {{in call to function 'f'}}
+  func f<T>(_ i: (T) -> T, _ j: Int) -> Void {}
   func f(_ d: (Double) -> Double) -> Void {}
   func test() -> Void {
-    f({x in x}, 2) // expected-error {{generic parameter 'T' could not be inferred}}
+    f({x in x}, 2) // expected-error {{unable to infer type of a closure parameter 'x' in the current context}}
   }
   
   func g<T>(_ a: T, _ b: Int) -> Void {}

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -68,7 +68,7 @@ typealias E<T1, T2> = Int  // expected-note {{generic type 'E' declared here}}
 // expected-note@-1 {{'T1' declared as parameter to type 'E'}}
 // expected-note@-2 {{'T2' declared as parameter to type 'E'}}
 
-typealias F<T1, T2> = (T1) -> T2 // expected-note {{'T1' declared as parameter to type 'F'}}
+typealias F<T1, T2> = (T1) -> T2
 
 // Type alias of type alias.
 typealias G<S1, S2> = A<S1, S2>
@@ -94,7 +94,7 @@ let _ : D<Int, Int, Float> = D(a: 1, b: 2)
 
 let _ : F = { (a : Int) -> Int in a }  // Infer the types of F
 
-let _ : F = { a in a } // expected-error {{generic parameter 'T1' could not be inferred}}
+let _ : F = { a in a } // expected-error {{unable to infer type of a closure parameter 'a' in the current context}}
 
 _ = MyType(a: "foo", b: 42)
 _ = A(a: "foo", b: 42)

--- a/test/expr/closure/anonymous.swift
+++ b/test/expr/closure/anonymous.swift
@@ -13,7 +13,7 @@ func takesIntArray(_: [Int]) { }
 func takesVariadicInt(_: (Int...) -> ()) { }
 func takesVariadicIntInt(_: (Int, Int...) -> ()) { }
 
-func takesVariadicGeneric<T>(_ f: (T...) -> ()) { } // expected-note {{in call to function 'takesVariadicGeneric'}}
+func takesVariadicGeneric<T>(_ f: (T...) -> ()) { }
 
 func variadic() {
   // These work
@@ -32,7 +32,7 @@ func variadic() {
   // FIXME: Problem here is related to multi-statement closure body not being type-checked together with
   // enclosing context. We could have inferred `$0` to be `[Int]` if `let` was a part of constraint system.
   takesVariadicGeneric({let _: [Int] = $0})
-  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-1 {{unable to infer type of a closure parameter $0 in the current context}}
 
   takesVariadicIntInt({_ = $0; takesIntArray($1)})
   takesVariadicIntInt({_ = $0; let _: [Int] = $1})

--- a/test/expr/closure/basic.swift
+++ b/test/expr/closure/basic.swift
@@ -26,7 +26,7 @@ func variadic() {
   _ = f(1, 2)
   _ = f(1, 3)
 
-  let D = { (Ss ...) in 1 } // expected-error{{'...' cannot be applied to a subpattern which is not explicitly typed}}, expected-error{{unable to infer closure type in the current context}}
+  let D = { (Ss ...) in 1 } // expected-error{{'...' cannot be applied to a subpattern which is not explicitly typed}}, expected-error{{unable to infer type of a closure parameter 'Ss' in the current context}}
 }
 
 // Closures with attributes in the parameter list.

--- a/test/expr/unary/keypath/salvage-with-other-type-errors.swift
+++ b/test/expr/unary/keypath/salvage-with-other-type-errors.swift
@@ -34,7 +34,7 @@ extension A: K {
 
 struct B {
     let v: String
-    func f1<T, E>(block: (T) -> E) -> B { // expected-note {{in call to function 'f1(block:)'}}
+    func f1<T, E>(block: (T) -> E) -> B {
         return self
     }
 
@@ -42,7 +42,7 @@ struct B {
     }
 }
 func f3() {
-    B(v: "").f1(block: { _ in }).f2(keyPath: \B.v) // expected-error{{}}
+    B(v: "").f1(block: { _ in }).f2(keyPath: \B.v) // expected-error{{unable to infer type of a closure parameter '_' in the current context}}
 }
 
 // SR-5375

--- a/validation-test/compiler_crashers_2_fixed/0186-rdar46497155.swift
+++ b/validation-test/compiler_crashers_2_fixed/0186-rdar46497155.swift
@@ -20,10 +20,9 @@ struct E {
 
 func foo(arr: [E], other: P) -> Bool {
   return arr.compactMap { i in
-    // expected-error@-1 {{generic parameter 'ElementOfResult' could not be inferred}}
     var flag = false
     return try? i.getB(&flag)
-  }.compactMap { u -> P? in
+  }.compactMap { u -> P? in // expected-error {{nable to infer type of a closure parameter 'u' in the current context}}
     guard let a = try? u.foo() else { return nil }
     return a.value!
   }.contains {


### PR DESCRIPTION
…sure parameter(s)

Cherry-pick of https://github.com/apple/swift/pull/31809

---
- Explanation: 

Detect situation when it's impossible to determine types for
closure parameters used in the body from the context. E.g.
when a call closure is associated with refers to a missing
member.

```swift
struct S {
}

S.foo { a, b in } // `S` doesn't have static member `foo`

let _ = { v in } // not enough context to infer type of `v`

_ = .foo { v in } // base type for `.foo` couldn't be determined
```

- Scope: Diagnostics related to parameters of a closure

- Resolves: rdar://problem/63230293

- Risk: Low

- Testing: Added a regression tests

- Reviewer: @hborla 

Resolves: [SR-12815](https://bugs.swift.org/browse/SR-12815)
Resolves: rdar://problem/63230293

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
