### PR TITLE
Remove three ObjC metadata fields from non-ObjC runtime

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -2623,6 +2623,7 @@ private:
     // WARNING: the following algorithm works on current modern Apple
     // runtimes but is not actually ABI.  But it is pretty reliable.
 
+#if SWIFT_OBJC_INTEROP
     StoredPointer dataPtr;
     if (!Reader->readInteger(RemoteAddress(classAddress +
                                TargetClassMetadata<Runtime>::offsetToData()),
@@ -2665,6 +2666,9 @@ private:
     }
 
     return dataPtr;
+#else
+    return StoredPointer();
+#endif
   }
 
   IsaEncodingKind getIsaEncoding() {

--- a/lib/IRGen/ClassMetadataVisitor.h
+++ b/lib/IRGen/ClassMetadataVisitor.h
@@ -58,15 +58,13 @@ public:
     // Metadata header.
     super::layout();
 
-    // ClassMetadata header.  In ObjCInterop mode, this must be
-    // layout-compatible with an Objective-C class.  The superclass
-    // pointer is useful regardless of mode, but the rest of the data
-    // isn't necessary.
-    // FIXME: Figure out what can be removed altogether in non-objc-interop
-    // mode and remove it. rdar://problem/18801263
+    // ClassMetadata header. This must be layout-compatible with Objective-C
+    // classes when interoperability is enabled.
     asImpl().addSuperclass();
-    asImpl().addClassCacheData();
-    asImpl().addClassDataPointer();
+    if (IGM.ObjCInterop) {
+      asImpl().addClassCacheData();
+      asImpl().addClassDataPointer();
+    }
 
     asImpl().addClassFlags();
     asImpl().addInstanceAddressPoint();

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -114,7 +114,9 @@ Metadata *TargetSingletonMetadataInitialization<InProcess>::allocate(
   // isn't Swift metadata but a plain old ObjC class instead.
   if (metadata->getKind() == MetadataKind::Class) {
     auto *classMetadata = static_cast<ClassMetadata*>(metadata);
+#if SWIFT_OBJC_INTEROP
     classMetadata->setAsTypeMetadata();
+#endif
     auto *fullMetadata = asFullMetadata(metadata);
 
     // Begin by initializing the value witness table; everything else is
@@ -537,8 +539,6 @@ initializeClassMetadataFromPattern(ClassMetadata *metadata,
   auto classRO = metadataExtraData + pattern->ClassRODataOffset;
   metadata->Data =
     reinterpret_cast<uintptr_t>(classRO) | SWIFT_CLASS_IS_SWIFT_MASK;
-#else
-  metadata->Data = SWIFT_CLASS_IS_SWIFT_MASK;
 #endif
 
   // Class flags.
@@ -2201,8 +2201,6 @@ _swift_relocateClassMetadata(const ClassDescriptor *description,
   auto classRO = pattern->Data.get();
   metadata->Data =
     reinterpret_cast<uintptr_t>(classRO) | SWIFT_CLASS_IS_SWIFT_MASK;
-#else
-  metadata->Data = SWIFT_CLASS_IS_SWIFT_MASK;
 #endif
 
   // Class flags.

--- a/test/IRGen/class_metadata.swift
+++ b/test/IRGen/class_metadata.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/class_metadata.swift
-// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %t/class_metadata.swift -check-prefix=CHECK -check-prefix=CHECK-%target-ptrsize -check-prefix CHECK-%target-import-type -check-prefix=CHECK-%target-cpu
+// RUN: %target-swift-frontend  -enable-objc-interop -emit-ir %s | %FileCheck %t/class_metadata.swift -check-prefixes=CHECK,CHECK-%target-ptrsize,CHECK-%target-import-type,CHECK-%target-cpu -D#MDSIZE=7
+// RUN: %target-swift-frontend -disable-objc-interop -emit-ir %s | %FileCheck %t/class_metadata.swift -check-prefixes=CHECK,CHECK-%target-ptrsize,CHECK-%target-import-type,CHECK-%target-cpu -D#MDSIZE=4
 
 class A {}
 
@@ -20,16 +21,16 @@ class A {}
 //   Negative size in words.
 // CHECK-SAME: i32 2,
 //   Positive size in words.
-// CHECK-32-SAME: i32 14,
-// CHECK-64-SAME: i32 11,
+// CHECK-32-SAME: i32 [[#MDSIZE + 6 + 1]],
+// CHECK-64-SAME: i32 [[#MDSIZE + 3 + 1]],
 //   Field count.
 // CHECK-SAME: i32 0,
 //   Field offset vector offset.
-// CHECK-32-SAME: i32 13,
-// CHECK-64-SAME: i32 10,
+// CHECK-32-SAME: i32 [[#MDSIZE + 6]],
+// CHECK-64-SAME: i32 [[#MDSIZE + 3]],
 //   V-table offset.
-// CHECK-32-SAME: i32 13,
-// CHECK-64-SAME: i32 10,
+// CHECK-32-SAME: i32 [[#MDSIZE + 6]],
+// CHECK-64-SAME: i32 [[#MDSIZE + 3]],
 //   V-table length.
 // CHECK-SAME: i32 1,
 // CHECK-SAME: %swift.method_descriptor {
@@ -61,15 +62,15 @@ class B : A {}
 //   Negative size in words.
 // CHECK-SAME: i32 2,
 //   Positive size in words.
-// CHECK-32-SAME: i32 14,
-// CHECK-64-SAME: i32 11,
+// CHECK-32-SAME: i32 [[#MDSIZE + 6 + 1]],
+// CHECK-64-SAME: i32 [[#MDSIZE + 3 + 1]],
 //   Immediate member count.
 // CHECK-SAME: i32 0,
 //   Field count.
 // CHECK-SAME: i32 0,
 //   Field offset vector offset.
-// CHECK-32-SAME: i32 14,
-// CHECK-64-SAME: i32 11,
+// CHECK-32-SAME: i32 [[#MDSIZE + 6 + 1]],
+// CHECK-64-SAME: i32 [[#MDSIZE + 3 + 1]],
 //   Number of method overrides.
 // CHECK-SAME: i32 1,
 // CHECK-SAME: %swift.method_override_descriptor {
@@ -100,15 +101,15 @@ class C<T> : B {}
 //   Negative size in words.
 // CHECK-SAME: i32 2,
 //   Positive size in words.
-// CHECK-32-SAME: i32 15,
-// CHECK-64-SAME: i32 12,
+// CHECK-32-SAME: i32 [[#MDSIZE + 6 + 2]],
+// CHECK-64-SAME: i32 [[#MDSIZE + 3 + 2]],
 //   Num immediate members.
 // CHECK-32-SAME: i32 1,
 //   Field count.
 // CHECK-SAME: i32 0,
 //   Field offset vector offset.
-// CHECK-32-SAME: i32 15,
-// CHECK-64-SAME: i32 12,
+// CHECK-32-SAME: i32 [[#MDSIZE + 6 + 2]],
+// CHECK-64-SAME: i32 [[#MDSIZE + 3 + 2]],
 //   Instantiation cache.
 // CHECK-SAME: i32 {{.*}} @"$s14class_metadata1CCMI"
 //   Instantiation pattern.
@@ -163,15 +164,15 @@ class D : E {}
 //   Negative size in words.
 // CHECK-SAME: i32 2,
 //   Positive size in words.
-// CHECK-32-SAME: i32 14,
-// CHECK-64-SAME: i32 11,
+// CHECK-32-SAME: i32 [[#MDSIZE + 6 + 1]],
+// CHECK-64-SAME: i32 [[#MDSIZE + 3 + 1]],
 //   Immediate member count.
 // CHECK-SAME: i32 0,
 //   Field count.
 // CHECK-SAME: i32 0,
 //   Field offset vector offset.
-// CHECK-32-SAME: i32 14,
-// CHECK-64-SAME: i32 11,
+// CHECK-32-SAME: i32 [[#MDSIZE + 6 + 1]],
+// CHECK-64-SAME: i32 [[#MDSIZE + 3 + 1]],
 //   Number of method overrides.
 // CHECK-SAME: i32 1,
 // CHECK-SAME: %swift.method_override_descriptor {

--- a/test/IRGen/class_resilience.sil
+++ b/test/IRGen/class_resilience.sil
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class %S/../Inputs/resilient_class.swift -I %t
-// RUN: %target-swift-frontend -I %t -emit-ir -enable-library-evolution %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objc-interop -I %t -emit-ir -enable-library-evolution %s | %FileCheck %s --check-prefixes=CHECK,CHECK-objc
+// RUN: %target-swift-frontend -disable-objc-interop -I %t -emit-ir -enable-library-evolution %s | %FileCheck %s --check-prefixes=CHECK,CHECK-native
 // RUN: %target-swift-frontend -I %t -emit-ir -enable-library-evolution -O %s
 
 // REQUIRES: CPU=x86_64
@@ -24,11 +25,13 @@ import resilient_class
 // CHECK:      [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s15resilient_class22ResilientOutsideParentCMa"(i64 0)
 // CHECK-NEXT: [[META:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK-NEXT: [[META_ADDR:%.*]] = bitcast %swift.type* [[META]] to i8*
-// CHECK-NEXT: [[SIZE_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 48
+// CHECK-objc-NEXT: [[SIZE_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 48
+// CHECK-native-NEXT: [[SIZE_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 24
 // CHECK-NEXT: [[SIZE_PTR:%.*]] = bitcast i8* [[SIZE_ADDR]] to i32*
 // CHECK-NEXT: [[SIZE_2:%.*]] = load i32, i32* [[SIZE_PTR]], align 8
 // CHECK-NEXT: [[SIZE:%.*]] = zext i32 [[SIZE_2]] to i64
-// CHECK-NEXT: [[ALIGN_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 52
+// CHECK-objc-NEXT: [[ALIGN_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 52
+// CHECK-native-NEXT: [[ALIGN_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 28
 // CHECK-NEXT: [[ALIGN_PTR:%.*]] = bitcast i8* [[ALIGN_ADDR]] to i16*
 // CHECK-NEXT: [[ALIGN_2:%.*]] = load i16, i16* [[ALIGN_PTR]], align 4
 // CHECK-NEXT: [[ALIGN:%.*]] = zext i16 [[ALIGN_2]] to i64

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/../Inputs/resilient_enum.swift
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class -I %t %S/../Inputs/resilient_class.swift
-// RUN: %target-swift-frontend -enable-objc-interop -I %t -emit-ir -enable-library-evolution %t/class_resilience.swift | %FileCheck %t/class_resilience.swift --check-prefixes=CHECK,CHECK-objc,CHECK-objc%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-cpu,CHECK-objc-STABLE-ABI-%target-mandates-stable-abi -DINT=i%target-ptrsize -D#MDWORDS=7 -D#MDSIZE32=52 -D#MDSIZE64=80 -D#WORDSIZE=%target-alignment
+// RUN: %target-swift-frontend -enable-objc-interop -I %t -emit-ir -enable-library-evolution %t/class_resilience.swift | %FileCheck %t/class_resilience.swift --check-prefixes=CHECK,CHECK-objc,CHECK-objc%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-cpu,CHECK-%target-import-type-objc-STABLE-ABI-%target-mandates-stable-abi -DINT=i%target-ptrsize -D#MDWORDS=7 -D#MDSIZE32=52 -D#MDSIZE64=80 -D#WORDSIZE=%target-alignment
 // RUN: %target-swift-frontend -disable-objc-interop -I %t -emit-ir -enable-library-evolution %t/class_resilience.swift | %FileCheck %t/class_resilience.swift --check-prefixes=CHECK,CHECK-native,CHECK-native%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-cpu,CHECK-native-STABLE-ABI-%target-mandates-stable-abi -DINT=i%target-ptrsize -D#MDWORDS=4 -D#MDSIZE32=40 -D#MDSIZE64=56 -D#WORDSIZE=%target-alignment
 // RUN: %target-swift-frontend -I %t -emit-ir -enable-library-evolution -O %t/class_resilience.swift
 
@@ -417,8 +417,9 @@ public class ClassWithResilientThenEmpty {
 
 // -- ClassLayoutFlags = 0x100 (HasStaticVTable)
 // CHECK-native:               [[T0:%.*]] = call swiftcc %swift.metadata_response @swift_initClassMetadata2(%swift.type* %0, [[INT]] 256, [[INT]] 3, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
-// CHECK-objc-STABLE-ABI-TRUE: [[T0:%.*]] = call swiftcc %swift.metadata_response @swift_updateClassMetadata2(%swift.type* %0, [[INT]] 256, [[INT]] 3, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
-// CHECK-objc-STABLE-ABI-FALSE:[[T0:%.*]] = call swiftcc %swift.metadata_response @swift_initClassMetadata2(%swift.type* %0, [[INT]] 256, [[INT]] 3, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
+// CHECK-DIRECT-objc-STABLE-ABI-TRUE: [[T0:%.*]] = call swiftcc %swift.metadata_response @swift_updateClassMetadata2(%swift.type* %0, [[INT]] 256, [[INT]] 3, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
+// CHECK-DIRECT-objc-STABLE-ABI-FALSE:[[T0:%.*]] = call swiftcc %swift.metadata_response @swift_initClassMetadata2(%swift.type* %0, [[INT]] 256, [[INT]] 3, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
+// CHECK-INDIRECT-objc-STABLE-ABI-TRUE:[[T0:%.*]] = call swiftcc %swift.metadata_response @swift_initClassMetadata2(%swift.type* %0, [[INT]] 256, [[INT]] 3, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
 // CHECK-NEXT: [[INITDEP_METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK-NEXT: [[INITDEP_STATUS:%.*]] = extractvalue %swift.metadata_response [[T0]], 1
 // CHECK-NEXT: [[INITDEP_PRESENT:%.*]] = icmp eq %swift.type* [[INITDEP_METADATA]], null
@@ -496,8 +497,9 @@ public class ClassWithResilientThenEmpty {
 
 // -- ClassLayoutFlags = 0x100 (HasStaticVTable)
 // CHECK-native:               [[T0:%.*]] = call swiftcc %swift.metadata_response @swift_initClassMetadata2(%swift.type* %0, [[INT]] 256, [[INT]] 2, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
-// CHECK-objc-STABLE-ABI-TRUE: [[T0:%.*]] = call swiftcc %swift.metadata_response @swift_updateClassMetadata2(%swift.type* %0, [[INT]] 256, [[INT]] 2, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
-// CHECK-objc-STABLE-ABI-FALSE:[[T0:%.*]] = call swiftcc %swift.metadata_response @swift_initClassMetadata2(%swift.type* %0, [[INT]] 256, [[INT]] 2, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
+// CHECK-DIRECT-objc-STABLE-ABI-TRUE: [[T0:%.*]] = call swiftcc %swift.metadata_response @swift_updateClassMetadata2(%swift.type* %0, [[INT]] 256, [[INT]] 2, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
+// CHECK-DIRECT-objc-STABLE-ABI-FALSE:[[T0:%.*]] = call swiftcc %swift.metadata_response @swift_initClassMetadata2(%swift.type* %0, [[INT]] 256, [[INT]] 2, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
+// CHECK-INDIRECT-objc-STABLE-ABI-TRUE:[[T0:%.*]] = call swiftcc %swift.metadata_response @swift_initClassMetadata2(%swift.type* %0, [[INT]] 256, [[INT]] 2, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
 // CHECK-NEXT: [[INITDEP_METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK-NEXT: [[INITDEP_STATUS:%.*]] = extractvalue %swift.metadata_response [[T0]], 1
 // CHECK-NEXT: [[INITDEP_PRESENT:%.*]] = icmp eq %swift.type* [[INITDEP_METADATA]], null

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -3,7 +3,8 @@
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/../Inputs/resilient_enum.swift
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class -I %t %S/../Inputs/resilient_class.swift
-// RUN: %target-swift-frontend -I %t -emit-ir -enable-library-evolution %t/class_resilience.swift | %FileCheck %t/class_resilience.swift --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-runtime -check-prefix=CHECK-%target-cpu --check-prefix=CHECK-%target-runtime-STABLE-ABI-%target-mandates-stable-abi -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -enable-objc-interop -I %t -emit-ir -enable-library-evolution %t/class_resilience.swift | %FileCheck %t/class_resilience.swift --check-prefixes=CHECK,CHECK-objc,CHECK-objc%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-cpu,CHECK-objc-STABLE-ABI-%target-mandates-stable-abi -DINT=i%target-ptrsize -D#MDWORDS=7 -D#MDSIZE32=52 -D#MDSIZE64=80 -D#WORDSIZE=%target-alignment
+// RUN: %target-swift-frontend -disable-objc-interop -I %t -emit-ir -enable-library-evolution %t/class_resilience.swift | %FileCheck %t/class_resilience.swift --check-prefixes=CHECK,CHECK-native,CHECK-native%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-cpu,CHECK-native-STABLE-ABI-%target-mandates-stable-abi -DINT=i%target-ptrsize -D#MDWORDS=4 -D#MDSIZE32=40 -D#MDSIZE64=56 -D#WORDSIZE=%target-alignment
 // RUN: %target-swift-frontend -I %t -emit-ir -enable-library-evolution -O %t/class_resilience.swift
 
 // CHECK: @"$s16class_resilience26ClassWithResilientPropertyC1s16resilient_struct4SizeVvpWvd" = hidden global [[INT]] 0
@@ -20,8 +21,8 @@
 // CHECK: @"$s16class_resilience27ClassWithResilientThenEmptyC9resilient0H7_struct0E3IntVvpWvd" = hidden global [[INT]] 0,
 
 // CHECK: @"$s16class_resilience26ClassWithResilientPropertyCMo" = {{(protected )?}}{{(dllexport )?}}constant [[BOUNDS]]
-// CHECK-32-SAME: { [[INT]] 52, i32 2, i32 17 }
-// CHECK-64-SAME: { [[INT]] 80, i32 2, i32 14 }
+// CHECK-32-SAME: { [[INT]] [[#MDSIZE32]], i32 2, i32 [[#MDWORDS + 6 + 4]] }
+// CHECK-64-SAME: { [[INT]] [[#MDSIZE64]], i32 2, i32 [[#MDWORDS + 3 + 4]] }
 
 // CHECK: @"$s16class_resilience28ClassWithMyResilientPropertyC1rAA0eF6StructVvpWvd" = hidden constant [[INT]] {{8|16}}
 // CHECK: @"$s16class_resilience28ClassWithMyResilientPropertyC5colors5Int32VvpWvd" = hidden constant [[INT]] {{12|20}}
@@ -101,20 +102,20 @@
 // CHECK-native-SAME: i32 0
 
 // CHECK: @"$s16class_resilience17MyResilientParentCMo" = {{(protected )?}}{{(dllexport )?}}constant [[BOUNDS]]
-// CHECK-32-SAME: { [[INT]] 52, i32 2, i32 15 }
-// CHECK-64-SAME: { [[INT]] 80, i32 2, i32 12 }
+// CHECK-32-SAME: { [[INT]] [[#MDSIZE32]], i32 2, i32 [[#MDWORDS + 6 + 2]] }
+// CHECK-64-SAME: { [[INT]] [[#MDSIZE64]], i32 2, i32 [[#MDWORDS + 3 + 2]] }
 
 // CHECK: @"$s16class_resilience16MyResilientChildCMo" = {{(protected )?}}{{(dllexport )?}}constant [[BOUNDS]]
-// CHECK-32-SAME: { [[INT]] 60, i32 2, i32 16 }
-// CHECK-64-SAME: { [[INT]] 96, i32 2, i32 13 }
+// CHECK-32-SAME: { [[INT]] [[#MDSIZE32 + WORDSIZE + WORDSIZE]], i32 2, i32 [[#MDWORDS + 6 + 3]] }
+// CHECK-64-SAME: { [[INT]] [[#MDSIZE64 + WORDSIZE + WORDSIZE]], i32 2, i32 [[#MDWORDS + 3 + 3]] }
 
 // CHECK: @"$s16class_resilience24MyResilientGenericParentCMo" = {{(protected )?}}{{(dllexport )?}}constant [[BOUNDS]]
-// CHECK-32-SAME: { [[INT]] 52, i32 2, i32 16 }
-// CHECK-64-SAME: { [[INT]] 80, i32 2, i32 13 }
+// CHECK-32-SAME: { [[INT]] [[#MDSIZE32]], i32 2, i32 [[#MDWORDS + 6 + 3]] }
+// CHECK-64-SAME: { [[INT]] [[#MDSIZE64]], i32 2, i32 [[#MDWORDS + 3 + 3]] }
 
 // CHECK: @"$s16class_resilience24MyResilientConcreteChildCMo" = {{(protected )?}}{{(dllexport )?}}constant [[BOUNDS]]
-// CHECK-32-SAME: { [[INT]] 64, i32 2, i32 18 }
-// CHECK-64-SAME: { [[INT]] 104, i32 2, i32 15 }
+// CHECK-32-SAME: { [[INT]] [[#MDSIZE32 + WORDSIZE + WORDSIZE + WORDSIZE]], i32 2, i32 [[#MDWORDS + 6 + 5]] }
+// CHECK-64-SAME: { [[INT]] [[#MDSIZE64 + WORDSIZE + WORDSIZE + WORDSIZE]], i32 2, i32 [[#MDWORDS + 3 + 5]] }
 
 // CHECK: @"$s16class_resilience27ClassWithEmptyThenResilientC5emptyAA0E0VvpWvd" = hidden constant [[INT]] 0,
 // CHECK: @"$s16class_resilience27ClassWithResilientThenEmptyC5emptyAA0G0VvpWvd" = hidden constant [[INT]] 0,
@@ -400,7 +401,8 @@ public class ClassWithResilientThenEmpty {
 // CHECK: entry:
 // CHECK-NEXT: [[FIELDS:%.*]] = alloca [3 x i8**]
 // CHECK-NEXT: [[METADATA_ADDR:%.*]] = bitcast %swift.type* %0 to [[INT]]*
-// CHECK-NEXT: [[FIELDS_DEST:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[METADATA_ADDR]], [[INT]] {{10|13}}
+// CHECK-objc-NEXT: [[FIELDS_DEST:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[METADATA_ADDR]], [[INT]] {{10|13}}
+// CHECK-native-NEXT: [[FIELDS_DEST:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[METADATA_ADDR]], [[INT]] {{7|10}}
 // CHECK-NEXT: [[FIELDS_ADDR:%.*]] = bitcast [3 x i8**]* [[FIELDS]] to i8*
 // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 {{12|24}}, i8* [[FIELDS_ADDR]])
 // CHECK-NEXT: [[FIELDS_PTR:%.*]] = getelementptr inbounds [3 x i8**], [3 x i8**]* [[FIELDS]], i32 0, i32 0
@@ -478,7 +480,8 @@ public class ClassWithResilientThenEmpty {
 // CHECK: entry:
 // CHECK-NEXT: [[FIELDS:%.*]] = alloca [2 x i8**]
 // CHECK-NEXT: [[METADATA_ADDR:%.*]] = bitcast %swift.type* %0 to [[INT]]*
-// CHECK-NEXT: [[FIELDS_DEST:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[METADATA_ADDR]], [[INT]] {{10|13}}
+// CHECK-objc-NEXT: [[FIELDS_DEST:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[METADATA_ADDR]], [[INT]] {{10|13}}
+// CHECK-native-NEXT: [[FIELDS_DEST:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[METADATA_ADDR]], [[INT]] {{7|10}}
 // CHECK-NEXT: [[FIELDS_ADDR:%.*]] = bitcast [2 x i8**]* [[FIELDS]] to i8*
 // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 {{8|16}}, i8* [[FIELDS_ADDR]])
 // CHECK-NEXT: [[FIELDS_PTR:%.*]] = getelementptr inbounds [2 x i8**], [2 x i8**]* [[FIELDS]], i32 0, i32 0

--- a/test/IRGen/dynamic_init.sil
+++ b/test/IRGen/dynamic_init.sil
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objc-interop  -emit-ir %s | %FileCheck %s --check-prefixes=CHECK,CHECK-objc
+// RUN: %target-swift-frontend -disable-objc-interop -emit-ir %s | %FileCheck %s --check-prefixes=CHECK,CHECK-native
 
 // REQUIRES: CPU=x86_64
 
@@ -20,7 +21,8 @@ sil @$s12dynamic_init1CCfD : $@convention(method) (@owned C) -> ()
 sil @$s12dynamic_init15testDynamicInityAA1CCm2cm_tF : $@convention(method) (@thick C.Type) -> () {
 bb0(%0 : $@thick C.Type):
   // CHECK:   [[META:%[0-9]+]] = bitcast %swift.type* %0 to %T12dynamic_init1CC* (%swift.type*)**
-  // CHECK:   [[VTABLE_OFFSET:%[0-9]+]] = getelementptr inbounds %T12dynamic_init1CC* (%swift.type*)*, %T12dynamic_init1CC* (%swift.type*)** [[META]], i64 10
+  // CHECK-objc:   [[VTABLE_OFFSET:%[0-9]+]] = getelementptr inbounds %T12dynamic_init1CC* (%swift.type*)*, %T12dynamic_init1CC* (%swift.type*)** [[META]], i64 10
+  // CHECK-native: [[VTABLE_OFFSET:%[0-9]+]] = getelementptr inbounds %T12dynamic_init1CC* (%swift.type*)*, %T12dynamic_init1CC* (%swift.type*)** [[META]], i64 7
   // CHECK:   [[CTOR:%[0-9]+]] = load %T12dynamic_init1CC* (%swift.type*)*, %T12dynamic_init1CC* (%swift.type*)** [[VTABLE_OFFSET]], align 8
   %2 = class_method %0 : $@thick C.Type, #C.init!allocator : (C.Type) -> () -> C, $@convention(method) (@thick C.Type) -> @owned C
   // CHECK:   [[RESULT:%[0-9]+]] = call swiftcc %T12dynamic_init1CC* [[CTOR]](%swift.type* swiftself %0)

--- a/test/IRGen/fulfillment.sil
+++ b/test/IRGen/fulfillment.sil
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -enable-objc-interop | %FileCheck %s --check-prefixes=CHECK,CHECK-objc
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-objc-interop | %FileCheck %s --check-prefixes=CHECK,CHECK-native
 
 // REQUIRES: CPU=x86_64
 
@@ -31,13 +32,16 @@ sil hidden_external @use_all : $@convention(thin) <T, U where T : P, U : P> () -
 // CHECK:      [[T0:%.*]] = bitcast %T11fulfillment1BC* %0 to %swift.type**
 // CHECK-NEXT: [[METADATA:%.*]] = load %swift.type*, %swift.type** [[T0]], align 8
 // CHECK:      [[T0:%.*]] = bitcast %swift.type* [[METADATA]] to %swift.type**
-// CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i64 10
+// CHECK-objc-NEXT: [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i64 10
+// CHECK-native-NEXT: [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i64 7
 // CHECK-NEXT:  %T = load %swift.type*, %swift.type** [[T1]], align 8
 // CHECK:      [[T0:%.*]] = bitcast %swift.type* [[METADATA]] to %swift.type**
-// CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i64 11
+// CHECK-objc-NEXT: [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i64 11
+// CHECK-native-NEXT: [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i64 8
 // CHECK-NEXT:  %U = load %swift.type*, %swift.type** [[T1]], align 8
 // CHECK:      [[T0:%.*]] = bitcast %swift.type* [[METADATA]] to i8***
-// CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds i8**, i8*** [[T0]], i64 12
+// CHECK-objc-NEXT: [[T1:%.*]] = getelementptr inbounds i8**, i8*** [[T0]], i64 12
+// CHECK-native-NEXT: [[T1:%.*]] = getelementptr inbounds i8**, i8*** [[T0]], i64 9
 // CHECK-NEXT:  %U.P = load i8**, i8*** [[T1]], align 8
 sil hidden @class_pointer : $@convention(thin) <T, U where T : P, U : P> (@guaranteed B<T, U>) -> () {
 bb0(%0 : $B<T, U>):
@@ -73,7 +77,8 @@ sil @callee : $@convention(method) <τ_0_0 where τ_0_0 : A2, τ_0_0.AssocTy : C
 // CHECK-LABEL: define{{.*}} swiftcc void @caller(%T11fulfillment1KC** {{.*}}, %swift.type* %Self, i8** %SelfWitnessTable)
 // CHECK: entry:
 // CHECK:   %1 = bitcast %swift.type* %Self to i8***
-// CHECK:   %2 = getelementptr inbounds i8**, i8*** %1, i64 11
+// CHECK-objc:   %2 = getelementptr inbounds i8**, i8*** %1, i64 11
+// CHECK-native:   %2 = getelementptr inbounds i8**, i8*** %1, i64 8
 // CHECK:   %"\CF\84_1_0.C" = load i8**, i8*** %2
 // CHECK:   call swiftcc void @callee(%swift.type* %Self, i8** %SelfWitnessTable, i8** %"\CF\84_1_0.C"
 sil @caller : $@convention(witness_method: A2) <τ_0_0><τ_1_0 where τ_0_0 : K<τ_1_0>, τ_1_0 : C> (@in_guaranteed τ_0_0) -> () {

--- a/test/IRGen/generic_classes.sil
+++ b/test/IRGen/generic_classes.sil
@@ -23,13 +23,15 @@ import Swift
 // --       negative size in words
 // CHECK-SAME:   i32 2,
 // --       positive size in words
-// CHECK-SAME:   i32 18,
+// CHECK-objc-SAME:   i32 18,
+// CHECK-native-SAME:   i32 15,
 // --       num immediate members
 // CHECK-SAME:   i32 8,
 // --       num fields
 // CHECK-SAME:   i32 3,
 // --       field offset vector offset
-// CHECK-SAME:   i32 11,
+// CHECK-objc-SAME:   i32 11,
+// CHECK-native-SAME:   i32 8,
 // --       template instantiation cache
 // CHECK-SAME:   [16 x i8*]* @"$s15generic_classes11RootGenericCMI"
 // --       template instantiation pattern
@@ -37,7 +39,8 @@ import Swift
 // --       generic parameters, requirements, key arguments, extra arguments
 // CHECK-SAME:   i16 1, i16 0, i16 1, i16 0
 // --       vtable offset
-// CHECK-SAME:   i32 14,
+// CHECK-objc-SAME:   i32 14,
+// CHECK-native-SAME:   i32 11,
 // --       vtable size
 // CHECK-SAME:   i32 4
 // CHECK-SAME: }
@@ -91,22 +94,27 @@ import Swift
 // CHECK-SAME: }>
 
 // CHECK: @"$s15generic_classes14RootNonGenericCMf" = internal global <{ {{.*}} }> <{
+// -- destructor
 // CHECK-SAME:                void (%T15generic_classes14RootNonGenericC*)* @"$s15generic_classes14RootNonGenericCfD",
+// -- witness table pointer
 // CHECK-DIRECT-SAME:         i8** @"$sBoWV",
 // CHECK-INDIRECT-SAME:       i8** null,
-// CHECK-native-SAME:         i64 0,
-// CHECK-native-SAME:         %swift.type* null,
-// CHECK-native-SAME:         %swift.opaque* null,
+// -- swift object type
 // CHECK-objc-SAME:           i64 ptrtoint (%objc_class* @"$s15generic_classes14RootNonGenericCMm" to i64),
+// CHECK-native-SAME:         i64 0,
+// -- superclass
 // CHECK-DIRECT-objc-SAME:    %objc_class* @"OBJC_CLASS_$_{{(_TtCs12_)?}}SwiftObject",
 // CHECK-INDIRECT-objc-SAME:  %swift.type* null,
+// CHECK-native-SAME:         %swift.type* null,
+// -- objc only fields
 // CHECK-objc-SAME:           %swift.opaque* @_objc_empty_cache,
-// CHECK-SAME:                %swift.opaque* null,
-// CHECK-native-SAME:         i64 1,
+// CHECK-objc-SAME:           %swift.opaque* null,
 // CHECK-objc-SAME:           @_DATA__TtC15generic_classes14RootNonGeneric
+// -- flags, sizes, and offsets...
 // CHECK-SAME:                i32 33,
 // CHECK-SAME:                i16 7,
 // CHECK-SAME:                i16 0,
+// -- nominal type descriptor
 // CHECK-SAME:                {{.*}}* @"$s15generic_classes14RootNonGenericCMn"
 // CHECK-SAME: }>
 
@@ -250,11 +258,13 @@ sil @$s15generic_classes024RecursiveGenericInheritsD0CfD : $@convention(method) 
 // CHECK:   [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s15generic_classes11RootGenericCMa"(i64 0, %swift.type* %G)
 // CHECK:   [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK:   [[METADATA_ARRAY:%.*]] = bitcast %swift.type* [[METADATA]] to i8*
-// CHECK:   [[T0:%.*]] = getelementptr inbounds i8, i8* [[METADATA_ARRAY]], i32 48
+// CHECK-objc:   [[T0:%.*]] = getelementptr inbounds i8, i8* [[METADATA_ARRAY]], i32 48
+// CHECK-native: [[T0:%.*]] = getelementptr inbounds i8, i8* [[METADATA_ARRAY]], i32 24
 // CHECK:   [[T1:%.*]] = bitcast i8* [[T0]] to i32*
 // CHECK:   [[SIZE32:%.*]] = load i32, i32* [[T1]], align 8
 // CHECK:   [[SIZE:%.*]] = zext i32 [[SIZE32]] to i64
-// CHECK:   [[T0:%.*]] = getelementptr inbounds i8, i8* [[METADATA_ARRAY]], i32 52
+// CHECK-objc:   [[T0:%.*]] = getelementptr inbounds i8, i8* [[METADATA_ARRAY]], i32 52
+// CHECK-native: [[T0:%.*]] = getelementptr inbounds i8, i8* [[METADATA_ARRAY]], i32 28
 // CHECK:   [[T1:%.*]] = bitcast i8* [[T0]] to i16*
 // CHECK:   [[ALIGN16:%.*]] = load i16, i16* [[T1]], align 4
 // CHECK:   [[ALIGN:%.*]] = zext i16 [[ALIGN16]] to i64
@@ -278,7 +288,8 @@ entry(%c : $RootGeneric<F>):
 // RootGeneric.y has dependent layout; load the offset from the metadata
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @RootGeneric_concrete_fragile_dependent_member_access_y
 // CHECK:   [[TYPE_METADATA_ARRAY:%.*]] = bitcast %swift.type* {{%.*}} to i64*
-// CHECK:   [[Y_OFFSET_ADDR:%.*]] = getelementptr inbounds i64, i64* [[TYPE_METADATA_ARRAY]], i64 12
+// CHECK-objc:   [[Y_OFFSET_ADDR:%.*]] = getelementptr inbounds i64, i64* [[TYPE_METADATA_ARRAY]], i64 12
+// CHECK-native: [[Y_OFFSET_ADDR:%.*]] = getelementptr inbounds i64, i64* [[TYPE_METADATA_ARRAY]], i64 9
 // CHECK:   [[Y_OFFSET:%.*]] = load i64, i64* [[Y_OFFSET_ADDR]], align 8
 // CHECK:   [[CLASS_BYTE_ARRAY:%.*]] = bitcast [[ROOTGENERIC]]* {{%.*}} to i8*
 // CHECK:   [[Y_ADDR:%.*]] = getelementptr inbounds i8, i8* [[CLASS_BYTE_ARRAY]], i64 [[Y_OFFSET]]
@@ -305,7 +316,8 @@ entry(%z : $*Int, %c : $RootGeneric<Int>):
 // RootGeneric.z has dependent layout; load the offset from the metadata
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @RootGeneric_concrete_fragile_dependent_member_access_z
 // CHECK:   [[TYPE_METADATA_ARRAY:%.*]] = bitcast %swift.type* {{%.*}} to i64*
-// CHECK:   [[Z_OFFSET_ADDR:%.*]] = getelementptr inbounds i64, i64* [[TYPE_METADATA_ARRAY]], i64 13
+// CHECK-objc:   [[Z_OFFSET_ADDR:%.*]] = getelementptr inbounds i64, i64* [[TYPE_METADATA_ARRAY]], i64 13
+// CHECK-native: [[Z_OFFSET_ADDR:%.*]] = getelementptr inbounds i64, i64* [[TYPE_METADATA_ARRAY]], i64 10
 // CHECK:   [[Z_OFFSET:%.*]] = load i64, i64* [[Z_OFFSET_ADDR]], align 8
 // CHECK:   [[CLASS_BYTE_ARRAY:%.*]] = bitcast [[ROOTGENERIC]]* {{%.*}} to i8*
 // CHECK:   [[Z_ADDR:%.*]] = getelementptr inbounds i8, i8* [[CLASS_BYTE_ARRAY]], i64 [[Z_OFFSET]]
@@ -375,7 +387,8 @@ entry(%c : $RootGeneric<Int32>):
 
 //   Initialize our own dependent field offsets.
 // CHECK:   [[METADATA_ARRAY:%.*]] = bitcast %swift.type* [[METADATA]] to i64*
-// CHECK:   [[OFFSETS:%.*]] = getelementptr inbounds i64, i64* [[METADATA_ARRAY]], i64 20
+// CHECK-objc:   [[OFFSETS:%.*]] = getelementptr inbounds i64, i64* [[METADATA_ARRAY]], i64 20
+// CHECK-native: [[OFFSETS:%.*]] = getelementptr inbounds i64, i64* [[METADATA_ARRAY]], i64 17
 // CHECK:   [[FIELDS_ADDR:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* %classFields, i32 0, i32 0
 // CHECK:   [[T0:%.*]] = call{{( tail)?}} swiftcc %swift.metadata_response @swift_checkMetadataState(i64 319, %swift.type* %B)
 // CHECK:   [[B_CHECKED:%.*]] = extractvalue %swift.metadata_response [[T0]], 0

--- a/test/IRGen/generic_types.swift
+++ b/test/IRGen/generic_types.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: %target-swift-frontend -enable-objc-interop %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-objc
+// RUN: %target-swift-frontend -disable-objc-interop %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-native
 
 // REQUIRES: CPU=x86_64
 
@@ -20,13 +21,15 @@
 // -- negative size in words
 // CHECK-SAME:   i32 2,
 // -- positive size in words
-// CHECK-SAME:   i32 17,
+// CHECK-objc-SAME:   i32 17,
+// CHECK-native-SAME:   i32 14,
 // -- num immediate members
 // CHECK-SAME:   i32 7,
 // -- num fields
 // CHECK-SAME:   i32 1,
 // -- field offset vector offset
-// CHECK-SAME:   i32 11,
+// CHECK-objc-SAME:   i32 11,
+// CHECK-native-SAME:   i32 8,
 // -- instantiation cache
 // CHECK-SAME:   @"$s13generic_types1ACMI"
 // -- instantiation pattern

--- a/test/IRGen/generic_vtable.swift
+++ b/test/IRGen/generic_vtable.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/generic_vtable.swift
-// RUN: %target-swift-frontend %t/generic_vtable.swift -emit-ir | %FileCheck %t/generic_vtable.swift --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize -check-prefix CHECK-%target-import-type -check-prefix CHECK-%target-abi
+// RUN: %target-swift-frontend -enable-objc-interop  %t/generic_vtable.swift -emit-ir | %FileCheck %t/generic_vtable.swift --check-prefixes=CHECK,CHECK-objc,CHECK-objc%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-import-type,CHECK-%target-abi -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -disable-objc-interop %t/generic_vtable.swift -emit-ir | %FileCheck %t/generic_vtable.swift --check-prefixes=CHECK,CHECK-native,CHECK-native%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-import-type,CHECK-%target-abi -DINT=i%target-ptrsize
 
 public class Base {
   public func m1() {}
@@ -25,8 +26,10 @@ public class Concrete : Derived<Int> {
 // CHECK-DIRECT-SAME: <i32 0x8000_0050>,
 // CHECK-INDIRECT-SAME: <i32 0x8001_0050>,
 // -- vtable offset
-// CHECK-32-SAME: i32 16,
-// CHECK-64-SAME: i32 10,
+// CHECK-objc32-SAME: i32 16,
+// CHECK-native32-SAME: i32 13,
+// CHECK-objc64-SAME: i32 10,
+// CHECK-native64-SAME: i32 7,
 // -- vtable size
 // CHECK-SAME: i32 3,
 // -- vtable entry for m1()
@@ -59,8 +62,10 @@ public class Concrete : Derived<Int> {
 // -- flags: has vtable, has override table, is class, is unique, is generic
 // CHECK-SAME: <i32 0xC000_00D0>,
 // -- vtable offset
-// CHECK-32-SAME: i32 17,
-// CHECK-64-SAME: i32 14,
+// CHECK-objc32-SAME: i32 17,
+// CHECK-native32-SAME: i32 14,
+// CHECK-objc64-SAME: i32 14,
+// CHECK-native64-SAME: i32 11,
 // -- vtable size
 // CHECK-SAME: i32 1,
 // -- vtable entry for m3()
@@ -95,8 +100,10 @@ public class Concrete : Derived<Int> {
 // -- flags: has vtable, has override table, in-place initialization, is class, is unique
 // CHECK-SAME: <i32 0xC001_0050>,
 // -- vtable offset
-// CHECK-32-SAME: i32 19,
-// CHECK-64-SAME: i32 15,
+// CHECK-objc32-SAME: i32 19,
+// CHECK-native32-SAME: i32 16,
+// CHECK-objc64-SAME: i32 15,
+// CHECK-native64-SAME: i32 12,
 // -- vtable size
 // CHECK-SAME: i32 1,
 // -- vtable entry for m4()

--- a/test/IRGen/partial_apply_forwarder.sil
+++ b/test/IRGen/partial_apply_forwarder.sil
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -enable-objc-interop  -primary-file %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize --check-prefixes=CHECK,CHECK-objc
+// RUN: %target-swift-frontend -disable-objc-interop -primary-file %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize --check-prefixes=CHECK,CHECK-native
 sil_stage canonical
 
 import Builtin
@@ -96,7 +97,8 @@ sil hidden_external @takingEmptyAndQ : $@convention(thin) <τ_0_0 where  τ_0_0 
 // CHECK:   [[TYADDR:%.*]] = getelementptr inbounds %T23partial_apply_forwarder7WeakBoxC, %T23partial_apply_forwarder7WeakBoxC* %1, i32 0, i32 0, i32 0
 // CHECK:   [[TY:%.*]] = load %swift.type*, %swift.type** [[TYADDR]]
 // CHECK:   [[GENPARAMSADDR:%.*]] = bitcast %swift.type* [[TY]] to %swift.type**
-// CHECK:   [[PARAMTYADDR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[GENPARAMSADDR]], {{(i64 10|i32 13)}}
+// CHECK-objc:   [[PARAMTYADDR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[GENPARAMSADDR]], {{(i64 10|i32 13)}}
+// CHECK-native: [[PARAMTYADDR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[GENPARAMSADDR]], {{(i64 7|i32 10)}}
 // CHECK:   %"BaseProducer<\CF\84_0_1>" = load %swift.type*, %swift.type** [[PARAMTYADDR]]
 // CHECK:   [[WITNESS:%.*]] = call i8** @swift_getWitnessTable(
 // CHECK:   [[OBJ:%.*]] = bitcast %swift.refcounted* %0 to %T23partial_apply_forwarder7WeakBoxC.1*
@@ -155,7 +157,8 @@ bb0(%0 : $*τ_0_1, %2: $EmptyType):
 // CHECK:   [[TY:%.*]] = load %swift.type*, %swift.type** [[TYADDR]]
 // CHECK:   [[CAST:%.*]] = bitcast %T23partial_apply_forwarder7WeakBoxC* %0 to %T23partial_apply_forwarder7WeakBoxC.1*
 // CHECK:   [[TYPARAMSADDR:%.*]] = bitcast %swift.type* [[TY]] to %swift.type**
-// CHECK:   [[TYPARAM:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[TYPARAMSADDR]], {{(i64 10|i32 13)}}
+// CHECK-objc:   [[TYPARAM:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[TYPARAMSADDR]], {{(i64 10|i32 13)}}
+// CHECK-native: [[TYPARAM:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[TYPARAMSADDR]], {{(i64 7|i32 10)}}
 // CHECK:   %"BaseProducer<\CF\84_0_1>" = load %swift.type*, %swift.type** [[TYPARAM]]
 // CHECK:   [[WITNESS:%.*]] = call i8** @swift_getWitnessTable
 // CHECK:   tail call swiftcc void @takingQ(%T23partial_apply_forwarder7WeakBoxC.1* [[CAST]], i8** [[WITNESS]])
@@ -209,7 +212,8 @@ sil hidden_external @takingQAndS : $@convention(thin) <τ_0_0 where  τ_0_0 : Q>
 // CHECK:   %.asUnsubstituted = bitcast %T23partial_apply_forwarder7WeakBoxC* [[WB]] to %T23partial_apply_forwarder7WeakBoxC.1*
 // CHECK:   call void @swift_release(%swift.refcounted* %0)
 // CHECK:   [[GENPARAMSADDR:%.*]] = bitcast %swift.type* [[TY]] to %swift.type**
-// CHECK:   [[GENPARAMADDR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[GENPARAMSADDR]], {{(i64 10|i32 13)}}
+// CHECK-objc:   [[GENPARAMADDR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[GENPARAMSADDR]], {{(i64 10|i32 13)}}
+// CHECK-native: [[GENPARAMADDR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[GENPARAMSADDR]], {{(i64 7|i32 10)}}
 // CHECK:   %"BaseProducer<\CF\84_0_1>" = load %swift.type*, %swift.type** [[GENPARAMADDR]]
 // CHECK:   [[WITNESS:%.*]] = call i8** @swift_getWitnessTable
 // CHECK:   tail call swiftcc void @takingQAndS(i64 [[X]], %T23partial_apply_forwarder7WeakBoxC.1* %.asUnsubstituted, i8** [[WITNESS]])

--- a/test/IRGen/sil_witness_methods.sil
+++ b/test/IRGen/sil_witness_methods.sil
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objc-interop  %s -emit-ir | %FileCheck --check-prefixes=CHECK,CHECK-objc %s
+// RUN: %target-swift-frontend -disable-objc-interop %s -emit-ir | %FileCheck --check-prefixes=CHECK,CHECK-native %s
 
 // REQUIRES: CPU=x86_64
 
@@ -36,13 +37,16 @@ entry(%x : $*Foo):
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @generic_type_concrete_method_witness(%T19sil_witness_methods3BarC** noalias nocapture swiftself dereferenceable({{.*}}) %0, %swift.type* %Self, i8** %SelfWitnessTable)
 // CHECK:         [[T0:%.*]] = bitcast %swift.type* %Self to %swift.type**
-// CHECK:         [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i64 10
+// CHECK-objc:    [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i64 10
+// CHECK-native:  [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i64 7
 // CHECK:         %T = load %swift.type*, %swift.type** [[T1]], align 8
 // CHECK:         [[U0:%.*]] = bitcast %swift.type* %Self to %swift.type**
-// CHECK:         [[U1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[U0]], i64 11
+// CHECK-objc:    [[U1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[U0]], i64 11
+// CHECK-native:  [[U1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[U0]], i64 8
 // CHECK:         %U = load %swift.type*, %swift.type** [[U1]], align 8
 // CHECK:         [[V0:%.*]] = bitcast %swift.type* %Self to %swift.type**
-// CHECK:         [[V1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[V0]], i64 12
+// CHECK-objc:    [[V1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[V0]], i64 12
+// CHECK-native:  [[V1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[V0]], i64 9
 // CHECK:         %V = load %swift.type*, %swift.type** [[V1]], align 8
 sil @generic_type_concrete_method_witness : $@convention(witness_method: P) <T, U, V> (@in Bar<T, U, V>) -> @thick Bar<T, U, V>.Type {
 entry(%x : $*Bar<T, U, V>):
@@ -66,13 +70,16 @@ entry(%x : $@thick Foo.Type):
 //   The use of %0 or %Self here is irrelevant.
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @generic_type_concrete_static_method_witness(%swift.type* swiftself %0, %swift.type* %Self, i8** %SelfWitnessTable)
 // CHECK:         [[T0:%.*]] = bitcast %swift.type* %Self to %swift.type**
-// CHECK:         [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i64 10
+// CHECK-objc:    [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i64 10
+// CHECK-native:  [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i64 7
 // CHECK:         %T = load %swift.type*, %swift.type** [[T1]], align 8
 // CHECK:         [[U0:%.*]] = bitcast %swift.type* %Self to %swift.type**
-// CHECK:         [[U1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[U0]], i64 11
+// CHECK-objc:    [[U1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[U0]], i64 11
+// CHECK-native:  [[U1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[U0]], i64 8
 // CHECK:         %U = load %swift.type*, %swift.type** [[U1]], align 8
 // CHECK:         [[V0:%.*]] = bitcast %swift.type* %Self to %swift.type**
-// CHECK:         [[V1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[V0]], i64 12
+// CHECK-objc:    [[V1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[V0]], i64 12
+// CHECK-native:  [[V1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[V0]], i64 9
 // CHECK:         %V = load %swift.type*, %swift.type** [[V1]], align 8
 sil @generic_type_concrete_static_method_witness : $@convention(witness_method: P) <T, U, V> (@thick Bar<T, U, V>.Type) -> @thick Bar<T, U, V>.Type {
 entry(%x : $@thick Bar<T, U, V>.Type):

--- a/test/IRGen/tail_alloc.sil
+++ b/test/IRGen/tail_alloc.sil
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -stack-promotion-limit 48 -Onone -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -enable-objc-interop  -stack-promotion-limit 48 -Onone -emit-ir %s | %FileCheck --check-prefixes=CHECK,CHECK-objc %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -disable-objc-interop -stack-promotion-limit 48 -Onone -emit-ir %s | %FileCheck --check-prefixes=CHECK,CHECK-native %s -DINT=i%target-ptrsize
 //
 // REQUIRES: CPU=x86_64
 
@@ -112,11 +113,13 @@ bb0(%0 : $Builtin.Word, %1 : $@thick T.Type):
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} {{.*}}* @alloc_dynamic
 // CHECK:      [[BYTE_PTR:%[0-9]+]] = bitcast %swift.type* %0 to i8*
-// CHECK-NEXT: [[SIZE_ADDR:%[0-9]+]] = getelementptr inbounds i8, i8* [[BYTE_PTR]], i32 48
+// CHECK-objc-NEXT:   [[SIZE_ADDR:%[0-9]+]] = getelementptr inbounds i8, i8* [[BYTE_PTR]], i32 48
+// CHECK-native-NEXT: [[SIZE_ADDR:%[0-9]+]] = getelementptr inbounds i8, i8* [[BYTE_PTR]], i32 24
 // CHECK-NEXT: [[INT_PTR:%[0-9]+]] = bitcast i8* [[SIZE_ADDR]] to i32*
 // CHECK-NEXT: [[SIZE:%[0-9]+]] = load i32, i32* [[INT_PTR]]
 // CHECK-NEXT: [[SIZE64:%[0-9]+]] = zext i32 [[SIZE]] to i64
-// CHECK-NEXT: [[ALIGN_ADDR:%[0-9]+]] = getelementptr inbounds i8, i8* [[BYTE_PTR]], i32 52
+// CHECK-objc-NEXT:   [[ALIGN_ADDR:%[0-9]+]] = getelementptr inbounds i8, i8* [[BYTE_PTR]], i32 52
+// CHECK-native-NEXT: [[ALIGN_ADDR:%[0-9]+]] = getelementptr inbounds i8, i8* [[BYTE_PTR]], i32 28
 // CHECK-NEXT: [[SHORT_PTR:%[0-9]+]] = bitcast i8* [[ALIGN_ADDR]] to i16*
 // CHECK-NEXT: [[ALIGN:%[0-9]+]] = load i16, i16* [[SHORT_PTR]]
 // CHECK-NEXT: [[ALIGN64:%[0-9]+]] = zext i16 [[ALIGN]] to i64

--- a/test/IRGen/vtable.sil
+++ b/test/IRGen/vtable.sil
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: %target-swift-frontend -enable-objc-interop -emit-ir %s | %FileCheck %s --check-prefixes=CHECK,CHECK-objc
+// RUN: %target-swift-frontend -disable-objc-interop -emit-ir %s | %FileCheck %s --check-prefixes=CHECK,CHECK-native
 // REQUIRES: executable_test
 
 // REQUIRES: CPU=x86_64
@@ -37,11 +38,8 @@ sil @$s6vtable1CCfD : $@convention(method) (@owned C) -> ()
 // CHECK-native: i8** {{@"\$sBoWV"|null}},
 // CHECK-native: i64 0,
 // CHECK-native: %swift.type* null,
-// CHECK-native: %swift.opaque* null,
-// CHECK-native: %swift.opaque* null,
-// CHECK-native: i64 1,
 // CHECK-native: i32 {{3|2}}, i32 0, i32 16, i16 7, i16 0,
-// CHECK-native: i32 104, i32 16,
+// CHECK-native: i32 80, i32 16,
 // CHECK-native: @"$s6vtable1CCMn"
 // CHECK-native: [[C]]* (%swift.type*)* @"$s6vtable1CCACycACmcfC"
 // CHECK-native: }>

--- a/test/IRGen/vtable.sil
+++ b/test/IRGen/vtable.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-objc-interop -emit-ir %s | %FileCheck %s --check-prefixes=CHECK,CHECK-objc
+// RUN: %target-swift-frontend -enable-objc-interop -emit-ir %s | %FileCheck %s --check-prefixes=CHECK,CHECK-objc,CHECK-%target-import-type-objc
 // RUN: %target-swift-frontend -disable-objc-interop -emit-ir %s | %FileCheck %s --check-prefixes=CHECK,CHECK-native
 // REQUIRES: executable_test
 
@@ -20,18 +20,19 @@ sil @$s6vtable1CCfd : $@convention(method) (@owned C) -> @owned Builtin.NativeOb
 sil @$s6vtable1CCfD : $@convention(method) (@owned C) -> ()
 
 // CHECK-objc: @"$s6vtable1CCMf" = internal global [[C_METADATA_T:<{.*\* }>]] <{
-// CHECK-objc: void ([[C]]*)* @"$s6vtable1CCfD",
-// CHECK-objc: i8** {{@"\$sBoWV"|null}},
-// CHECK-objc: i64 ptrtoint (%objc_class* @"$s6vtable1CCMm" to i64),
-// CHECK-objc: %objc_class* @"OBJC_CLASS_$_{{(_TtCs12_)?}}SwiftObject",
-// CHECK-objc: %swift.opaque* @_objc_empty_cache,
-// CHECK-objc: %swift.opaque* null,
-// CHECK-objc: i64 add (i64 ptrtoint ({ i32, i32, i32, i32, i8*, i8*, i8*, i8*, i8*, i8*, i8* }* @_DATA__TtC6vtable1C to i64), i64 {{1|2}}),
-// CHECK-objc: i32 {{3|2}}, i32 0, i32 16, i16 7, i16 0,
-// CHECK-objc: i32 104, i32 16,
-// CHECK-objc: @"$s6vtable1CCMn"
-// CHECK-objc: [[C]]* (%swift.type*)* @"$s6vtable1CCACycACmcfC"
-// CHECK-objc: }>
+// CHECK-objc:          void ([[C]]*)* @"$s6vtable1CCfD",
+// CHECK-objc:          i8** {{@"\$sBoWV"|null}},
+// CHECK-objc:          i64 ptrtoint (%objc_class* @"$s6vtable1CCMm" to i64),
+// CHECK-DIRECT-objc:   %objc_class* @"OBJC_CLASS_$_{{(_TtCs12_)?}}SwiftObject",
+// CHECK-INDIRECT-objc: %swift.type* null,
+// CHECK-objc:          %swift.opaque* @_objc_empty_cache,
+// CHECK-objc:          %swift.opaque* null,
+// CHECK-objc:          i64 add (i64 ptrtoint ({ i32, i32, i32, i32, i8*, i8*, i8*, i8*, i8*, i8*, i8* }* @_DATA__TtC6vtable1C to i64), i64 {{1|2}}),
+// CHECK-objc:          i32 {{3|2}}, i32 0, i32 16, i16 7, i16 0,
+// CHECK-objc:          i32 104, i32 16,
+// CHECK-objc:          @"$s6vtable1CCMn"
+// CHECK-objc:          [[C]]* (%swift.type*)* @"$s6vtable1CCACycACmcfC"
+// CHECK-objc:  }>
 
 // CHECK-native: @"$s6vtable1CCMf" = internal global [[C_METADATA_T:<{.*\* }>]] <{
 // CHECK-native: void ([[C]]*)* @"$s6vtable1CCfD",

--- a/test/IRGen/vtable_multi_file.swift
+++ b/test/IRGen/vtable_multi_file.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -primary-file %s %S/Inputs/vtable_multi_file_helper.swift -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objc-interop -primary-file %s %S/Inputs/vtable_multi_file_helper.swift -emit-ir | %FileCheck --check-prefixes=CHECK,CHECK-OBJC %s
+// RUN: %target-swift-frontend -disable-objc-interop -primary-file %s %S/Inputs/vtable_multi_file_helper.swift -emit-ir | %FileCheck --check-prefixes=CHECK,CHECK-NO-OBJC %s
 
 // REQUIRES: CPU=x86_64
 
@@ -15,7 +16,8 @@ func baseClassVtablesIncludeImplicitInits() {
   // CHECK: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$s17vtable_multi_file8SubclassCMa"(i64 0)
   // CHECK: [[T0:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
   // CHECK: [[T1:%.*]] = bitcast %swift.type* [[T0]] to { i64, %swift.bridge* } (%swift.type*)**
-  // CHECK: [[T2:%.*]] = getelementptr inbounds { i64, %swift.bridge* } (%swift.type*)*, { i64, %swift.bridge* } (%swift.type*)** [[T1]], i64 11
+  // CHECK-OBJC: [[T2:%.*]] = getelementptr inbounds { i64, %swift.bridge* } (%swift.type*)*, { i64, %swift.bridge* } (%swift.type*)** [[T1]], i64 11
+  // CHECK-NO-OBJC: [[T2:%.*]] = getelementptr inbounds { i64, %swift.bridge* } (%swift.type*)*, { i64, %swift.bridge* } (%swift.type*)** [[T1]], i64 8
   // CHECK: load { i64, %swift.bridge* } (%swift.type*)*, { i64, %swift.bridge* } (%swift.type*)** [[T2]]
   markUsed(Subclass.classProp)
 }

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -13,8 +13,8 @@
 // RUN: %target-swift-frontend -typecheck -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST -DVERIFY %s -verify
 // RUN: %target-swift-frontend -emit-silgen -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST %s | %FileCheck -check-prefix CHECK-SIL %s
 
-// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/custom-modules -DTEST %s | %FileCheck -check-prefix CHECK-IR %s
-// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST %s | %FileCheck -check-prefix CHECK-IR %s
+// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/custom-modules -DTEST %s | %FileCheck --check-prefixes=CHECK-IR,CHECK-IR-%target-runtime %s
+// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST %s | %FileCheck --check-prefixes=CHECK-IR,CHECK-IR-%target-runtime %s
 
 // RUN: %target-swift-frontend -typecheck -I %t -I %S/Inputs/custom-modules -Xcc -DBAD %S/Inputs/typedefs-helper.swift -verify
 
@@ -38,7 +38,8 @@ public func testVTableBuilding(user: User) {
   // for the vtable slot for 'lastMethod()'. If the layout here
   // changes, please check that offset is still correct.
   // CHECK-IR-NOT: ret
-  // CHECK-IR: getelementptr inbounds void (%T3Lib4UserC*)*, void (%T3Lib4UserC*)** %{{[0-9]+}}, {{i64 28|i32 31}}
+  // CHECK-IR-objc: getelementptr inbounds void (%T3Lib4UserC*)*, void (%T3Lib4UserC*)** %{{[0-9]+}}, {{i64 28|i32 31}}
+  // CHECK-IR-native: getelementptr inbounds void (%T3Lib4UserC*)*, void (%T3Lib4UserC*)** %{{[0-9]+}}, {{i64 25|i32 28}}
   user.lastMethod()
 } // CHECK-IR: ret void
 

--- a/test/multifile/require-layout-generic-arg-closure.swift
+++ b/test/multifile/require-layout-generic-arg-closure.swift
@@ -1,5 +1,8 @@
-// RUN: %target-swift-frontend -module-name test -emit-ir -verify -primary-file %s %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefix=FILE1 %s
-// RUN: %target-swift-frontend -module-name test -emit-ir -verify %s -primary-file %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefix=FILE2 %s
+// RUN: %target-swift-frontend -module-name test -enable-objc-interop -emit-ir -verify -primary-file %s %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE1,FILE1-objc %s
+// RUN: %target-swift-frontend -module-name test -enable-objc-interop -emit-ir -verify %s -primary-file %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE2,FILE2-objc %s
+
+// RUN: %target-swift-frontend -module-name test -disable-objc-interop -emit-ir -verify -primary-file %s %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE1,FILE1-native %s
+// RUN: %target-swift-frontend -module-name test -disable-objc-interop -emit-ir -verify %s -primary-file %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE2,FILE2-native %s
 
 // REQUIRES: CPU=x86_64
 
@@ -10,7 +13,8 @@
 // FILE1:   [[T1:%.*]] = bitcast %T4test3SubC* %0 to %swift.type**
 // FILE1:   [[TYPEMETADATA:%.*]] = load %swift.type*, %swift.type** [[T1]]
 // FILE1:   [[T2:%.*]] = bitcast %swift.type* [[TYPEMETADATA]] to %swift.type**
-// FILE1:   [[T_PTR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T2]], i64 16
+// FILE1-objc:     [[T_PTR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T2]], i64 16
+// FILE1-native:   [[T_PTR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T2]], i64 13
 // FILE1:   [[T:%.*]] = load %swift.type*, %swift.type** [[T_PTR]]
 // FILE1:   call swiftcc %swift.metadata_response @"$s4test3SubCMa"(i64 255, %swift.type* [[T]])
 

--- a/test/multifile/require-layout-generic-arg-subscript.swift
+++ b/test/multifile/require-layout-generic-arg-subscript.swift
@@ -1,5 +1,8 @@
-// RUN: %target-swift-frontend -module-name test -emit-ir -verify -primary-file %s %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefix=FILE1 %s
-// RUN: %target-swift-frontend -module-name test -emit-ir -verify %s -primary-file %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefix=FILE2 %s
+// RUN: %target-swift-frontend -module-name test -enable-objc-interop -emit-ir -verify -primary-file %s %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE1,FILE1-objc %s
+// RUN: %target-swift-frontend -module-name test -enable-objc-interop -emit-ir -verify %s -primary-file %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE2,FILE2-objc %s
+
+// RUN: %target-swift-frontend -module-name test -disable-objc-interop -emit-ir -verify -primary-file %s %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE1,FILE1-native %s
+// RUN: %target-swift-frontend -module-name test -disable-objc-interop -emit-ir -verify %s -primary-file %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE2,FILE2-native %s
 
 // REQUIRES: CPU=x86_64
 
@@ -9,7 +12,8 @@
 // FILE1:   [[T1:%.*]] = bitcast %T4test3SubC* %0 to %swift.type**
 // FILE1:   [[TYPEMETADATA:%.*]] = load %swift.type*, %swift.type** [[T1]]
 // FILE1:   [[T2:%.*]] = bitcast %swift.type* [[TYPEMETADATA]] to %swift.type**
-// FILE1:   [[T_IN_CLASSMETADATA:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T2]], i64 16
+// FILE1-objc:     [[T_IN_CLASSMETADATA:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T2]], i64 16
+// FILE1-native:   [[T_IN_CLASSMETADATA:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T2]], i64 13
 // FILE1:   [[T:%.*]] = load %swift.type*, %swift.type** [[T_IN_CLASSMETADATA]]
 // FILE1:   call %swift.type* @swift_getMetatypeMetadata(%swift.type* [[T]])
 public class AccessorTest {

--- a/test/multifile/require-layout-generic-arg.swift
+++ b/test/multifile/require-layout-generic-arg.swift
@@ -1,5 +1,8 @@
-// RUN: %target-swift-frontend -module-name test -emit-ir -verify -primary-file %s %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefix=FILE1 %s
-// RUN: %target-swift-frontend -module-name test -emit-ir -verify %s -primary-file %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefix=FILE2 %s
+// RUN: %target-swift-frontend -module-name test -enable-objc-interop -emit-ir -verify -primary-file %s %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE1,FILE1-objc %s
+// RUN: %target-swift-frontend -module-name test -enable-objc-interop -emit-ir -verify %s -primary-file %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE2,FILE2-objc %s
+
+// RUN: %target-swift-frontend -module-name test -disable-objc-interop -emit-ir -verify -primary-file %s %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE1,FILE1-native %s
+// RUN: %target-swift-frontend -module-name test -disable-objc-interop -emit-ir -verify %s -primary-file %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE2,FILE2-native %s
 
 // REQUIRES: CPU=x86_64
 
@@ -9,7 +12,8 @@
 // FILE1:  [[T1:%.*]] = bitcast %T4test3SubC* %0 to %swift.type**
 // FILE1:  [[TYPEMETADATA:%.*]] = load %swift.type*, %swift.type** [[T1]]
 // FILE1:  [[T2:%.*]] = bitcast %swift.type* [[TYPEMETADATA]] to %swift.type**
-// FILE1:  [[T_PTR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T2]], i64 16
+// FILE1-objc:    [[T_PTR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T2]], i64 16
+// FILE1-native:  [[T_PTR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T2]], i64 13
 // FILE1:  [[T:%.*]] = load %swift.type*, %swift.type** [[T_PTR]]
 public func requestType<T>(_ c: Sub<T>) {
   print(T.self)


### PR DESCRIPTION
Hi @rjmccall – Before I finish this draft pull request, I'd like to verify that:

1) The non-Apple ABI is still not locked down.
2) This change is reasonable.

I'll finish fixing all the broken tests if this is the case. Thanks! As a bonus, what other fields are good candidates for removal from the non-ObjC runtime?

**[EDIT]** – A related followup question for a followup PR: Should the vtable layout be more like C++? I.e. where the positive displacements are vtable slots and the negative displacements are language/runtime metadata? This would allow for better code density.