### PR TITLE
[NFC] AST: Define SubstitutionMap::getInnermostReplacementTypes

### DIFF
--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -150,6 +150,10 @@ public:
   /// generic parameters.
   ArrayRef<Type> getReplacementTypes() const;
 
+  /// Retrieve the array of replacement types for the innermost generic
+  /// parameters.
+  ArrayRef<Type> getInnermostReplacementTypes() const;
+
   /// Query whether any replacement types in the map contain archetypes.
   bool hasArchetypes() const;
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1806,7 +1806,7 @@ public:
   /// Get the direct generic arguments, which correspond to the generic
   /// arguments that are directly applied to the typealias declaration
   /// this type references.
-  SmallVector<Type, 2> getDirectGenericArgs() const;
+  ArrayRef<Type> getDirectGenericArgs() const;
 
   // Support for FoldingSet.
   void Profile(llvm::FoldingSetNodeID &id) const;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1803,13 +1803,10 @@ public:
     return *getTrailingObjects<SubstitutionMap>();
   }
 
-  /// Get the innermost generic arguments, which correspond to the generic
-  /// arguments that are directly applied to the typealias declaration in
-  /// produced by \c getDecl().
-  ///
-  /// The result can be empty, if the declaration itself is non-generic but
-  /// the parent is generic.
-  SmallVector<Type, 2> getInnermostGenericArgs() const;
+  /// Get the direct generic arguments, which correspond to the generic
+  /// arguments that are directly applied to the typealias declaration
+  /// this type references.
+  SmallVector<Type, 2> getDirectGenericArgs() const;
 
   // Support for FoldingSet.
   void Profile(llvm::FoldingSetNodeID &id) const;

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3506,7 +3506,7 @@ namespace {
       if (T->getParent())
         printRec("parent", T->getParent());
 
-      for (auto arg : T->getInnermostGenericArgs())
+      for (const auto arg : T->getDirectGenericArgs())
         printRec(arg);
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3727,7 +3727,7 @@ public:
     }
 
     printQualifiedType(T);
-    printGenericArgs(T->getInnermostGenericArgs());
+    printGenericArgs(T->getDirectGenericArgs());
   }
 
   void visitParenType(ParenType *T) {

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -97,6 +97,13 @@ ArrayRef<Type> SubstitutionMap::getReplacementTypes() const {
   return getReplacementTypesBuffer();
 }
 
+ArrayRef<Type> SubstitutionMap::getInnermostReplacementTypes() const {
+  if (empty()) return { };
+
+  return getReplacementTypes().take_back(
+      getGenericSignature()->getInnermostGenericParams().size());
+}
+
 GenericSignature SubstitutionMap::getGenericSignature() const {
   return storage ? storage->getGenericSignature() : nullptr;
 }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1385,7 +1385,7 @@ Type SugarType::getSinglyDesugaredTypeSlow() {
   return UnderlyingType;
 }
 
-SmallVector<Type, 2> TypeAliasType::getInnermostGenericArgs() const {
+SmallVector<Type, 2> TypeAliasType::getDirectGenericArgs() const {
   SmallVector<Type, 2> result;
 
   // If the typealias is not generic, there are no generic arguments

--- a/lib/AST/TypeWalker.cpp
+++ b/lib/AST/TypeWalker.cpp
@@ -39,7 +39,7 @@ class Traversal : public TypeVisitor<Traversal, bool>
     if (auto parent = ty->getParent())
       if (doIt(parent)) return true;
 
-    for (auto arg : ty->getInnermostGenericArgs())
+    for (const auto arg : ty->getDirectGenericArgs())
       if (doIt(arg))
         return true;
     


### PR DESCRIPTION
In preparation for storing substitution maps in bound generic types, centralize the logic for retrieving the innermost generic arguments in a new method on `SubstitutionMap`.

I wasn't able to find any duplication to clean up, so right now the only client is `TypeAliasType::getInnermostGenericArgs`. The idea is for the new method to ultimately have at least two clients, including a future `BoundGenericType::getInnermostGenericArgs`.
___
For #31895