### PR TITLE
[SR-12723][Sema] Validate function type param representations thick-to-thin conversions 

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1367,6 +1367,15 @@ static bool matchFunctionRepresentations(FunctionTypeRepresentation rep1,
     if (!(last && last->is<LocatorPathElt::FunctionArgument>()))
       return false;
     
+    auto isThin = [](FunctionTypeRepresentation rep) {
+      return rep == FunctionTypeRepresentation::CFunctionPointer ||
+          rep == FunctionTypeRepresentation::Thin;
+    };
+    
+    // Allowing "thin" (c, thin) to "thin" conventions
+    if (isThin(rep1) && isThin(rep2))
+      return false;
+    
     // Allowing all to "thick" (swift, block) conventions
     // "thin" (c, thin) to "thick" or "thick" to "thick"
     if (rep2 == FunctionTypeRepresentation::Swift ||

--- a/validation-test/compiler_crashers_2_fixed/sr12723.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr12723.swift
@@ -42,9 +42,8 @@ func cContext() {
 
     let _ :  (@convention(c) () -> Void) -> Void = c.function // OK
 
-    let _ :  (@convention(thin) () -> Void) -> Void = c.function 
-    // expected-error@-1 {{cannot convert value of type '(@convention(c) () -> Void) -> Void' to specified type '(@convention(thin) () -> Void) -> Void'}}
-
+    let _ :  (@convention(thin) () -> Void) -> Void = c.function // OK
+    
     let _ :  (() -> Void) -> Void = c.function 
     // expected-error@-1 {{cannot convert value of type '(@convention(c) () -> Void) -> Void' to specified type '(() -> Void) -> Void'}}
 
@@ -59,8 +58,7 @@ func thinContext() {
     let _ :  (@convention(block) () -> Void) -> Void = thin.function 
     // expected-error@-1 {{cannot convert value of type '(@convention(thin) () -> Void) -> Void' to specified type '(@convention(block) () -> Void) -> Void'}}
 
-    let _ :  (@convention(c) () -> Void) -> Void = thin.function 
-    // expected-error@-1 {{cannot convert value of type '(@convention(thin) () -> Void) -> Void' to specified type '(@convention(c) () -> Void) -> Void'}}
+    let _ :  (@convention(c) () -> Void) -> Void = thin.function // OK 
 
     let _ :  (@convention(thin) () -> Void) -> Void = thin.function // OK
 

--- a/validation-test/compiler_crashers_2_fixed/sr12723.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr12723.swift
@@ -1,0 +1,83 @@
+// RUN: %target-swift-emit-silgen %s -verify
+
+func SR12723_thin(_: (@convention(thin) () -> Void) -> Void) {}
+func SR12723_block(_: (@convention(block) () -> Void) -> Void) {}
+func SR12723_c(_: (@convention(c) () -> Void) -> Void) {}
+
+func SR12723_function(_: () -> Void) {}
+
+func context() {
+    SR12723_c(SR12723_function) 
+
+    SR12723_block(SR12723_function) 
+
+    SR12723_thin(SR12723_function) 
+}
+
+struct SR12723_C {
+    let function: (@convention(c) () -> Void) -> Void
+}
+
+struct SR12723_Thin {
+    let function: (@convention(thin) () -> Void) -> Void
+}
+
+struct SR12723_Block {
+    let function: (@convention(block) () -> Void) -> Void
+}
+
+func proxy(_ f: (() -> Void) -> Void) {
+    let a = 1
+    f { print(a) }
+}
+
+func cContext() {
+    let c = SR12723_C { app in app() }
+
+    proxy(c.function)
+    // expected-error@-1 {{cannot convert value of type '(@convention(c) () -> Void) -> Void' to expected argument type '(() -> Void) -> Void'}}
+
+    let _ :  (@convention(block) () -> Void) -> Void = c.function 
+    // expected-error@-1 {{cannot convert value of type '(@convention(c) () -> Void) -> Void' to specified type '(@convention(block) () -> Void) -> Void'}}
+
+    let _ :  (@convention(c) () -> Void) -> Void = c.function // OK
+
+    let _ :  (@convention(thin) () -> Void) -> Void = c.function 
+    // expected-error@-1 {{cannot convert value of type '(@convention(c) () -> Void) -> Void' to specified type '(@convention(thin) () -> Void) -> Void'}}
+
+    let _ :  (() -> Void) -> Void = c.function 
+    // expected-error@-1 {{cannot convert value of type '(@convention(c) () -> Void) -> Void' to specified type '(() -> Void) -> Void'}}
+
+}
+
+func thinContext() {
+    let thin = SR12723_Thin { app in app() }
+
+    proxy(thin.function) 
+    // expected-error@-1 {{cannot convert value of type '(@convention(thin) () -> Void) -> Void' to expected argument type '(() -> Void) -> Void'}}
+
+    let _ :  (@convention(block) () -> Void) -> Void = thin.function 
+    // expected-error@-1 {{cannot convert value of type '(@convention(thin) () -> Void) -> Void' to specified type '(@convention(block) () -> Void) -> Void'}}
+
+    let _ :  (@convention(c) () -> Void) -> Void = thin.function 
+    // expected-error@-1 {{cannot convert value of type '(@convention(thin) () -> Void) -> Void' to specified type '(@convention(c) () -> Void) -> Void'}}
+
+    let _ :  (@convention(thin) () -> Void) -> Void = thin.function // OK
+
+    let _ :  (() -> Void) -> Void = thin.function 
+    // expected-error@-1 {{cannot convert value of type '(@convention(thin) () -> Void) -> Void' to specified type '(() -> Void) -> Void'}}
+}
+
+func blockContext() {
+    let block = SR12723_Block { app in app() }
+
+    proxy(block.function)
+
+    let _ :  (@convention(block) () -> Void) -> Void = block.function // OK
+
+    let _ :  (@convention(c) () -> Void) -> Void = block.function // OK
+
+    let _ :  (@convention(thin) () -> Void) -> Void = block.function // OK
+
+    let _ :  (() -> Void) -> Void = block.function  // OK
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Check representations of function type parameters are valid conversions on SILGen and diagnose if they not instead of letting them hit assertions and crashing the compiler. 

cc @xedin @slavapestov :)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-12723.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
