### PR TITLE
[WIP][Sema] Don't use 'DotSyntaxCallExpr' in non-typechecked synthesized body

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4151,7 +4151,7 @@ namespace {
 static Expr *generateConstraintsFor(ConstraintSystem &cs, Expr *expr,
                                     DeclContext *DC) {
   // Remove implicit conversions from the expression.
-  expr = expr->walk(SanitizeExpr(cs));
+  // expr = expr->walk(SanitizeExpr(cs));
 
   // Walk the expression, generating constraints.
   ConstraintGenerator cg(cs, DC);

--- a/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
@@ -126,11 +126,10 @@ deriveBodyMathOperator(AbstractFunctionDecl *funcDecl, MathOperator op) {
               confRef.getConcrete()->getWitnessDecl(operatorReq))
         memberOpDecl = concreteMemberMethodDecl;
     assert(memberOpDecl && "Member operator declaration must exist");
-    auto memberOpDRE =
-        new (C) DeclRefExpr(memberOpDecl, DeclNameLoc(), /*Implicit*/ true);
     auto *memberTypeExpr = TypeExpr::createImplicit(memberType, C);
     auto memberOpExpr =
-        new (C) DotSyntaxCallExpr(memberOpDRE, SourceLoc(), memberTypeExpr);
+        new (C) MemberRefExpr(memberTypeExpr, SourceLoc(), memberOpDecl,
+                              DeclNameLoc(), /*Implicit=*/true);
 
     // Create expression `lhs.member <op> rhs.member`.
     // NOTE(TF-1054): create new `DeclRefExpr`s per loop iteration to avoid

--- a/lib/Sema/DerivedConformanceCaseIterable.cpp
+++ b/lib/Sema/DerivedConformanceCaseIterable.cpp
@@ -48,10 +48,10 @@ deriveCaseIterable_enum_getter(AbstractFunctionDecl *funcDecl, void *) {
 
   SmallVector<Expr *, 8> elExprs;
   for (EnumElementDecl *elt : parentEnum->getAllElements()) {
-    auto *ref = new (C) DeclRefExpr(elt, DeclNameLoc(), /*implicit*/true);
     auto *base = TypeExpr::createImplicit(enumTy, C);
-    auto *apply = new (C) DotSyntaxCallExpr(ref, SourceLoc(), base);
-    elExprs.push_back(apply);
+    auto *ref = new (C)
+        MemberRefExpr(base, SourceLoc(), elt, DeclNameLoc(), /*Implicit=*/true);
+    elExprs.push_back(ref);
   }
   auto *arrayExpr = ArrayExpr::create(C, SourceLoc(), elExprs, {}, SourceLoc());
 

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -284,11 +284,10 @@ deriveBodyCodingKey_init_stringValue(AbstractFunctionDecl *initDecl, void *) {
 
     auto labelItem = CaseLabelItem(litPat);
 
-    auto *eltRef = new (C) DeclRefExpr(elt, DeclNameLoc(), /*Implicit=*/true);
     auto *metaTyRef = TypeExpr::createImplicit(enumType, C);
-    auto *valueExpr = new (C) DotSyntaxCallExpr(eltRef, SourceLoc(), metaTyRef);
-
-    auto *assignment = new (C) AssignExpr(selfRef, SourceLoc(), valueExpr,
+    auto *memberRef = new (C) MemberRefExpr(metaTyRef, SourceLoc(), elt,
+                                            DeclNameLoc(), /*Implicit=*/true);
+    auto *assignment = new (C) AssignExpr(selfRef, SourceLoc(), memberRef,
                                           /*Implicit=*/true);
 
     auto *body = BraceStmt::create(C, SourceLoc(), ASTNode(assignment),

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -231,16 +231,14 @@ deriveBodyDifferentiable_method(AbstractFunctionDecl *funcDecl,
     if (confRef.isConcrete())
       memberMethodDecl = confRef.getConcrete()->getWitnessDecl(methodReq);
     assert(memberMethodDecl && "Member method declaration must exist");
-    auto *memberMethodDRE =
-        new (C) DeclRefExpr(memberMethodDecl, DeclNameLoc(), /*Implicit*/ true);
-    memberMethodDRE->setFunctionRefKind(FunctionRefKind::SingleApply);
 
     // Create reference to member method: `x.move(along:)`.
     Expr *memberExpr =
         new (C) MemberRefExpr(selfDRE, SourceLoc(), member, DeclNameLoc(),
                               /*Implicit*/ true);
     auto *memberMethodExpr =
-        new (C) DotSyntaxCallExpr(memberMethodDRE, SourceLoc(), memberExpr);
+        new (C) MemberRefExpr(memberExpr, SourceLoc(), memberMethodDecl,
+                              DeclNameLoc(), /*Implicit=*/true);
 
     // Create reference to parameter member: `direction.x`.
     VarDecl *paramMember = nullptr;

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -386,19 +386,15 @@ deriveBodyEquatable_struct_eq(AbstractFunctionDecl *eqDecl, void *) {
     if (!propertyDecl->isUserAccessible())
       continue;
 
-    auto aPropertyRef = new (C) DeclRefExpr(propertyDecl, DeclNameLoc(),
-                                            /*implicit*/ true);
     auto aParamRef = new (C) DeclRefExpr(aParam, DeclNameLoc(),
                                          /*implicit*/ true);
-    auto aPropertyExpr = new (C) DotSyntaxCallExpr(aPropertyRef, SourceLoc(),
-                                                   aParamRef);
+    auto aPropertyExpr = new (C) MemberRefExpr(
+        aParamRef, SourceLoc(), propertyDecl, DeclNameLoc(), /*Implicit=*/true);
 
-    auto bPropertyRef = new (C) DeclRefExpr(propertyDecl, DeclNameLoc(),
-                                            /*implicit*/ true);
     auto bParamRef = new (C) DeclRefExpr(bParam, DeclNameLoc(),
                                          /*implicit*/ true);
-    auto bPropertyExpr = new (C) DotSyntaxCallExpr(bPropertyRef, SourceLoc(),
-                                                   bParamRef);
+    auto bPropertyExpr = new (C) MemberRefExpr(
+        bParamRef, SourceLoc(), propertyDecl, DeclNameLoc(), /*Implicit=*/true);
 
     auto guardStmt = DerivedConformance::returnFalseIfNotEqualGuard(C,
       aPropertyExpr, bPropertyExpr);
@@ -874,12 +870,11 @@ deriveBodyHashable_struct_hashInto(AbstractFunctionDecl *hashIntoDecl, void *) {
     if (!propertyDecl->isUserAccessible())
       continue;
 
-    auto propertyRef = new (C) DeclRefExpr(propertyDecl, DeclNameLoc(),
-                                           /*implicit*/ true);
     auto selfRef = new (C) DeclRefExpr(selfDecl, DeclNameLoc(),
-                                       /*implicit*/ true);
-    auto selfPropertyExpr = new (C) DotSyntaxCallExpr(propertyRef, SourceLoc(),
-                                                      selfRef);
+                                       /*Implicit=*/true);
+    auto selfPropertyExpr = new (C) MemberRefExpr(
+        selfRef, SourceLoc(), propertyDecl, DeclNameLoc(), /*Implicit=*/true);
+
     // Generate: hasher.combine(self.<property>)
     auto combineExpr = createHasherCombineCall(C, hasherParam, selfPropertyExpr);
     statements.emplace_back(ASTNode(combineExpr));

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -332,15 +332,15 @@ deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl, void *) {
     // Create a statement which assigns the case to self.
 
     // valueExpr = "\(enumType).\(elt)"
-    auto eltRef = new (C) DeclRefExpr(elt, DeclNameLoc(), /*implicit*/true);
     auto metaTyRef = TypeExpr::createImplicit(enumType, C);
-    auto valueExpr = new (C) DotSyntaxCallExpr(eltRef, SourceLoc(), metaTyRef);
-    
+    auto memberRef = new (C) MemberRefExpr(metaTyRef, SourceLoc(), elt,
+                                           DeclNameLoc(), /*Implicit=*/true);
+
     // assignment = "self = \(valueExpr)"
     auto selfRef = new (C) DeclRefExpr(selfDecl, DeclNameLoc(),
                                        /*implicit*/true,
                                        AccessSemantics::DirectToStorage);
-    auto assignment = new (C) AssignExpr(selfRef, SourceLoc(), valueExpr,
+    auto assignment = new (C) AssignExpr(selfRef, SourceLoc(), memberRef,
                                          /*implicit*/ true);
 
     stmts.push_back(ASTNode(assignment));


### PR DESCRIPTION
`DotSyntaxCallExpr` is supposed to be only used in typechecked AST.
Use `MemberRefExpr` instead.

(This is a groundwork for removing `SanitizeExpr` from CSGen).