### PR TITLE
[TBDGen] Fix symbol mismatch for enum case constructors

### DIFF
--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -233,7 +233,7 @@ SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
 
   // Native function-local declarations have shared linkage.
   // FIXME: @objc declarations should be too, but we currently have no way
-  // of marking them "used" other than making them external. 
+  // of marking them "used" other than making them external.
   ValueDecl *d = getDecl();
   DeclContext *moduleContext = d->getDeclContext();
   while (!moduleContext->isModuleScopeContext()) {
@@ -333,6 +333,10 @@ SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
     if (fn->hasForcedStaticDispatch()) {
       limit = Limit::OnDemand;
     }
+  }
+
+  if (isEnumElement()) {
+    limit = Limit::OnDemand;
   }
 
   auto effectiveAccess = d->getEffectiveAccess();

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -498,7 +498,8 @@ void TBDGenVisitor::addConformances(const IterableDeclContext *IDC) {
             addSymbolIfNecessary(reqtAccessor, witnessAccessor);
           });
         } else if (isa<EnumElementDecl>(witnessDecl)) {
-          addSymbolIfNecessary(valueReq, witnessDecl);
+          auto getter = storage->getSynthesizedAccessor(AccessorKind::Get);
+          addSymbolIfNecessary(getter, witnessDecl);
         }
       }
     });
@@ -1018,13 +1019,12 @@ void TBDGenVisitor::visitProtocolDecl(ProtocolDecl *PD) {
 
 void TBDGenVisitor::visitEnumDecl(EnumDecl *ED) {
   visitNominalTypeDecl(ED);
-
-  if (!ED->isResilient())
-    return;
 }
 
 void TBDGenVisitor::visitEnumElementDecl(EnumElementDecl *EED) {
-  addSymbol(LinkEntity::forEnumCase(EED));
+  if (EED->getParentEnum()->isResilient())
+    addSymbol(LinkEntity::forEnumCase(EED));
+
   if (auto *PL = EED->getParameterList())
     visitDefaultArguments(EED, PL);
 }

--- a/test/SILGen/protocol_enum_witness.swift
+++ b/test/SILGen/protocol_enum_witness.swift
@@ -26,7 +26,7 @@ enum AnotherBar: AnotherFoo {
 // CHECK-NEXT: return [[TUPLE]] : $()
 // CHECK-END: }
 
-// CHECK-LABEL: sil hidden [transparent] [ossa] @$s21protocol_enum_witness3BarO6buttonyA2CmF : $@convention(method) (@thin Bar.Type) -> Bar {
+// CHECK-LABEL: sil shared [transparent] [ossa] @$s21protocol_enum_witness3BarO6buttonyA2CmF : $@convention(method) (@thin Bar.Type) -> Bar {
 // CHECK: bb0({{%.*}} : $@thin Bar.Type):
 // CHECK-NEXT: [[CASE:%.*]] = enum $Bar, #Bar.button!enumelt
 // CHECK-NEXT: return [[CASE]] : $Bar

--- a/test/TBD/enum_case_protocol_witness.swift
+++ b/test/TBD/enum_case_protocol_witness.swift
@@ -1,0 +1,23 @@
+// REQUIRES: VENDOR=apple
+// RUN: %target-swift-frontend -emit-ir -enable-testing -o/dev/null -module-name test -validate-tbd-against-ir=all %s
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -module-name test -validate-tbd-against-ir=all %s
+
+protocol ProtoInternal {
+  static var bar1: Self { get }
+  static func bar2(arg: Int) -> Self
+}
+
+enum EnumInternal: ProtoInternal {
+  case bar1
+  case bar2(arg: Int)
+}
+
+public protocol ProtoPublic {
+  static var bar3: Self { get }
+  static func bar4(arg: Int) -> Self
+}
+
+public enum EnumPublic: ProtoPublic {
+  case bar3
+  case bar4(arg: Int)
+}


### PR DESCRIPTION
For the following code:

```swift
protocol P {
  static var bar1: Self { get }
  static func bar2(arg: Int) -> Self
}

enum E: P {
  case bar1
  case bar2(arg: Int)
}
```

TBDGen validation fails with an error: `symbol '<case constructor symbol here>' is in generated IR file, but not in TBD file` when we pass the `-enable-testing` flag. It seems like it's looking for the enum case constructor symbols, which are not present when testing is enabled.

Resolves SR-12821
Resolves rdar://problem/63364542