### PR TITLE
[silgen] Rename DelegateInitSelfWritebackCleanup -> OwnedValueWritebackCleanup.

### DIFF
--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -121,6 +121,13 @@ public:
     return ManagedValue::forOwnedObjectRValue(value, cleanup);
   }
 
+  static ManagedValue
+  forExclusivelyBorrowedOwnedObjectRValue(SILValue value,
+                                          CleanupHandle cleanup) {
+    assert(value->getType().isObject());
+    return ManagedValue::forOwnedObjectRValue(value, cleanup);
+  }
+
   /// Create a managed value for a +0 borrowed non-trivial rvalue object.
   static ManagedValue
   forBorrowedObjectRValue(SILValue value) {

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1243,7 +1243,7 @@ public:
       if (superMV.getValue() != SGF.InitDelegationSelf.getValue()) {
         SILValue underlyingSelf = SGF.InitDelegationSelf.getValue();
         SGF.InitDelegationSelf = ManagedValue::forUnmanaged(underlyingSelf);
-        CleanupHandle newWriteback = SGF.enterDelegateInitSelfWritebackCleanup(
+        CleanupHandle newWriteback = SGF.enterOwnedValueWritebackCleanup(
             SGF.InitDelegationLoc.getValue(), SGF.InitDelegationSelfBox,
             superMV.forward(SGF));
         SGF.SuperInitDelegationSelf =

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1188,9 +1188,9 @@ public:
   CleanupHandle enterDeallocateUninitializedArrayCleanup(SILValue array);
   void emitUninitializedArrayDeallocation(SILLocation loc, SILValue array);
 
-  CleanupHandle enterDelegateInitSelfWritebackCleanup(SILLocation loc,
-                                                      SILValue address,
-                                                      SILValue newValue);
+  CleanupHandle enterOwnedValueWritebackCleanup(SILLocation loc,
+                                                SILValue address,
+                                                SILValue newValue);
 
   SILValue emitConversionToSemanticRValue(SILLocation loc, SILValue value,
                                           const TypeLowering &valueTL);


### PR DESCRIPTION
This cleanup is meant to be used with a value that is temporarily taken from a
memory location for a lexical scope. At end of scope, the value is returned back
to the original memory location.

It is used to implement in SILGen "move only loadable values". Note, a "move
only loadable value" is not a "move only type". It is just an abstraction for
working with a single copy of a loadable value as if that single copy was a move
only value.

This is currently only being used in initializer emission since we treat self in
such a context as a "move only value" before we delegate to a
super/convenience/peer initializer since we have to allow for such initializers
to change the underlying class we have stored which in certain use cases require
self to be guaranteed as /never/ being retained. The move only value
representation makes this easy to do/enforce.

My hope is that by changing the name of this cleanup it is more obvious what it
is meant to do and can become (hopefully) generally useful.

Part of: <rdar://problem/59830255>