### PR TITLE
SILGen: Extend scope for evaluation in memberwise initializers to include initializer expressions

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -252,6 +252,8 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
         selfTy.getFieldType(field, SGF.SGM.M, SGF.getTypeExpansionContext());
     RValue value;
 
+    FullExpr scope(SGF.Cleanups, field->getParentPatternBinding());
+
     // If it's memberwise initialized, do so now.
     if (field->isMemberwiseInitialized(/*preferDeclaredProperties=*/false)) {
       assert(elti != eltEnd && "number of args does not match number of fields");
@@ -276,7 +278,6 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
     }
 
     // Cleanup after this initialization.
-    FullExpr scope(SGF.Cleanups, field->getParentPatternBinding());
     SILValue v = maybeEmitPropertyWrapperInitFromValue(SGF, Loc, field, subs,
                                                        std::move(value))
         .forwardAsSingleStorageValue(SGF, fieldTy, Loc);

--- a/test/SILGen/memberwise_init_temporary_allocations.swift
+++ b/test/SILGen/memberwise_init_temporary_allocations.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-emit-silgen -verify %s
+
+protocol P { var x: Int { get } }
+
+extension Int: P { var x: Int { return self } }
+
+// rdar://problem/63187509: Evaluating the variable initializer for `px`
+// requires allocating a temporary stack slot for the address only value of
+// `Butt.p`. Ensure that this gets cleaned up appropriately (which is asserted
+// by the SIL verifier).
+struct Butt {
+    static var p: P = 0
+
+    let px = Butt.p.x
+
+    let y: Int
+}
+


### PR DESCRIPTION
Catch any cleanups that get emitted while evaluating the initializer expression for a property.
Fixes rdar://problem/63187509.