### PR TITLE
[5.3][ASTPrinter] Don't print inferred opaque result type witness

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3519,24 +3519,28 @@ static Type getMemberForBaseType(LookupConformanceFn lookupConformances,
 
     // Retrieve the type witness.
     auto witness =
-        conformance.getConcrete()->getTypeWitness(assocType, options);
-    if (!witness || witness->hasError())
+        conformance.getConcrete()->getTypeWitnessAndDecl(assocType, options);
+
+    auto witnessTy = witness.getWitnessType();
+    if (!witnessTy || witnessTy->hasError())
       return failed();
 
     // This is a hacky feature allowing code completion to migrate to
     // using Type::subst() without changing output.
     if (options & SubstFlags::DesugarMemberTypes) {
-      if (auto *aliasType =
-                   dyn_cast<TypeAliasType>(witness.getPointer())) {
-        if (!aliasType->is<ErrorType>())
-          witness = aliasType->getSinglyDesugaredType();
-      }
+      if (auto *aliasType = dyn_cast<TypeAliasType>(witnessTy.getPointer()))
+        witnessTy = aliasType->getSinglyDesugaredType();
+
+      // Another hack. If the type witness is a opaque result type. They can
+      // only be referred using the name of the associated type.
+      if (witnessTy->is<OpaqueTypeArchetypeType>())
+        witnessTy = witness.getWitnessDecl()->getDeclaredInterfaceType();
     }
 
-    if (witness->is<ErrorType>())
+    if (witnessTy->is<ErrorType>())
       return failed();
 
-    return witness;
+    return witnessTy;
   }
 
   return failed();

--- a/test/SourceKit/CursorInfo/cursor_opaque_result.swift
+++ b/test/SourceKit/CursorInfo/cursor_opaque_result.swift
@@ -1,0 +1,35 @@
+public protocol P {
+  associatedtype Assoc
+  func foo() -> Assoc
+}
+extension P {
+  func bar() -> Assoc { fatalError() }
+}
+
+public struct MyStruct: P {
+  public func foo() -> some Comparable { 1 }
+}
+func test(value: MyStruct) {
+  value.foo()
+  value.bar()
+}
+
+// RUN: %sourcekitd-test -req=cursor -pos=13:9 %s -- %s -module-name MyModule | %FileCheck --check-prefix=OPAQUE %s
+// RUN: %sourcekitd-test -req=cursor -pos=14:9 %s -- %s -module-name MyModule | %FileCheck --check-prefix=ASSOC %s
+
+// OPAQUE: foo()
+// OPAQUE-NEXT: s:8MyModule0A6StructV3fooQryF
+// OPAQUE-NEXT: (MyStruct) -> () -> some Comparable
+// OPAQUE-NEXT: $sQrycD
+// OPAQUE-NEXT: <Container>$s8MyModule0A6StructVD</Container>
+// OPAQUE-NEXT: <Declaration>public func foo() -&gt; some <Type usr="s:SL">Comparable</Type></Declaration>
+// OPAQUE-NEXT: <decl.function.method.instance><syntaxtype.keyword>public</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>() -&gt; <decl.function.returntype><syntaxtype.keyword>some</syntaxtype.keyword> <ref.protocol usr="s:SL">Comparable</ref.protocol></decl.function.returntype></decl.function.method.instance>
+
+
+// ASSOC: bar()
+// ASSOC-NEXT: s:8MyModule1PPAAE3bar5AssocQzyF
+// ASSOC-NEXT: <Self where Self : P> (Self) -> () -> Self.Assoc
+// ASSOC-NEXT: $s5AssocQzycD
+// ASSOC-NEXT: <Container>$s8MyModule0A6StructVD</Container>
+// ASSOC-NEXT: <Declaration>func bar() -&gt; <Type usr="s:8MyModule0A6StructV5Assoca">Assoc</Type></Declaration>
+// ASSOC-NEXT: <decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>bar</decl.name>() -&gt; <decl.function.returntype><ref.typealias usr="s:8MyModule0A6StructV5Assoca">Assoc</ref.typealias></decl.function.returntype></decl.function.method.instance>


### PR DESCRIPTION
Cherry-pick of #31821 into. `release/5.3`

* **Explanation**:  Opaque result type syntax is not usable except at the declaration itself. In other places, users need to let them inferred. Or, if they are used as associated types, they can only be referred by the name of the associated types. In `substType()`, if a type witness is found to be a opaque result type, use the interface type of the witness decl which is a implicit typealias decl/type so that opaque result types don't appear in function parameter position etc.
* **Scope**: AST type printing including code completion and cursor info.
* **Risk**: Low. This only affects type printing. Doesn't affect compilation or typechecking.
* **Issue**: rdar://problem/59817674, rdar://problem/62232092
* **Testing**: Added regression test cases
* **Reviewer**: Ben Langmuir (@benlangmuir)