### PR TITLE
GSB: Concretize nested types when adding a superclass constraint

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2542,7 +2542,13 @@ static void concretizeNestedTypeFromConcreteParent(
     GenericSignatureBuilder &builder) {
   auto parentEquiv = parent->getEquivalenceClassIfPresent();
   assert(parentEquiv && "can't have a concrete type without an equiv class");
+
+  bool isSuperclassConstrained = false;
   auto concreteParent = parentEquiv->concreteType;
+  if (!concreteParent) {
+    isSuperclassConstrained = true;
+    concreteParent = parentEquiv->superclass;
+  }
   assert(concreteParent &&
          "attempting to resolve concrete nested type of non-concrete PA");
 
@@ -2564,8 +2570,14 @@ static void concretizeNestedTypeFromConcreteParent(
          "No conformance requirement");
   const RequirementSource *parentConcreteSource = nullptr;
   for (const auto &constraint : parentEquiv->conformsTo.find(proto)->second) {
-    if (constraint.source->kind == RequirementSource::Concrete) {
-      parentConcreteSource = constraint.source;
+    if (!isSuperclassConstrained) {
+      if (constraint.source->kind == RequirementSource::Concrete) {
+        parentConcreteSource = constraint.source;
+      }
+    } else {
+      if (constraint.source->kind == RequirementSource::Superclass) {
+        parentConcreteSource = constraint.source;
+      }
     }
   }
 
@@ -4298,6 +4310,15 @@ bool GenericSignatureBuilder::updateSuperclass(
   auto updateSuperclassConformances = [&] {
     for (const auto &conforms : equivClass->conformsTo) {
       (void)resolveSuperConformance(type, conforms.first);
+    }
+
+    // Eagerly resolve any existing nested types to their concrete forms (others
+    // will be "concretized" as they are constructed, in getNestedType).
+    for (auto equivT : equivClass->members) {
+      for (auto nested : equivT->getNestedTypes()) {
+        concretizeNestedTypeFromConcreteParent(equivT, nested.second.front(),
+                                               *this);
+      }
     }
   };
 
@@ -7186,6 +7207,12 @@ void GenericSignatureBuilder::dump(llvm::raw_ostream &out) {
   out << "Potential archetypes:\n";
   for (auto pa : Impl->PotentialArchetypes) {
     pa->dump(out, &Context.SourceMgr, 2);
+  }
+  out << "\n";
+
+  out << "Equivalence classes:\n";
+  for (auto &equiv : Impl->EquivalenceClasses) {
+    equiv.dump(out, this);
   }
   out << "\n";
 }

--- a/test/Generics/superclass_constraint_nested_type.swift
+++ b/test/Generics/superclass_constraint_nested_type.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift
+
+// rdar://problem/39481178 - Introducing a superclass constraint does not add
+// same-type constraints on nested types
+
+protocol P {
+  associatedtype Q
+}
+
+class C : P {
+  typealias Q = Int
+}
+
+// Use the "generic parameter cannot be concrete" check as a proxy for the
+// same-type constraint 'T == C.Q (aka Int)' having been inferred:
+
+extension P {
+  func f1<T>(_: T) where T == Q, Self : C {}
+  // expected-error@-1 {{same-type requirement makes generic parameter 'T' non-generic}}
+
+  func f2<T>(_: T) where Self : C, T == Q {}
+  // expected-error@-1 {{same-type requirement makes generic parameter 'T' non-generic}}
+}

--- a/validation-test/compiler_crashers_2_fixed/sr11232.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11232.swift
@@ -1,6 +1,4 @@
-// RUN: not --crash %target-swift-emit-silgen %s
-
-// REQUIRES: asserts
+// RUN: not %target-swift-emit-silgen %s
 
 protocol Pub {
   associatedtype Other


### PR DESCRIPTION
When adding a superclass constraint, we need to find any nested
types belonging to protocols that the superclass conforms to,
and introduce implicit same-type constraints between each nested
type and the corresponding type witness in the superclass's
conformance to that protocol.

Fixes <rdar://problem/39481178>, https://bugs.swift.org/browse/SR-11232.