### PR TITLE
GSB: Concretize nested types when adding a superclass constraint [5.3]

### DIFF
--- a/test/Generics/superclass_constraint_nested_type.swift
+++ b/test/Generics/superclass_constraint_nested_type.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift
+
+// rdar://problem/39481178 - Introducing a superclass constraint does not add
+// same-type constraints on nested types
+
+protocol P {
+  associatedtype Q
+}
+
+class C : P {
+  typealias Q = Int
+}
+
+// Use the "generic parameter cannot be concrete" check as a proxy for the
+// same-type constraint 'T == C.Q (aka Int)' having been inferred:
+
+extension P {
+  func f1<T>(_: T) where T == Q, Self : C {}
+  // expected-error@-1 {{same-type requirement makes generic parameter 'T' non-generic}}
+
+  func f2<T>(_: T) where Self : C, T == Q {}
+  // expected-error@-1 {{same-type requirement makes generic parameter 'T' non-generic}}
+}

--- a/validation-test/compiler_crashers_2_fixed/sr11232.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11232.swift
@@ -1,6 +1,4 @@
-// RUN: not --crash %target-swift-emit-silgen %s
-
-// REQUIRES: asserts
+// RUN: not %target-swift-emit-silgen %s
 
 protocol Pub {
   associatedtype Other


### PR DESCRIPTION
When adding a superclass constraint, we need to find any nested
types belonging to protocols that the superclass conforms to,
and introduce implicit same-type constraints between each nested
type and the corresponding type witness in the superclass's
conformance to that protocol.

Fixes <rdar://problem/39481178>, <https://bugs.swift.org/browse/SR-11232>.