### PR TITLE
Naive Dependency Replay

### DIFF
--- a/include/swift/AST/AnyRequest.h
+++ b/include/swift/AST/AnyRequest.h
@@ -66,6 +66,9 @@ struct AnyRequestVTable {
     static SourceLoc getNearestLoc(const void *ptr) {
       return static_cast<const Request *>(ptr)->getNearestLoc();
     }
+    static bool isCached(const void *ptr) {
+      return static_cast<const Request *>(ptr)->isCached();
+    }
   };
 
   const uint64_t typeID;
@@ -78,8 +81,10 @@ struct AnyRequestVTable {
   const std::function<void(const void *, DiagnosticEngine &)> diagnoseCycle;
   const std::function<void(const void *, DiagnosticEngine &)> noteCycleStep;
   const std::function<SourceLoc(const void *)> getNearestLoc;
+  const std::function<bool(const void *)> isCached;
 
-  template <typename Request>
+  template <typename Request,
+            typename std::enable_if<Request::isEverCached>::type * = nullptr>
   static const AnyRequestVTable *get() {
     static const AnyRequestVTable vtable = {
         TypeID<Request>::value,
@@ -92,6 +97,26 @@ struct AnyRequestVTable {
         &Impl<Request>::diagnoseCycle,
         &Impl<Request>::noteCycleStep,
         &Impl<Request>::getNearestLoc,
+        &Impl<Request>::isCached,
+    };
+    return &vtable;
+  }
+
+  template <typename Request,
+            typename std::enable_if<!Request::isEverCached>::type * = nullptr>
+  static const AnyRequestVTable *get() {
+    static const AnyRequestVTable vtable = {
+        TypeID<Request>::value,
+        sizeof(Request),
+        &Impl<Request>::copy,
+        &Impl<Request>::getHash,
+        &Impl<Request>::deleter,
+        &Impl<Request>::isEqual,
+        &Impl<Request>::simpleDisplay,
+        &Impl<Request>::diagnoseCycle,
+        &Impl<Request>::noteCycleStep,
+        &Impl<Request>::getNearestLoc,
+        [](auto){ return false; },
     };
     return &vtable;
   }
@@ -192,6 +217,10 @@ public:
   /// Retrieve the nearest source location to which this request applies.
   SourceLoc getNearestLoc() const {
     return getVTable()->getNearestLoc(getRawStorage());
+  }
+
+  bool isCached() const {
+    return getVTable()->isCached(getRawStorage());
   }
 
   /// Compare two instances for equality.

--- a/include/swift/AST/IRGenRequests.h
+++ b/include/swift/AST/IRGenRequests.h
@@ -200,7 +200,7 @@ public:
 public:
   // Incremental dependencies.
   evaluator::DependencySource
-  readDependencySource(const evaluator::DependencyCollector &) const;
+  readDependencySource(const evaluator::DependencyRecorder &) const;
 };
 
 class IRGenWholeModuleRequest

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -189,7 +189,7 @@ public:
 public:
   // Incremental dependencies
   evaluator::DependencySource
-  readDependencySource(const evaluator::DependencyCollector &e) const;
+  readDependencySource(const evaluator::DependencyRecorder &e) const;
   void writeDependencySink(evaluator::DependencyCollector &tracker,
                            ArrayRef<ProtocolDecl *> result) const;
 };
@@ -330,7 +330,7 @@ public:
 public:
   // Incremental dependencies.
   evaluator::DependencySource
-  readDependencySource(const evaluator::DependencyCollector &) const;
+  readDependencySource(const evaluator::DependencyRecorder &) const;
 };
 
 class GenericParamListRequest :
@@ -434,7 +434,7 @@ private:
 public:
   // Incremental dependencies
   evaluator::DependencySource
-  readDependencySource(const evaluator::DependencyCollector &) const;
+  readDependencySource(const evaluator::DependencyRecorder &) const;
   void writeDependencySink(evaluator::DependencyCollector &tracker,
                            LookupResult res) const;
 };
@@ -506,7 +506,7 @@ private:
 public:
   // Incremental dependencies
   evaluator::DependencySource
-  readDependencySource(const evaluator::DependencyCollector &) const;
+  readDependencySource(const evaluator::DependencyRecorder &) const;
   void writeDependencySink(evaluator::DependencyCollector &tracker,
                            QualifiedLookupResult lookupResult) const;
 };
@@ -533,7 +533,7 @@ private:
 public:
   // Incremental dependencies.
   evaluator::DependencySource
-  readDependencySource(const evaluator::DependencyCollector &) const;
+  readDependencySource(const evaluator::DependencyRecorder &) const;
 };
 
 /// The input type for a direct lookup request.

--- a/include/swift/AST/ParseRequests.h
+++ b/include/swift/AST/ParseRequests.h
@@ -103,7 +103,7 @@ public:
 
 public:
   evaluator::DependencySource
-  readDependencySource(const evaluator::DependencyCollector &) const;
+  readDependencySource(const evaluator::DependencyRecorder &) const;
 };
 
 void simple_display(llvm::raw_ostream &out,
@@ -125,7 +125,7 @@ private:
 
 public:
   evaluator::DependencySource
-  readDependencySource(const evaluator::DependencyCollector &) const;
+  readDependencySource(const evaluator::DependencyRecorder &) const;
 };
 
 /// The zone number for the parser.

--- a/include/swift/AST/SILGenRequests.h
+++ b/include/swift/AST/SILGenRequests.h
@@ -104,7 +104,7 @@ private:
 public:
   // Incremental dependencies.
   evaluator::DependencySource
-  readDependencySource(const evaluator::DependencyCollector &) const;
+  readDependencySource(const evaluator::DependencyRecorder &) const;
 };
 
 /// Parses a .sil file into a SILModule.

--- a/include/swift/AST/SimpleRequest.h
+++ b/include/swift/AST/SimpleRequest.h
@@ -232,7 +232,7 @@ SourceLoc extractNearestSourceLoc(const std::tuple<First, Rest...> &value) {
 /// the 3 caching kinds defined above.
 /// \code
 ///   evaluator::DependencySource
-///   readDependencySource(const evaluator::DependencyCollector &) const;
+///   readDependencySource(const evaluator::DependencyRecorder &) const;
 /// \endcode
 ///
 /// Requests that define dependency sinks should instead override

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -123,7 +123,7 @@ public:
 public:
   // Incremental dependencies
   evaluator::DependencySource
-  readDependencySource(const evaluator::DependencyCollector &e) const;
+  readDependencySource(const evaluator::DependencyRecorder &e) const;
   void writeDependencySink(evaluator::DependencyCollector &tracker,
                            Type t) const;
 };
@@ -893,7 +893,7 @@ public:
 public:
   // Incremental dependencies.
   evaluator::DependencySource
-  readDependencySource(const evaluator::DependencyCollector &) const;
+  readDependencySource(const evaluator::DependencyRecorder &) const;
 };
 
 /// Request to obtain a list of stored properties in a nominal type.
@@ -2034,7 +2034,7 @@ public:
 public:
   // Incremental dependencies.
   evaluator::DependencySource
-  readDependencySource(const evaluator::DependencyCollector &) const;
+  readDependencySource(const evaluator::DependencyRecorder &) const;
 };
 
 /// Computes whether the specified type or a super-class/super-protocol has the
@@ -2277,7 +2277,7 @@ private:
 public:
   // Incremental dependencies
   evaluator::DependencySource
-  readDependencySource(const evaluator::DependencyCollector &eval) const;
+  readDependencySource(const evaluator::DependencyRecorder &eval) const;
   void writeDependencySink(evaluator::DependencyCollector &tracker,
                            ProtocolConformanceLookupResult r) const;
 };
@@ -2305,7 +2305,7 @@ public:
 
 public:
   evaluator::DependencySource
-  readDependencySource(const evaluator::DependencyCollector &eval) const;
+  readDependencySource(const evaluator::DependencyRecorder &eval) const;
   void writeDependencySink(evaluator::DependencyCollector &tracker,
                            evaluator::SideEffect) const;
 };

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -89,7 +89,7 @@ void InheritedProtocolsRequest::cacheResult(ArrayRef<ProtocolDecl *> PDs) const 
 }
 
 evaluator::DependencySource InheritedProtocolsRequest::readDependencySource(
-    const evaluator::DependencyCollector &e) const {
+    const evaluator::DependencyRecorder &e) const {
   auto *PD = std::get<0>(getStorage());
   // Ignore context changes for protocols outside our module. This
   // prevents transitive cascading edges when e.g. our private
@@ -184,7 +184,7 @@ void ExtendedNominalRequest::writeDependencySink(
   auto *SF = std::get<0>(getStorage())->getParentSourceFile();
   if (!SF)
     return;
-  if (SF != tracker.getActiveDependencySourceOrNull())
+  if (SF != tracker.getRecorder().getActiveDependencySourceOrNull())
     return;
   tracker.addPotentialMember(value);
 }
@@ -208,7 +208,7 @@ void GetDestructorRequest::cacheResult(DestructorDecl *value) const {
 }
 
 evaluator::DependencySource GetDestructorRequest::readDependencySource(
-    const evaluator::DependencyCollector &eval) const {
+    const evaluator::DependencyRecorder &eval) const {
   // Looking up the deinitializer currently always occurs in a private
   // scope because it is impossible to reference 'deinit' in user code, and a
   // valid 'deinit' declaration cannot occur outside of the
@@ -338,7 +338,7 @@ swift::extractNearestSourceLoc(const LookupConformanceDescriptor &desc) {
 //----------------------------------------------------------------------------//
 
 evaluator::DependencySource ModuleQualifiedLookupRequest::readDependencySource(
-    const evaluator::DependencyCollector &eval) const {
+    const evaluator::DependencyRecorder &eval) const {
   auto *DC = std::get<0>(getStorage());
   auto options = std::get<3>(getStorage());
 
@@ -385,7 +385,7 @@ void LookupConformanceInModuleRequest::writeDependencySink(
   if (!Adoptee)
     return;
 
-  auto *source = reqTracker.getActiveDependencySourceOrNull();
+  auto *source = reqTracker.getRecorder().getActiveDependencySourceOrNull();
   if (!source)
     return;
 
@@ -402,7 +402,7 @@ void LookupConformanceInModuleRequest::writeDependencySink(
 //----------------------------------------------------------------------------//
 
 evaluator::DependencySource UnqualifiedLookupRequest::readDependencySource(
-    const evaluator::DependencyCollector &) const {
+    const evaluator::DependencyRecorder &) const {
   auto &desc = std::get<0>(getStorage());
   // FIXME(Evaluator Incremental Dependencies): This maintains compatibility
   // with the existing scheme, but the existing scheme is totally ad-hoc. We
@@ -426,7 +426,7 @@ void UnqualifiedLookupRequest::writeDependencySink(
 //----------------------------------------------------------------------------//
 
 evaluator::DependencySource QualifiedLookupRequest::readDependencySource(
-    const evaluator::DependencyCollector &) const {
+    const evaluator::DependencyRecorder &) const {
   auto *dc = std::get<0>(getStorage());
   auto opts = std::get<3>(getStorage());
   // FIXME(Evaluator Incremental Dependencies): This is an artifact of the

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -158,7 +158,7 @@ void SuperclassTypeRequest::cacheResult(Type value) const {
 }
 
 evaluator::DependencySource SuperclassTypeRequest::readDependencySource(
-    const evaluator::DependencyCollector &e) const {
+    const evaluator::DependencyRecorder &e) const {
   const auto access = std::get<0>(getStorage())->getFormalAccess();
   return {
     e.getActiveDependencySourceOrNull(),
@@ -1349,7 +1349,7 @@ void CheckRedeclarationRequest::cacheResult(evaluator::SideEffect) const {
 }
 
 evaluator::DependencySource CheckRedeclarationRequest::readDependencySource(
-    const evaluator::DependencyCollector &eval) const {
+    const evaluator::DependencyRecorder &eval) const {
   auto *current = std::get<0>(getStorage());
   auto *currentDC = current->getDeclContext();
   return {
@@ -1384,7 +1384,7 @@ void CheckRedeclarationRequest::writeDependencySink(
 
 evaluator::DependencySource
 LookupAllConformancesInContextRequest::readDependencySource(
-    const evaluator::DependencyCollector &collector) const {
+    const evaluator::DependencyRecorder &collector) const {
   const auto *nominal = std::get<0>(getStorage())
                             ->getAsGenericContext()
                             ->getSelfNominalTypeDecl();
@@ -1427,7 +1427,7 @@ void ResolveTypeEraserTypeRequest::cacheResult(Type value) const {
 //----------------------------------------------------------------------------//
 
 evaluator::DependencySource TypeCheckSourceFileRequest::readDependencySource(
-    const evaluator::DependencyCollector &e) const {
+    const evaluator::DependencyRecorder &e) const {
   return {std::get<0>(getStorage()), evaluator::DependencyScope::Cascading};
 }
 
@@ -1460,7 +1460,7 @@ void TypeCheckSourceFileRequest::cacheResult(evaluator::SideEffect) const {
 
 evaluator::DependencySource
 TypeCheckFunctionBodyUntilRequest::readDependencySource(
-    const evaluator::DependencyCollector &e) const {
+    const evaluator::DependencyRecorder &e) const {
   // We're going under a function body scope, unconditionally flip the scope
   // to private.
   return {

--- a/lib/IRGen/IRGenRequests.cpp
+++ b/lib/IRGen/IRGenRequests.cpp
@@ -53,7 +53,7 @@ SourceLoc swift::extractNearestSourceLoc(const IRGenDescriptor &desc) {
 }
 
 evaluator::DependencySource IRGenSourceFileRequest::readDependencySource(
-    const evaluator::DependencyCollector &e) const {
+    const evaluator::DependencyRecorder &e) const {
   auto &desc = std::get<0>(getStorage());
   return {
     desc.Ctx.dyn_cast<SourceFile *>(),

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -168,7 +168,7 @@ ArrayRef<Decl *> ParseSourceFileRequest::evaluate(Evaluator &evaluator,
 }
 
 evaluator::DependencySource ParseSourceFileRequest::readDependencySource(
-    const evaluator::DependencyCollector &e) const {
+    const evaluator::DependencyRecorder &e) const {
   return {std::get<0>(getStorage()), evaluator::DependencyScope::Cascading};
 }
 
@@ -196,7 +196,7 @@ void swift::simple_display(llvm::raw_ostream &out,
 
 evaluator::DependencySource
 CodeCompletionSecondPassRequest::readDependencySource(
-    const evaluator::DependencyCollector &e) const {
+    const evaluator::DependencyRecorder &e) const {
   return {std::get<0>(getStorage()), e.getActiveSourceScope()};
 }
 

--- a/lib/SILGen/SILGenRequests.cpp
+++ b/lib/SILGen/SILGenRequests.cpp
@@ -47,7 +47,7 @@ SourceLoc swift::extractNearestSourceLoc(const SILGenDescriptor &desc) {
 }
 
 evaluator::DependencySource SILGenerationRequest::readDependencySource(
-    const evaluator::DependencyCollector &e) const {
+    const evaluator::DependencyRecorder &e) const {
   auto &desc = std::get<0>(getStorage());
 
   // We don't track dependencies in whole-module mode.


### PR DESCRIPTION
Split off the notion of "recording" dependencies from the notion of
"collecting" dependencies. This corrects an oversight in the previous
design where dependency replay and recording were actually not "free" in
WMO where we actually never track dependencies. This architecture also
lays the groundwork for the removal of the referenced name trackers.

The algorithm builds upon the infrastructure for dependency sources and
sinks laid down during the cut over to request-based dependency tracking
in #30723.

The idea of the naive algorithm is this:

For a chain of requests `A -> B* -> C -> D* -> ... -> L` where `L` is a lookup
request and all starred requests are cached, once `L` writes into the
dependency collector, the active stack is walked and at each cache-point
the results of dependency collection are associated with the request
itself (in this example, `B*` and `D*` have all the names `L` found associated
with them). Subsequent evaluations of these cached requests (`B*` and `D*`
et al) will then *replay* the previous lookup results from `L` into the
active referenced name tracker. One complication: suppose the
evaluation of a cached request involves multiple downstream name
lookups. More concretely, suppose we have the following request trace:

```
A* -> B -> L
      |
       -> C -> L
          |
           -> D -> L
              |
               -> ...
```

Then `A*` must see the union of the results of each `L`. If this reminds
anyone of a union-find, that is no accident! A persistent union-find
a la Conchon and Filliatre is probably in order to help bring down peak
heap usage...