### PR TITLE
[NFC] AST: Optimize GenericSignatureImpl::getInnermostGenericParams

### DIFF
--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -76,18 +76,22 @@ GenericSignatureImpl::GenericSignatureImpl(
 
 TypeArrayView<GenericTypeParamType>
 GenericSignatureImpl::getInnermostGenericParams() const {
-  auto params = getGenericParams();
+  const auto params = getGenericParams();
 
-  // Find the point at which the depth changes.
-  unsigned depth = params.back()->getDepth();
-  for (unsigned n = params.size(); n > 0; --n) {
-    if (params[n-1]->getDepth() != depth) {
-      return params.slice(n);
-    }
+  const unsigned maxDepth = params.back()->getDepth();
+  if (params.front()->getDepth() == maxDepth)
+    return params;
+
+  // There is a depth change. Count the number of elements
+  // to slice off the front.
+  unsigned sliceCount = params.size() - 1;
+  while (true) {
+    if (params[sliceCount - 1]->getDepth() != maxDepth)
+      break;
+    --sliceCount;
   }
 
-  // All parameters are at the same depth.
-  return params;
+  return params.slice(sliceCount);
 }
 
 void GenericSignatureImpl::forEachParam(


### PR DESCRIPTION
Adding a fast path that enables us to simplify the successive loop.

Judging by the abundance of `BoundGenericType::getGenericArgs` usage, we are going to have to call `GenericSignatureImpl::getInnermostGenericParams` much more often once we start storing substitution maps in bound generic type nodes, so this is ensuring the latter is as fast as possible without caching.
___
For #31895