### PR TITLE
[SR-12827] [Diagnostics] Improve diagnostics keypath hole involving generic argument

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1089,12 +1089,22 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
 
       ConstraintFix *fix = nullptr;
       if (auto *GP = TypeVar->getImpl().getGenericParameter()) {
-        auto path = dstLocator->getPath();
-        // Drop `generic parameter` locator element so that all missing
-        // generic parameters related to the same path can be coalesced later.
-        fix = DefaultGenericArgument::create(
-            cs, GP,
-            cs.getConstraintLocator(dstLocator->getAnchor(), path.drop_back()));
+        // If it is represetative for a key path root, let's emit a more
+        // specific diagnostic.
+        auto *keyPathRoot =
+            cs.isRepresentativeFor(TypeVar, ConstraintLocator::KeyPathRoot);
+        if (keyPathRoot) {
+          fix = SpecifyKeyPathRootType::create(
+              cs, keyPathRoot->getImpl().getLocator());
+        } else {
+          auto path = dstLocator->getPath();
+          // Drop `generic parameter` locator element so that all missing
+          // generic parameters related to the same path can be coalesced later.
+          fix = DefaultGenericArgument::create(
+              cs, GP,
+              cs.getConstraintLocator(dstLocator->getAnchor(),
+                                      path.drop_back()));
+        }
       } else if (TypeVar->getImpl().isClosureParameterType()) {
         fix = SpecifyClosureParameterType::create(cs, dstLocator);
       } else if (TypeVar->getImpl().isClosureResultType()) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -899,6 +899,31 @@ Type ConstraintSystem::getFixedTypeRecursive(Type type,
   return type;
 }
 
+TypeVariableType *ConstraintSystem::isRepresentativeFor(
+    TypeVariableType *typeVar, ConstraintLocator::PathElementKind kind) const {
+  // We only attempt to look for this if type variable is
+  // a representative.
+  if (getRepresentative(typeVar) != typeVar)
+    return nullptr;
+
+  auto &CG = getConstraintGraph();
+  auto result = CG.lookupNode(typeVar);
+  auto equivalence = result.first.getEquivalenceClass();
+  auto member = llvm::find_if(equivalence, [=](TypeVariableType *eq) {
+    auto *loc = eq->getImpl().getLocator();
+    if (!loc)
+      return false;
+
+    auto path = loc->getPath();
+    return !path.empty() && path.back().getKind() == kind;
+  });
+
+  if (member == equivalence.end())
+    return nullptr;
+
+  return *member;
+}
+
 /// Does a var or subscript produce an l-value?
 ///
 /// \param baseType - the type of the base on which this object

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3076,29 +3076,7 @@ public:
   /// If true returns the type variable which it is the representative for.
   TypeVariableType *
   isRepresentativeFor(TypeVariableType *typeVar,
-                      ConstraintLocator::PathElementKind kind) const {
-    // We only attempt to look for this if type variable is
-    // a representative.
-    if (getRepresentative(typeVar) != typeVar)
-      return nullptr;
-
-    auto &CG = getConstraintGraph();
-    auto result = CG.lookupNode(typeVar);
-    auto equivalence = result.first.getEquivalenceClass();
-    auto member = llvm::find_if(equivalence, [=](TypeVariableType *eq) {
-      auto *loc = eq->getImpl().getLocator();
-      if (!loc)
-        return false;
-
-      auto path = loc->getPath();
-      return !path.empty() && path.back().getKind() == kind;
-    });
-
-    if (member == equivalence.end())
-      return nullptr;
-
-    return *member;
-  }
+                      ConstraintLocator::PathElementKind kind) const;
 
   /// Gets the VarDecl associateed with resolvedOverload, and the type of the
   /// storage wrapper if the decl has an associated storage wrapper.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3071,6 +3071,35 @@ public:
     return typeVar->getImpl().getRepresentative(getSavedBindings());
   }
 
+  /// Finds if the given type variable is representative for a type
+  /// variable which last locator path element is of the specified kind.
+  /// If true returns the type variable which it is the representative for.
+  TypeVariableType *
+  isRepresentativeFor(TypeVariableType *typeVar,
+                      ConstraintLocator::PathElementKind kind) const {
+    // We only attempt to look for this if type variable is
+    // a representative.
+    if (getRepresentative(typeVar) != typeVar)
+      return nullptr;
+
+    auto &CG = getConstraintGraph();
+    auto result = CG.lookupNode(typeVar);
+    auto equivalence = result.first.getEquivalenceClass();
+    auto member = llvm::find_if(equivalence, [=](TypeVariableType *eq) {
+      auto *loc = eq->getImpl().getLocator();
+      if (!loc)
+        return false;
+
+      auto path = loc->getPath();
+      return !path.empty() && path.back().getKind() == kind;
+    });
+
+    if (member == equivalence.end())
+      return nullptr;
+
+    return *member;
+  }
+
   /// Gets the VarDecl associateed with resolvedOverload, and the type of the
   /// storage wrapper if the decl has an associated storage wrapper.
   Optional<std::pair<VarDecl *, Type>>

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3071,7 +3071,7 @@ public:
     return typeVar->getImpl().getRepresentative(getSavedBindings());
   }
 
-  /// Finds if the given type variable is representative for a type
+  /// Find if the given type variable is representative for a type
   /// variable which last locator path element is of the specified kind.
   /// If true returns the type variable which it is the representative for.
   TypeVariableType *

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -906,16 +906,15 @@ func testKeyPathHole() {
   f(\.x) // expected-error {{cannot infer key path type from context; consider explicitly specifying a root type}} {{6-6=<#Root#>}}
   f(\.x.y) // expected-error {{cannot infer key path type from context; consider explicitly specifying a root type}} {{6-6=<#Root#>}}
 
-  // FIXME(SR-12827): Instead of "generic parameter 'T' could not be inferred",
-  // we should offer the same diagnostic as above.
-  func provideValueButNotRoot<T>(_ fn: (T) -> String) {} // expected-note 2{{in call to function 'provideValueButNotRoot'}}
-  provideValueButNotRoot(\.x) // expected-error {{generic parameter 'T' could not be inferred}}
-  provideValueButNotRoot(\.x.y) // expected-error {{generic parameter 'T' could not be inferred}}
+  func provideValueButNotRoot<T>(_ fn: (T) -> String) {} 
+  provideValueButNotRoot(\.x) // expected-error {{cannot infer key path type from context; consider explicitly specifying a root type}}
+  provideValueButNotRoot(\.x.y) // expected-error {{cannot infer key path type from context; consider explicitly specifying a root type}}
   provideValueButNotRoot(\String.foo) // expected-error {{value of type 'String' has no member 'foo'}}
 
-  func provideKPValueButNotRoot<T>(_ kp: KeyPath<T, String>) {} // expected-note 3{{in call to function 'provideKPValueButNotRoot'}}
-  provideKPValueButNotRoot(\.x) // expected-error {{generic parameter 'T' could not be inferred}}
-  provideKPValueButNotRoot(\.x.y) // expected-error {{generic parameter 'T' could not be inferred}}
+  func provideKPValueButNotRoot<T>(_ kp: KeyPath<T, String>) {} // expected-note {{in call to function 'provideKPValueButNotRoot'}}
+  provideKPValueButNotRoot(\.x) // expected-error {{cannot infer key path type from context; consider explicitly specifying a root type}}
+  provideKPValueButNotRoot(\.x.y) // expected-error {{cannot infer key path type from context; consider explicitly specifying a root type}}
+
   provideKPValueButNotRoot(\String.foo)
   // expected-error@-1 {{value of type 'String' has no member 'foo'}}
   // expected-error@-2 {{generic parameter 'T' could not be inferred}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Improve diagnostics involving key path root and generic arguments.

cc @xedin @hamishknight 
Let me know what you think :) 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-12827.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
