### PR TITLE
[stdlib] sem_t is a nullable pointer on OpenBSD.

### DIFF
--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -382,14 +382,21 @@ internal var _ignore = _UnsupportedPlatformError()
 //===----------------------------------------------------------------------===//
 
 #if !os(Windows) 
+
+#if os(OpenBSD)
+public typealias Semaphore = UnsafeMutablePointer<sem_t?>
+#else
+public typealias Semaphore = UnsafeMutablePointer<sem_t>
+#endif
+
 /// The value returned by `sem_open()` in the case of failure.
-public var SEM_FAILED: UnsafeMutablePointer<sem_t>? {
+public var SEM_FAILED: Semaphore? {
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
   // The value is ABI.  Value verified to be correct for OS X, iOS, watchOS, tvOS.
-  return UnsafeMutablePointer<sem_t>(bitPattern: -1)
+  return Semaphore(bitPattern: -1)
 #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
   // The value is ABI.  Value verified to be correct on Glibc.
-  return UnsafeMutablePointer<sem_t>(bitPattern: 0)
+  return Semaphore(bitPattern: 0)
 #else
   _UnsupportedPlatformError()
 #endif
@@ -398,7 +405,7 @@ public var SEM_FAILED: UnsafeMutablePointer<sem_t>? {
 public func sem_open(
   _ name: UnsafePointer<CChar>,
   _ oflag: Int32
-) -> UnsafeMutablePointer<sem_t>? {
+) -> Semaphore? {
   return _stdlib_sem_open2(name, oflag)
 }
 
@@ -407,9 +414,10 @@ public func sem_open(
   _ oflag: Int32,
   _ mode: mode_t,
   _ value: CUnsignedInt
-) -> UnsafeMutablePointer<sem_t>? {
+) -> Semaphore? {
   return _stdlib_sem_open4(name, oflag, mode, value)
 }
+
 #endif
 
 //===----------------------------------------------------------------------===//

--- a/test/stdlib/POSIX.swift
+++ b/test/stdlib/POSIX.swift
@@ -5,7 +5,7 @@
 import StdlibUnittest
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
   import Glibc
 #else
 #error("Unsupported platform")


### PR DESCRIPTION
Platform defines sem_open in Swift that calls through to the underlying
platform functions because sem_open is variadic. However, the
definitions here assume sem_t is non-nullable, but this assumption only
holds when the platform has nullability annotations on the semaphore
type, or the semaphore type on the platform is not an opaque pointer.

On OpenBSD specifically, the semaphore type is an opaque pointer without
any nullability annotations. This means that the type gets inferred as
UnsafeMutablePointer<sem_t?>? instead of UnsafeMutablePointer<sem_t>?.
To make sure the pointer values returned and their types match, we
introduce a conditional typealias.

The other option is to coerce everything to UnsafeMutablePointer<sem_t>?
but this would be a rather blunt instrument. While sem_open is public in
stdlib, it is not so much codified stdlib API, so this is a slightly
nicer approach.