### PR TITLE
[IRGen testing] Reapply: Fix bogus FileCheck check-prefix "-SAME" usage

### DIFF
--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -20,8 +20,8 @@
 // CHECK: @"$s16class_resilience27ClassWithResilientThenEmptyC9resilient0H7_struct0E3IntVvpWvd" = hidden global [[INT]] 0,
 
 // CHECK: @"$s16class_resilience26ClassWithResilientPropertyCMo" = {{(protected )?}}{{(dllexport )?}}constant [[BOUNDS]]
-// CHECK-SAME-32: { [[INT]] 52, i32 2, i32 13 }
-// CHECK-SAME-64: { [[INT]] 80, i32 2, i32 10 }
+// CHECK-32-SAME: { [[INT]] 52, i32 2, i32 17 }
+// CHECK-64-SAME: { [[INT]] 80, i32 2, i32 14 }
 
 // CHECK: @"$s16class_resilience28ClassWithMyResilientPropertyC1rAA0eF6StructVvpWvd" = hidden constant [[INT]] {{8|16}}
 // CHECK: @"$s16class_resilience28ClassWithMyResilientPropertyC5colors5Int32VvpWvd" = hidden constant [[INT]] {{12|20}}
@@ -101,20 +101,20 @@
 // CHECK-native-SAME: i32 0
 
 // CHECK: @"$s16class_resilience17MyResilientParentCMo" = {{(protected )?}}{{(dllexport )?}}constant [[BOUNDS]]
-// CHECK-SAME-32: { [[INT]] 52, i32 2, i32 13 }
-// CHECK-SAME-64: { [[INT]] 80, i32 2, i32 10 }
+// CHECK-32-SAME: { [[INT]] 52, i32 2, i32 15 }
+// CHECK-64-SAME: { [[INT]] 80, i32 2, i32 12 }
 
 // CHECK: @"$s16class_resilience16MyResilientChildCMo" = {{(protected )?}}{{(dllexport )?}}constant [[BOUNDS]]
-// CHECK-SAME-32: { [[INT]] 60, i32 2, i32 15 }
-// CHECK-SAME-64: { [[INT]] 96, i32 2, i32 12 }
+// CHECK-32-SAME: { [[INT]] 60, i32 2, i32 16 }
+// CHECK-64-SAME: { [[INT]] 96, i32 2, i32 13 }
 
 // CHECK: @"$s16class_resilience24MyResilientGenericParentCMo" = {{(protected )?}}{{(dllexport )?}}constant [[BOUNDS]]
-// CHECK-SAME-32: { [[INT]] 52, i32 2, i32 13 }
-// CHECK-SAME-64: { [[INT]] 80, i32 2, i32 10 }
+// CHECK-32-SAME: { [[INT]] 52, i32 2, i32 16 }
+// CHECK-64-SAME: { [[INT]] 80, i32 2, i32 13 }
 
 // CHECK: @"$s16class_resilience24MyResilientConcreteChildCMo" = {{(protected )?}}{{(dllexport )?}}constant [[BOUNDS]]
-// CHECK-SAME-32: { [[INT]] 64, i32 2, i32 16 }
-// CHECK-SAME-64: { [[INT]] 104, i32 2, i32 13 }
+// CHECK-32-SAME: { [[INT]] 64, i32 2, i32 18 }
+// CHECK-64-SAME: { [[INT]] 104, i32 2, i32 15 }
 
 // CHECK: @"$s16class_resilience27ClassWithEmptyThenResilientC5emptyAA0E0VvpWvd" = hidden constant [[INT]] 0,
 // CHECK: @"$s16class_resilience27ClassWithResilientThenEmptyC5emptyAA0G0VvpWvd" = hidden constant [[INT]] 0,

--- a/test/IRGen/generic_classes.sil
+++ b/test/IRGen/generic_classes.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/generic_classes.sil
-// RUN: %target-swift-frontend %t/generic_classes.sil -emit-ir -enable-objc-interop | %FileCheck %t/generic_classes.sil --check-prefixes=CHECK,CHECK-objc,CHECK-%target-import-type
+// RUN: %target-swift-frontend %t/generic_classes.sil -emit-ir -enable-objc-interop | %FileCheck %t/generic_classes.sil --check-prefixes=CHECK,CHECK-objc,CHECK-%target-import-type,CHECK-%target-import-type-objc
 // RUN: %target-swift-frontend %t/generic_classes.sil -emit-ir -disable-objc-interop | %FileCheck %t/generic_classes.sil --check-prefixes=CHECK,CHECK-native,CHECK-%target-import-type
 // RUN: %target-swift-frontend -Osize %t/generic_classes.sil -emit-ir | %FileCheck %t/generic_classes.sil --check-prefix=OSIZE
 
@@ -91,22 +91,23 @@ import Swift
 // CHECK-SAME: }>
 
 // CHECK: @"$s15generic_classes14RootNonGenericCMf" = internal global <{ {{.*}} }> <{
-// CHECK-SAME:   void (%T15generic_classes14RootNonGenericC*)* @"$s15generic_classes14RootNonGenericCfD",
-// CHECK-DIRECT-SAME:   i8** @"$sBoWV",
-// CHECK-INDIRECT-SAME:   i8** null,
-// CHECK-native-SAME: i64 0,
-// CHECK-native-SAME: %swift.type* null,
-// CHECK-native-SAME: %swift.opaque* null,
-// CHECK-objc-SAME:   i64 ptrtoint (%objc_class* @"$s15generic_classes14RootNonGenericCMm" to i64),
-// CHECK-objc-SAME:   %objc_class* @"OBJC_CLASS_$_{{(_TtCs12_)?}}SwiftObject",
-// CHECK-objc-SAME:   %swift.opaque* @_objc_empty_cache,
-// CHECK-SAME:   %swift.opaque* null,
-// CHECK-native-SAME: i64 1,
-// CHECK-objc-SAME:   @_DATA__TtC15generic_classes14RootNonGeneric
-// CHECK-SAME:   i32 33,
-// CHECK-SAME:   i16 7,
-// CHECK-SAME:   i16 0,
-// CHECK-SAME:   {{.*}}* @"$s15generic_classes14RootNonGenericCMn"
+// CHECK-SAME:                void (%T15generic_classes14RootNonGenericC*)* @"$s15generic_classes14RootNonGenericCfD",
+// CHECK-DIRECT-SAME:         i8** @"$sBoWV",
+// CHECK-INDIRECT-SAME:       i8** null,
+// CHECK-native-SAME:         i64 0,
+// CHECK-native-SAME:         %swift.type* null,
+// CHECK-native-SAME:         %swift.opaque* null,
+// CHECK-objc-SAME:           i64 ptrtoint (%objc_class* @"$s15generic_classes14RootNonGenericCMm" to i64),
+// CHECK-DIRECT-objc-SAME:    %objc_class* @"OBJC_CLASS_$_{{(_TtCs12_)?}}SwiftObject",
+// CHECK-INDIRECT-objc-SAME:  %swift.type* null,
+// CHECK-objc-SAME:           %swift.opaque* @_objc_empty_cache,
+// CHECK-SAME:                %swift.opaque* null,
+// CHECK-native-SAME:         i64 1,
+// CHECK-objc-SAME:           @_DATA__TtC15generic_classes14RootNonGeneric
+// CHECK-SAME:                i32 33,
+// CHECK-SAME:                i16 7,
+// CHECK-SAME:                i16 0,
+// CHECK-SAME:                {{.*}}* @"$s15generic_classes14RootNonGenericCMn"
 // CHECK-SAME: }>
 
 // CHECK: @"$s15generic_classes015GenericInheritsC0CMn" = hidden constant

--- a/test/IRGen/generic_classes.sil
+++ b/test/IRGen/generic_classes.sil
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/generic_classes.sil
-// RUN: %target-swift-frontend %t/generic_classes.sil -emit-ir | %FileCheck %t/generic_classes.sil --check-prefix=CHECK --check-prefix=CHECK-%target-runtime -check-prefix CHECK-%target-import-type
+// RUN: %target-swift-frontend %t/generic_classes.sil -emit-ir -enable-objc-interop | %FileCheck %t/generic_classes.sil --check-prefixes=CHECK,CHECK-objc,CHECK-%target-import-type
+// RUN: %target-swift-frontend %t/generic_classes.sil -emit-ir -disable-objc-interop | %FileCheck %t/generic_classes.sil --check-prefixes=CHECK,CHECK-native,CHECK-%target-import-type
 // RUN: %target-swift-frontend -Osize %t/generic_classes.sil -emit-ir | %FileCheck %t/generic_classes.sil --check-prefix=OSIZE
 
 // REQUIRES: CPU=x86_64
@@ -52,21 +53,20 @@ import Swift
 // --       flags
 // CHECK_SAME:   i32 3,
 // --       immediate pattern size
-// CHECK-SAME:   i16 0,
+// CHECK-native-SAME:   i16 0,
+// CHECK-objc-SAME:     i16 5,
 // --       immediate pattern target offset
-// CHECK-SAME:   i16 0,
+// CHECK-SAME:          i16 0,
 // --       extra data size
-// CHECK-SAME-native:   i16 0,
-// CHECK-SAME-objc:     i16 23,
+// CHECK-native-SAME:   i16 0,
+// CHECK-objc-SAME:     i16 14,
 // --       class ro-data offset
-// CHECK-SAME-native:   i16 0,
-// CHECK-SAME-objc:     i16 5,
+// CHECK-native-SAME:   i16 0
+// CHECK-objc-SAME:     i16 0,
 // --       metaclass object offset
-// CHECK-SAME-native:   i16 0,
-// CHECK-SAME-objc:     i16 0,
+// CHECK-objc-SAME:     i16 0,
 // --       class ro-data offset
-// CHECK-SAME-native:   i16 0
-// CHECK-SAME-objc:     i16 14,
+// CHECK-objc-SAME:     i16 23
 // CHECK-SAME: }>
 
 // -- Check that offset vars are emitted for fixed-layout generics
@@ -94,15 +94,15 @@ import Swift
 // CHECK-SAME:   void (%T15generic_classes14RootNonGenericC*)* @"$s15generic_classes14RootNonGenericCfD",
 // CHECK-DIRECT-SAME:   i8** @"$sBoWV",
 // CHECK-INDIRECT-SAME:   i8** null,
-// CHECK-SAME-native: i64 0,
-// CHECK-SAME-native: %swift.type* null,
-// CHECK-SAME-native: %swift.opaque* null,
-// CHECK-SAME-objc:   i64 ptrtoint (%objc_class* @"$s15generic_classes14RootNonGenericCMm" to i64),
-// CHECK-SAME-objc:   %objc_class* @"OBJC_CLASS_$_{{(_TtCs12_)?}}SwiftObject",
-// CHECK-SAME-objc:   %swift.opaque* @_objc_empty_cache,
+// CHECK-native-SAME: i64 0,
+// CHECK-native-SAME: %swift.type* null,
+// CHECK-native-SAME: %swift.opaque* null,
+// CHECK-objc-SAME:   i64 ptrtoint (%objc_class* @"$s15generic_classes14RootNonGenericCMm" to i64),
+// CHECK-objc-SAME:   %objc_class* @"OBJC_CLASS_$_{{(_TtCs12_)?}}SwiftObject",
+// CHECK-objc-SAME:   %swift.opaque* @_objc_empty_cache,
 // CHECK-SAME:   %swift.opaque* null,
-// CHECK-SAME-native: i64 1,
-// CHECK-SAME-objc:   @_DATA__TtC15generic_classes14RootNonGeneric
+// CHECK-native-SAME: i64 1,
+// CHECK-objc-SAME:   @_DATA__TtC15generic_classes14RootNonGeneric
 // CHECK-SAME:   i32 33,
 // CHECK-SAME:   i16 7,
 // CHECK-SAME:   i16 0,
@@ -117,8 +117,8 @@ import Swift
 // --       template instantiation function
 // CHECK-SAME:   %swift.type* (%swift.type_descriptor*, i8**, i8*)* @"$s15generic_classes015GenericInheritsC0CMi"
 // --       pattern flags (1 == has extra data pattern)
-// CHECK-SAME-native: i32 0,
-// CHECK-SAME-objc:   i32 1,
+// CHECK-native-SAME: i32 0,
+// CHECK-objc-SAME:   i32 1,
 // --       heap destructor
 // CHECK-SAME:   @"$s15generic_classes015GenericInheritsC0CfD"
 // --       ivar destroyer
@@ -126,20 +126,21 @@ import Swift
 // --       class flags
 // CHECK_SAME:   i32 3,
 // --       extra data pattern offset
-// CHECK-SAME-objc:     i16 0,
+// CHECK-objc-SAME:     i16 5,
 // --       extra data pattern size
-// CHECK-SAME-objc:     i16 23,
+// CHECK-objc-SAME:     i16 0,
 // --       class ro-data offset
-// CHECK-SAME-native:   i16 0,
-// CHECK-SAME-objc:     i16 5,
+// CHECK-native-SAME:   i16 0,
+// CHECK-objc-SAME:     i16 14,
 // --       metaclass object offset
-// CHECK-SAME-native:   i16 0,
-// CHECK-SAME-objc:     i16 0,
+// CHECK-native-SAME:   i16 0,
+// CHECK-objc-SAME:     i16 0,
 // --       class ro-data offset
-// CHECK-SAME-native:   i16 0,
-// CHECK-SAME-objc:     i16 14,
+// CHECK-native-SAME:   i16 0,
+// CHECK-objc-SAME:     i16 0,
 // --       reserved
-// CHECK-SAME:          i16 0
+// CHECK-native-SAME:   i16 0
+// CHECK-objc-SAME:     i16 23
 // CHECK-SAME: }
 
 // CHECK: @"$s15generic_classes018GenericInheritsNonC0CMP"


### PR DESCRIPTION
The correct usage of "-SAME" is after the check-prefix, not in the middle. I've updated the constants to what is emitted today.

Now with verified 32-bit fixes.