### PR TITLE
[5.3] IRGen: Only replace opaque result types of function result types when performing a dynamic replacement

### DIFF
--- a/test/IRGen/Inputs/opaque_return_type_parameter.swift
+++ b/test/IRGen/Inputs/opaque_return_type_parameter.swift
@@ -1,0 +1,15 @@
+class Base {}
+class Sub: Base {}
+
+protocol Proto {
+  associatedtype Assoc
+  func make() -> Assoc
+}
+
+private struct Container : Proto {
+  func make() -> some Base {
+    return Sub()
+  }
+
+  func update(arg: Assoc) {}
+}

--- a/test/IRGen/dynamic_replaceable_opaque_return_type_parameter.swift
+++ b/test/IRGen/dynamic_replaceable_opaque_return_type_parameter.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -disable-availability-checking -enable-implicit-dynamic -enable-private-imports %S/Inputs/opaque_return_type_parameter.swift -module-name Repo -emit-module -emit-module-path %t/Repo.swiftmodule
+// RUN: %target-swift-frontend -disable-availability-checking -I %t -module-name A -swift-version 5 -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -disable-availability-checking -I %t -module-name A -swift-version 5 -primary-file %s -c -o %t/tmp.o
+@_private(sourceFile: "opaque_return_type_parameter.swift") import Repo
+
+// Make sure we are not emitting a replacement for the opaque result type used as parameter (Assoc).
+
+// CHECK-NOT: @"\01l_unnamed_dynamic_replacements"{{.*}}(%swift.type_descriptor* ()*
+
+extension Container {
+  @_dynamicReplacement(for: update(arg:)) private func __update(arg: Assoc) {}
+}


### PR DESCRIPTION
Explanation: When a opaque result type (``some P``) appeared as a parameter of a
dynamic replacement function we used to try to emit this opaque result
type as a replacement. This made no sense since you can only replace
result types that are opaque result types not parameters that happen to
have the type of an opaque result type. And doing so would lead to a
compiler crash.

Scope: Any use of a dynamic replacement with an opaque result type
parameter would crash the compiler.

Origination: This bug was introduced together with the dynamic
replacement feature.

Risk: Medium. Affects only dynamic replacements with opaque result
types.

Reviewed by: Joe Groff

Testing: Unit test added.

rdar://61936622
