### PR TITLE
[AST] Restore getSourceRange() on DefaultArgumentExpr

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4227,9 +4227,7 @@ public:
       DefaultArgsOwner(defaultArgsOwner), ParamIndex(paramIndex), Loc(loc),
       ContextOrCallerSideExpr(dc) { }
 
-  SourceRange getSourceRange() const { return {}; }
-
-  SourceLoc getArgumentListLoc() const { return Loc; }
+  SourceRange getSourceRange() const { return Loc; }
 
   ConcreteDeclRef getDefaultArgsOwner() const {
     return DefaultArgsOwner;

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1279,6 +1279,10 @@ SourceRange TupleExpr::getSourceRange() const {
     } else {
       // Scan backwards for a valid source loc.
       for (Expr *expr : llvm::reverse(getElements())) {
+        // Default arguments are located at the start of their parent tuple, so
+        // skip over them.
+        if (isa<DefaultArgumentExpr>(expr))
+          continue;
         end = expr->getEndLoc();
         if (end.isValid()) {
           break;

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -789,7 +789,7 @@ Expr *CallerSideDefaultArgExprRequest::evaluate(
 
   // Re-create the default argument using the location info of the call site.
   auto *initExpr =
-      synthesizeCallerSideDefault(param, defaultExpr->getArgumentListLoc());
+      synthesizeCallerSideDefault(param, defaultExpr->getLoc());
   auto *dc = defaultExpr->ContextOrCallerSideExpr.get<DeclContext *>();
   assert(dc && "Expected a DeclContext before type-checking caller-side arg");
 

--- a/test/DebugInfo/callexpr.swift
+++ b/test/DebugInfo/callexpr.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend %s -g -emit-ir -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -g -emit-ir -o - | %FileCheck --check-prefix=CHECK2 %s
 
 func markUsed<T>(_ t: T) {}
 
@@ -14,4 +15,12 @@ let r = foo(
             foo(2, 42)  // CHECK: ![[ARG2]] = !DILocation(line: [[@LINE]],
            )            // CHECK: ![[OUTER]] = !DILocation(line: [[@LINE-3]],
 markUsed(r)
+
+struct MyType {}
+func bar(x: MyType = MyType()) {}
+
+// CHECK2: call {{.*}}MyType{{.*}}, !dbg ![[DEFAULTARG:.*]]
+// CHECK2: call {{.*}}bar{{.*}}, !dbg ![[BARCALL:.*]]
+bar() // CHECK2: ![[DEFAULTARG]] = !DILocation(line: [[@LINE]], column: 4
+      // CHECK2: ![[BARCALL]] = !DILocation(line: [[@LINE-1]], column: 1
 


### PR DESCRIPTION
This restores getSourceRange() on DefaultArgumentExpr after it was removed in
#31184.

It was originally removed to solve the issues it was causing when computing the source range of its parent TupleExpr. To account for trailing closures we walk back through the tuple's arguments until one with a valid location is found, which we use as the end location. If the last argument was a DefaultArgumentExpr though that meant the end loc would end up being the tuple's start location, so none of the tuple's other arguments were contained in its range, triggering an
ASTVerifier assertion. Source tooling and diagnostics don't care about default arg expression locations as nothing can reference them on the caller side and any issues in them should be reported on the callee side, but their locations are output in the debug info. Added a regression test to catch that in future, and updated TupleExpr::getSourceRange() to ignore DefaultArgumentExprs when computing the end loc.

Resolves rdar://problem/63195504.