### PR TITLE
build: remove last `llvm::` reference in stdlib

### DIFF
--- a/include/swift/ABI/TypeIdentity.h
+++ b/include/swift/ABI/TypeIdentity.h
@@ -184,7 +184,7 @@ public:
   StringRef FullIdentity;
 
   /// Any extended information that type might have.
-  Optional<TypeImportInfo<StringRef>> ImportInfo;
+  llvm::Optional<TypeImportInfo<StringRef>> ImportInfo;
 
   /// The ABI name of the type.
   StringRef getABIName() const {

--- a/include/swift/Basic/LLVM.h
+++ b/include/swift/Basic/LLVM.h
@@ -45,7 +45,9 @@ namespace llvm {
   template<typename T> class MutableArrayRef;
 #endif
   template<typename T> class TinyPtrVector;
+#if !defined(swiftCore_EXPORTS)
   template<typename T> class Optional;
+#endif
   template <typename ...PTs> class PointerUnion;
   template <typename IteratorT> class iterator_range;
   class SmallBitVector;
@@ -75,7 +77,9 @@ namespace swift {
 #endif
   using llvm::iterator_range;
   using llvm::None;
+#if !defined(swiftCore_EXPORTS)
   using llvm::Optional;
+#endif
   using llvm::PointerUnion;
   using llvm::SmallBitVector;
   using llvm::SmallPtrSet;

--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -528,19 +528,18 @@ makeOptionalTransformRange(Range range, OptionalTransform op) {
 /// the result in an optional to indicate success or failure.
 template<typename Subclass>
 struct DowncastAsOptional {
-  template<typename Superclass>
+  template <typename Superclass>
   auto operator()(Superclass &value) const
-         -> Optional<decltype(llvm::cast<Subclass>(value))> {
+      -> llvm::Optional<decltype(llvm::cast<Subclass>(value))> {
     if (auto result = llvm::dyn_cast<Subclass>(value))
       return result;
 
     return None;
   }
 
-  template<typename Superclass>
+  template <typename Superclass>
   auto operator()(const Superclass &value) const
-         -> Optional<decltype(llvm::cast<Subclass>(value))>
-  {
+      -> llvm::Optional<decltype(llvm::cast<Subclass>(value))> {
     if (auto result = llvm::dyn_cast<Subclass>(value))
       return result;
 

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -94,7 +94,7 @@ enum class ImplParameterDifferentiability {
   NotDifferentiable
 };
 
-static inline Optional<ImplParameterDifferentiability>
+static inline llvm::Optional<ImplParameterDifferentiability>
 getDifferentiabilityFromString(StringRef string) {
   if (string.empty())
     return ImplParameterDifferentiability::DifferentiableOrNotApplicable;
@@ -115,7 +115,7 @@ public:
   using ConventionType = ImplParameterConvention;
   using DifferentiabilityType = ImplParameterDifferentiability;
 
-  static Optional<ConventionType>
+  static llvm::Optional<ConventionType>
   getConventionFromString(StringRef conventionString) {
     if (conventionString == "@in")
       return ConventionType::Indirect_In;
@@ -168,7 +168,7 @@ class ImplFunctionResult {
 public:
   using ConventionType = ImplResultConvention;
 
-  static Optional<ConventionType>
+  static llvm::Optional<ConventionType>
   getConventionFromString(StringRef conventionString) {
     if (conventionString == "@out")
       return ConventionType::Indirect;
@@ -268,8 +268,8 @@ public:
 #if SWIFT_OBJC_INTEROP
 /// For a mangled node that refers to an Objective-C class or protocol,
 /// return the class or protocol name.
-static inline Optional<StringRef> getObjCClassOrProtocolName(
-    NodePointer node) {
+static inline llvm::Optional<StringRef>
+getObjCClassOrProtocolName(NodePointer node) {
   if (node->getKind() != Demangle::Node::Kind::Class &&
       node->getKind() != Demangle::Node::Kind::Protocol)
     return None;
@@ -435,7 +435,7 @@ class TypeDecoder {
     case NodeKind::Metatype:
     case NodeKind::ExistentialMetatype: {
       unsigned i = 0;
-      Optional<ImplMetatypeRepresentation> repr;
+      llvm::Optional<ImplMetatypeRepresentation> repr;
 
       // Handle lowered metatypes in a hackish way. If the representation
       // was not thin, force the resulting typeref to have a non-empty
@@ -650,7 +650,7 @@ class TypeDecoder {
         }
       }
 
-      Optional<ImplFunctionResult<BuiltType>> errorResult;
+      llvm::Optional<ImplFunctionResult<BuiltType>> errorResult;
       switch (errorResults.size()) {
       case 0:
         break;
@@ -905,7 +905,7 @@ private:
       return true;
 
     StringRef conventionString = node->getChild(0)->getText();
-    Optional<typename T::ConventionType> convention =
+    llvm::Optional<typename T::ConventionType> convention =
         T::getConventionFromString(conventionString);
     if (!convention)
       return true;
@@ -1072,8 +1072,8 @@ private:
       return true;
     };
 
-    auto decodeParam = [&](NodePointer paramNode)
-        -> Optional<FunctionParam<BuiltType>> {
+    auto decodeParam =
+        [&](NodePointer paramNode) -> llvm::Optional<FunctionParam<BuiltType>> {
       if (paramNode->getKind() != NodeKind::TupleElement)
         return None;
 

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -248,8 +248,9 @@ class TypeRefBuilder {
 
 public:
   using BuiltType = const TypeRef *;
-  using BuiltTypeDecl = Optional<std::string>;
-  using BuiltProtocolDecl = Optional<std::pair<std::string, bool /*isObjC*/>>;
+  using BuiltTypeDecl = llvm::Optional<std::string>;
+  using BuiltProtocolDecl =
+      llvm::Optional<std::pair<std::string, bool /*isObjC*/>>;
 
   TypeRefBuilder(const TypeRefBuilder &other) = delete;
   TypeRefBuilder &operator=(const TypeRefBuilder &other) = delete;
@@ -295,8 +296,7 @@ public:
     return BuiltinTypeRef::create(*this, mangledName);
   }
 
-  Optional<std::string>
-  createTypeDecl(Node *node, bool &typeAlias) {
+  llvm::Optional<std::string> createTypeDecl(Node *node, bool &typeAlias) {
     return Demangle::mangleNode(node);
   }
 
@@ -310,25 +310,25 @@ public:
     return std::make_pair(name, true);
   }
 
-  Optional<std::string> createTypeDecl(std::string &&mangledName,
-                                       bool &typeAlias) {
+  llvm::Optional<std::string> createTypeDecl(std::string &&mangledName,
+                                             bool &typeAlias) {
     return std::move(mangledName);
   }
-  
-  const NominalTypeRef *createNominalType(
-                                    const Optional<std::string> &mangledName) {
+
+  const NominalTypeRef *
+  createNominalType(const llvm::Optional<std::string> &mangledName) {
     return NominalTypeRef::create(*this, *mangledName, nullptr);
   }
 
-  const NominalTypeRef *createNominalType(
-                                    const Optional<std::string> &mangledName,
-                                    const TypeRef *parent) {
+  const NominalTypeRef *
+  createNominalType(const llvm::Optional<std::string> &mangledName,
+                    const TypeRef *parent) {
     return NominalTypeRef::create(*this, *mangledName, parent);
   }
 
-  const TypeRef *createTypeAliasType(
-                                    const Optional<std::string> &mangledName,
-                                    const TypeRef *parent) {
+  const TypeRef *
+  createTypeAliasType(const llvm::Optional<std::string> &mangledName,
+                      const TypeRef *parent) {
     // TypeRefs don't contain sugared types
     return nullptr;
   }
@@ -354,13 +354,13 @@ public:
   }
 
   const BoundGenericTypeRef *
-  createBoundGenericType(const Optional<std::string> &mangledName,
+  createBoundGenericType(const llvm::Optional<std::string> &mangledName,
                          const std::vector<const TypeRef *> &args) {
     return BoundGenericTypeRef::create(*this, *mangledName, args, nullptr);
   }
 
   const BoundGenericTypeRef *
-  createBoundGenericType(const Optional<std::string> &mangledName,
+  createBoundGenericType(const llvm::Optional<std::string> &mangledName,
                          llvm::ArrayRef<const TypeRef *> args,
                          const TypeRef *parent) {
     return BoundGenericTypeRef::create(*this, *mangledName, args, parent);
@@ -420,7 +420,7 @@ public:
       Demangle::ImplParameterConvention calleeConvention,
       llvm::ArrayRef<Demangle::ImplFunctionParam<const TypeRef *>> params,
       llvm::ArrayRef<Demangle::ImplFunctionResult<const TypeRef *>> results,
-      Optional<Demangle::ImplFunctionResult<const TypeRef *>> errorResult,
+      llvm::Optional<Demangle::ImplFunctionResult<const TypeRef *>> errorResult,
       ImplFunctionTypeFlags flags) {
     // Minimal support for lowered function types. These come up in
     // reflection as capture types. For the reflection library's
@@ -467,14 +467,15 @@ public:
                                               isClassBound);
   }
 
-  const ExistentialMetatypeTypeRef *
-  createExistentialMetatypeType(const TypeRef *instance,
-                    Optional<Demangle::ImplMetatypeRepresentation> repr=None) {
+  const ExistentialMetatypeTypeRef *createExistentialMetatypeType(
+      const TypeRef *instance,
+      llvm::Optional<Demangle::ImplMetatypeRepresentation> repr = None) {
     return ExistentialMetatypeTypeRef::create(*this, instance);
   }
 
-  const MetatypeTypeRef *createMetatypeType(const TypeRef *instance,
-                    Optional<Demangle::ImplMetatypeRepresentation> repr=None) {
+  const MetatypeTypeRef *createMetatypeType(
+      const TypeRef *instance,
+      llvm::Optional<Demangle::ImplMetatypeRepresentation> repr = None) {
     bool WasAbstract = (repr && *repr != ImplMetatypeRepresentation::Thin);
     return MetatypeTypeRef::create(*this, instance, WasAbstract);
   }

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -466,7 +466,7 @@ public:
   }
 
   /// Get the remote process's swift_isaMask.
-  Optional<StoredPointer> readIsaMask() {
+  llvm::Optional<StoredPointer> readIsaMask() {
     auto encoding = getIsaEncoding();
     if (encoding != IsaEncodingKind::Masked) {
       // Still return success if there's no isa encoding at all.
@@ -480,7 +480,7 @@ public:
   }
 
   /// Given a remote pointer to metadata, attempt to discover its MetadataKind.
-  Optional<MetadataKind>
+  llvm::Optional<MetadataKind>
   readKindFromMetadata(StoredPointer MetadataAddress) {
     auto meta = readMetadata(MetadataAddress);
     if (!meta) return None;
@@ -501,8 +501,8 @@ public:
 
   /// Given a remote pointer to class metadata, attempt to discover its class
   /// instance size and whether fields should use the resilient layout strategy.
-  Optional<unsigned>
-  readInstanceStartAndAlignmentFromClassMetadata(StoredPointer MetadataAddress) {
+  llvm::Optional<unsigned> readInstanceStartAndAlignmentFromClassMetadata(
+      StoredPointer MetadataAddress) {
     auto meta = readMetadata(MetadataAddress);
     if (!meta || meta->getKind() != MetadataKind::Class)
       return None;
@@ -527,7 +527,7 @@ public:
   /// Given a pointer to the metadata, attempt to read the value
   /// witness table. Note that it's not safe to access any non-mandatory
   /// members of the value witness table, like extra inhabitants or enum members.
-  Optional<TargetValueWitnessTable<Runtime>>
+  llvm::Optional<TargetValueWitnessTable<Runtime>>
   readValueWitnessTable(StoredPointer MetadataAddress) {
     // The value witness table pointer is at offset -1 from the metadata
     // pointer, that is, the pointer-sized word immediately before the
@@ -548,7 +548,7 @@ public:
   /// pointer to its metadata address, its value address, and whether this
   /// is a toll-free-bridged NSError or an actual Error existential wrapper
   /// around a native Swift value.
-  Optional<RemoteExistential>
+  llvm::Optional<RemoteExistential>
   readMetadataAndValueErrorExistential(RemoteAddress ExistentialAddress) {
     // An pointer to an error existential is always an heap object.
     auto MetadataAddress =
@@ -629,7 +629,7 @@ public:
 
   /// Given a known-opaque existential, attemp to discover the pointer to its
   /// metadata address and its value.
-  Optional<RemoteExistential>
+  llvm::Optional<RemoteExistential>
   readMetadataAndValueOpaqueExistential(RemoteAddress ExistentialAddress) {
     // OpaqueExistentialContainer is the layout of an opaque existential.
     // `Type` is the pointer to the metadata.
@@ -1181,10 +1181,11 @@ public:
   }
 
   /// Read the isa pointer of an Object-C tagged pointer value.
-  Optional<StoredPointer>
+  llvm::Optional<StoredPointer>
   readMetadataFromTaggedPointer(StoredPointer objectAddress) {
-    auto readArrayElement = [&](StoredPointer base, StoredPointer tag)
-        -> Optional<StoredPointer> {
+    auto readArrayElement =
+        [&](StoredPointer base,
+            StoredPointer tag) -> llvm::Optional<StoredPointer> {
       StoredPointer addr = base + tag * sizeof(StoredPointer);
       StoredPointer isa;
       if (!Reader->readInteger(RemoteAddress(addr), &isa))
@@ -1210,7 +1211,7 @@ public:
 
   /// Read the isa pointer of a class or closure context instance and apply
   /// the isa mask.
-  Optional<StoredPointer>
+  llvm::Optional<StoredPointer>
   readMetadataFromInstance(StoredPointer objectAddress) {
     if (isTaggedPointer(objectAddress))
       return readMetadataFromTaggedPointer(objectAddress);
@@ -1281,9 +1282,8 @@ public:
   ///
   /// The offset is in units of words, from the start of the class's
   /// metadata.
-  Optional<int32_t>
-  readGenericArgsOffset(MetadataRef metadata,
-                        ContextDescriptorRef descriptor) {
+  llvm::Optional<int32_t>
+  readGenericArgsOffset(MetadataRef metadata, ContextDescriptorRef descriptor) {
     switch (descriptor->getKind()) {
     case ContextDescriptorKind::Class: {
       auto type = cast<TargetClassDescriptor<Runtime>>(descriptor);
@@ -1319,7 +1319,7 @@ public:
   using ClassMetadataBounds = TargetClassMetadataBounds<Runtime>;
 
   // This follows computeMetadataBoundsForSuperclass.
-  Optional<ClassMetadataBounds>
+  llvm::Optional<ClassMetadataBounds>
   readMetadataBoundsOfSuperclass(ContextDescriptorRef subclassRef) {
     auto subclass = cast<TargetClassDescriptor<Runtime>>(subclassRef);
     if (!subclass->hasResilientSuperclass())
@@ -1332,34 +1332,34 @@ public:
     }
 
     return forTypeReference<ClassMetadataBounds>(
-      subclass->getResilientSuperclassReferenceKind(), rawSuperclass,
-      [&](ContextDescriptorRef superclass)
-            -> Optional<ClassMetadataBounds> {
-        if (!isa<TargetClassDescriptor<Runtime>>(superclass))
-          return None;
-        return readMetadataBoundsOfSuperclass(superclass);
-      },
-      [&](MetadataRef metadata) -> Optional<ClassMetadataBounds> {
-        auto cls = dyn_cast<TargetClassMetadata<Runtime>>(metadata);
-        if (!cls)
-          return None;
+        subclass->getResilientSuperclassReferenceKind(), rawSuperclass,
+        [&](ContextDescriptorRef superclass)
+            -> llvm::Optional<ClassMetadataBounds> {
+          if (!isa<TargetClassDescriptor<Runtime>>(superclass))
+            return None;
+          return readMetadataBoundsOfSuperclass(superclass);
+        },
+        [&](MetadataRef metadata) -> llvm::Optional<ClassMetadataBounds> {
+          auto cls = dyn_cast<TargetClassMetadata<Runtime>>(metadata);
+          if (!cls)
+            return None;
 
-        return cls->getClassBoundsAsSwiftSuperclass();
-      },
-      [](StoredPointer objcClassName) -> Optional<ClassMetadataBounds> {
-        // We have no ability to look up an ObjC class by name.
-        // FIXME: add a query for this; clients may have a way to do it.
-        return None;
-      });
+          return cls->getClassBoundsAsSwiftSuperclass();
+        },
+        [](StoredPointer objcClassName) -> llvm::Optional<ClassMetadataBounds> {
+          // We have no ability to look up an ObjC class by name.
+          // FIXME: add a query for this; clients may have a way to do it.
+          return None;
+        });
   }
 
   template <class Result, class DescriptorFn, class MetadataFn,
             class ClassNameFn>
-  Optional<Result>
-  forTypeReference(TypeReferenceKind refKind, StoredPointer ref,
-                   const DescriptorFn &descriptorFn,
-                   const MetadataFn &metadataFn,
-                   const ClassNameFn &classNameFn) {
+  llvm::Optional<Result> forTypeReference(TypeReferenceKind refKind,
+                                          StoredPointer ref,
+                                          const DescriptorFn &descriptorFn,
+                                          const MetadataFn &metadataFn,
+                                          const ClassNameFn &classNameFn) {
     switch (refKind) {
     case TypeReferenceKind::IndirectTypeDescriptor: {
       StoredPointer descriptorAddress = 0;
@@ -1399,7 +1399,7 @@ public:
 
   /// Read a single generic type argument from a bound generic type
   /// metadata.
-  Optional<StoredPointer>
+  llvm::Optional<StoredPointer>
   readGenericArgFromMetadata(StoredPointer metadata, unsigned index) {
     auto Meta = readMetadata(metadata);
     if (!Meta)
@@ -1472,7 +1472,7 @@ public:
   }
 
   /// Given a remote pointer to class metadata, attempt to read its superclass.
-  Optional<StoredPointer>
+  llvm::Optional<StoredPointer>
   readOffsetToFirstCaptureFromMetadata(StoredPointer MetadataAddress) {
     auto meta = readMetadata(MetadataAddress);
     if (!meta || meta->getKind() != MetadataKind::HeapLocalVariable)
@@ -1481,12 +1481,13 @@ public:
     auto heapMeta = cast<TargetHeapLocalVariableMetadata<Runtime>>(meta);
     return heapMeta->OffsetToFirstCapture;
   }
-  
-  Optional<RemoteAbsolutePointer> readPointer(StoredPointer address) {
+
+  llvm::Optional<RemoteAbsolutePointer> readPointer(StoredPointer address) {
     return Reader->readPointer(RemoteAddress(address), sizeof(StoredPointer));
   }
-  
-  Optional<StoredPointer> readResolvedPointerValue(StoredPointer address) {
+
+  llvm::Optional<StoredPointer>
+  readResolvedPointerValue(StoredPointer address) {
     if (auto pointer = readPointer(address)) {
       if (!pointer->isResolved())
         return None;
@@ -1494,7 +1495,7 @@ public:
     }
     return None;
   }
-  
+
   template<typename T, typename U>
   RemoteAbsolutePointer resolvePointerField(RemoteRef<T> base,
                                             const U &field) {
@@ -1504,7 +1505,7 @@ public:
   }
 
   /// Given a remote pointer to class metadata, attempt to read its superclass.
-  Optional<RemoteAbsolutePointer>
+  llvm::Optional<RemoteAbsolutePointer>
   readCaptureDescriptorFromMetadata(StoredPointer MetadataAddress) {
     auto meta = readMetadata(MetadataAddress);
     if (!meta || meta->getKind() != MetadataKind::HeapLocalVariable)
@@ -1525,16 +1526,16 @@ protected:
                             RemoteRef<Base> base, const Field &field) {
     return (StoredPointer)base.resolveRelativeFieldData(field);
   }
-  
-  template<typename Base, typename Field>
-  Optional<RemoteAbsolutePointer> resolveRelativeIndirectableField(
-                            RemoteRef<Base> base, const Field &field) {
+
+  template <typename Base, typename Field>
+  llvm::Optional<RemoteAbsolutePointer>
+  resolveRelativeIndirectableField(RemoteRef<Base> base, const Field &field) {
     auto fieldRef = base.getField(field);
     int32_t offset;
     memcpy(&offset, fieldRef.getLocalBuffer(), sizeof(int32_t));
     
     if (offset == 0)
-      return Optional<RemoteAbsolutePointer>(nullptr);
+      return llvm::Optional<RemoteAbsolutePointer>(nullptr);
     bool indirect = offset & 1;
     offset &= ~1u;
     
@@ -1764,7 +1765,7 @@ private:
 
   /// Returns Optional(ParentContextDescriptorRef()) if there's no parent descriptor.
   /// Returns None if there was an error reading the parent descriptor.
-  Optional<ParentContextDescriptorRef>
+  llvm::Optional<ParentContextDescriptorRef>
   readParentContextDescriptor(ContextDescriptorRef base) {
     auto parentAddress = resolveRelativeIndirectableField(base, base->Parent);
     if (!parentAddress)
@@ -1798,9 +1799,9 @@ private:
   }
 
   /// Read the name from a module, type, or protocol context descriptor.
-  Optional<std::string> readContextDescriptorName(
+  llvm::Optional<std::string> readContextDescriptorName(
       ContextDescriptorRef descriptor,
-      Optional<TypeImportInfo<std::string>> &importInfo) {
+      llvm::Optional<TypeImportInfo<std::string>> &importInfo) {
     std::string name;
     auto context = descriptor.getLocalBuffer();
 
@@ -1964,11 +1965,10 @@ private:
   /// If we have a context whose parent context is an anonymous context
   /// that provides the local/private name for the current context,
   /// produce a mangled node describing the name of \c context.
-  Demangle::NodePointer
-  adoptAnonymousContextName(ContextDescriptorRef contextRef,
-                        Optional<ParentContextDescriptorRef> &parentContextRef,
-                        Demangler &dem,
-                        Demangle::NodePointer &outerNode) {
+  Demangle::NodePointer adoptAnonymousContextName(
+      ContextDescriptorRef contextRef,
+      llvm::Optional<ParentContextDescriptorRef> &parentContextRef,
+      Demangler &dem, Demangle::NodePointer &outerNode) {
     outerNode = nullptr;
 
     // Bail if there is no parent, or if the parent is in another image.
@@ -2016,7 +2016,7 @@ private:
       return nullptr;
 
     // Read the name of the current context.
-    Optional<TypeImportInfo<std::string>> importInfo;
+    llvm::Optional<TypeImportInfo<std::string>> importInfo;
     auto contextName = readContextDescriptorName(contextRef, importInfo);
     if (!contextName)
       return nullptr;
@@ -2133,7 +2133,7 @@ private:
     }
 
     Demangle::Node::Kind nodeKind;
-    Optional<TypeImportInfo<std::string>> importInfo;
+    llvm::Optional<TypeImportInfo<std::string>> importInfo;
 
     auto getContextName = [&]() -> bool {
       if (nameNode)

--- a/lib/Demangling/OldDemangler.cpp
+++ b/lib/Demangling/OldDemangler.cpp
@@ -29,9 +29,6 @@
 using namespace swift;
 using namespace Demangle;
 
-using llvm::Optional;
-using llvm::None;
-
 namespace {
   struct FindPtr {
     FindPtr(Node *v) : Target(v) {}
@@ -251,12 +248,12 @@ private:
     Parent->addChild(Child, Factory);
   }
   
-  Optional<Directness> demangleDirectness() {
+  llvm::Optional<Directness> demangleDirectness() {
     if (Mangled.nextIf('d'))
       return Directness::Direct;
     if (Mangled.nextIf('i'))
       return Directness::Indirect;
-    return None;
+    return llvm::None;
   }
 
   bool demangleNatural(Node::IndexType &num) {
@@ -288,13 +285,13 @@ private:
     return false;
   }
 
-  Optional<ValueWitnessKind> demangleValueWitnessKind() {
+  llvm::Optional<ValueWitnessKind> demangleValueWitnessKind() {
     char Code[2];
     if (!Mangled)
-      return None;
+      return llvm::None;
     Code[0] = Mangled.next();
     if (!Mangled)
-      return None;
+      return llvm::None;
     Code[1] = Mangled.next();
 
     StringRef CodeStr(Code, 2);
@@ -302,7 +299,7 @@ private:
   if (CodeStr == #MANGLING) return ValueWitnessKind::NAME;
 #include "swift/Demangling/ValueWitnessMangling.def"
 
-    return None;
+    return llvm::None;
   }
 
   NodePointer demangleGlobal() {
@@ -374,7 +371,7 @@ private:
 
     // Value witnesses.
     if (Mangled.nextIf('w')) {
-      Optional<ValueWitnessKind> w = demangleValueWitnessKind();
+      llvm::Optional<ValueWitnessKind> w = demangleValueWitnessKind();
       if (!w.hasValue())
         return nullptr;
       auto witness =
@@ -754,7 +751,7 @@ private:
     return demangleIdentifier();
   }
 
-  NodePointer demangleIdentifier(Optional<Node::Kind> kind = None) {
+  NodePointer demangleIdentifier(llvm::Optional<Node::Kind> kind = llvm::None) {
     if (!Mangled)
       return nullptr;
     

--- a/stdlib/include/llvm/ADT/STLExtras.h
+++ b/stdlib/include/llvm/ADT/STLExtras.h
@@ -736,8 +736,9 @@ static Iter next_or_end(const Iter &I, const Iter &End) {
 }
 
 template <typename Iter>
-static auto deref_or_none(const Iter &I, const Iter &End) -> llvm::Optional<
-    std::remove_const_t<std::remove_reference_t<decltype(*I)>>> {
+static auto deref_or_none(const Iter &I, const Iter &End)
+    -> __swift::__runtime::llvm::Optional<
+        std::remove_const_t<std::remove_reference_t<decltype(*I)>>> {
   if (I == End)
     return None;
   return *I;

--- a/stdlib/public/runtime/MetadataCache.h
+++ b/stdlib/public/runtime/MetadataCache.h
@@ -230,7 +230,7 @@ public:
 
   /// If an entry already exists, await it; otherwise report failure.
   template <class KeyType, class... ArgTys>
-  Optional<Status> tryAwaitExisting(KeyType key, ArgTys &&...args) {
+  llvm::Optional<Status> tryAwaitExisting(KeyType key, ArgTys &&... args) {
     EntryType *entry = Storage.find(key);
     if (!entry) return None;
     return entry->await(Storage.getConcurrency(),
@@ -324,8 +324,8 @@ public:
   }
 
   template <class... ArgTys>
-  Optional<Status> beginAllocation(ConcurrencyControl &concurrency,
-                                   ArgTys &&...args) {
+  llvm::Optional<Status> beginAllocation(ConcurrencyControl &concurrency,
+                                         ArgTys &&... args) {
     // Delegate to the implementation class.
     ValueType origValue = asImpl().allocate(std::forward<ArgTys>(args)...);
 
@@ -849,9 +849,9 @@ public:
 
   /// Perform the allocation operation.
   template <class... Args>
-  Optional<Status>
-  beginAllocation(ConcurrencyControl &concurrency, MetadataRequest request,
-                  Args &&...args) {
+  llvm::Optional<Status> beginAllocation(ConcurrencyControl &concurrency,
+                                         MetadataRequest request,
+                                         Args &&... args) {
     // Returning a non-None value here will preempt initialization, so we
     // should only do it if we're reached PrivateMetadataState::Complete.
 

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -550,7 +550,7 @@ swift::_contextDescriptorMatchesMangling(const ContextDescriptor *context,
 
     default:
       if (auto type = llvm::dyn_cast<TypeContextDescriptor>(context)) {
-        Optional<ParsedTypeIdentity> _identity;
+        llvm::Optional<ParsedTypeIdentity> _identity;
         auto getIdentity = [&]() -> const ParsedTypeIdentity & {
           if (_identity) return *_identity;
           _identity = ParsedTypeIdentity::parse(type);
@@ -892,7 +892,7 @@ public:
 
 #pragma mark Metadata lookup via mangled name
 
-Optional<unsigned>
+llvm::Optional<unsigned>
 swift::_depthIndexToFlatIndex(unsigned depth, unsigned index,
                               llvm::ArrayRef<unsigned> paramCounts) {
   // Out-of-bounds depth.
@@ -1054,9 +1054,8 @@ namespace {
 
 /// Find the offset of the protocol requirement for an associated type with
 /// the given name in the given protocol descriptor.
-Optional<const ProtocolRequirement *> findAssociatedTypeByName(
-                                        const ProtocolDescriptor *protocol,
-                                        StringRef name) {
+llvm::Optional<const ProtocolRequirement *>
+findAssociatedTypeByName(const ProtocolDescriptor *protocol, StringRef name) {
   // If we don't have associated type names, there's nothing to do.
   const char *associatedTypeNamesPtr = protocol->AssociatedTypeNames.get();
   if (!associatedTypeNamesPtr) return None;
@@ -1318,13 +1317,15 @@ public:
     return BuiltType();
   }
 
-  BuiltType createMetatypeType(BuiltType instance,
-              Optional<Demangle::ImplMetatypeRepresentation> repr=None) const {
+  BuiltType createMetatypeType(
+      BuiltType instance,
+      llvm::Optional<Demangle::ImplMetatypeRepresentation> repr = None) const {
     return swift_getMetatypeMetadata(instance);
   }
 
-  BuiltType createExistentialMetatypeType(BuiltType instance,
-              Optional<Demangle::ImplMetatypeRepresentation> repr=None) const {
+  BuiltType createExistentialMetatypeType(
+      BuiltType instance,
+      llvm::Optional<Demangle::ImplMetatypeRepresentation> repr = None) const {
     return swift_getExistentialMetatypeMetadata(instance);
   }
 
@@ -1389,7 +1390,7 @@ public:
       Demangle::ImplParameterConvention calleeConvention,
       llvm::ArrayRef<Demangle::ImplFunctionParam<BuiltType>> params,
       llvm::ArrayRef<Demangle::ImplFunctionResult<BuiltType>> results,
-      Optional<Demangle::ImplFunctionResult<BuiltType>> errorResult,
+      llvm::Optional<Demangle::ImplFunctionResult<BuiltType>> errorResult,
       ImplFunctionTypeFlags flags) {
     // We can't realize the metadata for a SILFunctionType.
     return BuiltType();
@@ -1956,7 +1957,7 @@ SubstGenericParametersFromWrittenArgs::getWitnessTable(const Metadata *type,
 
 /// Demangle the given type name to a generic parameter reference, which
 /// will be returned as (depth, index).
-static Optional<std::pair<unsigned, unsigned>>
+static llvm::Optional<std::pair<unsigned, unsigned>>
 demangleToGenericParamRef(StringRef typeName) {
   StackAllocatedDemangler<1024> demangler;
   NodePointer node = demangler.demangleType(typeName);


### PR DESCRIPTION
This removes the last reference to the `llvm::` namespace in the
standard library.  All uses of the LLVMSupport library now are
namespaced into the `__swift::__runtime` namespace.  This allows us to
incrementally vend the LLVMSupport library and make the separation
explicit.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
