### PR TITLE
[stdlib] Make non-native ArrayBuffer.capacity smaller

### DIFF
--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -510,7 +510,6 @@ extension _ArrayBuffer {
 
   @inlinable
   internal var _nonNative: _CocoaArrayWrapper {
-    @inline(__always)
     get {
       _internalInvariant(_isClassOrObjCExistential(Element.self))
       return _CocoaArrayWrapper(_storage.objCInstance)

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -315,7 +315,7 @@ extension _ArrayBuffer {
   /// The number of elements the buffer can store without reallocation.
   @inlinable
   internal var capacity: Int {
-    return _fastPath(_isNative) ? _native.capacity : _nonNative.count
+    return _fastPath(_isNative) ? _native.capacity : _nonNative.endIndex
   }
 
   @inlinable


### PR DESCRIPTION
Similar to #28486 in motivation.
Before this change `count` got lowered to multiple `endIndex` calls

Also remove @inline(always) from _nonNative getter.

Fixes rdar://46702232
