### PR TITLE
[5.3][AST] Restore getSourceRange() on DefaultArgumentExpr

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4133,9 +4133,7 @@ public:
       DefaultArgsOwner(defaultArgsOwner), ParamIndex(paramIndex), Loc(loc),
       ContextOrCallerSideExpr(dc) { }
 
-  SourceRange getSourceRange() const { return {}; }
-
-  SourceLoc getArgumentListLoc() const { return Loc; }
+  SourceRange getSourceRange() const { return Loc; }
 
   ConcreteDeclRef getDefaultArgsOwner() const {
     return DefaultArgsOwner;

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1244,6 +1244,10 @@ SourceRange TupleExpr::getSourceRange() const {
     } else {
       // Scan backwards for a valid source loc.
       for (Expr *expr : llvm::reverse(getElements())) {
+        // Default arguments are located at the start of their parent tuple, so
+        // skip over them.
+        if (isa<DefaultArgumentExpr>(expr))
+          continue;
         end = expr->getEndLoc();
         if (end.isValid()) {
           break;

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -789,7 +789,7 @@ Expr *CallerSideDefaultArgExprRequest::evaluate(
 
   // Re-create the default argument using the location info of the call site.
   auto *initExpr =
-      synthesizeCallerSideDefault(param, defaultExpr->getArgumentListLoc());
+      synthesizeCallerSideDefault(param, defaultExpr->getLoc());
   auto *dc = defaultExpr->ContextOrCallerSideExpr.get<DeclContext *>();
   assert(dc && "Expected a DeclContext before type-checking caller-side arg");
 

--- a/test/DebugInfo/callexpr.swift
+++ b/test/DebugInfo/callexpr.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend %s -g -emit-ir -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -g -emit-ir -o - | %FileCheck --check-prefix=CHECK2 %s
 
 func markUsed<T>(_ t: T) {}
 
@@ -14,4 +15,12 @@ let r = foo(
             foo(2, 42)  // CHECK: ![[ARG2]] = !DILocation(line: [[@LINE]],
            )            // CHECK: ![[OUTER]] = !DILocation(line: [[@LINE-3]],
 markUsed(r)
+
+struct MyType {}
+func bar(x: MyType = MyType()) {}
+
+// CHECK2: call {{.*}}MyType{{.*}}, !dbg ![[DEFAULTARG:.*]]
+// CHECK2: call {{.*}}bar{{.*}}, !dbg ![[BARCALL:.*]]
+bar() // CHECK2: ![[DEFAULTARG]] = !DILocation(line: [[@LINE]], column: 4
+      // CHECK2: ![[BARCALL]] = !DILocation(line: [[@LINE-1]], column: 1
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/31861

- **Explanation**:
This restores getSourceRange() on DefaultArgumentExpr after it was removed in
https://github.com/apple/swift/pull/31184. While source tooling and diagnostics don't care about default arg expression locations (nothing can reference them and any issues in them should be diagnosed on the callee rather than caller side), their locations are output in the debug info, so their removal resulted in a debug info regression (rdar://problem/63195504).

    It was originally removed to solve the issues it was causing when computing the source range of TupleExprs containing defaulted arguments after a trailing closure. The implementation assumes its argument expressions with valid source locations appear in source order, which default argument expressions violate (they point to the start of their parent tuple expression). This change works around that issue with a more targeted fix instead by updating TupleExpr::getSourceRange() to simply ignore DefaultArgExprs.

- **Scope of issue**: This results in having no debug info for frames corresponding to default argument expressions.
- **Origination**: This regressed due to a part of the fix to stop tuple expressions being incorrectly flagged as implicit when they contained defaulted arguments: https://github.com/apple/swift/pull/31184 (rdar 62118957)
- **Risk**: Low. This restores the previous functionality and adds a more targeted fix for the original issue it was resolving.
- **Testing**: Added a regression test to catch the debug info regression in future. All regression tests pass.
- **Reviewer**: @xedin (on the master PR)


Resolves rdar://problem/63195504