### PR TITLE
[driver/sourcekit] Avoid creating temporary output files in TMPDIR

### DIFF
--- a/include/swift/Driver/FrontendUtil.h
+++ b/include/swift/Driver/FrontendUtil.h
@@ -33,6 +33,9 @@ namespace driver {
 /// \param Action Called with the list of frontend arguments if there were no
 /// errors in processing \p ArgList. This is a callback rather than a return
 /// value to avoid copying the arguments more than necessary.
+/// \param ForceNoOutputs If true, override the output mode to "-typecheck" and
+/// produce no outputs. For example, this disables "-emit-module" and "-c" and
+/// prevents the creation of temporary files.
 ///
 /// \returns True on error, or if \p Action returns true.
 ///
@@ -40,7 +43,8 @@ namespace driver {
 /// suitable for use in REPL or immediate modes.
 bool getSingleFrontendInvocationFromDriverArguments(
     ArrayRef<const char *> ArgList, DiagnosticEngine &Diags,
-    llvm::function_ref<bool(ArrayRef<const char *> FrontendArgs)> Action);
+    llvm::function_ref<bool(ArrayRef<const char *> FrontendArgs)> Action,
+    bool ForceNoOutputs = false);
 
 } // end namespace driver
 } // end namespace swift

--- a/include/swift/Option/Options.h
+++ b/include/swift/Option/Options.h
@@ -36,6 +36,7 @@ namespace options {
     SwiftIndentOption = (1 << 11),
     ArgumentIsPath = (1 << 12),
     ModuleInterfaceOption = (1 << 13),
+    SupplementaryOutput = (1 << 14),
   };
 
   enum ID {

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -51,6 +51,10 @@ def ArgumentIsPath : OptionFlag;
 // and read/parsed from there when reconstituting a .swiftmodule from it.
 def ModuleInterfaceOption : OptionFlag;
 
+// The option causes the output of a supplementary output, or is the path option
+// for a supplementary output. E.g., `-emit-module` and `-emit-module-path`.
+def SupplementaryOutput : OptionFlag;
+
 /////////
 // Options
 
@@ -314,21 +318,24 @@ def profile_stats_entities: Flag<["-"], "profile-stats-entities">,
   HelpText<"Profile changes to stats in -stats-output-dir, subdivided by source entity">;
 
 def emit_dependencies : Flag<["-"], "emit-dependencies">,
-  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
+         SupplementaryOutput]>,
   HelpText<"Emit basic Make-compatible dependencies files">;
 def track_system_dependencies : Flag<["-"], "track-system-dependencies">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Track system dependencies while emitting Make-style dependencies">;
 
 def emit_loaded_module_trace : Flag<["-"], "emit-loaded-module-trace">,
-  Flags<[FrontendOption, NoInteractiveOption]>,
+  Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput]>,
   HelpText<"Emit a JSON file containing information about what modules were loaded">;
 def emit_loaded_module_trace_path : Separate<["-"], "emit-loaded-module-trace-path">,
-  Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath]>,
+  Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath,
+         SupplementaryOutput]>,
   HelpText<"Emit the loaded module trace JSON to <path>">,
   MetaVarName<"<path>">;
 def emit_loaded_module_trace_path_EQ : Joined<["-"], "emit-loaded-module-trace-path=">,
-  Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath]>,
+  Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath,
+         SupplementaryOutput]>,
   Alias<emit_loaded_module_trace_path>;
 def emit_cross_import_remarks : Flag<["-"], "Rcross-import">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
@@ -336,27 +343,32 @@ def emit_cross_import_remarks : Flag<["-"], "Rcross-import">,
 
 def emit_tbd : Flag<["-"], "emit-tbd">,
   HelpText<"Emit a TBD file">,
-  Flags<[FrontendOption, NoInteractiveOption]>;
+  Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput]>;
 def emit_tbd_path : Separate<["-"], "emit-tbd-path">,
-  Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath]>,
+  Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath,
+         SupplementaryOutput]>,
   HelpText<"Emit the TBD file to <path>">,
   MetaVarName<"<path>">;
 def emit_tbd_path_EQ : Joined<["-"], "emit-tbd-path=">,
-  Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath]>,
+  Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath,
+         SupplementaryOutput]>,
   Alias<emit_tbd_path>;
 def embed_tbd_for_module : Separate<["-"], "embed-tbd-for-module">,
   Flags<[FrontendOption]>,
   HelpText<"Embed symbols from the module in the emitted tbd file">;
 
 def serialize_diagnostics : Flag<["-"], "serialize-diagnostics">,
-  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
+         SupplementaryOutput]>,
   HelpText<"Serialize diagnostics in a binary format">;
 def serialize_diagnostics_path : Separate<["-"], "serialize-diagnostics-path">,
-  Flags<[FrontendOption, NoBatchOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
+  Flags<[FrontendOption, NoBatchOption, DoesNotAffectIncrementalBuild,
+         ArgumentIsPath, SupplementaryOutput]>,
   HelpText<"Emit a serialized diagnostics file to <path>">,
   MetaVarName<"<path>">;
 def serialize_diagnostics_path_EQ: Joined<["-"], "serialize-diagnostics-path=">,
-  Flags<[FrontendOption, NoBatchOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
+  Flags<[FrontendOption, NoBatchOption, DoesNotAffectIncrementalBuild,
+         ArgumentIsPath, SupplementaryOutput]>,
   Alias<serialize_diagnostics_path>;
 def color_diagnostics : Flag<["-"], "color-diagnostics">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
@@ -403,32 +415,34 @@ def autolink_force_load : Flag<["-"], "autolink-force-load">,
   HelpText<"Force ld to link against this module even if no symbols are used">;
 
 def emit_module : Flag<["-"], "emit-module">,
-  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
+         SupplementaryOutput]>,
   HelpText<"Emit an importable module">;
 def emit_module_path : Separate<["-"], "emit-module-path">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
-         ArgumentIsPath]>,
+         ArgumentIsPath, SupplementaryOutput]>,
   HelpText<"Emit an importable module to <path>">,
   MetaVarName<"<path>">;
 def emit_module_path_EQ : Joined<["-"], "emit-module-path=">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
-         ArgumentIsPath]>,
+         ArgumentIsPath, SupplementaryOutput]>,
   Alias<emit_module_path>;
 
 def emit_module_interface :
   Flag<["-"], "emit-module-interface">,
-  Flags<[NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  Flags<[NoInteractiveOption, DoesNotAffectIncrementalBuild,
+         SupplementaryOutput]>,
   HelpText<"Output module interface file">;
 def emit_module_interface_path :
   Separate<["-"], "emit-module-interface-path">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
-         ArgumentIsPath]>,
+         ArgumentIsPath, SupplementaryOutput]>,
   MetaVarName<"<path>">, HelpText<"Output module interface file to <path>">;
 
 def emit_private_module_interface_path :
   Separate<["-"], "emit-private-module-interface-path">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden,
-         DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
+         DoesNotAffectIncrementalBuild, ArgumentIsPath, SupplementaryOutput]>,
   MetaVarName<"<path>">, HelpText<"Output private module interface file to <path>">;
 
 def avoid_emit_module_source_info :
@@ -439,25 +453,27 @@ def avoid_emit_module_source_info :
 def emit_module_source_info_path :
   Separate<["-"], "emit-module-source-info-path">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
-         ArgumentIsPath]>,
+         ArgumentIsPath, SupplementaryOutput]>,
   MetaVarName<"<path>">, HelpText<"Output module source info file to <path>">;
 
 def emit_parseable_module_interface :
   Flag<["-"], "emit-parseable-module-interface">,
   Alias<emit_module_interface>,
-  Flags<[NoInteractiveOption, HelpHidden, DoesNotAffectIncrementalBuild]>;
+  Flags<[NoInteractiveOption, HelpHidden, DoesNotAffectIncrementalBuild,
+         SupplementaryOutput]>;
 def emit_parseable_module_interface_path :
   Separate<["-"], "emit-parseable-module-interface-path">,
   Alias<emit_module_interface_path>,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
-         HelpHidden, ArgumentIsPath]>;
+         HelpHidden, ArgumentIsPath, SupplementaryOutput]>;
 
 def emit_objc_header : Flag<["-"], "emit-objc-header">,
-  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
+         SupplementaryOutput]>,
   HelpText<"Emit an Objective-C header file">;
 def emit_objc_header_path : Separate<["-"], "emit-objc-header-path">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
-         ArgumentIsPath]>,
+         ArgumentIsPath, SupplementaryOutput]>,
   MetaVarName<"<path>">, HelpText<"Emit an Objective-C header file to <path>">;
 
 def static : Flag<["-"], "static">,

--- a/lib/Driver/FrontendUtil.cpp
+++ b/lib/Driver/FrontendUtil.cpp
@@ -25,7 +25,8 @@ using namespace swift::driver;
 
 bool swift::driver::getSingleFrontendInvocationFromDriverArguments(
     ArrayRef<const char *> Argv, DiagnosticEngine &Diags,
-    llvm::function_ref<bool(ArrayRef<const char *> FrontendArgs)> Action) {
+    llvm::function_ref<bool(ArrayRef<const char *> FrontendArgs)> Action,
+    bool ForceNoOutputs) {
   SmallVector<const char *, 16> Args;
   Args.push_back("<swiftc>"); // FIXME: Remove dummy argument.
   Args.insert(Args.end(), Argv.begin(), Argv.end());
@@ -56,6 +57,25 @@ bool swift::driver::getSingleFrontendInvocationFromDriverArguments(
     TheDriver.parseArgStrings(ArrayRef<const char *>(Args).slice(1));
   if (Diags.hadAnyError())
     return true;
+
+  if (ForceNoOutputs) {
+    // Clear existing output modes.
+    ArgList->eraseArg(options::OPT_modes_Group);
+    // Disable other output options that conflict with -typecheck.
+    ArgList->eraseArg(options::OPT_emit_module);
+    ArgList->eraseArg(options::OPT_emit_module_path);
+    ArgList->eraseArg(options::OPT_emit_module_source_info_path);
+    ArgList->eraseArg(options::OPT_emit_module_interface);
+    ArgList->eraseArg(options::OPT_emit_module_interface_path);
+    ArgList->eraseArg(options::OPT_emit_objc_header);
+    ArgList->eraseArg(options::OPT_emit_objc_header_path);
+
+    unsigned index = ArgList->MakeIndex("-typecheck");
+    // Takes ownership of the Arg.
+    ArgList->append(new llvm::opt::Arg(
+        TheDriver.getOpts().getOption(options::OPT_typecheck),
+        ArgList->getArgString(index), index));
+  }
 
   std::unique_ptr<ToolChain> TC = TheDriver.buildToolChain(*ArgList);
   if (Diags.hadAnyError())

--- a/lib/Driver/FrontendUtil.cpp
+++ b/lib/Driver/FrontendUtil.cpp
@@ -59,16 +59,11 @@ bool swift::driver::getSingleFrontendInvocationFromDriverArguments(
     return true;
 
   if (ForceNoOutputs) {
-    // Clear existing output modes.
+    // Clear existing output modes and supplementary outputs.
     ArgList->eraseArg(options::OPT_modes_Group);
-    // Disable other output options that conflict with -typecheck.
-    ArgList->eraseArg(options::OPT_emit_module);
-    ArgList->eraseArg(options::OPT_emit_module_path);
-    ArgList->eraseArg(options::OPT_emit_module_source_info_path);
-    ArgList->eraseArg(options::OPT_emit_module_interface);
-    ArgList->eraseArg(options::OPT_emit_module_interface_path);
-    ArgList->eraseArg(options::OPT_emit_objc_header);
-    ArgList->eraseArg(options::OPT_emit_objc_header_path);
+    ArgList->eraseArgIf([](const llvm::opt::Arg *A) {
+      return A && A->getOption().hasFlag(options::SupplementaryOutput);
+    });
 
     unsigned index = ArgList->MakeIndex("-typecheck");
     // Takes ownership of the Arg.

--- a/test/Driver/createCompilerInvocation.swift
+++ b/test/Driver/createCompilerInvocation.swift
@@ -7,3 +7,29 @@
 
 // CHECK-FAIL: error: unable to create a CompilerInvocation
 // CHECK-NOWARN-NOT: warning
+
+// RUN: %swift-ide-test_plain -test-createCompilerInvocation -module-name foo -emit-module -emit-module-path %t/foo.swiftmodule -emit-objc-header -emit-objc-header-path %t/foo.h -enable-library-evolution -emit-module-interface -emit-module-interface-path %t/foo.swiftinterface -emit-library %s 2>&1 | %FileCheck %s --check-prefix=NORMAL_ARGS --implicit-check-not="error: "
+// NORMAL_ARGS: Frontend Arguments BEGIN
+// NORMAL_ARGS-DAG: -o{{$}}
+// NORMAL_ARGS-DAG: foo-{{[a-z0-9]+}}.o
+// NORMAL_ARGS-DAG: -c{{$}}
+// NORMAL_ARGS-DAG: -module-name
+// NORMAL_ARGS-DAG: -emit-module-path
+// NORMAL_ARGS-DAG: -emit-module-doc-path
+// NORMAL_ARGS-DAG: -emit-module-source-info-path
+// NORMAL_ARGS-DAG: -emit-module-interface-path
+// NORMAL_ARGS-DAG: -emit-objc-header-path
+// NORMAL_ARGS: Frontend Arguments END
+
+// RUN: %swift-ide-test_plain -test-createCompilerInvocation -force-no-outputs -module-name foo -emit-module -emit-module-path %t/foo.swiftmodule -emit-objc-header -emit-objc-header-path %t/foo.h -enable-library-evolution -emit-module-interface -emit-module-interface-path %t/foo.swiftinterface -emit-library %s 2>&1 > %t.nooutput_args
+// RUN: %FileCheck %s --check-prefix=NOOUTPUT_ARGS --implicit-check-not="error: " < %t.nooutput_args
+// RUN: %FileCheck %s --check-prefix=NOOUTPUT_ARGS_NEG --implicit-check-not="error: " < %t.nooutput_args
+// NOOUTPUT_ARGS_NEG-NOT: -o{{$}}
+// NOOUTPUT_ARGS_NEG-NOT: foo-{{[a-z0-9]+}}.o
+// NOOUTPUT_ARGS_NEG-NOT: -o{{$}}
+// NOOUTPUT_ARGS_NEG-NOT: -emit
+
+// NOOUTPUT_ARGS: Frontend Arguments BEGIN
+// NOOUTPUT_ARGS-DAG: -typecheck
+// NOOUTPUT_ARGS-DAG: -module-name
+// NOOUTPUT_ARGS: Frontend Arguments END

--- a/test/Driver/createCompilerInvocation.swift
+++ b/test/Driver/createCompilerInvocation.swift
@@ -8,7 +8,9 @@
 // CHECK-FAIL: error: unable to create a CompilerInvocation
 // CHECK-NOWARN-NOT: warning
 
-// RUN: %swift-ide-test_plain -test-createCompilerInvocation -module-name foo -emit-module -emit-module-path %t/foo.swiftmodule -emit-objc-header -emit-objc-header-path %t/foo.h -enable-library-evolution -emit-module-interface -emit-module-interface-path %t/foo.swiftinterface -emit-library %s 2>&1 | %FileCheck %s --check-prefix=NORMAL_ARGS --implicit-check-not="error: "
+// RUN: %swift-ide-test_plain -test-createCompilerInvocation \
+// RUN:   -module-name foo -emit-module -emit-module-path %t/foo.swiftmodule -emit-objc-header -emit-objc-header-path %t/foo.h -enable-library-evolution -emit-module-interface -emit-module-interface-path %t/foo.swiftinterface -emit-library -emit-tbd -emit-tbd-path %t/foo.tbd -emit-dependencies -serialize-diagnostics %s \
+// RUN:   2>&1 | %FileCheck %s --check-prefix=NORMAL_ARGS --implicit-check-not="error: "
 // NORMAL_ARGS: Frontend Arguments BEGIN
 // NORMAL_ARGS-DAG: -o{{$}}
 // NORMAL_ARGS-DAG: foo-{{[a-z0-9]+}}.o
@@ -19,15 +21,20 @@
 // NORMAL_ARGS-DAG: -emit-module-source-info-path
 // NORMAL_ARGS-DAG: -emit-module-interface-path
 // NORMAL_ARGS-DAG: -emit-objc-header-path
+// NORMAL_ARGS-DAG: -emit-tbd-path
+// NORMAL_ARGS-DAG: -serialize-diagnostics-path
 // NORMAL_ARGS: Frontend Arguments END
 
-// RUN: %swift-ide-test_plain -test-createCompilerInvocation -force-no-outputs -module-name foo -emit-module -emit-module-path %t/foo.swiftmodule -emit-objc-header -emit-objc-header-path %t/foo.h -enable-library-evolution -emit-module-interface -emit-module-interface-path %t/foo.swiftinterface -emit-library %s 2>&1 > %t.nooutput_args
+// RUN: %swift-ide-test_plain -test-createCompilerInvocation -force-no-outputs \
+// RUN:   -module-name foo -emit-module -emit-module-path %t/foo.swiftmodule -emit-objc-header -emit-objc-header-path %t/foo.h -enable-library-evolution -emit-module-interface -emit-module-interface-path %t/foo.swiftinterface -emit-library -emit-tbd -emit-tbd-path %t/foo.tbd -emit-dependencies -serialize-diagnostics %s \
+// RUN:   2>&1 > %t.nooutput_args
 // RUN: %FileCheck %s --check-prefix=NOOUTPUT_ARGS --implicit-check-not="error: " < %t.nooutput_args
 // RUN: %FileCheck %s --check-prefix=NOOUTPUT_ARGS_NEG --implicit-check-not="error: " < %t.nooutput_args
 // NOOUTPUT_ARGS_NEG-NOT: -o{{$}}
 // NOOUTPUT_ARGS_NEG-NOT: foo-{{[a-z0-9]+}}.o
 // NOOUTPUT_ARGS_NEG-NOT: -o{{$}}
 // NOOUTPUT_ARGS_NEG-NOT: -emit
+// NOOUTPUT_ARGS_NEG-NOT: -serialize-diagnostics
 
 // NOOUTPUT_ARGS: Frontend Arguments BEGIN
 // NOOUTPUT_ARGS-DAG: -typecheck

--- a/test/SourceKit/Misc/no-driver-outputs.swift
+++ b/test/SourceKit/Misc/no-driver-outputs.swift
@@ -1,0 +1,29 @@
+// REQUIRES: shell
+
+// RUN: %empty-directory(%t)
+// RUN: env TMPDIR=%t __XPC_TMPDIR=%t %sourcekitd-test -req=syntax-map %s 
+// RUN: ls %t/ | count 0
+
+// RUN: %empty-directory(%t)
+// RUN: env TMPDIR=%t __XPC_TMPDIR=%t %sourcekitd-test -req=syntax-map %s -- %s
+// RUN: ls %t/ | count 0
+
+// RUN: %empty-directory(%t)
+// RUN: env TMPDIR=%t __XPC_TMPDIR=%t %sourcekitd-test -req=syntax-map %s -- %s -c -o %t/foo.o
+// RUN: ls %t/ | count 0
+
+// RUN: %empty-directory(%t)
+// RUN: env TMPDIR=%t __XPC_TMPDIR=%t %sourcekitd-test -req=sema %s -- %s
+// RUN: ls %t/ | count 0
+
+// RUN: %empty-directory(%t)
+// RUN: env TMPDIR=%t __XPC_TMPDIR=%t %sourcekitd-test -req=sema %s -- %s -c -o %t/foo.o
+// RUN: ls %t/ | count 0
+
+// RUN: %empty-directory(%t)
+// RUN: env TMPDIR=%t __XPC_TMPDIR=%t %sourcekitd-test -req=sema %s -- %s -emit-module -module-name main -emit-module-path %t/main.swiftmodule -emit-module-interface -enable-library-evolution -emit-module-interface-path %t/main.swiftinterface -emit-objc-header -emit-objc-header-path %t/main.h -c -o %t/foo.o
+// RUN: ls %t/ | count 0
+
+// RUN: %empty-directory(%t)
+// RUN: env TMPDIR=%t __XPC_TMPDIR=%t %sourcekitd-test -req=sema %s -- %s -emit-module -module-name main -emit-module-path %t/main.swiftmodule -emit-executable -o %t/foo
+// RUN: ls %t/ | count 0

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -507,7 +507,7 @@ bool SwiftASTManager::initCompilerInvocation(
   bool HadError = driver::getSingleFrontendInvocationFromDriverArguments(
       Args, Diags, [&](ArrayRef<const char *> FrontendArgs) {
     return Invocation.parseArgs(FrontendArgs, Diags);
-  });
+  }, /*ForceNoOutputs=*/true);
 
   // Remove the StreamDiagConsumer as it's no longer needed.
   Diags.removeConsumer(DiagConsumer);

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -3223,7 +3223,7 @@ static int doPrintUSRs(const CompilerInvocation &InitInvok,
   return 0;
 }
 
-static int doTestCreateCompilerInvocation(ArrayRef<const char *> Args) {
+static int doTestCreateCompilerInvocation(ArrayRef<const char *> Args, bool ForceNoOutputs) {
   PrintingDiagnosticConsumer PDC;
   SourceManager SM;
   DiagnosticEngine Diags(SM);
@@ -3232,8 +3232,13 @@ static int doTestCreateCompilerInvocation(ArrayRef<const char *> Args) {
   CompilerInvocation CI;
   bool HadError = driver::getSingleFrontendInvocationFromDriverArguments(
       Args, Diags, [&](ArrayRef<const char *> FrontendArgs) {
+    llvm::outs() << "Frontend Arguments BEGIN\n";
+    for (const char *arg : FrontendArgs) {
+      llvm::outs() << arg << "\n";
+    }
+    llvm::outs() << "Frontend Arguments END\n";
     return CI.parseArgs(FrontendArgs, Diags);
-  });
+  }, ForceNoOutputs);
 
   if (HadError) {
     llvm::errs() << "error: unable to create a CompilerInvocation\n";
@@ -3271,8 +3276,13 @@ int main(int argc, char *argv[]) {
     // llvm::cl::ParseCommandLineOptions.
     StringRef FirstArg(argv[1]);
     if (FirstArg == "-test-createCompilerInvocation") {
+      bool ForceNoOutputs = false;
       ArrayRef<const char *> Args(argv + 2, argc - 2);
-      return doTestCreateCompilerInvocation(Args);
+      if (argc > 2 && StringRef(argv[2]) == "-force-no-outputs") {
+        ForceNoOutputs = true;
+        Args = Args.drop_front();
+      }
+      return doTestCreateCompilerInvocation(Args, ForceNoOutputs);
     }
   }
 


### PR DESCRIPTION
When producing frontend arguments for sourcekitd, force the output mode
to -typecheck so that we do not create any temporary output files in the
driver. Previously, any sourcekitd operation that created a compiler
invocation would create 0-sized .o file inside $TMPDIR that would never
be cleaned up.

The new swift-driver project handles temporaries much better as
VirtualPath, and should not need this approach.

rdar://62366123