### PR TITLE
[Property Wrappers] Adjust composed property wrapper constraint generation

### DIFF
--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -219,7 +219,7 @@ struct MultipleWrappers {
   // attempting to splice a 'wrappedValue:' argument into the call to Wrapper's
   // init, but it doesn't have a matching init. We're then attempting to access
   // the nested 'wrappedValue', but Wrapper's 'wrappedValue' is Int.
-  @Wrapper(stored: 17) // expected-error{{value of type 'Int' has no member 'wrappedValue'}}
+  @Wrapper(stored: 17) // expected-error{{cannot convert value of type 'Int' to expected argument type 'WrapperWithInitialValue<Int>'}}
   @WrapperWithInitialValue // expected-error{{extra argument 'wrappedValue' in call}}
   var x: Int = 17
 
@@ -1067,6 +1067,51 @@ struct TestComposition {
     _p3 = d // expected-error{{cannot assign value of type 'Double' to type 'WrapperD<WrapperE<Int?>, Int, String>'}}
     // expected-error@-1 {{cannot assign to property: 'self' is immutable}}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Property wrapper composition type inference
+// ---------------------------------------------------------------------------
+
+protocol DefaultValue {
+  static var defaultValue: Self { get }
+}
+
+extension Int: DefaultValue {
+  static var defaultValue: Int { 0 }
+}
+
+struct TestCompositionTypeInference {
+  @propertyWrapper
+  struct A<Value: DefaultValue> {
+    var wrappedValue: Value
+
+    init(wrappedValue: Value = .defaultValue, key: String) {
+      self.wrappedValue = wrappedValue
+    }
+  }
+
+  @propertyWrapper
+  struct B<Value: DefaultValue>: DefaultValue {
+    var wrappedValue: Value
+
+    init(wrappedValue: Value = .defaultValue) {
+      self.wrappedValue = wrappedValue
+    }
+
+    static var defaultValue: B<Value> { B() }
+  }
+
+  // All of these are okay
+
+  @A(key: "b") @B
+  var a: Int = 0
+
+  @A(key: "b") @B
+  var b: Int
+
+  @A(key: "c") @B @B
+  var c: Int
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
When generating constraints for composed property wrappers, equate the former wrappedValue type with the current wrapper type rather than generating value member constraints.

Without connecting a wrappedValue type with the subsequent wrapper type, the constraint system couldn't infer types in some cases where the `wrappedValue` argument to the outermost wrapper init is defaulted.

This change also makes another step toward unifying how property wrapper backing types are computed. The code in `generateWrappedPropertyTypeConstraints` is now very similar to the computation of the property wrapper backing type in the absence of an initial value/default initialization in `PropertyWrapperBackingPropertyTypeRequest`. I intend to remove the duplication in a follow-up refactoring, which will also improve some diagnostics when the wrapped property has an incompatible type.

Resolves: rdar://problem/59740181
Resolves: [SR-12250](https://bugs.swift.org/browse/SR-12250)