### PR TITLE
Fix NULL deref for invalid mangled input

### DIFF
--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -2019,6 +2019,8 @@ NodePointer Demangler::demangleArchetype() {
     if (!demangleBoundGenerics(boundGenericArgs, retroactiveConformances))
       return nullptr;
     auto Name = popNode();
+    if (!Name)
+      return nullptr;
     auto opaque = createWithChildren(Node::Kind::OpaqueType, Name,
                                    createNode(Node::Kind::Index, index));
     auto boundGenerics = createNode(Node::Kind::TypeList);

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -358,3 +358,4 @@ $sSo17OS_dispatch_queueC4sync7executeyyyXE_tFTOTA ---> {T:$sSo17OS_dispatch_queu
 $sxq_Idgnr_D ---> @differentiable @callee_guaranteed (@in_guaranteed A) -> (@out B)
 $sxq_Ilgnr_D ---> @differentiable(linear) @callee_guaranteed (@in_guaranteed A) -> (@out B)
 $sS3fIedgyywd_D ---> @escaping @differentiable @callee_guaranteed (@unowned Swift.Float, @unowned @noDerivative Swift.Float) -> (@unowned Swift.Float)
+$syQo ---> $syQo


### PR DESCRIPTION
The `Qo` operator expects to consume a type name and a list (terminated with a `y` empty list marker) from the stack.  After popping the list, it doesn't check whether the stack is empty, so `$syQo` crashes (it pops down to the `y` then tries to pop again).

This PR just adds the obvious check to guard against this.

Resolves rdar://63128307
