### PR TITLE
[NFC] Clean Up Some Unneeded TypeCheckerOptions

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -484,11 +484,7 @@ namespace swift {
     /// 4.2 GHz Intel Core i7.
     /// (It's arbitrary, but will keep the compiler from taking too much time.)
     unsigned SwitchCheckingInvocationThreshold = 200000;
-
-    /// Whether to delay checking that benefits from having the entire
-    /// module parsed, e.g., Objective-C method override checking.
-    bool DelayWholeModuleChecking = false;
-
+    
     /// If true, the time it takes to type-check each function will be dumped
     /// to llvm::errs().
     bool DebugTimeFunctionBodies = false;

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -497,11 +497,6 @@ namespace swift {
     /// dumped to llvm::errs().
     bool DebugTimeExpressions = false;
 
-    /// Indicate that the type checker is checking code that will be
-    /// immediately executed. This will suppress certain warnings
-    /// when executing scripts.
-    bool InImmediateMode = false;
-
     /// Indicate that the type checker should skip type-checking non-inlinable
     /// function bodies.
     bool SkipNonInlinableFunctionBodies = false;

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1451,24 +1451,6 @@ void TypeCheckSourceFileRequest::cacheResult(evaluator::SideEffect) const {
     FrontendStatsTracer tracer(Ctx.Stats, "AST verification");
     // Verify the SourceFile.
     swift::verify(*SF);
-
-    // Verify imported modules.
-    //
-    // Skip per-file verification in whole-module mode. Verifying imports
-    // between files could cause the importer to cache declarations without
-    // adding them to the ASTContext. This happens when the importer registers a
-    // declaration without a valid TypeChecker instance, as is the case during
-    // verification. A subsequent file may require that declaration to be fully
-    // imported (e.g. to synthesized a function body), but since it has already
-    // been cached, it will never be added to the ASTContext. The solution is to
-    // skip verification and avoid caching it.
-#ifndef NDEBUG
-    if (!Ctx.TypeCheckerOpts.DelayWholeModuleChecking &&
-        SF->Kind != SourceFileKind::SIL &&
-        !Ctx.LangOpts.DebuggerSupport) {
-      Ctx.verifyAllLoadedModules();
-    }
-#endif
   }
 }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -883,11 +883,9 @@ void CompilerInstance::forEachFileToTypeCheck(
 }
 
 void CompilerInstance::finishTypeChecking() {
-  if (getASTContext().TypeCheckerOpts.DelayWholeModuleChecking) {
-    forEachSourceFileIn(MainModule, [&](SourceFile &SF) {
-      performWholeModuleTypeChecking(SF);
-    });
-  }
+  forEachSourceFileIn(MainModule, [&](SourceFile &SF) {
+    performWholeModuleTypeChecking(SF);
+  });
 }
 
 SourceFile *CompilerInstance::createSourceFileForMainModule(

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -311,15 +311,6 @@ bool CompilerInstance::setup(const CompilerInvocation &Invok) {
     Invocation.getLangOptions().AttachCommentsToDecls = true;
   }
 
-  // Set up the type checker options.
-  auto &typeCkOpts = Invocation.getTypeCheckerOptions();
-  if (isWholeModuleCompilation()) {
-    typeCkOpts.DelayWholeModuleChecking = true;
-  }
-  if (FrontendOptions::isActionImmediate(frontendOpts.RequestedAction)) {
-    typeCkOpts.InImmediateMode = true;
-  }
-
   assert(Lexer::isIdentifier(Invocation.getModuleName()));
 
   if (isInSILMode())

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -357,11 +357,6 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
       CheckInconsistentImplementationOnlyImportsRequest{SF->getParentModule()},
       {});
 
-  // Checking that benefits from having the whole module available.
-  if (!Ctx.TypeCheckerOpts.DelayWholeModuleChecking) {
-    performWholeModuleTypeChecking(*SF);
-  }
-
   // Perform various AST transforms we've been asked to perform.
   if (!Ctx.hadError() && Ctx.LangOpts.DebuggerTestingTransform)
     performDebuggerTestingTransform(*SF);


### PR DESCRIPTION
While refactoring in 48805b1, I accidentally added the computation of this bit before CompilerInstance::setupInputs is called. This means that the compiler currently does not have any knowledge of any primary input buffers, and thus the check for whole module mode is trivially true. As a consequence, this bit has been true ever since.

Since we seem to have got on just fine without computing this correctly, just inline that truthiness everywhere.

Whoops

Also, while I'm here, we don't need `InImmediateMode`.