### PR TITLE
Broaden the set of benchmarks tagged under .cpubench

### DIFF
--- a/benchmark/single-source/DataBenchmarks.swift
+++ b/benchmark/single-source/DataBenchmarks.swift
@@ -13,7 +13,7 @@
 import TestsUtils
 import Foundation
 
-let d: [BenchmarkCategory] =  [.validation, .api, .Data]
+let d: [BenchmarkCategory] =  [.validation, .api, .Data, .cpubench]
 
 public let DataBenchmarks = [
   BenchmarkInfo(name: "DataCreateEmpty",

--- a/benchmark/single-source/DictionarySwap.swift
+++ b/benchmark/single-source/DictionarySwap.swift
@@ -19,7 +19,7 @@ let numberMap = Dictionary(uniqueKeysWithValues: zip(1...size, 1...size))
 let boxedNums = (1...size).lazy.map { Box($0) }
 let boxedNumMap = Dictionary(uniqueKeysWithValues: zip(boxedNums, boxedNums))
 
-let t: [BenchmarkCategory] = [.validation, .api, .Dictionary]
+let t: [BenchmarkCategory] = [.validation, .api, .Dictionary, .cpubench]
 
 public let DictionarySwap = [
   BenchmarkInfo(name: "DictionarySwap",

--- a/benchmark/single-source/NIOChannelPipeline.swift
+++ b/benchmark/single-source/NIOChannelPipeline.swift
@@ -14,7 +14,7 @@ import TestsUtils
 
 // Mini benchmark implementing the gist of SwiftNIO's ChannelPipeline as
 // implemented by NIO 1 and NIO 2.[01]
-let t: [BenchmarkCategory] = [.runtime, .refcount]
+let t: [BenchmarkCategory] = [.runtime, .refcount, .cpubench]
 let N = 100
 
 public let NIOChannelPipeline = [

--- a/benchmark/single-source/ObjectiveCNoBridgingStubs.swift
+++ b/benchmark/single-source/ObjectiveCNoBridgingStubs.swift
@@ -21,7 +21,7 @@ import Foundation
 import ObjectiveCTests
 #endif
 
-let t: [BenchmarkCategory] = [.validation, .bridging]
+let t: [BenchmarkCategory] = [.validation, .bridging, .cpubench]
 
 public let ObjectiveCNoBridgingStubs = [
   BenchmarkInfo(name: "ObjectiveCBridgeStubToNSStringRef",

--- a/benchmark/single-source/ReversedCollections.swift
+++ b/benchmark/single-source/ReversedCollections.swift
@@ -16,7 +16,7 @@ public let ReversedCollections = [
   BenchmarkInfo(name: "ReversedArray2", runFunction: run_ReversedArray, tags: [.validation, .api, .Array],
       setUpFunction: { blackHole(arrayInput) },
       tearDownFunction: { arrayInput = nil }),
-  BenchmarkInfo(name: "ReversedBidirectional", runFunction: run_ReversedBidirectional, tags: [.validation, .api]),
+  BenchmarkInfo(name: "ReversedBidirectional", runFunction: run_ReversedBidirectional, tags: [.validation, .api, .cpubench]),
   BenchmarkInfo(name: "ReversedDictionary2", runFunction: run_ReversedDictionary, tags: [.validation, .api, .Dictionary],
       setUpFunction: { blackHole(dictionaryInput) },
       tearDownFunction: { dictionaryInput = nil })

--- a/benchmark/single-source/SortLargeExistentials.swift
+++ b/benchmark/single-source/SortLargeExistentials.swift
@@ -17,7 +17,7 @@ import TestsUtils
 public let SortLargeExistentials = BenchmarkInfo(
   name: "SortLargeExistentials",
   runFunction: run_SortLargeExistentials,
-  tags: [.validation, .api, .algorithm],
+  tags: [.validation, .api, .algorithm, .cpubench],
   legacyFactor: 100)
 
 protocol LetterKind {

--- a/benchmark/single-source/StackPromo.swift
+++ b/benchmark/single-source/StackPromo.swift
@@ -14,7 +14,7 @@ import TestsUtils
 public let StackPromo = BenchmarkInfo(
   name: "StackPromo",
   runFunction: run_StackPromo,
-  tags: [.regression],
+  tags: [.regression, .cpubench],
   legacyFactor: 100)
 
 protocol Proto {

--- a/benchmark/single-source/StringReplaceSubrange.swift
+++ b/benchmark/single-source/StringReplaceSubrange.swift
@@ -12,7 +12,7 @@
 
 import TestsUtils
 
-let tags: [BenchmarkCategory] = [.validation, .api, .String]
+let tags: [BenchmarkCategory] = [.validation, .api, .String, .cpubench]
 
 public let StringReplaceSubrange = [
   BenchmarkInfo(


### PR DESCRIPTION
These have all shown to be interesting, relevant, stable, and
optimized well enough by the compiler to be useful for cpu performance
tracking.

