### PR TITLE
Reenable a test for UnicodeScalar

### DIFF
--- a/test/stdlib/UnicodeScalarDiagnostics.swift
+++ b/test/stdlib/UnicodeScalarDiagnostics.swift
@@ -1,8 +1,7 @@
-// FIXME(integers): confusing diagnostics when new integer protocols are
-// implemented. <rdar://problem/29912193>
-// XFAIL: *
-
 // RUN: %target-typecheck-verify-swift
+
+// FIXME: The clarity of these diagnostics could be improved.
+// <rdar://problem/29912193>
 
 func isString(_ s: inout String) {}
 
@@ -10,29 +9,22 @@ func test_UnicodeScalarDoesNotImplementArithmetic(_ us: UnicodeScalar, i: Int) {
   var a1 = "a" + "b" // OK
   isString(&a1)
   let a2 = "a" - "b" // expected-error {{binary operator '-' cannot be applied to two 'String' operands}}
-  // expected-note @-1 {{overloads for '-' exist with these partially matching parameter lists:}}
   let a3 = "a" * "b" // expected-error {{binary operator '*' cannot be applied to two 'String' operands}}
-  // expected-note @-1 {{overloads for '*' exist with these partially matching parameter lists:}}
   let a4 = "a" / "b" // expected-error {{binary operator '/' cannot be applied to two 'String' operands}}
-  // expected-note @-1 {{overloads for '/' exist with these partially matching parameter lists:}}
 
-  let b1 = us + us // expected-error {{binary operator '+' cannot be applied to two 'UnicodeScalar' operands}}
-  // expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists:}}
-  let b2 = us - us // expected-error {{binary operator '-' cannot be applied to two 'UnicodeScalar' operands}}
-  // expected-note @-1 {{overloads for '-' exist with these partially matching parameter lists:}}
-  let b3 = us * us // expected-error {{binary operator '*' cannot be applied to two 'UnicodeScalar' operands}}
-  // expected-note @-1 {{overloads for '*' exist with these partially matching parameter lists:}}
-  let b4 = us / us // expected-error {{binary operator '/' cannot be applied to two 'UnicodeScalar' operands}}
-  // expected-note @-1 {{overloads for '/' exist with these partially matching parameter lists:}}
+  let b1 = us + us // expected-error {{referencing operator function '+' on 'RangeReplaceableCollection' requires that 'UnicodeScalar' (aka 'Unicode.Scalar') conform to 'RangeReplaceableCollection'}}
+  let b2 = us - us // expected-error {{referencing operator function '-' on 'FloatingPoint' requires that 'UnicodeScalar' (aka 'Unicode.Scalar') conform to 'FloatingPoint'}}
+  let b3 = us * us // expected-error {{referencing operator function '*' on 'FloatingPoint' requires that 'UnicodeScalar' (aka 'Unicode.Scalar') conform to 'FloatingPoint'}}
+  let b4 = us / us // expected-error {{referencing operator function '/' on 'FloatingPoint' requires that 'UnicodeScalar' (aka 'Unicode.Scalar') conform to 'FloatingPoint'}}
 
-  let c1 = us + i // expected-error {{binary operator '+' cannot be applied to operands of type 'UnicodeScalar' and 'Int'}} expected-note{{overloads for '+' exist with these partially matching parameter lists:}}
-  let c2 = us - i // expected-error {{binary operator '-' cannot be applied to operands of type 'UnicodeScalar' and 'Int'}} expected-note{{overloads for '-' exist with these partially matching parameter lists: (UnsafeMutablePointer<Pointee>, Int), (UnsafePointer<Pointee>, Int)}}
-  let c3 = us * i // expected-error {{binary operator '*' cannot be applied to operands of type 'UnicodeScalar' and 'Int'}} expected-note {{expected an argument list of type '(Int, Int)'}}
-  let c4 = us / i // expected-error {{binary operator '/' cannot be applied to operands of type 'UnicodeScalar' and 'Int'}} expected-note {{expected an argument list of type '(Int, Int)'}}
+  let c1 = us + i // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected argument type 'Int'}}
+  let c2 = us - i // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected argument type 'Int'}}
+  let c3 = us * i // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected argument type 'Int'}}
+  let c4 = us / i // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected argument type 'Int'}}
 
-  let d1 = i + us // expected-error {{binary operator '+' cannot be applied to operands of type 'Int' and 'UnicodeScalar'}} expected-note{{overloads for '+' exist with these partially matching parameter lists:}}
-  let d2 = i - us // expected-error {{binary operator '-' cannot be applied to operands of type 'Int' and 'UnicodeScalar'}} expected-note {{expected an argument list of type '(Int, Int)'}}
-  let d3 = i * us // expected-error {{binary operator '*' cannot be applied to operands of type 'Int' and 'UnicodeScalar'}} expected-note {{expected an argument list of type '(Int, Int)'}}
-  let d4 = i / us // expected-error {{binary operator '/' cannot be applied to operands of type 'Int' and 'UnicodeScalar'}} expected-note {{expected an argument list of type '(Int, Int)'}}
+  let d1 = i + us // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected argument type 'Int'}}
+  let d2 = i - us // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected argument type 'Int'}}
+  let d3 = i * us // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected argument type 'Int'}}
+  let d4 = i / us // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected argument type 'Int'}}
 }
 


### PR DESCRIPTION
This test was disabled back in 2017 when the new integer protocols were landing due to regressions in error messages. It is better to have a working test that verifies the desired behavior (UnicodeScalar not supporting arithmetic and the type checker producing somewhat readable messages), rather than a disabled test because the error messages are not perfect.
