### PR TITLE
SILOptimizer: a new phi-argument expansion optimization.

### DIFF
--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -99,8 +99,7 @@ public:
     Bits.SILArgument.VOKind = static_cast<unsigned>(newKind);
   }
 
-  SILBasicBlock *getParent() { return parentBlock; }
-  const SILBasicBlock *getParent() const { return parentBlock; }
+  SILBasicBlock *getParent() const { return parentBlock; }
 
   SILFunction *getFunction();
   const SILFunction *getFunction() const;

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -260,6 +260,8 @@ PASS(PredictableDeadAllocationElimination, "predictable-deadalloc-elim",
      "Eliminate dead temporary allocations after diagnostics")
 PASS(RedundantPhiElimination, "redundant-phi-elimination",
      "Redundant Phi Block Argument Elimination")
+PASS(PhiExpansion, "phi-expansion",
+     "Replace Phi arguments by their only used field")
 PASS(ReleaseDevirtualizer, "release-devirtualizer",
      "SIL release Devirtualization")
 PASS(RetainSinking, "retain-sinking",

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -351,6 +351,7 @@ void addFunctionPasses(SILPassPipelinePlan &P,
   // Jump threading can expose opportunity for SILCombine (enum -> is_enum_tag->
   // cond_br).
   P.addJumpThreadSimplifyCFG();
+  P.addPhiExpansion();
   P.addSILCombine();
   // SILCombine can expose further opportunities for SimplifyCFG.
   P.addSimplifyCFG();

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -23,9 +23,9 @@ target_sources(swiftSILOptimizer PRIVATE
   Outliner.cpp
   ObjectOutliner.cpp
   PerformanceInliner.cpp
+  PhiArgumentOptimizations.cpp
   RedundantLoadElimination.cpp
   RedundantOverflowCheckRemoval.cpp
-  RedundantPhiElimination.cpp
   ReleaseDevirtualizer.cpp
   SemanticARCOpts.cpp
   SILCodeMotion.cpp

--- a/test/SILOptimizer/phi-expansion.sil
+++ b/test/SILOptimizer/phi-expansion.sil
@@ -1,0 +1,115 @@
+// RUN: %target-sil-opt %s -phi-expansion | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+struct Mystruct {
+  @_hasStorage var i: Int { get set }
+  @_hasStorage var j: Int { get set }
+  init(i: Int)
+}
+
+// CHECK-LABEL: sil @test_simple
+// CHECK:   br bb3(%{{[0-9]*}} : $Int)
+// CHECK: bb3(%{{[0-9]*}} : $Int):
+// CHECK: } // end sil function 'test_simple'
+sil @test_simple : $@convention(thin) (Mystruct, Mystruct) -> Int {
+bb0(%0 : $Mystruct, %1 : $Mystruct):
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%0 : $Mystruct)
+
+bb2:
+  br bb3(%1 : $Mystruct)
+
+
+bb3(%5 : $Mystruct):
+  %6 = struct_extract %5 : $Mystruct, #Mystruct.i
+  return %6 : $Int
+}
+
+// CHECK-LABEL: sil @test_multiple_struct_extracts
+// CHECK:   br bb3(%{{[0-9]*}} : $Int)
+// CHECK: bb3(%{{[0-9]*}} : $Int):
+// CHECK: } // end sil function 'test_multiple_struct_extracts'
+sil @test_multiple_struct_extracts : $@convention(thin) (Mystruct, Mystruct) -> (Int, Int) {
+bb0(%0 : $Mystruct, %1 : $Mystruct):
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%0 : $Mystruct)
+
+bb2:
+  br bb3(%1 : $Mystruct)
+
+
+bb3(%5 : $Mystruct):
+  %6 = struct_extract %5 : $Mystruct, #Mystruct.i
+  %7 = struct_extract %5 : $Mystruct, #Mystruct.i
+  %8 = tuple (%6 : $Int, %7 : $Int)
+  return %8 : $(Int, Int)
+}
+
+// CHECK-LABEL: sil @dont_transform_multiple_fields
+// CHECK:   br bb3(%{{[0-9]*}} : $Mystruct)
+// CHECK: bb3(%{{[0-9]*}} : $Mystruct):
+// CHECK: } // end sil function 'dont_transform_multiple_fields'
+sil @dont_transform_multiple_fields : $@convention(thin) (Mystruct, Mystruct) -> (Int, Int) {
+bb0(%0 : $Mystruct, %1 : $Mystruct):
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%0 : $Mystruct)
+
+bb2:
+  br bb3(%1 : $Mystruct)
+
+
+bb3(%5 : $Mystruct):
+  %6 = struct_extract %5 : $Mystruct, #Mystruct.i
+  %7 = struct_extract %5 : $Mystruct, #Mystruct.j
+  %8 = tuple (%6 : $Int, %7 : $Int)
+  return %8 : $(Int, Int)
+}
+
+// CHECK-LABEL: sil @test_loop_with_br
+// CHECK:   br bb1(%{{[0-9]*}} : $Int)
+// CHECK: bb1(%{{[0-9]*}} : $Int):
+// CHECK:   br bb1(%{{[0-9]*}} : $Int)
+// CHECK: } // end sil function 'test_loop_with_br'
+sil @test_loop_with_br : $@convention(thin) (Mystruct) -> Int {
+bb0(%0 : $Mystruct):
+  br bb1(%0 : $Mystruct)
+
+bb1(%2 : $Mystruct):
+  %3 = struct_extract %2 : $Mystruct, #Mystruct.i
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1(%2 : $Mystruct)
+
+bb3:
+  return %3 : $Int
+}
+
+// CHECK-LABEL: sil @test_loop_with_cond_br
+// CHECK:   br bb1(%{{[0-9]*}} : $Int)
+// CHECK: bb1(%{{[0-9]*}} : $Int):
+// CHECK:   cond_br undef, bb1(%{{[0-9]*}} : $Int), bb2
+// CHECK: } // end sil function 'test_loop_with_cond_br'
+sil @test_loop_with_cond_br : $@convention(thin) (Mystruct) -> Int {
+bb0(%0 : $Mystruct):
+  br bb1(%0 : $Mystruct)
+
+bb1(%2 : $Mystruct):
+  %3 = struct_extract %2 : $Mystruct, #Mystruct.i
+  cond_br undef, bb1(%2 : $Mystruct), bb2
+
+bb2:
+  return %3 : $Int
+}
+


### PR DESCRIPTION
If only a single field of a struct phi-argument is used, replace the argument by the field value.
```
     br bb(%str)
   bb(%phi):
     %f = struct_extract %phi, #Field // the only use of %phi
     use %f
```
is replaced with
```
     %f = struct_extract %str, #Field
     br bb(%f)
   bb(%phi):
     use %phi
```
This also works if the phi-argument is in a def-use cycle.

The new PhiExpansionPass is in the same file as the RedundantPhiEliminationPass. Therefore I renamed the source file to PhiArgumentOptimizations.cpp

The motivation for this optimization is mainly to support the upcoming COW optimizations, where it's important that e.g. an array buffer reference is not wrapped in a struct.