### PR TITLE
[opt] Support multiple closure arguments in closure specialization.

### DIFF
--- a/test/SILOptimizer/closure_specialize.sil
+++ b/test/SILOptimizer/closure_specialize.sil
@@ -55,9 +55,9 @@ bb0(%0 : $Int, %1 : $Int, %2 : $Int):
 }
 
 // CHECK-LABEL: sil @$s7specgen6calleryySiF : $@convention(thin) (Int) -> () {
-// CHECK: [[ID1:%[0-9]+]] = function_ref @$s7specgen13take_closure2yyySi_SitcF023$s7specgen6calleryySiFyE8_SitcfU_SiTf1c_n : $@convention(thin) (Int) -> ()
 // CHECK: [[ID2:%[0-9]+]] = function_ref @$s7specgen12take_closureyyySi_SitcF023$s7specgen6calleryySiFyE8_SitcfU_SiTf1c_n : $@convention(thin) (Int) -> ()
 // CHECK: apply [[ID2]](%0) : $@convention(thin) (Int) -> ()
+// CHECK: [[ID1:%[0-9]+]] = function_ref @$s7specgen13take_closure2yyySi_SitcF023$s7specgen6calleryySiFyE8_SitcfU_SiTf1c_n : $@convention(thin) (Int) -> ()
 // CHECK: apply [[ID1]](%0) : $@convention(thin) (Int) -> ()
 sil @$s7specgen6calleryySiF : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
@@ -109,9 +109,9 @@ bb0(%0 : $Int, %1 : $Int):
 }
 
 // CHECK-LABEL: sil @$s7specgen11tttficalleryySiF : $@convention(thin) (Int) -> () {
-// CHECK: [[ID1:%[0-9]+]] = function_ref @$s7specgen13take_closure2yyySi_SitcF26$s7specgen6calleeyySi_SitFTf1c_n : $@convention(thin) () -> ()
 // CHECK: [[ID2:%[0-9]+]] = function_ref @$s7specgen12take_closureyyySi_SitcF26$s7specgen6calleeyySi_SitFTf1c_n : $@convention(thin) () -> ()
 // CHECK: apply [[ID2]]() : $@convention(thin) () -> ()
+// CHECK: [[ID1:%[0-9]+]] = function_ref @$s7specgen13take_closure2yyySi_SitcF26$s7specgen6calleeyySi_SitFTf1c_n : $@convention(thin) () -> ()
 // CHECK: apply [[ID1]]() : $@convention(thin) () -> ()
 sil @$s7specgen11tttficalleryySiF : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
@@ -190,19 +190,15 @@ bb0(%0 : $@callee_owned (@owned A) -> ()):
 // CHECK: bb0([[ARG:%.*]] : $A
 // CHECK:   strong_retain [[ARG]]
 // CHECK-NOT: partial_apply
-// CHECK:  [[SPECIALIZED_CLOSURE_USER:%.*]] = function_ref @$s11use_closure{{.*}}Tf
-// CHECK:   retain_value [[ARG]]
-// CHECK-NOT: partial_apply
-// CHECK:   integer_literal $Builtin.Int64, 0
 // CHECK: br bb2
 
 // CHECK: bb1:
 // CHECK:  strong_release [[ARG]]
-// CHECK:  release_value [[ARG]]
 // CHECK:  return
 
 // CHECK: bb2({{.*}}):
 // Match the partial_apply consume of arg.
+// CHECK:  [[SPECIALIZED_CLOSURE_USER:%.*]] = function_ref @$s11use_closure{{.*}}Tf
 // CHECK: retain_value [[ARG]]
 // CHECK: apply [[SPECIALIZED_CLOSURE_USER]]([[ARG]])
 // CHECK: cond_br {{.*}}, bb1, bb3
@@ -238,14 +234,13 @@ bb3:
 
 // CHECK-LABEL: sil @insert_release_in_liferange_exit_block
 // CHECK: bb0(%0 : $A):
-// CHECK:   retain_value %0
+// CHECK:   strong_retain %0
 // CHECK: bb1:
-// CHECK-NEXT: release_value %0
 // CHECK-NEXT: br bb3
 // CHECK: bb2:
+
 // CHECK:   retain_value %0
 // CHECK:   apply %{{[0-9]+}}(%0)
-// CHECK:   release_value %0
 // CHECK: bb3:
 // CHECK-NOT: %0
 // CHECK:   return
@@ -274,14 +269,12 @@ bb3:
 
 // CHECK-LABEL: sil @insert_release_at_critical_edge
 // CHECK: bb0(%0 : $A):
-// CHECK:   retain_value %0
+// CHECK:   strong_retain %0
 // CHECK: bb1:
-// CHECK-NEXT: release_value %0
 // CHECK-NEXT: br bb3
 // CHECK: bb2:
 // CHECK:   retain_value %0
 // CHECK:   apply %{{[0-9]+}}(%0)
-// CHECK:   release_value %0
 // CHECK: bb3:
 // CHECK-NOT: %0
 // CHECK:   return
@@ -307,7 +300,7 @@ bb2:
 
 // CHECK-LABEL: sil @insert_release_at_critical_loop_exit_edge
 // CHECK: bb0(%0 : $A):
-// CHECK:   retain_value %0
+// CHECK:   strong_retain %0
 // CHECK: bb1:
 // CHECK-NEXT:   br bb2
 // CHECK: bb2:
@@ -315,10 +308,8 @@ bb2:
 // CHECK:   apply %{{[0-9]+}}(%0)
 // CHECK-NOT:   %0
 // CHECK: bb3:
-// CHECK-NEXT: release_value %0
 // CHECK-NEXT: br bb5
 // CHECK: bb4:
-// CHECK-NEXT: release_value %0
 // CHECK-NEXT: br bb5
 // CHECK: bb5:
 // CHECK-NOT: %0
@@ -351,15 +342,12 @@ bb4:
 
 // CHECK-LABEL: sil @insert_release_in_loop_exit_block
 // CHECK: bb0(%0 : $A):
-// CHECK:   retain_value %0
+// CHECK:   strong_retain %0
 // CHECK: bb1:
 // CHECK-NEXT:   br bb2
 // CHECK: bb2:
 // CHECK:   retain_value %0
 // CHECK:   apply %{{[0-9]+}}(%0)
-// CHECK-NOT:   %0
-// CHECK: bb3:
-// CHECK-NEXT: release_value %0
 // CHECK-NOT: %0
 // CHECK:   return
 sil @insert_release_in_loop_exit_block : $@convention(thin) (@guaranteed A) -> () {
@@ -387,17 +375,14 @@ bb3:
 
 // CHECK-LABEL: sil @insert_release_after_try_apply
 // CHECK: bb0(%0 : $A):
-// CHECK:   retain_value %0
 // CHECK: bb1:
 // CHECK:   retain_value %0
 // CHECK-NEXT:   try_apply
 // CHECK: bb2(%{{[0-9]+}} : $()):
 // CHECK-NEXT:   strong_release %0
-// CHECK-NEXT:   release_value %0
 // CHECK-NEXT:   br bb4
 // CHECK: bb3(%{{[0-9]+}} : $Error):
 // CHECK-NEXT:   strong_release %0
-// CHECK-NEXT:   release_value %0
 // CHECK-NEXT:   br bb4
 // CHECK: bb4:
 // CHECK-NOT: %0
@@ -717,10 +702,8 @@ bb0(%0 : $*Int, %1 : $@callee_guaranteed () -> @out Int):
 // CHECK: [[F:%.*]] = function_ref @testClosureConvertHelper2
 // CHECK: [[PA:%.*]] = partial_apply [callee_guaranteed] [[F]](%0)
 // CHECK: [[CVT:%.*]] = convert_escape_to_noescape [[PA]]
-// CHECK: [[F2:%.*]] = function_ref @reabstractionThunk
-// CHECK: [[PA2:%.*]] = partial_apply [callee_guaranteed] [[F2]]([[CVT]])
-// CHECK: [[F3:%.*]] = function_ref @testClosureThunk4
-// CHECK:  apply [[F3]]([[STK]], [[PA2]])
+// CHECK: [[F2:%.*]] = function_ref @$s17testClosureThunk418reabstractionThunkSiIgd_Tf1nc_n
+// CHECK:  apply [[F2]]([[STK]], [[CVT]])
 // CHECK:  release_value [[PA]]
 // CHECK:  dealloc_stack [[STK]]
 // CHECK:  return

--- a/test/SILOptimizer/closure_specialize_consolidated.sil
+++ b/test/SILOptimizer/closure_specialize_consolidated.sil
@@ -208,7 +208,9 @@ bb0(%0 : $Int32, %1 : $*Int32):
 }
 
 // CHECK-LABEL: sil @address_caller_trivial
-// CHECK-NOT: partial_apply
+// CHECK: [[PA:%.*]] = partial_apply
+// CHECK-NEXT: [[CV:%.*]] convert_escape_to_noescape [[PA]]
+// CHECK-NOT: [[CV]]
 // CHECK:  [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (Int32, @inout_aliasable Int32) -> ()
 // CHECK: apply [[SPECIALIZED_FN1]]{{.*}}
 // CHECK-NOT: partial_apply
@@ -246,7 +248,9 @@ bb0(%0 : $*Int32):
 }
 
 // CHECK-LABEL: sil @address_caller_trivial_mutating
-// CHECK-NOT: partial_apply
+// CHECK: [[PA:%.*]] = partial_apply
+// CHECK-NEXT: [[CV:%.*]] convert_escape_to_noescape [[PA]]
+// CHECK-NOT: [[CV]]
 // CHECK:  [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable Int32) -> ()
 // CHECK: apply [[SPECIALIZED_FN1]]{{.*}}
 // CHECK-NOT: partial_apply
@@ -323,8 +327,9 @@ bb0(%0 : $*Q, %1 : $@noescape @callee_owned (@in Q) -> @out Q):
 // supported address type arguments, i.e. @inout or @inout_aliasable.
 //
 // CHECK-LABEL: sil @address_caller_out_result : $@convention(thin) (@in Q, @in Q) -> @out Q
-// CHECK-NOT: partial_apply
-// CHECK:  [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_user_out_result{{.*}} : $@convention(thin) (@inout_aliasable Q, @inout_aliasable Q) -> @out Q
+// CHECK: [[PA:%.*]] = partial_apply
+// CHECK-NEXT: [[CV:%.*]] convert_escape_to_noescape [[PA]]
+// CHECK-NOT: [[CV]]// CHECK:  [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_user_out_result{{.*}} : $@convention(thin) (@inout_aliasable Q, @inout_aliasable Q) -> @out Q
 // CHECK: apply [[SPECIALIZED_FN1]]{{.*}}
 // CHECK-NOT: partial_apply
 // CHECK: return
@@ -342,11 +347,13 @@ bb0(%0 : $*Q, %1 : $*Q, %2 : $*Q):
 }
 
 // CHECK-LABEL: sil @address_caller_existential
-// CHECK-NOT: partial_apply
+// CHECK: [[PA:%.*]] = partial_apply
+// CHECK-NEXT: [[CV:%.*]] convert_escape_to_noescape [[PA]]
+// CHECK-NOT: [[CV]]
 // CHECK:  [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable P) -> ()
+// CHECK: apply [[SPECIALIZED_FN1]]{{.*}}
 // CHECK:  [[SPECIALIZED_FN2:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable P) -> ()
 // CHECK: apply [[SPECIALIZED_FN2]]{{.*}}
-// CHECK: apply [[SPECIALIZED_FN1]]{{.*}}
 // CHECK-NOT: partial_apply
 // CHECK: return
 sil @address_caller_existential : $@convention(thin) (@in P, @in P, Int32) -> @out P {
@@ -414,8 +421,10 @@ bb0(%0 : $*S, %1 : $S):
 }
 
 // CHECK-LABEL: sil @address_caller_struct
-// CHECK-NOT: partial_apply
-// CHECK: [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable S, @owned S) -> () 
+// CHECK: [[PA:%.*]] = partial_apply
+// CHECK-NEXT: [[CV:%.*]] convert_escape_to_noescape [[PA]]
+// CHECK-NOT: [[CV]]
+// CHECK: [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
 // CHECK: apply [[SPECIALIZED_FN1]]
 // CHECK: [[SPECIALIZED_FN2:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable S, @owned S) -> () 
 // CHECK: apply [[SPECIALIZED_FN2]]
@@ -453,11 +462,13 @@ bb0(%0 : $*C, %1 : $C):
 }
 
 // CHECK-LABEL: sil @address_caller_class1
-// CHECK-NOT: partial_apply
+// CHECK: [[PA:%.*]] = partial_apply
+// CHECK-NEXT: [[CV:%.*]] convert_escape_to_noescape [[PA]]
+// CHECK-NOT: [[CV]]
 // CHECK:  [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable C, @owned C) -> ()
+// CHECK: apply [[SPECIALIZED_FN1]]{{.*}}
 // CHECK:  [[SPECIALIZED_FN2:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable C, @owned C) -> ()
 // CHECK: apply [[SPECIALIZED_FN2]]{{.*}}
-// CHECK: apply [[SPECIALIZED_FN1]]{{.*}}
 // CHECK-NOT: partial_apply
 // CHECK: return
 sil @address_caller_class1 : $@convention(thin) (@guaranteed C, @guaranteed C) -> @owned C {
@@ -571,34 +582,28 @@ bb0(%0 : $@callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.Nat
 // CHECK: retain_value [[ARG0]] : $Builtin.NativeObject
 // CHECK-NEXT: retain_value [[ARG2]] : $Builtin.NativeObject
 // CHECK-NEXT: retain_value [[ARG3]] : $Builtin.NativeObject
-// CHECK: [[SPECFUN0:%.*]] = function_ref @$s23guaranteed_apply_callee014large_closure_C0BoBi32_BoBoTf1cnnnn_n
-// CHECK: retain_value [[ARG0]] : $Builtin.NativeObject
-// CHECK-NEXT: retain_value [[ARG2]] : $Builtin.NativeObject
-// CHECK-NEXT: retain_value [[ARG3]] : $Builtin.NativeObject
+// CHECK: [[DEAD_CLOSURE_1:%.*]] = partial_apply [[OLD_CLOSURE_CALLEE1]]
+// CHECK-NEXT: [[DEAD_CLOSURE_2:%.*]] = thin_to_thick_function [[OLD_CLOSURE_CALLEE2]]
+// CHECK-NEXT: retain_value [[DEAD_CLOSURE_1]]
 // CHECK: [[SPECFUN1:%.*]] = function_ref @$s18owned_apply_callee014large_closure_C0BoBi32_BoBoTf1cnnnn_n
 // CHECK: retain_value [[ARG0]] : $Builtin.NativeObject
 // CHECK-NEXT: retain_value [[ARG2]] : $Builtin.NativeObject
 // CHECK-NEXT: retain_value [[ARG3]] : $Builtin.NativeObject
-// CHECK: [[DEAD_CLOSURE_1:%.*]] = partial_apply [[OLD_CLOSURE_CALLEE1]]
-// CHECK: [[SPECFUN2:%.*]] = function_ref @$s23guaranteed_apply_callee014small_closure_C0Tf1cnnnn_n 
+// CHECK: apply [[SPECFUN1]](
+// CHECK: release_value [[DEAD_CLOSURE_1]]
 // CHECK: [[SPECFUN3:%.*]] = function_ref @$s18owned_apply_callee014small_closure_C0Tf1cnnnn_n
-// CHECK: [[DEAD_CLOSURE_2:%.*]] = thin_to_thick_function [[OLD_CLOSURE_CALLEE2]]
-// CHECK: retain_value [[DEAD_CLOSURE_1]]
-// CHECK-NOT: retain_value [[DEAD_CLOSURE_2]]
+// CHECK: apply [[SPECFUN3]](
+// CHECK: [[SPECFUN0:%.*]] = function_ref @$s23guaranteed_apply_callee014large_closure_C0BoBi32_BoBoTf1cnnnn_n
+// CHECK: retain_value [[ARG0]] : $Builtin.NativeObject
+// CHECK-NEXT: retain_value [[ARG2]] : $Builtin.NativeObject
+// CHECK-NEXT: retain_value [[ARG3]] : $Builtin.NativeObject
+// CHECK: apply [[SPECFUN0]](
+// CHECK: [[SPECFUN2:%.*]] = function_ref @$s23guaranteed_apply_callee014small_closure_C0Tf1cnnnn_n
 // CHECK-NOT: apply [[DEAD_CLOSURE_1]]
 // CHECK-NOT: apply [[DEAD_CLOSURE_2]]
-// CHECK: apply [[SPECFUN1]](
-// CHECK-NEXT: release_value [[DEAD_CLOSURE_1]]
-// CHECK-NOT: release_value [[DEAD_CLOSURE_2]]
-// CHECK: apply [[SPECFUN3]](
 // CHECK-NOT: release_value [[DEAD_CLOSURE_1]]
-// CHECK-NOT: release_value [[DEAD_CLOSURE_2]]
-// CHECK: apply [[SPECFUN0]](
-// CHECK-NOT: release_value [[DEAD_CLOSURE_1]]
-// CHECK-NOT: release_value [[DEAD_CLOSURE_2]]
 // CHECK: apply [[SPECFUN2]](
 // CHECK-NEXT: release_value [[DEAD_CLOSURE_1]]
-// CHECK-NOT: release_value [[DEAD_CLOSURE_2]]
 
 // REMOVECLOSURES-LABEL: sil @thin_thick_and_partial_apply_test : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject, @owned Error) -> () {
 // REMOVECLOSURES: bb0([[ARG0:%.*]] : $Builtin.NativeObject, [[ARG1:%.*]] : $Builtin.Int32, [[ARG2:%.*]] : $Builtin.NativeObject, [[ARG3:%.*]] : $Builtin.NativeObject, [[ARG4:%.*]] : $Error):
@@ -607,26 +612,26 @@ bb0(%0 : $@callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.Nat
 // REMOVECLOSURES: retain_value [[ARG0]] : $Builtin.NativeObject
 // REMOVECLOSURES-NEXT: retain_value [[ARG2]] : $Builtin.NativeObject
 // REMOVECLOSURES-NEXT: retain_value [[ARG3]] : $Builtin.NativeObject
-// REMOVECLOSURES: [[SPECFUN0:%.*]] = function_ref @$s23guaranteed_apply_callee014large_closure_C0BoBi32_BoBoTf1cnnnn_n
-// REMOVECLOSURES: retain_value [[ARG0]] : $Builtin.NativeObject
-// REMOVECLOSURES-NEXT: retain_value [[ARG2]] : $Builtin.NativeObject
-// REMOVECLOSURES-NEXT: retain_value [[ARG3]] : $Builtin.NativeObject
 // REMOVECLOSURES: [[SPECFUN1:%.*]] = function_ref @$s18owned_apply_callee014large_closure_C0BoBi32_BoBoTf1cnnnn_n
 // REMOVECLOSURES: retain_value [[ARG0]] : $Builtin.NativeObject
 // REMOVECLOSURES-NEXT: retain_value [[ARG2]] : $Builtin.NativeObject
 // REMOVECLOSURES-NEXT: retain_value [[ARG3]] : $Builtin.NativeObject
-// REMOVECLOSURES-NOT: partial_apply [[OLD_CLOSURE_CALLEE1]]
-// REMOVECLOSURES: [[SPECFUN4:%.*]] = function_ref @$s29guaranteed_apply_callee_throw014small_closure_C0Tf1cnnnnn_n
-// REMOVECLOSURES: [[SPECFUN2:%.*]] = function_ref @$s23guaranteed_apply_callee014small_closure_C0Tf1cnnnn_n
+// REMOVECLOSURES-NEXT: apply [[SPECFUN1]](
 // REMOVECLOSURES: [[SPECFUN3:%.*]] = function_ref @$s18owned_apply_callee014small_closure_C0Tf1cnnnn_n
-// REMOVECLOSURES-NOT: thin_to_thick_function [[OLD_CLOSURE_CALLEE2]]
-// REMOVECLOSURES: apply [[SPECFUN1]](
 // REMOVECLOSURES-NEXT: apply [[SPECFUN3]](
+// REMOVECLOSURES: [[SPECFUN0:%.*]] = function_ref @$s23guaranteed_apply_callee014large_closure_C0BoBi32_BoBoTf1cnnnn_n
+// REMOVECLOSURES: retain_value [[ARG0]] : $Builtin.NativeObject
+// REMOVECLOSURES-NEXT: retain_value [[ARG2]] : $Builtin.NativeObject
+// REMOVECLOSURES-NEXT: retain_value [[ARG3]] : $Builtin.NativeObject
 // REMOVECLOSURES-NEXT: apply [[SPECFUN0]](
+// REMOVECLOSURES-NOT: partial_apply [[OLD_CLOSURE_CALLEE1]]
+// REMOVECLOSURES: [[SPECFUN2:%.*]] = function_ref @$s23guaranteed_apply_callee014small_closure_C0Tf1cnnnn_n
 // REMOVECLOSURES-NEXT: apply [[SPECFUN2]](
+// REMOVECLOSURES-NOT: thin_to_thick_function [[OLD_CLOSURE_CALLEE2]]
 // REMOVECLOSURES-NEXT: strong_release [[ARG0]] : $Builtin.NativeObject
 // REMOVECLOSURES-NEXT: strong_release [[ARG2]] : $Builtin.NativeObject
 // REMOVECLOSURES-NEXT: strong_release [[ARG3]] : $Builtin.NativeObject
+// REMOVECLOSURES: [[SPECFUN4:%.*]] = function_ref @$s29guaranteed_apply_callee_throw014small_closure_C0Tf1cnnnnn_n
 // REMOVECLOSURES-NEXT: try_apply [[SPECFUN4]](
 sil @thin_thick_and_partial_apply_test : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject, @owned Error) -> () {
 bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.Int32, %2 : $Builtin.NativeObject, %3 : $Builtin.NativeObject, %11: $Error):

--- a/test/SILOptimizer/closure_specialize_mutliple_closures.sil
+++ b/test/SILOptimizer/closure_specialize_mutliple_closures.sil
@@ -1,0 +1,186 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -closure-specialize -module-name=test %s | %FileCheck %s
+
+import Builtin
+import Swift
+
+class A {}
+
+//===----------------------------------------------------------------------===//
+//                        Closures and Closure Users
+//===----------------------------------------------------------------------===//
+
+sil hidden [noinline] @closure : $@convention(thin) (@owned A, @owned A) -> () {
+bb0(%0 : $A, %1 : $A):
+  strong_release %1 : $A
+  strong_release %0 : $A
+  %4 = tuple ()
+  return %4 : $()
+}
+
+sil hidden [noinline] @use_closures : $@convention(thin) (@owned @callee_owned (@owned A) -> (), @owned @callee_owned (@owned A) -> ()) -> () {
+bb0(%c1 : $@callee_owned (@owned A) -> (), %c2 : $@callee_owned (@owned A) -> ()):
+  %1 = alloc_ref $A
+  strong_retain %1 : $A
+  apply %c1(%1) : $@callee_owned (@owned A) -> ()
+  apply %c2(%1) : $@callee_owned (@owned A) -> ()
+  %3 = tuple ()
+  return %3 : $()
+}
+
+sil hidden [noinline] @use_closures_throw : $@convention(thin) (@owned @callee_owned (@owned A) -> (), @owned @callee_owned (@owned A) -> ()) -> @error Error {
+bb0(%c1 : $@callee_owned (@owned A) -> (), %c2 : $@callee_owned (@owned A) -> ()):
+  %1 = alloc_ref $A
+  strong_retain %1 : $A
+  apply %c1(%1) : $@callee_owned (@owned A) -> ()
+  apply %c2(%1) : $@callee_owned (@owned A) -> ()
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// Check that the specialized users call both closures.
+
+// CHECK-LABEL: sil shared [noinline] @$s12use_closures7closure4test1ACAbETf1cc_n : $@convention(thin) (@owned A, @owned A) -> ()
+// CHECK: bb0([[ARG1:%.*]] : $A, [[ARG2:%.*]] : $A):
+// CHECK: [[FN:%[0-9]+]] = function_ref @closure : $@convention(thin) (@owned A, @owned A) -> ()
+// CHECK: [[C1:%[0-9]+]] = partial_apply [[FN]]([[ARG1]]) : $@convention(thin) (@owned A, @owned A) -> ()
+// CHECK: [[FN:%[0-9]+]] = function_ref @closure : $@convention(thin) (@owned A, @owned A) -> ()
+// CHECK: [[C2:%[0-9]+]] = partial_apply [[FN]]([[ARG2]]) : $@convention(thin) (@owned A, @owned A) -> ()
+// CHECK: [[ALLOC:%[0-9]+]] = alloc_ref $A
+// CHECK: strong_retain [[ALLOC]] : $A
+// CHECK: apply [[C1]]([[ALLOC]]) : $@callee_owned (@owned A) -> ()
+// CHECK: apply [[C2]]([[ALLOC]]) : $@callee_owned (@owned A) -> ()
+// CHECK-LABEL: end sil function '$s12use_closures7closure4test1ACAbETf1cc_n'
+
+// CHECK-LABEL: @$s18use_closures_throw7closure4test1ACAbETf1cc_n : $@convention(thin) (@owned A, @owned A) -> @error Error
+// CHECK: bb0([[ARG1:%.*]] : $A, [[ARG2:%.*]] : $A):
+// CHECK: [[FN:%[0-9]+]] = function_ref @closure : $@convention(thin) (@owned A, @owned A) -> ()
+// CHECK: [[C1:%[0-9]+]] = partial_apply [[FN]]([[ARG1]]) : $@convention(thin) (@owned A, @owned A) -> ()
+// CHECK: [[FN:%[0-9]+]] = function_ref @closure : $@convention(thin) (@owned A, @owned A) -> ()
+// CHECK: [[C2:%[0-9]+]] = partial_apply [[FN]]([[ARG2]]) : $@convention(thin) (@owned A, @owned A) -> ()
+// CHECK: [[ALLOC:%[0-9]+]] = alloc_ref $A
+// CHECK: strong_retain [[ALLOC]] : $A
+// CHECK: apply [[C1]]([[ALLOC]]) : $@callee_owned (@owned A) -> ()
+// CHECK: apply [[C2]]([[ALLOC]]) : $@callee_owned (@owned A) -> ()
+// CHECK-LABEL: end sil function '$s18use_closures_throw7closure4test1ACAbETf1cc_n'
+
+//===----------------------------------------------------------------------===//
+//                                 Callers
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: sil {{.*}} @different_execution_counts
+// CHECK: bb0([[ARG:%.*]] : $A)
+// CHECK: strong_retain [[ARG]]
+// CHECK-NOT: partial_apply
+// CHECK: br bb2
+
+// CHECK: bb1:
+// CHECK:  strong_release [[ARG]]
+// CHECK:  strong_release [[ARG]]
+// CHECK:  return
+
+// CHECK: bb2({{.*}}):
+// CHECK: [[SPECIALIZED_CLOSURE_USER:%.*]] = function_ref @$s12use_closures7closure4test1ACAbETf1cc_n
+// CHECK: retain_value [[ARG]]
+// CHECK: retain_value [[ARG]]
+// CHECK: apply [[SPECIALIZED_CLOSURE_USER]]([[ARG]], [[ARG]])
+// CHECK-LABEL: end sil function 'different_execution_counts'
+sil hidden [noinline] @different_execution_counts : $@convention(thin) (@guaranteed A) -> () {
+bb0(%0 : $A):
+  strong_retain %0 : $A
+  %2 = function_ref @closure : $@convention(thin) (@owned A, @owned A) -> ()
+  %c1 = partial_apply %2(%0) : $@convention(thin) (@owned A, @owned A) -> ()
+  %c2 = partial_apply %2(%0) : $@convention(thin) (@owned A, @owned A) -> ()
+  %4 = integer_literal $Builtin.Int64, 0
+  %5 = integer_literal $Builtin.Int64, 5
+  %6 = integer_literal $Builtin.Int64, 1
+  %7 = integer_literal $Builtin.Int1, 0
+  %8 = function_ref @use_closures : $@convention(thin) (@owned @callee_owned (@owned A) -> (), @owned @callee_owned (@owned A) -> ()) -> ()
+  br bb2(%4 : $Builtin.Int64)
+
+bb1:
+  strong_release %c1 : $@callee_owned (@owned A) -> ()
+  strong_release %c2 : $@callee_owned (@owned A) -> ()
+  %11 = tuple ()
+  return %11 : $()
+
+bb2(%13 : $Builtin.Int64):
+  %14 = builtin "sadd_with_overflow_Int64"(%13 : $Builtin.Int64, %6 : $Builtin.Int64, %7 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %15 = tuple_extract %14 : $(Builtin.Int64, Builtin.Int1), 0
+  strong_retain %c1 : $@callee_owned (@owned A) -> ()
+  strong_retain %c2 : $@callee_owned (@owned A) -> ()
+  %17 = apply %8(%c1, %c2) : $@convention(thin) (@owned @callee_owned (@owned A) -> (), @owned @callee_owned (@owned A) -> ()) -> ()
+  %18 = builtin "cmp_eq_Int64"(%15 : $Builtin.Int64, %5 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %18, bb1, bb3
+
+bb3:
+  br bb2(%15 : $Builtin.Int64)
+}
+
+// CHECK-LABEL: sil @insert_release_at_critical_loop_exit_edge
+// CHECK: bb0([[ARG:%[0-9]+]] : $A):
+// CHECK: strong_retain [[ARG]]
+// CHECK: bb2:
+// CHECK: [[SPECIALIZED_CLOSURE_USER:%.*]] = function_ref @$s12use_closures7closure4test1ACAbETf1cc_n
+// CHECK: retain_value [[ARG]]
+// CHECK: retain_value [[ARG]]
+// CHECK: apply [[SPECIALIZED_CLOSURE_USER]]([[ARG]], [[ARG]])
+// CHECK-LABEL: end sil function 'insert_release_at_critical_loop_exit_edge'
+sil @insert_release_at_critical_loop_exit_edge : $@convention(thin) (@guaranteed A) -> () {
+bb0(%0 : $A):
+  strong_retain %0 : $A
+  %2 = function_ref @closure : $@convention(thin) (@owned A, @owned A) -> ()
+  %c1 = partial_apply %2(%0) : $@convention(thin) (@owned A, @owned A) -> ()
+  %c2 = partial_apply %2(%0) : $@convention(thin) (@owned A, @owned A) -> ()
+  %8 = function_ref @use_closures : $@convention(thin) (@owned @callee_owned (@owned A) -> (), @owned @callee_owned (@owned A) -> ()) -> ()
+  %5 = partial_apply %8(%c1, %c2) : $@convention(thin) (@owned @callee_owned (@owned A) -> (), @owned @callee_owned (@owned A) -> ()) -> ()
+  cond_br undef, bb3, bb1
+
+bb1:
+  br bb2
+
+bb2:
+  strong_retain %c1 : $@callee_owned (@owned A) -> ()
+  strong_retain %c2 : $@callee_owned (@owned A) -> ()
+  %17 = apply %8(%c1, %c2) : $@convention(thin) (@owned @callee_owned (@owned A) -> (), @owned @callee_owned (@owned A) -> ()) -> ()
+  cond_br undef, bb2, bb4
+
+bb3:
+  br bb4
+
+bb4:
+  strong_release %5 : $@callee_owned () -> ()
+  %11 = tuple ()
+  return %11 : $()
+}
+
+// CHECK-LABEL: sil @insert_release_after_try_apply
+// CHECK: bb0([[ARG:%[0-9]+]] : $A):
+// CHECK: bb1:
+// CHECK: [[SPECIALIZED_CLOSURE_USER:%.*]] = function_ref @$s18use_closures_throw7closure4test1ACAbETf1cc_n
+// CHECK: retain_value [[ARG]]
+// CHECK: retain_value [[ARG]]
+// CHECK: apply [[SPECIALIZED_CLOSURE_USER]]([[ARG]], [[ARG]])
+// CHECK-LABEL: end sil function 'insert_release_after_try_apply'
+sil @insert_release_after_try_apply : $@convention(thin) (@guaranteed A) -> () {
+bb0(%0 : $A):
+  %2 = function_ref @closure : $@convention(thin) (@owned A, @owned A) -> ()
+  %c1 = partial_apply %2(%0) : $@convention(thin) (@owned A, @owned A) -> ()
+  %c2 = partial_apply %2(%0) : $@convention(thin) (@owned A, @owned A) -> ()
+  %8 = function_ref @use_closures_throw : $@convention(thin) (@owned @callee_owned (@owned A) -> (), @owned @callee_owned (@owned A) -> ()) -> @error Error
+  br bb1
+
+bb1:
+  strong_retain %c1 : $@callee_owned (@owned A) -> ()
+  strong_retain %c2 : $@callee_owned (@owned A) -> ()
+  try_apply %8(%c1, %c2) : $@convention(thin) (@owned @callee_owned (@owned A) -> (), @owned @callee_owned (@owned A) -> ()) -> @error Error, normal bb2, error bb3
+
+bb2(%n : $()):
+  br bb4
+
+bb3(%e : $Error):
+  br bb4
+
+bb4:
+  %11 = tuple ()
+  return %11 : $()
+}

--- a/test/SILOptimizer/closure_specialize_opaque.sil
+++ b/test/SILOptimizer/closure_specialize_opaque.sil
@@ -24,8 +24,8 @@ bb0(%0 : $*TestView, %1 : $@callee_owned (@inout TestView) ->()):
 // CHECK-LABEL: sil @testSpecializeThunk : $@convention(thin) (@inout TestView, TestRange, @in TestSlice) -> () {
 // CHECK: bb0(%0 : $*TestView, %1 : $TestRange, %2 : $TestSlice):
 // CHECK:   [[CLOSURE:%.*]] = function_ref @closure : $@convention(thin) (@inout TestView, TestRange, @in TestSlice) -> ()
-// CHECK:   [[SPECIALIZED:%.*]] = function_ref @$s5thunk7closure4main9TestRangeVAC0D5SliceVTf1nc_n : $@convention(thin) (@inout TestView, TestRange, @in TestSlice) -> @out () // user: %6
 // CHECK:   [[THUNK:%.*]] = function_ref @thunk : $@convention(thin) (@inout TestView, @owned @callee_owned (@inout TestView) -> ()) -> @out ()
+// CHECK:   [[SPECIALIZED:%.*]] = function_ref @$s5thunk7closure4main9TestRangeVAC0D5SliceVTf1nc_n : $@convention(thin) (@inout TestView, TestRange, @in TestSlice) -> @out () // user: %6
 // CHECK:   [[CALL:%.*]] = apply [[SPECIALIZED]](%0, %1, %2) : $@convention(thin) (@inout TestView, TestRange, @in TestSlice) -> @out ()
 // CHECK:   %{{.*}} = tuple ()
 // CHECK:   return %{{.*}} : $()

--- a/test/SILOptimizer/closure_specialize_simple.sil
+++ b/test/SILOptimizer/closure_specialize_simple.sil
@@ -195,8 +195,8 @@ bb2:
 
 // CHECK-LABEL: sil @loop_driver : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> () {
 // CHECK-DAG: [[SPECIALIZED_FUN:%.*]] = function_ref @$s27simple_partial_apply_caller0a1_b1_C4_funBi1_Tf1c_n : $@convention(thin) (Builtin.Int1) -> Builtin.Int1
-// CHECK-DAG: [[SPECIALIZED_FUN2:%.*]] = function_ref @$s37simple_partial_apply_2nd_level_caller0a1_b1_C4_funBi1_Tf1c_n : $@convention(thin) (Builtin.Int1) -> Builtin.Int1
 // CHECK: apply [[SPECIALIZED_FUN]]
+// CHECK-DAG: [[SPECIALIZED_FUN2:%.*]] = function_ref @$s37simple_partial_apply_2nd_level_caller0a1_b1_C4_funBi1_Tf1c_n : $@convention(thin) (Builtin.Int1) -> Builtin.Int1
 // CHECK: apply [[SPECIALIZED_FUN2]]
 
 // We can't call this one b/c it is just a declaration.
@@ -205,9 +205,6 @@ bb2:
 
 // We handle closures with indirect results.
 // CHECK: [[CLOSUREFUN:%.*]] = function_ref @indirect_parameter_partial_apply_fun
-// CHECK-NOT: partial_apply [[CLOSUREFUN]]()
-// CHECK: [[INLINEDCLOSURE_CALLER1:%.*]] = function_ref @$s40indirect_parameter_partial_apply_caller10a1_b1_c1_D4_funTf1c_n
-// CHECK-NOT: partial_apply [[CLOSUREFUN]]()
 
 // We don't handle captured indirect @in and @in_guaranteed parameters yet.
 // CHECK: [[CLOSURE2:%.*]] = partial_apply [[CLOSUREFUN]](%{{.*}})
@@ -218,6 +215,8 @@ bb2:
 // CHECK:  [[CALLER2:%.*]] = function_ref @indirect_parameter_partial_apply_caller2
 // CHECK:  [[CALLER3:%.*]] = function_ref @indirect_parameter_partial_apply_caller3
 // CHECK:  [[CALLER4:%.*]] = function_ref @indirect_parameter_partial_apply_caller4
+
+// CHECK: [[INLINEDCLOSURE_CALLER1:%.*]] = function_ref @$s40indirect_parameter_partial_apply_caller10a1_b1_c1_D4_funTf1c_n
 
 // Closure with indirect result but no captured indirect parameter.
 // CHECK-NOT: apply [[CALLER1]]


### PR DESCRIPTION
Collect a map of applies to a vector of closures associated with that apply. Then, inline all the closures into the new specialized function and propagate all their arguments to the new function/apply. 

As much as possible I've tried to keep the logic the same. 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
