### PR TITLE
build: optimize the build of LLVMSupport

### DIFF
--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -62,6 +62,7 @@ endif()
 # built and cause link failures for mismatches. Without linking that library,
 # we get link failures regardless, so instead, this just disables the checks.
 add_compile_definitions($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1>)
+include_directories(BEFORE ${CMAKE_PROJECT_SOURCE_DIR}/include)
 
 set(SWIFT_STDLIB_LIBRARY_BUILD_TYPES)
 if(SWIFT_BUILD_DYNAMIC_STDLIB)

--- a/stdlib/public/LLVMSupport/CMakeLists.txt
+++ b/stdlib/public/LLVMSupport/CMakeLists.txt
@@ -18,7 +18,12 @@ set(LLVM_USE_PERF NO)
 configure_file(${PROJECT_SOURCE_DIR}/include/llvm/Config/llvm-config.h.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/llvm/Config/llvm-config.h)
 
-add_library(swiftLLVMSupport INTERFACE)
-target_include_directories(swiftLLVMSupport INTERFACE
-  ${CMAKE_CURRENT_BINARY_DIR}
-  ${CMAKE_PROJECT_SOURCE_DIR}/include)
+add_swift_target_library(swiftLLVMSupport OBJECT_LIBRARY
+    ErrorHandling.cpp
+    Hashing.cpp
+    MemAlloc.cpp
+    SmallPtrSet.cpp
+    SmallVector.cpp
+    StringRef.cpp
+  INSTALL_IN_COMPONENT
+    never_install)

--- a/stdlib/public/Reflection/CMakeLists.txt
+++ b/stdlib/public/Reflection/CMakeLists.txt
@@ -9,13 +9,7 @@ set(swiftReflection_SOURCES
   "${SWIFT_SOURCE_DIR}/lib/Demangling/NodePrinter.cpp"
   "${SWIFT_SOURCE_DIR}/lib/Demangling/ManglingUtils.cpp"
   "${SWIFT_SOURCE_DIR}/lib/Demangling/Punycode.cpp"
-  "${SWIFT_SOURCE_DIR}/lib/Demangling/Remangler.cpp"
-  "${SWIFT_SOURCE_DIR}/stdlib/public/LLVMSupport/ErrorHandling.cpp"
-  "${SWIFT_SOURCE_DIR}/stdlib/public/LLVMSupport/Hashing.cpp"
-  "${SWIFT_SOURCE_DIR}/stdlib/public/LLVMSupport/MemAlloc.cpp"
-  "${SWIFT_SOURCE_DIR}/stdlib/public/LLVMSupport/SmallPtrSet.cpp"
-  "${SWIFT_SOURCE_DIR}/stdlib/public/LLVMSupport/SmallVector.cpp"
-  "${SWIFT_SOURCE_DIR}/stdlib/public/LLVMSupport/StringRef.cpp")
+  "${SWIFT_SOURCE_DIR}/lib/Demangling/Remangler.cpp")
 
 # When we're building with assertions, include the demangle node dumper to aid
 # in debugging.
@@ -28,5 +22,6 @@ add_swift_target_library(swiftReflection STATIC
   ${swiftReflection_SOURCES}
   C_COMPILE_FLAGS ${SWIFT_RUNTIME_CXX_FLAGS} -DswiftCore_EXPORTS
   LINK_FLAGS ${SWIFT_RUNTIME_LINK_FLAGS}
+  INCORPORATE_OBJECT_LIBRARIES swiftLLVMSupport
   SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   INSTALL_IN_COMPONENT dev)

--- a/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
+++ b/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
@@ -4,18 +4,13 @@ if(SWIFT_BUILD_DYNAMIC_STDLIB)
   add_swift_target_library(swiftRemoteMirror
                            SHARED DONT_EMBED_BITCODE NOSWIFTRT
                            SwiftRemoteMirror.cpp
-                           "${SWIFT_SOURCE_DIR}/stdlib/public/LLVMSupport/ErrorHandling.cpp"
-                           "${SWIFT_SOURCE_DIR}/stdlib/public/LLVMSupport/Hashing.cpp"
-                           "${SWIFT_SOURCE_DIR}/stdlib/public/LLVMSupport/MemAlloc.cpp"
-                           "${SWIFT_SOURCE_DIR}/stdlib/public/LLVMSupport/SmallPtrSet.cpp"
-                           "${SWIFT_SOURCE_DIR}/stdlib/public/LLVMSupport/SmallVector.cpp"
-                           "${SWIFT_SOURCE_DIR}/stdlib/public/LLVMSupport/StringRef.cpp"
                            LINK_LIBRARIES
                              swiftReflection
                            C_COMPILE_FLAGS
                              ${SWIFT_RUNTIME_CXX_FLAGS} -DswiftRemoteMirror_EXPORTS
                            LINK_FLAGS
                              ${SWIFT_RUNTIME_LINK_FLAGS}
+                           INCORPORATE_OBJECT_LIBRARIES swiftLLVMSupport
                            SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
                            INSTALL_IN_COMPONENT
                              swift-remote-mirror)

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -319,7 +319,7 @@ add_swift_target_library(swiftCore
                   PRIVATE_LINK_LIBRARIES
                     ${swift_core_private_link_libraries}
                   INCORPORATE_OBJECT_LIBRARIES
-                    swiftRuntime swiftStdlibStubs
+                    swiftRuntime swiftLLVMSupport swiftStdlibStubs
                   FRAMEWORK_DEPENDS
                     ${swift_core_framework_depends}
                   INSTALL_IN_COMPONENT

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -63,12 +63,6 @@ set(swift_runtime_sources
     RefCount.cpp
     RuntimeInvocationsTracking.cpp
     SwiftDtoa.cpp
-    "${SWIFT_SOURCE_DIR}/stdlib/public/LLVMSupport/ErrorHandling.cpp"
-    "${SWIFT_SOURCE_DIR}/stdlib/public/LLVMSupport/Hashing.cpp"
-    "${SWIFT_SOURCE_DIR}/stdlib/public/LLVMSupport/MemAlloc.cpp"
-    "${SWIFT_SOURCE_DIR}/stdlib/public/LLVMSupport/SmallPtrSet.cpp"
-    "${SWIFT_SOURCE_DIR}/stdlib/public/LLVMSupport/SmallVector.cpp"
-    "${SWIFT_SOURCE_DIR}/stdlib/public/LLVMSupport/StringRef.cpp"
     "${SWIFT_SOURCE_DIR}/lib/Demangling/OldDemangler.cpp"
     "${SWIFT_SOURCE_DIR}/lib/Demangling/Demangler.cpp"
     "${SWIFT_SOURCE_DIR}/lib/Demangling/NodePrinter.cpp"
@@ -180,6 +174,7 @@ add_swift_target_library(swiftRuntime OBJECT_LIBRARY
     ${swift_runtime_library_compile_flags}
     ${_RUNTIME_NONATOMIC_FLAGS}
   LINK_FLAGS ${swift_runtime_linker_flags}
+  INCORPORATE_OBJECT_LIBRARIES swiftLLVMSupport
   SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   INSTALL_IN_COMPONENT never_install)
 

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -74,6 +74,7 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     # from the swiftCore dylib, so we need to link to both the runtime archive
     # and the stdlib.
     $<TARGET_OBJECTS:swiftRuntime${SWIFT_PRIMARY_VARIANT_SUFFIX}>
+    $<TARGET_OBJECTS:swiftLLVMSupport${SWIFT_PRIMARY_VARIANT_SUFFIX}>
     )
 
   # The local stdlib implementation provides definitions of the swiftCore

--- a/unittests/runtime/LongTests/CMakeLists.txt
+++ b/unittests/runtime/LongTests/CMakeLists.txt
@@ -37,6 +37,7 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     # from the swiftCore dylib, so we need to link to both the runtime archive
     # and the stdlib.
     $<TARGET_OBJECTS:swiftRuntime${SWIFT_PRIMARY_VARIANT_SUFFIX}>
+    $<TARGET_OBJECTS:swiftLLVMSupport${SWIFT_PRIMARY_VARIANT_SUFFIX}>
     )
 
   # The local stdlib implementation provides definitions of the swiftCore


### PR DESCRIPTION
Rather than build multiple copies of LLVMSupport (4x!) build it one and
merge it into the various targets.  This would ideally not be needed to
be named explicitly everywhere, but that requires using `add_library`
rather than `add_swift_target_library`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
