### PR TITLE
[silgen] Add an extra swift-version 5 run to initializer tests.

### DIFF
--- a/test/Interpreter/convenience_init_peer_delegation.swift
+++ b/test/Interpreter/convenience_init_peer_delegation.swift
@@ -1,11 +1,26 @@
 // RUN: %empty-directory(%t)
-
+//
 // RUN: %target-build-swift %s -Xfrontend -disable-objc-attr-requires-foundation-module -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 
+// RUN: %empty-directory(%t)
+//
 // RUN: sed -e 's/required//g' < %s > %t/without_required.swift
 // RUN: %target-build-swift %t/without_required.swift -Xfrontend -disable-objc-attr-requires-foundation-module -o %t/without_required
+// RUN: %target-codesign %t/without_required
+// RUN: %target-run %t/without_required | %FileCheck %s
+
+// RUN: %empty-directory(%t)
+//
+// RUN: %target-build-swift %s -Xfrontend -disable-objc-attr-requires-foundation-module -o %t/main -swift-version 5
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// RUN: %empty-directory(%t)
+//
+// RUN: sed -e 's/required//g' < %s > %t/without_required.swift
+// RUN: %target-build-swift %t/without_required.swift -Xfrontend -disable-objc-attr-requires-foundation-module -o %t/without_required -swift-version 5
 // RUN: %target-codesign %t/without_required
 // RUN: %target-run %t/without_required | %FileCheck %s
 

--- a/test/Interpreter/failable_initializers.swift
+++ b/test/Interpreter/failable_initializers.swift
@@ -1,4 +1,6 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-swift-version 4)
+// RUN: %target-run-simple-swift(-swift-version 5)
+
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/Interpreter/initializers.swift
+++ b/test/Interpreter/initializers.swift
@@ -1,4 +1,6 @@
-// RUN: %target-run-simple-swift | %FileCheck %s
+// RUN: %target-run-simple-swift(-swift-version 4) | %FileCheck %s
+// RUN: %target-run-simple-swift(-swift-version 5) | %FileCheck %s
+
 // REQUIRES: executable_test
 
 // Test initialization and initializer inheritance.

--- a/test/Interpreter/objc_failable_initializers.swift
+++ b/test/Interpreter/objc_failable_initializers.swift
@@ -5,6 +5,16 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 
+// RUN: %empty-directory(%t)
+//
+// target-build-swift assumes we want -swift-version 4. Behavior in initializers
+// changed in swift 5, so we want to explicitly check it as well.
+//
+// RUN: %target-clang -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o
+// RUN: %target-build-swift -I %S/Inputs/ObjCClasses/ -Xlinker %t/ObjCClasses.o %s -o %t/a.out -swift-version 5
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 

--- a/test/Interpreter/protocol_initializers.swift
+++ b/test/Interpreter/protocol_initializers.swift
@@ -1,8 +1,16 @@
+
 // RUN: %empty-directory(%t)
+//
+// RUN: %target-build-swift %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+
+// RUN: %empty-directory(%t)
+//
 // RUN: %target-build-swift -swift-version 5 %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
-//
 // RUN: %target-run %t/a.out
+
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/Interpreter/protocol_initializers_class.swift
+++ b/test/Interpreter/protocol_initializers_class.swift
@@ -1,8 +1,6 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-build-swift -swift-version 5 %s -o %t/a.out
-// RUN: %target-codesign %t/a.out
-//
-// RUN: %target-run %t/a.out
+// RUN: %target-run-simple-swift(-swift-version 4)
+// RUN: %target-run-simple-swift(-swift-version 5)
+
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/Interpreter/throwing_initializers.swift
+++ b/test/Interpreter/throwing_initializers.swift
@@ -1,4 +1,6 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-swift-version 4)
+// RUN: %target-run-simple-swift(-swift-version 5)
+
 // REQUIRES: executable_test
 
 import StdlibUnittest


### PR DESCRIPTION
We currently run these in swift-version 4 by default. This caused us to miss
some bugs that only occur in swift-version 5 due to initializer changes
happening in swift 5. This at least will allow us to catch such issues in the
future.

NOTE: I am also going to change objc_throwing_initializers.swift in the same
way, but after I fix the bugs that adding -swift-version 5 exposes therein
(which is actually <rdar://problem/59830255>)