### PR TITLE
Fix use iteration in replacePhiArgumentAndReplaceAllUses.

### DIFF
--- a/lib/SIL/IR/SILBasicBlock.cpp
+++ b/lib/SIL/IR/SILBasicBlock.cpp
@@ -226,9 +226,10 @@ SILPhiArgument *SILBasicBlock::replacePhiArgumentAndReplaceAllUses(
   // any uses.
   SmallVector<Operand *, 16> operands;
   SILValue undef = SILUndef::get(ty, *getParent());
-  for (auto *use : getArgument(i)->getUses()) {
+  while (!getArgument(i)->use_empty()) {
+    auto use = getArgument(i)->use_begin();
     use->set(undef);
-    operands.push_back(use);
+    operands.push_back(*use);
   }
 
   // Perform the replacement.


### PR DESCRIPTION
Iterate over uses of the specified argument in such a way that modifying the use range doesn't cause unexpected behavior while iterating.

Currently, `replacePhiArgumentAndReplaceAllUses` isn't ever used so, there are no tests accompanying this change (the only use of `replacePhiArgumentAndReplaceAllUses` is in the `CastOptimizer` in ownership mode which is only invoked from `SILCombine` and `SimplifyCFG` neither of which support ownership). 