### PR TITLE
AST: Transition to storing substitution maps in bound generic type nodes

### DIFF
--- a/include/swift/AST/TypeDifferenceVisitor.h
+++ b/include/swift/AST/TypeDifferenceVisitor.h
@@ -170,7 +170,8 @@ public:
       return asImpl().visitDifferentTypeStructure(type1, type2);
 
     return visitComponentArray(type1, type2,
-                               type1.getGenericArgs(), type2.getGenericArgs());
+                               type1.getDirectGenericArgs(),
+                               type2.getDirectGenericArgs());
   }
 
   bool visitAnyMetatypeType(CanAnyMetatypeType type1,

--- a/include/swift/AST/TypeMatcher.h
+++ b/include/swift/AST/TypeMatcher.h
@@ -284,11 +284,10 @@ class TypeMatcher {
                          sugaredFirstBGT->getParent()))
           return false;
 
-        for (unsigned i = 0, n = firstBGT->getGenericArgs().size();
-             i != n; ++i) {
-          if (!this->visit(firstBGT.getGenericArgs()[i],
-                           secondBGT->getGenericArgs()[i],
-                           sugaredFirstBGT->getGenericArgs()[i]))
+        for (const auto i: indices(firstBGT->getDirectGenericArgs())) {
+          if (!this->visit(firstBGT.getDirectGenericArgs()[i],
+                           secondBGT->getDirectGenericArgs()[i],
+                           sugaredFirstBGT->getDirectGenericArgs()[i]))
             return false;
         }
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2223,12 +2223,12 @@ public:
                                ArrayRef<Type> GenericArgs);
 
   /// Retrieve the set of generic arguments provided at this level.
-  ArrayRef<Type> getGenericArgs() const {
+  ArrayRef<Type> getDirectGenericArgs() const {
     return {getTrailingObjectsPointer(), Bits.BoundGenericType.GenericArgCount};
   }
 
   void Profile(llvm::FoldingSetNodeID &ID) {
-    Profile(ID, getDecl(), getParent(), getGenericArgs());
+    Profile(ID, getDecl(), getParent(), getDirectGenericArgs());
   }
   static void Profile(llvm::FoldingSetNodeID &ID, NominalTypeDecl *TheDecl,
                       Type Parent, ArrayRef<Type> GenericArgs);
@@ -2240,8 +2240,8 @@ public:
   }
 };
 BEGIN_CAN_TYPE_WRAPPER(BoundGenericType, NominalOrBoundGenericNominalType)
-  CanTypeArrayRef getGenericArgs() const {
-    return CanTypeArrayRef(getPointer()->getGenericArgs());
+  CanTypeArrayRef getDirectGenericArgs() const {
+    return CanTypeArrayRef(getPointer()->getDirectGenericArgs());
   }
 END_CAN_TYPE_WRAPPER(BoundGenericType, NominalOrBoundGenericNominalType)
 
@@ -6413,7 +6413,7 @@ inline Type TupleTypeElt::getVarargBaseTy() const {
     return AT->getBaseType();
   if (auto *BGT = dyn_cast<BoundGenericType>(T)) {
     // It's the stdlib Array<T>.
-    return BGT->getGenericArgs()[0];
+    return BGT->getDirectGenericArgs()[0];
   }
   assert(T->hasError());
   return T;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2262,13 +2262,6 @@ private:
   friend class BoundGenericType;
 
 public:
-  static BoundGenericClassType* get(ClassDecl *theDecl, Type parent,
-                                    ArrayRef<Type> genericArgs) {
-    return cast<BoundGenericClassType>(
-             BoundGenericType::get(reinterpret_cast<NominalTypeDecl*>(theDecl),
-                                   parent, genericArgs));
-  }
-
   /// Returns the declaration that declares this type.
   ClassDecl *getDecl() const {
     return reinterpret_cast<ClassDecl*>(BoundGenericType::getDecl());
@@ -2296,13 +2289,6 @@ private:
   friend class BoundGenericType;
 
 public:
-  static BoundGenericEnumType* get(EnumDecl *theDecl, Type parent,
-                                    ArrayRef<Type> genericArgs) {
-    return cast<BoundGenericEnumType>(
-             BoundGenericType::get(reinterpret_cast<NominalTypeDecl*>(theDecl),
-                                   parent, genericArgs));
-  }
-
   /// Returns the declaration that declares this type.
   EnumDecl *getDecl() const {
     return reinterpret_cast<EnumDecl*>(BoundGenericType::getDecl());
@@ -2330,13 +2316,6 @@ private:
   friend class BoundGenericType;
 
 public:
-  static BoundGenericStructType* get(StructDecl *theDecl, Type parent,
-                                    ArrayRef<Type> genericArgs) {
-    return cast<BoundGenericStructType>(
-             BoundGenericType::get(reinterpret_cast<NominalTypeDecl*>(theDecl),
-                                   parent, genericArgs));
-  }
-
   /// Returns the declaration that declares this type.
   StructDecl *getDecl() const {
     return reinterpret_cast<StructDecl*>(BoundGenericType::getDecl());

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2214,9 +2214,9 @@ class BoundGenericType : public NominalOrBoundGenericNominalType,
   }
 
 protected:
-  BoundGenericType(TypeKind theKind, NominalTypeDecl *theDecl, Type parent,
-                   ArrayRef<Type> genericArgs, const ASTContext *context,
-                   RecursiveTypeProperties properties);
+  BoundGenericType(TypeKind K, NominalTypeDecl *TheDecl, Type Parent,
+                   ArrayRef<Type> GenericArgs, const ASTContext *C,
+                   RecursiveTypeProperties Properties);
 
 public:
   static BoundGenericType* get(NominalTypeDecl *TheDecl, Type Parent,
@@ -2253,12 +2253,12 @@ class BoundGenericClassType final : public BoundGenericType,
   friend TrailingObjects;
 
 private:
-  BoundGenericClassType(ClassDecl *theDecl, Type parent,
-                        ArrayRef<Type> genericArgs, const ASTContext *context,
-                        RecursiveTypeProperties properties)
+  BoundGenericClassType(ClassDecl *TheDecl, Type Parent,
+                        ArrayRef<Type> GenericArgs, const ASTContext *C,
+                        RecursiveTypeProperties Properties)
     : BoundGenericType(TypeKind::BoundGenericClass,
-                       reinterpret_cast<NominalTypeDecl*>(theDecl), parent,
-                       genericArgs, context, properties) {}
+                       reinterpret_cast<NominalTypeDecl*>(TheDecl), Parent,
+                       GenericArgs, C, Properties) {}
   friend class BoundGenericType;
 
 public:
@@ -2280,12 +2280,12 @@ class BoundGenericEnumType final : public BoundGenericType,
   friend TrailingObjects;
 
 private:
-  BoundGenericEnumType(EnumDecl *theDecl, Type parent,
-                       ArrayRef<Type> genericArgs, const ASTContext *context,
-                       RecursiveTypeProperties properties)
+  BoundGenericEnumType(EnumDecl *TheDecl, Type Parent,
+                       ArrayRef<Type> GenericArgs, const ASTContext *C,
+                       RecursiveTypeProperties Properties)
     : BoundGenericType(TypeKind::BoundGenericEnum,
-                       reinterpret_cast<NominalTypeDecl*>(theDecl), parent,
-                       genericArgs, context, properties) {}
+                       reinterpret_cast<NominalTypeDecl*>(TheDecl), Parent,
+                       GenericArgs, C, Properties) {}
   friend class BoundGenericType;
 
 public:
@@ -2307,12 +2307,12 @@ class BoundGenericStructType final : public BoundGenericType,
   friend TrailingObjects;
 
 private:
-  BoundGenericStructType(StructDecl *theDecl, Type parent,
-                         ArrayRef<Type> genericArgs, const ASTContext *context,
-                         RecursiveTypeProperties properties)
+  BoundGenericStructType(StructDecl *TheDecl, Type Parent,
+                         ArrayRef<Type> GenericArgs, const ASTContext *C,
+                         RecursiveTypeProperties Properties)
     : BoundGenericType(TypeKind::BoundGenericStruct, 
-                       reinterpret_cast<NominalTypeDecl*>(theDecl), parent,
-                       genericArgs, context, properties) {}
+                       reinterpret_cast<NominalTypeDecl*>(TheDecl), Parent,
+                       GenericArgs, C, Properties) {}
   friend class BoundGenericType;
 
 public:

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -693,8 +693,7 @@ Type ASTBuilder::createBoundGenericObjCClassType(StringRef name,
     parent = dc->getDeclaredInterfaceType();
   }
 
-  return BoundGenericClassType::get(cast<ClassDecl>(typeDecl),
-                                    parent, args);
+  return BoundGenericType::get(cast<ClassDecl>(typeDecl), parent, args);
 }
 
 ProtocolDecl *ASTBuilder::createObjCProtocolDecl(StringRef name) {

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -292,8 +292,10 @@ Type ASTBuilder::createBoundGenericType(GenericTypeDecl *decl,
   if (!validateParentType(decl, parent))
     return Type();
 
+  // FIXME: This is the wrong module
+  auto *moduleDecl = decl->getParentModule();
   if (auto *nominalDecl = dyn_cast<NominalTypeDecl>(decl))
-    return BoundGenericType::get(nominalDecl, parent, args);
+    return BoundGenericType::get(nominalDecl, parent, args, moduleDecl);
 
   // Combine the substitutions from our parent type with our generic
   // arguments.
@@ -312,8 +314,6 @@ Type ASTBuilder::createBoundGenericType(GenericTypeDecl *decl,
       substTy;
   }
 
-  // FIXME: This is the wrong module
-  auto *moduleDecl = decl->getParentModule();
   auto subMap = SubstitutionMap::get(genericSig,
                                      QueryTypeSubstitutionMap{subs},
                                      LookUpConformanceInModule(moduleDecl));

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3868,7 +3868,7 @@ namespace {
       printField("decl", T->getDecl()->printRef());
       if (T->getParent())
         printRec("parent", T->getParent());
-      for (auto arg : T->getGenericArgs())
+      for (const auto &arg : T->getDirectGenericArgs())
         printRec(arg);
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
@@ -3879,7 +3879,7 @@ namespace {
       printField("decl", T->getDecl()->printRef());
       if (T->getParent())
         printRec("parent", T->getParent());
-      for (auto arg : T->getGenericArgs())
+      for (const auto &arg : T->getDirectGenericArgs())
         printRec(arg);
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
@@ -3889,7 +3889,7 @@ namespace {
       printField("decl", T->getDecl()->printRef());
       if (T->getParent())
         printRec("parent", T->getParent());
-      for (auto arg : T->getGenericArgs())
+      for (const auto &arg : T->getDirectGenericArgs())
         printRec(arg);
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1116,7 +1116,8 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
           return;
 
         if (Decl->isStdlibDecl() && Decl->getName().str() == "Optional") {
-          auto GenArgs = type->castTo<BoundGenericType>()->getGenericArgs();
+          const auto GenArgs =
+              type->castTo<BoundGenericType>()->getDirectGenericArgs();
           assert(GenArgs.size() == 1);
           appendType(GenArgs[0], forDecl);
           appendOperator("Sg");
@@ -1433,7 +1434,7 @@ void ASTMangler::appendBoundGenericArgs(Type type, bool &isFirstArgList) {
       appendBoundGenericArgs(parent->getDesugaredType(), isFirstArgList);
   } else {
     auto boundType = cast<BoundGenericType>(typePtr);
-    genericArgs = boundType->getGenericArgs();
+    genericArgs = boundType->getDirectGenericArgs();
     if (Type parent = boundType->getParent()) {
       GenericTypeDecl *decl = boundType->getAnyGeneric();
       if (!getSpecialManglingContext(decl, UseObjCRuntimeNames))

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2785,7 +2785,7 @@ void PrintAST::printOneParameter(const ParamDecl *param,
   // to strip off the added array type.
   if (param->isVariadic() && TheTypeLoc.getType()) {
     if (auto *BGT = TheTypeLoc.getType()->getAs<BoundGenericType>())
-      TheTypeLoc.setType(BGT->getGenericArgs()[0]);
+      TheTypeLoc.setType(BGT->getDirectGenericArgs()[0]);
   }
 
   if (!param->isVariadic() &&
@@ -3870,26 +3870,26 @@ public:
       auto &Ctx = T->getASTContext();
       if (NT == Ctx.getArrayDecl()) {
         Printer << "[";
-        visit(T->getGenericArgs()[0]);
+        visit(T->getDirectGenericArgs()[0]);
         Printer << "]";
         return;
       }
       if (NT == Ctx.getDictionaryDecl()) {
         Printer << "[";
-        visit(T->getGenericArgs()[0]);
+        visit(T->getDirectGenericArgs()[0]);
         Printer << " : ";
-        visit(T->getGenericArgs()[1]);
+        visit(T->getDirectGenericArgs()[1]);
         Printer << "]";
         return;
       }
       if (NT == Ctx.getOptionalDecl()) {
-        printWithParensIfNotSimple(T->getGenericArgs()[0]);
+        printWithParensIfNotSimple(T->getDirectGenericArgs()[0]);
         Printer << "?";
         return;
       }
     }
     printQualifiedType(T);
-    printGenericArgs(T->getGenericArgs());
+    printGenericArgs(T->getDirectGenericArgs());
   }
 
   void visitParentType(Type T) {

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2203,7 +2203,7 @@ public:
       } else if (auto bgt = keyPathTy->getAs<BoundGenericType>()) {
         if (bgt->getDecl() == Ctx.getPartialKeyPathDecl()) {
           // PartialKeyPath<T> application is rvalue T -> rvalue Any
-          if (!baseTy->isEqual(bgt->getGenericArgs()[0])) {
+          if (!baseTy->isEqual(bgt->getDirectGenericArgs()[0])) {
             Out << "PartialKeyPath application base doesn't match type\n";
             abort();
           }
@@ -2214,11 +2214,11 @@ public:
           return;
         } else if (bgt->getDecl() == Ctx.getKeyPathDecl()) {
           // KeyPath<T, U> application is rvalue T -> rvalue U
-          if (!baseTy->isEqual(bgt->getGenericArgs()[0])) {
+          if (!baseTy->isEqual(bgt->getDirectGenericArgs()[0])) {
             Out << "KeyPath application base doesn't match type\n";
             abort();
           }
-          if (!resultTy->isEqual(bgt->getGenericArgs()[1])) {
+          if (!resultTy->isEqual(bgt->getDirectGenericArgs()[1])) {
             Out << "KeyPath application result doesn't match type\n";
             abort();
           }
@@ -2236,11 +2236,11 @@ public:
             resultTy = resultTy->getRValueType();
           }
           
-          if (!baseTy->isEqual(bgt->getGenericArgs()[0])) {
+          if (!baseTy->isEqual(bgt->getDirectGenericArgs()[0])) {
             Out << "WritableKeyPath application base doesn't match type\n";
             abort();
           }
-          if (!resultTy->isEqual(bgt->getGenericArgs()[1])) {
+          if (!resultTy->isEqual(bgt->getDirectGenericArgs()[1])) {
             Out << "WritableKeyPath application result doesn't match type\n";
             abort();
           }
@@ -2262,12 +2262,12 @@ public:
             resultTy = resultTy->getRValueType();
           }
 
-          if (!baseTy->isEqual(bgt->getGenericArgs()[0])) {
+          if (!baseTy->isEqual(bgt->getDirectGenericArgs()[0])) {
             Out << "ReferenceWritableKeyPath application base doesn't "
                    "match type\n";
             abort();
           }
-          if (!resultTy->isEqual(bgt->getGenericArgs()[1])) {
+          if (!resultTy->isEqual(bgt->getDirectGenericArgs()[1])) {
             Out << "ReferenceWritableKeyPath application result doesn't "
                    "match type\n";
             abort();

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1331,7 +1331,7 @@ static ValueDecl *getConvertUnownedUnsafeToGuaranteed(ASTContext &ctx,
 
 static ValueDecl *getPoundAssert(ASTContext &Context, Identifier Id) {
   auto int1Type = BuiltinIntegerType::get(1, Context);
-  auto optionalRawPointerType = BoundGenericEnumType::get(
+  auto optionalRawPointerType = BoundGenericType::get(
       Context.getOptionalDecl(), Type(), {Context.TheRawPointerType});
   return getBuiltinFunction(Id, {int1Type, optionalRawPointerType},
                             Context.TheEmptyTupleType);

--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -473,7 +473,7 @@ ClangTypeConverter::visitBoundGenericType(BoundGenericType *type) {
   // The only possibilities are *Pointer<T>, SIMD*<T> and Optional<T>.
 
   if (type->getDecl()->isOptionalDecl()) {
-    auto args = type->getGenericArgs();
+    const auto args = type->getDirectGenericArgs();
     assert((args.size() == 1) && "Optional should have 1 generic argument.");
     clang::QualType innerTy = convert(args[0]);
     if (swift::canImportAsOptional(innerTy.getTypePtrOrNull()))
@@ -501,7 +501,7 @@ ClangTypeConverter::visitBoundGenericType(BoundGenericType *type) {
     .StartsWith("SIMD", StructKind::SIMD)
     .Default(StructKind::Invalid);
 
-  auto args = type->getGenericArgs();
+  const auto args = type->getDirectGenericArgs();
   if (args.size() != 1)
     // Must've got something other than *Pointer or SIMD*
     return clang::QualType();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3759,15 +3759,9 @@ static Type computeNominalType(NominalTypeDecl *decl, DeclTypeKind kind) {
     case DeclTypeKind::DeclaredType:
       return UnboundGenericType::get(decl, ParentTy, ctx);
     case DeclTypeKind::DeclaredInterfaceType: {
-      // Note that here, we need to be able to produce a type
-      // before the decl has been validated, so we rely on
-      // the generic parameter list directly instead of looking
-      // at the signature.
-      SmallVector<Type, 4> args;
-      for (auto param : decl->getGenericParams()->getParams())
-        args.push_back(param->getDeclaredInterfaceType());
-
-      return BoundGenericType::get(decl, ParentTy, args);
+      const auto sig = decl->getGenericSignature();
+      return BoundGenericType::get(decl, ParentTy,
+                                   sig->getIdentitySubstitutionMap());
     }
     }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4935,7 +4935,7 @@ findProtocolSelfReferences(const ProtocolDecl *proto, Type type,
 
   // Bound generic types are invariant.
   if (auto boundGenericType = type->getAs<BoundGenericType>()) {
-    for (auto paramType : boundGenericType->getGenericArgs()) {
+    for (const auto &paramType : boundGenericType->getDirectGenericArgs()) {
       if (findProtocolSelfReferences(proto, paramType,
                                      skipAssocTypes)) {
         return SelfReferenceKind::Other();
@@ -6302,7 +6302,7 @@ Type ParamDecl::getVarargBaseTy(Type VarArgT) {
     return AT->getBaseType();
   if (auto *BGT = dyn_cast<BoundGenericType>(T)) {
     // It's the stdlib Array<T>.
-    return BGT->getGenericArgs()[0];
+    return BGT->getDirectGenericArgs()[0];
   }
   return T;
 }

--- a/lib/AST/TypeWalker.cpp
+++ b/lib/AST/TypeWalker.cpp
@@ -181,7 +181,7 @@ class Traversal : public TypeVisitor<Traversal, bool>
       if (doIt(parent))
         return true;
 
-    for (auto arg : ty->getGenericArgs())
+    for (const auto &arg : ty->getDirectGenericArgs())
       if (doIt(arg))
         return true;
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5618,8 +5618,9 @@ SwiftDeclConverter::importSwiftNewtype(const clang::TypedefNameDecl *decl,
   // to determine whether to use this new_type, or an Unmanaged<CF...> type.
   if (auto genericType = storedUnderlyingType->getAs<BoundGenericType>()) {
     if (genericType->getDecl() == Impl.SwiftContext.getUnmanagedDecl()) {
-      assert(genericType->getGenericArgs().size() == 1 && "other args?");
-      storedUnderlyingType = genericType->getGenericArgs()[0];
+      assert(genericType->getDirectGenericArgs().size() == 1
+             && "other args?");
+      storedUnderlyingType = genericType->getDirectGenericArgs()[0];
     }
   }
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -973,7 +973,7 @@ namespace {
             }
           }
           assert(importedTypeArgs.size() == typeParamCount);
-          importedType = BoundGenericClassType::get(
+          importedType = BoundGenericType::get(
             imported, nullptr, importedTypeArgs);
         } else {
           importedType = imported->getDeclaredType();

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1289,10 +1289,10 @@ static Type maybeImportCFOutParameter(ClangImporter::Implementation &impl,
   if (boundGenericBase != impl.SwiftContext.getUnmanagedDecl())
     return Type();
 
-  assert(boundGenericTy->getGenericArgs().size() == 1 &&
+  assert(boundGenericTy->getDirectGenericArgs().size() == 1 &&
          "signature of Unmanaged has changed");
 
-  auto resultTy = boundGenericTy->getGenericArgs().front();
+  auto resultTy = boundGenericTy->getDirectGenericArgs().front();
   if (isOptional)
     resultTy = OptionalType::get(resultTy);
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -5878,7 +5878,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
   case CompletionKind::KeyPathExprSwift: {
     auto KPE = dyn_cast<KeyPathExpr>(ParsedExpr);
     auto BGT = (*ExprType)->getAs<BoundGenericType>();
-    if (!KPE || !BGT || BGT->getGenericArgs().size() != 2)
+    if (!KPE || !BGT || BGT->getDirectGenericArgs().size() != 2)
       break;
     assert(!KPE->isObjC());
 
@@ -5888,7 +5888,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
     bool OnRoot = !KPE->getComponents().front().isValid();
     Lookup.setIsSwiftKeyPathExpr(OnRoot);
 
-    Type baseType = BGT->getGenericArgs()[OnRoot ? 0 : 1];
+    Type baseType = BGT->getDirectGenericArgs()[OnRoot ? 0 : 1];
     if (OnRoot && baseType->is<UnresolvedType>()) {
       // Infer the root type of the keypath from the context type.
       ExprContextInfo ContextInfo(CurDeclContext, ParsedExpr);
@@ -5899,7 +5899,8 @@ void CodeCompletionCallbacksImpl::doneParsing() {
         // If the context type is any of the KeyPath types, use it.
         if (T->getAnyNominal() && T->getAnyNominal()->getKeyPathTypeKind() &&
             !T->hasUnresolvedType() && T->is<BoundGenericType>()) {
-          baseType = T->castTo<BoundGenericType>()->getGenericArgs()[0];
+          baseType =
+              T->castTo<BoundGenericType>()->getDirectGenericArgs()[0];
           break;
         }
 

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -484,7 +484,8 @@ static void collectPossibleCalleesByQualifiedLookup(
 
     auto *kpDecl = Ctx.getKeyPathDecl();
     Type kpTy = kpDecl->mapTypeIntoContext(kpDecl->getDeclaredInterfaceType());
-    Type kpValueTy = kpTy->castTo<BoundGenericType>()->getGenericArgs()[1];
+    Type kpValueTy =
+        kpTy->castTo<BoundGenericType>()->getDirectGenericArgs()[1];
     kpTy = BoundGenericType::get(kpDecl, Type(), {baseTy, kpValueTy});
 
     Type fnTy = FunctionType::get(
@@ -787,12 +788,12 @@ class ExprContextAnalyzer {
           // let _: [Element] = [#HERE#]
           // In this case, 'Element' is the expected type.
           if (boundGenericT->getDecl() == Context.getArrayDecl())
-            recordPossibleType(boundGenericT->getGenericArgs()[0]);
+            recordPossibleType(boundGenericT->getDirectGenericArgs()[0]);
 
           // let _: [Key : Value] = [#HERE#]
           // In this case, 'Key' is the expected type.
           if (boundGenericT->getDecl() == Context.getDictionaryDecl())
-            recordPossibleType(boundGenericT->getGenericArgs()[0]);
+            recordPossibleType(boundGenericT->getDirectGenericArgs()[0]);
         }
       }
       break;
@@ -812,14 +813,14 @@ class ExprContextAnalyzer {
               // '(Key,Value)' here, 'ExprKind::Tuple' branch can decide which
               // type in the tuple type is the exprected type.
               SmallVector<TupleTypeElt, 2> elts;
-              for (auto genericArg : boundGenericT->getGenericArgs())
-                elts.emplace_back(genericArg);
+              for (const auto &arg : boundGenericT->getDirectGenericArgs())
+                elts.emplace_back(arg);
               recordPossibleType(TupleType::get(elts, DC->getASTContext()));
             } else {
               // let _: [Key : Value] = [key: val, #HERE#]
               // In this case, assume 'Key' is the expected type.
               if (boundGenericT->getDecl() == Context.getDictionaryDecl())
-                recordPossibleType(boundGenericT->getGenericArgs()[0]);
+                recordPossibleType(boundGenericT->getDirectGenericArgs()[0]);
             }
           }
         }

--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -480,7 +480,7 @@ GenClangType::visitBoundGenericType(CanBoundGenericType type) {
     .StartsWith("SIMD", StructKind::SIMD)
     .Default(StructKind::Invalid);
   
-  auto args = type.getGenericArgs();
+  const auto args = type.getDirectGenericArgs();
   assert(args.size() == 1 &&
          "should have a single generic argument!");
   auto loweredArgTy = IGM.getLoweredType(args[0]).getASTType();

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1018,7 +1018,7 @@ private:
   /// resolved in the debugger without needing to query the Swift module.
   llvm::DINodeArray collectGenericParams(BoundGenericType *BGT) {
     SmallVector<llvm::Metadata *, 16> TemplateParams;
-    for (auto Param : BGT->getGenericArgs()) {
+    for (auto Param : BGT->getDirectGenericArgs()) {
       TemplateParams.push_back(DBuilder.createTemplateTypeParameter(
           TheCU, "", getOrCreateType(DebugTypeInfo::getForwardDecl(Param))));
     }

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -2497,7 +2497,7 @@ static bool shouldAccessByMangledName(IRGenModule &IGM, CanType type) {
       // accessor.
       //
       // TODO: Also need to count the parent type's generic arguments.
-      for (auto arg : bgt->getGenericArgs()) {
+      for (const auto arg : bgt->getDirectGenericArgs()) {
         visit(arg);
       }
       NumCalls += 1;

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -2913,9 +2913,9 @@ public:
       auto payloadTy = visit(objectTy);
       if (payloadTy == objectTy)
         return ty;
-      auto &C = ty->getASTContext();
-      auto optDecl = C.getOptionalDecl();
-      return CanType(BoundGenericType::get(optDecl, Type(), payloadTy));
+      auto *const optDecl = ty->getASTContext().getOptionalDecl();
+      return BoundGenericType::get(optDecl, Type(), payloadTy)
+          ->getCanonicalType();
     }
 
     // Otherwise, generic arguments are not lowered.

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -2915,7 +2915,7 @@ public:
         return ty;
       auto &C = ty->getASTContext();
       auto optDecl = C.getOptionalDecl();
-      return CanType(BoundGenericEnumType::get(optDecl, Type(), payloadTy));
+      return CanType(BoundGenericType::get(optDecl, Type(), payloadTy));
     }
 
     // Otherwise, generic arguments are not lowered.

--- a/lib/PrintAsObjC/ModuleContentsWriter.cpp
+++ b/lib/PrintAsObjC/ModuleContentsWriter.cpp
@@ -84,7 +84,7 @@ class ReferencedTypeFinder : public TypeDeclFinder {
     bool isObjCGeneric = decl->hasClangNode();
     auto sig = decl->getGenericSignature();
 
-    for_each(boundGeneric->getGenericArgs(),
+    for_each(boundGeneric->getDirectGenericArgs(),
              sig->getInnermostGenericParams(),
              [&](Type argTy, GenericTypeParamType *paramTy) {
       // FIXME: I think there's a bug here with recursive generic types.

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -3327,7 +3327,7 @@ static CanType copyOptionalityFromDerivedToBase(TypeConverter &tc,
     base = copyOptionalityFromDerivedToBase(tc, derived, base);
 
     auto optDecl = tc.Context.getOptionalDecl();
-    return CanType(BoundGenericEnumType::get(optDecl, Type(), base));
+    return CanType(BoundGenericType::get(optDecl, Type(), base));
   }
 
   // (T1, T2, ...) +> (S1, S2, ...) = (T1 +> S1, T2 +> S2, ...)
@@ -3807,8 +3807,8 @@ public:
       return visitType(origType);
     }
 
-    CanType origObjectType = origType.getGenericArgs()[0];
-    CanType substObjectType = visit(origObjectType);
+    const CanType origObjectType = origType.getDirectGenericArgs()[0];
+    const CanType substObjectType = visit(origObjectType);
     return CanType(BoundGenericType::get(origType->getDecl(), Type(),
                                          substObjectType));
   }

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -3327,7 +3327,7 @@ static CanType copyOptionalityFromDerivedToBase(TypeConverter &tc,
     base = copyOptionalityFromDerivedToBase(tc, derived, base);
 
     auto optDecl = tc.Context.getOptionalDecl();
-    return CanType(BoundGenericType::get(optDecl, Type(), base));
+    return BoundGenericType::get(optDecl, Type(), base)->getCanonicalType();
   }
 
   // (T1, T2, ...) +> (S1, S2, ...) = (T1 +> S1, T2 +> S2, ...)
@@ -3809,8 +3809,8 @@ public:
 
     const CanType origObjectType = origType.getDirectGenericArgs()[0];
     const CanType substObjectType = visit(origObjectType);
-    return CanType(BoundGenericType::get(origType->getDecl(), Type(),
-                                         substObjectType));
+    return BoundGenericType::get(origType->getDecl(), Type(), substObjectType)
+        ->getCanonicalType();
   }
 
   /// Any other type would be a valid type in the AST. Just apply the

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -71,8 +71,8 @@ SILType SILType::getBuiltinWordType(const ASTContext &C) {
 
 SILType SILType::getOptionalType(SILType type) {
   auto &ctx = type.getASTContext();
-  auto optType = BoundGenericEnumType::get(ctx.getOptionalDecl(), Type(),
-                                           { type.getASTType() });
+  auto optType = BoundGenericType::get(ctx.getOptionalDecl(), Type(),
+                                       { type.getASTType() });
   return getPrimitiveType(CanType(optType), type.getCategory());
 }
 

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -73,7 +73,7 @@ SILType SILType::getOptionalType(SILType type) {
   auto &ctx = type.getASTContext();
   auto optType = BoundGenericType::get(ctx.getOptionalDecl(), Type(),
                                        { type.getASTType() });
-  return getPrimitiveType(CanType(optType), type.getCategory());
+  return getPrimitiveType(optType->getCanonicalType(), type.getCategory());
 }
 
 SILType SILType::getSILTokenType(const ASTContext &C) {

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -1674,7 +1674,7 @@ static CanType computeLoweredOptionalType(TypeConverter &tc,
   }
 
   auto optDecl = tc.Context.getOptionalDecl();
-  return CanType(BoundGenericEnumType::get(optDecl, Type(), loweredObjectType));
+  return CanType(BoundGenericType::get(optDecl, Type(), loweredObjectType));
 }
 
 static CanType

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -1674,7 +1674,8 @@ static CanType computeLoweredOptionalType(TypeConverter &tc,
   }
 
   auto optDecl = tc.Context.getOptionalDecl();
-  return CanType(BoundGenericType::get(optDecl, Type(), loweredObjectType));
+  return BoundGenericType::get(optDecl, Type(), loweredObjectType)
+      ->getCanonicalType();
 }
 
 static CanType

--- a/lib/SIL/Utils/DynamicCasts.cpp
+++ b/lib/SIL/Utils/DynamicCasts.cpp
@@ -686,8 +686,8 @@ swift::classifyDynamicCast(ModuleDecl *M,
       // Both types have to be the same kind of collection.
       auto typeDecl = sourceStruct->getDecl();
       if (typeDecl == targetStruct->getDecl()) {
-        auto sourceArgs = sourceStruct.getGenericArgs();
-        auto targetArgs = targetStruct.getGenericArgs();
+        const auto sourceArgs = sourceStruct.getDirectGenericArgs();
+        const auto targetArgs = targetStruct.getDirectGenericArgs();
 
         // Note that we can never say that a collection cast is impossible:
         // a cast can always succeed on an empty collection.

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -4571,14 +4571,14 @@ public:
             || kpBGT->getDecl() == C.getReferenceWritableKeyPathDecl(),
             "keypath result must be a key path type");
     
-    auto baseTy = CanType(kpBGT->getGenericArgs()[0]);
+    auto baseTy = CanType(kpBGT->getDirectGenericArgs()[0]);
     auto pattern = KPI->getPattern();
     SubstitutionMap patternSubs = KPI->getSubstitutions();
     requireSameType(
         baseTy, pattern->getRootType().subst(patternSubs)->getCanonicalType(),
         "keypath root type should match root type of keypath pattern");
 
-    auto leafTy = CanType(kpBGT->getGenericArgs()[1]);
+    const auto leafTy = CanType(kpBGT->getDirectGenericArgs()[1]);
     requireSameType(
         leafTy, pattern->getValueType().subst(patternSubs)->getCanonicalType(),
         "keypath value type should match value type of keypath pattern");

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3629,8 +3629,8 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
   SmallVector<KeyPathPatternComponent, 4> loweredComponents;
   auto loweredTy = SGF.getLoweredType(E->getType());
 
-  CanType rootTy = E->getType()->castTo<BoundGenericType>()->getGenericArgs()[0]
-    ->getCanonicalType();
+  CanType rootTy = E->getType()->castTo<BoundGenericType>()
+    ->getDirectGenericArgs()[0]->getCanonicalType();
   
   bool needsGenericContext = false;
   if (rootTy->hasArchetype()) {
@@ -3829,7 +3829,7 @@ RValue RValueEmitter::visitCollectionExpr(CollectionExpr *E, SGFContext C) {
     arrayType = E->getType()->getCanonicalType();
     auto genericType = cast<BoundGenericStructType>(arrayType);
     assert(genericType->getDecl() == SGF.getASTContext().getArrayDecl());
-    elementType = genericType.getGenericArgs()[0];
+    elementType = genericType.getDirectGenericArgs()[0];
   }
 
   VarargsInfo varargsInfo =

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -586,7 +586,7 @@ bool swift::ArraySemanticsCall::mayHaveBridgedObjectElementType() const {
   if (auto BGT = Ty.getAs<BoundGenericStructType>()) {
     // Check the array element type parameter.
     bool isClass = true;
-    for (auto EltTy : BGT->getGenericArgs()) {
+    for (const auto &EltTy : BGT->getDirectGenericArgs()) {
       if (EltTy->isBridgeableObjectType())
         return true;
       isClass = false;

--- a/lib/SILOptimizer/Analysis/DestructorAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/DestructorAnalysis.cpp
@@ -111,7 +111,7 @@ bool DestructorAnalysis::areTypeParametersSafe(CanType Ty) {
     return false;
 
   // Make sure all type parameters are safe.
-  for (auto TP : BGT->getGenericArgs()) {
+  for (const auto &TP : BGT->getDirectGenericArgs()) {
     if (!isSafeType(TP->getCanonicalType()))
       return false;
   }

--- a/lib/SILOptimizer/Differentiation/PullbackEmitter.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackEmitter.cpp
@@ -1428,7 +1428,8 @@ PullbackEmitter::getArrayAdjointElementBuffer(SILValue arrayAdjoint,
   auto &ctx = builder.getASTContext();
   auto arrayTanType = cast<StructType>(arrayAdjoint->getType().getASTType());
   auto arrayType = arrayTanType->getParent()->castTo<BoundGenericStructType>();
-  auto eltTanType = arrayType->getGenericArgs().front()->getCanonicalType();
+  auto eltTanType =
+      arrayType->getDirectGenericArgs().front()->getCanonicalType();
   auto eltTanSILType = remapType(SILType::getPrimitiveAddressType(eltTanType));
   // Get `function_ref` and generic signature of
   // `Array.TangentVector.subscript.getter`.

--- a/lib/SILOptimizer/LoopTransforms/ArrayPropertyOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayPropertyOpt.cpp
@@ -368,7 +368,7 @@ private:
     if (auto BGT = Ty.getAs<BoundGenericStructType>()) {
       // Check the array element type parameter.
       bool isClass = false;
-      for (auto EltTy : BGT->getGenericArgs()) {
+      for (const auto &EltTy : BGT->getDirectGenericArgs()) {
         if (!EltTy->hasReferenceSemantics())
           return false;
         isClass = true;

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -819,7 +819,7 @@ extractStringOrStaticStringValue(SymbolicValue stringValue) {
 static Type getArrayElementType(Type ty) {
   if (auto bgst = ty->getAs<BoundGenericStructType>())
     if (bgst->getDecl() == bgst->getASTContext().getArrayDecl())
-      return bgst->getGenericArgs()[0];
+      return bgst->getDirectGenericArgs()[0];
   return Type();
 }
 

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -93,8 +93,7 @@ static std::pair<unsigned, unsigned> getTypeDepthAndWidth(Type t) {
     }
     ++Depth;
     unsigned MaxTypeDepth = 0;
-    auto GenericArgs = BGT->getGenericArgs();
-    for (auto Ty : GenericArgs) {
+    for (const auto &Ty : BGT->getDirectGenericArgs()) {
       unsigned TypeWidth;
       unsigned TypeDepth;
       std::tie(TypeDepth, TypeWidth) = getTypeDepthAndWidth(Ty);

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -636,8 +636,8 @@ void GenericArgumentsMismatchFailure::emitNoteForMismatch(int position) {
   auto genericTypeDecl = paramSourceTy->getAnyGeneric();
   auto param = genericTypeDecl->getGenericParams()->getParams()[position];
 
-  auto lhs = getActual()->getGenericArgs()[position];
-  auto rhs = getRequired()->getGenericArgs()[position];
+  const auto lhs = getActual()->getDirectGenericArgs()[position];
+  const auto rhs = getRequired()->getDirectGenericArgs()[position];
 
   auto noteLocation = param->getLoc();
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1023,7 +1023,8 @@ namespace {
           
           if (isa<IntegerLiteralExpr>(indexExpr)) {
             
-            outputTy = baseObjTy->getAs<BoundGenericType>()->getGenericArgs()[0];
+            outputTy = baseObjTy->getAs<BoundGenericType>()
+                ->getDirectGenericArgs()[0];
             
             if (isLValueBase)
               outputTy = LValueType::get(outputTy);
@@ -1691,7 +1692,7 @@ namespace {
       if (AnyMetatypeType *meta = baseTy->getAs<AnyMetatypeType>()) {
         if (BoundGenericType *bgt
               = meta->getInstanceType()->getAs<BoundGenericType>()) {
-          ArrayRef<Type> typeVars = bgt->getGenericArgs();
+          const ArrayRef<Type> typeVars = bgt->getDirectGenericArgs();
           auto specializations = expr->getUnresolvedParams();
 
           // If we have too many generic arguments, complain.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2213,8 +2213,8 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
       return result;
   }
 
-  auto args1 = bound1->getGenericArgs();
-  auto args2 = bound2->getGenericArgs();
+  const auto args1 = bound1->getDirectGenericArgs();
+  const auto args2 = bound2->getDirectGenericArgs();
 
   // Match up the generic arguments, exactly.
 
@@ -7694,7 +7694,8 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
       if (auto fromBGT = unwrappedToType->getAs<BoundGenericType>()) {
         if (fromBGT->getDecl() == ctx.getArrayDecl()) {
           // [AnyObject]
-          addConstraint(ConstraintKind::Bind, fromBGT->getGenericArgs()[0],
+          addConstraint(ConstraintKind::Bind,
+                        fromBGT->getDirectGenericArgs()[0],
                         ctx.getAnyObjectType(),
                         getConstraintLocator(locator.withPathElement(
                             LocatorPathElt::GenericArgument(0))));
@@ -7706,13 +7707,15 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
             return SolutionKind::Error;
           }
 
-          addConstraint(ConstraintKind::Bind, fromBGT->getGenericArgs()[0],
+          addConstraint(ConstraintKind::Bind,
+                        fromBGT->getDirectGenericArgs()[0],
                         nsObjectType,
                         getConstraintLocator(
                           locator.withPathElement(
                             LocatorPathElt::GenericArgument(0))));
 
-          addConstraint(ConstraintKind::Bind, fromBGT->getGenericArgs()[1],
+          addConstraint(ConstraintKind::Bind,
+                        fromBGT->getDirectGenericArgs()[1],
                         ctx.getAnyObjectType(),
                         getConstraintLocator(
                           locator.withPathElement(
@@ -7723,7 +7726,8 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
             // Not a bridging case. Should we detect this earlier?
             return SolutionKind::Error;
           }
-          addConstraint(ConstraintKind::Bind, fromBGT->getGenericArgs()[0],
+          addConstraint(ConstraintKind::Bind,
+                        fromBGT->getDirectGenericArgs()[0],
                         nsObjectType,
                         getConstraintLocator(
                           locator.withPathElement(
@@ -7863,14 +7867,14 @@ ConstraintSystem::simplifyKeyPathConstraint(
       if (bgt->getDecl() == getASTContext().getKeyPathDecl() ||
           bgt->getDecl() == getASTContext().getWritableKeyPathDecl() ||
           bgt->getDecl() == getASTContext().getReferenceWritableKeyPathDecl()) {
-        boundRoot = bgt->getGenericArgs()[0];
-        boundValue = bgt->getGenericArgs()[1];
+        boundRoot = bgt->getDirectGenericArgs()[0];
+        boundValue = bgt->getDirectGenericArgs()[1];
       } else if (bgt->getDecl() == getASTContext().getPartialKeyPathDecl()) {
         if (!allowPartial)
           return false;
 
         // We can still get the root from a PartialKeyPath.
-        boundRoot = bgt->getGenericArgs()[0];
+        boundRoot = bgt->getDirectGenericArgs()[0];
       }
     }
 
@@ -8145,7 +8149,7 @@ ConstraintSystem::simplifyKeyPathApplicationConstraint(
   
   if (auto bgt = keyPathTy->getAs<BoundGenericType>()) {
     // We have the key path type. Match it to the other ends of the constraint.
-    auto kpRootTy = bgt->getGenericArgs()[0];
+    const auto kpRootTy = bgt->getDirectGenericArgs()[0];
     
     // Try to match the root type.
     rootTy = getFixedTypeRecursive(rootTy, flags, /*wantRValue=*/false);
@@ -8177,9 +8181,9 @@ ConstraintSystem::simplifyKeyPathApplicationConstraint(
                         ConstraintKind::Bind, subflags, locator);
     }
 
-    if (bgt->getGenericArgs().size() < 2)
+    if (bgt->getDirectGenericArgs().size() < 2)
       return SolutionKind::Error;
-    auto kpValueTy = bgt->getGenericArgs()[1];
+    const auto kpValueTy = bgt->getDirectGenericArgs()[1];
 
     /// Solve for an rvalue base.
     auto solveRValue = [&]() -> ConstraintSystem::SolutionKind {
@@ -9205,7 +9209,7 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
     if (auto generic2 = type2->getAs<BoundGenericType>()) {
       if (generic2->getDecl()->isOptionalDecl()) {
         auto result = matchTypes(
-            type1, generic2->getGenericArgs()[0], matchKind, subflags,
+            type1, generic2->getDirectGenericArgs()[0], matchKind, subflags,
             locator.withPathElement(ConstraintLocator::OptionalPayload));
 
         if (!(shouldAttemptFixes() && result.isFailure()))
@@ -9233,7 +9237,8 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
         if (generic1->getDecl()->isOptionalDecl() &&
             generic2->getDecl()->isOptionalDecl()) {
           auto result = matchTypes(
-              generic1->getGenericArgs()[0], generic2->getGenericArgs()[0],
+              generic1->getDirectGenericArgs()[0],
+              generic2->getDirectGenericArgs()[0],
               matchKind, subflags,
               locator.withPathElement(LocatorPathElt::GenericArgument(0)));
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -940,8 +940,8 @@ void ConstraintSystem::shrink(Expr *expr) {
           return boundGeneric;
 
         llvm::SmallVector<TupleTypeElt, 2> params;
-        for (auto &type : boundGeneric->getGenericArgs()) {
-          // One of the generic arguments in invalid or unresolved.
+        for (const auto &type : boundGeneric->getDirectGenericArgs()) {
+          // One of the generic arguments is invalid or unresolved.
           if (isInvalidType(type))
             return type;
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -852,7 +852,7 @@ FunctionType *ConstraintSystem::openFunctionType(
 Optional<Type> ConstraintSystem::isArrayType(Type type) {
   if (auto boundStruct = type->getAs<BoundGenericStructType>()) {
     if (boundStruct->getDecl() == type->getASTContext().getArrayDecl())
-      return boundStruct->getGenericArgs()[0];
+      return boundStruct->getDirectGenericArgs()[0];
   }
 
   return None;
@@ -861,7 +861,7 @@ Optional<Type> ConstraintSystem::isArrayType(Type type) {
 Optional<std::pair<Type, Type>> ConstraintSystem::isDictionaryType(Type type) {
   if (auto boundStruct = type->getAs<BoundGenericStructType>()) {
     if (boundStruct->getDecl() == type->getASTContext().getDictionaryDecl()) {
-      auto genericArgs = boundStruct->getGenericArgs();
+      const auto genericArgs = boundStruct->getDirectGenericArgs();
       return std::make_pair(genericArgs[0], genericArgs[1]);
     }
   }
@@ -872,7 +872,7 @@ Optional<std::pair<Type, Type>> ConstraintSystem::isDictionaryType(Type type) {
 Optional<Type> ConstraintSystem::isSetType(Type type) {
   if (auto boundStruct = type->getAs<BoundGenericStructType>()) {
     if (boundStruct->getDecl() == type->getASTContext().getSetDecl())
-      return boundStruct->getGenericArgs()[0];
+      return boundStruct->getDirectGenericArgs()[0];
   }
 
   return None;
@@ -2238,8 +2238,8 @@ void ConstraintSystem::bindOverloadType(
     auto *keyPathLoc = getConstraintLocator(
         locator, LocatorPathElt::KeyPathDynamicMember(keyPathDecl));
 
-    auto rootTy = keyPathTy->getGenericArgs()[0];
-    auto leafTy = keyPathTy->getGenericArgs()[1];
+    const auto rootTy = keyPathTy->getDirectGenericArgs()[0];
+    const auto leafTy = keyPathTy->getDirectGenericArgs()[1];
 
     // Member would either point to mutable or immutable property, we
     // don't which at the moment, so let's allow its type to be l-value.

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -125,8 +125,7 @@ RootAndResultTypeOfKeypathDynamicMemberRequest::evaluate(Evaluator &evaluator,
   auto keyPathType = param->getType()->getAs<BoundGenericType>();
   if (!keyPathType)
     return TypePair();
-  auto genericArgs = keyPathType->getGenericArgs();
-  assert(!genericArgs.empty() && genericArgs.size() == 2 &&
-         "invalid keypath dynamic member");
+  const auto genericArgs = keyPathType->getDirectGenericArgs();
+  assert(genericArgs.size() == 2 && "invalid keypath dynamic member");
   return TypePair(genericArgs[0], genericArgs[1]);
 }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4496,7 +4496,7 @@ static OmissionTypeName getTypeNameForOmission(Type type) {
     // If we have a collection, get the element type.
     if (auto bound = type->getAs<BoundGenericType>()) {
       ASTContext &ctx = nominal->getASTContext();
-      auto args = bound->getGenericArgs();
+      const auto args = bound->getDirectGenericArgs();
       if (!args.empty() &&
           (bound->getDecl() == ctx.getArrayDecl() ||
            bound->getDecl() == ctx.getSetDecl())) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -550,7 +550,7 @@ isAcceptableOutletType(Type type, bool &isArray, ASTContext &ctx) {
 
     // Handle Array<T>. T must be an Objective-C class or protocol.
     auto boundTy = type->castTo<BoundGenericStructType>();
-    auto boundArgs = boundTy->getGenericArgs();
+    const auto boundArgs = boundTy->getDirectGenericArgs();
     assert(boundArgs.size() == 1 && "invalid Array declaration");
     Type elementTy = boundArgs.front();
     return isAcceptableOutletType(elementTy, isArray, ctx);

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2140,7 +2140,7 @@ bool isSubscriptReturningString(const ValueDecl *D, ASTContext &Context) {
   if (!inputTy)
     return false;
 
-  auto genericArgs = inputTy->getGenericArgs();
+  const auto genericArgs = inputTy->getDirectGenericArgs();
   if (genericArgs.size() != 1)
     return false;
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2581,7 +2581,7 @@ bool TypeChecker::isPassThroughTypealias(TypeAliasDecl *typealias,
   // If our arguments line up with our innermost generic parameters, it's
   // a passthrough typealias.
   auto innermostGenericParams = typealiasSig->getInnermostGenericParams();
-  auto boundArgs = boundGenericType->getGenericArgs();
+  const auto boundArgs = boundGenericType->getDirectGenericArgs();
   if (boundArgs.size() != innermostGenericParams.size())
     return false;
 

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -101,7 +101,7 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
       if (nominal == Context.getArrayDecl()) {
         // Further lookups into the element type.
         state = ResolvingArray;
-        currentType = boundGeneric->getGenericArgs()[0];
+        currentType = boundGeneric->getDirectGenericArgs()[0];
         return;
       }
 
@@ -109,7 +109,7 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
       if (nominal == Context.getSetDecl()) {
         // Further lookups into the element type.
         state = ResolvingSet;
-        currentType = boundGeneric->getGenericArgs()[0];
+        currentType = boundGeneric->getDirectGenericArgs()[0];
         return;
       }
 
@@ -118,7 +118,7 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
         // Key paths look into the keys of a dictionary; further
         // lookups into the value type.
         state = ResolvingDictionary;
-        currentType = boundGeneric->getGenericArgs()[1];
+        currentType = boundGeneric->getDirectGenericArgs()[1];
         return;
       }
     }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -523,11 +523,11 @@ static Type formExtensionInterfaceType(
 
   // Form the result.
   Type resultType;
-  SmallVector<Type, 2> genericArgs;
   if (!nominal->isGeneric() || isa<ProtocolDecl>(nominal)) {
     resultType = NominalType::get(nominal, parentType,
                                   nominal->getASTContext());
   } else {
+    SmallVector<Type, 2> genericArgs;
     auto currentBoundType = type->getAs<BoundGenericType>();
 
     // Form the bound generic type with the type parameters provided.
@@ -539,9 +539,8 @@ static Type formExtensionInterfaceType(
       genericArgs.push_back(gpType);
 
       if (currentBoundType) {
-        sameTypeReqs.emplace_back(
-            RequirementKind::SameType, gpType,
-            currentBoundType->getDirectGenericArgs()[gpIndex]);
+        sameTypeReqs.emplace_back(RequirementKind::SameType, gpType,
+                                  currentBoundType->getDirectGenericArgs()[gpIndex]);
       }
     }
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -539,8 +539,9 @@ static Type formExtensionInterfaceType(
       genericArgs.push_back(gpType);
 
       if (currentBoundType) {
-        sameTypeReqs.emplace_back(RequirementKind::SameType, gpType,
-                                  currentBoundType->getGenericArgs()[gpIndex]);
+        sameTypeReqs.emplace_back(
+            RequirementKind::SameType, gpType,
+            currentBoundType->getDirectGenericArgs()[gpIndex]);
       }
     }
 

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1084,7 +1084,8 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
       }
     } else if (auto *BST = diagTy->getAs<BoundGenericStructType>()) {
       if (BST->getDecl() == Context.getArrayDecl())
-          shouldRequireType = BST->getGenericArgs()[0]->isEqual(Context.TheEmptyTupleType);
+        shouldRequireType = BST->getDirectGenericArgs()[0]
+            ->isEqual(Context.TheEmptyTupleType);
     }
     
     if (shouldRequireType &&

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -591,8 +591,8 @@ static bool isPointerToVoid(ASTContext &Ctx, Type Ty, bool &IsMutable) {
       BGT->getDecl() != Ctx.getUnsafeMutablePointerDecl())
     return false;
   IsMutable = BGT->getDecl() == Ctx.getUnsafeMutablePointerDecl();
-  assert(BGT->getGenericArgs().size() == 1);
-  return BGT->getGenericArgs().front()->isVoid();
+  assert(BGT->getDirectGenericArgs().size() == 1);
+  return BGT->getDirectGenericArgs().front()->isVoid();
 }
 
 static Type checkContextualRequirements(Type type,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -809,7 +809,7 @@ Type TypeChecker::applyUnboundGenericArguments(GenericTypeDecl *decl,
          "invalid arguments, use applyGenericArguments for diagnostic emitting");
 
   auto genericSig = decl->getGenericSignature();
-  assert(!genericSig.isNull());
+  assert(genericSig);
 
   TypeSubstitutionMap subs;
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 562; // base_addr_for_offset instruction
+const uint16_t SWIFTMODULE_VERSION_MINOR = 563; // BoundGenericType layout;
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1029,7 +1029,7 @@ namespace decls_block {
     BOUND_GENERIC_TYPE,
     DeclIDField, // generic decl
     TypeIDField, // parent
-    BCArray<TypeIDField> // generic arguments
+    SubstitutionMapIDField // the arguments
   >;
 
   using GenericFunctionTypeLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4290,7 +4290,7 @@ public:
     using namespace decls_block;
     SmallVector<TypeID, 8> genericArgIDs;
 
-    for (auto next : generic->getGenericArgs())
+    for (const auto next : generic->getDirectGenericArgs())
       genericArgIDs.push_back(S.addTypeRef(next));
 
     unsigned abbrCode = S.DeclTypeAbbrCodes[BoundGenericTypeLayout::Code];

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4288,16 +4288,12 @@ public:
 
   void visitBoundGenericType(const BoundGenericType *generic) {
     using namespace decls_block;
-    SmallVector<TypeID, 8> genericArgIDs;
-
-    for (const auto next : generic->getDirectGenericArgs())
-      genericArgIDs.push_back(S.addTypeRef(next));
-
     unsigned abbrCode = S.DeclTypeAbbrCodes[BoundGenericTypeLayout::Code];
-    BoundGenericTypeLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
-                                       S.addDeclRef(generic->getDecl()),
-                                       S.addTypeRef(generic->getParent()),
-                                       genericArgIDs);
+    BoundGenericTypeLayout::emitRecord(
+        S.Out, S.ScratchRecord, abbrCode,
+        S.addDeclRef(generic->getDecl()),
+        S.addTypeRef(generic->getParent()),
+        S.addSubstitutionMapRef(generic->getSubstitutionMap()));
   }
 };
 

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -1508,7 +1508,7 @@ SwiftDeclCollector::constructTypeNode(Type T, TypeInitInfo Info) {
 
   // Handle the case where Type has sub-types.
   if (auto BGT = T->getAs<BoundGenericType>()) {
-    for (auto Arg : BGT->getGenericArgs()) {
+    for (auto Arg : BGT->getDirectGenericArgs()) {
       Root->addChild(constructTypeNode(Arg));
     }
   } else if (auto Tup = T->getAs<TupleType>()) {


### PR DESCRIPTION
This change as it currently is will cause diagnostics regressions whenever a type appears within its own generic signature, because we now have to compute the generic signature just to form the declared interface type. Having discussed the latter with Slava, one idea we settled on was to define a `StructuralBoundGenericType` counterpart that stores an array of generic arguments -- just like we do today -- for use during the type-checking stage *only*. More importantly, this would ultimately enable us to unlock recursive generic signature validation altogether.

There are still a few tests failing, in particular, I haven't figured yet how to deal with bound generic types with unbound generic parents. Representing unbound generic parameters as `T -> Type()` in the substitution map doesn't work right off the bat.

@slavapestov I would greatly appreciate any feedback, especially on the performance-critical parts.