### PR TITLE
No dummy constraint in the public swiftinterface for SPI extensions

### DIFF
--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -345,10 +345,16 @@ public:
   /// in \p map.
   ///
   /// \sa recordConditionalConformances
-  static void collectSkippedConditionalConformances(PerTypeMap &map,
-                                                    const Decl *D) {
+  static void collectSkippedConditionalConformances(
+                                            PerTypeMap &map,
+                                            const Decl *D,
+                                            const PrintOptions &printOptions) {
     auto *extension = dyn_cast<ExtensionDecl>(D);
     if (!extension || !extension->isConstrainedExtension())
+      return;
+
+    // Skip SPI extensions in the public interface.
+    if (!printOptions.PrintSPIs && extension->isSPI())
       return;
 
     const NominalTypeDecl *nominal = extension->getExtendedNominal();
@@ -497,8 +503,9 @@ bool swift::emitSwiftInterface(raw_ostream &out,
 
     if (!D->shouldPrintInContext(printOptions) ||
         !printOptions.shouldPrint(D)) {
+
       InheritedProtocolCollector::collectSkippedConditionalConformances(
-          inheritedProtocolMap, D);
+          inheritedProtocolMap, D, printOptions);
       continue;
     }
 

--- a/test/SPI/private_swiftinterface.swift
+++ b/test/SPI/private_swiftinterface.swift
@@ -87,3 +87,25 @@ private class PrivateClassLocal {}
   // CHECK-PRIVATE: @_spi(LocalSPI) public func extensionSPIMethod()
   // CHECK-PUBLIC-NOT: extensionSPIMethod
 }
+
+// Test the dummy conformance printed to replace private types used in
+// conditional conformances. rdar://problem/63352700
+
+// Conditional conformances using SPI types should appear in full in the
+// private swiftinterface.
+public struct PublicType<T> {}
+@_spi(LocalSPI) public protocol SPIProto {}
+private protocol PrivateConstraint {}
+@_spi(LocalSPI) public protocol SPIProto2 {}
+
+@_spi(LocalSPI)
+extension PublicType: SPIProto2 where T: SPIProto2 {}
+// CHECK-PRIVATE: extension PublicType : {{.*}}.SPIProto2 where T : {{.*}}.SPIProto2
+// CHECK-PUBLIC-NOT: _ConstraintThatIsNotPartOfTheAPIOfThisLibrary
+
+// The dummy conformance should be only in the private swiftinterface for
+// SPI extensions.
+@_spi(LocalSPI)
+extension PublicType: SPIProto where T: PrivateConstraint {}
+// CHECK-PRIVATE: extension {{.*}}.PublicType : {{.*}}.SPIProto where T : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary
+// CHECK-PUBLIC-NOT: _ConstraintThatIsNotPartOfTheAPIOfThisLibrary


### PR DESCRIPTION
Don't print the dummy constraint `_ConstraintThatIsNotPartOfTheAPIOfThisLibrary` for SPI extensions in the public swiftinterface.

rdar://problem/63352700

This will also require type-checking improvements to detect problematic SPI extensions earlier.