### PR TITLE
Fix warnings in loadable-types.h.

### DIFF
--- a/test/Interop/Cxx/class/Inputs/loadable-types.h
+++ b/test/Interop/Cxx/class/Inputs/loadable-types.h
@@ -60,7 +60,7 @@ struct StructWithSubobjectMoveConstructor {
 };
 
 struct StructWithCopyAssignment {
-  StructWithCopyAssignment &operator=(const StructWithCopyAssignment &) {}
+  StructWithCopyAssignment &operator=(const StructWithCopyAssignment &);
 };
 
 struct StructWithInheritedCopyAssignment : StructWithCopyAssignment {};
@@ -70,7 +70,7 @@ struct StructWithSubobjectCopyAssignment {
 };
 
 struct StructWithMoveAssignment {
-  StructWithMoveAssignment &operator=(StructWithMoveAssignment &&) {}
+  StructWithMoveAssignment &operator=(StructWithMoveAssignment &&);
 };
 
 struct StructWithInheritedMoveAssignment : StructWithMoveAssignment {};


### PR DESCRIPTION
The copy and move assignment operators weren't returning anything and
were hence producing "non-void function does not return a value"
warnings.

As the test doesn't actually need a definition for these operators, I've
removed the definition and simply declared them.