### PR TITLE
Use Clang's logic for adding the default IR attributes to a function

### DIFF
--- a/test/IRGen/c_globals.swift
+++ b/test/IRGen/c_globals.swift
@@ -32,4 +32,4 @@ public func testCaptureGlobal() {
 }
 
 // CHECK-DAG: attributes [[CLANG_FUNC_ATTR]] = { noinline nounwind {{.*}}"frame-pointer"="all"{{.*}}
-// CHECK-DAG: attributes [[SWIFT_FUNC_ATTR]] = { "frame-pointer"="all" {{.*}}"target-cpu"
+// CHECK-DAG: attributes [[SWIFT_FUNC_ATTR]] = { {{.*}}"frame-pointer"="all" {{.*}}"target-cpu"

--- a/test/IRGen/generic_metatypes.swift
+++ b/test/IRGen/generic_metatypes.swift
@@ -146,4 +146,4 @@ func makeGenericMetatypes() {
 // CHECK:   ret %swift.metadata_response
 
 // CHECK-DAG: attributes [[NOUNWIND_READNONE]] = { nounwind readnone }
-// CHECK-DAG: attributes [[NOUNWIND_OPT]] = { noinline nounwind "frame-pointer"="none" "target-cpu"
+// CHECK-DAG: attributes [[NOUNWIND_OPT]] = { noinline nounwind "

--- a/test/IRGen/generic_metatypes_future.swift
+++ b/test/IRGen/generic_metatypes_future.swift
@@ -176,4 +176,4 @@ func makeGenericMetatypes() {
 // CHECK:   ret %swift.metadata_response
 
 // CHECK-DAG: attributes [[NOUNWIND_READNONE]] = { nounwind readnone }
-// CHECK-DAG: attributes [[NOUNWIND_OPT]] = { noinline nounwind "frame-pointer"="none" "target-cpu"
+// CHECK-DAG: attributes [[NOUNWIND_OPT]] = { noinline nounwind "

--- a/test/IRGen/ptrauth-functions.sil
+++ b/test/IRGen/ptrauth-functions.sil
@@ -87,4 +87,4 @@ bb0(%0 : $T):
 
 sil_vtable F {
 }
-// CHECK: #[[ATTRS]] = {{{.*}} "ptrauth-calls" "ptrauth-returns"
+// CHECK: #[[ATTRS]] = {{{.*}} "ptrauth-auth-traps" "ptrauth-calls" "ptrauth-indirect-gotos" "ptrauth-returns"

--- a/test/SILOptimizer/opt_mode.swift
+++ b/test/SILOptimizer/opt_mode.swift
@@ -47,5 +47,5 @@ func test_ospeed(_ a: A) -> Int {
 }
 
 
-// CHECK-IR: attributes [[SIZE_ATTR]] = { minsize "
+// CHECK-IR: attributes [[SIZE_ATTR]] = { minsize optsize "
 // CHECK-IR: attributes [[NOSIZE_ATTR]] = { "


### PR DESCRIPTION
A lot of attributes are essentially default target configuration, and we should only differ when there's a good reason to.

For the attributes we were already setting:
- the ptrauth and target CPU/feature attributes are taken care of by Clang
- I've updated the optsize/minsize attributes to the apparent intent
- I've left the frame-pointer override in place for now

Fixes rdar://63289339, which was caused by Swift's ptrauth IR attributes getting out of sync with Clang's.