### PR TITLE
[5.3] [SR-12842] Restore missing docs for RangeExpression.~=

### DIFF
--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -74,6 +74,25 @@ public protocol RangeExpression {
 }
 
 extension RangeExpression {
+
+  /// Returns a Boolean value indicating whether a value is included in a
+  /// range.
+  ///
+  /// You can use the pattern-matching operator (`~=`) to test whether a value
+  /// is included in a range. The pattern-matching operator is used
+  /// internally in `case` statements for pattern matching. The following
+  /// example uses the `~=` operator to test whether an integer is included in
+  /// a range of single-digit numbers:
+  ///
+  ///     let chosenNumber = 3
+  ///     if 0..<10 ~= chosenNumber {
+  ///         print("\(chosenNumber) is a single digit.")
+  ///     }
+  ///     // Prints "3 is a single digit."
+  ///
+  /// - Parameters:
+  ///   - pattern: A range.
+  ///   - bound: A value to match against `pattern`.
   @inlinable
   public static func ~= (pattern: Self, value: Bound) -> Bool {
     return pattern.contains(value)


### PR DESCRIPTION
Restores an updated version of the documentation for the `RangeExpression.~=` operator.

Resolves [SR-12842](https://bugs.swift.org/browse/SR-12842).

Original: #31907

rdar://65491491