### PR TITLE
Use iPhone 5s for running tests on 32-bit iOS simulator

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -116,7 +116,7 @@ def get_simulator_command(run_os, run_cpu, sdk_path):
                 print("INFO: Xcode -> Preferences -> Components -> Simulators")
                 sys.exit(1)
             else:
-                return "simctl spawn --standalone 'iPhone 5'"
+                return "simctl spawn --standalone 'iPhone 5s'"
         else:
             return "simctl spawn --standalone 'iPhone 8'"
     elif run_os == 'tvos':


### PR DESCRIPTION
In Xcode 11.4.1 by default there is no 'iPhone 5' device, only 'iPhone 5s'.

```
% xcrun simctl spawn --standalone 'iPhone 5' /bin/true
Invalid device: iPhone 5
% xcrun simctl spawn --standalone 'iPhone 5s' /bin/true
An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=2):
The operation couldn’t be completed. No such file or directory
No such file or directory
```
