### PR TITLE
[SR-12648] Fixes filter function of RangeReplaceableCollection.

### DIFF
--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -1082,7 +1082,11 @@ extension RangeReplaceableCollection {
   public __consuming func filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> Self {
-    return try Self(self.lazy.filter(isIncluded))
+    var result = Self()
+    for element in self where try isIncluded(element) {
+      result.append(element)
+    }
+    return result
   }
 }
 


### PR DESCRIPTION
Fixes filter function of RangeReplaceableCollection.

<!-- What's in this pull request? -->

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-12648.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
