### PR TITLE
Emit `/DEFAULTLIB` directive for `#pragma comment(lib, ...)` in a C module

### DIFF
--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -113,6 +113,17 @@ IRGenModule::getAddrOfClangGlobalDecl(clang::GlobalDecl global,
 }
 
 void IRGenModule::finalizeClangCodeGen() {
+  // Ensure that code is emitted for any `PragmaCommentDecl`s. (These are
+  // always guaranteed to be directly below the TranslationUnitDecl.)
+  // In Clang, this happens automatically during the Sema phase, but here we
+  // need to take care of it manually because our Clang CodeGenerator is not
+  // attached to Clang Sema as an ASTConsumer.
+  for (const auto *D : ClangASTContext->getTranslationUnitDecl()->decls()) {
+    if (const auto *PCD = dyn_cast<clang::PragmaCommentDecl>(D)) {
+      emitClangDecl(PCD);
+    }
+  }
+
   ClangCodeGen->HandleTranslationUnit(
       *const_cast<clang::ASTContext *>(ClangASTContext));
 }

--- a/test/IRGen/Inputs/autolink-coff-c-pragma-transitive.h
+++ b/test/IRGen/Inputs/autolink-coff-c-pragma-transitive.h
@@ -1,0 +1,1 @@
+#pragma comment(lib, "transitive-module")

--- a/test/IRGen/Inputs/autolink-coff-c-pragma.h
+++ b/test/IRGen/Inputs/autolink-coff-c-pragma.h
@@ -1,0 +1,3 @@
+#include "autolink-coff-c-pragma-transitive.h"
+
+#pragma comment(lib, "module")

--- a/test/IRGen/Inputs/module.modulemap
+++ b/test/IRGen/Inputs/module.modulemap
@@ -1,0 +1,9 @@
+module AutolinkCoffCPragma {
+  header "autolink-coff-c-pragma.h"
+  export *
+}
+
+module AutolinkCoffCPragmaTransitive {
+  header "autolink-coff-c-pragma-transitive.h"
+  export *
+}

--- a/test/IRGen/autolink-coff-c-pragma.swift
+++ b/test/IRGen/autolink-coff-c-pragma.swift
@@ -1,0 +1,20 @@
+// Tests that a `#pragma comment(lib, ...)` in a C header imported as a module
+// causes a corresponding `/DEFAULTLIB` directive to be emitted.
+//
+// We test that this is true also for C headers included transitively from
+// another C header.
+
+// RUN: %swift -module-name Swift -target x86_64-unknown-windows-msvc -I %S/Inputs -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=CHECK-MSVC-IR
+// RUN: %swift -module-name Swift -target x86_64-unknown-windows-msvc -I %S/Inputs -S %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=CHECK-MSVC-ASM
+
+// REQUIRES: CODEGENERATOR=X86
+
+import AutolinkCoffCPragma
+
+// CHECK-MSVC-IR: !llvm.linker.options = !{!{{[0-9]+}}, !{{[0-9]+}}}
+// CHECK-MSVC-IR-DAG: !{{[0-9]+}} = !{!"/DEFAULTLIB:module.lib"}
+// CHECK-MSVC-IR-DAG: !{{[0-9]+}} = !{!"/DEFAULTLIB:transitive-module.lib"}
+
+// CHECK-MSVC-ASM: .section .drectve
+// CHECK-MSVC-ASM-DAG: .ascii " /DEFAULTLIB:module.lib"
+// CHECK-MSVC-ASM-DAG: .ascii " /DEFAULTLIB:transitive-module.lib"


### PR DESCRIPTION
This is important, for example, for linking correctly to the C++
standard library on Windows, which uses `#pragma comment(lib, ...)` in
its headers to specify the correct library to link against.