### PR TITLE
[Test] Have llvm-support-odr-violation.sh use platform-dylib-dir.

### DIFF
--- a/test/stdlib/llvm-support-odr-violation.test-sh
+++ b/test/stdlib/llvm-support-odr-violation.test-sh
@@ -1,2 +1,2 @@
-// RUN: %llvm-nm --defined-only -C %platform-module-dir/%target-library-name(swiftCore) | %FileCheck --allow-empty %s
+// RUN: %llvm-nm --defined-only -C %platform-dylib-dir/%target-library-name(swiftCore) | %FileCheck --allow-empty %s
 // CHECK-NOT: [^:]llvm::


### PR DESCRIPTION
platform-module-dir isn't quite right, since we're looking for libswiftCore.dylib. These directories are different when targeting maccatalyst.

rdar://problem/63437032