### PR TITLE
[Typechecker] Emit a specialised diagnostic for redeclaration errors when the declaration is synthesised

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5232,6 +5232,12 @@ public:
   Optional<PropertyWrapperMutability>
       getPropertyWrapperMutability() const;
 
+  /// Returns whether this property is the backing storage property or a storage
+  /// wrapper for wrapper instance's projectedValue. If this property is
+  /// neither, then it returns `None`.
+  Optional<PropertyWrapperSynthesizedPropertyKind>
+  getPropertyWrapperSynthesizedPropertyKind() const;
+
   /// Retrieve the backing storage property for a property that has an
   /// attached property wrapper.
   ///

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -760,12 +760,17 @@ ERROR(invalid_redecl,none,"invalid redeclaration of %0", (DeclName))
 ERROR(invalid_redecl_init,none,
       "invalid redeclaration of synthesized %select{|memberwise }1%0",
       (DeclName, bool))
+ERROR(invalid_redecl_implicit,none,
+      "invalid redeclaration of synthesized %select{%0|witness for protocol requirement}1 %2",
+      (DescriptiveDeclKind, bool, DeclName))
 WARNING(invalid_redecl_swift5_warning,none,
         "redeclaration of %0 is deprecated and will be an error in Swift 5",
         (DeclName))
 
 NOTE(invalid_redecl_prev,none,
      "%0 previously declared here", (DeclName))
+NOTE(invalid_redecl_implicit_wrapper,none,
+     "%0 synthesized for property wrapper %select{projected value|backing storage}1", (DeclName, bool))
 
 ERROR(ambiguous_type_base,none,
       "%0 is ambiguous for type lookup in this context", (DeclNameRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -761,7 +761,8 @@ ERROR(invalid_redecl_init,none,
       "invalid redeclaration of synthesized %select{|memberwise }1%0",
       (DeclName, bool))
 ERROR(invalid_redecl_implicit,none,
-      "invalid redeclaration of synthesized %select{%0|witness for protocol requirement}1 %2",
+      "invalid redeclaration of synthesized "
+      "%select{%0|implementation for protocol requirement}1 %2",
       (DescriptiveDeclKind, bool, DeclName))
 WARNING(invalid_redecl_swift5_warning,none,
         "redeclaration of %0 is deprecated and will be an error in Swift 5",
@@ -770,7 +771,9 @@ WARNING(invalid_redecl_swift5_warning,none,
 NOTE(invalid_redecl_prev,none,
      "%0 previously declared here", (DeclName))
 NOTE(invalid_redecl_implicit_wrapper,none,
-     "%0 synthesized for property wrapper %select{projected value|backing storage}1", (DeclName, bool))
+     "%0 synthesized for property wrapper "
+     "%select{projected value|backing storage}1",
+     (DeclName, bool))
 
 ERROR(ambiguous_type_base,none,
       "%0 is ambiguous for type lookup in this context", (DeclNameRef))

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5970,6 +5970,17 @@ VarDecl::getPropertyWrapperMutability() const {
       None);
 }
 
+Optional<PropertyWrapperSynthesizedPropertyKind>
+VarDecl::getPropertyWrapperSynthesizedPropertyKind() const {
+  if (getOriginalWrappedProperty(
+          PropertyWrapperSynthesizedPropertyKind::Backing))
+    return PropertyWrapperSynthesizedPropertyKind::Backing;
+  if (getOriginalWrappedProperty(
+          PropertyWrapperSynthesizedPropertyKind::StorageWrapper))
+    return PropertyWrapperSynthesizedPropertyKind::StorageWrapper;
+  return None;
+}
+
 VarDecl *VarDecl::getPropertyWrapperBackingProperty() const {
   return getPropertyWrapperBackingPropertyInfo().backingVar;
 }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -709,10 +709,20 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current) const {
           // 'other' is implicit, we diagnose 'current'.
           const auto *declToDiagnose = currentDC->getAsDecl();
           if (current->isImplicit() && other->isImplicit()) {
-            // Get the nearest non-implicit decl context
-            while (declToDiagnose && declToDiagnose->isImplicit() &&
-                   declToDiagnose->getDeclContext()) {
-              declToDiagnose = declToDiagnose->getDeclContext()->getAsDecl();
+            // If 'current' is a property wrapper backing storage property
+            // or projected value property, then diagnose the wrapped
+            // property instead of the nearest non-implicit DC.
+            if (auto VD = dyn_cast<VarDecl>(current)) {
+              if (auto originalWrappedProperty =
+                      VD->getOriginalWrappedProperty()) {
+                declToDiagnose = originalWrappedProperty;
+              }
+            } else {
+              // Get the nearest non-implicit decl context
+              while (declToDiagnose && declToDiagnose->isImplicit() &&
+                     declToDiagnose->getDeclContext()) {
+                declToDiagnose = declToDiagnose->getDeclContext()->getAsDecl();
+              }
             }
           } else {
             declToDiagnose = current->isImplicit() ? other : current;
@@ -735,7 +745,7 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current) const {
           // Emit a specialized note if the one of the declarations is
           // the backing storage property ('_foo') or projected value
           // property ('$foo') for a wrapped property. The backing or
-          // storage var has the same source location as the wrapped
+          // projected var has the same source location as the wrapped
           // property we diagnosed above, so we don't need to extract
           // the original property.
           const VarDecl *varToDiagnose = nullptr;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -699,48 +699,44 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current) const {
                               current->getName(),
                               otherInit->isMemberwiseInitializer());
         } else if (current->isImplicit() || other->isImplicit()) {
-          // If both declarations are implicit, we diagnose the nearest
-          // non-implicit DC because it is likely that we do not have a
-          // valid source location for the declaration and we want to
-          // avoid emitting it at an unknown location.
+          // If both declarations are implicit, we do not diagnose anything
+          // as it would lead to misleading diagnostics and it's likely that
+          // there's nothing actionable about it due to its implicit nature.
+          // One special case for this is property wrappers.
           //
           // Otherwise, if 'current' is implicit, then we diagnose 'other'
           // since 'other' is a redeclaration of 'current'. Similarly, if
           // 'other' is implicit, we diagnose 'current'.
-          const auto *declToDiagnose = currentDC->getAsDecl();
+          const Decl *declToDiagnose = nullptr;
           if (current->isImplicit() && other->isImplicit()) {
             // If 'current' is a property wrapper backing storage property
             // or projected value property, then diagnose the wrapped
-            // property instead of the nearest non-implicit DC.
+            // property.
             if (auto VD = dyn_cast<VarDecl>(current)) {
               if (auto originalWrappedProperty =
                       VD->getOriginalWrappedProperty()) {
                 declToDiagnose = originalWrappedProperty;
-              }
-            } else {
-              // Get the nearest non-implicit decl context
-              while (declToDiagnose && declToDiagnose->isImplicit() &&
-                     declToDiagnose->getDeclContext()) {
-                declToDiagnose = declToDiagnose->getDeclContext()->getAsDecl();
               }
             }
           } else {
             declToDiagnose = current->isImplicit() ? other : current;
           }
 
-          // Figure out if the the declaration we've redeclared is a synthesized
-          // witness for a protocol requirement.
-          bool isProtocolRequirement = false;
-          if (auto VD = dyn_cast<ValueDecl>(current->isImplicit() ? current
-                                                                  : other)) {
-            isProtocolRequirement = llvm::any_of(
-                VD->getSatisfiedProtocolRequirements(), [&](ValueDecl *req) {
-                  return req->getName() == VD->getName();
-                });
+          if (declToDiagnose) {
+            // Figure out if the the declaration we've redeclared is a
+            // synthesized witness for a protocol requirement.
+            bool isProtocolRequirement = false;
+            if (auto VD = dyn_cast<ValueDecl>(current->isImplicit() ? current
+                                                                    : other)) {
+              isProtocolRequirement = llvm::any_of(
+                  VD->getSatisfiedProtocolRequirements(), [&](ValueDecl *req) {
+                    return req->getName() == VD->getName();
+                  });
+            }
+            declToDiagnose->diagnose(diag::invalid_redecl_implicit,
+                                     current->getDescriptiveKind(),
+                                     isProtocolRequirement, other->getName());
           }
-          declToDiagnose->diagnose(diag::invalid_redecl_implicit,
-                                   current->getDescriptiveKind(),
-                                   isProtocolRequirement, other->getName());
 
           // Emit a specialized note if the one of the declarations is
           // the backing storage property ('_foo') or projected value

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -698,7 +698,69 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current) const {
             current->diagnose(diag::invalid_redecl_init,
                               current->getName(),
                               otherInit->isMemberwiseInitializer());
-        } else if (!current->isImplicit() && !other->isImplicit()) {
+        } else if (current->isImplicit() || other->isImplicit()) {
+          // If both declarations are implicit, we diagnose the nearest
+          // non-implicit DC because it is likely that we do not have a
+          // valid source location for the declaration and we want to
+          // avoid emitting it at an unknown location.
+          //
+          // Otherwise, if 'current' is implicit, then we diagnose 'other'
+          // since 'other' is a redeclaration of 'current'. Similarly, if
+          // 'other' is implicit, we diagnose 'current'.
+          const auto *declToDiagnose = currentDC->getAsDecl();
+          if (current->isImplicit() && other->isImplicit()) {
+            // Get the nearest non-implicit decl context
+            while (declToDiagnose && declToDiagnose->isImplicit() &&
+                   declToDiagnose->getDeclContext()) {
+              declToDiagnose = declToDiagnose->getDeclContext()->getAsDecl();
+            }
+          } else {
+            declToDiagnose = current->isImplicit() ? other : current;
+          }
+
+          // Figure out if the the declaration we've redeclared is a synthesized
+          // witness for a protocol requirement.
+          bool isProtocolRequirement = false;
+          if (auto VD = dyn_cast<ValueDecl>(current->isImplicit() ? current
+                                                                  : other)) {
+            isProtocolRequirement = llvm::any_of(
+                VD->getSatisfiedProtocolRequirements(), [&](ValueDecl *req) {
+                  return req->getName() == VD->getName();
+                });
+          }
+          declToDiagnose->diagnose(diag::invalid_redecl_implicit,
+                                   current->getDescriptiveKind(),
+                                   isProtocolRequirement, other->getName());
+
+          // Emit a specialized note if the one of the declarations is
+          // the backing storage property ('_foo') or projected value
+          // property ('$foo') for a wrapped property. The backing or
+          // storage var has the same source location as the wrapped
+          // property we diagnosed above, so we don't need to extract
+          // the original property.
+          const VarDecl *varToDiagnose = nullptr;
+          auto kind = PropertyWrapperSynthesizedPropertyKind::Backing;
+          if (auto currentVD = dyn_cast<VarDecl>(current)) {
+            if (auto currentKind =
+                    currentVD->getPropertyWrapperSynthesizedPropertyKind()) {
+              varToDiagnose = currentVD;
+              kind = *currentKind;
+            }
+          }
+          if (auto otherVD = dyn_cast<VarDecl>(other)) {
+            if (auto otherKind =
+                    otherVD->getPropertyWrapperSynthesizedPropertyKind()) {
+              varToDiagnose = otherVD;
+              kind = *otherKind;
+            }
+          }
+
+          if (varToDiagnose) {
+            varToDiagnose->diagnose(
+                diag::invalid_redecl_implicit_wrapper, varToDiagnose->getName(),
+                kind == PropertyWrapperSynthesizedPropertyKind::Backing);
+          }
+        } else {
           ctx.Diags.diagnoseWithNotes(
             current->diagnose(diag::invalid_redecl,
                               current->getName()), [&]() {

--- a/test/AutoDiff/compiler_crashers_fixed/sr12642-differentiable-derivation-redeclared-property.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr12642-differentiable-derivation-redeclared-property.swift
@@ -16,10 +16,12 @@ struct Generic<T> {}
 extension Generic: Differentiable where T: Differentiable {}
 
 struct WrappedProperties: Differentiable {
-  // expected-note @+2 {{'int' previously declared here}}
-  // expected-warning @+1 {{stored property 'int' has no derivative because 'Generic<Int>' does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}}
   @Wrapper var int: Generic<Int>
+  // expected-note@-1 {{'int' previously declared here}}
+  // expected-note@-2 {{'_int' synthesized for property wrapper backing storage}}
+  // expected-warning@-3 {{stored property 'int' has no derivative because 'Generic<Int>' does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}}
 
-  // expected-error @+1 {{invalid redeclaration of 'int'}}
   @Wrapper var int: Generic<Int>
+  // expected-error@-1 {{invalid redeclaration of 'int'}}
+  // expected-error@-2 {{invalid redeclaration of synthesized property '_int'}}
 }

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -61,7 +61,7 @@ func customHashable() {
 enum InvalidCustomHashable {
   case A, B
 
-  var hashValue: String { return "" }
+  var hashValue: String { return "" } // expected-error {{invalid redeclaration of synthesized witness for protocol requirement 'hashValue'}}
 }
 func ==(x: InvalidCustomHashable, y: InvalidCustomHashable) -> String {
   return ""
@@ -369,7 +369,6 @@ func canEatHotChip(_ birthyear:Birthyear) -> Bool {
   return birthyear > .nineties(3)
 }
 // FIXME: Remove -verify-ignore-unknown.
-// <unknown>:0: error: unexpected error produced: invalid redeclaration of 'hashValue'
 // <unknown>:0: error: unexpected note produced: candidate has non-matching type '(Foo, Foo) -> Bool'
 // <unknown>:0: error: unexpected note produced: candidate has non-matching type '<T> (Generic<T>, Generic<T>) -> Bool'
 // <unknown>:0: error: unexpected note produced: candidate has non-matching type '(InvalidCustomHashable, InvalidCustomHashable) -> Bool'

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -61,7 +61,7 @@ func customHashable() {
 enum InvalidCustomHashable {
   case A, B
 
-  var hashValue: String { return "" } // expected-error {{invalid redeclaration of synthesized witness for protocol requirement 'hashValue'}}
+  var hashValue: String { return "" } // expected-error {{invalid redeclaration of synthesized implementation for protocol requirement 'hashValue'}}
 }
 func ==(x: InvalidCustomHashable, y: InvalidCustomHashable) -> String {
   return ""

--- a/test/decl/protocol/special/coding/struct_codable_simple.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple.swift
@@ -31,24 +31,19 @@ let _ = SimpleStruct.encode(to:)
 let _ = SimpleStruct.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}
 
 // rdar://problem/59655704 
-struct SR_12248_1: Codable { 
-  // expected-error@-1 {{type 'SR_12248_1' does not conform to protocol 'Encodable'}}
-  // expected-error@-2 {{invalid redeclaration of synthesized enum case 'x'}} 
-
+struct SR_12248_1: Codable { // expected-error {{type 'SR_12248_1' does not conform to protocol 'Encodable'}}
   var x: Int // expected-note {{'x' previously declared here}}
   var x: Int // expected-error {{invalid redeclaration of 'x'}}
   // expected-note@-1 {{cannot automatically synthesize 'Encodable' because '<<error type>>' does not conform to 'Encodable'}}
   // expected-note@-2 {{cannot automatically synthesize 'Encodable' because '<<error type>>' does not conform to 'Encodable'}}
 }
 
-struct SR_12248_2: Decodable {
-  // expected-error@-1 {{invalid redeclaration of synthesized enum case 'x'}}
+struct SR_12248_2: Decodable { 
   var x: Int // expected-note {{'x' previously declared here}}
   var x: Int // expected-error {{invalid redeclaration of 'x'}}
 }
 
-struct SR_12248_3: Encodable {
-  // expected-error@-1 {{invalid redeclaration of synthesized enum case 'x'}} 
+struct SR_12248_3: Encodable { 
   var x: Int // expected-note {{'x' previously declared here}}
   var x: Int // expected-error {{invalid redeclaration of 'x'}}
 }

--- a/test/decl/protocol/special/coding/struct_codable_simple.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple.swift
@@ -31,19 +31,24 @@ let _ = SimpleStruct.encode(to:)
 let _ = SimpleStruct.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}
 
 // rdar://problem/59655704 
-struct SR_12248_1: Codable { // expected-error {{type 'SR_12248_1' does not conform to protocol 'Encodable'}}
+struct SR_12248_1: Codable { 
+  // expected-error@-1 {{type 'SR_12248_1' does not conform to protocol 'Encodable'}}
+  // expected-error@-2 {{invalid redeclaration of synthesized enum case 'x'}} 
+
   var x: Int // expected-note {{'x' previously declared here}}
   var x: Int // expected-error {{invalid redeclaration of 'x'}}
   // expected-note@-1 {{cannot automatically synthesize 'Encodable' because '<<error type>>' does not conform to 'Encodable'}}
   // expected-note@-2 {{cannot automatically synthesize 'Encodable' because '<<error type>>' does not conform to 'Encodable'}}
 }
 
-struct SR_12248_2: Decodable { 
+struct SR_12248_2: Decodable {
+  // expected-error@-1 {{invalid redeclaration of synthesized enum case 'x'}}
   var x: Int // expected-note {{'x' previously declared here}}
   var x: Int // expected-error {{invalid redeclaration of 'x'}}
 }
 
-struct SR_12248_3: Encodable { 
+struct SR_12248_3: Encodable {
+  // expected-error@-1 {{invalid redeclaration of synthesized enum case 'x'}} 
   var x: Int // expected-note {{'x' previously declared here}}
   var x: Int // expected-error {{invalid redeclaration of 'x'}}
 }

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -850,8 +850,6 @@ struct WrapperWithProjectedValue<T> {
 }
 
 class TestInvalidRedeclaration1 {
-  // expected-error@-1 {{invalid redeclaration of synthesized property '_i'}}
-  // expected-error@-2 {{invalid redeclaration of synthesized property '$i'}}
 
   @WrapperWithProjectedValue var i = 17
   // expected-note@-1 {{'i' previously declared here}}
@@ -860,6 +858,8 @@ class TestInvalidRedeclaration1 {
 
   @WrapperWithProjectedValue var i = 39
   // expected-error@-1 {{invalid redeclaration of 'i'}}
+  // expected-error@-2 {{invalid redeclaration of synthesized property '$i'}}
+  // expected-error@-3 {{invalid redeclaration of synthesized property '_i'}}
 }
 
 // SR-12839

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -849,11 +849,28 @@ struct WrapperWithProjectedValue<T> {
   var projectedValue: T { return wrappedValue }
 }
 
-class TestInvalidRedeclaration {
+class TestInvalidRedeclaration1 {
+  // expected-error@-1 {{invalid redeclaration of synthesized property '_i'}}
+  // expected-error@-2 {{invalid redeclaration of synthesized property '$i'}}
+
   @WrapperWithProjectedValue var i = 17
   // expected-note@-1 {{'i' previously declared here}}
+  // expected-note@-2 {{'$i' synthesized for property wrapper projected value}}
+  // expected-note@-3 {{'_i' synthesized for property wrapper backing storage}}
+
   @WrapperWithProjectedValue var i = 39
   // expected-error@-1 {{invalid redeclaration of 'i'}}
+}
+
+// SR-12839
+struct TestInvalidRedeclaration2 {
+  var _foo1 = 123 // expected-error {{invalid redeclaration of synthesized property '_foo1'}}
+  @WrapperWithInitialValue var foo1 = 123 // expected-note {{'_foo1' synthesized for property wrapper backing storage}}
+}
+
+struct TestInvalidRedeclaration3 {
+  @WrapperWithInitialValue var foo1 = 123 // expected-note {{'_foo1' synthesized for property wrapper backing storage}}
+  var _foo1 = 123 // expected-error {{invalid redeclaration of synthesized property '_foo1'}}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
At the moment, some redeclaration errors involving synthesised declarations can cause compiler crashes. For example:

```swift
@propertyWrapper 
struct Wrapper {
  var wrappedValue: Int
}

struct S {
  @Wrapper var foo1 = 123
  var _foo1 = 123
}
```

This currently crashes in the AST verifier on master and in SILGen on 5.3. Upon investigation, this seems to be a regression caused by #31037.

To fix the problem, I have added a specialised diagnostic for situations where the current declaration is synthesised. This also fixes a problem where the redeclaration diagnostics did not have a valid source location.

Resolves SR-12839
Resolves rdar://problem/63496795