### PR TITLE
[5.3][CodeCompletion] Avoid suggesting duplicated module names

### DIFF
--- a/test/IDE/Inputs/mock-sdk/OverlayTest.framework/Headers/OverlayTest.h
+++ b/test/IDE/Inputs/mock-sdk/OverlayTest.framework/Headers/OverlayTest.h
@@ -1,0 +1,2 @@
+#include <OverlayTest/Overlayed.h>
+

--- a/test/IDE/Inputs/mock-sdk/OverlayTest.framework/Headers/Overlayed.h
+++ b/test/IDE/Inputs/mock-sdk/OverlayTest.framework/Headers/Overlayed.h
@@ -1,0 +1,13 @@
+
+#ifndef OVERLAYED_H
+#define OVERLAYED_H
+
+struct __attribute__((swift_name("Overlayed"))) OVOverlayed {
+  double x, y, z;
+};
+
+double OVOverlayedInOriginalFunc(struct OVOverlayed s) __attribute__((swift_name("Overlayed.inOriginalFunc(self:)")));
+
+struct OVOverlayed createOverlayed();
+
+#endif

--- a/test/IDE/Inputs/mock-sdk/OverlayTest.framework/Modules/module.modulemap
+++ b/test/IDE/Inputs/mock-sdk/OverlayTest.framework/Modules/module.modulemap
@@ -1,0 +1,7 @@
+framework module OverlayTest {
+  umbrella header "OverlayTest.h"
+
+  export *
+  module * { export * }
+}
+

--- a/test/IDE/Inputs/mock-sdk/OverlayTest.swiftinterface
+++ b/test/IDE/Inputs/mock-sdk/OverlayTest.swiftinterface
@@ -1,0 +1,10 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name OverlayTest
+
+@_exported import OverlayTest
+
+public extension Overlayed {
+    public func inOverlayFunc() {}
+}
+
+public func createOverlayedInOverlay() -> Overlayed

--- a/test/IDE/complete_overlaymodule.swift
+++ b/test/IDE/complete_overlaymodule.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -I %S/Inputs/mock-sdk -F %S/Inputs/mock-sdk -code-completion-token=TYPE_GLOBAL | %FileCheck %s --check-prefix=TYPE_GLOBAL
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -I %S/Inputs/mock-sdk -F %S/Inputs/mock-sdk -code-completion-token=EXPR_GLOBAL | %FileCheck %s --check-prefix=EXPR_GLOBAL
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -I %S/Inputs/mock-sdk -F %S/Inputs/mock-sdk -code-completion-token=EXPR_MEMBER | %FileCheck %s --check-prefix=EXPR_MEMBER
+
+import OverlayTest
+
+func testGlobalType() {
+    let _: #^TYPE_GLOBAL^#
+// TYPE_GLOBAL: Begin completions
+// TYPE_GLOBAL-NOT: OverlayTest[#Module#]
+// TYPE_GLOBAL-DAG: Decl[Module]/None:                  OverlayTest[#Module#];
+// TYPE_GLOBAL-NOT: OverlayTest[#Module#]
+// TYPE_GLOBAL-DAG: Decl[Struct]/OtherModule[OverlayTest.Overlayed]: Overlayed[#Overlayed#];
+// TYPE_GLOBAL: End completions
+}
+func testGlobalExpr() {
+    let _ = #^EXPR_GLOBAL^#
+// EPXR_GLOBAL: Begin completions
+// EXPR_GLOBAL-NOT: OverlayTest[#Module#]
+// EXPR_GLOBAL-DAG: Decl[Module]/None:                  OverlayTest[#Module#];
+// EXPR_GLOBAL-NOT: OverlayTest[#Module#]
+// EXPR_GLOBAL-DAG: Decl[Struct]/OtherModule[OverlayTest.Overlayed]: Overlayed[#Overlayed#];
+// EXPR_GLOBAL-DAG: Decl[FreeFunction]/OtherModule[OverlayTest]: createOverlayedInOverlay()[#Overlayed#];
+// EXPR_GLOBAL-DAG: Decl[FreeFunction]/OtherModule[OverlayTest.Overlayed]: createOverlayed()[#Overlayed#];
+// EPXR_GLOBAL: End completions
+}
+func testGlobalExpr(value: Overlayed) {
+    value.#^EXPR_MEMBER^#
+// EXPR_MEMBER: Begin completions, 6 items
+// EXPR_MEMBER-DAG: Keyword[self]/CurrNominal:          self[#Overlayed#]; name=self
+// EXPR_MEMBER-DAG: Decl[InstanceVar]/CurrNominal:      x[#Double#]; name=x
+// EXPR_MEMBER-DAG: Decl[InstanceVar]/CurrNominal:      y[#Double#]; name=y
+// EXPR_MEMBER-DAG: Decl[InstanceVar]/CurrNominal:      z[#Double#]; name=z
+// EXPR_MEMBER-DAG: Decl[InstanceMethod]/CurrNominal:   inOverlayFunc()[#Void#]; name=inOverlayFunc()
+// EXPR_MEMBER-DAG: Decl[InstanceMethod]/CurrNominal:   inOriginalFunc()[#Double#]; name=inOriginalFunc()
+// EXPR_MEMBER: End completions
+}


### PR DESCRIPTION
Cherry-pick of #31892 into `release/5.3`

* **Explanation**: Overlay modules have the same name as the shadowed modules. For global symbol completions, we should not list both names because they are identical. Maintain a set of seen module names to avoid suggesting duplicated names. 
* **Scope**: Code completion for global symbols
* **Risk**: Very low. The change is pretty simple.
* **Issue**: rdar://problem/63370253
* **Testing**: Added regression test cases
* **Reviewers**: Nathan Hawes (@nathawes)