### PR TITLE
tools: disable ObjC for wasm in SILFunctionExtractor

### DIFF
--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -116,6 +116,11 @@ static llvm::cl::opt<bool> EnableOSSAModules(
                    "this is disabled we do not serialize in OSSA "
                    "form when optimizing."));
 
+static llvm::cl::opt<llvm::cl::boolOrDefault> EnableObjCInterop(
+    "enable-objc-interop",
+    llvm::cl::desc("Whether the Objective-C interop should be enabled. "
+                   "The value is `true` by default on Darwin platforms."));
+
 // This function isn't referenced outside its translation unit, but it
 // can't use the "static" keyword because its address is used for
 // getMainExecutable (since some platforms don't support taking the
@@ -249,6 +254,15 @@ int main(int argc, char **argv) {
   Invocation.getLangOptions().DisableAvailabilityChecking = true;
   Invocation.getLangOptions().EnableAccessControl = false;
   Invocation.getLangOptions().EnableObjCAttrRequiresFoundation = false;
+
+  if (EnableObjCInterop == llvm::cl::BOU_UNSET) {
+    Invocation.getLangOptions().EnableObjCInterop =
+        Invocation.getLangOptions().Target.isOSDarwin();
+  } else if (EnableObjCInterop == llvm::cl::BOU_TRUE) {
+    Invocation.getLangOptions().EnableObjCInterop = true;
+  } else {
+    Invocation.getLangOptions().EnableObjCInterop = false;
+  }
 
   SILOptions &Opts = Invocation.getSILOptions();
   Opts.EmitVerboseSIL = EmitVerboseSIL;

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -258,10 +258,9 @@ int main(int argc, char **argv) {
   if (EnableObjCInterop == llvm::cl::BOU_UNSET) {
     Invocation.getLangOptions().EnableObjCInterop =
         Invocation.getLangOptions().Target.isOSDarwin();
-  } else if (EnableObjCInterop == llvm::cl::BOU_TRUE) {
-    Invocation.getLangOptions().EnableObjCInterop = true;
   } else {
-    Invocation.getLangOptions().EnableObjCInterop = false;
+    Invocation.getLangOptions().EnableObjCInterop =
+        EnableObjCInterop == llvm::cl::BOU_TRUE;
   }
 
   SILOptions &Opts = Invocation.getSILOptions();


### PR DESCRIPTION
<!-- What's in this pull request? -->
Currently, `clang` doesn't support Objective-C with the WebAssembly object format. Because of this, `sil-function-extractor` tool crashes in [Clang's `CGObjCCommonMac::GetSectionName` function](https://github.com/apple/llvm-project/blob/c3e5ae3fdebb67d936aeec2b04b7d2b6a784f69e/clang/lib/CodeGen/CGObjCMac.cpp#L5065-L5084). Since Swift doesn't provide Objective-C interop for WebAssembly, it would make sense to disable it explicitly. `sil-function-extractor` is used in the test suite, so this PR is required for those tests to proceed when testing the WebAssembly toolchain and SDK.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Related to SR-9307.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
(cc @compnerd)