### PR TITLE
DependenciesScanner: report command-line arguments for building pcms explicitly

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -43,6 +43,12 @@ namespace clang {
   class Type;
   class VisibleDeclConsumer;
   class DeclarationName;
+  class CompilerInvocation;
+namespace tooling {
+namespace dependencies {
+  struct FullDependenciesResult;
+}
+}
 }
 
 namespace swift {
@@ -148,6 +154,14 @@ public:
          std::string swiftPCHHash = "", DependencyTracker *tracker = nullptr,
          DWARFImporterDelegate *dwarfImporterDelegate = nullptr);
 
+  static std::vector<std::string>
+  getClangArguments(ASTContext &ctx, const ClangImporterOptions &importerOpts);
+
+  static std::unique_ptr<clang::CompilerInvocation>
+  createClangInvocation(ClangImporter *importer,
+                        const ClangImporterOptions &importerOpts,
+                        ArrayRef<std::string> invocationArgStrs,
+                        std::vector<std::string> *CC1Args = nullptr);
   ClangImporter(const ClangImporter &) = delete;
   ClangImporter(ClangImporter &&) = delete;
   ClangImporter &operator=(const ClangImporter &) = delete;
@@ -369,6 +383,10 @@ public:
 
   void verifyAllModules() override;
 
+  void recordModuleDependencies(
+      ModuleDependenciesCache &cache,
+      const clang::tooling::dependencies::FullDependenciesResult &clangDependencies);
+
   Optional<ModuleDependencies> getModuleDependencies(
       StringRef moduleName, ModuleDependenciesCache &cache,
       InterfaceSubContextDelegate &delegate) override;
@@ -459,6 +477,12 @@ public:
 
 ImportDecl *createImportDecl(ASTContext &Ctx, DeclContext *DC, ClangNode ClangN,
                              ArrayRef<clang::Module *> Exported);
+
+/// Extract the specified-or-defaulted -module-cache-path that winds up in
+/// the clang importer, for reuse as the .swiftmodule cache path when
+/// building a ModuleInterfaceLoader.
+std::string
+getModuleCachePathFromClang(const clang::CompilerInstance &Instance);
 
 } // end namespace swift
 

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -198,12 +198,6 @@ public:
     bool RemarkOnRebuildFromInterface, bool DisableInterfaceFileLock);
 };
 
-/// Extract the specified-or-defaulted -module-cache-path that winds up in
-/// the clang importer, for reuse as the .swiftmodule cache path when
-/// building a ModuleInterfaceLoader.
-std::string
-getModuleCachePathFromClang(const clang::CompilerInstance &Instance);
-
 struct InterfaceSubContextDelegateImpl: InterfaceSubContextDelegate {
 private:
   SourceManager &SM;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -905,15 +905,10 @@ ClangImporter::getOrCreatePCH(const ClangImporterOptions &ImporterOptions,
   return PCHFilename.getValue();
 }
 
-std::unique_ptr<ClangImporter>
-ClangImporter::create(ASTContext &ctx, const ClangImporterOptions &importerOpts,
-                      std::string swiftPCHHash, DependencyTracker *tracker,
-                      DWARFImporterDelegate *dwarfImporterDelegate) {
-  std::unique_ptr<ClangImporter> importer{
-      new ClangImporter(ctx, importerOpts, tracker, dwarfImporterDelegate)};
-
+std::vector<std::string>
+ClangImporter::getClangArguments(ASTContext &ctx,
+                                 const ClangImporterOptions &importerOpts) {
   std::vector<std::string> invocationArgStrs;
-
   // Clang expects this to be like an actual command line. So we need to pass in
   // "clang" for argv[0]
   invocationArgStrs.push_back("clang");
@@ -927,6 +922,49 @@ ClangImporter::create(ASTContext &ctx, const ClangImporterOptions &importerOpts,
     break;
   }
   addCommonInvocationArguments(invocationArgStrs, ctx, importerOpts);
+  return invocationArgStrs;
+}
+
+std::unique_ptr<clang::CompilerInvocation>
+ClangImporter::createClangInvocation(ClangImporter *importer,
+                                     const ClangImporterOptions &importerOpts,
+                                     ArrayRef<std::string> invocationArgStrs,
+                                     std::vector<std::string> *CC1Args) {
+  std::vector<const char *> invocationArgs;
+  invocationArgs.reserve(invocationArgStrs.size());
+  for (auto &argStr : invocationArgStrs)
+    invocationArgs.push_back(argStr.c_str());
+  // Set up a temporary diagnostic client to report errors from parsing the
+  // command line, which may be important for Swift clients if, for example,
+  // they're using -Xcc options. Unfortunately this diagnostic engine has to
+  // use the default options because the /actual/ options haven't been parsed
+  // yet.
+  //
+  // The long-term client for Clang diagnostics is set up below, after the
+  // clang::CompilerInstance is created.
+  llvm::IntrusiveRefCntPtr<clang::DiagnosticOptions> tempDiagOpts{
+    new clang::DiagnosticOptions
+  };
+
+  ClangDiagnosticConsumer tempDiagClient{importer->Impl, *tempDiagOpts,
+                                         importerOpts.DumpClangDiagnostics};
+  llvm::IntrusiveRefCntPtr<clang::DiagnosticsEngine> tempClangDiags =
+      clang::CompilerInstance::createDiagnostics(tempDiagOpts.get(),
+                                                 &tempDiagClient,
+                                                 /*owned*/false);
+
+  return clang::createInvocationFromCommandLine(invocationArgs, tempClangDiags,
+                                                nullptr, false, CC1Args);
+}
+
+std::unique_ptr<ClangImporter>
+ClangImporter::create(ASTContext &ctx, const ClangImporterOptions &importerOpts,
+                      std::string swiftPCHHash, DependencyTracker *tracker,
+                      DWARFImporterDelegate *dwarfImporterDelegate) {
+  std::unique_ptr<ClangImporter> importer{
+      new ClangImporter(ctx, importerOpts, tracker, dwarfImporterDelegate)};
+  importer->Impl.ClangArgs = getClangArguments(ctx, importerOpts);
+  ArrayRef<std::string> invocationArgStrs = importer->Impl.ClangArgs;
 
   if (importerOpts.DumpClangDiagnostics) {
     llvm::errs() << "'";
@@ -936,10 +974,7 @@ ClangImporter::create(ASTContext &ctx, const ClangImporterOptions &importerOpts,
     llvm::errs() << "'\n";
   }
 
-  std::vector<const char *> invocationArgs;
-  invocationArgs.reserve(invocationArgStrs.size());
-  for (auto &argStr : invocationArgStrs)
-    invocationArgs.push_back(argStr.c_str());
+
 
   if (llvm::sys::path::extension(importerOpts.BridgingHeader)
         .endswith(file_types::getExtension(file_types::TY_PCH))) {
@@ -957,27 +992,9 @@ ClangImporter::create(ASTContext &ctx, const ClangImporterOptions &importerOpts,
 
   // Create a new Clang compiler invocation.
   {
-    // Set up a temporary diagnostic client to report errors from parsing the
-    // command line, which may be important for Swift clients if, for example,
-    // they're using -Xcc options. Unfortunately this diagnostic engine has to
-    // use the default options because the /actual/ options haven't been parsed
-    // yet.
-    //
-    // The long-term client for Clang diagnostics is set up below, after the
-    // clang::CompilerInstance is created.
-    llvm::IntrusiveRefCntPtr<clang::DiagnosticOptions> tempDiagOpts{
-      new clang::DiagnosticOptions
-    };
-
-    ClangDiagnosticConsumer tempDiagClient{importer->Impl, *tempDiagOpts,
-                                           importerOpts.DumpClangDiagnostics};
-    llvm::IntrusiveRefCntPtr<clang::DiagnosticsEngine> tempClangDiags =
-        clang::CompilerInstance::createDiagnostics(tempDiagOpts.get(),
-                                                   &tempDiagClient,
-                                                   /*owned*/false);
-
-    importer->Impl.Invocation =
-        clang::createInvocationFromCommandLine(invocationArgs, tempClangDiags);
+    importer->Impl.Invocation = createClangInvocation(importer.get(),
+                                                      importerOpts,
+                                                      invocationArgStrs);
     if (!importer->Impl.Invocation)
       return nullptr;
   }
@@ -4002,3 +4019,20 @@ bool ClangImporter::isInOverlayModuleForImportedModule(
   return !clangModule->ExportAsModule.empty() &&
     clangModule->ExportAsModule == overlayModule->getName().str();
 }
+
+/// Extract the specified-or-defaulted -module-cache-path that winds up in
+/// the clang importer, for reuse as the .swiftmodule cache path when
+/// building a ModuleInterfaceLoader.
+std::string
+swift::getModuleCachePathFromClang(const clang::CompilerInstance &Clang) {
+  if (!Clang.hasPreprocessor())
+    return "";
+  std::string SpecificModuleCachePath =
+      Clang.getPreprocessor().getHeaderSearchInfo().getModuleCachePath().str();
+
+  // The returned-from-clang module cache path includes a suffix directory
+  // that is specific to the clang version and invocation; we want the
+  // directory above that.
+  return llvm::sys::path::parent_path(SpecificModuleCachePath).str();
+}
+

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -188,12 +188,48 @@ static ClangModuleDependenciesCacheImpl *getOrCreateClangImpl(
   return clangImpl;
 }
 
+static std::string getModuleFilePath(StringRef moduleCacheDir,
+                                     StringRef moduleName,
+                                     StringRef contextHash) {
+  SmallString<128> outputPath(moduleCacheDir);
+  llvm::sys::path::append(outputPath, (llvm::Twine(moduleName)
+    + "-" + contextHash + ".pcm").str());
+  return outputPath.str().str();
+}
+
+static std::string getModuleFilePath(StringRef moduleCacheDir,
+                                     const ModuleDeps &dep) {
+  return getModuleFilePath(moduleCacheDir, dep.ModuleName, dep.ContextHash);
+}
+
 /// Record the module dependencies we found by scanning Clang modules into
 /// the module dependencies cache.
-static void recordModuleDependencies(
+void ClangImporter::recordModuleDependencies(
     ModuleDependenciesCache &cache,
     const FullDependenciesResult &clangDependencies) {
+  struct ModuleInfo {
+    std::string PCMPath;
+    std::string ModuleMapPath;
+  };
+  auto ModuleCacheDir = swift::getModuleCachePathFromClang(getClangInstance());
+
+  // A map keyed by module name and context hash.
+  llvm::StringMap<llvm::StringMap<ModuleInfo>> moduleInfoMap;
+
+  // Traverse all Clang modules to populate moduleInfoMap for cross
+  // referencing later.
   for (const auto &clangModuleDep : clangDependencies.DiscoveredModules) {
+    moduleInfoMap[clangModuleDep.ModuleName][clangModuleDep.ContextHash] =
+      {
+        // Keep track of pcm path for output.
+        getModuleFilePath(ModuleCacheDir, clangModuleDep),
+        // Keep track of modulemap file for input.
+        clangModuleDep.ClangModuleMapFile
+      };
+  }
+  for (const auto &clangModuleDep : clangDependencies.DiscoveredModules) {
+    assert(moduleInfoMap[clangModuleDep.ModuleName]
+      .count(clangModuleDep.ContextHash));
     // If we've already cached this information, we're done.
     if (cache.hasDependencies(clangModuleDep.ModuleName,
                               ModuleDependenciesKind::Clang))
@@ -204,14 +240,58 @@ static void recordModuleDependencies(
     for (const auto &fileDep : clangModuleDep.FileDeps) {
       fileDeps.push_back(fileDep.getKey().str());
     }
+    // Inherit all Clang driver args when creating the clang importer.
+    std::vector<std::string> allArgs = Impl.ClangArgs;
+    ClangImporterOptions Opts;
+    std::vector<std::string> cc1Args;
 
+    // Calling this to convert driver args to CC1 args.
+    createClangInvocation(this, Opts, allArgs, &cc1Args);
+    std::vector<std::string> swiftArgs;
+    // We are using Swift frontend mode.
+    swiftArgs.push_back("-frontend");
+    auto addClangArg = [&](StringRef arg) {
+      swiftArgs.push_back("-Xcc");
+      swiftArgs.push_back("-Xclang");
+      swiftArgs.push_back("-Xcc");
+      swiftArgs.push_back(arg);
+    };
+    // Add all args inheritted from creating the importer.
+    for (auto arg: cc1Args) {
+      addClangArg(arg);
+    }
+    // Add all args reported from the Clang dependencies scanner.
+    for(auto arg: clangModuleDep.NonPathCommandLine) {
+      addClangArg(arg);
+    }
+
+    // Add -fmodule-map-file and -fmodule-file for direct dependencies.
+    for (auto &dep: clangModuleDep.ClangModuleDeps) {
+      assert(moduleInfoMap[dep.ModuleName].count(dep.ContextHash));
+      addClangArg((llvm::Twine("-fmodule-map-file=")
+        + moduleInfoMap[dep.ModuleName][dep.ContextHash].ModuleMapPath).str());
+      addClangArg((llvm::Twine("-fmodule-file=")
+        + moduleInfoMap[dep.ModuleName][dep.ContextHash].PCMPath).str());
+    }
+    // Swift frontend action: -emit-pcm
+    swiftArgs.push_back("-emit-pcm");
+    swiftArgs.push_back("-module-name");
+    swiftArgs.push_back(clangModuleDep.ModuleName);
+
+    // Swift frontend option for output file path (Foo.pcm).
+    swiftArgs.push_back("-o");
+    swiftArgs.push_back(moduleInfoMap[clangModuleDep.ModuleName]
+      [clangModuleDep.ContextHash].PCMPath);
+
+    // Swift frontend option for input file path (Foo.modulemap).
+    swiftArgs.push_back(clangModuleDep.ClangModuleMapFile);
     // Module-level dependencies.
     llvm::StringSet<> alreadyAddedModules;
     auto dependencies = ModuleDependencies::forClangModule(
         clangModuleDep.ImplicitModulePCMPath,
         clangModuleDep.ClangModuleMapFile,
         clangModuleDep.ContextHash,
-        clangModuleDep.NonPathCommandLine,
+        swiftArgs,
         fileDeps);
     for (const auto &moduleName : clangModuleDep.ClangModuleDeps) {
       dependencies.addModuleDependency(moduleName.ModuleName, alreadyAddedModules);

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -390,6 +390,8 @@ private:
   /// Clang parser, which is used to load textual headers.
   std::unique_ptr<clang::MangleContext> Mangler;
 
+  /// Clang arguments used to create the Clang invocation.
+  std::vector<std::string> ClangArgs;
 public:
   /// Mapping of already-imported declarations.
   llvm::DenseMap<std::pair<const clang::Decl *, Version>, Decl *> ImportedDecls;

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -41,22 +41,6 @@
 using namespace swift;
 using FileDependency = SerializationOptions::FileDependency;
 
-/// Extract the specified-or-defaulted -module-cache-path that winds up in
-/// the clang importer, for reuse as the .swiftmodule cache path when
-/// building a ModuleInterfaceLoader.
-std::string
-swift::getModuleCachePathFromClang(const clang::CompilerInstance &Clang) {
-  if (!Clang.hasPreprocessor())
-    return "";
-  std::string SpecificModuleCachePath =
-      Clang.getPreprocessor().getHeaderSearchInfo().getModuleCachePath().str();
-
-  // The returned-from-clang module cache path includes a suffix directory
-  // that is specific to the clang version and invocation; we want the
-  // directory above that.
-  return llvm::sys::path::parent_path(SpecificModuleCachePath).str();
-}
-
 #pragma mark - Forwarding Modules
 
 namespace {
@@ -1048,6 +1032,7 @@ void ModuleInterfaceLoader::collectVisibleTopLevelModuleNames(
 void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
     const SearchPathOptions &SearchPathOpts,
     const LangOptions &LangOpts) {
+  GenericArgs.push_back("-frontend");
   // Start with a SubInvocation that copies various state from our
   // invoking ASTContext.
   GenericArgs.push_back("-compile-module-from-interface");

--- a/test/ScanDependencies/Inputs/BuildModulesFromGraph.swift
+++ b/test/ScanDependencies/Inputs/BuildModulesFromGraph.swift
@@ -1,0 +1,54 @@
+//===--------------- BuildModulesFromGraph.swift --------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+
+let fileName = CommandLine.arguments[1]
+let swiftPath = CommandLine.arguments[2]
+let moduleName = CommandLine.arguments[3]
+let data = try! Data(contentsOf: URL(fileURLWithPath: fileName))
+
+let decoder = JSONDecoder()
+let moduleDependencyGraph = try! decoder.decode(
+  ModuleDependencyGraph.self, from: data)
+
+func findModuleBuildingCommand(_ moduleName: String) -> [String]? {
+  for (_, dep) in moduleDependencyGraph.modules {
+    if dep.modulePath.hasSuffix(moduleName) {
+      switch dep.details {
+      case .swift(let details):
+        return details.commandLine
+      case .clang(let details):
+        return details.commandLine
+      }
+    } else {
+      continue
+    }
+  }
+  return nil
+}
+
+func run(command: String, arguments: [String] = []) -> Int32 {
+  let process = Process()
+  process.launchPath = command
+  process.arguments = arguments
+  let outputPipe = Pipe()
+  process.standardOutput = outputPipe
+  process.launch()
+  process.waitUntilExit()
+  return process.terminationStatus
+}
+
+if let command = findModuleBuildingCommand(moduleName) {
+  exit(run(command: swiftPath, arguments: command))
+} else {
+  fatalError("cannot find module building commands for \(moduleName)")
+}

--- a/test/ScanDependencies/Inputs/BuildModulesFromGraph.swift
+++ b/test/ScanDependencies/Inputs/BuildModulesFromGraph.swift
@@ -36,19 +36,11 @@ func findModuleBuildingCommand(_ moduleName: String) -> [String]? {
   return nil
 }
 
-func run(command: String, arguments: [String] = []) -> Int32 {
-  let process = Process()
-  process.launchPath = command
-  process.arguments = arguments
-  let outputPipe = Pipe()
-  process.standardOutput = outputPipe
-  process.launch()
-  process.waitUntilExit()
-  return process.terminationStatus
-}
-
 if let command = findModuleBuildingCommand(moduleName) {
-  exit(run(command: swiftPath, arguments: command))
+  var result = swiftPath
+  command.forEach { result += " \($0)"}
+  print(result)
+  exit(0)
 } else {
   fatalError("cannot find module building commands for \(moduleName)")
 }

--- a/test/ScanDependencies/Inputs/CHeaders/B.h
+++ b/test/ScanDependencies/Inputs/CHeaders/B.h
@@ -1,4 +1,4 @@
-#include <A.h>
+#include "A.h"
 
 void funcB(void);
 

--- a/test/ScanDependencies/Inputs/CHeaders/C.h
+++ b/test/ScanDependencies/Inputs/CHeaders/C.h
@@ -1,3 +1,3 @@
-#include <B.h>
+#include "B.h"
 
 void funcC(void);

--- a/test/ScanDependencies/Inputs/CommandRunner.py
+++ b/test/ScanDependencies/Inputs/CommandRunner.py
@@ -1,0 +1,7 @@
+#!/usr/bin/python
+
+import subprocess
+import sys
+
+for line in sys.stdin:
+    subprocess.check_call(line.split())

--- a/test/ScanDependencies/Inputs/ModuleDependencyGraph.swift
+++ b/test/ScanDependencies/Inputs/ModuleDependencyGraph.swift
@@ -65,6 +65,10 @@ struct SwiftModuleDetails: Codable {
 
   /// The bridging header, if any.
   var bridgingHeader: BridgingHeader?
+
+  /// The Swift command line arguments that need to be passed through
+  /// to the -compile-module-from-interface action to build this module.
+  var commandLine: [String]?
 }
 
 /// Details specific to Clang modules.

--- a/test/ScanDependencies/Inputs/ModuleDependencyGraph.swift
+++ b/test/ScanDependencies/Inputs/ModuleDependencyGraph.swift
@@ -144,11 +144,3 @@ struct ModuleDependencyGraph: Codable {
   /// Information about the main module.
   var mainModule: ModuleDependencies { modules[.swift(mainModuleName)]! }
 }
-
-let fileName = CommandLine.arguments[1]
-let data = try! Data(contentsOf: URL(fileURLWithPath: fileName))
-
-let decoder = JSONDecoder()
-let moduleDependencyGraph = try! decoder.decode(
-  ModuleDependencyGraph.self, from: data)
-print(moduleDependencyGraph)

--- a/test/ScanDependencies/Inputs/PrintGraph.swift
+++ b/test/ScanDependencies/Inputs/PrintGraph.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+let fileName = CommandLine.arguments[1]
+let data = try! Data(contentsOf: URL(fileURLWithPath: fileName))
+
+let decoder = JSONDecoder()
+let moduleDependencyGraph = try! decoder.decode(
+  ModuleDependencyGraph.self, from: data)
+print(moduleDependencyGraph)

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -17,6 +17,26 @@
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main %t/deps.json
 
+// RUN: mkdir -p %t/BuildModules
+// RUN: cp %S/Inputs/BuildModulesFromGraph.swift %t/BuildModules/main.swift
+// RUN: %target-build-swift %S/Inputs/ModuleDependencyGraph.swift %t/BuildModules/main.swift -o %t/ModuleBuilder
+// RUN: %target-codesign %t/ModuleBuilder
+
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path A.pcm
+// RUN: ls %t/clang-module-cache/A-*.pcm
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path B.pcm
+// RUN: ls %t/clang-module-cache/B-*.pcm
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path C.pcm
+// RUN: ls %t/clang-module-cache/C-*.pcm
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path A.swiftmodule
+// RUN: ls %t/clang-module-cache/A-*.swiftmodule
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path E.swiftmodule
+// RUN: ls %t/clang-module-cache/E-*.swiftmodule
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path F.swiftmodule
+// RUN: ls %t/clang-module-cache/F-*.swiftmodule
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path G.swiftmodule
+// RUN: ls %t/clang-module-cache/G-*.swiftmodule
+
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -82,7 +82,12 @@ import G
 // CHECK-SAME: "{{.*}}"
 
 // CHECK: "commandLine": [
-// CHECK-NEXT: "-remove-preceeding-explicit-module-build-incompatible-options"
+// CHECK-NEXT: "-frontend"
+// CHECK-NEXT: "-Xcc"
+// CHECK-NEXT: "-Xclang"
+// CHECK-NEXT: "-Xcc"
+// CHECK-NEXT: "-cc1"
+// CHECK: "-remove-preceeding-explicit-module-build-incompatible-options"
 
 /// --------Swift module E
 // CHECK: "swift": "E"

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -11,7 +11,9 @@
 // Check that the JSON parses correctly into the canonical Swift data
 // structures.
 
-// RUN: %target-build-swift %S/Inputs/ModuleDependencyGraph.swift -o %t/main
+// RUN: mkdir -p %t/PrintGraph
+// RUN: cp %S/Inputs/PrintGraph.swift %t/main.swift
+// RUN: %target-build-swift %S/Inputs/ModuleDependencyGraph.swift %t/main.swift -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main %t/deps.json
 

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -22,19 +22,19 @@
 // RUN: %target-build-swift %S/Inputs/ModuleDependencyGraph.swift %t/BuildModules/main.swift -o %t/ModuleBuilder
 // RUN: %target-codesign %t/ModuleBuilder
 
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path A.pcm
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path A.pcm | %S/Inputs/CommandRunner.py
 // RUN: ls %t/clang-module-cache/A-*.pcm
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path B.pcm
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path B.pcm | %S/Inputs/CommandRunner.py
 // RUN: ls %t/clang-module-cache/B-*.pcm
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path C.pcm
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path C.pcm | %S/Inputs/CommandRunner.py
 // RUN: ls %t/clang-module-cache/C-*.pcm
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path A.swiftmodule
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path A.swiftmodule | %S/Inputs/CommandRunner.py
 // RUN: ls %t/clang-module-cache/A-*.swiftmodule
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path E.swiftmodule
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path E.swiftmodule | %S/Inputs/CommandRunner.py
 // RUN: ls %t/clang-module-cache/E-*.swiftmodule
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path F.swiftmodule
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path F.swiftmodule | %S/Inputs/CommandRunner.py
 // RUN: ls %t/clang-module-cache/F-*.swiftmodule
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path G.swiftmodule
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path G.swiftmodule | %S/Inputs/CommandRunner.py
 // RUN: ls %t/clang-module-cache/G-*.swiftmodule
 
 // REQUIRES: executable_test

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -409,6 +409,7 @@ config.substitutions.append( ('%Benchmark_O', config.benchmark_o) )
 config.substitutions.append( ('%Benchmark_Driver', config.benchmark_driver) )
 config.substitutions.append( ('%llvm-strings', config.llvm_strings) )
 config.substitutions.append( ('%target-ptrauth', run_ptrauth ) )
+config.substitutions.append( ('%swift-path', config.swift) )
 
 # This must come after all substitutions containing "%swift".
 config.substitutions.append(


### PR DESCRIPTION
Clang PCM dependencies are currently implicitly built by the compiler. To allow build-system level to build these PCMs explicitly, we need to report the command line arguments from the compiler to the build system via a JSON file emitted from the dependencies scanner.

This PR combines and emits two sets of Clang compiler arguments: (1) arguments Swift used to construct ClangImporter instance, and (2) arguments collected from running Clang's fast dependency scanner. A high level build system can explicitly schedule PCM building by feeding these arguments to a Swift front-end invocation with an action kind `-emit-pcm`.

For testing purposes, a Swift script is also added to build modules explicitly by using these arguments from the JSON file.

rdar://62612967
rdar://62613017