### PR TITLE
Add instructions on how to create a 32-bit iOS simulator device

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -38,7 +38,7 @@ uses an iOS 10.3 simulator configuration named "iPhone 5" for 32-bit testing.
     window, or with the command line:
 
     ```sh
-    xcrun simctl create 'iPhone 5' 'com.apple.CoreSimulator.SimDeviceType.iPhone-5'
+    xcrun simctl create 'iPhone 5' com.apple.CoreSimulator.SimDeviceType.iPhone-5 com.apple.CoreSimulator.SimRuntime.iOS-10-3
     ```
 
 3.  Append `--ios` to the `utils/build-script` command line (see below).

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -82,8 +82,10 @@ def get_simulator_command(run_os, run_cpu, sdk_path):
     if run_os == 'ios':
         if run_cpu == "i386":
             if min(darwin_get_ios_sim_vers()) > 10.3:
-                print("ERROR: Install iOS 10.3 or older simulator for 32bit testing")
-                print("INFO: Xcode -> Preferences -> Components -> Simulators")
+                print("ERROR: Your system does not have a 32-bit iOS simulator installed.")
+                print("INFO: 1. Install iOS 10.3 or older simulator (Xcode -> Preferences -> Components -> Simulators).")
+                print("INFO: 2. Create a 32-bit iPhone 5 device. Run:")
+                print("INFO:    $ xcrun simctl create 'iPhone 5' com.apple.CoreSimulator.SimDeviceType.iPhone-5 com.apple.CoreSimulator.SimRuntime.iOS-10-3")
                 sys.exit(1)
             else:
                 return "simctl spawn --standalone 'iPhone 5'"


### PR DESCRIPTION
iPhone 5 device does not come preconfigured in the latest Xcode (11.4.1).
