### PR TITLE
test: repair SILOptimizer AutoDiff test on Windows

### DIFF
--- a/test/AutoDiff/SILOptimizer/semantic_member_accessors_sil.swift
+++ b/test/AutoDiff/SILOptimizer/semantic_member_accessors_sil.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -Xllvm -sil-print-after=differentiation %s -o /dev/null 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -sil-print-after=differentiation %s -module-name null -o /dev/null 2>&1 | %FileCheck %s
 
 // Test differentiation of semantic member accessors:
 // - Stored property accessors.


### PR DESCRIPTION
The module name is not specified but the test explicitly overfits to an
expected name.  Adjust the test invocation to accommodate the
expectation.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
