### PR TITLE
[WIP] Switch the two if branches dealing with SDKROOT

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1702,8 +1702,6 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
   {
     if (const Arg *A = Args.getLastArg(options::OPT_sdk)) {
       OI.SDKPath = A->getValue();
-    } else if (const char *SDKROOT = getenv("SDKROOT")) {
-      OI.SDKPath = SDKROOT;
     } else if (OI.CompilerMode == OutputInfo::Mode::Immediate ||
                OI.CompilerMode == OutputInfo::Mode::REPL) {
       if (TC.getTriple().isMacOSX()) {
@@ -1737,6 +1735,8 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
           });
         }
       }
+    } else if (const char *SDKROOT = getenv("SDKROOT")) {
+      OI.SDKPath = SDKROOT;
     }
 
     if (!OI.SDKPath.empty()) {


### PR DESCRIPTION
This attempts to fix an issue where running Swift scripts as build scripts within Xcode against targets other than macOS (e.g. iOS) to failed. See [SR-9216](https://bugs.swift.org/browse/SR-9216) or https://github.com/mxcl/swift-sh/issues/113 for more details.

Resolves SR-9216.