### PR TITLE
[5.3] IRGen: Fix enumPayload value witness emission for huge types

### DIFF
--- a/test/IRGen/Inputs/huge_c_type.h
+++ b/test/IRGen/Inputs/huge_c_type.h
@@ -1,0 +1,31 @@
+#include <stdint.h>
+
+typedef uint8_t bool;
+
+#define CREATE_ARRAY(T, N)                                                     \
+  struct {                                                                     \
+    T data[N];                                                                 \
+    uint64_t size;                                                             \
+  }
+
+typedef struct {
+    int32_t a;
+    double b[16];
+} Thing;
+
+typedef struct {
+  uint64_t a;
+  bool b;
+  CREATE_ARRAY(Thing, 16) c;
+  uint32_t d;
+  uint64_t e;
+  uint64_t f;
+  CREATE_ARRAY(uint32_t, 4) g;
+  CREATE_ARRAY(uint64_t, 4) h;
+  CREATE_ARRAY(uint64_t, 4) i;
+} Thing2;
+
+typedef struct {
+  int64_t a;
+  CREATE_ARRAY(Thing2, 512) c;
+} Thing3;

--- a/test/IRGen/huge_c_type.swift
+++ b/test/IRGen/huge_c_type.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/huge_c_type.h %s -disable-llvm-optzns -emit-ir | %FileCheck %s
+// Make sure that this does not crash during LLVM's ISel. It does not like huge
+// llvm::IntegerTypes.
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/huge_c_type.h %s -c
+
+// CHECK-NOT:i9535616
+
+public func doIt(a: Thing3) {
+  print(a)
+}


### PR DESCRIPTION
LLVM's isel does not like integer types beyond a certain size
(llvm::IntegerType::MAX_INT_BITS).

Explanation: The compiler would crash in the LLVM backend on imported C types
beyond a certain size.

Scope: Causes Swift programs that use types imported from C > 512K to crash the
compiler.

Risk: Low. Only affects code generation of enum witnesses for very large types
(512K).

Testing: Unit test added.

Original PR: https://github.com/apple/swift/pull/31918

rdar://63189452