### PR TITLE
[ASTMangler] Mangle enum case argument label

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -57,6 +57,10 @@ protected:
   /// to fill these in.
   bool AllowSymbolicReferences = false;
 
+  /// If enabled, include the argument labels (if present) of the associated
+  /// values of an enum case.
+  bool IncludeEnumCasePayloadLabels = true;
+
 public:
   using SymbolicReferent = llvm::PointerUnion<const NominalTypeDecl *,
                                               const OpaqueTypeDecl *>;

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -152,6 +152,11 @@ class LinkEntity {
     /// A resilient enum tag index. The pointer is a EnumElementDecl*.
     EnumCase,
 
+    /// A resilient enum tag index. The pointer is a EnumElementDecl*.
+    /// This one is for compatibility reasons, to emit the old label-less
+    /// symbol for enum cases.
+    EnumCaseCompatibility,
+
     /// A field offset.  The pointer is a VarDecl*.
     FieldOffset,
 
@@ -633,6 +638,12 @@ public:
   static LinkEntity forEnumCase(EnumElementDecl *decl) {
     LinkEntity entity;
     entity.setForDecl(Kind::EnumCase, decl);
+    return entity;
+  }
+
+  static LinkEntity forEnumCaseCompatibility(EnumElementDecl *decl) {
+    LinkEntity entity;
+    entity.setForDecl(Kind::EnumCaseCompatibility, decl);
     return entity;
   }
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2311,7 +2311,7 @@ void ASTMangler::appendFunctionInputType(
       // mangling as well, to avoid collisions when we have enum cases
       // that share the same base name, but have different labeled
       // arguments.
-      if (isa<EnumElementDecl>(forDecl) && param.hasLabel() &&
+      if (forDecl && isa<EnumElementDecl>(forDecl) && param.hasLabel() &&
           IncludeEnumCasePayloadLabels) {
         appendTypeListElement(param.getLabel(), param.getPlainType(),
                               param.getParameterFlags(), forDecl);

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2307,8 +2307,18 @@ void ASTMangler::appendFunctionInputType(
   default:
     bool isFirstParam = true;
     for (auto &param : params) {
-      appendTypeListElement(Identifier(), param.getPlainType(),
-                            param.getParameterFlags(), forDecl);
+      // We need to include the argument label for the enum case in the
+      // mangling as well, to avoid collisions when we have enum cases
+      // that share the same base name, but have different labeled
+      // arguments.
+      if (isa<EnumElementDecl>(forDecl) && param.hasLabel() &&
+          IncludeEnumCasePayloadLabels) {
+        appendTypeListElement(param.getLabel(), param.getPlainType(),
+                              param.getParameterFlags(), forDecl);
+      } else {
+        appendTypeListElement(Identifier(), param.getPlainType(),
+                              param.getParameterFlags(), forDecl);
+      }
       appendListSeparator(isFirstParam);
     }
     appendOperator("t");

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -4334,8 +4334,11 @@ Address IRGenModule::getAddrOfFieldOffset(VarDecl *var,
 }
 
 Address IRGenModule::getAddrOfEnumCase(EnumElementDecl *Case,
-                                       ForDefinition_t forDefinition) {
-  LinkEntity entity = LinkEntity::forEnumCase(Case);
+                                       ForDefinition_t forDefinition,
+                                       bool forCaseCompatibility) {
+  LinkEntity entity = forCaseCompatibility
+                          ? LinkEntity::forEnumCaseCompatibility(Case)
+                          : LinkEntity::forEnumCase(Case);
   auto addr = getAddrOfSimpleVariable(*this, GlobalVars, entity, forDefinition);
 
   auto *global = cast<llvm::GlobalVariable>(addr.getAddress());

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -259,6 +259,14 @@ static void emitResilientTagIndex(IRGenModule &IGM,
   auto *global = cast<llvm::GlobalVariable>(
     IGM.getAddrOfEnumCase(Case, ForDefinition).getAddress());
   global->setInitializer(llvm::ConstantInt::get(IGM.Int32Ty, resilientIdx));
+
+  // Emit an alias for compatibility reasons.
+  auto *globalCompat = cast<llvm::GlobalVariable>(
+      IGM.getAddrOfEnumCase(Case, ForDefinition, /*forCaseCompatibility*/ true)
+          .getAddress());
+  globalCompat->setInitializer(
+      llvm::ConstantInt::get(IGM.Int32Ty, resilientIdx));
+  IGM.defineAlias(LinkEntity::forEnumCase(Case), globalCompat);
 }
 
 void

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -331,7 +331,9 @@ public:
     return finalize();
   }
 
-  std::string mangleEnumCase(const ValueDecl *Decl) {
+  std::string mangleEnumCase(const ValueDecl *Decl,
+                             bool forCaseCompatibility = false) {
+    IncludeEnumCasePayloadLabels = !forCaseCompatibility;
     beginMangling();
     appendEntity(Decl);
     appendOperator("WC");

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1369,7 +1369,8 @@ public:
                                             ForDefinition_t forDefinition);
 
   Address getAddrOfEnumCase(EnumElementDecl *Case,
-                            ForDefinition_t forDefinition);
+                            ForDefinition_t forDefinition,
+                            bool forCaseCompatibility = false);
   Address getAddrOfFieldOffset(VarDecl *D, ForDefinition_t forDefinition);
   llvm::Function *getAddrOfValueWitness(CanType concreteType,
                                         ValueWitness index,

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -284,6 +284,9 @@ std::string LinkEntity::mangleAsString() const {
   case Kind::EnumCase:
     return mangler.mangleEnumCase(getDecl());
 
+  case Kind::EnumCaseCompatibility:
+    return mangler.mangleEnumCase(getDecl(), /*forCaseCompatibility*/ true);
+
   case Kind::FieldOffset:
     return mangler.mangleFieldOffset(getDecl());
 
@@ -559,7 +562,8 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
     llvm_unreachable("invalid metadata address");
   }
 
-  case Kind::EnumCase: {
+  case Kind::EnumCase:
+  case Kind::EnumCaseCompatibility: {
     auto *elementDecl = cast<EnumElementDecl>(getDecl());
     return getSILLinkage(getDeclLinkage(elementDecl), forDefinition);
   }
@@ -704,6 +708,7 @@ bool LinkEntity::isContextDescriptor() const {
   case Kind::MethodDescriptorAllocator:
   case Kind::MethodLookupFunction:
   case Kind::EnumCase:
+  case Kind::EnumCaseCompatibility:
   case Kind::FieldOffset:
   case Kind::ObjCClass:
   case Kind::ObjCClassRef:
@@ -831,6 +836,7 @@ llvm::Type *LinkEntity::getDefaultDeclarationType(IRGenModule &IGM) const {
   case Kind::FieldOffset:
     return IGM.SizeTy;
   case Kind::EnumCase:
+  case Kind::EnumCaseCompatibility:
     return IGM.Int32Ty;
   case Kind::ProtocolWitnessTableLazyCacheVariable:
     return IGM.WitnessTablePtrTy;
@@ -880,6 +886,7 @@ Alignment LinkEntity::getAlignment(IRGenModule &IGM) const {
   case Kind::ReflectionAssociatedTypeDescriptor:
   case Kind::PropertyDescriptor:
   case Kind::EnumCase:
+  case Kind::EnumCaseCompatibility:
   case Kind::MethodDescriptor:
   case Kind::MethodDescriptorInitializer:
   case Kind::MethodDescriptorAllocator:
@@ -959,6 +966,7 @@ bool LinkEntity::isWeakImported(ModuleDecl *module) const {
   case Kind::MethodDescriptorAllocator:
   case Kind::MethodLookupFunction:
   case Kind::EnumCase:
+  case Kind::EnumCaseCompatibility:
   case Kind::FieldOffset:
   case Kind::ObjCClass:
   case Kind::ObjCClassRef:
@@ -1029,6 +1037,7 @@ DeclContext *LinkEntity::getDeclContextForEmission() const {
   case Kind::MethodDescriptorAllocator:
   case Kind::MethodLookupFunction:
   case Kind::EnumCase:
+  case Kind::EnumCaseCompatibility:
   case Kind::FieldOffset:
   case Kind::ObjCClass:
   case Kind::ObjCMetaclass:

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -373,8 +373,14 @@ void TBDGenVisitor::addLinkerDirectiveSymbolsLdHide(StringRef name,
       llvm::SmallString<64> Buffer;
       llvm::raw_svector_ostream OS(Buffer);
       OS << "$ld$hide$os" << CurMaj << "." << CurMin << "$" << name;
-      addSymbolInternal(OS.str(), llvm::MachO::SymbolKind::GlobalSymbol,
-                        /*LinkerDirective*/true);
+      // Sometimes we can end up with duplicate symbols when emitting
+      // enum case symbols (for compatibility reasons, we emit both old
+      // and new symbols) so we need to make sure we're not adding a
+      // symbol more than once.
+      auto symbolStr = OS.str();
+      if (!StringSymbols->count(symbolStr))
+        addSymbolInternal(symbolStr, llvm::MachO::SymbolKind::GlobalSymbol,
+                          /*LinkerDirective*/ true);
     }
   }
 }

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -361,3 +361,5 @@ $sS3fIedgyywd_D ---> @escaping @differentiable @callee_guaranteed (@unowned Swif
 $sS5fIedtyyywddw_D ---> @escaping @differentiable @convention(thin) (@unowned Swift.Float, @unowned Swift.Float, @unowned @noDerivative Swift.Float) -> (@unowned Swift.Float, @unowned @noDerivative Swift.Float)
 $syQo ---> $syQo
 $sx1td_t ---> (t: A...)
+$s4test3FooO3fooyACSi3bar_tcACmFfA_ ---> default argument 0 of test.Foo.foo(test.Foo.Type) -> (bar: Swift.Int) -> test.Foo
+$s4test3FooO3fooyACSi3bar_tcACmFWC ---> enum case for test.Foo.foo(test.Foo.Type) -> (bar: Swift.Int) -> test.Foo

--- a/test/IRGen/enum_case_symbol_compat.swift
+++ b/test/IRGen/enum_case_symbol_compat.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -enable-library-evolution | %FileCheck %s
+
+public enum Foo {
+  case foo(bar: Int)
+}
+
+public let f = Foo.foo(bar: 1)
+
+// CHECK: @"$s23enum_case_symbol_compat3FooO3fooyACSi3bar_tcACmFWC" = alias [[INT:i32|i64]], [[INT:i32|i64]]* @"$s23enum_case_symbol_compat3FooO3fooyACSi_tcACmFWC"

--- a/test/SILGen/enum_default_arguments.swift
+++ b/test/SILGen/enum_default_arguments.swift
@@ -7,7 +7,7 @@ protocol DefaultInitializable {
 enum NonTrivialDefaults<T: DefaultInitializable> {
   case empty
 
-  // CHECK-LABEL: il hidden [ossa] @$s17default_arguments18NonTrivialDefaultsO7defarg1yACyxGSi1i_Sd1dSS1sx1ttcAEmAA20DefaultInitializableRzlFfA_{{.*}}
+  // CHECK-LABEL: sil hidden [ossa] @$s17default_arguments18NonTrivialDefaultsO7defarg1yACyxGSi1i_Sd1dSS1sx1ttcAEmAA20DefaultInitializableRzlFfA_{{.*}}
   // CHECK:   [[INT_VAL:%[0-9]+]]  = integer_literal $Builtin.IntLiteral, 17
   // CHECK:   [[META:%[0-9]+]] = metatype $@thin Int.Type
   // CHECK:   [[LIT_FN:%[0-9]+]] = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC

--- a/test/SILGen/enum_default_arguments.swift
+++ b/test/SILGen/enum_default_arguments.swift
@@ -7,41 +7,41 @@ protocol DefaultInitializable {
 enum NonTrivialDefaults<T: DefaultInitializable> {
   case empty
 
-  // CHECK-LABEL: sil hidden [ossa] @$s17default_arguments18NonTrivialDefaultsO7defarg1yACyxGSi_SdSSxtcAEmAA20DefaultInitializableRzlFfA_{{.*}}
+  // CHECK-LABEL: il hidden [ossa] @$s17default_arguments18NonTrivialDefaultsO7defarg1yACyxGSi1i_Sd1dSS1sx1ttcAEmAA20DefaultInitializableRzlFfA_{{.*}}
   // CHECK:   [[INT_VAL:%[0-9]+]]  = integer_literal $Builtin.IntLiteral, 17
   // CHECK:   [[META:%[0-9]+]] = metatype $@thin Int.Type
   // CHECK:   [[LIT_FN:%[0-9]+]] = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC
   // CHECK:   [[LIT_VAL:%[0-9]+]] = apply [[LIT_FN]]([[INT_VAL]], [[META]]) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
   // CHECK:   return [[LIT_VAL]] : $Int
-  // CHECK: } // end sil function '$s17default_arguments18NonTrivialDefaultsO7defarg1yACyxGSi_SdSSxtcAEmAA20DefaultInitializableRzlFfA_'
+  // CHECK: } // end sil function '$s17default_arguments18NonTrivialDefaultsO7defarg1yACyxGSi1i_Sd1dSS1sx1ttcAEmAA20DefaultInitializableRzlFfA_'
 
-  // CHECK-LABEL: sil hidden [ossa] @$s17default_arguments18NonTrivialDefaultsO7defarg1yACyxGSi_SdSSxtcAEmAA20DefaultInitializableRzlFfA1_{{.*}}
+  // CHECK-LABEL: sil hidden [ossa] @$s17default_arguments18NonTrivialDefaultsO7defarg1yACyxGSi1i_Sd1dSS1sx1ttcAEmAA20DefaultInitializableRzlFfA1_{{.*}}
   // CHECK:  [[LIT:%[0-9]+]] = string_literal utf8 "Hello"
   // CHECK:  [[LEN:%[0-9]+]] = integer_literal $Builtin.Word, 5
   // CHECK:  [[STRING:%[0-9]+]] = metatype $@thin String.Type
   // CHECK:  [[LIT_FN:%.*]]  = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
   // CHECK:  [[LIT_VAL:%.*]] = apply [[LIT_FN]]([[LIT]], [[LEN]], {{[^,]+}}, [[STRING]])
   // CHECK:  return [[LIT_VAL]] : $String
-  // CHECK: } // end sil function '$s17default_arguments18NonTrivialDefaultsO7defarg1yACyxGSi_SdSSxtcAEmAA20DefaultInitializableRzlFfA1_'
+  // CHECK: } // end sil function '$s17default_arguments18NonTrivialDefaultsO7defarg1yACyxGSi1i_Sd1dSS1sx1ttcAEmAA20DefaultInitializableRzlFfA1_'
 
-  // CHECK-LABEL: sil hidden [ossa] @$s17default_arguments18NonTrivialDefaultsO7defarg1yACyxGSi_SdSSxtcAEmAA20DefaultInitializableRzlFfA2_{{.*}}
+  // CHECK-LABEL: sil hidden [ossa] @$s17default_arguments18NonTrivialDefaultsO7defarg1yACyxGSi1i_Sd1dSS1sx1ttcAEmAA20DefaultInitializableRzlFfA2_{{.*}}
   // CHECK: bb0([[OUT:%[0-9]+]] : $*T):
   // CHECK:  [[META:%[0-9]+]] = metatype $@thick T.Type
   // CHECK:  [[DEF_INIT_WITNESS:%[0-9]+]] = witness_method $T, #DefaultInitializable.init!allocator : <Self where Self : DefaultInitializable> (Self.Type) -> () -> Self : $@convention(witness_method: DefaultInitializable) <τ_0_0 where τ_0_0 : DefaultInitializable> (@thick τ_0_0.Type) -> @out τ_0_0
   // CHECK:  [[LIT:%[0-9]+]] = apply [[DEF_INIT_WITNESS]]<T>([[OUT]], [[META]]) : $@convention(witness_method: DefaultInitializable) <τ_0_0 where τ_0_0 : DefaultInitializable> (@thick τ_0_0.Type) -> @out τ_0_0
   // CHECK:  [[RET:%[0-9]+]] = tuple ()
   // CHECK:  return [[RET]] : $()
-  // CHECK: } // end sil function '$s17default_arguments18NonTrivialDefaultsO7defarg1yACyxGSi_SdSSxtcAEmAA20DefaultInitializableRzlFfA2_'
+  // CHECK: } // end sil function '$s17default_arguments18NonTrivialDefaultsO7defarg1yACyxGSi1i_Sd1dSS1sx1ttcAEmAA20DefaultInitializableRzlFfA2_'
 
   case defarg1(i: Int = 17, d: Double, s: String = "Hello", t: T = .init())
 
-  // CHECK-LABEL: sil hidden [ossa] @$s17default_arguments18NonTrivialDefaultsO16indirect_defarg1yACyxGAE_AEt_tcAEmAA20DefaultInitializableRzlFfA_
+  // CHECK-LABEL: sil hidden [ossa] @$s17default_arguments18NonTrivialDefaultsO16indirect_defarg1yACyxGAE_AEt1f_tcAEmAA20DefaultInitializableRzlFfA_
   // CHECK: bb0([[OUT_VAL1:%[0-9]+]] : $*NonTrivialDefaults<T>, [[OUT_VAL2:%[0-9]+]] : $*NonTrivialDefaults<T>):
   // CHECK:   inject_enum_addr [[OUT_VAL1]] : $*NonTrivialDefaults<T>, #NonTrivialDefaults.empty!enumelt
   // CHECK:   inject_enum_addr [[OUT_VAL2]] : $*NonTrivialDefaults<T>, #NonTrivialDefaults.empty!enumelt
   // CHECK:   [[RET:%[0-9]+]] = tuple ()
   // CHECK:   return [[RET]] : $()
-  // CHECK: } // end sil function '$s17default_arguments18NonTrivialDefaultsO16indirect_defarg1yACyxGAE_AEt_tcAEmAA20DefaultInitializableRzlFfA_'
+  // CHECK: } // end sil function '$s17default_arguments18NonTrivialDefaultsO16indirect_defarg1yACyxGAE_AEt1f_tcAEmAA20DefaultInitializableRzlFfA_'
 
   indirect case indirect_defarg1(f: (NonTrivialDefaults, NonTrivialDefaults) = (.empty, .empty))
 

--- a/test/SILGen/protocol_enum_witness.swift
+++ b/test/SILGen/protocol_enum_witness.swift
@@ -35,7 +35,7 @@ enum AnotherBar: AnotherFoo {
 // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s21protocol_enum_witness10AnotherBarOAA0D3FooA2aDP3bar3argxSi_tFZTW : $@convention(witness_method: AnotherFoo) (Int, @thick AnotherBar.Type) -> @out AnotherBar {
 // CHECK: bb0([[ANOTHER_BAR:%.*]] : $*AnotherBar, [[INT_ARG:%.*]] : $Int, [[ANOTHER_BAR_TYPE:%.*]] : $@thick AnotherBar.Type):
 // CHECK-NEXT: [[META_TYPE:%.*]] = metatype $@thin AnotherBar.Type
-// CHECK: [[REF:%.*]] = function_ref @$s21protocol_enum_witness10AnotherBarO3baryACSi_tcACmF : $@convention(method) (Int, @thin AnotherBar.Type) -> AnotherBar
+// CHECK: [[REF:%.*]] = function_ref @$s21protocol_enum_witness10AnotherBarO3baryACSi3arg_tcACmF : $@convention(method) (Int, @thin AnotherBar.Type) -> AnotherBar
 // CHECK-NEXT: [[RESULT:%.*]] = apply [[REF]]([[INT_ARG]], [[META_TYPE]]) : $@convention(method) (Int, @thin AnotherBar.Type) -> AnotherBar
 // CHECK-NEXT: store [[RESULT]] to [trivial] [[ANOTHER_BAR]] : $*AnotherBar
 // CHECK-NEXT: [[TUPLE:%.*]] = tuple ()

--- a/test/SourceKit/CursorInfo/cursor_info.swift
+++ b/test/SourceKit/CursorInfo/cursor_info.swift
@@ -492,7 +492,7 @@ func checkAnyIsAKeyword(x: Any) {}
 // RUN: %sourcekitd-test -req=cursor -pos=92:8 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %s | %FileCheck %s -check-prefix=CHECK40
 // CHECK40: source.lang.swift.decl.enumelement (92:8-92:10)
 // CHECK40-NEXT: C2
-// CHECK40-NEXT: s:11cursor_info2E2O2C2yACSi_SStcACmF
+// CHECK40-NEXT: s:11cursor_info2E2O2C2yACSi1x_SS1ytcACmF
 // CHECK40-NEXT: (E2.Type) -> (Int, String) -> E2
 // CHECK40: <Declaration>case C2(x: <Type usr="s:Si">Int</Type>, y: <Type usr="s:SS">String</Type>)</Declaration>
 // CHECK40-NEXT: <decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>C2</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr="s:Si">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr="s:SS">String</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.enumelement>

--- a/test/SourceKit/Indexing/index_enum_case.swift.response
+++ b/test/SourceKit/Indexing/index_enum_case.swift.response
@@ -26,7 +26,7 @@
         {
           key.kind: source.lang.swift.decl.enumelement,
           key.name: "two(a:)",
-          key.usr: "s:15index_enum_case1EO3twoyACSS_tcACmF",
+          key.usr: "s:15index_enum_case1EO3twoyACSS1a_tcACmF",
           key.line: 6,
           key.column: 15,
           key.entities: [
@@ -72,7 +72,7 @@
                 {
                   key.kind: source.lang.swift.ref.enumelement,
                   key.name: "two(a:)",
-                  key.usr: "s:15index_enum_case1EO3twoyACSS_tcACmF",
+                  key.usr: "s:15index_enum_case1EO3twoyACSS1a_tcACmF",
                   key.line: 12,
                   key.column: 15
                 },
@@ -137,7 +137,7 @@
     {
       key.kind: source.lang.swift.ref.enumelement,
       key.name: "two(a:)",
-      key.usr: "s:15index_enum_case1EO3twoyACSS_tcACmF",
+      key.usr: "s:15index_enum_case1EO3twoyACSS1a_tcACmF",
       key.line: 21,
       key.column: 13
     },


### PR DESCRIPTION
We don't include the enum case's argument labels (if present) in the mangling for the enum case or the default argument generator. This leads to symbol collisions in SILGen or strange runtime behaviour.

This PR updates the ASTMangler to include the labels too. For example:

```swift
enum Foo {
  case foo(bar: Int = 0)
  case foo(bas: Int = 0)
}
```

The previous mangling for the default argument generator for `Foo.foo(bar:)` was:

```
$s4test3FooO3fooyACSi_tcACmFfA_ ---> default argument 0 of test.Foo.foo(test.Foo.Type) -> (Swift.Int) -> test.Foo
```

Now, the new mangling is:

```
$s4test3FooO3fooyACSi3bar_tcACmFfA_ ---> default argument 0 of test.Foo.foo(test.Foo.Type) -> (bar: Swift.Int) -> test.Foo
```

Similarly, for the enum case, the previous mangling was:

```
$s4test3FooO3fooyACSi_tcACmFWC ---> enum case for test.Foo.foo(test.Foo.Type) -> (Swift.Int) -> test.Foo
```

Now, the new mangling is:

```
$s4test3FooO3fooyACSi3bar_tcACmFWC ---> enum case for test.Foo.foo(test.Foo.Type) -> (bar: Swift.Int) -> test.Foo
```

Because this will break existing code, this PR also updates IRGen to emit the old symbols if the enum is resilient.

Resolves SR-12206
Resolves rdar://problem/59496023