### PR TITLE
[5.3] [Typechecker] Emit a specialised diagnostic for redeclaration errors when the declaration is synthesised

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5217,6 +5217,12 @@ public:
   Optional<PropertyWrapperMutability>
       getPropertyWrapperMutability() const;
 
+  /// Returns whether this property is the backing storage property or a storage
+  /// wrapper for wrapper instance's projectedValue. If this property is
+  /// neither, then it returns `None`.
+  Optional<PropertyWrapperSynthesizedPropertyKind>
+  getPropertyWrapperSynthesizedPropertyKind() const;
+
   /// Retrieve the backing storage property for a property that has an
   /// attached property wrapper.
   ///

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -755,12 +755,17 @@ ERROR(invalid_redecl,none,"invalid redeclaration of %0", (DeclName))
 ERROR(invalid_redecl_init,none,
       "invalid redeclaration of synthesized %select{|memberwise }1%0",
       (DeclName, bool))
+ERROR(invalid_redecl_implicit,none,
+      "invalid redeclaration of synthesized %select{%0|witness for protocol requirement}1 %2",
+      (DescriptiveDeclKind, bool, DeclName))
 WARNING(invalid_redecl_swift5_warning,none,
         "redeclaration of %0 is deprecated and will be an error in Swift 5",
         (DeclName))
 
 NOTE(invalid_redecl_prev,none,
      "%0 previously declared here", (DeclName))
+NOTE(invalid_redecl_implicit_wrapper,none,
+     "%0 synthesized for property wrapper %select{projected value|backing storage}1", (DeclName, bool))
 
 ERROR(ambiguous_type_base,none,
       "%0 is ambiguous for type lookup in this context", (DeclNameRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -756,7 +756,8 @@ ERROR(invalid_redecl_init,none,
       "invalid redeclaration of synthesized %select{|memberwise }1%0",
       (DeclName, bool))
 ERROR(invalid_redecl_implicit,none,
-      "invalid redeclaration of synthesized %select{%0|witness for protocol requirement}1 %2",
+      "invalid redeclaration of synthesized "
+      "%select{%0|implementation for protocol requirement}1 %2",
       (DescriptiveDeclKind, bool, DeclName))
 WARNING(invalid_redecl_swift5_warning,none,
         "redeclaration of %0 is deprecated and will be an error in Swift 5",
@@ -765,7 +766,9 @@ WARNING(invalid_redecl_swift5_warning,none,
 NOTE(invalid_redecl_prev,none,
      "%0 previously declared here", (DeclName))
 NOTE(invalid_redecl_implicit_wrapper,none,
-     "%0 synthesized for property wrapper %select{projected value|backing storage}1", (DeclName, bool))
+     "%0 synthesized for property wrapper "
+     "%select{projected value|backing storage}1",
+     (DeclName, bool))
 
 ERROR(ambiguous_type_base,none,
       "%0 is ambiguous for type lookup in this context", (DeclNameRef))

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5950,6 +5950,17 @@ VarDecl::getPropertyWrapperMutability() const {
       None);
 }
 
+Optional<PropertyWrapperSynthesizedPropertyKind>
+VarDecl::getPropertyWrapperSynthesizedPropertyKind() const {
+  if (getOriginalWrappedProperty(
+          PropertyWrapperSynthesizedPropertyKind::Backing))
+    return PropertyWrapperSynthesizedPropertyKind::Backing;
+  if (getOriginalWrappedProperty(
+          PropertyWrapperSynthesizedPropertyKind::StorageWrapper))
+    return PropertyWrapperSynthesizedPropertyKind::StorageWrapper;
+  return None;
+}
+
 VarDecl *VarDecl::getPropertyWrapperBackingProperty() const {
   return getPropertyWrapperBackingPropertyInfo().backingVar;
 }

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -61,7 +61,7 @@ func customHashable() {
 enum InvalidCustomHashable {
   case A, B
 
-  var hashValue: String { return "" }
+  var hashValue: String { return "" } // expected-error {{invalid redeclaration of synthesized witness for protocol requirement 'hashValue'}}
 }
 func ==(x: InvalidCustomHashable, y: InvalidCustomHashable) -> String {
   return ""
@@ -369,7 +369,6 @@ func canEatHotChip(_ birthyear:Birthyear) -> Bool {
   return birthyear > .nineties(3)
 }
 // FIXME: Remove -verify-ignore-unknown.
-// <unknown>:0: error: unexpected error produced: invalid redeclaration of 'hashValue'
 // <unknown>:0: error: unexpected note produced: candidate has non-matching type '(Foo, Foo) -> Bool'
 // <unknown>:0: error: unexpected note produced: candidate has non-matching type '<T> (Generic<T>, Generic<T>) -> Bool'
 // <unknown>:0: error: unexpected note produced: candidate has non-matching type '(InvalidCustomHashable, InvalidCustomHashable) -> Bool'

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -61,7 +61,7 @@ func customHashable() {
 enum InvalidCustomHashable {
   case A, B
 
-  var hashValue: String { return "" } // expected-error {{invalid redeclaration of synthesized witness for protocol requirement 'hashValue'}}
+  var hashValue: String { return "" } // expected-error {{invalid redeclaration of synthesized implementation for protocol requirement 'hashValue'}}
 }
 func ==(x: InvalidCustomHashable, y: InvalidCustomHashable) -> String {
   return ""

--- a/test/decl/protocol/special/coding/struct_codable_simple.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple.swift
@@ -31,24 +31,19 @@ let _ = SimpleStruct.encode(to:)
 let _ = SimpleStruct.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}
 
 // rdar://problem/59655704 
-struct SR_12248_1: Codable { 
-  // expected-error@-1 {{type 'SR_12248_1' does not conform to protocol 'Encodable'}}
-  // expected-error@-2 {{invalid redeclaration of synthesized enum case 'x'}} 
-
+struct SR_12248_1: Codable { // expected-error {{type 'SR_12248_1' does not conform to protocol 'Encodable'}}
   var x: Int // expected-note {{'x' previously declared here}}
   var x: Int // expected-error {{invalid redeclaration of 'x'}}
   // expected-note@-1 {{cannot automatically synthesize 'Encodable' because '<<error type>>' does not conform to 'Encodable'}}
   // expected-note@-2 {{cannot automatically synthesize 'Encodable' because '<<error type>>' does not conform to 'Encodable'}}
 }
 
-struct SR_12248_2: Decodable {
-  // expected-error@-1 {{invalid redeclaration of synthesized enum case 'x'}}
+struct SR_12248_2: Decodable { 
   var x: Int // expected-note {{'x' previously declared here}}
   var x: Int // expected-error {{invalid redeclaration of 'x'}}
 }
 
-struct SR_12248_3: Encodable {
-  // expected-error@-1 {{invalid redeclaration of synthesized enum case 'x'}} 
+struct SR_12248_3: Encodable { 
   var x: Int // expected-note {{'x' previously declared here}}
   var x: Int // expected-error {{invalid redeclaration of 'x'}}
 }

--- a/test/decl/protocol/special/coding/struct_codable_simple.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple.swift
@@ -31,19 +31,24 @@ let _ = SimpleStruct.encode(to:)
 let _ = SimpleStruct.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}
 
 // rdar://problem/59655704 
-struct SR_12248_1: Codable { // expected-error {{type 'SR_12248_1' does not conform to protocol 'Encodable'}}
+struct SR_12248_1: Codable { 
+  // expected-error@-1 {{type 'SR_12248_1' does not conform to protocol 'Encodable'}}
+  // expected-error@-2 {{invalid redeclaration of synthesized enum case 'x'}} 
+
   var x: Int // expected-note {{'x' previously declared here}}
   var x: Int // expected-error {{invalid redeclaration of 'x'}}
   // expected-note@-1 {{cannot automatically synthesize 'Encodable' because '<<error type>>' does not conform to 'Encodable'}}
   // expected-note@-2 {{cannot automatically synthesize 'Encodable' because '<<error type>>' does not conform to 'Encodable'}}
 }
 
-struct SR_12248_2: Decodable { 
+struct SR_12248_2: Decodable {
+  // expected-error@-1 {{invalid redeclaration of synthesized enum case 'x'}}
   var x: Int // expected-note {{'x' previously declared here}}
   var x: Int // expected-error {{invalid redeclaration of 'x'}}
 }
 
-struct SR_12248_3: Encodable { 
+struct SR_12248_3: Encodable {
+  // expected-error@-1 {{invalid redeclaration of synthesized enum case 'x'}} 
   var x: Int // expected-note {{'x' previously declared here}}
   var x: Int // expected-error {{invalid redeclaration of 'x'}}
 }

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -850,8 +850,6 @@ struct WrapperWithProjectedValue<T> {
 }
 
 class TestInvalidRedeclaration1 {
-  // expected-error@-1 {{invalid redeclaration of synthesized property '_i'}}
-  // expected-error@-2 {{invalid redeclaration of synthesized property '$i'}}
 
   @WrapperWithProjectedValue var i = 17
   // expected-note@-1 {{'i' previously declared here}}
@@ -860,6 +858,8 @@ class TestInvalidRedeclaration1 {
 
   @WrapperWithProjectedValue var i = 39
   // expected-error@-1 {{invalid redeclaration of 'i'}}
+  // expected-error@-2 {{invalid redeclaration of synthesized property '$i'}}
+  // expected-error@-3 {{invalid redeclaration of synthesized property '_i'}}
 }
 
 // SR-12839

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -849,11 +849,28 @@ struct WrapperWithProjectedValue<T> {
   var projectedValue: T { return wrappedValue }
 }
 
-class TestInvalidRedeclaration {
+class TestInvalidRedeclaration1 {
+  // expected-error@-1 {{invalid redeclaration of synthesized property '_i'}}
+  // expected-error@-2 {{invalid redeclaration of synthesized property '$i'}}
+
   @WrapperWithProjectedValue var i = 17
   // expected-note@-1 {{'i' previously declared here}}
+  // expected-note@-2 {{'$i' synthesized for property wrapper projected value}}
+  // expected-note@-3 {{'_i' synthesized for property wrapper backing storage}}
+
   @WrapperWithProjectedValue var i = 39
   // expected-error@-1 {{invalid redeclaration of 'i'}}
+}
+
+// SR-12839
+struct TestInvalidRedeclaration2 {
+  var _foo1 = 123 // expected-error {{invalid redeclaration of synthesized property '_foo1'}}
+  @WrapperWithInitialValue var foo1 = 123 // expected-note {{'_foo1' synthesized for property wrapper backing storage}}
+}
+
+struct TestInvalidRedeclaration3 {
+  @WrapperWithInitialValue var foo1 = 123 // expected-note {{'_foo1' synthesized for property wrapper backing storage}}
+  var _foo1 = 123 // expected-error {{invalid redeclaration of synthesized property '_foo1'}}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Cherry-pick of #31915 

---

**Explanation**: We are not diagnosing redeclaration errors when the declarations involved are synthesised. This sometimes leads to compiler crashes. Upon investigation, this is a regression caused by #31037.

**Scope**: Affects situations where we have re-declarations.

**SR Issue**: SR-12839 / rdar://problem/63496795

**Risk**: Low. This fixes a compiler crash while also emitting improved diagnostics.

**Testing**: Added new tests which pass on Swift CI and updated some existing ones.

**Reviewed by:** @hborla