### PR TITLE
Set the InMemoryOutputFileSystem on the SwiftModuleBuilder's subinstance.

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1213,6 +1213,17 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
     if (Opts.DetailedRecord) {
       subInvocation.getClangImporterOptions().DetailedPreprocessingRecord = true;
     }
+
+    // SWIFT_ENABLE_TENSORFLOW
+    // If the ClangModuleLoader is using an InMemoryOutputFileSystem, the
+    // subinstance loader should use it as well, as files written to the file
+    // system may not be visible to read, causing subinvocations to fail loading
+    // dependencies.
+    auto &Instance = clangImporter->getClangInstance();
+    if (Instance.getInMemoryOutputFileSystem()) {
+      subInvocation.getClangImporterOptions().InMemoryOutputFileSystem =
+          Instance.getInMemoryOutputFileSystem();
+    }
   }
 
   // Tell the subinvocation to serialize dependency hashes if asked to do so.


### PR DESCRIPTION
When the main compiler instance is using an InMemoryOutputFileSystem for
its ClangLoader, this should be used by the subinstance loader as well
as any files it otherwise writes to the filesystem may not be visible.