### PR TITLE
[SourceKit][SR-12837] Add effective access level of references

### DIFF
--- a/test/SourceKit/Indexing/Inputs/explicit-access/Exported.swift
+++ b/test/SourceKit/Indexing/Inputs/explicit-access/Exported.swift
@@ -1,0 +1,1 @@
+public class ExportedClass {}

--- a/test/SourceKit/Indexing/Inputs/explicit-access/Module.swift
+++ b/test/SourceKit/Indexing/Inputs/explicit-access/Module.swift
@@ -1,0 +1,2 @@
+@_exported import Exported
+public class ModuleClass {}

--- a/test/SourceKit/Indexing/Inputs/implicit-vis/a.index.response
+++ b/test/SourceKit/Indexing/Inputs/implicit-vis/a.index.response
@@ -28,8 +28,7 @@
               key.line: 2,
               key.column: 6,
               key.is_dynamic: 1,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_implicit: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
@@ -37,8 +36,7 @@
               key.line: 2,
               key.column: 6,
               key.is_dynamic: 1,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_implicit: 1
             }
           ],
           key.effective_access: source.decl.effective_access.internal

--- a/test/SourceKit/Indexing/Inputs/implicit-vis/a.index.response
+++ b/test/SourceKit/Indexing/Inputs/implicit-vis/a.index.response
@@ -28,7 +28,8 @@
               key.line: 2,
               key.column: 6,
               key.is_dynamic: 1,
-              key.is_implicit: 1
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.internal
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
@@ -36,9 +37,11 @@
               key.line: 2,
               key.column: 6,
               key.is_dynamic: 1,
-              key.is_implicit: 1
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.internal
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.ref.class,
@@ -47,7 +50,8 @@
           key.line: 2,
           key.column: 9
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     }
   ]
 }

--- a/test/SourceKit/Indexing/Inputs/implicit-vis/b.index.response
+++ b/test/SourceKit/Indexing/Inputs/implicit-vis/b.index.response
@@ -28,8 +28,7 @@
               key.line: 2,
               key.column: 6,
               key.is_dynamic: 1,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_implicit: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
@@ -37,8 +36,7 @@
               key.line: 2,
               key.column: 6,
               key.is_dynamic: 1,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_implicit: 1
             }
           ],
           key.effective_access: source.decl.effective_access.internal

--- a/test/SourceKit/Indexing/Inputs/implicit-vis/b.index.response
+++ b/test/SourceKit/Indexing/Inputs/implicit-vis/b.index.response
@@ -28,7 +28,8 @@
               key.line: 2,
               key.column: 6,
               key.is_dynamic: 1,
-              key.is_implicit: 1
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.internal
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
@@ -36,9 +37,11 @@
               key.line: 2,
               key.column: 6,
               key.is_dynamic: 1,
-              key.is_implicit: 1
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.internal
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.ref.class,
@@ -47,7 +50,8 @@
           key.line: 2,
           key.column: 9
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     }
   ]
 }

--- a/test/SourceKit/Indexing/Inputs/test_module.index.response
+++ b/test/SourceKit/Indexing/Inputs/test_module.index.response
@@ -25,7 +25,8 @@
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "Empty",
-      key.usr: "s:11test_module5EmptyC"
+      key.usr: "s:11test_module5EmptyC",
+      key.effective_access: source.decl.effective_access.public
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -41,15 +42,18 @@
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.usr: "s:11test_module7TwoIntsC1xSivg",
               key.is_dynamic: 1,
-              key.is_implicit: 1
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.public
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.usr: "s:11test_module7TwoIntsC1xSivs",
               key.is_dynamic: 1,
-              key.is_implicit: 1
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.public
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.public
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
@@ -60,22 +64,27 @@
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.usr: "s:11test_module7TwoIntsC1ySivg",
               key.is_dynamic: 1,
-              key.is_implicit: 1
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.public
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.usr: "s:11test_module7TwoIntsC1ySivs",
               key.is_dynamic: 1,
-              key.is_implicit: 1
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.public
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.public
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.name: "init(a:b:)",
-          key.usr: "s:11test_module7TwoIntsC1a1bACSi_Sitcfc"
+          key.usr: "s:11test_module7TwoIntsC1a1bACSi_Sitcfc",
+          key.effective_access: source.decl.effective_access.public
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.public
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -91,22 +100,27 @@
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:value",
               key.usr: "s:11test_module16ComputedPropertyC5valueSivg",
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.public
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.name: "setter:value",
               key.usr: "s:11test_module16ComputedPropertyC5valueSivs",
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.public
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.public
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.public
     },
     {
       key.kind: source.lang.swift.decl.protocol,
       key.name: "Prot1",
-      key.usr: "s:11test_module5Prot1P"
+      key.usr: "s:11test_module5Prot1P",
+      key.effective_access: source.decl.effective_access.public
     },
     {
       key.kind: source.lang.swift.decl.protocol,
@@ -118,17 +132,20 @@
           key.name: "Prot1",
           key.usr: "s:11test_module5Prot1P"
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.public
     },
     {
       key.kind: source.lang.swift.decl.protocol,
       key.name: "Prot3",
-      key.usr: "s:11test_module5Prot3P"
+      key.usr: "s:11test_module5Prot3P",
+      key.effective_access: source.decl.effective_access.public
     },
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "C2",
-      key.usr: "s:11test_module2C2C"
+      key.usr: "s:11test_module2C2C",
+      key.effective_access: source.decl.effective_access.public
     },
     {
       key.kind: source.lang.swift.decl.extension.class,
@@ -155,7 +172,8 @@
     {
       key.kind: source.lang.swift.decl.function.free,
       key.name: "globalFunc()",
-      key.usr: "s:11test_module10globalFuncyyF"
+      key.usr: "s:11test_module10globalFuncyyF",
+      key.effective_access: source.decl.effective_access.public
     },
     {
       key.kind: source.lang.swift.decl.extension.class,

--- a/test/SourceKit/Indexing/Inputs/test_module.index.response
+++ b/test/SourceKit/Indexing/Inputs/test_module.index.response
@@ -42,15 +42,13 @@
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.usr: "s:11test_module7TwoIntsC1xSivg",
               key.is_dynamic: 1,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.public
+              key.is_implicit: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.usr: "s:11test_module7TwoIntsC1xSivs",
               key.is_dynamic: 1,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.public
+              key.is_implicit: 1
             }
           ],
           key.effective_access: source.decl.effective_access.public
@@ -64,15 +62,13 @@
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.usr: "s:11test_module7TwoIntsC1ySivg",
               key.is_dynamic: 1,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.public
+              key.is_implicit: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.usr: "s:11test_module7TwoIntsC1ySivs",
               key.is_dynamic: 1,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.public
+              key.is_implicit: 1
             }
           ],
           key.effective_access: source.decl.effective_access.public
@@ -100,15 +96,13 @@
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:value",
               key.usr: "s:11test_module16ComputedPropertyC5valueSivg",
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.public
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.name: "setter:value",
               key.usr: "s:11test_module16ComputedPropertyC5valueSivs",
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.public
+              key.is_dynamic: 1
             }
           ],
           key.effective_access: source.decl.effective_access.public

--- a/test/SourceKit/Indexing/index.swift.response
+++ b/test/SourceKit/Indexing/index.swift.response
@@ -20,16 +20,14 @@
           key.usr: <usr>,
           key.line: 4,
           key.column: 5,
-          key.is_implicit: 1,
-          key.effective_access: source.decl.effective_access.internal
+          key.is_implicit: 1
         },
         {
           key.kind: source.lang.swift.decl.function.accessor.setter,
           key.usr: <usr>,
           key.line: 4,
           key.column: 5,
-          key.is_implicit: 1,
-          key.effective_access: source.decl.effective_access.internal
+          key.is_implicit: 1
         }
       ],
       key.effective_access: source.decl.effective_access.internal
@@ -69,8 +67,7 @@
               key.line: 8,
               key.column: 7,
               key.is_dynamic: 1,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_implicit: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
@@ -78,8 +75,7 @@
               key.line: 8,
               key.column: 7,
               key.is_dynamic: 1,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_implicit: 1
             }
           ],
           key.effective_access: source.decl.effective_access.internal
@@ -500,8 +496,7 @@
               key.usr: <usr>,
               key.line: 52,
               key.column: 18,
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_dynamic: 1
             }
           ],
           key.effective_access: source.decl.effective_access.internal
@@ -588,16 +583,14 @@
           key.usr: <usr>,
           key.line: 57,
           key.column: 5,
-          key.is_implicit: 1,
-          key.effective_access: source.decl.effective_access.internal
+          key.is_implicit: 1
         },
         {
           key.kind: source.lang.swift.decl.function.accessor.setter,
           key.usr: <usr>,
           key.line: 57,
           key.column: 5,
-          key.is_implicit: 1,
-          key.effective_access: source.decl.effective_access.internal
+          key.is_implicit: 1
         }
       ],
       key.effective_access: source.decl.effective_access.internal
@@ -629,8 +622,7 @@
               key.usr: <usr>,
               key.line: 61,
               key.column: 5,
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
@@ -638,8 +630,7 @@
               key.usr: <usr>,
               key.line: 65,
               key.column: 5,
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_dynamic: 1
             }
           ],
           key.effective_access: source.decl.effective_access.internal
@@ -664,8 +655,7 @@
               key.usr: <usr>,
               key.line: 70,
               key.column: 22,
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_dynamic: 1
             }
           ],
           key.effective_access: source.decl.effective_access.internal
@@ -839,8 +829,7 @@
               key.usr: <usr>,
               key.line: 82,
               key.column: 5,
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
@@ -858,8 +847,7 @@
                   key.column: 8,
                   key.receiver_usr: "s:Si"
                 }
-              ],
-              key.effective_access: source.decl.effective_access.internal
+              ]
             },
             {
               key.kind: source.lang.swift.ref.struct,
@@ -1057,8 +1045,7 @@
               key.line: 107,
               key.column: 12
             }
-          ],
-          key.effective_access: source.decl.effective_access.internal
+          ]
         }
       ],
       key.effective_access: source.decl.effective_access.internal
@@ -1437,8 +1424,7 @@
               key.line: 151,
               key.column: 7,
               key.is_dynamic: 1,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_implicit: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
@@ -1446,8 +1432,7 @@
               key.line: 151,
               key.column: 7,
               key.is_dynamic: 1,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_implicit: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.willset,
@@ -1463,8 +1448,7 @@
                   key.line: 153,
                   key.column: 7
                 }
-              ],
-              key.effective_access: source.decl.effective_access.less_than_fileprivate
+              ]
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.didset,
@@ -1480,8 +1464,7 @@
                   key.line: 156,
                   key.column: 7
                 }
-              ],
-              key.effective_access: source.decl.effective_access.less_than_fileprivate
+              ]
             }
           ],
           key.effective_access: source.decl.effective_access.internal
@@ -1516,8 +1499,7 @@
               key.usr: <usr>,
               key.line: 165,
               key.column: 5,
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
@@ -1525,16 +1507,14 @@
               key.usr: <usr>,
               key.line: 168,
               key.column: 5,
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.didset,
               key.name: "didSet:S1",
               key.usr: <usr>,
               key.line: 170,
-              key.column: 5,
-              key.effective_access: source.decl.effective_access.less_than_fileprivate
+              key.column: 5
             }
           ],
           key.effective_access: source.decl.effective_access.internal
@@ -1577,8 +1557,7 @@
               key.usr: <usr>,
               key.line: 177,
               key.column: 5,
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
@@ -1586,8 +1565,7 @@
               key.usr: <usr>,
               key.line: 178,
               key.column: 5,
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
@@ -1595,8 +1573,7 @@
               key.usr: <usr>,
               key.line: 179,
               key.column: 5,
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_dynamic: 1
             }
           ],
           key.effective_access: source.decl.effective_access.internal

--- a/test/SourceKit/Indexing/index.swift.response
+++ b/test/SourceKit/Indexing/index.swift.response
@@ -20,16 +20,19 @@
           key.usr: <usr>,
           key.line: 4,
           key.column: 5,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.accessor.setter,
           key.usr: <usr>,
           key.line: 4,
           key.column: 5,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.ref.struct,
@@ -50,7 +53,8 @@
           key.name: "init()",
           key.usr: <usr>,
           key.line: 7,
-          key.column: 3
+          key.column: 3,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
@@ -65,7 +69,8 @@
               key.line: 8,
               key.column: 7,
               key.is_dynamic: 1,
-              key.is_implicit: 1
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.internal
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
@@ -73,9 +78,11 @@
               key.line: 8,
               key.column: 7,
               key.is_dynamic: 1,
-              key.is_implicit: 1
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.internal
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.ref.class,
@@ -90,7 +97,8 @@
           key.usr: <usr>,
           key.line: 9,
           key.column: 8,
-          key.is_dynamic: 1
+          key.is_dynamic: 1,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -121,7 +129,8 @@
               key.line: 10,
               key.column: 45
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -152,7 +161,8 @@
               key.line: 13,
               key.column: 47
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.method.class,
@@ -160,9 +170,11 @@
           key.usr: <usr>,
           key.line: 16,
           key.column: 14,
-          key.is_dynamic: 1
+          key.is_dynamic: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.function.operator.infix,
@@ -192,7 +204,8 @@
           key.line: 19,
           key.column: 26
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.struct,
@@ -206,23 +219,27 @@
           key.name: "meth()",
           key.usr: <usr>,
           key.line: 24,
-          key.column: 8
+          key.column: 8,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.method.static,
           key.name: "smeth()",
           key.usr: <usr>,
           key.line: 25,
-          key.column: 15
+          key.column: 15,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.usr: <usr>,
           key.line: 23,
           key.column: 8,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.enum,
@@ -236,9 +253,11 @@
           key.name: "EElem",
           key.usr: <usr>,
           key.line: 29,
-          key.column: 8
+          key.column: 8,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.protocol,
@@ -262,9 +281,11 @@
               key.line: 33,
               key.column: 22
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.function.free,
@@ -373,7 +394,8 @@
           key.line: 42,
           key.column: 14
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.typealias,
@@ -389,7 +411,8 @@
           key.line: 47,
           key.column: 21
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.extension.class,
@@ -436,7 +459,8 @@
               key.line: 50,
               key.column: 19
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -460,7 +484,8 @@
               key.line: 51,
               key.column: 22
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
@@ -475,9 +500,11 @@
               key.usr: <usr>,
               key.line: 52,
               key.column: 18,
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.internal
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.ref.struct,
@@ -516,7 +543,8 @@
               key.name: "protMeth(_:)",
               key.usr: <usr>
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.ref.class,
@@ -542,9 +570,11 @@
             {
               key.attribute: source.decl.attribute.override
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.var.global,
@@ -558,16 +588,19 @@
           key.usr: <usr>,
           key.line: 57,
           key.column: 5,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.accessor.setter,
           key.usr: <usr>,
           key.line: 57,
           key.column: 5,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.ref.class,
@@ -596,7 +629,8 @@
               key.usr: <usr>,
               key.line: 61,
               key.column: 5,
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.internal
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
@@ -604,9 +638,11 @@
               key.usr: <usr>,
               key.line: 65,
               key.column: 5,
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.internal
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.ref.struct,
@@ -628,9 +664,11 @@
               key.usr: <usr>,
               key.line: 70,
               key.column: 22,
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.internal
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.ref.struct,
@@ -644,9 +682,11 @@
           key.usr: <usr>,
           key.line: 59,
           key.column: 7,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -670,16 +710,19 @@
               key.line: 74,
               key.column: 22
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.usr: <usr>,
           key.line: 73,
           key.column: 7,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -750,7 +793,8 @@
             {
               key.attribute: source.decl.attribute.override
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
@@ -769,9 +813,11 @@
             {
               key.attribute: source.decl.attribute.override
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -793,7 +839,8 @@
               key.usr: <usr>,
               key.line: 82,
               key.column: 5,
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.internal
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
@@ -811,7 +858,8 @@
                   key.column: 8,
                   key.receiver_usr: "s:Si"
                 }
-              ]
+              ],
+              key.effective_access: source.decl.effective_access.internal
             },
             {
               key.kind: source.lang.swift.ref.struct,
@@ -827,16 +875,19 @@
               key.line: 81,
               key.column: 26
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.usr: <usr>,
           key.line: 80,
           key.column: 7,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.function.free,
@@ -949,7 +1000,8 @@
             }
           ]
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.struct,
@@ -963,16 +1015,19 @@
           key.name: "sfoo()",
           key.usr: <usr>,
           key.line: 102,
-          key.column: 8
+          key.column: 8,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.usr: <usr>,
           key.line: 101,
           key.column: 8,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.var.global,
@@ -1002,9 +1057,11 @@
               key.line: 107,
               key.column: 12
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.ref.struct,
@@ -1044,7 +1101,8 @@
           key.column: 16,
           key.receiver_usr: "s:5index2S2V"
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -1059,16 +1117,19 @@
           key.usr: <usr>,
           key.line: 116,
           key.column: 8,
-          key.is_dynamic: 1
+          key.is_dynamic: 1,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.usr: <usr>,
           key.line: 115,
           key.column: 7,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -1139,7 +1200,8 @@
             {
               key.attribute: source.decl.attribute.override
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
@@ -1158,9 +1220,11 @@
             {
               key.attribute: source.decl.attribute.override
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.function.free,
@@ -1207,14 +1271,16 @@
           key.column: 5,
           key.receiver_usr: "s:5index2S2V"
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "meth()",
       key.usr: <usr>,
       key.line: 134,
-      key.column: 8
+      key.column: 8,
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -1251,16 +1317,19 @@
             {
               key.attribute: source.decl.attribute.convenience
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.usr: <usr>,
           key.line: 137,
           key.column: 7,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -1314,7 +1383,8 @@
               key.column: 11,
               key.receiver_usr: "s:5index3CC4C"
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
@@ -1333,9 +1403,11 @@
             {
               key.attribute: source.decl.attribute.override
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -1349,7 +1421,8 @@
           key.name: "init()",
           key.usr: <usr>,
           key.line: 150,
-          key.column: 3
+          key.column: 3,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
@@ -1364,7 +1437,8 @@
               key.line: 151,
               key.column: 7,
               key.is_dynamic: 1,
-              key.is_implicit: 1
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.internal
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
@@ -1372,7 +1446,8 @@
               key.line: 151,
               key.column: 7,
               key.is_dynamic: 1,
-              key.is_implicit: 1
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.internal
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.willset,
@@ -1388,7 +1463,8 @@
                   key.line: 153,
                   key.column: 7
                 }
-              ]
+              ],
+              key.effective_access: source.decl.effective_access.less_than_fileprivate
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.didset,
@@ -1404,9 +1480,11 @@
                   key.line: 156,
                   key.column: 7
                 }
-              ]
+              ],
+              key.effective_access: source.decl.effective_access.less_than_fileprivate
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.ref.struct,
@@ -1415,7 +1493,8 @@
           key.line: 151,
           key.column: 23
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -1437,7 +1516,8 @@
               key.usr: <usr>,
               key.line: 165,
               key.column: 5,
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.internal
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
@@ -1445,16 +1525,19 @@
               key.usr: <usr>,
               key.line: 168,
               key.column: 5,
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.internal
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.didset,
               key.name: "didSet:S1",
               key.usr: <usr>,
               key.line: 170,
-              key.column: 5
+              key.column: 5,
+              key.effective_access: source.decl.effective_access.less_than_fileprivate
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.ref.struct,
@@ -1468,9 +1551,11 @@
           key.usr: <usr>,
           key.line: 162,
           key.column: 7,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.protocol,
@@ -1492,7 +1577,8 @@
               key.usr: <usr>,
               key.line: 177,
               key.column: 5,
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.internal
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
@@ -1500,7 +1586,8 @@
               key.usr: <usr>,
               key.line: 178,
               key.column: 5,
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.internal
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
@@ -1508,9 +1595,11 @@
               key.usr: <usr>,
               key.line: 179,
               key.column: 5,
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.internal
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.ref.struct,
@@ -1519,7 +1608,8 @@
           key.line: 176,
           key.column: 11
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -1533,14 +1623,16 @@
           key.usr: <usr>,
           key.line: 184,
           key.column: 7,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
       ],
       key.attributes: [
         {
           key.attribute: source.decl.attribute.available
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -1554,14 +1646,16 @@
           key.usr: <usr>,
           key.line: 188,
           key.column: 7,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
       ],
       key.attributes: [
         {
           key.attribute: source.decl.attribute.available
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -1575,14 +1669,16 @@
           key.usr: <usr>,
           key.line: 192,
           key.column: 7,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
       ],
       key.attributes: [
         {
           key.attribute: source.decl.attribute.available
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     }
   ]
 }

--- a/test/SourceKit/Indexing/index_bad_modulename.swift.response
+++ b/test/SourceKit/Indexing/index_bad_modulename.swift.response
@@ -61,16 +61,14 @@
           key.usr: "s:4main1vSo8NSObjectCSgvg",
           key.line: 9,
           key.column: 5,
-          key.is_implicit: 1,
-          key.effective_access: source.decl.effective_access.internal
+          key.is_implicit: 1
         },
         {
           key.kind: source.lang.swift.decl.function.accessor.setter,
           key.usr: "s:4main1vSo8NSObjectCSgvs",
           key.line: 9,
           key.column: 5,
-          key.is_implicit: 1,
-          key.effective_access: source.decl.effective_access.internal
+          key.is_implicit: 1
         }
       ],
       key.effective_access: source.decl.effective_access.internal

--- a/test/SourceKit/Indexing/index_bad_modulename.swift.response
+++ b/test/SourceKit/Indexing/index_bad_modulename.swift.response
@@ -61,16 +61,19 @@
           key.usr: "s:4main1vSo8NSObjectCSgvg",
           key.line: 9,
           key.column: 5,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.accessor.setter,
           key.usr: "s:4main1vSo8NSObjectCSgvs",
           key.line: 9,
           key.column: 5,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.ref.class,

--- a/test/SourceKit/Indexing/index_big_array.swift.response
+++ b/test/SourceKit/Indexing/index_big_array.swift.response
@@ -20,16 +20,19 @@
           key.usr: "s:9big_array15gCubeVertexDataSaySfGvg",
           key.line: 1,
           key.column: 5,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.accessor.setter,
           key.usr: "s:9big_array15gCubeVertexDataSaySfGvs",
           key.line: 1,
           key.column: 5,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.ref.struct,

--- a/test/SourceKit/Indexing/index_big_array.swift.response
+++ b/test/SourceKit/Indexing/index_big_array.swift.response
@@ -20,16 +20,14 @@
           key.usr: "s:9big_array15gCubeVertexDataSaySfGvg",
           key.line: 1,
           key.column: 5,
-          key.is_implicit: 1,
-          key.effective_access: source.decl.effective_access.internal
+          key.is_implicit: 1
         },
         {
           key.kind: source.lang.swift.decl.function.accessor.setter,
           key.usr: "s:9big_array15gCubeVertexDataSaySfGvs",
           key.line: 1,
           key.column: 5,
-          key.is_implicit: 1,
-          key.effective_access: source.decl.effective_access.internal
+          key.is_implicit: 1
         }
       ],
       key.effective_access: source.decl.effective_access.internal

--- a/test/SourceKit/Indexing/index_constructors.swift.response
+++ b/test/SourceKit/Indexing/index_constructors.swift.response
@@ -51,8 +51,7 @@
               key.line: 9,
               key.column: 7,
               key.is_dynamic: 1,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_implicit: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
@@ -60,8 +59,7 @@
               key.line: 9,
               key.column: 7,
               key.is_dynamic: 1,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_implicit: 1
             }
           ],
           key.effective_access: source.decl.effective_access.internal

--- a/test/SourceKit/Indexing/index_constructors.swift.response
+++ b/test/SourceKit/Indexing/index_constructors.swift.response
@@ -51,7 +51,8 @@
               key.line: 9,
               key.column: 7,
               key.is_dynamic: 1,
-              key.is_implicit: 1
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.internal
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
@@ -59,9 +60,11 @@
               key.line: 9,
               key.column: 7,
               key.is_dynamic: 1,
-              key.is_implicit: 1
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.internal
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -77,9 +80,11 @@
             {
               key.attribute: source.decl.attribute.objc
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     }
   ]
 }

--- a/test/SourceKit/Indexing/index_effective_access_level.swift
+++ b/test/SourceKit/Indexing/index_effective_access_level.swift
@@ -49,6 +49,29 @@ private extension PrivateEnum {
     func methodFromPrivateExtension() {}
 }
 
+@propertyWrapper
+public struct PublicPropertyWrapper<T> {
+    public var wrappedValue: T
+    public init(wrappedValue: T) {
+        self.wrappedValue = wrappedValue
+    }
+}
+
+@propertyWrapper
+struct InternalPropertyWrapper<T> {
+    let wrappedValue: T
+}
+
+@propertyWrapper
+fileprivate struct FilePrivatePropertyWrapper<T> {
+    fileprivate let wrappedValue: T
+}
+
+@propertyWrapper
+private struct PrivatePropertyWrapper<T> {
+    private let wrappedValue: T
+}
+
 private struct ScopeReducerStruct {
     public init(publicInitializer: Int) {}
     init(internalInitializer: Int) {}
@@ -60,6 +83,11 @@ private struct ScopeReducerStruct {
     fileprivate let filePrivateProperty: Int = 0
     private let privateProperty: Int = 0
     public private(set) var publicPropertyWithPrivateSetter: Int = 0
+
+    @PublicPropertyWrapper public var publicPropertyWrappedProperty: Int = 0
+    @PublicPropertyWrapper var internalPropertyWrappedProperty: Int = 0
+    @PublicPropertyWrapper fileprivate var filePrivatePropertyWrappedProperty: Int = 0
+    @PublicPropertyWrapper private var privatePropertyWrappedProperty: Int = 0
 
     public subscript(publicSubscript: Int) -> Int { return 0 }
     subscript(internalSubscript: Int) -> Int { return 0 }
@@ -84,6 +112,11 @@ public struct ScopeKeeperStruct {
     private let privateProperty: Int = 0
     public private(set) var publicPropertyWithPrivateSetter: Int = 0
 
+    @PublicPropertyWrapper public var publicPropertyWrappedProperty: Int = 0
+    @PublicPropertyWrapper var internalPropertyWrappedProperty: Int = 0
+    @PublicPropertyWrapper fileprivate var filePrivatePropertyWrappedProperty: Int = 0
+    @PublicPropertyWrapper private var privatePropertyWrappedProperty: Int = 0
+
     public subscript(publicSubscript: Int) -> Int { return 0 }
     subscript(internalSubscript: Int) -> Int { return 0 }
     fileprivate subscript(filePrivateSubscript: Int) -> Int { return 0 }
@@ -106,6 +139,11 @@ struct PartialScopeReducerStruct {
     fileprivate let filePrivateProperty: Int = 0
     private let privateProperty: Int = 0
     public private(set) var publicPropertyWithPrivateSetter: Int = 0
+
+    @PublicPropertyWrapper public var publicPropertyWrappedProperty: Int = 0
+    @PublicPropertyWrapper var internalPropertyWrappedProperty: Int = 0
+    @PublicPropertyWrapper fileprivate var filePrivatePropertyWrappedProperty: Int = 0
+    @PublicPropertyWrapper private var privatePropertyWrappedProperty: Int = 0
 
     public subscript(publicSubscript: Int) -> Int { return 0 }
     subscript(internalSubscript: Int) -> Int { return 0 }

--- a/test/SourceKit/Indexing/index_effective_access_level.swift
+++ b/test/SourceKit/Indexing/index_effective_access_level.swift
@@ -1,71 +1,165 @@
-// RUN: %sourcekitd-test -req=index %s -- -Xfrontend -serialize-diagnostics-path -Xfrontend %t.dia %s | %sed_clean > %t.response
+// RUN: %empty-directory(%t)
+// RUN: %swift -emit-module -o %t/Exported.swiftmodule %S/Inputs/explicit-access/Exported.swift
+// RUN: %swift -emit-module -o %t/Module.swiftmodule %S/Inputs/explicit-access/Module.swift -I %t
+
+// RUN: %sourcekitd-test -req=index %s -- -I %t %s | %sed_clean > %t.response
 // RUN: %diff -u %s.response %t.response
 
-public enum PublicEn {
-    case a
-    case b
+public enum PublicEnum {
+    case publicEnumCase
 }
 
-enum InternalEn {
-    case a
-    case b
+enum InternalEnum {
+    case internalEnumCase
 }
 
-fileprivate enum FilePrivateEn {
-    case a
-    case b
+fileprivate enum FilePrivateEnum {
+    case filePrivateEnumCase
 }
 
-private enum PrivateEn {
-    case a
-    case b
+private enum PrivateEnum {
+    case privateEnumCase
 }
 
-extension PublicEn {
-    public func puFoo() {}
+extension PublicEnum {
+    public func publicMethod() {}
 }
 
-public extension PublicEn {
-    func puFooFromPublicExtension() {}
+public extension PublicEnum {
+    func methodFromPublicExtension() {}
 }
 
-extension InternalEn {
-    func foo() {}
+extension InternalEnum {
+    func internalMethod() {}
 }
 
-extension FilePrivateEn {
-    fileprivate func flPrFoo() {}
+extension FilePrivateEnum {
+    fileprivate func filePrivateMethod() {}
 }
 
-fileprivate extension FilePrivateEn {
-    func flPrFooFromFilePrivateExtension() {}
+fileprivate extension FilePrivateEnum {
+    func methodFromFilePrivateExtension() {}
 }
 
-extension PrivateEn {
-    private func prFoo() {}
+extension PrivateEnum {
+    private func privateMethod() {}
 }
 
-private extension PrivateEn {
-    func prFooFromPrivateExtension() {}
+private extension PrivateEnum {
+    func methodFromPrivateExtension() {}
 }
 
 private struct ScopeReducerStruct {
-    public func a() {}
-    func b() {}
-    fileprivate func c() {}
-    private func d() {}
+    public init(publicInitializer: Int) {}
+    init(internalInitializer: Int) {}
+    fileprivate init(filePrivateInitializer: Int) {}
+    private init(privateInitializer: Int) {}
+
+    public let publicProperty: Int = 0
+    let internalProperty: Int = 0
+    fileprivate let filePrivateProperty: Int = 0
+    private let privateProperty: Int = 0
+    public private(set) var publicPropertyWithPrivateSetter: Int = 0
+
+    public subscript(publicSubscript: Int) -> Int { return 0 }
+    subscript(internalSubscript: Int) -> Int { return 0 }
+    fileprivate subscript(filePrivateSubscript: Int) -> Int { return 0 }
+    private subscript(privateSubscript: Int) -> Int { return 0 }
+
+    public func publicMethod() {}
+    func internalMethod() {}
+    fileprivate func filePrivateMethod() {}
+    private func privateMethod() {}
 }
 
 public struct ScopeKeeperStruct {
-    public func a() {}
-    func b() {}
-    fileprivate func c() {}
-    private func d() {}
+    public init(publicInitializer: Int) {}
+    init(internalInitializer: Int) {}
+    fileprivate init(filePrivateInitializer: Int) {}
+    private init(privateInitializer: Int) {}
+
+    public let publicProperty: Int = 0
+    let internalProperty: Int = 0
+    fileprivate let filePrivateProperty: Int = 0
+    private let privateProperty: Int = 0
+    public private(set) var publicPropertyWithPrivateSetter: Int = 0
+
+    public subscript(publicSubscript: Int) -> Int { return 0 }
+    subscript(internalSubscript: Int) -> Int { return 0 }
+    fileprivate subscript(filePrivateSubscript: Int) -> Int { return 0 }
+    private subscript(privateSubscript: Int) -> Int { return 0 }
+
+    public func publicMethod() {}
+    func internalMethod() {}
+    fileprivate func filePrivateMethod() {}
+    private func privateMethod() {}
 }
 
 struct PartialScopeReducerStruct {
-    public func a() {}
-    func b() {}
-    fileprivate func c() {}
-    private func d() {}
+    public init(publicInitializer: Int) {}
+    init(internalInitializer: Int) {}
+    fileprivate init(filePrivateInitializer: Int) {}
+    private init(privateInitializer: Int) {}
+
+    public let publicProperty: Int = 0
+    let internalProperty: Int = 0
+    fileprivate let filePrivateProperty: Int = 0
+    private let privateProperty: Int = 0
+    public private(set) var publicPropertyWithPrivateSetter: Int = 0
+
+    public subscript(publicSubscript: Int) -> Int { return 0 }
+    subscript(internalSubscript: Int) -> Int { return 0 }
+    fileprivate subscript(filePrivateSubscript: Int) -> Int { return 0 }
+    private subscript(privateSubscript: Int) -> Int { return 0 }
+
+    public func publicMethod() {}
+    func internalMethod() {}
+    fileprivate func filePrivateMethod() {}
+    private func privateMethod() {}
+}
+
+private extension PrivateEnum {
+    private func privateMethodFromPrivateExtension() {}
+}
+
+public protocol PublicProtocol {
+    var member: Int { get set }
+    func method()
+}
+
+protocol InternalProtocol {
+    var member: Int { get set }
+    func method()
+}
+
+fileprivate protocol FilePrivateProtocol {
+    var member: Int { get set }
+    func method()
+}
+
+private protocol PrivateProtocol {
+    var member: Int { get set }
+    func method()
+}
+
+fileprivate struct FilePrivateImplementationOfPublicProtocol: PublicProtocol {
+    fileprivate var member: Int = 0
+    fileprivate func method() {}
+}
+
+open class OpenClass {
+    open var openProperty: Int { return 0 }
+    public var publicProperty: Int { return 0 }
+    var internalProperty: Int { return 0 }
+
+    open func openMethod() {}
+    public func publicMethod() {}
+    func internalMethod() {}
+}
+
+import Module
+
+struct InternalStruct {
+    let propertyReferencingPublicClassFromModule: Module.ModuleClass
+    let propertyReferencingPublicClassFromExportedModule: Exported.ExportedClass
 }

--- a/test/SourceKit/Indexing/index_effective_access_level.swift
+++ b/test/SourceKit/Indexing/index_effective_access_level.swift
@@ -201,3 +201,15 @@ struct InternalStruct {
     let propertyReferencingPublicClassFromModule: Module.ModuleClass
     let propertyReferencingPublicClassFromExportedModule: Exported.ExportedClass
 }
+
+public typealias Alias = Int
+
+public var globalVariable: Int = 0
+
+protocol ProtocolWithAssociatedType {
+    associatedtype T
+}
+
+struct ProtocolWithAssociatedTypeImpl: ProtocolWithAssociatedType {
+    typealias T = Int
+}

--- a/test/SourceKit/Indexing/index_effective_access_level.swift
+++ b/test/SourceKit/Indexing/index_effective_access_level.swift
@@ -212,4 +212,7 @@ protocol ProtocolWithAssociatedType {
 
 struct ProtocolWithAssociatedTypeImpl: ProtocolWithAssociatedType {
     typealias T = Int
+    func testLocalContent() {
+        let localVariableShouldntBeIndexed = 0
+    }
 }

--- a/test/SourceKit/Indexing/index_effective_access_level.swift
+++ b/test/SourceKit/Indexing/index_effective_access_level.swift
@@ -1,0 +1,71 @@
+// RUN: %sourcekitd-test -req=index %s -- -Xfrontend -serialize-diagnostics-path -Xfrontend %t.dia %s | %sed_clean > %t.response
+// RUN: %diff -u %s.response %t.response
+
+public enum PublicEn {
+    case a
+    case b
+}
+
+enum InternalEn {
+    case a
+    case b
+}
+
+fileprivate enum FilePrivateEn {
+    case a
+    case b
+}
+
+private enum PrivateEn {
+    case a
+    case b
+}
+
+extension PublicEn {
+    public func puFoo() {}
+}
+
+public extension PublicEn {
+    func puFooFromPublicExtension() {}
+}
+
+extension InternalEn {
+    func foo() {}
+}
+
+extension FilePrivateEn {
+    fileprivate func flPrFoo() {}
+}
+
+fileprivate extension FilePrivateEn {
+    func flPrFooFromFilePrivateExtension() {}
+}
+
+extension PrivateEn {
+    private func prFoo() {}
+}
+
+private extension PrivateEn {
+    func prFooFromPrivateExtension() {}
+}
+
+private struct ScopeReducerStruct {
+    public func a() {}
+    func b() {}
+    fileprivate func c() {}
+    private func d() {}
+}
+
+public struct ScopeKeeperStruct {
+    public func a() {}
+    func b() {}
+    fileprivate func c() {}
+    private func d() {}
+}
+
+struct PartialScopeReducerStruct {
+    public func a() {}
+    func b() {}
+    fileprivate func c() {}
+    private func d() {}
+}

--- a/test/SourceKit/Indexing/index_effective_access_level.swift.response
+++ b/test/SourceKit/Indexing/index_effective_access_level.swift.response
@@ -366,8 +366,7 @@
           key.name: "T",
           key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV1Txmfp",
           key.line: 53,
-          key.column: 37,
-          key.effective_access: source.decl.effective_access.internal
+          key.column: 37
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
@@ -477,8 +476,7 @@
           key.name: "T",
           key.usr: "s:28index_effective_access_level23InternalPropertyWrapperV1Txmfp",
           key.line: 61,
-          key.column: 32,
-          key.effective_access: source.decl.effective_access.internal
+          key.column: 32
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
@@ -539,8 +537,7 @@
           key.name: "T",
           key.usr: "s:28index_effective_access_level26FilePrivatePropertyWrapper33_2295DDF1454D6A6D9229E8222CD85214LLV1Txmfp",
           key.line: 66,
-          key.column: 47,
-          key.effective_access: source.decl.effective_access.fileprivate
+          key.column: 47
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
@@ -619,8 +616,7 @@
           key.name: "T",
           key.usr: "s:28index_effective_access_level22PrivatePropertyWrapper33_2295DDF1454D6A6D9229E8222CD85214LLV1Txmfp",
           key.line: 71,
-          key.column: 39,
-          key.effective_access: source.decl.effective_access.fileprivate
+          key.column: 39
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
@@ -3623,6 +3619,150 @@
           key.kind: source.lang.swift.decl.function.constructor,
           key.usr: "s:28index_effective_access_level14InternalStructV40propertyReferencingPublicClassFromModule0ghijk8ExportedL0AC0L00lJ0C_0M00mJ0Ctcfc",
           key.line: 200,
+          key.column: 8,
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
+        }
+      ],
+      key.effective_access: source.decl.effective_access.internal
+    },
+    {
+      key.kind: source.lang.swift.decl.typealias,
+      key.name: "Alias",
+      key.usr: "s:28index_effective_access_level5Aliasa",
+      key.line: 205,
+      key.column: 18,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 205,
+          key.column: 26
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.public
+        }
+      ],
+      key.effective_access: source.decl.effective_access.public
+    },
+    {
+      key.kind: source.lang.swift.decl.var.global,
+      key.name: "globalVariable",
+      key.usr: "s:28index_effective_access_level14globalVariableSivp",
+      key.line: 207,
+      key.column: 12,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.function.accessor.getter,
+          key.usr: "s:28index_effective_access_level14globalVariableSivg",
+          key.line: 207,
+          key.column: 12,
+          key.is_implicit: 1,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ]
+        },
+        {
+          key.kind: source.lang.swift.decl.function.accessor.setter,
+          key.usr: "s:28index_effective_access_level14globalVariableSivs",
+          key.line: 207,
+          key.column: 12,
+          key.is_implicit: 1,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ]
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.public
+        }
+      ],
+      key.effective_access: source.decl.effective_access.public
+    },
+    {
+      key.kind: source.lang.swift.ref.struct,
+      key.name: "Int",
+      key.usr: "s:Si",
+      key.line: 207,
+      key.column: 28
+    },
+    {
+      key.kind: source.lang.swift.decl.protocol,
+      key.name: "ProtocolWithAssociatedType",
+      key.usr: "s:28index_effective_access_level26ProtocolWithAssociatedTypeP",
+      key.line: 209,
+      key.column: 10,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.associatedtype,
+          key.name: "T",
+          key.usr: "s:28index_effective_access_level26ProtocolWithAssociatedTypeP1TQa",
+          key.line: 210,
+          key.column: 20,
+          key.effective_access: source.decl.effective_access.internal
+        }
+      ],
+      key.effective_access: source.decl.effective_access.internal
+    },
+    {
+      key.kind: source.lang.swift.decl.struct,
+      key.name: "ProtocolWithAssociatedTypeImpl",
+      key.usr: "s:28index_effective_access_level30ProtocolWithAssociatedTypeImplV",
+      key.line: 213,
+      key.column: 8,
+      key.related: [
+        {
+          key.kind: source.lang.swift.ref.protocol,
+          key.name: "ProtocolWithAssociatedType",
+          key.usr: "s:28index_effective_access_level26ProtocolWithAssociatedTypeP",
+          key.line: 213,
+          key.column: 40
+        }
+      ],
+      key.entities: [
+        {
+          key.kind: source.lang.swift.ref.protocol,
+          key.name: "ProtocolWithAssociatedType",
+          key.usr: "s:28index_effective_access_level26ProtocolWithAssociatedTypeP",
+          key.line: 213,
+          key.column: 40
+        },
+        {
+          key.kind: source.lang.swift.decl.typealias,
+          key.name: "T",
+          key.usr: "s:28index_effective_access_level30ProtocolWithAssociatedTypeImplV1Ta",
+          key.line: 214,
+          key.column: 15,
+          key.related: [
+            {
+              key.kind: source.lang.swift.ref.associatedtype,
+              key.name: "T",
+              key.usr: "s:28index_effective_access_level26ProtocolWithAssociatedTypeP1TQa"
+            }
+          ],
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 214,
+              key.column: 19
+            }
+          ],
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: "s:28index_effective_access_level30ProtocolWithAssociatedTypeImplVACycfc",
+          key.line: 213,
           key.column: 8,
           key.is_implicit: 1,
           key.effective_access: source.decl.effective_access.internal

--- a/test/SourceKit/Indexing/index_effective_access_level.swift.response
+++ b/test/SourceKit/Indexing/index_effective_access_level.swift.response
@@ -1,0 +1,549 @@
+{
+  key.dependencies: [
+    {
+      key.kind: source.lang.swift.import.module.swift,
+      key.name: "Swift",
+      key.filepath: Swift.swiftmodule,
+      key.is_system: 1
+    }
+  ],
+  key.entities: [
+    {
+      key.kind: source.lang.swift.decl.enum,
+      key.name: "PublicEn",
+      key.usr: "s:28index_effective_access_level8PublicEnO",
+      key.line: 4,
+      key.column: 13,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.enumelement,
+          key.name: "a",
+          key.usr: "s:28index_effective_access_level8PublicEnO1ayA2CmF",
+          key.line: 5,
+          key.column: 10,
+          key.effective_access_level: source.decl.effective_access.public
+        },
+        {
+          key.kind: source.lang.swift.decl.enumelement,
+          key.name: "b",
+          key.usr: "s:28index_effective_access_level8PublicEnO1byA2CmF",
+          key.line: 6,
+          key.column: 10,
+          key.effective_access_level: source.decl.effective_access.public
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.public
+        }
+      ],
+      key.effective_access_level: source.decl.effective_access.public
+    },
+    {
+      key.kind: source.lang.swift.decl.enum,
+      key.name: "InternalEn",
+      key.usr: "s:28index_effective_access_level10InternalEnO",
+      key.line: 9,
+      key.column: 6,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.enumelement,
+          key.name: "a",
+          key.usr: "s:28index_effective_access_level10InternalEnO1ayA2CmF",
+          key.line: 10,
+          key.column: 10,
+          key.effective_access_level: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.decl.enumelement,
+          key.name: "b",
+          key.usr: "s:28index_effective_access_level10InternalEnO1byA2CmF",
+          key.line: 11,
+          key.column: 10,
+          key.effective_access_level: source.decl.effective_access.internal
+        }
+      ],
+      key.effective_access_level: source.decl.effective_access.internal
+    },
+    {
+      key.kind: source.lang.swift.decl.enum,
+      key.name: "FilePrivateEn",
+      key.usr: "s:28index_effective_access_level13FilePrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO",
+      key.line: 14,
+      key.column: 18,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.enumelement,
+          key.name: "a",
+          key.usr: "s:28index_effective_access_level13FilePrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO1ayA2DmF",
+          key.line: 15,
+          key.column: 10,
+          key.effective_access_level: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.enumelement,
+          key.name: "b",
+          key.usr: "s:28index_effective_access_level13FilePrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO1byA2DmF",
+          key.line: 16,
+          key.column: 10,
+          key.effective_access_level: source.decl.effective_access.fileprivate
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.fileprivate
+        }
+      ],
+      key.effective_access_level: source.decl.effective_access.fileprivate
+    },
+    {
+      key.kind: source.lang.swift.decl.enum,
+      key.name: "PrivateEn",
+      key.usr: "s:28index_effective_access_level9PrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO",
+      key.line: 19,
+      key.column: 14,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.enumelement,
+          key.name: "a",
+          key.usr: "s:28index_effective_access_level9PrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO1ayA2DmF",
+          key.line: 20,
+          key.column: 10,
+          key.effective_access_level: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.enumelement,
+          key.name: "b",
+          key.usr: "s:28index_effective_access_level9PrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO1byA2DmF",
+          key.line: 21,
+          key.column: 10,
+          key.effective_access_level: source.decl.effective_access.fileprivate
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.private
+        }
+      ],
+      key.effective_access_level: source.decl.effective_access.fileprivate
+    },
+    {
+      key.kind: source.lang.swift.decl.extension.enum,
+      key.name: "PublicEn",
+      key.usr: "s:e:s:28index_effective_access_level8PublicEnO5puFooyyF",
+      key.line: 24,
+      key.column: 11,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.ref.enum,
+          key.name: "PublicEn",
+          key.usr: "s:28index_effective_access_level8PublicEnO",
+          key.line: 24,
+          key.column: 11
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "puFoo()",
+          key.usr: "s:28index_effective_access_level8PublicEnO5puFooyyF",
+          key.line: 25,
+          key.column: 17,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access_level: source.decl.effective_access.public
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.public
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension.enum,
+      key.name: "PublicEn",
+      key.usr: "s:e:s:28index_effective_access_level8PublicEnO09puFooFromE9ExtensionyyF",
+      key.line: 28,
+      key.column: 18,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.ref.enum,
+          key.name: "PublicEn",
+          key.usr: "s:28index_effective_access_level8PublicEnO",
+          key.line: 28,
+          key.column: 18
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "puFooFromPublicExtension()",
+          key.usr: "s:28index_effective_access_level8PublicEnO09puFooFromE9ExtensionyyF",
+          key.line: 29,
+          key.column: 10,
+          key.effective_access_level: source.decl.effective_access.public
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.public
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension.enum,
+      key.name: "InternalEn",
+      key.usr: "s:e:s:28index_effective_access_level10InternalEnO3fooyyF",
+      key.line: 32,
+      key.column: 11,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.ref.enum,
+          key.name: "InternalEn",
+          key.usr: "s:28index_effective_access_level10InternalEnO",
+          key.line: 32,
+          key.column: 11
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "foo()",
+          key.usr: "s:28index_effective_access_level10InternalEnO3fooyyF",
+          key.line: 33,
+          key.column: 10,
+          key.effective_access_level: source.decl.effective_access.internal
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension.enum,
+      key.name: "FilePrivateEn",
+      key.usr: "s:e:s:28index_effective_access_level13FilePrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO7flPrFooyyF",
+      key.line: 36,
+      key.column: 11,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.ref.enum,
+          key.name: "FilePrivateEn",
+          key.usr: "s:28index_effective_access_level13FilePrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO",
+          key.line: 36,
+          key.column: 11
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "flPrFoo()",
+          key.usr: "s:28index_effective_access_level13FilePrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO7flPrFooyyF",
+          key.line: 37,
+          key.column: 22,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ],
+          key.effective_access_level: source.decl.effective_access.fileprivate
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.fileprivate
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension.enum,
+      key.name: "FilePrivateEn",
+      key.usr: "s:e:s:28index_effective_access_level13FilePrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO011flPrFooFromeF9ExtensionyyF",
+      key.line: 40,
+      key.column: 23,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.ref.enum,
+          key.name: "FilePrivateEn",
+          key.usr: "s:28index_effective_access_level13FilePrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO",
+          key.line: 40,
+          key.column: 23
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "flPrFooFromFilePrivateExtension()",
+          key.usr: "s:28index_effective_access_level13FilePrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO011flPrFooFromeF9ExtensionyyF",
+          key.line: 41,
+          key.column: 10,
+          key.effective_access_level: source.decl.effective_access.fileprivate
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.fileprivate
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension.enum,
+      key.name: "PrivateEn",
+      key.usr: "s:e:s:28index_effective_access_level9PrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO5prFooyyF",
+      key.line: 44,
+      key.column: 11,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.ref.enum,
+          key.name: "PrivateEn",
+          key.usr: "s:28index_effective_access_level9PrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO",
+          key.line: 44,
+          key.column: 11
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "prFoo()",
+          key.usr: "s:28index_effective_access_level9PrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO5prFooyyF",
+          key.line: 45,
+          key.column: 18,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            }
+          ],
+          key.effective_access_level: source.decl.effective_access.less_than_fileprivate
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.private
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension.enum,
+      key.name: "PrivateEn",
+      key.usr: "s:e:s:28index_effective_access_level9PrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO09prFooFromE9ExtensionyyF",
+      key.line: 48,
+      key.column: 19,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.ref.enum,
+          key.name: "PrivateEn",
+          key.usr: "s:28index_effective_access_level9PrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO",
+          key.line: 48,
+          key.column: 19
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "prFooFromPrivateExtension()",
+          key.usr: "s:28index_effective_access_level9PrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO09prFooFromE9ExtensionyyF",
+          key.line: 49,
+          key.column: 10,
+          key.effective_access_level: source.decl.effective_access.fileprivate
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.private
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.struct,
+      key.name: "ScopeReducerStruct",
+      key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV",
+      key.line: 52,
+      key.column: 16,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "a()",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV1ayyF",
+          key.line: 53,
+          key.column: 17,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access_level: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "b()",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV1byyF",
+          key.line: 54,
+          key.column: 10,
+          key.effective_access_level: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "c()",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV1cyyF",
+          key.line: 55,
+          key.column: 22,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ],
+          key.effective_access_level: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "d()",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV1dyyF",
+          key.line: 56,
+          key.column: 18,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            }
+          ],
+          key.effective_access_level: source.decl.effective_access.less_than_fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVADycfc",
+          key.line: 52,
+          key.column: 16,
+          key.is_implicit: 1,
+          key.effective_access_level: source.decl.effective_access.fileprivate
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.private
+        }
+      ],
+      key.effective_access_level: source.decl.effective_access.fileprivate
+    },
+    {
+      key.kind: source.lang.swift.decl.struct,
+      key.name: "ScopeKeeperStruct",
+      key.usr: "s:28index_effective_access_level17ScopeKeeperStructV",
+      key.line: 59,
+      key.column: 15,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "a()",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV1ayyF",
+          key.line: 60,
+          key.column: 17,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access_level: source.decl.effective_access.public
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "b()",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV1byyF",
+          key.line: 61,
+          key.column: 10,
+          key.effective_access_level: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "c()",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV1c33_2295DDF1454D6A6D9229E8222CD85214LLyyF",
+          key.line: 62,
+          key.column: 22,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ],
+          key.effective_access_level: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "d()",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV1d33_2295DDF1454D6A6D9229E8222CD85214LLyyF",
+          key.line: 63,
+          key.column: 18,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            }
+          ],
+          key.effective_access_level: source.decl.effective_access.less_than_fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructVACycfc",
+          key.line: 59,
+          key.column: 15,
+          key.is_implicit: 1,
+          key.effective_access_level: source.decl.effective_access.internal
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.public
+        }
+      ],
+      key.effective_access_level: source.decl.effective_access.public
+    },
+    {
+      key.kind: source.lang.swift.decl.struct,
+      key.name: "PartialScopeReducerStruct",
+      key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV",
+      key.line: 66,
+      key.column: 8,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "a()",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV1ayyF",
+          key.line: 67,
+          key.column: 17,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access_level: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "b()",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV1byyF",
+          key.line: 68,
+          key.column: 10,
+          key.effective_access_level: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "c()",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV1c33_2295DDF1454D6A6D9229E8222CD85214LLyyF",
+          key.line: 69,
+          key.column: 22,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ],
+          key.effective_access_level: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "d()",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV1d33_2295DDF1454D6A6D9229E8222CD85214LLyyF",
+          key.line: 70,
+          key.column: 18,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            }
+          ],
+          key.effective_access_level: source.decl.effective_access.less_than_fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVACycfc",
+          key.line: 66,
+          key.column: 8,
+          key.is_implicit: 1,
+          key.effective_access_level: source.decl.effective_access.internal
+        }
+      ],
+      key.effective_access_level: source.decl.effective_access.internal
+    }
+  ]
+}

--- a/test/SourceKit/Indexing/index_effective_access_level.swift.response
+++ b/test/SourceKit/Indexing/index_effective_access_level.swift.response
@@ -356,126 +356,49 @@
     },
     {
       key.kind: source.lang.swift.decl.struct,
-      key.name: "ScopeReducerStruct",
-      key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV",
-      key.line: 52,
-      key.column: 16,
+      key.name: "PublicPropertyWrapper",
+      key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV",
+      key.line: 53,
+      key.column: 15,
       key.entities: [
         {
-          key.kind: source.lang.swift.decl.function.constructor,
-          key.name: "init(publicInitializer:)",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV17publicInitializerADSi_tcfc",
+          key.kind: source.lang.swift.decl.generic_type_param,
+          key.name: "T",
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV1Txmfp",
           key.line: 53,
-          key.column: 12,
-          key.entities: [
-            {
-              key.kind: source.lang.swift.ref.struct,
-              key.name: "Int",
-              key.usr: "s:Si",
-              key.line: 53,
-              key.column: 36
-            }
-          ],
-          key.attributes: [
-            {
-              key.attribute: source.decl.attribute.public
-            }
-          ],
-          key.effective_access: source.decl.effective_access.fileprivate
-        },
-        {
-          key.kind: source.lang.swift.decl.function.constructor,
-          key.name: "init(internalInitializer:)",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV19internalInitializerADSi_tcfc",
-          key.line: 54,
-          key.column: 5,
-          key.entities: [
-            {
-              key.kind: source.lang.swift.ref.struct,
-              key.name: "Int",
-              key.usr: "s:Si",
-              key.line: 54,
-              key.column: 31
-            }
-          ],
-          key.effective_access: source.decl.effective_access.fileprivate
-        },
-        {
-          key.kind: source.lang.swift.decl.function.constructor,
-          key.name: "init(filePrivateInitializer:)",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV22filePrivateInitializerADSi_tcfc",
-          key.line: 55,
-          key.column: 17,
-          key.entities: [
-            {
-              key.kind: source.lang.swift.ref.struct,
-              key.name: "Int",
-              key.usr: "s:Si",
-              key.line: 55,
-              key.column: 46
-            }
-          ],
-          key.attributes: [
-            {
-              key.attribute: source.decl.attribute.fileprivate
-            }
-          ],
-          key.effective_access: source.decl.effective_access.fileprivate
-        },
-        {
-          key.kind: source.lang.swift.decl.function.constructor,
-          key.name: "init(privateInitializer:)",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV18privateInitializerADSi_tcfc",
-          key.line: 56,
-          key.column: 13,
-          key.entities: [
-            {
-              key.kind: source.lang.swift.ref.struct,
-              key.name: "Int",
-              key.usr: "s:Si",
-              key.line: 56,
-              key.column: 38
-            }
-          ],
-          key.attributes: [
-            {
-              key.attribute: source.decl.attribute.private
-            }
-          ],
-          key.effective_access: source.decl.effective_access.less_than_fileprivate
+          key.column: 37,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
-          key.name: "publicProperty",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV14publicPropertySivp",
-          key.line: 58,
+          key.name: "wrappedValue",
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV12wrappedValuexvp",
+          key.line: 54,
           key.column: 16,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV14publicPropertySivg",
-              key.line: 58,
+              key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV12wrappedValuexvg",
+              key.line: 54,
               key.column: 16,
               key.is_implicit: 1,
               key.attributes: [
                 {
                   key.attribute: source.decl.attribute.public
                 }
-              ],
-              key.effective_access: source.decl.effective_access.fileprivate
+              ]
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
-              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV14publicPropertySivs",
-              key.line: 58,
+              key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV12wrappedValuexvs",
+              key.line: 54,
               key.column: 16,
               key.is_implicit: 1,
               key.attributes: [
                 {
                   key.attribute: source.decl.attribute.public
                 }
-              ],
-              key.effective_access: source.decl.effective_access.fileprivate
+              ]
             }
           ],
           key.attributes: [
@@ -483,229 +406,45 @@
               key.attribute: source.decl.attribute.public
             }
           ],
-          key.effective_access: source.decl.effective_access.fileprivate
+          key.effective_access: source.decl.effective_access.public
         },
         {
-          key.kind: source.lang.swift.ref.struct,
-          key.name: "Int",
-          key.usr: "s:Si",
-          key.line: 58,
-          key.column: 32
+          key.kind: source.lang.swift.ref.generic_type_param,
+          key.name: "T",
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV1Txmfp",
+          key.line: 54,
+          key.column: 30
         },
         {
-          key.kind: source.lang.swift.decl.var.instance,
-          key.name: "internalProperty",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV16internalPropertySivp",
-          key.line: 59,
-          key.column: 9,
-          key.entities: [
-            {
-              key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV16internalPropertySivg",
-              key.line: 59,
-              key.column: 9,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.fileprivate
-            },
-            {
-              key.kind: source.lang.swift.decl.function.accessor.setter,
-              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV16internalPropertySivs",
-              key.line: 59,
-              key.column: 9,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.fileprivate
-            }
-          ],
-          key.effective_access: source.decl.effective_access.fileprivate
-        },
-        {
-          key.kind: source.lang.swift.ref.struct,
-          key.name: "Int",
-          key.usr: "s:Si",
-          key.line: 59,
-          key.column: 27
-        },
-        {
-          key.kind: source.lang.swift.decl.var.instance,
-          key.name: "filePrivateProperty",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV19filePrivatePropertySivp",
-          key.line: 60,
-          key.column: 21,
-          key.entities: [
-            {
-              key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV19filePrivatePropertySivg",
-              key.line: 60,
-              key.column: 21,
-              key.is_implicit: 1,
-              key.attributes: [
-                {
-                  key.attribute: source.decl.attribute.fileprivate
-                }
-              ],
-              key.effective_access: source.decl.effective_access.fileprivate
-            },
-            {
-              key.kind: source.lang.swift.decl.function.accessor.setter,
-              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV19filePrivatePropertySivs",
-              key.line: 60,
-              key.column: 21,
-              key.is_implicit: 1,
-              key.attributes: [
-                {
-                  key.attribute: source.decl.attribute.fileprivate
-                }
-              ],
-              key.effective_access: source.decl.effective_access.fileprivate
-            }
-          ],
-          key.attributes: [
-            {
-              key.attribute: source.decl.attribute.fileprivate
-            }
-          ],
-          key.effective_access: source.decl.effective_access.fileprivate
-        },
-        {
-          key.kind: source.lang.swift.ref.struct,
-          key.name: "Int",
-          key.usr: "s:Si",
-          key.line: 60,
-          key.column: 42
-        },
-        {
-          key.kind: source.lang.swift.decl.var.instance,
-          key.name: "privateProperty",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV15privatePropertySivp",
-          key.line: 61,
-          key.column: 17,
-          key.entities: [
-            {
-              key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV15privatePropertySivg",
-              key.line: 61,
-              key.column: 17,
-              key.is_implicit: 1,
-              key.attributes: [
-                {
-                  key.attribute: source.decl.attribute.private
-                }
-              ],
-              key.effective_access: source.decl.effective_access.less_than_fileprivate
-            },
-            {
-              key.kind: source.lang.swift.decl.function.accessor.setter,
-              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV15privatePropertySivs",
-              key.line: 61,
-              key.column: 17,
-              key.is_implicit: 1,
-              key.attributes: [
-                {
-                  key.attribute: source.decl.attribute.private
-                }
-              ],
-              key.effective_access: source.decl.effective_access.less_than_fileprivate
-            }
-          ],
-          key.attributes: [
-            {
-              key.attribute: source.decl.attribute.private
-            }
-          ],
-          key.effective_access: source.decl.effective_access.less_than_fileprivate
-        },
-        {
-          key.kind: source.lang.swift.ref.struct,
-          key.name: "Int",
-          key.usr: "s:Si",
-          key.line: 61,
-          key.column: 34
-        },
-        {
-          key.kind: source.lang.swift.decl.var.instance,
-          key.name: "publicPropertyWithPrivateSetter",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV31publicPropertyWithPrivateSetterSivp",
-          key.line: 62,
-          key.column: 29,
-          key.entities: [
-            {
-              key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV31publicPropertyWithPrivateSetterSivg",
-              key.line: 62,
-              key.column: 29,
-              key.is_implicit: 1,
-              key.attributes: [
-                {
-                  key.attribute: source.decl.attribute.setter_access.private
-                },
-                {
-                  key.attribute: source.decl.attribute.public
-                }
-              ],
-              key.effective_access: source.decl.effective_access.fileprivate
-            },
-            {
-              key.kind: source.lang.swift.decl.function.accessor.setter,
-              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV31publicPropertyWithPrivateSetterSivs",
-              key.line: 62,
-              key.column: 29,
-              key.is_implicit: 1,
-              key.attributes: [
-                {
-                  key.attribute: source.decl.attribute.setter_access.private
-                },
-                {
-                  key.attribute: source.decl.attribute.public
-                }
-              ],
-              key.effective_access: source.decl.effective_access.fileprivate
-            }
-          ],
-          key.attributes: [
-            {
-              key.attribute: source.decl.attribute.setter_access.private
-            },
-            {
-              key.attribute: source.decl.attribute.public
-            }
-          ],
-          key.effective_access: source.decl.effective_access.fileprivate
-        },
-        {
-          key.kind: source.lang.swift.ref.struct,
-          key.name: "Int",
-          key.usr: "s:Si",
-          key.line: 62,
-          key.column: 62
-        },
-        {
-          key.kind: source.lang.swift.decl.function.subscript,
-          key.name: "subscript(_:)",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVyS2icip",
-          key.line: 64,
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.name: "init(wrappedValue:)",
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV12wrappedValueACyxGx_tcfc",
+          key.line: 55,
           key.column: 12,
           key.entities: [
             {
-              key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.name: "getter:subscript(_:)",
-              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVyS2icig",
-              key.line: 64,
-              key.column: 51,
-              key.effective_access: source.decl.effective_access.fileprivate
+              key.kind: source.lang.swift.ref.generic_type_param,
+              key.name: "T",
+              key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV1Txmfp",
+              key.line: 55,
+              key.column: 31
             },
             {
-              key.kind: source.lang.swift.ref.struct,
-              key.name: "Int",
-              key.usr: "s:Si",
-              key.line: 64,
-              key.column: 39
-            },
-            {
-              key.kind: source.lang.swift.ref.struct,
-              key.name: "Int",
-              key.usr: "s:Si",
-              key.line: 64,
-              key.column: 47
+              key.kind: source.lang.swift.ref.var.instance,
+              key.name: "wrappedValue",
+              key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV12wrappedValuexvp",
+              key.line: 56,
+              key.column: 14,
+              key.entities: [
+                {
+                  key.kind: source.lang.swift.ref.function.accessor.setter,
+                  key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV12wrappedValuexvs",
+                  key.line: 56,
+                  key.column: 14,
+                  key.receiver_usr: "s:28index_effective_access_level21PublicPropertyWrapperV",
+                  key.is_implicit: 1
+                }
+              ]
             }
           ],
           key.attributes: [
@@ -713,180 +452,252 @@
               key.attribute: source.decl.attribute.public
             }
           ],
-          key.effective_access: source.decl.effective_access.fileprivate
-        },
-        {
-          key.kind: source.lang.swift.decl.function.subscript,
-          key.name: "subscript(_:)",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeip",
-          key.line: 65,
-          key.column: 5,
-          key.entities: [
-            {
-              key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.name: "getter:subscript(_:)",
-              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeig",
-              key.line: 65,
-              key.column: 46,
-              key.effective_access: source.decl.effective_access.fileprivate
-            },
-            {
-              key.kind: source.lang.swift.ref.struct,
-              key.name: "Int",
-              key.usr: "s:Si",
-              key.line: 65,
-              key.column: 34
-            },
-            {
-              key.kind: source.lang.swift.ref.struct,
-              key.name: "Int",
-              key.usr: "s:Si",
-              key.line: 65,
-              key.column: 42
-            }
-          ],
-          key.effective_access: source.decl.effective_access.fileprivate
-        },
-        {
-          key.kind: source.lang.swift.decl.function.subscript,
-          key.name: "subscript(_:)",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeip",
-          key.line: 66,
-          key.column: 17,
-          key.entities: [
-            {
-              key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.name: "getter:subscript(_:)",
-              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeig",
-              key.line: 66,
-              key.column: 61,
-              key.effective_access: source.decl.effective_access.fileprivate
-            },
-            {
-              key.kind: source.lang.swift.ref.struct,
-              key.name: "Int",
-              key.usr: "s:Si",
-              key.line: 66,
-              key.column: 49
-            },
-            {
-              key.kind: source.lang.swift.ref.struct,
-              key.name: "Int",
-              key.usr: "s:Si",
-              key.line: 66,
-              key.column: 57
-            }
-          ],
-          key.attributes: [
-            {
-              key.attribute: source.decl.attribute.fileprivate
-            }
-          ],
-          key.effective_access: source.decl.effective_access.fileprivate
-        },
-        {
-          key.kind: source.lang.swift.decl.function.subscript,
-          key.name: "subscript(_:)",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeip",
-          key.line: 67,
-          key.column: 13,
-          key.entities: [
-            {
-              key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.name: "getter:subscript(_:)",
-              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeig",
-              key.line: 67,
-              key.column: 53,
-              key.effective_access: source.decl.effective_access.less_than_fileprivate
-            },
-            {
-              key.kind: source.lang.swift.ref.struct,
-              key.name: "Int",
-              key.usr: "s:Si",
-              key.line: 67,
-              key.column: 41
-            },
-            {
-              key.kind: source.lang.swift.ref.struct,
-              key.name: "Int",
-              key.usr: "s:Si",
-              key.line: 67,
-              key.column: 49
-            }
-          ],
-          key.attributes: [
-            {
-              key.attribute: source.decl.attribute.private
-            }
-          ],
-          key.effective_access: source.decl.effective_access.less_than_fileprivate
-        },
-        {
-          key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "publicMethod()",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV12publicMethodyyF",
-          key.line: 69,
-          key.column: 17,
-          key.attributes: [
-            {
-              key.attribute: source.decl.attribute.public
-            }
-          ],
-          key.effective_access: source.decl.effective_access.fileprivate
-        },
-        {
-          key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "internalMethod()",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV14internalMethodyyF",
-          key.line: 70,
-          key.column: 10,
-          key.effective_access: source.decl.effective_access.fileprivate
-        },
-        {
-          key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "filePrivateMethod()",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV17filePrivateMethodyyF",
-          key.line: 71,
-          key.column: 22,
-          key.attributes: [
-            {
-              key.attribute: source.decl.attribute.fileprivate
-            }
-          ],
-          key.effective_access: source.decl.effective_access.fileprivate
-        },
-        {
-          key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "privateMethod()",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV13privateMethodyyF",
-          key.line: 72,
-          key.column: 18,
-          key.attributes: [
-            {
-              key.attribute: source.decl.attribute.private
-            }
-          ],
-          key.effective_access: source.decl.effective_access.less_than_fileprivate
+          key.effective_access: source.decl.effective_access.public
         }
       ],
       key.attributes: [
         {
-          key.attribute: source.decl.attribute.private
+          key.attribute: source.decl.attribute.public
+        },
+        {
+          key.attribute: source.decl.attribute.propertyWrapper
+        }
+      ],
+      key.effective_access: source.decl.effective_access.public
+    },
+    {
+      key.kind: source.lang.swift.decl.struct,
+      key.name: "InternalPropertyWrapper",
+      key.usr: "s:28index_effective_access_level23InternalPropertyWrapperV",
+      key.line: 61,
+      key.column: 8,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.generic_type_param,
+          key.name: "T",
+          key.usr: "s:28index_effective_access_level23InternalPropertyWrapperV1Txmfp",
+          key.line: 61,
+          key.column: 32,
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "wrappedValue",
+          key.usr: "s:28index_effective_access_level23InternalPropertyWrapperV12wrappedValuexvp",
+          key.line: 62,
+          key.column: 9,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level23InternalPropertyWrapperV12wrappedValuexvg",
+              key.line: 62,
+              key.column: 9,
+              key.is_implicit: 1
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level23InternalPropertyWrapperV12wrappedValuexvs",
+              key.line: 62,
+              key.column: 9,
+              key.is_implicit: 1
+            }
+          ],
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.ref.generic_type_param,
+          key.name: "T",
+          key.usr: "s:28index_effective_access_level23InternalPropertyWrapperV1Txmfp",
+          key.line: 62,
+          key.column: 23
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: "s:28index_effective_access_level23InternalPropertyWrapperV12wrappedValueACyxGx_tcfc",
+          key.line: 61,
+          key.column: 8,
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.propertyWrapper
+        }
+      ],
+      key.effective_access: source.decl.effective_access.internal
+    },
+    {
+      key.kind: source.lang.swift.decl.struct,
+      key.name: "FilePrivatePropertyWrapper",
+      key.usr: "s:28index_effective_access_level26FilePrivatePropertyWrapper33_2295DDF1454D6A6D9229E8222CD85214LLV",
+      key.line: 66,
+      key.column: 20,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.generic_type_param,
+          key.name: "T",
+          key.usr: "s:28index_effective_access_level26FilePrivatePropertyWrapper33_2295DDF1454D6A6D9229E8222CD85214LLV1Txmfp",
+          key.line: 66,
+          key.column: 47,
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "wrappedValue",
+          key.usr: "s:28index_effective_access_level26FilePrivatePropertyWrapper33_2295DDF1454D6A6D9229E8222CD85214LLV12wrappedValuexvp",
+          key.line: 67,
+          key.column: 21,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level26FilePrivatePropertyWrapper33_2295DDF1454D6A6D9229E8222CD85214LLV12wrappedValuexvg",
+              key.line: 67,
+              key.column: 21,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.fileprivate
+                }
+              ]
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level26FilePrivatePropertyWrapper33_2295DDF1454D6A6D9229E8222CD85214LLV12wrappedValuexvs",
+              key.line: 67,
+              key.column: 21,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.fileprivate
+                }
+              ]
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.generic_type_param,
+          key.name: "T",
+          key.usr: "s:28index_effective_access_level26FilePrivatePropertyWrapper33_2295DDF1454D6A6D9229E8222CD85214LLV1Txmfp",
+          key.line: 67,
+          key.column: 35
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: "s:28index_effective_access_level26FilePrivatePropertyWrapper33_2295DDF1454D6A6D9229E8222CD85214LLV12wrappedValueADyxGx_tcfc",
+          key.line: 66,
+          key.column: 20,
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.fileprivate
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.fileprivate
+        },
+        {
+          key.attribute: source.decl.attribute.propertyWrapper
         }
       ],
       key.effective_access: source.decl.effective_access.fileprivate
     },
     {
       key.kind: source.lang.swift.decl.struct,
-      key.name: "ScopeKeeperStruct",
-      key.usr: "s:28index_effective_access_level17ScopeKeeperStructV",
+      key.name: "PrivatePropertyWrapper",
+      key.usr: "s:28index_effective_access_level22PrivatePropertyWrapper33_2295DDF1454D6A6D9229E8222CD85214LLV",
+      key.line: 71,
+      key.column: 16,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.generic_type_param,
+          key.name: "T",
+          key.usr: "s:28index_effective_access_level22PrivatePropertyWrapper33_2295DDF1454D6A6D9229E8222CD85214LLV1Txmfp",
+          key.line: 71,
+          key.column: 39,
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "wrappedValue",
+          key.usr: "s:28index_effective_access_level22PrivatePropertyWrapper33_2295DDF1454D6A6D9229E8222CD85214LLV12wrappedValuexvp",
+          key.line: 72,
+          key.column: 17,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level22PrivatePropertyWrapper33_2295DDF1454D6A6D9229E8222CD85214LLV12wrappedValuexvg",
+              key.line: 72,
+              key.column: 17,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.private
+                }
+              ]
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level22PrivatePropertyWrapper33_2295DDF1454D6A6D9229E8222CD85214LLV12wrappedValuexvs",
+              key.line: 72,
+              key.column: 17,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.private
+                }
+              ]
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            }
+          ],
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.generic_type_param,
+          key.name: "T",
+          key.usr: "s:28index_effective_access_level22PrivatePropertyWrapper33_2295DDF1454D6A6D9229E8222CD85214LLV1Txmfp",
+          key.line: 72,
+          key.column: 31
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: "s:28index_effective_access_level22PrivatePropertyWrapper33_2295DDF1454D6A6D9229E8222CD85214LLV12wrappedValueADyxGx_tcfc",
+          key.line: 71,
+          key.column: 16,
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.private
+        },
+        {
+          key.attribute: source.decl.attribute.propertyWrapper
+        }
+      ],
+      key.effective_access: source.decl.effective_access.fileprivate
+    },
+    {
+      key.kind: source.lang.swift.decl.struct,
+      key.name: "ScopeReducerStruct",
+      key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV",
       key.line: 75,
-      key.column: 15,
+      key.column: 16,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.name: "init(publicInitializer:)",
-          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV17publicInitializerACSi_tcfc",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV17publicInitializerADSi_tcfc",
           key.line: 76,
           key.column: 12,
           key.entities: [
@@ -903,12 +714,12 @@
               key.attribute: source.decl.attribute.public
             }
           ],
-          key.effective_access: source.decl.effective_access.public
+          key.effective_access: source.decl.effective_access.fileprivate
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.name: "init(internalInitializer:)",
-          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV19internalInitializerACSi_tcfc",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV19internalInitializerADSi_tcfc",
           key.line: 77,
           key.column: 5,
           key.entities: [
@@ -920,12 +731,12 @@
               key.column: 31
             }
           ],
-          key.effective_access: source.decl.effective_access.internal
+          key.effective_access: source.decl.effective_access.fileprivate
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.name: "init(filePrivateInitializer:)",
-          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV22filePrivateInitializerACSi_tc33_2295DDF1454D6A6D9229E8222CD85214Llfc",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV22filePrivateInitializerADSi_tcfc",
           key.line: 78,
           key.column: 17,
           key.entities: [
@@ -947,7 +758,7 @@
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.name: "init(privateInitializer:)",
-          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV18privateInitializerACSi_tc33_2295DDF1454D6A6D9229E8222CD85214Llfc",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV18privateInitializerADSi_tcfc",
           key.line: 79,
           key.column: 13,
           key.entities: [
@@ -969,13 +780,13 @@
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "publicProperty",
-          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV14publicPropertySivp",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV14publicPropertySivp",
           key.line: 81,
           key.column: 16,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV14publicPropertySivg",
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV14publicPropertySivg",
               key.line: 81,
               key.column: 16,
               key.is_implicit: 1,
@@ -983,12 +794,11 @@
                 {
                   key.attribute: source.decl.attribute.public
                 }
-              ],
-              key.effective_access: source.decl.effective_access.public
+              ]
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
-              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV14publicPropertySivs",
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV14publicPropertySivs",
               key.line: 81,
               key.column: 16,
               key.is_implicit: 1,
@@ -996,8 +806,7 @@
                 {
                   key.attribute: source.decl.attribute.public
                 }
-              ],
-              key.effective_access: source.decl.effective_access.public
+              ]
             }
           ],
           key.attributes: [
@@ -1005,7 +814,7 @@
               key.attribute: source.decl.attribute.public
             }
           ],
-          key.effective_access: source.decl.effective_access.public
+          key.effective_access: source.decl.effective_access.fileprivate
         },
         {
           key.kind: source.lang.swift.ref.struct,
@@ -1017,28 +826,26 @@
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "internalProperty",
-          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV16internalPropertySivp",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV16internalPropertySivp",
           key.line: 82,
           key.column: 9,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV16internalPropertySivg",
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV16internalPropertySivg",
               key.line: 82,
               key.column: 9,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_implicit: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
-              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV16internalPropertySivs",
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV16internalPropertySivs",
               key.line: 82,
               key.column: 9,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_implicit: 1
             }
           ],
-          key.effective_access: source.decl.effective_access.internal
+          key.effective_access: source.decl.effective_access.fileprivate
         },
         {
           key.kind: source.lang.swift.ref.struct,
@@ -1050,13 +857,13 @@
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "filePrivateProperty",
-          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV19filePrivateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivp",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV19filePrivatePropertySivp",
           key.line: 83,
           key.column: 21,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV19filePrivateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivg",
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV19filePrivatePropertySivg",
               key.line: 83,
               key.column: 21,
               key.is_implicit: 1,
@@ -1064,12 +871,11 @@
                 {
                   key.attribute: source.decl.attribute.fileprivate
                 }
-              ],
-              key.effective_access: source.decl.effective_access.fileprivate
+              ]
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
-              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV19filePrivateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivs",
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV19filePrivatePropertySivs",
               key.line: 83,
               key.column: 21,
               key.is_implicit: 1,
@@ -1077,8 +883,7 @@
                 {
                   key.attribute: source.decl.attribute.fileprivate
                 }
-              ],
-              key.effective_access: source.decl.effective_access.fileprivate
+              ]
             }
           ],
           key.attributes: [
@@ -1098,13 +903,13 @@
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "privateProperty",
-          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV15privateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivp",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV15privatePropertySivp",
           key.line: 84,
           key.column: 17,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV15privateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivg",
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV15privatePropertySivg",
               key.line: 84,
               key.column: 17,
               key.is_implicit: 1,
@@ -1112,12 +917,11 @@
                 {
                   key.attribute: source.decl.attribute.private
                 }
-              ],
-              key.effective_access: source.decl.effective_access.less_than_fileprivate
+              ]
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
-              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV15privateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivs",
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV15privatePropertySivs",
               key.line: 84,
               key.column: 17,
               key.is_implicit: 1,
@@ -1125,8 +929,7 @@
                 {
                   key.attribute: source.decl.attribute.private
                 }
-              ],
-              key.effective_access: source.decl.effective_access.less_than_fileprivate
+              ]
             }
           ],
           key.attributes: [
@@ -1146,13 +949,13 @@
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "publicPropertyWithPrivateSetter",
-          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV31publicPropertyWithPrivateSetterSivp",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV31publicPropertyWithPrivateSetterSivp",
           key.line: 85,
           key.column: 29,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV31publicPropertyWithPrivateSetterSivg",
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV31publicPropertyWithPrivateSetterSivg",
               key.line: 85,
               key.column: 29,
               key.is_implicit: 1,
@@ -1163,13 +966,787 @@
                 {
                   key.attribute: source.decl.attribute.public
                 }
-              ],
-              key.effective_access: source.decl.effective_access.public
+              ]
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV31publicPropertyWithPrivateSetterSivs",
+              key.line: 85,
+              key.column: 29,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.setter_access.private
+                },
+                {
+                  key.attribute: source.decl.attribute.public
+                }
+              ]
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.setter_access.private
+            },
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 85,
+          key.column: 62
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "PublicPropertyWrapper",
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV",
+          key.line: 87,
+          key.column: 6
+        },
+        {
+          key.kind: source.lang.swift.ref.function.constructor,
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV12wrappedValueACyxGx_tcfc",
+          key.line: 87,
+          key.column: 6,
+          key.is_implicit: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "publicPropertyWrappedProperty",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV021publicPropertyWrappedO0Sivp",
+          key.line: 87,
+          key.column: 39,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV021publicPropertyWrappedO0Sivg",
+              key.line: 87,
+              key.column: 39,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.public
+                },
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV021publicPropertyWrappedO0Sivs",
+              key.line: 87,
+              key.column: 39,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.public
+                },
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            },
+            {
+              key.attribute: source.decl.attribute._custom
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 87,
+          key.column: 70
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "PublicPropertyWrapper",
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV",
+          key.line: 88,
+          key.column: 6
+        },
+        {
+          key.kind: source.lang.swift.ref.function.constructor,
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV12wrappedValueACyxGx_tcfc",
+          key.line: 88,
+          key.column: 6,
+          key.is_implicit: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "internalPropertyWrappedProperty",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV023internalPropertyWrappedO0Sivp",
+          key.line: 88,
+          key.column: 32,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV023internalPropertyWrappedO0Sivg",
+              key.line: 88,
+              key.column: 32,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV023internalPropertyWrappedO0Sivs",
+              key.line: 88,
+              key.column: 32,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute._custom
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 88,
+          key.column: 65
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "PublicPropertyWrapper",
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV",
+          key.line: 89,
+          key.column: 6
+        },
+        {
+          key.kind: source.lang.swift.ref.function.constructor,
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV12wrappedValueACyxGx_tcfc",
+          key.line: 89,
+          key.column: 6,
+          key.is_implicit: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "filePrivatePropertyWrappedProperty",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV026filePrivatePropertyWrappedP0Sivp",
+          key.line: 89,
+          key.column: 44,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV026filePrivatePropertyWrappedP0Sivg",
+              key.line: 89,
+              key.column: 44,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.fileprivate
+                },
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV026filePrivatePropertyWrappedP0Sivs",
+              key.line: 89,
+              key.column: 44,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.fileprivate
+                },
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            },
+            {
+              key.attribute: source.decl.attribute._custom
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 89,
+          key.column: 80
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "PublicPropertyWrapper",
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV",
+          key.line: 90,
+          key.column: 6
+        },
+        {
+          key.kind: source.lang.swift.ref.function.constructor,
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV12wrappedValueACyxGx_tcfc",
+          key.line: 90,
+          key.column: 6,
+          key.is_implicit: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "privatePropertyWrappedProperty",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV022privatePropertyWrappedO0Sivp",
+          key.line: 90,
+          key.column: 40,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV022privatePropertyWrappedO0Sivg",
+              key.line: 90,
+              key.column: 40,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.private
+                },
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV022privatePropertyWrappedO0Sivs",
+              key.line: 90,
+              key.column: 40,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.private
+                },
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            },
+            {
+              key.attribute: source.decl.attribute._custom
+            }
+          ],
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 90,
+          key.column: 72
+        },
+        {
+          key.kind: source.lang.swift.decl.function.subscript,
+          key.name: "subscript(_:)",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVyS2icip",
+          key.line: 92,
+          key.column: 12,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:subscript(_:)",
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVyS2icig",
+              key.line: 92,
+              key.column: 51
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 92,
+              key.column: 39
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 92,
+              key.column: 47
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.subscript,
+          key.name: "subscript(_:)",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeip",
+          key.line: 93,
+          key.column: 5,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:subscript(_:)",
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeig",
+              key.line: 93,
+              key.column: 46
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 93,
+              key.column: 34
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 93,
+              key.column: 42
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.subscript,
+          key.name: "subscript(_:)",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeip",
+          key.line: 94,
+          key.column: 17,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:subscript(_:)",
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeig",
+              key.line: 94,
+              key.column: 61
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 94,
+              key.column: 49
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 94,
+              key.column: 57
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.subscript,
+          key.name: "subscript(_:)",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeip",
+          key.line: 95,
+          key.column: 13,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:subscript(_:)",
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeig",
+              key.line: 95,
+              key.column: 53
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 95,
+              key.column: 41
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 95,
+              key.column: 49
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            }
+          ],
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "publicMethod()",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV12publicMethodyyF",
+          key.line: 97,
+          key.column: 17,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "internalMethod()",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV14internalMethodyyF",
+          key.line: 98,
+          key.column: 10,
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "filePrivateMethod()",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV17filePrivateMethodyyF",
+          key.line: 99,
+          key.column: 22,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "privateMethod()",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV13privateMethodyyF",
+          key.line: 100,
+          key.column: 18,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            }
+          ],
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.private
+        }
+      ],
+      key.effective_access: source.decl.effective_access.fileprivate
+    },
+    {
+      key.kind: source.lang.swift.decl.struct,
+      key.name: "ScopeKeeperStruct",
+      key.usr: "s:28index_effective_access_level17ScopeKeeperStructV",
+      key.line: 103,
+      key.column: 15,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.name: "init(publicInitializer:)",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV17publicInitializerACSi_tcfc",
+          key.line: 104,
+          key.column: 12,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 104,
+              key.column: 36
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access: source.decl.effective_access.public
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.name: "init(internalInitializer:)",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV19internalInitializerACSi_tcfc",
+          key.line: 105,
+          key.column: 5,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 105,
+              key.column: 31
+            }
+          ],
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.name: "init(filePrivateInitializer:)",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV22filePrivateInitializerACSi_tc33_2295DDF1454D6A6D9229E8222CD85214Llfc",
+          key.line: 106,
+          key.column: 17,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 106,
+              key.column: 46
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.name: "init(privateInitializer:)",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV18privateInitializerACSi_tc33_2295DDF1454D6A6D9229E8222CD85214Llfc",
+          key.line: 107,
+          key.column: 13,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 107,
+              key.column: 38
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            }
+          ],
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "publicProperty",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV14publicPropertySivp",
+          key.line: 109,
+          key.column: 16,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV14publicPropertySivg",
+              key.line: 109,
+              key.column: 16,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.public
+                }
+              ]
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV14publicPropertySivs",
+              key.line: 109,
+              key.column: 16,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.public
+                }
+              ]
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access: source.decl.effective_access.public
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 109,
+          key.column: 32
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "internalProperty",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV16internalPropertySivp",
+          key.line: 110,
+          key.column: 9,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV16internalPropertySivg",
+              key.line: 110,
+              key.column: 9,
+              key.is_implicit: 1
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV16internalPropertySivs",
+              key.line: 110,
+              key.column: 9,
+              key.is_implicit: 1
+            }
+          ],
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 110,
+          key.column: 27
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "filePrivateProperty",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV19filePrivateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivp",
+          key.line: 111,
+          key.column: 21,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV19filePrivateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivg",
+              key.line: 111,
+              key.column: 21,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.fileprivate
+                }
+              ]
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV19filePrivateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivs",
+              key.line: 111,
+              key.column: 21,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.fileprivate
+                }
+              ]
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 111,
+          key.column: 42
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "privateProperty",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV15privateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivp",
+          key.line: 112,
+          key.column: 17,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV15privateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivg",
+              key.line: 112,
+              key.column: 17,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.private
+                }
+              ]
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV15privateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivs",
+              key.line: 112,
+              key.column: 17,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.private
+                }
+              ]
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            }
+          ],
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 112,
+          key.column: 34
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "publicPropertyWithPrivateSetter",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV31publicPropertyWithPrivateSetterSivp",
+          key.line: 113,
+          key.column: 29,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV31publicPropertyWithPrivateSetterSivg",
+              key.line: 113,
+              key.column: 29,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.setter_access.private
+                },
+                {
+                  key.attribute: source.decl.attribute.public
+                }
+              ]
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.usr: "s:28index_effective_access_level17ScopeKeeperStructV31publicPropertyWithPrivateSetterSivs",
-              key.line: 85,
+              key.line: 113,
               key.column: 29,
               key.is_implicit: 1,
               key.attributes: [
@@ -1179,8 +1756,7 @@
                 {
                   key.attribute: source.decl.attribute.public
                 }
-              ],
-              key.effective_access: source.decl.effective_access.public
+              ]
             }
           ],
           key.attributes: [
@@ -1197,36 +1773,302 @@
           key.kind: source.lang.swift.ref.struct,
           key.name: "Int",
           key.usr: "s:Si",
-          key.line: 85,
+          key.line: 113,
           key.column: 62
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "PublicPropertyWrapper",
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV",
+          key.line: 115,
+          key.column: 6
+        },
+        {
+          key.kind: source.lang.swift.ref.function.constructor,
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV12wrappedValueACyxGx_tcfc",
+          key.line: 115,
+          key.column: 6,
+          key.is_implicit: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "publicPropertyWrappedProperty",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV021publicPropertyWrappedI0Sivp",
+          key.line: 115,
+          key.column: 39,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV021publicPropertyWrappedI0Sivg",
+              key.line: 115,
+              key.column: 39,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.public
+                },
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV021publicPropertyWrappedI0Sivs",
+              key.line: 115,
+              key.column: 39,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.public
+                },
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            },
+            {
+              key.attribute: source.decl.attribute._custom
+            }
+          ],
+          key.effective_access: source.decl.effective_access.public
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 115,
+          key.column: 70
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "PublicPropertyWrapper",
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV",
+          key.line: 116,
+          key.column: 6
+        },
+        {
+          key.kind: source.lang.swift.ref.function.constructor,
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV12wrappedValueACyxGx_tcfc",
+          key.line: 116,
+          key.column: 6,
+          key.is_implicit: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "internalPropertyWrappedProperty",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV023internalPropertyWrappedI0Sivp",
+          key.line: 116,
+          key.column: 32,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV023internalPropertyWrappedI0Sivg",
+              key.line: 116,
+              key.column: 32,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV023internalPropertyWrappedI0Sivs",
+              key.line: 116,
+              key.column: 32,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute._custom
+            }
+          ],
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 116,
+          key.column: 65
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "PublicPropertyWrapper",
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV",
+          key.line: 117,
+          key.column: 6
+        },
+        {
+          key.kind: source.lang.swift.ref.function.constructor,
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV12wrappedValueACyxGx_tcfc",
+          key.line: 117,
+          key.column: 6,
+          key.is_implicit: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "filePrivatePropertyWrappedProperty",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV026filePrivatePropertyWrappedJ033_2295DDF1454D6A6D9229E8222CD85214LLSivp",
+          key.line: 117,
+          key.column: 44,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV026filePrivatePropertyWrappedJ033_2295DDF1454D6A6D9229E8222CD85214LLSivg",
+              key.line: 117,
+              key.column: 44,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.fileprivate
+                },
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV026filePrivatePropertyWrappedJ033_2295DDF1454D6A6D9229E8222CD85214LLSivs",
+              key.line: 117,
+              key.column: 44,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.fileprivate
+                },
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            },
+            {
+              key.attribute: source.decl.attribute._custom
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 117,
+          key.column: 80
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "PublicPropertyWrapper",
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV",
+          key.line: 118,
+          key.column: 6
+        },
+        {
+          key.kind: source.lang.swift.ref.function.constructor,
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV12wrappedValueACyxGx_tcfc",
+          key.line: 118,
+          key.column: 6,
+          key.is_implicit: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "privatePropertyWrappedProperty",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV022privatePropertyWrappedI033_2295DDF1454D6A6D9229E8222CD85214LLSivp",
+          key.line: 118,
+          key.column: 40,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV022privatePropertyWrappedI033_2295DDF1454D6A6D9229E8222CD85214LLSivg",
+              key.line: 118,
+              key.column: 40,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.private
+                },
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV022privatePropertyWrappedI033_2295DDF1454D6A6D9229E8222CD85214LLSivs",
+              key.line: 118,
+              key.column: 40,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.private
+                },
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            },
+            {
+              key.attribute: source.decl.attribute._custom
+            }
+          ],
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 118,
+          key.column: 72
         },
         {
           key.kind: source.lang.swift.decl.function.subscript,
           key.name: "subscript(_:)",
           key.usr: "s:28index_effective_access_level17ScopeKeeperStructVyS2icip",
-          key.line: 87,
+          key.line: 120,
           key.column: 12,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:subscript(_:)",
               key.usr: "s:28index_effective_access_level17ScopeKeeperStructVyS2icig",
-              key.line: 87,
-              key.column: 51,
-              key.effective_access: source.decl.effective_access.public
+              key.line: 120,
+              key.column: 51
             },
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 87,
+              key.line: 120,
               key.column: 39
             },
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 87,
+              key.line: 120,
               key.column: 47
             }
           ],
@@ -1241,29 +2083,28 @@
           key.kind: source.lang.swift.decl.function.subscript,
           key.name: "subscript(_:)",
           key.usr: "s:28index_effective_access_level17ScopeKeeperStructVXeip",
-          key.line: 88,
+          key.line: 121,
           key.column: 5,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:subscript(_:)",
               key.usr: "s:28index_effective_access_level17ScopeKeeperStructVXeig",
-              key.line: 88,
-              key.column: 46,
-              key.effective_access: source.decl.effective_access.internal
+              key.line: 121,
+              key.column: 46
             },
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 88,
+              key.line: 121,
               key.column: 34
             },
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 88,
+              key.line: 121,
               key.column: 42
             }
           ],
@@ -1273,29 +2114,28 @@
           key.kind: source.lang.swift.decl.function.subscript,
           key.name: "subscript(_:)",
           key.usr: "s:28index_effective_access_level17ScopeKeeperStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llip",
-          key.line: 89,
+          key.line: 122,
           key.column: 17,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:subscript(_:)",
               key.usr: "s:28index_effective_access_level17ScopeKeeperStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llig",
-              key.line: 89,
-              key.column: 61,
-              key.effective_access: source.decl.effective_access.fileprivate
+              key.line: 122,
+              key.column: 61
             },
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 89,
+              key.line: 122,
               key.column: 49
             },
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 89,
+              key.line: 122,
               key.column: 57
             }
           ],
@@ -1310,29 +2150,28 @@
           key.kind: source.lang.swift.decl.function.subscript,
           key.name: "subscript(_:)",
           key.usr: "s:28index_effective_access_level17ScopeKeeperStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llip",
-          key.line: 90,
+          key.line: 123,
           key.column: 13,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:subscript(_:)",
               key.usr: "s:28index_effective_access_level17ScopeKeeperStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llig",
-              key.line: 90,
-              key.column: 53,
-              key.effective_access: source.decl.effective_access.less_than_fileprivate
+              key.line: 123,
+              key.column: 53
             },
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 90,
+              key.line: 123,
               key.column: 41
             },
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 90,
+              key.line: 123,
               key.column: 49
             }
           ],
@@ -1347,7 +2186,7 @@
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "publicMethod()",
           key.usr: "s:28index_effective_access_level17ScopeKeeperStructV12publicMethodyyF",
-          key.line: 92,
+          key.line: 125,
           key.column: 17,
           key.attributes: [
             {
@@ -1360,7 +2199,7 @@
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "internalMethod()",
           key.usr: "s:28index_effective_access_level17ScopeKeeperStructV14internalMethodyyF",
-          key.line: 93,
+          key.line: 126,
           key.column: 10,
           key.effective_access: source.decl.effective_access.internal
         },
@@ -1368,7 +2207,7 @@
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "filePrivateMethod()",
           key.usr: "s:28index_effective_access_level17ScopeKeeperStructV17filePrivateMethod33_2295DDF1454D6A6D9229E8222CD85214LLyyF",
-          key.line: 94,
+          key.line: 127,
           key.column: 22,
           key.attributes: [
             {
@@ -1381,7 +2220,7 @@
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "privateMethod()",
           key.usr: "s:28index_effective_access_level17ScopeKeeperStructV13privateMethod33_2295DDF1454D6A6D9229E8222CD85214LLyyF",
-          key.line: 95,
+          key.line: 128,
           key.column: 18,
           key.attributes: [
             {
@@ -1402,21 +2241,21 @@
       key.kind: source.lang.swift.decl.struct,
       key.name: "PartialScopeReducerStruct",
       key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV",
-      key.line: 98,
+      key.line: 131,
       key.column: 8,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.name: "init(publicInitializer:)",
           key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV17publicInitializerACSi_tcfc",
-          key.line: 99,
+          key.line: 132,
           key.column: 12,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 99,
+              key.line: 132,
               key.column: 36
             }
           ],
@@ -1431,14 +2270,14 @@
           key.kind: source.lang.swift.decl.function.constructor,
           key.name: "init(internalInitializer:)",
           key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV19internalInitializerACSi_tcfc",
-          key.line: 100,
+          key.line: 133,
           key.column: 5,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 100,
+              key.line: 133,
               key.column: 31
             }
           ],
@@ -1448,14 +2287,14 @@
           key.kind: source.lang.swift.decl.function.constructor,
           key.name: "init(filePrivateInitializer:)",
           key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV22filePrivateInitializerACSi_tc33_2295DDF1454D6A6D9229E8222CD85214Llfc",
-          key.line: 101,
+          key.line: 134,
           key.column: 17,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 101,
+              key.line: 134,
               key.column: 46
             }
           ],
@@ -1470,14 +2309,14 @@
           key.kind: source.lang.swift.decl.function.constructor,
           key.name: "init(privateInitializer:)",
           key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV18privateInitializerACSi_tc33_2295DDF1454D6A6D9229E8222CD85214Llfc",
-          key.line: 102,
+          key.line: 135,
           key.column: 13,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 102,
+              key.line: 135,
               key.column: 38
             }
           ],
@@ -1492,34 +2331,32 @@
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "publicProperty",
           key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV14publicPropertySivp",
-          key.line: 104,
+          key.line: 137,
           key.column: 16,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV14publicPropertySivg",
-              key.line: 104,
+              key.line: 137,
               key.column: 16,
               key.is_implicit: 1,
               key.attributes: [
                 {
                   key.attribute: source.decl.attribute.public
                 }
-              ],
-              key.effective_access: source.decl.effective_access.internal
+              ]
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV14publicPropertySivs",
-              key.line: 104,
+              key.line: 137,
               key.column: 16,
               key.is_implicit: 1,
               key.attributes: [
                 {
                   key.attribute: source.decl.attribute.public
                 }
-              ],
-              key.effective_access: source.decl.effective_access.internal
+              ]
             }
           ],
           key.attributes: [
@@ -1533,31 +2370,29 @@
           key.kind: source.lang.swift.ref.struct,
           key.name: "Int",
           key.usr: "s:Si",
-          key.line: 104,
+          key.line: 137,
           key.column: 32
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "internalProperty",
           key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV16internalPropertySivp",
-          key.line: 105,
+          key.line: 138,
           key.column: 9,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV16internalPropertySivg",
-              key.line: 105,
+              key.line: 138,
               key.column: 9,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_implicit: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV16internalPropertySivs",
-              key.line: 105,
+              key.line: 138,
               key.column: 9,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_implicit: 1
             }
           ],
           key.effective_access: source.decl.effective_access.internal
@@ -1566,41 +2401,39 @@
           key.kind: source.lang.swift.ref.struct,
           key.name: "Int",
           key.usr: "s:Si",
-          key.line: 105,
+          key.line: 138,
           key.column: 27
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "filePrivateProperty",
           key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV19filePrivateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivp",
-          key.line: 106,
+          key.line: 139,
           key.column: 21,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV19filePrivateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivg",
-              key.line: 106,
+              key.line: 139,
               key.column: 21,
               key.is_implicit: 1,
               key.attributes: [
                 {
                   key.attribute: source.decl.attribute.fileprivate
                 }
-              ],
-              key.effective_access: source.decl.effective_access.fileprivate
+              ]
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV19filePrivateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivs",
-              key.line: 106,
+              key.line: 139,
               key.column: 21,
               key.is_implicit: 1,
               key.attributes: [
                 {
                   key.attribute: source.decl.attribute.fileprivate
                 }
-              ],
-              key.effective_access: source.decl.effective_access.fileprivate
+              ]
             }
           ],
           key.attributes: [
@@ -1614,41 +2447,39 @@
           key.kind: source.lang.swift.ref.struct,
           key.name: "Int",
           key.usr: "s:Si",
-          key.line: 106,
+          key.line: 139,
           key.column: 42
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "privateProperty",
           key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV15privateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivp",
-          key.line: 107,
+          key.line: 140,
           key.column: 17,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV15privateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivg",
-              key.line: 107,
+              key.line: 140,
               key.column: 17,
               key.is_implicit: 1,
               key.attributes: [
                 {
                   key.attribute: source.decl.attribute.private
                 }
-              ],
-              key.effective_access: source.decl.effective_access.less_than_fileprivate
+              ]
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV15privateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivs",
-              key.line: 107,
+              key.line: 140,
               key.column: 17,
               key.is_implicit: 1,
               key.attributes: [
                 {
                   key.attribute: source.decl.attribute.private
                 }
-              ],
-              key.effective_access: source.decl.effective_access.less_than_fileprivate
+              ]
             }
           ],
           key.attributes: [
@@ -1662,20 +2493,20 @@
           key.kind: source.lang.swift.ref.struct,
           key.name: "Int",
           key.usr: "s:Si",
-          key.line: 107,
+          key.line: 140,
           key.column: 34
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "publicPropertyWithPrivateSetter",
           key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV31publicPropertyWithPrivateSetterSivp",
-          key.line: 108,
+          key.line: 141,
           key.column: 29,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV31publicPropertyWithPrivateSetterSivg",
-              key.line: 108,
+              key.line: 141,
               key.column: 29,
               key.is_implicit: 1,
               key.attributes: [
@@ -1685,13 +2516,12 @@
                 {
                   key.attribute: source.decl.attribute.public
                 }
-              ],
-              key.effective_access: source.decl.effective_access.internal
+              ]
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV31publicPropertyWithPrivateSetterSivs",
-              key.line: 108,
+              key.line: 141,
               key.column: 29,
               key.is_implicit: 1,
               key.attributes: [
@@ -1701,8 +2531,7 @@
                 {
                   key.attribute: source.decl.attribute.public
                 }
-              ],
-              key.effective_access: source.decl.effective_access.internal
+              ]
             }
           ],
           key.attributes: [
@@ -1719,36 +2548,302 @@
           key.kind: source.lang.swift.ref.struct,
           key.name: "Int",
           key.usr: "s:Si",
-          key.line: 108,
+          key.line: 141,
           key.column: 62
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "PublicPropertyWrapper",
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV",
+          key.line: 143,
+          key.column: 6
+        },
+        {
+          key.kind: source.lang.swift.ref.function.constructor,
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV12wrappedValueACyxGx_tcfc",
+          key.line: 143,
+          key.column: 6,
+          key.is_implicit: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "publicPropertyWrappedProperty",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV021publicPropertyWrappedJ0Sivp",
+          key.line: 143,
+          key.column: 39,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV021publicPropertyWrappedJ0Sivg",
+              key.line: 143,
+              key.column: 39,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.public
+                },
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV021publicPropertyWrappedJ0Sivs",
+              key.line: 143,
+              key.column: 39,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.public
+                },
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            },
+            {
+              key.attribute: source.decl.attribute._custom
+            }
+          ],
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 143,
+          key.column: 70
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "PublicPropertyWrapper",
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV",
+          key.line: 144,
+          key.column: 6
+        },
+        {
+          key.kind: source.lang.swift.ref.function.constructor,
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV12wrappedValueACyxGx_tcfc",
+          key.line: 144,
+          key.column: 6,
+          key.is_implicit: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "internalPropertyWrappedProperty",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV023internalPropertyWrappedJ0Sivp",
+          key.line: 144,
+          key.column: 32,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV023internalPropertyWrappedJ0Sivg",
+              key.line: 144,
+              key.column: 32,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV023internalPropertyWrappedJ0Sivs",
+              key.line: 144,
+              key.column: 32,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute._custom
+            }
+          ],
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 144,
+          key.column: 65
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "PublicPropertyWrapper",
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV",
+          key.line: 145,
+          key.column: 6
+        },
+        {
+          key.kind: source.lang.swift.ref.function.constructor,
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV12wrappedValueACyxGx_tcfc",
+          key.line: 145,
+          key.column: 6,
+          key.is_implicit: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "filePrivatePropertyWrappedProperty",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV026filePrivatePropertyWrappedK033_2295DDF1454D6A6D9229E8222CD85214LLSivp",
+          key.line: 145,
+          key.column: 44,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV026filePrivatePropertyWrappedK033_2295DDF1454D6A6D9229E8222CD85214LLSivg",
+              key.line: 145,
+              key.column: 44,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.fileprivate
+                },
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV026filePrivatePropertyWrappedK033_2295DDF1454D6A6D9229E8222CD85214LLSivs",
+              key.line: 145,
+              key.column: 44,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.fileprivate
+                },
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            },
+            {
+              key.attribute: source.decl.attribute._custom
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 145,
+          key.column: 80
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "PublicPropertyWrapper",
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV",
+          key.line: 146,
+          key.column: 6
+        },
+        {
+          key.kind: source.lang.swift.ref.function.constructor,
+          key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV12wrappedValueACyxGx_tcfc",
+          key.line: 146,
+          key.column: 6,
+          key.is_implicit: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "privatePropertyWrappedProperty",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV022privatePropertyWrappedJ033_2295DDF1454D6A6D9229E8222CD85214LLSivp",
+          key.line: 146,
+          key.column: 40,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV022privatePropertyWrappedJ033_2295DDF1454D6A6D9229E8222CD85214LLSivg",
+              key.line: 146,
+              key.column: 40,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.private
+                },
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV022privatePropertyWrappedJ033_2295DDF1454D6A6D9229E8222CD85214LLSivs",
+              key.line: 146,
+              key.column: 40,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.private
+                },
+                {
+                  key.attribute: source.decl.attribute._custom
+                }
+              ]
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            },
+            {
+              key.attribute: source.decl.attribute._custom
+            }
+          ],
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 146,
+          key.column: 72
         },
         {
           key.kind: source.lang.swift.decl.function.subscript,
           key.name: "subscript(_:)",
           key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVyS2icip",
-          key.line: 110,
+          key.line: 148,
           key.column: 12,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:subscript(_:)",
               key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVyS2icig",
-              key.line: 110,
-              key.column: 51,
-              key.effective_access: source.decl.effective_access.internal
+              key.line: 148,
+              key.column: 51
             },
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 110,
+              key.line: 148,
               key.column: 39
             },
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 110,
+              key.line: 148,
               key.column: 47
             }
           ],
@@ -1763,29 +2858,28 @@
           key.kind: source.lang.swift.decl.function.subscript,
           key.name: "subscript(_:)",
           key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVXeip",
-          key.line: 111,
+          key.line: 149,
           key.column: 5,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:subscript(_:)",
               key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVXeig",
-              key.line: 111,
-              key.column: 46,
-              key.effective_access: source.decl.effective_access.internal
+              key.line: 149,
+              key.column: 46
             },
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 111,
+              key.line: 149,
               key.column: 34
             },
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 111,
+              key.line: 149,
               key.column: 42
             }
           ],
@@ -1795,29 +2889,28 @@
           key.kind: source.lang.swift.decl.function.subscript,
           key.name: "subscript(_:)",
           key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llip",
-          key.line: 112,
+          key.line: 150,
           key.column: 17,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:subscript(_:)",
               key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llig",
-              key.line: 112,
-              key.column: 61,
-              key.effective_access: source.decl.effective_access.fileprivate
+              key.line: 150,
+              key.column: 61
             },
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 112,
+              key.line: 150,
               key.column: 49
             },
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 112,
+              key.line: 150,
               key.column: 57
             }
           ],
@@ -1832,29 +2925,28 @@
           key.kind: source.lang.swift.decl.function.subscript,
           key.name: "subscript(_:)",
           key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llip",
-          key.line: 113,
+          key.line: 151,
           key.column: 13,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:subscript(_:)",
               key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llig",
-              key.line: 113,
-              key.column: 53,
-              key.effective_access: source.decl.effective_access.less_than_fileprivate
+              key.line: 151,
+              key.column: 53
             },
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 113,
+              key.line: 151,
               key.column: 41
             },
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 113,
+              key.line: 151,
               key.column: 49
             }
           ],
@@ -1869,7 +2961,7 @@
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "publicMethod()",
           key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV12publicMethodyyF",
-          key.line: 115,
+          key.line: 153,
           key.column: 17,
           key.attributes: [
             {
@@ -1882,7 +2974,7 @@
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "internalMethod()",
           key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV14internalMethodyyF",
-          key.line: 116,
+          key.line: 154,
           key.column: 10,
           key.effective_access: source.decl.effective_access.internal
         },
@@ -1890,7 +2982,7 @@
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "filePrivateMethod()",
           key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV17filePrivateMethod33_2295DDF1454D6A6D9229E8222CD85214LLyyF",
-          key.line: 117,
+          key.line: 155,
           key.column: 22,
           key.attributes: [
             {
@@ -1903,7 +2995,7 @@
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "privateMethod()",
           key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV13privateMethod33_2295DDF1454D6A6D9229E8222CD85214LLyyF",
-          key.line: 118,
+          key.line: 156,
           key.column: 18,
           key.attributes: [
             {
@@ -1919,21 +3011,21 @@
       key.kind: source.lang.swift.decl.extension.enum,
       key.name: "PrivateEnum",
       key.usr: "s:e:s:28index_effective_access_level11PrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO017privateMethodFromE9ExtensionyyF",
-      key.line: 121,
+      key.line: 159,
       key.column: 19,
       key.entities: [
         {
           key.kind: source.lang.swift.ref.enum,
           key.name: "PrivateEnum",
           key.usr: "s:28index_effective_access_level11PrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO",
-          key.line: 121,
+          key.line: 159,
           key.column: 19
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "privateMethodFromPrivateExtension()",
           key.usr: "s:28index_effective_access_level11PrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO017privateMethodFromE9ExtensionyyF",
-          key.line: 122,
+          key.line: 160,
           key.column: 18,
           key.attributes: [
             {
@@ -1953,33 +3045,31 @@
       key.kind: source.lang.swift.decl.protocol,
       key.name: "PublicProtocol",
       key.usr: "s:28index_effective_access_level14PublicProtocolP",
-      key.line: 125,
+      key.line: 163,
       key.column: 17,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "member",
           key.usr: "s:28index_effective_access_level14PublicProtocolP6memberSivp",
-          key.line: 126,
+          key.line: 164,
           key.column: 9,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:member",
               key.usr: "s:28index_effective_access_level14PublicProtocolP6memberSivg",
-              key.line: 126,
+              key.line: 164,
               key.column: 23,
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.public
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.name: "setter:member",
               key.usr: "s:28index_effective_access_level14PublicProtocolP6memberSivs",
-              key.line: 126,
+              key.line: 164,
               key.column: 27,
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.public
+              key.is_dynamic: 1
             }
           ],
           key.effective_access: source.decl.effective_access.public
@@ -1988,14 +3078,14 @@
           key.kind: source.lang.swift.ref.struct,
           key.name: "Int",
           key.usr: "s:Si",
-          key.line: 126,
+          key.line: 164,
           key.column: 17
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "method()",
           key.usr: "s:28index_effective_access_level14PublicProtocolP6methodyyF",
-          key.line: 127,
+          key.line: 165,
           key.column: 10,
           key.is_dynamic: 1,
           key.effective_access: source.decl.effective_access.public
@@ -2012,33 +3102,31 @@
       key.kind: source.lang.swift.decl.protocol,
       key.name: "InternalProtocol",
       key.usr: "s:28index_effective_access_level16InternalProtocolP",
-      key.line: 130,
+      key.line: 168,
       key.column: 10,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "member",
           key.usr: "s:28index_effective_access_level16InternalProtocolP6memberSivp",
-          key.line: 131,
+          key.line: 169,
           key.column: 9,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:member",
               key.usr: "s:28index_effective_access_level16InternalProtocolP6memberSivg",
-              key.line: 131,
+              key.line: 169,
               key.column: 23,
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.name: "setter:member",
               key.usr: "s:28index_effective_access_level16InternalProtocolP6memberSivs",
-              key.line: 131,
+              key.line: 169,
               key.column: 27,
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_dynamic: 1
             }
           ],
           key.effective_access: source.decl.effective_access.internal
@@ -2047,14 +3135,14 @@
           key.kind: source.lang.swift.ref.struct,
           key.name: "Int",
           key.usr: "s:Si",
-          key.line: 131,
+          key.line: 169,
           key.column: 17
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "method()",
           key.usr: "s:28index_effective_access_level16InternalProtocolP6methodyyF",
-          key.line: 132,
+          key.line: 170,
           key.column: 10,
           key.is_dynamic: 1,
           key.effective_access: source.decl.effective_access.internal
@@ -2066,33 +3154,31 @@
       key.kind: source.lang.swift.decl.protocol,
       key.name: "FilePrivateProtocol",
       key.usr: "s:28index_effective_access_level19FilePrivateProtocol33_2295DDF1454D6A6D9229E8222CD85214LLP",
-      key.line: 135,
+      key.line: 173,
       key.column: 22,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "member",
           key.usr: "s:28index_effective_access_level19FilePrivateProtocol33_2295DDF1454D6A6D9229E8222CD85214LLP6memberSivp",
-          key.line: 136,
+          key.line: 174,
           key.column: 9,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:member",
               key.usr: "s:28index_effective_access_level19FilePrivateProtocol33_2295DDF1454D6A6D9229E8222CD85214LLP6memberSivg",
-              key.line: 136,
+              key.line: 174,
               key.column: 23,
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.fileprivate
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.name: "setter:member",
               key.usr: "s:28index_effective_access_level19FilePrivateProtocol33_2295DDF1454D6A6D9229E8222CD85214LLP6memberSivs",
-              key.line: 136,
+              key.line: 174,
               key.column: 27,
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.fileprivate
+              key.is_dynamic: 1
             }
           ],
           key.effective_access: source.decl.effective_access.fileprivate
@@ -2101,14 +3187,14 @@
           key.kind: source.lang.swift.ref.struct,
           key.name: "Int",
           key.usr: "s:Si",
-          key.line: 136,
+          key.line: 174,
           key.column: 17
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "method()",
           key.usr: "s:28index_effective_access_level19FilePrivateProtocol33_2295DDF1454D6A6D9229E8222CD85214LLP6methodyyF",
-          key.line: 137,
+          key.line: 175,
           key.column: 10,
           key.is_dynamic: 1,
           key.effective_access: source.decl.effective_access.fileprivate
@@ -2125,33 +3211,31 @@
       key.kind: source.lang.swift.decl.protocol,
       key.name: "PrivateProtocol",
       key.usr: "s:28index_effective_access_level15PrivateProtocol33_2295DDF1454D6A6D9229E8222CD85214LLP",
-      key.line: 140,
+      key.line: 178,
       key.column: 18,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "member",
           key.usr: "s:28index_effective_access_level15PrivateProtocol33_2295DDF1454D6A6D9229E8222CD85214LLP6memberSivp",
-          key.line: 141,
+          key.line: 179,
           key.column: 9,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:member",
               key.usr: "s:28index_effective_access_level15PrivateProtocol33_2295DDF1454D6A6D9229E8222CD85214LLP6memberSivg",
-              key.line: 141,
+              key.line: 179,
               key.column: 23,
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.fileprivate
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.name: "setter:member",
               key.usr: "s:28index_effective_access_level15PrivateProtocol33_2295DDF1454D6A6D9229E8222CD85214LLP6memberSivs",
-              key.line: 141,
+              key.line: 179,
               key.column: 27,
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.fileprivate
+              key.is_dynamic: 1
             }
           ],
           key.effective_access: source.decl.effective_access.fileprivate
@@ -2160,14 +3244,14 @@
           key.kind: source.lang.swift.ref.struct,
           key.name: "Int",
           key.usr: "s:Si",
-          key.line: 141,
+          key.line: 179,
           key.column: 17
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "method()",
           key.usr: "s:28index_effective_access_level15PrivateProtocol33_2295DDF1454D6A6D9229E8222CD85214LLP6methodyyF",
-          key.line: 142,
+          key.line: 180,
           key.column: 10,
           key.is_dynamic: 1,
           key.effective_access: source.decl.effective_access.fileprivate
@@ -2184,14 +3268,14 @@
       key.kind: source.lang.swift.decl.struct,
       key.name: "FilePrivateImplementationOfPublicProtocol",
       key.usr: "s:28index_effective_access_level41FilePrivateImplementationOfPublicProtocol33_2295DDF1454D6A6D9229E8222CD85214LLV",
-      key.line: 145,
+      key.line: 183,
       key.column: 20,
       key.related: [
         {
           key.kind: source.lang.swift.ref.protocol,
           key.name: "PublicProtocol",
           key.usr: "s:28index_effective_access_level14PublicProtocolP",
-          key.line: 145,
+          key.line: 183,
           key.column: 63
         }
       ],
@@ -2200,14 +3284,14 @@
           key.kind: source.lang.swift.ref.protocol,
           key.name: "PublicProtocol",
           key.usr: "s:28index_effective_access_level14PublicProtocolP",
-          key.line: 145,
+          key.line: 183,
           key.column: 63
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "member",
           key.usr: "s:28index_effective_access_level41FilePrivateImplementationOfPublicProtocol33_2295DDF1454D6A6D9229E8222CD85214LLV6memberSivp",
-          key.line: 146,
+          key.line: 184,
           key.column: 21,
           key.related: [
             {
@@ -2220,28 +3304,26 @@
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.usr: "s:28index_effective_access_level41FilePrivateImplementationOfPublicProtocol33_2295DDF1454D6A6D9229E8222CD85214LLV6memberSivg",
-              key.line: 146,
+              key.line: 184,
               key.column: 21,
               key.is_implicit: 1,
               key.attributes: [
                 {
                   key.attribute: source.decl.attribute.fileprivate
                 }
-              ],
-              key.effective_access: source.decl.effective_access.fileprivate
+              ]
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.usr: "s:28index_effective_access_level41FilePrivateImplementationOfPublicProtocol33_2295DDF1454D6A6D9229E8222CD85214LLV6memberSivs",
-              key.line: 146,
+              key.line: 184,
               key.column: 21,
               key.is_implicit: 1,
               key.attributes: [
                 {
                   key.attribute: source.decl.attribute.fileprivate
                 }
-              ],
-              key.effective_access: source.decl.effective_access.fileprivate
+              ]
             }
           ],
           key.attributes: [
@@ -2255,14 +3337,14 @@
           key.kind: source.lang.swift.ref.struct,
           key.name: "Int",
           key.usr: "s:Si",
-          key.line: 146,
+          key.line: 184,
           key.column: 29
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "method()",
           key.usr: "s:28index_effective_access_level41FilePrivateImplementationOfPublicProtocol33_2295DDF1454D6A6D9229E8222CD85214LLV6methodyyF",
-          key.line: 147,
+          key.line: 185,
           key.column: 22,
           key.related: [
             {
@@ -2281,7 +3363,7 @@
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.usr: "s:28index_effective_access_level41FilePrivateImplementationOfPublicProtocol33_2295DDF1454D6A6D9229E8222CD85214LLV6memberADSi_tcfc",
-          key.line: 145,
+          key.line: 183,
           key.column: 20,
           key.is_implicit: 1,
           key.effective_access: source.decl.effective_access.fileprivate
@@ -2289,7 +3371,7 @@
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.usr: "s:28index_effective_access_level41FilePrivateImplementationOfPublicProtocol33_2295DDF1454D6A6D9229E8222CD85214LLVADycfc",
-          key.line: 145,
+          key.line: 183,
           key.column: 20,
           key.is_implicit: 1,
           key.effective_access: source.decl.effective_access.fileprivate
@@ -2306,24 +3388,23 @@
       key.kind: source.lang.swift.decl.class,
       key.name: "OpenClass",
       key.usr: "s:28index_effective_access_level9OpenClassC",
-      key.line: 150,
+      key.line: 188,
       key.column: 12,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "openProperty",
           key.usr: "s:28index_effective_access_level9OpenClassC12openPropertySivp",
-          key.line: 151,
+          key.line: 189,
           key.column: 14,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:openProperty",
               key.usr: "s:28index_effective_access_level9OpenClassC12openPropertySivg",
-              key.line: 151,
+              key.line: 189,
               key.column: 32,
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.public
+              key.is_dynamic: 1
             }
           ],
           key.attributes: [
@@ -2337,24 +3418,23 @@
           key.kind: source.lang.swift.ref.struct,
           key.name: "Int",
           key.usr: "s:Si",
-          key.line: 151,
+          key.line: 189,
           key.column: 28
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "publicProperty",
           key.usr: "s:28index_effective_access_level9OpenClassC14publicPropertySivp",
-          key.line: 152,
+          key.line: 190,
           key.column: 16,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:publicProperty",
               key.usr: "s:28index_effective_access_level9OpenClassC14publicPropertySivg",
-              key.line: 152,
+              key.line: 190,
               key.column: 36,
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.public
+              key.is_dynamic: 1
             }
           ],
           key.attributes: [
@@ -2368,24 +3448,23 @@
           key.kind: source.lang.swift.ref.struct,
           key.name: "Int",
           key.usr: "s:Si",
-          key.line: 152,
+          key.line: 190,
           key.column: 32
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "internalProperty",
           key.usr: "s:28index_effective_access_level9OpenClassC16internalPropertySivp",
-          key.line: 153,
+          key.line: 191,
           key.column: 9,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:internalProperty",
               key.usr: "s:28index_effective_access_level9OpenClassC16internalPropertySivg",
-              key.line: 153,
+              key.line: 191,
               key.column: 31,
-              key.is_dynamic: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_dynamic: 1
             }
           ],
           key.effective_access: source.decl.effective_access.internal
@@ -2394,14 +3473,14 @@
           key.kind: source.lang.swift.ref.struct,
           key.name: "Int",
           key.usr: "s:Si",
-          key.line: 153,
+          key.line: 191,
           key.column: 27
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "openMethod()",
           key.usr: "s:28index_effective_access_level9OpenClassC10openMethodyyF",
-          key.line: 155,
+          key.line: 193,
           key.column: 15,
           key.is_dynamic: 1,
           key.attributes: [
@@ -2415,7 +3494,7 @@
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "publicMethod()",
           key.usr: "s:28index_effective_access_level9OpenClassC12publicMethodyyF",
-          key.line: 156,
+          key.line: 194,
           key.column: 17,
           key.is_dynamic: 1,
           key.attributes: [
@@ -2429,7 +3508,7 @@
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "internalMethod()",
           key.usr: "s:28index_effective_access_level9OpenClassC14internalMethodyyF",
-          key.line: 157,
+          key.line: 195,
           key.column: 10,
           key.is_dynamic: 1,
           key.effective_access: source.decl.effective_access.internal
@@ -2437,7 +3516,7 @@
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.usr: "s:28index_effective_access_level9OpenClassCACycfc",
-          key.line: 150,
+          key.line: 188,
           key.column: 12,
           key.is_implicit: 1,
           key.effective_access: source.decl.effective_access.internal
@@ -2454,38 +3533,36 @@
       key.kind: source.lang.swift.ref.module,
       key.name: "Module",
       key.usr: "c:@M@Module",
-      key.line: 160,
+      key.line: 198,
       key.column: 8
     },
     {
       key.kind: source.lang.swift.decl.struct,
       key.name: "InternalStruct",
       key.usr: "s:28index_effective_access_level14InternalStructV",
-      key.line: 162,
+      key.line: 200,
       key.column: 8,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "propertyReferencingPublicClassFromModule",
           key.usr: "s:28index_effective_access_level14InternalStructV40propertyReferencingPublicClassFromModule0L00lJ0Cvp",
-          key.line: 163,
+          key.line: 201,
           key.column: 9,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.usr: "s:28index_effective_access_level14InternalStructV40propertyReferencingPublicClassFromModule0L00lJ0Cvg",
-              key.line: 163,
+              key.line: 201,
               key.column: 9,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_implicit: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.usr: "s:28index_effective_access_level14InternalStructV40propertyReferencingPublicClassFromModule0L00lJ0Cvs",
-              key.line: 163,
+              key.line: 201,
               key.column: 9,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_implicit: 1
             }
           ],
           key.effective_access: source.decl.effective_access.internal
@@ -2494,38 +3571,36 @@
           key.kind: source.lang.swift.ref.module,
           key.name: "Module",
           key.usr: "c:@M@Module",
-          key.line: 163,
+          key.line: 201,
           key.column: 51
         },
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "ModuleClass",
           key.usr: "s:6Module0A5ClassC",
-          key.line: 163,
+          key.line: 201,
           key.column: 58
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "propertyReferencingPublicClassFromExportedModule",
           key.usr: "s:28index_effective_access_level14InternalStructV48propertyReferencingPublicClassFromExportedModule0L00lJ0Cvp",
-          key.line: 164,
+          key.line: 202,
           key.column: 9,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.usr: "s:28index_effective_access_level14InternalStructV48propertyReferencingPublicClassFromExportedModule0L00lJ0Cvg",
-              key.line: 164,
+              key.line: 202,
               key.column: 9,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_implicit: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.usr: "s:28index_effective_access_level14InternalStructV48propertyReferencingPublicClassFromExportedModule0L00lJ0Cvs",
-              key.line: 164,
+              key.line: 202,
               key.column: 9,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_implicit: 1
             }
           ],
           key.effective_access: source.decl.effective_access.internal
@@ -2534,20 +3609,20 @@
           key.kind: source.lang.swift.ref.module,
           key.name: "Exported",
           key.usr: "c:@M@Exported",
-          key.line: 164,
+          key.line: 202,
           key.column: 59
         },
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "ExportedClass",
           key.usr: "s:8Exported0A5ClassC",
-          key.line: 164,
+          key.line: 202,
           key.column: 68
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.usr: "s:28index_effective_access_level14InternalStructV40propertyReferencingPublicClassFromModule0ghijk8ExportedL0AC0L00lJ0C_0M00mJ0Ctcfc",
-          key.line: 162,
+          key.line: 200,
           key.column: 8,
           key.is_implicit: 1,
           key.effective_access: source.decl.effective_access.internal

--- a/test/SourceKit/Indexing/index_effective_access_level.swift.response
+++ b/test/SourceKit/Indexing/index_effective_access_level.swift.response
@@ -3760,6 +3760,14 @@
           key.effective_access: source.decl.effective_access.internal
         },
         {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "testLocalContent()",
+          key.usr: "s:28index_effective_access_level30ProtocolWithAssociatedTypeImplV16testLocalContentyyF",
+          key.line: 215,
+          key.column: 10,
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
           key.kind: source.lang.swift.decl.function.constructor,
           key.usr: "s:28index_effective_access_level30ProtocolWithAssociatedTypeImplVACycfc",
           key.line: 213,

--- a/test/SourceKit/Indexing/index_effective_access_level.swift.response
+++ b/test/SourceKit/Indexing/index_effective_access_level.swift.response
@@ -5,31 +5,69 @@
       key.name: "Swift",
       key.filepath: Swift.swiftmodule,
       key.is_system: 1
+    },
+    {
+      key.kind: source.lang.swift.import.module.swift,
+      key.name: "Module",
+      key.filepath: Module.swiftmodule,
+      key.dependencies: [
+        {
+          key.kind: source.lang.swift.import.module.swift,
+          key.name: "Exported",
+          key.filepath: Exported.swiftmodule,
+          key.dependencies: [
+            {
+              key.kind: source.lang.swift.import.module.swift,
+              key.name: "Swift",
+              key.filepath: Swift.swiftmodule,
+              key.is_system: 1
+            },
+            {
+              key.kind: source.lang.swift.import.module.swift,
+              key.name: "SwiftOnoneSupport",
+              key.filepath: SwiftOnoneSupport.swiftmodule,
+              key.is_system: 1,
+              key.dependencies: [
+                {
+                  key.kind: source.lang.swift.import.module.swift,
+                  key.name: "Swift",
+                  key.filepath: Swift.swiftmodule,
+                  key.is_system: 1
+                }
+              ]
+            }
+          ]
+        },
+        {
+          key.kind: source.lang.swift.import.module.swift,
+          key.name: "Swift",
+          key.filepath: Swift.swiftmodule,
+          key.is_system: 1
+        },
+        {
+          key.kind: source.lang.swift.import.module.swift,
+          key.name: "SwiftOnoneSupport",
+          key.filepath: SwiftOnoneSupport.swiftmodule,
+          key.is_system: 1
+        }
+      ]
     }
   ],
   key.entities: [
     {
       key.kind: source.lang.swift.decl.enum,
-      key.name: "PublicEn",
-      key.usr: "s:28index_effective_access_level8PublicEnO",
-      key.line: 4,
+      key.name: "PublicEnum",
+      key.usr: "s:28index_effective_access_level10PublicEnumO",
+      key.line: 8,
       key.column: 13,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.enumelement,
-          key.name: "a",
-          key.usr: "s:28index_effective_access_level8PublicEnO1ayA2CmF",
-          key.line: 5,
+          key.name: "publicEnumCase",
+          key.usr: "s:28index_effective_access_level10PublicEnumO06publicF4CaseyA2CmF",
+          key.line: 9,
           key.column: 10,
-          key.effective_access_level: source.decl.effective_access.public
-        },
-        {
-          key.kind: source.lang.swift.decl.enumelement,
-          key.name: "b",
-          key.usr: "s:28index_effective_access_level8PublicEnO1byA2CmF",
-          key.line: 6,
-          key.column: 10,
-          key.effective_access_level: source.decl.effective_access.public
+          key.effective_access: source.decl.effective_access.public
         }
       ],
       key.attributes: [
@@ -37,56 +75,40 @@
           key.attribute: source.decl.attribute.public
         }
       ],
-      key.effective_access_level: source.decl.effective_access.public
+      key.effective_access: source.decl.effective_access.public
     },
     {
       key.kind: source.lang.swift.decl.enum,
-      key.name: "InternalEn",
-      key.usr: "s:28index_effective_access_level10InternalEnO",
-      key.line: 9,
+      key.name: "InternalEnum",
+      key.usr: "s:28index_effective_access_level12InternalEnumO",
+      key.line: 12,
       key.column: 6,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.enumelement,
-          key.name: "a",
-          key.usr: "s:28index_effective_access_level10InternalEnO1ayA2CmF",
-          key.line: 10,
+          key.name: "internalEnumCase",
+          key.usr: "s:28index_effective_access_level12InternalEnumO08internalF4CaseyA2CmF",
+          key.line: 13,
           key.column: 10,
-          key.effective_access_level: source.decl.effective_access.internal
-        },
-        {
-          key.kind: source.lang.swift.decl.enumelement,
-          key.name: "b",
-          key.usr: "s:28index_effective_access_level10InternalEnO1byA2CmF",
-          key.line: 11,
-          key.column: 10,
-          key.effective_access_level: source.decl.effective_access.internal
+          key.effective_access: source.decl.effective_access.internal
         }
       ],
-      key.effective_access_level: source.decl.effective_access.internal
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.enum,
-      key.name: "FilePrivateEn",
-      key.usr: "s:28index_effective_access_level13FilePrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO",
-      key.line: 14,
+      key.name: "FilePrivateEnum",
+      key.usr: "s:28index_effective_access_level15FilePrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO",
+      key.line: 16,
       key.column: 18,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.enumelement,
-          key.name: "a",
-          key.usr: "s:28index_effective_access_level13FilePrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO1ayA2DmF",
-          key.line: 15,
+          key.name: "filePrivateEnumCase",
+          key.usr: "s:28index_effective_access_level15FilePrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO04filefG4CaseyA2DmF",
+          key.line: 17,
           key.column: 10,
-          key.effective_access_level: source.decl.effective_access.fileprivate
-        },
-        {
-          key.kind: source.lang.swift.decl.enumelement,
-          key.name: "b",
-          key.usr: "s:28index_effective_access_level13FilePrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO1byA2DmF",
-          key.line: 16,
-          key.column: 10,
-          key.effective_access_level: source.decl.effective_access.fileprivate
+          key.effective_access: source.decl.effective_access.fileprivate
         }
       ],
       key.attributes: [
@@ -94,30 +116,22 @@
           key.attribute: source.decl.attribute.fileprivate
         }
       ],
-      key.effective_access_level: source.decl.effective_access.fileprivate
+      key.effective_access: source.decl.effective_access.fileprivate
     },
     {
       key.kind: source.lang.swift.decl.enum,
-      key.name: "PrivateEn",
-      key.usr: "s:28index_effective_access_level9PrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO",
-      key.line: 19,
+      key.name: "PrivateEnum",
+      key.usr: "s:28index_effective_access_level11PrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO",
+      key.line: 20,
       key.column: 14,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.enumelement,
-          key.name: "a",
-          key.usr: "s:28index_effective_access_level9PrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO1ayA2DmF",
-          key.line: 20,
-          key.column: 10,
-          key.effective_access_level: source.decl.effective_access.fileprivate
-        },
-        {
-          key.kind: source.lang.swift.decl.enumelement,
-          key.name: "b",
-          key.usr: "s:28index_effective_access_level9PrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO1byA2DmF",
+          key.name: "privateEnumCase",
+          key.usr: "s:28index_effective_access_level11PrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO07privateF4CaseyA2DmF",
           key.line: 21,
           key.column: 10,
-          key.effective_access_level: source.decl.effective_access.fileprivate
+          key.effective_access: source.decl.effective_access.fileprivate
         }
       ],
       key.attributes: [
@@ -125,26 +139,26 @@
           key.attribute: source.decl.attribute.private
         }
       ],
-      key.effective_access_level: source.decl.effective_access.fileprivate
+      key.effective_access: source.decl.effective_access.fileprivate
     },
     {
       key.kind: source.lang.swift.decl.extension.enum,
-      key.name: "PublicEn",
-      key.usr: "s:e:s:28index_effective_access_level8PublicEnO5puFooyyF",
+      key.name: "PublicEnum",
+      key.usr: "s:e:s:28index_effective_access_level10PublicEnumO12publicMethodyyF",
       key.line: 24,
       key.column: 11,
       key.entities: [
         {
           key.kind: source.lang.swift.ref.enum,
-          key.name: "PublicEn",
-          key.usr: "s:28index_effective_access_level8PublicEnO",
+          key.name: "PublicEnum",
+          key.usr: "s:28index_effective_access_level10PublicEnumO",
           key.line: 24,
           key.column: 11
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "puFoo()",
-          key.usr: "s:28index_effective_access_level8PublicEnO5puFooyyF",
+          key.name: "publicMethod()",
+          key.usr: "s:28index_effective_access_level10PublicEnumO12publicMethodyyF",
           key.line: 25,
           key.column: 17,
           key.attributes: [
@@ -152,7 +166,7 @@
               key.attribute: source.decl.attribute.public
             }
           ],
-          key.effective_access_level: source.decl.effective_access.public
+          key.effective_access: source.decl.effective_access.public
         }
       ],
       key.attributes: [
@@ -163,25 +177,25 @@
     },
     {
       key.kind: source.lang.swift.decl.extension.enum,
-      key.name: "PublicEn",
-      key.usr: "s:e:s:28index_effective_access_level8PublicEnO09puFooFromE9ExtensionyyF",
+      key.name: "PublicEnum",
+      key.usr: "s:e:s:28index_effective_access_level10PublicEnumO010methodFromE9ExtensionyyF",
       key.line: 28,
       key.column: 18,
       key.entities: [
         {
           key.kind: source.lang.swift.ref.enum,
-          key.name: "PublicEn",
-          key.usr: "s:28index_effective_access_level8PublicEnO",
+          key.name: "PublicEnum",
+          key.usr: "s:28index_effective_access_level10PublicEnumO",
           key.line: 28,
           key.column: 18
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "puFooFromPublicExtension()",
-          key.usr: "s:28index_effective_access_level8PublicEnO09puFooFromE9ExtensionyyF",
+          key.name: "methodFromPublicExtension()",
+          key.usr: "s:28index_effective_access_level10PublicEnumO010methodFromE9ExtensionyyF",
           key.line: 29,
           key.column: 10,
-          key.effective_access_level: source.decl.effective_access.public
+          key.effective_access: source.decl.effective_access.public
         }
       ],
       key.attributes: [
@@ -192,46 +206,46 @@
     },
     {
       key.kind: source.lang.swift.decl.extension.enum,
-      key.name: "InternalEn",
-      key.usr: "s:e:s:28index_effective_access_level10InternalEnO3fooyyF",
+      key.name: "InternalEnum",
+      key.usr: "s:e:s:28index_effective_access_level12InternalEnumO14internalMethodyyF",
       key.line: 32,
       key.column: 11,
       key.entities: [
         {
           key.kind: source.lang.swift.ref.enum,
-          key.name: "InternalEn",
-          key.usr: "s:28index_effective_access_level10InternalEnO",
+          key.name: "InternalEnum",
+          key.usr: "s:28index_effective_access_level12InternalEnumO",
           key.line: 32,
           key.column: 11
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "foo()",
-          key.usr: "s:28index_effective_access_level10InternalEnO3fooyyF",
+          key.name: "internalMethod()",
+          key.usr: "s:28index_effective_access_level12InternalEnumO14internalMethodyyF",
           key.line: 33,
           key.column: 10,
-          key.effective_access_level: source.decl.effective_access.internal
+          key.effective_access: source.decl.effective_access.internal
         }
       ]
     },
     {
       key.kind: source.lang.swift.decl.extension.enum,
-      key.name: "FilePrivateEn",
-      key.usr: "s:e:s:28index_effective_access_level13FilePrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO7flPrFooyyF",
+      key.name: "FilePrivateEnum",
+      key.usr: "s:e:s:28index_effective_access_level15FilePrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO04fileF6MethodyyF",
       key.line: 36,
       key.column: 11,
       key.entities: [
         {
           key.kind: source.lang.swift.ref.enum,
-          key.name: "FilePrivateEn",
-          key.usr: "s:28index_effective_access_level13FilePrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO",
+          key.name: "FilePrivateEnum",
+          key.usr: "s:28index_effective_access_level15FilePrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO",
           key.line: 36,
           key.column: 11
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "flPrFoo()",
-          key.usr: "s:28index_effective_access_level13FilePrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO7flPrFooyyF",
+          key.name: "filePrivateMethod()",
+          key.usr: "s:28index_effective_access_level15FilePrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO04fileF6MethodyyF",
           key.line: 37,
           key.column: 22,
           key.attributes: [
@@ -239,7 +253,7 @@
               key.attribute: source.decl.attribute.fileprivate
             }
           ],
-          key.effective_access_level: source.decl.effective_access.fileprivate
+          key.effective_access: source.decl.effective_access.fileprivate
         }
       ],
       key.attributes: [
@@ -250,25 +264,25 @@
     },
     {
       key.kind: source.lang.swift.decl.extension.enum,
-      key.name: "FilePrivateEn",
-      key.usr: "s:e:s:28index_effective_access_level13FilePrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO011flPrFooFromeF9ExtensionyyF",
+      key.name: "FilePrivateEnum",
+      key.usr: "s:e:s:28index_effective_access_level15FilePrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO010methodFromeF9ExtensionyyF",
       key.line: 40,
       key.column: 23,
       key.entities: [
         {
           key.kind: source.lang.swift.ref.enum,
-          key.name: "FilePrivateEn",
-          key.usr: "s:28index_effective_access_level13FilePrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO",
+          key.name: "FilePrivateEnum",
+          key.usr: "s:28index_effective_access_level15FilePrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO",
           key.line: 40,
           key.column: 23
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "flPrFooFromFilePrivateExtension()",
-          key.usr: "s:28index_effective_access_level13FilePrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO011flPrFooFromeF9ExtensionyyF",
+          key.name: "methodFromFilePrivateExtension()",
+          key.usr: "s:28index_effective_access_level15FilePrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO010methodFromeF9ExtensionyyF",
           key.line: 41,
           key.column: 10,
-          key.effective_access_level: source.decl.effective_access.fileprivate
+          key.effective_access: source.decl.effective_access.fileprivate
         }
       ],
       key.attributes: [
@@ -279,22 +293,22 @@
     },
     {
       key.kind: source.lang.swift.decl.extension.enum,
-      key.name: "PrivateEn",
-      key.usr: "s:e:s:28index_effective_access_level9PrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO5prFooyyF",
+      key.name: "PrivateEnum",
+      key.usr: "s:e:s:28index_effective_access_level11PrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO13privateMethodyyF",
       key.line: 44,
       key.column: 11,
       key.entities: [
         {
           key.kind: source.lang.swift.ref.enum,
-          key.name: "PrivateEn",
-          key.usr: "s:28index_effective_access_level9PrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO",
+          key.name: "PrivateEnum",
+          key.usr: "s:28index_effective_access_level11PrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO",
           key.line: 44,
           key.column: 11
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "prFoo()",
-          key.usr: "s:28index_effective_access_level9PrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO5prFooyyF",
+          key.name: "privateMethod()",
+          key.usr: "s:28index_effective_access_level11PrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO13privateMethodyyF",
           key.line: 45,
           key.column: 18,
           key.attributes: [
@@ -302,7 +316,7 @@
               key.attribute: source.decl.attribute.private
             }
           ],
-          key.effective_access_level: source.decl.effective_access.less_than_fileprivate
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
         }
       ],
       key.attributes: [
@@ -313,25 +327,25 @@
     },
     {
       key.kind: source.lang.swift.decl.extension.enum,
-      key.name: "PrivateEn",
-      key.usr: "s:e:s:28index_effective_access_level9PrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO09prFooFromE9ExtensionyyF",
+      key.name: "PrivateEnum",
+      key.usr: "s:e:s:28index_effective_access_level11PrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO010methodFromE9ExtensionyyF",
       key.line: 48,
       key.column: 19,
       key.entities: [
         {
           key.kind: source.lang.swift.ref.enum,
-          key.name: "PrivateEn",
-          key.usr: "s:28index_effective_access_level9PrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO",
+          key.name: "PrivateEnum",
+          key.usr: "s:28index_effective_access_level11PrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO",
           key.line: 48,
           key.column: 19
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "prFooFromPrivateExtension()",
-          key.usr: "s:28index_effective_access_level9PrivateEn33_2295DDF1454D6A6D9229E8222CD85214LLO09prFooFromE9ExtensionyyF",
+          key.name: "methodFromPrivateExtension()",
+          key.usr: "s:28index_effective_access_level11PrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO010methodFromE9ExtensionyyF",
           key.line: 49,
           key.column: 10,
-          key.effective_access_level: source.decl.effective_access.fileprivate
+          key.effective_access: source.decl.effective_access.fileprivate
         }
       ],
       key.attributes: [
@@ -348,59 +362,511 @@
       key.column: 16,
       key.entities: [
         {
-          key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "a()",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV1ayyF",
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.name: "init(publicInitializer:)",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV17publicInitializerADSi_tcfc",
           key.line: 53,
+          key.column: 12,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 53,
+              key.column: 36
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.name: "init(internalInitializer:)",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV19internalInitializerADSi_tcfc",
+          key.line: 54,
+          key.column: 5,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 54,
+              key.column: 31
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.name: "init(filePrivateInitializer:)",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV22filePrivateInitializerADSi_tcfc",
+          key.line: 55,
+          key.column: 17,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 55,
+              key.column: 46
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.name: "init(privateInitializer:)",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV18privateInitializerADSi_tcfc",
+          key.line: 56,
+          key.column: 13,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 56,
+              key.column: 38
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            }
+          ],
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "publicProperty",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV14publicPropertySivp",
+          key.line: 58,
+          key.column: 16,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV14publicPropertySivg",
+              key.line: 58,
+              key.column: 16,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.public
+                }
+              ],
+              key.effective_access: source.decl.effective_access.fileprivate
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV14publicPropertySivs",
+              key.line: 58,
+              key.column: 16,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.public
+                }
+              ],
+              key.effective_access: source.decl.effective_access.fileprivate
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 58,
+          key.column: 32
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "internalProperty",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV16internalPropertySivp",
+          key.line: 59,
+          key.column: 9,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV16internalPropertySivg",
+              key.line: 59,
+              key.column: 9,
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.fileprivate
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV16internalPropertySivs",
+              key.line: 59,
+              key.column: 9,
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.fileprivate
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 59,
+          key.column: 27
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "filePrivateProperty",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV19filePrivatePropertySivp",
+          key.line: 60,
+          key.column: 21,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV19filePrivatePropertySivg",
+              key.line: 60,
+              key.column: 21,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.fileprivate
+                }
+              ],
+              key.effective_access: source.decl.effective_access.fileprivate
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV19filePrivatePropertySivs",
+              key.line: 60,
+              key.column: 21,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.fileprivate
+                }
+              ],
+              key.effective_access: source.decl.effective_access.fileprivate
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 60,
+          key.column: 42
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "privateProperty",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV15privatePropertySivp",
+          key.line: 61,
+          key.column: 17,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV15privatePropertySivg",
+              key.line: 61,
+              key.column: 17,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.private
+                }
+              ],
+              key.effective_access: source.decl.effective_access.less_than_fileprivate
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV15privatePropertySivs",
+              key.line: 61,
+              key.column: 17,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.private
+                }
+              ],
+              key.effective_access: source.decl.effective_access.less_than_fileprivate
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            }
+          ],
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 61,
+          key.column: 34
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "publicPropertyWithPrivateSetter",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV31publicPropertyWithPrivateSetterSivp",
+          key.line: 62,
+          key.column: 29,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV31publicPropertyWithPrivateSetterSivg",
+              key.line: 62,
+              key.column: 29,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.setter_access.private
+                },
+                {
+                  key.attribute: source.decl.attribute.public
+                }
+              ],
+              key.effective_access: source.decl.effective_access.fileprivate
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV31publicPropertyWithPrivateSetterSivs",
+              key.line: 62,
+              key.column: 29,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.setter_access.private
+                },
+                {
+                  key.attribute: source.decl.attribute.public
+                }
+              ],
+              key.effective_access: source.decl.effective_access.fileprivate
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.setter_access.private
+            },
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 62,
+          key.column: 62
+        },
+        {
+          key.kind: source.lang.swift.decl.function.subscript,
+          key.name: "subscript(_:)",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVyS2icip",
+          key.line: 64,
+          key.column: 12,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:subscript(_:)",
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVyS2icig",
+              key.line: 64,
+              key.column: 51,
+              key.effective_access: source.decl.effective_access.fileprivate
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 64,
+              key.column: 39
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 64,
+              key.column: 47
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.subscript,
+          key.name: "subscript(_:)",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeip",
+          key.line: 65,
+          key.column: 5,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:subscript(_:)",
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeig",
+              key.line: 65,
+              key.column: 46,
+              key.effective_access: source.decl.effective_access.fileprivate
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 65,
+              key.column: 34
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 65,
+              key.column: 42
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.subscript,
+          key.name: "subscript(_:)",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeip",
+          key.line: 66,
+          key.column: 17,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:subscript(_:)",
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeig",
+              key.line: 66,
+              key.column: 61,
+              key.effective_access: source.decl.effective_access.fileprivate
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 66,
+              key.column: 49
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 66,
+              key.column: 57
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.subscript,
+          key.name: "subscript(_:)",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeip",
+          key.line: 67,
+          key.column: 13,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:subscript(_:)",
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeig",
+              key.line: 67,
+              key.column: 53,
+              key.effective_access: source.decl.effective_access.less_than_fileprivate
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 67,
+              key.column: 41
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 67,
+              key.column: 49
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            }
+          ],
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "publicMethod()",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV12publicMethodyyF",
+          key.line: 69,
           key.column: 17,
           key.attributes: [
             {
               key.attribute: source.decl.attribute.public
             }
           ],
-          key.effective_access_level: source.decl.effective_access.fileprivate
+          key.effective_access: source.decl.effective_access.fileprivate
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "b()",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV1byyF",
-          key.line: 54,
+          key.name: "internalMethod()",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV14internalMethodyyF",
+          key.line: 70,
           key.column: 10,
-          key.effective_access_level: source.decl.effective_access.fileprivate
+          key.effective_access: source.decl.effective_access.fileprivate
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "c()",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV1cyyF",
-          key.line: 55,
+          key.name: "filePrivateMethod()",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV17filePrivateMethodyyF",
+          key.line: 71,
           key.column: 22,
           key.attributes: [
             {
               key.attribute: source.decl.attribute.fileprivate
             }
           ],
-          key.effective_access_level: source.decl.effective_access.fileprivate
+          key.effective_access: source.decl.effective_access.fileprivate
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "d()",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV1dyyF",
-          key.line: 56,
+          key.name: "privateMethod()",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLV13privateMethodyyF",
+          key.line: 72,
           key.column: 18,
           key.attributes: [
             {
               key.attribute: source.decl.attribute.private
             }
           ],
-          key.effective_access_level: source.decl.effective_access.less_than_fileprivate
-        },
-        {
-          key.kind: source.lang.swift.decl.function.constructor,
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVADycfc",
-          key.line: 52,
-          key.column: 16,
-          key.is_implicit: 1,
-          key.effective_access_level: source.decl.effective_access.fileprivate
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
         }
       ],
       key.attributes: [
@@ -408,69 +874,521 @@
           key.attribute: source.decl.attribute.private
         }
       ],
-      key.effective_access_level: source.decl.effective_access.fileprivate
+      key.effective_access: source.decl.effective_access.fileprivate
     },
     {
       key.kind: source.lang.swift.decl.struct,
       key.name: "ScopeKeeperStruct",
       key.usr: "s:28index_effective_access_level17ScopeKeeperStructV",
-      key.line: 59,
+      key.line: 75,
       key.column: 15,
       key.entities: [
         {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.name: "init(publicInitializer:)",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV17publicInitializerACSi_tcfc",
+          key.line: 76,
+          key.column: 12,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 76,
+              key.column: 36
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access: source.decl.effective_access.public
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.name: "init(internalInitializer:)",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV19internalInitializerACSi_tcfc",
+          key.line: 77,
+          key.column: 5,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 77,
+              key.column: 31
+            }
+          ],
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.name: "init(filePrivateInitializer:)",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV22filePrivateInitializerACSi_tc33_2295DDF1454D6A6D9229E8222CD85214Llfc",
+          key.line: 78,
+          key.column: 17,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 78,
+              key.column: 46
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.name: "init(privateInitializer:)",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV18privateInitializerACSi_tc33_2295DDF1454D6A6D9229E8222CD85214Llfc",
+          key.line: 79,
+          key.column: 13,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 79,
+              key.column: 38
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            }
+          ],
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "publicProperty",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV14publicPropertySivp",
+          key.line: 81,
+          key.column: 16,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV14publicPropertySivg",
+              key.line: 81,
+              key.column: 16,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.public
+                }
+              ],
+              key.effective_access: source.decl.effective_access.public
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV14publicPropertySivs",
+              key.line: 81,
+              key.column: 16,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.public
+                }
+              ],
+              key.effective_access: source.decl.effective_access.public
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access: source.decl.effective_access.public
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 81,
+          key.column: 32
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "internalProperty",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV16internalPropertySivp",
+          key.line: 82,
+          key.column: 9,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV16internalPropertySivg",
+              key.line: 82,
+              key.column: 9,
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.internal
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV16internalPropertySivs",
+              key.line: 82,
+              key.column: 9,
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.internal
+            }
+          ],
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 82,
+          key.column: 27
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "filePrivateProperty",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV19filePrivateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivp",
+          key.line: 83,
+          key.column: 21,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV19filePrivateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivg",
+              key.line: 83,
+              key.column: 21,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.fileprivate
+                }
+              ],
+              key.effective_access: source.decl.effective_access.fileprivate
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV19filePrivateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivs",
+              key.line: 83,
+              key.column: 21,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.fileprivate
+                }
+              ],
+              key.effective_access: source.decl.effective_access.fileprivate
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 83,
+          key.column: 42
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "privateProperty",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV15privateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivp",
+          key.line: 84,
+          key.column: 17,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV15privateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivg",
+              key.line: 84,
+              key.column: 17,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.private
+                }
+              ],
+              key.effective_access: source.decl.effective_access.less_than_fileprivate
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV15privateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivs",
+              key.line: 84,
+              key.column: 17,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.private
+                }
+              ],
+              key.effective_access: source.decl.effective_access.less_than_fileprivate
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            }
+          ],
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 84,
+          key.column: 34
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "publicPropertyWithPrivateSetter",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV31publicPropertyWithPrivateSetterSivp",
+          key.line: 85,
+          key.column: 29,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV31publicPropertyWithPrivateSetterSivg",
+              key.line: 85,
+              key.column: 29,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.setter_access.private
+                },
+                {
+                  key.attribute: source.decl.attribute.public
+                }
+              ],
+              key.effective_access: source.decl.effective_access.public
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructV31publicPropertyWithPrivateSetterSivs",
+              key.line: 85,
+              key.column: 29,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.setter_access.private
+                },
+                {
+                  key.attribute: source.decl.attribute.public
+                }
+              ],
+              key.effective_access: source.decl.effective_access.public
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.setter_access.private
+            },
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access: source.decl.effective_access.public
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 85,
+          key.column: 62
+        },
+        {
+          key.kind: source.lang.swift.decl.function.subscript,
+          key.name: "subscript(_:)",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructVyS2icip",
+          key.line: 87,
+          key.column: 12,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:subscript(_:)",
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructVyS2icig",
+              key.line: 87,
+              key.column: 51,
+              key.effective_access: source.decl.effective_access.public
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 87,
+              key.column: 39
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 87,
+              key.column: 47
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access: source.decl.effective_access.public
+        },
+        {
+          key.kind: source.lang.swift.decl.function.subscript,
+          key.name: "subscript(_:)",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructVXeip",
+          key.line: 88,
+          key.column: 5,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:subscript(_:)",
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructVXeig",
+              key.line: 88,
+              key.column: 46,
+              key.effective_access: source.decl.effective_access.internal
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 88,
+              key.column: 34
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 88,
+              key.column: 42
+            }
+          ],
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.decl.function.subscript,
+          key.name: "subscript(_:)",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llip",
+          key.line: 89,
+          key.column: 17,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:subscript(_:)",
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llig",
+              key.line: 89,
+              key.column: 61,
+              key.effective_access: source.decl.effective_access.fileprivate
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 89,
+              key.column: 49
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 89,
+              key.column: 57
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.subscript,
+          key.name: "subscript(_:)",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llip",
+          key.line: 90,
+          key.column: 13,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:subscript(_:)",
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llig",
+              key.line: 90,
+              key.column: 53,
+              key.effective_access: source.decl.effective_access.less_than_fileprivate
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 90,
+              key.column: 41
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 90,
+              key.column: 49
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            }
+          ],
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
+        },
+        {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "a()",
-          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV1ayyF",
-          key.line: 60,
+          key.name: "publicMethod()",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV12publicMethodyyF",
+          key.line: 92,
           key.column: 17,
           key.attributes: [
             {
               key.attribute: source.decl.attribute.public
             }
           ],
-          key.effective_access_level: source.decl.effective_access.public
+          key.effective_access: source.decl.effective_access.public
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "b()",
-          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV1byyF",
-          key.line: 61,
+          key.name: "internalMethod()",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV14internalMethodyyF",
+          key.line: 93,
           key.column: 10,
-          key.effective_access_level: source.decl.effective_access.internal
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "c()",
-          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV1c33_2295DDF1454D6A6D9229E8222CD85214LLyyF",
-          key.line: 62,
+          key.name: "filePrivateMethod()",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV17filePrivateMethod33_2295DDF1454D6A6D9229E8222CD85214LLyyF",
+          key.line: 94,
           key.column: 22,
           key.attributes: [
             {
               key.attribute: source.decl.attribute.fileprivate
             }
           ],
-          key.effective_access_level: source.decl.effective_access.fileprivate
+          key.effective_access: source.decl.effective_access.fileprivate
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "d()",
-          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV1d33_2295DDF1454D6A6D9229E8222CD85214LLyyF",
-          key.line: 63,
+          key.name: "privateMethod()",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructV13privateMethod33_2295DDF1454D6A6D9229E8222CD85214LLyyF",
+          key.line: 95,
           key.column: 18,
           key.attributes: [
             {
               key.attribute: source.decl.attribute.private
             }
           ],
-          key.effective_access_level: source.decl.effective_access.less_than_fileprivate
-        },
-        {
-          key.kind: source.lang.swift.decl.function.constructor,
-          key.usr: "s:28index_effective_access_level17ScopeKeeperStructVACycfc",
-          key.line: 59,
-          key.column: 15,
-          key.is_implicit: 1,
-          key.effective_access_level: source.decl.effective_access.internal
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
         }
       ],
       key.attributes: [
@@ -478,72 +1396,1164 @@
           key.attribute: source.decl.attribute.public
         }
       ],
-      key.effective_access_level: source.decl.effective_access.public
+      key.effective_access: source.decl.effective_access.public
     },
     {
       key.kind: source.lang.swift.decl.struct,
       key.name: "PartialScopeReducerStruct",
       key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV",
-      key.line: 66,
+      key.line: 98,
       key.column: 8,
       key.entities: [
         {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.name: "init(publicInitializer:)",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV17publicInitializerACSi_tcfc",
+          key.line: 99,
+          key.column: 12,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 99,
+              key.column: 36
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.name: "init(internalInitializer:)",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV19internalInitializerACSi_tcfc",
+          key.line: 100,
+          key.column: 5,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 100,
+              key.column: 31
+            }
+          ],
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.name: "init(filePrivateInitializer:)",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV22filePrivateInitializerACSi_tc33_2295DDF1454D6A6D9229E8222CD85214Llfc",
+          key.line: 101,
+          key.column: 17,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 101,
+              key.column: 46
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.name: "init(privateInitializer:)",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV18privateInitializerACSi_tc33_2295DDF1454D6A6D9229E8222CD85214Llfc",
+          key.line: 102,
+          key.column: 13,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 102,
+              key.column: 38
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            }
+          ],
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "publicProperty",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV14publicPropertySivp",
+          key.line: 104,
+          key.column: 16,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV14publicPropertySivg",
+              key.line: 104,
+              key.column: 16,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.public
+                }
+              ],
+              key.effective_access: source.decl.effective_access.internal
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV14publicPropertySivs",
+              key.line: 104,
+              key.column: 16,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.public
+                }
+              ],
+              key.effective_access: source.decl.effective_access.internal
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 104,
+          key.column: 32
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "internalProperty",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV16internalPropertySivp",
+          key.line: 105,
+          key.column: 9,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV16internalPropertySivg",
+              key.line: 105,
+              key.column: 9,
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.internal
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV16internalPropertySivs",
+              key.line: 105,
+              key.column: 9,
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.internal
+            }
+          ],
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 105,
+          key.column: 27
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "filePrivateProperty",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV19filePrivateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivp",
+          key.line: 106,
+          key.column: 21,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV19filePrivateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivg",
+              key.line: 106,
+              key.column: 21,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.fileprivate
+                }
+              ],
+              key.effective_access: source.decl.effective_access.fileprivate
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV19filePrivateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivs",
+              key.line: 106,
+              key.column: 21,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.fileprivate
+                }
+              ],
+              key.effective_access: source.decl.effective_access.fileprivate
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 106,
+          key.column: 42
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "privateProperty",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV15privateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivp",
+          key.line: 107,
+          key.column: 17,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV15privateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivg",
+              key.line: 107,
+              key.column: 17,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.private
+                }
+              ],
+              key.effective_access: source.decl.effective_access.less_than_fileprivate
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV15privateProperty33_2295DDF1454D6A6D9229E8222CD85214LLSivs",
+              key.line: 107,
+              key.column: 17,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.private
+                }
+              ],
+              key.effective_access: source.decl.effective_access.less_than_fileprivate
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            }
+          ],
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 107,
+          key.column: 34
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "publicPropertyWithPrivateSetter",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV31publicPropertyWithPrivateSetterSivp",
+          key.line: 108,
+          key.column: 29,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV31publicPropertyWithPrivateSetterSivg",
+              key.line: 108,
+              key.column: 29,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.setter_access.private
+                },
+                {
+                  key.attribute: source.decl.attribute.public
+                }
+              ],
+              key.effective_access: source.decl.effective_access.internal
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV31publicPropertyWithPrivateSetterSivs",
+              key.line: 108,
+              key.column: 29,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.setter_access.private
+                },
+                {
+                  key.attribute: source.decl.attribute.public
+                }
+              ],
+              key.effective_access: source.decl.effective_access.internal
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.setter_access.private
+            },
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 108,
+          key.column: 62
+        },
+        {
+          key.kind: source.lang.swift.decl.function.subscript,
+          key.name: "subscript(_:)",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVyS2icip",
+          key.line: 110,
+          key.column: 12,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:subscript(_:)",
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVyS2icig",
+              key.line: 110,
+              key.column: 51,
+              key.effective_access: source.decl.effective_access.internal
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 110,
+              key.column: 39
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 110,
+              key.column: 47
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.decl.function.subscript,
+          key.name: "subscript(_:)",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVXeip",
+          key.line: 111,
+          key.column: 5,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:subscript(_:)",
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVXeig",
+              key.line: 111,
+              key.column: 46,
+              key.effective_access: source.decl.effective_access.internal
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 111,
+              key.column: 34
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 111,
+              key.column: 42
+            }
+          ],
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.decl.function.subscript,
+          key.name: "subscript(_:)",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llip",
+          key.line: 112,
+          key.column: 17,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:subscript(_:)",
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llig",
+              key.line: 112,
+              key.column: 61,
+              key.effective_access: source.decl.effective_access.fileprivate
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 112,
+              key.column: 49
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 112,
+              key.column: 57
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.subscript,
+          key.name: "subscript(_:)",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llip",
+          key.line: 113,
+          key.column: 13,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:subscript(_:)",
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llig",
+              key.line: 113,
+              key.column: 53,
+              key.effective_access: source.decl.effective_access.less_than_fileprivate
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 113,
+              key.column: 41
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 113,
+              key.column: 49
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            }
+          ],
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
+        },
+        {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "a()",
-          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV1ayyF",
-          key.line: 67,
+          key.name: "publicMethod()",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV12publicMethodyyF",
+          key.line: 115,
           key.column: 17,
           key.attributes: [
             {
               key.attribute: source.decl.attribute.public
             }
           ],
-          key.effective_access_level: source.decl.effective_access.internal
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "b()",
-          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV1byyF",
-          key.line: 68,
+          key.name: "internalMethod()",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV14internalMethodyyF",
+          key.line: 116,
           key.column: 10,
-          key.effective_access_level: source.decl.effective_access.internal
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "c()",
-          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV1c33_2295DDF1454D6A6D9229E8222CD85214LLyyF",
-          key.line: 69,
+          key.name: "filePrivateMethod()",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV17filePrivateMethod33_2295DDF1454D6A6D9229E8222CD85214LLyyF",
+          key.line: 117,
           key.column: 22,
           key.attributes: [
             {
               key.attribute: source.decl.attribute.fileprivate
             }
           ],
-          key.effective_access_level: source.decl.effective_access.fileprivate
+          key.effective_access: source.decl.effective_access.fileprivate
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.name: "d()",
-          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV1d33_2295DDF1454D6A6D9229E8222CD85214LLyyF",
-          key.line: 70,
+          key.name: "privateMethod()",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructV13privateMethod33_2295DDF1454D6A6D9229E8222CD85214LLyyF",
+          key.line: 118,
           key.column: 18,
           key.attributes: [
             {
               key.attribute: source.decl.attribute.private
             }
           ],
-          key.effective_access_level: source.decl.effective_access.less_than_fileprivate
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
+        }
+      ],
+      key.effective_access: source.decl.effective_access.internal
+    },
+    {
+      key.kind: source.lang.swift.decl.extension.enum,
+      key.name: "PrivateEnum",
+      key.usr: "s:e:s:28index_effective_access_level11PrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO017privateMethodFromE9ExtensionyyF",
+      key.line: 121,
+      key.column: 19,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.ref.enum,
+          key.name: "PrivateEnum",
+          key.usr: "s:28index_effective_access_level11PrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO",
+          key.line: 121,
+          key.column: 19
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "privateMethodFromPrivateExtension()",
+          key.usr: "s:28index_effective_access_level11PrivateEnum33_2295DDF1454D6A6D9229E8222CD85214LLO017privateMethodFromE9ExtensionyyF",
+          key.line: 122,
+          key.column: 18,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.private
+            }
+          ],
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.private
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.protocol,
+      key.name: "PublicProtocol",
+      key.usr: "s:28index_effective_access_level14PublicProtocolP",
+      key.line: 125,
+      key.column: 17,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "member",
+          key.usr: "s:28index_effective_access_level14PublicProtocolP6memberSivp",
+          key.line: 126,
+          key.column: 9,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:member",
+              key.usr: "s:28index_effective_access_level14PublicProtocolP6memberSivg",
+              key.line: 126,
+              key.column: 23,
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.public
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.name: "setter:member",
+              key.usr: "s:28index_effective_access_level14PublicProtocolP6memberSivs",
+              key.line: 126,
+              key.column: 27,
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.public
+            }
+          ],
+          key.effective_access: source.decl.effective_access.public
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 126,
+          key.column: 17
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "method()",
+          key.usr: "s:28index_effective_access_level14PublicProtocolP6methodyyF",
+          key.line: 127,
+          key.column: 10,
+          key.is_dynamic: 1,
+          key.effective_access: source.decl.effective_access.public
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.public
+        }
+      ],
+      key.effective_access: source.decl.effective_access.public
+    },
+    {
+      key.kind: source.lang.swift.decl.protocol,
+      key.name: "InternalProtocol",
+      key.usr: "s:28index_effective_access_level16InternalProtocolP",
+      key.line: 130,
+      key.column: 10,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "member",
+          key.usr: "s:28index_effective_access_level16InternalProtocolP6memberSivp",
+          key.line: 131,
+          key.column: 9,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:member",
+              key.usr: "s:28index_effective_access_level16InternalProtocolP6memberSivg",
+              key.line: 131,
+              key.column: 23,
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.internal
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.name: "setter:member",
+              key.usr: "s:28index_effective_access_level16InternalProtocolP6memberSivs",
+              key.line: 131,
+              key.column: 27,
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.internal
+            }
+          ],
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 131,
+          key.column: 17
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "method()",
+          key.usr: "s:28index_effective_access_level16InternalProtocolP6methodyyF",
+          key.line: 132,
+          key.column: 10,
+          key.is_dynamic: 1,
+          key.effective_access: source.decl.effective_access.internal
+        }
+      ],
+      key.effective_access: source.decl.effective_access.internal
+    },
+    {
+      key.kind: source.lang.swift.decl.protocol,
+      key.name: "FilePrivateProtocol",
+      key.usr: "s:28index_effective_access_level19FilePrivateProtocol33_2295DDF1454D6A6D9229E8222CD85214LLP",
+      key.line: 135,
+      key.column: 22,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "member",
+          key.usr: "s:28index_effective_access_level19FilePrivateProtocol33_2295DDF1454D6A6D9229E8222CD85214LLP6memberSivp",
+          key.line: 136,
+          key.column: 9,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:member",
+              key.usr: "s:28index_effective_access_level19FilePrivateProtocol33_2295DDF1454D6A6D9229E8222CD85214LLP6memberSivg",
+              key.line: 136,
+              key.column: 23,
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.fileprivate
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.name: "setter:member",
+              key.usr: "s:28index_effective_access_level19FilePrivateProtocol33_2295DDF1454D6A6D9229E8222CD85214LLP6memberSivs",
+              key.line: 136,
+              key.column: 27,
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.fileprivate
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 136,
+          key.column: 17
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "method()",
+          key.usr: "s:28index_effective_access_level19FilePrivateProtocol33_2295DDF1454D6A6D9229E8222CD85214LLP6methodyyF",
+          key.line: 137,
+          key.column: 10,
+          key.is_dynamic: 1,
+          key.effective_access: source.decl.effective_access.fileprivate
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.fileprivate
+        }
+      ],
+      key.effective_access: source.decl.effective_access.fileprivate
+    },
+    {
+      key.kind: source.lang.swift.decl.protocol,
+      key.name: "PrivateProtocol",
+      key.usr: "s:28index_effective_access_level15PrivateProtocol33_2295DDF1454D6A6D9229E8222CD85214LLP",
+      key.line: 140,
+      key.column: 18,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "member",
+          key.usr: "s:28index_effective_access_level15PrivateProtocol33_2295DDF1454D6A6D9229E8222CD85214LLP6memberSivp",
+          key.line: 141,
+          key.column: 9,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:member",
+              key.usr: "s:28index_effective_access_level15PrivateProtocol33_2295DDF1454D6A6D9229E8222CD85214LLP6memberSivg",
+              key.line: 141,
+              key.column: 23,
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.fileprivate
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.name: "setter:member",
+              key.usr: "s:28index_effective_access_level15PrivateProtocol33_2295DDF1454D6A6D9229E8222CD85214LLP6memberSivs",
+              key.line: 141,
+              key.column: 27,
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.fileprivate
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 141,
+          key.column: 17
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "method()",
+          key.usr: "s:28index_effective_access_level15PrivateProtocol33_2295DDF1454D6A6D9229E8222CD85214LLP6methodyyF",
+          key.line: 142,
+          key.column: 10,
+          key.is_dynamic: 1,
+          key.effective_access: source.decl.effective_access.fileprivate
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.private
+        }
+      ],
+      key.effective_access: source.decl.effective_access.fileprivate
+    },
+    {
+      key.kind: source.lang.swift.decl.struct,
+      key.name: "FilePrivateImplementationOfPublicProtocol",
+      key.usr: "s:28index_effective_access_level41FilePrivateImplementationOfPublicProtocol33_2295DDF1454D6A6D9229E8222CD85214LLV",
+      key.line: 145,
+      key.column: 20,
+      key.related: [
+        {
+          key.kind: source.lang.swift.ref.protocol,
+          key.name: "PublicProtocol",
+          key.usr: "s:28index_effective_access_level14PublicProtocolP",
+          key.line: 145,
+          key.column: 63
+        }
+      ],
+      key.entities: [
+        {
+          key.kind: source.lang.swift.ref.protocol,
+          key.name: "PublicProtocol",
+          key.usr: "s:28index_effective_access_level14PublicProtocolP",
+          key.line: 145,
+          key.column: 63
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "member",
+          key.usr: "s:28index_effective_access_level41FilePrivateImplementationOfPublicProtocol33_2295DDF1454D6A6D9229E8222CD85214LLV6memberSivp",
+          key.line: 146,
+          key.column: 21,
+          key.related: [
+            {
+              key.kind: source.lang.swift.ref.var.instance,
+              key.name: "member",
+              key.usr: "s:28index_effective_access_level14PublicProtocolP6memberSivp"
+            }
+          ],
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level41FilePrivateImplementationOfPublicProtocol33_2295DDF1454D6A6D9229E8222CD85214LLV6memberSivg",
+              key.line: 146,
+              key.column: 21,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.fileprivate
+                }
+              ],
+              key.effective_access: source.decl.effective_access.fileprivate
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level41FilePrivateImplementationOfPublicProtocol33_2295DDF1454D6A6D9229E8222CD85214LLV6memberSivs",
+              key.line: 146,
+              key.column: 21,
+              key.is_implicit: 1,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.fileprivate
+                }
+              ],
+              key.effective_access: source.decl.effective_access.fileprivate
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 146,
+          key.column: 29
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "method()",
+          key.usr: "s:28index_effective_access_level41FilePrivateImplementationOfPublicProtocol33_2295DDF1454D6A6D9229E8222CD85214LLV6methodyyF",
+          key.line: 147,
+          key.column: 22,
+          key.related: [
+            {
+              key.kind: source.lang.swift.ref.function.method.instance,
+              key.name: "method()",
+              key.usr: "s:28index_effective_access_level14PublicProtocolP6methodyyF"
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.fileprivate
+            }
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
-          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVACycfc",
-          key.line: 66,
-          key.column: 8,
+          key.usr: "s:28index_effective_access_level41FilePrivateImplementationOfPublicProtocol33_2295DDF1454D6A6D9229E8222CD85214LLV6memberADSi_tcfc",
+          key.line: 145,
+          key.column: 20,
           key.is_implicit: 1,
-          key.effective_access_level: source.decl.effective_access.internal
+          key.effective_access: source.decl.effective_access.fileprivate
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: "s:28index_effective_access_level41FilePrivateImplementationOfPublicProtocol33_2295DDF1454D6A6D9229E8222CD85214LLVADycfc",
+          key.line: 145,
+          key.column: 20,
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.fileprivate
         }
       ],
-      key.effective_access_level: source.decl.effective_access.internal
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.fileprivate
+        }
+      ],
+      key.effective_access: source.decl.effective_access.fileprivate
+    },
+    {
+      key.kind: source.lang.swift.decl.class,
+      key.name: "OpenClass",
+      key.usr: "s:28index_effective_access_level9OpenClassC",
+      key.line: 150,
+      key.column: 12,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "openProperty",
+          key.usr: "s:28index_effective_access_level9OpenClassC12openPropertySivp",
+          key.line: 151,
+          key.column: 14,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:openProperty",
+              key.usr: "s:28index_effective_access_level9OpenClassC12openPropertySivg",
+              key.line: 151,
+              key.column: 32,
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.public
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.open
+            }
+          ],
+          key.effective_access: source.decl.effective_access.public
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 151,
+          key.column: 28
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "publicProperty",
+          key.usr: "s:28index_effective_access_level9OpenClassC14publicPropertySivp",
+          key.line: 152,
+          key.column: 16,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:publicProperty",
+              key.usr: "s:28index_effective_access_level9OpenClassC14publicPropertySivg",
+              key.line: 152,
+              key.column: 36,
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.public
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access: source.decl.effective_access.public
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 152,
+          key.column: 32
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "internalProperty",
+          key.usr: "s:28index_effective_access_level9OpenClassC16internalPropertySivp",
+          key.line: 153,
+          key.column: 9,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:internalProperty",
+              key.usr: "s:28index_effective_access_level9OpenClassC16internalPropertySivg",
+              key.line: 153,
+              key.column: 31,
+              key.is_dynamic: 1,
+              key.effective_access: source.decl.effective_access.internal
+            }
+          ],
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "Int",
+          key.usr: "s:Si",
+          key.line: 153,
+          key.column: 27
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "openMethod()",
+          key.usr: "s:28index_effective_access_level9OpenClassC10openMethodyyF",
+          key.line: 155,
+          key.column: 15,
+          key.is_dynamic: 1,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.open
+            }
+          ],
+          key.effective_access: source.decl.effective_access.public
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "publicMethod()",
+          key.usr: "s:28index_effective_access_level9OpenClassC12publicMethodyyF",
+          key.line: 156,
+          key.column: 17,
+          key.is_dynamic: 1,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ],
+          key.effective_access: source.decl.effective_access.public
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "internalMethod()",
+          key.usr: "s:28index_effective_access_level9OpenClassC14internalMethodyyF",
+          key.line: 157,
+          key.column: 10,
+          key.is_dynamic: 1,
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: "s:28index_effective_access_level9OpenClassCACycfc",
+          key.line: 150,
+          key.column: 12,
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
+        }
+      ],
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.open
+        }
+      ],
+      key.effective_access: source.decl.effective_access.public
+    },
+    {
+      key.kind: source.lang.swift.ref.module,
+      key.name: "Module",
+      key.usr: "c:@M@Module",
+      key.line: 160,
+      key.column: 8
+    },
+    {
+      key.kind: source.lang.swift.decl.struct,
+      key.name: "InternalStruct",
+      key.usr: "s:28index_effective_access_level14InternalStructV",
+      key.line: 162,
+      key.column: 8,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "propertyReferencingPublicClassFromModule",
+          key.usr: "s:28index_effective_access_level14InternalStructV40propertyReferencingPublicClassFromModule0L00lJ0Cvp",
+          key.line: 163,
+          key.column: 9,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level14InternalStructV40propertyReferencingPublicClassFromModule0L00lJ0Cvg",
+              key.line: 163,
+              key.column: 9,
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.internal
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level14InternalStructV40propertyReferencingPublicClassFromModule0L00lJ0Cvs",
+              key.line: 163,
+              key.column: 9,
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.internal
+            }
+          ],
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.ref.module,
+          key.name: "Module",
+          key.usr: "c:@M@Module",
+          key.line: 163,
+          key.column: 51
+        },
+        {
+          key.kind: source.lang.swift.ref.class,
+          key.name: "ModuleClass",
+          key.usr: "s:6Module0A5ClassC",
+          key.line: 163,
+          key.column: 58
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "propertyReferencingPublicClassFromExportedModule",
+          key.usr: "s:28index_effective_access_level14InternalStructV48propertyReferencingPublicClassFromExportedModule0L00lJ0Cvp",
+          key.line: 164,
+          key.column: 9,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:28index_effective_access_level14InternalStructV48propertyReferencingPublicClassFromExportedModule0L00lJ0Cvg",
+              key.line: 164,
+              key.column: 9,
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.internal
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:28index_effective_access_level14InternalStructV48propertyReferencingPublicClassFromExportedModule0L00lJ0Cvs",
+              key.line: 164,
+              key.column: 9,
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.internal
+            }
+          ],
+          key.effective_access: source.decl.effective_access.internal
+        },
+        {
+          key.kind: source.lang.swift.ref.module,
+          key.name: "Exported",
+          key.usr: "c:@M@Exported",
+          key.line: 164,
+          key.column: 59
+        },
+        {
+          key.kind: source.lang.swift.ref.class,
+          key.name: "ExportedClass",
+          key.usr: "s:8Exported0A5ClassC",
+          key.line: 164,
+          key.column: 68
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: "s:28index_effective_access_level14InternalStructV40propertyReferencingPublicClassFromModule0ghijk8ExportedL0AC0L00lJ0C_0M00mJ0Ctcfc",
+          key.line: 162,
+          key.column: 8,
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
+        }
+      ],
+      key.effective_access: source.decl.effective_access.internal
     }
   ]
 }

--- a/test/SourceKit/Indexing/index_enum_case.swift.response
+++ b/test/SourceKit/Indexing/index_enum_case.swift.response
@@ -20,7 +20,8 @@
           key.name: "one",
           key.usr: "s:15index_enum_case1EO3oneyA2CmF",
           key.line: 6,
-          key.column: 10
+          key.column: 10,
+          key.effective_access: source.decl.effective_access.public
         },
         {
           key.kind: source.lang.swift.decl.enumelement,
@@ -36,14 +37,16 @@
               key.line: 6,
               key.column: 22
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.public
         },
         {
           key.kind: source.lang.swift.decl.enumelement,
           key.name: "three",
           key.usr: "s:15index_enum_case1EO5threeyA2CmF",
           key.line: 6,
-          key.column: 31
+          key.column: 31,
+          key.effective_access: source.decl.effective_access.public
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
@@ -80,9 +83,11 @@
                   key.line: 14,
                   key.column: 15
                 }
-              ]
+              ],
+              key.effective_access: source.decl.effective_access.internal
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.ref.struct,
@@ -96,7 +101,8 @@
         {
           key.attribute: source.decl.attribute.public
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.public
     },
     {
       key.kind: source.lang.swift.decl.var.global,
@@ -110,16 +116,19 @@
           key.usr: "s:15index_enum_case1eAA1EOvg",
           key.line: 21,
           key.column: 5,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.accessor.setter,
           key.usr: "s:15index_enum_case1eAA1EOvs",
           key.line: 21,
           key.column: 5,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.ref.enum,
@@ -156,7 +165,8 @@
           key.line: 28,
           key.column: 12
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     }
   ]
 }

--- a/test/SourceKit/Indexing/index_enum_case.swift.response
+++ b/test/SourceKit/Indexing/index_enum_case.swift.response
@@ -83,8 +83,7 @@
                   key.line: 14,
                   key.column: 15
                 }
-              ],
-              key.effective_access: source.decl.effective_access.internal
+              ]
             }
           ],
           key.effective_access: source.decl.effective_access.internal
@@ -116,16 +115,14 @@
           key.usr: "s:15index_enum_case1eAA1EOvg",
           key.line: 21,
           key.column: 5,
-          key.is_implicit: 1,
-          key.effective_access: source.decl.effective_access.internal
+          key.is_implicit: 1
         },
         {
           key.kind: source.lang.swift.decl.function.accessor.setter,
           key.usr: "s:15index_enum_case1eAA1EOvs",
           key.line: 21,
           key.column: 5,
-          key.is_implicit: 1,
-          key.effective_access: source.decl.effective_access.internal
+          key.is_implicit: 1
         }
       ],
       key.effective_access: source.decl.effective_access.internal

--- a/test/SourceKit/Indexing/index_forbid_typecheck.swift.response
+++ b/test/SourceKit/Indexing/index_forbid_typecheck.swift.response
@@ -20,16 +20,19 @@
           key.usr: "s:16forbid_typecheck10globalPrimSivg",
           key.line: 1,
           key.column: 5,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.accessor.setter,
           key.usr: "s:16forbid_typecheck10globalPrimSivs",
           key.line: 1,
           key.column: 5,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.ref.var.global,
@@ -93,7 +96,8 @@
             }
           ]
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     }
   ]
 }

--- a/test/SourceKit/Indexing/index_forbid_typecheck.swift.response
+++ b/test/SourceKit/Indexing/index_forbid_typecheck.swift.response
@@ -20,16 +20,14 @@
           key.usr: "s:16forbid_typecheck10globalPrimSivg",
           key.line: 1,
           key.column: 5,
-          key.is_implicit: 1,
-          key.effective_access: source.decl.effective_access.internal
+          key.is_implicit: 1
         },
         {
           key.kind: source.lang.swift.decl.function.accessor.setter,
           key.usr: "s:16forbid_typecheck10globalPrimSivs",
           key.line: 1,
           key.column: 5,
-          key.is_implicit: 1,
-          key.effective_access: source.decl.effective_access.internal
+          key.is_implicit: 1
         }
       ],
       key.effective_access: source.decl.effective_access.internal

--- a/test/SourceKit/Indexing/index_func_import.swift.response
+++ b/test/SourceKit/Indexing/index_func_import.swift.response
@@ -63,7 +63,8 @@
           key.line: 10,
           key.column: 3
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     }
   ]
 }

--- a/test/SourceKit/Indexing/index_is_test_candidate.swift.response
+++ b/test/SourceKit/Indexing/index_is_test_candidate.swift.response
@@ -13,7 +13,8 @@
       key.name: "test_takesNoParams_andReturnsVoid_butIsNotAnInstanceMethod()",
       key.usr: "s:23index_is_test_candidate0C54_takesNoParams_andReturnsVoid_butIsNotAnInstanceMethodyyF",
       key.line: 10,
-      key.column: 6
+      key.column: 6,
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.struct,
@@ -27,16 +28,19 @@
           key.name: "test_startsWithTest_takesNoParams_returnsVoid_butIsDefinedOnAStruct()",
           key.usr: "s:23index_is_test_candidate8MyStructV0C63_startsWithTest_takesNoParams_returnsVoid_butIsDefinedOnAStructyyF",
           key.line: 13,
-          key.column: 8
+          key.column: 8,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.usr: "s:23index_is_test_candidate8MyStructVACycfc",
           key.line: 12,
           key.column: 8,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -50,9 +54,11 @@
           key.usr: "s:23index_is_test_candidate10XCTestCaseCACycfc",
           key.line: 15,
           key.column: 7,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -83,7 +89,8 @@
           key.usr: "s:23index_is_test_candidate14MyPrivateClass33_E06F4E7BC5F577AB6E2EC6D3ECA1C8B9LLC0c47_startsWithTest_takesNoParams_returnsVoid_butIsF0yyF",
           key.line: 17,
           key.column: 8,
-          key.is_dynamic: 1
+          key.is_dynamic: 1,
+          key.effective_access: source.decl.effective_access.fileprivate
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
@@ -102,7 +109,8 @@
             {
               key.attribute: source.decl.attribute.override
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
         }
       ],
       key.attributes: [
@@ -110,7 +118,8 @@
           key.attribute: source.decl.attribute.private
         }
       ],
-      key.is_test_candidate: 1
+      key.is_test_candidate: 1,
+      key.effective_access: source.decl.effective_access.fileprivate
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -141,7 +150,8 @@
           key.usr: "s:23index_is_test_candidate7MyClassC20doesNotStartWithTestyyF",
           key.line: 21,
           key.column: 8,
-          key.is_dynamic: 1
+          key.is_dynamic: 1,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -158,7 +168,8 @@
               key.line: 22,
               key.column: 50
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -175,7 +186,8 @@
               key.line: 23,
               key.column: 68
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -188,7 +200,8 @@
             {
               key.attribute: source.decl.attribute.private
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -197,7 +210,8 @@
           key.line: 25,
           key.column: 8,
           key.is_dynamic: 1,
-          key.is_test_candidate: 1
+          key.is_test_candidate: 1,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -206,7 +220,8 @@
           key.line: 26,
           key.column: 8,
           key.is_dynamic: 1,
-          key.is_test_candidate: 1
+          key.is_test_candidate: 1,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
@@ -225,7 +240,8 @@
             {
               key.attribute: source.decl.attribute.override
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         }
       ],
       key.attributes: [
@@ -233,7 +249,8 @@
           key.attribute: source.decl.attribute.public
         }
       ],
-      key.is_test_candidate: 1
+      key.is_test_candidate: 1,
+      key.effective_access: source.decl.effective_access.public
     }
   ]
 }

--- a/test/SourceKit/Indexing/index_is_test_candidate_objc.swift.response
+++ b/test/SourceKit/Indexing/index_is_test_candidate_objc.swift.response
@@ -13,7 +13,8 @@
       key.name: "test_takesNoParams_andReturnsVoid_butIsNotAnInstanceMethod()",
       key.usr: "s:28index_is_test_candidate_objc0C54_takesNoParams_andReturnsVoid_butIsNotAnInstanceMethodyyF",
       key.line: 9,
-      key.column: 6
+      key.column: 6,
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.struct,
@@ -27,16 +28,19 @@
           key.name: "test_startsWithTest_takesNoParams_returnsVoid_butIsDefinedOnAStruct()",
           key.usr: "s:28index_is_test_candidate_objc8MyStructV0C63_startsWithTest_takesNoParams_returnsVoid_butIsDefinedOnAStructyyF",
           key.line: 12,
-          key.column: 8
+          key.column: 8,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.usr: "s:28index_is_test_candidate_objc8MyStructVACycfc",
           key.line: 11,
           key.column: 8,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -50,9 +54,11 @@
           key.usr: "s:28index_is_test_candidate_objc10XCTestCaseCACycfc",
           key.line: 14,
           key.column: 7,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -84,7 +90,8 @@
           key.line: 16,
           key.column: 8,
           key.is_dynamic: 1,
-          key.is_test_candidate: 1
+          key.is_test_candidate: 1,
+          key.effective_access: source.decl.effective_access.fileprivate
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
@@ -103,7 +110,8 @@
             {
               key.attribute: source.decl.attribute.override
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.fileprivate
         }
       ],
       key.attributes: [
@@ -111,7 +119,8 @@
           key.attribute: source.decl.attribute.private
         }
       ],
-      key.is_test_candidate: 1
+      key.is_test_candidate: 1,
+      key.effective_access: source.decl.effective_access.fileprivate
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -142,7 +151,8 @@
           key.usr: "s:28index_is_test_candidate_objc7MyClassC20doesNotStartWithTestyyF",
           key.line: 20,
           key.column: 8,
-          key.is_dynamic: 1
+          key.is_dynamic: 1,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -159,7 +169,8 @@
               key.line: 21,
               key.column: 50
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -176,7 +187,8 @@
               key.line: 22,
               key.column: 68
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -190,7 +202,8 @@
               key.attribute: source.decl.attribute.private
             }
           ],
-          key.is_test_candidate: 1
+          key.is_test_candidate: 1,
+          key.effective_access: source.decl.effective_access.less_than_fileprivate
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -199,7 +212,8 @@
           key.line: 24,
           key.column: 8,
           key.is_dynamic: 1,
-          key.is_test_candidate: 1
+          key.is_test_candidate: 1,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -208,7 +222,8 @@
           key.line: 25,
           key.column: 8,
           key.is_dynamic: 1,
-          key.is_test_candidate: 1
+          key.is_test_candidate: 1,
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
@@ -227,7 +242,8 @@
             {
               key.attribute: source.decl.attribute.override
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         }
       ],
       key.attributes: [
@@ -235,7 +251,8 @@
           key.attribute: source.decl.attribute.public
         }
       ],
-      key.is_test_candidate: 1
+      key.is_test_candidate: 1,
+      key.effective_access: source.decl.effective_access.public
     }
   ]
 }

--- a/test/SourceKit/Indexing/index_objcMembers.swift.response
+++ b/test/SourceKit/Indexing/index_objcMembers.swift.response
@@ -28,7 +28,8 @@
               key.line: 6,
               key.column: 9,
               key.is_dynamic: 1,
-              key.is_implicit: 1
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.internal
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
@@ -36,9 +37,11 @@
               key.line: 6,
               key.column: 9,
               key.is_dynamic: 1,
-              key.is_implicit: 1
+              key.is_implicit: 1,
+              key.effective_access: source.decl.effective_access.internal
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.ref.struct,
@@ -58,7 +61,8 @@
             {
               key.attribute: source.decl.attribute.objc
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
@@ -70,14 +74,16 @@
             {
               key.attribute: source.decl.attribute.objc
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         }
       ],
       key.attributes: [
         {
           key.attribute: source.decl.attribute.objcMembers
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     }
   ]
 }

--- a/test/SourceKit/Indexing/index_objcMembers.swift.response
+++ b/test/SourceKit/Indexing/index_objcMembers.swift.response
@@ -28,8 +28,7 @@
               key.line: 6,
               key.column: 9,
               key.is_dynamic: 1,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_implicit: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
@@ -37,8 +36,7 @@
               key.line: 6,
               key.column: 9,
               key.is_dynamic: 1,
-              key.is_implicit: 1,
-              key.effective_access: source.decl.effective_access.internal
+              key.is_implicit: 1
             }
           ],
           key.effective_access: source.decl.effective_access.internal

--- a/test/SourceKit/Indexing/index_operators.swift.response
+++ b/test/SourceKit/Indexing/index_operators.swift.response
@@ -20,9 +20,11 @@
           key.name: "init()",
           key.usr: "s:15index_operators6ClassACACycfc",
           key.line: 5,
-          key.column: 5
+          key.column: 5,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.function.operator.infix,
@@ -52,7 +54,8 @@
           key.line: 8,
           key.column: 37
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.struct,
@@ -111,7 +114,8 @@
               key.column: 19,
               key.receiver_usr: "s:15index_operators7StructBV"
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.operator.infix,
@@ -146,16 +150,19 @@
             {
               key.attribute: source.decl.attribute.public
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.usr: "s:15index_operators7StructBVACycfc",
           key.line: 12,
           key.column: 8,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     }
   ]
 }

--- a/test/SourceKit/Indexing/rdar_21602898.swift.response
+++ b/test/SourceKit/Indexing/rdar_21602898.swift.response
@@ -13,7 +13,8 @@
       key.name: "P",
       key.usr: "s:13rdar_216028981PP",
       key.line: 4,
-      key.column: 10
+      key.column: 10,
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -64,9 +65,11 @@
           key.usr: "s:13rdar_216028981CCACycfc",
           key.line: 5,
           key.column: 7,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     }
   ]
 }

--- a/test/SourceKit/Indexing/sr_3815.swift.response
+++ b/test/SourceKit/Indexing/sr_3815.swift.response
@@ -29,7 +29,8 @@
               key.line: 5,
               key.column: 21
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -37,9 +38,11 @@
           key.usr: "s:7sr_38151PP1fyyF",
           key.line: 6,
           key.column: 8,
-          key.is_dynamic: 1
+          key.is_dynamic: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     },
     {
       key.kind: source.lang.swift.decl.struct,
@@ -78,7 +81,8 @@
               key.line: 10,
               key.column: 21
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -92,16 +96,19 @@
               key.name: "f()",
               key.usr: "s:7sr_38151PP1fyyF"
             }
-          ]
+          ],
+          key.effective_access: source.decl.effective_access.internal
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.usr: "s:7sr_38151SVACycfc",
           key.line: 9,
           key.column: 8,
-          key.is_implicit: 1
+          key.is_implicit: 1,
+          key.effective_access: source.decl.effective_access.internal
         }
-      ]
+      ],
+      key.effective_access: source.decl.effective_access.internal
     }
   ]
 }

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -51,6 +51,7 @@ struct EntityInfo {
   unsigned Line = 0;
   unsigned Column = 0;
   ArrayRef<UIdent> Attrs;
+  Optional<UIdent> EffectiveAccessLevel;
 
   EntityInfo() = default;
 };

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -51,7 +51,7 @@ struct EntityInfo {
   unsigned Line = 0;
   unsigned Column = 0;
   ArrayRef<UIdent> Attrs;
-  Optional<UIdent> EffectiveAccessLevel;
+  Optional<UIdent> EffectiveAccess;
 
   EntityInfo() = default;
 };

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -158,7 +158,7 @@ private:
       case SymbolSubKind::SwiftGenericTypeParam:
         return false;
       default:
-       break;
+        break;
     }
     switch (Kind) {
       case SymbolKind::Enum:

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -135,7 +135,7 @@ private:
       uidAttrs = getDeclAttributeUIDs(symbol.decl);
       info.Attrs = uidAttrs;
       if (auto *VD = dyn_cast<ValueDecl>(symbol.decl)) {
-        if (symbol.symInfo.Kind != SymbolKind::Extension) {
+        if (shouldOutputEffectiveAccessOfValueSymbol(symbol.symInfo)) {
           AccessScope accessScope = VD->getFormalAccessScope();
           UIdent AttrUID = SwiftLangSupport::getUIDForFormalAccessScope(accessScope);
           info.EffectiveAccess = AttrUID;
@@ -143,6 +143,29 @@ private:
       }
     }
     return func(info);
+  }
+
+  bool shouldOutputEffectiveAccessOfValueSymbol(SymbolInfo Info) {
+    SymbolKind Kind = Info.Kind;
+    SymbolSubKind SubKind = Info.SubKind;
+    switch (Kind) {
+      case SymbolKind::Extension:
+        return false;
+     default:
+        break;
+    }
+    switch (SubKind) {
+      case SymbolSubKind::AccessorGetter:
+      case SymbolSubKind::AccessorSetter:
+      case SymbolSubKind::SwiftAccessorWillSet:
+      case SymbolSubKind::SwiftAccessorDidSet:
+      case SymbolSubKind::SwiftAccessorAddressor:
+      case SymbolSubKind::SwiftAccessorMutableAddressor:
+        return false;
+      default:
+       break;
+    }
+    return true;
   }
 
   template <typename F>

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -134,6 +134,13 @@ private:
     if (!isRef) {
       uidAttrs = getDeclAttributeUIDs(symbol.decl);
       info.Attrs = uidAttrs;
+      if (auto *VD = dyn_cast<ValueDecl>(symbol.decl)) {
+        if (symbol.symInfo.Kind != SymbolKind::Extension) {
+          AccessScope accessScope = VD->getFormalAccessScope();
+          UIdent AttrUID = SwiftLangSupport::getUIDForFormalAccessScope(accessScope);
+          info.EffectiveAccessLevel = AttrUID;
+        }
+      }
     }
     return func(info);
   }

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -148,12 +148,6 @@ private:
   bool shouldOutputEffectiveAccessOfValueSymbol(SymbolInfo Info) {
     SymbolKind Kind = Info.Kind;
     SymbolSubKind SubKind = Info.SubKind;
-    switch (Kind) {
-      case SymbolKind::Extension:
-        return false;
-     default:
-        break;
-    }
     switch (SubKind) {
       case SymbolSubKind::AccessorGetter:
       case SymbolSubKind::AccessorSetter:
@@ -161,11 +155,31 @@ private:
       case SymbolSubKind::SwiftAccessorDidSet:
       case SymbolSubKind::SwiftAccessorAddressor:
       case SymbolSubKind::SwiftAccessorMutableAddressor:
+      case SymbolSubKind::SwiftGenericTypeParam:
         return false;
       default:
        break;
     }
-    return true;
+    switch (Kind) {
+      case SymbolKind::Enum:
+      case SymbolKind::Struct:
+      case SymbolKind::Class:
+      case SymbolKind::Protocol:
+      case SymbolKind::Constructor:
+      case SymbolKind::EnumConstant:
+      case SymbolKind::Function:
+      case SymbolKind::StaticMethod:
+      case SymbolKind::Variable:
+      case SymbolKind::InstanceMethod:
+      case SymbolKind::ClassMethod:
+      case SymbolKind::InstanceProperty:
+      case SymbolKind::ClassProperty:
+      case SymbolKind::StaticProperty:
+      case SymbolKind::TypeAlias:
+        return true;
+     default:
+        return false;
+    }
   }
 
   template <typename F>

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -138,7 +138,7 @@ private:
         if (symbol.symInfo.Kind != SymbolKind::Extension) {
           AccessScope accessScope = VD->getFormalAccessScope();
           UIdent AttrUID = SwiftLangSupport::getUIDForFormalAccessScope(accessScope);
-          info.EffectiveAccessLevel = AttrUID;
+          info.EffectiveAccess = AttrUID;
         }
       }
     }

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -819,8 +819,10 @@ UIdent SwiftLangSupport::getUIDForFormalAccessScope(const swift::AccessScope Sco
     return EffectiveAccess_Internal;
   } else if (Scope.isFileScope()) {
     return EffectiveAccess_FilePrivate;
-  } else {
+  } else if (Scope.isPrivate()) {
     return EffectiveAccess_LessThanFilePrivate;
+  } else {
+    llvm_unreachable("Unsupported access scope");
   }
 }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -82,6 +82,10 @@ static UIdent Attr_Setter_FilePrivate("source.decl.attribute.setter_access.filep
 static UIdent Attr_Setter_Internal("source.decl.attribute.setter_access.internal");
 static UIdent Attr_Setter_Public("source.decl.attribute.setter_access.public");
 static UIdent Attr_Setter_Open("source.decl.attribute.setter_access.open");
+static UIdent EffectiveAccess_Public("source.decl.effective_access.public");
+static UIdent EffectiveAccess_Internal("source.decl.effective_access.internal");
+static UIdent EffectiveAccess_FilePrivate("source.decl.effective_access.fileprivate");
+static UIdent EffectiveAccess_LessThanFilePrivate("source.decl.effective_access.less_than_fileprivate");
 
 std::unique_ptr<LangSupport>
 SourceKit::createSwiftLangSupport(SourceKit::Context &SKCtx) {
@@ -806,6 +810,18 @@ Optional<UIdent> SwiftLangSupport::getUIDForDeclAttribute(const swift::DeclAttri
   }
 
   return None;
+}
+
+UIdent SwiftLangSupport::getUIDForFormalAccessScope(const swift::AccessScope Scope) {
+  if (Scope.isPublic()) {
+    return EffectiveAccess_Public;
+  } else if (Scope.isInternal()) {
+    return EffectiveAccess_Internal;
+  } else if (Scope.isFileScope()) {
+    return EffectiveAccess_FilePrivate;
+  } else {
+    return EffectiveAccess_LessThanFilePrivate;
+  }
 }
 
 std::vector<UIdent> SwiftLangSupport::UIDsFromDeclAttributes(const DeclAttributes &Attrs) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -383,6 +383,8 @@ public:
 
   static Optional<UIdent> getUIDForDeclAttribute(const swift::DeclAttribute *Attr);
 
+  static SourceKit::UIdent getUIDForFormalAccessScope(const swift::AccessScope Scope);
+
   static std::vector<UIdent> UIDsFromDeclAttributes(const swift::DeclAttributes &Attrs);
 
   static SourceKit::UIdent getUIDForNameKind(swift::ide::NameKind Kind);

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1355,6 +1355,9 @@ bool SKIndexingConsumer::startSourceEntity(const EntityInfo &Info) {
     }
   }
 
+  if (Info.EffectiveAccessLevel)
+    Elem.set(KeyEffectiveAccessLevel, Info.EffectiveAccessLevel.getValue());
+
   EntitiesStack.push_back({ Info.Kind, Elem, ResponseBuilder::Array(),
                             ResponseBuilder::Array()});
   return true;

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1355,8 +1355,8 @@ bool SKIndexingConsumer::startSourceEntity(const EntityInfo &Info) {
     }
   }
 
-  if (Info.EffectiveAccessLevel)
-    Elem.set(KeyEffectiveAccessLevel, Info.EffectiveAccessLevel.getValue());
+  if (Info.EffectiveAccess)
+    Elem.set(KeyEffectiveAccess, Info.EffectiveAccess.getValue());
 
   EntitiesStack.push_back({ Info.Kind, Elem, ResponseBuilder::Array(),
                             ResponseBuilder::Array()});

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -183,6 +183,7 @@ UID_KEYS = [
         'key.completion_check_dependency_interval'),
     KEY('AnnotatedTypename', 'key.annotated.typename'),
     KEY('CompileOperation', 'key.compile_operation'),
+    KEY('EffectiveAccessLevel', 'key.effective_access_level'),
 ]
 
 

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -183,7 +183,7 @@ UID_KEYS = [
         'key.completion_check_dependency_interval'),
     KEY('AnnotatedTypename', 'key.annotated.typename'),
     KEY('CompileOperation', 'key.compile_operation'),
-    KEY('EffectiveAccessLevel', 'key.effective_access_level'),
+    KEY('EffectiveAccess', 'key.effective_access'),
 ]
 
 


### PR DESCRIPTION
Since enum elements inherit their access level from their parent, the compiler wasn't indexing it:

![Screenshot 2020-05-21 at 19 53 28](https://user-images.githubusercontent.com/11647449/82596292-5a985d80-9ba7-11ea-9d2e-e53a01132b97.png)

This PR makes enum elements rob its parent's access attribute to allow SourceKit to index it as an attribute.

![Screenshot 2020-05-21 at 20 52 45](https://user-images.githubusercontent.com/11647449/82596469-a21ee980-9ba7-11ea-9d9f-1d90cef2033b.png)

I think it makes sense to have this because enum elements do have access levels, it's just that you don't write them explicitly. The context for this PR is that the lack of this property causes a bug in a tool I wrote when I need to determine if an enum element is public or not.

(FYI, the same problem exists in extensions that have the access level defined in the extension itself, instead of its inner methods.)