### PR TITLE
[NFC][SourceManager] Rename line and column APIs for clarity

### DIFF
--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -206,7 +206,7 @@ public:
   ///
   /// This respects \c #sourceLocation directives.
   std::pair<unsigned, unsigned>
-  getLineAndColumn(SourceLoc Loc, unsigned BufferID = 0) const {
+  getPresumedLineAndColumnForLoc(SourceLoc Loc, unsigned BufferID = 0) const {
     assert(Loc.isValid());
     int LineOffset = getLineOffset(Loc);
     int l, c;
@@ -215,14 +215,15 @@ public:
     return { LineOffset + l, c };
   }
 
-  /// Returns the real line number for a source location.
+  /// Returns the real line and column for a source location.
   ///
   /// If \p BufferID is provided, \p Loc must come from that source buffer.
   ///
   /// This does not respect \c #sourceLocation directives.
-  unsigned getLineNumber(SourceLoc Loc, unsigned BufferID = 0) const {
+  std::pair<unsigned, unsigned>
+  getLineAndColumnInBuffer(SourceLoc Loc, unsigned BufferID = 0) const {
     assert(Loc.isValid());
-    return LLVMSourceMgr.FindLineNumber(Loc.Value, BufferID);
+    return LLVMSourceMgr.getLineAndColumn(Loc.Value, BufferID);
   }
 
   StringRef getEntireTextForBuffer(unsigned BufferID) const;

--- a/include/swift/SIL/SILRemarkStreamer.h
+++ b/include/swift/SIL/SILRemarkStreamer.h
@@ -94,7 +94,7 @@ toRemarkLocation(const SourceLoc &loc, const SourceManager &srcMgr) {
 
   StringRef file = srcMgr.getDisplayNameForLoc(loc);
   unsigned line, col;
-  std::tie(line, col) = srcMgr.getLineAndColumn(loc);
+  std::tie(line, col) = srcMgr.getPresumedLineAndColumnForLoc(loc);
   return llvm::remarks::RemarkLocation{file, line, col};
 }
 

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -120,9 +120,9 @@ bool doesRangeableRangeMatch(const T *x, const SourceManager &SM,
   auto const r = getRangeableSourceRange(x);
   if (r.isInvalid())
     return false;
-  if (start && SM.getLineNumber(r.Start) != start)
+  if (start && SM.getLineAndColumnInBuffer(r.Start).first != start)
     return false;
-  if (end && SM.getLineNumber(r.End) != end)
+  if (end && SM.getLineAndColumnInBuffer(r.End).first != end)
     return false;
   if (file.empty())
     return true;
@@ -2122,7 +2122,7 @@ private:
       return;
     auto bufID = SM.findBufferContainingLoc(loc);
     auto f = SM.getIdentifierForBuffer(bufID);
-    auto lin = SM.getLineNumber(loc);
+    auto lin = SM.getLineAndColumnInBuffer(loc).first;
     if (f.endswith(file) && lin == line)
       if (isa<PatternBindingDecl>(D))
         llvm::errs() << "*** catchForDebugging: " << lin << " ***\n";

--- a/lib/AST/ASTScopePrinting.cpp
+++ b/lib/AST/ASTScopePrinting.cpp
@@ -118,8 +118,8 @@ static void printSourceRange(llvm::raw_ostream &out, const SourceRange range,
     return;
   }
 
-  auto startLineAndCol = SM.getLineAndColumn(range.Start);
-  auto endLineAndCol = SM.getLineAndColumn(range.End);
+  auto startLineAndCol = SM.getPresumedLineAndColumnForLoc(range.Start);
+  auto endLineAndCol = SM.getPresumedLineAndColumnForLoc(range.End);
 
   out << "[" << startLineAndCol.first << ":" << startLineAndCol.second << " - "
       << endLineAndCol.first << ":" << endLineAndCol.second << "]";

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -176,9 +176,9 @@ bool ASTScopeImpl::doesRangeMatch(unsigned start, unsigned end, StringRef file,
     return false;
   const auto &SM = getSourceManager();
   const auto r = getSourceRangeOfScope(true);
-  if (start && start != SM.getLineNumber(r.Start))
+  if (start && start != SM.getLineAndColumnInBuffer(r.Start).first)
     return false;
-  if (end && end != SM.getLineNumber(r.End))
+  if (end && end != SM.getLineAndColumnInBuffer(r.End).first)
     return false;
   if (file.empty())
     return true;

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -613,7 +613,7 @@ static unsigned getLineNumber(DCType *DC) {
     return 0;
 
   const ASTContext &ctx = static_cast<const DeclContext *>(DC)->getASTContext();
-  return ctx.SourceMgr.getLineAndColumn(loc).first;
+  return ctx.SourceMgr.getPresumedLineAndColumnForLoc(loc).first;
 }
 
 unsigned DeclContext::printContext(raw_ostream &OS, const unsigned indent,

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1406,7 +1406,7 @@ void RequirementSource::print(llvm::raw_ostream &out,
 
     unsigned bufferID = srcMgr->findBufferContainingLoc(loc);
 
-    auto lineAndCol = srcMgr->getLineAndColumn(loc, bufferID);
+    auto lineAndCol = srcMgr->getPresumedLineAndColumnForLoc(loc, bufferID);
     out << " @ " << lineAndCol.first << ':' << lineAndCol.second;
   };
 

--- a/lib/AST/IncrementalRanges.cpp
+++ b/lib/AST/IncrementalRanges.cpp
@@ -36,7 +36,7 @@ using namespace incremental_ranges;
 
 SerializableSourceLocation::SerializableSourceLocation(
     const SourceLoc loc, const SourceManager &SM) {
-  auto lc = SM.getLineAndColumn(loc);
+  auto lc = SM.getPresumedLineAndColumnForLoc(loc);
   line = lc.first;
   column = lc.second;
 }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -850,7 +850,7 @@ SourceFile::getBasicLocsForDecl(const Decl *D) const {
 
   auto setLineColumn = [&SM](LineColumn &Home, SourceLoc Loc) {
     if (Loc.isValid()) {
-      std::tie(Home.Line, Home.Column) = SM.getLineAndColumn(Loc);
+      std::tie(Home.Line, Home.Column) = SM.getPresumedLineAndColumnForLoc(Loc);
     }
   };
 #define SET(X) setLineColumn(Result.X, D->get##X());

--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -59,10 +59,11 @@ SingleRawComment::SingleRawComment(CharSourceRange Range,
                                    const SourceManager &SourceMgr)
     : Range(Range), RawText(SourceMgr.extractText(Range)),
       Kind(static_cast<unsigned>(getCommentKind(RawText))) {
-  auto StartLineAndColumn = SourceMgr.getLineAndColumn(Range.getStart());
+  auto StartLineAndColumn =
+      SourceMgr.getPresumedLineAndColumnForLoc(Range.getStart());
   StartLine = StartLineAndColumn.first;
   StartColumn = StartLineAndColumn.second;
-  EndLine = SourceMgr.getLineNumber(Range.getEnd());
+  EndLine = SourceMgr.getLineAndColumnInBuffer(Range.getEnd()).first;
 }
 
 SingleRawComment::SingleRawComment(StringRef RawText, unsigned StartColumn)

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -255,7 +255,7 @@ void SourceLoc::printLineAndColumn(raw_ostream &OS, const SourceManager &SM,
     return;
   }
 
-  auto LineAndCol = SM.getLineAndColumn(*this, BufferID);
+  auto LineAndCol = SM.getPresumedLineAndColumnForLoc(*this, BufferID);
   OS << "line:" << LineAndCol.first << ':' << LineAndCol.second;
 }
 
@@ -274,7 +274,7 @@ void SourceLoc::print(raw_ostream &OS, const SourceManager &SM,
     OS << "line";
   }
 
-  auto LineAndCol = SM.getLineAndColumn(*this, BufferID);
+  auto LineAndCol = SM.getPresumedLineAndColumnForLoc(*this, BufferID);
   OS << ':' << LineAndCol.first << ':' << LineAndCol.second;
 }
 

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -447,9 +447,11 @@ DiagnosticVerifier::Result DiagnosticVerifier::verifyFile(unsigned BufferID) {
     if (PrevExpectedContinuationLine)
       Expected.LineNo = PrevExpectedContinuationLine;
     else
-      Expected.LineNo = SM.getLineAndColumn(
-          BufferStartLoc.getAdvancedLoc(MatchStart.data() - InputFile.data()),
-          BufferID).first;
+      Expected.LineNo = SM.getPresumedLineAndColumnForLoc(
+                              BufferStartLoc.getAdvancedLoc(MatchStart.data() -
+                                                            InputFile.data()),
+                              BufferID)
+                            .first;
     Expected.LineNo += LineOffset;
 
     // Check if the next expected diagnostic should be in the same line.
@@ -961,7 +963,7 @@ void DiagnosticVerifier::handleDiagnostic(SourceManager &SM,
   }
 
   if (Info.Loc.isValid()) {
-    const auto lineAndColumn = SM.getLineAndColumn(Info.Loc);
+    const auto lineAndColumn = SM.getPresumedLineAndColumnForLoc(Info.Loc);
     const auto fileName = SM.getDisplayNameForLoc(Info.Loc);
     CapturedDiagnostics.emplace_back(message, fileName, Info.Kind, Info.Loc,
                                      lineAndColumn.first, lineAndColumn.second,

--- a/lib/Frontend/SerializedDiagnosticConsumer.cpp
+++ b/lib/Frontend/SerializedDiagnosticConsumer.cpp
@@ -250,7 +250,7 @@ void SerializedDiagnosticConsumer::addLocToRecord(SourceLoc Loc,
 
   auto bufferId = SM.findBufferContainingLoc(Loc);
   unsigned line, col;
-  std::tie(line, col) = SM.getLineAndColumn(Loc);
+  std::tie(line, col) = SM.getPresumedLineAndColumnForLoc(Loc);
 
   Record.push_back(getEmitFile(Filename));
   Record.push_back(line);

--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -318,7 +318,7 @@ void CommentToXMLConverter::visitDocComment(const DocComment *DC) {
     if (Loc.isValid()) {
       const auto &SM = D->getASTContext().SourceMgr;
       StringRef FileName = SM.getDisplayNameForLoc(Loc);
-      auto LineAndColumn = SM.getLineAndColumn(Loc);
+      auto LineAndColumn = SM.getPresumedLineAndColumnForLoc(Loc);
       OS << " file=\"";
       appendWithXMLEscaping(OS, FileName);
       OS << "\"";

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -392,7 +392,8 @@ bool CompletionInstance::performCachedOperationIfPossible(
     newBufferID = SM.addMemBufferCopy(sourceText, bufferName);
     SM.openVirtualFile(SM.getLocForBufferStart(newBufferID),
                        tmpSM.getDisplayNameForLoc(startLoc),
-                       tmpSM.getLineAndColumn(startLoc).first - 1);
+                       tmpSM.getPresumedLineAndColumnForLoc(startLoc).first -
+                           1);
     SM.setCodeCompletionPoint(newBufferID, newOffset);
 
     // Construct dummy scopes. We don't need to restore the original scope

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -316,7 +316,7 @@ public:
 
   std::pair<unsigned, unsigned> indentLineAndColumn() {
     if (InnermostCtx)
-      return SM.getLineAndColumn(InnermostCtx->ContextLoc);
+      return SM.getPresumedLineAndColumnForLoc(InnermostCtx->ContextLoc);
     return std::make_pair(0, 0);
   }
 

--- a/lib/IDE/IDERequests.cpp
+++ b/lib/IDE/IDERequests.cpp
@@ -320,7 +320,7 @@ void swift::simple_display(llvm::raw_ostream &out, const CursorInfoOwner &owner)
     return;
   auto &SM = owner.File->getASTContext().SourceMgr;
   out << SM.getIdentifierForBuffer(*owner.File->getBufferID());
-  auto LC = SM.getLineAndColumn(owner.Loc);
+  auto LC = SM.getPresumedLineAndColumnForLoc(owner.Loc);
   out << ":" << LC.first << ":" << LC.second;
 }
 
@@ -331,7 +331,7 @@ void swift::ide::simple_display(llvm::raw_ostream &out,
   out << "Resolved cursor info at ";
   auto &SM = info.SF->getASTContext().SourceMgr;
   out << SM.getIdentifierForBuffer(*info.SF->getBufferID());
-  auto LC = SM.getLineAndColumn(info.Loc);
+  auto LC = SM.getPresumedLineAndColumnForLoc(info.Loc);
   out << ":" << LC.first << ":" << LC.second;
 }
 
@@ -1052,8 +1052,8 @@ void swift::simple_display(llvm::raw_ostream &out,
     return;
   auto &SM = owner.File->getASTContext().SourceMgr;
   out << SM.getIdentifierForBuffer(*owner.File->getBufferID());
-  auto SLC = SM.getLineAndColumn(owner.StartLoc);
-  auto ELC = SM.getLineAndColumn(owner.EndLoc);
+  auto SLC = SM.getPresumedLineAndColumnForLoc(owner.StartLoc);
+  auto ELC = SM.getPresumedLineAndColumnForLoc(owner.EndLoc);
   out << ": (" << SLC.first << ":" << SLC.second << ", "
     << ELC.first << ":" << ELC.second << ")";
 }

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -538,8 +538,8 @@ static bool shouldTreatAsSingleToken(const SyntaxStructureNode &Node,
   // Avoid passing the individual syntax tokens corresponding to single-line
   // object literal expressions, as they will be reported as a single token.
   return Node.Kind == SyntaxStructureKind::ObjectLiteralExpression &&
-    SM.getLineNumber(Node.Range.getStart()) ==
-    SM.getLineNumber(Node.Range.getEnd());
+         SM.getLineAndColumnInBuffer(Node.Range.getStart()).first ==
+             SM.getLineAndColumnInBuffer(Node.Range.getEnd()).first;
 }
 
 std::pair<bool, Expr *> ModelASTWalker::walkToExprPre(Expr *E) {

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -602,7 +602,7 @@ private:
   getLineColAndOffset(SourceLoc Loc) {
     if (Loc.isInvalid())
       return std::make_tuple(0, 0, None);
-    auto lineAndColumn = SrcMgr.getLineAndColumn(Loc, BufferID);
+    auto lineAndColumn = SrcMgr.getPresumedLineAndColumnForLoc(Loc, BufferID);
     unsigned offset = SrcMgr.getLocOffsetInBuffer(Loc, BufferID);
     return std::make_tuple(lineAndColumn.first, lineAndColumn.second, offset);
   }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4855,9 +4855,10 @@ ParserStatus Parser::parseLineDirective(bool isLine) {
     diagnose(Tok.getLoc(), diag::extra_tokens_line_directive);
     return makeParserError();
   }
-  
-  int LineOffset = StartLine - SourceMgr.getLineNumber(nextLineStartLoc);
- 
+
+  int LineOffset =
+      StartLine - SourceMgr.getLineAndColumnInBuffer(nextLineStartLoc).first;
+
   // Create a new virtual file for the region started by the #line marker.
   bool isNewFile = SourceMgr.openVirtualFile(nextLineStartLoc,
                                              Filename.getValue(), LineOffset);

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3178,8 +3178,8 @@ Parser::parseTrailingClosures(bool isExprBasic, SourceRange calleeRange,
   // Record the line numbers for the diagnostics below.
   // Note that *do not* move this to after 'parseExprClosure()' it slows down
   // 'getLineNumber()' call because of cache in SourceMgr.
-  auto origLine = SourceMgr.getLineNumber(calleeRange.End);
-  auto braceLine = SourceMgr.getLineNumber(braceLoc);
+  auto origLine = SourceMgr.getLineAndColumnInBuffer(calleeRange.End).first;
+  auto braceLine = SourceMgr.getLineAndColumnInBuffer(braceLoc).first;
 
   ParserStatus result;
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -771,8 +771,8 @@ ParserResult<Stmt> Parser::parseStmtReturn(SourceLoc tryLoc) {
 
     // Issue a warning when the returned expression is on a different line than
     // the return keyword, but both have the same indentation.
-    if (SourceMgr.getLineAndColumn(ReturnLoc).second ==
-        SourceMgr.getLineAndColumn(ExprLoc).second) {
+    if (SourceMgr.getPresumedLineAndColumnForLoc(ReturnLoc).second ==
+        SourceMgr.getPresumedLineAndColumnForLoc(ExprLoc).second) {
       diagnose(ExprLoc, diag::unindented_code_after_return);
       diagnose(ExprLoc, diag::indent_expression_to_silence);
     }

--- a/lib/SIL/IR/SILLocation.cpp
+++ b/lib/SIL/IR/SILLocation.cpp
@@ -140,7 +140,7 @@ SILLocation::DebugLoc SILLocation::decode(SourceLoc Loc,
   DebugLoc DL;
   if (Loc.isValid()) {
     DL.Filename = SM.getDisplayNameForLoc(Loc);
-    std::tie(DL.Line, DL.Column) = SM.getLineAndColumn(Loc);
+    std::tie(DL.Line, DL.Column) = SM.getPresumedLineAndColumnForLoc(Loc);
   }
   return DL;
 }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -710,13 +710,20 @@ public:
       if (SILPrintSourceInfo) {
         auto CurSourceLoc = I.getLoc().getSourceLoc();
         if (CurSourceLoc.isValid()) {
-          if (!PrevLoc || SM.getLineNumber(CurSourceLoc) > SM.getLineNumber(PrevLoc->getSourceLoc())) {
-              auto Buffer = SM.findBufferContainingLoc(CurSourceLoc);
-              auto Line = SM.getLineNumber(CurSourceLoc);
-              auto LineLength = SM.getLineLength(Buffer, Line);
-              PrintState.OS << "  // " << SM.extractText({SM.getLocForLineCol(Buffer, Line, 0), LineLength.getValueOr(0)}) <<
-              "\tSourceLoc: " << SM.getDisplayNameForLoc(CurSourceLoc) << ":" << Line << "\n";
-              PrevLoc = I.getLoc();
+          if (!PrevLoc ||
+              SM.getLineAndColumnInBuffer(CurSourceLoc).first >
+                  SM.getLineAndColumnInBuffer(PrevLoc->getSourceLoc()).first) {
+            auto Buffer = SM.findBufferContainingLoc(CurSourceLoc);
+            auto Line = SM.getLineAndColumnInBuffer(CurSourceLoc).first;
+            auto LineLength = SM.getLineLength(Buffer, Line);
+            PrintState.OS << "  // "
+                          << SM.extractText(
+                                 {SM.getLocForLineCol(Buffer, Line, 0),
+                                  LineLength.getValueOr(0)})
+                          << "\tSourceLoc: "
+                          << SM.getDisplayNameForLoc(CurSourceLoc) << ":"
+                          << Line << "\n";
+            PrevLoc = I.getLoc();
           }
         }
       }

--- a/lib/SIL/IR/SILProfiler.cpp
+++ b/lib/SIL/IR/SILProfiler.cpp
@@ -884,8 +884,8 @@ public:
       assert(Region.hasStartLoc() && "invalid region");
       assert(Region.hasEndLoc() && "incomplete region");
 
-      auto Start = SM.getLineAndColumn(Region.getStartLoc());
-      auto End = SM.getLineAndColumn(Region.getEndLoc());
+      auto Start = SM.getPresumedLineAndColumnForLoc(Region.getStartLoc());
+      auto End = SM.getPresumedLineAndColumnForLoc(Region.getEndLoc());
       assert(Start.first <= End.first && "region start and end out of order");
 
       Regions.emplace_back(Start.first, Start.second, End.first, End.second,

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4881,8 +4881,8 @@ RValue SILGenFunction::emitLiteral(LiteralExpr *literal, SGFContext C) {
       unsigned Value = 0;
       if (Loc.isValid()) {
         Value = magicLiteral->getKind() == MagicIdentifierLiteralExpr::Line
-                    ? ctx.SourceMgr.getLineAndColumn(Loc).first
-                    : ctx.SourceMgr.getLineAndColumn(Loc).second;
+                    ? ctx.SourceMgr.getPresumedLineAndColumnForLoc(Loc).first
+                    : ctx.SourceMgr.getPresumedLineAndColumnForLoc(Loc).second;
       }
 
       auto silTy = SILType::getBuiltinIntegerLiteralType(ctx);

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -145,7 +145,8 @@ auto SILGenFunction::emitSourceLocationArgs(SourceLoc sourceLoc,
   unsigned column = 0;
   if (sourceLoc.isValid()) {
     filename = getMagicFileString(sourceLoc);
-    std::tie(line, column) = ctx.SourceMgr.getLineAndColumn(sourceLoc);
+    std::tie(line, column) =
+        ctx.SourceMgr.getPresumedLineAndColumnForLoc(sourceLoc);
   }
   
   bool isASCII = true;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4426,8 +4426,8 @@ bool ClosureParamDestructuringFailure::diagnoseAsError() {
   // If this is multi-line closure we'd have to insert new lines
   // in the suggested 'let' to keep the structure of the code intact,
   // otherwise just use ';' to keep everything on the same line.
-  auto inLine = sourceMgr.getLineNumber(inLoc);
-  auto bodyLine = sourceMgr.getLineNumber(bodyLoc);
+  auto inLine = sourceMgr.getLineAndColumnInBuffer(inLoc).first;
+  auto bodyLine = sourceMgr.getLineAndColumnInBuffer(bodyLoc).first;
   auto isMultiLineClosure = bodyLine > inLine;
   auto indent =
       bodyStmts.empty() ? "" : Lexer::getIndentationForLine(sourceMgr, bodyLoc);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1110,8 +1110,9 @@ static bool debugConstraintSolverForTarget(
   SourceRange range = target.getSourceRange();
   if (range.isValid()) {
     auto charRange = Lexer::getCharSourceRangeFromSourceRange(C.SourceMgr, range);
-    startLine = C.SourceMgr.getLineNumber(charRange.getStart());
-    endLine = C.SourceMgr.getLineNumber(charRange.getEnd());
+    startLine =
+        C.SourceMgr.getLineAndColumnInBuffer(charRange.getStart()).first;
+    endLine = C.SourceMgr.getLineAndColumnInBuffer(charRange.getEnd()).first;
   }
 
   assert(startLine <= endLine && "expr ends before it starts?");

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3163,8 +3163,8 @@ static void checkSwitch(ASTContext &ctx, const SwitchStmt *stmt) {
         continue;
       
       auto &SM = ctx.SourceMgr;
-      auto prevLineCol = SM.getLineAndColumn(prevLoc);
-      if (SM.getLineNumber(thisLoc) != prevLineCol.first)
+      auto prevLineCol = SM.getPresumedLineAndColumnForLoc(prevLoc);
+      if (SM.getLineAndColumnInBuffer(thisLoc).first != prevLineCol.first)
         continue;
 
       ctx.Diags.diagnose(items[i].getWhereLoc(), diag::where_on_one_item)

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -547,10 +547,11 @@ public:
     }
 
     std::pair<unsigned, unsigned> StartLC =
-        Context.SourceMgr.getLineAndColumn(SR.Start);
+        Context.SourceMgr.getPresumedLineAndColumnForLoc(SR.Start);
 
-    std::pair<unsigned, unsigned> EndLC = Context.SourceMgr.getLineAndColumn(
-        Lexer::getLocForEndOfToken(Context.SourceMgr, SR.End));
+    std::pair<unsigned, unsigned> EndLC =
+        Context.SourceMgr.getPresumedLineAndColumnForLoc(
+            Lexer::getLocForEndOfToken(Context.SourceMgr, SR.End));
 
     Expr *StartLine = IntegerLiteralExpr::createFromUnsigned(Context, StartLC.first);
     Expr *EndLine = IntegerLiteralExpr::createFromUnsigned(Context, EndLC.first);
@@ -617,10 +618,11 @@ public:
     }
 
     std::pair<unsigned, unsigned> StartLC =
-        Context.SourceMgr.getLineAndColumn(SR.Start);
+        Context.SourceMgr.getPresumedLineAndColumnForLoc(SR.Start);
 
-    std::pair<unsigned, unsigned> EndLC = Context.SourceMgr.getLineAndColumn(
-        Lexer::getLocForEndOfToken(Context.SourceMgr, SR.End));
+    std::pair<unsigned, unsigned> EndLC =
+        Context.SourceMgr.getPresumedLineAndColumnForLoc(
+            Lexer::getLocForEndOfToken(Context.SourceMgr, SR.End));
 
     Expr *StartLine = IntegerLiteralExpr::createFromUnsigned(Context, StartLC.first);
     Expr *EndLine = IntegerLiteralExpr::createFromUnsigned(Context, EndLC.first);

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -800,10 +800,11 @@ public:
     }
 
     std::pair<unsigned, unsigned> StartLC =
-        Context.SourceMgr.getLineAndColumn(SR.Start);
+        Context.SourceMgr.getPresumedLineAndColumnForLoc(SR.Start);
 
-    std::pair<unsigned, unsigned> EndLC = Context.SourceMgr.getLineAndColumn(
-        Lexer::getLocForEndOfToken(Context.SourceMgr, SR.End));
+    std::pair<unsigned, unsigned> EndLC =
+        Context.SourceMgr.getPresumedLineAndColumnForLoc(
+            Lexer::getLocForEndOfToken(Context.SourceMgr, SR.End));
 
     Expr *StartLine = IntegerLiteralExpr::createFromUnsigned(Context, StartLC.first);
     Expr *EndLine = IntegerLiteralExpr::createFromUnsigned(Context, EndLC.first);

--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -713,7 +713,7 @@ writer.write<uint32_t>(data.X.Column);
   LineColumn getLineColumn(SourceManager &SM, SourceLoc Loc) {
     LineColumn Result;
     if (Loc.isValid()) {
-      auto LC = SM.getLineAndColumn(Loc);
+      auto LC = SM.getPresumedLineAndColumnForLoc(Loc);
       Result.Line = LC.first;
       Result.Column = LC.second;
     }

--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -136,7 +136,7 @@ void Symbol::serializePosition(StringRef Key, SourceLoc Loc,
                                SourceManager &SourceMgr,
                                llvm::json::OStream &OS) const {
   // Note: Line and columns are zero-based in this serialized format.
-  auto LineAndColumn = SourceMgr.getLineAndColumn(Loc);
+  auto LineAndColumn = SourceMgr.getPresumedLineAndColumnForLoc(Loc);
   auto Line = LineAndColumn.first - 1;
   auto Column = LineAndColumn.second - 1;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -149,7 +149,7 @@ void EditorDiagConsumer::handleDiagnostic(SourceManager &SM,
 
     SKInfo.Offset = SM.getLocOffsetInBuffer(Info.Loc, BufferID);
     std::tie(SKInfo.Line, SKInfo.Column) =
-        SM.getLineAndColumn(Info.Loc, BufferID);
+        SM.getPresumedLineAndColumnForLoc(Info.Loc, BufferID);
     SKInfo.Filename = SM.getDisplayNameForLoc(Info.Loc).str();
 
     for (auto R : Info.Ranges) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1295,7 +1295,7 @@ static void resolveCursor(
         std::vector<RefactoringKind> Scratch;
         RangeConfig Range;
         Range.BufferId = BufferID;
-        auto Pair = SM.getLineAndColumn(Loc);
+        auto Pair = SM.getPresumedLineAndColumnForLoc(Loc);
         Range.Line = Pair.first;
         Range.Column = Pair.second;
         Range.Length = Length;

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1532,7 +1532,7 @@ private:
   void printLoc(SourceLoc Loc, raw_ostream &OS) {
     OS << '@';
     if (Loc.isValid() && SM.findBufferContainingLoc(Loc) == BufferID) {
-      auto LineCol = SM.getLineAndColumn(Loc, BufferID);
+      auto LineCol = SM.getPresumedLineAndColumnForLoc(Loc, BufferID);
       OS  << LineCol.first << ':' << LineCol.second;
     }
   }
@@ -2373,7 +2373,8 @@ public:
       SourceCode = SM.extractText({ SR.Start,
                                     SM.getByteDistance(SR.Start, EndCharLoc) });
       unsigned Column;
-      std::tie(Line, Column) = SM.getLineAndColumn(SR.Start, BufferID);
+      std::tie(Line, Column) =
+          SM.getPresumedLineAndColumnForLoc(SR.Start, BufferID);
     }
 
     OS.indent(IndentLevel * 2);
@@ -2597,7 +2598,7 @@ public:
     if (auto *VD = dyn_cast<ValueDecl>(D)) {
       SourceLoc Loc = D->getLoc();
       if (Loc.isValid()) {
-        auto LineAndColumn = SM.getLineAndColumn(Loc);
+        auto LineAndColumn = SM.getPresumedLineAndColumnForLoc(Loc);
         OS << SM.getDisplayNameForLoc(Loc)
            << ":" << LineAndColumn.first << ":" << LineAndColumn.second << ": ";
       } else {
@@ -2616,7 +2617,7 @@ public:
     } else if (isa<ExtensionDecl>(D)) {
       SourceLoc Loc = D->getLoc();
       if (Loc.isValid()) {
-        auto LineAndColumn = SM.getLineAndColumn(Loc);
+        auto LineAndColumn = SM.getPresumedLineAndColumnForLoc(Loc);
         OS << SM.getDisplayNameForLoc(Loc)
         << ":" << LineAndColumn.first << ":" << LineAndColumn.second << ": ";
       } else {
@@ -2895,7 +2896,7 @@ private:
 
   void printLoc(SourceLoc Loc) {
     if (Loc.isValid()) {
-      auto LineCol = SM.getLineAndColumn(Loc, BufferID);
+      auto LineCol = SM.getPresumedLineAndColumnForLoc(Loc, BufferID);
       OS << LineCol.first << ':' << LineCol.second;
     }
   }

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -864,7 +864,8 @@ int dumpEOFSourceLoc(const char *MainExecutablePath,
 
     // To ensure the correctness of position when translated to line & column
     // pair.
-    if (SourceMgr.getLineAndColumn(EndLoc) != AbPos.getLineAndColumn()) {
+    if (SourceMgr.getPresumedLineAndColumnForLoc(EndLoc) !=
+        AbPos.getLineAndColumn()) {
       llvm::outs() << "locations should be identical";
       return EXIT_FAILURE;
     }

--- a/unittests/Parse/LexerTests.cpp
+++ b/unittests/Parse/LexerTests.cpp
@@ -753,7 +753,7 @@ public:
     llvm::raw_string_ostream DiagOS(DiagMsg);
     DiagnosticEngine::formatDiagnosticText(DiagOS, Info.FormatString,
                                            Info.FormatArgs);
-    auto LC = SM.getLineAndColumn(Info.Loc);
+    auto LC = SM.getPresumedLineAndColumnForLoc(Info.Loc);
     std::ostringstream StrOS;
     StrOS << LC.first << ", " << LC.second << ": " << DiagOS.str();
     messages.push_back(StrOS.str());


### PR DESCRIPTION
getLineAndColumn -> getPresumedLineAndColumnForLoc (respects #sourceLocation )
getLineNumber -> getLineAndColumnInBuffer (doesn't respect #sourceLocation )

This is a purely mechanical change (via Xcode refactoring) that applies some of the renaming suggested in https://forums.swift.org/t/filename-line-and-column-for-sourceloc/5463 by @rintaro . I've also been auditing calls to these methods to find incorrect uses, I'm going to split those into multiple PRs because they'd make this too hard to review.

Some of the other SourceManager API should probably be renamed too, but I think this s a good first step and will help address the most common cases of misuse.