### PR TITLE
[5.3][SourceKit/CodeFormat] Fix var/let declaration continuation lines appearing over-indented.

### DIFF
--- a/test/SourceKit/CodeFormat/indent-multiline-string.swift
+++ b/test/SourceKit/CodeFormat/indent-multiline-string.swift
@@ -17,4 +17,4 @@ this is line1,
 // CHECK: key.sourcetext: "this is line1,"
 // CHECK: key.sourcetext: "     this is line2,"
 // CHECK: key.sourcetext: "\"\"\""
-// CHECK: key.sourcetext: "        \"content\""
+// CHECK: key.sourcetext: "    \"content\""

--- a/test/SourceKit/CodeFormat/rdar_32789463.swift
+++ b/test/SourceKit/CodeFormat/rdar_32789463.swift
@@ -12,5 +12,5 @@ $
 
 // CHECK: key.sourcetext: "struct $ {"
 // CHECK: key.sourcetext: "    let $: <#Type#>"
-// CHECK: key.sourcetext: "        = foo(\"foo \\($) bar\") {"
+// CHECK: key.sourcetext: "    = foo(\"foo \\($) bar\") {"
 // CHECK: key.sourcetext: "    $"

--- a/test/swift-indent/basic.swift
+++ b/test/swift-indent/basic.swift
@@ -68,9 +68,9 @@ test(arg1: 1,
 }
 
 let x = [1, 2, 3]
-        .filter {$0 < $1}
-        .filter {$0 < $1}
-        .filter {$0 < $1}
+    .filter {$0 < $1}
+    .filter {$0 < $1}
+    .filter {$0 < $1}
 
 bax(34949494949)
     .foo(a: Int,
@@ -141,11 +141,11 @@ if #available(
 // do the same.
 //
 let _ = []
-        .map {
-            f {
-                print()
-            } ?? 0
-        }
+    .map {
+        f {
+            print()
+        } ?? 0
+    }
 
 basename
     .foo(a: Int,
@@ -234,10 +234,10 @@ let arrayC = [2]
 let arrayD = [3]
 
 let array1 =
-        arrayA +
-        arrayB +
-        arrayC +
-        arrayD
+    arrayA +
+    arrayB +
+    arrayC +
+    arrayD
 
 array1 =
     arrayA +
@@ -254,9 +254,9 @@ arrayC +
 arrayD
 
 let array2 = arrayA +
-        arrayB +
-        arrayC +
-        arrayD
+    arrayB +
+    arrayC +
+    arrayD
 
 
 // Comments should not break exact alignment, and leading comments should be aligned, rather than the label.
@@ -867,7 +867,7 @@ func foo(
 ) {}
 
 var (d, e):
-        (Int, Int) = (1, 3),
+    (Int, Int) = (1, 3),
     (f, g): (
         Int,
         Int
@@ -1015,3 +1015,24 @@ catch MyErr.a(let code, let message),
 {
     print("ahhh!")
 }
+
+// Pattern binding decls should only column-align if no element spans from the first line to beyond it.
+
+public let x = 10,
+           y = 20
+
+private var firstThing = 20,
+            secondThing = item
+                .filter {},
+            thirdThing = 42
+
+public let myVar = itemWithALongName
+    .filter { $0 >= $1 && $0 - $1 < 50}
+
+public let first = 45, second = itemWithALongName
+    .filter { $0 >= $1 && $0 - $1 < 50}
+
+private var secondThing = item
+    .filter {},
+    firstThing = 20,
+    thirdThing = 56


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/31941 for 5.3

- **Explanation**:
The indentation of pattern binding decls was changed in 5.3 to improve their readability when they include multiple entries by column-aligning the entries and indenting their continuation lines relative to that column too. This change made pattern binding decls with a single entry that continued onto a second line seem over-indented, though, both relative to their surrounding code and to how they were treated in the 5.2 release, and single-entry pattern binding decls are used far more commonly than multiple-entry ones. This change fixes the over-indentation issue by not column-aligning the entries if any entry starts on the same line as the var/let and continues onto a later line. For example:

    ```swift
    // Previous behavior (with the over-indentation issue):
    let foo = someItem
          .getValue(), // Column-alignment (relative to `foo`) looks ok here...
        bar = otherItem
          .getValue()
    
    getAThing()
      .andDoStuffWithIt()
    let foo = someItem
          .getValue() // but looks over-indented with a single entry.
    getOtherThing()
      .andDoStuffWithIt()
    
    // New behavior after this fix:
    getAThing()
      .andDoStuffWithIt()
    let foo = someItem
      .getValue() // No column alignment in this case (good)...
    doOtherThing()
    
    let foo = someItem
      .getValue(), // or in this case (unfortunate, but far less common)...
      bar = otherItem
        .getValue()
    
    let foo = someItem.getValue(),
        bar = otherItem.getValue() // but still column-aligned in this case (good).
    ```

  Using this rule, as opposed to handling single and multi-entry PBDs differently, ensures that the as-typed-out indentation (where it's unclear how many entries the user intends to write) matches the selected-and-reindented indentation for multi-entry pattern binding decls.
- **Scope of issue**: The over-indentation affects all multi-line var/let declarations in Swift source files, and I expect many users would consider it a regression relative to the 5.2 behavior.
- **Origination**: Since the indentation implementation was overhauled in https://github.com/apple/swift/pull/30187
- **Risk**: Low. This only affects sourcekitd (not the compiler), and specifically only its CodeFormat request. It is a targeted fix that only affects the indentation within pattern binding declarations (var/let declarations).
- **Testing**: Updated and added regression tests for this change, regression tests pass, and I manually tested the changes in Xcode.
- **Reviewer**: @benlangmuir (on the master branch PR)

Resolves rdar://problem/63309288