### PR TITLE
PrintAsObjC: Fix crash when printing typedef that was imported inside an Objective-C generic class

### DIFF
--- a/lib/PrintAsObjC/ModuleContentsWriter.cpp
+++ b/lib/PrintAsObjC/ModuleContentsWriter.cpp
@@ -56,7 +56,7 @@ class ReferencedTypeFinder : public TypeDeclFinder {
   Action visitTypeAliasType(TypeAliasType *aliasTy) override {
     if (aliasTy->getDecl()->hasClangNode() &&
         !aliasTy->getDecl()->isCompatibilityAlias()) {
-      assert(!aliasTy->getGenericSignature());
+      assert(!aliasTy->getDecl()->isGeneric());
       Callback(*this, aliasTy->getDecl());
     } else {
       Type(aliasTy->getSinglyDesugaredType()).walk(*this);

--- a/test/PrintAsObjC/Inputs/imported-generic-typealias.h
+++ b/test/PrintAsObjC/Inputs/imported-generic-typealias.h
@@ -1,0 +1,11 @@
+@interface NSObject
+- (void) init;
+@end;
+
+@interface Horse<T> : NSObject
+@end
+
+@interface Barn : NSObject
+@end
+
+typedef int Hay __attribute__((swift_name("Horse.Hay")));

--- a/test/PrintAsObjC/imported-generic-typealias.swift
+++ b/test/PrintAsObjC/imported-generic-typealias.swift
@@ -1,0 +1,14 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %s -typecheck -emit-objc-header-path %t/imported-generic-typealias.h -import-objc-header %S/Inputs/imported-generic-typealias.h -disable-objc-attr-requires-foundation-module
+// RUN: %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PUBLIC %s < %t/imported-generic-typealias.h
+
+@objc public class MyRedBarn : Barn {
+  @objc public func feed(_: Horse<NSObject>.Hay) {}
+}
+
+// CHECK-LABEL: SWIFT_CLASS("_TtC4main9MyRedBarn")
+// CHECK-NEXT: @interface MyRedBarn : Barn
+// CHECK-NEXT: - (void)feed:(Hay)_;
+// CHECK-NEXT: @end


### PR DESCRIPTION
The assertion here is too strict. The TypeAliasDecl will inherit a
generic signature from the outer context even if it does not have
generic parameters of its own. Instead, let's just assert that the
TypeAliasDecl does not have its own generic parameters.

Fixes <rdar://problem/63188938>.