### PR TITLE
NFC: Remove SILParserState from Subsystems

### DIFF
--- a/include/swift/Parse/ParseSILSupport.h
+++ b/include/swift/Parse/ParseSILSupport.h
@@ -20,11 +20,11 @@ namespace swift {
 
   /// Interface between the Parse and ParseSIL libraries, to avoid circular
   /// dependencies.
-  class SILParserTUStateBase {
+  class SILParserStateBase {
     virtual void anchor();
   protected:
-    SILParserTUStateBase() = default;
-    virtual ~SILParserTUStateBase() = default;
+    SILParserStateBase() = default;
+    virtual ~SILParserStateBase() = default;
   public:
     virtual bool parseDeclSIL(Parser &P) = 0;
     virtual bool parseDeclSILStage(Parser &P) = 0;

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -50,7 +50,7 @@ namespace swift {
   class Lexer;
   class ParsedTypeSyntax;
   class PersistentParserState;
-  class SILParserTUStateBase;
+  class SILParserStateBase;
   class ScopeInfo;
   class SourceManager;
   class TupleType;
@@ -114,7 +114,7 @@ public:
   DiagnosticEngine &Diags;
   SourceFile &SF;
   Lexer *L;
-  SILParserTUStateBase *SIL; // Non-null when parsing SIL decls.
+  SILParserStateBase *SIL; // Non-null when parsing SIL decls.
   PersistentParserState *State;
   std::unique_ptr<PersistentParserState> OwnedState;
   DeclContext *CurDeclContext;
@@ -396,14 +396,13 @@ public:
 
 public:
   Parser(unsigned BufferID, SourceFile &SF, DiagnosticEngine* LexerDiags,
-         SILParserTUStateBase *SIL,
-         PersistentParserState *PersistentState,
+         SILParserStateBase *SIL, PersistentParserState *PersistentState,
          std::shared_ptr<SyntaxParseActions> SPActions = nullptr);
-  Parser(unsigned BufferID, SourceFile &SF, SILParserTUStateBase *SIL,
+  Parser(unsigned BufferID, SourceFile &SF, SILParserStateBase *SIL,
          PersistentParserState *PersistentState = nullptr,
          std::shared_ptr<SyntaxParseActions> SPActions = nullptr);
   Parser(std::unique_ptr<Lexer> Lex, SourceFile &SF,
-         SILParserTUStateBase *SIL = nullptr,
+         SILParserStateBase *SIL = nullptr,
          PersistentParserState *PersistentState = nullptr,
          std::shared_ptr<SyntaxParseActions> SPActions = nullptr);
   ~Parser();

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -58,7 +58,6 @@ namespace swift {
   class SerializationOptions;
   class SILOptions;
   class SILModule;
-  class SILParserTUState;
   class SourceFile;
   enum class SourceFileKind;
   class SourceManager;
@@ -73,17 +72,6 @@ namespace swift {
   namespace Lowering {
     class TypeConverter;
   }
-
-  /// Used to optionally maintain SIL parsing context for the parser.
-  ///
-  /// When not parsing SIL, this has no overhead.
-  class SILParserState {
-  public:
-    std::unique_ptr<SILParserTUState> Impl;
-
-    explicit SILParserState(SILModule *M);
-    ~SILParserState();
-  };
 
   /// @{
 

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -96,8 +96,7 @@ BraceStmt *ParseAbstractFunctionBodyRequest::evaluate(
     SourceFile &sf = *afd->getDeclContext()->getParentSourceFile();
     SourceManager &sourceMgr = sf.getASTContext().SourceMgr;
     unsigned bufferID = sourceMgr.findBufferContainingLoc(afd->getLoc());
-    Parser parser(bufferID, sf, static_cast<SILParserTUStateBase *>(nullptr),
-                  nullptr, nullptr);
+    Parser parser(bufferID, sf, /*SIL*/ nullptr);
     parser.SyntaxContext->disable();
     auto body = parser.parseAbstractFunctionBodyDelayed(afd);
     afd->setBodyKind(BodyKind::Parsed);

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -110,7 +110,7 @@ void tokenize(const LangOptions &LangOpts, const SourceManager &SM,
 using namespace swift;
 using namespace swift::syntax;
 
-void SILParserTUStateBase::anchor() { }
+void SILParserStateBase::anchor() { }
 
 void swift::performCodeCompletionSecondPass(
     SourceFile &SF, CodeCompletionCallbacksFactory &Factory) {
@@ -379,14 +379,14 @@ static LexerMode sourceFileKindToLexerMode(SourceFileKind kind) {
   llvm_unreachable("covered switch");
 }
 
-Parser::Parser(unsigned BufferID, SourceFile &SF, SILParserTUStateBase *SIL,
+Parser::Parser(unsigned BufferID, SourceFile &SF, SILParserStateBase *SIL,
                PersistentParserState *PersistentState,
                std::shared_ptr<SyntaxParseActions> SPActions)
     : Parser(BufferID, SF, &SF.getASTContext().Diags, SIL, PersistentState,
              std::move(SPActions)) {}
 
 Parser::Parser(unsigned BufferID, SourceFile &SF, DiagnosticEngine* LexerDiags,
-               SILParserTUStateBase *SIL,
+               SILParserStateBase *SIL,
                PersistentParserState *PersistentState,
                std::shared_ptr<SyntaxParseActions> SPActions)
     : Parser(
@@ -521,8 +521,7 @@ public:
 } // End of an anonymous namespace.
 
 Parser::Parser(std::unique_ptr<Lexer> Lex, SourceFile &SF,
-               SILParserTUStateBase *SIL,
-               PersistentParserState *PersistentState,
+               SILParserStateBase *SIL, PersistentParserState *PersistentState,
                std::shared_ptr<SyntaxParseActions> SPActions)
   : SourceMgr(SF.getASTContext().SourceMgr),
     Diags(SF.getASTContext().Diags),


### PR DESCRIPTION
Since SIL parsing has been requestified, this is now redundant. Remove the type from Subsystems.h, and rename `SILParserTUState` to take its place.
