### PR TITLE
[metadata prespecialization] Prespecialize canonically only in-module.

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -709,8 +709,10 @@ bool irgen::isNominalGenericContextTypeMetadataAccessTrivial(
   }
 
   if (IGM.getSILModule().isWholeModule()) {
-    if (nominal.isResilient(IGM.getSwiftModule(),
-                            ResilienceExpansion::Maximal)) {
+    // Canonical prespecializations can only be emitted within the module where
+    // the generic type is itself defined, since it is the module where the 
+    // metadata accessor is defined.
+    if (IGM.getSwiftModule() != nominal.getModuleContext()) {
       return false;
     }
   } else {
@@ -725,6 +727,11 @@ bool irgen::isNominalGenericContextTypeMetadataAccessTrivial(
         return false;
       }
     }
+  }
+
+  if (nominal.isResilient(IGM.getSwiftModule(),
+                          ResilienceExpansion::Maximal)) {
+    return false;
   }
 
   if (isa<ClassType>(type) || isa<BoundGenericClassType>(type)) {

--- a/test/IRGen/prespecialized-metadata/Inputs/enum-public-nonfrozen-1argument.swift
+++ b/test/IRGen/prespecialized-metadata/Inputs/enum-public-nonfrozen-1argument.swift
@@ -1,0 +1,3 @@
+public enum OneArgument<First> {
+  case first(First)
+}

--- a/test/IRGen/prespecialized-metadata/Inputs/struct-public-nonfrozen-1argument.swift
+++ b/test/IRGen/prespecialized-metadata/Inputs/struct-public-nonfrozen-1argument.swift
@@ -1,0 +1,17 @@
+public struct OneArgument<First> {
+  public let first: First
+
+  public let line: UInt
+
+  public init(_ first: First, line: UInt = #line) {
+    self.first = first
+    self.line = line
+  }
+}
+
+extension OneArgument : CustomStringConvertible {
+  public var description: String {
+    "\(first) @ \(line)"
+  }
+}
+

--- a/test/IRGen/prespecialized-metadata/enum-outmodule-1argument-1distinct_use-struct-inmodule.swift
+++ b/test/IRGen/prespecialized-metadata/enum-outmodule-1argument-1distinct_use-struct-inmodule.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future %S/Inputs/enum-public-nonfrozen-1argument.swift -emit-library -o %t/libArgument.dylib -emit-module -module-name Argument -emit-module-path %t/Argument.swiftmodule
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK-NOT: @"$s8Argument03OneA0Oy4main03TheA0VGMf" =
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+import Argument
+
+struct TheArgument {
+  let value: Int
+}
+
+func doit() {
+  consume( Argument.OneArgument.first(TheArgument(value: 13)) )
+}
+doit()
+

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-inmodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-inmodule.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future %S/Inputs/struct-public-nonfrozen-1argument.swift -emit-library -o %t/libArgument.dylib -emit-module -module-name Argument -emit-module-path %t/Argument.swiftmodule
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK-NOT: @"$s8Argument03OneA0Vy4main03TheA0VGMf" =
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+import Argument
+
+struct TheArgument {
+  let value: Int
+}
+
+func doit() {
+  consume( OneArgument(TheArgument(value: 13)) )
+}
+doit()
+


### PR DESCRIPTION
Previously, prespecialization was incorrectly being performed for non-resilient types defined by other modules.  This is incorrect for statically canonical metadata records because in order to be canonical, they need to be returned from the metadata accessor which is emitted by the module which defines the type.
