### PR TITLE
runtime: repair the android build

### DIFF
--- a/stdlib/public/LLVMSupport/ErrorHandling.cpp
+++ b/stdlib/public/LLVMSupport/ErrorHandling.cpp
@@ -44,7 +44,7 @@ void error(const char *fmt, ...) {
 #if defined(__APPLE__)
   asl_log(nullptr, nullptr, ASL_LEVEL_ERR, "%s", buffer);
 #elif defined(__ANDROID__)
-  __android_log_printf(ANDROID_LOG_FATAL, "SwiftRuntime", "%s", buffer);
+  __android_log_print(ANDROID_LOG_FATAL, "SwiftRuntime", "%s", buffer);
 #elif defined(_WIN32)
 #define STDERR_FILENO 2
   _write(STDERR_FILENO, buffer, strlen(buffer));


### PR DESCRIPTION
The android log symbol is `print` rather than `printf`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
