### PR TITLE
[NFC][SwiftSyntax] Fix 'Traling' typo

### DIFF
--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -424,7 +424,7 @@ EXPR_NODES = [
                    is_optional=True),
              Child('AdditionalTrailingClosures',
                    kind='MultipleTrailingClosureElementList',
-                   collection_element_name='AdditionalTralingClosure',
+                   collection_element_name='AdditionalTrailingClosure',
                    is_optional=True),
          ]),
 
@@ -440,7 +440,7 @@ EXPR_NODES = [
                    is_optional=True),
              Child('AdditionalTrailingClosures',
                    kind='MultipleTrailingClosureElementList',
-                   collection_element_name='AdditionalTralingClosure',
+                   collection_element_name='AdditionalTrailingClosure',
                    is_optional=True),
          ]),
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR amends #31052 to correct a (user-facing?) typo.

swift-syntax: apple/swift-syntax#220

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
