### PR TITLE
[5.3][Property Wrappers] Fix handling of properties that are default initialized via property wrapper

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6484,9 +6484,13 @@ ParamDecl::getDefaultValueStringRepresentation(
           return getASTContext().SourceMgr.extractText(charRange);
         }
 
-        // If there is no parent initializer, we used the default initializer.
-        auto parentInit = original->getParentInitializer();
-        if (!parentInit) {
+        // If there is no initial wrapped value, we used the default initializer.
+        Expr *wrappedValue = nullptr;
+        if (auto *parentInit = original->getParentInitializer())
+          if (auto *placeholder = findWrappedValuePlaceholder(parentInit))
+            wrappedValue = placeholder->getOriginalWrappedValue();
+
+        if (!wrappedValue) {
           if (auto type = original->getPropertyWrapperBackingPropertyType()) {
             if (auto nominal = type->getAnyNominal()) {
               scratch.clear();
@@ -6501,9 +6505,8 @@ ParamDecl::getDefaultValueStringRepresentation(
           return ".init()";
         }
 
-        auto init =
-            findWrappedValuePlaceholder(parentInit)->getOriginalWrappedValue();
-        return extractInlinableText(getASTContext().SourceMgr, init, scratch);
+        auto &sourceMgr = getASTContext().SourceMgr;
+        return extractInlinableText(sourceMgr, wrappedValue, scratch);
       }
     }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4247,6 +4247,8 @@ void SolutionApplicationTarget::maybeApplyPropertyWrapper() {
     if (!outermostWrapperType)
       return;
 
+    bool isImplicit = false;
+
     // Retrieve the outermost wrapper argument. If there isn't one, we're
     // performing default initialization.
     auto outermostArg = outermostWrapperAttr->getArg();
@@ -4254,6 +4256,7 @@ void SolutionApplicationTarget::maybeApplyPropertyWrapper() {
       SourceLoc fakeParenLoc = outermostWrapperAttr->getRange().End;
       outermostArg = TupleExpr::createEmpty(
           ctx, fakeParenLoc, fakeParenLoc, /*Implicit=*/true);
+      isImplicit = true;
     }
 
     auto typeExpr = TypeExpr::createImplicitHack(
@@ -4264,7 +4267,7 @@ void SolutionApplicationTarget::maybeApplyPropertyWrapper() {
         outermostWrapperAttr->getArgumentLabels(),
         outermostWrapperAttr->getArgumentLabelLocs(),
         /*hasTrailingClosure=*/false,
-        /*implicit=*/false);
+        /*implicit=*/isImplicit);
   }
   wrapperAttrs[0]->setSemanticInit(backingInitializer);
 

--- a/test/decl/var/property_wrappers_default_init.swift
+++ b/test/decl/var/property_wrappers_default_init.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -print-ast %s | %FileCheck %s
+
+@propertyWrapper
+struct Wrapper {
+  init() {}
+
+  var wrappedValue: Int = 0
+}
+
+// CHECK-LABEL: internal struct UseWrapperDefaultInit
+struct UseWrapperDefaultInit {
+  @Wrapper var value
+  // CHECK: internal init(value: Wrapper = Wrapper())
+}
+
+let _ = UseWrapperDefaultInit()
+


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/31949

Reviewer: @DougGregor 

---

- In `ParamDecl::getDefaultValueStringRepresentation `, only attempt to extract the text for an initial wrapped value if the property has a wrapped value placeholder in the initializer call. Otherwise, the compiler will crash when serializing the memberwise initializer.
- For properties that are implicitly default initialized via property wrapper (without `()` on the property wrapper attribute), mark the init call as implicit. There are assertions elsewhere (e.g. in `SemaAnnotator::handleCustomAttributes`) that expect an explicit argument on the custom attribute if the initializer is not implicit.

Resolves: rdar://problem/59471019
