### PR TITLE
[5.3][NFC][SwiftSyntax] Fix 'Traling' typo

### DIFF
--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -424,7 +424,7 @@ EXPR_NODES = [
                    is_optional=True),
              Child('AdditionalTrailingClosures',
                    kind='MultipleTrailingClosureElementList',
-                   collection_element_name='AdditionalTralingClosure',
+                   collection_element_name='AdditionalTrailingClosure',
                    is_optional=True),
          ]),
 
@@ -440,7 +440,7 @@ EXPR_NODES = [
                    is_optional=True),
              Child('AdditionalTrailingClosures',
                    kind='MultipleTrailingClosureElementList',
-                   collection_element_name='AdditionalTralingClosure',
+                   collection_element_name='AdditionalTrailingClosure',
                    is_optional=True),
          ]),
 


### PR DESCRIPTION
Cherry-pick of #31957 into `release/5.3`

* **Explanation**: This amends #31052 to correct a typo in user-facing API name for multiple trailing closures
* **Scope**: libSyntax and SwiftSyntax API
* **Risk**: Very Low. The affected APIs haven't been publicly released
* **Issue**: rdar://problem/63523343
* **Testing**: Passed the test suite
* **Reviewer**: Rintaro Ishizaki(@rintaro)

Changes for swift-syntax repo: apple/swift-syntax#221