### PR TITLE
Account for Deserialized VarDecls in Setter Mismatch Diagnostics

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2338,8 +2338,9 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
         diags.diagnose(witness, diag::protocol_witness_settable_conflict);
     if (auto VD = dyn_cast<VarDecl>(witness)) {
       if (VD->hasStorage()) {
-        auto PBD = VD->getParentPatternBinding();
-        diag.fixItReplace(PBD->getStartLoc(), getTokenText(tok::kw_var));
+        if (auto PBD = VD->getParentPatternBinding()) {
+          diag.fixItReplace(PBD->getStartLoc(), getTokenText(tok::kw_var));
+        }
       }
     }
     break;

--- a/test/decl/protocol/req/Inputs/witness_fix_its_other_module.swift
+++ b/test/decl/protocol/req/Inputs/witness_fix_its_other_module.swift
@@ -1,0 +1,7 @@
+public protocol OtherOS {
+  var name: String { get }
+}
+
+public struct Linux: OtherOS {
+  public let name = "Linux"
+}


### PR DESCRIPTION
If the setter conflict occurs in a deserialized declaration, the parent
pattern binding can be NULL. Guard the fixit on the existence of the
pattern binding so

1) we don't crash
2) we don't try to emit a fixit in otherwise extremely broken code

rdar://56558082