### PR TITLE
[5.3] Add all the ptrauth IR attributes that Clang does

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1028,11 +1028,14 @@ void IRGenModule::constructInitialFnAttributes(llvm::AttrBuilder &Attrs,
   if (FuncOptMode == OptimizationMode::ForSize)
     Attrs.addAttribute(llvm::Attribute::MinSize);
 
-  auto triple = llvm::Triple(ClangOpts.Triple);
-  if (triple.getArchName() == "arm64e") {
+  if (IRGen.Opts.PointerAuth.ReturnAddresses)
     Attrs.addAttribute("ptrauth-returns");
+  if (IRGen.Opts.PointerAuth.FunctionPointers)
     Attrs.addAttribute("ptrauth-calls");
-  }
+  if (IRGen.Opts.PointerAuth.IndirectGotos)
+    Attrs.addAttribute("ptrauth-indirect-gotos");
+  if (IRGen.Opts.PointerAuth.AuthTraps)
+    Attrs.addAttribute("ptrauth-auth-traps");
 }
 
 llvm::AttributeList IRGenModule::constructInitialAttributes() {

--- a/test/IRGen/ptrauth-functions.sil
+++ b/test/IRGen/ptrauth-functions.sil
@@ -87,4 +87,4 @@ bb0(%0 : $T):
 
 sil_vtable F {
 }
-// CHECK: #[[ATTRS]] = {{{.*}} "ptrauth-calls" "ptrauth-returns"
+// CHECK: #[[ATTRS]] = {{{.*}} "ptrauth-auth-traps" "ptrauth-calls" "ptrauth-indirect-gotos" "ptrauth-returns"


### PR DESCRIPTION
A more modest fix for rdar://63289339 for the 5.3 release.  The fix I made on master, #31906, potentially changes a lot of other attributes and so has a substantial amount of extra risk.  The risk for this PR is really just the inherent risk of guaranteeing traps during auths.