### PR TITLE
[5.3] IRGen: Always eliminate frame pointers of leaf functions

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -194,6 +194,7 @@ public:
   unsigned DisableLLVMSLPVectorizer : 1;
 
   /// Disable frame pointer elimination?
+  unsigned DisableFPElimLeaf : 1;
   unsigned DisableFPElim : 1;
   
   /// Special codegen for playgrounds.
@@ -322,6 +323,7 @@ public:
         DisableClangModuleSkeletonCUs(false), UseJIT(false),
         IntegratedREPL(false), DisableLLVMOptzns(false),
         DisableSwiftSpecificLLVMOptzns(false), DisableLLVMSLPVectorizer(false),
+        DisableFPElimLeaf(false),
         DisableFPElim(true), Playground(false), EmitStackPromotionChecks(false),
         FunctionSections(false), PrintInlineTree(false), EmbedMode(IRGenEmbedMode::None),
         HasValueNamesSetting(false), ValueNames(false),

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1012,6 +1012,10 @@ def enable_private_imports : Flag<["-"], "enable-private-imports">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
   HelpText<"Allows this module's internal and private API to be accessed">;
 
+def disable_leaf_frame_pointer_elim : Flag<["-"], "no-omit-leaf-frame-pointer">,
+  Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
+  HelpText<"Don't omit the frame pointer for leaf functions">;
+
 def sanitize_EQ : CommaJoined<["-"], "sanitize=">,
   Flags<[FrontendOption, NoInteractiveOption]>, MetaVarName<"<check>">,
   HelpText<"Turn on runtime checks for erroneous behavior.">;

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -289,6 +289,8 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
       arguments.push_back("-enable-anonymous-context-mangled-names");
   }
 
+  inputArgs.AddLastArg(arguments, options::OPT_disable_leaf_frame_pointer_elim);
+
   // Pass through any subsystem flags.
   inputArgs.AddAllArgs(arguments, options::OPT_Xllvm);
   inputArgs.AddAllArgs(arguments, options::OPT_Xcc);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1477,6 +1477,9 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
         getRuntimeCompatVersion();
   }
 
+  if (Args.hasArg(OPT_disable_leaf_frame_pointer_elim))
+    Opts.DisableFPElimLeaf = true;
+
   return false;
 }
 

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -90,24 +90,25 @@ static llvm::PointerType *createStructPointerType(IRGenModule &IGM,
 };
 
 static clang::CodeGenOptions::FramePointerKind
-shouldUseFramePointer(const IRGenOptions &Opts) {
+shouldUseFramePointer(const IRGenOptions &Opts, const llvm::Triple &triple) {
   if (Opts.DisableFPElim) {
     // General frame pointer elimination is disabled.
     // Should we at least eliminate in leaf functions?
+    // Currently we only do that on arm64 (this matches the behavior of clang).
     return Opts.DisableFPElimLeaf
                ? clang::CodeGenOptions::FramePointerKind::All
-               : clang::CodeGenOptions::FramePointerKind::NonLeaf;
+               : triple.isAArch64()
+                     ? clang::CodeGenOptions::FramePointerKind::NonLeaf
+                     : clang::CodeGenOptions::FramePointerKind::All;
   }
 
   return clang::CodeGenOptions::FramePointerKind::None;
-
 }
 
-static clang::CodeGenerator *createClangCodeGenerator(ASTContext &Context,
-                                                 llvm::LLVMContext &LLVMContext,
-                                                      const IRGenOptions &Opts,
-                                                      StringRef ModuleName,
-                                                      StringRef PD) {
+static clang::CodeGenerator *
+createClangCodeGenerator(ASTContext &Context, llvm::LLVMContext &LLVMContext,
+                         const IRGenOptions &Opts, StringRef ModuleName,
+                         StringRef PD, const llvm::Triple &triple) {
   auto Loader = Context.getClangModuleLoader();
   auto *Importer = static_cast<ClangImporter*>(&*Loader);
   assert(Importer && "No clang module loader!");
@@ -115,7 +116,7 @@ static clang::CodeGenerator *createClangCodeGenerator(ASTContext &Context,
 
   auto &CGO = Importer->getClangCodeGenOpts();
   CGO.OptimizationLevel = Opts.shouldOptimize() ? 3 : 0;
-  CGO.setFramePointer(shouldUseFramePointer(Opts));
+  CGO.setFramePointer(shouldUseFramePointer(Opts, triple));
   CGO.DiscardValueNames = !Opts.shouldProvideValueNames();
   switch (Opts.DebugInfoLevel) {
   case IRGenDebugInfoLevel::None:
@@ -205,17 +206,17 @@ static void sanityCheckStdlib(IRGenModule &IGM) {
 
 IRGenModule::IRGenModule(IRGenerator &irgen,
                          std::unique_ptr<llvm::TargetMachine> &&target,
-                         SourceFile *SF,
-                         StringRef ModuleName, StringRef OutputFilename,
+                         SourceFile *SF, StringRef ModuleName,
+                         StringRef OutputFilename,
                          StringRef MainInputFilenameForDebugInfo,
                          StringRef PrivateDiscriminator)
-    : LLVMContext(new llvm::LLVMContext()),
-      IRGen(irgen), Context(irgen.SIL.getASTContext()),
+    : LLVMContext(new llvm::LLVMContext()), IRGen(irgen),
+      Context(irgen.SIL.getASTContext()),
       // The LLVMContext (and the IGM itself) will get deleted by the IGMDeleter
       // as long as the IGM is registered with the IRGenerator.
-      ClangCodeGen(createClangCodeGenerator(Context, *LLVMContext,
-                                            irgen.Opts,
-                                            ModuleName, PrivateDiscriminator)),
+      ClangCodeGen(createClangCodeGenerator(Context, *LLVMContext, irgen.Opts,
+                                            ModuleName, PrivateDiscriminator,
+                                            irgen.getEffectiveClangTriple())),
       Module(*ClangCodeGen->GetModule()),
       DataLayout(irgen.getClangDataLayout()),
       Triple(irgen.getEffectiveClangTriple()), TargetMachine(std::move(target)),
@@ -995,8 +996,20 @@ bool swift::irgen::shouldRemoveTargetFeature(StringRef feature) {
 
 void IRGenModule::setHasFramePointer(llvm::AttrBuilder &Attrs,
                                      bool HasFramePointer) {
-  auto UseFramePointer = IRGen.Opts.DisableFPElimLeaf ? "all" : "non-leaf";
-  Attrs.addAttribute("frame-pointer", HasFramePointer ? UseFramePointer : "none");
+  if (!HasFramePointer) {
+    Attrs.addAttribute("frame-pointer", "none");
+    return;
+  }
+  if (IRGen.Opts.DisableFPElimLeaf) {
+    Attrs.addAttribute("frame-pointer", "all");
+    return;
+  }
+
+  // We omit frame pointers for leaf functions only for arm64 for now (matching
+  // clang's behavior).
+  auto framePointer =
+      IRGen.getEffectiveClangTriple().isAArch64() ? "non-leaf" : "all";
+  Attrs.addAttribute("frame-pointer", framePointer);
 }
 
 void IRGenModule::setHasFramePointer(llvm::Function *F,

--- a/test/IRGen/c_globals.swift
+++ b/test/IRGen/c_globals.swift
@@ -31,5 +31,5 @@ public func testCaptureGlobal() {
   }) // CHECK: {{^}$}}
 }
 
-// CHECK-DAG: attributes [[CLANG_FUNC_ATTR]] = { noinline nounwind {{.*}}"frame-pointer"="non-leaf"{{.*}}
-// CHECK-DAG: attributes [[SWIFT_FUNC_ATTR]] = { {{.*}}"frame-pointer"="non-leaf" {{.*}}"target-cpu"
+// CHECK-DAG: attributes [[CLANG_FUNC_ATTR]] = { noinline nounwind {{.*}}"frame-pointer"="all"{{.*}}
+// CHECK-DAG: attributes [[SWIFT_FUNC_ATTR]] = { {{.*}}"frame-pointer"="all" {{.*}}"target-cpu"

--- a/test/IRGen/c_globals.swift
+++ b/test/IRGen/c_globals.swift
@@ -32,4 +32,4 @@ public func testCaptureGlobal() {
 }
 
 // CHECK-DAG: attributes [[CLANG_FUNC_ATTR]] = { noinline nounwind {{.*}}"frame-pointer"="all"{{.*}}
-// CHECK-DAG: attributes [[SWIFT_FUNC_ATTR]] = { "frame-pointer"="all" {{.*}}"target-cpu"
+// CHECK-DAG: attributes [[SWIFT_FUNC_ATTR]] = { {{.*}}"frame-pointer"="non-leaf" {{.*}}"target-cpu"

--- a/test/IRGen/c_globals.swift
+++ b/test/IRGen/c_globals.swift
@@ -31,5 +31,5 @@ public func testCaptureGlobal() {
   }) // CHECK: {{^}$}}
 }
 
-// CHECK-DAG: attributes [[CLANG_FUNC_ATTR]] = { noinline nounwind {{.*}}"frame-pointer"="all"{{.*}}
+// CHECK-DAG: attributes [[CLANG_FUNC_ATTR]] = { noinline nounwind {{.*}}"frame-pointer"="non-leaf"{{.*}}
 // CHECK-DAG: attributes [[SWIFT_FUNC_ATTR]] = { {{.*}}"frame-pointer"="non-leaf" {{.*}}"target-cpu"

--- a/test/IRGen/framepointer.sil
+++ b/test/IRGen/framepointer.sil
@@ -1,0 +1,62 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -no-omit-leaf-frame-pointer| %FileCheck %s --check-prefix=CHECK-ALL
+// RUN: %target-swift-frontend -primary-file %s -S | %FileCheck %s  --check-prefix=CHECKASM --check-prefix=CHECKASM-%target-os-%target-cpu
+
+sil_stage canonical
+
+import Swift
+
+sil @leaf_function_no_frame_pointer : $@convention(thin) (Int32) -> Int32 {
+entry(%i : $Int32):
+  return %i : $Int32
+}
+
+sil @non_leaf_function_with_frame_pointer : $@convention(thin) (Int32) -> Int32 {
+entry(%i : $Int32):
+  %f = function_ref @leaf_function_no_frame_pointer : $@convention(thin) (Int32) -> Int32
+  %r = apply %f(%i) : $@convention(thin) (Int32) -> Int32
+  return %r : $Int32
+}
+
+// CHECK: define{{.*}} swiftcc i32 @leaf_function_no_frame_pointer(i32 %0) [[ATTR:#.*]] {
+// CHECK: entry:
+// CHECK:   ret i32 %0
+// CHECK: }
+
+// CHECK: define{{.*}} swiftcc i32 @non_leaf_function_with_frame_pointer(i32 %0) [[ATTR]] {
+// CHECK: entry:
+// CHECK:   %1 = call swiftcc i32 @leaf_function_no_frame_pointer(i32 %0)
+// CHECK:   ret i32 %1
+// CHECK: }
+
+// CHECK: attributes [[ATTR]] = {{{.*}}"frame-pointer"="non-leaf"
+
+// CHECK-ALL: define{{.*}} swiftcc i32 @leaf_function_no_frame_pointer(i32 %0) [[ATTR:#.*]] {
+// CHECK-ALL: entry:
+// CHECK-ALL:   ret i32 %0
+// CHECK-ALL: }
+
+// CHECK-ALL: define{{.*}} swiftcc i32 @non_leaf_function_with_frame_pointer(i32 %0) [[ATTR]] {
+// CHECK-ALL: entry:
+// CHECK-ALL:   %1 = call swiftcc i32 @leaf_function_no_frame_pointer(i32 %0)
+// CHECK-ALL:   ret i32 %1
+// CHECK-ALL: }
+
+// CHECK-ALL: attributes [[ATTR]] = {{{.*}}"frame-pointer"="all"
+
+// Silence other os-archs.
+// CHECKASM: {{.*}}
+
+// CHECKASM-macosx-x86_64-LABEL: _leaf_function_no_frame_pointer:
+// CHECKASM-macosx-x86_64-NOT: push
+// CHECKASM-macosx-x86_64: movl    %edi, %eax
+// CHECKASM-macosx-x86_64-NOT: pop
+// CHECKASM-macosx-x86_64: ret
+
+
+// CHECKASM-macosx-x86_64-LABEL: _non_leaf_function_with_frame_pointer:
+// CHECKASM-macosx-x86_64:   pushq %rbp
+// CHECKASM-macosx-x86_64:   movq %rsp, %rbp
+// CHECKASM-macosx-x86_64:   callq _leaf_function_no_frame_pointer
+// CHECKASM-macosx-x86_64:   popq %rbp
+// CHECKASM-macosx-x86_64:   ret

--- a/test/IRGen/framepointer_arm64.sil
+++ b/test/IRGen/framepointer_arm64.sil
@@ -1,8 +1,12 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK
-// RUN: %target-swift-frontend -primary-file %s -emit-ir -no-omit-leaf-frame-pointer| %FileCheck %s --check-prefix=CHECK-ALL
-// RUN: %target-swift-frontend -primary-file %s -S | %FileCheck %s  --check-prefix=CHECKASM --check-prefix=CHECKASM-%target-os-%target-cpu
+// RUN: %target-swift-frontend -target arm64-apple-ios8.0 -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK
+// RUN: %target-swift-frontend -target arm64-apple-ios8.0 -primary-file %s -emit-ir -no-omit-leaf-frame-pointer| %FileCheck %s --check-prefix=CHECK-ALL
+// RUN: %target-swift-frontend -target arm64-apple-ios8.0 -primary-file %s -S | %FileCheck %s --check-prefix=CHECKASM
+// RUN: %target-swift-frontend -target arm64-apple-ios8.0 -primary-file %s -S -no-omit-leaf-frame-pointer | %FileCheck %s --check-prefix=CHECKASM-ALL
 
-// REQUIRES: CPU=x86_64
+// REQUIRES: CODEGENERATOR=AArch64
+
+// UNSUPPORTED: OS=linux
+// UNSUPPORTED: OS=windows
 
 sil_stage canonical
 
@@ -31,7 +35,7 @@ entry(%i : $Int32):
 // CHECK:   ret i32 %1
 // CHECK: }
 
-// CHECK: attributes [[ATTR]] = {{{.*}}"frame-pointer"="all"
+// CHECK: attributes [[ATTR]] = {{{.*}}"frame-pointer"="non-leaf"
 
 // CHECK-ALL: define{{.*}} swiftcc i32 @leaf_function_no_frame_pointer(i32 %0) [[ATTR:#.*]] {
 // CHECK-ALL: entry:
@@ -46,19 +50,24 @@ entry(%i : $Int32):
 
 // CHECK-ALL: attributes [[ATTR]] = {{{.*}}"frame-pointer"="all"
 
-// Silence other os-archs.
-// CHECKASM: {{.*}}
+// CHECKASM-LABEL: _leaf_function_no_frame_pointer:
+// CHECKASM-NOT: stp
+// CHECKASM-NOT: ldp
+// CHECKASM: ret
 
-// CHECKASM-macosx-x86_64-LABEL: _leaf_function_no_frame_pointer:
-// CHECKASM-macosx-x86_64: push
-// CHECKASM-macosx-x86_64: movl    %edi, %eax
-// CHECKASM-macosx-x86_64: pop
-// CHECKASM-macosx-x86_64: ret
+// CHECKASM-LABEL: _non_leaf_function_with_frame_pointer:
+// CHECKASM: stp
+// CHECKASM: _leaf_function_no_frame_pointer
+// CHECKASM: ldp
+// CHECKASM: ret
 
+// CHECKASM-ALL-LABEL: _leaf_function_no_frame_pointer:
+// CHECKASM-ALL: stp
+// CHECKASM-ALL: ldp
+// CHECKASM-ALL: ret
 
-// CHECKASM-macosx-x86_64-LABEL: _non_leaf_function_with_frame_pointer:
-// CHECKASM-macosx-x86_64:   pushq %rbp
-// CHECKASM-macosx-x86_64:   movq %rsp, %rbp
-// CHECKASM-macosx-x86_64:   callq _leaf_function_no_frame_pointer
-// CHECKASM-macosx-x86_64:   popq %rbp
-// CHECKASM-macosx-x86_64:   ret
+// CHECKASM-ALL-LABEL: _non_leaf_function_with_frame_pointer:
+// CHECKASM-ALL: stp
+// CHECKASM-ALL: _leaf_function_no_frame_pointer
+// CHECKASM-ALL: ldp
+// CHECKASM-ALL: ret

--- a/test/IRGen/framepointer_arm64.sil
+++ b/test/IRGen/framepointer_arm64.sil
@@ -5,7 +5,7 @@
 
 // REQUIRES: CODEGENERATOR=AArch64
 
-// UNSUPPORTED: OS=linux
+// UNSUPPORTED: OS=linux-gnu
 // UNSUPPORTED: OS=windows
 
 sil_stage canonical

--- a/test/Misc/tbi.sil
+++ b/test/Misc/tbi.sil
@@ -19,19 +19,13 @@
 
 // NO_TBI-LABEL: .globl  _testTBI
 // NO_TBI: _testTBI
-// NO_TBI-NEXT: stp
-// NO_TBI-NEXT: mov
 // NO_TBI-NEXT: and
 // NO_TBI-NEXT: ldr
-// NO_TBI-NEXT: ldp
 // NO_TBI-NEXT: ret
 
 // TBI-LABEL: .globl  _testTBI
 // TBI: _testTBI:
-// TBI-NEXT: stp
-// TBI-NEXT: mov
 // TBI-NEXT: ldr
-// TBI-NEXT: ldp
 // TBI-NEXT: ret
 
 sil_stage canonical


### PR DESCRIPTION
Explanation: This change makes it such that we don't emit frame pointers
in leaf functions leading to decreased code size and improved
performance.

Scope: Should not visibly affect Swift programs other than making them
faster.

Risk: Medium. There might be unknown dependencies on having the frame
pointer available in leaf functions.

Testing: Unit test added

Reviewer: Andrew Trick

rdar://20933449