### PR TITLE
[ConstraintSystem] Disallow use of enum case as a key path component

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -557,6 +557,9 @@ ERROR(expr_keypath_mutating_getter,none,
 ERROR(expr_keypath_static_member,none,
       "%select{key path|dynamic key path member lookup}1 cannot refer to static member %0",
       (DeclName, bool))
+ERROR(expr_keypath_enum_case,none,
+      "%select{key path|dynamic key path member lookup}1 cannot refer to enum case %0",
+      (DeclName, bool))
 ERROR(expr_keypath_empty,none,
       "empty key path does not refer to a property", ())
 ERROR(expr_unsupported_objc_key_path_component,none,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4859,6 +4859,12 @@ bool InvalidStaticMemberRefInKeyPath::diagnoseAsError() {
   return true;
 }
 
+bool InvalidEnumCaseRefInKeyPath::diagnoseAsError() {
+  emitDiagnostic(diag::expr_keypath_enum_case, getName(),
+                 isForKeyPathDynamicMemberLookup());
+  return true;
+}
+
 bool InvalidMemberWithMutatingGetterInKeyPath::diagnoseAsError() {
   emitDiagnostic(diag::expr_keypath_mutating_getter, getName(),
                  isForKeyPathDynamicMemberLookup());

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1524,6 +1524,25 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose an attempt to reference an enum case as a key path component
+/// e.g.
+///
+/// ```swift
+/// enum E {
+///   case foo
+/// }
+///
+/// _ = \E.Type.foo
+/// ```
+class InvalidEnumCaseRefInKeyPath final : public InvalidMemberRefInKeyPath {
+public:
+  InvalidEnumCaseRefInKeyPath(const Solution &solution, ValueDecl *member,
+                              ConstraintLocator *locator)
+      : InvalidMemberRefInKeyPath(solution, member, locator) {}
+
+  bool diagnoseAsError() override;
+};
+
 /// Diagnose an attempt to reference a member which has a mutating getter as a
 /// key path component e.g.
 ///

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -767,6 +767,11 @@ bool AllowInvalidRefInKeyPath::diagnose(const Solution &solution,
     return failure.diagnose(asNote);
   }
 
+  case RefKind::EnumCase: {
+    InvalidEnumCaseRefInKeyPath failure(solution, Member, getLocator());
+    return failure.diagnose(asNote);
+  }
+
   case RefKind::MutatingGetter: {
     InvalidMemberWithMutatingGetterInKeyPath failure(solution, Member,
                                                      getLocator());
@@ -790,6 +795,12 @@ AllowInvalidRefInKeyPath::forRef(ConstraintSystem &cs, ValueDecl *member,
   if (isa<FuncDecl>(member))
     return AllowInvalidRefInKeyPath::create(cs, RefKind::Method, member,
                                             locator);
+
+  // Referencing enum cases in key path is not currently allowed.
+  if (isa<EnumElementDecl>(member)) {
+    return AllowInvalidRefInKeyPath::create(cs, RefKind::EnumCase, member,
+                                            locator);
+  }
 
   // Referencing initializers in key path is not currently allowed.
   if (isa<ConstructorDecl>(member))

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -1330,6 +1330,8 @@ class AllowInvalidRefInKeyPath final : public ConstraintFix {
     // Allow a reference to a initializer instance as a key path
     // component.
     Initializer,
+    // Allow a reference to an enum case as a key path component.
+    EnumCase,
   } Kind;
 
   ValueDecl *Member;
@@ -1351,6 +1353,8 @@ public:
       return "allow reference to a method as a key path component";
     case RefKind::Initializer:
       return "allow reference to an init method as a key path component";
+    case RefKind::EnumCase:
+      return "allow reference to an enum case as a key path component";
     }
     llvm_unreachable("covered switch");
   }

--- a/validation-test/compiler_crashers_2_fixed/sr12863.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr12863.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -typecheck %s -verify
+
+enum E {
+    case bar
+}
+
+@dynamicMemberLookup
+struct S {
+    subscript(dynamicMember key: KeyPath<E.Type, E>) -> Bool { true }
+}
+
+
+let s = S()
+let e = s.bar // expected-error {{dynamic key path member lookup cannot refer to enum case 'bar'}}


### PR DESCRIPTION
Using an enum case as key path component is not supported, but we fail to diagnose this in some cases. For example, when using dynamic member lookup:

```swift
enum E {
  case bar
}

@dynamicMemberLookup
struct S {
  subscript(dynamicMember key: KeyPath<E.Type, E>) -> Bool { true }
}


let s = S()
let e = s.bar // crash
```

The above code currently causes a compiler crash on master and 5.3.

Resolves SR-12863