### PR TITLE
Propagate `-vfsoverlay` from driver to frontend.

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -180,6 +180,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
 
   inputArgs.AddAllArgs(arguments, options::OPT_I);
   inputArgs.AddAllArgs(arguments, options::OPT_F, options::OPT_Fsystem);
+  inputArgs.AddAllArgs(arguments, options::OPT_vfsoverlay);
 
   inputArgs.AddLastArg(arguments, options::OPT_AssertConfig);
   inputArgs.AddLastArg(arguments, options::OPT_autolink_force_load);

--- a/test/Driver/vfs.swift
+++ b/test/Driver/vfs.swift
@@ -1,0 +1,9 @@
+// Verifies that the driver passes the -vfsoverlay flag to the frontend (SR-12834).
+// RUN: %swiftc_driver -driver-print-jobs -c -vfsoverlay overlay.yaml %s | %FileCheck --check-prefix=CHECK-ONE %s
+
+// CHECK-ONE: bin{{/|\\\\}}swift{{c?(\.exe)?"?}} -frontend{{.*}}-c{{.*}}-vfsoverlay overlay.yaml
+
+// Verifies that multiple occurrences are passed in order.
+// RUN: %swiftc_driver -driver-print-jobs -c -vfsoverlay overlay1.yaml -vfsoverlay overlay2.yaml -vfsoverlay overlay3.yaml %s | %FileCheck --check-prefix=CHECK-MULTIPLE %s
+
+// CHECK-MULTIPLE: bin{{/|\\\\}}swift{{c?(\.exe)?"?}} -frontend{{.*}}-c{{.*}}-vfsoverlay overlay1.yaml -vfsoverlay overlay2.yaml -vfsoverlay overlay3.yaml


### PR DESCRIPTION
Today, the driver does not propagate the flag to the frontend but also does not emit an error (silently consuming the flag instead).

I'll open a similar PR for [apple/swift-driver](https://github.com/apple/swift-driver) once this one is merged, in case there are any issues that need to be worked out first.

Fixes SR-12834.
