### PR TITLE
[5.3] OOB read in demangler with corrupted input

### DIFF
--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -564,8 +564,7 @@ protected:
   NodePointer demangleValueWitness();
 
   NodePointer demangleTypeMangling();
-  NodePointer demangleSymbolicReference(unsigned char rawKind,
-                                        const void *at);
+  NodePointer demangleSymbolicReference(unsigned char rawKind);
 
   bool demangleBoundGenerics(Vector<NodePointer> &TypeListList,
                              NodePointer &RetroactiveConformances);

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -677,12 +677,14 @@ NodePointer Demangler::demangleTypeMangling() {
   return TypeMangling;
 }
 
-NodePointer Demangler::demangleSymbolicReference(unsigned char rawKind,
-                                                 const void *at) {
+NodePointer Demangler::demangleSymbolicReference(unsigned char rawKind) {
   // The symbolic reference is a 4-byte machine integer encoded in the following
   // four bytes.
+  if (Pos + 4 > Text.size())
+    return nullptr;
+  const void *at = Text.data() + Pos;
   int32_t value;
-  memcpy(&value, Text.data() + Pos, 4);
+  memcpy(&value, at, 4);
   Pos += 4;
   
   // Map the encoded kind to a specific kind and directness.
@@ -734,7 +736,7 @@ recur:
       goto recur;
     case 1: case 2:   case 3:   case 4:   case 5: case 6: case 7: case 8:
     case 9: case 0xA: case 0xB: case 0xC:
-      return demangleSymbolicReference((unsigned char)c, Text.data() + Pos);
+      return demangleSymbolicReference((unsigned char)c);
     case 'A': return demangleMultiSubstitutions();
     case 'B': return demangleBuiltinType();
     case 'C': return demangleAnyGenericType(Node::Kind::Class);


### PR DESCRIPTION
Request to merge PR #31793 to release/5.3 branch.


*Original description*: A malformed mangled name that ends in a truncated symbolic reference could trigger a read beyond the end of the name.  This is because the code that grabs the next four bytes bypasses the existing bounds checks.  Insert an explicit bounds check to guard against this.

*Risk*: Minor.  It adds a check to see if we're about to read past the end-of-input and ends the parse if so.

*Testing*:  Ran validation tests locally, verified by original reporter.

Resolves rdar://63511132
