### PR TITLE
Extend AllocBoxToStack to handle apply

### DIFF
--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -29,12 +29,17 @@
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Statistic.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 using namespace swift;
 
 STATISTIC(NumStackPromoted, "Number of alloc_box's promoted to the stack");
 
-//===----------------------------------------------------------------------===//
+static llvm::cl::opt<unsigned> MaxLocalApplyRecurDepth(
+    "max-local-apply-recur-depth", llvm::cl::init(4),
+    llvm::cl::desc("Mac recursove depth for analyzing local functions"));
+
+//===-----------------------------------------------------------------------===//
 //                 SIL Utilities for alloc_box Promotion
 //===----------------------------------------------------------------------===//
 
@@ -276,37 +281,72 @@ static bool partialApplyEscapes(SILValue V, bool examineApply) {
 }
 
 static SILInstruction *findUnexpectedBoxUse(SILValue Box,
-                                            bool examinePartialApply,
                                             bool inAppliedFunction,
-                                            SmallVectorImpl<Operand *> &);
+                                            SmallVectorImpl<Operand *> &,
+                                            SmallPtrSetImpl<SILFunction *> &,
+                                            unsigned CurrentRecurDepth);
 
-/// checkPartialApplyBody - Check the body of a partial apply to see
+/// checkLocalApplyBody - Check the body of an apply's callee to see
 /// if the box pointer argument passed to it has uses that would
 /// disqualify it from being promoted to a stack location.  Return
-/// true if this partial apply will not block our promoting the box.
-static bool checkPartialApplyBody(Operand *O) {
+/// true if this apply will not block our promoting the box.
+static bool checkLocalApplyBody(Operand *O,
+                                SmallVectorImpl<Operand *> &PromotedOperands,
+                                SmallPtrSetImpl<SILFunction *> &VisitedCallees,
+                                unsigned CurrentRecurDepth) {
   SILFunction *F = ApplySite(O->getUser()).getReferencedFunctionOrNull();
   // If we cannot examine the function body, assume the worst.
   if (!F || F->empty())
     return false;
 
-  // We don't actually use these because we're not recursively
-  // rewriting the partial applies we find.
-  SmallVector<Operand *, 1> PromotedOperands;
+  auto iter = VisitedCallees.insert(F);
+  if (!iter.second)
+    return false;
+
   auto calleeArg = F->getArgument(ApplySite(O->getUser()).getCalleeArgIndex(*O));
-  return !findUnexpectedBoxUse(calleeArg, /* examinePartialApply = */ false,
-                               /* inAppliedFunction = */ true,
-                               PromotedOperands);
+  auto res =
+      !findUnexpectedBoxUse(calleeArg,
+                            /* inAppliedFunction = */ true, PromotedOperands,
+                            VisitedCallees, CurrentRecurDepth + 1);
+  return res;
+}
+
+// Returns true if a callee is eligible to be cloned and rewritten for
+// AllocBoxToStack opt. We don't want to increase code size, so this is
+// restricted only for private local functions currently.
+static bool isEligibleApply(ApplySite Apply) {
+  auto callee = Apply.getReferencedFunctionOrNull();
+  if (!callee) {
+    return false;
+  }
+
+  // Callee should be optimizable.
+  if (!callee->shouldOptimize())
+    return false;
+
+  // External function definitions.
+  if (!callee->isDefinition())
+    return false;
+
+  // Do not optimize always_inlinable functions.
+  if (callee->getInlineStrategy() == Inline_t::AlwaysInline)
+    return false;
+
+  if (callee->getLinkage() != SILLinkage::Private) {
+    return false;
+  }
+  return true;
 }
 
 /// Validate that the uses of a pointer to a box do not eliminate it from
 /// consideration for promotion to a stack element. Optionally examine the body
-/// of partial_apply to see if there is an unexpected use inside.  Return the
-/// instruction with the unexpected use if we find one.
+/// of an ApplySite to see if there is an unexpected use inside.
+/// Return the instruction with the unexpected use if we find one.
 static SILInstruction *
-findUnexpectedBoxUse(SILValue Box, bool examinePartialApply,
-                     bool inAppliedFunction,
-                     SmallVectorImpl<Operand *> &PromotedOperands) {
+findUnexpectedBoxUse(SILValue Box, bool inAppliedFunction,
+                     SmallVectorImpl<Operand *> &PromotedOperands,
+                     SmallPtrSetImpl<SILFunction *> &VisitedCallees,
+                     unsigned CurrentRecurDepth = 0) {
   assert((Box->getType().is<SILBoxType>()
           || Box->getType()
                  == SILType::getNativeObjectType(Box->getType().getASTContext()))
@@ -338,15 +378,32 @@ findUnexpectedBoxUse(SILValue Box, bool examinePartialApply,
       continue;
     }
 
-    // For partial_apply, if we've been asked to examine the body, the
-    // uses of the argument are okay there, and the partial_apply
-    // itself cannot escape, then everything is fine.
-    if (auto *PAI = dyn_cast<PartialApplyInst>(User))
-      if (examinePartialApply && checkPartialApplyBody(Op) &&
-          !partialApplyEscapes(PAI, /* examineApply = */ true)) {
-        LocalPromotedOperands.push_back(Op);
-        continue;
+    if (auto Apply = ApplySite::isa(User)) {
+      if (CurrentRecurDepth > MaxLocalApplyRecurDepth) {
+        return User;
       }
+      switch (Apply.getKind()) {
+      case ApplySiteKind::PartialApplyInst: {
+        if (checkLocalApplyBody(Op, LocalPromotedOperands, VisitedCallees,
+                                CurrentRecurDepth) &&
+            !partialApplyEscapes(cast<PartialApplyInst>(User),
+                                 /* examineApply = */ true)) {
+          LocalPromotedOperands.push_back(Op);
+          continue;
+        }
+        break;
+      }
+      case ApplySiteKind::ApplyInst:
+      case ApplySiteKind::BeginApplyInst:
+      case ApplySiteKind::TryApplyInst:
+        if (isEligibleApply(Apply) &&
+            checkLocalApplyBody(Op, LocalPromotedOperands, VisitedCallees,
+                                CurrentRecurDepth)) {
+          LocalPromotedOperands.push_back(Op);
+          continue;
+        }
+      }
+    }
 
     return User;
   }
@@ -365,12 +422,13 @@ static InFlightDiagnostic diagnose(ASTContext &Context, SourceLoc loc,
 /// canPromoteAllocBox - Can we promote this alloc_box to an alloc_stack?
 static bool canPromoteAllocBox(AllocBoxInst *ABI,
                                SmallVectorImpl<Operand *> &PromotedOperands) {
+  SmallPtrSet<SILFunction *, 8> VisitedCallees;
   // Scan all of the uses of the address of the box to see if any
   // disqualifies the box from being promoted to the stack.
   if (auto *User = findUnexpectedBoxUse(ABI,
-                                        /* examinePartialApply = */ true,
                                         /* inAppliedFunction = */ false,
-                                        PromotedOperands)) {
+                                        PromotedOperands, VisitedCallees,
+                                        /* CurrentRecurDepth = */ 0)) {
     (void)User;
     // Otherwise, we have an unexpected use.
     LLVM_DEBUG(llvm::dbgs() << "*** Failed to promote alloc_box in @"
@@ -558,6 +616,9 @@ private:
   void visitStrongRetainInst(StrongRetainInst *Inst);
   void visitCopyValueInst(CopyValueInst *Inst);
   void visitProjectBoxInst(ProjectBoxInst *Inst);
+  void checkNoPromotedBoxInApply(ApplySite Apply);
+#define APPLYSITE_INST(Name, Parent) void visit##Name(Name *Inst);
+#include "swift/SIL/SILNodes.def"
 };
 } // end anonymous namespace
 
@@ -680,9 +741,12 @@ PromotedParamCloner::populateCloned() {
       OrigPromotedParameters.insert(*I);
 
       NewPromotedArgs[ArgNo] = promotedArg;
-
-      // All uses of the promoted box should either be projections, which are
-      // folded when visited, or copy/destroy operations which are ignored.
+      // We only promote boxes used in apply or projections or copy/destroy
+      // value operations.
+      // We should never see an apply user of the box, because we rewrite the
+      // applies and specialize the callees in dfs order.
+      // Projection users are folded when visited and copy/destroy operations
+      // are ignored.
       entryArgs.push_back(SILValue());
     } else {
       // Create a new argument which copies the original argument.
@@ -762,34 +826,61 @@ void PromotedParamCloner::visitProjectBoxInst(ProjectBoxInst *Inst) {
   SILCloner<PromotedParamCloner>::visitProjectBoxInst(Inst);
 }
 
-/// Specialize a partial_apply by promoting the parameters indicated by
+// While cloning during specialization, make sure apply instructions do not have
+// box arguments that need to be promoted.
+// This is an assertion in debug builds only. This should never be true because
+// we process apply callees that take promotable boxes in dfs order
+void PromotedParamCloner::checkNoPromotedBoxInApply(ApplySite Apply) {
+#ifndef NDEBUG
+  for (auto &O : Apply.getArgumentOperands()) {
+    assert(OrigPromotedParameters.count(O.get()) == 0);
+  }
+#endif
+}
+void PromotedParamCloner::visitApplyInst(ApplyInst *Inst) {
+  checkNoPromotedBoxInApply(Inst);
+  SILCloner<PromotedParamCloner>::visitApplyInst(Inst);
+}
+void PromotedParamCloner::visitBeginApplyInst(BeginApplyInst *Inst) {
+  checkNoPromotedBoxInApply(Inst);
+  SILCloner<PromotedParamCloner>::visitBeginApplyInst(Inst);
+}
+void PromotedParamCloner::visitPartialApplyInst(PartialApplyInst *Inst) {
+  checkNoPromotedBoxInApply(Inst);
+  SILCloner<PromotedParamCloner>::visitPartialApplyInst(Inst);
+}
+void PromotedParamCloner::visitTryApplyInst(TryApplyInst *Inst) {
+  checkNoPromotedBoxInApply(Inst);
+  SILCloner<PromotedParamCloner>::visitTryApplyInst(Inst);
+}
+
+/// Specialize ApplySite by promoting the parameters indicated by
 /// indices. We expect these parameters to be replaced by stack address
 /// references.
-static PartialApplyInst *
-specializePartialApply(SILOptFunctionBuilder &FuncBuilder,
-                       PartialApplyInst *PartialApply,
-                       ArgIndexList &PromotedCalleeArgIndices,
-                       AllocBoxToStackState &pass) {
-  auto *FRI = cast<FunctionRefInst>(PartialApply->getCallee());
-  assert(FRI && "Expected a direct partial_apply!");
+static SILInstruction *specializeApply(SILOptFunctionBuilder &FuncBuilder,
+                                       ApplySite Apply,
+                                       ArgIndexList &PromotedCalleeArgIndices,
+                                       AllocBoxToStackState &pass) {
+  auto *FRI = cast<FunctionRefInst>(Apply.getCallee());
+  assert(FRI && "Expected a direct ApplySite");
   auto *F = FRI->getReferencedFunctionOrNull();
   assert(F && "Expected a referenced function!");
 
   IsSerialized_t Serialized = IsNotSerialized;
-  if (PartialApply->getFunction()->isSerialized())
+  if (Apply.getFunction()->isSerialized())
     Serialized = IsSerializable;
 
   std::string ClonedName =
     getClonedName(F, Serialized, PromotedCalleeArgIndices);
 
-  auto &M = PartialApply->getModule();
+  auto &M = Apply.getModule();
 
   SILFunction *ClonedFn;
   if (auto *PrevFn = M.lookUpFunction(ClonedName)) {
     assert(PrevFn->isSerialized() == Serialized);
     ClonedFn = PrevFn;
   } else {
-    // Clone the function the existing partial_apply references.
+    // Clone the function the existing ApplySite references.
     PromotedParamCloner Cloner(FuncBuilder, F, Serialized,
                                PromotedCalleeArgIndices,
                                ClonedName);
@@ -798,95 +889,132 @@ specializePartialApply(SILOptFunctionBuilder &FuncBuilder,
     pass.T->addFunctionToPassManagerWorklist(ClonedFn, F);
   }
 
-  // Now create the new partial_apply using the cloned function.
+  // Now create the new ApplySite using the cloned function.
   SmallVector<SILValue, 16> Args;
 
   ValueLifetimeAnalysis::Frontier PAFrontier;
 
   // Promote the arguments that need promotion.
-  for (auto &O : PartialApply->getArgumentOperands()) {
+  for (auto &O : Apply.getArgumentOperands()) {
     auto CalleeArgIndex = ApplySite(O.getUser()).getCalleeArgIndex(O);
     if (!count(PromotedCalleeArgIndices, CalleeArgIndex)) {
       Args.push_back(O.get());
       continue;
     }
 
-    // If this argument is promoted, it is a box that we're turning into an
-    // address because we've proven we can keep this value on the stack. The
-    // partial_apply had ownership of this box so we must now release it
-    // explicitly when the partial_apply is released.
-    auto *Box = cast<SingleValueInstruction>(O.get());
-    assert((isa<AllocBoxInst>(Box) || isa<CopyValueInst>(Box)) &&
-           "Expected either an alloc box or a copy of an alloc box");
-    SILBuilder B(Box);
-    Args.push_back(B.createProjectBox(Box->getLoc(), Box, 0));
+    auto Box = O.get();
+    assert(((isa<SingleValueInstruction>(Box) && isa<AllocBoxInst>(Box) ||
+             isa<CopyValueInst>(Box)) ||
+            isa<SILFunctionArgument>(Box)) &&
+           "Expected either an alloc box or a copy of an alloc box or a "
+           "function argument");
+    auto InsertPt = Box->getDefiningInsertionPoint();
+    assert(InsertPt);
+    SILBuilderWithScope B(InsertPt);
+    Args.push_back(B.createProjectBox(Box.getLoc(), Box, 0));
 
-    if (PAFrontier.empty()) {
-      ValueLifetimeAnalysis VLA(PartialApply);
-      pass.CFGChanged |= !VLA.computeFrontier(
-          PAFrontier, ValueLifetimeAnalysis::AllowToModifyCFG);
-      assert(!PAFrontier.empty() && "partial_apply must have at least one use "
-                                    "to release the returned function");
-    }
+    // For a partial_apply, if this argument is promoted, it is a box that we're
+    // turning into an address because we've proven we can keep this value on
+    // the stack. The partial_apply had ownership of this box so we must now
+    // release it explicitly when the partial_apply is released.
+    if (Apply.getKind() == ApplySiteKind::PartialApplyInst) {
+      if (PAFrontier.empty()) {
+        ValueLifetimeAnalysis VLA(cast<PartialApplyInst>(Apply));
+        pass.CFGChanged |= !VLA.computeFrontier(
+            PAFrontier, ValueLifetimeAnalysis::AllowToModifyCFG);
+        assert(!PAFrontier.empty() &&
+               "partial_apply must have at least one use "
+               "to release the returned function");
+      }
 
-    // Insert destroys of the box at each point where the partial_apply becomes
-    // dead.
-    for (SILInstruction *FrontierInst : PAFrontier) {
-      SILBuilderWithScope Builder(FrontierInst);
-      Builder.createDestroyValue(PartialApply->getLoc(), Box);
+      // Insert destroys of the box at each point where the partial_apply
+      // becomes dead.
+      for (SILInstruction *FrontierInst : PAFrontier) {
+        SILBuilderWithScope Builder(FrontierInst);
+        Builder.createDestroyValue(Apply.getLoc(), Box);
+      }
     }
   }
 
-  SILBuilderWithScope Builder(PartialApply);
+  auto ApplyInst = Apply.getInstruction();
+  SILBuilderWithScope Builder(ApplyInst);
 
-  // Build the function_ref and partial_apply.
-  SILValue FunctionRef = Builder.createFunctionRef(PartialApply->getLoc(),
-                                                   ClonedFn);
-  return Builder.createPartialApply(
-      PartialApply->getLoc(), FunctionRef, PartialApply->getSubstitutionMap(),
-      Args,
-      PartialApply->getType().getAs<SILFunctionType>()->getCalleeConvention());
+  // Build the function_ref and ApplySite.
+  SILValue FunctionRef = Builder.createFunctionRef(Apply.getLoc(), ClonedFn);
+  switch (Apply.getKind()) {
+  case ApplySiteKind::PartialApplyInst: {
+    auto *PAI = cast<PartialApplyInst>(ApplyInst);
+    return Builder.createPartialApply(
+        Apply.getLoc(), FunctionRef, Apply.getSubstitutionMap(), Args,
+        PAI->getType().getAs<SILFunctionType>()->getCalleeConvention(),
+        PAI->isOnStack(),
+        GenericSpecializationInformation::create(ApplyInst, Builder));
+  }
+  case ApplySiteKind::ApplyInst:
+    return Builder.createApply(
+        Apply.getLoc(), FunctionRef, Apply.getSubstitutionMap(), Args,
+        GenericSpecializationInformation::create(ApplyInst, Builder));
+  case ApplySiteKind::BeginApplyInst:
+    return Builder.createBeginApply(
+        Apply.getLoc(), FunctionRef, Apply.getSubstitutionMap(), Args,
+        GenericSpecializationInformation::create(ApplyInst, Builder));
+  case ApplySiteKind::TryApplyInst: {
+    auto TAI = cast<TryApplyInst>(Apply);
+    return Builder.createTryApply(
+        Apply.getLoc(), FunctionRef, Apply.getSubstitutionMap(), Args,
+        TAI->getNormalBB(), TAI->getErrorBB(),
+        GenericSpecializationInformation::create(ApplyInst, Builder));
+  }
+  }
 }
 
-static void rewritePartialApplies(AllocBoxToStackState &pass) {
-  llvm::DenseMap<PartialApplyInst *, ArgIndexList> IndexMap;
+static void rewriteApplies(AllocBoxToStackState &pass) {
+  llvm::DenseMap<ApplySite, ArgIndexList> IndexMap;
+  llvm::SmallVector<ApplySite, 8> AppliesToSpecialize;
   ArgIndexList Indices;
 
-  // Build a map from partial_apply to the indices of the operands
+  // Build a map from the ApplySite to the indices of the operands
   // that will be promoted in our rewritten version.
   for (auto *O : pass.PromotedOperands) {
-    auto CalleeArgIndexNumber = ApplySite(O->getUser()).getCalleeArgIndex(*O);
+    auto User = O->getUser();
+    auto Apply = ApplySite(User);
+
+    auto CalleeArgIndexNumber = Apply.getCalleeArgIndex(*O);
 
     Indices.clear();
     Indices.push_back(CalleeArgIndexNumber);
 
-    auto *PartialApply = cast<PartialApplyInst>(O->getUser());
-    llvm::DenseMap<PartialApplyInst *, ArgIndexList>::iterator It;
-    bool Inserted;
-    std::tie(It, Inserted) = IndexMap.insert(std::make_pair(PartialApply,
-                                                            Indices));
-    if (!Inserted)
-      It->second.push_back(CalleeArgIndexNumber);
+    auto iterAndSuccess = IndexMap.try_emplace(Apply, Indices);
+    // AllocBoxStack opt promotes boxes passed to a chain of applies when it is
+    // safe to do so. All such applies have to be specialized to take pointer
+    // arguments instead of box arguments This has to be done in dfs order.
+    // PromotedOperands is already in dfs order. Build AppliesToSpecialize in
+    // dfs order.
+    if (iterAndSuccess.second) {
+      AppliesToSpecialize.push_back(Apply);
+    } else {
+      iterAndSuccess.first->second.push_back(CalleeArgIndexNumber);
+    }
   }
 
-  // Clone the referenced function of each partial_apply, removing the
+  // Clone the referenced function of each ApplySite, removing the
   // operands that we will not need, and remove the existing
-  // partial_apply.
+  // ApplySite.
   SILOptFunctionBuilder FuncBuilder(*pass.T);
-  for (auto &It : IndexMap) {
-    auto *PartialApply = It.first;
-    auto &Indices = It.second;
+  for (auto &Apply : AppliesToSpecialize) {
+    auto It = IndexMap.find(Apply);
+    assert(It != IndexMap.end());
+    auto &Indices = It->second;
 
     // Sort the indices and unique them.
-    std::sort(Indices.begin(), Indices.end());
-    Indices.erase(std::unique(Indices.begin(), Indices.end()), Indices.end());
+    sortUnique(Indices);
 
-    PartialApplyInst *Replacement =
-      specializePartialApply(FuncBuilder, PartialApply, Indices, pass);
-    PartialApply->replaceAllUsesWith(Replacement);
+    auto *Replacement = specializeApply(FuncBuilder, Apply, Indices, pass);
+    assert(Apply.getKind() == ApplySite(Replacement).getKind());
+    Apply.getInstruction()->replaceAllUsesPairwiseWith(Replacement);
 
-    auto *FRI = cast<FunctionRefInst>(PartialApply->getCallee());
-    PartialApply->eraseFromParent();
+    auto *FRI = cast<FunctionRefInst>(Apply.getCallee());
+    Apply.getInstruction()->eraseFromParent();
 
     // TODO: Erase from module if there are no more uses.
     if (FRI->use_empty())
@@ -897,9 +1025,9 @@ static void rewritePartialApplies(AllocBoxToStackState &pass) {
 /// Clone closure bodies and rewrite partial applies. Returns the number of
 /// alloc_box allocations promoted.
 static unsigned rewritePromotedBoxes(AllocBoxToStackState &pass) {
-  // First we'll rewrite any partial applies that we can to remove the
-  // box container pointer from the operands.
-  rewritePartialApplies(pass);
+  // First we'll rewrite any ApplySite that we can to remove
+  // the box container pointer from the operands.
+  rewriteApplies(pass);
 
   unsigned Count = 0;
   auto rend = pass.Promotable.rend();

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -19,6 +19,7 @@
 #include "swift/SIL/SILCloner.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
 #include "swift/SILOptimizer/Utils/SpecializationMangler.h"
 #include "swift/SILOptimizer/Utils/StackNesting.h"
@@ -633,11 +634,12 @@ SILFunction *PromotedParamCloner::initCloned(SILOptFunctionBuilder &FuncBuilder,
          && "SILFunction missing DebugScope");
   assert(!Orig->isGlobalInit() && "Global initializer cannot be cloned");
   auto *Fn = FuncBuilder.createFunction(
-      SILLinkage::Shared, ClonedName, ClonedTy, Orig->getGenericEnvironment(),
-      Orig->getLocation(), Orig->isBare(), Orig->isTransparent(), Serialized,
-      IsNotDynamic, Orig->getEntryCount(), Orig->isThunk(),
-      Orig->getClassSubclassScope(), Orig->getInlineStrategy(),
-      Orig->getEffectsKind(), Orig, Orig->getDebugScope());
+      swift::getSpecializedLinkage(Orig, Orig->getLinkage()), ClonedName,
+      ClonedTy, Orig->getGenericEnvironment(), Orig->getLocation(),
+      Orig->isBare(), Orig->isTransparent(), Serialized, IsNotDynamic,
+      Orig->getEntryCount(), Orig->isThunk(), Orig->getClassSubclassScope(),
+      Orig->getInlineStrategy(), Orig->getEffectsKind(), Orig,
+      Orig->getDebugScope());
   for (auto &Attr : Orig->getSemanticsAttrs()) {
     Fn->addSemanticsAttr(Attr);
   }

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -395,7 +395,7 @@ bb0(%0 : $Int):
   return %10 : $()                                // id: %11
 }
 
-// CHECK-LABEL: sil shared @$s6struct8useStack1tySi_tFSiycfU_Tf0s_n
+// CHECK-LABEL: sil private @$s6struct8useStack1tySi_tFSiycfU_Tf0s_n
 // CHECK-LABEL: sil private @$s6struct8useStack1tySi_tFSiycfU_
 // struct.(useStack (t : Swift.Int) -> ()).(closure #1)
 sil private @$s6struct8useStack1tySi_tFSiycfU_ : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> Int {
@@ -513,8 +513,8 @@ bb0(%0 : $*T):
   return %9 : $()
 }
 
-// CHECK-LABEL: sil shared @$s21closure_to_specializeTf0ns_n : $@convention(thin) <T where T : P> (@inout_aliasable T) -> @out T
-sil shared @closure_to_specialize : $@convention(thin) <T where T : P> (@owned <τ_0_0> { var τ_0_0 } <T>) -> @out T {
+// CHECK-LABEL: sil private @$s21closure_to_specializeTf0ns_n : $@convention(thin) <T where T : P> (@inout_aliasable T) -> @out T
+sil private @closure_to_specialize : $@convention(thin) <T where T : P> (@owned <τ_0_0> { var τ_0_0 } <T>) -> @out T {
 // CHECK: bb0
 bb0(%0 : $*T, %1 : $<τ_0_0> { var τ_0_0 } <T>):
   %2 = project_box %1 : $<τ_0_0> { var τ_0_0 } <T>, 0

--- a/test/SILOptimizer/allocbox_to_stack_ownership.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ownership.sil
@@ -391,7 +391,7 @@ bb0(%0 : $Int):
   return %10 : $()                                // id: %11
 }
 
-// CHECK-LABEL: sil shared [transparent] [ossa] @$s6struct8useStack1tySi_tFSiycfU_Tf0s_n
+// CHECK-LABEL: sil private [transparent] [ossa] @$s6struct8useStack1tySi_tFSiycfU_Tf0s_n
 // CHECK-LABEL: sil private [transparent] [ossa] @$s6struct8useStack1tySi_tFSiycfU_
 // struct.(useStack (t : Swift.Int) -> ()).(closure #1)
 sil private [transparent] [ossa] @$s6struct8useStack1tySi_tFSiycfU_ : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> Int {

--- a/test/SILOptimizer/allocboxtostack_localapply.sil
+++ b/test/SILOptimizer/allocboxtostack_localapply.sil
@@ -1,0 +1,351 @@
+// RUN: %target-sil-opt %s -allocbox-to-stack -sil-deadfuncelim | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+
+sil hidden [noinline] [Onone] @$blackhole : $@convention(thin) <T> (@in_guaranteed T) -> () {
+bb0(%0 : $*T):
+  %2 = tuple ()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil [noinline] @$testapply :
+// CHECK-NOT: alloc_box
+// CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK-LABEL: } // end sil function '$testapply'
+sil [noinline] @$testapply : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ var Int }, var, name "x"
+  %1 = project_box %0 : ${ var Int }, 0
+  %2 = integer_literal $Builtin.Int64, 0
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  store %3 to %1 : $*Int
+  %5 = function_ref @$testapplybas : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  strong_release %0 : ${ var Int }
+  %8 = tuple ()
+  return %8 : $()
+}
+
+sil private [noinline] @$testapplybar : $@convention(thin) (@guaranteed { var Int }) -> () {
+bb0(%0 : ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = begin_access [read] [dynamic] %1 : $*Int
+  %4 = load %3 : $*Int
+  end_access %3 : $*Int
+  %6 = alloc_stack $Int
+  store %4 to %6 : $*Int
+  %8 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %9 = apply %8<Int>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %6 : $*Int
+  %11 = tuple ()
+  return %11 : $()
+}
+
+sil private [noinline] @$testapplybas : $@convention(thin) (@guaranteed { var Int }) -> () {
+bb0(%0 : ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = function_ref @$testapplybar : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: sil [noinline] @$testtryapply :
+// CHECK-NOT: alloc_box
+// CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK-LABEL: } // end sil function '$testtryapply'
+sil [noinline] @$testtryapply : $@convention(thin) () -> @error Error {
+bb0:
+  %1 = alloc_box ${ var Int }, var, name "x"
+  %2 = project_box %1 : ${ var Int }, 0
+  %3 = integer_literal $Builtin.Int64, 0
+  %4 = struct $Int (%3 : $Builtin.Int64)
+  store %4 to %2 : $*Int
+  %6 = function_ref @$testtryapplybas : $@convention(thin) (@guaranteed { var Int }) -> @error Error
+  try_apply %6(%1) : $@convention(thin) (@guaranteed { var Int }) -> @error Error, normal bb1, error bb2
+bb1(%8 : $()):
+  strong_release %1 : ${ var Int }
+  %10 = tuple ()
+  return %10 : $()
+bb2(%12 : $Error):
+  strong_release %1 : ${ var Int }
+  throw %12 : $Error
+}
+
+sil private [noinline] @$testtryapplybar : $@convention(thin) (@guaranteed { var Int }) -> @error Error {
+bb0(%0 : ${ var Int }):
+  %2 = project_box %0 : ${ var Int }, 0
+  %4 = begin_access [read] [dynamic] %2 : $*Int
+  %5 = load %4 : $*Int
+  end_access %4 : $*Int
+  %7 = alloc_stack $Int
+  store %5 to %7 : $*Int
+  %9 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %10 = apply %9<Int>(%7) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %7 : $*Int
+  %12 = tuple ()
+  return %12 : $()
+}
+
+sil private [noinline] @$testtryapplybas : $@convention(thin) (@guaranteed { var Int }) -> @error Error {
+bb0(%0 : ${ var Int }):
+  %2 = project_box %0 : ${ var Int }, 0
+  %4 = function_ref @$testtryapplybar : $@convention(thin) (@guaranteed { var Int }) -> @error Error
+  try_apply %4(%0) : $@convention(thin) (@guaranteed { var Int }) -> @error Error, normal bb1, error bb2
+bb1(%6 : $()):
+  %7 = tuple ()
+  return %7 : $()
+bb2(%9 : $Error):
+  throw %9 : $Error
+}
+
+
+// CHECK-LABEL: sil [noinline] @$testpartialapply :
+// CHECK-NOT: alloc_box
+// CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK-LABEL: } // end sil function '$testpartialapply'
+sil [noinline] @$testpartialapply : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ var Int }, var, name "x"
+  %1 = project_box %0 : ${ var Int }, 0
+  %2 = integer_literal $Builtin.Int64, 0
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  store %3 to %1 : $*Int
+  %5 = function_ref @$testpartialapplyclosure : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  strong_release %0 : ${ var Int }
+  %8 = tuple ()
+  return %8 : $()
+}
+
+sil private [noinline] @$testpartialapplybar : $@convention(thin) (@guaranteed { var Int }) -> () {
+bb0(%0 : ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = begin_access [read] [dynamic] %1 : $*Int
+  %4 = load %3 : $*Int
+  end_access %3 : $*Int
+  %6 = alloc_stack $Int
+  store %4 to %6 : $*Int
+  %8 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %9 = apply %8<Int>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %6 : $*Int
+  %11 = tuple ()
+  return %11 : $()
+}
+
+sil private [noinline] @$testpartialapplybas : $@convention(thin) (@guaranteed { var Int }) -> () {
+bb0(%0 : ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = function_ref @$testpartialapplybar : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %5 = tuple ()
+  return %5 : $()
+}
+
+sil private @$testpartialapplyclosure : $@convention(thin) (@guaranteed { var Int }) -> () {
+bb0(%0 : ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = function_ref @$testpartialapplybas : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: sil [noinline] @$testtwoboxes :
+// CHECK-NOT: alloc_box
+// CHECK: [[STK1:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK: [[STK2:%.*]] = alloc_stack $Int, var, name "y"
+// CHECK-LABEL: } // end sil function '$testtwoboxes'
+sil [noinline] @$testtwoboxes : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ var Int }, var, name "x"
+  %1 = project_box %0 : ${ var Int }, 0
+  %2 = integer_literal $Builtin.Int64, 0
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  store %3 to %1 : $*Int
+  %5 = alloc_box ${ var Int }, var, name "y"
+  %6 = project_box %5 : ${ var Int }, 0
+  %7 = integer_literal $Builtin.Int64, 0
+  %8 = struct $Int (%7 : $Builtin.Int64)
+  store %8 to %6 : $*Int
+  %10 = function_ref @$testtwoboxesbas : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> ()
+  %11 = apply %10(%0, %5) : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> ()
+  strong_release %5 : ${ var Int }
+  strong_release %0 : ${ var Int }
+  %14 = tuple ()
+  return %14 : $()
+}
+
+sil private [noinline] @$testtwoboxesbar : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> () {
+bb0(%0 : ${ var Int }, %1 : ${ var Int }):
+  %2 = project_box %0 : ${ var Int }, 0
+  %4 = project_box %1 : ${ var Int }, 0
+  %6 = begin_access [read] [dynamic] %2 : $*Int
+  %7 = load %6 : $*Int
+  end_access %6 : $*Int
+  %9 = alloc_stack $Int
+  store %7 to %9 : $*Int
+  %11 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %12 = apply %11<Int>(%9) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %9 : $*Int
+  %14 = begin_access [read] [dynamic] %4 : $*Int
+  %15 = load %14 : $*Int
+  end_access %14 : $*Int
+  %17 = alloc_stack $Int
+  store %15 to %17 : $*Int
+  %19 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %20 = apply %19<Int>(%17) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %17 : $*Int
+  %22 = tuple ()
+  return %22 : $()
+}
+
+sil private [noinline] @$testtwoboxesbas : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> () {
+bb0(%0 : ${ var Int }, %1 : ${ var Int }):
+  %2 = project_box %0 : ${ var Int }, 0
+  %4 = project_box %1 : ${ var Int }, 0
+  %6 = function_ref @$testtwoboxesbar : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> ()
+  %7 = apply %6(%0, %1) : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> ()
+  %8 = tuple ()
+  return %8 : $()
+}
+
+// CHECK-LABEL: sil [noinline] @$testboxescapes :
+// CHECK: alloc_box ${ var Int }, var, name "x"
+// CHECK-LABEL: } // end sil function '$testboxescapes'
+sil [noinline] @$testboxescapes : $@convention(thin) () -> @owned @callee_guaranteed () -> () {
+bb0:
+  %0 = alloc_box ${ var Int }, var, name "x"
+  %1 = project_box %0 : ${ var Int }, 0
+  %2 = integer_literal $Builtin.Int64, 0
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  store %3 to %1 : $*Int
+  %5 = function_ref @$testboxescapesbas : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> ()
+  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> ()
+  strong_release %0 : ${ var Int }
+  return %6 : $@callee_guaranteed () -> ()
+}
+
+sil private [noinline] @$testboxescapesbar : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> () {
+bb0(%0 : ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = function_ref @$testboxescapesclosure : $@convention(thin) (@guaranteed { var Int }) -> ()
+  strong_retain %0 : ${ var Int }
+  %5 = partial_apply [callee_guaranteed] %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  return %5 : $@callee_guaranteed () -> ()
+}
+
+sil private @$testboxescapesclosure : $@convention(thin) (@guaranteed { var Int }) -> () {
+bb0(%0 : ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = load %1 : $*Int
+  %4 = tuple ()
+  return %4 : $()
+}
+
+sil private [noinline] @$testboxescapesbas : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> () {
+bb0(%0 : ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = function_ref @$testboxescapesbar : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> ()
+  return %4 : $@callee_guaranteed () -> ()
+}
+
+// CHECK-LABEL: sil [noinline] @$testrecur :
+// CHECK: alloc_box ${ var Int }, var, name "x"
+// CHECK-LABEL: } // end sil function '$testrecur'
+sil [noinline] @$testrecur : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ var Int }, var, name "x"
+  %1 = project_box %0 : ${ var Int }, 0
+  %2 = integer_literal $Builtin.Int64, 0
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  store %3 to %1 : $*Int
+  %5 = function_ref @$testrecurbas : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %7 = function_ref @$testrecurbar : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %8 = apply %7(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  strong_release %0 : ${ var Int }
+  %10 = tuple ()
+  return %10 : $()
+}
+
+sil private [noinline] @$testrecurbar : $@convention(thin) (@guaranteed { var Int }) -> () {
+bb0(%0 : ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = begin_access [read] [dynamic] %1 : $*Int
+  %4 = load %3 : $*Int
+  end_access %3 : $*Int
+  %6 = alloc_stack $Int
+  store %4 to %6 : $*Int
+  %8 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %9 = apply %8<Int>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %6 : $*Int
+  %11 = function_ref @$testrecurbas : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %12 = apply %11(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %13 = tuple ()
+  return %13 : $()
+}
+
+sil private [noinline] @$testrecurbas : $@convention(thin) (@guaranteed { var Int }) -> () {
+bb0(%0 : ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = function_ref @$testrecurbar : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: sil [noinline] @$testbeginapply :
+// CHECK-NOT: alloc_box
+// CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK-LABEL: } // end sil function '$testbeginapply'
+sil [noinline] @$testbeginapply : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ var Int }, var, name "x"
+  %1 = project_box %0 : ${ var Int }, 0
+  %2 = integer_literal $Builtin.Int64, 0
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  store %3 to %1 : $*Int
+  %5 = function_ref @$testbeginapplybas : $@yield_once @convention(thin) (@guaranteed { var Int }) -> @yields ()
+  (%addr, %token) = begin_apply %5(%0) : $@yield_once @convention(thin) (@guaranteed { var Int }) -> @yields ()
+  end_apply %token
+  strong_release %0 : ${ var Int }
+  %8 = tuple ()
+  return %8 : $()
+}
+
+sil private [noinline] @$testbeginapplybar : $@convention(thin) (@guaranteed { var Int }) -> () {
+bb0(%0 : ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = begin_access [read] [dynamic] %1 : $*Int
+  %4 = load %3 : $*Int
+  end_access %3 : $*Int
+  %6 = alloc_stack $Int
+  store %4 to %6 : $*Int
+  %8 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %9 = apply %8<Int>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %6 : $*Int
+  %11 = tuple ()
+  return %11 : $()
+}
+
+sil private [noinline] @$testbeginapplybas : $@yield_once @convention(thin) (@guaranteed { var Int }) -> @yields () {
+bb0(%0 : ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = function_ref @$testbeginapplybar : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %5 = tuple ()
+  yield %5 : $(), resume bb1, unwind bb2
+bb1:
+  %rv = tuple()
+  return %rv : $()
+bb2:
+  unwind
+}
+

--- a/test/SILOptimizer/allocboxtostack_localapply.sil
+++ b/test/SILOptimizer/allocboxtostack_localapply.sil
@@ -15,88 +15,88 @@ bb0(%0 : $*T):
 
 // CHECK-LABEL: sil [noinline] @$testapply :
 // CHECK-NOT: alloc_box
-// CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK: [[STK:%.*]] = alloc_stack $Int64, var, name "x"
 // CHECK-LABEL: } // end sil function '$testapply'
 sil [noinline] @$testapply : $@convention(thin) () -> () {
 bb0:
-  %0 = alloc_box ${ var Int }, var, name "x"
-  %1 = project_box %0 : ${ var Int }, 0
+  %0 = alloc_box ${ var Int64 }, var, name "x"
+  %1 = project_box %0 : ${ var Int64 }, 0
   %2 = integer_literal $Builtin.Int64, 0
-  %3 = struct $Int (%2 : $Builtin.Int64)
-  store %3 to %1 : $*Int
-  %5 = function_ref @$testapplybas : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
-  strong_release %0 : ${ var Int }
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  store %3 to %1 : $*Int64
+  %5 = function_ref @$testapplybas : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  strong_release %0 : ${ var Int64 }
   %8 = tuple ()
   return %8 : $()
 }
 
-sil private [noinline] @$testapplybar : $@convention(thin) (@guaranteed { var Int }) -> () {
-bb0(%0 : ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = begin_access [read] [dynamic] %1 : $*Int
-  %4 = load %3 : $*Int
-  end_access %3 : $*Int
-  %6 = alloc_stack $Int
-  store %4 to %6 : $*Int
+sil private [noinline] @$testapplybar : $@convention(thin) (@guaranteed { var Int64 }) -> () {
+bb0(%0 : ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = begin_access [read] [dynamic] %1 : $*Int64
+  %4 = load %3 : $*Int64
+  end_access %3 : $*Int64
+  %6 = alloc_stack $Int64
+  store %4 to %6 : $*Int64
   %8 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  %9 = apply %8<Int>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  dealloc_stack %6 : $*Int
+  %9 = apply %8<Int64>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %6 : $*Int64
   %11 = tuple ()
   return %11 : $()
 }
 
-sil private [noinline] @$testapplybas : $@convention(thin) (@guaranteed { var Int }) -> () {
-bb0(%0 : ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = function_ref @$testapplybar : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+sil private [noinline] @$testapplybas : $@convention(thin) (@guaranteed { var Int64 }) -> () {
+bb0(%0 : ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = function_ref @$testapplybar : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
   %5 = tuple ()
   return %5 : $()
 }
 
 // CHECK-LABEL: sil [noinline] @$testtryapply :
 // CHECK-NOT: alloc_box
-// CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK: [[STK:%.*]] = alloc_stack $Int64, var, name "x"
 // CHECK-LABEL: } // end sil function '$testtryapply'
 sil [noinline] @$testtryapply : $@convention(thin) () -> @error Error {
 bb0:
-  %1 = alloc_box ${ var Int }, var, name "x"
-  %2 = project_box %1 : ${ var Int }, 0
+  %1 = alloc_box ${ var Int64 }, var, name "x"
+  %2 = project_box %1 : ${ var Int64 }, 0
   %3 = integer_literal $Builtin.Int64, 0
-  %4 = struct $Int (%3 : $Builtin.Int64)
-  store %4 to %2 : $*Int
-  %6 = function_ref @$testtryapplybas : $@convention(thin) (@guaranteed { var Int }) -> @error Error
-  try_apply %6(%1) : $@convention(thin) (@guaranteed { var Int }) -> @error Error, normal bb1, error bb2
+  %4 = struct $Int64 (%3 : $Builtin.Int64)
+  store %4 to %2 : $*Int64
+  %6 = function_ref @$testtryapplybas : $@convention(thin) (@guaranteed { var Int64 }) -> @error Error
+  try_apply %6(%1) : $@convention(thin) (@guaranteed { var Int64 }) -> @error Error, normal bb1, error bb2
 bb1(%8 : $()):
-  strong_release %1 : ${ var Int }
+  strong_release %1 : ${ var Int64 }
   %10 = tuple ()
   return %10 : $()
 bb2(%12 : $Error):
-  strong_release %1 : ${ var Int }
+  strong_release %1 : ${ var Int64 }
   throw %12 : $Error
 }
 
-sil private [noinline] @$testtryapplybar : $@convention(thin) (@guaranteed { var Int }) -> @error Error {
-bb0(%0 : ${ var Int }):
-  %2 = project_box %0 : ${ var Int }, 0
-  %4 = begin_access [read] [dynamic] %2 : $*Int
-  %5 = load %4 : $*Int
-  end_access %4 : $*Int
-  %7 = alloc_stack $Int
-  store %5 to %7 : $*Int
+sil private [noinline] @$testtryapplybar : $@convention(thin) (@guaranteed { var Int64 }) -> @error Error {
+bb0(%0 : ${ var Int64 }):
+  %2 = project_box %0 : ${ var Int64 }, 0
+  %4 = begin_access [read] [dynamic] %2 : $*Int64
+  %5 = load %4 : $*Int64
+  end_access %4 : $*Int64
+  %7 = alloc_stack $Int64
+  store %5 to %7 : $*Int64
   %9 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  %10 = apply %9<Int>(%7) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  dealloc_stack %7 : $*Int
+  %10 = apply %9<Int64>(%7) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %7 : $*Int64
   %12 = tuple ()
   return %12 : $()
 }
 
-sil private [noinline] @$testtryapplybas : $@convention(thin) (@guaranteed { var Int }) -> @error Error {
-bb0(%0 : ${ var Int }):
-  %2 = project_box %0 : ${ var Int }, 0
-  %4 = function_ref @$testtryapplybar : $@convention(thin) (@guaranteed { var Int }) -> @error Error
-  try_apply %4(%0) : $@convention(thin) (@guaranteed { var Int }) -> @error Error, normal bb1, error bb2
+sil private [noinline] @$testtryapplybas : $@convention(thin) (@guaranteed { var Int64 }) -> @error Error {
+bb0(%0 : ${ var Int64 }):
+  %2 = project_box %0 : ${ var Int64 }, 0
+  %4 = function_ref @$testtryapplybar : $@convention(thin) (@guaranteed { var Int64 }) -> @error Error
+  try_apply %4(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> @error Error, normal bb1, error bb2
 bb1(%6 : $()):
   %7 = tuple ()
   return %7 : $()
@@ -107,239 +107,239 @@ bb2(%9 : $Error):
 
 // CHECK-LABEL: sil [noinline] @$testpartialapply :
 // CHECK-NOT: alloc_box
-// CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK: [[STK:%.*]] = alloc_stack $Int64, var, name "x"
 // CHECK-LABEL: } // end sil function '$testpartialapply'
 sil [noinline] @$testpartialapply : $@convention(thin) () -> () {
 bb0:
-  %0 = alloc_box ${ var Int }, var, name "x"
-  %1 = project_box %0 : ${ var Int }, 0
+  %0 = alloc_box ${ var Int64 }, var, name "x"
+  %1 = project_box %0 : ${ var Int64 }, 0
   %2 = integer_literal $Builtin.Int64, 0
-  %3 = struct $Int (%2 : $Builtin.Int64)
-  store %3 to %1 : $*Int
-  %5 = function_ref @$testpartialapplyclosure : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
-  strong_release %0 : ${ var Int }
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  store %3 to %1 : $*Int64
+  %5 = function_ref @$testpartialapplyclosure : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  strong_release %0 : ${ var Int64 }
   %8 = tuple ()
   return %8 : $()
 }
 
-sil private [noinline] @$testpartialapplybar : $@convention(thin) (@guaranteed { var Int }) -> () {
-bb0(%0 : ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = begin_access [read] [dynamic] %1 : $*Int
-  %4 = load %3 : $*Int
-  end_access %3 : $*Int
-  %6 = alloc_stack $Int
-  store %4 to %6 : $*Int
+sil private [noinline] @$testpartialapplybar : $@convention(thin) (@guaranteed { var Int64 }) -> () {
+bb0(%0 : ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = begin_access [read] [dynamic] %1 : $*Int64
+  %4 = load %3 : $*Int64
+  end_access %3 : $*Int64
+  %6 = alloc_stack $Int64
+  store %4 to %6 : $*Int64
   %8 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  %9 = apply %8<Int>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  dealloc_stack %6 : $*Int
+  %9 = apply %8<Int64>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %6 : $*Int64
   %11 = tuple ()
   return %11 : $()
 }
 
-sil private [noinline] @$testpartialapplybas : $@convention(thin) (@guaranteed { var Int }) -> () {
-bb0(%0 : ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = function_ref @$testpartialapplybar : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+sil private [noinline] @$testpartialapplybas : $@convention(thin) (@guaranteed { var Int64 }) -> () {
+bb0(%0 : ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = function_ref @$testpartialapplybar : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
   %5 = tuple ()
   return %5 : $()
 }
 
-sil private @$testpartialapplyclosure : $@convention(thin) (@guaranteed { var Int }) -> () {
-bb0(%0 : ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = function_ref @$testpartialapplybas : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+sil private @$testpartialapplyclosure : $@convention(thin) (@guaranteed { var Int64 }) -> () {
+bb0(%0 : ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = function_ref @$testpartialapplybas : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
   %5 = tuple ()
   return %5 : $()
 }
 
 // CHECK-LABEL: sil [noinline] @$testtwoboxes :
 // CHECK-NOT: alloc_box
-// CHECK: [[STK1:%.*]] = alloc_stack $Int, var, name "x"
-// CHECK: [[STK2:%.*]] = alloc_stack $Int, var, name "y"
+// CHECK: [[STK1:%.*]] = alloc_stack $Int64, var, name "x"
+// CHECK: [[STK2:%.*]] = alloc_stack $Int64, var, name "y"
 // CHECK-LABEL: } // end sil function '$testtwoboxes'
 sil [noinline] @$testtwoboxes : $@convention(thin) () -> () {
 bb0:
-  %0 = alloc_box ${ var Int }, var, name "x"
-  %1 = project_box %0 : ${ var Int }, 0
+  %0 = alloc_box ${ var Int64 }, var, name "x"
+  %1 = project_box %0 : ${ var Int64 }, 0
   %2 = integer_literal $Builtin.Int64, 0
-  %3 = struct $Int (%2 : $Builtin.Int64)
-  store %3 to %1 : $*Int
-  %5 = alloc_box ${ var Int }, var, name "y"
-  %6 = project_box %5 : ${ var Int }, 0
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  store %3 to %1 : $*Int64
+  %5 = alloc_box ${ var Int64 }, var, name "y"
+  %6 = project_box %5 : ${ var Int64 }, 0
   %7 = integer_literal $Builtin.Int64, 0
-  %8 = struct $Int (%7 : $Builtin.Int64)
-  store %8 to %6 : $*Int
-  %10 = function_ref @$testtwoboxesbas : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> ()
-  %11 = apply %10(%0, %5) : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> ()
-  strong_release %5 : ${ var Int }
-  strong_release %0 : ${ var Int }
+  %8 = struct $Int64 (%7 : $Builtin.Int64)
+  store %8 to %6 : $*Int64
+  %10 = function_ref @$testtwoboxesbas : $@convention(thin) (@guaranteed { var Int64 }, @guaranteed { var Int64 }) -> ()
+  %11 = apply %10(%0, %5) : $@convention(thin) (@guaranteed { var Int64 }, @guaranteed { var Int64 }) -> ()
+  strong_release %5 : ${ var Int64 }
+  strong_release %0 : ${ var Int64 }
   %14 = tuple ()
   return %14 : $()
 }
 
-sil private [noinline] @$testtwoboxesbar : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> () {
-bb0(%0 : ${ var Int }, %1 : ${ var Int }):
-  %2 = project_box %0 : ${ var Int }, 0
-  %4 = project_box %1 : ${ var Int }, 0
-  %6 = begin_access [read] [dynamic] %2 : $*Int
-  %7 = load %6 : $*Int
-  end_access %6 : $*Int
-  %9 = alloc_stack $Int
-  store %7 to %9 : $*Int
+sil private [noinline] @$testtwoboxesbar : $@convention(thin) (@guaranteed { var Int64 }, @guaranteed { var Int64 }) -> () {
+bb0(%0 : ${ var Int64 }, %1 : ${ var Int64 }):
+  %2 = project_box %0 : ${ var Int64 }, 0
+  %4 = project_box %1 : ${ var Int64 }, 0
+  %6 = begin_access [read] [dynamic] %2 : $*Int64
+  %7 = load %6 : $*Int64
+  end_access %6 : $*Int64
+  %9 = alloc_stack $Int64
+  store %7 to %9 : $*Int64
   %11 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  %12 = apply %11<Int>(%9) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  dealloc_stack %9 : $*Int
-  %14 = begin_access [read] [dynamic] %4 : $*Int
-  %15 = load %14 : $*Int
-  end_access %14 : $*Int
-  %17 = alloc_stack $Int
-  store %15 to %17 : $*Int
+  %12 = apply %11<Int64>(%9) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %9 : $*Int64
+  %14 = begin_access [read] [dynamic] %4 : $*Int64
+  %15 = load %14 : $*Int64
+  end_access %14 : $*Int64
+  %17 = alloc_stack $Int64
+  store %15 to %17 : $*Int64
   %19 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  %20 = apply %19<Int>(%17) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  dealloc_stack %17 : $*Int
+  %20 = apply %19<Int64>(%17) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %17 : $*Int64
   %22 = tuple ()
   return %22 : $()
 }
 
-sil private [noinline] @$testtwoboxesbas : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> () {
-bb0(%0 : ${ var Int }, %1 : ${ var Int }):
-  %2 = project_box %0 : ${ var Int }, 0
-  %4 = project_box %1 : ${ var Int }, 0
-  %6 = function_ref @$testtwoboxesbar : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> ()
-  %7 = apply %6(%0, %1) : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> ()
+sil private [noinline] @$testtwoboxesbas : $@convention(thin) (@guaranteed { var Int64 }, @guaranteed { var Int64 }) -> () {
+bb0(%0 : ${ var Int64 }, %1 : ${ var Int64 }):
+  %2 = project_box %0 : ${ var Int64 }, 0
+  %4 = project_box %1 : ${ var Int64 }, 0
+  %6 = function_ref @$testtwoboxesbar : $@convention(thin) (@guaranteed { var Int64 }, @guaranteed { var Int64 }) -> ()
+  %7 = apply %6(%0, %1) : $@convention(thin) (@guaranteed { var Int64 }, @guaranteed { var Int64 }) -> ()
   %8 = tuple ()
   return %8 : $()
 }
 
 // CHECK-LABEL: sil [noinline] @$testboxescapes :
-// CHECK: alloc_box ${ var Int }, var, name "x"
+// CHECK: alloc_box ${ var Int64 }, var, name "x"
 // CHECK-LABEL: } // end sil function '$testboxescapes'
 sil [noinline] @$testboxescapes : $@convention(thin) () -> @owned @callee_guaranteed () -> () {
 bb0:
-  %0 = alloc_box ${ var Int }, var, name "x"
-  %1 = project_box %0 : ${ var Int }, 0
+  %0 = alloc_box ${ var Int64 }, var, name "x"
+  %1 = project_box %0 : ${ var Int64 }, 0
   %2 = integer_literal $Builtin.Int64, 0
-  %3 = struct $Int (%2 : $Builtin.Int64)
-  store %3 to %1 : $*Int
-  %5 = function_ref @$testboxescapesbas : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> ()
-  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> ()
-  strong_release %0 : ${ var Int }
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  store %3 to %1 : $*Int64
+  %5 = function_ref @$testboxescapesbas : $@convention(thin) (@guaranteed { var Int64 }) -> @owned @callee_guaranteed () -> ()
+  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> @owned @callee_guaranteed () -> ()
+  strong_release %0 : ${ var Int64 }
   return %6 : $@callee_guaranteed () -> ()
 }
 
-sil private [noinline] @$testboxescapesbar : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> () {
-bb0(%0 : ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = function_ref @$testboxescapesclosure : $@convention(thin) (@guaranteed { var Int }) -> ()
-  strong_retain %0 : ${ var Int }
-  %5 = partial_apply [callee_guaranteed] %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+sil private [noinline] @$testboxescapesbar : $@convention(thin) (@guaranteed { var Int64 }) -> @owned @callee_guaranteed () -> () {
+bb0(%0 : ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = function_ref @$testboxescapesclosure : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  strong_retain %0 : ${ var Int64 }
+  %5 = partial_apply [callee_guaranteed] %3(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
   return %5 : $@callee_guaranteed () -> ()
 }
 
-sil private @$testboxescapesclosure : $@convention(thin) (@guaranteed { var Int }) -> () {
-bb0(%0 : ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = load %1 : $*Int
+sil private @$testboxescapesclosure : $@convention(thin) (@guaranteed { var Int64 }) -> () {
+bb0(%0 : ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = load %1 : $*Int64
   %4 = tuple ()
   return %4 : $()
 }
 
-sil private [noinline] @$testboxescapesbas : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> () {
-bb0(%0 : ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = function_ref @$testboxescapesbar : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> ()
-  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> ()
+sil private [noinline] @$testboxescapesbas : $@convention(thin) (@guaranteed { var Int64 }) -> @owned @callee_guaranteed () -> () {
+bb0(%0 : ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = function_ref @$testboxescapesbar : $@convention(thin) (@guaranteed { var Int64 }) -> @owned @callee_guaranteed () -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> @owned @callee_guaranteed () -> ()
   return %4 : $@callee_guaranteed () -> ()
 }
 
 // CHECK-LABEL: sil [noinline] @$testrecur :
-// CHECK: alloc_box ${ var Int }, var, name "x"
+// CHECK: alloc_box ${ var Int64 }, var, name "x"
 // CHECK-LABEL: } // end sil function '$testrecur'
 sil [noinline] @$testrecur : $@convention(thin) () -> () {
 bb0:
-  %0 = alloc_box ${ var Int }, var, name "x"
-  %1 = project_box %0 : ${ var Int }, 0
+  %0 = alloc_box ${ var Int64 }, var, name "x"
+  %1 = project_box %0 : ${ var Int64 }, 0
   %2 = integer_literal $Builtin.Int64, 0
-  %3 = struct $Int (%2 : $Builtin.Int64)
-  store %3 to %1 : $*Int
-  %5 = function_ref @$testrecurbas : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %7 = function_ref @$testrecurbar : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %8 = apply %7(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
-  strong_release %0 : ${ var Int }
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  store %3 to %1 : $*Int64
+  %5 = function_ref @$testrecurbas : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %7 = function_ref @$testrecurbar : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %8 = apply %7(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  strong_release %0 : ${ var Int64 }
   %10 = tuple ()
   return %10 : $()
 }
 
-sil private [noinline] @$testrecurbar : $@convention(thin) (@guaranteed { var Int }) -> () {
-bb0(%0 : ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = begin_access [read] [dynamic] %1 : $*Int
-  %4 = load %3 : $*Int
-  end_access %3 : $*Int
-  %6 = alloc_stack $Int
-  store %4 to %6 : $*Int
+sil private [noinline] @$testrecurbar : $@convention(thin) (@guaranteed { var Int64 }) -> () {
+bb0(%0 : ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = begin_access [read] [dynamic] %1 : $*Int64
+  %4 = load %3 : $*Int64
+  end_access %3 : $*Int64
+  %6 = alloc_stack $Int64
+  store %4 to %6 : $*Int64
   %8 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  %9 = apply %8<Int>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  dealloc_stack %6 : $*Int
-  %11 = function_ref @$testrecurbas : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %12 = apply %11(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %9 = apply %8<Int64>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %6 : $*Int64
+  %11 = function_ref @$testrecurbas : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %12 = apply %11(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
   %13 = tuple ()
   return %13 : $()
 }
 
-sil private [noinline] @$testrecurbas : $@convention(thin) (@guaranteed { var Int }) -> () {
-bb0(%0 : ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = function_ref @$testrecurbar : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+sil private [noinline] @$testrecurbas : $@convention(thin) (@guaranteed { var Int64 }) -> () {
+bb0(%0 : ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = function_ref @$testrecurbar : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
   %5 = tuple ()
   return %5 : $()
 }
 
 // CHECK-LABEL: sil [noinline] @$testbeginapply :
 // CHECK-NOT: alloc_box
-// CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK: [[STK:%.*]] = alloc_stack $Int64, var, name "x"
 // CHECK-LABEL: } // end sil function '$testbeginapply'
 sil [noinline] @$testbeginapply : $@convention(thin) () -> () {
 bb0:
-  %0 = alloc_box ${ var Int }, var, name "x"
-  %1 = project_box %0 : ${ var Int }, 0
+  %0 = alloc_box ${ var Int64 }, var, name "x"
+  %1 = project_box %0 : ${ var Int64 }, 0
   %2 = integer_literal $Builtin.Int64, 0
-  %3 = struct $Int (%2 : $Builtin.Int64)
-  store %3 to %1 : $*Int
-  %5 = function_ref @$testbeginapplybas : $@yield_once @convention(thin) (@guaranteed { var Int }) -> @yields ()
-  (%addr, %token) = begin_apply %5(%0) : $@yield_once @convention(thin) (@guaranteed { var Int }) -> @yields ()
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  store %3 to %1 : $*Int64
+  %5 = function_ref @$testbeginapplybas : $@yield_once @convention(thin) (@guaranteed { var Int64 }) -> @yields ()
+  (%addr, %token) = begin_apply %5(%0) : $@yield_once @convention(thin) (@guaranteed { var Int64 }) -> @yields ()
   end_apply %token
-  strong_release %0 : ${ var Int }
+  strong_release %0 : ${ var Int64 }
   %8 = tuple ()
   return %8 : $()
 }
 
-sil private [noinline] @$testbeginapplybar : $@convention(thin) (@guaranteed { var Int }) -> () {
-bb0(%0 : ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = begin_access [read] [dynamic] %1 : $*Int
-  %4 = load %3 : $*Int
-  end_access %3 : $*Int
-  %6 = alloc_stack $Int
-  store %4 to %6 : $*Int
+sil private [noinline] @$testbeginapplybar : $@convention(thin) (@guaranteed { var Int64 }) -> () {
+bb0(%0 : ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = begin_access [read] [dynamic] %1 : $*Int64
+  %4 = load %3 : $*Int64
+  end_access %3 : $*Int64
+  %6 = alloc_stack $Int64
+  store %4 to %6 : $*Int64
   %8 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  %9 = apply %8<Int>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  dealloc_stack %6 : $*Int
+  %9 = apply %8<Int64>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %6 : $*Int64
   %11 = tuple ()
   return %11 : $()
 }
 
-sil private [noinline] @$testbeginapplybas : $@yield_once @convention(thin) (@guaranteed { var Int }) -> @yields () {
-bb0(%0 : ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = function_ref @$testbeginapplybar : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+sil private [noinline] @$testbeginapplybas : $@yield_once @convention(thin) (@guaranteed { var Int64 }) -> @yields () {
+bb0(%0 : ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = function_ref @$testbeginapplybar : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
   %5 = tuple ()
   yield %5 : $(), resume bb1, unwind bb2
 bb1:

--- a/test/SILOptimizer/allocboxtostack_localapply.swift
+++ b/test/SILOptimizer/allocboxtostack_localapply.swift
@@ -1,0 +1,120 @@
+// RUN: %target-swift-frontend -emit-sil %s -O | %FileCheck %s
+
+
+@_optimize(none)
+@inline(never)
+func blackhole<T>(_ x:T) {
+}
+
+// CHECK-LABEL: sil [noinline] @$s26allocboxtostack_localapply9testapplySiyF :
+// CHECK-NOT: alloc_box
+// CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK-LABEL: } // end sil function '$s26allocboxtostack_localapply9testapplySiyF'
+@inline(never)
+public func testapply() -> Int {
+  var x = 0
+  @inline(never)
+  func bar() -> Int {
+    blackhole(x)
+    return x + 1
+  }
+  @inline(never)
+  func bas() -> Int {
+    return bar()
+  }
+  return bas()
+}
+
+// CHECK-LABEL: sil [noinline] @$s26allocboxtostack_localapply12testtryapplySiyKF :
+// CHECK-NOT: alloc_box
+// CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK-LABEL: } // end sil function '$s26allocboxtostack_localapply12testtryapplySiyKF'
+@inline(never)
+public func testtryapply() throws -> Int {
+  var x = 0
+  @inline(never)
+  func bar() throws -> Int {
+    blackhole(x)
+    return x + 1
+  }
+  @inline(never)
+  func bas() throws -> Int {
+    return try bar()
+  }
+  let res = try bas()
+  return res
+}
+
+// CHECK-LABEL: sil [noinline] @$s26allocboxtostack_localapply16testpartialapplySiyF :
+// CHECK-NOT: alloc_box
+// CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK-LABEL: } // end sil function '$s26allocboxtostack_localapply16testpartialapplySiyF'
+@inline(never)
+public func testpartialapply() -> Int {
+  var x = 0
+  @inline(never)
+  func bar() -> Int {
+    blackhole(x)
+    return x + 1
+  }
+  @inline(never)
+  func bas() -> Int {
+    return bar()
+  }
+  return {bas()}()
+}
+
+// CHECK-LABEL: sil [noinline] @$s26allocboxtostack_localapply12testtwoboxesSiyF :
+// CHECK-NOT: alloc_box
+// CHECK: [[STK1:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK: [[STK2:%.*]] = alloc_stack $Int, var, name "y"
+// CHECK-LABEL: } // end sil function '$s26allocboxtostack_localapply12testtwoboxesSiyF'
+@inline(never)
+public func testtwoboxes() -> Int {
+  var x = 0
+  var y = 0
+  @inline(never)
+  func bar() -> Int {
+    blackhole(x)
+    return x + y 
+  }
+  @inline(never)
+  func bas() -> Int {
+    return bar()
+  }
+  return bas()
+}
+
+// CHECK-LABEL: sil [noinline] @$s26allocboxtostack_localapply14testboxescapesyycyF :
+// CHECK: alloc_box ${ var Int }, var, name "x"
+// CHECK-LABEL: } // end sil function '$s26allocboxtostack_localapply14testboxescapesyycyF'
+@inline(never)
+public func testboxescapes() -> (() -> ()) {
+  var x = 0
+  @inline(never)
+  func bar() -> (() -> ()) {
+    return {x + 1}
+  }
+  @inline(never)
+  func bas() -> (() -> ()) {
+    return bar()
+  }
+  return bas()
+}
+
+// CHECK-LABEL: sil [noinline] @$s26allocboxtostack_localapply9testrecurSiyF :
+// CHECK: alloc_box ${ var Int }, var, name "x"
+// CHECK-LABEL: } // end sil function '$s26allocboxtostack_localapply9testrecurSiyF'
+@inline(never)
+public func testrecur() -> Int {
+  var x = 0
+  @inline(never)
+  func bar() -> Int {
+    return x + bas()
+  }
+  @inline(never)
+  func bas() -> Int {
+    return bar()
+  }
+  return bas() + bar()
+}

--- a/test/SILOptimizer/allocboxtostack_localapply_ossa.sil
+++ b/test/SILOptimizer/allocboxtostack_localapply_ossa.sil
@@ -1,0 +1,351 @@
+// RUN: %target-sil-opt %s -allocbox-to-stack -sil-deadfuncelim | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+
+sil hidden [noinline] [ossa] [Onone] @$blackhole : $@convention(thin) <T> (@in_guaranteed T) -> () {
+bb0(%0 : $*T):
+  %2 = tuple ()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil [noinline] [ossa] @$testapply :
+// CHECK-NOT: alloc_box
+// CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK-LABEL: } // end sil function '$testapply'
+sil [noinline] [ossa] @$testapply : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ var Int }, var, name "x"
+  %1 = project_box %0 : ${ var Int }, 0
+  %2 = integer_literal $Builtin.Int64, 0
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  store %3 to [trivial] %1 : $*Int
+  %5 = function_ref @$testapplybas : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  destroy_value %0 : ${ var Int }
+  %8 = tuple ()
+  return %8 : $()
+}
+
+sil private [noinline] [ossa] @$testapplybar : $@convention(thin) (@guaranteed { var Int }) -> () {
+bb0(%0 : @guaranteed ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = begin_access [read] [dynamic] %1 : $*Int
+  %4 = load [trivial] %3 : $*Int
+  end_access %3 : $*Int
+  %6 = alloc_stack $Int
+  store %4 to [trivial] %6 : $*Int
+  %8 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %9 = apply %8<Int>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %6 : $*Int
+  %11 = tuple ()
+  return %11 : $()
+}
+
+sil private [noinline] [ossa] @$testapplybas : $@convention(thin) (@guaranteed { var Int }) -> () {
+bb0(%0 : @guaranteed ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = function_ref @$testapplybar : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: sil [noinline] [ossa] @$testtryapply :
+// CHECK-NOT: alloc_box
+// CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK-LABEL: } // end sil function '$testtryapply'
+sil [noinline] [ossa] @$testtryapply : $@convention(thin) () -> @error Error {
+bb0:
+  %1 = alloc_box ${ var Int }, var, name "x"
+  %2 = project_box %1 : ${ var Int }, 0
+  %3 = integer_literal $Builtin.Int64, 0
+  %4 = struct $Int (%3 : $Builtin.Int64)
+  store %4 to [trivial] %2 : $*Int
+  %6 = function_ref @$testtryapplybas : $@convention(thin) (@guaranteed { var Int }) -> @error Error
+  try_apply %6(%1) : $@convention(thin) (@guaranteed { var Int }) -> @error Error, normal bb1, error bb2
+bb1(%8 : $()):
+  destroy_value %1 : ${ var Int }
+  %10 = tuple ()
+  return %10 : $()
+bb2(%12 : $Error):
+  destroy_value %1 : ${ var Int }
+  throw %12 : $Error
+}
+
+sil private [noinline] [ossa] @$testtryapplybar : $@convention(thin) (@guaranteed { var Int }) -> @error Error {
+bb0(%0 : @guaranteed ${ var Int }):
+  %2 = project_box %0 : ${ var Int }, 0
+  %4 = begin_access [read] [dynamic] %2 : $*Int
+  %5 = load [trivial] %4 : $*Int
+  end_access %4 : $*Int
+  %7 = alloc_stack $Int
+  store %5 to [trivial] %7 : $*Int
+  %9 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %10 = apply %9<Int>(%7) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %7 : $*Int
+  %12 = tuple ()
+  return %12 : $()
+}
+
+sil private [noinline] [ossa] @$testtryapplybas : $@convention(thin) (@guaranteed { var Int }) -> @error Error {
+bb0(%0 : @guaranteed ${ var Int }):
+  %2 = project_box %0 : ${ var Int }, 0
+  %4 = function_ref @$testtryapplybar : $@convention(thin) (@guaranteed { var Int }) -> @error Error
+  try_apply %4(%0) : $@convention(thin) (@guaranteed { var Int }) -> @error Error, normal bb1, error bb2
+bb1(%6 : $()):
+  %7 = tuple ()
+  return %7 : $()
+bb2(%9 : $Error):
+  throw %9 : $Error
+}
+
+
+// CHECK-LABEL: sil [noinline] [ossa] @$testpartialapply :
+// CHECK-NOT: alloc_box
+// CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK-LABEL: } // end sil function '$testpartialapply'
+sil [noinline] [ossa] @$testpartialapply : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ var Int }, var, name "x"
+  %1 = project_box %0 : ${ var Int }, 0
+  %2 = integer_literal $Builtin.Int64, 0
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  store %3 to [trivial] %1 : $*Int
+  %5 = function_ref @$testpartialapplyclosure : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  destroy_value %0 : ${ var Int }
+  %8 = tuple ()
+  return %8 : $()
+}
+
+sil private [noinline] [ossa] @$testpartialapplybar : $@convention(thin) (@guaranteed { var Int }) -> () {
+bb0(%0 : @guaranteed ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = begin_access [read] [dynamic] %1 : $*Int
+  %4 = load [trivial] %3 : $*Int
+  end_access %3 : $*Int
+  %6 = alloc_stack $Int
+  store %4 to [trivial] %6 : $*Int
+  %8 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %9 = apply %8<Int>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %6 : $*Int
+  %11 = tuple ()
+  return %11 : $()
+}
+
+sil private [noinline] [ossa] @$testpartialapplybas : $@convention(thin) (@guaranteed { var Int }) -> () {
+bb0(%0 : @guaranteed ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = function_ref @$testpartialapplybar : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %5 = tuple ()
+  return %5 : $()
+}
+
+sil private [ossa] @$testpartialapplyclosure : $@convention(thin) (@guaranteed { var Int }) -> () {
+bb0(%0 : @guaranteed ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = function_ref @$testpartialapplybas : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: sil [noinline] [ossa] @$testtwoboxes :
+// CHECK-NOT: alloc_box
+// CHECK: [[STK1:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK: [[STK2:%.*]] = alloc_stack $Int, var, name "y"
+// CHECK-LABEL: } // end sil function '$testtwoboxes'
+sil [noinline] [ossa] @$testtwoboxes : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ var Int }, var, name "x"
+  %1 = project_box %0 : ${ var Int }, 0
+  %2 = integer_literal $Builtin.Int64, 0
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  store %3 to [trivial] %1 : $*Int
+  %5 = alloc_box ${ var Int }, var, name "y"
+  %6 = project_box %5 : ${ var Int }, 0
+  %7 = integer_literal $Builtin.Int64, 0
+  %8 = struct $Int (%7 : $Builtin.Int64)
+  store %8 to [trivial] %6 : $*Int
+  %10 = function_ref @$testtwoboxesbas : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> ()
+  %11 = apply %10(%0, %5) : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> ()
+  destroy_value %5 : ${ var Int }
+  destroy_value %0 : ${ var Int }
+  %14 = tuple ()
+  return %14 : $()
+}
+
+sil private [noinline] [ossa] @$testtwoboxesbar : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> () {
+bb0(%0 : @guaranteed ${ var Int }, %1 : @guaranteed ${ var Int }):
+  %2 = project_box %0 : ${ var Int }, 0
+  %4 = project_box %1 : ${ var Int }, 0
+  %6 = begin_access [read] [dynamic] %2 : $*Int
+  %7 = load [trivial] %6 : $*Int
+  end_access %6 : $*Int
+  %9 = alloc_stack $Int
+  store %7 to [trivial] %9 : $*Int
+  %11 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %12 = apply %11<Int>(%9) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %9 : $*Int
+  %14 = begin_access [read] [dynamic] %4 : $*Int
+  %15 = load [trivial] %14 : $*Int
+  end_access %14 : $*Int
+  %17 = alloc_stack $Int
+  store %15 to [trivial] %17 : $*Int
+  %19 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %20 = apply %19<Int>(%17) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %17 : $*Int
+  %22 = tuple ()
+  return %22 : $()
+}
+
+sil private [noinline] [ossa] @$testtwoboxesbas : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> () {
+bb0(%0 : @guaranteed ${ var Int }, %1 : @guaranteed ${ var Int }):
+  %2 = project_box %0 : ${ var Int }, 0
+  %4 = project_box %1 : ${ var Int }, 0
+  %6 = function_ref @$testtwoboxesbar : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> ()
+  %7 = apply %6(%0, %1) : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> ()
+  %8 = tuple ()
+  return %8 : $()
+}
+
+// CHECK-LABEL: sil [noinline] [ossa] @$testboxescapes :
+// CHECK: alloc_box ${ var Int }, var, name "x"
+// CHECK-LABEL: } // end sil function '$testboxescapes'
+sil [noinline] [ossa] @$testboxescapes : $@convention(thin) () -> @owned @callee_guaranteed () -> () {
+bb0:
+  %0 = alloc_box ${ var Int }, var, name "x"
+  %1 = project_box %0 : ${ var Int }, 0
+  %2 = integer_literal $Builtin.Int64, 0
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  store %3 to [trivial] %1 : $*Int
+  %5 = function_ref @$testboxescapesbas : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> ()
+  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> ()
+  destroy_value %0 : ${ var Int }
+  return %6 : $@callee_guaranteed () -> ()
+}
+
+sil private [noinline] [ossa] @$testboxescapesbar : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> () {
+bb0(%0 : @guaranteed ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = function_ref @$testboxescapesclosure : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %copy = copy_value %0 : ${ var Int }
+  %5 = partial_apply [callee_guaranteed] %3(%copy) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  return %5 : $@callee_guaranteed () -> ()
+}
+
+sil private [ossa] @$testboxescapesclosure : $@convention(thin) (@guaranteed { var Int }) -> () {
+bb0(%0 : @guaranteed ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = load [trivial] %1 : $*Int
+  %4 = tuple ()
+  return %4 : $()
+}
+
+sil private [noinline] [ossa] @$testboxescapesbas : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> () {
+bb0(%0 : @guaranteed ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = function_ref @$testboxescapesbar : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> ()
+  return %4 : $@callee_guaranteed () -> ()
+}
+
+// CHECK-LABEL: sil [noinline] [ossa] @$testrecur :
+// CHECK: alloc_box ${ var Int }, var, name "x"
+// CHECK-LABEL: } // end sil function '$testrecur'
+sil [noinline] [ossa] @$testrecur : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ var Int }, var, name "x"
+  %1 = project_box %0 : ${ var Int }, 0
+  %2 = integer_literal $Builtin.Int64, 0
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  store %3 to [trivial] %1 : $*Int
+  %5 = function_ref @$testrecurbas : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %7 = function_ref @$testrecurbar : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %8 = apply %7(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  destroy_value %0 : ${ var Int }
+  %10 = tuple ()
+  return %10 : $()
+}
+
+sil private [noinline] [ossa] @$testrecurbar : $@convention(thin) (@guaranteed { var Int }) -> () {
+bb0(%0 : @guaranteed ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = begin_access [read] [dynamic] %1 : $*Int
+  %4 = load [trivial] %3 : $*Int
+  end_access %3 : $*Int
+  %6 = alloc_stack $Int
+  store %4 to [trivial] %6 : $*Int
+  %8 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %9 = apply %8<Int>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %6 : $*Int
+  %11 = function_ref @$testrecurbas : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %12 = apply %11(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %13 = tuple ()
+  return %13 : $()
+}
+
+sil private [noinline] [ossa] @$testrecurbas : $@convention(thin) (@guaranteed { var Int }) -> () {
+bb0(%0 : @guaranteed ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = function_ref @$testrecurbar : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: sil [noinline] [ossa] @$testbeginapply :
+// CHECK-NOT: alloc_box
+// CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK-LABEL: } // end sil function '$testbeginapply'
+sil [noinline] [ossa] @$testbeginapply : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ var Int }, var, name "x"
+  %1 = project_box %0 : ${ var Int }, 0
+  %2 = integer_literal $Builtin.Int64, 0
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  store %3 to [trivial] %1 : $*Int
+  %5 = function_ref @$testbeginapplybas : $@yield_once @convention(thin) (@guaranteed { var Int }) -> @yields ()
+  (%addr, %token) = begin_apply %5(%0) : $@yield_once @convention(thin) (@guaranteed { var Int }) -> @yields ()
+  end_apply %token
+  destroy_value %0 : ${ var Int }
+  %8 = tuple ()
+  return %8 : $()
+}
+
+sil private [noinline] [ossa] @$testbeginapplybar : $@convention(thin) (@guaranteed { var Int }) -> () {
+bb0(%0 : @guaranteed ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = begin_access [read] [dynamic] %1 : $*Int
+  %4 = load [trivial] %3 : $*Int
+  end_access %3 : $*Int
+  %6 = alloc_stack $Int
+  store %4 to [trivial] %6 : $*Int
+  %8 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %9 = apply %8<Int>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %6 : $*Int
+  %11 = tuple ()
+  return %11 : $()
+}
+
+sil private [noinline] [ossa] @$testbeginapplybas : $@yield_once @convention(thin) (@guaranteed { var Int }) -> @yields () {
+bb0(%0 : @guaranteed ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %3 = function_ref @$testbeginapplybar : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %5 = tuple ()
+  yield %5 : $(), resume bb1, unwind bb2
+bb1:
+  %rv = tuple()
+  return %rv : $()
+bb2:
+  unwind
+}
+

--- a/test/SILOptimizer/allocboxtostack_localapply_ossa.sil
+++ b/test/SILOptimizer/allocboxtostack_localapply_ossa.sil
@@ -15,88 +15,88 @@ bb0(%0 : $*T):
 
 // CHECK-LABEL: sil [noinline] [ossa] @$testapply :
 // CHECK-NOT: alloc_box
-// CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK: [[STK:%.*]] = alloc_stack $Int64, var, name "x"
 // CHECK-LABEL: } // end sil function '$testapply'
 sil [noinline] [ossa] @$testapply : $@convention(thin) () -> () {
 bb0:
-  %0 = alloc_box ${ var Int }, var, name "x"
-  %1 = project_box %0 : ${ var Int }, 0
+  %0 = alloc_box ${ var Int64 }, var, name "x"
+  %1 = project_box %0 : ${ var Int64 }, 0
   %2 = integer_literal $Builtin.Int64, 0
-  %3 = struct $Int (%2 : $Builtin.Int64)
-  store %3 to [trivial] %1 : $*Int
-  %5 = function_ref @$testapplybas : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
-  destroy_value %0 : ${ var Int }
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  store %3 to [trivial] %1 : $*Int64
+  %5 = function_ref @$testapplybas : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  destroy_value %0 : ${ var Int64 }
   %8 = tuple ()
   return %8 : $()
 }
 
-sil private [noinline] [ossa] @$testapplybar : $@convention(thin) (@guaranteed { var Int }) -> () {
-bb0(%0 : @guaranteed ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = begin_access [read] [dynamic] %1 : $*Int
-  %4 = load [trivial] %3 : $*Int
-  end_access %3 : $*Int
-  %6 = alloc_stack $Int
-  store %4 to [trivial] %6 : $*Int
+sil private [noinline] [ossa] @$testapplybar : $@convention(thin) (@guaranteed { var Int64 }) -> () {
+bb0(%0 : @guaranteed ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = begin_access [read] [dynamic] %1 : $*Int64
+  %4 = load [trivial] %3 : $*Int64
+  end_access %3 : $*Int64
+  %6 = alloc_stack $Int64
+  store %4 to [trivial] %6 : $*Int64
   %8 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  %9 = apply %8<Int>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  dealloc_stack %6 : $*Int
+  %9 = apply %8<Int64>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %6 : $*Int64
   %11 = tuple ()
   return %11 : $()
 }
 
-sil private [noinline] [ossa] @$testapplybas : $@convention(thin) (@guaranteed { var Int }) -> () {
-bb0(%0 : @guaranteed ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = function_ref @$testapplybar : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+sil private [noinline] [ossa] @$testapplybas : $@convention(thin) (@guaranteed { var Int64 }) -> () {
+bb0(%0 : @guaranteed ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = function_ref @$testapplybar : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
   %5 = tuple ()
   return %5 : $()
 }
 
 // CHECK-LABEL: sil [noinline] [ossa] @$testtryapply :
 // CHECK-NOT: alloc_box
-// CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK: [[STK:%.*]] = alloc_stack $Int64, var, name "x"
 // CHECK-LABEL: } // end sil function '$testtryapply'
 sil [noinline] [ossa] @$testtryapply : $@convention(thin) () -> @error Error {
 bb0:
-  %1 = alloc_box ${ var Int }, var, name "x"
-  %2 = project_box %1 : ${ var Int }, 0
+  %1 = alloc_box ${ var Int64 }, var, name "x"
+  %2 = project_box %1 : ${ var Int64 }, 0
   %3 = integer_literal $Builtin.Int64, 0
-  %4 = struct $Int (%3 : $Builtin.Int64)
-  store %4 to [trivial] %2 : $*Int
-  %6 = function_ref @$testtryapplybas : $@convention(thin) (@guaranteed { var Int }) -> @error Error
-  try_apply %6(%1) : $@convention(thin) (@guaranteed { var Int }) -> @error Error, normal bb1, error bb2
+  %4 = struct $Int64 (%3 : $Builtin.Int64)
+  store %4 to [trivial] %2 : $*Int64
+  %6 = function_ref @$testtryapplybas : $@convention(thin) (@guaranteed { var Int64 }) -> @error Error
+  try_apply %6(%1) : $@convention(thin) (@guaranteed { var Int64 }) -> @error Error, normal bb1, error bb2
 bb1(%8 : $()):
-  destroy_value %1 : ${ var Int }
+  destroy_value %1 : ${ var Int64 }
   %10 = tuple ()
   return %10 : $()
 bb2(%12 : $Error):
-  destroy_value %1 : ${ var Int }
+  destroy_value %1 : ${ var Int64 }
   throw %12 : $Error
 }
 
-sil private [noinline] [ossa] @$testtryapplybar : $@convention(thin) (@guaranteed { var Int }) -> @error Error {
-bb0(%0 : @guaranteed ${ var Int }):
-  %2 = project_box %0 : ${ var Int }, 0
-  %4 = begin_access [read] [dynamic] %2 : $*Int
-  %5 = load [trivial] %4 : $*Int
-  end_access %4 : $*Int
-  %7 = alloc_stack $Int
-  store %5 to [trivial] %7 : $*Int
+sil private [noinline] [ossa] @$testtryapplybar : $@convention(thin) (@guaranteed { var Int64 }) -> @error Error {
+bb0(%0 : @guaranteed ${ var Int64 }):
+  %2 = project_box %0 : ${ var Int64 }, 0
+  %4 = begin_access [read] [dynamic] %2 : $*Int64
+  %5 = load [trivial] %4 : $*Int64
+  end_access %4 : $*Int64
+  %7 = alloc_stack $Int64
+  store %5 to [trivial] %7 : $*Int64
   %9 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  %10 = apply %9<Int>(%7) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  dealloc_stack %7 : $*Int
+  %10 = apply %9<Int64>(%7) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %7 : $*Int64
   %12 = tuple ()
   return %12 : $()
 }
 
-sil private [noinline] [ossa] @$testtryapplybas : $@convention(thin) (@guaranteed { var Int }) -> @error Error {
-bb0(%0 : @guaranteed ${ var Int }):
-  %2 = project_box %0 : ${ var Int }, 0
-  %4 = function_ref @$testtryapplybar : $@convention(thin) (@guaranteed { var Int }) -> @error Error
-  try_apply %4(%0) : $@convention(thin) (@guaranteed { var Int }) -> @error Error, normal bb1, error bb2
+sil private [noinline] [ossa] @$testtryapplybas : $@convention(thin) (@guaranteed { var Int64 }) -> @error Error {
+bb0(%0 : @guaranteed ${ var Int64 }):
+  %2 = project_box %0 : ${ var Int64 }, 0
+  %4 = function_ref @$testtryapplybar : $@convention(thin) (@guaranteed { var Int64 }) -> @error Error
+  try_apply %4(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> @error Error, normal bb1, error bb2
 bb1(%6 : $()):
   %7 = tuple ()
   return %7 : $()
@@ -107,239 +107,239 @@ bb2(%9 : $Error):
 
 // CHECK-LABEL: sil [noinline] [ossa] @$testpartialapply :
 // CHECK-NOT: alloc_box
-// CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK: [[STK:%.*]] = alloc_stack $Int64, var, name "x"
 // CHECK-LABEL: } // end sil function '$testpartialapply'
 sil [noinline] [ossa] @$testpartialapply : $@convention(thin) () -> () {
 bb0:
-  %0 = alloc_box ${ var Int }, var, name "x"
-  %1 = project_box %0 : ${ var Int }, 0
+  %0 = alloc_box ${ var Int64 }, var, name "x"
+  %1 = project_box %0 : ${ var Int64 }, 0
   %2 = integer_literal $Builtin.Int64, 0
-  %3 = struct $Int (%2 : $Builtin.Int64)
-  store %3 to [trivial] %1 : $*Int
-  %5 = function_ref @$testpartialapplyclosure : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
-  destroy_value %0 : ${ var Int }
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  store %3 to [trivial] %1 : $*Int64
+  %5 = function_ref @$testpartialapplyclosure : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  destroy_value %0 : ${ var Int64 }
   %8 = tuple ()
   return %8 : $()
 }
 
-sil private [noinline] [ossa] @$testpartialapplybar : $@convention(thin) (@guaranteed { var Int }) -> () {
-bb0(%0 : @guaranteed ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = begin_access [read] [dynamic] %1 : $*Int
-  %4 = load [trivial] %3 : $*Int
-  end_access %3 : $*Int
-  %6 = alloc_stack $Int
-  store %4 to [trivial] %6 : $*Int
+sil private [noinline] [ossa] @$testpartialapplybar : $@convention(thin) (@guaranteed { var Int64 }) -> () {
+bb0(%0 : @guaranteed ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = begin_access [read] [dynamic] %1 : $*Int64
+  %4 = load [trivial] %3 : $*Int64
+  end_access %3 : $*Int64
+  %6 = alloc_stack $Int64
+  store %4 to [trivial] %6 : $*Int64
   %8 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  %9 = apply %8<Int>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  dealloc_stack %6 : $*Int
+  %9 = apply %8<Int64>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %6 : $*Int64
   %11 = tuple ()
   return %11 : $()
 }
 
-sil private [noinline] [ossa] @$testpartialapplybas : $@convention(thin) (@guaranteed { var Int }) -> () {
-bb0(%0 : @guaranteed ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = function_ref @$testpartialapplybar : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+sil private [noinline] [ossa] @$testpartialapplybas : $@convention(thin) (@guaranteed { var Int64 }) -> () {
+bb0(%0 : @guaranteed ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = function_ref @$testpartialapplybar : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
   %5 = tuple ()
   return %5 : $()
 }
 
-sil private [ossa] @$testpartialapplyclosure : $@convention(thin) (@guaranteed { var Int }) -> () {
-bb0(%0 : @guaranteed ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = function_ref @$testpartialapplybas : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+sil private [ossa] @$testpartialapplyclosure : $@convention(thin) (@guaranteed { var Int64 }) -> () {
+bb0(%0 : @guaranteed ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = function_ref @$testpartialapplybas : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
   %5 = tuple ()
   return %5 : $()
 }
 
 // CHECK-LABEL: sil [noinline] [ossa] @$testtwoboxes :
 // CHECK-NOT: alloc_box
-// CHECK: [[STK1:%.*]] = alloc_stack $Int, var, name "x"
-// CHECK: [[STK2:%.*]] = alloc_stack $Int, var, name "y"
+// CHECK: [[STK1:%.*]] = alloc_stack $Int64, var, name "x"
+// CHECK: [[STK2:%.*]] = alloc_stack $Int64, var, name "y"
 // CHECK-LABEL: } // end sil function '$testtwoboxes'
 sil [noinline] [ossa] @$testtwoboxes : $@convention(thin) () -> () {
 bb0:
-  %0 = alloc_box ${ var Int }, var, name "x"
-  %1 = project_box %0 : ${ var Int }, 0
+  %0 = alloc_box ${ var Int64 }, var, name "x"
+  %1 = project_box %0 : ${ var Int64 }, 0
   %2 = integer_literal $Builtin.Int64, 0
-  %3 = struct $Int (%2 : $Builtin.Int64)
-  store %3 to [trivial] %1 : $*Int
-  %5 = alloc_box ${ var Int }, var, name "y"
-  %6 = project_box %5 : ${ var Int }, 0
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  store %3 to [trivial] %1 : $*Int64
+  %5 = alloc_box ${ var Int64 }, var, name "y"
+  %6 = project_box %5 : ${ var Int64 }, 0
   %7 = integer_literal $Builtin.Int64, 0
-  %8 = struct $Int (%7 : $Builtin.Int64)
-  store %8 to [trivial] %6 : $*Int
-  %10 = function_ref @$testtwoboxesbas : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> ()
-  %11 = apply %10(%0, %5) : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> ()
-  destroy_value %5 : ${ var Int }
-  destroy_value %0 : ${ var Int }
+  %8 = struct $Int64 (%7 : $Builtin.Int64)
+  store %8 to [trivial] %6 : $*Int64
+  %10 = function_ref @$testtwoboxesbas : $@convention(thin) (@guaranteed { var Int64 }, @guaranteed { var Int64 }) -> ()
+  %11 = apply %10(%0, %5) : $@convention(thin) (@guaranteed { var Int64 }, @guaranteed { var Int64 }) -> ()
+  destroy_value %5 : ${ var Int64 }
+  destroy_value %0 : ${ var Int64 }
   %14 = tuple ()
   return %14 : $()
 }
 
-sil private [noinline] [ossa] @$testtwoboxesbar : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> () {
-bb0(%0 : @guaranteed ${ var Int }, %1 : @guaranteed ${ var Int }):
-  %2 = project_box %0 : ${ var Int }, 0
-  %4 = project_box %1 : ${ var Int }, 0
-  %6 = begin_access [read] [dynamic] %2 : $*Int
-  %7 = load [trivial] %6 : $*Int
-  end_access %6 : $*Int
-  %9 = alloc_stack $Int
-  store %7 to [trivial] %9 : $*Int
+sil private [noinline] [ossa] @$testtwoboxesbar : $@convention(thin) (@guaranteed { var Int64 }, @guaranteed { var Int64 }) -> () {
+bb0(%0 : @guaranteed ${ var Int64 }, %1 : @guaranteed ${ var Int64 }):
+  %2 = project_box %0 : ${ var Int64 }, 0
+  %4 = project_box %1 : ${ var Int64 }, 0
+  %6 = begin_access [read] [dynamic] %2 : $*Int64
+  %7 = load [trivial] %6 : $*Int64
+  end_access %6 : $*Int64
+  %9 = alloc_stack $Int64
+  store %7 to [trivial] %9 : $*Int64
   %11 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  %12 = apply %11<Int>(%9) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  dealloc_stack %9 : $*Int
-  %14 = begin_access [read] [dynamic] %4 : $*Int
-  %15 = load [trivial] %14 : $*Int
-  end_access %14 : $*Int
-  %17 = alloc_stack $Int
-  store %15 to [trivial] %17 : $*Int
+  %12 = apply %11<Int64>(%9) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %9 : $*Int64
+  %14 = begin_access [read] [dynamic] %4 : $*Int64
+  %15 = load [trivial] %14 : $*Int64
+  end_access %14 : $*Int64
+  %17 = alloc_stack $Int64
+  store %15 to [trivial] %17 : $*Int64
   %19 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  %20 = apply %19<Int>(%17) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  dealloc_stack %17 : $*Int
+  %20 = apply %19<Int64>(%17) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %17 : $*Int64
   %22 = tuple ()
   return %22 : $()
 }
 
-sil private [noinline] [ossa] @$testtwoboxesbas : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> () {
-bb0(%0 : @guaranteed ${ var Int }, %1 : @guaranteed ${ var Int }):
-  %2 = project_box %0 : ${ var Int }, 0
-  %4 = project_box %1 : ${ var Int }, 0
-  %6 = function_ref @$testtwoboxesbar : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> ()
-  %7 = apply %6(%0, %1) : $@convention(thin) (@guaranteed { var Int }, @guaranteed { var Int }) -> ()
+sil private [noinline] [ossa] @$testtwoboxesbas : $@convention(thin) (@guaranteed { var Int64 }, @guaranteed { var Int64 }) -> () {
+bb0(%0 : @guaranteed ${ var Int64 }, %1 : @guaranteed ${ var Int64 }):
+  %2 = project_box %0 : ${ var Int64 }, 0
+  %4 = project_box %1 : ${ var Int64 }, 0
+  %6 = function_ref @$testtwoboxesbar : $@convention(thin) (@guaranteed { var Int64 }, @guaranteed { var Int64 }) -> ()
+  %7 = apply %6(%0, %1) : $@convention(thin) (@guaranteed { var Int64 }, @guaranteed { var Int64 }) -> ()
   %8 = tuple ()
   return %8 : $()
 }
 
 // CHECK-LABEL: sil [noinline] [ossa] @$testboxescapes :
-// CHECK: alloc_box ${ var Int }, var, name "x"
+// CHECK: alloc_box ${ var Int64 }, var, name "x"
 // CHECK-LABEL: } // end sil function '$testboxescapes'
 sil [noinline] [ossa] @$testboxescapes : $@convention(thin) () -> @owned @callee_guaranteed () -> () {
 bb0:
-  %0 = alloc_box ${ var Int }, var, name "x"
-  %1 = project_box %0 : ${ var Int }, 0
+  %0 = alloc_box ${ var Int64 }, var, name "x"
+  %1 = project_box %0 : ${ var Int64 }, 0
   %2 = integer_literal $Builtin.Int64, 0
-  %3 = struct $Int (%2 : $Builtin.Int64)
-  store %3 to [trivial] %1 : $*Int
-  %5 = function_ref @$testboxescapesbas : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> ()
-  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> ()
-  destroy_value %0 : ${ var Int }
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  store %3 to [trivial] %1 : $*Int64
+  %5 = function_ref @$testboxescapesbas : $@convention(thin) (@guaranteed { var Int64 }) -> @owned @callee_guaranteed () -> ()
+  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> @owned @callee_guaranteed () -> ()
+  destroy_value %0 : ${ var Int64 }
   return %6 : $@callee_guaranteed () -> ()
 }
 
-sil private [noinline] [ossa] @$testboxescapesbar : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> () {
-bb0(%0 : @guaranteed ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = function_ref @$testboxescapesclosure : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %copy = copy_value %0 : ${ var Int }
-  %5 = partial_apply [callee_guaranteed] %3(%copy) : $@convention(thin) (@guaranteed { var Int }) -> ()
+sil private [noinline] [ossa] @$testboxescapesbar : $@convention(thin) (@guaranteed { var Int64 }) -> @owned @callee_guaranteed () -> () {
+bb0(%0 : @guaranteed ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = function_ref @$testboxescapesclosure : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %copy = copy_value %0 : ${ var Int64 }
+  %5 = partial_apply [callee_guaranteed] %3(%copy) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
   return %5 : $@callee_guaranteed () -> ()
 }
 
-sil private [ossa] @$testboxescapesclosure : $@convention(thin) (@guaranteed { var Int }) -> () {
-bb0(%0 : @guaranteed ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = load [trivial] %1 : $*Int
+sil private [ossa] @$testboxescapesclosure : $@convention(thin) (@guaranteed { var Int64 }) -> () {
+bb0(%0 : @guaranteed ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = load [trivial] %1 : $*Int64
   %4 = tuple ()
   return %4 : $()
 }
 
-sil private [noinline] [ossa] @$testboxescapesbas : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> () {
-bb0(%0 : @guaranteed ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = function_ref @$testboxescapesbar : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> ()
-  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> ()
+sil private [noinline] [ossa] @$testboxescapesbas : $@convention(thin) (@guaranteed { var Int64 }) -> @owned @callee_guaranteed () -> () {
+bb0(%0 : @guaranteed ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = function_ref @$testboxescapesbar : $@convention(thin) (@guaranteed { var Int64 }) -> @owned @callee_guaranteed () -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> @owned @callee_guaranteed () -> ()
   return %4 : $@callee_guaranteed () -> ()
 }
 
 // CHECK-LABEL: sil [noinline] [ossa] @$testrecur :
-// CHECK: alloc_box ${ var Int }, var, name "x"
+// CHECK: alloc_box ${ var Int64 }, var, name "x"
 // CHECK-LABEL: } // end sil function '$testrecur'
 sil [noinline] [ossa] @$testrecur : $@convention(thin) () -> () {
 bb0:
-  %0 = alloc_box ${ var Int }, var, name "x"
-  %1 = project_box %0 : ${ var Int }, 0
+  %0 = alloc_box ${ var Int64 }, var, name "x"
+  %1 = project_box %0 : ${ var Int64 }, 0
   %2 = integer_literal $Builtin.Int64, 0
-  %3 = struct $Int (%2 : $Builtin.Int64)
-  store %3 to [trivial] %1 : $*Int
-  %5 = function_ref @$testrecurbas : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %7 = function_ref @$testrecurbar : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %8 = apply %7(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
-  destroy_value %0 : ${ var Int }
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  store %3 to [trivial] %1 : $*Int64
+  %5 = function_ref @$testrecurbas : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %6 = apply %5(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %7 = function_ref @$testrecurbar : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %8 = apply %7(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  destroy_value %0 : ${ var Int64 }
   %10 = tuple ()
   return %10 : $()
 }
 
-sil private [noinline] [ossa] @$testrecurbar : $@convention(thin) (@guaranteed { var Int }) -> () {
-bb0(%0 : @guaranteed ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = begin_access [read] [dynamic] %1 : $*Int
-  %4 = load [trivial] %3 : $*Int
-  end_access %3 : $*Int
-  %6 = alloc_stack $Int
-  store %4 to [trivial] %6 : $*Int
+sil private [noinline] [ossa] @$testrecurbar : $@convention(thin) (@guaranteed { var Int64 }) -> () {
+bb0(%0 : @guaranteed ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = begin_access [read] [dynamic] %1 : $*Int64
+  %4 = load [trivial] %3 : $*Int64
+  end_access %3 : $*Int64
+  %6 = alloc_stack $Int64
+  store %4 to [trivial] %6 : $*Int64
   %8 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  %9 = apply %8<Int>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  dealloc_stack %6 : $*Int
-  %11 = function_ref @$testrecurbas : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %12 = apply %11(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %9 = apply %8<Int64>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %6 : $*Int64
+  %11 = function_ref @$testrecurbas : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %12 = apply %11(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
   %13 = tuple ()
   return %13 : $()
 }
 
-sil private [noinline] [ossa] @$testrecurbas : $@convention(thin) (@guaranteed { var Int }) -> () {
-bb0(%0 : @guaranteed ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = function_ref @$testrecurbar : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+sil private [noinline] [ossa] @$testrecurbas : $@convention(thin) (@guaranteed { var Int64 }) -> () {
+bb0(%0 : @guaranteed ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = function_ref @$testrecurbar : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
   %5 = tuple ()
   return %5 : $()
 }
 
 // CHECK-LABEL: sil [noinline] [ossa] @$testbeginapply :
 // CHECK-NOT: alloc_box
-// CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK: [[STK:%.*]] = alloc_stack $Int64, var, name "x"
 // CHECK-LABEL: } // end sil function '$testbeginapply'
 sil [noinline] [ossa] @$testbeginapply : $@convention(thin) () -> () {
 bb0:
-  %0 = alloc_box ${ var Int }, var, name "x"
-  %1 = project_box %0 : ${ var Int }, 0
+  %0 = alloc_box ${ var Int64 }, var, name "x"
+  %1 = project_box %0 : ${ var Int64 }, 0
   %2 = integer_literal $Builtin.Int64, 0
-  %3 = struct $Int (%2 : $Builtin.Int64)
-  store %3 to [trivial] %1 : $*Int
-  %5 = function_ref @$testbeginapplybas : $@yield_once @convention(thin) (@guaranteed { var Int }) -> @yields ()
-  (%addr, %token) = begin_apply %5(%0) : $@yield_once @convention(thin) (@guaranteed { var Int }) -> @yields ()
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  store %3 to [trivial] %1 : $*Int64
+  %5 = function_ref @$testbeginapplybas : $@yield_once @convention(thin) (@guaranteed { var Int64 }) -> @yields ()
+  (%addr, %token) = begin_apply %5(%0) : $@yield_once @convention(thin) (@guaranteed { var Int64 }) -> @yields ()
   end_apply %token
-  destroy_value %0 : ${ var Int }
+  destroy_value %0 : ${ var Int64 }
   %8 = tuple ()
   return %8 : $()
 }
 
-sil private [noinline] [ossa] @$testbeginapplybar : $@convention(thin) (@guaranteed { var Int }) -> () {
-bb0(%0 : @guaranteed ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = begin_access [read] [dynamic] %1 : $*Int
-  %4 = load [trivial] %3 : $*Int
-  end_access %3 : $*Int
-  %6 = alloc_stack $Int
-  store %4 to [trivial] %6 : $*Int
+sil private [noinline] [ossa] @$testbeginapplybar : $@convention(thin) (@guaranteed { var Int64 }) -> () {
+bb0(%0 : @guaranteed ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = begin_access [read] [dynamic] %1 : $*Int64
+  %4 = load [trivial] %3 : $*Int64
+  end_access %3 : $*Int64
+  %6 = alloc_stack $Int64
+  store %4 to [trivial] %6 : $*Int64
   %8 = function_ref @$blackhole : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  %9 = apply %8<Int>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  dealloc_stack %6 : $*Int
+  %9 = apply %8<Int64>(%6) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %6 : $*Int64
   %11 = tuple ()
   return %11 : $()
 }
 
-sil private [noinline] [ossa] @$testbeginapplybas : $@yield_once @convention(thin) (@guaranteed { var Int }) -> @yields () {
-bb0(%0 : @guaranteed ${ var Int }):
-  %1 = project_box %0 : ${ var Int }, 0
-  %3 = function_ref @$testbeginapplybar : $@convention(thin) (@guaranteed { var Int }) -> ()
-  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int }) -> ()
+sil private [noinline] [ossa] @$testbeginapplybas : $@yield_once @convention(thin) (@guaranteed { var Int64 }) -> @yields () {
+bb0(%0 : @guaranteed ${ var Int64 }):
+  %1 = project_box %0 : ${ var Int64 }, 0
+  %3 = function_ref @$testbeginapplybar : $@convention(thin) (@guaranteed { var Int64 }) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed { var Int64 }) -> ()
   %5 = tuple ()
   yield %5 : $(), resume bb1, unwind bb2
 bb1:


### PR DESCRIPTION
AllocBoxToStack analyzes the uses of boxes and promotes them to stack if it is safe to do so. Currently the analysis is limited to only a few known users including partial_apply.
With this change, the pass also analyzes apply users, where the callee is a local private function. The analysis is recursive and bound by a threshold.

 Fixes rdar://59070139