### PR TITLE
[Gardening] Fix typo in documentation of SetAlgebra.remove(_:)

### DIFF
--- a/stdlib/public/core/SetAlgebra.swift
+++ b/stdlib/public/core/SetAlgebra.swift
@@ -202,7 +202,7 @@ public protocol SetAlgebra: Equatable, ExpressibleByArrayLiteral {
   /// - Parameter member: The element of the set to remove.
   /// - Returns: For ordinary sets, an element equal to `member` if `member` is
   ///   contained in the set; otherwise, `nil`. In some cases, a returned
-  ///   element may be distinguishable from `newMember` by identity comparison
+  ///   element may be distinguishable from `member` by identity comparison
   ///   or some other means.
   ///
   ///   For sets where the set type and element type are the same, like


### PR DESCRIPTION
"newMember" → "member"