### PR TITLE
[5.3] Fix NULL deref for invalid mangled input (#31878)

### DIFF
--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -2007,6 +2007,8 @@ NodePointer Demangler::demangleArchetype() {
     if (!demangleBoundGenerics(boundGenericArgs, retroactiveConformances))
       return nullptr;
     auto Name = popNode();
+    if (!Name)
+      return nullptr;
     auto opaque = createWithChildren(Node::Kind::OpaqueType, Name,
                                    createNode(Node::Kind::Index, index));
     auto boundGenerics = createNode(Node::Kind::TypeList);

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -357,3 +357,5 @@ $s17property_wrappers10WithTuplesV9fractionsSd_S2dtvpfP --> property wrapper bac
 $sSo17OS_dispatch_queueC4sync7executeyyyXE_tFTOTA ---> {T:$sSo17OS_dispatch_queueC4sync7executeyyyXE_tFTO} partial apply forwarder for @nonobjc __C.OS_dispatch_queue.sync(execute: () -> ()) -> ()
 $sxq_Idgnr_D ---> @differentiable @callee_guaranteed (@in_guaranteed A) -> (@out B)
 $sxq_Ilgnr_D ---> @differentiable(linear) @callee_guaranteed (@in_guaranteed A) -> (@out B)
+$sS3fIedgyywd_D ---> @escaping @differentiable @callee_guaranteed (@unowned Swift.Float, @unowned @noDerivative Swift.Float) -> (@unowned Swift.Float)
+$syQo ---> $syQo

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -357,5 +357,4 @@ $s17property_wrappers10WithTuplesV9fractionsSd_S2dtvpfP --> property wrapper bac
 $sSo17OS_dispatch_queueC4sync7executeyyyXE_tFTOTA ---> {T:$sSo17OS_dispatch_queueC4sync7executeyyyXE_tFTO} partial apply forwarder for @nonobjc __C.OS_dispatch_queue.sync(execute: () -> ()) -> ()
 $sxq_Idgnr_D ---> @differentiable @callee_guaranteed (@in_guaranteed A) -> (@out B)
 $sxq_Ilgnr_D ---> @differentiable(linear) @callee_guaranteed (@in_guaranteed A) -> (@out B)
-$sS3fIedgyywd_D ---> @escaping @differentiable @callee_guaranteed (@unowned Swift.Float, @unowned @noDerivative Swift.Float) -> (@unowned Swift.Float)
 $syQo ---> $syQo


### PR DESCRIPTION
This is a nomination to merge this change into release/5.3

**Original description**: The `Qo` operator expects to consume a type name and a list (terminated with a `y` empty list marker) from the stack.  After popping the list, it doesn't check whether the stack is empty, so `$syQo` crashes (it pops down to the `y` then tries to pop again).

This PR just adds the obvious check to guard against this.

**Risk**: Minor.  We just fail if a nullptr is encountered at one point where valid input should never give us a nullptr.  The code would previously segfault at this point.  This should only ever happen on malformed input.

**Testing**:  Verified by original reporter, CI testing, local validation test runs.

Resolves rdar://63128307

