### PR TITLE
[Diagnostics] Strip off unrelated optionals from generic parameter di…

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -630,10 +630,31 @@ void GenericArgumentsMismatchFailure::emitNoteForMismatch(int position) {
 
 bool GenericArgumentsMismatchFailure::diagnoseAsError() {
   auto anchor = getAnchor();
-  auto path = getLocator()->getPath();
 
   auto fromType = getFromType();
   auto toType = getToType();
+
+  // This is a situation where right-hand size type is wrapped
+  // into a number of optionals and argument isn't e.g.
+  //
+  // func test(_: UnsafePointer<Int>??) {}
+  //
+  // var value: Float = 0
+  // test(&value)
+  //
+  // `value` has to get implicitly wrapped into 2 optionals
+  // before pointer types could be compared.
+  auto path = getLocator()->getPath();
+  unsigned toDrop = 0;
+  for (const auto &elt : llvm::reverse(path)) {
+    if (!elt.is<LocatorPathElt::OptionalPayload>())
+      break;
+
+    // Disregard optional payload element to look at its source.
+    toDrop++;
+  }
+
+  path = path.drop_back(toDrop);
 
   Optional<Diag<Type, Type>> diagnostic;
   if (path.empty()) {
@@ -681,18 +702,6 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
     case ConstraintLocator::ClosureBody:
     case ConstraintLocator::ClosureResult: {
       diagnostic = diag::cannot_convert_closure_result;
-      break;
-    }
-
-    case ConstraintLocator::OptionalPayload: {
-      // If we have an inout expression, this comes from an
-      // InoutToPointer argument mismatch failure.
-      if (isExpr<InOutExpr>(anchor)) {
-        diagnostic = diag::cannot_convert_argument_value;
-        auto applyInfo = getFunctionArgApplyInfo(getLocator());
-        if (applyInfo)
-          toType = applyInfo->getParamType();
-      }
       break;
     }
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1433,7 +1433,7 @@ func assignGenericMismatch() {
   var a: [Int]?
   var b: [String]
 
-  a = b // expected-error {{cannot assign value of type '[String]' to type '[Int]?'}}
+  a = b // expected-error {{cannot assign value of type '[String]' to type '[Int]'}}
   // expected-note@-1 {{arguments to generic parameter 'Element' ('String' and 'Int') are expected to be equal}}
 
   b = a // expected-error {{cannot assign value of type '[Int]' to type '[String]'}}
@@ -1447,7 +1447,7 @@ func assignGenericMismatch() {
 let value: [Int] = []
 func gericArgToParamOptional(_ param: [String]?) {}
 
-gericArgToParamOptional(value) // expected-error {{convert value of type '[Int]' to expected argument type '[String]?'}}
+gericArgToParamOptional(value) // expected-error {{convert value of type '[Int]' to expected argument type '[String]'}}
 // expected-note@-1 {{arguments to generic parameter 'Element' ('Int' and 'String') are expected to be equal}}
 
 // Inout Expr conversions

--- a/test/Constraints/valid_pointer_conversions.swift
+++ b/test/Constraints/valid_pointer_conversions.swift
@@ -31,7 +31,7 @@ func givesPtr(_ str: String) {
   takesDoubleOptionalPtr(i) // expected-error {{cannot convert value of type 'Int' to expected argument type 'UnsafeRawPointer??'}}
   takesMutableDoubleOptionalPtr(arr) // expected-error {{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutableRawPointer??'}}
 
-  takesMutableDoubleOptionalTypedPtr(&i) // expected-error {{cannot convert value of type 'UnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<Double>??'}}
+  takesMutableDoubleOptionalTypedPtr(&i) // expected-error {{cannot convert value of type 'UnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<Double>'}}
   // expected-note@-1 {{arguments to generic parameter 'Pointee' ('Int' and 'Double') are expected to be equal}}
 }
 
@@ -39,5 +39,5 @@ func givesPtr(_ str: String) {
 func SR12382(_ x: UnsafeMutablePointer<Double>??) {}
 
 var i = 0
-SR12382(&i) // expected-error {{cannot convert value of type 'UnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<Double>??'}}
+SR12382(&i) // expected-error {{cannot convert value of type 'UnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<Double>'}}
 // expected-note@-1 {{arguments to generic parameter 'Pointee' ('Int' and 'Double') are expected to be equal}}


### PR DESCRIPTION
…agnostics

In situations where left-hand side requires value-to-optional
promotion which ends up in type mismatch let's not mention
optionals in the diagnostic because they are unrelated e.g.

```swift
func test(_: UnsafePointer<Int>??) {}

var value: Float = 0
test(&value)
```

In this example `value` gets implicitly wrapped into a double optional
before `UnsafePointer<Float>` could be matched against `UnsafePointer<Int>`
associated with the parameter.

Diagnostic is about generic argument mismatch `Float` vs. `Int`
and shouldn't mention any optionals.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
