### PR TITLE
[Frontend] Re-enable imported AST verification

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -761,8 +761,12 @@ void CompilerInstance::performSemaUpTo(SourceFile::ASTStage_t LimitStage,
   // If we aren't in a parse-only context, load the remaining serialized inputs
   // and resolve implicit imports.
   if (LimitStage > SourceFile::Unprocessed &&
-      loadPartialModulesAndImplicitImports())
+      loadPartialModulesAndImplicitImports()) {
+    // If we failed to load a partial module, mark the main module as having
+    // "failed to load", as it may contain no files.
+    mainModule->setFailedToLoad();
     return;
+  }
 
   // Then parse all the input files.
   // FIXME: This is the only demand point for InputSourceCodeBufferIDs. We

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -744,6 +744,10 @@ void CompilerInstance::performSemaUpTo(SourceFile::ASTStage_t LimitStage,
   if (LimitStage > SourceFile::Unprocessed &&
       Invocation.getImplicitStdlibKind() == ImplicitStdlibKind::Stdlib
       && !loadStdlib()) {
+    // If we failed to load the stdlib, mark the main module as having
+    // "failed to load", as it will contain no files.
+    // FIXME: We need to better handle a missing stdlib.
+    mainModule->setFailedToLoad();
     return;
   }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1209,6 +1209,9 @@ static bool emitAnyWholeModulePostTypeCheckSupplementaryOutputs(
 static void performEndOfPipelineActions(CompilerInstance &Instance) {
   assert(Instance.hasASTContext());
 
+  // Verify the AST for all the modules we've loaded.
+  Instance.getASTContext().verifyAllLoadedModules();
+
   // Emit dependencies and index data.
   emitReferenceDependenciesForAllPrimaryInputsIfNeeded(Instance);
   emitIndexData(Instance);

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -379,20 +379,6 @@ void swift::performWholeModuleTypeChecking(SourceFile &SF) {
   diagnoseObjCMethodConflicts(SF);
   diagnoseObjCUnsatisfiedOptReqConflicts(SF);
   diagnoseUnintendedObjCMethodOverrides(SF);
-
-  // In whole-module mode, import verification is deferred until all files have
-  // been type checked. This avoids caching imported declarations when a valid
-  // type checker is not present. The same declaration may need to be fully
-  // imported by subsequent files.
-  //
-  // FIXME: some playgrounds tests (playground_lvalues.swift) fail with
-  // verification enabled.
-#if 0
-  if (SF.Kind != SourceFileKind::SIL &&
-      !Ctx.LangOpts.DebuggerSupport) {
-    Ctx.verifyAllLoadedModules();
-  }
-#endif
 }
 
 bool swift::isAdditiveArithmeticConformanceDerivationEnabled(SourceFile &SF) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2487,9 +2487,9 @@ public:
                                                         depth,
                                                         index);
 
-    // Always create GenericTypeParamDecls in the associated module;
-    // the real context will reparent them.
-    auto DC = MF.getAssociatedModule();
+    // Always create GenericTypeParamDecls in the associated file; the real
+    // context will reparent them.
+    auto *DC = MF.getFile();
     auto genericParam = MF.createDecl<GenericTypeParamDecl>(
         DC, MF.getIdentifier(nameID), SourceLoc(), depth, index);
     declOrOffset = genericParam;

--- a/test/Serialization/failed-partial-module.swift
+++ b/test/Serialization/failed-partial-module.swift
@@ -1,0 +1,7 @@
+// RUN: %empty-directory(%t)
+
+// Make sure we don't crash if we fail to load a partial module.
+// RUN: %target-swift-frontend -emit-module -primary-file %s -module-name A -o %t/a.partial.swiftmodule
+// RUN: not %target-swift-frontend -emit-module -merge-modules %t/a.partial.swiftmodule -module-name Unrelated 2>&1 | %FileCheck %s
+
+// CHECK: error: cannot load module 'A' as 'Unrelated'


### PR DESCRIPTION
The reasons for disabling it appear to now be outdated. Re-enable it, and run it after the entire pipeline has finished to make sure we verify any decls deserialised during SIL/IRGen.