### PR TITLE
[Sema] NFC: Split test expectation to lines in `object_literals`

### DIFF
--- a/test/Sema/object_literals_ios.swift
+++ b/test/Sema/object_literals_ios.swift
@@ -6,20 +6,24 @@ struct S: _ExpressibleByColorLiteral {
 }
 
 let y: S = #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1)
-let y2 = #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1) // expected-error{{could not infer type of color literal}} expected-note{{import UIKit to use 'UIColor' as the default color literal type}}
+let y2 = #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1) // expected-error{{could not infer type of color literal}}
+// expected-note@-1{{import UIKit to use 'UIColor' as the default color literal type}}
 let y3 = #colorLiteral(red: 1, bleen: 0, grue: 0, alpha: 1) // expected-error{{incorrect argument labels in call (have 'red:bleen:grue:alpha:', expected 'red:green:blue:alpha:')}}
-// expected-error@-1 {{could not infer type of color literal}} expected-note@-1 {{import UIKit to use 'UIColor' as the default color literal type}}
+// expected-error@-1 {{could not infer type of color literal}}
+// expected-note@-2 {{import UIKit to use 'UIColor' as the default color literal type}}
 
 struct I: _ExpressibleByImageLiteral {
   init(imageLiteralResourceName: String) {}
 }
 
 let z: I = #imageLiteral(resourceName: "hello.png")
-let z2 = #imageLiteral(resourceName: "hello.png") // expected-error{{could not infer type of image literal}} expected-note{{import UIKit to use 'UIImage' as the default image literal type}}
+let z2 = #imageLiteral(resourceName: "hello.png") // expected-error{{could not infer type of image literal}}
+// expected-note@-1{{import UIKit to use 'UIImage' as the default image literal type}}
 
 struct Path: _ExpressibleByFileReferenceLiteral {
   init(fileReferenceLiteralResourceName: String) {}
 }
 
 let p1: Path = #fileLiteral(resourceName: "what.txt")
-let p2 = #fileLiteral(resourceName: "what.txt") // expected-error{{could not infer type of file reference literal}} expected-note{{import Foundation to use 'URL' as the default file reference literal type}}
+let p2 = #fileLiteral(resourceName: "what.txt") // expected-error{{could not infer type of file reference literal}}
+// expected-note@-1{{import Foundation to use 'URL' as the default file reference literal type}}

--- a/test/Sema/object_literals_osx.swift
+++ b/test/Sema/object_literals_osx.swift
@@ -6,24 +6,32 @@ struct S: _ExpressibleByColorLiteral {
 }
 
 let y: S = #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1)
-let y2 = #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1) // expected-error{{could not infer type of color literal}} expected-note{{import AppKit to use 'NSColor' as the default color literal type}}
-let y3 = #colorLiteral(red: 1, bleen: 0, grue: 0, alpha: 1) // expected-error{{incorrect argument labels in call (have 'red:bleen:grue:alpha:', expected 'red:green:blue:alpha:')}} expected-error{{could not infer type of color literal}} expected-note{{import AppKit to use 'NSColor' as the default color literal type}}
+let y2 = #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1) // expected-error{{could not infer type of color literal}}
+// expected-note@-1{{import AppKit to use 'NSColor' as the default color literal type}}
+let y3 = #colorLiteral(red: 1, bleen: 0, grue: 0, alpha: 1) // expected-error{{incorrect argument labels in call (have 'red:bleen:grue:alpha:', expected 'red:green:blue:alpha:')}}
+// expected-error@-1{{could not infer type of color literal}}
+// expected-note@-2{{import AppKit to use 'NSColor' as the default color literal type}}
 
 struct I: _ExpressibleByImageLiteral {
   init(imageLiteralResourceName: String) {}
 }
 
 let z: I = #imageLiteral(resourceName: "hello.png")
-let z2 = #imageLiteral(resourceName: "hello.png") // expected-error{{could not infer type of image literal}} expected-note{{import AppKit to use 'NSImage' as the default image literal type}}
+let z2 = #imageLiteral(resourceName: "hello.png") // expected-error{{could not infer type of image literal}}
+// expected-note@-1{{import AppKit to use 'NSImage' as the default image literal type}}
 
 struct Path: _ExpressibleByFileReferenceLiteral {
   init(fileReferenceLiteralResourceName: String) {}
 }
 
 let p1: Path = #fileLiteral(resourceName: "what.txt")
-let p2 = #fileLiteral(resourceName: "what.txt") // expected-error{{could not infer type of file reference literal}} expected-note{{import Foundation to use 'URL' as the default file reference literal type}}
+let p2 = #fileLiteral(resourceName: "what.txt") // expected-error{{could not infer type of file reference literal}}
+// expected-note@-1{{import Foundation to use 'URL' as the default file reference literal type}}
 
-let text = #fileLiteral(resourceName: "TextFile.txt").relativeString! // expected-error{{could not infer type of file reference literal}} expected-note{{import Foundation to use 'URL' as the default file reference literal type}}
+let text = #fileLiteral(resourceName: "TextFile.txt").relativeString! // expected-error{{could not infer type of file reference literal}}
+// expected-note@-1{{import Foundation to use 'URL' as the default file reference literal type}}
 
 // rdar://problem/49861813
-#fileLiteral() // expected-error{{missing argument for parameter 'resourceName' in call}} expected-error{{could not infer type of file reference literal}} expected-note{{import Foundation to use 'URL' as the default file reference literal type}}
+#fileLiteral() // expected-error{{missing argument for parameter 'resourceName' in call}}
+// expected-error@-1{{could not infer type of file reference literal}}
+// expected-note@-2{{import Foundation to use 'URL' as the default file reference literal type}}


### PR DESCRIPTION
Split lines as they has only one expectation at `object_literals_osx.swift`, `object_literals_ios.swift`.
It helps to review changes of diagnostics in future.

This patch changes only line breaking of test expectation comment
and doesn't have changes of compiler.

I planned this patch in response to comment here.
https://github.com/apple/swift/pull/31934

@xedin Please also review this.
