### PR TITLE
IRGen: Default to clang's frame pointer elimination settings

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -190,10 +190,6 @@ public:
   /// Whether we should run LLVM SLP vectorizer.
   unsigned DisableLLVMSLPVectorizer : 1;
 
-  /// Disable frame pointer elimination?
-  unsigned DisableFPElimLeaf : 1;
-  unsigned DisableFPElim : 1;
-  
   /// Special codegen for playgrounds.
   unsigned Playground : 1;
 
@@ -320,8 +316,7 @@ public:
         DisableClangModuleSkeletonCUs(false), UseJIT(false),
         DisableLLVMOptzns(false),
         DisableSwiftSpecificLLVMOptzns(false), DisableLLVMSLPVectorizer(false),
-        DisableFPElimLeaf(false),
-        DisableFPElim(true), Playground(false), EmitStackPromotionChecks(false),
+        Playground(false), EmitStackPromotionChecks(false),
         FunctionSections(false), PrintInlineTree(false), EmbedMode(IRGenEmbedMode::None),
         HasValueNamesSetting(false), ValueNames(false),
         EnableReflectionMetadata(true), EnableReflectionNames(true),

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1010,10 +1010,6 @@ def enable_private_imports : Flag<["-"], "enable-private-imports">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
   HelpText<"Allows this module's internal and private API to be accessed">;
 
-def disable_leaf_frame_pointer_elim : Flag<["-"], "no-omit-leaf-frame-pointer">,
-  Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
-  HelpText<"Don't omit the frame pointer for leaf functions">;
-
 def sanitize_EQ : CommaJoined<["-"], "sanitize=">,
   Flags<[FrontendOption, NoInteractiveOption]>, MetaVarName<"<check>">,
   HelpText<"Turn on runtime checks for erroneous behavior.">;

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -288,8 +288,6 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
       arguments.push_back("-enable-anonymous-context-mangled-names");
   }
 
-  inputArgs.AddLastArg(arguments, options::OPT_disable_leaf_frame_pointer_elim);
-
   // Pass through any subsystem flags.
   inputArgs.AddAllArgs(arguments, options::OPT_Xllvm);
   inputArgs.AddAllArgs(arguments, options::OPT_Xcc);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1514,9 +1514,6 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
         getRuntimeCompatVersion();
   }
 
-  if (Args.hasArg(OPT_disable_leaf_frame_pointer_elim))
-    Opts.DisableFPElimLeaf = true;
-
   return false;
 }
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -177,7 +177,7 @@ static void emitMetadataCompletionFunction(IRGenModule &IGM,
     IGM.getAddrOfTypeMetadataCompletionFunction(typeDecl, ForDefinition);
   f->setAttributes(IGM.constructInitialAttributes());
   f->setDoesNotThrow();
-  IGM.setHasFramePointer(f, false);
+  IGM.setHasNoFramePointer(f);
 
   IRGenFunction IGF(IGM, f);
 
@@ -2234,7 +2234,7 @@ namespace {
         IGM.getAddrOfTypeMetadataInstantiationFunction(Target, ForDefinition);
       f->setAttributes(IGM.constructInitialAttributes());
       f->setDoesNotThrow();
-      IGM.setHasFramePointer(f, false);
+      IGM.setHasNoFramePointer(f);
 
       IRGenFunction IGF(IGM, f);
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1305,8 +1305,8 @@ public:
   void constructInitialFnAttributes(llvm::AttrBuilder &Attrs,
                                     OptimizationMode FuncOptMode =
                                       OptimizationMode::NotSet);
-  void setHasFramePointer(llvm::AttrBuilder &Attrs, bool HasFP);
-  void setHasFramePointer(llvm::Function *F, bool HasFP);
+  void setHasNoFramePointer(llvm::AttrBuilder &Attrs);
+  void setHasNoFramePointer(llvm::Function *F);
   llvm::AttributeList constructInitialAttributes();
 
   void emitProtocolDecl(ProtocolDecl *D);

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1615,7 +1615,7 @@ void irgen::emitCacheAccessFunction(IRGenModule &IGM,
   accessor->addAttribute(llvm::AttributeList::FunctionIndex,
                          llvm::Attribute::NoInline);
   // Accessor functions don't need frame pointers.
-  IGM.setHasFramePointer(accessor, false);
+  IGM.setHasNoFramePointer(accessor);
 
   // This function is logically 'readnone': the caller does not need
   // to reason about any side effects or stores it might perform.
@@ -1997,8 +1997,8 @@ MetadataResponse irgen::emitGenericTypeMetadataAccessFunction(
       thunkFn->setCallingConv(IGM.SwiftCC);
       thunkFn->addAttribute(llvm::AttributeList::FunctionIndex,
                             llvm::Attribute::NoInline);
-      IGM.setHasFramePointer(thunkFn, false);
-      
+      IGM.setHasNoFramePointer(thunkFn);
+
       [&IGM, thunkFn]{
         IRGenFunction subIGF(IGM, thunkFn);
     
@@ -2469,7 +2469,7 @@ emitMetadataAccessByMangledName(IRGenFunction &IGF, CanType type,
     instantiationFn->setDoesNotThrow();
     instantiationFn->addAttribute(llvm::AttributeList::FunctionIndex,
                                   llvm::Attribute::NoInline);
-    IGM.setHasFramePointer(instantiationFn, false);
+    IGM.setHasNoFramePointer(instantiationFn);
 
     [&IGM, instantiationFn, request]{
       IRGenFunction subIGF(IGM, instantiationFn);

--- a/test/IRGen/framepointer.sil
+++ b/test/IRGen/framepointer.sil
@@ -1,6 +1,8 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK
-// RUN: %target-swift-frontend -primary-file %s -emit-ir -no-omit-leaf-frame-pointer| %FileCheck %s --check-prefix=CHECK-ALL
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -Xcc -mno-omit-leaf-frame-pointer | %FileCheck %s --check-prefix=CHECK-ALL
 // RUN: %target-swift-frontend -primary-file %s -S | %FileCheck %s  --check-prefix=CHECKASM --check-prefix=CHECKASM-%target-os-%target-cpu
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -Xcc -momit-leaf-frame-pointer | %FileCheck %s --check-prefix=LEAF
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -Xcc -fomit-frame-pointer | %FileCheck %s --check-prefix=NOFP
 
 // REQUIRES: CPU=x86_64
 
@@ -45,6 +47,32 @@ entry(%i : $Int32):
 // CHECK-ALL: }
 
 // CHECK-ALL: attributes [[ATTR]] = {{{.*}}"frame-pointer"="all"
+
+// LEAF: define{{.*}} swiftcc i32 @leaf_function_no_frame_pointer(i32 %0) [[ATTR:#.*]] {
+// LEAF: entry:
+// LEAF:   ret i32 %0
+// LEAF: }
+
+// LEAF: define{{.*}} swiftcc i32 @non_leaf_function_with_frame_pointer(i32 %0) [[ATTR]] {
+// LEAF: entry:
+// LEAF:   %1 = call swiftcc i32 @leaf_function_no_frame_pointer(i32 %0)
+// LEAF:   ret i32 %1
+// LEAF: }
+
+// LEAF: attributes [[ATTR]] = {{{.*}}"frame-pointer"="non-leaf"
+
+// NOFP: define{{.*}} swiftcc i32 @leaf_function_no_frame_pointer(i32 %0) [[ATTR:#.*]] {
+// NOFP: entry:
+// NOFP:   ret i32 %0
+// NOFP: }
+
+// NOFP: define{{.*}} swiftcc i32 @non_leaf_function_with_frame_pointer(i32 %0) [[ATTR]] {
+// NOFP: entry:
+// NOFP:   %1 = call swiftcc i32 @leaf_function_no_frame_pointer(i32 %0)
+// NOFP:   ret i32 %1
+// NOFP: }
+
+// NOFP: attributes [[ATTR]] = {{{.*}}"frame-pointer"="none"
 
 // Silence other os-archs.
 // CHECKASM: {{.*}}

--- a/test/IRGen/framepointer_arm64.sil
+++ b/test/IRGen/framepointer_arm64.sil
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -target arm64-apple-ios8.0 -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK
-// RUN: %target-swift-frontend -target arm64-apple-ios8.0 -primary-file %s -emit-ir -no-omit-leaf-frame-pointer| %FileCheck %s --check-prefix=CHECK-ALL
+// RUN: %target-swift-frontend -target arm64-apple-ios8.0 -primary-file %s -emit-ir -Xcc -mno-omit-leaf-frame-pointer| %FileCheck %s --check-prefix=CHECK-ALL
 // RUN: %target-swift-frontend -target arm64-apple-ios8.0 -primary-file %s -S | %FileCheck %s --check-prefix=CHECKASM
-// RUN: %target-swift-frontend -target arm64-apple-ios8.0 -primary-file %s -S -no-omit-leaf-frame-pointer | %FileCheck %s --check-prefix=CHECKASM-ALL
+// RUN: %target-swift-frontend -target arm64-apple-ios8.0 -primary-file %s -S -Xcc -mno-omit-leaf-frame-pointer | %FileCheck %s --check-prefix=CHECKASM-ALL
 
 // REQUIRES: CODEGENERATOR=AArch64
 // REQUIRES: OS=ios


### PR DESCRIPTION
Clang provides options to override that default value.
These options are accessible via the -Xcc flag.

Some Swift functions explicitly disable the frame pointer.

The clang options will not override those.