### PR TITLE
ASTDemangler: Add support for member types of opaque result types

### DIFF
--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -609,20 +609,35 @@ Type ASTBuilder::createGenericTypeParameterType(unsigned depth,
 
 Type ASTBuilder::createDependentMemberType(StringRef member,
                                            Type base) {
-  if (!base->isTypeParameter())
-    return Type();
+  auto identifier = Ctx.getIdentifier(member);
 
-  return DependentMemberType::get(base, Ctx.getIdentifier(member));
+  if (auto *archetype = base->getAs<ArchetypeType>()) {
+    if (archetype->hasNestedType(identifier))
+      return archetype->getNestedType(identifier);
+
+  }
+
+  if (base->isTypeParameter()) {
+    return DependentMemberType::get(base, identifier);
+  }
+
+  return Type();
 }
 
 Type ASTBuilder::createDependentMemberType(StringRef member,
                                            Type base,
                                            ProtocolDecl *protocol) {
-  if (!base->isTypeParameter())
-    return Type();
+  auto identifier = Ctx.getIdentifier(member);
 
-  if (auto assocType = protocol->getAssociatedType(Ctx.getIdentifier(member)))
-    return DependentMemberType::get(base, assocType);
+  if (auto *archetype = base->getAs<ArchetypeType>()) {
+    if (archetype->hasNestedType(identifier))
+      return archetype->getNestedType(identifier);
+  }
+
+  if (base->isTypeParameter()) {
+    if (auto assocType = protocol->getAssociatedType(identifier))
+      return DependentMemberType::get(base, assocType);
+  }
 
   return Type();
 }

--- a/test/TypeDecoder/opaque_return_type.swift
+++ b/test/TypeDecoder/opaque_return_type.swift
@@ -10,8 +10,16 @@ extension Int: P {}
 func foo() -> some P { return 0 }
 var prop: some P { return 0 }
 
+func bar() -> some Sequence { return [] }
+
 // DEMANGLE: $s18opaque_return_type3fooQryFQOyQo_
 // CHECK: some P
 
 // DEMANGLE: $s18opaque_return_type4propQrvpQOyQo_
 // CHECK: some P
+
+// DEMANGLE: $s18opaque_return_type3barQryFQOyQo_
+// CHECK: some Sequence
+
+// DEMANGLE: $s18opaque_return_type3barQryFQOyQo_7ElementSTQxD
+// CHECK: (some Sequence).Element


### PR DESCRIPTION
Fixes <rdar://problem/63188053>.