### PR TITLE
[stdlib] Eagerly allocate children in Mirror

### DIFF
--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -110,7 +110,7 @@ public enum _DebuggerSupport {
 
   private static func ivarCount(mirror: Mirror) -> Int {
     let ivars = mirror.superclassMirror.map(ivarCount) ?? 0
-    return ivars + mirror.children.count
+    return ivars + mirror._children.count
   }
 
   private static func shouldExpand(
@@ -119,7 +119,7 @@ public enum _DebuggerSupport {
     isRoot: Bool
   ) -> Bool {
     if isRoot || collectionStatus.isCollection { return true }
-    if !mirror.children.isEmpty { return true }
+    if !mirror._children.isEmpty { return true }
     if mirror.displayStyle == .`class` { return true }
     if let sc = mirror.superclassMirror { return ivarCount(mirror: sc) > 0 }
     return true
@@ -154,7 +154,7 @@ public enum _DebuggerSupport {
     // anyway, so there's that...
     let willExpand = mirror.displayStyle != .`class` || value is CustomReflectable?
 
-    let count = mirror.children.count
+    let count = mirror._children.count
     let bullet = isRoot && (count == 0 || !willExpand) ? ""
       : count == 0    ? "- "
       : maxDepth <= 0 ? "▹ " : "▿ "
@@ -202,7 +202,7 @@ public enum _DebuggerSupport {
         target: &target)
     }
   
-    for (optionalName,child) in mirror.children {
+    for (optionalName,child) in mirror._children {
       let childName = optionalName ?? "\(printedElements)"
       if maxItemCounter <= 0 {
         print(String(repeating: " ", count: indent+4), terminator: "", to: &target)

--- a/stdlib/public/core/Dump.swift
+++ b/stdlib/public/core/Dump.swift
@@ -99,7 +99,7 @@ internal func _dump_unlocked<TargetStream: TextOutputStream>(
   for _ in 0..<indent { target.write(" ") }
 
   let mirror = Mirror(reflecting: value)
-  let count = mirror.children.count
+  let count = mirror._children.count
   let bullet = count == 0    ? "-"
              : maxDepth <= 0 ? "▹" : "▿"
   target.write(bullet)
@@ -149,7 +149,7 @@ internal func _dump_unlocked<TargetStream: TextOutputStream>(
       visitedItems: &visitedItems)
   }
 
-  var currentIndex = mirror.children.startIndex
+  var currentIndex = mirror._children.startIndex
   for i in 0..<count {
     if maxItemCounter <= 0 {
       for _ in 0..<(indent+4) {
@@ -167,8 +167,8 @@ internal func _dump_unlocked<TargetStream: TextOutputStream>(
       return
     }
 
-    let (name, child) = mirror.children[currentIndex]
-    mirror.children.formIndex(after: &currentIndex)
+    let (name, child) = mirror._children[currentIndex]
+    mirror._children.formIndex(after: &currentIndex)
     _dump_unlocked(
       child,
       to: &target,
@@ -196,7 +196,7 @@ internal func _dumpSuperclass_unlocked<TargetStream: TextOutputStream>(
 
   for _ in 0..<indent { target.write(" ") }
 
-  let count = mirror.children.count
+  let count = mirror._children.count
   let bullet = count == 0    ? "-"
              : maxDepth <= 0 ? "▹" : "▿"
   target.write(bullet)
@@ -216,7 +216,7 @@ internal func _dumpSuperclass_unlocked<TargetStream: TextOutputStream>(
       visitedItems: &visitedItems)
   }
 
-  var currentIndex = mirror.children.startIndex
+  var currentIndex = mirror._children.startIndex
   for i in 0..<count {
     if maxItemCounter <= 0 {
       for _ in 0..<(indent+4) {
@@ -234,8 +234,8 @@ internal func _dumpSuperclass_unlocked<TargetStream: TextOutputStream>(
       return
     }
 
-    let (name, child) = mirror.children[currentIndex]
-    mirror.children.formIndex(after: &currentIndex)
+    let (name, child) = mirror._children[currentIndex]
+    mirror._children.formIndex(after: &currentIndex)
     _dump_unlocked(
       child,
       to: &target,

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -223,7 +223,7 @@ public struct Mirror {
     self._makeSuperclassMirror = Mirror._superclassIterator(
       subject, ancestorRepresentation)
       
-    self.children = Children(children)
+    self._children = Array(children)
     self.displayStyle = displayStyle
     self._defaultDescendantRepresentation
       = subject is CustomLeafReflectable ? .suppressed : .generated
@@ -266,9 +266,7 @@ public struct Mirror {
     self._makeSuperclassMirror = Mirror._superclassIterator(
       subject, ancestorRepresentation)
       
-    let lazyChildren =
-      unlabeledChildren.lazy.map { Child(label: nil, value: $0) }
-    self.children = Children(lazyChildren)
+    self._children = unlabeledChildren.map { Child(label: nil, value: $0) }
 
     self.displayStyle = displayStyle
     self._defaultDescendantRepresentation
@@ -314,8 +312,7 @@ public struct Mirror {
     self._makeSuperclassMirror = Mirror._superclassIterator(
       subject, ancestorRepresentation)
       
-    let lazyChildren = children.lazy.map { Child(label: $0.0, value: $0.1) }
-    self.children = Children(lazyChildren)
+    self._children = children.map { Child(label: $0.0, value: $0.1) }
 
     self.displayStyle = displayStyle
     self._defaultDescendantRepresentation
@@ -328,9 +325,11 @@ public struct Mirror {
   /// is the `superclassMirror` of another mirror.
   public let subjectType: Any.Type
 
+  internal let _children: [Child]
+
   /// A collection of `Child` elements describing the structure of the
   /// reflected subject.
-  public let children: Children
+  public var children: Children { Children(_children) }
 
   /// A suggested display style for the reflected subject.
   public let displayStyle: DisplayStyle?

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -434,17 +434,14 @@ extension Mirror {
   ) -> Any? {
     var result: Any = _Dummy(mirror: self)
     for e in [first] + rest {
-      let children = Mirror(reflecting: result).children
-      let position: Children.Index
-      if case let label as String = e {
+      let children = Mirror(reflecting: result)._children
+      let position: Int
+      switch e {
+      case let label as String:
         position = children.firstIndex { $0.label == label } ?? children.endIndex
-      }
-      else if let offset = e as? Int {
-        position = children.index(children.startIndex,
-          offsetBy: offset,
-          limitedBy: children.endIndex) ?? children.endIndex
-      }
-      else {
+      case let offset as Int:
+        position = offset < children.endIndex ? offset : children.endIndex
+      default:
         _preconditionFailure(
           "Someone added a conformance to MirrorPath; that privilege is reserved to the standard library")
       }

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -293,7 +293,7 @@ internal func _adHocPrint_unlocked<T, TargetStream: TextOutputStream>(
   if let displayStyle = mirror.displayStyle {
     switch displayStyle {
       case .optional:
-        if let child = mirror.children.first {
+        if let child = mirror._children.first {
           _debugPrint_unlocked(child.1, &target)
         } else {
           _debugPrint_unlocked("nil", &target)
@@ -301,7 +301,7 @@ internal func _adHocPrint_unlocked<T, TargetStream: TextOutputStream>(
       case .tuple:
         target.write("(")
         var first = true
-        for (label, value) in mirror.children {
+        for (label, value) in mirror._children {
           if first {
             first = false
           } else {
@@ -322,7 +322,7 @@ internal func _adHocPrint_unlocked<T, TargetStream: TextOutputStream>(
         printTypeName(mirror.subjectType)
         target.write("(")
         var first = true
-        for (label, value) in mirror.children {
+        for (label, value) in mirror._children {
           if let label = label {
             if first {
               first = false
@@ -348,7 +348,7 @@ internal func _adHocPrint_unlocked<T, TargetStream: TextOutputStream>(
           // If the case name is garbage, just print the type name.
           printTypeName(mirror.subjectType)
         }
-        if let (_, value) = mirror.children.first {
+        if let (_, value) = mirror._children.first {
           if Mirror(reflecting: value).displayStyle == .tuple {
             _debugPrint_unlocked(value, &target)
           } else {
@@ -453,19 +453,19 @@ internal func _dumpPrint_unlocked<T, TargetStream: TextOutputStream>(
     // count
     switch displayStyle {
     case .tuple:
-      let count = mirror.children.count
+      let count = mirror._children.count
       target.write(count == 1 ? "(1 element)" : "(\(count) elements)")
       return
     case .collection:
-      let count = mirror.children.count
+      let count = mirror._children.count
       target.write(count == 1 ? "1 element" : "\(count) elements")
       return
     case .dictionary:
-      let count = mirror.children.count
+      let count = mirror._children.count
       target.write(count == 1 ? "1 key/value pair" : "\(count) key/value pairs")
       return
     case .`set`:
-      let count = mirror.children.count
+      let count = mirror._children.count
       target.write(count == 1 ? "1 member" : "\(count) members")
       return
     default:

--- a/stdlib/public/core/ReflectionMirror.swift
+++ b/stdlib/public/core/ReflectionMirror.swift
@@ -111,10 +111,9 @@ extension Mirror {
     let subjectType = subjectType ?? _getNormalizedType(subject, type: type(of: subject))
     
     let childCount = _getChildCount(subject, type: subjectType)
-    let children = (0 ..< childCount).lazy.map({
+    self._children = (0 ..< childCount).map {
       getChild(of: subject, type: subjectType, index: $0)
-    })
-    self.children = Children(children)
+    }
     
     self._makeSuperclassMirror = {
       guard let subjectClass = subjectType as? AnyClass,

--- a/stdlib/public/core/RuntimeFunctionCounters.swift
+++ b/stdlib/public/core/RuntimeFunctionCounters.swift
@@ -79,11 +79,11 @@ internal func _collectAllReferencesInsideObjectImpl(
   }
 
   // Recursively visit the children of the current value.
-  let count = mirror.children.count
-  var currentIndex = mirror.children.startIndex
+  let count = mirror._children.count
+  var currentIndex = mirror._children.startIndex
   for _ in 0..<count {
-    let (_, child) = mirror.children[currentIndex]
-    mirror.children.formIndex(after: &currentIndex)
+    let (_, child) = mirror._children[currentIndex]
+    mirror._children.formIndex(after: &currentIndex)
     _collectAllReferencesInsideObjectImpl(
       child,
       references: &references,


### PR DESCRIPTION
The previous code used type erasure and lazy mapping to avoid allocating, but `AnyCollection` allocates anyway, was generating lots of metadata that allocates memory permanently, and is very inefficient to access.

Ideally, we'd switch the `children` property to just return the array, but it's ABI. So you'll still end up using `AnyCollection` if you access the children – but uses internal to the standard library (like printing arbitrary types) can avoid this.

`Mirror` isn't `@frozen` so this ought to be an ABI stable change.