### PR TITLE
test: restrict IRGen test to single platform

### DIFF
--- a/test/IRGen/framepointer_arm64.sil
+++ b/test/IRGen/framepointer_arm64.sil
@@ -4,9 +4,7 @@
 // RUN: %target-swift-frontend -target arm64-apple-ios8.0 -primary-file %s -S -no-omit-leaf-frame-pointer | %FileCheck %s --check-prefix=CHECKASM-ALL
 
 // REQUIRES: CODEGENERATOR=AArch64
-
-// UNSUPPORTED: OS=linux-gnu
-// UNSUPPORTED: OS=windows
+// REQUIRES: OS=ios
 
 sil_stage canonical
 


### PR DESCRIPTION
This test is iOS specific, and broke the android and Windows bots.
Rather than revert the change fix the test to restrict it.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
