### PR TITLE
API checker: only diagnose adding enum cases to exhaustive enums

### DIFF
--- a/include/swift/IDE/DigesterEnums.def
+++ b/include/swift/IDE/DigesterEnums.def
@@ -132,6 +132,7 @@ KEY_BOOL(HasStorage, hasStorage)
 KEY_BOOL(ReqNewWitnessTableEntry, reqNewWitnessTableEntry)
 KEY_BOOL(IsABIPlaceholder, isABIPlaceholder)
 KEY_BOOL(IsExternal, isExternal)
+KEY_BOOL(IsEnumExhaustive, isEnumExhaustive)
 KEY_BOOL(HasMissingDesignatedInitializers, hasMissingDesignatedInitializers)
 KEY_BOOL(InheritsConvenienceInitializers, inheritsConvenienceInitializers)
 

--- a/test/api-digester/Inputs/cake_baseline/cake.swift
+++ b/test/api-digester/Inputs/cake_baseline/cake.swift
@@ -40,6 +40,9 @@ public struct C6 {}
 @frozen
 public enum IceKind {}
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public enum FutureKind {}
+
 public protocol P1 {}
 
 public protocol P2 {}

--- a/test/api-digester/Inputs/cake_current/cake.swift
+++ b/test/api-digester/Inputs/cake_current/cake.swift
@@ -40,6 +40,11 @@ public struct C6 {}
 
 public enum IceKind {}
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public enum FutureKind {
+  case FineToAdd
+}
+
 public protocol P1 {}
 
 public protocol P2 {}

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -615,6 +615,7 @@
       "usr": "s:4cake6NumberO",
       "moduleName": "cake",
       "enumRawTypeName": "Int",
+      "isEnumExhaustive": true,
       "conformances": [
         {
           "kind": "Conformance",

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -635,6 +635,7 @@
       "usr": "s:4cake6NumberO",
       "moduleName": "cake",
       "enumRawTypeName": "Int",
+      "isEnumExhaustive": true,
       "conformances": [
         {
           "kind": "Conformance",

--- a/test/api-digester/dump-module.swift
+++ b/test/api-digester/dump-module.swift
@@ -1,4 +1,4 @@
-// REQUIRES: macosx
+// REQUIRES: OS=macosx
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -126,7 +126,9 @@ SDKNodeTypeAlias::SDKNodeTypeAlias(SDKNodeInitInfo Info):
 SDKNodeDeclType::SDKNodeDeclType(SDKNodeInitInfo Info):
   SDKNodeDecl(Info, SDKNodeKind::DeclType), SuperclassUsr(Info.SuperclassUsr),
   SuperclassNames(Info.SuperclassNames),
-  EnumRawTypeName(Info.EnumRawTypeName), IsExternal(Info.IsExternal),
+  EnumRawTypeName(Info.EnumRawTypeName),
+  IsExternal(Info.IsExternal),
+  IsEnumExhaustive(Info.IsEnumExhaustive),
   HasMissingDesignatedInitializers(Info.HasMissingDesignatedInitializers),
   InheritsConvenienceInitializers(Info.InheritsConvenienceInitializers) {}
 
@@ -1426,6 +1428,7 @@ SDKNodeInitInfo::SDKNodeInitInfo(SDKContext &Ctx, ValueDecl *VD)
 
   // Get enum raw type name if this is an enum.
   if (auto *ED = dyn_cast<EnumDecl>(VD)) {
+    IsEnumExhaustive = ED->isFormallyExhaustive(nullptr);
     if (auto RT = ED->getRawType()) {
       if (auto *D = RT->getNominalOrBoundGenericNominal()) {
         EnumRawTypeName = D->getName().str();
@@ -1981,6 +1984,7 @@ void SDKNodeDeclType::jsonize(json::Output &out) {
   output(out, KeyKind::KK_superclassUsr, SuperclassUsr);
   output(out, KeyKind::KK_enumRawTypeName, EnumRawTypeName);
   output(out, KeyKind::KK_isExternal, IsExternal);
+  output(out, KeyKind::KK_isEnumExhaustive, IsEnumExhaustive);
   output(out, KeyKind::KK_hasMissingDesignatedInitializers,
          HasMissingDesignatedInitializers);
   output(out, KeyKind::KK_inheritsConvenienceInitializers,

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.h
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.h
@@ -524,6 +524,7 @@ class SDKNodeDeclType: public SDKNodeDecl {
   // Check whether the type declaration is pulled from an external module so we
   // can incorporate extensions in the interested module.
   bool IsExternal;
+  bool IsEnumExhaustive;
   bool HasMissingDesignatedInitializers;
   bool InheritsConvenienceInitializers;
 public:
@@ -548,6 +549,11 @@ public:
   StringRef getEnumRawTypeName() const {
     assert(isEnum());
     return EnumRawTypeName;
+  }
+
+  bool isEnumExhaustive() const {
+    assert(isEnum());
+    return IsEnumExhaustive;
   }
 
   bool hasMissingDesignatedInitializers() const {

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -1216,7 +1216,9 @@ public:
       if (!Ctx.checkingABI()) {
         if (auto *Var = dyn_cast<SDKNodeDeclVar>(Right)) {
           if (Var->getDeclKind() == DeclKind::EnumElement) {
-            Var->emitDiag(Var->getLoc(), diag::enum_case_added);
+            if (Var->getParent()->getAs<SDKNodeDeclType>()->isEnumExhaustive()) {
+              Var->emitDiag(Var->getLoc(), diag::enum_case_added);
+            }
           }
         }
       }


### PR DESCRIPTION
Adding new cases to a non-exhaustive enum type isn't source-breaking
since it only triggers a warning.

rdar://63464929
