### PR TITLE
build: correct variable in SDK configuration

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -374,7 +374,7 @@ macro(configure_sdk_unix name architectures)
 
     # If the module triple wasn't set explicitly, it's the same as the triple.
     if(NOT SWIFT_SDK_${prefix}_ARCH_${arch}_MODULE)
-      set(SWIFT_SDK_${prefix}_ARCH_${arch}_MODULE "${SWIFT_SDK_${prefix}_ARCH_${arch}_MODULE}")
+      set(SWIFT_SDK_${prefix}_ARCH_${arch}_MODULE "${SWIFT_SDK_${prefix}_ARCH_${arch}_TRIPLE}")
     endif()
   endforeach()
 
@@ -407,7 +407,7 @@ macro(configure_sdk_windows name environment architectures)
           "${arch}-unknown-windows-${environment}")
     endif()
 
-    set(SWIFT_SDK_${prefix}_ARCH_${arch}_MODULE "${SWIFT_SDK_${prefix}_ARCH_${arch}_MODULE}")
+    set(SWIFT_SDK_${prefix}_ARCH_${arch}_MODULE "${SWIFT_SDK_${prefix}_ARCH_${arch}_TRIPLE}")
 
     # NOTE: set the path to / to avoid a spurious `--sysroot` from being passed
     # to the driver -- rely on the `INCLUDE` AND `LIB` environment variables


### PR DESCRIPTION
The variable was supported to be set to the triple, except it was set to
the variable itself, effectively setting the variable to nothing.  This
is needed to clear the path to directory style installation for
non-Apple targets.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
