### PR TITLE
[SR-12583] Added checks to catch 'foo() {} {}' and 'foo {} () {}'

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1189,6 +1189,9 @@ WARNING(trailing_closure_after_newlines,none,
 NOTE(trailing_closure_callee_here,none,
      "callee is here", ())
 
+ERROR(double_trailing_closure,none,
+    "double trailing closures", ())
+
 ERROR(string_literal_no_atsign,none,
       "string literals in Swift are not preceded by an '@' sign", ())
 

--- a/test/Parse/double_trailing_closure.swift
+++ b/test/Parse/double_trailing_closure.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift
+
+func bar(_ f: @escaping (Int) -> Int) -> ((Int) -> Int) -> Int {
+  let r : ((Int) -> Int) -> Int =
+  {(g: (_ r1 : Int) -> Int) in
+      g(f(2))
+  }
+  return r
+}
+
+// bad 1
+let q1 = bar()
+{7 * $0}
+{5 * $0} // expected-error {{double trailing closures}}
+
+// bad 2 (note that () can't be on its own line
+let q2 =
+bar {7 * $0} ()
+{5 * $0} // expected-error {{double trailing closures}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Addresses two parse problems in SR-12583, where (single) trailing closures should not be parsed in the neighborhood of other trailing closures. The parse trees for both forms are identical but the Parser takes two paths to get there. @jckarter entered the original bug. 

Several questions:

1. Is this the right place/method to do this? I just put an if(condition) check in two places in the parser and emitted a diagnostic. Should the check be in the CallExpr::create() instead of in the parser? 

1. I'm not completely sure that there's not a valid parse like this. The parse tree looks like the below. It indents poorly here but it's a call with a trailing closure containing another call with a trailing closure. I'm still thinking through whether there's some legitimate Swift code that could generate that: 
 (call_expr  (call_expr (paren_expr trailing-closure)) (paren_expr trailing-closure))

1. The diagnostic just says 'double trailing closures' right now, which is accurate but not clear enough. Any suggestions to improve the wording are welcome. I will think about it further. 

1. This may interfere or interact with work on multiple trailing closures that @xedin (I think) is working on now. 

1. The swift in the examples is kind of aesthetically displeasing but logically OK. I'm not sure this should actually be disallowed.  

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-12583.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
