### PR TITLE
[SR-12869] [Diagnostics] Fixes assertion hit on TupleContextualFailure involving optional tuple type

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2989,14 +2989,7 @@ bool TupleContextualFailure::diagnoseAsError() {
     diagnostic = diag::tuple_types_not_convertible_nelts;
   else if ((purpose == CTP_Initialization) && !getContextualType(getAnchor()))
     diagnostic = diag::tuple_types_not_convertible;
-  else if (purpose == CTP_AssignSource) {
-    auto assignExpr = castToExpr<AssignExpr>(getAnchor());
-    if (isa<SubscriptExpr>(assignExpr->getDest())) {
-      diagnostic = *getDiagnosticFor(CTP_SubscriptAssignSource, getToType());
-    } else {
-      diagnostic = *getDiagnosticFor(purpose, getToType());
-    }
-  } else if (auto diag = getDiagnosticFor(purpose, getToType()))
+  else if (auto diag = getDiagnosticFor(purpose, getToType()))
     diagnostic = *diag;
   else
     return false;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2989,7 +2989,14 @@ bool TupleContextualFailure::diagnoseAsError() {
     diagnostic = diag::tuple_types_not_convertible_nelts;
   else if ((purpose == CTP_Initialization) && !getContextualType(getAnchor()))
     diagnostic = diag::tuple_types_not_convertible;
-  else if (auto diag = getDiagnosticFor(purpose, getToType()))
+  else if (purpose == CTP_AssignSource) {
+    auto assignExpr = castToExpr<AssignExpr>(getAnchor());
+    if (isa<SubscriptExpr>(assignExpr->getDest())) {
+      diagnostic = *getDiagnosticFor(CTP_SubscriptAssignSource, getToType());
+    } else {
+      diagnostic = *getDiagnosticFor(purpose, getToType());
+    }
+  } else if (auto diag = getDiagnosticFor(purpose, getToType()))
     diagnostic = *diag;
   else
     return false;

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -289,7 +289,7 @@ getStructuralTypeContext(const Solution &solution, ConstraintLocator *locator) {
   } else if (auto *assignExpr = getAsExpr<AssignExpr>(locator->getAnchor())) {
     return std::make_tuple(CTP_AssignSource,
                            solution.getType(assignExpr->getSrc()),
-                           solution.getType(assignExpr->getDest()));
+                           solution.getType(assignExpr->getDest())->getRValueType());
   } else if (auto *call = getAsExpr<CallExpr>(locator->getAnchor())) {
     assert(isa<TypeExpr>(call->getFn()));
     return std::make_tuple(
@@ -332,8 +332,10 @@ bool AllowTupleTypeMismatch::coalesceAndDiagnose(
     return false;
   }
 
-  TupleContextualFailure failure(solution, purpose, fromType, toType, indices,
-                                 locator);
+  TupleContextualFailure failure(solution, purpose,
+                                 fromType->lookThroughAllOptionalTypes(),
+                                 toType->lookThroughAllOptionalTypes(),
+                                 indices, locator);
   return failure.diagnose(asNote);
 }
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -287,7 +287,9 @@ getStructuralTypeContext(const Solution &solution, ConstraintLocator *locator) {
                            solution.getType(coerceExpr->getSubExpr()),
                            solution.getType(coerceExpr));
   } else if (auto *assignExpr = getAsExpr<AssignExpr>(locator->getAnchor())) {
-    return std::make_tuple(CTP_AssignSource,
+    auto CTP = isa<SubscriptExpr>(assignExpr->getDest()) ? CTP_SubscriptAssignSource
+                                                         : CTP_AssignSource;
+    return std::make_tuple(CTP,
                            solution.getType(assignExpr->getSrc()),
                            solution.getType(assignExpr->getDest())->getRValueType());
   } else if (auto *call = getAsExpr<CallExpr>(locator->getAnchor())) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3367,8 +3367,7 @@ bool ConstraintSystem::repairFailures(
         conversionsOrFixes.push_back(
             IgnoreAssignmentDestinationType::create(*this, lhs, rhs, loc));
       } else {
-        conversionsOrFixes.push_back(
-            TreatRValueAsLValue::create(*this, loc));
+        conversionsOrFixes.push_back(TreatRValueAsLValue::create(*this, loc));
       }
 
       return true;
@@ -8876,11 +8875,11 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
       // tuple mismatch.
       if (hasFixFor(loc, FixKind::AllowTupleTypeMismatch))
         return true;
-      
+
       if (restriction == ConversionRestrictionKind::ValueToOptional ||
           restriction == ConversionRestrictionKind::OptionalToOptional)
         ++impact;
-      
+
       auto *fix =
           loc->isLastElement<LocatorPathElt::ApplyArgToParam>()
               ? AllowArgumentMismatch::create(*this, fromType, toType, loc)

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3356,13 +3356,19 @@ bool ConstraintSystem::repairFailures(
       // related to immutability, otherwise it's a type mismatch.
       auto result = matchTypes(lhs, rhs, ConstraintKind::Conversion,
                                TMF_ApplyingFix, locator);
-
+      
+      auto *loc = getConstraintLocator(locator);
       if (getType(destExpr)->is<LValueType>() || result.isFailure()) {
-        conversionsOrFixes.push_back(IgnoreAssignmentDestinationType::create(
-            *this, lhs, rhs, getConstraintLocator(locator)));
+        // Let this asignment failure be diagnosed by the AllowTupleTypeMismatch
+        // fix already recorded.
+        if (hasFixFor(loc, FixKind::AllowTupleTypeMismatch))
+          return true;
+
+        conversionsOrFixes.push_back(
+            IgnoreAssignmentDestinationType::create(*this, lhs, rhs, loc));
       } else {
         conversionsOrFixes.push_back(
-            TreatRValueAsLValue::create(*this, getConstraintLocator(locator)));
+            TreatRValueAsLValue::create(*this, loc));
       }
 
       return true;
@@ -8865,11 +8871,16 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
                 CoerceToCheckedCast::attempt(*this, fromType, toType, loc))
           return !recordFix(fix, impact);
       }
-
+      
+      // We already have a fix for this locator indicating a
+      // tuple mismatch.
+      if (hasFixFor(loc, FixKind::AllowTupleTypeMismatch))
+        return true;
+      
       if (restriction == ConversionRestrictionKind::ValueToOptional ||
           restriction == ConversionRestrictionKind::OptionalToOptional)
         ++impact;
-
+      
       auto *fix =
           loc->isLastElement<LocatorPathElt::ApplyArgToParam>()
               ? AllowArgumentMismatch::create(*this, fromType, toType, loc)

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -323,8 +323,15 @@ let _ = dupLabelSubscriptStruct[foo: 5, foo: 5] // ok
 
 var dict: [String: (Int, Int)] = [:]
 let bignum: Int64 = 1337
-dict["test"] = (bignum, 1) // expected-error {{cannot assign value of type '(Int64, Int)' to type '(Int, Int)'}}
-// expected-error@-1 {{cannot assign value of type '(Int64, Int)' to subscript of type '(Int, Int)'}}
+dict["test"] = (bignum, 1) // expected-error {{cannot assign value of type '(Int64, Int)' to subscript of type '(Int, Int)'}}
 
 var tuple: (Int, Int)
 tuple = (bignum, 1) // expected-error {{cannot assign value of type '(Int64, Int)' to type '(Int, Int)'}}
+
+var optionalTuple: (Int, Int)?
+var optionalTuple2: (Int64, Int)? = (bignum, 1) 
+var optionalTuple3: (UInt64, Int)? = (bignum, 1) // expected-error {{cannot convert value of type '(Int64, Int)' to specified type '(UInt64, Int)?'}}
+
+optionalTuple = (bignum, 1) // expected-error {{cannot assign value of type '(Int64, Int)' to type '(Int, Int)'}}
+// Optional to Optional
+optionalTuple = optionalTuple2 // expected-error {{cannot assign value of type '(Int64, Int)?' to type '(Int, Int)?'}}

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -318,3 +318,13 @@ struct DupLabelSubscript {
 
 let dupLabelSubscriptStruct = DupLabelSubscript()
 let _ = dupLabelSubscriptStruct[foo: 5, foo: 5] // ok
+
+// SR-12869
+
+var dict: [String: (Int, Int)] = [:]
+let bignum: Int64 = 1337
+dict["test"] = (bignum, 1) // expected-error {{cannot assign value of type '(Int64, Int)' to type '(Int, Int)'}}
+// expected-error@-1 {{cannot assign value of type '(Int64, Int)' to subscript of type '(Int, Int)'}}
+
+var tuple: (Int, Int)
+tuple = (bignum, 1) // expected-error {{cannot assign value of type '(Int64, Int)' to type '(Int, Int)'}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixes a crasher on the `TupleContextualFailure` when involving optional tuple type.
It also resolves a duplicated diagnostic when it diagnoses the mismatch in `IgnoreAssignmentDestinationType`/`ContextualMismatch` and `AllowTupleMismatch`.

cc @xedin :)

Resolves SR-12869.
