### PR TITLE
ModuleLoading: account for standard library in load path

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -101,9 +101,13 @@ static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
   if (SearchPathOpts.SkipRuntimeLibraryImportPaths)
     return;
 
-  if (!Triple.isOSDarwin())
-    llvm::sys::path::append(LibPath, swift::getMajorArchitectureName(Triple));
   SearchPathOpts.RuntimeLibraryImportPaths.push_back(std::string(LibPath.str()));
+
+  /* Compatibility for <=5.3 layout */
+  if (!Triple.isOSDarwin()) {
+    llvm::sys::path::append(LibPath, swift::getMajorArchitectureName(Triple));
+    SearchPathOpts.RuntimeLibraryImportPaths.push_back(std::string(LibPath.str()));
+  }
 
   if (!SearchPathOpts.SDKPath.empty()) {
     if (tripleIsMacCatalystEnvironment(Triple)) {

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -563,7 +563,9 @@ SerializedModuleLoaderBase::findModule(AccessPathElem moduleID,
             // Apple platforms always use target-specific files within a
             // .swiftmodule directory for the stdlib; non-Apple platforms
             // always use single-architecture swiftmodules.
-            checkTargetSpecificModule = Ctx.LangOpts.Target.isOSDarwin();
+            auto result = findTargetSpecificModuleFiles();
+            if (Ctx.LangOpts.Target.isOSDarwin() || result)
+              return result;
           } else {
             auto modulePath = currPath;
             llvm::sys::path::append(modulePath, genericModuleFileName);


### PR DESCRIPTION
The previous change did fix the handling for non-standard library cases,
but the standard library path still required the old layout.  This
unifies the behaviour across the standard library and any other imported
libraries.  With this patch, it is almost possible to enable the new
layout in the build tree for Windows/Linux.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
