### PR TITLE
[AutoDiff] Fix false 'Differentiable' synthesis warning on class property wrappers.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2764,10 +2764,10 @@ WARNING(differentiable_nondiff_type_implicit_noderivative_fixit,none,
        /*nominalCanDeriveAdditiveArithmetic*/ bool))
 WARNING(differentiable_immutable_wrapper_implicit_noderivative_fixit,none,
       "synthesis of the 'Differentiable.move(along:)' requirement for %1 "
-      "requires all stored properties not marked with `@noDerivative` to be "
-      "mutable; add an explicit '@noDerivative' attribute"
+      "requires 'wrappedValue' in property wrapper %0 to be mutable; "
+      "add an explicit '@noDerivative' attribute"
       "%select{|, or conform %1 to 'AdditiveArithmetic'}2",
-      (/*wrapperType*/ StringRef, /*nominalName*/ Identifier,
+      (/*wrapperType*/ Identifier, /*nominalName*/ Identifier,
        /*nominalCanDeriveAdditiveArithmetic*/ bool))
 WARNING(differentiable_let_property_implicit_noderivative_fixit,none,
       "synthesis of the 'Differentiable.move(along:)' requirement for %0 "

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -44,9 +44,7 @@ getStoredPropertiesForDifferentiation(NominalTypeDecl *nominal, DeclContext *DC,
     if (auto *originalProperty = vd->getOriginalWrappedProperty()) {
       // Skip immutable wrapped properties. `mutating func move(along:)` cannot
       // be synthesized to update these properties.
-      auto mutability = originalProperty->getPropertyWrapperMutability();
-      assert(mutability.hasValue() && "Expected wrapped property mutability");
-      if (mutability->Setter != PropertyWrapperMutability::Value::Mutating)
+      if (!originalProperty->getAccessor(AccessorKind::Set))
         continue;
       // Use the original wrapped property.
       vd = originalProperty;
@@ -508,11 +506,9 @@ static void checkAndDiagnoseImplicitNoDerivative(ASTContext &Context,
       // Diagnose wrapped properties whose property wrappers do not define
       // `wrappedValue.set`. `mutating func move(along:)` cannot be synthesized
       // to update these properties.
-      auto *wrapperDecl =
-          vd->getInterfaceType()->getNominalOrBoundGenericNominal();
-      auto mutability = originalProperty->getPropertyWrapperMutability();
-      assert(mutability.hasValue() && "Expected wrapped property mutability");
-      if (mutability->Setter != PropertyWrapperMutability::Value::Mutating) {
+      if (!originalProperty->getAccessor(AccessorKind::Set)) {
+        auto *wrapperDecl =
+            vd->getInterfaceType()->getNominalOrBoundGenericNominal();
         auto loc =
             originalProperty->getAttributeInsertionLoc(/*forModifier*/ false);
         Context.Diags
@@ -520,7 +516,7 @@ static void checkAndDiagnoseImplicitNoDerivative(ASTContext &Context,
                 loc,
                 diag::
                     differentiable_immutable_wrapper_implicit_noderivative_fixit,
-                wrapperDecl->getNameStr(), nominal->getName(),
+                wrapperDecl->getName(), nominal->getName(),
                 nominalCanDeriveAdditiveArithmetic)
             .fixItInsert(loc, "@noDerivative ");
         // Add an implicit `@noDerivative` attribute.

--- a/test/AutoDiff/Sema/DerivedConformances/class_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/class_differentiable.swift
@@ -541,18 +541,29 @@ struct Wrapper<Value> {
   var wrappedValue: Value
 }
 
+@propertyWrapper
+class ClassWrapper<Value> {
+  var wrappedValue: Value
+  init(wrappedValue: Value) { self.wrappedValue = wrappedValue }
+}
+
 struct Generic<T> {}
 extension Generic: Differentiable where T: Differentiable {}
 
 class WrappedProperties: Differentiable {
-  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'WrappedProperties' requires all stored properties not marked with `@noDerivative` to be mutable; add an explicit '@noDerivative' attribute}}
+  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'WrappedProperties' requires 'wrappedValue' in property wrapper 'ImmutableWrapper' to be mutable; add an explicit '@noDerivative' attribute}}
   @ImmutableWrapper var immutableInt: Generic<Int> = Generic()
 
   // expected-warning @+1 {{stored property 'mutableInt' has no derivative because 'Generic<Int>' does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}}
   @Wrapper var mutableInt: Generic<Int> = Generic()
 
   @Wrapper var float: Generic<Float> = Generic()
+  @ClassWrapper var float2: Generic<Float> = Generic()
   @noDerivative @ImmutableWrapper var nondiff: Generic<Int> = Generic()
+
+  static func testTangentMemberwiseInitializer() {
+    _ = TangentVector(float: .init(), float2: .init())
+  }
 }
 
 // Test derived conformances in disallowed contexts.

--- a/test/AutoDiff/Sema/DerivedConformances/struct_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/struct_differentiable.swift
@@ -354,18 +354,29 @@ struct Wrapper<Value> {
   var wrappedValue: Value
 }
 
+@propertyWrapper
+class ClassWrapper<Value> {
+  var wrappedValue: Value
+  init(wrappedValue: Value) { self.wrappedValue = wrappedValue }
+}
+
 struct Generic<T> {}
 extension Generic: Differentiable where T: Differentiable {}
 
 struct WrappedProperties: Differentiable {
-  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'WrappedProperties' requires all stored properties not marked with `@noDerivative` to be mutable; add an explicit '@noDerivative' attribute}}
+  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'WrappedProperties' requires 'wrappedValue' in property wrapper 'ImmutableWrapper' to be mutable; add an explicit '@noDerivative' attribute}}
   @ImmutableWrapper var immutableInt: Generic<Int>
 
   // expected-warning @+1 {{stored property 'mutableInt' has no derivative because 'Generic<Int>' does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}}
   @Wrapper var mutableInt: Generic<Int>
 
   @Wrapper var float: Generic<Float>
+  @ClassWrapper var float2: Generic<Float>
   @noDerivative @ImmutableWrapper var nondiff: Generic<Int>
+
+  static func testTangentMemberwiseInitializer() {
+    _ = TangentVector(float: .init(), float2: .init())
+  }
 }
 
 // Verify that cross-file derived conformances are disallowed.


### PR DESCRIPTION
In `Differentiable` derived conformances, determine whether a property-wrapped property is mutable by checking whether a setter exists, instead of calling `VarDecl::getPropertyWrapperMutability()`.

Resolves rdar://63577692 (SR-12873) where class-typed property wrappers with a mutable `wrappedValue` are rejected by synthesis (not included in the `TangentVector`). Also improve the property-wrapper-specific immutability warning message.