### PR TITLE
Ban classes conforming to _ObjectiveCBridgeable

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1876,6 +1876,10 @@ NOTE(anyobject_requirement,none,
 ERROR(non_class_cannot_conform_to_class_protocol,none,
       "non-class type %0 cannot conform to class protocol %1",
       (Type, Type))
+ERROR(dont_bridge_objc_classes_to_separate_swift_classes,none,
+      "class %0 cannot conform to protocol %1: Objective-C classes should be "
+      "used directly or bridged to a Swift value type, not a class",
+      (Type, Type))
 ERROR(cf_class_cannot_conform_to_objc_protocol,none,
       "Core Foundation class %0 cannot conform to @objc protocol %1 because "
       "Core Foundation types are not classes in Objective-C",

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -590,3 +590,28 @@ struct SR_11412_S0 {
     c0.foo3 = self // expected-error {{cannot assign value of type 'SR_11412_S0' to type 'SR_11412_P4?'}}
   }
 }
+
+// Classes should not use _ObjectiveCBridgeable //
+
+@objc class BridgeableType {}
+
+final class BridgedType: _ObjectiveCBridgeable { // expected-error {{class 'BridgedType' cannot conform to protocol '_ObjectiveCBridgeable': Objective-C classes should be used directly or bridged to a Swift value type, not a class}}
+  public func _bridgeToObjectiveC() -> BridgeableType {
+      return BridgeableType()
+  }
+
+  public static func _forceBridgeFromObjectiveC(_ input: BridgeableType, result: inout BridgedType?) {
+      result = BridgedType()
+  }
+
+  public static func _conditionallyBridgeFromObjectiveC(_ input: BridgeableType, result: inout BridgedType?) -> Bool {
+      result = BridgedType()
+      return true
+  }
+
+  public static func _unconditionallyBridgeFromObjectiveC(_ source: BridgeableType?) -> BridgedType {
+      var result: BridgedType?
+      _forceBridgeFromObjectiveC(source!, result: &result)
+      return result!
+  }
+}


### PR DESCRIPTION
This PR adds a special case to the declaration checker which makes it reject attempts to conform classes to `_ObjectiveCBridgeable`. It doesn’t make much sense to bridge a class to a different class when it comes into Swift, and PrintAsObjC has never handled these conformances correctly.

Banning is an aggressive solution, but we don’t promise source compatibility with underscored declarations, so it’s a matter of how badly this breaks things in practice. If this causes too much pain, we can instead add appropriate test coverage and fix PrintAsObjC.

This PR also changes a "can't happen" code path in PrintAsObjC which used to print syntactically invalid code into the generated header to instead abort with a detailed message asking the user to file a bug. Classes conforming to `_ObjectiveCBridgeable` used to end up in this place; if anything else does, I want to know about it.

Fixes rdar://62890964.
