### PR TITLE
Update LLVM development policy

### DIFF
--- a/docs/Branches.md
+++ b/docs/Branches.md
@@ -62,11 +62,15 @@ You can use any of the branch names as the argument to `--scheme`, such as `mast
 
   ... then these commits can be cherry-picked to an appropriate, `swift/master` aligned `apple/stable/*` branch in Apple's fork of [llvm-project](https://github.com/apple/llvm-project). Please see
   [Apple's branching scheme](https://github.com/apple/llvm-project/blob/apple/master/apple-docs/AppleBranchingScheme.md)
-  document to determine which `apple/stable/*` branch you should cherry-pick to. Note that no new changes should be submitted directly to `apple/master`. We are actively working on eliminating the differences from upstream LLVM.
+  document to determine which `apple/stable/*` branch you should cherry-pick to.
+  
+  Note that **no new changes should be submitted directly to `apple/master`**. We are actively working on eliminating the differences from upstream LLVM.
 
   2) Changes that depend on Swift (this only applies to LLDB): new commits go to `swift/master-next`
 
   ...then cherry-pick to the release branch (`swift/swift-x.y-branch`) if necessary, following the appropriate release   process. (Usually this means filling out a standard template, finding someone to review your code if that hasn't already happened, and getting approval from that repo's *release manager.)*
+
+  In the long term we want to eliminate the differences from upstream LLVM for these changes as well, but for now there is no concrete plan. So, submitting to `swift/master-next` continues to be allowed.
 
 ## Automerging
 

--- a/docs/Branches.md
+++ b/docs/Branches.md
@@ -62,7 +62,7 @@ You can use any of the branch names as the argument to `--scheme`, such as `mast
 
   ... then these commits can be cherry-picked to an appropriate, `swift/master` aligned `apple/stable/*` branch in Apple's fork of [llvm-project](https://github.com/apple/llvm-project). Please see
   [Apple's branching scheme](https://github.com/apple/llvm-project/blob/apple/master/apple-docs/AppleBranchingScheme.md)
-  document to determine which `apple/stable/*` branch you should cherry-pick to.
+  document to determine which `apple/stable/*` branch you should cherry-pick to. Note that no new changes should be submitted directly to `apple/master`. We are actively working on eliminating the differences from upstream LLVM.
 
   2) Changes that depend on Swift (this only applies to LLDB): new commits go to `swift/master-next`
 


### PR DESCRIPTION
State explicitly that we want to eliminate all differences between
`apple/master` and `llvm.org/master`. All new LLVM development should happen
upstream.