### PR TITLE
stdlib: Add direct.h to ucrt.modulemap

### DIFF
--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -85,6 +85,11 @@ module ucrt [system] {
     }
 
     module POSIX {
+      module direct {
+        header "direct.h"
+        export *
+      }
+
       module fcntl {
         header "fcntl.h"
         export *


### PR DESCRIPTION
`direct.h` is an header Windows provides that provides POSIX file system APIs such as [these](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/mkdir-wmkdir?view=vs-2019).