### PR TITLE
[DNM] Remove generic.never annotations as an experiment

### DIFF
--- a/stdlib/public/core/Dump.swift
+++ b/stdlib/public/core/Dump.swift
@@ -26,7 +26,6 @@
 ///     contents. The default is `Int.max`.
 /// - Returns: The instance passed as `value`.
 @discardableResult
-@_semantics("optimize.sil.specialize.generic.never")
 public func dump<T, TargetStream: TextOutputStream>(
   _ value: T,
   to target: inout TargetStream,
@@ -64,7 +63,6 @@ public func dump<T, TargetStream: TextOutputStream>(
 ///     contents. The default is `Int.max`.
 /// - Returns: The instance passed as `value`.
 @discardableResult
-@_semantics("optimize.sil.specialize.generic.never")
 public func dump<T>(
   _ value: T,
   name: String? = nil,
@@ -83,7 +81,6 @@ public func dump<T>(
 }
 
 /// Dump an object's contents. User code should use dump().
-@_semantics("optimize.sil.specialize.generic.never")
 internal func _dump_unlocked<TargetStream: TextOutputStream>(
   _ value: Any,
   to target: inout TargetStream,
@@ -182,7 +179,6 @@ internal func _dump_unlocked<TargetStream: TextOutputStream>(
 
 /// Dump information about an object's superclass, given a mirror reflecting
 /// that superclass.
-@_semantics("optimize.sil.specialize.generic.never")
 internal func _dumpSuperclass_unlocked<TargetStream: TextOutputStream>(
   mirror: Mirror,
   to target: inout TargetStream,

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -154,7 +154,6 @@ public struct Mirror {
 
   internal static func _noSuperclassMirror() -> Mirror? { return nil }
 
-  @_semantics("optimize.sil.specialize.generic.never")
   @inline(never)
   internal static func _superclassIterator<Subject>(
     _ subject: Subject, _ ancestorRepresentation: AncestorRepresentation

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -280,7 +280,6 @@ internal func _getEnumCaseName<T>(_ value: T) -> UnsafePointer<CChar>?
 internal func _opaqueSummary(_ metadata: Any.Type) -> UnsafePointer<CChar>?
 
 /// Do our best to print a value that cannot be printed directly.
-@_semantics("optimize.sil.specialize.generic.never")
 internal func _adHocPrint_unlocked<T, TargetStream: TextOutputStream>(
     _ value: T, _ mirror: Mirror, _ target: inout TargetStream,
     isDebugPrint: Bool
@@ -375,7 +374,6 @@ internal func _adHocPrint_unlocked<T, TargetStream: TextOutputStream>(
 }
 
 @usableFromInline
-@_semantics("optimize.sil.specialize.generic.never")
 internal func _print_unlocked<T, TargetStream: TextOutputStream>(
   _ value: T, _ target: inout TargetStream
 ) {
@@ -420,7 +418,6 @@ internal func _print_unlocked<T, TargetStream: TextOutputStream>(
 // `debugPrint`
 //===----------------------------------------------------------------------===//
 
-@_semantics("optimize.sil.specialize.generic.never")
 @inline(never)
 public func _debugPrint_unlocked<T, TargetStream: TextOutputStream>(
     _ value: T, _ target: inout TargetStream
@@ -444,7 +441,6 @@ public func _debugPrint_unlocked<T, TargetStream: TextOutputStream>(
   _adHocPrint_unlocked(value, mirror, &target, isDebugPrint: true)
 }
 
-@_semantics("optimize.sil.specialize.generic.never")
 internal func _dumpPrint_unlocked<T, TargetStream: TextOutputStream>(
     _ value: T, _ mirror: Mirror, _ target: inout TargetStream
 ) {


### PR DESCRIPTION
These were added pre-ABI stability and a lot has changed since. They're all non-`@inlinable` functions so it's only a question of whether they bloat the std lib binary itself.