### PR TITLE
[Diagnostics] Add -diagnostic-style=(llvm|swift) to control printed output

### DIFF
--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -32,6 +32,8 @@ public:
     VerifyAndApplyFixes
   } VerifyMode = NoVerify;
 
+  enum FormattingStyle { LLVM, Swift };
+
   /// Indicates whether to allow diagnostics for \c <unknown> locations if
   /// \c VerifyMode is not \c NoVerify.
   bool VerifyIgnoreUnknown = false;
@@ -61,7 +63,7 @@ public:
 
   // If set to true, use the more descriptive experimental formatting style for
   // diagnostics.
-  bool EnableExperimentalFormatting = false;
+  FormattingStyle PrintedFormattingStyle = FormattingStyle::LLVM;
 
   std::string DiagnosticDocumentationPath = "";
 

--- a/include/swift/Frontend/PrintingDiagnosticConsumer.h
+++ b/include/swift/Frontend/PrintingDiagnosticConsumer.h
@@ -18,8 +18,9 @@
 #ifndef SWIFT_PRINTINGDIAGNOSTICCONSUMER_H
 #define SWIFT_PRINTINGDIAGNOSTICCONSUMER_H
 
-#include "swift/Basic/LLVM.h"
 #include "swift/AST/DiagnosticConsumer.h"
+#include "swift/Basic/DiagnosticOptions.h"
+#include "swift/Basic/LLVM.h"
 
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/Process.h"
@@ -33,7 +34,8 @@ class PrintingDiagnosticConsumer : public DiagnosticConsumer {
   bool ForceColors = false;
   bool PrintEducationalNotes = false;
   bool DidErrorOccur = false;
-  bool ExperimentalFormattingEnabled = false;
+  DiagnosticOptions::FormattingStyle FormattingStyle =
+      DiagnosticOptions::FormattingStyle::LLVM;
   // The current snippet used to display an error/warning/remark and the notes
   // implicitly associated with it. Uses `std::unique_ptr` so that
   // `AnnotatedSourceSnippet` can be forward declared.
@@ -65,7 +67,9 @@ public:
     PrintEducationalNotes = ShouldPrint;
   }
 
-  void enableExperimentalFormatting() { ExperimentalFormattingEnabled = true; }
+  void setFormattingStyle(DiagnosticOptions::FormattingStyle style) {
+    FormattingStyle = style;
+  }
 
   bool didErrorOccur() {
     return DidErrorOccur;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -131,10 +131,6 @@ def enable_cross_import_overlays : Flag<["-"], "enable-cross-import-overlays">,
 def disable_cross_import_overlays : Flag<["-"], "disable-cross-import-overlays">,
   HelpText<"Do not automatically import declared cross-import overlays.">;
   
-def enable_experimental_diagnostic_formatting :
-  Flag<["-"], "enable-experimental-diagnostic-formatting">,
-  HelpText<"Enable experimental diagnostic formatting features.">;
-  
 def diagnostic_documentation_path
   : Separate<["-"], "diagnostic-documentation-path">, MetaVarName<"<path>">,
   HelpText<"Path to diagnostic documentation resources">;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -370,6 +370,13 @@ def debug_diagnostic_names : Flag<["-"], "debug-diagnostic-names">,
 def print_educational_notes : Flag<["-"], "print-educational-notes">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Include educational notes in printed diagnostic output, if available">;
+def diagnostic_style : Separate<["-"], "diagnostic-style">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  MetaVarName<"<style>">,
+  HelpText<"The formatting style used when printing diagnostics ('swift' or 'llvm')">;
+def diagnostic_style_EQ : Joined<["-"], "diagnostic-style=">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  MetaVarName<"<style>">, Alias<diagnostic_style>;
 
 def module_cache_path : Separate<["-"], "module-cache-path">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -243,6 +243,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_serialize_diagnostics_path);
   inputArgs.AddLastArg(arguments, options::OPT_debug_diagnostic_names);
   inputArgs.AddLastArg(arguments, options::OPT_print_educational_notes);
+  inputArgs.AddLastArg(arguments, options::OPT_diagnostic_style);
   inputArgs.AddLastArg(arguments, options::OPT_enable_astscope_lookup);
   inputArgs.AddLastArg(arguments, options::OPT_disable_astscope_lookup);
   inputArgs.AddLastArg(arguments, options::OPT_disable_parser_lookup);

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -932,7 +932,8 @@ void PrintingDiagnosticConsumer::handleDiagnostic(SourceManager &SM,
   if (Info.IsChildNote)
     return;
 
-  if (ExperimentalFormattingEnabled) {
+  switch (FormattingStyle) {
+  case DiagnosticOptions::FormattingStyle::Swift:
     if (Info.Kind == DiagnosticKind::Note && currentSnippet) {
       // If this is a note and we have an in-flight message, add it to that
       // instead of emitting it separately.
@@ -950,7 +951,9 @@ void PrintingDiagnosticConsumer::handleDiagnostic(SourceManager &SM,
           BufferedEducationalNotes.push_back(buffer->get()->getBuffer().str());
       }
     }
-  } else {
+    break;
+
+  case DiagnosticOptions::FormattingStyle::LLVM:
     printDiagnostic(SM, Info);
 
     if (PrintEducationalNotes) {
@@ -965,6 +968,7 @@ void PrintingDiagnosticConsumer::handleDiagnostic(SourceManager &SM,
     for (auto ChildInfo : Info.ChildDiagnosticInfo) {
       printDiagnostic(SM, *ChildInfo);
     }
+    break;
   }
 }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -2111,10 +2111,8 @@ int swift::performFrontend(ArrayRef<const char *> Args,
   PDC.setPrintEducationalNotes(
       Invocation.getDiagnosticOptions().PrintEducationalNotes);
 
-  // Temporarily stage the new diagnostic formatting style behind
-  // -enable-descriptive-diagnostics
-  if (Invocation.getDiagnosticOptions().EnableExperimentalFormatting)
-    PDC.enableExperimentalFormatting();
+  PDC.setFormattingStyle(
+      Invocation.getDiagnosticOptions().PrintedFormattingStyle);
 
   if (Invocation.getFrontendOptions().DebugTimeCompilation)
     SharedTimer::enableCompilationTimers();

--- a/test/Driver/color-diagnostics.swift
+++ b/test/Driver/color-diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swiftc_driver -color-diagnostics -emit-executable -o %t %s 2>&1 \
+// RUN: not %target-swiftc_driver -color-diagnostics -diagnostic-style=llvm -emit-executable -o %t %s 2>&1 \
 // RUN:     | %FileCheck -check-prefix=CHECK-CD %s
 // CHECK-CD: [0m1 = 2{{$}}
 

--- a/test/diagnostics/educational-notes.swift
+++ b/test/diagnostics/educational-notes.swift
@@ -1,6 +1,6 @@
-// RUN: not %target-swift-frontend -color-diagnostics -print-educational-notes -diagnostic-documentation-path %S/test-docs/ -typecheck %s 2>&1 | %FileCheck %s --match-full-lines --strict-whitespace
+// RUN: not %target-swift-frontend -color-diagnostics -diagnostic-style=llvm -print-educational-notes -diagnostic-documentation-path %S/test-docs/ -typecheck %s 2>&1 | %FileCheck %s --match-full-lines --strict-whitespace
 // RUN: not %target-swift-frontend -no-color-diagnostics -print-educational-notes -diagnostic-documentation-path %S/test-docs/ -typecheck %s 2>&1 | %FileCheck %s --match-full-lines --strict-whitespace --check-prefix=NO-COLOR
-// RUN: not %target-swift-frontend -enable-experimental-diagnostic-formatting -print-educational-notes -diagnostic-documentation-path %S/test-docs/ -typecheck %s 2>&1 | %FileCheck %s --check-prefix=CHECK-DESCRIPTIVE
+// RUN: not %target-swift-frontend -diagnostic-style=swift -print-educational-notes -diagnostic-documentation-path %S/test-docs/ -typecheck %s 2>&1 | %FileCheck %s --check-prefix=CHECK-DESCRIPTIVE
 
 // A diagnostic with no educational notes
 let x = 1 +

--- a/test/diagnostics/pretty-printed-diagnostics.swift
+++ b/test/diagnostics/pretty-printed-diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend -enable-experimental-diagnostic-formatting -typecheck %s 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -diagnostic-style=swift -typecheck %s 2>&1 | %FileCheck %s
 
 1 + 2
 

--- a/test/diagnostics/pretty-printed-diags-in-clang-buffer.swift
+++ b/test/diagnostics/pretty-printed-diags-in-clang-buffer.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t.mcp)
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-diagnostic-formatting -I %S/Inputs/ -typecheck %s -module-cache-path %t.mcp 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -diagnostic-style=swift -I %S/Inputs/ -typecheck %s -module-cache-path %t.mcp 2>&1 | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/diagnostics/pretty-printed-source-loc-directive-diags.swift
+++ b/test/diagnostics/pretty-printed-source-loc-directive-diags.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend -enable-experimental-diagnostic-formatting -typecheck %s 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -diagnostic-style=swift -typecheck %s 2>&1 | %FileCheck %s
 
 // Error split between the real file and a virtual one.
 #sourceLocation(file: "abc.swift", line: 9)


### PR DESCRIPTION
This default formatting style remains the same, "LLVM style". "Swift style"
is what was previously enabled via -enable-experimental-diagnostic-formatting

https://github.com/apple/swift/pull/31213 has some screenshots of the new style. I'm not making it the default because I want to gather some feedback from real-world use first.