### PR TITLE
[IRGen] NFC: Clean up Alignment type

### DIFF
--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -43,7 +43,7 @@ class DebugTypeInfo {
   /// the storage type for undefined variables.
   llvm::Type *StorageType = nullptr;
   Size size = Size(0);
-  Alignment align = Alignment(0);
+  Alignment align = Alignment();
   bool DefaultAlignment = true;
   bool IsMetadataType = false;
 
@@ -123,7 +123,7 @@ template <> struct DenseMapInfo<swift::irgen::DebugTypeInfo> {
   static swift::irgen::DebugTypeInfo getTombstoneKey() {
     return swift::irgen::DebugTypeInfo(
         llvm::DenseMapInfo<swift::TypeBase *>::getTombstoneKey(), nullptr,
-        swift::irgen::Size(0), swift::irgen::Alignment(0), false, false);
+        swift::irgen::Size(0), swift::irgen::Alignment(), false, false);
   }
   static unsigned getHashValue(swift::irgen::DebugTypeInfo Val) {
     return DenseMapInfo<swift::CanType>::getHashValue(Val.getType());

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1851,7 +1851,7 @@ void CallEmission::emitToExplosion(Explosion &out, bool isOutlined) {
       auto fnType = getCallee().getFunctionPointer().getFunctionType();
       assert(fnType->getNumParams() > 0);
       auto resultTy = fnType->getParamType(0)->getPointerElementType();
-      auto temp = IGF.createAlloca(resultTy, Alignment(0), "indirect.result");
+      auto temp = IGF.createAlloca(resultTy, Alignment(), "indirect.result");
       emitToMemory(temp, substResultTI, isOutlined);
       return;
     }

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -1056,28 +1056,28 @@ getAddrOfKnownValueWitnessTable(IRGenModule &IGM, CanType type,
     // Reuse one of the integer witnesses if applicable.
     switch (sizeAndAlignment(fixedTI->getFixedSize(),
                              fixedTI->getFixedAlignment())) {
-    case sizeAndAlignment(Size(0), Alignment(1)):
+    case sizeAndAlignment(Size(0), Alignment::create<1>()):
       witnessSurrogate = TupleType::getEmpty(C);
       break;
-    case sizeAndAlignment(Size(1), Alignment(1)):
+    case sizeAndAlignment(Size(1), Alignment::create<1>()):
       witnessSurrogate = BuiltinIntegerType::get(8, C)->getCanonicalType();
       break;
-    case sizeAndAlignment(Size(2), Alignment(2)):
+    case sizeAndAlignment(Size(2), Alignment::create<2>()):
       witnessSurrogate = BuiltinIntegerType::get(16, C)->getCanonicalType();
       break;
-    case sizeAndAlignment(Size(4), Alignment(4)):
+    case sizeAndAlignment(Size(4), Alignment::create<4>()):
       witnessSurrogate = BuiltinIntegerType::get(32, C)->getCanonicalType();
       break;
-    case sizeAndAlignment(Size(8), Alignment(8)):
+    case sizeAndAlignment(Size(8), Alignment::create<8>()):
       witnessSurrogate = BuiltinIntegerType::get(64, C)->getCanonicalType();
       break;
-    case sizeAndAlignment(Size(16), Alignment(16)):
+    case sizeAndAlignment(Size(16), Alignment::create<16>()):
       witnessSurrogate = BuiltinIntegerType::get(128, C)->getCanonicalType();
       break;
-    case sizeAndAlignment(Size(32), Alignment(32)):
+    case sizeAndAlignment(Size(32), Alignment::create<32>()):
       witnessSurrogate = BuiltinIntegerType::get(256, C)->getCanonicalType();
       break;
-    case sizeAndAlignment(Size(64), Alignment(64)):
+    case sizeAndAlignment(Size(64), Alignment::create<64>()):
       witnessSurrogate = BuiltinIntegerType::get(512, C)->getCanonicalType();
       break;
     }

--- a/lib/IRGen/IRGen.h
+++ b/lib/IRGen/IRGen.h
@@ -235,24 +235,21 @@ inline bool operator<=(OperationCost l, OperationCost r) {
 /// An alignment value, in eight-bit units.
 class Alignment {
 public:
-  using int_type = uint32_t;
+  using int_type = uint64_t;
 
-  constexpr Alignment() : Value(0) {}
-  constexpr explicit Alignment(int_type Value) : Value(Value) {}
-  explicit Alignment(clang::CharUnits value) : Value(value.getQuantity()) {}
+  constexpr Alignment() : Shift(0) {}
+  explicit Alignment(int_type Value) : Shift(llvm::Log2_64(Value)) {
+    assert(llvm::isPowerOf2_64(Value));
+  }
+  explicit Alignment(clang::CharUnits value) : Alignment(value.getQuantity()) {}
 
-  constexpr int_type getValue() const { return Value; }
-  constexpr int_type getMaskValue() const { return Value - 1; }
-
-  bool isOne() const { return Value == 1; }
-  bool isZero() const { return Value == 0; }
+  constexpr int_type getValue() const { return int_type(1) << Shift; }
+  constexpr int_type getMaskValue() const { return getValue() - 1; }
 
   Alignment alignmentAtOffset(Size S) const;
   Size asSize() const;
 
-  unsigned log2() const {
-    return llvm::Log2_64(Value);
-  }
+  unsigned log2() const { return Shift; }
 
   operator clang::CharUnits() const {
     return asCharUnits();
@@ -261,19 +258,24 @@ public:
     return clang::CharUnits::fromQuantity(getValue());
   }
 
-  explicit operator bool() const { return Value != 0; }
+  explicit operator llvm::MaybeAlign() const { return llvm::MaybeAlign(getValue()); }
 
-  explicit operator llvm::MaybeAlign() const { return llvm::MaybeAlign(Value); }
+  friend bool operator< (Alignment L, Alignment R){ return L.Shift <  R.Shift; }
+  friend bool operator<=(Alignment L, Alignment R){ return L.Shift <= R.Shift; }
+  friend bool operator> (Alignment L, Alignment R){ return L.Shift >  R.Shift; }
+  friend bool operator>=(Alignment L, Alignment R){ return L.Shift >= R.Shift; }
+  friend bool operator==(Alignment L, Alignment R){ return L.Shift == R.Shift; }
+  friend bool operator!=(Alignment L, Alignment R){ return L.Shift != R.Shift; }
 
-  friend bool operator< (Alignment L, Alignment R){ return L.Value <  R.Value; }
-  friend bool operator<=(Alignment L, Alignment R){ return L.Value <= R.Value; }
-  friend bool operator> (Alignment L, Alignment R){ return L.Value >  R.Value; }
-  friend bool operator>=(Alignment L, Alignment R){ return L.Value >= R.Value; }
-  friend bool operator==(Alignment L, Alignment R){ return L.Value == R.Value; }
-  friend bool operator!=(Alignment L, Alignment R){ return L.Value != R.Value; }
+  template<unsigned Value>
+  static constexpr Alignment create() {
+    Alignment result;
+    result.Shift = llvm::CTLog2<Value>();
+    return result;
+  }
 
 private:
-  int_type Value;
+  unsigned char Shift;
 };
 
 /// A size value, in eight-bit units.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -698,9 +698,8 @@ public:
 
   /// Unconditionally emit a stack shadow copy of an \c llvm::Value.
   llvm::Value *emitShadowCopy(llvm::Value *Storage, const SILDebugScope *Scope,
-                              SILDebugVariable VarInfo, Alignment Align) {
-    if (Align.isZero())
-      Align = IGM.getPointerAlignment();
+                              SILDebugVariable VarInfo, llvm::Optional<Alignment> _Align) {
+    auto Align = _Align.getValueOr(IGM.getPointerAlignment());
 
     unsigned ArgNo = VarInfo.ArgNo;
     auto &Alloca = ShadowStackSlots[{ArgNo, {Scope, VarInfo.Name}}];
@@ -721,7 +720,7 @@ public:
                                       const SILDebugScope *Scope,
                                       SILDebugVariable VarInfo,
                                       bool IsAnonymous,
-                                      Alignment Align = Alignment(0)) {
+                                      llvm::Optional<Alignment> Align = None) {
     // Never emit shadow copies when optimizing, or if already on the stack.
     // No debug info is emitted for refcounts either.
     if (IGM.IRGen.Opts.DisableDebuggerShadowCopies ||

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -148,7 +148,6 @@ protected:
            IsABIAccessible_t abiAccessible,
            SpecialTypeInfoKind stik) : StorageType(Type) {
     assert(stik >= SpecialTypeInfoKind::Fixed || !alwaysFixedSize);
-    assert(!A.isZero() && "Invalid alignment");
     Bits.OpaqueBits = 0;
     Bits.TypeInfo.Kind = unsigned(stik);
     Bits.TypeInfo.AlignmentShift = llvm::Log2_32(A.getValue());


### PR DESCRIPTION
1) Shrink from 4 bytes to 1 byte.
2) Assert that alignments are power-of-two at run time.
3) Assert that alignments are power-of-two at compile time when possible.
4) Eliminate "isZero"/"no alignment" from the type. Use `llvm::Optional`.