### PR TITLE
[SR-12881] DefaultIndices dynamic dispatch

### DIFF
--- a/stdlib/public/core/Indices.swift
+++ b/stdlib/public/core/Indices.swift
@@ -90,7 +90,7 @@ extension DefaultIndices: Collection {
   @inlinable
   public func index(
     _ i: Index, offsetBy distance: Int, limitedBy limit: Index
-    ) -> Index? {
+  ) -> Index? {
     return _elements.index(i, offsetBy: distance, limitedBy: limit)
   }
 

--- a/stdlib/public/core/Indices.swift
+++ b/stdlib/public/core/Indices.swift
@@ -87,14 +87,14 @@ extension DefaultIndices: Collection {
     return _elements.index(i, offsetBy: distance)
   }
 
-  @inlinable
+  @_alwaysEmitIntoClient
   public func index(
     _ i: Index, offsetBy distance: Int, limitedBy limit: Index
   ) -> Index? {
     return _elements.index(i, offsetBy: distance, limitedBy: limit)
   }
 
-  @inlinable
+  @_alwaysEmitIntoClient
   public func distance(from start: Index, to end: Index) -> Int {
     return _elements.distance(from: start, to: end)
   }

--- a/stdlib/public/core/Indices.swift
+++ b/stdlib/public/core/Indices.swift
@@ -82,7 +82,7 @@ extension DefaultIndices: Collection {
     return self
   }
   
-  @inlinable
+  @_alwaysEmitIntoClient
   public func index(_ i: Index, offsetBy distance: Int) -> Index {
     return _elements.index(i, offsetBy: distance)
   }

--- a/stdlib/public/core/Indices.swift
+++ b/stdlib/public/core/Indices.swift
@@ -89,7 +89,7 @@ extension DefaultIndices: Collection {
 
   @inlinable
   public func index(
-      _ i: Index, offsetBy distance: Int, limitedBy limit: Index
+    _ i: Index, offsetBy distance: Int, limitedBy limit: Index
     ) -> Index? {
     return _elements.index(i, offsetBy: distance, limitedBy: limit)
   }

--- a/stdlib/public/core/Indices.swift
+++ b/stdlib/public/core/Indices.swift
@@ -81,6 +81,23 @@ extension DefaultIndices: Collection {
   public var indices: Indices {
     return self
   }
+  
+  @inlinable
+  public func index(_ i: Index, offsetBy distance: Int) -> Index {
+    return _elements.index(i, offsetBy: distance)
+  }
+
+  @inlinable
+  public func index(
+      _ i: Index, offsetBy distance: Int, limitedBy limit: Index
+    ) -> Index? {
+    return _elements.index(i, offsetBy: distance, limitedBy: limit)
+  }
+
+  @inlinable
+  public func distance(from start: Index, to end: Index) -> Int {
+    return _elements.distance(from: start, to: end)
+  }
 }
 
 extension DefaultIndices: BidirectionalCollection

--- a/test/stdlib/DefaultIndices.swift
+++ b/test/stdlib/DefaultIndices.swift
@@ -1,0 +1,40 @@
+// RUN: %target-run-stdlib-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var suite = TestSuite("DefaultIndices")
+defer { runAllTests() }
+
+extension Collection {
+  func genericDistance(from start: Index, to end: Index) -> Int {
+    return distance(from: start, to: end)
+  }
+
+  func genericIndex(_ i: Index, offsetBy distance: Int) -> Index {
+    return index(i, offsetBy: distance)
+  }
+
+  func genericIndex(
+    _ i: Index, offsetBy distance: Int, limitedBy limit: Index
+  ) -> Index? {
+    return index(i, offsetBy: distance, limitedBy: limit)
+  }
+}
+
+suite.test("Bidirectional dispatch") {
+  var r = (0...10).indices
+  expectType(DefaultIndices<ClosedRange<Int>>.self, &r)
+
+  let d = r.distance(from: r.endIndex, to: r.startIndex)
+  let d2 = r.genericDistance(from: r.endIndex, to: r.startIndex)
+  expectEqual(d, d2)
+
+  let i = r.index(r.endIndex, offsetBy: -1)
+  let i2 = r.genericIndex(r.endIndex, offsetBy: -1)
+  expectEqual(i, i2)
+
+  let j = r.index(r.startIndex, offsetBy: -1, limitedBy: r.startIndex)
+  let j2 = r.genericIndex(r.startIndex, offsetBy: -1, limitedBy: r.startIndex)
+  expectEqual(j, j2)
+}


### PR DESCRIPTION
As seen in SR-12881, `DefaultIndices` was not properly dispatching certain `Collection` requirements through conditional conformances to `BidirectionalCollection` and `RandomAccessCollection`.  This should fix that by adding implementations for these methods at the point where `DefaultIndices` conforms to `Collection`:
```
index(_:offsetBy:)
index(_:offsetBy:limitedBy:)
distance(from:to:)
```