### PR TITLE
Fix comparisons between presumed and buffer line numbers

### DIFF
--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -771,8 +771,8 @@ ParserResult<Stmt> Parser::parseStmtReturn(SourceLoc tryLoc) {
 
     // Issue a warning when the returned expression is on a different line than
     // the return keyword, but both have the same indentation.
-    if (SourceMgr.getPresumedLineAndColumnForLoc(ReturnLoc).second ==
-        SourceMgr.getPresumedLineAndColumnForLoc(ExprLoc).second) {
+    if (SourceMgr.getLineAndColumnInBuffer(ReturnLoc).second ==
+        SourceMgr.getLineAndColumnInBuffer(ExprLoc).second) {
       diagnose(ExprLoc, diag::unindented_code_after_return);
       diagnose(ExprLoc, diag::indent_expression_to_silence);
     }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3163,7 +3163,7 @@ static void checkSwitch(ASTContext &ctx, const SwitchStmt *stmt) {
         continue;
       
       auto &SM = ctx.SourceMgr;
-      auto prevLineCol = SM.getPresumedLineAndColumnForLoc(prevLoc);
+      auto prevLineCol = SM.getLineAndColumnInBuffer(prevLoc);
       if (SM.getLineAndColumnInBuffer(thisLoc).first != prevLineCol.first)
         continue;
 


### PR DESCRIPTION
Found these while auditing calls to the line-and-column source manager methods after they were renamed. In the first case, comparing presumed line numbers for equality is not desirable when deciding if we should emit parsing warnings. In the second case, a presumed line number was incorrectly compared to a buffer line number.