### PR TITLE
[Profiler] Don't use presumed line numbers for profiling

### DIFF
--- a/lib/SIL/IR/SILProfiler.cpp
+++ b/lib/SIL/IR/SILProfiler.cpp
@@ -884,8 +884,8 @@ public:
       assert(Region.hasStartLoc() && "invalid region");
       assert(Region.hasEndLoc() && "incomplete region");
 
-      auto Start = SM.getPresumedLineAndColumnForLoc(Region.getStartLoc());
-      auto End = SM.getPresumedLineAndColumnForLoc(Region.getEndLoc());
+      auto Start = SM.getLineAndColumnInBuffer(Region.getStartLoc());
+      auto End = SM.getLineAndColumnInBuffer(Region.getEndLoc());
       assert(Start.first <= End.first && "region start and end out of order");
 
       Regions.emplace_back(Start.first, Start.second, End.first, End.second,

--- a/test/Profiler/coverage_no_presumed_loc.swift
+++ b/test/Profiler/coverage_no_presumed_loc.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -suppress-warnings -profile-generate -profile-coverage-mapping -emit-sil -module-name coverage_no_presumed_loc %s | %FileCheck %s
+
+func foo() {
+  var x : Int = 0
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// foo()
+// CHECK: [[@LINE+3]]:10 -> [[@LINE+6]]:4
+// CHECK-NOT: 200:10 -> 100:4
+#sourceLocation(file: "foo.swift", line: 200)
+  repeat {
+    x += 1
+#sourceLocation(file: "bar.swift", line: 100)
+  } while x < 10
+}


### PR DESCRIPTION
I'm not very familiar with the profiler so it's possible that this is incorrect. I think it should be possible to trip the assertion below the changed lines by using #sourceLocation , though I haven't been able to construct a test case. I think the actual line numbers in the buffer should be used instead.