### PR TITLE
[WIP]Frontend: add flags to support explicitly built Swift/Clang modules

### DIFF
--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -105,7 +105,6 @@ struct InterfaceSubContextDelegate {
                                         StringRef outputPath,
                                         SourceLoc diagLoc,
                     llvm::function_ref<bool(SubCompilerInstanceInfo&)> action) = 0;
-
   virtual ~InterfaceSubContextDelegate() = default;
 };
 

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -152,7 +152,8 @@ public:
   static std::unique_ptr<ClangImporter>
   create(ASTContext &ctx, const ClangImporterOptions &importerOpts,
          std::string swiftPCHHash = "", DependencyTracker *tracker = nullptr,
-         DWARFImporterDelegate *dwarfImporterDelegate = nullptr);
+         DWARFImporterDelegate *dwarfImporterDelegate = nullptr,
+         ArrayRef<StringRef> FrontendArgs = {});
 
   static std::vector<std::string>
   getClangArguments(ASTContext &ctx, const ClangImporterOptions &importerOpts);

--- a/include/swift/ClangImporter/ClangImporterOptions.h
+++ b/include/swift/ClangImporter/ClangImporterOptions.h
@@ -54,6 +54,9 @@ public:
   /// Disable validating the persistent PCH.
   bool PCHDisableValidation = false;
 
+  /// Disable builing PCMs implicitly from the compiler.
+  bool DisableImplicitPCMs = false;
+
   /// \see Mode
   enum class Modes : uint8_t {
     /// Set up Clang for importing modules into Swift and generating IR from

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -262,6 +262,8 @@ public:
   /// built and given to the compiler invocation.
   bool DisableImplicitModules = false;
 
+  std::vector<std::string> ExplicitSwiftModules;
+
   /// The different modes for validating TBD against the LLVM IR.
   enum class TBDValidationMode {
     Default,        ///< Do the default validation for the current platform.

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -258,6 +258,10 @@ public:
   /// By default, we include ImplicitObjCHeaderPath directly.
   llvm::Optional<std::string> BridgingHeaderDirForPrint;
 
+  /// Disable implicitly built Swift/Clang modules because they are explicitly
+  /// built and given to the compiler invocation.
+  bool DisableImplicitModules = false;
+
   /// The different modes for validating TBD against the LLVM IR.
   enum class TBDValidationMode {
     Default,        ///< Do the default validation for the current platform.

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -138,12 +138,13 @@ class ModuleInterfaceLoader : public SerializedModuleLoaderBase {
       DependencyTracker *tracker, ModuleLoadingMode loadMode,
       ArrayRef<std::string> PreferInterfaceForModules,
       bool RemarkOnRebuildFromInterface, bool IgnoreSwiftSourceInfoFile,
-      bool DisableInterfaceFileLock)
+      bool DisableInterfaceFileLock, bool DisableImplicitModules)
   : SerializedModuleLoaderBase(ctx, tracker, loadMode,
                                IgnoreSwiftSourceInfoFile),
   CacheDir(cacheDir), PrebuiltCacheDir(prebuiltCacheDir),
   RemarkOnRebuildFromInterface(RemarkOnRebuildFromInterface),
   DisableInterfaceFileLock(DisableInterfaceFileLock),
+  DisableImplicitModules(DisableImplicitModules),
   PreferInterfaceForModules(PreferInterfaceForModules)
   {}
 
@@ -151,6 +152,7 @@ class ModuleInterfaceLoader : public SerializedModuleLoaderBase {
   std::string PrebuiltCacheDir;
   bool RemarkOnRebuildFromInterface;
   bool DisableInterfaceFileLock;
+  bool DisableImplicitModules;
   ArrayRef<std::string> PreferInterfaceForModules;
 
   std::error_code findModuleFilesInDirectory(
@@ -170,14 +172,16 @@ public:
          ArrayRef<std::string> PreferInterfaceForModules = {},
          bool RemarkOnRebuildFromInterface = false,
          bool IgnoreSwiftSourceInfoFile = false,
-         bool DisableInterfaceFileLock = false) {
+         bool DisableInterfaceFileLock = false,
+         bool DisableImplicitModules = false) {
     return std::unique_ptr<ModuleInterfaceLoader>(
       new ModuleInterfaceLoader(ctx, cacheDir, prebuiltCacheDir,
                                          tracker, loadMode,
                                          PreferInterfaceForModules,
                                          RemarkOnRebuildFromInterface,
                                          IgnoreSwiftSourceInfoFile,
-                                         DisableInterfaceFileLock));
+                                         DisableInterfaceFileLock,
+                                         DisableImplicitModules));
   }
 
   /// Append visible module names to \p names. Note that names are possibly

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -197,8 +197,7 @@ public:
   FrontendArgsReconstructor(const SearchPathOptions &searchPathOpts,
                                   const LangOptions &langOpts,
                                   const FrontendOptions &FEOpts,
-                                  const ClangImporterOptions &ClangOpts,
-                                  StringRef moduleCachePath);
+                                  const ClangImporterOptions &ClangOpts);
   ArrayRef<StringRef> getArgs() const { return GenericArgs; }
   CompilerInvocation &getInvocation() { return subInvocation; }
   void inheritOptionsForSearchPaths(const SearchPathOptions &SearchPathOpts,
@@ -210,7 +209,7 @@ struct InterfaceSubContextDelegateImpl: InterfaceSubContextDelegate {
 private:
   SourceManager &SM;
   DiagnosticEngine &Diags;
-  FrontendArgsReconstructor ArgReconstructor;
+  std::unique_ptr<FrontendArgsReconstructor> ArgReconstructor;
   std::vector<SupplementaryOutputPaths> ModuleOutputPaths;
 
   template<typename ...ArgTypes>
@@ -237,7 +236,8 @@ public:
                                   const FrontendOptions &FEOpts,
                                   const ClangImporterOptions &ClangOpts,
                                   bool buildModuleCacheDirIfAbsent,
-                                  StringRef moduleCachePath);
+                                  StringRef moduleCachePath,
+                                  bool SerializeDependencyHashes);
   bool runInSubContext(StringRef moduleName,
                        StringRef interfacePath,
                        StringRef outputPath,

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -219,6 +219,12 @@ def disable_implicit_swift_modules: Flag<["-"], "disable-implicit-swift-modules"
 
 def disable_implicit_pcms: Flag<["-"], "disable-implicit-pcms">,
   HelpText<"Disable building Clang modules explicitly by the compiler">;
+
+def clang_module_map_file_EQ : Joined<["-"], "clang-module-map-file=">,
+  HelpText<"Pass down to Clang as -fmodule-map-file=">;
+
+def clang_module_file_EQ : Joined<["-"], "clang-module-file=">,
+  HelpText<"Pass down to Clang as -fmodule-file=">;
 }
 
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -214,6 +214,11 @@ def disable_objc_attr_requires_foundation_module :
 def enable_resilience : Flag<["-"], "enable-resilience">,
    HelpText<"Deprecated, use -enable-library-evolution instead">;
 
+def disable_implicit_swift_modules: Flag<["-"], "disable-implicit-swift-modules">,
+  HelpText<"Disable building Swift modules explicitly by the compiler">;
+
+def disable_implicit_pcms: Flag<["-"], "disable-implicit-pcms">,
+  HelpText<"Disable building Clang modules explicitly by the compiler">;
 }
 
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -225,6 +225,9 @@ def clang_module_map_file_EQ : Joined<["-"], "clang-module-map-file=">,
 
 def clang_module_file_EQ : Joined<["-"], "clang-module-file=">,
   HelpText<"Pass down to Clang as -fmodule-file=">;
+
+def swift_module_file_EQ : Joined<["-"], "swift-module-file=">,
+  HelpText<"Specify Swift module explicitly built from textual interface">;
 }
 
 

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -441,7 +441,8 @@ public:
   }
 };
 
-
+std::error_code getNameOfModule(ASTContext &Ctx, StringRef modulePath,
+                                std::string &name);
 } // end namespace swift
 
 #endif

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -518,7 +518,10 @@ importer::getNormalInvocationArguments(
   if (!importerOpts.DebuggerSupport)
     invocationArgStrs.push_back(
         "-Werror=non-modular-include-in-framework-module");
-
+  // Pass to Clang if no implicit modules are allowed.
+  if (importerOpts.DisableImplicitPCMs) {
+    invocationArgStrs.push_back("-fno-implicit-modules");
+  }
   if (LangOpts.EnableObjCInterop) {
     bool EnableCXXInterop = LangOpts.EnableCXXInterop;
     invocationArgStrs.insert(

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -963,11 +963,13 @@ ClangImporter::createClangInvocation(ClangImporter *importer,
 std::unique_ptr<ClangImporter>
 ClangImporter::create(ASTContext &ctx, const ClangImporterOptions &importerOpts,
                       std::string swiftPCHHash, DependencyTracker *tracker,
-                      DWARFImporterDelegate *dwarfImporterDelegate) {
+                      DWARFImporterDelegate *dwarfImporterDelegate,
+                      ArrayRef<StringRef> FrontendArgs) {
   std::unique_ptr<ClangImporter> importer{
       new ClangImporter(ctx, importerOpts, tracker, dwarfImporterDelegate)};
-  importer->Impl.ClangArgs = getClangArguments(ctx, importerOpts);
-  ArrayRef<std::string> invocationArgStrs = importer->Impl.ClangArgs;
+  importer->Impl.SwiftArgs.insert(importer->Impl.SwiftArgs.begin(),
+                                  FrontendArgs.begin(), FrontendArgs.end());
+  std::vector<std::string> invocationArgStrs = getClangArguments(ctx, importerOpts);
 
   if (importerOpts.DumpClangDiagnostics) {
     llvm::errs() << "'";

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -234,6 +234,11 @@ void ClangImporter::recordModuleDependencies(
     for(auto arg: clangModuleDep.NonPathCommandLine) {
       addClangArg(arg);
     }
+    // We shouldn't implicitly build Swift modules.
+    // We don't pass down "-disable-implicit-pcms" because a Clang flag
+    // "-fno-implicit-modules" is returned from the Clang dependencies scanner.
+    swiftArgs.push_back("-disable-implicit-swift-modules");
+
     // Swift frontend action: -emit-pcm
     swiftArgs.push_back("-emit-pcm");
     swiftArgs.push_back("-module-name");

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -188,20 +188,6 @@ static ClangModuleDependenciesCacheImpl *getOrCreateClangImpl(
   return clangImpl;
 }
 
-static std::string getModuleFilePath(StringRef moduleCacheDir,
-                                     StringRef moduleName,
-                                     StringRef contextHash) {
-  SmallString<128> outputPath(moduleCacheDir);
-  llvm::sys::path::append(outputPath, (llvm::Twine(moduleName)
-    + "-" + contextHash + ".pcm").str());
-  return outputPath.str().str();
-}
-
-static std::string getModuleFilePath(StringRef moduleCacheDir,
-                                     const ModuleDeps &dep) {
-  return getModuleFilePath(moduleCacheDir, dep.ModuleName, dep.ContextHash);
-}
-
 /// Record the module dependencies we found by scanning Clang modules into
 /// the module dependencies cache.
 void ClangImporter::recordModuleDependencies(
@@ -213,23 +199,7 @@ void ClangImporter::recordModuleDependencies(
   };
   auto ModuleCacheDir = swift::getModuleCachePathFromClang(getClangInstance());
 
-  // A map keyed by module name and context hash.
-  llvm::StringMap<llvm::StringMap<ModuleInfo>> moduleInfoMap;
-
-  // Traverse all Clang modules to populate moduleInfoMap for cross
-  // referencing later.
   for (const auto &clangModuleDep : clangDependencies.DiscoveredModules) {
-    moduleInfoMap[clangModuleDep.ModuleName][clangModuleDep.ContextHash] =
-      {
-        // Keep track of pcm path for output.
-        getModuleFilePath(ModuleCacheDir, clangModuleDep),
-        // Keep track of modulemap file for input.
-        clangModuleDep.ClangModuleMapFile
-      };
-  }
-  for (const auto &clangModuleDep : clangDependencies.DiscoveredModules) {
-    assert(moduleInfoMap[clangModuleDep.ModuleName]
-      .count(clangModuleDep.ContextHash));
     // If we've already cached this information, we're done.
     if (cache.hasDependencies(clangModuleDep.ModuleName,
                               ModuleDependenciesKind::Clang))
@@ -264,24 +234,10 @@ void ClangImporter::recordModuleDependencies(
     for(auto arg: clangModuleDep.NonPathCommandLine) {
       addClangArg(arg);
     }
-
-    // Add -fmodule-map-file and -fmodule-file for direct dependencies.
-    for (auto &dep: clangModuleDep.ClangModuleDeps) {
-      assert(moduleInfoMap[dep.ModuleName].count(dep.ContextHash));
-      addClangArg((llvm::Twine("-fmodule-map-file=")
-        + moduleInfoMap[dep.ModuleName][dep.ContextHash].ModuleMapPath).str());
-      addClangArg((llvm::Twine("-fmodule-file=")
-        + moduleInfoMap[dep.ModuleName][dep.ContextHash].PCMPath).str());
-    }
     // Swift frontend action: -emit-pcm
     swiftArgs.push_back("-emit-pcm");
     swiftArgs.push_back("-module-name");
     swiftArgs.push_back(clangModuleDep.ModuleName);
-
-    // Swift frontend option for output file path (Foo.pcm).
-    swiftArgs.push_back("-o");
-    swiftArgs.push_back(moduleInfoMap[clangModuleDep.ModuleName]
-      [clangModuleDep.ContextHash].PCMPath);
 
     // Swift frontend option for input file path (Foo.modulemap).
     swiftArgs.push_back(clangModuleDep.ClangModuleMapFile);

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -210,34 +210,19 @@ void ClangImporter::recordModuleDependencies(
     for (const auto &fileDep : clangModuleDep.FileDeps) {
       fileDeps.push_back(fileDep.getKey().str());
     }
-    // Inherit all Clang driver args when creating the clang importer.
-    std::vector<std::string> allArgs = Impl.ClangArgs;
-    ClangImporterOptions Opts;
-    std::vector<std::string> cc1Args;
-
-    // Calling this to convert driver args to CC1 args.
-    createClangInvocation(this, Opts, allArgs, &cc1Args);
-    std::vector<std::string> swiftArgs;
-    // We are using Swift frontend mode.
-    swiftArgs.push_back("-frontend");
+    // Inherit all Swift args when creating the clang importer.
+    std::vector<std::string> swiftArgs = Impl.SwiftArgs;
     auto addClangArg = [&](StringRef arg) {
       swiftArgs.push_back("-Xcc");
       swiftArgs.push_back("-Xclang");
       swiftArgs.push_back("-Xcc");
       swiftArgs.push_back(arg.str());
     };
-    // Add all args inheritted from creating the importer.
-    for (auto arg: cc1Args) {
-      addClangArg(arg);
-    }
+
     // Add all args reported from the Clang dependencies scanner.
     for(auto arg: clangModuleDep.NonPathCommandLine) {
       addClangArg(arg);
     }
-    // We shouldn't implicitly build Swift modules.
-    // We don't pass down "-disable-implicit-pcms" because a Clang flag
-    // "-fno-implicit-modules" is returned from the Clang dependencies scanner.
-    swiftArgs.push_back("-disable-implicit-swift-modules");
 
     // Swift frontend action: -emit-pcm
     swiftArgs.push_back("-emit-pcm");

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -390,8 +390,8 @@ private:
   /// Clang parser, which is used to load textual headers.
   std::unique_ptr<clang::MangleContext> Mangler;
 
-  /// Clang arguments used to create the Clang invocation.
-  std::vector<std::string> ClangArgs;
+  /// Swift arguments used to create the Clang invocation.
+  std::vector<std::string> SwiftArgs;
 public:
   /// Mapping of already-imported declarations.
   llvm::DenseMap<std::pair<const clang::Decl *, Version>, Decl *> ImportedDecls;

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -83,6 +83,8 @@ bool ArgsToFrontendOptionsConverter::convert(
 
   Opts.TrackSystemDeps |= Args.hasArg(OPT_track_system_dependencies);
 
+  Opts.DisableImplicitModules |= Args.hasArg(OPT_disable_implicit_swift_modules);
+
   // Always track system dependencies when scanning dependencies.
   if (const Arg *ModeArg = Args.getLastArg(OPT_modes_Group)) {
     if (ModeArg->getOption().matches(OPT_scan_dependencies))

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -85,6 +85,9 @@ bool ArgsToFrontendOptionsConverter::convert(
 
   Opts.DisableImplicitModules |= Args.hasArg(OPT_disable_implicit_swift_modules);
 
+  for (auto A: Args.getAllArgValues(OPT_swift_module_file_EQ)) {
+    Opts.ExplicitSwiftModules.push_back(A);
+  }
   // Always track system dependencies when scanning dependencies.
   if (const Arg *ModeArg = Args.getLastArg(OPT_modes_Group)) {
     if (ModeArg->getOption().matches(OPT_scan_dependencies))

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -817,6 +817,16 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
       Args.hasArg(OPT_disable_clangimporter_source_import);
 
   Opts.DisableImplicitPCMs |= Args.hasArg(OPT_disable_implicit_pcms);
+
+  // These flags are for explicitly built PCMs.
+  for (auto A: Args.getAllArgValues(OPT_clang_module_map_file_EQ)) {
+    Opts.ExtraArgs.push_back("-Xclang");
+    Opts.ExtraArgs.push_back((Twine("-fmodule-map-file=") + A).str());
+  }
+  for (auto A: Args.getAllArgValues(OPT_clang_module_file_EQ)) {
+    Opts.ExtraArgs.push_back("-Xclang");
+    Opts.ExtraArgs.push_back((Twine("-fmodule-file=") + A).str());
+  }
   return false;
 }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -816,6 +816,7 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
   Opts.DisableSourceImport |=
       Args.hasArg(OPT_disable_clangimporter_source_import);
 
+  Opts.DisableImplicitPCMs |= Args.hasArg(OPT_disable_implicit_pcms);
   return false;
 }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -457,11 +457,14 @@ bool CompilerInstance::setUpModuleLoaders() {
     StringRef PrebuiltModuleCachePath = FEOpts.PrebuiltModuleCachePath;
     auto PIML = ModuleInterfaceLoader::create(
         *Context, ModuleCachePath, PrebuiltModuleCachePath,
-        getDependencyTracker(), MLM, FEOpts.PreferInterfaceForModules,
+        getDependencyTracker(), MLM,
+        FEOpts.ExplicitSwiftModules,
+        FEOpts.PreferInterfaceForModules,
         FEOpts.RemarkOnRebuildFromModuleInterface,
         IgnoreSourceInfoFile,
         FEOpts.DisableInterfaceFileLock,
-        FEOpts.DisableImplicitModules);
+        FEOpts.DisableImplicitModules,
+        Invocation.getClangImporterOptions().DisableImplicitPCMs);
     Context->addModuleLoader(std::move(PIML));
   }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -460,7 +460,8 @@ bool CompilerInstance::setUpModuleLoaders() {
         getDependencyTracker(), MLM, FEOpts.PreferInterfaceForModules,
         FEOpts.RemarkOnRebuildFromModuleInterface,
         IgnoreSourceInfoFile,
-        FEOpts.DisableInterfaceFileLock);
+        FEOpts.DisableInterfaceFileLock,
+        FEOpts.DisableImplicitModules);
     Context->addModuleLoader(std::move(PIML));
   }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -446,8 +446,7 @@ bool CompilerInstance::setUpModuleLoaders() {
     ArgReconstructor(Invocation.getSearchPathOptions(),
                      Invocation.getLangOptions(),
                      Invocation.getFrontendOptions(),
-                     Invocation.getClangImporterOptions(),
-                     Invocation.getClangImporterOptions().ModuleCachePath);
+                     Invocation.getClangImporterOptions());
   std::unique_ptr<ClangImporter> clangImporter =
     ClangImporter::create(*Context, Invocation.getClangImporterOptions(),
                           Invocation.getPCHHash(),
@@ -470,8 +469,9 @@ bool CompilerInstance::setUpModuleLoaders() {
                                                         Invocation.getLangOptions(),
                                                         Invocation.getFrontendOptions(),
                                                         Invocation.getClangImporterOptions(),
-                                                        true,
-                                                        ModuleCachePath);
+                                                        /*buildModuleCacheDirIfAbsent*/true,
+                                                        ModuleCachePath,
+                                                        /*serializeDependencyHashes*/false);
     auto PIML = ModuleInterfaceLoader::create(
         *Context, ModuleCachePath, PrebuiltModuleCachePath,
         getDependencyTracker(), MLM, std::move(astDelegate),

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1344,10 +1344,6 @@ bool InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleN
   subInvocation.getFrontendOptions().InputsAndOutputs
     .setMainAndSupplementaryOutputs(outputFiles, ModuleOutputPaths);
 
-  // Add -o for building the module explicitly.
-  BuildArgs.push_back("-o");
-  BuildArgs.push_back(outputPath);
-
   SmallVector<const char *, 64> SubArgs;
   std::string CompilerVersion;
   // Extract compiler arguments from the interface file and use them to configure

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -785,7 +785,9 @@ static bool buildModuleFromInterface(CompilerInstance &Instance) {
                                               Invocation.getFrontendOptions(),
                                               Invocation.getClangImporterOptions(),
                                               /*CreateCacheDirIfAbsent*/true,
-                                              Invocation.getClangModuleCachePath());
+                                              Invocation.getClangModuleCachePath(),
+                                              Invocation.getFrontendOptions()
+                                                .SerializeModuleInterfaceDependencyHashes);
   return ModuleInterfaceLoader::buildSwiftModuleFromSwiftInterface(
       Instance.getSourceMgr(), Instance.getDiags(),
       Invocation.getSearchPathOptions(), Invocation.getLangOptions(),

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -778,6 +778,14 @@ static bool buildModuleFromInterface(CompilerInstance &Instance) {
   assert(FEOpts.InputsAndOutputs.hasSingleInput());
   StringRef InputPath = FEOpts.InputsAndOutputs.getFilenameOfFirstInput();
   StringRef PrebuiltCachePath = FEOpts.PrebuiltModuleCachePath;
+  InterfaceSubContextDelegateImpl astDelegate(Instance.getSourceMgr(),
+                                              Instance.getDiags(),
+                                              Invocation.getSearchPathOptions(),
+                                              Invocation.getLangOptions(),
+                                              Invocation.getFrontendOptions(),
+                                              Invocation.getClangImporterOptions(),
+                                              /*CreateCacheDirIfAbsent*/true,
+                                              Invocation.getClangModuleCachePath());
   return ModuleInterfaceLoader::buildSwiftModuleFromSwiftInterface(
       Instance.getSourceMgr(), Instance.getDiags(),
       Invocation.getSearchPathOptions(), Invocation.getLangOptions(),
@@ -786,8 +794,7 @@ static bool buildModuleFromInterface(CompilerInstance &Instance) {
       Invocation.getOutputFilename(),
       FEOpts.SerializeModuleInterfaceDependencyHashes,
       FEOpts.TrackSystemDeps, FEOpts.RemarkOnRebuildFromModuleInterface,
-      FEOpts.DisableInterfaceFileLock, FEOpts.DisableImplicitModules,
-      Invocation.getClangImporterOptions().DisableImplicitPCMs);
+      FEOpts.DisableInterfaceFileLock, astDelegate);
 }
 
 static bool compileLLVMIR(CompilerInstance &Instance) {

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -786,7 +786,8 @@ static bool buildModuleFromInterface(CompilerInstance &Instance) {
       Invocation.getOutputFilename(),
       FEOpts.SerializeModuleInterfaceDependencyHashes,
       FEOpts.TrackSystemDeps, FEOpts.RemarkOnRebuildFromModuleInterface,
-      FEOpts.DisableInterfaceFileLock);
+      FEOpts.DisableInterfaceFileLock, FEOpts.DisableImplicitModules,
+      Invocation.getClangImporterOptions().DisableImplicitPCMs);
 }
 
 static bool compileLLVMIR(CompilerInstance &Instance) {

--- a/lib/FrontendTool/ScanDependencies.cpp
+++ b/lib/FrontendTool/ScanDependencies.cpp
@@ -78,7 +78,10 @@ static std::vector<ModuleDependencyID> resolveDirectDependencies(
                                               FEOpts.SerializeModuleInterfaceDependencyHashes,
                                               FEOpts.TrackSystemDeps,
                                               FEOpts.RemarkOnRebuildFromModuleInterface,
-                                              FEOpts.DisableInterfaceFileLock);
+                                              FEOpts.DisableInterfaceFileLock,
+                                              FEOpts.DisableImplicitModules,
+                                              instance.getInvocation()
+                                                .getClangImporterOptions().DisableImplicitPCMs);
   // Find the dependencies of every module this module directly depends on.
   std::vector<ModuleDependencyID> result;
   for (auto dependsOn : knownDependencies.getModuleDependencies()) {

--- a/lib/FrontendTool/ScanDependencies.cpp
+++ b/lib/FrontendTool/ScanDependencies.cpp
@@ -74,7 +74,8 @@ static std::vector<ModuleDependencyID> resolveDirectDependencies(
                                               FEOpts,
                                               instance.getInvocation().getClangImporterOptions(),
                                               /*buildModuleCacheDirIfAbsent*/false,
-                                              ModuleCachePath);
+                                              ModuleCachePath,
+                                              FEOpts.SerializeModuleInterfaceDependencyHashes);
   // Find the dependencies of every module this module directly depends on.
   std::vector<ModuleDependencyID> result;
   for (auto dependsOn : knownDependencies.getModuleDependencies()) {

--- a/lib/FrontendTool/ScanDependencies.cpp
+++ b/lib/FrontendTool/ScanDependencies.cpp
@@ -71,17 +71,10 @@ static std::vector<ModuleDependencyID> resolveDirectDependencies(
   auto &FEOpts = instance.getInvocation().getFrontendOptions();
   InterfaceSubContextDelegateImpl ASTDelegate(ctx.SourceMgr, ctx.Diags,
                                               ctx.SearchPathOpts, ctx.LangOpts,
-                                              ctx.getClangModuleLoader(),
+                                              FEOpts,
+                                              instance.getInvocation().getClangImporterOptions(),
                                               /*buildModuleCacheDirIfAbsent*/false,
-                                              ModuleCachePath,
-                                              FEOpts.PrebuiltModuleCachePath,
-                                              FEOpts.SerializeModuleInterfaceDependencyHashes,
-                                              FEOpts.TrackSystemDeps,
-                                              FEOpts.RemarkOnRebuildFromModuleInterface,
-                                              FEOpts.DisableInterfaceFileLock,
-                                              FEOpts.DisableImplicitModules,
-                                              instance.getInvocation()
-                                                .getClangImporterOptions().DisableImplicitPCMs);
+                                              ModuleCachePath);
   // Find the dependencies of every module this module directly depends on.
   std::vector<ModuleDependencyID> result;
   for (auto dependsOn : knownDependencies.getModuleDependencies()) {

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -77,6 +77,8 @@ class ModuleFile
   /// The name of the module.
   StringRef Name;
   friend StringRef getNameOfModule(const ModuleFile *);
+  friend std::error_code getNameOfModule(ASTContext &Ctx, StringRef modulePath,
+                                         std::string &name);
 
   /// The target the module was built for.
   StringRef TargetTriple;

--- a/test/ScanDependencies/Inputs/BuildModulesFromGraph.swift
+++ b/test/ScanDependencies/Inputs/BuildModulesFromGraph.swift
@@ -39,6 +39,8 @@ func findModuleBuildingCommand(_ moduleName: String) -> [String]? {
 if let command = findModuleBuildingCommand(moduleName) {
   var result = swiftPath
   command.forEach { result += " \($0)"}
+  // Pass down additional args to the Swift invocation.
+  CommandLine.arguments.dropFirst(4).forEach { result += " \($0)"}
   print(result)
   exit(0)
 } else {

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -22,20 +22,20 @@
 // RUN: %target-build-swift %S/Inputs/ModuleDependencyGraph.swift %t/BuildModules/main.swift -o %t/ModuleBuilder
 // RUN: %target-codesign %t/ModuleBuilder
 
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path A.pcm | %S/Inputs/CommandRunner.py
-// RUN: ls %t/clang-module-cache/A-*.pcm
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path B.pcm | %S/Inputs/CommandRunner.py
-// RUN: ls %t/clang-module-cache/B-*.pcm
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path C.pcm | %S/Inputs/CommandRunner.py
-// RUN: ls %t/clang-module-cache/C-*.pcm
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path A.swiftmodule | %S/Inputs/CommandRunner.py
-// RUN: ls %t/clang-module-cache/A-*.swiftmodule
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path E.swiftmodule | %S/Inputs/CommandRunner.py
-// RUN: ls %t/clang-module-cache/E-*.swiftmodule
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path F.swiftmodule | %S/Inputs/CommandRunner.py
-// RUN: ls %t/clang-module-cache/F-*.swiftmodule
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path G.swiftmodule | %S/Inputs/CommandRunner.py
-// RUN: ls %t/clang-module-cache/G-*.swiftmodule
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path A.pcm -o %t/clang-module-cache/A.pcm | %S/Inputs/CommandRunner.py
+// RUN: ls %t/clang-module-cache/A.pcm
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path B.pcm -o %t/clang-module-cache/B.pcm -clang-module-map-file=%S/Inputs/CHeaders/module.modulemap -clang-module-file=%t/clang-module-cache/A.pcm | %S/Inputs/CommandRunner.py
+// RUN: ls %t/clang-module-cache/B.pcm
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path C.pcm -o %t/clang-module-cache/B.pcm -clang-module-map-file=%S/Inputs/CHeaders/module.modulemap -clang-module-file=%t/clang-module-cache/B.pcm | %S/Inputs/CommandRunner.py
+// RUN: ls %t/clang-module-cache/C.pcm
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path A.swiftmodule -o %t/clang-module-cache/A.swiftmodule | %S/Inputs/CommandRunner.py
+// RUN: ls %t/clang-module-cache/A.swiftmodule
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path E.swiftmodule -o %t/clang-module-cache/E.swiftmodule | %S/Inputs/CommandRunner.py
+// RUN: ls %t/clang-module-cache/E.swiftmodule
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path F.swiftmodule -o %t/clang-module-cache/F.swiftmodule | %S/Inputs/CommandRunner.py
+// RUN: ls %t/clang-module-cache/F.swiftmodule
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path G.swiftmodule -o %t/clang-module-cache/G.swiftmodule | %S/Inputs/CommandRunner.py
+// RUN: ls %t/clang-module-cache/G.swiftmodule
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
@@ -136,8 +136,6 @@ import G
 // CHECK: "-compile-module-from-interface"
 // CHECK: "-target"
 // CHECK: "-sdk"
-// CHECK: "-o"
-// CHECK: /clang-module-cache/G-{{.*}}.swiftmodule"
 // CHECK: "-module-name"
 // CHECK: "G"
 // CHECK: "-swift-version"

--- a/test/ScanDependencies/use_explicit_modules.swift
+++ b/test/ScanDependencies/use_explicit_modules.swift
@@ -1,0 +1,20 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+
+// RUN: not %target-swift-frontend -typecheck -emit-module-interface-path %t.swiftinterface %s -module-name AccessFilter -I %S/Inputs/CHeaders -I %S/Inputs/Swift -disable-implicit-swift-modules >%t/err.txt 2>&1
+
+// RUN: %FileCheck %s -check-prefix=CHECK-ERR-SWIFT <%t/err.txt
+
+// CHECK-ERR-SWIFT: {{error: no such module 'E'}}
+
+// RUN: not %target-swift-frontend -typecheck -emit-module-interface-path %t.swiftinterface %s -module-name AccessFilter -I %S/Inputs/CHeaders -I %S/Inputs/Swift -disable-implicit-pcms >%t/err.txt 2>&1
+
+// RUN: %FileCheck %s -check-prefix=CHECK-ERR-CLANG <%t/err.txt
+
+// CHECK-ERR-CLANG: {{module 'SwiftShims' is needed but has not been provided, and implicit use of module files is disabled}}
+
+import C
+import E
+import G


### PR DESCRIPTION
We need to introduce several front-end flags to support explicitly built modules for both Swift and Clang:

- For Clang modules, we need `-clang-module-map-file=` and `-clang-module-file=` and pass them down to the Clang invocation as `-fmodule-map-file=` and `-fmodule-file=`.

- For Swift modules, we need `-swift-module-file=` to specify the Swift module cache to use for each direct Swift module dependencies.

- New flags `-disable-implicit-swift-modules` and `-disable-implicit-pcms` to prevent and stop the compilers from building any modules implicitly and diagnose if they have to.

rdar://62613306