### PR TITLE
Type substitution: When substituting SILFunctionTypes we substitute u…

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3569,6 +3569,8 @@ public:
   /// initializer.
   bool hasDefaultInitializer() const;
 
+  bool isTypeErasedGenericClass() const;
+
   /// Retrieves the synthesized zero parameter default initializer for this
   /// declaration, or \c nullptr if it doesn't have one.
   ConstructorDecl *getDefaultInitializer() const;

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -386,6 +386,7 @@ class CanType : public Type {
   static bool isExistentialTypeImpl(CanType type);
   static bool isAnyExistentialTypeImpl(CanType type);
   static bool isObjCExistentialTypeImpl(CanType type);
+  static bool isTypeErasedGenericClassTypeImpl(CanType type);
   static CanType getOptionalObjectTypeImpl(CanType type);
   static CanType getReferenceStorageReferentImpl(CanType type);
   static CanType getWithoutSpecifierTypeImpl(CanType type);
@@ -470,6 +471,11 @@ public:
   /// Is this an ObjC-compatible existential type?
   bool isObjCExistentialType() const {
     return isObjCExistentialTypeImpl(*this);
+  }
+
+  // Is this an ObjC generic class.
+  bool isTypeErasedGenericClassType() const {
+    return isTypeErasedGenericClassTypeImpl(*this);
   }
 
   ClassDecl *getClassOrBoundGenericClass() const; // in Types.h

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4094,6 +4094,14 @@ bool NominalTypeDecl::hasDefaultInitializer() const {
                            false);
 }
 
+bool NominalTypeDecl::isTypeErasedGenericClass() const {
+  // ObjC classes are type erased.
+  // TODO: Unless they have magic methods...
+  if (auto clas = dyn_cast<ClassDecl>(this))
+    return clas->hasClangNode() && clas->isGenericContext();
+  return false;
+}
+
 ConstructorDecl *NominalTypeDecl::getDefaultInitializer() const {
   if (!hasDefaultInitializer())
     return nullptr;

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -441,26 +441,12 @@ static llvm::Value *emitObjCMetadataRef(IRGenFunction &IGF,
   return emitObjCMetadataRefForMetadata(IGF, classPtr);
 }
 
-static bool isTypeErasedGenericClass(NominalTypeDecl *ntd) {
-  // ObjC classes are type erased.
-  // TODO: Unless they have magic methods...
-  if (auto clas = dyn_cast<ClassDecl>(ntd))
-    return clas->hasClangNode() && clas->isGenericContext();
-  return false;
-}
-
-static bool isTypeErasedGenericClassType(CanType type) {
-  if (auto nom = type->getAnyNominal())
-    return isTypeErasedGenericClass(nom);
-  return false;
-}
-
 // Get the type that exists at runtime to represent a compile-time type.
 CanType IRGenModule::getRuntimeReifiedType(CanType type) {
   // Leave type-erased ObjC generics with their generic arguments unbound, since
   // the arguments do not exist at runtime.
   return CanType(type.transform([&](Type t) -> Type {
-    if (isTypeErasedGenericClassType(CanType(t))) {
+    if (CanType(t).isTypeErasedGenericClassType()) {
       return t->getAnyNominal()->getDeclaredType()->getCanonicalType();
     }
     return t;
@@ -2133,7 +2119,7 @@ static llvm::Function *getAccessFunctionPrototype(IRGenModule &IGM,
                                                ForDefinition_t forDefinition) {
   assert(!type->hasArchetype());
   // Type should be bound unless it's type erased.
-  assert(isTypeErasedGenericClassType(type)
+  assert(type.isTypeErasedGenericClassType()
            ? !isa<BoundGenericType>(type)
            : !isa<UnboundGenericType>(type));
 
@@ -2221,7 +2207,7 @@ irgen::getGenericTypeMetadataAccessFunction(IRGenModule &IGM,
                                             NominalTypeDecl *nominal,
                                             ForDefinition_t shouldDefine) {
   assert(nominal->isGenericContext());
-  assert(!isTypeErasedGenericClass(nominal));
+  assert(!nominal->isTypeErasedGenericClass());
 
   GenericArguments genericArgs;
   genericArgs.collectTypes(IGM, nominal);

--- a/test/IRGen/Inputs/usr/include/Gizmo.h
+++ b/test/IRGen/Inputs/usr/include/Gizmo.h
@@ -163,3 +163,6 @@ __attribute__((swift_name("OuterType.InnerType")))
 @protocol P
 - (oneway void)stuff;
 @end
+
+@interface ObjcGenericClass<__covariant SectionType>
+@end

--- a/test/IRGen/generic_classes_objc.sil
+++ b/test/IRGen/generic_classes_objc.sil
@@ -72,3 +72,15 @@ protocol P2 { }
 // CHECK-SAME: i16 3, i16 3, i16 5, i16 0
 class Generic3WithReqs<T: P1, U: P2, V: P2> { }
 sil_vtable Generic3WithReqs { }
+
+
+class SomeClass{}
+sil_vtable SomeClass {}
+
+// This used to assert.
+sil @repo : $@convention(thin) (@guaranteed Optional< @callee_guaranteed @substituted <τ_0_1> (@in_guaranteed Result<τ_0_1, Error>) -> () for <ObjcGenericClass<SomeClass>>>) -> () {
+bb0(%0 : $Optional< @callee_guaranteed @substituted <τ_0_1> (@in_guaranteed Result<τ_0_1, Error>) -> () for <ObjcGenericClass<SomeClass>> >):
+  debug_value %0 : $Optional<@callee_guaranteed @substituted <τ_0_1> (@in_guaranteed Result<τ_0_1, Error>) -> () for <ObjcGenericClass<SomeClass>>>, let, name "completion", argno 1
+  %2 = tuple ()
+  return %2 : $()
+}


### PR DESCRIPTION
…nbound Objective-C generic for bound ones

IRGen does so. So don't assert on this case.

rdar://63509292