### PR TITLE
[DerivedConformance] Fix a crasher where a decodable property has same type as context

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2513,6 +2513,21 @@ public:
   bool isCached() const { return true; }
 };
 
+class DeriveProtocolRequirementRequest
+    : public SimpleRequest<DeriveProtocolRequirementRequest,
+                           ValueDecl *(DeclContext *, NominalTypeDecl *,
+                                       ValueDecl *),
+                           RequestFlags::Uncached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  ValueDecl *evaluate(Evaluator &evaluator, DeclContext *DC,
+                      NominalTypeDecl *TypeDecl, ValueDecl *Requirement) const;
+};
+
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.
 template<>

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -268,3 +268,6 @@ SWIFT_REQUEST(TypeChecker, LookupAllConformancesInContextRequest,
               Uncached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SimpleDidSetRequest, 
               bool(AccessorDecl *), Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, DeriveProtocolRequirementRequest,
+              ValueDecl*(DeclContext *, NominalTypeDecl *, ValueDecl *),
+              Uncached, NoLocationInfo)

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -931,9 +931,9 @@ ProtocolConformanceRef checkConformanceToNSCopying(VarDecl *var);
 /// \returns nullptr if the derivation failed, or the derived declaration
 ///          if it succeeded. If successful, the derived declaration is added
 ///          to TypeDecl's body.
-ValueDecl *deriveProtocolRequirement(DeclContext *DC,
-                                     NominalTypeDecl *TypeDecl,
-                                     ValueDecl *Requirement);
+ValueDecl *deriveProtocolRequirement(DeclContext *DC, NominalTypeDecl *TypeDecl,
+                                     ValueDecl *Requirement,
+                                     NormalProtocolConformance *conformance);
 
 /// Derive an implicit type witness for the given associated type in
 /// the conformance of the given nominal type to some known

--- a/validation-test/compiler_crashers_2_fixed/sr12878.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr12878.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -typecheck %s -verify -verify-ignore-unknown
+
+class Foo: Codable { 
+    // expected-error@-1 2{{type 'Foo' does not conform to protocol 'Decodable'}}
+    let foo = Foo() 
+    // expected-error@-1 2{{circular reference}}
+    // expected-note@-2 4{{through reference here}}
+    // expected-note@-3 {{cannot automatically synthesize 'Decodable' because '<<error type>>' does not conform to 'Decodable'}}
+    // expected-note@-4 {{cannot automatically synthesize 'Decodable' because 'Foo' does not conform to 'Decodable'}}
+}


### PR DESCRIPTION
Basically, checking whether a type can conform to `Decodable` involves synthesising a `CodingKeys` enum, which involves checking whether each property conforms to `Decodable`, which involves the evaluation of the property's interface type, which involves deriving a witness for `init(from:)` and so on, which fails and we record that. After that, when we try to derive the witness (for the type) we crash in `setWitness` because we're trying to overwrite the existing (null) witness. This happens when the property has the same type as the context type, for example:

```swift
class Foo: Codable {
  let bar = Foo()
}
```

Previously (<= Swift 5.2), we would emit diagnostics so this is a regression.

Resolves SR-12878