### PR TITLE
Fixes deprecation in NWListener.swift

### DIFF
--- a/stdlib/public/Darwin/Network/NWListener.swift
+++ b/stdlib/public/Darwin/Network/NWListener.swift
@@ -78,8 +78,8 @@ public final class NWListener: CustomDebugStringConvertible {
 			get {
 				let descriptor = nw_advertise_descriptor_create_bonjour_service(name, type, domain)
 				if let txtRecord = txtRecord {
-					txtRecord.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) -> Void in
-                        nw_advertise_descriptor_set_txt_record(descriptor!, ptr.baseAddress!, txtRecord.count)
+					txtRecord.withUnsafeBytes { buffer in
+						nw_advertise_descriptor_set_txt_record(descriptor!, buffer.baseAddress!, buffer.count)
 					}
 				}
 				return descriptor!

--- a/stdlib/public/Darwin/Network/NWListener.swift
+++ b/stdlib/public/Darwin/Network/NWListener.swift
@@ -78,9 +78,9 @@ public final class NWListener: CustomDebugStringConvertible {
 			get {
 				let descriptor = nw_advertise_descriptor_create_bonjour_service(name, type, domain)
 				if let txtRecord = txtRecord {
-					txtRecord.withUnsafeBytes({ (ptr: UnsafePointer<UInt8>) -> Void in
-						nw_advertise_descriptor_set_txt_record(descriptor!, ptr, txtRecord.count)
-					})
+					txtRecord.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) -> Void in
+                        nw_advertise_descriptor_set_txt_record(descriptor!, ptr.baseAddress!, txtRecord.count)
+					}
 				}
 				return descriptor!
 			}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixes deprecation in NWListener.swift

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
