### PR TITLE
NFC: Rename performSILGeneration -> performASTLowering

### DIFF
--- a/include/swift/AST/SILGenRequests.h
+++ b/include/swift/AST/SILGenRequests.h
@@ -40,38 +40,39 @@ template<typename Request>
 void reportEvaluatedRequest(UnifiedStatsReporter &stats,
                             const Request &request);
 
-struct SILGenDescriptor {
+/// Describes a file or module to be lowered to SIL.
+struct ASTLoweringDescriptor {
   llvm::PointerUnion<FileUnit *, ModuleDecl *> context;
   Lowering::TypeConverter &conv;
   const SILOptions &opts;
 
-  friend llvm::hash_code hash_value(const SILGenDescriptor &owner) {
+  friend llvm::hash_code hash_value(const ASTLoweringDescriptor &owner) {
     return llvm::hash_combine(owner.context, (void *)&owner.conv,
                               (void *)&owner.opts);
   }
 
-  friend bool operator==(const SILGenDescriptor &lhs,
-                         const SILGenDescriptor &rhs) {
+  friend bool operator==(const ASTLoweringDescriptor &lhs,
+                         const ASTLoweringDescriptor &rhs) {
     return lhs.context == rhs.context &&
            &lhs.conv == &rhs.conv &&
            &lhs.opts == &rhs.opts;
   }
 
-  friend bool operator!=(const SILGenDescriptor &lhs,
-                         const SILGenDescriptor &rhs) {
+  friend bool operator!=(const ASTLoweringDescriptor &lhs,
+                         const ASTLoweringDescriptor &rhs) {
     return !(lhs == rhs);
   }
 
 public:
-  static SILGenDescriptor forFile(FileUnit &sf, Lowering::TypeConverter &conv,
-                                  const SILOptions &opts) {
-    return SILGenDescriptor{&sf, conv, opts};
+  static ASTLoweringDescriptor
+  forFile(FileUnit &sf, Lowering::TypeConverter &conv, const SILOptions &opts) {
+    return ASTLoweringDescriptor{&sf, conv, opts};
   }
 
-  static SILGenDescriptor forWholeModule(ModuleDecl *mod,
-                                         Lowering::TypeConverter &conv,
-                                         const SILOptions &opts) {
-    return SILGenDescriptor{mod, conv, opts};
+  static ASTLoweringDescriptor forWholeModule(ModuleDecl *mod,
+                                              Lowering::TypeConverter &conv,
+                                              const SILOptions &opts) {
+    return ASTLoweringDescriptor{mod, conv, opts};
   }
 
   /// For a single file input, returns a single element array containing that
@@ -83,13 +84,17 @@ public:
   SourceFile *getSourceFileToParse() const;
 };
 
-void simple_display(llvm::raw_ostream &out, const SILGenDescriptor &d);
+void simple_display(llvm::raw_ostream &out, const ASTLoweringDescriptor &d);
 
-SourceLoc extractNearestSourceLoc(const SILGenDescriptor &desc);
+SourceLoc extractNearestSourceLoc(const ASTLoweringDescriptor &desc);
 
-class SILGenerationRequest
+/// Lowers a file or module to SIL. In most cases this involves transforming
+/// a file's AST into SIL, through SILGen. However it can also handle files
+/// containing SIL in textual or binary form, which will be parsed or
+/// deserialized as needed.
+class ASTLoweringRequest
     : public SimpleRequest<
-          SILGenerationRequest, std::unique_ptr<SILModule>(SILGenDescriptor),
+          ASTLoweringRequest, std::unique_ptr<SILModule>(ASTLoweringDescriptor),
           RequestFlags::Uncached | RequestFlags::DependencySource> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -98,8 +103,8 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  std::unique_ptr<SILModule>
-  evaluate(Evaluator &evaluator, SILGenDescriptor desc) const;
+  std::unique_ptr<SILModule> evaluate(Evaluator &evaluator,
+                                      ASTLoweringDescriptor desc) const;
 
 public:
   // Incremental dependencies.
@@ -110,7 +115,7 @@ public:
 /// Parses a .sil file into a SILModule.
 class ParseSILModuleRequest
     : public SimpleRequest<ParseSILModuleRequest,
-                           std::unique_ptr<SILModule>(SILGenDescriptor),
+                           std::unique_ptr<SILModule>(ASTLoweringDescriptor),
                            RequestFlags::Uncached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -119,8 +124,8 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  std::unique_ptr<SILModule>
-  evaluate(Evaluator &evaluator, SILGenDescriptor desc) const;
+  std::unique_ptr<SILModule> evaluate(Evaluator &evaluator,
+                                      ASTLoweringDescriptor desc) const;
 };
 
 /// The zone number for SILGen.

--- a/include/swift/AST/SILGenTypeIDZone.def
+++ b/include/swift/AST/SILGenTypeIDZone.def
@@ -14,9 +14,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-SWIFT_REQUEST(SILGen, SILGenerationRequest,
-              std::unique_ptr<SILModule>(SILGenDescriptor),
+SWIFT_REQUEST(SILGen, ASTLoweringRequest,
+              std::unique_ptr<SILModule>(ASTLoweringDescriptor),
               Uncached, NoLocationInfo)
 SWIFT_REQUEST(SILGen, ParseSILModuleRequest,
-              std::unique_ptr<SILModule>(SILGenDescriptor),
+              std::unique_ptr<SILModule>(ASTLoweringDescriptor),
               Uncached, NoLocationInfo)

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -172,13 +172,13 @@ namespace swift {
   /// The module must contain source files. The optimizer will assume that the
   /// SIL of all files in the module is present in the SILModule.
   std::unique_ptr<SILModule>
-  performSILGeneration(ModuleDecl *M, Lowering::TypeConverter &TC,
-                       const SILOptions &options);
+  performASTLowering(ModuleDecl *M, Lowering::TypeConverter &TC,
+                     const SILOptions &options);
 
   /// Turn a source file into SIL IR.
   std::unique_ptr<SILModule>
-  performSILGeneration(FileUnit &SF, Lowering::TypeConverter &TC,
-                       const SILOptions &options);
+  performASTLowering(FileUnit &SF, Lowering::TypeConverter &TC,
+                     const SILOptions &options);
 
   using ModuleOrSourceFile = PointerUnion<ModuleDecl *, SourceFile *>;
 

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -209,7 +209,7 @@ bool ModuleInterfaceBuilder::buildSwiftModuleInternal(
     SILOptions &SILOpts = subInvocation.getSILOptions();
     auto Mod = SubInstance.getMainModule();
     auto &TC = SubInstance.getSILTypes();
-    auto SILMod = performSILGeneration(Mod, TC, SILOpts);
+    auto SILMod = performASTLowering(Mod, TC, SILOpts);
     if (!SILMod) {
       LLVM_DEBUG(llvm::dbgs() << "SILGen did not produce a module\n");
       return true;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1084,7 +1084,7 @@ static bool performCompileStepsPostSema(CompilerInstance &Instance,
   if (!opts.InputsAndOutputs.hasPrimaryInputs()) {
     // If there are no primary inputs the compiler is in WMO mode and builds one
     // SILModule for the entire module.
-    auto SM = performSILGeneration(mod, Instance.getSILTypes(), SILOpts);
+    auto SM = performASTLowering(mod, Instance.getSILTypes(), SILOpts);
     const PrimarySpecificPaths PSPs =
         Instance.getPrimarySpecificPathsForWholeModuleOptimizationMode();
     return performCompileStepsPostSILGen(Instance, std::move(SM), mod, PSPs,
@@ -1096,8 +1096,8 @@ static bool performCompileStepsPostSema(CompilerInstance &Instance,
   if (!Instance.getPrimarySourceFiles().empty()) {
     bool result = false;
     for (auto *PrimaryFile : Instance.getPrimarySourceFiles()) {
-      auto SM = performSILGeneration(*PrimaryFile, Instance.getSILTypes(),
-                                     SILOpts);
+      auto SM = performASTLowering(*PrimaryFile, Instance.getSILTypes(),
+                                   SILOpts);
       const PrimarySpecificPaths PSPs =
           Instance.getPrimarySpecificPathsForSourceFile(*PrimaryFile);
       result |= performCompileStepsPostSILGen(Instance, std::move(SM),
@@ -1114,7 +1114,7 @@ static bool performCompileStepsPostSema(CompilerInstance &Instance,
   for (FileUnit *fileUnit : mod->getFiles()) {
     if (auto SASTF = dyn_cast<SerializedASTFile>(fileUnit))
       if (opts.InputsAndOutputs.isInputPrimary(SASTF->getFilename())) {
-        auto SM = performSILGeneration(*SASTF, Instance.getSILTypes(), SILOpts);
+        auto SM = performASTLowering(*SASTF, Instance.getSILTypes(), SILOpts);
         const PrimarySpecificPaths &PSPs =
             Instance.getPrimarySpecificPathsForPrimary(SASTF->getFilename());
         result |= performCompileStepsPostSILGen(Instance, std::move(SM), mod,

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -101,7 +101,7 @@ SILParserState::~SILParserState() {
 
 std::unique_ptr<SILModule>
 ParseSILModuleRequest::evaluate(Evaluator &evaluator,
-                                SILGenDescriptor desc) const {
+                                ASTLoweringDescriptor desc) const {
   auto *SF = desc.getSourceFileToParse();
   assert(SF);
 

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1910,8 +1910,8 @@ public:
 } // end anonymous namespace
 
 std::unique_ptr<SILModule>
-SILGenerationRequest::evaluate(Evaluator &evaluator,
-                               SILGenDescriptor desc) const {
+ASTLoweringRequest::evaluate(Evaluator &evaluator,
+                             ASTLoweringDescriptor desc) const {
   // If we have a .sil file to parse, defer to the parsing request.
   if (desc.getSourceFileToParse()) {
     return llvm::cantFail(evaluator(ParseSILModuleRequest{desc}));
@@ -1942,17 +1942,16 @@ SILGenerationRequest::evaluate(Evaluator &evaluator,
 }
 
 std::unique_ptr<SILModule>
-swift::performSILGeneration(ModuleDecl *mod, Lowering::TypeConverter &tc,
-                            const SILOptions &options) {
-  auto desc = SILGenDescriptor::forWholeModule(mod, tc, options);
+swift::performASTLowering(ModuleDecl *mod, Lowering::TypeConverter &tc,
+                          const SILOptions &options) {
+  auto desc = ASTLoweringDescriptor::forWholeModule(mod, tc, options);
   return llvm::cantFail(
-      mod->getASTContext().evaluator(SILGenerationRequest{desc}));
+      mod->getASTContext().evaluator(ASTLoweringRequest{desc}));
 }
 
 std::unique_ptr<SILModule>
-swift::performSILGeneration(FileUnit &sf, Lowering::TypeConverter &tc,
-                            const SILOptions &options) {
-  auto desc = SILGenDescriptor::forFile(sf, tc, options);
-  return llvm::cantFail(
-      sf.getASTContext().evaluator(SILGenerationRequest{desc}));
+swift::performASTLowering(FileUnit &sf, Lowering::TypeConverter &tc,
+                          const SILOptions &options) {
+  auto desc = ASTLoweringDescriptor::forFile(sf, tc, options);
+  return llvm::cantFail(sf.getASTContext().evaluator(ASTLoweringRequest{desc}));
 }

--- a/lib/SILGen/SILGenRequests.cpp
+++ b/lib/SILGen/SILGenRequests.cpp
@@ -30,23 +30,23 @@ namespace swift {
 } // end namespace swift
 
 void swift::simple_display(llvm::raw_ostream &out,
-                           const SILGenDescriptor &desc) {
+                           const ASTLoweringDescriptor &desc) {
   auto *MD = desc.context.dyn_cast<ModuleDecl *>();
   auto *unit = desc.context.dyn_cast<FileUnit *>();
   if (MD) {
-    out << "SIL Generation for module " << MD->getName();
+    out << "Lowering AST to SIL for module " << MD->getName();
   } else {
     assert(unit);
-    out << "SIL Generation for file ";
+    out << "Lowering AST to SIL for file ";
     simple_display(out, unit);
   }
 }
 
-SourceLoc swift::extractNearestSourceLoc(const SILGenDescriptor &desc) {
+SourceLoc swift::extractNearestSourceLoc(const ASTLoweringDescriptor &desc) {
   return SourceLoc();
 }
 
-evaluator::DependencySource SILGenerationRequest::readDependencySource(
+evaluator::DependencySource ASTLoweringRequest::readDependencySource(
     const evaluator::DependencyRecorder &e) const {
   auto &desc = std::get<0>(getStorage());
 
@@ -60,7 +60,7 @@ evaluator::DependencySource SILGenerationRequest::readDependencySource(
   return {dyn_cast<SourceFile>(unit), evaluator::DependencyScope::Cascading};
 }
 
-ArrayRef<FileUnit *> SILGenDescriptor::getFiles() const {
+ArrayRef<FileUnit *> ASTLoweringDescriptor::getFiles() const {
   if (auto *mod = context.dyn_cast<ModuleDecl *>())
     return mod->getFiles();
 
@@ -69,7 +69,7 @@ ArrayRef<FileUnit *> SILGenDescriptor::getFiles() const {
   return llvm::makeArrayRef(*context.getAddrOfPtr1());
 }
 
-SourceFile *SILGenDescriptor::getSourceFileToParse() const {
+SourceFile *ASTLoweringDescriptor::getSourceFileToParse() const {
 #ifndef NDEBUG
   auto sfCount = llvm::count_if(getFiles(), [](FileUnit *file) {
     return isa<SourceFile>(file);

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -1051,7 +1051,7 @@ ASTUnitRef ASTProducer::createASTUnit(
     if (auto SF = CompIns.getPrimarySourceFile()) {
       SILOptions SILOpts = Invocation.getSILOptions();
       auto &TC = CompIns.getSILTypes();
-      std::unique_ptr<SILModule> SILMod = performSILGeneration(*SF, TC, SILOpts);
+      std::unique_ptr<SILModule> SILMod = performASTLowering(*SF, TC, SILOpts);
       runSILDiagnosticPasses(*SILMod);
     }
   }

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -272,8 +272,8 @@ int main(int argc, char **argv) {
   if (CI.getASTContext().hadError())
     return 1;
 
-  auto SILMod = performSILGeneration(CI.getMainModule(), CI.getSILTypes(),
-                                     CI.getSILOptions());
+  auto SILMod = performASTLowering(CI.getMainModule(), CI.getSILTypes(),
+                                   CI.getSILOptions());
 
   // Load the SIL if we have a non-SIB serialized module. SILGen handles SIB for
   // us.

--- a/tools/sil-llvm-gen/SILLLVMGen.cpp
+++ b/tools/sil-llvm-gen/SILLLVMGen.cpp
@@ -189,10 +189,10 @@ int main(int argc, char **argv) {
 
   std::unique_ptr<SILModule> SILMod;
   if (PerformWMO) {
-    SILMod = performSILGeneration(mod, CI.getSILTypes(), CI.getSILOptions());
+    SILMod = performASTLowering(mod, CI.getSILTypes(), CI.getSILOptions());
   } else {
-    SILMod = performSILGeneration(*mod->getFiles()[0], CI.getSILTypes(),
-                                  CI.getSILOptions());
+    SILMod = performASTLowering(*mod->getFiles()[0], CI.getSILTypes(),
+                                CI.getSILOptions());
   }
 
   // Load the SIL if we have a non-SIB serialized module. SILGen handles SIB for

--- a/tools/sil-nm/SILNM.cpp
+++ b/tools/sil-nm/SILNM.cpp
@@ -186,8 +186,8 @@ int main(int argc, char **argv) {
   if (CI.getASTContext().hadError())
     return 1;
 
-  auto SILMod = performSILGeneration(CI.getMainModule(), CI.getSILTypes(),
-                                     CI.getSILOptions());
+  auto SILMod = performASTLowering(CI.getMainModule(), CI.getSILTypes(),
+                                   CI.getSILOptions());
 
   // Load the SIL if we have a non-SIB serialized module. SILGen handles SIB for
   // us.

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -448,10 +448,10 @@ int main(int argc, char **argv) {
 
   std::unique_ptr<SILModule> SILMod;
   if (PerformWMO) {
-    SILMod = performSILGeneration(mod, CI.getSILTypes(), CI.getSILOptions());
+    SILMod = performASTLowering(mod, CI.getSILTypes(), CI.getSILOptions());
   } else {
-    SILMod = performSILGeneration(*mod->getFiles()[0], CI.getSILTypes(),
-                                  CI.getSILOptions());
+    SILMod = performASTLowering(*mod->getFiles()[0], CI.getSILTypes(),
+                                CI.getSILOptions());
   }
   SILMod->setSerializeSILAction([]{});
 


### PR DESCRIPTION
Belated follow-up to https://github.com/apple/swift/pull/31609. Rename `performSILGeneration` -> `performASTLowering` to try better reflect the fact that it may not perform SIL generation, it may parse or deserialize SIL instead.