### PR TITLE
[docs] Add 'gardening' to Lexicon.md

### DIFF
--- a/docs/Lexicon.md
+++ b/docs/Lexicon.md
@@ -167,6 +167,12 @@ and *zero* protocols; the latter is the `Any` type).
 Describes a type or function where making changes will break binary
 compatibility. See [LibraryEvolution.rst](LibraryEvolution.rst).
 
+## gardening
+
+Describes contributions which fix code that is not executed
+(such as in a manifesto or README) and written text
+(correcting typos and grammatical errors).
+
 ## generic environment
 
 Provides context for interpreting a type that may have generic parameters


### PR DESCRIPTION
I noticed this term was explicitly mentioned in Harlan and Robert's talk "Becoming An Effective Contributor to Swift" but this is not part of `Lexicon.md`.