### PR TITLE
[builtins] Fix a broken build by removing a ScalableVecArgument case.

### DIFF
--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1745,7 +1745,6 @@ Type IntrinsicTypeDecoder::decodeImmediate() {
   case IITDescriptor::ExtendArgument:
   case IITDescriptor::TruncArgument:
   case IITDescriptor::HalfVecArgument:
-  case IITDescriptor::ScalableVecArgument:
   case IITDescriptor::VarArg:
   case IITDescriptor::Token:
   case IITDescriptor::VecElementArgument:
@@ -1774,7 +1773,7 @@ Type IntrinsicTypeDecoder::decodeImmediate() {
   case IITDescriptor::Vector: {
     Type eltType = decodeImmediate();
     if (!eltType) return Type();
-    return makeVector(eltType, D.Vector_Width);
+    return makeVector(eltType, D.Vector_Width.Min);
   }
 
   // A pointer to an immediate type.


### PR DESCRIPTION
The following upstream commit removed the ScalableVecArgument:
https://reviews.llvm.org/D80107

I've remove that case from IntrinsicTypeDecoder::decodeImmediate()

The aforementioned patch also describes vector widths in terms of
ElementCounts, and not unsigned ints.  I've updated an access to the
vector width to make use of the ElementCount representation via access
of the Min member.

I've not been able to test this locally yet.