### PR TITLE
[builtins] Add the intrinsic BFloat to IntrinsicTypeDecoder::decodeImmediate

### DIFF
--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1740,6 +1740,7 @@ Type IntrinsicTypeDecoder::decodeImmediate() {
   IITDescriptor D = Table.front();
   Table = Table.slice(1);
   switch (D.Kind) {
+  case IITDescriptor::BFloat:
   case IITDescriptor::MMX:
   case IITDescriptor::Metadata:
   case IITDescriptor::ExtendArgument:


### PR DESCRIPTION
This type was introduced in https://reviews.llvm.org/D79707.
For now Swift does nothing in decodeImmediate() (e.g., return Type())
