### PR TITLE
[clangimporter] Fix a StringRef to std::string conversion.

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -254,7 +254,7 @@ void ClangImporter::recordModuleDependencies(
       swiftArgs.push_back("-Xcc");
       swiftArgs.push_back("-Xclang");
       swiftArgs.push_back("-Xcc");
-      swiftArgs.push_back(arg);
+      swiftArgs.push_back(arg.str());
     };
     // Add all args inheritted from creating the importer.
     for (auto arg: cc1Args) {


### PR DESCRIPTION
Explicitly call StringRef::str, the implicit conversion operator was
removed in an earlier commit:
(See https://github.com/llvm/llvm-project/commit/adcd02683856c)
