### PR TITLE
[DNM] Attempt to reproduce SR-12741 test failure.

### DIFF
--- a/test/AutoDiff/validation-test/control_flow.swift
+++ b/test/AutoDiff/validation-test/control_flow.swift
@@ -1,8 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// REQUIRES: SR12741
-
 import _Differentiation
 import StdlibUnittest
 


### PR DESCRIPTION
Attempt to reproduce SR-12741 test failure: specific to iphonesimulator-i386.