### PR TITLE
runtime: further isolate runtime from LLVMSupport

### DIFF
--- a/include/swift/Basic/LLVM.h
+++ b/include/swift/Basic/LLVM.h
@@ -36,8 +36,8 @@ namespace llvm {
   template <typename T, unsigned N> class SmallPtrSet;
 #if !defined(swiftCore_EXPORTS)
   template <typename T> class SmallVectorImpl;
-#endif
   template <typename T, unsigned N> class SmallVector;
+#endif
   template <unsigned N> class SmallString;
   template <typename T, unsigned N> class SmallSetVector;
 #if !defined(swiftCore_EXPORTS)
@@ -86,8 +86,8 @@ namespace swift {
   using llvm::SmallPtrSetImpl;
   using llvm::SmallSetVector;
   using llvm::SmallString;
-  using llvm::SmallVector;
 #if !defined(swiftCore_EXPORTS)
+  using llvm::SmallVector;
   using llvm::SmallVectorImpl;
 #endif
   using llvm::StringLiteral;

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -361,7 +361,7 @@ class TypeDecoder {
       if (Node->getNumChildren() < 2)
         return BuiltType();
 
-      SmallVector<BuiltType, 8> args;
+      llvm::SmallVector<BuiltType, 8> args;
 
       const auto &genericArgs = Node->getChild(1);
       if (genericArgs->getKind() != NodeKind::TypeList)
@@ -474,7 +474,7 @@ class TypeDecoder {
         return BuiltType();
 
       // Find the protocol list.
-      SmallVector<BuiltProtocolDecl, 8> Protocols;
+      llvm::SmallVector<BuiltProtocolDecl, 8> Protocols;
       auto TypeList = Node->getChild(0);
       if (TypeList->getKind() == NodeKind::ProtocolList &&
           TypeList->getNumChildren() >= 1) {
@@ -576,7 +576,7 @@ class TypeDecoder {
         return BuiltType();
 
       bool hasParamFlags = false;
-      SmallVector<FunctionParam<BuiltType>, 8> parameters;
+      llvm::SmallVector<FunctionParam<BuiltType>, 8> parameters;
       if (!decodeMangledFunctionInputType(Node->getChild(isThrow ? 1 : 0),
                                           parameters, hasParamFlags))
         return BuiltType();
@@ -598,9 +598,9 @@ class TypeDecoder {
     }
     case NodeKind::ImplFunctionType: {
       auto calleeConvention = ImplParameterConvention::Direct_Unowned;
-      SmallVector<ImplFunctionParam<BuiltType>, 8> parameters;
-      SmallVector<ImplFunctionResult<BuiltType>, 8> results;
-      SmallVector<ImplFunctionResult<BuiltType>, 8> errorResults;
+      llvm::SmallVector<ImplFunctionParam<BuiltType>, 8> parameters;
+      llvm::SmallVector<ImplFunctionResult<BuiltType>, 8> results;
+      llvm::SmallVector<ImplFunctionResult<BuiltType>, 8> errorResults;
       ImplFunctionTypeFlags flags;
 
       for (unsigned i = 0; i < Node->getNumChildren(); i++) {
@@ -684,7 +684,7 @@ class TypeDecoder {
       return decodeMangledType(Node->getChild(0));
 
     case NodeKind::Tuple: {
-      SmallVector<BuiltType, 8> elements;
+      llvm::SmallVector<BuiltType, 8> elements;
       std::string labels;
       bool variadic = false;
       for (auto &element : *Node) {

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -491,7 +491,7 @@ public:
       break;
     }
 
-    SmallVector<std::pair<NodePointer, bool>, 8> inputs;
+    llvm::SmallVector<std::pair<NodePointer, bool>, 8> inputs;
     for (const auto &param : F->getParameters()) {
       auto flags = param.getFlags();
       auto input = visit(param.getType());

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -34,7 +34,7 @@ swift::_buildDemanglingForContext(const ContextDescriptor *context,
   NodePointer node = nullptr;
 
   // Walk up the context tree.
-  SmallVector<const ContextDescriptor *, 8> descriptorPath;
+  llvm::SmallVector<const ContextDescriptor *, 8> descriptorPath;
   {
     const ContextDescriptor *parent = context;
     while (parent) {
@@ -285,11 +285,11 @@ _buildDemanglingForNominalType(const Metadata *type, Demangle::Demangler &Dem) {
 
   // Gather the complete set of generic arguments that must be written to
   // form this type.
-  SmallVector<const Metadata *, 8> allGenericArgs;
+  llvm::SmallVector<const Metadata *, 8> allGenericArgs;
   gatherWrittenGenericArgs(type, description, allGenericArgs, Dem);
 
   // Demangle the generic arguments.
-  SmallVector<NodePointer, 8> demangledGenerics;
+  llvm::SmallVector<NodePointer, 8> demangledGenerics;
   for (auto genericArg : allGenericArgs) {
     // When there is no generic argument, put in a placeholder.
     if (!genericArg) {
@@ -470,7 +470,7 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
       break;
     }
 
-    SmallVector<std::pair<NodePointer, bool>, 8> inputs;
+    llvm::SmallVector<std::pair<NodePointer, bool>, 8> inputs;
     for (unsigned i = 0, e = func->getNumParameters(); i < e; ++i) {
       auto param = func->getParameter(i);
       auto flags = func->getParameterFlags(i);

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -988,8 +988,8 @@ _gatherGenericParameters(const ContextDescriptor *context,
   // requirements and fill in the generic arguments vector.
   if (!genericParamCounts.empty()) {
     // Compute the set of generic arguments "as written".
-    SmallVector<const Metadata *, 8> allGenericArgs;
-    
+    llvm::SmallVector<const Metadata *, 8> allGenericArgs;
+
     // If we have a parent, gather it's generic arguments "as written".
     if (parent) {
       gatherWrittenGenericArgs(parent, parent->getTypeContextDescriptor(),
@@ -1183,16 +1183,16 @@ public:
     if (!descriptor)
       return BuiltType();
     auto outerContext = descriptor->Parent.get();
-    
-    SmallVector<BuiltType, 8> allGenericArgs;
+
+    llvm::SmallVector<BuiltType, 8> allGenericArgs;
     for (auto argSet : genericArgs) {
       allGenericArgs.append(argSet.begin(), argSet.end());
     }
     
     // Gather the generic parameters we need to parameterize the opaque decl.
-    SmallVector<unsigned, 8> genericParamCounts;
-    SmallVector<const void *, 8> allGenericArgsVec;
-    
+    llvm::SmallVector<unsigned, 8> genericParamCounts;
+    llvm::SmallVector<const void *, 8> allGenericArgsVec;
+
     if (!_gatherGenericParameters(outerContext,
                                   allGenericArgs,
                                   BuiltType(), /* no parent */
@@ -1291,8 +1291,8 @@ public:
 
     // Figure out the various levels of generic parameters we have in
     // this type.
-    SmallVector<unsigned, 8> genericParamCounts;
-    SmallVector<const void *, 8> allGenericArgsVec;
+    llvm::SmallVector<unsigned, 8> genericParamCounts;
+    llvm::SmallVector<const void *, 8> allGenericArgsVec;
 
     if (!_gatherGenericParameters(typeDecl,
                                   genericArgs,
@@ -1366,8 +1366,8 @@ public:
   BuiltType
   createFunctionType(llvm::ArrayRef<Demangle::FunctionParam<BuiltType>> params,
                      BuiltType result, FunctionTypeFlags flags) const {
-    SmallVector<BuiltType, 8> paramTypes;
-    SmallVector<uint32_t, 8> paramFlags;
+    llvm::SmallVector<BuiltType, 8> paramTypes;
+    llvm::SmallVector<uint32_t, 8> paramFlags;
 
     // Fill in the parameters.
     paramTypes.reserve(params.size());
@@ -2032,7 +2032,7 @@ void swift::gatherWrittenGenericArgs(
   // canonicalized away. Use same-type requirements to reconstitute them.
 
   // Retrieve the mapping information needed for depth/index -> flat index.
-  SmallVector<unsigned, 8> genericParamCounts;
+  llvm::SmallVector<unsigned, 8> genericParamCounts;
   (void)_gatherGenericParameterCounts(description, genericParamCounts,
                                       BorrowFrom);
 

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -162,7 +162,7 @@ template<>
 const WitnessTable *
 ProtocolConformanceDescriptor::getWitnessTable(const Metadata *type) const {
   // If needed, check the conditional requirements.
-  SmallVector<const void *, 8> conditionalArgs;
+  llvm::SmallVector<const void *, 8> conditionalArgs;
   if (hasConditionalRequirements()) {
     SubstGenericParametersFromMetadata substitutions(type);
     bool failed =


### PR DESCRIPTION
This cleans up some more `llvm::` leakage in the runtime when built into
a static library.  With this change we are down to 3 leaking symbols in
the static library related to a missed ADT (`StringSwitch`).

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
