### PR TITLE
[Builtins] Adjust for IITDescriptor::ScalableVecArgument removal

### DIFF
--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1745,7 +1745,6 @@ Type IntrinsicTypeDecoder::decodeImmediate() {
   case IITDescriptor::ExtendArgument:
   case IITDescriptor::TruncArgument:
   case IITDescriptor::HalfVecArgument:
-  case IITDescriptor::ScalableVecArgument:
   case IITDescriptor::VarArg:
   case IITDescriptor::Token:
   case IITDescriptor::VecElementArgument:
@@ -1774,7 +1773,7 @@ Type IntrinsicTypeDecoder::decodeImmediate() {
   case IITDescriptor::Vector: {
     Type eltType = decodeImmediate();
     if (!eltType) return Type();
-    return makeVector(eltType, D.Vector_Width);
+    return makeVector(eltType, D.Vector_Width.Min);
   }
 
   // A pointer to an immediate type.


### PR DESCRIPTION
Adjust for 1c3d9c2f3629c758db859b55e839dc97734fa171:

  [SVE] Remove IITDescriptor::ScalableVecArgument

  I have refactored the code so that we no longer need the
  ScalableVecArgument descriptor - the scalable property of vectors is
  now encoded using the ElementCount class in IITDescriptor. This means
  that when matching intrinsics we know precisely how to match the
  arguments and return values.

  Differential Revision: https://reviews.llvm.org/D80107