### PR TITLE
[Serialization] Skip SPI documentation in swiftdoc files

### DIFF
--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -344,6 +344,11 @@ static bool shouldIncludeDecl(Decl *D, bool ExcludeDoubleUnderscore) {
     if (VD->getEffectiveAccess() < swift::AccessLevel::Public)
       return false;
   }
+
+  // Skip SPI decls.
+  if (D->isSPI())
+    return false;
+
   if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
     return shouldIncludeDecl(ED->getExtendedNominal(), ExcludeDoubleUnderscore);
   }
@@ -745,7 +750,7 @@ Result.X.Column = Locs->X.Column;
     };
     // .swiftdoc doesn't include comments for double underscored symbols, but
     // for .swiftsourceinfo, having the source location for these symbols isn't
-    // a concern becuase these symbols are in .swiftinterface anyway.
+    // a concern because these symbols are in .swiftinterface anyway.
     if (!shouldIncludeDecl(D, /*ExcludeDoubleUnderscore*/false))
       return false;
     if (!shouldSerializeSourceLoc(D))

--- a/test/Serialization/comments-hidden.swift
+++ b/test/Serialization/comments-hidden.swift
@@ -43,6 +43,8 @@ public class PublicClass {
   public init(label __name: String) {}
   /// Public Filter Subscript Documentation NotForNormal NotForTesting
   public subscript(label __name: String) -> Int { return 0 }
+  /// SPI Function Documentation NotForNormal NotForTesting
+  @_spi(SPI) public func f_spi() { }
 }
 
 public extension PublicClass {
@@ -64,6 +66,16 @@ private class PrivateClass {
   private func f_private() { }
 }
 
+/// SPI Documentation NotForNormal NotForTesting
+@_spi(SPI) public class SPIClass {
+  /// SPI Function Documentation NotForNormal NotForTesting
+  public func f_spi() { }
+}
+
+/// SPI Extension Documentation NotForNormal NotForTesting
+@_spi(SPI) public extension PublicClass {
+}
+
 // NORMAL-NEGATIVE-NOT: NotForNormal
 // NORMAL-NEGATIVE-NOT: NotForTesting
 // NORMAL: PublicClass Documentation
@@ -74,7 +86,7 @@ private class PrivateClass {
 // TESTING-NEGATIVE-NOT: NotForTesting
 // TESTING: PublicClass Documentation
 // TESTING: Public Function Documentation
-// TESTINH: Public Init Documentation
+// TESTING: Public Init Documentation
 // TESTING: Public Subscript Documentation
 // TESTING: Internal Function Documentation
 // TESTING: InternalClass Documentation
@@ -85,4 +97,4 @@ private class PrivateClass {
 // SOURCE-LOC: comments-hidden.swift:41:10: Subscript/PublicClass.subscript RawComment=none BriefComment=none DocCommentAsXML=none
 // SOURCE-LOC: comments-hidden.swift:43:10: Constructor/PublicClass.init RawComment=none BriefComment=none DocCommentAsXML=none
 // SOURCE-LOC: comments-hidden.swift:45:10: Subscript/PublicClass.subscript RawComment=none BriefComment=none DocCommentAsXML=none
-// SOURCE-LOC: comments-hidden.swift:50:15: Func/-= RawComment=none BriefComment=none DocCommentAsXML=none
+// SOURCE-LOC: comments-hidden.swift:52:15: Func/-= RawComment=none BriefComment=none DocCommentAsXML=none


### PR DESCRIPTION
Hide comments from SPI decls in all swiftdoc files. This applies the same restrictions as private declarations. This is a temporary solution, a long term fix is to emit both a public and an internal swiftdoc file.

rdar://63729195