### PR TITLE
[Builtins] Adjust for IITDescriptor::BFloat addition

### DIFF
--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1762,6 +1762,7 @@ Type IntrinsicTypeDecoder::decodeImmediate() {
   case IITDescriptor::Half:
     return Context.TheIEEE16Type;
   case IITDescriptor::Float:
+  case IITDescriptor::BFloat:
     return Context.TheIEEE32Type;
   case IITDescriptor::Double:
     return Context.TheIEEE64Type;


### PR DESCRIPTION
Adjust for ad5d319ee85d31ee2b1ca5c29b3a10b340513fec:

  [IR][BFloat] add BFloat IR intrinsics support

  Summary:
  This patch is part of a series that adds support for the Bfloat16 extension of
  the Armv8.6-a architecture, as detailed here:

  https://community.arm.com/developer/ip-products/processors/b/processors-ip-blog/posts/arm-architecture-developments-armv8-6-a

  The bfloat type, and its properties are specified in the Arm Architecture
  Reference Manual:

  https://developer.arm.com/docs/ddi0487/latest/arm-architecture-reference-manual-armv8-for-armv8-a-architecture-profile

  Differential Revision: https://reviews.llvm.org/D79707