### PR TITLE
Revert "Disable objc_mangling.swift and SwiftObjectNSObject.swift tes…

### DIFF
--- a/test/Interpreter/SDK/objc_mangling.swift
+++ b/test/Interpreter/SDK/objc_mangling.swift
@@ -8,7 +8,6 @@
 
 // rdar://problem/56959761
 // UNSUPPORTED: OS=watchos
-// UNSUPPORTED: OS=tvos
 
 import Foundation
 

--- a/test/stdlib/SwiftObjectNSObject.swift
+++ b/test/stdlib/SwiftObjectNSObject.swift
@@ -23,7 +23,6 @@
 
 // rdar://problem/56959761
 // UNSUPPORTED: OS=watchos
-// UNSUPPORTED: OS=tvos
 
 import Foundation
 


### PR DESCRIPTION
…t on tvOS"

This reverts commit 7e2c2452ad218f0554c85eb8c93a5641c44ce1b9.