### PR TITLE
Adding `final` to public API is API-stable.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -126,7 +126,7 @@ DECL_ATTR(available, Available,
 CONTEXTUAL_SIMPLE_DECL_ATTR(final, Final,
   OnClass | OnFunc | OnAccessor | OnVar | OnSubscript |
   DeclModifier |
-  ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIStableToRemove,
+  ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
   2)
 DECL_ATTR(objc, ObjC,
   OnAbstractFunction | OnClass | OnProtocol | OnExtension | OnVar |

--- a/test/api-digester/Outputs/Cake.txt
+++ b/test/api-digester/Outputs/Cake.txt
@@ -40,7 +40,6 @@ cake: TypeAlias TChangesFromIntToString.T has underlying type change from Swift.
 /* Decl Attribute changes */
 cake: Enum IceKind is now without @frozen
 cake: Func C1.foo1() is now not static
-cake: Func FinalFuncContainer.NewFinalFunc() is now with final
 cake: Func HasMutatingMethodClone.foo() has self access kind changing from Mutating to NonMutating
 cake: Func S1.foo1() has self access kind changing from NonMutating to Mutating
 cake: Func S1.foo3() is now static


### PR DESCRIPTION
Client code can't override or subclass a `public` declaration already, so although the ABI differs, the API is the same whether something is `final` or not (unless the library makes additional, independently API-breaking changes, such as revoking `open`-ness or hiding public subclasses).