### PR TITLE
test: add a ODR violation check for the static standard library

### DIFF
--- a/test/stdlib/llvm-support-odr-violation-static.test-sh
+++ b/test/stdlib/llvm-support-odr-violation-static.test-sh
@@ -1,0 +1,5 @@
+// RUN: %llvm-nm --defined-only -C %target-static-stdlib-path/libswiftCore.a | %FileCheck --allow-empty %s
+// CHECK-NOT: [^:]llvm::
+
+// REQUIRES: OS=linux-gnu
+// REQUIRES: static_stdlib


### PR DESCRIPTION
The static version of the standard library was leaking symbols in the
`llvm::` namespace which would result in ODR violations were the
artifact linking against `LLVMSupport` (via another dependency).  In
particular, `llvm::SmallVector` and `llvm::StringSwitch` symbols were
being leaked.  This adds a test case specifically for the static variant
of the library.  The dynamic variant of the library is already tested in
a separate test.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
