### PR TITLE
Test C++ out-of-line operator functions

### DIFF
--- a/test/Interop/Cxx/operators/Inputs/module.modulemap
+++ b/test/Interop/Cxx/operators/Inputs/module.modulemap
@@ -1,3 +1,7 @@
 module NonMemberInline {
   header "non-member-inline.h"
 }
+
+module NonMemberOutOfLine {
+  header "non-member-out-of-line.h"
+}

--- a/test/Interop/Cxx/operators/Inputs/non-member-out-of-line.cpp
+++ b/test/Interop/Cxx/operators/Inputs/non-member-out-of-line.cpp
@@ -1,0 +1,17 @@
+#include "non-member-out-of-line.h"
+
+IntBox operator+(IntBox lhs, IntBox rhs) {
+  return IntBox{.value = lhs.value + rhs.value};
+}
+
+IntBox operator-(IntBox lhs, IntBox rhs) {
+  return IntBox{.value = lhs.value - rhs.value};
+}
+
+IntBox operator*(IntBox lhs, IntBox rhs) {
+  return IntBox{.value = lhs.value * rhs.value};
+}
+
+IntBox operator/(IntBox lhs, IntBox rhs) {
+  return IntBox{.value = lhs.value / rhs.value};
+}

--- a/test/Interop/Cxx/operators/Inputs/non-member-out-of-line.cpp
+++ b/test/Interop/Cxx/operators/Inputs/non-member-out-of-line.cpp
@@ -3,15 +3,3 @@
 IntBox operator+(IntBox lhs, IntBox rhs) {
   return IntBox{.value = lhs.value + rhs.value};
 }
-
-IntBox operator-(IntBox lhs, IntBox rhs) {
-  return IntBox{.value = lhs.value - rhs.value};
-}
-
-IntBox operator*(IntBox lhs, IntBox rhs) {
-  return IntBox{.value = lhs.value * rhs.value};
-}
-
-IntBox operator/(IntBox lhs, IntBox rhs) {
-  return IntBox{.value = lhs.value / rhs.value};
-}

--- a/test/Interop/Cxx/operators/Inputs/non-member-out-of-line.h
+++ b/test/Interop/Cxx/operators/Inputs/non-member-out-of-line.h
@@ -7,10 +7,4 @@ struct IntBox {
 
 IntBox operator+(IntBox lhs, IntBox rhs);
 
-IntBox operator-(IntBox lhs, IntBox rhs);
-
-IntBox operator*(IntBox lhs, IntBox rhs);
-
-IntBox operator/(IntBox lhs, IntBox rhs);
-
 #endif

--- a/test/Interop/Cxx/operators/Inputs/non-member-out-of-line.h
+++ b/test/Interop/Cxx/operators/Inputs/non-member-out-of-line.h
@@ -1,0 +1,16 @@
+#ifndef TEST_INTEROP_CXX_OPERATORS_INPUTS_NON_MEMBER_OUT_OF_LINE_H
+#define TEST_INTEROP_CXX_OPERATORS_INPUTS_NON_MEMBER_OUT_OF_LINE_H
+
+struct IntBox {
+  int value;
+};
+
+IntBox operator+(IntBox lhs, IntBox rhs);
+
+IntBox operator-(IntBox lhs, IntBox rhs);
+
+IntBox operator*(IntBox lhs, IntBox rhs);
+
+IntBox operator/(IntBox lhs, IntBox rhs);
+
+#endif

--- a/test/Interop/Cxx/operators/non-member-out-of-line-irgen.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line-irgen.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+
+import NonMemberOutOfLine
+
+public func add(_ lhs: IntBox, _ rhs: IntBox) -> IntBox { lhs + rhs }
+
+// CHECK: call i32 @_Zpl6IntBoxS_(i32 %{{[0-9]+}}, i32 %{{[0-9]+}})
+// CHECK: declare i32 @_Zpl6IntBoxS_(i32, i32)

--- a/test/Interop/Cxx/operators/non-member-out-of-line-irgen.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line-irgen.swift
@@ -4,5 +4,5 @@ import NonMemberOutOfLine
 
 public func add(_ lhs: IntBox, _ rhs: IntBox) -> IntBox { lhs + rhs }
 
-// CHECK: call i32 [[NAME:@.*]](i32 %{{[0-9]+}}, i32 %{{[0-9]+}})
-// CHECK: declare i32 [[NAME]](i32, i32)
+// CHECK: call i32 [[NAME:@(_Zpl6IntBoxS_|"\?\?H@YA\?AUIntBox@@U0@0@Z")]](i32 %{{[0-9]+}}, i32 %{{[0-9]+}})
+// CHECK: declare {{(dso_local )?}}i32 [[NAME]](i32, i32)

--- a/test/Interop/Cxx/operators/non-member-out-of-line-irgen.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line-irgen.swift
@@ -4,5 +4,5 @@ import NonMemberOutOfLine
 
 public func add(_ lhs: IntBox, _ rhs: IntBox) -> IntBox { lhs + rhs }
 
-// CHECK: call i32 @_Zpl6IntBoxS_(i32 %{{[0-9]+}}, i32 %{{[0-9]+}})
-// CHECK: declare i32 @_Zpl6IntBoxS_(i32, i32)
+// CHECK: call i32 [[NAME:@.*]](i32 %{{[0-9]+}}, i32 %{{[0-9]+}})
+// CHECK: declare i32 [[NAME]](i32, i32)

--- a/test/Interop/Cxx/operators/non-member-out-of-line-silgen.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line-silgen.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+
+import NonMemberOutOfLine
+
+public func add(_ lhs: IntBox, _ rhs: IntBox) -> IntBox { lhs + rhs }
+
+// CHECK: [[COUNTER:%.*]] = function_ref @_Zpl6IntBoxS_ : $@convention(c) (IntBox, IntBox) -> IntBox
+// CHECK: apply [[COUNTER]](%0, %1) : $@convention(c) (IntBox, IntBox) -> IntBox
+
+// CHECK: sil [serializable] [clang "+"] @_Zpl6IntBoxS_ : $@convention(c) (IntBox, IntBox) -> IntBox

--- a/test/Interop/Cxx/operators/non-member-out-of-line-silgen.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line-silgen.swift
@@ -4,7 +4,7 @@ import NonMemberOutOfLine
 
 public func add(_ lhs: IntBox, _ rhs: IntBox) -> IntBox { lhs + rhs }
 
-// CHECK: [[COUNTER:%.*]] = function_ref [[NAME:@.*]] : $@convention(c) (IntBox, IntBox) -> IntBox
+// CHECK: [[COUNTER:%.*]] = function_ref [[NAME:@(_Zpl6IntBoxS_|\?\?H@YA\?AUIntBox@@U0@0@Z)]] : $@convention(c) (IntBox, IntBox) -> IntBox
 // CHECK: apply [[COUNTER]](%0, %1) : $@convention(c) (IntBox, IntBox) -> IntBox
 
 // CHECK: sil [serializable] [clang "+"] [[NAME]] : $@convention(c) (IntBox, IntBox) -> IntBox

--- a/test/Interop/Cxx/operators/non-member-out-of-line-silgen.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line-silgen.swift
@@ -4,7 +4,7 @@ import NonMemberOutOfLine
 
 public func add(_ lhs: IntBox, _ rhs: IntBox) -> IntBox { lhs + rhs }
 
-// CHECK: [[COUNTER:%.*]] = function_ref @_Zpl6IntBoxS_ : $@convention(c) (IntBox, IntBox) -> IntBox
+// CHECK: [[COUNTER:%.*]] = function_ref [[NAME:@.*]] : $@convention(c) (IntBox, IntBox) -> IntBox
 // CHECK: apply [[COUNTER]](%0, %1) : $@convention(c) (IntBox, IntBox) -> IntBox
 
-// CHECK: sil [serializable] [clang "+"] @_Zpl6IntBoxS_ : $@convention(c) (IntBox, IntBox) -> IntBox
+// CHECK: sil [serializable] [clang "+"] [[NAME]] : $@convention(c) (IntBox, IntBox) -> IntBox

--- a/test/Interop/Cxx/operators/non-member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/non-member-out-of-line.cpp -I %S/Inputs -o %t/non-member-out-of-line.o
+// RUN: %target-clang -c %S/Inputs/non-member-out-of-line.cpp -I %S/Inputs -o %t/non-member-out-of-line.o -std=c++17
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/non-member-out-of-line %t/non-member-out-of-line.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/non-member-out-of-line
 // RUN: %target-run %t/non-member-out-of-line

--- a/test/Interop/Cxx/operators/non-member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line.swift
@@ -1,0 +1,50 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang -c %S/Inputs/non-member-out-of-line.cpp -I %S/Inputs -o %t/non-member-out-of-line.o
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/non-member-out-of-line %t/non-member-out-of-line.o -Xfrontend -enable-cxx-interop
+// RUN: %target-codesign %t/non-member-out-of-line
+// RUN: %target-run %t/non-member-out-of-line
+//
+// REQUIRES: executable_test
+
+import NonMemberOutOfLine
+import StdlibUnittest
+
+var OperatorsTestSuite = TestSuite("Operators")
+
+OperatorsTestSuite.test("plus") {
+  let lhs = IntBox(value: 42)
+  let rhs = IntBox(value: 23)
+
+  let result = lhs + rhs
+
+  expectEqual(65, result.value)
+}
+
+OperatorsTestSuite.test("minus") {
+  let lhs = IntBox(value: 42)
+  let rhs = IntBox(value: 23)
+
+  let result = lhs - rhs
+
+  expectEqual(19, result.value)
+}
+
+OperatorsTestSuite.test("star") {
+  let lhs = IntBox(value: 42)
+  let rhs = IntBox(value: 23)
+
+  let result = lhs * rhs
+
+  expectEqual(966, result.value)
+}
+
+OperatorsTestSuite.test("slash") {
+  let lhs = IntBox(value: 42)
+  let rhs = IntBox(value: 23)
+
+  let result = lhs / rhs
+
+  expectEqual(1, result.value)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/operators/non-member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line.swift
@@ -20,31 +20,4 @@ OperatorsTestSuite.test("plus") {
   expectEqual(65, result.value)
 }
 
-OperatorsTestSuite.test("minus") {
-  let lhs = IntBox(value: 42)
-  let rhs = IntBox(value: 23)
-
-  let result = lhs - rhs
-
-  expectEqual(19, result.value)
-}
-
-OperatorsTestSuite.test("star") {
-  let lhs = IntBox(value: 42)
-  let rhs = IntBox(value: 23)
-
-  let result = lhs * rhs
-
-  expectEqual(966, result.value)
-}
-
-OperatorsTestSuite.test("slash") {
-  let lhs = IntBox(value: 42)
-  let rhs = IntBox(value: 23)
-
-  let result = lhs / rhs
-
-  expectEqual(1, result.value)
-}
-
 runAllTests()


### PR DESCRIPTION
Add a test to verify that C++ out-of-line operator functions are imported correctly.

This is part of addressing SR-12748.