### PR TITLE
[ConstraintSystem] new argument matching algorithm

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5514,11 +5514,10 @@ Expr *ExprRewriter::coerceCallArguments(Expr *arg, AnyFunctionType *funcType,
 
   MatchCallArgumentListener listener;
   SmallVector<ParamBinding, 4> parameterBindings;
-  bool failed = constraints::matchCallArguments(args, params,
-                                                paramInfo,
-                       arg->getUnlabeledTrailingClosureIndexOfPackedArgument(),
-                                                /*allowFixes=*/false, listener,
-                                                parameterBindings);
+  bool failed = constraints::matchCallArguments(
+      args, params, paramInfo,
+      arg->getUnlabeledTrailingClosureIndexOfPackedArgument(), listener,
+      parameterBindings);
 
   assert((matchCanFail || !failed) && "Call arguments did not match up?");
   (void)failed;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4924,7 +4924,6 @@ public:
 /// \param paramInfo Declaration-level information about the parameters.
 /// \param unlabeledTrailingClosureIndex The index of an unlabeled trailing closure,
 ///   if any.
-/// \param allowFixes Whether to allow fixes when matching arguments.
 ///
 /// \param listener Listener that will be notified when certain problems occur,
 /// e.g., to produce a diagnostic.
@@ -4936,7 +4935,6 @@ bool matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
                         ArrayRef<AnyFunctionType::Param> params,
                         const ParameterListInfo &paramInfo,
                         Optional<unsigned> unlabeledTrailingClosureIndex,
-                        bool allowFixes,
                         MatchCallArgumentListener &listener,
                         SmallVectorImpl<ParamBinding> &parameterBindings);
 

--- a/test/Constraints/argument_matching.swift
+++ b/test/Constraints/argument_matching.swift
@@ -71,7 +71,9 @@ secondArgumentNotLabeled(10, 20)
 // expected-error@-1 {{missing argument label 'a:' in call}}
 
 func f_31849281(x: Int, y: Int, z: Int) {}
-f_31849281(42, y: 10, x: 20) // expected-error {{incorrect argument labels in call (have '_:y:x:', expected 'x:y:z:')}} {{12-12=x: }} {{23-24=z}}
+// expected-note@-1 {{'f_31849281(x:y:z:)' declared here}}
+f_31849281(42, y: 10, x: 20) // expected-error {{extra argument in call}}
+// expected-error@-1 {{missing argument for parameter 'z' in call}}
 
 // -------------------------------------------
 // Extraneous keywords
@@ -84,31 +86,40 @@ nokeywords1(x: 1, y: 1) // expected-error{{extraneous argument labels 'x:y:' in 
 // Some missing, some extraneous keywords
 // -------------------------------------------
 func somekeywords1(_ x: Int, y: Int, z: Int) { }
+// expected-note@-1 {{'somekeywords1(_:y:z:)' declared here}}
 
 somekeywords1(x: 1, y: 2, z: 3) // expected-error{{extraneous argument label 'x:' in call}}{{15-18=}}
 somekeywords1(1, 2, 3) // expected-error{{missing argument labels 'y:z:' in call}}{{18-18=y: }}{{21-21=z: }}
-somekeywords1(x: 1, 2, z: 3) // expected-error{{incorrect argument labels in call (have 'x:_:z:', expected '_:y:z:')}}{{15-18=}}{{21-21=y: }}
+somekeywords1(x: 1, 2, z: 3) // expected-error{{extra argument in call}}
+// expected-error@-1 {{missing argument for parameter #1 in call}}
 
 // SR-2242: poor diagnostic when argument label is omitted
 
 func r27212391(x: Int, _ y: Int) {
+  // expected-note@-1 2 {{'r27212391(x:_:)' declared here}}
   let _: Int = x + y
 }
 
 func r27212391(a: Int, x: Int, _ y: Int) {
+  // expected-note@-1 3 {{'r27212391(a:x:_:)' declared here}}
   let _: Int = a + x + y
 }
 
 r27212391(3, 5)             // expected-error {{missing argument label 'x:' in call}}
-r27212391(3, y: 5)          // expected-error {{incorrect argument labels in call (have '_:y:', expected 'x:_:')}}
-r27212391(3, x: 5)          // expected-error {{argument 'x' must precede unnamed argument #1}} {{11-11=x: 5, }} {{12-18=}}
-r27212391(y: 3, x: 5)       // expected-error {{incorrect argument labels in call (have 'y:x:', expected 'x:_:')}} {{11-12=x}} {{17-20=}}
+r27212391(3, y: 5)          // expected-error {{extra argument in call}}
+// expected-error@-1 {{missing argument for parameter #2 in call}}
+r27212391(3, x: 5)          // expected-error {{missing argument label 'a:' in call}} {{11-11=a: }}
+// expected-error@-1 {{missing argument for parameter #3 in call}}
+r27212391(y: 3, x: 5)       // expected-error {{extra argument 'y' in call}}
+// expected-error@-1 {{missing argument for parameter #2 in call}}
 r27212391(y: 3, 5)          // expected-error {{incorrect argument label in call (have 'y:_:', expected 'x:_:')}}
 r27212391(x: 3, x: 5)       // expected-error {{extraneous argument label 'x:' in call}}
-r27212391(a: 1, 3, y: 5)    // expected-error {{incorrect argument labels in call (have 'a:_:y:', expected 'a:x:_:')}}
-r27212391(1, x: 3, y: 5)    // expected-error {{incorrect argument labels in call (have '_:x:y:', expected 'a:x:_:')}}
-r27212391(a: 1, y: 3, x: 5) // expected-error {{incorrect argument labels in call (have 'a:y:x:', expected 'a:x:_:')}}
-r27212391(a: 1, 3, x: 5)    // expected-error {{argument 'x' must precede unnamed argument #2}} {{17-17=x: 5, }} {{18-24=}}
+r27212391(a: 1, 3, y: 5)    // expected-error {{extra argument 'y' in call}}
+r27212391(1, x: 3, y: 5)    // expected-error {{extra argument in call}}
+r27212391(a: 1, y: 3, x: 5) // expected-error {{extra argument 'y' in call}}
+// expected-error@-1 {{missing argument for parameter #3 in call}}
+r27212391(a: 1, 3, x: 5)    // expected-error {{extra argument in call}}
+// expected-error@-1 {{missing argument for parameter #3 in call}}
 
 // -------------------------------------------
 // Out-of-order keywords
@@ -200,6 +211,7 @@ func testLabelErrorDefault() {
 // Variadics
 // -------------------------------------------
 func variadics1(x: Int, y: Int, _ z: Int...) { }
+// expected-note@-1 {{'variadics1(x:y:_:)' declared here}}
 
 // Using variadics (in-order, complete)
 variadics1(x: 1, y: 2)
@@ -208,7 +220,7 @@ variadics1(x: 1, y: 2, 1, 2)
 variadics1(x: 1, y: 2, 1, 2, 3)
 
 // Using various (out-of-order)
-variadics1(1, 2, 3, 4, 5, x: 6, y: 7) // expected-error {{incorrect argument labels in call (have '_:_:_:_:_:x:y:', expected 'x:y:_:')}} {{12-12=x: }} {{15-15=y: }} {{27-30=}} {{33-36=}}
+variadics1(1, 2, 3, 4, 5, x: 6, y: 7) // expected-error {{extra arguments at positions #1, #2, #3, #4, #5 in call}}
 
 func variadics2(x: Int, y: Int = 2, z: Int...) { } // expected-note {{'variadics2(x:y:z:)' declared here}}
 
@@ -226,6 +238,7 @@ variadics2(z: 1, 2, 3, y: 2) // expected-error{{missing argument for parameter '
 variadics2(z: 1, 2, 3, x: 1) // expected-error{{argument 'x' must precede argument 'z'}} {{12-12=x: 1, }} {{22-28=}}
 
 func variadics3(_ x: Int..., y: Int = 2, z: Int = 3) { }
+// expected-note@-1 {{'variadics3(_:y:z:)' declared here}}
 
 // Using variadics (in-order, complete)
 variadics3(1, 2, 3, y: 0, z: 1)
@@ -246,8 +259,8 @@ variadics3(1)
 variadics3()
 
 // Using variadics (out-of-order)
-variadics3(y: 0, 1, 2, 3) // expected-error{{unnamed argument #2 must precede argument 'y'}} {{12-12=1, 2, 3, }} {{16-25=}}
-variadics3(z: 1, 1) // expected-error{{unnamed argument #2 must precede argument 'z'}} {{12-12=1, }} {{16-19=}}
+variadics3(y: 0, 1, 2, 3) // expected-error{{extra arguments at positions #3, #4 in call}}
+variadics3(z: 1, 1) // expected-error{{extra argument in call}}
 
 func variadics4(x: Int..., y: Int = 2, z: Int = 3) { }
 
@@ -274,6 +287,7 @@ variadics4(y: 0, x: 1, 2, 3) // expected-error{{argument 'x' must precede argume
 variadics4(z: 1, x: 1) // expected-error{{argument 'x' must precede argument 'z'}} {{12-12=x: 1, }} {{16-22=}}
 
 func variadics5(_ x: Int, y: Int, _ z: Int...) { } // expected-note {{declared here}}
+// expected-note@-1 {{'variadics5(_:y:_:)' declared here}}
 
 // Using variadics (in-order, complete)
 variadics5(1, y: 2)
@@ -282,7 +296,7 @@ variadics5(1, y: 2, 1, 2)
 variadics5(1, y: 2, 1, 2, 3)
 
 // Using various (out-of-order)
-variadics5(1, 2, 3, 4, 5, 6, y: 7) // expected-error{{argument 'y' must precede unnamed argument #2}} {{15-15=y: 7, }} {{28-34=}}
+variadics5(1, 2, 3, 4, 5, 6, y: 7) // expected-error{{extra arguments at positions #2, #3, #4, #5, #6 in call}}
 variadics5(y: 1, 2, 3, 4, 5, 6, 7) // expected-error{{missing argument for parameter #1 in call}}
 
 func variadics6(x: Int..., y: Int = 2, z: Int) { } // expected-note 4 {{'variadics6(x:y:z:)' declared here}}
@@ -306,12 +320,13 @@ variadics6(x: 1) // expected-error{{missing argument for parameter 'z' in call}}
 variadics6() // expected-error{{missing argument for parameter 'z' in call}}
 
 func outOfOrder(_ a : Int, b: Int) {
-  outOfOrder(b: 42, 52)  // expected-error {{unnamed argument #2 must precede argument 'b'}} {{14-14=52, }} {{19-23=}}
+  // expected-note@-1 {{'outOfOrder(_:b:)' declared here}}
+  outOfOrder(b: 42, 52)  // expected-error {{extra argument in call}}
+  // expected-error@-1 {{missing argument for parameter #1 in call}}
 }
 
 struct Variadics7 {
-  func f(alpha: Int..., bravo: Int) {} // expected-note {{'f(alpha:bravo:)' declared here}}
-  // expected-note@-1 {{'f(alpha:bravo:)' declared here}}
+  func f(alpha: Int..., bravo: Int) {}
 
   func test() {
     // no error
@@ -327,8 +342,8 @@ struct Variadics7 {
 
     // typo A
     f(alphax: 0, bravo: 3) // expected-error {{incorrect argument label in call (have 'alphax:bravo:', expected 'alpha:bravo:')}}
-    f(alphax: 0, 1, bravo: 3) // expected-error {{extra argument in call}}
-    f(alphax: 0, 1, 2, bravo: 3) // expected-error {{extra arguments at positions #2, #3 in call}}
+    f(alphax: 0, 1, bravo: 3) // expected-error {{incorrect argument label in call (have 'alphax:_:bravo:', expected 'alpha:_:bravo:')}}
+    f(alphax: 0, 1, 2, bravo: 3) // expected-error {{incorrect argument label in call (have 'alphax:_:_:bravo:', expected 'alpha:_:_:bravo:')}}
 
     // typo B
     f(bravox: 0) // expected-error {{incorrect argument label in call (have 'bravox:', expected 'bravo:')}}
@@ -338,13 +353,13 @@ struct Variadics7 {
 
     // OoO + typo A B
     f(bravox: 0, alphax: 1) // expected-error {{incorrect argument labels in call (have 'bravox:alphax:', expected 'alpha:bravo:')}}
-    f(bravox: 0, alphax: 1, 2) // expected-error {{extra argument in call}}
-    f(bravox: 0, alphax: 1, 2, 3) // expected-error {{extra arguments at positions #3, #4 in call}}
+    f(bravox: 0, alphax: 1, 2) // expected-error {{incorrect argument labels in call (have 'bravox:alphax:_:', expected 'alpha:bravo:')}}
+    f(bravox: 0, alphax: 1, 2, 3) // expected-error {{incorrect argument labels in call (have 'bravox:alphax:_:_:', expected 'alpha:bravo:')}}
   }
 }
 
 struct Variadics8 {
-  func f(alpha: Int..., bravo: Int, charlie: Int) {} // expected-note {{'f(alpha:bravo:charlie:)' declared here}}
+  func f(alpha: Int..., bravo: Int, charlie: Int) {}
 
   func test() {
     // no error
@@ -369,8 +384,8 @@ struct Variadics8 {
 
     // typo A
     f(alphax: 0, bravo: 3, charlie: 4) // expected-error {{incorrect argument label in call (have 'alphax:bravo:charlie:', expected 'alpha:bravo:charlie:')}}
-    f(alphax: 0, 1, bravo: 3, charlie: 4) // expected-error {{extra argument in call}}
-    f(alphax: 0, 1, 2, bravo: 3, charlie: 4) // expected-error {{extra arguments at positions #2, #3 in call}}
+    f(alphax: 0, 1, bravo: 3, charlie: 4) // expected-error {{incorrect argument label in call (have 'alphax:_:bravo:charlie:', expected 'alpha:_:bravo:charlie:')}}
+    f(alphax: 0, 1, 2, bravo: 3, charlie: 4) // expected-error {{incorrect argument label in call (have 'alphax:_:_:bravo:charlie:', expected 'alpha:_:_:bravo:charlie:')}}
     // typo B
     f(bravox: 3, charlie: 4) // expected-error {{incorrect argument label in call (have 'bravox:charlie:', expected 'bravo:charlie:')}}
     f(alpha: 0, bravox: 3, charlie: 4) // expected-error {{incorrect argument label in call (have 'alpha:bravox:charlie:', expected 'alpha:bravo:charlie:')}}
@@ -404,7 +419,9 @@ struct Variadics8 {
 }
 
 func var_31849281(_ a: Int, _ b: Int..., c: Int) {}
-var_31849281(1, c: 10, 3, 4, 5, 6, 7, 8, 9) // expected-error {{unnamed argument #3 must precede argument 'c'}} {{17-17=3, 4, 5, 6, 7, 8, 9, }} {{22-43=}}
+// expected-note@-1 {{'var_31849281(_:_:c:)' declared here}}
+
+var_31849281(1, c: 10, 3, 4, 5, 6, 7, 8, 9) // expected-error {{extra arguments at positions #3, #4, #5, #6, #7, #8, #9 in call}}
 
 func testLabelErrorVariadic() {
   func f(aa: Int, bb: Int, cc: Int...) {}
@@ -427,34 +444,36 @@ struct PositionsAroundDefaultsAndVariadics {
   func test_f1() {
     f1(true, 2, c: "3", [4])
 
-    f1(true, c: "3", 2, [4]) // expected-error {{unnamed argument #4 must precede argument 'c'}}
+    f1(true, c: "3", 2, [4]) // expected-error {{extra argument in call}}
+    // expected-error@-1 {{cannot convert value of type 'Int' to expected argument type '[Int]'}}
 
-    f1(true, c: "3", [4], 2) // expected-error {{unnamed argument #4 must precede argument 'c'}}
+    f1(true, c: "3", [4], 2) // expected-error {{extra argument in call}}
 
     f1(true, c: "3", 2) // expected-error {{cannot convert value of type 'Int' to expected argument type '[Int]'}}
 
     f1(true, c: "3", [4])
 
-    f1(c: "3", 2, [4]) // expected-error {{unnamed argument #3 must precede argument 'c'}}
+    f1(c: "3", 2, [4]) // expected-error {{extra argument in call}}
+    // expected-error@-1 {{cannot convert value of type 'Int' to expected argument type '[Int]'}}
 
-    f1(c: "3", [4], 2) // expected-error {{unnamed argument #3 must precede argument 'c'}}
+    f1(c: "3", [4], 2) // expected-error {{extra argument in call}}
     
     f1(c: "3", 2) // expected-error {{cannot convert value of type 'Int' to expected argument type '[Int]'}}
 
     f1(c: "3", [4])
 
-    f1(b: "2", [3]) // expected-error {{incorrect argument labels in call (have 'b:_:', expected '_:_:c:_:')}}
-    // expected-error@-1 {{cannot convert value of type '[Int]' to expected argument type 'Bool'}}
+    f1(b: "2", [3])
+    // expected-error@-1 {{incorrect argument label in call (have 'b:_:', expected 'c:_:')}}
     
-    f1(b: "2", 1) // expected-error {{incorrect argument labels in call (have 'b:_:', expected '_:_:c:_:')}}
-    // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+    f1(b: "2", 1) // expected-error {{cannot convert value of type 'Int' to expected argument type '[Int]'}}
+    // expected-error@-1 {{incorrect argument label in call (have 'b:_:', expected 'c:_:')}}
 
-    f1(b: "2", [3], 1) // expected-error {{incorrect argument labels in call (have 'b:_:_:', expected '_:_:c:_:')}}
-    // expected-error@-1 {{cannot convert value of type '[Int]' to expected argument type 'Bool'}}
+    f1(b: "2", [3], 1)
+    // expected-error@-1 {{extra argument in call}}
 
-    f1(b: "2", 1, [3]) // expected-error {{incorrect argument labels in call (have 'b:_:_:', expected '_:_:c:_:')}}
-    // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
-    // expected-error@-2 {{cannot convert value of type '[Int]' to expected argument type 'Int'}}
+    f1(b: "2", 1, [3])
+    // expected-error@-1 {{cannot convert value of type 'Int' to expected argument type '[Int]'}}
+    // expected-error@-2 {{extra argument in call}}
   }
 
   // unlabeled variadics before labeled parameter
@@ -475,11 +494,10 @@ struct PositionsAroundDefaultsAndVariadics {
 
     f2(true, c: "3", 21) // expected-error {{cannot convert value of type 'Int' to expected argument type '[Int]'}}
 
-    f2(true, c: "3", 21, [4]) // expected-error {{unnamed argument #4 must precede argument 'c'}}
-    // expected-error@-1 {{cannot pass array of type '[Int]' as variadic arguments of type 'Int'}}
-    // expected-note@-2 {{remove brackets to pass array elements directly}}
+    f2(true, c: "3", 21, [4]) // expected-error {{cannot convert value of type 'Int' to expected argument type '[Int]'}}
+    // expected-error@-1 {{extra argument in call}}
 
-    f2(true, c: "3", [4], 21) // expected-error {{unnamed argument #4 must precede argument 'c'}}
+    f2(true, c: "3", [4], 21) // expected-error {{extra argument in call}}
 
     f2(true, [4]) // expected-error {{cannot pass array of type '[Int]' as variadic arguments of type 'Int'}}
     // expected-note@-1 {{remove brackets to pass array elements directly}}
@@ -502,12 +520,12 @@ struct PositionsAroundDefaultsAndVariadics {
 
     f2(c: "3", 21) // expected-error {{cannot convert value of type 'Int' to expected argument type '[Int]'}}
     
-    f2(c: "3", 21, [4]) // expected-error {{incorrect argument labels in call (have 'c:_:_:', expected '_:_:c:_:')}}
+    f2(c: "3", 21, [4])
     // expected-error@-1 {{cannot convert value of type 'Int' to expected argument type '[Int]'}}
-    // expected-error@-2 {{cannot convert value of type '[Int]' to expected argument type 'Bool'}}
+    // expected-error@-2 {{extra argument in call}}
 
-    f2(c: "3", [4], 21) // expected-error {{incorrect argument labels in call (have 'c:_:_:', expected '_:_:c:_:')}}
-    // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+    f2(c: "3", [4], 21)
+    // expected-error@-1 {{extra argument in call}}
 
     f2([4]) // expected-error {{cannot convert value of type '[Int]' to expected argument type 'Bool'}}
 
@@ -581,9 +599,9 @@ struct PositionsAroundDefaultsAndVariadics {
     f4(true, b: "2", 31, d: [4])
     f4(true, b: "2", d: [4])
 
-    f4(true, 31, b: "2", d: [4]) // expected-error {{argument 'b' must precede unnamed argument #2}}
+    f4(true, 31, b: "2", d: [4]) // expected-error {{extra argument in call}}
 
-    f4(true, b: "2", d: [4], 31) // expected-error {{unnamed argument #4 must precede argument 'd'}}
+    f4(true, b: "2", d: [4], 31) // expected-error {{extra argument in call}}
 
     f4(true, b: "2", 31)
     f4(true, b: "2")
@@ -608,7 +626,7 @@ struct PositionsAroundDefaultsAndVariadics {
 
     f4(31, b: "2", d: [4]) // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
 
-    f4(b: "2", d: [4], 31) // expected-error {{unnamed argument #3 must precede argument 'b'}}
+    f4(b: "2", d: [4], 31) // expected-error {{extra argument in call}}
 
     f4(b: "2", 31)
     f4(b: "2", 31, 32)
@@ -643,7 +661,7 @@ struct PositionsAroundDefaultsAndVariadics {
 
     f5(true, c: 31, b: "2", d: [4]) // expected-error {{argument 'b' must precede argument 'c'}}
 
-    f5(true, b: "2", d: [4], 31) // expected-error {{incorrect argument labels in call (have '_:b:d:_:', expected '_:b:c:d:')}}
+    f5(true, b: "2", d: [4], 31) // expected-error {{extra argument in call}}
 
     f5(true, b: "2", c: 31)
     f5(true, b: "2")
@@ -709,8 +727,7 @@ func testUnlabeledParameterBindingPosition() {
     // expected-error@-2:14 {{extra argument 'xx' in call}}
 
     f(xx: 0, 1)
-    // expected-error@-1:7 {{missing argument for parameter 'aa' in call}}
-    // expected-error@-2:14 {{extra argument in call}}
+    // expected-error@-1:6 {{incorrect argument label in call (have 'xx:_:', expected 'aa:_:')}}
 
     f(0, 1, 9)
     // expected-error@-1:13 {{extra argument in call}}
@@ -719,15 +736,16 @@ func testUnlabeledParameterBindingPosition() {
     // expected-error@-1:17 {{extra argument 'xx' in call}}
 
     f(xx: 91, 1, 92)
-    // expected-error@-1 {{extra arguments at positions #2, #3 in call}}
-    // expected-error@-2 {{missing argument for parameter 'aa' in call}}
+    // expected-error@-1:11 {{extra argument 'xx' in call}}
   }
 
   do {
     func f(_ aa: Int, bb: Int, _ cc: Int) { }
+    // expected-note@-1 {{'f(_:bb:_:)' declared here}}
 
     f(bb: 1, 0, 2)
-    // expected-error@-1 {{unnamed argument #3 must precede argument 'bb'}}
+    // expected-error@-1 {{extra argument in call}}
+    // expected-error@-2 {{missing argument for parameter #1 in call}}
   }
 
   do {
@@ -771,7 +789,7 @@ func testUnlabeledParameterBindingPosition() {
     func f(aa: Int, bb: Int, _ cc: Int) {}
 
     f(0, 2)
-    // expected-error@-1:6 {{missing argument labels 'aa:bb:' in call}}
+    // expected-error@-1:6 {{missing argument label 'aa:' in call}}
     // expected-error@-2:8 {{missing argument for parameter 'bb' in call}}
 
     f(0, bb: 1, 2)
@@ -815,11 +833,11 @@ extraargs1(x: 1, 2, 3) // expected-error{{extra arguments at positions #2, #3 in
 // Argument name mismatch
 // -------------------------------------------
 
-func mismatch1(thisFoo: Int = 0, bar: Int = 0, wibble: Int = 0) { } // expected-note {{'mismatch1(thisFoo:bar:wibble:)' declared here}}
+func mismatch1(thisFoo: Int = 0, bar: Int = 0, wibble: Int = 0) { }
 
-mismatch1(foo: 5) // expected-error {{extra argument 'foo' in call}}
+mismatch1(foo: 5) // expected-error {{incorrect argument label in call (have 'foo:', expected 'thisFoo:')}}
 mismatch1(baz: 1, wobble: 2) // expected-error{{incorrect argument labels in call (have 'baz:wobble:', expected 'bar:wibble:')}} {{11-14=bar}} {{19-25=wibble}}
-mismatch1(food: 1, zap: 2) // expected-error{{extra arguments at positions #1, #2 in call}}
+mismatch1(food: 1, zap: 2) // expected-error{{incorrect argument labels in call (have 'food:zap:', expected 'thisFoo:bar:')}}
 
 // <rdar://problem/27891805> QoI: FailureDiagnosis doesn't look through 'try'
 struct rdar27891805 {
@@ -1159,7 +1177,7 @@ _ = CurriedClass.method3(1, 2)           // expected-error {{instance member 'me
 // expected-error@-1 {{missing argument label 'b:' in call}}
 CurriedClass.method3(c)(1.0, b: 1)       // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 CurriedClass.method3(c)(1)               // expected-error {{missing argument for parameter 'b' in call}}
-CurriedClass.method3(c)(c: 1.0)          // expected-error {{incorrect argument labels in call (have 'c:', expected '_:b:')}}
+CurriedClass.method3(c)(c: 1.0)          // expected-error {{incorrect argument label in call (have 'c:', expected 'b:')}}
 // expected-error@-1 {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 // expected-error@-2 {{missing argument for parameter #1 in call}}
 

--- a/test/Constraints/argument_matching.swift
+++ b/test/Constraints/argument_matching.swift
@@ -708,8 +708,121 @@ func testUnlabeledParameterBindingPosition() {
   do {
     func f(_ aa: Int) {}
 
+    f(1) // ok
+
+    f(xx: 1)
+    // expected-error@-1 {{extraneous argument label 'xx:' in call}}
+
     f(0, 1)
     // expected-error@-1:10 {{extra argument in call}}
+
+    f(xx: 1, 2)
+    // expected-error@-1:11 {{extra argument 'xx' in call}}
+
+    f(1, xx: 2)
+    // expected-error@-1:14 {{extra argument 'xx' in call}}
+
+    f(xx: 1, yy: 2)
+    // expected-error@-1:18 {{extra argument 'yy' in call}}
+  }
+
+  do {
+    func f(aa: Int) { }
+
+    f(1)
+    // expected-error@-1:7 {{missing argument label 'aa:' in call}}
+
+    f(aa: 1) // ok
+
+    f(xx: 1)
+    // expected-error@-1 {{incorrect argument label in call (have 'xx:', expected 'aa:')}}
+  }
+
+  do {
+    func f(_ aa: Int, _ bb: Int) { }
+    // expected-note@-1 3 {{'f' declared here}}
+
+    f(1)
+    // expected-error@-1:8 {{missing argument for parameter #2 in call}}
+
+    f(xx: 1)
+    // expected-error@-1 {{extraneous argument label 'xx:' in call}}
+    // expected-error@-2:12 {{missing argument for parameter #2 in call}}
+
+    f(1, 2) // ok
+
+    f(1, xx: 2)
+    // expected-error@-1 {{extraneous argument label 'xx:' in call}}
+
+    f(xx: 1, 2)
+    // expected-error@-1 {{extraneous argument label 'xx:' in call}}
+
+    f(xx: 1, yy: 2)
+    // expected-error@-1 {{extraneous argument labels 'xx:yy:' in call}}
+
+    f(xx: 1, 2, 3)
+    // expected-error@-1:11 {{extra argument 'xx' in call}}
+
+    f(1, xx: 2, 3)
+    // expected-error@-1:14 {{extra argument 'xx' in call}}
+
+    f(1, 2, xx: 3)
+    // expected-error@-1:17 {{extra argument 'xx' in call}}
+
+    f(xx: 1, yy: 2, 3)
+    // expected-error@-1:18 {{extra argument 'yy' in call}}
+
+    f(xx: 1, yy: 2, 3, 4)
+    // expected-error@-1:6 {{extra arguments at positions #1, #2 in call}}
+  }
+
+  do {
+    func f(_ aa: Int = 0, _ bb: Int) { }
+    // expected-note@-1 {{'f' declared here}}
+
+    f(1)
+    // expected-error@-1:8 {{missing argument for parameter #2 in call}}
+
+    f(1, 2) // ok
+  }
+
+  do {
+    func f(_ aa: Int, bb: Int) { }
+    // expected-note@-1 4 {{'f(_:bb:)' declared here}}
+
+    f(1)
+    // expected-error@-1:8 {{missing argument for parameter 'bb' in call}}
+
+    f(1, 2)
+    // expected-error@-1 {{missing argument label 'bb:' in call}}
+
+    f(1, bb: 2) // ok
+
+    f(xx: 1, 2)
+    // expected-error@-1:11 {{extra argument 'xx' in call}}
+    // expected-error@-2:12 {{missing argument for parameter 'bb' in call}}
+
+    f(xx: 1, bb: 2)
+    // expected-error@-1 {{extraneous argument label 'xx:' in call}}
+
+    f(bb: 1, 2, 3)
+    // expected-error@-1:6 {{extra arguments at positions #2, #3 in call}}
+    // expected-error@-2:7 {{missing argument for parameter #1 in call}}
+
+    f(1, bb: 2, 3)
+    // expected-error@-1:17 {{extra argument in call}}
+
+    f(1, 2, bb: 3)
+    // expected-error@-1:10 {{extra argument in call}}
+
+    f(xx: 1, 2, 3)
+    // expected-error@-1:11 {{extra argument 'xx' in call}}
+
+    f(1, xx: 2, 3)
+    // expected-error@-1:14 {{extra argument 'xx' in call}}
+
+    f(1, 2, xx: 3)
+    // expected-error@-1:17 {{extra argument 'xx' in call}}
   }
 
   do {
@@ -735,17 +848,98 @@ func testUnlabeledParameterBindingPosition() {
     f(0, 1, xx: 9)
     // expected-error@-1:17 {{extra argument 'xx' in call}}
 
+    f(0, 1, 2)
+    // expected-error@-1:13 {{extra argument in call}}
+
     f(xx: 91, 1, 92)
     // expected-error@-1:11 {{extra argument 'xx' in call}}
+
+    f(1, xx: 2, 3)
+    // expected-error@-1:14 {{extra argument 'xx' in call}}
+
+    f(1, 2, xx: 3)
+    // expected-error@-1:17 {{extra argument 'xx' in call}}
+  }
+
+  do {
+    func f(_ aa: Int, _ bb: Int = 82, _ cc: Int) { }
+    // expected-note@-1 {{'f' declared here}}
+
+    f(1, 2)
+    // expected-error@-1:11 {{missing argument for parameter #3 in call}}
+
+    f(1, 2, 3) // ok
+  }
+
+  do {
+    func f(_ aa: Int, _ bb: Int, cc: Int) { }
+    // expected-note@-1 6 {{'f(_:_:cc:)' declared here}}
+
+    f(1, 2, cc: 3) // ok
+
+    f(1, 2, xx: 3)
+    // expected-error@-1 {{incorrect argument label in call (have '_:_:xx:', expected '_:_:cc:')}}
+
+    f(1, cc: 2, 3)
+    // expected-error@-1:8 {{missing argument for parameter #2 in call}}
+    // expected-error@-2:17 {{extra argument in call}}
+
+    f(1, xx: 2, 3)
+    // expected-error@-1:14 {{extra argument 'xx' in call}}
+    // expected-error@-2:15 {{missing argument for parameter 'cc' in call}}
+
+    f(cc: 1, 2, 3)
+    // expected-error@-1:6 {{extra arguments at positions #2, #3 in call}}
+    // expected-error@-2:6 {{missing arguments for parameters #1, #2 in call}}
+
+    f(xx: 1, 2, 3)
+    // expected-error@-1:11 {{extra argument 'xx' in call}}
+    // expected-error@-2:15 {{missing argument for parameter 'cc' in call}}
+
+    f(xx: 1, yy: 2, 3)
+    // expected-error@-1:18 {{extra argument 'yy' in call}}
+    // expected-error@-2:19 {{missing argument for parameter 'cc' in call}}
+
+    f(xx: 1, 2, yy: 3)
+    // expected-error@-1 {{incorrect argument labels in call (have 'xx:_:yy:', expected '_:_:cc:')}}
+
+    f(1, xx: 2, yy: 3)
+    // expected-error@-1 {{incorrect argument labels in call (have '_:xx:yy:', expected '_:_:cc:')}}
   }
 
   do {
     func f(_ aa: Int, bb: Int, _ cc: Int) { }
-    // expected-note@-1 {{'f(_:bb:_:)' declared here}}
+    // expected-note@-1 6 {{'f(_:bb:_:)' declared here}}
+
+    f(1)
+    // expected-error@-1:7 {{missing arguments for parameters 'bb', #3 in call}}
+
+    f(1, 2)
+    // expected-error@-1:8 {{missing argument for parameter 'bb' in call}}
+
+    f(1, 2, 3)
+    // expected-error@-1 {{missing argument label 'bb:' in call}}
+
+    f(1, 2, bb: 3)
+    // expected-error@-1:10 {{extra argument in call}}
+    // expected-error@-2:11 {{missing argument for parameter #3 in call}}
+
+    f(1, bb: 2, 3) // ok
 
     f(bb: 1, 0, 2)
     // expected-error@-1 {{extra argument in call}}
     // expected-error@-2 {{missing argument for parameter #1 in call}}
+
+    f(xx: 1, 2, 3)
+    // expected-error@-1:11 {{extra argument 'xx' in call}}
+    // expected-error@-2:12 {{missing argument for parameter 'bb' in call}}
+
+    f(1, xx: 2, 3)
+    // expected-error@-1 {{incorrect argument label in call (have '_:xx:_:', expected '_:bb:_:')}}
+
+    f(1, 2, xx: 3)
+    // expected-error@-1:8 {{missing argument for parameter 'bb' in call}}
+    // expected-error@-2:17 {{extra argument 'xx' in call}}
   }
 
   do {
@@ -772,8 +966,51 @@ func testUnlabeledParameterBindingPosition() {
     // expected-note@+1 *{{'f(aa:_:_:)' declared here}}
     func f(aa: Int, _ bb: Int, _ cc: Int) {}
 
+    f(1)
+    // expected-error@-1:7 {{missing arguments for parameters 'aa', #3 in call}}
+
     f(0, 1)
     // expected-error@-1:7 {{missing argument for parameter 'aa' in call}}
+
+    f(1, 2, 3)
+    // expected-error@-1:6 {{missing argument label 'aa:' in call}}
+
+    f(1, aa: 2, 3)
+    // expected-error@-1:7 {{extra argument in call}}
+    // expected-error@-2:15 {{missing argument for parameter #3 in call}}
+
+    f(1, xx: 2, 3)
+    // expected-error@-1:7 {{missing argument for parameter 'aa' in call}}
+    // expected-error@-2:14 {{extra argument 'xx' in call}}
+
+    f(aa: 1, 2, 3) // ok
+
+    f(xx: 1, 2, 3)
+    // expected-error@-1 {{incorrect argument label in call (have 'xx:_:_:', expected 'aa:_:_:')}}
+
+    f(xx: 1, 2, yy: 3)
+    // expected-error@-1:7 {{missing argument for parameter 'aa' in call}}
+    // expected-error@-2:21 {{extra argument 'yy' in call}}
+
+    f(xx: 1, yy: 2, 3)
+    // expected-error@-1:7 {{missing argument for parameter 'aa' in call}}
+    // expected-error@-2:18 {{extra argument 'yy' in call}}
+
+    f(1, xx: 2, yy: 3)
+    // expected-error@-1:7 {{missing argument for parameter 'aa' in call}}
+    // expected-error@-2:21 {{extra argument 'yy' in call}}
+
+    f(1, 2, 3, 4)
+    // expected-error@-1:16 {{extra argument in call}}
+
+    f(1, aa: 2, 3, 4)
+    // expected-error@-1:7 {{extra argument in call}}
+
+    f(1, aa: 2, 3, xx: 4)
+    // expected-error@-1:7 {{extra argument in call}}
+
+    f(1, aa: 2, xx: 3, 4)
+    // expected-error@-1:7 {{extra argument in call}}
   }
 
   do {
@@ -794,6 +1031,37 @@ func testUnlabeledParameterBindingPosition() {
 
     f(0, bb: 1, 2)
     // expected-error@-1:6 {{missing argument label 'aa:' in call}}
+
+    f(xx: 1, 2, 3)
+    // expected-error@-1:11 {{extra argument 'xx' in call}}
+    // expected-error@-2:12 {{missing argument for parameter 'bb' in call}}
+
+    f(1, xx: 2, 3)
+    // expected-error@-1 {{incorrect argument labels in call (have '_:xx:_:', expected 'aa:bb:_:')}}
+
+    f(1, 2, xx: 3)
+    // expected-error@-1:8 {{missing argument for parameter 'bb' in call}}
+    // expected-error@-2:17 {{extra argument 'xx' in call}}
+  }
+
+  do {
+    func f(aa: Int, bb: Int, cc: Int) { }
+    // expected-note@-1 3 {{'f(aa:bb:cc:)' declared here}}
+
+    f(1, aa: 2, bb: 3)
+    // expected-error@-1:7 {{extra argument in call}}
+    // expected-error@-2:15 {{missing argument for parameter 'cc' in call}}
+
+    f(1, bb: 2, aa: 3)
+    // expected-error@-1:7 {{extra argument in call}}
+    // expected-error@-2:15 {{missing argument for parameter 'cc' in call}}
+
+    f(aa: 1, 2, bb: 3)
+    // expected-error@-1:14 {{extra argument in call}}
+    // expected-error@-2 {{missing argument for parameter 'cc' in call}}
+
+    f(aa: 1, bb: 2, 3)
+    // expected-error@-1 {{missing argument label 'cc:' in call}}
   }
 
   do {
@@ -804,8 +1072,142 @@ func testUnlabeledParameterBindingPosition() {
 
   do {
     func f(_ aa: Int, _ bb: Int = 81, cc: Int = 82, _ dd: Int) {}
+    // expected-note@-1 2 {{'f(_:_:cc:_:)' declared here}}
 
     f(0, cc: 2, 3) // ok
+
+    f(cc: 1, 2, 3, 4)
+    // expected-error@-1:6 {{extra arguments at positions #3, #4 in call}}
+    // expected-error@-2:7 {{missing argument for parameter #1 in call}}
+  }
+
+  do {
+    func f(_ aa: Int, _ bb: Int, cc: Int, dd: Int) { }
+    // expected-note@-1 6 {{'f(_:_:cc:dd:)' declared here}}
+
+    f(1, xx: 2)
+    // expected-error@-1 {{extraneous argument label 'xx:' in call}}
+    // expected-error@-2:6 {{missing arguments for parameters 'cc', 'dd' in call}}
+
+    f(xx: 1, 2)
+    // expected-error@-1:6 {{missing arguments for parameters 'cc', 'dd' in call}}
+    // expected-error@-2 {{extraneous argument label 'xx:' in call}}
+
+    f(1, xx: 2, cc: 3)
+    // expected-error@-1 {{extraneous argument label 'xx:' in call}}
+    // expected-error@-2:22 {{missing argument for parameter 'dd' in call}}
+
+    f(1, xx: 2, dd: 3)
+    // expected-error@-1 {{extraneous argument label 'xx:' in call}}
+    // expected-error@-2:15 {{missing argument for parameter 'cc' in call}}
+
+    f(xx: 1, 2, cc: 3)
+    // expected-error@-1 {{extraneous argument label 'xx:' in call}}
+    // expected-error@-2:22 {{missing argument for parameter 'dd' in call}}
+
+    f(xx: 1, 2, dd: 3)
+    // expected-error@-1 {{extraneous argument label 'xx:' in call}}
+    // expected-error@-2:15 {{missing argument for parameter 'cc' in call}}
+
+    f(1, xx: 2, cc: 3, dd: 4)
+    // expected-error@-1:6 {{extraneous argument label 'xx:' in call}}
+
+    f(xx: 1, 2, cc: 3, dd: 4)
+    // expected-error@-1:6 {{extraneous argument label 'xx:' in call}}
+  }
+
+  do {
+    func f(_ aa: Int, bb: Int = 82, _ cc: Int, _ dd: Int) { }
+    // expected-note@-1 {{'f(_:bb:_:_:)' declared here}}
+
+    f(1, bb: 2, 3, 4) // ok
+
+    f(1, 2, bb: 3, 4)
+    // expected-error@-1:10 {{extra argument in call}}
+    // expected-error@-2:18 {{missing argument for parameter #4 in call}}
+  }
+
+  do {
+    func f(aa: Int, _ bb: Int, cc: Int, _ dd: Int) { }
+    // expected-note@-1 3 {{'f(aa:_:cc:_:)' declared here}}
+
+    f(1)
+    // expected-error@-1:7 {{missing arguments for parameters 'aa', 'cc', #4 in call}}
+
+    f(1, 2)
+    // expected-error@-1:6 {{missing arguments for parameters 'aa', 'cc' in call}}
+
+    f(1, 2, 3)
+    // expected-error@-1 {{missing argument label 'aa:' in call}}
+    // expected-error@-2:11 {{missing argument for parameter 'cc' in call}}
+
+    f(1, 2, 3, 4)
+    // expected-error@-1:6 {{missing argument labels 'aa:cc:' in call}}
+
+    f(1, 2, 3, 4, 5)
+    // expected-error@-1:19 {{extra argument in call}}
+  }
+
+  do {
+    func f(aa: Int, bb: Int, _ cc: Int, _ dd: Int) { }
+    // expected-note@-1 6 {{'f(aa:bb:_:_:)' declared here}}
+
+    f(1, xx: 2)
+    // expected-error@-1:6 {{missing arguments for parameters 'aa', 'bb' in call}}
+    // expected-error@-2 {{extraneous argument label 'xx:' in call}}
+
+    f(xx: 1, 2)
+    // expected-error@-1 {{extraneous argument label 'xx:' in call}}
+    // expected-error@-2:6 {{missing arguments for parameters 'aa', 'bb' in call}}
+
+    f(bb: 1, 2, xx: 3)
+    // expected-error@-1 {{extraneous argument label 'xx:' in call}}
+    // expected-error@-2:7 {{missing argument for parameter 'aa' in call}}
+
+    f(bb: 1, xx: 2, 3)
+    // expected-error@-1 {{extraneous argument label 'xx:' in call}}
+    // expected-error@-2:7 {{missing argument for parameter 'aa' in call}}
+
+    f(aa: 1, 2, xx: 3)
+    // expected-error@-1 {{extraneous argument label 'xx:' in call}}
+    // expected-error@-2:12 {{missing argument for parameter 'bb' in call}}
+
+    f(aa: 1, xx: 2, 3)
+    // expected-error@-1 {{extraneous argument label 'xx:' in call}}
+    // expected-error@-2:12 {{missing argument for parameter 'bb' in call}}
+
+    f(aa: 1, bb: 2, 3, xx: 4)
+    // expected-error@-1 {{extraneous argument label 'xx:' in call}}
+
+    f(aa: 1, bb: 2, xx: 3, 4)
+    // expected-error@-1 {{extraneous argument label 'xx:' in call}}
+  }
+
+  do {
+    func f(_ aa: Int, bb: Int, _ cc: Int, dd: Int, _ ee: Int) { }
+    // expected-note@-1 2 {{'f(_:bb:_:dd:_:)' declared here}}
+
+    f(1, bb: 2, 3, 4, dd: 5)
+    // expected-error@-1:20 {{extra argument in call}}
+    // expected-error@-2:21 {{missing argument for parameter #5 in call}}
+
+    f(1, dd: 2, 3, 4, bb: 5)
+    // expected-error@-1:15 {{missing argument for parameter #3 in call}}
+    // expected-error@-2:20 {{extra argument in call}}
+
+    f(1, bb: 2, 3, dd: 4, 5) // ok
+
+    f(1, dd: 2, 3, bb: 4, 5)
+    // expected-error@-1 {{incorrect argument labels in call (have '_:dd:_:bb:_:', expected '_:bb:_:dd:_:')}}
+
+    f(1, 2, bb: 3, 4, dd: 5, 6)
+    // expected-error@-1:10 {{extra argument in call}}
+
+    f(1, bb: 2, 3, 4, dd: 5, 6)
+    // expected-error@-1:20 {{extra argument in call}}
+
+    f(1, dd: 2, 3, 4, bb: 5, 6)
+    // expected-error@-1:20 {{extra argument in call}}
   }
 }
 

--- a/test/Constraints/diagnostics_swift4.swift
+++ b/test/Constraints/diagnostics_swift4.swift
@@ -6,7 +6,7 @@ func sr_2505(_ a: Any) {} // expected-note {{}}
 sr_2505()          // expected-error {{missing argument for parameter #1 in call}}
 sr_2505(a: 1)      // expected-error {{extraneous argument label 'a:' in call}}
 sr_2505(1, 2)      // expected-error {{extra argument in call}}
-sr_2505(a: 1, 2)   // expected-error {{extra argument in call}}
+sr_2505(a: 1, 2)   // expected-error {{extra argument 'a' in call}}
 
 struct C_2505 {
   init(_ arg: Any) {

--- a/test/Constraints/function.swift
+++ b/test/Constraints/function.swift
@@ -36,7 +36,7 @@ var s: String = optFunc("hi")
 // <rdar://problem/17652759> Default arguments cause crash with tuple permutation
 func testArgumentShuffle(_ first: Int = 7, third: Int = 9) {
 }
-testArgumentShuffle(third: 1, 2) // expected-error {{unnamed argument #2 must precede argument 'third'}} {{21-21=2, }} {{29-32=}}
+testArgumentShuffle(third: 1, 2) // expected-error {{extra argument in call}} {{none}}
 
 
 

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -248,7 +248,7 @@ protocol Addable {
 }
 func addAddables<T : Addable, U>(_ x: T, y: T, u: U) -> T {
   // FIXME(diagnostics): This should report the "no exact matches" diagnostic.
-  u + u // expected-error{{operator function '+' requires that 'U' conform to 'RangeReplaceableCollection'}}
+  u + u // expected-error{{referencing operator function '+' on 'RangeReplaceableCollection' requires that 'U' conform to 'RangeReplaceableCollection'}}
   return x+y
 }
 

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -248,7 +248,7 @@ protocol Addable {
 }
 func addAddables<T : Addable, U>(_ x: T, y: T, u: U) -> T {
   // FIXME(diagnostics): This should report the "no exact matches" diagnostic.
-  u + u // expected-error{{referencing operator function '+' on 'RangeReplaceableCollection' requires that 'U' conform to 'RangeReplaceableCollection'}}
+  u + u // expected-error{{operator function '+' requires that 'U' conform to 'RangeReplaceableCollection'}}
   return x+y
 }
 

--- a/test/Parse/multiple_trailing_closures.swift
+++ b/test/Parse/multiple_trailing_closures.swift
@@ -79,10 +79,12 @@ multiple_trailing_with_defaults(duration: 42) {} completion: {}
 
 func test_multiple_trailing_syntax_without_labels() {
   func fn(f: () -> Void, g: () -> Void) {}
+  // expected-note@-1 {{'fn(f:g:)' declared here}}
 
   fn {} g: {} // Ok
 
   fn {} _: {} // expected-error {{extra argument in call}}
+  // expected-error@-1 {{missing argument for parameter 'f' in call}}
 
   fn {} g: <#T##() -> Void#> // expected-error {{editor placeholder in source file}}
 

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1208,7 +1208,7 @@ struct MissingPropertyWrapperUnwrap {
 
 struct InvalidPropertyDelegateUse {
   // TODO(diagnostics): We need to a tailored diagnostic for extraneous arguments in property delegate initialization
-  @Foo var x: Int = 42 // expected-error@:21 {{argument passed to call that takes no arguments}}
+  @Foo var x: Int = 42 // expected-error@:4 {{incorrect argument label in call (have 'wrappedValue:', expected 'prop:')}}
 
   func test() {
     self.x.foo() // expected-error {{value of type 'Int' has no member 'foo'}}

--- a/test/stdlib/PrintDiagnostics.swift
+++ b/test/stdlib/PrintDiagnostics.swift
@@ -5,10 +5,13 @@ var stream = ""
 print(3, &stream) // expected-error{{'&' used with non-inout argument of type 'Any'}}
 debugPrint(3, &stream) // expected-error{{'&' used with non-inout argument of type 'Any'}}
 
-print(3, &stream, appendNewline: false) // expected-error {{extra argument 'appendNewline' in call}}
+print(3, &stream, appendNewline: false) // expected-error {{incorrect argument label in call (have '_:_:appendNewline:', expected '_:_:separator:')}}
 // expected-error@-1:10 {{'&' used with non-inout argument of type 'Any'}}
+// expected-error@-2:34 {{cannot convert value of type 'Bool' to expected argument type 'String'}}
 
-debugPrint(3, &stream, appendNewline: false) // expected-error {{extra argument 'appendNewline' in call}}
+debugPrint(3, &stream, appendNewline: false) // expected-error {{incorrect argument label in call (have '_:_:appendNewline:', expected '_:_:separator:')}}
 // expected-error@-1:15 {{'&' used with non-inout argument of type 'Any'}}
+// expected-error@-2:39 {{cannot convert value of type 'Bool' to expected argument type 'String'}}
 
-print(4, quack: 5) // expected-error {{extra argument 'quack' in call}}
+print(4, quack: 5) // expected-error {{incorrect argument label in call (have '_:quack:', expected '_:separator:')}}
+// expected-error@-1 {{cannot convert value of type 'Int' to expected argument type 'String'}}


### PR DESCRIPTION
I created new algorithm of argument matching that produces expected result in all difficult situation we discussed at #32037 #30444.

- **EDIT at 2020/05/30 07:32:30 JST**: add document.

- **EDIT at 2020/05/30 23:59:30 JST**: add *result* section.

@xedin  Could you review this?

~~I am going to write full explanation soon.~~

# The new 3 stage argument matching algorithm

I propose a new 3 stage argument matching algorihm in this patch.

# Introduction

The current `matchCallArgument` has a problem with argument matching.
This is that diagnostic message about label errors doesn't match the result of argument matching
where input source code has a compilation error.

It is difficult to build argument matching that matches desired diagnostic message.
I tried it once with patch here #32307 , but it wasn't perfect.

This patch completely overhauls existing `matchCallArgument` implementation and changes it new algorithm.

In this document, I describe this algorithm.

## Expression form of bindings

I had `parameter => argument` form in past at #32307, but I actually use `argument => parameter` form because it's still easier to understand.

# Requirements

I enumerate an nature of expected bindings.

## R-1 Unlabeled arguments are aligned with labeled arguments

Unlabeled arguments should be aligned from where the preceding labeled arguments match.

For following example:

```swift
func f(aa: Int, _ bb: Int, cc: Int, _ dd: Int) {}

f(cc: 1, 2, aa: 3, 4)
/*
  bindings:
    cc: => cc:
    2 => _ dd:
    aa: => aa:
    4 => _ bb:
*/
```

`2` should match `_ dd:` since it follows `cc:` and
`4` should match `_ bb:` since it follows `aa:`.

## R-2 Unlabeled arguments must be bound to same number of unlabeled parameters

When there are same number of unlabeled arguments and parameters, they must be bound with higher priority.

For following example:

```swift
func f(aa: Int = 81, _ bb: Int, _ cc: Int) {}

f(1, xx: 2, 3)
/*
  bindings:
    1 => _ bb:
    xx: => none (extra argument)
    3 => _ cc:
*/
```

Since there are two unlabeled arguments in `1` and `3` and
two unlabeled parameters in `_ bb:` and `_ cc:`, 
they must be bound.

`xx:` should not match `_ bb:` or `_ cc:`.

## R-3 Unlabeled arguments(parameters) should be bound to labeled parameters(arguments) if possible

When there are more unlabeled arguments than unlabled parameters,
extra unlabeled arguments should be bound as much as labeled parameters.

For following example:

```swift
func f(aa: Int, _ bb: Int) {}

f(1, 2)
/*
  bindings:
    1 => aa:
    2 => _ bb:
*/
```

There are two arguments in `1` and `3`,
more than one parameter in `_ bb:`.

So, the extra `1` should be matched `aa:`.

In this case, crossed binding such as the following are undesirable.

```swift
/*
  unexpected bindings:
    1 => _ bb:
    2 => aa:
*/
```

Also, it is undesirable to build the following extra and missing arguments.

```swift
/*
  unexpected bindings:
    none => aa: (missing argument)
    1 => _ bb:
    2 => none (extra argument)
*/
```

As shown below,
even if unlabeled arguments has an unrelated labeled arguments near it,
unlabeled arguments should take precedence over labeled arguments and match labeled parameter.

```swift
func f(aa: Int, _ bb: Int) {}

f(1, xx: 2, 3)
/*
  bindings:
    1 => aa:
    xx: => none (extra argument)
    3 => bb:
*/
```

Contrary to what I have said,
when there are more unlabeled parameters than unlabeled arguments,
extra unlabeled parameters should be matched labeled arguments.

For example:

```swift
func f(_ aa: Int, bb: Int, _ cc: Int) {}

f(xx: 1, 2)
/*
  bindings:
    xx: => _ aa:
    none => bb: (missing argument)
    2 => _ cc:
*/
```

## R-4 Even different labels bind each other.

Even if it's a different label,
they should be matched if that's the only option.

For example:

```swift
func f(aa: Int) {}

f(xx: 1)
/*
  bindings:
    xx: => aa:
*/
```

It is undesirable to build the following extra and missing arguments.

```swift
/*
  unexpected bindings:
    none => aa: (missing argument)
    xx: => none (extra argument)
*/
```

# Discussion

Based on the requirements, consider the necessary rules.

## D-1 4 levels of priority

From requirements,
we can see that there are four levels of strength in binding of arguments.
In order of strength are the following

1. labeled arguments and labeled parameters that match
2. unlabeled arguments and unlabeled parameters
3. unlabeled arguments and labeled parameters, or, 
   labeled arguments and unlabeled parameters
4. labeled arguments and labeled parameters that doesn't natch

## D-2 Binding of unlabeled arguments

Consider the following situations.

```swift
func f(aa: Int, bb: Int, _ cc: Int, _ dd: Int) { }

f(1, 2, 3)
```

Now, we suppose to decide binding of `_ cc:`.

Since `aa:` and `cc:` are not claimed,
we would like to match unlabeled arguments to them if possible.
Now there are two unlabeled parameters and three unlabeled arguments,
so there is one unlabeled argument left over.
So, save `1` for binding labeled arguments later, and bind `2` to `_ cc:`.

Next, we suppose to decide binding of `_ dd:`.

Since `aa:` and `cc:` are not claimed,
we would like to match unlabeled arguments to them if possible.
Since we've already bind `2` to `_ cc:`,
there are one unlabeled parameter in `_ dd:` and two unlabeled arguments in `1` and `3`, so there is one unlabeled argument left over.
So, save `1` again for binding labeled argumets later, and bind `3` to `_ dd:`.

After binding of unlabeled arguments is finished,
unlabeled argument in `1` and unlabeled parameters in `aa:`, `bb:` are left.

So, if we match them positionally, finally get the following bindings.

```swift
/*
  bindings:
    1 => aa:
    none => bb: (missing argument)
    2 => _ cc:
    3 => _ dd:
*/
```

In this way, 
by examining the number of unlabeled parameters, 
the number of labeled parameters at left, 
and the number of unlabeled arguments, 
bindings satisfying `R-2` and `R-3` can be made.

If unlabeled parameters are more than unlabeled arguments,
the same process can be done with the opposite view.

# Proposal

Based on the above, I propose argument matching algorithm with three levels of grouping.

This method divides the steps into the following three stages.

1. Stage 1: label matching
2. Stage 2: unlabeled matching
3. Stage 3: label agnostic matching

In the first label match, 
look for a match between all parameters and arguments.
Once matching is complete,
split remaining arguments by bound pairs into groups.

For example:

```swift
func f(aa: Int, _ bb: Int, cc: Int, dd: Int, _ ee: Int, ff: Int, _ gg: Int, _ hh: Int) {}

f(1, 2, 3, ff: 4, 5, cc: 6, 7, 8)
```

In stage 1, `cc:` and `ff:` are matched.
By splitting arguments with these matchings, we group them as follows.

```swift
/*
  group 1 (most left):
    [1, 2, 3] => [aa:, _ bb:]
  
  group 2 (by cc:):
    [7, 8] => [dd:, _ ee:]

  group 3 (by ff:):
    [5] => [_ gg:, _ hh:]
*/
```

Next, in stage 2, do unlabeled matching among groups created in stage 1.
Use the procedure described in D-2 for matching.
Then we will get following bindings.

```swift
/*
  group 1:
    1 => aa:
    2 => none (extra argument)
    3 => _ bb:

  group 2:
    7 => dd:
    8 => _ ee:

  group 3:
    5 => _ gg:
    none => _ hh: (missing argument)
*/
```

Now we have complete bindings.

```swift
/*
  1 => aa:
  2 => none (extra argument)
  3 => _ bb:
  ff: => ff:
  5 => _ gg:
  none => _ hh: (missing argument)
  cc: => cc:
  7 => dd:
  8 => _ ee:
*/
```

In this way, we can get the desired bindings.

Next, consider following example:

```swift
func f(aa: Int, _ bb: Int, cc: Int, dd: Int, _ ee: Int) {}

f(1, xx: 2, 3, yy: 4, 5)
```

In this case, group will not be split in stage 1.
Unlabeled matching as following in stage 2.

```swift
/*
  1 => aa:
  3 => _ bb:
  5 => _ ee:
*/
```

In stage 2, as in stage 1, 
split arguments by bound pairs into groups.

```swift
/*
  group 1 (by 1):
    [xx:] => []

  group 2 (by 3):
    [yy:] => [cc:, dd:]
*/
```

Next, in stage 3, 
do posional matching ignoring labels among among groups created in stage 2.
Then we will get following bindings.

```swift
/*
  group 1:
    xx: => none (extra argument)

  group 2:
    yy: => cc:
    none => dd: (missing argument)
*/
```

Now we have complete bindings.

```swift
/*
  1 => aa:
  xx: => none (extra argument)
  3 => _ bb:
  yy: => cc:
  none => dd: (missing argument)
  5 => _ ee:
*/
```

In this way, we can get the desired bindings.

# Implementation

The implementation is as follows.

- `claim`: claims arguments same as current.

- `bindParameter`: After bind given `paramIdx` and `argIdx`,
  bind variadic tails if necessary.

- `claimNextNamed`: deleted.

- `bindNextParameter`: deleted.

- In the part with `Step 1` in comment, 
  label matching in stage 1 is done.

- In the part with `Step 2` in comment,
  label matching with typo correction in stage 1 is done.

- `bindUnlabeledParameters`:
  Unlabeled matching in first half of stage 2.
  Save extra unlabeled arguments.

- `bindParameterPositionally`:
  Match unlabeled and labeled in second half of stage 2.
  By argument `ignoreLabel`,
  it is used for label agnostic matching in stage 3.

- `iterateGroups`: Higher function that iterate each group which is split by existing bindings. It is used for stage 2 and 3.

- In the part with `Step 3` in comment, 
  stage 2 is done.

- In the part with `Step 4` in comment, 
  stage 3 is done.

- In the part with `Step 5` in comment, 
  it reports extra arguments.

- In the part with `Step 6` in comment, 
  it reports missing arguments.

- In the part with `Step 7` in comment, 
  it reports label errors.

# Result

Inconsistent bindings with diagnostics and undesired bindings are built currently in some cases.
This patch improve these cases.
I show some good results below.

```swift
func f(aa: Int, _ bb: Int) {}

// (1)
f(1, 2)
/*
  current:
    bindings:
      1 => _ bb:
      2 => aa:
    errors:
      - missing argument label 'aa:' in call
    problem:
      - inconsitent bindings with diagnostics

  patch:
    bindings:
      1 => aa:
      2 => _ bb:
    errors:
      - missing argument label 'aa:' in call
    resolved:
      - consistent bindings with diagnostics
 */

// (2)
f(xx: 1, 2, 3)
/*
  current:
    bindings:
      none => aa: (missing argument)
      xx: => _ bb:
      2 => none (extra argument)
      3 => none (extra argument)
    errors:
      - extra arguments at positions #2, #3 in call
      - missing argument for parameter 'aa' in call
    problem:
      - undesired result

  patch:
    bindings:
      xx: => none (extra argument)
      2 => aa:
      3 => _ bb:
    errors:
      - extra argument 'xx' in call
    resolved:
      - desired result
 */

// (3)
func f(_ aa: Int, bb: Int) {}
f(1, xx: 2)
/*
  current:
    bindings:
      1 => _ aa:
      xx: => bb:
    errors:
      - incorrect argument label in call (have '_:xx:', expected '_:bb:')
    problem:
      - no problem

  patch:
    bindings:
      1 => _ aa:
      xx: => bb:
    errors:
      - incorrect argument label in call (have '_:xx:', expected '_:bb:')
    resolved:
      - no problem
 */

// (4)
func f(_ aa: Int, bb: Int, cc: Int = 99) {}
f(1, xx: 2)

/*
  current:
    bindings:
      1 => _ aa:
      xx: => none (extra argument)
      none => bb: (missing argument)
      none => cc: (defaulted)
    errors:
      - extra argument 'xx' in call
      - missing argument for parameter 'bb' in call
    problems:
      - undesired result
      - inconsistent with (3)

  patch:
    bindings:
      1 => _ aa:
      xx: => bb:
      none => cc: (defaulted)
    errors:
      - incorrect argument label in call (have '_:xx:', expected '_:bb:')
    resolved:
      - desired result
      - consitent with (3)
 */
```


