### PR TITLE
[Fast Dependency Scanner] Ensure Swift modules don't depend on self.

### DIFF
--- a/lib/FrontendTool/ScanDependencies.cpp
+++ b/lib/FrontendTool/ScanDependencies.cpp
@@ -130,7 +130,10 @@ static std::vector<ModuleDependencyID> resolveDirectDependencies(
     for (const auto &clangDep : allClangModules) {
       if (auto found = ctx.getModuleDependencies(
               clangDep, /*onlyClangModule=*/false, cache, ASTDelegate)) {
-        if (found->getKind() == ModuleDependenciesKind::Swift)
+        // ASTContext::getModuleDependencies returns dependencies for a module with a given name.
+        // This Clang module may have the same name as the Swift module we are resolving, so we
+        // need to make sure we don't add a dependency from a Swift module to itself.
+        if (found->getKind() == ModuleDependenciesKind::Swift && clangDep != module.first)
           result.push_back({clangDep, found->getKind()});
       }
     }

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -126,10 +126,9 @@ import G
 // CHECK: "directDependencies"
 // CHECK-NEXT: {
 // CHECK-NEXT: "clang": "G"
-// CHECK-NEXT: },
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "G"
 // CHECK-NEXT: }
+// CHECK-NEXT: ],
+// CHECK-NEXT: "details": {
 
 // CHECK: "contextHash": "{{.*}}",
 // CHECK: "commandLine": [


### PR DESCRIPTION
When resolving direct dependencies for a given Swift module, we go over all Clang module dependencies and add, as additional dependencies, their Swift overlays. We find overlays by querying `ASTContext::getModuleDependencies` with the Clang module's name. If the Clang module in question is a dependency of a Swift module with the same name, we will end up adding the Swift module as its own dependence.

e.g.
- Swift A depends on Clang A
  - Add Clang A to dependencies of Swift A
- Look for overlays of Clang A, by name, and find Swift A
  - Add Swift A to dependencies of Swift A

From what I can tell, the logic upstream is sound, and `getModuleDependencies` is doing the right thing, so this change is simply restricting what gets added when we are resolving direct dependencies and looking for overlays.

Resolves rdar://problem/63731428