### PR TITLE
[CodeCompletion] Skip type checking unrelated statements in function body

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -867,14 +867,13 @@ public:
   bool isCached() const { return true; }
 };
 
-/// Request to type check the body of the given function up to the given
-/// source location.
+/// Request to type check the body of the given function.
 ///
 /// Produces true if an error occurred, false otherwise.
 /// FIXME: it would be far better to return the type-checked body.
 class TypeCheckFunctionBodyRequest :
     public SimpleRequest<TypeCheckFunctionBodyRequest,
-                         bool(AbstractFunctionDecl *, SourceLoc),
+                         bool(AbstractFunctionDecl *),
                          RequestFlags::Cached|RequestFlags::DependencySource> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -883,9 +882,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  bool
-  evaluate(Evaluator &evaluator, AbstractFunctionDecl *func,
-           SourceLoc endTypeCheckLoc) const;
+  bool evaluate(Evaluator &evaluator, AbstractFunctionDecl *func) const;
 
 public:
   bool isCached() const { return true; }
@@ -894,6 +891,24 @@ public:
   // Incremental dependencies.
   evaluator::DependencySource
   readDependencySource(const evaluator::DependencyRecorder &) const;
+};
+
+/// Request to typecheck a function body element at the given source location.
+///
+/// Produces true if an error occurred, false otherwise.
+class TypeCheckFunctionBodyAtLocRequest
+    : public SimpleRequest<TypeCheckFunctionBodyAtLocRequest,
+                           bool(AbstractFunctionDecl *, SourceLoc),
+                           RequestFlags::Uncached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  bool evaluate(Evaluator &evaluator, AbstractFunctionDecl *func,
+                SourceLoc Loc) const;
 };
 
 /// Request to obtain a list of stored properties in a nominal type.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -872,8 +872,8 @@ public:
 ///
 /// Produces true if an error occurred, false otherwise.
 /// FIXME: it would be far better to return the type-checked body.
-class TypeCheckFunctionBodyUntilRequest :
-    public SimpleRequest<TypeCheckFunctionBodyUntilRequest,
+class TypeCheckFunctionBodyRequest :
+    public SimpleRequest<TypeCheckFunctionBodyRequest,
                          bool(AbstractFunctionDecl *, SourceLoc),
                          RequestFlags::Cached|RequestFlags::DependencySource> {
 public:

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -196,7 +196,7 @@ SWIFT_REQUEST(TypeChecker, SuperclassTypeRequest,
 SWIFT_REQUEST(TypeChecker, SynthesizeAccessorRequest,
               AccessorDecl *(AbstractStorageDecl *, AccessorKind),
               SeparatelyCached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, TypeCheckFunctionBodyUntilRequest,
+SWIFT_REQUEST(TypeChecker, TypeCheckFunctionBodyRequest,
               bool(AbstractFunctionDecl *, SourceLoc),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, UnderlyingTypeRequest, Type(TypeAliasDecl *),

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -197,8 +197,10 @@ SWIFT_REQUEST(TypeChecker, SynthesizeAccessorRequest,
               AccessorDecl *(AbstractStorageDecl *, AccessorKind),
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, TypeCheckFunctionBodyRequest,
+              bool(AbstractFunctionDecl *), Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, TypeCheckFunctionBodyAtLocRequest,
               bool(AbstractFunctionDecl *, SourceLoc),
-              Cached, NoLocationInfo)
+              Uncached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, UnderlyingTypeRequest, Type(TypeAliasDecl *),
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, USRGenerationRequest, std::string(const ValueDecl *),

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -134,8 +134,8 @@ namespace swift {
   bool typeCheckExpression(DeclContext *DC, Expr *&parsedExpr);
 
   /// Partially typecheck the specified function body.
-  bool typeCheckAbstractFunctionBodyUntil(AbstractFunctionDecl *AFD,
-                                          SourceLoc EndTypeCheckLoc);
+  bool typeCheckAbstractFunctionBodyNodeAt(AbstractFunctionDecl *AFD,
+                                           SourceLoc TargetLoc);
 
   /// Typecheck top-level code parsed during code completion.
   ///

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -133,9 +133,9 @@ namespace swift {
   /// Typecheck the given expression.
   bool typeCheckExpression(DeclContext *DC, Expr *&parsedExpr);
 
-  /// Partially typecheck the specified function body.
-  bool typeCheckAbstractFunctionBodyNodeAt(AbstractFunctionDecl *AFD,
-                                           SourceLoc TargetLoc);
+  /// Type check a function body element which is at \p TagetLoc .
+  bool typeCheckAbstractFunctionBodyAtLoc(AbstractFunctionDecl *AFD,
+                                          SourceLoc TargetLoc);
 
   /// Typecheck top-level code parsed during code completion.
   ///

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1455,11 +1455,11 @@ void TypeCheckSourceFileRequest::cacheResult(evaluator::SideEffect) const {
 }
 
 //----------------------------------------------------------------------------//
-// TypeCheckFunctionBodyUntilRequest computation.
+// TypeCheckFunctionBodyRequest computation.
 //----------------------------------------------------------------------------//
 
 evaluator::DependencySource
-TypeCheckFunctionBodyUntilRequest::readDependencySource(
+TypeCheckFunctionBodyRequest::readDependencySource(
     const evaluator::DependencyRecorder &e) const {
   // We're going under a function body scope, unconditionally flip the scope
   // to private.

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -5736,7 +5736,9 @@ void CodeCompletionCallbacksImpl::doneParsing() {
 
   typeCheckContextUntil(
       CurDeclContext,
-      CurDeclContext->getASTContext().SourceMgr.getCodeCompletionLoc());
+      ParsedExpr
+          ? ParsedExpr->getLoc()
+          : CurDeclContext->getASTContext().SourceMgr.getCodeCompletionLoc());
 
   // Add keywords even if type checking fails completely.
   addKeywords(CompletionContext.getResultSink(), MaybeFuncBody);

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -5734,7 +5734,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
       CurDeclContext = DC;
   }
 
-  typeCheckContextUntil(
+  typeCheckContextAt(
       CurDeclContext,
       ParsedExpr
           ? ParsedExpr->getLoc()

--- a/lib/IDE/ConformingMethodList.cpp
+++ b/lib/IDE/ConformingMethodList.cpp
@@ -67,9 +67,7 @@ void ConformingMethodListCallbacks::doneParsing() {
   if (!ParsedExpr)
     return;
 
-  typeCheckContextUntil(
-      CurDeclContext,
-      CurDeclContext->getASTContext().SourceMgr.getCodeCompletionLoc());
+  typeCheckContextUntil(CurDeclContext, ParsedExpr->getLoc());
 
   Type T = ParsedExpr->getType();
 

--- a/lib/IDE/ConformingMethodList.cpp
+++ b/lib/IDE/ConformingMethodList.cpp
@@ -67,7 +67,7 @@ void ConformingMethodListCallbacks::doneParsing() {
   if (!ParsedExpr)
     return;
 
-  typeCheckContextUntil(CurDeclContext, ParsedExpr->getLoc());
+  typeCheckContextAt(CurDeclContext, ParsedExpr->getLoc());
 
   Type T = ParsedExpr->getType();
 

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -79,7 +79,7 @@ void typeCheckContextImpl(DeclContext *DC, SourceLoc Loc) {
     auto &SM = DC->getASTContext().SourceMgr;
     auto bodyRange = AFD->getBodySourceRange();
     if (SM.rangeContainsTokenLoc(bodyRange, Loc)) {
-      swift::typeCheckAbstractFunctionBodyUntil(AFD, Loc);
+      swift::typeCheckAbstractFunctionBodyNodeAt(AFD, Loc);
     } else {
       assert(bodyRange.isInvalid() && "The body should not be parsed if the "
                                       "completion happens in the signature");

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -37,7 +37,7 @@ using namespace swift;
 using namespace ide;
 
 //===----------------------------------------------------------------------===//
-// typeCheckContextUntil(DeclContext, SourceLoc)
+// typeCheckContextAt(DeclContext, SourceLoc)
 //===----------------------------------------------------------------------===//
 
 namespace {
@@ -99,7 +99,7 @@ void typeCheckContextImpl(DeclContext *DC, SourceLoc Loc) {
 }
 } // anonymous namespace
 
-void swift::ide::typeCheckContextUntil(DeclContext *DC, SourceLoc Loc) {
+void swift::ide::typeCheckContextAt(DeclContext *DC, SourceLoc Loc) {
   while (isa<AbstractClosureExpr>(DC))
     DC = DC->getParent();
 

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -79,7 +79,7 @@ void typeCheckContextImpl(DeclContext *DC, SourceLoc Loc) {
     auto &SM = DC->getASTContext().SourceMgr;
     auto bodyRange = AFD->getBodySourceRange();
     if (SM.rangeContainsTokenLoc(bodyRange, Loc)) {
-      swift::typeCheckAbstractFunctionBodyNodeAt(AFD, Loc);
+      swift::typeCheckAbstractFunctionBodyAtLoc(AFD, Loc);
     } else {
       assert(bodyRange.isInvalid() && "The body should not be parsed if the "
                                       "completion happens in the signature");
@@ -866,10 +866,10 @@ class ExprContextAnalyzer {
       break;
     }
     default:
-      if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
-        assert(isSingleExpressionBodyForCodeCompletion(AFD->getBody()));
+      if (auto *FD = dyn_cast<FuncDecl>(D)) {
+        assert(isSingleExpressionBodyForCodeCompletion(FD->getBody()));
         singleExpressionBody = true;
-        recordPossibleType(getReturnTypeFromContext(AFD));
+        recordPossibleType(getReturnTypeFromContext(FD));
         break;
       }
       llvm_unreachable("Unhandled decl kind.");
@@ -1003,8 +1003,8 @@ public:
         case DeclKind::PatternBinding:
           return true;
         default:
-          if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D))
-            if (auto *body = AFD->getBody())
+          if (auto *FD = dyn_cast<FuncDecl>(D))
+            if (auto *body = FD->getBody())
               return isSingleExpressionBodyForCodeCompletion(body);
           return false;
         }

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -104,22 +104,7 @@ void swift::ide::typeCheckContextUntil(DeclContext *DC, SourceLoc Loc) {
     DC = DC->getParent();
 
   if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(DC)) {
-    // Typecheck all 'TopLevelCodeDecl's up to the target one.
-    // In theory, this is not needed, but it fails to resolve the type of
-    // 'guard'ed variable. e.g.
-    //
-    //   guard value = something() else { fatalError() }
-    //   <complete>
-    // Here, 'value' is '<error type>' unless we explicitly typecheck the
-    // 'guard' statement.
-    SourceFile *SF = DC->getParentSourceFile();
-    for (auto *D : SF->getTopLevelDecls()) {
-      if (auto Code = dyn_cast<TopLevelCodeDecl>(D)) {
-        typeCheckTopLevelCodeDecl(Code);
-        if (Code == TLCD)
-          break;
-      }
-    }
+    typeCheckTopLevelCodeDecl(TLCD);
   } else {
     typeCheckContextImpl(DC, Loc);
   }

--- a/lib/IDE/ExprContextAnalysis.h
+++ b/lib/IDE/ExprContextAnalysis.h
@@ -28,7 +28,7 @@ enum class SemanticContextKind;
 
 /// Type check parent contexts of the given decl context, and the body of the
 /// given context until \c Loc if the context is a function body.
-void typeCheckContextUntil(DeclContext *DC, SourceLoc Loc);
+void typeCheckContextAt(DeclContext *DC, SourceLoc Loc);
 
 /// From \p DC, find and returns the outer most expression which source range is
 /// exact the same as \p TargetRange. Returns \c nullptr if not found.

--- a/lib/IDE/TypeContextInfo.cpp
+++ b/lib/IDE/TypeContextInfo.cpp
@@ -88,9 +88,7 @@ void ContextInfoCallbacks::doneParsing() {
   if (!ParsedExpr)
     return;
 
-  typeCheckContextUntil(
-      CurDeclContext,
-      CurDeclContext->getASTContext().SourceMgr.getCodeCompletionLoc());
+  typeCheckContextUntil(CurDeclContext, ParsedExpr->getLoc());
 
   ExprContextInfo Info(CurDeclContext, ParsedExpr);
 

--- a/lib/IDE/TypeContextInfo.cpp
+++ b/lib/IDE/TypeContextInfo.cpp
@@ -88,7 +88,7 @@ void ContextInfoCallbacks::doneParsing() {
   if (!ParsedExpr)
     return;
 
-  typeCheckContextUntil(CurDeclContext, ParsedExpr->getLoc());
+  typeCheckContextAt(CurDeclContext, ParsedExpr->getLoc());
 
   ExprContextInfo Info(CurDeclContext, ParsedExpr);
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2564,6 +2564,29 @@ bool TypeChecker::typeCheckStmtCondition(StmtCondition &cond, DeclContext *dc,
   return false;
 }
 
+bool TypeChecker::typeCheckConditionForStatement(LabeledConditionalStmt *stmt,
+                                                 DeclContext *dc) {
+  Diag<> diagnosticForAlwaysTrue = diag::invalid_diagnostic;
+  switch (stmt->getKind()) {
+  case StmtKind::If:
+    diagnosticForAlwaysTrue = diag::if_always_true;
+    break;
+  case StmtKind::While:
+    diagnosticForAlwaysTrue = diag::while_always_true;
+    break;
+  case StmtKind::Guard:
+    diagnosticForAlwaysTrue = diag::guard_always_succeeds;
+    break;
+  default:
+    llvm_unreachable("unknown LabeledConditionalStmt kind");
+  }
+
+  StmtCondition cond = stmt->getCond();
+  bool result = typeCheckStmtCondition(cond, dc, diagnosticForAlwaysTrue);
+  stmt->setCond(cond);
+  return result;
+}
+
 /// Find the '~=` operator that can compare an expression inside a pattern to a
 /// value of a given type.
 bool TypeChecker::typeCheckExprPattern(ExprPattern *EP, DeclContext *DC,

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2355,23 +2355,23 @@ bool TypeChecker::typeCheckBinding(
   if (!initializer->getType())
     initializer->setType(ErrorType::get(Context));
 
-  // If the type of the pattern is inferred, assign error types to the pattern
-  // and its variables, to prevent it from being referenced by the constraint
-  // system.
+  // Assign error types to the pattern and its variables, to prevent it from
+  // being referenced by the constraint system.
   if (patternType->hasUnresolvedType() ||
       patternType->hasUnboundGenericType()) {
     pattern->setType(ErrorType::get(Context));
-    pattern->forEachVariable([&](VarDecl *var) {
-      // Don't change the type of a variable that we've been able to
-      // compute a type for.
-      if (var->hasInterfaceType() &&
-          !var->getType()->hasUnboundGenericType() &&
-          !var->isInvalid())
-        return;
-
-      var->setInvalid();
-    });
   }
+
+  pattern->forEachVariable([&](VarDecl *var) {
+    // Don't change the type of a variable that we've been able to
+    // compute a type for.
+    if (var->hasInterfaceType() &&
+        !var->getType()->hasUnboundGenericType() &&
+        !var->isInvalid())
+      return;
+
+    var->setInvalid();
+  });
   return true;
 }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2360,23 +2360,33 @@ NamingPatternRequest::evaluate(Evaluator &evaluator, VarDecl *VD) const {
   if (!namingPattern) {
     auto *canVD = VD->getCanonicalVarDecl();
     namingPattern = canVD->NamingPattern;
+  }
 
+  if (!namingPattern) {
+    // Try type checking parent conditional statement.
+    if (auto parentStmt = VD->getParentPatternStmt()) {
+      if (auto LCS = dyn_cast<LabeledConditionalStmt>(parentStmt)) {
+        TypeChecker::typeCheckConditionForStatement(LCS, VD->getDeclContext());
+        namingPattern = VD->NamingPattern;
+      }
+    }
+  }
+
+  if (!namingPattern) {
     // HACK: If no other diagnostic applies, emit a generic diagnostic about
     // a variable being unbound. We can't do better than this at the
     // moment because TypeCheckPattern does not reliably invalidate parts of
     // the pattern AST on failure.
     //
     // Once that's through, this will only fire during circular validation.
-    if (!namingPattern) {
-      if (VD->hasInterfaceType() &&
-          !VD->isInvalid() && !VD->getParentPattern()->isImplicit()) {
-        VD->diagnose(diag::variable_bound_by_no_pattern, VD->getName());
-      }
-
-      VD->getParentPattern()->setType(ErrorType::get(Context));
-      setBoundVarsTypeError(VD->getParentPattern(), Context);
-      return nullptr;
+    if (VD->hasInterfaceType() &&
+        !VD->isInvalid() && !VD->getParentPattern()->isImplicit()) {
+      VD->diagnose(diag::variable_bound_by_no_pattern, VD->getName());
     }
+
+    VD->getParentPattern()->setType(ErrorType::get(Context));
+    setBoundVarsTypeError(VD->getParentPattern(), Context);
+    return nullptr;
   }
 
   if (!namingPattern->hasType()) {

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -625,9 +625,7 @@ public:
   }
   
   Stmt *visitIfStmt(IfStmt *IS) {
-    StmtCondition C = IS->getCond();
-    TypeChecker::typeCheckStmtCondition(C, DC, diag::if_always_true);
-    IS->setCond(C);
+    TypeChecker::typeCheckConditionForStatement(IS, DC);
 
     AddLabeledStmt ifNest(*this, IS);
 
@@ -644,10 +642,8 @@ public:
   }
   
   Stmt *visitGuardStmt(GuardStmt *GS) {
-    StmtCondition C = GS->getCond();
-    TypeChecker::typeCheckStmtCondition(C, DC, diag::guard_always_succeeds);
-    GS->setCond(C);
-    
+    TypeChecker::typeCheckConditionForStatement(GS, DC);
+
     AddLabeledStmt ifNest(*this, GS);
     
     Stmt *S = GS->getBody();
@@ -665,9 +661,7 @@ public:
   }
   
   Stmt *visitWhileStmt(WhileStmt *WS) {
-    StmtCondition C = WS->getCond();
-    TypeChecker::typeCheckStmtCondition(C, DC, diag::while_always_true);
-    WS->setCond(C);
+    TypeChecker::typeCheckConditionForStatement(WS, DC);
 
     AddLabeledStmt loopNest(*this, WS);
     Stmt *S = WS->getBody();

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -540,11 +540,12 @@ bool swift::typeCheckExpression(DeclContext *DC, Expr *&parsedExpr) {
   return !resultTy;
 }
 
-bool swift::typeCheckAbstractFunctionBodyUntil(AbstractFunctionDecl *AFD,
-                                               SourceLoc EndTypeCheckLoc) {
+bool swift::typeCheckAbstractFunctionBodyNodeAt(AbstractFunctionDecl *AFD,
+                                                SourceLoc TargetLoc) {
   auto &Ctx = AFD->getASTContext();
   DiagnosticSuppression suppression(Ctx.Diags);
-  return !TypeChecker::typeCheckAbstractFunctionBodyUntil(AFD, EndTypeCheckLoc);
+  return !evaluateOrDefault(Ctx.evaluator,
+                            TypeCheckFunctionBodyRequest{AFD, TargetLoc}, true);
 }
 
 bool swift::typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD) {

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -540,12 +540,13 @@ bool swift::typeCheckExpression(DeclContext *DC, Expr *&parsedExpr) {
   return !resultTy;
 }
 
-bool swift::typeCheckAbstractFunctionBodyNodeAt(AbstractFunctionDecl *AFD,
-                                                SourceLoc TargetLoc) {
+bool swift::typeCheckAbstractFunctionBodyAtLoc(AbstractFunctionDecl *AFD,
+                                               SourceLoc TargetLoc) {
   auto &Ctx = AFD->getASTContext();
   DiagnosticSuppression suppression(Ctx.Diags);
   return !evaluateOrDefault(Ctx.evaluator,
-                            TypeCheckFunctionBodyRequest{AFD, TargetLoc}, true);
+                            TypeCheckFunctionBodyAtLocRequest{AFD, TargetLoc},
+                            true);
 }
 
 bool swift::typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -763,16 +763,6 @@ bool typeCheckCondition(Expr *&expr, DeclContext *dc);
 bool typeCheckConditionForStatement(LabeledConditionalStmt *stmt,
                                     DeclContext *dc);
 
-/// Type check the given 'if', 'while', or 'guard' statement condition, which
-/// either converts an expression to a logic value or bind variables to the
-/// contents of an Optional.
-///
-/// \param cond The condition to type-check, which will be modified in place.
-///
-/// \returns true if an error occurred, false otherwise.
-bool typeCheckStmtCondition(StmtCondition &cond, DeclContext *dc,
-                            Diag<> diagnosticForAlwaysTrue);
-
 /// Determine the semantics of a checked cast operation.
 ///
 /// \param fromType       The source type of the cast.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -547,8 +547,6 @@ bool typesSatisfyConstraint(Type t1, Type t2, bool openArchetypes,
 /// of the function, set the result type of the expression to that sugar type.
 Expr *substituteInputSugarTypeForResult(ApplyExpr *E);
 
-bool typeCheckAbstractFunctionBodyUntil(AbstractFunctionDecl *AFD,
-                                        SourceLoc EndTypeCheckLoc);
 bool typeCheckAbstractFunctionBody(AbstractFunctionDecl *AFD);
 
 /// Try to apply the function builder transform of the given builder type

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -756,7 +756,16 @@ void checkSwitchExhaustiveness(const SwitchStmt *stmt, const DeclContext *DC,
 /// \returns true if an error occurred, false otherwise.
 bool typeCheckCondition(Expr *&expr, DeclContext *dc);
 
-/// Type check the given 'if' or 'while' statement condition, which
+/// Type check the given 'if', 'while', or 'guard' statement condition.
+///
+/// \param stmt The conditional statement to type-check, which will be modified
+/// in place.
+///
+/// \returns true if an error occurred, false otherwise.
+bool typeCheckConditionForStatement(LabeledConditionalStmt *stmt,
+                                    DeclContext *dc);
+
+/// Type check the given 'if', 'while', or 'guard' statement condition, which
 /// either converts an expression to a logic value or bind variables to the
 /// contents of an Optional.
 ///

--- a/test/IDE/complete_skipbody.swift
+++ b/test/IDE/complete_skipbody.swift
@@ -1,0 +1,26 @@
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token COMPLETE -debug-forbid-typecheck-prefix FORBIDDEN | %FileCheck %s
+struct FORBIDDEN_Struct {
+  func FORBIDDEN_method() -> Int? { 1 }
+}
+
+struct MyStruct {
+  var x: Int { 1 }
+  var y: Int { 1 }
+}
+
+func test(value: MyStruct) {
+
+  let FORBIDDEN_localVar = 1
+  let unrelated = FORBIDDEN_Struct()
+  guard let a = unrelated.FORBIDDEN_method() else {
+    return
+  }
+
+  _ = value.#^COMPLETE^#
+}
+
+// CHECK: Begin completions, 3 items
+// CHECK-DAG: Keyword[self]/CurrNominal:          self[#MyStruct#]; name=self
+// CHECK-DAG: Decl[InstanceVar]/CurrNominal:      x[#Int#]; name=x
+// CHECK-DAG: Decl[InstanceVar]/CurrNominal:      y[#Int#]; name=y
+// CHECK: End completions

--- a/test/IDE/complete_skipbody.swift
+++ b/test/IDE/complete_skipbody.swift
@@ -1,4 +1,6 @@
-// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token COMPLETE -debug-forbid-typecheck-prefix FORBIDDEN | %FileCheck %s
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token FUNCTIONBODY -debug-forbid-typecheck-prefix FORBIDDEN | %FileCheck %s
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token TOPLEVEL -debug-forbid-typecheck-prefix FORBIDDEN | %FileCheck %s
+
 struct FORBIDDEN_Struct {
   func FORBIDDEN_method() -> Int? { 1 }
 }
@@ -6,6 +8,13 @@ struct FORBIDDEN_Struct {
 struct MyStruct {
   var x: Int { 1 }
   var y: Int { 1 }
+}
+
+let globalUnrelated = FORBIDDEN_Struct();
+
+guard let globalValueOpt = MyStruct() as MyStruct?? else {
+  let localUnrelated = FORBIDDEN_Struct();
+  fatalError()
 }
 
 func test(valueOptOpt: MyStruct??) {
@@ -20,13 +29,25 @@ func test(valueOptOpt: MyStruct??) {
   }
 
   guard let value = valueOpt else {
+    let FORBIDDEN_localVar2 = 1
     return
   }
 
   if (value.x == 1) {
     let unrelated2 = FORBIDDEN_Struct()
-    _ = value.#^COMPLETE^#
+    _ = value.#^FUNCTIONBODY^#
   }
+}
+
+let globalValue = globalValueOpt!
+
+let FORBIDDEN_localVar = 1
+
+switch glovalValue.x {
+case let x where x < 2:
+  if x == globalValue.#^TOPLEVEL^# {}
+default:
+  break
 }
 
 // CHECK: Begin completions, 3 items

--- a/test/IDE/complete_skipbody.swift
+++ b/test/IDE/complete_skipbody.swift
@@ -35,13 +35,19 @@ func test(valueOptOpt: MyStruct??) {
 
   if (value.x == 1) {
     let unrelated2 = FORBIDDEN_Struct()
-    _ = value.#^FUNCTIONBODY^#
+    switch value.x {
+    case let x where x < 2:
+      let unrelated3 = FORBIDDEN_Struct()
+      if x == value.#^FUNCTIONBODY^# {}
+    default:
+      break
+    }
   }
 }
 
 let globalValue = globalValueOpt!
 
-let FORBIDDEN_localVar = 1
+let FORBIDDEN_globalVar = 1
 
 switch glovalValue.x {
 case let x where x < 2:

--- a/test/IDE/complete_skipbody.swift
+++ b/test/IDE/complete_skipbody.swift
@@ -8,15 +8,25 @@ struct MyStruct {
   var y: Int { 1 }
 }
 
-func test(value: MyStruct) {
+func test(valueOptOpt: MyStruct??) {
 
   let FORBIDDEN_localVar = 1
   let unrelated = FORBIDDEN_Struct()
+
+  let valueOpt = valueOptOpt!
+
   guard let a = unrelated.FORBIDDEN_method() else {
     return
   }
 
-  _ = value.#^COMPLETE^#
+  guard let value = valueOpt else {
+    return
+  }
+
+  if (value.x == 1) {
+    let unrelated2 = FORBIDDEN_Struct()
+    _ = value.#^COMPLETE^#
+  }
 }
 
 // CHECK: Begin completions, 3 items

--- a/test/Misc/stats_dir_profiler.swift
+++ b/test/Misc/stats_dir_profiler.swift
@@ -7,7 +7,7 @@
 // RUN: %FileCheck -check-prefix=ENTITIES -input-file %t/stats-entities/*.dir/Time.User.entities %s
 
 // EVENTS: {{perform-sema;.*;typecheck-decl.* [0-9]+}}
-// ENTITIES: {{perform-sema;.*;TypeCheckFunctionBodyUntilRequest bar\(\);typecheck-stmt.* [0-9]+}}
+// ENTITIES: {{perform-sema;.*;TypeCheckFunctionBodyRequest bar\(\);typecheck-stmt.* [0-9]+}}
 
 public func foo() {
     print("hello")

--- a/validation-test/compiler_scale/scale_neighbouring_getset.gyb
+++ b/validation-test/compiler_scale/scale_neighbouring_getset.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select TypeCheckFunctionBodyUntilRequest %s
+// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select TypeCheckFunctionBodyRequest %s
 // REQUIRES: asserts
 
 struct Struct${N} {


### PR DESCRIPTION
For example:
```swift
func foo(x: Int) {
  ...
  var unrelatedVar = 1 + ...
  ...
  _ = x.<HERE>
  ...
}
```
We don't need to type check `unrelatedVar` and any other statements in the body because they don't affect the completion result at all.

- In `StmtChecker::visitBraceStmt()`, skip elements until the target source location. Only type check the element at the location, and let it typechecking dependent declarations on demand.
- Renamed `typeCheckAbstractFunctionBodyUntil()` to `typeCheckAbstractFunctionBodyNodeAt()` because "until" is not relevant now.
- In `NamingPatternRequest`, type check statement conditions on demand.

rdar://problem/58687608