### PR TITLE
[Index][SR-12903] Index `@objc optional` references

### DIFF
--- a/include/swift/AST/ASTWalker.h
+++ b/include/swift/AST/ASTWalker.h
@@ -37,6 +37,7 @@ enum class SemaReferenceKind : uint8_t {
   TypeRef,
   EnumElementRef,
   SubscriptRef,
+  DynamicMemberRef,
 };
 
 struct ReferenceMetaData {

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -511,6 +511,12 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
 
       return doSkipChildren();
     }
+  } else if (auto DMRE = dyn_cast<DynamicMemberRefExpr>(E)) {
+    if (!passReference(DMRE->getMember().getDecl(), DMRE->getType(),
+                       DMRE->getNameLoc(),
+                       ReferenceMetaData(SemaReferenceKind::DynamicMemberRef,
+                                         OpAccess)))
+        return stopTraversal;
   }
 
   return { true, E };

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -512,11 +512,16 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
       return doSkipChildren();
     }
   } else if (auto DMRE = dyn_cast<DynamicMemberRefExpr>(E)) {
+    // Visit in source order.
+    if (!DMRE->getBase()->walk(*this))
+        return stopTraversal;
     if (!passReference(DMRE->getMember().getDecl(), DMRE->getType(),
                        DMRE->getNameLoc(),
                        ReferenceMetaData(SemaReferenceKind::DynamicMemberRef,
                                          OpAccess)))
         return stopTraversal;
+    // We already visited the children.
+    return doSkipChildren();
   }
 
   return { true, E };

--- a/test/Index/index_objc_dynamic_refs.swift
+++ b/test/Index/index_objc_dynamic_refs.swift
@@ -17,10 +17,10 @@ class AClass {
 
     func doSomething() {
         objcDelegate?.dynamicMethod?()
-        // CHECK: [[@LINE-1]]:23 | instance-method/Swift | dynamicMethod() | [[DynamicMethod_USR]] | Ref
-        // CHECK: [[@LINE-2]]:9 | instance-property/Swift | objcDelegate | [[Delegate_USR]] | Ref
+        // CHECK: [[@LINE-1]]:9 | instance-property/Swift | objcDelegate | [[Delegate_USR]] | Ref
+        // CHECK: [[@LINE-2]]:23 | instance-method/Swift | dynamicMethod() | [[DynamicMethod_USR]] | Ref
         _ = objcDelegate?.property
-        // CHECK: [[@LINE-1]]:27 | instance-property/Swift | property | [[DynamicProperty_USR]] | Ref
-        // CHECK: [[@LINE-2]]:13 | instance-property/Swift | objcDelegate | [[Delegate_USR]] | Ref
+        // CHECK: [[@LINE-1]]:13 | instance-property/Swift | objcDelegate | [[Delegate_USR]] | Ref
+        // CHECK: [[@LINE-2]]:27 | instance-property/Swift | property | [[DynamicProperty_USR]] | Ref
     }
 }

--- a/test/Index/index_objc_dynamic_refs.swift
+++ b/test/Index/index_objc_dynamic_refs.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc protocol AProtocol {
+    @objc optional func dynamicMethod()
+    // CHECK: [[@LINE-1]]:25 | instance-method/Swift | dynamicMethod() | [[DynamicMethod_USR:.*]] | Def
+    @objc optional var property: String { get }
+    // CHECK: [[@LINE-1]]:24 | instance-property/Swift | property | [[DynamicProperty_USR:.*]] | Def
+}
+
+class AClass {
+
+    weak var objcDelegate: AProtocol?
+    // CHECK: [[@LINE-1]]:14 | instance-property/Swift | objcDelegate | [[Delegate_USR:.*]] | Def
+
+    func doSomething() {
+        objcDelegate?.dynamicMethod?()
+        // CHECK: [[@LINE-1]]:23 | instance-method/Swift | dynamicMethod() | [[DynamicMethod_USR]] | Ref
+        // CHECK: [[@LINE-2]]:9 | instance-property/Swift | objcDelegate | [[Delegate_USR]] | Ref
+        _ = objcDelegate?.property
+        // CHECK: [[@LINE-1]]:27 | instance-property/Swift | property | [[DynamicProperty_USR]] | Ref
+        // CHECK: [[@LINE-2]]:13 | instance-property/Swift | objcDelegate | [[Delegate_USR]] | Ref
+    }
+}


### PR DESCRIPTION
Declarations of objc optional methods were indexed, but their references weren't.

```swift
import Foundation

@objc protocol Foo {
    @objc optional func bar()
}

class Sample {

    weak var delegate: Foo?

    func doSomething() {
        delegate?.bar()
    }
}
```

The `bar()` call was left unindexed. This provides a fix by walking `DynamicMemberRefExpr`s.
