### PR TITLE
Make an internal KeyPath helper final.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -126,7 +126,7 @@ DECL_ATTR(available, Available,
 CONTEXTUAL_SIMPLE_DECL_ATTR(final, Final,
   OnClass | OnFunc | OnAccessor | OnVar | OnSubscript |
   DeclModifier |
-  ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIStableToRemove,
+  ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
   2)
 DECL_ATTR(objc, ObjC,
   OnAbstractFunction | OnClass | OnProtocol | OnExtension | OnVar |

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -14,6 +14,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#define DEBUG_TYPE "type-metadata-layout"
+
 #include "swift/ABI/MetadataValues.h"
 #include "swift/ABI/TypeIdentity.h"
 #include "swift/AST/ASTContext.h"
@@ -1520,6 +1522,15 @@ namespace {
     void addVTable() {
       if (VTableEntries.empty())
         return;
+      
+      LLVM_DEBUG(
+        llvm::dbgs() << "VTable entries for " << getType()->getName() << ":\n";
+        for (auto entry : VTableEntries) {
+          llvm::dbgs() << "  ";
+          entry.print(llvm::dbgs());
+          llvm::dbgs() << '\n';
+        }
+      );
 
       // Only emit a method lookup function if the class is resilient
       // and has a non-empty vtable.

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -134,6 +134,7 @@ public class AnyKeyPath: Hashable, _AppendKeyPath {
   
   // Prevent normal initialization. We use tail allocation via
   // allocWithTailElems().
+  @available(*, unavailable)
   internal init() {
     _internalInvariantFailure("use _create(...)")
   }
@@ -158,7 +159,7 @@ public class AnyKeyPath: Hashable, _AppendKeyPath {
     return result
   }
   
-  internal func withBuffer<T>(_ f: (KeyPathBuffer) throws -> T) rethrows -> T {
+  final internal func withBuffer<T>(_ f: (KeyPathBuffer) throws -> T) rethrows -> T {
     defer { _fixLifetime(self) }
     
     let base = UnsafeRawPointer(Builtin.projectTailElems(self, Int32.self))
@@ -347,14 +348,6 @@ public class ReferenceWritableKeyPath<
   // MARK: Implementation detail
 
   internal final override class var kind: Kind { return .reference }
-  
-  internal final override func _projectMutableAddress(
-    from base: UnsafePointer<Root>
-  ) -> (pointer: UnsafeMutablePointer<Value>, owner: AnyObject?) {
-    // Since we're a ReferenceWritableKeyPath, we know we don't mutate the base
-    // in practice.
-    return _projectMutableAddress(from: base.pointee)
-  }
   
   @usableFromInline
   internal final func _projectMutableAddress(from origBase: Root)

--- a/test/api-digester/Outputs/Cake.txt
+++ b/test/api-digester/Outputs/Cake.txt
@@ -40,7 +40,6 @@ cake: TypeAlias TChangesFromIntToString.T has underlying type change from Swift.
 /* Decl Attribute changes */
 cake: Enum IceKind is now without @frozen
 cake: Func C1.foo1() is now not static
-cake: Func FinalFuncContainer.NewFinalFunc() is now with final
 cake: Func HasMutatingMethodClone.foo() has self access kind changing from Mutating to NonMutating
 cake: Func S1.foo1() has self access kind changing from NonMutating to Mutating
 cake: Func S1.foo3() is now static


### PR DESCRIPTION
And remove an unnecessary override, so that further work will allow this method not to need a
vtable entry.