### PR TITLE
[Frontend] Bail early if the stdlib is missing

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -646,10 +646,11 @@ private:
 public:
   void freeASTContext();
 
-private:
-  /// Load stdlib & return true if should continue, i.e. no error
-  bool loadStdlib();
+  /// If an implicit standard library import is expected, loads the standard
+  /// library, returning \c false if we should continue, i.e. no error.
+  bool loadStdlibIfNeeded();
 
+private:
   /// Retrieve a description of which modules should be implicitly imported.
   ImplicitImportInfo getImplicitImportInfo() const;
 

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2734,8 +2734,8 @@ public:
       const DeclContext *DC = GTPD->getDeclContext();
 
       // Skip verification of deserialized generic param decls that have the
-      // the file set as their parent. This happens when they have not yet had
-      // their correct parent set.
+      // file set as their parent. This happens when they have not yet had their
+      // correct parent set.
       // FIXME: This is a hack to workaround the fact that we don't necessarily
       // parent a GenericTypeParamDecl if we just deserialize its type.
       if (auto *fileDC = dyn_cast<FileUnit>(DC)) {

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -740,17 +740,6 @@ void CompilerInstance::performSemaUpTo(SourceFile::ASTStage_t LimitStage,
   ModuleDecl *mainModule = getMainModule();
   Context->LoadedModules[mainModule->getName()] = mainModule;
 
-  // If we aren't in a parse-only context, load the standard library.
-  if (LimitStage > SourceFile::Unprocessed &&
-      Invocation.getImplicitStdlibKind() == ImplicitStdlibKind::Stdlib
-      && !loadStdlib()) {
-    // If we failed to load the stdlib, mark the main module as having
-    // "failed to load", as it will contain no files.
-    // FIXME: We need to better handle a missing stdlib.
-    mainModule->setFailedToLoad();
-    return;
-  }
-
   // Make sure the main file is the first file in the module, so do this now.
   if (MainBufferID != NO_SUCH_BUFFER) {
     auto *mainFile = createSourceFileForMainModule(
@@ -813,23 +802,27 @@ void CompilerInstance::performSemaUpTo(SourceFile::ASTStage_t LimitStage,
   finishTypeChecking();
 }
 
-bool CompilerInstance::loadStdlib() {
+bool CompilerInstance::loadStdlibIfNeeded() {
+  // If we aren't expecting an implicit stdlib import, there's nothing to do.
+  if (getImplicitImportInfo().StdlibKind != ImplicitStdlibKind::Stdlib)
+    return false;
+
   FrontendStatsTracer tracer(getStatsReporter(), "load-stdlib");
-  ModuleDecl *M = Context->getStdlibModule(true);
+  ModuleDecl *M = Context->getStdlibModule(/*loadIfAbsent*/ true);
 
   if (!M) {
     Diagnostics.diagnose(SourceLoc(), diag::error_stdlib_not_found,
                          Invocation.getTargetTriple());
-    return false;
+    return true;
   }
 
-  // If we failed to load, we should have already diagnosed
+  // If we failed to load, we should have already diagnosed.
   if (M->failedToLoad()) {
     assert(Diagnostics.hadAnyError() &&
            "Module failed to load but nothing was diagnosed?");
-    return false;
+    return true;
   }
-  return true;
+  return false;
 }
 
 bool CompilerInstance::loadPartialModulesAndImplicitImports() {


### PR DESCRIPTION
Rather than trying to continue the compilation with an empty main module, let's bail out early if we expect an implicit stdlib import and fail to load in the stdlib.