### PR TITLE
runtime: extract `swiftDemangling` into a support library

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -50,6 +50,34 @@ endif()
 
 add_subdirectory(SwiftShims)
 
+# This static library is shared across swiftCore and swiftReflection
+if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)
+  # TODO: due to the use of `add_swift_target_library` rather than `add_library`
+  # we cannot use `target_sources` and thus must resort to list manipulations to
+  # adjust the source list.
+  set(swiftDemanglingSources
+    "${SWIFT_SOURCE_DIR}/lib/Demangling/Context.cpp"
+    "${SWIFT_SOURCE_DIR}/lib/Demangling/Demangler.cpp"
+    "${SWIFT_SOURCE_DIR}/lib/Demangling/ManglingUtils.cpp"
+    "${SWIFT_SOURCE_DIR}/lib/Demangling/NodePrinter.cpp"
+    "${SWIFT_SOURCE_DIR}/lib/Demangling/OldDemangler.cpp"
+    "${SWIFT_SOURCE_DIR}/lib/Demangling/OldRemangler.cpp"
+    "${SWIFT_SOURCE_DIR}/lib/Demangling/Punycode.cpp"
+    "${SWIFT_SOURCE_DIR}/lib/Demangling/Remangler.cpp")
+
+  # When we're building with assertions, include the demangle node dumper to aid
+  # in debugging.
+  if(LLVM_ENABLE_ASSERTIONS)
+    list(APPEND swiftDemanglingSources
+      "${SWIFT_SOURCE_DIR}/lib/Demangling/NodeDumper.cpp")
+  endif()
+
+  add_swift_target_library(swiftDemangling OBJECT_LIBRARY
+    ${swiftDemanglingSources}
+    C_COMPILE_FLAGS -DswiftCore_EXPORTS
+    INSTALL_IN_COMPONENT never_install)
+endif()
+
 if(SWIFT_BUILD_STDLIB)
   # These must be kept in dependency order so that any referenced targets
   # exist at the time we look for them in add_swift_*.

--- a/stdlib/public/Reflection/CMakeLists.txt
+++ b/stdlib/public/Reflection/CMakeLists.txt
@@ -2,26 +2,13 @@ set(swiftReflection_SOURCES
   MetadataSource.cpp
   TypeLowering.cpp
   TypeRef.cpp
-  TypeRefBuilder.cpp
-  "${SWIFT_SOURCE_DIR}/lib/Demangling/Context.cpp"
-  "${SWIFT_SOURCE_DIR}/lib/Demangling/OldDemangler.cpp"
-  "${SWIFT_SOURCE_DIR}/lib/Demangling/Demangler.cpp"
-  "${SWIFT_SOURCE_DIR}/lib/Demangling/NodePrinter.cpp"
-  "${SWIFT_SOURCE_DIR}/lib/Demangling/ManglingUtils.cpp"
-  "${SWIFT_SOURCE_DIR}/lib/Demangling/Punycode.cpp"
-  "${SWIFT_SOURCE_DIR}/lib/Demangling/Remangler.cpp")
-
-# When we're building with assertions, include the demangle node dumper to aid
-# in debugging.
-if (LLVM_ENABLE_ASSERTIONS)
-  list(APPEND swiftReflection_SOURCES
-    "${SWIFT_SOURCE_DIR}/lib/Demangling/NodeDumper.cpp")
-endif(LLVM_ENABLE_ASSERTIONS)
+  TypeRefBuilder.cpp)
 
 add_swift_target_library(swiftReflection STATIC
   ${swiftReflection_SOURCES}
   C_COMPILE_FLAGS ${SWIFT_RUNTIME_CXX_FLAGS} -DswiftCore_EXPORTS
   LINK_FLAGS ${SWIFT_RUNTIME_LINK_FLAGS}
-  INCORPORATE_OBJECT_LIBRARIES swiftLLVMSupport
+  INCORPORATE_OBJECT_LIBRARIES
+    swiftLLVMSupport swiftDemangling
   SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   INSTALL_IN_COMPONENT dev)

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -321,7 +321,7 @@ add_swift_target_library(swiftCore
                   PRIVATE_LINK_LIBRARIES
                     ${swift_core_private_link_libraries}
                   INCORPORATE_OBJECT_LIBRARIES
-                    swiftRuntime swiftLLVMSupport swiftStdlibStubs
+                    swiftRuntime swiftLLVMSupport swiftDemangling swiftStdlibStubs
                   FRAMEWORK_DEPENDS
                     ${swift_core_framework_depends}
                   INSTALL_IN_COMPONENT

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -23,10 +23,7 @@ set(swift_runtime_objc_sources
     SwiftObject.mm
     SwiftValue.mm
     ReflectionMirror.mm
-    ObjCRuntimeGetImageNameFromClass.mm
-    "${SWIFT_SOURCE_DIR}/lib/Demangling/OldRemangler.cpp"
-    "${SWIFT_SOURCE_DIR}/lib/Demangling/Remangler.cpp"
-    )
+    ObjCRuntimeGetImageNameFromClass.mm)
 
 set(swift_runtime_sources
     AnyHashableSupport.cpp
@@ -62,19 +59,7 @@ set(swift_runtime_sources
     ProtocolConformance.cpp
     RefCount.cpp
     RuntimeInvocationsTracking.cpp
-    SwiftDtoa.cpp
-    "${SWIFT_SOURCE_DIR}/lib/Demangling/OldDemangler.cpp"
-    "${SWIFT_SOURCE_DIR}/lib/Demangling/Demangler.cpp"
-    "${SWIFT_SOURCE_DIR}/lib/Demangling/NodePrinter.cpp"
-    "${SWIFT_SOURCE_DIR}/lib/Demangling/Context.cpp"
-    "${SWIFT_SOURCE_DIR}/lib/Demangling/ManglingUtils.cpp"
-    "${SWIFT_SOURCE_DIR}/lib/Demangling/Punycode.cpp")
-
-# When we're building with assertions, include the demangle node dumper to aid
-# in debugging.
-if (LLVM_ENABLE_ASSERTIONS)
-  list(APPEND swift_runtime_sources "${SWIFT_SOURCE_DIR}/lib/Demangling/NodeDumper.cpp")
-endif(LLVM_ENABLE_ASSERTIONS)
+    SwiftDtoa.cpp)
 
 # Acknowledge that the following sources are known.
 set(LLVM_OPTIONAL_SOURCES
@@ -174,7 +159,6 @@ add_swift_target_library(swiftRuntime OBJECT_LIBRARY
     ${swift_runtime_library_compile_flags}
     ${_RUNTIME_NONATOMIC_FLAGS}
   LINK_FLAGS ${swift_runtime_linker_flags}
-  INCORPORATE_OBJECT_LIBRARIES swiftLLVMSupport
   SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   INSTALL_IN_COMPONENT never_install)
 

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -75,6 +75,7 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     # and the stdlib.
     $<TARGET_OBJECTS:swiftRuntime${SWIFT_PRIMARY_VARIANT_SUFFIX}>
     $<TARGET_OBJECTS:swiftLLVMSupport${SWIFT_PRIMARY_VARIANT_SUFFIX}>
+    $<TARGET_OBJECTS:swiftDemangling${SWIFT_PRIMARY_VARIANT_SUFFIX}>
     )
 
   # The local stdlib implementation provides definitions of the swiftCore

--- a/unittests/runtime/LongTests/CMakeLists.txt
+++ b/unittests/runtime/LongTests/CMakeLists.txt
@@ -38,6 +38,7 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     # and the stdlib.
     $<TARGET_OBJECTS:swiftRuntime${SWIFT_PRIMARY_VARIANT_SUFFIX}>
     $<TARGET_OBJECTS:swiftLLVMSupport${SWIFT_PRIMARY_VARIANT_SUFFIX}>
+    $<TARGET_OBJECTS:swiftDemangling${SWIFT_PRIMARY_VARIANT_SUFFIX}>
     )
 
   # The local stdlib implementation provides definitions of the swiftCore


### PR DESCRIPTION
`swiftDemangling` was built three times:
1. swiftc
2. swiftRuntime
3. swiftReflection

Fold the last two instances into a single build, sharing the objects
across both the target libraries.  This ensures that `swiftDemangling`
is built with the same compiler as the target libraries and that the
target library build remains self-contained.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
