### PR TITLE
[ConstraintSystem] Add missing handling of `Stmt *` to `getLoc`

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4530,6 +4530,8 @@ SourceLoc constraints::getLoc(ASTNode anchor) {
     if (auto VD = dyn_cast<VarDecl>(V))
       return VD->getNameLoc();
     return anchor.getStartLoc();
+  } else if (auto *S = anchor.dyn_cast<Stmt *>()) {
+    return S->getStartLoc();
   } else {
     return anchor.get<Pattern *>()->getLoc();
   }


### PR DESCRIPTION
Something I have noticed while debugging a problem.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
