### PR TITLE
Add a demangler option to hide a current module.

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -42,7 +42,6 @@ std::string genericParameterName(uint64_t depth, uint64_t index);
 /// Display style options for the demangler.
 struct DemangleOptions {
   bool SynthesizeSugarOnTypes = false;
-  bool DisplayDebuggerGeneratedModule = true;
   bool QualifyEntities = true;
   bool DisplayExtensionContexts = true;
   bool DisplayUnmangledSuffix = true;
@@ -57,6 +56,8 @@ struct DemangleOptions {
   bool ShortenArchetype = false;
   bool ShowPrivateDiscriminators = true;
   bool ShowFunctionArgumentTypes = true;
+  bool DisplayDebuggerGeneratedModule = true;
+  bool DisplayStdlibModule = true;
   std::function<std::string(uint64_t, uint64_t)> GenericParameterName =
       genericParameterName;
 

--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -58,6 +58,7 @@ struct DemangleOptions {
   bool ShowFunctionArgumentTypes = true;
   bool DisplayDebuggerGeneratedModule = true;
   bool DisplayStdlibModule = true;
+  bool DisplayObjCModule = true;
   std::function<std::string(uint64_t, uint64_t)> GenericParameterName =
       genericParameterName;
 

--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -59,6 +59,9 @@ struct DemangleOptions {
   bool DisplayDebuggerGeneratedModule = true;
   bool DisplayStdlibModule = true;
   bool DisplayObjCModule = true;
+  /// If this is nonempty, entities in this module name will not be qualified.
+  llvm::StringRef HidingCurrentModule;
+  /// A function to render generic parameter names.
   std::function<std::string(uint64_t, uint64_t)> GenericParameterName =
       genericParameterName;
 

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -248,6 +248,8 @@ private:
         return Options.DisplayStdlibModule;
       if (Context->getText() == swift::MANGLING_MODULE_OBJC)
         return Options.DisplayObjCModule;
+      if (Context->getText() == Options.HidingCurrentModule)
+        return false;
       if (Context->getText().startswith(LLDB_EXPRESSIONS_MODULE_NAME_PREFIX))
         return Options.DisplayDebuggerGeneratedModule;
     }

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -243,9 +243,11 @@ private:
     if (!Options.QualifyEntities)
       return false;
 
-    if (Context->getKind() == Node::Kind::Module &&
-        Context->getText().startswith(LLDB_EXPRESSIONS_MODULE_NAME_PREFIX)) {
-      return Options.DisplayDebuggerGeneratedModule;
+    if (Context->getKind() == Node::Kind::Module) {
+      if (Context->getText() == swift::STDLIB_NAME)
+        return Options.DisplayStdlibModule;
+      if (Context->getText().startswith(LLDB_EXPRESSIONS_MODULE_NAME_PREFIX))
+        return Options.DisplayDebuggerGeneratedModule;
     }
     return true;
   }
@@ -1945,8 +1947,8 @@ NodePointer NodePrinter::print(NodePointer Node, bool asPrefixContext) {
       printChildren(type_list, " & ");
       Printer << " & ";
     }
-    if (Options.QualifyEntities)
-      Printer << "Swift.";
+    if (Options.QualifyEntities && Options.DisplayStdlibModule)
+      Printer << swift::STDLIB_NAME << ".";
     Printer << "AnyObject";
     return nullptr;
   }

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -246,6 +246,8 @@ private:
     if (Context->getKind() == Node::Kind::Module) {
       if (Context->getText() == swift::STDLIB_NAME)
         return Options.DisplayStdlibModule;
+      if (Context->getText() == swift::MANGLING_MODULE_OBJC)
+        return Options.DisplayObjCModule;
       if (Context->getText().startswith(LLDB_EXPRESSIONS_MODULE_NAME_PREFIX))
         return Options.DisplayDebuggerGeneratedModule;
     }

--- a/test/Demangle/demangle-special-options.test
+++ b/test/Demangle/demangle-special-options.test
@@ -2,3 +2,8 @@ RUN: swift-demangle -display-stdlib-module=true sSi | %FileCheck %s --check-pref
 SWIFT-INT: {{ Swift.Int$}}
 RUN: swift-demangle -display-stdlib-module=false sSi | %FileCheck %s --check-prefix=INT
 INT: {{ Int$}}
+
+RUN: swift-demangle -display-objc-module=true sSo6CGRectVD | %FileCheck %s --check-prefix=OBJC-CGRECT
+OBJC-CGRECT: {{ __C.CGRect$}}
+RUN: swift-demangle -display-objc-module=false sSo6CGRectVD | %FileCheck %s --check-prefix=CGRECT
+CGRECT: {{ CGRect$}}

--- a/test/Demangle/demangle-special-options.test
+++ b/test/Demangle/demangle-special-options.test
@@ -7,3 +7,6 @@ RUN: swift-demangle -display-objc-module=true sSo6CGRectVD | %FileCheck %s --che
 OBJC-CGRECT: {{ __C.CGRect$}}
 RUN: swift-demangle -display-objc-module=false sSo6CGRectVD | %FileCheck %s --check-prefix=CGRECT
 CGRECT: {{ CGRect$}}
+
+RUN: swift-demangle -hiding-module=foo _TtC3foo3bar | %FileCheck %s --check-prefix=BAR
+BAR: {{ bar$}}

--- a/test/Demangle/demangle-special-options.test
+++ b/test/Demangle/demangle-special-options.test
@@ -1,0 +1,4 @@
+RUN: swift-demangle -display-stdlib-module=true sSi | %FileCheck %s --check-prefix=SWIFT-INT
+SWIFT-INT: {{ Swift.Int$}}
+RUN: swift-demangle -display-stdlib-module=false sSi | %FileCheck %s --check-prefix=INT
+INT: {{ Int$}}

--- a/test/Demangle/lit.local.cfg
+++ b/test/Demangle/lit.local.cfg
@@ -1,0 +1,2 @@
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes.add('.test')

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -80,6 +80,11 @@ static llvm::cl::opt<bool> DisplayStdlibModule(
     "display-stdlib-module", llvm::cl::init(true),
     llvm::cl::desc("Qualify types originating from the Swift standard library"),
     llvm::cl::Hidden);
+
+static llvm::cl::opt<bool> DisplayObjCModule(
+    "display-objc-module", llvm::cl::init(true),
+    llvm::cl::desc("Qualify types originating from the __ObjC module"),
+    llvm::cl::Hidden);
 /// \}
 
 
@@ -243,6 +248,7 @@ int main(int argc, char **argv) {
   if (Simplified)
     options = swift::Demangle::DemangleOptions::SimplifiedUIDemangleOptions();
   options.DisplayStdlibModule = DisplayStdlibModule;
+  options.DisplayObjCModule = DisplayObjCModule;
 
   if (InputNames.empty()) {
     CompactMode = true;

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -85,6 +85,11 @@ static llvm::cl::opt<bool> DisplayObjCModule(
     "display-objc-module", llvm::cl::init(true),
     llvm::cl::desc("Qualify types originating from the __ObjC module"),
     llvm::cl::Hidden);
+
+static llvm::cl::opt<std::string> HidingModule(
+    "hiding-module",
+    llvm::cl::desc("Don't qualify types originating from this module"),
+    llvm::cl::Hidden);
 /// \}
 
 
@@ -249,6 +254,7 @@ int main(int argc, char **argv) {
     options = swift::Demangle::DemangleOptions::SimplifiedUIDemangleOptions();
   options.DisplayStdlibModule = DisplayStdlibModule;
   options.DisplayObjCModule = DisplayObjCModule;
+  options.HidingCurrentModule = HidingModule;
 
   if (InputNames.empty()) {
     CompactMode = true;

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -74,6 +74,15 @@ static llvm::cl::opt<bool>
 Classify("classify",
            llvm::cl::desc("Display symbol classification characters"));
 
+/// Options that are primarily used for testing.
+/// \{
+static llvm::cl::opt<bool> DisplayStdlibModule(
+    "display-stdlib-module", llvm::cl::init(true),
+    llvm::cl::desc("Qualify types originating from the Swift standard library"),
+    llvm::cl::Hidden);
+/// \}
+
+
 static llvm::cl::list<std::string>
 InputNames(llvm::cl::Positional, llvm::cl::desc("[mangled name...]"),
                llvm::cl::ZeroOrMore);
@@ -233,6 +242,7 @@ int main(int argc, char **argv) {
   options.SynthesizeSugarOnTypes = !DisableSugar;
   if (Simplified)
     options = swift::Demangle::DemangleOptions::SimplifiedUIDemangleOptions();
+  options.DisplayStdlibModule = DisplayStdlibModule;
 
   if (InputNames.empty()) {
     CompactMode = true;


### PR DESCRIPTION
This is analogous to ASTPrinter's FullyQualifiedTypesIfAmbiguous option.

This part of a series of patches to bring ASTPrinter and Swift Demangler to
feature parity, which is needed by LLDB, which depends on using the strings
produced by either interchangibly.

rdar://problem/63700540

Depends on https://github.com/apple/swift/pull/32094