### PR TITLE
ASTPrinter: Add an option to qualify ClangImported types.

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -435,6 +435,9 @@ struct PrintOptions {
   /// The information for converting archetypes to specialized types.
   llvm::Optional<TypeTransformContext> TransformContext;
 
+  /// Whether to display (Clang-)imported module names;
+  bool QualifyImportedTypes = false;
+
   /// Whether cross-import overlay modules are printed with their own name (e.g.
   /// _MyFrameworkYourFrameworkAdditions) or that of their underlying module
   /// (e.g.  MyFramework).

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3641,11 +3641,12 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
       return false;
 
     // Don't print qualifiers for imported types.
-    for (auto File : M->getFiles()) {
-      if (File->getKind() == FileUnitKind::ClangModule ||
-          File->getKind() == FileUnitKind::DWARFModule)
-        return false;
-    }
+    if (!Options.QualifyImportedTypes)
+      for (auto File : M->getFiles()) {
+        if (File->getKind() == FileUnitKind::ClangModule ||
+            File->getKind() == FileUnitKind::DWARFModule)
+          return false;
+      }
 
     return true;
   }

--- a/test/DebugInfo/ASTPrinter-imported-names.swift
+++ b/test/DebugInfo/ASTPrinter-imported-names.swift
@@ -1,0 +1,12 @@
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t)
+// RUN: echo '$sSo3FooVD' > %t/list
+// RUN: %target-build-swift -emit-executable %s -g -o %t/a.out -I %S/Inputs \
+// RUN:   -module-name ASTPrinter -emit-module
+// RUN: %lldb-moduleimport-test -qualify-types \
+// RUN:   -type-from-mangled=%t/list %t/a.out | %FileCheck %s
+// This name should come out fully qualified.
+// CHECK: ClangModule.Foo
+import ClangModule
+let foo = Foo()

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -95,8 +95,10 @@ static void resolveDeclFromMangledNameList(
   }
 }
 
-static void resolveTypeFromMangledNameList(
-    swift::ASTContext &Ctx, llvm::ArrayRef<std::string> MangledNames) {
+static void
+resolveTypeFromMangledNameList(swift::ASTContext &Ctx,
+                               llvm::ArrayRef<std::string> MangledNames,
+                               bool QualifyTypes) {
   for (auto &Mangled : MangledNames) {
     swift::Type ResolvedType =
         swift::Demangle::getTypeForMangling(Ctx, Mangled);
@@ -104,6 +106,8 @@ static void resolveTypeFromMangledNameList(
       llvm::outs() << "Can't resolve type of " << Mangled << "\n";
     } else {
       swift::PrintOptions PO;
+      PO.FullyQualifiedTypesIfAmbiguous = QualifyTypes;
+      PO.QualifyImportedTypes = QualifyTypes;
       PO.PrintStorageRepresentationAttrs = true;
       ResolvedType->print(llvm::outs(), PO);
       llvm::outs() << "\n";
@@ -233,6 +237,9 @@ int main(int argc, char **argv) {
       "dummy-dwarfimporter",
       desc("Install a dummy DWARFImporterDelegate"), cat(Visible));
 
+  opt<bool> QualifyTypes("qualify-types", desc("Qualify dumped types"),
+                         cat(Visible));
+
   ParseCommandLineOptions(argc, argv);
 
   // Unregister our options so they don't interfere with the command line
@@ -352,14 +359,14 @@ int main(int argc, char **argv) {
     if (DumpModule) {
       llvm::SmallVector<swift::Decl*, 10> Decls;
       Module->getTopLevelDecls(Decls);
-      for (auto Decl : Decls) {
+      for (auto Decl : Decls)
         Decl->dump(llvm::outs());
-      }
     }
     if (!DumpTypeFromMangled.empty()) {
       llvm::SmallVector<std::string, 8> MangledNames;
       collectMangledNames(DumpTypeFromMangled, MangledNames);
-      resolveTypeFromMangledNameList(CI.getASTContext(), MangledNames);
+      resolveTypeFromMangledNameList(CI.getASTContext(), MangledNames,
+                                     QualifyTypes);
     }
     if (!DumpDeclFromMangled.empty()) {
       llvm::SmallVector<std::string, 8> MangledNames;


### PR DESCRIPTION
This part of a series of patches to bring ASTPrinter and Swift Demangler to
feature parity, which is needed by LLDB, which depends on using the strings
produced by either interchangibly.

rdar://problem/63700540

