### PR TITLE
[NFC][ConstraintSystem] Move some inlined header methods to implementation file 

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -929,22 +929,21 @@ TypeVariableType *ConstraintSystem::isRepresentativeFor(
 }
 
 static Optional<std::pair<VarDecl *, Type>>
-getPropertyWrappersInformationFromOverload(
+getPropertyWrapperInformationFromOverload(
     SelectedOverload resolvedOverload, DeclContext *DC,
     llvm::function_ref<Optional<std::pair<VarDecl *, Type>>(VarDecl *)>
         getInformation) {
-  if (resolvedOverload.choice.isDecl()) {
-    if (auto *decl = dyn_cast<VarDecl>(resolvedOverload.choice.getDecl())) {
-      if (auto declInformation = getInformation(decl)) {
-        Type type;
-        VarDecl *memberDecl;
-        std::tie(memberDecl, type) = *declInformation;
-        if (Type baseType = resolvedOverload.choice.getBaseType()) {
-          type = baseType->getTypeOfMember(DC->getParentModule(), memberDecl,
-                                           type);
-        }
-        return std::make_pair(decl, type);
+  if (auto *decl =
+        dyn_cast_or_null<VarDecl>(resolvedOverload.choice.getDeclOrNull())) {
+    if (auto declInformation = getInformation(decl)) {
+      Type type;
+      VarDecl *memberDecl;
+      std::tie(memberDecl, type) = *declInformation;
+      if (Type baseType = resolvedOverload.choice.getBaseType()) {
+        type = baseType->getTypeOfMember(DC->getParentModule(), memberDecl,
+                                         type);
       }
+      return std::make_pair(decl, type);
     }
   }
   return None;
@@ -965,7 +964,7 @@ getStorageWrapperInformationFromDecl(VarDecl *decl) {
 Optional<std::pair<VarDecl *, Type>>
 ConstraintSystem::getStorageWrapperInformation(
     SelectedOverload resolvedOverload) {
-  return getPropertyWrappersInformationFromOverload(
+  return getPropertyWrapperInformationFromOverload(
       resolvedOverload, DC,
       [](VarDecl *decl) { return getStorageWrapperInformationFromDecl(decl); });
 }
@@ -981,7 +980,7 @@ getPropertyWrapperInformationFromDecl(VarDecl *decl) {
 Optional<std::pair<VarDecl *, Type>>
 ConstraintSystem::getPropertyWrapperInformation(
     SelectedOverload resolvedOverload) {
-  return getPropertyWrappersInformationFromOverload(
+  return getPropertyWrapperInformationFromOverload(
       resolvedOverload, DC, [](VarDecl *decl) {
         return getPropertyWrapperInformationFromDecl(decl);
       });
@@ -998,7 +997,7 @@ getWrappedPropertyInformationFromDecl(VarDecl *decl) {
 Optional<std::pair<VarDecl *, Type>>
 ConstraintSystem::getWrappedPropertyInformation(
     SelectedOverload resolvedOverload) {
-  return getPropertyWrappersInformationFromOverload(
+  return getPropertyWrapperInformationFromOverload(
       resolvedOverload, DC, [](VarDecl *decl) {
         return getWrappedPropertyInformationFromDecl(decl);
       });

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -928,6 +928,59 @@ TypeVariableType *ConstraintSystem::isRepresentativeFor(
   return *member;
 }
 
+Optional<std::pair<VarDecl *, Type>>
+ConstraintSystem::getStorageWrapperInformation(SelectedOverload resolvedOverload) {
+  if (resolvedOverload.choice.isDecl()) {
+    if (auto *decl = dyn_cast<VarDecl>(resolvedOverload.choice.getDecl())) {
+      if (decl->hasAttachedPropertyWrapper()) {
+        if (auto storageWrapper = decl->getPropertyWrapperStorageWrapper()) {
+          Type type = storageWrapper->getInterfaceType();
+          if (Type baseType = resolvedOverload.choice.getBaseType()) {
+            type = baseType->getTypeOfMember(DC->getParentModule(),
+                                             storageWrapper, type);
+          }
+          return std::make_pair(decl, type);
+        }
+      }
+    }
+  }
+  return None;
+}
+
+Optional<std::pair<VarDecl *, Type>>
+ConstraintSystem::getPropertyWrapperInformation(SelectedOverload resolvedOverload) {
+  if (resolvedOverload.choice.isDecl()) {
+    if (auto *decl = dyn_cast<VarDecl>(resolvedOverload.choice.getDecl())) {
+      if (decl->hasAttachedPropertyWrapper()) {
+        auto wrapperTy = decl->getPropertyWrapperBackingPropertyType();
+        if (Type baseType = resolvedOverload.choice.getBaseType()) {
+          wrapperTy = baseType->getTypeOfMember(DC->getParentModule(),
+                                                decl, wrapperTy);
+        }
+        return std::make_pair(decl, wrapperTy);
+      }
+    }
+  }
+  return None;
+}
+
+Optional<std::pair<VarDecl *, Type>>
+ConstraintSystem::getWrappedPropertyInformation(SelectedOverload resolvedOverload) {
+  if (resolvedOverload.choice.isDecl()) {
+    if (auto *decl = dyn_cast<VarDecl>(resolvedOverload.choice.getDecl())) {
+      if (auto wrapped = decl->getOriginalWrappedProperty()) {
+        Type type = wrapped->getInterfaceType();
+        if (Type baseType = resolvedOverload.choice.getBaseType()) {
+          type = baseType->getTypeOfMember(DC->getParentModule(),
+                                           wrapped, type);
+        }
+        return std::make_pair(decl, type);
+      }
+    }
+  }
+  return None;
+}
+
 /// Does a var or subscript produce an l-value?
 ///
 /// \param baseType - the type of the base on which this object

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3080,62 +3080,18 @@ public:
   /// Gets the VarDecl associateed with resolvedOverload, and the type of the
   /// storage wrapper if the decl has an associated storage wrapper.
   Optional<std::pair<VarDecl *, Type>>
-  getStorageWrapperInformation(SelectedOverload resolvedOverload) {
-    if (resolvedOverload.choice.isDecl()) {
-      if (auto *decl = dyn_cast<VarDecl>(resolvedOverload.choice.getDecl())) {
-        if (decl->hasAttachedPropertyWrapper()) {
-          if (auto storageWrapper = decl->getPropertyWrapperStorageWrapper()) {
-            Type type = storageWrapper->getInterfaceType();
-            if (Type baseType = resolvedOverload.choice.getBaseType()) {
-              type = baseType->getTypeOfMember(DC->getParentModule(),
-                                               storageWrapper, type);
-            }
-            return std::make_pair(decl, type);
-          }
-        }
-      }
-    }
-    return None;
-  }
+  getStorageWrapperInformation(SelectedOverload resolvedOverload);
 
   /// Gets the VarDecl associateed with resolvedOverload, and the type of the
   /// backing storage if the decl has an associated property wrapper.
   Optional<std::pair<VarDecl *, Type>>
-  getPropertyWrapperInformation(SelectedOverload resolvedOverload) {
-    if (resolvedOverload.choice.isDecl()) {
-      if (auto *decl = dyn_cast<VarDecl>(resolvedOverload.choice.getDecl())) {
-        if (decl->hasAttachedPropertyWrapper()) {
-          auto wrapperTy = decl->getPropertyWrapperBackingPropertyType();
-          if (Type baseType = resolvedOverload.choice.getBaseType()) {
-            wrapperTy = baseType->getTypeOfMember(DC->getParentModule(),
-                                                  decl, wrapperTy);
-          }
-          return std::make_pair(decl, wrapperTy);
-        }
-      }
-    }
-    return None;
-  }
+  getPropertyWrapperInformation(SelectedOverload resolvedOverload);
 
   /// Gets the VarDecl, and the type of the type property that it wraps if
   /// resolved overload has a decl which is the backing storage for a
   /// property wrapper.
   Optional<std::pair<VarDecl *, Type>>
-  getWrappedPropertyInformation(SelectedOverload resolvedOverload) {
-    if (resolvedOverload.choice.isDecl()) {
-      if (auto *decl = dyn_cast<VarDecl>(resolvedOverload.choice.getDecl())) {
-        if (auto wrapped = decl->getOriginalWrappedProperty()) {
-          Type type = wrapped->getInterfaceType();
-          if (Type baseType = resolvedOverload.choice.getBaseType()) {
-            type = baseType->getTypeOfMember(DC->getParentModule(),
-                                             wrapped, type);
-          }
-          return std::make_pair(decl, type);
-        }
-      }
-    }
-    return None;
-  }
+  getWrappedPropertyInformation(SelectedOverload resolvedOverload);
 
   /// Merge the equivalence sets of the two type variables.
   ///


### PR DESCRIPTION
<!-- What's in this pull request? -->
The initial intention was just to audit and see if some methods could be moved to implementation instead of inline in the header. As commented in another PR normally is recommended to inline only small methods. 
There is not a precise definition of what is a small method, but I thought in propose moving those in this PR. 
While moving I note, that these specific methods have almost exactly the same implementation, so I try to abstract the common logic which seems like an improvement, but TBH not sure if it is worthed nor got much better ... but sending anyway to see what you think cc @xedin @DougGregor 

