### PR TITLE
build: remove unnecessary `CXX_STANDARD` for Windows

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -517,7 +517,6 @@ function(add_swift_host_library name)
     endif()
 
     set_target_properties(${name} PROPERTIES
-      CXX_STANDARD 14
       NO_SONAME YES)
   endif()
 


### PR DESCRIPTION
The entire project is now at C++14.  Windows had to adopt C++14 earlier
to support processing the Windows SDK headers.  This is no longer
necessary, adopt the global settings instead.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
