### PR TITLE
[AutoDiff] Enable .swiftinterface verification for _Differentiation.

### DIFF
--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -50,7 +50,6 @@ for filename in os.listdir(sdk_overlay_dir):
         continue
 
     if module_name in [
-        "_Differentiation",
         "DifferentiationUnittest",
         "Swift",
         "SwiftLang",


### PR DESCRIPTION
Enable `.swiftinterface` verification for the `_Differentiation` module to prevent
regressions.