### PR TITLE
[cmake] Move ar linking optimization rule into UnixCompileRules.cmake and only run it on Unix-like platforms.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -413,6 +413,8 @@ endif()
 
 if(MSVC OR "${CMAKE_SIMULATE_ID}" STREQUAL MSVC)
   include(ClangClCompileRules)
+elseif(UNIX)
+  include(UnixCompileRules)
 endif()
 
 if(CMAKE_C_COMPILER_ID MATCHES Clang)
@@ -431,19 +433,6 @@ if(SWIFT_BUILD_SYNTAXPARSERLIB OR SWIFT_BUILD_SOURCEKIT)
     endif()
   endif()
 endif()
-
-#
-# Assume a new enough ar to generate the index at construction time. This avoids
-# having to invoke ranlib as a secondary command.
-#
-
-set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> crs <TARGET> <LINK_FLAGS> <OBJECTS>")
-set(CMAKE_C_ARCHIVE_APPEND "<CMAKE_AR> qs <TARGET> <LINK_FLAGS> <OBJECTS>")
-set(CMAKE_C_ARCHIVE_FINISH "")
-
-set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> crs <TARGET> <LINK_FLAGS> <OBJECTS>")
-set(CMAKE_CXX_ARCHIVE_APPEND "<CMAKE_AR> qs <TARGET> <LINK_FLAGS> <OBJECTS>")
-set(CMAKE_CXX_ARCHIVE_FINISH "")
 
 #
 # Include CMake modules

--- a/cmake/modules/UnixCompileRules.cmake
+++ b/cmake/modules/UnixCompileRules.cmake
@@ -1,0 +1,13 @@
+
+#
+# Assume a new enough ar to generate the index at construction time. This avoids
+# having to invoke ranlib as a secondary command.
+#
+
+set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> crs <TARGET> <LINK_FLAGS> <OBJECTS>")
+set(CMAKE_C_ARCHIVE_APPEND "<CMAKE_AR> qs <TARGET> <LINK_FLAGS> <OBJECTS>")
+set(CMAKE_C_ARCHIVE_FINISH "")
+
+set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> crs <TARGET> <LINK_FLAGS> <OBJECTS>")
+set(CMAKE_CXX_ARCHIVE_APPEND "<CMAKE_AR> qs <TARGET> <LINK_FLAGS> <OBJECTS>")
+set(CMAKE_CXX_ARCHIVE_FINISH "")


### PR DESCRIPTION
This doesn't make sense on Windows and from what compnerd has said it doesnt
even appear in the ninja rules file. This also moves this rule out of the main
flow of the top level CMakeLists.txt file so I can reuse it when compiling the
stdlib using a sub-cmake invocation.
