### PR TITLE
[Constraint system] Refactor type checking of closures

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -89,6 +89,20 @@ public:
     return TheFunction.get<AbstractClosureExpr *>()->getSingleExpressionBody();
   }
 
+  void setSingleExpressionBody(Expr *expr) {
+    if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>()) {
+      AFD->setSingleExpressionBody(expr);
+      return;
+    }
+
+    auto ACE = TheFunction.get<AbstractClosureExpr *>();
+    if (auto CE = dyn_cast<ClosureExpr>(ACE)) {
+      CE->setSingleExpressionBody(expr);
+    } else {
+      cast<AutoClosureExpr>(ACE)->setBody(expr);
+    }
+  }
+
   Type getType() const {
     if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>())
       return AFD->getInterfaceType();
@@ -121,6 +135,21 @@ public:
     if (auto *CE = dyn_cast<ClosureExpr>(ACE))
       return CE->getBody();
     return cast<AutoClosureExpr>(ACE)->getBody();
+  }
+
+  void setBody(BraceStmt *stmt, bool isSingleExpression) {
+    if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>()) {
+      AFD->setBody(stmt);
+      AFD->setHasSingleExpressionBody(isSingleExpression);
+      return;
+    }
+
+    auto *ACE = TheFunction.get<AbstractClosureExpr *>();
+    if (auto *CE = dyn_cast<ClosureExpr>(ACE)) {
+      return CE->setBody(stmt, isSingleExpression);
+    }
+
+    llvm_unreachable("autoclosures don't have statement bodies");
   }
 
   DeclContext *getAsDeclContext() const {

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -2,6 +2,7 @@ add_swift_host_library(swiftSema STATIC
   BuilderTransform.cpp
   CSApply.cpp
   CSBindings.cpp
+  CSClosure.cpp
   CSGen.cpp
   CSRanking.cpp
   CSSimplify.cpp

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1504,30 +1504,6 @@ namespace {
     }
 
   public:
-
-
-    /// Coerce a closure expression with a non-Void return type to a
-    /// contextual function type with a Void return type.
-    ///
-    /// This operation cannot fail.
-    ///
-    /// \param expr The closure expression to coerce.
-    ///
-    /// \returns The coerced closure expression.
-    ///
-    ClosureExpr *coerceClosureExprToVoid(ClosureExpr *expr);
-
-    /// Coerce a closure expression with a Never return type to a
-    /// contextual function type with some other return type.
-    ///
-    /// This operation cannot fail.
-    ///
-    /// \param expr The closure expression to coerce.
-    ///
-    /// \returns The coerced closure expression.
-    ///
-    ClosureExpr *coerceClosureExprFromNever(ClosureExpr *expr);
-    
     /// Coerce the given expression to the given type.
     ///
     /// This operation cannot fail.
@@ -4994,14 +4970,6 @@ namespace {
       return result;
     }
 
-    const AppliedBuilderTransform *getAppliedBuilderTransform(
-       AnyFunctionRef fn) {
-      auto known = solution.functionBuilderTransformed.find(fn);
-      return known != solution.functionBuilderTransformed.end()
-          ? &known->second
-          : nullptr;
-    }
-
     void finalize() {
       assert(ExprStack.empty());
       assert(OpenedExistentials.empty());
@@ -5829,83 +5797,6 @@ static bool applyTypeToClosureExpr(ConstraintSystem &cs,
 
   // Otherwise fail.
   return false;
-}
-
-ClosureExpr *ExprRewriter::coerceClosureExprToVoid(ClosureExpr *closureExpr) {
-  auto &ctx = cs.getASTContext();
-
-  // Re-write the single-expression closure to return '()'
-  assert(closureExpr->hasSingleExpressionBody());
-
-  // A single-expression body contains a single return statement
-  // prior to this transformation.
-  auto member = closureExpr->getBody()->getFirstElement();
- 
-  if (member.is<Stmt *>()) {
-    auto returnStmt = cast<ReturnStmt>(member.get<Stmt *>());
-    auto singleExpr = returnStmt->getResult();
-    auto voidExpr = cs.cacheType(TupleExpr::createEmpty(
-        ctx, singleExpr->getStartLoc(), singleExpr->getEndLoc(),
-        /*implicit*/ true));
-    returnStmt->setResult(voidExpr);
-
-    // For l-value types, reset to the object type. This might not be strictly
-    // necessary any more, but it's probably still a good idea.
-    if (cs.getType(singleExpr)->is<LValueType>())
-      cs.setType(singleExpr,
-                 cs.getType(singleExpr)->getWithoutSpecifierType());
-
-    solution.setExprTypes(singleExpr);
-    TypeChecker::checkIgnoredExpr(singleExpr);
-
-    SmallVector<ASTNode, 2> elements;
-    elements.push_back(singleExpr);
-    elements.push_back(returnStmt);
-
-    auto braceStmt = BraceStmt::create(ctx, closureExpr->getStartLoc(),
-                                       elements, closureExpr->getEndLoc(),
-                                       /*implicit*/ true);
-
-    closureExpr->setImplicit();
-    closureExpr->setBody(braceStmt, /*isSingleExpression*/true);
-  }
-  
-  // Finally, compute the proper type for the closure.
-  auto fnType = cs.getType(closureExpr)->getAs<FunctionType>();
-  auto newClosureType = FunctionType::get(
-      fnType->getParams(), ctx.TheEmptyTupleType, fnType->getExtInfo());
-  cs.setType(closureExpr, newClosureType);
-  return closureExpr;
-}
-
-ClosureExpr *ExprRewriter::coerceClosureExprFromNever(ClosureExpr *closureExpr) {
-  // Re-write the single-expression closure to drop the 'return'.
-  assert(closureExpr->hasSingleExpressionBody());
-
-  // A single-expression body contains a single return statement
-  // prior to this transformation.
-  auto member = closureExpr->getBody()->getFirstElement();
-
-  if (member.is<Stmt *>()) {
-    auto returnStmt = cast<ReturnStmt>(member.get<Stmt *>());
-    auto singleExpr = returnStmt->getResult();
-
-    solution.setExprTypes(singleExpr);
-    TypeChecker::checkIgnoredExpr(singleExpr);
-
-    SmallVector<ASTNode, 1> elements;
-    elements.push_back(singleExpr);
-
-    auto braceStmt =
-        BraceStmt::create(cs.getASTContext(), closureExpr->getStartLoc(),
-                          elements, closureExpr->getEndLoc(),
-                          /*implicit*/ true);
-
-    closureExpr->setImplicit();
-    closureExpr->setBody(braceStmt, /*isSingleExpression*/true);
-  }
-
-  return closureExpr;
 }
 
 // Look through sugar and DotSyntaxBaseIgnoredExprs.
@@ -7721,80 +7612,7 @@ namespace {
     std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
       // For closures, update the parameter types and check the body.
       if (auto closure = dyn_cast<ClosureExpr>(expr)) {
-        Rewriter.simplifyExprType(expr);
-        auto &cs = Rewriter.getConstraintSystem();
-
-        // Coerce the pattern, in case we resolved something.
-        auto fnType = cs.getType(closure)->castTo<FunctionType>();
-        auto *params = closure->getParameters();
-        TypeChecker::coerceParameterListToType(params, closure, fnType);
-
-        if (closure->hasExplicitResultType()) {
-          closure->setExplicitResultType(fnType->getResult());
-        }
-
-        if (auto transform =
-                       Rewriter.getAppliedBuilderTransform(closure)) {
-          // Apply the function builder to the closure. We want to be in the
-          // context of the closure for subsequent transforms.
-          llvm::SaveAndRestore<DeclContext *> savedDC(Rewriter.dc, closure);
-          auto newBody = applyFunctionBuilderTransform(
-              Rewriter.solution, *transform, closure->getBody(), closure,
-              [&](SolutionApplicationTarget target) {
-                auto resultTarget = rewriteTarget(target);
-                if (resultTarget) {
-                  if (auto expr = resultTarget->getAsExpr())
-                    Rewriter.solution.setExprTypes(expr);
-                }
-
-                return resultTarget;
-              });
-          closure->setBody(newBody, /*isSingleExpression=*/false);
-          closure->setAppliedFunctionBuilder();
-
-          Rewriter.solution.setExprTypes(closure);
-        } else if (closure->hasSingleExpressionBody()) {
-          // If this is a single-expression closure, convert the expression
-          // in the body to the result type of the closure.
-
-          // Enter the context of the closure when type-checking the body.
-          llvm::SaveAndRestore<DeclContext *> savedDC(Rewriter.dc, closure);
-          Expr *body = closure->getSingleExpressionBody()->walk(*this);
-          if (!body)
-            return { false, nullptr };
-          
-          if (body != closure->getSingleExpressionBody())
-            closure->setSingleExpressionBody(body);
-          
-          if (body) {
-            // A single-expression closure with a non-Void expression type
-            // coerces to a Void-returning function type.
-            if (fnType->getResult()->isVoid() && !cs.getType(body)->isVoid()) {
-              closure = Rewriter.coerceClosureExprToVoid(closure);
-            // A single-expression closure with a Never expression type
-            // coerces to any other function type.
-            } else if (cs.getType(body)->isUninhabited()) {
-              closure = Rewriter.coerceClosureExprFromNever(closure);
-            } else {
-            
-              body = Rewriter.coerceToType(body,
-                                           fnType->getResult(),
-                                           cs.getConstraintLocator(
-                                             closure,
-                                             ConstraintLocator::ClosureResult));
-              if (!body)
-                return { false, nullptr };
-
-              closure->setSingleExpressionBody(body);
-            }
-          }
-        } else {
-          // For other closures, type-check the body once we've finished with
-          // the expression.
-          Rewriter.solution.setExprTypes(closure);
-          ClosuresToTypeCheck.push_back(closure);
-        }
-
+        rewriteFunction(closure);
         return { false, closure };
       }
 
@@ -7823,6 +7641,37 @@ namespace {
     /// Rewrite the target, producing a new target.
     Optional<SolutionApplicationTarget>
     rewriteTarget(SolutionApplicationTarget target);
+
+    /// Rewrite the function for the given solution.
+    ///
+    /// \returns true if an error occurred.
+    bool rewriteFunction(AnyFunctionRef fn) {
+      auto result = Rewriter.cs.applySolution(
+          Rewriter.solution, fn, Rewriter.dc,
+          [&](SolutionApplicationTarget target) {
+            auto resultTarget = rewriteTarget(target);
+            if (resultTarget) {
+              if (auto expr = resultTarget->getAsExpr())
+                Rewriter.solution.setExprTypes(expr);
+            }
+
+            return resultTarget;
+          });
+
+      switch (result) {
+      case SolutionApplicationToFunctionResult::Success:
+        return false;
+
+      case SolutionApplicationToFunctionResult::Failure:
+        return true;
+
+      case SolutionApplicationToFunctionResult::Delay: {
+        auto closure = cast<ClosureExpr>(fn.getAbstractClosureExpr());
+        ClosuresToTypeCheck.push_back(closure);
+        return false;
+      }
+      }
+    }
   };
 } // end anonymous namespace
 
@@ -8256,28 +8105,10 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
     return target;
   } else {
     auto fn = *target.getAsFunction();
-
-    // Dig out the function builder transformation we applied.
-    auto transform = Rewriter.getAppliedBuilderTransform(fn);
-    assert(transform);
-
-    auto newBody = applyFunctionBuilderTransform(
-        solution, *transform, fn.getBody(), fn.getAsDeclContext(),
-        [&](SolutionApplicationTarget target) {
-          auto resultTarget = rewriteTarget(target);
-          if (resultTarget) {
-            if (auto expr = resultTarget->getAsExpr())
-              solution.setExprTypes(expr);
-          }
-
-          return resultTarget;
-        });
-
-    if (!newBody)
+    if (rewriteFunction(fn))
       return None;
 
-    result.setFunctionBody(newBody);
-    fn.getAbstractFunctionDecl()->setHasSingleExpressionBody(false);
+    result.setFunctionBody(fn.getBody());
   }
 
   // Follow-up tasks.

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -1,0 +1,37 @@
+//===--- CSClosure.cpp - Closures -----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements constraint generation and solution application for
+// closures. It provides part of the implementation of the ConstraintSystem
+// class.
+//
+//===----------------------------------------------------------------------===//
+
+#include "ConstraintSystem.h"
+using namespace swift;
+using namespace swift::constraints;
+
+bool ConstraintSystem::generateConstraints(
+    ClosureExpr *closure, Type resultType) {
+  assert(closure->hasSingleExpressionBody());
+  auto closureBody = generateConstraints(
+      closure->getSingleExpressionBody(), closure, /*isInputExpression=*/false);
+  if (!closureBody)
+    return true;
+
+  bool hasReturn = hasExplicitResult(closure);
+  addConstraint(
+      ConstraintKind::Conversion, getType(closureBody),
+      resultType,
+      getConstraintLocator(closure, LocatorPathElt::ClosureBody(hasReturn)));
+  return false;
+}

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -20,18 +20,111 @@
 using namespace swift;
 using namespace swift::constraints;
 
+namespace {
+
+/// Statement visitor that generates constraints for a given closure body.
+class ClosureConstraintGenerator
+    : public StmtVisitor<ClosureConstraintGenerator, void> {
+  friend StmtVisitor<ClosureConstraintGenerator, void>;
+
+  ConstraintSystem &cs;
+  ClosureExpr *closure;
+  Type closureResultType;
+
+public:
+  /// Whether an error was encountered while generating constraints.
+  bool hadError = false;
+
+  ClosureConstraintGenerator(ConstraintSystem &cs, ClosureExpr *closure,
+                             Type closureResultType)
+    : cs(cs), closure(closure), closureResultType(closureResultType) { }
+
+private:
+  void visitDecl(Decl *decl) {
+    // Just ignore #if; the chosen children should appear in the
+    // surrounding context.  This isn't good for source tools but it
+    // at least works.
+    if (isa<IfConfigDecl>(decl))
+      return;
+
+    // Skip #warning/#error; we'll handle them when applying the closure.
+    if (isa<PoundDiagnosticDecl>(decl))
+      return;
+
+    // Ignore variable declarations, because they're always handled within
+    // their enclosing pattern bindings.
+    if (isa<VarDecl>(decl))
+      return;
+
+    llvm_unreachable("Unimplemented case for closure body");
+  }
+
+  void visitBraceStmt(BraceStmt *braceStmt) {
+    for (auto node : braceStmt->getElements()) {
+      if (auto expr = node.dyn_cast<Expr *>()) {
+        auto generatedExpr = cs.generateConstraints(
+            expr, closure, /*isInputExpression=*/false);
+        if (!generatedExpr) {
+          hadError = true;
+        }
+      } else if (auto stmt = node.dyn_cast<Stmt *>()) {
+        visit(stmt);
+      } else {
+        visitDecl(node.get<Decl *>());
+      }
+    }
+  }
+
+  void visitReturnStmt(ReturnStmt *returnStmt) {
+    auto expr = returnStmt->getResult();
+
+    // FIXME: Implies Void return?
+    if (!expr)
+      return;
+
+    expr = cs.generateConstraints(expr, closure, /*isInputExpression=*/false);
+    if (!expr) {
+      hadError = true;
+      return;
+    }
+
+    // FIXME: Locator should point at the return statement?
+    bool hasReturn = hasExplicitResult(closure);
+    cs.addConstraint(
+        ConstraintKind::Conversion, cs.getType(expr),
+        closureResultType,
+        cs.getConstraintLocator(
+           closure, LocatorPathElt::ClosureBody(hasReturn)));
+  }
+
+#define UNSUPPORTED_STMT(STMT) void visit##STMT##Stmt(STMT##Stmt *) { \
+      llvm_unreachable("Unsupported statement kind " #STMT);          \
+  }
+  UNSUPPORTED_STMT(Yield)
+  UNSUPPORTED_STMT(Defer)
+  UNSUPPORTED_STMT(If)
+  UNSUPPORTED_STMT(Guard)
+  UNSUPPORTED_STMT(While)
+  UNSUPPORTED_STMT(Do)
+  UNSUPPORTED_STMT(DoCatch)
+  UNSUPPORTED_STMT(RepeatWhile)
+  UNSUPPORTED_STMT(ForEach)
+  UNSUPPORTED_STMT(Switch)
+  UNSUPPORTED_STMT(Case)
+  UNSUPPORTED_STMT(Break)
+  UNSUPPORTED_STMT(Continue)
+  UNSUPPORTED_STMT(Fallthrough)
+  UNSUPPORTED_STMT(Fail)
+  UNSUPPORTED_STMT(Throw)
+  UNSUPPORTED_STMT(PoundAssert)
+#undef UNSUPPORTED_STMT
+};
+
+}
+
 bool ConstraintSystem::generateConstraints(
     ClosureExpr *closure, Type resultType) {
-  assert(closure->hasSingleExpressionBody());
-  auto closureBody = generateConstraints(
-      closure->getSingleExpressionBody(), closure, /*isInputExpression=*/false);
-  if (!closureBody)
-    return true;
-
-  bool hasReturn = hasExplicitResult(closure);
-  addConstraint(
-      ConstraintKind::Conversion, getType(closureBody),
-      resultType,
-      getConstraintLocator(closure, LocatorPathElt::ClosureBody(hasReturn)));
-  return false;
+  ClosureConstraintGenerator generator(*this, closure, resultType);
+  generator.visit(closure->getBody());
+  return generator.hadError;
 }

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -22,6 +22,8 @@ using namespace swift::constraints;
 
 namespace {
 
+// MARK: Constraint generation
+
 /// Statement visitor that generates constraints for a given closure body.
 class ClosureConstraintGenerator
     : public StmtVisitor<ClosureConstraintGenerator, void> {
@@ -128,3 +130,191 @@ bool ConstraintSystem::generateConstraints(
   generator.visit(closure->getBody());
   return generator.hadError;
 }
+
+// MARK: Solution application
+
+/// Coerce the body of the given closure expression so that it returns
+/// Void rather than the value in it.
+static void coerceClosureExprToVoid(
+    Solution &solution, ClosureExpr *closure) {
+  auto &cs = solution.getConstraintSystem();
+  auto &ctx = cs.getASTContext();
+
+  // Re-write the single-expression closure to return '()'
+  assert(closure->hasSingleExpressionBody());
+
+  // A single-expression body contains a single return statement
+  // prior to this transformation.
+  auto member = closure->getBody()->getFirstElement();
+
+  if (member.is<Stmt *>()) {
+    auto returnStmt = cast<ReturnStmt>(member.get<Stmt *>());
+    auto singleExpr = returnStmt->getResult();
+    auto voidExpr = cs.cacheType(TupleExpr::createEmpty(
+        ctx, singleExpr->getStartLoc(), singleExpr->getEndLoc(),
+        /*implicit*/ true));
+    returnStmt->setResult(voidExpr);
+
+    // For l-value types, reset to the object type. This might not be strictly
+    // necessary any more, but it's probably still a good idea.
+    if (cs.getType(singleExpr)->is<LValueType>())
+      cs.setType(singleExpr,
+                 cs.getType(singleExpr)->getWithoutSpecifierType());
+
+    solution.setExprTypes(singleExpr);
+    TypeChecker::checkIgnoredExpr(singleExpr);
+
+    SmallVector<ASTNode, 2> elements;
+    elements.push_back(singleExpr);
+    elements.push_back(returnStmt);
+
+    auto braceStmt = BraceStmt::create(ctx, closure->getStartLoc(),
+                                       elements, closure->getEndLoc(),
+                                       /*implicit*/ true);
+
+    closure->setImplicit();
+    closure->setBody(braceStmt, /*isSingleExpression*/true);
+  }
+
+  // Finally, compute the proper type for the closure.
+  auto fnType = cs.getType(closure)->getAs<FunctionType>();
+  auto newClosureType = FunctionType::get(
+      fnType->getParams(), ctx.TheEmptyTupleType, fnType->getExtInfo());
+  cs.setType(closure, newClosureType);
+}
+
+/// Coerce a closure whose body produces \c Never into one that does not
+/// return its result.
+static void coerceClosureExprFromNever(
+    Solution &solution, ClosureExpr *closure) {
+  auto &cs = solution.getConstraintSystem();
+
+  // Re-write the single-expression closure to drop the 'return'.
+  assert(closure->hasSingleExpressionBody());
+
+  // A single-expression body contains a single return statement
+  // prior to this transformation.
+  auto member = closure->getBody()->getFirstElement();
+
+  if (member.is<Stmt *>()) {
+    auto returnStmt = cast<ReturnStmt>(member.get<Stmt *>());
+    auto singleExpr = returnStmt->getResult();
+
+    solution.setExprTypes(singleExpr);
+    TypeChecker::checkIgnoredExpr(singleExpr);
+
+    SmallVector<ASTNode, 1> elements;
+    elements.push_back(singleExpr);
+
+    auto braceStmt =
+        BraceStmt::create(cs.getASTContext(), closure->getStartLoc(),
+                          elements, closure->getEndLoc(),
+                          /*implicit*/ true);
+
+    closure->setImplicit();
+    closure->setBody(braceStmt, /*isSingleExpression*/true);
+  }
+}
+
+SolutionApplicationToFunctionResult ConstraintSystem::applySolution(
+    Solution &solution, AnyFunctionRef fn,
+    DeclContext *&currentDC,
+    std::function<
+      Optional<SolutionApplicationTarget> (SolutionApplicationTarget)>
+        rewriteTarget) {
+  auto &cs = solution.getConstraintSystem();
+  auto closure = dyn_cast_or_null<ClosureExpr>(fn.getAbstractClosureExpr());
+  FunctionType *closureFnType = nullptr;
+  if (closure) {
+    // Update the closure's type.
+    auto closureType = solution.simplifyType(cs.getType(closure));
+    cs.setType(closure, closureType);
+
+    // Coerce the parameter types.
+    closureFnType = closureType->castTo<FunctionType>();
+    auto *params = closure->getParameters();
+    TypeChecker::coerceParameterListToType(params, closure, closureFnType);
+
+    // Coerce the result type, if it was written explicitly.
+    if (closure->hasExplicitResultType()) {
+      closure->setExplicitResultType(closureFnType->getResult());
+    }
+  }
+
+  // Enter the context of the function before performing any additional
+  // transformations.
+  llvm::SaveAndRestore<DeclContext *> savedDC(currentDC, fn.getAsDeclContext());
+
+  // Apply the function builder transform, if there is one.
+  if (auto transform = solution.getAppliedBuilderTransform(fn)) {
+    // Apply the function builder to the closure. We want to be in the
+    // context of the closure for subsequent transforms.
+    auto newBody = applyFunctionBuilderTransform(
+        solution, *transform, fn.getBody(), fn.getAsDeclContext(),
+        [&](SolutionApplicationTarget target) {
+          auto resultTarget = rewriteTarget(target);
+          if (resultTarget) {
+            if (auto expr = resultTarget->getAsExpr())
+              solution.setExprTypes(expr);
+          }
+
+          return resultTarget;
+        });
+    if (!newBody)
+      return SolutionApplicationToFunctionResult::Failure;
+
+    fn.setBody(newBody, /*isSingleExpression=*/false);
+    if (closure) {
+      closure->setAppliedFunctionBuilder();
+      solution.setExprTypes(closure);
+    }
+
+    return SolutionApplicationToFunctionResult::Success;
+  }
+
+  // If there is a single-expression body, transform that body now.
+  if (fn.hasSingleExpressionBody()) {
+    // Rewrite the body.
+    SolutionApplicationTarget originalBody(
+        fn.getSingleExpressionBody(), fn.getAsDeclContext(), CTP_Unused,
+        Type(), /*isDiscarded=*/false);
+    auto rewrittenBody = rewriteTarget(originalBody);
+    if (!rewrittenBody)
+      return SolutionApplicationToFunctionResult::Failure;
+
+    auto body = rewrittenBody->getAsExpr();
+    fn.setSingleExpressionBody(body);
+
+    // Closures with a single-expression body have special rules regarding
+    // Void and Never returns. Handle them now.
+    if (closure && closure->hasSingleExpressionBody()) {
+      auto bodyType = body->getType();
+
+      // A single-expression closure with a non-Void expression type
+      // coerces to a Void-returning function type.
+      if (closureFnType->getResult()->isVoid() && !bodyType->isVoid()) {
+        coerceClosureExprToVoid(solution, closure);
+      // A single-expression closure with a Never expression type
+      // coerces to any other function type.
+      } else if (bodyType->isUninhabited()) {
+        coerceClosureExprFromNever(solution, closure);
+      } else {
+        body = solution.coerceToType(body, closureFnType->getResult(),
+                                     cs.getConstraintLocator(
+                                       closure,
+                                       ConstraintLocator::ClosureResult));
+        if (!body)
+          return SolutionApplicationToFunctionResult::Failure;
+
+        closure->setSingleExpressionBody(body);
+      }
+    }
+
+    return SolutionApplicationToFunctionResult::Success;
+  }
+
+  // Otherwise, we need to delay type checking of the closure until later.
+  solution.setExprTypes(closure);
+  return SolutionApplicationToFunctionResult::Delay;
+}
+

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4418,24 +4418,10 @@ bool ConstraintSystem::generateConstraints(
   llvm_unreachable("BOOM");
 }
 
-bool ConstraintSystem::generateConstraints(
-    ClosureExpr *closure, Type resultType) {
-  assert(closure->hasSingleExpressionBody());
-  auto closureBody = generateConstraintsFor(
-      *this, closure->getSingleExpressionBody(), closure);
-  if (!closureBody)
-    return true;
-
-  bool hasReturn = hasExplicitResult(closure);
-  addConstraint(
-      ConstraintKind::Conversion, getType(closureBody),
-      resultType,
-      getConstraintLocator(closure, LocatorPathElt::ClosureBody(hasReturn)));
-  return false;
-}
-
-Expr *ConstraintSystem::generateConstraints(Expr *expr, DeclContext *dc) {
-  InputExprs.insert(expr);
+Expr *ConstraintSystem::generateConstraints(
+    Expr *expr, DeclContext *dc, bool isInputExpression) {
+  if (isInputExpression)
+    InputExprs.insert(expr);
   return generateConstraintsFor(*this, expr, dc);
 }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4418,10 +4418,20 @@ bool ConstraintSystem::generateConstraints(
   llvm_unreachable("BOOM");
 }
 
-Expr *ConstraintSystem::generateConstraints(ClosureExpr *closure) {
+bool ConstraintSystem::generateConstraints(
+    ClosureExpr *closure, Type resultType) {
   assert(closure->hasSingleExpressionBody());
-  return generateConstraintsFor(*this, closure->getSingleExpressionBody(),
-                                closure);
+  auto closureBody = generateConstraintsFor(
+      *this, closure->getSingleExpressionBody(), closure);
+  if (!closureBody)
+    return true;
+
+  bool hasReturn = hasExplicitResult(closure);
+  addConstraint(
+      ConstraintKind::Conversion, getType(closureBody),
+      resultType,
+      getConstraintLocator(closure, LocatorPathElt::ClosureBody(hasReturn)));
+  return false;
 }
 
 Expr *ConstraintSystem::generateConstraints(Expr *expr, DeclContext *dc) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7162,14 +7162,8 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
   // If this is a multi-statement closure its body doesn't participate
   // in type-checking.
   if (closure->hasSingleExpressionBody()) {
-    auto *closureBody = generateConstraints(closure);
-    if (!closureBody)
+    if (generateConstraints(closure, closureType->getResult()))
       return false;
-
-    addConstraint(
-        ConstraintKind::Conversion, getType(closureBody),
-        closureType->getResult(),
-        getConstraintLocator(closure, LocatorPathElt::ClosureBody(hasReturn)));
   } else if (!hasReturn) {
     // If this closure has an empty body and no explicit result type
     // let's bind result type to `Void` since that's the only type empty body

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3576,10 +3576,13 @@ public:
   bool generateConstraints(SolutionApplicationTarget &target,
                            FreeTypeVariableBinding allowFreeTypeVariables);
 
-  /// Generate constraints for the body of the given single-statement closure.
+  /// Generate constraints for the body of the given closure.
   ///
-  /// \returns a possibly-sanitized expression, or null if an error occurred.
-  Expr *generateConstraints(ClosureExpr *closure);
+  /// \param closure the closure expression
+  /// \param resultType the closure's result type
+  ///
+  /// \returns \c true if constraint generation failed, \c false otherwise
+  bool generateConstraints(ClosureExpr *closure, Type resultType);
 
   /// Generate constraints for the given (unchecked) expression.
   ///

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1625,6 +1625,11 @@ public:
   SolutionApplicationTarget walk(ASTWalker &walker);
 };
 
+/// A function that rewrites a solution application target in the context
+/// of solution application.
+using RewriteTargetFn = std::function<
+    Optional<SolutionApplicationTarget> (SolutionApplicationTarget)>;
+
 enum class ConstraintSystemPhase {
   ConstraintGeneration,
   Solving,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3587,7 +3587,8 @@ public:
   /// Generate constraints for the given (unchecked) expression.
   ///
   /// \returns a possibly-sanitized expression, or null if an error occurred.
-  Expr *generateConstraints(Expr *E, DeclContext *dc);
+  Expr *generateConstraints(Expr *E, DeclContext *dc,
+                            bool isInputExpression = true);
 
   /// Generate constraints for binding the given pattern to the
   /// value of the given expression.

--- a/test/ModuleInterface/function_builders.swift
+++ b/test/ModuleInterface/function_builders.swift
@@ -26,7 +26,15 @@ public struct TupleBuilder {
     return (t1, t2, t3, t4, t5)
   }
 
-  public static func buildDo<T>(_ value: T) -> T { return value }
+  public static func buildDo<T1, T2>(_ t1: T1, _ t2: T2) -> (T1, T2) {
+    return (t1, t2)
+  }
+
+  public static func buildDo<T1, T2, T3>(_ t1: T1, _ t2: T2, _ t3: T3)
+      -> (T1, T2, T3) {
+    return (t1, t2, t3)
+  }
+
   public static func buildIf<T>(_ value: T?) -> T? { return value }
 }
 


### PR DESCRIPTION
Refactor the type checking of closures so that they use statement visitors to generate constraints and apply solutions, the same way as function builders do. This refactoring is not intended to change semantics; rather, it moves over to a pattern we use everywhere else in the type checker that can then be (experimentally) extended to support type inference through multi-statement closures.