### PR TITLE
DependenciesScanner: propagate front-end arguments for disabling implicit Swift/Clang modules  

### DIFF
--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -82,6 +82,9 @@ public:
   /// would for a non-system header.
   bool DisableModulesValidateSystemDependencies = false;
 
+  /// The paths to a set of explicitly built modules from interfaces.
+  std::vector<std::string> ExplicitSwiftModules;
+
 private:
   static StringRef
   pathStringFromFrameworkSearchPath(const FrameworkSearchPath &next) {

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -473,6 +473,7 @@ public:
 
   bool isSerializable(const clang::Type *type,
                       bool checkCanonical) const override;
+  ArrayRef<std::string> getExtraClangArgs() const;
 };
 
 ImportDecl *createImportDecl(ASTContext &Ctx, DeclContext *DC, ClangNode ClangN,

--- a/include/swift/ClangImporter/ClangImporterOptions.h
+++ b/include/swift/ClangImporter/ClangImporterOptions.h
@@ -103,6 +103,10 @@ public:
   /// DWARFImporter delegate.
   bool DisableSourceImport = false;
 
+  /// When set, use ExtraArgs alone to configure clang instance because ExtraArgs
+  /// contains the full option set.
+  bool ExtraArgsOnly = false;
+
   /// Return a hash code of any components from these options that should
   /// contribute to a Swift Bridging PCH hash.
   llvm::hash_code getPCHHashComponents() const {

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -262,9 +262,6 @@ public:
   /// built and given to the compiler invocation.
   bool DisableImplicitModules = false;
 
-  /// The paths to a set of explicitly built modules from interfaces.
-  std::vector<std::string> ExplicitSwiftModules;
-
   /// The different modes for validating TBD against the LLVM IR.
   enum class TBDValidationMode {
     Default,        ///< Do the default validation for the current platform.

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -258,6 +258,13 @@ public:
   /// By default, we include ImplicitObjCHeaderPath directly.
   llvm::Optional<std::string> BridgingHeaderDirForPrint;
 
+  /// Disable implicitly built Swift modules because they are explicitly
+  /// built and given to the compiler invocation.
+  bool DisableImplicitModules = false;
+
+  /// The paths to a set of explicitly built modules from interfaces.
+  std::vector<std::string> ExplicitSwiftModules;
+
   /// The different modes for validating TBD against the LLVM IR.
   enum class TBDValidationMode {
     Default,        ///< Do the default validation for the current platform.

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -131,10 +131,12 @@ struct ModuleInterfaceLoaderOptions {
   bool remarkOnRebuildFromInterface = false;
   bool disableInterfaceLock = false;
   bool disableImplicitSwiftModule = false;
+  std::vector<std::string> explicitSwiftModules;
   ModuleInterfaceLoaderOptions(const FrontendOptions &Opts):
     remarkOnRebuildFromInterface(Opts.RemarkOnRebuildFromModuleInterface),
     disableInterfaceLock(Opts.DisableInterfaceFileLock),
-    disableImplicitSwiftModule(Opts.DisableImplicitModules) {}
+    disableImplicitSwiftModule(Opts.DisableImplicitModules),
+    explicitSwiftModules(Opts.ExplicitSwiftModules) {}
   ModuleInterfaceLoaderOptions() = default;
 };
 /// A ModuleLoader that runs a subordinate \c CompilerInvocation and

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -131,12 +131,10 @@ struct ModuleInterfaceLoaderOptions {
   bool remarkOnRebuildFromInterface = false;
   bool disableInterfaceLock = false;
   bool disableImplicitSwiftModule = false;
-  std::vector<std::string> explicitSwiftModules;
   ModuleInterfaceLoaderOptions(const FrontendOptions &Opts):
     remarkOnRebuildFromInterface(Opts.RemarkOnRebuildFromModuleInterface),
     disableInterfaceLock(Opts.DisableInterfaceFileLock),
-    disableImplicitSwiftModule(Opts.DisableImplicitModules),
-    explicitSwiftModules(Opts.ExplicitSwiftModules) {}
+    disableImplicitSwiftModule(Opts.DisableImplicitModules) {}
   ModuleInterfaceLoaderOptions() = default;
 };
 /// A ModuleLoader that runs a subordinate \c CompilerInvocation and

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -214,6 +214,11 @@ def disable_objc_attr_requires_foundation_module :
 def enable_resilience : Flag<["-"], "enable-resilience">,
    HelpText<"Deprecated, use -enable-library-evolution instead">;
 
+def disable_implicit_swift_modules: Flag<["-"], "disable-implicit-swift-modules">,
+  HelpText<"Disable building Swift modules explicitly by the compiler">;
+
+def swift_module_file_EQ : Joined<["-"], "swift-module-file=">,
+  HelpText<"Specify Swift module explicitly built from textual interface">;
 }
 
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -217,8 +217,9 @@ def enable_resilience : Flag<["-"], "enable-resilience">,
 def disable_implicit_swift_modules: Flag<["-"], "disable-implicit-swift-modules">,
   HelpText<"Disable building Swift modules explicitly by the compiler">;
 
-def swift_module_file_EQ : Joined<["-"], "swift-module-file=">,
-  HelpText<"Specify Swift module explicitly built from textual interface">;
+def swift_module_file
+  : Separate<["-"], "swift-module-file">, MetaVarName<"<path>">,
+    HelpText<"Specify Swift module explicitly built from textual interface">;
 }
 
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -717,4 +717,6 @@ def target_sdk_version : Separate<["-"], "target-sdk-version">,
 def target_variant_sdk_version : Separate<["-"], "target-variant-sdk-version">,
   HelpText<"The version of target variant SDK used for compilation">;
 
+def extra_clang_options_only : Flag<["-"], "only-use-extra-clang-opts">,
+  HelpText<"Options passed via -Xcc are sufficient for Clang configuration">;
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -908,6 +908,9 @@ ClangImporter::getOrCreatePCH(const ClangImporterOptions &ImporterOptions,
 std::vector<std::string>
 ClangImporter::getClangArguments(ASTContext &ctx,
                                  const ClangImporterOptions &importerOpts) {
+  if (importerOpts.ExtraArgsOnly) {
+    return importerOpts.ExtraArgs;
+  }
   std::vector<std::string> invocationArgStrs;
   // Clang expects this to be like an actual command line. So we need to pass in
   // "clang" for argv[0]

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -957,6 +957,10 @@ ClangImporter::createClangInvocation(ClangImporter *importer,
                                                 nullptr, false, CC1Args);
 }
 
+ArrayRef<std::string> ClangImporter::getExtraClangArgs() const {
+  return Impl.ExtraClangArgs;
+}
+
 std::unique_ptr<ClangImporter>
 ClangImporter::create(ASTContext &ctx, const ClangImporterOptions &importerOpts,
                       std::string swiftPCHHash, DependencyTracker *tracker,
@@ -965,7 +969,7 @@ ClangImporter::create(ASTContext &ctx, const ClangImporterOptions &importerOpts,
       new ClangImporter(ctx, importerOpts, tracker, dwarfImporterDelegate)};
   importer->Impl.ClangArgs = getClangArguments(ctx, importerOpts);
   ArrayRef<std::string> invocationArgStrs = importer->Impl.ClangArgs;
-
+  importer->Impl.ExtraClangArgs = importerOpts.ExtraArgs;
   if (importerOpts.DumpClangDiagnostics) {
     llvm::errs() << "'";
     llvm::interleave(

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -392,6 +392,9 @@ private:
 
   /// Clang arguments used to create the Clang invocation.
   std::vector<std::string> ClangArgs;
+
+  /// Extra clang args specified via "-Xcc"
+  std::vector<std::string> ExtraClangArgs;
 public:
   /// Mapping of already-imported declarations.
   llvm::DenseMap<std::pair<const clang::Decl *, Version>, Decl *> ImportedDecls;

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -85,10 +85,6 @@ bool ArgsToFrontendOptionsConverter::convert(
 
   Opts.DisableImplicitModules |= Args.hasArg(OPT_disable_implicit_swift_modules);
 
-  for (auto A: Args.getAllArgValues(OPT_swift_module_file_EQ)) {
-    Opts.ExplicitSwiftModules.push_back(A);
-  }
-
   // Always track system dependencies when scanning dependencies.
   if (const Arg *ModeArg = Args.getLastArg(OPT_modes_Group)) {
     if (ModeArg->getOption().matches(OPT_scan_dependencies))

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -83,6 +83,12 @@ bool ArgsToFrontendOptionsConverter::convert(
 
   Opts.TrackSystemDeps |= Args.hasArg(OPT_track_system_dependencies);
 
+  Opts.DisableImplicitModules |= Args.hasArg(OPT_disable_implicit_swift_modules);
+
+  for (auto A: Args.getAllArgValues(OPT_swift_module_file_EQ)) {
+    Opts.ExplicitSwiftModules.push_back(A);
+  }
+
   // Always track system dependencies when scanning dependencies.
   if (const Arg *ModeArg = Args.getLastArg(OPT_modes_Group)) {
     if (ModeArg->getOption().matches(OPT_scan_dependencies))

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -865,6 +865,9 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts,
   Opts.DisableModulesValidateSystemDependencies |=
       Args.hasArg(OPT_disable_modules_validate_system_headers);
 
+  for (auto A: Args.filtered(OPT_swift_module_file_EQ)) {
+    Opts.ExplicitSwiftModules.push_back(resolveSearchPath(A->getValue()));
+  }
   // Opts.RuntimeIncludePath is set by calls to
   // setRuntimeIncludePath() or setMainExecutablePath().
   // Opts.RuntimeImportPath is set by calls to

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -802,6 +802,8 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
 
   Opts.DisableOverlayModules |= Args.hasArg(OPT_emit_imported_modules);
 
+  Opts.ExtraArgsOnly |= Args.hasArg(OPT_extra_clang_options_only);
+
   if (const Arg *A = Args.getLastArg(OPT_pch_output_dir)) {
     Opts.PrecompiledHeaderOutputDir = A->getValue();
     Opts.PCHDisableValidation |= Args.hasArg(OPT_pch_disable_validation);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -865,7 +865,7 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts,
   Opts.DisableModulesValidateSystemDependencies |=
       Args.hasArg(OPT_disable_modules_validate_system_headers);
 
-  for (auto A: Args.filtered(OPT_swift_module_file_EQ)) {
+  for (auto A: Args.filtered(OPT_swift_module_file)) {
     Opts.ExplicitSwiftModules.push_back(resolveSearchPath(A->getValue()));
   }
   // Opts.RuntimeIncludePath is set by calls to

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -455,13 +455,12 @@ bool CompilerInstance::setUpModuleLoaders() {
     std::string ModuleCachePath = getModuleCachePathFromClang(Clang);
     auto &FEOpts = Invocation.getFrontendOptions();
     StringRef PrebuiltModuleCachePath = FEOpts.PrebuiltModuleCachePath;
+    ModuleInterfaceLoaderOptions LoaderOpts(FEOpts);
     auto PIML = ModuleInterfaceLoader::create(
         *Context, ModuleCachePath, PrebuiltModuleCachePath,
         getDependencyTracker(), MLM, FEOpts.PreferInterfaceForModules,
-        FEOpts.RemarkOnRebuildFromModuleInterface,
-        IgnoreSourceInfoFile,
-        FEOpts.DisableInterfaceFileLock,
-        FEOpts.DisableImplicitModules);
+        LoaderOpts,
+        IgnoreSourceInfoFile);
     Context->addModuleLoader(std::move(PIML));
   }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -460,7 +460,8 @@ bool CompilerInstance::setUpModuleLoaders() {
         getDependencyTracker(), MLM, FEOpts.PreferInterfaceForModules,
         FEOpts.RemarkOnRebuildFromModuleInterface,
         IgnoreSourceInfoFile,
-        FEOpts.DisableInterfaceFileLock);
+        FEOpts.DisableInterfaceFileLock,
+        FEOpts.DisableImplicitModules);
     Context->addModuleLoader(std::move(PIML));
   }
 

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1201,6 +1201,14 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
     subInvocation.getFrontendOptions().DisableImplicitModules = true;
     GenericArgs.push_back("-disable-implicit-swift-modules");
   }
+  subInvocation.getFrontendOptions().ExplicitSwiftModules =
+    LoaderOpts.explicitSwiftModules;
+  // Dependencies scanner shouldn't know any explict Swift modules to use.
+  // Adding these argumnets may not be necessary.
+  // FIXME: remove it?
+  for (auto EM: LoaderOpts.explicitSwiftModules) {
+    GenericArgs.push_back(ArgSaver.save((llvm::Twine("-swift-module-file=") + EM).str()));
+  }
   if (clangImporter) {
     // We need to add these extra clang flags because explict module building
     // related flags are all there: -fno-implicit-modules, -fmodule-map-file=,

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1201,12 +1201,12 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
     subInvocation.getFrontendOptions().DisableImplicitModules = true;
     GenericArgs.push_back("-disable-implicit-swift-modules");
   }
-  subInvocation.getFrontendOptions().ExplicitSwiftModules =
-    LoaderOpts.explicitSwiftModules;
+  subInvocation.getSearchPathOptions().ExplicitSwiftModules =
+    searchPathOpts.ExplicitSwiftModules;
   // Dependencies scanner shouldn't know any explict Swift modules to use.
   // Adding these argumnets may not be necessary.
   // FIXME: remove it?
-  for (auto EM: LoaderOpts.explicitSwiftModules) {
+  for (auto EM: searchPathOpts.ExplicitSwiftModules) {
     GenericArgs.push_back(ArgSaver.save((llvm::Twine("-swift-module-file=") + EM).str()));
   }
   if (clangImporter) {

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1207,7 +1207,8 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
   // Adding these argumnets may not be necessary.
   // FIXME: remove it?
   for (auto EM: searchPathOpts.ExplicitSwiftModules) {
-    GenericArgs.push_back(ArgSaver.save((llvm::Twine("-swift-module-file=") + EM).str()));
+    GenericArgs.push_back("-swift-module-file");
+    GenericArgs.push_back(ArgSaver.save(EM));
   }
   if (clangImporter) {
     // We need to add these extra clang flags because explict module building

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1368,10 +1368,6 @@ bool InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleN
   subInvocation.getFrontendOptions().InputsAndOutputs
     .setMainAndSupplementaryOutputs(outputFiles, ModuleOutputPaths);
 
-  // Add -o for building the module explicitly.
-  BuildArgs.push_back("-o");
-  BuildArgs.push_back(outputPath);
-
   SmallVector<const char *, 64> SubArgs;
   std::string CompilerVersion;
   // Extract compiler arguments from the interface file and use them to configure

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -778,6 +778,7 @@ static bool buildModuleFromInterface(CompilerInstance &Instance) {
   assert(FEOpts.InputsAndOutputs.hasSingleInput());
   StringRef InputPath = FEOpts.InputsAndOutputs.getFilenameOfFirstInput();
   StringRef PrebuiltCachePath = FEOpts.PrebuiltModuleCachePath;
+  ModuleInterfaceLoaderOptions LoaderOpts(FEOpts);
   return ModuleInterfaceLoader::buildSwiftModuleFromSwiftInterface(
       Instance.getSourceMgr(), Instance.getDiags(),
       Invocation.getSearchPathOptions(), Invocation.getLangOptions(),
@@ -786,9 +787,7 @@ static bool buildModuleFromInterface(CompilerInstance &Instance) {
       PrebuiltCachePath, Invocation.getModuleName(), InputPath,
       Invocation.getOutputFilename(),
       FEOpts.SerializeModuleInterfaceDependencyHashes,
-      FEOpts.TrackSystemDeps, FEOpts.RemarkOnRebuildFromModuleInterface,
-      FEOpts.DisableInterfaceFileLock,
-      FEOpts.DisableImplicitModules);
+      FEOpts.TrackSystemDeps, LoaderOpts);
 }
 
 static bool compileLLVMIR(CompilerInstance &Instance) {

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -781,12 +781,14 @@ static bool buildModuleFromInterface(CompilerInstance &Instance) {
   return ModuleInterfaceLoader::buildSwiftModuleFromSwiftInterface(
       Instance.getSourceMgr(), Instance.getDiags(),
       Invocation.getSearchPathOptions(), Invocation.getLangOptions(),
+      Invocation.getClangImporterOptions(),
       Invocation.getClangModuleCachePath(),
       PrebuiltCachePath, Invocation.getModuleName(), InputPath,
       Invocation.getOutputFilename(),
       FEOpts.SerializeModuleInterfaceDependencyHashes,
       FEOpts.TrackSystemDeps, FEOpts.RemarkOnRebuildFromModuleInterface,
-      FEOpts.DisableInterfaceFileLock);
+      FEOpts.DisableInterfaceFileLock,
+      FEOpts.DisableImplicitModules);
 }
 
 static bool compileLLVMIR(CompilerInstance &Instance) {

--- a/lib/FrontendTool/ScanDependencies.cpp
+++ b/lib/FrontendTool/ScanDependencies.cpp
@@ -69,17 +69,16 @@ static std::vector<ModuleDependencyID> resolveDirectDependencies(
   auto ModuleCachePath = getModuleCachePathFromClang(ctx
     .getClangModuleLoader()->getClangInstance());
   auto &FEOpts = instance.getInvocation().getFrontendOptions();
+  ModuleInterfaceLoaderOptions LoaderOpts(FEOpts);
   InterfaceSubContextDelegateImpl ASTDelegate(ctx.SourceMgr, ctx.Diags,
                                               ctx.SearchPathOpts, ctx.LangOpts,
+                                              LoaderOpts,
                                               ctx.getClangModuleLoader(),
                                               /*buildModuleCacheDirIfAbsent*/false,
                                               ModuleCachePath,
                                               FEOpts.PrebuiltModuleCachePath,
                                               FEOpts.SerializeModuleInterfaceDependencyHashes,
-                                              FEOpts.TrackSystemDeps,
-                                              FEOpts.RemarkOnRebuildFromModuleInterface,
-                                              FEOpts.DisableInterfaceFileLock,
-                                              FEOpts.DisableImplicitModules);
+                                              FEOpts.TrackSystemDeps);
   // Find the dependencies of every module this module directly depends on.
   std::vector<ModuleDependencyID> result;
   for (auto dependsOn : knownDependencies.getModuleDependencies()) {

--- a/lib/FrontendTool/ScanDependencies.cpp
+++ b/lib/FrontendTool/ScanDependencies.cpp
@@ -78,7 +78,8 @@ static std::vector<ModuleDependencyID> resolveDirectDependencies(
                                               FEOpts.SerializeModuleInterfaceDependencyHashes,
                                               FEOpts.TrackSystemDeps,
                                               FEOpts.RemarkOnRebuildFromModuleInterface,
-                                              FEOpts.DisableInterfaceFileLock);
+                                              FEOpts.DisableInterfaceFileLock,
+                                              FEOpts.DisableImplicitModules);
   // Find the dependencies of every module this module directly depends on.
   std::vector<ModuleDependencyID> result;
   for (auto dependsOn : knownDependencies.getModuleDependencies()) {

--- a/test/ScanDependencies/Inputs/BuildModulesFromGraph.swift
+++ b/test/ScanDependencies/Inputs/BuildModulesFromGraph.swift
@@ -39,6 +39,8 @@ func findModuleBuildingCommand(_ moduleName: String) -> [String]? {
 if let command = findModuleBuildingCommand(moduleName) {
   var result = swiftPath
   command.forEach { result += " \($0)"}
+  // Pass down additional args to the Swift invocation.
+  CommandLine.arguments.dropFirst(4).forEach { result += " \($0)"}
   print(result)
   exit(0)
 } else {

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/clang-module-cache
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -disable-implicit-swift-modules -Xcc -Xclang -Xcc -fno-implicit-modules
 
 // Check the contents of the JSON output
 // RUN: %FileCheck %s < %t/deps.json

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -22,20 +22,15 @@
 // RUN: %target-build-swift %S/Inputs/ModuleDependencyGraph.swift %t/BuildModules/main.swift -o %t/ModuleBuilder
 // RUN: %target-codesign %t/ModuleBuilder
 
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path A.pcm | %S/Inputs/CommandRunner.py
-// RUN: ls %t/clang-module-cache/A-*.pcm
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path B.pcm | %S/Inputs/CommandRunner.py
-// RUN: ls %t/clang-module-cache/B-*.pcm
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path C.pcm | %S/Inputs/CommandRunner.py
-// RUN: ls %t/clang-module-cache/C-*.pcm
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path A.swiftmodule | %S/Inputs/CommandRunner.py
-// RUN: ls %t/clang-module-cache/A-*.swiftmodule
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path E.swiftmodule | %S/Inputs/CommandRunner.py
-// RUN: ls %t/clang-module-cache/E-*.swiftmodule
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path F.swiftmodule | %S/Inputs/CommandRunner.py
-// RUN: ls %t/clang-module-cache/F-*.swiftmodule
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path G.swiftmodule | %S/Inputs/CommandRunner.py
-// RUN: ls %t/clang-module-cache/G-*.swiftmodule
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path SwiftShims.pcm -o %t/clang-module-cache/SwiftShims.pcm | %S/Inputs/CommandRunner.py
+// RUN: ls %t/clang-module-cache/SwiftShims.pcm
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path A.pcm -o %t/clang-module-cache/A.pcm | %S/Inputs/CommandRunner.py
+// RUN: ls %t/clang-module-cache/A.pcm
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path B.pcm -o %t/clang-module-cache/B.pcm -Xcc -Xclang -Xcc -fmodule-map-file=%S/Inputs/CHeaders/module.modulemap -Xcc -Xclang -Xcc -fmodule-file=%t/clang-module-cache/A.pcm | %S/Inputs/CommandRunner.py
+// RUN: ls %t/clang-module-cache/B.pcm
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path C.pcm -o %t/clang-module-cache/C.pcm -Xcc -Xclang -Xcc -fmodule-map-file=%S/Inputs/CHeaders/module.modulemap -Xcc -Xclang -Xcc -fmodule-file=%t/clang-module-cache/B.pcm | %S/Inputs/CommandRunner.py
+// RUN: ls %t/clang-module-cache/C.pcm
+
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
@@ -135,8 +130,6 @@ import G
 // CHECK: "-compile-module-from-interface"
 // CHECK: "-target"
 // CHECK: "-sdk"
-// CHECK: "-o"
-// CHECK: /clang-module-cache/G-{{.*}}.swiftmodule"
 // CHECK: "-module-name"
 // CHECK: "G"
 // CHECK: "-swift-version"

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -31,6 +31,12 @@
 // RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path C.pcm -o %t/clang-module-cache/C.pcm -Xcc -Xclang -Xcc -fmodule-map-file=%S/Inputs/CHeaders/module.modulemap -Xcc -Xclang -Xcc -fmodule-file=%t/clang-module-cache/B.pcm | %S/Inputs/CommandRunner.py
 // RUN: ls %t/clang-module-cache/C.pcm
 
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path A.swiftmodule -o %t/clang-module-cache/A.swiftmodule -Xcc -Xclang -Xcc -fmodule-map-file=%S/Inputs/CHeaders/module.modulemap -Xcc -Xclang -Xcc -fmodule-file=%t/clang-module-cache/A.pcm -Xcc -Xclang -Xcc -fmodule-file=%t/clang-module-cache/SwiftShims.pcm | %S/Inputs/CommandRunner.py
+// RUN: ls %t/clang-module-cache/A.swiftmodule
+
+// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path E.swiftmodule -o %t/clang-module-cache/E.swiftmodule -Xcc -Xclang -Xcc -fmodule-map-file=%S/Inputs/CHeaders/module.modulemap -Xcc -Xclang -Xcc -fmodule-file=%t/clang-module-cache/SwiftShims.pcm | %S/Inputs/CommandRunner.py
+// RUN: ls %t/clang-module-cache/E.swiftmodule
+
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
@@ -100,11 +106,10 @@ import G
 
 // CHECK: "commandLine": [
 // CHECK-NEXT: "-frontend"
+// CHECK-NEXT: "-only-use-extra-clang-opts"
 // CHECK-NEXT: "-Xcc"
-// CHECK-NEXT: "-Xclang"
-// CHECK-NEXT: "-Xcc"
-// CHECK-NEXT: "-cc1"
-// CHECK: "-remove-preceeding-explicit-module-build-incompatible-options"
+// CHECK-NEXT: "clang"
+// CHECK: "-fno-implicit-modules"
 
 /// --------Swift module E
 // CHECK: "swift": "E"


### PR DESCRIPTION
The PR focuses on propagating several flags related to explicit module building:

- For Clang modules, we need build system to pass down extra clang flags `-fno-implicit-modules`, `-fmodule-map-file=` , `-fmodule-file=` to avoid building PCMs implicitly from the Swift compiler.

- New flags `-disable-implicit-swift-modules` to prevent and stop the compilers from building any Swift modules from interfaces implicitly and diagnose if they have to.

rdar://62613306