### PR TITLE
build: switch gyb to Python3

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -23,7 +23,7 @@ function(_swift_gyb_target_sources target scope)
 
     add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${generated}
       COMMAND
-        $<TARGET_FILE:Python2::Interpreter> ${SWIFT_SOURCE_DIR}/utils/gyb -D CMAKE_SIZEOF_VOID_P=${CMAKE_SIZEOF_VOID_P} ${SWIFT_GYB_FLAGS} -o ${CMAKE_CURRENT_BINARY_DIR}/${generated}.tmp ${absolute}
+        $<TARGET_FILE:Python3::Interpreter> ${SWIFT_SOURCE_DIR}/utils/gyb -D CMAKE_SIZEOF_VOID_P=${CMAKE_SIZEOF_VOID_P} ${SWIFT_GYB_FLAGS} -o ${CMAKE_CURRENT_BINARY_DIR}/${generated}.tmp ${absolute}
       COMMAND
         ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/${generated}.tmp ${CMAKE_CURRENT_BINARY_DIR}/${generated}
       COMMAND

--- a/cmake/modules/SwiftHandleGybSources.cmake
+++ b/cmake/modules/SwiftHandleGybSources.cmake
@@ -1,8 +1,6 @@
 include(SwiftAddCustomCommandTarget)
 include(SwiftSetIfArchBitness)
 
-find_package(Python2 COMPONENTS Interpreter REQUIRED)
-
 # Create a target to process single gyb source with the 'gyb' tool.
 #
 # handle_gyb_source_single(
@@ -60,7 +58,7 @@ function(handle_gyb_source_single dependency_out_var_name)
       COMMAND
           "${CMAKE_COMMAND}" -E make_directory "${dir}"
       COMMAND
-          "$<TARGET_FILE:Python2::Interpreter>" "${gyb_tool}" ${SWIFT_GYB_FLAGS} ${GYB_SINGLE_FLAGS} -o "${GYB_SINGLE_OUTPUT}.tmp" "${GYB_SINGLE_SOURCE}"
+          "$<TARGET_FILE:Python3::Interpreter>" "${gyb_tool}" ${SWIFT_GYB_FLAGS} ${GYB_SINGLE_FLAGS} -o "${GYB_SINGLE_OUTPUT}.tmp" "${GYB_SINGLE_SOURCE}"
       COMMAND
           "${CMAKE_COMMAND}" -E copy_if_different "${GYB_SINGLE_OUTPUT}.tmp" "${GYB_SINGLE_OUTPUT}"
       COMMAND

--- a/utils/gyb_syntax_support/__init__.py
+++ b/utils/gyb_syntax_support/__init__.py
@@ -144,34 +144,36 @@ def dedented_lines(description):
     return textwrap.dedent(description).split('\n')
 
 
-def digest_syntax_node(digest, node):
-    # Hash into the syntax name and serialization code
-    digest.update(node.name)
-    digest.update(str(get_serialization_code(node.syntax_kind)))
-    for child in node.children:
-        # Hash into the expected child syntax
-        digest.update(child.syntax_kind)
-        # Hash into the child name
-        digest.update(child.name)
-        # Hash into whether the child is optional
-        digest.update(str(child.is_optional))
-
-
-def digest_syntax_token(digest, token):
-    # Hash into the token name and serialization code
-    digest.update(token.name)
-    digest.update(str(token.serialization_code))
-
-
-def digest_trivia(digest, trivia):
-    digest.update(trivia.name)
-    digest.update(str(trivia.serialization_code))
-    digest.update(str(trivia.characters))
-
-
 def calculate_node_hash():
     digest = hashlib.sha1()
-    map(lambda node: digest_syntax_node(digest, node), SYNTAX_NODES)
-    map(lambda token: digest_syntax_token(digest, token), SYNTAX_TOKENS)
-    map(lambda trivia: digest_trivia(digest, trivia), TRIVIAS)
+
+    def _digest_syntax_node(node):
+        # Hash into the syntax name and serialization code
+        digest.update(node.name.encode("utf-8"))
+        digest.update(str(get_serialization_code(node.syntax_kind)).encode("utf-8"))
+        for child in node.children:
+            # Hash into the expected child syntax
+            digest.update(child.syntax_kind.encode("utf-8"))
+            # Hash into the child name
+            digest.update(child.name.encode("utf-8"))
+            # Hash into whether the child is optional
+            digest.update(str(child.is_optional).encode("utf-8"))
+
+    def _digest_syntax_token(token):
+        # Hash into the token name and serialization code
+        digest.update(token.name.encode("utf-8"))
+        digest.update(str(token.serialization_code).encode("utf-8"))
+
+    def _digest_trivia(trivia):
+        digest.update(trivia.name.encode("utf-8"))
+        digest.update(str(trivia.serialization_code).encode("utf-8"))
+        digest.update(str(trivia.characters).encode("utf-8"))
+
+    for node in SYNTAX_NODES:
+        _digest_syntax_node(node)
+    for token in SYNTAX_TOKENS:
+        _digest_syntax_token(token)
+    for trivia in TRIVIAS:
+        _digest_trivia(trivia)
+
     return digest.hexdigest()


### PR DESCRIPTION
Change the build system to invoke gyb with python3 instead of python2.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
