### PR TITLE
[Diagnostics] Refactor diagnostics related to raw representable types

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6377,7 +6377,7 @@ void UseOfRawRepresentableInsteadOfItsRawValueFailure::fixIt(
   // out first and then, if destination is not optional, allow to specify
   // default value.
   if (RawReprType->getOptionalObjectType()) {
-    fix += ".map { $0.rawValue }";
+    fix += "?.rawValue";
 
     if (!ExpectedType->getOptionalObjectType())
       fix += " ?? <#default value#>";

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6319,23 +6319,27 @@ bool UnableToInferKeyPathRootFailure::diagnoseAsError() {
   return true;
 }
 
-bool MissingRawRepresentativeInitFailure::diagnoseAsError() {
+Optional<Diag<Type, Type>>
+AbstractRawRepresentableFailure::getDiagnostic() const {
   auto *locator = getLocator();
 
-  Optional<Diag<Type, Type>> message;
-
   if (locator->isForContextualType()) {
-    message = diag::cannot_convert_initializer_value;
+    return diag::cannot_convert_initializer_value;
   } else if (locator->isForAssignment()) {
-    message = diag::cannot_convert_assign;
+    return diag::cannot_convert_assign;
   } else if (locator->isLastElement<LocatorPathElt::ApplyArgToParam>()) {
-    message = diag::cannot_convert_argument_value;
+    return diag::cannot_convert_argument_value;
   }
 
+  return None;
+}
+
+bool AbstractRawRepresentableFailure::diagnoseAsError() {
+  auto message = getDiagnostic();
   if (!message)
     return false;
 
-  auto diagnostic = emitDiagnostic(*message, ValueType, RawReprType);
+  auto diagnostic = emitDiagnostic(*message, getFromType(), getToType());
   fixIt(diagnostic);
   return true;
 }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6395,7 +6395,7 @@ void MissingRawRepresentativeInitFailure::fixIt(
   }
 }
 
-bool MissingRawRepresentativeInitFailure::diagnoseAsNote() {
+bool AbstractRawRepresentableFailure::diagnoseAsNote() {
   auto *locator = getLocator();
 
   Optional<InFlightDiagnostic> diagnostic;
@@ -6442,10 +6442,10 @@ void UseOfRawRepresentableInsteadOfItsRawValueFailure::fixIt(
   // out first and then, if destination is not optional, allow to specify
   // default value.
   if (RawReprType->getOptionalObjectType()) {
-    fix += ".map { $0.rawValue } ";
+    fix += ".map { $0.rawValue }";
 
     if (!ExpectedType->getOptionalObjectType())
-      fix += "?? <#default value#>";
+      fix += " ?? <#default value#>";
   } else {
     fix += ".rawValue";
   }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6359,8 +6359,7 @@ void MissingRawRepresentableInitFailure::fixIt(
   }
 }
 
-void UseOfRawRepresentableInsteadOfItsRawValueFailure::fixIt(
-    InFlightDiagnostic &diagnostic) const {
+void MissingRawValueFailure::fixIt(InFlightDiagnostic &diagnostic) const {
   auto *E = getAsExpr(getAnchor());
   if (!E)
     return;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6308,7 +6308,7 @@ bool AbstractRawRepresentableFailure::diagnoseAsNote() {
   return false;
 }
 
-void MissingRawRepresentativeInitFailure::fixIt(
+void MissingRawRepresentableInitFailure::fixIt(
     InFlightDiagnostic &diagnostic) const {
   if (auto *E = getAsExpr(getAnchor())) {
     auto range = E->getSourceRange();

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6349,7 +6349,7 @@ void MissingRawRepresentativeInitFailure::fixIt(
   if (auto *E = getAsExpr(getAnchor())) {
     auto range = E->getSourceRange();
     auto rawReprObjType = RawReprType->getOptionalObjectType();
-    auto valueObjType = ValueType->getOptionalObjectType();
+    auto valueObjType = ExpectedType->getOptionalObjectType();
 
     if (rawReprObjType && valueObjType) {
       std::string mapCodeFix;
@@ -6407,7 +6407,7 @@ bool MissingRawRepresentativeInitFailure::diagnoseAsNote() {
     if (auto *decl = overload->choice.getDeclOrNull()) {
       diagnostic.emplace(emitDiagnosticAt(
           decl, diag::cannot_convert_candidate_result_to_contextual_type,
-          decl->getName(), ValueType, RawReprType));
+          decl->getName(), ExpectedType, RawReprType));
     }
   } else if (auto argConv =
                  locator->getLastElementAs<LocatorPathElt::ApplyArgToParam>()) {
@@ -6444,7 +6444,7 @@ void UseOfRawRepresentableInsteadOfItsRawValueFailure::fixIt(
   if (RawReprType->getOptionalObjectType()) {
     fix += ".map { $0.rawValue } ";
 
-    if (!ValueType->getOptionalObjectType())
+    if (!ExpectedType->getOptionalObjectType())
       fix += "?? <#default value#>";
   } else {
     fix += ".rawValue";

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6279,6 +6279,35 @@ bool AbstractRawRepresentableFailure::diagnoseAsError() {
   return true;
 }
 
+bool AbstractRawRepresentableFailure::diagnoseAsNote() {
+  auto *locator = getLocator();
+
+  Optional<InFlightDiagnostic> diagnostic;
+  if (locator->isForContextualType()) {
+    auto overload = getCalleeOverloadChoiceIfAvailable(locator);
+    if (!overload)
+      return false;
+
+    if (auto *decl = overload->choice.getDeclOrNull()) {
+      diagnostic.emplace(emitDiagnosticAt(
+          decl, diag::cannot_convert_candidate_result_to_contextual_type,
+          decl->getName(), ExpectedType, RawReprType));
+    }
+  } else if (auto argConv =
+                 locator->getLastElementAs<LocatorPathElt::ApplyArgToParam>()) {
+    diagnostic.emplace(
+        emitDiagnostic(diag::candidate_has_invalid_argument_at_position,
+                       RawReprType, argConv->getParamIdx(), /*inOut=*/false));
+  }
+
+  if (diagnostic) {
+    fixIt(*diagnostic);
+    return true;
+  }
+
+  return false;
+}
+
 void MissingRawRepresentativeInitFailure::fixIt(
     InFlightDiagnostic &diagnostic) const {
   if (auto *E = getAsExpr(getAnchor())) {
@@ -6328,35 +6357,6 @@ void MissingRawRepresentativeInitFailure::fixIt(
           .fixItInsertAfter(range.End, ") ?? <#default value#>");
     }
   }
-}
-
-bool AbstractRawRepresentableFailure::diagnoseAsNote() {
-  auto *locator = getLocator();
-
-  Optional<InFlightDiagnostic> diagnostic;
-  if (locator->isForContextualType()) {
-    auto overload = getCalleeOverloadChoiceIfAvailable(locator);
-    if (!overload)
-      return false;
-
-    if (auto *decl = overload->choice.getDeclOrNull()) {
-      diagnostic.emplace(emitDiagnosticAt(
-          decl, diag::cannot_convert_candidate_result_to_contextual_type,
-          decl->getName(), ExpectedType, RawReprType));
-    }
-  } else if (auto argConv =
-                 locator->getLastElementAs<LocatorPathElt::ApplyArgToParam>()) {
-    diagnostic.emplace(
-        emitDiagnostic(diag::candidate_has_invalid_argument_at_position,
-                       RawReprType, argConv->getParamIdx(), /*inOut=*/false));
-  }
-
-  if (diagnostic) {
-    fixIt(*diagnostic);
-    return true;
-  }
-
-  return false;
 }
 
 void UseOfRawRepresentableInsteadOfItsRawValueFailure::fixIt(

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2128,6 +2128,10 @@ public:
         ValueType(resolveType(valueType)) {}
 
   bool diagnoseAsError() override;
+  bool diagnoseAsNote() override;
+
+private:
+  void fixIt(InFlightDiagnostic &diagnostic) const;
 };
 
 } // end namespace constraints

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2149,13 +2149,10 @@ protected:
 /// ```
 ///
 /// `E.one` has to use `.rawValue` to match `Int` expected by pattern binding.
-class UseOfRawRepresentableInsteadOfItsRawValueFailure final
-    : public AbstractRawRepresentableFailure {
+class MissingRawValueFailure final : public AbstractRawRepresentableFailure {
 public:
-  UseOfRawRepresentableInsteadOfItsRawValueFailure(const Solution &solution,
-                                                   Type rawReprType,
-                                                   Type expectedType,
-                                                   ConstraintLocator *locator)
+  MissingRawValueFailure(const Solution &solution, Type rawReprType,
+                         Type expectedType, ConstraintLocator *locator)
       : AbstractRawRepresentableFailure(solution, rawReprType, expectedType,
                                         locator) {}
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2118,7 +2118,7 @@ public:
   virtual Type getToType() const = 0;
 
   bool diagnoseAsError() override;
-  bool diagnoseAsNote() override { return false; }
+  bool diagnoseAsNote() override;
 
 protected:
   Optional<Diag<Type, Type>> getDiagnostic() const;
@@ -2150,8 +2150,6 @@ public:
 
   Type getFromType() const override { return ExpectedType; }
   Type getToType() const override { return RawReprType; }
-
-  bool diagnoseAsNote() override;
 
 protected:
   void fixIt(InFlightDiagnostic &diagnostic) const override;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -219,7 +219,6 @@ protected:
   }
 
   bool conformsToKnownProtocol(Type type, KnownProtocolKind protocol) const;
-  Type isRawRepresentable(Type type, KnownProtocolKind protocol) const;
 };
 
 /// Base class for all of the diagnostics related to generic requirement
@@ -620,23 +619,6 @@ public:
 
   /// Attempt to attach any relevant fix-its to already produced diagnostic.
   void tryFixIts(InFlightDiagnostic &diagnostic) const;
-
-  /// Attempts to add fix-its for these two mistakes:
-  ///
-  /// - Passing an integer where a type conforming to RawRepresentable is
-  ///   expected, by wrapping the expression in a call to the contextual
-  ///   type's initializer
-  ///
-  /// - Passing a type conforming to RawRepresentable where an integer is
-  ///   expected, by wrapping the expression in a call to the rawValue
-  ///   accessor
-  ///
-  /// - Return true on the fixit is added, false otherwise.
-  ///
-  /// This helps migration with SDK changes.
-  bool
-  tryRawRepresentableFixIts(InFlightDiagnostic &diagnostic,
-                            KnownProtocolKind rawRepresentablePrococol) const;
 
   /// Attempts to add fix-its for these two mistakes:
   ///

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2102,6 +2102,33 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose an attempt to initialize raw representable type or convert to it
+/// a value of some other type that matches its `RawValue` type.
+///
+/// ```swift
+/// enum E : Int {
+///   case a, b, c
+/// }
+///
+/// let _: E = 0
+/// ```
+///
+/// `0` has to be wrapped into `E(rawValue: 0)` and either defaulted via `??` or
+/// force unwrapped to constitute a valid binding.
+class MissingRawRepresentativeInitFailure final : public FailureDiagnostic {
+  Type RawReprType;
+  Type ValueType;
+
+public:
+  MissingRawRepresentativeInitFailure(const Solution &solution,
+                                      Type rawReprType, Type valueType,
+                                      ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator), RawReprType(rawReprType),
+        ValueType(valueType) {}
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2157,6 +2157,35 @@ protected:
   void fixIt(InFlightDiagnostic &diagnostic) const override;
 };
 
+/// Diagnose an attempt to pass raw representable type where its raw value
+/// is expected instead.
+///
+/// ```swift
+/// enum E : Int {
+///   case one = 1
+/// }
+///
+/// let _: Int = E.one
+/// ```
+///
+/// `E.one` has to use `.rawValue` to match `Int` expected by pattern binding.
+class UseOfRawRepresentableInsteadOfItsRawValueFailure final
+    : public AbstractRawRepresentableFailure {
+public:
+  UseOfRawRepresentableInsteadOfItsRawValueFailure(const Solution &solution,
+                                                   Type rawReprType,
+                                                   Type valueType,
+                                                   ConstraintLocator *locator)
+      : AbstractRawRepresentableFailure(solution, rawReprType, valueType,
+                                        locator) {}
+
+  Type getFromType() const override { return RawReprType; }
+  Type getToType() const override { return ValueType; }
+
+private:
+  void fixIt(InFlightDiagnostic &diagnostic) const override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2121,12 +2121,12 @@ protected:
 ///
 /// `0` has to be wrapped into `E(rawValue: 0)` and either defaulted via `??` or
 /// force unwrapped to constitute a valid binding.
-class MissingRawRepresentativeInitFailure final
+class MissingRawRepresentableInitFailure final
     : public AbstractRawRepresentableFailure {
 public:
-  MissingRawRepresentativeInitFailure(const Solution &solution,
-                                      Type rawReprType, Type expectedType,
-                                      ConstraintLocator *locator)
+  MissingRawRepresentableInitFailure(const Solution &solution, Type rawReprType,
+                                     Type expectedType,
+                                     ConstraintLocator *locator)
       : AbstractRawRepresentableFailure(solution, rawReprType, expectedType,
                                         locator) {}
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2105,13 +2105,13 @@ public:
 class AbstractRawRepresentableFailure : public FailureDiagnostic {
 protected:
   Type RawReprType;
-  Type ValueType;
+  Type ExpectedType;
 
   AbstractRawRepresentableFailure(const Solution &solution, Type rawReprType,
-                                  Type valueType, ConstraintLocator *locator)
+                                  Type expectedType, ConstraintLocator *locator)
       : FailureDiagnostic(solution, locator),
         RawReprType(resolveType(rawReprType)),
-        ValueType(resolveType(valueType)) {}
+        ExpectedType(resolveType(expectedType)) {}
 
 public:
   virtual Type getFromType() const = 0;
@@ -2143,12 +2143,12 @@ class MissingRawRepresentativeInitFailure final
     : public AbstractRawRepresentableFailure {
 public:
   MissingRawRepresentativeInitFailure(const Solution &solution,
-                                      Type rawReprType, Type valueType,
+                                      Type rawReprType, Type expectedType,
                                       ConstraintLocator *locator)
-      : AbstractRawRepresentableFailure(solution, rawReprType, valueType,
+      : AbstractRawRepresentableFailure(solution, rawReprType, expectedType,
                                         locator) {}
 
-  Type getFromType() const override { return ValueType; }
+  Type getFromType() const override { return ExpectedType; }
   Type getToType() const override { return RawReprType; }
 
   bool diagnoseAsNote() override;
@@ -2174,13 +2174,13 @@ class UseOfRawRepresentableInsteadOfItsRawValueFailure final
 public:
   UseOfRawRepresentableInsteadOfItsRawValueFailure(const Solution &solution,
                                                    Type rawReprType,
-                                                   Type valueType,
+                                                   Type expectedType,
                                                    ConstraintLocator *locator)
-      : AbstractRawRepresentableFailure(solution, rawReprType, valueType,
+      : AbstractRawRepresentableFailure(solution, rawReprType, expectedType,
                                         locator) {}
 
   Type getFromType() const override { return RawReprType; }
-  Type getToType() const override { return ValueType; }
+  Type getToType() const override { return ExpectedType; }
 
 private:
   void fixIt(InFlightDiagnostic &diagnostic) const override;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2123,8 +2123,9 @@ public:
   MissingRawRepresentativeInitFailure(const Solution &solution,
                                       Type rawReprType, Type valueType,
                                       ConstraintLocator *locator)
-      : FailureDiagnostic(solution, locator), RawReprType(rawReprType),
-        ValueType(valueType) {}
+      : FailureDiagnostic(solution, locator),
+        RawReprType(resolveType(rawReprType)),
+        ValueType(resolveType(valueType)) {}
 
   bool diagnoseAsError() override;
 };

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1139,8 +1139,8 @@ ExplicitlyConstructRawRepresentable::create(ConstraintSystem &cs,
 
 bool UseValueTypeOfRawRepresentative::diagnose(const Solution &solution,
                                                bool asNote) const {
-  ArgumentMismatchFailure failure(solution, RawReprType, ExpectedType,
-                                  getLocator());
+  UseOfRawRepresentableInsteadOfItsRawValueFailure failure(
+      solution, RawReprType, ExpectedType, getLocator());
   return failure.diagnose(asNote);
 }
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1124,8 +1124,8 @@ bool ExpandArrayIntoVarargs::diagnose(const Solution &solution,
 
 bool ExplicitlyConstructRawRepresentable::diagnose(const Solution &solution,
                                                    bool asNote) const {
-  MissingRawRepresentativeInitFailure failure(solution, RawReprType,
-                                              ExpectedType, getLocator());
+  MissingRawRepresentableInitFailure failure(solution, RawReprType,
+                                             ExpectedType, getLocator());
   return failure.diagnose(asNote);
 }
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1124,32 +1124,32 @@ bool ExpandArrayIntoVarargs::diagnose(const Solution &solution,
 
 bool ExplicitlyConstructRawRepresentable::diagnose(const Solution &solution,
                                                    bool asNote) const {
-  MissingRawRepresentativeInitFailure failure(solution, RawReprType, ValueType,
-                                              getLocator());
+  MissingRawRepresentativeInitFailure failure(solution, RawReprType,
+                                              ExpectedType, getLocator());
   return failure.diagnose(asNote);
 }
 
 ExplicitlyConstructRawRepresentable *
 ExplicitlyConstructRawRepresentable::create(ConstraintSystem &cs,
-                                            Type rawReprType, Type valueType,
+                                            Type rawReprType, Type expectedType,
                                             ConstraintLocator *locator) {
-  return new (cs.getAllocator())
-      ExplicitlyConstructRawRepresentable(cs, rawReprType, valueType, locator);
+  return new (cs.getAllocator()) ExplicitlyConstructRawRepresentable(
+      cs, rawReprType, expectedType, locator);
 }
 
 bool UseValueTypeOfRawRepresentative::diagnose(const Solution &solution,
                                                bool asNote) const {
-  ArgumentMismatchFailure failure(solution, RawReprType, ValueType,
+  ArgumentMismatchFailure failure(solution, RawReprType, ExpectedType,
                                   getLocator());
   return failure.diagnose(asNote);
 }
 
 UseValueTypeOfRawRepresentative *
 UseValueTypeOfRawRepresentative::create(ConstraintSystem &cs, Type rawReprType,
-                                        Type valueType,
+                                        Type expectedType,
                                         ConstraintLocator *locator) {
   return new (cs.getAllocator())
-      UseValueTypeOfRawRepresentative(cs, rawReprType, valueType, locator);
+      UseValueTypeOfRawRepresentative(cs, rawReprType, expectedType, locator);
 }
 
 unsigned AllowArgumentMismatch::getParamIdx() const {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1144,18 +1144,19 @@ bool ExpandArrayIntoVarargs::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool ExplicitlyConstructRawRepresentable::diagnose(const Solution &solution,
+                                                   bool asNote) const {
+  MissingRawRepresentativeInitFailure failure(solution, RawReprType, ValueType,
+                                              getLocator());
+  return failure.diagnose(asNote);
+}
+
 ExplicitlyConstructRawRepresentable *
-ExplicitlyConstructRawRepresentable::attempt(ConstraintSystem &cs, Type argType,
-                                             Type paramType,
-                                             ConstraintLocatorBuilder locator) {
-  auto rawRepresentableType = paramType->lookThroughAllOptionalTypes();
-  auto valueType = argType->lookThroughAllOptionalTypes();
-
-  if (isValueOfRawRepresentable(cs, rawRepresentableType, valueType))
-    return new (cs.getAllocator()) ExplicitlyConstructRawRepresentable(
-        cs, valueType, rawRepresentableType, cs.getConstraintLocator(locator));
-
-  return nullptr;
+ExplicitlyConstructRawRepresentable::create(ConstraintSystem &cs,
+                                            Type rawReprType, Type valueType,
+                                            ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      ExplicitlyConstructRawRepresentable(cs, rawReprType, valueType, locator);
 }
 
 UseValueTypeOfRawRepresentative *

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1137,19 +1137,17 @@ ExplicitlyConstructRawRepresentable::create(ConstraintSystem &cs,
       cs, rawReprType, expectedType, locator);
 }
 
-bool UseValueTypeOfRawRepresentative::diagnose(const Solution &solution,
-                                               bool asNote) const {
-  UseOfRawRepresentableInsteadOfItsRawValueFailure failure(
-      solution, RawReprType, ExpectedType, getLocator());
+bool UseRawValue::diagnose(const Solution &solution, bool asNote) const {
+  MissingRawValueFailure failure(solution, RawReprType, ExpectedType,
+                                 getLocator());
   return failure.diagnose(asNote);
 }
 
-UseValueTypeOfRawRepresentative *
-UseValueTypeOfRawRepresentative::create(ConstraintSystem &cs, Type rawReprType,
-                                        Type expectedType,
-                                        ConstraintLocator *locator) {
+UseRawValue *UseRawValue::create(ConstraintSystem &cs, Type rawReprType,
+                                 Type expectedType,
+                                 ConstraintLocator *locator) {
   return new (cs.getAllocator())
-      UseValueTypeOfRawRepresentative(cs, rawReprType, expectedType, locator);
+      UseRawValue(cs, rawReprType, expectedType, locator);
 }
 
 unsigned AllowArgumentMismatch::getParamIdx() const {

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -213,9 +213,10 @@ enum class FixKind : uint8_t {
   /// via forming `Foo(rawValue:)` instead of using its `RawValue` directly.
   ExplicitlyConstructRawRepresentable,
 
-  /// Use raw value type associated with raw representative accessible
+  /// Use raw value type associated with raw representable, accessible
   /// using `.rawValue` member.
-  UseValueTypeOfRawRepresentative,
+  UseRawValue,
+
   /// If an array was passed to a variadic argument, give a specific diagnostic
   /// and offer to drop the brackets if it's a literal.
   ExpandArrayIntoVarargs,
@@ -264,7 +265,7 @@ enum class FixKind : uint8_t {
 
   /// Allow key path to be bound to a function type with more than 1 argument
   AllowMultiArgFuncKeyPathMismatch,
-  
+
   /// Specify key path root type when it cannot be infered from context.
   SpecifyKeyPathRootType,
 
@@ -1617,13 +1618,13 @@ public:
          ConstraintLocator *locator);
 };
 
-class UseValueTypeOfRawRepresentative final : public ConstraintFix {
+class UseRawValue final : public ConstraintFix {
   Type RawReprType;
   Type ExpectedType;
 
-  UseValueTypeOfRawRepresentative(ConstraintSystem &cs, Type rawReprType,
-                                  Type expectedType, ConstraintLocator *locator)
-      : ConstraintFix(cs, FixKind::UseValueTypeOfRawRepresentative, locator),
+  UseRawValue(ConstraintSystem &cs, Type rawReprType, Type expectedType,
+              ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::UseRawValue, locator),
         RawReprType(rawReprType), ExpectedType(expectedType) {}
 
 public:
@@ -1633,10 +1634,8 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  static UseValueTypeOfRawRepresentative *create(ConstraintSystem &cs,
-                                                 Type rawReprType,
-                                                 Type expectedType,
-                                                 ConstraintLocator *locator);
+  static UseRawValue *create(ConstraintSystem &cs, Type rawReprType,
+                             Type expectedType, ConstraintLocator *locator);
 };
 
 /// Replace a coercion ('as') with a forced checked cast ('as!').

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -1596,14 +1596,14 @@ public:
 
 class ExplicitlyConstructRawRepresentable final : public ConstraintFix {
   Type RawReprType;
-  Type ValueType;
+  Type ExpectedType;
 
   ExplicitlyConstructRawRepresentable(ConstraintSystem &cs, Type rawReprType,
-                                      Type valueType,
+                                      Type expectedType,
                                       ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::ExplicitlyConstructRawRepresentable,
                       locator),
-        RawReprType(rawReprType), ValueType(valueType) {}
+        RawReprType(rawReprType), ExpectedType(expectedType) {}
 
 public:
   std::string getName() const override {
@@ -1613,18 +1613,18 @@ public:
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static ExplicitlyConstructRawRepresentable *
-  create(ConstraintSystem &cs, Type rawTypeRepr, Type valueType,
+  create(ConstraintSystem &cs, Type rawTypeRepr, Type expectedType,
          ConstraintLocator *locator);
 };
 
 class UseValueTypeOfRawRepresentative final : public ConstraintFix {
   Type RawReprType;
-  Type ValueType;
+  Type ExpectedType;
 
   UseValueTypeOfRawRepresentative(ConstraintSystem &cs, Type rawReprType,
-                                  Type valueType, ConstraintLocator *locator)
+                                  Type expectedType, ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::UseValueTypeOfRawRepresentative, locator),
-        RawReprType(rawReprType), ValueType(valueType) {}
+        RawReprType(rawReprType), ExpectedType(expectedType) {}
 
 public:
   std::string getName() const override {
@@ -1635,7 +1635,7 @@ public:
 
   static UseValueTypeOfRawRepresentative *create(ConstraintSystem &cs,
                                                  Type rawReprType,
-                                                 Type valueType,
+                                                 Type expectedType,
                                                  ConstraintLocator *locator);
 };
 

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -1594,21 +1594,27 @@ public:
                                          ConstraintLocatorBuilder locator);
 };
 
-class ExplicitlyConstructRawRepresentable final : public AllowArgumentMismatch {
-  ExplicitlyConstructRawRepresentable(ConstraintSystem &cs, Type argType,
-                                      Type paramType,
+class ExplicitlyConstructRawRepresentable final : public ConstraintFix {
+  Type RawReprType;
+  Type ValueType;
+
+  ExplicitlyConstructRawRepresentable(ConstraintSystem &cs, Type rawReprType,
+                                      Type valueType,
                                       ConstraintLocator *locator)
-      : AllowArgumentMismatch(cs, FixKind::ExplicitlyConstructRawRepresentable,
-                              argType, paramType, locator) {}
+      : ConstraintFix(cs, FixKind::ExplicitlyConstructRawRepresentable,
+                      locator),
+        RawReprType(rawReprType), ValueType(valueType) {}
 
 public:
   std::string getName() const override {
     return "explicitly construct a raw representable type";
   }
 
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
   static ExplicitlyConstructRawRepresentable *
-  attempt(ConstraintSystem &cs, Type argType, Type paramType,
-          ConstraintLocatorBuilder locator);
+  create(ConstraintSystem &cs, Type rawTypeRepr, Type valueType,
+         ConstraintLocator *locator);
 };
 
 class UseValueTypeOfRawRepresentative final : public AllowArgumentMismatch {

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -1617,20 +1617,26 @@ public:
          ConstraintLocator *locator);
 };
 
-class UseValueTypeOfRawRepresentative final : public AllowArgumentMismatch {
-  UseValueTypeOfRawRepresentative(ConstraintSystem &cs, Type argType,
-                                  Type paramType, ConstraintLocator *locator)
-      : AllowArgumentMismatch(cs, FixKind::UseValueTypeOfRawRepresentative,
-                              argType, paramType, locator) {}
+class UseValueTypeOfRawRepresentative final : public ConstraintFix {
+  Type RawReprType;
+  Type ValueType;
+
+  UseValueTypeOfRawRepresentative(ConstraintSystem &cs, Type rawReprType,
+                                  Type valueType, ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::UseValueTypeOfRawRepresentative, locator),
+        RawReprType(rawReprType), ValueType(valueType) {}
 
 public:
   std::string getName() const override {
     return "use `.rawValue` of a raw representable type";
   }
 
-  static UseValueTypeOfRawRepresentative *
-  attempt(ConstraintSystem &cs, Type argType, Type paramType,
-          ConstraintLocatorBuilder locator);
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  static UseValueTypeOfRawRepresentative *create(ConstraintSystem &cs,
+                                                 Type rawReprType,
+                                                 Type valueType,
+                                                 ConstraintLocator *locator);
 };
 
 /// Replace a coercion ('as') with a forced checked cast ('as!').

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3184,7 +3184,7 @@ bool ConstraintSystem::repairFailures(
     if (!isValueOfRawRepresentable(expectedType, rawReprType))
       return false;
 
-    conversionsOrFixes.push_back(UseValueTypeOfRawRepresentative::create(
+    conversionsOrFixes.push_back(UseRawValue::create(
         *this, rawReprType, expectedType, getConstraintLocator(locator)));
     return true;
   };
@@ -9578,7 +9578,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::UsePropertyWrapper:
   case FixKind::UseWrappedValue:
   case FixKind::ExpandArrayIntoVarargs:
-  case FixKind::UseValueTypeOfRawRepresentative:
+  case FixKind::UseRawValue:
   case FixKind::ExplicitlyConstructRawRepresentable:
   case FixKind::SpecifyBaseTypeForContextualMember:
   case FixKind::CoerceToCheckedCast:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3164,8 +3164,8 @@ bool ConstraintSystem::repairFailures(
   // and if so check that given `expectedType` matches its `RawValue` type. If
   // that condition holds add a tailored fix which is going to suggest to
   // explicitly construct a raw representable type from a given value type.
-  auto repairByExplicitRawRepresentativeUse = [&](Type expectedType,
-                                                  Type rawReprType) -> bool {
+  auto repairByConstructingRawRepresentableType =
+      [&](Type expectedType, Type rawReprType) -> bool {
     if (!isValueOfRawRepresentable(expectedType, rawReprType))
       return false;
 
@@ -3406,7 +3406,7 @@ bool ConstraintSystem::repairFailures(
         return true;
 
       // `rhs` - is an assignment destination and `lhs` is its source.
-      if (repairByExplicitRawRepresentativeUse(lhs, rhs))
+      if (repairByConstructingRawRepresentableType(lhs, rhs))
         return true;
 
       if (repairByUsingRawValueOfRawRepresentableType(lhs, rhs))
@@ -3674,7 +3674,7 @@ bool ConstraintSystem::repairFailures(
       return true;
 
     // `lhs` - is an argument and `rhs` is a parameter type.
-    if (repairByExplicitRawRepresentativeUse(lhs, rhs))
+    if (repairByConstructingRawRepresentableType(lhs, rhs))
       break;
 
     if (repairByUsingRawValueOfRawRepresentableType(lhs, rhs))
@@ -3914,7 +3914,7 @@ bool ConstraintSystem::repairFailures(
       break;
 
     // `lhs` - is an result type and `rhs` is a contextual type.
-    if (repairByExplicitRawRepresentativeUse(lhs, rhs))
+    if (repairByConstructingRawRepresentableType(lhs, rhs))
       break;
 
     conversionsOrFixes.push_back(IgnoreContextualType::create(

--- a/test/Migrator/rdar31892850.swift
+++ b/test/Migrator/rdar31892850.swift
@@ -21,6 +21,6 @@ func foo() {
 // CHECK:  {
 // CHECK:    "file": "{{.*}}rdar31892850.swift",
 // CHECK:    "offset": 329,
-// CHECK:    "text": ")"
+// CHECK:    "text": ") ?? <#default value#>"
 // CHECK:  }
 // CHECK:]

--- a/test/Sema/enum_raw_representable.swift
+++ b/test/Sema/enum_raw_representable.swift
@@ -195,11 +195,11 @@ func sr8150_mutable(obj: SR8150Box) {
 
   func test(_ opt: Bar?) {
     sr8150_helper1(opt)
-    // expected-error@-1 {{cannot convert value of type 'Bar?' to expected argument type 'Double'}} {{23-23=.map { $0.rawValue } ?? <#default value#>}}
+    // expected-error@-1 {{cannot convert value of type 'Bar?' to expected argument type 'Double'}} {{23-23=?.rawValue ?? <#default value#>}}
     sr8150_helper1(opt ?? Bar.a)
     // expected-error@-1 {{cannot convert value of type 'Bar' to expected argument type 'Double'}} {{20-20=(}} {{32-32=).rawValue}}
     let _: Double? = opt
-    // expected-error@-1 {{cannot convert value of type 'Bar?' to specified type 'Double?'}} {{25-25=.map { $0.rawValue }}}
+    // expected-error@-1 {{cannot convert value of type 'Bar?' to specified type 'Double?'}} {{25-25=?.rawValue}}
   }
 }
 

--- a/test/Sema/enum_raw_representable.swift
+++ b/test/Sema/enum_raw_representable.swift
@@ -131,15 +131,15 @@ func rdar32431165_2(_: Int) {}
 func rdar32431165_2(_: Int, _: String) {}
 
 rdar32431165_2(E_32431165.bar)
-// expected-error@-1 {{cannot convert value of type 'E_32431165' to expected argument type 'String'}} {{16-16=}} {{30-30=.rawValue}}
+// expected-error@-1 {{cannot convert value of type 'E_32431165' to expected argument type 'String'}} {{30-30=.rawValue}}
 rdar32431165_2(42, E_32431165.bar)
-// expected-error@-1 {{cannot convert value of type 'E_32431165' to expected argument type 'String'}} {{20-20=}} {{34-34=.rawValue}}
+// expected-error@-1 {{cannot convert value of type 'E_32431165' to expected argument type 'String'}} {{34-34=.rawValue}}
 
 E_32431165.bar == "bar"
-// expected-error@-1 {{cannot convert value of type 'E_32431165' to expected argument type 'String}} {{1-1=}} {{15-15=.rawValue}}
+// expected-error@-1 {{cannot convert value of type 'E_32431165' to expected argument type 'String}} {{15-15=.rawValue}}
 
 "bar" == E_32431165.bar
-// expected-error@-1 {{cannot convert value of type 'E_32431165' to expected argument type 'String}} {{10-10=}} {{24-24=.rawValue}}
+// expected-error@-1 {{cannot convert value of type 'E_32431165' to expected argument type 'String}} {{24-24=.rawValue}}
 
 func rdar32431165_overloaded() -> Int { 42 }     // expected-note {{found candidate with type 'Int'}}
 func rdar32431165_overloaded() -> String { "A" } // expected-note {{'rdar32431165_overloaded()' produces 'String', not the expected contextual result type 'E_32431165'}}
@@ -154,7 +154,7 @@ func test_candidate_diagnostic() {
 func rdar32432253(_ condition: Bool = false) {
   let choice: E_32431165 = condition ? .foo : .bar
   let _ = choice == "bar"
-  // expected-error@-1 {{cannot convert value of type 'E_32431165' to expected argument type 'String'}} {{11-11=}} {{17-17=.rawValue}}
+  // expected-error@-1 {{cannot convert value of type 'E_32431165' to expected argument type 'String'}} {{17-17=.rawValue}}
 }
 
 func sr8150_helper1(_: Int) {}
@@ -171,9 +171,9 @@ func sr8150_helper4(_: Foo) {}
 
 func sr8150(bar: Bar) {
   sr8150_helper1(bar)
-  // expected-error@-1 {{cannot convert value of type 'Bar' to expected argument type 'Double'}} {{18-18=}} {{21-21=.rawValue}}
+  // expected-error@-1 {{cannot convert value of type 'Bar' to expected argument type 'Double'}} {{21-21=.rawValue}}
   sr8150_helper2(bar)
-  // expected-error@-1 {{cannot convert value of type 'Bar' to expected argument type 'Double'}} {{18-18=}} {{21-21=.rawValue}}
+  // expected-error@-1 {{cannot convert value of type 'Bar' to expected argument type 'Double'}} {{21-21=.rawValue}}
   sr8150_helper3(0.0)
   // expected-error@-1 {{cannot convert value of type 'Double' to expected argument type 'Bar'}} {{18-18=Bar(rawValue: }} {{21-21=) ?? <#default value#>}}
   sr8150_helper4(0.0)
@@ -187,11 +187,20 @@ class SR8150Box {
 // Bonus problem with mutable values being passed.
 func sr8150_mutable(obj: SR8150Box) {
   sr8150_helper1(obj.bar)
-  // expected-error@-1 {{cannot convert value of type 'Bar' to expected argument type 'Double'}} {{18-18=}} {{25-25=.rawValue}}
+  // expected-error@-1 {{cannot convert value of type 'Bar' to expected argument type 'Double'}} {{25-25=.rawValue}}
 
   var bar = obj.bar
   sr8150_helper1(bar)
-  // expected-error@-1 {{cannot convert value of type 'Bar' to expected argument type 'Double'}} {{18-18=}} {{21-21=.rawValue}}
+  // expected-error@-1 {{cannot convert value of type 'Bar' to expected argument type 'Double'}} {{21-21=.rawValue}}
+
+  func test(_ opt: Bar?) {
+    sr8150_helper1(opt)
+    // expected-error@-1 {{cannot convert value of type 'Bar?' to expected argument type 'Double'}} {{23-23=.map { $0.rawValue } ?? <#default value#>}}
+    sr8150_helper1(opt ?? Bar.a)
+    // expected-error@-1 {{cannot convert value of type 'Bar' to expected argument type 'Double'}} {{20-20=(}} {{32-32=).rawValue}}
+    let _: Double? = opt
+    // expected-error@-1 {{cannot convert value of type 'Bar?' to specified type 'Double?'}} {{25-25=.map { $0.rawValue }}}
+  }
 }
 
 struct NotEquatable { }

--- a/test/Sema/enum_raw_representable.swift
+++ b/test/Sema/enum_raw_representable.swift
@@ -97,11 +97,11 @@ func rdar32431736() {
 
   let myE1: E = items1.first
   // expected-error@-1 {{cannot convert value of type 'String?' to specified type 'E'}}
-  // expected-note@-2 {{construct 'E' from unwrapped 'String' value}} {{17-17=E(rawValue: }} {{29-29=!)}}
+  // expected-note@-2 {{construct 'E' from unwrapped 'String' value}} {{17-17=E(rawValue: }} {{29-29=!) ?? <#default value#>}}
 
   let myE2: E = items2?.first
   // expected-error@-1 {{cannot convert value of type 'String?' to specified type 'E'}}
-  // expected-note@-2 {{construct 'E' from unwrapped 'String' value}} {{17-17=E(rawValue: (}} {{30-30=)!)}}
+  // expected-note@-2 {{construct 'E' from unwrapped 'String' value}} {{17-17=E(rawValue: (}} {{30-30=)!) ?? <#default value#>}}
 }
 
 // rdar://problem/32431165 - improve diagnostic for raw representable argument mismatch
@@ -122,9 +122,9 @@ rdar32431165_1(.baz)
 // expected-error@-1 {{reference to member 'baz' cannot be resolved without a contextual type}}
 
 rdar32431165_1("")
-// expected-error@-1 {{cannot convert value of type 'String' to expected argument type 'E_32431165'}} {{16-16=E_32431165(rawValue: }} {{18-18=)}}
+// expected-error@-1 {{cannot convert value of type 'String' to expected argument type 'E_32431165'}}
 rdar32431165_1(42, "")
-// expected-error@-1 {{cannot convert value of type 'String' to expected argument type 'E_32431165'}} {{20-20=E_32431165(rawValue: }} {{22-22=)}}
+// expected-error@-1 {{cannot convert value of type 'String' to expected argument type 'E_32431165'}} {{20-20=E_32431165(rawValue: }} {{22-22=) ?? <#default value#>}}
 
 func rdar32431165_2(_: String) {}
 func rdar32431165_2(_: Int) {}
@@ -140,6 +140,16 @@ E_32431165.bar == "bar"
 
 "bar" == E_32431165.bar
 // expected-error@-1 {{cannot convert value of type 'E_32431165' to expected argument type 'String}} {{10-10=}} {{24-24=.rawValue}}
+
+func rdar32431165_overloaded() -> Int { 42 }     // expected-note {{found candidate with type 'Int'}}
+func rdar32431165_overloaded() -> String { "A" } // expected-note {{'rdar32431165_overloaded()' produces 'String', not the expected contextual result type 'E_32431165'}}
+
+func test_candidate_diagnostic() {
+  func test_argument(_: E_32431165) {}
+
+  let _: E_32431165 = rdar32431165_overloaded() // expected-error {{no exact matches in call to global function 'rdar32431165_overloaded'}}
+  test_argument(rdar32431165_overloaded()) // expected-error {{cannot convert value of type 'String' to expected argument type 'E_32431165'}} {{17-17=E_32431165(rawValue: }} {{42-42=) ?? <#default value#>}}
+}
 
 func rdar32432253(_ condition: Bool = false) {
   let choice: E_32431165 = condition ? .foo : .bar
@@ -165,9 +175,9 @@ func sr8150(bar: Bar) {
   sr8150_helper2(bar)
   // expected-error@-1 {{cannot convert value of type 'Bar' to expected argument type 'Double'}} {{18-18=}} {{21-21=.rawValue}}
   sr8150_helper3(0.0)
-  // expected-error@-1 {{cannot convert value of type 'Double' to expected argument type 'Bar'}} {{18-18=Bar(rawValue: }} {{21-21=)}}
+  // expected-error@-1 {{cannot convert value of type 'Double' to expected argument type 'Bar'}} {{18-18=Bar(rawValue: }} {{21-21=) ?? <#default value#>}}
   sr8150_helper4(0.0)
-  // expected-error@-1 {{cannot convert value of type 'Double' to expected argument type 'Bar'}} {{18-18=Bar(rawValue: }} {{21-21=)}}
+  // expected-error@-1 {{cannot convert value of type 'Double' to expected argument type 'Bar'}} {{18-18=Bar(rawValue: }} {{21-21=) ?? <#default value#>}}
 }
 
 class SR8150Box {


### PR DESCRIPTION
Instead of having these diagnostics be a part of `ContextualFailure` extract them into
their own distinct diagnostic classes which allows to produce better fix-its.

Also move logic from `attempt` methods into `repairFailures` and use new fix logic
to diagnose assignment, contextual and argument-to-parameter conversion failures.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
