### PR TITLE
[5.3] [semantic-arc-opts] Use all consuming uses instead of just destroying uses when validating if a LiveRange is alive in a scope.

### DIFF
--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -59,6 +59,7 @@ class ClassLet {
   @_hasStorage let aLet: Klass
   @_hasStorage var aVar: Klass
   @_hasStorage let aLetTuple: (Klass, Klass)
+  @_hasStorage let anOptionalLet: FakeOptional<Klass>
 
   @_hasStorage let anotherLet: ClassLet
 }
@@ -2203,4 +2204,32 @@ bb5(%9 : @owned $Builtin.NativeObject):
 bb6:
   %9999 = tuple()
   return %9999 : $()
+}
+
+// Make sure that we do not promote the load [copy] to a load_borrow since it
+// has a use outside of the access scope.
+//
+// CHECK-LABEL: sil [ossa] @deadEndBlockDoNotPromote : $@convention(method) (@guaranteed ClassLet) -> () {
+// CHECK: load_borrow
+// CHECK: load [copy]
+// CHECK: } // end sil function 'deadEndBlockDoNotPromote'
+sil [ossa] @deadEndBlockDoNotPromote : $@convention(method) (@guaranteed ClassLet) -> () {
+bb0(%0 : @guaranteed $ClassLet):
+  %4 = ref_element_addr %0 : $ClassLet, #ClassLet.anotherLet
+  %5 = load [copy] %4 : $*ClassLet
+  %6 = begin_borrow %5 : $ClassLet
+  %7 = ref_element_addr %6 : $ClassLet, #ClassLet.anOptionalLet
+  %8 = begin_access [read] [dynamic] %7 : $*FakeOptional<Klass>
+  %9 = load [copy] %8 : $*FakeOptional<Klass>
+  end_access %8 : $*FakeOptional<Klass>
+  end_borrow %6 : $ClassLet
+  destroy_value %5 : $ClassLet
+  switch_enum %9 : $FakeOptional<Klass>, case #FakeOptional.none!enumelt: bb1, case #FakeOptional.some!enumelt: bb2
+
+bb1:
+  %107 = tuple ()
+  return %107 : $()
+
+bb2(%39 : @owned $Klass):
+  unreachable
 }


### PR DESCRIPTION
Just cherry-picking this fix.

rdar://63188362

----

Explanation: SemanticARCOpts is converting a legally leakable load [copy] from an access scope to a load_borrow in an harmless, incorrect way. Specifically to transform a load [copy] from an access_scope to a load_borrow, we need to validate that all uses of a load [copy] are within the access scope since load_borrows can only be used while the access_scope is valid. In the algorithm as written, we validate only that the destroy_value of the load [copy] are within that scope since all non-destroy uses will be earlier than such destroy_value. This is generally correct, except if our load [copy] is post-dominated by an unreachable. In such cases we may eliminate all destroy_value on the load [copy] since the program is going to end and we are going to leak the object. This can then cause us to ignore any non-destroy uses of the load [copy] outside of the access scope that would disqualify the load [copy] from being converted to a load_borrow. This change fixes the problem conservatively by just validating that /all/ uses of a load [copy] (rather than just destroy_value uses) are strictly within the access scope.
Scope: Fixes a miscompile. In terms of how likely this is in practice, I think it is not likely. That is because the optimizer is pretty aggressive about leaking objects on program exit. So given that we need to be post-dominated by unreachables, the base object is likely to be leaked rather than destroyed.
SR Issue: rdar://63188362
Risk: Low. I am only making the algorithm more conservative by adding all uses to a check instead of just the destroy_values.
Testing: Added a test case. Just run the compiler test suite.
Reviewer: @atrick