### PR TITLE
[SIL] NFC: Shrink SILGlobalVariable by 16 bytes

### DIFF
--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -53,7 +53,7 @@ private:
   
   /// The SIL location of the variable, which provides a link back to the AST.
   /// The variable only gets a location after it's been emitted.
-  Optional<SILLocation> Location;
+  const SILLocation Location;
 
   /// The linkage of the global variable.
   unsigned Linkage : NumSILLinkageBits;
@@ -67,12 +67,15 @@ private:
   /// once (either in its declaration, or once later), making it immutable.
   unsigned IsLet : 1;
 
+  /// Whether or not this is a declaration.
+  unsigned IsDeclaration : 1;
+
+  /// Whether or not there is a valid SILLocation.
+  unsigned HasLocation : 1;
+
   /// The VarDecl associated with this SILGlobalVariable. Must by nonnull for
   /// language-level global variables.
   VarDecl *VDecl;
-
-  /// Whether or not this is a declaration.
-  bool IsDeclaration;
 
   /// If this block is not empty, the global variable has a static initializer.
   ///
@@ -132,20 +135,17 @@ public:
 
   VarDecl *getDecl() const { return VDecl; }
 
-  /// Initialize the source location of the function.
-  void setLocation(SILLocation L) { Location = L; }
-
   /// Check if the function has a location.
   /// FIXME: All functions should have locations, so this method should not be
   /// necessary.
   bool hasLocation() const {
-    return Location.hasValue();
+    return HasLocation;
   }
 
   /// Get the source location of the function.
   SILLocation getLocation() const {
-    assert(Location.hasValue());
-    return Location.getValue();
+    assert(HasLocation);
+    return Location;
   }
 
   /// Returns the value of the static initializer or null if the global has no

--- a/include/swift/SIL/SILLocation.h
+++ b/include/swift/SIL/SILLocation.h
@@ -273,6 +273,8 @@ public:
     assert(isASTNode());
   }
 
+  static SILLocation invalid() { return SILLocation(); }
+
   /// Check if the location wraps an AST node or a valid SIL file
   /// location.
   ///

--- a/lib/SIL/IR/SILGlobalVariable.cpp
+++ b/lib/SIL/IR/SILGlobalVariable.cpp
@@ -48,8 +48,9 @@ SILGlobalVariable::SILGlobalVariable(SILModule &Module, SILLinkage Linkage,
   : Module(Module),
     Name(Name),
     LoweredType(LoweredType),
-    Location(Loc),
+    Location(Loc.getValueOr(SILLocation::invalid())),
     Linkage(unsigned(Linkage)),
+    HasLocation(Loc.hasValue()),
     VDecl(Decl) {
   setSerialized(isSerialized);
   IsDeclaration = isAvailableExternally(Linkage);


### PR DESCRIPTION
There are two changes here. One is simply moving a boolean. The other involves a specialization of `llvm::Optional` for `SILLocation`. This seems to tantalizingly close. When optimizations are enabled, only two tests fail but without optimizations, the Glibc swift module fails to build. Before I debug this further, is this a good idea? This technically collapses a level of optionality.