### PR TITLE
[Runtime] Unify debug variable parsing from the environment and avoid getenv when possible.

### DIFF
--- a/include/swift/Runtime/EnvironmentVariables.h
+++ b/include/swift/Runtime/EnvironmentVariables.h
@@ -1,0 +1,41 @@
+//===--- EnvironmentVariables.h - Debug variables. --------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Debug behavior conditionally enabled using environment variables.
+//
+//===----------------------------------------------------------------------===//
+
+#include "../Basic/Lazy.h"
+
+namespace swift {
+namespace runtime {
+namespace environment {
+
+void initialize(void *);
+
+extern OnceToken_t initializeToken;
+
+// Declare backing variables.
+#define VARIABLE(name, type, defaultValue, help) extern type name ## _variable;
+#include "../../../stdlib/public/runtime/EnvironmentVariables.def"
+
+// Define getter functions.
+#define VARIABLE(name, type, defaultValue, help)        \
+  inline type name() {                                  \
+    SWIFT_ONCE_F(initializeToken, initialize, nullptr); \
+    return name ## _variable;                           \
+  }
+#include "../../../stdlib/public/runtime/EnvironmentVariables.def"
+
+} // end namespace environment
+} // end namespace runtime
+} // end namespace Swift

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -34,6 +34,7 @@ set(swift_runtime_sources
     CygwinPort.cpp
     Demangle.cpp
     Enum.cpp
+    EnvironmentVariables.cpp
     ErrorObjectCommon.cpp
     ErrorObjectConstants.cpp
     ErrorObjectNative.cpp

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -1,0 +1,190 @@
+//===--- EnvironmentVariables.h - Debug variables. --------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Debug behavior conditionally enabled using environment variables.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Debug.h"
+#include "swift/Runtime/EnvironmentVariables.h"
+
+#include <string.h>
+
+using namespace swift;
+
+namespace {
+
+// Require all environment variable names to start with SWIFT_
+static constexpr bool hasSwiftPrefix(const char *str) {
+  const char prefix[] = "SWIFT_";
+  for (unsigned i = 0; i < sizeof(prefix) - 1; i++)
+    if (str[i] != prefix[i])
+      return false;
+  return true;
+}
+#define VARIABLE(name, type, defaultValue, help) \
+  static_assert(hasSwiftPrefix(#name), "Names must start with SWIFT");
+#include "EnvironmentVariables.def"
+
+// Value parsers. Add new functions named parse_<type> to accommodate more
+// debug variable types.
+static bool parse_bool(const char *name, const char *value, bool defaultValue) {
+  if (!value)
+    return defaultValue;
+  switch (value[0]) {
+  case 'Y':
+  case 'y':
+  case 'T':
+  case 't':
+  case '1':
+    return true;
+  case 'N':
+  case 'n':
+  case 'F':
+  case 'f':
+  case '0':
+    return false;
+  default:
+    swift::warning(RuntimeErrorFlagNone,
+                  "Warning: cannot parse value %s=%s, defaulting to %s.\n",
+                  name, value, defaultValue ? "true" : "false");
+    return defaultValue;
+  }
+}
+
+static uint8_t parse_uint8_t(const char *name,
+                             const char *value,
+                             uint8_t defaultValue) {
+  if (!value)
+    return defaultValue;
+  char *end;
+  long n = strtol(value, &end, 0);
+  if (*end != '\0') {
+    swift::warning(RuntimeErrorFlagNone,
+                   "Warning: cannot parse value %s=%s, defaulting to %u.\n",
+                   name, value, defaultValue);
+    return defaultValue;
+  }
+
+  if (n < 0) {
+    swift::warning(RuntimeErrorFlagNone,
+                   "Warning: %s=%s out of bounds, clamping to 0.\n",
+                   name, value);
+    return 0;
+  }
+  if (n > UINT8_MAX) {
+    swift::warning(RuntimeErrorFlagNone,
+                   "Warning: %s=%s out of bounds, clamping to %d.\n",
+                   name, value, UINT8_MAX);
+    return UINT8_MAX;
+  }
+
+  return n;
+}
+
+// Print a list of all the environment variables. Lazy initialization makes
+// this a bit odd, but the use of these variables in the metadata system means
+// it's almost certain to run early.
+//
+// The "extra" parameter is printed after the header and before the list of
+// variables.
+void printHelp(const char *extra) {
+  swift::warning(RuntimeErrorFlagNone, "Swift runtime debugging:\n");
+  if (extra)
+    swift::warning(RuntimeErrorFlagNone, "%s\n", extra);
+#define VARIABLE(name, type, defaultValue, help) \
+  swift::warning(RuntimeErrorFlagNone, "%7s %s [default: %s] - %s\n", \
+                 #type, #name, #defaultValue, help);
+#include "EnvironmentVariables.def"
+  swift::warning(RuntimeErrorFlagNone, "SWIFT_DEBUG_HELP=YES - Print this help.");
+}
+
+} // end anonymous namespace
+
+// Define backing variables.
+#define VARIABLE(name, type, defaultValue, help) \
+  type swift::runtime::environment::name ## _variable = defaultValue;
+#include "EnvironmentVariables.def"
+
+// Initialization code.
+OnceToken_t swift::runtime::environment::initializeToken;
+
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__linux__)
+extern "C" char **environ;
+#define ENVIRON environ
+#elif defined(_WIN32)
+extern "C" char **_environ;
+#define ENVIRON _environ
+#endif
+
+#ifdef ENVIRON
+void swift::runtime::environment::initialize(void *context) {
+  // On platforms where we have an environment variable array available, scan it
+  // directly. This optimizes for the common case where no variables are set,
+  // since we only need to perform one scan to set all variables. It also allows
+  // us to detect some spelling mistakes by warning on unknown SWIFT_ variables.
+
+  bool SWIFT_DEBUG_HELP_variable = false;
+  for (char **var = ENVIRON; *var; var++) {
+    // Immediately skip anything without a SWIFT_ prefix.
+    if (strncmp(*var, "SWIFT_", 6) != 0)
+      continue;
+
+    bool foundVariable = false;
+    // Check each defined variable in turn, plus SWIFT_DEBUG_HELP. Variables are
+    // parsed by functions named parse_<type> above. An unknown type will
+    // produce an error that parse_<unknown-type> doesn't exist. Add new parsers
+    // above.
+#define VARIABLE(name, type, defaultValue, help)                       \
+    if (strncmp(*var, #name "=", strlen(#name "=")) == 0) {            \
+      name ## _variable =                                              \
+        parse_ ## type(#name, *var + strlen(#name "="), defaultValue); \
+      foundVariable = true;                                            \
+    }
+    // SWIFT_DEBUG_HELP is not in the variables list. Parse it like the other
+    // variables.
+    VARIABLE(SWIFT_DEBUG_HELP, bool, false, )
+#include "EnvironmentVariables.def"
+
+    // Flag unknown SWIFT_DEBUG_ variables to catch misspellings. We don't flag
+    // all unknown SWIFT_ variables, because there are a bunch of other SWIFT_
+    // variables used for other purposes, such as SWIFT_SOURCE_ROOT and
+    // SWIFT_INSTALL_DIR, and we don't want to warn for all of those.
+    const char *swiftDebugPrefix = "SWIFT_DEBUG_";
+    if (!foundVariable &&
+        strncmp(*var, swiftDebugPrefix, strlen(swiftDebugPrefix)) == 0) {
+      const char *equals = strchr(*var, '=');
+      if (!equals)
+        equals = *var + strlen(*var);
+      swift::warning(RuntimeErrorFlagNone,
+                     "Warning: unknown environment variable %.*s\n",
+                     (int)(equals - *var), *var);
+    }
+  }
+
+  if (SWIFT_DEBUG_HELP_variable)
+    printHelp(nullptr);
+}
+#else
+void swift::runtime::environment::initialize(void *context) {
+  // Emit a getenv call for each variable. This is less efficient but works
+  // everywhere.
+#define VARIABLE(name, type, defaultValue, help) \
+  name ## _variable = parse_ ## type(#name, getenv(#name), defaultValue);
+#include "EnvironmentVariables.def"
+
+  // Print help if requested.
+  if (parse_bool("SWIFT_DEBUG_HELP", getenv("SWIFT_DEBUG_HELP"), false))
+    printHelp("Using getenv to read variables. Unknown SWIFT_DEBUG_ variables "
+              "will not be flagged.");
+}
+#endif

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -1,0 +1,40 @@
+//===--- EnvironmentVariables.def - Debug variables. ------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines x-macros used for metaprogramming with the set of
+// environment variables used for configuring or enabling debug features in the
+// runtime.
+//
+//===----------------------------------------------------------------------===//
+
+// #define VARIABLE(name, type, defaultValue, help)
+
+#ifndef VARIABLE
+#error "Must define VARIABLE to include EnvironmentVariables.def"
+#endif
+
+VARIABLE(SWIFT_DEBUG_ENABLE_METADATA_ALLOCATION_ITERATION, bool, false,
+         "Enable additional metadata allocation tracking for swift-inspect to "
+         "use.")
+
+VARIABLE(SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT, uint8_t, 2,
+         "Print warnings when using implicit @objc entrypoints. Set to "
+         "desired reporting level, 0-3.")
+
+VARIABLE(SWIFT_DETERMINISTIC_HASHING, bool, false,
+         "Disable randomized hash seeding.")
+
+VARIABLE(SWIFT_ENABLE_MANGLED_NAME_VERIFICATION, bool, false,
+         "Enable verification that metadata can roundtrip through a mangled "
+         "name each time metadata is instantiated.")
+
+#undef VARIABLE

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -26,6 +26,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "swift/Basic/Lazy.h"
 #include "swift/Runtime/Casting.h"
+#include "swift/Runtime/EnvironmentVariables.h"
 #include "swift/Runtime/Heap.h"
 #include "swift/Runtime/HeapObject.h"
 #include "swift/Runtime/Metadata.h"
@@ -1478,22 +1479,9 @@ void swift_objc_swift3ImplicitObjCEntrypoint(id self, SEL selector,
   //      if possible.
   //   3: Complain about uses of implicit @objc entrypoints, then abort().
   //
-  // The actual reportLevel is stored as the above values +1, so that
-  // 0 indicates we have not yet checked. It's fine to race through here.
-  //
   // The default, if SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT is not set, is 2.
-  static int storedReportLevel = 0;
-  if (storedReportLevel == 0) {
-    auto reportLevelStr = getenv("SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT");
-    if (reportLevelStr &&
-        reportLevelStr[0] >= '0' && reportLevelStr[0] <= '3' &&
-        reportLevelStr[1] == 0)
-      storedReportLevel = (reportLevelStr[0] - '0') + 1;
-    else
-      storedReportLevel = 3;
-  }
-
-  int reportLevel = storedReportLevel - 1;
+  uint8_t reportLevel =
+    runtime::environment::SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT();
   if (reportLevel < 1) return;
 
   // Report the error.

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -20,6 +20,7 @@
 #include "../SwiftShims/Random.h"
 #include "swift/Runtime/Metadata.h"
 #include "swift/Runtime/Debug.h"
+#include "swift/Runtime/EnvironmentVariables.h"
 #include <stdlib.h>
 
 namespace swift {
@@ -113,8 +114,7 @@ static swift::_SwiftHashingParameters initializeHashingParameters() {
   // results are repeatable, e.g., in certain test environments.  (Note that
   // even if the seed override is enabled, hash values aren't guaranteed to
   // remain stable across even minor stdlib releases.)
-  auto determinism = getenv("SWIFT_DETERMINISTIC_HASHING");
-  if (determinism && 0 == strcmp(determinism, "1")) {
+  if (swift::runtime::environment::SWIFT_DETERMINISTIC_HASHING()) {
     return { 0, 0, true };
   }
   __swift_uint64_t seed0 = 0, seed1 = 0;

--- a/test/Runtime/environment_variables.swift
+++ b/test/Runtime/environment_variables.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: env %env-SWIFT_DEBUG_HELP=YES %env-SWIFT_DEBUG_SOME_UNKNOWN_VARIABLE=42 %env-SWIFT_DEBUG_ENABLE_METADATA_ALLOCATION_ITERATION=YES %env-SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=abc %env-SWIFT_DETERMINISTIC_HASHING=whatever %env-SWIFT_ENABLE_MANGLED_NAME_VERIFICATION=YES %target-run %t/main 2>&1 | %FileCheck %s --dump-input fail
+
+// CHECK-DAG: {{Warning: unknown environment variable SWIFT_DEBUG_SOME_UNKNOWN_VARIABLE|Using getenv to read variables. Unknown variables will not be flagged.}}
+// CHECK-DAG: Warning: cannot parse value SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=abc, defaulting to 2.
+// CHECK-DAG: Warning: cannot parse value SWIFT_DETERMINISTIC_HASHING=whatever, defaulting to false.
+// CHECK-DAG: Swift runtime debugging:
+// CHECK-DAG:    bool SWIFT_DEBUG_ENABLE_METADATA_ALLOCATION_ITERATION [default: false] - Enable additional metadata allocation tracking for swift-inspect to use.
+// CHECK-DAG: uint8_t SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT [default: 2] - Print warnings when using implicit @objc entrypoints. Set to desired reporting level, 0-3.
+// CHECK-DAG:    bool SWIFT_DETERMINISTIC_HASHING [default: false] - Disable randomized hash seeding.
+// CHECK-DAG:    bool SWIFT_ENABLE_MANGLED_NAME_VERIFICATION [default: false] - Enable verification that metadata can roundtrip through a mangled name each time metadata is instantiated.
+
+print("Hello, world")
+// CHECK: Hello, world


### PR DESCRIPTION
There are a few environment variables used to enable debugging options in the
runtime, and we'll likely add more over time. These are implemented with
scattered getenv() calls at the point of use. This is inefficient, as most/all
OSes have to do a linear scan of the environment for each call. It's also not
discoverable, since the only way to find these variables is to inspect the
source.

This commit places all of these variables in a central location.
stdlib/public/runtime/EnvironmentVariables.def defines all of the debug
variables including their name, type, default value, and a help string. On OSes
which make an `environ` array available, the entire array is scanned in a single
pass the first time any debug variable is requested. By quickly rejecting
variables that do not start with `SWIFT_`, we optimize for the common case where
no debug variables are set. We also have a fallback to repeated `getenv()` calls
when a full scan is not possible.

Setting `SWIFT_HELP=YES` will print out all available debug variables along with
a brief description of what they do.