### PR TITLE
Revert "AST: Don't set source location on cloned parameter lists"

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6115,8 +6115,8 @@ ParamDecl::ParamDecl(SourceLoc specifierLoc,
 
 ParamDecl *ParamDecl::cloneWithoutType(const ASTContext &Ctx, ParamDecl *PD) {
   auto *Clone = new (Ctx) ParamDecl(
-      SourceLoc(), SourceLoc(), PD->getArgumentName(),
-      SourceLoc(), PD->getParameterName(), PD->getDeclContext());
+      PD->getSpecifierLoc(), PD->getArgumentNameLoc(), PD->getArgumentName(),
+      PD->getArgumentNameLoc(), PD->getParameterName(), PD->getDeclContext());
   Clone->DefaultValueAndFlags.setPointerAndInt(
       nullptr, PD->DefaultValueAndFlags.getInt());
   Clone->Bits.ParamDecl.defaultArgumentKind =

--- a/test/DebugInfo/Inputs/curry_thunk_other.swift
+++ b/test/DebugInfo/Inputs/curry_thunk_other.swift
@@ -1,7 +1,0 @@
-public struct HTTPMethod {
-  public let rawValue: String
-
-  public init(rawValue: String) {
-    self.rawValue = rawValue
-  }
-}

--- a/test/DebugInfo/curry_thunk.swift
+++ b/test/DebugInfo/curry_thunk.swift
@@ -1,8 +1,0 @@
-// RUN: %target-swift-frontend -primary-file %s %S/Inputs/curry_thunk_other.swift -emit-ir -g -o - | %FileCheck %s
-
-public func testCurryThunk() -> [HTTPMethod] {
-  return ["asdf"].map(HTTPMethod.init)
-}
-
-// CHECK: [[FILE:![0-9]+]] = !DIFile(filename: "{{.*}}/curry_thunk.swift", directory: "{{.*}}")
-// CHECK: {{![0-9]+}} = !DILocalVariable(name: "rawValue", arg: 1, scope: {{![0-9]+}}, file: {{![0-9]+}}, type: {{![0-9]+}}, flags: DIFlagArtificial)


### PR DESCRIPTION
Reverts apple/swift#31778