### PR TITLE
[NFC] Make some PassManager options to accept comma separated values

### DIFF
--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -69,42 +69,42 @@ llvm::cl::opt<std::string>
                                     "whose name contains this substring"));
 
 llvm::cl::list<std::string>
-    SILPrintBefore("sil-print-before",
+    SILPrintBefore("sil-print-before", llvm::cl::CommaSeparated,
                    llvm::cl::desc("Print out the sil before passes which "
                                   "contain a string from this list."));
 
 llvm::cl::list<std::string>
-    SILPrintAfter("sil-print-after",
+    SILPrintAfter("sil-print-after", llvm::cl::CommaSeparated,
                   llvm::cl::desc("Print out the sil after passes which contain "
                                  "a string from this list."));
 
 llvm::cl::list<std::string>
-    SILPrintAround("sil-print-around",
+    SILPrintAround("sil-print-around", llvm::cl::CommaSeparated,
                    llvm::cl::desc("Print out the sil before and after passes "
                                   "which contain a string from this list"));
 
 llvm::cl::list<std::string>
-    SILDisablePass("sil-disable-pass",
+    SILDisablePass("sil-disable-pass", llvm::cl::CommaSeparated,
                      llvm::cl::desc("Disable passes "
                                     "which contain a string from this list"));
 
 llvm::cl::list<std::string> SILVerifyBeforePass(
-    "sil-verify-before-pass",
+    "sil-verify-before-pass", llvm::cl::CommaSeparated,
     llvm::cl::desc("Verify the module/analyses before we run "
                    "a pass from this list"));
 
 llvm::cl::list<std::string> SILVerifyAroundPass(
-    "sil-verify-around-pass",
+    "sil-verify-around-pass", llvm::cl::CommaSeparated,
     llvm::cl::desc("Verify the module/analyses before/after we run "
                    "a pass from this list"));
 
 llvm::cl::list<std::string>
-    SILVerifyAfterPass("sil-verify-after-pass",
+    SILVerifyAfterPass("sil-verify-after-pass", llvm::cl::CommaSeparated,
                        llvm::cl::desc("Verify the module/analyses after we run "
                                       "a pass from this list"));
 
 llvm::cl::list<std::string> SILForceVerifyAroundPass(
-    "sil-verify-force-analysis-around-pass",
+    "sil-verify-force-analysis-around-pass", llvm::cl::CommaSeparated,
     llvm::cl::desc("For the given passes, precompute analyses before the pass "
                    "and verify analyses after the pass"));
 


### PR DESCRIPTION
Minor change to pass options like -Xllvm -sil-disable-pass='GenericSpecializer','ExistentialSpecializer' 
