### PR TITLE
[benchmarks] Add a benchmark for printing using mirrors

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -108,6 +108,7 @@ set(SWIFT_BENCH_MODULES
     single-source/LuhnAlgoLazy
     single-source/MapReduce
     single-source/Memset
+    single-source/Mirror
     single-source/MonteCarloE
     single-source/MonteCarloPi
     single-source/NSDictionaryCastToSwift

--- a/benchmark/single-source/Mirror.swift
+++ b/benchmark/single-source/Mirror.swift
@@ -37,7 +37,7 @@ struct G<T> { var t: T }
 class H<T>: C { var t: T; init(_ t: T) { self.t = t }}
 
 public func run_MirrorDefault(scale: Int) {
-  let N = 1_000*scale
+  let N = 100*scale
   
   let s1 = S1(s: "foo", d: 3.14)
   let s2 = S2(i: 42, a: [0..<4])

--- a/benchmark/single-source/Mirror.swift
+++ b/benchmark/single-source/Mirror.swift
@@ -1,0 +1,105 @@
+//===--- Mirror.swift ------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This test measures performance of Mirror and related things.
+import TestsUtils
+
+public let TypeName = BenchmarkInfo(
+  name: "TypeName",
+  runFunction: run_TypeName,
+  tags: [.api, .String])
+
+public let MirrorDefault = BenchmarkInfo(
+  name: "MirrorDefault",
+  runFunction: run_MirrorDefault,
+  tags: [.api, .String])
+
+struct S1 { var s: String; var d: Double }
+struct S2 { var i: Int; var a: [Range<Int>] }
+
+class C { var i: Int = 0 }
+class D: C { var s: String = "" }
+
+enum E {
+  case a,b(Int)
+}
+
+struct G<T> { var t: T }
+class H<T>: C { var t: T; init(_ t: T) { self.t = t }}
+
+public func run_MirrorDefault(scale: Int) {
+  let N = 1_000*scale
+  
+  let s1 = S1(s: "foo", d: 3.14)
+  let s2 = S2(i: 42, a: [0..<4])
+  let c = C()
+  let d = D()
+  let e = E.a
+  let f = E.b(99)
+  let g = G(t: 12.3)
+  let h = H<[Int]>([1,2,3])
+
+  var str = ""
+
+  for _ in 0..<N {
+    str = "\(s1),\(s2),\(c),\(d),\(e),\(f),\(g),\(h)"
+    blackHole(str)
+  }
+  
+  CheckResults(str ==
+    "S1(s: \"foo\", d: 3.14),S2(i: 42, a: [Range(0..<4)]),Mirror.C,Mirror.D,a,b(99),G<Double>(t: 12.3),Mirror.H<Swift.Array<Swift.Int>>")
+}
+
+func typename<T>(of: T.Type) -> String {
+  "\(T.self)"
+}
+
+public func run_TypeName(scale: Int) {
+  let N = 1_000*scale
+  var a: [String] = []
+  a.reserveCapacity(16)
+
+  for _ in 0..<N {
+    a = []
+    a.removeAll(keepingCapacity: true)
+    a.append(typename(of: S1.self))
+    a.append(typename(of: S2.self))
+    a.append(typename(of: C.self))
+    a.append(typename(of: D.self))
+    a.append(typename(of: G<S1>.self))
+    a.append(typename(of: G<C>.self))
+    a.append(typename(of: G<String>.self))
+    a.append(typename(of: H<Int>.self))
+    a.append(typename(of: [S1].self))
+    a.append(typename(of: [G<Int>].self))
+    a.append(typename(of: [H<S1>].self))
+    a.append(typename(of: S1?.self))
+    a.append(typename(of: C?.self))
+    blackHole(a)
+  }
+
+  let expected = ["S1",
+    "S2",
+    "C",
+    "D",
+    "G<S1>",
+    "G<C>",
+    "G<String>",
+    "H<Int>",
+    "Array<S1>",
+    "Array<G<Int>>",
+    "Array<H<S1>>",
+    "Optional<S1>",
+    "Optional<C>",
+  ]
+  CheckResults(a == expected)
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -96,6 +96,7 @@ import LuhnAlgoEager
 import LuhnAlgoLazy
 import MapReduce
 import Memset
+import Mirror
 import MonteCarloE
 import MonteCarloPi
 import NibbleSort
@@ -281,6 +282,7 @@ registerBenchmark(LuhnAlgoEager)
 registerBenchmark(LuhnAlgoLazy)
 registerBenchmark(MapReduce)
 registerBenchmark(Memset)
+registerBenchmark(MirrorDefault)
 registerBenchmark(MonteCarloE)
 registerBenchmark(MonteCarloPi)
 registerBenchmark(NSDictionaryCastToSwift)
@@ -366,6 +368,7 @@ registerBenchmark(Suffix)
 registerBenchmark(SuperChars)
 registerBenchmark(TwoSum)
 registerBenchmark(TypeFlood)
+registerBenchmark(TypeName)
 registerBenchmark(UTF8Decode)
 registerBenchmark(Walsh)
 registerBenchmark(WordCount)


### PR DESCRIPTION
Two new benchmarks. One for using internal mirror reflection to convert types that don't conform to `CustomStringConvertible` to strings, and another for specifically getting a type's name as a string.