### PR TITLE
gyb: clean up some linter warnings

### DIFF
--- a/utils/gyb_syntax_support/__init__.py
+++ b/utils/gyb_syntax_support/__init__.py
@@ -1,21 +1,17 @@
 import textwrap
+from . import Classification  # noqa: I201
+from . import Token
 from .AttributeNodes import ATTRIBUTE_NODES  # noqa: I201
 from .AvailabilityNodes import AVAILABILITY_NODES  # noqa: I201
-from . import Classification  # noqa: I201
 from .CommonNodes import COMMON_NODES  # noqa: I201
 from .DeclNodes import DECL_NODES  # noqa: I201
 from .ExprNodes import EXPR_NODES  # noqa: I201
 from .GenericNodes import GENERIC_NODES  # noqa: I201
-
-from . import Token
-
 from .NodeSerializationCodes import SYNTAX_NODE_SERIALIZATION_CODES, \
     get_serialization_code, \
     verify_syntax_node_serialization_codes
-
 from .PatternNodes import PATTERN_NODES  # noqa: I201
 from .StmtNodes import STMT_NODES  # noqa: I201
-
 from .Trivia import TRIVIAS  # noqa: I201
 from .TypeNodes import TYPE_NODES  # noqa: I201
 


### PR DESCRIPTION
These showed up after the python 2, python 3 compatibility cleanup.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
