### PR TITLE
Formalize some SourceFile parsing outputs

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -407,6 +407,12 @@ public:
                               array.size());
   }
 
+  template <typename T>
+  MutableArrayRef<T>
+  AllocateCopy(const std::vector<T> &vec,
+               AllocationArena arena = AllocationArena::Permanent) const {
+    return AllocateCopy(ArrayRef<T>(vec), arena);
+  }
 
   template<typename T>
   ArrayRef<T> AllocateCopy(const SmallVectorImpl<T> &vec,

--- a/include/swift/AST/ParseRequests.h
+++ b/include/swift/AST/ParseRequests.h
@@ -19,6 +19,7 @@
 #include "swift/AST/ASTTypeIDs.h"
 #include "swift/AST/EvaluatorDependencies.h"
 #include "swift/AST/SimpleRequest.h"
+#include "swift/Syntax/SyntaxNodes.h"
 
 namespace swift {
 
@@ -81,10 +82,17 @@ public:
   void cacheResult(BraceStmt *value) const;
 };
 
+struct SourceFileParsingResult {
+  ArrayRef<Decl *> TopLevelDecls;
+  Optional<ArrayRef<Token>> CollectedTokens;
+  Optional<llvm::MD5> InterfaceHash;
+  Optional<syntax::SourceFileSyntax> SyntaxRoot;
+};
+
 /// Parse the top-level decls of a SourceFile.
 class ParseSourceFileRequest
     : public SimpleRequest<
-          ParseSourceFileRequest, ArrayRef<Decl *>(SourceFile *),
+          ParseSourceFileRequest, SourceFileParsingResult(SourceFile *),
           RequestFlags::SeparatelyCached | RequestFlags::DependencySource> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -93,13 +101,13 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  ArrayRef<Decl *> evaluate(Evaluator &evaluator, SourceFile *SF) const;
+  SourceFileParsingResult evaluate(Evaluator &evaluator, SourceFile *SF) const;
 
 public:
   // Caching.
   bool isCached() const { return true; }
-  Optional<ArrayRef<Decl *>> getCachedResult() const;
-  void cacheResult(ArrayRef<Decl *> decls) const;
+  Optional<SourceFileParsingResult> getCachedResult() const;
+  void cacheResult(SourceFileParsingResult result) const;
 
 public:
   evaluator::DependencySource

--- a/include/swift/AST/ParseTypeIDZone.def
+++ b/include/swift/AST/ParseTypeIDZone.def
@@ -23,5 +23,5 @@ SWIFT_REQUEST(Parse, ParseAbstractFunctionBodyRequest,
               BraceStmt *(AbstractFunctionDecl *), SeparatelyCached,
               NoLocationInfo)
 SWIFT_REQUEST(Parse, ParseSourceFileRequest,
-              ArrayRef<Decl *>(SourceFile *), SeparatelyCached,
+              SourceFileParsingResult(SourceFile *), SeparatelyCached,
               NoLocationInfo)

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -573,9 +573,13 @@ public:
 
   std::vector<Token> &getTokenVector();
 
+  /// If this source file has been told to collect its parsed tokens, retrieve
+  /// those tokens.
   ArrayRef<Token> getAllTokens() const;
 
-  bool shouldCollectToken() const;
+  /// Whether the parsed tokens of this source file should be saved, allowing
+  /// them to be accessed from \c getAllTokens.
+  bool shouldCollectTokens() const;
 
   bool shouldBuildSyntaxTree() const;
 
@@ -602,8 +606,9 @@ public:
 
 private:
 
-  /// If not None, the underlying vector should contain tokens of this source file.
-  Optional<std::vector<Token>> AllCorrectedTokens;
+  /// If not \c None, the underlying vector contains the parsed tokens of this
+  /// source file.
+  Optional<std::vector<Token>> AllCollectedTokens;
 
   std::unique_ptr<SourceFileSyntaxInfo> SyntaxInfo;
 };

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -582,7 +582,6 @@ public:
   bool hasDelayedBodyParsing() const;
 
   syntax::SourceFileSyntax getSyntaxRoot() const;
-  bool hasSyntaxRoot() const;
 
   OpaqueTypeDecl *lookupOpaqueResultType(StringRef MangledName) override;
 

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -558,25 +558,14 @@ public:
     return ParsingOpts.contains(ParsingFlags::EnableInterfaceHash);
   }
 
-  NullablePtr<llvm::MD5> getInterfaceHashPtr() {
-    return InterfaceHash ? InterfaceHash.getPointer() : nullptr;
-  }
-
-  void getInterfaceHash(llvm::SmallString<32> &str) const {
-    // Copy to preserve idempotence.
-    llvm::MD5 md5 = *InterfaceHash;
-    llvm::MD5::MD5Result result;
-    md5.final(result);
-    llvm::MD5::stringifyResult(result, str);
-  }
+  /// Output this file's interface hash into the provided string buffer.
+  void getInterfaceHash(llvm::SmallString<32> &str) const;
 
   void dumpInterfaceHash(llvm::raw_ostream &out) {
     llvm::SmallString<32> str;
     getInterfaceHash(str);
     out << str << '\n';
   }
-
-  std::vector<Token> &getTokenVector();
 
   /// If this source file has been told to collect its parsed tokens, retrieve
   /// those tokens.
@@ -593,7 +582,6 @@ public:
   bool hasDelayedBodyParsing() const;
 
   syntax::SourceFileSyntax getSyntaxRoot() const;
-  void setSyntaxRoot(syntax::SourceFileSyntax &&Root);
   bool hasSyntaxRoot() const;
 
   OpaqueTypeDecl *lookupOpaqueResultType(StringRef MangledName) override;
@@ -611,7 +599,7 @@ private:
 
   /// If not \c None, the underlying vector contains the parsed tokens of this
   /// source file.
-  Optional<std::vector<Token>> AllCollectedTokens;
+  Optional<ArrayRef<Token>> AllCollectedTokens;
 
   /// The root of the syntax tree representing the source file.
   std::unique_ptr<syntax::SourceFileSyntax> SyntaxRoot;

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -583,8 +583,6 @@ public:
 
   bool shouldBuildSyntaxTree() const;
 
-  bool canBeParsedInFull() const;
-
   /// Whether the bodies of types and functions within this file can be lazily
   /// parsed.
   bool hasDelayedBodyParsing() const;

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -22,6 +22,7 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/DiagnosticsParse.h"
 #include "swift/AST/LayoutConstraint.h"
+#include "swift/AST/ParseRequests.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/Stmt.h"
 #include "swift/Basic/OptionSet.h"
@@ -92,8 +93,11 @@ public:
   /// This is called to update the kind of a token whose start location is Loc.
   virtual void registerTokenKindChange(SourceLoc Loc, tok NewKind) {};
 
-  /// This is called when a source file is fully parsed.
-  virtual void finalize() {};
+  /// This is called when a source file is fully parsed. It returns the
+  /// finalized vector of tokens, or \c None if the receiver isn't configured to
+  /// record them.
+  virtual Optional<std::vector<Token>> finalize() { return None; }
+
   virtual ~ConsumeTokenReceiver() = default;
 };
 
@@ -124,7 +128,10 @@ public:
   /// Tracks parsed decls that LLDB requires to be inserted at the top-level.
   std::vector<Decl *> ContextSwitchedTopLevelDecls;
 
-  NullablePtr<llvm::MD5> CurrentTokenHash;
+  /// The current token hash, or \c None if the parser isn't computing a hash
+  /// for the token stream.
+  Optional<llvm::MD5> CurrentTokenHash;
+
   void recordTokenHash(const Token Tok) {
     if (!Tok.getText().empty())
       recordTokenHash(Tok.getText());
@@ -414,6 +421,14 @@ public:
   OpaqueSyntaxNode finalizeSyntaxTree() {
     assert(Tok.is(tok::eof) && "not done parsing yet");
     return SyntaxContext->finalizeRoot();
+  }
+
+  /// Retrieve the token receiver from the parser once it has finished parsing.
+  std::unique_ptr<ConsumeTokenReceiver> takeTokenReceiver() {
+    assert(Tok.is(tok::eof) && "not done parsing yet");
+    auto *receiver = TokReceiver;
+    TokReceiver = nullptr;
+    return std::unique_ptr<ConsumeTokenReceiver>(receiver);
   }
 
   //===--------------------------------------------------------------------===//

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -487,6 +487,9 @@ public:
       void receive(Token tok) override {
         delayedTokens.push_back(tok);
       }
+      Optional<std::vector<Token>> finalize() override {
+        llvm_unreachable("Cannot finalize a DelayedTokenReciever");
+      }
       ~DelayedTokenReceiver() {
         if (!shouldTransfer)
           return;

--- a/include/swift/Parse/SyntaxParseActions.h
+++ b/include/swift/Parse/SyntaxParseActions.h
@@ -24,11 +24,13 @@ namespace swift {
 
 class CharSourceRange;
 class ParsedTriviaPiece;
+class SourceFile;
 class SourceLoc;
 enum class tok;
 
 namespace syntax {
-  enum class SyntaxKind;
+class SourceFileSyntax;
+enum class SyntaxKind;
 }
 
 typedef void *OpaqueSyntaxNode;
@@ -54,6 +56,12 @@ public:
   virtual OpaqueSyntaxNode recordRawSyntax(syntax::SyntaxKind kind,
                                            ArrayRef<OpaqueSyntaxNode> elements,
                                            CharSourceRange range) = 0;
+
+  /// Attempt to realize an opaque raw syntax node for a source file into a
+  /// SourceFileSyntax node. This will return \c None if the parsing action
+  /// doesn't support the realization of syntax nodes.
+  virtual Optional<syntax::SourceFileSyntax>
+  realizeSyntaxRoot(OpaqueSyntaxNode root, const SourceFile &SF) = 0;
 
   /// Discard raw syntax node.
   /// 

--- a/include/swift/SyntaxParse/SyntaxTreeCreator.h
+++ b/include/swift/SyntaxParse/SyntaxTreeCreator.h
@@ -23,7 +23,8 @@ namespace swift {
   class SourceFile;
 
 namespace syntax {
-  class SyntaxArena;
+class SyntaxArena;
+class SourceFileSyntax;
 }
 
 /// Receives the parsed syntax info from the parser and constructs a persistent
@@ -51,7 +52,8 @@ public:
                     RC<syntax::SyntaxArena> arena);
   ~SyntaxTreeCreator();
 
-  void acceptSyntaxRoot(OpaqueSyntaxNode root, SourceFile &SF);
+  Optional<syntax::SourceFileSyntax>
+  realizeSyntaxRoot(OpaqueSyntaxNode root, const SourceFile &SF) override;
 
 private:
   OpaqueSyntaxNode recordToken(tok tokenKind,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -44,7 +44,7 @@
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeLoc.h"
 #include "swift/AST/SwiftNameTranslation.h"
-#include "swift/Parse/Lexer.h"
+#include "swift/Parse/Lexer.h" // FIXME: Bad dependency
 #include "clang/Lex/MacroInfo.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallSet.h"

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2259,19 +2259,7 @@ bool SourceFile::shouldCollectTokens() const {
 }
 
 bool SourceFile::shouldBuildSyntaxTree() const {
-  return canBeParsedInFull() && SyntaxInfo->Enable;
-}
-
-bool SourceFile::canBeParsedInFull() const {
-  switch (Kind) {
-  case SourceFileKind::Library:
-  case SourceFileKind::Main:
-  case SourceFileKind::Interface:
-    return true;
-  case SourceFileKind::SIL:
-    return false;
-  }
-  llvm_unreachable("unhandled kind");
+  return Kind != SourceFileKind::SIL && SyntaxInfo->Enable;
 }
 
 bool SourceFile::hasDelayedBodyParsing() const {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2232,26 +2232,26 @@ SourceFile::SourceFile(ModuleDecl &M, SourceFileKind K,
     (void)problem;
   }
   if (KeepParsedTokens) {
-    AllCorrectedTokens = std::vector<Token>();
+    AllCollectedTokens = std::vector<Token>();
   }
 }
 
 std::vector<Token> &SourceFile::getTokenVector() {
-  assert(shouldCollectToken() && "Disabled");
-  return *AllCorrectedTokens;
+  assert(shouldCollectTokens() && "Disabled");
+  return *AllCollectedTokens;
 }
 
 ArrayRef<Token> SourceFile::getAllTokens() const {
-  assert(shouldCollectToken() && "Disabled");
-  return *AllCorrectedTokens;
+  assert(shouldCollectTokens() && "Disabled");
+  return *AllCollectedTokens;
 }
 
-bool SourceFile::shouldCollectToken() const {
+bool SourceFile::shouldCollectTokens() const {
   switch (Kind) {
   case SourceFileKind::Library:
   case SourceFileKind::Main:
   case SourceFileKind::Interface:
-    return (bool)AllCorrectedTokens;
+    return (bool)AllCollectedTokens;
   case SourceFileKind::SIL:
     return false;
   }
@@ -2283,7 +2283,7 @@ bool SourceFile::hasDelayedBodyParsing() const {
     return false;
   if (hasInterfaceHash())
     return false;
-  if (shouldCollectToken())
+  if (shouldCollectTokens())
     return false;
   if (shouldBuildSyntaxTree())
     return false;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1088,12 +1088,8 @@ void SourceFile::getInterfaceHash(llvm::SmallString<32> &str) const {
   llvm::MD5::stringifyResult(result, str);
 }
 
-bool SourceFile::hasSyntaxRoot() const {
-  return ParsingOpts.contains(ParsingFlags::BuildSyntaxTree);
-}
-
 syntax::SourceFileSyntax SourceFile::getSyntaxRoot() const {
-  assert(hasSyntaxRoot() && "has no syntax root");
+  assert(shouldBuildSyntaxTree() && "Syntax tree disabled");
   auto &eval = getASTContext().evaluator;
   auto *mutableThis = const_cast<SourceFile *>(this);
   return *evaluateOrDefault(eval, ParseSourceFileRequest{mutableThis}, {})

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -902,15 +902,17 @@ SourceFile *CompilerInstance::createSourceFileForMainModule(
     opts |= SourceFile::ParsingFlags::SuppressWarnings;
   }
 
-  SourceFile *inputFile = new (*Context)
-      SourceFile(*mainModule, fileKind, bufferID,
-                 Invocation.getLangOptions().CollectParsedToken,
-                 Invocation.getLangOptions().BuildSyntaxTree, opts, isPrimary);
+  // Enable interface hash computation for primaries, but not in WMO, as it's
+  // only currently needed for incremental mode.
+  if (isPrimary) {
+    opts |= SourceFile::ParsingFlags::EnableInterfaceHash;
+  }
+  opts |= SourceFile::getDefaultParsingOptions(getASTContext().LangOpts);
+
+  auto *inputFile = new (*Context)
+      SourceFile(*mainModule, fileKind, bufferID, opts, isPrimary);
   MainModule->addFile(*inputFile);
 
-  if (isPrimary) {
-    inputFile->enableInterfaceHash();
-  }
   return inputFile;
 }
 

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -328,9 +328,7 @@ bool CompletionInstance::performCachedOperationIfPossible(
   registerSILGenRequestFunctions(tmpCtx->evaluator);
   ModuleDecl *tmpM = ModuleDecl::create(Identifier(), *tmpCtx);
   SourceFile *tmpSF = new (*tmpCtx)
-      SourceFile(*tmpM, oldSF->Kind, tmpBufferID, /*KeepParsedTokens=*/false,
-                 /*BuildSyntaxTree=*/false, oldSF->getParsingOptions());
-  tmpSF->enableInterfaceHash();
+      SourceFile(*tmpM, oldSF->Kind, tmpBufferID, oldSF->getParsingOptions());
 
   // FIXME: Since we don't setup module loaders on the temporary AST context,
   // 'canImport()' conditional compilation directive always fails. That causes
@@ -441,10 +439,9 @@ bool CompletionInstance::performCachedOperationIfPossible(
     auto &Ctx = oldM->getASTContext();
     auto *newM = ModuleDecl::createMainModule(Ctx, oldM->getName(),
                                               oldM->getImplicitImportInfo());
-    auto *newSF =
-        new (Ctx) SourceFile(*newM, SourceFileKind::Main, newBufferID);
+    auto *newSF = new (Ctx) SourceFile(*newM, SourceFileKind::Main, newBufferID,
+                                       oldSF->getParsingOptions());
     newM->addFile(*newSF);
-    newSF->enableInterfaceHash();
 
     // Tell the compiler instance we've replaced the main module.
     CI.setMainModule(newM);

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -677,8 +677,9 @@ ParserResult<IfConfigDecl> Parser::parseIfConfig(
     llvm::SaveAndRestore<bool> S(InInactiveClauseEnvironment,
                                  InInactiveClauseEnvironment || !isActive);
     // Disable updating the interface hash inside inactive blocks.
-    llvm::SaveAndRestore<NullablePtr<llvm::MD5>> T(
-        CurrentTokenHash, isActive ? CurrentTokenHash : nullptr);
+    Optional<llvm::SaveAndRestore<Optional<llvm::MD5>>> T;
+    if (!isActive)
+      T.emplace(CurrentTokenHash, None);
 
     if (isActive || !isVersionCondition) {
       parseElements(Elements, isActive);

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -149,12 +149,8 @@ ArrayRef<Decl *> ParseSourceFileRequest::evaluate(Evaluator &evaluator,
     SF->setDelayedParserState({state, &deletePersistentParserState});
   }
 
-  FrontendStatsTracer tracer(ctx.Stats, "Parsing");
   Parser parser(*bufferID, *SF, /*SIL*/ nullptr, state, sTreeCreator);
   PrettyStackTraceParser StackTrace(parser);
-
-  llvm::SaveAndRestore<NullablePtr<llvm::MD5>> S(parser.CurrentTokenHash,
-                                                 SF->getInterfaceHashPtr());
 
   SmallVector<Decl *, 128> decls;
   parser.parseTopLevel(decls);

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -22,6 +22,7 @@
 #include "swift/Parse/Parser.h"
 #include "swift/Subsystems.h"
 #include "swift/Syntax/SyntaxArena.h"
+#include "swift/Syntax/SyntaxNodes.h"
 #include "swift/SyntaxParse/SyntaxTreeCreator.h"
 
 using namespace swift;
@@ -116,8 +117,8 @@ static void deletePersistentParserState(PersistentParserState *state) {
   delete state;
 }
 
-ArrayRef<Decl *> ParseSourceFileRequest::evaluate(Evaluator &evaluator,
-                                                  SourceFile *SF) const {
+SourceFileParsingResult ParseSourceFileRequest::evaluate(Evaluator &evaluator,
+                                                         SourceFile *SF) const {
   assert(SF);
   auto &ctx = SF->getASTContext();
   auto bufferID = SF->getBufferID();
@@ -155,11 +156,18 @@ ArrayRef<Decl *> ParseSourceFileRequest::evaluate(Evaluator &evaluator,
   SmallVector<Decl *, 128> decls;
   parser.parseTopLevel(decls);
 
+  Optional<SourceFileSyntax> syntaxRoot;
   if (sTreeCreator) {
     auto rawNode = parser.finalizeSyntaxTree();
-    sTreeCreator->acceptSyntaxRoot(rawNode, *SF);
+    syntaxRoot.emplace(*sTreeCreator->realizeSyntaxRoot(rawNode, *SF));
   }
-  return ctx.AllocateCopy(decls);
+
+  Optional<ArrayRef<Token>> tokensRef;
+  if (auto tokens = parser.takeTokenReceiver()->finalize())
+    tokensRef = ctx.AllocateCopy(*tokens);
+
+  return SourceFileParsingResult{ctx.AllocateCopy(decls), tokensRef,
+                                 parser.CurrentTokenHash, syntaxRoot};
 }
 
 evaluator::DependencySource ParseSourceFileRequest::readDependencySource(
@@ -167,15 +175,30 @@ evaluator::DependencySource ParseSourceFileRequest::readDependencySource(
   return {std::get<0>(getStorage()), evaluator::DependencyScope::Cascading};
 }
 
-Optional<ArrayRef<Decl *>> ParseSourceFileRequest::getCachedResult() const {
+Optional<SourceFileParsingResult>
+ParseSourceFileRequest::getCachedResult() const {
   auto *SF = std::get<0>(getStorage());
-  return SF->getCachedTopLevelDecls();
+  auto decls = SF->getCachedTopLevelDecls();
+  if (!decls)
+    return None;
+
+  Optional<SourceFileSyntax> syntaxRoot;
+  if (auto &rootPtr = SF->SyntaxRoot)
+    syntaxRoot.emplace(*rootPtr);
+
+  return SourceFileParsingResult{*decls, SF->AllCollectedTokens,
+                                 SF->InterfaceHash, syntaxRoot};
 }
 
-void ParseSourceFileRequest::cacheResult(ArrayRef<Decl *> decls) const {
+void ParseSourceFileRequest::cacheResult(SourceFileParsingResult result) const {
   auto *SF = std::get<0>(getStorage());
   assert(!SF->Decls);
-  SF->Decls = decls;
+  SF->Decls = result.TopLevelDecls;
+  SF->AllCollectedTokens = result.CollectedTokens;
+  SF->InterfaceHash = result.InterfaceHash;
+
+  if (auto &root = result.SyntaxRoot)
+    SF->SyntaxRoot = std::make_unique<SourceFileSyntax>(std::move(*root));
 
   // Verify the parsed source file.
   verify(*SF);

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -531,7 +531,7 @@ Parser::Parser(std::unique_ptr<Lexer> Lex, SourceFile &SF,
     CurDeclContext(&SF),
     Context(SF.getASTContext()),
     CurrentTokenHash(SF.getInterfaceHashPtr()),
-    TokReceiver(SF.shouldCollectToken() ?
+    TokReceiver(SF.shouldCollectTokens() ?
                 new TokenRecorder(SF, L->getBufferID()) :
                 new ConsumeTokenReceiver()),
     SyntaxContext(new SyntaxParsingContext(SyntaxContext, SF,

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -120,10 +120,9 @@ ModuleDecl *SourceLoader::loadModule(SourceLoc importLoc,
     importMod->setResilienceStrategy(ResilienceStrategy::Resilient);
   Ctx.LoadedModules[moduleID.Item] = importMod;
 
-  auto *importFile = new (Ctx) SourceFile(*importMod, SourceFileKind::Library,
-                                          bufferID,
-                                          Ctx.LangOpts.CollectParsedToken,
-                                          Ctx.LangOpts.BuildSyntaxTree);
+  auto *importFile =
+      new (Ctx) SourceFile(*importMod, SourceFileKind::Library, bufferID,
+                           SourceFile::getDefaultParsingOptions(Ctx.LangOpts));
   importMod->addFile(*importFile);
   performImportResolution(*importFile);
   importMod->setHasResolvedImports();

--- a/lib/SyntaxParse/SyntaxTreeCreator.cpp
+++ b/lib/SyntaxParse/SyntaxTreeCreator.cpp
@@ -93,18 +93,20 @@ public:
 };
 } // anonymous namespace
 
-void SyntaxTreeCreator::acceptSyntaxRoot(OpaqueSyntaxNode rootN,
-                                         SourceFile &SF) {
+Optional<SourceFileSyntax>
+SyntaxTreeCreator::realizeSyntaxRoot(OpaqueSyntaxNode rootN,
+                                     const SourceFile &SF) {
   auto raw = transferOpaqueNode(rootN);
-  SF.setSyntaxRoot(make<SourceFileSyntax>(raw));
+  auto rootNode = make<SourceFileSyntax>(raw);
 
   // Verify the tree if specified.
   if (SF.getASTContext().LangOpts.VerifySyntaxTree) {
     ASTContext &ctx = SF.getASTContext();
     SyntaxVerifier Verifier(ctx.SourceMgr, SF.getBufferID().getValue(),
                             ctx.Diags);
-    Verifier.verify(SF.getSyntaxRoot());
+    Verifier.verify(rootNode);
   }
+  return rootNode;
 }
 
 OpaqueSyntaxNode

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -719,9 +719,7 @@ public:
   }
 
   void parse() {
-    auto root = Parser->parse();
-    if (SynTreeCreator)
-      SynTreeCreator->acceptSyntaxRoot(root, Parser->getSourceFile());
+    Parser->parse();
   }
 
   SourceFile &getSourceFile() {

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -189,6 +189,12 @@ private:
     return getNodeHandler()(&node);
   }
 
+  Optional<SourceFileSyntax> realizeSyntaxRoot(OpaqueSyntaxNode root,
+                                               const SourceFile &SF) override {
+    // We don't support realizing syntax nodes from the C layout.
+    return None;
+  }
+
   void discardRecordedNode(OpaqueSyntaxNode node) override {
     // FIXME: This method should not be called at all.
   }

--- a/unittests/AST/TestContext.cpp
+++ b/unittests/AST/TestContext.cpp
@@ -43,7 +43,7 @@ TestContext::TestContext(ShouldDeclareOptionalTypes optionals)
   Ctx.LoadedModules[stdlibID] = module;
 
   FileForLookups = new (Ctx) SourceFile(*module, SourceFileKind::Library,
-                                        /*buffer*/ None, /*keeps token*/ false);
+                                        /*buffer*/ None);
   module->addFile(*FileForLookups);
 
   if (optionals == DeclareOptionalTypes) {

--- a/unittests/AST/TestContext.cpp
+++ b/unittests/AST/TestContext.cpp
@@ -53,7 +53,11 @@ TestContext::TestContext(ShouldDeclareOptionalTypes optionals)
     optionalTypes.push_back(createOptionalType(
         Ctx, FileForLookups, Ctx.getIdentifier("ImplicitlyUnwrappedOptional")));
 
+    auto result = SourceFileParsingResult{
+        Ctx.AllocateCopy(optionalTypes), /*tokens*/ None,
+        /*interfaceHash*/ None, /*syntaxRoot*/ None};
+
     Ctx.evaluator.cacheOutput(ParseSourceFileRequest{FileForLookups},
-                              Ctx.AllocateCopy(optionalTypes));
+                              std::move(result));
   }
 }


### PR DESCRIPTION
Currently when parsing a `SourceFile`, the parser gets handed pointers so that it can write the interface hash and collected tokens directly into the file. It can also call `setSyntaxRoot` at the end of parsing to set the syntax tree.

In preparation for the removal of `performParseOnly`, this PR formalizes these values as outputs of `ParseSourceFileRequest`, ensuring that the file gets parsed when the interface hash, collected tokens, or syntax tree is queried.

In addition, it cleans up `SourceFile` a little by sinking a couple of parsing options into `SourceFile::ParsingFlags`.