### PR TITLE
Disable tests on windows

### DIFF
--- a/test/IRGen/c_globals.swift
+++ b/test/IRGen/c_globals.swift
@@ -1,5 +1,9 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/abi %s -emit-ir -Xcc -mno-omit-leaf-frame-pointer | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-cpu
 
+// On windows we default to framepointer=none. Therefore the CHECKs fail. It is
+// not worth splitting the CHECK lines just for this.
+// XFAIL: OS=windows-msvc
+
 import c_layout
 
 @inline(never)

--- a/test/IRGen/framepointer.sil
+++ b/test/IRGen/framepointer.sil
@@ -6,6 +6,10 @@
 
 // REQUIRES: CPU=x86_64
 
+// On windows we default to framepointer=none. Therefore the CHECKs fail. It is
+// not worth splitting the CHECK lines just for this.
+// XFAIL: OS=windows-msvc
+
 sil_stage canonical
 
 import Swift


### PR DESCRIPTION
They fail because windows defaults to framepointer=none.