### PR TITLE
Fix dependency scanner test-case to use explicit imports

### DIFF
--- a/test/ScanDependencies/Inputs/Swift/A.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/A.swiftinterface
@@ -1,5 +1,6 @@
 // swift-interface-format-version: 1.0
 // swift-module-flags: -module-name A
+import Swift
 @_exported import A
 public func overlayFuncA() { }
 

--- a/test/ScanDependencies/Inputs/Swift/G.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/G.swiftinterface
@@ -2,7 +2,7 @@
 // swift-module-flags: -module-name G -swift-version 5
 
 #if swift(>=5.0)
-
+import Swift
 @_exported import G
 public func overlayFuncG() { }
 

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -125,7 +125,10 @@ import G
 // CHECK-LABEL: "modulePath": "G.swiftmodule"
 // CHECK: "directDependencies"
 // CHECK-NEXT: {
-// CHECK-NEXT: "clang": "G"
+// CHECK-NEXT:   "swift": "Swift"
+// CHECK-NEXT: },
+// CHECK-NEXT: {
+// CHECK-NEXT:   "clang": "G"
 // CHECK-NEXT: }
 // CHECK-NEXT: ],
 // CHECK-NEXT: "details": {
@@ -153,7 +156,10 @@ import G
 
 // CHECK: directDependencies
 // CHECK-NEXT: {
-// CHECK-NEXT: "clang": "A"
+// CHECK-NEXT:   "swift": "Swift"
+// CHECK-NEXT: },
+// CHECK-NEXT: {
+// CHECK-NEXT:   "clang": "A"
 // CHECK-NEXT: }
 
 /// --------Clang module B


### PR DESCRIPTION
Fast dependency scanner cannot currently handle implicit imports. (rdar://problem/63944222)
In the meantime, make the tests use explicit imports. 