### PR TITLE
[5.3] Fix dynamic member lookup index-while-building crash

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2062,7 +2062,7 @@ void ConstraintSystem::bindOverloadType(
 
     // If this is used inside of the keypath expression, we need to make
     // sure that argument is Hashable.
-    if (isa<KeyPathExpr>(locator->getAnchor()))
+    if (llvm::isa_and_nonnull<KeyPathExpr>(locator->getAnchor()))
       verifyThatArgumentIsHashable(0, argType, locator);
 
     // The resolved decl is for subscript(dynamicMember:), however the original
@@ -2184,7 +2184,7 @@ void ConstraintSystem::bindOverloadType(
       addConstraint(ConstraintKind::Equal, memberTy, leafTy, keyPathLoc);
     }
 
-    if (isa<KeyPathExpr>(locator->getAnchor()))
+    if (llvm::isa_and_nonnull<KeyPathExpr>(locator->getAnchor()))
       verifyThatArgumentIsHashable(0, keyPathTy, locator);
 
     // The resolved decl is for subscript(dynamicMember:), however the

--- a/test/Index/index_keypath_member_lookup.swift
+++ b/test/Index/index_keypath_member_lookup.swift
@@ -137,3 +137,24 @@ func testExplicit(r: Lens<Rectangle>, a: Lens<[Int]>) {
 // CHECK: [[EA_LINE]]:8 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,RelCont | rel: 1
 // CHECK: [[EA_LINE]]:26 | instance-property/subscript/Swift | subscript(_:) | s:SayxSicip | Ref,Read,RelCont | rel: 1
 }
+
+// Don't crash: rdar63558609
+//
+@dynamicMemberLookup
+protocol Foo {
+  var prop: Bar {get}
+  // CHECK: [[@LINE-1]]:7 | instance-property/Swift | prop | [[PROP_USR:.*]] | Def,RelChild | rel: 1
+}
+struct Bar {
+  let enabled = false
+}
+extension Foo {
+  subscript<T>(dynamicMember keyPath: KeyPath<Bar,T>) -> T {
+  // CHECK: [[@LINE-1]]:3 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB2_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-2]]:60 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | {{.*}} | Def,Dyn,RelChild,RelAcc | rel: 1
+  // CHECK-NEXT: RelChild,RelAcc | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB2_USR]]
+
+    prop[keyPath: keyPath]
+    // CHECK: [[@LINE-1]]:5 | instance-property/Swift | prop | [[PROP_USR]] | Ref,Read,RelCont | rel: 1
+  }
+}


### PR DESCRIPTION
- **Explanation**:
Index-while-building (which is enabled by default in Xcode) records the set of overridden decls for each decl it outputs in the index data. Protocols marked with the `@dynamicMemberLookup` attribute require conforming types to include a `subscript(dynamicMember: KeyPath<..., ...>`) member. If a default implementation of this member was provided, the compiler would crash trying to compute its overridden decls.
- **Scope of Issue**: Crashes the compiler when compiling any source code with `@dynamicMemberLookup` specified on a protocol that also provides a default implementation of the required subscript member (i.e. valid code).
- **Origination**: The change to add `@main` support modified the caller of the problematic code in the crashing case to pass a valid constraint system Locator with a null anchor rather than a null Locator like it used to: https://github.com/apple/swift/commit/f7e2abe#diff-ba9f048d1813343154c6702f3188c8b8R4554
- **Risk**: Low. The fix is a simple null check on the Locator's anchor before using it. This matches  the behavior of the equivalent code on the master branch (where the anchor's representation has been changed and it does an equivalent check).
- **Testing**: Added a regression test and all existing tests pass.
- **Reviewer**: Pavel Yaskevich (@xedin)

PR for master (with just the test, since it doesn't reproduce there): https://github.com/apple/swift/pull/32165

Resolves rdar://problem/63558609

