### PR TITLE
ABI: qualify use of `StringRef` and `Optional` (NFC)

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2660,7 +2660,7 @@ private:
 
 using ContextDescriptor = TargetContextDescriptor<InProcess>;
 
-inline bool isCImportedModuleName(StringRef name) {
+inline bool isCImportedModuleName(llvm::StringRef name) {
   // This does not include MANGLING_MODULE_CLANG_IMPORTER because that's
   // used only for synthesized declarations and not actual imported
   // declarations.
@@ -2757,7 +2757,7 @@ public:
 
   /// Retrieve the generic parameter that is the subject of this requirement,
   /// as a mangled type name.
-  StringRef getParam() const {
+  llvm::StringRef getParam() const {
     return swift::Demangle::makeSymbolicMangledNameStringRef(Param.get());
   }
 
@@ -2768,7 +2768,7 @@ public:
   }
 
   /// Retrieve the right-hand type for a SameType or BaseClass requirement.
-  StringRef getMangledTypeName() const {
+  llvm::StringRef getMangledTypeName() const {
     assert(getKind() == GenericRequirementKind::SameType ||
            getKind() == GenericRequirementKind::BaseClass);
     return swift::Demangle::makeSymbolicMangledNameStringRef(Type.get());
@@ -2999,7 +2999,7 @@ public:
 
   using TrailingGenericContextObjects::getGenericContext;
 
-  StringRef getMangledExtendedContext() const {
+  llvm::StringRef getMangledExtendedContext() const {
     return Demangle::makeSymbolicMangledNameStringRef(ExtendedContext.get());
   }
   
@@ -3223,13 +3223,13 @@ public:
     return (this
          ->template getTrailingObjects<RelativeDirectPointer<const char>>())[i];
   }
-  
-  StringRef getUnderlyingTypeArgument(unsigned i) const {
+
+  llvm::StringRef getUnderlyingTypeArgument(unsigned i) const {
     assert(i < getNumUnderlyingTypeArguments());
     const char *ptr = getUnderlyingTypeArgumentMangledName(i);    
     return Demangle::makeSymbolicMangledNameStringRef(ptr);
   }
-  
+
   static bool classof(const TargetContextDescriptor<Runtime> *cd) {
     return cd->getKind() == ContextDescriptorKind::OpaqueType;
   }

--- a/include/swift/ABI/TypeIdentity.h
+++ b/include/swift/ABI/TypeIdentity.h
@@ -114,7 +114,7 @@ public:
   ///
   /// \return true if collection was successful.
   template <bool Asserting>
-  bool collect(StringRef value) {
+  bool collect(llvm::StringRef value) {
 #define check(CONDITION, COMMENT)            \
     do {                                     \
       if (!Asserting) {                      \
@@ -177,17 +177,17 @@ public:
 class ParsedTypeIdentity {
 public:
   /// The user-facing name of the type.
-  StringRef UserFacingName;
+  llvm::StringRef UserFacingName;
 
   /// The full identity of the type.
   /// Note that this may include interior '\0' characters.
-  StringRef FullIdentity;
+  llvm::StringRef FullIdentity;
 
   /// Any extended information that type might have.
-  llvm::Optional<TypeImportInfo<StringRef>> ImportInfo;
+  llvm::Optional<TypeImportInfo<llvm::StringRef>> ImportInfo;
 
   /// The ABI name of the type.
-  StringRef getABIName() const {
+  llvm::StringRef getABIName() const {
     if (ImportInfo && !ImportInfo->ABIName.empty())
       return ImportInfo->ABIName;
     return UserFacingName;
@@ -202,11 +202,11 @@ public:
     return ImportInfo && !ImportInfo->RelatedEntityName.empty();
   }
 
-  bool isRelatedEntity(StringRef entityName) const {
+  bool isRelatedEntity(llvm::StringRef entityName) const {
     return ImportInfo && ImportInfo->RelatedEntityName == entityName;
   }
 
-  StringRef getRelatedEntityName() const {
+  llvm::StringRef getRelatedEntityName() const {
     assert(isAnyRelatedEntity());
     return ImportInfo->RelatedEntityName;
   }


### PR DESCRIPTION
This simply uses the qualified names for `StringRef` and `Optional` to
help with use of regular expressions to identify the usage to help
migrate the references away from `LLVMSupport` to enable explicitly
vending a custom `LLVMSupport` in the runtime.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
