### PR TITLE
[semantic-arc-opts] Teach semantic-arc-opts how to handle structs with multiple non-trivial values.

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -498,6 +498,10 @@ struct OwnedValueIntroducerKind {
     /// branch predecessors.
     Phi,
 
+    /// An owned value that is from a struct that has multiple operands that are
+    /// owned.
+    Struct,
+
     /// An owned value that is a function argument.
     FunctionArgument,
 
@@ -522,6 +526,8 @@ struct OwnedValueIntroducerKind {
       return OwnedValueIntroducerKind(Apply);
     case ValueKind::BeginApplyResult:
       return OwnedValueIntroducerKind(BeginApply);
+    case ValueKind::StructInst:
+      return OwnedValueIntroducerKind(Struct);
     case ValueKind::SILPhiArgument: {
       auto *phiArg = cast<SILPhiArgument>(value);
       if (dyn_cast_or_null<TryApplyInst>(phiArg->getSingleTerminator())) {
@@ -614,6 +620,7 @@ struct OwnedValueIntroducer {
     case OwnedValueIntroducerKind::TryApply:
     case OwnedValueIntroducerKind::LoadTake:
     case OwnedValueIntroducerKind::Phi:
+    case OwnedValueIntroducerKind::Struct:
     case OwnedValueIntroducerKind::FunctionArgument:
     case OwnedValueIntroducerKind::PartialApplyInit:
     case OwnedValueIntroducerKind::AllocBoxInit:
@@ -631,6 +638,7 @@ struct OwnedValueIntroducer {
     switch (kind) {
     case OwnedValueIntroducerKind::Phi:
       return true;
+    case OwnedValueIntroducerKind::Struct:
     case OwnedValueIntroducerKind::Copy:
     case OwnedValueIntroducerKind::LoadCopy:
     case OwnedValueIntroducerKind::Apply:

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -485,6 +485,9 @@ void OwnedValueIntroducerKind::print(llvm::raw_ostream &os) const {
   case OwnedValueIntroducerKind::Phi:
     os << "Phi";
     return;
+  case OwnedValueIntroducerKind::Struct:
+    os << "Struct";
+    return;
   case OwnedValueIntroducerKind::FunctionArgument:
     os << "FunctionArgument";
     return;

--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -2548,3 +2548,16 @@ bb1:
 bb2(%39 : @owned $Klass):
   unreachable
 }
+
+// CHECK-LABEL: sil [ossa] @struct_with_multiple_nontrivial_operands : $@convention(thin) (@guaranteed Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'struct_with_multiple_nontrivial_operands'
+sil [ossa] @struct_with_multiple_nontrivial_operands : $@convention(thin) (@guaranteed Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject, %1 : @guaranteed $Builtin.NativeObject):
+  %0a = copy_value %0 : $Builtin.NativeObject
+  %1a = copy_value %1 : $Builtin.NativeObject
+  %2 = struct $NativeObjectPair(%0a : $Builtin.NativeObject, %1a : $Builtin.NativeObject)
+  destroy_value %2 : $NativeObjectPair
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
Just like br inst, structs are phis in the ownership graph that one can induce
on top of the def-use graph. In this commit, I basically fill in the relevant
blanks in the ADT for such phis for struct so that the optimization for branches
is generalized onto structs.

<rdar://problem/63950481>

----

NOTE: The first commit is from #32172. I am using the original implementation to check the correctness of the refactor before I land this.
