### PR TITLE
[stdlib][cmake] OpenBSD target requires -lpthread.

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -351,6 +351,8 @@ function(_add_target_variant_link_flags)
     list(APPEND link_libraries "pthread" "dl")
   elseif("${LFLAGS_SDK}" STREQUAL "FREEBSD")
     list(APPEND link_libraries "pthread")
+  elseif("${LFLAGS_SDK}" STREQUAL "OPENBSD")
+    list(APPEND link_libraries "pthread")
   elseif("${LFLAGS_SDK}" STREQUAL "CYGWIN")
     # No extra libraries required.
   elseif("${LFLAGS_SDK}" STREQUAL "WINDOWS")


### PR DESCRIPTION
Like FreeBSD, OpenBSD needs -lpthread for a target link. This is
necessary to get the swift-reflection-test to link and build correctly.