### PR TITLE
[semantic-arc-opts] Teach semantic-arc-opts how to handle tuples with multiple non-trivial operands.

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -502,6 +502,10 @@ struct OwnedValueIntroducerKind {
     /// owned.
     Struct,
 
+    /// An owned value that is from a tuple that has multiple operands that are
+    /// owned.
+    Tuple,
+
     /// An owned value that is a function argument.
     FunctionArgument,
 
@@ -528,6 +532,8 @@ struct OwnedValueIntroducerKind {
       return OwnedValueIntroducerKind(BeginApply);
     case ValueKind::StructInst:
       return OwnedValueIntroducerKind(Struct);
+    case ValueKind::TupleInst:
+      return OwnedValueIntroducerKind(Tuple);
     case ValueKind::SILPhiArgument: {
       auto *phiArg = cast<SILPhiArgument>(value);
       if (dyn_cast_or_null<TryApplyInst>(phiArg->getSingleTerminator())) {
@@ -621,6 +627,7 @@ struct OwnedValueIntroducer {
     case OwnedValueIntroducerKind::LoadTake:
     case OwnedValueIntroducerKind::Phi:
     case OwnedValueIntroducerKind::Struct:
+    case OwnedValueIntroducerKind::Tuple:
     case OwnedValueIntroducerKind::FunctionArgument:
     case OwnedValueIntroducerKind::PartialApplyInit:
     case OwnedValueIntroducerKind::AllocBoxInit:
@@ -639,6 +646,7 @@ struct OwnedValueIntroducer {
     case OwnedValueIntroducerKind::Phi:
       return true;
     case OwnedValueIntroducerKind::Struct:
+    case OwnedValueIntroducerKind::Tuple:
     case OwnedValueIntroducerKind::Copy:
     case OwnedValueIntroducerKind::LoadCopy:
     case OwnedValueIntroducerKind::Apply:

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -488,6 +488,9 @@ void OwnedValueIntroducerKind::print(llvm::raw_ostream &os) const {
   case OwnedValueIntroducerKind::Struct:
     os << "Struct";
     return;
+  case OwnedValueIntroducerKind::Tuple:
+    os << "Tuple";
+    return;
   case OwnedValueIntroducerKind::FunctionArgument:
     os << "FunctionArgument";
     return;

--- a/test/SILOptimizer/semantic-arc-opts-canonical.sil
+++ b/test/SILOptimizer/semantic-arc-opts-canonical.sil
@@ -323,8 +323,6 @@ bb0(%0 : @guaranteed $StructMemberTest):
 // multiple trivial arguments), we can.
 //
 // CHECK-LABEL: sil [ossa] @multiple_arg_forwarding_inst_test : $@convention(thin) (@guaranteed Builtin.NativeObject, @guaranteed Builtin.NativeObject, Builtin.Int32) -> () {
-// CHECK: copy_value
-// CHECK: copy_value
 // CHECK-NOT: copy_value
 // CHECK: } // end sil function 'multiple_arg_forwarding_inst_test'
 sil [ossa] @multiple_arg_forwarding_inst_test : $@convention(thin) (@guaranteed Builtin.NativeObject, @guaranteed Builtin.NativeObject, Builtin.Int32) -> () {

--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -347,13 +347,7 @@ bb0(%0 : @guaranteed $StructMemberTest):
   return %7 : $Builtin.Int32
 }
 
-// Make sure that in a case where we have multiple non-trivial values passed to
-// a forwarding instruction we do not optimize... but if we only have one (and
-// multiple trivial arguments), we can.
-//
 // CHECK-LABEL: sil [ossa] @multiple_arg_forwarding_inst_test : $@convention(thin) (@guaranteed Builtin.NativeObject, @guaranteed Builtin.NativeObject, Builtin.Int32) -> () {
-// CHECK: copy_value
-// CHECK: copy_value
 // CHECK-NOT: copy_value
 // CHECK: } // end sil function 'multiple_arg_forwarding_inst_test'
 sil [ossa] @multiple_arg_forwarding_inst_test : $@convention(thin) (@guaranteed Builtin.NativeObject, @guaranteed Builtin.NativeObject, Builtin.Int32) -> () {
@@ -2558,6 +2552,19 @@ bb0(%0 : @guaranteed $Builtin.NativeObject, %1 : @guaranteed $Builtin.NativeObje
   %1a = copy_value %1 : $Builtin.NativeObject
   %2 = struct $NativeObjectPair(%0a : $Builtin.NativeObject, %1a : $Builtin.NativeObject)
   destroy_value %2 : $NativeObjectPair
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @tuple_with_multiple_nontrivial_operands : $@convention(thin) (@guaranteed Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'tuple_with_multiple_nontrivial_operands'
+sil [ossa] @tuple_with_multiple_nontrivial_operands : $@convention(thin) (@guaranteed Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject, %1 : @guaranteed $Builtin.NativeObject):
+  %0a = copy_value %0 : $Builtin.NativeObject
+  %1a = copy_value %1 : $Builtin.NativeObject
+  %2 = tuple (%0a : $Builtin.NativeObject, %1a : $Builtin.NativeObject)
+  destroy_value %2 : $(Builtin.NativeObject, Builtin.NativeObject)
   %9999 = tuple()
   return %9999 : $()
 }


### PR DESCRIPTION
This is the tuple version of #32173.
<rdar://problem/63950481>
