### PR TITLE
[test] Clang is now more strict about underlying type enums

### DIFF
--- a/test/DebugInfo/Inputs/Macro.h
+++ b/test/DebugInfo/Inputs/Macro.h
@@ -1,6 +1,12 @@
+#ifdef __cplusplus
 #define MY_ENUM(NAME) \
-  enum NAME : int NAME; \
   enum NAME : int
+#else
+#define MY_ENUM(NAME) \
+  enum NAME : int; \
+  typedef enum NAME NAME; \
+  enum NAME : int
+#endif
 
 MY_ENUM(macro_enum) {
   zero = 0


### PR DESCRIPTION
As of llvm/llvm-project@c90e198107431f64b73686bdce31c293e3380ac7, clang is now more strict about parsing of enum-base in order to follow C++11 rules.