### PR TITLE
[Frontend] Remove FrontendObserver

### DIFF
--- a/include/swift/FrontendTool/FrontendTool.h
+++ b/include/swift/FrontendTool/FrontendTool.h
@@ -19,6 +19,7 @@
 #define SWIFT_FRONTENDTOOL_H
 
 #include "swift/Basic/LLVM.h"
+#include "llvm/ADT/STLExtras.h"
 
 namespace llvm {
 class Module;
@@ -69,15 +70,16 @@ StringRef escapeForMake(StringRef raw, llvm::SmallVectorImpl<char> &buffer);
 /// \param args the arguments to use as the arguments to the frontend
 /// \param argv0 the name used as the frontend executable
 /// \param mainAddr an address from the main executable
+/// \param configuredCompilerCallback A callback that will be invoked after the
+/// CompilerInstance has been successfully setup.
 ///
 /// \return the exit value of the frontend: 0 or 1 on success unless
 ///   the frontend executes in immediate mode, in which case this will be
 ///   the exit value of the script, assuming it exits normally
-int performFrontend(ArrayRef<const char *> args,
-                    const char *argv0,
-                    void *mainAddr,
-                    FrontendObserver *observer = nullptr);
-
+int performFrontend(
+    ArrayRef<const char *> args, const char *argv0, void *mainAddr,
+    llvm::function_ref<void(CompilerInstance &)> configuredCompilerCallback =
+        [](CompilerInstance &) {});
 
 } // namespace swift
 

--- a/include/swift/FrontendTool/FrontendTool.h
+++ b/include/swift/FrontendTool/FrontendTool.h
@@ -21,42 +21,8 @@
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/STLExtras.h"
 
-namespace llvm {
-class Module;
-}
-
 namespace swift {
-class CompilerInvocation;
 class CompilerInstance;
-class SILModule;
-
-/// A simple observer of frontend activity.
-///
-/// Don't let this interface block enhancements to the frontend pipeline.
-class FrontendObserver {
-public:
-  FrontendObserver() = default;
-  virtual ~FrontendObserver() = default;
-
-  /// The frontend has parsed the command line.
-  virtual void parsedArgs(CompilerInvocation &invocation);
-
-  /// The frontend has configured the compiler instance.
-  virtual void configuredCompiler(CompilerInstance &instance);
-
-  /// The frontend has performed semantic analysis.
-  virtual void performedSemanticAnalysis(CompilerInstance &instance);
-
-  /// The frontend has performed basic SIL generation.
-  /// SIL diagnostic passes have not yet been applied.
-  virtual void performedSILGeneration(SILModule &module);
-
-  /// The frontend has executed the SIL optimization and diagnostics pipelines.
-  virtual void performedSILProcessing(SILModule &module);
-
-  // TODO: maybe enhance this interface to hear about IRGen and LLVM
-  // progress.
-};
 
 namespace frontend {
 namespace utils {

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -2209,9 +2209,3 @@ int swift::performFrontend(
     StatsReporter->noteCurrentProcessExitStatus(r);
   return r;
 }
-
-void FrontendObserver::parsedArgs(CompilerInvocation &invocation) {}
-void FrontendObserver::configuredCompiler(CompilerInstance &instance) {}
-void FrontendObserver::performedSemanticAnalysis(CompilerInstance &instance) {}
-void FrontendObserver::performedSILGeneration(SILModule &module) {}
-void FrontendObserver::performedSILProcessing(SILModule &module) {}

--- a/tools/swift-remoteast-test/swift-remoteast-test.cpp
+++ b/tools/swift-remoteast-test/swift-remoteast-test.cpp
@@ -198,16 +198,6 @@ stopRemoteAST() {
     remoteContext.reset();
 }
 
-namespace {
-
-struct Observer : public FrontendObserver {
-  void configuredCompiler(CompilerInstance &instance) override {
-    context = &instance.getASTContext();
-  }
-};
-
-} // end anonymous namespace
-
 int main(int argc, const char *argv[]) {
   PROGRAM_START(argc, argv);
 
@@ -221,7 +211,10 @@ int main(int argc, const char *argv[]) {
   forwardedArgs.push_back("-interpret");
   assert(forwardedArgs.size() == numForwardedArgs);
 
-  Observer observer;
-  return performFrontend(forwardedArgs, argv[0], (void*) &printMetadataType,
-                         &observer);
+  // FIXME: Once the compiler pipeline has been sufficiently inverted, we
+  // should be able to call into immediate mode directly rather than calling
+  // performFrontend with a callback to register the ASTContext.
+  return performFrontend(
+      forwardedArgs, argv[0], (void *)&printMetadataType,
+      [](CompilerInstance &instance) { context = &instance.getASTContext(); });
 }


### PR DESCRIPTION
It only has two clients, `swift-ast-script` and `swift-remoteast-test`. The former can be modified to use its own `CompilerInstance`, and the latter can use a callback on `performFrontend` instead.