### PR TITLE
[SymbolGraph] Don't print inherited list in declaration fragments

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -450,6 +450,9 @@ struct PrintOptions {
   /// Whether to print parameter specifiers as 'let' and 'var'.
   bool PrintParameterSpecifiers = false;
 
+  /// Whether to print inheritance lists for types.
+  bool PrintInherited = true;
+
   /// \see ShouldQualifyNestedDeclarations
   enum class QualifyNestedDeclarations {
     Never,

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2073,6 +2073,9 @@ void PrintAST::printDeclGenericRequirements(GenericContext *decl) {
 }
 
 void PrintAST::printInherited(const Decl *decl) {
+  if (!Options.PrintInherited) {
+    return;
+  }
   SmallVector<TypeLoc, 6> TypesToPrint;
   getInheritedForPrinting(decl, Options, TypesToPrint);
   if (TypesToPrint.empty())

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -61,6 +61,7 @@ PrintOptions SymbolGraph::getDeclarationFragmentsPrintOptions() const {
   Opts.SkipPrivateStdlibDecls = true;
   Opts.SkipUnderscoredStdlibProtocols = true;
   Opts.PrintGenericRequirements = true;
+  Opts.PrintInherited = false;
 
   Opts.ExclusiveAttrList.clear();
 

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/NominalTypes.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/NominalTypes.swift
@@ -6,7 +6,9 @@
 // RUN: %FileCheck %s --input-file %t/NominalTypes.symbols.json --check-prefix=ENUM
 // RUN: %FileCheck %s --input-file %t/NominalTypes.symbols.json --check-prefix=TYPEALIAS
 
-public struct S<T> where T: Sequence {}
+public protocol P {}
+
+public struct S<T> : P where T: Sequence {}
 
 // STRUCT-LABEL: "precise": "s:12NominalTypes1SV",
 // STRUCT: "declarationFragments": [


### PR DESCRIPTION
Add a new `PrintInherited` flag to `PrintOptions` to support this.

rdar://63033669