### PR TITLE
[5.3][CSGen] Allow `is` patterns to infer type from enclosing context

### DIFF
--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -478,3 +478,20 @@ func rdar_60048356() {
     }
   }
 }
+
+// rdar://problem/63510989 - valid pattern doesn't type-check
+func rdar63510989() {
+  enum Value : P {
+    func p() {}
+  }
+
+  enum E {
+    case foo(P?)
+  }
+
+  func test(e: E) {
+    if case .foo(_ as Value) = e {} // Ok
+    if case .foo(let v as Value) = e {} // Ok
+    // expected-warning@-1 {{immutable value 'v' was never used; consider replacing with '_' or removing it}}
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/31810

---
- Explanation:

Instead of assuming type of its sub-pattern `is` should be able
to infer type from context and then propagate that to the sub-pattern
via conversion. This enables support for patterns like `.foo(_ as Foo)`
where `is` would have a type different from `_` which gets inferred
from associated value of `foo` and converted to `Foo` that becomes
a type of `_` pattern.

- Scope: `is` pattern used to match associated type of an enum element in `if case` and other constructs.

- Resolves: rdar://problem/63510989

- Risk: Low

- Testing: Added regression tests

- Reviewer: @DougGregor 

Resolves: rdar://problem/63510989
(cherry picked from commit b14d9655ca4e1c32cf3a055bd9d4be2f5bf3471f)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
