### PR TITLE
[Parse] Avoid delayed member parsing for type decl with missing brace

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -928,9 +928,8 @@ public:
   std::pair<std::vector<Decl *>, Optional<std::string>>
   parseDeclListDelayed(IterableDeclContext *IDC);
 
-  bool parseMemberDeclList(SourceLoc LBLoc, SourceLoc &RBLoc,
-                           SourceLoc PosBeforeLB,
-                           Diag<> ErrorDiag,
+  bool parseMemberDeclList(SourceLoc &LBLoc, SourceLoc &RBLoc,
+                           Diag<> LBraceDiag, Diag<> RBraceDiag,
                            IterableDeclContext *IDC);
 
   bool canDelayMemberDeclParsing(bool &HasOperatorDeclarations,

--- a/test/SourceKit/CodeComplete/complete_sequence_innertype.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_innertype.swift
@@ -1,0 +1,10 @@
+func test() {
+  class C: 
+}
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=complete -pos=2:11 -repeat-request=2 %s -- %s -parse-as-library \
+// RUN:   | %FileCheck %s
+
+// CHECK: key.results: [
+// CHECK:   description: "Int",


### PR DESCRIPTION
Cache empty member list so that 'IterableDeclContext::loadAllMembers()'
doesn't perform delayed member parsing.

Fixes: rdar://problem/63921896

