### PR TITLE
Mark non-foreign entry points of `@objc dynamic` methods in generic c…

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2715,6 +2715,7 @@ public:
   /// Is this declaration marked with 'dynamic'?
   bool isDynamic() const;
 
+private:
   bool isObjCDynamic() const {
     return isObjC() && isDynamic();
   }
@@ -2722,6 +2723,37 @@ public:
   bool isNativeDynamic() const {
     return !isObjC() && isDynamic();
   }
+
+  bool isObjCDynamicInGenericClass() const;
+
+public:
+  /// Should we use Objective-C method dispatch for this decl.
+  bool shouldUseObjCDispatch() const {
+    return isObjCDynamic();
+  }
+
+  /// Should we use native dynamic function replacement dispatch for this decl.
+  bool shouldUseNativeDynamicDispatch() const {
+    return isNativeDynamic();
+  }
+
+  /// Should we use Objective-C category based function replacement for this
+  /// decl.
+  /// This is all `@objc dynamic` methods except for such methods in native
+  /// generic classes. We can't use a category for generic classes so we use
+  /// native replacement instead (this behavior is only enabled with
+  /// -enable-implicit-dynamic).
+  bool shouldUseObjCMethodReplacement() const;
+
+  /// Should we use native dynamic function replacement mechanism for this decl.
+  /// This is all native dynamic methods except for `@objc dynamic` methods in
+  /// generic classes (see above).
+  bool shouldUseNativeMethodReplacement() const;
+
+  /// Is this a native dynamic function replacement based replacement.
+  /// This is all @_dynamicReplacement(for:) of native functions and @objc
+  /// dynamic methods on generic classes (see above).
+  bool isNativeMethodReplacement() const;
 
   bool isEffectiveLinkageMoreVisibleThan(ValueDecl *other) const {
     return (std::min(getEffectiveAccess(), AccessLevel::Public) >

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -98,6 +98,7 @@ class ExtendedValidationInfo {
     unsigned IsSIB : 1;
     unsigned IsTestable : 1;
     unsigned ResilienceStrategy : 2;
+    unsigned IsImplicitDynamicEnabled: 1;
   } Bits;
 public:
   ExtendedValidationInfo() : Bits() {}
@@ -122,6 +123,10 @@ public:
   bool arePrivateImportsEnabled() { return Bits.ArePrivateImportsEnabled; }
   void setPrivateImportsEnabled(bool enabled) {
     Bits.ArePrivateImportsEnabled = enabled;
+  }
+  bool isImplicitDynamicEnabled() { return Bits.IsImplicitDynamicEnabled; }
+  void setImplicitDynamicEnabled(bool val) {
+    Bits.IsImplicitDynamicEnabled = val;
   }
   bool isTestable() const { return Bits.IsTestable; }
   void setIsTestable(bool val) {

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -3120,12 +3120,12 @@ public:
                storageDecl->getWriteImpl() ==
                    WriteImplKind::StoredWithObservers ||
                storageDecl->getWriteImpl() == WriteImplKind::MutableAddress) &&
-              storageDecl->isNativeDynamic()) &&
+              storageDecl->shouldUseNativeDynamicDispatch()) &&
             // We allow a non dynamic getter if there is a dynamic read.
             !(FD->isGetter() &&
               (storageDecl->getReadImpl() == ReadImplKind::Read ||
                storageDecl->getReadImpl() == ReadImplKind::Address) &&
-              storageDecl->isNativeDynamic())) {
+              storageDecl->shouldUseNativeDynamicDispatch())) {
           Out << "Property and accessor do not match for 'dynamic'\n";
           abort();
         }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1912,7 +1912,7 @@ SourceRange IfConfigDecl::getSourceRange() const {
 }
 
 static bool isPolymorphic(const AbstractStorageDecl *storage) {
-  if (storage->isObjCDynamic())
+  if (storage->shouldUseObjCDispatch())
     return true;
 
 
@@ -2063,7 +2063,7 @@ getDirectReadWriteAccessStrategy(const AbstractStorageDecl *storage) {
     return AccessStrategy::getStorage();
   case ReadWriteImplKind::Stored: {
     // If the storage isDynamic (and not @objc) use the accessors.
-    if (storage->isNativeDynamic())
+    if (storage->shouldUseNativeDynamicDispatch())
       return AccessStrategy::getMaterializeToTemporary(
           getOpaqueReadAccessStrategy(storage, false),
           getOpaqueWriteAccessStrategy(storage, false));
@@ -2148,7 +2148,7 @@ AbstractStorageDecl::getAccessStrategy(AccessSemantics semantics,
       if (isPolymorphic(this))
         return getOpaqueAccessStrategy(this, accessKind, /*dispatch*/ true);
 
-      if (isNativeDynamic())
+      if (shouldUseNativeDynamicDispatch())
         return getOpaqueAccessStrategy(this, accessKind, /*dispatch*/ false);
 
       // If the storage is resilient from the given module and resilience
@@ -2904,6 +2904,59 @@ bool ValueDecl::isDynamic() const {
   return evaluateOrDefault(ctx.evaluator,
     IsDynamicRequest{const_cast<ValueDecl *>(this)},
     getAttrs().hasAttribute<DynamicAttr>());
+}
+
+bool ValueDecl::isObjCDynamicInGenericClass() const {
+  if (!isObjCDynamic())
+    return false;
+
+  auto *DC = this->getDeclContext();
+  auto *classDecl = DC->getSelfClassDecl();
+  if (!classDecl)
+    return false;
+
+  return classDecl->isGenericContext() && !classDecl->usesObjCGenericsModel();
+}
+
+bool ValueDecl::shouldUseObjCMethodReplacement() const {
+  if (isNativeDynamic())
+    return false;
+
+  if (getModuleContext()->isImplicitDynamicEnabled() &&
+      isObjCDynamicInGenericClass())
+    return false;
+
+  return isObjCDynamic();
+}
+
+bool ValueDecl::shouldUseNativeMethodReplacement() const {
+  if (isNativeDynamic())
+    return true;
+
+  if (!isObjCDynamicInGenericClass())
+    return false;
+
+  auto *replacedDecl = getDynamicallyReplacedDecl();
+  if (replacedDecl)
+    return false;
+
+  return getModuleContext()->isImplicitDynamicEnabled();
+}
+
+bool ValueDecl::isNativeMethodReplacement() const {
+  // Is this a @_dynamicReplacement(for:) that use the native dynamic function
+  // replacement mechanism.
+  auto *replacedDecl = getDynamicallyReplacedDecl();
+  if (!replacedDecl)
+    return false;
+
+  if (isNativeDynamic())
+    return true;
+
+  if (isObjCDynamicInGenericClass())
+    return replacedDecl->getModuleContext()->isImplicitDynamicEnabled();
+
+  return false;
 }
 
 void ValueDecl::setIsDynamic(bool value) {
@@ -5132,7 +5185,7 @@ bool AbstractStorageDecl::hasDidSetOrWillSetDynamicReplacement() const {
 
 bool AbstractStorageDecl::hasAnyNativeDynamicAccessors() const {
   for (auto accessor : getAllAccessors()) {
-    if (accessor->isNativeDynamic())
+    if (accessor->shouldUseNativeDynamicDispatch())
       return true;
   }
   return false;

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -468,7 +468,7 @@ bool shouldUseOpaqueTypeDescriptorAccessor(OpaqueTypeDecl *opaque) {
 
   // Don't emit accessors for functions that are not dynamic or dynamic
   // replacements.
-  return namingDecl->isNativeDynamic() ||
+  return namingDecl->shouldUseNativeDynamicDispatch() ||
          (bool)namingDecl->getDynamicallyReplacedDecl();
 }
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2566,7 +2566,7 @@ void IRGenModule::emitOpaqueTypeDescriptorAccessor(OpaqueTypeDecl *opaque) {
   // Don't emit accessors for functions that are not dynamic or dynamic
   // replacements.
   if (!abstractStorage) {
-    isNativeDynamic = namingDecl->isNativeDynamic();
+    isNativeDynamic = namingDecl->shouldUseNativeDynamicDispatch();
     if (!isNativeDynamic && !isDynamicReplacement)
       return;
   }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1563,7 +1563,7 @@ namespace {
       auto flags = getMethodDescriptorFlags<Flags>(func);
 
       // Remember if the declaration was dynamic.
-      if (func->isObjCDynamic())
+      if (func->shouldUseObjCDispatch())
         flags = flags.withIsDynamic(true);
 
       // Include the pointer-auth discriminator.

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -1435,12 +1435,22 @@ void irgen::emitObjCSetterDescriptor(IRGenModule &IGM,
   emitObjCDescriptor(IGM, descriptors, descriptor);
 }
 
+static bool isObjCGenericClassExtension(ValueDecl *decl) {
+  // Don't emit category entries for @objc methods in extensions they would
+  // normally be disallowed except for @_dynamicReplacement(for:) methods that
+  // use the native dynamic replacement mechanism instead of objc categories.
+  auto *DC = decl->getDeclContext();
+  if (!isa<ExtensionDecl>(DC))
+    return false;
+  return decl->isNativeMethodReplacement();
+}
+
 bool irgen::requiresObjCMethodDescriptor(FuncDecl *method) {
   // Property accessors should be generated alongside the property.
   if (isa<AccessorDecl>(method))
     return false;
 
-  return method->isObjC();
+  return method->isObjC() && !isObjCGenericClassExtension(method);
 }
 
 bool irgen::requiresObjCMethodDescriptor(ConstructorDecl *constructor) {
@@ -1452,12 +1462,13 @@ bool irgen::requiresObjCPropertyDescriptor(IRGenModule &IGM,
   // Don't generate a descriptor for a property without any accessors.
   // This is only possible in SIL files because Sema will normally
   // implicitly synthesize accessors for @objc properties.
-  return property->isObjC() && property->requiresOpaqueAccessors();
+  return property->isObjC() && property->requiresOpaqueAccessors() &&
+         !isObjCGenericClassExtension(property);
 }
 
 bool irgen::requiresObjCSubscriptDescriptor(IRGenModule &IGM,
                                             SubscriptDecl *subscript) {
-  return subscript->isObjC();
+  return subscript->isObjC() && !isObjCGenericClassExtension(subscript);
 }
 
 llvm::Value *IRGenFunction::emitBlockCopyCall(llvm::Value *value) {

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -41,7 +41,7 @@ swift::getMethodDispatch(AbstractFunctionDecl *method) {
   auto dc = method->getDeclContext();
 
   if (dc->getSelfClassDecl()) {
-    if (method->isObjCDynamic()) {
+    if (method->shouldUseObjCDispatch()) {
       return MethodDispatch::Class;
     }
 
@@ -88,7 +88,7 @@ bool swift::requiresForeignToNativeThunk(ValueDecl *vd) {
 bool swift::requiresForeignEntryPoint(ValueDecl *vd) {
   assert(!isa<AbstractStorageDecl>(vd));
 
-  if (vd->isObjCDynamic()) {
+  if (vd->shouldUseObjCDispatch()) {
     return true;
   }
 
@@ -872,15 +872,15 @@ SILDeclRef SILDeclRef::getNextOverriddenVTableEntry() const {
     }
 
     // Overrides of @objc dynamic declarations are not in the vtable.
-    if (overridden.getDecl()->isObjCDynamic()) {
+    if (overridden.getDecl()->shouldUseObjCDispatch()) {
       return SILDeclRef();
     }
-    
+
     if (auto *accessor = dyn_cast<AccessorDecl>(overridden.getDecl())) {
       auto *asd = accessor->getStorage();
       if (asd->hasClangNode())
         return SILDeclRef();
-      if (asd->isObjCDynamic()) {
+      if (asd->shouldUseObjCDispatch()) {
         return SILDeclRef();
       }
     }
@@ -1111,6 +1111,10 @@ static bool isDesignatedConstructorForClass(ValueDecl *decl) {
 }
 
 bool SILDeclRef::canBeDynamicReplacement() const {
+  // The foreign entry of a @dynamicReplacement(for:) of @objc method in a
+  // generic class can't be a dynamic replacement.
+  if (isForeign && hasDecl() && getDecl()->isNativeMethodReplacement())
+    return false;
   if (kind == SILDeclRef::Kind::Destroyer ||
       kind == SILDeclRef::Kind::DefaultArgGenerator)
     return false;
@@ -1122,6 +1126,11 @@ bool SILDeclRef::canBeDynamicReplacement() const {
 }
 
 bool SILDeclRef::isDynamicallyReplaceable() const {
+  // The non-foreign entry of a @dynamicReplacement(for:) of @objc method in a
+  // generic class can't be a dynamically replaced.
+  if (!isForeign && hasDecl() && getDecl()->isNativeMethodReplacement())
+    return false;
+
   if (kind == SILDeclRef::Kind::DefaultArgGenerator)
     return false;
   if (isStoredPropertyInitializer() || isPropertyWrapperBackingInitializer())
@@ -1143,5 +1152,15 @@ bool SILDeclRef::isDynamicallyReplaceable() const {
     return false;
 
   auto decl = getDecl();
-  return decl->isNativeDynamic();
+
+  if (isForeign)
+    return false;
+
+  // We can't generate categories for generic classes. So the standard mechanism
+  // for replacing @objc dynamic methods in generic classes does not work.
+  // Instead we mark the non @objc entry dynamically replaceable and replace
+  // that.
+  // For now, we only support this behavior if -enable-implicit-dynamic is
+  // enabled.
+  return decl->shouldUseNativeMethodReplacement();
 }

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1005,7 +1005,7 @@ public:
       // @objc dynamic initializers are statically dispatched (we're
       // calling the allocating entry point, which is a thunk that
       // does the dynamic dispatch for us).
-      if (ctor->isObjCDynamic())
+      if (ctor->shouldUseObjCDispatch())
         return false;
 
       // Required constructors are statically dispatched when the 'self'

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1469,7 +1469,7 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
       // If @objc was inferred based on the Swift 3 @objc inference rules, emit
       // a call to Builtin.swift3ImplicitObjCEntrypoint() to enable runtime
       // logging of the uses of such entrypoints.
-      if (attr->isSwift3Inferred() && !decl->isObjCDynamic()) {
+      if (attr->isSwift3Inferred() && !decl->shouldUseObjCDispatch()) {
         // Get the starting source location of the declaration so we can say
         // exactly where to stick '@objc'.
         SourceLoc objcInsertionLoc =

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -576,7 +576,7 @@ void SILGenFunction::emitClassConstructorAllocator(ConstructorDecl *ctor) {
   bool useObjCAllocation = usesObjCAllocator(selfClassDecl);
 
   if (ctor->hasClangNode() ||
-      ctor->isObjCDynamic() ||
+      ctor->shouldUseObjCDispatch() ||
       ctor->isConvenienceInit()) {
     assert(ctor->hasClangNode() || ctor->isObjC());
     // For an allocator thunk synthesized for an @objc convenience initializer

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -154,7 +154,7 @@ SILGenFunction::emitSiblingMethodRef(SILLocation loc,
   // If the method is dynamic, access it through runtime-hookable virtual
   // dispatch (viz. objc_msgSend for now).
   if (methodConstant.hasDecl()
-      && methodConstant.getDecl()->isObjCDynamic()) {
+      && methodConstant.getDecl()->shouldUseObjCDispatch()) {
     methodValue =
         emitDynamicMethodRef(
             loc, methodConstant,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1463,7 +1463,7 @@ namespace {
         auto setterInfo =
             SGF.getConstantInfo(SGF.getTypeExpansionContext(), setter);
         SILValue setterFRef;
-        if (setter.hasDecl() && setter.getDecl()->isObjCDynamic()) {
+        if (setter.hasDecl() && setter.getDecl()->shouldUseObjCDispatch()) {
           // Emit a thunk we might have to bridge arguments.
           auto foreignSetterThunk = setter.asForeign(false);
           setterFRef =

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -4504,7 +4504,7 @@ static WitnessDispatchKind getWitnessDispatchKind(SILDeclRef witness,
   }
 
   // If the witness is dynamic, go through dynamic dispatch.
-  if (decl->isObjCDynamic()) {
+  if (decl->shouldUseObjCDispatch()) {
     // For initializers we still emit a static allocating thunk around
     // the dynamic initializing entry point.
     if (witness.kind == SILDeclRef::Kind::Allocator)

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4286,7 +4286,7 @@ static void maybeDiagnoseCallToKeyValueObserveMethod(const Expr *E,
       if (!property)
         return;
       auto propertyVar = cast<VarDecl>(property);
-      if (propertyVar->isObjCDynamic() ||
+      if (propertyVar->shouldUseObjCDispatch() ||
           (propertyVar->isObjC() &&
            propertyVar->getParsedAccessor(AccessorKind::Set)))
         return;

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -81,7 +81,7 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
   // Dynamic declarations were mistakenly not checked in Swift 4.2.
   // Do enforce the restriction even in pre-Swift-5 modes if the module we're
   // building is resilient, though.
-  if (D->isObjCDynamic() && !Context.isSwiftVersionAtLeast(5) &&
+  if (D->shouldUseObjCDispatch() && !Context.isSwiftVersionAtLeast(5) &&
       !DC->getParentModule()->isResilient()) {
     return false;
   }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2615,7 +2615,7 @@ void AttributeChecker::visitDynamicReplacementAttr(DynamicReplacementAttr *attr)
     return;
   }
 
-  if (replacement->isNativeDynamic()) {
+  if (replacement->shouldUseNativeDynamicDispatch()) {
     diagnose(attr->getLocation(), diag::dynamic_replacement_must_not_be_dynamic,
              replacement->getBaseName());
     attr->setInvalid();

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -838,7 +838,7 @@ NeedsNewVTableEntryRequest::evaluate(Evaluator &evaluator,
 
   // Final members are always be called directly.
   // Dynamic methods are always accessed by objc_msgSend().
-  if (decl->isFinal() || decl->isObjCDynamic() || decl->hasClangNode())
+  if (decl->isFinal() || decl->shouldUseObjCDispatch() || decl->hasClangNode())
     return false;
 
   auto &ctx = dc->getASTContext();
@@ -868,7 +868,7 @@ NeedsNewVTableEntryRequest::evaluate(Evaluator &evaluator,
 
   auto base = decl->getOverriddenDecl();
 
-  if (!base || base->hasClangNode() || base->isObjCDynamic())
+  if (!base || base->hasClangNode() || base->shouldUseObjCDispatch())
     return true;
 
   // As above, convenience initializers are not formally overridable in Swift

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -437,6 +437,14 @@ static bool checkObjCInExtensionContext(const ValueDecl *value,
       }
 
       if (classDecl->isGenericContext()) {
+        // We do allow one special case. A @_dynamicReplacement(for:) function.
+        // Currently, this is only supported if the replaced decl is from a
+        // module compiled with -enable-implicit-dynamic.
+        if (value->getDynamicallyReplacedDecl() &&
+            value->getDynamicallyReplacedDecl()
+                ->getModuleContext()
+                ->isImplicitDynamicEnabled())
+          return false;
         if (!classDecl->usesObjCGenericsModel()) {
           if (diagnose) {
             value->diagnose(diag::objc_in_generic_extension,

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1819,7 +1819,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
   if (auto *baseDecl = dyn_cast<ClassDecl>(base->getDeclContext())) {
     if (!isAccessor &&
         baseDecl->hasKnownSwiftImplementation() &&
-        !base->isObjCDynamic() &&
+        !base->shouldUseObjCDispatch() &&
         isa<ExtensionDecl>(override->getDeclContext())) {
       diags.diagnose(override, diag::override_class_declaration_in_extension);
       diags.diagnose(base, diag::overridden_here);

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2082,7 +2082,7 @@ RequiresOpaqueAccessorsRequest::evaluate(Evaluator &evaluator,
 
   } else if (dc->isModuleScopeContext()) {
     // Fixed-layout global variables don't require opaque accessors.
-    if (!var->isResilient() && !var->isNativeDynamic())
+    if (!var->isResilient() && !var->shouldUseNativeDynamicDispatch())
       return false;
 
   // Stored properties imported from Clang don't require opaque accessors.
@@ -2127,7 +2127,7 @@ RequiresOpaqueModifyCoroutineRequest::evaluate(Evaluator &evaluator,
 
   // Dynamic storage does not have an opaque modify coroutine.
   if (dc->getSelfClassDecl())
-    if (storage->isObjCDynamic())
+    if (storage->shouldUseObjCDispatch())
       return false;
 
   // Requirements of ObjC protocols don't have an opaque modify coroutine.

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -152,6 +152,9 @@ static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
     case options_block::ARE_PRIVATE_IMPORTS_ENABLED:
       extendedInfo.setPrivateImportsEnabled(true);
       break;
+    case options_block::IS_IMPLICIT_DYNAMIC_ENABLED:
+      extendedInfo.setImplicitDynamicEnabled(true);
+      break;
     case options_block::RESILIENCE_STRATEGY:
       unsigned Strategy;
       options_block::ResilienceStrategyLayout::readRecord(scratch, Strategy);

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 558; // SIL function type result differentiability
+const uint16_t SWIFTMODULE_VERSION_MINOR = 559; // Serialization of -implicit-dynamic
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -775,7 +775,8 @@ namespace options_block {
     IS_SIB,
     IS_TESTABLE,
     RESILIENCE_STRATEGY,
-    ARE_PRIVATE_IMPORTS_ENABLED
+    ARE_PRIVATE_IMPORTS_ENABLED,
+    IS_IMPLICIT_DYNAMIC_ENABLED
   };
 
   using SDKPathLayout = BCRecordLayout<
@@ -799,6 +800,10 @@ namespace options_block {
 
   using ArePrivateImportsEnabledLayout = BCRecordLayout<
     ARE_PRIVATE_IMPORTS_ENABLED
+  >;
+
+  using IsImplicitDynamicEnabledLayout = BCRecordLayout<
+    IS_IMPLICIT_DYNAMIC_ENABLED
   >;
 
   using ResilienceStrategyLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -903,6 +903,11 @@ void Serializer::writeHeader(const SerializationOptions &options) {
         PrivateImports.emit(ScratchRecord);
       }
 
+      if (M->isImplicitDynamicEnabled()) {
+        options_block::IsImplicitDynamicEnabledLayout ImplicitDynamic(Out);
+        ImplicitDynamic.emit(ScratchRecord);
+      }
+
       if (M->getResilienceStrategy() != ResilienceStrategy::Default) {
         options_block::ResilienceStrategyLayout Strategy(Out);
         Strategy.emit(ScratchRecord, unsigned(M->getResilienceStrategy()));
@@ -2792,7 +2797,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     // its overrides after they've been compiled: if the declaration is '@objc'
     // and 'dynamic'. In that case, all accesses to the method or property will
     // go through the Objective-C method tables anyway.
-    if (overridden->hasClangNode() || overridden->isObjCDynamic())
+    if (overridden->hasClangNode() || overridden->shouldUseObjCDispatch())
       return false;
     return true;
   }

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -690,6 +690,8 @@ FileUnit *SerializedModuleLoaderBase::loadAST(
       M.setTestingEnabled();
     if (extendedInfo.arePrivateImportsEnabled())
       M.setPrivateImportsEnabled();
+    if (extendedInfo.isImplicitDynamicEnabled())
+      M.setImplicitDynamicEnabled();
 
     auto diagLocOrInvalid = diagLoc.getValueOr(SourceLoc());
     loadInfo.status =

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -637,7 +637,7 @@ void TBDGenVisitor::visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
   addSymbol(SILDeclRef(AFD));
 
   // Add the global function pointer for a dynamically replaceable function.
-  if (AFD->isNativeDynamic()) {
+  if (AFD->shouldUseNativeMethodReplacement()) {
     bool useAllocator = shouldUseAllocatorMangling(AFD);
     addSymbol(LinkEntity::forDynamicallyReplaceableFunctionVariable(
         AFD, useAllocator));
@@ -682,7 +682,7 @@ void TBDGenVisitor::visitFuncDecl(FuncDecl *FD) {
   if (auto opaqueResult = FD->getOpaqueResultTypeDecl()) {
     addSymbol(LinkEntity::forOpaqueTypeDescriptor(opaqueResult));
     assert(opaqueResult->getNamingDecl() == FD);
-    if (FD->isNativeDynamic()) {
+    if (FD->shouldUseNativeDynamicDispatch()) {
       addSymbol(LinkEntity::forOpaqueTypeDescriptorAccessor(opaqueResult));
       addSymbol(LinkEntity::forOpaqueTypeDescriptorAccessorImpl(opaqueResult));
       addSymbol(LinkEntity::forOpaqueTypeDescriptorAccessorKey(opaqueResult));

--- a/test/SILGen/Inputs/objc_dynamic_replacement_ext.swift
+++ b/test/SILGen/Inputs/objc_dynamic_replacement_ext.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+public class Generic<ItemType>: NSObject {
+  @objc public dynamic func foo() {}
+
+  @objc public dynamic var x: Int {
+    get {
+      return 0;
+    }
+    set {
+      print("noop")
+    }
+  }
+
+  @objc public dynamic var y: Int = 0
+}

--- a/test/SILGen/objc_dynamic_replacement_ext.swift
+++ b/test/SILGen/objc_dynamic_replacement_ext.swift
@@ -1,0 +1,81 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-silgen -module-name SomeModule %S/Inputs/objc_dynamic_replacement_ext.swift -swift-version 5 -enable-implicit-dynamic | %FileCheck %s --check-prefix=IMPORT
+// RUN: %target-swift-emit-silgen -module-name SomeModule %S/Inputs/objc_dynamic_replacement_ext.swift -swift-version 5 | %FileCheck %s --check-prefix=NO
+// RUN: %target-swift-frontend -module-name SomeModule -emit-module -emit-module-path=%t/SomeModule.swiftmodule %S/Inputs/objc_dynamic_replacement_ext.swift -swift-version 5 -validate-tbd-against-ir=all
+// RUN: %target-swift-frontend -module-name SomeModule -emit-module -emit-module-path=%t/SomeModule.swiftmodule %S/Inputs/objc_dynamic_replacement_ext.swift -swift-version 5 -enable-implicit-dynamic -validate-tbd-against-ir=all
+// RUN: %target-swift-emit-silgen -I %t %s -swift-version 5 | %FileCheck %s
+// RUN: %target-swift-emit-ir -I %t %s -swift-version 5 -validate-tbd-against-ir=all
+
+// REQUIRES: objc_interop
+
+import Foundation
+import SomeModule
+
+// Make sure we support replacing @objc dynamic methods in generic classes.
+// Normally we would disallow such methods in extensions because we don't
+// support emitting objc categories for native generic classes. We special case
+// @_dynamicReplacements for such methods and use the native dynamic replacement
+// mechanism instead.
+
+// In imported file:
+// public class Generic<ItemType>: NSObject {
+//   @objc public dynamic func foo() {}
+//   @objc public dynamic var x: Int {
+//     get {
+//       return 0;
+//     }
+//     set {
+//       print("noop")
+//     }
+//   }
+//   @objc public dynamic var y: Int = 0
+// }
+
+// IMPORT-DAG: sil [dynamically_replacable] [ossa] @$s10SomeModule7GenericC3fooyyF : $@convention(method) <ItemType> (@guaranteed Generic<ItemType>) -> ()
+// IMPORT-DAG: sil [thunk] [ossa] @$s10SomeModule7GenericC3fooyyFTo : $@convention(objc_method) <ItemType> (Generic<ItemType>) -> ()
+
+// IMPORT-DAG: sil [thunk] [ossa] @$s10SomeModule7GenericC1xSivgTo : $@convention(objc_method) <ItemType> (Generic<ItemType>) -> Int
+// IMPORT-DAG: sil [dynamically_replacable] [ossa] @$s10SomeModule7GenericC1xSivg : $@convention(method) <ItemType> (@guaranteed Generic<ItemType>) -> Int
+// IMPORT-DAG: sil [thunk] [ossa] @$s10SomeModule7GenericC1xSivsTo : $@convention(objc_method) <ItemType> (Int, Generic<ItemType>) -> ()
+// IMPORT-DAG: sil [dynamically_replacable] [ossa] @$s10SomeModule7GenericC1xSivs : $@convention(method) <ItemType> (Int, @guaranteed Generic<ItemType>) -> ()
+
+// NO-DAG: sil [thunk] [ossa] @$s10SomeModule7GenericC1xSivgTo : $@convention(objc_method) <ItemType> (Generic<ItemType>) -> Int
+// NO-DAG: sil [ossa] @$s10SomeModule7GenericC1xSivg : $@convention(method) <ItemType> (@guaranteed Generic<ItemType>) -> Int
+// NO-DAG: sil [thunk] [ossa] @$s10SomeModule7GenericC1xSivsTo : $@convention(objc_method) <ItemType> (Int, Generic<ItemType>) -> ()
+// NO-DAG: sil [ossa] @$s10SomeModule7GenericC1xSivs : $@convention(method) <ItemType> (Int, @guaranteed Generic<ItemType>) -> ()
+
+// IMPORT-DAG: sil [thunk] [ossa] @$s10SomeModule7GenericC1ySivgTo : $@convention(objc_method) <ItemType> (Generic<ItemType>) -> Int
+// IMPORT-DAG: sil [dynamically_replacable] [ossa] @$s10SomeModule7GenericC1ySivg : $@convention(method) <ItemType> (@guaranteed Generic<ItemType>) -> Int
+// IMPORT-DAG: sil [thunk] [ossa] @$s10SomeModule7GenericC1ySivsTo : $@convention(objc_method) <ItemType> (Int, Generic<ItemType>) -> ()
+// IMPORT-DAG: sil [dynamically_replacable] [ossa] @$s10SomeModule7GenericC1ySivs : $@convention(method) <ItemType> (Int, @guaranteed Generic<ItemType>) -> ()
+
+extension Generic {
+  @_dynamicReplacement(for: foo()) public func __replacement__foo() {}
+// CHECK-DAG: sil [dynamic_replacement_for "$s10SomeModule7GenericC3fooyyF"] [ossa] @$s10SomeModule7GenericC28objc_dynamic_replacement_extE02__F5__fooyyF : $@convention(method) <ItemType> (@guaranteed Generic<ItemType>) -> ()
+// CHECK-NOT: sil {{.*}} @$s10SomeModule7GenericC28objc_dynamic_replacement_extE02__F5__fooyyFTo : $@convention(objc_method) <ItemType> (Generic<ItemType>) -> ()
+
+  @_dynamicReplacement(for: x) public var __replacement_x : Int {
+    get {
+      return 0;
+    }
+    set {
+      print("noop")
+    }
+  }
+// CHECK-NOT: sil {{.*}} @$s10SomeModule7GenericC28objc_dynamic_replacement_extE02__F2_xSivgTo : $@convention(objc_method) <ItemType> (Generic<ItemType>) -> Int
+// CHECK-DAG: sil [dynamic_replacement_for "$s10SomeModule7GenericC1xSivg"] [ossa] @$s10SomeModule7GenericC28objc_dynamic_replacement_extE02__F2_xSivg : $@convention(method) <ItemType> (@guaranteed Generic<ItemType>) -> Int
+// CHECK-NOT: sil {{.*}} @$s10SomeModule7GenericC28objc_dynamic_replacement_extE02__F2_xSivsTo : $@convention(objc_method) <ItemType> (Int, Generic<ItemType>) -> ()
+// CHECK-DAG: sil [dynamic_replacement_for "$s10SomeModule7GenericC1xSivs"] [ossa] @$s10SomeModule7GenericC28objc_dynamic_replacement_extE02__F2_xSivs : $@convention(method) <ItemType> (Int, @guaranteed Generic<ItemType>) -> ()
+
+  @_dynamicReplacement(for: y) public var __replacement_y : Int {
+    get {
+      return 7;
+    }
+    set {
+    }
+  }
+// CHECK-NOT: sil {{.*}} @$s10SomeModule7GenericC28objc_dynamic_replacement_extE02__F2_ySivgTo : $@convention(objc_method) <ItemType> (Generic<ItemType>) -> Int
+// CHECK-DAG: sil [dynamic_replacement_for "$s10SomeModule7GenericC1ySivg"] [ossa] @$s10SomeModule7GenericC28objc_dynamic_replacement_extE02__F2_ySivg : $@convention(method) <ItemType> (@guaranteed Generic<ItemType>) -> Int
+// CHECK-NOT: sil {{.*}} @$s10SomeModule7GenericC28objc_dynamic_replacement_extE02__F2_ySivsTo : $@convention(objc_method) <ItemType> (Int, Generic<ItemType>) -> ()
+// CHECK-DAG: sil [dynamic_replacement_for "$s10SomeModule7GenericC1ySivs"] [ossa] @$s10SomeModule7GenericC28objc_dynamic_replacement_extE02__F2_ySivs : $@convention(method) <ItemType> (Int, @guaranteed Generic<ItemType>) -> ()
+}


### PR DESCRIPTION
…lasses `dynamically_replaceable`

```
class Generic<T> {
  @objc dynamic func method() {}
}

extension Generic {
  @_dynamicReplacement(for:method())
  func replacement() {}
}
```

The standard mechanism of using Objective-C categories for dynamically
replacing @objc methods in generic classes does not work.

Instead we mark the native entry point as replaceable.

Because this affects all @objc methods in generic classes (whether there
is a replacement or not) by making the native entry point
`[dynamically_replaceable]` (regardless of optimization mode) we guard this by
the -enable-implicit-dynamic flag because we are late in the release cycle.

rdar://63679357
