### PR TITLE
[stdlib][test] Fix message test expectation.

### DIFF
--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -118,7 +118,7 @@ void printHelp(const char *extra) {
 // Initialization code.
 OnceToken_t swift::runtime::environment::initializeToken;
 
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__linux__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__linux__)
 extern "C" char **environ;
 #define ENVIRON environ
 #elif defined(_WIN32)

--- a/test/Runtime/environment_variables.swift
+++ b/test/Runtime/environment_variables.swift
@@ -3,7 +3,7 @@
 // RUN: %target-codesign %t/main
 // RUN: env %env-SWIFT_DEBUG_HELP=YES %env-SWIFT_DEBUG_SOME_UNKNOWN_VARIABLE=42 %env-SWIFT_DEBUG_ENABLE_METADATA_ALLOCATION_ITERATION=YES %env-SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=abc %env-SWIFT_DETERMINISTIC_HASHING=whatever %env-SWIFT_ENABLE_MANGLED_NAME_VERIFICATION=YES %target-run %t/main 2>&1 | %FileCheck %s --dump-input fail
 
-// CHECK-DAG: {{Warning: unknown environment variable SWIFT_DEBUG_SOME_UNKNOWN_VARIABLE|Using getenv to read variables. Unknown variables will not be flagged.}}
+// CHECK-DAG: {{Warning: unknown environment variable SWIFT_DEBUG_SOME_UNKNOWN_VARIABLE|Using getenv to read variables. Unknown SWIFT_DEBUG_ variables will not be flagged.}}
 // CHECK-DAG: Warning: cannot parse value SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=abc, defaulting to 2.
 // CHECK-DAG: Warning: cannot parse value SWIFT_DETERMINISTIC_HASHING=whatever, defaulting to false.
 // CHECK-DAG: Swift runtime debugging:


### PR DESCRIPTION
In #32137 direct environment variable parsing was introduced, the
availability of which is branched by a preprocessor symbol (`ENVIRON`)
if the environment is available directly on the platform, or if getenv
must be used.

The message expectation in the unit test in the however diverged on the
non-`ENVIRON` branch, causing a unit test failure. This PR fixes the
expectation, but also, while we're here, OpenBSD supports the `ENVIRON`
branch anyway.
