### PR TITLE
[AST] Clean up handling of single-expression closures

### DIFF
--- a/include/swift/AST/ASTWalker.h
+++ b/include/swift/AST/ASTWalker.h
@@ -216,12 +216,12 @@ public:
   virtual bool shouldWalkIntoLazyInitializers() { return true; }
 
   /// This method configures whether the walker should visit the body of a
-  /// non-single expression closure.
+  /// closure that was checked separately from its enclosing expression.
   ///
   /// For work that is performed for every top-level expression, this should
   /// be overridden to return false, to avoid duplicating work or visiting
   /// bodies of closures that have not yet been type checked.
-  virtual bool shouldWalkIntoNonSingleExpressionClosure(ClosureExpr *) {
+  virtual bool shouldWalkIntoSeparatelyCheckedClosure(ClosureExpr *) {
     return true;
   }
 

--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -89,20 +89,6 @@ public:
     return TheFunction.get<AbstractClosureExpr *>()->getSingleExpressionBody();
   }
 
-  void setSingleExpressionBody(Expr *expr) {
-    if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>()) {
-      AFD->setSingleExpressionBody(expr);
-      return;
-    }
-
-    auto ACE = TheFunction.get<AbstractClosureExpr *>();
-    if (auto CE = dyn_cast<ClosureExpr>(ACE)) {
-      CE->setSingleExpressionBody(expr);
-    } else {
-      cast<AutoClosureExpr>(ACE)->setBody(expr);
-    }
-  }
-
   Type getType() const {
     if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>())
       return AFD->getInterfaceType();

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3891,13 +3891,6 @@ public:
   /// Only valid when \c hasSingleExpressionBody() is true.
   Expr *getSingleExpressionBody() const;
 
-  /// Set the body for a closure that has a single expression as its
-  /// body.
-  ///
-  /// This routine cannot change whether a closure has a single expression as
-  /// its body; it can only update that expression.
-  void setSingleExpressionBody(Expr *NewBody);
-
   /// Is this a completely empty closure?
   bool hasEmptyBody() const;
 

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3770,10 +3770,7 @@ class ClosureExpr : public AbstractClosureExpr {
   /// the CaptureListExpr which would normally maintain this sort of
   /// information about captured variables), we need to have some way to access
   /// this information directly on the ClosureExpr.
-  ///
-  /// The bit indicates whether this closure has had a function builder
-  /// applied to it.
-  llvm::PointerIntPair<VarDecl *, 1, bool> CapturedSelfDeclAndAppliedBuilder;
+  VarDecl * CapturedSelfDecl;
 
   /// The location of the "throws", if present.
   SourceLoc ThrowsLoc;
@@ -3800,7 +3797,7 @@ public:
     : AbstractClosureExpr(ExprKind::Closure, Type(), /*Implicit=*/false,
                           discriminator, parent),
       BracketRange(bracketRange),
-      CapturedSelfDeclAndAppliedBuilder(capturedSelfDecl, false),
+      CapturedSelfDecl(capturedSelfDecl),
       ThrowsLoc(throwsLoc), ArrowLoc(arrowLoc), InLoc(inLoc),
       ExplicitResultTypeAndEnclosingChecked(explicitResultType, false),
       Body(nullptr) {
@@ -3906,21 +3903,13 @@ public:
 
   /// VarDecl captured by this closure under the literal name \c self , if any.
   VarDecl *getCapturedSelfDecl() const {
-    return CapturedSelfDeclAndAppliedBuilder.getPointer();
+    return CapturedSelfDecl;
   }
   
   /// Whether this closure captures the \c self param in its body in such a
   /// way that implicit \c self is enabled within its body (i.e. \c self is
   /// captured non-weakly).
   bool capturesSelfEnablingImplictSelf() const;
-
-  bool hasAppliedFunctionBuilder() const {
-    return CapturedSelfDeclAndAppliedBuilder.getInt();
-  }
-
-  void setAppliedFunctionBuilder(bool flag = true) {
-    CapturedSelfDeclAndAppliedBuilder.setInt(flag);
-  }
 
   /// Whether this closure's body was type checked within the enclosing
   /// context.

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3784,7 +3784,7 @@ class ClosureExpr : public AbstractClosureExpr {
 
   /// The explicitly-specified result type.
   llvm::PointerIntPair<TypeExpr *, 1, bool>
-    ExplicitResultTypeAndEnclosingChecked;
+    ExplicitResultTypeAndSeparatelyChecked;
 
   /// The body of the closure, along with a bit indicating whether it
   /// was originally just a single expression.
@@ -3799,7 +3799,7 @@ public:
       BracketRange(bracketRange),
       CapturedSelfDecl(capturedSelfDecl),
       ThrowsLoc(throwsLoc), ArrowLoc(arrowLoc), InLoc(inLoc),
-      ExplicitResultTypeAndEnclosingChecked(explicitResultType, false),
+      ExplicitResultTypeAndSeparatelyChecked(explicitResultType, false),
       Body(nullptr) {
     setParameterList(params);
     Bits.ClosureExpr.HasAnonymousClosureVars = false;
@@ -3854,14 +3854,14 @@ public:
 
   Type getExplicitResultType() const {
     assert(hasExplicitResultType() && "No explicit result type");
-    return ExplicitResultTypeAndEnclosingChecked.getPointer()
+    return ExplicitResultTypeAndSeparatelyChecked.getPointer()
         ->getInstanceType();
   }
   void setExplicitResultType(Type ty);
 
   TypeRepr *getExplicitResultTypeRepr() const {
     assert(hasExplicitResultType() && "No explicit result type");
-    return ExplicitResultTypeAndEnclosingChecked.getPointer()
+    return ExplicitResultTypeAndSeparatelyChecked.getPointer()
         ->getTypeRepr();
   }
 
@@ -3904,14 +3904,14 @@ public:
   /// captured non-weakly).
   bool capturesSelfEnablingImplictSelf() const;
 
-  /// Whether this closure's body was type checked within the enclosing
-  /// context.
-  bool wasTypeCheckedInEnclosingContext() const {
-    return ExplicitResultTypeAndEnclosingChecked.getInt();
+  /// Whether this closure's body was type checked separately from its
+  /// enclosing expression.
+  bool wasSeparatelyTypeChecked() const {
+    return ExplicitResultTypeAndSeparatelyChecked.getInt();
   }
 
-  void setTypeCheckedInEnclosingContext(bool flag = true) {
-    ExplicitResultTypeAndEnclosingChecked.setInt(flag);
+  void setSeparatelyTypeChecked(bool flag = true) {
+    ExplicitResultTypeAndSeparatelyChecked.setInt(flag);
   }
 
   static bool classof(const Expr *E) {

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -815,21 +815,15 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
         return nullptr;
     }
 
-    // Handle single-expression closures.
-    if (expr->hasSingleExpressionBody()) {
-      if (Expr *body = doIt(expr->getSingleExpressionBody())) {
-        expr->setSingleExpressionBody(body);
-        return expr;
-      }
-      return nullptr;
-    }
-
-    if (!Walker.shouldWalkIntoNonSingleExpressionClosure(expr))
+    // Always walk into closures with a single-expression body; for those
+    // that don't have a single-expression body, ask the walker first.
+    if (!expr->hasSingleExpressionBody() &&
+        !Walker.shouldWalkIntoNonSingleExpressionClosure(expr))
       return expr;
 
     // Handle other closures.
     if (BraceStmt *body = cast_or_null<BraceStmt>(doIt(expr->getBody()))) {
-      expr->setBody(body, false);
+      expr->setBody(body, expr->hasSingleExpressionBody());
       return expr;
     }
     return nullptr;

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -815,10 +815,10 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
         return nullptr;
     }
 
-    // Always walk into closures with a single-expression body; for those
-    // that don't have a single-expression body, ask the walker first.
-    if (!expr->hasSingleExpressionBody() &&
-        !Walker.shouldWalkIntoNonSingleExpressionClosure(expr))
+    // If the closure was separately type checked and we don't want to
+    // visit separately-checked closure bodies, bail out now.
+    if (expr->wasSeparatelyTypeChecked() &&
+        !Walker.shouldWalkIntoSeparatelyCheckedClosure(expr))
       return expr;
 
     // Handle other closures.

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1898,19 +1898,6 @@ Expr *ClosureExpr::getSingleExpressionBody() const {
   return body.get<Expr *>();
 }
 
-void ClosureExpr::setSingleExpressionBody(Expr *NewBody) {
-  assert(hasSingleExpressionBody() && "Not a single-expression body");
-  auto body = getBody()->getFirstElement();
-  if (auto stmt = body.dyn_cast<Stmt *>()) {
-    if (auto braceStmt = dyn_cast<BraceStmt>(stmt))
-      braceStmt->getFirstElement() = NewBody;
-    else
-      cast<ReturnStmt>(stmt)->setResult(NewBody);
-    return;
-  }
-  getBody()->setFirstElement(NewBody);
-}
-
 bool ClosureExpr::hasEmptyBody() const {
   return getBody()->empty();
 }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1910,7 +1910,7 @@ bool ClosureExpr::capturesSelfEnablingImplictSelf() const {
 
 void ClosureExpr::setExplicitResultType(Type ty) {
   assert(ty && !ty->hasTypeVariable());
-  ExplicitResultTypeAndEnclosingChecked.getPointer()
+  ExplicitResultTypeAndSeparatelyChecked.getPointer()
       ->setType(MetatypeType::get(ty));
 }
 

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -3663,7 +3663,8 @@ static CallExpr *findTrailingClosureTarget(SourceManager &SM,
   if (contexts.empty())
     return nullptr;
 
-  // If the innermost context is a brace statement, drop it.
+  // If the innermost context is a statement (which will be a BraceStmt per
+  // the filtering condition above), drop it.
   if (contexts.back().is<Stmt *>()) {
     contexts = contexts.drop_back();
   }

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -3659,16 +3659,24 @@ static CallExpr *findTrailingClosureTarget(SourceManager &SM,
            return N.isStmt(StmtKind::Brace) || N.isExpr(ExprKind::Call);
          });
   Finder.resolve();
-  if (Finder.getContexts().empty()
-      || !Finder.getContexts().back().is<Expr*>())
+  auto contexts = Finder.getContexts();
+  if (contexts.empty())
     return nullptr;
-  CallExpr *CE = cast<CallExpr>(Finder.getContexts().back().get<Expr*>());
+
+  // If the innermost context is a brace statement, drop it.
+  if (contexts.back().is<Stmt *>()) {
+    contexts = contexts.drop_back();
+  }
+
+  if (contexts.empty() || !contexts.back().is<Expr*>())
+    return nullptr;
+  CallExpr *CE = cast<CallExpr>(contexts.back().get<Expr*>());
 
   if (CE->hasTrailingClosure())
     // Call expression already has a trailing closure.
     return nullptr;
 
-  // The last arugment is a closure?
+  // The last argument is a closure?
   Expr *Args = CE->getArg();
   if (!Args)
     return nullptr;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3859,7 +3859,8 @@ namespace {
       if (expr->isLiteralInit()) {
         auto *literalInit = expr->getSubExpr();
         if (auto *call = dyn_cast<CallExpr>(literalInit)) {
-          call->getFn()->forEachChildExpr([&](Expr *subExpr) -> Expr * {
+          forEachExprInConstraintSystem(call->getFn(),
+                                        [&](Expr *subExpr) -> Expr * {
             auto *TE = dyn_cast<TypeExpr>(subExpr);
             if (!TE)
               return subExpr;
@@ -5788,7 +5789,7 @@ static bool applyTypeToClosureExpr(ConstraintSystem &cs,
     cs.setType(CE, toType);
 
     // If this closure isn't type-checked in its enclosing expression, write
-    // theg type into the ClosureExpr directly here, since the visitor won't.
+    // the type into the ClosureExpr directly here, since the visitor won't.
     if (!shouldTypeCheckInEnclosingExpression(CE))
       CE->setType(toType);
 

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -85,8 +85,6 @@ private:
       return;
 
     // FIXME: Use SolutionApplicationTarget?
-    cs.setContextualType(
-         expr, TypeLoc::withoutLoc(closureResultType), CTP_ClosureResult);
     expr = cs.generateConstraints(expr, closure, /*isInputExpression=*/false);
     if (!expr) {
       hadError = true;

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -84,6 +84,9 @@ private:
     if (!expr)
       return;
 
+    // FIXME: Use SolutionApplicationTarget?
+    cs.setContextualType(
+         expr, TypeLoc::withoutLoc(closureResultType), CTP_ClosureResult);
     expr = cs.generateConstraints(expr, closure, /*isInputExpression=*/false);
     if (!expr) {
       hadError = true;

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -333,7 +333,6 @@ SolutionApplicationToFunctionResult ConstraintSystem::applySolution(
 
     fn.setBody(newBody, /*isSingleExpression=*/false);
     if (closure) {
-      closure->setAppliedFunctionBuilder();
       closure->setTypeCheckedInEnclosingContext();
       solution.setExprTypes(closure);
     }

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -333,7 +333,6 @@ SolutionApplicationToFunctionResult ConstraintSystem::applySolution(
 
     fn.setBody(newBody, /*isSingleExpression=*/false);
     if (closure) {
-      closure->setTypeCheckedInEnclosingContext();
       solution.setExprTypes(closure);
     }
 
@@ -349,7 +348,6 @@ SolutionApplicationToFunctionResult ConstraintSystem::applySolution(
         solution, closure, closureFnType->getResult(), rewriteTarget);
     application.visit(fn.getBody());
 
-    closure->setTypeCheckedInEnclosingContext();
     return SolutionApplicationToFunctionResult::Success;
   }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -442,7 +442,7 @@ bool MissingConformanceFailure::diagnoseAsError() {
       }
 
       bool hasFix = false;
-      caseExpr->forEachChildExpr([&](Expr *expr) -> Expr * {
+      forEachExprInConstraintSystem(caseExpr, [&](Expr *expr) -> Expr * {
         hasFix |= anchors.count(expr);
         return hasFix ? nullptr : expr;
       });
@@ -3277,7 +3277,7 @@ bool MissingMemberFailure::diagnoseAsError() {
 
     bool hasUnresolvedPattern = false;
     if (auto *E = getAsExpr(anchor)) {
-      const_cast<Expr *>(E)->forEachChildExpr([&](Expr *expr) {
+      forEachExprInConstraintSystem(const_cast<Expr *>(E), [&](Expr *expr) {
         hasUnresolvedPattern |= isa<UnresolvedPatternExpr>(expr);
         return hasUnresolvedPattern ? nullptr : expr;
       });

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3882,6 +3882,13 @@ namespace {
           }
         }
 
+        // If this is a closure, only walk into its children if they
+        // are type-checked in the context of the enclosing expression.
+        if (auto closure = dyn_cast<ClosureExpr>(expr)) {
+          if (!shouldTypeCheckInEnclosingExpression(closure))
+            return { false, expr };
+        }
+
         // Now, we're ready to walk into sub expressions.
         return {true, expr};
       }
@@ -4021,12 +4028,6 @@ namespace {
 
     /// Ignore declarations.
     bool walkToDeclPre(Decl *decl) override { return false; }
-
-    // Don't walk into statements.  This handles the BraceStmt in
-    // non-single-expr closures, so we don't walk into their body.
-    std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
-      return { false, S };
-    }
   };
 
   class ConstraintWalker : public ASTWalker {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1548,7 +1548,7 @@ static bool fixMissingArguments(ConstraintSystem &cs, ASTNode anchor,
 
       // Something like `foo { x in }` or `foo { $0 }`
       if (auto *closure = getAsExpr<ClosureExpr>(anchor)) {
-        closure->forEachChildExpr([&](Expr *expr) -> Expr * {
+        forEachExprInConstraintSystem(closure, [&](Expr *expr) -> Expr * {
           if (auto *UDE = dyn_cast<UnresolvedDotExpr>(expr)) {
             if (!isParam(UDE->getBase()))
               return expr;
@@ -9334,7 +9334,7 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix, unsigned impact) {
 
   bool found = false;
   if (auto *expr = getAsExpr(anchor)) {
-    expr->forEachChildExpr([&](Expr *subExpr) -> Expr * {
+    forEachExprInConstraintSystem(expr, [&](Expr *subExpr) -> Expr * {
       found |= anchors.count(subExpr);
       return subExpr;
     });

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -5495,7 +5495,7 @@ bool shouldTypeCheckInEnclosingExpression(ClosureExpr *expr);
 
 /// Visit each subexpression that will be part of the constraint system
 /// of the given expression, including those in closure bodies that will be
-/// part of the constraint system/
+/// part of the constraint system.
 void forEachExprInConstraintSystem(
     Expr *expr, llvm::function_ref<Expr *(Expr *)> callback);
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -5493,6 +5493,12 @@ BraceStmt *applyFunctionBuilderTransform(
 /// of the parameter and result types without looking at the body.
 bool shouldTypeCheckInEnclosingExpression(ClosureExpr *expr);
 
+/// Visit each subexpression that will be part of the constraint system
+/// of the given expression, including those in closure bodies that will be
+/// part of the constraint system/
+void forEachExprInConstraintSystem(
+    Expr *expr, llvm::function_ref<Expr *(Expr *)> callback);
+
 } // end namespace swift
 
 #endif // LLVM_SWIFT_SEMA_CONSTRAINT_SYSTEM_H

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -86,14 +86,14 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
 
     bool walkToDeclPre(Decl *D) override {
       if (auto *closure = dyn_cast<ClosureExpr>(D->getDeclContext()))
-        return closure->wasTypeCheckedInEnclosingContext();
+        return !closure->wasSeparatelyTypeChecked();
       return false;
     }
 
     bool walkToTypeReprPre(TypeRepr *T) override { return true; }
 
-    bool shouldWalkIntoNonSingleExpressionClosure(ClosureExpr *expr) override {
-      return expr->wasTypeCheckedInEnclosingContext();
+    bool shouldWalkIntoSeparatelyCheckedClosure(ClosureExpr *expr) override {
+      return false;
     }
 
     bool shouldWalkIntoTapExpression() override { return false; }
@@ -1290,8 +1290,8 @@ static void diagRecursivePropertyAccess(const Expr *E, const DeclContext *DC) {
              cast<VarDecl>(DRE->getDecl())->isSelfParameter();
     }
 
-    bool shouldWalkIntoNonSingleExpressionClosure(ClosureExpr *expr) override {
-      return expr->wasTypeCheckedInEnclosingContext();
+    bool shouldWalkIntoSeparatelyCheckedClosure(ClosureExpr *expr) override {
+      return false;
     }
 
     bool shouldWalkIntoTapExpression() override { return false; }
@@ -1459,12 +1459,12 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
     // Don't walk into nested decls.
     bool walkToDeclPre(Decl *D) override {
       if (auto *closure = dyn_cast<ClosureExpr>(D->getDeclContext()))
-        return closure->wasTypeCheckedInEnclosingContext();
+        return !closure->wasSeparatelyTypeChecked();
       return false;
     }
 
-    bool shouldWalkIntoNonSingleExpressionClosure(ClosureExpr *expr) override {
-      return expr->wasTypeCheckedInEnclosingContext();
+    bool shouldWalkIntoSeparatelyCheckedClosure(ClosureExpr *expr) override {
+      return false;
     }
 
     bool shouldWalkIntoTapExpression() override { return false; }
@@ -3265,8 +3265,8 @@ static void checkStmtConditionTrailingClosure(ASTContext &ctx, const Expr *E) {
   public:
     DiagnoseWalker(ASTContext &ctx) : Ctx(ctx) { }
 
-    bool shouldWalkIntoNonSingleExpressionClosure(ClosureExpr *expr) override {
-      return expr->wasTypeCheckedInEnclosingContext();
+    bool shouldWalkIntoSeparatelyCheckedClosure(ClosureExpr *expr) override {
+      return false;
     }
 
     bool shouldWalkIntoTapExpression() override { return false; }
@@ -3415,8 +3415,8 @@ public:
   ObjCSelectorWalker(const DeclContext *dc, Type selectorTy)
     : Ctx(dc->getASTContext()), DC(dc), SelectorTy(selectorTy) { }
 
-  bool shouldWalkIntoNonSingleExpressionClosure(ClosureExpr *expr) override {
-    return expr->wasTypeCheckedInEnclosingContext();
+  bool shouldWalkIntoSeparatelyCheckedClosure(ClosureExpr *expr) override {
+    return false;
   }
 
   bool shouldWalkIntoTapExpression() override { return false; }
@@ -4155,8 +4155,8 @@ static void diagnoseUnintendedOptionalBehavior(const Expr *E,
       }
     }
 
-    bool shouldWalkIntoNonSingleExpressionClosure(ClosureExpr *expr) override {
-      return expr->wasTypeCheckedInEnclosingContext();
+    bool shouldWalkIntoSeparatelyCheckedClosure(ClosureExpr *expr) override {
+      return false;
     }
 
     bool shouldWalkIntoTapExpression() override { return false; }
@@ -4231,8 +4231,8 @@ static void diagnoseDeprecatedWritableKeyPath(const Expr *E,
       }
     }
 
-    bool shouldWalkIntoNonSingleExpressionClosure(ClosureExpr *expr) override {
-      return expr->wasTypeCheckedInEnclosingContext();
+    bool shouldWalkIntoSeparatelyCheckedClosure(ClosureExpr *expr) override {
+      return false;
     }
 
     bool shouldWalkIntoTapExpression() override { return false; }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -93,7 +93,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
     bool walkToTypeReprPre(TypeRepr *T) override { return true; }
 
     bool shouldWalkIntoNonSingleExpressionClosure(ClosureExpr *expr) override {
-      return expr->hasAppliedFunctionBuilder();
+      return expr->wasTypeCheckedInEnclosingContext();
     }
 
     bool shouldWalkIntoTapExpression() override { return false; }
@@ -1291,7 +1291,7 @@ static void diagRecursivePropertyAccess(const Expr *E, const DeclContext *DC) {
     }
 
     bool shouldWalkIntoNonSingleExpressionClosure(ClosureExpr *expr) override {
-      return expr->hasAppliedFunctionBuilder();
+      return expr->wasTypeCheckedInEnclosingContext();
     }
 
     bool shouldWalkIntoTapExpression() override { return false; }
@@ -1464,7 +1464,7 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
     }
 
     bool shouldWalkIntoNonSingleExpressionClosure(ClosureExpr *expr) override {
-      return expr->hasAppliedFunctionBuilder();
+      return expr->wasTypeCheckedInEnclosingContext();
     }
 
     bool shouldWalkIntoTapExpression() override { return false; }
@@ -3266,7 +3266,7 @@ static void checkStmtConditionTrailingClosure(ASTContext &ctx, const Expr *E) {
     DiagnoseWalker(ASTContext &ctx) : Ctx(ctx) { }
 
     bool shouldWalkIntoNonSingleExpressionClosure(ClosureExpr *expr) override {
-      return expr->hasAppliedFunctionBuilder();
+      return expr->wasTypeCheckedInEnclosingContext();
     }
 
     bool shouldWalkIntoTapExpression() override { return false; }
@@ -3416,7 +3416,7 @@ public:
     : Ctx(dc->getASTContext()), DC(dc), SelectorTy(selectorTy) { }
 
   bool shouldWalkIntoNonSingleExpressionClosure(ClosureExpr *expr) override {
-    return expr->hasAppliedFunctionBuilder();
+    return expr->wasTypeCheckedInEnclosingContext();
   }
 
   bool shouldWalkIntoTapExpression() override { return false; }
@@ -4156,7 +4156,7 @@ static void diagnoseUnintendedOptionalBehavior(const Expr *E,
     }
 
     bool shouldWalkIntoNonSingleExpressionClosure(ClosureExpr *expr) override {
-      return expr->hasAppliedFunctionBuilder();
+      return expr->wasTypeCheckedInEnclosingContext();
     }
 
     bool shouldWalkIntoTapExpression() override { return false; }
@@ -4232,7 +4232,7 @@ static void diagnoseDeprecatedWritableKeyPath(const Expr *E,
     }
 
     bool shouldWalkIntoNonSingleExpressionClosure(ClosureExpr *expr) override {
-      return expr->hasAppliedFunctionBuilder();
+      return expr->wasTypeCheckedInEnclosingContext();
     }
 
     bool shouldWalkIntoTapExpression() override { return false; }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2344,7 +2344,7 @@ public:
   }
 
   bool shouldWalkIntoNonSingleExpressionClosure(ClosureExpr *expr) override {
-    return expr->hasAppliedFunctionBuilder();
+    return expr->wasTypeCheckedInEnclosingContext();
   }
 
   bool shouldWalkIntoTapExpression() override { return false; }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1129,7 +1129,7 @@ static void findAvailabilityFixItNodes(SourceRange ReferenceRange,
         if (Expr *ParentExpr = Parent.getAsExpr()) {
           auto *ParentClosure = dyn_cast<ClosureExpr>(ParentExpr);
           if (!ParentClosure ||
-              !ParentClosure->wasTypeCheckedInEnclosingContext()) {
+              ParentClosure->wasSeparatelyTypeChecked()) {
             return false;
           }
         } else if (auto *ParentStmt = Parent.getAsStmt()) {
@@ -2343,8 +2343,8 @@ public:
     return true;
   }
 
-  bool shouldWalkIntoNonSingleExpressionClosure(ClosureExpr *expr) override {
-    return expr->wasTypeCheckedInEnclosingContext();
+  bool shouldWalkIntoSeparatelyCheckedClosure(ClosureExpr *expr) override {
+    return false;
   }
 
   bool shouldWalkIntoTapExpression() override { return false; }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1294,15 +1294,13 @@ namespace {
     }
 
     std::pair<bool, Stmt *> walkToStmtPre(Stmt *stmt) override {
-      // Never walk into statements.
-      return { false, stmt };
+      return { true, stmt };
     }
   };
 } // end anonymous namespace
 
 /// Perform prechecking of a ClosureExpr before we dive into it.  This returns
-/// true for single-expression closures, where we want the body to be considered
-/// part of this larger expression.
+/// true when we want the body to be considered part of this larger expression.
 bool PreCheckExpression::walkToClosureExprPre(ClosureExpr *closure) {
   auto *PL = closure->getParameters();
 
@@ -4060,4 +4058,31 @@ HasDynamicCallableAttributeRequest::evaluate(Evaluator &evaluator,
 
 bool swift::shouldTypeCheckInEnclosingExpression(ClosureExpr *expr) {
   return expr->hasSingleExpressionBody();
+}
+
+void swift::forEachExprInConstraintSystem(
+    Expr *expr, llvm::function_ref<Expr *(Expr *)> callback) {
+  struct ChildWalker : ASTWalker {
+    llvm::function_ref<Expr *(Expr *)> callback;
+
+    ChildWalker(llvm::function_ref<Expr *(Expr *)> callback)
+    : callback(callback) {}
+
+    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+      if (auto closure = dyn_cast<ClosureExpr>(E)) {
+        if (!shouldTypeCheckInEnclosingExpression(closure))
+          return { false, callback(E) };
+      }
+      return { true, callback(E) };
+    }
+
+    std::pair<bool, Pattern*> walkToPatternPre(Pattern *P) override {
+      return { false, P };
+    }
+    bool walkToDeclPre(Decl *D) override { return false; }
+    bool walkToTypeReprPre(TypeRepr *T) override { return false; }
+    bool walkToTypeLocPre(TypeLoc &TL) override { return false; }
+  };
+
+  expr->walk(ChildWalker(callback));
 }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -143,7 +143,7 @@ namespace {
         // If the closure was type checked within its enclosing context,
         // we need to walk into it with a new sequence.
         // Otherwise, it'll have been separately type-checked.
-        if (CE->wasTypeCheckedInEnclosingContext())
+        if (!CE->wasSeparatelyTypeChecked())
           CE->getBody()->walk(ContextualizeClosures(CE));
 
         TypeChecker::computeCaptures(CE);
@@ -1976,6 +1976,7 @@ bool TypeChecker::typeCheckClosureBody(ClosureExpr *closure) {
   if (body) {
     closure->setBody(body, closure->hasSingleExpressionBody());
   }
+  closure->setSeparatelyTypeChecked();
   return HadError;
 }
 

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -179,7 +179,7 @@ struct S1116 {
 
 let a1116: [S1116] = []
 var s1116 = Set(1...10).subtracting(a1116.map({ $0.s })) // expected-error {{value of optional type 'Int?' must be unwrapped to a value of type 'Int'}}
-// expected-note@-1{{coalesce using '??' to provide a default when the optional value contains 'nil'}} {{49-49=(}} {{53-53= ?? <#default value#>)}}
+// expected-note@-1{{coalesce using '??' to provide a default when the optional value contains 'nil'}} {{53-53= ?? <#default value#>}}
 // expected-note@-2{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}} {{53-53=!}}
 
 func makeArray<T>(_ x: T) -> [T] { [x] }

--- a/test/IDE/structure.swift
+++ b/test/IDE/structure.swift
@@ -285,9 +285,9 @@ struct Tuples {
 completion(a: 1) { (x: Any, y: Int) -> Int in
   return x as! Int + y
 }
-// CHECK: <call><name>completion</name>(<arg><name>a</name>: 1</arg>) <arg><closure>{ (<param>x: <type>Any</type></param>, <param>y: <type>Int</type></param>) -> <type>Int</type> in
+// CHECK: <call><name>completion</name>(<arg><name>a</name>: 1</arg>) <arg><closure><brace>{ (<param>x: <type>Any</type></param>, <param>y: <type>Int</type></param>) -> <type>Int</type> in
 // CHECK:    return x as! Int + y
-// CHECK: }</closure></arg></call>
+// CHECK: }</brace></closure></arg></call>
 
 myFunc(foo: 0,
        bar: baz == 0)
@@ -321,14 +321,14 @@ thirdCall("""
 """)
 // CHECK: <call><name>thirdCall</name>("""
 // CHECK-NEXT: \("""
-// CHECK-NEXT:   \(<call><name><closure>{
+// CHECK-NEXT:   \(<call><name><closure><brace>{
 // CHECK-NEXT:   return <call><name>a</name>()</call>
-// CHECK-NEXT:   }</closure></name>()</call>)
+// CHECK-NEXT:   }</brace></closure></name>()</call>)
 // CHECK-NEXT:   """)
 // CHECK-NEXT: """)</call>
 
 fourthCall(a: @escaping () -> Int)
 // CHECK: <call><name>fourthCall</name>(<arg><name>a</name>: @escaping () -> Int</arg>)</call>
 
-// CHECK: <call><name>foo</name> <closure>{ [unowned <lvar><name>self</name></lvar>, <lvar><name>x</name></lvar>] in _ }</closure></call>
+// CHECK: <call><name>foo</name> <closure><brace>{ [unowned <lvar><name>self</name></lvar>, <lvar><name>x</name></lvar>] in _ }</brace></closure></call>
 foo { [unowned self, x] in _ }

--- a/test/Sema/diag_constantness_check_os_log.swift
+++ b/test/Sema/diag_constantness_check_os_log.swift
@@ -73,6 +73,10 @@ func testValidLogCalls(x: Int) {
 func testTypeIncorrectLogCalls() {
   let message = "test message"
 
+  class TestClass {
+  }
+  let x = TestClass()
+
   _osLogTestHelper(message)
   // expected-error@-1 {{cannot convert value of type 'String' to expected argument type 'OSLogMessage'}}
   _osLogTestHelper("prefix" + "\(x)")
@@ -81,9 +85,6 @@ func testTypeIncorrectLogCalls() {
   // expected-error@-1 {{cannot convert value of type 'String' to expected argument type '(String, UnsafeBufferPointer<UInt8>) -> Void'}}
   // expected-error@-2 {{missing argument label 'assertion:' in call}}
 
-  class TestClass {
-  }
-  let x = TestClass()
   _osLogTestHelper("\(x, format: .hex)")
   //expected-error@-1 {{no exact matches in call to instance method 'appendInterpolation'}}
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1615,27 +1615,9 @@ private:
 
       bool walkToExprPre(Expr *E) override {
         auto SR = E->getSourceRange();
-        if (SR.isValid() && SM.rangeContainsTokenLoc(SR, TargetLoc)) {
-          if (auto closure = dyn_cast<ClosureExpr>(E)) {
-            if (closure->hasSingleExpressionBody()) {
-              // Treat a single-expression body like a brace statement and reset
-              // the enclosing context. Note: when the placeholder is the whole
-              // body it is handled specially as wrapped in braces by
-              // shouldUseTrailingClosureInTuple().
-              auto SR = closure->getSingleExpressionBody()->getSourceRange();
-              if (SR.isValid() && SR.Start != TargetLoc &&
-                  SM.rangeContainsTokenLoc(SR, TargetLoc)) {
-                OuterStmt = nullptr;
-                OuterExpr = nullptr;
-                EnclosingCallAndArg = {nullptr, nullptr};
-                return true;
-              }
-            }
-          }
-
-          if (!checkCallExpr(E) && !EnclosingCallAndArg.first) {
-            OuterExpr = E;
-          }
+        if (SR.isValid() && SM.rangeContainsTokenLoc(SR, TargetLoc) &&
+            !checkCallExpr(E) && !EnclosingCallAndArg.first) {
+          OuterExpr = E;
         }
         return true;
       }
@@ -1646,11 +1628,30 @@ private:
         return true;
       }
 
+      /// Whether this statement body consists of only an implicit "return",
+      /// possibly within braces.
+      bool isImplicitReturnBody(Stmt *S) {
+        if (auto RS = dyn_cast<ReturnStmt>(S))
+          return RS->isImplicit() && RS->getSourceRange().Start == TargetLoc;
+
+        if (auto BS = dyn_cast<BraceStmt>(S)) {
+          if (BS->getNumElements() == 1) {
+            if (auto innerS = BS->getFirstElement().dyn_cast<Stmt *>())
+              return isImplicitReturnBody(innerS);
+          }
+        }
+
+        return false;
+      }
+
       bool walkToStmtPre(Stmt *S) override {
         auto SR = S->getSourceRange();
-        if (SR.isValid() && SM.rangeContainsTokenLoc(SR, TargetLoc)) {
+        if (SR.isValid() && SM.rangeContainsTokenLoc(SR, TargetLoc) &&
+            !isImplicitReturnBody(S)) {
           // A statement inside an expression - e.g. `foo({ if ... })` - resets
           // the enclosing context.
+          //
+          // ... unless it's an implicit return.
           OuterExpr = nullptr;
           EnclosingCallAndArg = {nullptr, nullptr};
 
@@ -1766,7 +1767,6 @@ public:
                                ArrayRef<ClosureInfo> trailingClosures)>
                 MultiClosureCallback,
             std::function<bool(EditorPlaceholderExpr *)> NonClosureCallback) {
-
     SourceLoc PlaceholderStartLoc = SM.getLocForOffset(BufID, Offset);
 
     // See if the placeholder is encapsulated with an EditorPlaceholderExpr

--- a/validation-test/compiler_crashers_fixed/28653-child-source-range-not-contained-within-its-parent.swift
+++ b/validation-test/compiler_crashers_fixed/28653-child-source-range-not-contained-within-its-parent.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: swift_ast_verifier
 
 switch{case.b(u){


### PR DESCRIPTION
Stop treating single-expression closures as special throughout most of the compiler, with the exception of the constraint solver where the semantics *are* intentionally different. This eliminates a   bit of special-case code and paves the way toward experimental support for multi-statement closures checked within their enclosing expressions.