### PR TITLE
runtime: fix SwapByteOrder.h when building for WASI

### DIFF
--- a/stdlib/include/llvm/Support/SwapByteOrder.h
+++ b/stdlib/include/llvm/Support/SwapByteOrder.h
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 #endif
 
-#if defined(__linux__) || defined(__GNU__) || defined(__HAIKU__)
+#if defined(__linux__) || defined(__GNU__) || defined(__HAIKU__) || defined(__wasi__)
 #include <endian.h>
 #elif defined(_AIX)
 #include <sys/machine.h>


### PR DESCRIPTION
`<endian.h>` is in the WASI SDK include root, so should use that as some other platforms do, instead of `<machine/endian.h>`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Related to SR-9307.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

CC @compnerd
