### PR TITLE
Sema: Remove TypeLoc from ExplicitCast (via Pattern)

### DIFF
--- a/include/swift/AST/ASTNode.h
+++ b/include/swift/AST/ASTNode.h
@@ -30,7 +30,6 @@ namespace swift {
   class Stmt;
   class Decl;
   class Pattern;
-  class TypeLoc;
   class DeclContext;
   class SourceLoc;
   class SourceRange;
@@ -40,8 +39,8 @@ namespace swift {
   enum class PatternKind : uint8_t;
   enum class StmtKind;
 
-  struct ASTNode : public llvm::PointerUnion<Expr *, Stmt *, Decl *, Pattern *,
-                                             TypeLoc *> {
+  struct ASTNode : public llvm::PointerUnion<Expr *, Stmt *, Decl *,
+                                             Pattern *> {
     // Inherit the constructors from PointerUnion.
     using PointerUnion::PointerUnion;
 

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -556,7 +556,6 @@ public:
   SWIFT_DEBUG_DUMP;
   void dump(raw_ostream &OS, unsigned Indent = 0) const;
   void dump(raw_ostream &OS, llvm::function_ref<Type(Expr *)> getType,
-            llvm::function_ref<Type(TypeLoc &)> getTypeOfTypeLoc,
             llvm::function_ref<Type(KeyPathExpr *E, unsigned index)>
                 getTypeOfKeyPathComponent,
             unsigned Indent = 0) const;

--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -456,6 +456,31 @@ public:
   }
 };
 
+/// A leaf pattern used to stand in for a type representation and its type.
+/// FIXME: Remove this line once TypeLoc in patterns is fully replaced by this.
+class TypePattern final : public Pattern {
+  TypeRepr *const tyRepr;
+
+public:
+  TypePattern(TypeRepr *tyRepr) : Pattern(PatternKind::Type), tyRepr(tyRepr) {}
+
+  static TypePattern *createImplicit(ASTContext &ctx, Type ty) {
+    assert(ty && "Expected a non-null type for implicit pattern");
+    auto *const pat = new (ctx) TypePattern(/*typeRepr*/ nullptr);
+    pat->setType(ty);
+    pat->setImplicit();
+    return pat;
+  }
+
+  TypeRepr *getTypeRepr() const { return tyRepr; }
+
+  SourceRange getSourceRange() const;
+
+  static bool classof(const Pattern *P) {
+    return P->getKind() == PatternKind::Type;
+  }
+};
+
 /// A pattern which performs a dynamic type check. The match succeeds if the
 /// class, archetype, or existential value is dynamically of the given type.
 ///

--- a/include/swift/AST/PatternNodes.def
+++ b/include/swift/AST/PatternNodes.def
@@ -39,6 +39,7 @@ PATTERN(Named, Pattern) // let pat, var pat
 PATTERN(Any, Pattern)   // _
 PATTERN(Typed, Pattern) // pat : type
 PATTERN(Var, Pattern)   // x
+REFUTABLE_PATTERN(Type, Pattern)         // type
 REFUTABLE_PATTERN(Is, Pattern)           // x is myclass
 REFUTABLE_PATTERN(EnumElement, Pattern)  // .mycase(pat1, ..., patN)
                                          // MyType.mycase(pat1, ..., patN)

--- a/include/swift/AST/TypeAlignments.h
+++ b/include/swift/AST/TypeAlignments.h
@@ -51,7 +51,6 @@ namespace swift {
   class TypeVariableType;
   class TypeBase;
   class TypeDecl;
-  class TypeLoc;
   class ValueDecl;
 
   /// We frequently use three tag bits on all of these types.
@@ -64,7 +63,6 @@ namespace swift {
   constexpr size_t PatternAlignInBits = 3;
   constexpr size_t SILFunctionAlignInBits = 2;
   constexpr size_t TypeVariableAlignInBits = 4;
-  constexpr size_t TypeLocAlignInBits = 3;
 }
 
 namespace llvm {
@@ -125,8 +123,6 @@ LLVM_DECLARE_TYPE_ALIGNMENT(swift::SILFunction,
                             swift::SILFunctionAlignInBits)
 
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::AttributeBase, swift::AttrAlignInBits)
-
-LLVM_DECLARE_TYPE_ALIGNMENT(swift::TypeLoc, swift::TypeLocAlignInBits)
 
 static_assert(alignof(void*) >= 2, "pointer alignment is too small");
 

--- a/include/swift/AST/TypeLoc.h
+++ b/include/swift/AST/TypeLoc.h
@@ -29,7 +29,7 @@ class TypeRepr;
 
 /// TypeLoc - Provides source location information for a parsed type.
 /// A TypeLoc is stored in AST nodes which use an explicitly written type.
-class alignas(1 << TypeLocAlignInBits) TypeLoc {
+class alignas(8) TypeLoc final {
   Type Ty;
   TypeRepr *TyR = nullptr;
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1780,18 +1780,15 @@ class PrintExpr : public ExprVisitor<PrintExpr> {
 public:
   raw_ostream &OS;
   llvm::function_ref<Type(Expr *)> GetTypeOfExpr;
-  llvm::function_ref<Type(TypeLoc &)> GetTypeOfTypeLoc;
   llvm::function_ref<Type(KeyPathExpr *E, unsigned index)>
       GetTypeOfKeyPathComponent;
   unsigned Indent;
 
   PrintExpr(raw_ostream &os, llvm::function_ref<Type(Expr *)> getTypeOfExpr,
-            llvm::function_ref<Type(TypeLoc &)> getTypeOfTypeLoc,
             llvm::function_ref<Type(KeyPathExpr *E, unsigned index)>
                 getTypeOfKeyPathComponent,
             unsigned indent)
       : OS(os), GetTypeOfExpr(getTypeOfExpr),
-        GetTypeOfTypeLoc(getTypeOfTypeLoc),
         GetTypeOfKeyPathComponent(getTypeOfKeyPathComponent), Indent(indent) {}
 
   void printRec(Expr *E) {
@@ -2878,21 +2875,19 @@ void Expr::dump() const {
 }
 
 void Expr::dump(raw_ostream &OS, llvm::function_ref<Type(Expr *)> getTypeOfExpr,
-                llvm::function_ref<Type(TypeLoc &)> getTypeOfTypeLoc,
                 llvm::function_ref<Type(KeyPathExpr *E, unsigned index)>
                     getTypeOfKeyPathComponent,
                 unsigned Indent) const {
-  PrintExpr(OS, getTypeOfExpr, getTypeOfTypeLoc, getTypeOfKeyPathComponent, Indent)
+  PrintExpr(OS, getTypeOfExpr, getTypeOfKeyPathComponent, Indent)
       .visit(const_cast<Expr *>(this));
 }
 
 void Expr::dump(raw_ostream &OS, unsigned Indent) const {
   auto getTypeOfExpr = [](Expr *E) -> Type { return E->getType(); };
-  auto getTypeOfTypeLoc = [](TypeLoc &TL) -> Type { return TL.getType(); };
   auto getTypeOfKeyPathComponent = [](KeyPathExpr *E, unsigned index) -> Type {
     return E->getComponents()[index].getComponentType();
   };
-  dump(OS, getTypeOfExpr, getTypeOfTypeLoc, getTypeOfKeyPathComponent, Indent);
+  dump(OS, getTypeOfExpr, getTypeOfKeyPathComponent, Indent);
 }
 
 void Expr::print(ASTPrinter &Printer, const PrintOptions &Opts) const {

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2609,9 +2609,12 @@ public:
     printCommon(E, name) << ' ';
     if (auto checkedCast = dyn_cast<CheckedCastExpr>(E))
       OS << getCheckedCastKindName(checkedCast->getCastKind()) << ' ';
-    OS << "writtenType='";
-    GetTypeOfTypeLoc(E->getCastTypeLoc()).print(OS);
-    OS << "'\n";
+
+    if (E->getTypePattern()->getTypeRepr()) {
+      OS << "writtenType='";
+      E->getTypePattern()->getTypeRepr()->print(OS);
+      OS << "'\n";
+    }
     printRec(E->getSubExpr());
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -485,7 +485,12 @@ namespace {
       }
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
-
+    void visitTypePattern(TypePattern *P) {
+      printCommon(P, "pattern_type") << '\n';
+      if (P->getTypeRepr())
+        printRec(P->getTypeRepr());
+      PrintWithColorRAII(OS, ParenthesisColor) << ')';
+    }
     void visitIsPattern(IsPattern *P) {
       printCommon(P, "pattern_is")
         << ' ' << getCheckedCastKindName(P->getCastKind()) << ' ';

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -19,7 +19,6 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/Pattern.h"
-#include "swift/AST/TypeLoc.h"
 #include "swift/Basic/SourceLoc.h"
 
 using namespace swift;
@@ -33,8 +32,6 @@ SourceRange ASTNode::getSourceRange() const {
     return D->getSourceRange();
   if (const auto *P = this->dyn_cast<Pattern*>())
     return P->getSourceRange();
-  if (const auto *L = this->dyn_cast<TypeLoc *>())
-    return L->getSourceRange();
   llvm_unreachable("unsupported AST node");
 }
 
@@ -71,8 +68,6 @@ bool ASTNode::isImplicit() const {
     return D->isImplicit();
   if (const auto *P = this->dyn_cast<Pattern*>())
     return P->isImplicit();
-  if (const auto *L = this->dyn_cast<TypeLoc*>())
-    return false;
   llvm_unreachable("unsupported AST node");
 }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1155,6 +1155,15 @@ void PrintAST::printPattern(const Pattern *pattern) {
     printTypedPattern(cast<TypedPattern>(pattern));
     break;
 
+  case PatternKind::Type: {
+    const auto *const pat = cast<TypePattern>(pattern);
+    if (pat->hasType())
+      pat->getType().print(Printer, Options);
+    else
+      pat->getTypeRepr()->print(Printer, Options);
+    break;
+  }
+
   case PatternKind::Is: {
     auto isa = cast<IsPattern>(pattern);
     Printer << tok::kw_is << " ";

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -898,7 +898,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
       E->setSubExpr(Sub);
     }
 
-    if (doIt(E->getCastTypeLoc()))
+    if (doIt(E->getTypePattern()) == nullptr)
       return nullptr;
 
     return E;

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1687,6 +1687,14 @@ Pattern *Traversal::visitTypedPattern(TypedPattern *P) {
   return P;
 }
 
+Pattern *Traversal::visitTypePattern(TypePattern *P) {
+  if (auto *const tyRepr = P->getTypeRepr())
+    if (doIt(tyRepr))
+      return nullptr;
+
+  return P;
+}
+
 Pattern *Traversal::visitIsPattern(IsPattern *P) {
   if (auto sub = P->getSubPattern()) {
     if (Pattern *newSub = doIt(sub)) {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2480,6 +2480,7 @@ void FindLocalVal::checkPattern(const Pattern *Pat, DeclVisibilityKind Reason) {
   case PatternKind::Bool:
   case PatternKind::Expr:
   case PatternKind::Any:
+  case PatternKind::Type:
     return;
   }
 }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -648,10 +648,7 @@ synthesizeStructRawValueGetterBody(AbstractFunctionDecl *afd, void *context) {
     auto bridge = new (ctx) BridgeFromObjCExpr(storedRef, computedType);
     bridge->setType(computedType);
 
-    auto coerce = new (ctx) CoerceExpr(bridge, {}, {nullptr, computedType});
-    coerce->setType(computedType);
-
-    result = coerce;
+    result = CoerceExpr::createImplicit(ctx, bridge, computedType);;
   }
 
   auto ret = new (ctx) ReturnStmt(SourceLoc(), result);
@@ -1566,11 +1563,7 @@ synthesizeRawValueBridgingConstructorBody(AbstractFunctionDecl *afd,
     auto bridge = new (ctx) BridgeToObjCExpr(paramRef, storedType);
     bridge->setType(storedType);
 
-    auto coerce = new (ctx) CoerceExpr(bridge, SourceLoc(),
-                                       {nullptr, storedType});
-    coerce->setType(storedType);
-
-    rhs = coerce;
+    rhs = CoerceExpr::createImplicit(ctx, bridge, storedType);
   }
 
   // Add assignment.

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -78,7 +78,7 @@ ParserResult<Expr> Parser::parseExprIs() {
   if (type.isNull())
     return nullptr;
 
-  return makeParserResult(new (Context) IsExpr(isLoc, type.get()));
+  return makeParserResult(IsExpr::create(Context, isLoc, type.get()));
 }
 
 /// parseExprAs
@@ -108,12 +108,13 @@ ParserResult<Expr> Parser::parseExprAs() {
 
   Expr *parsed;
   if (questionLoc.isValid()) {
-    parsed = new (Context) ConditionalCheckedCastExpr(asLoc, questionLoc,
-                                                      type.get());
+    parsed = ConditionalCheckedCastExpr::create(Context, asLoc, questionLoc,
+                                                type.get());
   } else if (exclaimLoc.isValid()) {
-    parsed = new (Context) ForcedCheckedCastExpr(asLoc, exclaimLoc, type.get());
+    parsed = ForcedCheckedCastExpr::create(Context, asLoc, exclaimLoc,
+                                           type.get());
   } else {
-    parsed = new (Context) CoerceExpr(asLoc, type.get());
+    parsed = CoerceExpr::create(Context, asLoc, type.get());
   }
   return makeParserResult(parsed);
 }

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1045,6 +1045,10 @@ struct InitializationForPattern
   InitializationPtr visitVarPattern(VarPattern *P) {
     return visit(P->getSubPattern());
   }
+  InitializationPtr visitTypePattern(TypePattern *P) {
+    llvm_unreachable(
+        "non-semantic leaf pattern should be evaluated with its parent");
+  }
 
   // AnyPatterns (i.e, _) don't require any storage. Any value bound here will
   // just be dropped.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1972,7 +1972,8 @@ static RValue emitBoolLiteral(SILGenFunction &SGF, SILLocation loc,
 }
 RValue RValueEmitter::visitIsExpr(IsExpr *E, SGFContext C) {
   SILValue isa = emitIsa(SGF, E, E->getSubExpr(),
-                         E->getCastTypeLoc().getType(), E->getCastKind());
+                         E->getTypePattern()->getType(),
+                         E->getCastKind());
   return emitBoolLiteral(SGF, E, isa, C);
 }
 

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -100,6 +100,7 @@ static void dumpPattern(const Pattern *p, llvm::raw_ostream &os) {
   case PatternKind::Paren:
   case PatternKind::Typed:
   case PatternKind::Var:
+  case PatternKind::Type:
     llvm_unreachable("not semantic");
   }
 }
@@ -123,6 +124,7 @@ static bool isDirectlyRefutablePattern(const Pattern *p) {
   case PatternKind::Is:
   case PatternKind::EnumElement:
   case PatternKind::OptionalSome:
+  case PatternKind::Type:
   case PatternKind::Bool:
     return true;
 
@@ -185,7 +187,8 @@ static unsigned getNumSpecializationsRecursive(const Pattern *p, unsigned n) {
     return getNumSpecializationsRecursive(en->getSubPattern(), n+1);
   }
   case PatternKind::Bool:
-    return n+1;
+  case PatternKind::Type:
+    return ++n;
 
   // Recur into simple wrapping patterns.
   case PatternKind::Paren:
@@ -226,6 +229,7 @@ static bool isWildcardPattern(const Pattern *p) {
   case PatternKind::EnumElement:
   case PatternKind::OptionalSome:
   case PatternKind::Bool:
+  case PatternKind::Type:
     return false;
 
   // Recur into simple wrapping patterns.
@@ -292,10 +296,11 @@ static Pattern *getSimilarSpecializingPattern(Pattern *p, Pattern *first) {
     }
     return nullptr;
   }
-    
+
   case PatternKind::Paren:
   case PatternKind::Var:
   case PatternKind::Typed:
+  case PatternKind::Type:
     llvm_unreachable("not semantic");
   }
 
@@ -1338,6 +1343,7 @@ void PatternMatchEmission::emitSpecializedDispatch(ClauseMatrix &clauses,
 
   case PatternKind::Paren:
   case PatternKind::Typed:
+  case PatternKind::Type:
   case PatternKind::Var:
     llvm_unreachable("non-semantic pattern kind!");
   

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2356,8 +2356,8 @@ bool ContextualFailure::diagnoseCoercionToUnrelatedType() const {
   auto anchor = getAnchor();
 
   if (auto *coerceExpr = getAsExpr<CoerceExpr>(anchor)) {
-    auto fromType = getType(coerceExpr->getSubExpr());
-    auto toType = getType(&coerceExpr->getCastTypeLoc());
+    const auto fromType = getType(coerceExpr->getSubExpr());
+    const auto toType = getType(coerceExpr->getTypePattern());
 
     auto diagnostic = getDiagnosticFor(CTP_CoerceOperand, toType);
 
@@ -5115,7 +5115,7 @@ bool MissingGenericArgumentsFailure::diagnoseParameter(
   }
 
   if (auto *CE = getAsExpr<ExplicitCastExpr>(getRawAnchor())) {
-    auto castTo = getType(&CE->getCastTypeLoc());
+    const auto castTo = getType(CE->getTypePattern());
     auto *NTD = castTo->getAnyNominal();
     emitDiagnosticAt(loc, diag::unbound_generic_parameter_cast, GP,
                      NTD ? NTD->getDeclaredType() : castTo);
@@ -5213,15 +5213,17 @@ bool MissingGenericArgumentsFailure::findArgumentLocations(
     llvm::function_ref<void(TypeRepr *, GenericTypeParamType *)> callback) {
   using Callback = llvm::function_ref<void(TypeRepr *, GenericTypeParamType *)>;
 
-  auto anchor = getRawAnchor();
+  auto *const typeRepr = [this]() -> TypeRepr * {
+    const auto anchor = getRawAnchor();
+    if (const auto *TE = getAsExpr<TypeExpr>(anchor))
+      return TE->getTypeRepr();
+    else if (const auto *ECE = getAsExpr<ExplicitCastExpr>(anchor))
+      return ECE->getTypePattern()->getTypeRepr();
+    else
+      return nullptr;
+  }();
 
-  TypeLoc typeLoc;
-  if (auto *TE = getAsExpr<TypeExpr>(anchor))
-    typeLoc = TE->getTypeRepr();
-  else if (auto *ECE = getAsExpr<ExplicitCastExpr>(anchor))
-    typeLoc = ECE->getCastTypeLoc();
-
-  if (!typeLoc.hasLocation())
+  if (!typeRepr)
     return false;
 
   struct AssociateMissingParams : public ASTWalker {
@@ -5276,7 +5278,7 @@ bool MissingGenericArgumentsFailure::findArgumentLocations(
 
   } associator(Parameters, callback);
 
-  typeLoc.getTypeRepr()->walk(associator);
+  typeRepr->walk(associator);
   return associator.allParamsAssigned();
 }
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -147,12 +147,10 @@ CoerceToCheckedCast *CoerceToCheckedCast::attempt(ConstraintSystem &cs,
   if (!coerceExpr)
     return nullptr;
 
-  auto subExpr = coerceExpr->getSubExpr();
-  auto castKind =
-      TypeChecker::typeCheckCheckedCast(fromType, toType,
-                                        CheckedCastContextKind::None, cs.DC,
-                                        coerceExpr->getLoc(), subExpr,
-                                        coerceExpr->getCastTypeLoc().getSourceRange());
+  const auto castKind = TypeChecker::typeCheckCheckedCast(
+      fromType, toType, CheckedCastContextKind::None, cs.DC,
+      coerceExpr->getLoc(), coerceExpr->getSubExpr(),
+      coerceExpr->getTypePattern()->getSourceRange());
 
   // Invalid cast.
   if (castKind == CheckedCastKind::Unresolved)

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2440,6 +2440,10 @@ namespace {
         return setType(openedType);
       }
 
+      case PatternKind::Type:
+        llvm_unreachable(
+            "non-semantic leaf pattern is evaluated with its parent");
+
       case PatternKind::Tuple: {
         auto tuplePat = cast<TuplePattern>(pattern);
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -987,8 +987,7 @@ void ConstraintSystem::shrink(Expr *expr) {
         // let's allow collector discover it with assigned contextual type
         // of coercion, which allows collections to be solved in parts.
         if (auto collectionExpr = dyn_cast<CollectionExpr>(childExpr)) {
-          auto castTypeLoc = coerceExpr->getCastTypeLoc();
-          auto typeRepr = castTypeLoc.getTypeRepr();
+          auto *const typeRepr = coerceExpr->getTypePattern()->getTypeRepr();
 
           if (typeRepr && isSuitableCollection(typeRepr)) {
             auto resolution = TypeResolution::forContextual(CS.DC, None);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4524,8 +4524,6 @@ void ConstraintSystem::maybeProduceFallbackDiagnostic(
 SourceLoc constraints::getLoc(ASTNode anchor) {
   if (auto *E = anchor.dyn_cast<Expr *>()) {
     return E->getLoc();
-  } else if (auto *T = anchor.dyn_cast<TypeLoc *>()) {
-    return T->getLoc();
   } else if (auto *V = anchor.dyn_cast<Decl *>()) {
     if (auto VD = dyn_cast<VarDecl>(V))
       return VD->getNameLoc();

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2506,15 +2506,11 @@ public:
   /// map is used throughout the expression type checker in order to
   /// avoid mutating expressions until we know we have successfully
   /// type-checked them.
-  void setType(TypeLoc &L, Type T) { setType(ASTNode(&L), T); }
-
   void setType(KeyPathExpr *KP, unsigned I, Type T) {
     assert(KP && "Expected non-null key path parameter!");
     assert(T && "Expected non-null type!");
     KeyPathComponentTypes[std::make_pair(KP, I)] = T.getPointer();
   }
-
-  bool hasType(TypeLoc &L) const { return hasType(ASTNode(&L)); }
 
   /// Check to see if we have a type for a node.
   bool hasType(ASTNode node) const {
@@ -2537,8 +2533,6 @@ public:
     //           "Mismatched types!");
     return NodeTypes.find(node)->second;
   }
-
-  Type getType(TypeLoc &L) const { return getType(ASTNode(&L)); }
 
   Type getType(const KeyPathExpr *KP, unsigned I) const {
     assert(hasType(KP, I) && "Expected type to have been set!");

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -525,12 +525,14 @@ public:
     if (auto cast = dyn_cast<CheckedCastExpr>(E)) {
       // If we failed to resolve the written type, we've emitted an
       // earlier diagnostic and should bail.
-      auto toTy = cast->getCastTypeLoc().getType();
-      if (!toTy || toTy->hasError())
+      if (!cast->getTypePattern()->hasType())
         return false;
 
-      if (auto clas = dyn_cast_or_null<ClassDecl>(
-                         cast->getCastTypeLoc().getType()->getAnyNominal())) {
+      const auto toTy = cast->getTypePattern()->getType();
+      if (toTy->hasError())
+        return false;
+
+      if (auto clas = dyn_cast_or_null<ClassDecl>(toTy->getAnyNominal())) {
         if (clas->usesObjCGenericsModel()) {
           return false;
         }
@@ -558,7 +560,8 @@ public:
     }
 
     if (auto *ECE = dyn_cast<ExplicitCastExpr>(E)) {
-      checkType(ECE->getCastTypeLoc().getType(), ECE->getLoc());
+      if (ECE->getTypePattern()->hasType())
+        checkType(ECE->getTypePattern()->getType(), ECE->getLoc());
       return { true, E };
     }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3035,18 +3035,13 @@ void ConstraintSystem::print(raw_ostream &out, Expr *E) const {
       return getType(E);
     return Type();
   };
-  auto getTypeOfTypeLoc = [&](TypeLoc &TL) -> Type {
-    if (hasType(TL))
-      return getType(TL);
-    return Type();
-  };
   auto getTypeOfKeyPathComponent = [&](KeyPathExpr *KP, unsigned I) -> Type {
     if (hasType(KP, I))
       return getType(KP, I);
     return Type();
   };
 
-  E->dump(out, getTypeOfExpr, getTypeOfTypeLoc, getTypeOfKeyPathComponent);
+  E->dump(out, getTypeOfExpr, getTypeOfKeyPathComponent);
 }
 
 void ConstraintSystem::print(raw_ostream &out) const {

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -284,6 +284,7 @@ public:
   ALWAYS_RESOLVED_PATTERN(Tuple)
   ALWAYS_RESOLVED_PATTERN(EnumElement)
   ALWAYS_RESOLVED_PATTERN(Bool)
+  ALWAYS_RESOLVED_PATTERN(Type)
 #undef ALWAYS_RESOLVED_PATTERN
 
   Pattern *visitVarPattern(VarPattern *P) {
@@ -835,6 +836,10 @@ Type PatternTypeRequest::evaluate(Evaluator &evaluator,
     }
 
     return Context.TheUnresolvedType;
+
+  case PatternKind::Type:
+    llvm_unreachable(
+        "non-semantic leaf pattern is evaluated with its parent");
   }
   llvm_unreachable("bad pattern kind!");
 }
@@ -1580,6 +1585,9 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
   case PatternKind::Bool:
     P->setType(type);
     return P;
+  case PatternKind::Type:
+    llvm_unreachable(
+        "non-semantic leaf pattern is evaluated with its parent");
   }
   llvm_unreachable("bad pattern kind!");
 }

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -361,10 +361,11 @@ public:
     auto cast = dyn_cast<CoerceExpr>(E->getElement(1));
     if (!cast)
       return nullptr;
-    
+
+    const auto tyLoc = TypeLoc(cast->getTypePattern()->getTypeRepr());
     Pattern *subPattern = getSubExprPattern(E->getElement(0));
-    return new (Context) IsPattern(cast->getLoc(), cast->getCastTypeLoc(),
-                                   subPattern, CheckedCastKind::Unresolved);
+    return new (Context) IsPattern(cast->getLoc(), tyLoc, subPattern,
+                                   CheckedCastKind::Unresolved);
   }
   
   // Convert a paren expr to a pattern if it contains a pattern.

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1043,29 +1043,19 @@ static Expr *synthesizeCopyWithZoneCall(Expr *Val, VarDecl *VD,
   Call->setType(copyMethodType->getResult());
   Call->setThrows(false);
 
-  TypeLoc ResultTy;
-  ResultTy.setType(VD->getType());
-
   // If we're working with non-optional types, we're forcing the cast.
   if (!isOptional) {
-    auto *Cast =
-      new (Ctx) ForcedCheckedCastExpr(Call, SourceLoc(), SourceLoc(),
-                                      TypeLoc::withoutLoc(underlyingType));
+    auto *const Cast =
+        ForcedCheckedCastExpr::createImplicit(Ctx, Call, underlyingType);
     Cast->setCastKind(CheckedCastKind::ValueCast);
-    Cast->setType(underlyingType);
-    Cast->setImplicit();
-
     return Cast;
   }
 
   // We're working with optional types, so perform a conditional checked
   // downcast.
-  auto *Cast =
-    new (Ctx) ConditionalCheckedCastExpr(Call, SourceLoc(), SourceLoc(),
-                                         TypeLoc::withoutLoc(underlyingType));
+  auto *const Cast =
+      ConditionalCheckedCastExpr::createImplicit(Ctx, Call, underlyingType);
   Cast->setCastKind(CheckedCastKind::ValueCast);
-  Cast->setType(OptionalType::get(underlyingType));
-  Cast->setImplicit();
 
   // Use OptionalEvaluationExpr to evaluate the "?".
   auto *Result = new (Ctx) OptionalEvaluationExpr(Cast);

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1414,6 +1414,9 @@ namespace {
       }
       case PatternKind::Typed:
         llvm_unreachable("cannot appear in case patterns");
+      case PatternKind::Type:
+        llvm_unreachable(
+            "non-semantic leaf pattern should be evaluated with its parent");
       case PatternKind::Expr:
         return Space();
       case PatternKind::Var: {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3394,7 +3394,7 @@ Type TypeResolver::resolveImplicitlyUnwrappedOptionalType(
     break;
   }
 
-  if (doDiag) {
+  if (doDiag && !options.contains(TypeResolutionFlags::SilenceErrors)) {
     // Prior to Swift 5, we allow 'as T!' and turn it into a disjunction.
     if (Context.isSwiftVersionAtLeast(5)) {
       diagnose(repr->getStartLoc(),

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2704,6 +2704,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       writePattern(typed->getSubPattern());
       break;
     }
+    case PatternKind::Type:
     case PatternKind::Is:
     case PatternKind::EnumElement:
     case PatternKind::OptionalSome:

--- a/test/Sema/diag_erroneous_iuo.swift
+++ b/test/Sema/diag_erroneous_iuo.swift
@@ -116,7 +116,7 @@ _ = [Int!]() // expected-error {{'!' is not allowed here; perhaps '?' was intend
 let _: [Int!] = [1] // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{12-13=?}}
 _ = Optional<Int!>(nil) // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{17-18=?}}
 let _: Optional<Int!> = nil // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{20-21=?}}
-_ = Int!?(0) // expected-error 3 {{'!' is not allowed here; perhaps '?' was intended?}}{{8-9=?}}
+_ = Int!?(0) // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{8-9=?}}
 let _: Int!? = 0 // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{11-12=?}}
 _ = (
   Int!, // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{6-7=?}}


### PR DESCRIPTION
Reimplements #32138 by introducing a new leaf pattern `TypePattern`.

`test/[decl, Generics, Sema, Constraints, expr, SILGen]` are passing locally.