### PR TITLE
[NFC] AST: const-qualify ASTContext refs in PrettyStackTrace.h

### DIFF
--- a/include/swift/AST/PrettyStackTrace.h
+++ b/include/swift/AST/PrettyStackTrace.h
@@ -38,22 +38,24 @@ namespace swift {
   class TypeRepr;
 
 void printSourceLocDescription(llvm::raw_ostream &out, SourceLoc loc,
-                               ASTContext &Context, bool addNewline = true);
+                               const ASTContext &Context,
+                               bool addNewline = true);
 
 /// PrettyStackTraceLocation - Observe that we are doing some
 /// processing starting at a fixed location.
 class PrettyStackTraceLocation : public llvm::PrettyStackTraceEntry {
-  ASTContext &Context;
+  const ASTContext &Context;
   SourceLoc Loc;
   const char *Action;
 public:
-  PrettyStackTraceLocation(ASTContext &C, const char *action, SourceLoc loc)
+  PrettyStackTraceLocation(const ASTContext &C, const char *action,
+                           SourceLoc loc)
     : Context(C), Loc(loc), Action(action) {}
   virtual void print(llvm::raw_ostream &OS) const;
 };
 
 void printDeclDescription(llvm::raw_ostream &out, const Decl *D,
-                          ASTContext &Context, bool addNewline = true);
+                          const ASTContext &Context, bool addNewline = true);
 
 /// PrettyStackTraceDecl - Observe that we are processing a specific
 /// declaration.
@@ -78,60 +80,60 @@ public:
 };
 
 void printExprDescription(llvm::raw_ostream &out, Expr *E,
-                          ASTContext &Context, bool addNewline = true);
+                          const ASTContext &Context, bool addNewline = true);
 
 /// PrettyStackTraceExpr - Observe that we are processing a specific
 /// expression.
 class PrettyStackTraceExpr : public llvm::PrettyStackTraceEntry {
-  ASTContext &Context;
+  const ASTContext &Context;
   Expr *TheExpr;
   const char *Action;
 public:
-  PrettyStackTraceExpr(ASTContext &C, const char *action, Expr *E)
+  PrettyStackTraceExpr(const ASTContext &C, const char *action, Expr *E)
     : Context(C), TheExpr(E), Action(action) {}
   virtual void print(llvm::raw_ostream &OS) const;
 };
 
 void printStmtDescription(llvm::raw_ostream &out, Stmt *S,
-                          ASTContext &Context, bool addNewline = true);
+                          const ASTContext &Context, bool addNewline = true);
 
 /// PrettyStackTraceStmt - Observe that we are processing a specific
 /// statement.
 class PrettyStackTraceStmt : public llvm::PrettyStackTraceEntry {
-  ASTContext &Context;
+  const ASTContext &Context;
   Stmt *TheStmt;
   const char *Action;
 public:
-  PrettyStackTraceStmt(ASTContext &C, const char *action, Stmt *S)
+  PrettyStackTraceStmt(const ASTContext &C, const char *action, Stmt *S)
     : Context(C), TheStmt(S), Action(action) {}
   virtual void print(llvm::raw_ostream &OS) const;
 };
 
 void printPatternDescription(llvm::raw_ostream &out, Pattern *P,
-                             ASTContext &Context, bool addNewline = true);
+                             const ASTContext &Context, bool addNewline = true);
 
 /// PrettyStackTracePattern - Observe that we are processing a
 /// specific pattern.
 class PrettyStackTracePattern : public llvm::PrettyStackTraceEntry {
-  ASTContext &Context;
+  const ASTContext &Context;
   Pattern *ThePattern;
   const char *Action;
 public:
-  PrettyStackTracePattern(ASTContext &C, const char *action, Pattern *P)
+  PrettyStackTracePattern(const ASTContext &C, const char *action, Pattern *P)
     : Context(C), ThePattern(P), Action(action) {}
   virtual void print(llvm::raw_ostream &OS) const;
 };
 
 void printTypeDescription(llvm::raw_ostream &out, Type T,
-                          ASTContext &Context, bool addNewline = true);
+                          const ASTContext &Context, bool addNewline = true);
 
 /// PrettyStackTraceType - Observe that we are processing a specific type.
 class PrettyStackTraceType : public llvm::PrettyStackTraceEntry {
-  ASTContext &Context;
+  const ASTContext &Context;
   Type TheType;
   const char *Action;
 public:
-  PrettyStackTraceType(ASTContext &C, const char *action, Type type)
+  PrettyStackTraceType(const ASTContext &C, const char *action, Type type)
     : Context(C), TheType(type), Action(action) {}
   virtual void print(llvm::raw_ostream &OS) const;
 };
@@ -149,11 +151,12 @@ public:
 
 /// Observe that we are processing a specific type representation.
 class PrettyStackTraceTypeRepr : public llvm::PrettyStackTraceEntry {
-  ASTContext &Context;
+  const ASTContext &Context;
   TypeRepr *TheType;
   const char *Action;
 public:
-  PrettyStackTraceTypeRepr(ASTContext &C, const char *action, TypeRepr *type)
+  PrettyStackTraceTypeRepr(const ASTContext &C, const char *action,
+                           TypeRepr *type)
     : Context(C), TheType(type), Action(action) {}
   virtual void print(llvm::raw_ostream &OS) const;
 };
@@ -161,11 +164,11 @@ public:
 /// PrettyStackTraceConformance - Observe that we are processing a
 /// specific protocol conformance.
 class PrettyStackTraceConformance : public llvm::PrettyStackTraceEntry {
-  ASTContext &Context;
+  const ASTContext &Context;
   const ProtocolConformance *Conformance;
   const char *Action;
 public:
-  PrettyStackTraceConformance(ASTContext &C, const char *action,
+  PrettyStackTraceConformance(const ASTContext &C, const char *action,
                               const ProtocolConformance *conformance)
     : Context(C), Conformance(conformance), Action(action) {}
   virtual void print(llvm::raw_ostream &OS) const;
@@ -173,7 +176,8 @@ public:
 
 void printConformanceDescription(llvm::raw_ostream &out,
                                  const ProtocolConformance *conformance,
-                                 ASTContext &Context, bool addNewline = true);
+                                 const ASTContext &Context,
+                                 bool addNewline = true);
 
 class PrettyStackTraceGenericSignature : public llvm::PrettyStackTraceEntry {
   const char *Action;

--- a/lib/AST/PrettyStackTrace.cpp
+++ b/lib/AST/PrettyStackTrace.cpp
@@ -43,7 +43,7 @@ void PrettyStackTraceDecl::print(llvm::raw_ostream &out) const {
 }
 
 void swift::printDeclDescription(llvm::raw_ostream &out, const Decl *D,
-                                 ASTContext &Context, bool addNewline) {
+                                 const ASTContext &Context, bool addNewline) {
   SourceLoc loc = D->getStartLoc();
   bool hasPrintedName = false;
   if (auto *named = dyn_cast<ValueDecl>(D)) {
@@ -127,7 +127,7 @@ void PrettyStackTraceExpr::print(llvm::raw_ostream &out) const {
 }
 
 void swift::printExprDescription(llvm::raw_ostream &out, Expr *E,
-                                 ASTContext &Context, bool addNewline) {
+                                 const ASTContext &Context, bool addNewline) {
   out << "expression at ";
   E->getSourceRange().print(out, Context.SourceMgr);
   if (addNewline) out << '\n';
@@ -143,7 +143,7 @@ void PrettyStackTraceStmt::print(llvm::raw_ostream &out) const {
 }
 
 void swift::printStmtDescription(llvm::raw_ostream &out, Stmt *S,
-                                 ASTContext &Context, bool addNewline) {
+                                 const ASTContext &Context, bool addNewline) {
   out << "statement at ";
   S->getSourceRange().print(out, Context.SourceMgr);
   if (addNewline) out << '\n';
@@ -159,7 +159,8 @@ void PrettyStackTracePattern::print(llvm::raw_ostream &out) const {
 }
 
 void swift::printPatternDescription(llvm::raw_ostream &out, Pattern *P,
-                                    ASTContext &Context, bool addNewline) {
+                                    const ASTContext &Context,
+                                    bool addNewline) {
   out << "pattern at ";
   P->getSourceRange().print(out, Context.SourceMgr);
   if (addNewline) out << '\n';
@@ -198,7 +199,7 @@ void PrettyStackTraceType::print(llvm::raw_ostream &out) const {
 }
 
 void swift::printTypeDescription(llvm::raw_ostream &out, Type type,
-                                 ASTContext &Context, bool addNewline) {
+                                 const ASTContext &Context, bool addNewline) {
   out << "type '" << type << '\'';
   if (Decl *decl = InterestingDeclForType().visit(type)) {
     if (decl->getSourceRange().isValid()) {
@@ -236,7 +237,8 @@ void PrettyStackTraceConformance::print(llvm::raw_ostream &out) const {
 
 void swift::printConformanceDescription(llvm::raw_ostream &out,
                                         const ProtocolConformance *conformance,
-                                        ASTContext &ctxt, bool addNewline) {
+                                        const ASTContext &ctxt,
+                                        bool addNewline) {
   if (!conformance) {
     out << "NULL protocol conformance!";
     if (addNewline) out << '\n';
@@ -250,7 +252,7 @@ void swift::printConformanceDescription(llvm::raw_ostream &out,
 }
 
 void swift::printSourceLocDescription(llvm::raw_ostream &out,
-                                      SourceLoc loc, ASTContext &ctx,
+                                      SourceLoc loc, const ASTContext &ctx,
                                       bool addNewline) {
   loc.print(out, ctx.SourceMgr);
   if (addNewline) out << '\n';


### PR DESCRIPTION
These are stored just to read from the source manager.