### PR TITLE
Only perform parallel ir generation if -num-threads > 1

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -188,9 +188,7 @@ public:
     return OptMode > OptimizationMode::NoOptimization;
   }
 
-  bool hasMultipleIRGenThreads() const { return NumThreads > 1; }
-  bool shouldPerformIRGenerationInParallel() const { return NumThreads != 0; }
-  bool hasMultipleIGMs() const { return hasMultipleIRGenThreads(); }
+  bool shouldPerformIRGenerationInParallel() const { return NumThreads > 1; }
 };
 
 } // end namespace swift

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1204,7 +1204,7 @@ static bool ParseTBDGenArgs(TBDGenOptions &Opts, ArgList &Args,
                             CompilerInvocation &Invocation) {
   using namespace options;
 
-  Opts.HasMultipleIGMs = Invocation.getSILOptions().hasMultipleIGMs();
+  Opts.HasMultipleIGMs = Invocation.getSILOptions().shouldPerformIRGenerationInParallel();
 
   if (const Arg *A = Args.getLastArg(OPT_module_link_name)) {
     Opts.ModuleLinkName = A->getValue();


### PR DESCRIPTION
Previously if `-num-threads` was passed as 1, this would still use the
parallel codepath, but with only a single thread.

This is analogous to this swift-driver change https://github.com/apple/swift-driver/pull/117