### PR TITLE
Introduce a `PruneVTables` pass to mark non-overridden entries.

### DIFF
--- a/include/swift/SIL/SILVTable.h
+++ b/include/swift/SIL/SILVTable.h
@@ -128,6 +128,9 @@ public:
   /// Return all of the method entries.
   ArrayRef<Entry> getEntries() const { return {Entries, NumEntries}; }
 
+  /// Return all of the method entries mutably.
+  MutableArrayRef<Entry> getMutableEntries() { return {Entries, NumEntries}; }
+
   /// Look up the implementation function for the given method.
   Optional<Entry> getEntry(SILModule &M, SILDeclRef method) const;
 

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -340,7 +340,9 @@ PASS(MandatoryCombine, "mandatory-combine",
     "Perform mandatory peephole combines")
 PASS(BugReducerTester, "bug-reducer-tester",
      "sil-bug-reducer Tool Testing by Asserting on a Sentinel Function")
-PASS_RANGE(AllPasses, AADumper, BugReducerTester)
+PASS(PruneVTables, "prune-vtables",
+     "Mark class methods that do not require vtable dispatch")
+PASS_RANGE(AllPasses, AADumper, PruneVTables)
 
 #undef IRGEN_PASS
 #undef PASS

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(swiftSILOptimizer PRIVATE
   ObjectOutliner.cpp
   PerformanceInliner.cpp
   PhiArgumentOptimizations.cpp
+  PruneVTables.cpp
   RedundantLoadElimination.cpp
   RedundantOverflowCheckRemoval.cpp
   ReleaseDevirtualizer.cpp

--- a/lib/SILOptimizer/Transforms/PruneVTables.cpp
+++ b/lib/SILOptimizer/Transforms/PruneVTables.cpp
@@ -1,0 +1,72 @@
+//===--- PruneVTables.cpp - Prune unnecessary vtable entries --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Mark sil_vtable entries as [nonoverridden] when possible, so that we know
+// at IRGen time they can be elided from runtime vtables.
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "prune-vtables"
+
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/InstOptUtils.h"
+
+using namespace swift;
+
+namespace {
+class PruneVTables : public SILModuleTransform {
+  void runOnVTable(SILModule *M,
+                   SILVTable *vtable) {
+    for (auto &entry : vtable->getMutableEntries()) {
+      // We don't need to worry about entries that are inherited, overridden,
+      // or have already been found to have no overrides.
+      if (entry.TheKind != SILVTable::Entry::Normal) {
+        continue;
+      }
+      
+      // The destructor entry must remain.
+      if (entry.Method.kind == SILDeclRef::Kind::Deallocator) {
+        continue;
+      }
+      
+      auto methodDecl = entry.Method.getAbstractFunctionDecl();
+      if (!methodDecl)
+        continue;
+
+      // Is the method declared final?
+      if (!methodDecl->isFinal()) {
+        // Are callees of this entry statically knowable?
+        if (!calleesAreStaticallyKnowable(*M, entry.Method))
+          continue;
+        
+        // Does the method have any overrides in this module?
+        if (methodDecl->isOverridden())
+          continue;
+      }
+      
+      entry.TheKind = SILVTable::Entry::NormalNonOverridden;
+    }
+  }
+  
+  void run() override {
+    SILModule *M = getModule();
+    
+    for (auto &vtable : M->getVTables()) {
+      runOnVTable(M, &vtable);
+    }
+  }
+};
+}
+
+SILTransform *swift::createPruneVTables() {
+  return new PruneVTables();
+}

--- a/test/SILOptimizer/prune-vtables.sil
+++ b/test/SILOptimizer/prune-vtables.sil
@@ -1,0 +1,152 @@
+// RUN: %target-sil-opt -prune-vtables %s | %FileCheck --check-prefix=NOWMO %s
+// RUN: %target-sil-opt -wmo -prune-vtables %s | %FileCheck --check-prefix=WMO %s
+
+sil_stage canonical
+
+private class PrivateA {
+  func noOverrides() {}
+  func yesOverrides() {}
+  final func isFinal() {}
+}
+
+sil @PrivateA_noOverrides  : $@convention(method) (@guaranteed PrivateA) -> ()
+sil @PrivateA_yesOverrides : $@convention(method) (@guaranteed PrivateA) -> ()
+sil @PrivateA_isFinal      : $@convention(method) (@guaranteed PrivateA) -> ()
+
+// NOWMO-LABEL: sil_vtable PrivateA {
+// NOWMO:         #PrivateA.noOverrides{{.*}} [nonoverridden]
+// NOWMO-NOT:     #PrivateA.yesOverrides{{.*}} [nonoverridden]
+// NOWMO:         #PrivateA.isFinal{{.*}} [nonoverridden]
+
+// WMO-LABEL: sil_vtable PrivateA {
+// WMO:         #PrivateA.noOverrides{{.*}} [nonoverridden]
+// WMO-NOT:     #PrivateA.yesOverrides{{.*}} [nonoverridden]
+// WMO:         #PrivateA.isFinal{{.*}} [nonoverridden]
+sil_vtable PrivateA {
+  #PrivateA.noOverrides:  @PrivateA_noOverrides
+  #PrivateA.yesOverrides: @PrivateA_yesOverrides
+  #PrivateA.isFinal:      @PrivateA_isFinal
+}
+
+private class PrivateB: PrivateA {
+  override func yesOverrides() {}
+}
+
+sil @PrivateB_yesOverrides : $@convention(method) (@guaranteed PrivateB) -> ()
+
+sil_vtable PrivateB {
+  #PrivateA.noOverrides:  @PrivateA_noOverrides  [inherited]
+  #PrivateA.yesOverrides: @PrivateB_yesOverrides [override]
+  #PrivateA.isFinal:      @PrivateA_isFinal      [inherited]
+}
+
+internal class InternalA {
+  func noOverrides() {}
+  func yesOverrides() {}
+  final func isFinal() {}
+}
+
+sil @InternalA_noOverrides  : $@convention(method) (@guaranteed InternalA) -> ()
+sil @InternalA_yesOverrides : $@convention(method) (@guaranteed InternalA) -> ()
+sil @InternalA_isFinal      : $@convention(method) (@guaranteed InternalA) -> ()
+
+// NOWMO-LABEL: sil_vtable InternalA {
+// NOWMO-NOT:     #InternalA.noOverrides{{.*}} [nonoverridden]
+// NOWMO-NOT:     #InternalA.yesOverrides{{.*}} [nonoverridden]
+// NOWMO:         #InternalA.isFinal{{.*}} [nonoverridden]
+
+// WMO-LABEL: sil_vtable InternalA {
+// WMO:         #InternalA.noOverrides{{.*}} [nonoverridden]
+// WMO-NOT:     #InternalA.yesOverrides{{.*}} [nonoverridden]
+// WMO:         #InternalA.isFinal{{.*}} [nonoverridden]
+sil_vtable InternalA {
+  #InternalA.noOverrides:  @InternalA_noOverrides
+  #InternalA.yesOverrides: @InternalA_yesOverrides
+  #InternalA.isFinal:      @InternalA_isFinal
+}
+
+internal class InternalB: InternalA {
+  override func yesOverrides() {}
+}
+
+sil @InternalB_yesOverrides : $@convention(method) (@guaranteed InternalB) -> ()
+
+sil_vtable InternalB {
+  #InternalA.noOverrides:  @InternalA_noOverrides  [inherited]
+  #InternalA.yesOverrides: @InternalB_yesOverrides [override]
+  #InternalA.isFinal:      @InternalA_isFinal      [inherited]
+}
+
+public class PublicA {
+  public func noOverrides() {}
+  public func yesOverrides() {}
+  public final func isFinal() {}
+}
+
+sil @PublicA_noOverrides  : $@convention(method) (@guaranteed PublicA) -> ()
+sil @PublicA_yesOverrides : $@convention(method) (@guaranteed PublicA) -> ()
+sil @PublicA_isFinal      : $@convention(method) (@guaranteed PublicA) -> ()
+
+// NOWMO-LABEL: sil_vtable PublicA {
+// NOWMO-NOT:     #PublicA.noOverrides{{.*}} [nonoverridden]
+// NOWMO-NOT:     #PublicA.yesOverrides{{.*}} [nonoverridden]
+// NOWMO:         #PublicA.isFinal{{.*}} [nonoverridden]
+
+// WMO-LABEL: sil_vtable PublicA {
+// WMO:         #PublicA.noOverrides{{.*}} [nonoverridden]
+// WMO-NOT:     #PublicA.yesOverrides{{.*}} [nonoverridden]
+// WMO:         #PublicA.isFinal{{.*}} [nonoverridden]
+sil_vtable PublicA {
+  #PublicA.noOverrides:  @PublicA_noOverrides
+  #PublicA.yesOverrides: @PublicA_yesOverrides
+  #PublicA.isFinal:      @PublicA_isFinal
+}
+
+public class PublicB: PublicA {
+  public override func yesOverrides() {}
+}
+
+sil @PublicB_yesOverrides : $@convention(method) (@guaranteed PublicB) -> ()
+
+sil_vtable PublicB {
+  #PublicA.noOverrides:  @PublicA_noOverrides  [inherited]
+  #PublicA.yesOverrides: @PublicB_yesOverrides [override]
+  #PublicA.isFinal:      @PublicA_isFinal      [inherited]
+}
+
+open class OpenA {
+  open func noOverrides() {}
+  open func yesOverrides() {}
+  public final func isFinal() {}
+}
+
+sil @OpenA_noOverrides  : $@convention(method) (@guaranteed OpenA) -> ()
+sil @OpenA_yesOverrides : $@convention(method) (@guaranteed OpenA) -> ()
+sil @OpenA_isFinal      : $@convention(method) (@guaranteed OpenA) -> ()
+
+// NOWMO-LABEL: sil_vtable OpenA {
+// NOWMO-NOT:     #OpenA.noOverrides{{.*}} [nonoverridden]
+// NOWMO-NOT:     #OpenA.yesOverrides{{.*}} [nonoverridden]
+// NOWMO:         #OpenA.isFinal{{.*}} [nonoverridden]
+
+// WMO-LABEL: sil_vtable OpenA {
+// WMO-NOT:     #OpenA.noOverrides{{.*}} [nonoverridden]
+// WMO-NOT:     #OpenA.yesOverrides{{.*}} [nonoverridden]
+// WMO:         #OpenA.isFinal{{.*}} [nonoverridden]
+sil_vtable OpenA {
+  #OpenA.noOverrides:  @OpenA_noOverrides
+  #OpenA.yesOverrides: @OpenA_yesOverrides
+  #OpenA.isFinal:      @OpenA_isFinal
+}
+
+open class OpenB: OpenA {
+  open override func yesOverrides() {}
+}
+
+sil @OpenB_yesOverrides : $@convention(method) (@guaranteed OpenB) -> ()
+
+sil_vtable OpenB {
+  #OpenA.noOverrides:  @PublicA_noOverrides [inherited]
+  #OpenA.yesOverrides: @OpenB_yesOverrides  [override]
+  #OpenA.isFinal:      @PublicA_isFinal     [inherited]
+}


### PR DESCRIPTION
Start with some high-level checks of whether a declaration is formally final, or has no visible overrides
in the domain of the program visible to the SIL module.

We can eventually adopt more of the logic from the Devirtualizer pass to tell whether call sites are
"effectively final", and maybe make the Devirtualizer consume that information applied by this pass.