### PR TITLE
[ModuleInterface] Don't print SPI attributes on unsupported decls

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -991,7 +991,9 @@ void PrintAST::printAttributes(const Decl *D) {
     }
 
     // SPI groups
-    if (Options.PrintSPIs) {
+    if (Options.PrintSPIs &&
+        DeclAttribute::canAttributeAppearOnDeclKind(
+          DAK_SPIAccessControl, D->getKind())) {
       interleave(D->getSPIGroups(),
              [&](Identifier spiName) {
                Printer.printAttrName("_spi", true);

--- a/test/SPI/private_swiftinterface.swift
+++ b/test/SPI/private_swiftinterface.swift
@@ -88,6 +88,20 @@ private class PrivateClassLocal {}
   // CHECK-PUBLIC-NOT: extensionSPIMethod
 }
 
+@_spi(LocalSPI) public protocol SPIProto3 {
+// CHECK-PRIVATE: @_spi(LocalSPI) public protocol SPIProto3
+// CHECK-PUBLIC-NOT: SPIProto3
+
+  associatedtype AssociatedType
+  // CHECK-PRIVATE: associatedtype AssociatedType
+  // CHECK-PRIVATE-NOT: @_spi(LocalSPI) associatedtype AssociatedType
+  // CHECK-PUBLIC-NOT: AssociatedType
+
+  func implicitSPIMethod()
+  // CHECK-PRIVATE: @_spi(LocalSPI) func implicitSPIMethod()
+  // CHECK-PUBLIC-NOT: implicitSPIMethod
+}
+
 // Test the dummy conformance printed to replace private types used in
 // conditional conformances. rdar://problem/63352700
 


### PR DESCRIPTION
When emitting the private swiftinterface, the compiler prints the SPI attribute explicitly even when it is deduced from the context. This can lead to unparsable private swiftinterface files.

As the safest fix, check if the decl type is supported before printing the SPI attribute.

rdar://64039069