### PR TITLE
IRGen: Note use of types in conditional requirements of protocol conformances

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3303,7 +3303,10 @@ llvm::Constant *IRGenModule::emitSwiftProtocols() {
 }
 
 void IRGenModule::addProtocolConformance(ConformanceDescription &&record) {
-  // Add this protocol conformance.
+
+  emitProtocolConformance(record);
+
+  // Add this conformance to the conformance list.
   ProtocolConformances.push_back(std::move(record));
 }
 
@@ -3311,10 +3314,6 @@ void IRGenModule::addProtocolConformance(ConformanceDescription &&record) {
 llvm::Constant *IRGenModule::emitProtocolConformances() {
   if (ProtocolConformances.empty())
     return nullptr;
-
-  // Emit the conformances.
-  for (const auto &record : ProtocolConformances)
-    emitProtocolConformance(record);
 
   // Define the global variable for the conformance list.
   ConstantInitBuilder builder(*this);

--- a/test/IRGen/associated_type_witness.swift
+++ b/test/IRGen/associated_type_witness.swift
@@ -93,6 +93,16 @@ struct Pair<T, U> : P, Q {}
 // GLOBAL-SAME:    @"symbolic{{.*}}23associated_type_witness4PairV{{.*}}"
 // GLOBAL-SAME:  ]
 
+//   Protocol conformance descriptor for Computed : Assocked.
+// GLOBAL-LABEL: @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAMc" = hidden constant
+// GLOBAL-SAME:    i16 4,
+// GLOBAL-SAME:    i16 1,
+
+//    No instantiator function
+// GLOBAL-SAME:    i32 0,
+// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([16 x i8*]* [[PRIVATE:@.*]] to i64), i64 ptrtoint
+// GLOBAL-SAME:  }
+
 struct Computed<T, U> : Assocked {
   typealias Assoc = Pair<T, U>
 }
@@ -116,6 +126,14 @@ protocol DerivedFromSimpleAssoc : HasSimpleAssoc {}
 // GLOBAL-LABEL: @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWp" = internal constant [2 x i8*]
 // GLOBAL-SAME: @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAMc"
 // GLOBAL-SAME: i8* null
+
+//   Protocol conformance descriptor for GenericComputed : DerivedFromSimpleAssoc.
+// GLOBAL-LABEL: @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAMc" = hidden constant
+// GLOBAL-SAME:    i16 2,
+// GLOBAL-SAME:    i16 1,
+
+//   Relative reference to instantiator function
+// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint (void (i8**, %swift.type*, i8**)* @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWI" to i64),
 
 //   Relative reference to private data
 struct GenericComputed<T: P> : DerivedFromSimpleAssoc {
@@ -155,7 +173,6 @@ extension ValidatorType {
 
 // MARK: Failing example
 extension Validator where T == String {
-  // GLOBAL: @"symbolic _____ySS__G 23associated_type_witness9ValidatorVAASSRszlE1VV7FailureV"
   struct V: ValidatorType {
     typealias Data = T // or String
 
@@ -163,21 +180,6 @@ extension Validator where T == String {
   }
 }
 
+// GLOBAL-LABEL: @"symbolic _____ySS__G 23associated_type_witness9ValidatorVAASSRszlE1VV7FailureV"
 
-//   Protocol conformance descriptor for Computed : Assocked.
-// GLOBAL-LABEL: @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAMc" = hidden constant
-// GLOBAL-SAME:    i16 4,
-// GLOBAL-SAME:    i16 1,
 
-//    No instantiator function
-// GLOBAL-SAME:    i32 0,
-// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([16 x i8*]* [[PRIVATE:@.*]] to i64), i64 ptrtoint
-// GLOBAL-SAME:  }
-
-//   Protocol conformance descriptor for GenericComputed : DerivedFromSimpleAssoc.
-// GLOBAL-LABEL: @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAMc" = hidden constant
-// GLOBAL-SAME:    i16 2,
-// GLOBAL-SAME:    i16 1,
-
-//   Relative reference to instantiator function
-// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint (void (i8**, %swift.type*, i8**)* @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWI" to i64),

--- a/test/IRGen/conditional_conformance_typemetadata.swift
+++ b/test/IRGen/conditional_conformance_typemetadata.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -O -emit-ir %s
+// RUN: %target-swift-frontend -O -primary-file %s -emit-ir
+
+// Make sure that we don't crash in IRGen because the only reference to the type
+// E is in the protocol conformance descriptor describing the conditional
+// conformace.
+
+private enum E {}
+
+private protocol P { associatedtype AT }
+
+private struct S<A, B> {}
+
+extension S: P where A == E { typealias AT = B }
+
+print(S<E, Bool>.AT.self)

--- a/test/IRGen/lazy_metadata_no_reflection.swift
+++ b/test/IRGen/lazy_metadata_no_reflection.swift
@@ -34,5 +34,5 @@ public func forceMetadata() {
   takeMetadata(HasPropertyType.self)
 }
 
-// CHECK-LABEL: @"$s4test1SVMn" = hidden constant
 // CHECK-LABEL: @"$s4test1SVSQAAMc" = hidden constant
+// CHECK-LABEL: @"$s4test1SVMn" = hidden constant

--- a/test/IRGen/protocol_conformance_records.swift
+++ b/test/IRGen/protocol_conformance_records.swift
@@ -108,10 +108,6 @@ public struct Concrete : AssociateConformance {
 // -- no flags are set, and no generic witness table follows
 // CHECK-SAME:           i32 0 }
 
-// CHECK-LABEL: @"\01l_protocols"
-// CHECK-SAME: @"$s28protocol_conformance_records8RuncibleMp"
-// CHECK-SAME: @"$s28protocol_conformance_records5SpoonMp"
-
 public protocol Spoon { }
 
 // Conditional conformances
@@ -166,6 +162,10 @@ extension Int : OtherResilientProtocol { }
 extension Dependent : Associate {
   public typealias X = (T, T)
 }
+
+// CHECK-LABEL: @"\01l_protocols"
+// CHECK-SAME: @"$s28protocol_conformance_records8RuncibleMp"
+// CHECK-SAME: @"$s28protocol_conformance_records5SpoonMp"
 
 // CHECK-LABEL: @"\01l_protocol_conformances" = private constant
 // CHECK-SAME: @"$s28protocol_conformance_records15NativeValueTypeVAA8RuncibleAAMc"

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -11,6 +11,24 @@ import SwiftShims
 
 import resilient_protocol
 
+// Protocol conformance descriptor for ResilientConformingType : OtherResilientProtocol
+
+// CHECK: @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAMc" =
+
+// CHECK-SAME: i32 131072,
+
+// -- number of witness table entries
+// CHECK-SAME:   i16 0,
+
+// -- size of private area + 'requires instantiation' bit
+// CHECK-SAME:   i16 1,
+
+// -- instantiator function
+// CHECK-SAME:   i32 0
+
+// CHECK-SAME: }
+
+
 
 // Protocol descriptor for ResilientProtocol
 // CHECK: [[RESILIENT_PROTOCOL_NAME:@.*]] = private constant [18 x i8] c"ResilientProtocol\00
@@ -87,23 +105,6 @@ protocol InternalProtocol {
 
 // CHECK-NOT: @"$s19protocol_resilience26ConformsWithResilientAssocVAA03HaseF0AAWp" = {{(protected )?}}internal 
 
-
-// Protocol conformance descriptor for ResilientConformingType : OtherResilientProtocol
-
-// CHECK: @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAMc" =
-
-// CHECK-SAME: i32 131072,
-
-// -- number of witness table entries
-// CHECK-SAME:   i16 0,
-
-// -- size of private area + 'requires instantiation' bit
-// CHECK-SAME:   i16 1,
-
-// -- instantiator function
-// CHECK-SAME:   i32 0
-
-// CHECK-SAME: }
 
 // ConformsWithRequirements protocol conformance descriptor
 

--- a/test/IRGen/reflection_metadata.swift
+++ b/test/IRGen/reflection_metadata.swift
@@ -7,9 +7,9 @@
 // STRIP_REFLECTION_NAMES_DAG: section "{{[^"]*swift5_assocty|.sw5asty\$B}}
 // STRIP_REFLECTION_NAMES-DAG: section "{{[^"]*swift5_capture|.sw5cptr\$B}}
 // STRIP_REFLECTION_NAMES-DAG: section "{{[^"]*swift5_typeref|.sw5tyrf\$B}}
+// STRIP_REFLECTION_NAMES-DAG: private constant [6 x i8] c"Inner\00", section "{{[^"]*swift5_reflstr|.sw5rfst\$B}}
 // STRIP_REFLECTION_NAMES-NOT: section "{{[^"]*swift5_reflstr|.sw5rfst\$B}}
 // STRIP_REFLECTION_NAMES-NOT: section "{{[^"]*swift5_builtin|.sw5bltn\$B}}
-
 // STRIP_REFLECTION_NAMES-DAG: @"$s19reflection_metadata10MyProtocol_pMF" = internal constant {{.*}}section "{{[^"]*swift5_fieldmd|.sw5flmd\$B}}
 
 // STRIP_REFLECTION_METADATA-NOT: section "{{[^"]*swift5_reflect|.sw5rfst\$B}}


### PR DESCRIPTION
It is possible for the only mention of a conditional requirement to appear in
the protocol conformance record which is too late for lazy metadata type
emission.

SR-12891
rdar://63819461