### PR TITLE
[SymbolGraph] Don't consider @show_in_interface for underscored names

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -738,9 +738,6 @@ bool Decl::hasUnderscoredNaming() const {
   }
 
   if (const auto PD = dyn_cast<ProtocolDecl>(D)) {
-    if (PD->getAttrs().hasAttribute<ShowInInterfaceAttr>()) {
-      return false;
-    }
     StringRef NameStr = PD->getNameStr();
     if (NameStr.startswith("_Builtin")) {
       return true;
@@ -795,6 +792,10 @@ bool Decl::isPrivateStdlibDecl(bool treatNonBuiltinProtocolsAsPublic) const {
   if (isa<ProtocolDecl>(D)) {
     if (treatNonBuiltinProtocolsAsPublic)
       return false;
+  }
+
+  if (D->getAttrs().hasAttribute<ShowInInterfaceAttr>()) {
+    return false;
   }
 
   return hasUnderscoredNaming();

--- a/test/SymbolGraph/Symbols/SkipsPublicUnderscore.swift
+++ b/test/SymbolGraph/Symbols/SkipsPublicUnderscore.swift
@@ -7,6 +7,7 @@ public protocol PublicProtocol {}
 
 // CHECK-NOT: precise:{{.*}}_ProtocolShouldntAppear
 // CHECK-NOT: precise:{{.*}}PublicProtocol
+@_show_in_interface
 public protocol _ProtocolShouldntAppear {}
 
 // CHECK-NOT: _ShouldntAppear


### PR DESCRIPTION
The fact that a declaration has `@_show_in_interface` shouldn't be
used to decide whether something has underscored naming, which
is just one specific kind of check regarding naming only.

Move the check for this attribute out one level.

rdar://63120829