### PR TITLE
[build-script] Make is_build_script_impl_product() a pure method and get rid of default Yes answer.

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/cmark.py
+++ b/utils/swift_build_support/swift_build_support/products/cmark.py
@@ -14,4 +14,10 @@ from . import product
 
 
 class CMark(product.Product):
-    pass
+    @classmethod
+    def is_build_script_impl_product(cls):
+        """is_build_script_impl_product -> bool
+
+        Whether this product is produced by build-script-impl.
+        """
+        return True

--- a/utils/swift_build_support/swift_build_support/products/foundation.py
+++ b/utils/swift_build_support/swift_build_support/products/foundation.py
@@ -15,6 +15,14 @@ from . import product
 
 class Foundation(product.Product):
     @classmethod
+    def is_build_script_impl_product(cls):
+        """is_build_script_impl_product -> bool
+
+        Whether this product is produced by build-script-impl.
+        """
+        return True
+
+    @classmethod
     def product_source_name(cls):
         """product_source_name() -> str
 

--- a/utils/swift_build_support/swift_build_support/products/libcxx.py
+++ b/utils/swift_build_support/swift_build_support/products/libcxx.py
@@ -14,4 +14,10 @@ from . import product
 
 
 class LibCXX(product.Product):
-    pass
+    @classmethod
+    def is_build_script_impl_product(cls):
+        """is_build_script_impl_product -> bool
+
+        Whether this product is produced by build-script-impl.
+        """
+        return True

--- a/utils/swift_build_support/swift_build_support/products/libdispatch.py
+++ b/utils/swift_build_support/swift_build_support/products/libdispatch.py
@@ -15,6 +15,14 @@ from . import product
 
 class LibDispatch(product.Product):
     @classmethod
+    def is_build_script_impl_product(cls):
+        """is_build_script_impl_product -> bool
+
+        Whether this product is produced by build-script-impl.
+        """
+        return True
+
+    @classmethod
     def product_source_name(cls):
         """product_source_name() -> str
 

--- a/utils/swift_build_support/swift_build_support/products/libicu.py
+++ b/utils/swift_build_support/swift_build_support/products/libicu.py
@@ -15,6 +15,14 @@ from . import product
 
 class LibICU(product.Product):
     @classmethod
+    def is_build_script_impl_product(cls):
+        """is_build_script_impl_product -> bool
+
+        Whether this product is produced by build-script-impl.
+        """
+        return True
+
+    @classmethod
     def product_source_name(cls):
         """product_source_name() -> str
 

--- a/utils/swift_build_support/swift_build_support/products/llbuild.py
+++ b/utils/swift_build_support/swift_build_support/products/llbuild.py
@@ -14,4 +14,10 @@ from . import product
 
 
 class LLBuild(product.Product):
-    pass
+    @classmethod
+    def is_build_script_impl_product(cls):
+        """is_build_script_impl_product -> bool
+
+        Whether this product is produced by build-script-impl.
+        """
+        return True

--- a/utils/swift_build_support/swift_build_support/products/lldb.py
+++ b/utils/swift_build_support/swift_build_support/products/lldb.py
@@ -14,4 +14,10 @@ from . import product
 
 
 class LLDB(product.Product):
-    pass
+    @classmethod
+    def is_build_script_impl_product(cls):
+        """is_build_script_impl_product -> bool
+
+        Whether this product is produced by build-script-impl.
+        """
+        return True

--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -34,6 +34,14 @@ class LLVM(product.Product):
         # Add the cmake options for compiler version information.
         self.cmake_options.extend(self._version_flags)
 
+    @classmethod
+    def is_build_script_impl_product(cls):
+        """is_build_script_impl_product -> bool
+
+        Whether this product is produced by build-script-impl.
+        """
+        return True
+
     @property
     def _compiler_vendor_flags(self):
         if self.args.compiler_vendor == "none":

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -55,7 +55,7 @@ class Product(object):
 
         Whether this product is produced by build-script-impl.
         """
-        return True
+        raise NotImplementedError
 
     @classmethod
     def is_swiftpm_unified_build_product(cls):

--- a/utils/swift_build_support/swift_build_support/products/swift.py
+++ b/utils/swift_build_support/swift_build_support/products/swift.py
@@ -45,6 +45,14 @@ class Swift(product.Product):
         self.cmake_options.extend(
             self._enable_experimental_differentiable_programming)
 
+    @classmethod
+    def is_build_script_impl_product(cls):
+        """is_build_script_impl_product -> bool
+
+        Whether this product is produced by build-script-impl.
+        """
+        return True
+
     @property
     def _runtime_sanitizer_flags(self):
         sanitizer_list = []

--- a/utils/swift_build_support/swift_build_support/products/xctest.py
+++ b/utils/swift_build_support/swift_build_support/products/xctest.py
@@ -15,6 +15,14 @@ from . import product
 
 class XCTest(product.Product):
     @classmethod
+    def is_build_script_impl_product(cls):
+        """is_build_script_impl_product -> bool
+
+        Whether this product is produced by build-script-impl.
+        """
+        return True
+
+    @classmethod
     def product_source_name(cls):
         """product_source_name() -> str
 


### PR DESCRIPTION
This forces the code to self document this property. This is just an NFC
refactor.
