### PR TITLE
Simplest fix to a dependency bug.

### DIFF
--- a/lib/AST/AbstractSourceFileDepGraphFactory.cpp
+++ b/lib/AST/AbstractSourceFileDepGraphFactory.cpp
@@ -79,14 +79,30 @@ void AbstractSourceFileDepGraphFactory::addAUsedDecl(
     const DependencyKey &defKey, const DependencyKey &useKey) {
   auto *defNode =
       g.findExistingNodeOrCreateIfNew(defKey, None, false /* = !isProvides */);
+
   // If the depended-upon node is defined in this file, then don't
   // create an arc to the user, when the user is the whole file.
   // Otherwise, if the defNode's type-body fingerprint changes,
   // the whole file will be marked as dirty, losing the benefit of the
   // fingerprint.
-  if (defNode->getIsProvides() &&
-      useKey.getKind() == NodeKind::sourceFileProvide)
-    return;
+
+  //  if (defNode->getIsProvides() &&
+  //      useKey.getKind() == NodeKind::sourceFileProvide)
+  //    return;
+
+  // Turns out the above three lines cause miscompiles, so comment them out
+  // for now. We might want them back if we can change the inputs to this
+  // function to be more precise.
+
+  // Example of a miscompile:
+  // In main.swift
+  // func foo(_: Any) { print("Hello Any") }
+  //    foo(123)
+  // Then add the following line to another file:
+  // func foo(_: Int) { print("Hello Int") }
+  // Although main.swift needs to get recompiled, the commented-out code below
+  // prevents that.
+
   auto nullableUse = g.findExistingNode(useKey);
   assert(nullableUse.isNonNull() && "Use must be an already-added provides");
   auto *useNode = nullableUse.get();

--- a/test/Frontend/Fingerprints/class-fingerprint.swift
+++ b/test/Frontend/Fingerprints/class-fingerprint.swift
@@ -71,9 +71,4 @@
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 
-// RUN: %FileCheck -check-prefix=CHECK-MAINB-RECOMPILED %s < %t/output4
-
-// CHECK-MAINB-RECOMPILED-NOT: Queuing because of dependencies discovered later: {compile: usesB.o <= usesB.swift}
-// CHECK-MAINB-RECOMPILED: Queuing because of dependencies discovered later: {compile: usesA.o <= usesA.swift}
-// CHECK-MAINB-RECOMPILED-NOT: Queuing because of dependencies discovered later: {compile: usesB.o <= usesB.swift}
-
+// RUN: %FileCheck -check-prefix=CHECK-MAINAB-RECOMPILED %s < %t/output4

--- a/test/Frontend/Fingerprints/enum-fingerprint.swift
+++ b/test/Frontend/Fingerprints/enum-fingerprint.swift
@@ -71,9 +71,4 @@
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 
-// RUN: %FileCheck -check-prefix=CHECK-MAINB-RECOMPILED %s < %t/output4
-
-// CHECK-MAINB-RECOMPILED-NOT: Queuing because of dependencies discovered later: {compile: usesB.o <= usesB.swift}
-// CHECK-MAINB-RECOMPILED: Queuing because of dependencies discovered later: {compile: usesA.o <= usesA.swift}
-// CHECK-MAINB-RECOMPILED-NOT: Queuing because of dependencies discovered later: {compile: usesB.o <= usesB.swift}
-
+// RUN: %FileCheck -check-prefix=CHECK-MAINAB-RECOMPILED %s < %t/output4

--- a/test/Frontend/Fingerprints/protocol-fingerprint.swift
+++ b/test/Frontend/Fingerprints/protocol-fingerprint.swift
@@ -71,9 +71,5 @@
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 
-// RUN: %FileCheck -check-prefix=CHECK-MAINB-RECOMPILED %s < %t/output4
-
-// CHECK-MAINB-RECOMPILED-NOT: Queuing because of dependencies discovered later: {compile: usesB.o <= usesB.swift}
-// CHECK-MAINB-RECOMPILED: Queuing because of dependencies discovered later: {compile: usesA.o <= usesA.swift}
-// CHECK-MAINB-RECOMPILED-NOT: Queuing because of dependencies discovered later: {compile: usesB.o <= usesB.swift}
+// RUN: %FileCheck -check-prefix=CHECK-MAINAB-RECOMPILED %s < %t/output4
 

--- a/test/Frontend/Fingerprints/struct-fingerprint.swift
+++ b/test/Frontend/Fingerprints/struct-fingerprint.swift
@@ -71,9 +71,4 @@
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 
-// RUN: %FileCheck -check-prefix=CHECK-MAINB-RECOMPILED %s < %t/output4
-
-// CHECK-MAINB-RECOMPILED-NOT: Queuing because of dependencies discovered later: {compile: usesB.o <= usesB.swift}
-// CHECK-MAINB-RECOMPILED: Queuing because of dependencies discovered later: {compile: usesA.o <= usesA.swift}
-// CHECK-MAINB-RECOMPILED-NOT: Queuing because of dependencies discovered later: {compile: usesB.o <= usesB.swift}
-
+// RUN: %FileCheck -check-prefix=CHECK-MAINAB-RECOMPILED %s < %t/output4

--- a/unittests/Driver/TypeBodyFingerprintsDependencyGraphTests.cpp
+++ b/unittests/Driver/TypeBodyFingerprintsDependencyGraphTests.cpp
@@ -807,10 +807,10 @@ TEST(ModuleDepGraph, UseFingerprints) {
   {
     const auto jobs =
         simulateReload(graph, &job0, {{NodeKind::nominal, {"A1@11", "A2@2"}}});
-    EXPECT_EQ(2u, jobs.size());
+    EXPECT_EQ(3u, jobs.size());
     EXPECT_TRUE(contains(jobs, &job0));
     EXPECT_TRUE(contains(jobs, &job1));
-    EXPECT_FALSE(contains(jobs, &job2));
+    EXPECT_TRUE(contains(jobs, &job2));
     EXPECT_FALSE(contains(jobs, &job3));
   }
 }


### PR DESCRIPTION
Quickest simple fix for a miscompile bug introduced by type-body-fingerprints.