### PR TITLE
[QoI] Detect unintended generic params and provide a note and fixit.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -94,6 +94,9 @@ ERROR(could_not_find_enum_case,none,
 
 NOTE(did_you_mean_raw_type,none,
      "did you mean to specify a raw type on the enum declaration?", ())
+     
+NOTE(did_you_mean_generic_param_as_conformance,none,
+     "did you mean to declare %0 as a protocol conformance for %1?", (DeclName, Type))
 
 NOTE(any_as_anyobject_fixit, none,
      "cast 'Any' to 'AnyObject' or use 'as!' to force downcast to a more specific type to access members", ())

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -31,8 +31,6 @@
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/Types.h"
-#include "swift/AST/GenericEnvironment.h"
-#include "swift/AST/NameLookupRequests.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Parse/Lexer.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -3111,53 +3109,6 @@ DeclName MissingMemberFailure::findCorrectEnumCaseName(
   return (candidate ? candidate->getName() : DeclName());
 }
 
-bool MissingMemberFailure::findUnintendedExtraGenericParam(Type instanceTy, FunctionRefKind functionKind) {
-  auto archetype = instanceTy->getAs<ArchetypeType>();
-  if (!archetype)
-    return false;
-  auto genericTy = archetype->mapTypeOutOfContext()->getAs<GenericTypeParamType>();
-  if (!genericTy)
-    return false;
-  
-  for (auto param : archetype->getGenericEnvironment()->getGenericParams()) {
-    // Find a param at the same depth and one index past the type we're dealing with
-    if (param->getDepth() != genericTy->getDepth() || param->getIndex() != genericTy->getIndex() + 1)
-      continue;
-    
-    auto &cs = getConstraintSystem();
-    auto paramDecl = param->getDecl();
-    auto descriptor = UnqualifiedLookupDescriptor(
-        DeclNameRef(param->getName()), paramDecl->getDeclContext()->getParentForLookup(), paramDecl->getStartLoc(),
-        UnqualifiedLookupFlags::KnownPrivate | UnqualifiedLookupFlags::TypeLookup);
-    auto lookup = evaluateOrDefault(cs.getASTContext().evaluator, UnqualifiedLookupRequest{descriptor}, {});
-    for (auto &result : lookup) {
-      if (auto proto = dyn_cast_or_null<ProtocolDecl>(result.getValueDecl())) {
-        auto memberLookup = cs.performMemberLookup(
-            ConstraintKind::ValueMember, getName().withoutArgumentLabels(),
-            proto->getDeclaredType(), functionKind, getLocator(),
-            /*includeInaccessibleMembers=*/true);
-        if (memberLookup.ViableCandidates.size() || memberLookup.UnviableCandidates.size()) {
-          SourceLoc loc = genericTy->getDecl()->getSourceRange().End;
-          StringRef replacement;
-          
-          if (archetype->getConformsTo().size()) {
-            loc = loc.getAdvancedLoc(archetype->getConformsTo().back()->getName().getLength());
-            replacement = " &";
-          } else {
-            loc = loc.getAdvancedLoc(archetype->getName().getLength());
-            replacement = ":";
-          }
-          emitDiagnosticAt(loc, diag::did_you_mean_generic_param_as_conformance, paramDecl->getName(), archetype)
-              .fixItReplaceChars(loc, loc.getAdvancedLoc(1), replacement);
-          return true;
-        }
-      }
-    }
-    break;
-  }
-  return false;
-}
-
 bool MissingMemberFailure::diagnoseAsError() {
   auto anchor = getRawAnchor();
   auto memberBase = getAnchor();
@@ -3266,7 +3217,6 @@ bool MissingMemberFailure::diagnoseAsError() {
       }
     } else {
       emitBasicError(baseType);
-      findUnintendedExtraGenericParam(instanceTy, FunctionRefKind::DoubleApply);
     }
   } else if (auto moduleTy = baseType->getAs<ModuleType>()) {
     emitDiagnosticAt(::getLoc(memberBase), diag::no_member_of_module,
@@ -3328,7 +3278,6 @@ bool MissingMemberFailure::diagnoseAsError() {
         correction->addFixits(diagnostic);
       } else {
         emitBasicError(baseType);
-        findUnintendedExtraGenericParam(baseType, FunctionRefKind::SingleApply);
       }
     }
   }
@@ -3384,6 +3333,30 @@ bool MissingMemberFailure::diagnoseInLiteralCollectionContext() const {
     }
   }
   return false;
+}
+
+bool UnintendedExtraGenericParamMemberFailure::diagnoseAsError() {
+  MissingMemberFailure::diagnoseAsError();
+
+  auto baseType = resolveType(getBaseType())->getWithoutSpecifierType();
+  auto archetype = baseType->getMetatypeInstanceType()->castTo<ArchetypeType>();
+  auto genericTy =
+      archetype->mapTypeOutOfContext()->castTo<GenericTypeParamType>();
+  SourceLoc loc = genericTy->getDecl()->getSourceRange().End;
+  StringRef replacement;
+
+  if (archetype->getConformsTo().size()) {
+    loc = loc.getAdvancedLoc(
+        archetype->getConformsTo().back()->getName().getLength());
+    replacement = " &";
+  } else {
+    loc = loc.getAdvancedLoc(archetype->getName().getLength());
+    replacement = ":";
+  }
+  emitDiagnosticAt(loc, diag::did_you_mean_generic_param_as_conformance,
+                   ParamName, archetype)
+      .fixItReplaceChars(loc, loc.getAdvancedLoc(1), replacement);
+  return true;
 }
 
 bool InvalidMemberRefOnExistential::diagnoseAsError() {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1039,7 +1039,7 @@ protected:
 ///   let _: Int = s.foo(1, 2) // expected type is `(Int, Int) -> Int`
 /// }
 /// ```
-class MissingMemberFailure final : public InvalidMemberRefFailure {
+class MissingMemberFailure : public InvalidMemberRefFailure {
 public:
   MissingMemberFailure(const Solution &solution, Type baseType,
                        DeclNameRef memberName, ConstraintLocator *locator)
@@ -1066,8 +1066,22 @@ private:
   static DeclName findCorrectEnumCaseName(Type Ty,
                                           TypoCorrectionResults &corrections,
                                           DeclNameRef memberName);
-  
-  bool findUnintendedExtraGenericParam(Type instanceTy, FunctionRefKind functionKind);
+};
+
+class UnintendedExtraGenericParamMemberFailure final
+    : public MissingMemberFailure {
+  Identifier ParamName;
+
+public:
+  UnintendedExtraGenericParamMemberFailure(const Solution &solution,
+                                           Type baseType,
+                                           DeclNameRef memberName,
+                                           Identifier paramName,
+                                           ConstraintLocator *locator)
+      : MissingMemberFailure(solution, baseType, memberName, locator),
+        ParamName(paramName) {}
+
+  bool diagnoseAsError() override;
 };
 
 /// Diagnose cases where a member only accessible on generic constraints

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1066,6 +1066,8 @@ private:
   static DeclName findCorrectEnumCaseName(Type Ty,
                                           TypoCorrectionResults &corrections,
                                           DeclNameRef memberName);
+  
+  bool findUnintendedExtraGenericParam(Type instanceTy, FunctionRefKind functionKind);
 };
 
 /// Diagnose cases where a member only accessible on generic constraints

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -531,6 +531,23 @@ DefineMemberBasedOnUse::create(ConstraintSystem &cs, Type baseType,
       DefineMemberBasedOnUse(cs, baseType, member, alreadyDiagnosed, locator);
 }
 
+bool DefineMemberBasedOnUnintendedGenericParam::diagnose(
+    const Solution &solution, bool asNote) const {
+  UnintendedExtraGenericParamMemberFailure failure(solution, BaseType, Name,
+                                                   ParamName, getLocator());
+  return failure.diagnose(asNote);
+}
+
+DefineMemberBasedOnUnintendedGenericParam *
+DefineMemberBasedOnUnintendedGenericParam::create(ConstraintSystem &cs,
+                                                  Type baseType,
+                                                  DeclNameRef member,
+                                                  Identifier paramName,
+                                                  ConstraintLocator *locator) {
+  return new (cs.getAllocator()) DefineMemberBasedOnUnintendedGenericParam(
+      cs, baseType, member, paramName, locator);
+}
+
 AllowMemberRefOnExistential *
 AllowMemberRefOnExistential::create(ConstraintSystem &cs, Type baseType,
                                     ValueDecl *member, DeclNameRef memberName,

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -884,6 +884,33 @@ public:
   }
 };
 
+class DefineMemberBasedOnUnintendedGenericParam final : public ConstraintFix {
+  Type BaseType;
+  DeclNameRef Name;
+  Identifier ParamName;
+
+  DefineMemberBasedOnUnintendedGenericParam(ConstraintSystem &cs, Type baseType,
+                                            DeclNameRef member,
+                                            Identifier paramName,
+                                            ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::DefineMemberBasedOnUse, locator),
+        BaseType(baseType), Name(member), ParamName(paramName) {}
+
+public:
+  std::string getName() const override {
+    llvm::SmallVector<char, 16> scratch;
+    auto memberName = Name.getString(scratch);
+    return "allow access to invalid member '" + memberName.str() +
+           "' on archetype presumed intended to conform to protocol";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  static DefineMemberBasedOnUnintendedGenericParam *
+  create(ConstraintSystem &cs, Type baseType, DeclNameRef member,
+         Identifier paramName, ConstraintLocator *locator);
+};
+
 class AllowInvalidMemberRef : public ConstraintFix {
   Type BaseType;
   ValueDecl *Member;

--- a/test/Sema/diag_unintended_generic_param.swift
+++ b/test/Sema/diag_unintended_generic_param.swift
@@ -1,0 +1,24 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol Proto {
+  init?(string: String)
+  func foo()
+}
+
+struct TypedFoo<T: Hashable, Proto> {
+  // expected-note@-1 {{did you mean to declare 'Proto' as a protocol conformance for 'T'?}} {{28-29= &}}
+  func foo(value: String) {
+    if let str = T.init(string:value) { // expected-error {{type 'T' has no member 'init'}}
+      print(str)
+    }
+  }
+}
+
+func bar<T, Proto>(arg: T) { // expected-error {{generic parameter 'Proto' is not used in function signature}}
+  // expected-note@-1 {{did you mean to declare 'Proto' as a protocol conformance for 'T'?}} {{11-12=:}}
+  arg.foo() // expected-error {{value of type 'T' has no member 'foo'}}
+}
+
+func baz<T: Hashable, Proto>(arg: T) { // expected-error {{generic parameter 'Proto' is not used in function signature}}
+  arg.ugh() // expected-error {{value of type 'T' has no member 'ugh'}}
+}


### PR DESCRIPTION
I have seen several people make this mistake and wrongly assume that generic parameter conformances use the same separators (`,`) between conformances as happens with conformances in type declarations. When what is intended is forming protocol composition types with `&`.

For example:
```
protocol Proto {
  init?(string: String)
}

struct TypedFoo<T: Hashable, Proto> {
  func foo(value: String) {
    if let str = T.init(string:value) {
      print(str)
    }
  }
}
```
When the unintended extra generic parameter happens in a generic type, as here, the only error is that `type 'T' has no member 'init'`, which is very unhelpful.

This pull request adds a check to that existing missing member failure error that if the base type is an archetype, it looks to see if there is another generic param at the same depth and +1 index (in this case `Proto`), if that generic param name is the name of a protocol, and if that protocol has a member whose name matches the member name we're trying to find.

If so, this now adds a note: `did you mean to declare 'Proto' as a protocol conformance for 'T'?` and a fixit that changes the `,` in `Hashable, Proto` into a ` &`. 