### PR TITLE
Multi-statement closure type inference

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -576,6 +576,10 @@ namespace swift {
     /// Enable experimental support for one-way constraints for the
     /// parameters of closures.
     bool EnableOneWayClosureParameters = false;
+
+    /// Enable experimental support for type inference through multi-statement
+    /// closures.
+    bool EnableMultiStatementClosureInference = false;
   };
 } // end namespace swift
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -659,6 +659,10 @@ def experimental_one_way_closure_params :
   Flag<["-"], "experimental-one-way-closure-params">,
   HelpText<"Enable experimental support for one-way closure parameters">;
 
+def experimental_multi_statement_closures :
+  Flag<["-"], "experimental-multi-statement-closures">,
+  HelpText<"Enable experimental support for type inference in multi-statement closures">;
+
 def prebuilt_module_cache_path :
   Separate<["-"], "prebuilt-module-cache-path">,
   HelpText<"Directory of prebuilt modules for loading module interfaces">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -775,6 +775,8 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
       Args.hasArg(OPT_solver_enable_operator_designated_types);
   Opts.EnableOneWayClosureParameters |=
       Args.hasArg(OPT_experimental_one_way_closure_params);
+  Opts.EnableMultiStatementClosureInference |=
+      Args.hasArg(OPT_experimental_multi_statement_closures);
 
   Opts.DebugConstraintSolver |= Args.hasArg(OPT_debug_constraints);
   Opts.DebugGenericSignatures |= Args.hasArg(OPT_debug_generic_signatures);

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -58,6 +58,15 @@ private:
     if (isa<VarDecl>(decl))
       return;
 
+    // Generate constraints for pattern binding declarations.
+    if (auto patternBinding = dyn_cast<PatternBindingDecl>(decl)) {
+      SolutionApplicationTarget target(patternBinding);
+      if (cs.generateConstraints(target, FreeTypeVariableBinding::Disallow))
+        hadError = true;
+
+      return;
+    }
+
     llvm_unreachable("Unimplemented case for closure body");
   }
 
@@ -171,6 +180,20 @@ private:
   }
 
   void visitDecl(Decl *decl) {
+    // Ignore variable declarations, because they're always handled within
+    // their enclosing pattern bindings.
+    if (isa<VarDecl>(decl))
+      return;
+
+    // Generate constraints for pattern binding declarations.
+    if (auto patternBinding = dyn_cast<PatternBindingDecl>(decl)) {
+      SolutionApplicationTarget target(patternBinding);
+      if (!rewriteTarget(target))
+        hadError = true;
+
+      return;
+    }
+
     llvm_unreachable("Declarations not supported");
   }
 

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -86,6 +86,10 @@ private:
     }
   }
 
+  void visitDoStmt(DoStmt *doStmt) {
+    visit(doStmt->getBody());
+  }
+
   void visitReturnStmt(ReturnStmt *returnStmt) {
     auto expr = returnStmt->getResult();
 
@@ -117,7 +121,6 @@ private:
   UNSUPPORTED_STMT(If)
   UNSUPPORTED_STMT(Guard)
   UNSUPPORTED_STMT(While)
-  UNSUPPORTED_STMT(Do)
   UNSUPPORTED_STMT(DoCatch)
   UNSUPPORTED_STMT(RepeatWhile)
   UNSUPPORTED_STMT(ForEach)
@@ -215,6 +218,12 @@ private:
     return braceStmt;
   }
 
+  ASTNode visitDoStmt(DoStmt *doStmt) {
+    auto body = visit(doStmt->getBody()).get<Stmt *>();
+    doStmt->setBody(cast<BraceStmt>(body));
+    return doStmt;
+  }
+
   ASTNode visitReturnStmt(ReturnStmt *returnStmt) {
     auto resultExpr = returnStmt->getResult();
     if (!resultExpr)
@@ -289,7 +298,6 @@ private:
   UNSUPPORTED_STMT(If)
   UNSUPPORTED_STMT(Guard)
   UNSUPPORTED_STMT(While)
-  UNSUPPORTED_STMT(Do)
   UNSUPPORTED_STMT(DoCatch)
   UNSUPPORTED_STMT(RepeatWhile)
   UNSUPPORTED_STMT(ForEach)

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -174,12 +174,12 @@ private:
 
   void visitBreakStmt(BreakStmt *breakStmt) { }
   void visitContinueStmt(ContinueStmt *continueStmt) { }
+  void visitDeferStmt(DeferStmt *deferStmt) { }
 
 #define UNSUPPORTED_STMT(STMT) void visit##STMT##Stmt(STMT##Stmt *) { \
       llvm_unreachable("Unsupported statement kind " #STMT);          \
   }
   UNSUPPORTED_STMT(Yield)
-  UNSUPPORTED_STMT(Defer)
   UNSUPPORTED_STMT(DoCatch)
   UNSUPPORTED_STMT(Switch)
   UNSUPPORTED_STMT(Case)
@@ -440,11 +440,20 @@ private:
     return continueStmt;
   }
 
+  ASTNode visitDeferStmt(DeferStmt *deferStmt) {
+    TypeChecker::typeCheckDecl(deferStmt->getTempDecl());
+
+    Expr *theCall = deferStmt->getCallExpr();
+    TypeChecker::typeCheckExpression(theCall, closure);
+    deferStmt->setCallExpr(theCall);
+
+    return deferStmt;
+  }
+
 #define UNSUPPORTED_STMT(STMT) ASTNode visit##STMT##Stmt(STMT##Stmt *) { \
       llvm_unreachable("Unsupported statement kind " #STMT);          \
   }
   UNSUPPORTED_STMT(Yield)
-  UNSUPPORTED_STMT(Defer)
   UNSUPPORTED_STMT(DoCatch)
   UNSUPPORTED_STMT(Switch)
   UNSUPPORTED_STMT(Case)

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7523,7 +7523,8 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
   // type.
   bool oneWayConstraints =
     getASTContext().TypeCheckerOpts.EnableOneWayClosureParameters ||
-    functionBuilderType;
+    functionBuilderType ||
+    !closure->hasSingleExpressionBody();
 
   auto *paramList = closure->getParameters();
   SmallVector<AnyFunctionType::Param, 4> parameters;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -892,6 +892,7 @@ public:
   enum class Kind {
     empty,
     tombstone,
+    expr,
     stmtCondElement,
     stmt,
     patternBindingEntry,
@@ -903,6 +904,8 @@ private:
 
   union {
     const StmtConditionElement *stmtCondElement;
+
+    const Expr *expr;
 
     const Stmt *stmt;
 
@@ -923,6 +926,11 @@ public:
   SolutionApplicationTargetsKey(const StmtConditionElement *stmtCondElement) {
     kind = Kind::stmtCondElement;
     storage.stmtCondElement = stmtCondElement;
+  }
+
+  SolutionApplicationTargetsKey(const Expr *expr) {
+    kind = Kind::expr;
+    storage.expr = expr;
   }
 
   SolutionApplicationTargetsKey(const Stmt *stmt) {
@@ -954,6 +962,9 @@ public:
 
     case Kind::stmtCondElement:
       return lhs.storage.stmtCondElement == rhs.storage.stmtCondElement;
+
+    case Kind::expr:
+      return lhs.storage.expr == rhs.storage.expr;
 
     case Kind::stmt:
       return lhs.storage.stmt == rhs.storage.stmt;
@@ -993,6 +1004,11 @@ public:
       return hash_combine(
           DenseMapInfo<unsigned>::getHashValue(static_cast<unsigned>(kind)),
           DenseMapInfo<void *>::getHashValue(storage.stmt));
+
+    case Kind::expr:
+      return hash_combine(
+          DenseMapInfo<unsigned>::getHashValue(static_cast<unsigned>(kind)),
+          DenseMapInfo<void *>::getHashValue(storage.expr));
 
     case Kind::patternBindingEntry:
       return hash_combine(

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3906,7 +3906,9 @@ HasDynamicCallableAttributeRequest::evaluate(Evaluator &evaluator,
 }
 
 bool swift::shouldTypeCheckInEnclosingExpression(ClosureExpr *expr) {
-  return expr->hasSingleExpressionBody();
+  auto &ctx = expr->getASTContext();
+  return expr->hasSingleExpressionBody() ||
+    ctx.TypeCheckerOpts.EnableMultiStatementClosureInference;
 }
 
 void swift::forEachExprInConstraintSystem(

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1318,6 +1318,10 @@ namespace {
     std::pair<bool, Stmt *> walkToStmtPre(Stmt *stmt) override {
       return { true, stmt };
     }
+
+    std::pair<bool, Pattern *> walkToPatternPre(Pattern *pattern) override {
+      return { false, pattern };
+    }
   };
 } // end anonymous namespace
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1324,8 +1324,8 @@ public:
     // There is nothing more to do.
     return S;
   }
-
 };
+
 } // end anonymous namespace
 
 static bool isDiscardableType(Type type) {

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -401,7 +401,7 @@ static LabeledStmt *findUnlabeledBreakOrContinueStmtTarget(
 ///
 /// \returns the target, if one was found, or \c nullptr if no such target
 /// exists.
-static LabeledStmt *findBreakOrContinueStmtTarget(
+LabeledStmt *swift::findBreakOrContinueStmtTarget(
     ASTContext &ctx, SourceFile *sourceFile,
     SourceLoc loc, Identifier targetName, SourceLoc targetLoc,
     bool isContinue, DeclContext *dc,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1365,6 +1365,16 @@ bool areGenericRequirementsSatisfied(const DeclContext *DC,
                                      SubstitutionMap Substitutions,
                                      bool isExtension);
 
+/// Find the target of a break or continue statement.
+///
+/// \returns the target, if one was found, or \c nullptr if no such target
+/// exists.
+LabeledStmt *findBreakOrContinueStmtTarget(
+    ASTContext &ctx, SourceFile *sourceFile,
+    SourceLoc loc, Identifier targetName, SourceLoc targetLoc,
+    bool isContinue, DeclContext *dc,
+    ArrayRef<LabeledStmt *> oldActiveLabeledStmts);
+
 /// Check for restrictions on the use of the @unknown attribute on a
 /// case statement.
 void checkUnknownAttrRestrictions(

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1375,6 +1375,11 @@ LabeledStmt *findBreakOrContinueStmtTarget(
     bool isContinue, DeclContext *dc,
     ArrayRef<LabeledStmt *> oldActiveLabeledStmts);
 
+/// Check the correctness of a 'fallthrough' statement.
+///
+/// \returns true if an error occurred.
+bool checkFallthroughStmt(DeclContext *dc, FallthroughStmt *stmt);
+
 /// Check for restrictions on the use of the @unknown attribute on a
 /// case statement.
 void checkUnknownAttrRestrictions(

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -3,7 +3,9 @@
 func mapWithMoreStatements(ints: [Int]) {
   let _ = ints.map { i in
     let value = i + 1
-    print(value)
+    do {
+      print(value)
+    }
     return String(value)
   }
 }

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -33,6 +33,10 @@ func mapWithMoreStatements(ints: [Int]) {
       print("still here")
     } while random(i)
 
+    for j in 0..<i where j % 2 == 0 {
+      print("even")
+    }
+
     return String(value)
   }
 }

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -2,7 +2,8 @@
 
 func mapWithMoreStatements(ints: [Int]) {
   let _ = ints.map { i in
-    print(i)
-    return String(i)
+    let value = i + 1
+    print(value)
+    return String(value)
   }
 }

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -4,9 +4,17 @@ func isInt<T>(_ value: T) -> Bool {
   return value is Int
 }
 
+func maybeGetValue<T>(_ value: T) -> T? {
+  return value
+}
+
 func mapWithMoreStatements(ints: [Int]) {
   let _ = ints.map { i in
-    let value = i + 1
+    guard let actualValue = maybeGetValue(i) else {
+      return String(0)
+    }
+
+    let value = actualValue + 1
     do {
       if isInt(i) {
         print(value)

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -10,7 +10,7 @@ func maybeGetValue<T>(_ value: T) -> T? {
 
 func mapWithMoreStatements(ints: [Int]) {
   let _ = ints.map { i in
-    guard let actualValue = maybeGetValue(i) else {
+    guard var actualValue = maybeGetValue(i) else {
       return String(0)
     }
 
@@ -22,6 +22,11 @@ func mapWithMoreStatements(ints: [Int]) {
         print("seventeen!")
       }
     }
+
+    while actualValue < 100 {
+      actualValue += 1
+    }
+
     return String(value)
   }
 }

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -80,6 +80,17 @@ func mapWithMoreStatements(ints: [Int], state: State) throws {
 
     #assert(true)
 
+    // expected-warning@+1{{danger zone}}
+    #warning("danger zone")
+
+#if false
+    struct NothingHere { }
+#else
+    struct NestedStruct {
+      var x: Int
+    }
+#endif
+
     do {
       print(try mightThrow())
     } catch let e as MyError {

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -8,10 +8,14 @@ func maybeGetValue<T>(_ value: T) -> T? {
   return value
 }
 
+enum MyError: Error {
+  case featureIsTooCool
+}
+
 func random(_: Int) -> Bool { return false }
 
-func mapWithMoreStatements(ints: [Int]) {
-  let _ = ints.map { i in
+func mapWithMoreStatements(ints: [Int]) throws {
+  let _ = try ints.map { i in
     guard var actualValue = maybeGetValue(i) else {
       return String(0)
     }
@@ -46,7 +50,9 @@ func mapWithMoreStatements(ints: [Int]) {
       if j % 7 == 0 {
         continue
       }
+ 
       print("even")
+      throw MyError.featureIsTooCool
     }
 
     return String(value)

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -29,11 +29,19 @@ func mapWithMoreStatements(ints: [Int]) {
       actualValue += 1
     }
 
+  my_repeat:
     repeat {
       print("still here")
+
+      if i % 7 == 0 {
+        break my_repeat
+      }
     } while random(i)
 
     for j in 0..<i where j % 2 == 0 {
+      if j % 7 == 0 {
+        continue
+      }
       print("even")
     }
 

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -12,9 +12,15 @@ enum MyError: Error {
   case featureIsTooCool
 }
 
+enum State {
+  case suspended
+  case partial(Int, Int)
+  case finished
+}
+
 func random(_: Int) -> Bool { return false }
 
-func mapWithMoreStatements(ints: [Int]) throws {
+func mapWithMoreStatements(ints: [Int], state: State) throws {
   let _ = try ints.map { i in
     guard var actualValue = maybeGetValue(i) else {
       return String(0)
@@ -51,6 +57,19 @@ func mapWithMoreStatements(ints: [Int]) throws {
         continue
       }
 
+      switch (state, j) {
+      case (.suspended, 0):
+        print("something")
+        fallthrough
+      case (.finished, 0):
+        print("something else")
+
+      case (.partial(let current, let end), let j):
+        print("\(current) of \(end): \(j)")
+
+      default:
+        print("so, here we are")
+      }
       print("even")
       throw MyError.featureIsTooCool
     }

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -10,6 +10,8 @@ func maybeGetValue<T>(_ value: T) -> T? {
 
 enum MyError: Error {
   case featureIsTooCool
+
+  func doIt() { }
 }
 
 enum State {
@@ -19,6 +21,8 @@ enum State {
 }
 
 func random(_: Int) -> Bool { return false }
+
+func mightThrow() throws -> Bool { throw MyError.featureIsTooCool }
 
 func mapWithMoreStatements(ints: [Int], state: State) throws {
   let _ = try ints.map { i in
@@ -76,6 +80,13 @@ func mapWithMoreStatements(ints: [Int], state: State) throws {
 
     #assert(true)
 
+    do {
+      print(try mightThrow())
+    } catch let e as MyError {
+      e.doIt()
+    } catch {
+      print(error)
+    }
     return String(value)
   }
 }

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5 -experimental-multi-statement-closures
+
+func mapWithMoreStatements(ints: [Int]) {
+  let _ = ints.map { i in
+    print(i)
+    return String(i)
+  }
+}

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -1,10 +1,18 @@
 // RUN: %target-typecheck-verify-swift -swift-version 5 -experimental-multi-statement-closures
 
+func isInt<T>(_ value: T) -> Bool {
+  return value is Int
+}
+
 func mapWithMoreStatements(ints: [Int]) {
   let _ = ints.map { i in
     let value = i + 1
     do {
-      print(value)
+      if isInt(i) {
+        print(value)
+      } else if value == 17 {
+        print("seventeen!")
+      }
     }
     return String(value)
   }

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -8,6 +8,8 @@ func maybeGetValue<T>(_ value: T) -> T? {
   return value
 }
 
+func random(_: Int) -> Bool { return false }
+
 func mapWithMoreStatements(ints: [Int]) {
   let _ = ints.map { i in
     guard var actualValue = maybeGetValue(i) else {
@@ -26,6 +28,10 @@ func mapWithMoreStatements(ints: [Int]) {
     while actualValue < 100 {
       actualValue += 1
     }
+
+    repeat {
+      print("still here")
+    } while random(i)
 
     return String(value)
   }

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -101,3 +101,13 @@ func mapWithMoreStatements(ints: [Int], state: State) throws {
     return String(value)
   }
 }
+
+func acceptsWhateverClosure<T, R>(_ value: T, _ fn: (T) -> R) { }
+
+func testReturnWithoutExpr(i: Int) {
+  acceptsWhateverClosure(i) { i in
+    print(i)
+    return
+  }
+}
+

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 -experimental-multi-statement-closures
+// RUN: %target-typecheck-verify-swift -swift-version 5 -experimental-multi-statement-closures -enable-experimental-static-assert
 
 func isInt<T>(_ value: T) -> Bool {
   return value is Int
@@ -50,10 +50,12 @@ func mapWithMoreStatements(ints: [Int]) throws {
       if j % 7 == 0 {
         continue
       }
- 
+
       print("even")
       throw MyError.featureIsTooCool
     }
+
+    #assert(true)
 
     return String(value)
   }

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -38,6 +38,10 @@ func mapWithMoreStatements(ints: [Int]) {
       }
     } while random(i)
 
+    defer {
+      print("I am so done here")
+    }
+
     for j in 0..<i where j % 2 == 0 {
       if j % 7 == 0 {
         continue


### PR DESCRIPTION
Introduce support for type inference of closures with multiple
statements. Type inference flows from the closure parameters through
the body of the closure to determine the return type. This, for example,
allows a "map" closure with multiple statements to infer the result type
based on the "return" in the body:

    let _ = ints.map { i in
      let value = i + 1
      return String(value)
    }

The frontend option `-experimental-multi-statement-closures` enables
this new behavior. It should cover all statement and declaration kinds
in a closure now:

- [x] Expressions
- [x] Brace statements
- [x] `var`/`let` declarations (note: only when there is also an initializer)
- [x] `do` statements (without a catch)
- [x] `do` statements (with catch clauses)
- [x] `if` statements
- [x] `guard` statements
- [x] `while` loops
- [x] repeat-while loops
- [x] `for`..`in` loops
- [x] `throw` statements
- [x] `defer` statements
- [x] `break` and `continue`
- [x] `switch` statements
- [x] `#assert` statements
- [x] Other kinds of declarations (local types, etc.)