### PR TITLE
[build-script] Add dependencies for all build-script products as a first approximation.

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/benchmarks.py
+++ b/utils/swift_build_support/swift_build_support/products/benchmarks.py
@@ -57,6 +57,20 @@ class Benchmarks(product.Product):
     def install(self, host_target):
         pass
 
+    @classmethod
+    def get_dependencies(cls):
+        return [product.CMark,
+                product.LLVM,
+                product.LibCXX,
+                product.LibICU,
+                product.Swift,
+                product.LLDB,
+                product.LibDispatch,
+                product.Foundation,
+                product.XCTest,
+                product.LLBuild,
+                product.SwiftPM]
+
 
 def run_build_script_helper(host_target, product, args):
     toolchain_path = args.install_destdir

--- a/utils/swift_build_support/swift_build_support/products/cmark.py
+++ b/utils/swift_build_support/swift_build_support/products/cmark.py
@@ -21,3 +21,8 @@ class CMark(product.Product):
         Whether this product is produced by build-script-impl.
         """
         return True
+
+    # This is the root of the build-graph, so it doesn't have any dependencies.
+    @classmethod
+    def get_dependencies(cls):
+        return []

--- a/utils/swift_build_support/swift_build_support/products/foundation.py
+++ b/utils/swift_build_support/swift_build_support/products/foundation.py
@@ -29,3 +29,13 @@ class Foundation(product.Product):
         The name of the source code directory of this product.
         """
         return "swift-corelibs-foundation"
+
+    @classmethod
+    def get_dependencies(cls):
+        return [product.CMark,
+                product.LLVM,
+                product.LibCXX,
+                product.LibICU,
+                product.Swift,
+                product.LLDB,
+                product.LibDispatch]

--- a/utils/swift_build_support/swift_build_support/products/indexstoredb.py
+++ b/utils/swift_build_support/swift_build_support/products/indexstoredb.py
@@ -45,6 +45,21 @@ class IndexStoreDB(product.Product):
     def install(self, host_target):
         pass
 
+    @classmethod
+    def get_dependencies(cls):
+        return [product.CMark,
+                product.LLVM,
+                product.LibCXX,
+                product.LibICU,
+                product.Swift,
+                product.LLDB,
+                product.LibDispatch,
+                product.Foundation,
+                product.XCTest,
+                product.LLBuild,
+                product.SwiftPM,
+                product.SwiftSyntax]
+
 
 def run_build_script_helper(action, host_target, product, args,
                             sanitize_all=False):

--- a/utils/swift_build_support/swift_build_support/products/libcxx.py
+++ b/utils/swift_build_support/swift_build_support/products/libcxx.py
@@ -21,3 +21,8 @@ class LibCXX(product.Product):
         Whether this product is produced by build-script-impl.
         """
         return True
+
+    @classmethod
+    def get_dependencies(cls):
+        return [product.CMark,
+                product.LLVM]

--- a/utils/swift_build_support/swift_build_support/products/libdispatch.py
+++ b/utils/swift_build_support/swift_build_support/products/libdispatch.py
@@ -29,3 +29,12 @@ class LibDispatch(product.Product):
         The name of the source code directory of this product.
         """
         return "swift-corelibs-libdispatch"
+
+    @classmethod
+    def get_dependencies(cls):
+        return [product.CMark,
+                product.LLVM,
+                product.LibCXX,
+                product.LibICU,
+                product.Swift,
+                product.LLDB]

--- a/utils/swift_build_support/swift_build_support/products/libicu.py
+++ b/utils/swift_build_support/swift_build_support/products/libicu.py
@@ -29,3 +29,9 @@ class LibICU(product.Product):
         The name of the source code directory of this product.
         """
         return "icu"
+
+    @classmethod
+    def get_dependencies(cls):
+        return [product.CMark,
+                product.LLVM,
+                product.LibCXX]

--- a/utils/swift_build_support/swift_build_support/products/llbuild.py
+++ b/utils/swift_build_support/swift_build_support/products/llbuild.py
@@ -21,3 +21,15 @@ class LLBuild(product.Product):
         Whether this product is produced by build-script-impl.
         """
         return True
+
+    @classmethod
+    def get_dependencies(cls):
+        return [product.CMark,
+                product.LLVM,
+                product.LibCXX,
+                product.LibICU,
+                product.Swift,
+                product.LLDB,
+                product.LibDispatch,
+                product.Foundation,
+                product.XCTest]

--- a/utils/swift_build_support/swift_build_support/products/lldb.py
+++ b/utils/swift_build_support/swift_build_support/products/lldb.py
@@ -21,3 +21,11 @@ class LLDB(product.Product):
         Whether this product is produced by build-script-impl.
         """
         return True
+
+    @classmethod
+    def get_dependencies(cls):
+        return [product.CMark,
+                product.LLVM,
+                product.LibCXX,
+                product.LibICU,
+                product.Swift]

--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -65,3 +65,7 @@ class LLVM(product.Product):
                 'CLANG_REPOSITORY_STRING',
                 "clang-{}".format(self.args.clang_compiler_version))
         return result
+
+    @classmethod
+    def get_dependencies(cls):
+        return [product.CMark]

--- a/utils/swift_build_support/swift_build_support/products/playgroundsupport.py
+++ b/utils/swift_build_support/swift_build_support/products/playgroundsupport.py
@@ -110,3 +110,17 @@ class PlaygroundSupport(product.Product):
                 "TOOLCHAIN_INSTALL_DIR={}".format(toolchain_prefix),
                 "BUILD_PLAYGROUND_LOGGER_TESTS=NO",
             ])
+
+    @classmethod
+    def get_dependencies(cls):
+        return [product.CMark,
+                product.LLVM,
+                product.LibCXX,
+                product.LibICU,
+                product.Swift,
+                product.LLDB,
+                product.LibDispatch,
+                product.Foundation,
+                product.XCTest,
+                product.LLBuild,
+                product.SwiftPM]

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -66,6 +66,11 @@ class Product(object):
         """
         return False
 
+    @classmethod
+    def get_dependencies(cls):
+        """Return a list of products that this product depends upon"""
+        raise NotImplementedError
+
     def should_build(self, host_target):
         """should_build() -> Bool
 

--- a/utils/swift_build_support/swift_build_support/products/pythonkit.py
+++ b/utils/swift_build_support/swift_build_support/products/pythonkit.py
@@ -79,3 +79,17 @@ class PythonKit(product.Product):
             '--build', self.build_dir,
             '--target', 'install',
         ])
+
+    @classmethod
+    def get_dependencies(cls):
+        return [product.CMark,
+                product.LLVM,
+                product.LibCXX,
+                product.LibICU,
+                product.Swift,
+                product.LLDB,
+                product.LibDispatch,
+                product.Foundation,
+                product.XCTest,
+                product.LLBuild,
+                product.SwiftPM]

--- a/utils/swift_build_support/swift_build_support/products/skstresstester.py
+++ b/utils/swift_build_support/swift_build_support/products/skstresstester.py
@@ -1,4 +1,3 @@
-
 # swift_build_support/products/skstresstester.py -----------------*- python -*-
 #
 # This source file is part of the Swift.org open source project
@@ -90,3 +89,18 @@ class SKStressTester(product.Product):
         self.run_build_script_helper('install', [
             '--prefix', install_prefix
         ])
+
+    @classmethod
+    def get_dependencies(cls):
+        return [product.CMark,
+                product.LLVM,
+                product.LibCXX,
+                product.LibICU,
+                product.Swift,
+                product.LLDB,
+                product.LibDispatch,
+                product.Foundation,
+                product.XCTest,
+                product.LLBuild,
+                product.SwiftPM,
+                product.SwiftSyntax]

--- a/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
+++ b/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
@@ -44,3 +44,17 @@ class SourceKitLSP(product.Product):
     def install(self, host_target):
         indexstoredb.run_build_script_helper(
             'install', host_target, self, self.args)
+
+    @classmethod
+    def get_dependencies(cls):
+        return [product.CMark,
+                product.LLVM,
+                product.LibCXX,
+                product.LibICU,
+                product.Swift,
+                product.LLDB,
+                product.LibDispatch,
+                product.Foundation,
+                product.XCTest,
+                product.LLBuild,
+                product.SwiftPM]

--- a/utils/swift_build_support/swift_build_support/products/swift.py
+++ b/utils/swift_build_support/swift_build_support/products/swift.py
@@ -129,3 +129,10 @@ updated without updating swift.py?")
     def _enable_experimental_differentiable_programming(self):
         return [('SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING:BOOL',
                  self.args.enable_experimental_differentiable_programming)]
+
+    @classmethod
+    def get_dependencies(cls):
+        return [product.CMark,
+                product.LLVM,
+                product.LibCXX,
+                product.LibICU]

--- a/utils/swift_build_support/swift_build_support/products/swiftevolve.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftevolve.py
@@ -10,6 +10,7 @@
 #
 # ----------------------------------------------------------------------------
 
+from . import product
 from . import skstresstester
 
 
@@ -35,3 +36,19 @@ class SwiftEvolve(skstresstester.SKStressTester):
 
     def should_install(self, host_target):
         return self.args.install_swiftevolve
+
+    @classmethod
+    def get_dependencies(cls):
+        return [product.CMark,
+                product.LLVM,
+                product.LibCXX,
+                product.LibICU,
+                product.Swift,
+                product.LLDB,
+                product.LibDispatch,
+                product.Foundation,
+                product.XCTest,
+                product.LLBuild,
+                product.SwiftPM,
+                product.SwiftSyntax,
+                product.SKStressTester]

--- a/utils/swift_build_support/swift_build_support/products/swiftinspect.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftinspect.py
@@ -49,6 +49,20 @@ class SwiftInspect(product.Product):
     def install(self, host_target):
         pass
 
+    @classmethod
+    def get_dependencies(cls):
+        return [product.CMark,
+                product.LLVM,
+                product.LibCXX,
+                product.LibICU,
+                product.Swift,
+                product.LLDB,
+                product.LibDispatch,
+                product.Foundation,
+                product.XCTest,
+                product.LLBuild,
+                product.SwiftPM]
+
 
 def run_build_script_helper(host_target, product, args):
     toolchain_path = args.install_destdir

--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -93,3 +93,16 @@ class SwiftPM(product.Product):
         self.run_bootstrap_script('install', host_target, [
             '--prefix', install_prefix
         ])
+
+    @classmethod
+    def get_dependencies(cls):
+        return [product.CMark,
+                product.LLVM,
+                product.LibCXX,
+                product.LibICU,
+                product.Swift,
+                product.LLDB,
+                product.LibDispatch,
+                product.Foundation,
+                product.XCTest,
+                product.LLBuild]

--- a/utils/swift_build_support/swift_build_support/products/swiftsyntax.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftsyntax.py
@@ -91,3 +91,17 @@ class SwiftSyntax(product.Product):
 
         self.run_swiftsyntax_build_script(target=target_name,
                                           additional_params=additional_params)
+
+    @classmethod
+    def get_dependencies(cls):
+        return [product.CMark,
+                product.LLVM,
+                product.LibCXX,
+                product.LibICU,
+                product.Swift,
+                product.LLDB,
+                product.LibDispatch,
+                product.Foundation,
+                product.XCTest,
+                product.LLBuild,
+                product.SwiftPM]

--- a/utils/swift_build_support/swift_build_support/products/tensorflow.py
+++ b/utils/swift_build_support/swift_build_support/products/tensorflow.py
@@ -79,3 +79,17 @@ class TensorFlowSwiftAPIs(product.Product):
             '--build', self.build_dir,
             '--target', 'install',
         ])
+
+    @classmethod
+    def get_dependencies(cls):
+        return [product.CMark,
+                product.LLVM,
+                product.LibCXX,
+                product.LibICU,
+                product.Swift,
+                product.LLDB,
+                product.LibDispatch,
+                product.Foundation,
+                product.XCTest,
+                product.LLBuild,
+                product.SwiftPM]

--- a/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
+++ b/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
@@ -78,3 +78,17 @@ class TSanLibDispatch(product.Product):
 
     def install(self, host_target):
         pass
+
+    @classmethod
+    def get_dependencies(cls):
+        return [product.CMark,
+                product.LLVM,
+                product.LibCXX,
+                product.LibICU,
+                product.Swift,
+                product.LLDB,
+                product.LibDispatch,
+                product.Foundation,
+                product.XCTest,
+                product.LLBuild,
+                product.SwiftPM]

--- a/utils/swift_build_support/swift_build_support/products/xctest.py
+++ b/utils/swift_build_support/swift_build_support/products/xctest.py
@@ -29,3 +29,14 @@ class XCTest(product.Product):
         The name of the source code directory of this product.
         """
         return "swift-corelibs-xctest"
+
+    @classmethod
+    def get_dependencies(cls):
+        return [product.CMark,
+                product.LLVM,
+                product.LibCXX,
+                product.LibICU,
+                product.Swift,
+                product.LLDB,
+                product.LibDispatch,
+                product.Foundation]


### PR DESCRIPTION
In most cases, I followed the ordering of dependencies defined already by
build-script's product classes. In a subsequent commit I am going to add an
option (disabled by default) that schedules this via a simple topological sort
based on proving our dep graph is a DAG and using RPOT numbers.
