### PR TITLE
[POC] Extensible protocol conformances attempt III

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -335,7 +335,14 @@ private:
   llvm::BumpPtrAllocator &
   getAllocator(AllocationArena arena = AllocationArena::Permanent) const;
 
+  /// Record of conformances that have come about by extending a protocol
+  llvm::DenseMap<ProtocolDecl *, llvm::DenseMap<NominalTypeDecl *,
+                              ExtensionDecl *>> ExtendedConformances;
+
 public:
+  llvm::DenseMap<ProtocolDecl *, llvm::DenseMap<NominalTypeDecl *,
+    ExtensionDecl *>> &getExtendedConformances() { return ExtendedConformances; }
+
   /// Allocate - Allocate memory from the ASTContext bump pointer.
   void *Allocate(unsigned long bytes, unsigned alignment,
                  AllocationArena arena = AllocationArena::Permanent) const {
@@ -728,6 +735,12 @@ public:
   /// contains extensions loaded from any generation up to and including this
   /// one.
   void loadExtensions(NominalTypeDecl *nominal, unsigned previousGeneration);
+
+  /// Iterate over conformances arising from protocol extensions.
+  ///
+  /// \param emitWitness A function to call to emit a witness table.
+  void forEachExtendedConformance(ModuleDecl *module,
+                std::function<void (NormalProtocolConformance *)> emitWitness);
 
   /// Load the methods within the given class that produce
   /// Objective-C class or instance methods with the given selector.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1754,7 +1754,7 @@ public:
   MutableArrayRef<TypeLoc> getInherited() { return Inherited; }
   ArrayRef<TypeLoc> getInherited() const { return Inherited; }
 
-  void setInherited(MutableArrayRef<TypeLoc> i) { Inherited = i; }
+  void setInherited(MutableArrayRef<TypeLoc> i);
 
   bool hasDefaultAccessLevel() const {
     return Bits.ExtensionDecl.DefaultAndMaxAccessLevel != 0;
@@ -3367,9 +3367,6 @@ class NominalTypeDecl : public GenericTypeDecl, public IterableDeclContext {
   /// a given nominal type.
   mutable ConformanceLookupTable *ConformanceTable = nullptr;
 
-  /// Prepare the conformance table.
-  void prepareConformanceTable() const;
-
   /// Returns the protocol requirements that \c Member conforms to.
   ArrayRef<ValueDecl *>
     getSatisfiedProtocolRequirementsForMember(const ValueDecl *Member,
@@ -3478,6 +3475,9 @@ public:
   /// Collect the set of protocols to which this type should implicitly
   /// conform, such as AnyObject (for classes).
   void getImplicitProtocols(SmallVectorImpl<ProtocolDecl *> &protocols);
+
+  /// Prepare the conformance table (also acts as accessor).
+  ConformanceLookupTable *prepareConformanceTable() const;
 
   /// Look for conformances of this nominal type to the given
   /// protocol.
@@ -4332,6 +4332,9 @@ public:
   /// Retrieve the set of protocols inherited from this protocol.
   ArrayRef<ProtocolDecl *> getInheritedProtocols() const;
 
+  /// An extension has inherited a new protocol
+  void inheritedProtocolsChanged();
+
   /// Determine whether this protocol has a superclass.
   bool hasSuperclass() const { return (bool)getSuperclassDecl(); }
 
@@ -4421,6 +4424,9 @@ public:
   /// all the members do not contain any associated types, and do not
   /// contain 'Self' in 'parameter' or 'other' position.
   bool existentialTypeSupported() const;
+
+  /// Track conformances that have come about due to a  protocol extension
+  void recordExtendedNominal(NominalTypeDecl *nomial, ExtensionDecl *ext);
 
 private:
   void computeKnownProtocolKind() const;

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1751,6 +1751,8 @@ NOTE(composition_in_extended_type_alternative,none,
 ERROR(extension_access_with_conformances,none,
       "%0 modifier cannot be used with extensions that declare "
       "protocol conformances", (DeclAttribute))
+ERROR(protocol_extension_access_with_conformances,none,
+      "protocol extensions with conformances must currently be public", ())
 ERROR(extension_metatype,none,
       "cannot extend a metatype %0", (Type))
 ERROR(extension_specialization,none,
@@ -1764,8 +1766,12 @@ ERROR(extension_nongeneric_trailing_where,none,
       "trailing 'where' clause for extension of non-generic type %0",
       (Identifier))
 ERROR(extension_protocol_inheritance,none,
-      "extension of protocol %0 cannot have an inheritance clause",
-      (Identifier))
+      "inheritance clause in extension of protocol %0. "
+      "use -enable-conforming-protocol-extensions to enable this feature",
+      (DeclName))
+ERROR(extension_protocol_limitation,none,
+      "cannot extend protocol %0 that %1 already conforms to in another module",
+      (DeclName, Type))
 ERROR(objc_generic_extension_using_type_parameter,none,
       "extension of a generic Objective-C class cannot access the class's "
       "generic parameters at runtime", ())

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -182,7 +182,9 @@ private:
 
 public:
   // Caching
-  bool isCached() const { return true; }
+  bool isCached() const {
+    return std::get<0>(getStorage())->areInheritedProtocolsValid();
+  }
   Optional<ArrayRef<ProtocolDecl *>> getCachedResult() const;
   void cacheResult(ArrayRef<ProtocolDecl *> value) const;
 

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -96,11 +96,34 @@ class alignas(1 << DeclAlignInBits) ProtocolConformance {
   /// conformance definition.
   Type ConformingType;
 
+  // The conformance has been used during Sema.
+  mutable bool hasBeenReferenced = false;
+
+  // Ad-hoc conformances from protocol extensions must be private.
+  mutable bool fromProtocolExtension = false;
+
 protected:
   ProtocolConformance(ProtocolConformanceKind kind, Type conformingType)
     : Kind(kind), ConformingType(conformingType) {}
 
 public:
+  ProtocolConformance *recordReferenced() const {
+    hasBeenReferenced = true;
+    return const_cast<ProtocolConformance *>(this);
+  }
+
+  bool isInUse() {
+    return hasBeenReferenced;
+  }
+
+  void makePrivate() const {
+    fromProtocolExtension = true;
+  }
+
+  bool isFromProtocolExtension() const {
+    return fromProtocolExtension;
+  }
+
   /// Determine the kind of protocol conformance.
   ProtocolConformanceKind getKind() const { return Kind; }
 

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -85,9 +85,7 @@ public:
   bool isConcrete() const {
     return !isInvalid() && Union.is<ProtocolConformance*>();
   }
-  ProtocolConformance *getConcrete() const {
-    return Union.get<ProtocolConformance*>();
-  }
+  ProtocolConformance *getConcrete() const;
 
   bool isAbstract() const {
     return !isInvalid() && Union.is<ProtocolDecl*>();

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -60,10 +60,13 @@ class Requirement {
     LayoutConstraint SecondLayout;
   };
 
+  /// Module this requirement was derived from. Used to re-order witness table.
+  unsigned ModuleNumber;
+
 public:
   /// Create a conformance or same-type requirement.
-  Requirement(RequirementKind kind, Type first, Type second)
-    : FirstTypeAndKind(first, kind), SecondType(second) {
+  Requirement(RequirementKind kind, Type first, Type second, unsigned moduleNumber = 0)
+    : FirstTypeAndKind(first, kind), SecondType(second), ModuleNumber(moduleNumber) {
     assert(first);
     assert(second);
   }
@@ -87,6 +90,10 @@ public:
   Type getSecondType() const {
     assert(getKind() != RequirementKind::Layout);
     return SecondType;
+  }
+
+  unsigned getModuleNumber() const {
+    return ModuleNumber;
   }
 
   /// Subst the types involved in this requirement.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -111,6 +111,9 @@ namespace swift {
     /// when using RequireExplicitAvailability.
     std::string RequireExplicitAvailabilityTarget;
 
+    /// Gate for conforming protocol extensions code.
+    bool EnableConformingExtensions = false;
+
     /// If false, '#file' evaluates to the full path rather than a
     /// human-readable string.
     bool EnableConcisePoundFile = false;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -513,6 +513,11 @@ def enable_experimental_additive_arithmetic_derivation :
   Flags<[FrontendOption]>,
   HelpText<"Enable experimental 'AdditiveArithmetic' derived conformances">;
 
+def enable_conforming_protocol_extensions : Flag<["-"],
+    "enable-conforming-protocol-extensions">,
+  Flags<[FrontendOption]>,
+  HelpText<"Enable experimental feature to conforming protocol extensions">;
+
 def enable_experimental_concise_pound_file : Flag<["-"],
     "enable-experimental-concise-pound-file">,
   Flags<[FrontendOption]>,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1195,12 +1195,12 @@ ExtensionDecl::ExtensionDecl(SourceLoc extensionLoc,
     Decl(DeclKind::Extension, parent),
     IterableDeclContext(IterableDeclContextKind::ExtensionDecl),
     ExtensionLoc(extensionLoc),
-    ExtendedTypeRepr(extendedType),
-    Inherited(inherited)
+    ExtendedTypeRepr(extendedType)
 {
   Bits.ExtensionDecl.DefaultAndMaxAccessLevel = 0;
   Bits.ExtensionDecl.HasLazyConformances = false;
   setTrailingWhereClause(trailingWhereClause);
+  setInherited(inherited);
 }
 
 ExtensionDecl *ExtensionDecl::create(ASTContext &ctx, SourceLoc extensionLoc,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -250,6 +250,8 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_disable_astscope_lookup);
   inputArgs.AddLastArg(arguments, options::OPT_disable_parser_lookup);
   inputArgs.AddLastArg(arguments,
+                       options::OPT_enable_conforming_protocol_extensions);
+  inputArgs.AddLastArg(arguments,
                        options::OPT_enable_experimental_concise_pound_file);
   inputArgs.AddLastArg(arguments,
                        options::OPT_verify_incremental_dependencies);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -542,6 +542,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.OptimizationRemarkMissedPattern =
         generateOptimizationRemarkRegex(Diags, Args, A);
 
+  Opts.EnableConformingExtensions =
+      Args.hasArg(OPT_enable_conforming_protocol_extensions);
+
   Opts.EnableConcisePoundFile =
       Args.hasArg(OPT_enable_experimental_concise_pound_file);
 

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1884,6 +1884,13 @@ public:
         continue;
       SGM.visit(TD);
     }
+
+#if 01
+    SGM.getASTContext().forEachExtendedConformance(SGM.SwiftModule,
+                                 [&](NormalProtocolConformance *normal) {
+      SGM.getWitnessTable(normal);
+    });
+#endif
   }
 
   explicit SILGenModuleRAII(SILModule &M) : SGM{M, M.getSwiftModule()} {}

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -705,8 +705,10 @@ bool AttributeChecker::visitAbstractAccessControlAttr(
 
   if (auto extension = dyn_cast<ExtensionDecl>(D)) {
     if (!extension->getInherited().empty()) {
-      diagnoseAndRemoveAttr(attr, diag::extension_access_with_conformances,
-                            attr);
+      if (!extension->getExtendedProtocolDecl())
+        diagnoseAndRemoveAttr(attr, diag::extension_access_with_conformances, attr);
+      else if (!(attr->getAccess() == AccessLevel::Public))
+        diagnoseAndRemoveAttr(attr, diag::protocol_extension_access_with_conformances);
       return true;
     }
   }

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -962,4 +962,45 @@ void diagnoseConformanceFailure(Type T,
 
 }
 
+/// This is a wrapper of multiple instances of ConformanceChecker to allow us
+/// to diagnose and fix code from a more global perspective; for instance,
+/// having this wrapper can help issue a fixit that inserts protocol stubs from
+/// multiple protocols under checking.
+class swift::MultiConformanceChecker {
+  ASTContext &Context;
+  llvm::SmallVector<ValueDecl*, 16> UnsatisfiedReqs;
+  llvm::SmallVector<ConformanceChecker, 4> AllUsedCheckers;
+  llvm::SmallVector<NormalProtocolConformance*, 4> AllConformances;
+  llvm::SetVector<ValueDecl*> MissingWitnesses;
+  llvm::SmallPtrSet<ValueDecl *, 8> CoveredMembers;
+
+  /// Check one conformance.
+  ProtocolConformance * checkIndividualConformance(
+    NormalProtocolConformance *conformance, bool issueFixit);
+
+  /// Determine whether the given requirement was left unsatisfied.
+  bool isUnsatisfiedReq(NormalProtocolConformance *conformance, ValueDecl *req);
+public:
+  MultiConformanceChecker(ASTContext &ctx) : Context(ctx) {}
+
+  ASTContext &getASTContext() const { return Context; }
+
+  /// Add a conformance into the batched checker.
+  void addConformance(NormalProtocolConformance *conformance) {
+    AllConformances.push_back(conformance);
+  }
+
+  /// Peek the unsatisfied requirements collected during conformance checking.
+  ArrayRef<ValueDecl*> getUnsatisfiedRequirements() {
+    return llvm::makeArrayRef(UnsatisfiedReqs);
+  }
+
+  /// Whether this member is "covered" by one of the conformances.
+  bool isCoveredMember(ValueDecl *member) const {
+    return CoveredMembers.count(member) > 0;
+  }
+
+  /// Check all conformances and emit diagnosis globally.
+  bool checkAllConformances();
+};
 #endif // SWIFT_SEMA_PROTOCOL_H

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -349,6 +349,14 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
     }
 
     typeCheckDelayedFunctions(*SF);
+
+    // re-typecheck protocol extensions to diagnose any redundant conformances
+    if (SF->getASTContext().LangOpts.EnableConformingExtensions) {
+      for (auto D : SF->getTopLevelDecls())
+        if (auto *ED = dyn_cast<ExtensionDecl>(D))
+          if (ED->getExtendedProtocolDecl() && ED->getInherited().size())
+            TypeChecker::typeCheckDecl(ED);
+    }
   }
 
   // Check to see if there's any inconsistent @_implementationOnly imports.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3241,6 +3241,14 @@ public:
         dependencyTypes.insert(element.getType());
     }
 
+    for (ExtensionDecl *ED : const_cast<ProtocolDecl *>(proto)->getExtensions())
+      for (auto element : ED->getInherited()) {
+        assert(!element.getType()->hasArchetype());
+        inheritedAndDependencyTypes.push_back(S.addTypeRef(element.getType()));
+        if (element.getType()->is<ProtocolType>())
+          dependencyTypes.insert(element.getType());
+      }
+
     for (Requirement req : proto->getRequirementSignature()) {
       // Requirements can be cyclic, so for now filter out any requirements
       // from elsewhere in the module. This isn't perfect---something else in

--- a/test/decl/conforming_extensions.swift
+++ b/test/decl/conforming_extensions.swift
@@ -1,0 +1,113 @@
+// RUN: %target-run-swift -enable-conforming-protocol-extensions %s | %FileCheck %s
+
+public extension FixedWidthInteger: ExpressibleByUnicodeScalarLiteral {
+    @_transparent
+  init(unicodeScalarLiteral value: Unicode.Scalar) {
+    self = Self(value.value)
+  }
+  func foo() -> String {
+    return "Foo!"
+  }
+}
+
+let a: [Int16] = ["a", "b", "c", "d", "e"]
+let b: [UInt32] = ["a", "b", "c", "d", "e"]
+
+protocol Q {
+  var bar: Double { get }
+  func foo2() -> String
+}
+public protocol P {
+}
+public extension P: Q {
+  var bar: Double { return -888 }
+  func foo2() -> String {
+    return "Foo2 \(self)!"
+  }
+}
+class C {}
+struct S {
+  var a = 99
+}
+public protocol P2 : P {}
+public extension P2 {}
+
+ extension C: P2 {}
+ extension S: P2 {}
+
+//public extension Numeric: P2 {}
+public extension FixedWidthInteger: P2 {}
+
+// CHECK: Foo2 main.C!
+print(C().foo2())
+// CHECK: Foo2 S(a: 99)!
+print(S().foo2())
+// CHECK: Foo2 99!
+print(Int8(99).foo2())
+// CHECK: Foo2 99!
+//extension UInt32: P2 {}
+print(UInt32(99).foo2())
+// CHECK: Foo!
+print(Int8(99).foo())
+// CHECK: Foo!
+print(Int32(99).foo())
+// CHECK: Foo!
+print(UInt32(99).foo())
+
+// CHECK: [97, 98, 99, 100, 101]
+print(a)
+// CHECK: [97, 98, 99, 100, 101]
+print(b)
+// CHECK: ["Foo2 97!", "Foo2 98!", "Foo2 99!", "Foo2 100!", "Foo2 101!"]
+print(a.map {$0.foo2()})
+// CHECK: ["Foo!", "Foo!", "Foo!", "Foo!", "Foo!"]
+print(b.map {$0.foo()})
+// CHECK: ["Foo2 97!", "Foo2 98!", "Foo2 99!", "Foo2 100!", "Foo2 101!"]
+print(b.map {$0.foo2()})
+
+public func use<T>(_ value: T) -> T
+  where T : FixedWidthInteger {
+    print(value.foo2())
+    return value + "1" // ← Used ExpressibleByUnicodeScalarLiteral
+}
+
+// CHECK: 50
+print(use(1))
+
+let u = UInt32(99)
+
+// CHECK: 148
+print(use(u))
+
+func aaa(_ b: P2) {
+  print(b.foo2())
+}
+
+aaa(u)
+
+//aaa(88.0)
+//
+//print(99.0.foo2())
+
+let v = b.map { $0 as P2 }.map { $0.foo2() }
+// CHECK: ["Foo2 97!", "Foo2 98!", "Foo2 99!", "Foo2 100!", "Foo2 101!"]
+print(v)
+
+// CHECK: -888.0
+print(99.bar)
+
+import Foundation
+
+public protocol CC {
+}
+
+public struct AA: CC {
+    var a = 9
+    var b = 8
+}
+
+public extension CC: Codable {
+}
+
+// CHECK: {"a":9,"b":8}
+print(String(data: try! JSONEncoder().encode(AA()), encoding: .utf8) ?? "?")

--- a/test/decl/conforming_extensions.swift
+++ b/test/decl/conforming_extensions.swift
@@ -1,4 +1,5 @@
-// RUN: %target-run-swift -enable-conforming-protocol-extensions %s | %FileCheck %s
+// RUN: %target-build-swift -enable-conforming-protocol-extensions %s -o %t.out
+// RUN: %target-run %t.out | %FileCheck %s
 
 public extension FixedWidthInteger: ExpressibleByUnicodeScalarLiteral {
     @_transparent

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -947,7 +947,7 @@ enum Foo : Int, ReallyRaw {
 protocol BadProto1 { }
 protocol BadProto2 { }
 
-extension BadProto1 : BadProto2 { } // expected-error{{extension of protocol 'BadProto1' cannot have an inheritance clause}}
+extension BadProto1 : BadProto2 { } // expected-error{{protocol extensions with conformances must currently be public}} expected-error{{inheritance clause in extension of protocol 'BadProto1'. use -enable-conforming-protocol-extensions to enable this feature}}
 
 extension BadProto2 {
   struct S { } // expected-error{{type 'S' cannot be nested in protocol extension of 'BadProto2'}}


### PR DESCRIPTION
Hi Apple,

This is a third proof of concept PR looking at the possibility of allowing the adding of conformances to protocol extensions as mentioned in the [Generics Manifesto](https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md#retroactive-protocol-refinement) (after two previous attempts #29272, #25786). This version now works reliably across module boundaries subject to the known limitation that while you can now do pretty much anything extending conformances in whatever module you like, the conformances to potentially extended protocols of a specific nominal must be in the outermost module. If this limitation is not respected the compiler now reliably flags this as an error as the program could potentially crash at run time. It may be possible to lift this limitation later.

Edit: It’s been possible to lift this limitation at the cost of there now being instances where you could contrive a situation where a program compiles but crashes at run time if you return an existential created in a module that doesn’t have knowledge of the extended conformances to one that does. (See below)

To work across modules, the entries in a witness table for a nominal/protocol pair are extended in a manner that is compatible with the existing ordering to be:

* associated value entries
* pointers to witness tables of directly inherited protocols
* pointer to “FTW” member function thunks of the original protocol for the nominal
* witness tables of extended conformances in order of the module that added the conformance.

This means functions taking an argument of a protocol in a module defining the protocol will continue to operate if an existential from a module that has extended the protocol’s conformances should call that function with an existential.

As adding a conformance to a protocol affects any nominal that has an existing conformance to the protocol being extended, witness tables with the additional entries have to be generated for the nominals when the new conformances are used. As these ad-hoc witness tables can be generated in more than one source file, these witness tables are given `internal` linker scope. Protocol descriptors are also generated as are entries in the `__swift5_proto` section of the binary, and as a result dynamically finding these conformances at run time seems to "just work”. Adding a synthesised conformance such as `Codable` to another protocol also seems to work.

While I don’t imagine this will be merged, it could be as all the advantage of this feature is that it is an additive change not currently permitted in the language and only takes effect when it is used which is only possible when the flag `-enable-conforming-protocol-extensions` has been provided. Hence, existing tests pass. Having to an extent proved the concept I’ll attempt to re-engage the evolution forums to discuss the idea on [the existing thread](https://forums.swift.org/t/protocol-extensions-inheriting-protocols/25491/8) with a view to a proposal if there is any interest.

Edit: Raised a proposal PR on [swift-evolution REPO](https://github.com/apple/swift-evolution/pull/1155).

Toolchain for evaluation [available here](http://johnholdsworth.com/swift-LOCAL-2020-06-09-a-osx.tar.gz). Test SPM project [here](https://github.com/johnno1962/ExtApp).

Addresses: [SR-11013](https://bugs.swift.org/browse/SR-11013)