### PR TITLE
[Incremental compilation]: Merge pull request #32219 from davidungar/quick-dependency-bug-fix

### DIFF
--- a/lib/AST/AbstractSourceFileDepGraphFactory.cpp
+++ b/lib/AST/AbstractSourceFileDepGraphFactory.cpp
@@ -79,14 +79,30 @@ void AbstractSourceFileDepGraphFactory::addAUsedDecl(
     const DependencyKey &defKey, const DependencyKey &useKey) {
   auto *defNode =
       g.findExistingNodeOrCreateIfNew(defKey, None, false /* = !isProvides */);
+
   // If the depended-upon node is defined in this file, then don't
   // create an arc to the user, when the user is the whole file.
   // Otherwise, if the defNode's type-body fingerprint changes,
   // the whole file will be marked as dirty, losing the benefit of the
   // fingerprint.
-  if (defNode->getIsProvides() &&
-      useKey.getKind() == NodeKind::sourceFileProvide)
-    return;
+
+  //  if (defNode->getIsProvides() &&
+  //      useKey.getKind() == NodeKind::sourceFileProvide)
+  //    return;
+
+  // Turns out the above three lines cause miscompiles, so comment them out
+  // for now. We might want them back if we can change the inputs to this
+  // function to be more precise.
+
+  // Example of a miscompile:
+  // In main.swift
+  // func foo(_: Any) { print("Hello Any") }
+  //    foo(123)
+  // Then add the following line to another file:
+  // func foo(_: Int) { print("Hello Int") }
+  // Although main.swift needs to get recompiled, the commented-out code below
+  // prevents that.
+
   auto nullableUse = g.findExistingNode(useKey);
   assert(nullableUse.isNonNull() && "Use must be an already-added provides");
   auto *useNode = nullableUse.get();

--- a/test/Frontend/Fingerprints/class-fingerprint.swift
+++ b/test/Frontend/Fingerprints/class-fingerprint.swift
@@ -71,9 +71,4 @@
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 
-// RUN: %FileCheck -check-prefix=CHECK-MAINB-RECOMPILED %s < %t/output4
-
-// CHECK-MAINB-RECOMPILED-NOT: Queuing because of dependencies discovered later: {compile: usesB.o <= usesB.swift}
-// CHECK-MAINB-RECOMPILED: Queuing because of dependencies discovered later: {compile: usesA.o <= usesA.swift}
-// CHECK-MAINB-RECOMPILED-NOT: Queuing because of dependencies discovered later: {compile: usesB.o <= usesB.swift}
-
+// RUN: %FileCheck -check-prefix=CHECK-MAINAB-RECOMPILED %s < %t/output4

--- a/test/Frontend/Fingerprints/enum-fingerprint.swift
+++ b/test/Frontend/Fingerprints/enum-fingerprint.swift
@@ -71,9 +71,4 @@
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 
-// RUN: %FileCheck -check-prefix=CHECK-MAINB-RECOMPILED %s < %t/output4
-
-// CHECK-MAINB-RECOMPILED-NOT: Queuing because of dependencies discovered later: {compile: usesB.o <= usesB.swift}
-// CHECK-MAINB-RECOMPILED: Queuing because of dependencies discovered later: {compile: usesA.o <= usesA.swift}
-// CHECK-MAINB-RECOMPILED-NOT: Queuing because of dependencies discovered later: {compile: usesB.o <= usesB.swift}
-
+// RUN: %FileCheck -check-prefix=CHECK-MAINAB-RECOMPILED %s < %t/output4

--- a/test/Frontend/Fingerprints/protocol-fingerprint.swift
+++ b/test/Frontend/Fingerprints/protocol-fingerprint.swift
@@ -71,9 +71,5 @@
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 
-// RUN: %FileCheck -check-prefix=CHECK-MAINB-RECOMPILED %s < %t/output4
-
-// CHECK-MAINB-RECOMPILED-NOT: Queuing because of dependencies discovered later: {compile: usesB.o <= usesB.swift}
-// CHECK-MAINB-RECOMPILED: Queuing because of dependencies discovered later: {compile: usesA.o <= usesA.swift}
-// CHECK-MAINB-RECOMPILED-NOT: Queuing because of dependencies discovered later: {compile: usesB.o <= usesB.swift}
+// RUN: %FileCheck -check-prefix=CHECK-MAINAB-RECOMPILED %s < %t/output4
 

--- a/test/Frontend/Fingerprints/struct-fingerprint.swift
+++ b/test/Frontend/Fingerprints/struct-fingerprint.swift
@@ -71,9 +71,4 @@
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 
-// RUN: %FileCheck -check-prefix=CHECK-MAINB-RECOMPILED %s < %t/output4
-
-// CHECK-MAINB-RECOMPILED-NOT: Queuing because of dependencies discovered later: {compile: usesB.o <= usesB.swift}
-// CHECK-MAINB-RECOMPILED: Queuing because of dependencies discovered later: {compile: usesA.o <= usesA.swift}
-// CHECK-MAINB-RECOMPILED-NOT: Queuing because of dependencies discovered later: {compile: usesB.o <= usesB.swift}
-
+// RUN: %FileCheck -check-prefix=CHECK-MAINAB-RECOMPILED %s < %t/output4

--- a/unittests/Driver/TypeBodyFingerprintsDependencyGraphTests.cpp
+++ b/unittests/Driver/TypeBodyFingerprintsDependencyGraphTests.cpp
@@ -808,10 +808,10 @@ TEST(ModuleDepGraph, UseFingerprints) {
   {
     const auto jobs =
         simulateReload(graph, &job0, {{NodeKind::nominal, {"A1@11", "A2@2"}}});
-    EXPECT_EQ(2u, jobs.size());
+    EXPECT_EQ(3u, jobs.size());
     EXPECT_TRUE(contains(jobs, &job0));
     EXPECT_TRUE(contains(jobs, &job1));
-    EXPECT_FALSE(contains(jobs, &job2));
+    EXPECT_TRUE(contains(jobs, &job2));
     EXPECT_FALSE(contains(jobs, &job3));
   }
 }


### PR DESCRIPTION
Fixes a regression from 5.2. Undo a dependency optimization that causes miscompiles.

Explanation: In order to realize a benefit from type-body-fingerprints, code was added to omit a dependency wherein a file A depended upon a type defined in that same file A. However, if that same type is also used subsequently to its definition in the same file A, the omission causes miscompiles because a use of that type in file B depends upon file A. The omission causes file A to be insensitive to changes in the type, and thus causes the use in file B to be insensitive to changes in the type. In the future, refinements in the dependency system may well allow us to reenable this optimization, but for now, we need to disable the optimization in order to prevent miscompilations.

Origination: d09c9065534d75ebbd9cae75b9900819048a7ea2 Fed 27, 11:38 pm
Risk: Zero, because all it does is add dependencies. It effectively puts us back to pre-type-body-fingerprints.
Reviewed by: Slava Pestov
Testing: CI PR tests + the perturbation tester
Radar:rdar://64074744