### PR TITLE
[EduNotes] Explain some opaque type diagnostics

### DIFF
--- a/include/swift/AST/EducationalNotes.def
+++ b/include/swift/AST/EducationalNotes.def
@@ -59,6 +59,17 @@ EDUCATIONAL_NOTES(property_wrapper_failable_init,
 EDUCATIONAL_NOTES(property_wrapper_type_requirement_not_accessible,
                   "property-wrapper-requirements.md")
 
+EDUCATIONAL_NOTES(opaque_type_var_no_init, "opaque-type-inference.md")
+EDUCATIONAL_NOTES(opaque_type_no_underlying_type_candidates,
+                  "opaque-type-inference.md")
+EDUCATIONAL_NOTES(opaque_type_mismatched_underlying_type_candidates,
+                  "opaque-type-inference.md")
+EDUCATIONAL_NOTES(opaque_type_self_referential_underlying_type,
+                  "opaque-type-inference.md")
+EDUCATIONAL_NOTES(opaque_type_var_no_underlying_type,
+                  "opaque-type-inference.md")
+
+
 EDUCATIONAL_NOTES(missing_append_interpolation,
                   "string-interpolation-conformance.md")
 EDUCATIONAL_NOTES(append_interpolation_static,

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -13,7 +13,7 @@ class C {}
 class D: C, P, Q { func paul() {}; func priscilla() {}; func quinn() {} }
 
 let property: some P = 1
-let deflessLet: some P // expected-error{{has no initializer}}
+let deflessLet: some P // expected-error{{has no initializer}} {{educational-notes=opaque-type-inference}}
 var deflessVar: some P // expected-error{{has no initializer}}
 
 struct GenericProperty<T: P> {
@@ -173,13 +173,13 @@ func recursion(x: Int) -> some P {
   return recursion(x: x - 1)
 }
 
-func noReturnStmts() -> some P {} // expected-error {{function declares an opaque return type, but has no return statements in its body from which to infer an underlying type}}
+func noReturnStmts() -> some P {} // expected-error {{function declares an opaque return type, but has no return statements in its body from which to infer an underlying type}} {{educational-notes=opaque-type-inference}}
 
 func returnUninhabited() -> some P { // expected-note {{opaque return type declared here}}
     fatalError() // expected-error{{return type of global function 'returnUninhabited()' requires that 'Never' conform to 'P'}}
 }
 
-func mismatchedReturnTypes(_ x: Bool, _ y: Int, _ z: String) -> some P { // expected-error{{do not have matching underlying types}}
+func mismatchedReturnTypes(_ x: Bool, _ y: Int, _ z: String) -> some P { // expected-error{{do not have matching underlying types}} {{educational-notes=opaque-type-inference}}
   if x {
     return y // expected-note{{underlying type 'Int'}}
   } else {
@@ -209,7 +209,7 @@ func jan() -> some P {
   return [marcia(), marcia(), marcia()]
 }
 func marcia() -> some P {
-  return [marcia(), marcia(), marcia()] // expected-error{{defines the opaque type in terms of itself}}
+  return [marcia(), marcia(), marcia()] // expected-error{{defines the opaque type in terms of itself}} {{educational-notes=opaque-type-inference}}
 }
 
 protocol R {

--- a/userdocs/diagnostics/opaque-type-inference.md
+++ b/userdocs/diagnostics/opaque-type-inference.md
@@ -1,0 +1,68 @@
+# Underlying Type Inference for Opaque Result Types
+
+Opaque result types are a useful tool for abstracting the return type of a function or subscript, or type of a property. Although the concrete underlying type of an opaque type is hidden from clients, it is still inferred by the compiler, which enforces certain usage requirements:
+
+- Property declarations with opaque types must have an initializer expression or getter, and functions or subscripts returning opaque types must have at least one `return` statement:
+
+```swift
+let x: some Equatable // error: property declares an opaque return type, but has no initializer expression from which to infer an underlying type
+let y: some Equatable = 42 // OK
+let z: some Equatable { // Also OK
+  return "hello, " + "world!"
+}
+
+func foo() -> some Equatable { // error: function declares an opaque return type, but has no return statements in its body from which to infer an underlying type
+  fatalError("Unimplemented")
+}
+
+func bar() -> some Equatable { // OK
+  fatalError("Unimplemented")
+  return 42
+}
+```
+
+- The underlying type of an opaque type must be unique. In other words, if a function or subscript returns an opaque type, it must return values of the same underlying type from every `return` statement in its body.
+
+```swift
+func foo(bar: Bool) -> some Equatable { // error: function declares an opaque return type, but the return statements in its body do not have matching underlying types
+  if bar {
+    return "hello, world!" // note: return statement has underlying type 'String'
+  } else {
+    return 1 // note: return statement has underlying type 'Int'
+  }
+}
+
+func bar(baz: Bool) -> some Equatable { // OK, both branches of the if statement return a value of the same underlying type, Int.
+  if baz {
+    return 100
+  } else {
+    return 200
+  }
+}
+```
+
+- Functions returning opaque types may be recursive. However, such functions must have at least one `return` statement that returns a concrete underlying type as opposed to the function's own opaque result type. Additionally, recursive calls may not be used to create an infinitely recursive opaque type.
+
+```swift
+func foo(_ x: Int) -> some Equatable { // error: function declares an opaque return type, but has no return statements in its body from which to infer an underlying type
+  // Not allowed because there aren't any non-recursive returns to infer the underlying type from.
+  return foo(x+1)
+}
+
+struct EquatableWrapper<T: Equatable>: Equatable { var value: T }
+func foo() -> some Equatable { // error: function opaque return type was inferred as 'EquatableWrapper<some Equatable>', which defines the opaque type in terms of itself
+  // Not allowed because the use of EquatableWrapper creates an infinitely recursive underlying type: EquatableWrapper<EquatableWrapper<EquatableWrapper<...>>>...>
+  return EquatableWrapper(value: foo())
+}
+
+func bar(_ x: Int) -> some Equatable { // OK, the underlying type can be inferred from the second return statement.
+  if x > 0 {
+    return bar(x-1)
+  } else {
+    return x
+  }
+}
+```
+
+To learn more about opaque result types, see the [Opaque Types](https://docs.swift.org/swift-book/LanguageGuide/OpaqueTypes.html) section of _The Swift Programming Language_.
+


### PR DESCRIPTION
This just collects some of the info and examples from se-244 explaining restrictions on the use of opaque types that aren't covered in detail by _The Swift Programming Language_. 