### PR TITLE
[SR-12946] Don't warn cast to unrelated metatype when involves archetypes

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3706,9 +3706,11 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   else
     fromRequiresClass = fromType->mayHaveSuperclass();
   
-  // Casts between protocol metatypes only succeed if the type is existential.
+  // Casts between protocol metatypes only succeed if the type is existential
+  // or if it involves generic types because they may be protocol conformances
+  // we can't know at compile time.
   if (metatypeCast) {
-    if (toExistential || fromExistential)
+    if ((toExistential || fromExistential) && !(fromArchetype || toArchetype))
       return failed();
   }
 

--- a/test/expr/cast/metatype_casts.swift
+++ b/test/expr/cast/metatype_casts.swift
@@ -49,3 +49,10 @@ use(C.self as P.Type) // expected-error{{cannot convert value of type 'C.Type' t
 
 use(E.self as P.Protocol) // expected-error{{cannot convert value of type 'E.Type' to type 'P.Protocol' in coercion}}
 use(E.self as P.Type)
+
+// SR-12946
+func SR12946<T>(_ e: T) {
+  _ = AnyObject.self is T.Type // OK
+}
+
+SR12946(1 as AnyObject)


### PR DESCRIPTION
<!-- What's in this pull request? -->
When involving generic types some protocol conformances can only be known at runtime.

cc @xedin @CodaFi 
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-12946.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
