### PR TITLE
[LTO] Force to use lld when LTO on Unix like toolchain

### DIFF
--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -168,11 +168,11 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
 
   // Select the linker to use.
   std::string Linker;
-  if (const Arg *A = context.Args.getLastArg(options::OPT_use_ld)) {
-    Linker = A->getValue();
-  } else if (context.OI.LTOVariant != OutputInfo::LTOKind::None) {
+  if (context.OI.LTOVariant != OutputInfo::LTOKind::None) {
     // Force to use lld for LTO
     Linker = "lld";
+  } else if (const Arg *A = context.Args.getLastArg(options::OPT_use_ld)) {
+    Linker = A->getValue();
   } else {
     Linker = getDefaultLinker();
   }


### PR DESCRIPTION
Resolve CI failure on android and other hosts  https://github.com/apple/swift/pull/31146#issuecomment-640259541


Android test cases try to use gold linker `-use-ld=gold` but we don't support gold and other linkers except for lld for LTO now.
```
: 'RUN: at line 13';   /home/ubuntu/jenkins/workspace/oss-swift-RA-linux-ubuntu-16.04-android/buildbot_linux/swift-linux-x86_64/bin/swiftc -target armv7-none-linux-android -toolchain-stdlib-rpath -Xcc --sysroot=/home/ubuntu/android-ndk-r17/platforms/android-21/arch-arm -Xclang-linker --sysroot=/home/ubuntu/android-ndk-r17/platforms/android-21/arch-arm -tools-directory /home/ubuntu/android-ndk-r17/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/arm-linux-androideabi/bin -L /home/ubuntu/android-ndk-r17/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a -L /home/ubuntu/android-ndk-r17/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/lib/gcc/arm-linux-androideabi/4.9.x -L /home/ubuntu/android-ndk-r17/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/arm-linux-androideabi/lib  -module-cache-path '/home/ubuntu/jenkins/workspace/oss-swift-RA-linux-ubuntu-16.04-android/buildbot_linux/swift-linux-x86_64/swift-test-results/armv7-none-linux-androideabi/clang-module-cache' -use-ld=gold /home/ubuntu/jenkins/workspace/oss-swift-RA-linux-ubuntu-16.04-android/swift/test/Driver/Inputs/lto/lib.swift -static -lto=llvm -emit-library -emit-module -module-name A -working-directory /home/ubuntu/jenkins/workspace/oss-swift-RA-linux-ubuntu-16.04-android/buildbot_linux/swift-linux-x86_64/test-android-armv7/Driver/Output/link-time-opt-staticlib-thin.swift.tmp/thin-static

```

CC: @compnerd 