### PR TITLE
Revert "Revert "[LTO] Support LLVM level link time optimization on Darwin, Linux and Windows""

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -65,6 +65,12 @@ enum class IRGenDebugInfoFormat : unsigned {
   CodeView
 };
 
+enum class IRGenLLVMLTOKind : unsigned {
+  None,
+  Thin,
+  Full
+};
+
 enum class IRGenEmbedMode : unsigned {
   None,
   EmbedMarker,
@@ -217,6 +223,8 @@ public:
   /// Whether we should embed the bitcode file.
   IRGenEmbedMode EmbedMode : 2;
 
+  IRGenLLVMLTOKind LLVMLTOKind: 2;
+
   /// Add names to LLVM values.
   unsigned HasValueNamesSetting : 1;
   unsigned ValueNames : 1;
@@ -318,6 +326,7 @@ public:
         DisableSwiftSpecificLLVMOptzns(false), DisableLLVMSLPVectorizer(false),
         Playground(false), EmitStackPromotionChecks(false),
         FunctionSections(false), PrintInlineTree(false), EmbedMode(IRGenEmbedMode::None),
+        LLVMLTOKind(IRGenLLVMLTOKind::None),
         HasValueNamesSetting(false), ValueNames(false),
         EnableReflectionMetadata(true), EnableReflectionNames(true),
         EnableAnonymousContextMangledNames(false), ForcePublicLinkage(false),

--- a/include/swift/Driver/Action.h
+++ b/include/swift/Driver/Action.h
@@ -328,15 +328,18 @@ public:
 class DynamicLinkJobAction : public JobAction {
   virtual void anchor();
   LinkKind Kind;
+  bool LTO;
 
 public:
-  DynamicLinkJobAction(ArrayRef<const Action *> Inputs, LinkKind K)
+  DynamicLinkJobAction(ArrayRef<const Action *> Inputs, LinkKind K, bool LTO)
       : JobAction(Action::Kind::DynamicLinkJob, Inputs, file_types::TY_Image),
-        Kind(K) {
+        Kind(K), LTO(LTO) {
     assert(Kind != LinkKind::None && Kind != LinkKind::StaticLibrary);
   }
 
   LinkKind getKind() const { return Kind; }
+
+  bool PerformLTO() const { return LTO; }
 
   static bool classof(const Action *A) {
     return A->getKind() == Action::Kind::DynamicLinkJob;

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -101,6 +101,14 @@ public:
   /// The output type which should be used for compile actions.
   file_types::ID CompilerOutputType = file_types::ID::TY_INVALID;
 
+  enum class LTOKind {
+    None,
+    LLVMThin,
+    LLVMFull,
+  };
+
+  LTOKind LTOVariant = LTOKind::None;
+
   /// Describes if and how the output of compile actions should be
   /// linked together.
   LinkKind LinkAction = LinkKind::None;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -515,6 +515,10 @@ def disable_bridging_pch : Flag<["-"], "disable-bridging-pch">,
   Flags<[HelpHidden]>,
   HelpText<"Disable automatic generation of bridging PCH files">;
 
+def lto : Joined<["-"], "lto=">,
+  Flags<[FrontendOption, NoInteractiveOption]>,
+  HelpText<"Specify the LTO type to either 'llvm' or 'llvm-full'">;
+
 // Experimental feature options
 
 // Note: this flag will be removed when JVP/differential generation in the

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1427,12 +1427,15 @@ static bool isSDKTooOld(StringRef sdkPath, const llvm::Triple &target) {
 void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
                              const bool BatchMode, const InputFileList &Inputs,
                              OutputInfo &OI) const {
+  auto LinkerInputType = Args.hasArg(options::OPT_lto)
+                            ? file_types::TY_LLVM_BC
+                            : file_types::TY_Object;
   // By default, the driver does not link its output; this will be updated
   // appropriately below if linking is required.
 
   OI.CompilerOutputType = driverKind == DriverKind::Interactive
                               ? file_types::TY_Nothing
-                              : file_types::TY_Object;
+                              : LinkerInputType;
 
   if (const Arg *A = Args.getLastArg(options::OPT_num_threads)) {
     if (BatchMode) {
@@ -1462,14 +1465,14 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
                        diag::error_static_emit_executable_disallowed);
                        
       OI.LinkAction = LinkKind::Executable;
-      OI.CompilerOutputType = file_types::TY_Object;
+      OI.CompilerOutputType = LinkerInputType;
       break;
 
     case options::OPT_emit_library:
       OI.LinkAction = Args.hasArg(options::OPT_static) ?
                       LinkKind::StaticLibrary :
                       LinkKind::DynamicLibrary;
-      OI.CompilerOutputType = file_types::TY_Object;
+      OI.CompilerOutputType = LinkerInputType;
       break;
 
     case options::OPT_static:
@@ -1777,6 +1780,18 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
     (void)parseSanitizerCoverageArgValue(A, TC.getTriple(), Diags,
                                          OI.SelectedSanitizers);
 
+  }
+
+  if (const Arg *A = Args.getLastArg(options::OPT_lto)) {
+    auto LTOVariant = llvm::StringSwitch<Optional<OutputInfo::LTOKind>>(A->getValue())
+      .Case("llvm", OutputInfo::LTOKind::LLVMThin)
+      .Case("llvm-full", OutputInfo::LTOKind::LLVMFull)
+      .Default(llvm::None);
+    if (LTOVariant)
+      OI.LTOVariant = LTOVariant.getValue();
+    else
+      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                     A->getAsString(Args), A->getValue());
   }
 
   if (TC.getTriple().isOSWindows()) {
@@ -2113,15 +2128,17 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
     MergeModuleAction = C.createAction<MergeModuleJobAction>(AllModuleInputs);
   }
 
+  auto PerformLTO = Args.hasArg(options::OPT_lto);
   if (OI.shouldLink() && !AllLinkerInputs.empty()) {
     JobAction *LinkAction = nullptr;
 
     if (OI.LinkAction == LinkKind::StaticLibrary) {
       LinkAction = C.createAction<StaticLinkJobAction>(AllLinkerInputs,
-                                                    OI.LinkAction);
+                                                       OI.LinkAction);
     } else {
       LinkAction = C.createAction<DynamicLinkJobAction>(AllLinkerInputs,
-                                                 OI.LinkAction);
+                                                        OI.LinkAction,
+                                                        PerformLTO);
     }
 
     // On ELF platforms there's no built in autolinking mechanism, so we
@@ -2130,7 +2147,7 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
     const auto &Triple = TC.getTriple();
     SmallVector<const Action *, 2> AutolinkExtractInputs;
     for (const Action *A : AllLinkerInputs)
-      if (A->getType() == file_types::TY_Object) {
+      if (A->getType() == OI.CompilerOutputType) {
         // Shared objects on ELF platforms don't have a swift1_autolink_entries
         // section in them because the section in the .o files is marked as
         // SHF_EXCLUDE.
@@ -2146,7 +2163,7 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
         (Triple.getObjectFormat() == llvm::Triple::ELF && !Triple.isPS4()) ||
         Triple.getObjectFormat() == llvm::Triple::Wasm ||
         Triple.isOSCygMing();
-    if (!AutolinkExtractInputs.empty() && AutolinkExtractRequired) {
+    if (!AutolinkExtractInputs.empty() && AutolinkExtractRequired && !PerformLTO) {
       auto *AutolinkExtractAction =
           C.createAction<AutolinkExtractJobAction>(AutolinkExtractInputs);
       // Takes the same inputs as the linker...

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -518,6 +518,11 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     Arguments.push_back("-track-system-dependencies");
   }
 
+  if (auto arg = context.Args.getLastArg(options::OPT_lto)) {
+    Arguments.push_back(context.Args.MakeArgString(
+        Twine("-lto=") + arg->getValue()));
+  }
+
   context.Args.AddLastArg(
       Arguments,
       options::

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -48,6 +48,9 @@ protected:
   void addDeploymentTargetArgs(llvm::opt::ArgStringList &Arguments,
                                const JobContext &context) const;
 
+  void addLTOLibArgs(llvm::opt::ArgStringList &Arguments,
+                     const JobContext &context) const;
+
   void addCommonFrontendArgs(
       const OutputInfo &OI, const CommandOutput &output,
       const llvm::opt::ArgList &inputArgs,

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -168,11 +168,11 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
 
   // Select the linker to use.
   std::string Linker;
-  if (const Arg *A = context.Args.getLastArg(options::OPT_use_ld)) {
-    Linker = A->getValue();
-  } else if (context.OI.LTOVariant != OutputInfo::LTOKind::None) {
+  if (context.OI.LTOVariant != OutputInfo::LTOKind::None) {
     // Force to use lld for LTO
     Linker = "lld";
+  } else if (const Arg *A = context.Args.getLastArg(options::OPT_use_ld)) {
+    Linker = A->getValue();
   } else {
     Linker = getDefaultLinker();
   }

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -72,7 +72,10 @@ ToolChain::InvocationInfo toolchains::GenericUnix::constructInvocation(
 
   addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
                          file_types::TY_Object);
+  addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
+                         file_types::TY_LLVM_BC);
   addInputsOfType(Arguments, context.InputActions, file_types::TY_Object);
+  addInputsOfType(Arguments, context.InputActions, file_types::TY_LLVM_BC);
 
   Arguments.push_back("-o");
   Arguments.push_back(
@@ -167,6 +170,9 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
   std::string Linker;
   if (const Arg *A = context.Args.getLastArg(options::OPT_use_ld)) {
     Linker = A->getValue();
+  } else if (context.OI.LTOVariant != OutputInfo::LTOKind::None) {
+    // Force to use lld for LTO
+    Linker = "lld";
   } else {
     Linker = getDefaultLinker();
   }
@@ -218,6 +224,16 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
     Arguments.push_back("-pie");
   }
 
+  switch (context.OI.LTOVariant) {
+  case OutputInfo::LTOKind::LLVMThin:
+    Arguments.push_back("-flto=thin");
+    break;
+  case OutputInfo::LTOKind::LLVMFull:
+    Arguments.push_back("-flto=full");
+    break;
+  case OutputInfo::LTOKind::None: break;
+  }
+
   bool staticExecutable = false;
   bool staticStdlib = false;
 
@@ -253,7 +269,11 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
 
   addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
                          file_types::TY_Object);
+  addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
+                         file_types::TY_LLVM_BC);
   addInputsOfType(Arguments, context.InputActions, file_types::TY_Object);
+  addInputsOfType(Arguments, context.InputActions, file_types::TY_LLVM_BC);
+
 
   for (const Arg *arg :
        context.Args.filtered(options::OPT_F, options::OPT_Fsystem)) {
@@ -368,7 +388,7 @@ toolchains::GenericUnix::constructInvocation(const StaticLinkJobAction &job,
   ArgStringList Arguments;
 
   // Configure the toolchain.
-  const char *AR = "ar";
+  const char *AR = "llvm-ar";
   Arguments.push_back("crs");
 
   Arguments.push_back(
@@ -376,7 +396,11 @@ toolchains::GenericUnix::constructInvocation(const StaticLinkJobAction &job,
 
   addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
                          file_types::TY_Object);
+  addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
+                         file_types::TY_LLVM_BC);
   addInputsOfType(Arguments, context.InputActions, file_types::TY_Object);
+  addInputsOfType(Arguments, context.InputActions, file_types::TY_LLVM_BC);
+
 
   InvocationInfo II{AR, Arguments};
 

--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -143,7 +143,11 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
 
   addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
                          file_types::TY_Object);
+  addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
+                         file_types::TY_LLVM_BC);
   addInputsOfType(Arguments, context.InputActions, file_types::TY_Object);
+  addInputsOfType(Arguments, context.InputActions, file_types::TY_LLVM_BC);
+
 
   for (const Arg *arg :
        context.Args.filtered(options::OPT_F, options::OPT_Fsystem)) {
@@ -186,6 +190,21 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
   context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
   context.Args.AddAllArgValues(Arguments, options::OPT_Xclang_linker);
 
+  switch (context.OI.LTOVariant) {
+  case OutputInfo::LTOKind::LLVMThin:
+  case OutputInfo::LTOKind::LLVMFull: {
+    if (Linker.empty())
+      Arguments.push_back("-fuse-ld=lld");
+    if (context.OI.LTOVariant == OutputInfo::LTOKind::LLVMThin) {
+      Arguments.push_back("-flto=thin");
+    } else {
+      Arguments.push_back("-flto=full");
+    }
+    break;
+  }
+  case OutputInfo::LTOKind::None: break;
+  }
+
   // Run clang++ in verbose mode if "-v" is set
   if (context.Args.hasArg(options::OPT_v)) {
     Arguments.push_back("-v");
@@ -210,22 +229,46 @@ toolchains::Windows::constructInvocation(const StaticLinkJobAction &job,
 
   ArgStringList Arguments;
 
-  const char *Linker = "link";
-  if (const Arg *A = context.Args.getLastArg(options::OPT_use_ld))
-    Linker = context.Args.MakeArgString(A->getValue());
+  switch (context.OI.LTOVariant) {
+  case OutputInfo::LTOKind::LLVMThin:
+  case OutputInfo::LTOKind::LLVMFull: {
+    const char *AR = "llvm-ar";
+    Arguments.push_back("crs");
 
-  Arguments.push_back("/lib");
-  Arguments.push_back("-nologo");
+    Arguments.push_back(
+        context.Args.MakeArgString(context.Output.getPrimaryOutputFilename()));
 
-  addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
-                         file_types::TY_Object);
-  addInputsOfType(Arguments, context.InputActions, file_types::TY_Object);
+    addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
+                           file_types::TY_Object);
+    addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
+                           file_types::TY_LLVM_BC);
+    addInputsOfType(Arguments, context.InputActions, file_types::TY_Object);
+    addInputsOfType(Arguments, context.InputActions, file_types::TY_LLVM_BC);
 
-  StringRef OutputFile = context.Output.getPrimaryOutputFilename();
-  Arguments.push_back(context.Args.MakeArgString(Twine("/OUT:") + OutputFile));
+    InvocationInfo II{AR, Arguments};
 
-  InvocationInfo II{Linker, Arguments};
-  II.allowsResponseFiles = true;
+    return II;
+  }
+  case OutputInfo::LTOKind::None:
+    const char *Linker = "link";
+    if (const Arg *A = context.Args.getLastArg(options::OPT_use_ld))
+      Linker = context.Args.MakeArgString(A->getValue());
 
-  return II;
+    Arguments.push_back("/lib");
+    Arguments.push_back("-nologo");
+
+    addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
+                           file_types::TY_Object);
+    addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
+                           file_types::TY_LLVM_BC);
+    addInputsOfType(Arguments, context.InputActions, file_types::TY_Object);
+    addInputsOfType(Arguments, context.InputActions, file_types::TY_LLVM_BC);
+
+    StringRef OutputFile = context.Output.getPrimaryOutputFilename();
+    Arguments.push_back(context.Args.MakeArgString(Twine("/OUT:") + OutputFile));
+
+    InvocationInfo II{Linker, Arguments};
+    II.allowsResponseFiles = true;
+    return II;
+  }
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1428,6 +1428,17 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     }
   }
 
+  if (const Arg *A = Args.getLastArg(options::OPT_lto)) {
+    auto LLVMLTOKind = llvm::StringSwitch<Optional<IRGenLLVMLTOKind>>(A->getValue())
+      .Case("llvm", IRGenLLVMLTOKind::Thin)
+      .Case("llvm-full", IRGenLLVMLTOKind::Full)
+      .Default(llvm::None);
+    if (LLVMLTOKind)
+      Opts.LLVMLTOKind = LLVMLTOKind.getValue();
+    else
+      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                     A->getAsString(Args), A->getValue());
+  }
 
   if (const Arg *A = Args.getLastArg(options::OPT_sanitize_coverage_EQ)) {
     Opts.SanitizeCoverage =

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -548,9 +548,14 @@ bool swift::performLLVM(const IRGenOptions &Opts,
   case IRGenOutputKind::LLVMAssembly:
     EmitPasses.add(createPrintModulePass(*RawOS));
     break;
-  case IRGenOutputKind::LLVMBitcode:
-    EmitPasses.add(createBitcodeWriterPass(*RawOS));
+  case IRGenOutputKind::LLVMBitcode: {
+    if (Opts.LLVMLTOKind == IRGenLLVMLTOKind::Thin) {
+      EmitPasses.add(createWriteThinLTOBitcodePass(*RawOS));
+    } else {
+      EmitPasses.add(createBitcodeWriterPass(*RawOS));
+    }
     break;
+  }
   case IRGenOutputKind::NativeAssembly:
   case IRGenOutputKind::ObjectFile: {
     CodeGenFileType FileType;

--- a/test/Driver/Inputs/lto/lib.swift
+++ b/test/Driver/Inputs/lto/lib.swift
@@ -1,0 +1,1 @@
+public func libraryFunction() {}

--- a/test/Driver/Inputs/lto/main.swift
+++ b/test/Driver/Inputs/lto/main.swift
@@ -1,0 +1,3 @@
+import A
+
+libraryFunction()

--- a/test/Driver/Inputs/lto/multifiles/file.swift
+++ b/test/Driver/Inputs/lto/multifiles/file.swift
@@ -1,0 +1,3 @@
+func anotherFileFunction() {
+  print(#function)
+}

--- a/test/Driver/Inputs/lto/multifiles/main.swift
+++ b/test/Driver/Inputs/lto/multifiles/main.swift
@@ -1,0 +1,1 @@
+anotherFileFunction()

--- a/test/Driver/link-time-opt-lib-thin.swift
+++ b/test/Driver/link-time-opt-lib-thin.swift
@@ -1,0 +1,12 @@
+// FIXME: ld64 in Xcode toolchain uses older version of LLVM than swiftc, so ld64 can't read module summary for LTO 
+//        from bitcode file produced by compiler. This should be fixed before shipping Xcode toolchain by upgrading
+//        LLVM version used in ld64.
+// XFAIL: OS=macosx
+// XFAIL: OS=tvos
+// XFAIL: OS=watchos
+// XFAIL: OS=ios
+// RUN: rm -rf %t
+// RUN: %empty-directory(%t/thin)
+
+// RUN: %target-swiftc_driver %S/Inputs/lto/lib.swift -lto=llvm -emit-library -emit-module -module-name A -working-directory %t/thin
+// RUN: %target-swiftc_driver %S/Inputs/lto/main.swift -L. -I. -lA -lto=llvm -working-directory %t/thin

--- a/test/Driver/link-time-opt-lib.swift
+++ b/test/Driver/link-time-opt-lib.swift
@@ -1,0 +1,5 @@
+// RUN: rm -rf %t
+// RUN: %empty-directory(%t/full)
+
+// RUN: %target-swiftc_driver %S/Inputs/lto/lib.swift -lto=llvm-full -emit-library -emit-module -module-name A -working-directory %t/full
+// RUN: %target-swiftc_driver %S/Inputs/lto/main.swift -L. -I. -lA -lto=llvm-full -working-directory %t/full

--- a/test/Driver/link-time-opt-staticlib-thin.swift
+++ b/test/Driver/link-time-opt-staticlib-thin.swift
@@ -1,0 +1,14 @@
+// UNSUPPORTED: OS=windows-msvc
+// FIXME: ld64 in Xcode toolchain uses older version of LLVM than swiftc, so ld64 can't read module summary for LTO 
+//        from bitcode file produced by compiler. This should be fixed before shipping Xcode toolchain by upgrading
+//        LLVM version used in ld64.
+// XFAIL: OS=macosx
+// XFAIL: OS=tvos
+// XFAIL: OS=watchos
+// XFAIL: OS=ios
+
+// RUN: rm -rf %t
+// RUN: %empty-directory(%t/thin-static)
+
+// RUN: %target-swiftc_driver %S/Inputs/lto/lib.swift -static -lto=llvm -emit-library -emit-module -module-name A -working-directory %t/thin-static
+// RUN: %target-swiftc_driver %S/Inputs/lto/main.swift -L. -I. -lA -lto=llvm -working-directory %t/thin-static

--- a/test/Driver/link-time-opt-staticlib.swift
+++ b/test/Driver/link-time-opt-staticlib.swift
@@ -1,0 +1,6 @@
+// UNSUPPORTED: OS=windows-msvc
+// RUN: rm -rf %t
+// RUN: %empty-directory(%t/full-static)
+
+// RUN: %target-swiftc_driver %S/Inputs/lto/lib.swift -static -lto=llvm-full -emit-library -emit-module -module-name A -working-directory %t/full-static
+// RUN: %target-swiftc_driver %S/Inputs/lto/main.swift -L. -I. -lA -lto=llvm-full -working-directory %t/full-static

--- a/test/Driver/link-time-opt.swift
+++ b/test/Driver/link-time-opt.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift -lto=llvm | %FileCheck %s --check-prefix=CHECK-%target-os --check-prefix=CHECK
+// CHECK: swift{{(c\.exe")?}} -frontend -emit-bc
+// CHECK-macosx-NEXT: bin/ld {{.+}} -lto_library {{.+}}/lib/libLTO.dylib
+// CHECK-windows-msvc-NEXT: clang.exe" {{.+}} -fuse-ld=lld -flto=thin
+// CHECK-linux-gnu-NEXT: bin/clang {{.+}} -flto=thin

--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -97,6 +97,7 @@ git clone --depth 1 --single-branch https://github.com/apple/swift-cmark cmark %
 git clone --depth 1 --single-branch --branch swift/master https://github.com/apple/llvm-project llvm-project %exitOnError%
 mklink /D "%source_root%\clang" "%source_root%\llvm-project\clang"
 mklink /D "%source_root%\llvm" "%source_root%\llvm-project\llvm"
+mklink /D "%source_root%\lld" "%source_root%\llvm-project\lld"
 mklink /D "%source_root%\lldb" "%source_root%\llvm-project\lldb"
 mklink /D "%source_root%\compiler-rt" "%source_root%\llvm-project\compiler-rt"
 mklink /D "%source_root%\libcxx" "%source_root%\llvm-project\libcxx"
@@ -165,7 +166,7 @@ cmake^
     -DLLVM_DEFAULT_TARGET_TRIPLE=x86_64-unknown-windows-msvc^
     -DLLVM_ENABLE_PDB:BOOL=YES^
     -DLLVM_ENABLE_ASSERTIONS:BOOL=YES^
-    -DLLVM_ENABLE_PROJECTS:STRING=clang^
+    -DLLVM_ENABLE_PROJECTS:STRING=lld;clang^
     -DLLVM_TARGETS_TO_BUILD:STRING="AArch64;ARM;X86"^
     -DLLVM_INCLUDE_BENCHMARKS:BOOL=NO^
     -DLLVM_INCLUDE_DOCS:BOOL=NO^


### PR DESCRIPTION
Resolve CI failure on android and other hosts addressed at  https://github.com/apple/swift/pull/31146#issuecomment-640259541 and restore https://github.com/apple/swift/pull/32235


Android test cases try to use gold linker `-use-ld=gold` but we don't support gold and other linkers except for lld for LTO now. So I changed to force to use lld when LTO on Unix like toolchain
```
: 'RUN: at line 13';   /home/ubuntu/jenkins/workspace/oss-swift-RA-linux-ubuntu-16.04-android/buildbot_linux/swift-linux-x86_64/bin/swiftc -target armv7-none-linux-android -toolchain-stdlib-rpath -Xcc --sysroot=/home/ubuntu/android-ndk-r17/platforms/android-21/arch-arm -Xclang-linker --sysroot=/home/ubuntu/android-ndk-r17/platforms/android-21/arch-arm -tools-directory /home/ubuntu/android-ndk-r17/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/arm-linux-androideabi/bin -L /home/ubuntu/android-ndk-r17/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a -L /home/ubuntu/android-ndk-r17/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/lib/gcc/arm-linux-androideabi/4.9.x -L /home/ubuntu/android-ndk-r17/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/arm-linux-androideabi/lib  -module-cache-path '/home/ubuntu/jenkins/workspace/oss-swift-RA-linux-ubuntu-16.04-android/buildbot_linux/swift-linux-x86_64/swift-test-results/armv7-none-linux-androideabi/clang-module-cache' -use-ld=gold /home/ubuntu/jenkins/workspace/oss-swift-RA-linux-ubuntu-16.04-android/swift/test/Driver/Inputs/lto/lib.swift -static -lto=llvm -emit-library -emit-module -module-name A -working-directory /home/ubuntu/jenkins/workspace/oss-swift-RA-linux-ubuntu-16.04-android/buildbot_linux/swift-linux-x86_64/test-android-armv7/Driver/Output/link-time-opt-staticlib-thin.swift.tmp/thin-static

```

CC: @compnerd 
