### PR TITLE
[SIL] NFC: Simplify SILVTable and save 8 bytes per SILVTable

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -110,7 +110,7 @@ class SILModule {
 public:
   using FunctionListType = llvm::ilist<SILFunction>;
   using GlobalListType = llvm::ilist<SILGlobalVariable>;
-  using VTableListType = llvm::ilist<SILVTable>;
+  using VTableListType = llvm::ArrayRef<SILVTable*>;
   using PropertyListType = llvm::ilist<SILProperty>;
   using WitnessTableListType = llvm::ilist<SILWitnessTable>;
   using DefaultWitnessTableListType = llvm::ilist<SILDefaultWitnessTable>;
@@ -178,7 +178,7 @@ private:
   llvm::DenseMap<const ClassDecl *, SILVTable *> VTableMap;
 
   /// The list of SILVTables in the module.
-  VTableListType vtables;
+  std::vector<SILVTable*> vtables;
 
   /// This is a cache of vtable entries for quick look-up
   llvm::DenseMap<std::pair<const SILVTable *, SILDeclRef>, SILVTable::Entry>
@@ -404,20 +404,15 @@ public:
   const_iterator zombies_begin() const { return zombieFunctions.begin(); }
   const_iterator zombies_end() const { return zombieFunctions.end(); }
 
+  llvm::ArrayRef<SILVTable*> getVTables() const {
+    return llvm::ArrayRef<SILVTable*>(vtables);
+  }
   using vtable_iterator = VTableListType::iterator;
   using vtable_const_iterator = VTableListType::const_iterator;
-  VTableListType &getVTableList() { return vtables; }
-  const VTableListType &getVTableList() const { return vtables; }
-  vtable_iterator vtable_begin() { return vtables.begin(); }
-  vtable_iterator vtable_end() { return vtables.end(); }
-  vtable_const_iterator vtable_begin() const { return vtables.begin(); }
-  vtable_const_iterator vtable_end() const { return vtables.end(); }
-  iterator_range<vtable_iterator> getVTables() {
-    return {vtables.begin(), vtables.end()};
-  }
-  iterator_range<vtable_const_iterator> getVTables() const {
-    return {vtables.begin(), vtables.end()};
-  }
+  vtable_iterator vtable_begin() { return getVTables().begin(); }
+  vtable_iterator vtable_end() { return getVTables().end(); }
+  vtable_const_iterator vtable_begin() const { return getVTables().begin(); }
+  vtable_const_iterator vtable_end() const { return getVTables().end(); }
 
   using witness_table_iterator = WitnessTableListType::iterator;
   using witness_table_const_iterator = WitnessTableListType::const_iterator;

--- a/include/swift/SIL/SILVTable.h
+++ b/include/swift/SIL/SILVTable.h
@@ -29,8 +29,6 @@
 #include "swift/SIL/SILAllocated.h"
 #include "swift/SIL/SILDeclRef.h"
 #include "swift/SIL/SILFunction.h"
-#include "llvm/ADT/ilist_node.h"
-#include "llvm/ADT/ilist.h"
 #include "llvm/ADT/Optional.h"
 #include <algorithm>
 
@@ -44,8 +42,7 @@ class SILModule;
 /// A mapping from each dynamically-dispatchable method of a class to the
 /// SILFunction that implements the method for that class.
 /// Note that dead methods are completely removed from the vtable.
-class SILVTable : public llvm::ilist_node<SILVTable>,
-                  public SILAllocated<SILVTable> {
+class SILVTable : public SILAllocated<SILVTable> {
 public:
   // TODO: Entry should include substitutions needed to invoke an overridden
   // generic base class method.

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1000,7 +1000,7 @@ static void countStatsPostSILOpt(UnifiedStatsReporter &Stats,
   auto &C = Stats.getFrontendCounters();
   // FIXME: calculate these in constant time, via the dense maps.
   C.NumSILOptFunctions += Module.getFunctionList().size();
-  C.NumSILOptVtables += Module.getVTableList().size();
+  C.NumSILOptVtables += Module.getVTables().size();
   C.NumSILOptWitnessTables += Module.getWitnessTableList().size();
   C.NumSILOptDefaultWitnessTables += Module.getDefaultWitnessTableList().size();
   C.NumSILOptGlobalVariables += Module.getSILGlobalList().size();

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -736,7 +736,7 @@ static void countStatsPostSILGen(UnifiedStatsReporter &Stats,
   auto &C = Stats.getFrontendCounters();
   // FIXME: calculate these in constant time, via the dense maps.
   C.NumSILGenFunctions += Module.getFunctionList().size();
-  C.NumSILGenVtables += Module.getVTableList().size();
+  C.NumSILGenVtables += Module.getVTables().size();
   C.NumSILGenWitnessTables += Module.getWitnessTableList().size();
   C.NumSILGenDefaultWitnessTables += Module.getDefaultWitnessTableList().size();
   C.NumSILGenGlobalVariables += Module.getSILGlobalList().size();

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -115,6 +115,9 @@ SILModule::~SILModule() {
   for (SILGlobalVariable &v : silGlobals)
     v.dropAllReferences();
 
+  for (auto vt : vtables)
+    vt->~SILVTable();
+
   // Drop everything functions in this module reference.
   //
   // This is necessary since the functions may reference each other.  We don't

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -2797,15 +2797,15 @@ static void printSILFunctions(SILPrintContext &Ctx,
 static void printSILVTables(SILPrintContext &Ctx,
                             const SILModule::VTableListType &VTables) {
   if (!Ctx.sortSIL()) {
-    for (const SILVTable &vt : VTables)
-      vt.print(Ctx.OS(), Ctx.printVerbose());
+    for (const auto &vt : VTables)
+      vt->print(Ctx.OS(), Ctx.printVerbose());
     return;
   }
 
   std::vector<const SILVTable *> vtables;
   vtables.reserve(VTables.size());
-  for (const SILVTable &vt : VTables)
-    vtables.push_back(&vt);
+  for (const auto &vt : VTables)
+    vtables.push_back(vt);
   std::sort(vtables.begin(), vtables.end(),
     [] (const SILVTable *v1, const SILVTable *v2) -> bool {
       StringRef Name1 = v1->getClass()->getName().str();
@@ -3067,7 +3067,7 @@ void SILModule::print(SILPrintContext &PrintCtx, ModuleDecl *M,
   printSILDifferentiabilityWitnesses(PrintCtx,
                                      getDifferentiabilityWitnessList());
   printSILFunctions(PrintCtx, getFunctionList());
-  printSILVTables(PrintCtx, getVTableList());
+  printSILVTables(PrintCtx, getVTables());
   printSILWitnessTables(PrintCtx, getWitnessTableList());
   printSILDefaultWitnessTables(PrintCtx, getDefaultWitnessTableList());
   printSILCoverageMaps(PrintCtx, getCoverageMaps());

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -5367,8 +5367,8 @@ void SILVTable::verify(const SILModule &M) const {
   auto superclass = getClass()->getSuperclassDecl();
   if (superclass) {
     for (auto &vt : M.getVTables()) {
-      if (vt.getClass() == superclass) {
-        superVTable = &vt;
+      if (vt->getClass() == superclass) {
+        superVTable = vt;
         break;
       }
     }
@@ -5582,15 +5582,15 @@ void SILModule::verify() const {
   // Check all vtables and the vtable cache.
   llvm::DenseSet<ClassDecl*> vtableClasses;
   unsigned EntriesSZ = 0;
-  for (const SILVTable &vt : getVTables()) {
-    if (!vtableClasses.insert(vt.getClass()).second) {
-      llvm::errs() << "Vtable redefined: " << vt.getClass()->getName() << "!\n";
+  for (const auto &vt : getVTables()) {
+    if (!vtableClasses.insert(vt->getClass()).second) {
+      llvm::errs() << "Vtable redefined: " << vt->getClass()->getName() << "!\n";
       assert(false && "triggering standard assertion failure routine");
     }
-    vt.verify(*this);
+    vt->verify(*this);
     // Check if there is a cache entry for each vtable entry
-    for (auto entry : vt.getEntries()) {
-      if (VTableEntryCache.find({&vt, entry.Method}) == VTableEntryCache.end()) {
+    for (auto entry : vt->getEntries()) {
+      if (VTableEntryCache.find({vt, entry.Method}) == VTableEntryCache.end()) {
         llvm::errs() << "Vtable entry for function: "
                      << entry.Implementation->getName() << "not in cache!\n";
         assert(false && "triggering standard assertion failure routine");

--- a/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
@@ -107,10 +107,10 @@ void CalleeCache::computeClassMethodCallees() {
   // This is a little bit more complicated than to just check the VTable
   // entry.Method itself, because an overridden method might be more accessible
   // than the base method (e.g. a public method overrides a private method).
-  for (auto &VTable : M.getVTableList()) {
-    assert(!VTable.getClass()->hasClangNode());
+  for (auto &VTable : M.getVTables()) {
+    assert(!VTable->getClass()->hasClangNode());
 
-    for (Decl *member : VTable.getClass()->getMembers()) {
+    for (Decl *member : VTable->getClass()->getMembers()) {
       if (auto *afd = dyn_cast<AbstractFunctionDecl>(member)) {
         // If a method implementation might be overridden in another translation
         // unit, also mark all the base methods as 'unknown'.
@@ -127,8 +127,8 @@ void CalleeCache::computeClassMethodCallees() {
   }
 
   // Second step: collect all implementations of a method.
-  for (auto &VTable : M.getVTableList()) {
-    for (const SILVTable::Entry &entry : VTable.getEntries()) {
+  for (auto &VTable : M.getVTables()) {
+    for (const SILVTable::Entry &entry : VTable->getEntries()) {
       if (auto *afd = entry.Method.getAbstractFunctionDecl()) {
         CalleesAndCanCallUnknown &callees = getOrCreateCalleesForMethod(entry.Method);
         if (unknownCallees.count(afd) != 0)
@@ -308,8 +308,8 @@ void BasicCalleeAnalysis::print(llvm::raw_ostream &os) const {
     os << "<no cache>\n";
   }
   llvm::DenseSet<SILDeclRef> printed;
-  for (auto &VTable : M.getVTableList()) {
-    for (const SILVTable::Entry &entry : VTable.getEntries()) {
+  for (auto &VTable : M.getVTables()) {
+    for (const SILVTable::Entry &entry : VTable->getEntries()) {
       if (printed.insert(entry.Method).second) {
         os << "callees for " << entry.Method << ":\n";
         Cache->getCalleeList(entry.Method).print(os);

--- a/lib/SILOptimizer/Analysis/ClassHierarchyAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ClassHierarchyAnalysis.cpp
@@ -23,8 +23,8 @@ void ClassHierarchyAnalysis::init() {
   auto module = M->getSwiftModule();
 
   // For each class declaration in our V-table list:
-  for (auto &VT : M->getVTableList()) {
-    ClassDecl *C = VT.getClass();
+  for (auto &VT : M->getVTables()) {
+    ClassDecl *C = VT->getClass();
 
     while (true) {
       // Ignore classes that are at the top of the class hierarchy:

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -440,8 +440,8 @@ class DeadFunctionElimination : FunctionLivenessComputation {
 
   void collectMethodImplementations() {
     // Collect vtable method implementations.
-    for (SILVTable &vTable : Module->getVTableList()) {
-      for (const SILVTable::Entry &entry : vTable.getEntries()) {
+    for (auto &vTable : Module->getVTables()) {
+      for (const SILVTable::Entry &entry : vTable->getEntries()) {
         // We don't need to collect destructors because we mark them as alive
         // anyway.
         if (entry.Method.kind == SILDeclRef::Kind::Deallocator ||
@@ -452,7 +452,7 @@ class DeadFunctionElimination : FunctionLivenessComputation {
         auto *fd = getBaseMethod(cast<AbstractFunctionDecl>(
                                                     entry.Method.getDecl()));
         MethodInfo *mi = getMethodInfo(fd, /*isWitnessTable*/ false);
-        mi->addClassMethodImpl(F, vTable.getClass());
+        mi->addClassMethodImpl(F, vTable->getClass());
       }
     }
 
@@ -500,8 +500,8 @@ class DeadFunctionElimination : FunctionLivenessComputation {
     collectMethodImplementations();
 
     // Check vtable methods.
-    for (SILVTable &vTable : Module->getVTableList()) {
-      for (const SILVTable::Entry &entry : vTable.getEntries()) {
+    for (auto &vTable : Module->getVTables()) {
+      for (const SILVTable::Entry &entry : vTable->getEntries()) {
         if (entry.Method.kind == SILDeclRef::Kind::Deallocator ||
             entry.Method.kind == SILDeclRef::Kind::IVarDestroyer) {
           // Destructors are alive because they are called from swift_release
@@ -600,9 +600,9 @@ class DeadFunctionElimination : FunctionLivenessComputation {
   /// Removes all dead methods from vtables and witness tables.
   bool removeDeadEntriesFromTables() {
     bool changedTable = false;
-    for (SILVTable &vTable : Module->getVTableList()) {
-      vTable.removeEntries_if([this, &changedTable]
-                              (SILVTable::Entry &entry) -> bool {
+    for (auto &vTable : Module->getVTables()) {
+      vTable->removeEntries_if([this, &changedTable]
+                               (SILVTable::Entry &entry) -> bool {
         if (!isAlive(entry.Implementation)) {
           LLVM_DEBUG(llvm::dbgs() << "  erase dead vtable method "
                                   << entry.Implementation->getName() << "\n");

--- a/lib/SILOptimizer/Transforms/PruneVTables.cpp
+++ b/lib/SILOptimizer/Transforms/PruneVTables.cpp
@@ -61,7 +61,7 @@ class PruneVTables : public SILModuleTransform {
     SILModule *M = getModule();
     
     for (auto &vtable : M->getVTables()) {
-      runOnVTable(M, &vtable);
+      runOnVTable(M, vtable);
     }
   }
 };

--- a/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
@@ -427,7 +427,7 @@ class SerializeSILPass : public SILModuleTransform {
     }
 
     for (auto &VT : M.getVTables()) {
-      VT.setSerialized(IsNotSerialized);
+      VT->setSerialized(IsNotSerialized);
     }
   }
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2659,10 +2659,10 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
   // Go through all SILVTables in SILMod and write them if we should
   // serialize everything.
   // FIXME: Resilience: could write out vtable for fragile classes.
-  for (const SILVTable &vt : SILMod->getVTables()) {
-    if ((ShouldSerializeAll || vt.isSerialized()) &&
-        SILMod->shouldSerializeEntitiesAssociatedWithDeclContext(vt.getClass()))
-      writeSILVTable(vt);
+  for (const auto &vt : SILMod->getVTables()) {
+    if ((ShouldSerializeAll || vt->isSerialized()) &&
+        SILMod->shouldSerializeEntitiesAssociatedWithDeclContext(vt->getClass()))
+      writeSILVTable(*vt);
   }
   
   // Write out property descriptors.

--- a/tools/sil-nm/SILNM.cpp
+++ b/tools/sil-nm/SILNM.cpp
@@ -126,8 +126,8 @@ static void nmModule(SILModule *M) {
   {
     std::vector<StringRef> VTableNames;
     llvm::transform(M->getVTables(), std::back_inserter(VTableNames),
-                    [](const SILVTable &VT) -> StringRef {
-                      return VT.getClass()->getName().str();
+                    [](const SILVTable *VT) -> StringRef {
+                      return VT->getClass()->getName().str();
                     });
     printAndSortNames(VTableNames, 'V');
   }


### PR DESCRIPTION
**EDITED**

We are not using the primary benefits of an intrusive list, namely the ability to insert or remove from the middle of the list, so let's switch to a plain vector. This also avoids linked-list pointer chasing.

**OLD TEXT**

I noticed that vtables were being tracked redundantly by SILModule and nothing seems to be using the intrusive list aspect of SILVTable, so I tried just converging everything onto the DenseMap. This almost works, but then the destructor for SILModule blows up when it finds a function with a non-zero reference count. This surprised me.

Am I missing something obvious?