### PR TITLE
[GSoC] Refactor DiagnosticEngine to use `YAML` files

### DIFF
--- a/include/swift/AST/CMakeLists.txt
+++ b/include/swift/AST/CMakeLists.txt
@@ -1,0 +1,3 @@
+swift_install_in_component(DIRECTORY diagnostics
+                           DESTINATION "share/swift/"
+                           COMPONENT compiler)

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -58,6 +58,11 @@ namespace swift {
     DiagID ID;
   };
 
+  struct DiagnosticNode {
+    DiagID id;
+    std::string msg;    
+  };
+
   namespace detail {
     /// Describes how to pass a diagnostic argument of the given type.
     ///
@@ -629,6 +634,26 @@ namespace swift {
     DiagnosticState(DiagnosticState &&) = default;
     DiagnosticState &operator=(DiagnosticState &&) = default;
   };
+
+  class LocalizationProducer {
+  public:
+    /// If the  message isn't available/localized in the current `yaml` file,
+    /// return the fallback default message.
+    virtual std::string getMessageOr(DiagID id,
+                                     std::string defaultMessage) const {
+      return defaultMessage;
+    }
+    
+    virtual ~LocalizationProducer() { }
+  };
+
+  class YAMLLocalizationProducer final : public LocalizationProducer {
+  public:
+    std::vector<DiagnosticNode> diagnostics;
+    explicit YAMLLocalizationProducer(std::string locale, std::string path);
+    std::string getMessageOr(DiagID id,
+                             std::string defaultMessage) const override;
+  };
     
   /// Class responsible for formatting diagnostics and presenting them
   /// to the user.
@@ -662,6 +687,9 @@ namespace swift {
     /// This is required because diagnostics are not directly emitted
     /// but rather stored until all transactions complete.
     llvm::StringSet<llvm::BumpPtrAllocator &> TransactionStrings;
+
+    /// Diagnostic producer to handle the logic behind retriving a localized diagnostic message.
+    std::unique_ptr<LocalizationProducer> localization;
 
     /// The number of open diagnostic transactions. Diagnostics are only
     /// emitted once all transactions have closed.
@@ -732,6 +760,11 @@ namespace swift {
     }
     StringRef getDiagnosticDocumentationPath() {
       return diagnosticDocumentationPath;
+    }
+
+    void setLocalization(std::string locale, std::string path) {
+      if (!locale.empty() && !path.empty())
+        localization = std::make_unique<YAMLLocalizationProducer>(locale, path);
     }
 
     void ignoreDiagnostic(DiagID id) {
@@ -955,8 +988,8 @@ namespace swift {
     void emitTentativeDiagnostics();
 
   public:
-    static const char *diagnosticStringFor(const DiagID id,
-                                           bool printDiagnosticName);
+    const char *diagnosticStringFor(const DiagID id,
+                                    bool printDiagnosticName);
 
     /// If there is no clear .dia file for a diagnostic, put it in the one
     /// corresponding to the SourceLoc given here.

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -649,7 +649,7 @@ namespace swift {
 
   class YAMLLocalizationProducer final : public LocalizationProducer {
   public:
-    std::vector<DiagnosticNode> diagnostics;
+    std::vector<std::string> diagnostics;
     explicit YAMLLocalizationProducer(std::string locale, std::string path);
     std::string getMessageOr(DiagID id,
                              std::string defaultMessage) const override;

--- a/include/swift/AST/DiagnosticMessageFormat.h
+++ b/include/swift/AST/DiagnosticMessageFormat.h
@@ -1,0 +1,42 @@
+//===--- DiagnosticMessageFormat.h - YAML format for Diagnostic Messages ---*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the YAML format for diagnostic messages.
+// 
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/YAMLTraits.h"
+#include "DiagnosticList.cpp"
+
+namespace llvm {
+namespace yaml {
+
+template<>
+struct ScalarEnumerationTraits<swift::DiagID> {
+  static void enumeration(IO &io, swift::DiagID &value) {
+#define DIAG(KIND,ID,Options,Text,Signature) io.enumCase(value, #ID, swift::DiagID::ID);
+#include "swift/AST/DiagnosticsAll.def"
+  }
+};
+
+template <>
+struct MappingTraits<swift::DiagnosticNode> {
+  static void mapping(IO &io, swift::DiagnosticNode &node) {
+    io.mapRequired("id", node.id);
+    io.mapRequired("msg", node.msg);
+  }
+};
+
+}
+}
+
+LLVM_YAML_IS_SEQUENCE_VECTOR(swift::DiagnosticNode)

--- a/include/swift/AST/DiagnosticMessageFormat.h
+++ b/include/swift/AST/DiagnosticMessageFormat.h
@@ -1,0 +1,42 @@
+//===--- DiagnosticMessageFormat.h - YAML format for Diagnostic Messages ---*-
+//C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the YAML format for diagnostic messages.
+//
+//===----------------------------------------------------------------------===//
+
+#include "DiagnosticList.cpp"
+#include "llvm/Support/YAMLTraits.h"
+
+namespace llvm {
+namespace yaml {
+
+template <> struct ScalarEnumerationTraits<swift::DiagID> {
+  static void enumeration(IO &io, swift::DiagID &value) {
+#define DIAG(KIND, ID, Options, Text, Signature)                               \
+  io.enumCase(value, #ID, swift::DiagID::ID);
+#include "swift/AST/DiagnosticsAll.def"
+  }
+};
+
+template <> struct MappingTraits<swift::DiagnosticNode> {
+  static void mapping(IO &io, swift::DiagnosticNode &node) {
+    io.mapRequired("id", node.id);
+    io.mapRequired("msg", node.msg);
+  }
+};
+
+} // namespace yaml
+} // namespace llvm
+
+LLVM_YAML_IS_SEQUENCE_VECTOR(swift::DiagnosticNode)

--- a/include/swift/AST/Diagnostics/fr.yaml
+++ b/include/swift/AST/Diagnostics/fr.yaml
@@ -1,0 +1,19 @@
+#===--- fr.yaml - Localized diagnostic messages for French ---*- YAML -*-===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+#===----------------------------------------------------------------------===#
+#
+# This file defines the diagnostic messages for French language.
+# Each diagnostic is described in the following format:
+# - id: <diagnostic-id>
+#   msg: <diagnostic-message>
+# 
+#===----------------------------------------------------------------------===#
+

--- a/include/swift/AST/diagnostics/en.yaml
+++ b/include/swift/AST/diagnostics/en.yaml
@@ -1,0 +1,19 @@
+#===--- en.yaml - Localized diagnostic messages for English ---*- YAML -*-===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+#===----------------------------------------------------------------------===#
+#
+# This file defines the diagnostic messages for English language.
+# Each diagnostic is described in the following format:
+# - id: <diagnostic-id>
+#   msg: <diagnostic-message>
+# 
+#===----------------------------------------------------------------------===#
+

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -19,7 +19,6 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/Decl.h"
-#include "swift/AST/DiagnosticMessageFormat.h"
 #include "swift/AST/DiagnosticSuppression.h"
 #include "swift/AST/DiagnosticMessageFormat.h"
 #include "swift/AST/Module.h"
@@ -37,8 +36,6 @@
 #include "llvm/Support/YAMLParser.h"
 #include "llvm/Support/YAMLTraits.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Support/YAMLParser.h"
-#include "llvm/Support/YAMLTraits.h"
 
 using namespace swift;
 

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -165,8 +165,8 @@ class LocalizationInput : public llvm::yaml::Input {
         // YAML file isn't guaranteed to have diagnostics in order of their
         // declaration in `.def` files, to accommodate that we need to leave
         // holes in diagnostic array for diagnostics which haven't yet been
-        // localized and for the ones that
-        // have `DiagnosticNode::id` indicates their position.
+        // localized and for the ones that have `DiagnosticNode::id` 
+        // indicates their position.
         Seq[static_cast<unsigned>(current.id)] = std::move(current.msg);
       }
     }

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -167,7 +167,7 @@ class LocalizationInput : public llvm::yaml::Input {
         // holes in diagnostic array for diagnostics which haven't yet been
         // localized and for the ones that
         // have `DiagnosticNode::id` indicates their position.
-        Seq[static_cast<unsigned>(current.id)] = std::move(current);
+        Seq[static_cast<unsigned>(current.id)] = std::move(current.msg);
       }
     }
     io.endSequence();
@@ -376,7 +376,7 @@ YAMLLocalizationProducer::YAMLLocalizationProducer(std::string locale,
 std::string
 YAMLLocalizationProducer::getMessageOr(DiagID id,
                                        std::string defaultMessage) const {
-  std::string diagnosticMessage = diagnostics[(unsigned)id].msg;
+  std::string diagnosticMessage = diagnostics[(unsigned)id];
   if (diagnosticMessage.empty())
     return defaultMessage;
   return diagnosticMessage;

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -181,7 +181,7 @@ class LocalizationInput : public llvm::yaml::Input {
     llvm::yaml::EmptyContext Ctx;
     if (yin.setCurrentDocument()) {
       // If YAML file's format doesn't match the current format in
-      // DiagnosticMessageFormat, will through an error.
+      // DiagnosticMessageFormat, will throw an error.
       readYAML(yin, diagnostics, true, Ctx);
     }
 

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/DiagnosticMessageFormat.h"
 #include "swift/AST/DiagnosticSuppression.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Pattern.h"
@@ -32,6 +33,8 @@
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/YAMLParser.h"
+#include "llvm/Support/YAMLTraits.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace swift;
@@ -139,6 +142,53 @@ struct EducationalNotes {
 
 static constexpr EducationalNotes<LocalDiagID::NumDiags> _EducationalNotes = EducationalNotes<LocalDiagID::NumDiags>();
 static constexpr auto educationalNotes = _EducationalNotes.value;
+
+class LocalizationInput : public llvm::yaml::Input {
+  using Input::Input;
+
+  /// Read diagnostics in the YAML file iteratively
+  template <typename T, typename Context>
+  static typename std::enable_if<llvm::yaml::has_SequenceTraits<T>::value,
+                                 void>::type
+  readYAML(IO &io, T &Seq, bool, Context &Ctx) {
+    unsigned count = io.beginSequence();
+
+    // Resize Diags from YAML file to be the same size
+    // as diagnosticStrings from def files.
+    Seq.resize(LocalDiagID::NumDiags);
+    for (unsigned i = 0; i < count; ++i) {
+      void *SaveInfo;
+      if (io.preflightElement(i, SaveInfo)) {
+        DiagnosticNode current;
+        yamlize(io, current, true, Ctx);
+        io.postflightElement(SaveInfo);
+
+        // YAML file isn't guaranteed to have diagnostics in order of their
+        // declaration in `.def` files, to accommodate that we need to leave
+        // holes in diagnostic array for diagnostics which haven't yet been
+        // localized and for the ones that
+        // have `DiagnosticNode::id` indicates their position.
+        Seq[static_cast<unsigned>(current.id)] = std::move(current);
+      }
+    }
+    io.endSequence();
+  }
+
+  template <typename T>
+  inline friend
+      typename std::enable_if<llvm::yaml::has_SequenceTraits<T>::value,
+                              LocalizationInput &>::type
+      operator>>(LocalizationInput &yin, T &diagnostics) {
+    llvm::yaml::EmptyContext Ctx;
+    if (yin.setCurrentDocument()) {
+      // If YAML file's format doesn't match the current format in
+      // DiagnosticMessageFormat, will through an error.
+      readYAML(yin, diagnostics, true, Ctx);
+    }
+
+    return yin;
+  }
+};
 
 DiagnosticState::DiagnosticState() {
   // Initialize our per-diagnostic state to default
@@ -309,6 +359,29 @@ void Diagnostic::addChildNote(Diagnostic &&D) {
   assert(storedDiagnosticInfos[(unsigned)ID].kind != DiagnosticKind::Note &&
          "Notes can't have children.");
   ChildNotes.push_back(std::move(D));
+}
+
+YAMLLocalizationProducer::YAMLLocalizationProducer(std::string locale,
+                                                   std::string path) {
+  llvm::SmallString<128> DiagnosticsFilePath(path);
+  llvm::sys::path::append(DiagnosticsFilePath, locale);
+  llvm::sys::path::replace_extension(DiagnosticsFilePath, ".yaml");
+  auto FileBufOrErr = llvm::MemoryBuffer::getFileOrSTDIN(DiagnosticsFilePath);
+  if (!FileBufOrErr)
+    llvm_unreachable("Failed to read yaml file");
+
+  llvm::MemoryBuffer *document = FileBufOrErr->get();
+  LocalizationInput yin(document->getBuffer());
+  yin >> diagnostics;
+}
+
+std::string
+YAMLLocalizationProducer::getMessageOr(DiagID id,
+                                       std::string defaultMessage) const {
+  std::string diagnosticMessage = diagnostics[(unsigned)id].msg;
+  if (diagnosticMessage.empty())
+    return defaultMessage;
+  return diagnosticMessage;
 }
 
 bool DiagnosticEngine::isDiagnosticPointsToFirstBadToken(DiagID ID) const {
@@ -1011,10 +1084,17 @@ void DiagnosticEngine::emitDiagnostic(const Diagnostic &diagnostic) {
 
 const char *DiagnosticEngine::diagnosticStringFor(const DiagID id,
                                                   bool printDiagnosticName) {
+  // TODO: Print diagnostic names from `localization`.
   if (printDiagnosticName) {
     return debugDiagnosticStrings[(unsigned)id];
   }
-  return diagnosticStrings[(unsigned)id];
+  auto defaultMessage = diagnosticStrings[(unsigned)id];
+  if (localization) {
+    std::string localizedMessage =
+        localization.get()->getMessageOr(id, defaultMessage);
+    return localizedMessage.c_str();
+  }
+  return defaultMessage;
 }
 
 const char *InFlightDiagnostic::fixItStringFor(const FixItID id) {

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticSuppression.h"
+#include "swift/AST/DiagnosticMessageFormat.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/PrintOptions.h"
@@ -33,6 +34,8 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/YAMLParser.h"
+#include "llvm/Support/YAMLTraits.h"
 
 using namespace swift;
 
@@ -139,6 +142,53 @@ struct EducationalNotes {
 
 static constexpr EducationalNotes<LocalDiagID::NumDiags> _EducationalNotes = EducationalNotes<LocalDiagID::NumDiags>();
 static constexpr auto educationalNotes = _EducationalNotes.value;
+
+class LocalizationInput : public llvm::yaml::Input {
+  using Input::Input;
+  
+  /// Read diagnostics in the YAML file iteratively
+  template <typename T, typename Context>
+  static
+  typename std::enable_if<llvm::yaml::has_SequenceTraits<T>::value, void>::type
+  readYAML(IO &io, T &Seq, bool, Context &Ctx) {
+    unsigned count = io.beginSequence();
+    
+    // Resize Diags from YAML file to be the same size
+    // as diagnosticStrings from def files.
+    Seq.resize(LocalDiagID::NumDiags);
+    for(unsigned i = 0; i < count; ++i) {
+      void *SaveInfo;
+      if (io.preflightElement(i, SaveInfo)) {
+        DiagnosticNode current;
+        yamlize(io, current, true, Ctx);
+        io.postflightElement(SaveInfo);
+        
+        // YAML file isn't guaranteed to have diagnostics in order of their
+        // declaration in `.def` files, to accommodate that we need to leave
+        // holes in diagnostic array for diagnostics which haven't yet been
+        // localized and for the ones that
+        // have `DiagnosticNode::id` indicates their position.
+        Seq[static_cast<unsigned>(current.id)] = std::move(current);
+      }
+    }
+    io.endSequence();
+  }
+
+  template <typename T>
+  inline friend
+  typename std::enable_if<llvm::yaml::has_SequenceTraits<T>::value,
+  LocalizationInput &>::type
+  operator>> (LocalizationInput &yin, T &diagnostics) {
+    llvm::yaml::EmptyContext Ctx;
+    if (yin.setCurrentDocument()) {
+      // If YAML file's format doesn't match the current format in DiagnosticMessageFormat,
+      // will through an error.
+      readYAML(yin, diagnostics, true, Ctx);
+    }
+
+    return yin;
+  }
+};
 
 DiagnosticState::DiagnosticState() {
   // Initialize our per-diagnostic state to default
@@ -309,6 +359,29 @@ void Diagnostic::addChildNote(Diagnostic &&D) {
   assert(storedDiagnosticInfos[(unsigned)ID].kind != DiagnosticKind::Note &&
          "Notes can't have children.");
   ChildNotes.push_back(std::move(D));
+}
+
+YAMLLocalizationProducer::YAMLLocalizationProducer(std::string locale,
+                                                   std::string path) {
+  llvm::SmallString<128> DiagnosticsFilePath(path);
+  llvm::sys::path::append(DiagnosticsFilePath, locale);
+  llvm::sys::path::replace_extension(DiagnosticsFilePath, ".yaml");
+  auto FileBufOrErr = llvm::MemoryBuffer::getFileOrSTDIN(DiagnosticsFilePath);
+  if (!FileBufOrErr)
+    llvm_unreachable("Failed to read yaml file");
+  
+  llvm::MemoryBuffer *document = FileBufOrErr->get();
+  LocalizationInput yin(document->getBuffer());
+  yin >> diagnostics;
+}
+
+std::string
+YAMLLocalizationProducer::getMessageOr(DiagID id,
+                                   std::string defaultMessage) const {
+  std::string diagnosticMessage = diagnostics[(unsigned)id].msg;
+  if (diagnosticMessage.empty())
+    return defaultMessage;
+  return diagnosticMessage;
 }
 
 bool DiagnosticEngine::isDiagnosticPointsToFirstBadToken(DiagID ID) const {
@@ -1011,10 +1084,16 @@ void DiagnosticEngine::emitDiagnostic(const Diagnostic &diagnostic) {
 
 const char *DiagnosticEngine::diagnosticStringFor(const DiagID id,
                                                   bool printDiagnosticName) {
+  // TODO: Print diagnostic names from `localization`.
   if (printDiagnosticName) {
     return debugDiagnosticStrings[(unsigned)id];
   }
-  return diagnosticStrings[(unsigned)id];
+  auto defaultMessage = diagnosticStrings[(unsigned)id];
+  if (localization) {
+    std::string localizedMessage = localization.get()->getMessageOr(id, defaultMessage);
+    return localizedMessage.c_str();
+  }
+  return defaultMessage;
 }
 
 const char *InFlightDiagnostic::fixItStringFor(const FixItID id) {


### PR DESCRIPTION
<!-- What's in this pull request? -->
In this PR, I modified the current `DiagnosticEngine` class to be able to parse diagnostic messages from `YAML` files in the future.

**Summary of changes:**
- [x] Created a `DiagnosticNode` `struct` to hold the objects of the `YAML` files.
- [x] Defined the `YAML` format for `DiagnosticNode`
- [x] Created a `CMakeLists.txt` file to handle where the `YAML` diagnostic files will be in the toolchain.
- [x] Refactored `DiagnosticEngine::diagnosticStringFor` to handle returning the diagnostics messages from `YAML` files and handle fall-backs if the diagnostic message isn't present in the current `YAML` file.

**Next steps after this PR gets merged:**
- Retrieve the diagnostic messages path from the compiler toolchain.
- Create a `-locale` compiler frontend flag for choosing the language. 
- Create a `-diagnostic-messages-path` compiler frontend flag to provide a path for the `YAML` files (to use in testing).
- Write tests.

cc @xedin 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!-- Resolves SR-NNNN. -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
