### PR TITLE
[metadata prespecialization] NFC: Replaced bool with enum.

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -671,7 +671,7 @@ static MetadataResponse emitNominalMetadataRef(IRGenFunction &IGF,
   } else if (auto theClass = dyn_cast<ClassDecl>(theDecl)) {
     if (isCanonicalSpecializedNominalTypeMetadataStaticallyAddressable(
             IGF.IGM, *theClass, theType,
-            /*usingCanonicalSpecializedAccessor=*/true)) {
+            ForUseOnlyFromAccessor)) {
       llvm::Function *accessor =
           IGF.IGM
               .getAddrOfCanonicalSpecializedGenericTypeMetadataAccessFunction(
@@ -698,7 +698,7 @@ static MetadataResponse emitNominalMetadataRef(IRGenFunction &IGF,
 
 bool irgen::isCanonicalSpecializedNominalTypeMetadataStaticallyAddressable(
     IRGenModule &IGM, NominalTypeDecl &nominal, CanType type,
-    bool usingCanonicalSpecializedAccessor) {
+    CanonicalSpecializedMetadataUsageIsOnlyFromAccessor onlyFromAccessor) {
   assert(nominal.isGenericContext());
 
   if (!IGM.shouldPrespecializeGenericMetadata()) {
@@ -787,7 +787,7 @@ bool irgen::isCanonicalSpecializedNominalTypeMetadataStaticallyAddressable(
         (protocols.size() > 0);
     };
     auto metadataAccessIsTrivial = [&]() {
-      if (usingCanonicalSpecializedAccessor) {
+      if (onlyFromAccessor) {
         // If an accessor is being used, then the accessor will be able to
         // initialize the arguments, i.e. register classes with the ObjC
         // runtime.
@@ -820,7 +820,7 @@ bool irgen::
   //   Struct<Klass<Int>>
   //   Enum<Klass<Int>>
   return isCanonicalSpecializedNominalTypeMetadataStaticallyAddressable(
-      IGM, nominal, type, /*usingCanonicalSpecializedAccessor=*/false);
+      IGM, nominal, type, NotForUseOnlyFromAccessor);
 }
 
 /// Is there a known address for canonical specialized metadata?  The metadata
@@ -840,7 +840,7 @@ bool irgen::isInitializableTypeMetadataStaticallyAddressable(IRGenModule &IGM,
     // runtime.
     // Concretely, Clazz<Klass<Int>> can be prespecialized.
     return isCanonicalSpecializedNominalTypeMetadataStaticallyAddressable(
-        IGM, *nominal, type, /*usingCanonicalSpecializedAccessor=*/true);
+        IGM, *nominal, type, ForUseOnlyFromAccessor);
   }
 
   return false;
@@ -922,7 +922,7 @@ bool irgen::shouldCacheTypeMetadataAccess(IRGenModule &IGM, CanType type) {
       return true;
     if (classDecl->isGenericContext() &&
         isCanonicalSpecializedNominalTypeMetadataStaticallyAddressable(
-            IGM, *classDecl, type, /*usingCanonicalSpecializedAccessor=*/true))
+            IGM, *classDecl, type, ForUseOnlyFromAccessor))
       return false;
     auto strategy = IGM.getClassMetadataStrategy(classDecl);
     return strategy != ClassMetadataStrategy::Fixed;

--- a/lib/IRGen/MetadataRequest.h
+++ b/lib/IRGen/MetadataRequest.h
@@ -508,16 +508,21 @@ bool shouldCacheTypeMetadataAccess(IRGenModule &IGM, CanType type);
 bool isInitializableTypeMetadataStaticallyAddressable(IRGenModule &IGM,
                                                       CanType type);
 
+enum CanonicalSpecializedMetadataUsageIsOnlyFromAccessor : bool {
+  ForUseOnlyFromAccessor = true,
+  NotForUseOnlyFromAccessor = false
+};
+
 /// Is the address of the canonical specialization of a generic metadata
 /// statically known?
 ///
 /// In other words, can a canonical specialization be formed for the specified
-/// type. If usingCanonicalSpecializedAccessor is true, then metadata's address
+/// type. If onlyFromAccess is ForUseOnlyFromAccessor, then metadata's address
 /// is known, but access to the metadata must go through the canonical
 /// specialized accessor so that initialization of the metadata can occur.
 bool isCanonicalSpecializedNominalTypeMetadataStaticallyAddressable(
     IRGenModule &IGM, NominalTypeDecl &nominal, CanType type,
-    bool usingCanonicalSpecializedAccessor);
+    CanonicalSpecializedMetadataUsageIsOnlyFromAccessor onlyFromAccessor);
 
 bool isCompleteCanonicalSpecializedNominalTypeMetadataStaticallyAddressable(
     IRGenModule &IGM, NominalTypeDecl &nominal, CanType type);


### PR DESCRIPTION
Previously a bool argument was passed to isCanonicalSpecializedNominalTypeMetadataStaticallyAddressable to indicate whether the metadata was to be used only from a specialized metadata accessor.  Here, that bool is replaced with an enum.