### PR TITLE
[Frontend] Populate files in getMainModule

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -490,7 +490,7 @@ public:
   }
 
   SWIFT_DEBUG_DUMP;
-  void dump(raw_ostream &os) const;
+  void dump(raw_ostream &os, bool parseIfNeeded = false) const;
 
   /// Pretty-print the contents of this source file.
   ///

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -105,7 +105,7 @@ public:
     /// decl.
     ///
     /// FIXME: When condition evaluation moves to a later phase, remove this
-    /// and adjust the client call 'performParseOnly'.
+    /// and the associated language option.
     DisablePoundIfEvaluation = 1 << 1,
 
     /// Whether to build a syntax tree.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -335,6 +335,10 @@ namespace swift {
     /// Whether to verify the parsed syntax tree and emit related diagnostics.
     bool VerifySyntaxTree = false;
 
+    /// Whether to disable the evaluation of '#if' decls, such that the bodies
+    /// of active clauses aren't hoisted into the enclosing scope.
+    bool DisablePoundIfEvaluation = false;
+
     /// Instead of hashing tokens inside of NominalType and ExtensionBodies into
     /// the interface hash, hash them into per-iterable-decl-context
     /// fingerprints. Fine-grained dependency types won't dirty every provides

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -652,8 +652,6 @@ private:
   /// Retrieve a description of which modules should be implicitly imported.
   ImplicitImportInfo getImplicitImportInfo() const;
 
-  void performSemaUpTo(SourceFile::ASTStage_t LimitStage);
-
   /// For any serialized AST inputs, loads them in as partial module files,
   /// appending them to \p partialModules. If a loading error occurs, returns
   /// \c true.

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -616,8 +616,7 @@ public:
   void performSema();
 
   /// Parses the input file but does no type-checking or module imports.
-  void performParseOnly(bool EvaluateConditionals = false,
-                        bool CanDelayBodies = true);
+  void performParseOnly();
 
   /// Parses and performs import resolution on all input files.
   ///
@@ -633,8 +632,7 @@ public:
 private:
   SourceFile *
   createSourceFileForMainModule(SourceFileKind FileKind,
-                                Optional<unsigned> BufferID,
-                                SourceFile::ParsingOptions options = {});
+                                Optional<unsigned> BufferID);
 
 public:
   void freeASTContext();
@@ -647,8 +645,7 @@ private:
   /// Retrieve a description of which modules should be implicitly imported.
   ImplicitImportInfo getImplicitImportInfo() const;
 
-  void performSemaUpTo(SourceFile::ASTStage_t LimitStage,
-                       SourceFile::ParsingOptions POpts = {});
+  void performSemaUpTo(SourceFile::ASTStage_t LimitStage);
 
   /// Return true if had load error
   bool loadPartialModulesAndImplicitImports();

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -460,7 +460,7 @@ class CompilerInstance {
   /// If \p BufID is already in the set, do nothing.
   void recordPrimaryInputBuffer(unsigned BufID);
 
-  bool isWholeModuleCompilation() { return PrimaryBufferIDs.empty(); }
+  bool isWholeModuleCompilation() const { return PrimaryBufferIDs.empty(); }
 
 public:
   // Out of line to avoid having to import SILModule.h.
@@ -642,6 +642,9 @@ public:
   bool loadStdlibIfNeeded();
 
 private:
+  /// Compute the parsing options for a source file in the main module.
+  SourceFile::ParsingOptions getSourceFileParsingOptions(bool forPrimary) const;
+
   /// Retrieve a description of which modules should be implicitly imported.
   ImplicitImportInfo getImplicitImportInfo() const;
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -616,9 +616,6 @@ public:
   /// Parses and type-checks all input files.
   void performSema();
 
-  /// Parses the input file but does no type-checking or module imports.
-  void performParseOnly();
-
   /// Parses and performs import resolution on all input files.
   ///
   /// This is similar to a parse-only invocation, but module imports will also

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1420,7 +1420,13 @@ void SourceFile::dump() const {
   dump(llvm::errs());
 }
 
-void SourceFile::dump(llvm::raw_ostream &OS) const {
+void SourceFile::dump(llvm::raw_ostream &OS, bool parseIfNeeded) const {
+  // If we're allowed to parse the SourceFile, do so now. We need to force the
+  // parsing request as by default the dumping logic tries not to kick any
+  // requests.
+  if (parseIfNeeded)
+    (void)getTopLevelDecls();
+
   PrintDecl(OS).visitSourceFile(*this);
   llvm::errs() << '\n';
 }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2233,6 +2233,8 @@ SourceFile::SourceFile(ModuleDecl &M, SourceFileKind K,
 SourceFile::ParsingOptions
 SourceFile::getDefaultParsingOptions(const LangOptions &langOpts) {
   ParsingOptions opts;
+  if (langOpts.DisablePoundIfEvaluation)
+    opts |= ParsingFlags::DisablePoundIfEvaluation;
   if (langOpts.BuildSyntaxTree)
     opts |= ParsingFlags::BuildSyntaxTree;
   if (langOpts.CollectParsedToken)

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -784,8 +784,6 @@ void CompilerInstance::performParseOnly() {
   (void)Kind;
 
   performSemaUpTo(SourceFile::Unprocessed);
-  assert(Context->LoadedModules.size() == 1 &&
-         "Loaded a module during parse-only");
 }
 
 void CompilerInstance::performParseAndResolveImportsOnly() {

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -776,16 +776,6 @@ void CompilerInstance::setMainModule(ModuleDecl *newMod) {
   Context->LoadedModules[newMod->getName()] = newMod;
 }
 
-void CompilerInstance::performParseOnly() {
-  const InputFileKind Kind = Invocation.getInputKind();
-  assert((Kind == InputFileKind::Swift || Kind == InputFileKind::SwiftLibrary ||
-          Kind == InputFileKind::SwiftModuleInterface) &&
-         "only supports parsing .swift files");
-  (void)Kind;
-
-  performSemaUpTo(SourceFile::Unprocessed);
-}
-
 void CompilerInstance::performParseAndResolveImportsOnly() {
   performSemaUpTo(SourceFile::ImportsResolved);
 }

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1274,14 +1274,7 @@ static bool performCompile(CompilerInstance &Instance,
   }
 
   if (FrontendOptions::shouldActionOnlyParse(Action)) {
-    // Disable delayed parsing of type and function bodies when we've been
-    // asked to dump the resulting AST.
-    bool CanDelayBodies = Action != FrontendOptions::ActionType::DumpParse;
-    bool EvaluateConditionals =
-        Action == FrontendOptions::ActionType::EmitImportedModules
-        || Action == FrontendOptions::ActionType::ScanDependencies;
-    Instance.performParseOnly(EvaluateConditionals,
-                              CanDelayBodies);
+    Instance.performParseOnly();
   } else if (Action == FrontendOptions::ActionType::ResolveImports) {
     Instance.performParseAndResolveImportsOnly();
   } else {

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -1180,8 +1180,6 @@ getNotableRegions(StringRef SourceText, unsigned NameOffset, StringRef Name,
   if (Instance->setup(Invocation))
     llvm_unreachable("Failed setup");
 
-  Instance->performParseOnly();
-
   unsigned BufferId = Instance->getPrimarySourceFile()->getBufferID().getValue();
   SourceManager &SM = Instance->getSourceMgr();
   SourceLoc NameLoc = SM.getLocForOffset(BufferId, NameOffset);

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -1174,6 +1174,7 @@ getNotableRegions(StringRef SourceText, unsigned NameOffset, StringRef Name,
   Invocation.getFrontendOptions().InputsAndOutputs.addInput(
       InputFile("<extract>", true, InputBuffer.get()));
   Invocation.getFrontendOptions().ModuleName = "extract";
+  Invocation.getLangOptions().DisablePoundIfEvaluation = true;
 
   auto Instance = std::make_unique<swift::CompilerInstance>();
   if (Instance->setup(Invocation))

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -814,10 +814,7 @@ static bool makeParserAST(CompilerInstance &CI, StringRef Text,
   Buf = llvm::MemoryBuffer::getMemBuffer(Text, "<module-interface>");
   Invocation.getFrontendOptions().InputsAndOutputs.addInput(
       InputFile(Buf.get()->getBufferIdentifier(), false, Buf.get()));
-  if (CI.setup(Invocation))
-    return true;
-  CI.performParseOnly();
-  return false;
+  return CI.setup(Invocation);
 }
 
 static void collectFuncEntities(std::vector<TextEntity> &Ents,
@@ -1407,7 +1404,6 @@ SourceFile *SwiftLangSupport::getSyntacticSourceFile(
     Error = "Compiler invocation set up failed";
     return nullptr;
   }
-  ParseCI.performParseOnly();
 
   SourceFile *SF = nullptr;
   unsigned BufferID = ParseCI.getInputBufferIDs().back();

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -808,6 +808,7 @@ static bool makeParserAST(CompilerInstance &CI, StringRef Text,
   Invocation.getFrontendOptions().InputsAndOutputs.clearInputs();
   Invocation.setModuleName("main");
   Invocation.setInputKind(InputFileKind::Swift);
+  Invocation.getLangOptions().DisablePoundIfEvaluation = true;
 
   std::unique_ptr<llvm::MemoryBuffer> Buf;
   Buf = llvm::MemoryBuffer::getMemBuffer(Text, "<module-interface>");
@@ -1406,7 +1407,7 @@ SourceFile *SwiftLangSupport::getSyntacticSourceFile(
     Error = "Compiler invocation set up failed";
     return nullptr;
   }
-  ParseCI.performParseOnly(/*EvaluateConditionals*/true);
+  ParseCI.performParseOnly();
 
   SourceFile *SF = nullptr;
   unsigned BufferID = ParseCI.getInputBufferIDs().back();

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -234,6 +234,7 @@ static bool makeParserAST(CompilerInstance &CI, StringRef Text,
   Invocation.getFrontendOptions().InputsAndOutputs.clearInputs();
   Invocation.setModuleName("main");
   Invocation.setInputKind(InputFileKind::Swift);
+  Invocation.getLangOptions().DisablePoundIfEvaluation = true;
 
   std::unique_ptr<llvm::MemoryBuffer> Buf;
   Buf = llvm::MemoryBuffer::getMemBuffer(Text, "<module-interface>");

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -240,10 +240,7 @@ static bool makeParserAST(CompilerInstance &CI, StringRef Text,
   Buf = llvm::MemoryBuffer::getMemBuffer(Text, "<module-interface>");
   Invocation.getFrontendOptions().InputsAndOutputs.addInput(
       InputFile(Buf.get()->getBufferIdentifier(), false, Buf.get()));
-  if (CI.setup(Invocation))
-    return true;
-  CI.performParseOnly();
-  return false;
+  return CI.setup(Invocation);
 }
 
 static void reportSyntacticAnnotations(CompilerInstance &CI,

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1707,6 +1707,9 @@ static int doPrintAST(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
 
+  if (!RunTypeChecker)
+    Invocation.getLangOptions().DisablePoundIfEvaluation = true;
+
   CompilerInstance CI;
 
   // Display diagnostics to stderr.

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1727,9 +1727,7 @@ static int doPrintAST(const CompilerInvocation &InitInvok,
     CI.getMainModule()->setDebugClient(DebuggerClient.get());
   }
 
-  if (!RunTypeChecker)
-    CI.performParseOnly();
-  else
+  if (RunTypeChecker)
     CI.performSema();
 
   if (MangledNameToFind.empty()) {

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -268,7 +268,7 @@ int main(int argc, char *argv[]) {
   switch (options::Action) {
     case RefactoringKind::GlobalRename:
     case RefactoringKind::FindGlobalRenameRanges:
-      CI.performParseOnly(/*EvaluateConditionals*/true);
+      CI.performParseOnly();
       break;
     default:
       CI.performSema();

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -268,7 +268,7 @@ int main(int argc, char *argv[]) {
   switch (options::Action) {
     case RefactoringKind::GlobalRename:
     case RefactoringKind::FindGlobalRenameRanges:
-      CI.performParseOnly();
+      // No type-checking required.
       break;
     default:
       CI.performSema();

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -609,7 +609,10 @@ int parseFile(
   Invocation.getLangOptions().ParseForSyntaxTreeOnly = true;
   Invocation.getLangOptions().VerifySyntaxTree = options::VerifySyntaxTree;
   Invocation.getLangOptions().RequestEvaluatorGraphVizPath = options::GraphVisPath;
+  Invocation.getLangOptions().DisablePoundIfEvaluation = true;
+
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(InputFileName);
+
   if (InputFileName.endswith(".swiftinterface"))
     Invocation.setInputKind(InputFileKind::SwiftModuleInterface);
   Invocation.setMainExecutablePath(

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -636,9 +636,6 @@ int parseFile(
   assert(BufferIDs.size() == 1 && "Only expecting to process one source file");
   unsigned BufferID = BufferIDs.front();
 
-  // Parse the actual source file
-  Instance.performParseOnly();
-
   SourceFile *SF = nullptr;
   for (auto Unit : Instance.getMainModule()->getFiles()) {
     SF = dyn_cast<SourceFile>(Unit);
@@ -647,6 +644,9 @@ int parseFile(
     }
   }
   assert(SF && "No source file");
+
+  // Force parsing to populate the syntax cache.
+  (void)SF->getSyntaxRoot();
 
   // In case the action specific callback succeeds, we output this error code
   int InternalExitCode = EXIT_SUCCESS;


### PR DESCRIPTION
Rather than waiting until one of the `performXXX` methods are called on the `CompilerInstance`, populate the main module's files up-front when `getMainModule` is called.

This allows us to remove `performParseOnly` in favour of lazy parsing, and allows us to inline `performSemaUpTo` into `performParseAndResolveImportsOnly` & `performSema`.