### PR TITLE
DependenciesScanner: teach the scanner to handle cross-import overlays

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -159,11 +159,11 @@ NOTE(circular_type_resolution_note,none,
 // MARK: Cross-import overlay loading diagnostics
 //------------------------------------------------------------------------------
 ERROR(cannot_load_swiftoverlay_file, none,
-      "cannot load cross-import overlay for %0 and %1: %2 (declared by '%3')",
-      (Identifier, Identifier, StringRef, StringRef))
+      "cannot load cross-import overlay for '%0' and '%1': %2 (declared by '%3')",
+      (StringRef, StringRef, StringRef, StringRef))
 ERROR(cannot_list_swiftcrossimport_dir, none,
-      "cannot list cross-import overlays for %0: %1 (declared in '%2')",
-      (Identifier, StringRef, StringRef))
+      "cannot list cross-import overlays for '%0': %1 (declared in '%2')",
+      (StringRef, StringRef, StringRef))
 WARNING(cross_imported_by_both_modules, none,
         "modules %0 and %1 both declare module %2 as a cross-import overlay, "
         "which may cause paradoxical behavior when looking up names in them; "

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -391,6 +391,11 @@ public:
   /// Add a file declaring a cross-import overlay.
   void addCrossImportOverlayFile(StringRef file);
 
+  /// Collect cross-import overlay names from a given YAML file path.
+  static llvm::SmallSetVector<Identifier, 4>
+  collectCrossImportOverlay(ASTContext &ctx, StringRef file,
+                            StringRef moduleName, StringRef& bystandingModule);
+
   /// If this method returns \c false, the module does not declare any
   /// cross-import overlays.
   ///

--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -29,6 +29,8 @@ namespace swift {
 
 class ClangModuleDependenciesCacheImpl;
 class SourceFile;
+class ASTContext;
+class Identifier;
 
 /// Which kind of module dependencies we are looking for.
 enum class ModuleDependenciesKind : int8_t {
@@ -246,6 +248,11 @@ public:
   /// Add (Clang) module on which the bridging header depends.
   void addBridgingModuleDependency(StringRef module,
                                    llvm::StringSet<> &alreadyAddedModules);
+
+  /// Collect a map from a secondary module name to a list of cross-import
+  /// overlays, when this current module serves as the primary module.
+  llvm::StringMap<llvm::SmallSetVector<Identifier, 4>>
+  collectCrossImportOverlayNames(ASTContext &ctx, StringRef moduleName);
 };
 
 using ModuleDependencyID = std::pair<std::string, ModuleDependenciesKind>;

--- a/test/ScanDependencies/Inputs/Swift/E.swiftcrossimport/SubE.swiftoverlay
+++ b/test/ScanDependencies/Inputs/Swift/E.swiftcrossimport/SubE.swiftoverlay
@@ -1,0 +1,5 @@
+%YAML 1.2
+---
+version: 1
+modules:
+  - name: _cross_import_E

--- a/test/ScanDependencies/Inputs/Swift/_cross_import_E.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/_cross_import_E.swiftinterface
@@ -1,0 +1,6 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name _cross_import_E
+import Swift
+import E
+import SubE
+public func funcCrossImportE() {}

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -80,6 +80,9 @@ import SubE
 // CHECK-NEXT: {
 // CHECK-NEXT: "swift": "A"
 // CHECK-NEXT: }
+// CHECK-NEXT: {
+// CHECK-NEXT:   "swift": "_cross_import_E"
+// CHECK-NEXT: }
 
 // CHECK: "bridgingHeader":
 // CHECK-NEXT: "path":


### PR DESCRIPTION
Swift cross-import overlays are implicitly imported. The dependencies scanner needs to read the YAML files to figure out these modules and add them to the dependencies graph.