### PR TITLE
[build-script-impl] Require --install-llvm to be passed in to install llvm.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -39,6 +39,7 @@ build-ninja
 
 build-swift-stdlib-unittest-extra
 
+install-llvm
 install-swift
 
 # Path to the root of the installation filesystem.
@@ -391,6 +392,7 @@ skip-test-ios
 skip-test-tvos
 skip-test-watchos
 
+install-llvm
 install-swift
 install-llbuild
 install-swiftpm
@@ -602,6 +604,7 @@ llbuild
 swiftpm
 indexstore-db
 sourcekit-lsp
+install-llvm
 install-swift
 install-llbuild
 install-swiftpm
@@ -790,6 +793,7 @@ libcxx
 dash-dash
 
 build-ninja
+install-llvm
 install-swift
 install-lldb
 install-llbuild
@@ -908,6 +912,7 @@ host-test
 extra-cmake-options=-DSWIFT_ENABLE_LLD_LINKER:BOOL=OFF
 
 install-prefix=/usr
+install-llvm
 install-swift
 install-libicu
 install-libcxx
@@ -1016,6 +1021,7 @@ build-subdir=buildbot_linux
 
 dash-dash
 
+install-llvm
 install-swift
 install-lldb
 install-llbuild
@@ -1076,6 +1082,7 @@ indexstore-db
 sourcekit-lsp
 dash-dash
 
+install-llvm
 install-swift
 install-llbuild
 install-libicu
@@ -1117,6 +1124,7 @@ build-subdir=buildbot_incremental_tsan_libdispatch_test
 
 llvm-cmake-options=-DLLVM_INSTALL_UTILS=ON
 llvm-install-components=all
+install-llvm
 
 libdispatch-cmake-options=-DENABLE_SWIFT=OFF
 libdispatch
@@ -1208,6 +1216,7 @@ verbose-build
 build-ninja
 build-swift-stdlib-unittest-extra
 
+install-llvm
 install-swift
 install-lldb
 install-llbuild
@@ -1433,6 +1442,7 @@ build-swift-stdlib-unittest-extra
 libcxx
 
 # Install swift and libcxx
+install-llvm
 install-swift
 install-libcxx
 
@@ -1481,6 +1491,7 @@ swiftsyntax-verify-generated-files
 # Build sourcekit-lsp & indexstore-db
 indexstore-db
 sourcekit-lsp
+install-llvm
 install-swift
 install-llbuild
 install-swiftpm
@@ -1547,6 +1558,7 @@ libcxx
 llbuild
 swiftpm
 
+install-llvm
 install-swift
 install-llbuild
 install-swiftpm
@@ -1793,6 +1805,7 @@ install-foundation
 install-libdispatch
 install-libicu
 install-libcxx
+install-llvm
 install-swift
 install-llbuild
 install-swiftpm
@@ -1828,6 +1841,7 @@ skip-build-cmark
 skip-build-llvm
 skip-build-llbuild
 skip-build-benchmarks
+install-llvm
 install-swift
 install-prefix=%(install_toolchain_dir)s/usr
 build-swift-examples=0
@@ -2245,6 +2259,7 @@ no-assertions
 build-libparser-only
 verbose-build
 darwin-install-extract-symbols
+install-llvm
 install-swift
 
 
@@ -2338,6 +2353,7 @@ build-ninja
 llbuild
 swiftpm
 install-llbuild
+install-llvm
 install-swift
 install-swiftpm
 reconfigure

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2656,12 +2656,13 @@ for host in "${ALL_HOSTS[@]}"; do
                 fi
                 ;;
             llvm)
-                if [[ -z "${LLVM_INSTALL_COMPONENTS}" ]] ; then
+                if [[ -z "${INSTALL_LLVM}" ]] ; then
                     continue
                 fi
-                if [[ "${LLVM_INSTALL_COMPONENTS}" == "all" ]]; then
+
+                if [[ "${LLVM_INSTALL_COMPONENTS}" == "all" ]] ; then
                     INSTALL_TARGETS=install
-                else
+                elif [[ -n "${LLVM_INSTALL_COMPONENTS}" ]] ; then
                     INSTALL_TARGETS=install-$(echo ${LLVM_INSTALL_COMPONENTS} | sed -E 's/;/ install-/g')
                 fi
                 ;;


### PR DESCRIPTION
Before this patch, we assumed that if LLVM_INSTALL_COMPONENTS was non-empty that
we wanted to install llvm. This is different than /every other/ product in
build-script-impl where INSTALL_$PRODUCT controls if an install is attempted. If
a components sort of thing is required, we force it to only be a configuration
of an option that is a no-op if INSTALL_$PRODUCT is set to true.

I went through build-presets and looked at every place we had an install
statement and added install-llvm when appropriate. This was generally when we
did an install-swift. The one special case is with the tsan_libdsipatch
test. That being said, if I was too aggressive with where I put these
install-llvm, no harm will result since in those cases LLVM_INSTALL_COMPONENTS
had to be empty previously anyways (since otherwise we would have attempted an
install).
