### PR TITLE
Fix typo in 'KeyedEncodingContainer.superEncoder' documentation.

### DIFF
--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -471,7 +471,7 @@ public protocol KeyedEncodingContainerProtocol {
     forKey key: Key
   ) -> UnkeyedEncodingContainer
 
-  /// Stores a new nested container for the default `super` key and returns A
+  /// Stores a new nested container for the default `super` key and returns a
   /// new encoder instance for encoding `super` into that container.
   ///
   /// Equivalent to calling `superEncoder(forKey:)` with
@@ -480,7 +480,7 @@ public protocol KeyedEncodingContainerProtocol {
   /// - returns: A new encoder to pass to `super.encode(to:)`.
   mutating func superEncoder() -> Encoder
 
-  /// Stores a new nested container for the given key and returns A new encoder
+  /// Stores a new nested container for the given key and returns a new encoder
   /// instance for encoding `super` into that container.
   ///
   /// - parameter key: The key to encode `super` for.
@@ -911,7 +911,7 @@ public struct KeyedEncodingContainer<K: CodingKey> :
     return _box.nestedUnkeyedContainer(forKey: key)
   }
 
-  /// Stores a new nested container for the default `super` key and returns A
+  /// Stores a new nested container for the default `super` key and returns a
   /// new encoder instance for encoding `super` into that container.
   ///
   /// Equivalent to calling `superEncoder(forKey:)` with
@@ -922,7 +922,7 @@ public struct KeyedEncodingContainer<K: CodingKey> :
     return _box.superEncoder()
   }
 
-  /// Stores a new nested container for the given key and returns A new encoder
+  /// Stores a new nested container for the given key and returns a new encoder
   /// instance for encoding `super` into that container.
   ///
   /// - parameter key: The key to encode `super` for.


### PR DESCRIPTION
"returns A new encoder" -> "returns a new encoder"

Resolves rdar://64136400.