### PR TITLE
[build-script] Add support for specifying that a product is a non-darwin only product.

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/foundation.py
+++ b/utils/swift_build_support/swift_build_support/products/foundation.py
@@ -46,3 +46,7 @@ class Foundation(product.Product):
                 swift.Swift,
                 lldb.LLDB,
                 libdispatch.LibDispatch]
+
+    @classmethod
+    def is_nondarwin_only_build_product(cls):
+        return True

--- a/utils/swift_build_support/swift_build_support/products/libdispatch.py
+++ b/utils/swift_build_support/swift_build_support/products/libdispatch.py
@@ -37,6 +37,10 @@ class LibDispatch(product.Product):
         return "swift-corelibs-libdispatch"
 
     @classmethod
+    def is_nondarwin_only_build_product(cls):
+        return True
+
+    @classmethod
     def get_dependencies(cls):
         return [cmark.CMark,
                 llvm.LLVM,

--- a/utils/swift_build_support/swift_build_support/products/libicu.py
+++ b/utils/swift_build_support/swift_build_support/products/libicu.py
@@ -34,6 +34,10 @@ class LibICU(product.Product):
         return "icu"
 
     @classmethod
+    def is_nondarwin_only_build_product(cls):
+        return True
+
+    @classmethod
     def get_dependencies(cls):
         return [cmark.CMark,
                 llvm.LLVM,

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -67,6 +67,13 @@ class Product(object):
         return False
 
     @classmethod
+    def is_nondarwin_only_build_product(cls):
+        """Returns true if this target should be skipped in darwin builds when
+        inferring dependencies.
+        """
+        return False
+
+    @classmethod
     def get_dependencies(cls):
         """Return a list of products that this product depends upon"""
         raise NotImplementedError

--- a/utils/swift_build_support/swift_build_support/products/xctest.py
+++ b/utils/swift_build_support/swift_build_support/products/xctest.py
@@ -48,3 +48,7 @@ class XCTest(product.Product):
                 lldb.LLDB,
                 libdispatch.LibDispatch,
                 foundation.Foundation]
+
+    @classmethod
+    def is_nondarwin_only_build_product(cls):
+        return True


### PR DESCRIPTION
We have a few of these like foundation, libdispatch, icu, xctest that are built
outside of build-script on Darwin.

This just lets me ignore them when computing auto-dependencies.