### PR TITLE
[build-script] Define default llvm_install_components.

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -752,6 +752,11 @@ class BuildScriptInvocation(object):
                 os.path.abspath(args.coverage_db)
             ]
 
+        if args.llvm_install_components:
+            impl_args += [
+                "--llvm-install-components=%s" % args.llvm_install_components
+            ]
+
         # Compute the set of host-specific variables, which we pass through to
         # the build script via environment variables.
         host_specific_variables = self.compute_host_specific_variables()

--- a/utils/build_swift/build_swift/defaults.py
+++ b/utils/build_swift/build_swift/defaults.py
@@ -14,6 +14,7 @@ Default option value definitions.
 
 from __future__ import absolute_import, unicode_literals
 
+import os
 import platform
 
 from . import shell
@@ -111,6 +112,19 @@ def _default_swift_lto_link_jobs():
 
 LLVM_MAX_PARALLEL_LTO_LINK_JOBS = _default_llvm_lto_link_jobs()
 SWIFT_MAX_PARALLEL_LTO_LINK_JOBS = _default_swift_lto_link_jobs()
+
+
+def llvm_install_components():
+    """Convenience function for getting the default llvm install components for
+    platforms.
+    """
+    components = ['llvm-cov', 'llvm-profdata', 'IndexStore', 'clang',
+                  'clang-resource-headers', 'compiler-rt', 'clangd']
+    if os.sys.platform == 'darwin':
+        components.extend(['llvm-dsymutil'])
+    else:
+        components.extend(['lld'])
+    return ';'.join(components)
 
 
 # Options that can only be "configured" by editing this file.

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -497,6 +497,10 @@ def create_argument_parser():
     option('--coverage-db', store_path,
            help='coverage database to use when prioritizing testing')
 
+    option('--llvm-install-components', store,
+           default=defaults.llvm_install_components(),
+           help='A semi-colon split list of llvm components to install')
+
     # -------------------------------------------------------------------------
     in_group('Host and cross-compilation targets')
 

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -236,7 +236,8 @@ EXPECTED_DEFAULTS = {
     'validation_test': None,
     'verbose_build': False,
     'watchos': False,
-    'watchos_all': False
+    'watchos_all': False,
+    'llvm_install_components': defaults.llvm_install_components(),
 }
 
 
@@ -675,4 +676,6 @@ EXPECTED_OPTIONS = [
     IgnoreOption('--ios-all'),
     IgnoreOption('--tvos-all'),
     IgnoreOption('--watchos-all'),
+
+    StrOption('--llvm-install-components'),
 ]


### PR DESCRIPTION
This is just based off of the defaults that we use on the buildbots as of this
commit.

In order to not break the bots as they are, I left the internal representation
as a semicolon list of components. So this should be NFC from the perspective of
the bots since they all explicitly specify llvm-install-components if needed
(and we do not install without install-llvm anymore).
