### PR TITLE
[build-script] Remove a bunch of conservative dependencies on lldb.

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/benchmarks.py
+++ b/utils/swift_build_support/swift_build_support/products/benchmarks.py
@@ -19,7 +19,6 @@ from . import libcxx
 from . import libdispatch
 from . import libicu
 from . import llbuild
-from . import lldb
 from . import llvm
 from . import product
 from . import swift
@@ -75,7 +74,6 @@ class Benchmarks(product.Product):
                 libcxx.LibCXX,
                 libicu.LibICU,
                 swift.Swift,
-                lldb.LLDB,
                 libdispatch.LibDispatch,
                 foundation.Foundation,
                 xctest.XCTest,

--- a/utils/swift_build_support/swift_build_support/products/foundation.py
+++ b/utils/swift_build_support/swift_build_support/products/foundation.py
@@ -14,7 +14,6 @@ from . import cmark
 from . import libcxx
 from . import libdispatch
 from . import libicu
-from . import lldb
 from . import llvm
 from . import product
 from . import swift
@@ -44,5 +43,4 @@ class Foundation(product.Product):
                 libcxx.LibCXX,
                 libicu.LibICU,
                 swift.Swift,
-                lldb.LLDB,
                 libdispatch.LibDispatch]

--- a/utils/swift_build_support/swift_build_support/products/indexstoredb.py
+++ b/utils/swift_build_support/swift_build_support/products/indexstoredb.py
@@ -18,7 +18,6 @@ from . import libcxx
 from . import libdispatch
 from . import libicu
 from . import llbuild
-from . import lldb
 from . import llvm
 from . import product
 from . import swift
@@ -64,7 +63,6 @@ class IndexStoreDB(product.Product):
                 libcxx.LibCXX,
                 libicu.LibICU,
                 swift.Swift,
-                lldb.LLDB,
                 libdispatch.LibDispatch,
                 foundation.Foundation,
                 xctest.XCTest,

--- a/utils/swift_build_support/swift_build_support/products/libdispatch.py
+++ b/utils/swift_build_support/swift_build_support/products/libdispatch.py
@@ -13,7 +13,6 @@
 from . import cmark
 from . import libcxx
 from . import libicu
-from . import lldb
 from . import llvm
 from . import product
 from . import swift
@@ -42,5 +41,4 @@ class LibDispatch(product.Product):
                 llvm.LLVM,
                 libcxx.LibCXX,
                 libicu.LibICU,
-                swift.Swift,
-                lldb.LLDB]
+                swift.Swift]

--- a/utils/swift_build_support/swift_build_support/products/llbuild.py
+++ b/utils/swift_build_support/swift_build_support/products/llbuild.py
@@ -15,7 +15,6 @@ from . import foundation
 from . import libcxx
 from . import libdispatch
 from . import libicu
-from . import lldb
 from . import llvm
 from . import product
 from . import swift
@@ -38,7 +37,6 @@ class LLBuild(product.Product):
                 libcxx.LibCXX,
                 libicu.LibICU,
                 swift.Swift,
-                lldb.LLDB,
                 libdispatch.LibDispatch,
                 foundation.Foundation,
                 xctest.XCTest]

--- a/utils/swift_build_support/swift_build_support/products/pythonkit.py
+++ b/utils/swift_build_support/swift_build_support/products/pythonkit.py
@@ -18,7 +18,6 @@ from . import libcxx
 from . import libdispatch
 from . import libicu
 from . import llbuild
-from . import lldb
 from . import llvm
 from . import product
 from . import swift
@@ -98,7 +97,6 @@ class PythonKit(product.Product):
                 libcxx.LibCXX,
                 libicu.LibICU,
                 swift.Swift,
-                lldb.LLDB,
                 libdispatch.LibDispatch,
                 foundation.Foundation,
                 xctest.XCTest,

--- a/utils/swift_build_support/swift_build_support/products/skstresstester.py
+++ b/utils/swift_build_support/swift_build_support/products/skstresstester.py
@@ -21,7 +21,6 @@ from . import libcxx
 from . import libdispatch
 from . import libicu
 from . import llbuild
-from . import lldb
 from . import llvm
 from . import product
 from . import swift
@@ -109,7 +108,6 @@ class SKStressTester(product.Product):
                 libcxx.LibCXX,
                 libicu.LibICU,
                 swift.Swift,
-                lldb.LLDB,
                 libdispatch.LibDispatch,
                 foundation.Foundation,
                 xctest.XCTest,

--- a/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
+++ b/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
@@ -17,7 +17,6 @@ from . import libcxx
 from . import libdispatch
 from . import libicu
 from . import llbuild
-from . import lldb
 from . import llvm
 from . import product
 from . import swift
@@ -63,7 +62,6 @@ class SourceKitLSP(product.Product):
                 libcxx.LibCXX,
                 libicu.LibICU,
                 swift.Swift,
-                lldb.LLDB,
                 libdispatch.LibDispatch,
                 foundation.Foundation,
                 xctest.XCTest,

--- a/utils/swift_build_support/swift_build_support/products/swiftevolve.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftevolve.py
@@ -16,7 +16,6 @@ from . import libcxx
 from . import libdispatch
 from . import libicu
 from . import llbuild
-from . import lldb
 from . import llvm
 from . import skstresstester
 from . import swift
@@ -55,7 +54,6 @@ class SwiftEvolve(skstresstester.SKStressTester):
                 libcxx.LibCXX,
                 libicu.LibICU,
                 swift.Swift,
-                lldb.LLDB,
                 libdispatch.LibDispatch,
                 foundation.Foundation,
                 xctest.XCTest,

--- a/utils/swift_build_support/swift_build_support/products/swiftinspect.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftinspect.py
@@ -19,7 +19,6 @@ from . import libcxx
 from . import libdispatch
 from . import libicu
 from . import llbuild
-from . import lldb
 from . import llvm
 from . import product
 from . import swift
@@ -67,7 +66,6 @@ class SwiftInspect(product.Product):
                 libcxx.LibCXX,
                 libicu.LibICU,
                 swift.Swift,
-                lldb.LLDB,
                 libdispatch.LibDispatch,
                 foundation.Foundation,
                 xctest.XCTest,

--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -18,7 +18,6 @@ from . import libcxx
 from . import libdispatch
 from . import libicu
 from . import llbuild
-from . import lldb
 from . import llvm
 from . import product
 from . import swift
@@ -111,7 +110,6 @@ class SwiftPM(product.Product):
                 libcxx.LibCXX,
                 libicu.LibICU,
                 swift.Swift,
-                lldb.LLDB,
                 libdispatch.LibDispatch,
                 foundation.Foundation,
                 xctest.XCTest,

--- a/utils/swift_build_support/swift_build_support/products/swiftsyntax.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftsyntax.py
@@ -20,7 +20,6 @@ from . import libcxx
 from . import libdispatch
 from . import libicu
 from . import llbuild
-from . import lldb
 from . import llvm
 from . import product
 from . import swift
@@ -110,7 +109,6 @@ class SwiftSyntax(product.Product):
                 libcxx.LibCXX,
                 libicu.LibICU,
                 swift.Swift,
-                lldb.LLDB,
                 libdispatch.LibDispatch,
                 foundation.Foundation,
                 xctest.XCTest,

--- a/utils/swift_build_support/swift_build_support/products/tensorflow.py
+++ b/utils/swift_build_support/swift_build_support/products/tensorflow.py
@@ -18,7 +18,6 @@ from . import libcxx
 from . import libdispatch
 from . import libicu
 from . import llbuild
-from . import lldb
 from . import llvm
 from . import product
 from . import swift
@@ -98,7 +97,6 @@ class TensorFlowSwiftAPIs(product.Product):
                 libcxx.LibCXX,
                 libicu.LibICU,
                 swift.Swift,
-                lldb.LLDB,
                 libdispatch.LibDispatch,
                 foundation.Foundation,
                 xctest.XCTest,

--- a/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
+++ b/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
@@ -18,7 +18,6 @@ from . import libcxx
 from . import libdispatch
 from . import libicu
 from . import llbuild
-from . import lldb
 from . import llvm
 from . import product
 from . import swift
@@ -97,7 +96,6 @@ class TSanLibDispatch(product.Product):
                 libcxx.LibCXX,
                 libicu.LibICU,
                 swift.Swift,
-                lldb.LLDB,
                 libdispatch.LibDispatch,
                 foundation.Foundation,
                 xctest.XCTest,

--- a/utils/swift_build_support/swift_build_support/products/xctest.py
+++ b/utils/swift_build_support/swift_build_support/products/xctest.py
@@ -15,7 +15,6 @@ from . import foundation
 from . import libcxx
 from . import libdispatch
 from . import libicu
-from . import lldb
 from . import llvm
 from . import product
 from . import swift
@@ -45,6 +44,5 @@ class XCTest(product.Product):
                 libcxx.LibCXX,
                 libicu.LibICU,
                 swift.Swift,
-                lldb.LLDB,
                 libdispatch.LibDispatch,
                 foundation.Foundation]


### PR DESCRIPTION
I only didn't touch playground-support since I don't know if there are deps
there or not. Everything else here though shouldn't need lldb to be built.
