### PR TITLE
[NFC] Clarify comment on metatype casts on TypeCheckConstraints

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3706,9 +3706,9 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   else
     fromRequiresClass = fromType->mayHaveSuperclass();
   
-  // Casts between protocol metatypes only succeed if the type is existential
-  // or if it involves generic types because they may be protocol conformances
-  // we can't know at compile time.
+  // Casts between metatypes only succeed if none of the types are existentials
+  // or if one is an existential and the other is a generic type because there
+  // may be protocol conformances unknown at compile time.
   if (metatypeCast) {
     if ((toExistential || fromExistential) && !(fromArchetype || toArchetype))
       return failed();


### PR DESCRIPTION
<!-- What's in this pull request? -->
As pointed by @tbkka in #32234, the comment is not coherent with the code. So this is just clarifying the comment to match what is happening.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
