### PR TITLE
[AutoDiff] NFC: dedupe array semantic call utilities.

### DIFF
--- a/include/swift/SILOptimizer/Differentiation/Common.h
+++ b/include/swift/SILOptimizer/Differentiation/Common.h
@@ -37,15 +37,6 @@ namespace autodiff {
 /// This is being used to print short debug messages within the AD pass.
 raw_ostream &getADDebugStream();
 
-/// Returns true if this is an full apply site whose callee has
-/// `array.uninitialized_intrinsic` semantics.
-bool isArrayLiteralIntrinsic(FullApplySite applySite);
-
-/// If the given value `v` corresponds to an `ApplyInst` with
-/// `array.uninitialized_intrinsic` semantics, returns the corresponding
-/// `ApplyInst`. Otherwise, returns `nullptr`.
-ApplyInst *getAllocateUninitializedArrayIntrinsic(SILValue v);
-
 /// Given an element address from an `array.uninitialized_intrinsic` `apply`
 /// instruction, returns the `apply` instruction. The element address is either
 /// a `pointer_to_address` or `index_addr` instruction to the `RawPointer`
@@ -57,6 +48,8 @@ ApplyInst *getAllocateUninitializedArrayIntrinsic(SILValue v);
 ///     %index_1 = integer_literal $Builtin.Word, 1
 ///     %elt1 = index_addr %elt0, %index_1           // element address
 ///     ...
+// TODO(SR-12894): Find a better name and move this general utility to
+// ArraySemantic.h.
 ApplyInst *getAllocateUninitializedArrayIntrinsicElementAddress(SILValue v);
 
 /// Given a value, finds its single `destructure_tuple` user if the value is

--- a/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
@@ -403,7 +403,9 @@ void DifferentiableActivityInfo::setUsefulThroughArrayInitialization(
     SILValue value, unsigned dependentVariableIndex) {
   // Array initializer syntax is lowered to an intrinsic and one or more
   // stores to a `RawPointer` returned by the intrinsic.
-  auto *uai = getAllocateUninitializedArrayIntrinsic(value);
+  ArraySemanticsCall uninitCall(value,
+                                semantics::ARRAY_UNINITIALIZED_INTRINSIC);
+  ApplyInst *uai = uninitCall;
   if (!uai)
     return;
   for (auto use : value->getUses()) {

--- a/lib/SILOptimizer/Differentiation/JVPEmitter.cpp
+++ b/lib/SILOptimizer/Differentiation/JVPEmitter.cpp
@@ -1181,7 +1181,7 @@ void JVPEmitter::visitApplyInst(ApplyInst *ai) {
   // If the function should not be differentiated or its the array literal
   // initialization intrinsic, just do standard cloning.
   if (!differentialInfo.shouldDifferentiateApplySite(ai) ||
-      isArrayLiteralIntrinsic(ai)) {
+      ArraySemanticsCall(ai, semantics::ARRAY_UNINITIALIZED_INTRINSIC)) {
     LLVM_DEBUG(getADDebugStream() << "No active results:\n" << *ai << '\n');
     TypeSubstCloner::visitApplyInst(ai);
     return;

--- a/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
+++ b/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
@@ -412,7 +412,8 @@ void LinearMapInfo::generateDifferentiationDataStructures(
         // Add linear map field to struct for active `apply` instructions.
         // Skip array literal intrinsic applications since array literal
         // initialization is linear and handled separately.
-        if (!shouldDifferentiateApplySite(ai) || isArrayLiteralIntrinsic(ai))
+        if (!shouldDifferentiateApplySite(ai) ||
+            ArraySemanticsCall(ai, semantics::ARRAY_UNINITIALIZED_INTRINSIC))
           continue;
         if (ArraySemanticsCall(ai, semantics::ARRAY_FINALIZE_INTRINSIC))
           continue;
@@ -476,7 +477,9 @@ bool LinearMapInfo::shouldDifferentiateApplySite(FullApplySite applySite) {
 
   // TODO: Pattern match to make sure there is at least one `store` to the
   // array's active buffer.
-  if (isArrayLiteralIntrinsic(applySite) && hasActiveResults)
+  if (ArraySemanticsCall(applySite.getInstruction(),
+                         semantics::ARRAY_UNINITIALIZED_INTRINSIC) &&
+      hasActiveResults)
     return true;
 
   auto arguments = applySite.getArgumentsWithoutIndirectResults();

--- a/lib/SILOptimizer/Differentiation/PullbackEmitter.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackEmitter.cpp
@@ -272,7 +272,8 @@ void PullbackEmitter::accumulateArrayLiteralElementAddressAdjoints(
       originalValue->getDefiningInstruction());
   if (!dti)
     return;
-  if (!getAllocateUninitializedArrayIntrinsic(dti->getOperand()))
+  if (!ArraySemanticsCall(dti->getOperand(),
+                          semantics::ARRAY_UNINITIALIZED_INTRINSIC))
     return;
   if (originalValue != dti->getResult(0))
     return;
@@ -1420,9 +1421,9 @@ PullbackEmitter::getArrayAdjointElementBuffer(SILValue arrayAdjoint,
 
 void PullbackEmitter::visitApplyInst(ApplyInst *ai) {
   assert(getPullbackInfo().shouldDifferentiateApplySite(ai));
-  // Skip `array.uninitialized_intrinsic` intrinsic applications, which have
-  // special `store` and `copy_addr` support.
-  if (isArrayLiteralIntrinsic(ai))
+  // Skip `array.uninitialized_intrinsic` applications, which have special
+  // `store` and `copy_addr` support.
+  if (ArraySemanticsCall(ai, semantics::ARRAY_UNINITIALIZED_INTRINSIC))
     return;
   auto loc = ai->getLoc();
   auto *bb = ai->getParent();

--- a/lib/SILOptimizer/Differentiation/VJPEmitter.cpp
+++ b/lib/SILOptimizer/Differentiation/VJPEmitter.cpp
@@ -533,11 +533,12 @@ void VJPEmitter::visitApplyInst(ApplyInst *ai) {
     TypeSubstCloner::visitApplyInst(ai);
     return;
   }
-  // If callee is the array literal initialization intrinsic, do standard
-  // cloning. Array literal differentiation is handled separately.
-  if (isArrayLiteralIntrinsic(ai)) {
-    LLVM_DEBUG(getADDebugStream() << "Cloning array literal intrinsic `apply`\n"
-                                  << *ai << '\n');
+  // If callee is `array.uninitialized_intrinsic`, do standard cloning.
+  // `array.unininitialized_intrinsic` differentiation is handled separately.
+  if (ArraySemanticsCall(ai, semantics::ARRAY_UNINITIALIZED_INTRINSIC)) {
+    LLVM_DEBUG(getADDebugStream()
+               << "Cloning `array.unininitialized_intrinsic` `apply`:\n"
+               << *ai << '\n');
     TypeSubstCloner::visitApplyInst(ai);
     return;
   }


### PR DESCRIPTION
Delete differentiation array semantic call utilities:
- `bool isArrayLiteralIntrinsic(FullApplySite applySite)`
- `ApplyInst *getAllocateUninitializedArrayIntrinsic(SILValue v)`

Use `ArraySemanticsCall` from `ArraySemantics.h` instead.

Resolves SR-12894.