### PR TITLE
SILCombine: a peephole optimization to optimize alloc_stack of enums.

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -176,6 +176,7 @@ public:
   SILInstruction *optimizeLoadFromStringLiteral(LoadInst *LI);
   SILInstruction *visitLoadInst(LoadInst *LI);
   SILInstruction *visitIndexAddrInst(IndexAddrInst *IA);
+  bool optimizeStackAllocatedEnum(AllocStackInst *AS);
   SILInstruction *visitAllocStackInst(AllocStackInst *AS);
   SILInstruction *visitAllocRefInst(AllocRefInst *AR);
   SILInstruction *visitSwitchEnumAddrInst(SwitchEnumAddrInst *SEAI);

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -454,8 +454,107 @@ static bool somethingIsRetained(SILInstruction *from, AllocStackInst *alloc) {
   return false;
 }
 
+/// Replaces an alloc_stack of an enum by an alloc_stack of the payload if only
+/// one enum case (with payload) is stored to that location.
+///
+/// For example:
+///
+///   %loc = alloc_stack $Optional<T>
+///   %payload = init_enum_data_addr %loc
+///   store %value to %payload
+///   ...
+///   %take_addr = unchecked_take_enum_data_addr %loc
+///   %l = load %take_addr
+///
+/// is transformed to
+///
+///   %loc = alloc_stack $T
+///   store %value to %loc
+///   ...
+///   %l = load %loc
+bool SILCombiner::optimizeStackAllocatedEnum(AllocStackInst *AS) {
+  EnumDecl *enumDecl = AS->getType().getEnumOrBoundGenericEnum();
+  if (!enumDecl)
+    return false;
+  
+  EnumElementDecl *element = nullptr;
+  SILType payloadType;
+  
+  // First step: check if the stack location is only used to hold one specific
+  // enum case with payload.
+  for (auto *use : AS->getUses()) {
+    SILInstruction *user = use->getUser();
+    switch (user->getKind()) {
+      case SILInstructionKind::DebugValueAddrInst:
+      case SILInstructionKind::DestroyAddrInst:
+      case SILInstructionKind::DeallocStackInst:
+        break;
+      case SILInstructionKind::InitEnumDataAddrInst: {
+        auto *ieda = cast<InitEnumDataAddrInst>(user);
+        auto *el = ieda->getElement();
+        if (element && el != element)
+          return false;
+        element = el;
+        assert(!payloadType || payloadType == ieda->getType());
+        payloadType = ieda->getType();
+        break;
+      }
+      case SILInstructionKind::InjectEnumAddrInst: {
+        auto *el = cast<InjectEnumAddrInst>(user)->getElement();
+        if (element && el != element)
+          return false;
+        element = el;
+        break;
+      }
+      case SILInstructionKind::UncheckedTakeEnumDataAddrInst: {
+        auto *el = cast<UncheckedTakeEnumDataAddrInst>(user)->getElement();
+        if (element && el != element)
+          return false;
+        element = el;
+        break;
+      }
+      default:
+        return false;
+    }
+  }
+  if (!element || !payloadType)
+    return false;
+
+  // Second step: replace the enum alloc_stack with a payload alloc_stack.
+  auto *newAlloc = Builder.createAllocStack(
+      AS->getLoc(), payloadType, AS->getVarInfo(), AS->hasDynamicLifetime());
+
+  while (!AS->use_empty()) {
+    Operand *use = *AS->use_begin();
+    SILInstruction *user = use->getUser();
+    switch (user->getKind()) {
+      case SILInstructionKind::InjectEnumAddrInst:
+      case SILInstructionKind::DebugValueAddrInst:
+        eraseInstFromFunction(*user);
+        break;
+      case SILInstructionKind::DestroyAddrInst:
+      case SILInstructionKind::DeallocStackInst:
+        use->set(newAlloc);
+        break;
+      case SILInstructionKind::InitEnumDataAddrInst:
+      case SILInstructionKind::UncheckedTakeEnumDataAddrInst: {
+        auto *svi = cast<SingleValueInstruction>(user);
+        svi->replaceAllUsesWith(newAlloc);
+        eraseInstFromFunction(*svi);
+        break;
+      }
+      default:
+        llvm_unreachable("unexpected alloc_stack user");
+    }
+  }
+  return true;
+}
+
 SILInstruction *SILCombiner::visitAllocStackInst(AllocStackInst *AS) {
   if (AS->getFunction()->hasOwnership())
+    return nullptr;
+
+  if (optimizeStackAllocatedEnum(AS))
     return nullptr;
 
   // If we are testing SILCombine and we are asked not to eliminate

--- a/test/SILOptimizer/cast_optimizer_conditional_conformance.sil
+++ b/test/SILOptimizer/cast_optimizer_conditional_conformance.sil
@@ -35,13 +35,10 @@ extension S1 : HasFoo where T == UInt8 {
 // CHECK: [[EXIS:%.*]] = alloc_stack $HasFoo
 // CHECK: [[S1:%.*]] = alloc_stack $S1<UInt8>
 // CHECK: store %0 to [[S1]] : $*S1<UInt8>
-// CHECK: [[OPT:%.*]] = alloc_stack $Optional<HasFoo>
-// CHECK: [[INIT_DATA:%.*]] = init_enum_data_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt
-// CHECK: [[EXIS_ADDR:%.*]] = init_existential_addr [[INIT_DATA]] : $*HasFoo, $S1<UInt8>
+// CHECK: [[HASFOO:%.*]] = alloc_stack $HasFoo
+// CHECK: [[EXIS_ADDR:%.*]] = init_existential_addr [[HASFOO]] : $*HasFoo, $S1<UInt8>
 // CHECK: copy_addr [take] [[S1]] to [initialization] [[EXIS_ADDR]] : $*S1<UInt8>
-// CHECK: inject_enum_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt
-// CHECK: [[DATA:%.*]] = unchecked_take_enum_data_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt
-// CHECK: copy_addr [take] [[DATA]] to [initialization] [[EXIS]] : $*HasFoo
+// CHECK: copy_addr [take] [[HASFOO]] to [initialization] [[EXIS]] : $*HasFoo
 // CHECK: [[OPEN_EXIS_ADDR:%.*]] = open_existential_addr immutable_access [[EXIS]] : $*HasFoo to $*@opened("4E16CBC0-FD9F-11E8-A311-D0817AD9F6DD") HasFoo
 // CHECK: [[OPEN_ADDR:%.*]] = unchecked_addr_cast [[OPEN_EXIS_ADDR]] : $*@opened("4E16CBC0-FD9F-11E8-A311-D0817AD9F6DD") HasFoo to $*S1<UInt8>
 // CHECK: [[F:%.*]] = function_ref @witnessS1 : $@convention(witness_method: HasFoo) (@in_guaranteed S1<UInt8>) -> ()
@@ -171,13 +168,10 @@ struct IsP : P {}
 // CHECK: [[EXIS:%.*]] = alloc_stack $HasFoo
 // CHECK: [[S2:%.*]] = alloc_stack $S2<IsP>
 // CHECK: store %0 to [[S2]] : $*S2<IsP>
-// CHECK: [[OPT:%.*]] = alloc_stack $Optional<HasFoo>
-// CHECK: [[INIT_DATA:%.*]] = init_enum_data_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt
-// CHECK: [[EXIS_ADDR:%.*]] = init_existential_addr [[INIT_DATA]] : $*HasFoo, $S2<IsP>
+// CHECK: [[HASFOO:%.*]] = alloc_stack $HasFoo
+// CHECK: [[EXIS_ADDR:%.*]] = init_existential_addr [[HASFOO]] : $*HasFoo, $S2<IsP>
 // CHECK: copy_addr [take] [[S2]] to [initialization] [[EXIS_ADDR]] : $*S2<IsP>
-// CHECK: inject_enum_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt
-// CHECK: [[DATA:%.*]] = unchecked_take_enum_data_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt
-// CHECK: copy_addr [take] [[DATA]] to [initialization] [[EXIS]] : $*HasFoo
+// CHECK: copy_addr [take] [[HASFOO]] to [initialization] [[EXIS]] : $*HasFoo
 // CHECK: [[OPEN_EXIS_ADDR:%.*]] = open_existential_addr immutable_access [[EXIS]] : $*HasFoo to $*@opened("4E16D1CE-FD9F-11E8-A311-D0817AD9F6DD") HasFoo
 // CHECK: [[OPEN_ADDR:%.*]] = unchecked_addr_cast [[OPEN_EXIS_ADDR]] : $*@opened("4E16D1CE-FD9F-11E8-A311-D0817AD9F6DD") HasFoo to $*S2<IsP>
 // CHECK: [[F:%.*]] = function_ref @$s9witnessS24main3IsPV_Tg5 : $@convention(witness_method: HasFoo) (S2<IsP>) -> ()
@@ -246,13 +240,10 @@ extension S3 : HasFoo where T : AnyObject {
 // CHECK: [[EXIS:%.*]] = alloc_stack $HasFoo
 // CHECK: [[S3:%.*]] = alloc_stack $S3<C>
 // CHECK: store %0 to [[S3]] : $*S3<C>
-// CHECK: [[OPT:%.*]] = alloc_stack $Optional<HasFoo>
-// CHECK: [[INIT_DATA:%.*]] = init_enum_data_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt
-// CHECK: [[EXIS_ADDR:%.*]] = init_existential_addr [[INIT_DATA]] : $*HasFoo, $S3<C>
+// CHECK: [[HASFOO:%.*]] = alloc_stack $HasFoo
+// CHECK: [[EXIS_ADDR:%.*]] = init_existential_addr [[HASFOO]] : $*HasFoo, $S3<C>
 // CHECK: copy_addr [take] [[S3]] to [initialization] [[EXIS_ADDR]] : $*S3<C>
-// CHECK: inject_enum_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt
-// CHECK: [[DATA:%.*]] = unchecked_take_enum_data_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt
-// CHECK: copy_addr [take] [[DATA]] to [initialization] [[EXIS]] : $*HasFoo
+// CHECK: copy_addr [take] [[HASFOO]] to [initialization] [[EXIS]] : $*HasFoo
 // CHECK: [[OPEN_EXIS_ADDR:%.*]] = open_existential_addr immutable_access [[EXIS]] : $*HasFoo to $*@opened("4E16D5E8-FD9F-11E8-A311-D0817AD9F6DD") HasFoo
 // CHECK: [[OPEN_ADDR:%.*]] = unchecked_addr_cast [[OPEN_EXIS_ADDR]] : $*@opened("4E16D5E8-FD9F-11E8-A311-D0817AD9F6DD") HasFoo to $*S3<C>
 // CHECK: [[F:%.*]] = function_ref @$s9witnessS34main1CC_Tg5 : $@convention(witness_method: HasFoo) (S3<C>) -> ()
@@ -319,13 +310,10 @@ extension S4 : HasFoo where T : C {
 // CHECK: [[EXIS:%.*]] = alloc_stack $HasFoo
 // CHECK: [[S3:%.*]] = alloc_stack $S4<SubC>
 // CHECK: store %0 to [[S3]] : $*S4<SubC>
-// CHECK: [[OPT:%.*]] = alloc_stack $Optional<HasFoo>
-// CHECK: [[INIT_DATA:%.*]] = init_enum_data_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt
-// CHECK: [[EXIS_ADDR:%.*]] = init_existential_addr [[INIT_DATA]] : $*HasFoo, $S4<SubC>
+// CHECK: [[HASFOO:%.*]] = alloc_stack $HasFoo
+// CHECK: [[EXIS_ADDR:%.*]] = init_existential_addr [[HASFOO]] : $*HasFoo, $S4<SubC>
 // CHECK: copy_addr [take] [[S3]] to [initialization] [[EXIS_ADDR]] : $*S4<SubC>
-// CHECK: inject_enum_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt
-// CHECK: [[DATA:%.*]] = unchecked_take_enum_data_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt
-// CHECK: copy_addr [take] [[DATA]] to [initialization] [[EXIS]] : $*HasFoo
+// CHECK: copy_addr [take] [[HASFOO]] to [initialization] [[EXIS]] : $*HasFoo
 // CHECK: [[OPEN_EXIS_ADDR:%.*]] = open_existential_addr immutable_access [[EXIS]] : $*HasFoo to $*@opened("4E16E402-FD9F-11E8-A311-D0817AD9F6DD") HasFoo
 // CHECK: [[OPEN_ADDR:%.*]] = unchecked_addr_cast [[OPEN_EXIS_ADDR]] : $*@opened("4E16E402-FD9F-11E8-A311-D0817AD9F6DD") HasFoo to $*S4<SubC>
 // CHECK: [[F:%.*]] = function_ref @$s9witnessS44main4SubCC_Tg5 : $@convention(witness_method: HasFoo) (S4<SubC>) -> ()

--- a/test/SILOptimizer/optional_of_existential.swift
+++ b/test/SILOptimizer/optional_of_existential.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend -O -module-name=test -emit-sil -primary-file %s | %FileCheck %s
+
+protocol P { associatedtype A = Int }
+protocol Q : P {}
+
+protocol B { var x: Int { get } }
+struct Y<T> {}
+extension Y : B where T : Q { var x: Int { 0 }}
+
+extension P {
+  var z: Int? { (Y<Self>() as? B)?.x }
+}
+
+struct X : Q {
+
+// Check that this getter can be folded to a simple "return 0"
+
+// CHECK-LABEL: sil hidden @$s4test1XV0A2MeSiSgvg : $@convention(method) (X) -> Optional<Int> {
+// CHECK:      bb0(%0 : $X):
+// CHECK-NEXT:   integer_literal ${{.*}}, 0
+// CHECK-NEXT:   struct $Int
+// CHECK-NEXT:   enum $Optional<Int>, #Optional.some!enumelt
+// CHECK-NEXT:   return %3 : $Optional<Int>
+// CHECK-NEXT: } // end sil function '$s4test1XV0A2MeSiSgvg'
+  var testMe: Int? { z }
+}

--- a/test/SILOptimizer/sil_combine_concrete_existential.sil
+++ b/test/SILOptimizer/sil_combine_concrete_existential.sil
@@ -183,11 +183,10 @@ sil @$s37witness_return_optional_indirect_self1SVACycfC : $@convention(method) (
 // CHECK: [[R1:%.*]] = alloc_stack $Optional<@opened("83DE9694-7315-11E8-955C-ACDE48001122") PPP>
 // CHECK: [[W1:%.*]] = witness_method $S, #PPP.returnsOptionalIndirect : <Self where Self : PPP> (Self) -> () -> Self? : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
 // CHECK: apply [[W1]]<@opened("83DE9694-7315-11E8-955C-ACDE48001122") PPP>([[R1]], [[O1]]) : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
-// CHECK: inject_enum_addr [[OE1:%.*]] : $*Optional<PPP>, #Optional.some!enumelt
-// CHECK: [[E1:%.*]] = unchecked_take_enum_data_addr [[OE1]] : $*Optional<PPP>, #Optional.some!enumelt
-// CHECK: [[O2:%.*]] = open_existential_addr immutable_access [[E1]] : $*PPP to $*@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP
+// CHECK: [[E1:%.*]] = unchecked_take_enum_data_addr
+// CHECK: [[O2:%.*]] = open_existential_addr immutable_access {{.*}} : $*PPP to $*@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP
 // CHECK: [[R2:%.*]] = alloc_stack $Optional<@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP>
-// CHECK: [[W2:%.*]] = witness_method $@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP, #PPP.returnsOptionalIndirect : <Self where Self : PPP> (Self) -> () -> Self?, %19 : $*@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
+// CHECK: [[W2:%.*]] = witness_method $@opened("{{.*}}") PPP, #PPP.returnsOptionalIndirect
 // CHECK: apply [[W2]]<@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP>([[R2]], [[O2]]) : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
 // CHECK-LABEL: } // end sil function '$s37witness_return_optional_indirect_self37testWitnessReturnOptionalIndirectSelfyyF'
 sil @$s37witness_return_optional_indirect_self37testWitnessReturnOptionalIndirectSelfyyF : $@convention(thin) () -> () {
@@ -463,13 +462,10 @@ sil [transparent] [reabstraction_thunk] @testDevirtExistentialEnumThunk : $@conv
 //
 // CHECK-LABEL: sil shared [noinline] @testDevirtExistentialEnum : $@convention(thin) (@guaranteed Array<Int>) -> () {
 // CHECK: [[ALLOC_EXISTENTIAL:%.*]] = alloc_stack $ContiguousBytes
-// CHECK: [[ALLOC_ENUM:%.*]] = alloc_stack $Optional<ContiguousBytes>
-// CHECK: [[ENUM:%.*]] = init_enum_data_addr [[ALLOC_ENUM]] : $*Optional<ContiguousBytes>, #Optional.some!enumelt
-// CHECK: [[INIT_DATA:%.*]] = init_existential_addr [[ENUM]] : $*ContiguousBytes, $Array<Int>
+// CHECK: [[ALLOC_ENUM:%.*]] = alloc_stack $ContiguousBytes
+// CHECK: [[INIT_DATA:%.*]] = init_existential_addr [[ALLOC_ENUM]] : $*ContiguousBytes, $Array<Int>
 // CHECK: store %0 to [[INIT_DATA]] : $*Array<Int>
-// CHECK: inject_enum_addr [[ALLOC_ENUM]] : $*Optional<ContiguousBytes>, #Optional.some!enumelt
-// CHECK: [[TAKE_DATA:%.*]] = unchecked_take_enum_data_addr [[ALLOC_ENUM]] : $*Optional<ContiguousBytes>, #Optional.some!enumelt
-// CHECK: copy_addr [take] [[TAKE_DATA]] to [initialization] [[ALLOC_EXISTENTIAL]] : $*ContiguousBytes
+// CHECK: copy_addr [take] [[ALLOC_ENUM]] to [initialization] [[ALLOC_EXISTENTIAL]] : $*ContiguousBytes
 // CHECK: [[OPENED:%.*]] = open_existential_addr immutable_access [[ALLOC_EXISTENTIAL]] : $*ContiguousBytes to $*@opened("8402EC1A-F35D-11E8-950A-D0817AD9F6DD") ContiguousBytes
 // CHECK: [[THUNK:%.*]] = function_ref @testDevirtExistentialEnumThunk : $@convention(thin) (UnsafeRawBufferPointer) -> (@out (), @error Error)
 // CHECK: [[TTF:%.*]] = thin_to_thick_function [[THUNK:%.*]] : $@convention(thin) (UnsafeRawBufferPointer) -> (@out (), @error Error) to $@noescape @callee_guaranteed (UnsafeRawBufferPointer) -> (@out (), @error Error)

--- a/test/SILOptimizer/sil_combine_enum_addr.sil
+++ b/test/SILOptimizer/sil_combine_enum_addr.sil
@@ -6,8 +6,8 @@ import Builtin
 import Swift
 
 // CHECK-LABEL: sil  @convert_inject_enum_addr_select_enum_addr_into_cond_br : $@convention(thin) (@in Int, @inout _Stdout) -> ()
-// CHECK: init_existential_addr
-// CHECK: inject_enum_addr
+// CHECK-NOT: init_existential_addr
+// CHECK-NOT: inject_enum_addr
 // CHECK-NOT: select_enum_addr
 // CHECK-NOT: bb1
 // CHECK-NOT: unchecked_take_enum_data_addr
@@ -42,8 +42,8 @@ bb2:
 
 
 // CHECK-LABEL: sil  @convert_inject_enum_addr_switch_enum_addr_into_cond_br : $@convention(thin) (@in Int, @inout _Stdout) -> ()
-// CHECK: init_existential_addr
-// CHECK: inject_enum_addr
+// CHECK-NOT: init_existential_addr
+// CHECK-NOT: inject_enum_addr
 // CHECK-NOT: switch_enum_addr
 // CHECK-NOT: bb1
 // CHECK-NOT: unchecked_take_enum_data_addr

--- a/test/SILOptimizer/sil_combine_enums.sil
+++ b/test/SILOptimizer/sil_combine_enums.sil
@@ -140,9 +140,10 @@ bb0(%0 : $*G<T>):
 // CHECK: enum $Optional<Int32>, #Optional.some!enumelt
 // CHECK-NOT: inject_enum_addr
 // CHECK: return
-sil @canonicalize_init_enum_data_addr : $@convention(thin) (@inout Int32, Builtin.Int32) -> Int32 {
-bb0(%0 : $*Int32, %1 : $Builtin.Int32):
+sil @canonicalize_init_enum_data_addr : $@convention(thin) (@inout Int32, Builtin.Int32, Optional<Int32>) -> Int32 {
+bb0(%0 : $*Int32, %1 : $Builtin.Int32, %2 : $Optional<Int32>):
   %s1 = alloc_stack $Optional<Int32>
+  store %2 to %s1 : $*Optional<Int32>
   %e1 = init_enum_data_addr %s1 : $*Optional<Int32>, #Optional.some!enumelt
   %v = load %0 : $*Int32
   store %v to %e1 : $*Int32
@@ -163,9 +164,10 @@ bb0(%0 : $*Int32, %1 : $Builtin.Int32):
 // CHECK: enum $Optional<Int32>, #Optional.some!enumelt
 // CHECK-NOT: inject_enum_addr
 // CHECK: return
-sil @canonicalize_init_enum_data_addr_diff_basic_blocks : $@convention(thin) (@inout Int32, Builtin.Int32) -> Int32 {
-bb0(%0 : $*Int32, %1 : $Builtin.Int32):
+sil @canonicalize_init_enum_data_addr_diff_basic_blocks : $@convention(thin) (@inout Int32, Builtin.Int32, Optional<Int32>) -> Int32 {
+bb0(%0 : $*Int32, %1 : $Builtin.Int32, %2 : $Optional<Int32>):
   %s1 = alloc_stack $Optional<Int32>
+  store %2 to %s1 : $*Optional<Int32>
   %e1 = init_enum_data_addr %s1 : $*Optional<Int32>, #Optional.some!enumelt
   %v = load %0 : $*Int32
   store %v to %e1 : $*Int32
@@ -494,5 +496,116 @@ bb0(%0 : $Int, %1 : $Int):
   %r = load %17 : $*Optional<(Int, Int)>
   dealloc_stack %17 : $*Optional<(Int, Int)>
   return %r : $Optional<(Int, Int)>
+}
+
+enum MP {
+  case A(S)
+  case B(S)
+}
+
+sil @take_s : $@convention(thin) (@in S) -> ()
+sil @use_mp : $@convention(thin) (@in_guaranteed MP) -> ()
+
+// CHECK-LABEL: sil @expand_alloc_stack_of_enum1
+// CHECK:        [[A:%[0-9]+]] = alloc_stack $S
+// CHECK:      bb1:
+// CHECK-NEXT:   store %0 to [[A]]
+// CHECK:      bb2:
+// CHECK-NEXT:   store %0 to [[A]]
+// CHECK:      bb3:
+// CHECK:        apply {{%[0-9]+}}([[A]])
+// CHECK: } // end sil function 'expand_alloc_stack_of_enum1'
+sil @expand_alloc_stack_of_enum1 : $@convention(method) (S) -> () {
+bb0(%0 : $S):
+  %1 = alloc_stack $MP
+  cond_br undef, bb1, bb2
+bb1:
+  %2 = init_enum_data_addr %1 : $*MP, #MP.A!enumelt
+  store %0 to %2 : $*S
+  inject_enum_addr %1 : $*MP, #MP.A!enumelt
+  br bb3
+bb2:
+  %3 = init_enum_data_addr %1 : $*MP, #MP.A!enumelt
+  store %0 to %3 : $*S
+  inject_enum_addr %1 : $*MP, #MP.A!enumelt
+  br bb3
+bb3:
+  %7 = unchecked_take_enum_data_addr %1 : $*MP, #MP.A!enumelt
+  %8 = function_ref @take_s : $@convention(thin) (@in S) -> ()
+  %9 = apply %8(%7) : $@convention(thin) (@in S) -> ()
+  dealloc_stack %1 : $*MP
+  %11 = tuple ()
+  return %11 : $()
+}
+
+// CHECK-LABEL: sil @expand_alloc_stack_of_enum_without_take
+// CHECK:        [[A:%[0-9]+]] = alloc_stack $S
+// CHECK:      bb1:
+// CHECK-NEXT:   store %0 to [[A]]
+// CHECK:      bb2:
+// CHECK-NEXT:   store %0 to [[A]]
+// CHECK:      bb3:
+// CHECK:        destroy_addr [[A]]
+// CHECK: } // end sil function 'expand_alloc_stack_of_enum_without_take'
+sil @expand_alloc_stack_of_enum_without_take : $@convention(method) (S) -> () {
+bb0(%0 : $S):
+  %1 = alloc_stack $MP
+  cond_br undef, bb1, bb2
+bb1:
+  %2 = init_enum_data_addr %1 : $*MP, #MP.A!enumelt
+  store %0 to %2 : $*S
+  inject_enum_addr %1 : $*MP, #MP.A!enumelt
+  br bb3
+bb2:
+  %3 = init_enum_data_addr %1 : $*MP, #MP.A!enumelt
+  store %0 to %3 : $*S
+  inject_enum_addr %1 : $*MP, #MP.A!enumelt
+  br bb3
+bb3:
+  destroy_addr %1 : $*MP
+  dealloc_stack %1 : $*MP
+  %11 = tuple ()
+  return %11 : $()
+}
+
+// CHECK-LABEL: sil @dont_expand_alloc_stack_of_enum_multiple_cases
+// CHECK:   alloc_stack $MP
+// CHECK: } // end sil function 'dont_expand_alloc_stack_of_enum_multiple_cases'
+sil @dont_expand_alloc_stack_of_enum_multiple_cases : $@convention(method) (S) -> () {
+bb0(%0 : $S):
+  %1 = alloc_stack $MP
+  cond_br undef, bb1, bb2
+bb1:
+  %2 = init_enum_data_addr %1 : $*MP, #MP.A!enumelt
+  store %0 to %2 : $*S
+  inject_enum_addr %1 : $*MP, #MP.A!enumelt
+  br bb3
+bb2:
+  %3 = init_enum_data_addr %1 : $*MP, #MP.B!enumelt
+  store %0 to %3 : $*S
+  inject_enum_addr %1 : $*MP, #MP.B!enumelt
+  br bb3
+bb3:
+  destroy_addr %1 : $*MP
+  dealloc_stack %1 : $*MP
+  %11 = tuple ()
+  return %11 : $()
+}
+
+// CHECK-LABEL: sil @dont_expand_alloc_stack_of_enum_unknown_use
+// CHECK:   alloc_stack $MP
+// CHECK: } // end sil function 'dont_expand_alloc_stack_of_enum_unknown_use'
+sil @dont_expand_alloc_stack_of_enum_unknown_use : $@convention(method) (S) -> () {
+bb0(%0 : $S):
+  %1 = alloc_stack $MP
+  %2 = init_enum_data_addr %1 : $*MP, #MP.A!enumelt
+  store %0 to %2 : $*S
+  inject_enum_addr %1 : $*MP, #MP.A!enumelt
+  %8 = function_ref @use_mp : $@convention(thin) (@in_guaranteed MP) -> ()
+  %9 = apply %8(%1) : $@convention(thin) (@in_guaranteed MP) -> ()
+  destroy_addr %1 : $*MP
+  dealloc_stack %1 : $*MP
+  %11 = tuple ()
+  return %11 : $()
 }
 


### PR DESCRIPTION
Replaces an alloc_stack of an enum by an alloc_stack of the payload if only one enum case (with payload) is stored to that location.

For example:
```
  %loc = alloc_stack $Optional<T>
  %payload = init_enum_data_addr %loc
  store %value to %payload
  ...
  %take_addr = unchecked_take_enum_data_addr %loc
  %l = load %take_addr
```
is transformed to
```
  %loc = alloc_stack $T
  store %value to %loc
  ...
  %l = load %loc
```

https://bugs.swift.org/browse/SR-12710
