### PR TITLE
[NFC] Rename SerializeOptionsForDebugging to SerializeOptions

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -396,7 +396,7 @@ public:
   /// serialization options.
   ///
   /// FIXME: The \p module parameter supports the
-  /// \c SerializeOptionsForDebugging hack.
+  /// \c SerializeOptions hack.
   SerializationOptions
   computeSerializationOptions(const SupplementaryOutputPaths &outs,
                               const ModuleDecl *module) const;
@@ -406,7 +406,7 @@ public:
   ///
   /// FIXME: The scope of this computation should be limited entirely to
   /// PrintAsObjC. Unfortunately, it has been co-opted to support the
-  /// \c SerializeOptionsForDebugging hack. Once this information can be
+  /// \c SerializeOptions hack. Once this information can be
   /// transferred from module files to the dSYMs, remove this.
   bool isModuleExternallyConsumed(const ModuleDecl *mod) const;
 };

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -146,9 +146,9 @@ public:
   bool IgnoreSwiftSourceInfo = false;
 
   /// When true, emitted module files will always contain options for the
-  /// debugger to use. When unset, the options will only be present if the
-  /// module appears to not be a public module.
-  Optional<bool> SerializeOptionsForDebugging;
+  /// debugger and LTO plugin to use. When unset, the options will only be
+  /// present if the module appears to not be a public module.
+  Optional<bool> SerializeOptions;
 
   /// When true, check if all required SwiftOnoneSupport symbols are present in
   /// the module.

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -129,7 +129,7 @@ namespace swift {
 
     bool AutolinkForceLoad = false;
     bool SerializeAllSIL = false;
-    bool SerializeOptionsForDebugging = false;
+    bool SerializeOptions = false;
     bool IsSIB = false;
   };
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -174,7 +174,7 @@ bool ArgsToFrontendOptionsConverter::convert(
 
   if (const Arg *A = Args.getLastArg(OPT_serialize_debugging_options,
                                      OPT_no_serialize_debugging_options)) {
-    Opts.SerializeOptionsForDebugging =
+    Opts.SerializeOptions =
         A->getOption().matches(OPT_serialize_debugging_options);
   }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -170,9 +170,8 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
   // Options contain information about the developer's computer,
   // so only serialize them if the module isn't going to be shipped to
   // the public.
-  serializationOpts.SerializeOptionsForDebugging =
-      opts.SerializeOptionsForDebugging.getValueOr(
-          !isModuleExternallyConsumed(module));
+  serializationOpts.SerializeOptions =
+      opts.SerializeOptions.getValueOr(!isModuleExternallyConsumed(module));
 
   return serializationOpts;
 }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -908,7 +908,7 @@ void Serializer::writeHeader(const SerializationOptions &options) {
         Strategy.emit(ScratchRecord, unsigned(M->getResilienceStrategy()));
       }
 
-      if (options.SerializeOptionsForDebugging) {
+      if (options.SerializeOptions) {
         options_block::SDKPathLayout SDKPath(Out);
         options_block::XCCLayout XCC(Out);
 
@@ -981,7 +981,7 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
   input_block::DependencyDirectoryLayout DependencyDirectory(Out);
   input_block::ModuleInterfaceLayout ModuleInterface(Out);
 
-  if (options.SerializeOptionsForDebugging) {
+  if (options.SerializeOptions) {
     const SearchPathOptions &searchPathOpts = M->getASTContext().SearchPathOpts;
     // Put the framework search paths first so that they'll be preferred upon
     // deserialization.


### PR DESCRIPTION
This option is not only used for debugging but also for LTO to
serialize detail options.

This change is pulled out from https://github.com/apple/swift/pull/32233

CC: @compnerd 
<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
