### PR TITLE
[5.3][SourceKit] Disable complete_build_session.swift test file

### DIFF
--- a/test/SourceKit/CodeComplete/complete_build_session.swift
+++ b/test/SourceKit/CodeComplete/complete_build_session.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar60881337
 import Foo
 
 func test() {


### PR DESCRIPTION
Cherry-pick of #32163 into `release/5.3` (Test only changes)