### PR TITLE
[5.3][memory-lifetime] Teach the verifier that select_enum_addr doesn't write to memory.

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -536,6 +536,7 @@ struct ImmutableAddressUseVerifier {
       case SILInstructionKind::FixLifetimeInst:
       case SILInstructionKind::KeyPathInst:
       case SILInstructionKind::SwitchEnumAddrInst:
+      case SILInstructionKind::SelectEnumAddrInst:
         break;
       case SILInstructionKind::AddressToPointerInst:
         // We assume that the user is attempting to do something unsafe since we

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -377,3 +377,20 @@ bb6(%45 : @owned $Error):
   br bb4(%45 : $Error)
 }
 
+sil [ossa] @test_memory_lifetime_select_enum : $@convention(thin) (@in_guaranteed Optional<T>) -> () {
+bb0(%0 : $*Optional<T>):
+  %2 = integer_literal $Builtin.Int1, 0
+  %3 = integer_literal $Builtin.Int1, 1
+  %4 = select_enum_addr %0 : $*Optional<T>, case #Optional.none!enumelt: %2, case #Optional.some!enumelt: %3 : $Builtin.Int1
+  cond_br %4, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
This is an older verifier that checks that uses of addresses from things like
in_guaranteed parameters are never written to. We just never hit this before.

<rdar://problem/63188699>

(cherry picked from commit ebf291c4848409359d05e7c60057a62599d3336b)

----

Explanation: This is just eliminating a false positive case to a verifier that we only run when assertions are enabled. By fixing this, we ensure that when qualifying with an asserts compiler we do not hit this case.
Scope: This doesn't break source or anything of the sort but just helps us to qualify using assert compilers.
SR Issue: <rdar://problem/63188699>
Risk: None. This only is run in asserts builds.
Testing: Added an example to the swift test suite to make sure we accept this pattern.
Reviewer: @meg-gupta 
