### PR TITLE
[CS] Add a missing null check in repairFailures

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3047,11 +3047,12 @@ bool ConstraintSystem::repairFailures(
     // default values, let's see whether error is related to missing
     // explicit call.
     if (fnType->getNumParams() > 0) {
-      auto anchor = simplifyLocatorToAnchor(getConstraintLocator(locator));
-      if (!anchor.is<Expr *>())
+      auto *loc = getConstraintLocator(locator);
+      auto *anchor = getAsExpr(simplifyLocatorToAnchor(loc));
+      if (!anchor)
         return false;
 
-      auto overload = findSelectedOverloadFor(getAsExpr(anchor));
+      auto overload = findSelectedOverloadFor(anchor);
       if (!(overload && overload->choice.isDecl()))
         return false;
 

--- a/test/Constraints/sr12964.swift
+++ b/test/Constraints/sr12964.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {}
+typealias T = (P) -> Void
+let x: T! = [1, 2, 3].reversed().reduce()
+// expected-error@-1 {{no exact matches in call to instance method 'reduce'}}
+// expected-note@-2 2{{candidate has partially matching parameter list}}


### PR DESCRIPTION
If we fail to simplify the locator, such as in the case where we have synthesized a missing call argument, bail without trying to add a missing call fix.

Resolves SR-12964.
Resolves rdar://64168162.
