### PR TITLE
[ownership] Add new OwnershipEliminatorPass that does not run when the current module is the stdlib.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -248,6 +248,9 @@ PASS(OwnershipModelEliminator, "ownership-model-eliminator",
 PASS(NonTransparentFunctionOwnershipModelEliminator,
      "non-transparent-func-ownership-model-eliminator",
      "Eliminate Ownership Annotations from non-transparent SIL Functions")
+PASS(NonStdlibNonTransparentFunctionOwnershipModelEliminator,
+     "non-stdlib-non-transparent-func-ownership-model-eliminator",
+     "Eliminate Ownership Annotations from non-transparent SIL Functions only when not processing the stdlib.")
 PASS(RCIdentityDumper, "rc-id-dumper",
      "Print Reference Count Identities")
 PASS(AlwaysInlineInliner, "always-inline",

--- a/test/SILOptimizer/ome_ignore_stdlib.sil
+++ b/test/SILOptimizer/ome_ignore_stdlib.sil
@@ -1,0 +1,13 @@
+// RUN: %target-sil-opt -non-stdlib-non-transparent-func-ownership-model-eliminator %s | %FileCheck %s
+// RUN: %target-sil-opt -non-stdlib-non-transparent-func-ownership-model-eliminator %s -module-name Swift | %FileCheck -check-prefix=STDLIB-CHECK %s
+
+// CHECK-NOT: [ossa]
+// STDLIB-CHECK: [ossa]
+
+sil_stage canonical
+
+sil [ossa] @my_ossa : $@convention(thin) () -> () {
+bb0:
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
As part of bringing up ossa on the rest of the optimizer, I am going to be first
moving ossa back for the stdlib module since the stdlib module does not have any
sil based dependencies. To do so, I am adding this pass that I can place at the
beginning of the pipeline (where NonTransparentFunctionOwnershipModelEliminator
runs today) and then move NonTransparentFunctionOwnershipModelEliminator down as
I update passes. If we are processing the stdlib, the ome doesn't run early and
instead runs late. If we are not processing the stdlib, we perform first an OME
run early and then perform an additional OME run that does nothing since
lowering ownership is an idempotent operation.

----

NOTE: This does not actually enable anything. This just adds the pass and adds tests to validate the behavior.