### PR TITLE
[Incremental Dependencies] Coarse-grained dependencies by default

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -322,7 +322,7 @@ namespace swift {
     /// the interface hash, hash them into per-iterable-decl-context
     /// fingerprints. Fine-grained dependency types won't dirty every provides
     /// in a file when the user adds a member to, e.g., a struct.
-    bool EnableTypeFingerprints = true;
+    bool EnableTypeFingerprints = false;
 
     /// When using fine-grained dependencies, emit dot files for every swiftdeps
     /// file.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -316,7 +316,7 @@ namespace swift {
 
     /// Emit the newer, finer-grained swiftdeps file. Eventually will support
     /// faster rebuilds.
-    bool EnableFineGrainedDependencies = true;
+    bool EnableFineGrainedDependencies = false;
 
     /// Instead of hashing tokens inside of NominalType and ExtensionBodies into
     /// the interface hash, hash them into per-iterable-decl-context

--- a/test/InterfaceHash/added_method-type-fingerprints.swift
+++ b/test/InterfaceHash/added_method-type-fingerprints.swift
@@ -8,10 +8,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
 
 // RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs

--- a/test/InterfaceHash/added_private_class_private_property-type-fingerprints.swift
+++ b/test/InterfaceHash/added_private_class_private_property-type-fingerprints.swift
@@ -5,10 +5,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
 
 // RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs

--- a/test/InterfaceHash/added_private_class_property-type-fingerprints.swift
+++ b/test/InterfaceHash/added_private_class_property-type-fingerprints.swift
@@ -5,10 +5,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
 
 // RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs

--- a/test/InterfaceHash/added_private_enum_private_property-type-fingerprints.swift
+++ b/test/InterfaceHash/added_private_enum_private_property-type-fingerprints.swift
@@ -8,10 +8,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
 
 // RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs

--- a/test/InterfaceHash/added_private_enum_property-type-fingerprints.swift
+++ b/test/InterfaceHash/added_private_enum_property-type-fingerprints.swift
@@ -8,10 +8,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
 
 // RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs

--- a/test/InterfaceHash/added_private_method-type-fingerprints.swift
+++ b/test/InterfaceHash/added_private_method-type-fingerprints.swift
@@ -8,10 +8,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
 
 // RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs

--- a/test/InterfaceHash/added_private_method_value_types-type-fingerprints.swift
+++ b/test/InterfaceHash/added_private_method_value_types-type-fingerprints.swift
@@ -8,10 +8,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
 
 // RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs

--- a/test/InterfaceHash/added_private_protocol_method-type-fingerprints.swift
+++ b/test/InterfaceHash/added_private_protocol_method-type-fingerprints.swift
@@ -8,10 +8,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
 
 // RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs

--- a/test/InterfaceHash/added_private_protocol_property-type-fingerprints.swift
+++ b/test/InterfaceHash/added_private_protocol_property-type-fingerprints.swift
@@ -8,10 +8,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
 
 // RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs

--- a/test/InterfaceHash/added_private_struct_private_property-type-fingerprints.swift
+++ b/test/InterfaceHash/added_private_struct_private_property-type-fingerprints.swift
@@ -8,10 +8,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
 
 // RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs

--- a/test/InterfaceHash/added_private_struct_property-type-fingerprints.swift
+++ b/test/InterfaceHash/added_private_struct_property-type-fingerprints.swift
@@ -8,10 +8,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
 
 // RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs

--- a/test/InterfaceHash/edited_method_body-type-fingerprints.swift
+++ b/test/InterfaceHash/edited_method_body-type-fingerprints.swift
@@ -8,10 +8,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
 
 // RUN: cmp %t/{a,b}-processed.swiftdeps 

--- a/test/InterfaceHash/edited_property_getter-type-fingerprints.swift
+++ b/test/InterfaceHash/edited_property_getter-type-fingerprints.swift
@@ -8,10 +8,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
-// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %target-swift-frontend -typecheck -enable-fine-grained-dependencies -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
 
 // RUN: cmp %t/{a,b}-processed.swiftdeps 


### PR DESCRIPTION
Default to coarse-grained dependencies.

rdar://63984581

Explanation: The perturbation tester found a miscompile with fine-grained dependencies. Switch back to the legacy coarse-grained ones.

Scope: When using incremental compilation, it is possible that not all affected files will get miscompiled after adding a stored member. Based on the perturbation tester perturbing Alamofire, it is not likely, though it may be more likely in other code bases. Also will avoid a performance regression in 5.3.

Origination: When fine-grained dependencies were made the default, https://github.com/apple/swift/pull/29379, Jan 24, 2020.

Risk: Very low, since we used coarse-grained dependencies for years, and we still test them in 5.3.

Pull request URL: https://github.com/apple/swift/pull/32280

Reviewed by: Doug Gregor

Automated testing: Both the usual ci tests, and the Perturbation Tester. No miscompiles adding member functions or member storage to Alamofire.

Dependencies: none

Builder Impact: Anyone who uses incremental compilation.

Directions for exposing the bug: 
1. Download Alamofire, SHA dc671c9b5a71d16b457cf844a8e8e838e25cc5d1
2. Compile incrementally
3. At the top of  RevocationTrustEvaluator.Options in  ServerTrustEvaluation.swift, add “var foo = 17”
4. Compile incrementally, see what gets rebuilt.
5. Touch all the swift files, and compile again, comparing what gets rebuilt.

Because of the bug, the rebuilt files for 4 and 5 will differ. 