### PR TITLE
[Driver/SourceKit] Handle filelist driver args in getSingleFrontendInvocationFromDriverArguments

### DIFF
--- a/test/SourceKit/Misc/handle-filelist-driver-args.swift
+++ b/test/SourceKit/Misc/handle-filelist-driver-args.swift
@@ -1,0 +1,8 @@
+let x = 10
+x.littleEndian
+
+// RUN: %empty-directory(%t)
+// RUN: echo %s > %t/tmp.SwiftFileList
+// RUN: %target-swiftc_driver -typecheck @%t/tmp.SwiftFileList
+// RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- @%t/tmp.SwiftFileList | %FileCheck %s -check-prefix=COMPLETE
+// COMPLETE: littleEndian


### PR DESCRIPTION
`getSingleFrontendInvocationFromDriverArguments` is set up to never produce file lists in the output frontend arguments (since none of its clients care about command line argument limits), but since the driver proper accepts file lists as input arguments it seems like this function should handle them too.

This was causing the sourcekitd stress tester (which passes whatever the build gives to the driver through to sourcekitd verbatim) to report failures that didn't reproduce in Xcode (which seems to never include file lists when computing the arguments to pass through to sourcekitd).