### PR TITLE
[test] Set LD_LIBRARY_PATH if testing on OpenBSD.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -166,6 +166,12 @@ swift_obj_root = getattr(config, 'swift_obj_root', None)
 config.llvm_src_root = getattr(config, 'llvm_src_root', None)
 config.llvm_obj_root = getattr(config, 'llvm_obj_root', None)
 
+if platform.system() == 'OpenBSD':
+    llvm_libs_dir = getattr(config, 'llvm_libs_dir', None)
+    if not llvm_libs_dir:
+        lit_config.fatal('No LLVM libs dir set.')
+    config.environment['LD_LIBRARY_PATH'] = llvm_libs_dir
+
 def append_to_env_path(directory):
     config.environment['PATH'] = \
         os.path.pathsep.join((directory, config.environment['PATH']))


### PR DESCRIPTION
LLVM binaries are built with rpath and dynamic libraries referenced
relative to $ORIGIN. However, on OpenBSD, ld.so resolves $ORIGIN
relative to the working directory, because on this platform there is no
mechanism available to generically and portably track the path of a
running executable[1].

Therefore, work around this by setting LD_LIBRARY_PATH to ensure that
LLVM executables running in unit tests can properly reference the
necessary LLVM dynamic libraries.

[1] See https://marc.info/?l=openbsd-misc&m=144987773230417&w=2