### PR TITLE
[Refactoring] Print @escaping For Closures In Generated Memberwise Initializer

### DIFF
--- a/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/class_members.swift.expected
+++ b/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/class_members.swift.expected
@@ -1,11 +1,13 @@
 class Person {
-internal init(firstName: String? = nil, lastName: String? = nil, age: Int? = nil, planet: String = "Earth", solarSystem: String = "Milky Way", avgHeight: Int = 175) {
+internal init(firstName: String? = nil, lastName: String? = nil, age: Int? = nil, planet: String = "Earth", solarSystem: String = "Milky Way", avgHeight: Int = 175, location: @escaping () -> Place = { fatalError() }, secondLocation: (() -> Place)? = nil) {
 self.firstName = firstName
 self.lastName = lastName
 self.age = age
 self.planet = planet
 self.solarSystem = solarSystem
 self.avgHeight = avgHeight
+self.location = location
+self.secondLocation = secondLocation
 }
 
   var firstName: String!
@@ -15,9 +17,12 @@ self.avgHeight = avgHeight
   var avgHeight = 175
   let line = #line, file = #file, handle = #dsohandle
   lazy var idea: Idea = { fatalError() }()
+  var location: () -> Place = { fatalError() }
+  var secondLocation: (() -> Place)!
 }
 
 struct Place {
+  typealias Callback = () -> ()
   let person: Person
   let street: String
   let apartment: Optional<String>
@@ -25,6 +30,7 @@ struct Place {
   let state: String
   let postalCode: Int
   let plusFour: Int?
+  let callback: Callback
 }
 
 protocol Thing {

--- a/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/struct_members.swift.expected
+++ b/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/struct_members.swift.expected
@@ -6,10 +6,12 @@ class Person {
   var avgHeight = 175
   let line = #line, file = #file, handle = #dsohandle
   lazy var idea: Idea = { fatalError() }()
+  var location: () -> Place = { fatalError() }
+  var secondLocation: (() -> Place)!
 }
 
 struct Place {
-internal init(person: Person, street: String, apartment: Optional<String>, city: String, state: String, postalCode: Int, plusFour: Int?) {
+internal init(person: Person, street: String, apartment: Optional<String>, city: String, state: String, postalCode: Int, plusFour: Int?, callback: @escaping Place.Callback) {
 self.person = person
 self.street = street
 self.apartment = apartment
@@ -17,8 +19,10 @@ self.city = city
 self.state = state
 self.postalCode = postalCode
 self.plusFour = plusFour
+self.callback = callback
 }
 
+  typealias Callback = () -> ()
   let person: Person
   let street: String
   let apartment: Optional<String>
@@ -26,6 +30,7 @@ self.plusFour = plusFour
   let state: String
   let postalCode: Int
   let plusFour: Int?
+  let callback: Callback
 }
 
 protocol Thing {

--- a/test/refactoring/MemberwiseInit/generate_memberwise.swift
+++ b/test/refactoring/MemberwiseInit/generate_memberwise.swift
@@ -6,9 +6,12 @@ class Person {
   var avgHeight = 175
   let line = #line, file = #file, handle = #dsohandle
   lazy var idea: Idea = { fatalError() }()
+  var location: () -> Place = { fatalError() }
+  var secondLocation: (() -> Place)!
 }
 
 struct Place {
+  typealias Callback = () -> ()
   let person: Person
   let street: String
   let apartment: Optional<String>
@@ -16,6 +19,7 @@ struct Place {
   let state: String
   let postalCode: Int
   let plusFour: Int?
+  let callback: Callback
 }
 
 protocol Thing {
@@ -30,7 +34,7 @@ enum Idea {
 // RUN: %refactor -memberwise-init -source-filename %s -pos=1:8 > %t.result/generate_memberwise.swift
 // RUN: diff -u %S/Outputs/generate_memberwise/class_members.swift.expected %t.result/generate_memberwise.swift
 
-// RUN: %refactor -memberwise-init -source-filename %s -pos=11:8 > %t.result/struct_members.swift
+// RUN: %refactor -memberwise-init -source-filename %s -pos=13:8 > %t.result/struct_members.swift
 // RUN: diff -u %S/Outputs/generate_memberwise/struct_members.swift.expected %t.result/struct_members.swift
 
 // RUN: not %refactor -memberwise-init -source-filename %s -pos=21:10 > %t.result/protocol_members.swift


### PR DESCRIPTION
Augment the "generate memberwise initializer" refactoring action to
automatically print @escaping in parameter position. Closures as stored
properties always escape.

rdar://62202381