### PR TITLE
[5.3][CodeCompletion] Add keypath apply subscript after open bracket

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2762,23 +2762,32 @@ public:
       const AnyFunctionType *AFT, const SubscriptDecl *SD,
       const Optional<SemanticContextKind> SemanticContext = None) {
     foundFunction(AFT);
-    auto genericSig =
-        SD->getInnermostDeclContext()->getGenericSignatureOfContext();
-    AFT = eraseArchetypes(const_cast<AnyFunctionType *>(AFT), genericSig)
-              ->castTo<AnyFunctionType>();
+    if (SD) {
+      auto genericSig =
+          SD->getInnermostDeclContext()->getGenericSignatureOfContext();
+      AFT = eraseArchetypes(const_cast<AnyFunctionType *>(AFT), genericSig)
+                ->castTo<AnyFunctionType>();
+    }
 
     CommandWordsPairs Pairs;
     CodeCompletionResultBuilder Builder(
-        Sink, CodeCompletionResult::ResultKind::Declaration,
+        Sink,
+        SD ? CodeCompletionResult::ResultKind::Declaration
+           : CodeCompletionResult::ResultKind::Pattern,
         SemanticContext ? *SemanticContext : getSemanticContextKind(SD),
         expectedTypeContext);
-    Builder.setAssociatedDecl(SD);
-    setClangDeclKeywords(SD, Pairs, Builder);
+    if (SD) {
+      Builder.setAssociatedDecl(SD);
+      setClangDeclKeywords(SD, Pairs, Builder);
+    }
     if (!HaveLParen)
       Builder.addLeftBracket();
     else
       Builder.addAnnotatedLeftBracket();
-    addCallArgumentPatterns(Builder, AFT, SD->getIndices());
+    ArrayRef<const ParamDecl *> declParams;
+    if (SD)
+      declParams = SD->getIndices()->getArray();
+    addCallArgumentPatterns(Builder, AFT->getParams(), declParams);
     if (!HaveLParen)
       Builder.addRightBracket();
     else
@@ -6013,7 +6022,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
     Lookup.getUnresolvedMemberCompletions(ContextInfo.getPossibleTypes());
     break;
   }
-  case CompletionKind::CallArg : {
+  case CompletionKind::CallArg: {
     ExprContextInfo ContextInfo(CurDeclContext, CodeCompleteTokenExpr);
 
     bool shouldPerformGlobalCompletion = true;
@@ -6022,9 +6031,12 @@ void CodeCompletionCallbacksImpl::doneParsing() {
         !ContextInfo.getPossibleCallees().empty()) {
       Lookup.setHaveLParen(true);
       for (auto &typeAndDecl : ContextInfo.getPossibleCallees()) {
-        if (auto SD = dyn_cast_or_null<SubscriptDecl>(typeAndDecl.Decl)) {
-          Lookup.addSubscriptCallPattern(typeAndDecl.Type, SD,
-                                         typeAndDecl.SemanticContext);
+        auto apply = ContextInfo.getAnalyzedExpr();
+        if (apply && isa<SubscriptExpr>(apply)) {
+          Lookup.addSubscriptCallPattern(
+              typeAndDecl.Type,
+              dyn_cast_or_null<SubscriptDecl>(typeAndDecl.Decl),
+              typeAndDecl.SemanticContext);
         } else {
           Lookup.addFunctionCallPattern(
               typeAndDecl.Type,

--- a/test/IDE/complete_subscript.swift
+++ b/test/IDE/complete_subscript.swift
@@ -16,6 +16,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=SUPER_IN_STATICMETHOD | %FileCheck %s -check-prefix=SUPER_IN_STATICMETHOD
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=LABELED_SUBSCRIPT | %FileCheck %s -check-prefix=LABELED_SUBSCRIPT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TUPLE | %FileCheck %s -check-prefix=TUPLE
 
 struct MyStruct<T> {
   static subscript(x: Int, static defValue: T) -> MyStruct<T> {
@@ -62,6 +63,7 @@ func test1() {
   let _ = MyStruct<Int>()[#^INSTANCE_INT_BRACKET^#
 // INSTANCE_INT_BRACKET: Begin completions
 // INSTANCE_INT_BRACKET-DAG: Decl[Subscript]/CurrNominal:        ['[']{#(x): Int#}, {#instance: Int#}[']'][#Int#];
+// INSTANCE_INT_BRACKET-DAG: Pattern/CurrModule:                 ['[']{#keyPath: KeyPath<MyStruct<Int>, Value>#}[']'][#Value#];
 // INSTANCE_INT_BRACKET: End completions
 }
 func test2<U>(value: MyStruct<U>) {
@@ -87,6 +89,7 @@ func test2<U>(value: MyStruct<U>) {
   let _ = value[#^INSTANCE_ARCHETYPE_BRACKET^#
 // INSTANCE_ARCHETYPE_BRACKET: Begin completions
 // INSTANCE_ARCHETYPE_BRACKET-DAG: Decl[Subscript]/CurrNominal:        ['[']{#(x): Int#}, {#instance: U#}[']'][#Int#];
+// INSTANCE_ARCHETYPE_BRACKET-DAG: Pattern/CurrModule:                 ['[']{#keyPath: KeyPath<MyStruct<U>, Value>#}[']'][#Value#];
 // INSTANCE_ARCHETYPE_BRACKET: End completions
 
   let _ = MyStruct<U>[42, #^METATYPE_LABEL^#
@@ -110,14 +113,16 @@ class Derived: Base {
 
   func testInstance() {
     let _ = self[#^SELF_IN_INSTANCEMETHOD^#]
-// SELF_IN_INSTANCEMETHOD: Begin completions, 2 items
+// SELF_IN_INSTANCEMETHOD: Begin completions, 3 items
 // SELF_IN_INSTANCEMETHOD-DAG: Decl[Subscript]/CurrNominal: ['[']{#derivedInstance: Int#}[']'][#Int#];
 // SELF_IN_INSTANCEMETHOD-DAG: Decl[Subscript]/Super:       ['[']{#instance: Int#}[']'][#Int#];
+// SELF_IN_INSTANCEMETHOD-DAG: Pattern/CurrModule:          ['[']{#keyPath: KeyPath<Derived, Value>#}[']'][#Value#];
 // SELF_IN_INSTANCEMETHOD: End completions
 
     let _ = super[#^SUPER_IN_INSTANCEMETHOD^#]
-// SUPER_IN_INSTANCEMETHOD: Begin completions, 1 items
-// SUPER_IN_INSTANCEMETHOD-DAG: Decl[Subscript]/CurrNominal:        ['[']{#instance: Int#}[']'][#Int#];
+// SUPER_IN_INSTANCEMETHOD: Begin completions, 2 items
+// SUPER_IN_INSTANCEMETHOD-DAG: Decl[Subscript]/CurrNominal: ['[']{#instance: Int#}[']'][#Int#];
+// SUPER_IN_INSTANCEMETHOD-DAG: Pattern/CurrModule:          ['[']{#keyPath: KeyPath<Base, Value>#}[']'][#Value#];
 // SUPER_IN_INSTANCEMETHOD: End completions
   }
 
@@ -130,7 +135,7 @@ class Derived: Base {
 
     let _ = super[#^SUPER_IN_STATICMETHOD^#]
 // SUPER_IN_STATICMETHOD: Begin completions, 1 items
-// SUPER_IN_STATICMETHOD-DAG: Decl[Subscript]/CurrNominal:        ['[']{#static: Int#}[']'][#Int#];
+// SUPER_IN_STATICMETHOD-DAG: Decl[Subscript]/CurrNominal: ['[']{#static: Int#}[']'][#Int#];
 // SUPER_IN_STATICMETHOD: End completions
   }
 }
@@ -140,7 +145,15 @@ struct MyStruct1<X: Comparable> {
 }
 func testSubscriptCallSig<T>(val: MyStruct1<T>) {
   val[#^LABELED_SUBSCRIPT^#
-// LABELED_SUBSCRIPT: Begin completions, 1 items
-// LABELED_SUBSCRIPT: Decl[Subscript]/CurrNominal:        ['[']{#idx1: Int#}, {#idx2: Comparable#}[']'][#Int!#];
+// LABELED_SUBSCRIPT: Begin completions, 2 items
+// LABELED_SUBSCRIPT-DAG: Decl[Subscript]/CurrNominal:        ['[']{#idx1: Int#}, {#idx2: Comparable#}[']'][#Int!#];
+// LABELED_SUBSCRIPT-DAG: Pattern/CurrModule:                 ['[']{#keyPath: KeyPath<MyStruct1<T>, Value>#}[']'][#Value#];
 // LABELED_SUBSCRIPT: End completions
+}
+
+func testSubcscriptTuple(val: (x: Int, String)) {
+  val[#^TUPLE^#]
+// TUPLE: Begin completions, 1 items
+// TUPLE-DAG: Pattern/CurrModule:                 ['[']{#keyPath: KeyPath<(x: Int, String), Value>#}[']'][#Value#];
+// TUPLE: End completions
 }


### PR DESCRIPTION
Cherry-pick of #31980 into `release/5.3`

* **Explanation**: Most expression has `[keyPath: ]` subscript since SE-0161. But code completion didn't use to suggest calling signature of it. This patch adds `[keyPath: ]` subscript calling signature completion after opening bracket.
* **Scope**: Calling signature completion after open bracket
* **Risk**: Low. 
* **Testing**: Added regression test cases
* **Issue**: rdar://problem/61016147
* **Reviewer**: Ben Langmuir (@benlangmuir)