### PR TITLE
[cxx-interop] Add support for custom C++ destructors.

### DIFF
--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1062,10 +1062,10 @@ public:
                               SILType objectType, const TypeInfo &objectTI,
                               const OutliningMetadataCollector &collector);
 
-private:
   llvm::Constant *getAddrOfClangGlobalDecl(clang::GlobalDecl global,
                                            ForDefinition_t forDefinition);
 
+private:
   using CopyAddrHelperGenerator =
     llvm::function_ref<void(IRGenFunction &IGF, Address dest, Address src,
                             SILType objectType, const TypeInfo &objectTI)>;

--- a/test/Interop/Cxx/class/Inputs/destructors.h
+++ b/test/Interop/Cxx/class/Inputs/destructors.h
@@ -1,0 +1,20 @@
+#ifndef TEST_INTEROP_CXX_CLASS_INPUTS_DESTRUCTORS_H
+#define TEST_INTEROP_CXX_CLASS_INPUTS_DESTRUCTORS_H
+
+struct DummyStruct {};
+
+struct HasUserProvidedDestructorAndDummy {
+  DummyStruct dummy;
+  ~HasUserProvidedDestructorAndDummy() {}
+};
+
+struct HasUserProvidedDestructor {
+  int *value;
+  ~HasUserProvidedDestructor() { *value = 42; }
+};
+
+struct HasNonTrivialImplicitDestructor {
+  HasUserProvidedDestructor member;
+};
+
+#endif // TEST_INTEROP_CXX_CLASS_INPUTS_DESTRUCTORS_H

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -18,6 +18,11 @@ module ConstructorsObjC {
   requires cplusplus
 }
 
+module Destructors {
+  header "destructors.h"
+  requires cplusplus
+}
+
 module LoadableTypes {
   header "loadable-types.h"
   requires cplusplus

--- a/test/Interop/Cxx/class/destructors-correct-abi-irgen.swift
+++ b/test/Interop/Cxx/class/destructors-correct-abi-irgen.swift
@@ -1,0 +1,13 @@
+// RUN: %swift -I %S/Inputs -enable-cxx-interop -emit-ir %s | %FileCheck %s
+
+import Destructors
+
+// CHECK-LABEL: define {{.*}}void @"$s4main4testyyF"
+// CHECK: [[H:%.*]] = alloca %TSo33HasUserProvidedDestructorAndDummyV
+// CHECK: [[CXX_THIS:%.*]] = bitcast %TSo33HasUserProvidedDestructorAndDummyV* [[H]] to %struct.HasUserProvidedDestructorAndDummy*
+// CHECK: call {{.*}}@{{_ZN33HasUserProvidedDestructorAndDummyD(1|2)Ev|"\?\?1HasUserProvidedDestructorAndDummy@@QEAA@XZ"}}(%struct.HasUserProvidedDestructorAndDummy* [[CXX_THIS]])
+// CHECK: ret void
+public func test() {
+  let d = DummyStruct()
+  let h = HasUserProvidedDestructorAndDummy(dummy: d)
+}

--- a/test/Interop/Cxx/class/destructors-non-trivial-implicit-irgen.swift
+++ b/test/Interop/Cxx/class/destructors-non-trivial-implicit-irgen.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -enable-cxx-interop -I %S/Inputs %s -emit-ir | %FileCheck %s
+
+import Destructors
+
+// CHECK-LABEL: define {{.*}}void @"$s4main35testHasNonTrivialImplicitDestructoryyF"
+// CHECK:  call {{.*}}@{{_ZN31HasNonTrivialImplicitDestructorD(1|2)Ev|"\?\?1HasNonTrivialImplicitDestructor@@QEAA@XZ"}}(%struct.HasNonTrivialImplicitDestructor*
+// CHECK: ret void
+
+// TODO: Somehow check that _ZN31HasNonTrivialImplicitDestructorD1Ev (if present) calls _ZN25HasUserProvidedDestructorD2Ev.
+
+public func testHasNonTrivialImplicitDestructor() {
+  _ = HasNonTrivialImplicitDestructor()
+}
+
+// Check that we call the base destructor.
+// CHECK-LABEL: define {{.*}}@{{_ZN31HasNonTrivialImplicitDestructorD2Ev|"\?\?1HasNonTrivialImplicitDestructor@@QEAA@XZ"}}(%struct.HasNonTrivialImplicitDestructor*
+// CHECK: call {{.*}}@{{_ZN25HasUserProvidedDestructorD(1|2)Ev|"\?\?1HasUserProvidedDestructor@@QEAA@XZ"}}
+// CHECK: ret

--- a/test/Interop/Cxx/value-witness-table/Inputs/custom-destructors.h
+++ b/test/Interop/Cxx/value-witness-table/Inputs/custom-destructors.h
@@ -1,0 +1,76 @@
+#ifndef TEST_INTEROP_CXX_VALUE_WITNESS_TABLE_INPUTS_CUSTOM_DESTRUCTORS_H
+#define TEST_INTEROP_CXX_VALUE_WITNESS_TABLE_INPUTS_CUSTOM_DESTRUCTORS_H
+
+struct HasUserProvidedDestructor {
+  int *value;
+  ~HasUserProvidedDestructor() { *value = 42; }
+};
+
+struct HasEmptyDestructorAndMemberWithUserDefinedConstructor {
+  HasUserProvidedDestructor member;
+  ~HasEmptyDestructorAndMemberWithUserDefinedConstructor() { /* empty */
+  }
+};
+
+struct HasNonTrivialImplicitDestructor {
+  HasUserProvidedDestructor member;
+};
+
+struct HasNonTrivialDefaultedDestructor {
+  HasUserProvidedDestructor member;
+  ~HasNonTrivialDefaultedDestructor() = default;
+};
+
+struct HasDefaultedDestructor {
+  ~HasDefaultedDestructor() = default;
+};
+
+// For the following objects with virtual bases / destructors, make sure that
+// any exectuable user of these objects disable rtti and exceptions. Otherwise,
+// the linker will error because of undefined vtables.
+// FIXME: Once we can link with libc++ we can enable RTTI.
+
+struct HasVirtualBaseAndDestructor : virtual HasDefaultedDestructor {
+  int *value;
+  HasVirtualBaseAndDestructor(int *value) : value(value) {}
+  ~HasVirtualBaseAndDestructor() { *value = 42; }
+};
+
+struct HasVirtualDestructor {
+  // An object with a virtual destructor requires a delete operator in case
+  // we try to delete the base object. Until we can link against libc++, use
+  // this dummy implementation.
+  static void operator delete(void *p) { __builtin_unreachable(); }
+  virtual ~HasVirtualDestructor(){};
+};
+
+struct HasVirtualDefaultedDestructor {
+  static void operator delete(void *p) { __builtin_unreachable(); }
+  virtual ~HasVirtualDefaultedDestructor() = default;
+};
+
+struct HasBaseWithVirtualDestructor : HasVirtualDestructor {
+  int *value;
+  HasBaseWithVirtualDestructor(int *value) : value(value) {}
+  ~HasBaseWithVirtualDestructor() { *value = 42; }
+};
+
+struct HasVirtualBaseWithVirtualDestructor : virtual HasVirtualDestructor {
+  int *value;
+  HasVirtualBaseWithVirtualDestructor(int *value) : value(value) {}
+  ~HasVirtualBaseWithVirtualDestructor() { *value = 42; }
+};
+
+struct DummyStruct {};
+
+struct HasUserProvidedDestructorAndDummy {
+  DummyStruct dummy;
+  ~HasUserProvidedDestructorAndDummy() {}
+};
+
+// Make sure that we don't crash on struct templates with destructors.
+template <typename T> struct S {
+  ~S() {}
+};
+
+#endif // TEST_INTEROP_CXX_VALUE_WITNESS_TABLE_INPUTS_CUSTOM_DESTRUCTORS_H

--- a/test/Interop/Cxx/value-witness-table/Inputs/module.modulemap
+++ b/test/Interop/Cxx/value-witness-table/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module CustomDestructor {
+  header "custom-destructors.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/value-witness-table/custom-destructors-non-virtual-irgen.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-non-virtual-irgen.swift
@@ -1,0 +1,41 @@
+// RUN: %target-swift-frontend -enable-cxx-interop -I %S/Inputs %s -emit-ir | %FileCheck %s
+
+import CustomDestructor
+
+protocol InitWithDummy {
+  init(dummy: DummyStruct)
+}
+
+extension HasUserProvidedDestructorAndDummy : InitWithDummy { }
+
+// Make sure the destructor is added as a witness.
+// CHECK: @"$sSo33HasUserProvidedDestructorAndDummyVWV" = linkonce_odr hidden constant %swift.vwtable
+// CHECK-SAME: i8* bitcast (void (%swift.opaque*, %swift.type*)* @"$sSo33HasUserProvidedDestructorAndDummyVwxx" to i8*)
+
+// CHECK-LABEL: define {{.*}}void @"$s4main37testHasUserProvidedDestructorAndDummyyyF"
+// CHECK: [[OBJ:%.*]] = alloca %TSo33HasUserProvidedDestructorAndDummyV
+// CHECK: [[CXX_OBJ:%.*]] = bitcast %TSo33HasUserProvidedDestructorAndDummyV* [[OBJ]] to %struct.HasUserProvidedDestructorAndDummy*
+// CHECK: call {{.*}}@{{_ZN33HasUserProvidedDestructorAndDummyD(1|2)Ev|"\?\?1HasUserProvidedDestructorAndDummy@@QEAA@XZ"}}(%struct.HasUserProvidedDestructorAndDummy* [[CXX_OBJ]])
+// CHECK: ret void
+
+// Make sure we not only declare but define the destructor.
+// CHECK-LABEL: define {{.*}}@{{_ZN33HasUserProvidedDestructorAndDummyD(1|2)Ev|"\?\?1HasUserProvidedDestructorAndDummy@@QEAA@XZ"}}
+// CHECK: ret
+public func testHasUserProvidedDestructorAndDummy() {
+  _ = HasUserProvidedDestructorAndDummy(dummy: DummyStruct())
+}
+
+// CHECK-LABEL: define {{.*}}void @"$s4main26testHasDefaultedDestructoryyF"
+// CHECK: call {{.*}}@{{_ZN22HasDefaultedDestructorC(1|2)Ev|"\?\?0HasDefaultedDestructor@@QEAA@XZ"}}(%struct.HasDefaultedDestructor*
+// CHECK: ret void
+
+// CHECK-LABEL: define {{.*}}@{{_ZN22HasDefaultedDestructorC(1|2)Ev|"\?\?0HasDefaultedDestructor@@QEAA@XZ"}}(%struct.HasDefaultedDestructor*
+// CHECK: ret
+public func testHasDefaultedDestructor() {
+  _ = HasDefaultedDestructor()
+}
+
+// Make sure the destroy value witness calls the destructor.
+// CHECK-LABEL: define {{.*}}void @"$sSo33HasUserProvidedDestructorAndDummyVwxx"
+// CHECK: call {{.*}}@{{_ZN33HasUserProvidedDestructorAndDummyD(1|2)Ev|"\?\?1HasUserProvidedDestructorAndDummy@@QEAA@XZ"}}(%struct.HasUserProvidedDestructorAndDummy*
+// CHECK: ret

--- a/test/Interop/Cxx/value-witness-table/custom-destructors-non-virtual.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-non-virtual.swift
@@ -1,0 +1,128 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop -O)
+//
+// REQUIRES: executable_test
+
+import CustomDestructor
+import StdlibUnittest
+
+var CXXDestructorTestSuite = TestSuite("CXXDestructor")
+
+protocol InitWithPtr {
+  init(value: UnsafeMutablePointer<Int32>!)
+}
+
+extension HasUserProvidedDestructor : InitWithPtr { }
+
+protocol InitWithMember {
+  init(member: HasUserProvidedDestructor)
+}
+
+extension HasEmptyDestructorAndMemberWithUserDefinedConstructor
+  : InitWithMember { }
+
+@inline(never)
+@_optimize(none)
+func withCxxDestructorSideEffects<T>(_ _: inout T) { }
+
+func createTypeWithUserProvidedDestructor(_ ptr: UnsafeMutablePointer<Int32>) {
+  var obj = HasUserProvidedDestructor(value: ptr)
+  withCxxDestructorSideEffects(&obj)
+}
+
+func createTypeWithEmptyDestructorAndMemberWithUserDefinedConstructor(
+  _ ptr: UnsafeMutablePointer<Int32>
+) {
+  let member = HasUserProvidedDestructor(value: ptr)
+  var obj = HasEmptyDestructorAndMemberWithUserDefinedConstructor(member: member)
+  withCxxDestructorSideEffects(&obj)
+}
+
+func createTypeWithNonTrivialImplicitDestructor(
+  _ ptr: UnsafeMutablePointer<Int32>
+) {
+  let member = HasUserProvidedDestructor(value: ptr)
+  var obj = HasNonTrivialImplicitDestructor(member: member)
+  withCxxDestructorSideEffects(&obj)
+}
+
+func createTypeWithNonTrivialDefaultDestructor(
+  _ ptr: UnsafeMutablePointer<Int32>
+) {
+  let member = HasUserProvidedDestructor(value: ptr)
+  var obj = HasNonTrivialDefaultedDestructor(member: member)
+  withCxxDestructorSideEffects(&obj)
+}
+
+func createTypeWithGeneric<T : InitWithPtr>(
+  _ ptr: UnsafeMutablePointer<Int32>,
+  type: T.Type
+) {
+  var obj = T(value: ptr)
+  withCxxDestructorSideEffects(&obj)
+}
+
+func createTypeWithProtocol(
+  _ ptr: UnsafeMutablePointer<Int32>,
+  type: InitWithPtr.Type
+) {
+  var obj = type.self.init(value: ptr)
+  withCxxDestructorSideEffects(&obj)
+}
+
+func createTypeWithProtocol(
+  _ ptr: UnsafeMutablePointer<Int32>,
+  type: InitWithPtr.Type,
+  holder: InitWithMember.Type
+) {
+  let member = type.self.init(value: ptr)
+  var obj = holder.self.init(member: member as! HasUserProvidedDestructor)
+  withCxxDestructorSideEffects(&obj)
+}
+
+CXXDestructorTestSuite.test("Basic object with destructor") {
+  var value: Int32 = 0
+  createTypeWithUserProvidedDestructor(&value)
+  expectEqual(value, 42)
+}
+
+CXXDestructorTestSuite.test("Nested objects with destructors") {
+  var value: Int32 = 0
+  createTypeWithEmptyDestructorAndMemberWithUserDefinedConstructor(&value)
+  expectEqual(value, 42)
+}
+
+CXXDestructorTestSuite.test("Implicit destructor, member with user-defined destructor") {
+  var value: Int32 = 0
+  createTypeWithNonTrivialImplicitDestructor(&value)
+  expectEqual(value, 42)
+}
+
+CXXDestructorTestSuite.test("Default destructor, member with user-defined destructor") {
+  var value: Int32 = 0
+  createTypeWithNonTrivialDefaultDestructor(&value)
+  expectEqual(value, 42)
+}
+
+CXXDestructorTestSuite.test("Generic with destructor") {
+  var value: Int32 = 0
+  createTypeWithGeneric(&value, type: HasUserProvidedDestructor.self)
+  expectEqual(value, 42)
+}
+
+CXXDestructorTestSuite.test("Protocol with destructor") {
+  var value: Int32 = 0
+  createTypeWithProtocol(&value, type: HasUserProvidedDestructor.self)
+  expectEqual(value, 42)
+}
+
+CXXDestructorTestSuite.test("Protocol with member with destructor") {
+  var value: Int32 = 0
+  createTypeWithProtocol(
+    &value,
+    type: HasUserProvidedDestructor.self,
+    holder: HasEmptyDestructorAndMemberWithUserDefinedConstructor.self)
+  expectEqual(value, 42)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/value-witness-table/custom-destructors-typechecker.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-typechecker.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-cxx-interop
+
+import CustomDestructor
+
+_ = HasUserProvidedDestructor()
+_ = HasEmptyDestructorAndMemberWithUserDefinedConstructor()
+_ = HasNonTrivialImplicitDestructor()
+_ = HasNonTrivialDefaultedDestructor()

--- a/test/Interop/Cxx/value-witness-table/custom-destructors-virtual-irgen.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-virtual-irgen.swift
@@ -1,0 +1,19 @@
+// With RTTI some of the objects with virtual bases / destructors in this test
+// will cause linker errors because of undefined vtables.
+// FIXME: Once we can link with libc++ we can start using RTTI.
+//
+// RUN: %target-swift-frontend -enable-cxx-interop -I %S/Inputs %s -emit-ir -Xcc -fno-rtti | %FileCheck %s
+//
+// Windows doesn't support -fno-rtti.
+// UNSUPPORTED: OS=windows-msvc
+
+import CustomDestructor
+
+// CHECK-LABEL: define {{.*}}void @"$s4main022testHasVirtualBaseWithD10DestructoryySpys5Int32VGF"
+// CHECK: call {{.*}}@{{_ZN28HasBaseWithVirtualDestructorD(1|2)Ev|"\?\?1HasBaseWithVirtualDestructor@@UEAA@XZ"}}(%struct.HasBaseWithVirtualDestructor*
+// CHECK: ret
+public func testHasVirtualBaseWithVirtualDestructor(
+  _ ptr: UnsafeMutablePointer<Int32>
+) {
+  _ = HasBaseWithVirtualDestructor(ptr)
+}

--- a/test/Interop/Cxx/value-witness-table/custom-destructors-virtual.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-virtual.swift
@@ -1,0 +1,57 @@
+// With RTTI some of the objects with virtual bases / destructors in this test
+// will cause linker errors because of undefined vtables.
+// FIXME: Once we can link with libc++ we can start using RTTI.
+// 
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop -Xcc -fno-rtti)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop -Xcc -fno-rtti -O)
+//
+// REQUIRES: executable_test
+// Windows doesn't support -fno-rtti.
+// UNSUPPORTED: OS=windows-msvc
+
+import CustomDestructor
+import StdlibUnittest
+
+var CXXDestructorTestSuite = TestSuite("CXXDestructor")
+
+func createTypeWithVirtualBaseAndDestructor(
+  _ ptr: UnsafeMutablePointer<Int32>
+) {
+  _ = HasVirtualBaseAndDestructor(ptr)
+}
+
+func createTypeWithBaseWithVirtualDestructor(
+  _ ptr: UnsafeMutablePointer<Int32>
+) {
+  _ = HasBaseWithVirtualDestructor(ptr)
+}
+
+func createTypeWithVirtualBaseWithVirtualDestructor(
+  _ ptr: UnsafeMutablePointer<Int32>
+) {
+  _ = HasVirtualBaseWithVirtualDestructor(ptr)
+}
+
+CXXDestructorTestSuite.test("Virtual base and destructor") {
+  var value: Int32 = 0
+  createTypeWithVirtualBaseAndDestructor(&value)
+  expectEqual(value, 42)
+}
+
+CXXDestructorTestSuite.test("Base with virtual destructor") {
+  var value: Int32 = 0
+  createTypeWithBaseWithVirtualDestructor(&value)
+  expectEqual(value, 42)
+}
+
+CXXDestructorTestSuite.test("Virtual base with virtual destructor") {
+  var value: Int32 = 0
+  createTypeWithVirtualBaseWithVirtualDestructor(&value)
+  expectEqual(value, 42)
+}
+
+CXXDestructorTestSuite.test("Type with virtual defaulted destructor") {
+  _ = HasVirtualDefaultedDestructor()
+}
+
+runAllTests()


### PR DESCRIPTION
This patch adds support for custom C++ destructors. The most notable thing here, I think, is that this is the first place a struct type has a custom destructor. I suspect with more code we will expose a few places where optimization passes need to be fixed to account for this.

One of many patches to fix SR-12797.
