### PR TITLE
Don't require the stdlib to contain the _finalizeUninitializedArray intrinsic function.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4963,17 +4963,26 @@ void SILGenFunction::emitUninitializedArrayDeallocation(SILLocation loc,
 }
 
 ManagedValue SILGenFunction::emitUninitializedArrayFinalization(SILLocation loc,
-                                                      SILValue array) {
+                                                      ManagedValue array) {
   auto &Ctx = getASTContext();
-  auto finalize = Ctx.getFinalizeUninitializedArray();
+  FuncDecl *finalize = Ctx.getFinalizeUninitializedArray();
+  
+  // The _finalizeUninitializedArray function only needs to be called if the
+  // library contains it.
+  // The Array implementation in the stdlib <= 5.3 does not use SIL COW
+  // support yet and therefore does not provide the _finalizeUninitializedArray
+  // intrinsic function.
+  if (!finalize)
+    return array;
 
-  CanType arrayTy = array->getType().getASTType();
+  SILValue arrayVal = array.forward(*this);
+  CanType arrayTy = arrayVal->getType().getASTType();
 
   // Invoke the intrinsic.
   auto subMap = arrayTy->getContextSubstitutionMap(SGM.M.getSwiftModule(),
                                                    Ctx.getArrayDecl());
   RValue result = emitApplyOfLibraryIntrinsic(loc, finalize, subMap,
-                              ManagedValue::forUnmanaged(array),
+                              ManagedValue::forUnmanaged(arrayVal),
                               SGFContext());
   return std::move(result).getScalarValue();
 }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2117,7 +2117,7 @@ ManagedValue Lowering::emitEndVarargs(SILGenFunction &SGF, SILLocation loc,
   if (array.hasCleanup())
     SGF.Cleanups.setCleanupState(array.getCleanup(), CleanupState::Active);
 
-  return SGF.emitUninitializedArrayFinalization(loc, array.forward(SGF));
+  return SGF.emitUninitializedArrayFinalization(loc, std::move(array));
 }
 
 RValue RValueEmitter::visitTupleExpr(TupleExpr *E, SGFContext C) {

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1187,7 +1187,8 @@ public:
 
   CleanupHandle enterDeallocateUninitializedArrayCleanup(SILValue array);
   void emitUninitializedArrayDeallocation(SILLocation loc, SILValue array);
-  ManagedValue emitUninitializedArrayFinalization(SILLocation loc, SILValue array);
+  ManagedValue emitUninitializedArrayFinalization(SILLocation loc,
+                                                  ManagedValue array);
 
   /// Emit a cleanup for an owned value that should be written back at end of
   /// scope if the value is not forwarded.


### PR DESCRIPTION
Prevent SILGen to crash if the compiler is used with a stdlib which does not have the _finalizeUninitializedArray intrinsic function.

rdar://problem/64195028
