### PR TITLE
DependencyScanner: add a new extraPcmArgs field for each Swift module

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -73,6 +73,11 @@ public:
   /// interface.
   const std::vector<std::string> buildCommandLine;
 
+  /// To build a PCM to be used by this Swift module, we need to append these
+  /// arguments to the generic PCM build arguments reported from the dependency
+  /// graph.
+  const std::vector<std::string> extraPCMArgs;
+
   /// The hash value that will be used for the generated module
   const std::string contextHash;
 
@@ -92,10 +97,12 @@ public:
       const std::string &compiledModulePath,
       const Optional<std::string> &swiftInterfaceFile,
       ArrayRef<StringRef> buildCommandLine,
+      ArrayRef<StringRef> extraPCMArgs,
       StringRef contextHash
   ) : ModuleDependenciesStorageBase(/*isSwiftModule=*/true, compiledModulePath),
       swiftInterfaceFile(swiftInterfaceFile),
       buildCommandLine(buildCommandLine.begin(), buildCommandLine.end()),
+      extraPCMArgs(extraPCMArgs.begin(), extraPCMArgs.end()),
       contextHash(contextHash) { }
 
   ModuleDependenciesStorageBase *clone() const override {
@@ -176,10 +183,12 @@ public:
       const std::string &compiledModulePath,
       const std::string &swiftInterfaceFile,
       ArrayRef<StringRef> buildCommands,
+      ArrayRef<StringRef> extraPCMArgs,
       StringRef contextHash) {
     return ModuleDependencies(
         std::make_unique<SwiftModuleDependenciesStorage>(
-          compiledModulePath, swiftInterfaceFile, buildCommands, contextHash));
+          compiledModulePath, swiftInterfaceFile, buildCommands,
+          extraPCMArgs, contextHash));
   }
 
   /// Describe the module dependencies for a serialized or parsed Swift module.
@@ -187,7 +196,18 @@ public:
       const std::string &compiledModulePath) {
     return ModuleDependencies(
         std::make_unique<SwiftModuleDependenciesStorage>(
-          compiledModulePath, None, ArrayRef<StringRef>(), StringRef()));
+          compiledModulePath, None, ArrayRef<StringRef>(),
+          ArrayRef<StringRef>(), StringRef()));
+  }
+
+  /// Describe the main Swift module.
+  static ModuleDependencies forMainSwiftModule(
+      const std::string &compiledModulePath,
+      ArrayRef<StringRef> extraPCMArgs) {
+    return ModuleDependencies(
+        std::make_unique<SwiftModuleDependenciesStorage>(
+          compiledModulePath, None, ArrayRef<StringRef>(), extraPCMArgs,
+          StringRef()));
   }
 
   /// Describe the module dependencies for a Clang module that can be

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -89,6 +89,7 @@ struct SubCompilerInstanceInfo {
   CompilerInstance* Instance;
   StringRef Hash;
   ArrayRef<StringRef> BuildArguments;
+  ArrayRef<StringRef> ExtraPCMArgs;
 };
 
 /// Abstract interface to run an action in a sub ASTContext.
@@ -97,7 +98,8 @@ struct InterfaceSubContextDelegate {
                                StringRef interfacePath,
                                StringRef outputPath,
                                SourceLoc diagLoc,
-  llvm::function_ref<bool(ASTContext&,ArrayRef<StringRef>, StringRef)> action) = 0;
+  llvm::function_ref<bool(ASTContext&,ArrayRef<StringRef>,
+                          ArrayRef<StringRef>, StringRef)> action) = 0;
   virtual bool runInSubCompilerInstance(StringRef moduleName,
                                         StringRef interfacePath,
                                         StringRef outputPath,

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -280,7 +280,8 @@ public:
                        StringRef interfacePath,
                        StringRef outputPath,
                        SourceLoc diagLoc,
-    llvm::function_ref<bool(ASTContext&, ArrayRef<StringRef>, StringRef)> action) override;
+    llvm::function_ref<bool(ASTContext&, ArrayRef<StringRef>,
+                            ArrayRef<StringRef>, StringRef)> action) override;
   bool runInSubCompilerInstance(StringRef moduleName,
                                 StringRef interfacePath,
                                 StringRef outputPath,

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -231,14 +231,19 @@ void ClangImporter::recordModuleDependencies(
     // Add all args inheritted from creating the importer.
     auto It = allArgs.begin();
     while(It != allArgs.end()) {
+      StringRef arg = *It;
       // Remove the -target arguments because we should use the target triple
       // from the depending Swift modules.
-      if (*It == "-target") {
+      if (arg == "-target") {
         It += 2;
-        continue;
+      } else if (arg.startswith("-fapinotes-swift-version=")) {
+        // Remove the apinotes version because we should use the language version
+        // specified in the interface file.
+        It += 1;
+      } else {
+        addClangArg(*It);
+        ++ It;
       }
-      addClangArg(*It);
-      ++ It;
     }
 
     // Swift frontend action: -emit-pcm

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -229,9 +229,18 @@ void ClangImporter::recordModuleDependencies(
       swiftArgs.push_back(arg.str());
     };
     // Add all args inheritted from creating the importer.
-    for (auto arg: allArgs) {
-      addClangArg(arg);
+    auto It = allArgs.begin();
+    while(It != allArgs.end()) {
+      // Remove the -target arguments because we should use the target triple
+      // from the depending Swift modules.
+      if (*It == "-target") {
+        It += 2;
+        continue;
+      }
+      addClangArg(*It);
+      ++ It;
     }
+
     // Swift frontend action: -emit-pcm
     swiftArgs.push_back("-emit-pcm");
     swiftArgs.push_back("-module-name");

--- a/lib/FrontendTool/ScanDependencies.cpp
+++ b/lib/FrontendTool/ScanDependencies.cpp
@@ -426,10 +426,15 @@ bool swift::scanDependencies(CompilerInstance &instance) {
   llvm::SmallString<32> mainModulePath = mainModule->getName().str();
   llvm::sys::path::replace_extension(mainModulePath, newExt);
 
+  std::string apinotesVer = (llvm::Twine("-fapinotes-swift-version=")
+    + instance.getASTContext().LangOpts.EffectiveLanguageVersion
+      .asAPINotesVersionString()).str();
   // Compute the dependencies of the main module.
   auto mainDependencies =
     ModuleDependencies::forMainSwiftModule(mainModulePath.str().str(), {
-      "-Xcc", "-target", "-Xcc", instance.getASTContext().LangOpts.Target.str()
+      // ExtraPCMArgs
+      "-Xcc", "-target", "-Xcc", instance.getASTContext().LangOpts.Target.str(),
+      "-Xcc", apinotesVer
     });
   {
     llvm::StringSet<> alreadyAddedModules;

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -108,10 +108,12 @@ ErrorOr<ModuleDependencies> ModuleDependencyScanner::scanInterfaceFile(
                                               moduleInterfacePath.str(),
                                               StringRef(),
                                               SourceLoc(),
-                [&](ASTContext &Ctx, ArrayRef<StringRef> Args, StringRef Hash) {
+                [&](ASTContext &Ctx, ArrayRef<StringRef> Args,
+                    ArrayRef<StringRef> PCMArgs, StringRef Hash) {
     Result = ModuleDependencies::forSwiftInterface(modulePath.str().str(),
                                                    moduleInterfacePath.str(),
                                                    Args,
+                                                   PCMArgs,
                                                    Hash);
     // Open the interface file.
     auto &fs = *Ctx.SourceMgr.getFileSystem();

--- a/test/ScanDependencies/Inputs/ModuleDependencyGraph.swift
+++ b/test/ScanDependencies/Inputs/ModuleDependencyGraph.swift
@@ -69,6 +69,11 @@ struct SwiftModuleDetails: Codable {
   /// The Swift command line arguments that need to be passed through
   /// to the -compile-module-from-interface action to build this module.
   var commandLine: [String]?
+
+  /// To build a PCM to be used by this Swift module, we need to append these
+  /// arguments to the generic PCM build arguments reported from the dependency
+  /// graph.
+  var extraPcmArgs: [String]?
 }
 
 /// Details specific to Clang modules.

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -83,6 +83,12 @@ import SubE
 // CHECK-NEXT: {
 // CHECK-NEXT:   "swift": "_cross_import_E"
 // CHECK-NEXT: }
+// CHECK-NEXT: ],
+
+// CHECK:      "extraPcmArgs": [
+// CHECK-NEXT:    "-Xcc",
+// CHECK-NEXT:    "-target",
+// CHECK-NEXT:    "-Xcc",
 
 // CHECK: "bridgingHeader":
 // CHECK-NEXT: "path":

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -66,6 +66,7 @@ import SubE
 // CHECK-NEXT:    "-Xcc",
 // CHECK-NEXT:    "-target",
 // CHECK-NEXT:    "-Xcc",
+// CHECK:         "-fapinotes-swift-version=4"
 
 // CHECK: "bridgingHeader":
 // CHECK-NEXT: "path":
@@ -134,7 +135,11 @@ import SubE
 // CHECK: "G"
 // CHECK: "-swift-version"
 // CHECK: "5"
-// CHECK: ]
+// CHECK: ],
+// CHECK" "extraPcmArgs": [
+// CHECK"   "-target",
+// CHECK"   "-fapinotes-swift-version=5"
+// CHECK" ]
 
 /// --------Swift module Swift
 // CHECK-LABEL: "modulePath": "Swift.swiftmodule",

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -17,29 +17,6 @@
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main %t/deps.json
 
-// RUN: mkdir -p %t/BuildModules
-// RUN: cp %S/Inputs/BuildModulesFromGraph.swift %t/BuildModules/main.swift
-// RUN: %target-build-swift %S/Inputs/ModuleDependencyGraph.swift %t/BuildModules/main.swift -o %t/ModuleBuilder
-// RUN: %target-codesign %t/ModuleBuilder
-
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path SwiftShims.pcm -o %t/clang-module-cache/SwiftShims.pcm | %S/Inputs/CommandRunner.py
-// RUN: ls %t/clang-module-cache/SwiftShims.pcm
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path A.pcm -o %t/clang-module-cache/A.pcm | %S/Inputs/CommandRunner.py
-// RUN: ls %t/clang-module-cache/A.pcm
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path B.pcm -o %t/clang-module-cache/B.pcm -Xcc -Xclang -Xcc -fmodule-map-file=%S/Inputs/CHeaders/module.modulemap -Xcc -Xclang -Xcc -fmodule-file=%t/clang-module-cache/A.pcm | %S/Inputs/CommandRunner.py
-// RUN: ls %t/clang-module-cache/B.pcm
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path C.pcm -o %t/clang-module-cache/C.pcm -Xcc -Xclang -Xcc -fmodule-map-file=%S/Inputs/CHeaders/module.modulemap -Xcc -Xclang -Xcc -fmodule-file=%t/clang-module-cache/B.pcm | %S/Inputs/CommandRunner.py
-// RUN: ls %t/clang-module-cache/C.pcm
-
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path A.swiftmodule -o %t/clang-module-cache/A.swiftmodule -Xcc -Xclang -Xcc -fmodule-map-file=%S/Inputs/CHeaders/module.modulemap -Xcc -Xclang -Xcc -fmodule-file=%t/clang-module-cache/A.pcm -Xcc -Xclang -Xcc -fmodule-file=%t/clang-module-cache/SwiftShims.pcm | %S/Inputs/CommandRunner.py
-// RUN: ls %t/clang-module-cache/A.swiftmodule
-
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path E.swiftmodule -o %t/clang-module-cache/E.swiftmodule -Xcc -Xclang -Xcc -fmodule-map-file=%S/Inputs/CHeaders/module.modulemap -Xcc -Xclang -Xcc -fmodule-file=%t/clang-module-cache/SwiftShims.pcm | %S/Inputs/CommandRunner.py
-// RUN: ls %t/clang-module-cache/E.swiftmodule
-
-// RUN: %target-run %t/ModuleBuilder %t/deps.json %swift-path SubE.swiftmodule -o %t/clang-module-cache/SubE.swiftmodule -Xcc -Xclang -Xcc -fmodule-map-file=%S/Inputs/CHeaders/module.modulemap -Xcc -Xclang -Xcc -fmodule-file=%t/clang-module-cache/SwiftShims.pcm -swift-module-file %t/clang-module-cache/E.swiftmodule | %S/Inputs/CommandRunner.py
-// RUN: ls %t/clang-module-cache/SubE.swiftmodule
-
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 


### PR DESCRIPTION
Building each Swift module explicitly requires dependency PCMs to be built
with the exactly same deployment target version. This means we may need to
build a Clang module multiple times with different target triples.

This patch removes the -target arguments from the reported PCM build
arguments and inserts extraPcmArgs fields to each Swift module.
swift-driver can combine the generic PCM arguments with these extra arguments
to get the command suitable for building a PCM specifically for
that loading Swift module.
