### PR TITLE
Hide SILDebugScope members, NFC

### DIFF
--- a/include/swift/SIL/SILDebugScope.h
+++ b/include/swift/SIL/SILDebugScope.h
@@ -40,10 +40,11 @@ class SILDebugScope : public SILAllocated<SILDebugScope> {
   /// The AST node this lexical scope represents.
   SILLocation Loc;
 
-public:
   /// Always points to the parent lexical scope.
   /// For top-level scopes, this is the SILFunction.
   PointerUnion<const SILDebugScope *, SILFunction *> Parent;
+
+public:
   /// An optional chain of inlined call sites.
   ///
   /// If this scope is inlined, this points to a special "scope" that
@@ -67,6 +68,16 @@ public:
   /// inlined this recursively returns the function it was inlined
   /// into.
   SILFunction *getParentFunction() const;
+
+  /// Return the parent function of this scope, if it has one.
+  SILFunction *getImmediateParentFunction() const {
+    return Parent.dyn_cast<SILFunction *>();
+  }
+
+  /// Return the parent debug scope of this scope, if it has one.
+  const SILDebugScope *getImmediateParentScope() const {
+    return Parent.dyn_cast<const SILDebugScope *>();
+  }
 
   void print(SourceManager &SM, llvm::raw_ostream &OS = llvm::errs(),
              unsigned Indent = 0) const;

--- a/include/swift/SIL/SILDebugScope.h
+++ b/include/swift/SIL/SILDebugScope.h
@@ -44,13 +44,13 @@ class SILDebugScope : public SILAllocated<SILDebugScope> {
   /// For top-level scopes, this is the SILFunction.
   PointerUnion<const SILDebugScope *, SILFunction *> Parent;
 
-public:
   /// An optional chain of inlined call sites.
   ///
   /// If this scope is inlined, this points to a special "scope" that
   /// holds the location of the call site.
   const SILDebugScope *InlinedCallSite;
 
+public:
   SILDebugScope(SILLocation Loc, SILFunction *SILFn,
                 const SILDebugScope *ParentScope = nullptr,
                 const SILDebugScope *InlinedCallSite = nullptr);
@@ -78,6 +78,10 @@ public:
   const SILDebugScope *getImmediateParentScope() const {
     return Parent.dyn_cast<const SILDebugScope *>();
   }
+
+  /// Return the special scope pointing to the inlined call which produced
+  /// this scope.
+  const SILDebugScope *getInlinedAt() const { return InlinedCallSite; }
 
   void print(SourceManager &SM, llvm::raw_ostream &OS = llvm::errs(),
              unsigned Indent = 0) const;

--- a/include/swift/SIL/SILDebugScope.h
+++ b/include/swift/SIL/SILDebugScope.h
@@ -37,9 +37,10 @@ class SILInstruction;
 /// the inlining information. In LLVM IR the inline info is part of
 /// DILocation.
 class SILDebugScope : public SILAllocated<SILDebugScope> {
-public:
   /// The AST node this lexical scope represents.
   SILLocation Loc;
+
+public:
   /// Always points to the parent lexical scope.
   /// For top-level scopes, this is the SILFunction.
   PointerUnion<const SILDebugScope *, SILFunction *> Parent;
@@ -56,6 +57,7 @@ public:
   /// Create a scope for an artificial function.
   SILDebugScope(SILLocation Loc);
 
+  /// Get the location for the scope.
   SILLocation getLoc() const { return Loc; }
 
   /// Return the function this scope originated from before being inlined.

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -744,19 +744,19 @@ public:
   /// FIXME: All functions should have locations, so this method should not be
   /// necessary.
   bool hasLocation() const {
-    return DebugScope && !DebugScope->Loc.isNull();
+    return DebugScope && !DebugScope->getLoc().isNull();
   }
 
   /// Get the source location of the function.
   SILLocation getLocation() const {
     assert(DebugScope && "no scope/location");
-    return getDebugScope()->Loc;
+    return getDebugScope()->getLoc();
   }
 
   /// Initialize the debug scope of the function and also set the DeclCtxt.
   void setDebugScope(const SILDebugScope *DS) {
     DebugScope = DS;
-    DeclCtxt = (DS ? DebugScope->Loc.getAsDeclContext() : nullptr);
+    DeclCtxt = (DS ? DebugScope->getLoc().getAsDeclContext() : nullptr);
   }
 
   /// Initialize the debug scope for debug info on SIL level (-gsil).

--- a/include/swift/SILOptimizer/Utils/GenericCloner.h
+++ b/include/swift/SILOptimizer/Utils/GenericCloner.h
@@ -54,7 +54,8 @@ public:
                 CloneCollector::CallbackType Callback)
     : SuperTy(*initCloned(FuncBuilder, F, ReInfo, NewName), *F,
 	      ParamSubs), FuncBuilder(FuncBuilder), ReInfo(ReInfo), Callback(Callback) {
-    assert(F->getDebugScope()->Parent != getCloned()->getDebugScope()->Parent);
+    assert(F->getDebugScope()->getImmediateParentFunction() !=
+           getCloned()->getDebugScope()->getImmediateParentFunction());
   }
   /// Clone and remap the types in \p F according to the substitution
   /// list in \p Subs. Parameters are re-abstracted (changed from indirect to

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -337,7 +337,7 @@ private:
   }
 
   llvm::MDNode *createInlinedAt(const SILDebugScope *DS) {
-    auto *CS = DS->InlinedCallSite;
+    auto *CS = DS->getInlinedAt();
     if (!CS)
       return nullptr;
 
@@ -362,8 +362,8 @@ private:
   static bool parentScopesAreSane(const SILDebugScope *DS) {
     auto *Parent = DS;
     while ((Parent = Parent->getImmediateParentScope())) {
-      if (!DS->InlinedCallSite)
-        assert(!Parent->InlinedCallSite &&
+      if (!DS->getInlinedAt())
+        assert(!Parent->getInlinedAt() &&
                "non-inlined scope has an inlined parent");
     }
     return true;
@@ -2000,9 +2000,9 @@ void IRGenDebugInfoImpl::setInlinedTrapLocation(IRBuilder &Builder,
   // thought it was owned by Function B. Therefore, we need to find the last
   // inlined scope to point to.
   const SILDebugScope *TheLastScope = LastScope;
-  while (TheLastScope->InlinedCallSite &&
-         TheLastScope->InlinedCallSite != TheLastScope) {
-    TheLastScope = TheLastScope->InlinedCallSite;
+  while (TheLastScope->getInlinedAt() &&
+         TheLastScope->getInlinedAt() != TheLastScope) {
+    TheLastScope = TheLastScope->getInlinedAt();
   }
   auto LastLocation = llvm::DebugLoc::get(
       LastDebugLoc.Line, LastDebugLoc.Column, getOrCreateScope(TheLastScope));

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3922,7 +3922,7 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
   if (isa<SILUndef>(SILVal)) {
     // We cannot track the location of inlined error arguments because it has no
     // representation in SIL.
-    if (!i->getDebugScope()->InlinedCallSite && VarInfo->Name == "$error") {
+    if (!i->getDebugScope()->getInlinedAt() && VarInfo->Name == "$error") {
       auto funcTy = CurSILFn->getLoweredFunctionType();
       emitErrorResultVar(funcTy, funcTy->getErrorResult(), i);
     }

--- a/lib/SIL/IR/SILBasicBlock.cpp
+++ b/lib/SIL/IR/SILBasicBlock.cpp
@@ -348,9 +348,9 @@ ScopeCloner::getOrCreateClonedScope(const SILDebugScope *OrigScope) {
 
   const SILDebugScope *ClonedInlinedCallSite = nullptr;
   const SILDebugScope *ClonedParent = nullptr;
-  if (OrigScope->InlinedCallSite) {
+  if (OrigScope->getInlinedAt()) {
     // For inlined functions, we need to rewrite the inlined call site.
-    ClonedInlinedCallSite = getOrCreateClonedScope(OrigScope->InlinedCallSite);
+    ClonedInlinedCallSite = getOrCreateClonedScope(OrigScope->getInlinedAt());
   } else {
     if (auto *ParentScope = OrigScope->getImmediateParentScope())
       ClonedParent = getOrCreateClonedScope(ParentScope);

--- a/lib/SIL/IR/SILConstants.cpp
+++ b/lib/SIL/IR/SILConstants.cpp
@@ -821,16 +821,16 @@ static SILDebugLocation skipInternalLocations(SILDebugLocation loc) {
   // the user's code, not in the guts we inlined through.
   for (; auto ics = ds->InlinedCallSite; ds = ics) {
     // If we found a valid inlined-into location, then we are good.
-    if (ds->Loc.getSourceLoc().isValid())
-      return SILDebugLocation(ds->Loc, ds);
+    if (ds->getLoc().getSourceLoc().isValid())
+      return SILDebugLocation(ds->getLoc(), ds);
     if (SILFunction *F = ds->getInlinedFunction()) {
       if (F->getLocation().getSourceLoc().isValid())
         break;
     }
   }
 
-  if (ds->Loc.getSourceLoc().isValid())
-    return SILDebugLocation(ds->Loc, ds);
+  if (ds->getLoc().getSourceLoc().isValid())
+    return SILDebugLocation(ds->getLoc(), ds);
 
   return loc;
 }

--- a/lib/SIL/IR/SILConstants.cpp
+++ b/lib/SIL/IR/SILConstants.cpp
@@ -819,7 +819,7 @@ static SILDebugLocation skipInternalLocations(SILDebugLocation loc) {
   // Zip through inlined call site information that came from the
   // implementation guts of the library.  We want to report the message inside
   // the user's code, not in the guts we inlined through.
-  for (; auto ics = ds->InlinedCallSite; ds = ics) {
+  for (; auto ics = ds->getInlinedAt(); ds = ics) {
     // If we found a valid inlined-into location, then we are good.
     if (ds->getLoc().getSourceLoc().isValid())
       return SILDebugLocation(ds->getLoc(), ds);

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -42,8 +42,8 @@ const SILDebugScope *SILInstruction::getDebugScope() const {
 }
 
 void SILInstruction::setDebugScope(const SILDebugScope *DS) {
-  if (getDebugScope() && getDebugScope()->InlinedCallSite)
-    assert(DS->InlinedCallSite && "throwing away inlined scope info");
+  if (getDebugScope() && getDebugScope()->getInlinedAt())
+    assert(DS->getInlinedAt() && "throwing away inlined scope info");
 
   assert(DS->getParentFunction() == getFunction() &&
          "scope belongs to different function");

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -842,16 +842,16 @@ public:
       return;
 
     if (!Ctx.hasScopeID(DS)) {
-      printDebugScope(DS->Parent.dyn_cast<const SILDebugScope *>(), SM);
+      printDebugScope(DS->getImmediateParentScope(), SM);
       printDebugScope(DS->InlinedCallSite, SM);
       unsigned ID = Ctx.assignScopeID(DS);
       *this << "sil_scope " << ID << " { ";
       printDebugLocRef(DS->getLoc(), SM, false);
       *this << " parent ";
-      if (auto *F = DS->Parent.dyn_cast<SILFunction *>())
+      if (auto *F = DS->getImmediateParentFunction())
         *this << "@" << F->getName() << " : $" << F->getLoweredFunctionType();
       else {
-        auto *PS = DS->Parent.get<const SILDebugScope *>();
+        auto *PS = DS->getImmediateParentScope();
         *this << Ctx.getScopeID(PS);
       }
       if (auto *CS = DS->InlinedCallSite)

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -843,7 +843,7 @@ public:
 
     if (!Ctx.hasScopeID(DS)) {
       printDebugScope(DS->getImmediateParentScope(), SM);
-      printDebugScope(DS->InlinedCallSite, SM);
+      printDebugScope(DS->getInlinedAt(), SM);
       unsigned ID = Ctx.assignScopeID(DS);
       *this << "sil_scope " << ID << " { ";
       printDebugLocRef(DS->getLoc(), SM, false);
@@ -854,7 +854,7 @@ public:
         auto *PS = DS->getImmediateParentScope();
         *this << Ctx.getScopeID(PS);
       }
-      if (auto *CS = DS->InlinedCallSite)
+      if (auto *CS = DS->getInlinedAt())
         *this << " inlined_at " << Ctx.getScopeID(CS);
       *this << " }\n";
     }
@@ -933,7 +933,7 @@ public:
 
     // Print inlined-at location, if any.
     const SILDebugScope *CS = DS;
-    while ((CS = CS->InlinedCallSite)) {
+    while ((CS = CS->getInlinedAt())) {
       *this << ": ";
       if (auto *InlinedF = CS->getInlinedFunction())
         *this << demangleSymbol(InlinedF->getName());

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -846,7 +846,7 @@ public:
       printDebugScope(DS->InlinedCallSite, SM);
       unsigned ID = Ctx.assignScopeID(DS);
       *this << "sil_scope " << ID << " { ";
-      printDebugLocRef(DS->Loc, SM, false);
+      printDebugLocRef(DS->getLoc(), SM, false);
       *this << " parent ";
       if (auto *F = DS->Parent.dyn_cast<SILFunction *>())
         *this << "@" << F->getName() << " : $" << F->getLoweredFunctionType();
@@ -940,7 +940,7 @@ public:
       else
         *this << '?';
       *this << " perf_inlined_at ";
-      auto CallSite = CS->Loc;
+      auto CallSite = CS->getLoc();
       if (!CallSite.isNull() && CallSite.isASTNode())
         CallSite.getSourceLoc().print(
             PrintState.OS, M.getASTContext().SourceMgr, LastBufferID);

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1124,7 +1124,7 @@ public:
     // for each argument slot. This catches SIL transformations
     // that accidentally remove inline information (stored in the SILDebugScope)
     // from debug-variable-carrying instructions.
-    if (!DS->InlinedCallSite) {
+    if (!DS->getInlinedAt()) {
       Optional<SILDebugVariable> VarInfo;
       if (auto *DI = dyn_cast<AllocStackInst>(I))
         VarInfo = DI->getVarInfo();

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -891,7 +891,7 @@ public:
 
     auto *DebugScope = F.getDebugScope();
     require(DebugScope, "All SIL functions must have a debug scope");
-    require(DebugScope->Parent.get<SILFunction *>() == &F,
+    require(DebugScope->getImmediateParentFunction() == &F,
             "Scope of SIL function points to different function");
   }
 
@@ -5142,9 +5142,7 @@ public:
         const SILDebugScope *Tmp = Previous;
         assert(Tmp && "scope can't be null");
         while (Tmp) {
-          PointerUnion<const SILDebugScope *, SILFunction *> Parent =
-              Tmp->Parent;
-          auto *ParentScope = Parent.dyn_cast<const SILDebugScope *>();
+          auto *ParentScope = Tmp->getImmediateParentScope();
           if (!ParentScope)
             break;
           if (ParentScope == Cur)

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -633,7 +633,8 @@ void ExistentialTransform::createExistentialSpecializedFunction() {
   /// Step 2: Create the thunk with always_inline and populate its body.
   populateThunkBody();
 
-  assert(F->getDebugScope()->Parent != NewF->getDebugScope()->Parent);
+  assert(F->getDebugScope()->getImmediateParentFunction() !=
+         NewF->getDebugScope()->getImmediateParentFunction());
 
   LLVM_DEBUG(llvm::dbgs() << "After ExistentialSpecializer Pass\n"; F->dump();
              NewF->dump(););

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -630,7 +630,8 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
   // Do the last bit work to finalize the thunk.
   OwnedToGuaranteedFinalizeThunkFunction(Builder, F);
 
-  assert(F->getDebugScope()->Parent != NewF->getDebugScope()->Parent);
+  assert(F->getDebugScope()->getImmediateParentFunction() !=
+         NewF->getDebugScope()->getImmediateParentFunction());
 }
 
 // Run the optimization.

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -320,7 +320,8 @@ ClosureCloner::ClosureCloner(SILOptFunctionBuilder &FuncBuilder,
           *initCloned(FuncBuilder, Orig, Serialized, ClonedName,
                       PromotableIndices, resilienceExpansion)),
       Orig(Orig), PromotableIndices(PromotableIndices) {
-  assert(Orig->getDebugScope()->Parent != getCloned()->getDebugScope()->Parent);
+  assert(Orig->getDebugScope()->getImmediateParentFunction() !=
+         getCloned()->getDebugScope()->getImmediateParentFunction());
 }
 
 /// Compute the SILParameterInfo list for the new cloned closure.

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -278,7 +278,8 @@ SILFunction *CapturePropagation::specializeConstClosure(PartialApplyInst *PAI,
   });
   CapturePropagationCloner cloner(OrigF, NewF, PAI->getSubstitutionMap());
   cloner.cloneClosure(PAI->getArguments());
-  assert(OrigF->getDebugScope()->Parent != NewF->getDebugScope()->Parent);
+  assert(OrigF->getDebugScope()->getImmediateParentFunction() !=
+         NewF->getDebugScope()->getImmediateParentFunction());
   return NewF;
 }
 

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -177,7 +177,7 @@ const SILDebugScope *GenericCloner::remapScope(const SILDebugScope *DS) {
     return it->second;
 
   auto &M = getBuilder().getModule();
-  auto *ParentFunction = DS->Parent.dyn_cast<SILFunction *>();
+  auto *ParentFunction = DS->getImmediateParentFunction();
   if (ParentFunction == &Original)
     ParentFunction = getCloned();
   else if (ParentFunction)
@@ -185,7 +185,7 @@ const SILDebugScope *GenericCloner::remapScope(const SILDebugScope *DS) {
         FuncBuilder, M, ParentFunction, SubsMap,
         Original.getLoweredFunctionType()->getInvocationGenericSignature());
 
-  auto *ParentScope = DS->Parent.dyn_cast<const SILDebugScope *>();
+  auto *ParentScope = DS->getImmediateParentScope();
   auto *RemappedScope = new (M)
       SILDebugScope(DS->getLoc(), ParentFunction, remapScope(ParentScope),
                     remapScope(DS->InlinedCallSite));

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -188,7 +188,7 @@ const SILDebugScope *GenericCloner::remapScope(const SILDebugScope *DS) {
   auto *ParentScope = DS->getImmediateParentScope();
   auto *RemappedScope = new (M)
       SILDebugScope(DS->getLoc(), ParentFunction, remapScope(ParentScope),
-                    remapScope(DS->InlinedCallSite));
+                    remapScope(DS->getInlinedAt()));
   RemappedScopeCache.insert({DS, RemappedScope});
   return RemappedScope;
 }

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -186,9 +186,9 @@ const SILDebugScope *GenericCloner::remapScope(const SILDebugScope *DS) {
         Original.getLoweredFunctionType()->getInvocationGenericSignature());
 
   auto *ParentScope = DS->Parent.dyn_cast<const SILDebugScope *>();
-  auto *RemappedScope =
-      new (M) SILDebugScope(DS->Loc, ParentFunction, remapScope(ParentScope),
-                            remapScope(DS->InlinedCallSite));
+  auto *RemappedScope = new (M)
+      SILDebugScope(DS->getLoc(), ParentFunction, remapScope(ParentScope),
+                    remapScope(DS->InlinedCallSite));
   RemappedScopeCache.insert({DS, RemappedScope});
   return RemappedScope;
 }

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -411,7 +411,7 @@ SILInlineCloner::SILInlineCloner(
     // Performance inlining. Construct a proper inline scope pointing
     // back to the call site.
     CallSiteScope = new (F.getModule()) SILDebugScope(
-        apply.getLoc(), nullptr, applyScope, applyScope->InlinedCallSite);
+        apply.getLoc(), nullptr, applyScope, applyScope->getInlinedAt());
   }
   assert(CallSiteScope && "call site has no scope");
   assert(CallSiteScope->getParentFunction() == &F);
@@ -631,8 +631,7 @@ SILInlineCloner::getOrCreateInlineScope(const SILDebugScope *CalleeScope) {
     return it->second;
 
   auto &M = getBuilder().getModule();
-  auto InlinedAt =
-      getOrCreateInlineScope(CalleeScope->InlinedCallSite);
+  auto InlinedAt = getOrCreateInlineScope(CalleeScope->getInlinedAt());
 
   auto *ParentFunction = CalleeScope->getImmediateParentFunction();
   if (ParentFunction)

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -634,7 +634,7 @@ SILInlineCloner::getOrCreateInlineScope(const SILDebugScope *CalleeScope) {
   auto InlinedAt =
       getOrCreateInlineScope(CalleeScope->InlinedCallSite);
 
-  auto *ParentFunction = CalleeScope->Parent.dyn_cast<SILFunction *>();
+  auto *ParentFunction = CalleeScope->getImmediateParentFunction();
   if (ParentFunction)
     ParentFunction = remapParentFunction(
         FuncBuilder, M, ParentFunction, SubsMap,
@@ -642,7 +642,7 @@ SILInlineCloner::getOrCreateInlineScope(const SILDebugScope *CalleeScope) {
                            ->getInvocationGenericSignature(),
         ForInlining);
 
-  auto *ParentScope = CalleeScope->Parent.dyn_cast<const SILDebugScope *>();
+  auto *ParentScope = CalleeScope->getImmediateParentScope();
   auto *InlinedScope = new (M) SILDebugScope(
       CalleeScope->getLoc(), ParentFunction,
       ParentScope ? getOrCreateInlineScope(ParentScope) : nullptr, InlinedAt);

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -644,7 +644,7 @@ SILInlineCloner::getOrCreateInlineScope(const SILDebugScope *CalleeScope) {
 
   auto *ParentScope = CalleeScope->Parent.dyn_cast<const SILDebugScope *>();
   auto *InlinedScope = new (M) SILDebugScope(
-      CalleeScope->Loc, ParentFunction,
+      CalleeScope->getLoc(), ParentFunction,
       ParentScope ? getOrCreateInlineScope(ParentScope) : nullptr, InlinedAt);
   InlinedScopeCache.insert({CalleeScope, InlinedScope});
   return InlinedScope;


### PR DESCRIPTION
Hide the members of SILDebugScope for better data encapsulation.