### PR TITLE
[test] Mark XFAIL tests for OpenBSD.

### DIFF
--- a/test/ClangImporter/availability_returns_twice.swift
+++ b/test/ClangImporter/availability_returns_twice.swift
@@ -3,6 +3,7 @@
 // In Android jmp_buf is int[16], which doesn't convert to &Int (SR-9136)
 // XFAIL: OS=linux-androideabi
 // XFAIL: OS=linux-android
+// XFAIL: OS=openbsd
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin

--- a/test/Driver/Dependencies/only-skip-once.swift
+++ b/test/Driver/Dependencies/only-skip-once.swift
@@ -1,4 +1,4 @@
-// XFAIL: linux
+// XFAIL: linux, openbsd
 
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/only-skip-once/* %t

--- a/test/Driver/PrivateDependencies/only-skip-once.swift
+++ b/test/Driver/PrivateDependencies/only-skip-once.swift
@@ -1,4 +1,4 @@
-// XFAIL: linux
+// XFAIL: linux, openbsd
 
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/only-skip-once/* %t

--- a/test/Driver/parseable_output.swift
+++ b/test/Driver/parseable_output.swift
@@ -1,6 +1,6 @@
 // RUN: %swiftc_driver_plain -emit-executable %s -o %t.out -emit-module -emit-module-path %t.swiftmodule -emit-objc-header-path %t.h -serialize-diagnostics -emit-dependencies -parseable-output -driver-skip-execution 2>&1 | %FileCheck %s
 
-// XFAIL: freebsd, linux
+// XFAIL: freebsd, openbsd, linux
 
 // CHECK: {{[1-9][0-9]*}}
 // CHECK-NEXT: {

--- a/test/Driver/parseable_output_unicode.swift
+++ b/test/Driver/parseable_output_unicode.swift
@@ -2,7 +2,7 @@
 // RUN: cat "%S/Inputs/unicode.txt" >> %t.rsp
 // RUN: %swiftc_driver_plain -emit-executable @%t.rsp -o %t.out -emit-module -emit-module-path %t.swiftmodule -emit-objc-header-path %t.h -serialize-diagnostics -emit-dependencies -parseable-output -driver-skip-execution 2>&1 | %FileCheck %s
 
-// XFAIL: freebsd, linux
+// XFAIL: freebsd, openbsd, linux
 
 // CHECK: {{[1-9][0-9]*}}
 // CHECK-NEXT: {

--- a/test/Driver/sdk-apple.swift
+++ b/test/Driver/sdk-apple.swift
@@ -1,4 +1,4 @@
-// XFAIL: freebsd, linux, windows
+// XFAIL: freebsd, openbsd, linux, windows
 
 // Test SDK detection for immediate mode.
 // RUN: %empty-directory(%t)

--- a/test/Frontend/embed-bitcode.swift
+++ b/test/Frontend/embed-bitcode.swift
@@ -8,6 +8,7 @@
 // UNSUPPORTED: OS=linux-gnu
 // UNSUPPORTED: OS=linux-gnueabihf
 // UNSUPPORTED: OS=freebsd
+// UNSUPPORTED: OS=openbsd
 // UNSUPPORTED: OS=windows-msvc
 
 // MARKER: Contents of (__LLVM,__bitcode) section

--- a/test/IRGen/abitypes.swift
+++ b/test/IRGen/abitypes.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/abi %s -emit-ir -enable-objc-interop | %FileCheck -check-prefix=%target-cpu-%target-os %s
 
 // FIXME: rdar://problem/19648117 Needs splitting objc parts out
-// XFAIL: linux, windows
+// XFAIL: linux, windows, openbsd
 
 import gadget
 import Foundation

--- a/test/IRGen/address_sanitizer_recover.swift
+++ b/test/IRGen/address_sanitizer_recover.swift
@@ -1,3 +1,4 @@
+// REQUIRES: asan_runtime
 // RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-recover=address %s | %FileCheck %s -check-prefix=ASAN_RECOVER
 // RUN: %target-swift-frontend -emit-ir -sanitize=address  %s | %FileCheck %s -check-prefix=ASAN_NO_RECOVER
 // RUN: %target-swift-frontend -emit-ir -sanitize-recover=address %s | %FileCheck %s -check-prefix=NO_ASAN_RECOVER

--- a/test/IRGen/asan-attributes.swift
+++ b/test/IRGen/asan-attributes.swift
@@ -1,3 +1,4 @@
+// REQUIRES: asan_runtime
 // This test verifies that we add the function attributes used by ASan.
 
 // RUN: %target-swift-frontend -emit-ir -sanitize=address %s | %FileCheck %s -check-prefix=ASAN

--- a/test/IRGen/module_hash.swift
+++ b/test/IRGen/module_hash.swift
@@ -1,3 +1,4 @@
+// REQUIRES: fuzzer_runtime
 // RUN: %empty-directory(%t)
 
 

--- a/test/IRGen/sanitize_coverage.swift
+++ b/test/IRGen/sanitize_coverage.swift
@@ -1,3 +1,4 @@
+// REQUIRES: asan_runtime
 // RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=func %s | %FileCheck %s -check-prefix=SANCOV
 // RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=bb %s | %FileCheck %s -check-prefix=SANCOV
 // RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=edge %s | %FileCheck %s -check-prefix=SANCOV
@@ -10,7 +11,7 @@
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
   import Glibc
 #elseif os(Windows)
   import MSVCRT

--- a/test/IRGen/tsan-attributes.swift
+++ b/test/IRGen/tsan-attributes.swift
@@ -1,3 +1,4 @@
+// REQUIRES: tsan_runtime
 // This test verifies that we add the function attributes used by TSan.
 
 // RUN: %target-swift-frontend -emit-ir -sanitize=thread %s | %FileCheck %s -check-prefix=TSAN

--- a/test/IRGen/tsan_coroutines.swift
+++ b/test/IRGen/tsan_coroutines.swift
@@ -1,3 +1,4 @@
+// REQUIRES: tsan_runtime
 // This test case used to crash when tsan ran before co-routine lowering.
 // RUN: %target-swift-frontend -emit-ir -sanitize=thread %s | %FileCheck %s
 

--- a/test/Profiler/instrprof_tsan.swift
+++ b/test/Profiler/instrprof_tsan.swift
@@ -1,3 +1,4 @@
+// REQUIRES: tsan_runtime
 // RUN: %target-swift-frontend -emit-ir -profile-generate -sanitize=thread %s | %FileCheck %s
 
 // TSan is only supported on 64 bit.

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -200,7 +200,7 @@ import Darwin
 import Dispatch
 
 // FIXME: port to Linux.
-// XFAIL: linux, windows
+// XFAIL: linux, windows, openbsd
 
 // A wrapper for pthread_t with platform-independent interface.
 public struct _stdlib_pthread_t : Equatable, Hashable {

--- a/test/SILGen/tsan_instrumentation.swift
+++ b/test/SILGen/tsan_instrumentation.swift
@@ -1,3 +1,4 @@
+// REQUIRES: tsan_runtime
 // RUN: %target-swift-emit-silgen -sanitize=thread %s | %FileCheck %s
 
 // TSan is only supported on 64 bit.

--- a/test/stdlib/simd.swift.gyb
+++ b/test/stdlib/simd.swift.gyb
@@ -2,7 +2,7 @@
 // REQUIRES: executable_test
 
 // FIXME: No simd module on linux rdar://problem/20795411
-// XFAIL: linux, windows
+// XFAIL: linux, windows, openbsd
 
 import simd
 import StdlibUnittest

--- a/test/stdlib/simd_diagnostics.swift
+++ b/test/stdlib/simd_diagnostics.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // FIXME: No simd module on linux rdar://problem/20795411
-// XFAIL: linux, windows
+// XFAIL: linux, windows, openbsd
 
 import simd
 


### PR DESCRIPTION
These tests are marked XFAIL or UNSUPPORTED because either the tests:
require libc annotation, require Mach-O support, don't recognize calls to
swift-autolink-extract, requires porting alongside Linux, or rely on simd
which is not present.

Additionally, explicit REQUIRES for tsan/asan/fuzzer are added to some
tests, since OpenBSD does not support these sanitizers or fuzzers, since
it's nicer to mark that with REQUIRES rather than XFAIL.