### PR TITLE
Strip Attributes of their TypeLocs

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1125,7 +1125,7 @@ class TypeEraserAttr final : public DeclAttribute {
 public:
   static TypeEraserAttr *create(ASTContext &ctx,
                                 SourceLoc atLoc, SourceRange range,
-                                TypeLoc typeEraserLoc);
+                                TypeRepr *typeEraserRepr);
 
   static TypeEraserAttr *create(ASTContext &ctx,
                                 LazyMemberLoader *Resolver,
@@ -1628,8 +1628,8 @@ public:
   unsigned getNumArguments() const { return numArgLabels; }
   bool hasArgumentLabelLocs() const { return hasArgLabelLocs; }
 
-  TypeLoc &getTypeLoc() { return type; }
-  const TypeLoc &getTypeLoc() const { return type; }
+  TypeRepr *getTypeRepr() const { return type.getTypeRepr(); }
+  Type getType() const { return type.getType(); }
 
   Expr *getArg() const { return arg; }
   void setArg(Expr *newArg) { arg = newArg; }
@@ -1642,6 +1642,14 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DAK_Custom;
   }
+
+private:
+  friend class CustomAttrNominalRequest;
+  void resetTypeInformation(TypeRepr *repr) { type = TypeLoc(repr); }
+
+private:
+  friend class CustomAttrTypeRequest;
+  void setType(Type ty) { type = TypeLoc(getTypeRepr(), ty); }
 };
 
 /// Relates a property to its projection value property, as described by a property wrapper. For

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -36,7 +36,6 @@
 #include "swift/AST/PlatformKind.h"
 #include "swift/AST/Requirement.h"
 #include "swift/AST/TrailingCallArguments.h"
-#include "swift/AST/TypeLoc.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -1111,22 +1110,22 @@ public:
 
 /// The \c @_typeEraser(TypeEraserType) attribute.
 class TypeEraserAttr final : public DeclAttribute {
-  TypeLoc TypeEraserLoc;
+  TypeExpr *TypeEraserExpr;
   LazyMemberLoader *Resolver;
   uint64_t ResolverContextData;
 
   friend class ResolveTypeEraserTypeRequest;
 
-  TypeEraserAttr(SourceLoc atLoc, SourceRange range, TypeLoc typeEraserLoc,
+  TypeEraserAttr(SourceLoc atLoc, SourceRange range, TypeExpr *typeEraserExpr,
                  LazyMemberLoader *Resolver, uint64_t Data)
       : DeclAttribute(DAK_TypeEraser, atLoc, range, /*Implicit=*/false),
-        TypeEraserLoc(typeEraserLoc),
+        TypeEraserExpr(typeEraserExpr),
         Resolver(Resolver), ResolverContextData(Data) {}
 
 public:
   static TypeEraserAttr *create(ASTContext &ctx,
                                 SourceLoc atLoc, SourceRange range,
-                                TypeRepr *typeEraserRepr);
+                                TypeExpr *typeEraserRepr);
 
   static TypeEraserAttr *create(ASTContext &ctx,
                                 LazyMemberLoader *Resolver,
@@ -1134,14 +1133,10 @@ public:
 
   /// Retrieve the parsed type repr for this attribute, if it
   /// was parsed. Else returns \c nullptr.
-  TypeRepr *getParsedTypeEraserTypeRepr() const {
-    return TypeEraserLoc.getTypeRepr();
-  }
+  TypeRepr *getParsedTypeEraserTypeRepr() const;
 
   /// Retrieve the parsed location for this attribute, if it was parsed.
-  SourceLoc getLoc() const {
-    return TypeEraserLoc.getLoc();
-  }
+  SourceLoc getLoc() const;
 
   /// Retrieve the resolved type of this attribute if it has been resolved by a
   /// successful call to \c getResolvedType(). Otherwise,
@@ -1149,9 +1144,7 @@ public:
   ///
   /// This entrypoint is only suitable for syntactic clients like the
   /// AST printer. Semantic clients should use \c getResolvedType() instead.
-  Type getTypeWithoutResolving() const {
-    return TypeEraserLoc.getType();
-  }
+  Type getTypeWithoutResolving() const;
 
   /// Returns \c true if the type eraser type has a valid implementation of the
   /// erasing initializer for the given protocol.
@@ -1597,7 +1590,7 @@ public:
 /// Defines a custom attribute.
 class CustomAttr final : public DeclAttribute,
                          public TrailingCallArguments<CustomAttr> {
-  TypeLoc type;
+  TypeExpr *typeExpr;
   Expr *arg;
   PatternBindingInitializer *initContext;
   Expr *semanticInit = nullptr;
@@ -1605,19 +1598,19 @@ class CustomAttr final : public DeclAttribute,
   unsigned hasArgLabelLocs : 1;
   unsigned numArgLabels : 16;
 
-  CustomAttr(SourceLoc atLoc, SourceRange range, TypeLoc type,
+  CustomAttr(SourceLoc atLoc, SourceRange range, TypeExpr *type,
              PatternBindingInitializer *initContext, Expr *arg,
              ArrayRef<Identifier> argLabels, ArrayRef<SourceLoc> argLabelLocs,
              bool implicit);
 
 public:
-  static CustomAttr *create(ASTContext &ctx, SourceLoc atLoc, TypeLoc type,
+  static CustomAttr *create(ASTContext &ctx, SourceLoc atLoc, TypeExpr *type,
                             bool implicit = false) {
     return create(ctx, atLoc, type, false, nullptr, SourceLoc(), { }, { }, { },
                   SourceLoc(), implicit);
   }
 
-  static CustomAttr *create(ASTContext &ctx, SourceLoc atLoc, TypeLoc type,
+  static CustomAttr *create(ASTContext &ctx, SourceLoc atLoc, TypeExpr *type,
                             bool hasInitializer,
                             PatternBindingInitializer *initContext,
                             SourceLoc lParenLoc,
@@ -1630,8 +1623,8 @@ public:
   unsigned getNumArguments() const { return numArgLabels; }
   bool hasArgumentLabelLocs() const { return hasArgLabelLocs; }
 
-  TypeRepr *getTypeRepr() const { return type.getTypeRepr(); }
-  Type getType() const { return type.getType(); }
+  TypeRepr *getTypeRepr() const;
+  Type getType() const;
 
   Expr *getArg() const { return arg; }
   void setArg(Expr *newArg) { arg = newArg; }
@@ -1647,11 +1640,11 @@ public:
 
 private:
   friend class CustomAttrNominalRequest;
-  void resetTypeInformation(TypeRepr *repr) { type = TypeLoc(repr); }
+  void resetTypeInformation(TypeExpr *repr);
 
 private:
   friend class CustomAttrTypeRequest;
-  void setType(Type ty) { type = TypeLoc(getTypeRepr(), ty); }
+  void setType(Type ty);
 };
 
 /// Relates a property to its projection value property, as described by a property wrapper. For

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -56,6 +56,7 @@ class LazyConformanceLoader;
 class LazyMemberLoader;
 class PatternBindingInitializer;
 class TrailingWhereClause;
+class TypeExpr;
 
 /// TypeAttributes - These are attributes that may be applied to types.
 class TypeAttributes {
@@ -1464,25 +1465,26 @@ public:
 /// The @_implements attribute, which treats a decl as the implementation for
 /// some named protocol requirement (but otherwise not-visible by that name).
 class ImplementsAttr : public DeclAttribute {
-
-  TypeLoc ProtocolType;
+  TypeExpr *ProtocolType;
   DeclName MemberName;
   DeclNameLoc MemberNameLoc;
 
 public:
   ImplementsAttr(SourceLoc atLoc, SourceRange Range,
-                 TypeLoc ProtocolType,
+                 TypeExpr *ProtocolType,
                  DeclName MemberName,
                  DeclNameLoc MemberNameLoc);
 
   static ImplementsAttr *create(ASTContext &Ctx, SourceLoc atLoc,
                                 SourceRange Range,
-                                TypeLoc ProtocolType,
+                                TypeExpr *ProtocolType,
                                 DeclName MemberName,
                                 DeclNameLoc MemberNameLoc);
 
-  TypeLoc getProtocolType() const;
-  TypeLoc &getProtocolType();
+  void setProtocolType(Type ty);
+  Type getProtocolType() const;
+  TypeRepr *getProtocolTypeRepr() const;
+
   DeclName getMemberName() const { return MemberName; }
   DeclNameLoc getMemberNameLoc() const { return MemberNameLoc; }
 

--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -18,7 +18,6 @@
 #define SWIFT_AST_LAZYRESOLVER_H
 
 #include "swift/AST/ProtocolConformanceRef.h"
-#include "swift/AST/TypeLoc.h"
 #include "llvm/ADT/PointerEmbeddedInt.h"
 
 namespace swift {

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2513,6 +2513,41 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Kinds of types for CustomAttr.
+enum class CustomAttrTypeKind {
+  /// The type is required to not be expressed in terms of
+  /// any contextual type parameters.
+  NonGeneric,
+
+  /// Property delegates have some funky rules, like allowing
+  /// unbound generic types.
+  PropertyDelegate,
+};
+
+void simple_display(llvm::raw_ostream &out, CustomAttrTypeKind value);
+
+class CustomAttrTypeRequest
+    : public SimpleRequest<CustomAttrTypeRequest,
+                           Type(CustomAttr *, DeclContext *,
+                                CustomAttrTypeKind),
+                           RequestFlags::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  Type evaluate(Evaluator &evaluator, CustomAttr *, DeclContext *,
+                CustomAttrTypeKind) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+  Optional<Type> getCachedResult() const;
+  void cacheResult(Type value) const;
+};
+
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.
 template<>

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -41,6 +41,9 @@ SWIFT_REQUEST(TypeChecker, CodeCompletionFileRequest,
 SWIFT_REQUEST(TypeChecker, CompareDeclSpecializationRequest,
               bool (DeclContext *, ValueDecl *, ValueDecl *, bool), Cached,
               NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, CustomAttrTypeRequest,
+              Type(CustomAttr *, DeclContext *, CustomAttrTypeKind),
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultArgumentExprRequest,
               Expr *(ParamDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultArgumentInitContextRequest,

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -247,9 +247,6 @@ FRONTEND_STATISTIC(Sema, NamedLazyMemberLoadSuccessCount)
 /// Number of types deserialized.
 FRONTEND_STATISTIC(Sema, NumTypesDeserialized)
 
-/// Number of types validated.
-FRONTEND_STATISTIC(Sema, NumTypesValidated)
-
 /// Number of lazy iterable declaration contexts left unloaded.
 FRONTEND_STATISTIC(Sema, NumUnloadedLazyIterableDeclContexts)
 

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -99,9 +99,9 @@ AttachedPropertyWrapperScope::getSourceRangeOfVarDecl(const VarDecl *const vd) {
   SourceRange sr;
   for (auto *attr : vd->getAttrs().getAttributes<CustomAttr>()) {
     if (sr.isInvalid())
-      sr = attr->getTypeLoc().getSourceRange();
+      sr = attr->getTypeRepr()->getSourceRange();
     else
-      sr.widen(attr->getTypeLoc().getSourceRange());
+      sr.widen(attr->getTypeRepr()->getSourceRange());
   }
   return sr;
 }

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -975,7 +975,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     Printer.printAttrName("@_implements");
     Printer << "(";
     auto *attr = cast<ImplementsAttr>(this);
-    attr->getProtocolType().getType().print(Printer, Options);
+    attr->getProtocolType().print(Printer, Options);
     Printer << ", " << attr->getMemberName() << ")";
     break;
   }
@@ -1814,7 +1814,7 @@ TransposeAttr *TransposeAttr::create(ASTContext &context, bool implicit,
 }
 
 ImplementsAttr::ImplementsAttr(SourceLoc atLoc, SourceRange range,
-                               TypeLoc ProtocolType,
+                               TypeExpr *ProtocolType,
                                DeclName MemberName,
                                DeclNameLoc MemberNameLoc)
     : DeclAttribute(DAK_Implements, atLoc, range, /*Implicit=*/false),
@@ -1826,7 +1826,7 @@ ImplementsAttr::ImplementsAttr(SourceLoc atLoc, SourceRange range,
 
 ImplementsAttr *ImplementsAttr::create(ASTContext &Ctx, SourceLoc atLoc,
                                        SourceRange range,
-                                       TypeLoc ProtocolType,
+                                       TypeExpr *ProtocolType,
                                        DeclName MemberName,
                                        DeclNameLoc MemberNameLoc) {
   void *mem = Ctx.Allocate(sizeof(ImplementsAttr), alignof(ImplementsAttr));
@@ -1834,12 +1834,17 @@ ImplementsAttr *ImplementsAttr::create(ASTContext &Ctx, SourceLoc atLoc,
                                   MemberName, MemberNameLoc);
 }
 
-TypeLoc ImplementsAttr::getProtocolType() const {
-  return ProtocolType;
+void ImplementsAttr::setProtocolType(Type ty) {
+  assert(ty);
+  ProtocolType->setType(MetatypeType::get(ty));
 }
 
-TypeLoc &ImplementsAttr::getProtocolType() {
-  return ProtocolType;
+Type ImplementsAttr::getProtocolType() const {
+  return ProtocolType->getInstanceType();
+}
+
+TypeRepr *ImplementsAttr::getProtocolTypeRepr() const {
+  return ProtocolType->getTypeRepr();
 }
 
 CustomAttr::CustomAttr(SourceLoc atLoc, SourceRange range, TypeLoc type,

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1022,11 +1022,11 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
   case DAK_Custom: {
     Printer.callPrintNamePre(PrintNameContext::Attribute);
     Printer << "@";
-    const TypeLoc &typeLoc = cast<CustomAttr>(this)->getTypeLoc();
-    if (auto type = typeLoc.getType())
-      type->print(Printer, Options);
+    auto *attr = cast<CustomAttr>(this);
+    if (auto type = attr->getType())
+      type.print(Printer, Options);
     else
-      typeLoc.getTypeRepr()->print(Printer, Options);
+      attr->getTypeRepr()->print(Printer, Options);
     Printer.printNamePost(PrintNameContext::Attribute);
     break;
   }
@@ -1386,8 +1386,8 @@ SourceLoc DynamicReplacementAttr::getRParenLoc() const {
 
 TypeEraserAttr *TypeEraserAttr::create(ASTContext &ctx,
                                        SourceLoc atLoc, SourceRange range,
-                                       TypeLoc typeEraserLoc) {
-  return new (ctx) TypeEraserAttr(atLoc, range, typeEraserLoc, nullptr, 0);
+                                       TypeRepr *typeEraserRepr) {
+  return new (ctx) TypeEraserAttr(atLoc, range, typeEraserRepr, nullptr, 0);
 }
 
 TypeEraserAttr *TypeEraserAttr::create(ASTContext &ctx,

--- a/lib/AST/ConformanceLookupTable.h
+++ b/lib/AST/ConformanceLookupTable.h
@@ -21,7 +21,6 @@
 #define SWIFT_AST_CONFORMANCE_LOOKUP_TABLE_H
 
 #include "swift/AST/DeclContext.h"
-#include "swift/AST/TypeLoc.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/SourceLoc.h"

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6515,7 +6515,7 @@ ParamDecl::getDefaultValueStringRepresentation(
       if (wrapperAttrs.size() > 0) {
         auto attr = wrapperAttrs.front();
         if (auto arg = attr->getArg()) {
-          SourceRange fullRange(attr->getTypeLoc().getSourceRange().Start,
+          SourceRange fullRange(attr->getTypeRepr()->getSourceRange().Start,
                                 arg->getEndLoc());
           auto charRange = Lexer::getCharSourceRangeFromSourceRange(
               getASTContext().SourceMgr, fullRange);

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2347,7 +2347,8 @@ CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
               identTypeRepr
             };
 
-            attr->resetTypeInformation(IdentTypeRepr::create(ctx, components));
+            auto *newTE = new (ctx) TypeExpr(IdentTypeRepr::create(ctx, components));
+            attr->resetTypeInformation(newTE);
             return nominal;
           }
         }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2296,12 +2296,11 @@ CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
                                    CustomAttr *attr, DeclContext *dc) const {
   // Find the types referenced by the custom attribute.
   auto &ctx = dc->getASTContext();
-  TypeLoc &typeLoc = attr->getTypeLoc();
   DirectlyReferencedTypeDecls decls;
-  if (auto typeRepr = typeLoc.getTypeRepr()) {
+  if (auto *typeRepr = attr->getTypeRepr()) {
     decls = directReferencesForTypeRepr(
         evaluator, ctx, typeRepr, dc);
-  } else if (Type type = typeLoc.getType()) {
+  } else if (Type type = attr->getType()) {
     decls = directReferencesForType(type);
   }
 
@@ -2316,7 +2315,7 @@ CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
   // If we found declarations that are associated types, look outside of
   // the current context to see if we can recover.
   if (declsAreAssociatedTypes(decls)) {
-    if (auto typeRepr = typeLoc.getTypeRepr()) {
+    if (auto typeRepr = attr->getTypeRepr()) {
       if (auto identTypeRepr = dyn_cast<SimpleIdentTypeRepr>(typeRepr)) {
         auto assocType = cast<AssociatedTypeDecl>(decls.front());
 
@@ -2348,7 +2347,7 @@ CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
               identTypeRepr
             };
 
-            typeLoc = TypeLoc(IdentTypeRepr::create(ctx, components));
+            attr->resetTypeInformation(IdentTypeRepr::create(ctx, components));
             return nominal;
           }
         }

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1498,3 +1498,33 @@ SourceLoc swift::extractNearestSourceLoc(const TypeRepr *repr) {
     return SourceLoc();
   return repr->getLoc();
 }
+
+//----------------------------------------------------------------------------//
+// CustomAttrTypeRequest computation.
+//----------------------------------------------------------------------------//
+
+void swift::simple_display(llvm::raw_ostream &out, CustomAttrTypeKind value) {
+  switch (value) {
+  case CustomAttrTypeKind::NonGeneric:
+    out << "non-generic";
+    return;
+
+  case CustomAttrTypeKind::PropertyDelegate:
+    out << "property-delegate";
+    return;
+  }
+  llvm_unreachable("bad kind");
+}
+
+Optional<Type> CustomAttrTypeRequest::getCachedResult() const {
+  auto *attr = std::get<0>(getStorage());
+  if (auto ty = attr->getType()) {
+    return ty;
+  }
+  return None;
+}
+
+void CustomAttrTypeRequest::cacheResult(Type value) const {
+  auto *attr = std::get<0>(getStorage());
+  attr->setType(value);
+}

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -446,7 +446,7 @@ private:
       }
     }
     for (auto *customAttr : D->getAttrs().getAttributes<CustomAttr, true>()) {
-      if (auto *Repr = customAttr->getTypeLoc().getTypeRepr()) {
+      if (auto *Repr = customAttr->getTypeRepr()) {
         if (!Repr->walk(*this))
           return false;
       }
@@ -1260,7 +1260,7 @@ private:
       }
     }
     for (auto *customAttr : D->getAttrs().getAttributes<CustomAttr, true>()) {
-      if (auto *Repr = customAttr->getTypeLoc().getTypeRepr()) {
+      if (auto *Repr = customAttr->getTypeRepr()) {
         if (!Repr->walk(*this))
           return false;
       }

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -598,7 +598,7 @@ bool SemaAnnotator::handleCustomAttributes(Decl *D) {
     }
   }
   for (auto *customAttr : D->getAttrs().getAttributes<CustomAttr, true>()) {
-    if (auto *Repr = customAttr->getTypeLoc().getTypeRepr()) {
+    if (auto *Repr = customAttr->getTypeRepr()) {
       if (!Repr->walk(*this))
         return false;
     }

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -177,7 +177,7 @@ bool NameMatcher::handleCustomAttrs(Decl *D) {
     if (shouldSkip(customAttr->getRangeWithAt()))
       continue;
     auto *Arg = customAttr->getArg();
-    if (auto *Repr = customAttr->getTypeLoc().getTypeRepr()) {
+    if (auto *Repr = customAttr->getTypeRepr()) {
       // Note the associated call arguments of the semantic initializer call
       // in case we're resolving an explicit initializer call within the
       // CustomAttr's type, e.g. on `Wrapper` in `@Wrapper(wrappedValue: 10)`.

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -1199,7 +1199,7 @@ bool ModelASTWalker::handleSpecialDeclAttribute(const DeclAttribute *D,
                              ExcludeNodeAtLocation).shouldContinue)
       return false;
     if (auto *CA = dyn_cast<CustomAttr>(D)) {
-      if (auto *Repr = CA->getTypeLoc().getTypeRepr()) {
+      if (auto *Repr = CA->getTypeRepr()) {
         if (!Repr->walk(*this))
           return false;
       }

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -343,13 +343,13 @@ private:
       if (customAttr->isImplicit())
         continue;
 
-      auto &Loc = customAttr->getTypeLoc();
       if (auto *semanticInit = dyn_cast_or_null<CallExpr>(customAttr->getSemanticInit())) {
         if (auto *CD = semanticInit->getCalledValue()) {
           if (!shouldIndex(CD, /*IsRef*/true))
             continue;
           IndexSymbol Info;
-          if (initIndexSymbol(CD, Loc.getLoc(), /*IsRef=*/true, Info))
+          const auto reprLoc = customAttr->getTypeRepr()->getLoc();
+          if (initIndexSymbol(CD, reprLoc, /*IsRef=*/true, Info))
             continue;
           Info.roles |= (unsigned)SymbolRole::Call;
           if (semanticInit->isImplicit())

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -811,10 +811,10 @@ Parser::parseImplementsAttribute(SourceLoc AtLoc, SourceLoc Loc) {
   }
 
   // FIXME(ModQual): Reject module qualification on MemberName.
-
+  auto *TE = new (Context) TypeExpr(ProtocolType.get());
   return ParserResult<ImplementsAttr>(
     ImplementsAttr::create(Context, AtLoc, SourceRange(Loc, rParenLoc),
-                           ProtocolType.get(), MemberName.getFullName(),
+                           TE, MemberName.getFullName(),
                            MemberNameLoc));
 }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2218,7 +2218,8 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     if (invalid)
       return false;
 
-    Attributes.add(TypeEraserAttr::create(Context, AtLoc, {Loc, RParenLoc}, ErasedType.get()));
+    auto *TE = new (Context) TypeExpr(ErasedType.get());
+    Attributes.add(TypeEraserAttr::create(Context, AtLoc, {Loc, RParenLoc}, TE));
     break;
   }
 
@@ -2591,7 +2592,8 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes, SourceLoc At
     }
 
     // Form the attribute.
-    auto attr = CustomAttr::create(Context, AtLoc, type.get(), hasInitializer,
+    auto *TE = new (Context) TypeExpr(type.get());
+    auto attr = CustomAttr::create(Context, AtLoc, TE, hasInitializer,
                                    initContext, lParenLoc, args, argLabels,
                                    argLabelLocs, rParenLoc);
     Attributes.add(attr);

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -17,7 +17,6 @@
 #include "swift/Parse/Parser.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Attr.h"
-#include "swift/AST/TypeLoc.h"
 #include "swift/AST/TypeRepr.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/CodeCompletionCallbacks.h"

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1495,12 +1495,14 @@ namespace {
 
     Type resolveTypeReferenceInExpression(TypeRepr *repr,
                                           TypeResolverContext resCtx) {
-      TypeLoc loc(repr);
       TypeResolutionOptions options(resCtx);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
-      bool hadError = TypeChecker::validateType(
-          loc, TypeResolution::forContextual(CS.DC, options));
-      return hadError ? Type() : loc.getType();
+      auto result = TypeResolution::forContextual(CS.DC, options)
+                        .resolveType(repr);
+      if (!result || result->hasError()) {
+        return Type();
+      }
+      return result;
     }
 
     Type visitTypeExpr(TypeExpr *E) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4389,9 +4389,12 @@ void SolutionApplicationTarget::maybeApplyPropertyWrapper() {
       isImplicit = true;
     }
 
-    auto typeExpr = TypeExpr::createImplicitHack(
-        outermostWrapperAttr->getTypeLoc().getLoc(),
-        outermostWrapperType, ctx);
+    SourceLoc typeLoc;
+    if (auto *repr = outermostWrapperAttr->getTypeRepr()) {
+      typeLoc = repr->getLoc();
+    }
+    auto typeExpr =
+        TypeExpr::createImplicitHack(typeLoc, outermostWrapperType, ctx);
     backingInitializer = CallExpr::create(
         ctx, typeExpr, outermostArg,
         outermostWrapperAttr->getArgumentLabels(),
@@ -4405,7 +4408,8 @@ void SolutionApplicationTarget::maybeApplyPropertyWrapper() {
   // the initializer type later.
   expression.wrappedVar = singleVar;
   expression.expression = backingInitializer;
-  expression.convertType = outermostWrapperAttr->getTypeLoc();
+  expression.convertType = {outermostWrapperAttr->getTypeRepr(),
+                            outermostWrapperAttr->getType()};
 }
 
 SolutionApplicationTarget SolutionApplicationTarget::forInitialization(

--- a/lib/Sema/DerivedConformanceComparable.cpp
+++ b/lib/Sema/DerivedConformanceComparable.cpp
@@ -289,13 +289,13 @@ deriveComparable_lt(
   if (generatedIdentifier != C.Id_LessThanOperator) {
     auto comparable = C.getProtocol(KnownProtocolKind::Comparable);
     auto comparableType = comparable->getDeclaredType();
-    auto comparableTypeLoc = TypeLoc::withoutLoc(comparableType);
+    auto comparableTypeExpr = TypeExpr::createImplicit(comparableType, C);
     SmallVector<Identifier, 2> argumentLabels = { Identifier(), Identifier() };
     auto comparableDeclName = DeclName(C, DeclBaseName(C.Id_LessThanOperator),
                                    argumentLabels);
     comparableDecl->getAttrs().add(new (C) ImplementsAttr(SourceLoc(),
                                                           SourceRange(),
-                                                          comparableTypeLoc,
+                                                          comparableTypeExpr,
                                                           comparableDeclName,
                                                           DeclNameLoc()));
   }

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -506,13 +506,13 @@ deriveEquatable_eq(
   if (generatedIdentifier != C.Id_EqualsOperator) {
     auto equatableProto = C.getProtocol(KnownProtocolKind::Equatable);
     auto equatableTy = equatableProto->getDeclaredType();
-    auto equatableTypeLoc = TypeLoc::withoutLoc(equatableTy);
+    auto equatableTyExpr = TypeExpr::createImplicit(equatableTy, C);
     SmallVector<Identifier, 2> argumentLabels = { Identifier(), Identifier() };
     auto equalsDeclName = DeclName(C, DeclBaseName(C.Id_EqualsOperator),
                                    argumentLabels);
     eqDecl->getAttrs().add(new (C) ImplementsAttr(SourceLoc(),
                                                   SourceRange(),
-                                                  equatableTypeLoc,
+                                                  equatableTyExpr,
                                                   equalsDeclName,
                                                   DeclNameLoc()));
   }

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -526,7 +526,7 @@ public:
 
     // Check the property wrapper types.
     for (auto attr : anyVar->getAttachedPropertyWrappers()) {
-      checkTypeAccess(attr->getTypeLoc(), anyVar,
+      checkTypeAccess(attr->getType(), attr->getTypeRepr(), anyVar,
                       /*mayBeInferred=*/false,
                       [&](AccessScope typeAccessScope,
                           const TypeRepr *complainRepr,
@@ -1152,7 +1152,7 @@ public:
         });
 
     for (auto attr : anyVar->getAttachedPropertyWrappers()) {
-      checkTypeAccess(attr->getTypeLoc(),
+      checkTypeAccess(attr->getType(), attr->getTypeRepr(),
                       fixedLayoutStructContext ? fixedLayoutStructContext
                                                : anyVar,
                       /*mayBeInferred*/false,
@@ -1827,7 +1827,7 @@ public:
 
     // Check the property wrapper types.
     for (auto attr : anyVar->getAttachedPropertyWrappers())
-      checkType(attr->getTypeLoc(), anyVar,
+      checkType(attr->getType(), attr->getTypeRepr(), anyVar,
                 getDiagnoser(anyVar, Reason::PropertyWrapper));
   }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2850,8 +2850,8 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
     TypeResolutionOptions options = None;
     options |= TypeResolutionFlags::AllowUnboundGenerics;
 
-    auto resolution = TypeResolution::forContextual(DC, options);
-    T = resolution.resolveType(ProtoTypeLoc.getTypeRepr());
+    T = TypeResolution::forContextual(DC, options)
+          .resolveType(ProtoTypeLoc.getTypeRepr());
     ProtoTypeLoc.setType(T);
   }
 
@@ -2925,11 +2925,11 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
   // an unknown attribute.
   if (!nominal) {
     std::string typeName;
-    if (auto typeRepr = attr->getTypeLoc().getTypeRepr()) {
+    if (auto typeRepr = attr->getTypeRepr()) {
       llvm::raw_string_ostream out(typeName);
       typeRepr->print(out);
     } else {
-      typeName = attr->getTypeLoc().getType().getString();
+      typeName = attr->getType().getString();
     }
 
     diagnose(attr->getLocation(), diag::unknown_attribute, typeName);

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -556,16 +556,15 @@ Type AttachedPropertyWrapperTypeRequest::evaluate(Evaluator &evaluator,
   if (!customAttr)
     return Type();
 
-  TypeResolutionOptions options(TypeResolverContext::PatternBindingDecl);
-  options |= TypeResolutionFlags::AllowUnboundGenerics;
-
-  auto resolution =
-      TypeResolution::forContextual(var->getDeclContext(), options);
-  if (TypeChecker::validateType(customAttr->getTypeLoc(), resolution)) {
+  auto ty = evaluateOrDefault(
+      evaluator,
+      CustomAttrTypeRequest{customAttr, var->getDeclContext(),
+                            CustomAttrTypeKind::PropertyDelegate},
+      Type());
+  if (!ty || ty->hasError()) {
     return ErrorType::get(var->getASTContext());
   }
-
-  return customAttr->getTypeLoc().getType();
+  return ty;
 }
 
 Type
@@ -720,12 +719,16 @@ Expr *swift::buildPropertyWrapperWrappedValueCall(
                          : var->getAttachedPropertyWrapperType(i);
     if (!wrapperType)
       return nullptr;
-    
-    auto typeExpr = TypeExpr::createImplicitHack(
-        wrapperAttrs[i]->getTypeLoc().getLoc(),
-        wrapperType, ctx);
 
-    SourceLoc startLoc = wrapperAttrs[i]->getTypeLoc().getSourceRange().Start;
+    auto reprRange = SourceRange();
+    if (auto *repr = wrapperAttrs[i]->getTypeRepr()) {
+      reprRange = repr->getSourceRange();
+    }
+
+    auto typeExpr =
+        TypeExpr::createImplicitHack(reprRange.Start, wrapperType, ctx);
+
+    SourceLoc startLoc = reprRange.Start;
 
     // If there were no arguments provided for the attribute at this level,
     // call `init(wrappedValue:)` directly.
@@ -745,7 +748,7 @@ Expr *swift::buildPropertyWrapperWrappedValueCall(
 
       auto endLoc = initializer->getEndLoc();
       if (endLoc.isInvalid() && startLoc.isValid())
-        endLoc = wrapperAttrs[i]->getTypeLoc().getSourceRange().End;
+        endLoc = reprRange.End;
 
       auto *init =
           CallExpr::create(ctx, typeExpr, startLoc, {initializer}, {argName},
@@ -781,7 +784,7 @@ Expr *swift::buildPropertyWrapperWrappedValueCall(
     
     auto endLoc = attr->getArg()->getEndLoc();
     if (endLoc.isInvalid() && startLoc.isValid())
-      endLoc = wrapperAttrs[i]->getTypeLoc().getSourceRange().End;
+      endLoc = reprRange.End;
 
     auto *init = CallExpr::create(ctx, typeExpr, startLoc, elements,
                                    elementNames, elementLocs, endLoc,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1039,7 +1039,7 @@ witnessHasImplementsAttrForExactRequirement(ValueDecl *witness,
   assert(requirement->isProtocolRequirement());
   auto *PD = cast<ProtocolDecl>(requirement->getDeclContext());
   if (auto A = witness->getAttrs().getAttribute<ImplementsAttr>()) {
-    if (Type T = A->getProtocolType().getType()) {
+    if (Type T = A->getProtocolType()) {
       if (auto ProtoTy = T->getAs<ProtocolType>()) {
         if (ProtoTy->getDecl() == PD) {
           return A->getMemberName() == requirement->getName();

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -366,7 +366,7 @@ Type FunctionBuilderTypeRequest::evaluate(Evaluator &evaluator,
       evaluator,
       CustomAttrTypeRequest{mutableAttr, dc, CustomAttrTypeKind::NonGeneric},
       Type());
-  if (!type) return Type();
+  if (!type || type->hasError()) return Type();
 
   auto nominal = type->getAnyNominal();
   if (!nominal) {

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -362,8 +362,10 @@ Type FunctionBuilderTypeRequest::evaluate(Evaluator &evaluator,
   auto mutableAttr = const_cast<CustomAttr*>(attr);
   auto dc = decl->getDeclContext();
   auto &ctx = dc->getASTContext();
-  Type type = resolveCustomAttrType(mutableAttr, dc,
-                                    CustomAttrTypeKind::NonGeneric);
+  Type type = evaluateOrDefault(
+      evaluator,
+      CustomAttrTypeRequest{mutableAttr, dc, CustomAttrTypeKind::NonGeneric},
+      Type());
   if (!type) return Type();
 
   auto nominal = type->getAnyNominal();

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2479,7 +2479,11 @@ PropertyWrapperMutabilityRequest::evaluate(Evaluator &,
   result.Getter = getGetterMutatingness(firstWrapper.*varMember);
   result.Setter = getSetterMutatingness(firstWrapper.*varMember,
                                         var->getInnermostDeclContext());
-  
+
+  auto getCustomAttrTypeLoc = [](const CustomAttr *CA) -> TypeLoc {
+    return { CA->getTypeRepr(), CA->getType() };
+  };
+
   // Compose the traits of the following wrappers.
   for (unsigned i = 1; i < numWrappers && !isProjectedValue; ++i) {
     assert(var == originalVar);
@@ -2496,8 +2500,8 @@ PropertyWrapperMutabilityRequest::evaluate(Evaluator &,
       auto &ctx = var->getASTContext();
       ctx.Diags.diagnose(var->getAttachedPropertyWrappers()[i]->getLocation(),
                diag::property_wrapper_mutating_get_composed_to_get_only,
-               var->getAttachedPropertyWrappers()[i]->getTypeLoc(),
-               var->getAttachedPropertyWrappers()[i-1]->getTypeLoc());
+               getCustomAttrTypeLoc(var->getAttachedPropertyWrappers()[i]),
+               getCustomAttrTypeLoc(var->getAttachedPropertyWrappers()[i-1]));
 
       return None;
     }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1688,20 +1688,6 @@ static bool validateAutoClosureAttributeUse(DiagnosticEngine &Diags,
   return !isValid;
 }
 
-bool TypeChecker::validateType(TypeLoc &Loc, TypeResolution resolution) {
-  // If we've already validated this type, don't do so again.
-  if (Loc.wasValidated())
-    return Loc.isError();
-
-  if (auto *Stats = resolution.getASTContext().Stats)
-    ++Stats->getFrontendCounters().NumTypesValidated;
-
-  auto type = resolution.resolveType(Loc.getTypeRepr());
-  Loc.setType(type);
-
-  return type->hasError();
-}
-
 namespace {
   const auto DefaultParameterConvention = ParameterConvention::Direct_Unowned;
   const auto DefaultResultConvention = ResultConvention::Unowned;
@@ -3898,7 +3884,7 @@ Type CustomAttrTypeRequest::evaluate(Evaluator &eval, CustomAttr *attr,
   // We always require the type to resolve to a nominal type.
   if (!type->getAnyNominal()) {
     assert(ctx.Diags.hadAnyError());
-    return Type();
+    return ErrorType::get(ctx);
   }
 
   return type;

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -391,21 +391,6 @@ public:
   bool areSameType(Type type1, Type type2) const;
 };
 
-/// Kinds of types for CustomAttr.
-enum class CustomAttrTypeKind {
-  /// The type is required to not be expressed in terms of
-  /// any contextual type parameters.
-  NonGeneric,
-
-  /// Property delegates have some funky rules, like allowing
-  /// unbound generic types.
-  PropertyDelegate,
-};
-
-/// Attempt to resolve a concrete type for a custom attribute.
-Type resolveCustomAttrType(CustomAttr *attr, DeclContext *dc,
-                           CustomAttrTypeKind typeKind);
-
 } // end namespace swift
 
 #endif /* SWIFT_SEMA_TYPE_CHECK_TYPE_H */

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -424,7 +424,15 @@ bool swift::performTypeLocChecking(ASTContext &Ctx, TypeLoc &T,
   Optional<DiagnosticSuppression> suppression;
   if (!ProduceDiagnostics)
     suppression.emplace(Ctx.Diags);
-  return TypeChecker::validateType(T, resolution);
+
+  // If we've already validated this type, don't do so again.
+  if (T.wasValidated()) {
+    return T.isError();
+  }
+
+  auto type = resolution.resolveType(T.getTypeRepr());
+  T.setType(type);
+  return type->hasError();
 }
 
 /// Expose TypeChecker's handling of GenericParamList to SIL parsing.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4329,9 +4329,8 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
           } else
             return deserialized.takeError();
         } else {
-          Attr = CustomAttr::create(ctx, SourceLoc(),
-                                    TypeLoc::withoutLoc(deserialized.get()),
-                                    isImplicit);
+          auto *TE = TypeExpr::createImplicit(deserialized.get(), ctx);
+          Attr = CustomAttr::create(ctx, SourceLoc(), TE, isImplicit);
         }
         break;
       }

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -20,7 +20,6 @@
 #include "swift/AST/FileUnit.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/RawComment.h"
-#include "swift/AST/TypeLoc.h"
 #include "swift/Serialization/Validation.h"
 #include "swift/Basic/LLVM.h"
 #include "clang/AST/Type.h"

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2388,9 +2388,9 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     case DAK_Custom: {
       auto abbrCode = S.DeclTypeAbbrCodes[CustomDeclAttrLayout::Code];
       auto theAttr = cast<CustomAttr>(DA);
-      CustomDeclAttrLayout::emitRecord(
-        S.Out, S.ScratchRecord, abbrCode, theAttr->isImplicit(),
-        S.addTypeRef(theAttr->getTypeLoc().getType()));
+      CustomDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
+                                       theAttr->isImplicit(),
+                                       S.addTypeRef(theAttr->getType()));
       return;
     }
 


### PR DESCRIPTION
This lines up the final pieces needed to remove `TypeChecker::validateType`, so the last commit does just that. We can now start the process of fixing up TypeCheckType to not return the null type in earnest. 