### PR TITLE
Added protocol to support CVarArg objects that need to be retained

### DIFF
--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -63,6 +63,7 @@ protocol _CVarArgAligned: CVarArg {
   var _cVarArgAlignment: Int { get }
 }
 
+#if !_runtime(_ObjC)
 /// Some pointers require an alternate object to be retained.  The object
 /// that is returned will be used with _cVarArgEncoding and held until
 /// the closure is complete.  This is required since autoreleased storage
@@ -71,6 +72,7 @@ public protocol _CVarArgObject: CVarArg {
   /// Returns the alternate object that should be encoded.
   var _cVarArgObject: CVarArg { get }
 }
+#endif
 
 #if arch(x86_64)
 @usableFromInline
@@ -471,8 +473,10 @@ final internal class __VaListBuilder {
   @usableFromInline // c-abi
   internal var storage: ContiguousArray<Int>
 
+#if !_runtime(_ObjC)
   @usableFromInline // c-abi
   internal var retainer = [CVarArg]()
+#endif
 
   @inlinable // c-abi
   internal init() {
@@ -487,11 +491,13 @@ final internal class __VaListBuilder {
   internal func append(_ arg: CVarArg) {
     var arg = arg
 
+#if !_runtime(_ObjC)
     // We may need to retain an object that provides a pointer value.
     if let obj = arg as? _CVarArgObject {
       arg = obj._cVarArgObject
       retainer.append(arg)
     }
+#endif
 
     var encoded = arg._cVarArgEncoding
 
@@ -582,11 +588,13 @@ final internal class __VaListBuilder {
   internal func append(_ arg: CVarArg) {
     var arg = arg
 
+#if !_runtime(_ObjC)
     // We may need to retain an object that provides a pointer value.
     if let obj = arg as? _CVarArgObject {
       arg = obj._cVarArgObject
       retainer.append(arg)
     }
+#endif
 
     // Write alignment padding if necessary.
     // This is needed on architectures where the ABI alignment of some
@@ -693,8 +701,10 @@ final internal class __VaListBuilder {
   @usableFromInline // c-abi
   internal var storage: UnsafeMutablePointer<Int>?
 
+#if !_runtime(_ObjC)
   @usableFromInline // c-abi
   internal var retainer = [CVarArg]()
+#endif
 
   internal static var alignedStorageForEmptyVaLists: Double = 0
 }

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -489,9 +489,9 @@ final internal class __VaListBuilder {
 
   @inlinable // c-abi
   internal func append(_ arg: CVarArg) {
+#if !_runtime(_ObjC)
     var arg = arg
 
-#if !_runtime(_ObjC)
     // We may need to retain an object that provides a pointer value.
     if let obj = arg as? _CVarArgObject {
       arg = obj._cVarArgObject
@@ -586,9 +586,9 @@ final internal class __VaListBuilder {
 
   @inlinable // c-abi
   internal func append(_ arg: CVarArg) {
+#if !_runtime(_ObjC)
     var arg = arg
 
-#if !_runtime(_ObjC)
     // We may need to retain an object that provides a pointer value.
     if let obj = arg as? _CVarArgObject {
       arg = obj._cVarArgObject

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -66,7 +66,7 @@ protocol _CVarArgAligned: CVarArg {
 /// Some pointers require an alternate object to be retained.  The object
 /// that is returned will be used with _cVarArgEncoding and held until
 /// the closure is complete.  This is required since autoreleased storage
-/// is available on all platforms.
+/// is not available on all platforms.
 public protocol _CVarArgObject: CVarArg {
   /// Returns the alternate object that should be encoded.
   var _cVarArgObject: CVarArg { get }


### PR DESCRIPTION
<!-- What's in this pull request? -->
To fix string formatting using `%@` and a `String` argument, the `CVarArg` protocol needs to be implemented on `String`.  To do this, `String` requires an `NSString` to return a `CFString` which is what is finally used by the formatting.

However, without an autorelease pool (as is the case with most non-Apple platforms), `NSString` will get destroyed once out of scope of `_cVarArgEncoding`.

This pull request adds a new protocol to support retaining such objects without requiring an autorelease pool.

Please see [Foundation PR #2821](https://github.com/apple/swift-corelibs-foundation/pull/2821) and [this post](https://forums.swift.org/t/cvararg-support-for-nsstring-and-string/37404) for more details.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-957](https://bugs.swift.org/browse/SR-957).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
