### PR TITLE
[5.3][preset] Add missing libicu dependencies to package presets

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1579,13 +1579,16 @@ mixin-preset=
     mixin_linux_install_components_with_clang
 
 libdispatch
+libicu
 foundation
 xctest
 
+install-libicu
 install-foundation
 install-libdispatch
 install-xctest
 
+skip-test-libicu
 skip-test-foundation
 skip-test-libdispatch
 skip-test-xctest


### PR DESCRIPTION
We were accidentally using the system libicu instead of building it,
causing version mismatches.

This will unblock Linux PR testing for
https://github.com/apple/swift-llbuild/pull/674

(cherry picked from commit ccb41f044ac7bfb61e76460b7df59bfca6bbf286,
 #31733)