### PR TITLE
[opt] Re-work broadenSingleElementStores to use projections.

### DIFF
--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -462,7 +462,7 @@ public:
   static NullablePtr<SingleValueInstruction>
   createAggFromFirstLevelProjections(SILBuilder &B, SILLocation Loc,
                                      SILType BaseType,
-                                     llvm::SmallVectorImpl<SILValue> &Values);
+                                     ArrayRef<SILValue> Values);
 
   void print(raw_ostream &os, SILType baseType) const;
 private:

--- a/lib/SIL/Utils/Projection.cpp
+++ b/lib/SIL/Utils/Projection.cpp
@@ -803,10 +803,9 @@ Projection::operator<(const Projection &Other) const {
 }
 
 NullablePtr<SingleValueInstruction>
-Projection::
-createAggFromFirstLevelProjections(SILBuilder &B, SILLocation Loc,
-                                   SILType BaseType,
-                                   llvm::SmallVectorImpl<SILValue> &Values) {
+Projection::createAggFromFirstLevelProjections(
+    SILBuilder &B, SILLocation Loc, SILType BaseType,
+    ArrayRef<SILValue> Values) {
   if (BaseType.getStructOrBoundGenericStruct()) {
     return B.createStruct(Loc, BaseType, Values);
   }

--- a/test/SILOptimizer/Inputs/foo.h
+++ b/test/SILOptimizer/Inputs/foo.h
@@ -1,0 +1,18 @@
+#ifndef VALIDATION_TEST_SILOPTIMIZER_FOO_H
+#define VALIDATION_TEST_SILOPTIMIZER_FOO_H
+
+struct Foo {
+  int x;
+  ~Foo() {}
+};
+
+struct Loadable {
+  int x;
+};
+
+struct Bar {
+  Loadable y;
+  ~Bar() {}
+};
+
+#endif // VALIDATION_TEST_SILOPTIMIZER_FOO_H

--- a/test/SILOptimizer/Inputs/module.modulemap
+++ b/test/SILOptimizer/Inputs/module.modulemap
@@ -1,0 +1,3 @@
+module Foo {
+  header "foo.h"
+}

--- a/test/SILOptimizer/dont_broaden_cxx_address_only.sil
+++ b/test/SILOptimizer/dont_broaden_cxx_address_only.sil
@@ -1,0 +1,44 @@
+// RUN: %target-sil-opt -silgen-cleanup %s -I %S/Inputs -enable-sil-verify-all -enable-cxx-interop | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+import Foo
+
+// Make sure we don't try to create a struct here. Foo is not loadable, even
+// though it's only property is.
+// CHECK-LABEL: @test_foo
+// CHECK: bb0
+// CHECK-NEXT: [[E:%.*]] = struct_element_addr
+// CHECK-NEXT: store %1 to [trivial] [[E]]
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+// CHECK-LABEL: end sil function 'test_foo'
+sil shared [transparent] [serializable] [ossa] @test_foo : $@convention(method) (Int32, @thin Foo.Type) -> @out Foo {
+bb0(%0 : $*Foo, %1 : $Int32, %2 : $@thin Foo.Type):
+  %3 = struct_element_addr %0 : $*Foo, #Foo.x
+  store %1 to [trivial] %3 : $*Int32
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// Make sure we create a struct for the first (loadable) type but not the second
+// type (Bar).
+// CHECK-LABEL: @test_bar
+// CHECK: bb0
+// CHECK-NEXT: [[E:%.*]] = struct_element_addr
+// CHECK-NEXT: [[AGG:%.*]] = struct $Loadable (%1 : $Int32)
+// CHECK-NEXT: store [[AGG]] to [trivial] [[E]]
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+// CHECK-LABEL: end sil function 'test_bar'
+sil shared [transparent] [serializable] [ossa] @test_bar : $@convention(method) (Int32, @thin Bar.Type) -> @out Bar {
+bb0(%0 : $*Bar, %1 : $Int32, %2 : $@thin Bar.Type):
+  %3 = struct_element_addr %0 : $*Bar, #Bar.y
+  %3a = struct_element_addr %3 : $*Loadable, #Loadable.x
+  store %1 to [trivial] %3a : $*Int32
+  %5 = tuple ()
+  return %5 : $()
+}

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -270,6 +270,11 @@ static cl::opt<std::string> RemarksFormat(
     cl::desc("The format used for serializing remarks (default: YAML)"),
     cl::value_desc("format"), cl::init("yaml"));
 
+static llvm::cl::opt<bool>
+    EnableCxxInterop("enable-cxx-interop",
+                     llvm::cl::desc("Enable C++ interop."),
+                     llvm::cl::init(false));
+
 static void runCommandLineSelectedPasses(SILModule *Module,
                                          irgen::IRGenModule *IRGenMod) {
   auto &opts = Module->getOptions();
@@ -347,6 +352,8 @@ int main(int argc, char **argv) {
 
   Invocation.getLangOptions().EnableExperimentalDifferentiableProgramming =
       EnableExperimentalDifferentiableProgramming;
+
+  Invocation.getLangOptions().EnableCXXInterop = EnableCxxInterop;
 
   Invocation.getDiagnosticOptions().VerifyMode =
       VerifyMode ? DiagnosticOptions::Verify : DiagnosticOptions::NoVerify;


### PR DESCRIPTION
* Fixes loadable edge case for address-only types.
* Re-work, generalize, and simplify by using projections.
* Support `-enable-cxx-interop` in sil-opt.

Refs #32291.