### PR TITLE
Ignore onFastPath builtin while looking for valid static initializer of a global variable

### DIFF
--- a/lib/SIL/IR/SILGlobalVariable.cpp
+++ b/lib/SIL/IR/SILGlobalVariable.cpp
@@ -136,6 +136,8 @@ bool SILGlobalVariable::isValidStaticInitializerInst(const SILInstruction *I,
           auto *TE = bi->getSingleUserOfType<TupleExtractInst>();
           return TE && getOffsetSubtract(TE, M);
         }
+        case BuiltinValueKind::OnFastPath:
+          return true;
         default:
           break;
       }

--- a/test/SILOptimizer/optionset.swift
+++ b/test/SILOptimizer/optionset.swift
@@ -12,7 +12,13 @@ public struct TestOptions: OptionSet {
     static let fourth   = TestOptions(rawValue: 1 << 3)
 }
 
-// CHECK:      sil @{{.*}}returnTestOptions{{.*}}
+// CHECK-LABEL: sil_global hidden [let] @$s4test17globalTestOptionsAA0cD0Vvp : $TestOptions = {
+// CHECK:   [[CONST:%.*]] = integer_literal $Builtin.Int{{32|64}}, 15
+// CHECK:   [[INT:%.*]] = struct $Int (%0 : $Builtin.Int{{32|64}})
+// CHECK:   %initval = struct $TestOptions ([[INT]] : $Int)
+let globalTestOptions: TestOptions = [.first, .second, .third, .fourth]
+
+// CHECK-LABEL: sil @{{.*}}returnTestOptions{{.*}}
 // CHECK-NEXT: bb0:
 // CHECK-NEXT:   builtin
 // CHECK-NEXT:   integer_literal {{.*}}, 15
@@ -23,24 +29,13 @@ public func returnTestOptions() -> TestOptions {
     return [.first, .second, .third, .fourth]
 }
 
-// CHECK: sil @{{.*}}returnEmptyTestOptions{{.*}}
-// CHECK:   [[ZERO:%[0-9]+]] = integer_literal {{.*}}, 0
-// CHECK:   [[ZEROINT:%[0-9]+]] = struct $Int ([[ZERO]]
-// CHECK:   [[TO:%[0-9]+]] = struct $TestOptions ([[ZEROINT]]
-// CHECK:   return [[TO]]
-// CHECK: } // end sil function {{.*}}returnEmptyTestOptions{{.*}}
+// CHECK-LABEL: sil @{{.*}}returnEmptyTestOptions{{.*}}
+// CHECK-NEXT: bb0:
+// CHECK-NEXT:   integer_literal {{.*}}, 0
+// CHECK-NEXT:   builtin "onFastPath"() : $()
+// CHECK-NEXT:   struct $Int
+// CHECK-NEXT:   struct $TestOptions
+// CHECK-NEXT:   return
 public func returnEmptyTestOptions() -> TestOptions {
     return []
 }
-
-// CHECK:        alloc_global @{{.*}}globalTestOptions{{.*}}
-// CHECK-NEXT:   global_addr
-// CHECK-NEXT:   builtin
-// CHECK-NEXT:   integer_literal {{.*}}, 15
-// CHECK-NEXT:   struct $Int
-// CHECK-NEXT:   struct $TestOptions
-// CHECK-NEXT:   store
-// CHECK-NEXT:   tuple
-// CHECK-NEXT:   return
-let globalTestOptions: TestOptions = [.first, .second, .third, .fourth]
-


### PR DESCRIPTION
The presence of this builtin has no effect while optimizing initializers of global variables.