### PR TITLE
stdlib: Place @_semantics prespecialization requirement target under correct constraints

### DIFF
--- a/stdlib/public/SwiftOnoneSupport/SwiftOnoneSupport.swift
+++ b/stdlib/public/SwiftOnoneSupport/SwiftOnoneSupport.swift
@@ -276,16 +276,16 @@ extension Range where Bound: Strideable, Bound.Stride : SignedInteger {
 extension ClosedRange {
   // init(uncheckedBounds: (lower: A, upper: A)) -> Swift.ClosedRange<A>
   @_semantics("prespecialize.$sSN15uncheckedBoundsSNyxGx5lower_x5uppert_tcfC")
-  // endIndex.getter
-  @_semantics("prespecialize.$sSNsSxRzSZ6StrideRpzrlE8endIndexSNsSxRzSZABRQrlE0C0Oyx_Gvg")
-  // subscript.read
-  @_semantics("prespecialize.$sSNsSxRzSZ6StrideRpzrlEyxSNsSxRzSZABRQrlE5IndexOyx_Gcir")
   func _prespecializeClosedRange() {}
 }
 
 extension ClosedRange where Bound: Strideable, Bound.Stride : SignedInteger {
   // startIndex.getter
   @_semantics("prespecialize.$sSNsSxRzSZ6StrideRpzrlE10startIndexSNsSxRzSZABRQrlE0C0Oyx_Gvg")
+  // endIndex.getter
+  @_semantics("prespecialize.$sSNsSxRzSZ6StrideRpzrlE8endIndexSNsSxRzSZABRQrlE0C0Oyx_Gvg")
+  // subscript.read
+  @_semantics("prespecialize.$sSNsSxRzSZ6StrideRpzrlEyxSNsSxRzSZABRQrlE5IndexOyx_Gcir")
   func _prespecializeIntegerClosedRange() {}
 
   // index(after: ClosedRange<A>< where A: Swift.Strideable, A.Stride: Swift.SignedInteger>.Index)


### PR DESCRIPTION
`subscript.read` requires `Bound: Strideable, Bound.Stride: SignedInteger`.

The substitution map refactor in #31895 revealed this with a crash. With a bit of guidance, I am happy to add a regression test for master too, if warranted.