### PR TITLE
[test/Syntax/round_trip_stdlib.swift] Exclude the test for an ASAN build

### DIFF
--- a/test/Syntax/round_trip_stdlib.swift
+++ b/test/Syntax/round_trip_stdlib.swift
@@ -1,1 +1,3 @@
+// <rdar://problem/64269925> test/Syntax/round_trip_stdlib.swift is very slow on ASAN build
+// REQUIRES: no_asan
 // RUN: %round-trip-syntax-test -d %swift_src_root/stdlib --swift-syntax-test %swift-syntax-test


### PR DESCRIPTION
It is too slow, rdar://64215520
