### PR TITLE
IRGen: Don't reify internal vtable entries that are marked non-overridden.

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -595,7 +595,7 @@ public:
                                       bool deserializeLazily=true);
 
   /// Look up the VTable mapped to the given ClassDecl. Returns null on failure.
-  SILVTable *lookUpVTable(const ClassDecl *C);
+  SILVTable *lookUpVTable(const ClassDecl *C, bool deserializeLazily = true);
 
   /// Attempt to lookup the function corresponding to \p Member in the class
   /// hierarchy of \p Class.

--- a/include/swift/SIL/SILVTable.h
+++ b/include/swift/SIL/SILVTable.h
@@ -49,13 +49,12 @@ class SILVTableEntry {
   /// The function which implements the method for the class and the entry kind.
   llvm::PointerIntPair<SILFunction *, 2, unsigned> ImplAndKind;
 
+  bool IsNonOverridden;
+
 public:
   enum Kind : uint8_t {
     /// The vtable entry is for a method defined directly in this class.
     Normal,
-    /// The vtable entry is for a method defined directly in this class, and is
-    /// never overridden by subclasses.
-    NormalNonOverridden,
     /// The vtable entry is inherited from the superclass.
     Inherited,
     /// The vtable entry is inherited from the superclass, and overridden
@@ -67,13 +66,18 @@ public:
 
   SILVTableEntry() : ImplAndKind(nullptr, Kind::Normal) {}
 
-  SILVTableEntry(SILDeclRef Method, SILFunction *Implementation, Kind TheKind)
-      : Method(Method), ImplAndKind(Implementation, TheKind) {}
+  SILVTableEntry(SILDeclRef Method, SILFunction *Implementation, Kind TheKind,
+                 bool NonOverridden)
+      : Method(Method), ImplAndKind(Implementation, TheKind),
+        IsNonOverridden(NonOverridden) {}
 
   SILDeclRef getMethod() const { return Method; }
 
   Kind getKind() const { return Kind(ImplAndKind.getInt()); }
   void setKind(Kind kind) { ImplAndKind.setInt(kind); }
+
+  bool isNonOverridden() const { return IsNonOverridden; }
+  void setNonOverridden(bool value) { IsNonOverridden = value; }
 
   SILFunction *getImplementation() const { return ImplAndKind.getPointer(); }
 };

--- a/lib/IRGen/ClassMetadataVisitor.h
+++ b/lib/IRGen/ClassMetadataVisitor.h
@@ -21,6 +21,8 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/SIL/SILDeclRef.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/SIL/SILVTable.h"
 #include "swift/SIL/SILVTableVisitor.h"
 #include "IRGen.h"
 #include "NominalMetadataVisitor.h"
@@ -29,6 +31,15 @@ namespace swift {
 namespace irgen {
 
 class IRGenModule;
+
+/// Returns true if the given SILVTable entry needs to be reified as a runtime
+/// vtable entry.
+///
+/// Methods that have no overrides, and no ABI constraints that require a
+/// vtable to be present, can be left out of the runtime vtable for classes.
+bool methodRequiresReifiedVTableEntry(IRGenModule &IGM,
+                                      const SILVTable *vtable,
+                                      SILDeclRef method);
 
 /// A CRTP class for laying out class metadata.  Note that this does
 /// *not* handle the metadata template stuff.
@@ -43,9 +54,13 @@ protected:
 
   /// The most-derived class.
   ClassDecl *const Target;
+        
+  /// SILVTable entry for the class.
+  const SILVTable *VTable;
 
   ClassMetadataVisitor(IRGenModule &IGM, ClassDecl *target)
-    : super(IGM), Target(target) {}
+    : super(IGM), Target(target),
+      VTable(IGM.getSILModule().lookUpVTable(target, /*deserialize*/ false)) {}
 
 public:
   void layout() {
@@ -152,8 +167,15 @@ private:
     // Add vtable entries.
     asImpl().addVTableEntries(theClass);
   }
-  
-private:
+
+  friend SILVTableVisitor<Impl>;
+  void addMethod(SILDeclRef declRef) {
+    // Does this method require a reified runtime vtable entry?
+    if (methodRequiresReifiedVTableEntry(IGM, VTable, declRef)) {
+      asImpl().addReifiedVTableEntry(declRef);
+    }
+  }
+        
   void addFieldEntries(Decl *field) {
     if (auto var = dyn_cast<VarDecl>(field)) {
       asImpl().addFieldOffset(var);
@@ -194,7 +216,7 @@ public:
   void addClassAddressPoint() { addInt32(); }
   void addClassCacheData() { addPointer(); addPointer(); }
   void addClassDataPointer() { addPointer(); }
-  void addMethod(SILDeclRef declRef) {
+  void addReifiedVTableEntry(SILDeclRef declRef) {
     addPointer();
   }
   void addMethodOverride(SILDeclRef baseRef, SILDeclRef declRef) {}

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1437,7 +1437,13 @@ namespace {
     }
 
     void addMethod(SILDeclRef fn) {
-      VTableEntries.push_back(fn);
+      if (methodRequiresReifiedVTableEntry(IGM, VTable, fn)) {
+        VTableEntries.push_back(fn);
+      } else if (getType()->getEffectiveAccess() >= AccessLevel::Public) {
+        // Emit a stub method descriptor and lookup function for nonoverridden
+        // methods so that resilient code sequences can still use them.
+        emitNonoverriddenMethod(fn);
+      }
     }
 
     void addMethodOverride(SILDeclRef baseRef, SILDeclRef declRef) {
@@ -1521,9 +1527,6 @@ namespace {
     }
     
     void addVTable() {
-      if (VTableEntries.empty())
-        return;
-      
       LLVM_DEBUG(
         llvm::dbgs() << "VTable entries for " << getType()->getName() << ":\n";
         for (auto entry : VTableEntries) {
@@ -1533,6 +1536,9 @@ namespace {
         }
       );
 
+      if (VTableEntries.empty())
+        return;
+      
       // Only emit a method lookup function if the class is resilient
       // and has a non-empty vtable.
       if (IGM.hasResilientMetadata(getType(), ResilienceExpansion::Minimal))
@@ -1595,8 +1601,25 @@ namespace {
         IGM.emitDispatchThunk(fn);
       }
     }
+    
+    void emitNonoverriddenMethod(SILDeclRef fn) {
+      // TODO: Emit a freestanding method descriptor structure, and a method
+      // lookup function, to present the ABI of an overridable method even
+      // though the method has no real overrides currently.
+    }
 
     void addOverrideTable() {
+      LLVM_DEBUG(
+        llvm::dbgs() << "Override Table entries for " << getType()->getName() << ":\n";
+        for (auto entry : OverrideTableEntries) {
+          llvm::dbgs() << "  ";
+          entry.first.print(llvm::dbgs());
+          llvm::dbgs() << " -> ";
+          entry.second.print(llvm::dbgs());
+          llvm::dbgs() << '\n';
+        }
+      );
+
       if (OverrideTableEntries.empty())
         return;
 
@@ -2702,12 +2725,12 @@ namespace {
     using super::asImpl;
     using super::IGM;
     using super::Target;
+    using super::VTable;
 
     ConstantStructBuilder &B;
 
     const ClassLayout &FieldLayout;
     const ClassMetadataLayout &MetadataLayout;
-    const SILVTable *VTable;
 
     Size AddressPoint;
 
@@ -2717,8 +2740,7 @@ namespace {
                              const ClassLayout &fieldLayout)
       : super(IGM, theClass), B(builder),
         FieldLayout(fieldLayout),
-        MetadataLayout(IGM.getClassMetadataLayout(theClass)),
-        VTable(IGM.getSILModule().lookUpVTable(theClass)) {}
+        MetadataLayout(IGM.getClassMetadataLayout(theClass)) {}
 
   public:
     SILType getLoweredType() {
@@ -2854,7 +2876,7 @@ namespace {
                            PointerAuthEntity::Special::HeapDestructor);
       } else {
         // In case the optimizer removed the function. See comment in
-        // addMethod().
+        // addReifiedVTableEntry().
         B.addNullPointer(IGM.FunctionPtrTy);
       }
     }
@@ -2973,7 +2995,7 @@ namespace {
       B.add(data);
     }
 
-    void addMethod(SILDeclRef fn) {
+    void addReifiedVTableEntry(SILDeclRef fn) {
       // Find the vtable entry.
       assert(VTable && "no vtable?!");
       auto entry = VTable->getEntry(IGM.getSILModule(), fn);
@@ -5074,4 +5096,34 @@ llvm::Value *irgen::emitMetatypeInstanceType(IRGenFunction &IGF,
 void IRGenModule::emitOpaqueTypeDecl(OpaqueTypeDecl *D) {
   // Emit the opaque type descriptor.
   OpaqueTypeDescriptorBuilder(*this, D).emit();
+}
+
+bool irgen::methodRequiresReifiedVTableEntry(IRGenModule &IGM,
+                                             const SILVTable *vtable,
+                                             SILDeclRef method) {
+  auto &M = IGM.getSILModule();
+  auto entry = vtable->getEntry(IGM.getSILModule(), method);
+  if (!entry) {
+    return true;
+  }
+  
+  // We may be able to elide the vtable entry, ABI permitting, if it's not
+  // overridden.
+  if (!entry->isNonOverridden()) {
+    return true;
+  }
+  
+  // Does the ABI require a vtable entry to exist? If the class is public,
+  // and it's either marked fragile or part of a non-resilient module, then
+  // other modules will directly address vtable offsets and we can't remove
+  // vtable entries.
+  if (vtable->getClass()->getEffectiveAccess() >= AccessLevel::Public) {
+    // TODO: Check whether we use a resilient ABI to access this
+    // class's methods. We can drop unnecessary vtable entries if we do;
+    // otherwise fixed vtable offsets are part of the ABI.
+    return true;
+  }
+    
+  // Otherwise, we can leave this method out of the runtime vtable.
+  return false;
 }

--- a/lib/IRGen/MetadataLayout.cpp
+++ b/lib/IRGen/MetadataLayout.cpp
@@ -330,12 +330,12 @@ ClassMetadataLayout::ClassMetadataLayout(IRGenModule &IGM, ClassDecl *decl)
       super::addGenericArgument(requirement, forClass);
     }
 
-    void addMethod(SILDeclRef fn) {
+    void addReifiedVTableEntry(SILDeclRef fn) {
       if (fn.getDecl()->getDeclContext() == Target) {
         ++Layout.NumImmediateMembers;
         Layout.MethodInfos.try_emplace(fn, getNextOffset());
       }
-      super::addMethod(fn);
+      super::addReifiedVTableEntry(fn);
     }
 
     void noteStartOfFieldOffsets(ClassDecl *forClass) {

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -476,7 +476,8 @@ void SILModule::eraseGlobalVariable(SILGlobalVariable *G) {
   getSILGlobalList().erase(G);
 }
 
-SILVTable *SILModule::lookUpVTable(const ClassDecl *C) {
+SILVTable *SILModule::lookUpVTable(const ClassDecl *C,
+                                   bool deserializeLazily) {
   if (!C)
     return nullptr;
 
@@ -484,6 +485,9 @@ SILVTable *SILModule::lookUpVTable(const ClassDecl *C) {
   auto R = VTableMap.find(C);
   if (R != VTableMap.end())
     return R->second;
+
+  if (!deserializeLazily)
+    return nullptr;
 
   // If that fails, try to deserialize it. If that fails, return nullptr.
   SILVTable *Vtbl = getSILLoader()->lookupVTable(C);

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3131,9 +3131,6 @@ void SILVTable::print(llvm::raw_ostream &OS, bool Verbose) const {
     switch (entry.getKind()) {
     case SILVTable::Entry::Kind::Normal:
       break;
-    case SILVTable::Entry::Kind::NormalNonOverridden:
-      OS << " [nonoverridden]";
-      break;
     case SILVTable::Entry::Kind::Inherited:
       OS << " [inherited]";
       break;
@@ -3141,6 +3138,10 @@ void SILVTable::print(llvm::raw_ostream &OS, bool Verbose) const {
       OS << " [override]";
       break;
     }
+    if (entry.isNonOverridden()) {
+      OS << " [nonoverridden]";
+    }
+
     OS << "\t// " << demangleSymbol(entry.getImplementation()->getName());
     OS << "\n";
   }

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -6083,7 +6083,8 @@ bool SILParserState::parseSILVTable(Parser &P) {
       }
 
       auto Kind = SILVTable::Entry::Kind::Normal;
-      if (P.Tok.is(tok::l_square)) {
+      bool NonOverridden = false;
+      while (P.Tok.is(tok::l_square)) {
         P.consumeToken(tok::l_square);
         if (P.Tok.isNot(tok::identifier)) {
           P.diagnose(P.Tok.getLoc(), diag::sil_vtable_bad_entry_kind);
@@ -6098,7 +6099,7 @@ bool SILParserState::parseSILVTable(Parser &P) {
           Kind = SILVTable::Entry::Kind::Inherited;
         } else if (P.Tok.getText() == "nonoverridden") {
           P.consumeToken();
-          Kind = SILVTable::Entry::Kind::NormalNonOverridden;
+          NonOverridden = true;
         } else {
           P.diagnose(P.Tok.getLoc(), diag::sil_vtable_bad_entry_kind);
           return true;
@@ -6108,7 +6109,7 @@ bool SILParserState::parseSILVTable(Parser &P) {
           return true;
       }
 
-      vtableEntries.emplace_back(Ref, Func, Kind);
+      vtableEntries.emplace_back(Ref, Func, Kind, NonOverridden);
     } while (P.Tok.isNot(tok::r_brace) && P.Tok.isNot(tok::eof));
   }
 

--- a/lib/SILOptimizer/Transforms/PruneVTables.cpp
+++ b/lib/SILOptimizer/Transforms/PruneVTables.cpp
@@ -27,9 +27,18 @@ class PruneVTables : public SILModuleTransform {
   void runOnVTable(SILModule *M,
                    SILVTable *vtable) {
     for (auto &entry : vtable->getMutableEntries()) {
-      // We don't need to worry about entries that are inherited, overridden,
+      
+      // We don't need to worry about entries that are overridden,
       // or have already been found to have no overrides.
-      if (entry.getKind() != SILVTable::Entry::Normal) {
+      if (entry.isNonOverridden())
+        continue;
+      
+      switch (entry.getKind()) {
+      case SILVTable::Entry::Normal:
+      case SILVTable::Entry::Inherited:
+        break;
+          
+      case SILVTable::Entry::Override:
         continue;
       }
 
@@ -52,8 +61,7 @@ class PruneVTables : public SILModuleTransform {
         if (methodDecl->isOverridden())
           continue;
       }
-
-      entry.setKind(SILVTable::Entry::NormalNonOverridden);
+      entry.setNonOverridden(true);
     }
   }
   

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 559; // Serialization of -implicit-dynamic
+const uint16_t SWIFTMODULE_VERSION_MINOR = 560; // SILVTable flag for non-overridden entries
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -51,7 +51,6 @@ using SILLinkageField = BCFixed<4>;
 
 enum SILVTableEntryKindEncoding : uint8_t {
   SIL_VTABLE_ENTRY_NORMAL,
-  SIL_VTABLE_ENTRY_NORMAL_NON_OVERRIDDEN,
   SIL_VTABLE_ENTRY_INHERITED,
   SIL_VTABLE_ENTRY_OVERRIDE,
 };
@@ -183,6 +182,7 @@ namespace sil_block {
     SIL_VTABLE_ENTRY,
     DeclIDField,  // SILFunction name
     SILVTableEntryKindField,  // Kind
+    BCFixed<1>, // NonOverridden
     BCArray<ValueIDField> // SILDeclRef
   >;
   

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -73,8 +73,6 @@ static unsigned toStableSILLinkage(SILLinkage linkage) {
 static unsigned toStableVTableEntryKind(SILVTable::Entry::Kind kind) {
   switch (kind) {
   case SILVTable::Entry::Kind::Normal: return SIL_VTABLE_ENTRY_NORMAL;
-  case SILVTable::Entry::Kind::NormalNonOverridden:
-    return SIL_VTABLE_ENTRY_NORMAL_NON_OVERRIDDEN;
   case SILVTable::Entry::Kind::Inherited: return SIL_VTABLE_ENTRY_INHERITED;
   case SILVTable::Entry::Kind::Override: return SIL_VTABLE_ENTRY_OVERRIDE;
   }
@@ -2390,7 +2388,9 @@ void SILSerializer::writeSILVTable(const SILVTable &vt) {
         Out, ScratchRecord, SILAbbrCodes[VTableEntryLayout::Code],
         // SILFunction name
         S.addUniquedStringRef(entry.getImplementation()->getName()),
-        toStableVTableEntryKind(entry.getKind()), ListOfValues);
+        toStableVTableEntryKind(entry.getKind()),
+        entry.isNonOverridden(),
+        ListOfValues);
   }
 }
 

--- a/test/IRGen/vtable_non_overridden.sil
+++ b/test/IRGen/vtable_non_overridden.sil
@@ -1,0 +1,68 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+
+class InternalA {
+  init()
+  func foo()
+  func bar()
+  func bas()
+}
+
+sil @InternalA_foo : $@convention(method) (@guaranteed InternalA) -> ()
+sil @InternalA_bar : $@convention(method) (@guaranteed InternalA) -> ()
+sil @InternalA_bas : $@convention(method) (@guaranteed InternalA) -> ()
+sil @InternalA_init : $@convention(method) (@thick InternalA.Type) -> @owned InternalA
+sil @InternalA_dealloc : $@convention(method) (@owned InternalA) -> ()
+
+sil_vtable InternalA {
+  #InternalA.deinit!deallocator : @InternalA_dealloc
+  #InternalA.init!allocator : @InternalA_init
+  #InternalA.foo : @InternalA_foo [nonoverridden]
+  #InternalA.bar : @InternalA_bar
+  #InternalA.bas : @InternalA_bas [nonoverridden]
+}
+
+// -- only overridden entries in internal method descriptor table
+// CHECK-LABEL: @"$s21vtable_non_overridden9InternalACMn" =
+// CHECK-SAME:     i32 2, %swift.method_descriptor
+// CHECK-SAME:     @InternalA_init
+// CHECK-NOT:      @InternalA_foo
+// CHECK-SAME:     @InternalA_bar
+// CHECK-NOT:      @InternalA_bas
+
+// -- only overridden entries in internal vtable
+// CHECK-LABEL: @"$s21vtable_non_overridden9InternalACMf" = 
+// CHECK-SAME:     @InternalA_init
+// CHECK-NOT:      @InternalA_foo
+// CHECK-SAME:     @InternalA_bar
+// CHECK-NOT:      @InternalA_bas
+
+sil @InternalB_bar : $@convention(method) (@guaranteed InternalB) -> ()
+sil @InternalB_init : $@convention(method) (@thick InternalB.Type) -> @owned InternalB
+sil @InternalB_dealloc : $@convention(method) (@owned InternalB) -> ()
+
+class InternalB: InternalA {
+  override func bar()
+}
+
+sil_vtable InternalB {
+  #InternalB.deinit!deallocator : @InternalB_dealloc
+  #InternalA.init!allocator : @InternalB_init [override]
+  #InternalA.foo : @InternalA_foo [inherited] [nonoverridden]
+  #InternalA.bar : @InternalB_bar [override]
+  #InternalA.bas : @InternalA_bas [inherited] [nonoverridden]
+}
+
+// -- only overridden entries in internal method descriptor table
+// CHECK-LABEL: @"$s21vtable_non_overridden9InternalBCMn" =
+// CHECK-SAME:     i32 2, %swift.method_override_descriptor
+// CHECK-NOT:      @InternalA_foo
+// CHECK-SAME:     @InternalB_bar
+// CHECK-NOT:      @InternalA_bas
+// CHECK-SAME:     @InternalB_init
+
+// -- only overridden entries in internal vtable
+// CHECK-LABEL: @"$s21vtable_non_overridden9InternalBCMf" = 
+// CHECK-SAME:     @InternalB_init
+// CHECK-NOT:      @InternalA_foo
+// CHECK-SAME:     @InternalB_bar
+// CHECK-NOT:      @InternalA_bas

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -1700,10 +1700,10 @@ sil_vtable Foo {
 }
 
 // CHECK-LABEL: sil_vtable Foo2 {
-// CHECK: #Foo.subscript!getter: {{.*}} : @Foo_subscript_getter [inherited]
+// CHECK: #Foo.subscript!getter: {{.*}} : @Foo_subscript_getter [inherited] [nonoverridden]
 // CHECK: #Foo.subscript!setter: {{.*}} : @Foo_subscript_setter [override]
 // CHECK: }
 sil_vtable Foo2 {
-  #Foo.subscript!getter: @Foo_subscript_getter [inherited]
+  #Foo.subscript!getter: @Foo_subscript_getter [inherited] [nonoverridden]
   #Foo.subscript!setter: @Foo_subscript_setter [override]
 }


### PR DESCRIPTION
Private and internal classes shouldn't have ABI constraints on their concrete vtable layout, so if methods
don't have overrides in practice, we can elide their vtable entries.