### PR TITLE
[test][stdlib] Define stdio stubs for OpenBSD.

### DIFF
--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -142,6 +142,10 @@ public func snprintf(ptr: UnsafeMutablePointer<Int8>, _ len: Int, _ format: Unsa
     return vsnprintf(ptr, len, format, va_args)
   }
 }
+#elseif os(OpenBSD)
+public var stdin: UnsafeMutablePointer<FILE> { return _swift_stdlib_stdin() }
+public var stdout: UnsafeMutablePointer<FILE> { return _swift_stdlib_stdout() }
+public var stderr: UnsafeMutablePointer<FILE> { return _swift_stdlib_stderr() }
 #elseif os(Windows)
 public var stdin: UnsafeMutablePointer<FILE> { return __acrt_iob_func(0) }
 public var stdout: UnsafeMutablePointer<FILE> { return __acrt_iob_func(1) }

--- a/stdlib/public/SwiftShims/LibcOverlayShims.h
+++ b/stdlib/public/SwiftShims/LibcOverlayShims.h
@@ -20,6 +20,9 @@
 
 #include "Visibility.h"
 
+#if defined(__OpenBSD__)
+#include <stdio.h>
+#endif
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #include <errno.h>
 #include <io.h>
@@ -109,6 +112,20 @@ int static inline _swift_stdlib_open(const char *path, int oflag, mode_t mode) {
 int static inline _swift_stdlib_openat(int fd, const char *path, int oflag,
                                        mode_t mode) {
   return openat(fd, path, oflag, mode);
+}
+#endif
+
+#if defined(__OpenBSD__)
+static inline FILE *_swift_stdlib_stdin(void) {
+  return stdin;
+}
+
+static inline FILE *_swift_stdlib_stdout(void) {
+  return stdout;
+}
+
+static inline FILE *_swift_stdlib_stderr(void) {
+  return stderr;
 }
 #endif
 


### PR DESCRIPTION
These are macros on OpenBSD, which don't get imported to an equivalent
symbol in Swift.
