### PR TITLE
[CSGen] Replace `getInterfaceType() -> mapTypeIntoContext()` for VarD…

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1420,7 +1420,7 @@ namespace {
       if (auto *VD = dyn_cast<VarDecl>(E->getDecl())) {
         knownType = CS.getTypeIfAvailable(VD);
         if (!knownType)
-          knownType = VD->getInterfaceType();
+          knownType = VD->getType();
 
         if (knownType) {
           assert(!knownType->isHole());
@@ -1432,8 +1432,6 @@ namespace {
           }
 
           // Set the favored type for this expression to the known type.
-          if (knownType->hasTypeParameter())
-            knownType = VD->getDeclContext()->mapTypeIntoContext(knownType);
           CS.setFavoredType(E, knownType.getPointer());
         }
 

--- a/test/decl/protocol/req/recursion.swift
+++ b/test/decl/protocol/req/recursion.swift
@@ -48,8 +48,7 @@ public struct S<A: P> where A.T == S<A> { // expected-error {{circular reference
 // expected-error@-2 {{generic struct 'S' references itself}}
 // expected-note@-3 {{while resolving type 'S<A>'}}
   func f(a: A.T) {
-    g(a: id(t: a))
-    // expected-error@-1 {{type of expression is ambiguous without more context}}
+    g(a: id(t: a)) // `a` has error type which is diagnosed as circular reference
     _ = A.T.self
   }
 


### PR DESCRIPTION
…ecl with `getType`

In `ConstraintGenerator::visitDeclRefExpr` instead of using
`getInterfaceType()` for unknown type and later mapping it into
context, let's use `getType()` which does that interally, that
allows to detect presence of error types in resulting type and
abort constraint generation.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
