### PR TITLE
[cxx-interop] Add support for C++ logical and/or operators.

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1423,6 +1423,8 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     case clang::OverloadedOperatorKind::OO_Minus:
     case clang::OverloadedOperatorKind::OO_Star:
     case clang::OverloadedOperatorKind::OO_Slash:
+    case clang::OverloadedOperatorKind::OO_AmpAmp:
+    case clang::OverloadedOperatorKind::OO_PipePipe:
       if (auto FD = dyn_cast<clang::FunctionDecl>(D)) {
         baseName = clang::getOperatorSpelling(op);
         isFunction = true;

--- a/test/Interop/Cxx/operators/Inputs/non-member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/non-member-inline.h
@@ -21,6 +21,18 @@ inline IntBox operator/(IntBox lhs, IntBox rhs) {
   return IntBox{.value = lhs.value / rhs.value};
 }
 
+struct BoolBox {
+  bool value;
+};
+
+inline BoolBox operator&&(BoolBox lhs, BoolBox rhs) {
+  return BoolBox{.value = lhs.value && rhs.value};
+}
+
+inline BoolBox operator||(BoolBox lhs, BoolBox rhs) {
+  return BoolBox{.value = lhs.value || rhs.value};
+}
+
 // Make sure that we don't crash on templated operators
 template<typename T> struct S {};
 template<typename T> S<T> operator+(S<T> lhs, S<T> rhs);

--- a/test/Interop/Cxx/operators/non-member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/non-member-inline-module-interface.swift
@@ -4,3 +4,6 @@
 // CHECK-NEXT: func - (lhs: IntBox, rhs: IntBox) -> IntBox
 // CHECK-NEXT: func * (lhs: IntBox, rhs: IntBox) -> IntBox
 // CHECK-NEXT: func / (lhs: IntBox, rhs: IntBox) -> IntBox
+
+// CHECK:      func && (lhs: BoolBox, rhs: BoolBox) -> BoolBox
+// CHECK-NEXT: func || (lhs: BoolBox, rhs: BoolBox) -> BoolBox

--- a/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
@@ -9,3 +9,9 @@ let resultPlus = lhs + rhs
 let resultMinus = lhs - rhs
 let resultStar = lhs * rhs
 let resultSlash = lhs / rhs
+
+var lhsBool = BoolBox(value: true)
+var rhsBool = BoolBox(value: false)
+
+let resultAmpAmp = lhsBool && rhsBool
+let resultPipePipe = lhsBool && rhsBool

--- a/test/Interop/Cxx/operators/non-member-inline.swift
+++ b/test/Interop/Cxx/operators/non-member-inline.swift
@@ -43,4 +43,22 @@ OperatorsTestSuite.test("slash") {
   expectEqual(1, result.value)
 }
 
+OperatorsTestSuite.test("amp amp (&&)") {
+  let lhs = BoolBox(value: true)
+  let rhs = BoolBox(value: false)
+
+  let result = lhs && rhs
+
+  expectEqual(false, result.value)
+}
+
+OperatorsTestSuite.test("pipe pipe (||)") {
+  let lhs = BoolBox(value: true)
+  let rhs = BoolBox(value: false)
+
+  let result = lhs || rhs
+
+  expectEqual(true, result.value)
+}
+
 runAllTests()


### PR DESCRIPTION
Support imported C++ `&&` and `||` operators in Swift.
