### PR TITLE
Add a demangler option to hide local decl name contexts.  …

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -50,6 +50,7 @@ struct DemangleOptions {
   bool DisplayProtocolConformances = true;
   bool DisplayWhereClauses = true;
   bool DisplayEntityTypes = true;
+  bool DisplayLocalNameContexts = true;
   bool ShortenPartialApply = false;
   bool ShortenThunk = false;
   bool ShortenValueWitness = false;

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -1200,7 +1200,8 @@ NodePointer NodePrinter::print(NodePointer Node, bool asPrefixContext) {
                        /*hasName*/true);
   case Node::Kind::LocalDeclName:
     print(Node->getChild(1));
-    Printer << " #" << (Node->getChild(0)->getIndex() + 1);
+    if (Options.DisplayLocalNameContexts)
+      Printer << " #" << (Node->getChild(0)->getIndex() + 1);
     return nullptr;
   case Node::Kind::PrivateDeclName:
     if (Node->getNumChildren() > 1) {
@@ -2468,8 +2469,9 @@ printEntity(NodePointer Entity, bool asPrefixContext, TypePrinting TypePr,
   bool MultiWordName = ExtraName.contains(' ');
   // Also a local name (e.g. Mystruct #1) does not look good if its context is
   // printed in prefix form.
-  if (hasName &&
-      Entity->getChild(1)->getKind() == Node::Kind::LocalDeclName)
+  bool LocalName =
+      hasName && Entity->getChild(1)->getKind() == Node::Kind::LocalDeclName;
+  if (LocalName && Options.DisplayLocalNameContexts)
     MultiWordName = true;
 
   if (asPrefixContext && (TypePr != TypePrinting::NoType || MultiWordName)) {
@@ -2554,7 +2556,8 @@ printEntity(NodePointer Entity, bool asPrefixContext, TypePrinting TypePr,
       printEntityType(Entity, type, genericFunctionTypeList);
     }
   }
-  if (!asPrefixContext && PostfixContext) {
+  if (!asPrefixContext && PostfixContext &&
+      (!LocalName || Options.DisplayLocalNameContexts)) {
     // Print any left over context which couldn't be printed in prefix form.
     if (Entity->getKind() == Node::Kind::DefaultArgumentInitializer ||
         Entity->getKind() == Node::Kind::Initializer ||

--- a/test/Demangle/demangle-special-options.test
+++ b/test/Demangle/demangle-special-options.test
@@ -10,3 +10,9 @@ CGRECT: {{ CGRect$}}
 
 RUN: swift-demangle -hiding-module=foo _TtC3foo3bar | %FileCheck %s --check-prefix=BAR
 BAR: {{ bar$}}
+
+RUN: swift-demangle -display-local-name-contexts=true s1a4mainyyFySRys5UInt8VGXEfU4_10ByteBufferL_aD | %FileCheck %s --check-prefix=LOCAL
+LOCAL: ByteBuffer #1 in closure #6
+
+RUN: swift-demangle -display-local-name-contexts=false s1a4mainyyFySRys5UInt8VGXEfU4_10ByteBufferL_aD | %FileCheck %s --check-prefix=NOLOCAL
+NOLOCAL: {{ ByteBuffer$}}

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -76,6 +76,11 @@ Classify("classify",
 
 /// Options that are primarily used for testing.
 /// \{
+static llvm::cl::opt<bool> DisplayLocalNameContexts(
+    "display-local-name-contexts", llvm::cl::init(true),
+    llvm::cl::desc("Qualify local names"),
+    llvm::cl::Hidden);
+
 static llvm::cl::opt<bool> DisplayStdlibModule(
     "display-stdlib-module", llvm::cl::init(true),
     llvm::cl::desc("Qualify types originating from the Swift standard library"),
@@ -255,6 +260,7 @@ int main(int argc, char **argv) {
   options.DisplayStdlibModule = DisplayStdlibModule;
   options.DisplayObjCModule = DisplayObjCModule;
   options.HidingCurrentModule = HidingModule;
+  options.DisplayLocalNameContexts = DisplayLocalNameContexts;
 
   if (InputNames.empty()) {
     CompactMode = true;


### PR DESCRIPTION
This part of a series of patches to bring ASTPrinter and Swift Demangler to
feature parity, which is needed by LLDB, which depends on using the strings
produced by either interchangibly.

rdar://problem/64222171
