### PR TITLE
[SR-12955] [Sema] Don't diagnose invalid conversion if fnType has error

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2208,6 +2208,16 @@ getObjCObjectRepresentable(Type type, const DeclContext *dc) {
 static std::pair<ForeignRepresentableKind, ProtocolConformance *>
 getForeignRepresentable(Type type, ForeignLanguage language,
                         const DeclContext *dc) {
+  // Local function that simply produces a failing result.
+  auto failure = []() -> std::pair<ForeignRepresentableKind,
+                                   ProtocolConformance *> {
+    return { ForeignRepresentableKind::None, nullptr };
+  };
+  
+  // If type has an error let's fail early.
+  if (type->hasError())
+    return failure();
+  
   // Look through one level of optional type, but remember that we did.
   bool wasOptional = false;
   if (auto valueType = type->getOptionalObjectType()) {
@@ -2221,12 +2231,6 @@ getForeignRepresentable(Type type, ForeignLanguage language,
     if (representable != ForeignRepresentableKind::None)
       return { representable, nullptr };
   }
-
-  // Local function that simply produces a failing result.
-  auto failure = []() -> std::pair<ForeignRepresentableKind,
-                                   ProtocolConformance *> {
-    return { ForeignRepresentableKind::None, nullptr };
-  };
 
   // Function types.
   if (auto functionType = type->getAs<FunctionType>()) {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2705,7 +2705,8 @@ Type TypeResolver::resolveASTFunctionType(
   switch (representation) {
   case AnyFunctionType::Representation::Block:
   case AnyFunctionType::Representation::CFunctionPointer:
-    if (!fnTy->isRepresentableIn(ForeignLanguage::ObjectiveC, DC)) {
+    if (!fnTy->hasError() &&
+        !fnTy->isRepresentableIn(ForeignLanguage::ObjectiveC, DC)) {
       StringRef strName =
         (representation == AnyFunctionType::Representation::Block)
         ? "block"

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2700,13 +2700,16 @@ Type TypeResolver::resolveASTFunctionType(
   }
 
   auto fnTy = FunctionType::get(params, outputTy, extInfo);
+  
+  if (fnTy->hasError())
+    return fnTy;
+
   // If the type is a block or C function pointer, it must be representable in
   // ObjC.
   switch (representation) {
   case AnyFunctionType::Representation::Block:
   case AnyFunctionType::Representation::CFunctionPointer:
-    if (!fnTy->hasError() &&
-        !fnTy->isRepresentableIn(ForeignLanguage::ObjectiveC, DC)) {
+    if (!fnTy->isRepresentableIn(ForeignLanguage::ObjectiveC, DC)) {
       StringRef strName =
         (representation == AnyFunctionType::Representation::Block)
         ? "block"

--- a/test/expr/closure/inference.swift
+++ b/test/expr/closure/inference.swift
@@ -73,3 +73,8 @@ let cc = SR8563 { (_: (Int)) in }
 
 cc((1)) // Ok
 cc(1) // Ok
+
+// SR-12955
+func SR12955() {
+  let f: @convention(c) (T) -> Void // expected-error {{cannot find type 'T' in scope}}
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Avoid diagnosing ObjectiveC non-convertible if the function type has an error.

cc @mikeash 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-12955.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
