### PR TITLE
Adds entry points to the runtime that exposes metadata

### DIFF
--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -80,6 +80,11 @@ void
 swift_reflection_addReflectionInfo(SwiftReflectionContextRef ContextRef,
                                    swift_reflection_info_t Info);
 
+/// Add reflection sections from a loaded Swift image.
+SWIFT_REMOTE_MIRROR_LINKAGE
+void swift_reflection_addReflectionMappingInfo(
+    SwiftReflectionContextRef ContextRef, swift_reflection_mapping_info_t Info);
+
 /// Add reflection information from a loaded Swift image.
 /// Returns true on success, false if the image's memory couldn't be read.
 SWIFT_REMOTE_MIRROR_LINKAGE

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
@@ -48,10 +48,22 @@ typedef struct swift_reflection_section {
   void *End;
 } swift_reflection_section_t;
 
+/// Represents the remote address and size of an image's section
+typedef struct swift_remote_reflection_section {
+    uintptr_t StartAddress;
+    uintptr_t Size;
+} swift_remote_reflection_section_t;
+
 typedef struct swift_reflection_section_pair {
   swift_reflection_section_t section;
   swift_reflection_ptr_t offset; ///< DEPRECATED. Must be zero
 } swift_reflection_section_pair_t;
+
+/// Represents the mapping between an image sections's local and remote addresses
+typedef struct swift_reflection_section_mapping {
+  swift_reflection_section_t local_section;
+  swift_remote_reflection_section_t remote_section;
+} swift_reflection_section_mapping_t;
 
 /// Represents the set of Swift reflection sections of an image.
 /// Not all sections may be present.
@@ -70,6 +82,16 @@ typedef struct swift_reflection_info {
   swift_reflection_ptr_t LocalStartAddress;
   swift_reflection_ptr_t RemoteStartAddress;
 } swift_reflection_info_t;
+
+/// Represents the set of Swift reflection sections of an image,
+typedef struct swift_reflection_mapping_info {
+  swift_reflection_section_mapping_t field;
+  swift_reflection_section_mapping_t associated_types;
+  swift_reflection_section_mapping_t builtin_types;
+  swift_reflection_section_mapping_t capture;
+  swift_reflection_section_mapping_t type_references;
+  swift_reflection_section_mapping_t reflection_strings;
+} swift_reflection_mapping_info_t;
 
 /// The layout kind of a Swift type.
 typedef enum swift_layout_kind {

--- a/stdlib/private/CMakeLists.txt
+++ b/stdlib/private/CMakeLists.txt
@@ -23,8 +23,10 @@ if(SWIFT_BUILD_SDK_OVERLAY)
 
   if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     add_subdirectory(StdlibUnittestFoundationExtras)
-    if (SWIFT_INCLUDE_TESTS)
-      add_subdirectory(SwiftReflectionTest)
-    endif()
+  endif()
+  # Currently SwiftReflectionTest cannot be built on Windows, due to 
+  # dependencies on POSIX symbols 
+  if (SWIFT_INCLUDE_TESTS AND (NOT CMAKE_SYSTEM_NAME STREQUAL "Windows"))
+    add_subdirectory(SwiftReflectionTest)
   endif()
 endif()

--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -16,11 +16,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// FIXME: Make this work with Linux
-
-import MachO
-import Darwin
-
 let RequestInstanceKind = "k"
 let RequestInstanceAddress = "i"
 let RequestReflectionInfos = "r"
@@ -31,56 +26,10 @@ let RequestStringLength = "l"
 let RequestDone = "d"
 let RequestPointerSize = "p"
 
-internal func debugLog(_ message: @autoclosure () -> String) {
-#if DEBUG_LOG
-  fputs("Child: \(message())\n", stderr)
-  fflush(stderr)
-#endif
-}
 
-public enum InstanceKind : UInt8 {
-  case None
-  case Object
-  case Existential
-  case ErrorExistential
-  case Closure
-  case Enum
-  case EnumValue
-}
-
-/// Represents a section in a loaded image in this process.
-internal struct Section {
-  /// The absolute start address of the section's data in this address space.
-  let startAddress: UnsafeRawPointer
-
-  /// The size of the section in bytes.
-  let size: UInt
-}
-
-/// Holds the addresses and sizes of sections related to reflection
-internal struct ReflectionInfo : Sequence {
-  /// The name of the loaded image
-  internal let imageName: String
-
-  /// Reflection metadata sections
-  internal let fieldmd: Section?
-  internal let assocty: Section?
-  internal let builtin: Section?
-  internal let capture: Section?
-  internal let typeref: Section?
-  internal let reflstr: Section?
-
-  internal func makeIterator() -> AnyIterator<Section?> {
-    return AnyIterator([
-      fieldmd,
-      assocty,
-      builtin,
-      capture,
-      typeref,
-      reflstr
-    ].makeIterator())
-  }
-}
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import MachO
+import Darwin
 
 #if arch(x86_64) || arch(arm64)
 typealias MachHeader = mach_header_64
@@ -103,6 +52,36 @@ internal func getSectionInfo(_ name: String,
   guard let nonNullAddress = address else { return nil }
   guard size != 0 else { return nil }
   return Section(startAddress: nonNullAddress, size: size)
+}
+
+/// Get the TEXT segment location and size for a loaded image.
+///
+/// - Parameter i: The index of the loaded image as reported by Dyld.
+/// - Returns: The image name, address, and size.
+internal func getAddressInfoForImage(atIndex i: UInt32) ->
+        (name: String, address: UnsafeMutablePointer<UInt8>?, size: UInt) {
+  debugLog("BEGIN \(#function)"); defer { debugLog("END \(#function)") }
+  let header = unsafeBitCast(_dyld_get_image_header(i),
+          to: UnsafePointer<MachHeader>.self)
+  let name = String(validatingUTF8: _dyld_get_image_name(i)!)!
+  var size: UInt = 0
+  let address = getsegmentdata(header, "__TEXT", &size)
+  return (name, address, size)
+}
+
+/// Send all loadedimages loaded in the current process.
+internal func sendImages() {
+  debugLog("BEGIN \(#function)"); defer { debugLog("END \(#function)") }
+  let infos = (0..<getImageCount()).map(getAddressInfoForImage)
+
+  debugLog("\(infos.count) reflection info bundles.")
+  precondition(infos.count >= 1)
+  sendValue(infos.count)
+  for (name, address, size) in infos {
+    debugLog("Sending info for \(name)")
+    sendValue(address)
+    sendValue(size)
+  }
 }
 
 /// Get the Swift Reflection section locations for a loaded image.
@@ -140,19 +119,100 @@ internal func getReflectionInfoForImage(atIndex i: UInt32) -> ReflectionInfo? {
                         reflstr: reflstr)
 }
 
-/// Get the TEXT segment location and size for a loaded image.
-///
-/// - Parameter i: The index of the loaded image as reported by Dyld.
-/// - Returns: The image name, address, and size.
-internal func getAddressInfoForImage(atIndex i: UInt32) ->
-  (name: String, address: UnsafeMutablePointer<UInt8>?, size: UInt) {
-  debugLog("BEGIN \(#function)"); defer { debugLog("END \(#function)") }
-  let header = unsafeBitCast(_dyld_get_image_header(i),
-    to: UnsafePointer<MachHeader>.self)
-  let name = String(validatingUTF8: _dyld_get_image_name(i)!)!
-  var size: UInt = 0
-  let address = getsegmentdata(header, "__TEXT", &size)
-  return (name, address, size)
+internal func getImageCount() -> UInt32 {
+  return _dyld_image_count()
+}
+
+let rtldDefault = UnsafeMutableRawPointer(bitPattern: Int(-2))
+#elseif !os(Windows)
+import SwiftShims
+import Glibc
+
+let rtldDefault: UnsafeMutableRawPointer? = nil
+
+extension Section {
+  init(range: MetadataSectionRange) {
+    self.startAddress = UnsafeRawPointer(bitPattern: range.start)!
+    self.size = UInt(range.length)
+  }
+}
+
+internal func getReflectionInfoForImage(atIndex i: UInt32) -> ReflectionInfo? {
+  return _getMetadataSection(UInt(i)).map { rawPointer in
+    let name = _getMetadataSectionName(rawPointer)
+    let metadataSection = rawPointer.bindMemory(to: MetadataSections.self, capacity: 1).pointee
+    return ReflectionInfo(imageName: String(validatingUTF8: name)!,
+            fieldmd: Section(range: metadataSection.swift5_fieldmd),
+            assocty: Section(range: metadataSection.swift5_assocty),
+            builtin: Section(range: metadataSection.swift5_builtin),
+            capture: Section(range: metadataSection.swift5_capture),
+            typeref: Section(range: metadataSection.swift5_typeref),
+            reflstr: Section(range: metadataSection.swift5_reflstr))
+  }
+}
+
+internal func getImageCount() -> UInt32 {
+  return UInt32(_getMetadataSectionCount())
+}
+
+internal func sendImages() {
+  preconditionFailure("Should only be called in macOS!")
+}
+
+
+#else // os(Linux)
+#error("SwiftReflectionTest does not currently support this OS.")
+#endif
+
+internal func debugLog(_ message: @autoclosure () -> String) {
+#if DEBUG_LOG
+  fputs("Child: \(message())\n", stderr)
+  fflush(stderr)
+#endif
+}
+
+public enum InstanceKind: UInt8 {
+  case None
+  case Object
+  case Existential
+  case ErrorExistential
+  case Closure
+  case Enum
+  case EnumValue
+}
+
+/// Represents a section in a loaded image in this process.
+internal struct Section {
+  /// The absolute start address of the section's data in this address space.
+  let startAddress: UnsafeRawPointer
+
+  /// The size of the section in bytes.
+  let size: UInt
+}
+
+/// Holds the addresses and sizes of sections related to reflection.
+internal struct ReflectionInfo : Sequence {
+  /// The name of the loaded image.
+  internal let imageName: String
+
+  /// Reflection metadata sections.
+  internal let fieldmd: Section?
+  internal let assocty: Section?
+  internal let builtin: Section?
+  internal let capture: Section?
+  internal let typeref: Section?
+  internal let reflstr: Section?
+
+  internal func makeIterator() -> AnyIterator<Section?> {
+    return AnyIterator([
+      fieldmd,
+      assocty,
+      builtin,
+      capture,
+      typeref,
+      reflstr
+    ].makeIterator())
+  }
 }
 
 internal func sendBytes<T>(from address: UnsafePointer<T>, count: Int) {
@@ -197,7 +257,7 @@ internal func readUInt() -> UInt {
 /// process.
 internal func sendReflectionInfos() {
   debugLog("BEGIN \(#function)"); defer { debugLog("END \(#function)") }
-  let infos = (0..<_dyld_image_count()).compactMap(getReflectionInfoForImage)
+  let infos = (0..<getImageCount()).compactMap(getReflectionInfoForImage)
 
   var numInfos = infos.count
   debugLog("\(numInfos) reflection info bundles.")
@@ -209,21 +269,6 @@ internal func sendReflectionInfos() {
       sendValue(section?.startAddress)
       sendValue(section?.size ?? 0)
     }
-  }
-}
-
-/// Send all loadedimages loaded in the current process.
-internal func sendImages() {
-  debugLog("BEGIN \(#function)"); defer { debugLog("END \(#function)") }
-  let infos = (0..<_dyld_image_count()).map(getAddressInfoForImage)
-
-  debugLog("\(infos.count) reflection info bundles.")
-  precondition(infos.count >= 1)
-  sendValue(infos.count)
-  for (name, address, size) in infos {
-    debugLog("Sending info for \(name)")
-    sendValue(address)
-    sendValue(size)
   }
 }
 
@@ -261,8 +306,7 @@ internal func sendSymbolAddress() {
   debugLog("BEGIN \(#function)"); defer { debugLog("END \(#function)") }
   let name = readLine()!
   name.withCString {
-    let handle = UnsafeMutableRawPointer(bitPattern: Int(-2))!
-    let symbol = dlsym(handle, $0)
+    let symbol = dlsym(rtldDefault, $0)
     let symbolAddress = unsafeBitCast(symbol, to: UInt.self)
     sendValue(symbolAddress)
   }

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -132,3 +132,19 @@ public func _getTypeByMangledNameInContext(
   genericContext: UnsafeRawPointer?,
   genericArguments: UnsafeRawPointer?)
   -> Any.Type?
+
+
+@_silgen_name("swift_getMetadataSection")
+public func _getMetadataSection(
+  _ index: UInt)
+  -> UnsafeRawPointer?
+
+@_silgen_name("swift_getMetadataSectionCount")
+public func _getMetadataSectionCount()
+  -> UInt
+
+@_silgen_name("swift_getMetadataSectionName")
+public func _getMetadataSectionName(
+  _ metadata_section: UnsafeRawPointer)
+  -> UnsafePointer<CChar>
+

--- a/stdlib/public/runtime/ImageInspectionCommon.h
+++ b/stdlib/public/runtime/ImageInspectionCommon.h
@@ -12,7 +12,7 @@
 ///
 /// \file
 ///
-/// This file unifies common ELF and COFF image inspection routines
+/// This file unifies common ELF and COFF image inspection routines.
 ///
 //===----------------------------------------------------------------------===//
 
@@ -27,6 +27,7 @@
 
 #include "../SwiftShims/Visibility.h"
 #include <cstdint>
+#include <cstddef>
 
 namespace swift {
 struct MetadataSections;
@@ -41,6 +42,16 @@ struct SectionInfo {
 // Called by injected constructors when a dynamic library is loaded.
 SWIFT_RUNTIME_EXPORT
 void swift_addNewDSOImage(const void *addr);
+
+#ifndef NDEBUG
+
+SWIFT_RUNTIME_EXPORT
+const char *swift_getMetadataSectionName(void *metadata_section);
+
+SWIFT_RUNTIME_EXPORT
+size_t swift_getMetadataSectionCount();
+
+#endif // NDEBUG
 
 #endif // !defined(__MACH__)
 

--- a/test/api-digester/stability-stdlib-abi-with-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-with-asserts.test
@@ -39,3 +39,6 @@ Struct _ObjectRuntimeFunctionCountersState is a new API without @available attri
 Struct _RuntimeFunctionCounters is a new API without @available attribute
 Func _swift_isImmutableCOWBuffer(_:) is a new API without @available attribute
 Func _swift_setImmutableCOWBuffer(_:_:) is a new API without @available attribute
+Func _getMetadataSection(_:) is a new API without @available attribute
+Func _getMetadataSectionCount() is a new API without @available attribute
+Func _getMetadataSectionName(_:) is a new API without @available attribute

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1991,3 +1991,10 @@ if copy_env is not None:
     config.environment[key] = os.environ[key]
 
 lit_config.note("Available features: " + ", ".join(sorted(config.available_features)))
+
+# On macOS reflection information is read through the dyld APIs
+# On other platorms, this information is exported through extra
+# entry points in the Swift runtime that are only available in debug builds.
+# Windows currently does not support basic reflection support.
+if 'objc_interop' in config.available_features or ('swift_stdlib_asserts' in config.available_features and not kIsWindows):
+    config.available_features.add('reflection_test_support')

--- a/validation-test/Reflection/reflect_UInt16.swift
+++ b/validation-test/Reflection/reflect_UInt16.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_UInt16 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 


### PR DESCRIPTION
This PR will add the necessary functionality in order to enable SwiftReflectionTest to work on Linux. This will be done by adding entry points in the Swift runtime that only build in debug builds