### PR TITLE
[build-script] Print out inferred products/build order when --verbose-build is enabled.

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -889,6 +889,11 @@ class BuildScriptInvocation(object):
         # list.
         if self.args.infer_dependencies:
             combined = impl_product_classes + product_classes
+            if self.args.verbose_build:
+                print("-- Build Graph Inference --")
+                print("Initial Product List:")
+                for p in combined:
+                    print("    {}".format(p.product_name()))
 
             # Now that we have produced the schedule, resplit. We require our
             # dependencies to respect our build-script-impl property. This means
@@ -908,6 +913,12 @@ class BuildScriptInvocation(object):
                     impl_product_classes.append(p)
                 else:
                     product_classes.append(p)
+            if self.args.verbose_build:
+                print("Final Build Order:")
+                for p in impl_product_classes:
+                    print("    {}".format(p.product_name()))
+                for p in product_classes:
+                    print("    {}".format(p.product_name()))
         return (impl_product_classes, product_classes)
 
     def execute(self):

--- a/validation-test/BuildSystem/infer_dumps_deps_if_verbose_build.test
+++ b/validation-test/BuildSystem/infer_dumps_deps_if_verbose_build.test
@@ -1,0 +1,26 @@
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --verbose-build --dry-run --infer --swiftpm --cmake %cmake 2>&1 | %FileCheck %s
+
+# REQUIRES: standalone_build
+
+# Just make sure we compute the build graph/emit output.
+#
+# CHECK: -- Build Graph Inference --
+# CHECK: Initial Product List:
+# CHECK:     cmark
+# CHECK:     llvm
+# CHECK:     swift
+# CHECK: Final Build Order:
+# CHECK:     cmark
+# CHECK:     llvm
+# CHECK:     swift
+
+# Then make sure we are installing/building at the appropriate times.
+#
+# CHECK: --- Installing cmark ---
+# CHECK: --- Installing llvm ---
+# CHECK: --- Installing swift ---
+# CHECK: --- Installing llbuild ---
+# CHECK: --- Building swiftpm ---
+# CHECK: --- Installing swiftpm ---


### PR DESCRIPTION
@atrick as per your suggestion.