### PR TITLE
No-op change to see baseline breakage on source compatibility tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.12.4)
 
+# No-op change.
+
 # TODO: Fix RPATH usage to be CMP0068 compliant
 # Disable Policy CMP0068 for CMake 3.9
 # rdar://37725888


### PR DESCRIPTION
This is a no-op change to see which source compatibility tests are broken at baseline.

I'm seeing a lot of broken source compatibility tests in https://github.com/apple/swift/pull/32262, and I'd like to make sure none of them are due to my PR.