### PR TITLE
[Basic] Revise version printing

### DIFF
--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -34,7 +34,6 @@ function(generate_revision_inc revision_inc_var name dir)
 endfunction()
 
 generate_revision_inc(llvm_revision_inc LLVM "${LLVM_MAIN_SRC_DIR}")
-generate_revision_inc(clang_revision_inc Clang "${CLANG_MAIN_SRC_DIR}")
 generate_revision_inc(swift_revision_inc Swift "${SWIFT_SOURCE_DIR}")
 
 add_swift_host_library(swiftBasic STATIC

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -45,34 +45,25 @@
 #endif
 
 #include "LLVMRevision.inc"
-#include "ClangRevision.inc"
 #include "SwiftRevision.inc"
 
 namespace swift {
 namespace version {
 
-/// Print a string of the form "LLVM xxxxx, Clang yyyyy, Swift zzzzz",
-/// where each placeholder is the revision for the associated repository.
+/// Print a string of the form "LLVM xxxxx, Swift zzzzz", where each placeholder
+/// is the revision for the associated repository.
 static void printFullRevisionString(raw_ostream &out) {
-  // Arbitrarily truncate to 10 characters. This should be enough to unique
-  // Git hashes for the time being, and certainly enough for SVN revisions,
-  // while keeping the version string from being ridiculously long.
+  // Arbitrarily truncate to 15 characters. This should be enough to unique Git
+  // hashes while keeping the REPL version string from overflowing 80 columns.
 #if defined(LLVM_REVISION)
-  out << "LLVM " << StringRef(LLVM_REVISION).slice(0, 10);
-# if defined(CLANG_REVISION) || defined(SWIFT_REVISION)
-  out << ", ";
-# endif
-#endif
-
-#if defined(CLANG_REVISION)
-  out << "Clang " << StringRef(CLANG_REVISION).slice(0, 10);
+  out << "LLVM " << StringRef(LLVM_REVISION).slice(0, 15);
 # if defined(SWIFT_REVISION)
   out << ", ";
 # endif
 #endif
 
 #if defined(SWIFT_REVISION)
-  out << "Swift " << StringRef(SWIFT_REVISION).slice(0, 10);
+  out << "Swift " << StringRef(SWIFT_REVISION).slice(0, 15);
 #endif
 }
 
@@ -424,8 +415,7 @@ std::string getSwiftFullVersion(Version effectiveVersion) {
   OS << " clang-" CLANG_COMPILER_VERSION;
 #endif
   OS << ")";
-#elif defined(LLVM_REVISION) || defined(CLANG_REVISION) || \
-      defined(SWIFT_REVISION)
+#elif defined(LLVM_REVISION) || defined(SWIFT_REVISION)
   OS << " (";
   printFullRevisionString(OS);
   OS << ")";


### PR DESCRIPTION
Now that we use the LLVM mono-repo, we don't need to worry about clang's version number. Also, git has the ability to estimate the safe number of digits a hash can be truncated to and now git estimates that large projects like LLVM and Linux "require" 12 digits for safe commit hash abbreviation. Let's stay a little ahead of the curve and statically truncate to 15.