### PR TITLE
[Test] Exclude environment_variables.swift from testing against the OS stdlib.

### DIFF
--- a/test/Runtime/environment_variables.swift
+++ b/test/Runtime/environment_variables.swift
@@ -3,6 +3,7 @@
 // RUN: %target-codesign %t/main
 
 // REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
 
 // RUN: env %env-SWIFT_DEBUG_HELP=YES %env-SWIFT_DEBUG_SOME_UNKNOWN_VARIABLE=42 %env-SWIFT_DEBUG_ENABLE_METADATA_ALLOCATION_ITERATION=YES %env-SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=abc %env-SWIFT_DETERMINISTIC_HASHING=whatever %env-SWIFT_ENABLE_MANGLED_NAME_VERIFICATION=YES %target-run %t/main 2>&1 | %FileCheck %s --dump-input fail
 


### PR DESCRIPTION
rdar://problem/64301166